### PR TITLE
[Kernel] Fix Fish attention fallback on strided KV cache

### DIFF
--- a/tests/attention/test_fish_kvcache_attn.py
+++ b/tests/attention/test_fish_kvcache_attn.py
@@ -169,6 +169,28 @@ def test_fish_kvcache_attn_guard_rejects_unsupported_block_size(monkeypatch):
     )
 
 
+def test_fish_kvcache_attn_guard_rejects_non_dense_head_dimension(monkeypatch):
+    monkeypatch.setenv("VLLM_OMNI_FISH_KVCACHE_ATTN", "1")
+    monkeypatch.setattr(fish_kvcache_attn, "is_available", lambda: True)
+    key_cache = torch.empty((8, 16, 8, 256), dtype=torch.float16)[..., ::2]
+    value_cache = torch.empty((8, 16, 8, 256), dtype=torch.float16)[..., ::2]
+
+    assert key_cache.stride(-1) == 2
+    assert not fish_kvcache_attn.can_use_fish_kvcache_attn(
+        query=torch.empty((4, 32, 128), dtype=torch.float16),
+        key_cache=key_cache,
+        value_cache=value_cache,
+        block_table=torch.zeros((4, 8), dtype=torch.int32),
+        seq_lens=torch.ones((4,), dtype=torch.int32),
+        max_query_len=1,
+        max_seq_len=128,
+        dcp_world_size=1,
+        use_cascade=False,
+        alibi_slopes=None,
+        sliding_window=None,
+    )
+
+
 def test_fish_kvcache_backend_wraps_only_model_instance(monkeypatch):
     fish_kvcache_backend.reset_fish_kvcache_attn_stats()
     monkeypatch.setenv("VLLM_OMNI_FISH_KVCACHE_ATTN", "1")
@@ -262,24 +284,10 @@ def test_fish_kvcache_backend_unbinds_kv_on_vllm_cache_layout(monkeypatch):
     assert captured["value"] == expected
 
 
-def test_fish_kvcache_vllm_cache_unbinds_then_falls_back_until_contiguous(monkeypatch):
-    # End-to-end with the real vLLM cache layout and the real (unmocked) guard.
-    #
-    # The point of the transpose+split fix: unbind(1) on the old 5-D layout
-    # raised "too many values to unpack" on the vLLM 0.23.0 layout, and the
-    # upstream now packs K/V into the last dimension (4-D shape). The
-    # transpose(1, 2) + split correctly unpacks into separate key/value tensors
-    # and the backend gracefully falls back to the original attention with
-    # correct output. This test guards that fix and must NOT depend on the fast
-    # path firing.
-    #
-    # It also documents a known limitation (tracked separately):
-    # transpose(1, 2) on the interleaved (B, H, N, 2*D) layout yields
-    # *non-contiguous* key/value views, which the guard rejects on the
-    # is_contiguous() check. So the dimensions are compatible (4-D,
-    # block_size=16, head_size=128) -- the only thing keeping the fast path
-    # from engaging is contiguity, not shape. Making the fast path actually
-    # fire would require a .contiguous() copy and is out of scope here.
+def test_fish_kvcache_vllm_strided_cache_hits_fast_path(monkeypatch):
+    # Backend-level regression with the real vLLM cache layout and guard.
+    # transpose(1, 2) + split produces non-contiguous K/V views, so the Triton
+    # kernel must consume their strides directly without materializing copies.
     fish_kvcache_backend.reset_fish_kvcache_attn_stats()
     monkeypatch.setenv("VLLM_OMNI_FISH_KVCACHE_ATTN", "1")
     monkeypatch.setattr(fish_kvcache_backend, "is_available", lambda: True)
@@ -291,9 +299,11 @@ def test_fish_kvcache_vllm_cache_unbinds_then_falls_back_until_contiguous(monkey
 
     decode_calls = []
 
-    def fake_decode(*args, **kwargs):
-        del args, kwargs
-        decode_calls.append(True)
+    def fake_decode(query, key_cache, value_cache, block_table, seq_lens, out, *, scale, max_seq_len):
+        del query, block_table, seq_lens, scale, max_seq_len
+        decode_calls.append((key_cache.stride(), value_cache.stride()))
+        out.fill_(1)
+        return out
 
     monkeypatch.setattr(fish_kvcache_backend, "fish_decode_kvcache_attn", fake_decode)
 
@@ -304,22 +314,22 @@ def test_fish_kvcache_vllm_cache_unbinds_then_falls_back_until_contiguous(monkey
     output = torch.zeros_like(query)
     kv_cache = torch.zeros(cache_shape, dtype=torch.float16)
 
-    # Root cause record: transpose(1,2) + split gives the right 4-D shape but
-    # a non-contiguous view.
+    # Root cause record: transpose(1, 2) + split gives the right 4-D shape but
+    # a non-contiguous view with K/V packed in the same backing allocation.
     key_cache, value_cache = kv_cache.transpose(1, 2).split(head_size, dim=-1)
     assert tuple(key_cache.shape) == (num_blocks, block_size, num_kv_heads, head_size)
     assert not key_cache.is_contiguous()
+    assert value_cache.storage_offset() == head_size
 
-    # transpose+split no longer crashes (unbind(1) would have raised here) and
-    # the request completes via the correct fallback path.
     result = model.layers[0].self_attn.attn.impl.forward(None, query, None, None, kv_cache, _metadata(), output)
 
     assert result is output
-    assert decode_calls == []
-    assert model.layers[0].self_attn.attn.impl.original_calls == 1
-    assert torch.equal(output, torch.full_like(output, 2))
+    assert decode_calls == [(key_cache.stride(), value_cache.stride())]
+    assert model.layers[0].self_attn.attn.impl.original_calls == 0
+    assert torch.equal(output, torch.ones_like(output))
     stats = fish_kvcache_backend.get_fish_kvcache_attn_stats()
-    assert stats["fallback_count_by_reason"] == {"guard_miss": 1}
+    assert stats["small_hit_count"] == 1
+    assert stats["fallback_count_by_reason"] == {}
 
 
 def test_fish_kvcache_backend_install_is_idempotent(monkeypatch):
@@ -1037,6 +1047,63 @@ def test_fish_kvcache_native_op_matches_reference(seq_len, dtype, batch_size):
     torch.testing.assert_close(out, expected, atol=3e-2, rtol=3e-2)
 
 
+@pytest.mark.cuda
+@pytest.mark.parametrize("seq_len", [512, 2048])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not fish_kvcache_attn.is_available(),
+    reason="Fish kvcache Triton attention is not available",
+)
+def test_fish_kvcache_native_op_matches_reference_with_vllm_strided_cache(seq_len, dtype):
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    batch_size = 2
+    block_size = 16
+    num_q_heads = 4
+    num_kv_heads = 2
+    head_dim = 128
+    max_blocks = (seq_len + block_size - 1) // block_size
+    num_blocks = batch_size * max_blocks + 3
+    scale = head_dim**-0.5
+
+    q = torch.randn((batch_size, num_q_heads, head_dim), device=device, dtype=dtype)
+    packed_kv_cache = torch.randn(
+        (num_blocks, num_kv_heads, block_size, 2 * head_dim),
+        device=device,
+        dtype=dtype,
+    )
+    k_cache, v_cache = packed_kv_cache.transpose(1, 2).split(head_dim, dim=-1)
+    assert not k_cache.is_contiguous()
+    assert k_cache.stride() == v_cache.stride()
+    assert v_cache.storage_offset() == head_dim
+
+    block_table = torch.empty((batch_size, max_blocks), device=device, dtype=torch.int32)
+    for batch_idx in range(batch_size):
+        pages = torch.arange(
+            batch_idx * max_blocks,
+            (batch_idx + 1) * max_blocks,
+            device=device,
+            dtype=torch.int32,
+        )
+        block_table[batch_idx] = torch.flip(pages, dims=[0])
+    seq_lens = torch.full((batch_size,), seq_len, device=device, dtype=torch.int32)
+
+    out = torch.empty_like(q)
+    fish_kvcache_attn.fish_decode_kvcache_attn(
+        q,
+        k_cache,
+        v_cache,
+        block_table,
+        seq_lens,
+        out,
+        scale=scale,
+        max_seq_len=seq_len,
+    )
+
+    expected = _reference_decode_attention(q, k_cache, v_cache, block_table, seq_lens, scale)
+    torch.testing.assert_close(out, expected, atol=3e-2, rtol=3e-2)
+
+
 @pytest.mark.skipif(
     not torch.cuda.is_available() or not fish_kvcache_attn.is_available(),
     reason="Fish kvcache Triton attention is not available",
@@ -1094,8 +1161,13 @@ def test_fish_kvcache_native_op_handles_mixed_short_and_long_seq_lens():
     scale = head_dim**-0.5
 
     q = torch.randn((batch_size, num_q_heads, head_dim), device=device, dtype=dtype)
-    k_cache = torch.randn((num_blocks, block_size, num_kv_heads, head_dim), device=device, dtype=dtype)
-    v_cache = torch.randn((num_blocks, block_size, num_kv_heads, head_dim), device=device, dtype=dtype)
+    packed_kv_cache = torch.randn(
+        (num_blocks, num_kv_heads, block_size, 2 * head_dim),
+        device=device,
+        dtype=dtype,
+    )
+    k_cache, v_cache = packed_kv_cache.transpose(1, 2).split(head_dim, dim=-1)
+    assert not k_cache.is_contiguous()
     block_table = torch.empty((batch_size, max_blocks), device=device, dtype=torch.int32)
     for batch_idx in range(batch_size):
         pages = torch.arange(batch_idx * max_blocks, (batch_idx + 1) * max_blocks, device=device, dtype=torch.int32)
@@ -1137,8 +1209,13 @@ def test_fish_kvcache_native_op_handles_zero_short_and_long_seq_lens():
     scale = head_dim**-0.5
 
     q = torch.randn((batch_size, num_q_heads, head_dim), device=device, dtype=dtype)
-    k_cache = torch.randn((num_blocks, block_size, num_kv_heads, head_dim), device=device, dtype=dtype)
-    v_cache = torch.randn((num_blocks, block_size, num_kv_heads, head_dim), device=device, dtype=dtype)
+    packed_kv_cache = torch.randn(
+        (num_blocks, num_kv_heads, block_size, 2 * head_dim),
+        device=device,
+        dtype=dtype,
+    )
+    k_cache, v_cache = packed_kv_cache.transpose(1, 2).split(head_dim, dim=-1)
+    assert not k_cache.is_contiguous()
     block_table = torch.empty((batch_size, max_blocks), device=device, dtype=torch.int32)
     for batch_idx in range(batch_size):
         pages = torch.arange(batch_idx * max_blocks, (batch_idx + 1) * max_blocks, device=device, dtype=torch.int32)
@@ -1169,8 +1246,9 @@ def test_fish_kvcache_native_op_can_be_captured_by_cuda_graph():
     device = torch.device("cuda")
     dtype = torch.float16
     q = torch.randn((2, 4, 128), device=device, dtype=dtype)
-    k_cache = torch.randn((8, 16, 2, 128), device=device, dtype=dtype)
-    v_cache = torch.randn((8, 16, 2, 128), device=device, dtype=dtype)
+    packed_kv_cache = torch.randn((8, 2, 16, 256), device=device, dtype=dtype)
+    k_cache, v_cache = packed_kv_cache.transpose(1, 2).split(128, dim=-1)
+    assert not k_cache.is_contiguous()
     block_table = torch.arange(8, device=device, dtype=torch.int32).reshape(2, 4)
     seq_lens = torch.full((2,), 64, device=device, dtype=torch.int32)
     out = torch.empty_like(q)
@@ -1221,8 +1299,13 @@ def test_fish_kvcache_native_long_op_can_be_captured_by_cuda_graph():
     max_blocks = (seq_len + block_size - 1) // block_size
 
     q = torch.randn((2, num_q_heads, head_dim), device=device, dtype=dtype)
-    k_cache = torch.randn((2 * max_blocks, block_size, num_kv_heads, head_dim), device=device, dtype=dtype)
-    v_cache = torch.randn((2 * max_blocks, block_size, num_kv_heads, head_dim), device=device, dtype=dtype)
+    packed_kv_cache = torch.randn(
+        (2 * max_blocks, num_kv_heads, block_size, 2 * head_dim),
+        device=device,
+        dtype=dtype,
+    )
+    k_cache, v_cache = packed_kv_cache.transpose(1, 2).split(head_dim, dim=-1)
+    assert not k_cache.is_contiguous()
     block_table = torch.arange(2 * max_blocks, device=device, dtype=torch.int32).reshape(2, max_blocks)
     seq_lens = torch.full((2,), seq_len, device=device, dtype=torch.int32)
     out = torch.empty_like(q)

--- a/vllm_omni/attention/fish_kvcache_attn.py
+++ b/vllm_omni/attention/fish_kvcache_attn.py
@@ -85,9 +85,14 @@ def can_use_fish_kvcache_attn(
         return False
     if block_table.shape[0] != query.shape[0] or seq_lens.shape[0] != query.shape[0]:
         return False
-    if query.shape[-1] != 128 or key_cache.shape[-1] != 128:
+    if query.shape[-1] != 128 or key_cache.shape[-1] != 128 or value_cache.shape[-1] != 128:
+        return False
+    if key_cache.shape != value_cache.shape:
         return False
     if key_cache.shape[1] != 16:
+        return False
+    num_kv_heads = key_cache.shape[2]
+    if num_kv_heads <= 0 or query.shape[1] % num_kv_heads != 0:
         return False
     if query.dtype not in (torch.float16, torch.bfloat16):
         return False
@@ -95,17 +100,21 @@ def can_use_fish_kvcache_attn(
         return False
     if block_table.dtype != torch.int32 or seq_lens.dtype != torch.int32:
         return False
+    if not (query.device == key_cache.device == value_cache.device == block_table.device == seq_lens.device):
+        return False
     if max_seq_len <= 0:
         return False
     if max_seq_len > block_table.shape[1] * key_cache.shape[1]:
         return False
-    if not (
-        query.is_contiguous()
-        and key_cache.is_contiguous()
-        and value_cache.is_contiguous()
-        and block_table.is_contiguous()
-        and seq_lens.is_contiguous()
-    ):
+    if not (query.is_contiguous() and block_table.is_contiguous() and seq_lens.is_contiguous()):
+        return False
+    # vLLM packs K/V in the last dimension of a (block, head, token, 2*dim)
+    # allocation. transpose(1, 2) + split therefore returns strided views.
+    # The Triton kernel consumes all four strides directly; only the head
+    # dimension must remain dense for coalesced vector loads.
+    if key_cache.stride(-1) != 1 or value_cache.stride(-1) != 1:
+        return False
+    if any(stride <= 0 for stride in (*key_cache.stride(), *value_cache.stride())):
         return False
     return True
 

--- a/vllm_omni/attention/fish_kvcache_triton.py
+++ b/vllm_omni/attention/fish_kvcache_triton.py
@@ -46,6 +46,14 @@ if is_available():
         BLOCK_H: tl.constexpr,
         BLOCK_D: tl.constexpr,
         BLOCK_N: tl.constexpr,
+        K_STRIDE_BLOCK: tl.constexpr,
+        K_STRIDE_TOKEN: tl.constexpr,
+        K_STRIDE_HEAD: tl.constexpr,
+        K_STRIDE_DIM: tl.constexpr,
+        V_STRIDE_BLOCK: tl.constexpr,
+        V_STRIDE_TOKEN: tl.constexpr,
+        V_STRIDE_HEAD: tl.constexpr,
+        V_STRIDE_DIM: tl.constexpr,
         GUARD_MAX_SEQ_LEN: tl.constexpr,
     ):
         batch_id = tl.program_id(0)
@@ -80,14 +88,23 @@ if is_available():
                 other=0,
             )
 
-            kv_offsets = (
-                (physical_block[:, None] * 16 + block_offset[:, None]) * NUM_KV_HEADS + kv_head
-            ) * BLOCK_D + offs_d[None, :]
-            k = tl.load(K + kv_offsets, mask=mask_n[:, None], other=0.0)
+            k_offsets = (
+                physical_block[:, None] * K_STRIDE_BLOCK
+                + block_offset[:, None] * K_STRIDE_TOKEN
+                + kv_head * K_STRIDE_HEAD
+                + offs_d[None, :] * K_STRIDE_DIM
+            )
+            k = tl.load(K + k_offsets, mask=mask_n[:, None], other=0.0)
             qk = tl.dot(q, tl.trans(k)) * SCALE
             qk = tl.where(mask_h[:, None] & mask_n[None, :], qk, -float("inf"))
 
-            v = tl.load(V + kv_offsets, mask=mask_n[:, None], other=0.0)
+            v_offsets = (
+                physical_block[:, None] * V_STRIDE_BLOCK
+                + block_offset[:, None] * V_STRIDE_TOKEN
+                + kv_head * V_STRIDE_HEAD
+                + offs_d[None, :] * V_STRIDE_DIM
+            )
+            v = tl.load(V + v_offsets, mask=mask_n[:, None], other=0.0)
             m_new = tl.maximum(m_i, tl.max(qk, axis=1))
             p = tl.exp(qk - m_new[:, None])
             alpha = tl.exp(m_i - m_new)
@@ -119,6 +136,14 @@ if is_available():
         BLOCK_H: tl.constexpr,
         BLOCK_D: tl.constexpr,
         BLOCK_N: tl.constexpr,
+        K_STRIDE_BLOCK: tl.constexpr,
+        K_STRIDE_TOKEN: tl.constexpr,
+        K_STRIDE_HEAD: tl.constexpr,
+        K_STRIDE_DIM: tl.constexpr,
+        V_STRIDE_BLOCK: tl.constexpr,
+        V_STRIDE_TOKEN: tl.constexpr,
+        V_STRIDE_HEAD: tl.constexpr,
+        V_STRIDE_DIM: tl.constexpr,
         SPLIT_TOKENS: tl.constexpr,
         BATCH_SIZE: tl.constexpr,
         MIN_SEQ_LEN: tl.constexpr,
@@ -165,14 +190,23 @@ if is_available():
                 other=0,
             )
 
-            kv_offsets = (
-                (physical_block[:, None] * 16 + block_offset[:, None]) * NUM_KV_HEADS + kv_head
-            ) * BLOCK_D + offs_d[None, :]
-            k = tl.load(K + kv_offsets, mask=mask_n[:, None], other=0.0)
+            k_offsets = (
+                physical_block[:, None] * K_STRIDE_BLOCK
+                + block_offset[:, None] * K_STRIDE_TOKEN
+                + kv_head * K_STRIDE_HEAD
+                + offs_d[None, :] * K_STRIDE_DIM
+            )
+            k = tl.load(K + k_offsets, mask=mask_n[:, None], other=0.0)
             qk = tl.dot(q, tl.trans(k)) * SCALE
             qk = tl.where(mask_h[:, None] & mask_n[None, :], qk, -float("inf"))
 
-            v = tl.load(V + kv_offsets, mask=mask_n[:, None], other=0.0)
+            v_offsets = (
+                physical_block[:, None] * V_STRIDE_BLOCK
+                + block_offset[:, None] * V_STRIDE_TOKEN
+                + kv_head * V_STRIDE_HEAD
+                + offs_d[None, :] * V_STRIDE_DIM
+            )
+            v = tl.load(V + v_offsets, mask=mask_n[:, None], other=0.0)
             m_new = tl.maximum(m_i, tl.max(qk, axis=1))
             p = tl.exp(qk - m_new[:, None])
             alpha = tl.exp(m_i - m_new)
@@ -265,6 +299,8 @@ def fish_decode_kvcache_attn_triton(
     kv_group = num_q_heads // num_kv_heads
     block_h = triton.next_power_of_2(kv_group)
     max_blocks_per_seq = block_table.shape[1]
+    k_stride_block, k_stride_token, k_stride_head, k_stride_dim = key_cache.stride()
+    v_stride_block, v_stride_token, v_stride_head, v_stride_dim = value_cache.stride()
 
     if max_seq_len <= small_path_max_seq_len:
         _small_decode_kernel[(batch_size, num_kv_heads)](
@@ -283,6 +319,14 @@ def fish_decode_kvcache_attn_triton(
             BLOCK_H=block_h,
             BLOCK_D=head_dim,
             BLOCK_N=_BLOCK_N,
+            K_STRIDE_BLOCK=k_stride_block,
+            K_STRIDE_TOKEN=k_stride_token,
+            K_STRIDE_HEAD=k_stride_head,
+            K_STRIDE_DIM=k_stride_dim,
+            V_STRIDE_BLOCK=v_stride_block,
+            V_STRIDE_TOKEN=v_stride_token,
+            V_STRIDE_HEAD=v_stride_head,
+            V_STRIDE_DIM=v_stride_dim,
             GUARD_MAX_SEQ_LEN=0,
             num_warps=4,
             num_stages=3,
@@ -305,6 +349,14 @@ def fish_decode_kvcache_attn_triton(
         BLOCK_H=block_h,
         BLOCK_D=head_dim,
         BLOCK_N=_BLOCK_N,
+        K_STRIDE_BLOCK=k_stride_block,
+        K_STRIDE_TOKEN=k_stride_token,
+        K_STRIDE_HEAD=k_stride_head,
+        K_STRIDE_DIM=k_stride_dim,
+        V_STRIDE_BLOCK=v_stride_block,
+        V_STRIDE_TOKEN=v_stride_token,
+        V_STRIDE_HEAD=v_stride_head,
+        V_STRIDE_DIM=v_stride_dim,
         GUARD_MAX_SEQ_LEN=small_path_max_seq_len,
         num_warps=4,
         num_stages=3,
@@ -333,6 +385,14 @@ def fish_decode_kvcache_attn_triton(
         BLOCK_H=block_h,
         BLOCK_D=head_dim,
         BLOCK_N=_BLOCK_N,
+        K_STRIDE_BLOCK=k_stride_block,
+        K_STRIDE_TOKEN=k_stride_token,
+        K_STRIDE_HEAD=k_stride_head,
+        K_STRIDE_DIM=k_stride_dim,
+        V_STRIDE_BLOCK=v_stride_block,
+        V_STRIDE_TOKEN=v_stride_token,
+        V_STRIDE_HEAD=v_stride_head,
+        V_STRIDE_DIM=v_stride_dim,
         SPLIT_TOKENS=long_split_tokens,
         BATCH_SIZE=batch_size,
         MIN_SEQ_LEN=small_path_max_seq_len + 1,


### PR DESCRIPTION
## Purpose

Fixes #5942.

The Fish Speech decode-only KV-cache backend unpacks vLLM's current packed cache layout with `transpose(1, 2) + split`. This produces correctly shaped K/V tensors, but they are non-contiguous strided views. The fast-path guard required both tensors to be fully contiguous, so every otherwise-compatible decode request fell back to the original attention implementation.

This is the known limitation left by #4428 after the cache-unpacking fix.

This PR:

- allows safe strided K/V views when their head dimension is dense;
- passes the actual K/V strides into both the short- and long-context Triton kernels;
- calculates K and V offsets independently without materializing per-decode contiguous copies;
- adds a backend regression test proving the real vLLM packed cache layout hits the Fish fast path instead of recording `guard_miss`;
- validates strided-cache kernel outputs against a PyTorch reference.

No public API, model configuration, or dependency changes are included.

## Test Plan

The bug is reproducible with synthetic tensors using the cache shape returned by vLLM's `FlashAttentionBackend.get_kv_cache_shape`; loading the full Fish Speech checkpoint is not required.

Coverage in `tests/attention/test_fish_kvcache_attn.py` includes:

- real vLLM packed/strided KV-cache layout and backend fast-path dispatch;
- rejection of layouts whose head dimension is not dense;
- FP16 and BF16 numerical comparison against a PyTorch reference;
- short and long sequence lengths;
- mixed short/long and zero-length rows;
- short- and long-path CUDA Graph capture.

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** `90102075`

**Test hardware:** NVIDIA GeForce RTX 4090

## Test Result

```bash
pytest -q tests/attention/test_fish_kvcache_attn.py
```

All tests in the module passed locally, including the CUDA-gated FP16/BF16 strided-cache correctness and CUDA Graph cases.

```bash
pre-commit run --files \
  vllm_omni/attention/fish_kvcache_attn.py \
  vllm_omni/attention/fish_kvcache_triton.py \
  tests/attention/test_fish_kvcache_attn.py
```

All hooks passed.
