### PR TITLE
[Refactor][3/N Scheduler]Move model metadata interpretation out of scheduler internals into a typed adapter contract.

### DIFF
--- a/docs/design/module/ar_runtime.md
+++ b/docs/design/module/ar_runtime.md
@@ -31,6 +31,22 @@ last_reviewed: 2026-07-16
 The AR runtime extends vLLM scheduling and worker execution for omni-stage
 inputs and outputs while preserving vLLM scheduling and cache semantics.
 
+## Full-payload input scheduling
+
+For a downstream, non-async stage with `requires_full_payload_input`,
+`OmniSchedulingCoordinator` parks requests until the Model Runner receives the
+complete upstream payload. `OmniConnectorModelRunnerMixin` keeps that payload
+in its local cache and uses `SchedulingMetadataAdapter` to translate
+model-specific fields into `SchedulingMetadataUpdate`. The Scheduler consumes
+only the typed update and readiness signal; it does not inspect payload fields.
+
+The receive flow is
+`process_pending_full_payload_inputs()` -> `register_chunk_recv()` ->
+`recv_full_payload_inputs()` -> `SchedulingMetadataAdapter.extract()` ->
+`OmniConnectorOutput` -> `update_request_metadata()`. With `async_chunk`
+enabled, this coordinator is not created and `OmniChunkTransferAdapter` retains
+ownership of chunk transfer and request updates.
+
 ## Candidate invariants
 
 ### AR-INV-001: vLLM owns base scheduling semantics

--- a/docs/design/module/input_output_modality_contracts.md
+++ b/docs/design/module/input_output_modality_contracts.md
@@ -32,6 +32,7 @@ related_code_paths:
   - vllm_omni/model_executor/stage_input_processors/**
   - vllm_omni/core/sched/**
   - vllm_omni/distributed/omni_connectors/**
+  - vllm_omni/worker/scheduling_metadata_adapter.py
   - vllm_omni/diffusion/request.py
   - vllm_omni/diffusion/worker/request_batch.py
   - vllm_omni/errors.py
@@ -49,6 +50,9 @@ validation_paths:
   - tests/utils/test_mm_outputs.py
   - tests/utils/test_mm_outputs_partition.py
   - tests/diffusion/test_diffusion_output_metadata.py
+  - tests/core/sched/test_omni_scheduling_coordinator.py
+  - tests/worker/test_omni_connector_mixin.py
+  - tests/worker/test_scheduling_metadata_adapter.py
 upstream_refs:
   - vllm.inputs/**
   - vllm.outputs/**
@@ -82,6 +86,23 @@ It does not own route-specific validation or rendering, model-specific
 interpretation, connector transport mechanics, scheduling policy, or semantic
 error classification. The `ErrorMessage` schema belongs here; the meaning and
 public rendering of its error fields belong to `error_contracts.md`.
+
+## Full-payload scheduling metadata
+
+`SchedulingMetadataUpdate`, carried by
+`OmniConnectorOutput.request_metadata`, is the internal typed contract from a
+Model Runner to its Scheduler. The full payload remains in the Model Runner's
+local cache.
+
+| Field | Meaning |
+| --- | --- |
+| `prompt_token_ids` | Replace the prompt token IDs and reset prompt-computation state. |
+| `resize_prompt_to` | Resize a prompt that has not started decoding and reset prompt-computation state. |
+
+A runner-side `SchedulingMetadataAdapter` owns model-specific lookup and
+normalization and produces this update. This contract applies only to the
+runner-owned, non-async full-payload receive path. Async-chunk request updates
+remain owned by `OmniChunkTransferAdapter`.
 
 ## Candidate invariants
 

--- a/tests/config/test_config_factory.py
+++ b/tests/config/test_config_factory.py
@@ -6,7 +6,7 @@ Unit tests for StageConfigFactory and related classes.
 
 import importlib
 import warnings
-from dataclasses import dataclass, fields
+from dataclasses import fields
 from pathlib import Path
 from unittest.mock import patch
 
@@ -2765,6 +2765,36 @@ class TestCLIOverrideFlow:
         for s in stages:
             s.runtime_overrides = StageConfigFactory._merge_cli_overrides(s, overrides)
             assert s.runtime_overrides["enforce_eager"] is True
+
+    def test_topology_owned_fields_survive_final_legacy_merge(self):
+        stage = merge_pipeline_deploy(
+            PipelineConfig(
+                model_type="topology_override_test",
+                stages=(
+                    StagePipelineConfig(
+                        stage_id=0,
+                        model_stage="consumer",
+                        requires_full_payload_input=True,
+                        scheduling_metadata_adapter="pipeline.Adapter",
+                    ),
+                ),
+            ),
+            DeployConfig(),
+        )[0]
+        stage.runtime_overrides = StageConfigFactory._merge_cli_overrides(
+            stage,
+            {
+                "stage_0_requires_full_payload_input": False,
+                "stage_0_scheduling_metadata_adapter": "cli.Adapter",
+            },
+        )
+
+        assert stage.runtime_overrides["requires_full_payload_input"] is False
+        assert stage.runtime_overrides["scheduling_metadata_adapter"] == "cli.Adapter"
+
+        final_config = stage.to_omegaconf()
+        assert final_config.engine_args.requires_full_payload_input is True
+        assert final_config.engine_args.scheduling_metadata_adapter == "pipeline.Adapter"
 
 
 class TestAuraOmniDeploy:

--- a/tests/config/test_config_factory.py
+++ b/tests/config/test_config_factory.py
@@ -1663,6 +1663,25 @@ stages:
         )
         assert async_stages[1].custom_process_input_func is None
 
+    def test_propagates_scheduling_metadata_adapter(self):
+        pipeline = PipelineConfig(
+            model_type="metadata_adapter_test",
+            stages=(
+                StagePipelineConfig(
+                    stage_id=0,
+                    model_stage="consumer",
+                    scheduling_metadata_adapter="package.CustomSchedulingMetadataAdapter",
+                ),
+            ),
+        )
+
+        stage = merge_pipeline_deploy(pipeline, DeployConfig())[0]
+
+        assert (
+            stage.yaml_engine_args["scheduling_metadata_adapter"]
+            == "package.CustomSchedulingMetadataAdapter"
+        )
+
     def test_no_bundled_legacy_stage_config_yamls(self):
         repo_root = Path(__file__).resolve().parents[2]
         stage_config_dir = repo_root / "vllm_omni" / "model_executor" / "stage_configs"

--- a/tests/config/test_config_factory.py
+++ b/tests/config/test_config_factory.py
@@ -6,6 +6,7 @@ Unit tests for StageConfigFactory and related classes.
 
 import importlib
 import warnings
+from dataclasses import dataclass, fields
 from pathlib import Path
 from unittest.mock import patch
 
@@ -37,7 +38,8 @@ from vllm_omni.config.stage_config import (
     pipeline_cfg_resolver,
 )
 from vllm_omni.diffusion.data import DiffusionParallelConfig
-from vllm_omni.engine.arg_utils import SHARED_FIELDS, internal_blacklist_keys
+from vllm_omni.engine.arg_utils import SHARED_FIELDS, EngineArgs, OmniEngineArgs, internal_blacklist_keys
+from vllm_omni.entrypoints.utils import filter_dataclass_kwargs
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -1663,24 +1665,77 @@ stages:
         )
         assert async_stages[1].custom_process_input_func is None
 
-    def test_propagates_scheduling_metadata_adapter(self):
+    @pytest.mark.parametrize(
+        ("adapter_path", "deploy_path", "expected"),
+        [
+            pytest.param(
+                "pipeline.PipelineAdapter",
+                "deploy.IgnoredAdapter",
+                "pipeline.PipelineAdapter",
+                id="deploy_conflict_overridden_by_pipeline",
+            ),
+            pytest.param(None, "deploy.IgnoredAdapter", None, id="deploy_ignored_when_pipeline_unset"),
+            pytest.param("pipeline.PipelineAdapter", None, "pipeline.PipelineAdapter", id="deploy_absent"),
+        ],
+    )
+    def test_scheduling_metadata_adapter_pipeline_is_authoritative(self, adapter_path, deploy_path, expected):
+        """Pipeline config is the only source that sets the adapter; deploy cannot."""
+        deploy_kwargs = {} if deploy_path is None else {"engine_extras": {"scheduling_metadata_adapter": deploy_path}}
+        stage = merge_pipeline_deploy(
+            PipelineConfig(
+                model_type="metadata_adapter_test",
+                stages=(
+                    StagePipelineConfig(
+                        stage_id=0,
+                        model_stage="consumer",
+                        scheduling_metadata_adapter=adapter_path,
+                    ),
+                ),
+            ),
+            DeployConfig(stages=(StageDeployConfig(stage_id=0, **deploy_kwargs),)),
+        )[0]
+
+        assert stage.yaml_engine_args["scheduling_metadata_adapter"] == expected
+
+    def test_scheduling_metadata_adapter_survives_engine_args_filtering(self):
+        adapter_path = "package.CustomSchedulingMetadataAdapter"
         pipeline = PipelineConfig(
             model_type="metadata_adapter_test",
             stages=(
                 StagePipelineConfig(
                     stage_id=0,
                     model_stage="consumer",
-                    scheduling_metadata_adapter="package.CustomSchedulingMetadataAdapter",
+                    scheduling_metadata_adapter=adapter_path,
                 ),
             ),
         )
 
         stage = merge_pipeline_deploy(pipeline, DeployConfig())[0]
 
-        assert (
-            stage.yaml_engine_args["scheduling_metadata_adapter"]
-            == "package.CustomSchedulingMetadataAdapter"
+        assert "scheduling_metadata_adapter" in {f.name for f in fields(OmniEngineArgs)}
+
+        filtered = filter_dataclass_kwargs(OmniEngineArgs, dict(stage.yaml_engine_args))
+        assert filtered["scheduling_metadata_adapter"] == adapter_path
+
+    def test_scheduling_metadata_adapter_is_per_stage(self):
+        """Each stage carries only its own pipeline-defined adapter."""
+        stages = merge_pipeline_deploy(
+            PipelineConfig(
+                model_type="metadata_adapter_test",
+                stages=(
+                    StagePipelineConfig(stage_id=0, model_stage="thinker"),
+                    StagePipelineConfig(
+                        stage_id=1,
+                        model_stage="talker",
+                        scheduling_metadata_adapter="pipeline.TalkerAdapter",
+                    ),
+                ),
+            ),
+            DeployConfig(),
         )
+
+        assert stages[0].yaml_engine_args["scheduling_metadata_adapter"] is None
+        assert stages[1].yaml_engine_args["scheduling_metadata_adapter"] == "pipeline.TalkerAdapter"
 
     def test_no_bundled_legacy_stage_config_yamls(self):
         repo_root = Path(__file__).resolve().parents[2]

--- a/tests/config/test_config_factory.py
+++ b/tests/config/test_config_factory.py
@@ -38,7 +38,7 @@ from vllm_omni.config.stage_config import (
     pipeline_cfg_resolver,
 )
 from vllm_omni.diffusion.data import DiffusionParallelConfig
-from vllm_omni.engine.arg_utils import SHARED_FIELDS, EngineArgs, OmniEngineArgs, internal_blacklist_keys
+from vllm_omni.engine.arg_utils import SHARED_FIELDS, OmniEngineArgs, internal_blacklist_keys
 from vllm_omni.entrypoints.utils import filter_dataclass_kwargs
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]

--- a/tests/config/test_omni_config.py
+++ b/tests/config/test_omni_config.py
@@ -722,6 +722,8 @@ def test_sub_config_fields_match_structured_scopes():
         "model_subdir",
         "tokenizer_subdir",
         "requires_full_payload_input",
+        "stage_input_transport",
+        "scheduling_metadata_adapter",
     }
     vllm_load_fields = {f.name for f in fields(VllmLoadConfig)}
     assert issubclass(OmniStageLoadConfig, VllmLoadConfig)

--- a/tests/config/test_omni_config.py
+++ b/tests/config/test_omni_config.py
@@ -722,7 +722,6 @@ def test_sub_config_fields_match_structured_scopes():
         "model_subdir",
         "tokenizer_subdir",
         "requires_full_payload_input",
-        "stage_input_transport",
         "scheduling_metadata_adapter",
     }
     vllm_load_fields = {f.name for f in fields(VllmLoadConfig)}

--- a/tests/core/sched/test_omni_scheduling_coordinator.py
+++ b/tests/core/sched/test_omni_scheduling_coordinator.py
@@ -15,12 +15,12 @@ import unittest
 from types import SimpleNamespace
 
 import pytest
-import torch
 
 import vllm_omni.core.sched.omni_scheduling_coordinator as coord_mod
 from vllm_omni.core.sched.omni_scheduling_coordinator import (
     OmniSchedulingCoordinator,
 )
+from vllm_omni.outputs import SchedulingMetadataUpdate
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -106,9 +106,9 @@ class TestCoordinatorUpdateRequestMetadata(unittest.TestCase):
         requests = {"r1": req}
 
         # Only scheduling metadata is passed now (full payload stays in model runner)
-        request_metadata = {"r1": {"next_stage_prompt_len": 50}}
+        request_metadata = {"r1": SchedulingMetadataUpdate(resize_prompt_to=50)}
 
-        coord.update_request_metadata(requests, request_metadata, model_mode="ar")
+        coord.update_request_metadata(requests, request_metadata)
 
         # next_stage_prompt_len should update prompt_token_ids
         self.assertEqual(len(req.prompt_token_ids), 50)
@@ -127,13 +127,9 @@ class TestCoordinatorUpdateRequestMetadata(unittest.TestCase):
         req._output_token_ids = [99]
         requests = {"r1": req}
 
-        request_metadata = {
-            "r1": {
-                "code_predictor_codes": [10, 20, 30],
-            }
-        }
+        request_metadata = {"r1": SchedulingMetadataUpdate(prompt_token_ids=(10, 20, 30))}
 
-        coord.update_request_metadata(requests, request_metadata, model_mode="generation")
+        coord.update_request_metadata(requests, request_metadata)
 
         self.assertEqual(req.prompt_token_ids, [10, 20, 30])
         self.assertEqual(req.num_prompt_tokens, 3)
@@ -142,7 +138,7 @@ class TestCoordinatorUpdateRequestMetadata(unittest.TestCase):
         self.assertEqual(req._output_token_ids, [])
         self.assertIsNone(req.additional_information)
 
-    def test_generation_mode_flattens_tensor_code_predictor_codes(self):
+    def test_typed_prompt_update_replaces_existing_prompt(self):
         coord = OmniSchedulingCoordinator(stage_id=1)
 
         req = _make_request("r1")
@@ -154,8 +150,7 @@ class TestCoordinatorUpdateRequestMetadata(unittest.TestCase):
 
         coord.update_request_metadata(
             requests,
-            {"r1": {"code_predictor_codes": torch.tensor([[1, 2, 3]], dtype=torch.long)}},
-            model_mode="generation",
+            {"r1": SchedulingMetadataUpdate(prompt_token_ids=(1, 2, 3))},
         )
 
         self.assertEqual(req.prompt_token_ids, [1, 2, 3])
@@ -163,7 +158,7 @@ class TestCoordinatorUpdateRequestMetadata(unittest.TestCase):
         self.assertEqual(req._all_token_ids, [1, 2, 3])
         self.assertEqual(req._output_token_ids, [])
 
-    def test_generation_mode_flattens_nested_code_predictor_codes(self):
+    def test_typed_prompt_update_preserves_all_token_invariants(self):
         coord = OmniSchedulingCoordinator(stage_id=1)
 
         req = _make_request("r1")
@@ -175,8 +170,7 @@ class TestCoordinatorUpdateRequestMetadata(unittest.TestCase):
 
         coord.update_request_metadata(
             requests,
-            {"r1": {"code_predictor_codes": [[1, 2], [3, 4]]}},
-            model_mode="generation",
+            {"r1": SchedulingMetadataUpdate(prompt_token_ids=(1, 2, 3, 4))},
         )
 
         self.assertEqual(req.prompt_token_ids, [1, 2, 3, 4])

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -54,8 +54,8 @@ def test_default_stage_id_is_concrete_int():
     assert cfg.stage_id == 0
 
 
-def test_full_payload_capability_reaches_omni_model_config(monkeypatch):
-    """Keep the pipeline capability intact through the engine adapter."""
+def test_topology_owned_model_fields_reach_omni_model_config(monkeypatch):
+    """Keep pipeline-owned model fields intact through the engine adapter."""
     captured: dict[str, object] = {}
     baseline_config = Mock()
     worker_module = types.ModuleType("test_connector_worker")
@@ -86,10 +86,12 @@ def test_full_payload_capability_reaches_omni_model_config(monkeypatch):
     OmniEngineArgs(
         stage_id=1,
         requires_full_payload_input=True,
+        scheduling_metadata_adapter="pipeline.Adapter",
         worker_cls="test_connector_worker.ConnectorWorker",
     ).create_model_config()
 
     assert captured["requires_full_payload_input"] is True
+    assert captured["scheduling_metadata_adapter"] == "pipeline.Adapter"
 
 
 def test_stage_without_connector_configuration_accepts_plain_runner(monkeypatch):

--- a/tests/worker/test_omni_connector_mixin.py
+++ b/tests/worker/test_omni_connector_mixin.py
@@ -25,6 +25,7 @@ from vllm_omni.outputs import OmniConnectorOutput, SchedulingMetadataUpdate
 from vllm_omni.worker.omni_connector_model_runner_mixin import (
     OmniConnectorModelRunnerMixin,
 )
+from vllm_omni.worker.scheduling_metadata_adapter import resolve_scheduling_metadata_adapter
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -109,6 +110,18 @@ class _EchoSchedulingMetadataAdapter:
     def extract(self, payload: Any, *, model_mode: str) -> SchedulingMetadataUpdate:
         del payload, model_mode
         return SchedulingMetadataUpdate(resize_prompt_to=7)
+
+
+class _FailingSchedulingMetadataAdapter:
+    def extract(self, payload: Any, *, model_mode: str) -> SchedulingMetadataUpdate | None:
+        del payload, model_mode
+        raise ValueError("invalid scheduling metadata")
+
+
+class _WrongReturnSchedulingMetadataAdapter:
+    def extract(self, payload: Any, *, model_mode: str) -> dict[str, Any]:
+        del payload, model_mode
+        return {}
 
 
 # ------------------------------------------------------------------ #
@@ -974,32 +987,61 @@ class TestCustomSchedulingMetadataAdapterResolution(unittest.TestCase):
             )
         host._omni_connector = MagicMock()
         host._stage_id = 2
-        host._local_rank = 1
+        host._local_rank = 0
+        payload = {"meta": {"next_stage_prompt_len": 9}}
+        host._local_stage_payload_cache["r1"] = payload
         host._full_payload_pending_broadcast_req_ids.add("r1")
-        tp_group = _FakeTPGroup(
-            world_size=2,
-            rank_in_group=1,
-            follower_result={"r1": {"meta": {"next_stage_prompt_len": 9}}},
-        )
+        tp_group = _FakeTPGroup(world_size=2, rank_in_group=0)
 
-        with patch("vllm_omni.worker.omni_connector_model_runner_mixin.get_tp_group", return_value=tp_group):
+        with patch.object(host, "_get_local_tp_group", return_value=tp_group):
             results = host.recv_full_payload_inputs(scheduler_output=None)
 
+        self.assertEqual(results, {"r1": payload})
+        self.assertEqual(
+            host.get_local_request_metadata("r1"),
+            SchedulingMetadataUpdate(resize_prompt_to=7),
+        )
+        self.assertNotIn("r1", host._full_payload_pending_broadcast_req_ids)
+        host.shutdown_omni_connectors()
+
+    def test_adapter_exception_preserves_full_payload_receive_transition(self):
+        host = MixinHost()
+        host.init_omni_connectors(model_config=_make_model_config(stage_id=2, worker_type="generation"))
+        host._scheduling_metadata_adapter = resolve_scheduling_metadata_adapter(_FailingSchedulingMetadataAdapter())
+        host._local_stage_payload_cache["r1"] = {"meta": {"next_stage_prompt_len": 9}}
+        host._full_payload_pending_broadcast_req_ids.add("r1")
+
+        with self.assertRaisesRegex(ValueError, "invalid scheduling metadata"):
+            host.recv_full_payload_inputs(scheduler_output=None)
+
+        self.assertIn("r1", host._full_payload_pending_broadcast_req_ids)
+        self.assertNotIn("r1", host._stage_recv_req_ids)
+        self.assertIsNone(host.get_local_request_metadata("r1"))
+
+        host._scheduling_metadata_adapter = resolve_scheduling_metadata_adapter(_EchoSchedulingMetadataAdapter())
+        results = host.recv_full_payload_inputs(scheduler_output=None)
         self.assertEqual(results, {"r1": {"meta": {"next_stage_prompt_len": 9}}})
+        self.assertNotIn("r1", host._full_payload_pending_broadcast_req_ids)
+        self.assertIn("r1", host._stage_recv_req_ids)
         self.assertEqual(
             host.get_local_request_metadata("r1"),
             SchedulingMetadataUpdate(resize_prompt_to=7),
         )
         host.shutdown_omni_connectors()
 
-    def test_default_adapter_none_effect_is_not_stored(self):
+    def test_wrong_adapter_return_preserves_full_payload_receive_transition(self):
         host = MixinHost()
-        host.init_omni_connectors(model_config=_make_model_config(worker_type="ar"))
+        host.init_omni_connectors(model_config=_make_model_config(stage_id=2, worker_type="generation"))
+        host._scheduling_metadata_adapter = resolve_scheduling_metadata_adapter(_WrongReturnSchedulingMetadataAdapter())
+        host._local_stage_payload_cache["r1"] = {"meta": {"next_stage_prompt_len": 9}}
+        host._full_payload_pending_broadcast_req_ids.add("r1")
 
-        update = host._scheduling_metadata_adapter.extract({"tok": [1]}, model_mode="ar")
-        self.assertIsNone(update)
-        host.put_local_request_metadata("r1", update)
-        self.assertNotIn("r1", host._local_request_metadata)
+        with self.assertRaisesRegex(TypeError, "must return None or SchedulingMetadataUpdate"):
+            host.recv_full_payload_inputs(scheduler_output=None)
+
+        self.assertIn("r1", host._full_payload_pending_broadcast_req_ids)
+        self.assertNotIn("r1", host._stage_recv_req_ids)
+        self.assertIsNone(host.get_local_request_metadata("r1"))
         host.shutdown_omni_connectors()
 
 
@@ -1036,6 +1078,27 @@ class TestTPAsyncChunkFanout(unittest.TestCase):
         self.assertIn("r1", host._finished_load_reqs)
         self.assertIn("r1", host._async_chunk_updated_req_ids)
         self.assertEqual(tp_group.broadcast_inputs, [])
+        host.shutdown_omni_connectors()
+
+    def test_poll_single_request_accepts_tensor_audio_codes(self):
+        host = self._make_host(rank=0)
+        audio_codes = torch.tensor([[10, 11, 12]], dtype=torch.long)
+        payload = {
+            "codes": {"audio": audio_codes},
+            "meta": {"finished": torch.tensor(False)},
+        }
+        host._omni_connector.get.return_value = (payload, 123)
+
+        with patch.object(host, "_get_local_tp_group", return_value=None):
+            made_progress = host._poll_single_request("r1")
+
+        self.assertTrue(made_progress)
+        self.assertEqual(host._get_req_chunk["r1"], 1)
+        cached_payload = host.get_local_stage_payload("r1")
+        self.assertIsNotNone(cached_payload)
+        self.assertTrue(torch.equal(cached_payload["codes"]["audio"], audio_codes))
+        self.assertIn("r1", host._finished_load_reqs)
+        self.assertIn("r1", host._async_chunk_updated_req_ids)
         host.shutdown_omni_connectors()
 
     def test_tp_follower_skips_connector_poll_for_async_chunk(self):

--- a/tests/worker/test_omni_connector_mixin.py
+++ b/tests/worker/test_omni_connector_mixin.py
@@ -1235,11 +1235,12 @@ class TestAsyncPayloadLifecycle(unittest.TestCase):
         self.assertTrue(host._payload_is_consumable(payload))
         host.shutdown_omni_connectors()
 
-    def test_ar_metadata_only_followup_chunk_does_not_rewake_request(self):
+    def test_ar_metadata_only_followup_chunk_does_not_publish_scheduler_metadata(self):
         host = MixinHost()
         host.init_omni_connectors(
             model_config=_make_model_config(stage_id=1, async_chunk=True, worker_type="ar"),
         )
+        host._scheduling_metadata_adapter = MagicMock()
         host._omni_connector = MagicMock()
         host._stage_id = 1
         host._async_chunk = True
@@ -1270,7 +1271,8 @@ class TestAsyncPayloadLifecycle(unittest.TestCase):
         host._poll_single_request("r1")
         output2 = host.get_omni_connector_output()
         self.assertEqual(output2.chunk_ready_req_ids, set())
-        self.assertEqual(output2.request_metadata, {"r1": SchedulingMetadataUpdate(resize_prompt_to=7)})
+        self.assertEqual(output2.request_metadata, {})
+        host._scheduling_metadata_adapter.extract.assert_not_called()
 
         host.shutdown_omni_connectors()
 

--- a/tests/worker/test_omni_connector_mixin.py
+++ b/tests/worker/test_omni_connector_mixin.py
@@ -20,7 +20,7 @@ import torch
 from vllm_omni.distributed.omni_connectors.kv_transfer_manager import (
     OmniKVTransferManager,
 )
-from vllm_omni.outputs import OmniConnectorOutput
+from vllm_omni.outputs import OmniConnectorOutput, SchedulingMetadataUpdate
 from vllm_omni.worker.omni_connector_model_runner_mixin import (
     OmniConnectorModelRunnerMixin,
 )
@@ -66,6 +66,7 @@ def _make_model_config(
         async_chunk=async_chunk,
         worker_type=worker_type,
         custom_process_next_stage_input_func=custom_func,
+        scheduling_metadata_adapter=None,
     )
 
 
@@ -311,14 +312,14 @@ class TestOmniConnectorOutput(unittest.TestCase):
 
         host._chunk_ready_req_ids.add("req-1")
         host._chunk_finished_req_ids.add("req-2")
-        host._local_request_metadata["req-1"] = {"next_stage_prompt_len": 10}
+        host._local_request_metadata["req-1"] = SchedulingMetadataUpdate(resize_prompt_to=10)
         host._stage_recv_req_ids.add("req-3")
 
         output = host.get_omni_connector_output()
         self.assertIsInstance(output, OmniConnectorOutput)
         self.assertEqual(output.chunk_ready_req_ids, {"req-1"})
         self.assertEqual(output.chunk_finished_req_ids, {"req-2"})
-        self.assertEqual(output.request_metadata, {"req-1": {"next_stage_prompt_len": 10}})
+        self.assertEqual(output.request_metadata, {"req-1": SchedulingMetadataUpdate(resize_prompt_to=10)})
         self.assertEqual(output.stage_recv_req_ids, {"req-3"})
 
         output2 = host.get_omni_connector_output()
@@ -574,7 +575,7 @@ class TestChunkStreamCompletedGuard(unittest.TestCase):
             host._chunk_finished_req_ids.add(req_id)
             host._chunk_stream_completed.add(req_id)
             host._local_stage_payload_cache[req_id] = {"finished": True}
-            host._local_request_metadata[req_id] = {}
+            host._local_request_metadata[req_id] = SchedulingMetadataUpdate()
             host._finished_load_reqs.add(req_id)
             host._pending_load_reqs.pop(req_id, None)
 
@@ -641,7 +642,7 @@ class TestCleanupFinishedRequest(unittest.TestCase):
         host._chunk_stream_completed.add(req_id)
         host._stage_recv_req_ids.add(req_id)
         host._local_stage_payload_cache[req_id] = {"engine_inputs": {}}
-        host._local_request_metadata[req_id] = {"prompt_len": 10}
+        host._local_request_metadata[req_id] = SchedulingMetadataUpdate(resize_prompt_to=10)
 
         # Cleanup
         host.cleanup_finished_request(req_id)
@@ -767,7 +768,7 @@ class TestCleanupFinishedRequest(unittest.TestCase):
         host._request_ids_mapping[req_id] = ext_id
         host._put_req_chunk[ext_id] = 1
         host._local_stage_payload_cache[req_id] = {"engine_inputs": {"ids": [1, 2, 3]}}
-        host._local_request_metadata[req_id] = {"next_stage_prompt_len": 3}
+        host._local_request_metadata[req_id] = SchedulingMetadataUpdate(resize_prompt_to=3)
         host._stage_recv_req_ids.add(req_id)
 
         pruned = host.prune_inactive_requests(set())
@@ -918,7 +919,7 @@ class TestLocalPayloadCacheLifecycle(unittest.TestCase):
 
         self.assertEqual(results, {"r1": payload})
         self.assertEqual(host.get_local_stage_payload("r1"), payload)
-        self.assertEqual(host.get_local_request_metadata("r1"), {})
+        self.assertEqual(host.get_local_request_metadata("r1"), SchedulingMetadataUpdate())
         self.assertEqual(host._stage_recv_req_ids, {"r1"})
         self.assertNotIn("r1", host._pending_load_reqs)
         self.assertEqual(tp_group.broadcast_inputs, [None])
@@ -983,7 +984,7 @@ class TestTPAsyncChunkFanout(unittest.TestCase):
         }
         packet = {
             "staged_payloads": {"r1": payload},
-            "request_metadata": {"r1": {"code_predictor_codes": [10, 11], "left_context_size": 0}},
+            "request_metadata": {"r1": SchedulingMetadataUpdate(prompt_token_ids=(10, 11))},
             "newly_finished": {"r1"},
             "chunk_finished": {"r1"},
         }
@@ -996,7 +997,7 @@ class TestTPAsyncChunkFanout(unittest.TestCase):
         self.assertEqual(output.chunk_finished_req_ids, {"r1"})
         self.assertEqual(
             output.request_metadata,
-            {"r1": {"code_predictor_codes": [10, 11], "left_context_size": 0}},
+            {"r1": SchedulingMetadataUpdate(prompt_token_ids=(10, 11))},
         )
         self.assertEqual(host.get_local_stage_payload("r1"), payload)
         self.assertNotIn("r1", host._pending_load_reqs)
@@ -1192,7 +1193,7 @@ class TestAsyncPayloadLifecycle(unittest.TestCase):
         host._poll_single_request("r1")
         output2 = host.get_omni_connector_output()
         self.assertEqual(output2.chunk_ready_req_ids, set())
-        self.assertEqual(output2.request_metadata, {"r1": {"next_stage_prompt_len": 7}})
+        self.assertEqual(output2.request_metadata, {"r1": SchedulingMetadataUpdate(resize_prompt_to=7)})
 
         host.shutdown_omni_connectors()
 
@@ -1232,10 +1233,7 @@ class TestAsyncPayloadLifecycle(unittest.TestCase):
         host._model_mode = "gen"
         host._request_ids_mapping["r1"] = "ext-r1"
         host._get_req_chunk["r1"] = 1
-        host._local_request_metadata["r1"] = {
-            "code_predictor_codes": [10, 11, 12],
-            "left_context_size": 0,
-        }
+        host._local_request_metadata["r1"] = SchedulingMetadataUpdate(prompt_token_ids=(10, 11, 12))
         host._finished_load_reqs.add("r1")
 
         made_progress = host._poll_single_request("r1")
@@ -1245,7 +1243,7 @@ class TestAsyncPayloadLifecycle(unittest.TestCase):
         self.assertEqual(host._get_req_chunk["r1"], 1)
 
         output = host.get_omni_connector_output()
-        self.assertEqual(output.request_metadata["r1"]["code_predictor_codes"], [10, 11, 12])
+        self.assertEqual(output.request_metadata["r1"], SchedulingMetadataUpdate(prompt_token_ids=(10, 11, 12)))
         self.assertEqual(output.chunk_ready_req_ids, {"r1"})
 
         host._omni_connector.get.return_value = (

--- a/tests/worker/test_omni_connector_mixin.py
+++ b/tests/worker/test_omni_connector_mixin.py
@@ -8,6 +8,7 @@ GPU or vLLM runtime.
 
 from __future__ import annotations
 
+import sys
 import time
 import unittest
 from types import SimpleNamespace
@@ -60,13 +61,14 @@ def _make_model_config(
     async_chunk: bool = False,
     worker_type: str = "ar",
     custom_func: str | None = None,
+    scheduling_metadata_adapter: str | None = None,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         stage_connector_config=None,
         async_chunk=async_chunk,
         worker_type=worker_type,
         custom_process_next_stage_input_func=custom_func,
-        scheduling_metadata_adapter=None,
+        scheduling_metadata_adapter=scheduling_metadata_adapter,
     )
 
 
@@ -99,6 +101,14 @@ class _FakeTPGroup:
         if self.rank_in_group == src:
             return obj
         return self.follower_result
+
+
+class _EchoSchedulingMetadataAdapter:
+    """Dummy adapter resolved from a dotted path in mixin integration tests."""
+
+    def extract(self, payload: Any, *, model_mode: str) -> SchedulingMetadataUpdate:
+        del payload, model_mode
+        return SchedulingMetadataUpdate(resize_prompt_to=7)
 
 
 # ------------------------------------------------------------------ #
@@ -919,10 +929,77 @@ class TestLocalPayloadCacheLifecycle(unittest.TestCase):
 
         self.assertEqual(results, {"r1": payload})
         self.assertEqual(host.get_local_stage_payload("r1"), payload)
-        self.assertEqual(host.get_local_request_metadata("r1"), SchedulingMetadataUpdate())
+        self.assertIsNone(host.get_local_request_metadata("r1"))
         self.assertEqual(host._stage_recv_req_ids, {"r1"})
         self.assertNotIn("r1", host._pending_load_reqs)
         self.assertEqual(tp_group.broadcast_inputs, [None])
+        host.shutdown_omni_connectors()
+
+
+class TestCustomSchedulingMetadataAdapterResolution(unittest.TestCase):
+    """Runner-side resolution of a configured scheduling metadata adapter."""
+
+    @staticmethod
+    def _dotted_path() -> str:
+        return f"{__name__}._EchoSchedulingMetadataAdapter"
+
+    @staticmethod
+    def _resolve_import_module_patch():
+        """Return a context manager that resolves the local dummy class by path.
+
+        pytest may import this module under different fully qualified names
+        (``tests.worker.test_omni_connector_mixin`` vs ``test_omni_connector_mixin``),
+        so vendor the module lookup through ``sys.modules`` instead of relying
+        on the importable dotted name.
+        """
+        return patch(
+            "vllm_omni.worker.scheduling_metadata_adapter.importlib.import_module",
+            return_value=sys.modules[__name__],
+        )
+
+    def test_recv_full_payload_uses_configured_adapter(self):
+        """A dotted-path adapter is resolved at init and drives extraction.
+
+        Covering init resolution implicitly: the recv path can only return the
+        custom effect if ``init_omni_connectors`` loaded the dummy class.
+        """
+        with self._resolve_import_module_patch():
+            host = MixinHost()
+            host.init_omni_connectors(
+                model_config=_make_model_config(
+                    stage_id=2,
+                    worker_type="generation",
+                    scheduling_metadata_adapter=self._dotted_path(),
+                )
+            )
+        host._omni_connector = MagicMock()
+        host._stage_id = 2
+        host._local_rank = 1
+        host._full_payload_pending_broadcast_req_ids.add("r1")
+        tp_group = _FakeTPGroup(
+            world_size=2,
+            rank_in_group=1,
+            follower_result={"r1": {"meta": {"next_stage_prompt_len": 9}}},
+        )
+
+        with patch("vllm_omni.worker.omni_connector_model_runner_mixin.get_tp_group", return_value=tp_group):
+            results = host.recv_full_payload_inputs(scheduler_output=None)
+
+        self.assertEqual(results, {"r1": {"meta": {"next_stage_prompt_len": 9}}})
+        self.assertEqual(
+            host.get_local_request_metadata("r1"),
+            SchedulingMetadataUpdate(resize_prompt_to=7),
+        )
+        host.shutdown_omni_connectors()
+
+    def test_default_adapter_none_effect_is_not_stored(self):
+        host = MixinHost()
+        host.init_omni_connectors(model_config=_make_model_config(worker_type="ar"))
+
+        update = host._scheduling_metadata_adapter.extract({"tok": [1]}, model_mode="ar")
+        self.assertIsNone(update)
+        host.put_local_request_metadata("r1", update)
+        self.assertNotIn("r1", host._local_request_metadata)
         host.shutdown_omni_connectors()
 
 

--- a/tests/worker/test_scheduling_metadata_adapter.py
+++ b/tests/worker/test_scheduling_metadata_adapter.py
@@ -64,3 +64,20 @@ def test_resolve_accepts_an_adapter_instance() -> None:
     adapter = resolve_scheduling_metadata_adapter(CustomAdapter())
 
     assert adapter.extract({}, model_mode="generation") == SchedulingMetadataUpdate(resize_prompt_to=7)
+
+
+def test_resolve_rejects_an_incompatible_extract_signature() -> None:
+    class WrongSignatureAdapter:
+        def extract(self):
+            return None
+
+    with pytest.raises(TypeError, match=r"extract\(payload, \*, model_mode=\.\.\.\)"):
+        resolve_scheduling_metadata_adapter(WrongSignatureAdapter())
+
+
+def test_resolve_rejects_a_non_callable_extract() -> None:
+    class NonCallableExtractAdapter:
+        extract = None
+
+    with pytest.raises(TypeError, match="scheduling_metadata_adapter.extract must be callable"):
+        resolve_scheduling_metadata_adapter(NonCallableExtractAdapter())

--- a/tests/worker/test_scheduling_metadata_adapter.py
+++ b/tests/worker/test_scheduling_metadata_adapter.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for runner-side payload-to-scheduler metadata translation."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from vllm_omni.outputs import SchedulingMetadataUpdate
+from vllm_omni.worker.scheduling_metadata_adapter import (
+    DefaultSchedulingMetadataAdapter,
+    resolve_scheduling_metadata_adapter,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_default_adapter_extracts_generic_generation_effects() -> None:
+    update = DefaultSchedulingMetadataAdapter().extract(
+        {"codes": {"audio": [[10, 20], [30]]}, "meta": {"next_stage_prompt_len": 3}},
+        model_mode="generation",
+    )
+
+    assert update == SchedulingMetadataUpdate(
+        prompt_token_ids=(10, 20, 30),
+        resize_prompt_to=3,
+    )
+
+
+def test_default_adapter_flattens_tensor_codes() -> None:
+    update = DefaultSchedulingMetadataAdapter().extract(
+        {"codes": {"audio": torch.tensor([[1, 2, 3]], dtype=torch.long)}},
+        model_mode="generation",
+    )
+
+    assert update == SchedulingMetadataUpdate(prompt_token_ids=(1, 2, 3))
+
+
+def test_default_adapter_does_not_leak_codec_metadata_to_scheduler() -> None:
+    update = DefaultSchedulingMetadataAdapter().extract(
+        {"meta": {"left_context_size": 7}},
+        model_mode="generation",
+    )
+
+    assert update is None
+
+
+def test_default_adapter_keeps_ar_prompt_tokens_unchanged() -> None:
+    update = DefaultSchedulingMetadataAdapter().extract(
+        {"codes": {"audio": [1, 2]}, "meta": {"next_stage_prompt_len": 2}},
+        model_mode="ar",
+    )
+
+    assert update == SchedulingMetadataUpdate(resize_prompt_to=2)
+
+
+def test_resolve_accepts_an_adapter_instance() -> None:
+    class CustomAdapter:
+        def extract(self, payload, *, model_mode):
+            del payload, model_mode
+            return SchedulingMetadataUpdate(resize_prompt_to=7)
+
+    adapter = resolve_scheduling_metadata_adapter(CustomAdapter())
+
+    assert adapter.extract({}, model_mode="generation") == SchedulingMetadataUpdate(resize_prompt_to=7)

--- a/vllm_omni/config/model.py
+++ b/vllm_omni/config/model.py
@@ -155,6 +155,7 @@ class OmniModelConfig(ModelConfig):
     # ``cfg_role`` for classifier-free-guidance request pairs).
     sampling_extra_args_keys: tuple[str, ...] = ()
     requires_full_payload_input: bool = False
+    scheduling_metadata_adapter: str | None = None
 
     @property
     def registry(self):

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -443,7 +443,7 @@ class OmniStageModelConfig(_TrackExplicitConfigFields):
     model_subdir: str | None = None
     tokenizer_subdir: str | None = None
     requires_full_payload_input: bool = False
-
+    scheduling_metadata_adapter: str | None = None
 
 @_enforce_keyword_only_init
 @config(kw_only=True)
@@ -1711,6 +1711,8 @@ def _build_model_config(
         kwargs["model_subdir"] = topology.model_subdir
     if "tokenizer_subdir" not in kwargs and topology.tokenizer_subdir is not None:
         kwargs["tokenizer_subdir"] = topology.tokenizer_subdir
+    if "scheduling_metadata_adapter" not in kwargs:
+        kwargs["scheduling_metadata_adapter"] = topology.scheduling_metadata_adapter
     return cast(Any, OmniStageModelConfig)(
         default_sampling_params=default_sampling_params,
         session_mode=deploy.session_mode,

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -445,6 +445,7 @@ class OmniStageModelConfig(_TrackExplicitConfigFields):
     requires_full_payload_input: bool = False
     scheduling_metadata_adapter: str | None = None
 
+
 @_enforce_keyword_only_init
 @config(kw_only=True)
 class OmniStageLoadConfig(_TrackExplicitConfigFields, VllmLoadConfig):
@@ -1695,6 +1696,7 @@ def _build_model_config(
     kwargs = _config_kwargs(engine)
     kwargs["requires_full_payload_input"] = topology.requires_full_payload_input
     kwargs["model"] = _first_defined(kwargs.get("model"), model)
+    kwargs["scheduling_metadata_adapter"] = topology.scheduling_metadata_adapter
     if "model_arch" not in kwargs:
         kwargs["model_arch"] = topology.model_arch or pipeline.model_arch or None
     if "trust_remote_code" not in kwargs and deploy.trust_remote_code is not None:
@@ -1711,8 +1713,6 @@ def _build_model_config(
         kwargs["model_subdir"] = topology.model_subdir
     if "tokenizer_subdir" not in kwargs and topology.tokenizer_subdir is not None:
         kwargs["tokenizer_subdir"] = topology.tokenizer_subdir
-    if "scheduling_metadata_adapter" not in kwargs:
-        kwargs["scheduling_metadata_adapter"] = topology.scheduling_metadata_adapter
     return cast(Any, OmniStageModelConfig)(
         default_sampling_params=default_sampling_params,
         session_mode=deploy.session_mode,

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -274,6 +274,9 @@ class StagePipelineConfig:
     # Whether the non-async path waits for a complete upstream payload from
     # the model-runner connector before scheduling this stage.
     requires_full_payload_input: bool = False
+    # Optional model-owned adapter for runner payload metadata that affects
+    # scheduling. The scheduler only receives its typed effects.
+    scheduling_metadata_adapter: str | None = None
     extras: dict[str, Any] = field(default_factory=dict)
 
 
@@ -940,6 +943,7 @@ def _build_engine_args(
     if ps.model_path_resolver:
         engine_args["model_path_resolver"] = ps.model_path_resolver
     engine_args["inline_diffusion"] = ps.inline_diffusion
+    engine_args["scheduling_metadata_adapter"] = ps.scheduling_metadata_adapter
 
     # Pipeline-wide top-level DeployConfig settings, applied to every stage.
     for name in _PIPELINE_WIDE_ENGINE_FIELDS:

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -943,7 +943,6 @@ def _build_engine_args(
     if ps.model_path_resolver:
         engine_args["model_path_resolver"] = ps.model_path_resolver
     engine_args["inline_diffusion"] = ps.inline_diffusion
-    engine_args["scheduling_metadata_adapter"] = ps.scheduling_metadata_adapter
 
     # Pipeline-wide top-level DeployConfig settings, applied to every stage.
     for name in _PIPELINE_WIDE_ENGINE_FIELDS:
@@ -970,6 +969,7 @@ def _build_engine_args(
     if ps.omni_kv_config:
         engine_args["omni_kv_config"] = dict(ps.omni_kv_config)
     engine_args["requires_full_payload_input"] = ps.requires_full_payload_input
+    engine_args["scheduling_metadata_adapter"] = ps.scheduling_metadata_adapter
     return engine_args
 
 

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -28,6 +28,21 @@ _DEPLOY_DIR = Path(__file__).resolve().parent.parent / "deploy"
 
 _STAGE_OVERRIDE_PATTERN = re.compile(r"^stage_(\d+)_(.+)$")
 
+_RUNTIME_ONLY_OVERRIDE_FIELDS = frozenset(
+    {
+        "devices",
+        "max_batch_size",
+        "num_replicas",
+    }
+)
+
+_TOPOLOGY_OWNED_ENGINE_FIELDS = frozenset(
+    {
+        "requires_full_payload_input",
+        "scheduling_metadata_adapter",
+    }
+)
+
 
 def pipeline_cfg_resolver(config_type: type[PretrainedConfig]):
     """Wraps a resolver such that we return None if a hf_config of the wrong type is provided."""
@@ -1136,7 +1151,11 @@ class StageConfig:
 
         # CLI overrides take precedence over YAML defaults
         for key, value in runtime_overrides.items():
-            if value is not None and key not in ("devices", "max_batch_size", "num_replicas"):
+            if (
+                value is not None
+                and key not in _RUNTIME_ONLY_OVERRIDE_FIELDS
+                and key not in _TOPOLOGY_OWNED_ENGINE_FIELDS
+            ):
                 engine_args[key] = value
 
         # Build runtime config from YAML defaults + CLI overrides

--- a/vllm_omni/core/sched/omni_scheduler_mixin.py
+++ b/vllm_omni/core/sched/omni_scheduler_mixin.py
@@ -265,9 +265,7 @@ class OmniSchedulerMixin:
         if input_coordinator is None:
             return
         if connector_output and connector_output.request_metadata:
-            input_coordinator.update_request_metadata(
-                self.requests, connector_output.request_metadata
-            )
+            input_coordinator.update_request_metadata(self.requests, connector_output.request_metadata)
         input_coordinator.process_pending_full_payload_inputs(
             self.waiting,
             connector_output.stage_recv_req_ids if connector_output else set(),

--- a/vllm_omni/core/sched/omni_scheduler_mixin.py
+++ b/vllm_omni/core/sched/omni_scheduler_mixin.py
@@ -255,9 +255,9 @@ class OmniSchedulerMixin:
     def _consume_pending_connector_output(self, model_mode: str) -> None:
         """Drain ``self._latest_omni_connector_output`` into the coordinator.
 
-        Called at the top of every ``schedule()`` cycle.  Identical between
-        AR and generation schedulers except for the ``model_mode`` argument
-        forwarded to ``update_request_metadata``.
+        Called at the top of every ``schedule()`` cycle. ``model_mode`` is
+        retained for the shared call surface; the runner has already applied
+        model-specific interpretation before publishing the typed updates.
         """
         connector_output = getattr(self, "_latest_omni_connector_output", None)
         self._latest_omni_connector_output = None
@@ -266,7 +266,7 @@ class OmniSchedulerMixin:
             return
         if connector_output and connector_output.request_metadata:
             input_coordinator.update_request_metadata(
-                self.requests, connector_output.request_metadata, model_mode=model_mode
+                self.requests, connector_output.request_metadata
             )
         input_coordinator.process_pending_full_payload_inputs(
             self.waiting,

--- a/vllm_omni/core/sched/omni_scheduling_coordinator.py
+++ b/vllm_omni/core/sched/omni_scheduling_coordinator.py
@@ -18,6 +18,7 @@ from vllm.logger import init_logger
 from vllm.v1.request import Request, RequestStatus
 
 from vllm_omni.core.sched.output import OmniChunkRecvHandle
+from vllm_omni.outputs import SchedulingMetadataUpdate
 
 logger = init_logger(__name__)
 
@@ -202,90 +203,38 @@ class OmniSchedulingCoordinator:
             waiting_queue.add_request(request)
         self._waiting_for_input = deque()
 
-    @staticmethod
-    def _flatten_prompt_token_ids(value: Any) -> list[int]:
-        """Normalize connector metadata into flat prompt token ids."""
-        if value is None:
-            return []
-        if hasattr(value, "detach") and hasattr(value, "cpu") and hasattr(value, "tolist"):
-            value = value.detach().cpu().tolist()
-        elif hasattr(value, "tolist") and not isinstance(value, (list, tuple)):
-            value = value.tolist()
-
-        if isinstance(value, (list, tuple)):
-            flattened: list[int] = []
-            for item in value:
-                if hasattr(item, "detach") and hasattr(item, "cpu") and hasattr(item, "tolist"):
-                    item = item.detach().cpu().tolist()
-                elif hasattr(item, "tolist") and not isinstance(item, (list, tuple)):
-                    item = item.tolist()
-                if isinstance(item, (list, tuple)):
-                    flattened.extend(int(token_id) for token_id in item)
-                else:
-                    flattened.append(int(item))
-            return flattened
-        return [int(value)]
-
     def update_request_metadata(
         self,
         requests: dict[str, Request],
-        request_metadata: dict[str, dict[str, Any]],
-        model_mode: str = "ar",
+        request_metadata: dict[str, SchedulingMetadataUpdate],
     ) -> None:
-        """Apply received scheduling metadata to request objects.
-
-        For AR mode: only scheduler-visible metadata is applied locally.
-        For Generation mode: updates ``request.prompt_token_ids``.
-
-        Additionally, if the payload contains ``next_stage_prompt_len``,
-        updates the request's ``prompt_token_ids`` to the correct length.
-        """
-        for req_id, metadata in request_metadata.items():
+        """Apply typed runner updates without interpreting payload metadata."""
+        for req_id, update in request_metadata.items():
             request = requests.get(req_id)
             if request is None:
                 continue
+            self._apply_scheduling_update(request, update)
 
-            # Handle next_stage_prompt_len if present (for models like Qwen3-Omni).
-            # Only apply when the request has not started decoding yet
-            # (no output tokens). Resetting a mid-decode request would
-            # destroy generated tokens and desync KV cache state.
-            if "next_stage_prompt_len" in metadata:
-                next_len = metadata["next_stage_prompt_len"]
-                if isinstance(next_len, int) and next_len > 0:
-                    output_token_ids = getattr(request, "_output_token_ids", None)
-                    has_decode_output = output_token_ids is not None and len(output_token_ids) > 0
-                    if has_decode_output:
-                        logger.debug(
-                            "[Coordinator stage-%s] Skipping prompt resize for req %s: "
-                            "request already has %s output tokens",
-                            self._stage_id,
-                            req_id,
-                            len(output_token_ids),
-                        )
-                    else:
-                        current_prompt_ids = getattr(request, "prompt_token_ids", []) or []
-                        current_prompt_len = len(current_prompt_ids)
-                        if current_prompt_len != next_len or getattr(request, "num_prompt_tokens", None) != next_len:
-                            new_prompt = [0] * next_len
-                            request.prompt_token_ids = new_prompt
-                            request.num_prompt_tokens = next_len
-                            request._all_token_ids.clear()
-                            request._all_token_ids.extend(new_prompt)
-                            request._output_token_ids.clear()
-                            request.num_computed_tokens = 0
-                            logger.debug(
-                                "[Coordinator stage-%s] Updated prompt_token_ids length to %s for req %s",
-                                self._stage_id,
-                                next_len,
-                                req_id,
-                            )
-
-            if model_mode != "ar":
-                new_ids = self._flatten_prompt_token_ids(metadata.get("code_predictor_codes"))
-                if new_ids:
-                    request.prompt_token_ids = new_ids
-                    request.num_prompt_tokens = len(new_ids)
+    def _apply_scheduling_update(self, request: Request, update: SchedulingMetadataUpdate) -> None:
+        if update.resize_prompt_to is not None:
+            output_token_ids = getattr(request, "_output_token_ids", None)
+            if output_token_ids is None or not output_token_ids:
+                next_len = update.resize_prompt_to
+                current_prompt_ids = getattr(request, "prompt_token_ids", ()) or ()
+                if len(current_prompt_ids) != next_len or getattr(request, "num_prompt_tokens", None) != next_len:
+                    new_prompt = [0] * next_len
+                    request.prompt_token_ids = new_prompt
+                    request.num_prompt_tokens = next_len
                     request._all_token_ids.clear()
-                    request._all_token_ids.extend(new_ids)
+                    request._all_token_ids.extend(new_prompt)
                     request._output_token_ids.clear()
                     request.num_computed_tokens = 0
+
+        if update.prompt_token_ids is not None:
+            prompt_token_ids = list(update.prompt_token_ids)
+            request.prompt_token_ids = prompt_token_ids
+            request.num_prompt_tokens = len(prompt_token_ids)
+            request._all_token_ids.clear()
+            request._all_token_ids.extend(prompt_token_ids)
+            request._output_token_ids.clear()
+            request.num_computed_tokens = 0

--- a/vllm_omni/distributed/omni_connectors/model_runner/omni_connector_payload_transport.py
+++ b/vllm_omni/distributed/omni_connectors/model_runner/omni_connector_payload_transport.py
@@ -1065,12 +1065,11 @@ class _OmniConnectorPayloadTransportMixin(_OmniConnectorRuntimeMixin):
                     existing.update(payload_data)
                 else:
                     self._local_stage_payload_cache[req_id] = payload_data
-                staged_payload = self._local_stage_payload_cache[req_id]
                 self._async_chunk_updated_req_ids.add(req_id)
-                self.put_local_request_metadata(
-                    req_id,
-                    self._scheduling_metadata_adapter.extract(staged_payload, model_mode=self._model_mode),
-                )
+                # Runner-owned async receive is not wired into the current
+                # scheduler. Add typed metadata extraction only when async
+                # registration, consumption, and failure propagation migrate
+                # together from OmniChunkTransferAdapter.
                 # A finish-only sentinel still needs one terminal wake-up so
                 # the downstream stage can sync the merged local payload and
                 # flush/finish even when the last recv carries no new

--- a/vllm_omni/distributed/omni_connectors/model_runner/omni_connector_payload_transport.py
+++ b/vllm_omni/distributed/omni_connectors/model_runner/omni_connector_payload_transport.py
@@ -18,7 +18,7 @@ from vllm_omni.distributed.omni_connectors.model_runner.omni_connector_runtime i
     logger,
     should_accumulate_full_payload_output,
 )
-from vllm_omni.outputs import OmniConnectorOutput
+from vllm_omni.outputs import OmniConnectorOutput, SchedulingMetadataUpdate
 
 if TYPE_CHECKING:
     from vllm_omni.distributed.omni_connectors.connectors.base import (
@@ -45,43 +45,18 @@ class _OmniConnectorPayloadTransportMixin(_OmniConnectorRuntimeMixin):
         """Remove and return a stage payload (consume after use)."""
         return self._local_stage_payload_cache.pop(req_id, None)
 
-    def put_local_request_metadata(self, req_id: str, metadata: dict[str, Any]) -> None:
-        """Store lightweight scheduling metadata for a request."""
-        self._local_request_metadata[req_id] = metadata
+    def put_local_request_metadata(self, req_id: str, update: SchedulingMetadataUpdate | None) -> None:
+        """Store a scheduler-visible update for a request when one is needed."""
+        if update is not None:
+            self._local_request_metadata[req_id] = update
 
-    def get_local_request_metadata(self, req_id: str) -> dict[str, Any] | None:
-        """Retrieve scheduling metadata for a request."""
+    def get_local_request_metadata(self, req_id: str) -> SchedulingMetadataUpdate | None:
+        """Retrieve the pending scheduler-visible update for a request."""
         return self._local_request_metadata.get(req_id)
 
     # ------------------------------------------------------------------ #
     #  Scheduling metadata extraction
     # ------------------------------------------------------------------ #
-
-    @classmethod
-    def _extract_scheduling_metadata(cls, payload: OmniPayload) -> dict[str, Any]:
-        """Extract only the fields the scheduler needs from a full payload."""
-        extracted: dict[str, Any] = {}
-        meta = payload.get("meta") if isinstance(payload, dict) else None
-        meta = meta if isinstance(meta, dict) else {}
-
-        if "next_stage_prompt_len" in meta:
-            extracted["next_stage_prompt_len"] = meta["next_stage_prompt_len"]
-        elif "next_stage_prompt_len" in payload:
-            logger.warning_once(
-                "legacy flat 'next_stage_prompt_len' key in payload; expected 'meta.next_stage_prompt_len'"
-            )
-            extracted["next_stage_prompt_len"] = payload["next_stage_prompt_len"]
-
-        audio_codes = cls._payload_audio_codes(payload)
-        if audio_codes is not None:
-            extracted["code_predictor_codes"] = audio_codes
-
-        if "left_context_size" in meta:
-            extracted["left_context_size"] = meta["left_context_size"]
-        elif "left_context_size" in payload:
-            logger.warning_once("legacy flat 'left_context_size' key in payload; expected 'meta.left_context_size'")
-
-        return extracted
 
     _NON_CONSUMABLE_PAYLOAD_KEYS: set[tuple[str, str]] = {
         ("meta", "finished"),
@@ -465,7 +440,10 @@ class _OmniConnectorPayloadTransportMixin(_OmniConnectorRuntimeMixin):
                 self._pending_load_reqs.pop(req_id, None)
             self._apply_staged_payloads_locked(results)
             for req_id, payload in results.items():
-                self._local_request_metadata[req_id] = self._extract_scheduling_metadata(payload)
+                self.put_local_request_metadata(
+                    req_id,
+                    self._scheduling_metadata_adapter.extract(payload, model_mode=self._model_mode),
+                )
         logger.debug(
             "[Stage-%s] recv_full_payload_inputs: consumed %s reqs: %s, stage_recv_req_ids now=%s",
             self._stage_id,
@@ -1089,7 +1067,10 @@ class _OmniConnectorPayloadTransportMixin(_OmniConnectorRuntimeMixin):
                     self._local_stage_payload_cache[req_id] = payload_data
                 staged_payload = self._local_stage_payload_cache[req_id]
                 self._async_chunk_updated_req_ids.add(req_id)
-                self.put_local_request_metadata(req_id, self._extract_scheduling_metadata(staged_payload))
+                self.put_local_request_metadata(
+                    req_id,
+                    self._scheduling_metadata_adapter.extract(staged_payload, model_mode=self._model_mode),
+                )
                 # A finish-only sentinel still needs one terminal wake-up so
                 # the downstream stage can sync the merged local payload and
                 # flush/finish even when the last recv carries no new

--- a/vllm_omni/distributed/omni_connectors/model_runner/omni_connector_payload_transport.py
+++ b/vllm_omni/distributed/omni_connectors/model_runner/omni_connector_payload_transport.py
@@ -45,14 +45,18 @@ class _OmniConnectorPayloadTransportMixin(_OmniConnectorRuntimeMixin):
         """Remove and return a stage payload (consume after use)."""
         return self._local_stage_payload_cache.pop(req_id, None)
 
-    def put_local_request_metadata(self, req_id: str, update: SchedulingMetadataUpdate | None) -> None:
-        """Store a scheduler-visible update for a request when one is needed."""
-        if update is not None:
-            self._local_request_metadata[req_id] = update
-
     def get_local_request_metadata(self, req_id: str) -> SchedulingMetadataUpdate | None:
         """Retrieve the pending scheduler-visible update for a request."""
         return self._local_request_metadata.get(req_id)
+
+    def _extract_scheduling_metadata_update(self, payload: OmniPayload) -> SchedulingMetadataUpdate | None:
+        update = self._scheduling_metadata_adapter.extract(payload, model_mode=self._model_mode)
+        if update is not None and not isinstance(update, SchedulingMetadataUpdate):
+            raise TypeError(
+                "scheduling_metadata_adapter.extract must return None or "
+                f"SchedulingMetadataUpdate, got {type(update).__name__}"
+            )
+        return update
 
     # ------------------------------------------------------------------ #
     #  Scheduling metadata extraction
@@ -214,7 +218,7 @@ class _OmniConnectorPayloadTransportMixin(_OmniConnectorRuntimeMixin):
         for req_id, payload in staged_payloads.items():
             self._local_stage_payload_cache[req_id] = self._snapshot_payload(payload)
 
-    def _collect_full_payload_results_locked(self) -> dict[str, Any] | None:
+    def _snapshot_full_payload_results_locked(self) -> dict[str, Any] | None:
         if not self._full_payload_pending_broadcast_req_ids:
             return None
         results: dict[str, Any] = {}
@@ -225,10 +229,11 @@ class _OmniConnectorPayloadTransportMixin(_OmniConnectorRuntimeMixin):
                 missing_req_ids.append(req_id)
                 continue
             results[req_id] = self._snapshot_payload(payload)
-            self._full_payload_pending_broadcast_req_ids.discard(req_id)
+            # The caller clears this marker only after metadata extraction
+            # validates, so an adapter failure leaves the receive retryable.
         if missing_req_ids:
             logger.warning(
-                "[Stage-%s] _collect_full_payload_results_locked: "
+                "[Stage-%s] _snapshot_full_payload_results_locked: "
                 "pending full-payload reqs missing from local cache: %s",
                 self._stage_id,
                 missing_req_ids,
@@ -429,21 +434,28 @@ class _OmniConnectorPayloadTransportMixin(_OmniConnectorRuntimeMixin):
             tp_group is None or getattr(tp_group, "world_size", 1) <= 1
         ) and not self._full_payload_pending_broadcast_req_ids:
             return None
+        is_data_transfer_rank = self.is_data_transfer_rank()
         with self._lock:
-            results = self._collect_full_payload_results_locked() if self.is_data_transfer_rank() else None
+            results = self._snapshot_full_payload_results_locked() if is_data_transfer_rank else None
         results = self._broadcast_tp_payload_packet(results)
         if not results:
             return None
+
+        # Validate every update before committing any one-shot readiness state.
+        request_metadata: dict[str, SchedulingMetadataUpdate] = {}
+        for req_id, payload in results.items():
+            update = self._extract_scheduling_metadata_update(payload)
+            if update is not None:
+                request_metadata[req_id] = update
+
         with self._lock:
-            self._stage_recv_req_ids.update(results.keys())
+            self._apply_staged_payloads_locked(results)
+            self._local_request_metadata.update(request_metadata)
+            self._stage_recv_req_ids.update(results)
+            if is_data_transfer_rank:
+                self._full_payload_pending_broadcast_req_ids.difference_update(results)
             for req_id in results:
                 self._pending_load_reqs.pop(req_id, None)
-            self._apply_staged_payloads_locked(results)
-            for req_id, payload in results.items():
-                self.put_local_request_metadata(
-                    req_id,
-                    self._scheduling_metadata_adapter.extract(payload, model_mode=self._model_mode),
-                )
         logger.debug(
             "[Stage-%s] recv_full_payload_inputs: consumed %s reqs: %s, stage_recv_req_ids now=%s",
             self._stage_id,
@@ -1048,8 +1060,8 @@ class _OmniConnectorPayloadTransportMixin(_OmniConnectorRuntimeMixin):
                 payload_data = self._accumulate_payload(external_req_id, payload_data)
                 payload_consumable = incoming_payload_consumable
             else:
-                new_ids = self._payload_audio_codes(payload_data) or []
-                if not new_ids and not is_finished:
+                audio_codes = self._payload_audio_codes(payload_data)
+                if not self._payload_value_has_content(audio_codes) and not is_finished:
                     return False
                 payload_consumable = self._payload_is_consumable(payload_data)
 

--- a/vllm_omni/distributed/omni_connectors/model_runner/omni_connector_runtime.py
+++ b/vllm_omni/distributed/omni_connectors/model_runner/omni_connector_runtime.py
@@ -19,6 +19,11 @@ from vllm_omni.distributed.omni_connectors.utils.config import (
     ConnectorSpec,
     get_stage_connector_role,
 )
+from vllm_omni.outputs import SchedulingMetadataUpdate
+from vllm_omni.worker.scheduling_metadata_adapter import (
+    SchedulingMetadataAdapter,
+    resolve_scheduling_metadata_adapter,
+)
 
 logger = init_logger("vllm_omni.worker.omni_connector_model_runner_mixin")
 
@@ -82,6 +87,7 @@ class _OmniConnectorRuntimeMixin:
     _kv_transfer_manager: Any
     _async_chunk: bool
     _model_mode: str
+    _scheduling_metadata_adapter: SchedulingMetadataAdapter
     _stage_id: int
     _next_stage_id: int
     _from_tp: int
@@ -109,7 +115,7 @@ class _OmniConnectorRuntimeMixin:
     _full_payload_pending_broadcast_req_ids: set[str]
     _async_chunk_updated_req_ids: set[str]
     _local_stage_payload_cache: dict[str, dict[str, Any]]
-    _local_request_metadata: dict[str, dict[str, Any]]
+    _local_request_metadata: dict[str, SchedulingMetadataUpdate]
     _chunk_stream_completed: set[str]
     _pending_full_payload_send: dict[str, tuple[Any, ...]]
     _kv_sent_req_ids: list[str]
@@ -158,6 +164,9 @@ class _OmniConnectorRuntimeMixin:
 
         self._async_chunk: bool = getattr(model_config, "async_chunk", False)
         self._model_mode: str = getattr(model_config, "worker_type", "ar")
+        self._scheduling_metadata_adapter = resolve_scheduling_metadata_adapter(
+            getattr(model_config, "scheduling_metadata_adapter", None)
+        )
         stage_id = getattr(model_config, "stage_id", 0)
         if isinstance(stage_id, str):
             stage_id = int(stage_id)
@@ -240,7 +249,7 @@ class _OmniConnectorRuntimeMixin:
         # ownership.
         self._local_stage_payload_cache: dict[str, dict[str, Any]] = {}
         # Lightweight scheduling metadata pending delivery to the Scheduler.
-        self._local_request_metadata: dict[str, dict[str, Any]] = {}
+        self._local_request_metadata: dict[str, SchedulingMetadataUpdate] = {}
 
         # -- persistent set of request IDs whose chunk stream is complete --
         # Prevents re-registration after the finish sentinel has been received.

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -165,6 +165,9 @@ class OmniEngineArgs(EngineArgs):
         async_chunk: If set to True, perform async chunk
         session_mode: Request lifecycle mode, either turn-based or duplex
         worker_type: Model Type, e.g., "ar" or "generation"
+        scheduling_metadata_adapter: Optional dotted path of a runner-side
+            adapter that translates incoming payload metadata into typed
+            scheduler-visible updates. If None, the default adapter is used.
         task_type: Model-defined startup task type. Consumers validate the
             supported values and decide whether it selects request behavior,
             task-specific weights, or both.
@@ -206,6 +209,7 @@ class OmniEngineArgs(EngineArgs):
     quantization_config: Any | None = None
     force_cutlass_fp8: bool | None = None
     worker_type: str | None = None
+    scheduling_metadata_adapter: str | None = None
     # Dotted path of a per-stage pooling-output decoder applied worker-side.
     pooling_output_decoder: str | None = None
     task_type: str | None = None
@@ -424,6 +428,7 @@ class OmniEngineArgs(EngineArgs):
             model_stage=self.model_stage,
             model_arch=self.model_arch,
             worker_type=self.worker_type,
+            scheduling_metadata_adapter=self.scheduling_metadata_adapter,
             pooling_output_decoder=self.pooling_output_decoder,
             engine_output_type=self.engine_output_type,
             hf_config_name=self.hf_config_name,

--- a/vllm_omni/outputs/__init__.py
+++ b/vllm_omni/outputs/__init__.py
@@ -12,6 +12,14 @@ from vllm.v1.outputs import ModelRunnerOutput
 from vllm_omni.inputs.data import OmniPromptType
 
 
+@dataclass(frozen=True)
+class SchedulingMetadataUpdate:
+    """Typed scheduler-visible effects derived from a received payload."""
+
+    prompt_token_ids: tuple[int, ...] | None = None
+    resize_prompt_to: int | None = None
+
+
 @dataclass
 class OmniConnectorOutput:
     """Communication results from Model Runner to Scheduler.
@@ -22,9 +30,8 @@ class OmniConnectorOutput:
     Attributes:
         chunk_ready_req_ids: Request IDs with newly arrived chunks this cycle.
         chunk_finished_req_ids: Request IDs whose final chunk has arrived.
-        request_metadata: Lightweight scheduling metadata keyed by request ID
-            (e.g. next_stage_prompt_len, code_predictor_codes, left_context_size).
-            Full payloads are owned by the Model Runner's local cache.
+        request_metadata: Typed scheduling updates keyed by request ID. Full
+            payloads remain owned by the Model Runner's local cache.
         kv_sent_req_ids: Request IDs whose KV cache was successfully sent.
         stage_recv_req_ids: Request IDs that received batch stage inputs.
         has_pending_kv_work: True if the mixin has pending, active, or
@@ -33,7 +40,7 @@ class OmniConnectorOutput:
 
     chunk_ready_req_ids: set[str] = field(default_factory=set)
     chunk_finished_req_ids: set[str] = field(default_factory=set)
-    request_metadata: dict[str, dict[str, Any]] = field(default_factory=dict)
+    request_metadata: dict[str, SchedulingMetadataUpdate] = field(default_factory=dict)
     kv_sent_req_ids: list[str] = field(default_factory=list)
     stage_recv_req_ids: set[str] = field(default_factory=set)
     has_pending_kv_work: bool = False

--- a/vllm_omni/worker/scheduling_metadata_adapter.py
+++ b/vllm_omni/worker/scheduling_metadata_adapter.py
@@ -17,7 +17,11 @@ logger = init_logger(__name__)
 
 @runtime_checkable
 class SchedulingMetadataAdapter(Protocol):
-    """Translate a runner payload into generic scheduler-visible effects."""
+    """Translate runner payloads into generic scheduler-visible effects.
+
+    The current production consumer is the runner-owned full-payload receive
+    path. Async-chunk scheduling remains owned by OmniChunkTransferAdapter.
+    """
 
     def extract(
         self,

--- a/vllm_omni/worker/scheduling_metadata_adapter.py
+++ b/vllm_omni/worker/scheduling_metadata_adapter.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Runner-side adapters for payload metadata that affects scheduling."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any, Protocol, runtime_checkable
+
+from vllm.logger import init_logger
+
+from vllm_omni.data_entry_keys import OmniPayload
+from vllm_omni.outputs import SchedulingMetadataUpdate
+
+logger = init_logger(__name__)
+
+
+@runtime_checkable
+class SchedulingMetadataAdapter(Protocol):
+    """Translate a runner payload into generic scheduler-visible effects."""
+
+    def extract(
+        self,
+        payload: OmniPayload,
+        *,
+        model_mode: str,
+    ) -> SchedulingMetadataUpdate | None: ...
+
+
+class DefaultSchedulingMetadataAdapter:
+    """Adapter for the established ``meta`` and ``codes.audio`` payload schema."""
+
+    def extract(
+        self,
+        payload: OmniPayload,
+        *,
+        model_mode: str,
+    ) -> SchedulingMetadataUpdate | None:
+        meta = payload.get("meta") if isinstance(payload, dict) else None
+        meta = meta if isinstance(meta, dict) else {}
+
+        resize_prompt_to = self._extract_prompt_length(payload, meta)
+        prompt_token_ids = self._extract_prompt_token_ids(payload) if model_mode != "ar" else None
+        if resize_prompt_to is None and prompt_token_ids is None:
+            return None
+        return SchedulingMetadataUpdate(
+            prompt_token_ids=prompt_token_ids,
+            resize_prompt_to=resize_prompt_to,
+        )
+
+    @staticmethod
+    def _extract_prompt_length(payload: OmniPayload, meta: dict[str, Any]) -> int | None:
+        value = meta.get("next_stage_prompt_len")
+        if value is None and "next_stage_prompt_len" in payload:
+            logger.warning_once(
+                "legacy flat 'next_stage_prompt_len' key in payload; expected 'meta.next_stage_prompt_len'"
+            )
+            value = payload["next_stage_prompt_len"]
+        return value if isinstance(value, int) and value > 0 else None
+
+    @classmethod
+    def _extract_prompt_token_ids(cls, payload: OmniPayload) -> tuple[int, ...] | None:
+        codes = payload.get("codes") if isinstance(payload, dict) else None
+        value = codes.get("audio") if isinstance(codes, dict) else None
+        if value is None:
+            return None
+        flattened = tuple(cls._flatten(value))
+        return flattened or None
+
+    @classmethod
+    def _flatten(cls, value: Any) -> list[int]:
+        if hasattr(value, "detach") and hasattr(value, "cpu") and hasattr(value, "tolist"):
+            value = value.detach().cpu().tolist()
+        elif hasattr(value, "tolist") and not isinstance(value, (list, tuple)):
+            value = value.tolist()
+        if isinstance(value, (list, tuple)):
+            return [token_id for item in value for token_id in cls._flatten(item)]
+        return [int(value)]
+
+
+def resolve_scheduling_metadata_adapter(
+    adapter: str | SchedulingMetadataAdapter | None,
+) -> SchedulingMetadataAdapter:
+    """Resolve a configured adapter without exposing payload keys to schedulers."""
+    if adapter is None:
+        return DefaultSchedulingMetadataAdapter()
+    if isinstance(adapter, str):
+        module_name, separator, attribute_name = adapter.rpartition(".")
+        if not separator:
+            raise ValueError("scheduling_metadata_adapter must be a fully qualified import path")
+        adapter = getattr(importlib.import_module(module_name), attribute_name)
+    if isinstance(adapter, type):
+        adapter = adapter()
+    if not isinstance(adapter, SchedulingMetadataAdapter):
+        raise TypeError("scheduling_metadata_adapter must implement extract(payload, *, model_mode)")
+    return adapter

--- a/vllm_omni/worker/scheduling_metadata_adapter.py
+++ b/vllm_omni/worker/scheduling_metadata_adapter.py
@@ -5,7 +5,8 @@
 from __future__ import annotations
 
 import importlib
-from typing import Any, Protocol, runtime_checkable
+import inspect
+from typing import Any, Protocol, cast
 
 from vllm.logger import init_logger
 
@@ -15,7 +16,6 @@ from vllm_omni.outputs import SchedulingMetadataUpdate
 logger = init_logger(__name__)
 
 
-@runtime_checkable
 class SchedulingMetadataAdapter(Protocol):
     """Translate runner payloads into generic scheduler-visible effects.
 
@@ -95,6 +95,13 @@ def resolve_scheduling_metadata_adapter(
         adapter = getattr(importlib.import_module(module_name), attribute_name)
     if isinstance(adapter, type):
         adapter = adapter()
-    if not isinstance(adapter, SchedulingMetadataAdapter):
-        raise TypeError("scheduling_metadata_adapter must implement extract(payload, *, model_mode)")
-    return adapter
+    extract = getattr(adapter, "extract", None)
+    if not callable(extract):
+        raise TypeError("scheduling_metadata_adapter.extract must be callable")
+    try:
+        inspect.signature(extract).bind(object(), model_mode="generation")
+    except (TypeError, ValueError) as exc:
+        raise TypeError(
+            "scheduling_metadata_adapter.extract must be callable as extract(payload, *, model_mode=...)"
+        ) from exc
+    return cast(SchedulingMetadataAdapter, adapter)


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.
Move model metadata interpretation out of scheduler internals into a typed adapter contract..

## Purpose
Finish part of 3rd step of https://github.com/vllm-project/vllm-omni/issues/5279, make inter-stage input transport generic:
- Move code_predictor_codes, left_context_size, and other model metadata interpretation out of scheduler internals into a typed adapter contract.

## Test Plan

**vLLM Version:**
0.27.0

**vLLM-Omni Commit:**
0.27.0

## Test Result

| Case | Contract exercised | Status |
|------|--------------------|--------|
| Text-only, non-streaming | AR path; adapter returns `None` → no metadata entry | PASS |
| Text-only, streaming | AR async per-chunk poll | PASS |
| Image understanding + speech | `codes.audio → prompt_token_ids` (generation branch), WAV saved | PASS |
| Realtime duplex audio session | Multi-turn handoff → `next_stage_prompt_len → resize_prompt_to` | PASS |

#### Text-only, streaming
```text
vllm serve /data/MiniCPM-o-4_5/ --omni --host 0.0.0.0 --port 9000 --deploy-config path/vllm-omni/vllm_omni/deploy/minicpmo_4_5.yaml --trust-remote-code
```
```text
python3 openai_chat_completion_client_for_multimodal_generation.py --model /data/MiniCPM-o-4_5/ --port 9000 --host localhost --query-type text  --prompt "Briefly introduce yourself." --stream
```
```text
content:Hello, I am a MiniCPM and very happy to meet you.
Audio saved to audio_chatcmpl-8c27a1001705da68_0.wav

Audio saved to audio_chatcmpl-8c27a1001705da68_1.wav

Audio saved to audio_chatcmpl-8c27a1001705da68_2.wav

Audio saved to audio_chatcmpl-8c27a1001705da68_3.wav
```

#### Realtime duplex audio session

```text
vllm serve /data/MiniCPM-o-4_5/ --omni --host 0.0.0.0 --port 9000 --deploy-config path/vllm-omni/vllm_omni/deploy/minicpmo_4_5_duplex.yaml --trust-remote-code
```

```test
python3 realtime_duplex_demo.py --model /data/MiniCPM-o-4_5/  --url "ws://localhost:9000/v1/realtime?duplex=1" --input-wav path/vllm-omni/tests/assets/minicpmo_4_5/soft_interrupt_16k.wav --ref-audio audio_chatcmpl-8c27a1001705da68_0.wav
```

```
[audio chunk 1: 11520 bytes -> /tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0001.wav]
好啊，
[audio chunk 2: 48000 bytes -> /tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0002.wav]
中国
[audio chunk 3: 48000 bytes -> /tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0003.wav]
古代的四大
[audio chunk 4: 48000 bytes -> /tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0004.wav]
发明指的是南
[audio chunk 5: 48000 bytes -> /tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0005.wav]
宋
[audio chunk 6: 21120 bytes -> /tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0006.wav]

[audio chunk 7: 1920 bytes -> /tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0007.wav]
没问
[audio chunk 8: 48000 bytes -> /tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0008.wav]
题，我
[audio chunk 9: 48000 bytes -> /tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0009.wav]
明白你的意
[audio chunk 10: 48000 bytes -> /tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0010.wav]
思了。
[audio chunk 11: 13440 bytes -> /tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0011.wav]

[audio chunk 12: 40320 bytes -> /tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0012.wav]
一加一等于二。
[audio chunk 13: 48000 bytes -> /tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0013.wav]

[audio chunk 14: 15360 bytes -> /tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0014.wav]
{
  "ok": true,
  "model_decision": "listen",
  "post_commit": {
    "input_committed_event_index": 83,
    "decision": "listen",
    "decision_required": true,
    "input_had_residual_model_unit": true,
    "response_listen_count": 1,
    "response_done_count": 0
  },
  "audio_bytes": 487680,
  "audio_chunk_count": 14,
  "audio_chunk_files": [
    "/tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0001.wav",
    "/tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0002.wav",
    "/tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0003.wav",
    "/tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0004.wav",
    "/tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0005.wav",
    "/tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0006.wav",
    "/tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0007.wav",
    "/tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0008.wav",
    "/tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0009.wav",
    "/tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0010.wav",
    "/tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0011.wav",
    "/tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0012.wav",
    "/tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0013.wav",
    "/tmp/minicpmo_realtime_duplex_demo/audio_chunks/chunk_0014.wav"
  ],
  "output_sample_rate_hz": 24000,
  "latency": {
    "ttft_ms": null,
    "ttfp_ms": null,
    "rtf": null,
    "response_generation_ms": null,
    "text_stream_ms": null,
    "transcript_delta_count": 14,
    "audio_duration_s": 10.16,
    "measurement_origin": "input_audio_buffer.commit send"
  },
  "timing": {},
  "response_ids": [
    "resp-duplex-9e9b5ec790e44a268ecadd1cde1bb172-0-231961da",
    "resp-duplex-9e9b5ec790e44a268ecadd1cde1bb172-0-abb6c0d6",
    "resp-duplex-9e9b5ec790e44a268ecadd1cde1bb172-0-5400be4b"
  ],
  "transcript": "好啊，中国古代的四大发明指的是南宋没问题，我明白你的意思了。一加一等于二。",
  "errors": [],
  "output_dir": "/tmp/minicpmo_realtime_duplex_demo"
}
```

