### PR TITLE
[Feature][Wan2.2] Per-transformer quantization for Wan2.2 I2V

### DIFF
--- a/tests/diffusion/models/wan2_2/test_wan22_quant_config_propagation.py
+++ b/tests/diffusion/models/wan2_2/test_wan22_quant_config_propagation.py
@@ -8,7 +8,6 @@ Tests cover:
 - set_tf_model_config propagates quant_config to OmniDiffusionConfig
 - patch_wan_rms_norm safely iterates sys.modules with concurrent modifications
 - I2V per-component quantization routing
-- transformer checkpoint quantization auto-detection
 """
 
 import sys
@@ -242,7 +241,7 @@ class TestPatchWanRmsNorm:
 
 
 class TestI2VTransformerQuantConfig:
-    """Test I2V quantization routing and checkpoint auto-detection."""
+    """Test I2V per-component quantization routing."""
 
     @pytest.mark.parametrize(
         ("spec", "expected"),
@@ -262,13 +261,27 @@ class TestI2VTransformerQuantConfig:
             ),
             (
                 {
+                    "default": {"method": "fp8"},
+                    "transformer_2": None,
+                },
+                ("fp8", None),
+            ),
+            (
+                {
                     "transformer": {"method": "fp8"},
                     "transformer_2": {"method": "int8"},
                 },
                 ("fp8", "int8"),
             ),
         ],
-        ids=["none", "flat", "transformer-only", "transformer-2-only", "mixed"],
+        ids=[
+            "none",
+            "flat",
+            "transformer-only",
+            "transformer-2-only",
+            "default-with-transformer-2-disabled",
+            "mixed",
+        ],
     )
     def test_component_quantization_routing(self, spec, expected):
         config = build_quant_config(spec)
@@ -281,29 +294,3 @@ class TestI2VTransformerQuantConfig:
             transformer_2.get_name() if transformer_2 else None,
         )
         assert actual == expected
-
-    def test_checkpoint_quantization_auto_detected(self, mocker: MockerFixture):
-        captured = {}
-
-        class FakeTransformer:
-            def __init__(self, **kwargs):
-                captured.update(kwargs)
-
-        mocker.patch.object(wan22_module, "WanTransformer3DModel", FakeTransformer)
-
-        create_transformer_from_config(
-            {
-                "quantization_config": {
-                    "quant_method": "auto-round",
-                    "bits": 4,
-                    "group_size": 128,
-                    "sym": True,
-                    "packing_format": "auto_round:auto_gptq",
-                }
-            }
-        )
-
-        quant_config = captured["quant_config"]
-        assert quant_config.get_name() == "inc"
-        assert quant_config.weight_bits == 4
-        assert quant_config.group_size == 128

--- a/tests/diffusion/models/wan2_2/test_wan22_quant_config_propagation.py
+++ b/tests/diffusion/models/wan2_2/test_wan22_quant_config_propagation.py
@@ -7,7 +7,8 @@ Tests cover:
 - create_vace_transformer_from_config passes quant_config and prefix
 - set_tf_model_config propagates quant_config to OmniDiffusionConfig
 - patch_wan_rms_norm safely iterates sys.modules with concurrent modifications
-- I2V transformer_2 quant_config is built from config dict
+- I2V per-component quantization routing
+- transformer checkpoint quantization auto-detection
 """
 
 import sys
@@ -21,9 +22,13 @@ import vllm_omni.diffusion.models.wan2_2.pipeline_wan2_2_vace as wan22_vace_modu
 from vllm_omni.diffusion.models.wan2_2.pipeline_wan2_2 import (
     create_transformer_from_config,
 )
+from vllm_omni.diffusion.models.wan2_2.pipeline_wan2_2_i2v import (
+    _resolve_component_quant_config,
+)
 from vllm_omni.diffusion.models.wan2_2.pipeline_wan2_2_vace import (
     create_vace_transformer_from_config,
 )
+from vllm_omni.quantization import build_quant_config
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.diffusion]
 
@@ -232,70 +237,73 @@ class TestPatchWanRmsNorm:
 
 
 # ---------------------------------------------------------------------------
-# I2V transformer_2 quant_config extraction
+# I2V per-component quantization routing
 # ---------------------------------------------------------------------------
 
 
-class TestI2VTransformer2QuantConfig:
-    """Test the transformer_2 quant_config build logic from pipeline_wan2_2_i2v."""
+class TestI2VTransformerQuantConfig:
+    """Test I2V quantization routing and checkpoint auto-detection."""
 
-    def test_transformer_2_quant_config_built_from_dict(self):
-        """When transformer_2 config has quantization_config dict, build_quant_config is called."""
-        from vllm_omni.quantization.factory import build_quant_config
+    @pytest.mark.parametrize(
+        ("spec", "expected"),
+        [
+            (None, (None, None)),
+            (
+                {"method": "fp8", "activation_scheme": "dynamic"},
+                ("fp8", "fp8"),
+            ),
+            (
+                {"transformer": {"method": "fp8"}},
+                ("fp8", None),
+            ),
+            (
+                {"transformer_2": {"method": "fp8"}},
+                (None, "fp8"),
+            ),
+            (
+                {
+                    "transformer": {"method": "fp8"},
+                    "transformer_2": {"method": "int8"},
+                },
+                ("fp8", "int8"),
+            ),
+        ],
+        ids=["none", "flat", "transformer-only", "transformer-2-only", "mixed"],
+    )
+    def test_component_quantization_routing(self, spec, expected):
+        config = build_quant_config(spec)
 
-        t2_config = {
-            "patch_size": [1, 2, 2],
-            "num_layers": 2,
-            "quantization_config": {
-                "quant_method": "auto-round",
-                "bits": 4,
-                "group_size": 128,
-                "sym": True,
-                "packing_format": "auto_round:auto_gptq",
-            },
-        }
+        transformer = _resolve_component_quant_config(config, "transformer")
+        transformer_2 = _resolve_component_quant_config(config, "transformer_2")
 
-        # Replicate the logic from pipeline_wan2_2_i2v.py
-        t2_quant = t2_config.get("quantization_config")
-        if isinstance(t2_quant, dict) and "quant_method" in t2_quant:
-            method = t2_quant["quant_method"]
-            kwargs = {k: v for k, v in t2_quant.items() if k != "quant_method"}
-            t2_quant = build_quant_config(method, **kwargs)
-        else:
-            t2_quant = None
+        actual = (
+            transformer.get_name() if transformer else None,
+            transformer_2.get_name() if transformer_2 else None,
+        )
+        assert actual == expected
 
-        from vllm.model_executor.layers.quantization.inc import INCConfig
+    def test_checkpoint_quantization_auto_detected(self, mocker: MockerFixture):
+        captured = {}
 
-        assert isinstance(t2_quant, INCConfig)
-        assert t2_quant.weight_bits == 4
-        assert t2_quant.group_size == 128
+        class FakeTransformer:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
 
-    def test_transformer_2_quant_config_none_when_missing(self):
-        """When transformer_2 config has no quantization_config, result is None."""
-        t2_config = {
-            "patch_size": [1, 2, 2],
-            "num_layers": 2,
-        }
+        mocker.patch.object(wan22_module, "WanTransformer3DModel", FakeTransformer)
 
-        t2_quant = t2_config.get("quantization_config")
-        if isinstance(t2_quant, dict) and "quant_method" in t2_quant:
-            pass  # won't enter
-        else:
-            t2_quant = None
+        create_transformer_from_config(
+            {
+                "quantization_config": {
+                    "quant_method": "auto-round",
+                    "bits": 4,
+                    "group_size": 128,
+                    "sym": True,
+                    "packing_format": "auto_round:auto_gptq",
+                }
+            }
+        )
 
-        assert t2_quant is None
-
-    def test_transformer_2_quant_config_none_when_dict_lacks_method(self):
-        """When quantization_config is a dict but missing quant_method, result is None."""
-        t2_config = {
-            "patch_size": [1, 2, 2],
-            "quantization_config": {"bits": 4},  # no quant_method key
-        }
-
-        t2_quant = t2_config.get("quantization_config")
-        if isinstance(t2_quant, dict) and "quant_method" in t2_quant:
-            pass
-        else:
-            t2_quant = None
-
-        assert t2_quant is None
+        quant_config = captured["quant_config"]
+        assert quant_config.get_name() == "inc"
+        assert quant_config.weight_bits == 4
+        assert quant_config.group_size == 128

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
@@ -281,7 +281,6 @@ class Wan22I2VPipeline(
             od_config.quantization_config,
             "transformer",
         )
-        logger.warning("[quant-debug] transformer quant_config=%r", transformer_quant_config)
         self.transformer = create_transformer_from_config(
             transformer_config,
             quant_config=transformer_quant_config,
@@ -292,7 +291,6 @@ class Wan22I2VPipeline(
                 od_config.quantization_config,
                 "transformer_2",
             )
-            logger.warning("[quant-debug] transformer_2 quant_config=%r", transformer_2_quant_config)
             self.transformer_2 = create_transformer_from_config(
                 transformer_2_config,
                 quant_config=transformer_2_quant_config,

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
@@ -53,6 +53,13 @@ logger = logging.getLogger(__name__)
 DEBUG_PERF = False
 
 
+def _resolve_component_quant_config(quant_config, component: str):
+    component_configs = getattr(quant_config, "component_configs", None)
+    if component_configs is not None:
+        return component_configs.get(component, quant_config.default_config)
+    return quant_config
+
+
 def get_wan22_i2v_post_process_func(
     od_config: OmniDiffusionConfig,
 ):
@@ -270,24 +277,25 @@ class Wan22I2VPipeline(
         # Transformers (weights loaded via load_weights)
         # Load config from model directory or HF Hub to get correct in_channels for I2V models
         transformer_config = load_transformer_config(model, "transformer", local_files_only)
+        transformer_quant_config = _resolve_component_quant_config(
+            od_config.quantization_config,
+            "transformer",
+        )
+        logger.warning("[quant-debug] transformer quant_config=%r", transformer_quant_config)
         self.transformer = create_transformer_from_config(
             transformer_config,
-            quant_config=od_config.quantization_config,
+            quant_config=transformer_quant_config,
         )
         if self.has_transformer_2:
             transformer_2_config = load_transformer_config(model, "transformer_2", local_files_only)
-            t2_quant = transformer_2_config.get("quantization_config")
-            if isinstance(t2_quant, dict) and "quant_method" in t2_quant:
-                from vllm_omni.quantization.factory import build_quant_config
-
-                method = t2_quant["quant_method"]
-                kwargs = {k: v for k, v in t2_quant.items() if k != "quant_method"}
-                t2_quant = build_quant_config(method, **kwargs)
-            else:
-                t2_quant = None
+            transformer_2_quant_config = _resolve_component_quant_config(
+                od_config.quantization_config,
+                "transformer_2",
+            )
+            logger.warning("[quant-debug] transformer_2 quant_config=%r", transformer_2_quant_config)
             self.transformer_2 = create_transformer_from_config(
                 transformer_2_config,
-                quant_config=t2_quant,
+                quant_config=transformer_2_quant_config,
             )
         else:
             self.transformer_2 = None

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
@@ -16,6 +16,7 @@ import torchvision.transforms.functional as TF
 from diffusers.utils.torch_utils import randn_tensor
 from torch import nn
 from transformers import AutoTokenizer, CLIPImageProcessor, CLIPVisionModel, UMT5EncoderModel
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
 from vllm.model_executor.models.utils import AutoWeightsLoader
 from vllm.sequence import IntermediateTensors
 
@@ -53,7 +54,10 @@ logger = logging.getLogger(__name__)
 DEBUG_PERF = False
 
 
-def _resolve_component_quant_config(quant_config, component: str):
+def _resolve_component_quant_config(
+    quant_config: QuantizationConfig | None,
+    component: str,
+) -> QuantizationConfig | None:
     component_configs = getattr(quant_config, "component_configs", None)
     if component_configs is not None:
         return component_configs.get(component, quant_config.default_config)


### PR DESCRIPTION
## Purpose

Wan2.2 uses two transformers; the first acts as a coarse pass while the second handles finer details. Due to this architectural split it is often useful to set different quantization levels for each of the transformers, in order to not degrade the final output quality.

Using the `--diffusion-quantization-config` flag an end-user is able to specify quantization details, such as the method, activation scheme, and components to target.

However in the current codebase Wan2.2 is only able to specify a flat quantization config

```
--diffusion-quantization-config '{"method":"fp8","activation_scheme":"dynamic"}'
```

which further only targets the first transformer. The first transformer reads it's quantization settings from the `od_config.quantization_config` while the second reads from the transformer config directly. If the user tries to specify a specific transformer they are met with this message:
```
ValueError: All linear layers should support quant method.
```

This occurs because the unresolved `ComponentQuantizationConfig` is passed into the first transformer, whose internal layer names use blocks.* prefixes and therefore cannot resolve the requested transformer component. 

This PR adds the ability to set and experiment with per transformer quantization, allowing independent selection of existing methods.

## Test Plan

**vLLM Version:0.27.0**

**vLLM-Omni Commit: 5d50bd**

Tested with B200 USP=8. Temporary logging functions were used to inspect the transformer quantization.

#### Base command
```
vllm serve Wan-AI/Wan2.2-I2V-A14B-Diffusers \
--omni \
--ulysses-degree 8 \
--diffusion-quantization-config '{<See specific examples below>}'
```

## Test Result

### Baseline (vanilla behaviour)

#### Default flat config
```
--diffusion-quantization-config \
'{"method":"fp8","activation_scheme":"dynamic"}'

[quant-debug] transformer quant_config=<vllm.model_executor.layers.quantization.fp8.Fp8Config object at 0x7d57486e0ad0>
[quant-debug] transformer_2 quant_config=None
```


### PR behaviour

#### Default flat config
```
--diffusion-quantization-config \
'{"method":"fp8","activation_scheme":"dynamic"}'

[quant-debug] transformer_2 quant_config=<vllm.model_executor.layers.quantization.fp8.Fp8Config object at 0x716e218cc8c0>
[quant-debug] transformer quant_config=<vllm.model_executor.layers.quantization.fp8.Fp8Config object at 0x74b848d54a70>
```

#### Target first transformer
```
 --diffusion-quantization-config '{"transformer":{"method":"fp8","activation_scheme":"dynamic"}}'

[quant-debug] transformer quant_config=<vllm.model_executor.layers.quantization.fp8.Fp8Config object at 0x7d18f9528ad0>
[quant-debug] transformer_2 quant_config=None
```

#### Target second transformer
```
--diffusion-quantization-config '{"transformer_2":{"method":"fp8","activation_scheme":"dynamic"}}'

[quant-debug] transformer quant_config=None
[quant-debug] transformer_2 quant_config=<vllm.model_executor.layers.quantization.fp8.Fp8Config object at 0x783f84290920>
```

#### Target both transformers
```
--diffusion-quantization-config  '{"transformer":{"method":"fp8","activation_scheme":"dynamic"},"transformer_2": {"method":"int8","activation_scheme":"dynamic"}}'

[quant-debug] transformer quant_config=<vllm.model_executor.layers.quantization.fp8.Fp8Config object at 0x741823bcc770>
[quant-debug] transformer_2 quant_config=<vllm_omni.quantization.int8_config.DiffusionInt8Config object at 0x741823bcc800>
```


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
