### PR TITLE
[Bugfix] Bagel Packed Forward Refactor and Teacache CFG Bugfix

### DIFF
--- a/tests/diffusion/cache/test_cache_backends.py
+++ b/tests/diffusion/cache/test_cache_backends.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 """
 Unit tests for cache backends (cache-dit and teacache).
@@ -7,6 +7,7 @@ Unit tests for cache backends (cache-dit and teacache).
 This module tests the cache backend implementations:
 - CacheDiTBackend: cache-dit acceleration backend
 - TeaCacheBackend: TeaCache hook-based backend
+- TeaCacheHook skip / recompute decisions
 - Cache selector function: get_cache_backend
 - DiffusionCacheConfig: configuration dataclass
 """
@@ -16,6 +17,7 @@ from unittest.mock import Mock, patch
 
 import cache_dit
 import pytest
+import torch
 from cache_dit import ForwardPattern
 
 from vllm_omni.diffusion.cache.cachedit import (
@@ -27,6 +29,9 @@ from vllm_omni.diffusion.cache.cachedit import (
 from vllm_omni.diffusion.cache.magcache import MagCacheBackend
 from vllm_omni.diffusion.cache.selector import get_cache_backend
 from vllm_omni.diffusion.cache.teacache import TeaCacheBackend
+from vllm_omni.diffusion.cache.teacache.config import TeaCacheConfig
+from vllm_omni.diffusion.cache.teacache.hook import TeaCacheHook
+from vllm_omni.diffusion.cache.teacache.state import TeaCacheState
 from vllm_omni.diffusion.data import DiffusionCacheConfig
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
@@ -570,6 +575,43 @@ class TestTeaCacheBackend:
         # Test refresh
         backend.refresh(mock_pipeline, num_inference_steps=50)
         mock_registry.reset_hook.assert_called_once()
+
+
+class TestTeaCacheShouldCompute:
+    """Branch coverage for TeaCacheHook._should_compute_full_transformer.
+
+    Identity rescale (poly = x) and rel_l1_thresh=0.3 make L1 outcomes exact.
+    """
+
+    @staticmethod
+    def _hook() -> TeaCacheHook:
+        return TeaCacheHook(
+            TeaCacheConfig(
+                transformer_type="QwenImageTransformer2DModel",
+                rel_l1_thresh=0.3,
+                coefficients=[0.0, 0.0, 0.0, 1.0, 0.0],
+            )
+        )
+
+    @pytest.mark.parametrize(
+        ("cnt", "prev_shape", "curr_shape", "curr_scale", "accum", "expect_compute", "expect_accum"),
+        [
+            pytest.param(0, (4, 8), (2, 8), 1.0, 0.5, True, 0.0, id="first_step"),
+            pytest.param(1, None, (4, 8), 1.0, 0.2, True, 0.2, id="missing_previous"),
+            pytest.param(1, (4, 8), (2, 8), 1.0, 0.2, True, 0.0, id="shape_mismatch"),
+            pytest.param(1, (4, 8), (4, 8), 1.1, 0.25, True, 0.0, id="accum_crosses_threshold"),
+            pytest.param(1, (4, 8), (4, 8), 1.01, 0.25, False, pytest.approx(0.26, abs=1e-4), id="accum_stays_below"),
+        ],
+    )
+    def test_decision(self, cnt, prev_shape, curr_shape, curr_scale, accum, expect_compute, expect_accum):
+        state = TeaCacheState()
+        state.cnt = cnt
+        state.accumulated_rel_l1_distance = accum
+        state.previous_modulated_input = None if prev_shape is None else torch.ones(prev_shape)
+        current = torch.ones(curr_shape) * curr_scale
+
+        assert self._hook()._should_compute_full_transformer(state, current) is expect_compute
+        assert state.accumulated_rel_l1_distance == expect_accum
 
 
 class TestCacheSelector:

--- a/tests/diffusion/models/bagel/test_trajectory_recording.py
+++ b/tests/diffusion/models/bagel/test_trajectory_recording.py
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Unit tests for BAGEL trajectory recording in the denoising loop."""
 
-import types
 from dataclasses import dataclass
 
 import pytest
 import torch
-from pytest_mock import MockerFixture
+from torch import nn
 
 from vllm_omni.diffusion.models.bagel.bagel_transformer import (
     Bagel,
@@ -24,25 +23,17 @@ NUM_TIMESTEPS = 5
 EXPECTED_STEPS = NUM_TIMESTEPS - 1
 
 
-def _make_mock_bagel(mocker: MockerFixture):
-    """Create a mock Bagel with forward returning constant velocity."""
-    mock = mocker.MagicMock(spec=Bagel)
-    mock._sp_size = 1
-    # MagicMock would otherwise auto-return a truthy stub for this flag; pin it
-    # to the official BAGEL schedule convention (num_timesteps points).
-    mock._denoise_schedule_extra_step = False
+class _StubBagel(Bagel):
+    """CPU stand-in: stub ``forward``, inherit the rest of ``generate_image``."""
 
-    # forward returns a small constant velocity so x_t changes each step
-    def fake_forward(self, x_t, **kwargs):
-        return torch.ones_like(x_t) * 0.1
+    def __init__(self) -> None:
+        # Skip Bagel.__init__ (LLM/VAE). parallel_config=None => _sp_size == 1.
+        nn.Module.__init__(self)
+        self.parallel_config = None
 
-    mock.forward = types.MethodType(fake_forward, mock)
-    # _merge_naive_caches is called in the batched CFG path
-    mock._merge_naive_caches = types.MethodType(lambda self, caches: NaiveCache(1), mock)
-
-    # Bind the real generate_image to our mock
-    mock.generate_image = types.MethodType(Bagel.generate_image, mock)
-    return mock
+    def forward(self, x_t, **kwargs):
+        v = torch.ones_like(x_t) * 0.1
+        return [v] * len(kwargs["cfg_branch_pids"])
 
 
 def _make_generate_args(num_tokens=NUM_TOKENS, hidden_dim=HIDDEN_DIM, cfg=False):
@@ -79,9 +70,8 @@ def _make_generate_args(num_tokens=NUM_TOKENS, hidden_dim=HIDDEN_DIM, cfg=False)
 def bagel_and_args(
     request,
     monkeypatch: pytest.MonkeyPatch,
-    mocker: MockerFixture,
 ):
-    """Mock Bagel instance and generate_image arguments.
+    """Stub Bagel instance and generate_image arguments.
 
     Parametrized over CFG mode so every test runs on both the no-CFG
     and batched-CFG code paths.
@@ -91,7 +81,7 @@ def bagel_and_args(
         "vllm_omni.diffusion.models.bagel.bagel_transformer.get_classifier_free_guidance_world_size",
         lambda: 1,
     )
-    yield _make_mock_bagel(mocker), _make_generate_args(cfg=cfg)
+    yield _StubBagel(), _make_generate_args(cfg=cfg)
 
 
 class TestTrajectoryRecording:
@@ -242,13 +232,12 @@ class TestTrajectoryLogProbs:
     def bagel_scheduler_args(
         self,
         monkeypatch: pytest.MonkeyPatch,
-        mocker: MockerFixture,
     ):
         monkeypatch.setattr(
             "vllm_omni.diffusion.models.bagel.bagel_transformer.get_classifier_free_guidance_world_size",
             lambda: 1,
         )
-        yield _make_mock_bagel(mocker), _make_generate_args(), _MockScheduler()
+        yield _StubBagel(), _make_generate_args(), _MockScheduler()
 
     def test_log_probs_recorded_with_scheduler(self, bagel_scheduler_args):
         bagel, args, scheduler = bagel_scheduler_args

--- a/vllm_omni/diffusion/cache/teacache/extractors.py
+++ b/vllm_omni/diffusion/cache/teacache/extractors.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 """
 Model-specific extractors for TeaCache.
@@ -307,69 +307,101 @@ def extract_bagel_context(
     packed_vae_position_ids: torch.LongTensor,
     packed_text_ids: torch.LongTensor,
     packed_text_indexes: torch.LongTensor,
-    packed_position_ids: torch.LongTensor,
     packed_seqlens: torch.IntTensor,
-    past_key_values: Any,
+    cfg_branch_pids: list[torch.Tensor],
+    cfg_branch_caches: list[Any],
     **kwargs: Any,
 ) -> CacheContext:
+    """Extract cache context for Bagel's packed / single-branch ``forward``.
+
+    Mirrors ``Bagel.forward`` so TeaCache residuals match the packed query
+    sequence (including CFG packing). ``postprocess`` returns a list of
+    per-branch velocities, matching ``Bagel.forward``.
     """
-    Extract cache context for Bagel model.
+    from vllm_omni.diffusion.models.bagel.bagel_transformer import NaiveCache
 
-    Args:
-        module: Bagel instance
-        x_t: Latent image input
-        timestep: Current timestep
-        packed_vae_token_indexes: Indexes for VAE tokens in packed sequence
-        packed_vae_position_ids: Position IDs for VAE tokens
-        packed_text_ids: Text token IDs
-        packed_text_indexes: Indexes for text tokens in packed sequence
-        packed_position_ids: Global position IDs
-        packed_seqlens: Sequence lengths
-        past_key_values: KV cache
-        **kwargs: Additional keyword arguments
-
-    Returns:
-        CacheContext with all information needed for generic caching
-    """
-
-    # 1. Embed text
-    packed_text_embedding = module.language_model.model.embed_tokens(packed_text_ids)
-    packed_sequence = packed_text_embedding.new_zeros((sum(packed_seqlens), module.hidden_size))
-    packed_sequence[packed_text_indexes] = packed_text_embedding
-
-    # 2. Embed timestep
     if not isinstance(timestep, torch.Tensor):
         timestep = torch.tensor([timestep], device=x_t.device)
     if timestep.dim() == 0:
         timestep = timestep.unsqueeze(0)
 
-    # 3. Embed image (x_t)
+    num_branches = len(cfg_branch_pids)
+    packing = num_branches > 1
+    use_sp = getattr(module, "_sp_size", 1) > 1
+    branch_position_ids = cfg_branch_pids[0]
+    vae_per_branch = packed_vae_token_indexes.shape[0]
+
+    if use_sp:
+        if packing:
+            raise ValueError(
+                "Packed CFG + sequence parallel is not supported. "
+                "Run SP+CFG as sequential single-branch forwards (len(cfg_branch_pids)==1)."
+            )
+        (
+            x_t,
+            packed_vae_position_ids,
+            packed_vae_token_indexes,
+            packed_text_indexes,
+            packed_seqlens,
+            branch_position_ids,
+            timestep,
+        ) = module._split_vae_for_sp(
+            x_t,
+            packed_vae_position_ids,
+            packed_vae_token_indexes,
+            packed_text_indexes,
+            packed_seqlens,
+            branch_position_ids,
+            timestep,
+        )
+
+    packed_text_embedding = module.language_model.forward(
+        packed_text_ids=packed_text_ids,
+        return_embeddings_only=True,
+    ).packed_query_sequence
+    packed_sequence = packed_text_embedding.new_zeros((sum(packed_seqlens), module.hidden_size))
+    packed_sequence[packed_text_indexes] = packed_text_embedding
+
     packed_pos_embed = module.latent_pos_embed(packed_vae_position_ids)
     packed_timestep_embeds = module.time_embedder(timestep)
-
     x_t_emb = module.vae2llm(x_t) + packed_timestep_embeds + packed_pos_embed
     if x_t_emb.dtype != packed_sequence.dtype:
         x_t_emb = x_t_emb.to(packed_sequence.dtype)
-
     packed_sequence[packed_vae_token_indexes] = x_t_emb
 
-    # Use the full packed sequence as modulated input to match hidden_states size
-    modulated_input = packed_sequence
+    extra_inputs = {}
+    if module.use_moe:
+        extra_inputs = {
+            "mode": "gen",
+            "packed_vae_token_indexes": packed_vae_token_indexes,
+            "packed_text_indexes": packed_text_indexes,
+        }
+
+    if packing:
+        seq_len = int(packed_seqlens.sum())
+        packed_query_sequence = packed_sequence.repeat(num_branches, 1)
+        vae_indexes = torch.cat([packed_vae_token_indexes + i * seq_len for i in range(num_branches)])
+        query_position_ids = torch.cat(cfg_branch_pids, dim=1 if cfg_branch_pids[0].ndim == 2 else 0)
+        query_lens = packed_seqlens.repeat(num_branches)
+        cache = NaiveCache.merge(cfg_branch_caches)
+        if module.use_moe:
+            extra_inputs["packed_vae_token_indexes"] = vae_indexes
+            extra_inputs["packed_text_indexes"] = torch.cat(
+                [packed_text_indexes + i * seq_len for i in range(num_branches)]
+            )
+    else:
+        packed_query_sequence = packed_sequence
+        query_lens = packed_seqlens
+        query_position_ids = branch_position_ids
+        cache = cfg_branch_caches[0]
+        vae_indexes = packed_vae_token_indexes
 
     def run_transformer_blocks():
-        extra_inputs = {}
-        if module.use_moe:
-            extra_inputs = {
-                "mode": "gen",
-                "packed_vae_token_indexes": packed_vae_token_indexes,
-                "packed_text_indexes": packed_text_indexes,
-            }
-
         output = module.language_model.forward(
-            packed_query_sequence=packed_sequence,
-            query_lens=packed_seqlens,
-            packed_query_position_ids=packed_position_ids,
-            past_key_values=past_key_values,
+            packed_query_sequence=packed_query_sequence,
+            query_lens=query_lens,
+            packed_query_position_ids=query_position_ids,
+            past_key_values=cache,
             update_past_key_values=False,
             is_causal=False,
             **extra_inputs,
@@ -377,15 +409,18 @@ def extract_bagel_context(
         return (output.packed_query_sequence,)
 
     def postprocess(h):
-        v_t = module.llm2vae(h)
-        v_t = v_t[packed_vae_token_indexes]
-        return v_t
+        v_t = module.llm2vae(h)[vae_indexes]
+        if packing:
+            return list(v_t.split(vae_per_branch))
+        if use_sp:
+            v_t = module._gather_vae_for_sp(v_t)
+        return [v_t]
 
     return CacheContext(
-        modulated_input=modulated_input,
-        hidden_states=packed_sequence,  # Use full packed sequence
+        modulated_input=packed_query_sequence,
+        hidden_states=packed_query_sequence,
         encoder_hidden_states=None,
-        temb=packed_timestep_embeds,  # Approximate
+        temb=packed_timestep_embeds,
         run_transformer_blocks=run_transformer_blocks,
         postprocess=postprocess,
     )

--- a/vllm_omni/diffusion/cache/teacache/hook.py
+++ b/vllm_omni/diffusion/cache/teacache/hook.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 """
 Hook-based TeaCache implementation for vLLM-Omni.
@@ -214,6 +214,12 @@ class TeaCacheHook(ModelHook):
 
         # Need previous input for comparison
         if state.previous_modulated_input is None:
+            return True
+
+        # Packed CFG concatenates branches into one forward. A change in
+        # branch count makes the cached residual the wrong shape; recompute.
+        if state.previous_modulated_input.shape != modulated_inp.shape:
+            state.accumulated_rel_l1_distance = 0.0
             return True
 
         # Compute relative L1 distance between consecutive modulated inputs

--- a/vllm_omni/diffusion/models/bagel/bagel_transformer.py
+++ b/vllm_omni/diffusion/models/bagel/bagel_transformer.py
@@ -1,6 +1,7 @@
 # Copyright 2025 Bytedance Ltd. and/or its affiliates.
 # Copyright (c) 2024 The Qwen Team and The HuggingFace Inc. team.
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 #
 # This file has been modified by ByteDance Ltd. and/or its affiliates.
 #
@@ -1320,11 +1321,13 @@ class Bagel(CFGParallelMixin, nn.Module):
         packed_text_indexes: torch.Tensor,
         packed_seqlens: torch.Tensor,
         packed_position_ids: torch.Tensor,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        timestep: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """Split VAE tokens across SP ranks for the denoising loop.
 
         Returns adjusted (x_t, packed_vae_position_ids, packed_vae_token_indexes,
-        packed_text_indexes, packed_seqlens, packed_position_ids) for the local rank.
+        packed_text_indexes, packed_seqlens, packed_position_ids, timestep) for the
+        local rank.
         """
         sp_size = self._sp_size
         sp_rank = get_sequence_parallel_rank()
@@ -1336,6 +1339,7 @@ class Bagel(CFGParallelMixin, nn.Module):
 
         local_x_t = x_t[start:end]
         local_vae_pos_ids = packed_vae_position_ids[start:end]
+        local_timestep = timestep[start:end]
 
         # Rebuild local packed indices:
         # packed sequence = [start_of_image, local_vae_tokens..., end_of_image]
@@ -1365,7 +1369,15 @@ class Bagel(CFGParallelMixin, nn.Module):
         local_position_ids[local_text_indexes] = text_pos_ids
         local_position_ids[local_vae_indexes] = local_vae_pos
 
-        return local_x_t, local_vae_pos_ids, local_vae_indexes, local_text_indexes, local_seqlens, local_position_ids
+        return (
+            local_x_t,
+            local_vae_pos_ids,
+            local_vae_indexes,
+            local_text_indexes,
+            local_seqlens,
+            local_position_ids,
+            local_timestep,
+        )
 
     def _gather_vae_for_sp(self, local_v_t: torch.Tensor) -> torch.Tensor:
         """Gather VAE velocity outputs from all SP ranks."""
@@ -1811,13 +1823,6 @@ class Bagel(CFGParallelMixin, nn.Module):
         frame_condition_token_indexes: torch.LongTensor | None = None,
     ):
         x_t = packed_init_noises
-        # Snapshot the pinned subtensor BEFORE the denoise loop touches
-        # x_t; the cond positions in packed_init_noises hold the
-        # VAE-encoded conditioning latent that must be preserved verbatim.
-        pinned_x_t = None
-        if frame_condition_token_indexes is not None:
-            frame_condition_token_indexes = frame_condition_token_indexes.to(x_t.device).long()
-            pinned_x_t = x_t[frame_condition_token_indexes].clone()
 
         # Build the flow-matching schedule. BAGEL drops the terminal t=0 for
         # ``num_timesteps - 1`` Euler steps; Lance keeps it for ``num_timesteps``.
@@ -1838,157 +1843,43 @@ class Bagel(CFGParallelMixin, nn.Module):
 
         use_cfg_text = cfg_text_scale > 1.0
         use_cfg_img = cfg_img_scale > 1.0
-
-        # ── Detect CFG parallel mode ──
-        cfg_parallel_ready = use_cfg_text and get_classifier_free_guidance_world_size() > 1
+        use_sp = self._sp_size > 1
+        cfg_world_size = get_classifier_free_guidance_world_size()
+        cfg_parallel_ready = use_cfg_text and cfg_world_size > 1
 
         if cfg_parallel_ready:
-            return self._generate_image_parallel(
-                x_t=x_t,
-                timesteps=timesteps,
-                dts=dts,
-                packed_text_ids=packed_text_ids,
-                packed_text_indexes=packed_text_indexes,
-                packed_vae_position_ids=packed_vae_position_ids,
-                packed_vae_token_indexes=packed_vae_token_indexes,
-                packed_seqlens=packed_seqlens,
-                packed_position_ids=packed_position_ids,
-                past_key_values=past_key_values,
-                cfg_renorm_min=cfg_renorm_min,
-                cfg_renorm_type=cfg_renorm_type,
-                cfg_interval=cfg_interval,
-                cfg_text_scale=cfg_text_scale,
-                cfg_text_packed_position_ids=cfg_text_packed_position_ids,
-                cfg_text_past_key_values=cfg_text_past_key_values,
-                cfg_img_scale=cfg_img_scale,
-                cfg_img_packed_position_ids=cfg_img_packed_position_ids,
-                cfg_img_past_key_values=cfg_img_past_key_values,
-                return_trajectory_latents=return_trajectory_latents,
-                scheduler=scheduler,
-                scheduler_kwargs=scheduler_kwargs,
-            )
-
-        # ── SP + CFG: sequential single-branch forwards ──
-        use_sp = self._sp_size > 1
-        if use_sp and use_cfg_text:
-            if return_trajectory_latents and len(timesteps) > 0:
-                trajectory_latents.append(x_t.clone())
-            for i, t in enumerate(timesteps.tolist()):  # host floats; a 0-d tensor t would sync each step
-                timestep = torch.tensor([t] * x_t.shape[0], device=x_t.device)
-                if frame_condition_token_indexes is not None:
-                    # Cond positions stay at t=0 (clean signal).  Matches upstream
-                    # PR #33 lance.py line 1605:
-                    #     timestep[current_vae_mse_indexes_local_in_vae] = t
-                    # (cond positions remain at the ``torch.zeros`` init value).
-                    timestep[frame_condition_token_indexes] = 0.0
-                in_cfg_window = t > cfg_interval[0] and t <= cfg_interval[1]
-                cfg_text_scale_ = cfg_text_scale if in_cfg_window else 1.0
-                cfg_img_scale_ = cfg_img_scale if in_cfg_window else 1.0
-
-                common = dict(
-                    x_t=x_t,
-                    timestep=timestep,
-                    packed_vae_token_indexes=packed_vae_token_indexes,
-                    packed_vae_position_ids=packed_vae_position_ids,
-                    packed_text_ids=packed_text_ids,
-                    packed_text_indexes=packed_text_indexes,
-                    packed_seqlens=packed_seqlens,
+            # Validate cfg_parallel_size vs cfg_img_scale consistency
+            if cfg_world_size == 3 and not use_cfg_img:
+                raise ValueError(
+                    f"cfg_parallel_size=3 requires cfg_img_scale > 1.0, "
+                    f"but got cfg_img_scale={cfg_img_scale}. "
+                    f"Use cfg_parallel_size=2 for text-only CFG parallel(text2img), "
+                    f"or set cfg_img_scale > 1.0."
+                )
+            if cfg_world_size == 2 and use_cfg_img:
+                raise ValueError(
+                    f"Image CFG (cfg_img_scale={cfg_img_scale}) requires cfg_parallel_size=3, "
+                    f"but got cfg_parallel_size=2. "
+                    f"Use cfg_parallel_size=3 to enable image CFG in parallel mode."
                 )
 
-                v_t = self.forward_single_branch(
-                    **common,
-                    packed_position_ids=packed_position_ids,
-                    past_key_values=past_key_values,
-                )
+            # Ensure all ranks start with the same x_t (initial noise may differ
+            # across ranks when no per-request seed is set).
+            x_t = x_t.contiguous()
+            get_cfg_group().broadcast(x_t, src=0)
 
-                if cfg_text_scale_ > 1.0:
-                    cfg_text_v_t = self.forward_single_branch(
-                        **common,
-                        packed_position_ids=cfg_text_packed_position_ids,
-                        past_key_values=cfg_text_past_key_values,
-                    )
-                    cfg_img_v_t = None
-                    if cfg_img_scale_ > 1.0:
-                        cfg_img_v_t = self.forward_single_branch(
-                            **common,
-                            packed_position_ids=cfg_img_packed_position_ids,
-                            past_key_values=cfg_img_past_key_values,
-                        )
-                    v_t = self._combine_cfg(
-                        v_t,
-                        cfg_text_v_t,
-                        cfg_img_v_t,
-                        cfg_text_scale_,
-                        cfg_img_scale_,
-                        cfg_renorm_type,
-                        cfg_renorm_min,
-                    )
+        pinned_x_t = None
+        if frame_condition_token_indexes is not None:
+            frame_condition_token_indexes = frame_condition_token_indexes.to(x_t.device).long()
+            pinned_x_t = x_t[frame_condition_token_indexes].clone()
 
-                if scheduler is not None:
-                    out = scheduler.step(v_t.to(x_t.device), timesteps[i], x_t, dts[i], **_sched_kw)
-                    x_t = out.prev_sample
-                    if trajectory_log_probs is not None and out.log_prob is not None:
-                        trajectory_log_probs.append(out.log_prob)
-                else:
-                    x_t = x_t - v_t.to(x_t.device) * dts[i]
-                if return_trajectory_latents:
-                    trajectory_latents.append(x_t.clone())
-                    trajectory_timesteps.append(timesteps[i])
-
-            unpacked_latent = x_t.split((packed_seqlens - 2).tolist())
-            return unpacked_latent, trajectory_latents, trajectory_timesteps, trajectory_log_probs
-
-        # ── SP without CFG: direct single-branch loop ──
-        if use_sp:
-            if return_trajectory_latents and len(timesteps) > 0:
-                trajectory_latents.append(x_t.clone())
-            for i, t in enumerate(timesteps.tolist()):  # host floats; a 0-d tensor t would sync each step
-                timestep = torch.tensor([t] * x_t.shape[0], device=x_t.device)
-                if frame_condition_token_indexes is not None:
-                    # Cond positions stay at t=0 (clean signal).  Matches upstream
-                    # PR #33 lance.py line 1605:
-                    #     timestep[current_vae_mse_indexes_local_in_vae] = t
-                    # (cond positions remain at the ``torch.zeros`` init value).
-                    timestep[frame_condition_token_indexes] = 0.0
-                v_t = self.forward_single_branch(
-                    x_t=x_t,
-                    timestep=timestep,
-                    packed_vae_token_indexes=packed_vae_token_indexes,
-                    packed_vae_position_ids=packed_vae_position_ids,
-                    packed_text_ids=packed_text_ids,
-                    packed_text_indexes=packed_text_indexes,
-                    packed_position_ids=packed_position_ids,
-                    packed_seqlens=packed_seqlens,
-                    past_key_values=past_key_values,
-                )
-                if scheduler is not None:
-                    out = scheduler.step(v_t.to(x_t.device), timesteps[i], x_t, dts[i], **_sched_kw)
-                    x_t = out.prev_sample
-                    out_log_prob = getattr(out, "log_prob", None)
-                    if trajectory_log_probs is not None and out_log_prob is not None:
-                        trajectory_log_probs.append(out_log_prob)
-                else:
-                    x_t = x_t - v_t.to(x_t.device) * dts[i]
-                if return_trajectory_latents:
-                    trajectory_latents.append(x_t.clone())
-                    trajectory_timesteps.append(timesteps[i])
-
-            unpacked_latent = x_t.split((packed_seqlens - 2).tolist())
-            return unpacked_latent, trajectory_latents, trajectory_timesteps, trajectory_log_probs
-
-        # ── Sequential CFG mode (cfg_parallel_size=1, no SP) ──
-        # Each CFG branch runs its own LLM forward; we just need the
-        # per-branch packed_position_ids and past_key_values for
-        # ``Bagel.forward`` to dispatch through.
-        cfg_branch_pids: list[torch.Tensor] | None = None
-        cfg_branch_caches: list[NaiveCache] | None = None
-
-        if use_cfg_text:
-            cfg_branch_pids = [packed_position_ids, cfg_text_packed_position_ids]
-            cfg_branch_caches = [past_key_values, cfg_text_past_key_values]
-            if use_cfg_img:
-                cfg_branch_pids.append(cfg_img_packed_position_ids)
-                cfg_branch_caches.append(cfg_img_past_key_values)
+        pack_cfg = use_cfg_text and not use_sp and not cfg_parallel_ready
+        true_cfg_scale = {
+            "cfg_text_scale": cfg_text_scale,
+            "cfg_img_scale": cfg_img_scale,
+            "cfg_renorm_type": cfg_renorm_type,
+            "cfg_renorm_min": cfg_renorm_min,
+        }
 
         if return_trajectory_latents and len(timesteps) > 0:
             trajectory_latents.append(x_t.clone())
@@ -2001,129 +1892,8 @@ class Bagel(CFGParallelMixin, nn.Module):
                 #     timestep[current_vae_mse_indexes_local_in_vae] = t
                 # (cond positions remain at the ``torch.zeros`` init value).
                 timestep[frame_condition_token_indexes] = 0.0
-            if t > cfg_interval[0] and t <= cfg_interval[1]:
-                cfg_text_scale_ = cfg_text_scale
-                cfg_img_scale_ = cfg_img_scale
-            else:
-                cfg_text_scale_ = 1.0
-                cfg_img_scale_ = 1.0
-            v_t = self.forward(
-                x_t=x_t,
-                timestep=timestep,
-                packed_vae_token_indexes=packed_vae_token_indexes,
-                packed_vae_position_ids=packed_vae_position_ids,
-                packed_text_ids=packed_text_ids,
-                packed_text_indexes=packed_text_indexes,
-                packed_position_ids=packed_position_ids,
-                packed_seqlens=packed_seqlens,
-                past_key_values=past_key_values,
-                cfg_renorm_min=cfg_renorm_min,
-                cfg_renorm_type=cfg_renorm_type,
-                cfg_text_scale=cfg_text_scale_,
-                cfg_img_scale=cfg_img_scale_,
-                cfg_branch_pids=cfg_branch_pids,
-                cfg_branch_caches=cfg_branch_caches,
-            )
+            use_cfg_this_step = t > cfg_interval[0] and t <= cfg_interval[1] and use_cfg_text
 
-            if scheduler is not None:
-                out = scheduler.step(v_t.to(x_t.device), timesteps[i], x_t, dts[i], **_sched_kw)
-                x_t = out.prev_sample
-                if trajectory_log_probs is not None and out.log_prob is not None:
-                    trajectory_log_probs.append(out.log_prob)
-            else:
-                x_t = x_t - v_t.to(x_t.device) * dts[i]  # velocity pointing from data to noise
-                if pinned_x_t is not None:
-                    # i2v: restore cond positions to their encoded-image
-                    # latent.  Matches upstream PR #33 lance.py line 1712:
-                    #     x_t[mse_indexes] = x_t[mse_indexes] - v_t[mse_indexes] * dts[i]
-                    # (cond positions are excluded from the update).
-                    x_t[frame_condition_token_indexes] = pinned_x_t
-            if return_trajectory_latents:
-                trajectory_latents.append(x_t.clone())
-                trajectory_timesteps.append(timesteps[i])
-
-        unpacked_latent = x_t.split((packed_seqlens - 2).tolist())
-        return unpacked_latent, trajectory_latents, trajectory_timesteps, trajectory_log_probs
-
-    def _generate_image_parallel(
-        self,
-        x_t: torch.Tensor,
-        timesteps: torch.Tensor,
-        dts: torch.Tensor,
-        packed_text_ids: torch.LongTensor,
-        packed_text_indexes: torch.LongTensor,
-        packed_vae_position_ids: torch.LongTensor,
-        packed_vae_token_indexes: torch.LongTensor,
-        packed_seqlens: torch.IntTensor,
-        packed_position_ids: torch.LongTensor,
-        past_key_values: NaiveCache,
-        cfg_renorm_min: float,
-        cfg_renorm_type: str,
-        cfg_interval: tuple[float, float],
-        cfg_text_scale: float,
-        cfg_text_packed_position_ids: torch.LongTensor | None,
-        cfg_text_past_key_values: NaiveCache | None,
-        cfg_img_scale: float,
-        cfg_img_packed_position_ids: torch.LongTensor | None,
-        cfg_img_past_key_values: NaiveCache | None,
-        return_trajectory_latents: bool = False,
-        scheduler: object | None = None,
-        scheduler_kwargs: dict | None = None,
-        frame_condition_token_indexes: torch.LongTensor | None = None,
-    ):
-        """CFG parallel denoising loop: each rank computes one CFG branch.
-
-        Rank 0: gen branch (full conditioning)
-        Rank 1: text_cfg branch (unconditional text)
-        Rank 2: img_cfg branch (no image condition), only when cfg_img_scale > 1.0
-        """
-        cfg_group = get_cfg_group()
-        cfg_world_size = get_classifier_free_guidance_world_size()
-        use_cfg_img = cfg_img_scale > 1.0
-
-        # Validate cfg_parallel_size vs cfg_img_scale consistency
-        if cfg_world_size == 3 and not use_cfg_img:
-            raise ValueError(
-                f"cfg_parallel_size=3 requires cfg_img_scale > 1.0, "
-                f"but got cfg_img_scale={cfg_img_scale}. "
-                f"Use cfg_parallel_size=2 for text-only CFG parallel(text2img), or set cfg_img_scale > 1.0."
-            )
-        if cfg_world_size == 2 and use_cfg_img:
-            raise ValueError(
-                f"Image CFG (cfg_img_scale={cfg_img_scale}) requires cfg_parallel_size=3, "
-                f"but got cfg_parallel_size=2. "
-                f"Use cfg_parallel_size=3 to enable image CFG in parallel mode."
-            )
-
-        # Ensure all ranks start with the same x_t (initial noise may differ
-        # across ranks when no per-request seed is set).
-        x_t = x_t.contiguous()
-        cfg_group.broadcast(x_t, src=0)
-
-        trajectory_latents: list[torch.Tensor] | None = [] if return_trajectory_latents else None
-        trajectory_timesteps: list[torch.Tensor] | None = [] if return_trajectory_latents else None
-        trajectory_log_probs: list[torch.Tensor] | None = (
-            [] if (return_trajectory_latents and scheduler is not None) else None
-        )
-        _sched_kw = scheduler_kwargs or {}
-
-        if return_trajectory_latents and len(timesteps) > 0:
-            trajectory_latents.append(x_t.clone())
-
-        for i, t in enumerate(timesteps.tolist()):  # host floats; a 0-d tensor t would sync each step
-            timestep = torch.tensor([t] * x_t.shape[0], device=x_t.device)
-            if frame_condition_token_indexes is not None:
-                # Cond positions stay at t=0 (clean signal).  Matches upstream
-                # PR #33 lance.py line 1605:
-                #     timestep[current_vae_mse_indexes_local_in_vae] = t
-                # (cond positions remain at the ``torch.zeros`` init value).
-                timestep[frame_condition_token_indexes] = 0.0
-            use_cfg_this_step = t > cfg_interval[0] and t <= cfg_interval[1] and cfg_text_scale > 1.0
-
-            # Per-branch kwargs. Branch 0 (gen, full conditioning) is also the
-            # branch used by all ranks when do_true_cfg is False (outside the
-            # CFG interval) — CFGParallelMixin only runs branches_kwargs[0] then,
-            # mirroring the previous "all ranks compute gen inputs, no comm" path.
             common = dict(
                 x_t=x_t,
                 timestep=timestep,
@@ -2133,33 +1903,31 @@ class Bagel(CFGParallelMixin, nn.Module):
                 packed_text_indexes=packed_text_indexes,
                 packed_seqlens=packed_seqlens,
             )
-            branches_kwargs = [
-                dict(**common, packed_position_ids=packed_position_ids, past_key_values=past_key_values),
-                dict(
-                    **common, packed_position_ids=cfg_text_packed_position_ids, past_key_values=cfg_text_past_key_values
-                ),
-            ]
-            if use_cfg_img:
-                branches_kwargs.append(
-                    dict(
-                        **common,
-                        packed_position_ids=cfg_img_packed_position_ids,
-                        past_key_values=cfg_img_past_key_values,
-                    )
-                )
+            branch_pids_caches = [(packed_position_ids, past_key_values)]
 
-            # Each rank computes its assigned branch, then all_gather + combine
-            # happen inside the mixin (identical result on every rank).
-            v_t = self.predict_noise_with_multi_branch_cfg(
-                do_true_cfg=use_cfg_this_step,
-                true_cfg_scale={
-                    "cfg_text_scale": cfg_text_scale,
-                    "cfg_img_scale": cfg_img_scale,
-                    "cfg_renorm_type": cfg_renorm_type,
-                    "cfg_renorm_min": cfg_renorm_min,
-                },
-                branches_kwargs=branches_kwargs,
-            )
+            if use_cfg_this_step:
+                branch_pids_caches.append((cfg_text_packed_position_ids, cfg_text_past_key_values))
+                if use_cfg_img:
+                    branch_pids_caches.append((cfg_img_packed_position_ids, cfg_img_past_key_values))
+
+            if pack_cfg and use_cfg_this_step:
+                v_t = self.combine_multi_branch_cfg_noise(
+                    self.forward(
+                        **common,
+                        cfg_branch_pids=[pids for pids, _ in branch_pids_caches],
+                        cfg_branch_caches=[cache for _, cache in branch_pids_caches],
+                    ),
+                    true_cfg_scale,
+                )
+            else:
+                v_t = self.predict_noise_with_multi_branch_cfg(
+                    do_true_cfg=use_cfg_this_step,
+                    true_cfg_scale=true_cfg_scale,
+                    branches_kwargs=[
+                        dict(**common, cfg_branch_pids=[pids], cfg_branch_caches=[cache])
+                        for pids, cache in branch_pids_caches
+                    ],
+                )
 
             if scheduler is not None:
                 out = scheduler.step(v_t.to(x_t.device), timesteps[i], x_t, dts[i], **_sched_kw)
@@ -2168,6 +1936,14 @@ class Bagel(CFGParallelMixin, nn.Module):
                     trajectory_log_probs.append(out.log_prob)
             else:
                 x_t = x_t - v_t.to(x_t.device) * dts[i]
+
+            if pinned_x_t is not None:
+                # i2v: restore cond positions to their encoded-image
+                # latent.  Matches upstream PR #33 lance.py line 1712:
+                #     x_t[mse_indexes] = x_t[mse_indexes] - v_t[mse_indexes] * dts[i]
+                # (cond positions are excluded from the update).
+                x_t[frame_condition_token_indexes] = pinned_x_t
+
             if return_trajectory_latents:
                 trajectory_latents.append(x_t.clone())
                 trajectory_timesteps.append(timesteps[i])
@@ -2237,12 +2013,8 @@ class Bagel(CFGParallelMixin, nn.Module):
 
     def predict_noise(self, **kwargs) -> torch.Tensor:
         """Single-branch velocity prediction for CFGParallelMixin.
-
-        Each CFG branch differs only by ``packed_position_ids`` and
-        ``past_key_values`` (carried in ``kwargs``); the heavy lifting is the
-        per-branch ``forward_single_branch`` pass.
-        """
-        return self.forward_single_branch(**kwargs)
+        Assumes only 1 CFG branch is provided in the kwargs."""
+        return self.forward(**kwargs)[0]
 
     def combine_multi_branch_cfg_noise(
         self,
@@ -2267,7 +2039,7 @@ class Bagel(CFGParallelMixin, nn.Module):
             true_cfg_scale["cfg_renorm_min"],
         )
 
-    def forward_single_branch(
+    def forward(
         self,
         x_t: torch.Tensor,
         timestep: torch.LongTensor,
@@ -2275,73 +2047,49 @@ class Bagel(CFGParallelMixin, nn.Module):
         packed_vae_position_ids: torch.LongTensor,
         packed_text_ids: torch.LongTensor,
         packed_text_indexes: torch.LongTensor,
-        packed_position_ids: torch.LongTensor,
         packed_seqlens: torch.IntTensor,
-        past_key_values: NaiveCache,
-    ) -> torch.Tensor:
-        """Run a single-branch forward pass (no CFG batching).
+        cfg_branch_pids: list[torch.Tensor],
+        cfg_branch_caches: list[NaiveCache],
+    ) -> list[torch.Tensor]:
+        """Packed query forward. Returns uncombined VAE velocities (length 1 or N).
 
-        Used by CFG parallel mode where each rank computes one branch.
-        Returns the velocity v_t for the given branch.
-        Supports Ulysses / Ring SP when parallel_config.sequence_parallel_size > 1.
+        Per-branch RoPE position ids and KV caches are passed via
+        ``cfg_branch_pids`` and ``cfg_branch_caches`` (length 1 for a single
+        forward, length N for batched multi-branch CFG). When N > 1, query
+        sequences are stacked and caches are merged via ``NaiveCache.merge``.
+
+        Batched multi-branch CFG + sequence parallel is not supported and raises.
         """
+        num_branches = len(cfg_branch_pids)
+        packing = num_branches > 1
         use_sp = self._sp_size > 1
+        branch_position_ids = cfg_branch_pids[0]
 
         if use_sp:
-            # Split VAE tokens across SP ranks
+            if packing:
+                raise ValueError(
+                    "Packed CFG + sequence parallel is not supported. "
+                    "Run SP+CFG as sequential single-branch forwards (len(cfg_branch_pids)==1)."
+                )
             (
-                local_x_t,
-                local_vae_pos_ids,
-                local_vae_indexes,
-                local_text_indexes,
-                local_seqlens,
-                local_position_ids,
+                x_t,
+                packed_vae_position_ids,
+                packed_vae_token_indexes,
+                packed_text_indexes,
+                packed_seqlens,
+                branch_position_ids,
+                timestep,
             ) = self._split_vae_for_sp(
                 x_t,
                 packed_vae_position_ids,
                 packed_vae_token_indexes,
                 packed_text_indexes,
                 packed_seqlens,
-                packed_position_ids,
+                branch_position_ids,
+                timestep,
             )
 
-            packed_text_embedding = self.language_model.forward(
-                packed_text_ids=packed_text_ids,
-                return_embeddings_only=True,
-            ).packed_query_sequence
-            packed_sequence = packed_text_embedding.new_zeros((int(local_seqlens.sum()), self.hidden_size))
-            packed_sequence[local_text_indexes] = packed_text_embedding
-
-            # i2v relaxes this: per-token timestep (cond=0, noncond=t) is valid.
-            packed_pos_embed = self.latent_pos_embed(local_vae_pos_ids)
-            local_timestep = timestep[: local_x_t.shape[0]]
-            packed_timestep_embeds = self.time_embedder(local_timestep)
-            x_t_emb = self.vae2llm(local_x_t) + packed_timestep_embeds + packed_pos_embed
-            if x_t_emb.dtype != packed_sequence.dtype:
-                x_t_emb = x_t_emb.to(packed_sequence.dtype)
-            packed_sequence[local_vae_indexes] = x_t_emb
-
-            extra_inputs = {}
-            if self.use_moe:
-                extra_inputs["mode"] = "gen"
-                extra_inputs["packed_vae_token_indexes"] = local_vae_indexes
-                extra_inputs["packed_text_indexes"] = local_text_indexes
-
-            output = self.language_model.forward(
-                packed_query_sequence=packed_sequence,
-                query_lens=local_seqlens,
-                packed_query_position_ids=local_position_ids,
-                past_key_values=past_key_values,
-                update_past_key_values=False,
-                is_causal=False,
-                **extra_inputs,
-            )
-
-            local_v_t = self.llm2vae(output.packed_query_sequence)
-            local_v_t = local_v_t[local_vae_indexes]
-            return self._gather_vae_for_sp(local_v_t)
-
-        # Original non-SP path
+        # Build query sequence (identical for all CFG branches; local if SP)
         packed_text_embedding = self.language_model.forward(
             packed_text_ids=packed_text_ids,
             return_embeddings_only=True,
@@ -2363,117 +2111,37 @@ class Bagel(CFGParallelMixin, nn.Module):
             extra_inputs["packed_vae_token_indexes"] = packed_vae_token_indexes
             extra_inputs["packed_text_indexes"] = packed_text_indexes
 
+        if packing:
+            seq_len = int(packed_seqlens.sum())
+            packed_query_sequence = packed_sequence.repeat(num_branches, 1)
+            vae_indexes = torch.cat([packed_vae_token_indexes + i * seq_len for i in range(num_branches)])
+            query_position_ids = torch.cat(cfg_branch_pids, dim=1 if cfg_branch_pids[0].ndim == 2 else 0)
+            query_lens = packed_seqlens.repeat(num_branches)
+            cache = NaiveCache.merge(cfg_branch_caches)
+            if self.use_moe:
+                extra_inputs["packed_vae_token_indexes"] = vae_indexes
+                extra_inputs["packed_text_indexes"] = torch.cat(
+                    [packed_text_indexes + i * seq_len for i in range(num_branches)]
+                )
+        else:
+            packed_query_sequence = packed_sequence
+            query_lens = packed_seqlens
+            query_position_ids = branch_position_ids
+            cache = cfg_branch_caches[0]
+            vae_indexes = packed_vae_token_indexes
+
         output = self.language_model.forward(
-            packed_query_sequence=packed_sequence,
-            query_lens=packed_seqlens,
-            packed_query_position_ids=packed_position_ids,
-            past_key_values=past_key_values,
+            packed_query_sequence=packed_query_sequence,
+            query_lens=query_lens,
+            packed_query_position_ids=query_position_ids,
+            past_key_values=cache,
             update_past_key_values=False,
             is_causal=False,
             **extra_inputs,
         )
-        v_t = self.llm2vae(output.packed_query_sequence)
-        v_t = v_t[packed_vae_token_indexes]
-        return v_t
-
-    def forward(
-        self,
-        x_t: torch.Tensor,
-        timestep: torch.LongTensor,
-        packed_vae_token_indexes: torch.LongTensor,
-        packed_vae_position_ids: torch.LongTensor,
-        packed_text_ids: torch.LongTensor,
-        packed_text_indexes: torch.LongTensor,
-        packed_position_ids: torch.LongTensor,
-        packed_seqlens: torch.IntTensor,
-        past_key_values: NaiveCache,
-        cfg_renorm_min: float = 0.0,
-        cfg_renorm_type: str = "global",
-        cfg_text_scale: float = 1.0,
-        cfg_img_scale: float = 1.0,
-        cfg_branch_pids: list[torch.Tensor] | None = None,
-        cfg_branch_caches: list[NaiveCache] | None = None,
-    ):
-        # Build query sequence (identical for all CFG branches)
-        packed_text_embedding = self.language_model.forward(
-            packed_text_ids=packed_text_ids,
-            return_embeddings_only=True,
-        ).packed_query_sequence
-        packed_sequence = packed_text_embedding.new_zeros((sum(packed_seqlens), self.hidden_size))
-        packed_sequence[packed_text_indexes] = packed_text_embedding
-
-        # i2v relaxes this: per-token timestep (cond=0, noncond=t) is valid.
-        packed_pos_embed = self.latent_pos_embed(packed_vae_position_ids)
-        packed_timestep_embeds = self.time_embedder(timestep)
-        x_t = self.vae2llm(x_t) + packed_timestep_embeds + packed_pos_embed
-        if x_t.dtype != packed_sequence.dtype:
-            x_t = x_t.to(packed_sequence.dtype)
-        packed_sequence[packed_vae_token_indexes] = x_t
-
-        extra_inputs = {}
-        if self.use_moe:
-            extra_inputs["mode"] = "gen"
-            extra_inputs["packed_vae_token_indexes"] = packed_vae_token_indexes
-            extra_inputs["packed_text_indexes"] = packed_text_indexes
-
-        use_cfg = cfg_text_scale > 1.0
-        cfg_text_v_t = None
-        cfg_img_v_t = None
-
-        if use_cfg and cfg_branch_pids is not None and cfg_branch_caches is not None:
-            num_branches = len(cfg_branch_pids)
-            seq_len = int(packed_seqlens.sum())
-
-            batched_sequence = packed_sequence.repeat(num_branches, 1)
-            batched_vae_indexes = torch.cat([packed_vae_token_indexes + i * seq_len for i in range(num_branches)])
-            batched_position_ids = torch.cat(cfg_branch_pids, dim=1 if cfg_branch_pids[0].ndim == 2 else 0)
-            batched_seqlens = packed_seqlens.repeat(num_branches)
-            merged_cache = NaiveCache.merge(cfg_branch_caches)
-
-            if self.use_moe:
-                batched_text_indices = torch.cat([packed_text_indexes + i * seq_len for i in range(num_branches)])
-                extra_inputs["packed_vae_token_indexes"] = batched_vae_indexes
-                extra_inputs["packed_text_indexes"] = batched_text_indices
-
-            output = self.language_model.forward(
-                packed_query_sequence=batched_sequence,
-                query_lens=batched_seqlens,
-                packed_query_position_ids=batched_position_ids,
-                past_key_values=merged_cache,
-                update_past_key_values=False,
-                is_causal=False,
-                **extra_inputs,
-            )
-
-            all_vae_v_t = self.llm2vae(output.packed_query_sequence)[batched_vae_indexes]
-            vae_per_branch = packed_vae_token_indexes.shape[0]
-            branch_v_ts = all_vae_v_t.split(vae_per_branch)
-            v_t = branch_v_ts[0]
-            cfg_text_v_t = branch_v_ts[1]
-            cfg_img_v_t = branch_v_ts[2] if len(branch_v_ts) > 2 else None
-        else:
-            # Single forward (no CFG or outside cfg_interval).
-            output = self.language_model.forward(
-                packed_query_sequence=packed_sequence,
-                query_lens=packed_seqlens,
-                packed_query_position_ids=packed_position_ids,
-                past_key_values=past_key_values,
-                update_past_key_values=False,
-                is_causal=False,
-                **extra_inputs,
-            )
-            v_t = self.llm2vae(output.packed_query_sequence)[packed_vae_token_indexes]
-
-        # ── CFG combination ──
-        if use_cfg:
-            v_t = self._combine_cfg(
-                v_t,
-                cfg_text_v_t,
-                cfg_img_v_t,
-                cfg_text_scale,
-                cfg_img_scale,
-                cfg_renorm_type,
-                cfg_renorm_min,
-            )
-
-        return v_t
+        v_t = self.llm2vae(output.packed_query_sequence)[vae_indexes]
+        if packing:
+            return list(v_t.split(packed_vae_token_indexes.shape[0]))
+        if use_sp:
+            v_t = self._gather_vae_for_sp(v_t)
+        return [v_t]


### PR DESCRIPTION
## Purpose

1. **Fix [#4659](https://github.com/vllm-project/vllm-omni/issues/4659).** TeaCache wrapped Bagel's full step, including CFG, and only kept the conditional branch. Images got faster but lost guidance. This PR applies CFG *after* the cached forward, so skips no longer drop CFG. In scope: T2I and I2I without CFG-parallel or sequence parallel.

2. **One `forward` instead of `forward` + `forward_single_branch`.** TeaCache can only wrap the packed `forward`. CFG-parallel and Ulysses call `forward_single_branch`, so they never hit the cache. Unifying them is the first step towards supporting teacache in those configurations.

Sibling to #2371 (multi-branch CFG teacache support) and #6228 (implementing multi-branch teacache + SP support). After those land, we can finally support teacache + CFG parallel / SP for Bagel.

Related PR #4660: Both fix #4659. #4660 implements a Bagel-specific workaround. This PR accepts a larger refactor to support split CFG parallel / SP + teacache later.

## Test Plan

**vLLM Version:**
0.27.0

**vLLM-Omni Commit:**
0.27.0rc2.dev125+g13c2de684

## Test Result

https://gist.github.com/yzong-rh/029c6dca07ff8b7102faefd96fe3d300 E2E testing on H100s.

TeaCache is slower than main because CFG is no longer skipped but generation quality is fixed. No quality or performance regression otherwise.

| Scenario | main | this | Images |
| --- | ---: | ---: | --- |
| T2I | 12.52 | 12.54 | Pixel-perfect vs main |
| I2I | 19.19 | 17.78 | Pixel-perfect vs main |
| T2I + TeaCache | 2.14 | 3.62 | Main drops CFG (wrong pose/background). This is visually close to uncached, with residual cache error only. |
| I2I + TeaCache | 5.13 | 7.36 | Main drops CFG (weaker oil-paint color). This is visually close to uncached, with residual cache error only. |
| T2I + CacheDiT | 4.41 | 4.43 | Pixel-perfect vs main |
| I2I + CacheDiT | 8.61 | 8.50 | Pixel-perfect vs main |
| T2I + CFG-parallel | 6.80 | 6.83 | Pixel-perfect vs main |
| I2I + CFG-parallel | 13.01 | 12.46 | Pixel-perfect vs main |
| T2I + Ulysses | 7.39 | 7.37 | Pixel-perfect vs main |
| I2I + Ulysses | 18.76 | 17.10 | Pixel-perfect vs main |

T2I no teacache:
<img width="4096" height="3072" alt="grid_main" src="https://github.com/user-attachments/assets/9d254362-8c1e-49fd-b344-abec741f1eb4" />

T2I + Teacache (main):
<img width="4096" height="3072" alt="grid_cache_main" src="https://github.com/user-attachments/assets/1ed64447-1cf3-4a14-90c2-2233f640aaa0" />


T2I PR + Teacache (this PR):
<img width="4096" height="3072" alt="grid_cache_this" src="https://github.com/user-attachments/assets/befa76c0-2ac0-44eb-ac0d-af48b006886f" />


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
