### PR TITLE
Fix MiniCPM bug

### DIFF
--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -487,7 +487,16 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
             )
             while len(running_queue) > self.scheduler_max_num_seqs:
                 request = running_queue.pop()
-                request.status = RequestStatus.PREEMPTED
+                # Align with vLLM RECOMPUTE preemption semantics: marking the
+                # request PREEMPTED without resetting progress makes vLLM
+                # resume it via the cached-resume path with new_block_ids=None
+                # (KV not re-allocated), which crashes the runner's resumed
+                # branch (EngineDead). Reset to a fresh prefill (WAITING +
+                # num_computed_tokens=0 + is_prefill_chunk=True) so the
+                # scheduler re-allocates KV blocks on the next tick.
+                request.status = RequestStatus.WAITING
+                request.num_computed_tokens = 0
+                request.is_prefill_chunk = True
                 waiting_queue.prepend_requests([request])
             return
 


### PR DESCRIPTION
## Purpose

Fix MiniCPM-o streaming failures with chunk transfer when multiple concurrent
requests are preempted.

Previously, `chunk_transfer_adapter` marked requests as `PREEMPTED` without
fully resetting the request state required by RECOMPUTE semantics. As a result,
resumed requests could return `new_block_ids=None`, causing the resumed branch
to fail and potentially leading to `EngineDead`.

This change resets the request to `WAITING`, sets
`num_computed_tokens = 0`, and marks `is_prefill_chunk = True`, allowing the
scheduler to re-allocate KV blocks on the next scheduling tick.

## Test Plan

Tested MiniCPM-o streaming under multiple concurrency levels:

- C=1
- C=2
- C=4

Verified:

- request preemption and resume
- KV block re-allocation after preemption
- streaming completion
- codec output parity
- no `EngineDead` during the tested cases

**vLLM Version:** [fill in version if available]

**vLLM-Omni Commit:** d961b950

## Test Result

Before:

- C=2: 10/12 failed
- C=4: `EngineDead`

After:

- C=1/2/4 passed
- 42/42 test cases passed
- codec parity: 100%
- `finish_stream`: exactly 1 per request