### PR TITLE
[Bugfix] Restore per-stage runtime env during launch

### DIFF
--- a/tests/engine/test_async_omni_engine_stage_init.py
+++ b/tests/engine/test_async_omni_engine_stage_init.py
@@ -161,6 +161,17 @@ def _make_diffusion_plan(
     )
 
 
+def _make_stage_runtime() -> StageRuntime:
+    return StageRuntime(
+        stage_configs=[],
+        model="dummy-model",
+        config_path="dummy-config",
+        stage_init_timeout=1,
+        diffusion_batch_size=1,
+        async_chunk=False,
+    )
+
+
 def test_stage_engine_core_client_module_reload_keeps_forward_refs_deferred():
     """Regression test for forward references in make_async_mp_client."""
     import vllm_omni.engine.stage_engine_core_client as client_mod
@@ -231,6 +242,48 @@ def test_collect_initialized_clients_for_cleanup_deduplicates_clients():
     )
 
     assert cleanup_clients == [shared, extra]
+
+
+def test_initialize_local_diffusion_replica_scopes_runtime_env(monkeypatch):
+    import vllm_omni.engine.stage_runtime as runtime_mod
+    from vllm_omni.platforms import current_omni_platform
+
+    runtime = _make_stage_runtime()
+    plan = _make_diffusion_plan(0, stage_id=0).replicas[0]
+
+    runtime_env_var = "VLLM_OMNI_TEST_STAGE_RUNTIME_ENV"
+    device_env_var = current_omni_platform.device_control_env_var
+    runtime._init_visible_devices_baseline = "0,1"
+    plan.metadata.runtime_cfg = {
+        "devices": "0",
+        "env": {runtime_env_var: "stage-value"},
+    }
+    monkeypatch.delenv(runtime_env_var, raising=False)
+    monkeypatch.setenv(device_env_var, "0,1")
+
+    captured: dict[str, str | None] = {}
+    monkeypatch.setattr(runtime_mod, "inject_kv_stage_info", lambda *_: None)
+
+    def _capture_launch_diffusion_stage_replica(**_kwargs):
+        captured["runtime_env"] = os.environ.get(runtime_env_var)
+        captured["device_env"] = os.environ.get(device_env_var)
+        raise RuntimeError("stop after capturing launch environment")
+
+    monkeypatch.setattr(
+        runtime_mod,
+        "launch_diffusion_stage_replica",
+        _capture_launch_diffusion_stage_replica,
+    )
+
+    with pytest.raises(RuntimeError, match="stop after capturing launch environment"):
+        runtime._initialize_local_diffusion_replica(plan, stage_init_timeout=1)
+
+    assert captured == {
+        "runtime_env": "stage-value",
+        "device_env": "0",
+    }
+    assert runtime_env_var not in os.environ
+    assert os.environ[device_env_var] == "0,1"
 
 
 def test_initialize_local_diffusion_replica_restores_device_visibility_after_local_init(monkeypatch):
@@ -309,6 +362,41 @@ def test_initialize_local_diffusion_replica_passes_stage_init_timeout_and_inline
         "use_inline": True,
         "omni_master_server": None,
     }
+
+
+def test_initialize_local_llm_replica_scopes_runtime_env(monkeypatch):
+    import vllm_omni.engine.stage_runtime as runtime_mod
+
+    runtime = _make_stage_runtime()
+    plan = _make_llm_plan(0, stage_id=0, vllm_config=object()).replicas[0]
+    plan.engine_args_dict = {}
+
+    runtime_env_var = "VLLM_OMNI_TEST_STAGE_RUNTIME_ENV"
+    plan.metadata.runtime_cfg = {
+        "devices": "0",
+        "env": {runtime_env_var: "stage-value"},
+    }
+    monkeypatch.setenv(runtime_env_var, "parent-value")
+
+    captured: dict[str, str | None] = {}
+
+    @contextlib.contextmanager
+    def _capture_launch_stage_replica(*, stage_visible_devices, **_kwargs):
+        captured["runtime_env"] = os.environ.get(runtime_env_var)
+        captured["stage_visible_devices"] = stage_visible_devices
+        yield None
+
+    monkeypatch.setattr(runtime_mod, "acquire_device_locks", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(runtime_mod, "launch_stage_replica", _capture_launch_stage_replica)
+
+    with pytest.raises(RuntimeError, match="launcher returned no resources"):
+        runtime._initialize_local_llm_replica(plan, stage_init_timeout=1)
+
+    assert captured == {
+        "runtime_env": "stage-value",
+        "stage_visible_devices": "0",
+    }
+    assert os.environ[runtime_env_var] == "parent-value"
 
 
 def test_stage_runtime_initializes_stage_pools(monkeypatch):

--- a/vllm_omni/engine/stage_runtime.py
+++ b/vllm_omni/engine/stage_runtime.py
@@ -58,6 +58,7 @@ from vllm_omni.engine.stage_init_utils import (
     load_omni_transfer_config_for_model,
     prepare_engine_environment,
     release_device_locks,
+    stage_runtime_env,
 )
 from vllm_omni.engine.stage_pool import StagePool
 from vllm_omni.entrypoints.stage_utils import resolve_stage_physical_devices
@@ -576,7 +577,7 @@ class StageRuntime:
                 )
             # Serialize engine-core spawning across all LLM replicas to avoid
             # ZMQ port-allocation races and simultaneous CUDA context init.
-            with self._replica_launch_lock:
+            with self._replica_launch_lock, stage_runtime_env(plan.metadata.stage_id, plan.metadata.runtime_cfg):
                 with launch_stage_replica(
                     vllm_config=vllm_config,
                     executor_class=executor_class,
@@ -645,7 +646,10 @@ class StageRuntime:
         client = None
         resources = None
         try:
-            with self._stage_device_scope(plan.metadata.stage_id, plan.metadata.runtime_cfg):
+            with (
+                stage_runtime_env(plan.metadata.stage_id, plan.metadata.runtime_cfg),
+                self._stage_device_scope(plan.metadata.stage_id, plan.metadata.runtime_cfg),
+            ):
                 omni_conn_cfg, omni_from, omni_to = plan.omni_kv_connector
                 if omni_conn_cfg:
                     inject_omni_kv_config(plan.stage_cfg, omni_conn_cfg, omni_from, omni_to)


### PR DESCRIPTION
## Purpose

Per-stage `runtime.env` remains parsed into each stage's runtime config, but local LLM and diffusion launches no longer apply it. The observable result is that launch code sees the parent value (or an unset key) instead of the configured stage value.

Fixes #6210.

## Reproduction

Run the focused regression tests:

```bash
pytest -q tests/engine/test_async_omni_engine_stage_init.py \
  -k 'initialize_local_diffusion_replica_scopes_runtime_env or initialize_local_llm_replica_scopes_runtime_env'
```

Against the parent implementation, the LLM launch hook sees the parent value and the diffusion launch hook sees an unset key. Both should see the configured stage value.

## Root cause

The stage-runtime refactor replaced the old `stage_runtime_setup()` launch scopes with device-only scopes. `stage_runtime_env()` still handled conversion, key-only logging, and restoration, but had no production caller.

## Fix

- Enter `stage_runtime_env()` inside the existing serialized local LLM launch section.
- Compose `stage_runtime_env()` outside the local diffusion device scope, so `runtime.devices` remains the effective device selection during launch.
- Add L1 CPU regression coverage for value visibility, existing-parent restoration, previously-unset cleanup, and device-scope composition.

Remote replicas are unchanged: the controller only attaches to those processes and does not apply a local environment scope. Headless worker environments remain owned by their launcher/process environment.

## Test Plan

```bash
pytest -q tests/engine/test_async_omni_engine_stage_init.py \
  -k 'initialize_local_diffusion_replica_scopes_runtime_env or initialize_local_llm_replica_scopes_runtime_env'

uvx --from pre-commit==4.0.1 pre-commit run --files \
  vllm_omni/engine/stage_runtime.py \
  tests/engine/test_async_omni_engine_stage_init.py
```

**vLLM Version:** v0.27.0 target

**vLLM-Omni Commit:** `136cb27b05385cf2ce7246e6815154ee86525d0f`

## Test Result

- Full file-scoped pre-commit suite: passed.
- Python 3.12 compile check for both changed files: passed.
- Dependency-isolated probe of the actual `StageRuntime` class: reproduced parent/unset values on the base revision and observed stage values plus restoration on this branch.
- Focused pytest was not runnable on the local macOS arm64 host because vLLM v0.27.0 has no usable wheel there; Linux CI is expected to run the committed L1 CPU regressions.

AI assistance: Codex was used for implementation, regression-test design, and the repository `precheck-pr` / `vllm-omni-test` workflows.
