### PR TITLE
[Bugfix][MiniCPM-o] Code2Wav: tolerate trailing cudagraph pad tokens in _split_segments

### DIFF
--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
@@ -310,11 +310,17 @@ class MiniCPMO45Code2Wav(nn.Module):
         normalized = [int(value) for value in counts]
         if any(value < 0 for value in normalized):
             raise _batch_error("negative_seq_token_count", counts=normalized)
-        if sum(normalized) != int(flat.numel()):
+        total = int(flat.numel())
+        expected = sum(normalized)
+        if expected < total:
+            # cudagraph/aclgraph decode pads the batch with trailing dummy tokens
+            # that are not codec data; trim them before segmenting.
+            flat = flat[:expected]
+        elif expected > total:
             raise _batch_error(
                 "seq_token_count_mismatch",
                 counts=normalized,
-                total=int(flat.numel()),
+                total=total,
             )
         return list(torch.split(flat, normalized))
 


### PR DESCRIPTION
## Purpose

[Bugfix][MiniCPM-o] Code2Wav: tolerate trailing cudagraph pad tokens in `_split_segments`

With cudagraph/aclgraph decode enabled for the MiniCPM-o 4.5 Code2Wav stage (stage 2), the model runner pads the token batch to the captured graph sizes. The trailing pad tokens are not codec data, but `_split_segments` required `sum(seq_token_counts) == input_ids.numel()` exactly, so the first short final chunk (e.g. 3 real tokens padded to 4) raised `MiniCPMO45Code2WavBatchError("seq_token_count_mismatch")` and killed the EngineCore mid-benchmark (service returned HTTP 500 for all subsequent requests).

Trim trailing pad tokens when the counts sum to less than the batch length; still raise when counts exceed the batch (a genuine producer/consumer protocol violation). This makes stage 2 usable with `enforce_eager: false` + PIECEWISE graphs, matching the other two stages.

MiniCPM 昇腾挑战赛（子赛道 B）参赛队伍：梦归云帆（GitHub: Puiching-Memory）

## Test Plan

**vLLM Version:** 0.1.dev1+ge5588e49b (vllm-ascend, Ascend 910 aarch64)

**vLLM-Omni Commit:** 009b80d6 (minicpm-challenge)

- Deploy `vllm_omni/deploy/minicpmo_4_5.yaml` with stage 2 changed to `enforce_eager: false` + `compilation_config.cudagraph_mode: PIECEWISE`, run `vllm bench serve --dataset-name seed-tts`.
- BEFORE: engine dies at the first request whose final codec chunk is short (`counts=[3], total=4`); only 9/32 requests complete before the service is dead.
- AFTER: 32/32 requests complete; audio output verified by the seed-tts WER evaluation path.

## Test Result

- seed-tts 32/32 success with stage-2 graphs enabled (Ascend 910).
- Eager-mode deployments (current default) are unaffected: the trim branch only triggers when padding is present.
