### PR TITLE
[Perf][NPU] Fuse MiniMax H3 Qwen3-VL SwiGLU

### DIFF
--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_qwen3vl_swiglu.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_qwen3vl_swiglu.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm_omni.platforms import current_omni_platform
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion]
+
+
+@pytest.mark.skipif(not current_omni_platform.is_npu(), reason="requires Ascend NPU")
+@pytest.mark.parametrize("shape", [(1, 16, 256), (2, 1, 256)])
+def test_qwen3_vl_npu_swiglu_matches_split_reference(
+    shape: tuple[int, int, int],
+) -> None:
+    from vllm_omni.platforms.npu.models.minimax_h3 import npu_swiglu_from_packed
+
+    packed = torch.randn(*shape, device="npu", dtype=torch.bfloat16)
+    gate, up = packed.chunk(2, dim=-1)
+
+    torch.testing.assert_close(
+        npu_swiglu_from_packed(packed),
+        F.silu(gate) * up,
+        atol=2e-2,
+        rtol=2e-2,
+    )
+
+
+@pytest.mark.skipif(not current_omni_platform.is_npu(), reason="requires Ascend NPU")
+def test_qwen3_vl_npu_swiglu_matches_two_projection_reference() -> None:
+    from vllm_omni.platforms.npu.models.minimax_h3 import npu_swiglu_from_packed
+
+    x = torch.randn(1, 16, 128, device="npu", dtype=torch.bfloat16)
+    weight = torch.randn(256, 128, device="npu", dtype=torch.bfloat16)
+    packed = F.linear(x, weight)
+    gate = F.linear(x, weight[:128])
+    up = F.linear(x, weight[128:])
+
+    torch.testing.assert_close(
+        npu_swiglu_from_packed(packed),
+        F.silu(gate) * up,
+        atol=2e-2,
+        rtol=2e-2,
+    )

--- a/vllm_omni/platforms/npu/models/minimax_h3.py
+++ b/vllm_omni/platforms/npu/models/minimax_h3.py
@@ -5,7 +5,11 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import torch
+import torch.nn.functional as F
+import torch_npu
 from vllm.logger import init_logger
 
 from vllm_omni.platforms.npu.layers.rotary_embedding import (
@@ -14,7 +18,8 @@ from vllm_omni.platforms.npu.layers.rotary_embedding import (
 
 logger = init_logger(__name__)
 
-_PATCHED = False
+_ROPE_PATCHED = False
+_SWIGLU_PATCHED = False
 
 
 def _apply_rotary_pos_emb_npu(
@@ -32,12 +37,35 @@ def _apply_rotary_pos_emb_npu(
 
 def apply_minimax_h3_qwen3vl_patch() -> None:
     """Route MiniMax H3 Qwen3-VL text RoPE to the Ascend fused operator."""
-    global _PATCHED
-    if _PATCHED:
+    global _ROPE_PATCHED
+    if _ROPE_PATCHED:
         return
 
     from vllm_omni.diffusion.models.minimax_h3 import encoder
 
     encoder._apply_rotary_pos_emb = _apply_rotary_pos_emb_npu
-    _PATCHED = True
+    _ROPE_PATCHED = True
     logger.debug("Applied NPU fused RoPE patch for MiniMax H3 Qwen3-VL text encoder")
+
+
+def npu_swiglu_from_packed(gate_up: torch.Tensor) -> torch.Tensor:
+    """Apply fused SwiGLU to a packed gate/up projection tensor."""
+    return torch_npu.npu_swiglu(gate_up, dim=-1)
+
+
+def _forward_minimax_h3_qwen3vl_text_mlp_npu(self: Any, x: torch.Tensor) -> torch.Tensor:
+    """Run the Qwen3-VL MLP with one packed GEMM and fused SwiGLU."""
+    gate_up = F.linear(x, self.gate_up_proj.weight)
+    return self.down_proj(npu_swiglu_from_packed(gate_up))
+
+
+def apply_minimax_h3_qwen3vl_swiglu_patch() -> None:
+    """Route MiniMax H3 Qwen3-VL text MLP to the Ascend fused SwiGLU path."""
+    global _SWIGLU_PATCHED
+    if _SWIGLU_PATCHED:
+        return
+
+    from vllm_omni.diffusion.models.minimax_h3 import encoder
+
+    encoder.MiniMaxH3Qwen3VLTextMLP.forward = _forward_minimax_h3_qwen3vl_text_mlp_npu
+    _SWIGLU_PATCHED = True

--- a/vllm_omni/platforms/npu/platform.py
+++ b/vllm_omni/platforms/npu/platform.py
@@ -36,10 +36,7 @@ class NPUOmniPlatform(OmniPlatform, NPUPlatform):
         from vllm_ascend.utils import adapt_patch
 
         from vllm_omni.platforms.npu._310p import apply_patches as apply_310p_patches
-        from vllm_omni.platforms.npu.models.minimax_h3 import (
-            apply_minimax_h3_qwen3vl_patch,
-            apply_minimax_h3_qwen3vl_swiglu_patch,
-        )
+        from vllm_omni.platforms.npu.models.minimax_h3 import apply_minimax_h3_qwen3vl_patch
         from vllm_omni.platforms.npu.models.qwen3_tts_code2wav import (
             apply_qwen3_tts_code2wav_patch,
         )
@@ -49,7 +46,6 @@ class NPUOmniPlatform(OmniPlatform, NPUPlatform):
 
         adapt_patch(is_global_patch=True)
         apply_minimax_h3_qwen3vl_patch()
-        apply_minimax_h3_qwen3vl_swiglu_patch()
         apply_qwen3_tts_code2wav_patch()
         apply_qwen3_tts_tokenizer_v2_patch()
         apply_310p_patches()
@@ -86,6 +82,14 @@ class NPUOmniPlatform(OmniPlatform, NPUPlatform):
     def init_diffusion_model_runner_runtime(cls, vllm_config: Any, od_config: Any, device: torch.device) -> None:
         from vllm_ascend.ascend_forward_context import set_mc2_mask, set_mc2_tokens_capacity
 
+        from vllm_omni.platforms.npu.models.minimax_h3 import (
+            apply_minimax_h3_qwen3vl_swiglu_patch,
+        )
+
+        # The patch imports the MiniMax encoder, which depends on
+        # current_omni_platform. Run it only after platform construction has
+        # completed, but before the diffusion pipeline is loaded.
+        apply_minimax_h3_qwen3vl_swiglu_patch()
         set_mc2_tokens_capacity(vllm_config, od_config.max_num_seqs, 1)
         set_mc2_mask(vllm_config, device)
 

--- a/vllm_omni/platforms/npu/platform.py
+++ b/vllm_omni/platforms/npu/platform.py
@@ -36,7 +36,10 @@ class NPUOmniPlatform(OmniPlatform, NPUPlatform):
         from vllm_ascend.utils import adapt_patch
 
         from vllm_omni.platforms.npu._310p import apply_patches as apply_310p_patches
-        from vllm_omni.platforms.npu.models.minimax_h3 import apply_minimax_h3_qwen3vl_patch
+        from vllm_omni.platforms.npu.models.minimax_h3 import (
+            apply_minimax_h3_qwen3vl_patch,
+            apply_minimax_h3_qwen3vl_swiglu_patch,
+        )
         from vllm_omni.platforms.npu.models.qwen3_tts_code2wav import (
             apply_qwen3_tts_code2wav_patch,
         )
@@ -46,6 +49,7 @@ class NPUOmniPlatform(OmniPlatform, NPUPlatform):
 
         adapt_patch(is_global_patch=True)
         apply_minimax_h3_qwen3vl_patch()
+        apply_minimax_h3_qwen3vl_swiglu_patch()
         apply_qwen3_tts_code2wav_patch()
         apply_qwen3_tts_tokenizer_v2_patch()
         apply_310p_patches()


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

This PR adds an Ascend NPU optimized SwiGLU path for the MiniMax H3
Qwen3-VL text encoder.

The Qwen3-VL MLP stores the gate and up projection weights in one packed
`gate_up_proj` tensor, but the original forward path slices the weight and
launches two independent `F.linear` operations, followed by unfused
`SiLU(gate) * up`.

On NPU, this PR:

- uses one packed `F.linear` for the gate/up projection;
- applies `torch_npu.npu_swiglu` on the packed result;
- keeps the existing `down_proj` path unchanged;
- registers the patch only on the NPU platform, leaving CPU/CUDA behavior
  unchanged.

## Test Plan
### 拉起服务：
`export PORT=8078
export MODEL="/data/weights/h3/MiniMax-H3/FL2VA"
export VLLM_WORKER_MULTIPROC_METHOD=spawn
export VLLM_OMNI_VIDEO_SYNC_TIMEOUT=1800
export PYTHONDONTWRITEBYTECODE=1
export HF_HUB_OFFLINE=1
export TRANSFORMERS_OFFLINE=1
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
export ASCEND_RT_VISIBLE_DEVICES=8,9,10,11,12,13,14,15
export MINDIE_SD_FA_TYPE="ascend_laser_attention"

vllm serve "${MODEL}" \
  --omni \
  --host 0.0.0.0 \
  --port "${PORT}" \
  --trust-remote-code \
  --num-gpus 8 \
  --usp 8 \
  --ring 1 \
  --text-encoder-tp-size 8 \
  --enable-distributed-layerwise-offload \
  --vae-parallel-mode tile \
  --vae-use-tiling \
  --vae-patch-parallel-size 8 \
  --diffusion-attention-backend FLASH_ATTN`

### 推理：
`export PORT=8078
export API_URL="http://127.0.0.1:${PORT}/v1/videos/sync"
export FIRST_FRAME="./vllm-omni/server_test/model_card/fl2va.png"

HDR_FILE=$(mktemp)
curl -sS -D "$HDR_FILE" -X POST "${API_URL}" \
  -F 'prompt=For the target video, at 0.00 seconds into the target video, <Picture 1> (from [Shot 1]) is fully referenced.\n\nintegrated_multimodal_description: [Shot 1] This is a live-action, cinematic shot with a shallow depth of field. The camera holds a perfectly static shot throughout the entire eight-second duration, capturing a cozy family gathering in a traditional Japanese dining room. The scene opens with a large, intricately patterned blue and white ceramic bowl of ramen in the immediate foreground, rendered in crisp, sharp focus. The bowl sits on a smooth, polished long wooden table. Inside the bowl, a rich, oily golden-brown broth surrounds yellow wavy noodles, topped with two thick, round slices of chashu pork featuring visible fat marbling and a distinct spiral meat pattern. A generous mound of freshly chopped, bright green scallions rests in the center, and a crisp, dark green rectangular sheet of nori seaweed is tucked into the right edge. To the left of the bowl, a pair of light brown wooden chopsticks rests horizontally on a small, dark rectangular chopstick rest, near a small cylindrical ceramic teacup with blue painted patterns. On the right side of the table, a spherical paper lantern with a ribbed bamboo frame sits on a black wooden base. In the background, a large family of seven is gathered around the table, initially appearing as a soft, blurred presence. Behind them, traditional Japanese sliding shoji screens with wooden lattice frames are open, revealing a bright outdoor scene with lush green trees. Early in the clip, the thick, white steam rising from the hot ramen broth immediately intensifies, billowing upwards in thick, swirling clouds that dance continuously above the bowl. As the clip progresses into the middle seconds, the camera maintains its static position while the focus begins a deliberate, smooth shift deeper into the room. The foreground ramen bowl, its vibrant ingredients, and the rising steam gradually soften into a hazy, out-of-focus blur. Simultaneously, the family members in the background come into sharp, detailed clarity. The heavy steam continues to rise from the foreground, creating a dynamic, translucent veil between the camera and the family. With the focus now firmly locked on the background, the vibrant family dinner comes alive. The man in the dark navy blue long-sleeved shirt on the left leans forward, his mouth moving animatedly in a silent exchange. The young girl in the crisp white short-sleeved t-shirt beside him smiles brightly, looking toward the center of the table. The woman on the far left, wearing a soft light blue long-sleeved blouse, turns her head slightly, smiling gently. Across the table, the woman in the light grey button-down shirt smiles broadly, her eyes crinkling, as she rests her hands near her plate. The woman in the dark grey top further back uses her wooden chopsticks to pick up a small piece of food from a central ceramic dish filled with bright red pickled vegetables. The woman in the center back in the light grey sweater smiles gently, her hands clasped softly in front of her, observing the interaction. Throughout the remainder of the clip, the family continues their lively physical interaction, their mouths moving in continuous, silent cadences of conversation, while the thick, white steam from the blurred ramen bowl in the foreground never stops rising, adding a comforting atmosphere to the warm gathering.\n\noverall_soundscape: The soundscape begins with a quiet room tone mixed with the faint, airy rustle of the thick steam billowing from the hot ramen bowl in the foreground, accompanied by the subtle, continuous hissing and bubbling of the rich broth. As the visual focus shifts deeper into the room, the physical sounds of the bustling family dinner become dominant in the foreground. The clear, sharp clinking of ceramic bowls and wooden chopsticks touching plates is clearly heard as the family members reach for food. This is followed by the faint, muffled thud of a cup being set down on the smooth wooden table, and the subtle, rhythmic rustle of cotton and wool clothing as the family members lean forward and gesture, perfectly capturing the lively, physical atmosphere of the shared meal.\n\nnon_diegetic_music: A gentle, heartwarming acoustic guitar melody plays softly in the background, accompanied by the subtle, resonant notes of a traditional Japanese koto. The music maintains a slow, comforting tempo that enhances the cozy, nostalgic, and joyful atmosphere of the family gathering.' \
  -F 'short_edge=768' \
  -F 'aspect_ratio=auto' \
  -F 'fps=24' \
  -F 'num_inference_steps=50' \
  -F 'flow_shift=12' \
  -F 'seed=0' \
  -F "input_references=@${FIRST_FRAME};type=image/png" \
  -F 'extra_params={"task":"fl2va","duration":8}' \
  -o fl2va_la_hsdp.mp4`

### image:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9f65c39f-db4e-4637-8944-b027c8f4476a" />


**vLLM Version:**
0.26.0

**vLLM-Omni Commit:**
146fb8403ce226896ad7354116c6fb90a1647700 + a60c559ad0af4ac6c8ef20e3f8595aeb78650178

## Test Result

### Performance
E2E Latency: 248593ms -> 246671ms.

ori:
<img width="1908" height="1388" alt="image" src="https://github.com/user-attachments/assets/f1c4b44c-5c10-4d60-b9f9-a31d1b45fefd" />


opt:
<img width="1263" height="924" alt="image" src="https://github.com/user-attachments/assets/6a3ce8e8-0d59-49aa-8033-15df1f43f13e" />

### Precision
ori:

https://github.com/user-attachments/assets/1631f71e-795b-4adf-bdf0-05b73ec03e88

opt:

https://github.com/user-attachments/assets/a7e7f8fd-8a89-4133-a4d6-b2c81fd32d55




**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)

