### PR TITLE
[Perf][MiniMax-H3] Add online FP8 path for video VAE decoder

### DIFF
--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_quantization.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_quantization.py
@@ -66,6 +66,47 @@ def _small_od_config():
     )
 
 
+class _VideoVAEBlockWithRenamedLinears(nn.Module):
+    def __init__(self, *, include_output: bool = True):
+        super().__init__()
+        self.attention = nn.Module()
+        self.attention.qkv_proj = nn.Linear(4, 12)
+        self.mlp = nn.Module()
+        self.mlp.gate_up_proj = nn.Linear(4, 8)
+        if include_output:
+            self.mlp.down_proj = nn.Linear(8, 4)
+
+
+def test_video_vae_discovers_transformer_linears_without_fixed_names():
+    from vllm_omni.diffusion.models.minimax_h3.vae import (
+        _discover_video_vae_transformer_linear_paths,
+    )
+
+    blocks = nn.ModuleList([_VideoVAEBlockWithRenamedLinears() for _ in range(2)])
+
+    assert _discover_video_vae_transformer_linear_paths(blocks) == (
+        "attention.qkv_proj",
+        "mlp.down_proj",
+        "mlp.gate_up_proj",
+    )
+
+
+def test_video_vae_rejects_inconsistent_transformer_linear_schemas():
+    from vllm_omni.diffusion.models.minimax_h3.vae import (
+        _discover_video_vae_transformer_linear_paths,
+    )
+
+    blocks = nn.ModuleList(
+        [
+            _VideoVAEBlockWithRenamedLinears(),
+            _VideoVAEBlockWithRenamedLinears(include_output=False),
+        ]
+    )
+
+    with pytest.raises(RuntimeError, match="Linear schemas differ"):
+        _discover_video_vae_transformer_linear_paths(blocks)
+
+
 def test_fp8_scope_and_prefix_propagation(monkeypatch):
     from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
     from vllm.model_executor.layers.quantization.fp8 import Fp8Config

--- a/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
+++ b/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
@@ -715,6 +715,10 @@ class MiniMaxH3Pipeline(
             os.path.join(model_path, "video_vae"),
             device=self.device,
             load_device=component_load_device,
+            quant_config=_resolve_component_quant_config(
+                od_config.quantization_config,
+                "video_vae",
+            ),
         )
         self.audio_vae = MiniMaxH3AudioVAE(
             os.path.join(model_path, "audio_vae"),

--- a/vllm_omni/diffusion/models/minimax_h3/vae.py
+++ b/vllm_omni/diffusion/models/minimax_h3/vae.py
@@ -14,6 +14,9 @@ import torch.distributed as dist
 import torch.nn as nn
 from PIL import Image
 from transformers.dynamic_module_utils import get_class_from_dynamic_module
+from vllm.logger import init_logger
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
 
 from vllm_omni.diffusion.distributed.autoencoders.distributed_vae_executor import (
     DistributedVaeMixin,
@@ -26,6 +29,121 @@ from .packed_tokens import minimax_h3_patchify_video_latent
 MINIMAX_H3_KEYFRAME_ENCODE_SEED = 42
 MINIMAX_H3_AUDIO_SAMPLE_RATE = 32000
 MINIMAX_H3_AUDIO_CHANNELS = 2
+
+logger = init_logger(__name__)
+
+# MiniMax-H3 always runs video-VAE decode under FP16 autocast. vLLM's scaled
+# FP8 GEMM requires a fused bias to match the output dtype, so construct the
+# replacement linears (and therefore their biases) in that compute dtype.
+_VIDEO_VAE_DECODE_DTYPE = torch.float16
+
+
+def _validate_video_vae_quant_config(
+    quant_config: QuantizationConfig | None,
+) -> None:
+    if quant_config is None:
+        return
+    if quant_config.get_name() != "fp8":
+        raise ValueError(
+            f"MiniMax H3 video VAE currently supports online FP8 quantization only, got {quant_config.get_name()!r}"
+        )
+    if bool(getattr(quant_config, "is_checkpoint_fp8_serialized", False)):
+        raise ValueError("MiniMax H3 video VAE does not have serialized FP8 weights; use online FP8 quantization")
+
+
+def _make_online_fp8_linear(
+    linear: nn.Linear,
+    quant_config: QuantizationConfig,
+    prefix: str,
+) -> ReplicatedLinear:
+    """Build an FP16-in/out online-FP8 linear from a loaded VAE linear."""
+    replacement = ReplicatedLinear(
+        linear.in_features,
+        linear.out_features,
+        bias=linear.bias is not None,
+        params_dtype=_VIDEO_VAE_DECODE_DTYPE,
+        quant_config=quant_config,
+        prefix=prefix,
+        return_bias=False,
+        disable_tp=True,
+    )
+
+    # The global diffusion dtype is BF16, but video-VAE decode runs in FP16.
+    method = replacement.quant_method
+    method.input_dtype = method.out_dtype = _VIDEO_VAE_DECODE_DTYPE
+    method.fp8_linear.config.input_dtype = _VIDEO_VAE_DECODE_DTYPE
+    method.fp8_linear.config.out_dtype = _VIDEO_VAE_DECODE_DTYPE
+
+    # Use vLLM's loaders so online FP8 finalizes each loaded weight once.
+    replacement.weight.weight_loader(replacement.weight, linear.weight.detach())
+    if linear.bias is not None:
+        replacement.bias.weight_loader(replacement.bias, linear.bias.detach())
+    return replacement
+
+
+def _discover_video_vae_transformer_linear_paths(
+    blocks: nn.ModuleList,
+) -> tuple[str, ...]:
+    """Discover the common plain-Linear schema used by every VAE block."""
+    if not blocks:
+        raise RuntimeError("MiniMax H3 video VAE decoder has no transformer blocks")
+
+    schemas = [
+        tuple(sorted(name for name, module in block.named_modules() if name and isinstance(module, nn.Linear)))
+        for block in blocks
+    ]
+    expected = schemas[0]
+    if not expected:
+        raise RuntimeError("MiniMax H3 video VAE TransformerBlocks expose no nn.Linear modules")
+
+    for block_index, schema in enumerate(schemas[1:], start=1):
+        if schema != expected:
+            raise RuntimeError(
+                "MiniMax H3 video VAE TransformerBlock Linear schemas differ: "
+                f"block 0 has {expected}, block {block_index} has {schema}"
+            )
+    return expected
+
+
+@torch.no_grad()
+def _quantize_video_vae_transformer_linears(
+    decoder: nn.Module,
+    quant_config: QuantizationConfig | None,
+) -> int:
+    """Replace the decoder TransformerBlock GEMMs with online-FP8 linears.
+
+    The checkpoint-owned VAE is constructed and loaded before Omni sees it, so
+    its projections are ordinary ``nn.Linear`` modules. Input/output
+    projections, convolutions, norms, and control flow retain checkpoint
+    precision.
+    """
+    _validate_video_vae_quant_config(quant_config)
+    if quant_config is None:
+        return 0
+
+    blocks = getattr(decoder, "transformer_blocks", None)
+    if not isinstance(blocks, nn.ModuleList):
+        raise RuntimeError("MiniMax H3 video VAE decoder does not expose transformer_blocks")
+    linear_paths = _discover_video_vae_transformer_linear_paths(blocks)
+
+    replaced = 0
+    for block_index, block in enumerate(blocks):
+        for relative_path in linear_paths:
+            linear = block.get_submodule(relative_path)
+
+            prefix = f"video_vae.model.decoder.transformer_blocks.{block_index}.{relative_path}"
+            block.set_submodule(
+                relative_path,
+                _make_online_fp8_linear(linear, quant_config, prefix),
+            )
+            replaced += 1
+
+    logger.info(
+        "MiniMax H3 video VAE online FP8 enabled for %d decoder TransformerBlock linears at paths %s.",
+        replaced,
+        linear_paths,
+    )
+    return replaced
 
 
 def _load_component_config(component_path: str) -> dict[str, Any]:
@@ -111,6 +229,7 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
         *,
         device: torch.device,
         load_device: torch.device | None = None,
+        quant_config: QuantizationConfig | None = None,
     ) -> None:
         super().__init__()
         self._device_target = device
@@ -124,6 +243,13 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
         # checkpoint through FP16; decode still runs under FP16 autocast.
         initial_device = load_device or device
         self.remote.eval().to(device=initial_device, dtype=torch.float32)
+        self.quant_config = quant_config
+        self.quantized_decoder_linear_count = 0
+        if quant_config is not None:
+            self.quantized_decoder_linear_count = _quantize_video_vae_transformer_linears(
+                self.remote.model.decoder,
+                quant_config,
+            )
         self._stager = None
         if initial_device.type == "cpu" and device.type not in ("cpu", "meta"):
             self._stager = PinnedModuleStager(


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
This PR builds on #5910, which has been merged.

## Summary

- Routes the `video_vae` component through the quantization configuration introduced by #5910.
- Applies online FP8 to 144 linear layers in the video VAE decoder TransformerBlocks:
  - `attn.to_qkv`
  - `attn.to_out`
  - `ff.w1`
  - `ff.w2`
- Keeps convolutions, norms, control flow, and input/output projections at their existing precision.
- Preserves the video VAE's FP16 input/output contract.
- Supports both single-GPU and 4-GPU VAE tile parallel execution.

## Benchmark

NVIDIA B300, 672×384, 4 seconds, 10 steps, eager mode.  
DiT and text encoder use FP8 in both cases; only the video VAE configuration changes.

| GPUs | Video VAE | Decode | E2E | Peak memory |
|---:|---|---:|---:|---:|
| 1 | Baseline | 1.205s | 4.988s | 72,278 MiB |
| 1 | Online FP8 | 1.104s | 4.874s | 66,602 MiB |
| 4 | Baseline | 0.367s | 2.203s | 71,686 MiB |
| 4 | Online FP8 | 0.343s | 2.183s | 66,214 MiB |

| GPUs | Decode improvement | E2E improvement | Memory reduction |
|---:|---:|---:|---:|
| 1 | 8.4% | 2.3% | 5,676 MiB |
| 4 | 6.7% | 0.9% | 5,472 MiB |

The 4-GPU case uses USP=4 and VAE tile parallel size 4. The VAE weights remain replicated across ranks, so FP8 reduces memory on every GPU.

## Quality

| Configuration | PSNR | SSIM |
|---|---:|---:|
| 1-GPU FP8 vs baseline | 46.55 dB | 0.98535 |
| 4-GPU FP8 vs baseline | 46.54 dB | 0.98530 |

Steady-state measurements exclude the first request because online FP8 kernel initialization adds cold-start overhead.

## Validation

- Single-GPU  
 
GPU |   | VAE Decode | E2E | Peak memory
-- | -- | -- | -- | --
1 | Baseline | 1.205s | 4.988s | 72,278 MiB
1 | FP8 + compile + stacked | 0.447s | 3.444s | 66,566 MiB

 
- 121 MiniMax-H3 contract and quantization tests passed.
- Formatting and pre-commit checks passed.
## Test Plan

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)

