### PR TITLE
[BugFix] Fix HunyuanImage3 image edit serving flow

### DIFF
--- a/tests/entrypoints/openai_api/test_serving_chat_multistage_generation.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_multistage_generation.py
@@ -62,7 +62,12 @@ def test_build_multistage_generation_inputs_applies_stage_specific_overrides(ser
     assert engine_prompt["prompt"] == "draw a robot"
     assert engine_prompt["modalities"] == ["img2img"]
     assert engine_prompt["negative_prompt"] == "blurry"
-    assert engine_prompt["mm_processor_kwargs"] == {"target_h": 768, "target_w": 1024, "vae_generator_seed": 0}
+    assert engine_prompt["mm_processor_kwargs"] == {
+        "target_h": 768,
+        "target_w": 1024,
+        "vae_generator_seed": 0,
+        "modalities": ["img2img"],
+    }
     assert engine_prompt["multi_modal_data"]["img2img"].size == (24, 24)
 
     assert len(sampling_params_list) == 3
@@ -92,6 +97,45 @@ def test_build_multistage_generation_inputs_applies_stage_specific_overrides(ser
     assert engine.default_sampling_params_list[1].lora_request is None
     assert engine.default_sampling_params_list[2].resolution == 640
     assert engine.default_sampling_params_list[2].lora_request is None
+
+
+def test_build_multistage_generation_inputs_keeps_image_edit_serving_generic(serving_chat):
+    from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
+
+    engine = SimpleNamespace(
+        stage_configs=[
+            SimpleNamespace(
+                stage_type="llm",
+                is_comprehension=True,
+                engine_args=SimpleNamespace(model_arch="HunyuanImage3ForCausalMM"),
+            ),
+            SimpleNamespace(stage_type="diffusion", is_comprehension=False),
+        ],
+        default_sampling_params_list=[
+            SamplingParams(temperature=0.0, seed=11),
+            OmniDiffusionSamplingParams(),
+        ],
+    )
+    reference_image = Image.new("RGB", (24, 24), color="green")
+    gen_params = OmniDiffusionSamplingParams(height=768, width=1024, seed=42)
+
+    engine_prompt, sampling_params_list = OmniOpenAIServingChat._build_multistage_generation_inputs(
+        serving_chat,
+        engine=engine,
+        prompt="将背景更改为森林",
+        extra_body={},
+        reference_images=[reference_image],
+        gen_params=gen_params,
+        request_id="img-edit-request-1",
+    )
+
+    assert engine_prompt["prompt"] == "将背景更改为森林"
+    assert engine_prompt["modalities"] == ["img2img"]
+    assert engine_prompt["multi_modal_data"]["img2img"] is reference_image
+    assert engine_prompt["multi_modal_uuids"] == {"img2img": ["img-edit-request-1-img2img-0"]}
+    assert engine_prompt["mm_processor_kwargs"]["modalities"] == ["img2img"]
+    assert "use_system_prompt" not in engine_prompt
+    assert sampling_params_list[0].seed == 42
 
 
 def test_prepare_multistage_multimodal_inputs_defers_downstream_modalities(serving_chat):

--- a/tests/model_executor/models/hunyuan_image3/test_hunyuan_image3_prompt.py
+++ b/tests/model_executor/models/hunyuan_image3/test_hunyuan_image3_prompt.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for HunyuanImage3 image-edit prompt normalization."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_hunyuan_image3_img2img_prompt_gets_it2i_template():
+    from vllm_omni.model_executor.models.hunyuan_image3.hunyuan_image3 import (
+        _maybe_build_hunyuan_image3_it2i_prompt,
+    )
+
+    prompt = _maybe_build_hunyuan_image3_it2i_prompt(
+        "将背景更改为森林",
+        num_images=1,
+        mm_kwargs={"modalities": ["img2img"]},
+    )
+
+    assert "<|startoftext|>" in prompt
+    assert "User: <img>将背景更改为森林" in prompt
+    assert prompt.endswith("\n\nAssistant: <think>")
+
+
+def test_hunyuan_image3_prompt_with_existing_placeholder_is_unchanged():
+    from vllm_omni.model_executor.models.hunyuan_image3.hunyuan_image3 import (
+        _maybe_build_hunyuan_image3_it2i_prompt,
+    )
+
+    prompt = "User: <img>将背景更改为森林\n\nAssistant: <think>"
+
+    assert (
+        _maybe_build_hunyuan_image3_it2i_prompt(
+            prompt,
+            num_images=1,
+            mm_kwargs={"modalities": ["img2img"]},
+        )
+        == prompt
+    )
+
+
+def test_hunyuan_image3_image_modality_does_not_force_it2i_template():
+    from vllm_omni.model_executor.models.hunyuan_image3.hunyuan_image3 import (
+        _maybe_build_hunyuan_image3_it2i_prompt,
+    )
+
+    assert (
+        _maybe_build_hunyuan_image3_it2i_prompt(
+            "生成一张森林图片",
+            num_images=1,
+            mm_kwargs={"modalities": ["image"]},
+        )
+        == "生成一张森林图片"
+    )

--- a/tests/model_executor/stage_input_processors/test_hunyuan_image3.py
+++ b/tests/model_executor/stage_input_processors/test_hunyuan_image3.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for HunyuanImage3 stage input bridging."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image
+
+from vllm_omni.model_executor.stage_input_processors.hunyuan_image3 import ar2diffusion
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_ar2diffusion_forwards_img2img_source_image():
+    image = Image.new("RGB", (24, 24), color="green")
+    ar_output = SimpleNamespace(
+        outputs=[
+            SimpleNamespace(
+                cumulative_token_ids=[1, 2, 3],
+                text="latent",
+            )
+        ],
+    )
+    diffusion_input = ar2diffusion(
+        source_outputs=[ar_output],
+        prompt={
+            "prompt": "将背景更改为森林",
+            "multi_modal_data": {"img2img": image},
+            "seed": 42,
+            "use_system_prompt": "en_unified",
+        },
+        requires_multimodal_data=True,
+    )
+
+    assert diffusion_input["prompt"] == "将背景更改为森林"
+    assert diffusion_input["multi_modal_data"]["image"] is image
+    assert diffusion_input["seed"] == 42
+    assert diffusion_input["use_system_prompt"] == "en_unified"
+    assert diffusion_input["extra"]["ar_generated_text"] == "latent"

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -2962,6 +2962,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         reference_images: list[Image.Image],
         gen_params: OmniDiffusionSamplingParams,
         tokenizer: Any = None,
+        request_id: str | None = None,
     ) -> tuple[OmniTextPrompt, list[Any]]:
         """Build the shared multistage generation prompt and stage params."""
         stage_configs = getattr(engine, "stage_configs", None) or []
@@ -3066,6 +3067,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             mm_processor_kwargs["target_w"] = width
         if seed is not None and engine_prompt_data is not None:
             mm_processor_kwargs["vae_generator_seed"] = int(seed)
+        mm_processor_kwargs["modalities"] = modalities
         if mm_processor_kwargs:
             engine_prompt["mm_processor_kwargs"] = mm_processor_kwargs
         if engine_prompt_data is not None:
@@ -3073,8 +3075,11 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             # Provide multi_modal_uuids so that newer vLLM versions can
             # validate multi_modal_data / multi_modal_uuids consistency.
             # Generate one uuid per image when the value is a list (multi-image inputs).
+            uuid_prefix = request_id or f"img-{uuid.uuid4().hex[:16]}"
             engine_prompt["multi_modal_uuids"] = {
-                k: [f"img-{k}-{i}" for i in range(len(v))] if isinstance(v, list) else [f"img-{k}-0"]
+                k: [f"{uuid_prefix}-{k}-{i}" for i in range(len(v))]
+                if isinstance(v, list)
+                else [f"{uuid_prefix}-{k}-0"]
                 for k, v in engine_prompt_data.items()
             }
 
@@ -3293,6 +3298,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     reference_images=pil_images,
                     gen_params=gen_params,
                     tokenizer=tokenizer,
+                    request_id=request_id,
                 )
             else:
                 engine_prompt = gen_prompt

--- a/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
+++ b/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
@@ -75,6 +75,7 @@ from vllm.multimodal.inputs import (
 )
 from vllm.multimodal.parse import (
     MultiModalDataItems,
+    MultiModalDataParser,
 )
 from vllm.multimodal.processing import (
     BaseDummyInputsBuilder,
@@ -977,6 +978,21 @@ class HunyuanImage3Processor:
         return image.crop((crop_left, crop_top, crop_left + tw, crop_top + th))
 
 
+class HunyuanImage3DataParser(MultiModalDataParser):
+    """HunyuanImage3 treats ``img2img`` input identically to ``image``."""
+
+    def _get_subparsers(self):
+        parsers = super()._get_subparsers()
+        parsers["img2img"] = self._parse_image_data
+        return parsers
+
+    def parse_mm_data(self, mm_data, **kwargs):
+        normalized = {}
+        for key, value in mm_data.items():
+            normalized["image" if key == "img2img" else key] = value
+        return super().parse_mm_data(normalized, **kwargs)
+
+
 class HunyuanImage3ProcessingInfo(BaseProcessingInfo):
     """Processing information for HunyuanImage3 model."""
 
@@ -990,14 +1006,19 @@ class HunyuanImage3ProcessingInfo(BaseProcessingInfo):
             **kwargs,
         )
 
+    def get_data_parser(self) -> HunyuanImage3DataParser:
+        return HunyuanImage3DataParser(
+            expected_hidden_size=self.get_hf_config().hidden_size,
+        )
+
     def get_supported_mm_limits(self) -> Mapping[str, int | None]:
-        return {"image": None}
+        return {"image": None, "img2img": 1}
 
 
 class HunyuanImage3DummyInputsBuilder(BaseDummyInputsBuilder[HunyuanImage3ProcessingInfo]):
     def get_dummy_text(self, mm_counts: Mapping[str, int]) -> str:
         """Generate dummy text with image placeholders."""
-        num_images = mm_counts.get("image", 0)
+        num_images = mm_counts.get("image", 0) + mm_counts.get("img2img", 0)
         return "<img>" * num_images
 
     def get_dummy_mm_data(
@@ -1006,7 +1027,7 @@ class HunyuanImage3DummyInputsBuilder(BaseDummyInputsBuilder[HunyuanImage3Proces
         mm_counts: Mapping[str, int],
         mm_options: Mapping[str, BaseDummyOptions] | None = None,
     ) -> MultiModalDataDict:
-        num_images = mm_counts.get("image", 0)
+        num_images = mm_counts.get("image", 0) + mm_counts.get("img2img", 0)
 
         hf_config = self.info.get_hf_config()
         image_size = hf_config.image_base_size
@@ -1022,8 +1043,60 @@ class HunyuanImage3DummyInputsBuilder(BaseDummyInputsBuilder[HunyuanImage3Proces
         }
 
 
+def _maybe_build_hunyuan_image3_it2i_prompt(
+    prompt: str,
+    num_images: int,
+    mm_kwargs: Mapping[str, object],
+) -> str:
+    """Add HunyuanImage3's reference-image placeholder for image edits."""
+    modalities = mm_kwargs.get("modalities") or []
+    if isinstance(modalities, str):
+        modalities = [modalities]
+    if "img2img" not in modalities or num_images <= 0 or "<img>" in prompt:
+        return prompt
+
+    from vllm_omni.diffusion.models.hunyuan_image3.prompt_utils import build_prompt
+
+    return build_prompt(
+        prompt,
+        task="it2i",
+        bot_task=typing.cast(str | None, mm_kwargs.get("bot_task", "think")),
+        sys_type=typing.cast(
+            str | None,
+            mm_kwargs.get("use_system_prompt") or mm_kwargs.get("sys_type") or "en_unified",
+        ),
+        custom_system_prompt=typing.cast(str | None, mm_kwargs.get("system_prompt")),
+        num_images=num_images,
+    )
+
+
 class HunyuanImage3MultiModalProcessor(BaseMultiModalProcessor[HunyuanImage3ProcessingInfo]):
     """Multimodal processor for HunyuanImage3 model."""
+
+    def _apply_hf_processor_main(
+        self,
+        prompt: str | list[int],
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, object],
+        tokenization_kwargs: Mapping[str, object],
+        *,
+        enable_hf_prompt_update: bool,
+    ) -> tuple[list[int], BatchFeature, bool]:
+        if isinstance(prompt, str):
+            mm_counts = mm_items.get_all_counts()
+            prompt = _maybe_build_hunyuan_image3_it2i_prompt(
+                prompt,
+                num_images=mm_counts.get("image", 0) + mm_counts.get("img2img", 0),
+                mm_kwargs=hf_processor_mm_kwargs,
+            )
+
+        return super()._apply_hf_processor_main(
+            prompt=prompt,
+            mm_items=mm_items,
+            hf_processor_mm_kwargs=hf_processor_mm_kwargs,
+            tokenization_kwargs=tokenization_kwargs,
+            enable_hf_prompt_update=enable_hf_prompt_update,
+        )
 
     def _call_hf_processor(
         self,

--- a/vllm_omni/model_executor/stage_input_processors/hunyuan_image3.py
+++ b/vllm_omni/model_executor/stage_input_processors/hunyuan_image3.py
@@ -206,6 +206,8 @@ def ar2diffusion(
     if mm_data:
         prompt_images = mm_data.get("image")
         if prompt_images is None:
+            prompt_images = mm_data.get("img2img")
+        if prompt_images is None:
             prompt_images = mm_data.get("images")
         if prompt_images is not None:
             diffusion_input["multi_modal_data"] = {"image": prompt_images}


### PR DESCRIPTION
<!-- markdownlint-disable -->
Fix HunyuanImage3 image edit requests through the `/v1/images/edits` API.

## Purpose

HunyuanImage-3.0-Instruct can be deployed successfully with the multi-stage Omni serving flow, but image edit requests fail at request validation time.

Example request:

```bash
curl -sS -X POST "http://127.0.0.1:8898/v1/images/edits" \
  -F "model=/nas/disk1/HunyuanImage-3.0-Instruct" \
  -F "image=@/model/zzy/dataset/GEdit-Bench_samples/background_change/02_05040717fb0f2ac80083ef81ee206ace_input.png" \
  -F "prompt=将背景更改为森林" \
  -F "output_format=png" \
  -F "num_inference_steps=40" \
  -F "guidance_scale=1" \
  -F "seed=42" \
  > response.json

jq -r '.data[0].b64_json' response.json | base64 -d > output.png
```

The request fails with:
```
(APIServer pid=27935) ERROR 08-10 09:03:33 [api_server.py:2339] Validation error: Unsupported modality: img2img
(APIServer pid=27935) INFO:     127.0.0.1:55562 - "POST /v1/images/edits HTTP/1.1" 400 Bad Request
(APIServer pid=27935) INFO 08-10 09:03:33 [orchestrator.py:783] [Orchestrator] Aborted request(s) ['img_edit-9a08b0f6da5c1488-92a9bced']
(APIServer pid=27935) INFO 08-10 09:05:47 [async_omni.py:1074] [AsyncOmni] Aborted request(s) img_edit-88a114ea1beb9807-914be2f5
(APIServer pid=27935) INFO 08-10 09:05:47 [async_omni.py:650] [AsyncOmni] Request img_edit-88a114ea1beb9807-914be2f5 failed (input error): Unsupported modality: img2img
```
