### PR TITLE
[Perf] Regionally compile MiniMax H3 video VAE transformer blocks

### DIFF
--- a/recipes/MiniMaxAI/MiniMax-H3.md
+++ b/recipes/MiniMaxAI/MiniMax-H3.md
@@ -271,8 +271,13 @@ vllm serve "${MODEL}" \
 
 Do not add `--enforce-eager` to this performance configuration. The first
 request includes regional compilation; warm the server once before measuring
-steady-state latency. H3 is CFG-distilled, so `--cfg-parallel-size` must remain
-`1`. The H3 VAE supports its native `tile` mode, not
+steady-state latency. H3 also regionally compiles the repeated
+`TransformerBlock` modules in the video VAE decoder. It does not compile the
+audio VAE or the VAE tiling control flow. Dynamic shapes let supported frame
+and resolution changes reuse the compiled graphs after the first request.
+
+H3 is CFG-distilled, so `--cfg-parallel-size` must remain `1`. The H3 VAE
+supports its native `tile` mode, not
 `spatial_shard_height` or `spatial_shard_width`.
 
 ### Attention Backends

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
@@ -24,6 +24,57 @@ def _append_and_return(items: list[_ItemT], item: _ItemT, result: _ResultT) -> _
     return result
 
 
+class _CompileTrackingModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.compile_calls = []
+
+    def compile(self, *args, **kwargs):
+        self.compile_calls.append((args, kwargs))
+
+
+@pytest.mark.parametrize("granularity", ["full", "regional"])
+def test_h3_setup_compile_adds_video_vae_regions(monkeypatch, granularity):
+    from vllm_omni.diffusion.models.minimax_h3 import pipeline_minimax_h3 as pipeline_module
+
+    pipeline = object.__new__(pipeline_module.MiniMaxH3Pipeline)
+    nn.Module.__init__(pipeline)
+    pipeline.od_config = SimpleNamespace(
+        diffusion_compile_dynamic=False,
+        diffusion_compile_granularity=granularity,
+    )
+    pipeline._dit_modules = ["transformer"]
+    pipeline.transformer = _CompileTrackingModule()
+    decoder = nn.Module()
+    pipeline.video_vae = SimpleNamespace(
+        model=SimpleNamespace(decoder=decoder),
+    )
+    regional_calls = []
+
+    def fake_regional_compile(model, **kwargs):
+        regional_calls.append((model, kwargs))
+        return model
+
+    monkeypatch.setattr(
+        pipeline_module,
+        "regionally_compile",
+        fake_regional_compile,
+    )
+
+    pipeline.setup_compile()
+
+    if granularity == "full":
+        assert pipeline.transformer.compile_calls == [((), {"dynamic": False})]
+        assert regional_calls == [(decoder, {"dynamic": False})]
+    else:
+        assert pipeline.transformer.compile_calls == []
+        assert regional_calls == [
+            (pipeline.transformer, {"dynamic": False}),
+            (decoder, {"dynamic": False}),
+        ]
+    assert decoder._repeated_blocks == ["TransformerBlock"]
+
+
 def test_h3_prepares_resolved_cache_state_immediately_before_denoise():
     from vllm_omni.diffusion.models.minimax_h3 import MiniMaxH3Pipeline
     from vllm_omni.diffusion.request import OmniDiffusionRequest

--- a/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
+++ b/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
@@ -28,6 +28,7 @@ from vllm_omni.diffusion.cache.cachedit import (
     CacheDiTBackend,
     RequestScopedCacheDiTRuntime,
 )
+from vllm_omni.diffusion.compile import regionally_compile
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.parallel_state import (
     get_world_group,
@@ -780,6 +781,27 @@ class MiniMaxH3Pipeline(
             ) from exc
         if not math.isclose(audio_shift, MINIMAX_H3_TURBO_AUDIO_SHIFT):
             raise OmniClientError(f"MiniMax-H3 Turbo requires audio_flow_shift={MINIMAX_H3_TURBO_AUDIO_SHIFT:g}")
+
+    def setup_compile(self) -> None:
+        """Compile the DiTs and repeated video-VAE transformer blocks."""
+        dynamic = self.od_config.diffusion_compile_dynamic
+        granularity = self.od_config.diffusion_compile_granularity
+        for attr_name in self._dit_modules:
+            model = getattr(self, attr_name, None)
+            if model is None:
+                continue
+            if granularity == "full":
+                model.compile(dynamic=dynamic)
+            else:
+                regionally_compile(model, dynamic=dynamic)
+
+        decoder = self.video_vae.model.decoder
+        decoder._repeated_blocks = ["TransformerBlock"]
+        regionally_compile(decoder, dynamic=dynamic)
+        logger.info(
+            "MiniMax H3 regional torch.compile enabled for video VAE decoder TransformerBlock modules (dynamic=%s)",
+            dynamic,
+        )
 
     def adopt_cache_dit_backend(self, backend: CacheDiTBackend) -> None:
         """Adopt runner-installed generic Cache-DiT for request transitions."""


### PR DESCRIPTION

## Purpose

MiniMax H3 already uses regional `torch.compile` for its DiT blocks, but the 36 repeated `TransformerBlock` modules in the video VAE decoder still execute eagerly. At the official 1344x768, 209-frame shape, VAE decode takes about 12 seconds on one H200 and is a material part of end-to-end latency.

This PR extends the model-specific `MiniMaxH3Pipeline.setup_compile()` path to regionally compile those video VAE transformer blocks. The change is isolated to MiniMax H3 and reuses the existing regional compile path and dynamic-shape setting. It contributes to the H3 performance roadmap in [#5700](https://github.com/vllm-project/vllm-omni/issues/5700) and the production VAE optimization RFC in [#5948](https://github.com/vllm-project/vllm-omni/issues/5948).

## Performance

Configuration: one NVIDIA H200, local MiniMax H3 FL2VA BF16 checkpoint, T2VA, 1344x768, 209 frames, 5 sigma points, no offload, one full-shape warmup followed by two measured requests. Times below are arithmetic means.

| Mode | Denoise | Video/audio decode | E2E |
|---|---:|---:|---:|
| Eager | 53.078 s | 12.010 s | 68.379 s |
| DiT regional compile | 51.337 s | 12.020 s | 66.322 s |
| DiT + video VAE regional compile | 51.305 s | **8.366 s** | **62.812 s** |

Against the DiT-compiled baseline, compiling the video VAE reduces decode latency by **30.4%** (`1.44x`) and E2E latency by **5.3%**. Denoise time is unchanged within run-to-run noise.

The DiT-compiled and DiT+VAE-compiled outputs were compared with the same prompt and seed:

| Metric | Result |
|---|---:|
| Sampled video SSIM, mean / minimum | 0.9999997 / 0.9999993 |
| Sampled video PSNR | 93.20 dB |
| Sampled video MAE / maximum absolute error | 0.00000832 / 0.0012207 |
| Audio | Bitwise equal |

## Online dynamic-shape validation

A single online `vllm serve` process and the same diffusion worker handled all requests sequentially through `POST /v1/videos/sync`. The server used one H200, BF16, `FLASH_ATTN`, regional compile with `dynamic=True`, no offload, and two sigma points so every request executed one DiT forward. `TORCH_LOGS=recompiles` captured guard failures from both the DiT and VAE regions.

MiniMax H3 disables the engine's startup dummy request, so the first official-shape request performed the initial compilation and served as the warmup. Fourteen subsequent requests varied duration, resolution, aspect ratio, tile geometry, and then returned to the original shape. All 15 requests returned HTTP 200. The table counts recompiles only; initial compilation is not a recompile event.

| Request | Width x height | Requested frames | E2E | VAE Transformer recompile | DiT recompile |
|---|---:|---:|---:|---:|---:|
| Warmup, official | 1344x768 | 209 | 55.550 s | 0 | 1 |
| Official repeat | 1344x768 | 209 | 29.779 s | 0 | 0 |
| Temporal minimum | 1344x768 | 96 | 13.031 s | 0 | 0 |
| Temporal reference | 1344x768 | 124 | 14.578 s | 0 | 0 |
| Temporal long | 1344x768 | 294 | 46.067 s | 0 | 1 |
| 16:9 spatial change | 960x544 | 209 | 12.527 s | 0 | 0 |
| 1:1 | 768x768 | 209 | 14.359 s | 0 | 0 |
| 4:3 | 1024x768 | 124 | 10.408 s | 0 | 0 |
| 3:4, long | 768x1024 | 294 | 30.580 s | 0 | 0 |
| 21:9 | 1344x576 | 107 | 9.068 s | 0 | 0 |
| 9:16 | 768x1344 | 209 | 27.781 s | 0 | 0 |
| Sub-tile wide | 384x224 | 96 | 1.233 s | 0 | 0 |
| Sub-tile square | 256x256 | 124 | 0.976 s | 0 | 0 |
| Spatiotemporal change | 1152x640 | 158 | 12.797 s | 0 | 0 |
| Return to official | 1344x768 | 209 | 28.299 s | 0 | 0 |

**Video VAE result: 0 recompile events across the full 15-request sequence.** This includes real VAE token-length changes below the normal tile size, not only changes in the number of fixed-size tiles.

The two DiT events are recorded for completeness and are outside this PR's VAE-only scope:

- During warmup, the shared DiT attention function specializes once for `rope_freqs=None` versus non-`None`.
- The first 294-frame request crosses Inductor's 32-bit indexing guard and creates a 64-bit-indexing specialization. The later 294-frame request reuses it without another recompile.

The strict all-component checker therefore reports one post-warmup DiT event, while the VAE-specific acceptance criterion passes.

## Tests

```text
MiniMax H3 compile contract: 2 passed
pre-commit: PASS
git diff --check: PASS
online H200 requests: 15/15 HTTP 200
video VAE post-warmup recompiles: 0
```

The contract test covers both supported DiT granularities and verifies that the video VAE always remains regional and inherits the configured dynamic-shape setting.

Commit ```793f2f738ea069ef90f6a0f118812e1d7c3bd0a5```

