### PR TITLE
[WIP][Bugfix] Fix MiniCPM duplex handoff

### DIFF
--- a/tests/engine/test_cfg_companion_lifecycle.py
+++ b/tests/engine/test_cfg_companion_lifecycle.py
@@ -233,8 +233,13 @@ async def test_companion_abort_after_completion_does_not_fail_parent():
     assert orch._cfg_tracker.get_companion_outputs("p") == [{"o": 1}]  # bundle intact
 
 
-class _CapturedDispatchError(Exception):
-    """Sentinel raised by the capture hook to stop the forward after bundling."""
+class _CapturedDispatchError(BaseException):
+    """Sentinel raised by the capture hook to stop the forward after bundling.
+
+    Deliberately a BaseException: the orchestrator scopes every *Exception* a
+    stage bridge raises to the request (reporting it and cleaning up), so an
+    Exception sentinel would be swallowed and the capture loop would see a
+    torn-down request instead of a second bundle."""
 
 
 @pytest.mark.asyncio

--- a/tests/engine/test_orchestrator.py
+++ b/tests/engine/test_orchestrator.py
@@ -2434,3 +2434,56 @@ async def test_request_cleanup_failure_is_deferred_to_control_plane():
 
     assert orchestrator.duplex_control_plane.deferred == ["sid-cleanup"]
     assert orchestrator.duplex_control_plane.finalized == []
+
+
+@pytest.mark.asyncio
+async def test_streaming_terminal_update_is_skipped_once_the_forward_failed():
+    """A finished streaming request forwards twice: the segment update, then the
+    terminal (resumable=False) one. If the first forward already failed and
+    cleaned up the request, the second re-runs the same doomed bridge and
+    reports the same failure again."""
+    from vllm.sampling_params import SamplingParams
+
+    from vllm_omni.engine.cfg_companion_tracker import CfgCompanionTracker
+
+    orchestrator = object.__new__(Orchestrator)
+    orchestrator.stage_pools = [
+        SimpleNamespace(final_output=False),
+        SimpleNamespace(final_output=True),
+    ]
+    orchestrator.duplex_control_plane = None
+    orchestrator.async_chunk = False
+    orchestrator._pd_pair = None
+    orchestrator.output_async_queue = asyncio.Queue()
+    orchestrator.request_states = {}
+    orchestrator._cfg_tracker = CfgCompanionTracker()
+
+    req_state = OrchestratorRequestState(
+        request_id="req-streaming",
+        prompt={"prompt": "hello"},
+        sampling_params_list=[SamplingParams(max_tokens=1), SamplingParams(max_tokens=1)],
+        final_stage_id=1,
+    )
+    req_state.streaming.enabled = True
+    orchestrator.request_states["req-streaming"] = req_state
+
+    forwards: list[bool] = []
+
+    async def _fake_forward(req_id, stage_id, output, state, **kwargs):
+        forwards.append(kwargs.get("is_final_update", False))
+        # Stand in for a failed forward: the request is failed and cleaned up.
+        orchestrator.request_states.pop(req_id, None)
+
+    orchestrator._forward_to_next_stage = _fake_forward
+
+    await orchestrator._route_output(
+        0,
+        0,
+        SimpleNamespace(request_id="req-streaming", finished=True),
+        req_state,
+        None,
+    )
+
+    assert forwards == [False]
+
+

--- a/tests/engine/test_orchestrator.py
+++ b/tests/engine/test_orchestrator.py
@@ -2485,5 +2485,3 @@ async def test_streaming_terminal_update_is_skipped_once_the_forward_failed():
     )
 
     assert forwards == [False]
-
-

--- a/tests/engine/test_orchestrator_error_handling.py
+++ b/tests/engine/test_orchestrator_error_handling.py
@@ -5,6 +5,7 @@
 Covers:
 - EngineDeadError from an LLM stage poll → fatal error broadcast + replica eviction
 - Diffusion stage error output (OmniRequestOutput.from_error) → routed correctly
+- Stage input processor failure on the inter-stage bridge → request-scoped error
 """
 
 from __future__ import annotations
@@ -12,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import queue
 import time
+from http import HTTPStatus
 from types import SimpleNamespace
 
 import janus
@@ -27,6 +29,7 @@ from vllm_omni.engine.messages import (
 )
 from vllm_omni.engine.orchestrator import Orchestrator, OrchestratorRequestState
 from vllm_omni.engine.stage_pool import StageUnavailableError
+from vllm_omni.errors import DEFAULT_CLIENT_ERROR_TYPE, OmniClientError, StageInputProcessingError
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 from vllm_omni.outputs import OmniRequestOutput
 
@@ -289,6 +292,113 @@ async def test_forward_to_dead_downstream_stage_fails_request_not_server(orchest
         if orchestrator_fixture.thread.is_alive():
             orchestrator_fixture.request_sync_q.put_nowait(ShutdownRequestMessage())
             orchestrator_fixture.thread.join(timeout=5)
+
+
+class _FailingInputProcessorStageClient(FakeStageClient):
+    """LLM stage replica whose inter-stage input processor rejects the payload."""
+
+    def __init__(self, *args, exc: Exception, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.exc = exc
+
+    def process_engine_inputs(self, source_outputs, prompt=None, streaming_context=None):
+        raise self.exc
+
+
+async def _run_failing_bridge(
+    orchestrator_factory,
+    *,
+    request_id: str,
+    exc: Exception,
+) -> tuple[ErrorMessage, OrchestratorFixture, FakeStageClient]:
+    """Drive a two-stage pipeline whose stage-0 -> stage-1 bridge raises ``exc``."""
+    stage0 = FakeStageClient(stage_type="llm", final_output=False, next_inputs=[{"prompt_token_ids": [7, 8]}])
+    stage1 = _FailingInputProcessorStageClient(stage_type="llm", final_output=True, exc=exc)
+    proc0 = FakeOutputProcessor(request_outputs=[_build_request_output(request_id, token_ids=[3], finished=True)])
+    stage_pools = _build_stage_pools([[stage0], [stage1]], output_processors=[proc0, FakeOutputProcessor()])
+    fixture = orchestrator_factory([], stage_pools=stage_pools)
+
+    await _enqueue_add_request(
+        fixture,
+        request_id=request_id,
+        prompt=SimpleNamespace(request_id=request_id, prompt_token_ids=[1, 2]),
+        original_prompt={"prompt": "hello"},
+        sampling_params_list=[_sampling_params(), _sampling_params()],
+        final_stage_id=1,
+    )
+    await _wait_for(lambda: len(stage0.add_request_calls) == 1)
+
+    # Completing stage 0 triggers the stage-0 -> stage-1 bridge, which raises.
+    stage0.push_engine_core_outputs(_engine_core_outputs("s0-raw", 1.0))
+    error_msg = await _wait_for_error_message(fixture, request_id=request_id)
+    return error_msg, fixture, stage1
+
+
+@pytest.mark.asyncio
+async def test_stage_input_processor_rejection_fails_request_not_server(orchestrator_factory) -> None:
+    """A stage bridge that rejects one request's payload must fail only that
+    request. ``process_engine_inputs`` runs inline in the orchestration loop with
+    no per-request guard above it, so an escaping exception would unwind into
+    ``Orchestrator.run()`` and shut every stage down (#6099).
+    """
+    error_msg, fixture, stage1 = await _run_failing_bridge(
+        orchestrator_factory,
+        request_id="req-bad-handoff",
+        exc=StageInputProcessingError("No latent or hidden_states found in thinker output"),
+    )
+
+    assert error_msg.fatal is False
+    assert error_msg.stage_id == 1
+    assert error_msg.error == (
+        "Stage input processing failed for stage-0->stage-1: No latent or hidden_states found in thinker output"
+    )
+    # An anticipated rejection carries no client-error metadata, so the frontend
+    # surfaces it as a 500 rather than a 4xx.
+    assert error_msg.status_code is None
+    assert error_msg.error_type is None
+
+    # The failure is scoped to the request: the orchestrator keeps running, the
+    # request state is released, and nothing was submitted downstream.
+    assert fixture.thread.is_alive()
+    await _wait_for(lambda: "req-bad-handoff" not in fixture.orchestrator.request_states)
+    assert stage1.add_request_calls == []
+
+
+@pytest.mark.asyncio
+async def test_unexpected_stage_input_processor_bug_is_still_request_scoped(orchestrator_factory) -> None:
+    """An unanticipated processor bug must not tear the server down either, but it
+    is reported as an internal error rather than blamed on the request's input."""
+    error_msg, fixture, _ = await _run_failing_bridge(
+        orchestrator_factory,
+        request_id="req-processor-bug",
+        exc=AttributeError("'NoneType' object has no attribute 'shape'"),
+    )
+
+    assert error_msg.fatal is False
+    assert error_msg.stage_id == 1
+    assert error_msg.error == (
+        "Internal error in stage-0->stage-1 input processor: AttributeError: 'NoneType' object has no attribute 'shape'"
+    )
+    assert error_msg.status_code is None
+    assert fixture.thread.is_alive()
+    await _wait_for(lambda: "req-processor-bug" not in fixture.orchestrator.request_states)
+
+
+@pytest.mark.asyncio
+async def test_stage_input_processor_client_error_keeps_4xx_metadata(orchestrator_factory) -> None:
+    """An ``OmniClientError`` raised by a stage bridge keeps its 4xx status so the
+    frontend reports a client error instead of a generic 500."""
+    error_msg, fixture, _ = await _run_failing_bridge(
+        orchestrator_factory,
+        request_id="req-bad-input",
+        exc=OmniClientError("reference audio is malformed"),
+    )
+
+    assert error_msg.fatal is False
+    assert error_msg.status_code == HTTPStatus.BAD_REQUEST.value
+    assert error_msg.error_type == DEFAULT_CLIENT_ERROR_TYPE
+    assert "reference audio is malformed" in error_msg.error
+    assert fixture.thread.is_alive()
 
 
 @pytest.mark.asyncio

--- a/tests/engine/test_orchestrator_error_handling.py
+++ b/tests/engine/test_orchestrator_error_handling.py
@@ -294,17 +294,6 @@ async def test_forward_to_dead_downstream_stage_fails_request_not_server(orchest
             orchestrator_fixture.thread.join(timeout=5)
 
 
-class _FailingInputProcessorStageClient(FakeStageClient):
-    """LLM stage replica whose inter-stage input processor rejects the payload."""
-
-    def __init__(self, *args, exc: Exception, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.exc = exc
-
-    def process_engine_inputs(self, source_outputs, prompt=None, streaming_context=None):
-        raise self.exc
-
-
 async def _run_failing_bridge(
     orchestrator_factory,
     *,
@@ -312,8 +301,13 @@ async def _run_failing_bridge(
     exc: Exception,
 ) -> tuple[ErrorMessage, OrchestratorFixture, FakeStageClient]:
     """Drive a two-stage pipeline whose stage-0 -> stage-1 bridge raises ``exc``."""
+
+    def _reject(source_outputs, prompt=None, streaming_context=None):
+        raise exc
+
     stage0 = FakeStageClient(stage_type="llm", final_output=False, next_inputs=[{"prompt_token_ids": [7, 8]}])
-    stage1 = _FailingInputProcessorStageClient(stage_type="llm", final_output=True, exc=exc)
+    stage1 = FakeStageClient(stage_type="llm", final_output=True)
+    stage1.process_engine_inputs = _reject
     proc0 = FakeOutputProcessor(request_outputs=[_build_request_output(request_id, token_ids=[3], finished=True)])
     stage_pools = _build_stage_pools([[stage0], [stage1]], output_processors=[proc0, FakeOutputProcessor()])
     fixture = orchestrator_factory([], stage_pools=stage_pools)

--- a/tests/engine/test_orchestrator_error_handling.py
+++ b/tests/engine/test_orchestrator_error_handling.py
@@ -349,9 +349,12 @@ async def test_stage_input_processor_rejection_fails_request_not_server(orchestr
 
     assert error_msg.fatal is False
     assert error_msg.stage_id == 1
-    assert error_msg.error == (
-        "Stage input processing failed for stage-0->stage-1: No latent or hidden_states found in thinker output"
-    )
+    # Assert the classification and the payload, not the exact sentence: the
+    # bridge is named, the processor's own message survives, and the report is
+    # NOT dressed up as an internal error.
+    assert "stage-0->stage-1" in error_msg.error
+    assert "No latent or hidden_states found in thinker output" in error_msg.error
+    assert "Internal error" not in error_msg.error
     # An anticipated rejection carries no client-error metadata, so the frontend
     # surfaces it as a 500 rather than a 4xx.
     assert error_msg.status_code is None
@@ -376,9 +379,12 @@ async def test_unexpected_stage_input_processor_bug_is_still_request_scoped(orch
 
     assert error_msg.fatal is False
     assert error_msg.stage_id == 1
-    assert error_msg.error == (
-        "Internal error in stage-0->stage-1 input processor: AttributeError: 'NoneType' object has no attribute 'shape'"
-    )
+    # Same three properties as the rejection case, with the classification
+    # inverted: this one IS flagged as internal and names the exception type.
+    assert "stage-0->stage-1" in error_msg.error
+    assert "'NoneType' object has no attribute 'shape'" in error_msg.error
+    assert "Internal error" in error_msg.error
+    assert "AttributeError" in error_msg.error
     assert error_msg.status_code is None
     assert fixture.thread.is_alive()
     await _wait_for(lambda: "req-processor-bug" not in fixture.orchestrator.request_states)

--- a/tests/model_executor/models/minicpmo_4_5/test_llm2tts.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_llm2tts.py
@@ -25,6 +25,7 @@ import torch
 from vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni import (
     MiniCPMO45OmniForConditionalGeneration,
 )
+from vllm_omni.errors import StageInputProcessingError
 from vllm_omni.model_executor.stage_input_processors.minicpmo_4_5_omni import llm2tts
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
@@ -132,7 +133,7 @@ class TestInputValidation:
             prompt_token_ids=[10, 11],
             output_token_ids=[20],
         )
-        with pytest.raises(ValueError, match="No latent or hidden_states"):
+        with pytest.raises(StageInputProcessingError, match="No latent or hidden_states"):
             llm2tts([bad], prompt=None)
 
 

--- a/tests/model_executor/models/minicpmo_4_5/test_llm2tts.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_llm2tts.py
@@ -22,10 +22,10 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from vllm_omni.errors import StageInputProcessingError
 from vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni import (
     MiniCPMO45OmniForConditionalGeneration,
 )
-from vllm_omni.errors import StageInputProcessingError
 from vllm_omni.model_executor.stage_input_processors.minicpmo_4_5_omni import llm2tts
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]

--- a/tests/model_executor/stage_input_processors/test_minicpmo_4_5_omni.py
+++ b/tests/model_executor/stage_input_processors/test_minicpmo_4_5_omni.py
@@ -142,11 +142,9 @@ def test_native_duplex_speak_segment_reaches_split_talker() -> None:
 @pytest.mark.parametrize(
     "output_ids",
     (
-        [],
-        [9303],
-        [9303, 9303],
-        [9308],
-        [9303, 9308],
+        [],  # nothing generated
+        [9303],  # a listen run that consumes the whole delta
+        [9308],  # a bare control terminator
     ),
 )
 def test_native_duplex_no_speech_without_hidden_states_is_skipped(output_ids: list[int]) -> None:
@@ -174,19 +172,6 @@ def test_native_duplex_no_speech_without_hidden_states_is_skipped(output_ids: li
         )
         == []
     )
-
-
-def test_non_duplex_output_without_hidden_states_raises_stage_input_error() -> None:
-    source = _output(
-        prompt_ids=[101],
-        output_ids=[21],
-    )
-
-    with pytest.raises(StageInputProcessingError, match="No latent or hidden_states"):
-        llm2tts(
-            [source],
-            prompt=[{}],
-        )
 
 
 def test_native_duplex_speech_without_hidden_states_raises_stage_input_error() -> None:

--- a/tests/model_executor/stage_input_processors/test_minicpmo_4_5_omni.py
+++ b/tests/model_executor/stage_input_processors/test_minicpmo_4_5_omni.py
@@ -333,7 +333,7 @@ def test_native_duplex_requires_tokenizer_boundary_metadata() -> None:
         multimodal_output={"duplex_prompt_token_ids": [101]},
     )
 
-    with pytest.raises(ValueError, match="tokenizer-derived.*metadata"):
+    with pytest.raises(StageInputProcessingError, match="tokenizer-derived.*metadata"):
         llm2tts([source], prompt=[{}], _streaming_context=SimpleNamespace(bridge_states={}))
 
 

--- a/tests/model_executor/stage_input_processors/test_minicpmo_4_5_omni.py
+++ b/tests/model_executor/stage_input_processors/test_minicpmo_4_5_omni.py
@@ -15,12 +15,13 @@ def _output(
     *,
     prompt_ids: list[int],
     output_ids: list[int],
-    latent: torch.Tensor,
+    latent: torch.Tensor | None = None,
     multimodal_output: dict | None = None,
     token_list: list[int] | None = None,
 ):
     mm_output = dict(multimodal_output or {})
-    mm_output["latent"] = latent
+    if latent is not None:
+        mm_output["latent"] = latent
     completion = SimpleNamespace(
         token_ids=output_ids if token_list is None else token_list,
         text="hello",
@@ -135,6 +136,68 @@ def test_native_duplex_speak_segment_reaches_split_talker() -> None:
     assert info["meta"]["segment_end"] is True
     assert info["duplex"]["epoch"] == 3
     assert info["duplex"]["turn_id"] == 7
+
+
+@pytest.mark.parametrize(
+    "output_ids",
+    (
+        [],
+        [9303],
+        [9303, 9303],
+        [9308],
+        [9303, 9308],
+    ),
+)
+def test_native_duplex_no_speech_without_hidden_states_is_skipped(output_ids: list[int]) -> None:
+    source = _output(
+        prompt_ids=[101],
+        output_ids=output_ids,
+        multimodal_output={
+            "duplex_prompt_token_ids": [101],
+            "meta": {
+                "tts_bos_token_id": 9301,
+                "tts_eos_token_id": 9302,
+                "listen_token_id": 9303,
+                "speak_token_id": 9304,
+                "chunk_eos_token_id": 9308,
+                "chunk_tts_eos_token_id": 9309,
+                "turn_eos_token_id": 9310,
+            },
+        },
+    )
+
+    assert (
+        llm2tts(
+            [source],
+            prompt=[{}],
+        )
+        == []
+    )
+
+
+def test_native_duplex_speech_without_hidden_states_still_raises() -> None:
+    source = _output(
+        prompt_ids=[101],
+        output_ids=[9304, 21, 9308],
+        multimodal_output={
+            "duplex_prompt_token_ids": [101],
+            "meta": {
+                "tts_bos_token_id": 9301,
+                "tts_eos_token_id": 9302,
+                "listen_token_id": 9303,
+                "speak_token_id": 9304,
+                "chunk_eos_token_id": 9308,
+                "chunk_tts_eos_token_id": 9309,
+                "turn_eos_token_id": 9310,
+            },
+        },
+    )
+
+    with pytest.raises(ValueError, match="No latent or hidden_states"):
+        llm2tts(
+            [source],
+            prompt=[{}],
+        )
 
 
 def test_native_duplex_continuation_appends_only_new_talker_condition() -> None:

--- a/tests/model_executor/stage_input_processors/test_minicpmo_4_5_omni.py
+++ b/tests/model_executor/stage_input_processors/test_minicpmo_4_5_omni.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from vllm_omni.errors import StageInputProcessingError
 from vllm_omni.model_executor.stage_input_processors.minicpmo_4_5_omni import (
     _extract_first_audio_ref,
     llm2tts,
@@ -175,7 +176,20 @@ def test_native_duplex_no_speech_without_hidden_states_is_skipped(output_ids: li
     )
 
 
-def test_native_duplex_speech_without_hidden_states_still_raises() -> None:
+def test_non_duplex_output_without_hidden_states_raises_stage_input_error() -> None:
+    source = _output(
+        prompt_ids=[101],
+        output_ids=[21],
+    )
+
+    with pytest.raises(StageInputProcessingError, match="No latent or hidden_states"):
+        llm2tts(
+            [source],
+            prompt=[{}],
+        )
+
+
+def test_native_duplex_speech_without_hidden_states_raises_stage_input_error() -> None:
     source = _output(
         prompt_ids=[101],
         output_ids=[9304, 21, 9308],
@@ -193,7 +207,7 @@ def test_native_duplex_speech_without_hidden_states_still_raises() -> None:
         },
     )
 
-    with pytest.raises(ValueError, match="No latent or hidden_states"):
+    with pytest.raises(StageInputProcessingError, match="No latent or hidden_states"):
         llm2tts(
             [source],
             prompt=[{}],

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -1129,6 +1129,64 @@ class Orchestrator:
             abort=True,
         )
 
+    async def _fail_request_bridge_error(
+        self,
+        exc: BaseException,
+        *,
+        req_id: str,
+        src_stage_id: int,
+        next_logical: int,
+    ) -> None:
+        """Fail one request whose inter-stage bridge raised.
+
+        A stage bridge rejects ONE request's payload; that says nothing about
+        engine health. There is no per-request guard above this frame —
+        _handle_processed_outputs runs outside the stage-poll try/except — so
+        re-raising would unwind into Orchestrator.run() and tear down every
+        stage. Fail just this request (#4285).
+
+        Every failure here is request-scoped, but they are not equally
+        expected: StageInputProcessingError (and OmniClientError) mark a payload
+        the processor knowingly rejects, while anything else is a processor bug
+        that must keep its traceback and must not be reported to the caller as
+        if their input were at fault.
+
+        This handles the shared ``process_engine_inputs`` bridge used by the
+        MiniCPM-o Thinker-to-Talker handoff.
+        """
+        bridge = f"stage-{src_stage_id}->stage-{next_logical}"
+        if isinstance(exc, StageInputProcessingError | OmniClientError):
+            logger.warning(
+                "[Orchestrator] req=%s %s input processor rejected the payload: %s",
+                req_id,
+                bridge,
+                exc,
+            )
+            error = f"Stage input processing failed for {bridge}: {exc}"
+        else:
+            logger.exception(
+                "[Orchestrator] req=%s input processing FAILED for %s",
+                req_id,
+                bridge,
+                exc_info=exc,
+            )
+            error = f"Internal error in {bridge} input processor: {type(exc).__name__}: {exc}"
+        status_code, error_type = client_error_metadata(exc)
+        await self.output_async_queue.put(
+            ErrorMessage(
+                request_id=req_id,
+                stage_id=next_logical,
+                error=error,
+                status_code=status_code,
+                error_type=error_type,
+            )
+        )
+        await self._cleanup_request_ids(
+            [req_id, *self._cfg_tracker.cleanup_parent(req_id)],
+            abort=True,
+            close_duplex_sessions=True,
+        )
+
     async def _dispatch_or_fail_request(
         self,
         dispatch: Callable[[], Awaitable[Any]],
@@ -2124,47 +2182,11 @@ class Orchestrator:
                 streaming_context=req_state.streaming,
             )
         except Exception as exc:
-            # A stage bridge rejects ONE request's payload; that says nothing
-            # about engine health. There is no per-request guard above this
-            # frame — _handle_processed_outputs runs outside the stage-poll
-            # try/except — so re-raising would unwind into Orchestrator.run()
-            # and tear down every stage. Fail just this request (#4285).
-            #
-            # Every failure here is request-scoped, but they are not equally
-            # expected: StageInputProcessingError (and OmniClientError) mark a
-            # payload the processor knowingly rejects, while anything else is a
-            # processor bug that must keep its traceback and must not be
-            # reported to the caller as if their input were at fault.
-            bridge = f"stage-{src_stage_id}->stage-{next_logical}"
-            if isinstance(exc, (StageInputProcessingError, OmniClientError)):
-                logger.warning(
-                    "[Orchestrator] req=%s %s input processor rejected the payload: %s",
-                    req_id,
-                    bridge,
-                    exc,
-                )
-                error = f"Stage input processing failed for {bridge}: {exc}"
-            else:
-                logger.exception(
-                    "[Orchestrator] req=%s process_engine_inputs FAILED for stage-%s",
-                    req_id,
-                    next_logical,
-                )
-                error = f"Internal error in {bridge} input processor: {type(exc).__name__}: {exc}"
-            status_code, error_type = client_error_metadata(exc)
-            await self.output_async_queue.put(
-                ErrorMessage(
-                    request_id=req_id,
-                    stage_id=next_logical,
-                    error=error,
-                    status_code=status_code,
-                    error_type=error_type,
-                )
-            )
-            await self._cleanup_request_ids(
-                [req_id, *self._cfg_tracker.cleanup_parent(req_id)],
-                abort=True,
-                close_duplex_sessions=True,
+            await self._fail_request_bridge_error(
+                exc,
+                req_id=req_id,
+                src_stage_id=src_stage_id,
+                next_logical=next_logical,
             )
             return
         finally:

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -51,6 +51,7 @@ from vllm_omni.engine.messages import (
 from vllm_omni.engine.orchestrator_monitor import create_orch_monitor, replica_key
 from vllm_omni.engine.serialization import serialize_additional_information
 from vllm_omni.engine.stage_pool import StagePool, StageUnavailableError
+from vllm_omni.errors import OmniClientError, StageInputProcessingError, client_error_metadata
 from vllm_omni.metrics.prometheus import OmniRequestCounter
 from vllm_omni.metrics.stat_logger import OmniPrometheusStatLogger
 from vllm_omni.outputs import OmniRequestOutput
@@ -2122,13 +2123,50 @@ class Orchestrator:
                 req_state.prompt,
                 streaming_context=req_state.streaming,
             )
-        except Exception:
-            logger.exception(
-                "[Orchestrator] req=%s process_engine_inputs FAILED for stage-%s",
-                req_id,
-                next_logical,
+        except Exception as exc:
+            # A stage bridge rejects ONE request's payload; that says nothing
+            # about engine health. There is no per-request guard above this
+            # frame — _handle_processed_outputs runs outside the stage-poll
+            # try/except — so re-raising would unwind into Orchestrator.run()
+            # and tear down every stage. Fail just this request (#4285).
+            #
+            # Every failure here is request-scoped, but they are not equally
+            # expected: StageInputProcessingError (and OmniClientError) mark a
+            # payload the processor knowingly rejects, while anything else is a
+            # processor bug that must keep its traceback and must not be
+            # reported to the caller as if their input were at fault.
+            bridge = f"stage-{src_stage_id}->stage-{next_logical}"
+            if isinstance(exc, (StageInputProcessingError, OmniClientError)):
+                logger.warning(
+                    "[Orchestrator] req=%s %s input processor rejected the payload: %s",
+                    req_id,
+                    bridge,
+                    exc,
+                )
+                error = f"Stage input processing failed for {bridge}: {exc}"
+            else:
+                logger.exception(
+                    "[Orchestrator] req=%s process_engine_inputs FAILED for stage-%s",
+                    req_id,
+                    next_logical,
+                )
+                error = f"Internal error in {bridge} input processor: {type(exc).__name__}: {exc}"
+            status_code, error_type = client_error_metadata(exc)
+            await self.output_async_queue.put(
+                ErrorMessage(
+                    request_id=req_id,
+                    stage_id=next_logical,
+                    error=error,
+                    status_code=status_code,
+                    error_type=error_type,
+                )
             )
-            raise
+            await self._cleanup_request_ids(
+                [req_id, *self._cfg_tracker.cleanup_parent(req_id)],
+                abort=True,
+                close_duplex_sessions=True,
+            )
+            return
         finally:
             req_state.streaming.source_token_decoder = previous_decoder
 

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -1519,6 +1519,11 @@ class Orchestrator:
                     and finished
                     and not final_only_finished
                     and not self._is_duplex_session_request(req_state)
+                    # The forward above can fail the request (a rejected bridge
+                    # payload, a dead downstream stage) and clean it up. Sending
+                    # the terminal update anyway re-runs the same doomed bridge
+                    # and reports the same failure a second time.
+                    and req_id in self.request_states
                 ):
                     # For streaming sessions, send the terminal (resumable=False) update only on a finish
                     await self._forward_to_next_stage(

--- a/vllm_omni/errors.py
+++ b/vllm_omni/errors.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-"""Request-scoped client error types shared across vLLM-Omni entrypoints."""
+"""Request-scoped error types shared across vLLM-Omni components."""
 
 from __future__ import annotations
 
@@ -10,6 +10,18 @@ from http import HTTPStatus
 from typing import NoReturn
 
 DEFAULT_CLIENT_ERROR_TYPE = "BadRequestError"
+
+
+class StageInputProcessingError(RuntimeError):
+    """A stage bridge knowingly rejected the payload of one request.
+
+    Every exception escaping a stage input processor is request-scoped — the
+    orchestrator never lets one bad payload tear down the engine. This type
+    marks the rejections a processor *anticipates* (a malformed handoff, an
+    unusable intermediate tensor) so they are reported as such, while an
+    unexpected processor bug keeps its traceback and is surfaced as an internal
+    error instead of being blamed on the request.
+    """
 
 
 class OmniClientError(ValueError):

--- a/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
@@ -773,8 +773,6 @@ def llm2tts(
         if tts_bos_id is None and not is_native_duplex_handoff:
             tts_bos_id = 151703
             tts_end_ids = set(tts_end_ids) | {151704, 151645}
-        if thinker_hidden_states is None and not is_native_duplex_handoff:
-            raise StageInputProcessingError("No latent or hidden_states found in thinker output")
 
         tts_bos_idx = None
         # For native duplex the resumable prompt folds every earlier unit, so

--- a/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
@@ -516,7 +516,7 @@ def _has_native_duplex_prompt_metadata(mm_output):
 
 def _require_native_tts_boundary_metadata(special_token_ids):
     if special_token_ids.get("tts_bos_token_id") is None:
-        raise ValueError(
+        raise StageInputProcessingError(
             "MiniCPM-o native duplex TTS handoff requires tokenizer-derived "
             "<|tts_bos|> metadata; refusing to infer special token ids."
         )
@@ -669,7 +669,7 @@ def _build_tts_scheduler_prompt_token_ids(
         return llm_output_ids
     if prompt_token_ids:
         return prompt_token_ids[-1:]
-    raise ValueError("MiniCPM-o TTS stage requires at least one scheduler prompt token")
+    raise StageInputProcessingError("MiniCPM-o TTS stage requires at least one scheduler prompt token")
 
 
 def llm2tts(

--- a/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
@@ -10,6 +10,7 @@ import torch
 from vllm.inputs import TextPrompt
 
 from vllm_omni.data_entry_keys import CodesStruct, MetaStruct, OmniPayloadStruct
+from vllm_omni.errors import StageInputProcessingError
 from vllm_omni.experimental.fullduplex.engine.intermediate import (
     build_duplex_intermediate_buffer,
     set_ref_audio,
@@ -773,7 +774,7 @@ def llm2tts(
             tts_bos_id = 151703
             tts_end_ids = set(tts_end_ids) | {151704, 151645}
         if thinker_hidden_states is None and not is_native_duplex_handoff:
-            raise ValueError("No latent or hidden_states found in thinker output")
+            raise StageInputProcessingError("No latent or hidden_states found in thinker output")
 
         tts_bos_idx = None
         # For native duplex the resumable prompt folds every earlier unit, so
@@ -903,7 +904,7 @@ def llm2tts(
             # skip them before treating missing hidden states as an error.
             continue
         if thinker_hidden_states is None:
-            raise ValueError("No latent or hidden_states found in thinker output")
+            raise StageInputProcessingError("No latent or hidden_states found in thinker output")
         if is_native_duplex_handoff and handoff_ids:
             handoff_text = _decode_native_duplex_token_ids(
                 handoff_ids,

--- a/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
@@ -750,11 +750,12 @@ def llm2tts(
         latent = mm_output.get("latent", None)
         if latent is None:
             latent = output.hidden_states if hasattr(output, "hidden_states") else None
-            if latent is None:
-                raise ValueError("No latent or hidden_states found in thinker output")
-
-        thinker_hidden_states = latent.detach()
-        if thinker_hidden_states.ndim == 3 and thinker_hidden_states.shape[0] == 1:
+        thinker_hidden_states = latent.detach() if latent is not None else None
+        if (
+            thinker_hidden_states is not None
+            and thinker_hidden_states.ndim == 3
+            and thinker_hidden_states.shape[0] == 1
+        ):
             thinker_hidden_states = thinker_hidden_states.squeeze(0)
 
         # Build full token sequence and extract TTS region
@@ -771,6 +772,8 @@ def llm2tts(
         if tts_bos_id is None and not is_native_duplex_handoff:
             tts_bos_id = 151703
             tts_end_ids = set(tts_end_ids) | {151704, 151645}
+        if thinker_hidden_states is None and not is_native_duplex_handoff:
+            raise ValueError("No latent or hidden_states found in thinker output")
 
         tts_bos_idx = None
         # For native duplex the resumable prompt folds every earlier unit, so
@@ -797,8 +800,12 @@ def llm2tts(
 
         tts_token_ids_slice = tts_hidden_slice = None
         native_segment_end = False
-        if tts_bos_idx is not None and thinker_hidden_states.shape[0] > tts_bos_idx:
-            end_idx = tts_eos_idx if tts_eos_idx is not None else thinker_hidden_states.shape[0]
+        if tts_bos_idx is not None and (thinker_hidden_states is None or thinker_hidden_states.shape[0] > tts_bos_idx):
+            end_idx = (
+                tts_eos_idx
+                if tts_eos_idx is not None
+                else (thinker_hidden_states.shape[0] if thinker_hidden_states is not None else len(full_token_ids))
+            )
             if is_native_duplex_handoff and tts_eos_idx is not None:
                 boundary_token = full_token_ids[tts_eos_idx]
                 native_segment_end = boundary_token in {
@@ -806,7 +813,8 @@ def llm2tts(
                     special_token_ids.get("chunk_tts_eos_token_id"),
                 }
             tts_token_ids_slice = torch.tensor(full_token_ids[tts_bos_idx:end_idx], dtype=torch.long)
-            tts_hidden_slice = thinker_hidden_states[tts_bos_idx:end_idx].to(torch.float32).contiguous()
+            if thinker_hidden_states is not None:
+                tts_hidden_slice = thinker_hidden_states[tts_bos_idx:end_idx].to(torch.float32).contiguous()
         elif is_native_duplex_handoff:
             # Official MiniCPM-o duplex does not prefill an assistant
             # <|tts_bos|> boundary before generation. A segment delta can
@@ -846,14 +854,17 @@ def llm2tts(
                 # segments), so prompt_len + delta over-counts them and
                 # front-aligned indexing truncates the slice. The hidden
                 # tensor's last len(out_ids) rows are the delta's rows.
-                hidden_base = int(thinker_hidden_states.shape[0]) - len(out_ids)
-                if hidden_base >= 0 and out_end > out_start:
+                hidden_base = (
+                    int(thinker_hidden_states.shape[0]) - len(out_ids) if thinker_hidden_states is not None else None
+                )
+                if out_end > out_start and (hidden_base is None or hidden_base >= 0):
                     tts_token_ids_slice = torch.tensor(out_ids[out_start:out_end], dtype=torch.long)
-                    tts_hidden_slice = (
-                        thinker_hidden_states[hidden_base + out_start : hidden_base + out_end]
-                        .to(torch.float32)
-                        .contiguous()
-                    )
+                    if thinker_hidden_states is not None:
+                        tts_hidden_slice = (
+                            thinker_hidden_states[hidden_base + out_start : hidden_base + out_end]
+                            .to(torch.float32)
+                            .contiguous()
+                        )
             elif j < len(out_ids) and out_ids[j] not in tts_end_ids:
                 # HF streaming_generate does not require an explicit <|speak|>
                 # marker. If a unit starts directly with text, the first token
@@ -874,15 +885,25 @@ def llm2tts(
                             special_token_ids.get("chunk_tts_eos_token_id"),
                         }
                         break
-                hidden_base = int(thinker_hidden_states.shape[0]) - len(out_ids)
-                if hidden_base >= 0 and out_end > out_start:
+                hidden_base = (
+                    int(thinker_hidden_states.shape[0]) - len(out_ids) if thinker_hidden_states is not None else None
+                )
+                if out_end > out_start and (hidden_base is None or hidden_base >= 0):
                     tts_token_ids_slice = torch.tensor(out_ids[out_start:out_end], dtype=torch.long)
-                    tts_hidden_slice = (
-                        thinker_hidden_states[hidden_base + out_start : hidden_base + out_end]
-                        .to(torch.float32)
-                        .contiguous()
-                    )
+                    if thinker_hidden_states is not None:
+                        tts_hidden_slice = (
+                            thinker_hidden_states[hidden_base + out_start : hidden_base + out_end]
+                            .to(torch.float32)
+                            .contiguous()
+                        )
         handoff_ids = _coerce_token_id_list(tts_token_ids_slice) if tts_token_ids_slice is not None else None
+        if is_native_duplex_handoff and not handoff_ids:
+            # Listen/control/terminal outputs intentionally carry no Talker
+            # conditioning. They may also omit latent/hidden states entirely;
+            # skip them before treating missing hidden states as an error.
+            continue
+        if thinker_hidden_states is None:
+            raise ValueError("No latent or hidden_states found in thinker output")
         if is_native_duplex_handoff and handoff_ids:
             handoff_text = _decode_native_duplex_token_ids(
                 handoff_ids,
@@ -936,8 +957,6 @@ def llm2tts(
         if is_native_duplex_handoff:
             turn_eos_id = special_token_ids.get("turn_eos_token_id")
             native_turn_end_handoff = turn_eos_id is not None and handoff_ids is not None and turn_eos_id in handoff_ids
-            if not handoff_ids:
-                continue
         set_tts_handoff(model_intermediate_buffer, handoff_ids, handoff_hidden)
         if native_turn_end_handoff:
             model_intermediate_buffer.setdefault("meta", {})["turn_end"] = True


### PR DESCRIPTION
## Purpose

Fixes [#6099](https://github.com/vllm-project/vllm-omni/issues/6099).

MiniCPM-o 4.5 native duplex can emit listen, control, or terminal outputs with no speech conditioning. The Thinker-to-Talker processor required `latent` or `hidden_states` before deciding whether a Talker handoff was needed, so a valid no-speech output raised an exception. That exception could escape the shared `process_engine_inputs` bridge and terminate the orchestrator.

## Changes

- Skip confirmed native-duplex no-speech outputs before requiring hidden states.
- Keep missing conditioning for an output that is expected to speak as a typed `StageInputProcessingError`.
- Scope exceptions from the shared `process_engine_inputs` bridge to the affected request:
  - preserve anticipated processor messages;
  - preserve `OmniClientError` 4xx metadata;
  - report unexpected processor exceptions as internal errors with a traceback;
  - clean up only the failed request and keep the orchestrator running.
- Do not send a duplicate terminal update when an earlier streaming forward already failed and removed the request.

## Scope

- The model-specific behavior change is limited to the MiniCPM-o 4.5 Thinker-to-Talker handoff.
- The orchestrator error boundary covers the shared `process_engine_inputs` path used by this handoff.
- The direct AR-to-diffusion `custom_process_input_func` bridge is **not covered** by this PR.
- No diffusion processor, diffusion handoff logic, diffusion model behavior, or diffusion GPU path is changed or tested.
- MiniCPM-o soft-interrupt response policy tracked separately in [#5962](https://github.com/vllm-project/vllm-omni/issues/5962) is out of scope.

## Test Plan

### CPU: orchestrator stage-input handling

```bash
python -m pytest -q -rf \
  tests/engine/test_orchestrator_error_handling.py \
  tests/engine/test_orchestrator.py \
  tests/engine/test_cfg_companion_lifecycle.py \
  -k "stage_input_processor or streaming_terminal_update or repeated_forward_bundles" \
  -m "core_model and cpu"
```

### CPU: MiniCPM-o stage input

```bash
python -m pytest -q -rf \
  tests/model_executor/stage_input_processors/test_minicpmo_4_5_omni.py \
  tests/model_executor/models/minicpmo_4_5/test_llm2tts.py \
  -m "core_model and cpu"
```

### GPU: MiniCPM-o native duplex only

```bash
python -m pytest -s -vv \
  tests/e2e/online_serving/test_minicpmo_4_5_duplex.py::test_duplex_single_session_response_required \
  -m "advanced_model and cuda and omni" \
  --run-level advanced_model
```

**vLLM version:** 0.27.0
