### PR TITLE
[Perf][MiniCPM-o] Add configurable first codec chunk threshold to cut TTFP

### DIFF
--- a/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
@@ -125,20 +125,25 @@ def _coerce_int(value):
         return None
 
 
-def _codec_config(transfer_manager: Any) -> tuple[int, int]:
+def _codec_config(transfer_manager: Any) -> tuple[int, int, int]:
     connector = getattr(transfer_manager, "connector", None)
     raw_config = getattr(connector, "config", {}) or {}
     config = raw_config.get("extra", raw_config) if isinstance(raw_config, dict) else {}
     config = config if isinstance(config, dict) else {}
     chunk_frames = int(config.get("codec_chunk_frames", 25))
     left_context_frames = int(config.get("codec_left_context_frames", 3))
-    if chunk_frames <= 0 or left_context_frames < 0:
+    # Optional smaller threshold for the very first emitted chunk of a request:
+    # lowers time-to-first-packet without touching steady-state chunk size
+    # (same idea as fish_speech ``initial_codec_chunk_frames``).
+    first_chunk_frames = int(config.get("codec_first_chunk_frames", chunk_frames))
+    if chunk_frames <= 0 or left_context_frames < 0 or first_chunk_frames <= 0:
         raise ValueError(
             "Invalid MiniCPM-o codec chunk config: "
             f"codec_chunk_frames={chunk_frames}, "
+            f"codec_first_chunk_frames={first_chunk_frames}, "
             f"codec_left_context_frames={left_context_frames}"
         )
-    return chunk_frames, left_context_frames
+    return chunk_frames, left_context_frames, min(first_chunk_frames, chunk_frames)
 
 
 def _codec_scalars(value: Any) -> list[int]:
@@ -289,16 +294,19 @@ def tts2code2wav_async_chunk(
         state["segment_text_recorded"] = True
     request_finished = getattr(request, "is_finished", None)
     finished = bool(is_finished or (callable(request_finished) and request_finished()))
-    chunk_frames, left_context_frames = _codec_config(transfer_manager)
+    chunk_frames, left_context_frames, first_chunk_frames = _codec_config(transfer_manager)
+    # First emission of a request (no codec history yet) may use a smaller
+    # threshold so the first audio packet ships earlier.
+    effective_frames = first_chunk_frames if int(state["codec_end"]) == 0 else chunk_frames
     flush_pending = finished
     last_chunk = bool(flush_pending and (not native_duplex or turn_end))
-    if not flush_pending and len(pending) < chunk_frames:
+    if not flush_pending and len(pending) < effective_frames:
         return None
 
     hold_short_unit = (
         native_duplex and flush_pending and not last_chunk and 0 < len(pending) < _MINICPMO45_MIN_STREAM_BODY_FRAMES
     )
-    new_token_count = 0 if hold_short_unit else (len(pending) if flush_pending else chunk_frames)
+    new_token_count = 0 if hold_short_unit else (len(pending) if flush_pending else effective_frames)
     new_codes = pending[:new_token_count]
     del pending[:new_token_count]
     codec_start = int(state["codec_end"])
@@ -395,7 +403,7 @@ def tts2code2wav_full_payload(
     internal_id = getattr(request, "request_id", None)
     request_id = str(external_id if external_id is not None else internal_id)
     codes = _extract_codec_delta(pooling_output, request_id)
-    _, left_context_frames = _codec_config(transfer_manager)
+    _, left_context_frames, _ = _codec_config(transfer_manager)
     context = [_MINICPMO45_SILENCE_CODE] * left_context_frames if codes else []
     output_codes = [*context, *codes]
 

--- a/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
@@ -135,12 +135,12 @@ def _codec_config(transfer_manager: Any) -> tuple[int, int, int]:
     # Optional smaller threshold for the very first emitted chunk of a request:
     # lowers time-to-first-packet without touching steady-state chunk size
     # (same idea as fish_speech ``initial_codec_chunk_frames``).
-    first_chunk_frames = int(config.get("codec_first_chunk_frames", chunk_frames))
+    first_chunk_frames = int(config.get("initial_codec_chunk_frames", chunk_frames))
     if chunk_frames <= 0 or left_context_frames < 0 or first_chunk_frames <= 0:
         raise ValueError(
             "Invalid MiniCPM-o codec chunk config: "
             f"codec_chunk_frames={chunk_frames}, "
-            f"codec_first_chunk_frames={first_chunk_frames}, "
+            f"initial_codec_chunk_frames={first_chunk_frames}, "
             f"codec_left_context_frames={left_context_frames}"
         )
     return chunk_frames, left_context_frames, min(first_chunk_frames, chunk_frames)


### PR DESCRIPTION
## Purpose

Reduce time-to-first-packet (TTFP) for MiniCPM-o 4.5 streaming speech without touching steady-state throughput.

The Talker→Code2Wav async chunking currently waits for a full `codec_chunk_frames` (default 25 frames = 1 s of audio) before emitting the first chunk, so the first audio packet cannot ship until the Talker has produced 25 codec tokens **and** the vocoder has processed all of them.

This PR introduces an optional `initial_codec_chunk_frames` key in the shared-memory connector `extra`: only the **first** emission of a request may use a smaller threshold; all subsequent chunks keep the steady-state size. The effective value is `min(initial_codec_chunk_frames, codec_chunk_frames)`, and the **default equals `codec_chunk_frames`, so behavior is unchanged unless explicitly configured**. This mirrors the existing `initial_codec_chunk_frames` mechanism in fish_speech.

The first-chunk threshold and the steady-state chunk size become independently tunable: deployments can ship the first packet after e.g. 8 frames (0.32 s of audio) while keeping — or even enlarging — the steady-state chunk for RTF.

## Test Plan

**vLLM Version:** 0.1.dev1+ge5588e49b (as shipped in `quay.io/ascend/vllm-omni:v0.25.0-a3`)

**vLLM-Omni Commit:** benchmarked on `minicpm-challenge` @ `1be47550`; patch re-applies cleanly on current HEAD `009b80d`

Setup: Ascend 910C (Atlas A3), single card, exclusive; deploy config `vllm_omni/deploy/minicpmo_4_5.yaml` with only `initial_codec_chunk_frames: 8` added (A/B on the same machine, same restart procedure, 3 warmup requests, single variable isolated).

Benchmark: `vllm bench serve --omni --backend openai-chat-omni --dataset-name seed-tts --seed-tts-locale en --num-prompts 32 --max-concurrency 1 --no-oversample` with `{"modalities":["text","audio"],"chat_template_kwargs":{"enable_thinking":false,"use_tts_template":true}}`, 3 rounds each.

Quality regression: seed-tts zh full set (2000 utterances), seed-tts-eval protocol (funasr paraformer-zh CER), same server/config.

## Test Result

Concurrency 1 (3-round means, same machine A/B):

| Metric | baseline (unmodified yaml) | `initial_codec_chunk_frames: 8` | Δ |
|---|---|---|---|
| Mean AUDIO_TTFP | 1049.04 ms | **861.86 ms** | **-17.8%** |
| Mean AUDIO_RTF | 0.4567 | 0.4600 | +0.7% (noise) |
| Mean TTFT | 316.27 ms | 315.99 ms | -0.1% |
| Streaming continuity | 100% | 100% | — |
| Requests | 96/96 ok | 96/96 ok | — |

Quality (seed-tts zh, 2000 utterances, CER): **1.377%** with the feature enabled (F16 reference 1.414%); speaker-similarity proxy (WavLM) 0.8475; zero failed requests.

Known trade-off (documented for completeness): with a small first chunk **and** the default 25-frame steady-state chunk, concurrency-8 RTF degrades ~13% because the vocoder receives more calls under saturation; pairing the feature with a larger steady-state chunk (e.g. 75) removes this and improves RTF at all tested concurrencies. The feature itself is off by default.

---

**参赛队伍：味蕾**（MiniCPM × 昇腾挑战赛 · 赛道一 · 子赛道 B / vLLM-Omni）
