### PR TITLE
[New Model] Add Falcon Perception support

### DIFF
--- a/.buildkite/cuda/test-merge.yml
+++ b/.buildkite/cuda/test-merge.yml
@@ -184,6 +184,17 @@ steps:
           - pytest -s -v tests/e2e/online_serving/test_minicpmo_4_5_duplex.py -m 'advanced_model and cuda' --run-level 'advanced_model'
         mirror_hardwares: h100_1
 
+      - label: "Omni · Falcon Perception Offline Test"
+        source_file_dependencies:
+          - tests/e2e/offline_inference/test_falcon_perception.py
+          - vllm_omni/model_executor/models/falcon_perception/
+          - vllm_omni/model_executor/stage_input_processors/falcon_perception.py
+          - vllm_omni/deploy/falcon_perception.yaml
+        timeout_in_minutes: 20
+        commands:
+          - pytest -s -v tests/e2e/offline_inference/test_falcon_perception.py -m 'advanced_model and cuda' --run-level 'advanced_model'
+        mirror_hardwares: h100_1
+
       - label: "Diffusion · Qwen Image Test"
         source_file_dependencies:
           - tests/e2e/online_serving/test_qwen_image.py

--- a/.buildkite/cuda/test-ready.yml
+++ b/.buildkite/cuda/test-ready.yml
@@ -182,6 +182,19 @@ steps:
             "
         mirror_hardwares: h100_2
 
+      - label: "Omni · Falcon Perception Offline Test"
+        source_file_dependencies:
+          - tests/e2e/offline_inference/test_falcon_perception.py
+          - vllm_omni/model_executor/models/falcon_perception/
+          - vllm_omni/model_executor/stage_input_processors/falcon_perception.py
+          - vllm_omni/deploy/falcon_perception.yaml
+        commands:
+          - |
+            timeout 20m bash -c "
+              pytest -s -v tests/e2e/offline_inference/test_falcon_perception.py -m 'core_model' --run-level 'core_model'
+            "
+        mirror_hardwares: h100_2
+
       - label: "Omni · MiniCPM-o 4.5 Offline Test"
         source_file_dependencies:
           - tests/e2e/offline_inference/test_minicpmo_4_5.py

--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -70,6 +70,7 @@ th {
 | `DotsTTSForConditionalGeneration` | dots.tts | `rednote-hilab/dots.tts-soar` | ✅︎ | | | | — |
 | `MammothModa2ForConditionalGeneration` | MammothModa2-Preview | `bytedance-research/MammothModa2-Preview` | ✅︎ | ✅︎ | | | — |
 | `MammothModa2ForConditionalGeneration` | MammothModa2-Dev (AR-only image understanding) | `bytedance-research/MammothModa2-Dev` | ✅︎ | | | | — |
+| `FalconPerceptionForSegmentation` | Falcon Perception (image+text -> boxes and instance masks) | `tiiuae/Falcon-Perception` | ✅︎ | | | | [Repository](https://github.com/vllm-project/vllm-omni/blob/main/recipes/tiiuae/Falcon-Perception.md) |
 | `Flux2KleinPipeline` | FLUX.2-klein | `black-forest-labs/FLUX.2-klein-4B`, `black-forest-labs/FLUX.2-klein-9B` | ✅︎ | ✅︎ | ✅︎ | ✅︎ | — |
 | `FluxKontextPipeline` | FLUX.1-Kontext-dev | `black-forest-labs/FLUX.1-Kontext-dev` | ✅︎ | ✅︎ | | | — |
 | `FluxPipeline` | FLUX.1-dev | `black-forest-labs/FLUX.1-dev` | ✅︎ | ✅︎ | | ✅︎ | — |

--- a/examples/offline_inference/falcon_perception/README.md
+++ b/examples/offline_inference/falcon_perception/README.md
@@ -1,0 +1,146 @@
+# Falcon Perception — offline inference
+
+Image + text query → bounding boxes and per-instance segmentation masks.
+
+## Run
+
+```bash
+python examples/offline_inference/falcon_perception/end2end.py \
+    --model tiiuae/Falcon-Perception \
+    --image /path/to/photo.jpg \
+    --query "the red pepper" \
+    --out-dir /tmp/falcon_perception
+```
+
+Prints one normalised `(centre_x, centre_y, w, h)` box per instance and writes an
+overlay PNG with the masks drawn over the original image.
+
+## Many requests at once
+
+`end2end.py` runs a single request. `batch_inference.py` submits the whole set in
+**one** `omni.generate()` call so vLLM’s **scheduler** can keep up to
+`max_num_seqs` thinker requests **in flight** at once (continuous batching on a
+**paged** KV cache — not a fixed training-style batch tensor).
+
+A `for prompt in prompts: generate([prompt])` loop admits only one request per
+call, so stage 0 never overlaps prefill/decode across prompts and you measure
+serial latency, not throughput. Outputs may finish **out of order**; map them
+back by request id (as the script does), not by arrival order.
+
+Stage 1 (masks) still runs **once per request** after its thinker finishes; most
+wall time is usually stage-0 decode.
+
+```bash
+python examples/offline_inference/falcon_perception/batch_inference.py \
+    --model tiiuae/Falcon-Perception \
+    --manifest requests.jsonl \
+    --deploy-config falcon_perception.yaml \
+    --warmup 2 --passes 3 \
+    --out-dir /tmp/falcon_perception_batch
+```
+
+Requests come from `--image`/`--query` pairs (repeat both), a JSONL `--manifest`
+of `{"image": ..., "query": ...}` lines, or `--dataset` for a HuggingFace dataset
+with `image` and `expression` columns. It writes `results.json` (per-request
+instance counts, boxes, token ids, plus a throughput summary) and optional mask
+overlays.
+
+`falcon_perception.yaml` is the measured A100-80GB profile: `max_num_seqs: 4`
+on both stages, 16,384 batched prefill tokens, a ~236k-token stage-0 KV cache, a
+12 GiB AnyUp cache, and compiled AnyUp. Prefix caching is deliberately disabled
+because it changed dense-scene outputs. Do not assume that a larger
+`max_num_seqs` is faster: on the fixed 100-request PBench level-1 tuning set,
+the old reference-derived value of 128 took 84.0 s on its first pass, versus
+20.7 s at 4; warm passes at the tuned settings averaged 17.0 s (5.89 images/s).
+Retune the memory split for other GPUs or workloads.
+
+On the 20-sample PBench dense correctness check with prefix caching disabled,
+vLLM-Omni produced 3,691 masks versus 3,598 from the reference. Hungarian
+matching paired 3,591 masks at 0.8928 mean full-resolution IoU (0.9333 median).
+The two runs matched token streams on 4/20 samples and mask counts on 6/20.
+
+The shipped stage-0 profile uses `enforce_eager: false` with
+`compilation_config: {cudagraph_mode: FULL_DECODE_ONLY}` so autoregressive
+decode can use CUDA graphs. Edit a copy of the deploy YAML and pass
+`--deploy-config` only when changing nested compilation settings.
+
+Only the `generate()` call is timed; model load, `--warmup` requests, and writing
+overlays sit outside the measured region.
+
+## Prompt format
+
+The prompt is a fixed string, **not** a chat template. Both markers are required:
+
+```
+<|image|>Segment these expressions in the image:<|start_of_query|>{QUERY}<|REF_SEG|>
+```
+
+- `<|image|>` is replaced by the processor with the structural token run
+  (`<image_cls>` + 4 register tokens) plus one token per 16×16 patch, then
+  `<end_of_image>`. Pass the image through `multi_modal_data={"image": ...}`.
+- The query must sit between `<|start_of_query|>` and `<|REF_SEG|>`. Omitting
+  `<|REF_SEG|>` does not error — the model just never emits `<|seg|>` tokens and
+  you get no masks.
+
+## Sampling
+
+Greedy (`temperature=0.0`) is required rather than preferred. Each `<|coord|>` /
+`<|size|>` token's continuous value is decoded from the hidden state that
+*produced* it and fed back as the next input embedding, so sampling would
+desynchronise the geometry from the token stream. Stop tokens are `[11, 263]`
+(EOS and `<|end_of_query|>`).
+
+Two `SamplingParams` are passed, one per pipeline stage: the thinker (up to
+`--max-tokens`) and the mask head (always a single step).
+
+## What comes back
+
+`multimodal_output` on the final stage carries:
+
+| key | shape | meaning |
+|---|---|---|
+| `masks` | `(n_instances, H, W)` uint8 | binary masks at the **original** image resolution |
+| `boxes` | `(n_instances, 4)` float | `(centre_x, centre_y, w, h)`, normalised to `[0, 1]` |
+
+### Runtime mask filtering
+
+Before returning the masks, the segmentation stage applies dependency-free,
+area-ordered mask NMS with an IoU threshold of `0.6`. For bounded memory and
+latency on dense scenes, IoU is computed after bilinearly resizing masks so
+their longest side is at most 256 pixels.
+
+This serving-time approximation is intentionally not the official PBench
+scorer. The Falcon Perception evaluator uses full-resolution binary COCO-RLE
+IoU at a threshold of `0.5`, implemented with `pycocotools`. vLLM-Omni does not
+install `pycocotools` as a runtime dependency. The reference evaluation
+environment reproduces the official metric, but vLLM-Omni masks have already
+passed through the serving-time approximation, so the two inference outputs
+are not expected to be bit-identical.
+
+## Deployment knobs
+
+- Both stages set `enforce_eager: false`. Stage 0 uses
+  `cudagraph_mode: FULL_DECODE_ONLY`; stage 1 is a single-step generation stage
+  without an autoregressive decode loop and explicitly uses `cudagraph_mode:
+  NONE` to avoid capturing an empty graph. AnyUp compilation is controlled
+  separately below.
+- The shipped `falcon_perception.yaml` assigns the stage-1 AnyUp feature cache
+  12288 MiB through `hf_overrides.hr_cache_mb`. To disable it, copy the YAML and
+  set that value to `0`. `FALCON_PERCEPTION_HR_CACHE_MB` is only a fallback when
+  the model override is omitted.
+- AnyUp compilation is enabled through stage-1
+  `hf_overrides.compile_anyup: true`. Compilation can slightly change mask
+  boundaries, so revalidate accuracy when changing hardware or software.
+- Prefix caching is deliberately off. If experimenting with it, apply it to
+  stage 0 only because the segmentation stage has no attention/KV cache, and
+  revalidate dense scenes with multiple queries against the same image.
+
+## Notes
+
+- Detection-only (single-stage, boxes without masks) serving is not available;
+  the geometry feedback loop requires a downstream stage.
+- Verified on NVIDIA GPUs only.
+- Any standalone script needs `if __name__ == "__main__":` — the deploy YAML uses
+  `distributed_executor_backend: mp` with spawn and will otherwise hang.
+- The vendored AnyUp adaptation retains the upstream authorship and CC-BY-4.0
+  license notice in its source module.

--- a/examples/offline_inference/falcon_perception/batch_inference.py
+++ b/examples/offline_inference/falcon_perception/batch_inference.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Falcon Perception: multi-request offline inference over a whole request set.
+
+``end2end.py`` is the usage demo — one image, one query. This script is the
+throughput form: every request is handed to a **single** ``omni.generate()`` call
+so vLLM's scheduler can keep up to ``max_num_seqs`` stage-0 sequences in flight
+(continuous batching on a paged KV cache). Calling ``generate()`` once per
+request in a Python loop admits only one sequence at a time and measures serial
+latency, not overlapping prefill/decode. Stage 1 still runs once per finished
+thinker request; map outputs by request id, not finish order.
+
+Usage:
+    # explicit pairs
+    python batch_inference.py --model tiiuae/Falcon-Perception \\
+        --image a.jpg --query "the red pepper" \\
+        --image b.jpg --query "every person" --max-num-seqs 4
+
+    # a JSONL manifest of {"image": ..., "query": ...} lines
+    python batch_inference.py --manifest requests.jsonl \
+        --deploy-config falcon_perception.yaml
+
+    # a HuggingFace dataset with `image` and `expression` columns
+    python batch_inference.py --dataset tiiuae/PBench --split level_1 \\
+        --limit 50 --deploy-config falcon_perception.yaml
+
+Reading the throughput numbers
+------------------------------
+Four things decide whether the reported ``images/s`` means anything:
+
+* **``max_num_seqs``.** ``falcon_perception.yaml`` uses the measured A100-80GB
+  optimum of 4 on both stages. Larger is not faster for this model. Use
+  ``--max-num-seqs`` to retune on other hardware; this script warns if an
+  override serialises the workload at 1.
+* **``enforce_eager``.** The shipped YAML sets it to ``false`` on both stages.
+  Stage 0 also uses ``compilation_config: {cudagraph_mode: FULL_DECODE_ONLY}``
+  so autoregressive decode can use CUDA graphs. Stage 1 sets ``cudagraph_mode:
+  NONE`` because it has no decode loop; AnyUp has a separate compile knob. Edit
+  a copy of the deploy YAML and pass it as ``--deploy-config`` to change nested
+  compilation settings.
+* **Warmup.** ``--warmup`` requests run before the clock starts, absorbing
+  Triton JIT and allocator growth. They reuse request 0's image, which leaves
+  that image resident in the stage-1 AnyUp feature cache — so request 0's
+  measured cost is a cache hit. With the shipped profile, remove the effect by
+  copying the deploy YAML and setting ``hf_overrides.hr_cache_mb`` to ``0``, or
+  use ``--warmup 0`` to skip warmup entirely. The
+  ``FALCON_PERCEPTION_HR_CACHE_MB`` fallback works only when that model override
+  is omitted.
+* **Peak VRAM is not comparable to a single-process engine.** vLLM preallocates
+  its KV cache to ``gpu_memory_utilization`` up front, so the number reported
+  here is a reservation, not a working set.
+
+Only the ``generate()`` call is timed. Model load, warmup, and writing overlays
+sit outside the measured region.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from PIL import Image
+from vllm import SamplingParams
+
+import vllm_omni
+from vllm_omni.entrypoints.omni import Omni
+
+
+class _Phase:
+    """NVTX range naming the phase, so a trace separates warmup from measurement.
+
+    Uses the ``nvtx`` package rather than ``torch.cuda.nvtx``: this runs in the
+    driver process, which otherwise never touches CUDA, and the torch API would
+    create a context there purely to emit a marker. Enabled by
+    ``FALCON_PERCEPTION_NVTX``; a no-op otherwise, so untraced timing runs are
+    unaffected.
+
+    The phase boundary matters when reading a trace. Warmup requests carry
+    compilation, Triton JIT and a cold allocator, and they seed both caches — a
+    trace that cannot tell them apart will attribute all of that to the measured
+    work.
+    """
+
+    _push = _pop = None
+    if os.environ.get("FALCON_PERCEPTION_NVTX", "0") not in ("", "0"):
+        try:
+            import nvtx as _nvtx
+
+            _push, _pop = _nvtx.push_range, _nvtx.pop_range
+        except ImportError:
+            _push = _pop = None
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __enter__(self):
+        if _Phase._push is not None:
+            _Phase._push(message=self.name, domain="falcon_perception")
+        return self
+
+    def __exit__(self, *exc):
+        if _Phase._pop is not None:
+            _Phase._pop(domain="falcon_perception")
+        return False
+
+
+# The reference stops on EOS (11) and <|end_of_query|> (263).
+STOP_TOKEN_IDS = [11, 263]
+
+PALETTE = [
+    (255, 59, 48),
+    (52, 199, 89),
+    (0, 122, 255),
+    (255, 149, 0),
+    (175, 82, 222),
+    (255, 204, 0),
+    (90, 200, 250),
+    (255, 45, 85),
+    (162, 132, 94),
+    (48, 209, 88),
+]
+
+
+def build_prompt(query: str) -> str:
+    """The exact string the model expects. Deviating here silently degrades output."""
+    return f"<|image|>Segment these expressions in the image:<|start_of_query|>{query}<|REF_SEG|>"
+
+
+def overlay(image: Image.Image, masks: np.ndarray) -> Image.Image:
+    """Draw each instance mask over the original image so a reviewer can eyeball it."""
+    canvas = image.convert("RGBA")
+    layer = Image.new("RGBA", canvas.size, (0, 0, 0, 0))
+    width, height = canvas.size
+    for i, mask in enumerate(masks):
+        colour = PALETTE[i % len(PALETTE)]
+        binary = np.asarray(mask) > 0
+        if binary.shape != (height, width):
+            rows = (np.arange(height) * binary.shape[0] / height).astype(int).clip(0, binary.shape[0] - 1)
+            cols = (np.arange(width) * binary.shape[1] / width).astype(int).clip(0, binary.shape[1] - 1)
+            binary = binary[rows][:, cols]
+        stencil = Image.fromarray((binary * 255).astype(np.uint8))
+        layer = Image.composite(Image.new("RGBA", canvas.size, (*colour, 115)), layer, stencil)
+    return Image.alpha_composite(canvas, layer).convert("RGB")
+
+
+def load_requests(args: argparse.Namespace) -> list[tuple[str, str, Image.Image, dict[str, Any]]]:
+    """Collect ``(label, query, image, extras)`` tuples from whichever source was given.
+
+    ``extras`` carries any non-``image``/``query`` keys of a manifest line straight
+    through to ``results.json``, so a workload can label its own requests (sample
+    index, repeat number, ...) without this script having to know what they mean.
+    """
+    if args.manifest:
+        root = Path(args.manifest).parent
+        entries = [json.loads(line) for line in Path(args.manifest).read_text().splitlines() if line.strip()]
+        requests = []
+        for i, entry in enumerate(entries):
+            path = Path(entry["image"])
+            if not path.is_absolute():
+                path = root / path
+            extras = {k: v for k, v in entry.items() if k not in ("image", "query")}
+            requests.append((f"{i:04d}_{path.stem}", entry["query"], Image.open(path).convert("RGB"), extras))
+        return requests
+
+    if args.dataset:
+        # Streamed, matching how the reference benchmark takes its first N samples.
+        from datasets import load_dataset
+
+        stream = load_dataset(args.dataset, split=args.split, streaming=True)
+        requests = []
+        for i, sample in enumerate(stream):
+            if 0 < args.limit <= i:
+                break
+            requests.append((f"{i:04d}", sample["expression"], sample["image"].convert("RGB"), {}))
+        return requests
+
+    if len(args.image) != len(args.query):
+        raise SystemExit(
+            f"--image given {len(args.image)} times but --query {len(args.query)} times; they must pair up"
+        )
+    return [
+        (f"{i:04d}_{Path(p).stem}", q, Image.open(p).convert("RGB"), {})
+        for i, (p, q) in enumerate(zip(args.image, args.query))
+    ]
+
+
+def resolve_deploy_config(name: str) -> str:
+    """Expand a packaged deploy YAML name to a full path.
+
+    ``Omni`` resolves a bare name against ``vllm_omni/deploy/`` on one code path
+    but reads it as a literal path on another, so a bare name only works when the
+    CWD happens to contain the file. Resolve it here and pass a real path.
+    """
+    path = Path(name)
+    if path.exists():
+        return str(path)
+    packaged = Path(vllm_omni.__file__).parent / "deploy" / name
+    if packaged.exists():
+        return str(packaged)
+    raise SystemExit(f"deploy config not found: {name!r} (looked in ./ and {packaged.parent})")
+
+
+def stage_max_num_seqs(omni: Omni) -> list[Any]:
+    """Effective ``max_num_seqs`` per stage, or ``None`` where it can't be read."""
+    values: list[Any] = []
+    for cfg in getattr(omni, "stage_configs", None) or []:
+        engine_args = getattr(cfg, "engine_args", None)
+        value = None
+        if engine_args is not None:
+            value = (
+                engine_args.get("max_num_seqs")
+                if hasattr(engine_args, "get")
+                else getattr(engine_args, "max_num_seqs", None)
+            )
+        values.append(value)
+    return values
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--model", default="tiiuae/Falcon-Perception", help="HF id or local snapshot path")
+    parser.add_argument("--deploy-config", default="falcon_perception.yaml", help="deploy YAML name or path")
+
+    source = parser.add_argument_group("request source (pick one)")
+    source.add_argument("--image", action="append", default=[], help="input image; repeat, pairing with --query")
+    source.add_argument("--query", action="append", default=[], help="what to segment; repeat, pairing with --image")
+    source.add_argument("--manifest", help='JSONL file of {"image": ..., "query": ...} lines')
+    source.add_argument("--dataset", help="HF dataset id with `image` and `expression` columns")
+    source.add_argument("--split", default="level_1", help="dataset split (with --dataset)")
+    source.add_argument("--limit", type=int, default=50, help="max samples to take; -1 for all (with --dataset)")
+
+    parser.add_argument("--max-num-seqs", type=int, help="scheduler concurrency cap per stage (stage-0 throughput)")
+    parser.add_argument("--max-tokens", type=int, default=2048)
+    parser.add_argument("--warmup", type=int, default=1, help="untimed requests on image 0 before the measured run")
+    parser.add_argument(
+        "--passes", type=int, default=1, help="submit the set this many times, timing each; pass 2+ is cache-warm"
+    )
+    parser.add_argument("--seed", type=int, default=0)
+
+    parser.add_argument(
+        "--out-dir", default="/tmp/falcon_perception_batch", help="where results.json and any artifacts go"
+    )
+    parser.add_argument("--save-overlays", action="store_true", help="write a mask overlay PNG per request")
+    parser.add_argument("--save-masks", action="store_true", help="write compressed mask arrays per request")
+    args = parser.parse_args()
+
+    if not (args.image or args.manifest or args.dataset):
+        raise SystemExit("give requests via --image/--query pairs, --manifest, or --dataset")
+
+    requests = load_requests(args)
+    if not requests:
+        raise SystemExit("no requests to run")
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    print(f"loaded {len(requests)} requests")
+
+    engine_overrides: dict[str, Any] = {}
+    if args.max_num_seqs is not None:
+        engine_overrides["max_num_seqs"] = args.max_num_seqs
+    deploy_config = resolve_deploy_config(args.deploy_config)
+    omni = Omni(model=args.model, deploy_config=deploy_config, seed=args.seed, **engine_overrides)
+
+    batch_limits = stage_max_num_seqs(omni)
+    if len(requests) > 1 and any(v == 1 for v in batch_limits):
+        print(
+            f"\nWARNING: max_num_seqs per stage is {batch_limits} — at 1 the scheduler runs one\n"
+            f"         request at a time, so throughput here matches a per-prompt generate() loop.\n"
+            f"         Pass --max-num-seqs 4 or restore falcon_perception.yaml's default\n"
+            f"         before reading these numbers.\n"
+        )
+
+    # One SamplingParams per stage. Greedy is required, not a preference: the
+    # geometry (a bounding box per object) is decoded from the hidden state that
+    # produced each <|coord|> / <|size|> token, so sampling with temperature > 0
+    # would desynchronise boxes from tokens.
+    params = [
+        SamplingParams(
+            temperature=0.0,
+            max_tokens=args.max_tokens,
+            detokenize=True,
+            stop_token_ids=STOP_TOKEN_IDS,
+        ),
+        SamplingParams(temperature=0.0, max_tokens=1, detokenize=False),
+    ]
+
+    prompts = [{"prompt": build_prompt(query), "multi_modal_data": {"image": image}} for _, query, image, _ in requests]
+
+    for i in range(args.warmup):
+        print(f"warmup {i + 1}/{args.warmup} ...", flush=True)
+        with _Phase(f"fp/warmup[{i}]"):
+            omni.generate(prompts[:1], params, use_tqdm=False)
+
+    # One generate() admits every request; with max_num_seqs > 1 the stage-0
+    # scheduler can overlap them (continuous batching). A per-prompt loop admits
+    # one at a time.
+    #
+    # With --passes > 1 the same set is submitted again as a second batched call.
+    # That is the readable way to measure the caches: pass 1 is cold, pass 2 hits
+    # the KV prefix cache (identical prompts) and the stage-1 AnyUp feature cache
+    # (identical image hashes). Interleaving repeats *within* one call instead
+    # leaves both passes queued together, so cold and warm cost cannot be
+    # separated. Only the last pass's outputs are kept.
+    pass_wall_s: list[float] = []
+    for p_i in range(args.passes):
+        started = time.perf_counter()
+        with _Phase(f"fp/pass[{p_i}][n={len(prompts)}]"):
+            outputs = omni.generate(prompts, params)
+        pass_wall_s.append(time.perf_counter() - started)
+        if args.passes > 1:
+            print(f"pass {p_i + 1}/{args.passes}: {pass_wall_s[-1]:.1f}s", flush=True)
+    wall_s = pass_wall_s[-1]
+
+    # `Omni` builds request ids as f"{index}_{uuid}", so the submission index is
+    # recoverable exactly. Never map outputs back by arrival order — stages
+    # finish out of order under batching.
+    masks_by_idx: dict[int, np.ndarray] = {}
+    boxes_by_idx: dict[int, list[list[float]]] = {}
+    token_ids_by_idx: dict[int, list[int]] = {}
+    tokens_out_by_idx: dict[int, int] = {}
+    tokens_in_by_idx: dict[int, int] = {}
+    stage_metrics_by_idx: dict[int, dict[str, Any]] = {}
+    peak_memory_mb = 0.0
+
+    for output in outputs:
+        idx = int(str(output.request_id).split("_", 1)[0])
+        peak_memory_mb = max(peak_memory_mb, float(getattr(output, "peak_memory_mb", 0.0) or 0.0))
+
+        for stage in (output.metrics or {}).get("stage_metrics", {}).values():
+            # Per-stage generation time / TTFT / token counts, straight from the
+            # orchestrator. This is the profiling report: with everything in one
+            # batch there is no per-request wall clock to measure instead.
+            stage_metrics_by_idx.setdefault(idx, {})[str(stage.get("stage_id"))] = {
+                k: stage.get(k)
+                for k in ("stage_gen_time_ms", "vllm_ttft_ms", "vllm_tpot_ms", "num_tokens_in", "num_tokens_out")
+            }
+            if int(stage.get("stage_id", -1)) == 0:
+                tokens_in_by_idx[idx] = int(stage.get("num_tokens_in", 0))
+                tokens_out_by_idx[idx] = int(stage.get("num_tokens_out", 0))
+
+        completion = output.request_output.outputs[0]
+        if output.final_output_type == "text":
+            # `.text` is empty for this model: every generated token is a special
+            # token (<|coord|>, <|size|>, <|seg|>, ...) and detokenization skips
+            # them. The token ids are the thing worth recording.
+            token_ids_by_idx[idx] = [int(t) for t in completion.token_ids]
+            tokens_out_by_idx.setdefault(idx, len(completion.token_ids))
+        multimodal = getattr(completion, "multimodal_output", None)
+        if not multimodal:
+            continue
+        if "masks" in multimodal and hasattr(multimodal["masks"], "shape"):
+            masks_by_idx[idx] = np.asarray(multimodal["masks"].to(torch.uint8).cpu())
+        if "boxes" in multimodal and hasattr(multimodal["boxes"], "shape"):
+            boxes_by_idx[idx] = np.asarray(multimodal["boxes"].float().cpu()).tolist()
+
+    rows = []
+    for idx, (label, query, image, extras) in enumerate(requests):
+        masks = masks_by_idx.get(idx, np.zeros((0, 1, 1), dtype=np.uint8))
+        if args.save_masks:
+            np.savez_compressed(out_dir / f"{label}_masks.npz", masks=masks)
+        if args.save_overlays and masks.shape[0]:
+            overlay(image, masks).save(out_dir / f"{label}_masks.png")
+        rows.append(
+            {
+                "idx": idx,
+                "label": label,
+                "query": query,
+                "image_size": list(image.size),
+                "n_instances": int(masks.shape[0]),
+                "mask_shape": list(masks.shape),
+                "boxes": boxes_by_idx.get(idx, []),
+                "output_token_ids": token_ids_by_idx.get(idx, []),
+                "prompt_tokens": tokens_in_by_idx.get(idx),
+                "output_tokens": tokens_out_by_idx.get(idx),
+                "stage_metrics": stage_metrics_by_idx.get(idx, {}),
+                **extras,
+            }
+        )
+
+    prompt_tokens = sum(r["prompt_tokens"] or 0 for r in rows)
+    output_tokens = sum(r["output_tokens"] or 0 for r in rows)
+    total_instances = sum(r["n_instances"] for r in rows)
+    unresolved = [r["label"] for r in rows if r["idx"] not in masks_by_idx]
+
+    summary = {
+        "model": args.model,
+        "deploy_config": deploy_config,
+        "max_num_seqs_per_stage": batch_limits,
+        "requests": len(rows),
+        "warmup_requests": args.warmup,
+        "passes": args.passes,
+        "pass_wall_s": pass_wall_s,
+        "wall_s": wall_s,
+        "images_per_s": len(rows) / wall_s if wall_s else 0.0,
+        "prompt_tokens": prompt_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens_per_s": (prompt_tokens + output_tokens) / wall_s if wall_s else 0.0,
+        "output_tokens_per_s": output_tokens / wall_s if wall_s else 0.0,
+        "total_instances": total_instances,
+    }
+    (out_dir / "results.json").write_text(json.dumps({"summary": summary, "rows": rows}, indent=2))
+
+    print(f"\n{'=' * 62}\nMULTI-REQUEST OFFLINE INFERENCE — one generate() call\n{'=' * 62}")
+    print(f"  Requests         : {len(rows)}")
+    print(f"  max_num_seqs     : {batch_limits} (per stage)")
+    if args.passes > 1:
+        cold, warm = pass_wall_s[0], pass_wall_s[-1]
+        print(f"  Pass wall times  : {', '.join(f'{t:.1f}s' for t in pass_wall_s)}")
+        print(f"  Cold -> warm     : {cold:.1f}s -> {warm:.1f}s ({cold / warm:.2f}x from caching)")
+    print(f"  Wall time        : {wall_s:.1f}s  (last pass; all rates below use it)")
+    print(f"  Images/s         : {summary['images_per_s']:.3f}")
+    print(f"  Total tok/s      : {summary['total_tokens_per_s']:.1f}  (prompt + generated)")
+    print(f"  Output tok/s     : {summary['output_tokens_per_s']:.1f}")
+    print(f"  Prompt tokens    : {prompt_tokens}")
+    print(f"  Output tokens    : {output_tokens}")
+    print(f"  Total instances  : {total_instances}")
+    counts = [r["n_instances"] for r in rows]
+    print(f"  Instances/request: mean {statistics.mean(counts):.1f}  median {statistics.median(counts):.1f}")
+    if peak_memory_mb:
+        summary["worker_peak_memory_mb"] = peak_memory_mb
+        print(f"  Worker peak VRAM : {peak_memory_mb / 1024:.2f} GiB (includes preallocated KV cache)")
+    if unresolved:
+        print(f"  NOTE: {len(unresolved)} request(s) produced no mask output: {unresolved[:5]}")
+    print(f"\nwrote {out_dir / 'results.json'}")
+
+
+# Required: the deploy YAML uses distributed_executor_backend: mp with spawn, and
+# a script without this guard hangs in _check_not_importing_main.
+if __name__ == "__main__":
+    main()

--- a/examples/offline_inference/falcon_perception/end2end.py
+++ b/examples/offline_inference/falcon_perception/end2end.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Falcon Perception: image + text query -> bounding boxes and instance masks.
+
+Two stages run behind one ``Omni`` call:
+
+  0. thinker      — autoregressive; emits one box per detected instance
+  1. segmentation — AnyUp-upsamples the image features and contracts them with
+                    each ``<|seg|>`` hidden state to produce per-instance masks
+
+The prompt format is load-bearing and is *not* a chat template. Use as ti is. The image
+placeholder must be the literal ``<|image|>`` and the query must be wrapped in
+``<|start_of_query|> ... <|REF_SEG|>``; the processor replaces ``<|image|>``
+with the structural token run plus one token per patch.
+
+Usage:
+    python end2end.py --model tiiuae/Falcon-Perception --image photo.jpg \\
+        --query "the red pepper" --out-dir /tmp/falcon_perception
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import torch
+from PIL import Image
+from vllm import SamplingParams
+
+import vllm_omni
+from vllm_omni.entrypoints.omni import Omni
+
+# Passed as a full path, not a bare name: ``Omni`` resolves a bare deploy-config
+# name against ``vllm_omni/deploy/`` on one code path but reads it as a literal
+# path on another, so a bare name only works when the CWD happens to hold the file.
+DEPLOY_CONFIG = Path(vllm_omni.__file__).parent / "deploy" / "falcon_perception.yaml"
+
+# The reference stops on EOS (11) and <|end_of_query|> (263).
+STOP_TOKEN_IDS = [11, 263]
+
+PALETTE = [
+    (255, 59, 48),
+    (52, 199, 89),
+    (0, 122, 255),
+    (255, 149, 0),
+    (175, 82, 222),
+    (255, 204, 0),
+    (90, 200, 250),
+    (255, 45, 85),
+    (162, 132, 94),
+    (48, 209, 88),
+]
+
+
+def build_prompt(query: str) -> str:
+    """The exact string the model expects. Deviating here silently degrades output."""
+    return f"<|image|>Segment these expressions in the image:<|start_of_query|>{query}<|REF_SEG|>"
+
+
+def overlay(image: Image.Image, masks: np.ndarray) -> Image.Image:
+    """Draw each instance mask over the original image so a reviewer can eyeball it."""
+    canvas = image.convert("RGBA")
+    layer = Image.new("RGBA", canvas.size, (0, 0, 0, 0))
+    width, height = canvas.size
+    for i, mask in enumerate(masks):
+        colour = PALETTE[i % len(PALETTE)]
+        binary = np.asarray(mask) > 0
+        if binary.shape != (height, width):
+            rows = (np.arange(height) * binary.shape[0] / height).astype(int).clip(0, binary.shape[0] - 1)
+            cols = (np.arange(width) * binary.shape[1] / width).astype(int).clip(0, binary.shape[1] - 1)
+            binary = binary[rows][:, cols]
+        stencil = Image.fromarray((binary * 255).astype(np.uint8))
+        layer = Image.composite(Image.new("RGBA", canvas.size, (*colour, 115)), layer, stencil)
+    return Image.alpha_composite(canvas, layer).convert("RGB")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--model", default="tiiuae/Falcon-Perception", help="HF id or local snapshot path")
+    parser.add_argument("--image", required=True, help="path to the input image")
+    parser.add_argument("--query", default="the objects", help="what to segment, in plain English")
+    parser.add_argument("--out-dir", default="/tmp/falcon_perception", help="where to write the overlay")
+    parser.add_argument("--max-tokens", type=int, default=2048)
+    args = parser.parse_args()
+
+    image = Image.open(args.image).convert("RGB")
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    omni = Omni(model=args.model, deploy_config=str(DEPLOY_CONFIG), seed=0)
+
+    # One SamplingParams per stage. Greedy is required, not a preference: the
+    # geometry (i.e. bounding box for each object) is decoded from the hidden state that produced each <|coord|> /
+    # <|size|> token, so sampling with temperature > 0 might desynchronise boxes from tokens.
+    params = [
+        SamplingParams(
+            temperature=0.0,
+            max_tokens=args.max_tokens,
+            detokenize=True,
+            stop_token_ids=STOP_TOKEN_IDS,
+        ),
+        SamplingParams(temperature=0.0, max_tokens=1, detokenize=False),
+    ]
+
+    masks = np.zeros((0, 1, 1), dtype=np.uint8)
+    boxes: list[list[float]] = []
+    for stage_output in omni.generate(
+        [{"prompt": build_prompt(args.query), "multi_modal_data": {"image": image}}],
+        params,
+    ):
+        completion = stage_output.request_output.outputs[0]
+        multimodal = getattr(completion, "multimodal_output", None)
+        if not multimodal:
+            continue
+        if "masks" in multimodal and hasattr(multimodal["masks"], "shape"):
+            masks = np.asarray(multimodal["masks"].to(torch.uint8).cpu())
+        if "boxes" in multimodal and hasattr(multimodal["boxes"], "shape"):
+            boxes = np.asarray(multimodal["boxes"].float().cpu()).tolist()
+
+    print(f"query   : {args.query!r}")
+    print(f"image   : {image.size[0]}x{image.size[1]}")
+    print(f"instances: {masks.shape[0]}")
+    for i, box in enumerate(boxes[:10]):
+        x, y, w, h = box
+        print(f"  box {i:>3}: centre=({x:.3f}, {y:.3f}) size=({w:.3f}, {h:.3f})  [normalised]")
+    if len(boxes) > 10:
+        print(f"  ... {len(boxes) - 10} more")
+
+    # save the segm masks overlaid on the original image
+    if masks.shape[0]:
+        out_path = out_dir / f"{Path(args.image).stem}_masks.png"
+        overlay(image, masks).save(out_path)
+        print(f"\nwrote overlay to {out_path}")
+    else:
+        print("\nno instances matched the query — nothing to draw")
+
+
+# Required: the deploy YAML uses distributed_executor_backend: mp with spawn, and
+# a script without this guard hangs in _check_not_importing_main.
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,6 +213,10 @@ ignore = [
 # legacy typing, whitespace, unused-import shims) is exempted. TID251 and the
 # F-correctness rules still apply.
 "vllm_omni/model_executor/models/nemotron_voicechat/nemo_vendored/**" = ["E501", "E721", "E741", "F401", "F841", "I001", "N803", "N814", "UP006", "UP007", "UP008", "UP011", "UP032", "UP035", "W291", "W293"]
+# AnyUp upsampler vendored from the Falcon Perception reference implementation
+# (itself a copy of github.com/wimmerth/anyup). Kept diffable against upstream,
+# so its H/W/BLOCK_SIZE argument names stay as-is.
+"vllm_omni/model_executor/models/falcon_perception/anyup.py" = ["N803"]
 "vllm_omni/experimental/fullduplex/joyvl/decision/prompts.py" = ["E501"]  # System/summarizer prompts are long prose lines
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -88,6 +88,7 @@ recipes/
 | [`zai-org/GLM-TTS.md`](./zai-org/GLM-TTS.md) | Online serving for Chinese/English zero-shot voice-cloned TTS | 1x A40 48GB |
 | [`GLM/GLM-Image.md`](./GLM/GLM-Image.md) | Online serving for image generation | 1x A800 80GB / 2x A800 80GB |
 | [`JD/JoyAI-VL-Interaction.md`](./JD/JoyAI-VL-Interaction.md) | Real-time streaming video-language interaction (proactive speak/silence/delegate) | 1x GPU 24GB+ |
+| [`tiiuae/Falcon-Perception.md`](./tiiuae/Falcon-Perception.md) | Offline referring segmentation (image + text query -> boxes and instance masks) | 1x A100 80GB |
 
 Within a single recipe file, include different hardware support sections such
 as `GPU`, `ROCm`, and `NPU`, and add concrete tested configurations like

--- a/recipes/tiiuae/Falcon-Perception.md
+++ b/recipes/tiiuae/Falcon-Perception.md
@@ -1,0 +1,195 @@
+# Falcon Perception
+
+> Referring segmentation: an image plus a plain-English query in, bounding
+> boxes and per-instance masks out
+
+## Summary
+
+- Vendor: TII (Technology Innovation Institute)
+- Model: [`tiiuae/Falcon-Perception`](https://huggingface.co/tiiuae/Falcon-Perception)
+- Task: Referring expression detection and instance segmentation
+- Mode: Offline inference (`vllm_omni.entrypoints.omni.Omni`), two-stage pipeline
+- Maintainer: Community
+
+Falcon Perception is a two-stage model. Stage 0 (the "thinker") is an
+autoregressive VLM that emits one bounding box per matching instance, encoding
+each box as `<|coord|>` / `<|size|>` tokens whose continuous values are read
+off the hidden state that produced them and fed back as the next input
+embedding. Stage 1 (the mask head) AnyUp-upsamples the image features and takes
+an inner product with each `<|seg|>` hidden state to produce a binary mask per
+instance.
+
+Masks are returned at the **original** image resolution, not the patch-aligned
+resize used internally.
+
+## When to use this recipe
+
+Use it when you want open-vocabulary detection *and* pixel-accurate instance
+masks from a natural-language query — "the red pepper", "every person wearing a
+helmet" — rather than a fixed class list. Both outputs come from a single
+request; there is no separate detector.
+
+If you only want boxes and no masks, this recipe does not help you: the
+single-stage detection-only path is not available (see Known limitations).
+
+## References
+
+- Related example under `examples/`:
+  [`examples/offline_inference/falcon_perception/`](../../examples/offline_inference/falcon_perception/)
+  — runnable end-to-end script plus the full prompt-format reference
+- Deploy config: [`vllm_omni/deploy/falcon_perception.yaml`](../../vllm_omni/deploy/falcon_perception.yaml)
+- End-to-end test: `tests/e2e/offline_inference/test_falcon_perception.py`
+- AnyUp upsampler: [github.com/wimmerth/anyup](https://github.com/wimmerth/anyup)
+  ([CC-BY-4.0](https://github.com/wimmerth/anyup/blob/main/LICENSE); the vendored
+  adaptation retains upstream attribution and marks the Falcon Perception and
+  vLLM-Omni modifications)
+
+## Hardware Support
+
+Verified on NVIDIA CUDA GPUs only. ROCm, Ascend NPU, and Intel XPU are
+untested — no claim is made either way.
+
+## GPU
+
+### 1x A100 80GB
+
+#### Environment
+
+- OS: Ubuntu 22.04.5 LTS
+- Python: 3.12
+- Driver / runtime: NVIDIA 590.48.01, CUDA 13.0, PyTorch 2.11.0+cu130
+- vLLM version: 0.26.0
+- vLLM-Omni version or commit: this PR applied on top of `22dd96ec`
+
+The weights are small (~2.4 GB in bf16); the 80GB card is what this was
+validated on, not a floor. The dominant memory consumer is the KV cache
+budget you give stage 0, which you can lower substantially.
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install -e .
+
+export MODEL=tiiuae/Falcon-Perception
+hf download "${MODEL}" --local-dir /path/to/Falcon-Perception
+```
+
+#### Command
+
+Both stages are described by the shipped deploy config, so the only thing you
+supply is the image and the query:
+
+```bash
+python examples/offline_inference/falcon_perception/end2end.py \
+    --model tiiuae/Falcon-Perception \
+    --image /path/to/photo.jpg \
+    --query "the red pepper" \
+    --out-dir /tmp/falcon_perception
+```
+
+This prints one normalised `(centre_x, centre_y, w, h)` box per instance and
+writes an overlay PNG with the masks drawn over the original image.
+
+The canonical deploy config is tuned for batched throughput on one A100-80GB:
+
+```bash
+python examples/offline_inference/falcon_perception/batch_inference.py \
+    --model tiiuae/Falcon-Perception \
+    --manifest requests.jsonl \
+    --deploy-config falcon_perception.yaml \
+    --warmup 2 --passes 3 \
+    --out-dir /tmp/falcon_perception_batch
+```
+
+It uses `max_num_seqs: 4` on both stages, 16,384 batched prefill tokens,
+`gpu_memory_utilization: 0.66`/`0.10`, a 12 GiB AnyUp cache, CUDA graphs for
+stage-0 decode, and compiled AnyUp. Prefix caching is deliberately disabled
+because it changed dense-scene outputs. These are measured A100 values; retune
+the memory split for other cards and validate masks on the target workload.
+
+The prompt is a fixed string, **not** a chat template. Both markers are
+required, and the query must sit between them:
+
+```text
+<|image|>Segment these expressions in the image:<|start_of_query|>{QUERY}<|REF_SEG|>
+```
+
+Omitting `<|REF_SEG|>` does not raise — the model simply never emits `<|seg|>`
+tokens and you get zero masks back.
+
+Greedy decoding is **required**, not merely recommended. Each geometry token's
+continuous value is decoded from the hidden state that produced it, so sampling
+would desynchronise the boxes from the token stream. Stop tokens are `[11, 263]`.
+
+Any standalone script must guard its entry point with
+`if __name__ == "__main__":` — the deploy config uses
+`distributed_executor_backend: mp` with spawn and will otherwise hang.
+
+#### Verification
+
+The end-to-end test drives the shipped config and compares against a golden
+token stream, instance count, and mask summary. It runs at L3 (`advanced_model`)
+because it needs the real checkpoint — at `core_model` the harness forces
+`load_format: dummy`:
+
+```bash
+pytest -s -v tests/e2e/offline_inference/test_falcon_perception.py \
+    -m 'advanced_model and cuda' --run-level 'advanced_model'
+```
+
+CPU-only unit tests (no checkpoint or GPU needed) cover the M-RoPE transport,
+the processor, the stage bridge, and the mask head:
+
+```bash
+pytest -q tests/model_executor/models/falcon_perception/ \
+          tests/model_executor/stage_input_processors/test_falcon_perception.py
+```
+
+#### Notes
+
+- **Memory:** the shipped config gives stage 0 `gpu_memory_utilization: 0.66`
+  and stage 1 `0.10` on a single device. Stage 1's share must also leave room
+  for the AnyUp output cache, which the config sets to 12288 MiB through
+  `hf_overrides.hr_cache_mb`. It is allocated *after* vLLM profiles peak memory,
+  so it is not reflected in that fraction. To resize or disable it, copy the
+  YAML and set `hr_cache_mb` to the desired MiB value (`0` disables). The code
+  fallback is 512 MB, and `FALCON_PERCEPTION_HR_CACHE_MB` is consulted only when
+  the model override is omitted. Disabling the cache is measurably slower on
+  repeat queries against the same image.
+- **Key flags:** `temperature: 0.0` (mandatory, see above);
+  `max_num_seqs: 4`; `enforce_eager: false`; stage-0
+  `cudagraph_mode: FULL_DECODE_ONLY`; stage-1 `cudagraph_mode: NONE` because it
+  has no decode loop; `tensor_parallel_size: 1`.
+- **AnyUp compilation is on by default** through stage-1
+  `hf_overrides.compile_anyup: true`. It improves throughput but can slightly
+  move mask boundaries, so revalidate when changing hardware or software.
+- **Prefix caching is off by default, deliberately.** vllm-omni documents prefix
+  caching should be kept off for stages with engine output type = latent.
+- **Full-split validation:** completed all 1,108 PBench
+  level-1 requests in 180.4 s (6.14 images/s and 18,971 prompt+output tokens/s),
+  with about 73 GiB observed peak VRAM. Exact token streams matched the saved
+  reference inference for 1,073/1,108 requests
+- **Runtime NMS differs from the benchmark evaluator.** The serving path uses
+  dependency-free, area-ordered mask NMS at IoU `0.6`, with masks resized to a
+  maximum side of 256 for the IoU calculation. Official PBench scoring uses
+  full-resolution binary COCO-RLE IoU at `0.5` through `pycocotools`.
+  `pycocotools` is intentionally not a vLLM-Omni runtime dependency.
+- **Dense-split parity:** on 20 PBench dense samples with prefix caching off,
+  the reference/vLLM outputs contained 3598/3691 masks. Hungarian assignment
+  matched 3591 masks at 0.8928 mean (0.9333 median) full-resolution IoU. Exact
+  token streams matched on 4/20 samples and mask counts on 6/20 — dense scenes
+  diverge in instance ordering and count while the matched masks stay close, so
+  IoU rather than token equality is the meaningful parity signal on this split.
+- **Query phrasing is brittle.** The model is highly sensitive to rewording of
+  the query and the fixed instruction; paraphrases that read as equivalent can
+  change or collapse the instance count. Keep the instruction string exactly as
+  the example builds it.
+
+#### Known limitations
+
+- Detection-only (single-stage, boxes without masks) serving is **not**
+  available. The geometry feedback loop requires a downstream stage to carry
+  the hidden-state payload, so a lone final stage degenerates.
+- Tensor parallelism is untested; both shipped stages are TP=1.
+- Online / OpenAI-compatible HTTP serving is not covered by this recipe. Only
+  the offline two-stage path has been validated.

--- a/tests/e2e/offline_inference/test_falcon_perception.py
+++ b/tests/e2e/offline_inference/test_falcon_perception.py
@@ -1,0 +1,259 @@
+"""
+End-to-end test for Falcon Perception (image + text -> boxes and instance masks).
+
+Verifies that the thinker -> segmentation pipeline reproduces a golden token
+stream and instance count, and that the masks match a golden mask summary.
+
+Model Hub repo id: ``tiiuae/Falcon-Perception``.
+Deploy config: ``get_deploy_config_path("falcon_perception.yaml")``
+  -> ``vllm_omni/deploy/falcon_perception.yaml``
+
+The golden is the ``_GOLDEN`` constant below, inlined rather than stored as a
+fixture file. Regenerate it with::
+
+  UPDATE_GOLDEN=1 pytest tests/e2e/offline_inference/test_falcon_perception.py \
+      -m 'advanced_model and cuda' --run-level 'advanced_model'
+
+which prints a replacement block to paste over ``_GOLDEN``.
+
+Masks are asserted by per-instance area ratio and centroid distance rather than
+matching in a bit-exact manner. This is because bf16 attention is not batch-invariant
+So mask boundaries move slightly between runs (characterised as 0.98-0.99 IoU at 1px tolerance).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from vllm.assets.image import ImageAsset
+from vllm.sampling_params import SamplingParams
+
+from tests.helpers.mark import hardware_test
+from tests.helpers.runtime import OmniRunner
+from tests.helpers.stage_config import get_deploy_config_path
+
+MODEL_PATH = "tiiuae/Falcon-Perception"
+DEPLOY_CONFIG = get_deploy_config_path("falcon_perception.yaml")
+
+_OMNI_RUNNER_PARAM = (MODEL_PATH, DEPLOY_CONFIG)
+
+# Golden, inlined rather than kept in a fixture file: it is small enough to read
+# in a diff, and a reviewer can see the expected values without opening a second
+# file. Recorded with the compiled backbone and compiled AnyUp from the
+# canonical deploy profile on tiiuae/Falcon-Perception, 1x A100-80GB,
+# vLLM 0.26.0, greedy. AnyUp compilation can move mask boundaries enough to
+# change the area-ordered NMS output, so regenerate this golden when that
+# setting changes.
+# Regenerate with UPDATE_GOLDEN=1 -- it prints a replacement block to paste here.
+#
+# The token stream is one <|coord|>/<|size|>/<|seg|> triple (240, 241, 262) per
+# candidate, bracketed by 268 and the 263 stop token. Mask NMS removes one
+# overlapping candidate below, so the final mask count is intentionally lower.
+# fmt: off
+_GOLDEN = {
+    "tokens": [
+        268,
+        240, 241, 262,  240, 241, 262,  240, 241, 262,  240, 241, 262,  240, 241, 262,
+        240, 241, 262,  240, 241, 262,  240, 241, 262,  240, 241, 262,  240, 241, 262,
+        263,
+    ],
+    "n_instances": 9,
+    "masks": [
+        {"area": 806, "cy": 296.207, "cx": 634.453},
+        {"area": 725, "cy": 269.399, "cx": 654.549},
+        {"area": 663, "cy": 318.572, "cx": 471.002},
+        {"area": 594, "cy": 297.677, "cx": 770.177},
+        {"area": 585, "cy": 313.125, "cx": 682.398},
+        {"area": 474, "cy": 322.285, "cx": 573.530},
+        {"area": 517, "cy": 298.781, "cx": 792.294},
+        {"area": 417, "cy": 347.374, "cx": 642.914},
+        {"area": 340, "cy": 339.488, "cx": 719.497},
+    ],
+}
+# fmt: on
+
+# Reference stop tokens: EOS and <|end_of_query|>.
+_STOP_TOKEN_IDS = [11, 263]
+# A multi-instance query on purpose. A single-instance golden is a weak test:
+# 1 area + 1 centroid is cheap to match by accident. 10 instances means ten
+# areas and ten centroids must all land inside tolerance, which a broken mask
+# head cannot do. Measured alternatives on this same asset (each bit-identical
+# across two consecutive runs): "the stop sign" 1, "the stone lion statues" 2,
+# "the red lanterns" 9, "the lanterns" 10, "the signs" 27. Denser was available
+# but not taken -- "the signs" is a fuzzy referent in a busy street scene, and a
+# longer exact-matched token stream is more exposed to cross-GPU bf16 drift.
+_QUERY = "the lanterns"
+
+
+def _build_prompt(query: str) -> str:
+    return f"<|image|>Segment these expressions in the image:<|start_of_query|>{query}<|REF_SEG|>"
+
+
+def _test_image():
+    """A stock vLLM asset, so no image is checked into the repo.
+
+    Despite the name it is a busy Chinatown street scene, which is why it can
+    support a multi-instance query. It must be a real photograph containing the
+    queried object: synthetic noise makes the detector return zero instances,
+    which would make the golden vacuous -- the mask comparison would iterate an
+    empty list and pass even with the whole segmentation stage broken.
+    """
+    return ImageAsset("stop_sign").pil_image
+
+
+def _mask_summary(masks: np.ndarray) -> list[dict]:
+    """Per-instance area and centroid — stable enough to store, strict enough to catch drift."""
+    out = []
+    for mask in masks:
+        binary = np.asarray(mask) > 0
+        ys, xs = np.nonzero(binary)
+        out.append(
+            {
+                "area": int(binary.sum()),
+                "cy": round(float(ys.mean()), 3) if ys.size else 0.0,
+                "cx": round(float(xs.mean()), 3) if xs.size else 0.0,
+            }
+        )
+    return out
+
+
+# Both tests share the runner param; the run-level marks are per-test because the
+# two levels need different weights. See each test's docstring.
+pytestmark = [
+    pytest.mark.parametrize("omni_runner", [_OMNI_RUNNER_PARAM], indirect=True),
+]
+
+# Under dummy weights the thinker emits noise, so cap the decode instead of
+# letting it run to the 2048-token ceiling for nothing.
+_SMOKE_MAX_TOKENS = 64
+
+
+def _run_pipeline(omni_runner: OmniRunner, image, *, max_tokens: int):
+    """Drive the 2-stage pipeline once -> (tokens, masks, boxes, saw_text_stage).
+
+    This calls ``omni.generate`` directly rather than an
+    ``OmniRunnerHandler.send_*_request`` helper: no helper in
+    ``tests/helpers/runtime.py`` models the boxes+masks multimodal payload this
+    pipeline returns. Tracked as debt -- add ``send_falcon_perception_request``
+    there if a second Falcon test needs the same plumbing.
+    """
+    params = [
+        SamplingParams(temperature=0.0, max_tokens=max_tokens, detokenize=True, stop_token_ids=_STOP_TOKEN_IDS),
+        SamplingParams(temperature=0.0, max_tokens=1, detokenize=False),
+    ]
+
+    tokens: list[int] = []
+    masks = np.zeros((0, 1, 1), dtype=np.uint8)
+    boxes = np.zeros((0, 4), dtype=np.float32)
+    saw_text_stage = False
+    for stage_output in omni_runner.omni.generate(
+        [{"prompt": _build_prompt(_QUERY), "multi_modal_data": {"image": image}}], params
+    ):
+        completion = stage_output.request_output.outputs[0]
+        if stage_output.final_output_type == "text":
+            saw_text_stage = True
+            tokens = [int(t) for t in completion.token_ids]
+        multimodal = getattr(completion, "multimodal_output", None)
+        if not multimodal:
+            continue
+        if "masks" in multimodal and hasattr(multimodal["masks"], "shape"):
+            masks = np.asarray(multimodal["masks"].to(torch.uint8).cpu())
+        if "boxes" in multimodal and hasattr(multimodal["boxes"], "shape"):
+            boxes = np.asarray(multimodal["boxes"].float().cpu())
+    return tokens, masks, boxes, saw_text_stage
+
+
+@pytest.mark.core_model
+@pytest.mark.omni
+@hardware_test(res={"cuda": "H100"})
+def test_falcon_perception_pipeline_smoke(omni_runner: OmniRunner):
+    """L2 wiring check: both stages run and the output payload keeps its contract.
+
+    Runs at ``--run-level core_model``, where the harness rewrites every stage to
+    ``load_format: dummy``. The weights are therefore random and *nothing about
+    the content* of the output is meaningful -- no instance count, no geometry.
+    What this does catch, on every PR and without the checkpoint, is wiring:
+    the architecture resolves through the registry, the 2-stage pipeline builds
+    from the shipped YAML, stage 0 surfaces text, the stage bridge hands off, and
+    any instances stage 1 does emit satisfy the documented shape contract.
+
+    Accuracy is asserted separately by ``test_falcon_perception_masks_e2e`` (L3).
+    """
+    image = _test_image()
+    tokens, masks, boxes, saw_text_stage = _run_pipeline(omni_runner, image, max_tokens=_SMOKE_MAX_TOKENS)
+
+    assert saw_text_stage, "stage 0 produced no text output; the pipeline did not run end to end"
+    assert isinstance(tokens, list), "token stream should be a list of ids"
+    assert masks.ndim == 3, f"masks should be (n_instances, H, W), got {masks.shape}"
+
+    # Random weights may legitimately yield zero instances, so the count is not
+    # asserted. Whatever *is* returned must still honour the contract.
+    if masks.shape[0]:
+        assert masks.shape[1:] == (image.size[1], image.size[0]), (
+            f"masks are {masks.shape[1:]}, expected the original {(image.size[1], image.size[0])}"
+        )
+        assert boxes.shape == (masks.shape[0], 4), f"expected one (cx, cy, w, h) box per mask, got {boxes.shape}"
+        assert masks.max() <= 1, "masks should be binary"
+
+
+# L3 (``advanced_model``), not L2: at ``--run-level core_model`` the harness
+# patches every stage to ``load_format: dummy``, and a golden token stream means
+# nothing under random weights. The golden comparison needs the real checkpoint.
+@pytest.mark.advanced_model
+@pytest.mark.omni
+@hardware_test(res={"cuda": "H100"})
+def test_falcon_perception_masks_e2e(omni_runner: OmniRunner):
+    """Image + query -> token stream, boxes and instance masks.
+
+    Verifies:
+      - the 2-stage pipeline initialises from the shipped YAML
+      - the thinker's token stream matches the golden exactly
+      - the instance count matches, and masks are at the original resolution
+      - per-instance masks match the golden summary within tolerance
+    """
+    image = _test_image()
+    tokens, masks, boxes, _ = _run_pipeline(omni_runner, image, max_tokens=2048)
+
+    # Masks come back at the ORIGINAL image resolution, not the patch-aligned
+    # smart_resize size — this is what the reference's finalize_masks does.
+    if masks.shape[0]:
+        assert masks.shape[1:] == (image.size[1], image.size[0]), (
+            f"masks are {masks.shape[1:]}, expected the original {(image.size[1], image.size[0])}"
+        )
+        assert boxes.shape[0] == masks.shape[0], "one box per instance"
+
+    current = {
+        "tokens": tokens,
+        "n_instances": int(masks.shape[0]),
+        "masks": _mask_summary(masks),
+    }
+
+    # A zero-instance result would make every mask assertion below vacuous: the
+    # comparison would zip two empty lists and pass with the mask head entirely
+    # broken. Refuse to record or trust such a golden.
+    assert current["n_instances"] > 0, (
+        f"model returned no instances for {_QUERY!r}; a golden built from this would assert nothing about segmentation"
+    )
+
+    if os.environ.get("UPDATE_GOLDEN"):
+        print(f"\n=== replace _GOLDEN in {Path(__file__).name} with ===\n_GOLDEN = {json.dumps(current, indent=4)}\n")
+        pytest.skip("golden printed above; paste it into _GOLDEN")
+
+    golden = _GOLDEN
+    assert golden["n_instances"] > 0, "stored golden is vacuous; regenerate it"
+
+    # Exact: the token stream was validated byte-identical against the reference.
+    assert tokens == golden["tokens"], "thinker token stream drifted from the golden"
+    assert current["n_instances"] == golden["n_instances"], "instance count changed"
+
+    # Tolerant: sub-pixel boundary jitter is expected, structural drift is not.
+    for i, (got, want) in enumerate(zip(current["masks"], golden["masks"], strict=True)):
+        area_ratio = got["area"] / want["area"]
+        assert 0.9 <= area_ratio <= 1.1, f"instance {i} area moved by {area_ratio:.3f}x"
+        assert abs(got["cy"] - want["cy"]) <= 2.0, f"instance {i} centroid moved vertically"
+        assert abs(got["cx"] - want["cx"]) <= 2.0, f"instance {i} centroid moved horizontally"

--- a/tests/model_executor/models/falcon_perception/__init__.py
+++ b/tests/model_executor/models/falcon_perception/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/tests/model_executor/models/falcon_perception/test_pipeline.py
+++ b/tests/model_executor/models/falcon_perception/test_pipeline.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Falcon Perception pipeline topology and registry wiring."""
+
+import importlib
+from pathlib import Path
+
+import pytest
+from vllm.compilation.wrapper import TorchCompileWithNoGuardsWrapper
+
+from vllm_omni.config.pipeline_registry import OMNI_PIPELINES, resolve_pipeline_config
+from vllm_omni.config.stage_config import (
+    StageExecutionType,
+    load_deploy_config,
+    merge_pipeline_deploy,
+)
+from vllm_omni.model_executor.models.falcon_perception.falcon_perception_thinker import (
+    FalconPerceptionBackbone,
+)
+from vllm_omni.model_executor.models.falcon_perception.pipeline import (
+    FALCON_PERCEPTION_PIPELINE,
+)
+from vllm_omni.model_executor.models.registry import _OMNI_MODELS
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+_DEPLOY_DIR = Path(__file__).resolve().parents[4] / "vllm_omni" / "deploy"
+
+
+def test_pipelines_validate_and_are_registered():
+    assert FALCON_PERCEPTION_PIPELINE.validate() == []
+    assert OMNI_PIPELINES["falcon_perception"] is FALCON_PERCEPTION_PIPELINE
+    assert resolve_pipeline_config("falcon_perception") is FALCON_PERCEPTION_PIPELINE
+
+
+def test_two_stage_topology():
+    stages = FALCON_PERCEPTION_PIPELINE.stages
+    assert len(stages) == 2
+
+    thinker, segmentation = stages
+    assert thinker.model_stage == "thinker"
+    assert thinker.execution_type is StageExecutionType.LLM_AR
+    assert thinker.owns_tokenizer and thinker.requires_multimodal_data
+    # "latent" so the hidden-state trajectory is shipped to the mask head;
+    # the user-visible output is still text.
+    assert thinker.engine_output_type == "latent"
+    assert thinker.final_output_type == "text"
+
+    assert segmentation.model_stage == "segmentation"
+    # The mask head is not autoregressive — it runs once, after decode.
+    assert segmentation.execution_type is StageExecutionType.LLM_GENERATION
+    assert segmentation.input_sources == (0,)
+    # AnyUp guides upsampling with the original pixels, so stage 1 needs the image.
+    assert segmentation.requires_multimodal_data
+
+
+def test_stage_one_performance_knobs_are_model_local():
+    deploy = load_deploy_config(_DEPLOY_DIR / "falcon_perception.yaml")
+    stages = merge_pipeline_deploy(FALCON_PERCEPTION_PIPELINE, deploy)
+
+    assert stages[1].yaml_engine_args["hf_overrides"] == {"hr_cache_mb": 12288, "compile_anyup": True}
+    assert "env" not in stages[1].yaml_runtime
+
+
+def test_falcon_profile_is_non_eager():
+    deploy = load_deploy_config(_DEPLOY_DIR / "falcon_perception.yaml")
+    stages = merge_pipeline_deploy(FALCON_PERCEPTION_PIPELINE, deploy)
+
+    assert all(stage.yaml_engine_args["enforce_eager"] is False for stage in stages)
+    assert stages[0].yaml_engine_args["compilation_config"] == {"cudagraph_mode": "FULL_DECODE_ONLY"}
+    assert stages[1].yaml_engine_args["compilation_config"] == {"cudagraph_mode": "NONE"}
+
+
+def test_a100_profile_uses_measured_scheduler_limits():
+    deploy = load_deploy_config(_DEPLOY_DIR / "falcon_perception.yaml")
+    stages = merge_pipeline_deploy(FALCON_PERCEPTION_PIPELINE, deploy)
+
+    assert [stage.yaml_engine_args["max_num_seqs"] for stage in stages] == [4, 4]
+    assert stages[0].yaml_engine_args["max_num_batched_tokens"] == 16384
+    assert stages[0].yaml_engine_args["gpu_memory_utilization"] == 0.66
+    assert stages[1].yaml_engine_args["gpu_memory_utilization"] == 0.10
+    assert stages[0].yaml_engine_args["enable_prefix_caching"] is False
+
+
+def test_thinker_backbone_opts_into_torch_compile():
+    assert TorchCompileWithNoGuardsWrapper in FalconPerceptionBackbone.__bases__
+
+
+def test_stage_bridge_function_resolves():
+    """The pipeline references the processor by dotted path; it must exist."""
+    dotted = FALCON_PERCEPTION_PIPELINE.stages[1].sync_process_input_func
+    assert dotted, "stage bridge hook is not configured"
+    module_path, func_name = dotted.rsplit(".", 1)
+    module = importlib.import_module(module_path)
+    assert callable(getattr(module, func_name))
+
+
+def test_no_bare_bridge_function_shadows_the_token_only_hook():
+    """``_select_processor_funcs`` always prefers ``*_token_only`` in sync mode.
+
+    A bare ``thinker2segmentation`` alongside it would silently never run, which
+    the omni model guide calls out explicitly.
+    """
+    module = importlib.import_module("vllm_omni.model_executor.stage_input_processors.falcon_perception")
+    assert not hasattr(module, "thinker2segmentation")
+
+
+def test_greedy_sampling_and_both_reference_stop_tokens():
+    constraints = FALCON_PERCEPTION_PIPELINE.stages[0].sampling_constraints
+    # The reference stops on EOS *and* <|end_of_query|>; dropping the second
+    # makes generation run to max_tokens.
+    assert constraints["stop_token_ids"] == [11, 263]
+
+
+def test_registry_maps_the_published_architecture_and_both_stages():
+    # config.json ships architectures: ["FalconPerceptionForSegmentation"].
+    assert "FalconPerceptionForSegmentation" in _OMNI_MODELS
+    for arch in ("FalconPerceptionThinker", "FalconPerceptionSegmentation"):
+        assert arch in _OMNI_MODELS
+        folder, module, cls = _OMNI_MODELS[arch]
+        assert folder == "falcon_perception"
+        assert cls == arch
+
+
+def test_no_single_stage_pipeline_is_registered():
+    """Detection-only serving is deliberately absent.
+
+    A single-stage Falcon pipeline would have ``final_stage_id == 0``, so the AR
+    runner never collects ``postprocess`` output, the geometry feedback loop
+    never fires, and the model re-emits ``<|size|>`` forever — it runs and emits
+    plausible-looking garbage rather than failing. Re-adding one requires
+    generalizing the shared payload gate first.
+    """
+    assert "falcon_perception_thinker_only" not in OMNI_PIPELINES

--- a/tests/model_executor/models/falcon_perception/test_processor.py
+++ b/tests/model_executor/models/falcon_perception/test_processor.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Falcon Perception image-preprocessing and token-count parity.
+
+The expected grids below were captured from the reference implementation
+(``falcon_perception/data.py`` @ origin/main: ``resize_image_if_necessary`` ->
+``ImageProcessor.preprocess`` -> ``calculate_image_tokens``) and matched to
+float32 epsilon (1.19e-7) on the pixel values at the time of the port.
+
+Token counts feed vLLM's placeholder bookkeeping: if they drift by even one, the
+image block no longer lines up with the projected patch embeddings and the model
+fails at runtime rather than degrading gracefully.
+"""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from vllm_omni.model_executor.models.falcon_perception.configuration_falcon_perception import (
+    FalconPerceptionConfig,
+)
+from vllm_omni.model_executor.models.falcon_perception.processing_falcon_perception import (
+    FalconPerceptionImageProcessor,
+    FalconPerceptionProcessingInfo,
+    resize_image_if_necessary,
+    smart_resize_dims,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+# (width, height) -> (resized_w, resized_h, grid_h, grid_w)
+# Covers: pass-through, downscale-to-max, upscale-to-min, extreme aspect ratios,
+# and the pixel-budget clamp (1024x1024 -> 992x992).
+REFERENCE_GRIDS = [
+    (640, 480, 640, 480, 30, 40),
+    (1920, 1080, 1024, 576, 36, 64),
+    (100, 100, 256, 256, 16, 16),
+    (2048, 512, 1024, 256, 16, 64),
+    (333, 777, 336, 784, 49, 21),
+    (1024, 1024, 992, 992, 62, 62),
+    (57, 300, 192, 1024, 64, 12),
+]
+
+
+@pytest.fixture
+def processor() -> FalconPerceptionImageProcessor:
+    return FalconPerceptionImageProcessor(FalconPerceptionConfig())
+
+
+def _image(width: int, height: int) -> Image.Image:
+    rng = np.random.default_rng(0)
+    return Image.fromarray(rng.integers(0, 256, (height, width, 3), dtype=np.uint8))
+
+
+@pytest.mark.parametrize(("w", "h", "exp_w", "exp_h", "gh", "gw"), REFERENCE_GRIDS)
+def test_pixel_shape_and_grid_match_reference(processor, w, h, exp_w, exp_h, gh, gw):
+    pixels = processor(_image(w, h))
+    # Channels-last (H, W, C) — the reference keeps this layout end to end.
+    assert pixels.shape == (exp_h, exp_w, 3)
+    assert processor.target_grid(h, w) == (gh, gw)
+
+
+@pytest.mark.parametrize(("w", "h", "_exp_w", "_exp_h", "gh", "gw"), REFERENCE_GRIDS)
+def test_num_image_tokens_is_patches_plus_six(w, h, _exp_w, _exp_h, gh, gw):
+    """5 structural prefix tokens + one per patch + end_of_image."""
+    info = FalconPerceptionProcessingInfo.__new__(FalconPerceptionProcessingInfo)
+    info.ctx = SimpleNamespace(get_hf_config=lambda _cls: FalconPerceptionConfig())
+    assert info.get_num_image_tokens(image_width=w, image_height=h) == gh * gw + 6
+
+
+def test_normalisation_maps_to_symmetric_unit_range(processor):
+    """mean=std=0.5 on [0,1] pixels => exactly [-1, 1]."""
+    white = Image.fromarray(np.full((512, 512, 3), 255, dtype=np.uint8))
+    black = Image.fromarray(np.zeros((512, 512, 3), dtype=np.uint8))
+    assert torch.allclose(processor(white), torch.ones(1), atol=1e-6)
+    assert torch.allclose(processor(black), -torch.ones(1), atol=1e-6)
+
+
+def test_resize_if_necessary_passes_through_conforming_images():
+    img = _image(640, 480)
+    assert resize_image_if_necessary(img, 256, 1024) is img
+
+
+def test_resize_if_necessary_preserves_aspect_within_bounds():
+    for w, h in [(4000, 100), (10, 10), (2000, 3000)]:
+        out = resize_image_if_necessary(_image(w, h), 256, 1024)
+        assert max(out.size) <= 1024
+
+
+def test_smart_resize_dims_are_patch_aligned_and_within_budget():
+    cfg = FalconPerceptionConfig()
+    for w, h, *_ in REFERENCE_GRIDS:
+        rw, rh = resize_image_if_necessary(_image(w, h), 256, 1024).size
+        out_h, out_w = smart_resize_dims(rh, rw, factor=16, min_pixels=cfg.min_pixels, max_pixels=cfg.max_pixels)
+        assert out_h % 16 == 0 and out_w % 16 == 0
+        assert out_h * out_w <= cfg.max_pixels
+
+
+def test_smart_resize_rejects_degenerate_aspect_ratios():
+    # Both sides >= factor so the min-size guard passes; ratio 201 > 200.
+    with pytest.raises(ValueError, match="aspect ratio"):
+        smart_resize_dims(16, 16 * 201, factor=16, min_pixels=56 * 56, max_pixels=28 * 28 * 1280)
+
+
+def test_smart_resize_rejects_images_smaller_than_one_patch():
+    with pytest.raises(ValueError, match=">= 16"):
+        smart_resize_dims(8, 500, factor=16, min_pixels=56 * 56, max_pixels=28 * 28 * 1280)

--- a/tests/model_executor/models/falcon_perception/test_rope.py
+++ b/tests/model_executor/models/falcon_perception/test_rope.py
@@ -1,0 +1,361 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Falcon Perception split-RoPE parity against the reference implementation.
+
+The reference (``tiiuae/Falcon-Perception``, ``falcon_perception/rope.py``)
+operates on ``(batch, seq, heads, dim)``; the port operates on vLLM's flat
+``(num_tokens, heads, dim)``. The reference math is transcribed inline here so
+the test is self-contained — it was verified bit-exact (``max|diff| == 0.0``)
+against the actual reference module when the port was written.
+
+Getting any of this subtly wrong produces a model that loads and runs but emits
+garbage, so these are exact-equality assertions, not tolerances.
+"""
+
+import einops as E
+import pytest
+import torch
+
+from vllm_omni.model_executor.models.falcon_perception.rope import (
+    apply_3d_rotary_emb,
+    apply_golden_freqs_cis_to_visual_pos,
+    compute_image_spatial_positions,
+    compute_pos_hw,
+    pack_image_grid_positions,
+    precompute_freqs_cis,
+    unpack_image_grid_positions,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+HEAD_DIM = 128
+N_HEADS = 16
+ROPE_DIM = HEAD_DIM // 2  # temporal half
+N_FREQS = ROPE_DIM // 2  # complex pairs / golden freq rows
+
+
+# --------------------------------------------------------------------------
+# Reference math, transcribed from falcon_perception/rope.py @ origin/main.
+# --------------------------------------------------------------------------
+def _ref_precompute_freqs_cis(dim: int, end: int, theta: float = 10000.0) -> torch.Tensor:
+    freqs = 1.0 / (theta ** (torch.arange(0, dim, 2)[: (dim // 2)].float() / dim))
+    t = torch.arange(end, device=freqs.device)
+    freqs = torch.outer(t, freqs).float()
+    return torch.polar(torch.ones_like(freqs), freqs)
+
+
+def _ref_apply_rotary_emb(xq, xk, freqs_cis):
+    xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
+    xk_ = torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
+    freqs_cis = E.rearrange(freqs_cis, "b s d -> b s 1 d")
+    xq_out = torch.view_as_real(xq_ * freqs_cis).flatten(3)
+    xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(3)
+    return xq_out.type_as(xq), xk_out.type_as(xk)
+
+
+def _ref_golden_freqs(freqs_hfp, pos_bsp):
+    theta = torch.einsum("bsp,hfp->bshf", pos_bsp.float(), freqs_hfp.float())
+    return torch.polar(torch.ones_like(theta), theta)
+
+
+def _ref_golden_rotary(x, freqs_cis):
+    xf = x.float()
+    x_even, x_odd = xf[..., 0::2], xf[..., 1::2]
+    cos, sin = freqs_cis.real, freqs_cis.imag
+    out = torch.empty_like(xf)
+    out[..., 0::2] = x_even * cos - x_odd * sin
+    out[..., 1::2] = x_even * sin + x_odd * cos
+    return out.type_as(x)
+
+
+def _ref_apply_3d(xq, xk, freqs_cis, freqs_cis_2d):
+    xq_t, xq_hw = xq.chunk(2, dim=-1)
+    xk_t, xk_hw = xk.chunk(2, dim=-1)
+    xq_t, xk_t = _ref_apply_rotary_emb(xq_t, xk_t, freqs_cis)
+    if freqs_cis_2d is not None:
+        xq_hw = _ref_golden_rotary(xq_hw, freqs_cis_2d)
+        xk_hw = _ref_golden_rotary(xk_hw, freqs_cis_2d)
+    return (
+        torch.cat([xq_t, xq_hw], dim=-1).type_as(xq),
+        torch.cat([xk_t, xk_hw], dim=-1).type_as(xk),
+    )
+
+
+# --------------------------------------------------------------------------
+
+
+def _fixture(seq_len: int = 50, grid_h: int = 5, grid_w: int = 7, img_start: int = 3):
+    torch.manual_seed(0)
+    q = torch.randn(1, seq_len, N_HEADS, HEAD_DIM)
+    k = torch.randn(1, seq_len, N_HEADS, HEAD_DIM)
+    golden = torch.randn(N_HEADS, N_FREQS, 2)
+
+    pos_t = torch.arange(seq_len).clamp(max=20)
+    freqs_cis = _ref_precompute_freqs_cis(ROPE_DIM, 4096)[pos_t].unsqueeze(0)
+
+    pos_hw = torch.zeros(seq_len, 2)
+    n_img = grid_h * grid_w
+    pos_hw[img_start : img_start + n_img] = compute_image_spatial_positions(grid_h, grid_w)
+    return q, k, golden, freqs_cis, pos_hw
+
+
+def test_precompute_freqs_cis_matches_reference():
+    ours = precompute_freqs_cis(ROPE_DIM, 4096, 10000.0)
+    ref = _ref_precompute_freqs_cis(ROPE_DIM, 4096, 10000.0)
+    assert ours.shape == (4096, N_FREQS)
+    assert torch.equal(ours, ref)
+
+
+def test_golden_freqs_match_reference_and_are_identity_for_text():
+    _, _, golden, _, pos_hw = _fixture()
+    ours = apply_golden_freqs_cis_to_visual_pos(golden, pos_hw)
+    ref = _ref_golden_freqs(golden, pos_hw.unsqueeze(0))[0]
+    assert torch.equal(ours, ref)
+
+    # Text tokens sit at (0, 0) -> theta 0 -> exactly 1+0j, so the spatial half
+    # is a genuine no-op outside images (and can be skipped during decode).
+    text_row = ours[0]
+    assert torch.equal(text_row.real, torch.ones_like(text_row.real))
+    assert torch.equal(text_row.imag, torch.zeros_like(text_row.imag))
+
+
+def test_apply_3d_rotary_matches_reference_with_and_without_image():
+    q, k, golden, freqs_cis, pos_hw = _fixture()
+    golden_cis = apply_golden_freqs_cis_to_visual_pos(golden, pos_hw)
+
+    ours_q, ours_k = apply_3d_rotary_emb(q[0], k[0], freqs_cis[0], golden_cis)
+    ref_q, ref_k = _ref_apply_3d(q, k, freqs_cis, golden_cis.unsqueeze(0))
+    assert torch.equal(ours_q, ref_q[0])
+    assert torch.equal(ours_k, ref_k[0])
+
+    # Decode step: no image in the batch, spatial half must pass through.
+    dec_q, dec_k = apply_3d_rotary_emb(q[0], k[0], freqs_cis[0], None)
+    ref_dq, ref_dk = _ref_apply_3d(q, k, freqs_cis, None)
+    assert torch.equal(dec_q, ref_dq[0])
+    assert torch.equal(dec_k, ref_dk[0])
+
+    # The compiled backbone always supplies a spatial-frequency tensor. Its
+    # tensor gate must nevertheless preserve the reference's decode path
+    # exactly, rather than relying on an identity float32 rotation.
+    gated_q, gated_k = apply_3d_rotary_emb(q[0], k[0], freqs_cis[0], golden_cis, torch.tensor([False]))
+    assert torch.equal(gated_q, ref_dq[0])
+    assert torch.equal(gated_k, ref_dk[0])
+
+
+def test_spatial_grid_is_aspect_normalised_and_h_major():
+    """The grid must be h-major to match the patchify order in embed_multimodal."""
+    grid = compute_image_spatial_positions(2, 3)
+    assert grid.shape == (6, 2)
+    # h (row) index changes slowest.
+    assert torch.equal(grid[0:3, 0], grid[0].expand(3, 2)[:, 0])
+    assert grid[0, 0] < grid[3, 0]
+    # Aspect normalisation: wider than tall -> w spans a wider range than h.
+    assert grid[:, 1].max() > grid[:, 0].max()
+
+
+# --------------------------------------------------------------------------
+# The grid rides in rows 1/2 of the M-RoPE positions buffer.
+#
+# It cannot ride in state set by ``embed_multimodal``: on a multimodal encoder
+# cache hit (same image, different query) vLLM serves the stored embedding and
+# never makes that call, so a stashed grid is None, ``pos_hw`` is None, and the
+# golden 2-D RoPE is silently dropped for every image token. The model still
+# runs — it just emits garbage (measured: 18 masks instead of 121).
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("grid", [(5, 7), (7, 5), (62, 62), (26, 46), (1, 9), (9, 1), (1, 1)])
+def test_packed_grid_round_trips_exactly(grid):
+    """Reconstruction must be bit-exact, not close — it feeds a rotation."""
+    grid_h, grid_w = grid
+    got = unpack_image_grid_positions(pack_image_grid_positions(grid_h, grid_w))
+    assert torch.equal(got, compute_image_spatial_positions(grid_h, grid_w))
+
+
+def _positions_with_image(seq_len: int, spans: list[tuple[int, tuple[int, int]]]) -> torch.Tensor:
+    """A ``[3, seq_len]`` buffer with packed grids at the given start offsets."""
+    positions = torch.zeros((3, seq_len), dtype=torch.long)
+    positions[0] = torch.arange(seq_len)
+    for start, (grid_h, grid_w) in spans:
+        packed = pack_image_grid_positions(grid_h, grid_w)
+        positions[1:3, start : start + packed.shape[0]] = packed.t()
+    return positions
+
+
+def test_compute_pos_hw_scatters_only_onto_image_tokens():
+    grid_h, grid_w, img_start = 5, 7, 3
+    n_img = grid_h * grid_w
+    input_ids = torch.full((50,), 999, dtype=torch.long)
+    input_ids[img_start : img_start + n_img] = 227
+
+    got = compute_pos_hw(input_ids, _positions_with_image(50, [(img_start, (grid_h, grid_w))]), image_token_id=227)
+    expected = torch.zeros(50, 2)
+    expected[img_start : img_start + n_img] = compute_image_spatial_positions(grid_h, grid_w)
+    assert torch.equal(got, expected)
+
+
+def test_compute_pos_hw_keeps_two_batched_images_of_different_sizes_apart():
+    """A batch concatenates requests, so one shared ``max()`` would be wrong."""
+    first, second = (5, 7), (3, 11)
+    n_first, n_second = first[0] * first[1], second[0] * second[1]
+    start_a, start_b = 2, 2 + n_first + 6
+
+    input_ids = torch.full((start_b + n_second + 4,), 999, dtype=torch.long)
+    input_ids[start_a : start_a + n_first] = 227
+    input_ids[start_b : start_b + n_second] = 227
+    positions = _positions_with_image(input_ids.shape[0], [(start_a, first), (start_b, second)])
+
+    got = compute_pos_hw(input_ids, positions, image_token_id=227)
+    assert torch.equal(got[start_a : start_a + n_first], compute_image_spatial_positions(*first))
+    assert torch.equal(got[start_b : start_b + n_second], compute_image_spatial_positions(*second))
+
+
+def test_compute_pos_hw_survives_a_window_that_starts_mid_image():
+    """Prefix caching resumes inside the image span; the runner slices these
+    rows by ``num_computed_tokens``, so only a tail of the grid is present.
+
+    Carrying the grid *dimensions* on every token — not just the indices — is
+    what makes that tail reconstruct to the same values as the full pass.
+    """
+    grid_h, grid_w, img_start = 5, 7, 3
+    n_img = grid_h * grid_w
+    input_ids = torch.full((50,), 999, dtype=torch.long)
+    input_ids[img_start : img_start + n_img] = 227
+    positions = _positions_with_image(50, [(img_start, (grid_h, grid_w))])
+
+    full = compute_pos_hw(input_ids, positions, image_token_id=227)
+    # Resume 20 tokens in, i.e. 17 patches into the image.
+    resumed = compute_pos_hw(input_ids[20:], positions[:, 20:], image_token_id=227)
+    assert torch.equal(resumed, full[20:])
+
+
+def test_compute_pos_hw_returns_none_when_there_is_nothing_to_rotate():
+    # Pure decode step: no image tokens in the batch.
+    assert compute_pos_hw(torch.full((4,), 999), _positions_with_image(4, []), image_token_id=227) is None
+    # Profile run: image tokens but a zeroed positions buffer, so no packed grid.
+    assert compute_pos_hw(torch.full((4,), 227), torch.zeros((3, 4), dtype=torch.long), image_token_id=227) is None
+
+
+def test_mrope_positions_carry_pos_t_and_the_grid_together():
+    """End-to-end: what ``get_mrope_input_positions`` writes is what
+    ``compute_pos_hw`` reads back, and row 0 still carries ``pos_t`` alone."""
+    from types import SimpleNamespace
+
+    from vllm_omni.model_executor.models.falcon_perception.configuration_falcon_perception import (
+        FalconPerceptionConfig,
+    )
+    from vllm_omni.model_executor.models.falcon_perception.falcon_perception_thinker import (
+        FalconPerceptionThinker,
+    )
+
+    config = FalconPerceptionConfig()
+    grid_h, grid_w = 3, 5
+    tokens = (
+        [7, 8]
+        + config.image_structural_token_ids
+        + [config.img_id] * (grid_h * grid_w)
+        + [config.img_end_id]
+        + [9, 10, 11]
+    )
+    mm_features = [
+        SimpleNamespace(data=SimpleNamespace(get_data=lambda: {"image_grid_hw": torch.tensor([grid_h, grid_w])}))
+    ]
+    stub = SimpleNamespace(config=config, _end_of_image_token_id=config.img_end_id)
+
+    positions, delta = FalconPerceptionThinker.get_mrope_input_positions(stub, tokens, mm_features=mm_features)
+
+    # Row 0: the whole image block collapses onto the <image_cls> position.
+    img_block = slice(2, 2 + 5 + grid_h * grid_w + 1)
+    assert torch.equal(positions[0][img_block], torch.full((5 + grid_h * grid_w + 1,), 2))
+    assert positions[0].tolist()[-3:] == [3, 4, 5]
+    assert delta == int(positions[0].max()) + 1 - len(tokens)
+
+    # Rows 1/2: the grid, recovered exactly.
+    pos_hw = compute_pos_hw(torch.tensor(tokens), positions, image_token_id=config.img_id)
+    patches = slice(2 + 5, 2 + 5 + grid_h * grid_w)
+    assert torch.equal(pos_hw[patches], compute_image_spatial_positions(grid_h, grid_w))
+    assert torch.equal(pos_hw[:2], torch.zeros(2, 2))
+    assert torch.equal(pos_hw[patches.stop :], torch.zeros(len(tokens) - patches.stop, 2))
+
+
+def test_mrope_positions_reject_a_grid_that_disagrees_with_the_placeholder_run():
+    """A prompt update that leaves the literal ``<|image|>`` in place gives one
+    patch token too many; that must fail loudly, not rotate by a part-patch."""
+    from types import SimpleNamespace
+
+    from vllm_omni.model_executor.models.falcon_perception.configuration_falcon_perception import (
+        FalconPerceptionConfig,
+    )
+    from vllm_omni.model_executor.models.falcon_perception.falcon_perception_thinker import (
+        FalconPerceptionThinker,
+    )
+
+    config = FalconPerceptionConfig()
+    tokens = [*config.image_structural_token_ids, *([config.img_id] * 16), config.img_end_id]
+    mm_features = [SimpleNamespace(data=SimpleNamespace(get_data=lambda: {"image_grid_hw": torch.tensor([3, 5])}))]
+    stub = SimpleNamespace(config=config, _end_of_image_token_id=config.img_end_id)
+
+    with pytest.raises(ValueError, match="must agree exactly"):
+        FalconPerceptionThinker.get_mrope_input_positions(stub, tokens, mm_features=mm_features)
+
+
+# --------------------------------------------------------------------------
+# freqs_cis_golden is a BUFFER, not a parameter. vLLM's missing-weight guard
+# only inspects named_parameters()
+# (model_loader/default_loader.py: weights_to_load = {name for name, _ in
+# model.named_parameters()}), so a checkpoint without this key would leave
+# torch.empty memory serving as the learned 2-D rotation — no exception, and
+# masks that look plausible but are wrong. load_weights must catch it.
+# --------------------------------------------------------------------------
+
+
+def _thinker_stub():
+    """Minimal stand-in exposing only what ``load_weights`` reads before the guard."""
+    from types import SimpleNamespace
+
+    from vllm_omni.model_executor.models.falcon_perception.configuration_falcon_perception import (
+        FalconPerceptionConfig,
+    )
+
+    config = FalconPerceptionConfig()
+    golden = torch.zeros((config.num_attention_heads, config.head_dim // 4, 2))
+    return SimpleNamespace(
+        named_parameters=dict,
+        config=config,
+        model=SimpleNamespace(freqs_cis_golden=golden),
+        _map_weight_name=lambda _name: None,
+    )
+
+
+@pytest.fixture
+def _no_tp(monkeypatch):
+    """``load_weights`` reads the TP rank/size; no distributed group in a CPU test."""
+    import vllm_omni.model_executor.models.falcon_perception.falcon_perception_thinker as mod
+
+    monkeypatch.setattr(mod, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(mod, "get_tensor_model_parallel_world_size", lambda: 1)
+
+
+def test_load_weights_raises_when_the_golden_freqs_buffer_is_absent(_no_tp):
+    from vllm_omni.model_executor.models.falcon_perception.falcon_perception_thinker import (
+        FalconPerceptionThinker,
+    )
+
+    stub = _thinker_stub()
+    # A checkpoint carrying everything *except* freqs_cis_golden.
+    weights = iter([("tok_embeddings.weight", torch.zeros(4, 4))])
+    with pytest.raises(ValueError, match="freqs_cis_golden"):
+        FalconPerceptionThinker.load_weights(stub, weights)
+
+
+def test_load_weights_accepts_the_checkpoint_when_the_buffer_is_present(_no_tp):
+    from vllm_omni.model_executor.models.falcon_perception.falcon_perception_thinker import (
+        FalconPerceptionThinker,
+    )
+
+    stub = _thinker_stub()
+    n_heads = stub.config.num_attention_heads
+    golden = torch.randn(n_heads, stub.config.head_dim // 4, 2)
+    loaded = FalconPerceptionThinker.load_weights(stub, iter([("freqs_cis_golden", golden)]))
+    assert "model.freqs_cis_golden" in loaded
+    assert torch.equal(stub.model.freqs_cis_golden, golden)

--- a/tests/model_executor/models/falcon_perception/test_segmentation.py
+++ b/tests/model_executor/models/falcon_perception/test_segmentation.py
@@ -1,0 +1,357 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Falcon Perception mask head: geometry, chunking, and the AnyUp cache.
+
+These run on CPU with tiny tensors and no checkpoint. They target the parts of
+the stage whose failures are silent rather than loud — a wrong canvas or a
+badly stitched chunk still returns plausible masks, just of the wrong pixels.
+"""
+
+from collections import OrderedDict
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_omni.model_executor.models.falcon_perception.falcon_perception_segmentation import (
+    DEFAULT_HR_UPSAMPLE_RATIO,
+    FalconPerceptionSegmentation,
+    _apply_mask_nms,
+    _boxes_to_xywh,
+    _mask_nms,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+PATCH = 16
+MAX_IMAGE = 1024
+
+
+# --------------------------------------------------------------------------
+# Wiring failures must raise, not return empty masks.
+#
+# An empty mask list with a success status is indistinguishable from "nothing
+# detected", so a broken payload would silently serve maskless results forever.
+# These three are deterministic faults: they surface on the first request.
+# --------------------------------------------------------------------------
+
+
+def _seg_stub():
+    """Enough of the stage to reach the validation branches."""
+    from vllm_omni.model_executor.models.falcon_perception.configuration_falcon_perception import (
+        FalconPerceptionConfig,
+    )
+
+    config = FalconPerceptionConfig()
+    stub = SimpleNamespace(
+        config=config,
+        segm_out_dim=config.segm_out_dim,
+        patch_size=config.spatial_patch_size,
+        max_image_size=config.max_image_size,
+        parameters=lambda: iter([torch.zeros(1)]),
+    )
+    return stub
+
+
+def _run(stub, info, kwargs=None):
+    return FalconPerceptionSegmentation._run_one_request(stub, info, kwargs or {})
+
+
+# --------------------------------------------------------------------------
+# Square canvas geometry.
+#
+# The reference pads the image and the feature grid to a square max_image_size
+# before AnyUp and crops afterwards. Running on the native non-square grid is
+# 3.3x faster BUT destroys the masks: because AnyUp was trained on square inputs.
+# These assert the padded extent and the crop-back extent explicitly, since a
+# regression here produces smeared masks rather than an exception.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("grid", [(26, 46), (51, 64), (36, 64), (64, 64), (16, 16)])
+def test_square_canvas_pads_to_max_image_size_and_crops_back_to_the_image(grid):
+    grid_h, grid_w = grid
+    img_h, img_w = grid_h * PATCH, grid_w * PATCH
+
+    # What the stage feeds AnyUp: image padded to the square canvas, features
+    # padded to the square patch grid, output a square side.
+    square = ((MAX_IMAGE + PATCH - 1) // PATCH) * PATCH
+    square_patches = square // PATCH
+    ratio = DEFAULT_HR_UPSAMPLE_RATIO
+
+    stub = _seg_stub()
+    stub.conv_segm = lambda x: torch.zeros(1, 256, x.shape[2], x.shape[3])
+    stub.proj_segm = lambda x: torch.zeros(x.shape[0], 256)
+    stub._hr_cache_lookup = lambda k, e: None
+    stub._hr_cache_store = lambda k, v: None
+
+    captured = {}
+
+    def mock_upsampler(images, features, attn_mask, output_size):
+        captured["images"] = images
+        captured["features"] = features
+        captured["output_size"] = output_size
+        # Return a tensor we can trace through the crop
+        return [
+            torch.arange(256 * output_size[0] * output_size[1], dtype=torch.float32).reshape(
+                256, output_size[0], output_size[1]
+            )
+        ]
+
+    stub.itok_upsampler = mock_upsampler
+
+    # Intercept the cropped hr_features before they are consumed by the rest of the pipeline
+    def mock_cache_store(k, v):
+        captured["cropped_hr"] = v
+
+    stub._hr_cache_store = mock_cache_store
+
+    pixels = torch.zeros(img_h, img_w, 3)
+    info = {
+        "hidden_states": {
+            "image_features": torch.zeros(grid_h * grid_w, 1024),
+            "seg_features": torch.zeros(1, 1024),
+            "pixel_values": pixels,
+        }
+    }
+
+    _run(stub, info)
+
+    # Assert padding
+    assert captured["images"].shape == (1, 3, square, square)
+    assert captured["features"].shape == (1, 256, square_patches, square_patches)
+    assert captured["output_size"] == (square_patches * ratio, square_patches * ratio)
+
+    # And what it keeps afterwards: this image's own extent, not the canvas.
+    out_side = square_patches * ratio
+    crop_h, crop_w = grid_h * ratio, grid_w * ratio
+    assert crop_h <= out_side and crop_w <= out_side
+
+    cropped = captured["cropped_hr"]
+    assert cropped.shape == (256, crop_h, crop_w)
+    assert (crop_h, crop_w) == (grid_h * 8, grid_w * 8)
+
+    # The pad is bottom/right, so the valid region is the top-left corner.
+    # We returned arange from mock_upsampler, so we can verify the crop slice.
+    hr = captured["images"].new_empty(0)  # just to get the device/dtype if needed, but we returned CPU float32
+    hr = torch.arange(256 * out_side * out_side, dtype=torch.float32).reshape(256, out_side, out_side)
+    assert torch.equal(cropped[0, :3, :3], hr[0, :3, :3])
+
+
+# --------------------------------------------------------------------------
+# Chunked mask decode. Dense scenes carry 250+ instances and materialising all
+# (n, H, W) float32 logits at once OOMs, so decoding is chunked — which must be
+# arithmetically identical to one pass.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n_inst", [1, 31, 32, 33, 64, 65])
+def test_chunked_mask_decode_matches_a_single_pass(n_inst):
+    from vllm_omni.model_executor.models.falcon_perception.falcon_perception_segmentation import _MASK_CHUNK
+
+    torch.manual_seed(0)
+    seg = torch.randn(n_inst, 8)
+    hr = torch.randn(8, 5, 7)
+    threshold = 0.3
+
+    one = (torch.sigmoid(torch.einsum("kc,chw->khw", seg, hr)) > threshold).to(torch.uint8)
+
+    chunks = []
+    for start in range(0, seg.shape[0], _MASK_CHUNK):
+        block = seg[start : start + _MASK_CHUNK]
+        chunks.append((torch.sigmoid(torch.einsum("kc,chw->khw", block, hr)) > threshold).to(torch.uint8))
+    chunked = torch.cat(chunks, dim=0)
+
+    assert chunked.shape == one.shape == (n_inst, 5, 7)
+    assert torch.equal(chunked, one)
+
+
+# --------------------------------------------------------------------------
+# Reference mask NMS. It must suppress duplicate masks and apply the same kept
+# indices to the boxes, or mask/geometry pairs silently become misaligned.
+# --------------------------------------------------------------------------
+
+
+def test_mask_nms_suppresses_overlapping_duplicates():
+    masks = torch.zeros((3, 8, 8), dtype=torch.uint8)
+    masks[0, 1:5, 1:5] = 1
+    masks[1, 1:5, 1:5] = 1
+    masks[2, 6:8, 6:8] = 1
+
+    keep = _mask_nms(masks)
+
+    assert keep.tolist() == [0, 2]
+
+
+def test_mask_nms_filters_boxes_with_the_same_indices():
+    masks = torch.zeros((3, 8, 8), dtype=torch.uint8)
+    masks[0, 1:5, 1:5] = 1
+    masks[1, 1:5, 1:5] = 1
+    masks[2, 6:8, 6:8] = 1
+    boxes = torch.tensor(
+        [
+            [0.1, 0.1, 0.2, 0.2],
+            [0.3, 0.3, 0.4, 0.4],
+            [0.5, 0.5, 0.6, 0.6],
+        ]
+    )
+
+    kept_masks, kept_boxes = _apply_mask_nms(masks, boxes)
+
+    assert kept_masks.shape[0] == kept_boxes.shape[0] == 2
+    assert torch.equal(kept_boxes, boxes[[0, 2]])
+
+
+# --------------------------------------------------------------------------
+# AnyUp output cache. A hit is bit-exact by construction (the features depend
+# only on the image), so the risk is not numerical — it is serving the wrong
+# entry, or letting the budget stop binding.
+# --------------------------------------------------------------------------
+
+
+def _cache_stub(budget_mb: int = 1):
+    stub = SimpleNamespace(
+        _hr_cache=OrderedDict(),
+        _hr_cache_bytes=0,
+        _hr_cache_budget=budget_mb * 1024 * 1024,
+    )
+    stub._hr_cache_lookup = lambda k, e: FalconPerceptionSegmentation._hr_cache_lookup(stub, k, e)
+    stub._hr_cache_store = lambda k, v: FalconPerceptionSegmentation._hr_cache_store(stub, k, v)
+    return stub
+
+
+def test_cache_returns_the_stored_tensor_on_a_hit_and_none_on_a_miss():
+    stub = _cache_stub()
+    value = torch.randn(4, 8, 8)
+    key = (123, 8, 1024, 26, 46)
+    assert stub._hr_cache_lookup(key, tuple(value.shape)) is None
+    stub._hr_cache_store(key, value)
+    hit = stub._hr_cache_lookup(key, tuple(value.shape))
+    assert hit is not None and torch.equal(hit, value)
+    assert stub._hr_cache_lookup((999, 8, 1024, 26, 46), tuple(value.shape)) is None
+
+
+def test_a_shape_disagreement_is_a_miss_not_a_wrong_feature_map():
+    """A hash collision must degrade to recompute, never reshape the mask head."""
+    stub = _cache_stub()
+    key = (123, 8, 1024, 26, 46)
+    stub._hr_cache_store(key, torch.randn(4, 8, 8))
+    assert stub._hr_cache_lookup(key, (4, 9, 9)) is None
+
+
+def test_no_key_means_no_caching_rather_than_a_shared_entry():
+    stub = _cache_stub()
+    stub._hr_cache_store(None, torch.randn(4, 8, 8))
+    assert len(stub._hr_cache) == 0
+    assert stub._hr_cache_lookup(None, (4, 8, 8)) is None
+
+
+def test_budget_evicts_least_recently_used_and_accounting_stays_exact():
+    # 4 KB entries, 1 MB budget -> 256 fit; use a tiny budget to force eviction.
+    stub = _cache_stub()
+    stub._hr_cache_budget = 3 * 4 * 1024  # exactly 3 entries of (4, 16, 16) float32
+    entries = {}
+    for i in range(5):
+        v = torch.randn(4, 16, 16)
+        entries[i] = v
+        stub._hr_cache_store((i, 8, 1024, 4, 4), v)
+
+    assert len(stub._hr_cache) <= 3
+    # Accounting must equal the real footprint, or the budget silently stops binding.
+    real = sum(v.element_size() * v.numel() for v in stub._hr_cache.values())
+    assert stub._hr_cache_bytes == real
+    # The oldest keys went first.
+    assert (0, 8, 1024, 4, 4) not in stub._hr_cache
+    assert (4, 8, 1024, 4, 4) in stub._hr_cache
+
+
+def test_replacing_a_key_with_a_different_size_keeps_the_byte_count_honest():
+    """The shape-mismatch miss path re-stores the same key with a new shape."""
+    stub = _cache_stub()
+    key = (7, 8, 1024, 4, 4)
+    stub._hr_cache_store(key, torch.randn(4, 16, 16))
+    first = stub._hr_cache_bytes
+    stub._hr_cache_store(key, torch.randn(4, 32, 32))
+    assert stub._hr_cache_bytes != first
+    real = sum(v.element_size() * v.numel() for v in stub._hr_cache.values())
+    assert stub._hr_cache_bytes == real, "stale bytes left behind would unbind the budget"
+
+
+def test_a_zero_budget_disables_the_cache():
+    stub = _cache_stub(budget_mb=0)
+    stub._hr_cache_store((1, 8, 1024, 4, 4), torch.randn(4, 8, 8))
+    assert len(stub._hr_cache) == 0
+
+
+# --------------------------------------------------------------------------
+# Box packing.
+# --------------------------------------------------------------------------
+
+
+def test_boxes_are_truncated_to_the_shorter_stream_rather_than_mispaired():
+    empty = torch.zeros((0, 4))
+    xy = torch.tensor([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]])
+    hw = torch.tensor([[0.7, 0.8], [0.9, 1.0]])
+    out = _boxes_to_xywh(xy, hw, empty)
+    assert out.shape == (2, 4)
+    # hw is stored (h, w) and emitted as (w, h) after the flip.
+    assert torch.allclose(out[0], torch.tensor([0.1, 0.2, 0.8, 0.7]))
+
+
+def test_boxes_missing_entirely_give_the_empty_tensor():
+    empty = torch.zeros((0, 4))
+    assert _boxes_to_xywh(None, None, empty).shape == (0, 4)
+    assert _boxes_to_xywh(torch.zeros((0, 2)), torch.zeros((0, 2)), empty).shape == (0, 4)
+
+
+# --------------------------------------------------------------------------
+# Wiring failures must raise, not return empty masks.
+#
+# An empty mask list with a success status is indistinguishable from "nothing
+# detected", so a broken payload would silently serve maskless results forever.
+# These three are deterministic faults: they surface on the first request.
+# --------------------------------------------------------------------------
+
+
+def test_missing_payload_raises_rather_than_reporting_nothing_detected():
+    with pytest.raises(ValueError, match="stage payload missing"):
+        _run(_seg_stub(), {"hidden_states": {}})
+
+
+def test_missing_image_raises():
+    info = {
+        "hidden_states": {
+            "image_features": torch.zeros(4, 1024),
+            "seg_features": torch.zeros(2, 1024),
+        }
+    }
+    with pytest.raises(ValueError, match="no image reached the mask head"):
+        _run(_seg_stub(), info)
+
+
+def test_a_grid_that_disagrees_with_the_features_raises():
+    """Decoding against a misaligned feature map would give confident, wrong masks."""
+    # 2x2 patch grid = 4 rows expected; supply 7.
+    pixels = torch.zeros(2 * 16, 2 * 16, 3)
+    info = {
+        "hidden_states": {
+            "image_features": torch.zeros(7, 1024),
+            "seg_features": torch.zeros(1, 1024),
+            "pixel_values": pixels,
+        }
+    }
+    with pytest.raises(ValueError, match="image feature rows"):
+        _run(_seg_stub(), info)
+
+
+def test_no_seg_tokens_is_a_normal_empty_result_not_an_error():
+    """A detection-only answer is legitimate — this one must NOT raise."""
+    info = {
+        "hidden_states": {
+            "image_features": torch.zeros(4, 1024),
+            "seg_features": torch.zeros(0, 1024),
+        }
+    }
+    masks, boxes = _run(_seg_stub(), info)
+    assert masks.shape[0] == 0
+    assert boxes.shape == (0, 4)

--- a/tests/model_executor/models/falcon_perception/test_thinker_geometry.py
+++ b/tests/model_executor/models/falcon_perception/test_thinker_geometry.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Falcon Perception coordinate normalization and request-scoped deduplication."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_omni.model_executor.models.falcon_perception.falcon_perception_thinker import (
+    FalconPerceptionThinker,
+    _select_coordinate_from_logits,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_coordinate_bins_cover_the_closed_unit_interval():
+    bins = 4
+    logits = torch.full((1, 2, bins), -10.0)
+    logits[0, 0, -1] = 10.0
+    logits[0, 1, -1] = 10.0
+    stub = SimpleNamespace(coord_decoder=lambda hidden: logits.reshape(1, -1).expand(hidden.shape[0], -1))
+
+    decoded = FalconPerceptionThinker._decode_coords(stub, torch.zeros(1, 3))
+
+    assert torch.equal(decoded, torch.ones(1, 2))
+
+
+def test_coordinate_dedup_is_scoped_to_the_supplied_request_history():
+    # Both axes prefer bin 1, then bin 2. With four bins those centres are
+    # 1/3 and 2/3 respectively.
+    logits = torch.tensor(
+        [
+            [0.0, 5.0, 4.0, 1.0],
+            [0.0, 5.0, 4.0, 1.0],
+        ]
+    )
+    repeated_for_request_a = torch.tensor([[1.0 / 3.0, 1.0 / 3.0]])
+
+    selected_a = _select_coordinate_from_logits(logits, repeated_for_request_a)
+    selected_b = _select_coordinate_from_logits(logits, None)
+
+    assert torch.allclose(selected_a, torch.tensor([[2.0 / 3.0, 2.0 / 3.0]]))
+    assert torch.allclose(selected_b, torch.tensor([[1.0 / 3.0, 1.0 / 3.0]]))
+
+
+def test_make_omni_output_emits_selected_coordinates_as_per_request_deltas():
+    stub = SimpleNamespace(
+        config=SimpleNamespace(perception_heads=True),
+        _decode_coords=lambda hidden: torch.zeros(hidden.shape[0], 2),
+        _decode_sizes=lambda hidden: torch.ones(hidden.shape[0], 2),
+    )
+    runtime_infos = [
+        {
+            "falcon_perception_geometry": {
+                "selected_xy": torch.tensor([[0.25, 0.75]]),
+                "selected_xy_active": torch.tensor([True]),
+            }
+        },
+        {
+            "falcon_perception_geometry": {
+                "selected_xy": torch.tensor([[0.5, 0.5]]),
+                "selected_xy_active": torch.tensor([False]),
+            }
+        },
+    ]
+
+    output = FalconPerceptionThinker.make_omni_output(
+        stub,
+        torch.zeros(2, 3),
+        runtime_additional_information=runtime_infos,
+    )
+    selected = output.multimodal_outputs["hidden_states"]["selected_box_xy"]
+
+    assert torch.equal(selected[0], torch.tensor([[0.25, 0.75]]))
+    assert selected[1].shape == (0, 2)

--- a/tests/model_executor/stage_input_processors/test_falcon_perception.py
+++ b/tests/model_executor/stage_input_processors/test_falcon_perception.py
@@ -1,0 +1,298 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Falcon Perception thinker -> segmentation stage bridge.
+
+The row indexing is the subtle part and the easiest thing to get silently
+wrong: ``hidden[i]`` is the state that *produced* token ``i + 1``, so the row
+behind ``output_token_ids[i]`` is ``hidden[len(prompt) - 1 + i]``. An off-by-one
+here still runs and still produces masks — just of the wrong instances — so it
+is asserted directly against hand-computed indices.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_omni.model_executor.stage_input_processors.falcon_perception import (
+    build_segmentation_payload,
+    thinker2segmentation_token_only,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+IMG_ID = 227
+SEG_ID = 262
+COORD_ID = 240
+SIZE_ID = 241
+HIDDEN = 8
+
+
+def _source_output(prompt_ids, output_ids, latent, xy=None, hw=None, finished=True):
+    """Mimic a stage-0 RequestOutput carrying its latent trajectory."""
+    mm = {"latent": latent}
+    if xy is not None:
+        mm["geometry"] = {"xy": xy, "hw": hw}
+    completion = SimpleNamespace(cumulative_token_ids=output_ids, multimodal_output=mm)
+    return SimpleNamespace(finished=finished, prompt_token_ids=prompt_ids, outputs=[completion])
+
+
+def test_selects_image_rows_and_seg_rows_at_the_right_offsets():
+    # prompt: [text, cls, img, img, img, eoi]  -> image rows at 2, 3, 4
+    prompt = [1, 244, IMG_ID, IMG_ID, IMG_ID, 230]
+    # output: [<object>, <coord>, <size>, <seg>, <seg>]
+    output = [239, COORD_ID, SIZE_ID, SEG_ID, SEG_ID]
+    n_prompt = len(prompt)
+
+    # Row value == row index, so the assertions read directly.
+    hidden = torch.arange(n_prompt + len(output), dtype=torch.float32).unsqueeze(1).repeat(1, HIDDEN)
+
+    payload = build_segmentation_payload(hidden, prompt, output)
+
+    image_features = payload["hidden_states"]["image_features"]
+    assert image_features.shape == (3, HIDDEN)
+    assert image_features[:, 0].tolist() == [2.0, 3.0, 4.0]
+
+    # <seg> is at output indices 3 and 4 -> hidden rows 6-1+3=8 and 6-1+4=9.
+    seg_features = payload["hidden_states"]["seg_features"]
+    assert seg_features.shape == (2, HIDDEN)
+    assert seg_features[:, 0].tolist() == [8.0, 9.0]
+
+    assert bool(payload["meta"]["finished"])
+    assert int(payload["meta"]["num_seg_tokens"]) == 2
+    assert int(payload["meta"]["num_image_tokens"]) == 3
+
+
+def test_no_seg_tokens_yields_empty_features_not_a_failure():
+    """A detection-only answer is legitimate and must still hand over the image."""
+    prompt = [1, IMG_ID, IMG_ID]
+    output = [239, COORD_ID, SIZE_ID]
+    hidden = torch.randn(len(prompt) + len(output), HIDDEN)
+
+    payload = build_segmentation_payload(hidden, prompt, output)
+    assert payload is not None
+    assert payload["hidden_states"]["seg_features"].shape == (0, HIDDEN)
+    assert payload["hidden_states"]["image_features"].shape == (2, HIDDEN)
+
+
+def test_geometry_rows_follow_the_same_offset_rule():
+    prompt = [1, IMG_ID, IMG_ID]
+    output = [239, COORD_ID, SIZE_ID, SEG_ID]
+    n_rows = len(prompt) + len(output)
+    hidden = torch.randn(n_rows, HIDDEN)
+    xy = torch.arange(n_rows, dtype=torch.float32).unsqueeze(1).repeat(1, 2)
+    hw = xy.clone()
+
+    payload = build_segmentation_payload(hidden, prompt, output, xy=xy, hw=hw)
+    # <coord> at output idx 1 -> row 3-1+1 = 3 ; <size> at idx 2 -> row 4.
+    assert payload["hidden_states"]["box_xy"][:, 0].tolist() == [3.0]
+    assert payload["hidden_states"]["box_hw"][:, 0].tolist() == [4.0]
+
+
+def test_accepted_coordinate_deltas_override_the_raw_argmax_rows():
+    prompt = [1, IMG_ID, IMG_ID]
+    output = [COORD_ID, SIZE_ID, SEG_ID, COORD_ID, SIZE_ID, SEG_ID]
+    n_rows = len(prompt) + len(output)
+    hidden = torch.randn(n_rows, HIDDEN)
+    raw_xy = torch.full((n_rows, 2), 0.125)
+    hw = torch.arange(n_rows, dtype=torch.float32).unsqueeze(1).repeat(1, 2)
+    selected_xy = torch.tensor([[0.25, 0.75], [0.5, 1.0]])
+
+    payload = build_segmentation_payload(
+        hidden,
+        prompt,
+        output,
+        xy=raw_xy,
+        hw=hw,
+        selected_xy=selected_xy,
+    )
+
+    assert torch.equal(payload["hidden_states"]["box_xy"], selected_xy)
+
+
+@pytest.mark.parametrize(
+    ("hidden", "prompt", "output"),
+    [
+        (torch.randn(2, HIDDEN), [], [SEG_ID]),  # no prompt ids
+        (torch.randn(1, HIDDEN), [1, IMG_ID, IMG_ID], [SEG_ID]),  # trajectory too short
+        (torch.randn(4, HIDDEN), [1, 2, 3], [SEG_ID]),  # no image tokens
+        (torch.randn(4), [1, IMG_ID], [SEG_ID]),  # not 2-D
+    ],
+)
+def test_unusable_inputs_return_none_rather_than_a_wrong_payload(hidden, prompt, output):
+    assert build_segmentation_payload(hidden, prompt, output) is None
+
+
+def test_token_only_builds_one_input_per_finished_request_with_the_payload():
+    prompt = [1, IMG_ID, IMG_ID, 230]
+    output = [COORD_ID, SIZE_ID, SEG_ID]
+    hidden = torch.randn(len(prompt) + len(output), HIDDEN)
+    # A real image: the hook processes it for real now that a processing failure
+    # propagates instead of being swallowed into a maskless payload.
+    image = _rgb(64, 48)
+
+    finished = _source_output(prompt, output, hidden)
+    unfinished = _source_output(prompt, output, hidden, finished=False)
+
+    inputs = thinker2segmentation_token_only(
+        [finished, unfinished, finished],
+        prompt={"multi_modal_data": {"image": image}},
+    )
+    assert len(inputs) == 2
+    for item in inputs:
+        assert len(item["prompt_token_ids"]) == 1
+        # AnyUp guides upsampling with the original pixels, so the image must
+        # reach stage 1 alongside the sliced features.
+        assert item["multi_modal_data"]["image"] is image
+        info = item["additional_information"]
+        assert info["hidden_states"]["seg_features"].shape == (1, HIDDEN)
+        assert info["hidden_states"]["image_features"].shape == (2, HIDDEN)
+
+
+def test_token_only_ships_processed_pixels_that_match_the_image_feature_grid():
+    """The mask head gets its pixels through the payload, not model kwargs.
+
+    The generation runner has no multimodal plumbing, so
+    ``requires_multimodal_data`` never reaches stage 1's forward. This asserts
+    the pixels travel in ``additional_information`` *and* that their patch grid
+    matches the number of image feature rows — a mismatch there makes the mask
+    head silently skip every request.
+    """
+    import numpy as np
+    from PIL import Image
+
+    from vllm_omni.model_executor.models.falcon_perception.configuration_falcon_perception import (
+        FalconPerceptionConfig,
+    )
+    from vllm_omni.model_executor.models.falcon_perception.processing_falcon_perception import (
+        FalconPerceptionImageProcessor,
+    )
+
+    config = FalconPerceptionConfig()
+    rng = np.random.default_rng(0)
+    image = Image.fromarray(rng.integers(0, 256, (414, 738, 3), dtype=np.uint8))
+    gh, gw = FalconPerceptionImageProcessor(config).target_grid(414, 738)
+
+    prompt_ids = [1] + [IMG_ID] * (gh * gw) + [230]
+    output_ids = [COORD_ID, SIZE_ID, SEG_ID]
+    hidden = torch.randn(len(prompt_ids) + len(output_ids), HIDDEN)
+
+    inputs = thinker2segmentation_token_only(
+        [_source_output(prompt_ids, output_ids, hidden)],
+        prompt={"multi_modal_data": {"image": image}},
+    )
+    info = inputs[0]["additional_information"]
+
+    pixels = info["hidden_states"]["pixel_values"]
+    assert pixels.ndim == 3 and pixels.shape[2] == 3
+    assert pixels.dtype == torch.float32, "bfloat16 cannot cross the stage process boundary"
+    # The grid the mask head derives from the pixels must match the rows it got.
+    patch = config.spatial_patch_size
+    assert (pixels.shape[0] // patch) * (pixels.shape[1] // patch) == info["hidden_states"]["image_features"].shape[0]
+
+
+@pytest.mark.parametrize("nested", [True, False])
+def test_geometry_is_read_from_either_nested_or_flat_dotted_payloads(nested):
+    """Exercises the real runtime shape of stage-0's multimodal output.
+
+    Guards a specific trap: resolving these with ``a or b`` raises
+    "Boolean value of Tensor with more than one value is ambiguous",
+    which only shows up once real (multi-element) tensors flow through.
+    """
+    prompt = [1, IMG_ID, IMG_ID]
+    output = [COORD_ID, SIZE_ID, SEG_ID]
+    n = len(prompt) + len(output)
+    hidden = torch.randn(n, HIDDEN)
+    xy = torch.arange(n, dtype=torch.float32).unsqueeze(1).repeat(1, 2)
+
+    mm = (
+        {"latent": hidden, "hidden_states": {"box_xy": xy, "box_hw": xy}}
+        if nested
+        else {"latent": hidden, "hidden_states.box_xy": xy, "hidden_states.box_hw": xy}
+    )
+    completion = SimpleNamespace(cumulative_token_ids=output, multimodal_output=mm)
+    source = SimpleNamespace(finished=True, prompt_token_ids=prompt, outputs=[completion])
+
+    info = thinker2segmentation_token_only([source], prompt=None)[0]["additional_information"]
+    # <coord> at output idx 0 -> hidden row 3-1+0 = 2.
+    assert info["hidden_states"]["box_xy"][:, 0].tolist() == [2.0]
+
+
+def test_payload_tensors_are_float32_for_cross_process_transfer():
+    prompt = [1, IMG_ID, IMG_ID]
+    output = [COORD_ID, SIZE_ID, SEG_ID]
+    n = len(prompt) + len(output)
+    payload = build_segmentation_payload(
+        torch.randn(n, HIDDEN, dtype=torch.bfloat16),
+        prompt,
+        output,
+        xy=torch.randn(n, 2, dtype=torch.bfloat16),
+        hw=torch.randn(n, 2, dtype=torch.bfloat16),
+    )
+    assert payload["hidden_states"]["image_features"].dtype == torch.float32
+    assert payload["hidden_states"]["seg_features"].dtype == torch.float32
+    assert payload["hidden_states"]["box_xy"].dtype == torch.float32
+
+
+def test_token_only_still_allocates_a_slot_when_the_latent_is_missing():
+    """Stage 1 must not hang just because stage 0 shipped nothing usable."""
+    completion = SimpleNamespace(cumulative_token_ids=[SEG_ID], multimodal_output=None)
+    source = SimpleNamespace(finished=True, prompt_token_ids=[1, IMG_ID], outputs=[completion])
+
+    inputs = thinker2segmentation_token_only([source], prompt=None)
+    assert len(inputs) == 1
+    assert inputs[0]["additional_information"] == {}
+    assert inputs[0].get("multi_modal_data") is None
+
+
+# --------------------------------------------------------------------------
+# Image key: lets stage 1 skip AnyUp for an image it has already upsampled.
+# AnyUp is the most expensive step of a request (~560 ms) and depends only on
+# the image, so the key must track image *content* and nothing else.
+# --------------------------------------------------------------------------
+
+
+def _rgb(width, height, colour=(10, 20, 30)):
+    from PIL import Image
+
+    return Image.new("RGB", (width, height), colour)
+
+
+def test_image_key_is_stable_for_the_same_image_and_differs_for_others():
+    from vllm_omni.model_executor.stage_input_processors.falcon_perception import _image_key
+
+    a = _image_key({"image": _rgb(64, 48)})
+    same_content = _image_key({"image": _rgb(64, 48)})
+    other_colour = _image_key({"image": _rgb(64, 48, (10, 20, 31))})
+    other_size = _image_key({"image": _rgb(48, 64)})
+
+    assert a is not None
+    # Equal content must hit, or the cache never fires for the workload it exists for.
+    assert int(a) == int(same_content)
+    # A one-channel-value difference must miss, or masks come from the wrong image.
+    assert int(a) != int(other_colour)
+    assert int(a) != int(other_size)
+    # Crosses a process boundary as a tensor, and negative ids would be a nuisance.
+    assert a.dtype == torch.long and int(a) >= 0
+
+
+def test_image_key_absent_rather_than_wrong_when_there_is_no_image():
+    from vllm_omni.model_executor.stage_input_processors.falcon_perception import _image_key
+
+    # None means "do not cache", which is safe. A fabricated key would collide.
+    assert _image_key({}) is None
+    assert _image_key({"image": None}) is None
+    assert _image_key("not-a-dict") is None
+
+
+def test_payload_carries_the_image_key_for_the_mask_stage():
+    prompt = [1, IMG_ID, IMG_ID, 2]
+    output = [SEG_ID]
+    latent = torch.randn(len(prompt) + len(output), HIDDEN)
+    inputs = thinker2segmentation_token_only(
+        [_source_output(prompt, output, latent)],
+        prompt={"multi_modal_data": {"image": _rgb(64, 48)}},
+    )
+    meta = inputs[0]["additional_information"]["meta"]
+    assert "image_key" in meta, "stage 1 cannot cache AnyUp without an image identity"
+    assert meta["image_key"].dtype == torch.long

--- a/vllm_omni/config/pipeline_registry.py
+++ b/vllm_omni/config/pipeline_registry.py
@@ -51,6 +51,9 @@ from vllm_omni.model_executor.models.covo_audio.pipeline import COVO_AUDIO_PIPEL
 from vllm_omni.model_executor.models.dots_tts.pipeline import DOTS_TTS_PIPELINE
 from vllm_omni.model_executor.models.dreamzero.pipeline import DREAMZERO_PIPELINE
 from vllm_omni.model_executor.models.dynin_omni.pipeline import DYNIN_OMNI_PIPELINE
+from vllm_omni.model_executor.models.falcon_perception.pipeline import (
+    FALCON_PERCEPTION_PIPELINE,
+)
 from vllm_omni.model_executor.models.fish_speech.pipeline import FISH_SPEECH_PIPELINE
 from vllm_omni.model_executor.models.gepard.pipeline import GEPARD_PIPELINE
 from vllm_omni.model_executor.models.glm_image.pipeline import GLM_IMAGE_PIPELINE
@@ -184,6 +187,7 @@ OMNI_PIPELINES: dict[str, PipelineConfig | PipelineResolverFunc] = {
     "dynin_omni": DYNIN_OMNI_PIPELINE,
     "indextts2": INDEXTTS2_PIPELINE,
     "indextts2_5": INDEXTTS25_PIPELINE,
+    "falcon_perception": FALCON_PERCEPTION_PIPELINE,
     "soulxsinger_svc": SOULXSINGER_SVC_PIPELINE,
     "soulxsinger_svs": SOULXSINGER_SVS_PIPELINE,
 }

--- a/vllm_omni/deploy/falcon_perception.yaml
+++ b/vllm_omni/deploy/falcon_perception.yaml
@@ -1,0 +1,103 @@
+# Falcon Perception — A100-80GB throughput-tuned deployment.
+#
+# This is the canonical Falcon Perception profile for batched offline inference
+# when both stages share one A100-80GB GPU. The settings below were measured,
+# not copied from the reference engine's scheduler. The tuning workload used
+# 100 fixed, distinct PBench level-1 requests in one `generate()` call, with two
+# warmups and three measured passes. Model load, warmup, and artifact writes
+# were outside the timer. On an A100-SXM4-80GB:
+#
+# * `max_num_seqs: 4` was fastest; Falcon's vision prefill and structured decode
+#   make oversized vLLM batches counterproductive.
+# * `max_num_batched_tokens: 16384` and stage-0
+#   `gpu_memory_utilization: 0.66` create a ~236k-token KV cache. Going higher
+#   did not improve runtime.
+# * the AnyUp cache was swept over 0, 4096, 8192, 12288, and 14336 MiB. 12288
+#   MiB was the knee:
+# * these scheduler and cache settings completed the full 1108-request level-1
+#   split in 180.4 s (6.14 images/s, 18,971 prompt+output tokens/s processed),
+#   with about 73 GiB observed peak VRAM.
+#
+# Treat these numbers as tuning guidance. Output length and image size change
+# the optimum; retune on materially different hardware or workloads.
+# `gpu_memory_utilization` is a per-engine reservation, while `hr_cache_mb` is
+# allocated afterward and shares the card.
+#
+# Prefix caching is deliberately disabled
+# `torch.compile` is only partly matched. The reference compiles the whole
+# model; here the transformer backbone and AnyUp are compiled independently,
+# while request-aware position reconstruction and geometry feedback stay eager.
+# `load_and_prepare_model(compile=True)` compiles the reference's transformer
+# FFNs, its coord/size heads, and `itok_upsampler`. On this side:
+#
+# * stage 0 compiles `FalconPerceptionBackbone` with Inductor and captures its
+#   decode with CUDA graphs. Spatial-position reconstruction and the geometry
+#   callbacks remain outside that compiled submodule;
+# * stage 1 compiles AnyUp through the model-local toggle below. In a separate
+#   Nsight sweep, this reduced total GPU time by 3X
+#   by fusing the encoders' GroupNorm (`RowwiseMomentsCUDAKernel`: 8.78 s eager
+#   to 0.19 s compiled) and reflection padding. `compile_anyup` defaults to
+#   false when omitted.
+#
+# Memory is split because both stages share one GPU:
+#
+# * the stage-0 KV cache is ~50 GiB (~236k tokens);
+# * stage 1 and the AnyUp feature cache must fit on the same card;
+# * stage 1 also uses `max_num_seqs: 4`. It is a single-step stage, but each
+#   request can hold an (n_instances, H, W) mask tensor; keeping its cap aligned
+#   with stage 0 avoids an unsafe dense-scene backlog;
+# * `hr_cache_mb: 12288` holds ~100-130 entries. An entry is
+#   (256, gh*8, gw*8) bf16, or roughly 90-134 MB. The reference pool is host
+#   pinned memory and sized by entry count; this cache lives on the GPU next to
+#   the KV cache and is sized in bytes.
+
+pipeline: falcon_perception
+async_chunk: false
+distributed_executor_backend: mp
+enable_prefix_caching: false
+
+stages:
+  - stage_id: 0
+    max_num_seqs: 4
+    max_num_batched_tokens: 16384
+    max_model_len: 8192
+    gpu_memory_utilization: 0.66
+    # Compile the transformer backbone and capture autoregressive decode. NVTX
+    # ranges and dynamic position/geometry work stay outside the backbone.
+    enforce_eager: false
+    tensor_parallel_size: 1
+    devices: "0"
+    compilation_config:
+      cudagraph_mode: FULL_DECODE_ONLY
+    default_sampling_params:
+      # Greedy: geometry is read from the hidden state that produced each
+      # <coord>/<size> token, so sampling would desynchronise boxes from tokens.
+      temperature: 0.0
+      max_tokens: 2048
+      detokenize: true
+      ignore_eos: false
+
+  - stage_id: 1
+    max_num_seqs: 4
+    gpu_memory_utilization: 0.10
+    # This stage runs max_tokens=1 and has no decode loop to capture. Its main
+    # compilation lever is AnyUp's model-local torch.compile toggle below.
+    enforce_eager: false
+    compilation_config:
+      cudagraph_mode: NONE
+    tensor_parallel_size: 1
+    devices: "0"
+    hf_overrides:
+      # Allocated after vLLM profiles peak memory, so gpu_memory_utilization
+      # above must leave room for it. Set to 0 to disable the cache.
+      hr_cache_mb: 12288
+      # The largest GPU-time lever on this stage. Compilation can cause small
+      # floating-point mask-boundary differences, so validate on new hardware.
+      compile_anyup: true
+    default_sampling_params:
+      temperature: 0.0
+      max_tokens: 1
+      detokenize: false
+
+# Verified on CUDA only.
+platforms: {}

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -49,6 +49,9 @@ def _register_omni_hf_configs() -> None:
     try:
         from transformers import AutoConfig
 
+        from vllm_omni.model_executor.models.falcon_perception.configuration_falcon_perception import (
+            FalconPerceptionConfig,
+        )
         from vllm_omni.model_executor.models.indextts2.configuration_indextts2 import (
             IndexTTS2Config,
             IndexTTS25Config,
@@ -89,6 +92,7 @@ def _register_omni_hf_configs() -> None:
     for model_type, config_cls in [
         ("dense", MingDenseConfig),
         ("bailingmm", MingMoeConfig),
+        ("falcon_perception", FalconPerceptionConfig),
         ("indextts2", IndexTTS2Config),
         ("indextts2_5", IndexTTS25Config),
         ("moss_tts_local", MossTTSLocalConfig),

--- a/vllm_omni/model_executor/models/falcon_perception/__init__.py
+++ b/vllm_omni/model_executor/models/falcon_perception/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# NOTE: Do not import model classes in this file. Importing any
+# submodule in this package triggers __init__.py execution, and
+# both the model registry and pipeline registry import submodules
+# directly — heavy imports here would be loaded as a side effect
+# even though nothing depends on these re-exports.

--- a/vllm_omni/model_executor/models/falcon_perception/anyup.py
+++ b/vllm_omni/model_executor/models/falcon_perception/anyup.py
@@ -1,0 +1,533 @@
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Copyright (c) 2025 Technology Innovation Institute (TII), UAE.
+"""AnyUp feature upsampler, vendored for Falcon Perception.
+
+This is an adaptation of AnyUp by Thomas Wimmer, Prune Truong, Marie-Julie
+Rakotosaona, Michael Oechsle, Federico Tombari, Bernt Schiele, and Jan Eric
+Lenssen:
+
+* source: https://github.com/wimmerth/anyup
+* license: CC-BY-4.0, https://creativecommons.org/licenses/by/4.0/
+
+It was flattened and modified by Technology Innovation Institute for the
+Apache-2.0 Falcon Perception reference implementation
+(https://github.com/tiiuae/Falcon-Perception), then adapted for vLLM-Omni.
+"""
+
+from functools import lru_cache
+
+import einops as E
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.attention.flex_attention import BlockMask, flex_attention
+
+_COMPILED_FLEX_ATTN = None
+
+
+def _flex_attn_prefill(*args, **kwargs):
+    """Compile ``flex_attention`` on first call rather than at import."""
+    global _COMPILED_FLEX_ATTN
+    if _COMPILED_FLEX_ATTN is None:
+        _COMPILED_FLEX_ATTN = torch.compile(flex_attention, dynamic=True)
+    return _COMPILED_FLEX_ATTN(*args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# ResBlock (from layers/convolutions.py)
+# ---------------------------------------------------------------------------
+
+
+class ResBlock(nn.Module):
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        kernel_size=3,
+        num_groups=8,
+        pad_mode="zeros",
+        norm_fn=None,
+        activation_fn=nn.SiLU,
+        use_conv_shortcut=False,
+    ):
+        super().__init__()
+        N = (lambda c: norm_fn(num_groups, c)) if norm_fn else (lambda c: nn.Identity())
+        p = kernel_size // 2
+        self.block = nn.Sequential(
+            N(in_channels),
+            activation_fn(),
+            nn.Conv2d(
+                in_channels,
+                out_channels,
+                kernel_size,
+                padding=p,
+                padding_mode=pad_mode,
+                bias=False,
+            ),
+            N(out_channels),
+            activation_fn(),
+            nn.Conv2d(
+                out_channels,
+                out_channels,
+                kernel_size,
+                padding=p,
+                padding_mode=pad_mode,
+                bias=False,
+            ),
+        )
+        self.shortcut = (
+            nn.Conv2d(in_channels, out_channels, 1, bias=False, padding_mode=pad_mode)
+            if use_conv_shortcut or in_channels != out_channels
+            else nn.Identity()
+        )
+
+    def forward(self, x):
+        return self.block(x) + self.shortcut(x)
+
+
+# ---------------------------------------------------------------------------
+# LearnedFeatureUnification (from layers/feature_unification.py)
+# ---------------------------------------------------------------------------
+
+
+class LearnedFeatureUnification(nn.Module):
+    def __init__(
+        self,
+        out_channels: int,
+        kernel_size: int = 3,
+        init_gaussian_derivatives: bool = False,
+    ):
+        super().__init__()
+        self.out_channels = out_channels
+        self.kernel_size = kernel_size
+        self.basis = nn.Parameter(torch.randn(out_channels, 1, kernel_size, kernel_size))
+
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        b, c, h, w = features.shape
+        x = self._depthwise_conv(features, self.basis, self.kernel_size).view(b, self.out_channels, c, h, w)
+        attn = F.softmax(x, dim=1)
+        return attn.mean(dim=2)
+
+    @staticmethod
+    def _depthwise_conv(feats, basis, k):
+        b, c, h, w = feats.shape
+        p = k // 2
+        x = F.pad(feats, (p, p, p, p), value=0)
+        x = F.conv2d(x, basis.repeat(c, 1, 1, 1), groups=c)
+        mask = torch.ones(1, 1, h, w, dtype=x.dtype, device=x.device)
+        denom = F.conv2d(
+            F.pad(mask, (p, p, p, p), value=0),
+            torch.ones(1, 1, k, k, device=x.device, dtype=x.dtype),
+        )
+        return x / denom
+
+
+# ---------------------------------------------------------------------------
+# RoPE (from layers/positional_encoding.py) – AnyUp-internal, separate from
+# the main model's 3D RoPE
+# ---------------------------------------------------------------------------
+
+
+def _rotate_half(x):
+    x1, x2 = x.chunk(2, dim=-1)
+    return torch.cat((-x2, x1), dim=-1)
+
+
+class AnyUpRoPE(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        theta: int = 100,
+    ):
+        super().__init__()
+        self.dim = dim
+        self.theta = theta
+        self.freqs = nn.Parameter(torch.empty(2, self.dim))
+
+    def forward(self, x: torch.Tensor, coords: torch.Tensor) -> torch.Tensor:
+        angle = coords @ self.freqs
+        return x * angle.cos() + _rotate_half(x) * angle.sin()
+
+
+# ---------------------------------------------------------------------------
+# Attention masking (from layers/attention/attention_masking.py)
+# ---------------------------------------------------------------------------
+
+
+def window2d(
+    low_res: int | tuple[int, int],
+    high_res: int | tuple[int, int],
+    ratio: float,
+    *,
+    device: str = "cpu",
+) -> torch.Tensor:
+    """Calculate the lower and upper bounds of row and col for each pixel/position"""
+    if isinstance(high_res, int):
+        H = W = high_res
+    else:
+        H, W = high_res
+    if isinstance(low_res, int):
+        Lh = Lw = low_res
+    else:
+        Lh, Lw = low_res
+
+    r_pos = (torch.arange(H, device=device, dtype=torch.float32) + 0.5) / H
+    c_pos = (torch.arange(W, device=device, dtype=torch.float32) + 0.5) / W
+    pos_r, pos_c = torch.meshgrid(r_pos, c_pos, indexing="ij")
+
+    r_lo = (pos_r - ratio).clamp(0.0, 1.0)
+    r_hi = (pos_r + ratio).clamp(0.0, 1.0)
+    c_lo = (pos_c - ratio).clamp(0.0, 1.0)
+    c_hi = (pos_c + ratio).clamp(0.0, 1.0)
+
+    r0 = (r_lo * Lh).floor().long()
+    r1 = (r_hi * Lh).ceil().long()
+    c0 = (c_lo * Lw).floor().long()
+    c1 = (c_hi * Lw).ceil().long()
+
+    return torch.stack([r0, r1, c0, c1], dim=2)
+
+
+def get_attention_mask_mod(high_res_h, high_res_w, low_res_h, low_res_w, window_size_ratio=0.1, device="cpu"):
+    """Window Attention as above but for FlexAttention."""
+    h, w = high_res_h, high_res_w
+    h_, w_ = low_res_h, low_res_w
+
+    windows = window2d(
+        low_res=(h_, w_),
+        high_res=(h, w),
+        ratio=window_size_ratio,
+        device=device,
+    )
+
+    r0 = windows[..., 0]
+    r1 = windows[..., 1]
+    c0 = windows[..., 2]
+    c1 = windows[..., 3]
+
+    def _mask_mod(b_idx, h_idx, q_idx, kv_idx):
+        q_r_idx = q_idx // w
+        q_c_idx = q_idx % w
+        kv_r_idx = kv_idx // w_
+        kv_c_idx = kv_idx % w_
+        row_lower = kv_r_idx >= r0[q_r_idx, q_c_idx]
+        row_upper = kv_r_idx < r1[q_r_idx, q_c_idx]
+        col_lower = kv_c_idx >= c0[q_r_idx, q_c_idx]
+        col_upper = kv_c_idx < c1[q_r_idx, q_c_idx]
+
+        return row_lower & row_upper & col_lower & col_upper
+
+    return _mask_mod
+
+
+@lru_cache(maxsize=32)
+def build_upsampler_block_mask(
+    H: int,
+    W: int,
+    h: int,
+    w: int,
+    ratio: float = 0.1,
+    BLOCK_SIZE: int = 128,
+    device: str | torch.device = "cpu",
+):
+    """Build a FlexAttention ``BlockMask`` for the AnyUp upsampler analytically.
+    Equivalent to:
+        mask = create_attention_mask(
+                get_attn_mask_mod(H, W, h, w, device=device),
+                B=None, H=None, Q_LEN=H * W, KV_LEN=h * w,
+            )
+    Instead of running the expensive compiled ``create_block_mask`` Triton
+    kernel (~100 ms), this computes the block-level sparsity pattern directly
+    from window geometry using numpy (~1-5 ms) and returns a ``BlockMask``
+    via ``BlockMask.from_kv_blocks``.
+
+    Parameters match ``get_attention_mask_mod`` — *H, W* are high-res
+    (query) dims, *h, w* are low-res (key/value) dims.
+    """
+
+    BQ = BKV = BLOCK_SIZE
+    Q_LEN = H * W
+    KV_LEN = h * w
+    num_q_blocks = (Q_LEN + BQ - 1) // BQ
+    num_kv_blocks = (KV_LEN + BKV - 1) // BKV
+
+    # --- per-Q-block union window bounds (O(num_q_blocks), not O(Q_LEN)) ---
+    # Q pixels are row-major in the H×W grid.  Each Q block covers a
+    # contiguous slice of BQ linear indices.  We find the extreme row/col
+    # corners per block and evaluate the window bounds only at those corners.
+    first_q = np.arange(num_q_blocks, dtype=np.int64) * BQ
+    last_q = np.minimum(first_q + BQ, Q_LEN) - 1
+
+    first_row = first_q // W
+    last_row = last_q // W
+    first_col = first_q % W
+    last_col = last_q % W
+    multi_row = first_row < last_row
+
+    # Minimum-row pixel gives the smallest union_r0.
+    min_r_pos = (first_row.astype(np.float64) + 0.5) / H
+    union_r0 = np.floor(np.clip(min_r_pos - ratio, 0.0, 1.0) * h).astype(np.int64)
+
+    # Maximum-row pixel gives the largest union_r1.
+    max_r_pos = (last_row.astype(np.float64) + 0.5) / H
+    union_r1 = np.ceil(np.clip(max_r_pos + ratio, 0.0, 1.0) * h).astype(np.int64)
+
+    # For multi-row blocks every column (0..W-1) is present, giving the
+    # widest possible column window.  For single-row blocks the column
+    # range is [first_col, last_col].
+    min_c_col = np.where(multi_row, 0, first_col)
+    max_c_col = np.where(multi_row, W - 1, last_col)
+    min_c_pos = (min_c_col.astype(np.float64) + 0.5) / W
+    max_c_pos = (max_c_col.astype(np.float64) + 0.5) / W
+    union_c0 = np.floor(np.clip(min_c_pos - ratio, 0.0, 1.0) * w).astype(np.int64)
+    union_c1 = np.ceil(np.clip(max_c_pos + ratio, 0.0, 1.0) * w).astype(np.int64)
+
+    # Conservative KV block range: all blocks between the first and last
+    # linear KV index covered by the union window.
+    first_kv_lin = union_r0 * w + union_c0
+    last_kv_lin = np.maximum((union_r1 - 1) * w + (union_c1 - 1), first_kv_lin)
+    first_kv = first_kv_lin // BKV
+    last_kv = np.minimum(last_kv_lin // BKV, num_kv_blocks - 1)
+    kv_count = last_kv - first_kv + 1
+
+    # Padded Q blocks (beyond Q_LEN) attend to nothing.
+    kv_count[first_q >= Q_LEN] = 0
+
+    max_kv = int(kv_count.max()) if kv_count.max() > 0 else 1
+
+    # Build kv_indices: (num_q_blocks, num_kv_blocks).
+    # The last dim MUST equal num_kv_blocks because from_kv_blocks /
+    # _ordered_to_dense uses shape[-1] as the dense matrix width.
+    offsets = np.arange(max_kv, dtype=np.int64)[None, :]
+    indices = first_kv[:, None] + offsets
+    valid = offsets < kv_count[:, None]
+    indices = np.where(valid, indices, 0).astype(np.int32)
+    kv_count_i32 = kv_count.astype(np.int32)
+
+    full_indices = np.zeros((num_q_blocks, num_kv_blocks), dtype=np.int32)
+    full_indices[:, :max_kv] = indices
+
+    # Tensors with [B=1, H=1, ...] dims, placed on target device.
+    kv_num_blocks_t = torch.from_numpy(kv_count_i32).view(1, 1, num_q_blocks).to(device)
+    kv_indices_t = torch.from_numpy(full_indices).view(1, 1, num_q_blocks, num_kv_blocks).to(device)
+
+    mask_mod = get_attention_mask_mod(H, W, h, w, ratio, device=str(device))
+
+    return BlockMask.from_kv_blocks(
+        kv_num_blocks_t,
+        kv_indices_t,
+        full_kv_num_blocks=None,
+        full_kv_indices=None,
+        BLOCK_SIZE=(BQ, BKV),
+        mask_mod=mask_mod,
+        seq_lengths=(Q_LEN, KV_LEN),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cross-attention (from layers/attention/chunked_attention.py)
+# ---------------------------------------------------------------------------
+
+
+class AttentionWrapper(nn.Module):
+    def __init__(self, qk_dim: int):
+        super().__init__()
+        self.in_proj_weight = nn.Parameter(torch.empty([qk_dim * 3, qk_dim]))
+        self.in_proj_bias = nn.Parameter(torch.empty([qk_dim * 3]))
+
+    def forward(self, x_q, x_k, x_v):
+        w_q, w_k, w_v = self.in_proj_weight.chunk(3, dim=0)
+        b_q, b_k, b_v = self.in_proj_bias.chunk(3)
+        x_q = x_q @ w_q.T + b_q
+        x_k = x_k @ w_k.T + b_k
+        return x_q, x_k, x_v
+
+
+class FlexCrossAttention(nn.Module):
+    def __init__(self, qk_dim: int, num_heads: int, **kwargs):
+        super().__init__()
+        self.dim = qk_dim
+        self.num_head = num_heads
+        self.norm_q = nn.RMSNorm(qk_dim)
+        self.norm_k = nn.RMSNorm(qk_dim)
+        self.attention = AttentionWrapper(qk_dim)
+
+    def forward(self, query, key, value, mask=None, **kwargs):
+        x_q = self.norm_q(query)
+        x_k = self.norm_k(key)
+        x_q, x_k, x_v = self.attention(x_q, x_k, value)
+        x_q = E.rearrange(x_q, "b HW (h d) -> b h HW d", h=self.num_head)
+        x_k = E.rearrange(x_k, "b hw (h d) -> b h hw d", h=self.num_head)
+
+        x_v = E.rearrange(value, "b hw (h d) -> b h hw d", h=self.num_head)
+        output = _flex_attn_prefill(x_q, x_k, x_v, block_mask=mask)
+        output = E.rearrange(output, "b h hw d -> b hw (h d)")
+
+        return output
+
+
+class CrossAttentionBlock(nn.Module):
+    def __init__(
+        self,
+        qk_dim,
+        num_heads,
+        window_ratio: float = 0.1,
+        **kwargs,
+    ):
+        super().__init__()
+        self.cross_attn = FlexCrossAttention(qk_dim, num_heads)
+        self.window_ratio = window_ratio
+        self.conv2d = nn.Conv2d(qk_dim, qk_dim, kernel_size=3, stride=1, padding=1, bias=False)
+
+    def forward(self, q, k, v, block_mask, **kwargs):
+        b, _, h, w = q.shape
+
+        q = self.conv2d(q)
+        q = E.rearrange(q, "b c h w -> b (h w) c")
+        k = E.rearrange(k, "b c h w -> b (h w) c")
+        v = E.rearrange(v, "b c h w -> b (h w) c")
+
+        features = self.cross_attn(q, k, v, mask=block_mask)
+        return E.rearrange(features, "b (h w) c -> b c h w", h=h, w=w)
+
+
+# ---------------------------------------------------------------------------
+# AnyUp (from model.py)
+# ---------------------------------------------------------------------------
+
+IMAGENET_MEAN = torch.tensor([0.485, 0.456, 0.406]).reshape(1, 3, 1, 1)
+IMAGENET_STD = torch.tensor([0.229, 0.224, 0.225]).reshape(1, 3, 1, 1)
+
+
+def _pool_to(x: torch.Tensor, size: tuple[int, int]) -> torch.Tensor:
+    """Reshape-based area pooling that works with symbolic shapes.
+
+    Equivalent to ``F.adaptive_avg_pool2d(x, size)`` when the input spatial
+    dims are exactly divisible by the target size.  Uses reshape + mean
+    instead of adaptive_avg_pool2d so the inductor can lower it without
+    concrete-value guards on kernel size.
+    """
+    b, c, H, W = x.shape
+    oh, ow = size
+    if H == oh and W == ow:
+        return x
+    return x.reshape(b, c, oh, H // oh, ow, W // ow).mean(dim=(3, 5))
+
+
+def create_coordinate(h, w, start=0.0, end=1.0, device=None, dtype=None):
+    x = torch.linspace(start, end, h, device=device, dtype=dtype)
+    y = torch.linspace(start, end, w, device=device, dtype=dtype)
+    xx, yy = torch.meshgrid(x, y, indexing="ij")
+    return torch.stack((xx, yy), -1).view(1, h * w, 2)
+
+
+class AnyUp(nn.Module):
+    def __init__(
+        self,
+        input_dim=3,
+        qk_dim=128,
+        kernel_size=1,
+        kernel_size_lfu=5,
+        window_ratio=0.1,
+        num_heads=4,
+        init_gaussian_derivatives=False,
+        **kwargs,
+    ):
+        super().__init__()
+        self.qk_dim = qk_dim
+        self.window_ratio = window_ratio
+        self._rb_args = dict(
+            kernel_size=1,
+            num_groups=8,
+            pad_mode="reflect",
+            norm_fn=nn.GroupNorm,
+            activation_fn=nn.SiLU,
+        )
+
+        self.image_encoder = self._make_encoder(input_dim, kernel_size)
+        self.key_encoder = self._make_encoder(qk_dim, 1)
+        self.query_encoder = self._make_encoder(qk_dim, 1)
+        self.key_features_encoder = self._make_encoder(
+            None,
+            1,
+            first_layer_k=kernel_size_lfu,
+            init_gaussian_derivatives=init_gaussian_derivatives,
+        )
+
+        self.cross_decode = CrossAttentionBlock(qk_dim=qk_dim, num_heads=num_heads, window_ratio=window_ratio)
+        self.aggregation = self._make_encoder(2 * qk_dim, 3)
+
+        self.rope = AnyUpRoPE(qk_dim)
+
+        self._compiled = False
+
+    def compile(self, *, mode: str | None = None, dynamic: bool = True):
+        if self._compiled:
+            return self
+        self.forward = torch.compile(self.forward, dynamic=dynamic, mode=mode)
+        self._compiled = True
+        return self
+
+    def _make_encoder(self, in_ch, k, layers=2, first_layer_k=0, init_gaussian_derivatives=False):
+        pre = (
+            nn.Conv2d(
+                in_ch,
+                self.qk_dim,
+                k,
+                padding=k // 2,
+                padding_mode="reflect",
+                bias=False,
+            )
+            if first_layer_k == 0
+            else LearnedFeatureUnification(
+                self.qk_dim,
+                first_layer_k,
+                init_gaussian_derivatives=init_gaussian_derivatives,
+            )
+        )
+        blocks = [ResBlock(self.qk_dim, self.qk_dim, **self._rb_args) for _ in range(layers)]
+        return nn.Sequential(pre, *blocks)
+
+    def upsample(self, enc_img, feats, attn_mask, out_size, vis_attn=False, q_chunk_size=None):
+        b, c, h, w = feats.shape
+
+        q = _pool_to(self.query_encoder(enc_img), out_size)
+        k = _pool_to(self.key_encoder(enc_img), (h, w))
+        k = torch.cat([k, self.key_features_encoder(F.normalize(feats, dim=1))], dim=1)
+        k = self.aggregation(k)
+        v = feats
+
+        result = self.cross_decode(q, k, v, attn_mask, vis_attn=vis_attn, q_chunk_size=q_chunk_size)
+        return result
+
+    def forward(
+        self,
+        images,
+        features,
+        attn_mask,
+        output_size=None,
+        vis_attn=False,
+        q_chunk_size=None,
+    ):
+        output_size = output_size if output_size is not None else images.shape[-2:]
+        images = images * 0.5 + 0.5
+        images = (images - IMAGENET_MEAN.to(images)) / IMAGENET_STD.to(images)
+        images = images.to(features)
+        enc = self.image_encoder(images)
+        h = enc.shape[-2]
+        coords = create_coordinate(h, enc.shape[-1], device=enc.device, dtype=enc.dtype)
+        enc = enc.permute(0, 2, 3, 1).view(enc.shape[0], -1, enc.shape[1])
+        enc = self.rope(enc, coords)
+        enc = enc.view(enc.shape[0], h, -1, enc.shape[-1]).permute(0, 3, 1, 2)
+
+        result = self.upsample(
+            enc,
+            features,
+            attn_mask,
+            output_size,
+            vis_attn=vis_attn,
+            q_chunk_size=q_chunk_size,
+        )
+        return result

--- a/vllm_omni/model_executor/models/falcon_perception/configuration_falcon_perception.py
+++ b/vllm_omni/model_executor/models/falcon_perception/configuration_falcon_perception.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Falcon Perception configuration.
+
+The published checkpoints (``tiiuae/Falcon-Perception``,
+``tiiuae/Falcon-Perception-300M``) ship a flat ``config.json`` that uses the
+reference implementation's own field names (``dim``, ``n_layers``, ``ffn_dim``,
+...) rather than the usual Transformers ones. This class accepts those names
+and mirrors them onto the standard aliases so vLLM's generic config plumbing
+(head size, KV-cache sizing, max model len) works unchanged.
+"""
+
+from __future__ import annotations
+
+from transformers.configuration_utils import PretrainedConfig
+
+
+class FalconPerceptionConfig(PretrainedConfig):
+    """Config for Falcon Perception / Falcon OCR style checkpoints."""
+
+    model_type = "falcon_perception"
+
+    # Image tokens attend bidirectionally within their own image (the reference
+    # mask is ``causal OR same-image``). vLLM reads this attribute directly in
+    # ``ModelArchConfigConvertor.is_mm_prefix_lm`` before consulting its own
+    # hardcoded model list, so declaring it here is enough — no vLLM patching
+    # (unlike for HunyuanImage3 where we need to patch the model_type in patch.py)
+    is_mm_prefix_lm: bool = True
+
+    def __init__(
+        self,
+        # --- backbone ---
+        dim: int = 1024,
+        n_layers: int = 28,
+        n_heads: int = 16,
+        head_dim: int = 128,
+        n_kv_heads: int = 8,
+        vocab_size: int = 65536,
+        ffn_dim: int = 3072,
+        norm_eps: float = 1e-5,
+        max_seq_len: int = 8192,
+        rope_theta: float = 10000.0,
+        # --- image patchification ---
+        channel_size: int = 3,
+        spatial_patch_size: int = 16,
+        temporal_patch_size: int = 1,
+        # --- perception heads ---
+        perception_heads: bool = True,
+        do_segmentation: bool = True,
+        coord_enc_dim: int = 512,
+        coord_dec_dim: int = 8192,
+        coord_out_dim: int = 2048,
+        size_enc_dim: int = 512,
+        size_dec_dim: int = 8192,
+        size_out_dim: int = 2048,
+        segm_out_dim: int = 256,
+        num_segm_layers: int = 3,
+        # --- special token ids ---
+        eos_id: int = 11,
+        img_id: int = 227,
+        img_end_id: int = 230,
+        image_cls_token_id: int = 244,
+        image_reg_1_token_id: int = 245,
+        image_reg_2_token_id: int = 246,
+        image_reg_3_token_id: int = 247,
+        image_reg_4_token_id: int = 248,
+        coord_token_id: int = 240,
+        size_token_id: int = 241,
+        seg_token_id: int = 262,
+        end_of_query_token_id: int = 263,
+        # --- image preprocessing (mirrors the reference engine defaults) ---
+        min_image_size: int = 256,
+        max_image_size: int = 1024,
+        min_pixels: int = 56 * 56,
+        max_pixels: int = 28 * 28 * 1280,
+        # --- vLLM-Omni stage-1 deployment knobs ---
+        hr_cache_mb: int | None = None,
+        compile_anyup: bool | None = None,
+        **kwargs,
+    ) -> None:
+        self.dim = dim
+        self.n_layers = n_layers
+        self.n_heads = n_heads
+        self.head_dim = head_dim or (dim // n_heads)
+        self.n_kv_heads = n_kv_heads or n_heads
+        self.vocab_size = vocab_size
+        self.ffn_dim = ffn_dim
+        self.norm_eps = norm_eps
+        self.max_seq_len = max_seq_len
+        self.rope_theta = float(rope_theta)
+
+        self.channel_size = channel_size
+        self.spatial_patch_size = spatial_patch_size
+        self.temporal_patch_size = temporal_patch_size
+
+        self.perception_heads = perception_heads
+        self.do_segmentation = do_segmentation
+        self.coord_enc_dim = coord_enc_dim
+        self.coord_dec_dim = coord_dec_dim
+        self.coord_out_dim = coord_out_dim
+        self.size_enc_dim = size_enc_dim
+        self.size_dec_dim = size_dec_dim
+        self.size_out_dim = size_out_dim
+        self.segm_out_dim = segm_out_dim
+        self.num_segm_layers = num_segm_layers
+
+        self.eos_id = eos_id
+        self.img_id = img_id
+        self.img_end_id = img_end_id
+        self.image_cls_token_id = image_cls_token_id
+        self.image_reg_1_token_id = image_reg_1_token_id
+        self.image_reg_2_token_id = image_reg_2_token_id
+        self.image_reg_3_token_id = image_reg_3_token_id
+        self.image_reg_4_token_id = image_reg_4_token_id
+        self.coord_token_id = coord_token_id
+        self.size_token_id = size_token_id
+        self.seg_token_id = seg_token_id
+        self.end_of_query_token_id = end_of_query_token_id
+
+        self.min_image_size = min_image_size
+        self.max_image_size = max_image_size
+        self.min_pixels = min_pixels
+        self.max_pixels = max_pixels
+        self.hr_cache_mb = hr_cache_mb
+        self.compile_anyup = compile_anyup
+
+        # Standard Transformers aliases so vLLM's generic accessors work.
+        self.hidden_size = self.dim
+        self.num_hidden_layers = self.n_layers
+        self.num_attention_heads = self.n_heads
+        self.num_key_value_heads = self.n_kv_heads
+        self.intermediate_size = self.ffn_dim
+        self.max_position_embeddings = self.max_seq_len
+        self.rms_norm_eps = self.norm_eps
+
+        # The model applies its own split RoPE (1-D temporal on the first half
+        # of head_dim, learned 2-D "golden" on the second half). Declaring an
+        # ``mrope_section`` is what makes ``ModelConfig.uses_mrope`` true so the
+        # runner allocates the [3, N] positions buffer that
+        # ``get_mrope_input_positions`` fills; the H/W sections are 0 because
+        # the spatial half is not driven by integer positions.
+        kwargs.setdefault(
+            "rope_parameters",
+            {"rope_type": "default", "rope_theta": self.rope_theta, "mrope_section": [self.head_dim // 2, 0, 0]},
+        )
+
+        kwargs.setdefault("tie_word_embeddings", False)
+        super().__init__(**kwargs)
+
+    @property
+    def image_structural_token_ids(self) -> list[int]:
+        """The 5 tokens that precede an image's patch tokens, in order."""
+        return [
+            self.image_cls_token_id,
+            self.image_reg_1_token_id,
+            self.image_reg_2_token_id,
+            self.image_reg_3_token_id,
+            self.image_reg_4_token_id,
+        ]

--- a/vllm_omni/model_executor/models/falcon_perception/falcon_perception_segmentation.py
+++ b/vllm_omni/model_executor/models/falcon_perception/falcon_perception_segmentation.py
@@ -1,0 +1,600 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Falcon Perception segmentation stage: hidden states -> per-instance masks.
+
+Not autoregressive. It runs once per request, after the thinker has finished,
+and turns the payload built by
+``stage_input_processors.falcon_perception.thinker2segmentation_token_only``
+into one binary mask per detected instance:
+
+1. the ``<|image|>`` hidden rows are folded back into the ``(h, w)`` patch grid
+   and pushed through ``conv_segm`` -> ``(1, 256, h, w)``;
+2. ``AnyUp`` cross-attends high-resolution queries built from the original image
+   against those low-resolution features, giving ``(256, H', W')``;
+3. each ``<|seg|>`` hidden row goes through ``proj_segm`` -> ``(256,)`` and is
+   contracted with the upsampled features, giving one logit map per instance;
+4. sigmoid, threshold, and resize back to the original image resolution.
+
+That padding looks like waste — a 26x46 image fills 29% of the canvas — but it
+is **not** removable. Dropping it and upsampling on the image's own grid makes
+stage1 3x faster BUT destroys the masks. This is because
+AnyUp was only ever trained on square inputs..
+"""
+
+from __future__ import annotations
+
+import os
+from collections import OrderedDict
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.models.interfaces import SupportsMRoPE
+
+from vllm_omni.model_executor.models.falcon_perception.anyup import (
+    AnyUp,
+    build_upsampler_block_mask,
+)
+from vllm_omni.model_executor.models.falcon_perception.profiling import (
+    install_anyup_hooks,
+    mark,
+    nvtx_range,
+)
+from vllm_omni.model_executor.models.output_templates import OmniOutput
+
+logger = init_logger(__name__)
+
+# The reference thresholds mask logits at 0.3 (``SamplingParams.segmentation_threshold``)
+# and upsamples to 8 feature cells per 16-pixel patch (``hr_upsample_ratio``).
+DEFAULT_SEGMENTATION_THRESHOLD = 0.3
+DEFAULT_HR_UPSAMPLE_RATIO = 8
+DEFAULT_MASK_NMS_IOU_THRESHOLD = 0.6
+
+# How many instances to decode into masks at once. Bounds peak memory
+# independently of how many instances a scene contains.
+_MASK_CHUNK = 32
+
+# Default budget for the AnyUp output cache. One entry is ``(256, gh*8, gw*8)``
+# in the model dtype — 39 MB for a 26x46 grid, 107 MB for 51x64 — so this holds
+# a handful of distinct images.
+#
+# This memory is allocated *after* vLLM has profiled peak usage and sized the KV
+# cache, so it is not covered by the stage's ``gpu_memory_utilization``: the
+# stage's budget must leave room for it. Deploy profiles set
+# ``hf_overrides.hr_cache_mb``. The environment variable is a fallback only
+# when that model override is omitted. Set the selected value to 0 to disable
+# the cache entirely.
+_DEFAULT_HR_CACHE_MB = 512
+
+
+def _mask_nms(
+    binary_masks: torch.Tensor,
+    *,
+    iou_threshold: float = DEFAULT_MASK_NMS_IOU_THRESHOLD,
+    nms_max_side: int = 256,
+) -> torch.Tensor:
+    """Return indices kept by dependency-free area-ordered mask NMS."""
+    if binary_masks.ndim != 3:
+        raise ValueError(f"binary masks must have shape (N, H, W), got {tuple(binary_masks.shape)}")
+
+    count, height, width = binary_masks.shape
+    if count <= 1:
+        return torch.arange(count, device=binary_masks.device, dtype=torch.long)
+
+    scale = min(1.0, nms_max_side / max(height, width))
+    target_h = max(1, int(round(height * scale)))
+    target_w = max(1, int(round(width * scale)))
+    masks = binary_masks.float()
+    if (height, width) != (target_h, target_w):
+        masks = F.interpolate(
+            masks.unsqueeze(1),
+            size=(target_h, target_w),
+            mode="bilinear",
+            align_corners=False,
+        ).squeeze(1)
+
+    flat = masks.reshape(count, -1)
+    areas = flat.sum(dim=1)
+    intersection = flat @ flat.T
+    union = areas[:, None] + areas[None, :] - intersection
+    iou = intersection / union.clamp(min=1)
+    order = areas.argsort(descending=True)
+
+    suppressed = torch.zeros(count, dtype=torch.bool, device=binary_masks.device)
+    keep: list[int] = []
+    for index in order.tolist():
+        if suppressed[index]:
+            continue
+        keep.append(index)
+        suppressed |= iou[index] > iou_threshold
+    return torch.tensor(keep, device=binary_masks.device, dtype=torch.long)
+
+
+def _apply_mask_nms(binary_masks: torch.Tensor, boxes: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Align mask/box candidates and suppress overlapping instances."""
+    candidate_count = min(binary_masks.shape[0], boxes.shape[0])
+    binary_masks = binary_masks[:candidate_count]
+    boxes = boxes[:candidate_count]
+    keep = _mask_nms(binary_masks)
+    return binary_masks.index_select(0, keep), boxes.index_select(0, keep.to(boxes.device))
+
+
+# ---------------------------------------------------------------------------
+# Profiling / experiment toggles. All default to the shipped behaviour, so a
+# run with none of them set is byte-identical to one built without this block.
+# ---------------------------------------------------------------------------
+
+# ``FALCON_PERCEPTION_COMPILE_ANYUP=1`` compiles AnyUp's forward. Worth ~5.8x on
+# the AnyUp call: it fuses the encoders' GroupNorm and reflection padding,
+# otherwise the single largest GPU cost of this stage
+#
+# Off by default because it is **not output-neutral**: masks shift by roughly
+# 0.98 mean IoU against the eager path. That is ``torch.compile`` numerics, not a
+# defect here — the reference repo moves by the same magnitude when its own
+# ``itok_upsampler`` is compiled, and token streams are unaffected either way.
+#
+# ``flex_attention`` is compiled unconditionally either way (``anyup.py``:
+# ``_flex_attn_prefill``), so this toggle covers everything *except* the
+# attention kernel.
+#
+# The deploy profiles use model-local ``hf_overrides.compile_anyup``. The
+# environment variable is a process-wide fallback when that override is absent.
+_COMPILE_ANYUP_ENV = "FALCON_PERCEPTION_COMPILE_ANYUP"
+
+# ``FALCON_PERCEPTION_SQUARE_DIV=2`` halves the side of the square canvas AnyUp
+# upsamples on. AnyUp always pads out to ``max_image_size`` and its cost is set
+# by that canvas, not by the image — a 26x46 grid fills 29% of it — so this is
+# the obvious lever. It is expected to cost accuracy
+# Issue is that any image whose longest edge exceeds the reduced canvas gets cropped rather than
+# padded. Kept as a measurable knob, not as a recommended setting.
+try:
+    _SQUARE_DIV = max(1, int(os.environ.get("FALCON_PERCEPTION_SQUARE_DIV", "1")))
+except ValueError:
+    _SQUARE_DIV = 1
+
+
+class SegmDecoder(nn.Module):
+    """Squared-ReLU MLP mapping a hidden state to the mask embedding space."""
+
+    def __init__(self, in_dim: int, out_dim: int, num_layers: int) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList([nn.Linear(in_dim, in_dim) for _ in range(num_layers - 1)])
+        self.pixel_layer = nn.Linear(in_dim, out_dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        for layer in self.layers:
+            x = F.relu(layer(x)).square()
+        return self.pixel_layer(x)
+
+
+class FalconPerceptionSegmentation(nn.Module, SupportsMRoPE):
+    """Stage 1: AnyUp-upsampled image features x ``<|seg|>`` embeddings -> masks.
+
+    ``SupportsMRoPE`` is implemented only to claim the position-building hook.
+    Both stages share one HF config, so this stage inherits its ``mrope_section``
+    and the runner therefore believes it uses M-RoPE; without the hook it would
+    fall through to the generic Qwen-VL position builder, which reads
+    ``config.image_token_id`` and does not apply here. Positions are meaningless
+    for a non-autoregressive stage whose prompt is a single placeholder token.
+    """
+
+    have_multimodal_outputs = True
+    has_preprocess = False
+    has_postprocess = False
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        config = vllm_config.model_config.hf_config
+        self.config = config
+
+        hidden_size = config.hidden_size
+        self.segm_out_dim = config.segm_out_dim
+        self.patch_size = config.spatial_patch_size
+        self.max_image_size = int(getattr(config, "max_image_size", 1024))
+
+        self.conv_segm = nn.Conv2d(hidden_size, self.segm_out_dim, kernel_size=3, padding=1)
+        self.proj_segm = SegmDecoder(hidden_size, self.segm_out_dim, config.num_segm_layers)
+        self.itok_upsampler = AnyUp()
+
+        # AnyUp output cache, keyed by image **content** — not by request. Two
+        # requests sharing a key are entitled to the same tensor, so this is
+        # safe under continuous batching; contrast the per-request module state
+        # in the earlier port attempt, which leaked across concurrent requests
+        # precisely because its key was positional.
+        self._hr_cache: OrderedDict[tuple[int, ...], torch.Tensor] = OrderedDict()
+        self._hr_cache_bytes = 0
+        budget_mb = getattr(config, "hr_cache_mb", None)
+        if budget_mb is None:
+            budget_mb = os.environ.get("FALCON_PERCEPTION_HR_CACHE_MB", _DEFAULT_HR_CACHE_MB)
+        self._hr_cache_budget = int(budget_mb) * 1024 * 1024
+
+        # Order matters: NVTX hooks must never be installed on a module that is
+        # about to be compiled, so ``install_anyup_hooks`` is told what happened
+        # and declines in that case. It also declines unless
+        # FALCON_PERCEPTION_NVTX >= 2. See profiling.py for why sub-module
+        # ranges inside a compiled AnyUp are not merely risky but impossible.
+        compile_anyup = getattr(config, "compile_anyup", None)
+        if compile_anyup is None:
+            compile_anyup = os.environ.get(_COMPILE_ANYUP_ENV, "0") not in ("", "0")
+        if compile_anyup:
+            self.itok_upsampler.compile()
+            logger.info("Falcon Perception: AnyUp compiled")
+        n_hooks = install_anyup_hooks(self.itok_upsampler, compiled=compile_anyup)
+        if n_hooks:
+            logger.info("Falcon Perception: %d AnyUp NVTX hooks installed", n_hooks)
+
+    def _hr_cache_lookup(self, key: tuple[int, ...] | None, expected: tuple[int, ...]) -> torch.Tensor | None:
+        """Cached AnyUp output for this image, or ``None``."""
+        if key is None:
+            return None
+        hit = self._hr_cache.get(key)
+        if hit is None:
+            return None
+        if tuple(hit.shape) != expected:
+            # An 8-byte content hash makes collisions vanishingly unlikely, but
+            # a silently reshaped feature map would corrupt every mask rather
+            # than fail, so treat a shape disagreement as a miss.
+            logger.warning(
+                "falcon_perception: cached AnyUp features are %s but this image needs %s; recomputing",
+                tuple(hit.shape),
+                expected,
+            )
+            return None
+        self._hr_cache.move_to_end(key)
+        return hit
+
+    def _hr_cache_store(self, key: tuple[int, ...] | None, value: torch.Tensor) -> None:
+        if key is None or self._hr_cache_budget <= 0:
+            return
+        nbytes = value.element_size() * value.numel()
+        if nbytes > self._hr_cache_budget:
+            return
+        # Drop the previous entry's bytes before adding the new ones. Replacing a
+        # key with a different-sized tensor is exactly what the shape-mismatch
+        # miss path in ``_hr_cache_lookup`` produces, and counting only the new
+        # value there would make ``_hr_cache_bytes`` drift low until the budget
+        # stopped binding at all.
+        existing = self._hr_cache.pop(key, None)
+        if existing is not None:
+            self._hr_cache_bytes -= existing.element_size() * existing.numel()
+        self._hr_cache[key] = value
+        self._hr_cache_bytes += nbytes
+        while self._hr_cache_bytes > self._hr_cache_budget and len(self._hr_cache) > 1:
+            _, evicted = self._hr_cache.popitem(last=False)
+            self._hr_cache_bytes -= evicted.element_size() * evicted.numel()
+
+    # The generation runner still calls embed_input_ids on the placeholder
+    # prompt; nothing here consumes token embeddings, so return zeros of the
+    # right width rather than carrying an unused embedding table.
+    def embed_input_ids(self, input_ids: torch.Tensor, **_: Any) -> torch.Tensor:
+        return torch.zeros(
+            (input_ids.numel(), self.config.hidden_size),
+            device=input_ids.device,
+            dtype=next(self.parameters()).dtype,
+        )
+
+    def compute_logits(self, hidden_states: Any, sampling_metadata: Any = None) -> None:
+        return None
+
+    def get_mrope_input_positions(
+        self,
+        input_tokens: list[int],
+        **kwargs: Any,
+    ) -> tuple[torch.Tensor, int]:
+        """Flat zero positions — see the class docstring for why this exists."""
+        n = len(input_tokens)
+        positions = torch.zeros((3, n), dtype=torch.long)
+        return positions, -n
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        positions: torch.Tensor | None = None,
+        intermediate_tensors: Any = None,
+        inputs_embeds: torch.Tensor | None = None,
+        runtime_additional_information: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> OmniOutput:
+        runtime_infos = runtime_additional_information or []
+        masks: list[torch.Tensor] = []
+        boxes: list[torch.Tensor] = []
+
+        # Safe to annotate inside this forward: the class carries no
+        # ``@support_torch_compile``, so vLLM never traces it whatever
+        # ``enforce_eager`` says. The one compiled callee below is
+        # ``itok_upsampler.forward``, and no range crosses into it.
+        with nvtx_range(f"fp/s1/forward[reqs={len(runtime_infos)}]"):
+            for info in runtime_infos:
+                mask, box = self._run_one_request(info, kwargs)
+                masks.append(mask)
+                boxes.append(box)
+
+        if not masks:
+            empty = torch.zeros((0,), dtype=torch.float32)
+            return OmniOutput(text_hidden_states=None, multimodal_outputs={"masks": [empty]})
+
+        return OmniOutput(
+            text_hidden_states=None,
+            multimodal_outputs={"masks": masks, "boxes": boxes},
+        )
+
+    def _run_one_request(self, info: dict[str, Any], kwargs: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
+        device = next(self.parameters()).device
+        dtype = next(self.parameters()).dtype
+
+        image_features = _payload_tensor(info, "hidden_states", "image_features")
+        seg_features = _payload_tensor(info, "hidden_states", "seg_features")
+        boxes = _payload_tensor(info, "hidden_states", "box_xy")
+        sizes = _payload_tensor(info, "hidden_states", "box_hw")
+        pixel_values = _first_image(info, kwargs)
+
+        empty_mask = torch.zeros((0, 1, 1), dtype=torch.float32)
+        empty_box = torch.zeros((0, 4), dtype=torch.float32)
+        if image_features is None or seg_features is None:
+            # A missing payload is a wiring failure, not an empty answer. Returning
+            # empty masks with a success status makes it indistinguishable from
+            # "nothing detected", so the caller silently gets no segmentation
+            # forever. Raise instead — this is deterministic, so it surfaces on
+            # the first request rather than corrupting a whole run.
+            raise ValueError(
+                "Falcon Perception: stage payload missing "
+                f"(image_features={image_features is not None}, "
+                f"seg_features={seg_features is not None}); available keys={sorted(info.keys())}"
+            )
+        if seg_features.shape[0] == 0:
+            # Legitimately empty: a detection-only answer, or nothing matched.
+            return empty_mask, _boxes_to_xywh(boxes, sizes, empty_box)
+        if pixel_values is None:
+            # Same reasoning as the payload check above: AnyUp needs the pixels,
+            # and their absence is a wiring failure, not an empty result.
+            raise ValueError(
+                "Falcon Perception: no image reached the mask head. payload sections="
+                f"{sorted(info.keys())} hidden_states keys="
+                f"{sorted(info['hidden_states'].keys()) if isinstance(info.get('hidden_states'), dict) else 'n/a'}"
+            )
+
+        image_features = image_features.to(device=device, dtype=dtype)
+        seg_features = seg_features.to(device=device, dtype=dtype)
+        # (H, W, C) channels-last, as produced by the image processor.
+        pixels = pixel_values.to(device=device, dtype=dtype)
+        img_h, img_w = int(pixels.shape[0]), int(pixels.shape[1])
+        grid_h, grid_w = img_h // self.patch_size, img_w // self.patch_size
+
+        n_patches = grid_h * grid_w
+        if image_features.shape[0] != n_patches:
+            # The feature rows and the pixel grid disagree, so every mask would be
+            # decoded against a misaligned feature map. Fail rather than emit
+            # confidently-wrong masks.
+            raise ValueError(
+                f"Falcon Perception: {image_features.shape[0]} image feature rows but a "
+                f"{grid_h}x{grid_w} grid needs {n_patches}. The stage-0 payload and the "
+                "re-processed image disagree."
+            )
+
+        ratio = DEFAULT_HR_UPSAMPLE_RATIO
+
+        # Everything up to and including AnyUp is a pure function of the image:
+        # the image block sits at position 0 and attention is causal, so image
+        # tokens never see the query. Verified bit-identical across queries of
+        # 11/14/70 characters, so a hit here is exactly equivalent to
+        # recomputing — no tolerance, no accuracy cost.
+        #
+        # ``ratio`` is in the key even though it is a module constant today: the
+        # reference exposes ``hr_upsample_ratio`` per request, and if it is ever
+        # plumbed through here a stale entry computed at another ratio must not
+        # be served.
+        key_tensor = _payload_tensor(info, "meta", "image_key")
+        # ``_SQUARE_DIV`` belongs in the key: it changes the upsampled map, so an
+        # entry computed at another canvas size must not be served.
+        cache_key = (
+            (int(key_tensor.reshape(-1)[0]), ratio, self.max_image_size, _SQUARE_DIV, grid_h, grid_w)
+            if key_tensor is not None
+            else None
+        )
+        # The stored map is the AnyUp output cropped to this image's extent, and
+        # a reduced canvas can be *smaller* than that extent — so the expected
+        # shape is the crop that will actually happen, not the full-resolution
+        # one. Assuming the latter made every lookup fail its shape check under
+        # FALCON_PERCEPTION_SQUARE_DIV=2, silently disabling the cache and
+        # making the canvas experiment measure cache misses instead of AnyUp.
+        _canvas = self.max_image_size // _SQUARE_DIV
+        _square_patches = ((_canvas + self.patch_size - 1) // self.patch_size * self.patch_size) // self.patch_size
+        _out_side = _square_patches * ratio
+        expected_shape = (
+            self.segm_out_dim,
+            min(grid_h * ratio, _out_side),
+            min(grid_w * ratio, _out_side),
+        )
+        with nvtx_range("fp/s1/hr_cache_lookup"):
+            hr_features = self._hr_cache_lookup(cache_key, expected_shape)
+        mark("fp/s1/hr_cache_miss" if hr_features is None else "fp/s1/hr_cache_hit")
+
+        if hr_features is None:
+            # (n_patches, D) -> (1, D, grid_h, grid_w) -> conv_segm -> (1, 256, h, w)
+            with nvtx_range("fp/s1/conv_segm"):
+                lr_features = image_features.reshape(1, grid_h, grid_w, -1).permute(0, 3, 1, 2)
+                lr_features = self.conv_segm(lr_features)
+
+            image_bchw = pixels.permute(2, 0, 1).unsqueeze(0)
+
+            # AnyUp must see a SQUARE canvas. The reference pads the image and the
+            # feature grid out to ``max_image_size`` before upsampling and crops
+            # afterwards, "for AnyUp training consistency"
+            # (paged_inference.py:575-597). Running it on the native non-square
+            # aspect instead changes the windowed cross-attention geometry and
+            # yields smeared, vertically displaced masks — measured, mean IoU
+            # 0.885 -> 0.566, and the same on the reference engine, because
+            # AnyUp was only ever trained on square inputs.
+            # ``_SQUARE_DIV`` is 1 unless the canvas-size experiment is running.
+            canvas = self.max_image_size // _SQUARE_DIV
+            square = ((canvas + self.patch_size - 1) // self.patch_size) * self.patch_size
+            square_patches = square // self.patch_size
+            pad_h, pad_w = square - img_h, square - img_w
+            with nvtx_range("fp/s1/pad_to_square"):
+                if pad_h > 0 or pad_w > 0:
+                    image_bchw = F.pad(image_bchw, (0, max(0, pad_w), 0, max(0, pad_h)))
+                    lr_features = F.pad(
+                        lr_features, (0, max(0, square_patches - grid_w), 0, max(0, square_patches - grid_h))
+                    )
+                if pad_h < 0 or pad_w < 0:
+                    # A reduced canvas can be smaller than the image. Crop so the
+                    # shapes still agree; this is the accuracy cost the canvas
+                    # experiment exists to measure, so it is allowed, not raised.
+                    image_bchw = image_bchw[:, :, :square, :square]
+                    lr_features = lr_features[:, :, :square_patches, :square_patches]
+
+            out_side = square_patches * ratio
+            with nvtx_range("fp/s1/block_mask"):
+                attn_mask = build_upsampler_block_mask(
+                    out_side, out_side, square_patches, square_patches, device=image_bchw.device
+                )
+            # The range wraps the *call*, so it closes before the compiled
+            # forward is entered — no NVTX op is ever traced by Dynamo.
+            with nvtx_range("fp/s1/anyup"):
+                hr_features = self.itok_upsampler(
+                    images=image_bchw,
+                    features=lr_features,
+                    attn_mask=attn_mask,
+                    output_size=(out_side, out_side),
+                )[0]  # (256, out_side, out_side)
+            # Crop back to this image's extent. With a reduced canvas the
+            # upsampled map can be shorter than the full-resolution grid, so the
+            # slice is clamped rather than assumed to fit.
+            hr_features = hr_features[:, : grid_h * ratio, : grid_w * ratio].contiguous()
+            # Cache the cropped, model-dtype map: half the bytes of the float32
+            # form used below, and the float() cast is deterministic.
+            self._hr_cache_store(cache_key, hr_features)
+
+        # (n_seg, D) -> (n_seg, 256), then contract against the feature map.
+        with nvtx_range("fp/s1/proj_segm"):
+            seg_embeds = self.proj_segm(seg_features).float()
+        hr_features = hr_features.float()
+        threshold = DEFAULT_SEGMENTATION_THRESHOLD
+
+        # Chunk over instances. A dense PBench scene can carry 250+ instances,
+        # and materialising (n, H, W) float32 for all of them before
+        # thresholding is ~0.5 GB at 1024x624 — enough to OOM on its own. Each
+        # chunk is reduced to uint8 immediately. The complete binary set stays
+        # on-device for vectorized mask NMS, while the much larger float32 peak
+        # is still bounded by the chunk size rather than the instance count.
+        # The reference upsamples logits to the *original* image size before
+        # thresholding, not to the patch-aligned processed size, so the binary
+        # boundary lands at display resolution.
+        target_hw = _original_hw(info) or (img_h, img_w)
+        chunks: list[torch.Tensor] = []
+        with nvtx_range(f"fp/s1/mask_decode[n={int(seg_embeds.shape[0])}]"):
+            for start in range(0, seg_embeds.shape[0], _MASK_CHUNK):
+                block = seg_embeds[start : start + _MASK_CHUNK]
+                logits = torch.einsum("kc,chw->khw", block, hr_features)
+                # Upsample before thresholding so the binary boundary is placed at
+                # display resolution, matching the reference's finalize_masks.
+                logits = F.interpolate(logits.unsqueeze(0), size=target_hw, mode="bilinear", align_corners=False)[0]
+                # Keep masks on the accelerator through NMS. The reduced IoU
+                # matrix is cheap on GPU and avoids a model-specific CPU
+                # dependency in the serving path.
+                chunks.append((torch.sigmoid(logits) > threshold).to(torch.uint8))
+                del logits
+
+        binary = torch.cat(chunks, dim=0) if chunks else torch.zeros((0, *target_hw), dtype=torch.uint8)
+        packed_boxes = _boxes_to_xywh(boxes, sizes, empty_box)
+        binary, packed_boxes = _apply_mask_nms(binary, packed_boxes)
+        return binary.cpu(), packed_boxes.cpu()
+
+    def make_omni_output(self, model_outputs: Any, **kwargs: Any) -> OmniOutput:
+        if isinstance(model_outputs, OmniOutput):
+            return model_outputs
+        return OmniOutput(text_hidden_states=None, multimodal_outputs={"masks": model_outputs})
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        """Load only this stage's tensors; the thinker owns the rest of the file."""
+        params_dict = dict(self.named_parameters())
+        loaded: set[str] = set()
+        owned = ("conv_segm.", "proj_segm.", "itok_upsampler.")
+
+        for name, weight in weights:
+            if name.startswith("model."):
+                name = name[len("model.") :]
+            if not name.startswith(owned):
+                continue
+            param = params_dict.get(name)
+            if param is None:
+                logger.warning("falcon_perception segmentation: no parameter for checkpoint key %s", name)
+                continue
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, weight)
+            loaded.add(name)
+
+        missing = set(params_dict) - loaded
+        if missing:
+            raise ValueError(
+                f"Falcon Perception segmentation stage: {len(missing)} parameters were not loaded, "
+                f"e.g. {sorted(missing)[:5]}. The checkpoint must contain conv_segm / proj_segm / "
+                "itok_upsampler tensors (a do_segmentation=False checkpoint has none)."
+            )
+        return loaded
+
+
+def _payload_tensor(info: dict[str, Any], section: str, key: str) -> torch.Tensor | None:
+    """Read ``section.key`` from a stage payload, flat-dotted or nested."""
+    value = info.get(f"{section}.{key}")
+    if value is None:
+        nested = info.get(section)
+        if isinstance(nested, dict):
+            value = nested.get(key)
+    if isinstance(value, list):
+        value = value[0] if value else None
+    return value if isinstance(value, torch.Tensor) else None
+
+
+def _original_hw(info: dict[str, Any]) -> tuple[int, int] | None:
+    """Original (pre-resize) image size, if the bridge shipped it."""
+    hw = _payload_tensor(info, "hidden_states", "original_hw")
+    if isinstance(hw, torch.Tensor) and hw.numel() == 2:
+        return int(hw[0].item()), int(hw[1].item())
+    return None
+
+
+def _first_image(info: dict[str, Any], kwargs: dict[str, Any]) -> torch.Tensor | None:
+    """The processed ``(H, W, 3)`` pixels AnyUp guides the upsampling with.
+
+    They arrive in the stage payload rather than as model kwargs: the
+    generation runner carries no multimodal plumbing, so
+    ``requires_multimodal_data`` never reaches this model's forward.
+    """
+    candidates = [
+        _payload_tensor(info, "hidden_states", "pixel_values"),
+        _payload_tensor(info, "image", "pixel_values"),
+        info.get("pixel_values"),
+        kwargs.get("pixel_values"),
+    ]
+    for pixel_values in candidates:
+        if isinstance(pixel_values, list) and pixel_values:
+            pixel_values = pixel_values[0]
+        if isinstance(pixel_values, torch.Tensor) and pixel_values.ndim == 3:
+            return pixel_values
+    return None
+
+
+def _boxes_to_xywh(
+    xy: torch.Tensor | None,
+    hw: torch.Tensor | None,
+    empty: torch.Tensor,
+) -> torch.Tensor:
+    """Pack per-instance centre + size into ``(n, 4)`` as ``(x, y, w, h)``.
+
+    Both are normalised to [0, 1] by the thinker's decoders, matching the
+    reference. Rows are dropped rather than padded when the two streams
+    disagree in length, since a mismatched pairing would be worse than a
+    shorter list.
+    """
+    if xy is None or hw is None or xy.numel() == 0:
+        return empty
+    n = min(int(xy.shape[0]), int(hw.shape[0]))
+    if n == 0:
+        return empty
+    return torch.cat([xy[:n].float(), hw[:n].float().flip(-1)], dim=-1).cpu()

--- a/vllm_omni/model_executor/models/falcon_perception/falcon_perception_thinker.py
+++ b/vllm_omni/model_executor/models/falcon_perception/falcon_perception_thinker.py
@@ -1,0 +1,1030 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Falcon Perception thinker: the autoregressive image+text stage.
+
+Architecture notes that differ from a stock decoder-only LLM:
+
+* **No vision tower.** Raw RGB is cut into ``spatial_patch_size`` squares and
+  pushed through a single ``img_projector`` linear into the token stream, so
+  image and text tokens share one transformer stack (early fusion).
+* **Weightless norms.** The pre-attention, pre-FFN and QK norms are plain
+  ``F.rms_norm`` — the checkpoint carries no per-layer norm parameters. Only
+  the final ``norm`` is learned.
+* **Attention sinks.** The reference scales the attention output by
+  ``sigmoid(lse - sink)``, which is algebraically identical to adding
+  ``exp(sink)`` to the softmax denominator — i.e. exactly vLLM's ``sinks=``.
+* **Interleaved gated FFN.** ``w13`` packs gate/up as ``[g0, u0, g1, u1, ...]``
+  with a ``sqrt(2)`` folded into the gate rows; the activation is ``relu()**2``.
+* **Split RoPE.** See ``rope.py``. The learned 2-D frequencies are per
+  *attention* head, so K cannot be shared across a GQA group and is expanded to
+  ``num_heads`` before the rotation.
+* **Geometry feedback loop.** ``<coord>`` / ``<size>`` tokens carry continuous
+  values decoded from the *previous* step's hidden state and re-injected as
+  input embeddings through Fourier encoders.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import VllmConfig
+from vllm.distributed import get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size
+from vllm.logger import init_logger
+from vllm.model_executor.layers.attention import Attention
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import (
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    ReplicatedLinear,
+    RowParallelLinear,
+)
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.models.interfaces import SupportsMRoPE, SupportsMultiModal
+from vllm.model_executor.models.utils import maybe_prefix
+from vllm.model_executor.utils import set_weight_attrs
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.sequence import IntermediateTensors
+
+from vllm_omni.model_executor.custom_process_mixin import CustomProcessMixin
+from vllm_omni.model_executor.models.falcon_perception.processing_falcon_perception import (
+    FalconPerceptionDummyInputsBuilder,
+    FalconPerceptionMultiModalProcessor,
+    FalconPerceptionProcessingInfo,
+)
+from vllm_omni.model_executor.models.falcon_perception.profiling import mark, nvtx_range
+from vllm_omni.model_executor.models.falcon_perception.rope import (
+    apply_3d_rotary_emb,
+    apply_golden_freqs_cis_to_visual_pos,
+    compute_pos_hw,
+    pack_image_grid_positions,
+    precompute_freqs_cis,
+)
+from vllm_omni.model_executor.models.output_templates import OmniOutput
+
+logger = init_logger(__name__)
+
+
+def _grid_hws_from_mm_features(mm_features: list | None) -> list[tuple[int, int]]:
+    """Read ``(grid_h, grid_w)`` per image out of the runner's mm features.
+
+    ``mm_features`` carries the multimodal processor's own fields, so this sees
+    ``image_grid_hw`` for every image in the request whether or not the encoder
+    cache will later short-circuit ``embed_multimodal``.
+    """
+    grids: list[tuple[int, int]] = []
+    for feature in mm_features or ():
+        item = getattr(feature, "data", None)
+        if item is None:
+            continue
+        value = item.get_data().get("image_grid_hw")
+        if value is None:
+            continue
+        for grid_h, grid_w in torch.as_tensor(value).reshape(-1, 2).tolist():
+            grids.append((int(grid_h), int(grid_w)))
+    return grids
+
+
+class FalconPerceptionMLP(nn.Module):
+    """Squared-ReLU gated FFN with a weightless pre-norm."""
+
+    def __init__(self, hidden_size: int, intermediate_size: int, quant_config=None, prefix: str = "") -> None:
+        super().__init__()
+        self.gate_up_proj = MergedColumnParallelLinear(
+            hidden_size,
+            [intermediate_size] * 2,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.gate_up_proj",
+        )
+        self.down_proj = RowParallelLinear(
+            intermediate_size,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.down_proj",
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = F.rms_norm(x, (x.size(-1),))
+        gate_up, _ = self.gate_up_proj(x)
+        gate, up = gate_up.chunk(2, dim=-1)
+        # relu(gate)**2 * up — the sqrt(2) scale is pre-baked into the gate rows.
+        out, _ = self.down_proj(F.relu(gate).square() * up)
+        return out
+
+
+class FalconPerceptionAttention(nn.Module):
+    """GQA with weightless QK-norm, split RoPE and attention sinks.
+
+    ``Attention`` is configured with ``num_kv_heads == num_heads`` on purpose.
+    The learned 2-D rotation is indexed per *query* head and its rows differ
+    within a GQA group, so the two K heads of a group receive different
+    rotations and cannot share a cache entry. The projection stays GQA-shaped
+    (``total_num_kv_heads`` KV heads, so TP sharding and the checkpoint layout
+    are unchanged); K/V are expanded right before the rotation.
+    """
+
+    def __init__(
+        self,
+        *,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        cache_config=None,
+        quant_config=None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        tp_size = get_tensor_model_parallel_world_size()
+        self.head_dim = head_dim
+        self.total_num_heads = num_heads
+        self.total_num_kv_heads = num_kv_heads
+        assert num_heads % tp_size == 0, f"num_heads={num_heads} must be divisible by TP size {tp_size}"
+        self.num_heads = num_heads // tp_size
+        # ``QKVParallelLinear`` replicates KV heads when num_kv_heads < tp_size,
+        # so mirror its arithmetic rather than assuming clean division.
+        self.num_kv_heads = max(1, num_kv_heads // tp_size)
+        self.n_rep = self.num_heads // self.num_kv_heads
+        self.q_size = self.num_heads * head_dim
+        self.kv_size = self.num_kv_heads * head_dim
+        self.scaling = head_dim**-0.5
+
+        self.qkv_proj = QKVParallelLinear(
+            hidden_size,
+            head_dim,
+            num_heads,
+            num_kv_heads,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.qkv_proj",
+        )
+        self.o_proj = RowParallelLinear(
+            num_heads * head_dim,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.o_proj",
+        )
+
+        # One learned sink logit per (local) attention head.
+        self.sinks = nn.Parameter(torch.empty(self.num_heads))
+        set_weight_attrs(self.sinks, {"weight_loader": self._load_sinks})
+
+        self.attn = Attention(
+            self.num_heads,
+            head_dim,
+            self.scaling,
+            num_kv_heads=self.num_heads,
+            cache_config=cache_config,
+            quant_config=quant_config,
+            prefix=f"{prefix}.attn",
+            sinks=self.sinks,
+        )
+
+    def _load_sinks(self, param: nn.Parameter, loaded_weight: torch.Tensor) -> None:
+        tp_rank = get_tensor_model_parallel_rank()
+        shard = loaded_weight.narrow(0, tp_rank * self.num_heads, self.num_heads)
+        param.data.copy_(shard)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        freqs_cis: torch.Tensor,
+        freqs_cis_2d: torch.Tensor,
+        spatial_enabled: torch.Tensor,
+    ) -> torch.Tensor:
+        num_tokens = hidden_states.shape[0]
+        x = F.rms_norm(hidden_states, (hidden_states.size(-1),))
+
+        qkv, _ = self.qkv_proj(x)
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        q = q.view(num_tokens, self.num_heads, self.head_dim)
+        k = k.view(num_tokens, self.num_kv_heads, self.head_dim)
+        v = v.view(num_tokens, self.num_kv_heads, self.head_dim)
+
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+
+        # Expand K/V to the query head count *before* RoPE — see class docstring.
+        k = k.repeat_interleave(self.n_rep, dim=1)
+        v = v.repeat_interleave(self.n_rep, dim=1)
+
+        q, k = apply_3d_rotary_emb(q, k, freqs_cis, freqs_cis_2d, spatial_enabled)
+
+        attn_out = self.attn(
+            q.reshape(num_tokens, -1),
+            k.reshape(num_tokens, -1),
+            v.reshape(num_tokens, -1),
+        )
+        out, _ = self.o_proj(attn_out)
+        return out
+
+
+class FalconPerceptionDecoderLayer(nn.Module):
+    def __init__(self, *, config, cache_config=None, quant_config=None, prefix: str = "") -> None:
+        super().__init__()
+        self.self_attn = FalconPerceptionAttention(
+            hidden_size=config.hidden_size,
+            num_heads=config.num_attention_heads,
+            num_kv_heads=config.num_key_value_heads,
+            head_dim=config.head_dim,
+            cache_config=cache_config,
+            quant_config=quant_config,
+            prefix=f"{prefix}.self_attn",
+        )
+        self.mlp = FalconPerceptionMLP(
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.mlp",
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        freqs_cis: torch.Tensor,
+        freqs_cis_2d: torch.Tensor,
+        spatial_enabled: torch.Tensor,
+    ) -> torch.Tensor:
+        hidden_states = hidden_states + self.self_attn(hidden_states, freqs_cis, freqs_cis_2d, spatial_enabled)
+        return hidden_states + self.mlp(hidden_states)
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "positions": {1: "num_tokens"},
+        "inputs_embeds": {0: "num_tokens"},
+        "pos_hw": {0: "num_tokens"},
+    }
+)
+class FalconPerceptionBackbone(nn.Module):
+    """Token embeddings, the transformer stack, the final norm and the patch projector."""
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        config = vllm_config.model_config.hf_config
+        cache_config = vllm_config.cache_config
+        quant_config = vllm_config.quant_config
+        self.config = config
+
+        self.embed_tokens = VocabParallelEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "embed_tokens"),
+        )
+        self.layers = nn.ModuleList(
+            [
+                FalconPerceptionDecoderLayer(
+                    config=config,
+                    cache_config=cache_config,
+                    quant_config=quant_config,
+                    prefix=maybe_prefix(prefix, f"layers.{i}"),
+                )
+                for i in range(config.num_hidden_layers)
+            ]
+        )
+        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+        patch_dim = config.temporal_patch_size * (config.spatial_patch_size**2) * config.channel_size
+        self.img_projector = ReplicatedLinear(
+            patch_dim,
+            config.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "img_projector"),
+        )
+
+        # Temporal RoPE table (first half of head_dim), rebuilt at init.
+        rope_dim = config.head_dim // 2
+        self.register_buffer(
+            "freqs_cis",
+            precompute_freqs_cis(rope_dim, config.max_seq_len, config.rope_theta),
+            persistent=False,
+        )
+        # Learned 2-D frequencies, loaded from the checkpoint and sharded by head.
+        tp_size = get_tensor_model_parallel_world_size()
+        num_local_heads = config.num_attention_heads // tp_size
+        self.register_buffer(
+            "freqs_cis_golden",
+            torch.empty((num_local_heads, rope_dim // 2, 2), dtype=torch.float32),
+            persistent=True,
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        inputs_embeds: torch.Tensor,
+        pos_hw: torch.Tensor,
+        spatial_enabled: torch.Tensor,
+    ) -> torch.Tensor:
+        hidden_states = inputs_embeds
+
+        # ``positions`` is the [3, N] M-RoPE buffer; all three rows hold the same
+        # collapsed temporal position (see get_mrope_input_positions).
+        pos_t = positions[0] if positions.dim() == 2 else positions
+        freqs_cis = self.freqs_cis[pos_t]
+
+        freqs_cis_2d = apply_golden_freqs_cis_to_visual_pos(self.freqs_cis_golden, pos_hw)
+
+        for layer in self.layers:
+            hidden_states = layer(hidden_states, freqs_cis, freqs_cis_2d, spatial_enabled)
+
+        return self.norm(hidden_states)
+
+
+class FourierEncoder(nn.Module):
+    """Fourier-feature encoder used to turn continuous (x, y) / (h, w) into embeddings."""
+
+    def __init__(self, in_dim: int, feat_dim: int, out_dim: int) -> None:
+        super().__init__()
+        self.embed = ReplicatedLinear(in_dim, feat_dim // 2, bias=False)
+        self.transform = ReplicatedLinear(feat_dim, out_dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # The decoders return normalised float32 coordinates while the weights
+        # follow the model dtype (bf16), so align before the GEMM.
+        x = x.to(self.embed.weight.dtype)
+        f, _ = self.embed(x)
+        f = 2 * math.pi * f
+        f = torch.cat([f.cos(), f.sin()], dim=-1)
+        out, _ = self.transform(f)
+        return out
+
+
+class BboxDecoder(nn.Module):
+    """Two-layer squared-ReLU MLP producing per-axis bin logits."""
+
+    def __init__(self, in_dim: int, hidden_dim: int, out_dim: int) -> None:
+        super().__init__()
+        self.w1 = ReplicatedLinear(in_dim, hidden_dim, bias=False)
+        self.w2 = ReplicatedLinear(hidden_dim, out_dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h, _ = self.w1(x.to(self.w1.weight.dtype))
+        out, _ = self.w2(F.relu(h).square())
+        return out
+
+
+_COORD_STATE_KEY = "falcon_perception_geometry"
+_COORD_REPEAT_THRESHOLD = 0.01
+_MAX_COORD_ATTEMPTS = 100
+
+
+def _select_coordinate_from_logits(
+    logits: torch.Tensor,
+    existing_coords: torch.Tensor | None,
+    *,
+    repeat_threshold: float = _COORD_REPEAT_THRESHOLD,
+    max_attempts: int = _MAX_COORD_ATTEMPTS,
+) -> torch.Tensor:
+    """Select one non-repeated ``(x, y)`` coordinate from ``(2, bins)`` logits.
+
+    Falcon Perception feeds the selected coordinate back into the next decode
+    step. Re-emitting a previous centre therefore changes the future token
+    trajectory, rather than merely duplicating a box in post-processing. Match
+    the reference by masking both selected axis bins and retrying when a centre
+    is within one percent of an earlier centre for this request.
+    """
+    if logits.ndim != 2 or logits.shape[0] != 2:
+        raise ValueError(f"coordinate logits must have shape (2, bins), got {tuple(logits.shape)}")
+
+    num_bins = logits.shape[-1]
+    if num_bins <= 1:
+        raise ValueError(f"coordinate decoder must expose at least two bins, got {num_bins}")
+
+    history = None
+    if isinstance(existing_coords, torch.Tensor) and existing_coords.numel() > 0:
+        history = existing_coords.reshape(-1, 2).to(device=logits.device, dtype=torch.float32)
+
+    working = logits.clone()
+    selected = torch.zeros(2, device=logits.device, dtype=torch.float32)
+    for _ in range(max_attempts):
+        selected_bins = torch.argmax(working, dim=-1)
+        selected = selected_bins.float() / (num_bins - 1)
+        if history is None:
+            break
+        repeated = torch.all(torch.abs(history - selected) < repeat_threshold, dim=-1).any()
+        if not bool(repeated.item()):
+            break
+        working[0, selected_bins[0]] = float("-inf")
+        working[1, selected_bins[1]] = float("-inf")
+    return selected.unsqueeze(0)
+
+
+@MULTIMODAL_REGISTRY.register_processor(
+    FalconPerceptionMultiModalProcessor,
+    info=FalconPerceptionProcessingInfo,
+    dummy_inputs=FalconPerceptionDummyInputsBuilder,
+)
+class FalconPerceptionThinker(nn.Module, CustomProcessMixin, SupportsMultiModal, SupportsMRoPE):
+    """Image + text -> tokens, bounding boxes and per-instance segmentation features."""
+
+    merge_by_field_config = True
+
+    # The runner probes these to decide which hooks to call. ``preprocess``
+    # re-injects the previous step's decoded geometry; ``postprocess`` stashes
+    # the last hidden state each step. Both are per-request via the runner's
+    # intermediate buffer — the model itself holds no per-request state.
+    has_preprocess = True
+    has_postprocess = True
+    postprocess_uses_multimodal_outputs = False
+    have_multimodal_outputs = True
+
+    @classmethod
+    def get_placeholder_str(cls, modality: str, i: int) -> str | None:
+        if modality.startswith("image"):
+            return "<|image|>"
+        return None
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        config = vllm_config.model_config.hf_config
+        quant_config = vllm_config.quant_config
+        self.config = config
+
+        self.model = FalconPerceptionBackbone(vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model"))
+        self.lm_head = ParallelLMHead(
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "lm_head"),
+        )
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+
+        if config.perception_heads:
+            self.coord_encoder = FourierEncoder(2, config.coord_enc_dim, config.hidden_size)
+            self.coord_decoder = BboxDecoder(config.hidden_size, config.coord_dec_dim, config.coord_out_dim)
+            self.size_encoder = FourierEncoder(2, config.size_enc_dim, config.hidden_size)
+            self.size_decoder = BboxDecoder(config.hidden_size, config.size_dec_dim, config.size_out_dim)
+
+        # Lazily captured CUDA graph for the per-step geometry block; see
+        # ``_geometry_embed_cached``.
+        self._geom_graph: torch.cuda.CUDAGraph | None = None
+        self._geom_sig: tuple | None = None
+        self._geom_static: dict[str, torch.Tensor] = {}
+        self._geom_graph_disabled = False
+
+        self._patch_dim = config.temporal_patch_size * (config.spatial_patch_size**2) * config.channel_size
+        self._structural_ids = config.image_structural_token_ids
+        self._end_of_image_token_id = config.img_end_id
+
+    def get_language_model(self) -> nn.Module:
+        return self.model
+
+    # ---------------------------------------------------------------- M-RoPE
+
+    def get_mrope_input_positions(
+        self,
+        input_tokens: list[int],
+        mm_features: list | None = None,
+        **kwargs: Any,
+    ) -> tuple[torch.Tensor, int]:
+        """Collapse each image block to a single temporal position.
+
+        The reference builds ``pos_t`` as a cumulative sum that does not
+        increment on the 4 register tokens, the image patch tokens or
+        ``<end_of_image>`` — only ``<image_cls>`` consumes an increment. The
+        net effect is that ``[cls, reg1..4, patches..., eoi]`` all share the
+        position assigned to ``cls``, and the following text resumes at +1.
+
+        Returns ``[3, N]``. Row 0 is ``pos_t``, the only row the rotation reads.
+        Rows 1 and 2 are dead weight for this model (``mrope_section`` is
+        ``[head_dim // 2, 0, 0]``), so they carry the packed image patch grid —
+        that is how ``forward`` learns the grid without depending on
+        ``embed_multimodal`` having run. The runner rebuilds this buffer from
+        ``mm_features`` for every request, including the ones whose image the
+        multimodal encoder cache will serve from an earlier request.
+        """
+        start_id = self.config.image_cls_token_id
+        end_id = self._end_of_image_token_id
+
+        pos_t: list[int] = []
+        in_image = False
+        next_pos = 0
+
+        for tok in input_tokens:
+            if tok == start_id and not in_image:
+                in_image = True
+            pos_t.append(next_pos)
+            if not in_image:
+                next_pos += 1
+            if tok == end_id and in_image:
+                in_image = False
+                next_pos += 1
+
+        positions = torch.zeros((3, len(input_tokens)), dtype=torch.long)
+        positions[0] = torch.tensor(pos_t, dtype=torch.long)
+        # Row 0 only: rows 1/2 hold packed grid values, not positions.
+        mrope_position_delta = int(positions[0].max().item()) + 1 - len(input_tokens)
+
+        grids = _grid_hws_from_mm_features(mm_features)
+        if grids:
+            image_index = torch.tensor(
+                [i for i, tok in enumerate(input_tokens) if tok == self.config.img_id],
+                dtype=torch.long,
+            )
+            packed = torch.cat([pack_image_grid_positions(grid_h, grid_w) for grid_h, grid_w in grids])
+            # A prompt update that leaves the literal ``<|image|>`` in place, or
+            # drops one, would misalign every patch row against its grid. Fail
+            # loudly here rather than rotate the image by a fraction of a patch.
+            if packed.shape[0] != image_index.numel():
+                raise ValueError(
+                    f"Falcon Perception: prompt has {image_index.numel()} image patch tokens but grids "
+                    f"{grids} describe {packed.shape[0]} patches. The placeholder run and the processor "
+                    "grid must agree exactly."
+                )
+            positions[1:3, image_index] = packed.t()
+
+        return positions, mrope_position_delta
+
+    # --------------------------------------------------------- multimodal in
+
+    def embed_multimodal(
+        self,
+        pixel_values: torch.Tensor | list[torch.Tensor] | None = None,
+        image_grid_hw: torch.Tensor | list[tuple[int, int]] | None = None,
+        **kwargs: Any,
+    ) -> tuple[torch.Tensor, ...]:
+        """Patchify, project, and wrap each image with its structural tokens.
+
+        Returns one tensor per image of shape ``(5 + n_patches + 1, hidden)``,
+        matching the placeholder run inserted by the processor.
+        """
+        assert pixel_values is not None, "Falcon Perception requires pixel_values"
+        if isinstance(pixel_values, torch.Tensor):
+            pixel_values = [pixel_values] if pixel_values.ndim == 3 else list(pixel_values)
+        if isinstance(image_grid_hw, torch.Tensor):
+            image_grid_hw = image_grid_hw.tolist()
+
+        proj_weight = self.model.img_projector.weight
+        device, dtype = proj_weight.device, proj_weight.dtype
+        patch = self.config.spatial_patch_size
+
+        # Annotating here is safe: the runner calls ``embed_multimodal`` from the
+        # multimodal encoder path, outside the region vLLM compiles. It is also
+        # the range that shows whether the encoder cache hit — on a hit this
+        # method is not called at all, so the range is simply absent.
+        with nvtx_range("fp/s0/embed_multimodal"):
+            all_patches: list[torch.Tensor] = []
+            patch_counts: list[int] = []
+            for idx, pv in enumerate(pixel_values):
+                pv = pv.to(device=device, dtype=dtype)
+                h, w = int(pv.shape[0]), int(pv.shape[1])
+                gh, gw = h // patch, w // patch
+                if image_grid_hw is not None and idx < len(image_grid_hw):
+                    gh, gw = int(image_grid_hw[idx][0]), int(image_grid_hw[idx][1])
+                pv = pv[: gh * patch, : gw * patch]
+                # (gh*ps, gw*ps, C) -> (gh*gw, ps*ps*C), h-major to match the
+                # spatial position grid built in rope.compute_pos_hw.
+                patches = pv.reshape(gh, patch, gw, patch, -1).permute(0, 2, 1, 3, 4).reshape(gh * gw, self._patch_dim)
+                all_patches.append(patches)
+                patch_counts.append(gh * gw)
+
+            projected, _ = self.model.img_projector(torch.cat(all_patches, dim=0))
+            per_image = projected.split(patch_counts)
+
+            structural_ids = torch.tensor(
+                [*self._structural_ids, self._end_of_image_token_id],
+                device=device,
+                dtype=torch.long,
+            )
+            structural = self.model.embed_input_ids(structural_ids).to(dtype=dtype)
+            n_prefix = len(self._structural_ids)
+
+            return tuple(torch.cat([structural[:n_prefix], img, structural[n_prefix:]], dim=0) for img in per_image)
+
+    # -------------------------------------------------------------- forward
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        # The patch grid is read back per token from the M-RoPE positions
+        # buffer, which the runner rebuilds from mm_features on every step.
+        # Nothing here may depend on embed_multimodal having run: on a
+        # multimodal encoder cache hit (same image, different query — the
+        # workload this model is served for) vLLM returns the stored embedding
+        # and skips that call entirely, so a grid derived there is unavailable
+        # by construction. Losing it leaves pos_hw None, which silently drops
+        # the golden 2-D RoPE for every image token and degenerates the output.
+        pos_hw = None
+        if input_ids is not None:
+            pos_hw = compute_pos_hw(input_ids, positions, image_token_id=self.config.img_id)
+
+        # Keep multimodal position reconstruction eager, but give the compiled
+        # backbone one stable tensor signature in both prefill and decode. A
+        # tensor gate preserves the reference's no-spatial-RoPE decode path;
+        # merely rotating by identity would still round-trip bf16 values
+        # through float32 and can move mask boundaries.
+        if pos_hw is None:
+            pos_hw = torch.zeros((positions.shape[-1], 2), device=positions.device, dtype=torch.float32)
+            spatial_enabled = torch.zeros((1,), device=positions.device, dtype=torch.bool)
+        else:
+            spatial_enabled = torch.ones((1,), device=positions.device, dtype=torch.bool)
+        if inputs_embeds is None:
+            if input_ids is None:
+                raise ValueError("Falcon Perception requires input_ids or inputs_embeds")
+            inputs_embeds = self.model.embed_input_ids(input_ids)
+
+        return self.model(positions, inputs_embeds, pos_hw, spatial_enabled)
+
+    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor | None:
+        return self.logits_processor(self.lm_head, hidden_states)
+
+    def make_omni_output(self, model_output: torch.Tensor, **kwargs: Any) -> OmniOutput:
+        """Emit per-row geometry alongside the hidden states.
+
+        The decoders run on every row rather than only on ``<coord>`` /
+        ``<size>`` rows: which rows matter is decided by the *sampled* token,
+        which is not known until after this call. Emitting unconditionally and
+        letting the consumer mask by token id keeps this stateless and
+        batch-safe, and mirrors the reference, which also runs both heads every
+        step to stay sync-free. The rows accumulate across steps, so the
+        consumer sees one ``(xy, hw)`` pair per generated token, index-aligned
+        with the token stream.
+        """
+        if not self.config.perception_heads or model_output.numel() == 0:
+            return OmniOutput(text_hidden_states=model_output)
+
+        hidden = model_output.reshape(-1, model_output.shape[-1])
+        # Under ``hidden_states`` rather than a "geometry" section of its own:
+        # the stage payload only transports the schema's sections
+        # (data_entry_keys.py), so a custom top-level section is dropped.
+        geometry = {
+            "box_xy": self._decode_coords(hidden),
+            "box_hw": self._decode_sizes(hidden),
+        }
+
+        # ``box_xy`` above is hidden-row aligned and therefore emitted before
+        # sampling reveals whether a row produced ``<coord>``. The request's
+        # preprocess hook selects and de-duplicates that coordinate one step
+        # later. Ship those accepted coordinates as per-request deltas so the
+        # stage bridge can use exactly the values that were fed back into the
+        # model, rather than the pre-dedup argmax rows.
+        runtime_infos = kwargs.get("runtime_additional_information") or []
+        if isinstance(runtime_infos, list):
+            selected_xy: list[torch.Tensor] = []
+            for info in runtime_infos:
+                state = info.get(_COORD_STATE_KEY, {}) if isinstance(info, dict) else {}
+                active = state.get("selected_xy_active") if isinstance(state, dict) else None
+                xy = state.get("selected_xy") if isinstance(state, dict) else None
+                is_active = isinstance(active, torch.Tensor) and active.numel() > 0 and bool(active.reshape(-1)[-1])
+                if is_active and isinstance(xy, torch.Tensor) and xy.numel() == 2:
+                    selected_xy.append(xy.reshape(1, 2))
+                else:
+                    selected_xy.append(torch.zeros((0, 2), dtype=torch.float32))
+            geometry["selected_box_xy"] = selected_xy
+        return OmniOutput(text_hidden_states=model_output, multimodal_outputs={"hidden_states": geometry})
+
+    # ------------------------------------------------- geometry feedback loop
+
+    def postprocess(self, hidden_states: torch.Tensor, **_: Any) -> dict[str, Any]:
+        """Stash this step's last hidden state for the next step's preprocess.
+
+        Same contract as the in-tree talker stages: the runner writes the
+        returned dict into its per-request intermediate buffer, so nothing is
+        kept on the module and continuous batching stays safe.
+        """
+        # Runner-called, once per decode step, outside the compiled model.
+        with nvtx_range("fp/s0/postprocess"):
+            if hidden_states.numel() == 0:
+                return {}
+            return {"hidden_states": {"last": hidden_states[-1].detach().contiguous()}}
+
+    def preprocess(
+        self,
+        input_ids: torch.Tensor,
+        input_embeds: torch.Tensor | None,
+        **info_dict: Any,
+    ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
+        """Re-inject geometry decoded from the previous step's hidden state.
+
+        The reference decodes ``(x, y)`` / ``(h, w)`` from the hidden state that
+        *produced* the ``<coord>`` / ``<size>`` token, then feeds those values
+        back as that token's input embedding one step later. Here the previous
+        hidden state arrives through ``info_dict['hidden_states']['last']``.
+        """
+        additional = info_dict.get("additional_information")
+        if isinstance(additional, dict):
+            merged = {k: v for k, v in info_dict.items() if k != "additional_information"}
+            for k, v in additional.items():
+                merged.setdefault(k, v)
+            info_dict = merged
+
+        if input_embeds is None:
+            input_embeds = self.model.embed_input_ids(input_ids)
+
+        if not self.config.perception_heads:
+            return input_ids, input_embeds, {}
+
+        last_hidden = (info_dict.get("hidden_states") or {}).get("last")
+        is_decode = isinstance(last_hidden, torch.Tensor) and input_ids.numel() > 0
+
+        # Step boundary marker. ``preprocess`` is called by the runner exactly
+        # once per model step, before the forward, and outside every compiled
+        # region — so this is the one safe place to delimit steps from inside the
+        # model. It is a *mark*, not a range: a range would have to be popped in
+        # ``postprocess``, and a push/pop split across two callbacks corrupts the
+        # whole NVTX stack the first time one of them is skipped.
+        # Measure a step as the gap between consecutive marks; the phase label
+        # tells you which side of prefill you are on.
+        mark(f"fp/s0/step[{'decode' if is_decode else 'prefill'}]")
+
+        if not is_decode:
+            # Prefill (or the very first decode step): the prompt carries no
+            # <coord>/<size> tokens, so the embeddings pass through unchanged.
+            return input_ids, input_embeds, {}
+
+        # Only the newest token can be a geometry token during decode.
+        # Runner-called per decode step and outside the compiled model, so the
+        # range is safe. This is the loop the phase profile put at 33 ms/step,
+        # i.e. most of a dense request — the reason it is annotated separately
+        # from the backbone forward it precedes.
+        with nvtx_range("fp/s0/preprocess/geometry"):
+            token = input_ids[-1]
+            h = last_hidden.to(device=input_embeds.device, dtype=input_embeds.dtype).reshape(1, -1)
+
+            is_coord = token == self.config.coord_token_id
+            is_size = token == self.config.size_token_id
+            token_id = int(token.item())
+            state = info_dict.get(_COORD_STATE_KEY)
+            if not isinstance(state, dict):
+                state = {}
+
+            update: dict[str, Any]
+            if token_id == self.config.coord_token_id:
+                selected_xy = self._select_coord(h, state.get("coord_history"))
+                new_embed = self.coord_encoder(selected_xy).to(input_embeds.dtype)
+                previous = state.get("coord_history")
+                if isinstance(previous, torch.Tensor) and previous.numel() > 0:
+                    previous = previous.reshape(-1, 2).to(device=selected_xy.device, dtype=selected_xy.dtype)
+                    coord_history = torch.cat((previous, selected_xy), dim=0)
+                else:
+                    coord_history = selected_xy
+                update = {
+                    _COORD_STATE_KEY: {
+                        "coord_history": coord_history,
+                        "selected_xy": selected_xy,
+                        "selected_xy_active": torch.ones(1, device=selected_xy.device, dtype=torch.bool),
+                    }
+                }
+            else:
+                new_embed = self._geometry_embed_cached(h, is_coord, is_size, input_embeds[-1:])
+                # Clear the delta marker every non-coordinate step so a prior
+                # accepted centre is emitted exactly once by make_omni_output.
+                update = {
+                    _COORD_STATE_KEY: {
+                        "selected_xy_active": torch.zeros(1, device=input_embeds.device, dtype=torch.bool),
+                    }
+                }
+            input_embeds = torch.cat([input_embeds[:-1], new_embed], dim=0)
+
+        # The update contains only request-scoped coordinate feedback state.
+        # The mask head still takes its row-aligned geometry from
+        # ``make_omni_output`` and its ``<seg>`` rows from the latent trajectory;
+        # keeping geometry out of this dict avoids the five CPU transfers an
+        # earlier implementation performed on every decode step.
+        return input_ids, input_embeds, update
+
+    def _geometry_embed(
+        self,
+        h: torch.Tensor,
+        is_coord: torch.Tensor,
+        is_size: torch.Tensor,
+        last_embed: torch.Tensor,
+    ) -> torch.Tensor:
+        """Decode geometry from the previous hidden state, re-encode it as an embedding.
+
+        Both heads run unconditionally and the result is selected with
+        ``torch.where``: branching on a GPU token id would force a device sync
+        on every decode step.
+        """
+        xy = self._decode_coords(h)
+        hw = self._decode_sizes(h)
+        # ``torch.where`` is out-of-place, so the first call already allocates a
+        # fresh tensor and leaves ``last_embed`` untouched: no defensive clone.
+        new_embed = torch.where(is_coord, self.coord_encoder(xy).to(last_embed.dtype), last_embed)
+        new_embed = torch.where(is_size, self.size_encoder(hw).to(new_embed.dtype), new_embed)
+        return new_embed
+
+    def _geometry_embed_cached(
+        self,
+        h: torch.Tensor,
+        is_coord: torch.Tensor,
+        is_size: torch.Tensor,
+        last_embed: torch.Tensor,
+    ) -> torch.Tensor:
+        """``_geometry_embed`` replayed from a CUDA graph, when that is possible.
+        This is because the block is launch-bound, not compute-bound
+        A graph is the right tool rather than ``torch.compile``
+        """
+        eager_ok = (
+            self._geom_graph_disabled
+            or h.device.type != "cuda"
+            # Nested capture is illegal, and attempting one inside vLLM's own
+            # capture would corrupt *its* graph, not just fail ours.
+            or torch.cuda.is_current_stream_capturing()
+        )
+        if eager_ok:
+            return self._geometry_embed(h, is_coord, is_size, last_embed)
+
+        sig = (tuple(h.shape), h.dtype, tuple(last_embed.shape), last_embed.dtype)
+        if self._geom_graph is None or self._geom_sig != sig:
+            if not self._capture_geometry_graph(h, is_coord, is_size, last_embed, sig):
+                return self._geometry_embed(h, is_coord, is_size, last_embed)
+
+        static = self._geom_static
+        static["h"].copy_(h)
+        static["last"].copy_(last_embed)
+        static["is_coord"].copy_(is_coord)
+        static["is_size"].copy_(is_size)
+        self._geom_graph.replay()
+        # Cloned because the graph writes into this buffer again next step.
+        return static["out"].clone()
+
+    def _capture_geometry_graph(
+        self,
+        h: torch.Tensor,
+        is_coord: torch.Tensor,
+        is_size: torch.Tensor,
+        last_embed: torch.Tensor,
+        sig: tuple,
+    ) -> bool:
+        """Capture ``_geometry_embed`` into a CUDA graph. ``False`` if unavailable."""
+        try:
+            static = {
+                "h": h.clone(),
+                "last": last_embed.clone(),
+                "is_coord": is_coord.clone(),
+                "is_size": is_size.clone(),
+            }
+            # Warm up on a side stream first: the first call allocates
+            # workspaces and picks cuBLAS kernels, none of which may happen
+            # during capture.
+            side = torch.cuda.Stream()
+            side.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(side):
+                for _ in range(3):
+                    self._geometry_embed(static["h"], static["is_coord"], static["is_size"], static["last"])
+            torch.cuda.current_stream().wait_stream(side)
+
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                static["out"] = self._geometry_embed(static["h"], static["is_coord"], static["is_size"], static["last"])
+        except (RuntimeError, torch.cuda.CudaError) as exc:
+            logger.warning(
+                "falcon_perception: could not capture the geometry CUDA graph (%s); "
+                "falling back to eager for the rest of this process",
+                exc,
+            )
+            self._geom_graph_disabled = True
+            return False
+
+        self._geom_graph = graph
+        self._geom_static = static
+        self._geom_sig = sig
+        return True
+
+    def _decode_coords(self, hidden: torch.Tensor) -> torch.Tensor:
+        """(N, D) hidden -> (N, 2) normalised centre coordinates in [0, 1]."""
+        logits = self.coord_decoder(hidden).view(hidden.shape[0], 2, -1)
+        num_bins = logits.shape[-1]
+        return torch.argmax(logits, dim=-1).float() / (num_bins - 1)
+
+    def _select_coord(self, hidden: torch.Tensor, existing_coords: torch.Tensor | None) -> torch.Tensor:
+        logits = self.coord_decoder(hidden).view(hidden.shape[0], 2, -1)
+        if logits.shape[0] != 1:
+            raise ValueError(f"coordinate feedback expects one request row, got {logits.shape[0]}")
+        return _select_coordinate_from_logits(logits[0], existing_coords)
+
+    def _decode_sizes(self, hidden: torch.Tensor) -> torch.Tensor:
+        """(N, D) hidden -> (N, 2) normalised (h, w) sizes, de-bucketed in log2 space."""
+        logits = self.size_decoder(hidden).view(hidden.shape[0], 2, -1)
+        num_bins = logits.shape[-1]
+        pred = torch.argmax(logits, dim=-1).float() / (num_bins - 1)
+        min_size = math.log2(1.0 / num_bins)
+        pred = pred * (0.0 - min_size) + min_size
+        return torch.pow(2.0, pred)
+
+    # -------------------------------------------------------- weight loading
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        params_dict = dict(self.named_parameters())
+        loaded: set[str] = set()
+        tp_rank = get_tensor_model_parallel_rank()
+        tp_size = get_tensor_model_parallel_world_size()
+
+        head_dim = self.config.head_dim
+        n_heads = self.config.num_attention_heads
+        n_kv = self.config.num_key_value_heads
+        q_dim, kv_dim = n_heads * head_dim, n_kv * head_dim
+
+        for name, weight in weights:
+            if name.startswith("model."):
+                name = name[len("model.") :]
+
+            if name == "freqs_cis_golden":
+                rows = n_heads // tp_size
+                shard = weight[:n_heads].narrow(0, tp_rank * rows, rows)
+                self.model.freqs_cis_golden.copy_(shard.to(self.model.freqs_cis_golden.dtype))
+                loaded.add("model.freqs_cis_golden")
+                continue
+
+            if name.endswith("attention.wqkv.weight"):
+                layer = name.split(".")[1]
+                target = f"model.layers.{layer}.self_attn.qkv_proj.weight"
+                param = params_dict[target]
+                loader = param.weight_loader
+                q, k, v = weight.split([q_dim, kv_dim, kv_dim], dim=0)
+                loader(param, q, "q")
+                loader(param, k, "k")
+                loader(param, v, "v")
+                loaded.add(target)
+                continue
+
+            if name.endswith("feed_forward.w13.weight"):
+                layer = name.split(".")[1]
+                target = f"model.layers.{layer}.mlp.gate_up_proj.weight"
+                param = params_dict[target]
+                loader = param.weight_loader
+                # Checkpoint packs gate/up interleaved as [g0, u0, g1, u1, ...];
+                # MergedColumnParallelLinear wants them as two contiguous shards.
+                pairs = weight.view(-1, 2, weight.shape[-1])
+                loader(param, pairs[:, 0, :].contiguous(), 0)
+                loader(param, pairs[:, 1, :].contiguous(), 1)
+                loaded.add(target)
+                continue
+
+            target = self._map_weight_name(name)
+            if target is None or target not in params_dict:
+                continue
+            param = params_dict[target]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, weight)
+            loaded.add(target)
+
+        # ``freqs_cis_golden`` is a *buffer*, and vLLM's missing-weight guard
+        # only covers ``named_parameters()``
+        # (model_loader/default_loader.py: ``weights_to_load = {name for name, _
+        # in model.named_parameters()}``). So a checkpoint that lacks this key,
+        # or an upstream rename, would leave ``torch.empty`` memory serving as
+        # the learned 2-D rotation: no exception, and masks that look plausible
+        # but are wrong. That is the same silent-corruption shape as the
+        # encoder-cache bug (18 masks vs 121), so fail loudly instead.
+        if "model.freqs_cis_golden" not in loaded:
+            raise ValueError(
+                "Falcon Perception: checkpoint has no 'freqs_cis_golden'. It is a buffer, "
+                "not a parameter, so vLLM's missing-weight check cannot catch it and the "
+                "golden 2-D RoPE would silently run on uninitialized memory."
+            )
+
+        return loaded
+
+    def _map_weight_name(self, name: str) -> str | None:
+        """Map a reference checkpoint key onto this module's parameter names."""
+        direct = {
+            "tok_embeddings.weight": "model.embed_tokens.weight",
+            "output.weight": "lm_head.weight",
+            "norm.weight": "model.norm.weight",
+            "img_projector.weight": "model.img_projector.weight",
+        }
+        if name in direct:
+            return direct[name]
+
+        if name.startswith("layers."):
+            parts = name.split(".")
+            layer = parts[1]
+            rest = ".".join(parts[2:])
+            rest = rest.replace("attention.wo.", "self_attn.o_proj.")
+            rest = rest.replace("attention.sinks", "self_attn.sinks")
+            rest = rest.replace("feed_forward.w2.", "mlp.down_proj.")
+            return f"model.layers.{layer}.{rest}"
+
+        # Perception heads live on this module under their reference names.
+        if name.startswith(("coord_encoder.", "coord_decoder.", "size_encoder.", "size_decoder.")):
+            return name
+
+        return None
+
+
+__all__: Sequence[str] = ["FalconPerceptionThinker"]

--- a/vllm_omni/model_executor/models/falcon_perception/pipeline.py
+++ b/vllm_omni/model_executor/models/falcon_perception/pipeline.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Falcon Perception pipeline topology.
+
+Two stages:
+
+  0. **thinker** (``LLM_AR``) — image + text query -> token stream, plus a
+     ``(x, y, h, w)`` box per detected instance and one hidden state per
+     ``<seg>`` token.
+  1. **segmentation** (``LLM_GENERATION``) — the ``<seg>`` features and the
+     image patch features are upsampled by AnyUp into per-instance masks.
+
+The mask decoder (i.e. segmentation mask generator) is not autoregressive and runs once per request,
+so it is kept out of the AR loop as its own generation stage
+(the same shape as the TTS talker -> code2wav split).
+
+Detection-only (single-stage) serving for falcon perception is deliberately not offered:
+the geometry feedback loop needs ``postprocess`` output (i.e. the last hidden state),
+which the AR runner only collects when a downstream stage exists
+(``gpu_ar_model_runner.py``: ``needs_payload = final_stage_id is None or final_stage_id > 0``).
+With stage 0 final, the filter set is empty and the model doesn't get correct
+feedback from the geometry feedback loop, hence producing wrong results.
+Enabling it means generalizing that shared gate, which belongs in its own PR.
+"""
+
+from vllm_omni.config.stage_config import (
+    PipelineConfig,
+    StageExecutionType,
+    StagePipelineConfig,
+)
+
+_PROC = "vllm_omni.model_executor.stage_input_processors.falcon_perception"
+
+# Greedy decoding, and the reference's second stop token (``<|end_of_query|>``)
+# alongside EOS.
+_THINKER_SAMPLING = {
+    "detokenize": True,
+    "stop_token_ids": [11, 263],  # [eos, end_of_query]
+}
+
+FALCON_PERCEPTION_PIPELINE = PipelineConfig(
+    model_type="falcon_perception",
+    default_deploy_config_name="falcon_perception.yaml",
+    model_arch="FalconPerceptionThinker",
+    hf_architectures=("FalconPerceptionForSegmentation",),
+    stages=(
+        StagePipelineConfig(
+            stage_id=0,
+            model_stage="thinker",
+            execution_type=StageExecutionType.LLM_AR,
+            input_sources=(),
+            final_output=True,  # this stage is allowed to surface results to the caller (not only an internal bridge).
+            # final_output_type tells orchestration and APIs how to interpret and route each stage’s OmniRequestOutput
+            final_output_type="text",  # those surfaced results are treated as text
+            owns_tokenizer=True,
+            requires_multimodal_data=True,
+            # "latent": the stage also ships its hidden-state trajectory to
+            # stage1 , exactly like the Qwen2.5-Omni thinker. The user-visible
+            # output is still text (``final_output_type`` above).
+            engine_output_type="latent",  # latent never reaches the user (client)
+            # these latents are used by the segmentation stage (next stage in the pipeline) to generate the segm masks
+            # Stage0's ``RequestOutput`` carries the last-layer hidden-states (``multimodal_output["latent"]``).
+            # These hidden-states (and related mm fields) are also used for the geometry feedback path in the AR loop.
+            model_arch="FalconPerceptionThinker",
+            sampling_constraints=_THINKER_SAMPLING,
+        ),
+        StagePipelineConfig(
+            stage_id=1,
+            model_stage="segmentation",
+            execution_type=StageExecutionType.LLM_GENERATION,
+            input_sources=(0,),
+            final_output=True,
+            final_output_type="image",
+            # AnyUp guides the upsampling with the original pixels, so the
+            # request's image is re-supplied to this stage.
+            requires_multimodal_data=True,
+            engine_output_type="image",
+            model_arch="FalconPerceptionSegmentation",
+            sync_process_input_func=f"{_PROC}.thinker2segmentation_token_only",
+            sampling_constraints={"detokenize": False},
+        ),
+    ),
+)

--- a/vllm_omni/model_executor/models/falcon_perception/processing_falcon_perception.py
+++ b/vllm_omni/model_executor/models/falcon_perception/processing_falcon_perception.py
@@ -1,0 +1,316 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Falcon Perception multimodal input processing.
+
+The published checkpoints ship no ``AutoProcessor``; the reference engine drives
+a small numpy/PIL image pipeline directly. This module reimplements that
+pipeline against vLLM's processing interfaces so the token counts, the pixel
+normalisation and the placeholder layout all match the reference exactly.
+
+Per image the prompt gains ``5 + (H/patch)*(W/patch) + 1`` tokens:
+``[image_cls, reg1..reg4] + <|image|> * n_patches + [end_of_image]``.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+import torch
+from PIL import Image
+from vllm.inputs import MultiModalDataDict
+from vllm.multimodal.inputs import MultiModalFieldConfig, MultiModalKwargsItems
+from vllm.multimodal.parse import ImageProcessorItems, MultiModalDataItems
+from vllm.multimodal.processing import (
+    BaseDummyInputsBuilder,
+    BaseMultiModalProcessor,
+    BaseProcessingInfo,
+    PromptReplacement,
+    PromptUpdate,
+    PromptUpdateDetails,
+)
+
+IMAGE_MEAN = (0.5, 0.5, 0.5)
+IMAGE_STD = (0.5, 0.5, 0.5)
+
+
+def resize_image_if_necessary(
+    image: Image.Image,
+    min_dimension: int = 256,
+    max_dimension: int = 1024,
+) -> Image.Image:
+    """Soft-clamp both sides into ``[min_dimension, max_dimension]``.
+
+    Aspect ratio is preserved and an already-conforming image is returned
+    untouched. Mirrors ``falcon_perception.data.resize_image_if_necessary``,
+    which the reference paged engine applies before the image processor.
+    """
+    width, height = image.size
+    if min_dimension <= width <= max_dimension and min_dimension <= height <= max_dimension:
+        return image
+
+    aspect = width / height
+    is_vertical = width < height
+    if width < min_dimension or height < min_dimension:
+        target = min_dimension
+    else:
+        target = max_dimension
+
+    if is_vertical:
+        new_width = target
+        new_height = int(new_width / aspect)
+    else:
+        new_height = target
+        new_width = int(new_height * aspect)
+
+    if new_width > max_dimension:
+        new_width = max_dimension
+        new_height = int(new_width / aspect)
+    if new_height > max_dimension:
+        new_height = max_dimension
+        new_width = int(new_height * aspect)
+
+    return image.resize((new_width, new_height))
+
+
+def smart_resize_dims(
+    height: int,
+    width: int,
+    *,
+    factor: int,
+    min_pixels: int,
+    max_pixels: int,
+) -> tuple[int, int]:
+    """Round both sides to a multiple of ``factor`` inside the pixel budget.
+
+    Pure-arithmetic twin of ``falcon_perception.data.smart_resize`` so token
+    counts can be computed without materialising the resized image.
+    """
+    if height < factor or width < factor:
+        raise ValueError(f"height={height} and width={width} must both be >= {factor}")
+    if max(height, width) / min(height, width) > 200:
+        raise ValueError(
+            f"absolute aspect ratio must be smaller than 200, got {max(height, width) / min(height, width)}"
+        )
+
+    h_bar = round(height / factor) * factor
+    w_bar = round(width / factor) * factor
+    if h_bar * w_bar > max_pixels:
+        beta = math.sqrt((height * width) / max_pixels)
+        h_bar = math.floor(height / beta / factor) * factor
+        w_bar = math.floor(width / beta / factor) * factor
+    elif h_bar * w_bar < min_pixels:
+        beta = math.sqrt(min_pixels / (height * width))
+        h_bar = math.ceil(height * beta / factor) * factor
+        w_bar = math.ceil(width * beta / factor) * factor
+    return h_bar, w_bar
+
+
+class FalconPerceptionImageProcessor:
+    """Reference-equivalent image pipeline: resize -> smart_resize -> rescale -> normalize."""
+
+    def __init__(self, config: Any) -> None:
+        self.patch_size = config.spatial_patch_size
+        self.min_image_size = config.min_image_size
+        self.max_image_size = config.max_image_size
+        self.min_pixels = config.min_pixels
+        self.max_pixels = config.max_pixels
+
+    def target_grid(self, height: int, width: int) -> tuple[int, int]:
+        """Patch-grid ``(gh, gw)`` an image of this size will produce."""
+        image = Image.new("RGB", (width, height))
+        image = resize_image_if_necessary(image, self.min_image_size, self.max_image_size)
+        w0, h0 = image.size
+        h_bar, w_bar = smart_resize_dims(
+            h0,
+            w0,
+            factor=self.patch_size,
+            min_pixels=self.min_pixels,
+            max_pixels=self.max_pixels,
+        )
+        return h_bar // self.patch_size, w_bar // self.patch_size
+
+    def __call__(self, image: Image.Image) -> torch.Tensor:
+        """Return a channels-last ``(H, W, 3)`` float tensor."""
+        image = image.convert("RGB")
+        image = resize_image_if_necessary(image, self.min_image_size, self.max_image_size)
+        width, height = image.size
+        h_bar, w_bar = smart_resize_dims(
+            height,
+            width,
+            factor=self.patch_size,
+            min_pixels=self.min_pixels,
+            max_pixels=self.max_pixels,
+        )
+        image = image.resize((w_bar, h_bar), Image.Resampling.BICUBIC)
+
+        # Normalised in numpy, in place. Bit-identical to the torch expression
+        # this replaces -- same ops, same order, same float32 rounding, checked
+        # with torch.equal -- but ~3.5x faster (40 ms -> 11 ms on a 1024x681
+        # image): torch's CPU kernels do not vectorise the size-3 trailing
+        # broadcast, and each out-of-place step allocated another 8.4 MB.
+        # Worth the extra lines because this runs on the stage-0 -> stage-1
+        # handoff, which is serial CPU time with both stages' GPUs idle.
+        pixels = _as_float_array(image)
+        mean = np.array(IMAGE_MEAN, dtype=pixels.dtype)
+        std = np.array(IMAGE_STD, dtype=pixels.dtype)
+        np.divide(pixels, np.float32(255.0), out=pixels)
+        np.subtract(pixels, mean, out=pixels)
+        np.divide(pixels, std, out=pixels)
+        return torch.from_numpy(pixels)
+
+
+def _as_float_array(image: Image.Image) -> np.ndarray:
+    # ``np.array`` rather than ``np.asarray``: PIL hands back a read-only view,
+    # and the caller normalises in place.
+    return np.array(image, dtype=np.float32)
+
+
+class FalconPerceptionProcessingInfo(BaseProcessingInfo):
+    def get_hf_config(self):
+        from vllm_omni.model_executor.models.falcon_perception.configuration_falcon_perception import (
+            FalconPerceptionConfig,
+        )
+
+        return self.ctx.get_hf_config(FalconPerceptionConfig)
+
+    def get_supported_mm_limits(self) -> Mapping[str, int | None]:
+        # The reference prompt builder inserts a single image block; multi-image
+        # prompts are not part of any released Falcon Perception task.
+        return {"image": 1}
+
+    def get_image_processor(self) -> FalconPerceptionImageProcessor:
+        return FalconPerceptionImageProcessor(self.get_hf_config())
+
+    def get_image_grid(self, *, image_width: int, image_height: int) -> tuple[int, int]:
+        return self.get_image_processor().target_grid(image_height, image_width)
+
+    def get_num_image_tokens(self, *, image_width: int, image_height: int) -> int:
+        gh, gw = self.get_image_grid(image_width=image_width, image_height=image_height)
+        # 5 structural prefix tokens + patches + end_of_image
+        return 5 + gh * gw + 1
+
+
+class FalconPerceptionDummyInputsBuilder(BaseDummyInputsBuilder[FalconPerceptionProcessingInfo]):
+    def get_dummy_text(self, mm_counts: Mapping[str, int]) -> str:
+        return "<|image|>" * mm_counts.get("image", 0)
+
+    def get_dummy_mm_data(
+        self,
+        seq_len: int,
+        mm_counts: Mapping[str, int],
+        mm_options: Mapping[str, Any] | None = None,
+    ) -> MultiModalDataDict:
+        config = self.info.get_hf_config()
+        # Largest image the pixel budget allows, so profiling sees the worst case.
+        side = int(math.sqrt(config.max_pixels))
+        side = min(max(side, config.min_image_size), config.max_image_size)
+        num_images = mm_counts.get("image", 0)
+        return {"image": self._get_dummy_images(width=side, height=side, num_images=num_images)}
+
+
+class FalconPerceptionMultiModalProcessor(BaseMultiModalProcessor[FalconPerceptionProcessingInfo]):
+    def _call_hf_processor(
+        self,
+        prompt: str,
+        mm_data: Mapping[str, object],
+        mm_kwargs: Mapping[str, object],
+        tok_kwargs: Mapping[str, object],
+    ) -> MultiModalKwargsItems | dict[str, Any]:
+        tokenizer = self.info.get_tokenizer()
+        prompt_ids = tokenizer.encode(prompt, add_special_tokens=False)
+
+        images = mm_data.get("images") or []
+        if not isinstance(images, list):
+            images = [images]
+
+        processor = self.info.get_image_processor()
+        pixel_values: list[torch.Tensor] = []
+        grids: list[list[int]] = []
+        for image in images:
+            pixels = processor(image)
+            pixel_values.append(pixels)
+            grids.append([pixels.shape[0] // processor.patch_size, pixels.shape[1] // processor.patch_size])
+
+        out: dict[str, Any] = {"input_ids": [prompt_ids]}
+        if pixel_values:
+            # Kept as a list: images keep their native size, so this cannot be
+            # stacked into one dense tensor.
+            out["pixel_values"] = pixel_values
+            out["image_grid_hw"] = torch.tensor(grids, dtype=torch.long)
+        return out
+
+    def _hf_processor_applies_updates(
+        self,
+        prompt_text: str,
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, object],
+        tokenization_kwargs: Mapping[str, object],
+    ) -> bool:
+        # ``_call_hf_processor`` returns the raw prompt ids; vLLM inserts the
+        # image placeholder run for us via ``_get_prompt_updates``.
+        return False
+
+    def _get_mm_fields_config(
+        self,
+        hf_inputs: Any,
+        hf_processor_mm_kwargs: Mapping[str, object],
+    ) -> Mapping[str, MultiModalFieldConfig]:
+        return {
+            "pixel_values": MultiModalFieldConfig.batched("image"),
+            "image_grid_hw": MultiModalFieldConfig.batched("image"),
+        }
+
+    def _get_prompt_updates(
+        self,
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, object],
+        out_mm_kwargs: MultiModalKwargsItems,
+    ) -> Sequence[PromptUpdate]:
+        config = self.info.get_hf_config()
+        images = mm_items.get_items("image", ImageProcessorItems)
+
+        def get_replacement(item_idx: int) -> PromptUpdateDetails[list[int]]:
+            size = images.get_image_size(item_idx)
+            gh, gw = self.info.get_image_grid(image_width=size.width, image_height=size.height)
+            n_patches = gh * gw
+
+            tokens = [
+                *config.image_structural_token_ids,
+                *([config.img_id] * n_patches),
+                config.img_end_id,
+            ]
+
+            # ``is_embed`` marks the span that receives projected patch
+            # embeddings AND, via ``extract_embeds_range``, the span vLLM makes
+            # bidirectional for prefix-LM models. The reference mask covers
+            # image_cls through the last patch but excludes end_of_image, so the
+            # trailing False is load-bearing, not cosmetic.
+            def is_embed(tokenizer: object, full: object, *, _n: int = n_patches) -> torch.Tensor:
+                return torch.tensor([True] * (5 + _n) + [False])
+
+            return PromptUpdateDetails(full=tokens, is_embed=is_embed)
+
+        # The reference tokenizer splits the prompt on the literal "<|image|>"
+        # and splices the block in its place, so this is a replacement of that
+        # single token — not an insertion, which would leave the original
+        # placeholder behind as a 1201st patch token.
+        return [
+            PromptReplacement(
+                modality="image",
+                target=[config.img_id],
+                replacement=get_replacement,
+            )
+        ]
+
+
+__all__ = [
+    "FalconPerceptionDummyInputsBuilder",
+    "FalconPerceptionImageProcessor",
+    "FalconPerceptionMultiModalProcessor",
+    "FalconPerceptionProcessingInfo",
+    "resize_image_if_necessary",
+    "smart_resize_dims",
+]

--- a/vllm_omni/model_executor/models/falcon_perception/profiling.py
+++ b/vllm_omni/model_executor/models/falcon_perception/profiling.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""NVTX ranges for Falcon Perception, arranged so they cannot break a graph.
+
+``torch.cuda.nvtx.range_push`` is an untraceable CUDA call: if TorchDynamo sees
+one it graph-breaks, which is worse than having no annotation at all — a break
+inside AnyUp costs more than the range measures. So the placement rule here is
+absolute, not best-effort:
+
+    **Level 1 ranges only ever wrap call sites that live outside every
+    compiled region.**
+
+Concretely, the annotated sites are the runner-facing entry points
+(``preprocess`` / ``postprocess`` / ``embed_multimodal`` / ``make_omni_output``)
+and the stage-1 request body. Stage 1's only compiled callee is
+``itok_upsampler.forward``; wrapping the *call* to it is outside that boundary,
+so the compiled function is entered with no NVTX op in its trace.
+
+Nothing is annotated inside ``FalconPerceptionThinker.forward``. That is the
+entry point vLLM compiles when ``enforce_eager: false``, and a range there would
+be traced. Per-layer detail inside the backbone is already available for free
+from upstream's ``VLLM_NVTX_SCOPES_FOR_PROFILING=1``, which registers its hooks
+*after* the first Dynamo trace for exactly this reason
+(``vllm/v1/worker/gpu_model_runner.py``: ``_register_layerwise_nvtx_hooks``).
+
+Level 2 adds ranges *inside* AnyUp via forward hooks. Those are installed only
+when AnyUp is not compiled, and ``install_anyup_hooks`` refuses to install
+otherwise — a hook on a submodule of a compiled module either gets traced (a
+break) or is silently skipped, and neither is a measurement worth trusting.
+
+Environment
+-----------
+``FALCON_PERCEPTION_NVTX``
+    ``0`` (default) off — every helper here becomes a no-op with no CUDA call.
+    ``1`` coarse ranges at the safe call sites above.
+    ``2`` additionally per-submodule ranges inside AnyUp (requires compile off).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    import torch.nn as nn
+
+__all__ = ["fine_enabled", "install_anyup_hooks", "mark", "nvtx_enabled", "nvtx_range"]
+
+
+def _level() -> int:
+    try:
+        return int(os.environ.get("FALCON_PERCEPTION_NVTX", "0"))
+    except ValueError:
+        return 0
+
+
+def _anyup_compiled() -> bool:
+    return os.environ.get("FALCON_PERCEPTION_COMPILE_ANYUP", "0") not in ("", "0")
+
+
+# Resolved once at import. The toggles are read from the environment at process
+# start and never change mid-run, and re-reading os.environ inside a per-decode-
+# step helper would itself cost more than the range.
+_LEVEL = _level()
+_ENABLED = _LEVEL >= 1
+# Level 2 is dropped, not honoured-and-broken, when AnyUp is compiled.
+_FINE = _LEVEL >= 2 and not _anyup_compiled()
+
+
+class _NullRange:
+    """Zero-cost stand-in so call sites need no ``if`` around them."""
+
+    __slots__ = ()
+
+    def __enter__(self) -> _NullRange:
+        return self
+
+    def __exit__(self, *_exc: object) -> bool:
+        return False
+
+
+_NULL = _NullRange()
+
+
+def nvtx_enabled() -> bool:
+    return _ENABLED
+
+
+def fine_enabled() -> bool:
+    return _FINE
+
+
+if _ENABLED:
+
+    def nvtx_range(name: str):
+        """Context manager pushing an NVTX range. Never call inside a graph."""
+        return torch.cuda.nvtx.range(name)
+
+    def mark(name: str) -> None:
+        """Instantaneous NVTX marker — used for cache hit/miss, not timing."""
+        torch.cuda.nvtx.mark(name)
+
+else:
+
+    def nvtx_range(name: str) -> _NullRange:  # noqa: ARG001
+        return _NULL
+
+    def mark(name: str) -> None:  # noqa: ARG001
+        return
+
+
+def install_anyup_hooks(anyup: nn.Module, *, compiled: bool) -> int:
+    """Wrap AnyUp's submodules in NVTX ranges via forward hooks.
+
+    Returns the number of hooks installed (0 when level < 2 or when AnyUp is
+    compiled). Hooks — rather than inline ranges — because they can be attached
+    after the fact and removed without touching the module's own code, and
+    because that is the shape upstream vLLM already uses for layerwise scopes.
+
+    Refuses to install on a compiled module: the ranges would either be traced
+    into the graph (a break) or never fire, and a profile that silently measures
+    neither is worse than one that measures nothing.
+    """
+    if not _FINE or compiled:
+        return 0
+
+    names = (
+        "image_encoder",
+        "key_encoder",
+        "query_encoder",
+        "key_features_encoder",
+        "cross_decode",
+        "aggregation",
+    )
+
+    installed = 0
+    for name in names:
+        sub = getattr(anyup, name, None)
+        if sub is None or getattr(sub, "_fp_nvtx_hooked", False):
+            continue
+
+        def _pre(_mod: nn.Module, _args: tuple, _name: str = name) -> None:
+            torch.cuda.nvtx.range_push(f"fp/anyup/{_name}")
+
+        def _post(_mod: nn.Module, _args: tuple, _out: object) -> None:
+            torch.cuda.nvtx.range_pop()
+
+        sub.register_forward_pre_hook(_pre)
+        sub.register_forward_hook(_post)
+        sub._fp_nvtx_hooked = True
+        installed += 1
+
+    return installed

--- a/vllm_omni/model_executor/models/falcon_perception/rope.py
+++ b/vllm_omni/model_executor/models/falcon_perception/rope.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Falcon Perception split rotary embeddings.
+
+``head_dim`` is split in half:
+
+* the first half gets a standard 1-D RoPE indexed by the temporal position
+  ``pos_t`` (the whole image block shares a single temporal position);
+* the second half gets a learned 2-D "golden gate" rotation driven by a
+  continuous, aspect-normalised ``(h, w)`` grid. Text tokens sit at ``(0, 0)``,
+  which gives ``theta = 0`` and therefore an identity rotation, so the spatial
+  half is a no-op outside images and can be skipped entirely during decode.
+
+The frequencies for the spatial half are **learned per attention head** and
+loaded from the checkpoint buffer ``freqs_cis_golden`` of shape
+``(n_heads, head_dim // 4, 2)``. Because those rows differ across heads within
+a GQA group, K must be expanded to ``n_heads`` before the rotation is applied —
+see the note in ``falcon_perception_thinker.FalconPerceptionAttention``.
+
+Ported from the reference implementation's ``falcon_perception/rope.py``, with
+tensors in vLLM's flat ``(num_tokens, num_heads, head_dim)`` layout instead of
+``(batch, seq, heads, dim)``.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def precompute_freqs_cis(dim: int, end: int, theta: float = 10000.0) -> torch.Tensor:
+    """Precompute complex 1-D RoPE frequencies. Returns ``(end, dim // 2)``."""
+    freqs = 1.0 / (theta ** (torch.arange(0, dim, 2)[: (dim // 2)].float() / dim))
+    t = torch.arange(end, device=freqs.device)
+    freqs = torch.outer(t, freqs).float()
+    return torch.polar(torch.ones_like(freqs), freqs)
+
+
+def apply_rotary_emb_1d(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    freqs_cis: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Standard interleaved-pair RoPE over the temporal half.
+
+    ``xq``/``xk`` are ``(num_tokens, num_heads, head_dim // 2)`` and
+    ``freqs_cis`` is ``(num_tokens, head_dim // 4)`` complex.
+    """
+    # (N, f) -> (N, 1, f) so it broadcasts across heads.
+    freqs_cis = freqs_cis.unsqueeze(1)
+    cos, sin = freqs_cis.real, freqs_cis.imag
+
+    def rotate(x_in: torch.Tensor) -> torch.Tensor:
+        # Spell out complex multiplication in real arithmetic. This remains
+        # bit-exact with the reference operation, while avoiding an AOT-load
+        # failure in Inductor's symbolic handling of ``view_as_complex``.
+        x = x_in.float()
+        x_even, x_odd = x[..., 0::2], x[..., 1::2]
+        out = torch.empty_like(x)
+        out[..., 0::2] = x_even * cos - x_odd * sin
+        out[..., 1::2] = x_even * sin + x_odd * cos
+        return out.type_as(x_in)
+
+    return rotate(xq), rotate(xk)
+
+
+def apply_golden_freqs_cis_to_visual_pos(
+    golden_freqs: torch.Tensor,
+    pos_hw: torch.Tensor,
+) -> torch.Tensor:
+    """Build per-token, per-head complex 2-D frequencies.
+
+    ``golden_freqs`` is the learned ``(num_heads, head_dim // 4, 2)`` buffer and
+    ``pos_hw`` is ``(num_tokens, 2)`` holding ``(h, w)``. Text tokens are at
+    ``(0, 0)`` so they come back as ``1 + 0j`` (identity).
+
+    Returns ``(num_tokens, num_heads, head_dim // 4)`` complex.
+    """
+    theta = torch.einsum("np,hfp->nhf", pos_hw.float(), golden_freqs.float())
+    return torch.polar(torch.ones_like(theta), theta)
+
+
+def apply_golden_rotary_emb(x_in: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tensor:
+    """Apply the learned 2-D rotation to the spatial half.
+
+    Note this uses the **even/odd interleaved** convention (``x[..., 0::2]`` /
+    ``x[..., 1::2]``), not the split-half convention used elsewhere in vLLM.
+    """
+    x = x_in.float()
+    x_even = x[..., 0::2]
+    x_odd = x[..., 1::2]
+
+    cos = freqs_cis.real
+    sin = freqs_cis.imag
+
+    out = torch.empty_like(x)
+    out[..., 0::2] = x_even * cos - x_odd * sin
+    out[..., 1::2] = x_even * sin + x_odd * cos
+    return out.type_as(x_in)
+
+
+def apply_3d_rotary_emb(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    freqs_cis_2d: torch.Tensor | None,
+    spatial_enabled: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Temporal RoPE on the first half of ``head_dim``, golden 2-D on the second."""
+    xq_t, xq_hw = xq.chunk(chunks=2, dim=-1)
+    xk_t, xk_hw = xk.chunk(chunks=2, dim=-1)
+
+    xq_t, xk_t = apply_rotary_emb_1d(xq_t, xk_t, freqs_cis)
+    if freqs_cis_2d is not None:
+        xq_hw_rotated = apply_golden_rotary_emb(xq_hw, freqs_cis_2d)
+        xk_hw_rotated = apply_golden_rotary_emb(xk_hw, freqs_cis_2d)
+        if spatial_enabled is None:
+            xq_hw, xk_hw = xq_hw_rotated, xk_hw_rotated
+        else:
+            # A tensor gate keeps the compiled backbone's signature stable
+            # across prefill and decode. Selecting the original values when
+            # disabled also preserves the reference decode path bit-for-bit;
+            # rotating by an identity complex value still introduces a float
+            # round trip for bf16 inputs.
+            enabled = spatial_enabled.reshape(1, 1, 1)
+            xq_hw = torch.where(enabled, xq_hw_rotated, xq_hw)
+            xk_hw = torch.where(enabled, xk_hw_rotated, xk_hw)
+
+    xq_out = torch.cat([xq_t, xq_hw], dim=-1).type_as(xq)
+    xk_out = torch.cat([xk_t, xk_hw], dim=-1).type_as(xk)
+    return xq_out, xk_out
+
+
+def compute_image_spatial_positions(
+    grid_h: int,
+    grid_w: int,
+    *,
+    device: torch.device | None = None,
+    dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Continuous aspect-normalised ``(h, w)`` grid for one image.
+
+    Mirrors ``data._compute_image_spatial_positions``: the grid is normalised so
+    that the longer side spans a wider range, keeping the aspect ratio in the
+    rotation rather than in the token count.
+
+    Returns ``(grid_h * grid_w, 2)`` in row-major (h-major) patch order.
+    """
+    xlim = (grid_w / grid_h) ** 0.5
+    ylim = (grid_h / grid_w) ** 0.5
+    xpos = torch.linspace(-xlim, xlim, grid_w, device=device, dtype=dtype)
+    ypos = torch.linspace(-ylim, ylim, grid_h, device=device, dtype=dtype)
+    # meshgrid(..., indexing="ij") over (y, x) gives h-major row order, matching
+    # numpy's meshgrid(xpos, ypos, indexing="xy") in the reference.
+    hpos, wpos = torch.meshgrid(ypos, xpos, indexing="ij")
+    return torch.stack([hpos.flatten(), wpos.flatten()], dim=-1)
+
+
+# Rows 1 and 2 of the ``[3, N]`` M-RoPE positions buffer are unused by this
+# model (``mrope_section`` is ``[head_dim // 2, 0, 0]``), so they transport the
+# patch grid instead: each image token packs its grid dimension and its index
+# along that axis as ``dim * _GRID_STRIDE + index``. Any patch grid is bounded
+# by ``max_image_size // spatial_patch_size`` (64 for the released configs), so
+# this stride leaves three orders of magnitude of headroom.
+_GRID_STRIDE = 4096
+
+
+def pack_image_grid_positions(
+    grid_h: int,
+    grid_w: int,
+    *,
+    device: torch.device | None = None,
+) -> torch.Tensor:
+    """Pack one image's patch grid into two int64 columns.
+
+    Returns ``(grid_h * grid_w, 2)`` in the same h-major patch order as
+    :func:`compute_image_spatial_positions`; column 0 packs ``(grid_h, row)``
+    and column 1 packs ``(grid_w, col)``.
+
+    Repeating the grid *dimensions* on every token, rather than only the
+    indices, is what makes the unpacking exact when a forward pass sees only
+    part of an image — a prefix-cache hit resumes mid-span, and the runner
+    slices these rows by ``num_computed_tokens`` — or several images of
+    different sizes at once.
+    """
+    if not 0 < grid_h < _GRID_STRIDE or not 0 < grid_w < _GRID_STRIDE:
+        raise ValueError(f"Falcon Perception: patch grid {(grid_h, grid_w)} is outside 1..{_GRID_STRIDE - 1}")
+    rows = torch.arange(grid_h, device=device).repeat_interleave(grid_w)
+    cols = torch.arange(grid_w, device=device).repeat(grid_h)
+    return torch.stack([grid_h * _GRID_STRIDE + rows, grid_w * _GRID_STRIDE + cols], dim=-1)
+
+
+def unpack_image_grid_positions(packed: torch.Tensor) -> torch.Tensor:
+    """Inverse of :func:`pack_image_grid_positions`, giving continuous ``(h, w)``.
+
+    ``packed`` is ``(n, 2)`` int64. Rows are grouped by their ``(grid_h,
+    grid_w)`` and each group is rebuilt with the very same ``linspace`` call
+    :func:`compute_image_spatial_positions` makes, so the result is bit-exact
+    rather than merely close.
+    """
+    grid = torch.div(packed, _GRID_STRIDE, rounding_mode="floor")
+    index = packed - grid * _GRID_STRIDE
+    out = torch.zeros((packed.shape[0], 2), device=packed.device, dtype=torch.float32)
+    # One iteration per distinct image size in the batch, not per image.
+    for grid_h, grid_w in torch.unique(grid, dim=0).tolist():
+        rows = (grid[:, 0] == grid_h) & (grid[:, 1] == grid_w)
+        flat = index[rows, 0] * grid_w + index[rows, 1]
+        out[rows] = compute_image_spatial_positions(grid_h, grid_w, device=packed.device)[flat]
+    return out
+
+
+def compute_pos_hw(
+    input_ids: torch.Tensor,
+    positions: torch.Tensor,
+    *,
+    image_token_id: int,
+) -> torch.Tensor | None:
+    """Rebuild the continuous ``(h, w)`` grid from the M-RoPE positions buffer.
+
+    The grid is read back per token from rows 1/2 of ``positions`` (see
+    :func:`pack_image_grid_positions`) rather than from the multimodal kwargs.
+    That keeps it immune to the multimodal encoder cache, which serves the
+    stored *output* of ``embed_multimodal`` on a hit and so never runs the call
+    — nor its kwargs — for a repeated image.
+
+    Non-image tokens keep ``(0, 0)`` so their golden rotation is the identity.
+    Returns ``(num_tokens, 2)``, or ``None`` when there is nothing to rotate:
+    no image patch tokens in the batch (a pure decode step), or unpacked rows
+    (the profile run feeds a zeroed positions buffer).
+    """
+    if positions.dim() != 2 or positions.shape[0] < 3:
+        return None
+    image_positions = (input_ids == image_token_id).nonzero(as_tuple=True)[0]
+    if image_positions.numel() == 0:
+        return None
+
+    packed = torch.stack([positions[1][image_positions], positions[2][image_positions]], dim=-1)
+    # Every packed entry carries a grid dimension of at least 1, so anything
+    # below one stride means these rows were never filled in.
+    if bool((packed < _GRID_STRIDE).any()):
+        return None
+
+    pos_hw = torch.zeros((input_ids.shape[0], 2), device=input_ids.device, dtype=torch.float32)
+    pos_hw[image_positions] = unpack_image_grid_positions(packed)
+    return pos_hw

--- a/vllm_omni/model_executor/models/registry.py
+++ b/vllm_omni/model_executor/models/registry.py
@@ -468,6 +468,25 @@ _OMNI_MODELS = {
         "acoustic",
         "MiniMaxMusic3AcousticForConditionalGeneration",
     ),
+    ## Falcon Perception
+    # Alias: the HF repo ships this architecture name in config.json, so this
+    # entry is what lets a bare `tiiuae/Falcon-Perception` resolve for offline
+    # loading. Online serving is not supported -- see the model docs.
+    "FalconPerceptionForSegmentation": (
+        "falcon_perception",
+        "falcon_perception_thinker",
+        "FalconPerceptionThinker",
+    ),
+    "FalconPerceptionThinker": (
+        "falcon_perception",
+        "falcon_perception_thinker",
+        "FalconPerceptionThinker",
+    ),
+    "FalconPerceptionSegmentation": (
+        "falcon_perception",
+        "falcon_perception_segmentation",
+        "FalconPerceptionSegmentation",
+    ),
 }
 
 

--- a/vllm_omni/model_executor/stage_input_processors/falcon_perception.py
+++ b/vllm_omni/model_executor/stage_input_processors/falcon_perception.py
@@ -1,0 +1,475 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Falcon Perception stage transition: thinker (stage 0) -> segmentation (stage 1).
+
+Stage 0 runs with ``engine_output_type="latent"``, so its ``RequestOutput``
+carries the whole last-layer hidden-state trajectory
+(``multimodal_output["latent"]``, one row per prompt + generated token). The
+orchestrator-side hook below slices that tensor into the two things the mask
+head needs and hands them over in ``additional_information`` — no worker
+connector involved.
+
+From the trajectory we take:
+
+* **image patch features** — prompt rows sitting at ``<|image|>`` positions,
+  which fold back into the ``(h, w)`` patch grid;
+* **segmentation features** — for each generated ``<|seg|>`` token, the row
+  that *produced* it;
+* **boxes** — the per-row ``(xy, hw)`` the thinker emits, sampled at the
+  ``<|coord|>`` / ``<|size|>`` rows.
+
+Deliberately, no segmentation weights run here: ``proj_segm`` / ``conv_segm`` /
+``itok_upsampler`` all belong to stage 1, which applies them to these raw rows.
+That keeps the handoff a plain tensor ship and avoids inventing any new
+runner<->model protocol.
+
+Row indexing, which is easy to get subtly wrong
+-----------------------------------------------
+``hidden[i]`` is the state that *produced* the token at position ``i + 1``.
+The prompt occupies ``[0, len(prompt))`` and its last row produces
+``output_token_ids[0]``. So the row behind ``output_token_ids[i]`` is::
+
+    hidden[len(prompt) - 1 + i]
+
+This mirrors the reference, where ``get_segm_tokens(h_last, next_token)`` is
+called with the token that was just sampled *from* ``h_last``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections import OrderedDict
+from typing import Any
+
+import torch
+from vllm.logger import init_logger
+
+from vllm_omni.inputs.data import OmniTokensPrompt
+
+logger = init_logger(__name__)
+
+# Placeholder token for the stage-1 prompt. The segmentation stage is not
+# autoregressive and never embeds these ids; the scheduler only needs a slot.
+_PLACEHOLDER_TOKEN_ID = 0
+
+# Defaults match the published tiiuae/Falcon-Perception config, used only when
+# the caller cannot supply a config object.
+_DEFAULT_IMG_ID = 227
+_DEFAULT_SEG_ID = 262
+_DEFAULT_COORD_ID = 240
+_DEFAULT_SIZE_ID = 241
+
+
+def _ship(tensor: torch.Tensor) -> torch.Tensor:
+    """Make a tensor safe to serialise across the stage process boundary."""
+    return tensor.detach().to(device="cpu", dtype=torch.float32).contiguous()
+
+
+def _as_int_list(value: Any) -> list[int]:
+    if value is None:
+        return []
+    if isinstance(value, torch.Tensor):
+        return [int(x) for x in value.flatten().tolist()]
+    return [int(x) for x in value]
+
+
+def _first_not_none(*values: Any) -> Any:
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+def _payload_get(payload: Any, *keys: str) -> Any:
+    """Read a key from a payload that may be flat-dotted, nested, or a Mapping."""
+    for key in keys:
+        if payload is None:
+            return None
+        try:
+            value = payload.get(key)
+        except AttributeError:
+            return None
+        if value is not None:
+            return value
+    return None
+
+
+def _extract_latent(source_output: Any) -> torch.Tensor | None:
+    """The stage-0 hidden-state trajectory, ``(prompt + generated, hidden)``."""
+    outputs = getattr(source_output, "outputs", None) or []
+    for completion in outputs:
+        mm = getattr(completion, "multimodal_output", None)
+        if mm is None:
+            continue
+        latent = _payload_get(mm, "latent", "hidden", "hidden_states")
+        if isinstance(latent, torch.Tensor) and latent.numel() > 0:
+            return latent
+    return None
+
+
+def _extract_geometry(source_output: Any) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+    outputs = getattr(source_output, "outputs", None) or []
+    for completion in outputs:
+        mm = getattr(completion, "multimodal_output", None)
+        if mm is None:
+            continue
+        xy = _payload_get(mm, "hidden_states.box_xy", "geometry.xy")
+        hw = _payload_get(mm, "hidden_states.box_hw", "geometry.hw")
+        if xy is None or hw is None:
+            nested = _payload_get(mm, "hidden_states", "geometry")
+            if isinstance(nested, dict):
+                # Explicit None checks, not ``a or b``: truth-testing a tensor
+                # raises "Boolean value of Tensor with more than one value is
+                # ambiguous".
+                if xy is None:
+                    xy = _first_not_none(nested.get("box_xy"), nested.get("xy"))
+                if hw is None:
+                    hw = _first_not_none(nested.get("box_hw"), nested.get("hw"))
+        if isinstance(xy, torch.Tensor) and isinstance(hw, torch.Tensor):
+            return xy, hw
+    return None, None
+
+
+def _extract_selected_coords(source_output: Any) -> torch.Tensor | None:
+    """Coordinates accepted by the request-scoped decode feedback loop."""
+    outputs = getattr(source_output, "outputs", None) or []
+    for completion in outputs:
+        mm = getattr(completion, "multimodal_output", None)
+        if mm is None:
+            continue
+        selected = _payload_get(mm, "hidden_states.selected_box_xy")
+        if selected is None:
+            nested = _payload_get(mm, "hidden_states")
+            if isinstance(nested, dict):
+                selected = nested.get("selected_box_xy")
+        if isinstance(selected, torch.Tensor):
+            return selected.reshape(-1, 2)
+    return None
+
+
+def _token_ids(source_output: Any) -> tuple[list[int], list[int]]:
+    prompt_ids = _as_int_list(getattr(source_output, "prompt_token_ids", None))
+    output_ids: list[int] = []
+    outputs = getattr(source_output, "outputs", None) or []
+    if outputs:
+        completion = outputs[0]
+        output_ids = _as_int_list(
+            getattr(completion, "cumulative_token_ids", None) or getattr(completion, "token_ids", None)
+        )
+    return prompt_ids, output_ids
+
+
+def build_segmentation_payload(
+    hidden: torch.Tensor,
+    prompt_token_ids: list[int],
+    output_token_ids: list[int],
+    *,
+    xy: torch.Tensor | None = None,
+    hw: torch.Tensor | None = None,
+    selected_xy: torch.Tensor | None = None,
+    img_id: int = _DEFAULT_IMG_ID,
+    seg_id: int = _DEFAULT_SEG_ID,
+    coord_id: int = _DEFAULT_COORD_ID,
+    size_id: int = _DEFAULT_SIZE_ID,
+) -> dict[str, Any] | None:
+    """Slice the trajectory into the mask head's inputs. ``None`` if unusable."""
+    n_prompt = len(prompt_token_ids)
+    if hidden.ndim != 2 or n_prompt == 0 or hidden.shape[0] < n_prompt:
+        logger.warning(
+            "falcon_perception: unusable stage-0 trajectory (hidden=%s, prompt_len=%d)",
+            tuple(hidden.shape),
+            n_prompt,
+        )
+        return None
+
+    img_positions = [i for i, t in enumerate(prompt_token_ids) if t == img_id]
+    if not img_positions:
+        logger.warning("falcon_perception: no <|image|> tokens in the stage-0 prompt")
+        return None
+
+    def rows_for(token_id: int, limit: int) -> list[int]:
+        rows = [n_prompt - 1 + i for i, t in enumerate(output_token_ids) if t == token_id]
+        return [r for r in rows if 0 <= r < limit]
+
+    n_rows = hidden.shape[0]
+    image_features = hidden[torch.tensor(img_positions, device=hidden.device)]
+    seg_rows = rows_for(seg_id, n_rows)
+    seg_features = (
+        hidden[torch.tensor(seg_rows, device=hidden.device)] if seg_rows else hidden.new_zeros((0, hidden.shape[-1]))
+    )
+
+    # float32, not the model dtype: this payload is serialised to the stage-1
+    # engine process, and bfloat16 has no numpy equivalent
+    # ("Got unsupported ScalarType BFloat16"). Stage 1 casts back on arrival.
+    payload: dict[str, Any] = {
+        "hidden_states": {
+            "image_features": _ship(image_features),
+            "seg_features": _ship(seg_features),
+        },
+        "meta": {
+            "finished": torch.tensor(True, dtype=torch.bool),
+            "num_image_tokens": torch.tensor(len(img_positions), dtype=torch.long),
+            "num_seg_tokens": torch.tensor(len(seg_rows), dtype=torch.long),
+        },
+    }
+
+    # Boxes ride along so the client gets geometry and masks from one place.
+    if isinstance(xy, torch.Tensor) and isinstance(hw, torch.Tensor):
+        coord_rows = rows_for(coord_id, xy.shape[0])
+        size_rows = rows_for(size_id, hw.shape[0])
+        if coord_rows:
+            # Same reason as the pixels below: only the schema's sections
+            # survive transit, so the boxes ride inside ``hidden_states``.
+            if isinstance(selected_xy, torch.Tensor) and selected_xy.numel() > 0:
+                # Accepted coordinates are emitted one-per-<coord> token, in
+                # generation order. They are the exact values re-encoded into
+                # the next model step after duplicate rejection.
+                selected_xy = selected_xy.reshape(-1, 2)
+                payload["hidden_states"]["box_xy"] = _ship(selected_xy[: len(coord_rows)])
+            else:
+                payload["hidden_states"]["box_xy"] = _ship(xy[torch.tensor(coord_rows, device=xy.device)])
+            payload["hidden_states"]["box_hw"] = (
+                _ship(hw[torch.tensor(size_rows, device=hw.device)])
+                if size_rows
+                else torch.zeros((0, 2), dtype=torch.float32)
+            )
+
+    return payload
+
+
+def _original_hw(multi_modal_data: Any) -> torch.Tensor | None:
+    """Original (H, W) of the request's image, before any resizing.
+
+    The reference thresholds mask logits at the original image resolution
+    (``finalize_masks(original_image_size=...)``), not at the patch-aligned
+    processed size, so the mask head needs the true size to target.
+    """
+    if not isinstance(multi_modal_data, dict):
+        return None
+    size = getattr(_resolve_image(multi_modal_data), "size", None)
+    if not size:
+        return None
+    w, h = size
+    return torch.tensor([int(h), int(w)], dtype=torch.float32)
+
+
+def _resolve_image(multi_modal_data: Any) -> Any:
+    """The request's single image, or ``None``."""
+    image = None
+    if isinstance(multi_modal_data, dict):
+        image = multi_modal_data.get("image") or multi_modal_data.get("images")
+    if isinstance(image, (list, tuple)):
+        image = image[0] if image else None
+    return image
+
+
+# ------------------------------------------------------------- per-image memo
+#
+# The content hash and the processed pixels are both pure functions of the
+# request's image, and both sit on the stage-0 -> stage-1 critical path, which
+# is dead GPU time: the hook below runs synchronously on the orchestrator's
+# asyncio loop, after stage 0's last decode step and before stage 1 has
+# anything to do. Measured on a 1024x681 image, the hash costs ~4 ms and the
+# processor ~53 ms per call. A workload that asks several queries about one
+# image -- exactly the workload stage 1's AnyUp cache exists to serve -- paid
+# both on every request for a result it had already computed.
+#
+# Keyed on object identity, not content: hashing the image to find out whether
+# we already hashed it is circular. The entry holds a strong reference to the
+# image, so ``id()`` cannot be recycled onto a different object while the entry
+# is live. Two equal-but-distinct image objects therefore miss and recompute,
+# which is merely slow, never wrong. A caller that mutates an image in place
+# after submitting it would read a stale entry, but mutating a request's
+# payload mid-flight is not a supported pattern.
+_IMAGE_MEMO_MAX = 4
+
+
+class _ImageMemo:
+    """Lazily-filled cache of the two pure functions of one image."""
+
+    __slots__ = ("image", "key", "pixels")
+
+    def __init__(self, image: Any) -> None:
+        self.image = image  # strong ref: pins id(image) for this entry's life
+        self.key: torch.Tensor | None = None
+        self.pixels: torch.Tensor | None = None
+
+
+_IMAGE_MEMO: OrderedDict[tuple, _ImageMemo] = OrderedDict()
+
+
+def _memo_for(image: Any) -> _ImageMemo | None:
+    if image is None:
+        return None
+    ident = (id(image), getattr(image, "size", None), getattr(image, "mode", None))
+    entry = _IMAGE_MEMO.get(ident)
+    if entry is not None and entry.image is image:
+        _IMAGE_MEMO.move_to_end(ident)
+        return entry
+    entry = _ImageMemo(image)
+    _IMAGE_MEMO[ident] = entry
+    while len(_IMAGE_MEMO) > _IMAGE_MEMO_MAX:
+        _IMAGE_MEMO.popitem(last=False)
+    return entry
+
+
+def _image_key(multi_modal_data: Any) -> torch.Tensor | None:
+    """Stable content identity for the image, so stage 1 can reuse its AnyUp output.
+
+    AnyUp is by far the most expensive step of a request and depends only on
+    the image: the image block sits at position 0 of the prompt and attention is
+    causal (bidirectional only *within* the span), so image tokens never see the
+    query. Measured over different text queries on the same image, both the
+    thinker's image hidden states and the AnyUp output come back **bit-identical**,
+    so reusing them is exactly equivalent to recomputing them.
+
+    Hashing the source image (~2.5 MB of uint8) costs ~4 ms against the ~560 ms
+    it lets stage 1 skip. The processed float tensor would be 4x larger to hash
+    for no extra safety. Memoised per image, so repeat queries about the same
+    image pay it once.
+    """
+    image = _resolve_image(multi_modal_data)
+    if image is None or not hasattr(image, "tobytes"):
+        return None
+
+    memo = _memo_for(image)
+    if memo is not None and memo.key is not None:
+        return memo.key
+
+    # Narrow, and non-fatal on purpose: the only consequence of no key is that
+    # stage 1 recomputes AnyUp, which is correct, just slower.
+    try:
+        digest = hashlib.blake2b(digest_size=8)
+        digest.update(f"{getattr(image, 'mode', '?')}:{getattr(image, 'size', '?')}|".encode())
+        digest.update(image.tobytes())
+    except (OSError, ValueError, TypeError):
+        logger.warning("falcon_perception: could not hash the image; stage 1 will recompute AnyUp")
+        return None
+    # Positive int64: the payload crosses a process boundary as a tensor.
+    key = torch.tensor([int.from_bytes(digest.digest(), "big") >> 1], dtype=torch.long)
+    if memo is not None:
+        memo.key = key
+    return key
+
+
+def _processed_pixels(multi_modal_data: Any) -> torch.Tensor | None:
+    """Re-run the image pipeline to get the pixels AnyUp needs.
+
+    The generation runner has no multimodal plumbing — ``requires_multimodal_data``
+    forwards the request's data to *this* hook but never reaches the stage-1
+    model's forward kwargs. So the pixels travel in the payload instead.
+
+    Re-running the processor is a pure function of the image
+    (resize -> smart_resize -> rescale -> normalize), so it reproduces
+    stage 0's tensor exactly, including the patch grid the features align to.
+
+    It is not cheap, though: ~53 ms for a 1024x681 image, all of it on the
+    handoff's critical path with the GPU idle. Memoised per image so a run of
+    queries about one image pays it once; see the memo above for why identity
+    rather than content is the key.
+    """
+    image = _resolve_image(multi_modal_data)
+    if image is None:
+        logger.warning(
+            "falcon_perception: no image found for the mask head (multi_modal_data=%s); stage 1 will emit no masks",
+            sorted(multi_modal_data) if isinstance(multi_modal_data, dict) else type(multi_modal_data).__name__,
+        )
+        return None
+
+    memo = _memo_for(image)
+    if memo is not None and memo.pixels is not None:
+        return memo.pixels
+
+    from vllm_omni.model_executor.models.falcon_perception.configuration_falcon_perception import (
+        FalconPerceptionConfig,
+    )
+    from vllm_omni.model_executor.models.falcon_perception.processing_falcon_perception import (
+        FalconPerceptionImageProcessor,
+    )
+
+    # Deliberately not wrapped: AnyUp cannot run without these pixels, so a
+    # processing failure has no meaningful fallback. Swallowing it here would
+    # return a payload with no image and the mask head would report "nothing
+    # detected" for a broken request.
+    processor = FalconPerceptionImageProcessor(FalconPerceptionConfig())
+    pixels = _ship(processor(image))
+    if memo is not None:
+        # Shared with every later request for this image. ``_ship`` already
+        # detached it and the payload path only reads it, so handing out the
+        # same tensor is safe; stage 1 gets its own copy across the process
+        # boundary regardless.
+        memo.pixels = pixels
+    return pixels
+
+
+def thinker2segmentation_token_only(
+    source_outputs: list[Any],
+    prompt: Any = None,
+    _requires_multimodal_data: bool = False,
+) -> list[OmniTokensPrompt]:
+    """Build one stage-1 input per finished request.
+
+    Carries the sliced hidden states, the boxes and the processed pixels in
+    ``additional_information``; stage 1 reads everything from there.
+    """
+    multi_modal_data = None
+    if isinstance(prompt, dict):
+        multi_modal_data = prompt.get("multi_modal_data") or prompt.get("multi_modal_inputs")
+    elif prompt is not None:
+        multi_modal_data = getattr(prompt, "multi_modal_data", None)
+    if multi_modal_data is None:
+        logger.warning(
+            "falcon_perception: stage-1 hook got no multimodal data (prompt type=%s, keys=%s)",
+            type(prompt).__name__,
+            sorted(prompt) if isinstance(prompt, dict) else "n/a",
+        )
+    pixel_values = _processed_pixels(multi_modal_data)
+    original_hw = _original_hw(multi_modal_data)
+    image_key = _image_key(multi_modal_data)
+
+    inputs: list[OmniTokensPrompt] = []
+    for source_output in source_outputs:
+        if not getattr(source_output, "finished", False):
+            continue
+
+        latent = _extract_latent(source_output)
+        prompt_ids, output_ids = _token_ids(source_output)
+        payload: dict[str, Any] | None = None
+        if latent is None:
+            logger.warning(
+                "falcon_perception: stage-0 output carries no latent hidden states; "
+                "stage 1 will emit no masks. Is engine_output_type='latent' set on stage 0?"
+            )
+        else:
+            xy, hw = _extract_geometry(source_output)
+            selected_xy = _extract_selected_coords(source_output)
+            payload = build_segmentation_payload(
+                latent,
+                prompt_ids,
+                output_ids,
+                xy=xy,
+                hw=hw,
+                selected_xy=selected_xy,
+            )
+
+        if payload is not None and pixel_values is not None:
+            # Inside ``hidden_states`` on purpose: the stage payload only
+            # transports a fixed set of sections (see data_entry_keys.py —
+            # hidden_states / embed / codes / ids / meta). A custom top-level
+            # "image" section is silently dropped in transit.
+            payload["hidden_states"]["pixel_values"] = pixel_values
+        if payload is not None and original_hw is not None:
+            payload["hidden_states"]["original_hw"] = original_hw
+        if payload is not None and image_key is not None:
+            # ``meta`` rather than ``hidden_states``: this is an identifier, not
+            # a feature, and meta already carries non-float tensors safely.
+            payload["meta"]["image_key"] = image_key
+
+        inputs.append(
+            OmniTokensPrompt(
+                prompt_token_ids=[_PLACEHOLDER_TOKEN_ID],
+                multi_modal_data=multi_modal_data,
+                additional_information=payload or {},
+            )
+        )
+    return inputs


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Add vLLM-Omni support for Falcon Perception, which is a vision-language model for open-vocabulary instance segmentation
https://github.com/tiiuae/Falcon-Perception
https://huggingface.co/tiiuae/Falcon-Perception

This model follows a **2 stage pipeline**:
- **Stage0:** thinker stage (AR LLM): generates the `<coord>`, `<size>`, `<seg>` tokens autoregressively for each object instance. Object coordinates and sizes are decoded from the hidden states corresponding to the the sampled `<coord>`,` <size>` tokens. Their embeddings are then injected back into the next autoregressive decoding step.
- **Stage1:** segmentation stage : takes in the patch features, hidden states of <seg> tokens of each object instance as input. And as output, generates one segmentation mask per detected object instance

## Test Plan
**vLLM Version:** `0.26.0`

## Test Result
Examples of output segmentation masks overlayed on top of the original image.

- Query = birds
- Input image
<img width="1030" height="562" alt="image" src="https://github.com/user-attachments/assets/0ff0d3a9-66c2-4570-8be7-98ee33acd4f0" />

- Output segmentation mask overlayed on top of the original image
<img width="1282" height="688" alt="image" src="https://github.com/user-attachments/assets/0f84f4e8-d628-44b8-a548-16793d461af8" />

### L2 test : pass
```
python -m pytest -s -v \
  tests/e2e/offline_inference/test_falcon_perception.py \
  -m "core_model and cuda" \
  --run-level core_model
```
<img width="1518" height="54" alt="image" src="https://github.com/user-attachments/assets/1ee9b085-3b82-4492-b2ac-1e7e507fd193" />

### L3 test result: pass
```
VLLM_USE_FLASHINFER_SAMPLER=0 \
python -m pytest -s -v \
  tests/e2e/offline_inference/test_falcon_perception.py \
  -m "advanced_model and cuda" \
  --run-level advanced_model
```
<img width="1002" height="55" alt="image" src="https://github.com/user-attachments/assets/265821a3-4d54-4a64-8942-58bbe59f2f9c" />


## Out of scope
Support for Falcon perception detection-only model is not added here. That is left for a future PR

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
