### PR TITLE
[Model] Add NeuTTS-Air TTS support

### DIFF
--- a/docs/user_guide/examples/online_serving/text_to_speech.md
+++ b/docs/user_guide/examples/online_serving/text_to_speech.md
@@ -22,6 +22,7 @@ For the full list of supported architectures across all modalities, see
 | higgs-audio v2 | `bosonai/higgs-audio-v2-generation-3B-base` | ✓ (`ref_audio`+`ref_text`) | ✓ (codec_streaming) | — | — |
 | GLM-TTS | `zai-org/GLM-TTS` | ✓ (`ref_audio`+`ref_text`, required) | ✓ (PCM stream) | — | ✓ |
 | OmniVoice | `k2-fsa/OmniVoice` | (offline only) | — | — | — |
+| NeuTTS-Air | `neuphonic/neutts-air` | ✓ (`ref_audio`+`ref_text`, required) | ✓ (PCM stream) | — | — |
 | Qwen3-TTS | `Qwen/Qwen3-TTS-12Hz-1.7B-{CustomVoice,VoiceDesign,Base}` | ✓ (Base) | ✓ (PCM + WebSocket) | ✓ (presets + `/v1/audio/voices` upload) | ✓ (standard + FastRTC) |
 | VoxCPM2 | `openbmb/VoxCPM2` | ✓ | ✓ (AudioWorklet via gradio) | — | ✓ |
 | Voxtral TTS | `mistralai/Voxtral-4B-TTS-2603` | ✓ (gated upstream) | ✓ | ✓ (presets) | ✓ |
@@ -303,6 +304,38 @@ The client supports `--api-base`, `--model`, `--text`, `--response-format`, `--l
 - Voice cloning and voice design require offline inference; see the [offline OmniVoice section](https://github.com/vllm-project/vllm-omni/tree/main/examples/offline_inference/text_to_speech/README.md#omnivoice).
 
 ---
+
+## NeuTTS-Air
+
+### Prerequisites
+
+```bash
+pip install -e '.[neutts-air]'
+```
+
+### Launch
+
+```bash
+vllm serve neuphonic/neutts-air --omni --host 0.0.0.0 --port 8000
+```
+
+### Voice cloning
+
+```bash
+curl http://localhost:8000/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "neuphonic/neutts-air",
+    "input": "Hello from NeuTTS-Air.",
+    "ref_audio": "file:///path/to/reference.wav",
+    "ref_text": "Transcript of the reference audio.",
+    "response_format": "wav",
+    "stream": true
+  }' \
+  --output neutts_air.wav
+```
+
+NeuTTS-Air currently supports English synthesis and produces 24 kHz audio. Each request requires one reference-audio and reference-text pair. Reference audio is encoded on CPU unless precomputed reference codes are supplied. The default deployment supports up to four concurrent sequences.
 
 ## Qwen3-TTS
 

--- a/examples/offline_inference/text_to_speech/README.md
+++ b/examples/offline_inference/text_to_speech/README.md
@@ -21,6 +21,7 @@ list of supported architectures across all modalities, see
 | Ming-flash-omni-TTS | `Jonathan1909/Ming-flash-omni-2.0` | single (talker only) | — (caption-controlled) | — | style / IP / basic captions | 44.1 kHz |
 | MOSS-TTS-Nano | `OpenMOSS-Team/MOSS-TTS-Nano` | single (AR + codec) | ✓ (required) | ✓ | voice_clone, continuation | 48 kHz |
 | OmniVoice | `k2-fsa/OmniVoice` | 2 (gen + dec) | ✓ | — | voice design, language hint | 24 kHz |
+| NeuTTS-Air | `neuphonic/neutts-air` | 2 (Qwen2 + NeuCodec) | ✓ (required) | ✓ | — | 24 kHz |
 | Qwen3-TTS | `Qwen/Qwen3-TTS-12Hz-1.7B-{CustomVoice,VoiceDesign,Base}` | 2 (talker + code2wav) | ✓ (Base) | ✓ | 3 task variants | 24 kHz |
 | VoxCPM2 | `openbmb/VoxCPM2` | single (native AR) | ✓ | ✓ (online) | continuation | 48 kHz |
 | dots.tts | `rednote-hilab/dots.tts-soar` | single (native AR) | — (not wired yet) | — | — | 48 kHz |
@@ -328,6 +329,30 @@ python examples/offline_inference/text_to_speech/omnivoice/end2end.py \
 - Stage 1 (Decoder): HiggsAudioV2 RVQ + DAC at 24 kHz.
 
 ---
+
+## NeuTTS-Air
+
+NeuTTS-Air uses a native vLLM Qwen2 stage to generate speech tokens, followed by NeuCodec waveform decoding.
+
+### Prerequisites
+
+```bash
+pip install -e '.[neutts-air]'
+```
+
+### Voice cloning
+
+```bash
+python neutts_air/end2end.py \
+  --text "Hello from NeuTTS-Air." \
+  --ref-audio /path/to/reference.wav \
+  --ref-text "Transcript of the reference audio." \
+  --output outputs/neutts_air.wav
+```
+
+The reference audio and transcript are required. Reference audio is converted to mono 16 kHz before NeuCodec encoding. Supplying precomputed reference codes avoids this CPU encoding step.
+
+NeuTTS-Air currently supports English synthesis and produces 24 kHz audio. Its two-stage pipeline supports asynchronous chunked streaming.
 
 ## Qwen3-TTS
 

--- a/examples/offline_inference/text_to_speech/neutts_air/end2end.py
+++ b/examples/offline_inference/text_to_speech/neutts_air/end2end.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Offline end-to-end inference example for NeuTTS-Air."""
+
+import argparse
+import time
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+import torch
+from vllm import SamplingParams
+
+from vllm_omni import Omni
+
+OUTPUT_SAMPLE_RATE = 24_000
+SPEECH_GENERATION_END_TOKEN_ID = 151670
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="NeuTTS-Air E2E TTS inference")
+    parser.add_argument("--model", default="neuphonic/neutts-air")
+    parser.add_argument("--text", required=True, help="Target text to synthesize.")
+    parser.add_argument("--ref-audio", required=True, help="Reference voice audio path.")
+    parser.add_argument(
+        "--ref-text",
+        required=True,
+        help="Transcript of the reference audio.",
+    )
+    parser.add_argument("--output", default="outputs/neutts_air.wav")
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--temperature", type=float, default=1.0)
+    parser.add_argument("--top-p", type=float, default=0.8)
+    parser.add_argument("--top-k", type=int, default=50)
+    parser.add_argument("--repetition-penalty", type=float, default=1.1)
+    parser.add_argument("--max-tokens", type=int, default=512)
+    return parser.parse_args()
+
+
+def load_reference_audio(path: str) -> tuple[np.ndarray, int]:
+    audio, sample_rate = sf.read(path, dtype="float32", always_2d=False)
+    if audio.ndim == 2:
+        audio = audio.mean(axis=1)
+    return np.asarray(audio, dtype=np.float32), int(sample_rate)
+
+
+def main() -> None:
+    args = parse_args()
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    reference_audio, reference_sample_rate = load_reference_audio(args.ref_audio)
+    request = {
+        "prompt": args.text,
+        "multi_modal_data": {
+            "audio": (reference_audio, reference_sample_rate),
+        },
+        "mm_processor_kwargs": {
+            "ref_text": args.ref_text,
+        },
+    }
+
+    stage0_params = SamplingParams(
+        temperature=args.temperature,
+        top_p=args.top_p,
+        top_k=args.top_k,
+        repetition_penalty=args.repetition_penalty,
+        max_tokens=args.max_tokens,
+        min_tokens=50,
+        seed=args.seed,
+        detokenize=False,
+        stop_token_ids=[SPEECH_GENERATION_END_TOKEN_ID],
+        ignore_eos=True,
+    )
+    stage1_params = SamplingParams(
+        temperature=0.0,
+        top_p=1.0,
+        top_k=-1,
+        max_tokens=1,
+        seed=args.seed,
+        detokenize=False,
+    )
+
+    omni = None
+    try:
+        omni = Omni(model=args.model, trust_remote_code=True, log_stats=False)
+        started_at = time.perf_counter()
+        outputs = omni.generate([request], [stage0_params, stage1_params])
+        elapsed = time.perf_counter() - started_at
+
+        audio_array = None
+        for stage_output in outputs:
+            print("final output type:", stage_output.final_output_type)
+            if stage_output.final_output_type != "audio":
+                continue
+            multimodal_output = stage_output.request_output.outputs[0].multimodal_output
+            audio = multimodal_output.get("audio")
+            if audio is None:
+                raise RuntimeError("NeuTTS-Air returned an empty audio output.")
+            if isinstance(audio, torch.Tensor):
+                audio = audio.float().detach().cpu().numpy()
+            audio_array = np.asarray(audio, dtype=np.float32).reshape(-1)
+
+        if audio_array is None or audio_array.size == 0:
+            raise RuntimeError("NeuTTS-Air produced no final audio samples.")
+        if not np.isfinite(audio_array).all():
+            raise RuntimeError("NeuTTS-Air produced NaN or infinite audio samples.")
+
+        sf.write(output_path, audio_array, OUTPUT_SAMPLE_RATE, format="WAV")
+
+        peak = float(np.max(np.abs(audio_array)))
+        rms = float(np.sqrt(np.mean(audio_array**2)))
+        clipped_ratio = float(np.mean(np.abs(audio_array) >= 0.999))
+        print("sample rate:", OUTPUT_SAMPLE_RATE)
+        print("duration:", audio_array.size / OUTPUT_SAMPLE_RATE)
+        print("latency:", elapsed)
+        print("max abs:", peak)
+        print("rms:", rms)
+        print("clipped ratio:", clipped_ratio)
+        print("saved:", output_path)
+    finally:
+        if omni is not None:
+            omni.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,12 @@ demo = [
     "cn2an>=0.5.22",  # Chinese number normalization for TTS (e.g. "1次" -> "一次")
 ]
 
+neutts-air = [
+    "neucodec>=0.0.4",
+    "phonemizer>=3.0.0",
+    "espeakng-loader==0.2.4",
+]
+
 forced-aligner = [
     "qwen-asr>=0.0.6",  # faithful Japanese/Korean word segmentation for the TTS forced aligner
 ]

--- a/tests/config/test_neutts_air_pipeline.py
+++ b/tests/config/test_neutts_air_pipeline.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_omni.config import load_deploy_config
+from vllm_omni.config.pipeline_registry import OMNI_PIPELINES
+from vllm_omni.model_executor.models.neutts_air.pipeline import (
+    NEUTTS_AIR_PIPELINE,
+    is_neutts_air_config,
+)
+from vllm_omni.model_executor.models.registry import _OMNI_MODELS
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _neutts_config(**overrides):
+    values = {
+        "model_type": "qwen2",
+        "vocab_size": 217652,
+        "hidden_size": 896,
+        "num_hidden_layers": 24,
+        "num_attention_heads": 14,
+        "num_key_value_heads": 2,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_neutts_air_config_fingerprint_accepts_the_backbone():
+    assert is_neutts_air_config(_neutts_config())
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("model_type", "qwen2_audio"),
+        ("vocab_size", 151936),
+        ("hidden_size", 4096),
+        ("num_hidden_layers", 32),
+        ("num_attention_heads", 32),
+        ("num_key_value_heads", 8),
+    ],
+)
+def test_neutts_air_config_fingerprint_rejects_other_qwen2_models(
+    field,
+    value,
+):
+    assert not is_neutts_air_config(_neutts_config(**{field: value}))
+
+
+def test_neutts_air_pipeline_and_decoder_are_registered():
+    assert OMNI_PIPELINES["neutts_air"] is NEUTTS_AIR_PIPELINE
+    assert _OMNI_MODELS["NeuTTSAirForCausalLM"] == (
+        "neutts_air",
+        "neutts_air_talker",
+        "NeuTTSAirForCausalLM",
+    )
+    assert _OMNI_MODELS["NeuTTSAirCode2Wav"] == (
+        "neutts_air",
+        "neutts_air_code2wav",
+        "NeuTTSAirCode2Wav",
+    )
+    assert NEUTTS_AIR_PIPELINE.model_arch == "NeuTTSAirForCausalLM"
+    assert NEUTTS_AIR_PIPELINE.validate() == []
+
+
+def test_neutts_air_default_deploy_enables_async_chunking():
+    deploy_path = Path(__file__).parents[2] / "vllm_omni" / "deploy" / "neutts_air.yaml"
+
+    deploy = load_deploy_config(deploy_path)
+
+    assert deploy.async_chunk is True
+    assert len(deploy.stages) == 2
+
+
+def test_neutts_air_deploy_capacity_defaults():
+    from pathlib import Path
+
+    import yaml
+
+    deploy_path = Path(__file__).resolve().parents[2] / "vllm_omni" / "deploy" / "neutts_air.yaml"
+    config = yaml.safe_load(deploy_path.read_text(encoding="utf-8"))
+    stages = {stage["stage_id"]: stage for stage in config["stages"]}
+
+    stage0 = stages[0]
+    stage1 = stages[1]
+
+    assert stage0["max_num_seqs"] == 4
+    assert stage0["kv_cache_memory_bytes"] == 512 * 1024 * 1024
+    assert "gpu_memory_utilization" not in stage0
+    assert stage1["max_num_seqs"] == 4

--- a/tests/entrypoints/openai_api/test_neutts_air_tts_adapter.py
+++ b/tests/entrypoints/openai_api/test_neutts_air_tts_adapter.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from vllm import SamplingParams
+
+from vllm_omni.entrypoints.openai.serving_speech import OmniOpenAIServingSpeech
+from vllm_omni.entrypoints.openai.tts_adapters import (
+    detect_tts_model_type,
+    resolve_adapter,
+)
+from vllm_omni.entrypoints.openai.tts_adapters.base import SpeechServingContext
+from vllm_omni.entrypoints.openai.tts_adapters.neutts_air import (
+    NEUTTS_SPEECH_GENERATION_END_TOKEN_ID,
+    NeuTTSAirAdapter,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class FakeSpeechServer:
+    def __init__(self) -> None:
+        self.resolved_ref_audio: str | None = None
+
+    def _validate_ref_audio_format(self, ref_audio: str) -> str | None:
+        if ref_audio == "bad-audio":
+            return "Invalid reference audio"
+        return None
+
+    async def _resolve_ref_audio(self, ref_audio: str) -> tuple[list[float], int]:
+        self.resolved_ref_audio = ref_audio
+        return [0.0, 0.25, -0.25], 16_000
+
+
+def _request(**changes):
+    values = {
+        "input": "Hello, this is a test.",
+        "ref_audio": "file:///tmp/reference.wav",
+        "ref_text": "My name is Jo.",
+        "max_new_tokens": None,
+    }
+    values.update(changes)
+    return SimpleNamespace(**values)
+
+
+def _adapter() -> tuple[NeuTTSAirAdapter, FakeSpeechServer]:
+    server = FakeSpeechServer()
+    adapter = NeuTTSAirAdapter(SpeechServingContext(server=server))
+    return adapter, server
+
+
+def test_neutts_air_adapter_is_registered_and_detectable():
+    assert resolve_adapter("neutts_air") is NeuTTSAirAdapter
+    assert detect_tts_model_type("neucodec", "NeuTTSAirCode2Wav") == "neutts_air"
+
+    serving = object.__new__(OmniOpenAIServingSpeech)
+    serving._tts_stage = SimpleNamespace(
+        engine_args=SimpleNamespace(
+            model_stage="neucodec",
+            model_arch="NeuTTSAirCode2Wav",
+        )
+    )
+    assert serving._detect_tts_model_type() == "neutts_air"
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"input": "  "}, "Input text cannot be empty"),
+        ({"ref_audio": None}, "requires 'ref_audio'"),
+        ({"ref_audio": ["one.wav", "two.wav"]}, "exactly one 'ref_audio'"),
+        ({"ref_audio": "bad-audio"}, "Invalid reference audio"),
+        ({"ref_text": "  "}, "requires 'ref_text'"),
+        ({"max_new_tokens": 49}, "must be at least 50"),
+        ({"max_new_tokens": 4097}, "cannot exceed 4096"),
+    ],
+)
+def test_neutts_air_adapter_validation(changes, message):
+    adapter, _ = _adapter()
+    assert message in (adapter.validate(_request(**changes)) or "")
+
+
+def test_neutts_air_adapter_builds_the_offline_prompt_contract():
+    adapter, server = _adapter()
+    request = _request()
+
+    prepared = asyncio.run(adapter.build(request, [], True))
+
+    assert prepared.model_type == "neutts_air"
+    assert prepared.prompt["prompt"] == request.input
+    assert prepared.prompt["mm_processor_kwargs"] == {
+        "ref_text": request.ref_text,
+    }
+
+    audio, sample_rate = prepared.prompt["multi_modal_data"]["audio"]
+    assert isinstance(audio, np.ndarray)
+    assert audio.dtype == np.float32
+    assert audio.ndim == 1
+    np.testing.assert_array_equal(
+        audio,
+        np.asarray([0.0, 0.25, -0.25], dtype=np.float32),
+    )
+    assert sample_rate == 16_000
+    assert server.resolved_ref_audio == request.ref_audio
+
+
+def test_neutts_air_adapter_applies_required_sampling_contract():
+    adapter, _ = _adapter()
+    original = [
+        SamplingParams(
+            temperature=0.7,
+            top_p=0.6,
+            top_k=20,
+            max_tokens=2048,
+        ),
+        SamplingParams(max_tokens=2048),
+    ]
+
+    params = adapter.apply_sampling_overrides(
+        original,
+        _request(max_new_tokens=256),
+    )
+
+    assert params is not original
+    assert original[0].max_tokens == 2048
+    assert params[0].temperature == 0.7
+    assert params[0].top_p == 0.6
+    assert params[0].top_k == 20
+    assert params[0].max_tokens == 256
+    assert params[0].min_tokens == 50
+    assert params[0].stop_token_ids == [NEUTTS_SPEECH_GENERATION_END_TOKEN_ID]
+    assert params[0].ignore_eos
+    assert not params[0].detokenize
+    assert params[1].max_tokens == 1
+    assert not params[1].detokenize

--- a/tests/model_executor/models/test_neutts_air_code2wav.py
+++ b/tests/model_executor/models/test_neutts_air_code2wav.py
@@ -1,0 +1,278 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+from vllm_omni.model_executor.models.neutts_air.neutts_air_code2wav import (
+    NEUTTS_HOP_LENGTH,
+    NEUTTS_SAMPLE_RATE,
+    NeuTTSAirCode2Wav,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class FakeNeuCodec(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.received_codes: list[torch.Tensor] = []
+        self.returned_audio: list[torch.Tensor] = []
+
+    def decode_code(self, codes: torch.Tensor) -> torch.Tensor:
+        call_index = len(self.received_codes)
+        self.received_codes.append(codes.clone())
+        values = codes[0, 0].to(torch.float32) + call_index * 0.25
+        waveform = torch.repeat_interleave(values, NEUTTS_HOP_LENGTH)
+        audio = waveform.reshape(1, 1, -1)
+        self.returned_audio.append(audio.clone())
+        return audio
+
+
+def _make_decoder() -> tuple[NeuTTSAirCode2Wav, FakeNeuCodec]:
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(hf_config=SimpleNamespace()),
+        device_config=SimpleNamespace(device=torch.device("cpu")),
+    )
+    decoder = NeuTTSAirCode2Wav(vllm_config=config)
+    codec = FakeNeuCodec()
+    decoder._codec = codec
+    return decoder, codec
+
+
+def _stream_info(
+    request_id: str,
+    *,
+    left_context: int,
+    right_holdback: int,
+    processed_frames: int,
+    finished: bool = False,
+) -> list[dict]:
+    return [
+        {
+            "meta": {
+                "req_id": [request_id],
+                "left_context_size": left_context,
+                "right_holdback_size": right_holdback,
+                "num_processed_tokens": processed_frames,
+                "codec_streaming": True,
+                "codec_chunk_frames": 25,
+                "stream_finished": torch.tensor(finished),
+            }
+        }
+    ]
+
+
+def _audio(output) -> torch.Tensor:
+    assert output.multimodal_outputs is not None
+    return output.multimodal_outputs["model_outputs"][0]
+
+
+def _reference_overlap_add(
+    frames: list[torch.Tensor],
+    stride: int,
+) -> torch.Tensor:
+    arrays = [frame.detach().cpu().numpy() for frame in frames]
+    total_size = max(stride * index + frame.shape[-1] for index, frame in enumerate(arrays))
+    output = np.zeros(total_size, dtype=np.float32)
+    sum_weight = np.zeros(total_size, dtype=np.float32)
+    for index, frame in enumerate(arrays):
+        positions = np.linspace(
+            0,
+            1,
+            frame.shape[-1] + 2,
+            dtype=np.float32,
+        )[1:-1]
+        weight = 0.5 - np.abs(positions - 0.5)
+        offset = index * stride
+        output[offset : offset + frame.shape[-1]] += weight * frame
+        sum_weight[offset : offset + frame.shape[-1]] += weight
+    return torch.from_numpy(output / sum_weight)
+
+
+def test_forward_splits_requests_before_neucodec_decode():
+    decoder, codec = _make_decoder()
+
+    output = decoder(
+        input_ids=torch.tensor([0, 29, 8, 15, 20]),
+        seq_token_counts=[2, 3],
+    )
+
+    assert len(codec.received_codes) == 2
+    assert codec.received_codes[0].tolist() == [[[0, 29]]]
+    assert codec.received_codes[1].tolist() == [[[8, 15, 20]]]
+
+    assert output.multimodal_outputs is not None
+    audios = output.multimodal_outputs["model_outputs"]
+    sample_rates = output.multimodal_outputs["sr"]
+    assert [audio.numel() for audio in audios] == [960, 1440]
+    assert [int(sample_rate.item()) for sample_rate in sample_rates] == [
+        NEUTTS_SAMPLE_RATE,
+        NEUTTS_SAMPLE_RATE,
+    ]
+    assert all(audio.dtype == torch.float32 for audio in audios)
+    assert all(audio.device.type == "cpu" for audio in audios)
+    assert all(bool(torch.isfinite(audio).all()) for audio in audios)
+
+
+def test_forward_empty_input_does_not_load_neucodec():
+    decoder, codec = _make_decoder()
+
+    output = decoder(input_ids=torch.empty((0,), dtype=torch.long))
+
+    assert codec.received_codes == []
+    assert output.multimodal_outputs is not None
+    assert output.multimodal_outputs["model_outputs"][0].numel() == 0
+
+
+def test_streaming_30_55_63_chunks_match_official_overlap_add():
+    decoder, codec = _make_decoder()
+    stride = 25 * NEUTTS_HOP_LENGTH
+
+    first = _audio(
+        decoder(
+            input_ids=torch.arange(81),
+            runtime_additional_information=_stream_info(
+                "rid-flow",
+                left_context=51,
+                right_holdback=3,
+                processed_frames=25,
+            ),
+        )
+    )
+    second = _audio(
+        decoder(
+            input_ids=torch.arange(81) + 25,
+            runtime_additional_information=_stream_info(
+                "rid-flow",
+                left_context=51,
+                right_holdback=3,
+                processed_frames=25,
+            ),
+        )
+    )
+    final = _audio(
+        decoder(
+            input_ids=torch.arange(64) + 50,
+            runtime_additional_information=_stream_info(
+                "rid-flow",
+                left_context=50,
+                right_holdback=0,
+                processed_frames=13,
+                finished=True,
+            ),
+        )
+    )
+
+    cropped_frames = [
+        codec.returned_audio[0][0, 0][51 * NEUTTS_HOP_LENGTH : -3 * NEUTTS_HOP_LENGTH],
+        codec.returned_audio[1][0, 0][51 * NEUTTS_HOP_LENGTH : -3 * NEUTTS_HOP_LENGTH],
+        codec.returned_audio[2][0, 0][50 * NEUTTS_HOP_LENGTH :],
+    ]
+    expected = _reference_overlap_add(cropped_frames, stride)
+
+    assert [first.numel(), second.numel(), final.numel()] == [
+        stride,
+        stride,
+        expected.numel() - 2 * stride,
+    ]
+    assert torch.allclose(
+        torch.cat([first, second, final]),
+        expected,
+        atol=1e-5,
+        rtol=1e-5,
+    )
+    assert "rid-flow" not in decoder._stream_states
+
+
+def test_streaming_context_only_terminal_flushes_tail_without_decoding():
+    decoder, codec = _make_decoder()
+    stride = 25 * NEUTTS_HOP_LENGTH
+
+    first = _audio(
+        decoder(
+            input_ids=torch.arange(81),
+            runtime_additional_information=_stream_info(
+                "rid-eof",
+                left_context=51,
+                right_holdback=3,
+                processed_frames=25,
+            ),
+        )
+    )
+    terminal = _audio(
+        decoder(
+            input_ids=torch.tensor([80]),
+            runtime_additional_information=_stream_info(
+                "rid-eof",
+                left_context=1,
+                right_holdback=0,
+                processed_frames=0,
+                finished=True,
+            ),
+        )
+    )
+
+    cropped = codec.returned_audio[0][0, 0][51 * NEUTTS_HOP_LENGTH : -3 * NEUTTS_HOP_LENGTH]
+    assert len(codec.received_codes) == 1
+    assert first.numel() == stride
+    assert terminal.numel() == cropped.numel() - stride
+    assert torch.allclose(torch.cat([first, terminal]), cropped)
+    assert "rid-eof" not in decoder._stream_states
+
+
+def test_streaming_state_is_isolated_by_request_id():
+    decoder, _ = _make_decoder()
+
+    for request_id in ["rid-a", "rid-b"]:
+        decoder(
+            input_ids=torch.arange(81),
+            runtime_additional_information=_stream_info(
+                request_id,
+                left_context=51,
+                right_holdback=3,
+                processed_frames=25,
+            ),
+        )
+
+    assert set(decoder._stream_states) == {"rid-a", "rid-b"}
+
+    decoder(
+        input_ids=torch.tensor([80]),
+        runtime_additional_information=_stream_info(
+            "rid-a",
+            left_context=1,
+            right_holdback=0,
+            processed_frames=0,
+            finished=True,
+        ),
+    )
+
+    assert set(decoder._stream_states) == {"rid-b"}
+
+
+def test_on_requests_finished_clears_only_target_stream_state():
+    decoder, _ = _make_decoder()
+
+    for request_id in ["rid-a", "rid-b"]:
+        decoder(
+            input_ids=torch.arange(81),
+            runtime_additional_information=_stream_info(
+                request_id,
+                left_context=51,
+                right_holdback=3,
+                processed_frames=25,
+            ),
+        )
+
+    assert set(decoder._stream_states) == {"rid-a", "rid-b"}
+
+    decoder.on_requests_finished(["rid-a", "unknown"])
+    assert set(decoder._stream_states) == {"rid-b"}
+
+    decoder.on_requests_finished(["rid-b"])
+    assert decoder._stream_states == {}

--- a/tests/model_executor/models/test_neutts_air_talker.py
+++ b/tests/model_executor/models/test_neutts_air_talker.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+from vllm.model_executor.models.qwen2 import Qwen2ForCausalLM
+from vllm.multimodal.parse import MultiModalDataItems
+from vllm.multimodal.processing import ProcessorInputs, TimingContext
+
+from vllm_omni.model_executor.models.neutts_air import neutts_air_talker
+from vllm_omni.model_executor.models.neutts_air.neutts_air_talker import (
+    NEUTTS_SPEECH_TOKEN_OFFSET,
+    NeuTTSAirForCausalLM,
+    NeuTTSAirMultiModalProcessor,
+    build_neutts_air_prompt_token_ids,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class FakeTokenizer:
+    special_ids = {
+        "<|TEXT_REPLACE|>": 10,
+        "<|TEXT_PROMPT_START|>": 11,
+        "<|TEXT_PROMPT_END|>": 12,
+        "<|SPEECH_REPLACE|>": 13,
+        "<|SPEECH_GENERATION_START|>": 14,
+    }
+
+    def encode(self, text, add_special_tokens=True):
+        del add_special_tokens
+        if text.startswith("user: Convert"):
+            return [100, 10, 101, 13, 102]
+        if text == "REF TARGET":
+            return [200, 201]
+        raise AssertionError(f"Unexpected tokenizer input: {text}")
+
+    def convert_tokens_to_ids(self, token):
+        return self.special_ids[token]
+
+
+class FakePhonemizer:
+    def phonemize(self, texts):
+        values = {"reference": "REF", "target": "TARGET"}
+        return [values[text] for text in texts]
+
+
+def test_prompt_builder_matches_the_official_neutts_layout():
+    prompt_ids = build_neutts_air_prompt_token_ids(
+        FakeTokenizer(),
+        ref_codes=[0, 29],
+        ref_text="reference",
+        target_text="target",
+        phonemize=lambda text: {"reference": "REF", "target": "TARGET"}[text],
+    )
+
+    assert prompt_ids == [
+        100,
+        11,
+        200,
+        201,
+        12,
+        101,
+        14,
+        NEUTTS_SPEECH_TOKEN_OFFSET,
+        NEUTTS_SPEECH_TOKEN_OFFSET + 29,
+    ]
+
+
+def test_prompt_builder_rejects_out_of_range_reference_codes():
+    with pytest.raises(ValueError, match="must be in"):
+        build_neutts_air_prompt_token_ids(
+            FakeTokenizer(),
+            ref_codes=[65536],
+            ref_text="reference",
+            target_text="target",
+            phonemize=str.upper,
+        )
+
+
+def test_processor_consumes_reference_codes_into_an_ordinary_token_prompt(
+    monkeypatch,
+):
+    monkeypatch.setattr(neutts_air_talker, "_PHONEMIZER", FakePhonemizer())
+    processor = object.__new__(NeuTTSAirMultiModalProcessor)
+    processor.info = SimpleNamespace(ctx=SimpleNamespace(tokenizer=FakeTokenizer()))
+    inputs = ProcessorInputs(
+        prompt="target",
+        mm_data_items=MultiModalDataItems({}),
+        hf_processor_mm_kwargs={
+            "ref_text": "reference",
+            "ref_codes": [0, 29],
+        },
+    )
+
+    output = processor.apply(inputs, TimingContext(enabled=False))
+
+    assert output["prompt_token_ids"][-2:] == [
+        NEUTTS_SPEECH_TOKEN_OFFSET,
+        NEUTTS_SPEECH_TOKEN_OFFSET + 29,
+    ]
+    assert output["mm_kwargs"] == {}
+    assert output["mm_placeholders"] == {}
+
+
+def test_talker_is_a_thin_native_qwen2_subclass():
+    assert issubclass(NeuTTSAirForCausalLM, Qwen2ForCausalLM)
+    assert NeuTTSAirForCausalLM.requires_raw_input_tokens
+
+
+def test_explicit_espeak_assets_configure_exact_paths(monkeypatch, tmp_path):
+    library = tmp_path / "libespeak-ng.so"
+    library.write_bytes(b"fake")
+    data_path = tmp_path / "espeak-ng-data"
+    data_path.mkdir()
+    configured = {}
+
+    wrapper = SimpleNamespace(
+        set_library=lambda path: configured.setdefault("library", path),
+        set_data_path=lambda path: configured.setdefault("data_path", path),
+    )
+    monkeypatch.setenv(
+        neutts_air_talker.NEUTTS_ESPEAK_LIBRARY_ENV,
+        str(library),
+    )
+    monkeypatch.setenv(
+        neutts_air_talker.NEUTTS_ESPEAK_DATA_PATH_ENV,
+        str(data_path),
+    )
+
+    assert neutts_air_talker._configure_explicit_espeak_assets(wrapper)
+    assert configured == {
+        "library": str(library),
+        "data_path": str(data_path),
+    }
+
+
+def test_explicit_espeak_assets_require_both_paths(monkeypatch, tmp_path):
+    library = tmp_path / "libespeak-ng.so"
+    library.write_bytes(b"fake")
+    monkeypatch.setenv(
+        neutts_air_talker.NEUTTS_ESPEAK_LIBRARY_ENV,
+        str(library),
+    )
+    monkeypatch.delenv(
+        neutts_air_talker.NEUTTS_ESPEAK_DATA_PATH_ENV,
+        raising=False,
+    )
+
+    with pytest.raises(RuntimeError, match="must be set together"):
+        neutts_air_talker._configure_explicit_espeak_assets(SimpleNamespace())
+
+
+def _install_fake_phonemizer(monkeypatch, version):
+    class FakeEspeakBackend:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def version(self):
+            return version
+
+    class FakeEspeakWrapper:
+        pass
+
+    phonemizer_module = ModuleType("phonemizer")
+    backend_module = ModuleType("phonemizer.backend")
+    espeak_module = ModuleType("phonemizer.backend.espeak")
+    wrapper_module = ModuleType("phonemizer.backend.espeak.wrapper")
+
+    phonemizer_module.__path__ = []
+    backend_module.__path__ = []
+    espeak_module.__path__ = []
+    backend_module.EspeakBackend = FakeEspeakBackend
+    wrapper_module.EspeakWrapper = FakeEspeakWrapper
+
+    monkeypatch.setitem(sys.modules, "phonemizer", phonemizer_module)
+    monkeypatch.setitem(sys.modules, "phonemizer.backend", backend_module)
+    monkeypatch.setitem(sys.modules, "phonemizer.backend.espeak", espeak_module)
+    monkeypatch.setitem(
+        sys.modules,
+        "phonemizer.backend.espeak.wrapper",
+        wrapper_module,
+    )
+    monkeypatch.setattr(
+        neutts_air_talker,
+        "_configure_explicit_espeak_assets",
+        lambda wrapper: True,
+    )
+    monkeypatch.setattr(neutts_air_talker, "_PHONEMIZER", None)
+
+
+def test_phonemizer_accepts_and_caches_the_official_espeak_version(monkeypatch):
+    expected = neutts_air_talker.EXPECTED_NEUTTS_ESPEAK_VERSION
+    _install_fake_phonemizer(monkeypatch, expected)
+
+    phonemizer = neutts_air_talker._get_english_phonemizer()
+
+    assert tuple(phonemizer.version()) == expected
+    assert neutts_air_talker._get_english_phonemizer() is phonemizer
+
+
+def test_phonemizer_rejects_an_unexpected_espeak_version(monkeypatch):
+    _install_fake_phonemizer(monkeypatch, (1, 52, 0))
+
+    with pytest.raises(RuntimeError, match="official eSpeak assets"):
+        neutts_air_talker._get_english_phonemizer()

--- a/tests/model_executor/stage_input_processors/test_neutts_air_stage_input_processors.py
+++ b/tests/model_executor/stage_input_processors/test_neutts_air_stage_input_processors.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections import defaultdict
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_omni.model_executor.stage_input_processors.neutts_air import (
+    NEUTTS_SPEECH_GENERATION_START_TOKEN_ID,
+    NEUTTS_SPEECH_TOKEN_OFFSET,
+    filter_speech_codes,
+    llm2neucodec_async_chunk,
+    llm2neucodec_sync,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _speech_tokens(codes: list[int]) -> list[int]:
+    return [NEUTTS_SPEECH_TOKEN_OFFSET + code for code in codes]
+
+
+def _request(
+    request_id: str,
+    reference_codes: list[int],
+    target_codes: list[int],
+    *,
+    finished: bool = False,
+):
+    prompt_token_ids = [
+        100,
+        NEUTTS_SPEECH_GENERATION_START_TOKEN_ID,
+        *_speech_tokens(reference_codes),
+    ]
+    all_token_ids = [
+        *prompt_token_ids,
+        *_speech_tokens(target_codes),
+    ]
+    if finished:
+        all_token_ids.append(151670)
+    return SimpleNamespace(
+        request_id=f"internal-{request_id}",
+        external_req_id=request_id,
+        prompt_token_ids=prompt_token_ids,
+        all_token_ids=all_token_ids,
+        is_finished=lambda: finished,
+    )
+
+
+def _transfer_manager(**extra):
+    return SimpleNamespace(
+        code_prompt_token_ids=defaultdict(list),
+        connector=SimpleNamespace(config={"extra": extra}),
+    )
+
+
+def _payload_codes(payload) -> list[int]:
+    assert payload is not None
+    assert payload.codes is not None
+    assert payload.codes.audio is not None
+    return payload.codes.audio.tolist()
+
+
+def test_filter_speech_codes_rebases_valid_boundary_tokens():
+    token_ids = [151671, 151681, 217206]
+
+    assert filter_speech_codes(token_ids) == [0, 10, 65535]
+
+
+def test_filter_speech_codes_ignores_tokens_outside_codec_range():
+    token_ids = [151643, 151669, 151670, 217207, 217651]
+
+    assert filter_speech_codes(token_ids) == []
+
+
+def test_filter_speech_codes_preserves_order_and_duplicates():
+    token_ids = [151681, 151671, 151681]
+
+    assert filter_speech_codes(token_ids) == [10, 0, 10]
+
+
+def test_llm2neucodec_sync_supports_batched_source_outputs():
+    source_outputs = [
+        SimpleNamespace(outputs=[SimpleNamespace(token_ids=[151671, 151681])]),
+        SimpleNamespace(outputs=[SimpleNamespace(token_ids=[151691])]),
+    ]
+
+    outputs = llm2neucodec_sync(source_outputs)
+
+    assert len(outputs) == 2
+    assert outputs[0]["prompt_token_ids"] == [0, 10]
+    assert outputs[1]["prompt_token_ids"] == [20]
+
+
+def test_async_chunk_waits_for_25_frames_plus_5_lookforward_frames():
+    manager = _transfer_manager()
+    request = _request("rid-wait", list(range(60)), list(range(29)))
+
+    payload = llm2neucodec_async_chunk(manager, None, request)
+
+    assert payload is None
+    assert manager.code_prompt_token_ids["rid-wait"] == []
+
+
+def test_async_chunk_matches_official_30_55_63_lifecycle():
+    manager = _transfer_manager()
+    reference = list(range(60))
+    target = list(range(100, 163))
+
+    first = llm2neucodec_async_chunk(
+        manager,
+        None,
+        _request("rid-flow", reference, target[:30]),
+    )
+    assert _payload_codes(first) == reference[9:] + target[:30]
+    assert first.meta is not None
+    assert first.meta.left_context_size == 51
+    assert first.meta.right_holdback_size == 3
+    assert first.meta.num_processed_tokens == 25
+    assert not bool(first.meta.stream_finished.item())
+    assert manager.code_prompt_token_ids["rid-flow"] == target[:25]
+
+    second = llm2neucodec_async_chunk(
+        manager,
+        None,
+        _request("rid-flow", reference, target[:55]),
+    )
+    assert _payload_codes(second) == reference[34:] + target[:55]
+    assert second.meta is not None
+    assert second.meta.left_context_size == 51
+    assert second.meta.right_holdback_size == 3
+    assert second.meta.num_processed_tokens == 25
+    assert not bool(second.meta.stream_finished.item())
+    assert manager.code_prompt_token_ids["rid-flow"] == target[:50]
+
+    final = llm2neucodec_async_chunk(
+        manager,
+        None,
+        _request("rid-flow", reference, target[:63], finished=True),
+        is_finished=True,
+    )
+    assert _payload_codes(final) == reference[59:] + target[:63]
+    assert final.meta is not None
+    assert final.meta.left_context_size == 50
+    assert final.meta.right_holdback_size == 0
+    assert final.meta.num_processed_tokens == 13
+    assert bool(final.meta.finished.item())
+    assert bool(final.meta.stream_finished.item())
+    assert manager.code_prompt_token_ids["rid-flow"] == target[:63]
+
+
+def test_async_chunk_finished_without_remaining_codes_emits_cleanup_wakeup():
+    manager = _transfer_manager()
+    target = list(range(50))
+    manager.code_prompt_token_ids["rid-eof"] = target.copy()
+
+    payload = llm2neucodec_async_chunk(
+        manager,
+        None,
+        _request("rid-eof", list(range(60)), target, finished=True),
+        is_finished=True,
+    )
+
+    # One old context code wakes Stage 1; num_processed_tokens=0 means it is
+    # not new speech and is only used to clean the streaming decoder cache.
+    assert _payload_codes(payload) == [target[-1]]
+    assert payload.meta is not None
+    assert payload.meta.left_context_size == 1
+    assert payload.meta.num_processed_tokens == 0
+    assert bool(payload.meta.finished.item())
+    assert bool(payload.meta.stream_finished.item())
+
+
+def test_async_chunk_keeps_request_progress_isolated():
+    manager = _transfer_manager()
+    reference = list(range(60))
+
+    assert (
+        llm2neucodec_async_chunk(
+            manager,
+            None,
+            _request("rid-a", reference, list(range(30))),
+        )
+        is not None
+    )
+    assert (
+        llm2neucodec_async_chunk(
+            manager,
+            None,
+            _request("rid-b", reference, list(range(29))),
+        )
+        is None
+    )
+    assert len(manager.code_prompt_token_ids["rid-a"]) == 25
+    assert manager.code_prompt_token_ids["rid-b"] == []
+
+
+def test_async_chunk_rejects_prompt_without_generation_marker():
+    manager = _transfer_manager()
+    request = SimpleNamespace(
+        request_id="internal-bad",
+        external_req_id="rid-bad",
+        prompt_token_ids=[100, *_speech_tokens([0, 1])],
+        all_token_ids=[100, *_speech_tokens([0, 1, 2])],
+        is_finished=lambda: False,
+    )
+
+    with pytest.raises(ValueError, match="SPEECH_GENERATION_START"):
+        llm2neucodec_async_chunk(manager, None, request)

--- a/vllm_omni/config/pipeline_registry.py
+++ b/vllm_omni/config/pipeline_registry.py
@@ -92,6 +92,7 @@ from vllm_omni.model_executor.models.moss_tts_nano.pipeline import MOSS_TTS_NANO
 from vllm_omni.model_executor.models.nemotron_voicechat.pipeline import (
     NEMOTRON_VOICECHAT_PIPELINE,
 )
+from vllm_omni.model_executor.models.neutts_air.pipeline import NEUTTS_AIR_PIPELINE
 from vllm_omni.model_executor.models.omnivoice.pipeline import OMNIVOICE_PIPELINE
 from vllm_omni.model_executor.models.personaplex.pipeline import PERSONAPLEX_PIPELINE
 from vllm_omni.model_executor.models.qwen2_5_omni.pipeline import (
@@ -166,6 +167,7 @@ OMNI_PIPELINES: dict[str, PipelineConfig | PipelineResolverFunc] = {
     "ming_flash_omni_thinker_only": MING_FLASH_OMNI_THINKER_ONLY_PIPELINE,
     "ming_flash_omni_image": MING_FLASH_OMNI_IMAGE_PIPELINE,
     "moss_tts_nano": MOSS_TTS_NANO_PIPELINE,
+    "neutts_air": NEUTTS_AIR_PIPELINE,
     "omnivoice": OMNIVOICE_PIPELINE,
     "mammoth_moda2": MAMMOTH_MODA2_PIPELINE,
     "mammoth_moda2_ar": MAMMOTH_MODA2_AR_PIPELINE,

--- a/vllm_omni/deploy/neutts_air.yaml
+++ b/vllm_omni/deploy/neutts_air.yaml
@@ -1,0 +1,37 @@
+# NeuTTS-Air deploy: Qwen2 backbone to NeuCodec on one GPU.
+# Async chunking is enabled after synchronous and streaming validation.
+async_chunk: true
+stages:
+  - stage_id: 0
+    max_num_seqs: 4
+    kv_cache_memory_bytes: 536870912
+    enable_prefix_caching: false
+    max_num_batched_tokens: 2048
+    max_model_len: 2048
+    devices: "0"
+    default_sampling_params:
+      temperature: 1.0
+      top_p: 0.8
+      top_k: 50
+      repetition_penalty: 1.1
+      max_tokens: 512
+      min_tokens: 50
+      seed: 1234
+      detokenize: false
+      ignore_eos: true
+  - stage_id: 1
+    max_num_seqs: 4
+    gpu_memory_utilization: 0.3
+    enforce_eager: true
+    dtype: float32
+    enable_prefix_caching: false
+    async_scheduling: false
+    max_num_batched_tokens: 2048
+    max_model_len: 2048
+    devices: "0"
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 1
+      detokenize: false

--- a/vllm_omni/entrypoints/openai/tts_adapters/__init__.py
+++ b/vllm_omni/entrypoints/openai/tts_adapters/__init__.py
@@ -122,6 +122,7 @@ from vllm_omni.entrypoints.openai.tts_adapters import (  # noqa: E402,F401
     ming_flash_omni_tts,
     ming_tts,
     moss_tts,
+    neutts_air,
     omnivoice,
     qwen3_tts,
     step_audio2,

--- a/vllm_omni/entrypoints/openai/tts_adapters/neutts_air.py
+++ b/vllm_omni/entrypoints/openai/tts_adapters/neutts_air.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""NeuTTS-Air TTS serving adapter."""
+
+import copy
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from vllm_omni.entrypoints.openai.tts_adapters import register_tts_adapter
+from vllm_omni.entrypoints.openai.tts_adapters.base import (
+    ARTTSAdapter,
+    PreparedRequest,
+)
+
+if TYPE_CHECKING:
+    from vllm_omni.entrypoints.openai.protocol.audio import (
+        OpenAICreateSpeechRequest,
+    )
+
+
+NEUTTS_MIN_NEW_TOKENS = 50
+NEUTTS_DEFAULT_MAX_NEW_TOKENS = 512
+NEUTTS_SPEECH_GENERATION_END_TOKEN_ID = 151670
+
+
+@register_tts_adapter
+class NeuTTSAirAdapter(ARTTSAdapter):
+    """Translate OpenAI speech requests into the NeuTTS-Air pipeline input."""
+
+    stage_keys = frozenset({"neucodec"})
+    name = "neutts_air"
+    max_new_tokens_min = NEUTTS_MIN_NEW_TOKENS
+
+    def validate(self, request: "OpenAICreateSpeechRequest") -> str | None:
+        if not request.input or not request.input.strip():
+            return "Input text cannot be empty"
+        if request.ref_audio is None:
+            return "NeuTTS-Air requires 'ref_audio' (reference audio for voice cloning)"
+        if isinstance(request.ref_audio, list):
+            return "NeuTTS-Air requires exactly one 'ref_audio'"
+
+        fmt_err = self.ctx.server._validate_ref_audio_format(request.ref_audio)
+        if fmt_err:
+            return fmt_err
+        if not request.ref_text or not request.ref_text.strip():
+            return "NeuTTS-Air requires 'ref_text' (transcript of the reference audio)"
+        if request.max_new_tokens is not None:
+            if request.max_new_tokens < self.max_new_tokens_min:
+                return f"max_new_tokens must be at least {self.max_new_tokens_min}"
+            if request.max_new_tokens > self.max_new_tokens_max:
+                return f"max_new_tokens cannot exceed {self.max_new_tokens_max}"
+        return None
+
+    async def build(
+        self,
+        request: "OpenAICreateSpeechRequest",
+        sampling_params_list: list,
+        has_inline_ref_audio: bool,
+    ) -> PreparedRequest:
+        del sampling_params_list, has_inline_ref_audio
+        assert isinstance(request.ref_audio, str)
+        wav_list, sample_rate = await self.ctx.server._resolve_ref_audio(request.ref_audio)
+        prompt = {
+            "prompt": request.input,
+            "multi_modal_data": {
+                "audio": (np.asarray(wav_list, dtype=np.float32), sample_rate),
+            },
+            "mm_processor_kwargs": {
+                "ref_text": request.ref_text,
+            },
+        }
+        return PreparedRequest(
+            prompt=prompt,
+            tts_params={},
+            model_type="neutts_air",
+        )
+
+    def apply_sampling_overrides(
+        self,
+        sampling_params_list: list,
+        request: "OpenAICreateSpeechRequest",
+    ) -> list:
+        if not sampling_params_list:
+            return sampling_params_list
+
+        params = copy.deepcopy(sampling_params_list)
+        stage0 = params[0]
+        requested_max = request.max_new_tokens
+        if requested_max is not None:
+            stage0.max_tokens = int(requested_max)
+        elif stage0.max_tokens is None or stage0.max_tokens < NEUTTS_MIN_NEW_TOKENS:
+            stage0.max_tokens = NEUTTS_DEFAULT_MAX_NEW_TOKENS
+        stage0.min_tokens = NEUTTS_MIN_NEW_TOKENS
+        stage0.detokenize = False
+        stage0.stop_token_ids = [NEUTTS_SPEECH_GENERATION_END_TOKEN_ID]
+        stage0.ignore_eos = True
+
+        if len(params) > 1:
+            stage1 = params[1]
+            stage1.max_tokens = 1
+            stage1.detokenize = False
+        return params

--- a/vllm_omni/model_executor/models/neutts_air/__init__.py
+++ b/vllm_omni/model_executor/models/neutts_air/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""NeuTTS-Air model components."""

--- a/vllm_omni/model_executor/models/neutts_air/neutts_air_code2wav.py
+++ b/vllm_omni/model_executor/models/neutts_air/neutts_air_code2wav.py
@@ -1,0 +1,398 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""NeuCodec waveform decoder for NeuTTS-Air Stage 1."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+from torch import nn
+from vllm.config import VllmConfig
+from vllm.forward_context import get_forward_context, is_forward_context_available
+from vllm.logger import init_logger
+
+from vllm_omni.model_executor.models.output_templates import OmniOutput
+
+logger = init_logger(__name__)
+
+DEFAULT_NEUCODEC_REPO = "neuphonic/neucodec"
+NEUTTS_SAMPLE_RATE = 24_000
+NEUTTS_HOP_LENGTH = 480
+NEUTTS_STREAMING_CHUNK_FRAMES = 25
+
+
+@dataclass
+class _StreamAudioState:
+    frames: list[torch.Tensor] = field(default_factory=list)
+    emitted_samples: int = 0
+    stride_samples: int = NEUTTS_STREAMING_CHUNK_FRAMES * NEUTTS_HOP_LENGTH
+
+
+def _meta_scalar(value: Any, default: Any = None) -> Any:
+    if isinstance(value, torch.Tensor):
+        if value.numel() == 0:
+            return default
+        return value.detach().reshape(-1)[0].item()
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return default
+        return _meta_scalar(value[0], default)
+    return default if value is None else value
+
+
+def _linear_overlap_add(
+    frames: list[torch.Tensor],
+    stride: int,
+) -> torch.Tensor:
+    """Match NeuTTS' triangular weighted overlap-add on one-dimensional audio."""
+    if not frames:
+        raise ValueError("NeuTTS-Air overlap-add requires at least one frame.")
+    if stride <= 0:
+        raise ValueError(f"NeuTTS-Air overlap-add stride must be positive, got {stride}.")
+
+    first = frames[0]
+    if first.ndim != 1:
+        raise ValueError("NeuTTS-Air overlap-add expects one-dimensional audio frames.")
+
+    total_size = max(stride * index + int(frame.numel()) for index, frame in enumerate(frames))
+    output = torch.zeros(total_size, dtype=first.dtype, device=first.device)
+    sum_weight = torch.zeros_like(output)
+
+    for index, frame in enumerate(frames):
+        if frame.ndim != 1:
+            raise ValueError("NeuTTS-Air overlap-add expects one-dimensional audio frames.")
+        if frame.dtype != first.dtype or frame.device != first.device:
+            raise ValueError("NeuTTS-Air overlap-add frames must share dtype and device.")
+
+        frame_length = int(frame.numel())
+        if frame_length == 0:
+            continue
+        positions = torch.linspace(
+            0,
+            1,
+            frame_length + 2,
+            dtype=frame.dtype,
+            device=frame.device,
+        )[1:-1]
+        weight = 0.5 - torch.abs(positions - 0.5)
+        offset = stride * index
+        output[offset : offset + frame_length] += weight * frame
+        sum_weight[offset : offset + frame_length] += weight
+
+    if bool(torch.any(sum_weight <= 0).item()):
+        raise RuntimeError("NeuTTS-Air overlap-add produced uncovered audio samples.")
+    return output / sum_weight
+
+
+class NeuTTSAirCode2Wav(nn.Module):
+    """Decode NeuTTS-Air's single-codebook speech codes into waveforms."""
+
+    input_modalities = "audio"
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+        del prefix
+
+        self.vllm_config = vllm_config
+
+        self.have_multimodal_outputs = True
+        self.has_preprocess = False
+        self.has_postprocess = False
+        self.enable_update_additional_information = True
+        self.requires_raw_input_tokens = True
+
+        hf_config = vllm_config.model_config.hf_config
+        self._codec_repo = str(getattr(hf_config, "neutts_codec_repo", DEFAULT_NEUCODEC_REPO))
+        self._codec: nn.Module | None = None
+        self._output_sample_rate = NEUTTS_SAMPLE_RATE
+        self._stream_states: dict[str, _StreamAudioState] = {}
+
+    def _ensure_codec_loaded(self) -> None:
+        if self._codec is not None:
+            return
+
+        try:
+            from neucodec import NeuCodec
+        except (ImportError, ModuleNotFoundError) as exc:
+            raise RuntimeError(
+                "NeuTTS-Air Stage 1 requires the NeuCodec runtime and its compatible optional dependencies."
+            ) from exc
+
+        device = self.vllm_config.device_config.device
+        codec = NeuCodec.from_pretrained(self._codec_repo)
+        codec = codec.eval().to(device)
+        self._codec = codec
+        logger.info(
+            "Loaded NeuCodec from %s on %s (sample_rate=%d).",
+            self._codec_repo,
+            device,
+            self._output_sample_rate,
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor, **_: Any) -> torch.Tensor:
+        """Give the generation runner a stable placeholder embedding shape."""
+        if input_ids.numel() == 0:
+            return torch.empty((0, 1), device=input_ids.device, dtype=torch.float32)
+        return torch.zeros(
+            (input_ids.shape[0], 1),
+            device=input_ids.device,
+            dtype=torch.float32,
+        )
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor | OmniOutput,
+        sampling_metadata: Any = None,
+    ) -> None:
+        del hidden_states, sampling_metadata
+        return None
+
+    def _split_request_ids(
+        self,
+        ids: torch.Tensor,
+        seq_token_counts: list[int] | None = None,
+    ) -> list[torch.Tensor]:
+        if seq_token_counts is not None and len(seq_token_counts) > 1:
+            boundaries = [0]
+            for count in seq_token_counts:
+                boundaries.append(boundaries[-1] + count)
+            num_ids = ids.numel()
+            return [ids[boundaries[i] : min(boundaries[i + 1], num_ids)] for i in range(len(seq_token_counts))]
+
+        if is_forward_context_available():
+            slices = get_forward_context().ubatch_slices
+            if slices is not None and len(slices) > 1 and not any(hasattr(item, "token_slice") for item in slices):
+                boundaries = [0]
+                for item in slices:
+                    boundaries.append(boundaries[-1] + item)
+                return [ids[boundaries[i] : boundaries[i + 1]] for i in range(len(boundaries) - 1)]
+
+        return [ids]
+
+    def _decode_codes(self, one_request_codes: torch.Tensor) -> torch.Tensor:
+        self._ensure_codec_loaded()
+        assert self._codec is not None
+
+        codes = one_request_codes.reshape(1, 1, -1).to(dtype=torch.long)
+        audio = self._codec.decode_code(codes)
+        if not isinstance(audio, torch.Tensor) or audio.ndim != 3 or audio.shape[0] != 1 or audio.shape[1] != 1:
+            raise RuntimeError("NeuCodec.decode_code() must return a [1, 1, T] tensor.")
+        return audio[0, 0].to(dtype=torch.float32).reshape(-1)
+
+    @staticmethod
+    def _runtime_info_list(
+        model_intermediate_buffer: list[dict[str, Any]] | None,
+        runtime_additional_information: list[dict[str, Any]] | None,
+        num_requests: int,
+    ) -> list[dict[str, Any]]:
+        raw_infos = (
+            model_intermediate_buffer if isinstance(model_intermediate_buffer, list) else runtime_additional_information
+        )
+        infos = [info if isinstance(info, dict) else {} for info in (raw_infos or [])]
+        if len(infos) < num_requests:
+            infos.extend({} for _ in range(num_requests - len(infos)))
+        return infos[:num_requests]
+
+    @staticmethod
+    def _stream_metadata(
+        info: dict[str, Any],
+    ) -> tuple[bool, str | None, int, int, int, int, bool]:
+        meta = info.get("meta", {}) if isinstance(info, dict) else {}
+        if not isinstance(meta, dict):
+            meta = {}
+
+        streaming = bool(_meta_scalar(meta.get("codec_streaming"), False))
+        request_id_raw = _meta_scalar(
+            meta.get("req_id", meta.get("request_id")),
+            None,
+        )
+        request_id = str(request_id_raw) if request_id_raw is not None else None
+        left_context = int(_meta_scalar(meta.get("left_context_size"), 0))
+        right_holdback = int(_meta_scalar(meta.get("right_holdback_size"), 0))
+        processed_frames = int(_meta_scalar(meta.get("num_processed_tokens"), 0))
+        chunk_frames = int(
+            _meta_scalar(
+                meta.get("codec_chunk_frames"),
+                NEUTTS_STREAMING_CHUNK_FRAMES,
+            )
+        )
+        finished = bool(
+            _meta_scalar(
+                meta.get("stream_finished", meta.get("finished")),
+                False,
+            )
+        )
+
+        if min(left_context, right_holdback, processed_frames) < 0:
+            raise ValueError("NeuTTS-Air streaming metadata cannot be negative.")
+        if chunk_frames <= 0:
+            raise ValueError("NeuTTS-Air codec_chunk_frames must be positive.")
+        return (
+            streaming,
+            request_id,
+            left_context,
+            right_holdback,
+            processed_frames,
+            chunk_frames,
+            finished,
+        )
+
+    def _decode_streaming_request(
+        self,
+        one_request_codes: torch.Tensor,
+        *,
+        request_id: str,
+        left_context_frames: int,
+        right_holdback_frames: int,
+        processed_frames: int,
+        chunk_frames: int,
+        finished: bool,
+    ) -> torch.Tensor:
+        state = self._stream_states.get(request_id)
+
+        if processed_frames == 0:
+            if not finished:
+                raise RuntimeError("NeuTTS-Air received a non-final streaming chunk with no processed frames.")
+            if state is None:
+                return torch.zeros((0,), dtype=torch.float32)
+            mixed = _linear_overlap_add(state.frames, state.stride_samples)
+            delta = mixed[state.emitted_samples :]
+            self._stream_states.pop(request_id, None)
+            return delta
+
+        decoded = self._decode_codes(one_request_codes)
+        left_samples = left_context_frames * NEUTTS_HOP_LENGTH
+        right_samples = right_holdback_frames * NEUTTS_HOP_LENGTH
+        if left_samples + right_samples >= decoded.numel():
+            raise RuntimeError(
+                "NeuTTS-Air streaming trim removes the entire decoded waveform: "
+                f"decoded={decoded.numel()}, left={left_samples}, right={right_samples}."
+            )
+        end = int(decoded.numel()) - right_samples if right_samples else None
+        cropped = decoded[left_samples:end]
+
+        stride_samples = chunk_frames * NEUTTS_HOP_LENGTH
+        if state is None:
+            state = _StreamAudioState(stride_samples=stride_samples)
+            self._stream_states[request_id] = state
+        elif state.stride_samples != stride_samples:
+            raise RuntimeError("NeuTTS-Air streaming chunk size changed within one request.")
+
+        state.frames.append(cropped)
+        mixed = _linear_overlap_add(state.frames, state.stride_samples)
+        output_start = state.emitted_samples
+        if finished:
+            output_end = int(mixed.numel())
+        else:
+            output_end = min(
+                output_start + processed_frames * NEUTTS_HOP_LENGTH,
+                int(mixed.numel()),
+            )
+        delta = mixed[output_start:output_end]
+        state.emitted_samples = output_end
+
+        if finished:
+            self._stream_states.pop(request_id, None)
+        return delta
+
+    @torch.inference_mode()
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        positions: torch.Tensor | None = None,
+        intermediate_tensors: Any = None,
+        inputs_embeds: torch.Tensor | None = None,
+        model_intermediate_buffer: list[dict[str, Any]] | None = None,
+        runtime_additional_information: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> OmniOutput:
+        """Decode synchronous code sequences or streaming code windows."""
+        del positions, intermediate_tensors, inputs_embeds
+
+        sample_rate = torch.tensor(
+            self._output_sample_rate,
+            dtype=torch.int32,
+        )
+        empty = torch.zeros((0,), dtype=torch.float32)
+
+        if input_ids is None or input_ids.numel() == 0:
+            return OmniOutput(
+                text_hidden_states=None,
+                multimodal_outputs={
+                    "model_outputs": [empty],
+                    "sr": [sample_rate],
+                },
+            )
+
+        ids = input_ids.reshape(-1).to(dtype=torch.long)
+        request_codes = self._split_request_ids(
+            ids,
+            kwargs.get("seq_token_counts"),
+        )
+        info_list = self._runtime_info_list(
+            model_intermediate_buffer,
+            runtime_additional_information,
+            len(request_codes),
+        )
+
+        audio_outputs: list[torch.Tensor] = []
+        for index, one_request_codes in enumerate(request_codes):
+            if one_request_codes.numel() == 0:
+                audio_outputs.append(empty)
+                continue
+
+            (
+                streaming,
+                request_id,
+                left_context,
+                right_holdback,
+                processed_frames,
+                chunk_frames,
+                finished,
+            ) = self._stream_metadata(info_list[index])
+
+            if not streaming:
+                audio_outputs.append(self._decode_codes(one_request_codes))
+                continue
+            if request_id is None:
+                raise RuntimeError("NeuTTS-Air streaming Stage 1 requires meta.req_id.")
+
+            audio_outputs.append(
+                self._decode_streaming_request(
+                    one_request_codes,
+                    request_id=request_id,
+                    left_context_frames=left_context,
+                    right_holdback_frames=right_holdback,
+                    processed_frames=processed_frames,
+                    chunk_frames=chunk_frames,
+                    finished=finished,
+                )
+            )
+
+        return OmniOutput(
+            text_hidden_states=None,
+            multimodal_outputs={
+                "model_outputs": audio_outputs,
+                "sr": [sample_rate] * len(audio_outputs),
+            },
+        )
+
+    def on_requests_finished(
+        self,
+        finished_req_ids: Iterable[str],
+    ) -> None:
+        """Release streaming decoder state for finished or aborted requests."""
+        for request_id in finished_req_ids:
+            self._stream_states.pop(str(request_id), None)
+
+    def load_weights(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> set[str]:
+        # NeuCodec loads its own external checkpoint, not Stage 0's Qwen2 weights.
+        del weights
+        return set()

--- a/vllm_omni/model_executor/models/neutts_air/neutts_air_talker.py
+++ b/vllm_omni/model_executor/models/neutts_air/neutts_air_talker.py
@@ -1,0 +1,364 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""NeuTTS-Air prompt processing backed by vLLM's native Qwen2 model."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+import numpy as np
+import torch
+from vllm.config.multimodal import BaseDummyOptions
+from vllm.inputs import MultiModalDataDict
+from vllm.inputs import MultiModalInput as MultiModalInputs
+from vllm.model_executor.models.interfaces import SupportsMultiModal
+from vllm.model_executor.models.qwen2 import Qwen2ForCausalLM
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.inputs import MultiModalFieldConfig, MultiModalKwargsItems
+from vllm.multimodal.parse import MultiModalDataItems, MultiModalDataParser
+from vllm.multimodal.processing import (
+    BaseDummyInputsBuilder,
+    BaseMultiModalProcessor,
+    BaseProcessingInfo,
+    ProcessorInputs,
+    PromptUpdate,
+    TimingContext,
+)
+
+NEUTTS_SPEECH_TOKEN_OFFSET = 151671
+NEUTTS_CODEC_VOCAB_SIZE = 65536
+NEUTTS_REFERENCE_SAMPLE_RATE = 16_000
+DEFAULT_NEUCODEC_REPO = "neuphonic/neucodec"
+NEUTTS_ESPEAK_LIBRARY_ENV = "NEUTTS_ESPEAK_LIBRARY"
+NEUTTS_ESPEAK_DATA_PATH_ENV = "NEUTTS_ESPEAK_DATA_PATH"
+EXPECTED_NEUTTS_ESPEAK_VERSION = (1, 52, 0, 1)
+
+_TEXT_REPLACE = "<|TEXT_REPLACE|>"
+_TEXT_PROMPT_START = "<|TEXT_PROMPT_START|>"
+_TEXT_PROMPT_END = "<|TEXT_PROMPT_END|>"
+_SPEECH_REPLACE = "<|SPEECH_REPLACE|>"
+_SPEECH_GENERATION_START = "<|SPEECH_GENERATION_START|>"
+_PROMPT_TEMPLATE = "user: Convert the text to speech:<|TEXT_REPLACE|>\nassistant:<|SPEECH_REPLACE|>"
+
+_PHONEMIZER: Any | None = None
+_PHONEMIZER_LOCK = Lock()
+_REFERENCE_CODECS: dict[str, Any] = {}
+_REFERENCE_CODEC_LOCK = Lock()
+
+
+def _normalize_codes(ref_codes: Any) -> list[int]:
+    if isinstance(ref_codes, torch.Tensor):
+        values = ref_codes.detach().cpu().reshape(-1).tolist()
+    elif isinstance(ref_codes, np.ndarray):
+        values = ref_codes.reshape(-1).tolist()
+    else:
+        values = list(ref_codes)
+
+    codes = [int(value) for value in values]
+    invalid = [code for code in codes if not 0 <= code < NEUTTS_CODEC_VOCAB_SIZE]
+    if invalid:
+        raise ValueError(f"NeuTTS-Air reference codes must be in [0, 65535]; found {invalid[0]}.")
+    if not codes:
+        raise ValueError("NeuTTS-Air reference codes cannot be empty.")
+    return codes
+
+
+def _configure_explicit_espeak_assets(espeak_wrapper: Any) -> bool:
+    """Configure exact NeuTTS eSpeak assets supplied through environment variables."""
+    library = os.environ.get(NEUTTS_ESPEAK_LIBRARY_ENV, "").strip()
+    data_path = os.environ.get(NEUTTS_ESPEAK_DATA_PATH_ENV, "").strip()
+
+    if bool(library) != bool(data_path):
+        raise RuntimeError(f"{NEUTTS_ESPEAK_LIBRARY_ENV} and {NEUTTS_ESPEAK_DATA_PATH_ENV} must be set together.")
+    if not library:
+        return False
+
+    library_path = Path(library).expanduser()
+    data_dir = Path(data_path).expanduser()
+    if not library_path.is_file():
+        raise RuntimeError(f"NeuTTS-Air eSpeak library does not exist: {library_path}")
+    if not data_dir.is_dir():
+        raise RuntimeError(f"NeuTTS-Air eSpeak data directory does not exist: {data_dir}")
+    if not hasattr(espeak_wrapper, "set_data_path"):
+        raise RuntimeError("The installed phonemizer does not support an explicit eSpeak data path.")
+
+    espeak_wrapper.set_library(str(library_path))
+    espeak_wrapper.set_data_path(str(data_dir))
+    return True
+
+
+def _get_english_phonemizer() -> Any:
+    global _PHONEMIZER
+    if _PHONEMIZER is not None:
+        return _PHONEMIZER
+
+    with _PHONEMIZER_LOCK:
+        if _PHONEMIZER is not None:
+            return _PHONEMIZER
+        try:
+            from phonemizer.backend import EspeakBackend
+            from phonemizer.backend.espeak.wrapper import EspeakWrapper
+
+            if not _configure_explicit_espeak_assets(EspeakWrapper):
+                try:
+                    import espeakng_loader
+
+                    EspeakWrapper.set_library(espeakng_loader.get_library_path())
+                    EspeakWrapper.set_data_path(espeakng_loader.get_data_path())
+                except ImportError:
+                    # A system espeak-ng installation is also supported.
+                    pass
+
+            phonemizer = EspeakBackend(
+                language="en-us",
+                preserve_punctuation=True,
+                with_stress=True,
+                words_mismatch="ignore",
+                language_switch="remove-flags",
+            )
+            version = tuple(phonemizer.version())
+            if version != EXPECTED_NEUTTS_ESPEAK_VERSION:
+                raise RuntimeError(
+                    "NeuTTS-Air requires the official eSpeak assets with version "
+                    f"{EXPECTED_NEUTTS_ESPEAK_VERSION}; found {version}. Set "
+                    f"{NEUTTS_ESPEAK_LIBRARY_ENV} and {NEUTTS_ESPEAK_DATA_PATH_ENV} "
+                    "to the matching library and data directory."
+                )
+            _PHONEMIZER = phonemizer
+        except ImportError as exc:
+            raise RuntimeError("NeuTTS-Air text processing requires phonemizer and espeak-ng.") from exc
+    return _PHONEMIZER
+
+
+def phonemize_english(text: str) -> str:
+    """Match NeuTTS-Air's English phoneme normalization."""
+    phonemes = _get_english_phonemizer().phonemize([text])[0]
+    return " ".join(phonemes.split())
+
+
+def build_neutts_air_prompt_token_ids(
+    tokenizer: Any,
+    ref_codes: Any,
+    ref_text: str,
+    target_text: str,
+    *,
+    phonemize=phonemize_english,
+) -> list[int]:
+    """Build the exact prompt consumed by the official PyTorch backend."""
+    if not ref_text.strip():
+        raise ValueError("NeuTTS-Air reference text cannot be empty.")
+    if not target_text.strip():
+        raise ValueError("NeuTTS-Air target text cannot be empty.")
+
+    codes = _normalize_codes(ref_codes)
+    text = f"{phonemize(ref_text)} {phonemize(target_text)}"
+    text_ids = tokenizer.encode(text, add_special_tokens=False)
+
+    ids = list(tokenizer.encode(_PROMPT_TEMPLATE))
+    text_replace = tokenizer.convert_tokens_to_ids(_TEXT_REPLACE)
+    text_start = tokenizer.convert_tokens_to_ids(_TEXT_PROMPT_START)
+    text_end = tokenizer.convert_tokens_to_ids(_TEXT_PROMPT_END)
+    speech_replace = tokenizer.convert_tokens_to_ids(_SPEECH_REPLACE)
+    speech_start = tokenizer.convert_tokens_to_ids(_SPEECH_GENERATION_START)
+
+    text_replace_idx = ids.index(text_replace)
+    ids = ids[:text_replace_idx] + [text_start] + list(text_ids) + [text_end] + ids[text_replace_idx + 1 :]
+
+    speech_replace_idx = ids.index(speech_replace)
+    speech_ids = [NEUTTS_SPEECH_TOKEN_OFFSET + code for code in codes]
+    return ids[:speech_replace_idx] + [speech_start] + speech_ids
+
+
+class NeuTTSAirProcessingInfo(BaseProcessingInfo):
+    def get_supported_mm_limits(self) -> Mapping[str, int | None]:
+        return {"audio": 1}
+
+    def get_mm_max_tokens_per_item(
+        self,
+        seq_len: int,
+        mm_counts: Mapping[str, int],
+    ) -> Mapping[str, int]:
+        del seq_len, mm_counts
+        # Reference audio becomes ordinary Qwen2 prompt token IDs, so there is
+        # no model-side multimodal tower to profile.
+        return {}
+
+    def get_data_parser(self) -> MultiModalDataParser:
+        return MultiModalDataParser(
+            target_sr=NEUTTS_REFERENCE_SAMPLE_RATE,
+            target_channels=1,
+            expected_hidden_size=self._get_expected_hidden_size(),
+        )
+
+
+class NeuTTSAirDummyInputsBuilder(BaseDummyInputsBuilder[NeuTTSAirProcessingInfo]):
+    def get_dummy_text(self, mm_counts: Mapping[str, int]) -> str:
+        del mm_counts
+        return "This is a NeuTTS-Air test."
+
+    def get_dummy_mm_data(
+        self,
+        seq_len: int,
+        mm_counts: Mapping[str, int],
+        mm_options: Mapping[str, BaseDummyOptions] | None = None,
+    ) -> MultiModalDataDict:
+        del seq_len
+        count = mm_counts.get("audio", 0)
+        if count <= 0:
+            return {}
+        overrides = mm_options.get("audio") if mm_options else None
+        return {
+            "audio": self._get_dummy_audios(
+                length=NEUTTS_REFERENCE_SAMPLE_RATE,
+                num_audios=count,
+                overrides=overrides,
+            )
+        }
+
+    def get_dummy_processor_inputs(
+        self,
+        seq_len: int,
+        mm_counts: Mapping[str, int],
+        mm_options: Mapping[str, BaseDummyOptions] | None = None,
+    ) -> ProcessorInputs:
+        inputs = super().get_dummy_processor_inputs(seq_len, mm_counts, mm_options)
+        inputs.hf_processor_mm_kwargs = {
+            "ref_text": "This is the reference voice.",
+            "ref_codes": [0],
+        }
+        return inputs
+
+
+class NeuTTSAirMultiModalProcessor(BaseMultiModalProcessor[NeuTTSAirProcessingInfo]):
+    def _get_mm_fields_config(
+        self,
+        hf_inputs: Any,
+        hf_processor_mm_kwargs: Mapping[str, object],
+    ) -> Mapping[str, MultiModalFieldConfig]:
+        del hf_inputs, hf_processor_mm_kwargs
+        return {}
+
+    def _get_prompt_updates(
+        self,
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, object],
+        out_mm_kwargs: MultiModalKwargsItems,
+    ) -> Sequence[PromptUpdate]:
+        del mm_items, hf_processor_mm_kwargs, out_mm_kwargs
+        return []
+
+    @staticmethod
+    def _load_reference_codec(repo_id: str) -> Any:
+        codec = _REFERENCE_CODECS.get(repo_id)
+        if codec is not None:
+            return codec
+
+        with _REFERENCE_CODEC_LOCK:
+            codec = _REFERENCE_CODECS.get(repo_id)
+            if codec is not None:
+                return codec
+            try:
+                from neucodec import NeuCodec
+            except (ImportError, ModuleNotFoundError) as exc:
+                raise RuntimeError("NeuTTS-Air reference-audio encoding requires NeuCodec.") from exc
+            codec = NeuCodec.from_pretrained(repo_id).eval().cpu()
+            _REFERENCE_CODECS[repo_id] = codec
+            return codec
+
+    def _encode_reference_audio(
+        self,
+        audio: np.ndarray,
+        repo_id: str,
+    ) -> list[int]:
+        waveform = torch.from_numpy(np.asarray(audio)).float().reshape(1, 1, -1)
+        codec = self._load_reference_codec(repo_id)
+        with torch.inference_mode():
+            codes = codec.encode_code(waveform)
+        return _normalize_codes(codes)
+
+    def _resolve_reference_codes(self, inputs: ProcessorInputs) -> list[int]:
+        raw_codes = inputs.hf_processor_mm_kwargs.get("ref_codes")
+        if raw_codes is not None:
+            return _normalize_codes(raw_codes)
+
+        audio_items = inputs.mm_data_items.get("audio")
+        if audio_items is None or audio_items.get_count() != 1:
+            raise ValueError(
+                "NeuTTS-Air requires exactly one reference audio item or mm_processor_kwargs['ref_codes']."
+            )
+        repo_id = str(inputs.hf_processor_mm_kwargs.get("codec_repo", DEFAULT_NEUCODEC_REPO))
+        return self._encode_reference_audio(audio_items.get_all()[0], repo_id)
+
+    def apply(
+        self,
+        inputs: ProcessorInputs,
+        timing_ctx: TimingContext,
+    ) -> MultiModalInputs:
+        if not isinstance(inputs.prompt, str):
+            raise TypeError("NeuTTS-Air requires a string target-text prompt.")
+
+        ref_text = inputs.hf_processor_mm_kwargs.get("ref_text")
+        if not isinstance(ref_text, str):
+            raise ValueError("NeuTTS-Air requires mm_processor_kwargs['ref_text'].")
+
+        with timing_ctx.record("encode_reference_audio"):
+            ref_codes = self._resolve_reference_codes(inputs)
+        with timing_ctx.record("build_neutts_prompt"):
+            prompt_ids = build_neutts_air_prompt_token_ids(
+                self.info.ctx.tokenizer,
+                ref_codes,
+                ref_text,
+                inputs.prompt,
+            )
+
+        # The reference audio has already become ordinary Qwen2 token IDs.
+        return MultiModalInputs(
+            type="multimodal",
+            prompt_token_ids=prompt_ids,
+            mm_kwargs=MultiModalKwargsItems({}),
+            mm_hashes={},
+            mm_placeholders={},
+        )
+
+
+@MULTIMODAL_REGISTRY.register_processor(
+    NeuTTSAirMultiModalProcessor,
+    info=NeuTTSAirProcessingInfo,
+    dummy_inputs=NeuTTSAirDummyInputsBuilder,
+)
+class NeuTTSAirForCausalLM(Qwen2ForCausalLM, SupportsMultiModal):
+    """NeuTTS-Air identity and processor binding over native vLLM Qwen2."""
+
+    supports_multimodal_raw_input_only = True
+    supports_multimodal = True
+    requires_raw_input_tokens = True
+
+    def embed_input_ids(self, input_ids: torch.Tensor, **_: Any) -> torch.Tensor:
+        """Delegate Omni's unified embedding hook to native vLLM Qwen2."""
+        return super().embed_input_ids(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: Any = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **_: Any,
+    ) -> Any:
+        """Delegate Omni's unified forward hook to native vLLM Qwen2."""
+        return super().forward(
+            input_ids=input_ids,
+            positions=positions,
+            intermediate_tensors=intermediate_tensors,
+            inputs_embeds=inputs_embeds,
+        )
+
+    @classmethod
+    def get_placeholder_str(cls, modality: str, i: int) -> None:
+        del modality, i
+        return None

--- a/vllm_omni/model_executor/models/neutts_air/pipeline.py
+++ b/vllm_omni/model_executor/models/neutts_air/pipeline.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""NeuTTS-Air pipeline: Qwen2 speech-token generation to NeuCodec audio."""
+
+from typing import Any
+
+from vllm_omni.config.stage_config import (
+    PipelineConfig,
+    StageExecutionType,
+    StagePipelineConfig,
+)
+
+_PROC = "vllm_omni.model_executor.stage_input_processors.neutts_air"
+_SPEECH_GENERATION_END_TOKEN_ID = 151670
+
+# NeuTTS-Air publishes a generic qwen2/Qwen2ForCausalLM config without a
+# model-specific marker. Use its full architecture fingerprint so unrelated
+# Qwen2 checkpoints are not routed into this TTS pipeline.
+_CONFIG_FINGERPRINT: dict[str, Any] = {
+    "model_type": "qwen2",
+    "vocab_size": 217652,
+    "hidden_size": 896,
+    "num_hidden_layers": 24,
+    "num_attention_heads": 14,
+    "num_key_value_heads": 2,
+}
+
+
+def is_neutts_air_config(hf_config: Any) -> bool:
+    """Return whether an HF config matches the NeuTTS-Air backbone."""
+    return all(getattr(hf_config, field, None) == expected for field, expected in _CONFIG_FINGERPRINT.items())
+
+
+NEUTTS_AIR_PIPELINE = PipelineConfig(
+    model_type="neutts_air",
+    default_deploy_config_name="neutts_air.yaml",
+    model_arch="NeuTTSAirForCausalLM",
+    hf_architectures=("Qwen2ForCausalLM",),
+    hf_config_predicate=is_neutts_air_config,
+    stages=(
+        StagePipelineConfig(
+            stage_id=0,
+            model_stage="backbone",
+            execution_type=StageExecutionType.LLM_AR,
+            input_sources=(),
+            owns_tokenizer=True,
+            engine_output_type="latent",
+            async_chunk_process_next_stage_input_func=(f"{_PROC}.llm2neucodec_async_chunk"),
+            sampling_constraints={
+                "detokenize": False,
+                "stop_token_ids": [_SPEECH_GENERATION_END_TOKEN_ID],
+            },
+        ),
+        StagePipelineConfig(
+            stage_id=1,
+            model_stage="neucodec",
+            execution_type=StageExecutionType.LLM_GENERATION,
+            input_sources=(0,),
+            final_output=True,
+            final_output_type="audio",
+            engine_output_type="audio",
+            model_arch="NeuTTSAirCode2Wav",
+            sync_process_input_func=f"{_PROC}.llm2neucodec_sync",
+            sampling_constraints={"detokenize": False},
+        ),
+    ),
+)

--- a/vllm_omni/model_executor/models/registry.py
+++ b/vllm_omni/model_executor/models/registry.py
@@ -345,6 +345,17 @@ _OMNI_MODELS = {
         "covo_audio_code2wav",
         "CovoAudioCode2WavForConditionalGeneration",
     ),
+    ## NeuTTS-Air
+    "NeuTTSAirForCausalLM": (
+        "neutts_air",
+        "neutts_air_talker",
+        "NeuTTSAirForCausalLM",
+    ),
+    "NeuTTSAirCode2Wav": (
+        "neutts_air",
+        "neutts_air_code2wav",
+        "NeuTTSAirCode2Wav",
+    ),
     ## MOSS-TTS-Nano
     "MossTTSNanoForCausalLM": (
         "moss_tts_nano",

--- a/vllm_omni/model_executor/stage_input_processors/neutts_air.py
+++ b/vllm_omni/model_executor/stage_input_processors/neutts_air.py
@@ -1,0 +1,253 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Stage input processing for NeuTTS-Air."""
+
+from collections.abc import Mapping
+from typing import Any
+
+import torch
+
+from vllm_omni.data_entry_keys import CodesStruct, MetaStruct, OmniPayloadStruct
+from vllm_omni.inputs.data import OmniTokensPrompt
+
+NEUTTS_SPEECH_GENERATION_START_TOKEN_ID = 151669
+NEUTTS_SPEECH_TOKEN_OFFSET = 151671
+NEUTTS_CODEC_VOCAB_SIZE = 65536
+NEUTTS_SPEECH_TOKEN_LIMIT = NEUTTS_SPEECH_TOKEN_OFFSET + NEUTTS_CODEC_VOCAB_SIZE
+
+NEUTTS_STREAMING_CHUNK_FRAMES = 25
+NEUTTS_STREAMING_LOOKFORWARD_FRAMES = 5
+NEUTTS_STREAMING_LOOKBACK_FRAMES = 50
+NEUTTS_STREAMING_OVERLAP_FRAMES = 1
+
+
+def _ensure_token_list(token_ids: Any) -> list[int]:
+    """Convert vLLM ConstantList, tensors, and iterables to Python ints."""
+    if hasattr(token_ids, "_x"):
+        token_ids = token_ids._x
+    if isinstance(token_ids, torch.Tensor):
+        values = token_ids.detach().cpu().reshape(-1).tolist()
+    elif isinstance(token_ids, list):
+        values = token_ids
+    else:
+        values = list(token_ids)
+    return [int(value) for value in values]
+
+
+def filter_speech_codes(token_ids: list[int]) -> list[int]:
+    """Extract NeuTTS speech tokens and convert them to NeuCodec codes."""
+    return [
+        token_id - NEUTTS_SPEECH_TOKEN_OFFSET
+        for token_id in token_ids
+        if NEUTTS_SPEECH_TOKEN_OFFSET <= token_id < NEUTTS_SPEECH_TOKEN_LIMIT
+    ]
+
+
+def _extract_reference_codes(prompt_token_ids: list[int]) -> list[int]:
+    """Read reference codes appended after the prompt's generation marker."""
+    try:
+        marker_index = len(prompt_token_ids) - 1 - prompt_token_ids[::-1].index(NEUTTS_SPEECH_GENERATION_START_TOKEN_ID)
+    except ValueError as exc:
+        raise ValueError("NeuTTS-Air streaming prompt is missing <|SPEECH_GENERATION_START|>.") from exc
+
+    reference_codes = filter_speech_codes(prompt_token_ids[marker_index + 1 :])
+    if not reference_codes:
+        raise ValueError("NeuTTS-Air streaming requires reference speech codes.")
+    return reference_codes
+
+
+def _streaming_config(transfer_manager: Any) -> tuple[int, int, int, int]:
+    connector = getattr(transfer_manager, "connector", None)
+    raw_config = getattr(connector, "config", {}) or {}
+    if not isinstance(raw_config, Mapping):
+        raw_config = {}
+    config = raw_config.get("extra", raw_config)
+    if not isinstance(config, Mapping):
+        config = {}
+
+    chunk_frames = int(config.get("codec_chunk_frames", NEUTTS_STREAMING_CHUNK_FRAMES))
+    lookforward_frames = int(
+        config.get(
+            "codec_pre_lookahead_frames",
+            NEUTTS_STREAMING_LOOKFORWARD_FRAMES,
+        )
+    )
+    lookback_frames = int(
+        config.get(
+            "codec_left_context_frames",
+            NEUTTS_STREAMING_LOOKBACK_FRAMES,
+        )
+    )
+    overlap_frames = int(config.get("codec_overlap_frames", NEUTTS_STREAMING_OVERLAP_FRAMES))
+
+    if chunk_frames <= 0 or lookforward_frames < 2 * overlap_frames or lookback_frames < 0 or overlap_frames < 0:
+        raise ValueError(
+            "Invalid NeuTTS-Air streaming config: "
+            f"chunk={chunk_frames}, lookforward={lookforward_frames}, "
+            f"lookback={lookback_frames}, overlap={overlap_frames}."
+        )
+    return chunk_frames, lookforward_frames, lookback_frames, overlap_frames
+
+
+def _request_finished(request: Any, is_finished: bool) -> bool:
+    request_is_finished = getattr(request, "is_finished", None)
+    return bool(is_finished or (callable(request_is_finished) and request_is_finished()))
+
+
+def _stream_payload(
+    *,
+    request_id: str,
+    codes: list[int],
+    left_context_size: int,
+    right_holdback_size: int,
+    num_processed_tokens: int,
+    chunk_frames: int,
+    lookback_frames: int,
+    finished: bool,
+) -> OmniPayloadStruct:
+    return OmniPayloadStruct(
+        codes=CodesStruct(audio=torch.tensor(codes, dtype=torch.long)),
+        meta=MetaStruct(
+            finished=torch.tensor(finished, dtype=torch.bool),
+            stream_finished=torch.tensor(finished, dtype=torch.bool),
+            last_chunk=finished,
+            req_id=[request_id],
+            left_context_size=left_context_size,
+            right_holdback_size=right_holdback_size,
+            num_processed_tokens=num_processed_tokens,
+            codec_streaming=True,
+            codec_chunk_frames=chunk_frames,
+            codec_left_context_frames=lookback_frames,
+        ),
+    )
+
+
+def llm2neucodec_async_chunk(
+    transfer_manager: Any,
+    multimodal_output: dict[str, Any] | None,
+    request: Any,
+    is_finished: bool = False,
+) -> OmniPayloadStruct | None:
+    """Build NeuCodec windows matching the official NeuTTS stream decoder."""
+    del multimodal_output
+
+    request_id = getattr(request, "external_req_id", None) or getattr(request, "request_id", None)
+    if not request_id:
+        raise ValueError("NeuTTS-Air streaming request has no request ID.")
+    request_id = str(request_id)
+
+    prompt_token_ids = _ensure_token_list(request.prompt_token_ids)
+    all_token_ids = _ensure_token_list(request.all_token_ids)
+    if len(all_token_ids) < len(prompt_token_ids):
+        raise ValueError("NeuTTS-Air all_token_ids is shorter than its prompt.")
+
+    reference_codes = _extract_reference_codes(prompt_token_ids)
+    generated_ids = all_token_ids[len(prompt_token_ids) :]
+    target_codes = filter_speech_codes(generated_ids)
+    finished = _request_finished(request, is_finished)
+
+    state_by_request = getattr(transfer_manager, "code_prompt_token_ids", None)
+    if state_by_request is None:
+        state_by_request = {}
+        transfer_manager.code_prompt_token_ids = state_by_request
+    consumed_codes = state_by_request.setdefault(request_id, [])
+    consumed = len(consumed_codes)
+    if consumed > len(target_codes):
+        raise RuntimeError("NeuTTS-Air streaming state is ahead of the generated code stream.")
+    if [int(code) for code in consumed_codes] != target_codes[:consumed]:
+        raise RuntimeError("NeuTTS-Air streaming state does not match the generated code prefix.")
+
+    chunk_frames, lookforward_frames, lookback_frames, overlap_frames = _streaming_config(transfer_manager)
+    available = len(target_codes) - consumed
+    continuous_codes = reference_codes + target_codes
+
+    if not finished:
+        required_frames = chunk_frames + lookforward_frames
+        if available < required_frames:
+            return None
+
+        cursor = len(reference_codes) + consumed
+        window_start = max(cursor - lookback_frames - overlap_frames, 0)
+        window_end = min(
+            cursor + required_frames + overlap_frames,
+            len(continuous_codes),
+        )
+        window_codes = continuous_codes[window_start:window_end]
+        left_context_size = cursor - window_start
+        decoded_window_frames = chunk_frames + 2 * overlap_frames
+        right_holdback_size = len(window_codes) - left_context_size - decoded_window_frames
+        if right_holdback_size < 0:
+            raise RuntimeError("NeuTTS-Air streaming window is too short to decode.")
+
+        newly_consumed = target_codes[consumed : consumed + chunk_frames]
+        consumed_codes.extend(newly_consumed)
+        return _stream_payload(
+            request_id=request_id,
+            codes=window_codes,
+            left_context_size=left_context_size,
+            right_holdback_size=right_holdback_size,
+            num_processed_tokens=len(newly_consumed),
+            chunk_frames=chunk_frames,
+            lookback_frames=lookback_frames,
+            finished=False,
+        )
+
+    remaining_codes = target_codes[consumed:]
+    if not remaining_codes:
+        # A zero-token non-AR request is finished by the scheduler without
+        # calling Stage 1. Send one context-only code so Stage 1 can observe
+        # stream_finished and release its overlap-add cache. The metadata says
+        # that this transport wake-up contains zero newly processed frames.
+        return _stream_payload(
+            request_id=request_id,
+            codes=continuous_codes[-1:],
+            left_context_size=1,
+            right_holdback_size=0,
+            num_processed_tokens=0,
+            chunk_frames=chunk_frames,
+            lookback_frames=lookback_frames,
+            finished=True,
+        )
+
+    window_start = max(
+        len(continuous_codes) - (lookback_frames + overlap_frames + len(remaining_codes)),
+        0,
+    )
+    left_context_size = max(
+        len(continuous_codes) - window_start - len(remaining_codes) - overlap_frames,
+        0,
+    )
+    window_codes = continuous_codes[window_start:]
+    consumed_codes.extend(remaining_codes)
+    return _stream_payload(
+        request_id=request_id,
+        codes=window_codes,
+        left_context_size=left_context_size,
+        right_holdback_size=0,
+        num_processed_tokens=len(remaining_codes),
+        chunk_frames=chunk_frames,
+        lookback_frames=lookback_frames,
+        finished=True,
+    )
+
+
+def llm2neucodec_sync(
+    source_outputs: list[Any],
+    prompt: Any = None,
+    requires_multimodal_data: bool = False,
+) -> list[OmniTokensPrompt]:
+    """Forward generated NeuCodec codes directly in synchronous mode."""
+    code2wav_inputs: list[OmniTokensPrompt] = []
+    for output_wrapper in source_outputs:
+        output = output_wrapper.outputs[0]
+        speech_codes = filter_speech_codes(list(output.token_ids))
+        code2wav_inputs.append(
+            OmniTokensPrompt(
+                prompt_token_ids=speech_codes,
+                additional_information=None,
+                multi_modal_data=None,
+                mm_processor_kwargs=None,
+            )
+        )
+    return code2wav_inputs


### PR DESCRIPTION
# Summary

Add end-to-end NeuTTS-Air support to vLLM-Omni, including offline inference, the OpenAI-compatible Speech API, asynchronous chunked streaming, request isolation, and a production-oriented single-GPU deployment configuration.

## Architecture

The integration uses a two-stage pipeline:

1. Stage 0 reuses vLLM's native Qwen2 implementation to generate NeuTTS speech-token IDs.
2. The stage input processor converts speech-token IDs into NeuCodec code IDs and prepares synchronous or streaming decoder windows.
3. Stage 1 lazily loads the external NeuCodec runtime and decodes the codes into 24 kHz waveform chunks.

The request path is:

```text
target text + reference text + reference audio
  -> NeuTTS-Air processor
  -> phonemes + reference NeuCodec codes
  -> NeuTTS prompt token IDs
  -> native vLLM Qwen2 generation
  -> speech-token filtering and code conversion
  -> NeuCodec decoding
  -> 24 kHz audio
```

Reference audio is normalized to mono 16 kHz before NeuCodec encoding. Callers may provide precomputed reference codes to avoid repeated CPU encoding.

## What Changed

- Register NeuTTS-Air model detection, model classes, and pipeline configuration.
- Add the NeuTTS prompt processor while retaining vLLM's native Qwen2 execution path.
- Add synchronous and asynchronous Stage 0 to Stage 1 transfer.
- Add stateful streaming NeuCodec decoding with lookback, lookahead, overlap-add, terminal flushing, and abort cleanup.
- Add a NeuTTS-Air Speech API adapter with request validation and sampling overrides.
- Add offline inference and online serving documentation.
- Add the `neutts-air` optional dependency extra.
- Add focused tests for discovery, prompting, transfer, decoding, serving, streaming, and cleanup.

## Interfaces

- Offline inference through `examples/offline_inference/text_to_speech/neutts_air/end2end.py`.
- OpenAI-compatible `/v1/audio/speech` requests using `input`, `ref_audio`, and `ref_text`.
- Synchronous full-waveform generation.
- Asynchronous PCM/WAV chunk streaming.
- Concurrent request isolation and cleanup after completion, abort, and request errors.

## Correctness Evidence

Five representative English cases were checked across prompt construction, Stage 0 generation, and audio decoding.

- Phoneme and prompt-token parity: 5/5 exact against the original implementation.
- Stage 0 structure: 5/5 produced valid speech-token IDs and a terminal stop token.
- Fixed-code NeuCodec parity: exact waveform equality, maximum absolute difference `0.0`.
- Streaming decoder parity: maximum absolute difference `7.276e-12` with complete terminal flushing.
- Async end-to-end run: six chunks, terminal `finished=true`, finite 24 kHz audio, and no clipping.
- Two concurrent requests completed independently.
- Aborting one request did not affect another request, and the engine remained reusable afterward.

BF16 Stage 0 output is not expected to be token-for-token identical to Hugging Face generation. The first candidate differences have small score margins and are amplified by autoregressive generation. FP32 eager execution restored same-batch reproducibility, locating this behavior in the low-precision optimized Qwen2 execution path rather than prompt construction, stage transfer, or NeuCodec decoding.

## Performance Evidence

Measurements were collected on one RTX 5090 after warmup. Core benchmarks exclude startup, reference-audio encoding, and optional watermark postprocessing.

| Metric | Original NeuTTS-Air | vLLM-Omni |
|---|---:|---:|
| Median latency | 3.370 s | 0.828 s |
| Median RTF | 0.629 | 0.152 |
| Approximate latency speedup | - | 4.07x |

Additional vLLM-Omni measurements:

- Batch 4: 3.773 requests/s and 20.845 generated audio-seconds/s.
- Streaming with precomputed reference codes: median TTFA 0.151 s, median total latency 0.780 s, nine chunks.
- Stage 0: 282 generated codes in 0.465 s, approximately 607 tokens/s.
- Stage 1: 355 codes decoded in approximately 6.7 ms.
- Default 512 MiB Stage 0 KV cache deployment: approximately 6.6 GiB peak GPU memory in the validated batch-4 run.
- CPU reference encoding for a 13.06-second clip: median 4.02 s; precomputed reference codes avoid this cost.

## Tests

```bash
python -m pytest -q   tests/config/test_neutts_air_pipeline.py   tests/entrypoints/openai_api/test_neutts_air_tts_adapter.py   tests/model_executor/models/test_neutts_air_talker.py   tests/model_executor/models/test_neutts_air_code2wav.py   tests/model_executor/stage_input_processors/test_neutts_air_stage_input_processors.py   tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
```

Result: `98 passed`.

Relevant pre-commit checks also pass, including Ruff check/format, YAML validation, whitespace and line-ending checks, typos, pytest markers, TTS adapter migration, and pickle import checks. No GitHub workflow files are changed.

## Limitations

- English synthesis only.
- Voice cloning requires one reference-audio and reference-text pair.
- Exact prompt parity requires the expected eSpeak backend behavior.
- Raw reference-audio encoding currently runs on CPU and can dominate first-request latency.
- BF16 generation is structurally correct but not bitwise identical to the Hugging Face baseline.
- The core benchmarks exclude optional watermark postprocessing.
- Performance and memory figures above are from a single RTX 5090.
