### PR TITLE
[minicpmo] Add opt-in streaming audio input for native duplex

### DIFF
--- a/tests/entrypoints/openai_api/test_duplex_handler.py
+++ b/tests/entrypoints/openai_api/test_duplex_handler.py
@@ -1368,6 +1368,29 @@ def test_runtime_capabilities_rejects_invalid_optional_hook_signature():
         validate_serving_runtime_adapter(adapter)
 
 
+@pytest.mark.parametrize("chunk_period_ms", [500, 1000])
+def test_minicpmo_pcm_buffer_emits_configured_chunks_and_pads_short_final_tail(chunk_period_ms: int):
+    buffer = MiniCPMO45PcmAppendBuffer()
+    chunk = _native_audio_payload(samples=4800)
+    total_samples = 9600
+
+    first = buffer.append(chunk, chunk_period_ms=chunk_period_ms)
+    second = buffer.append(chunk, chunk_period_ms=chunk_period_ms)
+    final = buffer.commit(chunk_period_ms=chunk_period_ms)
+
+    emitted = [payload for payload in (first, second, final) if payload is not None]
+    chunk_samples = 16000 * chunk_period_ms // 1000
+    complete_samples = total_samples - (total_samples % chunk_samples)
+    assert [len(np.frombuffer(base64.b64decode(payload["audio"]), dtype="<f4")) for payload in emitted] == [
+        chunk_samples
+    ] * ((complete_samples // chunk_samples) + int(total_samples % chunk_samples != 0))
+
+    tail_samples = total_samples - complete_samples
+    final_audio = np.frombuffer(base64.b64decode(emitted[-1]["audio"]), dtype="<f4")
+    assert np.allclose(final_audio[:tail_samples], 0.05)
+    assert np.allclose(final_audio[tail_samples:], 0.0)
+
+
 def _native_realtime_session_update(
     session_id: str,
     *,
@@ -5543,6 +5566,55 @@ async def test_minicpmo_native_duplex_audio_append_does_not_retain_pending_audio
     cancelled = next(m for m in ws.sent if m.get("type") == "input.cancelled")
     assert cancelled["cancelled"] == {"text_chunks": 0, "audio_chunks": 0}
     assert cancelled["epoch"] == 1
+
+
+@pytest.mark.asyncio
+async def test_session_create_preserves_legacy_runtime_adapter_capabilities_signature():
+    session_states: dict[str, MiniCPMO45ServingSessionState] = {}
+    capabilities_calls: list[int] = []
+
+    def session_state(session_id: str) -> MiniCPMO45ServingSessionState:
+        return session_states.setdefault(session_id, MiniCPMO45ServingSessionState())
+
+    def capabilities(*, max_sessions: int) -> DuplexCapabilities:
+        capabilities_calls.append(max_sessions)
+        return DuplexCapabilities.minicpmo45_native(max_sessions=max_sessions)
+
+    async def prepare_runtime_config(config, *, model_config):
+        del config, model_config
+        return {"streaming_audio_chunk_size": 25}
+
+    adapter = SimpleNamespace(
+        adapter_id="legacy-test-adapter",
+        session_states=session_states,
+        data_plane=_test_data_plane(),
+        clean_response_done_prefix="",
+        interrupted_tts_prefix="",
+        private_runtime_config_keys=frozenset(),
+        create_session_state=MiniCPMO45ServingSessionState,
+        session_state=session_state,
+        remove_session_state=session_states.pop,
+        is_enabled=lambda config: True,
+        capabilities=capabilities,
+        validate_client_extra_body=lambda extra_body: None,
+        prepare_runtime_config=prepare_runtime_config,
+        runtime_config_for_update=lambda config, current: dict(current),
+        data_plane_context=lambda **kwargs: MiniCPMO45DataPlaneContext(**kwargs),
+    )
+    handler = OmniDuplexSessionHandler(
+        chat_service=FakeChatService(FakeEngineClient()),
+        config_timeout_s=0.1,
+        idle_timeout_s=1,
+        serving_runtime_adapter=adapter,
+    )
+    ws = TimedWebSocket()
+    ws.put(_native_session_create("sid-legacy-capabilities"))
+
+    handshake = await handler._open_session(ws, ws.send_json)
+
+    assert handshake is not None
+    assert handshake.session.runtime_config == {"streaming_audio_chunk_size": 25}
+    assert capabilities_calls == [1]
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/openai_api/test_duplex_handler.py
+++ b/tests/entrypoints/openai_api/test_duplex_handler.py
@@ -27,6 +27,9 @@ from vllm_omni.experimental.fullduplex.minicpmo45.data_plane import (
 from vllm_omni.experimental.fullduplex.minicpmo45.runtime import (
     MiniCPMO45DuplexRuntimeExtension,
 )
+from vllm_omni.experimental.fullduplex.minicpmo45.serving_adapter import (
+    MiniCPMO45ServingRuntimeAdapter,
+)
 from vllm_omni.experimental.fullduplex.minicpmo45.session import (
     MiniCPMO45ServingSessionState,
 )
@@ -39,7 +42,11 @@ from vllm_omni.experimental.fullduplex.openai.protocol import (
     ResponseCreateOptions,
 )
 from vllm_omni.experimental.fullduplex.openai.realtime_session import NativeRealtimeSessionProtocol
-from vllm_omni.experimental.fullduplex.openai.runtime_adapter import ServingRuntimeConfigError
+from vllm_omni.experimental.fullduplex.openai.runtime_adapter import (
+    ServingRuntimeConfigError,
+    runtime_capabilities,
+    validate_serving_runtime_adapter,
+)
 from vllm_omni.experimental.fullduplex.openai.serving import (
     OmniDuplexSessionHandler,
     should_enable_duplex_endpoint,
@@ -1305,6 +1312,60 @@ def _native_session_create(
     event["session"]["instructions"] = "You are a concise assistant."
     event["session"]["extra_body"] = {"minicpmo45_native_duplex": True}
     return event
+
+
+class _LegacyCapabilitiesAdapter(MiniCPMO45ServingRuntimeAdapter):
+    """Adapter published before runtime-derived capabilities were added."""
+
+    capabilities_with_runtime_config_v1 = None
+
+    @staticmethod
+    def capabilities(*, max_sessions: int) -> DuplexCapabilities:
+        return DuplexCapabilities.minicpmo45_native(max_sessions=max_sessions)
+
+
+class _InvalidRuntimeCapabilitiesAdapter(MiniCPMO45ServingRuntimeAdapter):
+    @staticmethod
+    def capabilities_with_runtime_config_v1(*, max_sessions: int) -> DuplexCapabilities:
+        return DuplexCapabilities.minicpmo45_native(max_sessions=max_sessions)
+
+
+@pytest.mark.asyncio
+async def test_native_session_create_accepts_legacy_capabilities_adapter():
+    engine = FakeEngineClient()
+    handler = OmniDuplexSessionHandler(
+        chat_service=FakeChatService(engine),
+        serving_runtime_adapter=_LegacyCapabilitiesAdapter(lambda *_: None),
+        config_timeout_s=0.1,
+        idle_timeout_s=1,
+    )
+    ws = TimedWebSocket()
+    ws.put(_native_session_create("sid-legacy-capabilities"))
+    ws.put({"type": "session.close"})
+
+    await handler.handle_session(ws)
+
+    assert ws.sent_types()[0] == "session.created"
+    assert engine.opened == ["sid-legacy-capabilities"]
+
+
+def test_runtime_capabilities_uses_versioned_runtime_hook():
+    adapter = MiniCPMO45ServingRuntimeAdapter(lambda *_: None)
+
+    capabilities = runtime_capabilities(
+        adapter,
+        max_sessions=1,
+        runtime_config={"streaming_audio_chunk_ms": 600},
+    )
+
+    assert capabilities.chunk_period_ms == 600
+
+
+def test_runtime_capabilities_rejects_invalid_optional_hook_signature():
+    adapter = _InvalidRuntimeCapabilitiesAdapter(lambda *_: None)
+
+    with pytest.raises(TypeError, match="capabilities_with_runtime_config_v1"):
+        validate_serving_runtime_adapter(adapter)
 
 
 def _native_realtime_session_update(

--- a/tests/worker/test_native_duplex_hooks.py
+++ b/tests/worker/test_native_duplex_hooks.py
@@ -480,6 +480,35 @@ def test_minicpmo_model_cleans_incarnation_state_when_request_finishes():
     }
 
 
+def test_minicpmo_encoder_latency_uses_tp_critical_path(monkeypatch):
+    import vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni as minicpmo_module
+    from vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni import (
+        MiniCPMO45OmniForConditionalGeneration,
+    )
+
+    tp_group = SimpleNamespace(world_size=4, device_group=object())
+    calls: list[tuple[torch.Tensor, object, object]] = []
+
+    def fake_all_reduce(tensor, *, op, group):
+        calls.append((tensor.clone(), op, group))
+        tensor.copy_(torch.tensor([19.5, 7.0], dtype=tensor.dtype))
+
+    monkeypatch.setattr(minicpmo_module, "get_tp_group", lambda: tp_group)
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+    monkeypatch.setattr(
+        minicpmo_module,
+        "current_omni_platform",
+        SimpleNamespace(get_torch_device=lambda: torch.device("cpu")),
+    )
+
+    latency_ms = MiniCPMO45OmniForConditionalGeneration._max_reduce_audio_encoder_latency_ms([12.5, 0.0])
+
+    assert latency_ms == [19.5, 7.0]
+    assert calls[0][0].tolist() == [12.5, 0.0]
+    assert calls[0][1] == torch.distributed.ReduceOp.MAX
+    assert calls[0][2] is tp_group.device_group
+
+
 def test_minicpmo_stage0_routes_duplex_metadata_per_batched_request():
     from vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni import (
         MiniCPMO45OmniForConditionalGeneration,

--- a/vllm_omni/data_entry_keys.py
+++ b/vllm_omni/data_entry_keys.py
@@ -59,6 +59,7 @@ class Ids(TypedDict, total=False):
 
 
 class OmniPayloadMeta(TypedDict, total=False):
+    audio_encoder_latency_ms: torch.Tensor
     finished: torch.Tensor
     is_segment_finished: torch.Tensor
     stream_finished: torch.Tensor
@@ -165,6 +166,7 @@ class IdsStruct(_StructBase):
 
 
 class MetaStruct(_StructBase):
+    audio_encoder_latency_ms: torch.Tensor | None = None
     finished: torch.Tensor | None = None
     is_segment_finished: torch.Tensor | None = None
     stream_finished: torch.Tensor | None = None

--- a/vllm_omni/engine/stage_engine_core_client.py
+++ b/vllm_omni/engine/stage_engine_core_client.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import inspect
 import os
 import socket
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
@@ -48,7 +49,12 @@ def _default_process_engine_inputs(
     if not isinstance(prompt, list):
         prompt = [prompt]
 
-    mm_data = {so.request_id: p.get("multi_modal_data") for so, p in zip(source_outputs, prompt)}
+    mm_data = {
+        source_output.request_id: prompt_item.get("multi_modal_data")
+        if isinstance(prompt_item, Mapping)
+        else None
+        for source_output, prompt_item in zip(source_outputs, prompt)
+    }
 
     return [
         OmniTokensPrompt(

--- a/vllm_omni/engine/stage_engine_core_client.py
+++ b/vllm_omni/engine/stage_engine_core_client.py
@@ -50,9 +50,7 @@ def _default_process_engine_inputs(
         prompt = [prompt]
 
     mm_data = {
-        source_output.request_id: prompt_item.get("multi_modal_data")
-        if isinstance(prompt_item, Mapping)
-        else None
+        source_output.request_id: prompt_item.get("multi_modal_data") if isinstance(prompt_item, Mapping) else None
         for source_output, prompt_item in zip(source_outputs, prompt)
     }
 

--- a/vllm_omni/experimental/fullduplex/minicpmo45/adapter.py
+++ b/vllm_omni/experimental/fullduplex/minicpmo45/adapter.py
@@ -163,7 +163,7 @@ class MiniCPMO45NativeDuplexServingAdapter:
             MiniCPMO45DuplexPolicy.DEFAULT_STREAMING_AUDIO_CHUNK_SIZE,
         )
         frame_rate = cls._positive_int(
-            cls._config_value(hf_config, "streaming_sliding_window_audio_frame_rate"),
+            cls._config_value(tts_config, "streaming_sliding_window_audio_frame_rate"),
             MiniCPMO45DuplexPolicy.DEFAULT_STREAMING_AUDIO_FRAME_RATE,
         )
         chunk_ms = max(1, (chunk_size * 1000 + frame_rate // 2) // frame_rate)

--- a/vllm_omni/experimental/fullduplex/minicpmo45/adapter.py
+++ b/vllm_omni/experimental/fullduplex/minicpmo45/adapter.py
@@ -97,7 +97,6 @@ class MiniCPMO45NativeDuplexServingAdapter:
             raise ValueError("ref_audio_path is not accepted by native duplex; use ref_audio URI instead")
         cls.validate_client_config(config)
         runtime_config: dict[str, object] = {"instructions": config.instructions}
-<<<<<<< HEAD
         initial_user_text = extra_body.pop("duplex_initial_user_text", None)
         if isinstance(initial_user_text, str) and initial_user_text:
             runtime_config["initial_user_text"] = initial_user_text

--- a/vllm_omni/experimental/fullduplex/minicpmo45/adapter.py
+++ b/vllm_omni/experimental/fullduplex/minicpmo45/adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+from collections.abc import Mapping
 from copy import deepcopy
 from typing import Any
 
@@ -38,6 +39,11 @@ class MiniCPMO45NativeDuplexServingAdapter:
             "ref_audio_format",
             "ref_audio_sample_rate_hz",
             "initial_user_text",
+            MiniCPMO45DuplexPolicy.RUNTIME_STREAMING_AUDIO_CHUNK_SIZE,
+            MiniCPMO45DuplexPolicy.RUNTIME_STREAMING_AUDIO_FRAME_RATE,
+            MiniCPMO45DuplexPolicy.RUNTIME_STREAMING_AUDIO_CHUNK_MS,
+            MiniCPMO45DuplexPolicy.RUNTIME_STREAMING_AUDIO_FIRST_CHUNK_MS,
+            MiniCPMO45DuplexPolicy.RUNTIME_STREAMING_AUDIO_CHUNK_SAMPLES,
         }
     )
 
@@ -91,9 +97,11 @@ class MiniCPMO45NativeDuplexServingAdapter:
             raise ValueError("ref_audio_path is not accepted by native duplex; use ref_audio URI instead")
         cls.validate_client_config(config)
         runtime_config: dict[str, object] = {"instructions": config.instructions}
+<<<<<<< HEAD
         initial_user_text = extra_body.pop("duplex_initial_user_text", None)
         if isinstance(initial_user_text, str) and initial_user_text:
             runtime_config["initial_user_text"] = initial_user_text
+        cls._apply_streaming_audio_config(runtime_config, model_config=model_config)
         cls._apply_default_scheduler_policy(runtime_config, config=config, model_config=model_config)
 
         ref_audio = config.ref_audio
@@ -141,6 +149,65 @@ class MiniCPMO45NativeDuplexServingAdapter:
         config.extra_body = extra_body
         config.ref_audio = None
         return runtime_config
+
+    @classmethod
+    def _apply_streaming_audio_config(
+        cls,
+        runtime_config: dict[str, object],
+        *,
+        model_config: Any,
+    ) -> None:
+        hf_config = cls._config_value(model_config, "hf_config") or model_config
+        tts_config = cls._config_value(hf_config, "tts_config")
+        chunk_size = cls._positive_int(
+            cls._config_value(tts_config, "streaming_audio_chunk_size"),
+            MiniCPMO45DuplexPolicy.DEFAULT_STREAMING_AUDIO_CHUNK_SIZE,
+        )
+        frame_rate = cls._positive_int(
+            cls._config_value(hf_config, "streaming_sliding_window_audio_frame_rate"),
+            MiniCPMO45DuplexPolicy.DEFAULT_STREAMING_AUDIO_FRAME_RATE,
+        )
+        chunk_ms = max(1, (chunk_size * 1000 + frame_rate // 2) // frame_rate)
+        chunk_samples = chunk_ms * MiniCPMO45DuplexPolicy.SAMPLE_RATE_HZ // 1000
+        if chunk_samples < MiniCPMO45DuplexPolicy.SAMPLES_PER_AUDIO_TOKEN or (
+            chunk_samples % MiniCPMO45DuplexPolicy.SAMPLES_PER_AUDIO_TOKEN
+        ):
+            raise MiniCPMO45ClientRuntimeConfigError(
+                "MiniCPM-o streaming_audio_chunk_size must resolve to whole 100 ms audio encoder frames",
+                code="invalid_streaming_audio_chunk_size",
+            )
+        runtime_config.update(
+            {
+                MiniCPMO45DuplexPolicy.RUNTIME_STREAMING_AUDIO_CHUNK_SIZE: chunk_size,
+                MiniCPMO45DuplexPolicy.RUNTIME_STREAMING_AUDIO_FRAME_RATE: frame_rate,
+                MiniCPMO45DuplexPolicy.RUNTIME_STREAMING_AUDIO_CHUNK_MS: chunk_ms,
+                MiniCPMO45DuplexPolicy.RUNTIME_STREAMING_AUDIO_FIRST_CHUNK_MS: (
+                    chunk_ms + MiniCPMO45DuplexPolicy.FIRST_CHUNK_ALIGNMENT_MS
+                ),
+                MiniCPMO45DuplexPolicy.RUNTIME_STREAMING_AUDIO_CHUNK_SAMPLES: chunk_samples,
+            }
+        )
+
+    @classmethod
+    def runtime_streaming_audio_chunk_ms(cls, runtime_config: Mapping[str, object] | None) -> int:
+        value = None
+        if runtime_config is not None:
+            value = runtime_config.get(MiniCPMO45DuplexPolicy.RUNTIME_STREAMING_AUDIO_CHUNK_MS)
+        return cls._positive_int(value, MiniCPMO45DuplexPolicy.DEFAULT_STREAMING_AUDIO_CHUNK_MS)
+
+    @staticmethod
+    def _config_value(config: object, name: str) -> object | None:
+        if isinstance(config, Mapping):
+            return config.get(name)
+        return getattr(config, name, None)
+
+    @staticmethod
+    def _positive_int(value: object, default: int) -> int:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return default
+        return parsed if parsed > 0 else default
 
     @classmethod
     def _apply_default_scheduler_policy(

--- a/vllm_omni/experimental/fullduplex/minicpmo45/data_plane.py
+++ b/vllm_omni/experimental/fullduplex/minicpmo45/data_plane.py
@@ -175,6 +175,16 @@ class MiniCPMO45DataPlaneSession:
                         mm_output = inner_mm_output
         mm_output = dict(mm_output) if isinstance(mm_output, Mapping) else {}
 
+        audio_encoder_latency_ms = mm_output.get("audio_encoder_latency_ms")
+        stage0_metrics = stage_metrics.get("0") if stage_metrics is not None else None
+        if (
+            isinstance(stage0_metrics, dict)
+            and isinstance(audio_encoder_latency_ms, int | float)
+            and not isinstance(audio_encoder_latency_ms, bool)
+            and audio_encoder_latency_ms > 0
+        ):
+            stage0_metrics["audio_encoder_latency_ms"] = float(audio_encoder_latency_ms)
+
         output_turn_id = output_turn_id_from_metadata(mm_output)
         output_epoch = output_epoch_from_metadata(mm_output)
         expected_turn_id = context.active_response_turn_id

--- a/vllm_omni/experimental/fullduplex/minicpmo45/policy.py
+++ b/vllm_omni/experimental/fullduplex/minicpmo45/policy.py
@@ -11,16 +11,26 @@ class MiniCPMO45DuplexPolicy:
     MiniCPM-o 4.5 remote-code contract, not a general vLLM-Omni duplex schema.
     """
 
-    # Audio framing contract shared by serving, orchestrator, and worker.
-    # MiniCPM-o consumes 1 s units at 16 kHz and pools audio to one embedding
-    # per 100 ms, so a unit contributes exactly 10 audio embeddings plus the
-    # <unit> open (and a </unit> closure for every unit after the first).
+    # Audio framing contract shared by serving, orchestrator, and worker. The
+    # released checkpoint uses 50 streaming frames at 50 fps (one second) and
+    # pools audio to one embedding per 100 ms. Runtime keys carry the derived
+    # period so custom checkpoints do not leave serving and Stage0 out of sync.
     # Scheduler token budgets must match the worker-built embeddings exactly:
     # surplus slots become pad embeddings inside the KV and measurably corrupt
     # the model's listen/speak behavior.
     SAMPLE_RATE_HZ = 16000
     CHUNK_SAMPLES = 16000
     SAMPLES_PER_AUDIO_TOKEN = 1600
+    DEFAULT_STREAMING_AUDIO_CHUNK_SIZE = 50
+    DEFAULT_STREAMING_AUDIO_FRAME_RATE = 50
+    DEFAULT_STREAMING_AUDIO_CHUNK_MS = 1000
+    DEFAULT_STREAMING_AUDIO_FIRST_CHUNK_MS = 1035
+    FIRST_CHUNK_ALIGNMENT_MS = 35
+    RUNTIME_STREAMING_AUDIO_CHUNK_SIZE = "streaming_audio_chunk_size"
+    RUNTIME_STREAMING_AUDIO_FRAME_RATE = "streaming_audio_frame_rate"
+    RUNTIME_STREAMING_AUDIO_CHUNK_MS = "streaming_audio_chunk_ms"
+    RUNTIME_STREAMING_AUDIO_FIRST_CHUNK_MS = "streaming_audio_first_chunk_ms"
+    RUNTIME_STREAMING_AUDIO_CHUNK_SAMPLES = "streaming_audio_chunk_samples"
     # Vision framing contract (omni duplex). Official streaming_prefill feeds
     # each frame as <image> + 64 resampler embeddings + </image> inside the
     # unit, ahead of the unit's audio embeddings (max_slice_nums=1 in

--- a/vllm_omni/experimental/fullduplex/minicpmo45/runtime.py
+++ b/vllm_omni/experimental/fullduplex/minicpmo45/runtime.py
@@ -250,7 +250,7 @@ def _multimodal_output(output: object, completion: object | None) -> dict[str, A
     return dict(metadata) if isinstance(metadata, Mapping) else {}
 
 
-def _special_token_ids(metadata: dict[str, Any]) -> dict[str, int]:
+def _special_token_ids(metadata: Mapping[str, Any]) -> dict[str, int]:
     sources: list[object] = [metadata.get("special_token_ids"), metadata.get("meta")]
     sources.append(
         {
@@ -261,7 +261,7 @@ def _special_token_ids(metadata: dict[str, Any]) -> dict[str, int]:
     )
     token_ids: dict[str, int] = {}
     for source in sources:
-        if not isinstance(source, dict):
+        if not isinstance(source, Mapping):
             continue
         for key, value in source.items():
             if not isinstance(key, str) or not key.endswith("_token_id"):
@@ -272,9 +272,9 @@ def _special_token_ids(metadata: dict[str, Any]) -> dict[str, int]:
     return token_ids
 
 
-def _audio_encoder_latency_ms(metadata: dict[str, Any]) -> float | None:
+def _audio_encoder_latency_ms(metadata: Mapping[str, Any]) -> float | None:
     nested_meta = metadata.get("meta")
-    raw_latency = nested_meta.get("audio_encoder_latency_ms") if isinstance(nested_meta, dict) else None
+    raw_latency = nested_meta.get("audio_encoder_latency_ms") if isinstance(nested_meta, Mapping) else None
     if raw_latency is None:
         raw_latency = metadata.get("meta.audio_encoder_latency_ms")
     return _coerce_float(raw_latency)
@@ -372,9 +372,7 @@ class MiniCPMO45DuplexRuntimeExtension:
         # ``is_segment_finished`` marker in the processed output. Its sampled
         # listen token is still a Stage-0 control result and must not enter the
         # text-to-codec stages.
-        if stage_id >= final_stage_id or not (
-            segment_finished or bool(getattr(output, "finished", False))
-        ):
+        if stage_id >= final_stage_id or not (segment_finished or bool(getattr(output, "finished", False))):
             return None
 
         completion = _first_completion(output)

--- a/vllm_omni/experimental/fullduplex/minicpmo45/runtime.py
+++ b/vllm_omni/experimental/fullduplex/minicpmo45/runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from base64 import b64decode
 from binascii import Error as BinasciiError
+from collections.abc import Mapping
 from typing import Any
 
 from vllm.sampling_params import SamplingParams
@@ -16,9 +17,10 @@ from vllm_omni.experimental.fullduplex.engine.duplex_runtime import (
     DuplexOutputDecision,
 )
 from vllm_omni.experimental.fullduplex.engine.messages import DuplexFence
+from vllm_omni.experimental.fullduplex.minicpmo45.policy import MiniCPMO45DuplexPolicy
 
-_DUPLEX_CHUNK_SAMPLES = 16000
-_DUPLEX_SAMPLES_PER_AUDIO_TOKEN = 1600
+_DUPLEX_CHUNK_SAMPLES = MiniCPMO45DuplexPolicy.CHUNK_SAMPLES
+_DUPLEX_SAMPLES_PER_AUDIO_TOKEN = MiniCPMO45DuplexPolicy.SAMPLES_PER_AUDIO_TOKEN
 # <image> + 64 resampler embeddings + </image> per frame (max_slice_nums=1),
 # matching MiniCPMO45DuplexPolicy.VISION_TOKENS_PER_FRAME.
 _DUPLEX_VISION_TOKENS_PER_FRAME = 66
@@ -46,27 +48,48 @@ def _duplex_pcm_sample_count(payload: object) -> int | None:
     return len(raw) // 4
 
 
-def duplex_payload_is_exact_chunks(payload: object) -> bool:
-    sample_count = _duplex_pcm_sample_count(payload)
-    return bool(sample_count) and sample_count % _DUPLEX_CHUNK_SAMPLES == 0
+def _duplex_runtime_chunk_samples(runtime_config: object) -> int:
+    value = None
+    if isinstance(runtime_config, dict):
+        value = runtime_config.get(MiniCPMO45DuplexPolicy.RUNTIME_STREAMING_AUDIO_CHUNK_SAMPLES)
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return _DUPLEX_CHUNK_SAMPLES
+    return parsed if parsed > 0 else _DUPLEX_CHUNK_SAMPLES
 
 
-def duplex_first_append_unit_count(payload: object) -> int | None:
+def duplex_payload_is_exact_chunks(payload: object, *, chunk_samples: int = _DUPLEX_CHUNK_SAMPLES) -> bool:
     sample_count = _duplex_pcm_sample_count(payload)
-    if not sample_count or sample_count % _DUPLEX_CHUNK_SAMPLES != 0:
+    return bool(sample_count) and sample_count % chunk_samples == 0
+
+
+def duplex_first_append_unit_count(
+    payload: object,
+    *,
+    chunk_samples: int = _DUPLEX_CHUNK_SAMPLES,
+) -> int | None:
+    sample_count = _duplex_pcm_sample_count(payload)
+    if not sample_count or sample_count % chunk_samples != 0:
         return None
-    return max(1, sample_count // _DUPLEX_CHUNK_SAMPLES - 1)
+    return max(1, sample_count // chunk_samples - 1)
 
 
-def duplex_scheduler_token_budget(payload: object, *, default: int = 64) -> int:
+def duplex_scheduler_token_budget(
+    payload: object,
+    *,
+    default: int = 64,
+    chunk_samples: int = _DUPLEX_CHUNK_SAMPLES,
+) -> int:
     vision_tokens = _duplex_frame_count(payload) * _DUPLEX_VISION_TOKENS_PER_FRAME
     sample_count = _duplex_pcm_sample_count(payload)
     if sample_count is None:
         return max(1, int(default)) + vision_tokens
     sample_count = max(1, sample_count)
-    if sample_count % _DUPLEX_CHUNK_SAMPLES == 0:
-        units = sample_count // _DUPLEX_CHUNK_SAMPLES
-        return units * (2 + _DUPLEX_CHUNK_SAMPLES // _DUPLEX_SAMPLES_PER_AUDIO_TOKEN) + vision_tokens
+    if sample_count % chunk_samples == 0:
+        units = sample_count // chunk_samples
+        tokens_per_unit = 2 + chunk_samples // _DUPLEX_SAMPLES_PER_AUDIO_TOKEN
+        return units * tokens_per_unit + vision_tokens
     return max(16, min(768, sample_count // _DUPLEX_SAMPLES_PER_AUDIO_TOKEN + 8)) + vision_tokens
 
 
@@ -108,19 +131,24 @@ def build_duplex_data_plane_prompt(
     payload: object,
     final: bool,
 ) -> dict[str, Any]:
-    token_budget = duplex_scheduler_token_budget(payload)
+    chunk_samples = _duplex_runtime_chunk_samples(runtime_config)
+    tokens_per_unit = 2 + chunk_samples // _DUPLEX_SAMPLES_PER_AUDIO_TOKEN
+    token_budget = duplex_scheduler_token_budget(payload, chunk_samples=chunk_samples)
     if seq <= 1:
         context_reserve = duplex_first_append_context_reserve(runtime_config)
         token_budget += context_reserve
-        first_units = duplex_first_append_unit_count(payload)
+        first_units = duplex_first_append_unit_count(payload, chunk_samples=chunk_samples)
         if first_units is not None:
             token_budget = (
-                context_reserve + first_units * 12 - 1 + _duplex_frame_count(payload) * _DUPLEX_VISION_TOKENS_PER_FRAME
+                context_reserve
+                + first_units * tokens_per_unit
+                - 1
+                + _duplex_frame_count(payload) * _DUPLEX_VISION_TOKENS_PER_FRAME
             )
-    if seq > 1 and duplex_payload_is_exact_chunks(payload):
+    if seq > 1 and duplex_payload_is_exact_chunks(payload, chunk_samples=chunk_samples):
         token_budget += 1
-    if final and duplex_payload_is_exact_chunks(payload):
-        token_budget += 12
+    if final and duplex_payload_is_exact_chunks(payload, chunk_samples=chunk_samples):
+        token_budget += tokens_per_unit
     extra_body = session_config.get("extra_body")
     raw_token_id = runtime_config.get("duplex_scheduler_token_id")
     try:
@@ -177,6 +205,25 @@ def _coerce_int(value: object) -> int | None:
         return None
 
 
+def _coerce_float(value: object) -> float | None:
+    while isinstance(value, (list, tuple)):
+        if not value:
+            return None
+        value = value[-1]
+    if hasattr(value, "detach"):
+        try:
+            value = value.detach().cpu().reshape(-1)
+            if value.numel() == 0:
+                return None
+            value = value[-1].item()
+        except Exception:  # noqa: BLE001 - optional tensor metadata
+            return None
+    try:
+        return float(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
 def _coerce_int_list(value: object) -> list[int]:
     if value is None:
         return []
@@ -197,10 +244,10 @@ def _first_completion(output: object) -> object | None:
 
 def _multimodal_output(output: object, completion: object | None) -> dict[str, Any]:
     metadata = getattr(output, "multimodal_output", None)
-    if isinstance(metadata, dict):
-        return metadata
+    if isinstance(metadata, Mapping):
+        return dict(metadata)
     metadata = getattr(completion, "multimodal_output", None) if completion is not None else None
-    return metadata if isinstance(metadata, dict) else {}
+    return dict(metadata) if isinstance(metadata, Mapping) else {}
 
 
 def _special_token_ids(metadata: dict[str, Any]) -> dict[str, int]:
@@ -217,10 +264,20 @@ def _special_token_ids(metadata: dict[str, Any]) -> dict[str, int]:
         if not isinstance(source, dict):
             continue
         for key, value in source.items():
+            if not isinstance(key, str) or not key.endswith("_token_id"):
+                continue
             token_id = _coerce_int(value)
-            if isinstance(key, str) and token_id is not None and token_id >= 0:
+            if token_id is not None and token_id >= 0:
                 token_ids[key] = token_id
     return token_ids
+
+
+def _audio_encoder_latency_ms(metadata: dict[str, Any]) -> float | None:
+    nested_meta = metadata.get("meta")
+    raw_latency = nested_meta.get("audio_encoder_latency_ms") if isinstance(nested_meta, dict) else None
+    if raw_latency is None:
+        raw_latency = metadata.get("meta.audio_encoder_latency_ms")
+    return _coerce_float(raw_latency)
 
 
 def _completion_token_ids(completion: object | None) -> list[int]:
@@ -311,7 +368,13 @@ class MiniCPMO45DuplexRuntimeExtension:
         segment_output_metadata: dict[str, Any],
         output: object,
     ) -> DuplexOutputDecision | None:
-        if stage_id >= final_stage_id or not segment_finished:
+        # A final append can finish the resumable request without preserving an
+        # ``is_segment_finished`` marker in the processed output. Its sampled
+        # listen token is still a Stage-0 control result and must not enter the
+        # text-to-codec stages.
+        if stage_id >= final_stage_id or not (
+            segment_finished or bool(getattr(output, "finished", False))
+        ):
             return None
 
         completion = _first_completion(output)
@@ -328,6 +391,12 @@ class MiniCPMO45DuplexRuntimeExtension:
             return None
 
         metadata = dict(output_metadata)
+        audio_encoder_latency_ms = _audio_encoder_latency_ms(output_metadata)
+        if audio_encoder_latency_ms is None:
+            audio_encoder_latency_ms = _audio_encoder_latency_ms(segment_output_metadata)
+        if audio_encoder_latency_ms is not None:
+            metadata["audio_encoder_latency_ms"] = audio_encoder_latency_ms
+            metadata.pop("meta.audio_encoder_latency_ms", None)
         for key, value in special_token_ids.items():
             metadata.setdefault(f"meta.{key}", value)
         metadata.update(

--- a/vllm_omni/experimental/fullduplex/minicpmo45/serving_adapter.py
+++ b/vllm_omni/experimental/fullduplex/minicpmo45/serving_adapter.py
@@ -48,8 +48,16 @@ class MiniCPMO45ServingRuntimeAdapter:
         return MiniCPMO45NativeDuplexServingAdapter.is_enabled(config)  # type: ignore[arg-type]
 
     @staticmethod
-    def capabilities(*, max_sessions: int) -> DuplexCapabilities:
-        return DuplexCapabilities.minicpmo45_native(max_sessions=max_sessions)
+    def capabilities(
+        *,
+        max_sessions: int,
+        runtime_config: Mapping[str, object] | None = None,
+    ) -> DuplexCapabilities:
+        chunk_period_ms = MiniCPMO45NativeDuplexServingAdapter.runtime_streaming_audio_chunk_ms(runtime_config)
+        return DuplexCapabilities.minicpmo45_native(
+            max_sessions=max_sessions,
+            chunk_period_ms=chunk_period_ms,
+        )
 
     @staticmethod
     def validate_client_extra_body(extra_body: object) -> None:

--- a/vllm_omni/experimental/fullduplex/minicpmo45/serving_adapter.py
+++ b/vllm_omni/experimental/fullduplex/minicpmo45/serving_adapter.py
@@ -51,7 +51,16 @@ class MiniCPMO45ServingRuntimeAdapter:
     def capabilities(
         *,
         max_sessions: int,
-        runtime_config: Mapping[str, object] | None = None,
+    ) -> DuplexCapabilities:
+        return DuplexCapabilities.minicpmo45_native(
+            max_sessions=max_sessions,
+        )
+
+    @staticmethod
+    def capabilities_with_runtime_config_v1(
+        *,
+        max_sessions: int,
+        runtime_config: Mapping[str, object],
     ) -> DuplexCapabilities:
         chunk_period_ms = MiniCPMO45NativeDuplexServingAdapter.runtime_streaming_audio_chunk_ms(runtime_config)
         return DuplexCapabilities.minicpmo45_native(

--- a/vllm_omni/experimental/fullduplex/minicpmo45/stage0.py
+++ b/vllm_omni/experimental/fullduplex/minicpmo45/stage0.py
@@ -23,6 +23,8 @@ class _MiniCPMO45Stage0SessionState:
     streaming_processor: Any | None = None
     audio_buffer: np.ndarray = field(default_factory=lambda: np.array([], dtype=np.float32))
     audio_chunk_idx: int = 0
+    streaming_audio_chunk_ms: int | None = None
+    streaming_audio_first_chunk_ms: int | None = None
     context_embeds: list[Any] = field(default_factory=list)
     context_token_ids: list[int] = field(default_factory=list)
     current_turn_ended: bool = True
@@ -65,6 +67,44 @@ class MiniCPMO45Stage0DuplexRuntime:
     def _stage_runtime_ready(self) -> bool:
         return self.processor is not None and self.tokenizer is not None and self.thinker is not None
 
+    @staticmethod
+    def _apply_streaming_runtime_config(
+        state: _MiniCPMO45Stage0SessionState,
+        runtime_config: dict[str, Any],
+    ) -> None:
+        def positive_int(key: str, default: int) -> int:
+            try:
+                value = int(runtime_config.get(key, default))
+            except (TypeError, ValueError):
+                return default
+            return value if value > 0 else default
+
+        chunk_ms = positive_int(
+            MiniCPMO45DuplexPolicy.RUNTIME_STREAMING_AUDIO_CHUNK_MS,
+            MiniCPMO45DuplexPolicy.DEFAULT_STREAMING_AUDIO_CHUNK_MS,
+        )
+        first_chunk_ms = positive_int(
+            MiniCPMO45DuplexPolicy.RUNTIME_STREAMING_AUDIO_FIRST_CHUNK_MS,
+            chunk_ms + MiniCPMO45DuplexPolicy.FIRST_CHUNK_ALIGNMENT_MS,
+        )
+        state.streaming_audio_chunk_ms = chunk_ms
+        state.streaming_audio_first_chunk_ms = max(chunk_ms, first_chunk_ms)
+
+    def _session_chunk_ms(self, state: _MiniCPMO45Stage0SessionState | None) -> int:
+        if state is not None and state.streaming_audio_chunk_ms is not None:
+            return state.streaming_audio_chunk_ms
+        return int(self._stage_param("chunk_ms", MiniCPMO45DuplexPolicy.DEFAULT_STREAMING_AUDIO_CHUNK_MS))
+
+    def _session_first_chunk_ms(self, state: _MiniCPMO45Stage0SessionState | None) -> int:
+        if state is not None and state.streaming_audio_first_chunk_ms is not None:
+            return state.streaming_audio_first_chunk_ms
+        return int(
+            self._stage_param(
+                "first_chunk_ms",
+                MiniCPMO45DuplexPolicy.DEFAULT_STREAMING_AUDIO_FIRST_CHUNK_MS,
+            )
+        )
+
     def _configure_streaming_processor(
         self,
         state: _MiniCPMO45Stage0SessionState | None = None,
@@ -86,8 +126,8 @@ class MiniCPMO45Stage0DuplexRuntime:
         if callable(set_streaming_mode):
             set_streaming_mode(
                 mode="exact",
-                chunk_ms=int(self._stage_param("chunk_ms", 1000)),
-                first_chunk_ms=int(self._stage_param("first_chunk_ms", 1035)),
+                chunk_ms=self._session_chunk_ms(state),
+                first_chunk_ms=self._session_first_chunk_ms(state),
                 cnn_redundancy_ms=int(self._stage_param("cnn_redundancy_ms", 20)),
                 enable_sliding_window=True,
                 slide_trigger_seconds=30.0,
@@ -102,7 +142,7 @@ class MiniCPMO45Stage0DuplexRuntime:
         configure_streaming = getattr(processor, "configure_streaming", None)
         if callable(configure_streaming):
             configure_streaming(
-                chunk_ms=int(self._stage_param("chunk_ms", 1000)),
+                chunk_ms=self._session_chunk_ms(state),
                 enable_sliding_window=True,
                 slide_trigger_seconds=30.0,
                 slide_stride_seconds=10.0,
@@ -185,7 +225,7 @@ class MiniCPMO45Stage0DuplexRuntime:
             if frame_blocks is None or len(frame_blocks) != len(video_frames):
                 return self._stage_prefill_result(False, start_time, "streaming vision embedding failed")
         state.audio_buffer = np.concatenate([state.audio_buffer, np.asarray(audio_waveform, dtype=np.float32)])
-        chunk_size = self._streaming_chunk_size(processor)
+        chunk_size = self._streaming_chunk_size(processor, state=state)
         self._pad_first_audio_chunk_if_needed(state, processor)
         if len(state.audio_buffer) < chunk_size:
             return self._stage_prefill_result(
@@ -206,6 +246,7 @@ class MiniCPMO45Stage0DuplexRuntime:
         # pad again here: the first processor chunk is hop-aligned below 1035ms
         # and intentionally leaves a small carry that is not another model unit.
         units_built = 0
+        audio_encoder_cuda_timings: list[tuple[Any, Any]] = []
         while True:
             if len(state.audio_buffer) < chunk_size:
                 break
@@ -219,15 +260,21 @@ class MiniCPMO45Stage0DuplexRuntime:
             ):
                 with suppress(Exception):
                     setattr(batch_feature, name, value)
+            audio_encoder_timing = self._start_cuda_timing()
             audio_embeds = self._stage_audio_embeddings(batch_feature, state=state)
+            if audio_encoder_timing is not None:
+                audio_encoder_timing[1].record()
             if audio_embeds is None:
                 if units_built == 0:
                     return self._stage_prefill_result(False, start_time, "streaming audio embedding returned empty")
                 break
+            if audio_encoder_timing is not None:
+                audio_encoder_cuda_timings.append(audio_encoder_timing)
             consumed_samples = self._consumed_audio_samples(
                 state.audio_chunk_idx,
                 chunk_size,
                 processor=processor,
+                state=state,
             )
             if state.audio_chunk_idx > 0:
                 # Official duplex closes every unit (finalize_unit feeds the
@@ -263,7 +310,7 @@ class MiniCPMO45Stage0DuplexRuntime:
             state.audio_buffer = state.audio_buffer[consumed_samples:]
             state.audio_chunk_idx += 1
             units_built += 1
-            chunk_size = self._streaming_chunk_size(processor)
+            chunk_size = self._streaming_chunk_size(processor, state=state)
         if frame_blocks:
             # Each frame reserves one image block in the append plan. A frame
             # without a matching audio unit would desynchronize that plan.
@@ -294,6 +341,10 @@ class MiniCPMO45Stage0DuplexRuntime:
                 "runtime_impl": "scheduler_data_plane",
             }
         )
+        if audio_encoder_cuda_timings:
+            # The model wrapper consumes these events after the current forward.
+            # They never enter the request buffer or wire payload.
+            result["_audio_encoder_cuda_timings"] = audio_encoder_cuda_timings
         if is_speech and (append_identity is None or state.pending_speech_append_identity != append_identity):
             state.pending_speech_context = True
             state.pending_speech_append_identity = append_identity
@@ -301,8 +352,28 @@ class MiniCPMO45Stage0DuplexRuntime:
             state.prepared_append_identity = append_identity
             state.prepared_inputs_embeds = inputs_embeds
             state.prepared_input_token_ids = list(token_ids)
-            state.prepared_result = {k: v for k, v in result.items() if k not in {"inputs_embeds", "input_token_ids"}}
+            state.prepared_result = {
+                k: v
+                for k, v in result.items()
+                if k not in {"inputs_embeds", "input_token_ids", "_audio_encoder_cuda_timings"}
+            }
         return result
+
+    def _start_cuda_timing(self) -> tuple[Any, Any] | None:
+        import torch
+
+        if not torch.cuda.is_available():
+            return None
+        try:
+            model_device = torch.device(self._model_device())
+        except (AttributeError, RuntimeError, TypeError):
+            return None
+        if model_device.type != "cuda":
+            return None
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        return start, end
 
     @staticmethod
     def _stage_prefill_result(success: bool, start_time: float, reason: str = "") -> dict[str, Any]:
@@ -357,12 +428,17 @@ class MiniCPMO45Stage0DuplexRuntime:
             pass
         return self.device
 
-    def _streaming_chunk_size(self, processor: Any | None = None) -> int:
+    def _streaming_chunk_size(
+        self,
+        processor: Any | None = None,
+        *,
+        state: _MiniCPMO45Stage0SessionState | None = None,
+    ) -> int:
         processor = processor or self.processor
         get_chunk = getattr(processor, "get_streaming_chunk_size", None)
         if callable(get_chunk):
             return int(get_chunk())
-        return 16000
+        return max(1, self._session_chunk_ms(state) * self._sample_rate(processor) // 1000)
 
     def _sample_rate(self, processor: Any | None = None) -> int:
         processor = processor or self.processor
@@ -373,11 +449,17 @@ class MiniCPMO45Stage0DuplexRuntime:
             )
         )
 
-    def _first_chunk_samples(self, default_chunk_size: int, processor: Any | None = None) -> int:
+    def _first_chunk_samples(
+        self,
+        default_chunk_size: int,
+        processor: Any | None = None,
+        *,
+        state: _MiniCPMO45Stage0SessionState | None = None,
+    ) -> int:
         processor = processor or self.processor
         if getattr(processor, "_streaming_mel_processor", None) is None:
             return default_chunk_size
-        return int(self._stage_param("first_chunk_ms", 1035) * self._sample_rate(processor) / 1000)
+        return self._session_first_chunk_ms(state) * self._sample_rate(processor) // 1000
 
     def _pad_first_audio_chunk_if_needed(
         self,
@@ -387,8 +469,9 @@ class MiniCPMO45Stage0DuplexRuntime:
         if state.audio_chunk_idx != 0 or len(state.audio_buffer) == 0:
             return
         first_chunk_samples = self._first_chunk_samples(
-            self._streaming_chunk_size(processor),
+            self._streaming_chunk_size(processor, state=state),
             processor,
+            state=state,
         )
         if len(state.audio_buffer) >= first_chunk_samples:
             return
@@ -411,17 +494,18 @@ class MiniCPMO45Stage0DuplexRuntime:
         default_chunk_size: int,
         *,
         processor: Any | None = None,
+        state: _MiniCPMO45Stage0SessionState | None = None,
     ) -> int:
         processor = processor or self.processor
         if chunk_idx != 0:
-            chunk_ms = int(self._stage_param("chunk_ms", 1000))
+            chunk_ms = self._session_chunk_ms(state)
             return int(chunk_ms * self._sample_rate(processor) / 1000)
         mel_processor = getattr(processor, "_streaming_mel_processor", None)
         get_config = getattr(mel_processor, "get_config", None)
         if callable(get_config):
             cfg = get_config()
             if isinstance(cfg, dict):
-                consumed_ms = int(cfg.get("effective_first_chunk_ms", self._stage_param("first_chunk_ms", 1035)))
+                consumed_ms = int(cfg.get("effective_first_chunk_ms", self._session_first_chunk_ms(state)))
                 return int(consumed_ms * self._sample_rate(processor) / 1000)
         return default_chunk_size
 

--- a/vllm_omni/experimental/fullduplex/openai/protocol.py
+++ b/vllm_omni/experimental/fullduplex/openai/protocol.py
@@ -97,7 +97,14 @@ class DuplexCapabilities:
     target_barge_in_latency_ms: int | None = 1000
 
     @classmethod
-    def minicpmo45_native(cls, *, max_sessions: int = 1) -> DuplexCapabilities:
+    def minicpmo45_native(
+        cls,
+        *,
+        max_sessions: int = 1,
+        chunk_period_ms: int = 1000,
+    ) -> DuplexCapabilities:
+        if chunk_period_ms <= 0:
+            raise ValueError("MiniCPM-o native chunk_period_ms must be positive")
         supports_multi_session = max_sessions > 1
         return cls(
             supports_model_native_turn_policy=True,
@@ -128,7 +135,7 @@ class DuplexCapabilities:
             input_modes=["append_audio_chunk"],
             signal_sources=["model_native", "client_event", "server_policy"],
             stage_handoff_transport="scheduler_data_plane",
-            chunk_period_ms=1000,
+            chunk_period_ms=chunk_period_ms,
             target_barge_in_latency_ms=None,
         )
 

--- a/vllm_omni/experimental/fullduplex/openai/runtime_adapter.py
+++ b/vllm_omni/experimental/fullduplex/openai/runtime_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 from collections.abc import Awaitable, Callable, Iterable, Mapping, MutableMapping
 from importlib import import_module
 from typing import Any, Protocol
@@ -124,7 +125,6 @@ class ServingRuntimeAdapter(Protocol):
         self,
         *,
         max_sessions: int,
-        runtime_config: Mapping[str, object] | None = None,
     ) -> object: ...
 
     def validate_client_extra_body(self, extra_body: object) -> None: ...
@@ -162,6 +162,40 @@ def load_serving_runtime_adapter(
     return validate_serving_runtime_adapter(adapter_type(encode_audio))
 
 
+_RUNTIME_CAPABILITIES_HOOK = "capabilities_with_runtime_config_v1"
+
+
+def runtime_capabilities(
+    adapter: ServingRuntimeAdapter,
+    *,
+    max_sessions: int,
+    runtime_config: Mapping[str, object],
+) -> object:
+    """Return adapter capabilities without widening the legacy call contract."""
+    hook = getattr(adapter, _RUNTIME_CAPABILITIES_HOOK, None)
+    if hook is None:
+        return adapter.capabilities(max_sessions=max_sessions)
+    if not callable(hook):
+        raise TypeError(f"Duplex serving runtime adapter {_RUNTIME_CAPABILITIES_HOOK} must be callable")
+    return hook(max_sessions=max_sessions, runtime_config=runtime_config)
+
+
+def _validate_runtime_capabilities_hook(adapter: object) -> None:
+    hook = getattr(adapter, _RUNTIME_CAPABILITIES_HOOK, None)
+    if hook is None:
+        return
+    if not callable(hook):
+        raise TypeError(f"Duplex serving runtime adapter {_RUNTIME_CAPABILITIES_HOOK} must be callable")
+    try:
+        inspect.signature(hook).bind(max_sessions=1, runtime_config={})
+    except (TypeError, ValueError) as exc:
+        raise TypeError(
+            "Duplex serving runtime adapter "
+            f"{_RUNTIME_CAPABILITIES_HOOK} must accept keyword arguments "
+            "max_sessions and runtime_config"
+        ) from exc
+
+
 def validate_serving_runtime_adapter(adapter: object) -> ServingRuntimeAdapter:
     required_methods = (
         "create_session_state",
@@ -177,6 +211,7 @@ def validate_serving_runtime_adapter(adapter: object) -> ServingRuntimeAdapter:
     missing = [name for name in required_methods if not callable(getattr(adapter, name, None))]
     if missing:
         raise TypeError(f"Duplex serving runtime adapter is missing callable method(s): {', '.join(missing)}")
+    _validate_runtime_capabilities_hook(adapter)
     if not isinstance(getattr(adapter, "adapter_id", None), str) or not adapter.adapter_id:
         raise TypeError("Duplex serving runtime adapter must declare adapter_id")
     if not isinstance(getattr(adapter, "session_states", None), MutableMapping):

--- a/vllm_omni/experimental/fullduplex/openai/runtime_adapter.py
+++ b/vllm_omni/experimental/fullduplex/openai/runtime_adapter.py
@@ -120,7 +120,12 @@ class ServingRuntimeAdapter(Protocol):
 
     def is_enabled(self, config: object) -> bool: ...
 
-    def capabilities(self, *, max_sessions: int) -> object: ...
+    def capabilities(
+        self,
+        *,
+        max_sessions: int,
+        runtime_config: Mapping[str, object] | None = None,
+    ) -> object: ...
 
     def validate_client_extra_body(self, extra_body: object) -> None: ...
 

--- a/vllm_omni/experimental/fullduplex/openai/serving.py
+++ b/vllm_omni/experimental/fullduplex/openai/serving.py
@@ -914,6 +914,7 @@ class OmniDuplexSessionHandler(
             session.replace_capabilities(
                 self._serving_runtime_adapter.capabilities(
                     max_sessions=self._duplex_session_config.max_sessions,
+                    runtime_config=runtime_config,
                 )
             )
             session.replace_runtime_config(runtime_config)

--- a/vllm_omni/experimental/fullduplex/openai/serving.py
+++ b/vllm_omni/experimental/fullduplex/openai/serving.py
@@ -44,6 +44,7 @@ from vllm_omni.experimental.fullduplex.openai.runtime_adapter import (
     ServingRuntimeConfigError,
     ServingRuntimeSessionState,
     load_serving_runtime_adapter,
+    runtime_capabilities,
     validate_serving_runtime_adapter,
 )
 from vllm_omni.experimental.fullduplex.openai.runtime_bridge import (
@@ -912,7 +913,8 @@ class OmniDuplexSessionHandler(
         session = self._registry.create(config=config, session_id=session_id)
         if use_native_runtime:
             session.replace_capabilities(
-                self._serving_runtime_adapter.capabilities(
+                runtime_capabilities(
+                    self._serving_runtime_adapter,
                     max_sessions=self._duplex_session_config.max_sessions,
                     runtime_config=runtime_config,
                 )

--- a/vllm_omni/experimental/fullduplex/personaplex/serving_adapter.py
+++ b/vllm_omni/experimental/fullduplex/personaplex/serving_adapter.py
@@ -105,7 +105,12 @@ class PersonaPlexServingRuntimeAdapter:
         return True
 
     @staticmethod
-    def capabilities(*, max_sessions: int) -> DuplexCapabilities:
+    def capabilities(
+        *,
+        max_sessions: int,
+        runtime_config: Mapping[str, object] | None = None,
+    ) -> DuplexCapabilities:
+        del runtime_config
         supports_multi_session = max_sessions > 1
         return DuplexCapabilities(
             supports_model_native_turn_policy=True,

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py
@@ -26,6 +26,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from vllm.config import VllmConfig
+from vllm.distributed.parallel_state import get_tp_group
 from vllm.logger import init_logger
 from vllm.model_executor.models.interfaces import SupportsMRoPE, SupportsMultiModal, SupportsPP
 from vllm.model_executor.models.utils import init_vllm_registered_model, maybe_prefix
@@ -641,7 +642,8 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
             return None
 
         timing_rows = [pending.pop(str(req_id), None) if isinstance(pending, dict) else None for req_id in req_ids]
-        if not any(timing_rows):
+        has_timing_rows = [timings is not None for timings in timing_rows]
+        if not any(has_timing_rows):
             return None
 
         # Synchronizing the last encoder event waits only for the measured
@@ -651,14 +653,39 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
             if timings:
                 timings[-1][1].synchronize()
 
-        latency_rows: list[torch.Tensor | None] = []
+        local_latency_ms: list[float] = []
         for timings in timing_rows:
             if not timings:
-                latency_rows.append(None)
+                local_latency_ms.append(0.0)
                 continue
-            latency_ms = sum(float(start.elapsed_time(end)) for start, end in timings)
-            latency_rows.append(torch.tensor([latency_ms], dtype=torch.float64))
+            local_latency_ms.append(sum(float(start.elapsed_time(end)) for start, end in timings))
+
+        # Every TP rank reduces the same request rows. A zero preserves a rank
+        # without local events while MAX reports the encoder critical path.
+        latency_ms = self._max_reduce_audio_encoder_latency_ms(local_latency_ms)
+        latency_rows = [
+            torch.tensor([value], dtype=torch.float64) if has_timings else None
+            for value, has_timings in zip(latency_ms, has_timing_rows, strict=True)
+        ]
         return {"meta": {"audio_encoder_latency_ms": latency_rows}}
+
+    @staticmethod
+    def _max_reduce_audio_encoder_latency_ms(local_latency_ms: list[float]) -> list[float]:
+        tp_group = get_tp_group()
+        if tp_group.world_size <= 1:
+            return local_latency_ms
+
+        latency_tensor = torch.tensor(
+            local_latency_ms,
+            dtype=torch.float64,
+            device=current_omni_platform.get_torch_device(),
+        )
+        torch.distributed.all_reduce(
+            latency_tensor,
+            op=torch.distributed.ReduceOp.MAX,
+            group=tp_group.device_group,
+        )
+        return latency_tensor.cpu().tolist()
 
     def make_omni_output(self, model_outputs, **kwargs):
         if self.model_stage != "tts":

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py
@@ -350,6 +350,7 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
             runtime_config = dict(runtime_config) if isinstance(runtime_config, dict) else {}
             if hasattr(helper.thinker, "audio_past_key_values"):
                 helper.thinker.audio_past_key_values = None
+            helper._apply_streaming_runtime_config(state, runtime_config)
             helper._configure_streaming_processor(state)
             helper._prepare_session_context(state, session_config, runtime_config=runtime_config)
 
@@ -378,6 +379,14 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
             is_speech=bool(payload.get("is_speech", False)),
             final=bool(duplex.get("final")),
         )
+        audio_encoder_cuda_timings = result.pop("_audio_encoder_cuda_timings", None)
+        request_id = kwargs.get("request_id")
+        if isinstance(request_id, str) and audio_encoder_cuda_timings:
+            pending = getattr(self, "_minicpmo45_pending_audio_encoder_timings", None)
+            if not isinstance(pending, dict):
+                pending = {}
+                self._minicpmo45_pending_audio_encoder_timings = pending
+            pending.setdefault(request_id, []).extend(audio_encoder_cuda_timings)
         update_result = dict(result)
         update_result.pop("inputs_embeds", None)
         if result.get("success") is not True:
@@ -607,6 +616,7 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
                         ]
                         for key in sorted(special_keys)
                     }
+
             return OmniOutput(
                 text_hidden_states=text_hidden_states,
                 multimodal_outputs=multimodal_outputs,
@@ -624,6 +634,31 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
             )
 
         raise ValueError(f"Unsupported model stage: {self.model_stage}")
+
+    def flush_pending_metadata(self, req_ids: list[str]) -> dict[str, object] | None:
+        pending = getattr(self, "_minicpmo45_pending_audio_encoder_timings", None)
+        if self.model_stage != "llm":
+            return None
+
+        timing_rows = [pending.pop(str(req_id), None) if isinstance(pending, dict) else None for req_id in req_ids]
+        if not any(timing_rows):
+            return None
+
+        # Synchronizing the last encoder event waits only for the measured
+        # encoder work. The subsequent LLM forward has already been enqueued on
+        # the same stream, so this does not add a device-wide synchronization.
+        for timings in timing_rows:
+            if timings:
+                timings[-1][1].synchronize()
+
+        latency_rows: list[torch.Tensor | None] = []
+        for timings in timing_rows:
+            if not timings:
+                latency_rows.append(None)
+                continue
+            latency_ms = sum(float(start.elapsed_time(end)) for start, end in timings)
+            latency_rows.append(torch.tensor([latency_ms], dtype=torch.float64))
+        return {"meta": {"audio_encoder_latency_ms": latency_rows}}
 
     def make_omni_output(self, model_outputs, **kwargs):
         if self.model_stage != "tts":
@@ -647,6 +682,10 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
                 session_key = request_sessions.pop(request_id, None)
                 if session_key is not None and isinstance(sessions, dict):
                     sessions.pop(session_key, None)
+        pending_timings = getattr(self, "_minicpmo45_pending_audio_encoder_timings", None)
+        if isinstance(pending_timings, dict):
+            for request_id in finished_req_ids:
+                pending_timings.pop(request_id, None)
         forced_segments = getattr(self, "_minicpmo45_force_listen_applied_segments", None)
         if isinstance(forced_segments, set):
             finished = set(finished_req_ids)

--- a/vllm_omni/utils/mm_outputs.py
+++ b/vllm_omni/utils/mm_outputs.py
@@ -28,6 +28,7 @@ _CLIENT_MM_ROOT_KEYS: frozenset[str] = frozenset(
 
 _CLIENT_MM_META_KEYS: frozenset[str] = frozenset(
     {
+        "audio_encoder_latency_ms",
         "audio_text_total_chars",
         "duplex_epoch",
         "duplex_turn_id",

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -46,6 +46,7 @@ from vllm_omni.experimental.fullduplex.model_executor import DuplexSamplingRunne
 from vllm_omni.outputs import OmniModelRunnerOutput
 from vllm_omni.utils.mm_outputs import (
     build_mm_cpu,
+    partition_flat_payload,
     partition_payload_list,
     snapshot_mm_payload,
 )
@@ -450,6 +451,22 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
             downstream_req_ids = req_ids_output_copy
         return engine_output_type, downstream_req_ids
 
+    @staticmethod
+    def _merge_pending_multimodal_metadata(
+        multimodal_outputs: Any,
+        pending_metadata: object,
+    ) -> Any:
+        """Merge metadata finalized after forward into the current output."""
+        if not isinstance(pending_metadata, dict) or not pending_metadata:
+            return multimodal_outputs
+        merged = dict(multimodal_outputs) if isinstance(multimodal_outputs, dict) else {}
+        for key, value in pending_metadata.items():
+            if isinstance(value, dict) and isinstance(merged.get(key), dict):
+                merged[key] = {**merged[key], **value}
+            else:
+                merged[key] = value
+        return merged
+
     def capture_model(self) -> int:
         result = super().capture_model()
         self._capture_talker_mtp_graphs()
@@ -796,6 +813,12 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
         )
         return hidden_states_cpu, combined_hidden_states, combined_multimodal_outputs
 
+    @staticmethod
+    def _build_current_client_mm_cpu(multimodal_outputs: Any) -> dict[str, object] | None:
+        if not multimodal_outputs:
+            return None
+        _, client_payload = partition_flat_payload(flatten_payload(multimodal_outputs))
+        return build_mm_cpu(client_payload) or None
     def _build_omni_pooler_payload(
         self,
         *,
@@ -1185,6 +1208,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
         # When spec decode is enabled, defer connector finalization
         # (wait_for_save + clear metadata) until after draft model runs.
         defer_kv_connector_finalize = self.speculative_config is not None
+        pending_multimodal_metadata = None
         try:
             with (
                 nullcontext(),
@@ -1215,10 +1239,11 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
                     sampler=self.sampler,
                 )
 
-                # [Omni] Map pending ropes metadata to req_ids.
+                # [Omni] Finalize model metadata that depends on current-step
+                # CUDA work, then attach it to this step's output below.
                 flush_pending_metadata = getattr(self.model, "flush_pending_metadata", None)
                 if callable(flush_pending_metadata):
-                    flush_pending_metadata(req_ids[:num_reqs])
+                    pending_multimodal_metadata = flush_pending_metadata(req_ids[:num_reqs])
 
                 # [Omni] Hand the model the batch's req_ids in logits order, for
                 # models that gate logits per request. Only valid without spec
@@ -1247,6 +1272,10 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
                 multimodal_outputs = None
             else:
                 hidden_states, multimodal_outputs = self.extract_multimodal_outputs(model_output)
+                multimodal_outputs = self._merge_pending_multimodal_metadata(
+                    multimodal_outputs,
+                    pending_multimodal_metadata,
+                )
             hidden_states_cpu = None
 
             # Async-write pipeline (replaces the per-step blocking
@@ -1544,6 +1573,8 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
     def _build_multimodal_outputs(
         self,
         per_req_payloads: list[dict[str, object] | None] | None,
+        *,
+        allow_text_output: bool = False,
     ) -> list[dict[str, torch.Tensor] | None] | None:
         """Build per-request multimodal output payloads (dedicated channel).
 
@@ -1556,7 +1587,10 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
         converted is dropped.
         """
         if self.vllm_config.model_config.engine_output_type == "text":
-            return None
+            if not allow_text_output:
+                return None
+            _, client_payloads = partition_payload_list([payload or {} for payload in per_req_payloads or []])
+            per_req_payloads = client_payloads
         if per_req_payloads is None:
             return None
         wire_payloads: list[dict[str, torch.Tensor] | None] = []
@@ -1640,9 +1674,14 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
             # Nothing from an intermediate stage needs to cross the worker/core
             # boundary on each decode step.
             return None, None
-        inter_stage_outputs = self._build_multimodal_outputs(pooler_inter)
+        inter_stage_outputs = self._build_multimodal_outputs(
+            pooler_inter,
+            allow_text_output=pooler_client is pooler_inter,
+        )
         multimodal_outputs = (
-            inter_stage_outputs if pooler_client is pooler_inter else self._build_multimodal_outputs(pooler_client)
+            inter_stage_outputs
+            if pooler_client is pooler_inter
+            else self._build_multimodal_outputs(pooler_client, allow_text_output=True)
         )
         return inter_stage_outputs, multimodal_outputs
 
@@ -1852,7 +1891,9 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
             hidden_seq_len = int(hidden_states.shape[0])
             scheduled_seq_len = int(scheduler_output.total_num_scheduled_tokens)
             mm_cpu = None
+            current_client_mm_cpu = None
             if self.omni_prefix_cache is not None:
+                current_client_mm_cpu = self._build_current_client_mm_cpu(multimodal_outputs)
                 (
                     hidden_states_cpu,
                     combined_hidden_states,
@@ -1912,6 +1953,21 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
                         hidden_seq_len=hidden_seq_len,
                         scheduled_seq_len=scheduled_seq_len,
                     )
+                    if current_client_mm_cpu:
+                        payload.update(
+                            build_omni_mm_payload(
+                                combined_multimodal_outputs=None,
+                                mm_cpu=current_client_mm_cpu,
+                                rid=rid,
+                                idx=idx,
+                                start=start,
+                                end=end,
+                                audio_sparse_output=audio_sparse_output,
+                                sparse_mm_index=sparse_mm_index,
+                                hidden_seq_len=hidden_seq_len,
+                                scheduled_seq_len=scheduled_seq_len,
+                            )
+                        )
                     pooler_output.append(flatten_payload(payload))
 
         pooler_output = pooler_output or []

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -819,6 +819,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
             return None
         _, client_payload = partition_flat_payload(flatten_payload(multimodal_outputs))
         return build_mm_cpu(client_payload) or None
+
     def _build_omni_pooler_payload(
         self,
         *,


### PR DESCRIPTION
Part of #5069

## Summary

- Wire `streaming_audio_chunk_size` from the MiniCPM-o config into the existing native full-duplex session path.
- Keep the released-model default at 50 frames / 1000 ms; a 25-frame probe configuration advertises and schedules 500 ms input units.
- Preserve append ordering, residual padding, per-session Stage 0 state, and model-owned `listen` handling without adding a serving path.
- Measure each audio-encoder invocation with CUDA events and expose the positive scalar latency as `response.metadata.vllm_omni.stage_metrics["0"].audio_encoder_latency_ms` without leaking the internal tensor payload.

## Live acceptance

Both probes used the native duplex Realtime endpoint, two 600 ms PCM16 appends, `commit(final=true)`, a post-tail heartbeat, and a final `/health` check.

| Configuration | Chunk period | Listen units | Stage 0 TTFT (ms) | Encoder latency (ms) | GPU0 peak | GPU1 peak |
| --- | ---: | ---: | --- | --- | ---: | ---: |
| 25-frame probe | 500 ms | 3 | 554.51, 579.63, 604.81 | 25.879, 10.154, 7.527 | 26183 MiB | 22574 MiB |
| Released default | 1000 ms | 2 | 594.68, 616.92 | 29.803, 10.048 | 26185 MiB | 22574 MiB |

- Every `response.listen` contained a positive `audio_encoder_latency_ms` under Stage 0 metrics.
- No client event contained the internal `meta.audio_encoder_latency_ms` tensor key.
- Heartbeat acknowledgement and `/health=200` passed after both probes.
- Both probes started from 26181 MiB on GPU0 and 22574 MiB on GPU1; request-window peaks were +2/+0 MiB for 500 ms and +4/+0 MiB for 1000 ms.
- Server logs contained no traceback, engine-dead, OOM, or error entries during either acceptance run.

## Regression coverage

- Full duplex handler regression: `204 passed, 16 warnings`.
- Earlier focused CUDA suite: `307 passed, 16 warnings`.
- Ruff and format checks pass for the final core-code delta.
- DCO passes. The current Read the Docs status fails before project installation: its PyTorch CPU-index bootstrap cannot resolve `flit_core` while building `typing-extensions`; no PR code or docs build command is reached.

Tests, probe scripts, machine-specific logs, and branch-sync archives are intentionally excluded from this PR.
