### PR TITLE
[Bugfix][Higgs-Audio-V3] Disable XQA decode

### DIFF
--- a/tests/config/test_omni_config.py
+++ b/tests/config/test_omni_config.py
@@ -471,6 +471,7 @@ def test_sub_config_fields_match_structured_scopes():
         "trust_remote_code",
         "dtype",
         "attention_backend",
+        "attention_config",
         "moe_backend",
         "hf_overrides",
         "limit_mm_per_prompt",

--- a/tests/engine/test_stage_engine_args.py
+++ b/tests/engine/test_stage_engine_args.py
@@ -139,6 +139,7 @@ def _engine_arg_inputs(tmp_path: Path) -> tuple[PipelineConfig, DeployConfig, st
                 engine_extras={
                     "model": str(stage_model),
                     "attention_backend": "FLASHINFER",
+                    "attention_config": {"use_trtllm_attention": False},
                     "hf_overrides": {"rope_scaling": {"factor": 2}},
                     "limit_mm_per_prompt": {"audio": 1},
                     "logits_processors": ["test.custom.LogitsProcessor"],
@@ -229,6 +230,7 @@ def test_typed_llm_engine_args_preserve_legacy_adapter_behavior(tmp_path):
     assert thinker_args["omni_kv_config"] == {"need_send_cache": True}
     assert thinker_args["worker_cls"] == "test.custom.Worker"
     assert thinker_args["attention_backend"] == "FLASHINFER"
+    assert thinker_args["attention_config"] == {"use_trtllm_attention": False}
     assert thinker_args["trust_remote_code"] is True
     assert thinker_args["dtype"] == "float16"
     assert thinker_args["distributed_executor_backend"] == "mp"

--- a/tests/model_executor/models/higgs_audio_v3/test_higgs_audio_v3.py
+++ b/tests/model_executor/models/higgs_audio_v3/test_higgs_audio_v3.py
@@ -1326,7 +1326,9 @@ class TestRegistry:
 
         assert "higgs_multimodal_qwen3" in OMNI_PIPELINES
 
-    def test_deploy_yaml_exists(self):
+    def test_deploy_yaml_uses_native_flashinfer(self):
+        from vllm_omni.config.stage_config import load_deploy_config
+
         for name in (
             "higgs_multimodal_qwen3.yaml",
             "higgs_multimodal_qwen3_high_throughput.yaml",
@@ -1334,6 +1336,10 @@ class TestRegistry:
         ):
             yaml_path = get_deploy_config_path(name)
             assert os.path.isfile(yaml_path), f"Deploy YAML not found at {yaml_path}"
+            deploy_config = load_deploy_config(yaml_path)
+            stage_0 = next(stage for stage in deploy_config.stages if stage.stage_id == 0)
+            assert stage_0.engine_extras["attention_backend"] == "FLASHINFER"
+            assert stage_0.engine_extras["attention_config"] == {"use_trtllm_attention": False}
 
 
 # ---- AC-3: Prompt Builder ----

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -91,6 +91,7 @@ class _ModelEngineOverrides(TypedDict, total=False):
     trust_remote_code: bool
     dtype: Any
     attention_backend: Any
+    attention_config: Any
     moe_backend: str
     hf_overrides: Any
     limit_mm_per_prompt: dict[str, Any]
@@ -321,6 +322,7 @@ class OmniStageModelConfig:
     trust_remote_code: bool = False
     dtype: Any = "auto"
     attention_backend: Any = None
+    attention_config: Any = None
     moe_backend: str = "auto"
     hf_overrides: Any = None
     limit_mm_per_prompt: dict[str, Any] | None = None

--- a/vllm_omni/deploy/README_higgs_audio_v3.md
+++ b/vllm_omni/deploy/README_higgs_audio_v3.md
@@ -44,6 +44,65 @@ vllm-omni serve bosonai/higgs-audio-v3-tts-4b \
     --deploy-config vllm_omni/deploy/higgs_multimodal_qwen3_low_latency.yaml
 ```
 
+## Why Stage 0 Pins Native FlashInfer
+
+The three Stage 0 profiles set `attention_backend: FLASHINFER` and also set:
+
+```yaml
+attention_config:
+  use_trtllm_attention: false
+```
+
+`FLASHINFER` names the overall vLLM attention backend. Starting with vLLM
+0.25, that backend can internally route Hopper decode to the TRT-LLM XQA
+kernel. The XQA eligibility check answers whether the kernel can run, not
+whether it is the fastest kernel for the current workload. In particular, the
+decode builder can select XQA statically when all of the following hold:
+
+- the explicit `use_trtllm_attention` override is not `false`;
+- the device is Hopper/SM90 and the XQA cubin is available; and
+- the query-head count is divisible by the KV-head count.
+
+Higgs has 32 query heads and 8 KV heads, so it passes the head-layout check.
+The static gate does not include a model dtype, KV-cache dtype, context-length,
+batch-shape, or measured-performance comparison. This matters because kernel
+support is not a performance guarantee.
+
+Higgs also has an unusual output shape that must not be confused with its
+attention shape. One autoregressive audio step advances one token per request.
+The resulting hidden row is then projected into eight codebook distributions
+with shape `[1, 8, codebook_size]`. The eight codebooks therefore do not turn
+the attention query into `q_len=8`; at concurrency one, XQA still receives a
+single BF16 query row. At this small per-step shape, any XQA advantage for
+other KV dtypes, batch sizes, or context lengths does not necessarily apply.
+The difference is paid in every transformer layer and every generated audio
+step, so even a small per-call disadvantage accumulates in TTFP and RTF.
+
+The upstream XQA integration also showed that the result is dtype-sensitive:
+its FP8 benchmark favored XQA, while its BF16 benchmark reported 21.16 ms mean
+TPOT for XQA versus 19.47 ms for FA3. That is not a direct native-FlashInfer
+comparison, but it demonstrates why SM90 compatibility alone is insufficient
+to choose the fastest BF16 kernel. See the
+[vLLM XQA benchmark](https://github.com/vllm-project/vllm/pull/43232#issuecomment-4501176335).
+
+The end-to-end H800 A/B in
+[issue #5584](https://github.com/vllm-project/vllm-omni/issues/5584#issuecomment-5188700218)
+isolated the routing decision on the same vLLM 0.25 stack:
+
+| Decode path | TTFP (ms) | RTF |
+|---|---:|---:|
+| XQA (automatic default) | 175.76 | 0.3405 |
+| Native FlashInfer (`use_trtllm_attention: false`) | 166.39 | 0.3233 |
+| vLLM 0.24 reference | 166.68 | 0.3209 |
+
+This proves that XQA selection causes the observed local regression and that
+native FlashInfer recovers the pre-v0.25 range. It does not by itself identify
+one defective XQA instruction or memory transaction. Establishing that deeper
+kernel-level cause requires an attention-only microbenchmark and GPU profiler
+trace for the exact Higgs batch/context distribution. Until vLLM has a
+workload-aware selector or XQA is faster for this BF16 shape, the model-level
+pin is the deterministic choice.
+
 ## Notes
 
 - Stage 1 remains `enforce_eager: true` in both profiles.

--- a/vllm_omni/deploy/higgs_multimodal_qwen3.yaml
+++ b/vllm_omni/deploy/higgs_multimodal_qwen3.yaml
@@ -38,8 +38,9 @@ stages:
     gpu_memory_utilization: 0.6
     enforce_eager: true
     attention_backend: FLASHINFER
-    # Native FlashInfer is faster for Higgs' BF16, q_len=1 decode workload.
-    # Avoid vLLM 0.25+ auto-selecting TRT-LLM XQA on Hopper (see #5584).
+    # Eight codebooks share one attention row, so decode remains BF16 q_len=1
+    # per request. vLLM's SM90 XQA capability gate does not benchmark this
+    # shape; keep the faster native path (README_higgs_audio_v3.md, #5584).
     attention_config:
       use_trtllm_attention: false
     trust_remote_code: true

--- a/vllm_omni/deploy/higgs_multimodal_qwen3.yaml
+++ b/vllm_omni/deploy/higgs_multimodal_qwen3.yaml
@@ -38,6 +38,10 @@ stages:
     gpu_memory_utilization: 0.6
     enforce_eager: true
     attention_backend: FLASHINFER
+    # Native FlashInfer is faster for Higgs' BF16, q_len=1 decode workload.
+    # Avoid vLLM 0.25+ auto-selecting TRT-LLM XQA on Hopper (see #5584).
+    attention_config:
+      use_trtllm_attention: false
     trust_remote_code: true
     # Stage-0 prefix caching is on by default. The talker's HS opt-out and
     # deferred ``codes.audio`` mm-output write (see higgs_audio_v3_talker.py)

--- a/vllm_omni/deploy/higgs_multimodal_qwen3_high_throughput.yaml
+++ b/vllm_omni/deploy/higgs_multimodal_qwen3_high_throughput.yaml
@@ -37,6 +37,10 @@ stages:
     gpu_memory_utilization: 0.6
     enforce_eager: true
     attention_backend: FLASHINFER
+    # Native FlashInfer is faster for Higgs' BF16, q_len=1 decode workload.
+    # Avoid vLLM 0.25+ auto-selecting TRT-LLM XQA on Hopper (see #5584).
+    attention_config:
+      use_trtllm_attention: false
     trust_remote_code: true
     # Stage-0 prefix caching is on by default. The talker's HS opt-out and
     # deferred ``codes.audio`` mm-output write (see higgs_audio_v3_talker.py)

--- a/vllm_omni/deploy/higgs_multimodal_qwen3_high_throughput.yaml
+++ b/vllm_omni/deploy/higgs_multimodal_qwen3_high_throughput.yaml
@@ -37,8 +37,9 @@ stages:
     gpu_memory_utilization: 0.6
     enforce_eager: true
     attention_backend: FLASHINFER
-    # Native FlashInfer is faster for Higgs' BF16, q_len=1 decode workload.
-    # Avoid vLLM 0.25+ auto-selecting TRT-LLM XQA on Hopper (see #5584).
+    # Eight codebooks share one attention row, so decode remains BF16 q_len=1
+    # per request. vLLM's SM90 XQA capability gate does not benchmark this
+    # shape; keep the faster native path (README_higgs_audio_v3.md, #5584).
     attention_config:
       use_trtllm_attention: false
     trust_remote_code: true

--- a/vllm_omni/deploy/higgs_multimodal_qwen3_low_latency.yaml
+++ b/vllm_omni/deploy/higgs_multimodal_qwen3_low_latency.yaml
@@ -43,8 +43,9 @@ stages:
     gpu_memory_utilization: 0.6
     enforce_eager: false
     attention_backend: FLASHINFER
-    # Native FlashInfer is faster for Higgs' BF16, q_len=1 decode workload.
-    # Avoid vLLM 0.25+ auto-selecting TRT-LLM XQA on Hopper (see #5584).
+    # Eight codebooks share one attention row, so decode remains BF16 q_len=1
+    # per request. vLLM's SM90 XQA capability gate does not benchmark this
+    # shape; keep the faster native path (README_higgs_audio_v3.md, #5584).
     attention_config:
       use_trtllm_attention: false
     trust_remote_code: true

--- a/vllm_omni/deploy/higgs_multimodal_qwen3_low_latency.yaml
+++ b/vllm_omni/deploy/higgs_multimodal_qwen3_low_latency.yaml
@@ -43,6 +43,10 @@ stages:
     gpu_memory_utilization: 0.6
     enforce_eager: false
     attention_backend: FLASHINFER
+    # Native FlashInfer is faster for Higgs' BF16, q_len=1 decode workload.
+    # Avoid vLLM 0.25+ auto-selecting TRT-LLM XQA on Hopper (see #5584).
+    attention_config:
+      use_trtllm_attention: false
     trust_remote_code: true
     enable_prefix_caching: true
     async_scheduling: false


### PR DESCRIPTION
## Purpose

### What broke

Higgs Audio V3 Stage 0 explicitly selects `FLASHINFER`, but `FLASHINFER` is the overall vLLM backend rather than a guarantee that its native decode kernel will run. Starting with vLLM 0.25, the backend can route Hopper decode to TRT-LLM XQA when `attention_config.use_trtllm_attention` is unset. For the Higgs BF16 workload, that route regresses TTFP and RTF on H800. The H100 nightly regression is tracked in #5584.

### Reproduction

Run the existing Higgs performance test on Hopper:

```bash
export VLLM_USE_DEEP_GEMM=0 VLLM_MOE_USE_DEEP_GEMM=0
pytest -s -v tests/dfx/perf/scripts/run_benchmark.py \
  --test-config-file tests/dfx/perf/tests/test_higgs_audio_v3.json
```

With the current Stage 0 config, vLLM 0.25+ logs `decode_backend=xqa`. Adding `attention_config.use_trtllm_attention: false` changes it to `decode_backend=flashinfer-native` and restores the pre-v0.25 latency range.

### Why XQA is selected

The selection chain is:

```text
attention_backend: FLASHINFER
  -> use_trtllm_attention is unset (None)
  -> Hopper/SM90 has an available XQA cubin
  -> Higgs query/KV heads are divisible (32 / 8)
  -> FlashInfer decode builder statically selects backend=xqa
```

The important distinction is capability versus performance. `can_use_trtllm_attention()` checks whether TRT-LLM attention is disabled, supported on the platform, and compatible with the head layout. Higgs passes those correctness checks. The decode builder then resolves the kernel statically so CUDA graph capture does not switch backends at runtime.

That static decision does **not** compare model dtype, KV-cache dtype, context length, batch shape, or measured kernel time. In other words, `32 % 8 == 0` proves that XQA can execute; it does not prove that XQA is the fastest kernel for Higgs.

### Why this shape regresses

Higgs' eight audio codebooks are easy to misread as eight attention queries. They are not. One autoregressive audio step produces one hidden row per request, and the fused modality head projects that row into logits with shape `[1, 8, codebook_size]`. The codebook dimension is created **after** attention, so at concurrency one the attention kernel still sees one BF16 query row (`q_len=1`), not `q_len=8`.

This makes the relevant workload a repeated small BF16 decode shape. XQA's benefit is shape- and dtype-dependent: the upstream XQA integration reported a clear FP8 gain, but its BF16 benchmark had 21.16 ms mean TPOT for XQA versus 19.47 ms for FA3 ([upstream data](https://github.com/vllm-project/vllm/pull/43232#issuecomment-4501176335)). That comparison uses FA3 rather than native FlashInfer, so it is not the direct evidence for this fix; it does show why an SM90 capability gate is insufficient as a BF16 performance policy.

The direct evidence is the same-stack H800 A/B below: changing only `use_trtllm_attention` moves Higgs from XQA to native FlashInfer and recovers essentially the entire v0.25 regression. Since attention runs in every transformer layer and every generated audio step, the per-call disadvantage accumulates into visible TTFP and RTF loss.

What is proven here is the routing-level root cause: automatic XQA selection is slower for this end-to-end Higgs workload. The current data does not isolate one defective XQA instruction, launch, or memory transaction. Pinning that deeper mechanism down requires an attention-only benchmark and GPU profiler trace across the exact Higgs batch/context distribution; the local deployment note states this boundary explicitly.

### Fix

- Pin `attention_config.use_trtllm_attention: false` for Stage 0 in the default, high-throughput, and low-latency Higgs deploy profiles.
- Register vLLM 0.27 `attention_config` in the structured per-stage model scope so typed config projection preserves the pin instead of rejecting it as unowned.
- Extend the deploy-config unit test to require both `FLASHINFER` and the native FlashInfer pin in all three profiles.
- Document the selector mismatch, the actual one-row attention shape, the benchmark evidence, and the remaining kernel-level uncertainty in `vllm_omni/deploy/README_higgs_audio_v3.md`.

The change only disables the optional XQA sub-backend for these Higgs profiles; it keeps the existing FlashInfer backend and does not change Stage 1 or other models. A possible tradeoff is that a future XQA version could outperform native FlashInfer for some high-concurrency BF16 shapes while this model-level pin remains conservative. H100 c1/c16 A/B validation and a future workload-aware upstream selector are therefore follow-up items.

Related to #5584.

## Test Plan

**vLLM Version:** v0.25.0 for the H800 A/B; v0.27.0 on the current vLLM-Omni base

**vLLM-Omni Commit:** 5d2ecf15

- [x] `ruff check tests/model_executor/models/higgs_audio_v3/test_higgs_audio_v3.py`
- [x] `ruff format --check tests/model_executor/models/higgs_audio_v3/test_higgs_audio_v3.py`
- [x] Parse all three deploy YAMLs and verify Stage 0 selects native FlashInfer
- [x] Diff-scoped `precheck-pr` quick review (DCO, title, code quality, scope, and regression test)
- [ ] `pytest -q tests/model_executor/models/higgs_audio_v3/test_higgs_audio_v3.py::TestRegistry::test_deploy_yaml_uses_native_flashinfer` (local environment has no vLLM/Torch test dependencies)
- [x] Main CUDA Buildkite #13512: Engine&Entrypoints (`1849 passed`) and Other (`2204 passed`)
- [x] `TTS · Higgs-Audio-V3 Test`: `9 passed, 1 skipped`; Stage 0 logged `decode_backend=flashinfer-native`
- [x] H100 nightly c1/c16 benchmark: `2 passed`; c16 mean TTFP `291.03 ms`, mean RTF `0.55`

## Test Result

H800, `seed-tts-text`, c1/p20, same vLLM 0.25 stack unless noted ([full investigation](https://github.com/vllm-project/vllm-omni/issues/5584#issuecomment-5188700218)):

| Mode | Decode backend | TTFP (ms) | RTF |
|---|---|---:|---:|
| vLLM 0.25 default | XQA | 175.76 | 0.3405 |
| vLLM 0.25 with this pin | FlashInfer native | 166.39 | 0.3233 |
| vLLM 0.24 reference | FlashInfer native | 166.68 | 0.3209 |