### PR TITLE
[Perf][Diffusion] Add auto stacked tiling for MiniMax-H3 VAE

### DIFF
--- a/tests/diffusion/model_loader/test_diffusers_loader.py
+++ b/tests/diffusion/model_loader/test_diffusers_loader.py
@@ -142,6 +142,54 @@ def test_initialize_model_sets_current_diffusion_config_during_model_constructio
     assert get_current_diffusion_config_or_none() is None
 
 
+def test_configure_vae_stack_tiling_enables_tiling_and_native_capability():
+    from vllm_omni.diffusion.registry import _configure_vae_stack_tiling
+
+    calls = []
+    vae = SimpleNamespace(
+        supports_stack_tiling=True,
+        set_stack_tiling=lambda enabled: calls.append(enabled),
+    )
+    model = SimpleNamespace(vae=vae)
+    od_config = SimpleNamespace(
+        model_class_name="MiniMaxH3Pipeline",
+        vae_stack_tiling="auto",
+        vae_use_tiling=False,
+    )
+
+    _configure_vae_stack_tiling(model, od_config)
+
+    assert od_config.vae_use_tiling is True
+    assert calls == ["auto"]
+
+
+def test_configure_vae_stack_tiling_rejects_unsupported_vae():
+    from vllm_omni.diffusion.registry import _configure_vae_stack_tiling
+
+    od_config = SimpleNamespace(
+        model_class_name="UnsupportedPipeline",
+        vae_stack_tiling="true",
+        vae_use_tiling=False,
+    )
+
+    with pytest.raises(ValueError, match="does not declare stacked-tiling support"):
+        _configure_vae_stack_tiling(SimpleNamespace(vae=SimpleNamespace()), od_config)
+
+
+def test_configure_vae_stack_tiling_auto_falls_back_for_unsupported_vae():
+    from vllm_omni.diffusion.registry import _configure_vae_stack_tiling
+
+    od_config = SimpleNamespace(
+        model_class_name="UnsupportedPipeline",
+        vae_stack_tiling="auto",
+        vae_use_tiling=False,
+    )
+
+    _configure_vae_stack_tiling(SimpleNamespace(vae=SimpleNamespace()), od_config)
+
+    assert od_config.vae_use_tiling is False
+
+
 def test_load_model_custom_pipeline_sets_current_diffusion_config(monkeypatch):
     import vllm_omni.diffusion.model_loader.diffusers_loader as loader_mod
 

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
@@ -119,6 +119,63 @@ def test_h3_profiler_records_video_and_audio_vae_decode(monkeypatch):
     assert "decode" in MiniMaxH3Pipeline._PROFILER_TARGETS
 
 
+def test_h3_video_vae_exposes_native_stack_tiling_capability():
+    from vllm_omni.diffusion.models.minimax_h3.vae import MiniMaxH3VideoVAE
+
+    vae = object.__new__(MiniMaxH3VideoVAE)
+    nn.Module.__init__(vae)
+    vae.model = SimpleNamespace(stack_tiling=False)
+    vae.stack_tiling_mode = "false"
+
+    assert vae.supports_stack_tiling
+    vae.set_stack_tiling(True)
+    assert vae.model.stack_tiling is True
+    vae.set_stack_tiling(False)
+    assert vae.model.stack_tiling is False
+
+
+@pytest.mark.parametrize(
+    ("parallel_size", "tile_rows", "tile_columns", "expected"),
+    [
+        (1, 1, 2, True),
+        (2, 1, 2, False),
+        (2, 2, 2, True),
+        (4, 2, 4, True),
+    ],
+)
+def test_h3_video_vae_auto_stacks_only_multiple_local_tiles(parallel_size, tile_rows, tile_columns, expected):
+    from vllm_omni.diffusion.models.minimax_h3.vae import MiniMaxH3VideoVAE
+
+    def split_tiles(input_len, is_decoder=False):
+        assert is_decoder
+        count = tile_rows if input_len == 16 else tile_columns
+        return list(range(count)), [1] * count, [0] * max(0, count - 1)
+
+    vae = object.__new__(MiniMaxH3VideoVAE)
+    nn.Module.__init__(vae)
+    vae.model = SimpleNamespace(
+        stack_tiling=False,
+        vae_ratio=16,
+        split_tiles=split_tiles,
+    )
+    vae.parallel_size = parallel_size
+    vae.stack_tiling_mode = "auto"
+    latent = torch.zeros(1, 32, 1, 1, 2)
+
+    assert vae._should_stack_decode_tiles(latent) is expected
+
+
+def test_h3_video_vae_rejects_remote_without_stack_tiling():
+    from vllm_omni.diffusion.models.minimax_h3.vae import MiniMaxH3VideoVAE
+
+    vae = object.__new__(MiniMaxH3VideoVAE)
+    nn.Module.__init__(vae)
+    vae.model = SimpleNamespace()
+
+    with pytest.raises(RuntimeError, match="does not expose stack_tiling"):
+        vae.set_stack_tiling(True)
+
+
 def _write_partition_index(path, *, partition, tasks):
     path.mkdir(parents=True)
     (path / "model_index.json").write_text(

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
@@ -100,6 +100,25 @@ def test_pipeline_import_registry_and_component_discovery():
     assert MiniMaxH3Pipeline._vae_modules == ["video_vae", "audio_vae"]
 
 
+def test_h3_profiler_records_video_and_audio_vae_decode(monkeypatch):
+    from vllm_omni.diffusion.models.minimax_h3 import MiniMaxH3Pipeline
+    from vllm_omni.diffusion.profiler import diffusion_pipeline_profiler as profiler_module
+
+    pipeline = object.__new__(MiniMaxH3Pipeline)
+    nn.Module.__init__(pipeline)
+    pipeline.video_vae = SimpleNamespace(decode_latent=lambda latent: latent + 1)
+    pipeline.audio_vae = SimpleNamespace(decode_latent=lambda latent: latent + 2)
+    monkeypatch.setattr(profiler_module.current_omni_platform, "is_available", lambda: False)
+
+    pipeline.setup_diffusion_pipeline_profiler(enable_diffusion_pipeline_profiler=True)
+
+    assert pipeline.video_vae.decode_latent(1) == 2
+    assert pipeline.audio_vae.decode_latent(1) == 3
+    assert pipeline.stage_durations["MiniMaxH3Pipeline.video_vae.decode_latent"] >= 0
+    assert pipeline.stage_durations["MiniMaxH3Pipeline.audio_vae.decode_latent"] >= 0
+    assert "decode" in MiniMaxH3Pipeline._PROFILER_TARGETS
+
+
 def _write_partition_index(path, *, partition, tasks):
     path.mkdir(parents=True)
     (path / "model_index.json").write_text(

--- a/tests/entrypoints/test_async_omni_diffusion_config.py
+++ b/tests/entrypoints/test_async_omni_diffusion_config.py
@@ -284,6 +284,28 @@ def test_serve_cli_accepts_diffusion_pipeline_profiler_flag():
     assert stage_cfg["engine_args"]["enable_diffusion_pipeline_profiler"] is True
 
 
+def test_serve_cli_forwards_vae_stack_tiling():
+    parser = TrackingArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    OmniServeCommand().subparser_init(subparsers)
+
+    args = parser.parse_args(
+        [
+            "serve",
+            "MiniMaxAI/MiniMax-H3",
+            "--omni",
+            "--vae-stack-tiling",
+            "auto",
+        ]
+    )
+
+    explicit_kwargs = args.get_explicit_kwargs_dict()
+    stage_cfg = AsyncOmniEngine._create_default_diffusion_stage_cfg(explicit_kwargs)[0]
+
+    assert args.vae_stack_tiling == "auto"
+    assert stage_cfg["engine_args"]["vae_stack_tiling"] == "auto"
+
+
 def test_serve_cli_forwards_distributed_offload_residency():
     """Ensure the two-GPU DLO placement controls reach the diffusion stage."""
     parser = TrackingArgumentParser()

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -573,6 +573,7 @@ class _DiffusionConfigProjection:
     fa_deterministic: bool = False
     vae_use_slicing: bool = False
     vae_use_tiling: bool = False
+    vae_stack_tiling: Literal["auto", "true", "false"] = "false"
     mask_strategy_file_path: str | None = None
     skip_time_steps: int = 15
     VSA_sparsity: float = 0.0

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -12,7 +12,7 @@ from collections.abc import Callable
 from dataclasses import asdict, dataclass, field, fields
 from enum import Enum
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import Any, Literal, NamedTuple
 
 from transformers import PretrainedConfig
 from vllm.logger import init_logger
@@ -401,6 +401,7 @@ class StageDeployConfig:
     step_execution: bool | None = None
     vae_use_slicing: bool | None = None
     vae_use_tiling: bool | None = None
+    vae_stack_tiling: Literal["auto", "true", "false"] | None = None
     boundary_ratio: float | None = None
     flow_shift: float | None = None
     diffusion_kv_cache_dtype: str | None = None

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -8,7 +8,7 @@ import random
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field, fields
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import diffusers
 import huggingface_hub
@@ -711,6 +711,7 @@ class OmniDiffusionConfig:
     # VAE memory optimization parameters
     vae_use_slicing: bool = False
     vae_use_tiling: bool = False
+    vae_stack_tiling: Literal["auto", "true", "false"] = "false"
 
     # STA (Sliding Tile Attention) parameters
     mask_strategy_file_path: str | None = None

--- a/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
+++ b/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
@@ -540,6 +540,8 @@ class MiniMaxH3Pipeline(
         "_encode_video_audio_conditions",
         "diffuse",
         "decode",
+        "video_vae.decode_latent",
+        "audio_vae.decode_latent",
     ]
     dummy_run_num_frames: ClassVar[int] = 0
 

--- a/vllm_omni/diffusion/models/minimax_h3/vae.py
+++ b/vllm_omni/diffusion/models/minimax_h3/vae.py
@@ -7,7 +7,7 @@ import importlib
 import json
 from contextlib import AbstractContextManager
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import torch
 import torch.distributed as dist
@@ -105,6 +105,8 @@ class _AudioVAEDeterminismContext(AbstractContextManager):
 class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
     """Adapter around the checkpoint's native parallel-tiled video VAE."""
 
+    supports_stack_tiling: ClassVar[bool] = True
+
     def __init__(
         self,
         component_path: str,
@@ -136,6 +138,29 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
         self.use_slicing = False
         self.parallel_size = 1
         self.device_module = torch.get_device_module()
+        self.stack_tiling_mode = "false"
+
+    def set_stack_tiling(self, mode: str | bool) -> None:
+        if not hasattr(self.model, "stack_tiling"):
+            raise RuntimeError("MiniMax H3 video VAE remote model does not expose stack_tiling")
+        if isinstance(mode, bool):
+            mode = "true" if mode else "false"
+        if mode not in ("auto", "true", "false"):
+            raise ValueError(f"invalid VAE stacked-tiling mode: {mode!r}")
+        self.stack_tiling_mode = mode
+        self.model.stack_tiling = mode == "true"
+
+    def _should_stack_decode_tiles(self, latent: torch.Tensor) -> bool:
+        if self.stack_tiling_mode != "auto":
+            return self.stack_tiling_mode == "true"
+
+        ratio = int(self.model.vae_ratio)
+        height = int(latent.shape[-2]) * ratio
+        width = int(latent.shape[-1]) * ratio
+        y_idx, _, _ = self.model.split_tiles(height, is_decoder=True)
+        x_idx, _, _ = self.model.split_tiles(width, is_decoder=True)
+        global_tile_count = len(y_idx) * len(x_idx)
+        return global_tile_count >= 2 * self.parallel_size
 
     def load_to_device(self) -> None:
         if self._stager is not None:
@@ -293,7 +318,12 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
             device=latent.device,
             dtype=latent.dtype,
         ).view(1, channels, 1, 1, 1)
-        decoded = self.model.decode_base(latent * std + mean)
+        previous_stack_tiling = self.model.stack_tiling
+        self.model.stack_tiling = self._should_stack_decode_tiles(latent)
+        try:
+            decoded = self.model.decode_base(latent * std + mean)
+        finally:
+            self.model.stack_tiling = previous_stack_tiling
         frames = self.model.processor.revert_tensor(decoded)
         if frames.ndim == 4:
             frames = frames.unsqueeze(0).transpose(1, 2)

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -352,6 +352,37 @@ def _prepare_diffusion_quant_config(
     configure_quant_config(quant_config, model_class)
 
 
+def _configure_vae_stack_tiling(model: nn.Module, od_config: OmniDiffusionConfig) -> None:
+    mode = getattr(od_config, "vae_stack_tiling", "false")
+    if isinstance(mode, bool):
+        mode = "true" if mode else "false"
+    if mode not in ("auto", "true", "false"):
+        raise ValueError(f"invalid vae_stack_tiling mode: {mode!r}")
+    if mode == "false":
+        return
+
+    vae = getattr(model, "vae", None)
+    if vae is None or not getattr(vae, "supports_stack_tiling", False):
+        if mode == "auto":
+            logger.info(
+                "VAE stacked tiling auto mode is unavailable for %s; using sequential tiles.",
+                od_config.model_class_name,
+            )
+            return
+        raise ValueError(
+            f"vae_stack_tiling was requested, but {od_config.model_class_name} does not declare stacked-tiling support"
+        )
+    setter = getattr(vae, "set_stack_tiling", None)
+    if not callable(setter):
+        raise ValueError("vae_stack_tiling was requested, but the VAE does not provide set_stack_tiling()")
+
+    if not od_config.vae_use_tiling:
+        logger.info("vae_stack_tiling requires vae_use_tiling; automatically enabling it.")
+        od_config.vae_use_tiling = True
+    setter(mode)
+    logger.info("VAE stacked tiling mode set to %s for %s.", mode, od_config.model_class_name)
+
+
 def initialize_model(
     od_config: OmniDiffusionConfig,
 ) -> nn.Module:
@@ -392,6 +423,8 @@ def initialize_model(
                 vae_pp_size,
             )
             od_config.vae_use_tiling = True
+
+        _configure_vae_stack_tiling(model, od_config)
 
         # Configure VAE memory optimization settings from config
         if hasattr(model, "vae") and hasattr(model.vae, "use_slicing"):

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -3,7 +3,7 @@ import json
 import os
 import tempfile
 from dataclasses import dataclass, field, fields
-from typing import Any
+from typing import Any, Literal
 
 from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
 from vllm.logger import init_logger
@@ -491,6 +491,7 @@ class OrchestratorArgs:
     step_execution: bool = False
     vae_use_slicing: bool = False
     vae_use_tiling: bool = False
+    vae_stack_tiling: Literal["auto", "true", "false"] = "false"
     enable_multithread_weight_load: bool = True
     num_weight_load_threads: int = 4
     enable_cpu_offload: bool = False

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1026,6 +1026,7 @@ class AsyncOmniEngine:
             "request_batch_max_wait_ms": kwargs.get("request_batch_max_wait_ms", 0.0),
             "vae_use_slicing": kwargs.get("vae_use_slicing", False),
             "vae_use_tiling": kwargs.get("vae_use_tiling", False),
+            "vae_stack_tiling": kwargs.get("vae_stack_tiling", "false"),
             "cache_backend": cache_backend,
             "cache_config": cache_config,
             "enable_cache_dit_summary": kwargs.get("enable_cache_dit_summary", False),

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -629,6 +629,15 @@ class OmniServeCommand(CLISubcommand):
             action="store_true",
             help="Enable VAE tiling for memory optimization (useful for mitigating OOM issues).",
         )
+        omni_config_group.add_argument(
+            "--vae-stack-tiling",
+            choices=("auto", "true", "false"),
+            default="false",
+            help=(
+                "Batch native VAE tiles into fewer model calls. 'auto' enables it "
+                "when each VAE-parallel rank has multiple tiles (default: false)."
+            ),
+        )
 
         # Parallel weight loading (faster diffusion startup)
         omni_config_group.add_argument(


### PR DESCRIPTION
Depends on #6014. Tested together with #5979; this PR currently includes #6014's commit and will be rebased after it lands.

## Summary

- Add `--vae-stack-tiling {auto,true,false}` (default: `false`).
- Add a capability-gated stacked-tiling hook and wire MiniMax-H3's native implementation.
- In `auto`, stack decode tiles only when every VAE-parallel rank receives at least two tiles; otherwise keep sequential decoding.

## Benchmark

MiniMax-H3 FL2VA on B300 GPUs, eager + TORCH_SDPA, 8.7 s video, 2 denoising steps, 1 warmup + 5 measured runs. Video VAE is the mean; E2E is the median. Explicit `false` and `true` modes were compared.

| GPUs | Output | Tiles/rank | Video VAE (seq → stack) | VAE speedup | E2E (seq → stack) | E2E speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 384×224 | 2 | 0.526s → 0.459s | 12.6% | 1.481s → 1.401s | 5.4% |
| 1 | 672×384 | 8 | 2.333s → 1.932s | 17.2% | 4.708s → 4.269s | 9.3% |
| 1 | 1024×576 | 15 | 4.377s → 3.551s | 18.9% | 10.701s → 9.908s | 7.4% |
| 1 | 1344×768 | 28 | 8.153s → 6.552s | 19.6% | 22.335s → 20.781s | 7.0% |
| 2 | 384×224 | 1 | 0.292s → 0.291s | 0.4% | 1.287s → 1.303s | -1.2% |
| 2 | 672×384 | 4 | 1.318s → 1.090s | 17.3% | 4.296s → 4.072s | 5.2% |
| 2 | 1024×576 | 7–8 | 2.386s → 1.973s | 17.3% | 12.504s → 12.086s | 3.3% |
| 2 | 1344×768 | 14 | 4.605s → 3.676s | 20.2% | 30.254s → 29.328s | 3.1% |
| 4 | 384×224 | N/A | N/A | N/A | N/A | N/A |
| 4 | 672×384 | 2 | 0.674s → 0.584s | 13.4% | 2.898s → 2.824s | 2.6% |
| 4 | 1024×576 | 3–4 | 1.333s → 1.119s | 16.1% | 8.248s → 8.086s | 2.0% |
| 4 | 1344×768 | 7 | 2.319s → 1.909s | 17.7% | 17.669s → 17.220s | 2.5% |

`auto` stays sequential for the 2-GPU 384×224 case. The 4-GPU 384×224 case is unsupported because two global tiles cannot cover four VAE-parallel ranks.

Same-seed sequential and stacked 1344×768 outputs were byte-identical.

### With regional compile (#5979)

Two B300 GPUs, 1344×768, `dynamic=false`, 4 warmups + 8 measured runs:

| Metric | Compile + false | Compile + auto | Reduction |
|---|---:|---:|---:|
| Video VAE | 2.594s | 1.933s | 25.5% |
| Decode | 2.642s | 2.000s | 24.3% |
| E2E | 28.583s | 27.993s | 2.1% |
| Peak memory | 139390 MiB | 139390 MiB | 0 MiB |

Relative to the eager sequential Video VAE baseline (4.605s), regional compile + auto reduces Video VAE latency by 58.0%.

## Tests

- 10 focused tests passed.
- Pre-commit hooks passed.