### PR TITLE
[Perf][Diffusion] Keep the FlowUniPC coefficient chain on CPU

### DIFF
--- a/vllm_omni/diffusion/models/schedulers/scheduling_flow_unipc_multistep.py
+++ b/vllm_omni/diffusion/models/schedulers/scheduling_flow_unipc_multistep.py
@@ -291,12 +291,12 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
                 "is now handled via an internal counter `self.step_index`",
             )
 
-        sigma = self.sigmas[self.step_index].to(sample.device)
+        sigma = self.sigmas[self.step_index]
         alpha_t, sigma_t = self._sigma_to_alpha_sigma_t(sigma)
 
         if self.predict_x0:
             if self.config.prediction_type == "flow_prediction":
-                sigma_t = sigma.to(sample.device)
+                sigma_t = sigma
                 x0_pred = sample - sigma_t * model_output
             else:
                 raise ValueError(
@@ -375,8 +375,8 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
 
         device = sample.device
         sigma_t, sigma_s0 = (
-            self.sigmas[self.step_index + 1].to(device),
-            self.sigmas[self.step_index].to(device),
+            self.sigmas[self.step_index + 1],
+            self.sigmas[self.step_index],
         )
         alpha_t, sigma_t = self._sigma_to_alpha_sigma_t(sigma_t)
         alpha_s0, sigma_s0 = self._sigma_to_alpha_sigma_t(sigma_s0)
@@ -391,7 +391,7 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
         for i in range(1, order):
             si = self.step_index - i
             mi = model_output_list[-(i + 1)]
-            alpha_si, sigma_si = self._sigma_to_alpha_sigma_t(self.sigmas[si].to(device))
+            alpha_si, sigma_si = self._sigma_to_alpha_sigma_t(self.sigmas[si])
             lambda_si = torch.log(alpha_si) - torch.log(sigma_si)
             rk = (lambda_si - lambda_s0) / h
             rks.append(rk)
@@ -399,7 +399,7 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
             D1s.append((mi - m0) / rk)
 
         rks.append(1.0)
-        rks = torch.tensor(rks, device=device)
+        rks = torch.tensor(rks)
 
         R = []
         b = []
@@ -424,7 +424,7 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
             h_phi_k = h_phi_k / hh - 1 / factorial_i
 
         R = torch.stack(R)
-        b = torch.tensor(b, device=device)
+        b = torch.tensor(b)
 
         if D1s is not None and len(D1s) > 0:
             D1s = torch.stack(D1s, dim=1)
@@ -507,8 +507,8 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
 
         device = this_sample.device
         sigma_t, sigma_s0 = (
-            self.sigmas[self.step_index].to(device),
-            self.sigmas[self.step_index - 1].to(device),
+            self.sigmas[self.step_index],
+            self.sigmas[self.step_index - 1],
         )
         alpha_t, sigma_t = self._sigma_to_alpha_sigma_t(sigma_t)
         alpha_s0, sigma_s0 = self._sigma_to_alpha_sigma_t(sigma_s0)
@@ -523,7 +523,7 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
         for i in range(1, order):
             si = self.step_index - (i + 1)
             mi = model_output_list[-(i + 1)]
-            alpha_si, sigma_si = self._sigma_to_alpha_sigma_t(self.sigmas[si].to(device))
+            alpha_si, sigma_si = self._sigma_to_alpha_sigma_t(self.sigmas[si])
             lambda_si = torch.log(alpha_si) - torch.log(sigma_si)
             rk = (lambda_si - lambda_s0) / h
             rks.append(rk)
@@ -531,7 +531,7 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
             D1s.append((mi - m0) / rk)
 
         rks.append(1.0)
-        rks = torch.tensor(rks, device=device)
+        rks = torch.tensor(rks)
 
         R = []
         b = []
@@ -556,7 +556,7 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
             h_phi_k = h_phi_k / hh - 1 / factorial_i
 
         R = torch.stack(R)
-        b = torch.tensor(b, device=device)
+        b = torch.tensor(b)
 
         if D1s is not None and len(D1s) > 0:
             D1s = torch.stack(D1s, dim=1)


### PR DESCRIPTION
## Purpose

`FlowUniPCMultistepScheduler` rebuilds its scalar coefficients at every step from `self.sigmas` and
`self.step_index`. Neither depends on the sample, but every read moved the value to the sample's
device first, so `log`, `expm1`, `pow` and the ≤3×3 solve ran on the accelerator as 0-dim tensors.

The cost is not the arithmetic — it is that **reading a 0-dim device tensor back drains the queue**,
and the predictor and corrector do this several times per step, putting the host on the critical path
while the accelerator idles.

This PR drops the `.to(device)` at the eight sigma reads; `self.sigmas` is already a CPU float32
tensor, so the chain stays where it starts. The latent math is unchanged: a 0-dim CPU tensor
broadcasts as a scalar against a CUDA tensor, so the large tensors never move. `rhos_p` / `rhos_c`
still go to the device because the `einsum` consumes them, and `safe_linalg_solve` takes the CPU
branch [#5329](https://github.com/vllm-project/vllm-omni/pull/5329) already added once `R` and `b`
are CPU tensors.

The scheduler is shared — Wan2.2, Cosmos3, LingBot-Video and four others use it — so the saving is
not specific to the model benchmarked below.

## Numerical behaviour

**No model-level precision change.** The coefficients stay float32 either way; only the backend
evaluating `log` and `expm1` changes, and the two agree to within one or two ulp. Each coefficient is
then rounded into the sample's dtype before it multiplies anything — `rhos_p` / `rhos_c` through
`.to(x.dtype)`, `sigma_t * model_output` in the latent's dtype — so at bf16 that difference sits four
orders of magnitude below what the tensors can represent.

## Performance

DreamZero streaming rollout, MI350X (gfx950), 2 GPUs (TP=1 + CFG-parallel=2), 15 chunks × 16 steps,
first step dropped as warm-up, mean over the remaining 15:

| | before | after | saved |
|---|---|---|---|
| **mean step latency** | 521.7 ms | **505.4 ms** | **16.3 ms (1.032x)** |
| peak reserved VRAM | 71.33 GiB | 71.31 GiB | unchanged |

Paired by step position, all 15 improve: mean +16.3 ms, sd 3.6, min +12.3, max +24.5.

A single-GPU micro-benchmark of one scheduler control step, isolated from the rest of the rollout,
drops `aten::_local_scalar_dense` from **206 to 178** and the step from 50.99 ms to 32.82 ms. The op
count is the change's hard signal: no clock jitter touches it.


