### PR TITLE
[Bugfix] Sync TeaCache skip decision across SP to prevent deadlock

### DIFF
--- a/vllm_omni/diffusion/cache/teacache/hook.py
+++ b/vllm_omni/diffusion/cache/teacache/hook.py
@@ -23,8 +23,31 @@ from vllm_omni.diffusion.cache.teacache.state import TeaCacheState
 from vllm_omni.diffusion.distributed.parallel_state import (
     get_classifier_free_guidance_rank,
     get_classifier_free_guidance_world_size,
+    get_sp_group,
+    model_parallel_is_initialized,
 )
 from vllm_omni.diffusion.hooks import HookRegistry, ModelHook, StateManager
+
+
+def _average_l1_stats_across_sp(mean_diff: torch.Tensor, mean_prev: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Average TeaCache L1 stats across sequence-parallel ranks.
+
+    Skip vs compute must be identical on every rank that participates in
+    transformer SP collectives. Sequence shards otherwise produce different
+    local means and deadlock. TP is not included: the residual TeaCache reads
+    is replicated across TP ranks. CFG/DP ranks are also excluded: they do
+    not share those collectives.
+    """
+    if not model_parallel_is_initialized():
+        return mean_diff, mean_prev
+
+    sp_group = get_sp_group()
+    if sp_group.world_size <= 1:
+        return mean_diff, mean_prev
+
+    stats = torch.stack((mean_diff.detach(), mean_prev.detach()))
+    stats = sp_group.all_reduce(stats) / sp_group.world_size
+    return stats[0], stats[1]
 
 
 class TeaCacheHook(ModelHook):
@@ -196,6 +219,7 @@ class TeaCacheHook(ModelHook):
         1. Always compute first timestep
         2. For intermediate steps:
            - Compute relative L1 distance between current and previous modulated inputs
+           - Average that distance across SP so all ranks share the skip decision
            - Apply polynomial rescaling with model-specific coefficients
            - Accumulate rescaled distances
            - Compare to threshold: below = cache, above = compute
@@ -216,15 +240,14 @@ class TeaCacheHook(ModelHook):
         if state.previous_modulated_input is None:
             return True
 
-        # Compute relative L1 distance between consecutive modulated inputs
-        rel_distance = (
-            (
-                (modulated_inp - state.previous_modulated_input).abs().mean()
-                / (state.previous_modulated_input.abs().mean() + 1e-8)
-            )
-            .cpu()
-            .item()
-        )
+        # Compute relative L1 distance between consecutive modulated inputs.
+        # Reduce across SP before the threshold so every rank takes the same
+        # skip/compute path (otherwise a cache hit on one rank deadlocks
+        # waiting on collectives the miss path never enters).
+        mean_diff = (modulated_inp - state.previous_modulated_input).abs().mean()
+        mean_prev = state.previous_modulated_input.abs().mean()
+        mean_diff, mean_prev = _average_l1_stats_across_sp(mean_diff, mean_prev)
+        rel_distance = (mean_diff / (mean_prev + 1e-8)).item()
 
         # Apply model-specific polynomial rescaling
         rescaled_distance = float(self.rescale_func(rel_distance))


### PR DESCRIPTION
## Purpose

Fix TeaCache + sequence parallelism deadlock https://github.com/vllm-project/vllm-omni/issues/6180. Repro in issue.

Average the L1 stats across the SP group before the threshold so every rank takes the same skip/compute path. TP is not included: the residual TeaCache reads is already replicated. CFG/DP ranks are also excluded.


## Test Plan

**vLLM Version:** 0.27.0

**vLLM-Omni Commit:** 9798bc3a8d5a400b97fba7402f42510577e7302d

Longcat repro script: https://gist.github.com/yzong-rh/b9deacd8178fc0a1295c6382c2f8b059

## Test Result

Repro no longer deadlocks.


LongCat with teacache but no SP:

<img width="4096" height="3072" alt="teacache" src="https://github.com/user-attachments/assets/da5ca5b5-03f0-47ca-b8b7-ffc3df6e6e0d" />

```
=== Summary (measured runs) ===
Mean latency:         14.83s
Median latency:       14.84s
Stddev:               0.07s
Min latency:          14.73s
Max latency:          14.91s
```

LongCat with teacache and SP=2:

<img width="4096" height="3072" alt="teacache_sp2" src="https://github.com/user-attachments/assets/eec8382f-edd1-4283-bf90-42f5a0b88544" />

```
=== Summary (measured runs) ===
Mean latency:         10.62s
Median latency:       10.59s
Stddev:               0.06s
Min latency:          10.57s
Max latency:          10.75s
```

cc @alex-jw-brooks 
