### PR TITLE
[Model] Enable LongCat-Video-Avatar CPU offload

### DIFF
--- a/docs/user_guide/diffusion/cpu_offload.md
+++ b/docs/user_guide/diffusion/cpu_offload.md
@@ -366,6 +366,7 @@ reasoner/generator components inside the model forward pass.
 |--------------|----------------|-----------|---------------------|-------------------|-------------------------------|-----------------------------------|
 | Flux2Pipeline | `black-forest-labs/FLUX.2-dev` | `Flux2Transformer2DModel` | ✓ | ✓ | - | `"transformer_blocks"`, `"single_transformer_blocks"` |
 | LongCatImagePipeline | `meituan-longcat/LongCat-Image` | `LongCatImageTransformer2DModel` | - | ✓ | - | `"transformer_blocks"`, `"single_transformer_blocks"` |
+| LongCatVideoAvatarPipeline | `meituan-longcat/LongCat-Video-Avatar-1.5` | `LongCatVideoAvatarTransformer3DModel` | ✓ | ✓ | - | `"blocks"` |
 | NextStep11Pipeline | `stepfun-ai/NextStep-1.1` | `NextStepModel` | - | ✓ | - | `"layers"` |
 | OvisImagePipeline | `AIDC-AI/Ovis-Image-7B` | `OvisImageTransformer2DModel` | - | ✓ | - | `"transformer"` |
 | QwenImagePipeline | `Qwen/Qwen-Image` | `QwenImageTransformer2DModel` | ✓ | ✓ | - | `"transformer_blocks"` |

--- a/docs/user_guide/diffusion_features.md
+++ b/docs/user_guide/diffusion_features.md
@@ -162,7 +162,7 @@ The following tables show which models support each feature:
 | **HunyuanVideo-1.5 T2V I2V** |     ❌     |     ✅      |           ✅           |       ✅        |         ✅         |         ❌         |   ✅    |             ✅             |  ✅ (encode/decode)   |       ✅        |        ❌         |
 | **DreamID-Omni**             |     ❌     |     ❌      |           ❌           |       ✅        |         ❌         |         ❌         |   ✅    |             ✅             |          ❌           |       ❌        |        ❌         |
 | **Cosmos3**                  |     ❌     |     ✅      |           ✅           |       ✅        |         ✅         |         ❌         |   ✅    |             ✅             |  ✅ (encode/decode)   |       ✅        |        ❌         |
-| **LongCat-Video-Avatar-1.5** |     ❌     |     ❌      |           ❌           |       ❌        |         ❌         |         ❌         |   ❌    |             ❌             |          ❌           |       ❌        |        ❌         |
+| **LongCat-Video-Avatar-1.5** |     ❌     |     ❌      |           ❌           |       ❌        |         ❌         |         ❌         |   ❌    |             ✅             |          ❌           |       ❌        |        ❌         |
 | **MiniMax-H3**               | ✅ (FL2VA) |     ✅      |           ✅           |       ❌        |       ✅ (DiT/TE)  |         ❌         |   ✅    |             ✅             |       ✅ (tile)       |      ✅ (DiT)      |        ❌         |
 
 > **Step execution note:** Helios supports single-request step execution only;

--- a/examples/offline_inference/longcat_video/end2end.py
+++ b/examples/offline_inference/longcat_video/end2end.py
@@ -55,6 +55,17 @@ def parse_args():
     )
     parser.add_argument("--use-kv-cache", action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument("--offload-kv-cache", action=argparse.BooleanOptionalAction, default=False)
+    offload_group = parser.add_mutually_exclusive_group()
+    offload_group.add_argument(
+        "--enable-cpu-offload",
+        action="store_true",
+        help="Swap the DiT with the T5 and Whisper encoders between inference phases.",
+    )
+    offload_group.add_argument(
+        "--enable-layerwise-offload",
+        action="store_true",
+        help="Stream LongCat DiT blocks from host memory during denoising.",
+    )
     parser.add_argument("--enforce-eager", action="store_true")
     return parser.parse_args()
 
@@ -235,6 +246,8 @@ def main():
         model_class_name="LongCatVideoAvatarPipeline",
         dtype="bfloat16",
         enforce_eager=args.enforce_eager,
+        enable_cpu_offload=args.enable_cpu_offload,
+        enable_layerwise_offload=args.enable_layerwise_offload,
         additional_config=additional_config,
         parallel_config=DiffusionParallelConfig(
             ulysses_degree=1,

--- a/recipes/meituan-longcat/LongCat-Video-Avatar-1.5.md
+++ b/recipes/meituan-longcat/LongCat-Video-Avatar-1.5.md
@@ -208,6 +208,28 @@ ffprobe -hide_banner longcat_avatar_ai2v.mp4
 The output must report one video stream and one audio stream: the example muxes
 the generated frames with the input audio.
 
+#### Memory-constrained inference
+
+LongCat-Video-Avatar can keep its DiT mutually exclusive with the T5 text and
+Whisper audio encoders on the accelerator. The VAE remains accelerator-resident:
+
+```bash
+python examples/offline_inference/longcat_video/end2end.py \
+  --model "$AVATAR_MODEL" \
+  --base-model-dir "$BASE_MODEL_DIR" \
+  --stage ai2v \
+  --audio "$LONGCAT_VIDEO_ASSET_DIR/single/man.mp3" \
+  --image "$LONGCAT_VIDEO_ASSET_DIR/single/man.png" \
+  --prompt "$PROMPT" \
+  --enable-cpu-offload \
+  --output longcat_avatar_cpu_offload.mp4
+```
+
+For tighter accelerator memory limits, replace `--enable-cpu-offload` with
+`--enable-layerwise-offload`. Layerwise offload keeps the non-DiT components
+resident and streams the DiT blocks from host memory during denoising. The
+two offload modes are mutually exclusive.
+
 #### Notes
 
 **Support matrix**
@@ -276,7 +298,8 @@ memory guidance rather than a performance benchmark.
 **Known limitations**
 
 - Single GPU only. Cache acceleration, sequence/CFG/tensor parallelism, HSDP,
-  CPU offload, VAE patch parallelism and quantization are not wired up for this
-  pipeline yet; see the diffusion feature matrix in
+  VAE patch parallelism and runtime quantization beyond the bundled INT8
+  weights are not wired up for this pipeline yet; see the diffusion feature
+  matrix in
   [`docs/user_guide/diffusion_features.md`](../../docs/user_guide/diffusion_features.md).
 - Offline inference only. Online serving is not supported yet.

--- a/tests/diffusion/models/longcat_video/test_longcat_video_avatar.py
+++ b/tests/diffusion/models/longcat_video/test_longcat_video_avatar.py
@@ -4,18 +4,23 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 
 import numpy as np
 import pytest
 import torch
 from PIL import Image
 
+from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
+from vllm_omni.diffusion.models.longcat_video import longcat_video_avatar_transformer as avatar_transformer
 from vllm_omni.diffusion.models.longcat_video.longcat_video_avatar_transformer import (
     LongCatVideoAvatarTransformer3DModel,
     _read_config,
     replace_linear_with_quantized,
 )
 from vllm_omni.diffusion.models.longcat_video.pipeline_longcat_video_avatar import (
+    LongCatVideoAvatarPipeline,
     _avatar_model_allow_patterns,
     _build_multi_speaker_ref_target_masks,
     _default_at2v_shape,
@@ -24,8 +29,353 @@ from vllm_omni.diffusion.models.longcat_video.pipeline_longcat_video_avatar impo
     _resolve_num_segments,
     prepare_longcat_video_avatar_model_for_omni,
 )
+from vllm_omni.diffusion.offloader.block_discovery import get_blocks_from_dit
+from vllm_omni.diffusion.offloader.module_collector import ModuleDiscovery
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.diffusion]
+
+
+@dataclass
+class _FeatureExtractorOutput:
+    input_features: torch.Tensor
+
+
+@dataclass
+class _WhisperEncoderOutput:
+    hidden_states: tuple[torch.Tensor, ...]
+
+
+@dataclass
+class _OffloadConfigStub:
+    enable_cpu_offload: bool = False
+    enable_layerwise_offload: bool = False
+    enable_distributed_layerwise_offload: bool = False
+
+
+class _DeviceRecordingModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.to_devices: list[torch.device] = []
+
+    def to(self, device: torch.device | str):
+        self.to_devices.append(torch.device(device))
+        return self
+
+
+def _small_avatar_transformer(depth: int = 2) -> LongCatVideoAvatarTransformer3DModel:
+    return LongCatVideoAvatarTransformer3DModel(
+        hidden_size=8,
+        depth=depth,
+        num_heads=1,
+        caption_channels=8,
+        intermediate_dim=8,
+        output_dim=8,
+        audio_channel=8,
+        context_tokens=1,
+    )
+
+
+def _single_block_lora_state(lora_dim: int = 2) -> dict[str, torch.Tensor]:
+    prefix = "lora___lorahyphen___blocks___lorahyphen___0___lorahyphen___attn___lorahyphen___qkv"
+    return {
+        f"{prefix}.alpha_scale": torch.tensor(1.0),
+        f"{prefix}.lora_down.weight": torch.ones(3 * lora_dim, 8),
+        **{f"{prefix}.lora_up.blocks.{idx}.weight": torch.ones(8, lora_dim) for idx in range(3)},
+    }
+
+
+def _outer_loader_with_weights(weights: list[tuple[str, torch.Tensor]]) -> DiffusersPipelineLoader:
+    loader = DiffusersPipelineLoader.__new__(DiffusersPipelineLoader)
+    loader.quant_config = None
+    loader.counter_before_loading_weights = 0.0
+    loader.counter_after_loading_weights = 0.0
+    loader.get_all_weights = lambda model: iter(weights)
+    return loader
+
+
+def _pipeline_with_small_transformer() -> LongCatVideoAvatarPipeline:
+    pipeline = LongCatVideoAvatarPipeline.__new__(LongCatVideoAvatarPipeline)
+    torch.nn.Module.__init__(pipeline)
+    pipeline.transformer = _small_avatar_transformer(depth=1)
+    pipeline.weights_sources = [
+        DiffusersPipelineLoader.ComponentSource(
+            model_or_path="unused",
+            subfolder=None,
+            revision=None,
+            prefix="transformer.",
+        )
+    ]
+    pipeline._distill_lora_path = None
+    return pipeline
+
+
+def test_longcat_video_avatar_declares_all_offload_components():
+    pipeline = LongCatVideoAvatarPipeline.__new__(LongCatVideoAvatarPipeline)
+    torch.nn.Module.__init__(pipeline)
+    pipeline.transformer = torch.nn.Identity()
+    pipeline.text_encoder = torch.nn.Identity()
+    pipeline.audio_encoder = torch.nn.Identity()
+    pipeline.vae = torch.nn.Identity()
+
+    assert isinstance(pipeline, SupportsComponentDiscovery)
+
+    modules = ModuleDiscovery.discover(pipeline)
+
+    assert modules.dit_names == ["transformer"]
+    assert modules.dits == [pipeline.transformer]
+    assert modules.encoder_names == ["text_encoder", "audio_encoder"]
+    assert modules.encoders == [pipeline.text_encoder, pipeline.audio_encoder]
+    assert modules.vae_names == ["vae"]
+    assert modules.vaes == [pipeline.vae]
+
+
+def test_longcat_video_avatar_declares_layerwise_offload_blocks():
+    model = _small_avatar_transformer()
+
+    block_attr_names, blocks = get_blocks_from_dit(model)
+
+    assert block_attr_names == ["blocks"]
+    assert blocks == list(model.blocks)
+
+
+@pytest.mark.parametrize(
+    ("od_config", "build_components_on_gpu", "expected_device", "build_on_accelerator"),
+    [
+        (_OffloadConfigStub(), False, torch.device("cuda:7"), False),
+        (_OffloadConfigStub(), True, torch.device("cuda:7"), True),
+        (_OffloadConfigStub(enable_cpu_offload=True), True, torch.device("cpu"), False),
+        (_OffloadConfigStub(enable_layerwise_offload=True), True, torch.device("cpu"), False),
+        (_OffloadConfigStub(enable_distributed_layerwise_offload=True), True, torch.device("cpu"), False),
+    ],
+)
+def test_longcat_video_avatar_initial_component_placement_respects_offload(
+    od_config: _OffloadConfigStub,
+    build_components_on_gpu: bool,
+    expected_device: torch.device,
+    build_on_accelerator: bool,
+):
+    pipeline = LongCatVideoAvatarPipeline.__new__(LongCatVideoAvatarPipeline)
+    torch.nn.Module.__init__(pipeline)
+    pipeline.od_config = od_config
+    pipeline.device = torch.device("cuda:7")
+    pipeline.build_components_on_gpu = build_components_on_gpu
+    pipeline.text_encoder = _DeviceRecordingModule()
+    pipeline.audio_encoder = _DeviceRecordingModule()
+    pipeline.transformer = _DeviceRecordingModule()
+    pipeline.vae = _DeviceRecordingModule()
+
+    pipeline._place_components_after_construction()
+
+    for component in (pipeline.text_encoder, pipeline.audio_encoder, pipeline.transformer, pipeline.vae):
+        assert component.to_devices == [expected_device]
+    assert pipeline._build_components_on_accelerator() is build_on_accelerator
+    assert pipeline.device == torch.device("cuda:7")
+
+
+def test_longcat_video_avatar_registers_lora_with_owning_block(monkeypatch, tmp_path):
+    model = _small_avatar_transformer()
+    lora_state = _single_block_lora_state()
+    monkeypatch.setattr(avatar_transformer, "load_file", lambda path, device: lora_state)
+
+    model.load_lora(
+        tmp_path / "dmd_lora.safetensors",
+        "dmd",
+        lora_network_dim=2,
+        lora_network_alpha=2,
+    )
+    qkv_input = torch.ones(1, 8)
+    base_output = model.blocks[0].attn.qkv(qkv_input)
+    model.enable_loras(["dmd"])
+
+    lora = model.lora_dict["dmd"].loras[0]
+    assert torch.allclose(model.blocks[0].attn.qkv(qkv_input) - base_output, torch.full((1, 24), 16.0))
+    assert dict(model.lora_dict["dmd"].named_modules())[lora.lora_name] is lora
+    assert model.blocks[0].attn.qkv._longcat_lora_adapters["dmd"] is lora
+    adapter_parameter_names = [name for name, _ in model.named_parameters() if "_longcat_lora_adapters" in name]
+    assert adapter_parameter_names == [
+        "blocks.0.attn.qkv._longcat_lora_adapters.dmd.lora_down.weight",
+        "blocks.0.attn.qkv._longcat_lora_adapters.dmd.lora_up.blocks.0.weight",
+        "blocks.0.attn.qkv._longcat_lora_adapters.dmd.lora_up.blocks.1.weight",
+        "blocks.0.attn.qkv._longcat_lora_adapters.dmd.lora_up.blocks.2.weight",
+    ]
+    assert not any(name.startswith("lora_dict.") for name, _ in model.named_parameters())
+    root_parameter_ids = [id(parameter) for _, parameter in model.named_parameters()]
+    for _, parameter in lora.named_parameters():
+        assert root_parameter_ids.count(id(parameter)) == 1
+    assert not any("_longcat_lora_adapters" in name for name, _ in model.blocks[1].named_parameters())
+    assert {
+        "blocks.0.attn.qkv._longcat_lora_adapters.dmd.alpha_scale",
+        "blocks.0.attn.qkv._longcat_lora_adapters.dmd.lora_down.weight",
+        "blocks.0.attn.qkv._longcat_lora_adapters.dmd.lora_up.blocks.0.weight",
+        "blocks.0.attn.qkv._longcat_lora_adapters.dmd.lora_up.blocks.1.weight",
+        "blocks.0.attn.qkv._longcat_lora_adapters.dmd.lora_up.blocks.2.weight",
+    }.issubset(model.state_dict())
+
+    block_attr_names, blocks = get_blocks_from_dit(model)
+    assert block_attr_names == ["blocks"]
+    assert blocks[0].attn.qkv._longcat_lora_adapters["dmd"] is lora
+
+    pipeline = LongCatVideoAvatarPipeline.__new__(LongCatVideoAvatarPipeline)
+    torch.nn.Module.__init__(pipeline)
+    pipeline.transformer = model
+    pipeline.text_encoder = torch.nn.Identity()
+    pipeline.audio_encoder = torch.nn.Identity()
+    pipeline.vae = torch.nn.Identity()
+    discovered = ModuleDiscovery.discover(pipeline)
+    assert discovered.dits == [model]
+    assert any(
+        "_longcat_lora_adapters.dmd.lora_down.weight" in name for name, _ in discovered.dits[0].named_parameters()
+    )
+
+    model.blocks[0].to(dtype=torch.float64)
+
+    assert lora.lora_down.weight.dtype == torch.float64
+    assert all(block.weight.dtype == torch.float64 for block in lora.lora_up.blocks)
+    assert next(model.blocks[0].parameters()).device == lora.lora_down.weight.device
+
+
+def test_longcat_video_avatar_adds_distill_lora_after_base_weight_accounting(monkeypatch, tmp_path):
+    pipeline = LongCatVideoAvatarPipeline.__new__(LongCatVideoAvatarPipeline)
+    torch.nn.Module.__init__(pipeline)
+    pipeline.transformer = _small_avatar_transformer(depth=1)
+    pipeline._distill_lora_path = tmp_path / "dmd_lora.safetensors"
+    base_parameter_names = {name for name, _ in pipeline.named_parameters()}
+    assert not any("_longcat_lora_adapters" in name for name in base_parameter_names)
+
+    loaded_base_weights = {"transformer.x_embedder.proj.weight"}
+
+    class BaseWeightsLoaderStub:
+        init_calls: list[list[str]] = []
+
+        def __init__(self, module, *, skip_substrs):
+            assert {name for name, _ in module.named_parameters()} == base_parameter_names
+            self.init_calls.append(skip_substrs)
+
+        def load_weights(self, weights):
+            assert list(weights) == []
+            return loaded_base_weights
+
+    monkeypatch.setattr(
+        "vllm_omni.diffusion.models.longcat_video.pipeline_longcat_video_avatar.AutoWeightsLoader",
+        BaseWeightsLoaderStub,
+    )
+    monkeypatch.setattr(avatar_transformer, "load_file", lambda path, device: _single_block_lora_state(128))
+
+    loaded_weights = pipeline.load_weights([])
+
+    assert loaded_weights == loaded_base_weights
+    assert BaseWeightsLoaderStub.init_calls == [["._longcat_lora_adapters."]]
+    assert not any("_longcat_lora_adapters" in name for name in loaded_weights)
+    assert any("_longcat_lora_adapters.dmd.lora_down.weight" in name for name, _ in pipeline.named_parameters())
+
+
+def test_longcat_video_avatar_base_weight_reload_skips_registered_lora(monkeypatch, tmp_path):
+    pipeline = LongCatVideoAvatarPipeline.__new__(LongCatVideoAvatarPipeline)
+    torch.nn.Module.__init__(pipeline)
+    pipeline.transformer = _small_avatar_transformer(depth=1)
+    pipeline._distill_lora_path = tmp_path / "dmd_lora.safetensors"
+    monkeypatch.setattr(avatar_transformer, "load_file", lambda path, device: _single_block_lora_state(128))
+
+    loader_calls = 0
+
+    class ReloadableWeightsLoaderStub:
+        def __init__(self, module, *, skip_substrs):
+            assert skip_substrs == ["._longcat_lora_adapters."]
+            assert not any(
+                "_longcat_lora_adapters" in name and "._longcat_lora_adapters." not in name
+                for name, _ in module.named_parameters()
+            )
+
+        def load_weights(self, weights):
+            nonlocal loader_calls
+            loader_calls += 1
+            return {"transformer.x_embedder.proj.weight"}
+
+    monkeypatch.setattr(
+        "vllm_omni.diffusion.models.longcat_video.pipeline_longcat_video_avatar.AutoWeightsLoader",
+        ReloadableWeightsLoaderStub,
+    )
+
+    first_loaded = pipeline.load_weights([])
+    first_lora = pipeline.transformer.lora_dict["dmd"].loras[0]
+    second_loaded = pipeline.load_weights([])
+    retained_adapter_names = {name for name, _ in pipeline.named_parameters() if "._longcat_lora_adapters." in name}
+
+    assert loader_calls == 2
+    assert first_loaded == {"transformer.x_embedder.proj.weight"}
+    assert second_loaded == {"transformer.x_embedder.proj.weight"} | retained_adapter_names
+    assert pipeline.transformer.lora_dict["dmd"].loras[0] is first_lora
+
+
+def test_longcat_video_avatar_real_outer_loader_allows_base_weight_reload(monkeypatch, tmp_path):
+    pipeline = _pipeline_with_small_transformer()
+    pipeline._distill_lora_path = tmp_path / "dmd_lora.safetensors"
+    monkeypatch.setattr(avatar_transformer, "load_file", lambda path, device: _single_block_lora_state(128))
+    base_weights = [
+        (f"transformer.{name}", parameter.detach().clone())
+        for name, parameter in pipeline.transformer.named_parameters()
+    ]
+    loader = _outer_loader_with_weights(base_weights)
+
+    loader.load_weights(pipeline)
+    first_lora = pipeline.transformer.lora_dict["dmd"].loras[0]
+    first_lora_values = {name: value.detach().clone() for name, value in first_lora.named_parameters()}
+
+    loader.load_weights(pipeline)
+
+    assert pipeline.transformer.lora_dict["dmd"].loras[0] is first_lora
+    for name, value in first_lora.named_parameters():
+        assert torch.equal(value, first_lora_values[name])
+
+
+def test_longcat_video_avatar_real_outer_loader_keeps_base_weight_check_strict():
+    pipeline = _pipeline_with_small_transformer()
+    base_weights = [
+        (f"transformer.{name}", parameter.detach().clone())
+        for name, parameter in pipeline.transformer.named_parameters()
+    ]
+    missing_name, _ = base_weights.pop()
+    loader = _outer_loader_with_weights(base_weights)
+
+    with pytest.raises(ValueError, match="were not initialized from checkpoint") as exc_info:
+        loader.load_weights(pipeline)
+
+    assert missing_name in str(exc_info.value)
+
+
+def test_longcat_video_avatar_invokes_managed_whisper_encoder_directly(monkeypatch):
+    class FakeFeatureExtractor:
+        def __call__(self, *args, **kwargs):
+            return _FeatureExtractorOutput(input_features=torch.ones(1, 80, 4))
+
+    class FakeWhisperEncoder(torch.nn.Module):
+        dtype = torch.float32
+
+        def __init__(self):
+            super().__init__()
+            self.call_count = 0
+
+        def forward(self, input_features, *, output_hidden_states):
+            self.call_count += 1
+            assert output_hidden_states is True
+            hidden_state = torch.ones(input_features.shape[0], input_features.shape[-1], 2)
+            return _WhisperEncoderOutput(hidden_states=(hidden_state,) * 33)
+
+    pipeline = LongCatVideoAvatarPipeline.__new__(LongCatVideoAvatarPipeline)
+    torch.nn.Module.__init__(pipeline)
+    pipeline.device = torch.device("cpu")
+    pipeline.audio_feature_extractor = FakeFeatureExtractor()
+    pipeline.audio_encoder = FakeWhisperEncoder()
+    monkeypatch.setattr(pipeline, "_loudness_norm", lambda audio, *args, **kwargs: audio)
+
+    embedding = pipeline._get_audio_embedding_whisper(
+        np.ones(1600, dtype=np.float32),
+        fps=25,
+        sample_rate=16000,
+    )
+
+    assert pipeline.audio_encoder.call_count == 1
+    assert embedding.shape == (2, 5, 2)
 
 
 @pytest.mark.parametrize(

--- a/vllm_omni/diffusion/models/longcat_video/longcat_video_avatar_transformer.py
+++ b/vllm_omni/diffusion/models/longcat_video/longcat_video_avatar_transformer.py
@@ -1139,6 +1139,9 @@ def create_lora_network(
     return network
 
 
+_LORA_ADAPTERS_ATTR = "_longcat_lora_adapters"
+
+
 class LongCatAvatarSingleStreamBlock(nn.Module):
     def __init__(
         self,
@@ -1308,6 +1311,7 @@ class LongCatAvatarSingleStreamBlock(nn.Module):
 
 class LongCatVideoAvatarTransformer3DModel(nn.Module):
     _supports_gradient_checkpointing = True
+    _layerwise_offload_blocks_attrs = ["blocks"]
 
     def __init__(
         self,
@@ -1353,8 +1357,11 @@ class LongCatVideoAvatarTransformer3DModel(nn.Module):
         self.audio_window = audio_window
         self.text_tokens_zero_pad = text_tokens_zero_pad
         self.gradient_checkpointing = False
-        self.lora_dict = {}
-        self.active_loras = []
+        # Keep the networks out of the top-level module tree. Individual LoRA
+        # modules are registered on their target Linear modules in load_lora(),
+        # so model-level and block-level offload traverse them exactly once.
+        self.lora_dict: dict[str, LoRANetwork] = {}
+        self.active_loras: list[str] = []
         self.config = SimpleNamespace(
             in_channels=in_channels,
             out_channels=out_channels,
@@ -1427,20 +1434,63 @@ class LongCatVideoAvatarTransformer3DModel(nn.Module):
     def dtype(self) -> torch.dtype:
         return self.x_embedder.proj.weight.dtype
 
-    def load_lora(self, lora_path, lora_key, multiplier=1.0, lora_network_dim=128, lora_network_alpha=64):
+    def load_lora(
+        self,
+        lora_path: str | os.PathLike[str],
+        lora_key: str,
+        multiplier: float = 1.0,
+        lora_network_dim: int = 128,
+        lora_network_alpha: float = 64,
+    ) -> None:
+        if not lora_key or "." in lora_key:
+            raise ValueError("LongCat LoRA keys must be non-empty and cannot contain '.'.")
+        if lora_key in self.lora_dict:
+            raise ValueError(f"LongCat LoRA {lora_key!r} is already loaded.")
+
         lora_state_dict = load_file(lora_path, device="cpu")
-        self.lora_dict[lora_key] = create_lora_network(
+        network = create_lora_network(
             self,
             lora_state_dict,
             multiplier=multiplier,
             network_dim=lora_network_dim,
             network_alpha=lora_network_alpha,
         )
+        self._register_loras_on_targets(lora_key, network)
+        self.lora_dict[lora_key] = network
 
-    def enable_loras(self, lora_key_list=None):
+    @staticmethod
+    def _lora_target_name(lora: LoRAModule) -> str:
+        return lora.lora_name.replace("lora___lorahyphen___", "").replace("___lorahyphen___", ".")
+
+    def _register_loras_on_targets(self, lora_key: str, network: LoRANetwork) -> None:
+        targets: list[nn.Module] = []
+        seen_targets: set[int] = set()
+        for lora in network.loras:
+            target = self._get_module_by_name(self._lora_target_name(lora))
+            if id(target) in seen_targets:
+                raise ValueError(f"LongCat LoRA {lora_key!r} contains multiple adapters for the same target.")
+            seen_targets.add(id(target))
+
+            adapters = getattr(target, _LORA_ADAPTERS_ATTR, None)
+            if adapters is not None and not isinstance(adapters, nn.ModuleDict):
+                raise TypeError(f"{_LORA_ADAPTERS_ATTR} on {target.__class__.__name__} must be an nn.ModuleDict.")
+            if adapters is not None and lora_key in adapters:
+                raise ValueError(f"LongCat LoRA {lora_key!r} is already registered on a target module.")
+            targets.append(target)
+
+        # Registration happens only after all targets have been validated, so
+        # a malformed adapter cannot leave a partially registered module tree.
+        for target, lora in zip(targets, network.loras, strict=True):
+            adapters = getattr(target, _LORA_ADAPTERS_ATTR, None)
+            if adapters is None:
+                adapters = nn.ModuleDict()
+                target.add_module(_LORA_ADAPTERS_ATTR, adapters)
+            adapters[lora_key] = lora
+
+    def enable_loras(self, lora_key_list: list[str] | None = None) -> None:
         lora_key_list = lora_key_list or []
         self.disable_all_loras()
-        module_loras = {}
+        module_loras: dict[str, list[LoRAModule]] = {}
         model_device = next(self.parameters()).device
         model_dtype = next(self.parameters()).dtype
         for lora_key in lora_key_list:
@@ -1448,7 +1498,7 @@ class LongCatVideoAvatarTransformer3DModel(nn.Module):
                 continue
             for lora in self.lora_dict[lora_key].loras:
                 lora.to(model_device, dtype=model_dtype, non_blocking=True)
-                module_name = lora.lora_name.replace("lora___lorahyphen___", "").replace("___lorahyphen___", ".")
+                module_name = self._lora_target_name(lora)
                 module_loras.setdefault(module_name, []).append(lora)
             self.active_loras.append(lora_key)
 
@@ -1474,7 +1524,7 @@ class LongCatVideoAvatarTransformer3DModel(nn.Module):
 
         return multi_lora_forward
 
-    def _get_module_by_name(self, module_name):
+    def _get_module_by_name(self, module_name: str) -> nn.Module:
         module = self
         for part in module_name.split("."):
             module = getattr(module, part)

--- a/vllm_omni/diffusion/models/longcat_video/pipeline_longcat_video_avatar.py
+++ b/vllm_omni/diffusion/models/longcat_video/pipeline_longcat_video_avatar.py
@@ -31,8 +31,13 @@ from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_wan import DistributedAutoencoderKLWan
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
-from vllm_omni.diffusion.models.interface import SupportAudioInput, SupportImageInput
+from vllm_omni.diffusion.models.interface import (
+    SupportAudioInput,
+    SupportImageInput,
+    SupportsComponentDiscovery,
+)
 from vllm_omni.diffusion.models.longcat_video.longcat_video_avatar_transformer import (
+    _LORA_ADAPTERS_ATTR,
     create_full_precision_avatar_dit,
     create_quantized_avatar_dit,
 )
@@ -511,12 +516,20 @@ def get_longcat_video_avatar_pre_process_func(od_config: OmniDiffusionConfig):
     return pre_process_func
 
 
-class LongCatVideoAvatarPipeline(nn.Module, SupportImageInput, SupportAudioInput):
+class LongCatVideoAvatarPipeline(
+    nn.Module,
+    SupportImageInput,
+    SupportAudioInput,
+    SupportsComponentDiscovery,
+):
     """Native LongCat-Video-Avatar A2V/AI2V pipeline."""
 
     support_image_input: ClassVar[bool] = True
     support_audio_input: ClassVar[bool] = True
     dummy_run_num_frames: ClassVar[int] = 1
+    _dit_modules: ClassVar[list[str]] = ["transformer"]
+    _encoder_modules: ClassVar[list[str]] = ["text_encoder", "audio_encoder"]
+    _vae_modules: ClassVar[list[str]] = ["vae"]
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
         super().__init__()
@@ -537,6 +550,7 @@ class LongCatVideoAvatarPipeline(nn.Module, SupportImageInput, SupportAudioInput
         self.save_fps = 25
         self.audio_stride = 1
         self.default_num_frames = 93
+        self._distill_lora_path: Path | None = None
         self.video_processor = VideoProcessor(vae_scale_factor=8)
         dit_subfolder = "base_model_int8" if self.use_int8 else "base_model"
         self.weights_sources = [
@@ -566,6 +580,34 @@ class LongCatVideoAvatarPipeline(nn.Module, SupportImageInput, SupportAudioInput
             allow_patterns=["tokenizer/*", "text_encoder/*", "vae/*", "config.json", "model_index.json"],
         )
 
+    def _stage_components_on_cpu(self) -> bool:
+        return bool(
+            getattr(self.od_config, "enable_cpu_offload", False)
+            or getattr(self.od_config, "enable_layerwise_offload", False)
+            or getattr(self.od_config, "enable_distributed_layerwise_offload", False)
+        )
+
+    def _initial_component_device(self) -> torch.device:
+        return torch.device("cpu") if self._stage_components_on_cpu() else self.device
+
+    def _build_components_on_accelerator(self) -> bool:
+        return self.build_components_on_gpu and not self._stage_components_on_cpu()
+
+    def _place_components_after_construction(self) -> None:
+        """Place components without changing the request execution device.
+
+        Offload backends are enabled only after pipeline loading. Keeping large
+        components on CPU here prevents a transient all-components accelerator
+        allocation; the selected backend then materializes the components it
+        owns. ``self.device`` remains the execution device so request tensors
+        match the module after its pre-forward offload hook runs.
+        """
+        component_device = self._initial_component_device()
+        self.text_encoder = self.text_encoder.to(component_device)
+        self.vae = self.vae.to(component_device)
+        self.transformer = self.transformer.to(device=component_device)
+        self.audio_encoder = self.audio_encoder.to(component_device)
+
     def _load_components(self) -> None:
         try:
             from audio_separator.separator import Separator
@@ -583,8 +625,7 @@ class LongCatVideoAvatarPipeline(nn.Module, SupportImageInput, SupportAudioInput
         # vLLM initializes native pipelines under the target device context.
         # Build LongCat's large components on CPU first by default to avoid
         # transient full-precision CUDA allocations before int8 DiT replacement.
-        build_context = nullcontext() if self.build_components_on_gpu else torch.device("cpu")
-        enable_distill_lora = False
+        build_context = nullcontext() if self._build_components_on_accelerator() else torch.device("cpu")
         with build_context:
             self.text_encoder = UMT5EncoderModel.from_pretrained(
                 str(base_dir), subfolder="text_encoder", torch_dtype=dtype
@@ -608,24 +649,21 @@ class LongCatVideoAvatarPipeline(nn.Module, SupportImageInput, SupportAudioInput
             if self.use_distill:
                 lora_path = self.model_dir / "lora" / "dmd_lora.safetensors"
                 if lora_path.exists():
-                    self.transformer.load_lora(
-                        str(lora_path),
-                        "dmd",
-                        multiplier=1.0,
-                        lora_network_dim=128,
-                        lora_network_alpha=64,
-                    )
-                    enable_distill_lora = True
+                    # Register the LoRA after base weights are loaded. This
+                    # keeps adapter parameters out of the loader's strict base
+                    # checkpoint accounting while still registering them on
+                    # their target modules before offload hooks are installed.
+                    self._distill_lora_path = lora_path
 
             audio_model_path = self.model_dir / "whisper-large-v3"
-            self.audio_encoder = WhisperModel.from_pretrained(str(audio_model_path)).eval()
+            whisper_model = WhisperModel.from_pretrained(str(audio_model_path)).eval()
+            # Avatar inference only consumes Whisper encoder hidden states. Keep
+            # the encoder as the managed component so sequential offload hooks
+            # run on the exact module whose forward method is invoked, and do
+            # not retain the unused decoder on the accelerator.
+            self.audio_encoder = whisper_model.encoder
 
-        self.text_encoder = self.text_encoder.to(self.device)
-        self.vae = self.vae.to(self.device)
-        self.transformer = self.transformer.to(device=self.device)
-        if enable_distill_lora:
-            self.transformer.enable_loras(["dmd"])
-        self.audio_encoder = self.audio_encoder.to(self.device)
+        self._place_components_after_construction()
         self.audio_encoder.requires_grad_(False)
         self.audio_feature_extractor = AutoFeatureExtractor.from_pretrained(str(audio_model_path))
 
@@ -654,8 +692,27 @@ class LongCatVideoAvatarPipeline(nn.Module, SupportImageInput, SupportAudioInput
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         """Load DiT weights using vLLM's diffusion weight loader."""
-        loader = AutoWeightsLoader(self)
-        return loader.load_weights(weights)
+        # LoRA adapters are attached after the first base-weight load. Exclude
+        # their private target-module path if a caller explicitly reloads base
+        # weights, so strict checkpoint accounting remains base-only.
+        retained_adapter_names = {name for name, _ in self.named_parameters() if f".{_LORA_ADAPTERS_ATTR}." in name}
+        loader = AutoWeightsLoader(self, skip_substrs=[f".{_LORA_ADAPTERS_ATTR}."])
+        loaded_weights = loader.load_weights(weights)
+        if self._distill_lora_path is not None and "dmd" not in self.transformer.lora_dict:
+            self.transformer.load_lora(
+                str(self._distill_lora_path),
+                "dmd",
+                multiplier=1.0,
+                lora_network_dim=128,
+                lora_network_alpha=64,
+            )
+            self.transformer.enable_loras(["dmd"])
+        # The outer diffusion loader performs its strict missing-weight check
+        # against parameters that existed before this call. On a base-weight
+        # reload, adapters registered by the first call are intentionally
+        # retained rather than reloaded from the base checkpoint, so count only
+        # that pre-existing snapshot as satisfied.
+        return loaded_weights | retained_adapter_names
 
     @staticmethod
     def _prompt_clean(text: str) -> str:
@@ -961,7 +1018,7 @@ class LongCatVideoAvatarPipeline(nn.Module, SupportImageInput, SupportAudioInput
 
         enc_chunks = []
         for idx in range(0, audio_features.shape[-1], _WHISPER_ENCODER_CHUNK_FRAMES):
-            chunk_hs = self.audio_encoder.encoder(
+            chunk_hs = self.audio_encoder(
                 audio_features[:, :, idx : idx + _WHISPER_ENCODER_CHUNK_FRAMES].to(self.device),
                 output_hidden_states=True,
             ).hidden_states


### PR DESCRIPTION
## Purpose

Enable memory-oriented inference for `meituan-longcat/LongCat-Video-Avatar-1.5` through the existing diffusion offload infrastructure.

This change:

- adds component discovery for the LongCat DiT, T5 text encoder, Whisper encoder, and VAE;
- supports model-level CPU offload and layerwise DiT offload through the model's real `blocks` attribute;
- stages large components on CPU before offload hooks are installed, avoiding a transient all-components accelerator allocation;
- keeps only the Whisper encoder used by inference instead of retaining its unused decoder;
- registers the bundled DMD LoRA on each owning target module so block migration carries its parameters and buffers exactly once;
- preserves strict base-checkpoint accounting across repeated outer-loader reloads while retaining already-loaded adapters;
- adds mutually exclusive example CLI flags, focused regression coverage, recipe instructions, and support-matrix updates.

Current scope remains single-GPU offline inference; this PR does not claim distributed offload, online serving, runtime quantization beyond the bundled INT8 weights, a GPU end-to-end run, or measured VRAM/performance results.

> AI assistance disclosure: this change was researched and implemented with OpenAI Codex assistance. It is opened as a Draft and must receive final human-owner review before being marked ready.

## Test Plan

```bash
python -m pytest \
  tests/diffusion/models/longcat_video/test_longcat_video_avatar.py -q

pre-commit run --files \
  docs/user_guide/diffusion/cpu_offload.md \
  docs/user_guide/diffusion_features.md \
  examples/offline_inference/longcat_video/end2end.py \
  recipes/meituan-longcat/LongCat-Video-Avatar-1.5.md \
  tests/diffusion/models/longcat_video/test_longcat_video_avatar.py \
  vllm_omni/diffusion/models/longcat_video/longcat_video_avatar_transformer.py \
  vllm_omni/diffusion/models/longcat_video/pipeline_longcat_video_avatar.py
```

**vLLM Version:** `v0.27.0` repository CI target

**vLLM-Omni Commit:** `a52caa5567efcfb13f9e61788c9fecb83fe38396`

## Test Result

- Focused CPU-only offload/loader contract suite: **8 passed**, including two real outer `DiffusersPipelineLoader` strict reloads and the missing-base-weight failure path.
- Complete changed-file precheck passed (Ruff check/format, typos, test marks, and repository convention hooks).
- Independent static cross-review: **zero blockers**.
- The committed target test module could not be collected in this local macOS environment because optional `aenum` and the compiled vLLM extension are unavailable. Standard CI and GPU hardware validation remain required; no GPU E2E or VRAM benchmark is claimed.