### PR TITLE
[CI] Add L4 (nightly) Ascend NPU CI coverage for MiniMax-H3

### DIFF
--- a/.buildkite/npu/test-npu-nightly.yml
+++ b/.buildkite/npu/test-npu-nightly.yml
@@ -231,3 +231,23 @@ steps:
             buildkite-agent artifact upload "tests/dfx/perf/results/diffusion_result_*.json"
             buildkite-agent artifact upload "tests/dfx/perf/results/logs/*.log"
             exit $$EXIT
+      - label: ":full_moon: Diffusion X2V · Perf Test · MiniMax H3"
+        key: nightly-diffusion-x2v-performance-minimax-h3
+        timeout_in_minutes: 180
+        mirror_hardwares: a3_npu_8
+        env:
+          VLLM_WORKER_MULTIPROC_METHOD: spawn
+          VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
+          VLLM_OMNI_VIDEO_SYNC_TIMEOUT: "1800"
+          PYTHONDONTWRITEBYTECODE: "1"
+          HF_TOKEN: "${HF_TOKEN}"
+          DIFFUSION_ATTENTION_BACKEND: FLASH_ATTN
+        commands:
+          - export DIFFUSION_BENCHMARK_DIR=tests/dfx/perf/results
+          - |
+            set +e
+            pytest -s -v tests/dfx/perf/scripts/run_diffusion_benchmark.py -m 'npu and A3' --test-config-file tests/dfx/perf/tests/test_minimax_h3_vllm_omni.json
+            EXIT=$$?
+            buildkite-agent artifact upload "tests/dfx/perf/results/diffusion_result_*.json"
+            buildkite-agent artifact upload "tests/dfx/perf/results/logs/*.log"
+            exit $$EXIT

--- a/tests/dfx/perf/tests/test_minimax_h3_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_minimax_h3_vllm_omni.json
@@ -291,5 +291,68 @@
         }
       }
     ]
+  },
+  {
+    "test_name": "test_minimax_h3_t2va_npu_a3_8card",
+    "mark": [
+      {
+        "hardware_marks": {
+          "res": {
+            "npu": "A3"
+          },
+          "num_cards": 8
+        }
+      },
+      "full_model",
+      "diffusion"
+    ],
+    "description": "MiniMax-H3 T2VA text-to-video+audio on 8 Ascend A3 NPUs (USP8, encoder TP8, tiled VAE PP8, distributed layerwise offload)",
+    "server_type": "vllm-omni",
+    "benchmark_endpoint": "/v1/videos",
+    "server_params": {
+      "model": "MiniMaxAI/MiniMax-H3",
+      "serve_args": {
+        "trust-remote-code": true,
+        "num-gpus": 8,
+        "usp": 8,
+        "ring": 1,
+        "text-encoder-tp-size": 8,
+        "enable-distributed-layerwise-offload": true,
+        "vae-parallel-mode": "tile",
+        "vae-use-tiling": true,
+        "vae-patch-parallel-size": 8,
+        "diffusion-attention-backend": "FLASH_ATTN",
+        "stage-init-timeout": 1800,
+        "init-timeout": 1800,
+        "enable-diffusion-pipeline-profiler": true
+      }
+    },
+    "benchmark_params": [
+      {
+        "name": "1344x768_frames209_steps8",
+        "dataset": "random",
+        "task": "t2v",
+        "num-prompts": 1,
+        "max-concurrency": 1,
+        "warmup-requests": 1,
+        "warmup-concurrency": 1,
+        "seed": 42,
+        "random-request-config": [
+          {
+            "width": 1344,
+            "height": 768,
+            "prompt": "Cinematic drone shot pushing through misty mountain ridges at sunrise, golden light catching the clouds, slow and smooth.",
+            "num_inference_steps": 8,
+            "num_frames": 209,
+            "fps": 24,
+            "weight": 1
+          }
+        ],
+        "extra-body": {
+          "flow_shift": 12.0,
+          "extra_params": "{\"task\":\"t2va\",\"duration\":8.7,\"aspect_ratio\":\"16:9\",\"audio_flow_shift\":3.0}"
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
**Purpose**

Add L4 (nightly) Ascend NPU CI coverage for MiniMax-H3 T2VA inference.

- Add a dedicated MiniMax-H3 performance/smoke job to the NPU Diffusion X2V nightly pipeline.
- Run on 8 Ascend A3 NPUs with the validated H3 serving configuration: USP8, text-encoder TP8, tiled VAE PP8, distributed layerwise offload, and FLASH_ATTN.
- Add an NPU A3 × 8 benchmark case for a 1344×768, 209-frame, 8-step T2VA request.
- Preserve the existing trigger policy: the job runs for scheduled nightly builds or PRs labeled `nightly-test` / `diffusion-x2v-test`.

**Test Plan**

**vLLM Version:** N/A (CI/Buildkite configuration only)

**vLLM-Omni Commit:** e04210d6

No new pytest coverage — this change adds a Buildkite L4 job and its benchmark configuration.

Validation completed:

- `python3 -m json.tool tests/dfx/perf/tests/test_minimax_h3_vllm_omni.json`
- YAML syntax validation for `.buildkite/npu/test-npu-nightly.yml`
- `git diff --check`

Buildkite validation pending:

- Trigger the NPU nightly pipeline with `NIGHTLY=1`, or add the `nightly-test` / `diffusion-x2v-test` label to a PR.
- Confirm the `Diffusion X2V · Perf Test · MiniMax H3` job is scheduled on `a3_npu_8`.
- Confirm the H3 service starts with the expected 8-card configuration and the benchmark uploads result JSON and logs.

**Test Result**

Pending Buildkite NPU A3 × 8 validation. The full job cannot be exercised locally because it requires the NPU runner, CI image, and model access.