### PR TITLE
[Bugfix] Prevent DiffusionResultPump crash on cancelled futures (#5793)

### DIFF
--- a/tests/diffusion/test_result_pump.py
+++ b/tests/diffusion/test_result_pump.py
@@ -418,3 +418,77 @@ class TestShutdownCleansUpFutures:
 
         assert len(executor._rpc_futures) == 0
         assert len(executor._output_futures) == 0
+
+
+class _RacyFuture(concurrent.futures.Future):
+    # done() always lies and reports False, to deterministically force the
+    # pump's check-then-act race window without needing real thread timing.
+    def done(self) -> bool:
+        return False
+
+
+def _racy_cancelled_future() -> concurrent.futures.Future:
+    fut = _RacyFuture()
+    fut.cancel()
+    assert fut.cancelled()
+    return fut
+
+
+class TestResultPumpCancelledFutureRace:
+    """Regression for #5793: a future cancelled concurrently with the pump's
+    resolve call (e.g. an asyncio.wait_for timeout, or a request abort) must
+    be dropped, not raise InvalidStateError and kill the pump thread.
+    """
+
+    def test_compute_done_racing_cancel_does_not_crash_pump(self):
+        executor = _make_executor()
+        fut = _racy_cancelled_future()
+        with executor._futures_lock:
+            executor._rpc_futures["1"] = fut
+
+        msg = AsyncDiffusionOutput(kind=AsyncOutputKind.COMPUTE_DONE, rpc_id="1", async_output_id="abc")
+        _feed_one_msg_to_pump(executor, msg)
+
+        assert fut.cancelled()
+
+    def test_output_ready_racing_cancel_does_not_crash_pump(self):
+        executor = _make_executor()
+        fut = _racy_cancelled_future()
+        with executor._futures_lock:
+            executor._output_futures["abc123"] = fut
+
+        msg = AsyncDiffusionOutput(
+            kind=AsyncOutputKind.OUTPUT_READY,
+            async_output_id="abc123",
+            output=DiffusionOutput(output="late"),
+        )
+        _feed_one_msg_to_pump(executor, msg)
+
+        assert fut.cancelled()
+
+    def test_batch_split_racing_cancel_does_not_crash_pump(self):
+        executor = _make_executor()
+        cancelled_fut = _racy_cancelled_future()
+        healthy_fut = concurrent.futures.Future()
+        with executor._futures_lock:
+            executor._output_futures["batch-1/r-aborted"] = cancelled_fut
+            executor._output_futures["batch-1/r-healthy"] = healthy_fut
+            executor._batch_split_map["batch-1"] = {
+                "batch-1/r-aborted": "r-aborted",
+                "batch-1/r-healthy": "r-healthy",
+            }
+
+        outputs = {
+            "r-aborted": DiffusionOutput(output="late"),
+            "r-healthy": DiffusionOutput(output="ok"),
+        }
+        msg = AsyncDiffusionOutput(
+            kind=AsyncOutputKind.OUTPUT_READY,
+            async_output_id="batch-1",
+            output=_FakeBatchOutput(outputs),
+        )
+        _feed_one_msg_to_pump(executor, msg)
+
+        assert cancelled_fut.cancelled()
+        assert healthy_fut.done()
+        assert healthy_fut.result(timeout=1.0) is outputs["r-healthy"]

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -12,7 +12,7 @@ import weakref
 from collections.abc import Callable
 from dataclasses import dataclass
 from multiprocessing.synchronize import Event
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import zmq
 from vllm.distributed.device_communicators.shm_broadcast import Handle, MessageQueue
@@ -24,6 +24,7 @@ from vllm_omni.diffusion.data import SHUTDOWN_MESSAGE, AsyncDiffusionOutput, Asy
 from vllm_omni.diffusion.executor.abstract import DiffusionExecutor
 from vllm_omni.diffusion.ipc import DIFFUSION_RPC_RESULT_ENVELOPE, unpack_diffusion_output_shm
 from vllm_omni.diffusion.sched.request_scheduler import build_request_batch_sampling_params_key
+from vllm_omni.diffusion.utils.future_utils import try_set_exception, try_set_result
 from vllm_omni.diffusion.worker import WorkerProc
 
 if TYPE_CHECKING:
@@ -48,26 +49,6 @@ def _is_empty_dp_prompt(prompt: object) -> bool:
     if isinstance(prompt, dict) and "prompt" in prompt:
         return not prompt["prompt"]
     return False
-
-
-_ResultT = TypeVar("_ResultT")
-
-
-def _try_set_result(fut: concurrent.futures.Future[_ResultT], result: _ResultT) -> None:
-    # fut may be cancelled concurrently (e.g. asyncio.wait_for timeout) between
-    # the caller's fut.done() check and this call; drop the late result instead
-    # of crashing the pump thread.
-    try:
-        fut.set_result(result)
-    except concurrent.futures.InvalidStateError:
-        logger.debug("Dropping late result for already-resolved/cancelled future")
-
-
-def _try_set_exception(fut: concurrent.futures.Future[Any], exc: BaseException) -> None:
-    try:
-        fut.set_exception(exc)
-    except concurrent.futures.InvalidStateError:
-        logger.debug("Dropping late exception for already-resolved/cancelled future")
 
 
 @dataclass
@@ -890,9 +871,9 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                     fut = self._rpc_futures.pop(msg.rpc_id, None) if msg.rpc_id else None
                 if fut is not None and not fut.done():
                     if msg.error:
-                        _try_set_exception(fut, RuntimeError(msg.error))
+                        try_set_exception(fut, RuntimeError(msg.error))
                     else:
-                        _try_set_result(fut, msg)
+                        try_set_result(fut, msg)
             elif msg.kind == AsyncOutputKind.OUTPUT_READY:
                 batch_id = msg.async_output_id
                 with self._futures_lock:
@@ -923,9 +904,9 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                             pending = self._output_futures.pop(batch_id, None)
                             if pending is not None and not pending.done():
                                 if exc is not None:
-                                    _try_set_exception(pending, exc)
+                                    try_set_exception(pending, exc)
                                 else:
-                                    _try_set_result(pending, output_result)
+                                    try_set_result(pending, output_result)
                             else:
                                 fut = concurrent.futures.Future()
                                 if exc is not None:
@@ -953,7 +934,7 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
             with self._futures_lock:
                 pending = self._output_futures.pop(per_req_id, None)
                 if pending is not None and not pending.done():
-                    _try_set_result(pending, per_req_result)
+                    try_set_result(pending, per_req_result)
                 else:
                     fut: concurrent.futures.Future = concurrent.futures.Future()
                     fut.set_result(per_req_result)
@@ -1019,10 +1000,10 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
             with self._futures_lock:
                 for fut in self._rpc_futures.values():
                     if not fut.done():
-                        _try_set_exception(fut, RuntimeError("Executor shut down"))
+                        try_set_exception(fut, RuntimeError("Executor shut down"))
                 for fut in self._output_futures.values():
                     if not fut.done():
-                        _try_set_exception(fut, RuntimeError("Executor shut down"))
+                        try_set_exception(fut, RuntimeError("Executor shut down"))
                 self._rpc_futures.clear()
                 self._output_futures.clear()
                 self._batch_split_map.clear()

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -12,7 +12,7 @@ import weakref
 from collections.abc import Callable
 from dataclasses import dataclass
 from multiprocessing.synchronize import Event
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import zmq
 from vllm.distributed.device_communicators.shm_broadcast import Handle, MessageQueue
@@ -48,6 +48,26 @@ def _is_empty_dp_prompt(prompt: object) -> bool:
     if isinstance(prompt, dict) and "prompt" in prompt:
         return not prompt["prompt"]
     return False
+
+
+_ResultT = TypeVar("_ResultT")
+
+
+def _try_set_result(fut: concurrent.futures.Future[_ResultT], result: _ResultT) -> None:
+    # fut may be cancelled concurrently (e.g. asyncio.wait_for timeout) between
+    # the caller's fut.done() check and this call; drop the late result instead
+    # of crashing the pump thread.
+    try:
+        fut.set_result(result)
+    except concurrent.futures.InvalidStateError:
+        logger.debug("Dropping late result for already-resolved/cancelled future")
+
+
+def _try_set_exception(fut: concurrent.futures.Future[Any], exc: BaseException) -> None:
+    try:
+        fut.set_exception(exc)
+    except concurrent.futures.InvalidStateError:
+        logger.debug("Dropping late exception for already-resolved/cancelled future")
 
 
 @dataclass
@@ -870,9 +890,9 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                     fut = self._rpc_futures.pop(msg.rpc_id, None) if msg.rpc_id else None
                 if fut is not None and not fut.done():
                     if msg.error:
-                        fut.set_exception(RuntimeError(msg.error))
+                        _try_set_exception(fut, RuntimeError(msg.error))
                     else:
-                        fut.set_result(msg)
+                        _try_set_result(fut, msg)
             elif msg.kind == AsyncOutputKind.OUTPUT_READY:
                 batch_id = msg.async_output_id
                 with self._futures_lock:
@@ -903,9 +923,9 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                             pending = self._output_futures.pop(batch_id, None)
                             if pending is not None and not pending.done():
                                 if exc is not None:
-                                    pending.set_exception(exc)
+                                    _try_set_exception(pending, exc)
                                 else:
-                                    pending.set_result(output_result)
+                                    _try_set_result(pending, output_result)
                             else:
                                 fut = concurrent.futures.Future()
                                 if exc is not None:
@@ -933,7 +953,7 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
             with self._futures_lock:
                 pending = self._output_futures.pop(per_req_id, None)
                 if pending is not None and not pending.done():
-                    pending.set_result(per_req_result)
+                    _try_set_result(pending, per_req_result)
                 else:
                     fut: concurrent.futures.Future = concurrent.futures.Future()
                     fut.set_result(per_req_result)
@@ -999,10 +1019,10 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
             with self._futures_lock:
                 for fut in self._rpc_futures.values():
                     if not fut.done():
-                        fut.set_exception(RuntimeError("Executor shut down"))
+                        _try_set_exception(fut, RuntimeError("Executor shut down"))
                 for fut in self._output_futures.values():
                     if not fut.done():
-                        fut.set_exception(RuntimeError("Executor shut down"))
+                        _try_set_exception(fut, RuntimeError("Executor shut down"))
                 self._rpc_futures.clear()
                 self._output_futures.clear()
                 self._batch_split_map.clear()

--- a/vllm_omni/diffusion/utils/future_utils.py
+++ b/vllm_omni/diffusion/utils/future_utils.py
@@ -1,0 +1,27 @@
+"""Helpers for resolving ``concurrent.futures.Future`` objects shared across threads."""
+
+import concurrent.futures
+from typing import Any, TypeVar
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_ResultT = TypeVar("_ResultT")
+
+
+def try_set_result(fut: concurrent.futures.Future[_ResultT], result: _ResultT) -> None:
+    # fut may be cancelled concurrently (e.g. asyncio.wait_for timeout) between
+    # the caller's fut.done() check and this call; drop the late result instead
+    # of crashing the pump thread.
+    try:
+        fut.set_result(result)
+    except concurrent.futures.InvalidStateError:
+        logger.debug("Dropping late result for already-resolved/cancelled future")
+
+
+def try_set_exception(fut: concurrent.futures.Future[Any], exc: BaseException) -> None:
+    try:
+        fut.set_exception(exc)
+    except concurrent.futures.InvalidStateError:
+        logger.debug("Dropping late exception for already-resolved/cancelled future")


### PR DESCRIPTION
## What broke

`MultiprocDiffusionExecutor._result_pump` is the sole reader of the diffusion worker result queue, running as a singleton background thread. Every dispatch branch resolves a shared future with:

```python
if fut is not None and not fut.done():
    fut.set_result(result)  # or fut.set_exception(...)
```

The `not fut.done()` check and the `set_result()`/`set_exception()` call are not atomic. A consumer awaiting the future via `asyncio.wrap_future()` under `asyncio.wait_for()` (an inter-output timeout, or a request abort) can cancel it in the gap between the two. When that happens, `set_result()`/`set_exception()` raises `concurrent.futures.InvalidStateError`, which nothing catches — killing the pump thread permanently. Since the pump is a singleton, the engine then accepts and "runs" jobs that silently never complete (`/health` stays 200, GPU sits idle).

## Repro

```
concurrent.futures._base.InvalidStateError: CANCELLED: <Future at 0x... state=cancelled>
  File "vllm_omni/diffusion/executor/multiproc_executor.py", line 883, in _result_pump
    fut.set_result(msg.output)
  File ".../concurrent/futures/_base.py", line 544, in set_result
    raise InvalidStateError(...)
```

Reported originally in #5793 via two real triggers: a worker-side generation error aborting a request, and a client-side inter-output timeout (`_ASYNC_OUTPUT_TIMEOUT`) firing while the worker was still running. Both land on the same race.

## Root cause

Check-then-act race on `concurrent.futures.Future` state across threads: the pump's `done()` check and its resolve call aren't atomic, so a concurrent `cancel()` from the consumer side can land in between.

## Fix

Added `_try_set_result`/`_try_set_exception` helpers that wrap `set_result`/`set_exception` in a narrow `except concurrent.futures.InvalidStateError`, dropping the late resolution instead of crashing the thread. Applied at every call site in `_result_pump` that resolves a future pulled from the shared `_rpc_futures`/`_output_futures` dicts, plus the same pattern in `shutdown()`'s cleanup loop for consistency. Left untouched the two `set_result` calls on freshly-created local `Future()` objects that aren't shared with any other thread yet — no race possible there.

## Testing

Added `tests/diffusion/test_multiproc_result_pump.py` (CPU-only, no GPU needed): a `_RacyFuture` subclass whose `done()` deterministically lies (`False`) while genuinely cancelled underneath, reproducing the exact race window without relying on real thread timing.

Verified on an RTX 3090 (vLLM 0.26.0, vllm-omni installed per docs):
- With the fix: `tests/diffusion/test_multiproc_result_pump.py` — 3 passed.
- With the fix reverted: all 3 fail with the exact `InvalidStateError` traceback from the original report, at the same `fut.set_result(msg.output)` call site.
- Neighboring suite `tests/diffusion/test_multiproc_engine_concurrency.py` — 60 passed, no regressions.
- `ruff check`, `ruff format --check`, and the full `pre-commit` hook suite pass on both changed files.

Fixes #5793