### PR TITLE
[Bugfix][Offload] Fix corrupted strides when layerwise offload round-trips F-order weights through CPU

### DIFF
--- a/tests/diffusion/offloader/test_layerwise_backend.py
+++ b/tests/diffusion/offloader/test_layerwise_backend.py
@@ -240,3 +240,141 @@ class TestGetBlocksAttrNames:
         LayerWiseOffloadBackend.set_blocks_attr_names(model, ["new_blocks"])
         assert hasattr(model.__class__, "_layerwise_offload_blocks_attrs")
         assert model.__class__._layerwise_offload_blocks_attrs == ["new_blocks"]
+
+
+def _round_trip(params: dict, bufs: dict | None = None) -> dict[str, torch.Tensor]:
+    """Serialise params+bufs to CPU via _to_cpu, then restore via the prefetch path.
+
+    Returns a mapping of name -> restored tensor, matching the shapes and
+    strides that LayerwiseOffloadHook.prefetch_layer would write back.
+    """
+    bufs = bufs or {}
+    cpu_weights, metadata = LayerwiseOffloadHook._to_cpu(
+        params, bufs, device=torch.device("cpu"), pin_memory=False
+    )
+
+    restored: dict[str, torch.Tensor] = {}
+    for dtype, ordered_meta in metadata.items():
+        flat = cpu_weights[dtype]
+        for m in ordered_meta:
+            base = flat[m["offset"] : m["offset"] + m["numel"]].view(m["shape"])
+            restored[m["name"]] = base.t() if m.get("store_transposed") else base
+
+    return restored
+
+
+class TestNonContigRoundTrip:
+    """_to_cpu / prefetch_layer must preserve the original strides and data.
+
+    FP8 linear weights are often stored as F.pad(...).t() — a 2-D column-major
+    (F-order) tensor. The old code called .flatten() (C-logical order) and
+    restored with .view(shape), assigning C-major strides and causing the Cutlass
+    W8A8 kernel to read garbage data.
+    """
+
+    def test_forder_weight_strides_are_preserved(self):
+        """Restored tensor has the same strides as the original F-order weight."""
+        w = torch.randn(8, 16, dtype=torch.float32).t().contiguous().t()
+        assert w.t().is_contiguous()
+
+        params = {"weight": nn.Parameter(w)}
+        restored = _round_trip(params)
+
+        assert restored["weight"].stride() == w.stride()
+
+    def test_corder_weight_is_unaffected(self):
+        """Standard C-contiguous weights pass through without transposition."""
+        w = torch.randn(16, 32, dtype=torch.float32)
+        assert w.is_contiguous()
+
+        params = {"weight": nn.Parameter(w)}
+        restored = _round_trip(params)
+
+        assert torch.equal(restored["weight"], w)
+        assert restored["weight"].stride() == w.stride()
+        assert restored["weight"].is_contiguous()
+
+    def test_1d_bias_is_unaffected(self):
+        """1-D tensors (biases) are never transposed regardless of layout."""
+        b = torch.randn(64, dtype=torch.float32)
+        params = {"bias": nn.Parameter(b)}
+        restored = _round_trip(params)
+
+        assert torch.equal(restored["bias"], b)
+
+    def test_mixed_forder_and_corder_in_same_block(self):
+        """F-order weight and C-order bias coexist correctly in one serialisation."""
+        W = torch.randn(8, 16, dtype=torch.float32)
+        W_forder = W.t().contiguous().t()
+        bias = torch.randn(8, dtype=torch.float32)
+
+        params = {
+            "weight": nn.Parameter(W_forder),
+            "bias": nn.Parameter(bias),
+        }
+        restored = _round_trip(params)
+
+        assert torch.equal(restored["weight"], W_forder)
+        assert restored["weight"].stride() == W_forder.stride()
+        assert torch.equal(restored["bias"], bias)
+
+    def test_fp8_padded_weight_pattern(self):
+        """Reproduce the exact FP8 padding pattern used by vLLM's linear layers.
+
+        vLLM pads weight rows to a GEMM-friendly alignment then transposes:
+            qweight = F.pad(weight, (0, pad_cols)).t()
+        The result is F-order. Verify round-trip preserves data exactly.
+        """
+        rows, cols, pad_cols = 32, 60, 4  # pad to 64
+        weight = torch.randn(rows, cols, dtype=torch.float32)
+        qweight = torch.nn.functional.pad(weight, (0, pad_cols)).t()
+
+        assert qweight.t().is_contiguous(), "padded+transposed weight should be F-order"
+        assert not qweight.is_contiguous()
+
+        params = {"qweight": nn.Parameter(qweight)}
+        restored = _round_trip(params)
+
+        assert torch.equal(restored["qweight"], qweight)
+        assert restored["qweight"].stride() == qweight.stride()
+
+    def test_hook_full_round_trip_with_forder_weight(self, monkeypatch):
+        """End-to-end: LayerwiseOffloadHook initialize → prefetch preserves F-order weight."""
+
+        monkeypatch.setattr(layerwise_backend_module.current_omni_platform, "Stream", DummyStream)
+        monkeypatch.setattr(layerwise_backend_module.current_omni_platform, "Event", DummyEvent)
+        monkeypatch.setattr(layerwise_backend_module.current_omni_platform, "current_stream", lambda: DummyStream())
+        monkeypatch.setattr(layerwise_backend_module.current_omni_platform, "stream", dummy_stream)
+
+        class FOrderBlock(nn.Module):
+            def __init__(self):
+                super().__init__()
+                w = torch.arange(24, dtype=torch.float32).reshape(4, 6)
+                # Store as F-order (column-major) to mimic FP8 padded weight
+                self.weight = nn.Parameter(w.t().contiguous().t())
+
+        current_block = FOrderBlock()
+        next_block = FOrderBlock()
+        original_weight = next_block.weight.data.clone()
+        original_stride = next_block.weight.data.stride()
+
+        hook = LayerwiseOffloadHook(
+            next_block=next_block,
+            device=torch.device("cpu"),
+            stream=DummyStream(),
+            pin_memory=False,
+        )
+        hook.initialize_hook(current_block)
+
+        # initialize_hook serialises the NEXT block to CPU; next_block's weight
+        # becomes a zero-numel placeholder.
+        assert next_block.weight.data.numel() == 0, "next block weight should be offloaded"
+
+        hook.prefetch_layer(non_blocking=False)
+
+        assert torch.equal(next_block.weight.data, original_weight), (
+            "weight data corrupted after prefetch_layer"
+        )
+        assert next_block.weight.data.stride() == original_stride, (
+            "strides changed after prefetch_layer"
+        )

--- a/tests/diffusion/offloader/test_layerwise_backend.py
+++ b/tests/diffusion/offloader/test_layerwise_backend.py
@@ -249,9 +249,7 @@ def _round_trip(params: dict, bufs: dict | None = None) -> dict[str, torch.Tenso
     strides that LayerwiseOffloadHook.prefetch_layer would write back.
     """
     bufs = bufs or {}
-    cpu_weights, metadata = LayerwiseOffloadHook._to_cpu(
-        params, bufs, device=torch.device("cpu"), pin_memory=False
-    )
+    cpu_weights, metadata = LayerwiseOffloadHook._to_cpu(params, bufs, device=torch.device("cpu"), pin_memory=False)
 
     restored: dict[str, torch.Tensor] = {}
     for dtype, ordered_meta in metadata.items():
@@ -372,9 +370,5 @@ class TestNonContigRoundTrip:
 
         hook.prefetch_layer(non_blocking=False)
 
-        assert torch.equal(next_block.weight.data, original_weight), (
-            "weight data corrupted after prefetch_layer"
-        )
-        assert next_block.weight.data.stride() == original_stride, (
-            "strides changed after prefetch_layer"
-        )
+        assert torch.equal(next_block.weight.data, original_weight), "weight data corrupted after prefetch_layer"
+        assert next_block.weight.data.stride() == original_stride, "strides changed after prefetch_layer"

--- a/vllm_omni/diffusion/offloader/layerwise_backend.py
+++ b/vllm_omni/diffusion/offloader/layerwise_backend.py
@@ -146,14 +146,7 @@ class LayerwiseOffloadHook(ModelHook):
             current_offset = 0
             for name, original_tensor, local_tensor in weights_with_local:
                 numel = local_tensor.numel()
-                # Non-contiguous tensors (e.g. FP8 padded weights stored as
-                # F.pad(...).t(), column-major) must be serialised in physical
-                # storage order. .flatten() on a column-major tensor re-orders
-                # data in C-logical order; .view(shape) on restore then assigns
-                # C-major strides — a different layout than the original, causing
-                # the Cutlass W8A8 kernel to read wrong data. Fix: if the tensor
-                # is 2-D and its transpose is contiguous (F-order), store .t()
-                # in the flat buffer and restore via .view(t_shape).t().
+                # Non-contiguous tensors must be serialised in physical storage order. 
                 if local_tensor.dim() == 2 and local_tensor.t().is_contiguous():
                     data_to_store = local_tensor.t()
                     store_transposed = True

--- a/vllm_omni/diffusion/offloader/layerwise_backend.py
+++ b/vllm_omni/diffusion/offloader/layerwise_backend.py
@@ -223,9 +223,7 @@ class LayerwiseOffloadHook(ModelHook):
                     layer_params[target_name] if target_name in layer_params else layer_bufs[target_name]
                 )
 
-                base = gpu_weight[
-                    metadata["offset"] : metadata["offset"] + metadata["numel"]
-                ].view(metadata["shape"])
+                base = gpu_weight[metadata["offset"] : metadata["offset"] + metadata["numel"]].view(metadata["shape"])
                 restored = base.t() if metadata.get("store_transposed") else base
                 LayerwiseOffloadHook._set_tensor_storage(target_param_or_buf, restored)
 

--- a/vllm_omni/diffusion/offloader/layerwise_backend.py
+++ b/vllm_omni/diffusion/offloader/layerwise_backend.py
@@ -146,7 +146,21 @@ class LayerwiseOffloadHook(ModelHook):
             current_offset = 0
             for name, original_tensor, local_tensor in weights_with_local:
                 numel = local_tensor.numel()
-                cpu_tensor[current_offset : current_offset + numel].copy_(local_tensor.flatten())
+                # Non-contiguous tensors (e.g. FP8 padded weights stored as
+                # F.pad(...).t(), column-major) must be serialised in physical
+                # storage order. .flatten() on a column-major tensor re-orders
+                # data in C-logical order; .view(shape) on restore then assigns
+                # C-major strides — a different layout than the original, causing
+                # the Cutlass W8A8 kernel to read wrong data. Fix: if the tensor
+                # is 2-D and its transpose is contiguous (F-order), store .t()
+                # in the flat buffer and restore via .view(t_shape).t().
+                if local_tensor.dim() == 2 and local_tensor.t().is_contiguous():
+                    data_to_store = local_tensor.t()
+                    store_transposed = True
+                else:
+                    data_to_store = local_tensor
+                    store_transposed = False
+                cpu_tensor[current_offset : current_offset + numel].copy_(data_to_store.flatten())
                 if dtype not in dtype_metadata:
                     dtype_metadata[dtype] = []
                 dtype_metadata[dtype].append(
@@ -154,7 +168,8 @@ class LayerwiseOffloadHook(ModelHook):
                         "name": name,
                         "offset": current_offset,
                         "numel": numel,
-                        "shape": local_tensor.shape,
+                        "shape": data_to_store.shape,
+                        "store_transposed": store_transposed,
                     }
                 )
 
@@ -208,10 +223,11 @@ class LayerwiseOffloadHook(ModelHook):
                     layer_params[target_name] if target_name in layer_params else layer_bufs[target_name]
                 )
 
-                LayerwiseOffloadHook._set_tensor_storage(
-                    target_param_or_buf,
-                    gpu_weight[metadata["offset"] : metadata["offset"] + metadata["numel"]].view(metadata["shape"]),
-                )
+                base = gpu_weight[
+                    metadata["offset"] : metadata["offset"] + metadata["numel"]
+                ].view(metadata["shape"])
+                restored = base.t() if metadata.get("store_transposed") else base
+                LayerwiseOffloadHook._set_tensor_storage(target_param_or_buf, restored)
 
         self._prefetch_done = evt
 


### PR DESCRIPTION
## What broke

Running Cosmos3-Nano with both `--quantization fp8` and `--enable-layerwise-offload` crashes during the dummy warmup run:

```
RuntimeError: Dummy run failed: cutlass_scaled_mm,
  .../quantization/w8a8/cutlass/scaled_mm_entry.cu:209
```

The Cutlass W8A8 kernel fires before any user request is processed.

## Repro

```bash
python examples/offline_inference/text_to_video/text_to_video.py \
  --model nvidia/Cosmos3-Nano \
  --quantization fp8 \
  --enable-layerwise-offload \
  --extra-body '{"guardrails": false}' \
  --output out.mp4
```

Tested on vllm-omni `main` + `vllm/vllm-openai:v0.26.0` base image, 1× B200.

## Root cause

FP8 linear weights (e.g. `to_q`, `to_k`, `to_v`, `to_out`) are stored as column-major (F-order) tensors via `F.pad(...).t()`. `LayerwiseOffloadHook._to_cpu` serialised them with `.flatten()`, which traverses elements in C-logical order regardless of storage layout, then restored with `.view(shape)`, which assigns C-major strides — a different layout from the original. The Cutlass W8A8 kernel receives a pointer to the weight's raw memory along with its strides, and asserts that the layout is column-major. After the broken round-trip the tensor has C-major strides, which violates that contract and triggers the assertion at `scaled_mm_entry.cu:209`.

## Fix

Detect 2-D F-order tensors at serialisation time (`local_tensor.t().is_contiguous()`), store `.t()` in the flat CPU buffer instead, and record `store_transposed=True` in the metadata. On restore, apply `.t()` after `.view()` to recover the original strides. C-contiguous and higher-dimensional tensors are unaffected.

## Tests

Added `TestNonContigRoundTrip` (6 CPU-only, `core_model` tests) to `tests/diffusion/offloader/test_layerwise_backend.py`:

- F-order weight strides are preserved after round-trip
- C-order weight is unaffected
- 1-D bias is never transposed
- Mixed F-order weight + C-order bias in one block
- Exact `F.pad(...).t()` pattern used by vLLM linear layers
- End-to-end hook `initialize_hook` → `prefetch_layer` with F-order weight

The 4 F-order tests fail on unpatched `main` and pass on this branch. The 2 unaffected-path tests (`test_corder_weight_is_unaffected`, `test_1d_bias_is_unaffected`) pass on both.