### PR TITLE
[Benchmark][aarch64] Video-MME parquet: read via duckdb (pyarrow 25 segfaults on aarch64 dict pages)

### DIFF
--- a/vllm_omni/benchmarks/data_modules/videomme_dataset.py
+++ b/vllm_omni/benchmarks/data_modules/videomme_dataset.py
@@ -476,7 +476,14 @@ class VideoMMEDataset(BenchmarkDataset):
             raise ImportError("pandas is required to load Video-MME parquet") from e
         if not path.is_file():
             raise FileNotFoundError(f"Video-MME parquet not found: {path}")
-        df = pd.read_parquet(path)
+        # aarch64 pyarrow 25 can segfault on dict-encoded pages; duckdb reader is safe.
+        try:
+            import duckdb
+
+            cur = duckdb.connect().execute(f"SELECT * FROM read_parquet('{path}')")
+            df = pd.DataFrame(cur.fetchall(), columns=[d[0] for d in cur.description])
+        except ImportError:
+            df = pd.read_parquet(path)
         self._set_rows([row.to_dict() for _, row in df.iterrows()])
 
     def _load_from_huggingface(self) -> None:


### PR DESCRIPTION
## Purpose

[Benchmark][aarch64] Video-MME parquet: read via duckdb (pyarrow 25 segfaults on aarch64 dict pages)

On aarch64 (Ascend 910, Linux aarch64, pyarrow 25.0.0), `pd.read_parquet` crashes — either a hard segfault or `Invalid: Index not in dictionary bounds` — when reading real-scale parquet files (dictionary-encoded pages), including files freshly written by the same pyarrow build. This makes the Video-MME data module unusable on aarch64: `vllm bench serve --dataset-name videomme` dies during dataset load before any request is issued.

This patch reads the parquet via duckdb (`SELECT * FROM read_parquet(...)`) when duckdb is importable, falling back to `pd.read_parquet` otherwise. duckdb's parquet reader does not hit the pyarrow dictionary-page bug and produces an identical DataFrame.

MiniCPM 昇腾挑战赛（子赛道 B）参赛队伍：梦归云帆（GitHub: Puiching-Memory）

## Test Plan

**vLLM Version:** 0.1.dev1+ge5588e49b (vllm-ascend, Ascend 910 aarch64)

**vLLM-Omni Commit:** 009b80d6 (minicpm-challenge)

- Before: `python -c "from vllm_omni.benchmarks.data_modules.videomme_dataset import ..."` → pyarrow segfault on `hf://datasets/lmms-lab/Video-MME` parquet shards (aarch64).
- After: dataset loads 900 rows; Video-MME bench runs end-to-end (300 samples, concurrency 4) on Ascend 910.

## Test Result

- aarch64: Video-MME bench completes; parquet load time comparable to pd.read_parquet.
- x86 / non-duckdb environments: unchanged (fallback path preserved; duckdb is an optional import).
