### PR TITLE
[Perf][Diffusion] MiniMax-H3: leaner VAE decode (autocast cache off, in-place revert, uint8 output)

### DIFF
--- a/recipes/MiniMaxAI/MiniMax-H3-NPU.md
+++ b/recipes/MiniMaxAI/MiniMax-H3-NPU.md
@@ -79,7 +79,8 @@ sharing the tokenizer, processor, text encoder, and VAEs from `FL2VA`.
 ### Multi-NPU: 768P combined-service configuration
 
 Use Ulysses sequence parallelism degree 8, text-encoder tensor parallelism
-degree 8, native tiled VAE patch parallelism degree 8, and layerwise offload:
+degree 8, native tiled VAE patch parallelism degree 8, and distributed
+layerwise offload:
 
 ```bash
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
@@ -98,7 +99,7 @@ vllm serve "${MODEL}" \
   --usp 8 \
   --ring 1 \
   --text-encoder-tp-size 8 \
-  --enable-layerwise-offload \
+  --enable-distributed-layerwise-offload \
   --vae-parallel-mode tile \
   --vae-use-tiling \
   --vae-patch-parallel-size 8 \
@@ -111,6 +112,11 @@ H3 is CFG-distilled, so `--cfg-parallel-size` must remain 1.
 
 The same endpoint accepts `task=t2va`, `task=fl2va`, and `task=ref2va`; no
 partition restart is required. Layerwise offload applies to both DiTs.
+
+On Atlas 800I A3 (64 GB HBM per device) the combined service does not fit at
+768P without offloading or sharding: use distributed layerwise offload (as
+above) or HSDP — see
+[§ Memory and attention optimizations](#memory-and-attention-optimizations-a3).
 
 ### Optional optimizations
 
@@ -134,6 +140,63 @@ Keep `--ring 1` when using RainFusion: the `rf_v2` kernel ranks key blocks
 over the whole sequence, so ring parallelism would split away the keys it
 needs. Scale with `--usp` instead.
 
+## Memory and attention optimizations (A3)
+
+### Fitting 768P into 64 GB HBM: distributed layerwise offload or HSDP
+
+Each Atlas 800I A3 NPU has 64 GB of HBM, which is not enough for the
+combined MiniMax-H3 service at 768P. Enable **one** of the following at
+server startup:
+
+**Distributed layerwise offload** — DiT layers are offloaded with parameters
+gathered across the parallel group instead of replicated per rank:
+
+```bash
+  --enable-distributed-layerwise-offload
+```
+
+Measured peak NPU memory is about 45 GB per device for Ref2VA with a 13.88 s
+input video generating a 15 s 768P (1344x768) output video. Host (CPU) memory
+usage is high with this option.
+
+**HSDP** — hybrid sharded data parallelism for the DiT parameters. The
+multi-stream memory-reuse knob is mandatory with this flag:
+
+```bash
+export MULTI_STREAM_MEMORY_REUSE=2
+```
+
+```bash
+  --use-hsdp
+```
+
+Host memory usage is small, but large shapes may still OOM; HBM usage
+optimizations for this path are ongoing.
+
+### FLASH_ATTN backend with MindIE-SD
+
+Keep `--diffusion-attention-backend FLASH_ATTN` and install MindIE-SD (see
+[§ Environment](#environment)). On NPU this backend carries most of the
+memory-reduction and performance work: a mask-free packed varlen path that
+never materializes the quadratic `full_qk` padding mask, and K/V prefix
+slicing, both driven by the packed `cu_seqlens` metadata emitted by the H3
+transformer.
+
+### Optional: LaserAttention fused kernel
+
+For an additional attention speedup, select the Ascend LaserAttention fused
+kernel before starting the server:
+
+```bash
+export MINDIE_SD_FA_TYPE="ascend_laser_attention"
+```
+
+This requires the FLASH_ATTN backend and MindIE-SD. H3 automatically applies
+exact power-of-two input pre-scaling (`laser_input_scale=256`) so the
+kernel's fp16 workspace cannot overflow on outlier activations. Measured
+speedup numbers will be added here.
+
+
 ## HTTP API examples
 
 The request format is identical to the GPU recipe; see
@@ -154,8 +217,8 @@ configuration above:
 
 | Workload | Configuration |
 |----------|---------------|
-| T2VA, 209 frames, 1344x768 | TE TP8, layerwise offload, Ulysses 8, VPP8 tile, regional compile |
-| Ref2VA (prompt + video), 124 frames, 1344x768 | TE TP8, layerwise offload, Ulysses 8, VPP8 tile, regional compile |
+| T2VA, 209 frames, 1344x768 | TE TP8, distributed layerwise offload, Ulysses 8, VPP8 tile, regional compile |
+| Ref2VA (prompt + video), 124 frames, 1344x768 | TE TP8, distributed layerwise offload, Ulysses 8, VPP8 tile, regional compile |
 
 These measurements describe the validated shapes rather than a general
 throughput guarantee.

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
@@ -492,6 +492,10 @@ def test_cudnn_packed_attention_uses_python_length_without_padding_mask():
     class FakeBackend:
         supports_prefix_kv_slicing = True
 
+        @classmethod
+        def supports_packed_mask_free(cls) -> bool:
+            return False
+
     class FakeAttention(torch.nn.Module):
         attn_backend = FakeBackend
 
@@ -526,6 +530,48 @@ def test_cudnn_packed_attention_uses_python_length_without_padding_mask():
     assert attention.attention.metadata.extra["valid_kv_length"] == 5
 
 
+def test_packed_attention_skips_mask_for_packed_mask_free_backend():
+    from vllm_omni.diffusion.models.minimax_h3.minimax_h3_transformer import (
+        MiniMaxH3Attention,
+    )
+
+    class FakeBackend:
+        supports_prefix_kv_slicing = False
+
+        @classmethod
+        def supports_packed_mask_free(cls) -> bool:
+            return True
+
+    class FakeAttention(torch.nn.Module):
+        attn_backend = FakeBackend
+
+        def __init__(self):
+            super().__init__()
+            self.metadata = None
+
+        def forward(self, query, key, value, metadata):
+            self.metadata = metadata
+            return query
+
+    attention = object.__new__(MiniMaxH3Attention)
+    torch.nn.Module.__init__(attention)
+    attention.attention = FakeAttention()
+    q = torch.randn(8, 2, 4)
+
+    attention._run_packed_attention(
+        q,
+        q,
+        q,
+        cu_seqlens=torch.tensor([0, 5, 8], dtype=torch.int32),
+        max_seqlen=5,
+        packed_total=8,
+    )
+
+    assert attention.attention.metadata.attn_mask is None
+    assert attention.attention.metadata.extra["valid_kv_length"] == 5
+    assert attention.attention.metadata.extra["npu_attn_varlen"] is True
+
+
 def test_packed_attention_keeps_padding_mask_for_other_backends():
     from vllm_omni.diffusion.models.minimax_h3.minimax_h3_transformer import (
         MiniMaxH3Attention,
@@ -533,6 +579,10 @@ def test_packed_attention_keeps_padding_mask_for_other_backends():
 
     class FakeBackend:
         supports_prefix_kv_slicing = False
+
+        @classmethod
+        def supports_packed_mask_free(cls) -> bool:
+            return False
 
     class FakeAttention(torch.nn.Module):
         attn_backend = FakeBackend

--- a/vllm_omni/diffusion/attention/backends/abstract.py
+++ b/vllm_omni/diffusion/attention/backends/abstract.py
@@ -20,6 +20,17 @@ class AttentionBackend(ABC):
     # avoid a slower masked-attention plan when tail padding is not semantic.
     supports_prefix_kv_slicing: bool = False
 
+    @classmethod
+    def supports_packed_mask_free(cls) -> bool:
+        """Whether packed attention never reads attn_mask on this platform.
+
+        When True, models that pack a [real, pad] two-document layout and
+        carry cu_seqlens/max_seqlen in ``AttentionMetadata.extra`` may skip
+        constructing the padding mask entirely. Backends whose mask-free
+        behavior is platform-dependent must check current_omni_platform.
+        """
+        return False
+
     # ``OmniPlatformEnum`` values this backend runs on; None means unrestricted.
     # Platform resolution rejects an explicit selection outside this set, so a
     # hardware-specific backend fails before the model is built.
@@ -121,6 +132,17 @@ class AttentionMetadata:
     #     the packed cu_seqlens tensors.
     #   "valid_kv_length": int — contiguous valid K/V prefix length for a
     #     backend that advertises supports_prefix_kv_slicing.
+    #   "npu_attn_varlen": bool — model opt-in for the NPU packed varlen path
+    #     (TND npu_fusion_attention driven by cu_seqlens, mask never read).
+    #     Requires the [real, pad] two-document packing contract; see
+    #     FlashAttentionImpl._forward_varlen_packed_npu.
+    #   "laser_input_scale": float — model opt-in input pre-scale for the NPU
+    #     ascend_laser_attention path. The kernel stores unscaled QK^T in an
+    #     fp16 workspace, so outlier activations overflow 65504 into NaN rows;
+    #     with this set (>1), q/k/v are divided by the factor before the op,
+    #     the kernel scale_value is multiplied by its square, and the output
+    #     is scaled back (exact for power-of-two factors). Absent means no
+    #     pre-scaling. See FlashAttentionImpl._forward_prefix_kv_slice_npu.
 
     # Piecewise attention metadata (mixed causal/full masks).
     # full_attn_spans: per-sample [start, end) spans in global coordinates using full attention.

--- a/vllm_omni/diffusion/attention/backends/flash_attn.py
+++ b/vllm_omni/diffusion/attention/backends/flash_attn.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from functools import partial
 
 import torch
@@ -16,6 +17,7 @@ from vllm_omni.diffusion.attention.backends.utils.piecewise_attn import (
     piecewise_attn,
 )
 from vllm_omni.diffusion.config import get_current_diffusion_config_or_none
+from vllm_omni.platforms import current_omni_platform
 
 logger = init_logger(__name__)
 
@@ -23,6 +25,15 @@ logger = init_logger(__name__)
 class FlashAttentionBackend(AttentionBackend):
     accept_output_buffer: bool = True
     supports_piecewise_spans: bool = True
+
+    @classmethod
+    def supports_packed_mask_free(cls) -> bool:
+        # CUDA: forward_cuda dispatches the packed cu_seqlens varlen path
+        # before ever reading attn_mask. NPU: forward_fa_npu honors the
+        # npu_attn_varlen opt-in and rebuilds the padding mask itself if the
+        # packed contract fails. XPU reads attn_mask, so models must keep
+        # constructing it there.
+        return current_omni_platform.is_cuda() or current_omni_platform.is_npu()
 
     @classmethod
     def supports_attention_mask(cls) -> bool:
@@ -55,6 +66,10 @@ class FlashAttentionImpl(AttentionImpl):
     _supported_kv_cache_dtypes = {
         "npu": {"fp8"},
     }
+
+    # Set when the MINDIE_SD_FA_TYPE-selected op (e.g. ascend_laser_attention)
+    # fails at runtime; subsequent slice-path calls bypass the env override.
+    _npu_env_op_broken: bool = False
 
     def __init__(
         self,
@@ -415,7 +430,36 @@ class FlashAttentionImpl(AttentionImpl):
                 "For installation details, see https://gitcode.com/Ascend/MindIE-SD"
                 "Otherwise, use SDPA backend by setting DIFFUSION_ATTENTION_BACKEND=TORCH_SDPA"
             )
+        # Opt-in mask-free paths (mirror the CUDA cu_seqlens behavior): the
+        # model marks extra["npu_attn_varlen"] and carries packed metadata, so
+        # the padding document is excluded without reading or materializing
+        # the quadratic full_qk mask.
+        #   - default: packed varlen via mindiesd attention_forward_varlen;
+        #   - when MINDIE_SD_FA_TYPE=ascend_laser_attention: prefix K/V
+        #     slicing via mindiesd attention_forward (so the env-selected op
+        #     type is honored; the TND varlen op cannot be).
+        extra = attn_metadata.extra if attn_metadata else {}
+        if extra.get("npu_attn_varlen"):
+            if os.environ.get("MINDIE_SD_FA_TYPE") == "ascend_laser_attention":
+                out = self._forward_prefix_kv_slice_npu(query, key, value, extra)
+            else:
+                out = self._forward_varlen_packed_npu(query, key, value, extra)
+            if out is not None:
+                return out
         attention_mask = attn_metadata.attn_mask if attn_metadata else None
+        if attention_mask is None and extra.get("npu_attn_varlen"):
+            # Models skip mask construction when this opt-in is set
+            # (FlashAttentionBackend.supports_packed_mask_free). The packed
+            # paths above declined (contract mismatch), so rebuild the padding
+            # mask here to keep the masked fallback correct.
+            used = extra.get("valid_kv_length")
+            if not isinstance(used, int) or not 0 < used <= query.shape[1]:
+                raise ValueError(
+                    "npu_attn_varlen packed metadata is unusable and no attn_mask "
+                    f"was constructed (valid_kv_length={used!r}, seq_len={query.shape[1]}); "
+                    "refusing to run unmasked attention over padding rows."
+                )
+            attention_mask = torch.arange(query.shape[1], device=query.device)[None] < used
 
         # NPU aclnnFlashAttentionScore requires mask shape to be one of:
         # [B, N, Sq, Skv], [B, 1, Sq, Skv], [1, 1, Sq, Skv], or [Sq, Skv]
@@ -432,4 +476,170 @@ class FlashAttentionImpl(AttentionImpl):
             opt_mode="manual",
             op_type="fused_attn_score",
             layout=layout,
+        )
+
+    def _resolve_packed_seq_npu(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        extra: dict,
+    ) -> tuple[list[int], list[int]] | None:
+        """Resolve packed document boundaries (cumulative end offsets per doc).
+
+        Returns (seq_q, seq_k), e.g. ([used_q, total_q], [used_k, total_k]),
+        or None unless the metadata matches the exact contract MiniMax-H3
+        produces:
+          - q/k/v are [1, T, N, D] (BSND, single packed batch);
+          - cu_seqlens describe a [real, pad] two-document packing, with the
+            padding document as a strict suffix;
+          - max_seqlen_q/k are Python ints equal to the real document length
+            (so boundaries are derived without any device sync).
+        """
+        if self.causal:
+            return None
+        packed_keys = ("cu_seqlens_q", "cu_seqlens_k", "max_seqlen_q", "max_seqlen_k")
+        if any(k not in extra for k in packed_keys):
+            return None
+        cu_q, cu_k = extra["cu_seqlens_q"], extra["cu_seqlens_k"]
+        used_q, used_k = extra["max_seqlen_q"], extra["max_seqlen_k"]
+        if query.shape[0] != 1 or key.shape[0] != 1:
+            return None
+        if not isinstance(used_q, int) or not isinstance(used_k, int):
+            return None
+        total_q, total_k = query.shape[1], key.shape[1]
+        # .shape is host-side metadata: counting documents never syncs.
+        if cu_q.shape[0] != cu_k.shape[0] or cu_q.shape[0] > 3:
+            return None
+        if not (0 < used_q <= total_q) or not (0 < used_k <= total_k):
+            return None
+        if used_q == total_q and used_k == total_k:
+            # No padding document: one full-length document.
+            return [total_q], [total_k]
+        if cu_q.shape[0] == 3 and used_q >= total_q - used_q and used_k >= total_k - used_k:
+            # [real, pad] packing: the real document must be the longer one
+            # (consistent with the max_seqlen naming).
+            return [used_q, total_q], [used_k, total_k]
+        return None
+
+    def _forward_varlen_packed_npu(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        extra: dict,
+    ) -> torch.Tensor | None:
+        """Packed varlen attention on NPU via mindiesd attention_forward_varlen.
+
+        Returns None (caller falls back to the mask path) when the packed
+        contract does not hold; see _resolve_packed_seq_npu.
+        """
+        resolved = self._resolve_packed_seq_npu(query, key, extra)
+        if resolved is None:
+            return None
+        seq_q, seq_k = resolved
+        from mindiesd import attention_forward_varlen
+
+        q = query.squeeze(0)  # [T, N, D] == TND
+        k = key.squeeze(0)
+        v = value.squeeze(0)
+        # attention_forward_varlen wants cu_seqlens as host lists of cumulative
+        # offsets and forwards cu[1:] as actual_seq_qlen/actual_seq_kvlen.
+        out = attention_forward_varlen(
+            q,
+            k,
+            v,
+            [0, *seq_q],
+            [0, *seq_k],
+            softmax_scale=self.softmax_scale,
+        )
+        return out.unsqueeze(0)
+
+    def _forward_prefix_kv_slice_npu(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        extra: dict,
+    ) -> torch.Tensor | None:
+        """Mask-free attention by slicing K/V to the valid prefix (zero-copy
+        views), then mindiesd attention_forward without a mask.
+
+        Same numerical contract as the varlen path: the padding document is a
+        strict suffix, so dropping it from K/V is identical to masking it out.
+        Query keeps full length; outputs on padding rows are never consumed
+        downstream. Returns None when the packed contract does not hold.
+
+        Used when MINDIE_SD_FA_TYPE=ascend_laser_attention: the TND varlen op
+        cannot honor the env-selected op type, while attention_forward can.
+        If the env-selected op is unusable in this runtime (e.g. the soc has
+        no LaserAttention binary), fall back to mindiesd's runtime dispatch
+        (which ignores MINDIE_SD_FA_TYPE) and remember the failure for the
+        rest of the process.
+
+        The laser kernel stores unscaled S=QK^T in an fp16 GM workspace, so
+        bf16 activations with large outliers overflow 65504 into ±inf and the
+        affected rows turn NaN. Models may opt into exact power-of-two input
+        pre-scaling via extra["laser_input_scale"] (see abstract.py): q/k/v
+        are divided by the factor, the kernel scale_value is multiplied by its
+        square, and the output is scaled back. Absent or invalid factor means
+        no pre-scaling. The compensation is mathematically transparent to the
+        runtime-dispatch fallback op as well.
+        """
+        resolved = self._resolve_packed_seq_npu(query, key, extra)
+        if resolved is None:
+            return None
+        _, seq_k = resolved
+        used_k = seq_k[0]  # real document length (first cumulative end)
+        from mindiesd import attention_forward
+
+        layout = self.qkv_layout or "BNSD"
+        key = key[:, :used_k]
+        value = value[:, :used_k]
+
+        input_scale = extra.get("laser_input_scale")
+        preserve_input_range = isinstance(input_scale, (int, float)) and input_scale > 1
+        if preserve_input_range:
+            query = query / input_scale
+            key = key / input_scale
+            value = value / input_scale
+        scale = self.softmax_scale
+        if preserve_input_range:
+            scale *= input_scale**2
+
+        def _postprocess(out: torch.Tensor) -> torch.Tensor:
+            return out * input_scale if preserve_input_range else out
+
+        if not FlashAttentionImpl._npu_env_op_broken:
+            try:
+                return _postprocess(
+                    attention_forward(
+                        query,
+                        key,
+                        value,
+                        attn_mask=None,
+                        opt_mode="manual",
+                        op_type="fused_attn_score",  # MINDIE_SD_FA_TYPE env overrides this
+                        layout=layout,
+                        scale=scale,
+                    )
+                )
+            except RuntimeError as e:
+                FlashAttentionImpl._npu_env_op_broken = True
+                logger.warning(
+                    "MINDIE_SD_FA_TYPE=%s attention op failed (%s); falling back to "
+                    "runtime dispatch (fused_attn_score) for the rest of this process.",
+                    os.environ.get("MINDIE_SD_FA_TYPE"),
+                    str(e).splitlines()[0] if str(e) else type(e).__name__,
+                )
+        # "runtime" mode ignores MINDIE_SD_FA_TYPE and picks a supported op.
+        return _postprocess(
+            attention_forward(
+                query,
+                key,
+                value,
+                attn_mask=None,
+                opt_mode="runtime",
+                layout=layout,
+                scale=scale,
+            )
         )

--- a/vllm_omni/diffusion/attention/backends/flash_attn.py
+++ b/vllm_omni/diffusion/attention/backends/flash_attn.py
@@ -67,10 +67,6 @@ class FlashAttentionImpl(AttentionImpl):
         "npu": {"fp8"},
     }
 
-    # Set when the MINDIE_SD_FA_TYPE-selected op (e.g. ascend_laser_attention)
-    # fails at runtime; subsequent slice-path calls bypass the env override.
-    _npu_env_op_broken: bool = False
-
     def __init__(
         self,
         num_heads: int,
@@ -439,7 +435,7 @@ class FlashAttentionImpl(AttentionImpl):
         #     slicing via mindiesd attention_forward (so the env-selected op
         #     type is honored; the TND varlen op cannot be).
         extra = attn_metadata.extra if attn_metadata else {}
-        if extra.get("npu_attn_varlen"):
+        if extra.get("npu_attn_varlen", False):
             if os.environ.get("MINDIE_SD_FA_TYPE") == "ascend_laser_attention":
                 out = self._forward_prefix_kv_slice_npu(query, key, value, extra)
             else:
@@ -447,7 +443,7 @@ class FlashAttentionImpl(AttentionImpl):
             if out is not None:
                 return out
         attention_mask = attn_metadata.attn_mask if attn_metadata else None
-        if attention_mask is None and extra.get("npu_attn_varlen"):
+        if attention_mask is None and extra.get("npu_attn_varlen", False):
             # Models skip mask construction when this opt-in is set
             # (FlashAttentionBackend.supports_packed_mask_free). The packed
             # paths above declined (contract mismatch), so rebuild the padding
@@ -537,8 +533,16 @@ class FlashAttentionImpl(AttentionImpl):
         if resolved is None:
             return None
         seq_q, seq_k = resolved
-        from mindiesd import attention_forward_varlen
 
+        try:
+            from mindiesd import attention_forward_varlen
+        except ImportError:
+            raise ImportError(
+                "FlashAttentionBackend NPU implementation requires MindIE-SD. "
+                "Please install MindIE-SD to enable NPU attention support. "
+                "For installation details, see https://gitcode.com/Ascend/MindIE-SD"
+                "Otherwise, use SDPA backend by setting DIFFUSION_ATTENTION_BACKEND=TORCH_SDPA"
+            )
         q = query.squeeze(0)  # [T, N, D] == TND
         k = key.squeeze(0)
         v = value.squeeze(0)
@@ -571,10 +575,6 @@ class FlashAttentionImpl(AttentionImpl):
 
         Used when MINDIE_SD_FA_TYPE=ascend_laser_attention: the TND varlen op
         cannot honor the env-selected op type, while attention_forward can.
-        If the env-selected op is unusable in this runtime (e.g. the soc has
-        no LaserAttention binary), fall back to mindiesd's runtime dispatch
-        (which ignores MINDIE_SD_FA_TYPE) and remember the failure for the
-        rest of the process.
 
         The laser kernel stores unscaled S=QK^T in an fp16 GM workspace, so
         bf16 activations with large outliers overflow 65504 into ±inf and the
@@ -582,17 +582,27 @@ class FlashAttentionImpl(AttentionImpl):
         pre-scaling via extra["laser_input_scale"] (see abstract.py): q/k/v
         are divided by the factor, the kernel scale_value is multiplied by its
         square, and the output is scaled back. Absent or invalid factor means
-        no pre-scaling. The compensation is mathematically transparent to the
-        runtime-dispatch fallback op as well.
+        no pre-scaling.
         """
         resolved = self._resolve_packed_seq_npu(query, key, extra)
         if resolved is None:
             return None
         _, seq_k = resolved
         used_k = seq_k[0]  # real document length (first cumulative end)
-        from mindiesd import attention_forward
 
-        layout = self.qkv_layout or "BNSD"
+        try:
+            from mindiesd import attention_forward
+        except ImportError:
+            raise ImportError(
+                "FlashAttentionBackend NPU implementation requires MindIE-SD. "
+                "Please install MindIE-SD to enable NPU attention support. "
+                "For installation details, see https://gitcode.com/Ascend/MindIE-SD"
+                "Otherwise, use SDPA backend by setting DIFFUSION_ATTENTION_BACKEND=TORCH_SDPA"
+            )
+        # mindiesd always takes BSND input regardless of `layout`; the arg
+        # selects the op-internal layout and laser only supports BNSD, so do
+        # NOT forward the model's qkv_layout ("BSND" for MiniMax-H3) here.
+        layout = "BNSD"
         key = key[:, :used_k]
         value = value[:, :used_k]
 
@@ -609,36 +619,14 @@ class FlashAttentionImpl(AttentionImpl):
         def _postprocess(out: torch.Tensor) -> torch.Tensor:
             return out * input_scale if preserve_input_range else out
 
-        if not FlashAttentionImpl._npu_env_op_broken:
-            try:
-                return _postprocess(
-                    attention_forward(
-                        query,
-                        key,
-                        value,
-                        attn_mask=None,
-                        opt_mode="manual",
-                        op_type="fused_attn_score",  # MINDIE_SD_FA_TYPE env overrides this
-                        layout=layout,
-                        scale=scale,
-                    )
-                )
-            except RuntimeError as e:
-                FlashAttentionImpl._npu_env_op_broken = True
-                logger.warning(
-                    "MINDIE_SD_FA_TYPE=%s attention op failed (%s); falling back to "
-                    "runtime dispatch (fused_attn_score) for the rest of this process.",
-                    os.environ.get("MINDIE_SD_FA_TYPE"),
-                    str(e).splitlines()[0] if str(e) else type(e).__name__,
-                )
-        # "runtime" mode ignores MINDIE_SD_FA_TYPE and picks a supported op.
         return _postprocess(
             attention_forward(
                 query,
                 key,
                 value,
                 attn_mask=None,
-                opt_mode="runtime",
+                opt_mode="manual",
+                op_type="fused_attn_score",  # MINDIE_SD_FA_TYPE env overrides this
                 layout=layout,
                 scale=scale,
             )

--- a/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
+++ b/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
@@ -107,6 +107,15 @@ MINIMAX_H3_FP32_BUFFER_NAMES = frozenset({"rope.inv_freq"})
 # lookup and masked out afterwards).
 MINIMAX_H3_ADALN_MODALITY_NUM = 3
 
+# Opt-in fp16-range protection for the NPU ascend_laser_attention kernel
+# (consumed only via the "laser_input_scale" extra key; other backends and
+# platforms ignore it). The kernel stores unscaled QK^T in an fp16 GM
+# workspace, and H3's outlier activations (per-element amax in the hundreds)
+# push dot products past fp16 max 65504, turning whole 128-row blocks NaN.
+# 256 is a power of two, so pre-dividing q/k/v and the compensating
+# kernel-scale/output multiplies are exact in floating point.
+MINIMAX_H3_LASER_INPUT_SCALE = 256.0
+
 
 def _required_kwarg(kwargs: dict[str, Any], key: str) -> Any:
     if key not in kwargs or kwargs[key] is None:
@@ -401,11 +410,16 @@ class MiniMaxH3Attention(nn.Module):
         used = min(max_seqlen, packed_total)
         attn_mask = None
         # Ring attention can dispatch to a different implementation from the
-        # configured backend, so this no-mask fast path is local-only.
-        prefix_slice = (
-            not getattr(self.attention, "use_ring", False) and self.attention.attn_backend.supports_prefix_kv_slicing
+        # configured backend, so the no-mask fast paths are local-only.
+        # supports_prefix_kv_slicing: backend slices K/V itself (cuDNN).
+        # supports_packed_mask_free: backend consumes the packed metadata
+        # without ever reading attn_mask (CUDA packed varlen, NPU
+        # npu_attn_varlen opt-in with its own fallback rebuild).
+        no_mask = not getattr(self.attention, "use_ring", False) and (
+            self.attention.attn_backend.supports_prefix_kv_slicing
+            or self.attention.attn_backend.supports_packed_mask_free()
         )
-        if used < packed_total and not prefix_slice:
+        if used < packed_total and not no_mask:
             attn_mask = torch.arange(packed_total, device=q.device)[None] < used
         metadata = AttentionMetadata(
             attn_mask=attn_mask,
@@ -415,6 +429,15 @@ class MiniMaxH3Attention(nn.Module):
                 "max_seqlen_q": max_seqlen,
                 "max_seqlen_k": max_seqlen,
                 "valid_kv_length": used,
+                # Opt the NPU flash backend into the packed varlen path so the
+                # quadratic full_qk mask is never materialized. Ring attention
+                # is excluded: it keeps the aligned padding rows for its
+                # fixed-size P2P buffers and still needs the mask.
+                "npu_attn_varlen": not getattr(self.attention, "use_ring", False),
+                # fp16-range protection for the ascend_laser_attention kernel
+                # (see MINIMAX_H3_LASER_INPUT_SCALE). Ignored by every other
+                # backend/path.
+                "laser_input_scale": MINIMAX_H3_LASER_INPUT_SCALE,
             },
             video_layout=video_layout,
         )

--- a/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
+++ b/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
@@ -187,9 +187,17 @@ def _minimax_h3_post_process(output, output_type: str = "np"):
     if output_type == "latent":
         return output
     if output_type == "np":
-        video = video.detach().float().cpu().permute(0, 2, 3, 4, 1).clamp(0, 1).numpy()
+        video = video.detach().cpu()
+        if video.is_floating_point():
+            # Legacy float [0,1] path (on-device uint8 quantization disabled).
+            video = video.float().clamp(0, 1).permute(0, 2, 3, 4, 1).numpy()
+            video = [sample for sample in video]
+        else:
+            # D′ uint8 path: already quantized 0-255 by decode(). Emit uint8
+            # HWC frames so the mp4 encoder short-circuits the float round-trip.
+            video = video.permute(0, 2, 3, 4, 1).squeeze(0).contiguous().numpy()
+            video = [video[i] for i in range(video.shape[0])]
         audio = audio.detach().float().cpu().numpy()
-        video = [sample for sample in video]
     return {
         "video": video,
         "audio": audio,
@@ -1549,13 +1557,22 @@ class MiniMaxH3Pipeline(
         width: int,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         with self._component_on_device(self.video_vae):
+            # cache_enabled=False: VAE weights are fp32 and each is consumed
+            # only once per tile within this region, so autocast's fp16 cast
+            # cache has zero reuse and would pin ~4.5 GiB for the whole decode.
             with current_omni_platform.create_autocast_context(
                 device_type=self.device.type,
                 dtype=torch.float16,
                 enabled=True,
+                cache_enabled=False,
             ):
                 video = self.video_vae.decode_latent(video_latent)
-        video = video[..., :height, :width].contiguous()
+        video = video[..., :height, :width]
+        # D′: quantize to uint8 on-device. decode_latent already clamps to
+        # [0,1] in-place (see vae.py), so this only adds a cheap scale+cast.
+        # uint8 cuts the D2H transfer 4x (2.41 -> 0.6 GiB) and lets the mp4
+        # encoder skip a full float->uint8 recompute (~250 -> ~31 ms).
+        video = video.clamp(0, 1).mul(255).round().to(torch.uint8)
         with self._component_on_device(self.audio_vae):
             audio = self.audio_vae.decode_latent(audio_latent)
         return video, audio

--- a/vllm_omni/diffusion/models/minimax_h3/vae.py
+++ b/vllm_omni/diffusion/models/minimax_h3/vae.py
@@ -294,12 +294,34 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
             dtype=latent.dtype,
         ).view(1, channels, 1, 1, 1)
         decoded = self.model.decode_base(latent * std + mean)
-        frames = self.model.processor.revert_tensor(decoded)
+        # C: collapse processor.revert_tensor (3 full-size copies: Normalize
+        # output, clamp output, final contiguous) into 1 copy: the Normalize
+        # denorm is unavoidable, but clamp runs in place and the trailing
+        # contiguous is dropped (downstream only slices / casts / D2Hs, none of
+        # which need contiguity). NPU's in-place broadcast is unreliable here,
+        # so the denorm still goes through the proven torchvision Normalize.
+        frames = self._inplace_revert(decoded)
         if frames.ndim == 4:
             frames = frames.unsqueeze(0).transpose(1, 2)
         if frames.ndim != 5:
             raise ValueError(f"unexpected decoded video shape {tuple(frames.shape)}")
         return frames.float()
+
+    def _inplace_revert(self, decoded: torch.Tensor) -> torch.Tensor:
+        """Memory-lean equivalent of ``processor.revert_tensor``.
+
+        Channel-wise denormalize via the processor's torchvision ``Normalize``
+        (1 unavoidable copy), then clamp in place and reshape — skipping the
+        separate clamp copy and the final contiguous that ``revert_tensor``
+        allocates.
+        """
+        transform_rev = self.model.processor.transform_rev
+        if decoded.ndim == 5:
+            B, C, T, H, W = decoded.shape
+            flat = decoded.reshape(B * T, C, H, W)
+            return transform_rev(flat).clamp_(0, 1).reshape(B, C, T, H, W)
+        # 4D NCHW
+        return transform_rev(decoded).clamp_(0, 1)
 
 
 class MiniMaxH3AudioVAE(nn.Module):

--- a/vllm_omni/entrypoints/openai/video_api_utils.py
+++ b/vllm_omni/entrypoints/openai/video_api_utils.py
@@ -477,6 +477,14 @@ def _coerce_audio_to_numpy(audio: Any) -> np.ndarray:
 
 def _coerce_video_to_uint8_frames(video: Any) -> np.ndarray:
     """Convert a video payload into contiguous uint8 frames shaped (F, H, W, 3)."""
+    # Fast path: a payload that is already uint8 HWC frames (e.g. MiniMax-H3
+    # on-device quantized decode) skips the float normalization round-trip
+    # entirely — a ~8x postprocess speedup for long videos.
+    if isinstance(video, np.ndarray) and video.dtype == np.uint8 and video.ndim == 4:
+        return np.ascontiguousarray(video)
+    if isinstance(video, list) and video and all(isinstance(f, np.ndarray) and f.dtype == np.uint8 for f in video):
+        return np.ascontiguousarray(np.stack(video, axis=0))
+
     frames = _coerce_video_to_frames(video)
     if not frames:
         raise ValueError("No frames found to encode.")

--- a/vllm_omni/platforms/interface.py
+++ b/vllm_omni/platforms/interface.py
@@ -246,12 +246,22 @@ class OmniPlatform(Platform):
         device_type: str,
         dtype: torch.dtype,
         enabled: bool = True,
+        cache_enabled: bool = True,
     ):
         if not enabled:
             return nullcontext()
 
         try:
-            return torch.autocast(device_type=device_type, dtype=dtype, enabled=True)
+            # cache_enabled controls the autocast weight-cast cache. Disable it
+            # for workloads where each weight is consumed only once inside the
+            # region (e.g. MiniMax-H3 tiled VAE decode): the cached fp16 copies
+            # would live for the whole region with zero reuse, wasting HBM.
+            return torch.autocast(
+                device_type=device_type,
+                dtype=dtype,
+                enabled=True,
+                cache_enabled=cache_enabled,
+            )
         except (RuntimeError, TypeError, ValueError) as exc:
             logger.warning("autocast unavailable for device_type=%s dtype=%s: %s", device_type, dtype, exc)
             return nullcontext()

--- a/vllm_omni/platforms/npu/platform.py
+++ b/vllm_omni/platforms/npu/platform.py
@@ -139,6 +139,18 @@ class NPUOmniPlatform(OmniPlatform, NPUPlatform):
                 )
                 backend_upper = "FLASH_ATTN"
 
+            if backend_upper == "FLASH_ATTN" and find_spec("mindiesd"):
+                # The NPU FLASH_ATTN backend imports mindiesd lazily at first
+                # forward, but CANN snapshots the custom-op registry at the
+                # first custom-op regInfo lookup in the process (e.g. a
+                # vllm-ascend custom op during model load/warmup). Import
+                # mindiesd here so its env.py prepends the mindiesd vendor
+                # dirs (aie_ascendc etc.) to ASCEND_CUSTOM_OPP_PATH before
+                # that snapshot; otherwise aclnnLaserAttention /
+                # FusedAttentionScore fail with EZ1001 "does not support
+                # opType" for the rest of the process.
+                import mindiesd  # noqa: F401
+
             backend = DiffusionAttentionBackendEnum[backend_upper]
             logger.debug("Using diffusion attention backend '%s'", backend_upper)
             return backend.get_path()


### PR DESCRIPTION
### Purpose

显存快照分析显示 MiniMax-H3 的 VAE 解码峰值约 **11.75 GiB**(npu-smi 观察"解码时涨约 10G"),
其中三块可优化:

1. **autocast fp16 权重缓存 ~4.5 GiB**:`decode()` 在 fp16 autocast 下跑 fp32 权重的 VAE,
   autocast 默认把每个权重的 fp16 cast 副本缓存到整个 region 结束。但 tiled decode 每个 tile/chunk
   内每个权重只用一次,缓存零复用,纯白占;
2. **revert 链 ~4.8 GiB**:`processor.revert_tensor` 做反归一化时三步各新建一份全量(2.41 GiB)拷贝
   (Normalize 输出、clamp 输出、末尾 contiguous);
3. **后处理 ~250 ms**:`.float().cpu()` 下卡 2.41 GiB fp32,再在 CPU 上 clamp/×255 转 uint8。

### What this PR does

三个独立、可单独回退的优化:

- **A — autocast `cache_enabled=False`**(`pipeline.decode` + `interface.create_autocast_context`):
  关闭权重 cast 缓存,每个 tile 用完即释放。**省 ~4.5 GiB**。代价:每个 temporal chunk 重新 cast
  一遍权重(~9 ms × 6 chunk ≈ 55 ms),decode 是秒级,可忽略。
- **B — `_inplace_revert`**(`vae.decode_latent`):反归一化仍走 torchvision Normalize(1 份不可避免拷贝),
  但 clamp 改原地、去掉末尾 contiguous(downstream 只 slice/cast/D2H,不需要 contiguous)。
  **3 拷贝 → 1 拷贝,省 ~4.8 GiB**。
- **C — NPU/设备侧直出 uint8**(`pipeline.decode` + `post_process` + `video_api_utils`):
  decode 后直接 `clamp(0,1).mul(255).round().to(uint8)`,D2H 从 2.41 GiB fp32 降到 0.6 GiB uint8,
  且 mp4 编码器短路 uint8 不做 float 往返。**后处理 ~250 → ~31 ms(~8×)**。

实现注意:
- NPU 的 `inplace_sub` 对 `[1,3,1,1,1]` 广播有 op-plugin 对齐 bug(报 `8 and 3 cannot broadcast`),
  故 B 用已验证可用的 torchvision `transform_rev` 做反归一化而非手写 `sub_/div_`;
- C的 post_process 保留 `is_floating_point()` 分支:若 decode 出 float(C)仍走原 float 路径,
  向后兼容;`_coerce_video_to_uint8_frames` 的 uint8 短路仅在输入已是 uint8 时触发,其他模型不变。

### Test evidence

数值验证:

| 检查 | 结果 |
|---|---|
| B: `_inplace_revert` vs 完整 `revert_tensor` | maxdiff = **0.0(逐位等价)** |
| C: uint8 量化 vs numpy rint | maxdiff = 0 |
| C: `_coerce_video_to_uint8_frames` uint8 短路 | 数值一致 |

性能(真机 910,`bench_postprocess.py`):D2H fp32 2.41 GiB = 77 ms → uint8 0.6 GiB = 31 ms;
NPU clamp+×255+uint8 = 11 ms。后处理整链 ~250 → ~31 ms。

### 预期效果

| 组合 | decode 峰值(估) |
|---|---|
| 现状 | 11.75 GiB |
| +A | ~7.3 GiB(①4.5 消失) |
| +A+B | ~4.8 GiB(②从 4.8 降到 2.4) |
| +A +B +C | ~4.8 GiB(C 主要省**时延**和下卡带宽) |
