### PR TITLE
[diffusion][bugfix][ROCm] Keep Hunyuan Image 3.0 GroupNorm on PyTorch

### DIFF
--- a/tests/platforms/test_rocm_groupnorm_patch.py
+++ b/tests/platforms/test_rocm_groupnorm_patch.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch.nn as nn
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+_PATCH_PATH = Path(__file__).parents[2] / "vllm_omni" / "platforms" / "rocm" / "patch" / "worker" / "patch_groupnorm.py"
+_SPEC = importlib.util.spec_from_file_location("test_patch_groupnorm", _PATCH_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+patch_groupnorm = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = patch_groupnorm
+_SPEC.loader.exec_module(patch_groupnorm)
+patch_groupnorm._registry_mod.initialize_model = patch_groupnorm._original_initialize_model
+
+
+def test_hunyuan_image3_keeps_pytorch_groupnorm(monkeypatch):
+    model = types.SimpleNamespace(vae=nn.Sequential(nn.GroupNorm(4, 8)))
+    monkeypatch.setattr(patch_groupnorm, "_original_initialize_model", lambda _: model)
+    monkeypatch.setattr(
+        patch_groupnorm,
+        "_replace_groupnorm_with_aiter",
+        lambda _: pytest.fail("Hunyuan Image 3.0 must keep PyTorch GroupNorm"),
+    )
+
+    od_config = types.SimpleNamespace(model_class_name="HunyuanImage3ForCausalMM")
+    assert patch_groupnorm._patched_initialize_model(od_config) is model
+    assert type(model.vae[0]) is nn.GroupNorm

--- a/vllm_omni/platforms/rocm/patch/worker/patch_groupnorm.py
+++ b/vllm_omni/platforms/rocm/patch/worker/patch_groupnorm.py
@@ -42,6 +42,13 @@ def _patched_initialize_model(od_config):
     model = _original_initialize_model(od_config)
 
     if hasattr(model, "vae"):
+        # AITER GroupNorm does not preserve the PyTorch autocast behavior required
+        # by Hunyuan Image 3.0. Keep PyTorch GroupNorm until the fix is released:
+        # https://github.com/ROCm/aiter/issues/4780
+        # https://github.com/ROCm/aiter/pull/4779
+        if od_config.model_class_name == "HunyuanImage3ForCausalMM":
+            return model
+
         try:
             from vllm._aiter_ops import is_aiter_found_and_supported
 


### PR DESCRIPTION
Fixes #6223.

## Purpose

### What broke

Hunyuan Image 3.0 gets wrong VAE output on ROCm when vLLM-Omni replaces its PyTorch GroupNorm layers with AITER GroupNorm layers.

The first VAE GroupNorm gets an FP16 input and BF16 weight and bias while autocast is on. PyTorch returns FP32 output for this call. AITER returns FP16 output with a mean error of `1.0778` and a maximum error of `6.1785` against PyTorch.

### How to reproduce

```bash
HIP_VISIBLE_DEVICES=0,1,2,3 \
VLLM_ROCM_USE_AITER=1 \
python examples/offline_inference/hunyuan_image3/end2end.py \
  --model tencent/HunyuanImage-3.0-Instruct \
  --modality text2img \
  --deploy-config vllm_omni/deploy/hunyuan_image3_dit.yaml \
  --prompts "A brown and white dog is running on the grass." \
  --steps 1 \
  --guidance-scale 2.5 \
  --seed 42 \
  --height 1024 \
  --width 1024 \
  --bot-task none \
  --sys-type en_unified \
  --init-timeout 900 \
  --enforce-eager
```

### Root cause

PyTorch runs GroupNorm in FP32 when autocast is on. The AITER GroupNorm module calls its custom operator directly, so it does not apply the PyTorch autocast rule.

AITER chooses the kernel type from the input type. With an FP16 input, it runs the FP16 kernel and reads the BF16 weight and bias as FP16. The saved Hunyuan tensors produced the same wrong values when we read the BF16 bits as FP16.


### Fix

Keep the original PyTorch GroupNorm layers for `HunyuanImage3ForCausalMM` until vLLM-Omni uses an AITER release with the fix.

Other VAE models keep the current AITER GroupNorm path. This PR does not change how `VLLM_ROCM_USE_AITER` controls those models.

## Test Plan

**vLLM Version:** `0.26.0+rocm723`

**vLLM-Omni Commit:** `077fc6895`

```bash
pytest -q tests/platforms/test_rocm_groupnorm_patch.py --run-level core_model

```



## Test Result

```text
Local: 1 passed

```

The full Hunyuan generation test was not repeated on this branch. Issue #6223 contains the full diagnosis and exact tensor comparison from the failing run.
