### PR TITLE
[BugFix] Don't fail the TTS ratchet when the branch count goes down

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,10 @@ repos:
       entry: python tools/pre_commit/check_tts_adapter.py
       language: python
       pass_filenames: false
-      files: ^vllm_omni/entrypoints/openai/(serving_speech\.py|tts_adapters/__init__\.py)$
+      files: ^(vllm_omni/entrypoints/openai/(serving_speech\.py|tts_adapters/__init__\.py)|tools/pre_commit/check_tts_adapter\.py)$
+      # The budget-is-now-slack reminder is printed on a PASSING run, and
+      # pre-commit hides output from passing hooks unless the hook is verbose.
+      verbose: true
 
     # Keep `suggestion` last
     - id: suggestion

--- a/tools/pre_commit/check_tts_adapter.py
+++ b/tools/pre_commit/check_tts_adapter.py
@@ -123,18 +123,29 @@ def _legacy_detectors(tree: ast.AST) -> list[tuple[int, str]]:
     return found
 
 
-def _check(label: str, path: Path, actual: int, budget: int, sample: list[str], budget_name: str) -> list[str]:
+def _check(
+    label: str,
+    path: Path,
+    actual: int,
+    budget: int,
+    sample: list[str],
+    budget_name: str,
+    notices: list[str],
+) -> list[str]:
     if actual > budget:
         listing = "\n".join(f"      {line}" for line in sample)
         return [
             f"{path}: {actual} {label} exceeds the budget of {budget}.\n{listing}\n\n{_GUIDANCE}\n",
         ]
     if actual < budget:
-        return [
-            f"{path}: {actual} {label}, down from a budget of {budget}. "
-            f"Lower {budget_name} to {actual} in {Path(__file__).relative_to(REPO_ROOT)} "
-            f"so the ratchet holds the new ground.",
-        ]
+        # Progress is never a build failure. Removing branches is the goal, so a
+        # PR that does it must not hand-edit this file to stay green -- nor break
+        # `main` for everyone else when it merges from a stale base.
+        notices.append(
+            f"{path}: {actual} {label}, below the budget of {budget}. "
+            f"Lower {budget_name} to {actual} in "
+            f"{Path(__file__).relative_to(REPO_ROOT)} to hold the new ground."
+        )
     return []
 
 
@@ -152,6 +163,7 @@ def main(argv: list[str] | None = None) -> int:
             print(f"check_tts_adapter: expected file not found: {path}", file=sys.stderr)
             return 1
 
+    notices: list[str] = []
     branches = _model_type_branches(ast.parse(serving_path.read_text()))
     detectors = _legacy_detectors(ast.parse(adapters_path.read_text()))
 
@@ -162,6 +174,7 @@ def main(argv: list[str] | None = None) -> int:
         MAX_MODEL_TYPE_BRANCHES,
         [f"line {lineno}: {src}" for lineno, src in branches],
         "MAX_MODEL_TYPE_BRANCHES",
+        notices,
     )
     errors += _check(
         "unmigrated model types in LEGACY_TTS_DETECTORS",
@@ -170,8 +183,11 @@ def main(argv: list[str] | None = None) -> int:
         MAX_LEGACY_DETECTORS,
         [f"line {lineno}: {name}" for lineno, name in detectors],
         "MAX_LEGACY_DETECTORS",
+        notices,
     )
 
+    for notice in notices:
+        print(f"check_tts_adapter: {notice}", file=sys.stderr)
     for error in errors:
         print(f"check_tts_adapter: {error}", file=sys.stderr)
     return 1 if errors else 0


### PR DESCRIPTION
## Purpose

The TTS ratchet I added in #5682 fails when the branch count goes **down**. That is backwards, and it broke `main`.

`check_tts_adapter.py` counts `self._tts_model_type ==` comparisons and compares them to a hardcoded budget. It errored if the count was over budget — correct — and also if it was under, with a message demanding someone hand-edit the constant. So removing a branch, which is the entire point of the tool, failed the build.

That is what happened. #5746 migrated the last legacy detector and the counts dropped to 27/0. It was green on its own base, which predated the ratchet, so nothing in its pipeline could have caught it. `main` went red on merge and stayed red **5h19m across 5 commits**:

| time (+0800) | commit | pre-commit |
|---|---|---|
| 08-09 21:30 | `ebe93f5d1` ratchet lands, budgets 29/1 | pass |
| 08-10 09:47 | `11f633aa8` #5746 migrates the last detector | **fail** |
| 08-10 10:02 | `36135ef09` LingBot-Video | fail |
| 08-10 10:04 | `e1aa6eae7` WeChat QR docs | fail |
| 08-10 11:26 | `e28bf8ff8` bagel CI | fail |
| 08-10 11:27 | `c588208cc` lora support | fail |
| 08-10 15:06 | `33dd9a5a3` #5843 carries the fix | pass |

Four unrelated PRs merged onto a red main, and #5843 — a diffusion scheduler refactor — had to bundle a change to my tool to get its own CI green. Sorry about that, @fhfuih.

## What changed

Only an increase fails now. A decrease prints a reminder and exits 0.

Two more problems turned up while testing the fix:

**The reminder was invisible.** pre-commit hides output from hooks that pass unless the hook is `verbose`. Verified on pre-commit 4.3.0 — a passing hook's stderr is shown only with `verbose: true`. Without it the ratchet would have kept its ceiling but lost all tightening pressure, which is worse than the behaviour I was trying to preserve.

**The checker could not check itself.** The hook's `files:` pattern listed only `serving_speech.py` and `tts_adapters/__init__.py`, so a commit that edited nothing but a budget constant ran no hook at all — `(no files to check) Skipped`. A typo'd budget would merge and land on whoever touched `serving_speech.py` next. Same shape as the bug above: the person who pays is not the person who caused it.

## Test plan

| budget vs actual | expected | exit |
|---|---|---|
| 40 > 27 (count went down) | pass with a reminder | 0 |
| 27 = 27 | pass silently | 0 |
| 5 < 27 (count went up) | **fail**, list the offenders | 1 |

Checked against `main` as-is (27/0) — exits 0.

## What this does not fix

The budget is still a hand-edited constant, so the check's verdict still depends on repo-wide counts and therefore on merge order. Two individually-green PRs can still collide. Both reviewers I consulted converged on the same better answer: derive the baseline from the merge base and require `current <= merge_base`, so the invariant is local to the PR and merge order stops mattering. That is a bigger change than a hotfix should carry, so I would rather land this and do it separately — happy to be told otherwise.

cc @sphinxkkkbc @Sy0307
