### PR TITLE
Fix MiniMax H3 Ref2VA target alignment

### DIFF
--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
@@ -1196,8 +1196,35 @@ def test_r7_r8_ref2va_video_segment_matrix(monkeypatch, tmp_path, case, start_ti
     )
 
     assert prepared[0]["duration_seconds"] == pytest.approx(expected_duration)
+    assert prepared[0]["audio_duration_seconds"] == pytest.approx(min(expected_duration, 209 / 24.0))
     assert prepared[0]["start_time_seconds"] == pytest.approx(start_time or 0.0)
     assert transcode_calls[0][1]["duration_seconds"] == pytest.approx(expected_duration)
+    assert transcode_calls[0][1]["target_frame_count"] == 209
+
+
+def test_ref2va_qwen_sampling_decodes_prepared_video_once(monkeypatch):
+    from vllm_omni.diffusion.models.minimax_h3 import reference_video as reference_video_module
+
+    decoded = np.arange(25 * 2 * 2 * 3, dtype=np.uint8).reshape(25, 2, 2, 3)
+    load_calls = []
+    monkeypatch.setattr(
+        reference_video_module,
+        "_probe_video",
+        lambda _path: {"frame_count": len(decoded)},
+    )
+    monkeypatch.setattr(
+        reference_video_module,
+        "load_video_frames",
+        lambda path: load_calls.append(path) or decoded,
+    )
+
+    sampled = reference_video_module.sample_reference_video_frames(
+        "prepared.mp4",
+        workdir="unused",
+    )
+
+    assert load_calls == ["prepared.mp4"]
+    assert [int(frame[0, 0, 0]) for frame in sampled["frames"]] == [0, int(decoded[12, 0, 0, 0]), int(decoded[24, 0, 0, 0])]
 
 
 def test_ref2va_two_video_recipe_tolerates_container_rounding(monkeypatch, tmp_path):
@@ -1435,6 +1462,32 @@ def test_g4_standalone_audio_duration_and_total_duration_contract():
                 (torch.zeros(1, 8 * sample_rate), sample_rate),
             ]
         )
+
+
+def test_ref2va_standalone_audio_condition_is_bounded_to_output_duration():
+    from vllm_omni.diffusion.models.minimax_h3.pipeline_minimax_h3 import MiniMaxH3Pipeline
+
+    pipeline = object.__new__(MiniMaxH3Pipeline)
+    pipeline.device = torch.device("cpu")
+    observed = []
+
+    class FakeAudioVAE:
+        def encode_waveform(self, waveform, sample_rate):
+            observed.append((waveform.clone(), sample_rate))
+            return waveform, waveform.shape[-1]
+
+    pipeline.audio_vae = FakeAudioVAE()
+    waveform = torch.arange(40, dtype=torch.float32).reshape(1, 40)
+
+    encoded, lengths = pipeline._encode_audio_conditions(
+        [(waveform, 10)],
+        max_duration_seconds=2.5,
+    )
+
+    assert observed[0][0].shape == (1, 25)
+    assert observed[0][1] == 10
+    assert encoded.shape == (1, 25)
+    assert lengths == [25]
 
 
 @pytest.mark.parametrize(

--- a/tests/entrypoints/openai_api/test_video_server.py
+++ b/tests/entrypoints/openai_api/test_video_server.py
@@ -15,6 +15,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from types import SimpleNamespace
 
+import av
 import numpy as np
 import pytest
 from fastapi import FastAPI, HTTPException
@@ -247,6 +248,25 @@ def _make_test_video_bytes(size=(32, 24), num_frames=3) -> bytes:
         frames[idx, :, :, 1] = 128
         frames[idx, :, :, 2] = 255 - idx * 40
     return mux_video_audio_bytes(frames, fps=8, video_codec_options={"preset": "ultrafast", "threads": "0"})
+
+
+def test_mux_video_audio_marks_aac_priming_timestamp():
+    frames = np.zeros((2, 16, 16, 3), dtype=np.uint8)
+    audio = np.zeros((2, 2048), dtype=np.float32)
+
+    payload = mux_video_audio_bytes(
+        frames,
+        fps=24,
+        audio_waveform=audio,
+        audio_sample_rate=32000,
+        video_codec_options={"preset": "ultrafast", "threads": "0"},
+    )
+
+    with av.open(io.BytesIO(payload)) as container:
+        audio_stream = container.streams.audio[0]
+        first_packet = next(packet for packet in container.demux(audio_stream) if packet.pts is not None)
+
+    assert first_packet.pts < 0
 
 
 def _make_test_video_data_url(size=(32, 24), num_frames=3) -> str:

--- a/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
+++ b/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
@@ -538,6 +538,7 @@ class MiniMaxH3Pipeline(
         "encode_prompt",
         "_encode_video_conditions",
         "_encode_video_audio_conditions",
+        "_encode_audio_conditions",
         "diffuse",
         "decode",
     ]
@@ -1204,6 +1205,8 @@ class MiniMaxH3Pipeline(
     def _encode_audio_conditions(
         self,
         audios: list[tuple[torch.Tensor, int]],
+        *,
+        max_duration_seconds: float | None = None,
     ) -> tuple[torch.Tensor | None, list[int]]:
         if not audios:
             return None, []
@@ -1211,7 +1214,17 @@ class MiniMaxH3Pipeline(
         rows = None
         lengths = torch.zeros(len(audios), dtype=torch.long, device=self.device)
         if rank == 0:
-            encoded = [self.audio_vae.encode_waveform(*audio) for audio in audios]
+            if max_duration_seconds is not None:
+                max_duration_seconds = float(max_duration_seconds)
+                if max_duration_seconds <= 0:
+                    raise ValueError("max_duration_seconds must be positive")
+            bounded_audios = []
+            for waveform, sample_rate in audios:
+                if max_duration_seconds is not None:
+                    max_samples = int(round(max_duration_seconds * int(sample_rate)))
+                    waveform = waveform[..., :max_samples]
+                bounded_audios.append((waveform, sample_rate))
+            encoded = [self.audio_vae.encode_waveform(*audio) for audio in bounded_audios]
             rows = torch.cat([item[0] for item in encoded])
             lengths = torch.tensor(
                 [int(item[1]) for item in encoded],
@@ -1311,7 +1324,10 @@ class MiniMaxH3Pipeline(
                     *load_video_audio(
                         item["original_path"],
                         start_time_seconds=float(item.get("start_time_seconds", 0.0)),
-                        duration_seconds=item.get("duration_seconds"),
+                        duration_seconds=item.get(
+                            "audio_duration_seconds",
+                            item.get("duration_seconds"),
+                        ),
                     )
                 )
                 for item in prepared_videos
@@ -1710,7 +1726,10 @@ class MiniMaxH3Pipeline(
                     prepared_videos,
                     has_audio=has_audio,
                 )
-                external_audio_condition, external_audio_lengths = self._encode_audio_conditions(standalone_audios)
+                external_audio_condition, external_audio_lengths = self._encode_audio_conditions(
+                    standalone_audios,
+                    max_duration_seconds=float(num_frames) / float(sampling.fps or MINIMAX_H3_FPS),
+                )
                 audio_parts = [
                     item for item in (embedded_audio_condition, external_audio_condition) if item is not None
                 ]

--- a/vllm_omni/diffusion/models/minimax_h3/reference_video.py
+++ b/vllm_omni/diffusion/models/minimax_h3/reference_video.py
@@ -272,6 +272,7 @@ def _transcode_reference_video(
     *,
     target_width: int,
     target_height: int,
+    target_frame_count: int,
     workdir: str,
     start_time_seconds: float = 0.0,
     duration_seconds: float | None = None,
@@ -294,12 +295,22 @@ def _transcode_reference_video(
             "-vf",
             (f"fps={MINIMAX_H3_FPS:g},scale={target_width}:{target_height}:flags=lanczos,setsar=1"),
             *duration_args,
+            "-frames:v",
+            str(int(target_frame_count)),
             "-metadata:s:v:0",
             "rotate=0",
+            # Keep the transformed RGB pixels lossless. The same prepared
+            # stream is decoded by Qwen3VL and the video VAE; a yuv420p
+            # intermediate would make the two consumers see different
+            # pixels from the model-card reference recipe.
             "-c:v",
-            "libx264",
+            "libx264rgb",
+            "-crf",
+            "0",
+            "-preset",
+            "veryfast",
             "-pix_fmt",
-            "yuv420p",
+            "rgb24",
             output,
         ],
         check=True,
@@ -314,10 +325,6 @@ def prepare_reference_videos(
     workdir: str,
     start_time_seconds: Any = None,
 ) -> list[dict[str, Any]]:
-    # Keep this argument for compatibility with existing pipeline callers;
-    # reference inputs are now bounded by their source/segment durations, not
-    # clipped to the generated frame count.
-    del target_frame_count
     if isinstance(values, (str, os.PathLike)):
         values = [values]
     if not isinstance(values, (list, tuple)) or not values:
@@ -366,6 +373,7 @@ def prepare_reference_videos(
             source,
             target_width=width,
             target_height=height,
+            target_frame_count=target_frame_count,
             workdir=str(item_workdir),
             start_time_seconds=start,
             duration_seconds=duration,
@@ -379,6 +387,14 @@ def prepare_reference_videos(
                 "height": height,
                 "start_time_seconds": start,
                 "duration_seconds": duration,
+                # Reference video frames and their soundtrack are conditioned
+                # only for the generated temporal extent. Keep the source
+                # segment duration for metadata/validation, and expose the
+                # bounded duration separately for audio extraction.
+                "audio_duration_seconds": min(
+                    duration,
+                    float(target_frame_count) / MINIMAX_H3_FPS,
+                ),
             }
         )
     return prepared
@@ -408,8 +424,7 @@ def sample_reference_video_frames(
     *,
     workdir: str,
 ) -> dict[str, Any]:
-    from PIL import Image
-
+    del workdir
     meta = _probe_video(prepared_path)
     ratio = MINIMAX_H3_FPS / MINIMAX_H3_QWEN_VIDEO_SAMPLE_FPS
     indices: list[int] = []
@@ -424,30 +439,11 @@ def sample_reference_video_frames(
     if not indices:
         raise OmniClientError(f"no frames sampled from {prepared_path}")
 
-    frame_dir = Path(workdir)
-    frame_dir.mkdir(parents=True, exist_ok=True)
-    frames = []
-    for output_index, source_index in enumerate(indices, start=1):
-        output = frame_dir / f"frame_{output_index:06d}.png"
-        subprocess.run(
-            [
-                "ffmpeg",
-                "-y",
-                "-loglevel",
-                "error",
-                "-i",
-                prepared_path,
-                "-vf",
-                f"select=eq(n\\,{source_index})",
-                "-vsync",
-                "vfr",
-                "-frames:v",
-                "1",
-                str(output),
-            ],
-            check=True,
-        )
-        frames.append(np.asarray(Image.open(output).convert("RGB")))
+    # The preparation step emits a lossless RGB stream. Decode it once and
+    # sample from that array so Qwen3VL sees exactly the same pixels as the
+    # video VAE, without starting one full-video ffmpeg decode per sample.
+    decoded_frames = load_video_frames(prepared_path)
+    frames = [np.asarray(decoded_frames[source_index]) for source_index in indices]
 
     timestamps = [index / MINIMAX_H3_QWEN_VIDEO_SAMPLE_FPS for index in range(len(indices))]
     timestamps += [timestamps[-1]] * ((-len(timestamps)) % MINIMAX_H3_QWEN_TEMPORAL_PATCH)

--- a/vllm_omni/diffusion/utils/media_utils.py
+++ b/vllm_omni/diffusion/utils/media_utils.py
@@ -188,6 +188,11 @@ def mux_video_audio_bytes(
             raise ValueError("Audio samples were not prepared for muxing.")
         audio_frame = av.AudioFrame.from_ndarray(samples, format="fltp", layout=layout)
         audio_frame.sample_rate = audio_sample_rate
+        # AAC has a one-frame encoder delay. Mark the input waveform as
+        # starting at t=0 so the MP4 muxer writes the corresponding negative
+        # priming timestamp instead of exposing the delay as leading silence.
+        audio_frame.pts = 0
+        audio_frame.time_base = Fraction(1, audio_sample_rate)
         for packet in a_stream.encode(audio_frame):
             container.mux(packet)
         for packet in a_stream.encode():


### PR DESCRIPTION
## Purpose

Align the MiniMax H3 Ref2VA reference-input path with the model-card temporal and pixel contract.

- Bound prepared reference video streams to the generated frame count.
- Preserve transformed RGB pixels losslessly for both Qwen3VL and video VAE conditioning.
- Bound reference soundtracks and standalone audio conditions to the generated duration.
- Set AAC input timestamps so muxed audio does not expose encoder priming as leading silence.
- Expose standalone audio VAE encoding in the MiniMax H3 stage profiler and add regression coverage.

## Test Plan

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** c588208cc6132b08f5066420468e047ca581fbdc

- `ruff check` on all changed source and test files.
- `git diff --check`.
- `pytest tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py tests/entrypoints/openai_api/test_video_server.py -q` — 167 passed.
- 4x NVIDIA B300, BF16, Ulysses 4, ring 1, tiled VAE, 50 steps, seed 0, 5-second output.

## Test Result

Compared with the model-card output: video pixel cosine 0.999728, video SSIM 0.984048, audio waveform cosine 0.997246, and audio log-mel cosine 0.999122.

The measured pipeline stage-0 generation time is 144.751 seconds for 124 frames at 24 FPS. Peak device memory is 137630 MB.
