### PR TITLE
[Docs][CI] Template the pinned vLLM release version and bump to 0.27.0

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=vllm/vllm-openai:v0.26.0
+ARG BASE_IMAGE=vllm/vllm-openai:v0.27.0
 FROM ${BASE_IMAGE}
 
 ARG COMMON_WORKDIR=/app

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -2,7 +2,7 @@
 
 This section lists the most common options for running vLLM-Omni.
 
-For options within a vLLM Engine, please refer to the [vLLM 0.26 configuration guide](https://docs.vllm.ai/en/v0.26.0/configuration/index.html).
+For options within a vLLM Engine, please refer to the [vLLM {{vllm_minor}} configuration guide](https://docs.vllm.ai/en/v{{vllm_version}}/configuration/index.html).
 
 Each model defines fixed topology in a registered `PipelineConfig` and runtime
 overrides in a deploy YAML.

--- a/docs/getting_started/installation/README.md
+++ b/docs/getting_started/installation/README.md
@@ -1,7 +1,7 @@
 # Installation
 
 !!! important
-    vLLM-Omni is released against the matching upstream vLLM major/minor version. vLLM-Omni 0.26.x requires vLLM 0.26.x; the stable v0.26.0 instructions pin vLLM 0.26.0.
+    vLLM-Omni is released against the matching upstream vLLM major/minor version. vLLM-Omni {{vllm_minor}}.x requires vLLM {{vllm_minor}}.x; the stable v{{vllm_version}} instructions pin vLLM {{vllm_version}}.
 
 vLLM-Omni supports the following hardware platforms:
 

--- a/docs/getting_started/installation/gpu/cuda.inc.md
+++ b/docs/getting_started/installation/gpu/cuda.inc.md
@@ -5,7 +5,7 @@
 # --8<-- [end:requirements]
 # --8<-- [start:set-up-using-python]
 
-vLLM-Omni depends on the matching major/minor release of vLLM. The vLLM-Omni 0.26.x release line uses vLLM 0.26.x.
+vLLM-Omni depends on the matching major/minor release of vLLM. The vLLM-Omni {{vllm_minor}}.x release line uses vLLM {{vllm_minor}}.x.
 
 !!! note
     PyTorch installed via `conda` will statically link `NCCL` library, which can cause issues when vLLM tries to use `NCCL`. See <gh-issue:8420> for more details.
@@ -20,7 +20,7 @@ Therefore, it is recommended to install vLLM and vLLM-Omni with a **fresh new** 
 
 vLLM-Omni is built based on vLLM. Please install it with command below.
 ```bash
-uv pip install vllm==0.26.0 --torch-backend=auto
+uv pip install vllm=={{vllm_version}} --torch-backend=auto
 ```
 
 #### Installation of vLLM-Omni
@@ -39,13 +39,13 @@ uv pip install 'vllm-omni[demo]'
 # --8<-- [start:build-wheel-from-source]
 
 #### Installation of vLLM
-If you do not need to modify source code of vLLM, you can directly install the stable 0.26.0 release version of the library
+If you do not need to modify source code of vLLM, you can directly install the stable {{vllm_version}} release version of the library
 
 ```bash
-uv pip install vllm==0.26.0 --torch-backend=auto
+uv pip install vllm=={{vllm_version}} --torch-backend=auto
 ```
 
-The 0.26.0 release of vLLM ships CUDA 13.0-compatible binaries by default. If you need a different CUDA variant or want to reuse an existing PyTorch installation, build vLLM from source instead.
+The {{vllm_version}} release of vLLM ships CUDA 13.0-compatible binaries by default. If you need a different CUDA variant or want to reuse an existing PyTorch installation, build vLLM from source instead.
 
 #### Installation of vLLM-Omni
 Since vllm-omni is rapidly evolving, it's recommended to install it from source
@@ -66,12 +66,12 @@ If you want to check, modify or debug with source code of vLLM, install the libr
 ```bash
 git clone https://github.com/vllm-project/vllm.git
 cd vllm
-git checkout v0.26.0
+git checkout v{{vllm_version}}
 ```
 Set up environment variables to get pre-built wheels. If there are internet problems, just download the whl file manually. And set `VLLM_PRECOMPILED_WHEEL_LOCATION` as your local absolute path of whl file.
 ```bash
-#For CUDA 13.0 (the default for v0.26.0; the wheel filename has no `+cu130` suffix)
-export VLLM_PRECOMPILED_WHEEL_LOCATION=https://github.com/vllm-project/vllm/releases/download/v0.26.0/vllm-0.26.0-cp38-abi3-manylinux_2_28_x86_64.whl
+#For CUDA 13.0 (the default for v{{vllm_version}}; the wheel filename has no `+cu130` suffix)
+export VLLM_PRECOMPILED_WHEEL_LOCATION=https://github.com/vllm-project/vllm/releases/download/v{{vllm_version}}/vllm-{{vllm_version}}-cp38-abi3-manylinux_2_28_x86_64.whl
 ```
 Install vllm with command below (If you have no existing PyTorch).
 ```bash
@@ -124,7 +124,7 @@ If you want to specify the base vLLM version:
 ```bash
 DOCKER_BUILDKIT=1 docker build \
   -f docker/Dockerfile.cuda \
-  --build-arg BASE_IMAGE=vllm/vllm-openai:v0.26.0 \
+  --build-arg BASE_IMAGE=vllm/vllm-openai:v{{vllm_version}} \
   -t vllm-omni-cuda .
 ```
 

--- a/docs/getting_started/installation/gpu/rocm.inc.md
+++ b/docs/getting_started/installation/gpu/rocm.inc.md
@@ -13,7 +13,7 @@ vLLM-Omni current recommends the steps in under setup through Docker Images.
 
 vLLM-Omni is built based on vLLM. Please install it with command below.
 ```bash
-uv pip install vllm==0.26.0+rocm723 --extra-index-url https://wheels.vllm.ai/rocm/0.26.0/rocm723
+uv pip install vllm=={{vllm_version}}+rocm723 --extra-index-url https://wheels.vllm.ai/rocm/{{vllm_version}}/rocm723
 ```
 
 #### Installation of vLLM-Omni
@@ -34,13 +34,13 @@ uv pip install onnxruntime-rocm
 # --8<-- [start:build-wheel-from-source]
 
 #### Installation of vLLM
-If you do not need to modify source code of vLLM, you can directly install the stable 0.26.0 release version of the library
+If you do not need to modify source code of vLLM, you can directly install the stable {{vllm_version}} release version of the library
 
 ```bash
-uv pip install vllm==0.26.0+rocm723 --extra-index-url https://wheels.vllm.ai/rocm/0.26.0/rocm723
+uv pip install vllm=={{vllm_version}}+rocm723 --extra-index-url https://wheels.vllm.ai/rocm/{{vllm_version}}/rocm723
 ```
 
-The pre-built 0.26.0 vLLM wheel targets ROCm 7.2.3. If you need a different ROCm stack or want to reuse an existing PyTorch installation, build vLLM from source instead.
+The pre-built {{vllm_version}} vLLM wheel targets ROCm 7.2.3. If you need a different ROCm stack or want to reuse an existing PyTorch installation, build vLLM from source instead.
 
 #### Installation of vLLM-Omni
 Since vllm-omni is rapidly evolving, it's recommended to install it from source
@@ -58,7 +58,7 @@ If you want to check, modify or debug with source code of vLLM, install the libr
 ```bash
 git clone https://github.com/vllm-project/vllm.git
 cd vllm
-git checkout v0.26.0
+git checkout v{{vllm_version}}
 python3 -m pip install -r requirements/rocm.txt
 python3 setup.py develop
 ```

--- a/docs/getting_started/installation/npu/npu.inc.md
+++ b/docs/getting_started/installation/npu/npu.inc.md
@@ -9,8 +9,8 @@ The recommended way to use vLLM-Omni on NPU is through the vLLM-Ascend pre-built
 
 ```bash
 # vLLM-Ascend image
-# Atlas A2: quay.io/atlas-ci/vllm-ascend:v0.26.0
-# Atlas A3: quay.io/atlas-ci/vllm-ascend:v0.26.0-a3
+# Atlas A2: quay.io/atlas-ci/vllm-ascend:v{{vllm_version}}
+# Atlas A3: quay.io/atlas-ci/vllm-ascend:v{{vllm_version}}-a3
 docker run --rm \
     --name vllm-omni-npu \
     --shm-size=1g \
@@ -28,11 +28,11 @@ docker run --rm \
     -v /etc/ascend_install.info:/etc/ascend_install.info \
     -v /root/.cache:/root/.cache \
     -p 8000:8000 \
-    -it quay.io/atlas-ci/vllm-ascend:v0.26.0-a3 bash
+    -it quay.io/atlas-ci/vllm-ascend:v{{vllm_version}}-a3 bash
 
 # Inside the container, install vLLM-Omni from source
 cd /vllm-workspace
-git clone -b v0.26.0 https://github.com/vllm-project/vllm-omni.git
+git clone -b v{{vllm_version}} https://github.com/vllm-project/vllm-omni.git
 cd vllm-omni
 pip install -v -e . --no-build-isolation
 # or VLLM_OMNI_TARGET_DEVICE=npu pip install -v -e .
@@ -53,13 +53,13 @@ We are keeping [issue #886](https://github.com/vllm-project/vllm-omni/issues/886
 You can also build vLLM-Omni from the latest main branch if you want to use the latest features or bug fixes. (But sometimes it will break for a while. You can check [issue #886](https://github.com/vllm-project/vllm-omni/issues/886) for the status of the latest commit of vLLM-Omni main branch on NPU.)
 
 ```bash
-# Pin vLLM and vLLM-Ascend to the v0.26 release line
-git clone -b v0.26.0 https://github.com/vllm-project/vllm.git
+# Pin vLLM and vLLM-Ascend to the v{{vllm_version}} release line
+git clone -b v{{vllm_version}} https://github.com/vllm-project/vllm.git
 cd vllm
 VLLM_TARGET_DEVICE=empty pip install -v -e .
 cd ..
 
-git clone -b releases/v0.26.0rc https://github.com/vllm-project/vllm-ascend.git
+git clone -b releases/v{{vllm_version}}rc https://github.com/vllm-project/vllm-ascend.git
 cd vllm-ascend
 pip install -v -e .
 cd ..
@@ -88,8 +88,8 @@ Supported images as following.
 Here's an example deployment command that has been verified on 4 x NPUs:
 
 ```bash
-# Atlas A2: quay.io/ascend/vllm-omni:v0.26.0
-# Atlas A3: quay.io/ascend/vllm-omni:v0.26.0-a3
+# Atlas A2: quay.io/ascend/vllm-omni:v{{vllm_version}}
+# Atlas A3: quay.io/ascend/vllm-omni:v{{vllm_version}}-a3
 docker run --rm \
     --name vllm-omni-a3 \
     --shm-size=4g \
@@ -114,7 +114,7 @@ docker run --rm \
     -v /etc/ascend_install.info:/etc/ascend_install.info \
     -v ~/.cache:/root/.cache \
     -p 8091:8091 \
-    -it quay.io/ascend/vllm-omni:v0.26.0-a3 bash
+    -it quay.io/ascend/vllm-omni:v{{vllm_version}}-a3 bash
 ```
 
 !!! tip

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -19,10 +19,10 @@ uv venv --python 3.12 --seed
 source .venv/bin/activate
 
 # On CUDA
-uv pip install vllm==0.26.0 --torch-backend=auto
+uv pip install vllm=={{vllm_version}} --torch-backend=auto
 
 # On ROCm
-uv pip install vllm==0.26.0+rocm723 --extra-index-url https://wheels.vllm.ai/rocm/0.26.0/rocm723
+uv pip install vllm=={{vllm_version}}+rocm723 --extra-index-url https://wheels.vllm.ai/rocm/{{vllm_version}}/rocm723
 
 git clone https://github.com/vllm-project/vllm-omni.git
 cd vllm-omni

--- a/docs/mkdocs/hooks/version_vars.py
+++ b/docs/mkdocs/hooks/version_vars.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Substitutes version placeholder tokens with the pinned upstream vLLM
+release, so install instructions scattered across the docs can be bumped
+in one place (the `extra.vllm_version` value in mkdocs.yml) instead of
+hunting down every hardcoded occurrence.
+
+Supported tokens:
+  - `{{vllm_version}}` -> full release, e.g. "0.27.0"
+  - `{{vllm_minor}}`   -> major.minor, e.g. "0.27"
+
+This can't be a normal `on_page_markdown`/`on_page_content` mkdocs hook.
+Most usages sit inside fenced ```bash blocks in install docs that are only
+ever pulled into a real page (gpu.md) through a pymdownx.snippets `--8<--`
+include, and both the snippet expansion and the Pygments syntax
+highlighting happen *inside* the single `markdown.Markdown().convert()`
+call that a page hook can only see the before/after of:
+
+  - `on_page_markdown` sees gpu.md's raw text, before the `--8<--`
+    reference is expanded, so the token (which lives in the *included*
+    file) isn't present in the text yet.
+  - `on_page_content` sees the final HTML, but by then Pygments has
+    already tokenized the fenced code block into separate <span>s (e.g.
+    `{{` and `}}` end up in different spans), so the token is no longer a
+    contiguous string to search-and-replace.
+
+So instead `on_config` registers a real Python-Markdown preprocessor
+(`_VersionVarsExtension`), passing a live instance straight into
+`config.markdown_extensions` (Python-Markdown accepts already-constructed
+Extension objects there, so this needs no import-path/sys.path setup).
+Preprocessors run in descending priority order on plain text lines, before
+any block-level parsing. pymdownx.snippets registers its preprocessor at
+priority 32 and pymdownx.superfences pulls fenced blocks out for
+highlighting at priority 25, so priority 28 runs after snippets have
+expanded includes but before code fences are extracted and highlighted -
+the one window where the text is both fully assembled and still plain.
+
+`on_post_build` is a defense-in-depth check: it strips HTML tags before
+searching the built site for a leftover token, since a plain substring
+search would miss a token that Pygments (or any other treeprocessor)
+fragmented across tags - the same blind spot that let the original,
+broken on_page_content approach ship silently.
+"""
+
+import re
+from pathlib import Path
+
+from markdown.extensions import Extension
+from markdown.preprocessors import Preprocessor
+from mkdocs.config.defaults import MkDocsConfig
+from mkdocs.exceptions import PluginError
+
+_TOKEN_RE = re.compile(r"\{\{\s*vllm_(?:version|minor)\s*\}\}")
+_TAG_RE = re.compile(r"<[^>]+>")
+
+# Below pymdownx.snippets (32), above pymdownx.superfences' fenced-code
+# extraction (25).
+_PREPROCESSOR_PRIORITY = 28
+
+
+class _VersionVarsPreprocessor(Preprocessor):
+    def __init__(self, md, version: str, minor: str) -> None:
+        super().__init__(md)
+        self.version = version
+        self.minor = minor
+
+    def run(self, lines: list[str]) -> list[str]:
+        return [line.replace("{{vllm_minor}}", self.minor).replace("{{vllm_version}}", self.version) for line in lines]
+
+
+class _VersionVarsExtension(Extension):
+    def __init__(self, version: str) -> None:
+        self.version = version
+        self.minor = ".".join(version.split(".")[:2])
+        super().__init__()
+
+    def extendMarkdown(self, md) -> None:
+        md.preprocessors.register(
+            _VersionVarsPreprocessor(md, self.version, self.minor),
+            "vllm_version_vars",
+            _PREPROCESSOR_PRIORITY,
+        )
+
+
+def on_config(config: MkDocsConfig) -> MkDocsConfig:
+    version = config.extra.get("vllm_version")
+    if version:
+        config.markdown_extensions.append(_VersionVarsExtension(version))
+    return config
+
+
+def on_post_build(*, config: MkDocsConfig) -> None:
+    site_dir = Path(config.site_dir)
+    leaked = sorted(
+        str(path.relative_to(site_dir))
+        for path in site_dir.rglob("*.html")
+        if _TOKEN_RE.search(_TAG_RE.sub("", path.read_text(encoding="utf-8")))
+    )
+    if leaked:
+        raise PluginError(
+            "Unresolved {{vllm_version}}/{{vllm_minor}} token(s) found in built pages "
+            f"(hooks/version_vars.py failed to substitute them): {', '.join(leaked)}"
+        )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,11 @@ edit_uri: edit/main/docs/
 # Copyright
 copyright: Copyright &copy; 2026 vLLM-Omni Team
 
+# Single source of truth for the pinned upstream vLLM release. Referenced in
+# docs via the {{vllm_version}} token, substituted by hooks/version_vars.py.
+extra:
+  vllm_version: "0.27.0"
+
 # Theme
 theme:
   name: material
@@ -60,6 +65,7 @@ hooks:
   - docs/mkdocs/hooks/url_schemes.py
   - docs/mkdocs/hooks/generate_examples.py
   - docs/mkdocs/hooks/generate_argparse.py
+  - docs/mkdocs/hooks/version_vars.py
 
 # Exclude include files from navigation warnings
 exclude_docs: |


### PR DESCRIPTION

## Purpose

Introduces a {{vllm_version}} / {{vllm_minor}} token, defined once in mkdocs.yml's extra block and substituted by a new on_page_markdown hook (docs/mkdocs/hooks/version_vars.py), so the many scattered vLLM install pins across the getting-started docs no longer need to be hand-updated in lockstep on every vLLM bump.

## Test Plan

**vLLM Version:** 0.27.0

**vLLM-Omni Commit:** 66d1de0851937ecfd0045e4f534b4c2c9f0ba8bf

Manually inspect the rendered doc.

## Test Result

TBD
