### PR TITLE
[CI][MiniCPM-o] Add MiniCPM-o 4.5 perf coverage to the ready gate

### DIFF
--- a/.buildkite/cuda/test-ready.yml
+++ b/.buildkite/cuda/test-ready.yml
@@ -227,6 +227,18 @@ steps:
             "
         mirror_hardwares: h100_1
 
+      - label: "Omni · MiniCPM-o 4.5 Perf Test"
+        timeout_in_minutes: 60
+        source_file_dependencies:
+          - tests/dfx/perf/tests/test_minicpmo_4_5_ready.json
+          - vllm_omni/deploy/minicpmo_4_5.yaml
+          - vllm_omni/model_executor/models/minicpmo_4_5/
+          - vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
+        commands:
+          - export BENCHMARK_DIR=tests/dfx/perf/results
+          - pytest -s -v tests/dfx/perf/scripts/run_benchmark.py --test-config-file tests/dfx/perf/tests/test_minicpmo_4_5_ready.json -m 'core_model and cuda'
+        mirror_hardwares: h100_1
+
       - label: "TTS · VoxCPM2 Test"
         source_file_dependencies:
           - tests/e2e/online_serving/test_voxcpm2_tts.py

--- a/.buildkite/npu/test-npu-ready.yml
+++ b/.buildkite/npu/test-npu-ready.yml
@@ -17,6 +17,15 @@ steps:
           VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
         commands:
           - pytest -s -v tests/e2e/online_serving/test_minicpmo_4_5_duplex.py -m 'core_model and npu and A3 and omni' --run-level 'core_model'
+      - label: "Omni · MiniCPM-o 4.5 Perf Test"
+        timeout_in_minutes: 60
+        mirror_hardwares: a3_npu_2
+        env:
+          VLLM_WORKER_MULTIPROC_METHOD: spawn
+          VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
+        commands:
+          - export BENCHMARK_DIR=tests/dfx/perf/results
+          - pytest -s -v tests/dfx/perf/scripts/run_benchmark.py --test-config-file tests/dfx/perf/tests/test_minicpmo_4_5_ready.json -m 'core_model and npu and A3 and omni'
 
   - group: ":card_index_dividers: TTS Model Test"
     key: ready-tts-group

--- a/tests/dfx/perf/tests/test_minicpmo_4_5_ready.json
+++ b/tests/dfx/perf/tests/test_minicpmo_4_5_ready.json
@@ -1,0 +1,80 @@
+[
+  {
+    "test_name": "test_minicpmo_4_5_ready",
+    "mark": [
+      {
+        "hardware_marks": {
+          "res": {
+            "cuda": "H100",
+            "npu": "A3"
+          },
+          "num_cards": 1
+        }
+      },
+      "core_model",
+      "omni"
+    ],
+    "server_params": {
+      "model": "openbmb/MiniCPM-o-4_5",
+      "extra_cli_args": [
+        "--deploy-config",
+        "vllm_omni/deploy/minicpmo_4_5.yaml",
+        "--trust-remote-code"
+      ]
+    },
+    "benchmark_params": [
+      {
+        "dataset_name": "seed-tts",
+        "dataset_path": "zhaochenyang20/seed-tts-eval",
+        "backend": "openai-chat-omni",
+        "endpoint": "/v1/chat/completions",
+        "num_prompts": [
+          10,
+          40
+        ],
+        "max_concurrency": [
+          1,
+          4
+        ],
+        "no_oversample": true,
+        "trust_remote_code": true,
+        "seed_tts_locale": "en",
+        "extra_body": {
+          "modalities": [
+            "text",
+            "audio"
+          ],
+          "chat_template_kwargs": {
+            "enable_thinking": false,
+            "use_tts_template": true
+          }
+        },
+        "percentile-metrics": "ttft,e2el,audio_ttfp,audio_rtf,audio_duration",
+        "baseline": {
+          "H100": {
+            "request_throughput": [
+              0.7803,
+              1.1008
+            ],
+            "mean_ttft_ms": [
+              166.9764,
+              307.7133
+            ],
+            "mean_e2el_ms": [
+              1361.1682,
+              3800.6332
+            ],
+            "mean_audio_ttfp_ms": [
+              635.8099,
+              1615.6591
+            ],
+            "mean_audio_rtf": [
+              0.3151,
+              0.8568
+            ]
+          }
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Purpose

MiniCPM-o 4.5 performance is currently only measured nightly, so a per-PR
performance regression is not visible until the next nightly run. This adds a
trimmed-down version of the nightly perf case to the ready gate on both CUDA and
NPU.

The new `tests/dfx/perf/tests/test_minicpmo_4_5_ready.json` mirrors the nightly
`test_minicpmo_4_5.json` (same deploy config, same seed-tts dataset, same request
body and percentile metrics) with two differences:

- Marked `core_model` instead of `full_model` so it runs in the ready gate.
- Concurrency sweep narrowed from `[1, 4, 8]` to `[1, 4]`, with `num_prompts`
  `[10, 40]`, to keep the step within the ready-gate time budget.

CI wiring:

- `.buildkite/cuda/test-ready.yml`: new `Omni · MiniCPM-o 4.5 Perf Test` step on
  `h100_1`, gated by `source_file_dependencies` on the perf config, the runner,
  and the MiniCPM-o deploy/model sources.
- `.buildkite/npu/test-npu-ready.yml`: matching step on `a3_npu_2`, using the
  same env and mark convention as the other MiniCPM-o steps in that group.

Both steps run the benchmark directly without `--assert-baseline`, so they gate
on request failures (`assert_result`) rather than on baseline deltas — same as
the existing nightly perf jobs.

## Test Plan

**vLLM Version:** 0.26.0
**vLLM-Omni Commit:** (fill after push)

- Config/pipeline validation:
  - `python -c "import json,yaml; json.load(open('tests/dfx/perf/tests/test_minicpmo_4_5_ready.json'))"`
  - YAML parse of both modified pipeline files
  - `pytest tests/dfx/perf/scripts/run_benchmark.py --test-config-file tests/dfx/perf/tests/test_minicpmo_4_5_ready.json -m 'core_model and cuda' --collect-only`
  - `pytest tests/dfx/perf/scripts/run_benchmark.py --test-config-file tests/dfx/perf/tests/test_minicpmo_4_5_ready.json -m 'core_model and npu and A3 and omni' --collect-only`
- [ ] Full run on H100 (1x)
- [ ] Full run on A3 (1x)

## Test Result

- JSON and both pipeline YAMLs parse cleanly.
- Mark selection resolves to exactly 1 case under both the CUDA and the NPU
  mark expression.
- (fill in wall-clock time and measured metrics from the first H100 / A3 runs)
