### PR TITLE
Update Wan2.2 I2V performance baselines

### DIFF
--- a/tests/dfx/perf/tests/test_wan22_i2v_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_wan22_i2v_vllm_omni.json
@@ -43,9 +43,9 @@
         ],
         "baseline": {
           "H100": {
-            "throughput_qps": 0.0434,
-            "latency_mean": 23.0654,
-            "peak_memory_mb_mean": 76360.0
+            "throughput_qps": 0.0361,
+            "latency_mean": 27.6206,
+            "peak_memory_mb_mean": 80548.0
           }
         }
       }
@@ -100,9 +100,9 @@
         ],
         "baseline": {
           "H100": {
-            "throughput_qps": 0.0606,
-            "latency_mean": 16.4928,
-            "peak_memory_mb_mean": 47164.8
+            "throughput_qps": 0.05263,
+            "latency_mean": 18.9415,
+            "peak_memory_mb_mean": 50053.7
           }
         }
       },
@@ -127,9 +127,9 @@
         ],
         "baseline": {
           "H100": {
-            "throughput_qps": 0.0124,
-            "latency_mean": 80.7784,
-            "peak_memory_mb_mean": 55374.3429
+            "throughput_qps": 0.009595,
+            "latency_mean": 104.1058,
+            "peak_memory_mb_mean": 59718.0
           }
         }
       }


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Update the Wan2.2 I2V performance baselines for #5694, following the corrected default guidance-scale behavior in #5615.

For the 4-step benchmark, #5615 restores the low-noise negative CFG pass: DiT forwards change from 6 to 8, so denoising compute and latency are expected to increase by approximately 1/3.

## Test Plan

**vLLM Version:** N/A

**vLLM-Omni Commit:** `0580c436`

```bash
../.b_rdma/bin/pre-commit run --all-files
../.b_rdma/bin/pre-commit run --files tests/dfx/perf/tests/test_wan22_i2v_vllm_omni.json
../.b_rdma/bin/python -m json.tool tests/dfx/perf/tests/test_wan22_i2v_vllm_omni.json
```

## Test Result

The file-scoped pre-commit checks and JSON validation pass.

The full pre-commit run fails on existing repository-wide pytest-mark coverage checks and `check-tts-adapter-migration`; this PR changes only `tests/dfx/perf/tests/test_wan22_i2v_vllm_omni.json`.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)