### PR TITLE
[Diffusion][Bugfix] Align LTX numerical behavior

### DIFF
--- a/tests/diffusion/models/ltx2/test_ltx2_latents.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_latents.py
@@ -23,7 +23,18 @@ def _make_pipeline(pipeline_cls, sequence_parallel_size: int = 1):
     return pipeline
 
 
-def test_prepare_video_latents_samples_directly_in_packed_token_space():
+def test_create_noised_state_matches_official_float32_lerp(monkeypatch):
+    latents = torch.tensor([1.125, -0.875], dtype=torch.bfloat16)
+    noise = torch.tensor([-0.3125, 0.5625], dtype=torch.bfloat16)
+    monkeypatch.setattr(latent_ops, "randn_tensor", lambda *args, **kwargs: noise)
+
+    actual = latent_ops.create_noised_state(latents, torch.tensor(0.37), generator=None)
+    expected = torch.lerp(latents.float(), noise.float(), torch.tensor(0.37)).to(torch.bfloat16)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_prepare_video_latents_matches_official_values_and_token_major_layout():
     pipeline = _make_pipeline(LTX2Pipeline)
     pipeline.vae_spatial_compression_ratio = 8
     pipeline.vae_temporal_compression_ratio = 8
@@ -44,6 +55,7 @@ def test_prepare_video_latents_samples_directly_in_packed_token_space():
     )
 
     torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert actual.stride()[1:] == (1, actual.shape[1])
 
 
 def test_prepare_audio_latents_samples_directly_in_packed_token_space():
@@ -81,6 +93,42 @@ def test_prepare_audio_latents_pads_generated_dummy_length_for_sp():
     assert original_num_frames == 1
     assert padded_num_frames == 2
     assert latents.shape == (1, 2, 128)
+    torch.testing.assert_close(latents[:, 1:], torch.zeros_like(latents[:, 1:]))
+
+
+def test_prepare_audio_latents_request_rng_is_invariant_to_sp_padding():
+    pipeline_sp1 = _make_pipeline(LTX2Pipeline, sequence_parallel_size=1)
+    pipeline_sp4 = _make_pipeline(LTX2Pipeline, sequence_parallel_size=4)
+    generator_sp1 = torch.Generator().manual_seed(42)
+    generator_sp4 = torch.Generator().manual_seed(42)
+
+    latents_sp1, _, _ = pipeline_sp1.prepare_audio_latents(
+        batch_size=1,
+        num_channels_latents=2,
+        num_mel_bins=8,
+        audio_latent_length=3,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+        generator=generator_sp1,
+    )
+    latents_sp4, _, _ = pipeline_sp4.prepare_audio_latents(
+        batch_size=1,
+        num_channels_latents=2,
+        num_mel_bins=8,
+        audio_latent_length=3,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+        generator=generator_sp4,
+    )
+
+    torch.testing.assert_close(latents_sp4[:, :3], latents_sp1, rtol=0, atol=0)
+    torch.testing.assert_close(latents_sp4[:, 3:], torch.zeros_like(latents_sp4[:, 3:]))
+    torch.testing.assert_close(
+        torch.randn(8, generator=generator_sp4),
+        torch.randn(8, generator=generator_sp1),
+        rtol=0,
+        atol=0,
+    )
 
 
 def test_prepare_audio_latents_pads_packed_sequence_dim_for_provided_latents():
@@ -137,7 +185,18 @@ def test_prepare_audio_latents_accepts_already_padded_4d_latents_for_sp():
     assert original_num_frames == 10
     assert padded_num_frames == 12
     assert padded.shape == (1, 12, 8)
-    torch.testing.assert_close(padded, latent_ops.pack_audio_latents(latents))
+    packed = latent_ops.pack_audio_latents(latents)
+    torch.testing.assert_close(padded[:, :10], packed[:, :10])
+    torch.testing.assert_close(padded[:, 10:], torch.zeros_like(padded[:, 10:]))
+
+
+def test_clear_audio_padding_keeps_padding_outside_sampler_state():
+    latents = torch.arange(24, dtype=torch.float32).view(1, 6, 4)
+
+    actual = latent_ops.clear_audio_padding(latents, 4)
+
+    torch.testing.assert_close(actual[:, :4], latents[:, :4])
+    torch.testing.assert_close(actual[:, 4:], torch.zeros_like(actual[:, 4:]))
 
 
 def test_resolve_audio_latent_length_preserves_legacy_4d_shape_inference():

--- a/tests/diffusion/models/ltx2/test_ltx2_parallel.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_parallel.py
@@ -12,6 +12,19 @@ import torch
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 
+def test_velocity_from_x0_uses_official_host_scalar_sigma(mocker):
+    from vllm_omni.diffusion.models.ltx2.ltx2_guidance import velocity_from_x0
+
+    sigma = mocker.MagicMock()
+    sigma.to.return_value.item.return_value = 0.5
+
+    actual = velocity_from_x0(torch.tensor([1.0]), torch.tensor([0.0]), sigma)
+
+    sigma.to.assert_called_once_with(torch.float32)
+    sigma.to.return_value.item.assert_called_once_with()
+    torch.testing.assert_close(actual, torch.tensor([2.0]))
+
+
 class TestCFGParallelHelpers:
     """Test LTX-2.3 CFG helper math without loading model weights."""
 
@@ -199,6 +212,7 @@ class TestCFGParallelHelpers:
             ),
             attention_kwargs=None,
             audio_scheduler=SimpleNamespace(sigmas=torch.stack([audio_sigma])),
+            original_audio_num_frames=state.audio.shape[1],
         )
 
         actual_video, actual_audio = executor.predict_parallel_guidance(

--- a/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
@@ -33,6 +33,7 @@ from vllm_omni.diffusion.models.ltx2.ltx2_guidance import (
     LTXGuidancePlan,
     LTXGuidanceSpec,
     LTXModalityGuidance,
+    _repeat_batch,
     build_perturbation_kwargs,
     combine_guided_x0,
 )
@@ -64,6 +65,16 @@ def _make_ltx_request_pipe(cls):
     pipe.vae_spatial_compression_ratio = 32
     pipe.vae_temporal_compression_ratio = 8
     return pipe
+
+
+def test_ltx_rejects_advanced_uaa_before_component_initialization():
+    od_config = SimpleNamespace(
+        model="unused",
+        parallel_config=SimpleNamespace(ulysses_mode="advanced_uaa"),
+    )
+
+    with pytest.raises(ValueError, match="does not support ulysses_mode='advanced_uaa'"):
+        LTX2Pipeline(od_config=od_config)
 
 
 def _resolve_request_inputs_for_test(
@@ -330,6 +341,15 @@ def test_ltx_guidance_uses_official_close_to_disabled_semantics():
     assert LTXGuidancePlan.build(LTXGuidanceSpec(video=guidance)).names == ("cond",)
 
 
+def test_ltx_positive_only_guidance_preserves_token_major_layout():
+    tensor = torch.arange(24).view(1, 3, 8).transpose(1, 2).contiguous().transpose(1, 2)
+
+    repeated = _repeat_batch(tensor, 1)
+
+    assert repeated is tensor
+    assert repeated.stride() == tensor.stride()
+
+
 def test_ltx_guidance_rescale_is_invariant_to_request_batching():
     cond = torch.tensor(
         [
@@ -378,6 +398,32 @@ def test_ltx_guidance_rescale_handles_zero_variance_prediction():
 
     assert torch.isfinite(actual).all()
     torch.testing.assert_close(actual, torch.zeros_like(cond))
+
+
+def test_ltx_audio_guidance_rescale_ignores_sp_padding_tokens():
+    logical_cond = torch.tensor([[[1.0, 2.0], [3.0, 5.0]]])
+    logical_uncond = torch.tensor([[[0.5, -1.0], [2.0, 1.0]]])
+    guidance = LTXModalityGuidance(cfg_scale=3.0, rescale_scale=1.0)
+    expected = combine_guided_x0(
+        cond=logical_cond,
+        uncond_text=logical_uncond,
+        uncond_perturbed=0.0,
+        uncond_modality=0.0,
+        guidance=guidance,
+    )
+    padded_cond = torch.cat([logical_cond, torch.tensor([[[1000.0, -1000.0]]])], dim=1)
+    padded_uncond = torch.cat([logical_uncond, torch.tensor([[[-500.0, 500.0]]])], dim=1)
+
+    actual = combine_guided_x0(
+        cond=padded_cond,
+        uncond_text=padded_uncond,
+        uncond_perturbed=0.0,
+        uncond_modality=0.0,
+        guidance=guidance,
+        rescale_token_count=2,
+    )
+
+    torch.testing.assert_close(actual[:, :2], expected)
 
 
 def test_ltx_guidance_builds_per_sample_stg_and_modality_masks():

--- a/tests/diffusion/models/ltx2/test_ltx2_transformer.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_transformer.py
@@ -1,13 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import pytest
+import torch
 from torch import nn
 
+from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.cache.cachedit import CacheDiTAdapterConfig
-from vllm_omni.diffusion.models.ltx2.ltx2_transformer import LTX2VideoTransformer3DModel, _make_rms_norm
-
-pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+from vllm_omni.diffusion.models.ltx2.ltx2_transformer import (
+    LTX2AudioVideoAttnProcessor,
+    LTX2VideoTransformer3DModel,
+    _LTX2ParallelAttention,
+    _make_rms_norm,
+)
 
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
 
@@ -66,3 +73,83 @@ def test_ltx_sp_plan_shards_video_and_audio_timesteps_together(rope_type):
     assert video_timestep.expected_dims == audio_timestep.expected_dims == 2
     assert not video_timestep.split_output
     assert not audio_timestep.split_output
+
+
+def test_ltx_sp_keeps_cross_attention_key_padding_mask(monkeypatch):
+    monkeypatch.setattr(LTX2AudioVideoAttnProcessor, "_is_sp_enabled", staticmethod(lambda: True))
+    processor = LTX2AudioVideoAttnProcessor()
+    hidden_states = torch.zeros(1, 3, 4)
+    encoder_hidden_states = torch.zeros(1, 4, 4)
+    key_padding_mask = torch.tensor([[True, True, True, False]])
+
+    actual = processor._prepare_attention_mask(
+        SimpleNamespace(),
+        hidden_states,
+        encoder_hidden_states,
+        key_padding_mask,
+        batch_size=1,
+        sequence_length=4,
+    )
+
+    torch.testing.assert_close(actual, key_padding_mask[:, None, None, :])
+
+
+def _fake_ltx_parallel_attention():
+    calls = []
+
+    class Backend:
+        @staticmethod
+        def get_name():
+            return "FLASH_ATTN"
+
+        @staticmethod
+        def supports_attention_mask():
+            return True
+
+    def run(name):
+        def forward(query, _key, _value, _metadata):
+            calls.append(name)
+            return torch.zeros_like(query)
+
+        return forward
+
+    layer = object.__new__(_LTX2ParallelAttention)
+    nn.Module.__init__(layer)
+    layer.attn_backend = Backend
+    layer.attention = SimpleNamespace(forward=run("native"))
+    layer.sdpa_fallback = SimpleNamespace(forward=run("sdpa"))
+    layer.backend_pref = "FLASH_ATTN"
+    return layer, calls
+
+
+@pytest.mark.parametrize(("query_length", "key_length"), [(4, 4), (3, 4)])
+def test_ltx_masked_cross_attention_uses_sdpa(query_length, key_length):
+    layer, calls = _fake_ltx_parallel_attention()
+    query = torch.zeros(1, query_length, 2, 4, dtype=torch.bfloat16)
+    key = value = torch.zeros(1, key_length, 2, 4, dtype=torch.bfloat16)
+    key_padding_mask = torch.tensor([[True] * (key_length - 1) + [False]])
+    metadata = AttentionMetadata(attn_mask=key_padding_mask[:, None, None, :])
+
+    layer._run_local_attention(query, key, value, metadata)
+
+    assert calls == ["sdpa"]
+
+
+def test_ltx_masked_self_attention_uses_sdpa():
+    layer, calls = _fake_ltx_parallel_attention()
+    query = key = value = torch.zeros(1, 4, 2, 4, dtype=torch.bfloat16)
+    key_padding_mask = torch.tensor([[True, True, True, False]])
+    metadata = AttentionMetadata(attn_mask=key_padding_mask[:, None, None, :])
+
+    layer._run_local_attention(query, key, value, metadata)
+
+    assert calls == ["sdpa"]
+
+
+def test_ltx_unmasked_cross_attention_keeps_native_backend():
+    layer, calls = _fake_ltx_parallel_attention()
+    query = key = value = torch.zeros(1, 4, 2, 4, dtype=torch.bfloat16)
+
+    layer._run_local_attention(query, key, value, None)
+
+    assert calls == ["native"]

--- a/vllm_omni/diffusion/models/ltx2/ltx2_denoise.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_denoise.py
@@ -62,6 +62,7 @@ class LTXDenoiseContext:
     audio_latents: torch.Tensor
     video_coords: torch.Tensor
     audio_coords: torch.Tensor
+    audio_attention_mask: torch.Tensor | None = None
     conditioning_mask: torch.Tensor | None = None
     conditioning_mask_for_model: torch.Tensor | None = None
 
@@ -331,6 +332,7 @@ def build_transformer_kwargs(
         # with a learned register, making all output context tokens valid.
         "encoder_attention_mask": None,
         "audio_encoder_attention_mask": None,
+        "audio_attention_mask": denoise_ctx.audio_attention_mask,
         "num_frames": forward_ctx.latent_num_frames,
         "height": forward_ctx.latent_height,
         "width": forward_ctx.latent_width,
@@ -442,11 +444,25 @@ class LTXPhaseExecutor:
             video_audio_step_adapter=video_audio_step_adapter,
         )
         video_coords, audio_coords = prepare_rope_coords_stage(pipeline, forward_ctx, latents, audio_latents)
+        ring_degree = getattr(pipeline.od_config.parallel_config, "ring_degree", 1) or 1
+        if padded_audio_num_frames > original_audio_num_frames and ring_degree > 1:
+            raise ValueError(
+                "LTX audio padding requires an attention mask, which Ring sequence parallelism does not support. "
+                "Use Ulysses-only SP or choose a request whose audio latent length is divisible by the SP size."
+            )
         denoise_ctx = LTXDenoiseContext(
             latents=latents,
             audio_latents=audio_latents,
             video_coords=video_coords,
             audio_coords=audio_coords,
+            audio_attention_mask=(
+                torch.arange(padded_audio_num_frames, device=audio_latents.device)
+                .lt(original_audio_num_frames)
+                .unsqueeze(0)
+                .expand(audio_latents.shape[0], -1)
+                if padded_audio_num_frames > original_audio_num_frames
+                else None
+            ),
             conditioning_mask=conditioning_mask,
         )
         denoise_ctx = pipeline._prepare_denoise_context_for_guidance(forward_ctx, denoise_ctx)

--- a/vllm_omni/diffusion/models/ltx2/ltx2_guidance.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_guidance.py
@@ -126,7 +126,10 @@ def x0_from_velocity(sample: torch.Tensor, velocity: torch.Tensor, sigma: torch.
 
 def velocity_from_x0(sample: torch.Tensor, x0: torch.Tensor, sigma: torch.Tensor) -> torch.Tensor:
     """Convert x0 back to velocity using the official fp32 arithmetic order."""
-    sigma = sigma.to(torch.float32)
+    # Official LTX converts the scalar scheduler sigma to a host value before
+    # division. A CUDA scalar selects different kernel arithmetic and can cross
+    # bf16 rounding boundaries late in the denoise trajectory.
+    sigma = sigma.to(torch.float32).item()
     return ((sample.to(torch.float32) - x0.to(torch.float32)) / sigma).to(sample.dtype)
 
 
@@ -148,6 +151,7 @@ def combine_guided_x0(
     uncond_perturbed: torch.Tensor | float,
     uncond_modality: torch.Tensor | float,
     guidance: LTXModalityGuidance,
+    rescale_token_count: int | None = None,
 ) -> torch.Tensor:
     dtype = cond.dtype
     cond = cond.float()
@@ -163,9 +167,18 @@ def combine_guided_x0(
         # uses its full-tensor standard deviation. In Omni, dimension 0 may
         # instead contain independently scheduled requests. Reduce each item
         # separately so its result cannot depend on unrelated co-batched work.
-        reduce_dims = tuple(range(1, pred.ndim))
-        cond_std = cond.std(dim=reduce_dims, keepdim=True)
-        pred_std = pred.std(dim=reduce_dims, keepdim=True)
+        stats_cond = cond
+        stats_pred = pred
+        if rescale_token_count is not None:
+            if cond.ndim < 2 or not 0 < rescale_token_count <= cond.shape[1]:
+                raise ValueError(
+                    f"Guidance rescale token count must be in [1, {cond.shape[1]}], got {rescale_token_count}."
+                )
+            stats_cond = cond[:, :rescale_token_count]
+            stats_pred = pred[:, :rescale_token_count]
+        reduce_dims = tuple(range(1, stats_pred.ndim))
+        cond_std = stats_cond.std(dim=reduce_dims, keepdim=True)
+        pred_std = stats_pred.std(dim=reduce_dims, keepdim=True)
         eps = torch.finfo(pred.dtype).eps
         factor = cond_std / pred_std.clamp_min(eps)
         factor = torch.where(pred_std > eps, factor, torch.ones_like(factor))
@@ -175,6 +188,8 @@ def combine_guided_x0(
 
 
 def _repeat_batch(tensor: torch.Tensor, repeats: int) -> torch.Tensor:
+    if repeats == 1:
+        return tensor
     return tensor.repeat((repeats,) + (1,) * (tensor.ndim - 1))
 
 
@@ -278,6 +293,11 @@ class LTXGuidanceExecutor:
         if model_pass_count > 1:
             denoise_ctx.video_coords = _repeat_batch(denoise_ctx.video_coords, model_pass_count)
             denoise_ctx.audio_coords = _repeat_batch(denoise_ctx.audio_coords, model_pass_count)
+            if denoise_ctx.audio_attention_mask is not None:
+                denoise_ctx.audio_attention_mask = _repeat_batch(
+                    denoise_ctx.audio_attention_mask,
+                    model_pass_count,
+                )
         return denoise_ctx
 
     @staticmethod
@@ -322,6 +342,7 @@ class LTXGuidanceExecutor:
         guidance: LTXModalityGuidance,
         *,
         model_sigma: torch.Tensor | None = None,
+        rescale_token_count: int | None = None,
     ) -> torch.Tensor:
         model_sigma = sigma if model_sigma is None else model_sigma
         # Official guidance reduces contiguous BSC tensors. The fused
@@ -334,6 +355,7 @@ class LTXGuidanceExecutor:
             uncond_perturbed=x0.get("ptb", 0.0),
             uncond_modality=x0.get("mod", 0.0),
             guidance=guidance,
+            rescale_token_count=rescale_token_count,
         )
         return velocity_from_x0(sample, guided, sigma)
 
@@ -434,6 +456,7 @@ class LTXGuidanceExecutor:
                 audio_splits,
                 forward_ctx.audio_scheduler.sigmas[index],
                 plan.spec.audio,
+                rescale_token_count=forward_ctx.original_audio_num_frames,
             ),
         )
 
@@ -509,6 +532,7 @@ class LTXGuidanceExecutor:
                 audio_splits,
                 forward_ctx.audio_scheduler.sigmas[index],
                 plan.spec.audio,
+                rescale_token_count=forward_ctx.original_audio_num_frames,
             ),
         )
 

--- a/vllm_omni/diffusion/models/ltx2/ltx2_latents.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_latents.py
@@ -117,7 +117,9 @@ def create_noised_state(
         device=latents.device,
         dtype=latents.dtype,
     )
-    return noise_scale * noise + (1 - noise_scale) * latents
+    if isinstance(noise_scale, torch.Tensor):
+        noise_scale = noise_scale.float()
+    return torch.lerp(latents.float(), noise.float(), noise_scale).to(latents.dtype)
 
 
 def pack_audio_latents(latents: torch.Tensor) -> torch.Tensor:
@@ -133,6 +135,16 @@ def unpack_audio_latents(
 
 def unpad_audio_latents(latents: torch.Tensor, num_frames: int) -> torch.Tensor:
     return latents[:, :num_frames]
+
+
+def clear_audio_padding(latents: torch.Tensor, num_frames: int) -> torch.Tensor:
+    """Keep SP-only audio padding outside the logical sampler state."""
+    if not 0 < num_frames <= latents.shape[1]:
+        raise ValueError(f"Audio frame count must be in [1, {latents.shape[1]}], got {num_frames}.")
+    if num_frames == latents.shape[1]:
+        return latents
+    padding = latents.new_zeros(latents.shape[0], latents.shape[1] - num_frames, latents.shape[2])
+    return torch.cat([latents[:, :num_frames], padding], dim=1)
 
 
 def get_sp_padded_audio_latent_length(audio_latent_length: int, sp_size: int) -> int:
@@ -205,7 +217,11 @@ def prepare_video_latents(
             f"You have passed a list of generators of length {len(generator)}, but requested an effective batch"
             f" size of {batch_size}. Make sure the batch size matches the length of the generators."
         )
-    return randn_tensor(shape, generator=generator, device=device, dtype=dtype)
+    latents = randn_tensor(shape, generator=generator, device=device, dtype=dtype)
+    # Official LTX samples the 5D video latent first and then patchifies it,
+    # leaving token-major storage behind the [B, tokens, channels] view. The
+    # values are unchanged, but the layout selects a different bf16 GEMM path.
+    return latents.transpose(1, 2).contiguous().transpose(1, 2)
 
 
 def prepare_audio_latents(
@@ -226,6 +242,16 @@ def prepare_audio_latents(
     sp_size = getattr(pipeline.od_config.parallel_config, "sequence_parallel_size", 1) or 1
     padded_latent_length = get_sp_padded_audio_latent_length(original_latent_length, int(sp_size))
 
+    def pad_logical_latents(logical_latents: torch.Tensor) -> torch.Tensor:
+        if padded_latent_length == original_latent_length:
+            return logical_latents
+        padding = logical_latents.new_zeros(
+            logical_latents.shape[0],
+            padded_latent_length - original_latent_length,
+            logical_latents.shape[2],
+        )
+        return torch.cat([logical_latents, padding], dim=1)
+
     if latents is not None:
         if latents.ndim == 4:
             latents = pack_audio_latents(latents)
@@ -237,29 +263,23 @@ def prepare_audio_latents(
                 pipeline.audio_vae.latents_mean,
                 pipeline.audio_vae.latents_std,
             )
-        latents = create_noised_state(latents, noise_scale, generator)
-
         if latents.shape[1] not in {original_latent_length, padded_latent_length}:
             raise ValueError(
                 "Provided `audio_latents` has incompatible audio frame count "
                 f"{latents.shape[1]}; expected {original_latent_length} or {padded_latent_length}."
             )
-        if latents.shape[1] == original_latent_length and padded_latent_length > original_latent_length:
-            padding = torch.zeros(
-                latents.shape[0],
-                padded_latent_length - original_latent_length,
-                latents.shape[2],
-                dtype=latents.dtype,
-                device=latents.device,
-            )
-            latents = torch.cat([latents, padding], dim=1)
+        # Padding is an Omni implementation detail, not part of the official
+        # audio state. Draw request RNG only for logical tokens so later phases
+        # remain seed-invariant across SP degrees, then append deterministic 0s.
+        latents = create_noised_state(latents[:, :original_latent_length], noise_scale, generator)
+        latents = pad_logical_latents(latents)
         return latents.to(device=device, dtype=dtype), original_latent_length, padded_latent_length
 
-    shape = (batch_size, padded_latent_length, num_channels_latents * latent_mel_bins)
+    shape = (batch_size, original_latent_length, num_channels_latents * latent_mel_bins)
     if isinstance(generator, list) and len(generator) != batch_size:
         raise ValueError(
             f"You have passed a list of generators of length {len(generator)}, but requested an effective batch"
             f" size of {batch_size}. Make sure the batch size matches the length of the generators."
         )
-    latents = randn_tensor(shape, generator=generator, device=device, dtype=dtype)
+    latents = pad_logical_latents(randn_tensor(shape, generator=generator, device=device, dtype=dtype))
     return latents, original_latent_length, padded_latent_length

--- a/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
@@ -137,6 +137,12 @@ class LTXRuntime(
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = "") -> None:
         del prefix
+        parallel_config = getattr(od_config, "parallel_config", None)
+        if getattr(parallel_config, "ulysses_mode", "strict") == "advanced_uaa":
+            raise ValueError(
+                f"{self.__class__.__name__} does not support ulysses_mode='advanced_uaa'. "
+                "Use the default ulysses_mode='strict' for LTX sequence parallelism."
+            )
         self.model_version = detect_ltx_model_version(od_config.model)
         self.component_profile = resolve_ltx_component_profile(self.pipeline_kind, self.model_version)
         self.pipeline_recipe = resolve_ltx_pipeline_recipe(self.pipeline_kind, self.model_version)
@@ -692,6 +698,7 @@ class LTXRuntime(
             noise_pred_audio,
             timestep,
         )
+        audio = latent_ops.clear_audio_padding(audio, forward_ctx.original_audio_num_frames)
         return latent_ops.LTXAVState(video=video, audio=audio)
 
     def _unpack_and_denormalize_stage(

--- a/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
@@ -355,6 +355,19 @@ def to_ltx_padding_mask(attention_mask: torch.Tensor) -> torch.Tensor:
     return attention_mask
 
 
+class _LTX2ParallelAttention(Attention):
+    """Preserve LTX SP collectives while applying model-specific padding masks."""
+
+    def _run_local_attention(self, query, key, value, attn_metadata):
+        attention_mask = attn_metadata.attn_mask if attn_metadata is not None else None
+        if attention_mask is not None:
+            # LTX masks describe K/V padding. Flash varlen applies a 2D mask
+            # to both Q and K, while SP uses a broadcast key-only mask. SDPA
+            # preserves the intended semantics in both cases.
+            return self.sdpa_fallback.forward(query, key, value, attn_metadata)
+        return super()._run_local_attention(query, key, value, attn_metadata)
+
+
 class LTX2AudioVideoAttnProcessor:
     r"""
     Processor for implementing attention (SDPA is used by default if you're using PyTorch 2.0) for the LTX-2.0 model.
@@ -396,11 +409,10 @@ class LTX2AudioVideoAttnProcessor:
             return None
 
         if self._is_sp_enabled():
-            # In SP, Ulysses expects a 2D padding mask that matches query length.
-            # For cross-attention, encoder sequence length != query length, so drop the mask.
-            if encoder_hidden_states is not None and encoder_hidden_states.shape[1] != hidden_states.shape[1]:
-                return None
-            return to_ltx_padding_mask(attention_mask)
+            # Keep the full key mask replicated while strict Ulysses reshards
+            # Q/K/V. The broadcast Q dimension also supports cross-attention
+            # where Q and K have different sequence lengths.
+            return to_ltx_padding_mask(attention_mask)[:, None, None, :]
 
         attention_mask = attn.prepare_attention_mask(attention_mask, sequence_length, batch_size)
         attention_mask = attention_mask.view(batch_size, attn.heads, -1, attention_mask.shape[-1])
@@ -696,7 +708,7 @@ class LTX2Attention(torch.nn.Module):
                 torch.nn.Dropout(dropout) if dropout > 0 else torch.nn.Identity(),
             ]
         )
-        self.attn = Attention(
+        self.attn = _LTX2ParallelAttention(
             num_heads=self.query_num_heads,
             head_size=dim_head,
             num_kv_heads=self.kv_num_heads,
@@ -1828,6 +1840,7 @@ class LTX2VideoTransformer3DModel(nn.Module):
         audio_sigma: torch.Tensor | None = None,
         encoder_attention_mask: torch.Tensor | None = None,
         audio_encoder_attention_mask: torch.Tensor | None = None,
+        audio_attention_mask: torch.Tensor | None = None,
         num_frames: int | None = None,
         height: int | None = None,
         width: int | None = None,
@@ -1861,6 +1874,8 @@ class LTX2VideoTransformer3DModel(nn.Module):
                 Optional multiplicative text attention mask of shape `(batch_size, text_seq_len)`.
             audio_encoder_attention_mask (`torch.Tensor`, *optional*):
                 Optional multiplicative text attention mask of shape `(batch_size, text_seq_len)` for audio modeling.
+            audio_attention_mask (`torch.Tensor`, *optional*):
+                Optional audio-token key padding mask shared by audio self-attention and audio-to-video attention.
             num_frames (`int`, *optional*):
                 The number of latent video frames. Used if calculating the video coordinates for RoPE.
             height (`int`, *optional*):
@@ -2044,6 +2059,8 @@ class LTX2VideoTransformer3DModel(nn.Module):
                 "ca_audio_rotary_emb": audio_cross_attn_rotary_emb,
                 "encoder_attention_mask": encoder_attention_mask,
                 "audio_encoder_attention_mask": audio_encoder_attention_mask,
+                "audio_self_attention_mask": audio_attention_mask,
+                "a2v_cross_attention_mask": audio_attention_mask,
                 "video_self_attention_perturbation_mask": perturbation_mask_for("video_self_attention", block_idx),
                 "audio_self_attention_perturbation_mask": perturbation_mask_for("audio_self_attention", block_idx),
                 "a2v_cross_attention_perturbation_mask": perturbation_mask_for("a2v_cross_attention", block_idx),


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This PR extracts the shared LTX correctness fixes found while developing #5500. It fixes existing LTX execution paths without bringing in phased LoRA or full two-stage support; those remain in #5500.

## What changes

- Match the official seeded numerical trajectory:
  - preserve the official token-major video latent layout;
  - use FP32 `torch.lerp` for latent noising;
  - use an FP32 host scalar for Euler velocity conversion;
  - preserve the original tensor and layout for positive-only guidance.
- Keep SP-only audio padding outside the model result:
  - consume RNG for logical audio tokens only, then append zero padding;
  - clear padded tokens after every sampler update;
  - exclude padding from guidance rescale statistics;
  - propagate a key-only audio mask through audio self-attention and audio-to-video cross-attention.
- Keep the attention policy LTX-scoped:
  - use SDPA for masked LTX attention;
  - reject `advanced_uaa` for LTX;
  - reject Ring only when the request actually needs audio padding.

There are no public API, recipe, checkpoint, or LoRA behavior changes in this PR.

## A/B correctness

All runs used the same checkpoint, prompt, seed, shape, eager mode, and PyTorch SDPA. `A` is unmodified main at `877beeaa`; `B` is this PR. The reference is the native Lightricks pipeline pinned to the same source revision.

### Cross-version accuracy matrix

The complete matrix uses one H200, eager mode, PyTorch SDPA, 512×384 output, and 25 frames. `Full one-stage` uses `LTX2Pipeline` with 20 steps and the official guidance defaults. `Distilled two-stage` uses `LTX2DistilledPipeline` with the fixed official 8+3 positive-only recipe.

| Version | Pipeline | Task | Video SSIM mean | Video SSIM min | PSNR | Audio cosine | Audio relative L2 | Result |
|---|---|---|---:|---:|---:|---:|---:|---|
| LTX-2 | Full one-stage | T2V | 0.999954 | 0.999945 | 70.62 dB | 1.000000 | 0.000000 | Pass; audio bitwise equal |
| LTX-2 | Full one-stage | I2V | 0.999712 | 0.999660 | 63.39 dB | 1.000000 | 0.000000 | Pass; audio bitwise equal |
| LTX-2 | Distilled two-stage | T2V | 0.999976 | 0.999974 | 71.79 dB | 1.000000 | 0.000000 | Pass; audio bitwise equal |
| LTX-2 | Distilled two-stage | I2V | 0.997550 | 0.996286 | 46.78 dB | 0.993462 | 0.114387 | Pass |
| LTX-2.3 | Full one-stage | T2V | 0.999892 | 0.999831 | 65.56 dB | 0.999264 | 0.038377 | Pass |
| LTX-2.3 | Full one-stage | I2V | 0.999833 | 0.999770 | 66.16 dB | 0.998521 | 0.054455 | Pass |
| LTX-2.3 | Distilled two-stage | T2V | — | — | — | — | — | Not supported by #6146 |
| LTX-2.3 | Distilled two-stage | I2V | — | — | — | — | — | Not supported by #6146 |

All six combinations supported by #6146 pass the strict native-official thresholds. The native LTX-2.3 distilled two-stage reference also runs successfully, but #6146 does not register its Omni component profile or recipe and rejects it during initialization:

```text
ValueError: Unsupported LTX component kind/version: 'distilled_two_stage'/'2.3'.
```

LTX-2.3 distilled two-stage support remains in #5500 and is intentionally not added by this correctness-only PR.

### Distilled two-stage T2V

Configuration: `Lightricks/LTX-2`, 512×384, 25 frames, 8+3 fixed positive-only steps, seed 10.

| Metric vs. official | A: main | B: this PR |
|---|---:|---:|
| Video SSIM mean | 0.866897 | **0.999976** |
| Video SSIM min | 0.863779 | **0.999974** |
| Video PSNR | 21.364 dB | **71.786 dB** |
| Video max absolute error | 0.957031 | **0.007812** |
| Video mean absolute error | 0.051779 | **0.000020** |
| Audio cosine | 0.871622 | **1.000000** |
| Audio relative L2 | 0.513435 | **0.000000** |
| Audio bitwise equal | No | **Yes** |

This trajectory exercises the token layout, positive-only layout preservation, FP32 noising, and Euler scalar arithmetic changes together.

### USP2 request requiring audio padding

Configuration: the same distilled path at 9 frames. This produces 9 logical audio tokens padded to 10 for USP2, so the padding path is active.

| Metric vs. official | A: main USP2 | B: this PR USP2 |
|---|---:|---:|
| Video SSIM mean | 0.913684 | **0.930010** |
| Video SSIM min | 0.913011 | **0.928806** |
| Video PSNR | 23.380 dB | **24.740 dB** |
| Audio cosine | 0.393072 | **0.889772** |
| Audio relative L2 | 1.165546 | **0.469857** |

This validates the padding fix, but it does not claim exact USP/single-GPU parity. A divisible-length control still diverges under Ulysses, confirming a separate existing parallel numerical-trajectory difference outside this PR's scope.

## Test plan

- LTX unit tests: `146 passed`
- Changed-file pre-commit hooks: passed
- `git diff --check`: passed
- GPU A/B: distilled two-stage T2V on 1 GPU and USP2 padding case
