### PR TITLE
[Dependency] Upgrade Cache-DiT to 1.5.0

### DIFF
--- a/.buildkite/cuda/test-nightly.yml
+++ b/.buildkite/cuda/test-nightly.yml
@@ -345,7 +345,7 @@ steps:
         commands:
           - export DIFFUSION_BENCHMARK_DIR=tests/dfx/perf/results
           - export DIFFUSION_ATTENTION_BACKEND=FLASH_ATTN
-          - export CACHE_DIT_VERSION=1.3.0
+          - export CACHE_DIT_VERSION=1.5.0
           - |
             set +e
             pytest -s -v tests/dfx/perf/scripts/run_diffusion_benchmark.py --test-config-file tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
@@ -361,7 +361,7 @@ steps:
         commands:
           - export DIFFUSION_BENCHMARK_DIR=tests/dfx/perf/results
           - export DIFFUSION_ATTENTION_BACKEND=FLASH_ATTN
-          - export CACHE_DIT_VERSION=1.3.0
+          - export CACHE_DIT_VERSION=1.5.0
           - |
             set +e
             pytest -s -v tests/dfx/perf/scripts/run_diffusion_benchmark.py --test-config-file tests/dfx/perf/tests/test_qwen_image_edit_vllm_omni.json
@@ -377,7 +377,7 @@ steps:
         commands:
           - export DIFFUSION_BENCHMARK_DIR=tests/dfx/perf/results
           - export DIFFUSION_ATTENTION_BACKEND=FLASH_ATTN
-          - export CACHE_DIT_VERSION=1.3.0
+          - export CACHE_DIT_VERSION=1.5.0
           - |
             set +e
             pytest -s -v tests/dfx/perf/scripts/run_diffusion_benchmark.py --test-config-file tests/dfx/perf/tests/test_qwen_image_edit_2511_vllm_omni.json
@@ -393,7 +393,7 @@ steps:
         commands:
           - export DIFFUSION_BENCHMARK_DIR=tests/dfx/perf/results
           - export DIFFUSION_ATTENTION_BACKEND=FLASH_ATTN
-          - export CACHE_DIT_VERSION=1.3.0
+          - export CACHE_DIT_VERSION=1.5.0
           - |
             set +e
             pytest -s -v tests/dfx/perf/scripts/run_diffusion_benchmark.py --test-config-file tests/dfx/perf/tests/test_qwen_image_layered_vllm_omni.json
@@ -409,7 +409,7 @@ steps:
         commands:
           - export DIFFUSION_BENCHMARK_DIR=tests/dfx/perf/results
           - export DIFFUSION_ATTENTION_BACKEND=FLASH_ATTN
-          - export CACHE_DIT_VERSION=1.3.0
+          - export CACHE_DIT_VERSION=1.5.0
           - |
             set +e
             pytest -s -v tests/dfx/perf/scripts/run_diffusion_benchmark.py --test-config-file tests/dfx/perf/tests/test_bagel_vllm_omni.json

--- a/.buildkite/npu/test-npu-nightly.yml
+++ b/.buildkite/npu/test-npu-nightly.yml
@@ -115,7 +115,7 @@ steps:
           DIFFUSION_ATTENTION_BACKEND: TORCH_SDPA
         commands:
           - export DIFFUSION_BENCHMARK_DIR=tests/dfx/perf/results
-          - export CACHE_DIT_VERSION=1.3.0
+          - export CACHE_DIT_VERSION=1.5.0
           - |
             set +e
             pytest -s -v tests/dfx/perf/scripts/run_diffusion_benchmark.py -m npu --test-config-file tests/dfx/perf/tests/test_qwen_image_edit_2511_vllm_omni.json

--- a/recipes/Tencent/HunyuanImage-3.0-Instruct.md
+++ b/recipes/Tencent/HunyuanImage-3.0-Instruct.md
@@ -82,7 +82,7 @@ example and the DiT sections below.
 - Optional environment variables:
 
 ```bash
-export CACHE_DIT_VERSION=1.3.0
+export CACHE_DIT_VERSION=1.5.0
 ```
 
 HunyuanImage-3.0 sets the diffusion attention backend to `TORCH_SDPA`

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -16,7 +16,7 @@ diffusers==0.38.0
 safetensors>=0.8.0
 accelerate==1.12.0
 soundfile>=0.13.1
-cache-dit==1.3.0
+cache-dit==1.5.0
 tqdm>=4.66.0
 torchsde>=0.2.6
 openai-whisper>=20250625


### PR DESCRIPTION
## Summary

- upgrade the pinned Cache-DiT dependency from 1.3.0 to 1.5.0
- align CUDA and NPU nightly benchmark version metadata with the runtime dependency
- update the HunyuanImage3 recipe's Cache-DiT version

## Why

Cache-DiT 1.5.0 is the latest stable release. This draft keeps vLLM-Omni's dependency and validation metadata aligned while hardware-specific validation finishes.

## Validation

- `57 passed` — focused Cache-DiT backend, model-specific, and request-runtime tests (post-rebase)
- `2709 passed, 21 skipped, 367 deselected` — CPU-marked diffusion suite
- `8 passed, 160 deselected` — ready CI CUDA cache shard (post-rebase)
- `1 passed` — full-model Qwen-Image online-serving smoke with Cache-DiT + layerwise offload; Cache-DiT initialized, refreshed its request context, and returned a 512x512 image
- `3 passed, 6 subtests passed` — previously run two-GPU Cache-DiT tiny-model matrix:
  - Flux2-Klein: Ulysses + Cache-DiT + layerwise offload
  - LTX2: HSDP + Cache-DiT
  - LTX2: Ulysses + Cache-DiT + layerwise offload
- `6 passed, 12 deselected` — all six Cache-DiT nodes from the CUDA nightly Qwen-Image, Image-Edit, and Image-Edit-2511 performance configs on 4×L20X; `60/60` requests completed
- applicable pre-commit hooks passed
- YAML parsing and `git diff --check` passed
- GitHub build (Python 3.11/3.12), pre-commit, DCO, docs, and Buildkite release checks passed

### Four-GPU Cache-DiT performance smoke (L20X)

| Model | Resolution / steps | Throughput (req/s) | Mean / P99 latency (s) | Peak memory (MiB) | Throughput vs stored H100 baseline |
|---|---:|---:|---:|---:|---:|
| Qwen-Image | 512² / 20 | 0.6282 | 1.5915 / 2.2195 | 55,266 | +12.39% |
| Qwen-Image | 1536² / 35 | 0.1832 | 5.4588 / 5.8449 | 64,842 | -4.49% |
| Qwen-Image-Edit | 512² / 20 | 0.2808 | 3.5613 / 4.2280 | 58,770 | -2.47% |
| Qwen-Image-Edit | 1536² / 35 | 0.1034 | 9.6751 / 10.3464 | 67,492 | -7.14% |
| Qwen-Image-Edit-2511 (2 input images) | 512² / 20 | 0.2831 | 3.5325 / 4.7625 | 57,748 | +1.97% |
| Qwen-Image-Edit-2511 (2 input images) | 1536² / 35 | 0.0987 | 10.1313 / 10.6281 | 67,762 | -6.09% |

These configs are routed to 4×H100 in CI. The L20X run validates the same test nodes and runtime paths, but its cross-SKU performance deltas are indicative only and do not replace H100 baseline revalidation. The harness emitted worker/resource-tracker messages during forced server teardown after each node had already passed; every pytest invocation exited 0 and no benchmark request failed.

## Remaining validation

- H100-specific performance/baseline revalidation in nightly CI
- the post-rebase nightly tiny-model matrix now collects a fourth case, FluxKontext TP + CPU offload + Cache-DiT; it still needs the four-GPU nightly shard
- NPU runtime coverage

## CI coverage notes

- Cache-DiT unit/adapter coverage is in the CPU diffusion job; the ready CUDA cache shard currently selects eight TeaCache tests, not Cache-DiT tests
- the CUDA nightly Qwen Image, Qwen Image Edit, and Qwen Image Edit 2511 benchmark configs contain six Cache-DiT benchmark nodes total
- the NPU Qwen Image Edit 2511 selector currently collects only its non-Cache-DiT case
- `CACHE_DIT_VERSION` is exported by nightly jobs but is not consumed by repository code; the dependency pin in `requirements/common.txt` controls the installed version
- benchmark baselines are recorded in result artifacts, but the test currently asserts request completion only

## Upstream note

The published distribution metadata reports Cache-DiT 1.5.0, while `cache_dit.__version__` currently reports `1.3.13.dev9`. vLLM-Omni does not consume that module-level value.
