### PR TITLE
[Diffusion] Add bounded and pipelined host staging for DLO

### DIFF
--- a/recipes/MiniMaxAI/MiniMax-H3-5090.md
+++ b/recipes/MiniMaxAI/MiniMax-H3-5090.md
@@ -39,6 +39,35 @@ private transfer memory is approximately:
 staging buffer count × sum(max layer-shard elements per dtype)
 ```
 
+For the checked FL2VA BF16 checkpoint, safetensors metadata gives the following
+single-rank capacity model for the 50 DiT blocks and two token-refiner blocks:
+
+| DLO tensor payload | GiB |
+| --- | ---: |
+| Persistent pinned shards without bounded staging | 61.559 |
+| Largest layer | 1.202 |
+| Two bounded staging buffers | 2.405 |
+| Pinned payload avoided | 59.154 (96.09%) |
+
+These values describe tensor payload, not process RSS. Runtime TP sharding,
+quantization, allocator overhead, and model revisions can change the per-rank
+values, so the startup log reports the actual file-backed bytes,
+private staging bytes, and pinned-payload reduction for the selected topology.
+
+The background copy also prevents the new file-backed-to-pinned transfer from
+remaining entirely on the layer critical path. In a host-only microbenchmark
+using four 1.202 GiB file-backed BF16 shards, two pinned buffers, a 250 ms
+per-layer compute window, local ext4 storage, and 16 PyTorch CPU threads, the
+median of three alternating runs was:
+
+| Bounded staging path | Exposed staging wait | Four-layer pipeline time |
+| --- | ---: | ---: |
+| Synchronous copy | 1.8149 s | 2.8159 s |
+| Background one-layer-ahead copy | 1.0182 s (-43.90%) | 2.0196 s (1.394x) |
+
+This is a staging-pipeline microbenchmark, not an end-to-end H3 latency claim.
+Measure request latency and storage bandwidth on the production host.
+
 This mode has important capacity boundaries:
 
 - The cache directory needs space for one finalized rank-local streamed DiT copy
@@ -52,8 +81,10 @@ This mode has important capacity boundaries:
   200 GiB startup requirement in the table. A reusable preprocessed cache or
   streaming model loader is needed to remove that peak.
 - Cold requests can fault pages from NVMe. `--dlo-prefetch-depth 2` submits the
-  current and following shard for best-effort OS readahead; deeper values trade
-  more page-cache residency for fewer storage stalls.
+  current and following shard for OS readahead and copies the following shard
+  into a pinned buffer on a background worker. Deeper values extend readahead;
+  pinned background work remains bounded to at most one fewer than the configured
+  staging-buffer count.
 - Cache files are removed on clean shutdown. After `SIGKILL` or a host crash,
   remove stale `vllm-omni-dlo-*` directories manually.
 

--- a/recipes/MiniMaxAI/MiniMax-H3-5090.md
+++ b/recipes/MiniMaxAI/MiniMax-H3-5090.md
@@ -15,9 +15,47 @@ increase CPU-to-GPU transfer time.
 | Recommended system RAM | 384 GiB | 384 GiB |
 
 `FL2VA` and `Ref2VA` are separate 135 GiB checkpoint partitions. Start one
-server at a time. DLO keeps rank-local weights in pinned host memory; increasing
-`--dlo-resident-layers` improves latency but does **not** reduce host RAM in the
-current implementation because resident layers retain pinned CPU master copies.
+server at a time. By default, DLO keeps every rank-local streamed weight in
+pinned host memory; increasing `--dlo-resident-layers` improves latency but does
+**not** reduce host RAM because resident layers retain pinned CPU master copies.
+
+### Optional bounded host staging
+
+On a discrete-GPU host with local NVMe, add the following flags to either command
+below to replace persistent pinned DiT shards with file-backed rank-local shards:
+
+```bash
+  --dlo-host-memory-budget-gib 8 \
+  --dlo-host-cache-dir /local-nvme/vllm-omni-dlo \
+  --dlo-pinned-staging-buffer-count 2 \
+  --dlo-prefetch-depth 2
+```
+
+The 8 GiB value is a cap, not a reservation. Startup fails with the exact required
+byte count if two buffers cannot hold the largest per-rank layer shard. Steady
+private transfer memory is approximately:
+
+```text
+staging buffer count × sum(max layer-shard elements per dtype)
+```
+
+This mode has important capacity boundaries:
+
+- The cache directory needs space for one finalized rank-local streamed DiT copy
+  per worker, in addition to the original checkpoint. Use local SSD/NVMe, not
+  `tmpfs` or a network filesystem.
+- The limit covers DLO's private transfer buffers only. OS page cache is
+  reclaimable but can still grow, and encoders, VAEs, request data, and CUDA
+  allocations remain outside the limit.
+- The standard loader still constructs the rank-local model before DLO writes
+  the file-backed cache. Therefore this first version does **not** lower the
+  200 GiB startup requirement in the table. A reusable preprocessed cache or
+  streaming model loader is needed to remove that peak.
+- Cold requests can fault pages from NVMe. `--dlo-prefetch-depth 2` submits the
+  current and following shard for best-effort OS readahead; deeper values trade
+  more page-cache residency for fewer storage stalls.
+- Cache files are removed on clean shutdown. After `SIGKILL` or a host crash,
+  remove stale `vllm-omni-dlo-*` directories manually.
 
 > **Modular H3:** after #5720 lands, preserve this recipe's one-partition
 > behavior with `--task-type fl2va` or `--task-type ref2va`.

--- a/recipes/MiniMaxAI/MiniMax-H3-Spark-GB10.md
+++ b/recipes/MiniMaxAI/MiniMax-H3-Spark-GB10.md
@@ -19,10 +19,14 @@ at a time.
 On GB10 the CPU and GPU share one physical memory pool, which changes the capacity
 math relative to the RTX and datacenter recipes:
 
-- **Do not use `--enable-distributed-layerwise-offload`.** DLO stages rank-local
-  weights into pinned host memory, which on GB10 is the same pool the weights are
-  already in. Peak usage roughly doubles and the process is killed by the OOM
-  killer (`Exit code: -9`) shortly after `Enabling offloader backend`.
+- **Do not use `--enable-distributed-layerwise-offload`.** Default DLO stages
+  rank-local weights into pinned host memory, which on GB10 is the same pool the
+  weights are already in. Peak usage roughly doubles and the process is killed
+  by the OOM killer (`Exit code: -9`) shortly after
+  `Enabling offloader backend`. Optional file-backed bounded staging is not a
+  workaround here: the regular loader's BF16 startup still exceeds the unified
+  pool, while the required online FP8 path is incompatible with layerwise
+  offload.
 - **Do not use `--enable-cpu-offload`.** Moving weights from "VRAM" to "host RAM"
   frees nothing here.
 - **`--quantization fp8` is mandatory.** A BF16 partition is 135 GiB and does not

--- a/tests/diffusion/offloader/test_distributed_layerwise_backend.py
+++ b/tests/diffusion/offloader/test_distributed_layerwise_backend.py
@@ -3,6 +3,7 @@
 
 """Unit tests for DistributedLayerwiseOffloadHook and backend utilities."""
 
+import errno
 import gc
 import json
 import os
@@ -45,8 +46,14 @@ class DummyStream:
 
 
 class DummyEvent:
+    def __init__(self) -> None:
+        self.synchronize_calls = 0
+
     def record(self, _stream) -> None:
         return None
+
+    def synchronize(self) -> None:
+        self.synchronize_calls += 1
 
 
 @contextmanager
@@ -349,6 +356,149 @@ class TestDistributedLayerwiseOffloadHook:
         hook.initialize_hook(block)
 
         assert torch.equal(hook.cpu_shards[torch.float32], torch.tensor([0.0, 1.0]))
+
+
+class TestBoundedHostStaging:
+    def test_file_backed_shard_uses_two_shared_staging_slots(
+        self,
+        tmp_path,
+        dist_group,
+        patched_offload_runtime,
+    ):
+        store = dist_backend_module.FileBackedShardStore(tmp_path)
+        current_block = TinyBlock(_make_values(1.0))
+        next_block = TinyBlock(_make_values(10.0))
+        hook = DistributedLayerwiseOffloadHook(
+            next_block=next_block,
+            device=torch.device("cpu"),
+            dp_group=None,
+            dp_size=1,
+            rank=0,
+            copy_stream=DummyStream(),
+            comm_stream=DummyStream(),
+            pin_memory=False,
+            host_shard_store=store,
+        )
+
+        hook.initialize_hook(current_block)
+        pool = dist_backend_module.PinnedHostStagingPool.from_shard_sets(
+            [hook.cpu_shards],
+            pin_memory=False,
+            budget_bytes=32,
+        )
+        hook.host_staging_pool = pool
+
+        assert store.allocated_bytes == 16
+        assert len(list(store.cache_dir.iterdir())) == 1
+        assert not hook.cpu_shards[torch.float32].is_pinned()
+        assert len(pool.buffers) == 2
+        assert pool.allocated_bytes == 32
+
+        first_slot_ptr = pool.buffers[0][torch.float32].data_ptr()
+        hook.prefetch_layer(slot=0, non_blocking=False)
+        assert torch.equal(next_block.weight.to_local(), _make_values(10.0))
+
+        first_event = pool.slot_events[0]
+        hook.prefetch_layer(slot=0, non_blocking=False)
+        hook.prefetch_layer(slot=0, non_blocking=False)
+        assert pool.buffers[0][torch.float32].data_ptr() == first_slot_ptr
+        assert first_event.synchronize_calls == 1
+
+    def test_file_backed_store_removes_ephemeral_cache_on_close(self, tmp_path):
+        store = dist_backend_module.FileBackedShardStore(tmp_path)
+        shard = store.allocate(4, torch.float32)
+        shard.copy_(torch.arange(4, dtype=torch.float32))
+        store.finalize(shard)
+        cache_dir = store.cache_dir
+
+        del shard
+        gc.collect()
+        store.close()
+
+        assert not cache_dir.exists()
+
+    def test_file_backed_store_fails_cleanly_when_cache_is_full(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        if not hasattr(os, "posix_fallocate"):
+            pytest.skip("posix_fallocate is unavailable")
+
+        store = dist_backend_module.FileBackedShardStore(tmp_path)
+
+        def fail_reservation(_fd, _offset, _length):
+            raise OSError(errno.ENOSPC, "no space left on device")
+
+        monkeypatch.setattr(os, "posix_fallocate", fail_reservation)
+        with pytest.raises(OSError) as exc_info:
+            store.allocate(4, torch.float32)
+
+        assert exc_info.value.errno == errno.ENOSPC
+        assert not any(store.cache_dir.iterdir())
+        store.close()
+
+    def test_staging_budget_rejects_two_slots_larger_than_limit(
+        self,
+        tmp_path,
+        dist_group,
+        patched_offload_runtime,
+    ):
+        store = dist_backend_module.FileBackedShardStore(tmp_path)
+        current_block = TinyBlock(_make_values(1.0))
+        next_block = TinyBlock(_make_values(10.0))
+        hook = DistributedLayerwiseOffloadHook(
+            next_block=next_block,
+            device=torch.device("cpu"),
+            dp_group=None,
+            dp_size=1,
+            rank=0,
+            pin_memory=False,
+            host_shard_store=store,
+        )
+        hook.initialize_hook(current_block)
+
+        with pytest.raises(ValueError, match="2 pinned host staging slots require 32 bytes"):
+            dist_backend_module.PinnedHostStagingPool.from_shard_sets(
+                [hook.cpu_shards],
+                pin_memory=False,
+                budget_bytes=31,
+            )
+
+    def test_resident_layers_reuse_bounded_staging_pool(self, tmp_path, patched_offload_runtime):
+        store = dist_backend_module.FileBackedShardStore(tmp_path)
+        blocks = [nn.Linear(2, 2), nn.Linear(2, 2)]
+        expected = []
+        for index, block in enumerate(blocks):
+            block.weight.data.fill_(index + 1)
+            block.bias.data.fill_(index + 3)
+            expected.append((block.weight.detach().clone(), block.bias.detach().clone()))
+
+        group = PinnedResidentLayerGroup(
+            blocks,
+            device=torch.device("cpu"),
+            copy_stream=DummyStream(),
+            pin_memory=False,
+            host_shard_store=store,
+        )
+        pool = dist_backend_module.PinnedHostStagingPool.from_shard_sets(
+            group.host_shard_sets,
+            pin_memory=False,
+            budget_bytes=48,
+        )
+        group.host_staging_pool = pool
+
+        assert pool.allocated_bytes == 48
+        group.load()
+        for block, (weight, bias) in zip(blocks, expected):
+            assert torch.equal(block.weight, weight)
+            assert torch.equal(block.bias, bias)
+
+        group.offload()
+        group.load()
+        for block, (weight, bias) in zip(blocks, expected):
+            assert torch.equal(block.weight, weight)
+            assert torch.equal(block.bias, bias)
 
 
 class TestPinnedResidentLayerGroup:
@@ -997,6 +1147,100 @@ class TestMmapValidation:
 
 class TestConfigValidation:
     """Tests for configuration validation in OffloadConfig / execute_request."""
+
+    def test_bounded_host_staging_converts_gib_budget_to_bytes(self, tmp_path):
+        od_config = SimpleNamespace(
+            enable_cpu_offload=False,
+            enable_layerwise_offload=False,
+            enable_distributed_layerwise_offload=True,
+            dlo_use_allgather=False,
+            dlo_resident_layers=0,
+            dlo_host_memory_budget_gib=1.5,
+            dlo_host_cache_dir=str(tmp_path),
+            dlo_pinned_staging_buffer_count=3,
+            dlo_prefetch_depth=4,
+            pin_cpu_memory=True,
+            parallel_config=SimpleNamespace(
+                data_parallel_size=1,
+                sequence_parallel_size=1,
+                use_hsdp=False,
+            ),
+            model="/fake/path",
+        )
+
+        config = OffloadConfig.from_od_config(od_config)
+
+        assert config.dlo_host_memory_budget_bytes == int(1.5 * 1024**3)
+        assert config.dlo_host_cache_dir == str(tmp_path)
+        assert config.dlo_pinned_staging_buffer_count == 3
+        assert config.dlo_prefetch_depth == 4
+
+    def test_bounded_host_staging_requires_cache_directory(self):
+        od_config = SimpleNamespace(
+            enable_cpu_offload=False,
+            enable_layerwise_offload=False,
+            enable_distributed_layerwise_offload=True,
+            dlo_use_allgather=False,
+            dlo_resident_layers=0,
+            dlo_host_memory_budget_gib=1.0,
+            dlo_host_cache_dir=None,
+            pin_cpu_memory=True,
+            parallel_config=SimpleNamespace(
+                data_parallel_size=1,
+                sequence_parallel_size=1,
+                use_hsdp=False,
+            ),
+            model="/fake/path",
+        )
+
+        with pytest.raises(ValueError, match="dlo_host_cache_dir is required"):
+            OffloadConfig.from_od_config(od_config)
+
+    def test_bounded_host_staging_rejects_allgather_mode(self, tmp_path):
+        od_config = SimpleNamespace(
+            enable_cpu_offload=False,
+            enable_layerwise_offload=False,
+            enable_distributed_layerwise_offload=True,
+            dlo_use_allgather=True,
+            dlo_resident_layers=0,
+            dlo_host_memory_budget_gib=1.0,
+            dlo_host_cache_dir=str(tmp_path),
+            pin_cpu_memory=True,
+            parallel_config=SimpleNamespace(
+                data_parallel_size=2,
+                sequence_parallel_size=1,
+                use_hsdp=False,
+            ),
+            model="/fake/path",
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="bounded DLO host staging currently requires --dlo-no-use-allgather",
+        ):
+            OffloadConfig.from_od_config(od_config)
+
+    @pytest.mark.parametrize("budget_gib", [0, -1, float("inf"), float("nan")])
+    def test_bounded_host_staging_rejects_invalid_budget(self, tmp_path, budget_gib):
+        od_config = SimpleNamespace(
+            enable_cpu_offload=False,
+            enable_layerwise_offload=False,
+            enable_distributed_layerwise_offload=True,
+            dlo_use_allgather=False,
+            dlo_resident_layers=0,
+            dlo_host_memory_budget_gib=budget_gib,
+            dlo_host_cache_dir=str(tmp_path),
+            pin_cpu_memory=True,
+            parallel_config=SimpleNamespace(
+                data_parallel_size=1,
+                sequence_parallel_size=1,
+                use_hsdp=False,
+            ),
+            model="/fake/path",
+        )
+
+        with pytest.raises(ValueError, match="dlo_host_memory_budget_gib must be finite and > 0"):
+            OffloadConfig.from_od_config(od_config)
 
     def test_hsdp_with_allgather_rejected(self):
         """HSDP + DLO + AllGather should raise ValueError (double sharding)."""

--- a/tests/diffusion/offloader/test_distributed_layerwise_backend.py
+++ b/tests/diffusion/offloader/test_distributed_layerwise_backend.py
@@ -8,6 +8,7 @@ import gc
 import json
 import os
 import socket
+import threading
 from contextlib import contextmanager
 from types import SimpleNamespace
 
@@ -403,6 +404,90 @@ class TestBoundedHostStaging:
         hook.prefetch_layer(slot=0, non_blocking=False)
         assert pool.buffers[0][torch.float32].data_ptr() == first_slot_ptr
         assert first_event.synchronize_calls == 1
+
+    def test_background_prepare_stages_next_shard_without_blocking(
+        self,
+        monkeypatch,
+    ):
+        pool = dist_backend_module.PinnedHostStagingPool.from_shard_sets(
+            [{torch.float32: torch.arange(4, dtype=torch.float32)}],
+            pin_memory=False,
+            budget_bytes=32,
+        )
+        source = {torch.float32: torch.arange(4, dtype=torch.float32)}
+        copy_started = threading.Event()
+        allow_copy = threading.Event()
+        original_stage_into = pool._stage_into
+
+        def blocked_stage_into(slot, sources):
+            copy_started.set()
+            assert allow_copy.wait(timeout=5)
+            return original_stage_into(slot, sources)
+
+        monkeypatch.setattr(pool, "_stage_into", blocked_stage_into)
+
+        assert pool.prepare([source]) == 1
+        assert copy_started.wait(timeout=5)
+        assert pool.pending_count == 1
+        allow_copy.set()
+
+        slot, staged = pool.stage(source)
+        assert torch.equal(staged[torch.float32], source[torch.float32])
+        assert pool.prefetch_hits == 1
+        assert pool.staging_misses == 0
+        pool.mark_in_flight(slot, DummyEvent())
+        pool.close()
+
+    def test_prepare_waits_for_h2d_event_off_the_caller_thread(self):
+        class BlockingEvent:
+            def __init__(self):
+                self.synchronize_started = threading.Event()
+                self.allow_reuse = threading.Event()
+
+            def synchronize(self):
+                self.synchronize_started.set()
+                assert self.allow_reuse.wait(timeout=5)
+
+        sources = [{torch.float32: torch.full((4,), value, dtype=torch.float32)} for value in range(3)]
+        pool = dist_backend_module.PinnedHostStagingPool.from_shard_sets(
+            sources,
+            pin_memory=False,
+            budget_bytes=32,
+        )
+
+        first_slot, _ = pool.stage(sources[0])
+        blocking_event = BlockingEvent()
+        pool.mark_in_flight(first_slot, blocking_event)
+        second_slot, _ = pool.stage(sources[1])
+        pool.mark_in_flight(second_slot, DummyEvent())
+
+        # The worker owns the event wait; prepare itself must return.
+        assert pool.prepare([sources[2]]) == 1
+        assert blocking_event.synchronize_started.wait(timeout=5)
+        blocking_event.allow_reuse.set()
+
+        staged_slot, staged = pool.stage(sources[2])
+        assert staged_slot == first_slot
+        assert torch.equal(staged[torch.float32], sources[2][torch.float32])
+        pool.mark_in_flight(staged_slot, DummyEvent())
+        pool.close()
+
+    def test_prepare_keeps_one_slot_for_unexpected_request(self):
+        sources = [{torch.float32: torch.full((4,), value, dtype=torch.float32)} for value in range(3)]
+        pool = dist_backend_module.PinnedHostStagingPool.from_shard_sets(
+            sources,
+            pin_memory=False,
+            budget_bytes=32,
+        )
+
+        assert pool.prepare(sources[:2]) == 1
+        slot, staged = pool.stage(sources[2])
+        assert torch.equal(staged[torch.float32], sources[2][torch.float32])
+        assert pool.staging_misses == 1
+        pool.mark_in_flight(slot, DummyEvent())
+        assert pool.pending_count == 0
+        assert pool.prefetch_discarded == 1
+        pool.close()
 
     def test_file_backed_store_removes_ephemeral_cache_on_close(self, tmp_path):
         store = dist_backend_module.FileBackedShardStore(tmp_path)

--- a/tests/entrypoints/test_async_omni_diffusion_config.py
+++ b/tests/entrypoints/test_async_omni_diffusion_config.py
@@ -299,6 +299,14 @@ def test_serve_cli_forwards_distributed_offload_residency():
             "--dlo-no-use-allgather",
             "--dlo-resident-layers",
             "20",
+            "--dlo-host-memory-budget-gib",
+            "8",
+            "--dlo-host-cache-dir",
+            "/tmp/dlo-cache",
+            "--dlo-pinned-staging-buffer-count",
+            "3",
+            "--dlo-prefetch-depth",
+            "4",
         ]
     )
 
@@ -309,9 +317,17 @@ def test_serve_cli_forwards_distributed_offload_residency():
     assert args.enable_distributed_layerwise_offload is True
     assert args.dlo_use_allgather is False
     assert args.dlo_resident_layers == 20
+    assert args.dlo_host_memory_budget_gib == 8
+    assert args.dlo_host_cache_dir == "/tmp/dlo-cache"
+    assert args.dlo_pinned_staging_buffer_count == 3
+    assert args.dlo_prefetch_depth == 4
     assert engine_args["enable_distributed_layerwise_offload"] is True
     assert engine_args["dlo_use_allgather"] is False
     assert engine_args["dlo_resident_layers"] == 20
+    assert engine_args["dlo_host_memory_budget_gib"] == 8
+    assert engine_args["dlo_host_cache_dir"] == "/tmp/dlo-cache"
+    assert engine_args["dlo_pinned_staging_buffer_count"] == 3
+    assert engine_args["dlo_prefetch_depth"] == 4
 
 
 def test_serve_cli_accepts_diffusion_compile_controls():

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -565,6 +565,10 @@ class _DiffusionConfigProjection:
     enable_distributed_layerwise_offload: bool = False
     dlo_use_allgather: bool = True
     dlo_resident_layers: int = Field(default=0, ge=0)
+    dlo_host_memory_budget_gib: float | None = Field(default=None, gt=0)
+    dlo_host_cache_dir: str | None = None
+    dlo_pinned_staging_buffer_count: int = Field(default=2, ge=2)
+    dlo_prefetch_depth: int = Field(default=2, ge=0)
     pin_cpu_memory: bool = True
     diffusion_compile_granularity: Literal["regional", "full"] = "regional"
     diffusion_compile_dynamic: bool = Field(default=True, strict=True)

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -417,6 +417,10 @@ class StageDeployConfig:
     enable_distributed_layerwise_offload: bool | None = None
     dlo_use_allgather: bool | None = None
     dlo_resident_layers: int | None = None
+    dlo_host_memory_budget_gib: float | None = None
+    dlo_host_cache_dir: str | None = None
+    dlo_pinned_staging_buffer_count: int | None = None
+    dlo_prefetch_depth: int | None = None
     # Diffusion-specific debug and observability knobs.
     enable_diffusion_pipeline_profiler: bool | None = None
 

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -698,6 +698,14 @@ class OmniDiffusionConfig:
     dlo_use_allgather: bool = True
     # Leading main-DiT blocks kept resident by distributed layerwise offload.
     dlo_resident_layers: int = 0
+    # Optional bounded private host staging. Persistent rank-local DiT shards
+    # are file-backed; only a fixed ring of transfer buffers is pinned.
+    dlo_host_memory_budget_gib: float | None = None
+    dlo_host_cache_dir: str | None = None
+    dlo_pinned_staging_buffer_count: int = 2
+    # Number of upcoming file-backed layer shards submitted for best-effort
+    # OS readahead. This does not reserve equivalent anonymous RAM.
+    dlo_prefetch_depth: int = 2
 
     pin_cpu_memory: bool = True  # Use pinned memory for faster transfers when offloading
 

--- a/vllm_omni/diffusion/offloader/base.py
+++ b/vllm_omni/diffusion/offloader/base.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import math
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
@@ -31,6 +32,10 @@ class OffloadConfig:
     # rank-local tensors (including TP-local shards) with H2D only.
     dlo_use_allgather: bool = True
     dlo_resident_layers: int = 0  # leading DiT layers kept on device
+    dlo_host_memory_budget_bytes: int | None = None
+    dlo_host_cache_dir: str | None = None
+    dlo_pinned_staging_buffer_count: int = 2
+    dlo_prefetch_depth: int = 2
     model_path: str | None = None  # checkpoint path for mmap weight loading
 
     @classmethod
@@ -111,6 +116,32 @@ class OffloadConfig:
                 "resident blocks use weights prepared by the standard TP-aware loader"
             )
 
+        staging_buffer_count = int(getattr(od_config, "dlo_pinned_staging_buffer_count", 2))
+        if staging_buffer_count < 2:
+            raise ValueError(f"dlo_pinned_staging_buffer_count must be >= 2, got {staging_buffer_count}")
+        prefetch_depth = int(getattr(od_config, "dlo_prefetch_depth", 2))
+        if prefetch_depth < 0:
+            raise ValueError(f"dlo_prefetch_depth must be >= 0, got {prefetch_depth}")
+
+        budget_gib = getattr(od_config, "dlo_host_memory_budget_gib", None)
+        budget_bytes: int | None = None
+        host_cache_dir = getattr(od_config, "dlo_host_cache_dir", None)
+        if budget_gib is not None:
+            try:
+                budget_gib = float(budget_gib)
+            except (TypeError, ValueError) as exc:
+                raise ValueError("dlo_host_memory_budget_gib must be finite and > 0") from exc
+            if not math.isfinite(budget_gib) or budget_gib <= 0:
+                raise ValueError("dlo_host_memory_budget_gib must be finite and > 0")
+            if not enable_distributed_layerwise_offload:
+                raise ValueError("dlo_host_memory_budget_gib requires enable_distributed_layerwise_offload")
+            if dlo_use_allgather:
+                raise ValueError("bounded DLO host staging currently requires --dlo-no-use-allgather")
+            if host_cache_dir is None or not str(host_cache_dir).strip():
+                raise ValueError("dlo_host_cache_dir is required when dlo_host_memory_budget_gib is set")
+            host_cache_dir = str(host_cache_dir)
+            budget_bytes = int(budget_gib * 1024**3)
+
         # If dlo_use_allgather=False, force dp_size=1 (each rank independent)
         if enable_distributed_layerwise_offload and not dlo_use_allgather:
             dp_size = 1
@@ -137,6 +168,10 @@ class OffloadConfig:
             dp_size=dp_size,
             dlo_use_allgather=dlo_use_allgather,
             dlo_resident_layers=dlo_resident_layers,
+            dlo_host_memory_budget_bytes=budget_bytes,
+            dlo_host_cache_dir=host_cache_dir,
+            dlo_pinned_staging_buffer_count=staging_buffer_count,
+            dlo_prefetch_depth=prefetch_depth,
             model_path=getattr(od_config, "model", None),
         )
 

--- a/vllm_omni/diffusion/offloader/distributed_layerwise_backend.py
+++ b/vllm_omni/diffusion/offloader/distributed_layerwise_backend.py
@@ -383,6 +383,12 @@ class DistributedLayerwiseOffloadHook(ModelHook):
                     )
                 evt.record(self.comm_stream)
 
+        if staging_pool is not None and len(self.host_prefetch_shards) > 1:
+            # Copy the next file-backed shard into the other pinned slot
+            # while this layer's H2D/compute proceeds. prepare leaves one
+            # emergency slot free for cache skips and module-group switches.
+            staging_pool.prepare(self.host_prefetch_shards[1:])
+
         self.ready_events[slot] = evt
         self._prefetch_done = evt
         self._prefetched_slot = slot
@@ -609,6 +615,9 @@ class PinnedResidentLayerGroup:
             if self.host_shard_store is not None and self.host_prefetch_depth:
                 end = min(index + self.host_prefetch_depth, len(self._states))
                 self.host_shard_store.prefetch(candidate["cpu_shards"] for candidate in self._states[index:end])
+            if staging_pool is not None and self.host_prefetch_depth:
+                end = min(index + self.host_prefetch_depth, len(self._states))
+                staging_pool.prepare(candidate["cpu_shards"] for candidate in self._states[index:end])
 
             host_slot: int | None = None
             copy_sources = state["cpu_shards"]
@@ -1477,13 +1486,17 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
                     group[(index + offset) % len(group)].cpu_shards for offset in range(group_depth)
                 ]
 
+        saved_pinned_bytes = max(store.allocated_bytes - pool.allocated_bytes, 0)
         logger.info(
             "Bounded DLO host staging enabled: file-backed shards=%.2f GiB, "
-            "private staging=%.2f GiB (%d buffers), prefetch_depth=%d. "
+            "private staging=%.2f GiB (%d buffers), pinned payload reduction=%.2f GiB (%.1f%%), "
+            "prefetch_depth=%d. "
             "OS page cache and initial checkpoint-loader memory are not bounded.",
             store.allocated_bytes / 1024**3,
             pool.allocated_bytes / 1024**3,
             len(pool.buffers),
+            saved_pinned_bytes / 1024**3,
+            100.0 * saved_pinned_bytes / store.allocated_bytes,
             prefetch_depth,
         )
 
@@ -1806,6 +1819,23 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
 
     def _release_host_storage(self) -> None:
         current_omni_platform.synchronize()
+        if self._host_staging_pool is not None:
+            pool = self._host_staging_pool
+            logger.info(
+                "Bounded DLO host staging runtime: staged=%.2f GiB, prefetched=%d, "
+                "prefetch_hits=%d, discarded=%d, synchronous_misses=%d, staging_wait=%.3fs",
+                pool.staged_bytes / 1024**3,
+                pool.prefetch_scheduled,
+                pool.prefetch_hits,
+                pool.prefetch_discarded,
+                pool.staging_misses,
+                pool.stage_wait_seconds,
+            )
+            # Pending workers still reference mmap-backed shard dictionaries.
+            # Stop them before clearing hooks or closing the backing mappings.
+            pool.close()
+        self._host_staging_pool = None
+
         for group in self._all_hook_groups:
             for hook in group:
                 hook.cpu_shards.clear()
@@ -1814,8 +1844,6 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
                 hook.host_shard_store = None
         if self._resident_layer_group is not None:
             self._resident_layer_group.release_host_storage()
-
-        self._host_staging_pool = None
         if self._host_shard_store is not None:
             import gc
 

--- a/vllm_omni/diffusion/offloader/distributed_layerwise_backend.py
+++ b/vllm_omni/diffusion/offloader/distributed_layerwise_backend.py
@@ -30,6 +30,7 @@ from vllm_omni.platforms import current_omni_platform
 
 from .base import OffloadBackend, OffloadConfig
 from .block_discovery import get_blocks_from_dit
+from .host_staging import FileBackedShardStore, PinnedHostStagingPool
 from .module_collector import ModuleDiscovery
 from .offload_plan import OffloadPlan, get_offload_plan, supports_mmap_loading
 from .tensor_utils import (
@@ -74,6 +75,7 @@ class DistributedLayerwiseOffloadHook(ModelHook):
         comm_stream: Any | None = None,
         pin_memory: bool = True,
         shared_buffers: list[dict[torch.dtype, torch.Tensor] | None] | None = None,
+        host_shard_store: FileBackedShardStore | None = None,
     ):
         assert isinstance(next_block, nn.Module), "transformer block must be type `torch.nn.Module`"
 
@@ -83,6 +85,9 @@ class DistributedLayerwiseOffloadHook(ModelHook):
         self.dp_size = dp_size
         self.rank = rank
         self.pin_memory = pin_memory
+        self.host_shard_store = host_shard_store
+        self.host_staging_pool: PinnedHostStagingPool | None = None
+        self.host_prefetch_shards: list[dict[torch.dtype, torch.Tensor]] = []
 
         self.copy_stream = copy_stream or current_omni_platform.Stream()
         self.comm_stream = comm_stream or current_omni_platform.Stream()
@@ -161,6 +166,7 @@ class DistributedLayerwiseOffloadHook(ModelHook):
             self.dp_size,
             self.rank,
             self.pin_memory,
+            self.host_shard_store,
         )
 
         # Allocate device buffers only if not using shared buffers from backend
@@ -197,6 +203,7 @@ class DistributedLayerwiseOffloadHook(ModelHook):
         dp_size: int,
         rank: int,
         pin_memory: bool,
+        host_shard_store: FileBackedShardStore | None = None,
     ) -> tuple[dict[torch.dtype, torch.Tensor], dict[torch.dtype, list[dict[str, Any]]]]:
         """Flatten params+buffers by dtype, split into DP shards, store local shard.
 
@@ -239,7 +246,10 @@ class DistributedLayerwiseOffloadHook(ModelHook):
 
             # Allocate ONLY the shard (1/dp_size), zero-padded to ceil.
             # Avoids materialising the full block on CPU.
-            shard = torch.zeros(shard_size, dtype=dtype, device="cpu")
+            if host_shard_store is None:
+                shard = torch.zeros(shard_size, dtype=dtype, device="cpu")
+            else:
+                shard = host_shard_store.allocate(shard_size, dtype)
 
             current_offset = 0
             for name, original_tensor, local_tensor in weights_with_local:
@@ -274,7 +284,9 @@ class DistributedLayerwiseOffloadHook(ModelHook):
                 )
                 current_offset += numel
 
-            if pin_memory:
+            if host_shard_store is not None:
+                host_shard_store.finalize(shard)
+            elif pin_memory:
                 shard = shard.pin_memory()
 
             cpu_shards[dtype] = shard
@@ -316,25 +328,41 @@ class DistributedLayerwiseOffloadHook(ModelHook):
         """
         self.copy_stream.wait_stream(current_omni_platform.current_stream())
 
+        if self.host_shard_store is not None and self.host_prefetch_shards:
+            self.host_shard_store.prefetch(self.host_prefetch_shards)
+
+        staging_pool = self.host_staging_pool
+        host_slot: int | None = None
+        copy_sources = self.cpu_shards
+        if staging_pool is not None:
+            host_slot, copy_sources = staging_pool.stage(self.cpu_shards)
+
         evt = current_omni_platform.Event()
         gpu_weights = self.gpu_buffers[slot]
         assert gpu_weights is not None, f"gpu_buffers[{slot}] not allocated"
 
         if self.dp_size <= 1 or self.dp_group is None:
             with current_omni_platform.stream(self.copy_stream):
-                for dtype, cpu_shard in self.cpu_shards.items():
+                for dtype, cpu_shard in copy_sources.items():
                     gw = gpu_weights[dtype]
                     gw[: cpu_shard.numel()].copy_(cpu_shard, non_blocking=non_blocking)
                 evt.record(self.copy_stream)
+            if host_slot is not None:
+                staging_pool.mark_in_flight(host_slot, evt)
         else:
             gpu_shards: dict[torch.dtype, torch.Tensor] = {}
             shard_bufs = self.gpu_shard_buffers[slot]
             assert shard_bufs is not None, f"gpu_shard_buffers[{slot}] not allocated"
             with current_omni_platform.stream(self.copy_stream):
-                for dtype, cpu_shard in self.cpu_shards.items():
+                for dtype, cpu_shard in copy_sources.items():
                     gpu_shard = shard_bufs[dtype][: cpu_shard.numel()]
                     gpu_shard.copy_(cpu_shard, non_blocking=non_blocking)
                     gpu_shards[dtype] = gpu_shard
+                if host_slot is not None:
+                    h2d_evt = current_omni_platform.Event()
+                    h2d_evt.record(self.copy_stream)
+            if host_slot is not None:
+                staging_pool.mark_in_flight(host_slot, h2d_evt)
 
             self.comm_stream.wait_stream(self.copy_stream)
             with current_omni_platform.stream(self.comm_stream):
@@ -468,6 +496,7 @@ def apply_distributed_block_hook(
     comm_stream: Any | None = None,
     pin_memory: bool = True,
     shared_buffers: list[dict[torch.dtype, torch.Tensor] | None] | None = None,
+    host_shard_store: FileBackedShardStore | None = None,
 ) -> DistributedLayerwiseOffloadHook:
     """Register a DistributedLayerwiseOffloadHook on *module*."""
     registry = HookRegistry.get_or_create(module)
@@ -481,6 +510,7 @@ def apply_distributed_block_hook(
         comm_stream=comm_stream,
         pin_memory=pin_memory,
         shared_buffers=shared_buffers,
+        host_shard_store=host_shard_store,
     )
     registry.register_hook(DistributedLayerwiseOffloadHook._HOOK_NAME, hook)
     return hook
@@ -518,10 +548,15 @@ class PinnedResidentLayerGroup:
         device: torch.device,
         copy_stream: Any,
         pin_memory: bool,
+        host_shard_store: FileBackedShardStore | None = None,
+        host_prefetch_depth: int = 0,
     ) -> None:
         self.device = device
         self.copy_stream = copy_stream
         self.loaded = False
+        self.host_shard_store = host_shard_store
+        self.host_staging_pool: PinnedHostStagingPool | None = None
+        self.host_prefetch_depth = host_prefetch_depth
         self._states: list[dict[str, Any]] = []
         self._gpu_buffers: list[dict[torch.dtype, torch.Tensor]] = []
 
@@ -535,6 +570,7 @@ class PinnedResidentLayerGroup:
                 dp_size=1,
                 rank=0,
                 pin_memory=pin_memory,
+                host_shard_store=host_shard_store,
             )
             self._states.append(
                 {
@@ -543,6 +579,10 @@ class PinnedResidentLayerGroup:
                     "metadata": metadata,
                 }
             )
+
+    @property
+    def host_shard_sets(self) -> list[dict[torch.dtype, torch.Tensor]]:
+        return [state["cpu_shards"] for state in self._states]
 
     def load(self) -> None:
         if self.loaded:
@@ -564,10 +604,27 @@ class PinnedResidentLayerGroup:
 
         self.copy_stream.wait_stream(current_omni_platform.current_stream())
         ready = current_omni_platform.Event()
-        with current_omni_platform.stream(self.copy_stream):
-            for state, block_buffers in zip(self._states, gpu_buffers):
-                for dtype, cpu_shard in state["cpu_shards"].items():
+        staging_pool = self.host_staging_pool
+        for index, (state, block_buffers) in enumerate(zip(self._states, gpu_buffers)):
+            if self.host_shard_store is not None and self.host_prefetch_depth:
+                end = min(index + self.host_prefetch_depth, len(self._states))
+                self.host_shard_store.prefetch(candidate["cpu_shards"] for candidate in self._states[index:end])
+
+            host_slot: int | None = None
+            copy_sources = state["cpu_shards"]
+            if staging_pool is not None:
+                host_slot, copy_sources = staging_pool.stage(copy_sources)
+
+            with current_omni_platform.stream(self.copy_stream):
+                for dtype, cpu_shard in copy_sources.items():
                     block_buffers[dtype].copy_(cpu_shard, non_blocking=True)
+                if host_slot is not None:
+                    h2d_evt = current_omni_platform.Event()
+                    h2d_evt.record(self.copy_stream)
+            if host_slot is not None:
+                staging_pool.mark_in_flight(host_slot, h2d_evt)
+
+        with current_omni_platform.stream(self.copy_stream):
             ready.record(self.copy_stream)
 
         for state, block_buffers in zip(self._states, gpu_buffers):
@@ -597,6 +654,12 @@ class PinnedResidentLayerGroup:
                 set_tensor_storage(target, make_offload_placeholder(target))
         self._gpu_buffers.clear()
         self.loaded = False
+
+    def release_host_storage(self) -> None:
+        for state in self._states:
+            state["cpu_shards"].clear()
+        self.host_staging_pool = None
+        self.host_shard_store = None
 
 
 # ---------------------------------------------------------------------- #
@@ -630,6 +693,8 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
         self._all_hook_groups: list[list[DistributedLayerwiseOffloadHook]] = []
         self._resident_blocks: list[nn.Module] = []
         self._resident_layer_group: PinnedResidentLayerGroup | None = None
+        self._host_shard_store: FileBackedShardStore | None = None
+        self._host_staging_pool: PinnedHostStagingPool | None = None
 
     def load_resident_layers(self) -> None:
         """Load the model-declared leading blocks for the denoise stage."""
@@ -1265,6 +1330,7 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
             self.comm_stream,
             self.config.pin_cpu_memory,
             shared_buffers=[None, None],
+            host_shard_store=self._host_shard_store,
         )
         sub_hooks = [last_hook]
         for i, block in enumerate(blocks[:-1]):
@@ -1280,6 +1346,7 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
                 self.comm_stream,
                 self.config.pin_cpu_memory,
                 shared_buffers=[None, None],
+                host_shard_store=self._host_shard_store,
             )
             sub_hooks.append(hook)
 
@@ -1374,6 +1441,52 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
             if buffer is not None:
                 buffer.data = buffer.data.to(self.device, non_blocking=True)
 
+    def _configure_bounded_host_staging(
+        self,
+        hooks: list[DistributedLayerwiseOffloadHook],
+    ) -> None:
+        store = self._host_shard_store
+        if store is None:
+            return
+
+        shard_sets = [hook.cpu_shards for hook in hooks]
+        if self._resident_layer_group is not None:
+            shard_sets.extend(self._resident_layer_group.host_shard_sets)
+        if not shard_sets:
+            return
+
+        budget_bytes = self.config.dlo_host_memory_budget_bytes
+        assert budget_bytes is not None
+        pool = PinnedHostStagingPool.from_shard_sets(
+            shard_sets,
+            pin_memory=self.config.pin_cpu_memory,
+            budget_bytes=budget_bytes,
+            buffer_count=self.config.dlo_pinned_staging_buffer_count,
+        )
+        self._host_staging_pool = pool
+        for hook in hooks:
+            hook.host_staging_pool = pool
+        if self._resident_layer_group is not None:
+            self._resident_layer_group.host_staging_pool = pool
+
+        prefetch_depth = self.config.dlo_prefetch_depth
+        for group in self._all_hook_groups:
+            group_depth = min(prefetch_depth, len(group))
+            for index, hook in enumerate(group):
+                hook.host_prefetch_shards = [
+                    group[(index + offset) % len(group)].cpu_shards for offset in range(group_depth)
+                ]
+
+        logger.info(
+            "Bounded DLO host staging enabled: file-backed shards=%.2f GiB, "
+            "private staging=%.2f GiB (%d buffers), prefetch_depth=%d. "
+            "OS page cache and initial checkpoint-loader memory are not bounded.",
+            store.allocated_bytes / 1024**3,
+            pool.allocated_bytes / 1024**3,
+            len(pool.buffers),
+            prefetch_depth,
+        )
+
     def enable(self, pipeline: nn.Module) -> None:
         if self.enabled:
             logger.warning("DistributedLayerwiseOffloadBackend already enabled")
@@ -1390,6 +1503,13 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
         if not modules.dits:
             logger.warning("No DiT/transformer modules found, skipping distributed layer-wise offloading")
             return
+        if self.config.dlo_host_memory_budget_bytes is not None:
+            assert self.config.dlo_host_cache_dir is not None
+            self._host_shard_store = FileBackedShardStore(self.config.dlo_host_cache_dir)
+            logger.info(
+                "Bounded DLO host staging cache: %s",
+                self._host_shard_store.cache_dir,
+            )
 
         # Retrieve optional declarative OffloadPlan from the pipeline.
         # When present, replaces heuristic block discovery.
@@ -1528,6 +1648,7 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
                 self.comm_stream,
                 self.config.pin_cpu_memory,
                 shared_buffers=[None, None],
+                host_shard_store=self._host_shard_store,
             )
 
             block_hooks: list[DistributedLayerwiseOffloadHook] = [last_hook]
@@ -1544,6 +1665,7 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
                     self.comm_stream,
                     self.config.pin_cpu_memory,
                     shared_buffers=[None, None],
+                    host_shard_store=self._host_shard_store,
                 )
                 block_hooks.append(hook)
 
@@ -1572,12 +1694,10 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
                 self.device,
                 self.copy_stream,
                 self.config.pin_cpu_memory,
+                host_shard_store=self._host_shard_store,
+                host_prefetch_depth=self.config.dlo_prefetch_depth,
             )
             pipeline._dlo_residency_controller = self
-
-        if not self._all_hook_groups:
-            self.enabled = bool(self._resident_blocks)
-            return
 
         # Unified allocation: 2 shared output buffers + 2 shared shard buffers
         # sized to the max block across ALL module groups (gen_layers +
@@ -1585,6 +1705,17 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
         all_hooks: list[DistributedLayerwiseOffloadHook] = []
         for group in self._all_hook_groups:
             all_hooks.extend(group)
+        self._configure_bounded_host_staging(all_hooks)
+
+        if not self._all_hook_groups:
+            self.enabled = bool(self._resident_blocks)
+            if self.enabled:
+                self._release_mmap_handles()
+                self._cleanup_after_loading()
+            elif self._host_shard_store is not None:
+                self._host_shard_store.close()
+                self._host_shard_store = None
+            return
 
         unified_buffers = self._allocate_shared_buffers(all_hooks)
         unified_shard_buffers = None
@@ -1673,6 +1804,25 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
         except Exception:
             pass
 
+    def _release_host_storage(self) -> None:
+        current_omni_platform.synchronize()
+        for group in self._all_hook_groups:
+            for hook in group:
+                hook.cpu_shards.clear()
+                hook.host_prefetch_shards.clear()
+                hook.host_staging_pool = None
+                hook.host_shard_store = None
+        if self._resident_layer_group is not None:
+            self._resident_layer_group.release_host_storage()
+
+        self._host_staging_pool = None
+        if self._host_shard_store is not None:
+            import gc
+
+            gc.collect()
+            self._host_shard_store.close()
+            self._host_shard_store = None
+
     def disable(self) -> None:
         if not self.enabled:
             return
@@ -1687,6 +1837,7 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
         self._on_demand_shard_infos = []
 
         self.offload_resident_layers()
+        self._release_host_storage()
         self._blocks.clear()
         self._all_hook_groups.clear()
         self._resident_blocks.clear()

--- a/vllm_omni/diffusion/offloader/host_staging.py
+++ b/vllm_omni/diffusion/offloader/host_staging.py
@@ -8,7 +8,10 @@ import errno
 import mmap
 import os
 import tempfile
+import time
+from collections import deque
 from collections.abc import Iterable
+from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
@@ -119,7 +122,13 @@ class FileBackedShardStore:
 
 
 class PinnedHostStagingPool:
-    """A fixed-size ring of shared CPU staging buffers."""
+    """A fixed-size ring of shared CPU staging buffers.
+
+    File-backed shards are copied into these buffers on one background
+    thread. prepare is best effort and never waits for a free slot; stage is
+    the correctness boundary and waits only when the requested shard has not
+    finished staging yet.
+    """
 
     def __init__(
         self,
@@ -129,7 +138,18 @@ class PinnedHostStagingPool:
         self.buffers = buffers
         self.allocated_bytes = allocated_bytes
         self.slot_events: list[Any | None] = [None] * len(buffers)
-        self._next_slot = 0
+        self._available_slots = deque(range(len(buffers)))
+        self._leased_slots: set[int] = set()
+        self._pending: dict[int, tuple[int, Future[dict[torch.dtype, torch.Tensor]]]] = {}
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="dlo-host-stage")
+        self._closed = False
+
+        self.prefetch_scheduled = 0
+        self.prefetch_hits = 0
+        self.staging_misses = 0
+        self.staged_bytes = 0
+        self.prefetch_discarded = 0
+        self.stage_wait_seconds = 0.0
 
     @classmethod
     def from_shard_sets(
@@ -164,13 +184,17 @@ class PinnedHostStagingPool:
             buffers.append(slot)
         return cls(buffers, required_bytes)
 
-    def stage(
-        self,
-        sources: dict[torch.dtype, torch.Tensor],
-    ) -> tuple[int, dict[torch.dtype, torch.Tensor]]:
-        slot = self._next_slot
-        self._next_slot = (slot + 1) % len(self.buffers)
+    @staticmethod
+    def _source_key(sources: dict[torch.dtype, torch.Tensor]) -> int:
+        # Shard dictionaries belong to long-lived hooks, so their identity is
+        # stable for the lifetime of the pool and avoids hashing large tensors.
+        return id(sources)
 
+    def _stage_into(
+        self,
+        slot: int,
+        sources: dict[torch.dtype, torch.Tensor],
+    ) -> dict[torch.dtype, torch.Tensor]:
         previous_event = self.slot_events[slot]
         if previous_event is not None:
             previous_event.synchronize()
@@ -181,7 +205,115 @@ class PinnedHostStagingPool:
             target = self.buffers[slot][dtype][: source.numel()]
             target.copy_(source)
             staged[dtype] = target
+        return staged
+
+    def _submit(
+        self,
+        sources: dict[torch.dtype, torch.Tensor],
+    ) -> tuple[int, Future[dict[torch.dtype, torch.Tensor]]] | None:
+        if not self._available_slots:
+            return None
+        slot = self._available_slots.popleft()
+        future = self._executor.submit(self._stage_into, slot, sources)
+        return slot, future
+
+    def prepare(self, shard_sets: Iterable[dict[torch.dtype, torch.Tensor]]) -> int:
+        """Submit upcoming shards for background staging without blocking.
+
+        At least one slot is deliberately left unreserved so an unexpected
+        synchronous request (cache skip or module-group transition) can still
+        make progress without waiting for an unrelated prefetched shard.
+        """
+        if self._closed:
+            raise RuntimeError("pinned DLO host staging pool is closed")
+
+        scheduled = 0
+        max_pending = len(self.buffers) - 1
+        for sources in shard_sets:
+            key = self._source_key(sources)
+            if key in self._pending:
+                continue
+            if len(self._pending) >= max_pending:
+                break
+            submitted = self._submit(sources)
+            if submitted is None:
+                break
+            self._pending[key] = submitted
+            self.prefetch_scheduled += 1
+            scheduled += 1
+        return scheduled
+
+    def _discard_pending(self) -> None:
+        first_error: Exception | None = None
+        pending = list(self._pending.values())
+        self._pending.clear()
+        for slot, future in pending:
+            try:
+                if not future.cancel():
+                    future.result()
+            except Exception as exc:
+                if first_error is None:
+                    first_error = exc
+            finally:
+                self._available_slots.append(slot)
+        self.prefetch_discarded += len(pending)
+        if first_error is not None:
+            raise first_error
+
+    def stage(
+        self,
+        sources: dict[torch.dtype, torch.Tensor],
+    ) -> tuple[int, dict[torch.dtype, torch.Tensor]]:
+        if self._closed:
+            raise RuntimeError("pinned DLO host staging pool is closed")
+
+        key = self._source_key(sources)
+        pending = self._pending.pop(key, None)
+        if pending is None:
+            self.staging_misses += 1
+            if self._pending:
+                self._discard_pending()
+            submitted = self._submit(sources)
+            if submitted is None:
+                # prepare reserves at most N-1 slots, so this can only happen
+                # after an invalid lifecycle: a staged slot was not returned
+                # through mark_in_flight.
+                raise RuntimeError("no DLO host staging slot is available")
+            slot, future = submitted
+        else:
+            self.prefetch_hits += 1
+            slot, future = pending
+
+        wait_started = time.perf_counter()
+        try:
+            staged = future.result()
+        except Exception:
+            self._available_slots.append(slot)
+            raise
+        self.stage_wait_seconds += time.perf_counter() - wait_started
+        self.staged_bytes += sum(source.numel() * dtype_size(dtype) for dtype, source in sources.items())
+        self._leased_slots.add(slot)
         return slot, staged
 
     def mark_in_flight(self, slot: int, event: Any) -> None:
+        if slot not in self._leased_slots:
+            raise RuntimeError(f"DLO host staging slot {slot} is not leased")
+        self._leased_slots.remove(slot)
         self.slot_events[slot] = event
+        self._available_slots.append(slot)
+
+    @property
+    def pending_count(self) -> int:
+        return len(self._pending)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._executor.shutdown(wait=True)
+        for event in self.slot_events:
+            if event is not None:
+                event.synchronize()
+        self._pending.clear()
+        self._available_slots.clear()
+        self._leased_slots.clear()
+        self._closed = True

--- a/vllm_omni/diffusion/offloader/host_staging.py
+++ b/vllm_omni/diffusion/offloader/host_staging.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Bounded host-memory staging for distributed layerwise offload."""
+
+from __future__ import annotations
+
+import errno
+import mmap
+import os
+import tempfile
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from .tensor_utils import dtype_size
+
+_FALLOCATE_UNSUPPORTED_ERRNOS = {errno.EINVAL, errno.ENOSYS, errno.EOPNOTSUPP}
+
+
+class FileBackedShardStore:
+    """Store finalized rank-local shards in private file-backed mappings.
+
+    The cache files hold the persistent copy.  Their pages may be cached by
+    the OS, but unlike anonymous or pinned tensors those pages are reclaimable
+    under host-memory pressure.
+    """
+
+    def __init__(self, root: str | os.PathLike[str]) -> None:
+        root_path = Path(root).expanduser()
+        root_path.mkdir(parents=True, exist_ok=True)
+        self._temp_dir = tempfile.TemporaryDirectory(
+            prefix=f"vllm-omni-dlo-{os.getpid()}-",
+            dir=root_path,
+        )
+        self.cache_dir = Path(self._temp_dir.name)
+        self.allocated_bytes = 0
+        self._entries: dict[int, tuple[mmap.mmap, int, Path, int]] = {}
+        self._next_file_id = 0
+        self._closed = False
+
+    def allocate(self, numel: int, dtype: torch.dtype) -> torch.Tensor:
+        if self._closed:
+            raise RuntimeError("file-backed DLO shard store is closed")
+        if numel <= 0:
+            raise ValueError(f"file-backed DLO shard must contain elements, got {numel}")
+
+        nbytes = numel * dtype_size(dtype)
+        path = self.cache_dir / f"shard-{self._next_file_id:06d}.bin"
+        self._next_file_id += 1
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600)
+        try:
+            os.ftruncate(fd, nbytes)
+            if hasattr(os, "posix_fallocate"):
+                try:
+                    os.posix_fallocate(fd, 0, nbytes)
+                except OSError as exc:
+                    if exc.errno not in _FALLOCATE_UNSUPPORTED_ERRNOS:
+                        raise
+            mapping = mmap.mmap(fd, nbytes, access=mmap.ACCESS_WRITE)
+        except Exception:
+            os.close(fd)
+            path.unlink(missing_ok=True)
+            raise
+
+        tensor = torch.frombuffer(mapping, dtype=dtype, count=numel)
+        self._entries[id(tensor)] = (mapping, fd, path, nbytes)
+        self.allocated_bytes += nbytes
+        return tensor
+
+    def finalize(self, tensor: torch.Tensor) -> None:
+        """Write back a completed shard and make its clean pages reclaimable."""
+        entry = self._entries.get(id(tensor))
+        if entry is None:
+            return
+        mapping, fd, _, nbytes = entry
+        mapping.flush()
+        try:
+            if hasattr(mapping, "madvise") and hasattr(mmap, "MADV_DONTNEED"):
+                mapping.madvise(mmap.MADV_DONTNEED)
+            if hasattr(os, "posix_fadvise") and hasattr(os, "POSIX_FADV_DONTNEED"):
+                os.posix_fadvise(fd, 0, nbytes, os.POSIX_FADV_DONTNEED)
+        except (OSError, ValueError):
+            pass
+
+    def prefetch(self, shard_sets: Iterable[dict[torch.dtype, torch.Tensor]]) -> None:
+        """Best-effort OS readahead for upcoming file-backed shards."""
+        seen: set[int] = set()
+        for shards in shard_sets:
+            for tensor in shards.values():
+                tensor_id = id(tensor)
+                if tensor_id in seen:
+                    continue
+                seen.add(tensor_id)
+                entry = self._entries.get(tensor_id)
+                if entry is None:
+                    continue
+                mapping, fd, _, nbytes = entry
+                try:
+                    if hasattr(mapping, "madvise") and hasattr(mmap, "MADV_WILLNEED"):
+                        mapping.madvise(mmap.MADV_WILLNEED)
+                    elif hasattr(os, "posix_fadvise") and hasattr(os, "POSIX_FADV_WILLNEED"):
+                        os.posix_fadvise(fd, 0, nbytes, os.POSIX_FADV_WILLNEED)
+                except (OSError, ValueError):
+                    # Readahead is an optimization.  The following tensor copy
+                    # remains the correctness path when the filesystem rejects it.
+                    continue
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        for mapping, fd, _, _ in self._entries.values():
+            mapping.close()
+            os.close(fd)
+        self._entries.clear()
+        self._temp_dir.cleanup()
+        self._closed = True
+
+
+class PinnedHostStagingPool:
+    """A fixed-size ring of shared CPU staging buffers."""
+
+    def __init__(
+        self,
+        buffers: list[dict[torch.dtype, torch.Tensor]],
+        allocated_bytes: int,
+    ) -> None:
+        self.buffers = buffers
+        self.allocated_bytes = allocated_bytes
+        self.slot_events: list[Any | None] = [None] * len(buffers)
+        self._next_slot = 0
+
+    @classmethod
+    def from_shard_sets(
+        cls,
+        shard_sets: Iterable[dict[torch.dtype, torch.Tensor]],
+        *,
+        pin_memory: bool,
+        budget_bytes: int,
+        buffer_count: int = 2,
+    ) -> PinnedHostStagingPool:
+        if buffer_count < 2:
+            raise ValueError(f"dlo_pinned_staging_buffer_count must be >= 2, got {buffer_count}")
+
+        max_numels: dict[torch.dtype, int] = {}
+        for shards in shard_sets:
+            for dtype, shard in shards.items():
+                max_numels[dtype] = max(max_numels.get(dtype, 0), shard.numel())
+
+        required_bytes = buffer_count * sum(numel * dtype_size(dtype) for dtype, numel in max_numels.items())
+        if required_bytes > budget_bytes:
+            raise ValueError(
+                f"{buffer_count} pinned host staging slots require {required_bytes} bytes, "
+                f"but dlo_host_memory_budget_gib allows {budget_bytes} bytes"
+            )
+
+        buffers: list[dict[torch.dtype, torch.Tensor]] = []
+        for _ in range(buffer_count):
+            slot = {
+                dtype: torch.empty(numel, dtype=dtype, device="cpu", pin_memory=pin_memory)
+                for dtype, numel in max_numels.items()
+            }
+            buffers.append(slot)
+        return cls(buffers, required_bytes)
+
+    def stage(
+        self,
+        sources: dict[torch.dtype, torch.Tensor],
+    ) -> tuple[int, dict[torch.dtype, torch.Tensor]]:
+        slot = self._next_slot
+        self._next_slot = (slot + 1) % len(self.buffers)
+
+        previous_event = self.slot_events[slot]
+        if previous_event is not None:
+            previous_event.synchronize()
+            self.slot_events[slot] = None
+
+        staged: dict[torch.dtype, torch.Tensor] = {}
+        for dtype, source in sources.items():
+            target = self.buffers[slot][dtype][: source.numel()]
+            target.copy_(source)
+            staged[dtype] = target
+        return slot, staged
+
+    def mark_in_flight(self, slot: int, event: Any) -> None:
+        self.slot_events[slot] = event

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -498,6 +498,10 @@ class OrchestratorArgs:
     enable_distributed_layerwise_offload: bool = False
     dlo_use_allgather: bool = True
     dlo_resident_layers: int = 0
+    dlo_host_memory_budget_gib: float | None = None
+    dlo_host_cache_dir: str | None = None
+    dlo_pinned_staging_buffer_count: int = 2
+    dlo_prefetch_depth: int = 2
     boundary_ratio: float | None = None
     flow_shift: float | None = None
     diffusion_kv_cache_dtype: str | None = None

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1034,6 +1034,10 @@ class AsyncOmniEngine:
             "enable_distributed_layerwise_offload": kwargs.get("enable_distributed_layerwise_offload", False),
             "dlo_use_allgather": kwargs.get("dlo_use_allgather", True),
             "dlo_resident_layers": kwargs.get("dlo_resident_layers", 0),
+            "dlo_host_memory_budget_gib": kwargs.get("dlo_host_memory_budget_gib"),
+            "dlo_host_cache_dir": kwargs.get("dlo_host_cache_dir"),
+            "dlo_pinned_staging_buffer_count": kwargs.get("dlo_pinned_staging_buffer_count", 2),
+            "dlo_prefetch_depth": kwargs.get("dlo_prefetch_depth", 2),
             "enforce_eager": False if kwargs.get("enforce_eager") is None else kwargs.get("enforce_eager"),
             "diffusion_compile_granularity": (
                 "regional"

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -678,6 +678,39 @@ class OmniServeCommand(CLISubcommand):
             help="Keep this many leading main-DiT blocks resident on the device "
             "while distributed layerwise offload streams the remaining blocks.",
         )
+        omni_config_group.add_argument(
+            "--dlo-host-memory-budget-gib",
+            type=float,
+            default=None,
+            help="Enable bounded rank-local DLO host staging and cap its private "
+            "transfer-buffer allocation in GiB. Requires "
+            "--dlo-no-use-allgather and --dlo-host-cache-dir. This limit excludes "
+            "OS page cache, initial checkpoint loading, encoders, and VAEs.",
+        )
+        omni_config_group.add_argument(
+            "--dlo-host-cache-dir",
+            type=str,
+            default=None,
+            help="Local SSD/NVMe directory for ephemeral file-backed rank-local "
+            "DiT shards used by bounded DLO host staging. Avoid tmpfs and network "
+            "filesystems; files are removed on clean shutdown.",
+        )
+        omni_config_group.add_argument(
+            "--dlo-pinned-staging-buffer-count",
+            type=int,
+            default=2,
+            help="Number of shared host transfer buffers for bounded DLO staging "
+            "(default: 2, minimum: 2). The configured host budget must fit all "
+            "buffers at the largest per-rank layer-shard size.",
+        )
+        omni_config_group.add_argument(
+            "--dlo-prefetch-depth",
+            type=int,
+            default=2,
+            help="Number of upcoming file-backed layer shards submitted for "
+            "best-effort OS readahead (default: 2). This may increase reclaimable "
+            "page-cache residency but not private pinned staging allocation.",
+        )
         # Video model parameters (e.g., Wan2.2) - engine-level
         omni_config_group.add_argument(
             "--boundary-ratio",


### PR DESCRIPTION
## H3 capacity benefit

The checked MiniMax-H3 FL2VA BF16 safetensors headers contain 50 DiT blocks plus two token-refiner blocks:

| Payload | GiB |
| --- | ---: |
| Persistent pinned shards without bounded staging | 61.559 |
| Largest layer | 1.202 |
| Two bounded pinned staging buffers | 2.405 |
| Pinned tensor payload avoided | **59.154 (96.09%)** |

This is the single-rank checkpoint-layout capacity model, not process RSS. TP sharding, quantization, allocator overhead, and model revisions can change per-rank values. The implementation therefore prints the actual reduction for the selected runtime topology.

The host-memory budget covers the private staging pool only. OS page cache, the initial checkpoint loader, encoders, VAEs, request state, and accelerator allocations are outside the bound.

## Host staging pipeline result

Host-only microbenchmark methodology:

- four file-backed BF16 shards at the H3 maximum layer size: 1.202 GiB each
- two pinned staging buffers
- 250 ms simulated per-layer compute window
- local ext4 storage
- 16 PyTorch CPU threads
- median of three alternating synchronous/async runs

| Bounded path | Exposed staging wait | Four-layer pipeline time |
| --- | ---: | ---: |
| Synchronous file-backed to pinned copy | 1.8149 s | 2.8159 s |
| Background one-layer-ahead copy | **1.0182 s (-43.90%)** | **2.0196 s (1.394x)** |

This measures the bounded host staging pipeline. It is not an end-to-end H3 GPU latency or production throughput claim.

## Correctness and lifecycle

- At most `buffer_count - 1` background tasks reserve slots, so an unexpected layer can always make progress.
- A staging slot is unavailable between `stage` and `mark_in_flight`.
- Reuse waits for the recorded H2D event on the background worker, not the model caller thread.
- An unexpected miss drains stale prefetches before rebuilding the correct lookahead sequence.
- Shutdown stops pending workers before hook dictionaries and mmap mappings are released.
- The bounded mode currently fails closed with DLO AllGather; it is scoped to rank-local no-AllGather DLO.

## Configuration

```bash
--enable-distributed-layerwise-offload \
--dlo-no-use-allgather \
--dlo-host-memory-budget-gib 8 \
--dlo-host-cache-dir /local-nvme/vllm-omni-dlo \
--dlo-pinned-staging-buffer-count 2 \
--dlo-prefetch-depth 2
```
=
## Limitations and follow-ups

- The regular H3 loader still constructs the model before the file-backed cache is finalized, so this PR reduces steady private pinned payload but does not lower the documented 200 GiB first-start RAM requirement.
- Each worker needs additional local cache storage. Files are ephemeral and removed on clean shutdown.
- Cold requests remain dependent on local storage and page-cache behavior.
- A persistent preprocessed rank-local cache plus a block-streaming loader is the follow-up needed to reduce first-start peak RAM.
- Full H3 end-to-end capacity and latency A/B remains pending on an unoccupied GPU host, so this PR stays Draft.

## Documentation

The RTX 5090 recipe documents flags, the exact H3 payload model, host pipeline benchmark, storage requirements, and first-start boundary. The GB10 recipe continues to reject DLO because pinned staging shares the same unified-memory pool.