### PR TITLE
[Model] Add LTX-2.5 Duration Head support

### DIFF
--- a/recipes/LTX/LTX-2.5.md
+++ b/recipes/LTX/LTX-2.5.md
@@ -117,6 +117,28 @@ python examples/offline_inference/image_to_video/image_to_video.py \
 
 LTX-2.5 uses the official CRF-18 first-frame conditioning path by default.
 
+## Automatic duration
+
+LTX-2.5 can predict the natural shot length from the prompt. To enable the
+Duration Head for offline T2V or I2V, remove `--num-frames` and add:
+
+```bash
+--extra-body '{"auto_duration":true}'
+```
+
+The default range is 1 to 20 seconds. Override it with
+`min_seconds` and `max_seconds`, for example:
+
+```bash
+--extra-body '{"auto_duration":true,"min_seconds":2,"max_seconds":12}'
+```
+
+For online requests, pass the same object through the `extra_params` form
+field. Duration prediction accepts one prompt per request, reuses the connector
+conditioning used by denoising, and snaps the result to the VAE's `8k+1`
+frame grid. Without `auto_duration`, the selected pipeline keeps its fixed
+frame-count default.
+
 ## Online serving
 
 Start one server for the selected pipeline:

--- a/tests/diffusion/models/ltx2/test_ltx25_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx25_pipeline.py
@@ -187,7 +187,7 @@ def test_ltx25_missing_gemma4_recommends_supported_transformers_range(monkeypatc
 
 def test_ltx_converted_component_loading_propagates_revision(monkeypatch):
     revision = "pinned-revision"
-    calls = {"components": []}
+    calls = {"components": [], "component_configs": []}
     profile = replace(
         LTX25_DISTILLED_COMPONENT_PROFILE,
         text_encoder_cls=object,
@@ -228,13 +228,22 @@ def test_ltx_converted_component_loading_propagates_revision(monkeypatch):
         return object()
 
     def fake_transformer_config(model, subfolder, local_files_only, *, revision):
-        calls["transformer_config"] = (model, subfolder, local_files_only, revision)
+        calls["component_configs"].append((model, subfolder, local_files_only, revision))
+        if subfolder == "duration_head":
+            return {
+                "video_cross_attention_dim": 12,
+                "audio_cross_attention_dim": 8,
+                "pooler_hidden_dim": 16,
+                "num_queries": 1,
+                "num_pooler_heads": 4,
+                "mlp_hidden_dim": 10,
+            }
         return {"component": "transformer"}
 
     monkeypatch.setattr(ltx2_components, "prefetch_subfolders", fake_prefetch)
     monkeypatch.setattr(ltx2_components.AutoTokenizer, "from_pretrained", fake_tokenizer)
     monkeypatch.setattr(ltx2_components, "_load_component", fake_component)
-    monkeypatch.setattr(ltx2_components, "load_transformer_config", fake_transformer_config)
+    monkeypatch.setattr(ltx2_components, "load_component_config", fake_transformer_config)
     monkeypatch.setattr(
         ltx2_components,
         "create_transformer_from_config",
@@ -250,6 +259,8 @@ def test_ltx_converted_component_loading_propagates_revision(monkeypatch):
     ltx2_components.initialize_pipeline_components(pipeline, od_config)
 
     assert pipeline.weights_sources[0].revision == revision
+    assert pipeline.weights_sources[1].prefix == "duration_head."
+    assert pipeline.weights_sources[1].revision == revision
     assert calls["prefetch"][2]["revision"] == revision
     assert calls["tokenizer"][1]["revision"] == revision
     assert {call[2] for call in calls["components"]} == {
@@ -261,12 +272,11 @@ def test_ltx_converted_component_loading_propagates_revision(monkeypatch):
         "latent_upsampler",
     }
     assert all(call[3]["revision"] == revision for call in calls["components"])
-    assert calls["transformer_config"] == (
-        od_config.model,
-        profile.transformer_subfolder,
-        False,
-        revision,
-    )
+    assert calls["component_configs"] == [
+        (od_config.model, "duration_head", False, revision),
+        (od_config.model, profile.transformer_subfolder, False, revision),
+    ]
+    assert pipeline.duration_head.video_input_proj.in_features == 12
     assert calls["scheduler"][1]["revision"] == revision
 
 
@@ -404,6 +414,13 @@ def test_ltx25_four_public_pipeline_semantics_are_disjoint():
     assert resolve_ltx_pipeline_recipe("distilled_one_stage", "2.5") is LTX25_DISTILLED_ONE_STAGE_RECIPE
     assert resolve_ltx_component_profile("distilled_two_stage", "2.5") is LTX25_DISTILLED_COMPONENT_PROFILE
     assert resolve_ltx_pipeline_recipe("distilled_two_stage", "2.5") is LTX25_DISTILLED_TWO_STAGE_RECIPE
+    for profile in (
+        LTX25_FULL_COMPONENT_PROFILE,
+        LTX25_TWO_STAGE_COMPONENT_PROFILE,
+        LTX25_DISTILLED_ONE_STAGE_COMPONENT_PROFILE,
+        LTX25_DISTILLED_COMPONENT_PROFILE,
+    ):
+        assert "duration_head" in profile.resident_modules
 
     assert LTX2Pipeline.pipeline_kind == "one_stage"
     assert LTX2TwoStagePipeline.pipeline_kind == "two_stage"
@@ -815,6 +832,144 @@ class TestLTXRequestParsing:
 
         with pytest.raises(ValueError, match="image_crf"):
             _resolve_request_inputs_for_test(_make_ltx_request_pipe(LTX2Pipeline), req)
+
+    def test_request_resolves_auto_duration_bounds(self):
+        from vllm_omni.diffusion.request import OmniDiffusionRequest
+        from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+        from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+        req = DiffusionRequestBatch(
+            [
+                OmniDiffusionRequest(
+                    prompt="prompt",
+                    sampling_params=OmniDiffusionSamplingParams(
+                        extra_args={"auto_duration": True, "min_seconds": 2.0, "max_seconds": 12.5}
+                    ),
+                    request_id="ltx-auto-duration",
+                )
+            ]
+        )
+
+        inputs = _resolve_request_inputs_for_test(_make_ltx_request_pipe(LTX2Pipeline), req)
+
+        assert inputs.auto_duration
+        assert inputs.min_seconds == 2.0
+        assert inputs.max_seconds == 12.5
+
+    @pytest.mark.parametrize(
+        ("extra_args", "match"),
+        [
+            ({"auto_duration": "yes"}, "auto_duration"),
+            ({"min_seconds": 0}, "min_seconds"),
+            ({"max_seconds": float("inf")}, "max_seconds"),
+            ({"min_seconds": 4.0, "max_seconds": 4.0}, "min_seconds"),
+        ],
+    )
+    def test_request_rejects_invalid_auto_duration_options(self, extra_args, match):
+        from vllm_omni.diffusion.request import OmniDiffusionRequest
+        from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+        from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+        req = DiffusionRequestBatch(
+            [
+                OmniDiffusionRequest(
+                    prompt="prompt",
+                    sampling_params=OmniDiffusionSamplingParams(extra_args=extra_args),
+                    request_id="ltx-invalid-auto-duration",
+                )
+            ]
+        )
+
+        with pytest.raises(ValueError, match=match):
+            _resolve_request_inputs_for_test(_make_ltx_request_pipe(LTX2Pipeline), req)
+
+
+def test_ltx25_auto_duration_reuses_positive_connector_context():
+    request_inputs = LTXRequestInputs(
+        prompt=["prompt"],
+        negative_prompt=[""],
+        height=544,
+        width=960,
+        num_frames=121,
+        frame_rate=24.0,
+        num_inference_steps=30,
+        guidance=LTX25_FULL_RECIPE.request_guidance,
+        num_videos_per_prompt=1,
+        generator=None,
+        latents=None,
+        audio_latents=None,
+        prompt_embeds=None,
+        negative_prompt_embeds=None,
+        prompt_attention_mask=None,
+        negative_prompt_attention_mask=None,
+        decode_timestep=0.0,
+        decode_noise_scale=None,
+        output_type="np",
+        max_sequence_length=32,
+        auto_duration=True,
+        min_seconds=2.0,
+        max_seconds=10.0,
+    )
+    prompt_context = SimpleNamespace(
+        positive_connector_prompt_embeds=torch.randn(1, 4, 12),
+        positive_connector_audio_prompt_embeds=torch.randn(1, 5, 8),
+    )
+    calls = {}
+
+    class FakeDurationHead:
+        def predict_num_frames(self, video_tokens, audio_tokens, **kwargs):
+            calls["video_tokens"] = video_tokens
+            calls["audio_tokens"] = audio_tokens
+            calls["kwargs"] = kwargs
+            return 97
+
+    pipe = _make_ltx_request_pipe(LTX2Pipeline)
+    pipe.duration_head = FakeDurationHead()
+    object.__setattr__(pipe, "_prepare_prompt_context", lambda **_kwargs: prompt_context)
+
+    resolved, resolved_context = LTXRuntime._predict_duration(pipe, request_inputs)
+
+    assert resolved.num_frames == 97
+    assert resolved_context is prompt_context
+    torch.testing.assert_close(calls["video_tokens"], prompt_context.positive_connector_prompt_embeds)
+    torch.testing.assert_close(calls["audio_tokens"], prompt_context.positive_connector_audio_prompt_embeds)
+    assert calls["kwargs"] == {
+        "frame_rate": 24.0,
+        "temporal_compression_ratio": 8,
+        "min_seconds": 2.0,
+        "max_seconds": 10.0,
+    }
+
+
+def test_ltx25_auto_duration_rejects_multiple_prompts():
+    request_inputs = LTXRequestInputs(
+        prompt=["first", "second"],
+        negative_prompt=["", ""],
+        height=544,
+        width=960,
+        num_frames=121,
+        frame_rate=24.0,
+        num_inference_steps=30,
+        guidance=LTX25_FULL_RECIPE.request_guidance,
+        num_videos_per_prompt=1,
+        generator=None,
+        latents=None,
+        audio_latents=None,
+        prompt_embeds=None,
+        negative_prompt_embeds=None,
+        prompt_attention_mask=None,
+        negative_prompt_attention_mask=None,
+        decode_timestep=0.0,
+        decode_noise_scale=None,
+        output_type="np",
+        max_sequence_length=32,
+        auto_duration=True,
+    )
+    pipe = _make_ltx_request_pipe(LTX2Pipeline)
+    pipe.duration_head = SimpleNamespace()
+
+    with pytest.raises(ValueError, match="one prompt"):
+        LTXRuntime._predict_duration(pipe, request_inputs)
 
 
 class TestLTXForwardStages:

--- a/tests/diffusion/models/ltx2/test_ltx2_duration_head.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_duration_head.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.models.ltx2.ltx2_duration_head import LTX2DurationHead
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _tiny_duration_head() -> LTX2DurationHead:
+    return LTX2DurationHead(
+        video_cross_attention_dim=12,
+        audio_cross_attention_dim=8,
+        pooler_hidden_dim=16,
+        num_queries=1,
+        num_pooler_heads=4,
+        mlp_hidden_dim=10,
+    )
+
+
+def test_duration_head_accepts_video_and_audio_connector_tokens():
+    head = _tiny_duration_head()
+
+    duration = head(torch.randn(2, 5, 12), torch.randn(2, 7, 8))
+
+    assert duration.shape == (2,)
+    assert torch.all(duration > 0)
+
+
+def test_duration_head_requires_at_least_one_modality():
+    with pytest.raises(ValueError, match="video_tokens and/or audio_tokens"):
+        _tiny_duration_head()()
+
+
+def test_duration_head_state_dict_matches_converted_checkpoint_names():
+    names = set(_tiny_duration_head().state_dict())
+
+    assert {
+        "video_input_proj.weight",
+        "audio_input_proj.weight",
+        "attention_pooler.query_tokens",
+        "attention_pooler.to_q.weight",
+        "attention_pooler.to_k.weight",
+        "attention_pooler.to_v.weight",
+        "attention_pooler.to_out.weight",
+        "mlp_hidden.weight",
+        "mlp_out.weight",
+    } <= names
+
+
+@pytest.mark.parametrize(
+    ("seconds", "expected_frames"),
+    [
+        (5.2, 121),
+        (0.1, 25),
+        (30.0, 473),
+    ],
+)
+def test_predict_num_frames_clamps_and_snaps_to_vae_grid(monkeypatch, seconds, expected_frames):
+    head = _tiny_duration_head()
+    monkeypatch.setattr(head, "forward", lambda *_args, **_kwargs: torch.tensor([seconds]))
+
+    frames = head.predict_num_frames(
+        torch.empty(1, 1, 12),
+        frame_rate=24.0,
+        temporal_compression_ratio=8,
+    )
+
+    assert frames == expected_frames
+    assert (frames - 1) % 8 == 0
+
+
+def test_predict_num_frames_rejects_multiple_prompts(monkeypatch):
+    head = _tiny_duration_head()
+    monkeypatch.setattr(head, "forward", lambda *_args, **_kwargs: torch.tensor([2.0, 3.0]))
+
+    with pytest.raises(ValueError, match="one prompt"):
+        head.predict_num_frames(
+            torch.empty(2, 1, 12),
+            frame_rate=24.0,
+            temporal_compression_ratio=8,
+        )

--- a/tests/model_extras/test_model_extras.py
+++ b/tests/model_extras/test_model_extras.py
@@ -235,6 +235,9 @@ def test_ltx_extra_registry_declares_official_guidance_params() -> None:
             "stage_1_sigmas",
             "stage_2_sigmas",
             "image_crf",
+            "auto_duration",
+            "min_seconds",
+            "max_seconds",
         }
     )
 

--- a/vllm_omni/diffusion/models/ltx2/ltx2_components.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_components.py
@@ -35,6 +35,7 @@ from vllm_omni.diffusion.offloader.module_collector import ModuleDiscovery
 if TYPE_CHECKING:
     from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
 
+from .ltx2_duration_head import LTX2DurationHead
 from .ltx2_request import LTXCheckpointKind, validate_ltx_checkpoint
 from .ltx2_transformer import (
     LTX2VideoTransformer3DModel,
@@ -66,6 +67,7 @@ _LTX_COMPONENT_SUBFOLDERS = (
     "vocoder",
     "scheduler",
     "latent_upsampler",
+    "duration_head",
 )
 logger = logging.getLogger(__name__)
 
@@ -117,7 +119,7 @@ LTX25_FULL_COMPONENT_PROFILE = LTXComponentProfile(
     dit_modules=("transformer",),
     encoder_modules=("text_encoder", "connectors"),
     vae_modules=("vae", "audio_vae"),
-    resident_modules=("vocoder",),
+    resident_modules=("vocoder", "duration_head"),
     video_vae_cls=DistributedAutoencoderKLLTX2Video,
     vocoder_cls=LTX2VocoderWithBWE or LTX2Vocoder,
     vocoder_fallback_cls=LTX2Vocoder,
@@ -143,7 +145,7 @@ LTX25_DISTILLED_COMPONENT_PROFILE = LTXComponentProfile(
     dit_modules=("transformer",),
     encoder_modules=("text_encoder", "connectors"),
     vae_modules=("vae", "audio_vae"),
-    resident_modules=("vocoder", "latent_upsampler"),
+    resident_modules=("vocoder", "latent_upsampler", "duration_head"),
     video_vae_cls=DistributedAutoencoderKLLTX2Video,
     vocoder_cls=LTX2VocoderWithBWE or LTX2Vocoder,
     vocoder_fallback_cls=LTX2Vocoder,
@@ -565,6 +567,16 @@ def initialize_pipeline_components(pipeline: Any, od_config: Any) -> None:
             fall_back_to_pt=True,
         ),
     ]
+    if "duration_head" in profile.resident_modules:
+        pipeline.weights_sources.append(
+            DiffusersPipelineLoader.ComponentSource(
+                model_or_path=model,
+                subfolder="duration_head",
+                revision=revision,
+                prefix="duration_head.",
+                fall_back_to_pt=True,
+            )
+        )
     prefetch_subfolders(model, _LTX_COMPONENT_SUBFOLDERS, local_files_only=local_files_only, revision=revision)
 
     pipeline.tokenizer = AutoTokenizer.from_pretrained(
@@ -664,6 +676,19 @@ def initialize_pipeline_components(pipeline: Any, od_config: Any) -> None:
             )
             pipeline.latent_upsampler = _load_ltx_latent_upsampler_single_file(upsampler_path, dtype)
 
+    if "duration_head" in profile.resident_modules:
+        duration_head_config = load_component_config(
+            model,
+            "duration_head",
+            local_files_only,
+            revision=revision,
+        )
+        signature = inspect.signature(LTX2DurationHead.__init__)
+        duration_head_kwargs = {
+            key: value for key, value in duration_head_config.items() if key in signature.parameters
+        }
+        pipeline.duration_head = LTX2DurationHead(**duration_head_kwargs).to(dtype=dtype)
+
     transformer_config = load_transformer_config(
         model, profile.transformer_subfolder, local_files_only, revision=revision
     )
@@ -709,18 +734,18 @@ def initialize_pipeline_components(pipeline: Any, od_config: Any) -> None:
     pipeline._interrupt = False
 
 
-def load_transformer_config(
+def load_component_config(
     model_path: str,
-    subfolder: str = "transformer",
+    subfolder: str,
     local_files_only: bool = True,
     *,
     revision: str | None = None,
 ) -> dict:
-    """Load an LTX transformer config from a local model or the HF Hub."""
+    """Load an LTX component config from a local model or the HF Hub."""
     if local_files_only:
         config_path = os.path.join(model_path, subfolder, "config.json")
         if not os.path.exists(config_path):
-            raise FileNotFoundError(f"LTX transformer config not found: {config_path}")
+            raise FileNotFoundError(f"LTX component config not found: {config_path}")
     else:
         config_path = hf_hub_download(
             repo_id=model_path,
@@ -729,6 +754,17 @@ def load_transformer_config(
         )
     with open(config_path) as config_file:
         return json.load(config_file)
+
+
+def load_transformer_config(
+    model_path: str,
+    subfolder: str = "transformer",
+    local_files_only: bool = True,
+    *,
+    revision: str | None = None,
+) -> dict:
+    """Load an LTX transformer config from a local model or the HF Hub."""
+    return load_component_config(model_path, subfolder, local_files_only, revision=revision)
 
 
 def create_transformer_from_config(

--- a/vllm_omni/diffusion/models/ltx2/ltx2_duration_head.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_duration_head.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""LTX-2.5 caption-conditioned duration prediction."""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+logger = logging.getLogger(__name__)
+
+
+class LTX2DurationAttentionPooler(nn.Module):
+    """Pool connector tokens with learned cross-attention queries."""
+
+    def __init__(self, hidden_dim: int = 256, num_queries: int = 1, num_heads: int = 4) -> None:
+        super().__init__()
+        if hidden_dim % num_heads != 0:
+            raise ValueError(f"hidden_dim ({hidden_dim}) must be divisible by num_heads ({num_heads}).")
+        self.num_heads = num_heads
+        self.head_dim = hidden_dim // num_heads
+        self.query_tokens = nn.Parameter(torch.randn(num_queries, hidden_dim) * 0.02)
+        self.to_q = nn.Linear(hidden_dim, hidden_dim)
+        self.to_k = nn.Linear(hidden_dim, hidden_dim)
+        self.to_v = nn.Linear(hidden_dim, hidden_dim)
+        self.to_out = nn.Linear(hidden_dim, hidden_dim)
+
+    def forward(self, tokens: torch.Tensor) -> torch.Tensor:
+        batch_size = tokens.shape[0]
+        queries = self.query_tokens.unsqueeze(0).expand(batch_size, -1, -1)
+        query = self.to_q(queries).unflatten(2, (self.num_heads, self.head_dim)).transpose(1, 2)
+        key = self.to_k(tokens).unflatten(2, (self.num_heads, self.head_dim)).transpose(1, 2)
+        value = self.to_v(tokens).unflatten(2, (self.num_heads, self.head_dim)).transpose(1, 2)
+        hidden_states = F.scaled_dot_product_attention(query, key, value)
+        hidden_states = hidden_states.transpose(1, 2).flatten(2, 3)
+        return self.to_out(hidden_states)
+
+
+class LTX2DurationHead(nn.Module):
+    """Predict a shot duration in seconds from LTX connector outputs."""
+
+    def __init__(
+        self,
+        video_cross_attention_dim: int = 4096,
+        audio_cross_attention_dim: int = 2048,
+        pooler_hidden_dim: int = 256,
+        num_queries: int = 1,
+        num_pooler_heads: int = 4,
+        mlp_hidden_dim: int = 256,
+    ) -> None:
+        super().__init__()
+        self.video_input_proj = nn.Linear(video_cross_attention_dim, pooler_hidden_dim)
+        self.video_modality_emb = nn.Parameter(torch.randn(pooler_hidden_dim) * 0.02)
+        self.audio_input_proj = nn.Linear(audio_cross_attention_dim, pooler_hidden_dim)
+        self.audio_modality_emb = nn.Parameter(torch.randn(pooler_hidden_dim) * 0.02)
+        self.attention_pooler = LTX2DurationAttentionPooler(
+            hidden_dim=pooler_hidden_dim,
+            num_queries=num_queries,
+            num_heads=num_pooler_heads,
+        )
+        self.mlp_hidden = nn.Linear(pooler_hidden_dim * num_queries, mlp_hidden_dim)
+        self.mlp_out = nn.Linear(mlp_hidden_dim, 1)
+
+    def forward(
+        self,
+        video_tokens: torch.Tensor | None = None,
+        audio_tokens: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if video_tokens is None and audio_tokens is None:
+            raise ValueError("LTX2DurationHead requires video_tokens and/or audio_tokens.")
+
+        dtype = self.video_input_proj.weight.dtype
+        token_groups = []
+        if video_tokens is not None:
+            token_groups.append(self.video_input_proj(video_tokens.to(dtype)) + self.video_modality_emb)
+        if audio_tokens is not None:
+            token_groups.append(self.audio_input_proj(audio_tokens.to(dtype)) + self.audio_modality_emb)
+
+        pooled = self.attention_pooler(torch.cat(token_groups, dim=1)).flatten(1)
+        hidden_states = F.gelu(self.mlp_hidden(pooled), approximate="tanh")
+        return self.mlp_out(hidden_states).squeeze(-1).exp()
+
+    def predict_num_frames(
+        self,
+        video_tokens: torch.Tensor | None = None,
+        audio_tokens: torch.Tensor | None = None,
+        *,
+        frame_rate: float,
+        temporal_compression_ratio: int,
+        min_seconds: float = 1.0,
+        max_seconds: float = 20.0,
+    ) -> int:
+        """Clamp one duration prediction and snap it to the VAE frame grid."""
+        predicted_seconds = self(video_tokens, audio_tokens)
+        if predicted_seconds.numel() != 1:
+            raise ValueError(
+                f"predict_num_frames supports one prompt at a time, but got shape {tuple(predicted_seconds.shape)}."
+            )
+        if frame_rate <= 0:
+            raise ValueError("frame_rate must be positive.")
+        if temporal_compression_ratio < 1:
+            raise ValueError("temporal_compression_ratio must be positive.")
+        if min_seconds >= max_seconds:
+            raise ValueError("min_seconds must be less than max_seconds.")
+
+        seconds = predicted_seconds.item()
+        min_frames = max(1, round(min_seconds * frame_rate))
+        max_frames = round(max_seconds * frame_rate)
+        clamped_frames = max(min_frames, min(round(seconds * frame_rate), max_frames))
+        num_frames = ((clamped_frames - 1) // temporal_compression_ratio) * temporal_compression_ratio + 1
+
+        if num_frames < min_frames:
+            snapped_up = num_frames + temporal_compression_ratio
+            if snapped_up <= max_frames:
+                num_frames = snapped_up
+            else:
+                if abs(snapped_up - clamped_frames) < abs(num_frames - clamped_frames):
+                    num_frames = snapped_up
+                logger.warning(
+                    "Duration bounds [%.2fs, %.2fs] at %.2f fps contain no frame count on the %dk + 1 grid; "
+                    "using %d frames.",
+                    min_seconds,
+                    max_seconds,
+                    frame_rate,
+                    temporal_compression_ratio,
+                    num_frames,
+                )
+
+        if seconds < min_seconds or seconds > max_seconds:
+            logger.warning(
+                "Duration prediction %.2fs was clamped to %.2fs (%d frames at %.2f fps).",
+                seconds,
+                num_frames / frame_rate,
+                num_frames,
+                frame_rate,
+            )
+        else:
+            logger.info(
+                "Predicted duration %.2fs (%d frames at %.2f fps).",
+                seconds,
+                num_frames,
+                frame_rate,
+            )
+        return num_frames

--- a/vllm_omni/diffusion/models/ltx2/ltx2_request.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_request.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from typing import Any, Literal
@@ -44,6 +45,9 @@ class LTXRequestInputs:
     max_sequence_length: int
     audio_latents_normalized: bool = False
     image_crf: int | None = None
+    auto_duration: bool = False
+    min_seconds: float = 1.0
+    max_seconds: float = 20.0
 
     @property
     def guidance_scale(self) -> float:
@@ -194,6 +198,33 @@ def _normalize_image_crf(value: Any) -> int | None:
     if not 0 <= value <= 51:
         raise ValueError("`image_crf` must be an integer from 0 through 51.")
     return value
+
+
+def _resolve_identical_extra_arg(sampling_params: list[Any], name: str) -> Any:
+    values = [_get_extra_arg(item, name) for item in sampling_params]
+    first = values[0] if values else None
+    if any(item != first for item in values[1:]):
+        raise ValueError(f"Batched LTX requests must use identical `{name}` values.")
+    return first
+
+
+def _normalize_auto_duration(value: Any) -> bool:
+    if value is None:
+        return False
+    if not isinstance(value, bool):
+        raise ValueError("`auto_duration` must be a boolean.")
+    return value
+
+
+def _normalize_duration_seconds(value: Any, *, name: str, default: float) -> float:
+    if value is None:
+        return default
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"`{name}` must be a positive number.")
+    seconds = float(value)
+    if not math.isfinite(seconds) or seconds <= 0:
+        raise ValueError(f"`{name}` must be a positive number.")
+    return seconds
 
 
 def _normalize_stg_blocks(value: Any, default: tuple[int, ...]) -> tuple[int, ...]:
@@ -483,8 +514,20 @@ class LTXRequestMixin:
             raise ValueError("Batched LTX requests must use identical `image_crf` values.")
         image_crf = _normalize_image_crf(first_image_crf if first_image_crf is not None else image_crf)
 
+        auto_duration = _normalize_auto_duration(_resolve_identical_extra_arg(sampling_params_list, "auto_duration"))
+        min_seconds = _normalize_duration_seconds(
+            _resolve_identical_extra_arg(sampling_params_list, "min_seconds"), name="min_seconds", default=1.0
+        )
+        max_seconds = _normalize_duration_seconds(
+            _resolve_identical_extra_arg(sampling_params_list, "max_seconds"), name="max_seconds", default=20.0
+        )
+        if min_seconds >= max_seconds:
+            raise ValueError("`min_seconds` must be less than `max_seconds`.")
+
         sampling = sampling_params_list[0]
         is_dummy_run = req.is_dummy_run()
+        if is_dummy_run:
+            auto_duration = False
         prompt = [item if isinstance(item, str) else (item.get("prompt") or "") for item in req.prompts] or prompt
         negative_prompt = _resolve_negative_prompts(
             req.prompts,
@@ -614,4 +657,7 @@ class LTXRequestMixin:
             output_type=output_type,
             max_sequence_length=int(max_sequence_length),
             image_crf=image_crf,
+            auto_duration=auto_duration,
+            min_seconds=min_seconds,
+            max_seconds=max_seconds,
         )

--- a/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
@@ -226,6 +226,9 @@ class LTXRuntime(
             raise ValueError(f"{self.__class__.__name__} does not support `image` input.")
         request_sigmas = self._resolve_request_sigmas(req, sigmas)
         request_phase_sigmas = self._resolve_request_phase_sigmas(req, stage_1_sigmas, stage_2_sigmas)
+        prompt_context = None
+        if request_inputs.auto_duration:
+            request_inputs, prompt_context = self._predict_duration(request_inputs)
         validate_pipeline_request(
             request_inputs,
             pipeline_recipe=self.pipeline_recipe,
@@ -242,6 +245,15 @@ class LTXRuntime(
             raise ValueError(
                 f"{self.__class__.__name__} cannot compose a request LoRA with its internal phase adapter."
             )
+        if prompt_context is not None:
+            return self._run_recipe(
+                req,
+                request_inputs,
+                request_sigmas=request_sigmas,
+                request_phase_sigmas=request_phase_sigmas,
+                image=image,
+                prompt_context=prompt_context,
+            )
         return self._run_recipe(
             req,
             request_inputs,
@@ -249,6 +261,52 @@ class LTXRuntime(
             request_phase_sigmas=request_phase_sigmas,
             image=image,
         )
+
+    def _predict_duration(
+        self,
+        request_inputs: LTXRequestInputs,
+    ) -> tuple[LTXRequestInputs, LTXPromptContext]:
+        duration_head = getattr(self, "duration_head", None)
+        if duration_head is None:
+            raise ValueError(
+                f"{self.__class__.__name__} does not provide a Duration Head; "
+                "auto duration is available for LTX-2.5 checkpoints only."
+            )
+        if request_inputs.latents is not None or request_inputs.audio_latents is not None:
+            raise ValueError("LTX auto duration cannot be combined with request-provided latents.")
+
+        if isinstance(request_inputs.prompt, list):
+            prompt_batch_size = len(request_inputs.prompt)
+        elif request_inputs.prompt_embeds is not None:
+            prompt_batch_size = request_inputs.prompt_embeds.shape[0]
+        else:
+            prompt_batch_size = 1
+        if prompt_batch_size != 1:
+            raise ValueError(
+                "LTX auto duration supports one prompt per request because one predicted frame count "
+                "cannot serve prompts with different natural durations."
+            )
+
+        self._guidance_plan = LTXGuidancePlan.build(request_inputs.guidance)
+        prompt_context = self._prepare_prompt_context(
+            prompt=request_inputs.prompt,
+            negative_prompt=request_inputs.negative_prompt,
+            prompt_embeds=request_inputs.prompt_embeds,
+            negative_prompt_embeds=request_inputs.negative_prompt_embeds,
+            prompt_attention_mask=request_inputs.prompt_attention_mask,
+            negative_prompt_attention_mask=request_inputs.negative_prompt_attention_mask,
+            num_videos_per_prompt=request_inputs.num_videos_per_prompt,
+            max_sequence_length=request_inputs.max_sequence_length,
+        )
+        num_frames = duration_head.predict_num_frames(
+            prompt_context.positive_connector_prompt_embeds[:1],
+            prompt_context.positive_connector_audio_prompt_embeds[:1],
+            frame_rate=request_inputs.frame_rate,
+            temporal_compression_ratio=self.vae_temporal_compression_ratio,
+            min_seconds=request_inputs.min_seconds,
+            max_seconds=request_inputs.max_seconds,
+        )
+        return replace(request_inputs, num_frames=num_frames), prompt_context
 
     def _run_recipe(
         self,
@@ -258,10 +316,10 @@ class LTXRuntime(
         request_sigmas: list[float] | None,
         request_phase_sigmas: tuple[list[float] | None, ...] | None = None,
         image: Any | None = None,
+        prompt_context: LTXPromptContext | None = None,
     ) -> DiffusionOutput | list[DiffusionOutput]:
         """Execute one- and multi-phase recipes through the same control flow."""
         phase_results: list[LTXPhaseResult] = []
-        prompt_context = None
         for phase_index, phase_recipe in enumerate(self.pipeline_recipe.phases):
             override_sigmas = None if request_phase_sigmas is None else request_phase_sigmas[phase_index]
             phase_sigmas = (

--- a/vllm_omni/model_extras/ltx2.py
+++ b/vllm_omni/model_extras/ltx2.py
@@ -25,6 +25,9 @@ LTX_EXTRA_BODY_PARAMS = frozenset(
         "stage_1_sigmas",
         "stage_2_sigmas",
         "image_crf",
+        "auto_duration",
+        "min_seconds",
+        "max_seconds",
     }
 )
 


### PR DESCRIPTION
## Summary

- load the LTX-2.5 `duration_head` component for all four canonical LTX-2.5 pipelines
- add opt-in prompt-based frame-count prediction with the official 1-20 second bounds and VAE `8k+1` frame snapping
- reuse the positive connector context for denoising and expose the controls through LTX model extras
- document offline and online usage in the LTX-2.5 recipe

## Validation

- `python -m pytest -q tests/diffusion/models/ltx2 tests/model_extras/test_model_extras.py` (302 passed)
- repository pre-commit hooks on all changed files
- exact local output/frame-count match against the pinned Diffusers Duration Head using the converted LTX-2.5 checkpoint (`max_abs_diff=0.0`)
