### PR TITLE
[MiniMax-H3] Enable calibrated TeaCache for Ref2VA

### DIFF
--- a/docs/user_guide/diffusion_features.md
+++ b/docs/user_guide/diffusion_features.md
@@ -163,7 +163,7 @@ The following tables show which models support each feature:
 | **DreamID-Omni**             |     ❌     |     ❌      |           ❌           |       ✅        |         ❌         |         ❌         |   ✅    |             ✅             |          ❌           |       ❌        |        ❌         |
 | **Cosmos3**                  |     ❌     |     ✅      |           ✅           |       ✅        |         ✅         |         ❌         |   ✅    |             ✅             |  ✅ (encode/decode)   |       ✅        |        ❌         |
 | **LongCat-Video-Avatar-1.5** |     ❌     |     ❌      |           ❌           |       ❌        |         ❌         |         ❌         |   ❌    |             ❌             |          ❌           |       ❌        |        ❌         |
-| **MiniMax-H3**               | ✅ (FL2VA) |     ✅      |           ✅           |       ❌        |       ✅ (DiT/TE)  |         ❌         |   ✅    |             ✅             |       ✅ (tile)       |      ✅ (DiT)      |        ❌         |
+| **MiniMax-H3**               |     ✅     |     ✅      |           ✅           |       ❌        |       ✅ (DiT/TE)  |         ❌         |   ✅    |             ✅             |       ✅ (tile)       |      ✅ (DiT)      |        ❌         |
 
 > **Step execution note:** Helios supports single-request step execution only;
 > use `max_num_seqs=1`.

--- a/recipes/MiniMaxAI/MiniMax-H3.md
+++ b/recipes/MiniMaxAI/MiniMax-H3.md
@@ -753,18 +753,40 @@ reduction.
 ## TeaCache acceleration
 
 TeaCache reuses DiT block residuals across denoising steps when consecutive
-timestep embeddings are similar. MiniMax-H3 TeaCache is currently calibrated
-only for the FL2VA partition. In combined serving, FL2VA requests use TeaCache
-while Ref2VA requests run uncached; Ref2VA-only serving rejects TeaCache.
+timestep embeddings are similar. MiniMax-H3 has independently calibrated
+profiles for FL2VA and Ref2VA. A combined server installs a separate hook and
+request-scoped cache state on each DiT, so task switching cannot reuse residuals
+from the other checkpoint partition.
+
+Omit `cache_config` to use the calibrated defaults. FL2VA uses
+`rel_l1_thresh=0.17`. Ref2VA uses its own coefficients and
+`rel_l1_thresh=0.295`, computes the first 35 denoising calls in full, and allows
+at most five cache hits in the remaining calls. The late-step policy prevents a
+small number of early high-noise skips from changing the rest of a long-reference
+trajectory. This profile is calibrated for 50 inference steps; other step counts
+fail closed and run uncached. A 50-step request that never meets the late-step
+criterion also runs uncached.
 
 TeaCache and Cache-DiT are mutually exclusive; pick one cache backend per server.
+Changing `rel_l1_thresh` can trade quality for speed, but it does not remove the
+Ref2VA warmup or five-hit safety budget. Validate custom thresholds on both video
+and audio outputs.
 
-The model-specific default and examples use `rel_l1_thresh=0.17`, which
-provided the best conservative speed/quality balance in the validated 107-frame
-T2VA workload. Lower values
-may produce few or no cache hits, while higher values can improve performance
-at the cost of output quality. Validate the threshold on representative
-prompts and generation settings before changing it.
+### Ref2VA validation
+
+The Ref2VA profile was fitted from 15 full-compute requests: six image-only, six
+image+audio, and three video+audio cases. A same-seed single-B300 A/B used BF16,
+`CUDNN_ATTN`, a four-second request, 448x256, 107 output frames, and 50 requested
+inference steps:
+
+| Case | Cache hits | Baseline | TeaCache | Speedup | Video quality vs baseline | Audio quality |
+|---|---:|---:|---:|---:|---:|---:|
+| Image-only | 0 / 49 | 53.34 s | 53.26 s | 1.00x | SSIM 1.000 | sample-identical |
+| Video+audio | 5 / 49 | 244.19 s | 221.24 s | 1.10x | SSIM 0.9795 / PSNR 41.60 dB | 168.8 dB PSNR |
+
+Both video+audio runs peaked at 140,972 MiB; TeaCache is a compute optimization,
+not a weight-memory optimization. The image case demonstrates the conservative
+fallback: no qualifying late steps means no approximation and no speedup.
 
 ### Offline (Python API)
 
@@ -780,7 +802,6 @@ from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 omni = Omni(
     model=os.path.join(os.environ["MODEL_ROOT"], "FL2VA"),
     cache_backend="tea_cache",
-    cache_config={"rel_l1_thresh": 0.17},
     trust_remote_code=True,
     enable_cpu_offload=True,
 )
@@ -804,19 +825,20 @@ outputs = omni.generate(
 )
 ```
 
+For Ref2VA, point `model` at `${MODEL_ROOT}/Ref2VA`; combined serving selects
+the matching calibrated profile per request.
+
 ### Online serving
 
 ```bash
-vllm serve "${MODEL_ROOT}/FL2VA" \
+vllm serve "${MODEL_ROOT}/Ref2VA" \
   --omni \
   --trust-remote-code \
-  --cache-backend tea_cache \
-  --cache-config '{"rel_l1_thresh":0.17}'
+  --cache-backend tea_cache
 ```
 
 ## Known limitations
 
-- TeaCache is calibrated for FL2VA only; Ref2VA requests run uncached.
 - Combined serving requires sibling `FL2VA` and `Ref2VA` directories, loads
   both task-specific DiTs, and loads shared components once from `FL2VA`.
 - H3 currently executes one generation request per diffusion batch.

--- a/tests/diffusion/cache/test_cache_backends.py
+++ b/tests/diffusion/cache/test_cache_backends.py
@@ -455,6 +455,8 @@ class TestTeaCacheBackend:
         [
             ({"max_cached_steps": -1}, "max_cached_steps"),
             ({"min_compute_steps": -1}, "min_compute_steps"),
+            ({"calibrated_num_inference_steps": 0}, "calibrated_num_inference_steps"),
+            ({"calibrated_num_inference_steps": -1}, "calibrated_num_inference_steps"),
         ],
     )
     def test_config_rejects_negative_step_policy(self, config, field):
@@ -496,88 +498,64 @@ class TestTeaCacheBackend:
         TeaCacheBackend(DiffusionCacheConfig()).enable(pipeline)
         assert mock_apply_hook.call_args.args[1].rel_l1_thresh == 0.2
 
-    @pytest.mark.parametrize(
-        ("partition", "expected_targets", "default_thresholds", "profiles", "max_cached_steps", "min_compute_steps"),
-        [
-            ("fl2va", ("transformer",), (0.17,), (None,), (None,), (0,)),
-            ("ref2va", ("transformer",), (0.295,), ("MiniMaxH3DiTModel:ref2va",), (5,), (35,)),
-            (
-                "combined",
-                ("transformer", "transformers_ref"),
-                (0.17, 0.295),
-                (None, "MiniMaxH3DiTModel:ref2va"),
-                (None, 5),
-                (0, 35),
-            ),
-        ],
-    )
-    @pytest.mark.parametrize(
-        "configured_threshold",
-        [None, 0.2],
-    )
     @patch("vllm_omni.diffusion.cache.teacache.backend.apply_teacache_hook")
-    def test_minimax_h3_enables_each_partition_transformer(
-        self,
-        mock_apply_hook,
-        partition,
-        expected_targets,
-        default_thresholds,
-        profiles,
-        configured_threshold,
-        max_cached_steps,
-        min_compute_steps,
-    ):
-        pipeline = Mock()
-        pipeline.__class__.__name__ = "MiniMaxH3Pipeline"
-        pipeline.partition = partition
-        pipeline.transformer = Mock()
-        pipeline.transformer.__class__.__name__ = "MiniMaxH3DiTModel"
-        pipeline.transformers_ref = Mock()
+    def test_enable_uses_pipeline_declared_hook_configs(self, mock_apply_hook):
+        primary = Mock()
+        secondary = Mock()
+        primary_config = TeaCacheConfig()
+        secondary_config = TeaCacheConfig(rel_l1_thresh=0.3)
 
-        config = (
-            DiffusionCacheConfig()
-            if configured_threshold is None
-            else DiffusionCacheConfig(rel_l1_thresh=configured_threshold)
-        )
-        backend = TeaCacheBackend(config)
+        class DeclaredPipeline:
+            transformer = primary
+            nested = SimpleNamespace(transformer=secondary)
+
+            def _teacache_hook_configs(self, config):
+                assert config.rel_l1_thresh == 0.4
+                return {
+                    "transformer": primary_config,
+                    "nested.transformer": secondary_config,
+                }
+
+        backend = TeaCacheBackend(DiffusionCacheConfig(rel_l1_thresh=0.4))
+        pipeline = DeclaredPipeline()
         backend.enable(pipeline)
 
-        expected_transformers = [getattr(pipeline, name) for name in expected_targets]
-        assert [call.args[0] for call in mock_apply_hook.call_args_list] == expected_transformers
-        configs = [call.args[1] for call in mock_apply_hook.call_args_list]
-        expected_thresholds = (
-            default_thresholds if configured_threshold is None else (configured_threshold,) * len(configs)
-        )
-        assert [config.rel_l1_thresh for config in configs] == list(expected_thresholds)
-        assert [config.calibration_profile for config in configs] == list(profiles)
-        assert [config.max_cached_steps for config in configs] == list(max_cached_steps)
-        assert [config.min_compute_steps for config in configs] == list(min_compute_steps)
-        assert len({id(config) for config in configs}) == len(configs)
+        assert mock_apply_hook.call_args_list[0].args == (primary, primary_config)
+        assert mock_apply_hook.call_args_list[1].args == (secondary, secondary_config)
 
-    @pytest.mark.parametrize(("num_inference_steps", "expected_ref_min_compute"), [(50, 35), (20, 20)])
-    def test_minimax_h3_refreshes_each_partition_transformer(self, num_inference_steps, expected_ref_min_compute):
-        pipeline = Mock()
-        pipeline.__class__.__name__ = "MiniMaxH3Pipeline"
-        pipeline._dit_modules = ["transformer", "transformers_ref"]
-        pipeline.transformer = Mock(_hook_registry=Mock())
-        pipeline.transformers_ref = Mock(_hook_registry=Mock())
-        fl2va_hook = Mock(config=SimpleNamespace(calibration_profile=None, min_compute_steps=0))
-        ref2va_hook = Mock(
-            config=SimpleNamespace(
-                calibration_profile="MiniMaxH3DiTModel:ref2va",
-                min_compute_steps=35,
-            )
+    def test_refresh_prepares_each_declared_dit(self):
+        primary_hook = Mock()
+        primary_hook.prepare_for_request.return_value = True
+        secondary_hook = Mock(
+            config=SimpleNamespace(calibrated_num_inference_steps=50),
         )
-        pipeline.transformer._hook_registry.get_hook.return_value = fl2va_hook
-        pipeline.transformers_ref._hook_registry.get_hook.return_value = ref2va_hook
+        secondary_hook.prepare_for_request.return_value = False
+        primary = SimpleNamespace(_hook_registry=Mock())
+        secondary = SimpleNamespace(_hook_registry=Mock())
+        primary._hook_registry.get_hook.return_value = primary_hook
+        secondary._hook_registry.get_hook.return_value = secondary_hook
+        pipeline = SimpleNamespace(
+            _dit_modules=["transformer", "nested.transformer"],
+            transformer=primary,
+            nested=SimpleNamespace(transformer=secondary),
+        )
 
         backend = TeaCacheBackend(DiffusionCacheConfig())
-        backend.refresh(pipeline, num_inference_steps=num_inference_steps)
+        backend.refresh(pipeline, num_inference_steps=20)
 
-        for transformer in (pipeline.transformer, pipeline.transformers_ref):
+        for hook in (primary_hook, secondary_hook):
+            hook.prepare_for_request.assert_called_once_with(20)
+        for transformer in (primary, secondary):
             transformer._hook_registry.reset_hook.assert_called_once_with(TeaCacheHook._HOOK_NAME)
-        assert fl2va_hook.config.min_compute_steps == 0
-        assert ref2va_hook.config.min_compute_steps == expected_ref_min_compute
+
+    def test_config_fails_closed_outside_calibrated_step_count(self):
+        config = TeaCacheConfig(
+            min_compute_steps=35,
+            calibrated_num_inference_steps=50,
+        )
+
+        assert config.resolve_min_compute_steps(50) == 35
+        assert config.resolve_min_compute_steps(20) == 20
 
     @patch("vllm_omni.diffusion.cache.teacache.backend.apply_teacache_hook")
     def test_enable_with_coefficients(self, mock_apply_hook):

--- a/tests/diffusion/cache/test_cache_backends.py
+++ b/tests/diffusion/cache/test_cache_backends.py
@@ -26,7 +26,11 @@ from vllm_omni.diffusion.cache.cachedit import (
 )
 from vllm_omni.diffusion.cache.magcache import MagCacheBackend
 from vllm_omni.diffusion.cache.selector import get_cache_backend
-from vllm_omni.diffusion.cache.teacache import TeaCacheBackend
+from vllm_omni.diffusion.cache.teacache import (
+    TeaCacheBackend,
+    TeaCacheConfig,
+    TeaCacheHook,
+)
 from vllm_omni.diffusion.data import DiffusionCacheConfig
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
@@ -446,6 +450,17 @@ class TestCacheDiTBackend:
 class TestTeaCacheBackend:
     """Test TeaCacheBackend implementation."""
 
+    @pytest.mark.parametrize(
+        ("config", "field"),
+        [
+            ({"max_cached_steps": -1}, "max_cached_steps"),
+            ({"min_compute_steps": -1}, "min_compute_steps"),
+        ],
+    )
+    def test_config_rejects_negative_step_policy(self, config, field):
+        with pytest.raises(ValueError, match=field):
+            TeaCacheConfig(**config)
+
     def test_init(self):
         """Test initialization."""
         config = DiffusionCacheConfig(rel_l1_thresh=0.3)
@@ -481,18 +496,36 @@ class TestTeaCacheBackend:
         TeaCacheBackend(DiffusionCacheConfig()).enable(pipeline)
         assert mock_apply_hook.call_args.args[1].rel_l1_thresh == 0.2
 
-    @pytest.mark.parametrize("partition", ["fl2va", "combined"])
     @pytest.mark.parametrize(
-        ("configured_threshold", "expected_threshold"),
-        [(None, 0.17), (0.2, 0.2)],
+        ("partition", "expected_targets", "default_thresholds", "profiles", "max_cached_steps", "min_compute_steps"),
+        [
+            ("fl2va", ("transformer",), (0.17,), (None,), (None,), (0,)),
+            ("ref2va", ("transformer",), (0.295,), ("MiniMaxH3DiTModel:ref2va",), (5,), (35,)),
+            (
+                "combined",
+                ("transformer", "transformers_ref"),
+                (0.17, 0.295),
+                (None, "MiniMaxH3DiTModel:ref2va"),
+                (None, 5),
+                (0, 35),
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "configured_threshold",
+        [None, 0.2],
     )
     @patch("vllm_omni.diffusion.cache.teacache.backend.apply_teacache_hook")
-    def test_minimax_h3_only_enables_fl2va_teacache(
+    def test_minimax_h3_enables_each_partition_transformer(
         self,
         mock_apply_hook,
         partition,
+        expected_targets,
+        default_thresholds,
+        profiles,
         configured_threshold,
-        expected_threshold,
+        max_cached_steps,
+        min_compute_steps,
     ):
         pipeline = Mock()
         pipeline.__class__.__name__ = "MiniMaxH3Pipeline"
@@ -509,27 +542,42 @@ class TestTeaCacheBackend:
         backend = TeaCacheBackend(config)
         backend.enable(pipeline)
 
-        mock_apply_hook.assert_called_once()
-        transformer, teacache_config = mock_apply_hook.call_args.args
-        assert transformer is pipeline.transformer
-        assert transformer is not pipeline.transformers_ref
-        assert teacache_config.rel_l1_thresh == expected_threshold
+        expected_transformers = [getattr(pipeline, name) for name in expected_targets]
+        assert [call.args[0] for call in mock_apply_hook.call_args_list] == expected_transformers
+        configs = [call.args[1] for call in mock_apply_hook.call_args_list]
+        expected_thresholds = (
+            default_thresholds if configured_threshold is None else (configured_threshold,) * len(configs)
+        )
+        assert [config.rel_l1_thresh for config in configs] == list(expected_thresholds)
+        assert [config.calibration_profile for config in configs] == list(profiles)
+        assert [config.max_cached_steps for config in configs] == list(max_cached_steps)
+        assert [config.min_compute_steps for config in configs] == list(min_compute_steps)
+        assert len({id(config) for config in configs}) == len(configs)
 
-    @patch("vllm_omni.diffusion.cache.teacache.backend.apply_teacache_hook")
-    def test_minimax_h3_rejects_ref2va_teacache(self, mock_apply_hook):
+    @pytest.mark.parametrize(("num_inference_steps", "expected_ref_min_compute"), [(50, 35), (20, 20)])
+    def test_minimax_h3_refreshes_each_partition_transformer(self, num_inference_steps, expected_ref_min_compute):
         pipeline = Mock()
         pipeline.__class__.__name__ = "MiniMaxH3Pipeline"
-        pipeline.partition = "ref2va"
-        pipeline.transformer = Mock()
-        pipeline.transformer.__class__.__name__ = "MiniMaxH3DiTModel"
+        pipeline._dit_modules = ["transformer", "transformers_ref"]
+        pipeline.transformer = Mock(_hook_registry=Mock())
+        pipeline.transformers_ref = Mock(_hook_registry=Mock())
+        fl2va_hook = Mock(config=SimpleNamespace(calibration_profile=None, min_compute_steps=0))
+        ref2va_hook = Mock(
+            config=SimpleNamespace(
+                calibration_profile="MiniMaxH3DiTModel:ref2va",
+                min_compute_steps=35,
+            )
+        )
+        pipeline.transformer._hook_registry.get_hook.return_value = fl2va_hook
+        pipeline.transformers_ref._hook_registry.get_hook.return_value = ref2va_hook
 
         backend = TeaCacheBackend(DiffusionCacheConfig())
+        backend.refresh(pipeline, num_inference_steps=num_inference_steps)
 
-        with pytest.raises(ValueError, match="only supports the MiniMax-H3 FL2VA partition"):
-            backend.enable(pipeline)
-
-        assert backend.enabled is False
-        mock_apply_hook.assert_not_called()
+        for transformer in (pipeline.transformer, pipeline.transformers_ref):
+            transformer._hook_registry.reset_hook.assert_called_once_with(TeaCacheHook._HOOK_NAME)
+        assert fl2va_hook.config.min_compute_steps == 0
+        assert ref2va_hook.config.min_compute_steps == expected_ref_min_compute
 
     @patch("vllm_omni.diffusion.cache.teacache.backend.apply_teacache_hook")
     def test_enable_with_coefficients(self, mock_apply_hook):

--- a/tests/diffusion/cache/test_teacache_extractors.py
+++ b/tests/diffusion/cache/test_teacache_extractors.py
@@ -705,6 +705,39 @@ class TestMiniMaxH3Extractor(BaseExtractorTest):
         assert video_logits.shape[0] == sample_inputs["img_pos_info"]["position_ids"].shape[0]
         assert audio_logits.shape[0] == sample_inputs["audio_pos_info"]["position_ids"].shape[0]
 
+    def test_teacache_honors_and_resets_cache_hit_budget(self, minimax_h3_module, sample_inputs, monkeypatch):
+        from vllm_omni.diffusion.cache.teacache.config import TeaCacheConfig
+        from vllm_omni.diffusion.cache.teacache.hook import TeaCacheHook
+
+        block = minimax_h3_module.blocks[0]
+        original_forward = block.forward
+        block_calls = 0
+
+        def counted_forward(*args, **kwargs):
+            nonlocal block_calls
+            block_calls += 1
+            return original_forward(*args, **kwargs)
+
+        monkeypatch.setattr(block, "forward", counted_forward)
+        hook = TeaCacheHook(
+            TeaCacheConfig(
+                transformer_type="MiniMaxH3DiTModel",
+                rel_l1_thresh=10.0,
+                max_cached_steps=1,
+                min_compute_steps=2,
+            )
+        )
+        hook.initialize_hook(minimax_h3_module)
+
+        for _ in range(4):
+            hook.new_forward(minimax_h3_module, **sample_inputs)
+        assert block_calls == 3
+
+        hook.reset_state(minimax_h3_module)
+        for _ in range(3):
+            hook.new_forward(minimax_h3_module, **sample_inputs)
+        assert block_calls == 5
+
     def test_invalid_module_raises_error(self):
         """Test that invalid module without blocks raises ValueError."""
         invalid_module = Mock()

--- a/tests/diffusion/cache/test_teacache_extractors.py
+++ b/tests/diffusion/cache/test_teacache_extractors.py
@@ -33,6 +33,7 @@ from vllm_omni.diffusion.cache.teacache.extractors import (
     extract_flux_context,
     extract_minimax_h3_context,
 )
+from vllm_omni.diffusion.data import DiffusionCacheConfig
 from vllm_omni.diffusion.models.flux.flux_transformer import FluxTransformer2DModel
 from vllm_omni.diffusion.models.flux2_klein.flux2_klein_transformer import (
     Flux2Transformer2DModel,
@@ -677,8 +678,10 @@ class TestMiniMaxH3Extractor(BaseExtractorTest):
 
     def test_teacache_reuses_h3_block_residual(self, minimax_h3_module, sample_inputs, monkeypatch):
         """A guaranteed cache hit must skip the H3 transformer block."""
-        from vllm_omni.diffusion.cache.teacache.config import TeaCacheConfig
         from vllm_omni.diffusion.cache.teacache.hook import TeaCacheHook
+        from vllm_omni.diffusion.models.minimax_h3.quality_policy import (
+            minimax_h3_teacache_hook_configs,
+        )
 
         block = minimax_h3_module.blocks[0]
         original_forward = block.forward
@@ -690,12 +693,11 @@ class TestMiniMaxH3Extractor(BaseExtractorTest):
             return original_forward(*args, **kwargs)
 
         monkeypatch.setattr(block, "forward", counted_forward)
-        hook = TeaCacheHook(
-            TeaCacheConfig(
-                transformer_type="MiniMaxH3DiTModel",
-                rel_l1_thresh=0.3,
-            )
+        teacache_config = minimax_h3_teacache_hook_configs(
+            "fl2va",
+            DiffusionCacheConfig(rel_l1_thresh=0.3),
         )
+        hook = TeaCacheHook(teacache_config["transformer"])
         hook.initialize_hook(minimax_h3_module)
 
         hook.new_forward(minimax_h3_module, **sample_inputs)
@@ -706,8 +708,10 @@ class TestMiniMaxH3Extractor(BaseExtractorTest):
         assert audio_logits.shape[0] == sample_inputs["audio_pos_info"]["position_ids"].shape[0]
 
     def test_teacache_honors_and_resets_cache_hit_budget(self, minimax_h3_module, sample_inputs, monkeypatch):
-        from vllm_omni.diffusion.cache.teacache.config import TeaCacheConfig
         from vllm_omni.diffusion.cache.teacache.hook import TeaCacheHook
+        from vllm_omni.diffusion.models.minimax_h3.quality_policy import (
+            minimax_h3_teacache_hook_configs,
+        )
 
         block = minimax_h3_module.blocks[0]
         original_forward = block.forward
@@ -719,14 +723,13 @@ class TestMiniMaxH3Extractor(BaseExtractorTest):
             return original_forward(*args, **kwargs)
 
         monkeypatch.setattr(block, "forward", counted_forward)
-        hook = TeaCacheHook(
-            TeaCacheConfig(
-                transformer_type="MiniMaxH3DiTModel",
-                rel_l1_thresh=10.0,
-                max_cached_steps=1,
-                min_compute_steps=2,
-            )
+        teacache_config = minimax_h3_teacache_hook_configs(
+            "fl2va",
+            DiffusionCacheConfig(rel_l1_thresh=10.0),
         )
+        teacache_config["transformer"].max_cached_steps = 1
+        teacache_config["transformer"].min_compute_steps = 2
+        hook = TeaCacheHook(teacache_config["transformer"])
         hook.initialize_hook(minimax_h3_module)
 
         for _ in range(4):

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
@@ -98,6 +98,7 @@ def test_pipeline_import_registry_and_component_discovery():
     assert MiniMaxH3Pipeline._dit_modules == ["transformer", "transformers_ref"]
     assert MiniMaxH3Pipeline._encoder_modules == ["text_encoder"]
     assert MiniMaxH3Pipeline._vae_modules == ["video_vae", "audio_vae"]
+    assert MiniMaxH3Pipeline.num_inference_steps == 50
 
 
 def _write_partition_index(path, *, partition, tasks):

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_quality_policy.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_quality_policy.py
@@ -192,6 +192,69 @@ def test_model_policy_owns_request_cache_target(cache_backend, quality, expected
             assert plan.cache_dit.cache_config is config.cache_config
 
 
+@pytest.mark.parametrize(
+    ("partition", "expected"),
+    [
+        ("fl2va", [("transformer", 0.17, None, 0, None)]),
+        ("ref2va", [("transformer", 0.295, 5, 35, 50)]),
+        (
+            "combined",
+            [
+                ("transformer", 0.17, None, 0, None),
+                ("transformers_ref", 0.295, 5, 35, 50),
+            ],
+        ),
+    ],
+)
+def test_h3_owns_teacache_partition_calibration(partition, expected):
+    from vllm_omni.diffusion.models.minimax_h3.quality_policy import (
+        minimax_h3_teacache_hook_configs,
+    )
+
+    configs = minimax_h3_teacache_hook_configs(partition, DiffusionCacheConfig())
+
+    actual = [
+        (
+            path,
+            config.rel_l1_thresh,
+            config.max_cached_steps,
+            config.min_compute_steps,
+            config.calibrated_num_inference_steps,
+        )
+        for path, config in configs.items()
+    ]
+    assert actual == expected
+    assert all(config.transformer_type == "MiniMaxH3DiTModel" for config in configs.values())
+    assert len({id(config) for config in configs.values()}) == len(configs)
+
+
+def test_h3_teacache_user_overrides_apply_to_every_partition():
+    from vllm_omni.diffusion.models.minimax_h3.quality_policy import (
+        minimax_h3_teacache_hook_configs,
+    )
+
+    coefficients = [1.0, 0.5, 0.25, 0.125, 0.0]
+    configs = minimax_h3_teacache_hook_configs(
+        "combined",
+        DiffusionCacheConfig(
+            rel_l1_thresh=0.4,
+            coefficients=coefficients,
+        ),
+    )
+
+    assert all(config.rel_l1_thresh == 0.4 for config in configs.values())
+    assert all(config.coefficients is coefficients for config in configs.values())
+
+
+def test_h3_teacache_rejects_unknown_partition():
+    from vllm_omni.diffusion.models.minimax_h3.quality_policy import (
+        minimax_h3_teacache_hook_configs,
+    )
+
+    with pytest.raises(ValueError, match="Unsupported MiniMax-H3 partition"):
+        minimax_h3_teacache_hook_configs("unknown", DiffusionCacheConfig())
+
+
 def test_h3_adopts_runner_installed_cache_dit_backend():
     from vllm_omni.diffusion.models.minimax_h3 import MiniMaxH3Pipeline
 

--- a/tests/diffusion/test_diffusion_model_runner.py
+++ b/tests/diffusion/test_diffusion_model_runner.py
@@ -453,6 +453,28 @@ def test_execute_model_emits_cache_summary_with_active_cache_dit_backend(monkeyp
     assert cache_backend.refresh_calls == [(runner.pipeline, 4, True)]
 
 
+def test_refresh_cache_uses_pipeline_default_when_steps_are_omitted():
+    class _EnabledCacheBackend:
+        def __init__(self):
+            self.refresh_calls = []
+
+        def is_enabled(self):
+            return True
+
+        def refresh(self, pipeline, num_inference_steps, verbose=True):
+            self.refresh_calls.append((pipeline, num_inference_steps, verbose))
+
+    cache_backend = _EnabledCacheBackend()
+    runner = _make_runner(cache_backend=cache_backend, cache_backend_name="tea_cache")
+    runner.pipeline.num_inference_steps = 50
+    req = _make_request()
+    req.sampling_params.num_inference_steps = None
+
+    runner._refresh_cache_for_requests([req], od_config=runner.od_config)
+
+    assert cache_backend.refresh_calls == [(runner.pipeline, 50, True)]
+
+
 @pytest.mark.core_model
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 @pytest.mark.parametrize("cache_dit_enabled", [False, True])

--- a/tests/engine/test_async_omni_engine_input.py
+++ b/tests/engine/test_async_omni_engine_input.py
@@ -14,6 +14,10 @@ from vllm_omni.model_executor.stage_input_processors.bagel import ExpandedPrompt
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 
+def test_teacache_default_config_defers_to_model_profile():
+    assert AsyncOmniEngine._get_default_cache_config("tea_cache") == {}
+
+
 def _make_engine_core_request(request_id: str = "req-1") -> EngineCoreRequest:
     return EngineCoreRequest(
         request_id=request_id,

--- a/vllm_omni/diffusion/cache/teacache/backend.py
+++ b/vllm_omni/diffusion/cache/teacache/backend.py
@@ -19,6 +19,11 @@ from vllm_omni.diffusion.data import DiffusionCacheConfig
 
 logger = init_logger(__name__)
 
+_MINIMAX_H3_REF2VA_PROFILE = "MiniMaxH3DiTModel:ref2va"
+_MINIMAX_H3_REF2VA_CALIBRATED_STEPS = 50
+_MINIMAX_H3_REF2VA_MIN_COMPUTE_STEPS = 35
+_MINIMAX_H3_REF2VA_MAX_CACHED_STEPS = 5
+
 
 def enable_hunyuan_image3_teacache(pipeline: Any, config: DiffusionCacheConfig) -> None:
     """
@@ -74,31 +79,37 @@ def enable_sensenova_u1_teacache(pipeline: Any, config: DiffusionCacheConfig) ->
 
 
 def enable_minimax_h3_teacache(pipeline: Any, config: DiffusionCacheConfig) -> None:
-    """Enable TeaCache for the calibrated MiniMax-H3 FL2VA partition."""
+    """Enable TeaCache for every loaded MiniMax-H3 task partition."""
     partition = getattr(pipeline, "partition", None)
-    if partition == "ref2va":
-        raise ValueError(
-            "TeaCache only supports the MiniMax-H3 FL2VA partition; Ref2VA TeaCache has not been calibrated"
+    if partition == "fl2va":
+        targets = (("FL2VA", pipeline.transformer, None),)
+    elif partition == "ref2va":
+        targets = (("Ref2VA", pipeline.transformer, _MINIMAX_H3_REF2VA_PROFILE),)
+    elif partition == "combined":
+        transformer_ref = getattr(pipeline, "transformers_ref", None)
+        if transformer_ref is None:
+            raise ValueError("MiniMax-H3 combined partition is missing transformers_ref")
+        targets = (
+            ("FL2VA", pipeline.transformer, None),
+            ("Ref2VA", transformer_ref, _MINIMAX_H3_REF2VA_PROFILE),
         )
-    if partition not in {"fl2va", "combined"}:
+    else:
         raise ValueError(f"Unsupported MiniMax-H3 partition for TeaCache: {partition!r}")
 
-    teacache_config = TeaCacheConfig(
-        transformer_type="MiniMaxH3DiTModel",
-        rel_l1_thresh=config.rel_l1_thresh,
-        coefficients=config.coefficients,
-    )
-    apply_teacache_hook(pipeline.transformer, teacache_config)
-
-    if partition == "combined":
-        logger.warning(
-            "TeaCache is enabled only for MiniMax-H3 FL2VA; "
-            "Ref2VA requests on this combined pipeline will run without TeaCache"
+    for partition_name, transformer, calibration_profile in targets:
+        teacache_config = TeaCacheConfig(
+            transformer_type="MiniMaxH3DiTModel",
+            calibration_profile=calibration_profile,
+            max_cached_steps=_MINIMAX_H3_REF2VA_MAX_CACHED_STEPS if calibration_profile is not None else None,
+            min_compute_steps=_MINIMAX_H3_REF2VA_MIN_COMPUTE_STEPS if calibration_profile is not None else 0,
+            rel_l1_thresh=config.rel_l1_thresh,
+            coefficients=config.coefficients,
         )
-    logger.info(
-        f"TeaCache applied with rel_l1_thresh={teacache_config.rel_l1_thresh}, "
-        "transformer_class=MiniMaxH3DiTModel, partition=FL2VA"
-    )
+        apply_teacache_hook(transformer, teacache_config)
+        logger.info(
+            f"TeaCache applied with rel_l1_thresh={teacache_config.rel_l1_thresh}, "
+            f"transformer_class=MiniMaxH3DiTModel, partition={partition_name}"
+        )
 
 
 def enable_flux2_klein_teacache(pipeline: Any, config: DiffusionCacheConfig) -> None:
@@ -223,20 +234,43 @@ class TeaCacheBackend(CacheBackend):
                 logger.debug(f"TeaCache state refreshed for HunyuanImage3 (num_inference_steps={num_inference_steps})")
             return
 
-        # Extract transformer from pipeline
-        transformer = pipeline.transformer
-        if not hasattr(transformer, "_hook_registry") and hasattr(pipeline, "denoising_transformer"):
-            transformer = pipeline.denoising_transformer
+        if pipeline.__class__.__name__ == "MiniMaxH3Pipeline":
+            target_names = getattr(pipeline, "_dit_modules", ("transformer",))
+            targets = [(name, getattr(pipeline, name)) for name in target_names if hasattr(pipeline, name)]
+        else:
+            transformer = pipeline.transformer
+            target_name = "transformer"
+            if not hasattr(transformer, "_hook_registry") and hasattr(pipeline, "denoising_transformer"):
+                transformer = pipeline.denoising_transformer
+                target_name = "denoising_transformer"
+            targets = [(target_name, transformer)]
 
-        if hasattr(transformer, "_hook_registry"):
+        for target_name, transformer in targets:
+            if not hasattr(transformer, "_hook_registry"):
+                if verbose:
+                    logger.warning(f"Transformer {target_name} has no hook registry, TeaCache may not be applied")
+                continue
+
             hook = transformer._hook_registry.get_hook(TeaCacheHook._HOOK_NAME)
-            if hook is not None:
+            if hook is None:
+                if verbose:
+                    logger.warning(f"TeaCache hook not found on {target_name}, nothing to refresh")
+            else:
+                hook_config = getattr(hook, "config", None)
+                if getattr(hook_config, "calibration_profile", None) == _MINIMAX_H3_REF2VA_PROFILE:
+                    if num_inference_steps == _MINIMAX_H3_REF2VA_CALIBRATED_STEPS:
+                        hook_config.min_compute_steps = _MINIMAX_H3_REF2VA_MIN_COMPUTE_STEPS
+                    else:
+                        hook_config.min_compute_steps = num_inference_steps
+                        if verbose:
+                            logger.warning(
+                                "MiniMax-H3 Ref2VA TeaCache is calibrated for %d inference steps; "
+                                "got %d, so this request will run uncached",
+                                _MINIMAX_H3_REF2VA_CALIBRATED_STEPS,
+                                num_inference_steps,
+                            )
                 transformer._hook_registry.reset_hook(TeaCacheHook._HOOK_NAME)
                 if verbose:
-                    logger.debug(f"TeaCache state refreshed (num_inference_steps={num_inference_steps})")
-            else:
-                if verbose:
-                    logger.warning("TeaCache hook not found, nothing to refresh")
-        else:
-            if verbose:
-                logger.warning("Transformer has no hook registry, TeaCache may not be applied")
+                    logger.debug(
+                        f"TeaCache state refreshed for {target_name} (num_inference_steps={num_inference_steps})"
+                    )

--- a/vllm_omni/diffusion/cache/teacache/backend.py
+++ b/vllm_omni/diffusion/cache/teacache/backend.py
@@ -8,6 +8,7 @@ This module provides the TeaCache backend that implements the CacheBackend
 interface using the hooks-based TeaCache system.
 """
 
+from operator import attrgetter
 from typing import Any
 
 from vllm.logger import init_logger
@@ -18,11 +19,6 @@ from vllm_omni.diffusion.cache.teacache.hook import TeaCacheHook, apply_teacache
 from vllm_omni.diffusion.data import DiffusionCacheConfig
 
 logger = init_logger(__name__)
-
-_MINIMAX_H3_REF2VA_PROFILE = "MiniMaxH3DiTModel:ref2va"
-_MINIMAX_H3_REF2VA_CALIBRATED_STEPS = 50
-_MINIMAX_H3_REF2VA_MIN_COMPUTE_STEPS = 35
-_MINIMAX_H3_REF2VA_MAX_CACHED_STEPS = 5
 
 
 def enable_hunyuan_image3_teacache(pipeline: Any, config: DiffusionCacheConfig) -> None:
@@ -78,40 +74,6 @@ def enable_sensenova_u1_teacache(pipeline: Any, config: DiffusionCacheConfig) ->
     )
 
 
-def enable_minimax_h3_teacache(pipeline: Any, config: DiffusionCacheConfig) -> None:
-    """Enable TeaCache for every loaded MiniMax-H3 task partition."""
-    partition = getattr(pipeline, "partition", None)
-    if partition == "fl2va":
-        targets = (("FL2VA", pipeline.transformer, None),)
-    elif partition == "ref2va":
-        targets = (("Ref2VA", pipeline.transformer, _MINIMAX_H3_REF2VA_PROFILE),)
-    elif partition == "combined":
-        transformer_ref = getattr(pipeline, "transformers_ref", None)
-        if transformer_ref is None:
-            raise ValueError("MiniMax-H3 combined partition is missing transformers_ref")
-        targets = (
-            ("FL2VA", pipeline.transformer, None),
-            ("Ref2VA", transformer_ref, _MINIMAX_H3_REF2VA_PROFILE),
-        )
-    else:
-        raise ValueError(f"Unsupported MiniMax-H3 partition for TeaCache: {partition!r}")
-
-    for partition_name, transformer, calibration_profile in targets:
-        teacache_config = TeaCacheConfig(
-            transformer_type="MiniMaxH3DiTModel",
-            calibration_profile=calibration_profile,
-            max_cached_steps=_MINIMAX_H3_REF2VA_MAX_CACHED_STEPS if calibration_profile is not None else None,
-            min_compute_steps=_MINIMAX_H3_REF2VA_MIN_COMPUTE_STEPS if calibration_profile is not None else 0,
-            rel_l1_thresh=config.rel_l1_thresh,
-            coefficients=config.coefficients,
-        )
-        apply_teacache_hook(transformer, teacache_config)
-        logger.info(
-            f"TeaCache applied with rel_l1_thresh={teacache_config.rel_l1_thresh}, "
-            f"transformer_class=MiniMaxH3DiTModel, partition={partition_name}"
-        )
-
-
 def enable_flux2_klein_teacache(pipeline: Any, config: DiffusionCacheConfig) -> None:
     """
     Enable TeaCache for Flux2 Klein model.
@@ -135,7 +97,6 @@ CUSTOM_TEACACHE_ENABLERS = {
     "BagelPipeline": enable_bagel_teacache,
     "Flux2KleinPipeline": enable_flux2_klein_teacache,
     "HunyuanImage3Pipeline": enable_hunyuan_image3_teacache,
-    "MiniMaxH3Pipeline": enable_minimax_h3_teacache,
     "SenseNovaU1Pipeline": enable_sensenova_u1_teacache,
 }
 
@@ -172,11 +133,28 @@ class TeaCacheBackend(CacheBackend):
                      - transformer: pipeline.transformer
                      - transformer_type: pipeline.transformer.__class__.__name__
         """
-        # Helper to get pipeline class name
         pipeline_type = pipeline.__class__.__name__
+        config_factory = getattr(type(pipeline), "_teacache_hook_configs", None)
 
-        # Check for pipeline-level custom enablers
-        if pipeline_type in CUSTOM_TEACACHE_ENABLERS:
+        if callable(config_factory):
+            hook_configs = config_factory(pipeline, self.config)
+            if not hook_configs:
+                raise ValueError(f"{pipeline_type} declared no TeaCache hook targets")
+            for target_path, teacache_config in hook_configs.items():
+                if not isinstance(teacache_config, TeaCacheConfig):
+                    raise TypeError(
+                        f"{pipeline_type} TeaCache config for {target_path!r} "
+                        f"must be TeaCacheConfig, got {type(teacache_config).__name__}"
+                    )
+                transformer = attrgetter(target_path)(pipeline)
+                apply_teacache_hook(transformer, teacache_config)
+                logger.info(
+                    "TeaCache applied with rel_l1_thresh=%s, transformer_class=%s, component=%s",
+                    teacache_config.rel_l1_thresh,
+                    teacache_config.transformer_type,
+                    target_path,
+                )
+        elif pipeline_type in CUSTOM_TEACACHE_ENABLERS:
             logger.info(f"Using custom TeaCache enabler for model: {pipeline_type}")
             CUSTOM_TEACACHE_ENABLERS[pipeline_type](pipeline, self.config)
         else:
@@ -234,9 +212,11 @@ class TeaCacheBackend(CacheBackend):
                 logger.debug(f"TeaCache state refreshed for HunyuanImage3 (num_inference_steps={num_inference_steps})")
             return
 
-        if pipeline.__class__.__name__ == "MiniMaxH3Pipeline":
-            target_names = getattr(pipeline, "_dit_modules", ("transformer",))
-            targets = [(name, getattr(pipeline, name)) for name in target_names if hasattr(pipeline, name)]
+        target_names = vars(pipeline).get("_dit_modules")
+        if target_names is None:
+            target_names = getattr(type(pipeline), "_dit_modules", None)
+        if target_names:
+            targets = [(name, attrgetter(name)(pipeline)) for name in target_names]
         else:
             transformer = pipeline.transformer
             target_name = "transformer"
@@ -256,19 +236,15 @@ class TeaCacheBackend(CacheBackend):
                 if verbose:
                     logger.warning(f"TeaCache hook not found on {target_name}, nothing to refresh")
             else:
-                hook_config = getattr(hook, "config", None)
-                if getattr(hook_config, "calibration_profile", None) == _MINIMAX_H3_REF2VA_PROFILE:
-                    if num_inference_steps == _MINIMAX_H3_REF2VA_CALIBRATED_STEPS:
-                        hook_config.min_compute_steps = _MINIMAX_H3_REF2VA_MIN_COMPUTE_STEPS
-                    else:
-                        hook_config.min_compute_steps = num_inference_steps
-                        if verbose:
-                            logger.warning(
-                                "MiniMax-H3 Ref2VA TeaCache is calibrated for %d inference steps; "
-                                "got %d, so this request will run uncached",
-                                _MINIMAX_H3_REF2VA_CALIBRATED_STEPS,
-                                num_inference_steps,
-                            )
+                calibration_matches = hook.prepare_for_request(num_inference_steps)
+                if not calibration_matches and verbose:
+                    logger.warning(
+                        "TeaCache on %s is calibrated for %d inference steps; "
+                        "got %d, so this request will run uncached",
+                        target_name,
+                        hook.config.calibrated_num_inference_steps,
+                        num_inference_steps,
+                    )
                 transformer._hook_registry.reset_hook(TeaCacheHook._HOOK_NAME)
                 if verbose:
                     logger.debug(

--- a/vllm_omni/diffusion/cache/teacache/config.py
+++ b/vllm_omni/diffusion/cache/teacache/config.py
@@ -83,29 +83,9 @@ _MODEL_COEFFICIENTS = {
     ],
     # LongCat Image transformer coefficients
     "LongCatImageTransformer2DModel": [652.5980, -424.1615, 84.5526, -4.5923, 0.1694],
-    # MiniMax-H3 FL2VA coefficients.
-    "MiniMaxH3DiTModel": [
-        2.283704065852778e03,
-        -7.775977277886368e02,
-        9.408414741359490e01,
-        -4.232669906169421e00,
-        2.173782527946167e-01,
-    ],
-    # MiniMax-H3 Ref2VA coefficients.
-    "MiniMaxH3DiTModel:ref2va": [
-        2.1282372412524368e04,
-        -2.2712379331933703e03,
-        -5.8373015511205919e00,
-        6.2854270826260406e00,
-        2.5209538122600766e-01,
-    ],
 }
 
 _DEFAULT_REL_L1_THRESH = 0.2
-_MODEL_DEFAULT_REL_L1_THRESH = {
-    "MiniMaxH3DiTModel": 0.17,
-    "MiniMaxH3DiTModel:ref2va": 0.295,
-}
 
 
 @dataclass
@@ -119,43 +99,43 @@ class TeaCacheConfig:
 
     Args:
         rel_l1_thresh: Threshold for accumulated relative L1 distance. When below threshold,
-            cached residual is reused. If None, uses the model-specific default or 0.2
-            when no model-specific default is registered.
+            cached residual is reused. Defaults to 0.2.
         coefficients: Polynomial coefficients for rescaling L1 distance. If None, uses
             model-specific defaults based on transformer_type.
         transformer_type: Transformer class name (e.g., "QwenImageTransformer2DModel").
             Auto-detected from pipeline.transformer.__class__.__name__ in backend.
             Defaults to "QwenImageTransformer2DModel".
-        calibration_profile: Optional coefficient/default-threshold profile. This lets
-            task-specific checkpoints of the same transformer class use independent
-            calibration while retaining the transformer_type extractor.
         max_cached_steps: Optional total cache-hit budget per inference. None means
             unlimited.
         min_compute_steps: Number of initial denoising calls that must run the full transformer.
+        calibrated_num_inference_steps: Optional calibrated request length. When set,
+            requests with a different number of inference steps run uncached.
     """
 
     rel_l1_thresh: float | None = None
     coefficients: list[float] | None = None
     transformer_type: str = "QwenImageTransformer2DModel"
-    calibration_profile: str | None = None
     max_cached_steps: int | None = None
     min_compute_steps: int = 0
+    calibrated_num_inference_steps: int | None = None
 
     def __post_init__(self) -> None:
         """Validate and set default coefficients."""
-        profile = self.calibration_profile or self.transformer_type
         threshold = self.rel_l1_thresh
         if threshold is None:
-            threshold = _MODEL_DEFAULT_REL_L1_THRESH.get(profile, _DEFAULT_REL_L1_THRESH)
+            threshold = _DEFAULT_REL_L1_THRESH
         if threshold <= 0:
             raise ValueError(f"rel_l1_thresh must be positive, got {threshold}")
         self.rel_l1_thresh = threshold
 
         if self.coefficients is None:
             # Use model-specific coefficients, explicitly check if the type exists or not
-            if profile not in _MODEL_COEFFICIENTS:
-                raise KeyError(f"Cannot find coefficients for {profile}. Supported: {list(_MODEL_COEFFICIENTS.keys())}")
-            self.coefficients = _MODEL_COEFFICIENTS[profile]
+            if self.transformer_type not in _MODEL_COEFFICIENTS:
+                raise KeyError(
+                    f"Cannot find coefficients for {self.transformer_type}. "
+                    f"Supported: {list(_MODEL_COEFFICIENTS.keys())}"
+                )
+            self.coefficients = _MODEL_COEFFICIENTS[self.transformer_type]
 
         if len(self.coefficients) != 5:
             raise ValueError(f"coefficients must contain exactly 5 elements, got {len(self.coefficients)}")
@@ -165,3 +145,17 @@ class TeaCacheConfig:
 
         if self.min_compute_steps < 0:
             raise ValueError(f"min_compute_steps must be non-negative, got {self.min_compute_steps}")
+
+        if self.calibrated_num_inference_steps is not None and self.calibrated_num_inference_steps <= 0:
+            raise ValueError(
+                f"calibrated_num_inference_steps must be positive or None, got {self.calibrated_num_inference_steps}"
+            )
+
+    def resolve_min_compute_steps(self, num_inference_steps: int) -> int:
+        """Return the request-local warmup, failing closed outside calibration."""
+        if (
+            self.calibrated_num_inference_steps is not None
+            and num_inference_steps != self.calibrated_num_inference_steps
+        ):
+            return num_inference_steps
+        return self.min_compute_steps

--- a/vllm_omni/diffusion/cache/teacache/config.py
+++ b/vllm_omni/diffusion/cache/teacache/config.py
@@ -91,11 +91,20 @@ _MODEL_COEFFICIENTS = {
         -4.232669906169421e00,
         2.173782527946167e-01,
     ],
+    # MiniMax-H3 Ref2VA coefficients.
+    "MiniMaxH3DiTModel:ref2va": [
+        2.1282372412524368e04,
+        -2.2712379331933703e03,
+        -5.8373015511205919e00,
+        6.2854270826260406e00,
+        2.5209538122600766e-01,
+    ],
 }
 
 _DEFAULT_REL_L1_THRESH = 0.2
 _MODEL_DEFAULT_REL_L1_THRESH = {
     "MiniMaxH3DiTModel": 0.17,
+    "MiniMaxH3DiTModel:ref2va": 0.295,
 }
 
 
@@ -117,29 +126,42 @@ class TeaCacheConfig:
         transformer_type: Transformer class name (e.g., "QwenImageTransformer2DModel").
             Auto-detected from pipeline.transformer.__class__.__name__ in backend.
             Defaults to "QwenImageTransformer2DModel".
+        calibration_profile: Optional coefficient/default-threshold profile. This lets
+            task-specific checkpoints of the same transformer class use independent
+            calibration while retaining the transformer_type extractor.
+        max_cached_steps: Optional total cache-hit budget per inference. None means
+            unlimited.
+        min_compute_steps: Number of initial denoising calls that must run the full transformer.
     """
 
     rel_l1_thresh: float | None = None
     coefficients: list[float] | None = None
     transformer_type: str = "QwenImageTransformer2DModel"
+    calibration_profile: str | None = None
+    max_cached_steps: int | None = None
+    min_compute_steps: int = 0
 
     def __post_init__(self) -> None:
         """Validate and set default coefficients."""
+        profile = self.calibration_profile or self.transformer_type
         threshold = self.rel_l1_thresh
         if threshold is None:
-            threshold = _MODEL_DEFAULT_REL_L1_THRESH.get(self.transformer_type, _DEFAULT_REL_L1_THRESH)
+            threshold = _MODEL_DEFAULT_REL_L1_THRESH.get(profile, _DEFAULT_REL_L1_THRESH)
         if threshold <= 0:
             raise ValueError(f"rel_l1_thresh must be positive, got {threshold}")
         self.rel_l1_thresh = threshold
 
         if self.coefficients is None:
             # Use model-specific coefficients, explicitly check if the type exists or not
-            if self.transformer_type not in _MODEL_COEFFICIENTS:
-                raise KeyError(
-                    f"Cannot find coefficients for {self.transformer_type}. "
-                    f"Supported: {list(_MODEL_COEFFICIENTS.keys())}"
-                )
-            self.coefficients = _MODEL_COEFFICIENTS[self.transformer_type]
+            if profile not in _MODEL_COEFFICIENTS:
+                raise KeyError(f"Cannot find coefficients for {profile}. Supported: {list(_MODEL_COEFFICIENTS.keys())}")
+            self.coefficients = _MODEL_COEFFICIENTS[profile]
 
         if len(self.coefficients) != 5:
             raise ValueError(f"coefficients must contain exactly 5 elements, got {len(self.coefficients)}")
+
+        if self.max_cached_steps is not None and self.max_cached_steps < 0:
+            raise ValueError(f"max_cached_steps must be non-negative or None, got {self.max_cached_steps}")
+
+        if self.min_compute_steps < 0:
+            raise ValueError(f"min_compute_steps must be non-negative, got {self.min_compute_steps}")

--- a/vllm_omni/diffusion/cache/teacache/hook.py
+++ b/vllm_omni/diffusion/cache/teacache/hook.py
@@ -138,12 +138,19 @@ class TeaCacheHook(ModelHook):
         state = self.state_manager.get_state()
 
         # Decide whether to compute or cache based on modulated input similarity
-        should_compute = self._should_compute_full_transformer(state, ctx.modulated_input)
-
+        cache_budget_exhausted = (
+            self.config.max_cached_steps is not None and state.cached_steps >= self.config.max_cached_steps
+        )
+        should_compute = (
+            state.cnt < self.config.min_compute_steps
+            or cache_budget_exhausted
+            or self._should_compute_full_transformer(state, ctx.modulated_input)
+        )
         if not should_compute and state.previous_residual is not None:
             # ============================================================================
             # FAST PATH: Reuse cached residuals
             # ============================================================================
+            state.cached_steps += 1
             ctx.hidden_states = ctx.hidden_states + state.previous_residual
             if state.previous_residual_encoder is not None and ctx.encoder_hidden_states is not None:
                 ctx.encoder_hidden_states = ctx.encoder_hidden_states + state.previous_residual_encoder

--- a/vllm_omni/diffusion/cache/teacache/hook.py
+++ b/vllm_omni/diffusion/cache/teacache/hook.py
@@ -64,6 +64,18 @@ class TeaCacheHook(ModelHook):
         self.state_manager = StateManager(TeaCacheState)
         self.extractor_fn = None
         self._forward_cnt = 0
+        self._request_min_compute_steps = config.min_compute_steps
+
+    def prepare_for_request(self, num_inference_steps: int) -> bool:
+        """Apply request-length policy before resetting cached state.
+
+        Returns whether the request matches the optional calibrated step count.
+        """
+        self._request_min_compute_steps = self.config.resolve_min_compute_steps(num_inference_steps)
+        return (
+            self.config.calibrated_num_inference_steps is None
+            or num_inference_steps == self.config.calibrated_num_inference_steps
+        )
 
     def initialize_hook(self, module: torch.nn.Module) -> torch.nn.Module:
         """
@@ -142,7 +154,7 @@ class TeaCacheHook(ModelHook):
             self.config.max_cached_steps is not None and state.cached_steps >= self.config.max_cached_steps
         )
         should_compute = (
-            state.cnt < self.config.min_compute_steps
+            state.cnt < self._request_min_compute_steps
             or cache_budget_exhausted
             or self._should_compute_full_transformer(state, ctx.modulated_input)
         )

--- a/vllm_omni/diffusion/cache/teacache/state.py
+++ b/vllm_omni/diffusion/cache/teacache/state.py
@@ -25,6 +25,7 @@ class TeaCacheState:
 
         # Caching state
         self.accumulated_rel_l1_distance = 0.0
+        self.cached_steps = 0
         self.previous_modulated_input: torch.Tensor | None = None
         self.previous_residual: torch.Tensor | None = None
         self.previous_residual_encoder: torch.Tensor | None = None
@@ -33,6 +34,7 @@ class TeaCacheState:
         """Reset all state variables for a new inference run."""
         self.cnt = 0
         self.accumulated_rel_l1_distance = 0.0
+        self.cached_steps = 0
         self.previous_modulated_input = None
         self.previous_residual = None
         self.previous_residual_encoder = None

--- a/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
+++ b/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
@@ -554,6 +554,7 @@ class MiniMaxH3Pipeline(
         "decode",
     ]
     dummy_run_num_frames: ClassVar[int] = 0
+    num_inference_steps: ClassVar[int] = 50
     # Only distilled releases pin a schedule, so the default keeps the legacy
     # uniform path available to partially constructed pipelines.
     _base_schedule_by_partition: ClassVar[Mapping[str, DMD2SigmaSchedule | None]] = {}
@@ -1807,7 +1808,7 @@ class MiniMaxH3Pipeline(
         sigma_schedule = self._base_schedule_for_task(task)
         if sigma_schedule is None:
             base_schedule = None
-            num_steps = int(sampling.num_inference_steps or 50)
+            num_steps = int(sampling.num_inference_steps or self.num_inference_steps)
         else:
             # The schedule lists sigma boundaries; the denoise loop runs one
             # step per interval, and that count is what requests and Cache-DiT

--- a/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
+++ b/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
@@ -26,7 +26,8 @@ from vllm_omni.diffusion.cache.cachedit import (
     CacheDiTBackend,
     RequestScopedCacheDiTRuntime,
 )
-from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+from vllm_omni.diffusion.cache.teacache.config import TeaCacheConfig
+from vllm_omni.diffusion.data import DiffusionCacheConfig, DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.parallel_state import (
     get_dit_group,
     init_world_group,
@@ -78,7 +79,11 @@ from .presentation import (
     minimax_h3_ref2va_video_presentation,
     minimax_h3_text_only_ids,
 )
-from .quality_policy import MINIMAX_H3_GENERIC_CACHE_KEY, MiniMaxH3QualityPolicy
+from .quality_policy import (
+    MINIMAX_H3_GENERIC_CACHE_KEY,
+    MiniMaxH3QualityPolicy,
+    minimax_h3_teacache_hook_configs,
+)
 from .reference_video import (
     load_audio_file,
     load_video_audio,
@@ -552,6 +557,10 @@ class MiniMaxH3Pipeline(
     # Only distilled releases pin a schedule, so the default keeps the legacy
     # uniform path available to partially constructed pipelines.
     _base_schedule_by_partition: ClassVar[Mapping[str, DMD2SigmaSchedule | None]] = {}
+
+    def _teacache_hook_configs(self, config: DiffusionCacheConfig) -> dict[str, TeaCacheConfig]:
+        """Return model-owned TeaCache policy keyed by DiT component path."""
+        return minimax_h3_teacache_hook_configs(self.partition, config)
 
     def adopt_cache_dit_backend(self, backend: CacheDiTBackend) -> None:
         """Adopt runner-installed generic Cache-DiT for request transitions."""

--- a/vllm_omni/diffusion/models/minimax_h3/quality_policy.py
+++ b/vllm_omni/diffusion/models/minimax_h3/quality_policy.py
@@ -11,6 +11,7 @@ from numbers import Integral
 from typing import Any
 
 from vllm_omni.diffusion.cache.cachedit import CacheDiTRequestSpec
+from vllm_omni.diffusion.cache.teacache.config import TeaCacheConfig
 from vllm_omni.diffusion.data import DiffusionCacheConfig
 from vllm_omni.errors import OmniClientError
 
@@ -19,6 +20,64 @@ MINIMAX_H3_HIGH_CACHE_KEY = "minimax_h3.high"
 MINIMAX_H3_FORCE_REFRESH_STEP_HINT_ARG = "force_refresh_step_hint"
 MINIMAX_H3_FORCE_REFRESH_STEP_POLICY_ARG = "force_refresh_step_policy"
 MINIMAX_H3_FORCE_REFRESH_POLICIES = ("once", "repeat")
+
+_MINIMAX_H3_FL2VA_TEACACHE_COEFFICIENTS = [
+    2.283704065852778e03,
+    -7.775977277886368e02,
+    9.408414741359490e01,
+    -4.232669906169421e00,
+    2.173782527946167e-01,
+]
+_MINIMAX_H3_REF2VA_TEACACHE_COEFFICIENTS = [
+    2.1282372412524368e04,
+    -2.2712379331933703e03,
+    -5.8373015511205919e00,
+    6.2854270826260406e00,
+    2.5209538122600766e-01,
+]
+_MINIMAX_H3_FL2VA_TEACACHE_THRESHOLD = 0.17
+_MINIMAX_H3_REF2VA_TEACACHE_THRESHOLD = 0.295
+_MINIMAX_H3_REF2VA_TEACACHE_STEPS = 50
+_MINIMAX_H3_REF2VA_TEACACHE_MIN_COMPUTE_STEPS = 35
+_MINIMAX_H3_REF2VA_TEACACHE_MAX_CACHED_STEPS = 5
+
+
+def _minimax_h3_teacache_config(
+    config: DiffusionCacheConfig,
+    *,
+    ref2va: bool,
+) -> TeaCacheConfig:
+    coefficients = config.coefficients
+    if coefficients is None:
+        coefficients = _MINIMAX_H3_REF2VA_TEACACHE_COEFFICIENTS if ref2va else _MINIMAX_H3_FL2VA_TEACACHE_COEFFICIENTS
+    threshold = config.rel_l1_thresh
+    if threshold is None:
+        threshold = _MINIMAX_H3_REF2VA_TEACACHE_THRESHOLD if ref2va else _MINIMAX_H3_FL2VA_TEACACHE_THRESHOLD
+    return TeaCacheConfig(
+        transformer_type="MiniMaxH3DiTModel",
+        rel_l1_thresh=threshold,
+        coefficients=coefficients,
+        max_cached_steps=_MINIMAX_H3_REF2VA_TEACACHE_MAX_CACHED_STEPS if ref2va else None,
+        min_compute_steps=_MINIMAX_H3_REF2VA_TEACACHE_MIN_COMPUTE_STEPS if ref2va else 0,
+        calibrated_num_inference_steps=_MINIMAX_H3_REF2VA_TEACACHE_STEPS if ref2va else None,
+    )
+
+
+def minimax_h3_teacache_hook_configs(
+    partition: str,
+    config: DiffusionCacheConfig,
+) -> dict[str, TeaCacheConfig]:
+    """Declare TeaCache targets and calibrated policy for an H3 partition."""
+    if partition == "fl2va":
+        return {"transformer": _minimax_h3_teacache_config(config, ref2va=False)}
+    if partition == "ref2va":
+        return {"transformer": _minimax_h3_teacache_config(config, ref2va=True)}
+    if partition == "combined":
+        return {
+            "transformer": _minimax_h3_teacache_config(config, ref2va=False),
+            "transformers_ref": _minimax_h3_teacache_config(config, ref2va=True),
+        }
+    raise ValueError(f"Unsupported MiniMax-H3 partition for TeaCache: {partition!r}")
 
 
 def _high_quality_cache_config() -> DiffusionCacheConfig:
@@ -175,4 +234,5 @@ __all__ = [
     "MINIMAX_H3_HIGH_CACHE_KEY",
     "MiniMaxH3QualityPlan",
     "MiniMaxH3QualityPolicy",
+    "minimax_h3_teacache_hook_configs",
 ]

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -815,9 +815,7 @@ class AsyncOmniEngine:
                 "scm_steps_policy": "dynamic",
             }
         if cache_backend == "tea_cache":
-            return {
-                "rel_l1_thresh": 0.2,
-            }
+            return {}
         if cache_backend == "mag_cache":
             return {
                 "mag_threshold": 0.24,


### PR DESCRIPTION
## Summary

Follow-up to #5840. This removes the FL2VA-only TeaCache limitation for MiniMax-H3.

- add an independently fitted Ref2VA TeaCache coefficient profile and model default threshold
- enable Ref2VA-only and combined serving, with isolated hooks and request-scoped state for the FL2VA and Ref2VA DiTs
- use a conservative Ref2VA policy: 35 full-compute calls followed by at most five cache hits on the calibrated 50-step workload
- fail closed to full computation for non-50-step Ref2VA requests
- let online serving defer to model-specific TeaCache defaults instead of forcing `rel_l1_thresh=0.2`
- document the ready-to-run Ref2VA serve command and measured trade-off

## B300 validation

The profile was fitted from 15 BF16 full-compute Ref2VA cases on one B300: 6 image-only, 6 image+audio, and 3 video+audio cases (720 consecutive full-compute pairs).

Same-seed A/B, CUDNN attention, 448x256, 107 output frames, 50 steps:

| Case | Cache hits | Baseline | TeaCache | Video quality | Audio quality |
|---|---:|---:|---:|---:|---:|
| Image-only | 0/49 | 53.34 s | 53.26 s | SSIM 1.000 | sample-identical |
| Video+audio | 5/49 | 244.19 s | 221.24 s | SSIM 0.9795, PSNR 41.60 dB | PSNR 168.8 dB |

Both video+audio runs peaked at 140,972 MiB. TeaCache reduces compute latency; it is not a weight-memory optimization.

## User-facing usage

```bash
vllm serve "${MODEL_ROOT}/Ref2VA" \
  --omni \
  --trust-remote-code \
  --cache-backend tea_cache
```

Omitting `cache_config` selects the task-specific calibrated default. Custom thresholds keep the Ref2VA warmup and cache-hit budget.

## Tests

- `ruff check` on all changed Python files
- `pytest -q tests/diffusion/cache/test_cache_backends.py tests/diffusion/cache/test_teacache.py tests/diffusion/cache/test_teacache_extractors.py tests/engine/test_async_omni_engine_input.py`
- 82 passed
- `git diff --check`
