### PR TITLE
[Bugfix][Frontend] Accept the msgpack-numpy package's numpy markers on the OpenPI endpoint

### DIFF
--- a/tests/entrypoints/openai_api/test_openpi_connection.py
+++ b/tests/entrypoints/openai_api/test_openpi_connection.py
@@ -68,7 +68,7 @@ def test_pack_and_unpack_round_trip_numpy_values():
     assert decoded["nested"][0]["done"] == np.bool_(True)
 
 
-def test_unpack_accepts_msgpack_numpy_marker_dicts():
+def test_unpack_accepts_vllm_native_marker_dicts():
     action = np.asarray([[1.0, 2.0]], dtype=np.float32)
     payload = {
         b"actions": {
@@ -86,6 +86,58 @@ def test_unpack_accepts_msgpack_numpy_marker_dicts():
     assert decoded[b"actions"].flags.writeable is True
     decoded[b"actions"][:, -1] = 0.0
     np.testing.assert_allclose(decoded[b"actions"], np.asarray([[1.0, 0.0]], dtype=np.float32))
+
+
+def test_unpack_accepts_msgpack_numpy_marker_dicts():
+    action = np.asarray([[1.0, 2.0]], dtype=np.float32)
+    payload = {
+        b"actions": {
+            b"nd": True,
+            b"type": action.dtype.str,
+            b"kind": b"",
+            b"shape": action.shape,
+            b"data": action.tobytes(),
+        }
+    }
+
+    decoded = openpi_connection._unpack_numpy(payload)
+
+    np.testing.assert_allclose(decoded[b"actions"], action)
+    assert decoded[b"actions"].dtype == np.float32
+
+
+def test_unpack_rejects_msgpack_numpy_structured_array_markers():
+    values = np.zeros(2, dtype=[("a", "<i4"), ("b", "<f4")])
+    payload = {
+        b"nd": True,
+        b"type": values.dtype.descr,
+        b"kind": b"V",
+        b"shape": values.shape,
+        b"data": values.tobytes(),
+    }
+
+    with pytest.raises(ValueError, match="Unsupported dtype"):
+        openpi_connection._unpack_numpy(payload)
+
+
+def test_unpack_msgpack_numpy_packed_observation():
+    msgpack_numpy = pytest.importorskip("msgpack_numpy")
+    obs = {
+        "observation/exterior_image_0_left": np.zeros((180, 320, 3), dtype=np.uint8),
+        "observation/joint_position": np.arange(7, dtype=np.float32),
+    }
+
+    decoded = openpi_connection._unpack(msgpack_numpy.packb(obs))
+
+    np.testing.assert_array_equal(
+        decoded["observation/exterior_image_0_left"],
+        obs["observation/exterior_image_0_left"],
+    )
+    np.testing.assert_allclose(
+        decoded["observation/joint_position"],
+        obs["observation/joint_position"],
+    )
+    assert decoded["observation/joint_position"].dtype == np.float32
 
 
 def test_unpack_accepts_openpi_client_ndarray_markers():

--- a/vllm_omni/entrypoints/openpi/connection.py
+++ b/vllm_omni/entrypoints/openpi/connection.py
@@ -17,6 +17,13 @@ Inbound payloads accept both the openpi-client markers above and the legacy
 vLLM-native markers:
     ndarray -> {nd: true, type, kind, shape, data}
     scalar  -> {nd: false, type, kind, data}
+
+`kind` is required on the `nd` markers because it is what separates them from a
+plain user mapping, but its value is dialect-specific: the vLLM-native markers
+carry the dtype kind character while the `msgpack-numpy` package leaves it empty
+for plain dtypes and sets "V" for structured ones. Both spellings are accepted.
+Scalars packed by `msgpack-numpy` omit `kind` entirely and are therefore left as
+mappings.
 """
 
 from __future__ import annotations
@@ -83,9 +90,14 @@ def _decode_vllm_numpy_marker(obj: dict[Any, Any]) -> Any:
     if nd is _MISSING or dtype is _MISSING or kind is _MISSING or data is _MISSING:
         return _MISSING
 
-    dtype_obj = np.dtype(_decode_marker_text(dtype))
     kind_text = _decode_marker_text(kind)
-    if dtype_obj.kind != kind_text:
+    # Structured markers carry a dtype descriptor list in `type`, so reject them
+    # before `np.dtype()` sees something it cannot parse.
+    if kind_text == "V":
+        raise ValueError("Unsupported dtype: structured arrays")
+
+    dtype_obj = np.dtype(_decode_marker_text(dtype))
+    if kind_text not in ("", dtype_obj.kind):
         raise ValueError(f"NumPy dtype marker kind mismatch: {dtype_obj.kind!r} != {kind_text!r}")
     if dtype_obj.kind in ("V", "O", "c"):
         raise ValueError(f"Unsupported dtype: {dtype_obj}")


### PR DESCRIPTION
## Purpose

`/v1/realtime/robot/openpi` rejects every array packed by the [`msgpack-numpy`](https://pypi.org/project/msgpack-numpy/) PyPI package — the observation fails to decode and the client gets `Invalid request payload` instead of an action chunk:

```
ValueError: NumPy dtype marker kind mismatch: 'f' != ''
```

This breaks a client we ship: MolmoSpaces' `DreamZeroWebsocketClient` packs with that package, so `examples/online_serving/dreamzero/molmospace_dreamzero_eval_demo.py` cannot reach the endpoint today.

**Root cause.** Three dialects share the `nd` marker shape but disagree on `kind`:

| Dialect | plain ndarray | `kind` |
|---|---|---|
| `openpi-client` | `{__ndarray__, dtype, shape, data}` | field absent |
| vLLM-native, from #4282 | `{nd, type, kind, shape, data}` | dtype kind character, e.g. `'f'` |
| `msgpack-numpy` package | `{nd, type, kind, shape, data}` | `b''` plain, `b'V'` structured |

`_decode_vllm_numpy_marker` required `kind == dtype.kind`, which no plain array from the package can satisfy. #4506 fixed the outbound half of this mismatch; the inbound half was listed in its suggested fix but never implemented.

**Fix.** Accept either spelling of `kind` — `""` or the dtype kind character. Reject the structured form before `np.dtype()` runs: with `kind == "V"` the package puts a dtype *descriptor list* in `type`, which would otherwise surface as an opaque `TypeError`.

`kind` stays **required** — it is what separates an array marker from a plain user mapping (`test_unpack_leaves_user_dict_without_numpy_kind_marker_unchanged` pins this). Outbound packing is unchanged: replies keep the `openpi-client` markers.

## Test Plan

**vLLM Version:** N/A — the fix is in the vLLM-Omni entrypoint and does not depend on the bundled vLLM version.

**vLLM-Omni Commit:** `03a56644`, base `4ab1b4ff`

CPU only, no GPU and no model load:

```bash
pytest -q tests/entrypoints/openai_api/test_openpi_connection.py
```

New and changed cases:

- `test_unpack_msgpack_numpy_packed_observation` — round-trip through the **real package** under `importorskip`. This is what would have caught the bug.
- `test_unpack_accepts_msgpack_numpy_marker_dicts` — hand-built `kind=b""`, unconditional.
- `test_unpack_rejects_msgpack_numpy_structured_array_markers` — structured form raises.
- The previous holder of the second name asserted the vLLM-native dialect, so it is renamed to `test_unpack_accepts_vllm_native_marker_dicts`. That naming is how the two dialects got conflated.

Direct reproduction of the reported failure:

```bash
pip install msgpack-numpy
python -c "
import msgpack_numpy, numpy as np
from vllm_omni.entrypoints.openpi.connection import _unpack
print(_unpack(msgpack_numpy.packb({'observation/joint_position': np.zeros(7, dtype=np.float32)})))
"
```

## Test Result

```
# base 4ab1b4ff
3 failed, 12 passed

# this branch
15 passed
```

The repro snippet raises the `ValueError` above on base and prints the decoded `float32` array on this branch. Environment: `msgpack-numpy 0.4.8`, `msgpack 1.2.1`, `numpy 2.4.6`, Python 3.12.

The real-package round-trip also covers what #5934 gives up by swapping `openpi-client` for a stand-in built from our own pack/unpack, and `msgpack-numpy` has no `numpy<2` pin so it fits that CI. The two PRs are independent.

## Not in scope

A compatibility fix, not a redesign of the marker handling:

- **Scalars.** The package's scalar branch emits `{nd: False, type, data}` with no `kind`, so it still decodes as a mapping. Fixing that means moving the discriminator off `kind` — e.g. onto the presence of the `nd` key — which reclassifies every inbound payload. Nothing in-tree hits it: DreamZero observations are arrays.
- **One inbound dialect.** The `nd` branch exists only for clients written against servers from the #4282 era. If there are none, dropping it and keeping `__ndarray__` only is less surface than maintaining two, which also matches the principle in #3554 that each policy takes its wire from its upstream community. Worth confirming with the author of #4282.
