### PR TITLE
[Bugfix] Fix diffusion TTS adapter lookup in speech serving

### DIFF
--- a/tests/entrypoints/openai_api/test_serving_speech.py
+++ b/tests/entrypoints/openai_api/test_serving_speech.py
@@ -737,6 +737,19 @@ class TestTTSMethods:
         yield server
         server.shutdown()
 
+    def test_diffusion_audio_encode_speed_skips_ar_adapter(self, mocker: MockerFixture):
+        """Pure-diffusion speech keeps generic speed handling outside AR adapters."""
+        server = OmniOpenAIServingSpeech.for_diffusion(
+            diffusion_engine=mocker.MagicMock(),
+            model_name="test-model",
+        )
+        resolve_adapter = mocker.patch.object(serving_speech_module, "resolve_adapter")
+
+        speed = server._audio_encode_speed(OpenAICreateSpeechRequest(input="Hello", speed=1.25))
+
+        assert speed == 1.25
+        resolve_adapter.assert_not_called()
+
     def test_is_tts_detection_no_stage(self, speech_server):
         """Test TTS model detection when no TTS stage exists."""
         # Fixture creates server with stage_configs = [] -> _is_tts should be False

--- a/tests/entrypoints/openai_api/test_serving_speech.py
+++ b/tests/entrypoints/openai_api/test_serving_speech.py
@@ -680,7 +680,7 @@ class TestSpeechAPI:
 
     @pytest.mark.asyncio
     async def test_create_diffusion_speech_extra_params(self, mocker: MockerFixture):
-        """Test that extra_params are correctly applied to sampling_params_list in diffusion mode."""
+        """Test public diffusion speech success and extra_params propagation."""
         # Mock the engine client
         mock_engine = mocker.MagicMock()
 
@@ -704,7 +704,11 @@ class TestSpeechAPI:
 
         req = OpenAICreateSpeechRequest(input="Hello", extra_params={"new_arg": 123, "existing_arg": "new_value"})
 
-        await server._create_diffusion_speech(req)
+        response = await server.create_speech(req)
+
+        assert response.status_code == 200
+        assert response.media_type == "audio/wav"
+        assert response.body == b"dummy"
 
         # Verify generate was called
         mock_engine.generate.assert_called_once()

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -502,11 +502,17 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
     def _get_tts_adapter(self):
         """Return the per-model serving adapter for the current ``_tts_model_type``.
 
+        Pure-diffusion speech uses its dedicated request path and does not
+        resolve adapters for AR-stage TTS models.
+
         Resolved lazily (rebuilt if ``_tts_model_type`` changed since the cached
         instance was built) so callers that set ``_tts_model_type`` after
         construction still dispatch to the matching adapter. In production
         ``_tts_model_type`` is fixed at init, so the cached instance is reused.
         """
+        if self._diffusion_mode:
+            return None
+
         adapter_cls = resolve_adapter(self._tts_model_type)
         if adapter_cls is None:
             self._adapter = None


### PR DESCRIPTION
## Purpose

Fixes #6118.

### What broke

Speech requests to pure-diffusion TTS models such as OmniVoice returned HTTP 500:

```text
Speech generation failed: 'OmniOpenAIServingSpeech' object has no attribute '_adapter'
```

### Reproduction

Start an OmniVoice server:

```bash
vllm serve k2-fsa/OmniVoice --omni --port 8091 --trust-remote-code
```

Then send a text-only speech request:

```bash
python examples/online_serving/text_to_speech/omnivoice/speech_client.py \
  --api-base http://localhost:8091/v1 \
  --text "Hello, how are you?"
```

### Root cause

`OmniOpenAIServingSpeech.for_diffusion()` constructs the handler with `__new__`
and intentionally bypasses the regular initializer. The diffusion speech encoding
path recently started checking adapter-native speed control, which attempted to
resolve an AR-stage TTS adapter and read `_adapter` on this specialized instance.

### Fix

Keep pure-diffusion speech on its dedicated request path by returning no AR-stage
adapter before adapter resolution or AR engine state is accessed. Normal AR TTS
instances retain their existing adapter and native-speed behavior.

## Test Plan

- Regress diffusion speech speed handling at the adapter boundary.
- Exercise the public `create_speech()` handler path and assert HTTP 200,
  `audio/wav`, and the generated response body.
- Run the complete speech serving L1 CPU suite.
- Run the TTS adapter and model-detection L1 CPU suites.
- Run diff-scoped pre-submit checks and Ruff.

**vLLM Version:** `0.27.0`

**vLLM-Omni Commit:** `eb4b37922a7f33b20bbd6dbd1d204b5fb0b9864b`

Test environment: Python 3.12, PyTorch 2.12.1+cu126,
Transformers 5.15.0. Tests were CPU-only and did not allocate a GPU.

## Test Result

```text
tests/entrypoints/openai_api/test_serving_speech.py
214 passed, 15 warnings in 5.34s

tests/entrypoints/openai_api/test_tts_adapter.py
tests/entrypoints/openai_api/test_tts_detection.py
132 passed, 15 warnings in 3.05s

Focused #6118 regression tests
2 passed, 15 warnings in 3.04s

Ruff check: passed
Ruff format --check: passed
check_test_marks.py: passed
check_tts_adapter.py: passed
check_pickle_imports.py: passed
git diff --check: passed
```

A real-weight OmniVoice GPU E2E was not run. The failure occurs before model
inference in the speech request-routing/adapter boundary, and the regression is
covered deterministically by the L1 CPU tests above.
