### PR TITLE
[CI/Build] Bound OmniRunner teardown and clean up after a failed init

### DIFF
--- a/tests/helpers/deadline.py
+++ b/tests/helpers/deadline.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Bounded setup and teardown for fixtures that own a live engine.
+
+Tearing an engine down can block indefinitely: ``destroy_process_group()`` waits on
+peer ranks that a mid-initialization failure has already killed, and a stuck
+``close()`` carries no timeout of its own. A fixture that blocks there never returns
+control to pytest, so the run reports no failure at all and dies on the CI step
+timeout instead -- which hides the error that started it.
+
+Deliberately free of vllm imports so these can be unit tested without an accelerator.
+"""
+
+import threading
+from collections.abc import Callable
+from typing import TypeVar
+
+_T = TypeVar("_T")
+
+
+def run_with_deadline(
+    fn: Callable[[], None],
+    timeout: float,
+    label: str,
+    report: Callable[[str], None] = print,
+) -> bool:
+    """Run ``fn`` on a daemon thread, giving up the wait after ``timeout`` seconds.
+
+    Returns True when ``fn`` finished. On overrun the thread is left running: it is a
+    daemon, so it cannot hold the interpreter open, and the caller continues, because
+    the alternative is blocking forever. Exceptions are reported rather than raised --
+    a teardown failure must not replace the error that caused the teardown.
+    """
+    raised: list[BaseException] = []
+
+    def _run() -> None:
+        try:
+            fn()
+        except BaseException as exc:  # noqa: BLE001 - must not mask the original error
+            raised.append(exc)
+
+    thread = threading.Thread(target=_run, name=f"deadline-{label}", daemon=True)
+    thread.start()
+    thread.join(timeout)
+
+    if thread.is_alive():
+        report(f"{label} did not finish within {timeout:g}s; continuing without it")
+        return False
+    if raised:
+        report(f"{label} raised {raised[0]!r}; continuing")
+    return True
+
+
+def build_with_cleanup(
+    factory: Callable[[], _T],
+    cleanup: Callable[[], None],
+    report: Callable[[str], None] = print,
+) -> _T:
+    """Build via ``factory``, running ``cleanup`` if it raises, and re-raise regardless.
+
+    ``with Runner(...) as runner`` evaluates the constructor before ``__enter__``, so a
+    constructor that fails part-way never reaches ``__exit__`` and abandons whatever it
+    already started -- engine subprocesses among it, which the interpreter then joins at
+    exit. Callers that own that cleanup have to run it here instead.
+
+    A failure inside ``cleanup`` is reported and dropped: the build error is the one the
+    test author needs, and letting the cleanup error replace it hides the cause.
+    """
+    try:
+        return factory()
+    except BaseException:
+        try:
+            cleanup()
+        except BaseException as exc:  # noqa: BLE001 - must not mask the build error
+            report(f"cleanup after a failed build raised {exc!r}; continuing")
+        raise

--- a/tests/helpers/runtime.py
+++ b/tests/helpers/runtime.py
@@ -44,6 +44,7 @@ from tests.helpers.assertions import (
     assert_images_generations_response,
     assert_omni_response,
 )
+from tests.helpers.deadline import build_with_cleanup, run_with_deadline
 from tests.helpers.env import run_post_test_cleanup, run_pre_test_cleanup
 from tests.helpers.media import (
     _merge_base64_audio_to_segment,
@@ -56,6 +57,10 @@ from vllm_omni.outputs import OmniRequestOutput
 from vllm_omni.platforms import current_omni_platform
 
 logger = init_logger(__name__)
+
+# Ample for a healthy teardown (the psutil sweep alone allows 8s); this only bounds
+# the pathological case where close() or destroy_process_group() never returns.
+TEARDOWN_DEADLINE_S = 180.0
 
 
 def cleanup_dist_env_and_memory(shutdown_ray: bool = False):
@@ -2880,7 +2885,8 @@ class OmniRunner:
     def stop_profile(self, stages: list[int] | None = None) -> list[Any]:
         return self.omni.stop_profile(stages=stages)
 
-    def _cleanup_process(self):
+    @staticmethod
+    def _cleanup_process():
         try:
             keywords = ["enginecore"]
             matched = []
@@ -2918,13 +2924,29 @@ class OmniRunner:
     def __enter__(self):
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def _teardown(self) -> None:
         if hasattr(self.omni, "close"):
             self.omni.close()
         self._cleanup_process()
         run_pre_test_cleanup()
         run_post_test_cleanup()
         cleanup_dist_env_and_memory()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # close() and destroy_process_group() can both block indefinitely -- the latter
+        # waits on peer ranks a mid-init failure already killed. A fixture stuck in
+        # teardown reports no failure at all; the run dies on the CI step timeout instead.
+        run_with_deadline(self._teardown, TEARDOWN_DEADLINE_S, "OmniRunner teardown")
+
+
+def cleanup_after_failed_runner_init() -> None:
+    """Teardown for a runner whose constructor raised, so there is no instance to use.
+
+    Mirrors ``OmniRunner._teardown`` without the engine handle, which was never assigned.
+    """
+    OmniRunner._cleanup_process()
+    run_post_test_cleanup()
+    cleanup_dist_env_and_memory()
 
 
 class OmniRunnerHandler:
@@ -3237,7 +3259,16 @@ def iter_omni_runner(
         model = model_prefix + model
         if run_level == "core_model" and request.node.get_closest_marker("diffusion"):
             model = resolve_tiny_model_path(model)
-        with OmniRunner(model, seed=42, stage_configs_path=stage_config_path, **extra_omni_kwargs) as runner:
+        # Constructed before the ``with``, so a constructor failing part-way never reaches
+        # __exit__ and would abandon the engine subprocesses it already started -- which the
+        # interpreter then joins at exit, stalling the run with no failure reported.
+        runner = build_with_cleanup(
+            lambda: OmniRunner(model, seed=42, stage_configs_path=stage_config_path, **extra_omni_kwargs),
+            lambda: run_with_deadline(
+                cleanup_after_failed_runner_init, TEARDOWN_DEADLINE_S, "OmniRunner failed-init cleanup"
+            ),
+        )
+        with runner:
             print("OmniRunner started successfully")
             yield runner
             print("OmniRunner stopping...")

--- a/tests/helpers/tests/test_deadline.py
+++ b/tests/helpers/tests/test_deadline.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import threading
+import time
+
+import pytest
+
+from tests.helpers.deadline import build_with_cleanup, run_with_deadline
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_completed_work_reports_success():
+    done = []
+    assert run_with_deadline(lambda: done.append(True), timeout=5.0, label="fast", report=lambda _: None)
+    assert done == [True]
+
+
+def test_stuck_work_returns_instead_of_blocking():
+    release = threading.Event()
+    messages: list[str] = []
+
+    started = time.monotonic()
+    finished = run_with_deadline(release.wait, timeout=0.2, label="stuck", report=messages.append)
+    elapsed = time.monotonic() - started
+
+    # The point of the helper: a teardown that never returns must not hold the caller.
+    assert finished is False
+    assert elapsed < 3.0, elapsed
+    assert "did not finish within" in messages[0]
+    release.set()
+
+
+def test_raising_work_is_reported_not_propagated():
+    messages: list[str] = []
+
+    # A teardown failure must not replace the error that caused the teardown.
+    assert run_with_deadline(
+        lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+        timeout=5.0,
+        label="raising",
+        report=messages.append,
+    )
+    assert "boom" in messages[0]
+
+
+def test_failed_build_runs_cleanup_and_reraises():
+    cleaned = []
+
+    def factory():
+        raise OSError("Can't load image processor")
+
+    with pytest.raises(OSError, match="image processor"):
+        build_with_cleanup(factory, lambda: cleaned.append(True))
+
+    # Without this the constructor's half-built engine subprocesses are abandoned.
+    assert cleaned == [True]
+
+
+def test_successful_build_skips_cleanup():
+    cleaned = []
+    assert build_with_cleanup(lambda: "runner", lambda: cleaned.append(True)) == "runner"
+    assert cleaned == []
+
+
+def test_cleanup_failure_does_not_mask_the_build_error():
+    messages: list[str] = []
+
+    def cleanup():
+        raise RuntimeError("cleanup also broke")
+
+    # The build error is what the test author needs; a cleanup error must not replace it.
+    with pytest.raises(OSError, match="original"):
+        build_with_cleanup(lambda: (_ for _ in ()).throw(OSError("original")), cleanup, report=messages.append)
+
+    assert "cleanup also broke" in messages[0]


### PR DESCRIPTION
## Purpose

A test runner whose constructor fails skips its own teardown entirely, so the run stalls with no failure reported and dies on the CI step timeout instead.

`iter_omni_runner` builds the runner inside the `with` expression, and Python evaluates the constructor before `__enter__`. `OmniRunner.__init__` builds the engine eagerly (`self.omni = Omni(...)`), so when it raises, `__exit__` never runs: no `close()`, no `_cleanup_process()` sweep for residual `enginecore` processes, no `cleanup_dist_env_and_memory()`. The subprocesses the constructor already started are abandoned, and the interpreter joins those non-daemon children at exit. Observed on a Merge-tier build: the test errored at 3m30s on a model-asset load failure, then sat idle for 37 minutes until the 40-minute ceiling, recorded as `timed_out` with exit `-1` — so the real exception is visible only by reading the log. Separately, `__exit__` is unbounded even on the success path: `destroy_process_group()` waits on peer ranks a mid-init failure has already killed, and `close()` carries no timeout.

This PR:

- Adds `tests/helpers/deadline.py` with `run_with_deadline` (runs on a daemon thread, stops waiting after a deadline, reports rather than raises so a teardown failure cannot replace the error that caused it) and `build_with_cleanup` (runs cleanup when a constructor raises, then re-raises the original error). Both are free of vllm imports, so they are unit-testable without an accelerator.
- Runs `OmniRunner._teardown` under `TEARDOWN_DEADLINE_S` (180s — ample for a healthy teardown, whose psutil sweep alone allows 8s; it bounds only the pathological case).
- Runs the orphan sweep and device cleanup when construction fails, via `cleanup_after_failed_runner_init`.
- Makes `_cleanup_process` a `staticmethod`; it never used `self`, and the failed-init path has no instance.

Deliberately not included: raising Buildkite `timeout_in_minutes`, or wrapping pytest in a shell `timeout`. Both relabel the stall rather than fix it, and neither restores the cleanup that was skipped.

Backward compatibility: no test-facing API changes. `__exit__` runs the same steps in the same order, now under a deadline; the only new behaviour is cleanup on a path that previously ran none.

## Test Plan

**vLLM Version:** 0.26.0
**vLLM-Omni Commit:** 12f81681 (base)

- [x] `pytest tests/helpers/tests/test_deadline.py -v` — CPU only, no accelerator
- [x] `python -c "import tests.helpers.runtime"` — the changed module still imports
- [x] `pytest tests/e2e/offline_inference/test_bagel.py --collect-only` — the fixture path still collects
- [x] Mutation checks that the new tests are not vacuous, reverting each behaviour in turn:
  - [x] `thread.join()` with no timeout
  - [x] no cleanup when the constructor raises (current `main` behaviour)
  - [x] cleanup error propagating instead of the build error
- [x] `ruff check` + `ruff format --check` (v0.14.10, as pinned)

## Test Result

- `tests/helpers/tests/test_deadline.py` — **6 passed**
- `import tests.helpers.runtime` — clean; `TEARDOWN_DEADLINE_S = 180.0`
- `test_bagel.py --collect-only` — **2 tests collected**
- Mutation checks, each landing on its covering test:
  - `thread.join()` unbounded → pytest **hangs**, killed at a 30s ceiling (exit 124); restored, exit 0
  - no cleanup on failed construction → 2 tests fail
  - cleanup error replaces build error → 1 test fails
- Run on 2× RTX PRO 6000 with vLLM 0.26.0 (unit tests, import and collection checks) and on CPU locally

The first mutation is the point of the change: it reproduces this failure mode in miniature — a fixture that never returns, so pytest reports nothing — in 30 seconds without a GPU.

Not reproduced end to end: the original 37-minute stall needs an H100, BAGEL-7B, and the model fetch to fail again. The claim this PR defends is narrower and provable by reading the code — the failed-init path skips teardown, and `__exit__` has no upper bound.

Not a duplicate: no open PR touches `iter_omni_runner` or `OmniRunner` teardown, and no open issue covers a fixture stalling after a failed initialization. #5675 also edits `tests/helpers/`, but in `media.py`'s Whisper device selection — no overlap.

AI assistance was used for this change (log analysis, drafting and the mutation checks). I have reviewed every changed line and run the tests reported here.
