### PR TITLE
[CI][MiniCPM-o] Disable Seed-TTS shuffle in MiniCPM-o 4.5 perf benches

### DIFF
--- a/tests/dfx/perf/tests/test_minicpmo_4_5.json
+++ b/tests/dfx/perf/tests/test_minicpmo_4_5.json
@@ -39,6 +39,7 @@
           8
         ],
         "no_oversample": true,
+        "disable_shuffle": true,
         "trust_remote_code": true,
         "seed_tts_locale": "en",
         "extra_body": {
@@ -123,6 +124,7 @@
           8
         ],
         "no_oversample": true,
+        "disable_shuffle": true,
         "trust_remote_code": true,
         "seed_tts_locale": "en",
         "extra_body": {

--- a/tests/dfx/perf/tests/test_minicpmo_4_5_duplex_seed_tts.json
+++ b/tests/dfx/perf/tests/test_minicpmo_4_5_duplex_seed_tts.json
@@ -35,6 +35,7 @@
           1
         ],
         "no_oversample": true,
+        "disable_shuffle": true,
         "trust_remote_code": true,
         "seed_tts_locale": "en",
         "seed_tts_turns_per_session": 4,

--- a/tests/dfx/perf/tests/test_minicpmo_4_5_ready.json
+++ b/tests/dfx/perf/tests/test_minicpmo_4_5_ready.json
@@ -37,6 +37,7 @@
           4
         ],
         "no_oversample": true,
+        "disable_shuffle": true,
         "trust_remote_code": true,
         "seed_tts_locale": "en",
         "extra_body": {


### PR DESCRIPTION
## Summary
- Keep MiniCPM-o 4.5 Seed-TTS perf prompts in dataset order by setting `disable_shuffle: true` on the ready, nightly, A2, and duplex benches.
- `run_benchmark.py` already maps this JSON flag to `--disable-shuffle`, so the same prompt sequence is used across GPU/NPU concurrency sweeps.

## Test plan
- [ ] Confirm nightly MiniCPM-o 4.5 perf (`test_minicpmo_4_5.json`) still launches `vllm bench serve --omni` with `--disable-shuffle`.
- [ ] Confirm ready-gate MiniCPM-o 4.5 perf (`test_minicpmo_4_5_ready.json`) does the same.
- [ ] Confirm duplex Seed-TTS perf (`test_minicpmo_4_5_duplex_seed_tts.json`) does the same.
