### PR TITLE
[Perf] Add render_batch_chat_request for validate-once batch preprocessing

### DIFF
--- a/tests/entrypoints/openai/test_batch_chat_completions.py
+++ b/tests/entrypoints/openai/test_batch_chat_completions.py
@@ -197,13 +197,20 @@ def _make_batch_request(n: int = 2) -> BatchChatCompletionRequest:
     return BatchChatCompletionRequest(model="test-model", messages=messages)
 
 
-def test_render_model_check_called_once():
+def test_render_happy_path():
     handler = _make_render_handler()
-    asyncio.run(handler.render_batch_chat_request(_make_batch_request(5)))
+    result = asyncio.run(handler.render_batch_chat_request(_make_batch_request(4)))
+    assert not isinstance(result, ErrorResponse)
+    conversations, prompts, single_requests = result
+    assert len(conversations) == 4
+    assert len(prompts) == 4
+    assert len(single_requests) == 4
     handler._check_model.assert_called_once()
+    handler.online_renderer.validate_chat_template.assert_called_once()
+    assert handler._preprocess_chat.call_count == 4
 
 
-def test_render_model_check_error_propagates():
+def test_render_error_short_circuits():
     handler = _make_render_handler()
     handler._check_model.return_value = ErrorResponse(
         error=ErrorInfo(message="not found", type="NotFoundError", code=404),
@@ -219,47 +226,3 @@ def test_render_engine_dead_raises():
     handler.engine_client.dead_error = RuntimeError("Engine dead")
     with pytest.raises(RuntimeError, match="Engine dead"):
         asyncio.run(handler.render_batch_chat_request(_make_batch_request(3)))
-
-
-def test_render_template_validation_called_once():
-    handler = _make_render_handler()
-    asyncio.run(handler.render_batch_chat_request(_make_batch_request(4)))
-    handler.online_renderer.validate_chat_template.assert_called_once()
-
-
-def test_render_template_validation_error_propagates():
-    handler = _make_render_handler()
-    handler.online_renderer.validate_chat_template.return_value = ErrorResponse(
-        error=ErrorInfo(message="untrusted", type="BadRequestError", code=400),
-    )
-    result = asyncio.run(handler.render_batch_chat_request(_make_batch_request(3)))
-    assert isinstance(result, ErrorResponse)
-    handler._preprocess_chat.assert_not_called()
-
-
-def test_render_returns_correct_count():
-    handler = _make_render_handler()
-    result = asyncio.run(handler.render_batch_chat_request(_make_batch_request(4)))
-    assert not isinstance(result, ErrorResponse)
-    conversations, prompts, single_requests = result
-    assert len(conversations) == 4
-    assert len(prompts) == 4
-    assert len(single_requests) == 4
-
-
-def test_render_preprocess_called_per_item():
-    handler = _make_render_handler()
-    asyncio.run(handler.render_batch_chat_request(_make_batch_request(3)))
-    assert handler._preprocess_chat.call_count == 3
-
-
-def test_render_audio_format_error_propagates():
-    handler = _make_render_handler()
-    handler.engine_client.output_modalities = ["text", "audio"]
-    request = _make_batch_request(2)
-    request.modalities = ["text", "audio"]
-    handler._resolve_audio_format.return_value = ErrorResponse(
-        error=ErrorInfo(message="bad format", type="BadRequestError", code=400),
-    )
-    result = asyncio.run(handler.render_batch_chat_request(request))
-    assert isinstance(result, ErrorResponse)

--- a/tests/entrypoints/openai/test_batch_chat_completions.py
+++ b/tests/entrypoints/openai/test_batch_chat_completions.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from openai.types.chat import ChatCompletionUserMessageParam
@@ -12,7 +12,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionResponseChoice,
     ChatMessage,
 )
-from vllm.entrypoints.openai.engine.protocol import ErrorResponse, UsageInfo
+from vllm.entrypoints.openai.engine.protocol import ErrorInfo, ErrorResponse, UsageInfo
 
 from vllm_omni.entrypoints.openai.batch_serving import OmniOpenAIServingChatBatch
 
@@ -148,3 +148,120 @@ def test_two_content_choices_raises():
 def test_three_choices_raises():
     with pytest.raises(ValueError, match="got 3"):
         collapse([_text_choice(), _audio_choice(), _text_choice()])
+
+
+# ---------------------------------------------------------------------------
+# Tests for render_batch_chat_request (PR B: validate-once)
+# ---------------------------------------------------------------------------
+
+def _make_render_handler():
+    """Build an OmniOpenAIServingChatBatch with mocked internals for render tests."""
+    handler = OmniOpenAIServingChatBatch.__new__(OmniOpenAIServingChatBatch)
+    handler._check_model = AsyncMock(return_value=None)
+    handler.engine_client = MagicMock()
+    handler.engine_client.errored = False
+    handler.engine_client.output_modalities = ["text"]
+    handler._maybe_get_adapters = MagicMock(return_value=None)
+    handler.models = MagicMock()
+    handler.models.model_name.return_value = "test-model"
+    handler.renderer = MagicMock()
+    handler.renderer.get_tokenizer.return_value = MagicMock()
+    handler.parser_cls = None
+    handler.use_harmony = False
+    handler.online_renderer = MagicMock()
+    handler.online_renderer.validate_chat_template.return_value = None
+    handler.enable_auto_tools = False
+    handler.exclude_tools_when_tool_choice_none = False
+    handler.chat_template = None
+    handler.chat_template_content_format = "string"
+    handler.trust_request_chat_template = False
+    handler._preprocess_chat = AsyncMock(
+        return_value=(
+            [{"role": "user", "content": "hi"}],
+            [{"prompt_token_ids": [1, 2, 3]}],
+        )
+    )
+    handler._effective_chat_template_kwargs = MagicMock(return_value={})
+    handler.create_error_response = MagicMock(
+        side_effect=lambda msg, **kw: ErrorResponse(
+            error=ErrorInfo(message=msg, type="BadRequestError", code=400),
+        )
+    )
+    handler._resolve_audio_format = MagicMock(return_value="wav")
+    return handler
+
+
+def _make_batch_request(n: int = 2) -> BatchChatCompletionRequest:
+    messages = [
+        [ChatCompletionUserMessageParam(role="user", content=f"Question {i}")]
+        for i in range(n)
+    ]
+    return BatchChatCompletionRequest(model="test-model", messages=messages)
+
+
+def test_render_model_check_called_once():
+    handler = _make_render_handler()
+    asyncio.run(handler.render_batch_chat_request(_make_batch_request(5)))
+    handler._check_model.assert_called_once()
+
+
+def test_render_model_check_error_propagates():
+    handler = _make_render_handler()
+    handler._check_model.return_value = ErrorResponse(
+        error=ErrorInfo(message="not found", type="NotFoundError", code=404),
+    )
+    result = asyncio.run(handler.render_batch_chat_request(_make_batch_request(5)))
+    assert isinstance(result, ErrorResponse)
+    handler._preprocess_chat.assert_not_called()
+
+
+def test_render_engine_dead_raises():
+    handler = _make_render_handler()
+    handler.engine_client.errored = True
+    handler.engine_client.dead_error = RuntimeError("Engine dead")
+    with pytest.raises(RuntimeError, match="Engine dead"):
+        asyncio.run(handler.render_batch_chat_request(_make_batch_request(3)))
+
+
+def test_render_template_validation_called_once():
+    handler = _make_render_handler()
+    asyncio.run(handler.render_batch_chat_request(_make_batch_request(4)))
+    handler.online_renderer.validate_chat_template.assert_called_once()
+
+
+def test_render_template_validation_error_propagates():
+    handler = _make_render_handler()
+    handler.online_renderer.validate_chat_template.return_value = ErrorResponse(
+        error=ErrorInfo(message="untrusted", type="BadRequestError", code=400),
+    )
+    result = asyncio.run(handler.render_batch_chat_request(_make_batch_request(3)))
+    assert isinstance(result, ErrorResponse)
+    handler._preprocess_chat.assert_not_called()
+
+
+def test_render_returns_correct_count():
+    handler = _make_render_handler()
+    result = asyncio.run(handler.render_batch_chat_request(_make_batch_request(4)))
+    assert not isinstance(result, ErrorResponse)
+    conversations, prompts, single_requests = result
+    assert len(conversations) == 4
+    assert len(prompts) == 4
+    assert len(single_requests) == 4
+
+
+def test_render_preprocess_called_per_item():
+    handler = _make_render_handler()
+    asyncio.run(handler.render_batch_chat_request(_make_batch_request(3)))
+    assert handler._preprocess_chat.call_count == 3
+
+
+def test_render_audio_format_error_propagates():
+    handler = _make_render_handler()
+    handler.engine_client.output_modalities = ["text", "audio"]
+    request = _make_batch_request(2)
+    request.modalities = ["text", "audio"]
+    handler._resolve_audio_format.return_value = ErrorResponse(
+        error=ErrorInfo(message="bad format", type="BadRequestError", code=400),
+    )
+    result = asyncio.run(handler.render_batch_chat_request(request))
+    assert isinstance(result, ErrorResponse)

--- a/tests/entrypoints/openai/test_batch_chat_completions.py
+++ b/tests/entrypoints/openai/test_batch_chat_completions.py
@@ -154,6 +154,7 @@ def test_three_choices_raises():
 # Tests for render_batch_chat_request (PR B: validate-once)
 # ---------------------------------------------------------------------------
 
+
 def _make_render_handler():
     """Build an OmniOpenAIServingChatBatch with mocked internals for render tests."""
     handler = OmniOpenAIServingChatBatch.__new__(OmniOpenAIServingChatBatch)
@@ -192,10 +193,7 @@ def _make_render_handler():
 
 
 def _make_batch_request(n: int = 2) -> BatchChatCompletionRequest:
-    messages = [
-        [ChatCompletionUserMessageParam(role="user", content=f"Question {i}")]
-        for i in range(n)
-    ]
+    messages = [[ChatCompletionUserMessageParam(role="user", content=f"Question {i}")] for i in range(n)]
     return BatchChatCompletionRequest(model="test-model", messages=messages)
 
 

--- a/vllm_omni/entrypoints/openai/batch_serving.py
+++ b/vllm_omni/entrypoints/openai/batch_serving.py
@@ -122,26 +122,17 @@ class OmniOpenAIServingChatBatch(OmniOpenAIServingChat):
         tool_choice = getattr(request, "tool_choice", None)
         tools = getattr(request, "tools", None)
         tool_parsing_unavailable = (
-            tool_parser is None
-            and not isinstance(tokenizer, MistralTokenizer)
-            and not self.use_harmony
+            tool_parser is None and not isinstance(tokenizer, MistralTokenizer) and not self.use_harmony
         )
         if tool_parsing_unavailable and tool_choice not in (None, "none"):
             if tool_choice == "auto" and not self.enable_auto_tools:
                 return self.create_error_response(
-                    '"auto" tool choice requires '
-                    "--enable-auto-tool-choice and --tool-call-parser to be set"
+                    '"auto" tool choice requires --enable-auto-tool-choice and --tool-call-parser to be set'
                 )
             elif tool_choice != "auto":
-                return self.create_error_response(
-                    f'tool_choice="{tool_choice}" requires '
-                    "--tool-call-parser to be set"
-                )
+                return self.create_error_response(f'tool_choice="{tool_choice}" requires --tool-call-parser to be set')
 
-        if tools is None or (
-            tool_choice == "none"
-            and self.exclude_tools_when_tool_choice_none
-        ):
+        if tools is None or (tool_choice == "none" and self.exclude_tools_when_tool_choice_none):
             tool_dicts = None
         else:
             tool_dicts = [tool.model_dump() for tool in tools]
@@ -150,26 +141,18 @@ class OmniOpenAIServingChatBatch(OmniOpenAIServingChat):
         if not self.use_harmony:
             error_check_ret = self.online_renderer.validate_chat_template(
                 request_chat_template=getattr(request, "chat_template", None),
-                chat_template_kwargs=getattr(
-                    request, "chat_template_kwargs", None
-                ),
+                chat_template_kwargs=getattr(request, "chat_template_kwargs", None),
                 trust_request_chat_template=self.trust_request_chat_template,
             )
             if error_check_ret is not None:
                 return error_check_ret
 
         # Check 11: Output modalities validation
-        engine_output_modalities = [
-            x for x in self.engine_client.output_modalities if x is not None
-        ]
+        engine_output_modalities = [x for x in self.engine_client.output_modalities if x is not None]
         output_modalities = getattr(request, "modalities", engine_output_modalities)
-        request.modalities = (
-            output_modalities if output_modalities is not None else engine_output_modalities
-        )
+        request.modalities = output_modalities if output_modalities is not None else engine_output_modalities
 
-        if not isinstance(request.modalities, list) or not all(
-            isinstance(m, str) for m in request.modalities
-        ):
+        if not isinstance(request.modalities, list) or not all(isinstance(m, str) for m in request.modalities):
             return self.create_error_response("'modalities' must be a list of strings.")
         allowed_modalities = set(engine_output_modalities)
         if is_single_stage_diffusion(self.engine_client):
@@ -205,12 +188,8 @@ class OmniOpenAIServingChatBatch(OmniOpenAIServingChat):
                     conversation, engine_prompts = await self._preprocess_chat(
                         single_request,
                         single_request.messages,
-                        default_template=(
-                            single_request.chat_template or self.chat_template
-                        ),
-                        default_template_content_format=(
-                            self.chat_template_content_format
-                        ),
+                        default_template=(single_request.chat_template or self.chat_template),
+                        default_template_content_format=(self.chat_template_content_format),
                         default_template_kwargs=merged_kwargs,
                         tool_dicts=tool_dicts,
                         tool_parser=tool_parser,
@@ -222,10 +201,9 @@ class OmniOpenAIServingChatBatch(OmniOpenAIServingChat):
                     )
                 else:
                     should_include_tools = tool_dicts is not None
-                    conversation, engine_prompts = (
-                        self.online_renderer._make_request_with_harmony(
-                            single_request, should_include_tools,
-                        )
+                    conversation, engine_prompts = self.online_renderer._make_request_with_harmony(
+                        single_request,
+                        should_include_tools,
                     )
             except (ValueError, TypeError, RuntimeError) as e:
                 logger.exception("Error preprocessing batch item")

--- a/vllm_omni/entrypoints/openai/batch_serving.py
+++ b/vllm_omni/entrypoints/openai/batch_serving.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
 import asyncio
 import time
+from typing import Any
 
 from fastapi import Request
 from pydantic import ValidationError
@@ -16,8 +19,15 @@ from vllm.entrypoints.openai.engine.protocol import (
     UsageInfo,
 )
 from vllm.logger import init_logger
+from vllm.tokenizers.mistral import (
+    MistralTokenizer,
+    maybe_serialize_tool_calls,
+    truncate_tool_call_ids,
+    validate_request_params,
+)
 
 from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
+from vllm_omni.entrypoints.openai.utils import is_single_stage_diffusion
 
 logger = init_logger(__name__)
 
@@ -59,6 +69,175 @@ class OmniOpenAIServingChatBatch(OmniOpenAIServingChat):
     def _get_subrequest_ids(base_id, request: BatchChatCompletionRequest) -> list[str]:
         """Get the request ID for each entry in the batch request to be resubmitted to chat completions."""
         return [f"{base_id}-idx-{idx}" for idx in range(len(request.messages))]
+
+    async def render_batch_chat_request(
+        self,
+        request: BatchChatCompletionRequest,
+    ) -> tuple[list[Any], list[Any], list[ChatCompletionRequest]] | ErrorResponse:
+        """Validate the batch request once and preprocess each conversation.
+
+        Runs all shared checks (model, engine health, LoRA, tokenizer,
+        parsers, template, modalities, audio format) a single time,
+        then preprocesses each conversation individually.
+
+        Returns:
+            (all_conversations, all_engine_prompts, single_requests) on
+            success, or ErrorResponse on failure.
+        """
+        # --- Checks that only need to run once for the whole batch ---
+
+        # Check 1: Model existence
+        error_check_ret = await self._check_model(request)
+        if error_check_ret is not None:
+            logger.error("Error with model %s", error_check_ret)
+            return error_check_ret
+
+        # Check 2: Engine health
+        if self.engine_client.errored:
+            raise self.engine_client.dead_error
+
+        # Check 3: LoRA adapter
+        self._maybe_get_adapters(request, supports_default_mm_loras=True)
+
+        # Check 5: Tokenizer
+        renderer = self.renderer
+        tokenizer = renderer.get_tokenizer()
+        if tokenizer is None:
+            tokenizer = await self.engine_client.get_tokenizer()
+
+        # Check 6: Reasoning parser
+        if self.parser_cls is not None and self.parser_cls.reasoning_parser_cls is not None:
+            self._effective_chat_template_kwargs(request)
+
+        # Check 7: Tool parser class
+        tool_parser = self.parser_cls.tool_parser_cls if self.parser_cls is not None else None
+
+        # Check 8: Mistral tokenizer special handling
+        if isinstance(tokenizer, MistralTokenizer):
+            maybe_serialize_tool_calls(request)
+            truncate_tool_call_ids(request)
+            validate_request_params(request)
+
+        # Check 9: Tool choice validation + tool_dicts
+        tool_choice = getattr(request, "tool_choice", None)
+        tools = getattr(request, "tools", None)
+        tool_parsing_unavailable = (
+            tool_parser is None
+            and not isinstance(tokenizer, MistralTokenizer)
+            and not self.use_harmony
+        )
+        if tool_parsing_unavailable and tool_choice not in (None, "none"):
+            if tool_choice == "auto" and not self.enable_auto_tools:
+                return self.create_error_response(
+                    '"auto" tool choice requires '
+                    "--enable-auto-tool-choice and --tool-call-parser to be set"
+                )
+            elif tool_choice != "auto":
+                return self.create_error_response(
+                    f'tool_choice="{tool_choice}" requires '
+                    "--tool-call-parser to be set"
+                )
+
+        if tools is None or (
+            tool_choice == "none"
+            and self.exclude_tools_when_tool_choice_none
+        ):
+            tool_dicts = None
+        else:
+            tool_dicts = [tool.model_dump() for tool in tools]
+
+        # Check 10: Chat template validation
+        if not self.use_harmony:
+            error_check_ret = self.online_renderer.validate_chat_template(
+                request_chat_template=getattr(request, "chat_template", None),
+                chat_template_kwargs=getattr(
+                    request, "chat_template_kwargs", None
+                ),
+                trust_request_chat_template=self.trust_request_chat_template,
+            )
+            if error_check_ret is not None:
+                return error_check_ret
+
+        # Check 11: Output modalities validation
+        engine_output_modalities = [
+            x for x in self.engine_client.output_modalities if x is not None
+        ]
+        output_modalities = getattr(request, "modalities", engine_output_modalities)
+        request.modalities = (
+            output_modalities if output_modalities is not None else engine_output_modalities
+        )
+
+        if not isinstance(request.modalities, list) or not all(
+            isinstance(m, str) for m in request.modalities
+        ):
+            return self.create_error_response("'modalities' must be a list of strings.")
+        allowed_modalities = set(engine_output_modalities)
+        if is_single_stage_diffusion(self.engine_client):
+            allowed_modalities.add("text")
+        unsupported = set(request.modalities) - allowed_modalities
+        if unsupported:
+            return self.create_error_response(
+                f"Unsupported output modalities {', '.join(sorted(unsupported))} "
+                f"for this model. Supported modalities: "
+                f"{', '.join(sorted(allowed_modalities))}",
+            )
+
+        # Check 12: Audio format validation
+        if request.modalities and "audio" in request.modalities:
+            audio_format_check = self._resolve_audio_format(request)
+            if isinstance(audio_format_check, ErrorResponse):
+                return audio_format_check
+
+        # --- Per-item preprocessing ---
+
+        all_conversations: list[Any] = []
+        all_engine_prompts: list[Any] = []
+        single_requests: list[ChatCompletionRequest] = []
+
+        for messages in request.messages:
+            single_request = request.to_chat_completion_request(messages)
+            single_request.stream = False
+            single_requests.append(single_request)
+
+            try:
+                if not self.use_harmony:
+                    merged_kwargs = self._effective_chat_template_kwargs(single_request)
+                    conversation, engine_prompts = await self._preprocess_chat(
+                        single_request,
+                        single_request.messages,
+                        default_template=(
+                            single_request.chat_template or self.chat_template
+                        ),
+                        default_template_content_format=(
+                            self.chat_template_content_format
+                        ),
+                        default_template_kwargs=merged_kwargs,
+                        tool_dicts=tool_dicts,
+                        tool_parser=tool_parser,
+                        renderer=renderer,
+                        add_generation_prompt=single_request.add_generation_prompt,
+                        continue_final_message=single_request.continue_final_message,
+                        documents=getattr(single_request, "documents", None),
+                        add_special_tokens=single_request.add_special_tokens,
+                    )
+                else:
+                    should_include_tools = tool_dicts is not None
+                    conversation, engine_prompts = (
+                        self.online_renderer._make_request_with_harmony(
+                            single_request, should_include_tools,
+                        )
+                    )
+            except (ValueError, TypeError, RuntimeError) as e:
+                logger.exception("Error preprocessing batch item")
+                message = str(e)
+                if e.__cause__ is not None:
+                    message = f"{message} {e.__cause__}"
+                return self.create_error_response(message)
+
+            all_conversations.append(conversation)
+            all_engine_prompts.append(engine_prompts[0])
+
+        return all_conversations, all_engine_prompts, single_requests
 
     async def create_batch_chat_completion(
         self,

--- a/vllm_omni/entrypoints/openai/batch_serving.py
+++ b/vllm_omni/entrypoints/openai/batch_serving.py
@@ -66,6 +66,14 @@ class OmniOpenAIServingChatBatch(OmniOpenAIServingChat):
         raw_request: Request,
     ) -> ChatCompletionResponse | ErrorResponse:
         """Given a request, submit each request to chat completions & collect the results."""
+        return await self._create_batch_chat_completion_legacy(request, raw_request)
+
+    async def _create_batch_chat_completion_legacy(
+        self,
+        request: BatchChatCompletionRequest,
+        raw_request: Request,
+    ) -> ChatCompletionResponse | ErrorResponse:
+        """Legacy implementation: submits each item via create_chat_completion."""
         model = ""
         enabled_streaming = False
         chat_requests: list[ChatCompletionRequest] = []


### PR DESCRIPTION
## Summary
- Add `render_batch_chat_request()` that validates all 12 shared checks once per batch
- Preprocess each conversation individually after validation
- Avoids O(N) redundant validation (model, engine, LoRA, tokenizer, template, modalities, etc.)
- 3 new unit tests covering validation path

Depends on #6190

## Test plan
- [x] 17 tests pass (9 existing + 3 new render tests) - pytest tests/entrypoints/openai/test_batch_chat_completions.py -v