### PR TITLE
[Bugfix] Compat: accept legacy str-based Auto* register calls on transformers >= 5.3

### DIFF
--- a/tests/model_executor/models/minicpmo_4_5/test_auto_register_compat.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_auto_register_compat.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+Tests for the transformers 5.x auto-registration compatibility shim in
+vllm_omni.patch.
+
+Remote model files written against the pre-5.3 signature
+``AutoImageProcessor.register(str_name, cls)`` crash on transformers >= 5.3
+with ``AttributeError: 'str' object has no attribute '__module__'``. vLLM
+imports remote model modules during model-architecture inspection (in a
+subprocess), so this crash breaks ``vllm serve`` startup. The shim in
+vllm_omni.patch forwards every call unchanged and drops a legacy str
+registration only when the installed transformers rejects it; new-style
+config-class registrations pass through untouched.
+"""
+
+import pytest
+from transformers import AutoFeatureExtractor, AutoImageProcessor, AutoProcessor, AutoTokenizer
+from transformers.image_processing_utils import BaseImageProcessor
+
+from vllm_omni import patch
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+@pytest.fixture(autouse=True)
+def _apply_compat_shim():
+    patch._patch_auto_register_compat()
+
+
+class _StubImageProcessor(BaseImageProcessor):
+    """Stand-in for a remote image processor class."""
+
+
+def _register_is_wrapped(auto_cls):
+    return getattr(auto_cls.__dict__["register"].__func__, "_omni_str_register_compat", False)
+
+
+@pytest.mark.parametrize(
+    "auto_cls",
+    [AutoProcessor, AutoImageProcessor, AutoFeatureExtractor, AutoTokenizer],
+)
+def test_legacy_str_registration_is_noop(auto_cls):
+    """Old-style (str, cls) registration must not raise on transformers >= 5.3."""
+    assert _register_is_wrapped(auto_cls)
+    # Old-style registration by name: either accepted by the installed
+    # transformers (older releases) or dropped by the shim — never raised.
+    auto_cls.register("SomeLegacyProcessorName", _StubImageProcessor)
+
+
+@pytest.mark.parametrize(
+    "auto_cls",
+    [AutoProcessor, AutoImageProcessor, AutoFeatureExtractor, AutoTokenizer],
+)
+def test_new_style_config_class_registration_forwarded(auto_cls):
+    """New-style (config_class, cls) registration must reach the original register."""
+    from transformers import PretrainedConfig
+
+    assert _register_is_wrapped(auto_cls)
+
+    class _StubConfig(PretrainedConfig):
+        model_type = "omni-test-stub"
+
+    # Should not raise (and must not hit the str branch).
+    auto_cls.register(_StubConfig, _StubImageProcessor, exist_ok=True)

--- a/vllm_omni/patch.py
+++ b/vllm_omni/patch.py
@@ -338,6 +338,89 @@ def _patch_chat_template_registry():
 _patch_chat_template_registry()
 
 
+# =============================================================================
+# Compat: transformers >= 5.3 auto-registration wants config classes, not str
+# =============================================================================
+# transformers 5.3+ changed the Auto* `register()` signature from
+# ``register(str_name, cls)`` to ``register(config_class, cls, ...)``. The
+# new implementations look up ``config_class.__module__``, so remote model
+# files written against the old signature (e.g. MiniCPM-o 4.5's
+# ``processing_minicpmo.py``, which calls
+# ``AutoImageProcessor.register("MiniCPMVImageProcessor", ...)``) raise
+# ``AttributeError: 'str' object has no attribute '__module__'``.
+#
+# Under vLLM, that crash surfaces during model-architecture inspection:
+# ``ModelRegistry`` imports the remote model module in a subprocess
+# (``python -m vllm.model_executor.models.registry``), the uncaught
+# AttributeError aborts that subprocess, and the parent turns it into a
+# serve startup failure (SIGABRT on some platforms / glibc builds).
+#
+# AutoProcessor.from_pretrained() still resolves the class from the
+# checkpoint's ``preprocessor_config.json`` ``auto_map`` regardless of the
+# registry, so these registrations are informational. The wrapper therefore
+# forwards every call unchanged and only drops a legacy ``(str, cls)`` call
+# when the installed transformers rejects it (AttributeError on
+# ``__module__``). On older transformers, where str-keyed registration is
+# still accepted, behavior is byte-identical to upstream. The new
+# ``(config_class, cls)`` signature (used by vLLM-Omni's own vendored
+# processors, e.g. minicpmo_4_5_omni_llm.py) is forwarded unchanged.
+_AUTO_REGISTER_COMPAT_PATCHED = set()
+
+
+def _patch_auto_register_compat():
+    from transformers import (
+        AutoFeatureExtractor,
+        AutoImageProcessor,
+        AutoProcessor,
+        AutoTokenizer,
+    )
+
+    for auto_cls in (
+        AutoProcessor,
+        AutoImageProcessor,
+        AutoFeatureExtractor,
+        AutoTokenizer,
+    ):
+        if auto_cls in _AUTO_REGISTER_COMPAT_PATCHED:
+            continue
+        original_register = auto_cls.register
+        if getattr(original_register, "_omni_str_register_compat", False):
+            _AUTO_REGISTER_COMPAT_PATCHED.add(auto_cls)
+            continue
+
+        def _make_patched(original):
+            def _patched_register(config_class, *args, **kwargs):
+                if isinstance(config_class, str):
+                    try:
+                        return original(config_class, *args, **kwargs)
+                    except AttributeError as exc:
+                        # transformers >= 5.3 rejects str-keyed registration
+                        # with "'str' object has no attribute '__module__'".
+                        # The class is resolved via preprocessor auto_map at
+                        # load time, so the registration is redundant — drop
+                        # it instead of crashing model-architecture
+                        # inspection subprocesses.
+                        if "__module__" not in str(exc):
+                            raise
+                        _PATCH_LOGGER.debug(
+                            "[auto-register] dropping legacy str registration %r "
+                            "(transformers >= 5.3 requires a config class); "
+                            "resolved via preprocessor auto_map at load time",
+                            config_class,
+                        )
+                        return None
+                return original(config_class, *args, **kwargs)
+
+            _patched_register._omni_str_register_compat = True
+            return _patched_register
+
+        auto_cls.register = staticmethod(_make_patched(original_register))
+        _AUTO_REGISTER_COMPAT_PATCHED.add(auto_cls)
+
+
+_patch_auto_register_compat()
+
+
 def _patch_scaled_mm_fp8_contiguous_activation():
     """Support batched diffusion activations on the ModelOpt FP8 (ScaledMM) path.
 


### PR DESCRIPTION
## Purpose

`vllm serve` crashes at startup (SIGABRT) for models whose **remote** processing files
use the pre-5.3 auto-registration signature, e.g. MiniCPM-o 4.5's
`processing_minicpmo.py`:

```python
AutoImageProcessor.register("MiniCPMVImageProcessor", MiniCPMVImageProcessor)
```

transformers >= 5.3 changed `AutoProcessor` / `AutoImageProcessor` /
`AutoFeatureExtractor` / `AutoTokenizer` `register()` to take a **config class** as the
first argument and dereference `config_class.__module__` internally. A `str` key raises:

```
AttributeError: 'str' object has no attribute '__module__'
```

vLLM imports remote model modules during model-architecture inspection
(`ModelRegistry.inspect_model_cls`, which runs a subprocess `python -m vllm.model_executor.models.registry`),
so the uncaught AttributeError aborts that subprocess and the parent process dies
with SIGABRT (`corrupted size vs. prev_size` glibc abort on some builds) — before the
server ever listens. The official A3 (Ascend NPU) evaluation image ships
transformers 5.13.0, so this breaks out-of-the-box reproduction of MiniCPM-o 4.5
serving.

## Fix

Wrap the four `Auto*` `register()` methods in `vllm_omni/patch.py`:

- every call is forwarded unchanged (new-style `(config_class, cls)`, used by
  vLLM-Omni's own vendored processors — passes through untouched);
- a legacy `(str, cls)` call is only dropped when the installed transformers
  rejects it with the `__module__` AttributeError. The registration is
  redundant: `AutoProcessor.from_pretrained()` resolves the class at load time
  from the checkpoint's `preprocessor_config.json` `auto_map` regardless of the
  registry. On older transformers where str-keyed registration is still
  accepted, behavior is byte-identical to upstream.

## Test Plan

**vLLM Version:** 0.1.dev1+ge5588e49b (vllm-omni v0.25.0 image)

**vLLM-Omni Commit:** `bb0a513d` (minicpm-challenge HEAD)

- New unit tests `tests/model_executor/models/minicpmo_4_5/test_auto_register_compat.py`
  (8 cases: legacy str + new config-class signatures x 4 Auto classes): **8 passed**.
- End-to-end on the official Ascend A3 image (transformers 5.13.0): with the
  **unmodified** checkpoint file (`processing_minicpmo.py` line 408, original
  `AutoImageProcessor.register("MiniCPMVImageProcessor", ...)` call) and only the
  vllm-omni patch applied, `vllm serve` starts cleanly — all 3 stages initialize,
  `/v1/models` returns 200, no SIGABRT / AttributeError in the serve log.

## Test Result

- Unit tests: 8/8 passed (transformers 5.13.0).
- Serve startup (A3 NPU, transformers 5.13.0, original unpatched checkpoint):
  clean start, `/v1/models` 200, 3 stages initialized, zero SIGABRT /
  AttributeError in the serve log.
- Seed-TTS 16 regression (16 requests, same protocol as official harness):
  WER 0.0097 / SIM 0.8468 (reference run: 0.0097 / 0.8467 — no degradation),
  0 failed. No throughput/latency regression observed.
- Regression: new-style config-class registrations (e.g. vendored
  `minicpmo_4_5_omni_llm.py`, `gr00t` processors) pass through unchanged.

Team: **KuaaMU**
