### PR TITLE
[Perf] optimized batch chat completion

### DIFF
--- a/tests/entrypoints/openai/test_batch_chat_completions.py
+++ b/tests/entrypoints/openai/test_batch_chat_completions.py
@@ -105,7 +105,7 @@ def test_subrequest_ids_are_unique(has_header: bool):
         messages=MSG_BATCH,
         seed=42,
     )
-    result = asyncio.run(handler.create_batch_chat_completion(request, _make_raw_request(headers)))
+    result = asyncio.run(handler._create_batch_chat_completion_legacy(request, _make_raw_request(headers)))
     assert not isinstance(result, ErrorResponse)
     assert result.id.startswith("chatcmpl-batch")
 
@@ -429,3 +429,125 @@ def test_generator_batch_empty_generator_returns_error():
         )
     )
     assert isinstance(result, ErrorResponse)
+
+
+# ---------------------------------------------------------------------------
+# Tests for create_batch_chat_completion wiring (PR D: optimized path)
+# ---------------------------------------------------------------------------
+
+def _make_wiring_handler(n_items=2):
+    """Build handler with mocked render + engine for optimized-path tests."""
+    handler = OmniOpenAIServingChatBatch.__new__(OmniOpenAIServingChatBatch)
+
+    conversations = [[{"role": "user", "content": f"Q{i}"}] for i in range(n_items)]
+    engine_prompts = [{"prompt_token_ids": [1, 2, 3]} for _ in range(n_items)]
+    single_reqs = [MagicMock() for _ in range(n_items)]
+
+    async def _render_side_effect(req):
+        req.modalities = ["text"]
+        return (conversations, engine_prompts, single_reqs)
+
+    handler.render_batch_chat_request = AsyncMock(
+        side_effect=_render_side_effect,
+    )
+    handler._maybe_get_adapters = MagicMock(return_value=None)
+    handler.models = MagicMock()
+    handler.models.model_name.return_value = "test-model"
+    handler.renderer = MagicMock()
+    handler.renderer.get_tokenizer.return_value = MagicMock()
+    handler.parser_cls = None
+    handler._log_inputs = MagicMock()
+    handler._build_sampling_params_list_from_request = MagicMock(
+        return_value=[MagicMock()],
+    )
+
+    handler.engine_client = MagicMock()
+    handler.engine_client.generate = MagicMock(
+        side_effect=lambda **kw: _async_gen(
+            _make_text_omni_output("ok", prompt_tokens=5, completion_tokens=3),
+        ),
+    )
+
+    handler.chat_completion_full_generator_batch = AsyncMock(
+        return_value=ChatCompletionResponse(
+            model="test-model",
+            choices=[
+                ChatCompletionResponseChoice(
+                    index=i,
+                    message=ChatMessage(role="assistant", content="ok"),
+                )
+                for i in range(n_items)
+            ],
+            usage=UsageInfo(prompt_tokens=10, completion_tokens=6, total_tokens=16),
+        ),
+    )
+    handler.create_error_response = MagicMock(
+        side_effect=lambda msg, **kw: ErrorResponse(
+            error=ErrorInfo(message=msg, type="InternalServerError", code=500),
+        ),
+    )
+    return handler
+
+
+def test_optimized_path_calls_render_once():
+    handler = _make_wiring_handler(3)
+    request = _make_batch_request(3)
+    raw_request = _make_raw_request([])
+
+    result = asyncio.run(handler.create_batch_chat_completion(request, raw_request))
+    assert not isinstance(result, ErrorResponse)
+    handler.render_batch_chat_request.assert_called_once_with(request)
+    # Verify request_id passed to generator_batch starts with chatcmpl-batch
+    call_args = handler.chat_completion_full_generator_batch.call_args
+    passed_request_id = call_args[0][2]  # 3rd positional arg
+    assert passed_request_id.startswith("chatcmpl-batch")
+
+
+def test_optimized_path_submits_to_engine_per_item():
+    handler = _make_wiring_handler(3)
+    request = _make_batch_request(3)
+    raw_request = _make_raw_request([])
+
+    asyncio.run(handler.create_batch_chat_completion(request, raw_request))
+    assert handler.engine_client.generate.call_count == 3
+
+
+def test_optimized_path_unique_subrequest_ids():
+    handler = _make_wiring_handler(3)
+    request = _make_batch_request(3)
+    raw_request = _make_raw_request([])
+
+    asyncio.run(handler.create_batch_chat_completion(request, raw_request))
+    ids = [
+        call.kwargs["request_id"]
+        for call in handler.engine_client.generate.call_args_list
+    ]
+    assert len(set(ids)) == 3
+
+
+def test_optimized_path_header_in_request_ids():
+    handler = _make_wiring_handler(2)
+    request = _make_batch_request(2)
+    raw_request = _make_raw_request([(b"x-request-id", b"user-456")])
+
+    asyncio.run(handler.create_batch_chat_completion(request, raw_request))
+    ids = [
+        call.kwargs["request_id"]
+        for call in handler.engine_client.generate.call_args_list
+    ]
+    assert all("user-456" in rid for rid in ids)
+
+
+def test_optimized_path_render_error_short_circuits():
+    handler = _make_wiring_handler(2)
+    handler.render_batch_chat_request = AsyncMock(
+        return_value=ErrorResponse(
+            error=ErrorInfo(message="bad model", type="NotFoundError", code=404),
+        ),
+    )
+    request = _make_batch_request(2)
+    raw_request = _make_raw_request([])
+
+    result = asyncio.run(handler.create_batch_chat_completion(request, raw_request))
+    assert isinstance(result, ErrorResponse)
+    handler.engine_client.generate.assert_not_called()

--- a/tests/entrypoints/openai/test_batch_chat_completions.py
+++ b/tests/entrypoints/openai/test_batch_chat_completions.py
@@ -197,13 +197,20 @@ def _make_batch_request(n: int = 2) -> BatchChatCompletionRequest:
     return BatchChatCompletionRequest(model="test-model", messages=messages)
 
 
-def test_render_model_check_called_once():
+def test_render_happy_path():
     handler = _make_render_handler()
-    asyncio.run(handler.render_batch_chat_request(_make_batch_request(5)))
+    result = asyncio.run(handler.render_batch_chat_request(_make_batch_request(4)))
+    assert not isinstance(result, ErrorResponse)
+    conversations, prompts, single_requests = result
+    assert len(conversations) == 4
+    assert len(prompts) == 4
+    assert len(single_requests) == 4
     handler._check_model.assert_called_once()
+    handler.online_renderer.validate_chat_template.assert_called_once()
+    assert handler._preprocess_chat.call_count == 4
 
 
-def test_render_model_check_error_propagates():
+def test_render_error_short_circuits():
     handler = _make_render_handler()
     handler._check_model.return_value = ErrorResponse(
         error=ErrorInfo(message="not found", type="NotFoundError", code=404),
@@ -219,47 +226,3 @@ def test_render_engine_dead_raises():
     handler.engine_client.dead_error = RuntimeError("Engine dead")
     with pytest.raises(RuntimeError, match="Engine dead"):
         asyncio.run(handler.render_batch_chat_request(_make_batch_request(3)))
-
-
-def test_render_template_validation_called_once():
-    handler = _make_render_handler()
-    asyncio.run(handler.render_batch_chat_request(_make_batch_request(4)))
-    handler.online_renderer.validate_chat_template.assert_called_once()
-
-
-def test_render_template_validation_error_propagates():
-    handler = _make_render_handler()
-    handler.online_renderer.validate_chat_template.return_value = ErrorResponse(
-        error=ErrorInfo(message="untrusted", type="BadRequestError", code=400),
-    )
-    result = asyncio.run(handler.render_batch_chat_request(_make_batch_request(3)))
-    assert isinstance(result, ErrorResponse)
-    handler._preprocess_chat.assert_not_called()
-
-
-def test_render_returns_correct_count():
-    handler = _make_render_handler()
-    result = asyncio.run(handler.render_batch_chat_request(_make_batch_request(4)))
-    assert not isinstance(result, ErrorResponse)
-    conversations, prompts, single_requests = result
-    assert len(conversations) == 4
-    assert len(prompts) == 4
-    assert len(single_requests) == 4
-
-
-def test_render_preprocess_called_per_item():
-    handler = _make_render_handler()
-    asyncio.run(handler.render_batch_chat_request(_make_batch_request(3)))
-    assert handler._preprocess_chat.call_count == 3
-
-
-def test_render_audio_format_error_propagates():
-    handler = _make_render_handler()
-    handler.engine_client.output_modalities = ["text", "audio"]
-    request = _make_batch_request(2)
-    request.modalities = ["text", "audio"]
-    handler._resolve_audio_format.return_value = ErrorResponse(
-        error=ErrorInfo(message="bad format", type="BadRequestError", code=400),
-    )
-    result = asyncio.run(handler.render_batch_chat_request(request))
-    assert isinstance(result, ErrorResponse)

--- a/tests/entrypoints/openai/test_batch_chat_completions.py
+++ b/tests/entrypoints/openai/test_batch_chat_completions.py
@@ -342,14 +342,15 @@ def _make_generator_handler():
     return handler
 
 
-def test_generator_batch_text_only():
+def test_generator_batch_happy_path():
     handler = _make_generator_handler()
     generators = [
-        _async_gen(_make_text_omni_output(f"Answer {i}", prompt_tokens=10, completion_tokens=5)) for i in range(3)
+        _async_gen(_make_text_omni_output("a", prompt_tokens=10, completion_tokens=5)),
+        _async_gen(_make_text_omni_output("b", prompt_tokens=20, completion_tokens=15)),
     ]
-    request = _make_batch_request(3)
+    request = _make_batch_request(2)
     request.modalities = ["text"]
-    conversations = [[{"role": "user", "content": f"Q{i}"}] for i in range(3)]
+    conversations = [[{"role": "user", "content": "q"}]] * 2
     metadata = RequestResponseMetadata(request_id="batch-1")
 
     result = asyncio.run(
@@ -364,9 +365,12 @@ def test_generator_batch_text_only():
         )
     )
     assert not isinstance(result, ErrorResponse)
-    assert len(result.choices) == 3
+    assert len(result.choices) == 2
     for i, choice in enumerate(result.choices):
         assert choice.index == i
+    assert result.usage.prompt_tokens == 30
+    assert result.usage.completion_tokens == 20
+    assert result.usage.total_tokens == 50
 
 
 def test_generator_batch_text_plus_audio():
@@ -400,34 +404,6 @@ def test_generator_batch_text_plus_audio():
         assert choice.message.content == "hello"
         assert choice.message.audio is not None
         assert choice.message.audio.data == "base64audio"
-
-
-def test_generator_batch_usage_aggregation():
-    handler = _make_generator_handler()
-    generators = [
-        _async_gen(_make_text_omni_output("a", prompt_tokens=10, completion_tokens=5)),
-        _async_gen(_make_text_omni_output("b", prompt_tokens=20, completion_tokens=15)),
-    ]
-    request = _make_batch_request(2)
-    request.modalities = ["text"]
-    conversations = [[{"role": "user", "content": "q"}]] * 2
-    metadata = RequestResponseMetadata(request_id="batch-3")
-
-    result = asyncio.run(
-        handler.chat_completion_full_generator_batch(
-            request,
-            generators,
-            "batch-3",
-            "test-model",
-            conversations,
-            MagicMock(),
-            metadata,
-        )
-    )
-    assert not isinstance(result, ErrorResponse)
-    assert result.usage.prompt_tokens == 30
-    assert result.usage.completion_tokens == 20
-    assert result.usage.total_tokens == 50
 
 
 def test_generator_batch_empty_generator_returns_error():

--- a/tests/entrypoints/openai/test_batch_chat_completions.py
+++ b/tests/entrypoints/openai/test_batch_chat_completions.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from openai.types.chat import ChatCompletionUserMessageParam
@@ -12,7 +12,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionResponseChoice,
     ChatMessage,
 )
-from vllm.entrypoints.openai.engine.protocol import ErrorResponse, UsageInfo
+from vllm.entrypoints.openai.engine.protocol import ErrorInfo, ErrorResponse, UsageInfo
 
 from vllm_omni.entrypoints.openai.batch_serving import OmniOpenAIServingChatBatch
 
@@ -148,3 +148,120 @@ def test_two_content_choices_raises():
 def test_three_choices_raises():
     with pytest.raises(ValueError, match="got 3"):
         collapse([_text_choice(), _audio_choice(), _text_choice()])
+
+
+# ---------------------------------------------------------------------------
+# Tests for render_batch_chat_request (PR B: validate-once)
+# ---------------------------------------------------------------------------
+
+def _make_render_handler():
+    """Build an OmniOpenAIServingChatBatch with mocked internals for render tests."""
+    handler = OmniOpenAIServingChatBatch.__new__(OmniOpenAIServingChatBatch)
+    handler._check_model = AsyncMock(return_value=None)
+    handler.engine_client = MagicMock()
+    handler.engine_client.errored = False
+    handler.engine_client.output_modalities = ["text"]
+    handler._maybe_get_adapters = MagicMock(return_value=None)
+    handler.models = MagicMock()
+    handler.models.model_name.return_value = "test-model"
+    handler.renderer = MagicMock()
+    handler.renderer.get_tokenizer.return_value = MagicMock()
+    handler.parser_cls = None
+    handler.use_harmony = False
+    handler.online_renderer = MagicMock()
+    handler.online_renderer.validate_chat_template.return_value = None
+    handler.enable_auto_tools = False
+    handler.exclude_tools_when_tool_choice_none = False
+    handler.chat_template = None
+    handler.chat_template_content_format = "string"
+    handler.trust_request_chat_template = False
+    handler._preprocess_chat = AsyncMock(
+        return_value=(
+            [{"role": "user", "content": "hi"}],
+            [{"prompt_token_ids": [1, 2, 3]}],
+        )
+    )
+    handler._effective_chat_template_kwargs = MagicMock(return_value={})
+    handler.create_error_response = MagicMock(
+        side_effect=lambda msg, **kw: ErrorResponse(
+            error=ErrorInfo(message=msg, type="BadRequestError", code=400),
+        )
+    )
+    handler._resolve_audio_format = MagicMock(return_value="wav")
+    return handler
+
+
+def _make_batch_request(n: int = 2) -> BatchChatCompletionRequest:
+    messages = [
+        [ChatCompletionUserMessageParam(role="user", content=f"Question {i}")]
+        for i in range(n)
+    ]
+    return BatchChatCompletionRequest(model="test-model", messages=messages)
+
+
+def test_render_model_check_called_once():
+    handler = _make_render_handler()
+    asyncio.run(handler.render_batch_chat_request(_make_batch_request(5)))
+    handler._check_model.assert_called_once()
+
+
+def test_render_model_check_error_propagates():
+    handler = _make_render_handler()
+    handler._check_model.return_value = ErrorResponse(
+        error=ErrorInfo(message="not found", type="NotFoundError", code=404),
+    )
+    result = asyncio.run(handler.render_batch_chat_request(_make_batch_request(5)))
+    assert isinstance(result, ErrorResponse)
+    handler._preprocess_chat.assert_not_called()
+
+
+def test_render_engine_dead_raises():
+    handler = _make_render_handler()
+    handler.engine_client.errored = True
+    handler.engine_client.dead_error = RuntimeError("Engine dead")
+    with pytest.raises(RuntimeError, match="Engine dead"):
+        asyncio.run(handler.render_batch_chat_request(_make_batch_request(3)))
+
+
+def test_render_template_validation_called_once():
+    handler = _make_render_handler()
+    asyncio.run(handler.render_batch_chat_request(_make_batch_request(4)))
+    handler.online_renderer.validate_chat_template.assert_called_once()
+
+
+def test_render_template_validation_error_propagates():
+    handler = _make_render_handler()
+    handler.online_renderer.validate_chat_template.return_value = ErrorResponse(
+        error=ErrorInfo(message="untrusted", type="BadRequestError", code=400),
+    )
+    result = asyncio.run(handler.render_batch_chat_request(_make_batch_request(3)))
+    assert isinstance(result, ErrorResponse)
+    handler._preprocess_chat.assert_not_called()
+
+
+def test_render_returns_correct_count():
+    handler = _make_render_handler()
+    result = asyncio.run(handler.render_batch_chat_request(_make_batch_request(4)))
+    assert not isinstance(result, ErrorResponse)
+    conversations, prompts, single_requests = result
+    assert len(conversations) == 4
+    assert len(prompts) == 4
+    assert len(single_requests) == 4
+
+
+def test_render_preprocess_called_per_item():
+    handler = _make_render_handler()
+    asyncio.run(handler.render_batch_chat_request(_make_batch_request(3)))
+    assert handler._preprocess_chat.call_count == 3
+
+
+def test_render_audio_format_error_propagates():
+    handler = _make_render_handler()
+    handler.engine_client.output_modalities = ["text", "audio"]
+    request = _make_batch_request(2)
+    request.modalities = ["text", "audio"]
+    handler._resolve_audio_format.return_value = ErrorResponse(
+        error=ErrorInfo(message="bad format", type="BadRequestError", code=400),
+    )
+    result = asyncio.run(handler.render_batch_chat_request(request))
+    assert isinstance(result, ErrorResponse)

--- a/tests/entrypoints/openai/test_batch_chat_completions.py
+++ b/tests/entrypoints/openai/test_batch_chat_completions.py
@@ -490,7 +490,7 @@ def _make_wiring_handler(n_items=2):
     return handler
 
 
-def test_optimized_path_calls_render_once():
+def test_optimized_path_happy_path():
     handler = _make_wiring_handler(3)
     request = _make_batch_request(3)
     raw_request = _make_raw_request([])
@@ -498,29 +498,12 @@ def test_optimized_path_calls_render_once():
     result = asyncio.run(handler.create_batch_chat_completion(request, raw_request))
     assert not isinstance(result, ErrorResponse)
     handler.render_batch_chat_request.assert_called_once_with(request)
-    # Verify request_id passed to generator_batch starts with chatcmpl-batch
-    call_args = handler.chat_completion_full_generator_batch.call_args
-    passed_request_id = call_args[0][2]  # 3rd positional arg
-    assert passed_request_id.startswith("chatcmpl-batch")
-
-
-def test_optimized_path_submits_to_engine_per_item():
-    handler = _make_wiring_handler(3)
-    request = _make_batch_request(3)
-    raw_request = _make_raw_request([])
-
-    asyncio.run(handler.create_batch_chat_completion(request, raw_request))
     assert handler.engine_client.generate.call_count == 3
-
-
-def test_optimized_path_unique_subrequest_ids():
-    handler = _make_wiring_handler(3)
-    request = _make_batch_request(3)
-    raw_request = _make_raw_request([])
-
-    asyncio.run(handler.create_batch_chat_completion(request, raw_request))
     ids = [call.kwargs["request_id"] for call in handler.engine_client.generate.call_args_list]
     assert len(set(ids)) == 3
+    call_args = handler.chat_completion_full_generator_batch.call_args
+    passed_request_id = call_args[0][2]
+    assert passed_request_id.startswith("chatcmpl-batch")
 
 
 def test_optimized_path_header_in_request_ids():

--- a/tests/entrypoints/openai/test_batch_chat_completions.py
+++ b/tests/entrypoints/openai/test_batch_chat_completions.py
@@ -1,4 +1,6 @@
 import asyncio
+from dataclasses import dataclass
+from dataclasses import field as dc_field
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -12,7 +14,13 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionResponseChoice,
     ChatMessage,
 )
-from vllm.entrypoints.openai.engine.protocol import ErrorInfo, ErrorResponse, UsageInfo
+from vllm.entrypoints.openai.engine.protocol import (
+    ErrorInfo,
+    ErrorResponse,
+    RequestResponseMetadata,
+    UsageInfo,
+)
+from vllm.outputs import CompletionOutput
 
 from vllm_omni.entrypoints.openai.batch_serving import OmniOpenAIServingChatBatch
 
@@ -226,3 +234,222 @@ def test_render_engine_dead_raises():
     handler.engine_client.dead_error = RuntimeError("Engine dead")
     with pytest.raises(RuntimeError, match="Engine dead"):
         asyncio.run(handler.render_batch_chat_request(_make_batch_request(3)))
+
+
+# ---------------------------------------------------------------------------
+# Tests for chat_completion_full_generator_batch (PR C: response builder)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeOmniOutput:
+    """Minimal stand-in for OmniRequestOutput for testing."""
+
+    request_id: str = "req-1"
+    finished: bool = True
+    stage_id: int | None = 0
+    final_output_type: str = "text"
+    outputs: list = dc_field(default_factory=list)
+    prompt_token_ids: list = dc_field(default_factory=lambda: [1, 2, 3])
+    prompt_logprobs: object = None
+    encoder_prompt_token_ids: list | None = None
+    kv_transfer_params: dict | None = None
+    metrics: dict = dc_field(default_factory=dict)
+    _multimodal_output: dict = dc_field(default_factory=dict)
+
+
+def _fake_completion_output(text="hello", n_tokens=3):
+    out = CompletionOutput.__new__(CompletionOutput)
+    out.index = 0
+    out.text = text
+    out.token_ids = list(range(n_tokens))
+    out.cumulative_logprob = None
+    out.logprobs = None
+    out.finish_reason = "stop"
+    out.stop_reason = None
+    out.lora_request = None
+    return out
+
+
+def _make_text_omni_output(text="hello", prompt_tokens=5, completion_tokens=3):
+    return _FakeOmniOutput(
+        final_output_type="text",
+        stage_id=0,
+        prompt_token_ids=list(range(prompt_tokens)),
+        outputs=[_fake_completion_output(text, completion_tokens)],
+    )
+
+
+def _make_audio_omni_output():
+    return _FakeOmniOutput(
+        final_output_type="audio",
+        stage_id=1,
+        outputs=[],
+    )
+
+
+async def _async_gen(*items):
+    for item in items:
+        yield item
+
+
+def _make_generator_handler():
+    """Build handler with mocked internals for generator batch tests."""
+    handler = OmniOpenAIServingChatBatch.__new__(OmniOpenAIServingChatBatch)
+    handler.create_error_response = MagicMock(
+        side_effect=lambda msg, **kw: ErrorResponse(
+            error=ErrorInfo(message=msg, type="InternalServerError", code=500),
+        )
+    )
+    handler.get_chat_request_role = MagicMock(return_value="assistant")
+
+    def fake_create_text_choice(request, omni_output, tokenizer, conversation, role, reasoning_parser=None):
+        n_prompt = len(omni_output.prompt_token_ids or [])
+        n_completion = sum(len(o.token_ids) for o in omni_output.outputs)
+        choices = [
+            ChatCompletionResponseChoice(
+                index=0,
+                message=ChatMessage(role="assistant", content=omni_output.outputs[0].text),
+                logprobs=None,
+                finish_reason="stop",
+                stop_reason=None,
+            )
+        ]
+        usage = UsageInfo(
+            prompt_tokens=n_prompt,
+            completion_tokens=n_completion,
+            total_tokens=n_prompt + n_completion,
+        )
+        return choices, usage, None, None, None
+
+    handler._create_text_choice = MagicMock(side_effect=fake_create_text_choice)
+
+    def fake_create_audio_choice(omni_output, role, request, stream=False):
+        audio = ChatCompletionAudio(id="a1", data="base64audio", expires_at=0, transcript="")
+        return [
+            ChatCompletionResponseChoice(
+                index=0,
+                message=ChatMessage(role="assistant", content=None, audio=audio),
+                logprobs=None,
+                finish_reason="stop",
+                stop_reason=None,
+            )
+        ]
+
+    handler._create_audio_choice = MagicMock(side_effect=fake_create_audio_choice)
+    handler._get_diffusion_text_output = MagicMock(return_value="diffusion text")
+    handler._create_image_choice = MagicMock(return_value=[])
+    return handler
+
+
+def test_generator_batch_text_only():
+    handler = _make_generator_handler()
+    generators = [
+        _async_gen(_make_text_omni_output(f"Answer {i}", prompt_tokens=10, completion_tokens=5)) for i in range(3)
+    ]
+    request = _make_batch_request(3)
+    request.modalities = ["text"]
+    conversations = [[{"role": "user", "content": f"Q{i}"}] for i in range(3)]
+    metadata = RequestResponseMetadata(request_id="batch-1")
+
+    result = asyncio.run(
+        handler.chat_completion_full_generator_batch(
+            request,
+            generators,
+            "batch-1",
+            "test-model",
+            conversations,
+            MagicMock(),
+            metadata,
+        )
+    )
+    assert not isinstance(result, ErrorResponse)
+    assert len(result.choices) == 3
+    for i, choice in enumerate(result.choices):
+        assert choice.index == i
+
+
+def test_generator_batch_text_plus_audio():
+    handler = _make_generator_handler()
+    generators = [
+        _async_gen(
+            _make_text_omni_output("hello", prompt_tokens=5, completion_tokens=2),
+            _make_audio_omni_output(),
+        )
+        for _ in range(2)
+    ]
+    request = _make_batch_request(2)
+    request.modalities = ["text", "audio"]
+    conversations = [[{"role": "user", "content": "hi"}]] * 2
+    metadata = RequestResponseMetadata(request_id="batch-2")
+
+    result = asyncio.run(
+        handler.chat_completion_full_generator_batch(
+            request,
+            generators,
+            "batch-2",
+            "test-model",
+            conversations,
+            MagicMock(),
+            metadata,
+        )
+    )
+    assert not isinstance(result, ErrorResponse)
+    assert len(result.choices) == 2
+    for choice in result.choices:
+        assert choice.message.content == "hello"
+        assert choice.message.audio is not None
+        assert choice.message.audio.data == "base64audio"
+
+
+def test_generator_batch_usage_aggregation():
+    handler = _make_generator_handler()
+    generators = [
+        _async_gen(_make_text_omni_output("a", prompt_tokens=10, completion_tokens=5)),
+        _async_gen(_make_text_omni_output("b", prompt_tokens=20, completion_tokens=15)),
+    ]
+    request = _make_batch_request(2)
+    request.modalities = ["text"]
+    conversations = [[{"role": "user", "content": "q"}]] * 2
+    metadata = RequestResponseMetadata(request_id="batch-3")
+
+    result = asyncio.run(
+        handler.chat_completion_full_generator_batch(
+            request,
+            generators,
+            "batch-3",
+            "test-model",
+            conversations,
+            MagicMock(),
+            metadata,
+        )
+    )
+    assert not isinstance(result, ErrorResponse)
+    assert result.usage.prompt_tokens == 30
+    assert result.usage.completion_tokens == 20
+    assert result.usage.total_tokens == 50
+
+
+def test_generator_batch_empty_generator_returns_error():
+    handler = _make_generator_handler()
+    generators = [
+        _async_gen(_make_text_omni_output("ok")),
+        _async_gen(),  # empty
+    ]
+    request = _make_batch_request(2)
+    request.modalities = ["text"]
+    conversations = [[{"role": "user", "content": "q"}]] * 2
+    metadata = RequestResponseMetadata(request_id="batch-4")
+
+    result = asyncio.run(
+        handler.chat_completion_full_generator_batch(
+            request,
+            generators,
+            "batch-4",
+            "test-model",
+            conversations,
+            MagicMock(),
+            metadata,
+        )
+    )
+    assert isinstance(result, ErrorResponse)

--- a/tests/entrypoints/openai/test_batch_chat_completions.py
+++ b/tests/entrypoints/openai/test_batch_chat_completions.py
@@ -435,6 +435,7 @@ def test_generator_batch_empty_generator_returns_error():
 # Tests for create_batch_chat_completion wiring (PR D: optimized path)
 # ---------------------------------------------------------------------------
 
+
 def _make_wiring_handler(n_items=2):
     """Build handler with mocked render + engine for optimized-path tests."""
     handler = OmniOpenAIServingChatBatch.__new__(OmniOpenAIServingChatBatch)
@@ -518,10 +519,7 @@ def test_optimized_path_unique_subrequest_ids():
     raw_request = _make_raw_request([])
 
     asyncio.run(handler.create_batch_chat_completion(request, raw_request))
-    ids = [
-        call.kwargs["request_id"]
-        for call in handler.engine_client.generate.call_args_list
-    ]
+    ids = [call.kwargs["request_id"] for call in handler.engine_client.generate.call_args_list]
     assert len(set(ids)) == 3
 
 
@@ -531,10 +529,7 @@ def test_optimized_path_header_in_request_ids():
     raw_request = _make_raw_request([(b"x-request-id", b"user-456")])
 
     asyncio.run(handler.create_batch_chat_completion(request, raw_request))
-    ids = [
-        call.kwargs["request_id"]
-        for call in handler.engine_client.generate.call_args_list
-    ]
+    ids = [call.kwargs["request_id"] for call in handler.engine_client.generate.call_args_list]
     assert all("user-456" in rid for rid in ids)
 
 

--- a/tests/entrypoints/openai/test_batch_chat_completions.py
+++ b/tests/entrypoints/openai/test_batch_chat_completions.py
@@ -154,6 +154,7 @@ def test_three_choices_raises():
 # Tests for render_batch_chat_request (PR B: validate-once)
 # ---------------------------------------------------------------------------
 
+
 def _make_render_handler():
     """Build an OmniOpenAIServingChatBatch with mocked internals for render tests."""
     handler = OmniOpenAIServingChatBatch.__new__(OmniOpenAIServingChatBatch)
@@ -192,10 +193,7 @@ def _make_render_handler():
 
 
 def _make_batch_request(n: int = 2) -> BatchChatCompletionRequest:
-    messages = [
-        [ChatCompletionUserMessageParam(role="user", content=f"Question {i}")]
-        for i in range(n)
-    ]
+    messages = [[ChatCompletionUserMessageParam(role="user", content=f"Question {i}")] for i in range(n)]
     return BatchChatCompletionRequest(model="test-model", messages=messages)
 
 

--- a/vllm_omni/entrypoints/openai/batch_serving.py
+++ b/vllm_omni/entrypoints/openai/batch_serving.py
@@ -16,15 +16,19 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
 )
 from vllm.entrypoints.openai.engine.protocol import (
     ErrorResponse,
+    RequestResponseMetadata,
     UsageInfo,
 )
 from vllm.logger import init_logger
+from vllm.tokenizers import TokenizerLike
 from vllm.tokenizers.mistral import (
     MistralTokenizer,
     maybe_serialize_tool_calls,
     truncate_tool_call_ids,
     validate_request_params,
 )
+
+from vllm.utils.async_utils import merge_async_iterators
 
 from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
 from vllm_omni.entrypoints.openai.utils import is_single_stage_diffusion
@@ -216,6 +220,156 @@ class OmniOpenAIServingChatBatch(OmniOpenAIServingChat):
             all_engine_prompts.append(engine_prompts[0])
 
         return all_conversations, all_engine_prompts, single_requests
+
+    async def chat_completion_full_generator_batch(
+        self,
+        request: BatchChatCompletionRequest,
+        generators: list[Any],
+        request_id: str,
+        model_name: str,
+        all_conversations: list[Any],
+        tokenizer: TokenizerLike,
+        request_metadata: RequestResponseMetadata,
+        reasoning_parser: Any = None,
+    ) -> ErrorResponse | ChatCompletionResponse:
+        """Collect results from N generators and build one response.
+
+        Uses ``merge_async_iterators`` to fan out N generators (one per
+        conversation).  Each generator may yield multiple
+        ``OmniRequestOutput`` objects (e.g. text + audio), which are
+        grouped by prompt index.  Multi-modal choices are collapsed
+        into one choice per conversation via ``_maybe_collapse_choices``.
+        """
+        from collections import defaultdict
+
+        from vllm.entrypoints.openai.chat_completion.protocol import ChatMessage
+
+        created_time = int(time.time())
+
+        per_item_outputs: dict[int, list[Any]] = defaultdict(list)
+        try:
+            async for prompt_idx, res in merge_async_iterators(*generators):
+                per_item_outputs[prompt_idx].append(res)
+        except asyncio.CancelledError:
+            return self.create_error_response("Client disconnected")
+
+        choices: list[ChatCompletionResponseChoice] = []
+        total_prompt_tokens = 0
+        total_completion_tokens = 0
+
+        requested_modalities = (
+            set(request.modalities)
+            if hasattr(request, "modalities") and request.modalities
+            else None
+        )
+        role = self.get_chat_request_role(request)
+
+        for prompt_idx in range(len(generators)):
+            outputs = per_item_outputs.get(prompt_idx)
+            if not outputs:
+                return self.create_error_response(
+                    f"No output received from the engine for prompt {prompt_idx}.",
+                )
+
+            item_choices: list[ChatCompletionResponseChoice] = []
+
+            for omni_output in outputs:
+                if (
+                    hasattr(omni_output, "finished")
+                    and not omni_output.finished
+                ):
+                    continue
+
+                output_type = getattr(
+                    omni_output, "final_output_type", "text"
+                )
+                if (
+                    requested_modalities is not None
+                    and output_type not in requested_modalities
+                ):
+                    continue
+
+                if output_type == "text":
+                    has_ar_output = (
+                        getattr(omni_output, "stage_id", None) is not None
+                        or getattr(omni_output, "outputs", None)
+                    )
+                    if has_ar_output:
+                        conversation = all_conversations[prompt_idx]
+                        (
+                            choices_data,
+                            usage,
+                            _prompt_logprobs,
+                            _prompt_token_ids,
+                            _kv_transfer_params,
+                        ) = self._create_text_choice(
+                            request,
+                            omni_output,
+                            tokenizer,
+                            conversation,
+                            role,
+                            reasoning_parser,
+                        )
+                        item_choices.extend(choices_data)
+                        total_prompt_tokens += usage.prompt_tokens
+                        total_completion_tokens += usage.completion_tokens
+                    else:
+                        text_body = self._get_diffusion_text_output(
+                            omni_output
+                        )
+                        message = ChatMessage(role=role, content=text_body)
+                        item_choices.append(
+                            ChatCompletionResponseChoice(
+                                index=0,
+                                message=message,
+                                logprobs=None,
+                                finish_reason="stop",
+                                stop_reason=None,
+                            )
+                        )
+
+                elif output_type == "audio":
+                    audio_choices = self._create_audio_choice(
+                        omni_output, role, request, stream=False,
+                    )
+                    if isinstance(audio_choices, ErrorResponse):
+                        return audio_choices
+                    item_choices.extend(audio_choices)
+
+                elif output_type == "image":
+                    img_choices = self._create_image_choice(
+                        omni_output, role, request, stream=False,
+                    )
+                    item_choices.extend(img_choices)
+
+            if not item_choices:
+                return self.create_error_response(
+                    f"No valid output for prompt {prompt_idx}.",
+                )
+
+            try:
+                collapsed = self._maybe_collapse_choices(item_choices)
+            except ValueError as e:
+                return self.create_error_response(
+                    f"Failed to collapse choices for item {prompt_idx}: {e}",
+                )
+            collapsed.index = prompt_idx
+            choices.append(collapsed)
+
+        usage = UsageInfo(
+            prompt_tokens=total_prompt_tokens,
+            completion_tokens=total_completion_tokens,
+            total_tokens=total_prompt_tokens + total_completion_tokens,
+        )
+        request_metadata.final_usage_info = usage
+
+        return ChatCompletionResponse(
+            id=request_id,
+            created=created_time,
+            model=model_name,
+            choices=choices,
+            usage=usage,
+        )
 
     async def create_batch_chat_completion(
         self,

--- a/vllm_omni/entrypoints/openai/batch_serving.py
+++ b/vllm_omni/entrypoints/openai/batch_serving.py
@@ -27,7 +27,6 @@ from vllm.tokenizers.mistral import (
     truncate_tool_call_ids,
     validate_request_params,
 )
-
 from vllm.utils.async_utils import merge_async_iterators
 
 from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
@@ -258,9 +257,7 @@ class OmniOpenAIServingChatBatch(OmniOpenAIServingChat):
         total_completion_tokens = 0
 
         requested_modalities = (
-            set(request.modalities)
-            if hasattr(request, "modalities") and request.modalities
-            else None
+            set(request.modalities) if hasattr(request, "modalities") and request.modalities else None
         )
         role = self.get_chat_request_role(request)
 
@@ -274,25 +271,16 @@ class OmniOpenAIServingChatBatch(OmniOpenAIServingChat):
             item_choices: list[ChatCompletionResponseChoice] = []
 
             for omni_output in outputs:
-                if (
-                    hasattr(omni_output, "finished")
-                    and not omni_output.finished
-                ):
+                if hasattr(omni_output, "finished") and not omni_output.finished:
                     continue
 
-                output_type = getattr(
-                    omni_output, "final_output_type", "text"
-                )
-                if (
-                    requested_modalities is not None
-                    and output_type not in requested_modalities
-                ):
+                output_type = getattr(omni_output, "final_output_type", "text")
+                if requested_modalities is not None and output_type not in requested_modalities:
                     continue
 
                 if output_type == "text":
-                    has_ar_output = (
-                        getattr(omni_output, "stage_id", None) is not None
-                        or getattr(omni_output, "outputs", None)
+                    has_ar_output = getattr(omni_output, "stage_id", None) is not None or getattr(
+                        omni_output, "outputs", None
                     )
                     if has_ar_output:
                         conversation = all_conversations[prompt_idx]
@@ -314,9 +302,7 @@ class OmniOpenAIServingChatBatch(OmniOpenAIServingChat):
                         total_prompt_tokens += usage.prompt_tokens
                         total_completion_tokens += usage.completion_tokens
                     else:
-                        text_body = self._get_diffusion_text_output(
-                            omni_output
-                        )
+                        text_body = self._get_diffusion_text_output(omni_output)
                         message = ChatMessage(role=role, content=text_body)
                         item_choices.append(
                             ChatCompletionResponseChoice(
@@ -330,7 +316,10 @@ class OmniOpenAIServingChatBatch(OmniOpenAIServingChat):
 
                 elif output_type == "audio":
                     audio_choices = self._create_audio_choice(
-                        omni_output, role, request, stream=False,
+                        omni_output,
+                        role,
+                        request,
+                        stream=False,
                     )
                     if isinstance(audio_choices, ErrorResponse):
                         return audio_choices
@@ -338,7 +327,10 @@ class OmniOpenAIServingChatBatch(OmniOpenAIServingChat):
 
                 elif output_type == "image":
                     img_choices = self._create_image_choice(
-                        omni_output, role, request, stream=False,
+                        omni_output,
+                        role,
+                        request,
+                        stream=False,
                     )
                     item_choices.extend(img_choices)
 

--- a/vllm_omni/entrypoints/openai/batch_serving.py
+++ b/vllm_omni/entrypoints/openai/batch_serving.py
@@ -122,26 +122,17 @@ class OmniOpenAIServingChatBatch(OmniOpenAIServingChat):
         tool_choice = getattr(request, "tool_choice", None)
         tools = getattr(request, "tools", None)
         tool_parsing_unavailable = (
-            tool_parser is None
-            and not isinstance(tokenizer, MistralTokenizer)
-            and not self.use_harmony
+            tool_parser is None and not isinstance(tokenizer, MistralTokenizer) and not self.use_harmony
         )
         if tool_parsing_unavailable and tool_choice not in (None, "none"):
             if tool_choice == "auto" and not self.enable_auto_tools:
                 return self.create_error_response(
-                    '"auto" tool choice requires '
-                    "--enable-auto-tool-choice and --tool-call-parser to be set"
+                    '"auto" tool choice requires --enable-auto-tool-choice and --tool-call-parser to be set'
                 )
             elif tool_choice != "auto":
-                return self.create_error_response(
-                    f'tool_choice="{tool_choice}" requires '
-                    "--tool-call-parser to be set"
-                )
+                return self.create_error_response(f'tool_choice="{tool_choice}" requires --tool-call-parser to be set')
 
-        if tools is None or (
-            tool_choice == "none"
-            and self.exclude_tools_when_tool_choice_none
-        ):
+        if tools is None or (tool_choice == "none" and self.exclude_tools_when_tool_choice_none):
             tool_dicts = None
         else:
             tool_dicts = [tool.model_dump() for tool in tools]
@@ -150,26 +141,18 @@ class OmniOpenAIServingChatBatch(OmniOpenAIServingChat):
         if not self.use_harmony:
             error_check_ret = self.online_renderer.validate_chat_template(
                 request_chat_template=getattr(request, "chat_template", None),
-                chat_template_kwargs=getattr(
-                    request, "chat_template_kwargs", None
-                ),
+                chat_template_kwargs=getattr(request, "chat_template_kwargs", None),
                 trust_request_chat_template=self.trust_request_chat_template,
             )
             if error_check_ret is not None:
                 return error_check_ret
 
         # Check 11: Output modalities validation
-        engine_output_modalities = [
-            x for x in self.engine_client.output_modalities if x is not None
-        ]
+        engine_output_modalities = [x for x in self.engine_client.output_modalities if x is not None]
         output_modalities = getattr(request, "modalities", engine_output_modalities)
-        request.modalities = (
-            output_modalities if output_modalities is not None else engine_output_modalities
-        )
+        request.modalities = output_modalities if output_modalities is not None else engine_output_modalities
 
-        if not isinstance(request.modalities, list) or not all(
-            isinstance(m, str) for m in request.modalities
-        ):
+        if not isinstance(request.modalities, list) or not all(isinstance(m, str) for m in request.modalities):
             return self.create_error_response("'modalities' must be a list of strings.")
         allowed_modalities = set(engine_output_modalities)
         if is_single_stage_diffusion(self.engine_client):
@@ -205,12 +188,8 @@ class OmniOpenAIServingChatBatch(OmniOpenAIServingChat):
                     conversation, engine_prompts = await self._preprocess_chat(
                         single_request,
                         single_request.messages,
-                        default_template=(
-                            single_request.chat_template or self.chat_template
-                        ),
-                        default_template_content_format=(
-                            self.chat_template_content_format
-                        ),
+                        default_template=(single_request.chat_template or self.chat_template),
+                        default_template_content_format=(self.chat_template_content_format),
                         default_template_kwargs=merged_kwargs,
                         tool_dicts=tool_dicts,
                         tool_parser=tool_parser,
@@ -222,10 +201,9 @@ class OmniOpenAIServingChatBatch(OmniOpenAIServingChat):
                     )
                 else:
                     should_include_tools = tool_dicts is not None
-                    conversation, engine_prompts = (
-                        self.online_renderer._make_request_with_harmony(
-                            single_request, should_include_tools,
-                        )
+                    conversation, engine_prompts = self.online_renderer._make_request_with_harmony(
+                        single_request,
+                        should_include_tools,
                     )
             except (ValueError, TypeError, RuntimeError) as e:
                 logger.exception("Error preprocessing batch item")

--- a/vllm_omni/entrypoints/openai/batch_serving.py
+++ b/vllm_omni/entrypoints/openai/batch_serving.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
 import asyncio
 import time
+from typing import Any
 
 from fastapi import Request
 from pydantic import ValidationError
@@ -16,8 +19,15 @@ from vllm.entrypoints.openai.engine.protocol import (
     UsageInfo,
 )
 from vllm.logger import init_logger
+from vllm.tokenizers.mistral import (
+    MistralTokenizer,
+    maybe_serialize_tool_calls,
+    truncate_tool_call_ids,
+    validate_request_params,
+)
 
 from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
+from vllm_omni.entrypoints.openai.utils import is_single_stage_diffusion
 
 logger = init_logger(__name__)
 
@@ -59,6 +69,175 @@ class OmniOpenAIServingChatBatch(OmniOpenAIServingChat):
     def _get_subrequest_ids(base_id, request: BatchChatCompletionRequest) -> list[str]:
         """Get the request ID for each entry in the batch request to be resubmitted to chat completions."""
         return [f"{base_id}-idx-{idx}" for idx in range(len(request.messages))]
+
+    async def render_batch_chat_request(
+        self,
+        request: BatchChatCompletionRequest,
+    ) -> tuple[list[Any], list[Any], list[ChatCompletionRequest]] | ErrorResponse:
+        """Validate the batch request once and preprocess each conversation.
+
+        Runs all shared checks (model, engine health, LoRA, tokenizer,
+        parsers, template, modalities, audio format) a single time,
+        then preprocesses each conversation individually.
+
+        Returns:
+            (all_conversations, all_engine_prompts, single_requests) on
+            success, or ErrorResponse on failure.
+        """
+        # --- Checks that only need to run once for the whole batch ---
+
+        # Check 1: Model existence
+        error_check_ret = await self._check_model(request)
+        if error_check_ret is not None:
+            logger.error("Error with model %s", error_check_ret)
+            return error_check_ret
+
+        # Check 2: Engine health
+        if self.engine_client.errored:
+            raise self.engine_client.dead_error
+
+        # Check 3: LoRA adapter
+        self._maybe_get_adapters(request, supports_default_mm_loras=True)
+
+        # Check 5: Tokenizer
+        renderer = self.renderer
+        tokenizer = renderer.get_tokenizer()
+        if tokenizer is None:
+            tokenizer = await self.engine_client.get_tokenizer()
+
+        # Check 6: Reasoning parser
+        if self.parser_cls is not None and self.parser_cls.reasoning_parser_cls is not None:
+            self._effective_chat_template_kwargs(request)
+
+        # Check 7: Tool parser class
+        tool_parser = self.parser_cls.tool_parser_cls if self.parser_cls is not None else None
+
+        # Check 8: Mistral tokenizer special handling
+        if isinstance(tokenizer, MistralTokenizer):
+            maybe_serialize_tool_calls(request)
+            truncate_tool_call_ids(request)
+            validate_request_params(request)
+
+        # Check 9: Tool choice validation + tool_dicts
+        tool_choice = getattr(request, "tool_choice", None)
+        tools = getattr(request, "tools", None)
+        tool_parsing_unavailable = (
+            tool_parser is None
+            and not isinstance(tokenizer, MistralTokenizer)
+            and not self.use_harmony
+        )
+        if tool_parsing_unavailable and tool_choice not in (None, "none"):
+            if tool_choice == "auto" and not self.enable_auto_tools:
+                return self.create_error_response(
+                    '"auto" tool choice requires '
+                    "--enable-auto-tool-choice and --tool-call-parser to be set"
+                )
+            elif tool_choice != "auto":
+                return self.create_error_response(
+                    f'tool_choice="{tool_choice}" requires '
+                    "--tool-call-parser to be set"
+                )
+
+        if tools is None or (
+            tool_choice == "none"
+            and self.exclude_tools_when_tool_choice_none
+        ):
+            tool_dicts = None
+        else:
+            tool_dicts = [tool.model_dump() for tool in tools]
+
+        # Check 10: Chat template validation
+        if not self.use_harmony:
+            error_check_ret = self.online_renderer.validate_chat_template(
+                request_chat_template=getattr(request, "chat_template", None),
+                chat_template_kwargs=getattr(
+                    request, "chat_template_kwargs", None
+                ),
+                trust_request_chat_template=self.trust_request_chat_template,
+            )
+            if error_check_ret is not None:
+                return error_check_ret
+
+        # Check 11: Output modalities validation
+        engine_output_modalities = [
+            x for x in self.engine_client.output_modalities if x is not None
+        ]
+        output_modalities = getattr(request, "modalities", engine_output_modalities)
+        request.modalities = (
+            output_modalities if output_modalities is not None else engine_output_modalities
+        )
+
+        if not isinstance(request.modalities, list) or not all(
+            isinstance(m, str) for m in request.modalities
+        ):
+            return self.create_error_response("'modalities' must be a list of strings.")
+        allowed_modalities = set(engine_output_modalities)
+        if is_single_stage_diffusion(self.engine_client):
+            allowed_modalities.add("text")
+        unsupported = set(request.modalities) - allowed_modalities
+        if unsupported:
+            return self.create_error_response(
+                f"Unsupported output modalities {', '.join(sorted(unsupported))} "
+                f"for this model. Supported modalities: "
+                f"{', '.join(sorted(allowed_modalities))}",
+            )
+
+        # Check 12: Audio format validation
+        if request.modalities and "audio" in request.modalities:
+            audio_format_check = self._resolve_audio_format(request)
+            if isinstance(audio_format_check, ErrorResponse):
+                return audio_format_check
+
+        # --- Per-item preprocessing ---
+
+        all_conversations: list[Any] = []
+        all_engine_prompts: list[Any] = []
+        single_requests: list[ChatCompletionRequest] = []
+
+        for messages in request.messages:
+            single_request = request.to_chat_completion_request(messages)
+            single_request.stream = False
+            single_requests.append(single_request)
+
+            try:
+                if not self.use_harmony:
+                    merged_kwargs = self._effective_chat_template_kwargs(single_request)
+                    conversation, engine_prompts = await self._preprocess_chat(
+                        single_request,
+                        single_request.messages,
+                        default_template=(
+                            single_request.chat_template or self.chat_template
+                        ),
+                        default_template_content_format=(
+                            self.chat_template_content_format
+                        ),
+                        default_template_kwargs=merged_kwargs,
+                        tool_dicts=tool_dicts,
+                        tool_parser=tool_parser,
+                        renderer=renderer,
+                        add_generation_prompt=single_request.add_generation_prompt,
+                        continue_final_message=single_request.continue_final_message,
+                        documents=getattr(single_request, "documents", None),
+                        add_special_tokens=single_request.add_special_tokens,
+                    )
+                else:
+                    should_include_tools = tool_dicts is not None
+                    conversation, engine_prompts = (
+                        self.online_renderer._make_request_with_harmony(
+                            single_request, should_include_tools,
+                        )
+                    )
+            except (ValueError, TypeError, RuntimeError) as e:
+                logger.exception("Error preprocessing batch item")
+                message = str(e)
+                if e.__cause__ is not None:
+                    message = f"{message} {e.__cause__}"
+                return self.create_error_response(message)
+
+            all_conversations.append(conversation)
+            all_engine_prompts.append(engine_prompts[0])
+
+        return all_conversations, all_engine_prompts, single_requests
 
     async def create_batch_chat_completion(
         self,

--- a/vllm_omni/entrypoints/openai/batch_serving.py
+++ b/vllm_omni/entrypoints/openai/batch_serving.py
@@ -31,6 +31,7 @@ from vllm.utils.async_utils import merge_async_iterators
 
 from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
 from vllm_omni.entrypoints.openai.utils import is_single_stage_diffusion
+from vllm_omni.entrypoints.utils import coerce_param_message_types
 
 logger = init_logger(__name__)
 
@@ -368,8 +369,110 @@ class OmniOpenAIServingChatBatch(OmniOpenAIServingChat):
         request: BatchChatCompletionRequest,
         raw_request: Request,
     ) -> ChatCompletionResponse | ErrorResponse:
-        """Given a request, submit each request to chat completions & collect the results."""
-        return await self._create_batch_chat_completion_legacy(request, raw_request)
+        """Process N conversations concurrently via direct engine submission.
+
+        Validates the request once, preprocesses each conversation, submits
+        each to the engine directly, and collects results into a single
+        response.
+        """
+        render_result = await self.render_batch_chat_request(request)
+        if isinstance(render_result, ErrorResponse):
+            return render_result
+        all_conversations, all_engine_prompts, single_requests = render_result
+
+        base_id = self._base_request_id(raw_request, request.request_id)
+        request_id = f"chatcmpl-batch-{base_id}"
+
+        lora_request = self._maybe_get_adapters(
+            request, supports_default_mm_loras=True,
+        )
+        model_name = self.models.model_name(lora_request)
+
+        tokenizer = self.renderer.get_tokenizer()
+        if tokenizer is None:
+            tokenizer = await self.engine_client.get_tokenizer()
+
+        reasoning_parser = None
+        if (
+            self.parser_cls is not None
+            and self.parser_cls.reasoning_parser_cls is not None
+        ):
+            chat_template_kwargs = self._effective_chat_template_kwargs(
+                request,
+            )
+            reasoning_parser = self.parser_cls.reasoning_parser_cls(
+                tokenizer,
+                chat_template_kwargs=chat_template_kwargs,
+            )
+
+        request_metadata = RequestResponseMetadata(request_id=request_id)
+        if raw_request:
+            raw_request.state.request_metadata = request_metadata
+
+        output_modalities = request.modalities
+
+        request_timestamp = time.time()
+        if raw_request is not None:
+            request_timestamp = float(
+                getattr(
+                    raw_request.state,
+                    "request_timestamp",
+                    request_timestamp,
+                )
+            )
+
+        generators = []
+        try:
+            for i, engine_prompt in enumerate(all_engine_prompts):
+                sub_request_id = f"{request_id}-idx-{i}"
+
+                if (
+                    hasattr(request, "sampling_params_list")
+                    and request.sampling_params_list
+                ):
+                    sampling_params_list = self._to_sampling_params_list(
+                        request.sampling_params_list,
+                    )
+                else:
+                    sampling_params_list = (
+                        self._build_sampling_params_list_from_request(
+                            single_requests[i],
+                        )
+                    )
+
+                sampling_params_list = coerce_param_message_types(
+                    sampling_params_list, False,
+                )
+
+                self._log_inputs(
+                    sub_request_id,
+                    engine_prompt,
+                    params_list=sampling_params_list,
+                    lora_request=lora_request,
+                )
+
+                generator = self.engine_client.generate(
+                    prompt=engine_prompt,
+                    request_id=sub_request_id,
+                    sampling_params_list=sampling_params_list,
+                    output_modalities=output_modalities,
+                    arrival_time=request_timestamp,
+                    lora_request=lora_request,
+                )
+                generators.append(generator)
+        except ValueError as e:
+            return self.create_error_response(str(e))
+
+        return await self.chat_completion_full_generator_batch(
+            request,
+            generators,
+            request_id,
+            model_name,
+            all_conversations,
+            tokenizer,
+            request_metadata,
+            reasoning_parser,
+        )
 
     async def _create_batch_chat_completion_legacy(
         self,

--- a/vllm_omni/entrypoints/openai/batch_serving.py
+++ b/vllm_omni/entrypoints/openai/batch_serving.py
@@ -384,7 +384,8 @@ class OmniOpenAIServingChatBatch(OmniOpenAIServingChat):
         request_id = f"chatcmpl-batch-{base_id}"
 
         lora_request = self._maybe_get_adapters(
-            request, supports_default_mm_loras=True,
+            request,
+            supports_default_mm_loras=True,
         )
         model_name = self.models.model_name(lora_request)
 
@@ -393,10 +394,7 @@ class OmniOpenAIServingChatBatch(OmniOpenAIServingChat):
             tokenizer = await self.engine_client.get_tokenizer()
 
         reasoning_parser = None
-        if (
-            self.parser_cls is not None
-            and self.parser_cls.reasoning_parser_cls is not None
-        ):
+        if self.parser_cls is not None and self.parser_cls.reasoning_parser_cls is not None:
             chat_template_kwargs = self._effective_chat_template_kwargs(
                 request,
             )
@@ -426,22 +424,18 @@ class OmniOpenAIServingChatBatch(OmniOpenAIServingChat):
             for i, engine_prompt in enumerate(all_engine_prompts):
                 sub_request_id = f"{request_id}-idx-{i}"
 
-                if (
-                    hasattr(request, "sampling_params_list")
-                    and request.sampling_params_list
-                ):
+                if hasattr(request, "sampling_params_list") and request.sampling_params_list:
                     sampling_params_list = self._to_sampling_params_list(
                         request.sampling_params_list,
                     )
                 else:
-                    sampling_params_list = (
-                        self._build_sampling_params_list_from_request(
-                            single_requests[i],
-                        )
+                    sampling_params_list = self._build_sampling_params_list_from_request(
+                        single_requests[i],
                     )
 
                 sampling_params_list = coerce_param_message_types(
-                    sampling_params_list, False,
+                    sampling_params_list,
+                    False,
                 )
 
                 self._log_inputs(

--- a/vllm_omni/entrypoints/openai/batch_serving.py
+++ b/vllm_omni/entrypoints/openai/batch_serving.py
@@ -66,6 +66,14 @@ class OmniOpenAIServingChatBatch(OmniOpenAIServingChat):
         raw_request: Request,
     ) -> ChatCompletionResponse | ErrorResponse:
         """Given a request, submit each request to chat completions & collect the results."""
+        return await self._create_batch_chat_completion_legacy(request, raw_request)
+
+    async def _create_batch_chat_completion_legacy(
+        self,
+        request: BatchChatCompletionRequest,
+        raw_request: Request,
+    ) -> ChatCompletionResponse | ErrorResponse:
+        """Legacy implementation: submits each item via create_chat_completion."""
         model = ""
         enabled_streaming = False
         chat_requests: list[ChatCompletionRequest] = []


### PR DESCRIPTION
## Summary

Replace the legacy per-request delegation in `create_batch_chat_completion` with a validate-once, direct-engine-submission path. Batch-level checks (model, LoRA, tokenizer, template, modalities) run once, while per-item work (Mistral normalization, chat preprocessing, response role) runs per conversation. Diffusion batches fall back to the legacy path.

## Test plan
- [x] `pytest tests/entrypoints/openai/test_batch_chat_completions.py` — 16 tests pass