### PR TITLE
[CI/Build] Fix ReadTheDocs build under RTD's seeded pip 23.1

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -21,7 +21,9 @@ build:
       # 1 GB memory cap and time out the mkdocs build. `--index-url` replaces
       # PyPI rather than adding to it, so keep the resolve wheel-only: an sdist
       # fallback cannot reach its build dependencies from the PyTorch index.
-      - python -m pip install --only-binary=:all: --index-url https://download.pytorch.org/whl/cpu torch
+      # Quoted: `--only-binary=:all:` ends in a colon, which YAML would
+      # otherwise read as a mapping key rather than part of the command.
+      - "python -m pip install --only-binary=:all: --index-url https://download.pytorch.org/whl/cpu torch"
 
 mkdocs:
   configuration: mkdocs.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,10 +11,17 @@ build:
     post_checkout:
       - git fetch --unshallow || true
     pre_install:
+      # RTD seeds the venv with pip 23.1 and upgrades it only in the step after
+      # `pre_install`. pip < 23.2 compares distribution names unnormalised when
+      # reading PEP 658 metadata, so it rejects the `typing_extensions` wheel
+      # that torch requires as `typing-extensions`.
+      - python -m pip install --upgrade pip
       # Pre-install CPU torch so the subsequent `pip install .[docs]` does not
       # pull ~2 GB of CUDA 13 libs (cuBLAS/cuDNN/NCCL/...) that exceed RTD's
-      # 1 GB memory cap and time out the mkdocs build.
-      - python -m pip install --index-url https://download.pytorch.org/whl/cpu torch
+      # 1 GB memory cap and time out the mkdocs build. `--index-url` replaces
+      # PyPI rather than adding to it, so keep the resolve wheel-only: an sdist
+      # fallback cannot reach its build dependencies from the PyTorch index.
+      - python -m pip install --only-binary=:all: --index-url https://download.pytorch.org/whl/cpu torch
 
 mkdocs:
   configuration: mkdocs.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,18 +11,14 @@ build:
     post_checkout:
       - git fetch --unshallow || true
     pre_install:
-      # RTD seeds the venv with pip 23.1 and upgrades it only in the step after
-      # `pre_install`. pip < 23.2 compares distribution names unnormalised when
-      # reading PEP 658 metadata, so it rejects the `typing_extensions` wheel
-      # that torch requires as `typing-extensions`.
+      # `pre_install` runs before RTD upgrades pip, and the seeded pip 23.1
+      # rejects the `typing_extensions` wheel torch needs (fixed in pip 23.2).
       - python -m pip install --upgrade pip
       # Pre-install CPU torch so the subsequent `pip install .[docs]` does not
       # pull ~2 GB of CUDA 13 libs (cuBLAS/cuDNN/NCCL/...) that exceed RTD's
-      # 1 GB memory cap and time out the mkdocs build. `--index-url` replaces
-      # PyPI rather than adding to it, so keep the resolve wheel-only: an sdist
-      # fallback cannot reach its build dependencies from the PyTorch index.
-      # Quoted: `--only-binary=:all:` ends in a colon, which YAML would
-      # otherwise read as a mapping key rather than part of the command.
+      # 1 GB memory cap and time out the mkdocs build. Wheel-only: `--index-url`
+      # replaces PyPI, so an sdist fallback cannot reach its build deps. The
+      # quotes keep YAML from reading `:all:` as a mapping key.
       - "python -m pip install --only-binary=:all: --index-url https://download.pytorch.org/whl/cpu torch"
 
 mkdocs:


### PR DESCRIPTION
## Purpose

Fixes #6128.

The `docs/readthedocs.org:vllm-omni` check has failed on **every** build since 2026-08-12 19:20 UTC, `main` included, so the docs site no longer updates and every open PR carries a red check.

```text
Discarding .../typing_extensions-4.15.0-py3-none-any.whl
  (from https://download.pytorch.org/whl/cpu/typing-extensions/):
  Requested typing-extensions>=4.10.0 ... has inconsistent Name:
  expected 'typing-extensions', but metadata has 'typing_extensions'
  Downloading typing_extensions-4.15.0.tar.gz (109 kB)
      ERROR: Could not find a version that satisfies the requirement flit_core<4,>=3.11 (from versions: none)
```

Root cause, in four steps:

1. RTD runs `jobs.pre_install` **before** its own `pip install --upgrade pip setuptools`, so the CPU-torch pre-install runs under the virtualenv-seeded **pip 23.1**.
2. pip < 23.2 compares distribution names **unnormalised** on the PEP 658 metadata path — `prepare.py::_fetch_metadata_using_link_data_attr` does `if metadata_dist.raw_name != req.req.name`. `typing_extensions` ships `Name: typing_extensions`, `torch` requires it as `typing-extensions`, so every wheel is discarded. pip 23.2 canonicalises both sides.
3. `--index-url` **replaces** PyPI rather than adding to it, so the sdist fallback cannot reach its build dependency `flit_core` — hard failure.
4. The trigger is upstream of us: `download.pytorch.org/whl/cpu/typing-extensions/` now proxies `files.pythonhosted.org` **including sdists**. Before that pip had no sdist to fall back to and backtracked `torch` instead.

**The green builds were already degraded.** [Build 34038140](https://app.readthedocs.org/projects/vllm-omni/builds/34038140/), the last green one, discarded typing-extensions 4.15.0 / 4.14.0 / 4.12.2, backtracked `torch` through nine versions and settled on `torch-2.5.1+cpu typing-extensions-4.9.0` in 406 s — it only passed because those older mirrored wheels carry no PEP 658 sidecar, so the buggy check never ran. So this also un-pins the docs environment from a two-year-old torch.

### Why this fix

`--upgrade pip` is the actual fix — the pin is RTD's seeded pip, not the index URL. `--only-binary=:all:` is the guard: under a single index there is no working sdist fallback, so a source build is never the right answer here, and failing loudly beats silently backtracking to torch 2.5.1.

**Not taken:** `--extra-index-url https://pypi.org/simple` also turns the build green, but it pools PyPI into candidate selection. The moment PyPI's `torch` outranks the CPU index (`2.13.1 > 2.13.0+cpu` under PEP 440) the ~2 GB CUDA wheels come back — which is exactly what this line was added in #3762 to prevent.

## Test Plan

The change is to `.readthedocs.yml` itself, so the RTD check on this PR is the test. Locally I resolved the same command under a current pip against the live index:

```bash
pip install --dry-run --python-version 3.12 --platform manylinux_2_28_x86_64 \
  --only-binary=:all: --index-url https://download.pytorch.org/whl/cpu torch
```

**vLLM Version:** n/a (CI configuration only)

**vLLM-Omni Commit:** 12f8168176e1

## Test Result

- `pip 26.1.2`, unchanged index URL, wheel-only: resolves to **torch 2.13.0+cpu, typing_extensions 4.15.0**, zero discards — confirming the seeded pip is the fault and the index URL is fine.
- Cross-checked pip's source: `raw_name != req.req.name` in 23.1 / 23.1.2, `canonicalize_name(...) != canonicalize_name(...)` from 23.2 onward.
- `pre-commit run --files .readthedocs.yml`: all hooks pass.
- The RTD check on this PR: **green** ([build 34040124](https://app.readthedocs.org/projects/vllm-omni/builds/34040124/), 352 s), exercising the real path end to end:

```text
python -m pip install --upgrade pip
    Uninstalling pip-23.1:  Successfully installed pip-26.2.1
python -m pip install --only-binary=:all: --index-url https://download.pytorch.org/whl/cpu torch
    Successfully installed ... torch-2.13.0+cpu       # zero discards, no backtracking
python -m mkdocs build ...
    INFO - Documentation built in 203.22 seconds
```
