### PR TITLE
[Observability] Add MiniMax-H3 video/audio VAE decode timings

### DIFF
--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
@@ -148,6 +148,25 @@ def test_encoder_free_stage_skips_missing_component_during_dlo_registration():
     audio_vae.set_omni_component_cache.assert_called_once_with(cache)
 
 
+def test_h3_profiler_records_video_and_audio_vae_decode(monkeypatch):
+    from vllm_omni.diffusion.models.minimax_h3 import MiniMaxH3Pipeline
+    from vllm_omni.diffusion.profiler import diffusion_pipeline_profiler as profiler_module
+
+    pipeline = object.__new__(MiniMaxH3Pipeline)
+    nn.Module.__init__(pipeline)
+    pipeline.video_vae = SimpleNamespace(decode_latent=lambda latent: latent + 1)
+    pipeline.audio_vae = SimpleNamespace(decode_latent=lambda latent: latent + 2)
+    monkeypatch.setattr(profiler_module.current_omni_platform, "is_available", lambda: False)
+
+    pipeline.setup_diffusion_pipeline_profiler(enable_diffusion_pipeline_profiler=True)
+
+    assert pipeline.video_vae.decode_latent(1) == 2
+    assert pipeline.audio_vae.decode_latent(1) == 3
+    assert pipeline.stage_durations["MiniMaxH3Pipeline.video_vae.decode_latent"] >= 0
+    assert pipeline.stage_durations["MiniMaxH3Pipeline.audio_vae.decode_latent"] >= 0
+    assert "decode" in MiniMaxH3Pipeline._PROFILER_TARGETS
+
+
 def _write_partition_index(path, *, partition, tasks):
     path.mkdir(parents=True)
     (path / "model_index.json").write_text(

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
@@ -100,6 +100,25 @@ def test_pipeline_import_registry_and_component_discovery():
     assert MiniMaxH3Pipeline._vae_modules == ["video_vae", "audio_vae"]
 
 
+def test_h3_profiler_records_video_and_audio_vae_decode(monkeypatch):
+    from vllm_omni.diffusion.models.minimax_h3 import MiniMaxH3Pipeline
+    from vllm_omni.diffusion.profiler import diffusion_pipeline_profiler as profiler_module
+
+    pipeline = object.__new__(MiniMaxH3Pipeline)
+    nn.Module.__init__(pipeline)
+    pipeline.video_vae = SimpleNamespace(decode_latent=lambda latent: latent + 1)
+    pipeline.audio_vae = SimpleNamespace(decode_latent=lambda latent: latent + 2)
+    monkeypatch.setattr(profiler_module.current_omni_platform, "is_available", lambda: False)
+
+    pipeline.setup_diffusion_pipeline_profiler(enable_diffusion_pipeline_profiler=True)
+
+    assert pipeline.video_vae.decode_latent(1) == 2
+    assert pipeline.audio_vae.decode_latent(1) == 3
+    assert pipeline.stage_durations["MiniMaxH3Pipeline.video_vae.decode_latent"] >= 0
+    assert pipeline.stage_durations["MiniMaxH3Pipeline.audio_vae.decode_latent"] >= 0
+    assert "decode" in MiniMaxH3Pipeline._PROFILER_TARGETS
+
+
 def _write_partition_index(path, *, partition, tasks):
     path.mkdir(parents=True)
     (path / "model_index.json").write_text(

--- a/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
+++ b/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
@@ -540,6 +540,8 @@ class MiniMaxH3Pipeline(
         "_encode_video_audio_conditions",
         "diffuse",
         "decode",
+        "video_vae.decode_latent",
+        "audio_vae.decode_latent",
     ]
     dummy_run_num_frames: ClassVar[int] = 0
 

--- a/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
+++ b/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
@@ -681,6 +681,8 @@ class MiniMaxH3Pipeline(
         "prepare_encode",
         "denoise_step",
         "post_decode",
+        "video_vae.decode_latent",
+        "audio_vae.decode_latent",
     ]
     dummy_run_num_frames: ClassVar[int] = 0
     # Only distilled releases pin a schedule, so the default keeps the legacy


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
 

- Keep the existing aggregate `decode` timing.
- Add `video_vae.decode_latent` and `audio_vae.decode_latent` timings.
- Add contract coverage for both profiler targets.

The new targets are active only with `--enable-diffusion-pipeline-profiler`; normal serving is unchanged.

Related to #5948.

## Results

Configuration: 1× NVIDIA B300, BF16, `TORCH_SDPA`, eager mode, VAE tiling, one warmup followed by two measured requests.
### FL2VA (T2VA)

| Metric | Mean |
|---|---:|
| `encode_prompt` | 0.023s |
| `diffuse` | 43.277s |
| `video_vae.decode_latent` | 8.225s |
| `audio_vae.decode_latent` | 0.047s |
| `decode` | 8.273s |
| E2E | 55.258s |
| Peak memory | 139846 MiB |

### Ref2VA

| Metric | Mean |
|---|---:|
| `_prepare_reference_videos` | 1.008s |
| `encode_prompt` | 3.805s |
| `_encode_video_conditions` | 18.315s |
| `_encode_video_audio_conditions` | 0.191s |
| `diffuse` | 117.206s |
| `video_vae.decode_latent` | 4.783s |
| `audio_vae.decode_latent` | 0.031s |
| `decode` | 4.814s |
| E2E | 147.467s |
| Peak memory | 155646 MiB |
## Tests

```text
tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py: 86 passed
git diff --check: PASS
## Test Plan

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
