### PR TITLE
[Model][Feat] LTX HQ pipelines

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -44,10 +44,12 @@ th {
 | `Wan22VACEPipeline` | Wan2.2-VACE | `Pyros13/Wan2.2-VACE-Fun-A14B-Diffusers` | ✅︎ |   |   |   | — |
 | `LTX2Pipeline` | LTX-2 / LTX-2.3 one-stage T2V and I2V | `Lightricks/LTX-2`, `diffusers/LTX-2.3-Diffusers` | ✅︎ | ✅︎ | | | — |
 | `LTX2TwoStagePipeline` | LTX-2 / LTX-2.3 ordinary two-stage T2V and I2V | `Lightricks/LTX-2`, `diffusers/LTX-2.3-Diffusers` + matching Lightricks LoRA and upsampler | ✅︎ | ✅︎ | | | — |
+| `LTX2TwoStageHQPipeline` | LTX-2.3 Res2s HQ two-stage T2V and I2V | `diffusers/LTX-2.3-Diffusers` + `Lightricks/LTX-2.3` LoRA and upsampler | ✅︎ | ✅︎ | | | — |
 | `LTX2DistilledOneStagePipeline` | LTX-2 / LTX-2.3 merged-distilled one-stage T2V and I2V | `rootonchair/LTX-2-19b-distilled`, `diffusers/LTX-2.3-Distilled-Diffusers` | ✅︎ | ✅︎ | | | — |
 | `LTX2DistilledTwoStagePipeline` | LTX-2 / LTX-2.3 merged-distilled two-stage T2V and I2V | `rootonchair/LTX-2-19b-distilled`, `diffusers/LTX-2.3-Distilled-Diffusers` + matching Lightricks upsampler | ✅︎ | ✅︎ | | | — |
 | `LTX2Pipeline` | LTX-2.5 Full/SFT one-stage T2V and I2V | `Lightricks/LTX-2.5-Diffusers` | ✅︎ | | | | [Repository](https://github.com/vllm-project/vllm-omni/blob/main/recipes/LTX/LTX-2.5.md) |
 | `LTX2TwoStagePipeline` | LTX-2.5 Full/SFT two-stage T2V and I2V | `Lightricks/LTX-2.5-Diffusers` + `Lightricks/LTX-2.5` LoRA | ✅︎ | | | | [Repository](https://github.com/vllm-project/vllm-omni/blob/main/recipes/LTX/LTX-2.5.md) |
+| `LTX2TwoStageHQPipeline` | LTX-2.5 Res2s HQ two-stage T2V and I2V | `Lightricks/LTX-2.5-Diffusers` + `Lightricks/LTX-2.5` LoRA and upsampler | ✅︎ | | | | [Repository](https://github.com/vllm-project/vllm-omni/blob/main/recipes/LTX/LTX-2.5.md) |
 | `LTX2DistilledOneStagePipeline` | LTX-2.5 merged-distilled one-stage T2V and I2V | `Lightricks/LTX-2.5-Diffusers` | ✅︎ | | | | [Repository](https://github.com/vllm-project/vllm-omni/blob/main/recipes/LTX/LTX-2.5.md) |
 | `LTX2DistilledTwoStagePipeline` | LTX-2.5 merged-distilled two-stage T2V and I2V | `Lightricks/LTX-2.5-Diffusers` | ✅︎ | | | | [Repository](https://github.com/vllm-project/vllm-omni/blob/main/recipes/LTX/LTX-2.5.md) |
 | `LingBotVideoPipeline` | LingBot-Video dense and MoE T2I, T2V, TI2V | `robbyant/lingbot-video-dense-1.3b`, `robbyant/lingbot-video-moe-30b-a3b` | ✅︎ | | | | — |

--- a/recipes/LTX/LTX-2.5.md
+++ b/recipes/LTX/LTX-2.5.md
@@ -20,11 +20,18 @@ both model licenses and authenticate before first use.
 |---|---|---:|---:|
 | `LTX2Pipeline` | Full/SFT one-stage | 960x544 | 30 steps |
 | `LTX2TwoStagePipeline` | Full/SFT two-stage | 1920x1088 | 30 + 3 steps |
+| `LTX2TwoStageHQPipeline` | Full/SFT Res2s HQ two-stage | 1920x1088 | 15 + 3 steps |
 | `LTX2DistilledOneStagePipeline` | Distilled one-stage | 960x544 | 8 steps |
 | `LTX2DistilledTwoStagePipeline` | Distilled two-stage | 1920x1088 | 8 + 3 steps |
 
-Both two-stage pipelines generate at half resolution, apply the official x2
-latent upsampler, and run a three-step refinement stage. Select the class with
+All three two-stage pipelines generate at half resolution, apply the official
+x2 latent upsampler, and run a three-step refinement stage.
+`LTX2TwoStagePipeline` uses the Full/SFT transformer with guided Stage 1 and
+applies the official distilled LoRA only for Stage 2.
+`LTX2TwoStageHQPipeline` uses Res2s in both stages, disables STG, and applies
+the LoRA at strength 0.25 in Stage 1 and 0.5 in Stage 2.
+`LTX2DistilledTwoStagePipeline` uses the positive-only merged-distilled
+transformer in both stages. Select the class with
 `--model-class-name`; no `--task-type` flag is required. Supplying one initial
 image selects I2V, while omitting it selects T2V.
 
@@ -43,9 +50,9 @@ Install matching vLLM and vLLM-Omni versions, and ensure `ffmpeg` and
 
 | GPU | Status | Recommended scope |
 |---|---|---|
-| NVIDIA B300 | Verified | All four canonical pipelines |
-| NVIDIA B200 or H200 | Capacity-based recommendation; not yet verified | All four canonical pipelines |
-| NVIDIA GB200 or GB300 | Capacity-based recommendation; not yet verified | All four canonical pipelines |
+| NVIDIA B300 | Verified | All five canonical pipelines |
+| NVIDIA B200 or H200 | Capacity-based recommendation; not yet verified | All five canonical pipelines |
+| NVIDIA GB200 or GB300 | Capacity-based recommendation; not yet verified | All five canonical pipelines |
 | NVIDIA H100 80 GB | FP8 recipe | Distilled one-stage at 960x544 |
 
 The 1920x1088 two-stage examples require about 114 GB of peak GPU memory.
@@ -116,6 +123,11 @@ python examples/offline_inference/image_to_video/image_to_video.py \
 ```
 
 LTX-2.5 uses the official CRF-18 first-frame conditioning path by default.
+
+For HQ, set `PIPELINE=LTX2TwoStageHQPipeline`, `WIDTH=1920`, `HEIGHT=1088`,
+and `STEPS=15`. Stage 1 derives its terminal-stretched sigma schedule from the
+packed video token count and both stages use Res2s. Pass `stage_1_sigmas`
+and/or `stage_2_sigmas` through `--extra-body` to override either schedule.
 
 ## Online serving
 

--- a/recipes/LTX/LTX-2.md
+++ b/recipes/LTX/LTX-2.md
@@ -12,6 +12,7 @@
 | `LTX2DistilledTwoStagePipeline` | LTX-2 merged-distilled two-stage T2V/I2V | `rootonchair/LTX-2-19b-distilled` |
 | `LTX2Pipeline` | LTX-2.3 one-stage T2V/I2V | `diffusers/LTX-2.3-Diffusers` |
 | `LTX2TwoStagePipeline` | LTX-2.3 ordinary two-stage T2V/I2V | `diffusers/LTX-2.3-Diffusers`<br>`Lightricks/LTX-2.3` |
+| `LTX2TwoStageHQPipeline` | LTX-2.3 Res2s HQ two-stage T2V/I2V | `diffusers/LTX-2.3-Diffusers`<br>`Lightricks/LTX-2.3` |
 | `LTX2DistilledOneStagePipeline` | LTX-2.3 merged-distilled one-stage T2V/I2V | `diffusers/LTX-2.3-Distilled-Diffusers` |
 | `LTX2DistilledTwoStagePipeline` | LTX-2.3 merged-distilled two-stage T2V/I2V | `diffusers/LTX-2.3-Distilled-Diffusers`<br>`Lightricks/LTX-2.3` |
 
@@ -28,7 +29,10 @@ image selects I2V. Both one-stage repositories declare this class, so
 the raw `Lightricks/LTX-2.3` safetensors repository is not directly loadable.
 
 `LTX2TwoStagePipeline` samples the regular model at half resolution, upsamples,
-then refines with the distilled LoRA. `LTX2DistilledOneStagePipeline` uses a
+then refines with the distilled LoRA. `LTX2TwoStageHQPipeline` is the LTX-2.3
+and LTX-2.5 HQ entry: it uses the Res2s second-order sampler in both stages and
+applies the distilled LoRA at strengths 0.25 and 0.5 respectively.
+`LTX2DistilledOneStagePipeline` uses a
 merged distilled Transformer without upsampling, while
 `LTX2DistilledTwoStagePipeline` uses it in both stages. All entries support
 T2V and I2V; select their class explicitly. The deprecated
@@ -84,13 +88,14 @@ default to `121`.
 
 ## Two-Stage Defaults
 
-| Parameter | Ordinary | Full-distilled |
-|---|---:|---:|
-| Final width × height | 1536 × 1024 | 1536 × 1024 |
-| Stage 1 width × height | 768 × 512 | 768 × 512 |
-| Frames / frame rate | 121 / 24 | 121 / 24 |
-| Stage 1 / Stage 2 steps | 40 (LTX-2) or 30 (LTX-2.3) / 3 | 8 / 3 |
-| Guidance | Stage 1 guided; Stage 2 positive-only | Fixed positive-only |
+| Parameter | Ordinary | HQ (LTX-2.3) | Full-distilled |
+|---|---:|---:|---:|
+| Final width × height | 1536 × 1024 | 1920 × 1088 | 1536 × 1024 |
+| Stage 1 width × height | 768 × 512 | 960 × 544 | 768 × 512 |
+| Frames / frame rate | 121 / 24 | 121 / 24 | 121 / 24 |
+| Stage 1 / Stage 2 steps | 40 (LTX-2) or 30 (LTX-2.3) / 3 | 15 / 3 | 8 / 3 |
+| Sampler | Euler / Euler | Res2s / Res2s | Euler / Euler |
+| Guidance | Stage 1 guided; Stage 2 positive-only | Stage 1 guided without STG; Stage 2 positive-only | Fixed positive-only |
 
 API dimensions are final dimensions and must be divisible by 64. All LTX
 requests require `num_frames = 8k+1`. Ordinary Stage 1 uses the LTX-2 or
@@ -100,6 +105,10 @@ sigmas and input latents.
 
 Ordinary two-stage uses layer-fused LoRA for an unquantized BF16 Transformer
 and automatically switches to dynamic LoRA when quantization is enabled.
+HQ uses the same execution modes, with LoRA strength 0.25 in Stage 1 and 0.5
+in Stage 2. Its Stage-1 sigma schedule is derived from the actual packed video
+token count. `stage_1_sigmas` and `stage_2_sigmas` may override either HQ
+phase; an omitted phase retains the official schedule.
 
 ## Serving
 
@@ -124,6 +133,11 @@ vllm serve diffusers/LTX-2.3-Distilled-Diffusers --omni \
 # Ordinary LTX-2.3 two-stage
 vllm serve diffusers/LTX-2.3-Diffusers --omni \
   --model-class-name LTX2TwoStagePipeline \
+  --enable-layerwise-offload \
+  --stage-init-timeout 600
+# LTX-2.3 Res2s HQ two-stage
+vllm serve diffusers/LTX-2.3-Diffusers --omni \
+  --model-class-name LTX2TwoStageHQPipeline \
   --enable-layerwise-offload \
   --stage-init-timeout 600
 ```
@@ -208,6 +222,10 @@ per denoise step: `cond`, `uncond`, `ptb` (STG), and `mod`
 | `1` | 4 | 100% | Single-rank fused guidance batch |
 | `2` | 2 | 100% | Recommended two-rank configuration |
 | `4` | 1 | 100% | One guidance pass per rank |
+
+HQ Stage 1 disables STG and therefore executes three passes: `cond`, `uncond`,
+and `mod`. CFG parallel sizes 1 or 3 are balanced for that path. HQ Stage 2 is
+positive-only.
 
 Other positive sizes are accepted. When the pass count is not divisible by
 `cfg_parallel_size`, ranks are padded to an equal number of execution slots

--- a/tests/diffusion/models/ltx2/test_ltx2_hq_recipe.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_hq_recipe.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Declarative contract tests for the LTX-2.3/2.5 two-stage HQ entry."""
+
+import pytest
+
+from vllm_omni.diffusion.models.ltx2.ltx2_components import (
+    LTX23_TWO_STAGE_COMPONENT_PROFILE,
+    LTX25_TWO_STAGE_COMPONENT_PROFILE,
+    resolve_ltx_component_profile,
+)
+from vllm_omni.diffusion.models.ltx2.ltx2_guidance import LTXGuidancePlan, LTXGuidanceSpec
+from vllm_omni.diffusion.models.ltx2.ltx2_recipes import (
+    LTX23_TWO_STAGE_HQ_RECIPE,
+    LTX23_TWO_STAGE_RECIPE,
+    LTX25_DEFAULT_NEGATIVE_PROMPT,
+    LTX25_TWO_STAGE_HQ_RECIPE,
+    LTX_STAGE_2_DISTILLED_SIGMAS,
+    LTXPhaseRecipe,
+    resolve_ltx_pipeline_recipe,
+)
+from vllm_omni.diffusion.models.ltx2.pipeline_ltx2_two_stage import LTX2TwoStageHQPipeline
+from vllm_omni.model_extras import get_extra_body_params, get_extra_output_params
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+@pytest.mark.parametrize("recipe", [LTX23_TWO_STAGE_HQ_RECIPE, LTX25_TWO_STAGE_HQ_RECIPE])
+def test_ltx_hq_recipe_matches_official_phase_contract(recipe):
+    stage1, stage2 = recipe.phases
+
+    assert (recipe.width, recipe.height) == (1920, 1088)
+    assert recipe.num_frames == 121
+    assert recipe.frame_rate == 24.0
+    assert recipe.num_inference_steps == 15
+    assert (recipe.video_output_phase, recipe.audio_output_phase) == (1, 0)
+    assert not recipe.allow_request_sigmas
+    assert recipe.allow_request_phase_sigmas
+    assert not recipe.allow_request_latents
+
+    assert stage1.name == "generate_lowres"
+    assert stage1.spatial_downscale == 2
+    assert stage1.noise_scale == 1.0
+    assert stage1.sampler == "res2s"
+    assert stage1.sigmas is None
+    assert not stage1.use_official_sigma_schedule
+    assert stage1.use_latent_dependent_sigma_schedule
+    assert (stage1.adapter_slot, stage1.adapter_strength) == ("ltx_distilled", 0.25)
+    assert LTXGuidancePlan.build(stage1.guidance).names == ("cond", "uncond", "mod")
+    assert (
+        stage1.guidance.video.cfg_scale,
+        stage1.guidance.video.stg_scale,
+        stage1.guidance.video.modality_scale,
+        stage1.guidance.video.rescale_scale,
+    ) == (3.0, 0.0, 3.0, 0.45)
+    assert (
+        stage1.guidance.audio.cfg_scale,
+        stage1.guidance.audio.stg_scale,
+        stage1.guidance.audio.modality_scale,
+        stage1.guidance.audio.rescale_scale,
+    ) == (7.0, 0.0, 3.0, 1.0)
+
+    assert stage2.name == "refine"
+    assert stage2.input_transform == "spatial_upsample"
+    assert stage2.sampler == "res2s"
+    assert stage2.guidance == LTXGuidanceSpec.positive_only()
+    assert not stage2.allow_guidance_override
+    assert stage2.sigmas == LTX_STAGE_2_DISTILLED_SIGMAS
+    assert stage2.num_inference_steps == 3
+    assert (stage2.adapter_slot, stage2.adapter_strength) == ("ltx_distilled", 0.5)
+
+
+def test_ltx25_hq_keeps_generation_specific_negative_prompt():
+    assert LTX25_TWO_STAGE_HQ_RECIPE.negative_prompt == LTX25_DEFAULT_NEGATIVE_PROMPT
+    assert LTX23_TWO_STAGE_HQ_RECIPE.negative_prompt != LTX25_DEFAULT_NEGATIVE_PROMPT
+
+
+def test_ltx_hq_entry_supports_ltx23_and_ltx25():
+    assert resolve_ltx_component_profile("two_stage_hq", "2.3") is LTX23_TWO_STAGE_COMPONENT_PROFILE
+    assert resolve_ltx_component_profile("two_stage_hq", "2.5") is LTX25_TWO_STAGE_COMPONENT_PROFILE
+    assert resolve_ltx_pipeline_recipe("two_stage_hq", "2.3") is LTX23_TWO_STAGE_HQ_RECIPE
+    assert resolve_ltx_pipeline_recipe("two_stage_hq", "2.5") is LTX25_TWO_STAGE_HQ_RECIPE
+    with pytest.raises(ValueError, match="Unsupported LTX component kind/version"):
+        resolve_ltx_component_profile("two_stage_hq", "2")
+    with pytest.raises(ValueError, match="Unsupported LTX pipeline kind/version"):
+        resolve_ltx_pipeline_recipe("two_stage_hq", "2")
+
+    assert LTX2TwoStageHQPipeline.pipeline_kind == "two_stage_hq"
+    assert LTX2TwoStageHQPipeline.support_image_input
+    assert LTX2TwoStageHQPipeline.unified_text_image_entry
+    assert not LTX2TwoStageHQPipeline.supports_request_batch
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error"),
+    [
+        ({"adapter_slot": "ltx_distilled"}, "slot and strength"),
+        ({"adapter_strength": 0.25}, "slot and strength"),
+        ({"adapter_slot": "ltx_distilled", "adapter_strength": float("nan")}, "finite"),
+        ({"adapter_slot": "ltx_distilled", "adapter_strength": float("inf")}, "finite"),
+        ({"sampler": "unknown"}, "sampler"),
+        (
+            {"use_official_sigma_schedule": True, "use_latent_dependent_sigma_schedule": True},
+            "both official and latent-dependent",
+        ),
+        (
+            {
+                "sigmas": (1.0, 0.0),
+                "use_official_sigma_schedule": False,
+                "use_latent_dependent_sigma_schedule": True,
+            },
+            "explicit sigmas",
+        ),
+    ],
+)
+def test_ltx_phase_recipe_validates_sampler_schedule_and_adapter(kwargs, error):
+    with pytest.raises(ValueError, match=error):
+        LTXPhaseRecipe(name="invalid", guidance=LTXGuidanceSpec.positive_only(), **kwargs)
+
+
+def test_existing_two_stage_recipe_keeps_euler_and_unit_strength():
+    stage1, stage2 = LTX23_TWO_STAGE_RECIPE.phases
+
+    assert stage1.sampler == stage2.sampler == "euler"
+    assert not stage1.use_latent_dependent_sigma_schedule
+    assert not stage2.use_latent_dependent_sigma_schedule
+    assert (stage1.adapter_slot, stage1.adapter_strength) == (None, None)
+    assert (stage2.adapter_slot, stage2.adapter_strength) == ("ltx_distilled", 1.0)
+
+
+def test_ltx_hq_registry_and_request_extras():
+    from vllm_omni.diffusion.registry import _DIFFUSION_MODELS, _DIFFUSION_POST_PROCESS_FUNCS
+
+    assert _DIFFUSION_MODELS["LTX2TwoStageHQPipeline"] == (
+        "ltx2",
+        "pipeline_ltx2_two_stage",
+        "LTX2TwoStageHQPipeline",
+    )
+    assert _DIFFUSION_POST_PROCESS_FUNCS["LTX2TwoStageHQPipeline"] == "get_ltx2_post_process_func"
+    assert get_extra_body_params("LTX2TwoStageHQPipeline") == get_extra_body_params("LTX2TwoStagePipeline")
+    assert get_extra_output_params("LTX2TwoStageHQPipeline") == frozenset()

--- a/tests/diffusion/models/ltx2/test_ltx2_hq_recipe.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_hq_recipe.py
@@ -8,6 +8,7 @@ import pytest
 from vllm_omni.diffusion.models.ltx2.ltx2_components import (
     LTX23_TWO_STAGE_COMPONENT_PROFILE,
     LTX25_TWO_STAGE_COMPONENT_PROFILE,
+    resolve_ltx_checkpoint_kind,
     resolve_ltx_component_profile,
 )
 from vllm_omni.diffusion.models.ltx2.ltx2_guidance import LTXGuidancePlan, LTXGuidanceSpec
@@ -77,6 +78,7 @@ def test_ltx25_hq_keeps_generation_specific_negative_prompt():
 
 
 def test_ltx_hq_entry_supports_ltx23_and_ltx25():
+    assert resolve_ltx_checkpoint_kind("two_stage_hq") == "regular"
     assert resolve_ltx_component_profile("two_stage_hq", "2.3") is LTX23_TWO_STAGE_COMPONENT_PROFILE
     assert resolve_ltx_component_profile("two_stage_hq", "2.5") is LTX25_TWO_STAGE_COMPONENT_PROFILE
     assert resolve_ltx_pipeline_recipe("two_stage_hq", "2.3") is LTX23_TWO_STAGE_HQ_RECIPE

--- a/tests/diffusion/models/ltx2/test_ltx2_hq_runtime.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_hq_runtime.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Runtime integration tests for the LTX-2.3/2.5 HQ sampler path."""
+
+import math
+from contextlib import contextmanager, nullcontext
+from types import SimpleNamespace
+
+import pytest
+import torch
+from diffusers import FlowMatchEulerDiscreteScheduler
+
+from vllm_omni.diffusion.models.ltx2.ltx2_denoise import prepare_scheduler_stage, run_res2s_phase
+from vllm_omni.diffusion.models.ltx2.ltx2_guidance import LTXGuidanceExecutor, LTXGuidancePlan, LTXGuidanceSpec
+from vllm_omni.diffusion.models.ltx2.ltx2_latents import LTXAVState
+from vllm_omni.diffusion.models.ltx2.ltx2_res2s import build_ltx2_res2s_sigmas
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_guidance_prediction_uses_explicit_sigma_instead_of_scheduler_index():
+    video_state = torch.tensor([[[1.0, 2.0]]])
+    audio_state = torch.tensor([[[3.0, 4.0]]])
+    video_velocity = torch.tensor([[[2.0, -1.0]]])
+    audio_velocity = torch.tensor([[[1.5, -0.5]]])
+    context = torch.zeros(1, 1, 1)
+    prompt = SimpleNamespace(
+        positive_connector_prompt_embeds=context,
+        positive_connector_audio_prompt_embeds=context,
+        negative_connector_prompt_embeds=None,
+        negative_connector_audio_prompt_embeds=None,
+    )
+
+    pipeline = SimpleNamespace(
+        scheduler=SimpleNamespace(sigmas=torch.tensor([0.95])),
+        _build_transformer_kwargs=lambda *_args, **_kwargs: {},
+        _transformer_cache_context=lambda *_args, **_kwargs: nullcontext(),
+        transformer=lambda **_kwargs: (video_velocity, audio_velocity),
+        _video_guidance_model_sigma=lambda sigma, _ctx: sigma,
+    )
+    forward_ctx = SimpleNamespace(
+        guidance_parallel_ready=False,
+        prompt_context=prompt,
+        attention_kwargs=None,
+        original_audio_num_frames=1,
+    )
+    denoise_ctx = SimpleNamespace()
+    state = LTXAVState(video=video_state, audio=audio_state)
+
+    video_x0, audio_x0 = LTXGuidanceExecutor().predict_denoised(
+        pipeline,
+        LTXGuidancePlan.build(LTXGuidanceSpec.positive_only()),
+        0,
+        torch.tensor(500.0),
+        state,
+        forward_ctx,
+        denoise_ctx,
+        video_sigma=torch.tensor(0.2),
+        audio_sigma=torch.tensor(0.3),
+    )
+
+    torch.testing.assert_close(video_x0, video_state - video_velocity * 0.2)
+    torch.testing.assert_close(audio_x0, audio_state - audio_velocity * 0.3)
+
+
+def test_latent_dependent_scheduler_stage_uses_actual_packed_token_count():
+    scheduler = FlowMatchEulerDiscreteScheduler(
+        use_dynamic_shifting=True,
+        base_shift=0.95,
+        max_shift=2.05,
+        shift_terminal=0.1,
+        base_image_seq_len=1024,
+        max_image_seq_len=4096,
+    )
+    pipeline = SimpleNamespace(scheduler=scheduler, device=torch.device("cpu"))
+    token_count = 16 * 17 * 30
+
+    _, _, timesteps = prepare_scheduler_stage(
+        pipeline,
+        SimpleNamespace(num_inference_steps=15, generator=None),
+        device=torch.device("cpu"),
+        sigmas=None,
+        timesteps=None,
+        latent_num_frames=16,
+        latent_height=17,
+        latent_width=30,
+        video_token_count=token_count,
+        use_official_sigma_schedule=False,
+        use_latent_dependent_sigma_schedule=True,
+        sampler="res2s",
+    )
+
+    expected = build_ltx2_res2s_sigmas(15, token_count)
+    torch.testing.assert_close(pipeline.scheduler.sigmas, expected, rtol=0, atol=0)
+    torch.testing.assert_close(timesteps, expected[:-1] * 1000, rtol=0, atol=0)
+
+
+def test_res2s_phase_threads_midpoint_sigma_and_restores_i2v_tokens():
+    model_calls: list[tuple[float, float, float]] = []
+    model_inputs: list[torch.Tensor] = []
+    model_audio_inputs: list[torch.Tensor] = []
+    progress_updates = 0
+
+    def predict_denoised(
+        _index,
+        timestep,
+        state,
+        _forward_ctx,
+        _denoise_ctx,
+        *,
+        video_sigma,
+        audio_sigma,
+    ):
+        model_calls.append((float(timestep), float(video_sigma), float(audio_sigma)))
+        model_inputs.append(state.video.clone())
+        model_audio_inputs.append(state.audio.clone())
+        return torch.zeros_like(state.video), torch.ones_like(state.audio)
+
+    @contextmanager
+    def progress_bar(*, total):
+        assert total == 2
+
+        class Progress:
+            def update(self):
+                nonlocal progress_updates
+                progress_updates += 1
+
+        yield Progress()
+
+    pipeline = SimpleNamespace(
+        scheduler=SimpleNamespace(
+            sigmas=torch.tensor([0.8, 0.4, 0.0]),
+            config={"num_train_timesteps": 1000},
+        ),
+        _predict_denoised_for_step=predict_denoised,
+        progress_bar=progress_bar,
+    )
+    clean_video = torch.tensor([[[7.0, 0.0], [0.0, 0.0]]], dtype=torch.float64)
+    conditioning_mask = torch.tensor([[1.0, 0.0]], dtype=torch.float64)
+    state = LTXAVState(
+        video=clean_video.clone(),
+        audio=torch.zeros(1, 2, 2, dtype=torch.float64),
+    )
+    forward_ctx = SimpleNamespace(original_audio_num_frames=1)
+    denoise_ctx = SimpleNamespace(
+        latents=state.video,
+        audio_latents=state.audio,
+        clean_video_latents=clean_video,
+        conditioning_mask=conditioning_mask,
+    )
+
+    result = run_res2s_phase(pipeline, state, forward_ctx, denoise_ctx)
+
+    expected_sigmas = [0.8, math.sqrt(0.8 * 0.4), 0.4, math.sqrt(0.4 * 0.0011), 0.0011]
+    assert [call[1] for call in model_calls] == pytest.approx(expected_sigmas)
+    assert [call[2] for call in model_calls] == pytest.approx(expected_sigmas)
+    assert [call[0] for call in model_calls] == pytest.approx([sigma * 1000 for sigma in expected_sigmas])
+    assert progress_updates == 2
+    for model_input in model_inputs:
+        assert model_input[0, 0, 0] == 7.0
+    for model_audio_input in model_audio_inputs:
+        torch.testing.assert_close(model_audio_input[:, 1:], torch.zeros_like(model_audio_input[:, 1:]))
+    assert result.video[0, 0, 0] == 7.0
+    torch.testing.assert_close(result.audio[:, 1:], torch.zeros_like(result.audio[:, 1:]))

--- a/tests/diffusion/models/ltx2/test_ltx2_phase_adapter.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_phase_adapter.py
@@ -220,6 +220,14 @@ def test_ltx_phase_adapter_keeps_one_transformer_and_switches_a_fixed_slot(tmp_p
     torch.testing.assert_close(transformer.proj(x), torch.tensor([[1.0, 1.0]]))
     runtime.activate(LTX_DISTILLED_ADAPTER_SLOT)
     torch.testing.assert_close(transformer.proj(x), torch.tensor([[10.0, 13.0]]))
+    runtime.activate(LTX_DISTILLED_ADAPTER_SLOT, strength=0.25)
+    torch.testing.assert_close(transformer.proj(x), torch.tensor([[3.25, 4.0]]))
+    runtime.activate(LTX_DISTILLED_ADAPTER_SLOT, strength=0.5)
+    torch.testing.assert_close(transformer.proj(x), torch.tensor([[5.5, 7.0]]))
+    with pytest.raises(ValueError, match="finite"):
+        runtime.activate(LTX_DISTILLED_ADAPTER_SLOT, strength=float("nan"))
+    with pytest.raises(ValueError, match="requires an adapter slot"):
+        runtime.activate(None, strength=0.25)
 
 
 def test_ltx_layer_fused_adapter_matches_official_bf16_weight_fusion():
@@ -253,6 +261,13 @@ def test_ltx_layer_fused_adapter_matches_official_bf16_weight_fusion():
     x = torch.tensor([[0.6015625, -0.703125, 0.8046875, -0.90625]], dtype=torch.bfloat16)
     expected = torch.nn.functional.linear(x, expected_weight, layer.bias)
 
+    assert torch.equal(wrapper(x), expected)
+    assert torch.equal(layer.weight, base_weight)
+
+    wrapper.set_enabled(True, strength=0.25)
+    expected_weight = torch.matmul(lora_b * 0.25, lora_a)
+    expected_weight.add_(base_weight)
+    expected = torch.nn.functional.linear(x, expected_weight, layer.bias)
     assert torch.equal(wrapper(x), expected)
     assert torch.equal(layer.weight, base_weight)
 

--- a/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_pipeline.py
@@ -961,7 +961,9 @@ def test_ltx_two_stage_executes_declarative_i2v_phase_plan(pipeline_cls):
     pipeline.latent_upsampler = FakeUpsampler()
     activated_slots = []
     if pipeline_cls is LTX2TwoStagePipeline:
-        pipeline._phase_adapter = SimpleNamespace(activate=activated_slots.append)
+        pipeline._phase_adapter = SimpleNamespace(
+            activate=lambda slot, *, strength=None: activated_slots.append((slot, strength))
+        )
     object.__setattr__(pipeline, "_resolve_request_inputs", resolve_request_inputs)
     object.__setattr__(pipeline, "run_phase", run_phase)
     object.__setattr__(pipeline, "decode_phase", decode_phase)
@@ -972,7 +974,7 @@ def test_ltx_two_stage_executes_declarative_i2v_phase_plan(pipeline_cls):
     assert len(phase_calls) == 2
     assert phase_calls[1][2] is prompt_context_sentinel
     if pipeline_cls is LTX2TwoStagePipeline:
-        assert activated_slots == [None, "ltx_distilled"]
+        assert activated_slots == [(None, None), ("ltx_distilled", 1.0)]
     torch.testing.assert_close(output.output[0], torch.full((1, 128, 1, 2, 2), 3.0))
     expected_audio = 2.0 if pipeline_cls is LTX2TwoStagePipeline else 4.0
     torch.testing.assert_close(output.output[1], torch.full((1, 8, 1, 2), expected_audio))
@@ -1286,10 +1288,12 @@ def test_ltx_official_two_stage_recipes_only_vary_by_model_defaults(recipe, step
 def test_ltx_two_stage_entries_select_the_official_adapter_slots():
     phase_switches = []
     ordinary_pipeline = object.__new__(LTX2TwoStagePipeline)
-    ordinary_pipeline._phase_adapter = SimpleNamespace(activate=phase_switches.append)
+    ordinary_pipeline._phase_adapter = SimpleNamespace(
+        activate=lambda slot, *, strength=None: phase_switches.append((slot, strength))
+    )
     for phase in LTX2_TWO_STAGE_RECIPE.phases:
         ordinary_pipeline._enter_phase(phase)
-    assert phase_switches == [None, "ltx_distilled"]
+    assert phase_switches == [(None, None), ("ltx_distilled", 1.0)]
 
     distilled_pipeline = object.__new__(LTX2DistilledPipeline)
     for phase in LTX2_DISTILLED_TWO_STAGE_RECIPE.phases:

--- a/tests/diffusion/models/ltx2/test_ltx2_res2s.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_res2s.py
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Golden tests for the official LTX-2 res_2s sampler."""
+
+import math
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.models.ltx2.ltx2_latents import LTXAVState
+from vllm_omni.diffusion.models.ltx2.ltx2_res2s import (
+    LTX_RES2S_STEP_NOISE_SEED,
+    LTX_RES2S_SUBSTEP_NOISE_SEED,
+    LTX_RES2S_TERMINAL_SIGMA,
+    LTXRes2sExecutor,
+    build_ltx2_res2s_sigmas,
+    get_res2s_coefficients,
+    normalized_res2s_audio_noise,
+    refine_res2s_anchor,
+    res2s_sde_step,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_default_hq_schedule_matches_official_token_dependent_golden():
+    sigmas = build_ltx2_res2s_sigmas(15, 16 * 17 * 30)
+    expected = torch.tensor(
+        [
+            1.0,
+            0.9934906959533691,
+            0.9860149025917053,
+            0.9773396253585815,
+            0.9671507477760315,
+            0.9550145864486694,
+            0.9403136372566223,
+            0.9221396446228027,
+            0.8990960121154785,
+            0.8689230680465698,
+            0.8277072310447693,
+            0.7680275440216064,
+            0.6738965511322021,
+            0.5033778548240662,
+            0.10000002384185791,
+            0.0,
+        ],
+        dtype=torch.float32,
+    )
+    torch.testing.assert_close(sigmas, expected, rtol=0, atol=0)
+
+
+def test_token_dependent_schedule_rejects_single_step_terminal_stretch():
+    with pytest.raises(ValueError, match="at least 2"):
+        build_ltx2_res2s_sigmas(1, 16 * 17 * 30)
+
+
+def test_token_dependent_schedule_rejects_zero_stretch_terminal():
+    with pytest.raises(ValueError, match="strictly between 0 and 1"):
+        build_ltx2_res2s_sigmas(2, 16 * 17 * 30, terminal=0.0)
+
+
+def test_res2s_coefficients_match_log_two_golden():
+    actual = get_res2s_coefficients(math.log(2))
+    expected = (0.4225555942921739, -0.08267358032783734, 0.804021100772319)
+    assert actual == pytest.approx(expected, rel=1e-14, abs=1e-14)
+
+
+def test_legacy_sde_step_matches_official_golden():
+    result = res2s_sde_step(
+        torch.tensor([1.0, 2.0], dtype=torch.float64),
+        torch.tensor([0.25, -0.5], dtype=torch.float64),
+        0.8,
+        0.4,
+        torch.tensor([0.1, -0.2], dtype=torch.float64),
+    )
+    expected = torch.tensor([0.1963139720814414, -0.7141669750802295], dtype=torch.float64)
+    torch.testing.assert_close(result, expected, rtol=1e-14, atol=1e-14)
+
+
+def test_bongmath_runs_the_exact_fixed_recurrence():
+    midpoint = torch.tensor([0.3, -0.7], dtype=torch.float64)
+    denoised = torch.tensor([0.2, 0.4], dtype=torch.float64)
+    epsilon = torch.tensor([-0.5, 0.25], dtype=torch.float64)
+    h = 0.2
+    a21 = 0.47
+
+    expected_anchor = midpoint
+    expected_epsilon = epsilon
+    for _ in range(100):
+        expected_anchor = midpoint - h * a21 * expected_epsilon
+        expected_epsilon = denoised - expected_anchor
+
+    anchor, refined_epsilon = refine_res2s_anchor(midpoint, denoised, epsilon, h, a21)
+    torch.testing.assert_close(anchor, expected_anchor, rtol=0, atol=0)
+    torch.testing.assert_close(refined_epsilon, expected_epsilon, rtol=0, atol=0)
+
+
+def test_executor_matches_full_interval_golden_and_passes_explicit_sigma():
+    calls = []
+
+    def predict_x0(state, sigma):
+        calls.append((float(sigma), sigma.dtype))
+        return LTXAVState(video=0.25 * state.video + 0.1 * sigma, audio=0.25 * state.audio + 0.1 * sigma)
+
+    sub_noise = torch.tensor([[[0.2, -0.1]]], dtype=torch.float64)
+    main_noise = torch.tensor([[[-0.3, 0.4]]], dtype=torch.float64)
+
+    def fixed_noise(reference, generator):
+        noise = sub_noise if generator.initial_seed() == LTX_RES2S_SUBSTEP_NOISE_SEED else main_noise
+        return noise.expand_as(reference)
+
+    initial = torch.tensor([[[1.0, -2.0]]], dtype=torch.float64)
+    result = LTXRes2sExecutor.run(
+        LTXAVState(video=initial, audio=initial.clone()),
+        torch.tensor([0.8, 0.4]),
+        predict_x0,
+        bongmath=False,
+        model_dtype=torch.float64,
+        noise_fn=fixed_noise,
+    )
+
+    # Current/midpoint integration is fp64, but the official full-step SDE
+    # deliberately retains the original fp32 schedule boundaries.
+    expected = torch.tensor([[[0.49638621085862233, -0.9269363256806813]]], dtype=torch.float64)
+    torch.testing.assert_close(result.video, expected, rtol=1e-13, atol=1e-13)
+    torch.testing.assert_close(result.audio, expected, rtol=1e-13, atol=1e-13)
+    assert calls[0][0] == pytest.approx(0.8)
+    assert calls[0][1] is torch.float32
+    assert calls[1][0] == pytest.approx(math.sqrt(0.8 * 0.4))
+    assert calls[1][1] is torch.float64
+
+
+def test_executor_terminal_prediction_and_i2v_restore_cover_every_intermediate_state():
+    clean = torch.tensor([[[7.0, 0.0]]], dtype=torch.float64)
+    mask = torch.tensor([[[0.0, 1.0]]], dtype=torch.float64)
+    model_sigmas = []
+    model_inputs = []
+    restore_calls = 0
+
+    def restore(video):
+        nonlocal restore_calls
+        restore_calls += 1
+        return video * mask + clean * (1 - mask)
+
+    def predict_x0(state, sigma):
+        model_sigmas.append(float(sigma))
+        model_inputs.append(state.video.clone())
+        return LTXAVState(video=torch.zeros_like(state.video), audio=torch.zeros_like(state.audio))
+
+    def zero_noise(reference, generator):
+        del generator
+        return torch.zeros_like(reference, dtype=torch.float64)
+
+    result = LTXRes2sExecutor.run(
+        LTXAVState(video=clean.clone(), audio=torch.zeros_like(clean)),
+        torch.tensor([0.8, 0.4, 0.0]),
+        predict_x0,
+        bongmath=False,
+        model_dtype=torch.float64,
+        noise_fn=zero_noise,
+        restore_video=restore,
+    )
+
+    assert model_sigmas == pytest.approx([0.8, math.sqrt(0.8 * 0.4), 0.4, math.sqrt(0.4 * 0.0011), 0.0011])
+    assert 0.0 not in model_sigmas
+    assert restore_calls == 9
+    for model_input in model_inputs:
+        assert model_input[0, 0, 0] == 7.0
+    assert result.video[0, 0, 0] == 7.0
+
+
+@pytest.mark.parametrize("penultimate_sigma", [LTX_RES2S_TERMINAL_SIGMA, 0.001])
+def test_executor_rejects_zero_terminal_after_too_small_sigma(penultimate_sigma):
+    state = LTXAVState(
+        video=torch.zeros(1, 1, 2),
+        audio=torch.zeros(1, 1, 2),
+    )
+
+    with pytest.raises(ValueError, match="preceding sigma must be greater than"):
+        LTXRes2sExecutor.run(
+            state,
+            torch.tensor([0.8, penultimate_sigma, 0.0]),
+            lambda current, sigma: current,
+        )
+
+
+def test_executor_uses_fresh_fixed_rngs_and_video_then_audio_order_per_phase():
+    records = []
+
+    def recording_noise(reference, generator):
+        records.append((generator.initial_seed(), float(reference.flatten()[0])))
+        return torch.zeros_like(reference, dtype=torch.float64)
+
+    def predict_x0(state, sigma):
+        del sigma
+        return state
+
+    state = LTXAVState(
+        video=torch.tensor([[[1.0, 0.0]]], dtype=torch.float64),
+        audio=torch.tensor([[[2.0, 0.0]]], dtype=torch.float64),
+    )
+    for _ in range(2):
+        LTXRes2sExecutor.run(
+            state,
+            torch.tensor([0.8, 0.4]),
+            predict_x0,
+            bongmath=False,
+            model_dtype=torch.float64,
+            noise_fn=recording_noise,
+        )
+
+    main_seed = torch.Generator().manual_seed(LTX_RES2S_STEP_NOISE_SEED).initial_seed()
+    one_phase = [
+        (LTX_RES2S_SUBSTEP_NOISE_SEED, 1.0),
+        (LTX_RES2S_SUBSTEP_NOISE_SEED, 2.0),
+        (main_seed, 1.0),
+        (main_seed, 2.0),
+    ]
+    assert records == one_phase + one_phase
+
+
+def test_audio_noise_excludes_sequence_parallel_padding_from_normalization():
+    logical = torch.zeros(1, 3, 4)
+    padded = torch.zeros(1, 4, 4)
+    logical_generator = torch.Generator().manual_seed(123)
+    padded_generator = torch.Generator().manual_seed(123)
+
+    expected = normalized_res2s_audio_noise(logical, logical_generator, logical_token_count=3)
+    actual = normalized_res2s_audio_noise(padded, padded_generator, logical_token_count=3)
+
+    torch.testing.assert_close(actual[:, :3], expected, rtol=0, atol=0)
+    torch.testing.assert_close(actual[:, 3:], torch.zeros_like(actual[:, 3:]), rtol=0, atol=0)

--- a/tests/diffusion/models/ltx2/test_ltx2_vae.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_vae.py
@@ -3,12 +3,69 @@
 
 """Unit tests for LTX-2.3 VAE tiling and distributed decode behavior."""
 
+from contextlib import contextmanager
 from types import SimpleNamespace
 
 import pytest
 import torch
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_ltx_bwe_vocoder_uses_fp32_autocast(monkeypatch):
+    import vllm_omni.diffusion.models.ltx2.ltx2_runtime as ltx_runtime
+
+    class FakeBWEVocoder(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.ones((), dtype=torch.bfloat16))
+            self.bwe_generator = torch.nn.Identity()
+            self.input_dtype = None
+
+        def forward(self, value):
+            self.input_dtype = value.dtype
+            return value.float()
+
+    autocast_calls = []
+
+    @contextmanager
+    def fake_autocast(*, device_type, dtype):
+        autocast_calls.append((device_type, dtype))
+        yield
+
+    monkeypatch.setattr(ltx_runtime.torch, "autocast", fake_autocast)
+    vocoder = FakeBWEVocoder()
+
+    output = ltx_runtime._run_ltx_vocoder(vocoder, torch.ones(1, dtype=torch.bfloat16))
+
+    assert vocoder.input_dtype == torch.float32
+    assert output.dtype == torch.bfloat16
+    assert autocast_calls == [("cpu", torch.float32)]
+
+
+def test_ltx_base_vocoder_keeps_native_dtype(monkeypatch):
+    import vllm_omni.diffusion.models.ltx2.ltx2_runtime as ltx_runtime
+
+    class FakeBaseVocoder(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.input_dtype = None
+
+        def forward(self, value):
+            self.input_dtype = value.dtype
+            return value
+
+    monkeypatch.setattr(
+        ltx_runtime.torch,
+        "autocast",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("base vocoder must not use autocast")),
+    )
+    vocoder = FakeBaseVocoder()
+
+    output = ltx_runtime._run_ltx_vocoder(vocoder, torch.ones(1, dtype=torch.bfloat16))
+
+    assert vocoder.input_dtype == torch.bfloat16
+    assert output.dtype == torch.bfloat16
 
 
 class TestLTXOutputRank:

--- a/tests/e2e/accuracy/ltx/run_ltx25_reference.py
+++ b/tests/e2e/accuracy/ltx/run_ltx25_reference.py
@@ -36,7 +36,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--connector-model", type=Path)
     parser.add_argument(
         "--official-pipeline",
-        choices=("distilled_two_stage", "full_one_stage", "full_two_stage", "full_two_stage_hq"),
+        choices=("distilled_two_stage", "full_one_stage", "full_two_stage"),
         default="distilled_two_stage",
     )
     parser.add_argument("--enable-layerwise-offload", action="store_true")
@@ -217,9 +217,9 @@ def _run_official(args: argparse.Namespace, request: dict[str, Any]) -> None:
             "--video-vae-path": args.video_vae_path,
             "--audio-vae-path": args.audio_vae_path,
         }
-        if args.official_pipeline in {"distilled_two_stage", "full_two_stage", "full_two_stage_hq"}:
+        if args.official_pipeline in {"distilled_two_stage", "full_two_stage"}:
             required["--spatial-upsampler-path"] = args.spatial_upsampler_path
-        if args.official_pipeline in {"full_two_stage", "full_two_stage_hq"}:
+        if args.official_pipeline == "full_two_stage":
             required["--distilled-lora-path"] = args.distilled_lora_path
         missing = [name for name, value in required.items() if value is None]
         if missing:
@@ -253,44 +253,27 @@ def _run_official(args: argparse.Namespace, request: dict[str, Any]) -> None:
                 images=images,
             )
             pipeline_name = "DistilledPipeline"
-        elif args.official_pipeline in {"full_two_stage", "full_two_stage_hq"}:
+        elif args.official_pipeline == "full_two_stage":
             from ltx_core.components.guiders import MultiModalGuiderParams
             from ltx_core.loader import LTXV_LORA_COMFY_RENAMING_MAP, LoraPathStrengthAndSDOps
             from ltx_pipelines.ti2vid_two_stages import TI2VidTwoStagesPipeline
-            from ltx_pipelines.ti2vid_two_stages_hq import TI2VidTwoStagesHQPipeline
 
-            two_stage_kwargs = {
-                "model_paths": model_paths,
-                "distilled_lora": [
+            pipeline = TI2VidTwoStagesPipeline(
+                model_paths=model_paths,
+                distilled_lora=[
                     LoraPathStrengthAndSDOps(
                         path=str(args.distilled_lora_path),
                         strength=1.0,
                         sd_ops=LTXV_LORA_COMFY_RENAMING_MAP,
                     )
                 ],
-                "spatial_upsampler_path": str(args.spatial_upsampler_path),
-                "loras": [],
-                "offload_mode": offload_mode,
-            }
-            if args.official_pipeline == "full_two_stage_hq":
-                pipeline = TI2VidTwoStagesHQPipeline(
-                    **two_stage_kwargs,
-                    distilled_lora_strength_stage_1=0.25,
-                    distilled_lora_strength_stage_2=0.5,
-                )
-            else:
-                pipeline = TI2VidTwoStagesPipeline(**two_stage_kwargs)
+                spatial_upsampler_path=str(args.spatial_upsampler_path),
+                loras=[],
+                offload_mode=offload_mode,
+            )
             if args.connector_model is not None:
                 _use_diffusers_connector_weights(pipeline.prompt_encoder, args.connector_model)
             _configure_official_sdpa(pipeline)
-            schedule_kwargs = (
-                {}
-                if args.official_pipeline == "full_two_stage_hq"
-                else {
-                    "stage_1_sigmas": torch.tensor(request["stage_1_sigmas"], dtype=torch.float32),
-                    "stage_2_sigmas": torch.tensor(request["stage_2_sigmas"], dtype=torch.float32),
-                }
-            )
             video, audio, _, _ = pipeline(
                 prompt=request["prompt"],
                 negative_prompt=request["negative_prompt"],
@@ -318,13 +301,10 @@ def _run_official(args: argparse.Namespace, request: dict[str, Any]) -> None:
                 ),
                 images=images,
                 max_batch_size=4,
-                **schedule_kwargs,
+                stage_1_sigmas=torch.tensor(request["stage_1_sigmas"], dtype=torch.float32),
+                stage_2_sigmas=torch.tensor(request["stage_2_sigmas"], dtype=torch.float32),
             )
-            pipeline_name = (
-                "TI2VidTwoStagesHQPipeline"
-                if args.official_pipeline == "full_two_stage_hq"
-                else "TI2VidTwoStagesPipeline"
-            )
+            pipeline_name = "TI2VidTwoStagesPipeline"
         else:
             from ltx_core.components.guiders import MultiModalGuiderParams
             from ltx_pipelines.ti2vid_one_stage import TI2VidOneStagePipeline

--- a/tests/e2e/accuracy/ltx/run_ltx25_reference.py
+++ b/tests/e2e/accuracy/ltx/run_ltx25_reference.py
@@ -36,7 +36,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--connector-model", type=Path)
     parser.add_argument(
         "--official-pipeline",
-        choices=("distilled_two_stage", "full_one_stage", "full_two_stage"),
+        choices=("distilled_two_stage", "full_one_stage", "full_two_stage", "full_two_stage_hq"),
         default="distilled_two_stage",
     )
     parser.add_argument("--enable-layerwise-offload", action="store_true")
@@ -217,9 +217,9 @@ def _run_official(args: argparse.Namespace, request: dict[str, Any]) -> None:
             "--video-vae-path": args.video_vae_path,
             "--audio-vae-path": args.audio_vae_path,
         }
-        if args.official_pipeline in {"distilled_two_stage", "full_two_stage"}:
+        if args.official_pipeline in {"distilled_two_stage", "full_two_stage", "full_two_stage_hq"}:
             required["--spatial-upsampler-path"] = args.spatial_upsampler_path
-        if args.official_pipeline == "full_two_stage":
+        if args.official_pipeline in {"full_two_stage", "full_two_stage_hq"}:
             required["--distilled-lora-path"] = args.distilled_lora_path
         missing = [name for name, value in required.items() if value is None]
         if missing:
@@ -253,27 +253,44 @@ def _run_official(args: argparse.Namespace, request: dict[str, Any]) -> None:
                 images=images,
             )
             pipeline_name = "DistilledPipeline"
-        elif args.official_pipeline == "full_two_stage":
+        elif args.official_pipeline in {"full_two_stage", "full_two_stage_hq"}:
             from ltx_core.components.guiders import MultiModalGuiderParams
             from ltx_core.loader import LTXV_LORA_COMFY_RENAMING_MAP, LoraPathStrengthAndSDOps
             from ltx_pipelines.ti2vid_two_stages import TI2VidTwoStagesPipeline
+            from ltx_pipelines.ti2vid_two_stages_hq import TI2VidTwoStagesHQPipeline
 
-            pipeline = TI2VidTwoStagesPipeline(
-                model_paths=model_paths,
-                distilled_lora=[
+            two_stage_kwargs = {
+                "model_paths": model_paths,
+                "distilled_lora": [
                     LoraPathStrengthAndSDOps(
                         path=str(args.distilled_lora_path),
                         strength=1.0,
                         sd_ops=LTXV_LORA_COMFY_RENAMING_MAP,
                     )
                 ],
-                spatial_upsampler_path=str(args.spatial_upsampler_path),
-                loras=[],
-                offload_mode=offload_mode,
-            )
+                "spatial_upsampler_path": str(args.spatial_upsampler_path),
+                "loras": [],
+                "offload_mode": offload_mode,
+            }
+            if args.official_pipeline == "full_two_stage_hq":
+                pipeline = TI2VidTwoStagesHQPipeline(
+                    **two_stage_kwargs,
+                    distilled_lora_strength_stage_1=0.25,
+                    distilled_lora_strength_stage_2=0.5,
+                )
+            else:
+                pipeline = TI2VidTwoStagesPipeline(**two_stage_kwargs)
             if args.connector_model is not None:
                 _use_diffusers_connector_weights(pipeline.prompt_encoder, args.connector_model)
             _configure_official_sdpa(pipeline)
+            schedule_kwargs = (
+                {}
+                if args.official_pipeline == "full_two_stage_hq"
+                else {
+                    "stage_1_sigmas": torch.tensor(request["stage_1_sigmas"], dtype=torch.float32),
+                    "stage_2_sigmas": torch.tensor(request["stage_2_sigmas"], dtype=torch.float32),
+                }
+            )
             video, audio, _, _ = pipeline(
                 prompt=request["prompt"],
                 negative_prompt=request["negative_prompt"],
@@ -301,10 +318,13 @@ def _run_official(args: argparse.Namespace, request: dict[str, Any]) -> None:
                 ),
                 images=images,
                 max_batch_size=4,
-                stage_1_sigmas=torch.tensor(request["stage_1_sigmas"], dtype=torch.float32),
-                stage_2_sigmas=torch.tensor(request["stage_2_sigmas"], dtype=torch.float32),
+                **schedule_kwargs,
             )
-            pipeline_name = "TI2VidTwoStagesPipeline"
+            pipeline_name = (
+                "TI2VidTwoStagesHQPipeline"
+                if args.official_pipeline == "full_two_stage_hq"
+                else "TI2VidTwoStagesPipeline"
+            )
         else:
             from ltx_core.components.guiders import MultiModalGuiderParams
             from ltx_pipelines.ti2vid_one_stage import TI2VidOneStagePipeline

--- a/tests/e2e/accuracy/ltx/run_ltx_reference.py
+++ b/tests/e2e/accuracy/ltx/run_ltx_reference.py
@@ -22,7 +22,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--backend", choices=("official", "omni"), required=True)
     parser.add_argument(
         "--pipeline-kind",
-        choices=("one_stage", "distilled", "two_stage"),
+        choices=("one_stage", "distilled", "two_stage", "two_stage_hq"),
         default="one_stage",
     )
     parser.add_argument("--request", type=Path, required=True)
@@ -134,6 +134,7 @@ def _run_official(args: argparse.Namespace, request: dict[str, Any]) -> None:
     from ltx_pipelines.distilled import DistilledPipeline
     from ltx_pipelines.ti2vid_one_stage import TI2VidOneStagePipeline
     from ltx_pipelines.ti2vid_two_stages import TI2VidTwoStagesPipeline
+    from ltx_pipelines.ti2vid_two_stages_hq import TI2VidTwoStagesHQPipeline
     from ltx_pipelines.utils.args import ImageConditioningInput
     from ltx_pipelines.utils.types import OffloadMode
 
@@ -170,14 +171,22 @@ def _run_official(args: argparse.Namespace, request: dict[str, Any]) -> None:
                 sd_ops=LTXV_LORA_COMFY_RENAMING_MAP,
             )
         ]
-        pipeline = TI2VidTwoStagesPipeline(
-            checkpoint_path=checkpoint,
-            distilled_lora=distilled_lora,
-            spatial_upsampler_path=_require_path(args.spatial_upsampler, "spatial upsampler"),
-            gemma_root=gemma_root,
-            loras=(),
-            offload_mode=offload_mode,
-        )
+        two_stage_kwargs = {
+            "checkpoint_path": checkpoint,
+            "distilled_lora": distilled_lora,
+            "spatial_upsampler_path": _require_path(args.spatial_upsampler, "spatial upsampler"),
+            "gemma_root": gemma_root,
+            "loras": (),
+            "offload_mode": offload_mode,
+        }
+        if args.pipeline_kind == "two_stage_hq":
+            pipeline = TI2VidTwoStagesHQPipeline(
+                **two_stage_kwargs,
+                distilled_lora_strength_stage_1=0.25,
+                distilled_lora_strength_stage_2=0.5,
+            )
+        else:
+            pipeline = TI2VidTwoStagesPipeline(**two_stage_kwargs)
     _configure_official_sdpa(pipeline)
     image_path = request.get("image")
     images = (

--- a/tests/e2e/accuracy/ltx/test_ltx25_official_similarity.py
+++ b/tests/e2e/accuracy/ltx/test_ltx25_official_similarity.py
@@ -22,6 +22,7 @@ import shutil
 import subprocess
 import sys
 import time
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 import numpy as np
@@ -83,33 +84,25 @@ NEGATIVE_PROMPT = (
 # Release parity exercises the accelerated BF16 cuDNN path in both runtimes.
 # Degenerate one-token attention falls back to PyTorch SDPA MATH.
 ATTENTION_BACKEND = "torch_sdpa_cudnn_bf16"
-VIDEO_SSIM_MEAN_THRESHOLD = 0.95
-VIDEO_SSIM_MIN_THRESHOLD = 0.90
-VIDEO_PSNR_MEAN_THRESHOLD = 30.0
-AUDIO_RELATIVE_L2_THRESHOLD = 0.2
-AUDIO_COSINE_THRESHOLD = 0.95
-
-# Decoded-output gates for the pinned official/Omni BF16 cuDNN comparison.
-# The metrics artifact preserves the exact observed values.
-LTX25_VIDEO_SSIM_MEAN_THRESHOLD = 0.99
-LTX25_I2V_VIDEO_SSIM_MEAN_THRESHOLD = 0.99
-LTX25_VIDEO_SSIM_MIN_THRESHOLD = 0.99
-LTX25_VIDEO_PSNR_MEAN_THRESHOLD = 40.0
-LTX25_VIDEO_LPIPS_MEAN_THRESHOLD = 0.01
-LTX25_AUDIO_RELATIVE_L2_THRESHOLD = 0.32
-LTX25_AUDIO_COSINE_THRESHOLD = 0.95
-
-# Full/SFT uses independently converted dev weights, but the release contract
-# still requires decoded-video parity at the same 0.99 SSIM floor as the
-# distilled paths when both runtimes use BF16 cuDNN attention.
-LTX25_FULL_VIDEO_SSIM_MEAN_THRESHOLD = 0.99
-LTX25_FULL_VIDEO_SSIM_MIN_THRESHOLD = 0.99
-LTX25_FULL_VIDEO_PSNR_MEAN_THRESHOLD = 40.0
-LTX25_FULL_AUDIO_RELATIVE_L2_THRESHOLD = 0.3
-LTX25_FULL_VIDEO_LPIPS_MEAN_THRESHOLD = 0.01
-LTX25_FULL_I2V_VIDEO_LPIPS_MEAN_THRESHOLD = 0.02
-LTX25_FULL_AUDIO_COSINE_THRESHOLD = AUDIO_COSINE_THRESHOLD
 LTX25_STAGE_2_SIGMAS = [0.909375, 0.725, 0.421875, 0.0]
+
+
+@dataclass(frozen=True)
+class LTXAccuracyThresholds:
+    video_ssim_mean: float
+    video_ssim_min: float
+    video_psnr_mean_db: float
+    audio_relative_l2: float
+    audio_cosine_similarity: float
+
+
+STRICT_THRESHOLDS = LTXAccuracyThresholds(
+    video_ssim_mean=0.99,
+    video_ssim_min=0.99,
+    video_psnr_mean_db=40.0,
+    audio_relative_l2=0.10,
+    audio_cosine_similarity=0.99,
+)
 
 
 def test_ltx_reference_runner_unwraps_flattened_pipeline_output() -> None:
@@ -419,8 +412,6 @@ def test_ltx25_i2v_requests_pin_official_crf() -> None:
 
 
 def _video_metrics(reference: np.ndarray, prediction: np.ndarray) -> dict[str, float]:
-    from benchmarks.diffusion.quantization_quality import compute_lpips_video
-
     assert reference.shape == prediction.shape
     assert reference.ndim == 4 and reference.shape[-1] == 3
     ssim_scores: list[float] = []
@@ -435,7 +426,6 @@ def _video_metrics(reference: np.ndarray, prediction: np.ndarray) -> dict[str, f
         "ssim_mean": float(np.mean(ssim_scores)),
         "ssim_min": float(np.min(ssim_scores)),
         "psnr_mean_db": float(np.mean(psnr_scores)),
-        "lpips_alex_mean": compute_lpips_video(reference, prediction),
         "max_abs": float(difference.max()),
         "mean_abs": float(difference.mean()),
     }
@@ -461,6 +451,17 @@ def _audio_metrics(reference: np.ndarray, prediction: np.ndarray) -> dict[str, f
         "relative_l2": float(np.linalg.norm(difference) / reference_norm),
         "cosine_similarity": float(np.vdot(reference.ravel(), prediction.ravel()) / (reference_norm * prediction_norm)),
     }
+
+
+def _assert_strict_similarity(
+    video_metrics: dict[str, float],
+    audio_metrics: dict[str, float | bool],
+) -> None:
+    assert video_metrics["ssim_mean"] >= STRICT_THRESHOLDS.video_ssim_mean
+    assert video_metrics["ssim_min"] >= STRICT_THRESHOLDS.video_ssim_min
+    assert video_metrics["psnr_mean_db"] >= STRICT_THRESHOLDS.video_psnr_mean_db
+    assert audio_metrics["relative_l2"] <= STRICT_THRESHOLDS.audio_relative_l2
+    assert audio_metrics["cosine_similarity"] >= STRICT_THRESHOLDS.audio_cosine_similarity
 
 
 @pytest.mark.slow
@@ -569,6 +570,7 @@ def test_ltx25_distilled_two_stage_matches_official(accuracy_artifact_root: Path
         "omni_model": omni_model_source,
         "omni_model_revision": omni_model_revision,
         "resolved_omni_model_path": str(omni_model),
+        "thresholds": asdict(STRICT_THRESHOLDS),
         "peak_memory_mb": {
             "official_allocated": official_metadata["peak_memory_allocated_mb"],
             "official_reserved": official_metadata["peak_memory_reserved_mb"],
@@ -582,13 +584,7 @@ def test_ltx25_distilled_two_stage_matches_official(accuracy_artifact_root: Path
     (output_root / "metrics.json").write_text(json.dumps(result, indent=2) + "\n")
     print(json.dumps(result, indent=2))
 
-    ssim_mean_threshold = LTX25_VIDEO_SSIM_MEAN_THRESHOLD if task == "t2v" else LTX25_I2V_VIDEO_SSIM_MEAN_THRESHOLD
-    assert video_metrics["ssim_mean"] >= ssim_mean_threshold
-    assert video_metrics["ssim_min"] >= LTX25_VIDEO_SSIM_MIN_THRESHOLD
-    assert video_metrics["psnr_mean_db"] >= LTX25_VIDEO_PSNR_MEAN_THRESHOLD
-    assert video_metrics["lpips_alex_mean"] <= LTX25_VIDEO_LPIPS_MEAN_THRESHOLD
-    assert audio_metrics["cosine_similarity"] >= LTX25_AUDIO_COSINE_THRESHOLD
-    assert audio_metrics["relative_l2"] <= LTX25_AUDIO_RELATIVE_L2_THRESHOLD
+    _assert_strict_similarity(video_metrics, audio_metrics)
 
 
 @pytest.mark.slow
@@ -729,6 +725,7 @@ def test_ltx25_full_matches_official(accuracy_artifact_root: Path, task: str, pi
         "omni_model": omni_model_source,
         "omni_model_revision": omni_model_revision,
         "resolved_omni_model_path": str(omni_model),
+        "thresholds": asdict(STRICT_THRESHOLDS),
         "peak_memory_mb": {
             "official_allocated": official_metadata["peak_memory_allocated_mb"],
             "official_reserved": official_metadata["peak_memory_reserved_mb"],
@@ -742,12 +739,4 @@ def test_ltx25_full_matches_official(accuracy_artifact_root: Path, task: str, pi
     (output_root / "metrics.json").write_text(json.dumps(result, indent=2) + "\n")
     print(json.dumps(result, indent=2))
 
-    assert video_metrics["ssim_mean"] >= LTX25_FULL_VIDEO_SSIM_MEAN_THRESHOLD
-    assert video_metrics["ssim_min"] >= LTX25_FULL_VIDEO_SSIM_MIN_THRESHOLD
-    assert video_metrics["psnr_mean_db"] >= LTX25_FULL_VIDEO_PSNR_MEAN_THRESHOLD
-    lpips_threshold = (
-        LTX25_FULL_VIDEO_LPIPS_MEAN_THRESHOLD if task == "t2v" else LTX25_FULL_I2V_VIDEO_LPIPS_MEAN_THRESHOLD
-    )
-    assert audio_metrics["relative_l2"] <= LTX25_FULL_AUDIO_RELATIVE_L2_THRESHOLD
-    assert video_metrics["lpips_alex_mean"] <= lpips_threshold
-    assert audio_metrics["cosine_similarity"] >= LTX25_FULL_AUDIO_COSINE_THRESHOLD
+    _assert_strict_similarity(video_metrics, audio_metrics)

--- a/tests/e2e/accuracy/ltx/test_ltx25_official_similarity.py
+++ b/tests/e2e/accuracy/ltx/test_ltx25_official_similarity.py
@@ -10,7 +10,9 @@ only the generation shape and step count are reduced for CI runtime.
 LTX-2.5 runs the official split-artifact pipelines with connector weights from
 the same Diffusers checkpoint under test. The distilled case covers the fixed
 two-stage schedule; the Full/SFT case covers raw dev weights and an explicit
-shared one-stage schedule.
+shared one-stage schedule. A separate reduced Full/SFT HQ guard exercises
+Res2s and weighted phase LoRAs without registering the expensive case in
+nightly CI.
 """
 
 from __future__ import annotations
@@ -109,7 +111,40 @@ LTX25_FULL_AUDIO_RELATIVE_L2_THRESHOLD = 0.3
 LTX25_FULL_VIDEO_LPIPS_MEAN_THRESHOLD = 0.01
 LTX25_FULL_I2V_VIDEO_LPIPS_MEAN_THRESHOLD = 0.02
 LTX25_FULL_AUDIO_COSINE_THRESHOLD = AUDIO_COSINE_THRESHOLD
+# Res2s deliberately injects noise after each BF16 model evaluation. The two
+# runtimes start from bitwise-identical latents and schedules, but small kernel
+# rounding differences are amplified by later stochastic second-order steps.
+# These manual-only gates guard perceptual/semantic parity without pretending
+# that the final decoded tensors should retain deterministic Euler tolerances.
+LTX25_HQ_VIDEO_SSIM_MEAN_THRESHOLD = 0.72
+LTX25_HQ_VIDEO_SSIM_MIN_THRESHOLD = 0.68
+LTX25_HQ_VIDEO_PSNR_MEAN_THRESHOLD = 17.0
+LTX25_HQ_VIDEO_LPIPS_MEAN_THRESHOLD = 0.22
+LTX25_HQ_AUDIO_RELATIVE_L2_THRESHOLD = 0.60
+LTX25_HQ_AUDIO_COSINE_THRESHOLD = 0.82
 LTX25_STAGE_2_SIGMAS = [0.909375, 0.725, 0.421875, 0.0]
+
+
+def _ltx25_full_thresholds(task: str, pipeline_mode: str) -> dict[str, float]:
+    if pipeline_mode == "full_two_stage_hq":
+        return {
+            "video_ssim_mean": LTX25_HQ_VIDEO_SSIM_MEAN_THRESHOLD,
+            "video_ssim_min": LTX25_HQ_VIDEO_SSIM_MIN_THRESHOLD,
+            "video_psnr_mean_db": LTX25_HQ_VIDEO_PSNR_MEAN_THRESHOLD,
+            "video_lpips_mean": LTX25_HQ_VIDEO_LPIPS_MEAN_THRESHOLD,
+            "audio_relative_l2": LTX25_HQ_AUDIO_RELATIVE_L2_THRESHOLD,
+            "audio_cosine": LTX25_HQ_AUDIO_COSINE_THRESHOLD,
+        }
+    return {
+        "video_ssim_mean": LTX25_FULL_VIDEO_SSIM_MEAN_THRESHOLD,
+        "video_ssim_min": LTX25_FULL_VIDEO_SSIM_MIN_THRESHOLD,
+        "video_psnr_mean_db": LTX25_FULL_VIDEO_PSNR_MEAN_THRESHOLD,
+        "video_lpips_mean": (
+            LTX25_FULL_VIDEO_LPIPS_MEAN_THRESHOLD if task == "t2v" else LTX25_FULL_I2V_VIDEO_LPIPS_MEAN_THRESHOLD
+        ),
+        "audio_relative_l2": LTX25_FULL_AUDIO_RELATIVE_L2_THRESHOLD,
+        "audio_cosine": LTX25_FULL_AUDIO_COSINE_THRESHOLD,
+    }
 
 
 def test_ltx_reference_runner_unwraps_flattened_pipeline_output() -> None:
@@ -399,6 +434,34 @@ def _ltx25_full_request(image: Path | None = None) -> dict[str, object]:
     return request
 
 
+def _ltx25_hq_request(image: Path | None = None) -> dict[str, object]:
+    request: dict[str, object] = {
+        "prompt": LTX25_PROMPT,
+        "negative_prompt": NEGATIVE_PROMPT,
+        # Preserve the HQ sampler and phase topology while keeping this manual
+        # precision guard practical on one accelerator.
+        "width": 512,
+        "height": 384,
+        "num_frames": 25,
+        "fps": 24,
+        "num_inference_steps": 8,
+        "seed": 42,
+        "video_cfg_scale": 3.0,
+        "audio_cfg_scale": 7.0,
+        "video_stg_scale": 0.0,
+        "audio_stg_scale": 0.0,
+        "video_modality_scale": 3.0,
+        "audio_modality_scale": 3.0,
+        "video_rescale_scale": 0.45,
+        "audio_rescale_scale": 1.0,
+        "video_stg_blocks": [],
+        "audio_stg_blocks": [],
+    }
+    if image is not None:
+        request.update(image=str(image.resolve()), image_crf=18)
+    return request
+
+
 def test_ltx25_full_request_pins_official_schedule() -> None:
     request = _ltx25_full_request()
     sigmas = request["sigmas"]
@@ -413,9 +476,23 @@ def test_ltx25_full_request_pins_official_schedule() -> None:
 
 def test_ltx25_i2v_requests_pin_official_crf() -> None:
     image = Path("conditioning.png")
-    for request in (_ltx25_request(image), _ltx25_full_request(image)):
+    for request in (_ltx25_request(image), _ltx25_full_request(image), _ltx25_hq_request(image)):
         assert request["image"] == str(image.resolve())
         assert request["image_crf"] == 18
+
+
+def test_ltx25_hq_request_matches_official_contract() -> None:
+    request = _ltx25_hq_request()
+
+    assert (request["width"], request["height"], request["num_frames"]) == (512, 384, 25)
+    assert request["num_inference_steps"] == 8
+    assert (request["video_cfg_scale"], request["audio_cfg_scale"]) == (3.0, 7.0)
+    assert (request["video_stg_scale"], request["audio_stg_scale"]) == (0.0, 0.0)
+    assert (request["video_modality_scale"], request["audio_modality_scale"]) == (3.0, 3.0)
+    assert (request["video_rescale_scale"], request["audio_rescale_scale"]) == (0.45, 1.0)
+    assert "sigmas" not in request
+    assert "stage_1_sigmas" not in request
+    assert "stage_2_sigmas" not in request
 
 
 def _video_metrics(reference: np.ndarray, prediction: np.ndarray) -> dict[str, float]:
@@ -591,20 +668,15 @@ def test_ltx25_distilled_two_stage_matches_official(accuracy_artifact_root: Path
     assert audio_metrics["relative_l2"] <= LTX25_AUDIO_RELATIVE_L2_THRESHOLD
 
 
-@pytest.mark.slow
-@pytest.mark.benchmark
-@pytest.mark.diffusion
-@hardware_test(res={"cuda": "H100"}, num_cards=1)
-@pytest.mark.parametrize("task", ["t2v", "i2v"])
-@pytest.mark.parametrize("pipeline_mode", ["full_one_stage", "full_two_stage"])
-def test_ltx25_full_matches_official(accuracy_artifact_root: Path, task: str, pipeline_mode: str) -> None:
-    """Compare raw official Full/SFT weights with Omni's converted Full pipeline."""
+def _run_ltx25_full_comparison(accuracy_artifact_root: Path, task: str, pipeline_mode: str) -> None:
+    """Compare one raw official Full/SFT pipeline with its Omni equivalent."""
     _require_ltx25_model_access()
     artifact_parent = accuracy_artifact_root / "ltx_official"
     output_root = reset_artifact_dir(artifact_parent / f"ltx2_5_{pipeline_mode}_{task}")
     model_class_name = {
         "full_one_stage": "LTX2Pipeline",
         "full_two_stage": "LTX2TwoStagePipeline",
+        "full_two_stage_hq": "LTX2TwoStageHQPipeline",
     }[pipeline_mode]
     official_root, official_revision = _ltx25_official_source(artifact_parent)
     official_artifacts, official_model_source, official_model_revision = _resolve_ltx25_official_artifacts(
@@ -614,7 +686,7 @@ def test_ltx25_full_matches_official(accuracy_artifact_root: Path, task: str, pi
         transformer_subfolder="transformer_full"
     )
     image = _resolve_ltx25_image() if task == "i2v" else None
-    request = _ltx25_full_request(image)
+    request = _ltx25_hq_request(image) if pipeline_mode == "full_two_stage_hq" else _ltx25_full_request(image)
     if pipeline_mode == "full_two_stage":
         request["stage_1_sigmas"] = request.pop("sigmas")
         request["stage_2_sigmas"] = LTX25_STAGE_2_SIGMAS
@@ -639,7 +711,7 @@ def test_ltx25_full_matches_official(accuracy_artifact_root: Path, task: str, pi
 
     official_output = output_root / "official"
     official_sidecar_args: list[str] = []
-    if pipeline_mode == "full_two_stage":
+    if pipeline_mode in {"full_two_stage", "full_two_stage_hq"}:
         official_sidecar_args = [
             "--spatial-upsampler-path",
             str(official_artifacts["spatial_upsampler"]),
@@ -699,6 +771,7 @@ def test_ltx25_full_matches_official(accuracy_artifact_root: Path, task: str, pi
         == {
             "full_one_stage": "TI2VidOneStagePipeline",
             "full_two_stage": "TI2VidTwoStagesPipeline",
+            "full_two_stage_hq": "TI2VidTwoStagesHQPipeline",
         }[pipeline_mode]
     )
     assert official_metadata["attention_backend"] == ATTENTION_BACKEND
@@ -717,6 +790,7 @@ def test_ltx25_full_matches_official(accuracy_artifact_root: Path, task: str, pi
         np.load(official_output / "audio.npy"),
         np.load(omni_output / "audio.npy"),
     )
+    thresholds = _ltx25_full_thresholds(task, pipeline_mode)
     result = {
         "case": f"ltx2_5_{pipeline_mode}",
         "task": task,
@@ -736,18 +810,38 @@ def test_ltx25_full_matches_official(accuracy_artifact_root: Path, task: str, pi
             "omni_parent_allocated": omni_metadata["peak_memory_allocated_mb"],
             "omni_parent_reserved": omni_metadata["peak_memory_reserved_mb"],
         },
+        "threshold_profile": "res2s_hq" if pipeline_mode == "full_two_stage_hq" else "full_euler",
+        "thresholds": thresholds,
         "video": video_metrics,
         "audio": audio_metrics,
     }
     (output_root / "metrics.json").write_text(json.dumps(result, indent=2) + "\n")
     print(json.dumps(result, indent=2))
 
-    assert video_metrics["ssim_mean"] >= LTX25_FULL_VIDEO_SSIM_MEAN_THRESHOLD
-    assert video_metrics["ssim_min"] >= LTX25_FULL_VIDEO_SSIM_MIN_THRESHOLD
-    assert video_metrics["psnr_mean_db"] >= LTX25_FULL_VIDEO_PSNR_MEAN_THRESHOLD
-    lpips_threshold = (
-        LTX25_FULL_VIDEO_LPIPS_MEAN_THRESHOLD if task == "t2v" else LTX25_FULL_I2V_VIDEO_LPIPS_MEAN_THRESHOLD
-    )
-    assert audio_metrics["relative_l2"] <= LTX25_FULL_AUDIO_RELATIVE_L2_THRESHOLD
-    assert video_metrics["lpips_alex_mean"] <= lpips_threshold
-    assert audio_metrics["cosine_similarity"] >= LTX25_FULL_AUDIO_COSINE_THRESHOLD
+    assert video_metrics["ssim_mean"] >= thresholds["video_ssim_mean"]
+    assert video_metrics["ssim_min"] >= thresholds["video_ssim_min"]
+    assert video_metrics["psnr_mean_db"] >= thresholds["video_psnr_mean_db"]
+    assert audio_metrics["relative_l2"] <= thresholds["audio_relative_l2"]
+    assert video_metrics["lpips_alex_mean"] <= thresholds["video_lpips_mean"]
+    assert audio_metrics["cosine_similarity"] >= thresholds["audio_cosine"]
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+@pytest.mark.diffusion
+@hardware_test(res={"cuda": "H100"}, num_cards=1)
+@pytest.mark.parametrize("task", ["t2v", "i2v"])
+@pytest.mark.parametrize("pipeline_mode", ["full_one_stage", "full_two_stage"])
+def test_ltx25_full_matches_official(accuracy_artifact_root: Path, task: str, pipeline_mode: str) -> None:
+    """Compare the nightly Full/SFT one-stage and ordinary two-stage paths."""
+    _run_ltx25_full_comparison(accuracy_artifact_root, task, pipeline_mode)
+
+
+@pytest.mark.full_model
+@pytest.mark.benchmark
+@pytest.mark.diffusion
+@hardware_test(res={"cuda": "H100"}, num_cards=1)
+@pytest.mark.parametrize("task", ["t2v", "i2v"])
+def test_ltx25_hq_matches_official(accuracy_artifact_root: Path, task: str) -> None:
+    """Compare the manual-only Full/SFT Res2s HQ path with the official runtime."""
+    _run_ltx25_full_comparison(accuracy_artifact_root, task, "full_two_stage_hq")

--- a/tests/e2e/accuracy/ltx/test_ltx25_official_similarity.py
+++ b/tests/e2e/accuracy/ltx/test_ltx25_official_similarity.py
@@ -10,9 +10,7 @@ only the generation shape and step count are reduced for CI runtime.
 LTX-2.5 runs the official split-artifact pipelines with connector weights from
 the same Diffusers checkpoint under test. The distilled case covers the fixed
 two-stage schedule; the Full/SFT case covers raw dev weights and an explicit
-shared one-stage schedule. A separate reduced Full/SFT HQ guard exercises
-Res2s and weighted phase LoRAs without registering the expensive case in
-nightly CI.
+shared one-stage schedule.
 """
 
 from __future__ import annotations
@@ -112,19 +110,6 @@ LTX25_FULL_VIDEO_LPIPS_MEAN_THRESHOLD = 0.01
 LTX25_FULL_I2V_VIDEO_LPIPS_MEAN_THRESHOLD = 0.02
 LTX25_FULL_AUDIO_COSINE_THRESHOLD = AUDIO_COSINE_THRESHOLD
 LTX25_STAGE_2_SIGMAS = [0.909375, 0.725, 0.421875, 0.0]
-
-
-def _ltx25_full_thresholds(task: str) -> dict[str, float]:
-    return {
-        "video_ssim_mean": LTX25_FULL_VIDEO_SSIM_MEAN_THRESHOLD,
-        "video_ssim_min": LTX25_FULL_VIDEO_SSIM_MIN_THRESHOLD,
-        "video_psnr_mean_db": LTX25_FULL_VIDEO_PSNR_MEAN_THRESHOLD,
-        "video_lpips_mean": (
-            LTX25_FULL_VIDEO_LPIPS_MEAN_THRESHOLD if task == "t2v" else LTX25_FULL_I2V_VIDEO_LPIPS_MEAN_THRESHOLD
-        ),
-        "audio_relative_l2": LTX25_FULL_AUDIO_RELATIVE_L2_THRESHOLD,
-        "audio_cosine": LTX25_FULL_AUDIO_COSINE_THRESHOLD,
-    }
 
 
 def test_ltx_reference_runner_unwraps_flattened_pipeline_output() -> None:
@@ -414,34 +399,6 @@ def _ltx25_full_request(image: Path | None = None) -> dict[str, object]:
     return request
 
 
-def _ltx25_hq_request(image: Path | None = None) -> dict[str, object]:
-    request: dict[str, object] = {
-        "prompt": LTX25_PROMPT,
-        "negative_prompt": NEGATIVE_PROMPT,
-        # Preserve the HQ sampler and phase topology while keeping this manual
-        # precision guard practical on one accelerator.
-        "width": 512,
-        "height": 384,
-        "num_frames": 25,
-        "fps": 24,
-        "num_inference_steps": 8,
-        "seed": 42,
-        "video_cfg_scale": 3.0,
-        "audio_cfg_scale": 7.0,
-        "video_stg_scale": 0.0,
-        "audio_stg_scale": 0.0,
-        "video_modality_scale": 3.0,
-        "audio_modality_scale": 3.0,
-        "video_rescale_scale": 0.45,
-        "audio_rescale_scale": 1.0,
-        "video_stg_blocks": [],
-        "audio_stg_blocks": [],
-    }
-    if image is not None:
-        request.update(image=str(image.resolve()), image_crf=18)
-    return request
-
-
 def test_ltx25_full_request_pins_official_schedule() -> None:
     request = _ltx25_full_request()
     sigmas = request["sigmas"]
@@ -456,23 +413,9 @@ def test_ltx25_full_request_pins_official_schedule() -> None:
 
 def test_ltx25_i2v_requests_pin_official_crf() -> None:
     image = Path("conditioning.png")
-    for request in (_ltx25_request(image), _ltx25_full_request(image), _ltx25_hq_request(image)):
+    for request in (_ltx25_request(image), _ltx25_full_request(image)):
         assert request["image"] == str(image.resolve())
         assert request["image_crf"] == 18
-
-
-def test_ltx25_hq_request_matches_official_contract() -> None:
-    request = _ltx25_hq_request()
-
-    assert (request["width"], request["height"], request["num_frames"]) == (512, 384, 25)
-    assert request["num_inference_steps"] == 8
-    assert (request["video_cfg_scale"], request["audio_cfg_scale"]) == (3.0, 7.0)
-    assert (request["video_stg_scale"], request["audio_stg_scale"]) == (0.0, 0.0)
-    assert (request["video_modality_scale"], request["audio_modality_scale"]) == (3.0, 3.0)
-    assert (request["video_rescale_scale"], request["audio_rescale_scale"]) == (0.45, 1.0)
-    assert "sigmas" not in request
-    assert "stage_1_sigmas" not in request
-    assert "stage_2_sigmas" not in request
 
 
 def _video_metrics(reference: np.ndarray, prediction: np.ndarray) -> dict[str, float]:
@@ -648,15 +591,20 @@ def test_ltx25_distilled_two_stage_matches_official(accuracy_artifact_root: Path
     assert audio_metrics["relative_l2"] <= LTX25_AUDIO_RELATIVE_L2_THRESHOLD
 
 
-def _run_ltx25_full_comparison(accuracy_artifact_root: Path, task: str, pipeline_mode: str) -> None:
-    """Compare one raw official Full/SFT pipeline with its Omni equivalent."""
+@pytest.mark.slow
+@pytest.mark.benchmark
+@pytest.mark.diffusion
+@hardware_test(res={"cuda": "H100"}, num_cards=1)
+@pytest.mark.parametrize("task", ["t2v", "i2v"])
+@pytest.mark.parametrize("pipeline_mode", ["full_one_stage", "full_two_stage"])
+def test_ltx25_full_matches_official(accuracy_artifact_root: Path, task: str, pipeline_mode: str) -> None:
+    """Compare raw official Full/SFT weights with Omni's converted Full pipeline."""
     _require_ltx25_model_access()
     artifact_parent = accuracy_artifact_root / "ltx_official"
     output_root = reset_artifact_dir(artifact_parent / f"ltx2_5_{pipeline_mode}_{task}")
     model_class_name = {
         "full_one_stage": "LTX2Pipeline",
         "full_two_stage": "LTX2TwoStagePipeline",
-        "full_two_stage_hq": "LTX2TwoStageHQPipeline",
     }[pipeline_mode]
     official_root, official_revision = _ltx25_official_source(artifact_parent)
     official_artifacts, official_model_source, official_model_revision = _resolve_ltx25_official_artifacts(
@@ -666,7 +614,7 @@ def _run_ltx25_full_comparison(accuracy_artifact_root: Path, task: str, pipeline
         transformer_subfolder="transformer_full"
     )
     image = _resolve_ltx25_image() if task == "i2v" else None
-    request = _ltx25_hq_request(image) if pipeline_mode == "full_two_stage_hq" else _ltx25_full_request(image)
+    request = _ltx25_full_request(image)
     if pipeline_mode == "full_two_stage":
         request["stage_1_sigmas"] = request.pop("sigmas")
         request["stage_2_sigmas"] = LTX25_STAGE_2_SIGMAS
@@ -691,7 +639,7 @@ def _run_ltx25_full_comparison(accuracy_artifact_root: Path, task: str, pipeline
 
     official_output = output_root / "official"
     official_sidecar_args: list[str] = []
-    if pipeline_mode in {"full_two_stage", "full_two_stage_hq"}:
+    if pipeline_mode == "full_two_stage":
         official_sidecar_args = [
             "--spatial-upsampler-path",
             str(official_artifacts["spatial_upsampler"]),
@@ -751,7 +699,6 @@ def _run_ltx25_full_comparison(accuracy_artifact_root: Path, task: str, pipeline
         == {
             "full_one_stage": "TI2VidOneStagePipeline",
             "full_two_stage": "TI2VidTwoStagesPipeline",
-            "full_two_stage_hq": "TI2VidTwoStagesHQPipeline",
         }[pipeline_mode]
     )
     assert official_metadata["attention_backend"] == ATTENTION_BACKEND
@@ -770,7 +717,6 @@ def _run_ltx25_full_comparison(accuracy_artifact_root: Path, task: str, pipeline
         np.load(official_output / "audio.npy"),
         np.load(omni_output / "audio.npy"),
     )
-    thresholds = _ltx25_full_thresholds(task)
     result = {
         "case": f"ltx2_5_{pipeline_mode}",
         "task": task,
@@ -790,38 +736,18 @@ def _run_ltx25_full_comparison(accuracy_artifact_root: Path, task: str, pipeline
             "omni_parent_allocated": omni_metadata["peak_memory_allocated_mb"],
             "omni_parent_reserved": omni_metadata["peak_memory_reserved_mb"],
         },
-        "threshold_profile": "full_strict",
-        "thresholds": thresholds,
         "video": video_metrics,
         "audio": audio_metrics,
     }
     (output_root / "metrics.json").write_text(json.dumps(result, indent=2) + "\n")
     print(json.dumps(result, indent=2))
 
-    assert video_metrics["ssim_mean"] >= thresholds["video_ssim_mean"]
-    assert video_metrics["ssim_min"] >= thresholds["video_ssim_min"]
-    assert video_metrics["psnr_mean_db"] >= thresholds["video_psnr_mean_db"]
-    assert audio_metrics["relative_l2"] <= thresholds["audio_relative_l2"]
-    assert video_metrics["lpips_alex_mean"] <= thresholds["video_lpips_mean"]
-    assert audio_metrics["cosine_similarity"] >= thresholds["audio_cosine"]
-
-
-@pytest.mark.slow
-@pytest.mark.benchmark
-@pytest.mark.diffusion
-@hardware_test(res={"cuda": "H100"}, num_cards=1)
-@pytest.mark.parametrize("task", ["t2v", "i2v"])
-@pytest.mark.parametrize("pipeline_mode", ["full_one_stage", "full_two_stage"])
-def test_ltx25_full_matches_official(accuracy_artifact_root: Path, task: str, pipeline_mode: str) -> None:
-    """Compare the nightly Full/SFT one-stage and ordinary two-stage paths."""
-    _run_ltx25_full_comparison(accuracy_artifact_root, task, pipeline_mode)
-
-
-@pytest.mark.full_model
-@pytest.mark.benchmark
-@pytest.mark.diffusion
-@hardware_test(res={"cuda": "H100"}, num_cards=1)
-@pytest.mark.parametrize("task", ["t2v", "i2v"])
-def test_ltx25_hq_matches_official(accuracy_artifact_root: Path, task: str) -> None:
-    """Compare the manual-only Full/SFT Res2s HQ path with the official runtime."""
-    _run_ltx25_full_comparison(accuracy_artifact_root, task, "full_two_stage_hq")
+    assert video_metrics["ssim_mean"] >= LTX25_FULL_VIDEO_SSIM_MEAN_THRESHOLD
+    assert video_metrics["ssim_min"] >= LTX25_FULL_VIDEO_SSIM_MIN_THRESHOLD
+    assert video_metrics["psnr_mean_db"] >= LTX25_FULL_VIDEO_PSNR_MEAN_THRESHOLD
+    lpips_threshold = (
+        LTX25_FULL_VIDEO_LPIPS_MEAN_THRESHOLD if task == "t2v" else LTX25_FULL_I2V_VIDEO_LPIPS_MEAN_THRESHOLD
+    )
+    assert audio_metrics["relative_l2"] <= LTX25_FULL_AUDIO_RELATIVE_L2_THRESHOLD
+    assert video_metrics["lpips_alex_mean"] <= lpips_threshold
+    assert audio_metrics["cosine_similarity"] >= LTX25_FULL_AUDIO_COSINE_THRESHOLD

--- a/tests/e2e/accuracy/ltx/test_ltx25_official_similarity.py
+++ b/tests/e2e/accuracy/ltx/test_ltx25_official_similarity.py
@@ -111,30 +111,10 @@ LTX25_FULL_AUDIO_RELATIVE_L2_THRESHOLD = 0.3
 LTX25_FULL_VIDEO_LPIPS_MEAN_THRESHOLD = 0.01
 LTX25_FULL_I2V_VIDEO_LPIPS_MEAN_THRESHOLD = 0.02
 LTX25_FULL_AUDIO_COSINE_THRESHOLD = AUDIO_COSINE_THRESHOLD
-# Res2s deliberately injects noise after each BF16 model evaluation. The two
-# runtimes start from bitwise-identical latents and schedules, but small kernel
-# rounding differences are amplified by later stochastic second-order steps.
-# These manual-only gates guard perceptual/semantic parity without pretending
-# that the final decoded tensors should retain deterministic Euler tolerances.
-LTX25_HQ_VIDEO_SSIM_MEAN_THRESHOLD = 0.72
-LTX25_HQ_VIDEO_SSIM_MIN_THRESHOLD = 0.68
-LTX25_HQ_VIDEO_PSNR_MEAN_THRESHOLD = 17.0
-LTX25_HQ_VIDEO_LPIPS_MEAN_THRESHOLD = 0.22
-LTX25_HQ_AUDIO_RELATIVE_L2_THRESHOLD = 0.60
-LTX25_HQ_AUDIO_COSINE_THRESHOLD = 0.82
 LTX25_STAGE_2_SIGMAS = [0.909375, 0.725, 0.421875, 0.0]
 
 
-def _ltx25_full_thresholds(task: str, pipeline_mode: str) -> dict[str, float]:
-    if pipeline_mode == "full_two_stage_hq":
-        return {
-            "video_ssim_mean": LTX25_HQ_VIDEO_SSIM_MEAN_THRESHOLD,
-            "video_ssim_min": LTX25_HQ_VIDEO_SSIM_MIN_THRESHOLD,
-            "video_psnr_mean_db": LTX25_HQ_VIDEO_PSNR_MEAN_THRESHOLD,
-            "video_lpips_mean": LTX25_HQ_VIDEO_LPIPS_MEAN_THRESHOLD,
-            "audio_relative_l2": LTX25_HQ_AUDIO_RELATIVE_L2_THRESHOLD,
-            "audio_cosine": LTX25_HQ_AUDIO_COSINE_THRESHOLD,
-        }
+def _ltx25_full_thresholds(task: str) -> dict[str, float]:
     return {
         "video_ssim_mean": LTX25_FULL_VIDEO_SSIM_MEAN_THRESHOLD,
         "video_ssim_min": LTX25_FULL_VIDEO_SSIM_MIN_THRESHOLD,
@@ -790,7 +770,7 @@ def _run_ltx25_full_comparison(accuracy_artifact_root: Path, task: str, pipeline
         np.load(official_output / "audio.npy"),
         np.load(omni_output / "audio.npy"),
     )
-    thresholds = _ltx25_full_thresholds(task, pipeline_mode)
+    thresholds = _ltx25_full_thresholds(task)
     result = {
         "case": f"ltx2_5_{pipeline_mode}",
         "task": task,
@@ -810,7 +790,7 @@ def _run_ltx25_full_comparison(accuracy_artifact_root: Path, task: str, pipeline
             "omni_parent_allocated": omni_metadata["peak_memory_allocated_mb"],
             "omni_parent_reserved": omni_metadata["peak_memory_reserved_mb"],
         },
-        "threshold_profile": "res2s_hq" if pipeline_mode == "full_two_stage_hq" else "full_euler",
+        "threshold_profile": "full_strict",
         "thresholds": thresholds,
         "video": video_metrics,
         "audio": audio_metrics,

--- a/tests/e2e/accuracy/ltx/test_ltx_official_similarity.py
+++ b/tests/e2e/accuracy/ltx/test_ltx_official_similarity.py
@@ -85,17 +85,6 @@ STRICT_THRESHOLDS = LTXAccuracyThresholds(
     audio_cosine_similarity=0.95,
 )
 
-# Res2s feeds every BF16 forward into a stochastic second-order update, so
-# harmless backend rounding grows across the phase. Keep a meaningful manual
-# parity floor while reserving the strict thresholds for deterministic Euler.
-RES2S_HQ_THRESHOLDS = LTXAccuracyThresholds(
-    video_ssim_mean=0.70,
-    video_ssim_min=0.65,
-    video_psnr_mean_db=16.0,
-    audio_relative_l2=0.65,
-    audio_cosine_similarity=0.80,
-)
-
 
 @dataclass(frozen=True)
 class LTXAccuracyCase:
@@ -335,7 +324,7 @@ MANUAL_HQ_CASES = (
         seed=10,
         stg_block=None,
         enable_layerwise_offload=True,
-        thresholds=RES2S_HQ_THRESHOLDS,
+        thresholds=STRICT_THRESHOLDS,
     ),
 )
 

--- a/tests/e2e/accuracy/ltx/test_ltx_official_similarity.py
+++ b/tests/e2e/accuracy/ltx/test_ltx_official_similarity.py
@@ -5,7 +5,9 @@
 
 The original reduced one-stage guards remain unchanged. Four complementary
 default-shape cases cover both model versions, both two-stage weight families,
-and T2V/I2V without expanding every combination into a duplicate golden.
+and T2V/I2V without expanding every combination into a duplicate golden. A
+reduced LTX-2.3 HQ case is available for manual precision checks but is not
+registered in nightly CI.
 """
 
 from __future__ import annotations
@@ -83,11 +85,22 @@ STRICT_THRESHOLDS = LTXAccuracyThresholds(
     audio_cosine_similarity=0.95,
 )
 
+# Res2s feeds every BF16 forward into a stochastic second-order update, so
+# harmless backend rounding grows across the phase. Keep a meaningful manual
+# parity floor while reserving the strict thresholds for deterministic Euler.
+RES2S_HQ_THRESHOLDS = LTXAccuracyThresholds(
+    video_ssim_mean=0.70,
+    video_ssim_min=0.65,
+    video_psnr_mean_db=16.0,
+    audio_relative_l2=0.65,
+    audio_cosine_similarity=0.80,
+)
+
 
 @dataclass(frozen=True)
 class LTXAccuracyCase:
     name: str
-    pipeline_kind: Literal["one_stage", "distilled", "two_stage"]
+    pipeline_kind: Literal["one_stage", "distilled", "two_stage", "two_stage_hq"]
     model_id: str
     model_revision: str
     model_env: str
@@ -304,7 +317,29 @@ TWO_STAGE_CASES = (
     ),
 )
 
-CASES = (*LEGACY_CASES, *TWO_STAGE_CASES)
+MANUAL_HQ_CASES = (
+    LTXAccuracyCase(
+        name="ltx23_two_stage_hq_t2v",
+        pipeline_kind="two_stage_hq",
+        model_id="diffusers/LTX-2.3-Diffusers",
+        model_revision="8eee8edcf067e838b843f926ec4d4cc9b2be1aaf",
+        model_env="VLLM_TEST_LTX23_MODEL",
+        model_class_name="LTX2TwoStageHQPipeline",
+        checkpoint=LTX23_CHECKPOINT,
+        spatial_upsampler=LTX23_UPSAMPLER,
+        distilled_lora=LTX23_DISTILLED_LORA,
+        width=512,
+        height=384,
+        num_frames=25,
+        num_inference_steps=8,
+        seed=10,
+        stg_block=None,
+        enable_layerwise_offload=True,
+        thresholds=RES2S_HQ_THRESHOLDS,
+    ),
+)
+
+CASES = (*LEGACY_CASES, *TWO_STAGE_CASES, *MANUAL_HQ_CASES)
 
 
 def _run(command: list[str], *, env: dict[str, str], timeout: int = 1800) -> None:
@@ -472,7 +507,20 @@ def _request(case: LTXAccuracyCase, image: Path | None) -> dict[str, object]:
         "num_inference_steps": case.num_inference_steps,
         "seed": case.seed,
     }
-    if case.pipeline_kind != "distilled":
+    if case.pipeline_kind == "two_stage_hq":
+        request.update(
+            video_cfg_scale=3.0,
+            audio_cfg_scale=7.0,
+            video_stg_scale=0.0,
+            audio_stg_scale=0.0,
+            video_modality_scale=3.0,
+            audio_modality_scale=3.0,
+            video_rescale_scale=0.45,
+            audio_rescale_scale=1.0,
+            video_stg_blocks=[],
+            audio_stg_blocks=[],
+        )
+    elif case.pipeline_kind != "distilled":
         assert case.stg_block is not None
         request.update(
             video_cfg_scale=3.0,
@@ -489,6 +537,17 @@ def _request(case: LTXAccuracyCase, image: Path | None) -> dict[str, object]:
     if image is not None:
         request["image"] = str(image.resolve())
     return request
+
+
+def test_ltx23_hq_request_matches_official_contract() -> None:
+    request = _request(MANUAL_HQ_CASES[0], None)
+
+    assert (request["width"], request["height"], request["num_frames"]) == (512, 384, 25)
+    assert request["num_inference_steps"] == 8
+    assert (request["video_cfg_scale"], request["audio_cfg_scale"]) == (3.0, 7.0)
+    assert (request["video_stg_scale"], request["audio_stg_scale"]) == (0.0, 0.0)
+    assert (request["video_modality_scale"], request["audio_modality_scale"]) == (3.0, 3.0)
+    assert (request["video_rescale_scale"], request["audio_rescale_scale"]) == (0.45, 1.0)
 
 
 def _video_metrics(reference: np.ndarray, prediction: np.ndarray) -> dict[str, float]:

--- a/tests/e2e/accuracy/ltx/test_ltx_official_similarity.py
+++ b/tests/e2e/accuracy/ltx/test_ltx_official_similarity.py
@@ -3,11 +3,9 @@
 
 """E2E accuracy guard against a pinned Lightricks LTX pipeline revision.
 
-The original reduced one-stage guards remain unchanged. Four complementary
-default-shape cases cover both model versions, both two-stage weight families,
-and T2V/I2V without expanding every combination into a duplicate golden. A
-reduced LTX-2.3 HQ case is available for manual precision checks but is not
-registered in nightly CI.
+Four complementary default-shape cases cover both model versions, both
+two-stage weight families, and T2V/I2V without duplicating one-stage coverage.
+A reduced LTX-2.3 HQ case covers the Res2s path in weekly CI.
 """
 
 from __future__ import annotations
@@ -71,25 +69,23 @@ class LTXAccuracyThresholds:
     video_ssim_mean: float
     video_ssim_min: float
     video_psnr_mean_db: float
-    # Zero disables gating for waveform-sensitive audio that is not expected
-    # to align with the official output.
     audio_relative_l2: float
     audio_cosine_similarity: float
 
 
 STRICT_THRESHOLDS = LTXAccuracyThresholds(
-    video_ssim_mean=0.95,
-    video_ssim_min=0.90,
-    video_psnr_mean_db=30.0,
-    audio_relative_l2=0.20,
-    audio_cosine_similarity=0.95,
+    video_ssim_mean=0.99,
+    video_ssim_min=0.99,
+    video_psnr_mean_db=40.0,
+    audio_relative_l2=0.10,
+    audio_cosine_similarity=0.99,
 )
 
 
 @dataclass(frozen=True)
 class LTXAccuracyCase:
     name: str
-    pipeline_kind: Literal["one_stage", "distilled", "two_stage", "two_stage_hq"]
+    pipeline_kind: Literal["distilled", "two_stage", "two_stage_hq"]
     model_id: str
     model_revision: str
     model_env: str
@@ -101,8 +97,6 @@ class LTXAccuracyCase:
     num_inference_steps: int
     seed: int
     stg_block: int | None
-    thresholds: LTXAccuracyThresholds
-    prompt: str = PROMPT
     gemma_model_id: str | None = None
     gemma_model_revision: str | None = None
     gemma_model_env: str | None = None
@@ -170,59 +164,6 @@ I2V_IMAGE = LTXArtifact(
 )
 
 
-LEGACY_CASES = (
-    LTXAccuracyCase(
-        name="ltx2",
-        pipeline_kind="one_stage",
-        model_id="Lightricks/LTX-2",
-        model_revision=LTX2_REVISION,
-        model_env="VLLM_TEST_LTX2_MODEL",
-        model_class_name="LTX2Pipeline",
-        checkpoint=LTX2_CHECKPOINT,
-        width=512,
-        height=384,
-        num_frames=25,
-        num_inference_steps=20,
-        seed=42,
-        stg_block=29,
-        thresholds=STRICT_THRESHOLDS,
-    ),
-    LTXAccuracyCase(
-        name="ltx2_3",
-        pipeline_kind="one_stage",
-        model_id="diffusers/LTX-2.3-Diffusers",
-        model_revision="8eee8edcf067e838b843f926ec4d4cc9b2be1aaf",
-        model_env="VLLM_TEST_LTX23_MODEL",
-        model_class_name="LTX2Pipeline",
-        checkpoint=LTX23_CHECKPOINT,
-        width=512,
-        height=384,
-        num_frames=25,
-        num_inference_steps=20,
-        seed=42,
-        stg_block=28,
-        thresholds=STRICT_THRESHOLDS,
-    ),
-    LTXAccuracyCase(
-        name="ltx2_3_i2v",
-        pipeline_kind="one_stage",
-        model_id="diffusers/LTX-2.3-Diffusers",
-        model_revision="8eee8edcf067e838b843f926ec4d4cc9b2be1aaf",
-        model_env="VLLM_TEST_LTX23_MODEL",
-        model_class_name="LTX2Pipeline",
-        checkpoint=LTX23_CHECKPOINT,
-        width=512,
-        height=384,
-        num_frames=25,
-        num_inference_steps=20,
-        seed=42,
-        stg_block=28,
-        thresholds=STRICT_THRESHOLDS,
-        image=I2V_IMAGE,
-    ),
-)
-
-
 TWO_STAGE_CASES = (
     LTXAccuracyCase(
         name="ltx2_distilled_t2v",
@@ -242,7 +183,6 @@ TWO_STAGE_CASES = (
         gemma_model_id="Lightricks/LTX-2",
         gemma_model_revision=LTX2_REVISION,
         gemma_model_env="VLLM_TEST_LTX2_MODEL",
-        thresholds=STRICT_THRESHOLDS,
     ),
     LTXAccuracyCase(
         name="ltx23_distilled_i2v",
@@ -262,7 +202,6 @@ TWO_STAGE_CASES = (
         gemma_model_id="diffusers/LTX-2.3-Diffusers",
         gemma_model_revision="8eee8edcf067e838b843f926ec4d4cc9b2be1aaf",
         gemma_model_env="VLLM_TEST_LTX23_MODEL",
-        thresholds=STRICT_THRESHOLDS,
         image=I2V_IMAGE,
     ),
     LTXAccuracyCase(
@@ -282,7 +221,6 @@ TWO_STAGE_CASES = (
         seed=10,
         stg_block=29,
         enable_layerwise_offload=True,
-        thresholds=STRICT_THRESHOLDS,
     ),
     LTXAccuracyCase(
         name="ltx23_two_stage_layer_fused_i2v",
@@ -301,34 +239,30 @@ TWO_STAGE_CASES = (
         seed=10,
         stg_block=28,
         enable_layerwise_offload=True,
-        thresholds=STRICT_THRESHOLDS,
         image=I2V_IMAGE,
     ),
 )
 
-MANUAL_HQ_CASES = (
-    LTXAccuracyCase(
-        name="ltx23_two_stage_hq_t2v",
-        pipeline_kind="two_stage_hq",
-        model_id="diffusers/LTX-2.3-Diffusers",
-        model_revision="8eee8edcf067e838b843f926ec4d4cc9b2be1aaf",
-        model_env="VLLM_TEST_LTX23_MODEL",
-        model_class_name="LTX2TwoStageHQPipeline",
-        checkpoint=LTX23_CHECKPOINT,
-        spatial_upsampler=LTX23_UPSAMPLER,
-        distilled_lora=LTX23_DISTILLED_LORA,
-        width=512,
-        height=384,
-        num_frames=25,
-        num_inference_steps=8,
-        seed=10,
-        stg_block=None,
-        enable_layerwise_offload=True,
-        thresholds=STRICT_THRESHOLDS,
-    ),
+HQ_CASE = LTXAccuracyCase(
+    name="ltx23_two_stage_hq_t2v",
+    pipeline_kind="two_stage_hq",
+    model_id="diffusers/LTX-2.3-Diffusers",
+    model_revision="8eee8edcf067e838b843f926ec4d4cc9b2be1aaf",
+    model_env="VLLM_TEST_LTX23_MODEL",
+    model_class_name="LTX2TwoStageHQPipeline",
+    checkpoint=LTX23_CHECKPOINT,
+    spatial_upsampler=LTX23_UPSAMPLER,
+    distilled_lora=LTX23_DISTILLED_LORA,
+    width=512,
+    height=384,
+    num_frames=25,
+    num_inference_steps=8,
+    seed=10,
+    stg_block=None,
+    enable_layerwise_offload=True,
 )
 
-CASES = (*LEGACY_CASES, *TWO_STAGE_CASES, *MANUAL_HQ_CASES)
+WEEKLY_CASES = (*TWO_STAGE_CASES, HQ_CASE)
 
 
 def _run(command: list[str], *, env: dict[str, str], timeout: int = 1800) -> None:
@@ -484,10 +418,49 @@ def _resolve_image(case: LTXAccuracyCase) -> Path | None:
     return _resolve_artifact(case.image)
 
 
+def _omni_model_with_pinned_artifacts(
+    model: Path,
+    output_root: Path,
+    artifacts: tuple[Path | None, ...],
+) -> Path:
+    """Expose the already-resolved sidecars to Omni without copying the model."""
+    resolved_artifacts = tuple(artifact for artifact in artifacts if artifact is not None)
+    if not resolved_artifacts:
+        return model
+
+    overlay = output_root / "omni-model"
+    overlay.mkdir()
+    for source in model.iterdir():
+        (overlay / source.name).symlink_to(source.resolve(), target_is_directory=source.is_dir())
+    for artifact in resolved_artifacts:
+        target = overlay / artifact.name
+        if target.exists():
+            assert target.samefile(artifact), f"Model sidecar does not match pinned artifact: {target} != {artifact}"
+        else:
+            target.symlink_to(artifact.resolve())
+    return overlay
+
+
+def test_omni_model_overlay_pins_artifacts(tmp_path: Path) -> None:
+    model = tmp_path / "model"
+    model.mkdir()
+    component = model / "model_index.json"
+    component.write_text("{}\n")
+    artifact = tmp_path / "sidecar.safetensors"
+    artifact.write_bytes(b"pinned")
+    output_root = tmp_path / "output"
+    output_root.mkdir()
+
+    overlay = _omni_model_with_pinned_artifacts(model, output_root, (artifact,))
+
+    assert (overlay / component.name).samefile(component)
+    assert (overlay / artifact.name).samefile(artifact)
+
+
 def _request(case: LTXAccuracyCase, image: Path | None) -> dict[str, object]:
     request: dict[str, object] = {
         "pipeline_kind": case.pipeline_kind,
-        "prompt": case.prompt,
+        "prompt": PROMPT,
         "negative_prompt": "" if case.pipeline_kind == "distilled" else NEGATIVE_PROMPT,
         "width": case.width,
         "height": case.height,
@@ -496,28 +469,27 @@ def _request(case: LTXAccuracyCase, image: Path | None) -> dict[str, object]:
         "num_inference_steps": case.num_inference_steps,
         "seed": case.seed,
     }
-    if case.pipeline_kind == "two_stage_hq":
+    if case.pipeline_kind != "distilled":
         request.update(
             video_cfg_scale=3.0,
             audio_cfg_scale=7.0,
-            video_stg_scale=0.0,
-            audio_stg_scale=0.0,
             video_modality_scale=3.0,
             audio_modality_scale=3.0,
+        )
+    if case.pipeline_kind == "two_stage_hq":
+        request.update(
+            video_stg_scale=0.0,
+            audio_stg_scale=0.0,
             video_rescale_scale=0.45,
             audio_rescale_scale=1.0,
             video_stg_blocks=[],
             audio_stg_blocks=[],
         )
-    elif case.pipeline_kind != "distilled":
+    elif case.pipeline_kind == "two_stage":
         assert case.stg_block is not None
         request.update(
-            video_cfg_scale=3.0,
-            audio_cfg_scale=7.0,
             video_stg_scale=1.0,
             audio_stg_scale=1.0,
-            video_modality_scale=3.0,
-            audio_modality_scale=3.0,
             video_rescale_scale=0.7,
             audio_rescale_scale=0.7,
             video_stg_blocks=[case.stg_block],
@@ -529,7 +501,7 @@ def _request(case: LTXAccuracyCase, image: Path | None) -> dict[str, object]:
 
 
 def test_ltx23_hq_request_matches_official_contract() -> None:
-    request = _request(MANUAL_HQ_CASES[0], None)
+    request = _request(HQ_CASE, None)
 
     assert (request["width"], request["height"], request["num_frames"]) == (512, 384, 25)
     assert request["num_inference_steps"] == 8
@@ -591,7 +563,7 @@ def _audio_metrics(reference: np.ndarray, prediction: np.ndarray) -> dict[str, f
     }
 
 
-@pytest.mark.parametrize("case", CASES, ids=lambda case: case.name)
+@pytest.mark.parametrize("case", WEEKLY_CASES, ids=lambda case: case.name)
 @pytest.mark.slow
 @pytest.mark.benchmark
 @pytest.mark.diffusion
@@ -609,9 +581,11 @@ def test_ltx_matches_official(case: LTXAccuracyCase, accuracy_artifact_root: Pat
     checkpoint = _resolve_artifact(case.checkpoint, model)
     spatial_upsampler = _resolve_artifact(case.spatial_upsampler, model) if case.spatial_upsampler is not None else None
     distilled_lora = _resolve_artifact(case.distilled_lora, model) if case.distilled_lora is not None else None
+    omni_model = _omni_model_with_pinned_artifacts(model, output_root, (spatial_upsampler, distilled_lora))
     image = _resolve_image(case)
+    request = _request(case, image)
     request_path = output_root / "request.json"
-    request_path.write_text(json.dumps(_request(case, image), indent=2) + "\n")
+    request_path.write_text(json.dumps(request, indent=2) + "\n")
 
     runner = Path(__file__).with_name("run_ltx_reference.py")
     runner_args = [
@@ -667,7 +641,7 @@ def test_ltx_matches_official(case: LTXAccuracyCase, accuracy_artifact_root: Pat
             "--output-dir",
             str(omni_output),
             "--model",
-            str(model),
+            str(omni_model),
             "--model-class-name",
             case.model_class_name,
         ]
@@ -699,18 +673,16 @@ def test_ltx_matches_official(case: LTXAccuracyCase, accuracy_artifact_root: Pat
         "spatial_upsampler_revision": (case.spatial_upsampler.revision if case.spatial_upsampler is not None else None),
         "distilled_lora_revision": case.distilled_lora.revision if case.distilled_lora is not None else None,
         "enable_layerwise_offload": enable_layerwise_offload,
-        "thresholds": asdict(case.thresholds),
-        "request": _request(case, image),
+        "thresholds": asdict(STRICT_THRESHOLDS),
+        "request": request,
         "video": video_metrics,
         "audio": audio_metrics,
     }
     (output_root / "metrics.json").write_text(json.dumps(result, indent=2) + "\n")
     print(json.dumps(result, indent=2))
 
-    assert video_metrics["ssim_mean"] >= case.thresholds.video_ssim_mean
-    assert video_metrics["ssim_min"] >= case.thresholds.video_ssim_min
-    assert video_metrics["psnr_mean_db"] >= case.thresholds.video_psnr_mean_db
-    if case.thresholds.audio_relative_l2 > 0:
-        assert audio_metrics["relative_l2"] <= case.thresholds.audio_relative_l2
-    if case.thresholds.audio_cosine_similarity > 0:
-        assert audio_metrics["cosine_similarity"] >= case.thresholds.audio_cosine_similarity
+    assert video_metrics["ssim_mean"] >= STRICT_THRESHOLDS.video_ssim_mean
+    assert video_metrics["ssim_min"] >= STRICT_THRESHOLDS.video_ssim_min
+    assert video_metrics["psnr_mean_db"] >= STRICT_THRESHOLDS.video_psnr_mean_db
+    assert audio_metrics["relative_l2"] <= STRICT_THRESHOLDS.audio_relative_l2
+    assert audio_metrics["cosine_similarity"] >= STRICT_THRESHOLDS.audio_cosine_similarity

--- a/tests/e2e/online_serving/test_ltx.py
+++ b/tests/e2e/online_serving/test_ltx.py
@@ -71,6 +71,16 @@ def _cases():
             id="two_stage",
             marks=SINGLE_CARD_MARKS,
         ),
+        pytest.param(
+            _server(
+                BASE_MODEL,
+                "LTX2TwoStageHQPipeline",
+                "--enable-layerwise-offload",
+            ),
+            3,
+            id="two_stage_hq",
+            marks=SINGLE_CARD_MARKS,
+        ),
     ]
 
 

--- a/tests/e2e/online_serving/test_ltx25.py
+++ b/tests/e2e/online_serving/test_ltx25.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-"""Online serving smokes for all four canonical LTX-2.5 pipelines."""
+"""Online serving smokes for all five canonical LTX-2.5 pipelines."""
 
 import os
 
@@ -53,6 +53,7 @@ def _cases():
     return [
         pytest.param(_server("LTX2Pipeline"), 30, id="full_one_stage", marks=SINGLE_CARD_MARKS),
         pytest.param(_server("LTX2TwoStagePipeline"), 30, id="full_two_stage", marks=SINGLE_CARD_MARKS),
+        pytest.param(_server("LTX2TwoStageHQPipeline"), 3, id="full_two_stage_hq", marks=SINGLE_CARD_MARKS),
         pytest.param(_server("LTX2DistilledOneStagePipeline"), 8, id="distilled_one_stage", marks=SINGLE_CARD_MARKS),
         pytest.param(_server("LTX2DistilledTwoStagePipeline"), 8, id="distilled_two_stage", marks=SINGLE_CARD_MARKS),
     ]

--- a/tests/model_tests/diffusion/test_alignment.py
+++ b/tests/model_tests/diffusion/test_alignment.py
@@ -28,6 +28,7 @@ EXCLUDED_MODELS = [
     "WanPipeline",
     "WanVACEPipeline",
     "LTX2TwoStagePipeline",
+    "LTX2TwoStageHQPipeline",
     "LTX2DistilledOneStagePipeline",
     "LTX2DistilledTwoStagePipeline",
     "LTX2DistilledPipeline",

--- a/vllm_omni/diffusion/models/ltx2/__init__.py
+++ b/vllm_omni/diffusion/models/ltx2/__init__.py
@@ -16,6 +16,7 @@ from vllm_omni.diffusion.models.ltx2.pipeline_ltx2 import (
 from vllm_omni.diffusion.models.ltx2.pipeline_ltx2_two_stage import (
     LTX2DistilledPipeline,
     LTX2DistilledTwoStagePipeline,
+    LTX2TwoStageHQPipeline,
     LTX2TwoStagePipeline,
 )
 
@@ -25,6 +26,7 @@ __all__ = [
     "LTX2T2VDMD2Pipeline",
     "LTX2I2VDMD2Pipeline",
     "LTX2TwoStagePipeline",
+    "LTX2TwoStageHQPipeline",
     "LTX2DistilledPipeline",
     "LTX2DistilledTwoStagePipeline",
     "get_ltx2_post_process_func",

--- a/vllm_omni/diffusion/models/ltx2/ltx2_components.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_components.py
@@ -228,7 +228,7 @@ _COMPONENT_PROFILES: dict[tuple[str, str], LTXComponentProfile] = {
 
 def resolve_ltx_checkpoint_kind(pipeline_kind: str) -> LTXCheckpointKind | None:
     """Derive checkpoint requirements from the execution contract."""
-    if pipeline_kind in {"one_stage", "two_stage"}:
+    if pipeline_kind in {"one_stage", "two_stage", "two_stage_hq"}:
         return "regular"
     if pipeline_kind in {"distilled_one_stage", "distilled_two_stage"}:
         return "distilled"

--- a/vllm_omni/diffusion/models/ltx2/ltx2_components.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_components.py
@@ -213,6 +213,8 @@ _COMPONENT_PROFILES: dict[tuple[str, str], LTXComponentProfile] = {
     ("two_stage", "2"): LTX2_TWO_STAGE_COMPONENT_PROFILE,
     ("two_stage", "2.3"): LTX23_TWO_STAGE_COMPONENT_PROFILE,
     ("two_stage", "2.5"): LTX25_TWO_STAGE_COMPONENT_PROFILE,
+    ("two_stage_hq", "2.3"): LTX23_TWO_STAGE_COMPONENT_PROFILE,
+    ("two_stage_hq", "2.5"): LTX25_TWO_STAGE_COMPONENT_PROFILE,
     ("distilled_one_stage", "2"): LTX2_DISTILLED_ONE_STAGE_COMPONENT_PROFILE,
     ("distilled_one_stage", "2.3"): LTX23_DISTILLED_ONE_STAGE_COMPONENT_PROFILE,
     ("distilled_one_stage", "2.5"): LTX25_DISTILLED_ONE_STAGE_COMPONENT_PROFILE,

--- a/vllm_omni/diffusion/models/ltx2/ltx2_components.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_components.py
@@ -639,14 +639,18 @@ def initialize_pipeline_components(pipeline: Any, od_config: Any) -> None:
         upsampler_config = os.path.join(model, "latent_upsampler", "config.json")
         if os.path.isfile(upsampler_config) or not local_files_only:
             try:
-                pipeline.latent_upsampler = _load_component(
-                    LTX2LatentUpsamplerModel,
-                    model,
-                    "latent_upsampler",
-                    local_files_only=local_files_only,
-                    dtype=dtype,
-                    revision=revision,
-                )
+                # Diffusers builds the rational-resampler kernel with Long
+                # tensors; constructing it under a CUDA default-device context
+                # attempts an unsupported Long addmm before weights are loaded.
+                with torch.device("cpu"):
+                    pipeline.latent_upsampler = _load_component(
+                        LTX2LatentUpsamplerModel,
+                        model,
+                        "latent_upsampler",
+                        local_files_only=local_files_only,
+                        dtype=dtype,
+                        revision=revision,
+                    )
             except (OSError, ValueError):
                 if profile.latent_upsampler_filename is None or profile.artifact_repo_id is None:
                     raise

--- a/vllm_omni/diffusion/models/ltx2/ltx2_conditioning.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_conditioning.py
@@ -48,6 +48,23 @@ def _repeat_prompt_tensor_for_outputs(tensor: torch.Tensor, num_outputs: int) ->
     return tensor.repeat_interleave(num_outputs, dim=0)
 
 
+def restore_conditioned_video_latents(
+    value: torch.Tensor,
+    clean: torch.Tensor | None,
+    conditioning_mask: torch.Tensor | None,
+) -> torch.Tensor:
+    """Restore packed I2V conditioning tokens using official fp32 blending."""
+    if clean is None or conditioning_mask is None:
+        return value
+    if value.shape != clean.shape or value.shape[:2] != conditioning_mask.shape:
+        raise ValueError(
+            "LTX conditioned video tensors must share packed batch/token dimensions: "
+            f"value={tuple(value.shape)}, clean={tuple(clean.shape)}, mask={tuple(conditioning_mask.shape)}."
+        )
+    mask = conditioning_mask.unsqueeze(-1).float()
+    return (value.float() * (1.0 - mask) + clean.float() * mask).to(value.dtype)
+
+
 def _preprocess_i2v_pil_images(
     images: PIL.Image.Image | list[PIL.Image.Image],
     *,

--- a/vllm_omni/diffusion/models/ltx2/ltx2_denoise.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_denoise.py
@@ -9,6 +9,7 @@ import copy
 import math
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
+from functools import partial
 from typing import TYPE_CHECKING, Any, Protocol
 
 import torch
@@ -16,8 +17,14 @@ from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion import retri
 
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 
+from .ltx2_conditioning import restore_conditioned_video_latents
 from .ltx2_guidance import euler_step_from_velocity
-from .ltx2_latents import LTXAVState, unpack_audio_latents, unpad_audio_latents
+from .ltx2_latents import LTXAVState, clear_audio_padding, unpack_audio_latents, unpad_audio_latents
+from .ltx2_res2s import (
+    LTXRes2sExecutor,
+    build_ltx2_res2s_sigmas,
+    normalized_res2s_audio_noise,
+)
 
 if TYPE_CHECKING:
     from .ltx2_conditioning import LTXPromptContext
@@ -66,6 +73,7 @@ class LTXDenoiseContext:
     audio_attention_mask: torch.Tensor | None = None
     conditioning_mask: torch.Tensor | None = None
     conditioning_mask_for_model: torch.Tensor | None = None
+    clean_video_latents: torch.Tensor | None = None
 
 
 @dataclass
@@ -328,6 +336,8 @@ def prepare_scheduler_stage(
     latent_height: int,
     latent_width: int,
     use_official_sigma_schedule: bool,
+    video_token_count: int | None = None,
+    use_latent_dependent_sigma_schedule: bool = False,
     image_conditioned: bool = False,
     sampler: str = "euler",
     generator: torch.Generator | list[torch.Generator] | None = None,
@@ -360,6 +370,25 @@ def prepare_scheduler_stage(
 
     if sigmas is None and timesteps is None and use_official_sigma_schedule:
         scheduler_sigmas = _official_ltx_sigmas(pipeline.scheduler, request_inputs.num_inference_steps, device)
+        timesteps_tensor = _set_scheduler_sigmas(pipeline.scheduler, scheduler_sigmas)
+        _set_scheduler_sigmas(audio_scheduler, scheduler_sigmas.clone())
+        return audio_scheduler, video_audio_step_adapter, timesteps_tensor
+
+    if sigmas is None and timesteps is None and use_latent_dependent_sigma_schedule:
+        if video_token_count is None:
+            raise ValueError("A latent-dependent LTX sigma schedule requires the packed video token count.")
+        config = pipeline.scheduler.config
+        terminal = config.get("shift_terminal")
+        scheduler_sigmas = build_ltx2_res2s_sigmas(
+            request_inputs.num_inference_steps,
+            video_token_count,
+            device=device,
+            base_seq_len=config.get("base_image_seq_len", 1024),
+            max_seq_len=config.get("max_image_seq_len", 4096),
+            base_shift=config.get("base_shift", 0.95),
+            max_shift=config.get("max_shift", 2.05),
+            terminal=0.1 if terminal is None else terminal,
+        )
         timesteps_tensor = _set_scheduler_sigmas(pipeline.scheduler, scheduler_sigmas)
         _set_scheduler_sigmas(audio_scheduler, scheduler_sigmas.clone())
         return audio_scheduler, video_audio_step_adapter, timesteps_tensor
@@ -496,6 +525,57 @@ def step_denoised_latents(
     )
 
 
+def run_res2s_phase(
+    pipeline: Any,
+    state: LTXAVState,
+    forward_ctx: LTXForwardContext,
+    denoise_ctx: LTXDenoiseContext,
+) -> LTXAVState:
+    """Run the official stochastic second-order sampler for one HQ phase."""
+
+    def predict_x0(current: LTXAVState, sigma: torch.Tensor) -> LTXAVState:
+        denoise_ctx.latents = current.video
+        denoise_ctx.audio_latents = current.audio
+        timestep_scale = pipeline.scheduler.config.get("num_train_timesteps", 1000)
+        timestep = sigma.to(device=current.video.device) * timestep_scale
+        video, audio = pipeline._predict_denoised_for_step(
+            0,
+            timestep,
+            current,
+            forward_ctx,
+            denoise_ctx,
+            video_sigma=sigma,
+            audio_sigma=sigma,
+        )
+        return LTXAVState(video=video, audio=audio)
+
+    def restore_video(value: torch.Tensor) -> torch.Tensor:
+        return restore_conditioned_video_latents(
+            value,
+            denoise_ctx.clean_video_latents,
+            denoise_ctx.conditioning_mask,
+        )
+
+    def restore_audio(value: torch.Tensor) -> torch.Tensor:
+        return clear_audio_padding(value, forward_ctx.original_audio_num_frames)
+
+    sigmas = pipeline.scheduler.sigmas
+    with pipeline.progress_bar(total=len(sigmas) - 1) as progress_bar:
+        return LTXRes2sExecutor.run(
+            state,
+            sigmas,
+            predict_x0,
+            restore_video=restore_video if denoise_ctx.conditioning_mask is not None else None,
+            restore_audio=restore_audio,
+            model_dtype=state.video.dtype,
+            audio_noise_fn=partial(
+                normalized_res2s_audio_noise,
+                logical_token_count=forward_ctx.original_audio_num_frames,
+            ),
+            on_step=progress_bar.update,
+        )
+
+
 class LTXPhaseExecutor:
     """Prepare and execute one LTX phase without owning model modules."""
 
@@ -553,7 +633,9 @@ class LTXPhaseExecutor:
             latent_num_frames=latent_num_frames,
             latent_height=latent_height,
             latent_width=latent_width,
+            video_token_count=latents.shape[1],
             use_official_sigma_schedule=phase_recipe.use_official_sigma_schedule,
+            use_latent_dependent_sigma_schedule=phase_recipe.use_latent_dependent_sigma_schedule,
             image_conditioned=conditioning_mask is not None,
             sampler=phase_recipe.sampler,
             generator=request_inputs.generator,
@@ -598,20 +680,25 @@ class LTXPhaseExecutor:
                 else None
             ),
             conditioning_mask=conditioning_mask,
+            clean_video_latents=latents.clone() if conditioning_mask is not None else None,
         )
         denoise_ctx = pipeline._prepare_denoise_context_for_guidance(forward_ctx, denoise_ctx)
-        state = LTXDenoiseExecutor.run(
-            pipeline,
-            LTXAVState(video=denoise_ctx.latents, audio=denoise_ctx.audio_latents),
-            forward_ctx.timesteps,
-            lambda index, timestep, state: pipeline._denoise_step(
-                index,
-                timestep,
-                state,
-                forward_ctx,
-                denoise_ctx,
-            ),
-        )
+        initial_state = LTXAVState(video=denoise_ctx.latents, audio=denoise_ctx.audio_latents)
+        if phase_recipe.sampler == "res2s":
+            state = run_res2s_phase(pipeline, initial_state, forward_ctx, denoise_ctx)
+        else:
+            state = LTXDenoiseExecutor.run(
+                pipeline,
+                initial_state,
+                forward_ctx.timesteps,
+                lambda index, timestep, state: pipeline._denoise_step(
+                    index,
+                    timestep,
+                    state,
+                    forward_ctx,
+                    denoise_ctx,
+                ),
+            )
         denoise_ctx.latents = state.video
         denoise_ctx.audio_latents = state.audio
         latents, audio_latents = pipeline._unpack_and_denormalize_stage(

--- a/vllm_omni/diffusion/models/ltx2/ltx2_guidance.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_guidance.py
@@ -386,21 +386,96 @@ class LTXGuidanceExecutor:
         )
         return velocity_from_x0(sample, guided, sigma)
 
-    def predict_parallel_denoised(
+    @staticmethod
+    def _pass_contexts(
+        prompt: Any,
+        passes: tuple[LTXDenoisePass, ...],
+    ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+        video_contexts: list[torch.Tensor] = []
+        audio_contexts: list[torch.Tensor] = []
+        for denoise_pass in passes:
+            video_context = (
+                prompt.negative_connector_prompt_embeds
+                if denoise_pass.negative_video_context
+                else prompt.positive_connector_prompt_embeds
+            )
+            audio_context = (
+                prompt.negative_connector_audio_prompt_embeds
+                if denoise_pass.negative_audio_context
+                else prompt.positive_connector_audio_prompt_embeds
+            )
+            if video_context is None or audio_context is None:
+                raise ValueError("Negative prompt context is required when LTX CFG is enabled.")
+            video_contexts.append(video_context)
+            audio_contexts.append(audio_context)
+        return video_contexts, audio_contexts
+
+    def _execute_model_passes(
         self,
         pipeline: Any,
-        plan: LTXGuidancePlan,
-        index: int,
+        execution_plan: LTXGuidancePlan,
         timestep: torch.Tensor,
         state: LTXAVState,
         forward_ctx: LTXForwardContext,
         denoise_ctx: LTXDenoiseContext,
-        *,
-        video_sigma: torch.Tensor,
-        audio_sigma: torch.Tensor,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Run guidance-parallel prediction and return guided x0 tensors."""
-        del index
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[torch.Tensor, ...]]:
+        """Execute one rank's guidance passes and return raw velocity slots."""
+        prompt = forward_ctx.prompt_context
+        video_contexts, audio_contexts = self._pass_contexts(prompt, execution_plan.passes)
+        pass_count = len(execution_plan.passes)
+        video_input = _repeat_batch(state.video, pass_count).to(prompt.positive_connector_prompt_embeds.dtype)
+        audio_input = _repeat_batch(state.audio, pass_count).to(prompt.positive_connector_audio_prompt_embeds.dtype)
+        attention_kwargs = dict(forward_ctx.attention_kwargs or {})
+        perturbations = build_perturbation_kwargs(execution_plan, state.video.shape[0], video_input)
+        if perturbations:
+            attention_kwargs["ltx_perturbation_kwargs"] = perturbations
+        kwargs = pipeline._build_transformer_kwargs(
+            forward_ctx,
+            denoise_ctx,
+            hidden_states=video_input,
+            audio_hidden_states=audio_input,
+            encoder_hidden_states=torch.cat(video_contexts),
+            audio_encoder_hidden_states=torch.cat(audio_contexts),
+            encoder_attention_mask=None,
+            audio_encoder_attention_mask=None,
+            ts=timestep.expand(video_input.shape[0]),
+            attention_kwargs=attention_kwargs,
+        )
+        with pipeline._transformer_cache_context("guided"):
+            video_velocity, audio_velocity = pipeline.transformer(**kwargs)
+        return video_velocity.chunk(pass_count), audio_velocity.chunk(pass_count)
+
+    def _execute_guidance_plan(
+        self,
+        pipeline: Any,
+        plan: LTXGuidancePlan,
+        timestep: torch.Tensor,
+        state: LTXAVState,
+        forward_ctx: LTXForwardContext,
+        denoise_ctx: LTXDenoiseContext,
+    ) -> tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]]:
+        video_slots, audio_slots = self._execute_model_passes(
+            pipeline,
+            plan,
+            timestep,
+            state,
+            forward_ctx,
+            denoise_ctx,
+        )
+        return (
+            dict(zip(plan.names, video_slots, strict=True)),
+            dict(zip(plan.names, audio_slots, strict=True)),
+        )
+
+    def _execute_parallel_guidance_plan(
+        self,
+        pipeline: Any,
+        plan: LTXGuidancePlan,
+        timestep: torch.Tensor,
+        state: LTXAVState,
+        forward_ctx: LTXForwardContext,
+        denoise_ctx: LTXDenoiseContext,
+    ) -> tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]]:
         guidance_world_size = get_guidance_parallel_world_size()
         self.validate_guidance_world_size(plan, guidance_world_size)
         guidance_rank = get_guidance_parallel_rank()
@@ -417,49 +492,14 @@ class LTXGuidanceExecutor:
             plan.passes[0] if pass_index is None else plan.passes[pass_index] for pass_index in padded_pass_indices
         )
         local_plan = LTXGuidancePlan(spec=plan.spec, passes=local_passes)
-        prompt = forward_ctx.prompt_context
-        video_contexts: list[torch.Tensor] = []
-        audio_contexts: list[torch.Tensor] = []
-        for denoise_pass in local_passes:
-            video_context = (
-                prompt.negative_connector_prompt_embeds
-                if denoise_pass.negative_video_context
-                else prompt.positive_connector_prompt_embeds
-            )
-            audio_context = (
-                prompt.negative_connector_audio_prompt_embeds
-                if denoise_pass.negative_audio_context
-                else prompt.positive_connector_audio_prompt_embeds
-            )
-            if video_context is None or audio_context is None:
-                raise ValueError("Negative prompt context is required when LTX CFG is enabled.")
-            video_contexts.append(video_context)
-            audio_contexts.append(audio_context)
-
-        video_input = _repeat_batch(state.video, model_pass_count).to(prompt.positive_connector_prompt_embeds.dtype)
-        audio_input = _repeat_batch(state.audio, model_pass_count).to(
-            prompt.positive_connector_audio_prompt_embeds.dtype
-        )
-        attention_kwargs = dict(forward_ctx.attention_kwargs or {})
-        perturbations = build_perturbation_kwargs(local_plan, state.video.shape[0], video_input)
-        if perturbations:
-            attention_kwargs["ltx_perturbation_kwargs"] = perturbations
-        kwargs = pipeline._build_transformer_kwargs(
+        local_video_slots, local_audio_slots = self._execute_model_passes(
+            pipeline,
+            local_plan,
+            timestep,
+            state,
             forward_ctx,
             denoise_ctx,
-            hidden_states=video_input,
-            audio_hidden_states=audio_input,
-            encoder_hidden_states=torch.cat(video_contexts),
-            audio_encoder_hidden_states=torch.cat(audio_contexts),
-            encoder_attention_mask=None,
-            audio_encoder_attention_mask=None,
-            ts=timestep.expand(video_input.shape[0]),
-            attention_kwargs=attention_kwargs,
         )
-        with pipeline._transformer_cache_context("guided"):
-            local_video, local_audio = pipeline.transformer(**kwargs)
-        local_video_slots = local_video.chunk(model_pass_count)
-        local_audio_slots = local_audio.chunk(model_pass_count)
 
         group = get_guidance_parallel_group()
         gathered_video_slots = [group.all_gather(value, separate_tensors=True) for value in local_video_slots]
@@ -472,6 +512,31 @@ class LTXGuidanceExecutor:
             slot_index = pass_index // guidance_world_size
             video_splits[denoise_pass.name] = gathered_video_slots[slot_index][owner_rank]
             audio_splits[denoise_pass.name] = gathered_audio_slots[slot_index][owner_rank]
+        return video_splits, audio_splits
+
+    def predict_parallel_denoised(
+        self,
+        pipeline: Any,
+        plan: LTXGuidancePlan,
+        index: int,
+        timestep: torch.Tensor,
+        state: LTXAVState,
+        forward_ctx: LTXForwardContext,
+        denoise_ctx: LTXDenoiseContext,
+        *,
+        video_sigma: torch.Tensor,
+        audio_sigma: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Run guidance-parallel prediction and return guided x0 tensors."""
+        del index
+        video_splits, audio_splits = self._execute_parallel_guidance_plan(
+            pipeline,
+            plan,
+            timestep,
+            state,
+            forward_ctx,
+            denoise_ctx,
+        )
 
         return (
             self._guide_modality_denoised(
@@ -501,78 +566,14 @@ class LTXGuidanceExecutor:
         denoise_ctx: LTXDenoiseContext,
         preserve_positive_velocity: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        guidance_world_size = get_guidance_parallel_world_size()
-        self.validate_guidance_world_size(plan, guidance_world_size)
-        guidance_rank = get_guidance_parallel_rank()
-        assignments = self._parallel_assignments(len(plan.passes), guidance_world_size)
-        local_pass_indices = assignments[guidance_rank]
-        model_pass_count = max(len(indices) for indices in assignments)
-
-        # Every rank executes and gathers the same number of slots. Shorter
-        # assignments use a conditional pass whose output is discarded.
-        padded_pass_indices: list[int | None] = local_pass_indices + [None] * (
-            model_pass_count - len(local_pass_indices)
-        )
-        local_passes = tuple(
-            plan.passes[0] if pass_index is None else plan.passes[pass_index] for pass_index in padded_pass_indices
-        )
-        local_plan = LTXGuidancePlan(spec=plan.spec, passes=local_passes)
-
-        prompt = forward_ctx.prompt_context
-        video_contexts: list[torch.Tensor] = []
-        audio_contexts: list[torch.Tensor] = []
-        for denoise_pass in local_passes:
-            video_context = (
-                prompt.negative_connector_prompt_embeds
-                if denoise_pass.negative_video_context
-                else prompt.positive_connector_prompt_embeds
-            )
-            audio_context = (
-                prompt.negative_connector_audio_prompt_embeds
-                if denoise_pass.negative_audio_context
-                else prompt.positive_connector_audio_prompt_embeds
-            )
-            if video_context is None or audio_context is None:
-                raise ValueError("Negative prompt context is required when LTX CFG is enabled.")
-            video_contexts.append(video_context)
-            audio_contexts.append(audio_context)
-
-        video_input = _repeat_batch(state.video, model_pass_count).to(prompt.positive_connector_prompt_embeds.dtype)
-        audio_input = _repeat_batch(state.audio, model_pass_count).to(
-            prompt.positive_connector_audio_prompt_embeds.dtype
-        )
-        attention_kwargs = dict(forward_ctx.attention_kwargs or {})
-        perturbations = build_perturbation_kwargs(local_plan, state.video.shape[0], video_input)
-        if perturbations:
-            attention_kwargs["ltx_perturbation_kwargs"] = perturbations
-        kwargs = pipeline._build_transformer_kwargs(
+        video_splits, audio_splits = self._execute_parallel_guidance_plan(
+            pipeline,
+            plan,
+            timestep,
+            state,
             forward_ctx,
             denoise_ctx,
-            hidden_states=video_input,
-            audio_hidden_states=audio_input,
-            encoder_hidden_states=torch.cat(video_contexts),
-            audio_encoder_hidden_states=torch.cat(audio_contexts),
-            encoder_attention_mask=None,
-            audio_encoder_attention_mask=None,
-            ts=timestep.expand(video_input.shape[0]),
-            attention_kwargs=attention_kwargs,
         )
-        with pipeline._transformer_cache_context("guided"):
-            local_video, local_audio = pipeline.transformer(**kwargs)
-        local_video_slots = local_video.chunk(model_pass_count)
-        local_audio_slots = local_audio.chunk(model_pass_count)
-
-        group = get_guidance_parallel_group()
-        gathered_video_slots = [group.all_gather(value, separate_tensors=True) for value in local_video_slots]
-        gathered_audio_slots = [group.all_gather(value, separate_tensors=True) for value in local_audio_slots]
-
-        video_splits: dict[str, torch.Tensor] = {}
-        audio_splits: dict[str, torch.Tensor] = {}
-        for pass_index, denoise_pass in enumerate(plan.passes):
-            owner_rank = pass_index % guidance_world_size
-            slot_index = pass_index // guidance_world_size
-            video_splits[denoise_pass.name] = gathered_video_slots[slot_index][owner_rank]
-            audio_splits[denoise_pass.name] = gathered_audio_slots[slot_index][owner_rank]
 
         video_sigma = pipeline.scheduler.sigmas[index]
         return (
@@ -621,48 +622,14 @@ class LTXGuidanceExecutor:
                 audio_sigma=audio_sigma,
             )
 
-        prompt = forward_ctx.prompt_context
-        video_contexts: list[torch.Tensor] = []
-        audio_contexts: list[torch.Tensor] = []
-        for denoise_pass in plan.passes:
-            video_context = (
-                prompt.negative_connector_prompt_embeds
-                if denoise_pass.negative_video_context
-                else prompt.positive_connector_prompt_embeds
-            )
-            audio_context = (
-                prompt.negative_connector_audio_prompt_embeds
-                if denoise_pass.negative_audio_context
-                else prompt.positive_connector_audio_prompt_embeds
-            )
-            if video_context is None or audio_context is None:
-                raise ValueError("Negative prompt context is required when LTX CFG is enabled.")
-            video_contexts.append(video_context)
-            audio_contexts.append(audio_context)
-
-        pass_count = len(plan.passes)
-        video_input = _repeat_batch(state.video, pass_count).to(prompt.positive_connector_prompt_embeds.dtype)
-        audio_input = _repeat_batch(state.audio, pass_count).to(prompt.positive_connector_audio_prompt_embeds.dtype)
-        attention_kwargs = dict(forward_ctx.attention_kwargs or {})
-        perturbations = build_perturbation_kwargs(plan, state.video.shape[0], video_input)
-        if perturbations:
-            attention_kwargs["ltx_perturbation_kwargs"] = perturbations
-        kwargs = pipeline._build_transformer_kwargs(
+        video_splits, audio_splits = self._execute_guidance_plan(
+            pipeline,
+            plan,
+            timestep,
+            state,
             forward_ctx,
             denoise_ctx,
-            hidden_states=video_input,
-            audio_hidden_states=audio_input,
-            encoder_hidden_states=torch.cat(video_contexts),
-            audio_encoder_hidden_states=torch.cat(audio_contexts),
-            encoder_attention_mask=None,
-            audio_encoder_attention_mask=None,
-            ts=timestep.expand(video_input.shape[0]),
-            attention_kwargs=attention_kwargs,
         )
-        with pipeline._transformer_cache_context("guided"):
-            video_velocity, audio_velocity = pipeline.transformer(**kwargs)
-        video_splits = dict(zip(plan.names, video_velocity.chunk(pass_count), strict=True))
-        audio_splits = dict(zip(plan.names, audio_velocity.chunk(pass_count), strict=True))
 
         return (
             self._guide_modality_denoised(
@@ -707,48 +674,14 @@ class LTXGuidanceExecutor:
                 preserve_positive_velocity=preserve_positive_velocity,
             )
 
-        prompt = forward_ctx.prompt_context
-        video_contexts: list[torch.Tensor] = []
-        audio_contexts: list[torch.Tensor] = []
-        for denoise_pass in plan.passes:
-            video_context = (
-                prompt.negative_connector_prompt_embeds
-                if denoise_pass.negative_video_context
-                else prompt.positive_connector_prompt_embeds
-            )
-            audio_context = (
-                prompt.negative_connector_audio_prompt_embeds
-                if denoise_pass.negative_audio_context
-                else prompt.positive_connector_audio_prompt_embeds
-            )
-            if video_context is None or audio_context is None:
-                raise ValueError("Negative prompt context is required when LTX CFG is enabled.")
-            video_contexts.append(video_context)
-            audio_contexts.append(audio_context)
-
-        pass_count = len(plan.passes)
-        video_input = _repeat_batch(state.video, pass_count).to(prompt.positive_connector_prompt_embeds.dtype)
-        audio_input = _repeat_batch(state.audio, pass_count).to(prompt.positive_connector_audio_prompt_embeds.dtype)
-        attention_kwargs = dict(forward_ctx.attention_kwargs or {})
-        perturbations = build_perturbation_kwargs(plan, state.video.shape[0], video_input)
-        if perturbations:
-            attention_kwargs["ltx_perturbation_kwargs"] = perturbations
-        kwargs = pipeline._build_transformer_kwargs(
+        video_splits, audio_splits = self._execute_guidance_plan(
+            pipeline,
+            plan,
+            timestep,
+            state,
             forward_ctx,
             denoise_ctx,
-            hidden_states=video_input,
-            audio_hidden_states=audio_input,
-            encoder_hidden_states=torch.cat(video_contexts),
-            audio_encoder_hidden_states=torch.cat(audio_contexts),
-            encoder_attention_mask=None,
-            audio_encoder_attention_mask=None,
-            ts=timestep.expand(video_input.shape[0]),
-            attention_kwargs=attention_kwargs,
         )
-        with pipeline._transformer_cache_context("guided"):
-            video_velocity, audio_velocity = pipeline.transformer(**kwargs)
-        video_splits = dict(zip(plan.names, video_velocity.chunk(pass_count), strict=True))
-        audio_splits = dict(zip(plan.names, audio_velocity.chunk(pass_count), strict=True))
 
         return (
             self._guide_modality(

--- a/vllm_omni/diffusion/models/ltx2/ltx2_guidance.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_guidance.py
@@ -342,6 +342,28 @@ class LTXGuidanceExecutor:
         return velocity_from_x0(sample, guided_x0, sigma)
 
     @staticmethod
+    def _guide_modality_denoised(
+        sample: torch.Tensor,
+        splits: dict[str, torch.Tensor],
+        sigma: torch.Tensor,
+        guidance: LTXModalityGuidance,
+        *,
+        model_sigma: torch.Tensor | None = None,
+        rescale_token_count: int | None = None,
+    ) -> torch.Tensor:
+        """Combine velocity predictions directly into a guided x0 tensor."""
+        model_sigma = sigma if model_sigma is None else model_sigma
+        x0 = {name: x0_from_velocity(sample, value, model_sigma).contiguous() for name, value in splits.items()}
+        return combine_guided_x0(
+            cond=x0["cond"],
+            uncond_text=x0.get("uncond", 0.0),
+            uncond_perturbed=x0.get("ptb", 0.0),
+            uncond_modality=x0.get("mod", 0.0),
+            guidance=guidance,
+            rescale_token_count=rescale_token_count,
+        )
+
+    @staticmethod
     def _guide_modality(
         sample: torch.Tensor,
         splits: dict[str, torch.Tensor],
@@ -354,20 +376,119 @@ class LTXGuidanceExecutor:
     ) -> torch.Tensor:
         if preserve_positive_velocity and tuple(splits) == ("cond",):
             return splits["cond"]
-        model_sigma = sigma if model_sigma is None else model_sigma
-        # Official guidance reduces contiguous BSC tensors. The fused
-        # transformer output may be channel-major after splitting, which
-        # changes fp32 reduction order and can cross bf16 rounding bounds.
-        x0 = {name: x0_from_velocity(sample, value, model_sigma).contiguous() for name, value in splits.items()}
-        guided = combine_guided_x0(
-            cond=x0["cond"],
-            uncond_text=x0.get("uncond", 0.0),
-            uncond_perturbed=x0.get("ptb", 0.0),
-            uncond_modality=x0.get("mod", 0.0),
-            guidance=guidance,
+        guided = LTXGuidanceExecutor._guide_modality_denoised(
+            sample,
+            splits,
+            sigma,
+            guidance,
+            model_sigma=model_sigma,
             rescale_token_count=rescale_token_count,
         )
         return velocity_from_x0(sample, guided, sigma)
+
+    def predict_parallel_denoised(
+        self,
+        pipeline: Any,
+        plan: LTXGuidancePlan,
+        index: int,
+        timestep: torch.Tensor,
+        state: LTXAVState,
+        forward_ctx: LTXForwardContext,
+        denoise_ctx: LTXDenoiseContext,
+        *,
+        video_sigma: torch.Tensor,
+        audio_sigma: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Run guidance-parallel prediction and return guided x0 tensors."""
+        del index
+        guidance_world_size = get_guidance_parallel_world_size()
+        self.validate_guidance_world_size(plan, guidance_world_size)
+        guidance_rank = get_guidance_parallel_rank()
+        assignments = self._parallel_assignments(len(plan.passes), guidance_world_size)
+        local_pass_indices = assignments[guidance_rank]
+        model_pass_count = max(len(indices) for indices in assignments)
+
+        # Every rank executes and gathers the same number of slots. Shorter
+        # assignments use a conditional pass whose output is discarded.
+        padded_pass_indices: list[int | None] = local_pass_indices + [None] * (
+            model_pass_count - len(local_pass_indices)
+        )
+        local_passes = tuple(
+            plan.passes[0] if pass_index is None else plan.passes[pass_index] for pass_index in padded_pass_indices
+        )
+        local_plan = LTXGuidancePlan(spec=plan.spec, passes=local_passes)
+        prompt = forward_ctx.prompt_context
+        video_contexts: list[torch.Tensor] = []
+        audio_contexts: list[torch.Tensor] = []
+        for denoise_pass in local_passes:
+            video_context = (
+                prompt.negative_connector_prompt_embeds
+                if denoise_pass.negative_video_context
+                else prompt.positive_connector_prompt_embeds
+            )
+            audio_context = (
+                prompt.negative_connector_audio_prompt_embeds
+                if denoise_pass.negative_audio_context
+                else prompt.positive_connector_audio_prompt_embeds
+            )
+            if video_context is None or audio_context is None:
+                raise ValueError("Negative prompt context is required when LTX CFG is enabled.")
+            video_contexts.append(video_context)
+            audio_contexts.append(audio_context)
+
+        video_input = _repeat_batch(state.video, model_pass_count).to(prompt.positive_connector_prompt_embeds.dtype)
+        audio_input = _repeat_batch(state.audio, model_pass_count).to(
+            prompt.positive_connector_audio_prompt_embeds.dtype
+        )
+        attention_kwargs = dict(forward_ctx.attention_kwargs or {})
+        perturbations = build_perturbation_kwargs(local_plan, state.video.shape[0], video_input)
+        if perturbations:
+            attention_kwargs["ltx_perturbation_kwargs"] = perturbations
+        kwargs = pipeline._build_transformer_kwargs(
+            forward_ctx,
+            denoise_ctx,
+            hidden_states=video_input,
+            audio_hidden_states=audio_input,
+            encoder_hidden_states=torch.cat(video_contexts),
+            audio_encoder_hidden_states=torch.cat(audio_contexts),
+            encoder_attention_mask=None,
+            audio_encoder_attention_mask=None,
+            ts=timestep.expand(video_input.shape[0]),
+            attention_kwargs=attention_kwargs,
+        )
+        with pipeline._transformer_cache_context("guided"):
+            local_video, local_audio = pipeline.transformer(**kwargs)
+        local_video_slots = local_video.chunk(model_pass_count)
+        local_audio_slots = local_audio.chunk(model_pass_count)
+
+        group = get_guidance_parallel_group()
+        gathered_video_slots = [group.all_gather(value, separate_tensors=True) for value in local_video_slots]
+        gathered_audio_slots = [group.all_gather(value, separate_tensors=True) for value in local_audio_slots]
+
+        video_splits: dict[str, torch.Tensor] = {}
+        audio_splits: dict[str, torch.Tensor] = {}
+        for pass_index, denoise_pass in enumerate(plan.passes):
+            owner_rank = pass_index % guidance_world_size
+            slot_index = pass_index // guidance_world_size
+            video_splits[denoise_pass.name] = gathered_video_slots[slot_index][owner_rank]
+            audio_splits[denoise_pass.name] = gathered_audio_slots[slot_index][owner_rank]
+
+        return (
+            self._guide_modality_denoised(
+                state.video,
+                video_splits,
+                video_sigma,
+                plan.spec.video,
+                model_sigma=pipeline._video_guidance_model_sigma(video_sigma, denoise_ctx),
+            ),
+            self._guide_modality_denoised(
+                state.audio,
+                audio_splits,
+                audio_sigma,
+                plan.spec.audio,
+                rescale_token_count=forward_ctx.original_audio_num_frames,
+            ),
+        )
 
     def predict_parallel_guidance(
         self,
@@ -469,6 +590,96 @@ class LTXGuidanceExecutor:
                 forward_ctx.audio_scheduler.sigmas[index],
                 plan.spec.audio,
                 preserve_positive_velocity=preserve_positive_velocity,
+                rescale_token_count=forward_ctx.original_audio_num_frames,
+            ),
+        )
+
+    def predict_denoised(
+        self,
+        pipeline: Any,
+        plan: LTXGuidancePlan,
+        index: int,
+        timestep: torch.Tensor,
+        state: LTXAVState,
+        forward_ctx: LTXForwardContext,
+        denoise_ctx: LTXDenoiseContext,
+        *,
+        video_sigma: torch.Tensor,
+        audio_sigma: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return guided video/audio x0 predictions at an explicit sigma."""
+        if forward_ctx.guidance_parallel_ready:
+            return self.predict_parallel_denoised(
+                pipeline,
+                plan,
+                index,
+                timestep,
+                state,
+                forward_ctx,
+                denoise_ctx,
+                video_sigma=video_sigma,
+                audio_sigma=audio_sigma,
+            )
+
+        prompt = forward_ctx.prompt_context
+        video_contexts: list[torch.Tensor] = []
+        audio_contexts: list[torch.Tensor] = []
+        for denoise_pass in plan.passes:
+            video_context = (
+                prompt.negative_connector_prompt_embeds
+                if denoise_pass.negative_video_context
+                else prompt.positive_connector_prompt_embeds
+            )
+            audio_context = (
+                prompt.negative_connector_audio_prompt_embeds
+                if denoise_pass.negative_audio_context
+                else prompt.positive_connector_audio_prompt_embeds
+            )
+            if video_context is None or audio_context is None:
+                raise ValueError("Negative prompt context is required when LTX CFG is enabled.")
+            video_contexts.append(video_context)
+            audio_contexts.append(audio_context)
+
+        pass_count = len(plan.passes)
+        video_input = _repeat_batch(state.video, pass_count).to(prompt.positive_connector_prompt_embeds.dtype)
+        audio_input = _repeat_batch(state.audio, pass_count).to(prompt.positive_connector_audio_prompt_embeds.dtype)
+        attention_kwargs = dict(forward_ctx.attention_kwargs or {})
+        perturbations = build_perturbation_kwargs(plan, state.video.shape[0], video_input)
+        if perturbations:
+            attention_kwargs["ltx_perturbation_kwargs"] = perturbations
+        kwargs = pipeline._build_transformer_kwargs(
+            forward_ctx,
+            denoise_ctx,
+            hidden_states=video_input,
+            audio_hidden_states=audio_input,
+            encoder_hidden_states=torch.cat(video_contexts),
+            audio_encoder_hidden_states=torch.cat(audio_contexts),
+            encoder_attention_mask=None,
+            audio_encoder_attention_mask=None,
+            ts=timestep.expand(video_input.shape[0]),
+            attention_kwargs=attention_kwargs,
+        )
+        with pipeline._transformer_cache_context("guided"):
+            video_velocity, audio_velocity = pipeline.transformer(**kwargs)
+        video_splits = dict(zip(plan.names, video_velocity.chunk(pass_count), strict=True))
+        audio_splits = dict(zip(plan.names, audio_velocity.chunk(pass_count), strict=True))
+
+        return (
+            self._guide_modality_denoised(
+                state.video,
+                video_splits,
+                video_sigma,
+                plan.spec.video,
+                model_sigma=pipeline._video_guidance_model_sigma(
+                    video_sigma,
+                    denoise_ctx,
+                ),
+            ),
+            self._guide_modality_denoised(
+                state.audio,
+                audio_splits,
+                audio_sigma,
+                plan.spec.audio,
                 rescale_token_count=forward_ctx.original_audio_num_frames,
             ),
         )

--- a/vllm_omni/diffusion/models/ltx2/ltx2_phase_adapter.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_phase_adapter.py
@@ -10,6 +10,7 @@ adapter-capable while retaining their quantization and tensor-parallel paths.
 
 from __future__ import annotations
 
+import math
 from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -190,11 +191,11 @@ class _AdapterPiece(nn.Module):
             delta = tensor_model_parallel_all_reduce(delta)
         return delta
 
-    def weight_delta(self) -> torch.Tensor:
+    def weight_delta(self, strength: float = 1.0) -> torch.Tensor:
         """Materialize the rank-local BF16 weight delta used by official fusion."""
         if self.lora_a.numel() == 0 or self.lora_b.numel() == 0:
             raise RuntimeError(f"LTX phase adapter target {self.target.module!r} was not materialized.")
-        return torch.matmul(self.lora_b, self.lora_a)
+        return torch.matmul(self.lora_b * strength, self.lora_a)
 
 
 def _apply_unquantized_gemm_with_weight(
@@ -274,6 +275,7 @@ class _PhaseAdapterLinear(nn.Module):
         self.pieces = nn.ModuleList(pieces)
         self._pieces_by_target = {piece.target: piece for piece in pieces}
         self._enabled = False
+        self._strength = 1.0
 
     def load_target(self, target: AdapterTarget, lora_a: torch.Tensor, lora_b: torch.Tensor) -> None:
         try:
@@ -282,8 +284,9 @@ class _PhaseAdapterLinear(nn.Module):
             raise ValueError(f"Adapter target {target.module!r} is not installed on this layer.") from exc
         piece.load(lora_a, lora_b, device=_module_device(self.base_layer), dtype=self.adapter_dtype)
 
-    def set_enabled(self, enabled: bool) -> None:
+    def set_enabled(self, enabled: bool, *, strength: float = 1.0) -> None:
         self._enabled = enabled
+        self._strength = strength
 
     def _add_adapter_delta(self, input_: torch.Tensor, output: torch.Tensor) -> torch.Tensor:
         if not self._enabled:
@@ -291,7 +294,7 @@ class _PhaseAdapterLinear(nn.Module):
         if output.requires_grad:
             output = output.clone()
         for piece in self.pieces:
-            delta = piece.delta(input_).to(dtype=output.dtype)
+            delta = piece.delta(input_).mul_(self._strength).to(dtype=output.dtype)
             start = piece.layout.output_start
             output[..., start : start + piece.layout.b_output_size].add_(delta)
         return output
@@ -303,7 +306,7 @@ class _PhaseAdapterLinear(nn.Module):
         for piece in self.pieces:
             start = piece.layout.output_start
             base_slice = base_weight.narrow(0, start, piece.layout.b_output_size)
-            delta = piece.weight_delta()
+            delta = piece.weight_delta(self._strength)
             if delta.shape != base_slice.shape:
                 raise ValueError(
                     f"LTX layer-fused delta shape {tuple(delta.shape)} does not match base weight slice "
@@ -387,14 +390,22 @@ class LTXPhaseAdapterRuntime:
         self._materialized = True
         logger.info("Materialized %d LTX phase-adapter tensor pairs", len(self.manifest.targets))
 
-    def activate(self, adapter_slot: str | None) -> None:
+    def activate(self, adapter_slot: str | None, *, strength: float | None = None) -> None:
+        if adapter_slot is None:
+            if strength is not None:
+                raise ValueError("An LTX phase adapter strength requires an adapter slot.")
+            resolved_strength = 1.0
+        else:
+            resolved_strength = 1.0 if strength is None else float(strength)
+            if not math.isfinite(resolved_strength):
+                raise ValueError("An LTX phase adapter strength must be finite.")
         if adapter_slot is not None:
             if adapter_slot != LTX_DISTILLED_ADAPTER_SLOT:
                 raise ValueError(f"Unknown LTX phase adapter slot {adapter_slot!r}.")
             if not self._materialized:
                 raise RuntimeError("LTX phase adapter data must be materialized before activation.")
         for wrapper in self._wrappers.values():
-            wrapper.set_enabled(adapter_slot is not None)
+            wrapper.set_enabled(adapter_slot is not None, strength=resolved_strength)
 
 
 def build_ltx_phase_adapter(pipeline: Any) -> LTXPhaseAdapterRuntime | None:

--- a/vllm_omni/diffusion/models/ltx2/ltx2_recipes.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_recipes.py
@@ -3,6 +3,7 @@
 
 """Declarative execution recipes for the LTX model family."""
 
+import math
 from dataclasses import dataclass, replace
 from typing import Literal
 
@@ -43,17 +44,27 @@ class LTXPhaseRecipe:
     noise_scale: float = 0.0
     input_transform: Literal["initial", "spatial_upsample"] = "initial"
     adapter_slot: str | None = None
-    sampler: Literal["euler", "euler_ancestral"] = "euler"
+    adapter_strength: float | None = None
+    sampler: Literal["euler", "euler_ancestral", "res2s"] = "euler"
     allow_guidance_override: bool = True
     use_official_sigma_schedule: bool = True
+    use_latent_dependent_sigma_schedule: bool = False
 
     def __post_init__(self) -> None:
         if self.spatial_downscale < 1:
             raise ValueError("LTX phase spatial_downscale must be positive.")
         if self.sigmas is not None and len(self.sigmas) < 2:
             raise ValueError("An explicit LTX sigma schedule must contain at least two denoise sigmas.")
-        if self.sampler not in ("euler", "euler_ancestral"):
+        if (self.adapter_slot is None) != (self.adapter_strength is None):
+            raise ValueError("An LTX phase adapter slot and strength must be configured together.")
+        if self.adapter_strength is not None and not math.isfinite(self.adapter_strength):
+            raise ValueError("An LTX phase adapter strength must be finite.")
+        if self.sampler not in ("euler", "euler_ancestral", "res2s"):
             raise ValueError(f"Unsupported LTX sampler: {self.sampler!r}.")
+        if self.use_official_sigma_schedule and self.use_latent_dependent_sigma_schedule:
+            raise ValueError("An LTX phase cannot enable both official and latent-dependent sigma schedules.")
+        if self.sigmas is not None and self.use_latent_dependent_sigma_schedule:
+            raise ValueError("An LTX phase cannot combine explicit sigmas with a latent-dependent sigma schedule.")
 
     @property
     def num_inference_steps(self) -> int | None:
@@ -280,6 +291,7 @@ def _official_two_stage_recipe(one_stage_recipe: LTXPipelineRecipe) -> LTXPipeli
                 noise_scale=LTX_STAGE_2_DISTILLED_SIGMAS[0],
                 input_transform="spatial_upsample",
                 adapter_slot=LTX_DISTILLED_ADAPTER_SLOT,
+                adapter_strength=1.0,
                 allow_guidance_override=False,
                 use_official_sigma_schedule=False,
             ),
@@ -299,6 +311,65 @@ LTX23_TWO_STAGE_RECIPE = _official_two_stage_recipe(LTX23_ONE_STAGE_RECIPE)
 LTX25_TWO_STAGE_RECIPE = _official_two_stage_recipe(LTX25_FULL_RECIPE)
 
 
+def _hq_two_stage_recipe(one_stage_recipe: LTXPipelineRecipe) -> LTXPipelineRecipe:
+    """Build the official Res2s HQ topology for a regular LTX checkpoint."""
+    return LTXPipelineRecipe(
+        height=1088,
+        width=1920,
+        num_frames=one_stage_recipe.num_frames,
+        frame_rate=one_stage_recipe.frame_rate,
+        num_inference_steps=15,
+        negative_prompt=one_stage_recipe.negative_prompt,
+        phases=(
+            LTXPhaseRecipe(
+                name="generate_lowres",
+                guidance=LTXGuidanceSpec(
+                    video=LTXModalityGuidance(
+                        cfg_scale=3.0,
+                        stg_scale=0.0,
+                        modality_scale=3.0,
+                        rescale_scale=0.45,
+                    ),
+                    audio=LTXModalityGuidance(
+                        cfg_scale=7.0,
+                        stg_scale=0.0,
+                        modality_scale=3.0,
+                        rescale_scale=1.0,
+                    ),
+                ),
+                spatial_downscale=2,
+                noise_scale=1.0,
+                adapter_slot=LTX_DISTILLED_ADAPTER_SLOT,
+                adapter_strength=0.25,
+                sampler="res2s",
+                use_official_sigma_schedule=False,
+                use_latent_dependent_sigma_schedule=True,
+            ),
+            LTXPhaseRecipe(
+                name="refine",
+                guidance=LTXGuidanceSpec.positive_only(),
+                sigmas=LTX_STAGE_2_DISTILLED_SIGMAS,
+                noise_scale=LTX_STAGE_2_DISTILLED_SIGMAS[0],
+                input_transform="spatial_upsample",
+                adapter_slot=LTX_DISTILLED_ADAPTER_SLOT,
+                adapter_strength=0.5,
+                sampler="res2s",
+                allow_guidance_override=False,
+                use_official_sigma_schedule=False,
+            ),
+        ),
+        video_output_phase=1,
+        audio_output_phase=0,
+        allow_request_sigmas=False,
+        allow_request_phase_sigmas=True,
+        allow_request_latents=False,
+    )
+
+
+LTX23_TWO_STAGE_HQ_RECIPE = _hq_two_stage_recipe(LTX23_ONE_STAGE_RECIPE)
+LTX25_TWO_STAGE_HQ_RECIPE = _hq_two_stage_recipe(LTX25_FULL_RECIPE)
+
+
 _PIPELINE_RECIPES: dict[tuple[str, str], LTXPipelineRecipe] = {
     ("one_stage", "2"): LTX2_ONE_STAGE_RECIPE,
     ("one_stage", "2.3"): LTX23_ONE_STAGE_RECIPE,
@@ -306,6 +377,8 @@ _PIPELINE_RECIPES: dict[tuple[str, str], LTXPipelineRecipe] = {
     ("two_stage", "2"): LTX2_TWO_STAGE_RECIPE,
     ("two_stage", "2.3"): LTX23_TWO_STAGE_RECIPE,
     ("two_stage", "2.5"): LTX25_TWO_STAGE_RECIPE,
+    ("two_stage_hq", "2.3"): LTX23_TWO_STAGE_HQ_RECIPE,
+    ("two_stage_hq", "2.5"): LTX25_TWO_STAGE_HQ_RECIPE,
     ("distilled_one_stage", "2"): LTX2_DISTILLED_ONE_STAGE_RECIPE,
     ("distilled_one_stage", "2.3"): LTX23_DISTILLED_ONE_STAGE_RECIPE,
     ("distilled_one_stage", "2.5"): LTX25_DISTILLED_ONE_STAGE_RECIPE,

--- a/vllm_omni/diffusion/models/ltx2/ltx2_res2s.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_res2s.py
@@ -1,0 +1,368 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Official LTX-2 res_2s sampling primitives.
+
+The executor in this module deliberately owns only sampler state. Model
+execution and image-conditioning restoration are callbacks, which keeps the
+normalized sigma used for every prediction explicit and lets the LTX runtime
+compose guidance independently.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+from typing import Protocol
+
+import torch
+
+from .ltx2_latents import LTXAVState
+
+LTX_RES2S_STEP_NOISE_SEED = -1
+LTX_RES2S_SUBSTEP_NOISE_SEED = 9999
+LTX_RES2S_TERMINAL_SIGMA = 0.0011
+LTX_RES2S_BONG_ITERATIONS = 100
+
+
+class LTXRes2sPredictX0(Protocol):
+    """Predict denoised video and audio x0 at an explicit normalized sigma."""
+
+    def __call__(self, state: LTXAVState, sigma: torch.Tensor) -> LTXAVState: ...
+
+
+LTXLatentRestore = Callable[[torch.Tensor], torch.Tensor]
+LTXRes2sNoise = Callable[[torch.Tensor, torch.Generator], torch.Tensor]
+
+
+def build_ltx2_res2s_sigmas(
+    num_inference_steps: int,
+    video_token_count: int,
+    *,
+    device: torch.device | str | None = None,
+    base_seq_len: int = 1024,
+    max_seq_len: int = 4096,
+    base_shift: float = 0.95,
+    max_shift: float = 2.05,
+    terminal: float = 0.1,
+) -> torch.Tensor:
+    """Build the official token-dependent, terminal-stretched LTX-2 schedule."""
+    if num_inference_steps < 2:
+        raise ValueError("num_inference_steps must be at least 2 for a terminal-stretched LTX schedule")
+    if video_token_count < 1:
+        raise ValueError("video_token_count must be positive")
+    if max_seq_len == base_seq_len:
+        raise ValueError("max_seq_len and base_seq_len must differ")
+    if not 0 < terminal < 1:
+        raise ValueError("terminal must be strictly between 0 and 1")
+
+    # The official scheduler constructs this schedule on CPU from latent shape
+    # metadata and only moves the finished fp32 tensor to the execution device.
+    sigmas = torch.linspace(1.0, 0.0, num_inference_steps + 1)
+    slope = (max_shift - base_shift) / (max_seq_len - base_seq_len)
+    sigma_shift = video_token_count * slope + (base_shift - slope * base_seq_len)
+    exp_shift = math.exp(sigma_shift)
+    sigmas = torch.where(sigmas != 0, exp_shift / (exp_shift + (1 / sigmas - 1)), 0)
+
+    non_zero = sigmas != 0
+    one_minus_sigmas = 1.0 - sigmas[non_zero]
+    scale = one_minus_sigmas[-1] / (1.0 - terminal)
+    sigmas[non_zero] = 1.0 - one_minus_sigmas / scale
+    return sigmas.to(dtype=torch.float32, device=device)
+
+
+def res2s_phi(order: int, negative_h: float) -> float:
+    """Evaluate the exponential-integrator phi function used by res_2s."""
+    if order < 1:
+        raise ValueError("order must be positive")
+    if abs(negative_h) < 1e-10:
+        return 1.0 / math.factorial(order)
+    remainder = sum(negative_h**k / math.factorial(k) for k in range(order))
+    return (math.exp(negative_h) - remainder) / negative_h**order
+
+
+def get_res2s_coefficients(h: float, c2: float = 0.5) -> tuple[float, float, float]:
+    """Return the official ``(a21, b1, b2)`` coefficients for one log-sigma step."""
+    if c2 == 0:
+        raise ValueError("c2 must be non-zero")
+    a21 = c2 * res2s_phi(1, -h * c2)
+    b2 = res2s_phi(2, -h) / c2
+    b1 = res2s_phi(1, -h) - b2
+    return a21, b1, b2
+
+
+def normalized_res2s_noise(reference: torch.Tensor, generator: torch.Generator) -> torch.Tensor:
+    """Draw and normalize the high-precision noise used by the official sampler."""
+    dtype = torch.float32 if reference.device.type == "mps" else torch.float64
+    noise = torch.randn(reference.shape, generator=generator, dtype=dtype, device=generator.device)
+    noise = (noise - noise.mean()) / noise.std()
+    return noise.sub_(noise.mean(dim=(-2, -1), keepdim=True)).div_(noise.std(dim=(-2, -1), keepdim=True))
+
+
+def normalized_res2s_audio_noise(
+    reference: torch.Tensor,
+    generator: torch.Generator,
+    *,
+    logical_token_count: int,
+) -> torch.Tensor:
+    """Draw official noise without letting SP-only padding alter valid audio."""
+    if not 0 < logical_token_count <= reference.shape[1]:
+        raise ValueError(f"Logical audio token count must be in [1, {reference.shape[1]}], got {logical_token_count}.")
+    logical_noise = normalized_res2s_noise(reference[:, :logical_token_count], generator)
+    if logical_token_count == reference.shape[1]:
+        return logical_noise
+    padding = logical_noise.new_zeros(
+        reference.shape[0],
+        reference.shape[1] - logical_token_count,
+        reference.shape[2],
+    )
+    return torch.cat([logical_noise, padding], dim=1)
+
+
+def res2s_sde_step(
+    sample: torch.Tensor,
+    proposed_sample: torch.Tensor,
+    sigma: torch.Tensor | float,
+    sigma_next: torch.Tensor | float,
+    noise: torch.Tensor,
+    *,
+    eta: float = 0.5,
+) -> torch.Tensor:
+    """Apply the legacy LTX variance-preserving SDE transition."""
+    # The official loop deliberately uses fp64 sigma for the midpoint SDE and
+    # the original fp32 schedule values for the full-step SDE. Preserve a
+    # tensor caller's dtype; promoting both paths to the sample dtype changes
+    # a few bf16 rounding decisions and quickly diverges under stochastic HQ
+    # sampling. Python scalars retain the historical sample-dtype behavior.
+    sigma = (
+        sigma.to(device=sample.device)
+        if isinstance(sigma, torch.Tensor)
+        else torch.as_tensor(sigma, dtype=sample.dtype, device=sample.device)
+    )
+    sigma_next = (
+        sigma_next.to(device=sample.device)
+        if isinstance(sigma_next, torch.Tensor)
+        else torch.as_tensor(sigma_next, dtype=sample.dtype, device=sample.device)
+    )
+    sigma_up = (sigma_next * eta).clamp(max=sigma_next * 0.9999)
+    sigma_residual = (sigma_next**2 - sigma_up**2).clamp(min=0).sqrt()
+    alpha_ratio = (1 - sigma_next) + sigma_residual
+    sigma_down = sigma_residual / alpha_ratio
+
+    if torch.any(sigma_up == 0) or torch.any(sigma_next == 0):
+        return proposed_sample
+
+    epsilon = (sample - proposed_sample) / (sigma - sigma_next)
+    denoised = sample - sigma * epsilon
+    result = alpha_ratio * (denoised + sigma_down * epsilon) + sigma_up * noise
+    return result.to(proposed_sample.dtype)
+
+
+def refine_res2s_anchor(
+    midpoint: torch.Tensor,
+    denoised_x0: torch.Tensor,
+    epsilon: torch.Tensor,
+    h: float,
+    a21: float,
+    *,
+    iterations: int = LTX_RES2S_BONG_ITERATIONS,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run the fixed-count official ``bongmath`` anchor recurrence."""
+    anchor = denoised_x0 - epsilon
+    for _ in range(iterations):
+        anchor = midpoint - h * a21 * epsilon
+        epsilon = denoised_x0 - anchor
+    return anchor, epsilon
+
+
+def _validate_state(reference: LTXAVState, candidate: LTXAVState) -> None:
+    for name in ("video", "audio"):
+        expected = getattr(reference, name)
+        actual = getattr(candidate, name)
+        if actual.shape != expected.shape:
+            raise ValueError(f"Predicted {name} x0 shape {actual.shape} does not match latent shape {expected.shape}")
+        if actual.device != expected.device:
+            raise ValueError(f"Predicted {name} x0 must remain on {expected.device}, got {actual.device}")
+
+
+def _restore_state(
+    state: LTXAVState,
+    restore_video: LTXLatentRestore | None,
+    restore_audio: LTXLatentRestore | None,
+) -> LTXAVState:
+    video = state.video if restore_video is None else restore_video(state.video)
+    audio = state.audio if restore_audio is None else restore_audio(state.audio)
+    if video.shape != state.video.shape or video.device != state.video.device:
+        raise ValueError("The video conditioning restore callback must preserve shape and device")
+    if audio.shape != state.audio.shape or audio.device != state.audio.device:
+        raise ValueError("The audio padding restore callback must preserve shape and device")
+    return LTXAVState(video=video, audio=audio)
+
+
+def _inject_av_sde(
+    reference_state: LTXAVState,
+    sample: LTXAVState,
+    proposed: LTXAVState,
+    sigma: torch.Tensor,
+    sigma_next: torch.Tensor,
+    generator: torch.Generator,
+    video_noise_fn: LTXRes2sNoise,
+    audio_noise_fn: LTXRes2sNoise,
+    eta: float,
+    restore_video: LTXLatentRestore | None,
+    restore_audio: LTXLatentRestore | None,
+) -> LTXAVState:
+    # A shared generator and this explicit order match official joint AV sampling.
+    video_noise = video_noise_fn(reference_state.video, generator)
+    audio_noise = audio_noise_fn(reference_state.audio, generator)
+    result = LTXAVState(
+        video=res2s_sde_step(sample.video, proposed.video, sigma, sigma_next, video_noise, eta=eta),
+        audio=res2s_sde_step(sample.audio, proposed.audio, sigma, sigma_next, audio_noise, eta=eta),
+    )
+    return _restore_state(result, restore_video, restore_audio)
+
+
+class LTXRes2sExecutor:
+    """Run one LTX AV res_2s phase around an explicit x0 prediction callback."""
+
+    @staticmethod
+    def run(  # noqa: PLR0913, PLR0915
+        state: LTXAVState,
+        sigmas: torch.Tensor,
+        predict_x0: LTXRes2sPredictX0,
+        *,
+        restore_video: LTXLatentRestore | None = None,
+        restore_audio: LTXLatentRestore | None = None,
+        eta: float = 0.5,
+        bongmath: bool = True,
+        bongmath_max_iter: int = LTX_RES2S_BONG_ITERATIONS,
+        model_dtype: torch.dtype = torch.bfloat16,
+        noise_fn: LTXRes2sNoise = normalized_res2s_noise,
+        audio_noise_fn: LTXRes2sNoise | None = None,
+        on_step: Callable[[], None] | None = None,
+    ) -> LTXAVState:
+        """Execute res_2s; every invocation creates fresh official phase RNGs."""
+        if state.video.device != state.audio.device:
+            raise ValueError("Video and audio latents must be on the same device")
+        if bongmath_max_iter < 0:
+            raise ValueError("bongmath_max_iter must be non-negative")
+
+        device = state.video.device
+        sigmas = torch.as_tensor(sigmas, dtype=torch.float32, device=device)
+        if sigmas.ndim != 1 or sigmas.numel() < 2:
+            raise ValueError("sigmas must be a one-dimensional tensor with at least two values")
+        if not torch.all(torch.isfinite(sigmas)) or torch.any(sigmas < 0) or torch.any(sigmas > 1):
+            raise ValueError("sigmas must contain finite normalized values in [0, 1]")
+        if torch.any(sigmas[:-1] <= sigmas[1:]):
+            raise ValueError("sigmas must be strictly decreasing")
+
+        num_steps = len(sigmas) - 1
+        has_zero_terminal = bool(sigmas[-1] == 0)
+        if has_zero_terminal:
+            terminal_sigma = sigmas.new_tensor(LTX_RES2S_TERMINAL_SIGMA)
+            if bool(sigmas[-2] <= terminal_sigma):
+                raise ValueError(
+                    "When an LTX Res2s sigma schedule ends at zero, the preceding sigma must be greater than "
+                    f"{LTX_RES2S_TERMINAL_SIGMA}."
+                )
+            sigmas = torch.cat([sigmas[:-1], terminal_sigma.unsqueeze(0), sigmas.new_zeros(1)])
+
+        hp = torch.float32 if device.type == "mps" else torch.float64
+        high_precision_sigmas = sigmas.to(hp)
+        hs = -torch.log(high_precision_sigmas[1:].cpu() / high_precision_sigmas[:-1].cpu())
+        step_generator = torch.Generator(device=device).manual_seed(LTX_RES2S_STEP_NOISE_SEED)
+        substep_generator = torch.Generator(device=device).manual_seed(LTX_RES2S_SUBSTEP_NOISE_SEED)
+        audio_noise_fn = noise_fn if audio_noise_fn is None else audio_noise_fn
+
+        for step_index in range(num_steps):
+            sigma = high_precision_sigmas[step_index]
+            sigma_next = high_precision_sigmas[step_index + 1]
+            h = hs[step_index].item()
+            a21, b1, b2 = get_res2s_coefficients(h)
+            midpoint_sigma = torch.sqrt(sigma * sigma_next)
+
+            anchor = LTXAVState(video=state.video.clone().to(hp), audio=state.audio.clone().to(hp))
+            denoised_1 = predict_x0(state, sigmas[step_index])
+            _validate_state(state, denoised_1)
+            denoised_1 = _restore_state(denoised_1, restore_video, restore_audio)
+            denoised_1_hp = LTXAVState(video=denoised_1.video.to(hp), audio=denoised_1.audio.to(hp))
+            epsilon_1 = LTXAVState(
+                video=denoised_1_hp.video - anchor.video,
+                audio=denoised_1_hp.audio - anchor.audio,
+            )
+            midpoint = LTXAVState(
+                video=anchor.video + h * a21 * epsilon_1.video,
+                audio=anchor.audio + h * a21 * epsilon_1.audio,
+            )
+            midpoint = _inject_av_sde(
+                state,
+                anchor,
+                midpoint,
+                sigma,
+                midpoint_sigma,
+                substep_generator,
+                noise_fn,
+                audio_noise_fn,
+                0.5,
+                restore_video,
+                restore_audio,
+            )
+
+            if bongmath and h < 0.5 and sigma > 0.03:
+                video_anchor, video_epsilon = refine_res2s_anchor(
+                    midpoint.video,
+                    denoised_1_hp.video,
+                    epsilon_1.video,
+                    h,
+                    a21,
+                    iterations=bongmath_max_iter,
+                )
+                audio_anchor, audio_epsilon = refine_res2s_anchor(
+                    midpoint.audio,
+                    denoised_1_hp.audio,
+                    epsilon_1.audio,
+                    h,
+                    a21,
+                    iterations=bongmath_max_iter,
+                )
+                anchor = LTXAVState(video=video_anchor, audio=audio_anchor)
+                epsilon_1 = LTXAVState(video=video_epsilon, audio=audio_epsilon)
+
+            model_midpoint = LTXAVState(
+                video=midpoint.video.to(model_dtype),
+                audio=midpoint.audio.to(model_dtype),
+            )
+            denoised_2 = predict_x0(model_midpoint, midpoint_sigma)
+            _validate_state(model_midpoint, denoised_2)
+            denoised_2 = _restore_state(denoised_2, restore_video, restore_audio)
+            epsilon_2 = LTXAVState(
+                video=denoised_2.video.to(hp) - anchor.video,
+                audio=denoised_2.audio.to(hp) - anchor.audio,
+            )
+            proposed = LTXAVState(
+                video=anchor.video + h * (b1 * epsilon_1.video + b2 * epsilon_2.video),
+                audio=anchor.audio + h * (b1 * epsilon_1.audio + b2 * epsilon_2.audio),
+            )
+            state = _inject_av_sde(
+                state,
+                anchor,
+                proposed,
+                sigmas[step_index],
+                sigmas[step_index + 1],
+                step_generator,
+                noise_fn,
+                audio_noise_fn,
+                eta,
+                restore_video,
+                restore_audio,
+            )
+            state = LTXAVState(video=state.video.to(model_dtype), audio=state.audio.to(model_dtype))
+            if on_step is not None:
+                on_step()
+
+        if has_zero_terminal:
+            denoised = predict_x0(state, sigmas[num_steps])
+            _validate_state(state, denoised)
+            denoised = _restore_state(denoised, restore_video, restore_audio)
+            state = LTXAVState(video=denoised.video.to(model_dtype), audio=denoised.audio.to(model_dtype))
+        return state

--- a/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
@@ -60,6 +60,29 @@ from .ltx2_request import (
 )
 
 
+def _run_ltx_vocoder(vocoder: nn.Module, generated_mel: torch.Tensor) -> torch.Tensor:
+    """Run the BWE vocoder in FP32, matching the official LTX pipeline."""
+    if not hasattr(vocoder, "bwe_generator"):
+        return vocoder(generated_mel)
+
+    input_dtype = generated_mel.dtype
+    device_type = generated_mel.device.type
+    module_dtype = next(vocoder.parameters()).dtype
+    if device_type == "mps":
+        if module_dtype != torch.float32:
+            vocoder.float()
+        try:
+            return vocoder(generated_mel.float()).to(input_dtype)
+        finally:
+            if module_dtype != torch.float32:
+                vocoder.to(module_dtype)
+
+    # BF16 errors compound through the BWE model's long convolution stack.
+    # FP32 autocast upcasts each op without materializing a second FP32 model.
+    with torch.autocast(device_type=device_type, dtype=torch.float32):
+        return vocoder(generated_mel.float()).to(input_dtype)
+
+
 def _expand_per_prompt_decode_value(
     value: float | list[float],
     *,
@@ -558,7 +581,7 @@ class LTXRuntime(
         if video.numel() > 0:
             video = self.video_processor.postprocess_video(video, output_type=output_type)
         generated_mel = self.audio_vae.decode(audio_latents.to(self.audio_vae.dtype), return_dict=False)[0]
-        audio = self.vocoder(generated_mel)
+        audio = _run_ltx_vocoder(self.vocoder, generated_mel)
         return self._make_output((video, audio))
 
     def _prepare_video_latents_stage(

--- a/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
@@ -314,7 +314,7 @@ class LTXRuntime(
             if phase.adapter_slot is not None:
                 raise RuntimeError(f"LTX phase {phase.name!r} requires adapter slot {phase.adapter_slot!r}.")
             return
-        phase_adapter.activate(phase.adapter_slot)
+        phase_adapter.activate(phase.adapter_slot, strength=phase.adapter_strength)
 
     def eval(self):
         result = super().eval()
@@ -733,6 +733,29 @@ class LTXRuntime(
             forward_ctx,
             denoise_ctx,
             preserve_positive_velocity=forward_ctx.sampler == "euler_ancestral",
+        )
+
+    def _predict_denoised_for_step(
+        self,
+        index: int,
+        timestep: torch.Tensor,
+        state: latent_ops.LTXAVState,
+        forward_ctx: LTXForwardContext,
+        denoise_ctx: LTXDenoiseContext,
+        *,
+        video_sigma: torch.Tensor,
+        audio_sigma: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.guidance_executor.predict_denoised(
+            self,
+            self._guidance_plan,
+            index,
+            timestep,
+            state,
+            forward_ctx,
+            denoise_ctx,
+            video_sigma=video_sigma,
+            audio_sigma=audio_sigma,
         )
 
     def _denoise_step(

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_two_stage.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_two_stage.py
@@ -16,6 +16,7 @@ from .ltx2_conditioning import LTXI2VConditioningMixin
 from .ltx2_recipes import (
     LTX2_DISTILLED_TWO_STAGE_RECIPE,
     LTX2_TWO_STAGE_RECIPE,
+    LTX23_TWO_STAGE_HQ_RECIPE,
 )
 from .ltx2_runtime import LTXRuntime
 
@@ -38,6 +39,14 @@ class LTX2TwoStagePipeline(_LTX2TwoStageBase):
     pipeline_kind = "two_stage"
     component_profile = LTX2_TWO_STAGE_COMPONENT_PROFILE
     pipeline_recipe = LTX2_TWO_STAGE_RECIPE
+
+
+class LTX2TwoStageHQPipeline(_LTX2TwoStageBase):
+    """LTX-2.3/2.5 high-quality two-stage T2V/I2V with Res2s."""
+
+    pipeline_kind = "two_stage_hq"
+    component_profile = LTX2_TWO_STAGE_COMPONENT_PROFILE
+    pipeline_recipe = LTX23_TWO_STAGE_HQ_RECIPE
 
 
 class LTX2DistilledTwoStagePipeline(_LTX2TwoStageBase):

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -76,6 +76,11 @@ _DIFFUSION_MODELS = {
         "pipeline_ltx2_two_stage",
         "LTX2TwoStagePipeline",
     ),
+    "LTX2TwoStageHQPipeline": (
+        "ltx2",
+        "pipeline_ltx2_two_stage",
+        "LTX2TwoStageHQPipeline",
+    ),
     "LTX2DistilledOneStagePipeline": (
         "ltx2",
         "pipeline_ltx2",
@@ -548,6 +553,7 @@ _DIFFUSION_POST_PROCESS_FUNCS = {
     "WanVACEPipeline": "get_wan22_vace_post_process_func",
     "LTX2Pipeline": "get_ltx2_post_process_func",
     "LTX2TwoStagePipeline": "get_ltx2_post_process_func",
+    "LTX2TwoStageHQPipeline": "get_ltx2_post_process_func",
     "LTX2DistilledOneStagePipeline": "get_ltx2_post_process_func",
     "LTX2DistilledTwoStagePipeline": "get_ltx2_post_process_func",
     "LTX2DistilledPipeline": "get_ltx2_post_process_func",

--- a/vllm_omni/model_extras/registry.py
+++ b/vllm_omni/model_extras/registry.py
@@ -230,6 +230,7 @@ _EXTRA_SPECS: dict[str, dict[str, Any]] = {
         for model_class_name in (
             "LTX2Pipeline",
             "LTX2TwoStagePipeline",
+            "LTX2TwoStageHQPipeline",
             "LTX2DistilledOneStagePipeline",
             "LTX2DistilledPipeline",
             "LTX2DistilledTwoStagePipeline",


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

- Add the Res2s high-quality two-stage pipeline for LTX-2.3 and LTX-2.5.
- Expose `LTX2TwoStageHQPipeline` for T2V and first-frame I2V through offline inference and OpenAI-compatible `/v1/videos` serving.
- Reuse the existing two-stage component profiles and sidecar weights while selecting an independent HQ execution recipe.
- Extend LTX accuracy coverage and fix BWE vocoder precision.

Based on #6070 and #5500.

## What this PR adds

| Pipeline | Model | Components | Sampling recipe | Coverage |
|---|---:|---|---|---|
| `LTX2TwoStageHQPipeline` | 2.3 | 2.3 dev Transformer, x2 spatial upsampler, distilled LoRA 384 | Res2s 15 + 3; LoRA strengths `0.25` / `0.5` | T2V, I2V, offline, online, similarity |
| `LTX2TwoStageHQPipeline` | 2.5 | `transformer_full/`, x2 spatial upsampler, distilled LoRA 450 | Res2s 15 + 3; LoRA strengths `0.25` / `0.5` | T2V, I2V, offline, online |

The implementation adds the token-count-dependent sigma schedule, second-order midpoint prediction, deterministic joint audio/video noise streams, SDE injection, explicit normalized-sigma guidance, SP-safe audio padding, and I2V conditioning restoration at each Res2s substep. Version-specific recipes select the correct Transformer and sidecars without introducing another component profile or another set of weights.

## H200 full-resolution qualification

Cold single-process runs used one H200, BF16 `CUDNN_ATTN`, eager mode, seed 42, 1920x1088, 121 frames, and 24 FPS. TP, VAE tiling/slicing, CPU offload, and layerwise offload were disabled. Generation excludes initialization and MP4 encoding.

| Model | Pipeline | Schedule | Generation | Peak GPU memory reserved |
|---|---|---:|---:|---:|
| LTX-2.3 | Ordinary Full two-stage | 30 + 3 | 96.687 s | 119,672 MiB (116.87 GiB) |
| LTX-2.3 | HQ Res2s two-stage | 15 + 3 | 97.199 s | 123,316 MiB (120.43 GiB) |
| LTX-2.5 | Ordinary Full two-stage | 30 + 3 | 96.711 s | 120,680 MiB (117.85 GiB) |
| LTX-2.5 | HQ Res2s two-stage | 15 + 3 | 98.315 s | 122,280 MiB (119.41 GiB) |

For this request, HQ changes latency by `+0.53%` on 2.3 and `+1.66%` on 2.5, and peak reserved memory by `+3,644 MiB` and `+1,600 MiB`, respectively.

## Demo videos

The demos use the model-card prompt, seed 42, 1920x1088, 121 frames, and 24 FPS. Ordinary two-stage is on the left and HQ Res2s is on the right; each MP4 contains 48 kHz stereo audio.

> A cinematic shot of a red fox walking through a snowy forest at dawn, the camera tracking alongside, snow crunching underfoot.

https://github.com/user-attachments/assets/225036cf-90d5-4db1-b4cb-f9529d1e75d5

https://github.com/user-attachments/assets/04b41b2b-b72e-4abc-a089-d5c5ab32ffe9

The demos show the sampling-recipe difference; they are not pixel-parity comparisons because Res2s changes the stochastic trajectory.

### Similarity coverage and vocoder precision

The similarity suite is simplified around representative two-stage coverage:

- Remove the redundant LTX-2.0/LTX-2.3 one-stage cases; the retained Distilled and Full two-stage cases cover their Stage-1 denoising paths at larger representative shapes.
- Remove the duplicate LTX-2.5 HQ similarity case because the HQ-only Res2s behavior is already covered by LTX-2.3; LTX-2.5 keeps Distilled and Full/SFT coverage, while HQ dispatch remains covered by serving E2E.
- Use one strict threshold profile for all retained LTX similarity cases: SSIM mean/min `>= 0.99`, PSNR `>= 40 dB`, audio relative L2 `<= 0.10`, and audio cosine `>= 0.99`.

LTX-2.3+ uses a bandwidth-extension vocoder with a long convolution stack. Running that stack in BF16 accumulated enough waveform error for the LTX-2.5 Distilled T2V case to reach audio relative L2 `0.331759` and cosine `0.947790`. The BWE vocoder now runs under FP32 autocast and converts the final waveform back to the input dtype; the base vocoder is unchanged. The same case now reaches relative L2 `0.013621` and cosine `0.999908`.

<details>
<summary><strong>Recent H200 similarity results</strong></summary>

All retained cases below pass the single strict profile: SSIM mean/min `>= 0.99`, PSNR `>= 40 dB`, audio relative L2 `<= 0.10`, and audio cosine `>= 0.99`.

| Version | Pipeline / task | SSIM mean | SSIM min | PSNR | Audio relative L2 | Audio cosine | Result |
|---|---|---:|---:|---:|---:|---:|---|
| LTX-2.0 | Distilled T2V | 0.999568 | 0.999457 | 62.466 dB | 0.000000 | 1.000000 | Pass |
| LTX-2.0 | Full two-stage T2V | 0.999635 | 0.999515 | 63.068 dB | 0.000000 | 1.000000 | Pass |
| LTX-2.3 | Distilled I2V | 0.999476 | 0.999151 | 62.408 dB | 0.033802 | 0.999429 | Pass |
| LTX-2.3 | Full two-stage I2V | 0.999523 | 0.999237 | 62.599 dB | 0.045554 | 0.998973 | Pass |
| LTX-2.3 | HQ Res2s T2V | 0.999762 | 0.999702 | 64.473 dB | 0.029472 | 0.999578 | Pass |
| LTX-2.5 | Distilled two-stage T2V | 0.997656 | 0.996499 | 46.961 dB | 0.013621 | 0.999908 | Pass |
| LTX-2.5 | Distilled two-stage I2V | 0.997642 | 0.997191 | 47.914 dB | 0.026768 | 0.999643 | Pass |
| LTX-2.5 | Full one-stage T2V | 0.999910 | 0.999842 | 66.769 dB | 0.003933 | 0.999994 | Pass |
| LTX-2.5 | Full one-stage I2V | 0.999798 | 0.999749 | 64.975 dB | 0.004341 | 0.999992 | Pass |
| LTX-2.5 | Full two-stage T2V | 0.999726 | 0.999657 | 59.788 dB | 0.003854 | 0.999994 | Pass |
| LTX-2.5 | Full two-stage I2V | 0.999819 | 0.999766 | 66.230 dB | 0.007642 | 0.999972 | Pass |

</details>
