### PR TITLE
[Refactor] Rename batch chat completion as legacy fallback

### DIFF
--- a/vllm_omni/entrypoints/openai/batch_serving.py
+++ b/vllm_omni/entrypoints/openai/batch_serving.py
@@ -66,6 +66,14 @@ class OmniOpenAIServingChatBatch(OmniOpenAIServingChat):
         raw_request: Request,
     ) -> ChatCompletionResponse | ErrorResponse:
         """Given a request, submit each request to chat completions & collect the results."""
+        return await self._create_batch_chat_completion_legacy(request, raw_request)
+
+    async def _create_batch_chat_completion_legacy(
+        self,
+        request: BatchChatCompletionRequest,
+        raw_request: Request,
+    ) -> ChatCompletionResponse | ErrorResponse:
+        """Legacy implementation: submits each item via create_chat_completion."""
         model = ""
         enabled_streaming = False
         chat_requests: list[ChatCompletionRequest] = []


### PR DESCRIPTION
## Summary
- Rename `create_batch_chat_completion` → `_create_batch_chat_completion_legacy`
- Add new `create_batch_chat_completion` that delegates to the legacy method
- Prepares for an optimized path that submits directly to the engine (follow-up PRs)

## Test plan
- [x] All 9 existing tests pass unchanged - pytest tests/entrypoints/openai/test_batch_chat_completions.py -v
