### PR TITLE
[Example][Lance] Drop removed nullify_stage_engine_defaults call

### DIFF
--- a/examples/offline_inference/lance/end2end.py
+++ b/examples/offline_inference/lance/end2end.py
@@ -82,9 +82,6 @@ def parse_args():
     # ``max_num_seqs=1`` …) are passed as flat kwargs to ``Omni`` below
     # and ``create_default_diffusion`` materializes the stage config.
 
-    from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
-
-    nullify_stage_engine_defaults(p)
     return p.parse_args()
 
 


### PR DESCRIPTION
## Problem
Running the Lance example on current main fails immediately, before the
model is even constructed:

    ImportError: cannot import name 'nullify_stage_engine_defaults'
    from 'vllm_omni.engine.arg_utils'

`examples/offline_inference/lance/end2end.py` imports and calls
`nullify_stage_engine_defaults`, but that helper was removed from
`arg_utils.py` when `TrackingArgumentParser` was integrated (#3369). The
example was never updated, so it raises `ImportError` at import time —
the Lance example is currently unusable on main for everyone.

## Fix
`TrackingArgumentParser` now nullifies stage-engine defaults
automatically, so the explicit call is redundant. Remove the dead import
and the call.

## Test
```
python examples/offline_inference/lance/end2end.py
--model bytedance-research/Lance --modality text2img
--prompts "a corgi astronaut on the moon, cinematic lighting, 4k"
--steps 30 --seed 42 --enable-cpu-offload --output out/
```

Previously died at import; now launches and runs to completion. Pure
example cleanup — no library/runtime code changed.