### PR TITLE
[Misc] Add VLLM_OMNI_DETERMINISTIC for bitwise-reproducible runs

### DIFF
--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -60,6 +60,7 @@ from vllm_omni.inputs.data import OmniInteractionPrompt
 from vllm_omni.lora.request import LoRARequest
 from vllm_omni.platforms import current_omni_platform
 from vllm_omni.profiler import OmniTorchProfilerWrapper, create_omni_profiler
+from vllm_omni.worker.determinism import maybe_enable_determinism
 from vllm_omni.worker.gpu_memory_utils import get_process_gpu_memory
 
 logger = init_logger(__name__)
@@ -275,6 +276,7 @@ class DiffusionWorker:
         # Setup device
         self.device = current_omni_platform.get_torch_device(rank)
         current_omni_platform.set_device(self.device)
+        maybe_enable_determinism()
 
         # Create vllm_config for parallel configuration. Pass explicit device_config
         # so DeviceConfig does not rely on current_platform in worker subprocesses.

--- a/vllm_omni/worker/determinism.py
+++ b/vllm_omni/worker/determinism.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Opt-in switch for bitwise-reproducible runs."""
+
+import os
+
+import torch
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+ENV_VAR = "VLLM_OMNI_DETERMINISTIC"
+
+
+def is_deterministic_requested() -> bool:
+    return os.environ.get(ENV_VAR, "0").strip().lower() in ("1", "true", "yes", "on")
+
+
+def maybe_enable_determinism() -> None:
+    """Restrict convolution to deterministic algorithms when ``VLLM_OMNI_DETERMINISTIC`` is set.
+
+    cuDNN/MIOpen may pick convolution algorithms whose cross-workgroup reduction uses
+    atomics, in which case the reduction order follows thread completion order and the
+    output differs run to run even at a fixed shape. Models with a VAE or a convolutional
+    image encoder therefore replay the same request differently.
+
+    The guarantee is intra-request: the same request, under the same config, in the same
+    process, produces bitwise identical output. Results are *not* made invariant to batch
+    composition.
+
+    Off by default -- the deterministic algorithms are slower. Intended for evaluation,
+    accuracy CI and RL rollouts.
+    """
+    if not is_deterministic_requested():
+        return
+    if not torch.backends.cudnn.is_available():
+        logger.warning("%s is set but cuDNN/MIOpen is unavailable; convolution is left as is.", ENV_VAR)
+        return
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+    logger.info("%s=1: convolution restricted to deterministic algorithms.", ENV_VAR)

--- a/vllm_omni/worker/gpu_ar_worker.py
+++ b/vllm_omni/worker/gpu_ar_worker.py
@@ -14,6 +14,7 @@ from vllm.v1.worker.workspace import init_workspace_manager
 from vllm_omni.diffusion.data import OmniACK, OmniSleepTask, OmniWakeTask
 from vllm_omni.platforms import current_omni_platform
 from vllm_omni.worker.base import OmniGPUWorkerBase
+from vllm_omni.worker.determinism import maybe_enable_determinism
 from vllm_omni.worker.gpu_ar_model_runner import GPUARModelRunner
 from vllm_omni.worker.memory_utils import request_memory_tolerant
 from vllm_omni.worker.mixins import OmniWorkerMixin
@@ -94,6 +95,7 @@ class GPUARWorker(OmniWorkerMixin, OmniGPUWorkerBase):
 
             # Set random seed.
             set_random_seed(self.model_config.seed)
+            maybe_enable_determinism()
 
             # Now take memory snapshot after NCCL is initialized
             gc.collect()

--- a/vllm_omni/worker/gpu_generation_worker.py
+++ b/vllm_omni/worker/gpu_generation_worker.py
@@ -13,6 +13,7 @@ from vllm.v1.worker.workspace import init_workspace_manager
 
 from vllm_omni.platforms import current_omni_platform
 from vllm_omni.worker.base import OmniGPUWorkerBase
+from vllm_omni.worker.determinism import maybe_enable_determinism
 from vllm_omni.worker.gpu_generation_model_runner import GPUGenerationModelRunner
 from vllm_omni.worker.memory_utils import request_memory_tolerant
 from vllm_omni.worker.mixins import OmniWorkerMixin
@@ -77,6 +78,7 @@ class GPUGenerationWorker(OmniWorkerMixin, OmniGPUWorkerBase):
 
             # Set random seed.
             set_random_seed(self.model_config.seed)
+            maybe_enable_determinism()
 
             # Now take memory snapshot after NCCL is initialized
             gc.collect()


### PR DESCRIPTION
## Purpose

cuDNN/MIOpen may pick convolution algorithms whose cross-workgroup reduction uses atomics. The
reduction order then follows thread completion order, so the output differs run to run **even at a
fixed shape**. Any model with a VAE or a convolutional image encoder therefore replays the same
request differently, and there is currently no way to turn that off.

`--fa-deterministic` does not cover this: it reaches the FlashAttention dense path only. On the
setup below, attention was already bitwise stable run to run; convolution was the one op that was
not.

This adds `VLLM_OMNI_DETERMINISTIC=1`, which restricts convolution to deterministic algorithms.
It is applied in the diffusion, AR and generation GPU workers, because `torch.backends.cudnn`
is process-global state and the stages of an omni pipeline run in separate processes.

The guarantee is intra-request: the same request, under the same config, in the same process,
produces bitwise identical output. Results are **not** made invariant to batch composition.

Off by default -- the deterministic algorithms are slower. Intended for evaluation, accuracy CI
and RL rollouts.

## Test Plan

DreamZero-DROID, CFG-parallel over 2 GPUs, `torch.compile` on, Cache-DiT step cache on.

1. **Single request, offline.** One real observation, 3 inferences per arm, 2 arms (fixed session
   with `reset=True`, fresh session per trial). Compare action chunks bitwise.
2. **Closed loop.** The same simulated episode run twice against one long-lived server
   (455 steps, `end_on_success=False`), comparing the h5 trajectories bitwise.
3. **Cost.** Median wall time of `generate()` with the switch off and on, 8 calls per arm,
   excluding the first (autotune, cold caches).

**vLLM Version:** 0.27.1

**vLLM-Omni Commit:** `bbe6ccc5`

## Test Result

| | switch off | switch on |
| --- | --- | --- |
| single request, within arm | `max abs diff` 1.14e-01 | **bitwise identical** |
| single request, across arms | `max abs diff` 7.94e-02 | **bitwise identical** |
| closed loop, 456 steps | diverges at the first action | **bitwise identical**, 6/6 channels |
| median latency per inference | 2.611 s | 4.195 s (**+61%**) |

The closed-loop channels compared are the scene initial conditions (`obj_start`, `tcp_pose`), the
policy output (`commanded_action`) and the simulator feedback (`qpos`, `panda`, `rewards`).

The +61% is per inference. In closed-loop evaluation it amortizes to about +11% of wall clock,
because a 4.5 min episode calls the policy only 19 times.

Ruled out as sources on the same setup, each a single-variable control: session lifecycle,
Cache-DiT step skipping, compile-time autotune, caching allocator reuse, `MIOPEN_FIND_MODE`,
the CFG collective, stream races, and uninitialized memory. Pinning the algorithm search with
`MIOPEN_FIND_MODE=NORMAL` has no effect; the algorithm that gets picked is itself
nondeterministic.

Not claimed: measured on ROCm (gfx942, MIOpen 3.5.1) only, no CUDA numbers -- the flag itself is
platform neutral, `torch.backends.cudnn` maps to MIOpen on ROCm. Verified on the DreamZero
AR-diffusion path only. The switch is shown to be sufficient, without localizing which
convolutions are responsible.

## Related

- #3435 (RFC: deterministic rollout for RL training of omni-modal & diffusion models) -- this is
  the intra-request half of that goal, available today without kernel work.
- #5512 (batch-invariant diffusion rollouts) -- complementary and strictly harder. Batch
  invariance assumes single-request determinism already holds; for convolutional pipelines it
  does not, so this switch is a prerequisite rather than a substitute.

## Question for maintainers

`--fa-deterministic` and this switch serve the same purpose from two directions. Would you like a
single `--deterministic` that turns on both, with the mechanism-level knobs kept as escape
hatches? Happy to follow up with that if so; kept out of this PR to avoid changing the semantics
of an existing flag.
