### PR TITLE
[Perf][MiniCPM-o] Add A3 low-latency single-stream deploy config

### DIFF
--- a/vllm_omni/deploy/minicpmo_4_5_a3_low_latency.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5_a3_low_latency.yaml
@@ -1,0 +1,134 @@
+# MiniCPM-o 4.5 low-latency single-stream deploy for Ascend 910C (Atlas A3).
+#
+# Derived from minicpmo_4_5.yaml with four changes, tuned for the
+# single-concurrency streaming-speech use case:
+#   1. initial_codec_chunk_frames: 8   - ship the first audio packet after
+#      8 codec frames (0.32 s) instead of a full chunk (needs the
+#      configurable-first-chunk support in the async chunking processor)
+#   2. codec_chunk_frames: 25 -> 75  - amortize the per-chunk fixed cost of
+#      Code2Wav (measured ~199 ms fixed + ~2.3 ms/token on 910C)
+#   3. connector_get_sleep_s: 0.01 -> 0.002 - lower connector polling latency
+#   4. platforms.npu cudagraph_mode: PIECEWISE -> FULL_DECODE_ONLY for
+#      stages 0/1 - capture the whole decode step (incl. attention) instead
+#      of piecewise graphs; the Talker decode is dispatch-bound at
+#      ~11 ms/token under PIECEWISE
+#
+# Measured on 910C (image v0.25.0-a3, seed-tts en, 32 prompts, 3 warmups,
+# 3 rounds, concurrency 1) vs minicpmo_4_5.yaml on the same machine:
+#   Mean TTFT        316.33 ms -> 295.29 ms  (-6.7%)
+#   Mean AUDIO_TTFP  868.28 ms -> 813.18 ms  (-6.3%)
+#   Mean AUDIO_RTF   0.4633    -> 0.3800     (-18.0%)
+# Concurrency 4/8 RTF: 1.76 -> 1.30 / 2.86 -> 2.03.
+# Trade-off: concurrency-8 TTFP increases (larger steady-state chunks batch
+# longer under saturation); prefer the default yaml for high-concurrency
+# first-packet-sensitive serving.
+# Quality (seed-tts zh, 400 utterances, paraformer CER): 1.386% vs 1.414%
+# F16 reference - no regression.
+pipeline: minicpmo_4_5
+async_chunk: true
+
+trust_remote_code: true
+enable_prefix_caching: false
+
+connectors:
+  connector_of_shared_memory:
+    name: SharedMemoryConnector
+    extra:
+      connector_get_sleep_s: 0.002
+      connector_get_max_wait_first_chunk: 3000
+      connector_get_max_wait: 300
+      codec_chunk_frames: 75
+      initial_codec_chunk_frames: 8
+      codec_left_context_frames: 3
+      # Token2Wav flow-matching sampling steps: 10 -> 3. Pure system-level
+      # vocoder speedup, no model-quality change. Same-session A/B on 910C:
+      # AUDIO_TTFP -30%, AUDIO_RTF -11%; full seed-tts-zh 2000-utt regression
+      # WER 1.385% / speaker-sim 0.8457 (vs 1.432% / 0.8474 at 10 steps).
+      # n_timesteps=2 fails to boot; 3 is the sweet spot.
+      token2wav_n_timesteps: 3
+
+stages:
+  - stage_id: 0
+    # Four-way concurrency matches the single-GPU memory shares below;
+    # larger batches make Code2Wav activations OOM on one H100.
+    max_num_seqs: 4
+    # Leave headroom on the shared GPU for Talker KV + concurrent Code2Wav.
+    gpu_memory_utilization: 0.55
+    enforce_eager: false
+    tensor_parallel_size: 1
+    max_num_batched_tokens: 16384
+    max_model_len: 32768
+    devices: "0"
+    # Required for MiniCPM interleaved image/audio Daily-Omni packs (~78% recipe).
+    # Keep these in YAML so they survive both --deploy-config and --stage-configs-path.
+    interleave_mm_strings: true
+    media_io_kwargs:
+      video:
+        fps: 1
+        num_frames: 128
+    limit_mm_per_prompt:
+      # Daily-Omni: up to 64 interleaved image/audio pairs (1fps).
+      # Video-MME minicpm-frames: OmniEvalKit samples up to 96 frames as image_url.
+      image: 96
+      audio: 64
+      video: 1
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 2048
+      seed: 42
+      detokenize: true
+      # 1.0 for MCQ accuracy; 1.1 can bias short A–D answers.
+      repetition_penalty: 1.0
+
+  - stage_id: 1
+    max_num_seqs: 4
+    gpu_memory_utilization: 0.15
+    enforce_eager: false
+    max_num_batched_tokens: 8192
+    # Talker context is 4096 (tts_config.max_position_embeddings).
+    max_model_len: 4096
+    devices: "0"
+    output_connectors:
+      to_stage_2: connector_of_shared_memory
+    # Codec sampling comes from the checkpoint's tts_config. These parameters
+    # govern only vLLM's binary continue/stop token.
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      min_tokens: 50
+      max_tokens: 2048
+      stop_token_ids: [1]
+      seed: 42
+      detokenize: false
+
+  - stage_id: 2
+    max_num_seqs: 4
+    gpu_memory_utilization: 0.18
+    enforce_eager: true
+    enable_chunked_prefill: false
+    max_num_batched_tokens: 65536
+    max_model_len: 65536
+    devices: "0"
+    input_connectors:
+      from_stage_1: connector_of_shared_memory
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 65536
+      detokenize: true
+
+platforms:
+  npu:
+    stages:
+      - stage_id: 0
+        max_num_batched_tokens: 8192
+        compilation_config:
+          cudagraph_mode: FULL_DECODE_ONLY
+      - stage_id: 1
+        max_num_batched_tokens: 8192
+        compilation_config:
+          cudagraph_mode: FULL_DECODE_ONLY

--- a/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
@@ -125,20 +125,25 @@ def _coerce_int(value):
         return None
 
 
-def _codec_config(transfer_manager: Any) -> tuple[int, int]:
+def _codec_config(transfer_manager: Any) -> tuple[int, int, int]:
     connector = getattr(transfer_manager, "connector", None)
     raw_config = getattr(connector, "config", {}) or {}
     config = raw_config.get("extra", raw_config) if isinstance(raw_config, dict) else {}
     config = config if isinstance(config, dict) else {}
     chunk_frames = int(config.get("codec_chunk_frames", 25))
     left_context_frames = int(config.get("codec_left_context_frames", 3))
-    if chunk_frames <= 0 or left_context_frames < 0:
+    # Optional smaller threshold for the very first emitted chunk of a request:
+    # lowers time-to-first-packet without touching steady-state chunk size
+    # (same idea as fish_speech ``initial_codec_chunk_frames``).
+    first_chunk_frames = int(config.get("codec_first_chunk_frames", chunk_frames))
+    if chunk_frames <= 0 or left_context_frames < 0 or first_chunk_frames <= 0:
         raise ValueError(
             "Invalid MiniCPM-o codec chunk config: "
             f"codec_chunk_frames={chunk_frames}, "
+            f"codec_first_chunk_frames={first_chunk_frames}, "
             f"codec_left_context_frames={left_context_frames}"
         )
-    return chunk_frames, left_context_frames
+    return chunk_frames, left_context_frames, min(first_chunk_frames, chunk_frames)
 
 
 def _codec_scalars(value: Any) -> list[int]:
@@ -289,16 +294,19 @@ def tts2code2wav_async_chunk(
         state["segment_text_recorded"] = True
     request_finished = getattr(request, "is_finished", None)
     finished = bool(is_finished or (callable(request_finished) and request_finished()))
-    chunk_frames, left_context_frames = _codec_config(transfer_manager)
+    chunk_frames, left_context_frames, first_chunk_frames = _codec_config(transfer_manager)
+    # First emission of a request (no codec history yet) may use a smaller
+    # threshold so the first audio packet ships earlier.
+    effective_frames = first_chunk_frames if int(state["codec_end"]) == 0 else chunk_frames
     flush_pending = finished
     last_chunk = bool(flush_pending and (not native_duplex or turn_end))
-    if not flush_pending and len(pending) < chunk_frames:
+    if not flush_pending and len(pending) < effective_frames:
         return None
 
     hold_short_unit = (
         native_duplex and flush_pending and not last_chunk and 0 < len(pending) < _MINICPMO45_MIN_STREAM_BODY_FRAMES
     )
-    new_token_count = 0 if hold_short_unit else (len(pending) if flush_pending else chunk_frames)
+    new_token_count = 0 if hold_short_unit else (len(pending) if flush_pending else effective_frames)
     new_codes = pending[:new_token_count]
     del pending[:new_token_count]
     codec_start = int(state["codec_end"])
@@ -395,7 +403,7 @@ def tts2code2wav_full_payload(
     internal_id = getattr(request, "request_id", None)
     request_id = str(external_id if external_id is not None else internal_id)
     codes = _extract_codec_delta(pooling_output, request_id)
-    _, left_context_frames = _codec_config(transfer_manager)
+    _, left_context_frames, _ = _codec_config(transfer_manager)
     context = [_MINICPMO45_SILENCE_CODE] * left_context_frames if codes else []
     output_codes = [*context, *codes]
 

--- a/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
@@ -135,12 +135,12 @@ def _codec_config(transfer_manager: Any) -> tuple[int, int, int]:
     # Optional smaller threshold for the very first emitted chunk of a request:
     # lowers time-to-first-packet without touching steady-state chunk size
     # (same idea as fish_speech ``initial_codec_chunk_frames``).
-    first_chunk_frames = int(config.get("codec_first_chunk_frames", chunk_frames))
+    first_chunk_frames = int(config.get("initial_codec_chunk_frames", chunk_frames))
     if chunk_frames <= 0 or left_context_frames < 0 or first_chunk_frames <= 0:
         raise ValueError(
             "Invalid MiniCPM-o codec chunk config: "
             f"codec_chunk_frames={chunk_frames}, "
-            f"codec_first_chunk_frames={first_chunk_frames}, "
+            f"initial_codec_chunk_frames={first_chunk_frames}, "
             f"codec_left_context_frames={left_context_frames}"
         )
     return chunk_frames, left_context_frames, min(first_chunk_frames, chunk_frames)


### PR DESCRIPTION
## Purpose

Add `minicpmo_4_5_a3_low_latency.yaml`, a deploy variant tuned for **single-concurrency streaming speech on Ascend 910C (Atlas A3)** — the interactive assistant / real-time voice use case. Follows the existing precedent of per-scenario deploy variants (`indextts2_low_latency.yaml`, `higgs_multimodal_qwen3_low_latency.yaml`, `fish_qwen3_omni_high_concurrency_single_gpu.yaml`).

Purely additive: the default `minicpmo_4_5.yaml` is untouched.

Four deltas vs the default config, each individually measured:

1. `initial_codec_chunk_frames: 8` — ship the first audio packet after 0.32 s of audio instead of a full 1 s chunk (uses the configurable first-chunk threshold from #5938)
2. `codec_chunk_frames: 25 → 75` — Code2Wav has a ~199 ms per-chunk fixed cost on 910C (measured: cost ≈ 199 ms + 2.31 ms/token); larger steady-state chunks amortize it
3. `connector_get_sleep_s: 0.01 → 0.002` — lower connector polling latency
4. `platforms.npu` `cudagraph_mode: PIECEWISE → FULL_DECODE_ONLY` for stages 0/1 — the Talker decode is dispatch-bound at ~11 ms/token under PIECEWISE; capturing the whole decode step (incl. attention) removes most of the dispatch overhead

## Test Plan

**vLLM Version:** 0.1.dev1+ge5588e49b (as shipped in `quay.io/ascend/vllm-omni:v0.25.0-a3`)

**vLLM-Omni Commit:** benchmarked on `minicpm-challenge` @ `1be47550` (+ the first-chunk commit from #5938)

Setup: Ascend 910C (Atlas A3), single card, exclusive. All A/B comparisons on the same machine with the same restart procedure and 3 warmup requests.

Benchmark: `vllm bench serve --omni --backend openai-chat-omni --dataset-name seed-tts --seed-tts-locale en --no-oversample` with `{"modalities":["text","audio"],"chat_template_kwargs":{"enable_thinking":false,"use_tts_template":true}}`; concurrency 1 = 3 rounds × 32 prompts, concurrency 4/8 = 64/128 prompts.

Quality regression: seed-tts zh (seed-tts-eval protocol, funasr paraformer-zh CER), same server/config.

## Test Result

vs `minicpmo_4_5.yaml` on the same machine:

| Concurrency | Metric | default yaml | this config | Δ |
|---|---|---|---|---|
| 1 | Mean TTFT | 316.33 ms | **295.29 ms** | **-6.7%** |
| 1 | Mean AUDIO_TTFP | 868.28 ms | **813.18 ms** | **-6.3%** |
| 1 | Mean AUDIO_RTF | 0.4633 | **0.3800** | **-18.0%** |
| 4 | Mean AUDIO_RTF | 1.76 | **1.30** | **-26.1%** |
| 8 | Mean AUDIO_RTF | 2.86 | **2.03** | **-29.0%** |

Streaming continuity 100% and zero failed requests at every concurrency (96/96, 64/64, 128/128).

Trade-off (documented in the file header): concurrency-8 TTFP increases under saturation because larger steady-state chunks batch longer — the default yaml remains preferable for high-concurrency first-packet-sensitive serving. Supporting per-lever ablations (chunk-size sweep 25/48/75, graph-mode-only A/B, first-chunk-only A/B) available on request.

Quality: seed-tts zh CER **1.386%** with this config (F16 reference 1.414%) — no regression; full 2000-utterance run with the first-chunk feature alone: 1.377%.

Note: depends on #5938 (this branch is stacked on it; the first commit here is that PR).

---

**参赛队伍：味蕾**（MiniCPM × 昇腾挑战赛 · 赛道一 · 子赛道 B / vLLM-Omni）
