### PR TITLE
[Refactor] Init and use per_request_initial_chunk_size_override helper 

### DIFF
--- a/tests/model_executor/stage_input_processors/test_tts_utils.py
+++ b/tests/model_executor/stage_input_processors/test_tts_utils.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_omni.model_executor.stage_input_processors.tts_utils import (
+    per_request_initial_chunk_size_override,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _req(entries=None):
+    if entries is None:
+        return SimpleNamespace(additional_information=None)
+    return SimpleNamespace(additional_information=SimpleNamespace(entries=entries))
+
+
+def test_no_additional_information_keeps_configured_value():
+    value, overridden = per_request_initial_chunk_size_override(_req(), 10)
+    assert (value, overridden) == (10, False)
+
+
+def test_missing_additional_information_attribute_keeps_configured_value():
+    value, overridden = per_request_initial_chunk_size_override(SimpleNamespace(), 10)
+    assert (value, overridden) == (10, False)
+
+
+def test_entries_missing_key_keeps_configured_value():
+    value, overridden = per_request_initial_chunk_size_override(_req(entries={}), 10)
+    assert (value, overridden) == (10, False)
+
+
+def test_list_data_none_keeps_configured_value():
+    entry = SimpleNamespace(list_data=None)
+    value, overridden = per_request_initial_chunk_size_override(_req(entries={"initial_codec_chunk_frames": entry}), 10)
+    assert (value, overridden) == (10, False)
+
+
+def test_list_data_empty_keeps_configured_value():
+    entry = SimpleNamespace(list_data=[])
+    value, overridden = per_request_initial_chunk_size_override(_req(entries={"initial_codec_chunk_frames": entry}), 10)
+    assert (value, overridden) == (10, False)
+
+
+def test_list_data_multiple_values_keeps_configured_value():
+    entry = SimpleNamespace(list_data=[5, 6])
+    value, overridden = per_request_initial_chunk_size_override(_req(entries={"initial_codec_chunk_frames": entry}), 10)
+    assert (value, overridden) == (10, False)
+
+
+def test_single_value_override_takes_precedence():
+    entry = SimpleNamespace(list_data=[7])
+    value, overridden = per_request_initial_chunk_size_override(_req(entries={"initial_codec_chunk_frames": entry}), 10)
+    assert (value, overridden) == (7, True)
+
+
+def test_override_value_is_coerced_to_int():
+    entry = SimpleNamespace(list_data=["7"])
+    value, overridden = per_request_initial_chunk_size_override(_req(entries={"initial_codec_chunk_frames": entry}), 10)
+    assert (value, overridden) == (7, True)

--- a/vllm_omni/model_executor/stage_input_processors/audex.py
+++ b/vllm_omni/model_executor/stage_input_processors/audex.py
@@ -22,6 +22,7 @@ from vllm.logger import init_logger
 from vllm_omni.data_entry_keys import CodesStruct, MetaStruct, OmniPayloadStruct
 from vllm_omni.inputs.data import OmniTokensPrompt
 from vllm_omni.model_executor.stage_input_processors.bagel import ExpandedPrompt
+from vllm_omni.model_executor.stage_input_processors.tts_utils import per_request_initial_chunk_size_override
 
 logger = init_logger(__name__)
 
@@ -179,6 +180,7 @@ def thinker2code2wav_async_chunk(
     cfg = _connector_extra(transfer_manager)
     chunk_frames = int(cfg.get("codec_chunk_frames", 25))
     initial_chunk_frames = int(cfg.get("initial_codec_chunk_frames", chunk_frames))
+    initial_chunk_frames, _ = per_request_initial_chunk_size_override(request, initial_chunk_frames)
     codec_offset = int(cfg.get("codec_token_offset", _DEFAULT_CODEC_TOKEN_OFFSET))
     codec_size = int(cfg.get("codec_vocab_size", _DEFAULT_CODEC_VOCAB_SIZE))
     if chunk_frames <= 0 or initial_chunk_frames <= 0:

--- a/vllm_omni/model_executor/stage_input_processors/fish_speech.py
+++ b/vllm_omni/model_executor/stage_input_processors/fish_speech.py
@@ -10,6 +10,7 @@ from vllm_omni.data_entry_keys import (
     MetaStruct,
     OmniPayloadStruct,
 )
+from vllm_omni.model_executor.stage_input_processors.tts_utils import per_request_initial_chunk_size_override
 
 
 def _get_connector_extra(transfer_manager: Any) -> dict[str, Any]:
@@ -141,18 +142,7 @@ def slow_ar_to_dac_decoder_async_chunk(
     left_context_size_config = int(cfg.get("codec_left_context_frames", 25))
     configured_initial_chunk_size = int(cfg.get("initial_codec_chunk_frames", 0))
 
-    initial_chunk_size = configured_initial_chunk_size
-
-    # Per-request override.
-    additional_information = getattr(request, "additional_information", None)
-    if (
-        additional_information is not None
-        and hasattr(additional_information, "entries")
-        and "initial_codec_chunk_frames" in additional_information.entries
-    ):
-        entry = additional_information.entries["initial_codec_chunk_frames"]
-        if entry.list_data is not None and len(entry.list_data) == 1:
-            initial_chunk_size = int(entry.list_data[0])
+    initial_chunk_size, _ = per_request_initial_chunk_size_override(request, configured_initial_chunk_size)
 
     if chunk_size <= 0 or left_context_size_config < 0 or configured_initial_chunk_size < 0 or initial_chunk_size < 0:
         raise ValueError(

--- a/vllm_omni/model_executor/stage_input_processors/higgs_audio_v3.py
+++ b/vllm_omni/model_executor/stage_input_processors/higgs_audio_v3.py
@@ -33,6 +33,7 @@ from vllm_omni.data_entry_keys import (
     OmniPayloadStruct,
 )
 from vllm_omni.inputs.data import OmniTokensPrompt
+from vllm_omni.model_executor.stage_input_processors.tts_utils import per_request_initial_chunk_size_override
 
 __all__ = ["talker2code2wav", "talker2code2wav_async_chunk"]
 
@@ -268,6 +269,7 @@ def talker2code2wav_async_chunk(
     left_context_size_config = int(cfg.get("codec_left_context_frames", _DEFAULT_CODEC_LEFT_CONTEXT_FRAMES))
     right_holdback_size_config = int(cfg.get("codec_right_holdback_frames", _DEFAULT_CODEC_RIGHT_HOLDBACK_FRAMES))
     configured_initial_chunk_size = int(cfg.get("initial_codec_chunk_frames") or 0)
+    configured_initial_chunk_size, _ = per_request_initial_chunk_size_override(request, configured_initial_chunk_size)
 
     if (
         chunk_size <= 0

--- a/vllm_omni/model_executor/stage_input_processors/moss_tts.py
+++ b/vllm_omni/model_executor/stage_input_processors/moss_tts.py
@@ -14,6 +14,7 @@ from vllm.inputs import TokensPrompt as OmniTokensPrompt
 from vllm.logger import init_logger
 
 from vllm_omni.data_entry_keys import CodesStruct, MetaStruct, OmniPayloadStruct
+from vllm_omni.model_executor.stage_input_processors.tts_utils import per_request_initial_chunk_size_override
 
 logger = init_logger(__name__)
 
@@ -271,6 +272,7 @@ def talker2codec_raw_async_chunk(
     cfg = cfg if isinstance(cfg, dict) else {}
     chunk_frames = int(cfg.get("codec_chunk_frames", 15) or 15)
     initial_chunk_frames = int(cfg.get("initial_codec_chunk_frames") or 0)
+    initial_chunk_frames, _ = per_request_initial_chunk_size_override(request, initial_chunk_frames)
     if chunk_frames <= 0:
         raise ValueError(f"codec_chunk_frames must be positive for MOSS raw streaming, got {chunk_frames}")
     if initial_chunk_frames < 0:

--- a/vllm_omni/model_executor/stage_input_processors/personaplex.py
+++ b/vllm_omni/model_executor/stage_input_processors/personaplex.py
@@ -25,6 +25,7 @@ from vllm_omni.data_entry_keys import (
     MetaStruct,
     OmniPayloadStruct,
 )
+from vllm_omni.model_executor.stage_input_processors.tts_utils import per_request_initial_chunk_size_override
 
 _NUM_ACTIVE_CODEBOOKS = 8  # agent cb 0..7 (the PCM-bearing rows)
 
@@ -196,6 +197,7 @@ def talker2code2wav_async_chunk(
     cfg = raw_cfg.get("extra", raw_cfg) if isinstance(raw_cfg, dict) else {}
     chunk = int(cfg.get("codec_chunk_frames", 25))
     initial_chunk = int(cfg.get("initial_codec_chunk_frames") or 0)
+    initial_chunk, _ = per_request_initial_chunk_size_override(request, initial_chunk)
     if chunk <= 0 or initial_chunk < 0:
         raise ValueError(
             "PersonaPlex codec chunk sizes must be positive/non-negative: "

--- a/vllm_omni/model_executor/stage_input_processors/qwen3_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/qwen3_omni.py
@@ -28,6 +28,7 @@ from vllm_omni.model_executor.stage_input_processors.tts_utils import (
     extract_language_from_request,
     extract_speaker_from_prompt,
     extract_speaker_from_request,
+    per_request_initial_chunk_size_override,
 )
 
 logger = logging.getLogger(__name__)
@@ -719,6 +720,7 @@ def talker2code2wav_async_chunk(
     chunk_size_config = int(cfg.get("codec_chunk_frames", 25))
     left_context_size_config = int(cfg.get("codec_left_context_frames", 25))
     configured_initial_chunk_size = int(cfg.get("initial_codec_chunk_frames") or 0)
+    configured_initial_chunk_size, _ = per_request_initial_chunk_size_override(request, configured_initial_chunk_size)
 
     chunk_id = transfer_manager.put_req_chunk[request_id]
     length = len(transfer_manager.code_prompt_token_ids[request_id])

--- a/vllm_omni/model_executor/stage_input_processors/qwen3_tts.py
+++ b/vllm_omni/model_executor/stage_input_processors/qwen3_tts.py
@@ -24,6 +24,7 @@ from vllm_omni.model_executor.stage_input_processors.tts_utils import (
     extract_language_from_request,
     extract_speaker_from_prompt,
     extract_speaker_from_request,
+    per_request_initial_chunk_size_override,
 )
 
 logger = init_logger(__name__)
@@ -108,20 +109,11 @@ def talker2code2wav_async_chunk(
         transfer_manager._ramp_parsed = parse_chunk_ramp(cfg, steady=chunk_size)
     ramp = transfer_manager._ramp_parsed
 
-    # Per-request override takes priority over dynamic IC.
-    fixed_initial_chunk_size = configured_initial_chunk_size > 0
-    initial_chunk_size = configured_initial_chunk_size
-    additional_information = getattr(request, "additional_information", None)
-
-    if (
-        additional_information is not None
-        and hasattr(additional_information, "entries")
-        and "initial_codec_chunk_frames" in additional_information.entries
-    ):
-        entry = additional_information.entries["initial_codec_chunk_frames"]
-        if entry.list_data is not None and len(entry.list_data) == 1:
-            initial_chunk_size = int(entry.list_data[0])
-            fixed_initial_chunk_size = True
+    # Config or per-request override takes priority over dynamic IC.
+    initial_chunk_size, fixed_initial_chunk_size = per_request_initial_chunk_size_override(
+        request, configured_initial_chunk_size
+    )
+    fixed_initial_chunk_size |= configured_initial_chunk_size > 0
 
     # Dynamic IC: cache per request so boundaries stay stable for its lifetime.
     # Skipped when ramp is active (ramp replaces IC/steady entirely).

--- a/vllm_omni/model_executor/stage_input_processors/tts_utils.py
+++ b/vllm_omni/model_executor/stage_input_processors/tts_utils.py
@@ -181,3 +181,19 @@ def extract_language_from_prompt(
     if isinstance(language, list) and language:
         return language
     return None
+
+
+def per_request_initial_chunk_size_override(request: Any, initial_codec_chunk_frames: int) -> tuple[int, bool]:
+    overridden = False
+    additional_information = getattr(request, "additional_information", None)
+    if (
+        additional_information is not None
+        and hasattr(additional_information, "entries")
+        and "initial_codec_chunk_frames" in additional_information.entries
+    ):
+        entry = additional_information.entries["initial_codec_chunk_frames"]
+        if entry.list_data is not None and len(entry.list_data) == 1:
+            initial_codec_chunk_frames = int(entry.list_data[0])
+            overridden = True
+
+    return initial_codec_chunk_frames, overridden


### PR DESCRIPTION
## Purpose

So that the per request override for initial_chunk_size is honored.

## Test Plan

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** 0dbf8fac3564829455738f6b729752eab1c20203

`pytest tests/model_executor/stage_input_processors/test_tts_utils.py`

## Test Result

`8 passed, 15 warnings in 0.02s`
