### PR TITLE
[Model] Optimize Audex streaming decoder KV cache

### DIFF
--- a/benchmarks/audex/bench_streaming_decoder_cache.py
+++ b/benchmarks/audex/bench_streaming_decoder_cache.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Microbenchmark the Audex streaming decoder cache path without model weights.
+
+The legacy runner reproduces the previous per-chunk ``torch.cat`` cache,
+per-layer attention-mask construction, and RoPE position readback. The optimized
+runner calls the production ``CausalVocosBackbone.forward`` path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import statistics
+import time
+from collections.abc import Callable
+
+import torch
+from torch import Tensor
+
+from vllm_omni.model_executor.models.audex.speech_decoder.modeling_audex_causal_speech_decoder import (
+    CausalCodecDecoderCache,
+    CausalVocosBackbone,
+)
+
+
+class _LegacyConcatCache:
+    def __init__(self) -> None:
+        self.key_values: dict[int, tuple[Tensor, Tensor]] = {}
+        self.position = 0
+
+    def input_positions(self, length: int, device: torch.device) -> Tensor:
+        return torch.arange(self.position, self.position + length, device=device).unsqueeze(0)
+
+    def update(self, layer_idx: int, key: Tensor, value: Tensor) -> tuple[Tensor, Tensor]:
+        if layer_idx in self.key_values:
+            prev_key, prev_value = self.key_values[layer_idx]
+            key = torch.cat([prev_key, key], dim=2)
+            value = torch.cat([prev_value, value], dim=2)
+        self.key_values[layer_idx] = (key, value)
+        return key, value
+
+    def advance(self, length: int) -> None:
+        self.position += length
+
+
+def _legacy_forward(model: CausalVocosBackbone, x: Tensor, cache: _LegacyConcatCache) -> Tensor:
+    input_pos = cache.input_positions(x.size(1), x.device).expand(x.size(0), -1)
+    for block in model.transformers:
+        # The old RoPE forward did this once for Q and once for K in every layer.
+        for _ in range(2):
+            needed_seq_len = int(input_pos.max().item()) + 1
+            model.rotary_embed.prepare(needed_seq_len, x.device)
+        # No shared mask reproduces the old per-layer mask construction.
+        x = block(x, cache=cache, input_pos=input_pos)
+    cache.advance(x.size(1))
+    return model.final_layer_norm(x)
+
+
+def _decode_stream(
+    model: CausalVocosBackbone,
+    hidden_states: Tensor,
+    chunk_frames: int,
+    *,
+    legacy: bool,
+) -> Tensor:
+    cache = _LegacyConcatCache() if legacy else CausalCodecDecoderCache()
+    outputs = []
+    for start in range(0, hidden_states.size(1), chunk_frames):
+        chunk = hidden_states[:, start : start + chunk_frames]
+        if legacy:
+            outputs.append(_legacy_forward(model, chunk, cache))
+        else:
+            outputs.append(model(chunk, cache=cache))
+    return torch.cat(outputs, dim=1)
+
+
+def _synchronize(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.accelerator.synchronize(device)
+
+
+def _measure_pair(
+    legacy_fn: Callable[[], Tensor],
+    optimized_fn: Callable[[], Tensor],
+    device: torch.device,
+    warmups: int,
+    iterations: int,
+) -> tuple[list[float], list[float]]:
+    for _ in range(warmups):
+        legacy_fn()
+        optimized_fn()
+    _synchronize(device)
+
+    timings: dict[str, list[float]] = {"legacy": [], "optimized": []}
+    runners = {"legacy": legacy_fn, "optimized": optimized_fn}
+    for iteration in range(iterations):
+        order = ("legacy", "optimized") if iteration % 2 == 0 else ("optimized", "legacy")
+        for name in order:
+            start = time.perf_counter()
+            runners[name]()
+            _synchronize(device)
+            timings[name].append((time.perf_counter() - start) * 1000)
+    return timings["legacy"], timings["optimized"]
+
+
+def _peak_extra_memory(fn: Callable[[], Tensor], device: torch.device) -> int | None:
+    if device.type != "cuda":
+        return None
+    gc.collect()
+    torch.accelerator.empty_cache()
+    torch.accelerator.reset_peak_memory_stats(device)
+    before = torch.accelerator.memory_allocated(device)
+    fn()
+    _synchronize(device)
+    return torch.accelerator.max_memory_allocated(device) - before
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    parser.add_argument("--dtype", choices=("float32", "bfloat16", "float16"), default="float32")
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--hidden-dim", type=int, default=512)
+    parser.add_argument("--depth", type=int, default=4)
+    parser.add_argument("--heads", type=int, default=8)
+    parser.add_argument("--total-frames", type=int, default=512)
+    parser.add_argument("--chunk-frames", type=int, default=5)
+    parser.add_argument("--warmups", type=int, default=3)
+    parser.add_argument("--iterations", type=int, default=10)
+    parser.add_argument("--seed", type=int, default=0)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    device = torch.device(args.device)
+    dtype = getattr(torch, args.dtype)
+    if device.type == "cpu" and dtype == torch.float16:
+        raise ValueError("float16 SDPA is not supported on CPU; use float32 or bfloat16")
+    if args.hidden_dim % args.heads != 0:
+        raise ValueError("hidden-dim must be divisible by heads")
+    head_dim = args.hidden_dim // args.heads
+
+    torch.manual_seed(args.seed)
+    model = CausalVocosBackbone(
+        hidden_dim=args.hidden_dim,
+        depth=args.depth,
+        heads=args.heads,
+        pos_meb_dim=head_dim,
+    ).to(device=device, dtype=dtype)
+    model.eval()
+    hidden_states = torch.randn(
+        args.batch_size,
+        args.total_frames,
+        args.hidden_dim,
+        device=device,
+        dtype=dtype,
+    )
+
+    def legacy_fn() -> Tensor:
+        return _decode_stream(model, hidden_states, args.chunk_frames, legacy=True)
+
+    def optimized_fn() -> Tensor:
+        return _decode_stream(model, hidden_states, args.chunk_frames, legacy=False)
+
+    with torch.inference_mode():
+        legacy_output = legacy_fn()
+        optimized_output = optimized_fn()
+        tolerance = 1e-4 if dtype == torch.float32 else 2e-2
+        torch.testing.assert_close(optimized_output, legacy_output, rtol=tolerance, atol=tolerance)
+
+        legacy_ms, optimized_ms = _measure_pair(
+            legacy_fn,
+            optimized_fn,
+            device,
+            args.warmups,
+            args.iterations,
+        )
+        legacy_peak = _peak_extra_memory(legacy_fn, device)
+        optimized_peak = _peak_extra_memory(optimized_fn, device)
+
+    legacy_median = statistics.median(legacy_ms)
+    optimized_median = statistics.median(optimized_ms)
+    legacy_stddev = statistics.pstdev(legacy_ms)
+    optimized_stddev = statistics.pstdev(optimized_ms)
+    chunks = (args.total_frames + args.chunk_frames - 1) // args.chunk_frames
+    max_diff = (optimized_output.float() - legacy_output.float()).abs().max().item()
+
+    print(
+        f"device={device} dtype={dtype} batch={args.batch_size} hidden={args.hidden_dim} "
+        f"depth={args.depth} heads={args.heads} frames={args.total_frames} chunk={args.chunk_frames}"
+    )
+    print(
+        f"legacy median:    {legacy_median:.3f} ms/request ({legacy_median / chunks:.3f} ms/chunk), "
+        f"stddev={legacy_stddev:.3f}, range={min(legacy_ms):.3f}-{max(legacy_ms):.3f}"
+    )
+    print(
+        f"optimized median: {optimized_median:.3f} ms/request ({optimized_median / chunks:.3f} ms/chunk), "
+        f"stddev={optimized_stddev:.3f}, range={min(optimized_ms):.3f}-{max(optimized_ms):.3f}"
+    )
+    print(f"speedup: {legacy_median / optimized_median:.3f}x")
+    if legacy_peak is not None and optimized_peak is not None:
+        mib = 1024**2
+        print(f"extra peak allocated: legacy={legacy_peak / mib:.1f} MiB optimized={optimized_peak / mib:.1f} MiB")
+    print(f"max absolute difference: {max_diff:.6g}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/model_executor/models/audex/test_audex_causal_speech_decoder_cache.py
+++ b/tests/model_executor/models/audex/test_audex_causal_speech_decoder_cache.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm_omni.model_executor.models.audex.speech_decoder.modeling_audex_causal_speech_decoder import (
+    CausalCodecDecoderCache,
+    CausalVocosBackbone,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.tts, pytest.mark.cache]
+
+
+def _kv(values: list[float]) -> tuple[torch.Tensor, torch.Tensor]:
+    key = torch.tensor(values, dtype=torch.float32).view(1, 1, -1, 1)
+    return key, -key
+
+
+def test_growable_cache_reuses_storage_and_preserves_values() -> None:
+    cache = CausalCodecDecoderCache(initial_capacity=2)
+
+    key, value = cache.update(0, *_kv([1.0, 2.0]))
+    first_storage = key.untyped_storage().data_ptr()
+    torch.testing.assert_close(key.flatten(), torch.tensor([1.0, 2.0]))
+    torch.testing.assert_close(value.flatten(), torch.tensor([-1.0, -2.0]))
+    cache.advance(2)
+
+    key, value = cache.update(0, *_kv([3.0]))
+    grown_storage = key.untyped_storage().data_ptr()
+    assert grown_storage != first_storage
+    torch.testing.assert_close(key.flatten(), torch.tensor([1.0, 2.0, 3.0]))
+    torch.testing.assert_close(value.flatten(), torch.tensor([-1.0, -2.0, -3.0]))
+    cache.advance(1)
+
+    key, value = cache.update(0, *_kv([4.0]))
+    assert key.untyped_storage().data_ptr() == grown_storage
+    torch.testing.assert_close(key.flatten(), torch.tensor([1.0, 2.0, 3.0, 4.0]))
+    torch.testing.assert_close(value.flatten(), torch.tensor([-1.0, -2.0, -3.0, -4.0]))
+    cache.advance(1)
+
+    assert cache.position == 4
+    assert cache.key_values[0][0].shape == (1, 1, 4, 1)
+
+
+def test_cache_validates_layer_progress_and_reset() -> None:
+    cache = CausalCodecDecoderCache(initial_capacity=2)
+    cache.update(0, *_kv([1.0]))
+    cache.update(1, *_kv([2.0]))
+    cache.advance(1)
+
+    cache.update(0, *_kv([3.0]))
+    with pytest.raises(RuntimeError, match="layers were not updated"):
+        cache.advance(1)
+
+    cache.reset()
+    assert cache.position == 0
+    assert cache.key_values == {}
+
+
+@pytest.mark.parametrize("chunk_sizes", [(1,) * 11, (3, 1, 4, 3), (5, 6)])
+def test_cached_decode_matches_full_causal_decode(chunk_sizes: tuple[int, ...]) -> None:
+    torch.manual_seed(0)
+    model = CausalVocosBackbone(hidden_dim=32, depth=2, heads=4, pos_meb_dim=8).eval()
+    hidden_states = torch.randn(2, sum(chunk_sizes), 32)
+
+    with torch.inference_mode():
+        expected = model(hidden_states)
+        cache = CausalCodecDecoderCache(initial_capacity=2)
+        actual = torch.cat(
+            [model(chunk, cache=cache) for chunk in hidden_states.split(chunk_sizes, dim=1)],
+            dim=1,
+        )
+
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-5)
+    assert cache.position == hidden_states.size(1)
+
+
+def test_cached_decode_does_not_read_positions_back_to_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    model = CausalVocosBackbone(hidden_dim=16, depth=2, heads=2, pos_meb_dim=8).eval()
+    cache = CausalCodecDecoderCache()
+    hidden_states = torch.randn(1, 2, 16)
+
+    def fail_item(_tensor: torch.Tensor) -> None:
+        raise AssertionError("streaming decode must not call Tensor.item()")
+
+    monkeypatch.setattr(torch.Tensor, "item", fail_item)
+    with torch.inference_mode():
+        model(hidden_states, cache=cache)
+
+
+def test_cached_decode_builds_attention_mask_once_per_chunk(monkeypatch: pytest.MonkeyPatch) -> None:
+    model = CausalVocosBackbone(hidden_dim=16, depth=3, heads=2, pos_meb_dim=8).eval()
+    cache = CausalCodecDecoderCache()
+    hidden_states = torch.randn(1, 2, 16)
+    original_arange = torch.arange
+    arange_calls = 0
+
+    def count_arange(*args, **kwargs):
+        nonlocal arange_calls
+        arange_calls += 1
+        return original_arange(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "arange", count_arange)
+    with torch.inference_mode():
+        model(hidden_states, cache=cache)
+
+    # One range creates input positions and one creates the shared causal mask.
+    assert arange_calls == 2

--- a/vllm_omni/model_executor/models/audex/speech_decoder/modeling_audex_causal_speech_decoder.py
+++ b/vllm_omni/model_executor/models/audex/speech_decoder/modeling_audex_causal_speech_decoder.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
 from typing import Any
 
 import torch
@@ -35,7 +36,6 @@ class RotaryPositionalEmbeddings(nn.Module):
         self.base = base
         self.max_seq_len = max_seq_len
         self.rope_init()
-        self._rope_ready = False
 
     def rope_init(self, device: torch.device | None = None) -> None:
         theta = 1.0 / (self.base ** (torch.arange(0, self.dim, 2, device=device)[: (self.dim // 2)].float() / self.dim))
@@ -49,19 +49,19 @@ class RotaryPositionalEmbeddings(nn.Module):
         cache = torch.stack([torch.cos(idx_theta), torch.sin(idx_theta)], dim=-1)
         self.register_buffer("cache", cache, persistent=False)
 
+    def prepare(self, needed_seq_len: int, device: torch.device) -> None:
+        """Ensure the RoPE cache is ready without reading a device tensor."""
+        if needed_seq_len < 0:
+            raise ValueError(f"needed_seq_len must be non-negative, got {needed_seq_len}")
+        if self.theta.device != device:
+            self.rope_init(device=device)
+        if needed_seq_len > self.cache.size(0):
+            self.build_rope_cache(max(needed_seq_len, self.cache.size(0) * 2))
+
     def forward(self, x: torch.Tensor, *, input_pos: torch.Tensor | None = None) -> torch.Tensor:
         seq_len = x.size(1)
-        needed_seq_len = seq_len if input_pos is None else int(input_pos.max().item()) + 1
-        if (
-            not getattr(self, "_rope_ready", False)
-            or self.theta.device != x.device
-            or needed_seq_len > self.cache.size(0)
-        ):
-            self.rope_init(device=x.device)
-            if needed_seq_len > self.cache.size(0):
-                self.build_rope_cache(max(needed_seq_len, self.cache.size(0) * 2))
-            self._rope_ready = True
-
+        if input_pos is None:
+            self.prepare(seq_len, x.device)
         rope_cache = self.cache[:seq_len] if input_pos is None else self.cache[input_pos]
         xshaped = x.float().reshape(*x.shape[:-1], -1, 2)
         rope_cache = rope_cache.view(-1, xshaped.size(1), 1, xshaped.size(3), 2)
@@ -75,27 +75,97 @@ class RotaryPositionalEmbeddings(nn.Module):
         return x_out.flatten(3).type_as(x)
 
 
+@dataclass
+class _LayerKVCache:
+    key: Tensor
+    value: Tensor
+    length: int
+
+
 class CausalCodecDecoderCache:
-    def __init__(self) -> None:
-        self.key_values: dict[int, tuple[Tensor, Tensor]] = {}
+    """Per-request growable KV cache for streaming causal decoding."""
+
+    def __init__(self, initial_capacity: int = 16) -> None:
+        if initial_capacity <= 0:
+            raise ValueError(f"initial_capacity must be positive, got {initial_capacity}")
+        self._initial_capacity = initial_capacity
+        self._layers: dict[int, _LayerKVCache] = {}
         self.position = 0
+
+    @property
+    def key_values(self) -> dict[int, tuple[Tensor, Tensor]]:
+        """Return views of the initialized portion of every layer cache."""
+        return {
+            layer_idx: (layer.key[:, :, : layer.length], layer.value[:, :, : layer.length])
+            for layer_idx, layer in self._layers.items()
+        }
 
     def input_positions(self, length: int, device: torch.device) -> Tensor:
         return torch.arange(self.position, self.position + length, device=device).unsqueeze(0)
 
     def update(self, layer_idx: int, key: Tensor, value: Tensor) -> tuple[Tensor, Tensor]:
-        if layer_idx in self.key_values:
-            prev_key, prev_value = self.key_values[layer_idx]
-            key = torch.cat([prev_key, key], dim=2)
-            value = torch.cat([prev_value, value], dim=2)
-        self.key_values[layer_idx] = (key, value)
-        return key, value
+        if key.shape != value.shape:
+            raise ValueError(f"key and value shapes must match, got {key.shape} and {value.shape}")
+        if key.ndim != 4:
+            raise ValueError(f"key and value must have shape [batch, heads, time, dim], got {key.shape}")
+
+        chunk_length = key.size(2)
+        required_capacity = self.position + chunk_length
+        layer = self._layers.get(layer_idx)
+        if layer is None:
+            if self.position != 0:
+                raise RuntimeError(f"layer {layer_idx} was first initialized at cache position {self.position}")
+            capacity = self._next_capacity(0, required_capacity)
+            cache_shape = (*key.shape[:2], capacity, key.shape[3])
+            layer = _LayerKVCache(key=key.new_empty(cache_shape), value=value.new_empty(cache_shape), length=0)
+            self._layers[layer_idx] = layer
+        else:
+            if layer.length != self.position:
+                raise RuntimeError(
+                    f"layer {layer_idx} cache length {layer.length} does not match position {self.position}"
+                )
+            expected_shape = (*layer.key.shape[:2], chunk_length, layer.key.shape[3])
+            if key.shape != expected_shape:
+                raise ValueError(f"key shape changed from {expected_shape} to {key.shape}")
+            if key.device != layer.key.device or value.device != layer.value.device:
+                raise ValueError("key and value device must match the existing cache")
+            if key.dtype != layer.key.dtype or value.dtype != layer.value.dtype:
+                raise ValueError("key and value dtype must match the existing cache")
+
+        if required_capacity > layer.key.size(2):
+            capacity = self._next_capacity(layer.key.size(2), required_capacity)
+            cache_shape = (*layer.key.shape[:2], capacity, layer.key.shape[3])
+            new_key = layer.key.new_empty(cache_shape)
+            new_value = layer.value.new_empty(cache_shape)
+            # Geometric growth makes retained-prefix copies amortized O(total frames).
+            new_key[:, :, : self.position].copy_(layer.key[:, :, : self.position])
+            new_value[:, :, : self.position].copy_(layer.value[:, :, : self.position])
+            layer.key = new_key
+            layer.value = new_value
+
+        # The steady-state path copies only the new chunk, never the full history.
+        layer.key[:, :, self.position : required_capacity].copy_(key)
+        layer.value[:, :, self.position : required_capacity].copy_(value)
+        layer.length = required_capacity
+        return layer.key[:, :, :required_capacity], layer.value[:, :, :required_capacity]
+
+    def _next_capacity(self, current_capacity: int, required_capacity: int) -> int:
+        capacity = max(current_capacity, self._initial_capacity)
+        while capacity < required_capacity:
+            capacity *= 2
+        return capacity
 
     def advance(self, length: int) -> None:
-        self.position += length
+        if length < 0:
+            raise ValueError(f"length must be non-negative, got {length}")
+        next_position = self.position + length
+        incomplete_layers = [idx for idx, layer in self._layers.items() if layer.length != next_position]
+        if incomplete_layers:
+            raise RuntimeError(f"cache layers were not updated through position {next_position}: {incomplete_layers}")
+        self.position = next_position
 
     def reset(self) -> None:
-        self.key_values.clear()
+        self._layers.clear()
         self.position = 0
 
 
@@ -137,6 +207,7 @@ class Attention(nn.Module):
         x: torch.Tensor,
         cache: CausalCodecDecoderCache | None = None,
         input_pos: Tensor | None = None,
+        attn_mask: Tensor | None = None,
     ) -> torch.Tensor:
         batch_size, seq_len, _ = x.shape
         qkv = self.c_attn(x)
@@ -152,8 +223,9 @@ class Attention(nn.Module):
             if input_pos is None:
                 raise ValueError("input_pos is required when cache is set")
             k, v = cache.update(self.layer_idx, k, v)
-            key_pos = torch.arange(k.size(2), device=x.device).view(1, 1, 1, -1)
-            attn_mask = key_pos <= input_pos.view(input_pos.size(0), 1, -1, 1)
+            if attn_mask is None:
+                key_pos = torch.arange(k.size(2), device=x.device).view(1, 1, 1, -1)
+                attn_mask = key_pos <= input_pos.view(input_pos.size(0), 1, -1, 1)
             y = F.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask)
         return self.c_proj(y.transpose(1, 2).contiguous().view(batch_size, seq_len, -1))
 
@@ -171,8 +243,9 @@ class TransformerBlock(nn.Module):
         x: torch.Tensor,
         cache: CausalCodecDecoderCache | None = None,
         input_pos: Tensor | None = None,
+        attn_mask: Tensor | None = None,
     ) -> torch.Tensor:
-        x = x + self.att(self.att_norm(x), cache=cache, input_pos=input_pos)
+        x = x + self.att(self.att_norm(x), cache=cache, input_pos=input_pos, attn_mask=attn_mask)
         return x + self.mlp(self.ffn_norm(x))
 
 
@@ -195,10 +268,10 @@ class CausalVocosBackbone(nn.Module):
         pos_meb_dim: int = 64,
     ):
         super().__init__()
-        rotary_embed = RotaryPositionalEmbeddings(dim=pos_meb_dim)
+        self.rotary_embed = RotaryPositionalEmbeddings(dim=pos_meb_dim)
         self.transformers = nn.ModuleList(
             [
-                TransformerBlock(dim=hidden_dim, n_heads=heads, rotary_embed=rotary_embed, layer_idx=idx)
+                TransformerBlock(dim=hidden_dim, n_heads=heads, rotary_embed=self.rotary_embed, layer_idx=idx)
                 for idx in range(depth)
             ]
         )
@@ -206,10 +279,16 @@ class CausalVocosBackbone(nn.Module):
 
     def forward(self, x: torch.Tensor, cache: CausalCodecDecoderCache | None = None) -> torch.Tensor:
         input_pos = None
+        attn_mask = None
+        needed_seq_len = x.size(1)
         if cache is not None:
             input_pos = cache.input_positions(x.size(1), x.device).expand(x.size(0), -1)
+            needed_seq_len = cache.position + x.size(1)
+            key_pos = torch.arange(needed_seq_len, device=x.device).view(1, 1, 1, -1)
+            attn_mask = key_pos <= input_pos.view(input_pos.size(0), 1, -1, 1)
+        self.rotary_embed.prepare(needed_seq_len, x.device)
         for block in self.transformers:
-            x = block(x, cache=cache, input_pos=input_pos)
+            x = block(x, cache=cache, input_pos=input_pos, attn_mask=attn_mask)
         if cache is not None:
             cache.advance(x.size(1))
         return self.final_layer_norm(x)


### PR DESCRIPTION
## Purpose

Fixes #5964.

Audex performs streaming causal speech decoding in small chunks, but the existing cache path does repeated work in every transformer layer:

- K/V are appended with `torch.cat`, which copies the full history on every chunk and produces quadratic cumulative cache-copy traffic.
- RoPE reads `input_pos.max().item()` for Q and K in every layer, causing repeated device-to-host synchronization.
- The same causal mask is rebuilt independently in every layer.

This PR:

- replaces repeated concatenation with per-layer geometrically growing K/V buffers, copying only the new chunk on the steady-state path;
- prepares the shared RoPE cache once per decoder call from the Python-side cache position;
- builds the causal mask once per chunk and reuses it across layers;
- validates cache shape, dtype, device, and layer progress;
- adds CPU regression tests and a standalone legacy-vs-optimized microbenchmark that requires no model download.

The cache remains per request/session and grows on demand instead of reserving the maximum sequence length up front. No API, deploy configuration, model weight, or decoder dtype changes are included.

## Test Plan

```bash
pytest -q \
  tests/model_executor/models/audex/test_audex_causal_speech_decoder_cache.py \
  -m "core_model and cpu" \
  --run-level=core_model
```

Representative benchmark command:

```bash
python benchmarks/audex/bench_streaming_decoder_cache.py \
  --device cuda \
  --dtype float32 \
  --batch-size 1 \
  --hidden-dim 2048 \
  --depth 12 \
  --heads 32 \
  --total-frames 512 \
  --chunk-frames 5 \
  --warmups 2 \
  --iterations 10
```

The benchmark alternates legacy and optimized execution order between measured iterations. The checked-in legacy runner reproduces repeated K/V concatenation, per-layer mask construction, and per-layer RoPE position readback.

**vLLM Version:** `0.26.0`

**vLLM-Omni Commit:** `f64028769b43b91987c2d53e3f3a9e8fdfaedcb5`

Benchmark environment:

- 1x NVIDIA GeForce RTX 4090
- Driver 591.86
- PyTorch 2.11.0+cu130 / CUDA 13.0
- Audex decoder dimensions: hidden size 2048, 12 layers, 32 heads
- 2 warmups and 10 alternating measured iterations per configuration

## Test Result

### Sequence-length scaling

FP32, batch 1, 5 frames/chunk. Latencies are median ± population stddev per complete stream.

| Frames | Decoder calls | Legacy latency (ms) | Optimized latency (ms) | Speedup | Extra peak allocated (MiB) |
|---:|---:|---:|---:|---:|---:|
| 128 | 26 | 400.433 ± 15.598 | 246.925 ± 9.512 | 1.622x | 27.1 → 26.0 |
| 256 | 52 | 1019.739 ± 76.751 | 660.972 ± 86.546 | 1.543x | 54.5 → 52.0 |
| 512 | 103 | 1950.904 ± 150.964 | 1126.015 ± 155.918 | 1.733x | 108.9 → 104.0 |
| 1024 | 205 | 3613.092 ± 396.153 | 2321.342 ± 223.844 | 1.556x | 216.1 → 208.0 |
| 2048 | 410 | 6417.564 ± 68.153 | 4228.245 ± 15.446 | 1.518x | 432.1 → 416.0 |

### Chunk-size sensitivity

FP32, batch 1, 512 total frames.

| Frames/chunk | Decoder calls | Legacy latency (ms) | Optimized latency (ms) | Speedup | Extra peak allocated (MiB) |
|---:|---:|---:|---:|---:|---:|
| 1 | 512 | 8162.571 ± 729.178 | 4764.850 ± 730.387 | 1.713x | 108.5 → 104.0 |
| 2 | 256 | 3645.382 ± 262.222 | 2291.523 ± 11.625 | 1.591x | 108.7 → 104.0 |
| 5 | 103 | 1950.904 ± 150.964 | 1126.015 ± 155.918 | 1.733x | 108.9 → 104.0 |
| 10 | 52 | 1016.488 ± 95.669 | 655.039 ± 69.436 | 1.552x | 109.5 → 104.0 |
| 20 | 26 | 434.923 ± 34.968 | 268.875 ± 28.650 | 1.618x | 109.4 → 104.0 |
| 40 | 13 | 216.109 ± 20.641 | 144.148 ± 23.129 | 1.499x | 109.0 → 104.1 |

### Decoder tensor batch scaling

FP32, 512 total frames, 5 frames/chunk. This is decoder tensor batching, not online serving concurrency.

| Batch | Legacy latency (ms) | Optimized latency (ms) | Speedup | Extra peak allocated (MiB) |
|---:|---:|---:|---:|---:|
| 1 | 1950.904 ± 150.964 | 1126.015 ± 155.918 | 1.733x | 108.9 → 104.0 |
| 2 | 1574.488 ± 227.946 | 980.861 ± 140.427 | 1.605x | 216.1 → 208.0 |
| 4 | 1774.456 ± 56.734 | 1076.868 ± 18.714 | 1.648x | 432.3 → 416.0 |
| 8 | 1779.759 ± 22.294 | 1152.118 ± 20.528 | 1.545x | 865.8 → 832.0 |

### Dtype robustness

Batch 1, 512 total frames, 5 frames/chunk.

| Dtype | Legacy latency (ms) | Optimized latency (ms) | Speedup | Extra peak allocated (MiB) |
|---|---:|---:|---:|---:|
| FP32 | 1950.904 ± 150.964 | 1126.015 ± 155.918 | 1.733x | 108.9 → 104.0 |
| BF16 | 1358.388 ± 34.513 | 1046.986 ± 57.033 | 1.297x | 54.1 → 52.0 |

All 14 benchmark configurations reported maximum absolute output difference `0` between the legacy and optimized paths.

```text
7 passed in 0.41s
```

All diff-scoped pre-commit hooks pass, including Ruff, formatting, typos, pytest marker validation, and pickle-import validation.
