### PR TITLE
[Perf] Minimax H3 vae decode support omni layers rmsnorm and rope fused opt

### DIFF
--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_vae_ops.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_vae_ops.py
@@ -12,6 +12,7 @@ import torch.nn as nn
 from vllm_omni.diffusion.layers.norm import RMSNorm
 from vllm_omni.diffusion.layers.rope import RotaryEmbedding
 from vllm_omni.diffusion.models.minimax_h3.vae_ops import (
+    _apply_h3_omni_rope,
     patch_minimax_h3_video_vae,
 )
 
@@ -173,6 +174,41 @@ def test_rotary_embedding_accepts_h3_four_dimensional_full_rotary_layout() -> No
     cos, sin = _h3_rotary_embedding(batch=2, seq_len=7, dtype=x.dtype)
     rope = RotaryEmbedding(is_neox_style=True, half_head_dim=False)
 
-    actual = rope.forward_native(x, cos, sin)
+    actual = _apply_h3_omni_rope(rope, x, cos, sin)
     expected = _apply_h3_rope(x, (cos, sin))
     torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("is_npu", [False, True])
+def test_h3_rope_only_passes_the_rotary_prefix_to_omni(
+    monkeypatch: pytest.MonkeyPatch,
+    is_npu: bool,
+) -> None:
+    from vllm_omni.diffusion.models.minimax_h3 import vae_ops
+
+    class _RecordingRope(nn.Module):
+        def forward(self, tensor, cos, sin):
+            self.tensor = tensor
+            self.cos = cos
+            self.sin = sin
+            return tensor + 1
+
+    class _Platform:
+        @staticmethod
+        def is_npu() -> bool:
+            return is_npu
+
+    monkeypatch.setattr(vae_ops, "current_omni_platform", _Platform())
+    rope = _RecordingRope()
+    x = torch.randn(2, 7, 3, 64)
+    cos = torch.randn(2, 7, 1, 48)
+    sin = torch.randn(2, 7, 1, 48)
+
+    actual = _apply_h3_omni_rope(rope, x, cos, sin)
+
+    assert rope.tensor.shape == (2, 7, 3, 48)
+    expected_cos_shape = (2, 7, 1, 48) if is_npu else (2, 7, 48)
+    assert rope.cos.shape == expected_cos_shape
+    assert rope.sin.shape == expected_cos_shape
+    torch.testing.assert_close(actual[..., :48], x[..., :48] + 1, atol=0, rtol=0)
+    torch.testing.assert_close(actual[..., 48:], x[..., 48:], atol=0, rtol=0)

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_vae_ops.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_vae_ops.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the local MiniMax H3 remote-VAE operator injection."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+import torch
+import torch.nn as nn
+
+from vllm_omni.diffusion.layers.norm import RMSNorm
+from vllm_omni.diffusion.layers.rope import RotaryEmbedding
+from vllm_omni.diffusion.models.minimax_h3.vae_ops import (
+    patch_minimax_h3_video_vae,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.diffusion]
+
+
+def all_to_all_4D(tensor, *_args, **_kwargs):
+    """Single-rank spatial-parallel stand-in exposed like the remote helper."""
+    return tensor
+
+
+def get_parallel_state():
+    return {"sp_process_group": None}
+
+
+def _vit_norm_input(_module, hidden_states):
+    return hidden_states.float()
+
+
+def _apply_h3_rope(tensor: torch.Tensor, rotary_pos_emb: tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:
+    cos, sin = (value.to(tensor.dtype) for value in rotary_pos_emb)
+    rotary_dim = cos.shape[-1]
+    rotated, passed = tensor[..., :rotary_dim], tensor[..., rotary_dim:]
+    first, second = rotated.chunk(2, dim=-1)
+    rotated = rotated * cos + torch.cat((-second, first), dim=-1) * sin
+    return torch.cat((rotated, passed), dim=-1)
+
+
+class _RemoteAttention(nn.Module):
+    """Small faithful model of the remote H3 attention surface."""
+
+    def __init__(self, *, qk_affine: bool) -> None:
+        super().__init__()
+        self.dim_head = 8
+        self.heads = 2
+        self.to_qkv = nn.Linear(16, 48, bias=False)
+        self.to_out = nn.Linear(16, 16, bias=False)
+        self.norm_q = nn.RMSNorm(8, eps=1e-5, elementwise_affine=qk_affine)
+        self.norm_k = nn.RMSNorm(8, eps=1e-5, elementwise_affine=qk_affine)
+        self.spatial_parallel = False
+
+    def perform_attention(self, query, key, value, _pack_info):
+        return query + key + value
+
+    def forward(self, hidden_states, rotary_pos_emb=None, pack_info=None):
+        if pack_info is None:
+            pack_info = {}
+        batch_size, seq_len, _ = hidden_states.shape
+        qkv = self.to_qkv(hidden_states).view(batch_size, seq_len, -1, 3 * self.dim_head)
+        query, key, value = torch.chunk(qkv, 3, dim=-1)
+        query = self.norm_q(_vit_norm_input(self.norm_q, query)).to(query.dtype)
+        key = self.norm_k(_vit_norm_input(self.norm_k, key)).to(key.dtype)
+        if rotary_pos_emb is not None:
+            query = _apply_h3_rope(query, rotary_pos_emb)
+            key = _apply_h3_rope(key, rotary_pos_emb)
+        return self.to_out(self.perform_attention(query, key, value, pack_info).reshape(batch_size, seq_len, -1))
+
+
+class _RemoteBlock(nn.Module):
+    def __init__(self, *, qk_affine: bool) -> None:
+        super().__init__()
+        self.norm1 = nn.RMSNorm(16, eps=1e-5)
+        self.norm2 = nn.RMSNorm(16, eps=1e-5)
+        self.layer_norm = nn.LayerNorm(16, eps=1e-5)
+        self.attn = _RemoteAttention(qk_affine=qk_affine)
+
+
+class _RemoteVAE(nn.Module):
+    def __init__(self, *, qk_affine: bool) -> None:
+        super().__init__()
+        self.decoder = nn.Module()
+        self.decoder.transformer_blocks = nn.ModuleList([_RemoteBlock(qk_affine=qk_affine)])
+
+
+def _h3_rotary_embedding(*, batch: int, seq_len: int, dtype: torch.dtype) -> tuple[torch.Tensor, torch.Tensor]:
+    # H3's complete layout repeats the half rotation frequencies.
+    half_cos = torch.randn(batch, seq_len, 1, 3, dtype=dtype)
+    half_sin = torch.randn(batch, seq_len, 1, 3, dtype=dtype)
+    return torch.cat((half_cos, half_cos), dim=-1), torch.cat((half_sin, half_sin), dim=-1)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_h3_vae_patch_matches_remote_rmsnorm_and_full_dim_rope(dtype: torch.dtype) -> None:
+    torch.manual_seed(0)
+    reference = _RemoteVAE(qk_affine=True).to(dtype=dtype)
+    patched = copy.deepcopy(reference)
+    patch_minimax_h3_video_vae(patched)
+
+    reference_block = reference.decoder.transformer_blocks[0]
+    patched_block = patched.decoder.transformer_blocks[0]
+    assert isinstance(patched_block.norm1, RMSNorm)
+    assert isinstance(patched_block.norm2, RMSNorm)
+    assert isinstance(patched_block.attn.norm_q, RMSNorm)
+    assert isinstance(patched_block.attn.norm_k, RMSNorm)
+    assert isinstance(patched_block.layer_norm, nn.LayerNorm)
+    assert isinstance(patched_block.attn.omni_rope, RotaryEmbedding)
+
+    # Remote H3 always feeds FP32 into decoder RMSNorm and casts back.
+    norm_input = torch.randn(2, 5, 16, dtype=torch.float32)
+    for reference_norm, patched_norm in (
+        (reference_block.norm1, patched_block.norm1),
+        (reference_block.norm2, patched_block.norm2),
+    ):
+        expected_norm = reference_norm(norm_input).to(dtype)
+        actual_norm = patched_norm(norm_input).to(dtype)
+        torch.testing.assert_close(actual_norm, expected_norm, atol=3e-3, rtol=3e-3)
+
+    hidden_states = norm_input.to(dtype)
+    rotary_pos_emb = _h3_rotary_embedding(batch=2, seq_len=5, dtype=dtype)
+    expected = reference_block.attn(hidden_states, rotary_pos_emb)
+    actual = patched_block.attn(hidden_states, rotary_pos_emb)
+    torch.testing.assert_close(actual, expected, atol=3e-3, rtol=3e-3)
+
+    # Running a second time keeps the injected RoPE and parameters intact.
+    rope = patched_block.attn.omni_rope
+    patch_minimax_h3_video_vae(patched)
+    assert patched_block.attn.omni_rope is rope
+
+
+def test_video_vae_enables_local_ops_from_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    from vllm_omni.diffusion.models.minimax_h3 import vae as vae_module
+
+    class _RemoteWrapper(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.model = _RemoteVAE(qk_affine=False)
+
+    monkeypatch.setenv("MINIMAX_H3_VAE_USE_OMNI_OPS", "1")
+    monkeypatch.setattr(
+        vae_module,
+        "_load_component_config",
+        lambda _path: {"latent_channels": 1, "latents_mean": [0.0], "latents_std": [1.0]},
+    )
+    monkeypatch.setattr(vae_module, "_load_remote_component", lambda _path, _config: _RemoteWrapper())
+
+    video_vae = vae_module.MiniMaxH3VideoVAE("unused", device=torch.device("cpu"))
+    assert isinstance(video_vae.model.decoder.transformer_blocks[0].norm1, RMSNorm)
+
+
+def test_h3_vae_patch_leaves_non_affine_rmsnorm_parameter_contract_unchanged() -> None:
+    model = _RemoteVAE(qk_affine=False)
+    block = model.decoder.transformer_blocks[0]
+    original_norm_q = block.attn.norm_q
+    original_norm_k = block.attn.norm_k
+    original_state_keys = set(model.state_dict())
+
+    patch_minimax_h3_video_vae(model)
+
+    assert block.attn.norm_q is original_norm_q
+    assert block.attn.norm_k is original_norm_k
+    assert block.attn.norm_q.weight is None
+    assert block.attn.norm_k.weight is None
+    assert set(model.state_dict()) == original_state_keys
+
+
+def test_rotary_embedding_accepts_h3_four_dimensional_full_rotary_layout() -> None:
+    torch.manual_seed(1)
+    x = torch.randn(2, 7, 3, 8)
+    cos, sin = _h3_rotary_embedding(batch=2, seq_len=7, dtype=x.dtype)
+    rope = RotaryEmbedding(is_neox_style=True, half_head_dim=False)
+
+    actual = rope.forward_native(x, cos, sin)
+    expected = _apply_h3_rope(x, (cos, sin))
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)

--- a/vllm_omni/diffusion/layers/rope.py
+++ b/vllm_omni/diffusion/layers/rope.py
@@ -119,7 +119,21 @@ class RotaryEmbedding(CustomOp):
         cos: torch.Tensor,
         sin: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Normalize shared cos/sin to the half-dim layout used by CUDA/native kernels."""
+        """Normalize shared cos/sin to the layout used by CUDA/native kernels.
+
+        MiniMax H3 VAE supplies complete rotary dimensions as ``[B, S, 1, D]``.
+        Its singleton head axis carries no data, so remove it before following
+        the normal full-dim conversion below.  The complete H3 layout is kept
+        intact until this common operator boundary.
+        """
+        if cos.dim() == 4:
+            if cos.shape[2] != 1 or sin.shape[2] != 1:
+                raise ValueError(
+                    "4D RoPE cos/sin must use a singleton head dimension, "
+                    f"got {tuple(cos.shape)} and {tuple(sin.shape)}"
+                )
+            cos = cos.squeeze(2)
+            sin = sin.squeeze(2)
         if cos.dim() == 3:
             # All batch elements share the same rotary position encoding.
             cos = cos[0]

--- a/vllm_omni/diffusion/layers/rope.py
+++ b/vllm_omni/diffusion/layers/rope.py
@@ -119,21 +119,7 @@ class RotaryEmbedding(CustomOp):
         cos: torch.Tensor,
         sin: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Normalize shared cos/sin to the layout used by CUDA/native kernels.
-
-        MiniMax H3 VAE supplies complete rotary dimensions as ``[B, S, 1, D]``.
-        Its singleton head axis carries no data, so remove it before following
-        the normal full-dim conversion below.  The complete H3 layout is kept
-        intact until this common operator boundary.
-        """
-        if cos.dim() == 4:
-            if cos.shape[2] != 1 or sin.shape[2] != 1:
-                raise ValueError(
-                    "4D RoPE cos/sin must use a singleton head dimension, "
-                    f"got {tuple(cos.shape)} and {tuple(sin.shape)}"
-                )
-            cos = cos.squeeze(2)
-            sin = sin.squeeze(2)
+        """Normalize shared cos/sin to the half-dim layout used by CUDA/native kernels."""
         if cos.dim() == 3:
             # All batch elements share the same rotary position encoding.
             cos = cos[0]

--- a/vllm_omni/diffusion/models/minimax_h3/vae.py
+++ b/vllm_omni/diffusion/models/minimax_h3/vae.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import os
 from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import Any
@@ -22,10 +23,16 @@ from vllm_omni.diffusion.distributed.parallel_state import get_dit_group
 from vllm_omni.diffusion.offloader.module_residency import PinnedModuleStager
 
 from .packed_tokens import minimax_h3_patchify_video_latent
+from .vae_ops import patch_minimax_h3_video_vae
 
 MINIMAX_H3_KEYFRAME_ENCODE_SEED = 42
 MINIMAX_H3_AUDIO_SAMPLE_RATE = 32000
 MINIMAX_H3_AUDIO_CHANNELS = 2
+
+
+def _minimax_h3_vae_use_omni_ops() -> bool:
+    value = os.getenv("MINIMAX_H3_VAE_USE_OMNI_OPS", "0")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _load_component_config(component_path: str) -> dict[str, Any]:
@@ -124,6 +131,9 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
         # checkpoint through FP16; decode still runs under FP16 autocast.
         initial_device = load_device or device
         self.remote.eval().to(device=initial_device, dtype=torch.float32)
+        self.model = self.remote.model
+        if _minimax_h3_vae_use_omni_ops():
+            patch_minimax_h3_video_vae(self.model)
         self._stager = None
         if initial_device.type == "cpu" and device.type not in ("cpu", "meta"):
             self._stager = PinnedModuleStager(
@@ -131,7 +141,6 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
                 device,
                 pin_memory=True,
             )
-        self.model = self.remote.model
         self.use_tiling = True
         self.use_slicing = False
         self.parallel_size = 1

--- a/vllm_omni/diffusion/models/minimax_h3/vae_ops.py
+++ b/vllm_omni/diffusion/models/minimax_h3/vae_ops.py
@@ -30,9 +30,7 @@ def _replace_rms_norm(parent: nn.Module, name: str) -> bool:
     if not isinstance(old, nn.RMSNorm) or old.weight is None:
         return False
     if old.weight.ndim != 1:
-        raise ValueError(
-            f"MiniMax H3 VAE only supports 1D RMSNorm weights, got {tuple(old.weight.shape)}"
-        )
+        raise ValueError(f"MiniMax H3 VAE only supports 1D RMSNorm weights, got {tuple(old.weight.shape)}")
 
     eps = old.eps if old.eps is not None else torch.finfo(torch.float32).eps
     new = RMSNorm(
@@ -70,9 +68,7 @@ def _apply_h3_omni_rope(
 
     rotary_dim = cos.shape[-1]
     if rotary_dim > tensor.shape[-1]:
-        raise ValueError(
-            f"H3 RoPE rotary_dim ({rotary_dim}) exceeds attention head_dim ({tensor.shape[-1]})"
-        )
+        raise ValueError(f"H3 RoPE rotary_dim ({rotary_dim}) exceeds attention head_dim ({tensor.shape[-1]})")
     rotary, passthrough = tensor[..., :rotary_dim], tensor[..., rotary_dim:]
 
     # MindIE accepts the native H3 [B, S, 1, D] coefficients.  CUDA/native
@@ -144,9 +140,7 @@ def _patch_attention(attn: nn.Module) -> None:
         get_parallel_state = forward_globals["get_parallel_state"]
         norm_input = forward_globals["_vit_norm_input"]
     except KeyError as exc:
-        raise RuntimeError(
-            "unsupported MiniMax H3 VAE attention remote code; required helper is missing"
-        ) from exc
+        raise RuntimeError("unsupported MiniMax H3 VAE attention remote code; required helper is missing") from exc
 
     # ``half_head_dim=False`` declares that H3 supplies its complete rotary
     # dimension.  RotaryEmbedding retains the full H3 [B, S, 1, D] layout.

--- a/vllm_omni/diffusion/models/minimax_h3/vae_ops.py
+++ b/vllm_omni/diffusion/models/minimax_h3/vae_ops.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Local optimized decoder operators for the MiniMax H3 remote VAE.
+
+The VAE itself remains checkpoint-owned remote code.  This module only swaps
+the decoder's RMSNorm modules and binds an attention ``forward`` implementation
+which applies Omni's RoPE at the same point as the remote implementation.
+"""
+
+from __future__ import annotations
+
+from types import MethodType
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from vllm_omni.diffusion.layers.norm import RMSNorm
+from vllm_omni.diffusion.layers.rope import RotaryEmbedding
+
+
+def _replace_rms_norm(parent: nn.Module, name: str) -> bool:
+    """Replace an affine ``nn.RMSNorm`` without changing its state-dict key.
+
+    Omni RMSNorm always has a scale parameter.  H3's Q/K norms are configured
+    without one, so they must remain untouched rather than gaining a new,
+    non-checkpoint parameter.
+    """
+    old = getattr(parent, name, None)
+    if not isinstance(old, nn.RMSNorm) or old.weight is None:
+        return False
+    if old.weight.ndim != 1:
+        raise ValueError(
+            f"MiniMax H3 VAE only supports 1D RMSNorm weights, got {tuple(old.weight.shape)}"
+        )
+
+    eps = old.eps if old.eps is not None else torch.finfo(torch.float32).eps
+    new = RMSNorm(
+        old.weight.numel(),
+        eps=float(eps),
+        dtype=old.weight.dtype,
+    ).to(device=old.weight.device, dtype=old.weight.dtype)
+    with torch.no_grad():
+        new.weight.copy_(old.weight)
+    new.weight.requires_grad_(old.weight.requires_grad)
+    setattr(parent, name, new)
+    return True
+
+
+def _patched_attention_forward(
+    self: nn.Module,
+    hidden_states: torch.Tensor,
+    rotary_pos_emb: tuple[torch.Tensor, torch.Tensor] | None = None,
+    pack_info: dict[str, Any] | None = None,
+) -> torch.Tensor:
+    """H3 remote ``Attention.forward`` with only Q/K RoPE redirected.
+
+    This deliberately mirrors the remote-code ordering, including its spatial
+    all-to-all boundaries.  The functions are saved per instance while
+    patching, avoiding any mutation of the dynamic module's global helpers.
+    """
+    if pack_info is None:
+        pack_info = {}
+    batch_size, seq_len, _ = hidden_states.shape
+
+    qkv = self.to_qkv(hidden_states)
+    qkv = qkv.view(batch_size, seq_len, -1, 3 * self.dim_head)
+    query, key, value = torch.chunk(qkv, 3, dim=-1)
+
+    if self.spatial_parallel:
+        local_process_group = self._minimax_h3_omni_get_parallel_state()["sp_process_group"]
+        query = self._minimax_h3_omni_all_to_all_4d(query, 2, 1, group=local_process_group)
+        key = self._minimax_h3_omni_all_to_all_4d(key, 2, 1, group=local_process_group)
+        value = self._minimax_h3_omni_all_to_all_4d(value, 2, 1, group=local_process_group)
+
+    if self.norm_q is not None:
+        query = self.norm_q(self._minimax_h3_omni_norm_input(self.norm_q, query)).to(query.dtype)
+    if self.norm_k is not None:
+        key = self.norm_k(self._minimax_h3_omni_norm_input(self.norm_k, key)).to(key.dtype)
+
+    if rotary_pos_emb is not None:
+        cos, sin = rotary_pos_emb
+        query = self.omni_rope(query, cos.to(query.dtype), sin.to(query.dtype))
+        key = self.omni_rope(key, cos.to(key.dtype), sin.to(key.dtype))
+
+    hidden_states = self.perform_attention(query, key, value, pack_info)
+
+    if self.spatial_parallel:
+        hidden_states = self._minimax_h3_omni_all_to_all_4d(
+            hidden_states,
+            1,
+            2,
+            group=local_process_group,
+        )
+
+    hidden_states = hidden_states.reshape(batch_size, seq_len, -1)
+    return self.to_out(hidden_states)
+
+
+def _patch_attention(attn: nn.Module) -> None:
+    if bool(getattr(attn, "_minimax_h3_omni_ops_patched", False)):
+        return
+
+    forward_globals = attn.forward.__func__.__globals__
+    try:
+        all_to_all_4d = forward_globals["all_to_all_4D"]
+        get_parallel_state = forward_globals["get_parallel_state"]
+        norm_input = forward_globals["_vit_norm_input"]
+    except KeyError as exc:
+        raise RuntimeError(
+            "unsupported MiniMax H3 VAE attention remote code; required helper is missing"
+        ) from exc
+
+    # ``half_head_dim=False`` declares that H3 supplies its complete rotary
+    # dimension.  RotaryEmbedding retains the full H3 [B, S, 1, D] layout.
+    attn.omni_rope = RotaryEmbedding(is_neox_style=True, half_head_dim=False)
+    attn._minimax_h3_omni_all_to_all_4d = all_to_all_4d
+    attn._minimax_h3_omni_get_parallel_state = get_parallel_state
+    attn._minimax_h3_omni_norm_input = norm_input
+    attn.forward = MethodType(_patched_attention_forward, attn)
+    attn._minimax_h3_omni_ops_patched = True
+
+
+def patch_minimax_h3_video_vae(model: nn.Module) -> None:
+    """Inject Omni RMSNorm and RoPE into a loaded MiniMax H3 video VAE.
+
+    The operation is idempotent.  ``LayerNorm`` and non-affine RMSNorm are
+    intentionally retained as remote modules because replacing either would
+    change the checkpoint parameter contract.
+    """
+    decoder = getattr(model, "decoder", None)
+    blocks = getattr(decoder, "transformer_blocks", None)
+    if blocks is None:
+        raise ValueError("MiniMax H3 VAE decoder.transformer_blocks is required")
+
+    for block in blocks:
+        _replace_rms_norm(block, "norm1")
+        _replace_rms_norm(block, "norm2")
+        attn = getattr(block, "attn", None)
+        if attn is None:
+            raise ValueError("MiniMax H3 VAE transformer block is missing attention")
+        _replace_rms_norm(attn, "norm_q")
+        _replace_rms_norm(attn, "norm_k")
+        _patch_attention(attn)
+
+
+__all__ = ["patch_minimax_h3_video_vae"]

--- a/vllm_omni/diffusion/models/minimax_h3/vae_ops.py
+++ b/vllm_omni/diffusion/models/minimax_h3/vae_ops.py
@@ -16,6 +16,7 @@ import torch.nn as nn
 
 from vllm_omni.diffusion.layers.norm import RMSNorm
 from vllm_omni.diffusion.layers.rope import RotaryEmbedding
+from vllm_omni.platforms import current_omni_platform
 
 
 def _replace_rms_norm(parent: nn.Module, name: str) -> bool:
@@ -44,6 +45,43 @@ def _replace_rms_norm(parent: nn.Module, name: str) -> bool:
     new.weight.requires_grad_(old.weight.requires_grad)
     setattr(parent, name, new)
     return True
+
+
+def _apply_h3_omni_rope(
+    rope: RotaryEmbedding,
+    tensor: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> torch.Tensor:
+    """Apply H3's partial, full-dimension 3D RoPE with an Omni operator.
+
+    H3 uses a 48-dimensional rotary prefix in each 64-dimensional attention
+    head.  Its remote ``RotaryEmbeddingND`` returns the complete rotation
+    coefficients as ``[B, S, 1, 48]``.  Split the head locally so the NPU
+    fused operator receives matching widths, then preserve the 16-dimensional
+    non-rotary suffix exactly.
+    """
+    if cos.shape != sin.shape:
+        raise ValueError(f"H3 RoPE cos/sin shapes differ: {tuple(cos.shape)} vs {tuple(sin.shape)}")
+    if cos.dim() not in (3, 4):
+        raise ValueError(f"H3 RoPE cos/sin must be [B, S, D] or [B, S, 1, D], got {tuple(cos.shape)}")
+    if cos.dim() == 4 and cos.shape[2] != 1:
+        raise ValueError(f"H3 RoPE head axis must be singleton, got {tuple(cos.shape)}")
+
+    rotary_dim = cos.shape[-1]
+    if rotary_dim > tensor.shape[-1]:
+        raise ValueError(
+            f"H3 RoPE rotary_dim ({rotary_dim}) exceeds attention head_dim ({tensor.shape[-1]})"
+        )
+    rotary, passthrough = tensor[..., :rotary_dim], tensor[..., rotary_dim:]
+
+    # MindIE accepts the native H3 [B, S, 1, D] coefficients.  CUDA/native
+    # Omni paths consume shared [B, S, D] coefficients instead.
+    if not current_omni_platform.is_npu() and cos.dim() == 4:
+        cos = cos.squeeze(2)
+        sin = sin.squeeze(2)
+    rotary = rope(rotary, cos.to(rotary.dtype), sin.to(rotary.dtype))
+    return torch.cat((rotary, passthrough), dim=-1)
 
 
 def _patched_attention_forward(
@@ -79,8 +117,8 @@ def _patched_attention_forward(
 
     if rotary_pos_emb is not None:
         cos, sin = rotary_pos_emb
-        query = self.omni_rope(query, cos.to(query.dtype), sin.to(query.dtype))
-        key = self.omni_rope(key, cos.to(key.dtype), sin.to(key.dtype))
+        query = _apply_h3_omni_rope(self.omni_rope, query, cos, sin)
+        key = _apply_h3_omni_rope(self.omni_rope, key, cos, sin)
 
     hidden_states = self.perform_attention(query, key, value, pack_info)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
Enable MiniMax-H3 VAE decoder to use vLLM-Omni RMSNorm and RoPE operators without modifying the Hugging Face remote-code cache.
The H3-specific adapter replaces affine decoder RMSNorm modules and redirects Q/K RoPE application at the original attention execution point. It also handles H3’s partial RoPE layout by applying rotary embedding only to the rotary prefix of each attention head, preserving the non-rotary suffix and fixing MindIE NPU shape compatibility.

## Test Plan

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
