### PR TITLE
[diffusion][bugfix] Honor LingBot model-scoped video dimensions

### DIFF
--- a/tests/diffusion/models/lingbot_video/test_request_utils.py
+++ b/tests/diffusion/models/lingbot_video/test_request_utils.py
@@ -340,6 +340,20 @@ def test_normalize_lingbot_request_model_size_overrides_sampling_dimensions():
     )
     assert (config.height, config.width) == (192, 320)
 
+    # Online TI2V requests carry model-scoped dimensions through extra_params.
+    config = _normalize(
+        {
+            "prompt": "motion",
+            "modalities": ["video"],
+            "multi_modal_data": {"image": Image.new("RGB", (320, 192))},
+        },
+        width=480,
+        height=480,
+        num_frames=9,
+        extra_args={"size": "320x192"},
+    )
+    assert (config.height, config.width) == (192, 320)
+
     # Without a prompt size, the sampling dimensions are used.
     config = _normalize(
         {"prompt": "motion", "modalities": ["video"]},

--- a/vllm_omni/diffusion/models/lingbot_video/request_utils.py
+++ b/vllm_omni/diffusion/models/lingbot_video/request_utils.py
@@ -410,10 +410,18 @@ def normalize_lingbot_request(
     else:
         num_frames = normalize_lingbot_num_frames(default_num_frames)
 
+    dimension_fields = dict(prompt_fields)
+    dimension_fields.update(
+        {
+            key: value
+            for key in ("width", "height", "size", "resolution", "ratio")
+            if (value := _pick(extra_args, key)) is not None
+        }
+    )
     width, height = resolve_lingbot_output_dimensions(
         sampling_width=sampling.width,
         sampling_height=sampling.height,
-        prompt_fields=prompt_fields,
+        prompt_fields=dimension_fields,
         default_width=default_width,
         default_height=default_height,
     )


### PR DESCRIPTION
## What broke

Nightly issue #6020 consistently failed `tests/e2e/online_serving/test_lingbot_video_moe.py::test_video_generation_modes_moe[default]` in TI2V mode. T2V passed, but TI2V produced a first frame whose shape did not match the requested `320x192` reference image.

## Reproduction

```bash
pytest -s -v \
  'tests/e2e/online_serving/test_lingbot_video_moe.py::test_video_generation_modes_moe[default]' \
  -m 'full_model and diffusion and H100' \
  --run-level=full_model
```

## Root cause

`/v1/videos` correctly merges `extra_params` into `sampling.extra_args`. LingBot dimension normalization only read structured prompt fields and top-level sampling `width`/`height`, so model-scoped `extra_params={"size": "320x192"}` was ignored. With top-level dimensions intentionally omitted for TI2V, generation fell back to `480x480`.

## Fix

- Merge non-null model-scoped `width`, `height`, `size`, `resolution`, and `ratio` values from `extra_args` into LingBot's dimension fields before resolution.
- Add a CPU regression case covering the online TI2V `extra_params.size` path and its precedence over sampling dimensions.

## Validation

- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- `pytest -q tests/diffusion/models/lingbot_video/test_request_utils.py` — 73 passed
- `pytest -s -v 'tests/e2e/online_serving/test_lingbot_video_moe.py::test_video_generation_modes_moe[default]' -m 'full_model and diffusion' --run-level=full_model` — 1 passed on 1x NVIDIA L20X (140 GiB; model load 65.58 GiB)

Fixes #6020
