### PR TITLE
Add cosmos-guardrail dependency and update error message

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -34,3 +34,5 @@ pydantic-settings>=2.0.0
 # base image does not ship it, so declare it explicitly. The loader also guards
 # this import so a missing gguf no longer breaks all diffusion model loading.
 gguf>=0.10.0
+# Required for running the Cosmos3 model with guardrails enabled (default behavior).
+cosmos-guardrail>=0.3.1

--- a/vllm_omni/diffusion/models/cosmos3/guardrails.py
+++ b/vllm_omni/diffusion/models/cosmos3/guardrails.py
@@ -65,11 +65,10 @@ except ImportError:
         # ``model_config["guardrails"]`` is False.
         def __init__(self, *args, **kwargs):
             raise ValueError(
-                f"You have disabled the safety checker for {self.__class__}. This is in violation of the "
+                f"The guardrails are enabled but not functional for {self.__class__}. This is most likely due to a"
+                f"missing cosmos-guardrail package. Please install cosmos-guardrail to be compliant with the "
                 "[NVIDIA Open Model License Agreement]"
-                "(https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license). "
-                f"Please ensure that you are compliant with the license agreement."
-                f"Please install cosmos-guardrail package to enable safety checks."
+                "(https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license)."
             )
 
 


### PR DESCRIPTION
<!-- markdownlint-disable -->


## Purpose
Add a missing cosmos-guardrail dependency to the requirements, as currently vllm-omni docker images fail to run Cosmos3 models without explicitly disabling guardrails or installing `cosmos-guardrail` package.

## Test Plan
Test that `cosmos-guardrail` package installs fine and Cosmos3 model runs without any extra installations (HF authentication may still be required, error message about that comes from the cosmos-guardrail package).

**vLLM Version:**
0.27
**vLLM-Omni Commit:**
ToT
## Test Result

For latest `vllm/vllm-omni:latest` docker image (tested on 8.12.2026, nightly pin is `vllm/vllm-omni:nightly-61a678bd2671237fda844c5c88ff51614bc7c579`) `cosmos-guardrail` installs fine and doesn't reinstall any packages. It installs 10 other dependencies:

```
Installing collected packages: tifffile, opencv-python, lazy-loader, joblib, defusedxml, better-profanity, scikit-image, nltk, retinaface-py, peft, cosmos-guardrail
Successfully installed better-profanity-0.7.0 cosmos-guardrail-0.3.1 defusedxml-0.7.1 joblib-1.5.3 lazy-loader-0.5 nltk-3.10.2 opencv-python-5.0.0.93 peft-0.20.0 retinaface-py-0.0.2 scikit-image-0.26.0 tifffile-2026.7.31
```

Cosmos3 models load fine without any extra errors after that.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
