### PR TITLE
[Perf][MiniCPM-o] Cut Talker per-step host overhead in the sampling path

### DIFF
--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py
@@ -133,6 +133,10 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
 
         self._language_model_names = ["model"]
         self.prefer_model_sampler = self.model_stage in {"llm", "tts"}
+        # The Talker samples over 2-wide stop logits and keeps its own codec
+        # history; the duplex LLM sampler is the only stage reading vLLM's
+        # decoded-token history.
+        self.model_sampler_needs_output_token_ids = self.model_stage != "tts"
         # Both AR stages require model-specific embeddings.  The Thinker uses
         # preprocess for duplex audio, while the Talker converts the
         # tts_token_ids/tts_hidden_states handoff into its conditioning

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
@@ -23,6 +23,7 @@ from vllm.logger import init_logger
 from vllm.model_executor.models.interfaces import SupportsPP
 from vllm.model_executor.models.llama import LlamaModel
 from vllm.model_executor.models.utils import maybe_prefix
+from vllm.v1.outputs import SamplerOutput
 from vllm.v1.sample.sampler import Sampler
 
 from vllm_omni.experimental.fullduplex.engine.intermediate import get_tts_handoff
@@ -65,6 +66,17 @@ def _restore_weight_norm_weight(weight_g: torch.Tensor, weight_v: torch.Tensor) 
     return torch._weight_norm(weight_v, weight_g, dim=0)
 
 
+_SHARED_VLLM_SAMPLER: "Sampler | None" = None
+
+
+def _shared_vllm_sampler() -> "Sampler":
+    """The vLLM sampler is stateless; constructing it per decode step is pure overhead."""
+    global _SHARED_VLLM_SAMPLER
+    if _SHARED_VLLM_SAMPLER is None:
+        _SHARED_VLLM_SAMPLER = Sampler()
+    return _SHARED_VLLM_SAMPLER
+
+
 def _apply_repetition_penalty(
     logits: torch.Tensor,
     history: torch.Tensor,
@@ -87,9 +99,10 @@ def _apply_top_k_top_p(
     top_k: int | None,
     top_p: float | None,
     min_tokens_to_keep: int = 3,
+    inplace: bool = False,
 ) -> torch.Tensor:
     """Apply the same candidate floors as the upstream Transformers warpers."""
-    filtered = logits.clone()
+    filtered = logits if inplace else logits.clone()
     vocab_size = filtered.shape[-1]
     # MiniCPM-o's gen_logits() appends TopPLogitsWarper before
     # TopKLogitsWarper. The order is observable for fixed-seed sampling.
@@ -392,11 +405,14 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
         )
         if step < min_tokens:
             logits[..., eos_id] = float("-inf")
+        # ``logits`` is freshly materialized above (head_code -> float -> penalty),
+        # so the warpers may mask it in place.
         logits = _apply_top_k_top_p(
             logits,
             top_k=self._codec_top_k,
             top_p=self._codec_top_p,
             min_tokens_to_keep=3,
+            inplace=True,
         )
         probabilities = torch.softmax(logits, dim=-1)
         return torch.multinomial(
@@ -404,6 +420,29 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
             num_samples=1,
             generator=self._request_generator(request_id, probabilities.device),
         ).reshape(())
+
+    def _step_constants(self, hidden: torch.Tensor):
+        """Constant per-step tensors, cached per (device, dtype).
+
+        These never change and downstream consumers only read them, so the
+        per-step H2D copies from ``new_tensor``/``torch.tensor`` are avoidable.
+        """
+        cache = getattr(self, "_step_constants_cache", None)
+        key = (hidden.device, hidden.dtype)
+        if cache is None or cache[0] != key:
+            neg_inf = float("-inf")
+            cache = (
+                key,
+                (
+                    hidden.new_tensor([0.0, neg_inf]),
+                    hidden.new_tensor([neg_inf, 0.0]),
+                    torch.tensor(False, dtype=torch.bool),
+                    torch.tensor(True, dtype=torch.bool),
+                    hidden.new_empty((0, 1), dtype=torch.long),
+                ),
+            )
+            self._step_constants_cache = cache
+        return cache[1]
 
     def make_omni_output(
         self,
@@ -434,7 +473,7 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
         duplex_turn_ids: list[torch.Tensor] = []
         segment_texts_utf8: list[torch.Tensor] = []
         turn_end_flags: list[torch.Tensor] = []
-        empty_delta = hidden.new_empty((0, 1), dtype=torch.long)
+        row_continue, row_stop, flag_false, flag_true, empty_delta = self._step_constants(hidden)
         for index, info in enumerate(infos):
             info_dict = info if isinstance(info, dict) else {}
             native_duplex = info_dict.get("native_duplex") is True
@@ -480,16 +519,16 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
                 turn_end_flags.append(torch.tensor(native_duplex and contains_turn_eos, dtype=torch.bool))
 
             if not isinstance(info, dict):
-                stop_rows.append(hidden.new_tensor([0.0, float("-inf")]))
+                stop_rows.append(row_continue)
                 codec_deltas.append(empty_delta)
-                terminal_flags.append(torch.tensor(False, dtype=torch.bool))
+                terminal_flags.append(flag_false)
                 continue
             start, end = spans[index]
             end = min(int(end), int(hidden.shape[0]))
             if int(start) >= end:
-                stop_rows.append(hidden.new_tensor([0.0, float("-inf")]))
+                stop_rows.append(row_continue)
                 codec_deltas.append(empty_delta)
-                terminal_flags.append(torch.tensor(False, dtype=torch.bool))
+                terminal_flags.append(flag_false)
                 continue
             request_id = str(info.get("request_id", index))
             request_states = getattr(self, "_request_audio_states", None)
@@ -501,17 +540,17 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
                 state = dict(info.get("audio_state", {}) or {})
                 request_states[request_id] = state
             if state.get("finished"):
-                stop_rows.append(hidden.new_tensor([float("-inf"), 0.0]))
+                stop_rows.append(row_stop)
                 codec_deltas.append(empty_delta)
-                terminal_flags.append(torch.tensor(False, dtype=torch.bool))
+                terminal_flags.append(flag_false)
                 continue
             if not sample_eligible[index]:
                 # vLLM computes a logit row for incomplete chunked prefills but
                 # discards its sampled token. Advancing codec/RNG state here
                 # would make output depend on prefill chunking and compaction.
-                stop_rows.append(hidden.new_tensor([0.0, float("-inf")]))
+                stop_rows.append(row_continue)
                 codec_deltas.append(empty_delta)
-                terminal_flags.append(torch.tensor(False, dtype=torch.bool))
+                terminal_flags.append(flag_false)
                 continue
             codes = state.get("codes")
             if not isinstance(codes, torch.Tensor):
@@ -542,8 +581,8 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
                 "accumulated": codes,
             }
             codec_deltas.append(delta)
-            terminal_flags.append(torch.tensor(finished, dtype=torch.bool))
-            stop_rows.append(hidden.new_tensor([float("-inf"), 0.0] if finished else [0.0, float("-inf")]))
+            terminal_flags.append(flag_true if finished else flag_false)
+            stop_rows.append(row_stop if finished else row_continue)
 
         self._batch_stop_logits = torch.stack(stop_rows, dim=0) if stop_rows else hidden.new_empty((0, 2))
         # Lists are deliberate: the runner routes element i to request i,
@@ -635,7 +674,22 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
         return logits
 
     def sample(self, logits, sampling_metadata):
-        return Sampler()(logits, sampling_metadata)
+        # ``compute_logits`` emits one-hot stop rows ([0, -inf] / [-inf, 0]),
+        # so a full sampler pass is ~10 host-dispatched kernels for a
+        # deterministic pick; argmax is bit-identical on these rows. int32
+        # matches the standard sampler's output dtype -- the runner scatters
+        # these ids into int32 input buffers on the async path.
+        if (
+            isinstance(logits, torch.Tensor)
+            and logits.ndim == 2
+            and logits.shape[-1] == 2
+            and not getattr(sampling_metadata, "max_num_logprobs", None)
+        ):
+            return SamplerOutput(
+                sampled_token_ids=logits.argmax(dim=-1, keepdim=True).to(torch.int32),
+                logprobs_tensors=None,
+            )
+        return _shared_vllm_sampler()(logits, sampling_metadata)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         return self._load_native_weights(weights)

--- a/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
@@ -886,7 +886,15 @@ class NPUARModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
                         self.input_batch.idx_mapping_np,
                         self.input_batch.positions[self.input_batch.logits_indices],
                     )
-                prepared_sampling_metadata = self._sampling_metadata_for_model_sampler(sampling_metadata)
+                if getattr(self.model, "model_sampler_needs_output_token_ids", True) or not getattr(
+                    sampling_metadata, "no_penalties", False
+                ):
+                    prepared_sampling_metadata = self._sampling_metadata_for_model_sampler(sampling_metadata)
+                else:
+                    # Rebuilding decoded-token history costs a D2H sync + full
+                    # list copies per step; skip it for model samplers that
+                    # declare they never read it (unless penalties need it).
+                    prepared_sampling_metadata = sampling_metadata
                 self._apply_duplex_sampling(logits, prepared_sampling_metadata)
                 sampler_output = model_sample(logits, prepared_sampling_metadata)
                 if sampler_output is not None:

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -1449,7 +1449,15 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
                         self.input_batch.idx_mapping_np,
                         self.input_batch.positions[self.input_batch.logits_indices],
                     )
-                prepared_sampling_metadata = self._sampling_metadata_for_model_sampler(sampling_metadata)
+                if getattr(self.model, "model_sampler_needs_output_token_ids", True) or not getattr(
+                    sampling_metadata, "no_penalties", False
+                ):
+                    prepared_sampling_metadata = self._sampling_metadata_for_model_sampler(sampling_metadata)
+                else:
+                    # Rebuilding decoded-token history costs a D2H sync + full
+                    # list copies per step; skip it for model samplers that
+                    # declare they never read it (unless penalties need it).
+                    prepared_sampling_metadata = sampling_metadata
                 self._apply_duplex_sampling(logits, prepared_sampling_metadata)
                 sampler_output = model_sample(logits, prepared_sampling_metadata)
                 if sampler_output is not None:


### PR DESCRIPTION
## Purpose

Cut avoidable per-step host overhead in the MiniCPM-o 4.5 Talker decode path. On Ascend 910C the Talker step is host-bound; py-spy profiling (200 Hz, steady-state decode) shows the sampling path spends ~1 ms/step on work that produces no value:

| Hot spot | Cost | Fix |
|---|---|---|
| `sample()` constructs `Sampler()` every decode step | module init per token | module-level singleton (the vLLM sampler is stateless) |
| Full sampler pipeline over 2-wide one-hot stop rows (`[0,-inf]` / `[-inf,0]`) | ~10 host-dispatched kernels for a deterministic pick | argmax fast-path, guarded on 2-wide logits and no logprobs request |
| `make_omni_output()` rebuilds constant tensors (stop rows, terminal flags, empty delta) via `new_tensor`/`torch.tensor` each step | per-step H2D copies | cache per (device, dtype) |
| `_apply_top_k_top_p()` clones the full-vocab row each step | one 6.5k-float copy per token | in-place masking behind an explicit `inplace=True` opt-in (caller's tensor is freshly materialized; default unchanged) |
| AR runners rebuild the full decoded-token history (D2H sync + list copies per step) for `prefer_model_sampler` models | grows with sequence length | models may declare `model_sampler_needs_output_token_ids = False`; skipped only when penalties don't need the history either. The Talker keeps its own codec history; only the duplex LLM sampler reads vLLM's. Applied to both the NPU and GPU AR runners. |

All changes are **bit-exact by construction**: no sampling distribution, RNG draw order, or output value changes. The argmax fast-path emits **int32** to match the standard sampler's output dtype — the runner `scatter_`s the ids into int32 input buffers on the async-scheduling path (int64 crashes there at concurrency > 1).

## Test Plan

**vLLM Version:** 0.1.dev1+ge5588e49b (as shipped in `quay.io/ascend/vllm-omni:v0.25.0-a3`)

**vLLM-Omni Commit:** benchmarked on `minicpm-challenge` (base of this branch)

Setup: Ascend 910C (Atlas A3), single card, exclusive; same-machine A/B with identical restart procedure and 3 warmup requests. Deploy config: the A3 low-latency variant from #5939 (also reproduces on the default `minicpmo_4_5.yaml` — the levers are config-independent).

- Per-step timing: env-gated instrumentation around the sampling path, plus stage ITL from server stats logs.
- E2E: `vllm bench serve --omni --backend openai-chat-omni --dataset-name seed-tts --seed-tts-locale en --no-oversample`, concurrency 1 = 3 rounds × 32 prompts, concurrency 4/8 = 64/128 prompts.
- Quality: seed-tts zh, seed-tts-eval protocol (funasr paraformer-zh CER), 400 utterances, same server.

## Test Result

Per-step (stage1 Talker, single stream):

| Metric | before | after |
|---|---|---|
| sampling path (chain + sync) | 1.50 ms/step | 1.35 ms/step |
| output assembly total | 1.75 ms/step | 1.48 ms/step |
| stage1 ITL | 8.7–9.6 ms/token | **7.6–8.4 ms/token** |

E2E (3-round means, concurrency 1): AUDIO_RTF **0.38 → 0.37**, TTFT/TTFP unchanged (295.8 ms / 811.8 ms), streaming continuity 100%, 96/96 requests OK.

Concurrency: no regression — conc 4 RTF 1.31 (64/64 OK), conc 8 RTF 2.01 (128/128 OK), continuity 100%.

Quality: seed-tts zh 400-utterance check CER **1.409%** (median 0.0, speaker-sim proxy 0.8485, zero failures) — within run-to-run noise of the F16 reference (1.414%) and of pre-change runs (1.377%/1.386%), as expected for a bit-exact change (the Talker's per-request RNG is not request-seed controlled, so run-to-run CER jitters regardless).

---

**参赛队伍：味蕾**（MiniCPM × 昇腾挑战赛 · 赛道一 · 子赛道 B / vLLM-Omni）
