### PR TITLE
[Bugfix] Stop reading the removed OmniRequestOutput.request_output accessor

### DIFF
--- a/docs/features/custom_pipeline.md
+++ b/docs/features/custom_pipeline.md
@@ -101,7 +101,7 @@ outputs = omni.generate(
 )
 
 # Access custom trajectory data
-output = outputs[0].request_output
+output = outputs[0]
 print(f"Trajectory timesteps shape: {output.metrics['trajectory_timesteps'].shape}")
 print(f"Trajectory latents shape: {output.latents.shape}")
 ```

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -47,7 +47,7 @@ if __name__ == "__main__":
     omni = Omni(model="Tongyi-MAI/Z-Image-Turbo")
     prompt = "a cup of coffee on the table"
     outputs = omni.generate(prompt)
-    images = outputs[0].request_output.images
+    images = outputs[0].images
     images[0].save("coffee.png")
 ```
 
@@ -75,8 +75,7 @@ if __name__ == "__main__":
     ]
     omni_outputs = omni.generate(prompts)
     for i_prompt, prompt_output in enumerate(omni_outputs):
-        this_request_output = prompt_output.request_output
-        this_images = this_request_output.images
+        this_images = prompt_output.images
         for i_image, image in enumerate(this_images):
             image.save(f"p{i_prompt}-img{i_image}.jpg")
             print("saved to", f"p{i_prompt}-img{i_image}.jpg")

--- a/docs/user_guide/examples/offline_inference/glm_image.md
+++ b/docs/user_guide/examples/offline_inference/glm_image.md
@@ -43,7 +43,7 @@ if __name__ == "__main__":
             ),
         ],
     )
-    outputs[0].request_output.images[0].save("output.png")
+    outputs[0].images[0].save("output.png")
 ```
 
 ## Image-to-Image (Image Editing)
@@ -72,7 +72,7 @@ if __name__ == "__main__":
             ),
         ],
     )
-    outputs[0].request_output.images[0].save("output.png")
+    outputs[0].images[0].save("output.png")
 ```
 
 ## Generation Parameters

--- a/docs/user_guide/examples/offline_inference/text_to_image.md
+++ b/docs/user_guide/examples/offline_inference/text_to_image.md
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     omni = Omni(model="Qwen/Qwen-Image")
     prompt = "a cup of coffee on the table"
     outputs = omni.generate(prompt)
-    images = outputs[0].request_output.images
+    images = outputs[0].images
     images[0].save("coffee.png")
 ```
 
@@ -179,7 +179,7 @@ if __name__ == "__main__":
     ]
     outputs = omni.generate(prompts)
     for i, output in enumerate(outputs):
-        output.request_output.images[0].save(f"{i}.jpg")
+        output.images[0].save(f"{i}.jpg")
 ```
 
 !!! info
@@ -207,7 +207,7 @@ if __name__ == "__main__":
         }
     ])
     for i, output in enumerate(outputs):
-        output.request_output.images[0].save(f"{i}.jpg")
+        output.images[0].save(f"{i}.jpg")
 ```
 
 You can also pass a negative prompt via the CLI argument `--negative-prompt`:

--- a/examples/offline_inference/image_to_video/README.md
+++ b/examples/offline_inference/image_to_video/README.md
@@ -96,7 +96,7 @@ if __name__ == "__main__":
         ),
     )
     from diffusers.utils import export_to_video
-    frames = outputs[0].request_output.images
+    frames = outputs[0].images
     export_to_video(frames, "quick_test_i2v.mp4", fps=16)
 ```
 

--- a/examples/offline_inference/minicpmo/end2end.py
+++ b/examples/offline_inference/minicpmo/end2end.py
@@ -335,7 +335,7 @@ def main(args):
     print(f"use_tts (tts_bos): {use_tts}")
 
     for stage_outputs in omni_generator:
-        output = stage_outputs.request_output
+        output = stage_outputs
         if stage_outputs.final_output_type == "text":
             request_id = output.request_id
             text_output = output.outputs[0].text

--- a/examples/offline_inference/text_to_image/README.md
+++ b/examples/offline_inference/text_to_image/README.md
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     omni = Omni(model="Qwen/Qwen-Image")
     prompt = "a cup of coffee on the table"
     outputs = omni.generate(prompt)
-    images = outputs[0].request_output.images
+    images = outputs[0].images
     images[0].save("coffee.png")
 ```
 
@@ -265,7 +265,7 @@ if __name__ == "__main__":
     ]
     outputs = omni.generate(prompts)
     for i, output in enumerate(outputs):
-        output.request_output.images[0].save(f"{i}.jpg")
+        output.images[0].save(f"{i}.jpg")
 ```
 
 !!! info
@@ -301,7 +301,7 @@ if __name__ == "__main__":
         }
     ])
     for i, output in enumerate(outputs):
-        output.request_output.images[0].save(f"{i}.jpg")
+        output.images[0].save(f"{i}.jpg")
 ```
 
 You can also pass a negative prompt via the CLI argument `--negative-prompt`:

--- a/tests/diffusion/distributed/test_flux2_vae_patch_parallel.py
+++ b/tests/diffusion/distributed/test_flux2_vae_patch_parallel.py
@@ -53,14 +53,10 @@ def _diff_metrics(a: Image.Image, b: Image.Image) -> tuple[float, float]:
 def _extract_single_image(outputs) -> Image.Image:
     first_output = outputs[0]
     assert first_output.final_output_type == "image"
-    if not hasattr(first_output, "request_output") or not first_output.request_output:
-        raise ValueError("No request_output found in OmniRequestOutput")
+    if not isinstance(first_output, OmniRequestOutput):
+        raise ValueError(f"Expected an OmniRequestOutput, got {type(first_output).__name__}")
 
-    req_out = first_output.request_output
-    if not isinstance(req_out, OmniRequestOutput) or not hasattr(req_out, "images"):
-        raise ValueError("Invalid request_output structure or missing 'images' key")
-
-    images = req_out.images
+    images = first_output.images
     if images is None or len(images) != 1:
         raise ValueError(f"Expected 1 image, got {0 if images is None else len(images)}")
     return images[0]

--- a/tests/diffusion/distributed/test_vae_decode_parallelism.py
+++ b/tests/diffusion/distributed/test_vae_decode_parallelism.py
@@ -72,8 +72,7 @@ def _to_float_array(data: Any) -> np.ndarray:
 
 
 def _extract_output_array(output: Any) -> np.ndarray:
-    req_out = output.request_output
-    payload = req_out.images[0]
+    payload = output.images[0]
     return _to_float_array(payload)
 
 

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_quantization_quality.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_quantization_quality.py
@@ -142,12 +142,6 @@ def _generate_joint_output(omni, config: QualityTestConfig):
 
     first = outputs[0]
     worker_peak_memory_mb = float(getattr(first, "peak_memory_mb", 0.0) or 0.0)
-    if hasattr(first, "request_output") and isinstance(first.request_output, list):
-        first = first.request_output[0]
-        worker_peak_memory_mb = max(
-            worker_peak_memory_mb,
-            float(getattr(first, "peak_memory_mb", 0.0) or 0.0),
-        )
     if not hasattr(first, "images") or not first.images:
         raise ValueError("Could not extract video frames from H3 output")
     frames = first.images[0]

--- a/tests/docs/test_example_output_accessors.py
+++ b/tests/docs/test_example_output_accessors.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Guard the public accessor that examples and docs use to read omni outputs.
+
+``OmniRequestOutput`` used to hold a nested ``RequestOutput`` in a
+``request_output`` field.  Since #5146 it *inherits* ``RequestOutput``, so the
+generation content lives on the object itself and the nested field is gone.
+
+Call sites that kept the old accessor only fail once a real model runs, which
+means a GPU nightly job is the first thing to notice.  These checks pin both
+halves of the contract on CPU instead: the field is really gone, and no doc,
+example, test or tool still reaches for it.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from vllm_omni.outputs import OmniRequestOutput
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+ROOT_DIR = Path(__file__).parents[2]
+SCANNED_DIRS = ("docs", "examples", "tests", "tools")
+SCANNED_SUFFIXES = (".py", ".md")
+
+# ``.request_outputs`` (plural, an OutputProcessor batch) is a different and
+# still-valid attribute, so require a non-identifier character after the name.
+NESTED_ACCESSOR = re.compile(r"\.request_output(?![\w])")
+
+
+def _iter_scanned_files():
+    for directory in SCANNED_DIRS:
+        for path in sorted((ROOT_DIR / directory).rglob("*")):
+            if path.suffix in SCANNED_SUFFIXES and path.resolve() != Path(__file__).resolve():
+                yield path
+
+
+def test_omni_request_output_has_no_nested_request_output():
+    assert not hasattr(OmniRequestOutput(request_id="req-accessor"), "request_output")
+
+
+def test_no_source_reads_the_nested_request_output():
+    offenders = []
+    for path in _iter_scanned_files():
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if NESTED_ACCESSOR.search(line):
+                offenders.append(f"{path.relative_to(ROOT_DIR)}:{lineno}: {line.strip()}")
+
+    assert not offenders, (
+        "OmniRequestOutput no longer nests a RequestOutput; read the content off the "
+        "output itself (e.g. `outputs[0].images`) instead of `.request_output`:\n" + "\n".join(offenders)
+    )

--- a/tests/e2e/accuracy/ltx/run_ltx_reference.py
+++ b/tests/e2e/accuracy/ltx/run_ltx_reference.py
@@ -260,15 +260,9 @@ def _unwrap_omni_output(output: Any) -> tuple[Any, Any, int]:
         multimodal_output = frames.multimodal_output or {}
         audio = multimodal_output.get("audio")
         audio_sample_rate = multimodal_output.get("audio_sample_rate")
-        if frames.is_pipeline_output and isinstance(frames.request_output, OmniRequestOutput):
-            frames = frames.request_output
-            multimodal_output = frames.multimodal_output or {}
-            audio = multimodal_output.get("audio", audio)
-            audio_sample_rate = multimodal_output.get("audio_sample_rate", audio_sample_rate)
-        if isinstance(frames, OmniRequestOutput):
-            if not frames.images:
-                raise ValueError("No video frames found in OmniRequestOutput")
-            frames = frames.images
+        if not frames.images:
+            raise ValueError("No video frames found in OmniRequestOutput")
+        frames = frames.images
 
     if isinstance(frames, list) and len(frames) == 1:
         frames = frames[0]

--- a/tools/baselines/omni_hash_baseline.py
+++ b/tools/baselines/omni_hash_baseline.py
@@ -159,11 +159,10 @@ def _run_once(model: str, yaml_path: str, *, async_mode: bool) -> list[dict]:
             wav: bytes = b""
             # Batch size 1: submit a single prompt so scheduling is deterministic.
             for step in omni.generate([_text_prompt(question)], _sampling_params(), py_generator=False):
-                out = step.request_output
                 if step.final_output_type == "text":
-                    text = out.outputs[0].text  # exact text, no strip -> truly bit-identical
+                    text = step.outputs[0].text  # exact text, no strip -> truly bit-identical
                 elif step.final_output_type == "audio":
-                    wav = _audio_bytes(out.outputs[0].multimodal_output["audio"])
+                    wav = _audio_bytes(step.outputs[0].multimodal_output["audio"])
             if text is None:
                 raise RuntimeError(f"prompt_id={prompt_id} async={async_mode}: produced no text output")
             if not wav:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fixes #6133.

`OmniRequestOutput` used to hold a nested `RequestOutput` in a `request_output` field. #5146 made
it *inherit* `RequestOutput`, so the generation content lives on the object itself and the nested
field no longer exists. 21 call sites across 12 files still read it, and three nightly CUDA jobs
fail deterministically:

```text
AttributeError: 'OmniRequestOutput' object has no attribute 'request_output'
```

This PR routes every one of them at the output object directly (`outputs[0].images` rather than
`outputs[0].request_output.images`).

Two things worth flagging that are not in the issue:

**The blast radius is wider than the three jobs.** `examples/offline_inference/image_to_video/README.md:99`
sits inside a python snippet that `tests/examples/offline_inference/test_image_to_video.py`
collects and runs, so the image-to-video Doc Test fails the same way.

**Two call sites fail differently, which is why the log-scraped issue did not group them.** They
guarded the access with `hasattr`, so instead of the `AttributeError` they take a branch that was
never meant to run: `tests/diffusion/distributed/test_flux2_vae_patch_parallel.py` now always
raises `ValueError("No request_output found in OmniRequestOutput")`, and
`tests/diffusion/models/minimax_h3/test_minimax_h3_quantization_quality.py` silently skips its
worker peak-memory update. Both guards are dropped along with the accessor.

One correction to the issue's list: `more_cli_examples_003` is the bash NextStep-1.1 snippet.
Neither it, nor `text_to_image.py`, nor `diffusion/utils/image_output.py` reads the removed
accessor — #5146 already updated those — so **that case is not addressed here** and, if it is
still failing, it has another cause.

`tests/e2e/accuracy/ltx/run_ltx_reference.py` and
`tests/diffusion/models/minimax_h3/test_minimax_h3_quantization_quality.py` lose a few lines
rather than gaining a rename: their nested-unwrap blocks became unreachable when the nesting went
away, and the code immediately around them already reads the content off the outer object.

### Regression test

`tests/docs/test_example_output_accessors.py` (new, `core_model` + `cpu`, following the
`tests/docs/test_generate_examples.py` idiom) pins both halves of the contract: the field really is
gone from the class, and no doc, example, test or tool reads it. The nested field only fails once a
real model has produced an output, which is why a GPU nightly job was the first thing to notice;
this turns that into a millisecond CPU check. #5146 is part of a series, so the next removal should
not have to wait for nightly either.

## Test Plan

```bash
# regression test, red on unmodified main and green here
pytest tests/docs/test_example_output_accessors.py -q
pytest tests/docs/ -q

# adjacent output-contract suites, untouched by this PR
pytest tests/engine/test_omni_request_output.py tests/engine/test_output_processor.py -q

# the edited GPU tests still import and collect
pytest --collect-only -q tests/diffusion/distributed/test_vae_decode_parallelism.py \
    tests/diffusion/distributed/test_flux2_vae_patch_parallel.py \
    tests/diffusion/models/minimax_h3/test_minimax_h3_quantization_quality.py
python -m py_compile tests/e2e/accuracy/ltx/run_ltx_reference.py \
    tools/baselines/omni_hash_baseline.py examples/offline_inference/minicpmo/end2end.py

# the four CI-collected snippets, read back through the repo's own extractor
python -c "from tests.examples.helpers import ReadmeSnippet; ..."

pre-commit run --files <the 13 changed files>
```

**vLLM Version:** 0.27.0

**vLLM-Omni Commit:** dbc0dd6d (upstream main)

## Test Result

The accessor is gone and the replacement is the right one, against an output built the way
`diffusion/output_formatter.py` builds it:

```text
final_output_type : image
out.images        : [<PIL.Image.Image image mode=RGB size=8x8 ...>]
out.request_output: AttributeError: 'OmniRequestOutput' object has no attribute 'request_output'
```

The snippets the Doc Test collects, read back through `ReadmeSnippet.extract_readme_snippets`:

```text
examples/offline_inference/text_to_image/README.md: 15 snippets collected, 0 still using .request_output
    quick_start_001       : images = outputs[0].images
    more_cli_examples_008 : output.images[0].save(f"{i}.jpg")
    more_cli_examples_009 : output.images[0].save(f"{i}.jpg")
examples/offline_inference/image_to_video/README.md: 17 snippets collected, 0 still using .request_output
    quick_start_001       : frames = outputs[0].images
```

The new test is red on unmodified main and green here:

```text
# upstream main dbc0dd6d
pytest tests/docs/test_example_output_accessors.py -q
FAILED tests/docs/test_example_output_accessors.py::test_no_source_reads_the_nested_request_output
  ... 21 offenders across 12 files ...
1 failed, 1 passed, 14 warnings in 0.22s

# this branch
pytest tests/docs/ -q
6 passed, 14 warnings in 0.21s
```

Adjacent suites and collection:

```text
pytest tests/engine/test_omni_request_output.py tests/engine/test_output_processor.py -q
41 passed, 14 warnings in 0.18s

pytest --collect-only -q <the three edited GPU tests>
7 tests collected in 1.48s
py_compile: ltx reference + hash baseline + minicpmo end2end OK
```

pre-commit on the 13 changed files: all hooks pass (`actionlint` skipped, no workflow files
touched).

Run on one A800 against upstream main `dbc0dd6d`, vLLM 0.27.0. The three failing nightly jobs
themselves need the CUDA runners and are covered by the Diffusion X2I Doc Test, X2V Other Accuracy
Test and Distributed Test with H100 jobs.
