### PR TITLE
[MiniCPM-o] Fix seq_token_count_mismatch crash in Code2Wav under graph mode

### DIFF
--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
@@ -310,12 +310,18 @@ class MiniCPMO45Code2Wav(nn.Module):
         normalized = [int(value) for value in counts]
         if any(value < 0 for value in normalized):
             raise _batch_error("negative_seq_token_count", counts=normalized)
-        if sum(normalized) != int(flat.numel()):
+        total = sum(normalized)
+        if total > int(flat.numel()):
             raise _batch_error(
                 "seq_token_count_mismatch",
                 counts=normalized,
                 total=int(flat.numel()),
             )
+        # Graph mode pads input_ids up to a captured batch size while
+        # seq_token_counts keeps the real per-request counts, so the tail
+        # belongs to no request and must be dropped rather than rejected.
+        # In eager mode total == numel and this slice is a no-op.
+        flat = flat[:total]
         return list(torch.split(flat, normalized))
 
     def _parse_item(


### PR DESCRIPTION
## Problem

With graph capture enabled, the Code2Wav stage of MiniCPM-o 4.5 raises `seq_token_count_mismatch` and takes down EngineCore. Under the same configuration `completed` drops to 9 with 23 `failed`. The issue never reproduces in eager mode.

## Root cause

Two sites disagree on the length of `input_ids`:

- `vllm_omni/platforms/npu/worker/npu_generation_model_runner.py` builds `input_ids` with `num_tokens_padded`, since graph mode must pad up to a captured batch size.
- The same file sets `model_kwargs["seq_token_counts"] = tokens`, which keeps the **real** per-request counts and is not padded.

`_split_segments` in `vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py` then checks `sum(normalized) != flat.numel()`, which can never hold under graph mode, so it always raises. In eager mode the two are equal, which is why this has gone unnoticed.

## Fix

The padding tail belongs to no request, so it should be dropped before splitting rather than rejected.

- `!=` is tightened to `>`, so counts *exceeding* the actual length remain a genuine error and still raise.
- `flat` is truncated to `total` before the split.

In eager mode `total == numel`, so the slice is a no-op and behavior is unchanged.

## Precedent

`split_request_ids` in `glm_tts_dit_wrapper.py` already clamps the same boundary with `min()`. This change brings the MiniCPM-o path in line with that existing guard, rather than introducing a new pattern.

## Validation

Same configuration and inputs, graph mode enabled:

| | before | after |
|---|---:|---:|
| `completed` | 9 | 32 |
| `failed` | 23 | 0 |

Eager mode behavior is unchanged.

---

Team: **七七饱**
