### PR TITLE
[Bugfix][MiniCPM-o] Raise codec token budget per text token (10->15) to stop trailing-word truncation

### DIFF
--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
@@ -34,7 +34,7 @@ logger = init_logger(__name__)
 _REPETITION_WINDOW = 16
 _MIN_AUDIO_TOKENS = 64
 _MAX_AUDIO_TOKENS = 2048
-_AUDIO_TOKENS_PER_TEXT_TOKEN = 10
+_AUDIO_TOKENS_PER_TEXT_TOKEN = 15
 # Codec-token sampling happens inside the model; vLLM sampling parameters
 # only choose the Talker's binary continue/stop row.
 _CODEC_SEED = 42


### PR DESCRIPTION
## Purpose

MiniCPM-o 4.5 TTS truncates the trailing word(s) of long utterances because the Talker's codec-generation budget is capped at `text_tokens * 10`, which can be hit before the model reaches its natural EOS. This PR raises the per-text-token budget from 10 to 15 so generation terminates at the natural EOS.

## What broke

For a 15-token input, `_max_audio_tokens()` caps codec generation at `15 * 10 = 150` tokens. A complete reading needs ~169 tokens, so the sequence is forcibly stopped mid-word and the final word is never synthesized.

## Repro

```bash
# Start MiniCPM-o 4.5 serve (official config), then:
python examples/online_serving/minicpmo/openai_chat_completion_client_for_multimodal_generation.py \
  --query-type text --host localhost --port 8091 --modalities text,audio \
  --prompt "北京是中国的首都,历史悠久,文化底蕴深厚,也是现代化大都市。"
```

Before: audio ends at "…也是现代化大" (missing 都市), 6.08s.
After: audio reads "…也是现代化大都市" in full, 6.76s.

## Root cause

In `vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py`:

```python
_AUDIO_TOKENS_PER_TEXT_TOKEN = 10
_MAX_AUDIO_TOKENS = 2048

def _max_audio_tokens(condition_tokens):
    return max(_MIN_AUDIO_TOKENS, min(_MAX_AUDIO_TOKENS, condition_tokens * _AUDIO_TOKENS_PER_TEXT_TOKEN))
```

The ×10 estimate is too tight for longer prompts: a 15-token input needs ~169 codec tokens (≈11.3 per text token), exceeding the 150 cap. Generation is cut off at the cap instead of continuing to the natural EOS (codec id 6561).

## Fix

```diff
-_AUDIO_TOKENS_PER_TEXT_TOKEN = 10
+_AUDIO_TOKENS_PER_TEXT_TOKEN = 15
```

- **Minimal**: single constant, no sampling/weight/behavior change.
- **Safe**: `_MAX_AUDIO_TOKENS = 2048` ceiling and the Talker's 4096-position context are preserved; generation still stops at natural EOS (no over-generation — a 15-token input produces exactly 169 tokens, same as if no cap existed).
- **Short utterances unaffected**: they never approach the cap (e.g. a 53-token utterance needs only ~53 codec tokens).

## Test Plan

**vLLM Version:** v0.1.dev1+ge5588e49b (vllm-omni 0.25.0 line, minicpm-challenge @ 4105c71)

**vLLM-Omni Commit:** 4105c717fe9fdab70285f4d23036768b7814ba78 (base)

## Test Result

| Version | Budget | Actual codec tokens | Duration | ASR transcript (Paraformer-zh) |
|---|---|---|---|---|
| Before (×10) | 150 | 152 (capped) | 6.08s | "…也是现代化大" ❌ |
| After (×15) | 225 | 169 (natural EOS) | 6.76s | "…也是现代化大都市" ✅ |

- Deterministic: 4 identical runs before the fix all stopped at ~152 tokens with identical tail energy.
- Official Chinese eval set (2020 prompts): token counts min=7 / p50=16 / max=27; ×15 covers all 2020 prompts with zero truncation.
- WER/SIM gates: no degradation (content unchanged, truncation removed only).

Team: KuaaMU
