### PR TITLE
[Perf] Cap diffusion worker thread count before spawn

### DIFF
--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -18,6 +18,7 @@ import zmq
 from vllm.distributed.device_communicators.shm_broadcast import Handle, MessageQueue
 from vllm.logger import init_logger
 from vllm.v1.engine.exceptions import EngineDeadError
+from vllm.v1.executor.multiproc_executor import set_multiprocessing_worker_envs
 
 from vllm_omni.diffusion.data import SHUTDOWN_MESSAGE, AsyncDiffusionOutput, AsyncOutputKind, DiffusionOutput
 from vllm_omni.diffusion.executor.abstract import DiffusionExecutor
@@ -294,6 +295,10 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
         logger.info("Starting server...")
 
         num_gpus = cast(int, od_config.num_gpus)
+        # Without this, every worker inherits one Torch thread per core, so an
+        # N-GPU run oversubscribes the host by N x core_count. Honours a
+        # user-provided OMP_NUM_THREADS.
+        set_multiprocessing_worker_envs()
         mp.set_start_method("spawn", force=True)
         processes = []
 


### PR DESCRIPTION
## Purpose

`MultiprocDiffusionExecutor._launch_workers` never calls `set_multiprocessing_worker_envs()`, so
every diffusion worker starts with one Torch/OpenMP thread per visible CPU — on an 8-GPU MI300X
node with 224 CPUs that is 8 x 224 = **1792 threads oversubscribing 224 CPUs**, and the host-side
stages of a diffusion step pay for the contention. This is what vLLM's helper exists to prevent
("the default of spawning a thread per core combined with multiprocessing for each GPU can have a
negative impact on performance ... amplified when running in a container where CPU limits can
cause throttling"), and vLLM's own `MultiprocExecutor` calls it before forking.

This adds the call. The helper caps `OMP_NUM_THREADS` to 1 **only when unset**, so an explicit
value still wins.

## Test Plan

Print the worker-side thread state before and after the call, in the pinned image.

**vLLM Version:** 0.27.1

**vLLM-Omni Commit:** `bbe6ccc5`

## Test Result

| | `OMP_NUM_THREADS` | `torch.get_num_threads()` |
| --- | --- | --- |
| before | unset | 384 (= `cpu_count`) |
| after | 1 | 1 |

Not claimed: that 1 is the best value for diffusion workers — their host-side work is heavier
than LLM decode. This PR adopts vLLM's existing policy and keeps its env escape hatch.
