### PR TITLE
[Perf] release unused Code2Wav stream caches

### DIFF
--- a/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
@@ -50,6 +50,8 @@ class _FakeEstimator(nn.Module):
         self.blocks = [_FakeBlock()]
         self.cfg_batches: list[int] = []
         self.speaker_order: list[list[float]] = []
+        self.register_buffer("att_cache_buffer", torch.ones(1), persistent=False)
+        self.register_buffer("cnn_cache_buffer", torch.ones(1), persistent=False)
 
     def t_embedder(self, time):
         return time[:, None]
@@ -79,6 +81,8 @@ class _FakeDecoder(nn.Module):
         self.estimator = _FakeEstimator()
         self.inference_cfg_rate = 0.7
         self.register_buffer("rand_noise", torch.zeros(1, 1, 100), persistent=False)
+        self.register_buffer("att_cache_buffer", torch.ones(1), persistent=False)
+        self.register_buffer("cnn_cache_buffer", torch.ones(1), persistent=False)
 
 
 class _FakeFlow(nn.Module):
@@ -156,6 +160,24 @@ def _model():
     model = MiniCPMO45Code2Wav(vllm_config=_config())
     model.backend = backend
     return model, token2wav
+
+
+def test_adapter_releases_unused_upstream_streaming_buffers():
+    token2wav = _FakeToken2Wav()
+    decoder = token2wav.flow.decoder
+    modules = (decoder, decoder.estimator)
+
+    assert all(
+        getattr(module, name) is not None for module in modules for name in ("att_cache_buffer", "cnn_cache_buffer")
+    )
+
+    BatchedToken2Wav(token2wav)
+
+    assert all(
+        name in module._buffers and getattr(module, name) is None
+        for module in modules
+        for name in ("att_cache_buffer", "cnn_cache_buffer")
+    )
 
 
 def test_code2wav_resolves_hf_model_id_for_assets(mocker, tmp_path):

--- a/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
@@ -65,6 +65,14 @@ class BatchedToken2Wav(nn.Module):
         self._token2wav = token2wav
         self.flow = token2wav.flow
         self.hift = token2wav.hift
+        # The upstream streaming path preallocates fixed-size CFM and DiT
+        # caches. This adapter never calls that path and supplies dynamically
+        # sized request-owned buffers to ``blocks_forward_chunk`` instead.
+        decoder = self.flow.decoder
+        for module in (decoder, decoder.estimator):
+            for buffer_name in ("att_cache_buffer", "cnn_cache_buffer"):
+                if buffer_name in module._buffers:
+                    setattr(module, buffer_name, None)
         hift_parameter = next(self.hift.parameters(), None)
         if hift_parameter is not None and hift_parameter.device.type == "cuda":
             # Prime the CUDA state used by HiFT during backend construction.


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Reduce MiniCPM-o 4.5 Code2Wav GPU memory usage by releasing the upstream CFM decoder and DiT estimator `att_cache_buffer` and `cnn_cache_buffer` tensors after `BatchedToken2Wav` takes ownership.

These fixed streaming buffers are unused because the batched backend maintains dynamically sized per-request caches and does not invoke the upstream sequential streaming path.

This change does not modify model computation, batching, deployment configuration, sampling, or session capacity.

## Test Plan

### Code2Wav tests

```bash
python -m pytest -q \
  tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
```

### Default-configuration realtime E2E

The unmodified `minicpmo_4_5_duplex.yaml` configuration was used.

```bash
python \
  tests/e2e/online_serving/run_minicpmo_realtime_duplex_multi_session.py \
  --url 'ws://127.0.0.1:38351/v1/realtime?duplex=1' \
  --model openbmb/MiniCPM-o-4_5 \
  --sessions 2 \
  --turns 3 \
  --input-wav tests/assets/minicpmo_4_5/response_required_16k.wav \
  --ref-audio <MiniCPM-o-4_5>/assets/HT_ref_audio.wav \
  --realtime-input \
  --chunk-ms 200 \
  --first-turn-ms 1400 \
  --turn-duration-ms 1400 \
  --turn-duration-ms 1200 \
  --turn-duration-ms 1200 \
  --response-required \
  --temperature 0 \
  --timeout-s 480
```

### GPU memory comparison

Baseline and candidate were run sequentially on the same empty H800 GPU.

- Whole-GPU memory was sampled every 200 ms with `nvidia-smi`.
- Per-process memory was sampled every 500 ms.
- Ready-state memory was recorded after the health check passed.
- Request peak was the maximum sample during the complete E2E request window.
- The client process was prevented from using CUDA.

**vLLM Version:**

0.25.0

**vLLM-Omni Commit:**

- Base: `b4cc0d6da6b0efb9a081f3960e7ab91ddb9a5758`
- PR: `c72f305a8844ec6fbdda5903a5ad4bd7bec8a32f`

## Test Result

### Code2Wav tests

```text
27 passed, 16 warnings in 0.19s
```

### Realtime E2E

```text
E2E RESULT: PASS
```

- 2 concurrent sessions × 3 turns.
- 6/6 audio responses completed.
- Zero request errors or failures.
- Audio, transcript, event-order, and session-isolation checks passed.
- No CUDA OOM, EngineDead, traceback, illegal-memory-access, or stale-watermark errors.

### GPU memory

| Measurement | Base | PR | Reduction |
| --- | ---: | ---: | ---: |
| Ready-state GPU memory | 61,654 MiB | 59,506 MiB | 2,148 MiB |
| Request-window GPU peak | 66,846 MiB | 65,260 MiB | 1,586 MiB |
| Stage 2 process peak | 9,794 MiB | 8,226 MiB | 1,568 MiB |


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
