### PR TITLE
[Tests] Add tiny model test for StableDiffusionXLPipeline

### DIFF
--- a/tests/model_tests/diffusion/diff_model_builders.py
+++ b/tests/model_tests/diffusion/diff_model_builders.py
@@ -256,6 +256,20 @@ def tiny_flux_kontext_builder() -> str:
     )
 
 
+def tiny_sdxl_builder() -> str:
+    # The UNet's architecture (block_out_channels, transformer_layers_per_block, etc.)
+    # is hardcoded in SDXLUNet2DConditionModel rather than read from config, so it
+    # can't be shrunk here; only the two CLIP text encoders are reduced.
+    return build_tiny_from_configs(
+        "StableDiffusionXLPipeline",
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        transform={
+            "text_encoder": _shrink_flux_clip_text_encoder,
+            "text_encoder_2": _shrink_flux_clip_text_encoder,
+        },
+    )
+
+
 def tiny_flux2_builder() -> str:
     def shrink_text_encoder(config: dict) -> dict:
         config["tie_word_embeddings"] = False

--- a/tests/model_tests/diffusion/diff_model_builders.py
+++ b/tests/model_tests/diffusion/diff_model_builders.py
@@ -129,6 +129,20 @@ def tiny_flux_kontext_builder() -> str:
     )
 
 
+def tiny_sdxl_builder() -> str:
+    # The UNet's architecture (block_out_channels, transformer_layers_per_block, etc.)
+    # is hardcoded in SDXLUNet2DConditionModel rather than read from config, so it
+    # can't be shrunk here; only the two CLIP text encoders are reduced.
+    return build_tiny_from_configs(
+        "StableDiffusionXLPipeline",
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        transform={
+            "text_encoder": _shrink_flux_clip_text_encoder,
+            "text_encoder_2": _shrink_flux_clip_text_encoder,
+        },
+    )
+
+
 def tiny_flux2_builder() -> str:
     def shrink_text_encoder(config: dict) -> dict:
         # The real checkpoint ships language_model.lm_head.weight as its own

--- a/tests/model_tests/diffusion/model_settings.py
+++ b/tests/model_tests/diffusion/model_settings.py
@@ -136,4 +136,10 @@ DIFFUSION_TEST_SETTINGS = {
         builder=diff_model_builders.tiny_qwen_image_edit_plus_builder,
         supported_tasks=[DiffusionTasks.IMAGE_TO_IMAGE],
     ),
+    "StableDiffusionXLPipeline": DiffusionModelTestOpts(
+        model="stabilityai/stable-diffusion-xl-base-1.0",
+        builder=diff_model_builders.tiny_sdxl_builder,
+        supported_tasks=[DiffusionTasks.TEXT_TO_IMAGE],
+        extra_test_groups=[[DiffusionAccs.CPU_OFFLOAD]],
+    ),
 }

--- a/tests/model_tests/diffusion/model_settings.py
+++ b/tests/model_tests/diffusion/model_settings.py
@@ -84,4 +84,10 @@ DIFFUSION_TEST_SETTINGS = {
         builder=diff_model_builders.tiny_qwen_image_edit_plus_builder,
         supported_tasks=[DiffusionTasks.IMAGE_TO_IMAGE],
     ),
+    "StableDiffusionXLPipeline": DiffusionModelTestOpts(
+        model="stabilityai/stable-diffusion-xl-base-1.0",
+        builder=diff_model_builders.tiny_sdxl_builder,
+        supported_tasks=[DiffusionTasks.TEXT_TO_IMAGE],
+        extra_test_groups=[[DiffusionAccs.CPU_OFFLOAD]],
+    ),
 }

--- a/tests/model_tests/diffusion/test_alignment.py
+++ b/tests/model_tests/diffusion/test_alignment.py
@@ -75,7 +75,6 @@ EXCLUDED_MODELS = [
     "DiffusersAdapterPipeline",
     "HiDreamImagePipeline",
     "DreamZeroPipeline",
-    "StableDiffusionXLPipeline",
     "Gr00tN1d7Pipeline",
     "Pi0Pipeline",
     "SoulXSingerPipeline",

--- a/tests/model_tests/diffusion/test_alignment.py
+++ b/tests/model_tests/diffusion/test_alignment.py
@@ -79,7 +79,6 @@ EXCLUDED_MODELS = [
     "HiDreamImagePipeline",
     "HiDreamO1ImagePipeline",
     "DreamZeroPipeline",
-    "StableDiffusionXLPipeline",
     "Gr00tN1d7Pipeline",
     "Pi0Pipeline",
     "SanaWmPipeline",


### PR DESCRIPTION
## Purpose

Covers base text-to-image plus CPU offload; UNet stays full-size since its architecture is hardcoded rather than config-driven.

## Test Plan

**vLLM Version:** 0.27.0

**vLLM-Omni Commit:** af5ed0b9c16b5a73d81db3e4d9691192412d3954

```
pytest -s -v tests/model_tests/diffusion/ -k StableDiffusionXLPipeline
```

## Test Result

```
2 failed, 2 passed, 27 deselected, 17 warnings, 6 subtests passed in 82.81s (0:01:22)
```
Due to CPU offload failure

With https://github.com/vllm-project/vllm-omni/pull/6125
```
3 passed, 27 deselected, 17 warnings, 7 subtests passed in 82.60s (0:01:22)
```
