### PR TITLE
[Bugfix][Diffusion] Restore supports_packed_mask_free on teacache FakeBackend

### DIFF
--- a/tests/diffusion/cache/test_teacache_extractors.py
+++ b/tests/diffusion/cache/test_teacache_extractors.py
@@ -488,6 +488,14 @@ class _MiniMaxH3FakeAttention(nn.Module):
     class FakeBackend:
         supports_prefix_kv_slicing = False
 
+        # Mirror AttentionBackend.supports_packed_mask_free: H3's packed
+        # attention path calls attn_backend.supports_packed_mask_free() to decide
+        # whether to build the padding mask. Return False so the fake exercises
+        # the masked path (the abstract backend default).
+        @classmethod
+        def supports_packed_mask_free(cls) -> bool:
+            return False
+
     def __init__(self, **kwargs):
         del kwargs
         super().__init__()


### PR DESCRIPTION
### Context
#5891 added `supports_packed_mask_free` to `AttentionBackend` and calls it in the
H3 packed-attention path (`minimax_h3_transformer.py:421`). The `FakeBackend` in
`tests/diffusion/cache/test_teacache_extractors.py` did not implement it, so after
#5891 merged, 7 `TestMiniMaxH3Extractor` tests fail with
`AttributeError: type object 'FakeBackend' has no attribute 'supports_packed_mask_free'`,
leaving `buildkite/vllm-omni` red on main.

### Fix
Add the classmethod to `FakeBackend` returning `False` (the abstract-backend default →
masked path), matching the fakes already in `test_minimax_h3_contract.py`.

### Verification
AttributeError resolved (traceback now advances past the attention call). These tests
exercise NPU ops (npu_rms_norm) that require real NPU hardware, so they're validated in CI.