### PR TITLE
[Bugfix] Wire MOSS-TTS-Realtime reference conditioning online

### DIFF
--- a/tests/entrypoints/openai_api/test_serving_speech.py
+++ b/tests/entrypoints/openai_api/test_serving_speech.py
@@ -1106,6 +1106,62 @@ class TestTTSMethods:
             ref_audio
         ) == speech_server._make_ref_audio_artifact_cache_key(np.asarray(first[0], dtype=np.float32), 24000)
 
+    def test_encode_moss_realtime_reference_keeps_sixteen_codebooks(self, speech_server, mocker: MockerFixture):
+        codec = mocker.MagicMock()
+        codec.batch_encode.return_value = SimpleNamespace(
+            audio_codes=torch.arange(16 * 3).reshape(16, 1, 3),
+            audio_codes_lengths=torch.tensor([2]),
+        )
+
+        codes = speech_server._encode_moss_realtime_wav_sync(codec, [0.0, 0.25, -0.25], 24000)
+
+        codec.batch_encode.assert_called_once()
+        assert codec.batch_encode.call_args.kwargs == {"num_quantizers": 16}
+        assert codes.shape == (2, 16)
+        assert torch.equal(codes, torch.arange(16 * 3).reshape(16, 3)[:, :2].transpose(0, 1))
+
+    @pytest.mark.asyncio
+    async def test_build_moss_realtime_params_conditions_prompt_on_reference(
+        self, speech_server, mocker: MockerFixture
+    ):
+        tokenizer = mocker.MagicMock()
+
+        def encode(text, *, add_special_tokens):
+            assert add_special_tokens is False
+            if text == "<|im_start|>assistant\n":
+                return [50, 51]
+            assert text == "Hello from Realtime"
+            return list(range(100, 115))
+
+        tokenizer.encode.side_effect = encode
+        processor = mocker.MagicMock()
+        system_grid = np.arange(2 * 17, dtype=np.int64).reshape(2, 17)
+        processor.make_ensemble.return_value = system_grid
+        audio_tokens = torch.arange(3 * 16).reshape(3, 16)
+        mocker.patch.object(
+            speech_server,
+            "_encode_moss_realtime_reference",
+            new=mocker.AsyncMock(return_value=(tokenizer, processor, audio_tokens)),
+        )
+        speech_server._moss_variant = "realtime"
+        request = OpenAICreateSpeechRequest(
+            input="Hello from Realtime",
+            ref_audio="data:audio/wav;base64,ZmFrZQ==",
+            max_new_tokens=96,
+        )
+
+        params = await speech_server._build_moss_tts_params(request)
+
+        np.testing.assert_array_equal(
+            processor.make_ensemble.call_args.kwargs["prompt_audio_tokens"],
+            audio_tokens.numpy(),
+        )
+        assert params["prompt_token_ids"] == [0, 17, 50, 51, *range(100, 112)]
+        assert params["codes"]["ref"].shape == (16, 16)
+        assert params["codes"]["ref"][-1, 0].item() == 1025
+        assert params["ids"] == {"all": [112, 113, 114]}
+        assert params["max_new_frames"] == [96]
+
     def test_precomputed_qwen3_voice_infers_base_without_ref_audio(self, speech_server):
         """Precomputed Qwen3 voices are reusable by name without per-request ref_audio."""
         speech_server._tts_model_type = "qwen3_tts"

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -1,12 +1,14 @@
 import asyncio
 import base64
 import hashlib
+import importlib.util
 import io
 import json
 import math
 import os
 import re
 import struct
+import sys
 import time
 from collections import OrderedDict
 from collections.abc import Mapping
@@ -1537,7 +1539,172 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
         self._moss_processor_cache = proc
         return proc
 
-    async def _build_moss_tts_params(self, request: OpenAICreateSpeechRequest) -> dict[str, Any]:
+    def _get_moss_realtime_components(self):
+        """Load the Realtime processor and reference codec on CPU.
+
+        ``MossTTSRealtimeProcessor`` is shipped as a standalone module rather
+        than an AutoProcessor, so the online path must load it explicitly.
+        The standalone reference codec stays on CPU; Stage 1 keeps its
+        independent GPU decoder instance.
+        """
+        cached = getattr(self, "_moss_realtime_components_cache", None)
+        if cached is not None:
+            return cached
+
+        from huggingface_hub import snapshot_download
+        from transformers import AutoModel, AutoTokenizer
+
+        model_id = self.engine_client.model_config.model
+        candidate_path = Path(model_id).expanduser()
+        model_path = (
+            candidate_path.resolve()
+            if candidate_path.is_dir()
+            else Path(
+                snapshot_download(
+                    repo_id=model_id,
+                    revision=getattr(self.engine_client.model_config, "revision", None),
+                )
+            )
+        )
+        processor_path = model_path / "processing_mossttsrealtime.py"
+        if not processor_path.is_file():
+            raise RuntimeError(
+                f"MOSS-TTS-Realtime processor module is missing: {processor_path}"
+            )
+        module_digest = hashlib.sha256(str(processor_path).encode()).hexdigest()[:12]
+        module_name = f"_vllm_omni_moss_tts_realtime_processor_{module_digest}"
+        module = sys.modules.get(module_name)
+        if module is None:
+            spec = importlib.util.spec_from_file_location(module_name, processor_path)
+            if spec is None or spec.loader is None:
+                raise RuntimeError(
+                    f"Cannot load MOSS-TTS-Realtime processor: {processor_path}"
+                )
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[module_name] = module
+            spec.loader.exec_module(module)
+
+        tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+        processor = module.MossTTSRealtimeProcessor(tokenizer=tokenizer)
+        codec_id = os.environ.get(
+            "MOSS_TTS_CODEC_PATH", "OpenMOSS-Team/MOSS-Audio-Tokenizer"
+        )
+        codec = AutoModel.from_pretrained(codec_id, trust_remote_code=True)
+        codec = codec.to("cpu").eval()
+        cached = (tokenizer, processor, codec, codec_id)
+        self._moss_realtime_components_cache = cached
+        return cached
+
+    @staticmethod
+    def _encode_moss_realtime_wav_sync(
+        codec: Any, wav_list: list[float], sr: int
+    ) -> torch.Tensor:
+        wav = torch.tensor(wav_list, dtype=torch.float32)
+        if sr != 24_000:
+            import torchaudio
+
+            wav = torchaudio.functional.resample(wav.unsqueeze(0), sr, 24_000).squeeze(
+                0
+            )
+        with torch.no_grad():
+            encoded = codec.batch_encode([wav], num_quantizers=16)
+        length = int(encoded.audio_codes_lengths[0].item())
+        codes = encoded.audio_codes[:, 0, :length].transpose(0, 1)
+        codes = codes.detach().to("cpu", dtype=torch.long).contiguous()
+        if codes.ndim != 2 or codes.shape[1] != 16 or codes.shape[0] < 1:
+            raise RuntimeError(
+                f"Invalid MOSS-TTS-Realtime reference codes shape: {tuple(codes.shape)}"
+            )
+        return codes
+
+    async def _encode_moss_realtime_reference(
+        self, ref_audio: str
+    ) -> tuple[Any, Any, torch.Tensor]:
+        wav_list, sr = await self._resolve_ref_audio(ref_audio)
+        tokenizer, processor, codec, codec_id = self._get_moss_realtime_components()
+        artifact_key = self._get_resolved_ref_audio_artifact_key(ref_audio)
+        if not artifact_key:
+            raise RuntimeError("MOSS-TTS-Realtime reference identity is unavailable")
+        cache_key = self._speaker_cache.make_cache_key(
+            f"ref:{artifact_key}",
+            model_type=f"moss_tts_realtime:{codec_id}:nq16:sr24000",
+        )
+        cached = self._speaker_cache.get(cache_key)
+        if cached is not None:
+            return tokenizer, processor, cached["codes"].clone()
+
+        inflight = getattr(self, "_moss_realtime_ref_code_inflight", None)
+        if inflight is None:
+            inflight = {}
+            self._moss_realtime_ref_code_inflight = inflight
+        task = inflight.get(cache_key)
+        if task is None:
+            encode_lock = getattr(self, "_moss_realtime_encode_lock", None)
+            if encode_lock is None:
+                encode_lock = asyncio.Lock()
+                self._moss_realtime_encode_lock = encode_lock
+
+            async def _encode_and_cache() -> torch.Tensor:
+                async with encode_lock:
+                    already_cached = self._speaker_cache.get(cache_key)
+                    if already_cached is not None:
+                        return already_cached["codes"].clone()
+                    codes = await asyncio.to_thread(
+                        self._encode_moss_realtime_wav_sync,
+                        codec,
+                        wav_list,
+                        sr,
+                    )
+                    self._speaker_cache.put(cache_key, {"codes": codes})
+                    return codes.clone()
+
+            task = asyncio.create_task(_encode_and_cache())
+            inflight[cache_key] = task
+        try:
+            return tokenizer, processor, (await task).clone()
+        finally:
+            if inflight.get(cache_key) is task:
+                inflight.pop(cache_key, None)
+
+    async def _build_moss_realtime_params(
+        self, request: OpenAICreateSpeechRequest
+    ) -> dict[str, Any]:
+        """Build the exact upstream ``(L, 17)`` conditioned prompt grid."""
+        if not request.ref_audio:
+            raise ValueError("MOSS-TTS-Realtime requires ref_audio")
+        tokenizer, processor, audio_tokens = await self._encode_moss_realtime_reference(
+            request.ref_audio
+        )
+        system_grid = processor.make_ensemble(prompt_audio_tokens=audio_tokens.numpy())
+
+        assistant_ids = tokenizer.encode(
+            "<|im_start|>assistant\n", add_special_tokens=False
+        )
+        assistant_grid = np.full((len(assistant_ids), 17), 1024, dtype=np.int64)
+        assistant_grid[:, 0] = assistant_ids
+
+        text_ids = tokenizer.encode(request.input or "", add_special_tokens=False)
+        if not text_ids:
+            raise ValueError("MOSS-TTS-Realtime input produced no text tokens")
+        prefill_text = min(len(text_ids), 12)
+        text_grid = np.full((prefill_text, 17), 1024, dtype=np.int64)
+        text_grid[:, 0] = text_ids[:prefill_text]
+        text_grid[-1, 1] = 1025
+
+        grid = np.concatenate((system_grid, assistant_grid, text_grid), axis=0)
+        params: dict[str, Any] = {
+            "prompt_token_ids": grid[:, 0].tolist(),
+            "codes": {"ref": torch.from_numpy(grid[:, 1:].copy()).to(torch.long)},
+        }
+        if len(text_ids) > prefill_text:
+            params["ids"] = {"all": list(text_ids[prefill_text:])}
+        if request.max_new_tokens is not None:
+            params["max_new_frames"] = [request.max_new_tokens]
+        return params
+
+    async def _build_moss_tts_params(
+        self, request: OpenAICreateSpeechRequest
+    ) -> dict[str, Any]:
         """Build the talker prompt + ``additional_information`` payload for any
         MOSS-TTS-family request (nano + 5 full variants).
 
@@ -1569,24 +1736,9 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
             params["prompt_audio_array"] = [[wav_list, sr]]
             return params
 
-        # ---- MOSS-TTS-Realtime: keep the old prompt_audio_array path ----
-        # ``AutoProcessor.from_pretrained`` doesn't auto-discover
-        # ``MossTTSRealtimeProcessor`` (no ``processor_config.json`` in the
-        # snapshot), and Realtime's prompt format diverges from MossTTSDelay
-        # (16-channel grid, separate per-step text feed). The
-        # ``prompt_audio_array`` shape lines up well enough with what the
-        # talker reads for short prompts; full Realtime support needs a
-        # separate processor.from_module path which we don't wire here.
+        # ---- MOSS-TTS-Realtime: explicit processor + codec path ----
         if v == "realtime":
-            params: dict[str, Any] = {
-                "text": [request.input or ""],
-                "mode": ["voice_clone"],
-            }
-            if request.max_new_tokens is not None:
-                params["max_new_frames"] = [request.max_new_tokens]
-            wav_list, sr = await self._resolve_ref_audio(request.ref_audio)
-            params["prompt_audio_array"] = [[wav_list, sr]]
-            return params
+            return await self._build_moss_realtime_params(request)
 
         # ---- MossTTSDelay family (tts/ttsd/sound_effect/voice_generator)
         # and MOSS-TTS-Local-Transformer-v1.5: call the upstream processor


### PR DESCRIPTION
## Purpose

The online MOSS-TTS-Realtime path accepts and decodes `ref_audio`, but sends it
to the engine as `prompt_audio_array`. The Realtime talker does not consume that
field: it expects the processor-built `(L, 17)` prompt in `prompt_token_ids` and
`codes.ref`, with remaining text tokens in `ids.all`.

As a result `/v1/audio/speech` *requires* a reference clip and then generates
without conditioning on it. The current code says as much:

> `AutoProcessor.from_pretrained` doesn't auto-discover `MossTTSRealtimeProcessor`
> […] full Realtime support needs a separate `processor.from_module` path which
> we don't wire here.

This PR wires that path:

- Locate `processing_mossttsrealtime.py` in the exact local or Hugging Face model
  snapshot and instantiate `MossTTSRealtimeProcessor` explicitly.
- Encode the reference at 24 kHz with the standalone 16-codebook
  `OpenMOSS-Team/MOSS-Audio-Tokenizer` codec. `MOSS_TTS_CODEC_PATH` remains an
  optional local-model override.
- Build the same system/reference, assistant-header and 12-token prefill grid the
  upstream Realtime inference path uses, then forward remaining text in `ids.all`.
- Cache CPU reference codes by decoded-audio identity and codec contract, with a
  single-flight guard so concurrent requests encode a given reference once.
  Encoding runs outside the asyncio event loop.

## Test Plan

Added regressions for the 16-codebook orientation and for reference codes
reaching the online Realtime prompt. Verified `py_compile` on both changed
modules and that the branch merges cleanly with current `main`.

Behaviour was exercised in a downstream deployment of
`OpenMOSS-Team/MOSS-TTS-Realtime` on a single dedicated RTX 5090: two different
official reference clips, identical prompt text and identical seed, each
repeated.

A matched control run of the upstream Transformers implementation, same
checkpoint revision and sampling defaults, was used to check that the
constructed prompt does not introduce behaviour of its own.

**vLLM Version:** as pinned by vllm-omni `main` at the base commit below

**vLLM-Omni Commit:** `12a5f6fbf3ac`

## Test Result

- Two different reference voices produced byte-distinct PCM, where before the
  output was byte-identical regardless of the reference supplied.
- Each reference repeated bit-for-bit at a fixed seed. The companion
  request-scoped RNG change (#6034) was applied in the same canary, so the
  fixed-seed comparison isolates reference identity rather than process-global
  sampling state.
- The Transformers control reproduced the model's quiet-output and
  long-output tail at least as strongly as this path, so the constructed prompt
  is not the source of that behaviour.

A full pytest run was not available in the scratch environment used; CI coverage
would be welcome.

## Operational note

The processor and CPU reference codec are loaded lazily, and the first encode in
a fresh process is substantially slower than subsequent ones. Deployments that
care about first-request latency should issue a reference-conditioned warmup
before marking the endpoint ready; later references reuse the loaded codec and
the decoded-reference cache.
