### PR TITLE
[CI][MiniCPM-o] Align MiniCPM-o 4.5 online serving tests with minicpm…

### DIFF
--- a/tests/e2e/online_serving/helpers/minicpmo_4_5_duplex.py
+++ b/tests/e2e/online_serving/helpers/minicpmo_4_5_duplex.py
@@ -19,38 +19,11 @@ DEPLOY_CONFIG = modify_stage_config(
     get_deploy_config_path("minicpmo_4_5_duplex.yaml"),
     updates={
         "base_config": get_deploy_config_path("minicpmo_4_5.yaml"),
-        # Cap per-stage KV so Thinker/Talker/Code2Wav share one GPU with
-        # max_sessions=2. Talker must stay within its 4096 context so the
-        # 0.5 GiB budget passes vLLM's min-KV check at init.
+        # Talker context is 4096 (tts_config.max_position_embeddings); KV sizing
+        # is left automatic so duplex matches the simplex deploy profiles.
         "stages": {
-            0: {"kv_cache_memory_bytes": 6 * 1024 * 1024 * 1024},
-            1: {
-                "max_model_len": 4096,
-                "kv_cache_memory_bytes": 512 * 1024 * 1024,
-            },
-            2: {"kv_cache_memory_bytes": 256 * 1024 * 1024},
+            1: {"max_model_len": 4096},
         },
-        # Platform overrides apply after ordinary stage settings and would
-        # otherwise reinstate the base CUDA 2 GiB Talker default.
-        "platforms": {
-            "cuda": {
-                "stages": [
-                    {
-                        "stage_id": 1,
-                        "kv_cache_memory_bytes": 512 * 1024 * 1024,
-                    }
-                ]
-            }
-        },
-    },
-)
-CORE_DEPLOY_CONFIG = modify_stage_config(
-    DEPLOY_CONFIG,
-    updates={
-        "stages": {
-            0: {"enforce_eager": True},
-            1: {"enforce_eager": True},
-        }
     },
 )
 ASSET_DIR = Path(__file__).resolve().parents[3] / "assets" / "minicpmo_4_5"
@@ -65,17 +38,6 @@ SERVER_PARAMS = [
         OmniServerParams(
             model=MODEL,
             stage_config_path=DEPLOY_CONFIG,
-            use_stage_cli=False,
-            server_args=["--trust-remote-code"],
-        ),
-        id="three-stage-single-gpu",
-    )
-]
-CORE_SERVER_PARAMS = [
-    pytest.param(
-        OmniServerParams(
-            model=MODEL,
-            stage_config_path=CORE_DEPLOY_CONFIG,
             use_stage_cli=False,
             server_args=["--trust-remote-code"],
         ),
@@ -112,9 +74,11 @@ def validated_soft_interrupt_wav() -> Path:
 
 
 def resolve_ref_audio(model_prefix: str) -> Path:
-    if model_prefix:
-        model_root = Path(model_prefix) / MODEL
-    else:
+    # ``MODEL`` may be a local checkpoint directory instead of a Hub repo id
+    # (``Path("/prefix") / "/abs/path"`` collapses to the absolute path), so only
+    # fall back to the Hub cache when no such directory exists on disk.
+    model_root = Path(model_prefix) / MODEL if model_prefix else Path(MODEL)
+    if not model_root.is_dir():
         model_root = Path(snapshot_download(MODEL, local_files_only=True))
     ref_audio = model_root / REF_AUDIO_RELATIVE_PATH
     if not ref_audio.is_file():

--- a/tests/e2e/online_serving/test_minicpmo_4_5.py
+++ b/tests/e2e/online_serving/test_minicpmo_4_5.py
@@ -1,10 +1,7 @@
-"""
-E2E Online tests for MiniCPM-o 4.5 model with multimodal input and audio / text output.
+"""E2E online tests for MiniCPM-o 4.5 multimodal input and audio/text output.
 
-MiniCPM-o 4.5 is a three-stage pipeline: Stage 0 Thinker (text), Stage 1 Talker
-(TTS codec), Stage 2 Code2Wav (vocoder). The talker -> Code2Wav bridge supports
-both async_chunk (streaming) and full-payload (``--no-async-chunk``) modes, so the
-tests below exercise the sync path as well.
+Exercises async chunk streaming (``--async-chunk``) across separate Thinker,
+Talker, and Code2Wav stages.
 """
 
 import os
@@ -14,12 +11,17 @@ import pytest
 from tests.helpers.mark import hardware_test
 from tests.helpers.media import generate_synthetic_audio, generate_synthetic_image, generate_synthetic_video
 from tests.helpers.runtime import OmniServerParams, dummy_messages_from_mix_data
-from tests.helpers.stage_config import get_deploy_config_path
+from tests.helpers.stage_config import get_deploy_config_path, modify_stage_config
 
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
 _MODEL = "openbmb/MiniCPM-o-4_5"
-_CI_DEPLOY = get_deploy_config_path("minicpmo_4_5.yaml")
+_CI_DEPLOY = modify_stage_config(
+    get_deploy_config_path("minicpmo_4_5.yaml"),
+    updates={
+        "stages": {0: {"default_sampling_params.max_tokens": 64}, 1: {"default_sampling_params.max_tokens": 1024}}
+    },
+)
 
 test_params = [
     pytest.param(
@@ -27,12 +29,10 @@ test_params = [
             model=_MODEL,
             stage_config_path=_CI_DEPLOY,
             use_stage_cli=False,
-            server_args=[
-                "--trust-remote-code",
-            ],
+            server_args=["--trust-remote-code", "--async-chunk"],
         ),
-        id="default",
-    )
+        id="async_chunk",
+    ),
 ]
 
 
@@ -98,7 +98,7 @@ def test_text_to_text_001(omni_server, openai_client) -> None:
 def test_text_to_audio_001(omni_server, openai_client) -> None:
     """
     Test text-only input generating text + audio output via OpenAI API.
-    This exercises the talker TTS region detection and in-process token2wav vocoder.
+    This exercises Talker TTS region detection and the Code2Wav stage.
     Deploy Setting: default single GPU
     Input Modal: text
     Output Modal: text + audio
@@ -132,13 +132,21 @@ def test_audio_to_text_audio_001(omni_server, openai_client) -> None:
     messages = dummy_messages_from_mix_data(
         system_prompt=get_system_prompt(),
         audio_data_url=audio_data_url,
-        content_text=get_prompt("mix"),
+        content_text=get_prompt(),
     )
 
     request_config = {
         "model": omni_server.model,
         "messages": messages,
         "stream": True,
+        "key_words": {"text": ["Beijing"]},
+        "modalities": ["text", "audio"],
+        "extra_body": {
+            "chat_template_kwargs": {
+                "use_tts_template": True,
+                "enable_thinking": False,
+            }
+        },
     }
 
     openai_client.send_omni_request(request_config, request_num=get_max_batch_size())

--- a/tests/e2e/online_serving/test_minicpmo_4_5_duplex.py
+++ b/tests/e2e/online_serving/test_minicpmo_4_5_duplex.py
@@ -11,7 +11,6 @@ import pytest
 import websockets
 
 from tests.e2e.online_serving.helpers.minicpmo_4_5_duplex import (
-    CORE_SERVER_PARAMS,
     SERVER_PARAMS,
     demo_args,
     multi_session_args,
@@ -107,7 +106,7 @@ async def _run_protocol_smoke(*, url: str, model: str, ref_audio: Path) -> list[
 
 @pytest.mark.core_model
 @hardware_test(res={"cuda": "H100", "npu": "A3"}, num_cards=1)
-@pytest.mark.parametrize("omni_server", CORE_SERVER_PARAMS, indirect=True)
+@pytest.mark.parametrize("omni_server", SERVER_PARAMS, indirect=True)
 def test_duplex_websocket_protocol_smoke(omni_server, model_prefix: str) -> None:
     ref_audio = resolve_ref_audio(model_prefix)
     events = asyncio.run(
@@ -134,8 +133,12 @@ def test_duplex_single_session_response_required(omni_server, model_prefix: str,
         output_dir=tmp_path / "single_session",
     )
     args.turns = 2
+    # Every turn replays the same active-speech window as the first one. The default
+    # shorter follow-up window is a different mid-utterance slice, which the native
+    # duplex model may legitimately answer with "listen" instead of a response.
+    args.turn_duration_ms = [args.first_turn_ms] * args.turns
     result = asyncio.run(run_demo(args))
-    assert result["ok"] is True, json.dumps(result, ensure_ascii=False, indent=2)
+    assert result["ok"] is True
     assert result["audio_delta_count"] > 0
     assert result["done_count"] == 2
     assert result["error_count"] == 0
@@ -160,7 +163,7 @@ def test_duplex_two_sessions_resume_and_takeover(omni_server, model_prefix: str,
             )
         )
     )
-    assert result["ok"] is True, json.dumps(result, ensure_ascii=False, indent=2)
+    assert result["ok"] is True
     assert result["session_count"] == 2
     assert result["resume"]["ok"] is True
     assert result["takeover"]["ok"] is True

--- a/tests/e2e/online_serving/test_minicpmo_4_5_expansion.py
+++ b/tests/e2e/online_serving/test_minicpmo_4_5_expansion.py
@@ -2,6 +2,9 @@
 
 These cover modality combinations, separate Code2Wav behavior, sequential
 request isolation, longer audio output, and Chinese speech.
+
+Like Qwen3-Omni expansion, ``default`` exercises ``--no-async-chunk`` and
+``async_chunk`` exercises ``--async-chunk``.
 """
 
 import os
@@ -20,18 +23,27 @@ os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 _MODEL = "openbmb/MiniCPM-o-4_5"
 _CI_DEPLOY = get_deploy_config_path("minicpmo_4_5.yaml")
 
+# Deploy YAML defaults to ``async_chunk: true``; keep sync and async as
+# separate parametrizations so both handoff paths are exercised.
 test_params = [
     pytest.param(
         OmniServerParams(
             model=_MODEL,
             stage_config_path=_CI_DEPLOY,
             use_stage_cli=False,
-            server_args=[
-                "--trust-remote-code",
-            ],
+            server_args=["--trust-remote-code", "--no-async-chunk"],
         ),
         id="default",
-    )
+    ),
+    pytest.param(
+        OmniServerParams(
+            model=_MODEL,
+            stage_config_path=_CI_DEPLOY,
+            use_stage_cli=False,
+            server_args=["--trust-remote-code", "--async-chunk"],
+        ),
+        id="async_chunk",
+    ),
 ]
 
 


### PR DESCRIPTION
## Purpose
Fix : https://github.com/vllm-project/vllm-omni/issues/6047
Port MiniCPM-o 4.5 online-serving E2E test updates from `minicpm-challenge` onto `bugfix`, so CI exercises the intended async-chunk / duplex contracts more reliably.

Key changes:
- Core online suite now pins `--async-chunk` and caps Thinker/Talker `max_tokens` for CI runtime.
- Expansion suite parametrizes both `--no-async-chunk` and `--async-chunk` (same pattern as Qwen3-Omni).
- Audio→text+audio coverage adds keyword checks, modalities, and TTS template kwargs.
- Duplex helper drops hard-coded per-stage KV caps (keep Talker `max_model_len=4096`, auto KV sizing), removes eager-only `CORE_SERVER_PARAMS`, and fixes local-checkpoint `resolve_ref_audio` lookup.
- Duplex multi-turn response-required uses a stable turn window so follow-up turns are not flaky `listen` answers.

## Test Plan

**vLLM Version:** (fill)
**vLLM-Omni Commit:** (fill after push)

- [ ] `pytest -s -v tests/e2e/online_serving/test_minicpmo_4_5.py -m 'core_model and cuda'`
- [ ] `pytest -s -v tests/e2e/online_serving/test_minicpmo_4_5_expansion.py -m 'full_model and cuda'`
- [ ] `pytest -s -v tests/e2e/online_serving/test_minicpmo_4_5_duplex.py -m 'core_model and cuda'`
- [ ] `pytest -s -v tests/e2e/online_serving/test_minicpmo_4_5_duplex.py -m 'advanced_model and cuda'`

## Test Result

(fill after local/CI runs)
