### PR TITLE
[Docs] Fix broken attention backend link

### DIFF
--- a/docs/user_guide/examples/online_serving/diffusers_pipeline_adapter.md
+++ b/docs/user_guide/examples/online_serving/diffusers_pipeline_adapter.md
@@ -99,7 +99,7 @@ a native vLLM-Omni pipeline for those cases.
 ### Attention Backends
 
 The diffusers backend converts
-[vLLM-Omni standard of attention backend setting](../../../docs/user_guide/diffusion/attention_backends.md)
+[vLLM-Omni standard of attention backend setting](../../diffusion/attention_backends.md)
 to [diffusers standard](https://huggingface.co/docs/diffusers/optimization/attention_backends#available-backends).
 
 Specifically for `FLASH_ATTN`, it will first attempt to use FlashAttention-3 and then FlashAttention-2.


### PR DESCRIPTION
## Purpose

Fix the strict MkDocs failure reported by [Read the Docs build 33993190](https://app.readthedocs.org/projects/vllm-omni/builds/33993190/).

The attention-backend link in `diffusers_pipeline_adapter.md` included an extra `docs/` path segment. MkDocs therefore resolved it to the nonexistent `docs/docs/user_guide/diffusion/attention_backends.md` target and aborted because Read the Docs builds with `--strict`.

This PR points the link at the existing `docs/user_guide/diffusion/attention_backends.md` page.

## User impact

The documentation build can complete successfully, and readers can follow the attention-backend link.

## Test plan

- `DISABLE_MKDOCS_2_WARNING=true /home/hsliu/tmp/venvs/vllm-omni-pr5139-docs/bin/python -m mkdocs build --clean --site-dir <temp-dir> --config-file mkdocs.yml --strict` (passed; documentation built in 138.07 seconds)
- `git diff --check`

## Checklist

- [x] Documentation-only change; no code tests are required.
- [x] Commit includes a DCO `Signed-off-by` line.