### PR TITLE
[Bugfix][MiniCPM-o] Keep duplex scheduler placeholder tokens out of the KV on failed appends

### DIFF
--- a/vllm_omni/experimental/fullduplex/minicpmo45/runtime.py
+++ b/vllm_omni/experimental/fullduplex/minicpmo45/runtime.py
@@ -111,9 +111,18 @@ def build_duplex_data_plane_prompt(
     token_budget = duplex_scheduler_token_budget(payload)
     if seq <= 1:
         context_reserve = duplex_first_append_context_reserve(runtime_config)
-        token_budget += context_reserve
         first_units = duplex_first_append_unit_count(payload)
-        if first_units is not None:
+        if first_units is None:
+            # The first append carries no whole model chunk, so Stage0 cannot
+            # build a unit from it. Reserving placeholder slots here would
+            # turn the budget into <unit>/</unit> pad embeddings inside the KV
+            # and corrupt the model's listen/speak decision (see
+            # MiniCPMO45DuplexPolicy framing note). Reserve zero tokens; the
+            # worker reports the failed append and nothing enters the KV.
+            token_budget = 0
+        else:
+            # One first unit is <unit> + 10 audio embeddings (11 tokens);
+            # every further unit adds </unit> + <unit> + 10 (12 tokens).
             token_budget = (
                 context_reserve + first_units * 12 - 1 + _duplex_frame_count(payload) * _DUPLEX_VISION_TOKENS_PER_FRAME
             )

--- a/vllm_omni/experimental/fullduplex/minicpmo45/stage0.py
+++ b/vllm_omni/experimental/fullduplex/minicpmo45/stage0.py
@@ -222,7 +222,28 @@ class MiniCPMO45Stage0DuplexRuntime:
             audio_embeds = self._stage_audio_embeddings(batch_feature, state=state)
             if audio_embeds is None:
                 if units_built == 0:
-                    return self._stage_prefill_result(False, start_time, "streaming audio embedding returned empty")
+                    # The encoder emitted no stable frames for this chunk (the
+                    # first streaming window needs more samples than the buffer
+                    # holds, or the tail residual is shorter than one unit).
+                    # Consume the attempted chunk and keep looping instead of
+                    # returning early: an early return leaves the consumed-but-
+                    # unadvanced cursor in the next append, and the scheduler's
+                    # placeholder <unit> slots then fall into the KV and pin the
+                    # model's listen/speak decision (see policy.py note). Keep
+                    # audio_chunk_idx unchanged: no unit was built, so the next
+                    # successful emit is still the first unit (no </unit>
+                    # closure, first-chunk consumption).
+                    consumed_samples = self._consumed_audio_samples(
+                        state.audio_chunk_idx,
+                        chunk_size,
+                        processor=processor,
+                    )
+                    if consumed_samples <= 0:
+                        # Degenerate guard: never spin on a zero-advance chunk.
+                        break
+                    state.audio_buffer = state.audio_buffer[min(consumed_samples, len(state.audio_buffer)) :]
+                    chunk_size = self._streaming_chunk_size(processor)
+                    continue
                 break
             consumed_samples = self._consumed_audio_samples(
                 state.audio_chunk_idx,
@@ -272,6 +293,13 @@ class MiniCPMO45Stage0DuplexRuntime:
                 start_time,
                 f"{len(frame_blocks)} video frame(s) left without a matching audio unit",
             )
+        if units_built == 0:
+            # The encoder produced no unit for this append (e.g. the serving
+            # layer emitted a short first window that cannot complete one
+            # 1035 ms unit, or a tail residual below one chunk). Report a
+            # failed append; the scheduler's zero-budget planning keeps the
+            # placeholder tokens out of the KV.
+            return self._stage_prefill_result(False, start_time, "no model unit built for this append")
         # Match official streaming_prefill: per chunk feed ONLY <unit>+audio. The assistant
         # turn is opened once at session init; re-emitting the turn-open prefix per chunk
         # re-opened the turn each chunk -> degenerate repetition. tts_bos/listen/turn_eos are

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py
@@ -381,8 +381,15 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
         update_result = dict(result)
         update_result.pop("inputs_embeds", None)
         if result.get("success") is not True:
-            embeds = input_embeds if input_embeds is not None else self.get_input_embeddings(input_ids)
-            return input_ids, embeds, {"duplex": update_result}
+            # A failed append must not feed the scheduler's placeholder
+            # <unit>/</unit> embeddings into the KV. Returning the span as-is
+            # lets the reserved placeholder slots embed through the runner and
+            # land in the KV, measurably corrupting the model's listen/speak
+            # decision (see MiniCPMO45DuplexPolicy framing note). Return an
+            # empty span so the runner's overlay copies nothing and the
+            # request simply does not advance this step.
+            empty = input_ids.new_empty(0)
+            return empty, empty, {"duplex": update_result}
 
         target_dtype = (
             input_embeds.dtype if input_embeds is not None else self.get_input_embeddings(input_ids[:1]).dtype


### PR DESCRIPTION
## Purpose

Fix vllm-project/vllm-omni#6143 (MiniCPM-o 4.5 native duplex never speaks on NPU).

Root cause: the duplex scheduler pre-builds `[<unit>]*budget` placeholder tokens per append. When a Stage0 append cannot produce a model unit (the first streaming window is shorter than one 1035ms unit, `stable=101 < required=102`, or the tail residual is below one chunk), the placeholder `<unit>`/`</unit>` embeddings fall through into the KV. They measurably corrupt the model's listen/speak decision (see the framing note in `MiniCPMO45DuplexPolicy`), pinning argmax to `<|listen|>` forever. The model itself is healthy: with a clean context on NPU it produces `<|speak|>` at unit 6 with p=0.766 (probe-verified).

## What broke

- Scheduler token budgets must match the worker-built embeddings exactly; surplus slots become pad embeddings inside the KV and corrupt the model's listen/speak behavior.
- A first append that cannot build a unit still reserved `context_reserve` placeholder tokens, and a failed prefill returned the scheduler's placeholder `input_ids`/embeds back to the runner.

## Repro

- Start a native duplex session on NPU (vllm-ascend), send ~5.5s of audio, then silence. The model never emits `<|speak|>`; every unit decision is `<|listen|>`.
- Probe evidence: any injected `<unit>`/`</unit>` pollution before the decision position flips `unit6 speak 76.6%` to `listen 76.5%` (argmax inversion). Clean context speaks correctly.

## Root cause

`vllm_omni/experimental/fullduplex/minicpmo45/`:
- `stage0.py::_stage_prefill_embeddings_only`: on an empty encoder emit it returned early without consuming the attempted chunk, so the consumed-but-unadvanced cursor made the next append re-process the chunk and left placeholder slots unresolved.
- `stage0.py`: an append that built zero units still reported success, leaving the scheduler's placeholders live.
- `runtime.py::build_duplex_data_plane_prompt`: a first append with no buildable unit still reserved `context_reserve` placeholder tokens.
- `minicpmo_4_5_omni.py::preprocess`: a failed append returned the scheduler's placeholder `input_ids`/embeds, which the runner embedded into the KV.

## Fix

All changes are confined to the experimental native-duplex path; no weights, APM, mel extraction, samplers, or CUDA/NPU kernels are touched.

1. `stage0.py::_stage_prefill_embeddings_only`: on an empty encoder emit, consume the attempted chunk and continue looping (with a zero-advance guard), so the next append builds the first unit in the same call and no failed-append placeholder survives.
2. `stage0.py`: return a failed result when an append builds no model unit.
3. `runtime.py::build_duplex_data_plane_prompt`: reserve zero tokens for a first append that cannot produce a unit (`first_units is None`).
4. `minicpmo_4_5_omni.py::preprocess`: return a zero-length span for a failed append so the runner copies nothing into the KV.

## Test Plan

**vLLM Version:** vllm 0.1.dev (aligned with vllm-omni main)

**vLLM-Omni Commit:** `963710a9` on `fix/duplex-token-budget-pollution`

- [ ] Unit: extend `tests/worker/test_native_duplex_hooks.py` - assert failed-append buffer consumption, zero-length span on failed prefill, zero budget for first append without units. (Local env lacks the vllm test dependency; covered as follow-up CI work.)
- [x] NPU E2E (primary): duplex serve on Ascend 910C, send ~5.5s audio + silence - PASSED, see Test Result below.
- [ ] CUDA E2E: no regression on the existing duplex single-session test. (CI covers the CUDA path.)

## Test Result

**NPU E2E PASSED** (Ascend 910C single chip, bf16, official duplex yaml, fix applied):

```
[client] session.created
[client] session.updated
[client] sent 5469ms audio, committed
[   3.94] LISTEN reason=model_listen model_listen=True   (x5, while user is speaking)
[   6.49] response.created + response.speak               <- model speaks
[   6.49] audio.delta 5120 bytes                          (full audio response ~10s)
[  16.26] response.done
[client] done. total listens=5 events=48
```

Before the fix (issue #6143): model never speaks, session ends with `events=3` and zero `audio.delta`. After the fix: the model correctly listens for 5 units while the user speaks, then emits `<|speak|>` at unit 6 and produces a complete audio response. This matches the probe prediction (clean context speaks at unit 6 with p=0.766 on NPU).

- Syntax check: PASS (py_compile on all 3 modified files).
- CI: build (3.11/3.12), pre-commit, DCO all green; mergeable.

(anything written below this line will be removed by GitHub Actions)
