### PR TITLE
[Docs] Unify recipe serve commands on `vllm serve --omni`

### DIFF
--- a/recipes/BosonAI/Higgs-Audio-V3-TTS.md
+++ b/recipes/BosonAI/Higgs-Audio-V3-TTS.md
@@ -45,7 +45,7 @@ MusicGen-style delay pattern).
 **Online serving:**
 
 ```bash
-vllm-omni serve bosonai/higgs-audio-v3-tts-4b \
+vllm serve bosonai/higgs-audio-v3-tts-4b \
     --host 0.0.0.0 --port 8095 \
     --trust-remote-code --omni
 ```

--- a/recipes/NVIDIA/Nemotron-Labs-Audex.md
+++ b/recipes/NVIDIA/Nemotron-Labs-Audex.md
@@ -51,7 +51,7 @@ NemotronH (~3B active parameters). Pick the pipeline by task:
 `model_type` auto-resolves `audex_tts.yaml`):
 
 ```bash
-vllm-omni serve nvidia/Nemotron-Labs-Audex-2B \
+vllm serve nvidia/Nemotron-Labs-Audex-2B \
     --host 0.0.0.0 --port 8097 \
     --trust-remote-code --omni
 # other modes: add --stage-configs-path vllm_omni/deploy/audex_{tta,thinker_only,s2s}.yaml
@@ -109,7 +109,7 @@ The 30B REQUIRES its explicit deploy yaml (the shared HF `model_type`
 auto-resolves to the 2B-tuned config otherwise):
 
 ```bash
-vllm-omni serve nvidia/Nemotron-Labs-Audex-30B-A3B \
+vllm serve nvidia/Nemotron-Labs-Audex-30B-A3B \
     --host 0.0.0.0 --port 8097 \
     --trust-remote-code --omni \
     --stage-configs-path vllm_omni/deploy/audex_tts_30b.yaml

--- a/recipes/StabilityAI/Stable-Audio-Open.md
+++ b/recipes/StabilityAI/Stable-Audio-Open.md
@@ -78,7 +78,7 @@ python examples/offline_inference/text_to_audio/text_to_audio.py \
 Start the online serving endpoint:
 
 ```bash
-vllm-omni serve /path/to/stable-audio-open-1.0 \
+vllm serve /path/to/stable-audio-open-1.0 \
   --host 0.0.0.0 \
   --port 8091 \
   --gpu-memory-utilization 0.9 \

--- a/recipes/TEMPLATE.md
+++ b/recipes/TEMPLATE.md
@@ -39,6 +39,9 @@ platform section, document one or more tested hardware configurations.
 
 #### Command
 
+Serve commands use `vllm serve <model> --omni`. The `--omni` flag is what
+selects the Omni pipeline, so it is required and cannot be dropped.
+
 ```bash
 # Add the exact command(s) here
 ```

--- a/recipes/inclusionAI/Ming-omni-tts.md
+++ b/recipes/inclusionAI/Ming-omni-tts.md
@@ -39,7 +39,7 @@ Other hardware is welcome as community validation lands.
 Launch the two-stage talker:
 
 ```bash
-vllm-omni serve inclusionAI/Ming-omni-tts-0.5B \
+vllm serve inclusionAI/Ming-omni-tts-0.5B \
     --deploy-config vllm_omni/deploy/ming_tts.yaml \
     --omni \
     --port 8091 \

--- a/recipes/zai-org/GLM-TTS.md
+++ b/recipes/zai-org/GLM-TTS.md
@@ -44,20 +44,20 @@ conditioned on reference audio and its transcript.
 Start the server from the repository root:
 
 ```bash
-vllm-omni serve zai-org/GLM-TTS --omni --trust-remote-code --port 8091
+vllm serve zai-org/GLM-TTS --omni --trust-remote-code --port 8091
 ```
 
 Async chunking is enabled by default in the bundled deployment config. For
 the sync (non-streaming) path:
 
 ```bash
-vllm-omni serve zai-org/GLM-TTS --omni --trust-remote-code --port 8091 --no-async-chunk
+vllm serve zai-org/GLM-TTS --omni --trust-remote-code --port 8091 --no-async-chunk
 ```
 
 Use a custom deploy config for advanced cases:
 
 ```bash
-vllm-omni serve zai-org/GLM-TTS --omni --trust-remote-code --port 8091 \
+vllm serve zai-org/GLM-TTS --omni --trust-remote-code --port 8091 \
   --deploy-config /path/to/your_glm_tts_overrides.yaml
 ```
 


### PR DESCRIPTION
## Purpose

The recipes were split between two forms of the same command:

- `vllm serve <model> --omni`
- `vllm-omni serve <model> --omni`

Both work, so nothing was broken, but the inconsistency is visible on
recipes.vllm.ai and prompted a maintainer to ask whether one of the cards was a
typo. This standardizes `recipes/` on `vllm serve ... --omni`, which matches
`docs/getting_started/quickstart.md`, `docs/cli/serve.md`, and the majority of
the tree.

## Why the two forms are equivalent

Dispatch keys on the `--omni` flag, never on the binary name:

- Upstream vLLM `vllm/entrypoints/cli/main.py` delegates to
  `vllm_omni.entrypoints.cli.main` when `--omni` is in `sys.argv`.
- `vllm_omni/entrypoints/cli/main.py` does the inverse: without `--omni` in
  `sys.argv` it falls through to stock `vllm.entrypoints.cli.main`.

So `--omni` is required in both forms, and `vllm-omni serve <model>` **without**
`--omni` silently starts a non-Omni server.

One caveat worth recording: that delegation landed in vLLM **0.20.0**. Checking
the upstream tags, it is absent in 0.14.1 through 0.19.0 and present from 0.20.0
onward. Every recipe touched here targets a newer vLLM, so the rewrite is safe.

## Changes

| File | Commands |
|---|---|
| `recipes/BosonAI/Higgs-Audio-V3-TTS.md` | 1 |
| `recipes/NVIDIA/Nemotron-Labs-Audex.md` | 2 |
| `recipes/StabilityAI/Stable-Audio-Open.md` | 1 |
| `recipes/inclusionAI/Ming-omni-tts.md` | 1 |
| `recipes/zai-org/GLM-TTS.md` | 3 |

All eight already carried `--omni`, so this is a rename with no behavior change.

`recipes/TEMPLATE.md` now records the convention, including that `--omni` is
required, so new recipes do not drift back.

## Not changed

`recipes/JD/JoyAI-VL-Interaction.md` intentionally uses stock `vllm serve` with
no `--omni` (the VL backend is served by plain vLLM), so it is left alone.

`docs/` still mixes the two forms in roughly 48 places. That is a larger sweep
and is deliberately out of scope here; happy to follow up if wanted.

## Test plan

Docs only, no code paths touched. Verified by:

- Every `vllm serve` command under `recipes/` still carries `--omni` after the
  change, checked by script across all continuation lines; the only hits without
  it are the intentional JoyAI ones and prose references.
- No `vllm-omni serve` occurrences remain under `recipes/` (all file types).
- `pre-commit run --files` on the changed files: passed.
