### PR TITLE
[Core] Add session-affinity routing for replicated AR-Diffusion

### DIFF
--- a/docs/design/feature/realtime_ar_diffusion.md
+++ b/docs/design/feature/realtime_ar_diffusion.md
@@ -151,13 +151,23 @@ reports the measured 603 MiB per-session Wan VAE causal-convolution state.
 The current runner executes one request at a time:
 
 - `max_num_seqs` must be one;
-- request batching and diffusion step execution are rejected;
-- one AR block is generated per engine request; and
-- an AR-Diffusion stage must have exactly one replica.
+- request batching and diffusion step execution are rejected; and
+- one AR block is generated per engine request.
 
-The single-replica restriction is intentional. Multi-replica support requires
-session-affine routing so every tick, reset, and close reaches the worker that
-owns the session. Random or round-robin routing is not correct.
+An AR-Diffusion stage may be replicated. Each tick carries its `session_id`
+into dispatch, and `StagePool` pins a session to the replica that owns its
+state: the first tick is placed by the stage's ordinary load-balancing policy,
+every later tick is routed back to that replica, and the route is released on
+session reset or close. Reset and close themselves fan out to every live
+replica through the existing collective RPC and are idempotent for unknown
+session ids, so they reach the owner without the caller tracking placement.
+
+Placement is fail-closed. Session state is worker-local and is neither
+migrated nor rebuilt, so if the owning replica dies, later ticks for that
+session raise `SessionOwnerLostError` (a `StageUnavailableError`, so the
+orchestrator fails just that request) instead of silently landing on a replica
+that holds none of its state. The session stays in that state until it is
+explicitly reset or closed.
 
 Multiple resident sessions may share one runner. Capacity selection accounts
 for all persistent pools, and the runner performs LRU eviction through the same
@@ -186,7 +196,9 @@ This contract does not currently provide:
   frontend is tracked separately in
   [#5527](https://github.com/vllm-project/vllm-omni/pull/5527));
 - camera/action semantics shared by every world model;
-- session migration or replication across workers;
+- session-state migration between replicas, or rebuild/recovery after the
+  owning replica is lost;
+- byte-aware or HBM-aware session admission and placement;
 - retry of an ambiguous partially executed chunk;
 - cross-stage KV transfer; or
 - stateful streaming VAE decode.
@@ -204,7 +216,10 @@ CPU contract tests cover:
 - capacity one under the default fraction for shipped LingBot geometry;
 - capacity expansion under a tuned fraction;
 - DreamZero model-owned state accounting;
-- runner session reuse, reset, close, LRU eviction, and forward cleanup; and
+- runner session reuse, reset, close, LRU eviction, and forward cleanup;
+- session-to-replica affinity: stickiness across ticks on both dispatch paths,
+  release on reset/close, fail-closed routing after the owner is lost, and a
+  single owner under concurrent first ticks; and
 - LingBot model registration, imports, camera/action reduction, and one-block
   output metadata.
 

--- a/examples/offline_inference/diffusion/lingbot_world_v2_realtime.py
+++ b/examples/offline_inference/diffusion/lingbot_world_v2_realtime.py
@@ -173,7 +173,14 @@ async def run(argv: Sequence[str] | None = None) -> Path:
     )
     manager = ARDiffusionSessionManager(
         tick_consumer=consumer,
-        lifecycle=ARDiffusionWorkerLifecycle(engine, stage_ids=[0], timeout=180.0),
+        lifecycle=ARDiffusionWorkerLifecycle(
+            engine,
+            stage_ids=[0],
+            timeout=180.0,
+            # Ticks are pinned to the replica owning the session's AR state;
+            # reset/close hand the id back to the load balancer.
+            route_release=consumer.release_session_route,
+        ),
         max_pending_events=32,
         control_reducer_factory=LingBotCameraControlReducer,
     )

--- a/examples/offline_inference/diffusion/lingbot_world_v2_realtime.py
+++ b/examples/offline_inference/diffusion/lingbot_world_v2_realtime.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Run LingBot-World 2.0 as an in-process realtime AR-Diffusion session.
+"""Run one or more LingBot-World 2.0 realtime AR-Diffusion sessions.
 
 This example exercises the internal session API. It is not a public HTTP or
 WebSocket protocol. Each JSONL event advances the world by one three-latent
-frame AR block and writes the latent plus its identity metadata. The current
+frame AR block and writes the latent plus its identity and replica-route
+metadata. With ``--deploy-config`` and ``--num-sessions 2`` this is also the
+hardware driver for session-affine Replica-DP validation. The current
 scoped implementation supports at most ten ticks per generation epoch because
 its image condition is bounded to 117 pixel frames; reset or create a session
 to start a new world.
@@ -34,7 +36,7 @@ def _camera_event_data(frames: list[list[str]]) -> dict[str, Any]:
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run an in-process realtime LingBot-World 2.0 session.")
+    parser = argparse.ArgumentParser(description="Run in-process realtime LingBot-World 2.0 sessions.")
     parser.add_argument("--model", default=_MODEL, help="Hugging Face model ID or local checkpoint path.")
     parser.add_argument("--image", required=True, help="Initial RGB image.")
     parser.add_argument("--prompt", required=True, help="Initial scene prompt.")
@@ -44,12 +46,32 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="JSONL file with one prompt/action event per AR block; at most 10 events.",
     )
     parser.add_argument("--output-dir", required=True, help="Directory for chunk latents and metadata.")
-    parser.add_argument("--session-id", default="lingbot-world", help="Persistent world session identifier.")
+    parser.add_argument(
+        "--session-id",
+        default="lingbot-world",
+        help="Session id, or the prefix when --num-sessions is greater than one.",
+    )
+    parser.add_argument("--num-sessions", type=int, default=1, help="Number of sessions driven concurrently.")
+    parser.add_argument(
+        "--deploy-config",
+        default=None,
+        help="Optional deploy YAML. Required for a replicated stage; direct mode keeps the original single engine.",
+    )
+    parser.add_argument(
+        "--require-distinct-replicas",
+        action="store_true",
+        help="Fail unless every session is placed on a different replica after its first tick.",
+    )
     parser.add_argument("--height", type=int, default=480)
     parser.add_argument("--width", type=int, default=832)
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--gpu-memory-fraction", type=float, default=0.1)
-    parser.add_argument("--tensor-parallel-size", type=int, default=1)
+    parser.add_argument(
+        "--tensor-parallel-size",
+        type=int,
+        default=1,
+        help="Tensor parallel size in direct mode; deploy YAML owns TP when --deploy-config is set.",
+    )
     parser.add_argument("--enforce-eager", action="store_true")
     return parser.parse_args(argv)
 
@@ -96,28 +118,35 @@ def _load_events(path: Path) -> list[dict[str, Any]]:
     return events
 
 
-def _validate_args(args: argparse.Namespace) -> tuple[Path, Path, Path]:
+def _validate_args(args: argparse.Namespace) -> tuple[Path, Path, Path, Path | None]:
     image = Path(args.image).expanduser().resolve()
     events = Path(args.events).expanduser().resolve()
     output_dir = Path(args.output_dir).expanduser().resolve()
+    deploy_config = Path(args.deploy_config).expanduser().resolve() if args.deploy_config else None
     if not image.is_file():
         raise ValueError("--image must point to an existing file.")
     if not events.is_file():
         raise ValueError("--events must point to an existing JSONL file.")
     if not args.prompt.strip():
         raise ValueError("--prompt must contain non-whitespace text.")
+    if args.num_sessions <= 0:
+        raise ValueError("--num-sessions must be positive.")
+    if args.require_distinct_replicas and args.num_sessions < 2:
+        raise ValueError("--require-distinct-replicas needs at least two sessions.")
+    if deploy_config is not None and not deploy_config.is_file():
+        raise ValueError("--deploy-config must point to an existing YAML file.")
     if args.height <= 0 or args.width <= 0 or args.height % 16 or args.width % 16:
         raise ValueError("--height and --width must be positive multiples of 16.")
     if args.tensor_parallel_size <= 0:
         raise ValueError("--tensor-parallel-size must be positive.")
     if not math.isfinite(args.gpu_memory_fraction) or not 0 < args.gpu_memory_fraction <= 1:
         raise ValueError("--gpu-memory-fraction must be in (0, 1].")
-    return image, events, output_dir
+    return image, events, output_dir, deploy_config
 
 
 async def run(argv: Sequence[str] | None = None) -> Path:
     args = parse_args(argv)
-    image, events_path, output_dir = _validate_args(args)
+    image, events_path, output_dir, deploy_config = _validate_args(args)
     events = _load_events(events_path)
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -137,21 +166,29 @@ async def run(argv: Sequence[str] | None = None) -> Path:
     from vllm_omni.experimental.ar_diffusion.tick_protocol import ARDiffusionControlInput
     from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
-    engine = AsyncOmni(
-        model=args.model,
-        engine_backend="vllm_omni.experimental.ar_diffusion.engine.ARDiffusionEngine",
-        enforce_eager=args.enforce_eager,
-        parallel_config=DiffusionParallelConfig(tensor_parallel_size=args.tensor_parallel_size),
-        max_num_seqs=1,
-        model_config={
-            "ar_diffusion_height": args.height,
-            "ar_diffusion_width": args.width,
-            "ar_diffusion_kv_config": {
-                "gpu_memory_fraction": args.gpu_memory_fraction,
-                "warmup_cudagraph": True,
+    engine_kwargs: dict[str, Any] = {"model": args.model}
+    if deploy_config is None:
+        engine_kwargs.update(
+            {
+                "engine_backend": "vllm_omni.experimental.ar_diffusion.engine.ARDiffusionEngine",
+                "enforce_eager": args.enforce_eager,
+                "parallel_config": DiffusionParallelConfig(tensor_parallel_size=args.tensor_parallel_size),
+                "max_num_seqs": 1,
+                "model_config": {
+                    "ar_diffusion_height": args.height,
+                    "ar_diffusion_width": args.width,
+                    "ar_diffusion_kv_config": {
+                        "gpu_memory_fraction": args.gpu_memory_fraction,
+                        "warmup_cudagraph": True,
+                    },
+                },
             },
-        },
-    )
+        )
+    else:
+        # The deploy config owns engine selection, memory, compile mode,
+        # replica count, device partitioning, and per-replica TP.
+        engine_kwargs["deploy_config"] = str(deploy_config)
+    engine = AsyncOmni(**engine_kwargs)
     sampling = OmniDiffusionSamplingParams(
         height=args.height,
         width=args.width,
@@ -184,8 +221,54 @@ async def run(argv: Sequence[str] | None = None) -> Path:
         max_pending_events=32,
         control_reducer_factory=LingBotCameraControlReducer,
     )
-    session = await manager.create_session(args.session_id)
-    measurements: list[dict[str, Any]] = []
+    session_ids = (
+        [args.session_id]
+        if args.num_sessions == 1
+        else [f"{args.session_id}-{index}" for index in range(args.num_sessions)]
+    )
+    sessions = {session_id: await manager.create_session(session_id) for session_id in session_ids}
+    measurements: dict[str, list[dict[str, Any]]] = {session_id: [] for session_id in session_ids}
+    rounds: list[dict[str, float | int]] = []
+    route_owners: dict[str, int | None] = {session_id: None for session_id in session_ids}
+    stage_pool = engine.engine.stage_pools[0]
+
+    async def run_one_chunk(session_id: str, chunk_index: int) -> None:
+        started = time.perf_counter()
+        output = await sessions[session_id].next_chunk()
+        elapsed = time.perf_counter() - started
+        if len(output.images) != 1 or not isinstance(output.images[0], torch.Tensor):
+            raise RuntimeError("Expected one latent tensor from each realtime LingBot chunk.")
+        latent = output.images[0].detach().float().cpu()
+        metadata = consumer.chunk_metadata(output).to_dict()
+        is_finite = bool(torch.isfinite(latent).all())
+        if not is_finite:
+            raise RuntimeError(f"Session {session_id!r} chunk {chunk_index} contains non-finite values.")
+        replica_id = stage_pool.get_session_replica_id(session_id)
+        if replica_id is None:
+            raise RuntimeError(f"Session {session_id!r} completed a tick without a replica route.")
+        previous_owner = route_owners[session_id]
+        if previous_owner is not None and replica_id != previous_owner:
+            raise RuntimeError(f"Session {session_id!r} moved from replica {previous_owner} to {replica_id}.")
+        route_owners[session_id] = replica_id
+
+        session_dir = output_dir / session_id
+        session_dir.mkdir(parents=True, exist_ok=True)
+        torch.save(latent, session_dir / f"chunk_{chunk_index:03d}.pt")
+        chunk_record = {
+            "chunk_index": chunk_index,
+            "latency_seconds": elapsed,
+            "shape": list(latent.shape),
+            "finite": is_finite,
+            "replica_id": replica_id,
+            "metadata": metadata,
+        }
+        (session_dir / f"chunk_{chunk_index:03d}.json").write_text(
+            json.dumps(chunk_record, indent=2, sort_keys=True) + "\n"
+        )
+        measurements[session_id].append(chunk_record)
+        print(json.dumps({"session_id": session_id, **chunk_record}, sort_keys=True), flush=True)
+
+    ticks_started = time.perf_counter()
     try:
         for chunk_index, event in enumerate(events):
             controls = ()
@@ -197,44 +280,72 @@ async def run(argv: Sequence[str] | None = None) -> Path:
                         data=_camera_event_data(event["frames"]),
                     ),
                 )
-            await session.accept_event(
-                ARDiffusionSessionEvent(
-                    event_id=event["event_id"],
-                    prompt=event["prompt"]
-                    if event["prompt"] is not None
-                    else (args.prompt if chunk_index == 0 else None),
-                    controls=controls,
+            await asyncio.gather(
+                *(
+                    sessions[session_id].accept_event(
+                        ARDiffusionSessionEvent(
+                            event_id=event["event_id"],
+                            prompt=event["prompt"]
+                            if event["prompt"] is not None
+                            else (args.prompt if chunk_index == 0 else None),
+                            controls=controls,
+                        )
+                    )
+                    for session_id in session_ids
                 )
             )
-            started = time.perf_counter()
-            output = await session.next_chunk()
-            elapsed = time.perf_counter() - started
-            if len(output.images) != 1 or not isinstance(output.images[0], torch.Tensor):
-                raise RuntimeError("Expected one latent tensor from each realtime LingBot chunk.")
-            latent = output.images[0].detach().float().cpu()
-            metadata = consumer.chunk_metadata(output).to_dict()
-            torch.save(latent, output_dir / f"chunk_{chunk_index:03d}.pt")
-            (output_dir / f"chunk_{chunk_index:03d}.json").write_text(
-                json.dumps(metadata, indent=2, sort_keys=True) + "\n"
-            )
-            measurements.append(
+            # The first gather exercises concurrent route binding. Following
+            # rounds assert that each session remains on its original owner.
+            round_started = time.perf_counter()
+            await asyncio.gather(*(run_one_chunk(session_id, chunk_index) for session_id in session_ids))
+            rounds.append(
                 {
                     "chunk_index": chunk_index,
-                    "latency_seconds": elapsed,
-                    "shape": list(latent.shape),
-                    "finite": bool(torch.isfinite(latent).all()),
-                    "metadata": metadata,
+                    "wall_seconds": time.perf_counter() - round_started,
                 }
             )
-            print(json.dumps(measurements[-1], sort_keys=True), flush=True)
+            if chunk_index == 0 and args.require_distinct_replicas:
+                owners = [route_owners[session_id] for session_id in session_ids]
+                if len(set(owners)) != len(owners):
+                    raise RuntimeError(
+                        "Expected one distinct replica per session, but first-tick owners were "
+                        f"{dict(zip(session_ids, owners, strict=True))}."
+                    )
+        tick_wall_seconds = time.perf_counter() - ticks_started
     finally:
         try:
-            await manager.close_session(args.session_id)
+            await asyncio.gather(*(manager.close_session(session_id) for session_id in session_ids))
+            leaked_routes = {
+                session_id: stage_pool.get_session_replica_id(session_id)
+                for session_id in session_ids
+                if stage_pool.get_session_replica_id(session_id) is not None
+            }
+            if leaked_routes:
+                raise RuntimeError(f"Session routes were not released on close: {leaked_routes}.")
         finally:
             engine.shutdown()
 
+    completed_chunks = sum(len(chunks) for chunks in measurements.values())
     summary_path = output_dir / "summary.json"
-    summary_path.write_text(json.dumps({"chunks": measurements}, indent=2, sort_keys=True) + "\n")
+    summary_path.write_text(
+        json.dumps(
+            {
+                "model": args.model,
+                "deploy_config": str(deploy_config) if deploy_config is not None else None,
+                "resolution": [args.height, args.width],
+                "num_sessions": args.num_sessions,
+                "route_owners": route_owners,
+                "tick_wall_seconds": tick_wall_seconds,
+                "aggregate_chunks_per_second": completed_chunks / tick_wall_seconds,
+                "aggregate_latent_frames_per_second": (completed_chunks * _FRAMES_PER_BLOCK / tick_wall_seconds),
+                "rounds": rounds,
+                "sessions": measurements,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
     return summary_path
 
 

--- a/examples/offline_inference/diffusion/lingbot_world_v2_realtime_events.jsonl
+++ b/examples/offline_inference/diffusion/lingbot_world_v2_realtime_events.jsonl
@@ -1,0 +1,4 @@
+{"event_id": 0, "frames": [["W"], ["W"], ["A"]]}
+{"event_id": 1, "frames": [["W"], ["D"], ["W"]]}
+{"event_id": 2, "frames": [["A"], ["W"], ["D"]]}
+{"event_id": 3, "frames": [["W"], ["W"], ["W"]]}

--- a/examples/offline_inference/diffusion/lingbot_world_v2_replica_dp.md
+++ b/examples/offline_inference/diffusion/lingbot_world_v2_replica_dp.md
@@ -1,0 +1,94 @@
+# LingBot realtime Replica-DP validation
+
+This recipe validates session-affine routing with two independent LingBot
+AR-Diffusion replicas. Each replica uses TP=2, for four GPUs total:
+
+```text
+GPU 0,1 -> replica 0, TP=2
+GPU 2,3 -> replica 1, TP=2
+```
+
+It is a hardware-validation recipe for PR #6233. The checked-in CPU tests
+validate the routing state machine; this run validates real worker-local AR
+state, concurrent execution, and the four-GPU process layout.
+
+## Run
+
+Use a single node with four mutually visible GPUs. Record the code revision,
+topology, driver, and neighboring processes before loading the checkpoint:
+
+```bash
+git rev-parse HEAD
+git status --short
+nvidia-smi
+nvidia-smi topo -m
+```
+
+Then run two sessions concurrently:
+
+```bash
+python examples/offline_inference/diffusion/lingbot_world_v2_realtime.py \
+  --model robbyant/lingbot-world-v2-14b-causal-fast-diffusers \
+  --deploy-config examples/offline_inference/diffusion/lingbot_world_v2_replica_dp_tp2.yaml \
+  --image /absolute/path/to/input.png \
+  --prompt "A vehicle travels through an outdoor scene" \
+  --events examples/offline_inference/diffusion/lingbot_world_v2_realtime_events.jsonl \
+  --output-dir runs/lingbot_replica_dp_tp2 \
+  --session-id world \
+  --num-sessions 2 \
+  --require-distinct-replicas
+```
+
+The driver submits both first ticks with one `asyncio.gather()`, then advances
+both sessions concurrently for every later chunk. It fails if:
+
+- a completed tick has no session route;
+- a session moves to another replica;
+- `--require-distinct-replicas` is set and the two sessions share an owner;
+- metadata validation, model execution, or finite-output checks fail.
+
+Output is grouped by session:
+
+```text
+runs/lingbot_replica_dp_tp2/
+  summary.json
+  world-0/chunk_000.{pt,json}
+  world-0/chunk_001.{pt,json}
+  world-1/chunk_000.{pt,json}
+  world-1/chunk_001.{pt,json}
+```
+
+`summary.json` records the replica owner of every session, per-round wall time,
+aggregate chunks/s, aggregate latent-frames/s, and every chunk's latency,
+latent shape, finite flag, and correlated AR metadata. Preserve the raw
+stdout/stderr and `nvidia-smi dmon` output with this directory.
+
+## Pass criteria
+
+1. `world-0` and `world-1` have distinct `route_owners`.
+2. Each session reports the same `replica_id` for all chunks.
+3. Every latent is finite and every metadata session/chunk id matches.
+4. Both replica GPU groups are active during the same wall-clock interval.
+5. Closing the sessions completes without a leaked route warning.
+
+This run proves routing and concurrent execution. It does not by itself prove
+video quality or realtime RGB delivery: the driver writes latent chunks, and
+the current AR path still needs the separate streaming-VAE validation for
+end-to-end frame delivery.
+
+## Recommended comparison
+
+Run these with the same checkpoint, image, events, seed, and compile mode:
+
+```text
+1 replica x TP=2, one session       single-session latency baseline
+1 replica x TP=2, two sessions      serialized-session throughput baseline
+2 replicas x TP=2, two sessions     session-affine Replica-DP result
+```
+
+Report `tick_wall_seconds`, per-session chunk latency,
+`aggregate_latent_frames_per_second`, per-GPU utilization, and peak HBM. The
+reported latent-frame rate is a generation throughput metric, not delivered RGB
+FPS or delivery RTF. Do not compare the two-replica result only against TP=4:
+TP changes single-session model parallelism, while replicas change cross-session
+throughput.

--- a/examples/offline_inference/diffusion/lingbot_world_v2_replica_dp_tp2.yaml
+++ b/examples/offline_inference/diffusion/lingbot_world_v2_replica_dp_tp2.yaml
@@ -1,0 +1,29 @@
+# LingBot-World 2.0 realtime AR-Diffusion: two replicas, TP=2 each.
+#
+# Device layout:
+#   replica 0 -> GPUs 0,1
+#   replica 1 -> GPUs 2,3
+#
+# Every session is placed on one replica by its first tick and remains there
+# until reset/close. This file is an H200 validation recipe, not a claim that
+# the topology has already been measured on H200.
+
+async_chunk: false
+distributed_executor_backend: mp
+dtype: bfloat16
+
+stages:
+  - stage_id: 0
+    devices: "0,1,2,3"
+    num_replicas: 2
+    tensor_parallel_size: 2
+    max_num_seqs: 1
+    enforce_eager: false
+    model_class_name: LingBotWorldCausalDMDPipeline
+    engine_backend: vllm_omni.experimental.ar_diffusion.engine.ARDiffusionEngine
+    model_config:
+      ar_diffusion_height: 480
+      ar_diffusion_width: 832
+      ar_diffusion_kv_config:
+        gpu_memory_fraction: 0.6
+        warmup_cudagraph: true

--- a/recipes/Robbyant/LingBot-World-2.0.md
+++ b/recipes/Robbyant/LingBot-World-2.0.md
@@ -105,8 +105,9 @@ tested commit.
 
 - Only the 14B causal-fast checkpoint is supported.
 - The realtime control plane is internal; there is no public server transport yet.
-- AR-Diffusion stages currently require one replica because session-affine
-  routing across replicas is not implemented.
+- AR-Diffusion stages may be replicated: ticks are pinned to the replica
+  owning the session's state. Session state is not migrated, so if that
+  replica is lost the session fails and must be reset or closed.
 - One AR block is generated per request and `max_num_seqs` must be one.
 - Stateful streaming VAE decode is not implemented; the realtime example emits
   latent chunks.

--- a/tests/diffusion/ar_diffusion/test_consumer.py
+++ b/tests/diffusion/ar_diffusion/test_consumer.py
@@ -33,8 +33,8 @@ class FakeStagePool:
 
 
 class FakeEngine:
-    def __init__(self, num_replicas: int = 1) -> None:
-        self.stage_pools = [FakeStagePool(num_replicas)]
+    def __init__(self, num_replicas: int = 1, num_stages: int = 2) -> None:
+        self.stage_pools = [FakeStagePool(num_replicas) for _ in range(num_stages)]
 
 
 class FakeGenerateClient:
@@ -51,6 +51,10 @@ class FakeGenerateClient:
         self.applied_event_ids = applied_event_ids
         self.output_error = output_error
         self.calls: list[dict[str, Any]] = []
+        self.released_sessions: list[tuple[str, Any]] = []
+
+    def release_session_affinity(self, session_id: str, *, stage_ids: Sequence[int] | None = None) -> None:
+        self.released_sessions.append((session_id, None if stage_ids is None else list(stage_ids)))
 
     async def generate(
         self,
@@ -59,6 +63,7 @@ class FakeGenerateClient:
         request_id: str,
         sampling_params_list: Sequence[OmniSamplingParams],
         output_modalities: list[str] | None = None,
+        session_id: str | None = None,
     ) -> AsyncIterator[OmniRequestOutput]:
         self.calls.append(
             {
@@ -66,6 +71,7 @@ class FakeGenerateClient:
                 "request_id": request_id,
                 "sampling_params_list": sampling_params_list,
                 "output_modalities": output_modalities,
+                "session_id": session_id,
             }
         )
         params = sampling_params_list[0]
@@ -112,13 +118,25 @@ def make_tick() -> ARDiffusionTickRequest:
     )
 
 
-def test_consumer_rejects_replicated_ar_diffusion_stage() -> None:
-    client = FakeGenerateClient(num_replicas=2)
+def test_consumer_accepts_replicated_ar_diffusion_stage() -> None:
+    """Replicated AR stages are allowed now that ticks carry session affinity."""
+    client = FakeGenerateClient(num_replicas=4)
 
-    with pytest.raises(
-        ValueError,
-        match=r"require exactly one replica.*num_replicas=2",
-    ):
+    consumer = ARDiffusionOmniTickConsumer(
+        client,
+        prompt_provider=lambda tick: tick.prompt or "",
+        sampling_params_list=[OmniDiffusionSamplingParams()],
+        diffusion_stage_id=0,
+    )
+
+    assert consumer is not None
+    assert client.calls == []
+
+
+def test_consumer_rejects_non_positive_replica_count() -> None:
+    client = FakeGenerateClient(num_replicas=0)
+
+    with pytest.raises(ValueError, match=r"positive num_replicas"):
         ARDiffusionOmniTickConsumer(
             client,
             prompt_provider=lambda tick: tick.prompt or "",
@@ -126,7 +144,34 @@ def test_consumer_rejects_replicated_ar_diffusion_stage() -> None:
             diffusion_stage_id=0,
         )
 
-    assert client.calls == []
+
+@pytest.mark.asyncio
+async def test_consumer_pins_tick_to_its_session() -> None:
+    client = FakeGenerateClient(num_replicas=2)
+    consumer = ARDiffusionOmniTickConsumer(
+        client,
+        prompt_provider=lambda tick: tick.prompt or "",
+        sampling_params_list=[OmniDiffusionSamplingParams()],
+        diffusion_stage_id=0,
+    )
+
+    await consumer.execute_tick(make_tick())
+
+    assert client.calls[0]["session_id"] == "world-1"
+
+
+def test_consumer_releases_session_route_on_the_owning_stage() -> None:
+    client = FakeGenerateClient(num_replicas=2)
+    consumer = ARDiffusionOmniTickConsumer(
+        client,
+        prompt_provider=lambda tick: tick.prompt or "",
+        sampling_params_list=[OmniDiffusionSamplingParams(), OmniDiffusionSamplingParams()],
+        diffusion_stage_id=1,
+    )
+
+    consumer.release_session_route("world-1")
+
+    assert client.released_sessions == [("world-1", [1])]
 
 
 @pytest.mark.asyncio

--- a/tests/diffusion/ar_diffusion/test_session.py
+++ b/tests/diffusion/ar_diffusion/test_session.py
@@ -495,6 +495,50 @@ async def test_worker_lifecycle_routes_to_selected_stage_rpc() -> None:
 
 
 @pytest.mark.asyncio
+async def test_worker_lifecycle_releases_the_route_after_a_successful_rpc() -> None:
+    released: list[str] = []
+    lifecycle = ARDiffusionWorkerLifecycle(
+        FakeRPCClient([[True]]),
+        stage_ids=[0],
+        route_release=released.append,
+    )
+
+    await lifecycle.reset_session("world-1")
+    await lifecycle.close_session("world-1")
+
+    assert released == ["world-1", "world-1"]
+
+
+@pytest.mark.asyncio
+async def test_worker_lifecycle_keeps_the_route_when_the_rpc_fails() -> None:
+    """A session whose worker state survived must stay pinned to its owner.
+
+    Releasing the route first would let the next tick be load-balanced onto a
+    replica holding none of the session's state, while the original replica
+    still holds all of it.
+    """
+    released: list[str] = []
+    lifecycle = ARDiffusionWorkerLifecycle(
+        FakeRPCClient([{"supported": False, "error": "worker refused"}]),
+        stage_ids=[0],
+        route_release=released.append,
+    )
+
+    with pytest.raises(ARDiffusionSessionError, match="worker refused"):
+        await lifecycle.close_session("world-1")
+
+    assert released == []
+
+
+def test_worker_lifecycle_warns_when_no_route_release_is_wired(caplog) -> None:
+    """Without the hook, StagePool keeps one entry per session forever."""
+    with caplog.at_level("WARNING"):
+        ARDiffusionWorkerLifecycle(FakeRPCClient([[True]]), stage_ids=[0])
+
+    assert any("route_release" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
 async def test_worker_lifecycle_rejects_unsupported_stage_result() -> None:
     lifecycle = ARDiffusionWorkerLifecycle(
         FakeRPCClient([{"supported": False, "error": "not an AR stage"}]),

--- a/tests/engine/test_orchestrator.py
+++ b/tests/engine/test_orchestrator.py
@@ -481,6 +481,7 @@ async def _enqueue_add_request(
     original_prompt,
     sampling_params_list,
     final_stage_id: int,
+    session_id: str | None = None,
 ) -> None:
     orchestrator_fixture.request_sync_q.put_nowait(
         StageSubmissionMessage(
@@ -494,6 +495,7 @@ async def _enqueue_add_request(
             preprocess_ms=0.0,
             request_timestamp=time.time(),
             enqueue_ts=time.perf_counter(),
+            session_id=session_id,
         )
     )
 
@@ -1652,6 +1654,68 @@ async def test_multi_replica_round_robin_distribution(orchestrator_factory) -> N
         assert output_msg.stage_id == 1
         assert output_msg.finished is True
         assert "req-0" not in orchestrator_fixture.orchestrator.request_states
+    finally:
+        await _shutdown_orchestrator(orchestrator_fixture)
+
+
+@pytest.mark.asyncio
+async def test_multi_replica_session_affinity_is_threaded_through_the_orchestrator(
+    orchestrator_factory,
+) -> None:
+    """A ``session_id`` on the submission message must reach StagePool placement.
+
+    The stage-level behavior is covered by
+    ``tests/engine/test_stage_pool_session_affinity.py``; this pins the plumbing
+    in between, where ``AsyncOmni.generate`` puts ``session_id`` on
+    ``StageSubmissionMessage`` and the orchestrator forwards it to
+    ``submit_initial``. Realtime AR-Diffusion issues a new ``request_id`` per
+    tick, so without that hop every tick would be round-robined away from the
+    replica holding the session's state.
+    """
+    stage0_r0 = FakeStageClient(stage_type="llm", final_output=False)
+    stage0_r1 = FakeStageClient(stage_type="llm", final_output=False)
+    stage1 = FakeStageClient(stage_type="llm", final_output=True)
+
+    default_vllm_cfg = SimpleNamespace(model_config=SimpleNamespace(max_model_len=64))
+    stage_pools = _build_stage_pools(
+        [[stage0_r0, stage0_r1], [stage1]],
+        stage_vllm_configs=[default_vllm_cfg, default_vllm_cfg],
+    )
+
+    orchestrator_fixture = orchestrator_factory([], stage_pools=stage_pools)
+
+    async def submit(request_id: str, *, session_id: str | None) -> None:
+        await _enqueue_add_request(
+            orchestrator_fixture,
+            request_id=request_id,
+            prompt=SimpleNamespace(request_id=request_id, prompt_token_ids=[1, 2]),
+            original_prompt={"prompt": request_id},
+            sampling_params_list=[_sampling_params(), _sampling_params()],
+            final_stage_id=1,
+            session_id=session_id,
+        )
+
+    try:
+        # Tick 0 places the session with the ordinary policy: replica 0.
+        await submit("world-1-tick-0", session_id="world-1")
+        await _wait_for(lambda: len(stage0_r0.add_request_calls) == 1)
+        assert len(stage0_r1.add_request_calls) == 0
+        assert stage_pools[0].get_session_replica_id("world-1") == 0
+
+        # Tick 1 is a different request_id, so round-robin alone would send it
+        # to replica 1. Affinity must keep it on the owner.
+        await submit("world-1-tick-1", session_id="world-1")
+        await _wait_for(lambda: len(stage0_r0.add_request_calls) == 2)
+        assert len(stage0_r1.add_request_calls) == 0
+
+        # A request without a session_id still load-balances normally.
+        await submit("stateless-0", session_id=None)
+        await _wait_for(lambda: len(stage0_r1.add_request_calls) == 1)
+        assert len(stage0_r0.add_request_calls) == 2
+
+        # Releasing the route frees the id for placement again.
+        stage_pools[0].release_session("world-1")
+        assert stage_pools[0].get_session_replica_id("world-1") is None
     finally:
         await _shutdown_orchestrator(orchestrator_fixture)
 

--- a/tests/engine/test_stage_pool_session_affinity.py
+++ b/tests/engine/test_stage_pool_session_affinity.py
@@ -1,0 +1,290 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Session-to-replica affinity in StagePool (RFC #6226, Phase 0).
+
+A long-lived AR-Diffusion session keeps its persistent state on one worker, so
+every tick of that session has to land on the replica owning it. These tests
+cover both dispatch paths (legacy ``select_replica_id`` and distributed
+``pick``) plus the fail-closed behavior when the owning replica disappears.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_omni.distributed.omni_coordinator.messages import ReplicaInfo, ReplicaStatus
+from vllm_omni.engine.stage_pool import (
+    SessionOwnerLostError,
+    StagePool,
+    StageUnavailableError,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _client(addr: str) -> SimpleNamespace:
+    # StagePool._client_input_addr() reads `request_address` for diffusion
+    # clients; that address is what keys the replica in the hub.
+    return SimpleNamespace(request_address=addr, stage_type="diffusion", final_output=False)
+
+
+def _replica(addr: str, status: ReplicaStatus = ReplicaStatus.UP) -> ReplicaInfo:
+    return ReplicaInfo(
+        input_addr=addr,
+        output_addr=f"{addr}-out",
+        stage_id=0,
+        status=status,
+        queue_length=0,
+        last_heartbeat=0.0,
+        registered_at=0.0,
+    )
+
+
+class _Hub:
+    def __init__(self, replicas: list[ReplicaInfo]) -> None:
+        self.replicas = replicas
+
+    def get_replicas_for_stage(self, _stage_id: int) -> SimpleNamespace:
+        return SimpleNamespace(replicas=list(self.replicas))
+
+
+class _RoundRobinLB:
+    """Deterministic stand-in for the real load balancer."""
+
+    def __init__(self) -> None:
+        self._n = 0
+
+    def select(self, _task, candidates):
+        index = self._n % len(candidates)
+        self._n += 1
+        return index
+
+
+def _local_pool(num_replicas: int = 3) -> StagePool:
+    """A pool with no hub attached: the legacy select_replica_id path."""
+    return StagePool(0, [_client(f"tcp://replica-{i}") for i in range(num_replicas)])
+
+
+def _distributed_pool(num_replicas: int = 3) -> tuple[StagePool, _Hub]:
+    clients = [_client(f"tcp://replica-{i}") for i in range(num_replicas)]
+    pool = StagePool(0, clients)
+    hub = _Hub([_replica(c.request_address) for c in clients])
+    pool.attach_hub(hub)
+    pool.attach_load_balancer(_RoundRobinLB())
+    return pool, hub
+
+
+# ---------------------------------------------------------------- legacy path
+
+
+def test_ticks_of_one_session_stay_on_the_owner_replica():
+    pool = _local_pool()
+
+    owner = pool.select_replica_id("tick-0", session_id="world-1")
+    later = [pool.select_replica_id(f"tick-{i}", session_id="world-1") for i in range(1, 12)]
+
+    assert later == [owner] * 11
+
+
+def test_distinct_sessions_are_spread_by_the_existing_policy():
+    pool = _local_pool()
+
+    owners = {sid: pool.select_replica_id(f"{sid}-0", session_id=sid) for sid in ("a", "b", "c")}
+
+    # Placement of a *new* session still uses the ordinary round-robin policy.
+    assert sorted(owners.values()) == [0, 1, 2]
+    # And each one then stays put.
+    assert all(pool.select_replica_id(f"{sid}-1", session_id=sid) == owner for sid, owner in owners.items())
+
+
+def test_stateless_routing_is_unchanged():
+    """Requests that pass no session_id keep the plain round-robin behavior."""
+    pool = _local_pool()
+
+    assert [pool.select_replica_id(f"r{i}") for i in range(6)] == [0, 1, 2, 0, 1, 2]
+
+
+def test_stateless_requests_still_spread_while_a_session_is_pinned():
+    """A pinned session must not starve or capture ordinary request routing."""
+    pool = _local_pool()
+    owner = pool.select_replica_id("tick-0", session_id="world-1")
+
+    # Interleave ticks of the pinned session with ordinary requests.
+    stateless = []
+    for i in range(6):
+        pool.select_replica_id(f"tick-{i + 1}", session_id="world-1")
+        stateless.append(pool.select_replica_id(f"r{i}"))
+
+    assert sorted(set(stateless)) == [0, 1, 2]  # every replica still reachable
+    assert pool.select_replica_id("tick-99", session_id="world-1") == owner
+
+
+def test_release_lets_the_session_be_placed_again():
+    pool = _local_pool()
+    pool.select_replica_id("tick-0", session_id="world-1")
+
+    pool.release_session("world-1")
+
+    assert not pool.has_session("world-1")
+    assert pool.get_session_replica_id("world-1") is None
+    # Re-placing the same id afterwards is allowed.
+    pool.select_replica_id("tick-1", session_id="world-1")
+    assert pool.has_session("world-1")
+
+
+def test_release_is_idempotent_and_tolerates_unknown_sessions():
+    pool = _local_pool()
+    pool.select_replica_id("tick-0", session_id="world-1")
+
+    pool.release_session("world-1")
+    pool.release_session("world-1")
+    pool.release_session("never-existed")
+
+    assert not pool.has_session("world-1")
+
+
+def test_bind_session_rejects_an_out_of_range_replica():
+    pool = _local_pool(2)
+
+    with pytest.raises(ValueError, match="no replica 7"):
+        pool.bind_session("world-1", 7)
+
+
+def test_session_ids_for_replica_reports_ownership():
+    pool = _local_pool(2)
+    owners = {sid: pool.select_replica_id(f"{sid}-0", session_id=sid) for sid in ("a", "b", "c", "d")}
+
+    expected = sorted(sid for sid, owner in owners.items() if owner == 0)
+
+    assert sorted(pool.session_ids_for_replica(0)) == expected
+
+
+# ----------------------------------------------------------- failure handling
+
+
+def test_lost_owner_fails_closed_instead_of_silently_rerouting():
+    pool = _local_pool()
+    owner = pool.select_replica_id("tick-0", session_id="world-1")
+
+    pool.mark_replica_unavailable(owner)
+
+    # Phase 0 does not migrate or rebuild state, so the tick must fail rather
+    # than land on a replica holding none of this session's state.
+    with pytest.raises(SessionOwnerLostError, match="world-1"):
+        pool.select_replica_id("tick-1", session_id="world-1")
+
+
+def test_lost_owner_keeps_failing_until_the_session_is_released():
+    pool = _local_pool()
+    owner = pool.select_replica_id("tick-0", session_id="world-1")
+    pool.mark_replica_unavailable(owner)
+
+    with pytest.raises(SessionOwnerLostError):
+        pool.select_replica_id("tick-1", session_id="world-1")
+    # The tombstone survives the first failure: a retry must not be re-placed
+    # onto a healthy-but-empty replica.
+    with pytest.raises(SessionOwnerLostError):
+        pool.select_replica_id("tick-2", session_id="world-1")
+
+    pool.release_session("world-1")
+
+    assert pool.select_replica_id("tick-3", session_id="world-1") != owner
+
+
+def test_session_owner_lost_is_a_stage_unavailable_error():
+    """Keeps the orchestrator's dispatch guard failing one request, not the server."""
+    assert issubclass(SessionOwnerLostError, StageUnavailableError)
+
+
+def test_replica_death_leaves_other_sessions_alone():
+    pool = _local_pool()
+    owners = {sid: pool.select_replica_id(f"{sid}-0", session_id=sid) for sid in ("a", "b", "c")}
+    victim = owners["a"]
+
+    pool.mark_replica_unavailable(victim)
+
+    for sid, owner in owners.items():
+        if owner == victim:
+            continue
+        assert pool.select_replica_id(f"{sid}-1", session_id=sid) == owner
+
+
+def test_replica_death_drops_the_route_but_remembers_the_session():
+    pool = _local_pool()
+    owner = pool.select_replica_id("tick-0", session_id="world-1")
+
+    orphaned = pool.mark_replica_unavailable(owner)
+
+    assert "world-1" not in orphaned  # request ids, not session ids
+    assert pool.get_session_replica_id("world-1") is None  # no dangling route
+    assert pool.has_session("world-1")  # but still known, so ticks fail closed
+
+
+# ----------------------------------------------------------- distributed path
+
+
+@pytest.mark.asyncio
+async def test_distributed_ticks_stay_on_the_owner_replica():
+    pool, _hub = _distributed_pool()
+
+    owner = await pool.pick("tick-0", session_id="world-1")
+    later = [await pool.pick(f"tick-{i}", session_id="world-1") for i in range(1, 10)]
+
+    assert later == [owner] * 9
+
+
+@pytest.mark.asyncio
+async def test_distributed_stateless_requests_still_load_balance():
+    pool, _hub = _distributed_pool()
+
+    picks = [await pool.pick(f"r{i}") for i in range(6)]
+
+    assert sorted(set(picks)) == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_distributed_down_owner_fails_closed():
+    pool, hub = _distributed_pool()
+    owner = await pool.pick("tick-0", session_id="world-1")
+    for replica in hub.replicas:
+        if pool.get_replica_id_by_addr(replica.input_addr) == owner:
+            replica.status = ReplicaStatus.DOWN
+
+    with pytest.raises(SessionOwnerLostError, match="world-1"):
+        await pool.pick("tick-1", session_id="world-1")
+
+
+@pytest.mark.asyncio
+async def test_invalidate_addr_orphans_sessions_on_that_replica():
+    pool, _hub = _distributed_pool()
+    owner = await pool.pick("tick-0", session_id="world-1")
+
+    pool.invalidate_addr(f"tcp://replica-{owner}")
+
+    assert pool.get_session_replica_id("world-1") is None
+    with pytest.raises(SessionOwnerLostError):
+        await pool.pick("tick-1", session_id="world-1")
+
+
+@pytest.mark.asyncio
+async def test_concurrent_first_ticks_cannot_create_two_owners():
+    """The RFC's key correctness requirement for the initial placement."""
+    clients = [_client(f"tcp://replica-{i}") for i in range(3)]
+    pool = StagePool(0, clients)
+    # An empty replica set parks every pick() in its bounded retry loop, which
+    # is the only suspension point where two first ticks could interleave.
+    hub = _Hub([])
+    pool.attach_hub(hub)
+    pool.attach_load_balancer(_RoundRobinLB())
+    pool.DISPATCH_RETRY_INTERVAL_S = 0.01
+    pool.DISPATCH_WAIT_TIMEOUT_S = 5.0
+
+    tasks = [asyncio.create_task(pool.pick(f"tick-{i}", session_id="world-1")) for i in range(8)]
+    await asyncio.sleep(0.05)
+    hub.replicas = [_replica(c.request_address) for c in clients]
+    owners = await asyncio.gather(*tasks)
+
+    assert len(set(owners)) == 1

--- a/tests/examples/offline_inference/test_lingbot_world_v2_realtime.py
+++ b/tests/examples/offline_inference/test_lingbot_world_v2_realtime.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from examples.offline_inference.diffusion.lingbot_world_v2_realtime import (
+    _load_events,
+    _validate_args,
+    parse_args,
+)
+from vllm_omni.config.stage_config import load_deploy_config
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+EXAMPLE_DIR = Path(__file__).parents[3] / "examples" / "offline_inference" / "diffusion"
+DEPLOY_CONFIG = EXAMPLE_DIR / "lingbot_world_v2_replica_dp_tp2.yaml"
+EVENTS = EXAMPLE_DIR / "lingbot_world_v2_realtime_events.jsonl"
+
+
+def _args(tmp_path: Path, *extra: str):
+    image = tmp_path / "input.png"
+    image.touch()
+    return parse_args(
+        [
+            "--image",
+            str(image),
+            "--prompt",
+            "drive forward",
+            "--events",
+            str(EVENTS),
+            "--output-dir",
+            str(tmp_path / "output"),
+            *extra,
+        ]
+    )
+
+
+def test_replica_dp_recipe_is_two_replicas_with_tp2() -> None:
+    deploy = load_deploy_config(DEPLOY_CONFIG)
+
+    assert deploy.distributed_executor_backend == "mp"
+    assert len(deploy.stages) == 1
+    stage = deploy.stages[0]
+    assert stage.devices == "0,1,2,3"
+    assert stage.num_replicas == 2
+    assert stage.tensor_parallel_size == 2
+    assert stage.max_num_seqs == 1
+
+
+def test_multisession_cli_accepts_checked_in_recipe(tmp_path: Path) -> None:
+    args = _args(
+        tmp_path,
+        "--deploy-config",
+        str(DEPLOY_CONFIG),
+        "--num-sessions",
+        "2",
+        "--require-distinct-replicas",
+    )
+
+    _, events, _, deploy_config = _validate_args(args)
+
+    assert events == EVENTS.resolve()
+    assert deploy_config == DEPLOY_CONFIG.resolve()
+    assert len(_load_events(events)) >= 2
+
+
+def test_distinct_replica_check_requires_multiple_sessions(tmp_path: Path) -> None:
+    args = _args(tmp_path, "--require-distinct-replicas")
+
+    with pytest.raises(ValueError, match="at least two sessions"):
+        _validate_args(args)

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -648,6 +648,7 @@ class AsyncOmniEngine:
         reasoning_ended: bool | None = None,
         *,
         resumable: bool = False,
+        session_id: str | None = None,
         message_type: Literal["add_request", "streaming_update"] = "add_request",
     ) -> StageSubmissionMessage:
         """Build an add_request message after stage-0 preprocessing."""
@@ -741,6 +742,7 @@ class AsyncOmniEngine:
             preprocess_ms=_preprocess_ms,
             request_timestamp=request_timestamp,
             enqueue_ts=time.perf_counter(),
+            session_id=session_id,
         )
 
     def _enqueue_cfg_companions(
@@ -1255,6 +1257,7 @@ class AsyncOmniEngine:
         reasoning_ended: bool | None = None,
         *,
         resumable: bool = False,
+        session_id: str | None = None,
     ) -> None:
         """Process stage-0 input locally, then send to the Orchestrator.
 
@@ -1278,6 +1281,7 @@ class AsyncOmniEngine:
             data_parallel_rank=data_parallel_rank,
             reasoning_ended=reasoning_ended,
             resumable=resumable,
+            session_id=session_id,
         )
         self.request_queue.sync_q.put(msg)
 
@@ -1307,6 +1311,7 @@ class AsyncOmniEngine:
         reasoning_ended: bool | None = None,
         *,
         resumable: bool = False,
+        session_id: str | None = None,
     ) -> None:
         """Async add_request API."""
         self.add_request(
@@ -1324,7 +1329,29 @@ class AsyncOmniEngine:
             data_parallel_rank=data_parallel_rank,
             reasoning_ended=reasoning_ended,
             resumable=resumable,
+            session_id=session_id,
         )
+
+    def release_session_affinity(
+        self,
+        session_id: str,
+        *,
+        stage_ids: Sequence[int] | None = None,
+    ) -> None:
+        """Drop the replica route pinned to ``session_id``; idempotent.
+
+        Called when a stateful session is reset or closed, after its
+        worker-local state has been released. Only the routing entry goes
+        away here — freeing the state itself is the session lifecycle's job.
+
+        ``stage_ids`` defaults to every stage, which is what a caller that
+        cannot know where the session's state landed should use.
+        """
+        pools = self.stage_pools
+        selected = range(len(pools)) if stage_ids is None else stage_ids
+        for stage_id in selected:
+            if 0 <= stage_id < len(pools):
+                pools[stage_id].release_session(session_id)
 
     def add_streaming_update(
         self,

--- a/vllm_omni/engine/messages.py
+++ b/vllm_omni/engine/messages.py
@@ -27,6 +27,10 @@ class StageSubmissionMessage(EngineQueueMessage, kw_only=True):
     request_timestamp: float
     enqueue_ts: float
     final_output_stage_ids: list[int] | None = None
+    # Routing key for long-lived stateful workloads (realtime AR-Diffusion
+    # ticks): pins this request to the replica owning the session's persistent
+    # state. ``None`` keeps the ordinary request-level routing behavior.
+    session_id: str | None = None
 
 
 class AddCompanionRequestMessage(EngineQueueMessage, kw_only=True):

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -688,6 +688,7 @@ class Orchestrator:
                 req_state,
                 prompt,
                 prompt_text=msg.output_prompt_text,
+                session_id=msg.session_id,
             ),
             req_id=request_id,
             stage_id=stage_id,

--- a/vllm_omni/engine/stage_pool.py
+++ b/vllm_omni/engine/stage_pool.py
@@ -57,6 +57,19 @@ class StageUnavailableError(RuntimeError):
     """
 
 
+class SessionOwnerLostError(StageUnavailableError):
+    """Raised when the replica owning a live session's state is gone.
+
+    Phase 0 session affinity is fail-closed: persistent per-session state is
+    worker-local and is not migrated or rebuilt, so a tick for a session whose
+    owner died cannot be re-routed to a replica that holds no state without
+    silently corrupting the rollout. Subclassing ``StageUnavailableError``
+    keeps the existing dispatch guards' behavior — fail this one request and
+    keep the server serving — while letting callers distinguish "lost owner"
+    from ordinary "no replica available".
+    """
+
+
 @dataclass
 class _ReplicaMetrics:
     """Per-replica metrics accumulators owned by a stage pool."""
@@ -83,6 +96,13 @@ class StagePool:
     In non-distributed mode (no hub attached), :meth:`pick` falls back to the
     legacy ``select_replica_id`` round-robin path so the multi-stage
     in-process invocation is unchanged.
+
+    Session affinity: callers that own long-lived worker-local state (realtime
+    AR-Diffusion sessions) pass a ``session_id`` to the dispatch entry points.
+    The first tick picks a replica with the ordinary load-balancing policy and
+    binds the session to it; every later tick for that session is routed back
+    to the owning replica until :meth:`release_session` runs. Requests without
+    a ``session_id`` are routed exactly as before.
 
     Dynamic replica membership: when a remote replica is added or removed
     (driven by :class:`Orchestrator` via :meth:`add_client` /
@@ -140,6 +160,23 @@ class StagePool:
         # Kept separate from the legacy ``_request_bindings`` so the two
         # binding shapes do not collide.
         self._affinity: dict[str, str] = {}
+
+        # ``session_id`` → replica route for long-lived stateful sessions
+        # (e.g. realtime AR-Diffusion ticks). Deliberately a third pair of
+        # maps rather than a reuse of the request-scoped ones above: a session
+        # outlives every individual request bound to it, is keyed in its own
+        # namespace so a session_id can never collide with a request_id, and
+        # is released explicitly on reset/close instead of on request
+        # completion. Same split as above — replica_id locally, input_addr in
+        # distributed mode, where replica_id is not stable across the hub.
+        self._session_bindings: dict[str, int] = {}
+        self._session_affinity: dict[str, str] = {}
+        # Sessions whose owner replica died. The route row is dropped eagerly
+        # so nothing points at a dead replica, but the id is remembered so the
+        # next tick still fails closed instead of silently landing on a replica
+        # that holds none of the session's state. Cleared only by an explicit
+        # release_session(), i.e. session reset/close.
+        self._lost_sessions: set[str] = set()
 
     # ---- Stage-level properties ----
 
@@ -296,6 +333,7 @@ class StagePool:
         task: Task | None = None,
         *,
         affinity_request_id: str | None = None,
+        session_id: str | None = None,
     ) -> int:
         """Return a replica id for ``request_id``.
 
@@ -306,9 +344,23 @@ class StagePool:
 
         In non-distributed (legacy) mode: delegates to
         :meth:`select_replica_id`.
+
+        When ``session_id`` is given, an existing session route wins over every
+        other policy, and a fresh pick binds the session to the chosen replica.
         """
         if self._hub is None or self._lb is None:
-            return self.select_replica_id(request_id, affinity_request_id=affinity_request_id)
+            return self.select_replica_id(
+                request_id,
+                affinity_request_id=affinity_request_id,
+                session_id=session_id,
+            )
+
+        # 0. Session-sticky: the owner of this session's state wins outright.
+        if session_id is not None:
+            owner_replica_id = self._resolve_session_replica_id(session_id)
+            if owner_replica_id is not None:
+                self._affinity[request_id] = self._session_affinity[session_id]
+                return owner_replica_id
 
         # 1. Sticky: previously bound and still serviceable?
         bound_addr = self._affinity.get(request_id)
@@ -338,6 +390,8 @@ class StagePool:
                 lb_idx = self._lb.select(task, [rep for rep, _ in candidates])
                 replica_info, replica_id = candidates[lb_idx]
                 self._affinity[request_id] = replica_info.input_addr
+                if session_id is not None:
+                    self.bind_session(session_id, replica_id)
                 return replica_id
 
             now = _time.monotonic()
@@ -346,6 +400,15 @@ class StagePool:
                     f"no UP replica for stage {self.stage_id} after {self.DISPATCH_WAIT_TIMEOUT_S:.1f}s"
                 )
             await asyncio.sleep(min(self.DISPATCH_RETRY_INTERVAL_S, deadline - now))
+            # The sleep above is the only suspension point between the session
+            # lookup at step 0 and the bind below, so it is also the only place
+            # a concurrent first tick for the same session could have installed
+            # an owner. Re-resolve rather than racing it to the bind.
+            if session_id is not None:
+                owner_replica_id = self._resolve_session_replica_id(session_id)
+                if owner_replica_id is not None:
+                    self._affinity[request_id] = self._session_affinity[session_id]
+                    return owner_replica_id
 
     def preselect_replica_id(
         self,
@@ -353,6 +416,7 @@ class StagePool:
         task: Task | None = None,
         *,
         affinity_request_id: str | None = None,
+        session_id: str | None = None,
     ) -> int | None:
         """Synchronously pick and bind a replica before request preprocessing.
 
@@ -365,7 +429,17 @@ class StagePool:
         submit-time router wait without blocking the caller.
         """
         if self._hub is None or self._lb is None:
-            return self.select_replica_id(request_id, affinity_request_id=affinity_request_id)
+            return self.select_replica_id(
+                request_id,
+                affinity_request_id=affinity_request_id,
+                session_id=session_id,
+            )
+
+        if session_id is not None:
+            owner_replica_id = self._resolve_session_replica_id(session_id)
+            if owner_replica_id is not None:
+                self._affinity[request_id] = self._session_affinity[session_id]
+                return owner_replica_id
 
         bound_addr = self._affinity.get(request_id)
         if bound_addr is not None:
@@ -390,6 +464,8 @@ class StagePool:
         lb_idx = self._lb.select(task, [rep for rep, _ in candidates])
         replica_info, replica_id = candidates[lb_idx]
         self._affinity[request_id] = replica_info.input_addr
+        if session_id is not None:
+            self.bind_session(session_id, replica_id)
         return replica_id
 
     def _collect_serviceable_replicas(self) -> list[tuple[ReplicaInfo, int]]:
@@ -431,11 +507,139 @@ class StagePool:
         self._affinity.pop(request_id, None)
         self.release_binding(request_id)
 
+    # ---- Session affinity (long-lived stateful sessions) ----
+
+    def has_session(self, session_id: str) -> bool:
+        """True iff ``session_id`` has ever acquired an owner and not been released.
+
+        Includes sessions whose owner has since died, so callers can tell
+        "never bound" (route freely) apart from "owner lost" (fail closed).
+        """
+        return (
+            session_id in self._session_bindings
+            or session_id in self._session_affinity
+            or session_id in self._lost_sessions
+        )
+
+    def get_session_replica_id(self, session_id: str) -> int | None:
+        """Return the replica owning ``session_id``, or ``None`` if unusable.
+
+        ``None`` covers both "no binding" and "the bound replica is gone or
+        DOWN"; use :meth:`has_session` to distinguish them.
+        """
+        if self._hub is not None:
+            input_addr = self._session_affinity.get(session_id)
+            if input_addr is None:
+                return None
+            return self._serviceable_replica_id_for_addr(input_addr)
+
+        replica_id = self._session_bindings.get(session_id)
+        if replica_id is None:
+            return None
+        if not self.is_replica_available(replica_id) or self.clients[replica_id] is None:
+            return None
+        return replica_id
+
+    def bind_session(self, session_id: str, replica_id: int) -> None:
+        """Pin ``session_id`` to ``replica_id`` for the rest of its lifetime."""
+        if not 0 <= replica_id < self.num_replicas:
+            raise ValueError(f"stage {self.stage_id} has no replica {replica_id} to bind session {session_id!r} to")
+
+        if self._hub is None:
+            self._session_bindings[session_id] = replica_id
+            self._lost_sessions.discard(session_id)
+            return
+
+        # Distributed mode keys on the address, never the slot index: a slot
+        # can be reused by a different replica after remove/add, which would
+        # silently re-point the session at a worker holding none of its state.
+        client = self.clients[replica_id]
+        input_addr = None if client is None else self._client_input_addr(client)
+        if input_addr is None:
+            raise ValueError(
+                f"stage {self.stage_id} replica {replica_id} advertises no input address; "
+                f"session {session_id!r} cannot be pinned to it"
+            )
+        self._session_affinity[session_id] = input_addr
+        self._lost_sessions.discard(session_id)
+
+    def release_session(self, session_id: str) -> None:
+        """Drop the route for ``session_id``; idempotent.
+
+        Called on session reset/close, and the only thing that clears a
+        lost-owner tombstone. Only the routing entry is dropped here —
+        releasing the worker-local state itself is the session lifecycle's job.
+        """
+        self._session_bindings.pop(session_id, None)
+        self._session_affinity.pop(session_id, None)
+        self._lost_sessions.discard(session_id)
+
+    def session_ids_for_replica(self, replica_id: int) -> list[str]:
+        """Return the sessions currently owned by ``replica_id``."""
+        owned = [sid for sid, bound in self._session_bindings.items() if bound == replica_id]
+        owned.extend(
+            sid
+            for sid, input_addr in self._session_affinity.items()
+            if self._addr_to_replica_id.get(input_addr) == replica_id
+        )
+        return list(dict.fromkeys(owned))
+
+    def orphan_replica_sessions(self, replica_id: int) -> list[str]:
+        """Tombstone every session owned by ``replica_id``; return their ids.
+
+        The route row is dropped so nothing points at the dead replica, but the
+        session stays known-lost: every later tick for it fails closed with
+        :class:`SessionOwnerLostError` rather than silently landing on a
+        replica that holds none of its state. Call sites are replica eviction
+        and hub-driven address invalidation.
+        """
+        orphaned = self.session_ids_for_replica(replica_id)
+        for session_id in orphaned:
+            self._session_bindings.pop(session_id, None)
+            self._session_affinity.pop(session_id, None)
+            self._lost_sessions.add(session_id)
+        if orphaned:
+            logger.warning(
+                "[StagePool] stage %s replica %s died owning %d live session(s); "
+                "their ticks will fail until the sessions are reset or closed: %s",
+                self.stage_id,
+                replica_id,
+                len(orphaned),
+                orphaned,
+            )
+        return orphaned
+
+    def _resolve_session_replica_id(self, session_id: str) -> int | None:
+        """Return the owner replica for ``session_id``, failing closed if lost.
+
+        Returns ``None`` only for a session that has never been placed, which
+        is the caller's signal to run the ordinary load-balancing policy.
+        """
+        replica_id = self.get_session_replica_id(session_id)
+        if replica_id is not None:
+            return replica_id
+        if self.has_session(session_id):
+            # Bound before, but the owner is not serviceable now. Tombstone it
+            # so the session cannot be resurrected against fresh, empty state
+            # by this or any later tick, and surface a distinguishable failure.
+            self._session_bindings.pop(session_id, None)
+            self._session_affinity.pop(session_id, None)
+            self._lost_sessions.add(session_id)
+            raise SessionOwnerLostError(
+                f"stage {self.stage_id}: the replica owning session {session_id!r} is no longer available; "
+                "its worker-local state is not recoverable in this version. "
+                "Reset or close the session to release the route."
+            )
+        return None
+
     def invalidate_addr(self, input_addr: str) -> list[str]:
         """Drop affinity rows pointing at ``input_addr``; return affected request ids."""
         affected: list[str] = [rid for rid, addr in self._affinity.items() if addr == input_addr]
         for rid in affected:
             self._affinity.pop(rid, None)
+        replica_id = self._addr_to_replica_id.get(input_addr)
+        if replica_id is not None:
+            self.orphan_replica_sessions(replica_id)
         return affected
 
     # ---- Legacy (non-distributed) route binding ----
@@ -534,6 +738,7 @@ class StagePool:
         """Evict a failed replica from admission and release its bindings."""
         if 0 <= replica_id < self.num_replicas:
             self._unavailable_replicas.add(replica_id)
+        self.orphan_replica_sessions(replica_id)
         return self.release_replica_bindings(replica_id)
 
     def is_replica_available(self, replica_id: int) -> bool:
@@ -551,8 +756,15 @@ class StagePool:
         request_id: str,
         *,
         affinity_request_id: str | None = None,
+        session_id: str | None = None,
     ) -> int:
         """Pick a replica id for *request_id* and cache the choice (legacy path)."""
+        if session_id is not None:
+            owner_replica_id = self._resolve_session_replica_id(session_id)
+            if owner_replica_id is not None:
+                self._request_bindings[request_id] = owner_replica_id
+                return owner_replica_id
+
         cached = self.get_bound_replica_id(request_id)
         if cached is not None and self.clients[cached] is not None and self.is_replica_available(cached):
             return cached
@@ -580,6 +792,8 @@ class StagePool:
                 self._next_replica_id = (self._next_replica_id + 1) % len(live)
 
         self._request_bindings[request_id] = chosen
+        if session_id is not None:
+            self.bind_session(session_id, chosen)
         return chosen
 
     def _llm_client(self, replica_id: int) -> StagePoolLLMClient:
@@ -947,10 +1161,15 @@ class StagePool:
         *,
         prompt_text: Any = None,
         affinity_request_id: str | None = None,
+        session_id: str | None = None,
         submit_kwargs: dict[str, Any] | None = None,
         params_override: Any = None,
     ) -> int:
-        """Submit a stage-entry request into this pool."""
+        """Submit a stage-entry request into this pool.
+
+        ``session_id`` pins this request to the replica owning that session's
+        persistent state; see the session-affinity note on :class:`StagePool`.
+        """
         params = params_override if params_override is not None else req_state.sampling_params_list[self.stage_id]
         # Direct engine callers may provide plain vLLM SamplingParams.
         if self.stage_type == "diffusion":
@@ -965,6 +1184,7 @@ class StagePool:
             replica_id = await self._pick_or_select(
                 request_id,
                 affinity_request_id=affinity_request_id,
+                session_id=session_id,
             )
             client = self._diffusion_client(replica_id)
             await client.add_request_async(request_id, request, params, **submit_kwargs)
@@ -973,6 +1193,7 @@ class StagePool:
         replica_id = await self._pick_or_select(
             request_id,
             affinity_request_id=affinity_request_id,
+            session_id=session_id,
         )
         client = self.clients[replica_id]
         if client is None:
@@ -1085,11 +1306,20 @@ class StagePool:
         request_id: str,
         *,
         affinity_request_id: str | None = None,
+        session_id: str | None = None,
     ) -> int:
         """Bridge to ``pick`` in distributed mode or ``select_replica_id`` legacy."""
         if self.is_distributed:
-            return await self.pick(request_id, affinity_request_id=affinity_request_id)
-        return self.select_replica_id(request_id, affinity_request_id=affinity_request_id)
+            return await self.pick(
+                request_id,
+                affinity_request_id=affinity_request_id,
+                session_id=session_id,
+            )
+        return self.select_replica_id(
+            request_id,
+            affinity_request_id=affinity_request_id,
+            session_id=session_id,
+        )
 
     # ---- Stage-local polling ----
 

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -467,6 +467,7 @@ class AsyncOmni(EngineClient, OmniBase):
         reasoning_ended: bool | None = None,
         reasoning_parser_kwargs: dict[str, Any] | None = None,
         arrival_time: float | None = None,
+        session_id: str | None = None,
     ) -> AsyncGenerator[OmniRequestOutput, None]:
         """Generate outputs for the given prompt(s) asynchronously.
 
@@ -490,6 +491,12 @@ class AsyncOmni(EngineClient, OmniBase):
                 Must have the same length as the number of stages.
                 If *None*, uses default sampling params for each stage.
             output_modalities: Optional list of output modalities.
+            session_id: Optional routing key for long-lived stateful
+                workloads. Every request carrying the same ``session_id`` is
+                routed to the replica that owns that session's persistent
+                worker-local state; the first one is placed by the ordinary
+                load-balancing policy. Release it with
+                :meth:`release_session_affinity` when the session ends.
 
         Yields:
             OmniRequestOutput objects as they are produced by each stage.
@@ -609,6 +616,7 @@ class AsyncOmni(EngineClient, OmniBase):
                     final_output_stage_ids=final_output_stage_ids,
                     arrival_time=wall_start_ts,
                     lora_request=lora_request,
+                    session_id=session_id,
                 )
             submit_ts = time.time()
             req_state.metrics.stage_first_ts[0] = submit_ts
@@ -1028,6 +1036,20 @@ class AsyncOmni(EngineClient, OmniBase):
         # aborted. This is also what happens in this case in vLLM's output processor.
         internal_ids = [s.request_id for s in self.request_states.values() if s.external_request_id in request_ids]
         await self._abort(internal_ids)
+
+    def release_session_affinity(
+        self,
+        session_id: str,
+        *,
+        stage_ids: Sequence[int] | None = None,
+    ) -> None:
+        """Drop the replica route pinned to ``session_id``; idempotent.
+
+        See :meth:`generate` for how a session acquires a route. Call this
+        once the session's worker-local state has been released, so the id is
+        free to be placed again.
+        """
+        self.engine.release_session_affinity(session_id, stage_ids=stage_ids)
 
     async def submit_interaction_async(
         self,

--- a/vllm_omni/experimental/ar_diffusion/consumer.py
+++ b/vllm_omni/experimental/ar_diffusion/consumer.py
@@ -31,7 +31,10 @@ class ARDiffusionGenerateClient(Protocol):
         request_id: str,
         sampling_params_list: Sequence[OmniSamplingParams],
         output_modalities: list[str] | None = None,
+        session_id: str | None = None,
     ) -> AsyncIterator[OmniRequestOutput]: ...
+
+    def release_session_affinity(self, session_id: str, *, stage_ids: Sequence[int] | None = None) -> None: ...
 
 
 def _metadata_mapping(output: OmniRequestOutput) -> Mapping[str, Any]:
@@ -111,12 +114,6 @@ class ARDiffusionOmniTickConsumer:
         replica_count = getattr(stage_pools[diffusion_stage_id], "num_replicas", None)
         if isinstance(replica_count, bool) or not isinstance(replica_count, int) or replica_count < 1:
             raise ValueError("The selected AR-Diffusion stage must expose a positive num_replicas.")
-        if replica_count != 1:
-            raise ValueError(
-                "AR-Diffusion realtime sessions currently require exactly one "
-                "replica for the selected diffusion stage; session-affine "
-                f"routing is not implemented (got num_replicas={replica_count})."
-            )
         self._engine_client = engine_client
         self._prompt_provider = prompt_provider
         self._sampling_params_templates = templates
@@ -139,11 +136,15 @@ class ARDiffusionOmniTickConsumer:
     async def execute_tick(self, tick: ARDiffusionTickRequest) -> OmniRequestOutput:
         prompt = self._prompt_provider(tick)
         final_output: OmniRequestOutput | None = None
+        # Passing session_id pins every tick of this session to the replica
+        # holding its persistent AR state; the first tick is placed by the
+        # stage's ordinary load-balancing policy.
         async for output in self._engine_client.generate(
             prompt,
             request_id=tick.request_id,
             sampling_params_list=self._sampling_params_for_tick(tick),
             output_modalities=self._output_modalities,
+            session_id=tick.session_id,
         ):
             if output.stage_id != self._diffusion_stage_id:
                 continue
@@ -166,3 +167,13 @@ class ARDiffusionOmniTickConsumer:
 
     def chunk_metadata(self, output: OmniRequestOutput) -> ARDiffusionChunkMetadata:
         return _parse_chunk_metadata(output)
+
+    def release_session_route(self, session_id: str) -> None:
+        """Free the replica route pinned to ``session_id``; idempotent.
+
+        Wire this as the lifecycle's ``route_release`` so that a reset session
+        is re-placed by the load balancer and a closed one leaves no affinity
+        entry behind. Scoped to the diffusion stage this consumer submits to,
+        which is the only stage whose route it owns.
+        """
+        self._engine_client.release_session_affinity(session_id, stage_ids=[self._diffusion_stage_id])

--- a/vllm_omni/experimental/ar_diffusion/session.py
+++ b/vllm_omni/experimental/ar_diffusion/session.py
@@ -15,11 +15,15 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Generic, Protocol, TypeVar
 
+from vllm.logger import init_logger
+
 from vllm_omni.experimental.ar_diffusion.tick_protocol import (
     ARDiffusionChunkMetadata,
     ARDiffusionControlInput,
     ARDiffusionTickRequest,
 )
+
+logger = init_logger(__name__)
 
 
 class ARDiffusionSessionError(RuntimeError):
@@ -191,6 +195,11 @@ class ARDiffusionWorkerLifecycle:
     session's replica affinity (see ``StagePool.release_session``). It runs
     last, and only on success: a session whose worker state could not be
     released must stay pinned to the replica still holding it.
+
+    It is optional only for backwards compatibility. ``StagePool.release_session``
+    is the only path that drops a binding, so a lifecycle built without the hook
+    leaves one entry per session behind for the life of the process; construction
+    warns in that case.
     """
 
     def __init__(
@@ -210,6 +219,17 @@ class ARDiffusionWorkerLifecycle:
         self._stage_ids = normalized_stage_ids
         self._timeout = timeout
         self._route_release = route_release
+        if route_release is None:
+            # Releasing the worker state does not release the replica route:
+            # StagePool.release_session is the only path that drops a binding.
+            # Without this hook a closed session keeps its affinity entry
+            # forever, so the table grows with every session the server sees.
+            logger.warning(
+                "ARDiffusionWorkerLifecycle was built without route_release, so "
+                "reset/close will not free the session's replica affinity. Pass "
+                "ARDiffusionOmniTickConsumer.release_session_route to keep the "
+                "StagePool session table bounded on a replicated stage."
+            )
 
     async def _invoke(self, method: str, session_id: str) -> None:
         results = await self._rpc_client.collective_rpc(

--- a/vllm_omni/experimental/ar_diffusion/session.py
+++ b/vllm_omni/experimental/ar_diffusion/session.py
@@ -180,7 +180,18 @@ def _collect_rpc_support_results(value: Any, *, errors: list[str], supported: li
 
 
 class ARDiffusionWorkerLifecycle:
-    """Routes reset/close through the existing orchestrator collective RPC."""
+    """Routes reset/close through the existing orchestrator collective RPC.
+
+    The RPC fans out to every live replica of the selected stages and the
+    worker-side release is idempotent for unknown session ids, so a replicated
+    stage is cleaned up correctly without the caller knowing which replica
+    owned the session.
+
+    ``route_release`` is invoked after a successful reset/close to drop the
+    session's replica affinity (see ``StagePool.release_session``). It runs
+    last, and only on success: a session whose worker state could not be
+    released must stay pinned to the replica still holding it.
+    """
 
     def __init__(
         self,
@@ -188,6 +199,7 @@ class ARDiffusionWorkerLifecycle:
         *,
         stage_ids: Sequence[int],
         timeout: float | None = None,
+        route_release: Callable[[str], None] | None = None,
     ) -> None:
         normalized_stage_ids = tuple(stage_ids)
         if not normalized_stage_ids:
@@ -197,6 +209,7 @@ class ARDiffusionWorkerLifecycle:
         self._rpc_client = rpc_client
         self._stage_ids = normalized_stage_ids
         self._timeout = timeout
+        self._route_release = route_release
 
     async def _invoke(self, method: str, session_id: str) -> None:
         results = await self._rpc_client.collective_rpc(
@@ -213,11 +226,19 @@ class ARDiffusionWorkerLifecycle:
         if not supported or not all(supported):
             raise ARDiffusionSessionError(f"{method} is not supported by every selected worker.")
 
+    def _release_route(self, session_id: str) -> None:
+        if self._route_release is not None:
+            self._route_release(session_id)
+
     async def reset_session(self, session_id: str) -> None:
         await self._invoke("reset_ar_diffusion_session", session_id)
+        # Every replica has now dropped this session's state, so the next tick
+        # is free to be re-placed by the ordinary load-balancing policy.
+        self._release_route(session_id)
 
     async def close_session(self, session_id: str) -> None:
         await self._invoke("close_ar_diffusion_session", session_id)
+        self._release_route(session_id)
 
 
 def _default_request_id(session_id: str, chunk_index: int) -> str:


### PR DESCRIPTION
## Purpose

Phase 0 of [RFC #6226](https://github.com/vllm-project/vllm-omni/issues/6226): keep every tick of a live realtime AR-Diffusion session on the replica that owns its worker-local state, so the AR stage can be replicated for Replica-DP scaling.

#5491 landed the realtime tick/session path but pinned the AR stage to exactly one replica, because session state is worker-local while `StagePool` routing is request-oriented:

```python
# vllm_omni/experimental/ar_diffusion/consumer.py (before)
if replica_count != 1:
    raise ValueError(
        "AR-Diffusion realtime sessions currently require exactly one "
        "replica for the selected diffusion stage; session-affine "
        f"routing is not implemented (got num_replicas={replica_count})."
    )
```

This PR implements that routing and lifts the restriction.

## Design

`StagePool` gains a session-scoped route alongside its existing request-scoped ones (`_request_bindings` / `_affinity`):

```text
bind_session(session_id, replica_id)
get_session_replica_id(session_id) -> replica_id | None
release_session(session_id)
session_ids_for_replica(replica_id)
orphan_replica_sessions(replica_id)
```

The first tick of a session is placed by the stage's existing load-balancing policy and binds the session; every later tick routes back to the owner. `session_id` is threaded from `AsyncOmni.generate()` through `StageSubmissionMessage` and `submit_initial()` into **both** dispatch paths — distributed `pick()` and legacy `select_replica_id()`.

Requests that pass no `session_id` route exactly as before; this is covered by a test.

Sessions are kept in their own key namespace rather than reusing the request-scoped maps: a session outlives every request bound to it, is released on reset/close instead of on request completion, and must not be able to collide with a `request_id`.

### Failure semantics: fail-closed

Session state is neither migrated nor rebuilt in this version. If the owning replica dies, the route row is dropped (nothing points at a dead replica) and the session is **tombstoned**, so later ticks raise `SessionOwnerLostError` rather than silently landing on a replica that holds none of its state — which would corrupt the rollout without any error surfacing.

`SessionOwnerLostError` subclasses `StageUnavailableError`, so the orchestrator's existing dispatch guard fails just that one request and keeps the server serving. Only an explicit reset/close clears the tombstone.

This answers open questions 2 and 5 in the RFC with the conservative option; an explicit rebind/rebuild hook can be layered on later.

### Lifecycle

Reset and close release the route through `ARDiffusionWorkerLifecycle`, **after** the worker RPC succeeds — a session whose state could not be released must stay pinned to the replica still holding it. That RPC already fans out to every live replica via `Orchestrator._handle_collective_rpc`, and the worker-side release is idempotent for unknown session ids (`self._sessions.pop(session_id, None)`), so replicated cleanup is correct without the caller tracking placement.

### Concurrency

The RFC requires that concurrent first ticks for one session cannot create two owners. In `pick()` the fast path from the session lookup to the bind contains no `await`, so it is atomic with respect to the event loop. The bounded retry loop (entered only when no replica is serviceable) is the one suspension point, so the session is re-resolved after each sleep instead of racing to the bind. Covered by a test that parks eight concurrent first ticks and then brings replicas up.

## Out of scope

Per the RFC's Phase 0 boundary: state migration between replicas, CPU/NVMe offload, byte-budget admission control, EDF/SLO scheduling, recompute-aware placement, session fork / CoW placement, and PP/Stream-Batch scheduling changes.

## Test Plan

New `tests/engine/test_stage_pool_session_affinity.py` (CPU, no GPU required) covers:

- ticks of one session stay on the owner replica, on both dispatch paths;
- new sessions are still spread by the existing load-balancing policy;
- stateless routing is unchanged, and stateless requests still reach every replica while a session is pinned;
- release on reset/close leaves no entry, is idempotent, and allows re-placement;
- lost owner fails closed, and keeps failing until the session is explicitly released;
- `invalidate_addr` / `mark_replica_unavailable` orphan only that replica's sessions;
- unrelated sessions are unaffected by a replica death;
- concurrent first ticks converge on a single owner.

`tests/diffusion/ar_diffusion/test_consumer.py` is updated: the old "rejects replicated stage" test becomes "accepts replicated stage", plus new coverage that the tick carries its `session_id` and that the route release is scoped to the consumer's diffusion stage.

`tests/engine/test_orchestrator.py` pins the plumbing in between, which nothing else exercised: the stage behavior is covered directly and the consumer is covered with fakes, but the `session_id` hop from `StageSubmissionMessage` through the orchestrator into `submit_initial` was untested. The new test runs real `StagePool`s with two replicas and asserts that a second tick of the same session lands on the owner where round-robin alone would have moved it, that a request without a `session_id` still load-balances, and that release frees the id. I verified it fails (`assert None == 0`) when the orchestrator stops forwarding `msg.session_id`.

`tests/diffusion/ar_diffusion/test_session.py` covers `route_release` itself, which also had no test: it runs after a successful reset/close, and does **not** run when the RPC fails.

## Known limitations

Stating these up front rather than leaving them to be found:

1. **A lifecycle built without `route_release` leaks routing entries.** `StagePool.release_session` is the only path that drops a binding, and it only runs through that hook. The hook is optional for backwards compatibility, so a caller that omits it leaves one entry per session behind for the process lifetime, keyed by a client-supplied session id. The only in-tree wiring (the LingBot realtime example) passes it; construction now warns when it is missing. Making it required would be the stricter fix and I am happy to switch if that is preferred.
2. **Lost-owner tombstones are unbounded.** `_lost_sessions` is cleared only by an explicit reset/close, which is what makes the fail-closed guarantee hold — a client that disappears after its owner died leaves a tombstone behind. Bounding it means choosing an expiry policy, which felt like it belonged with the residency/byte-accounting work in #4480 rather than here.
3. **Worker-side LRU eviction is invisible to the routing table.** `ARDiffusionModelRunner` can evict a session (`reason="lru_eviction"`) without the engine side releasing its binding, so the next tick routes to a replica that no longer holds the state. This is pre-existing rather than a regression — the same tick fails the chunk-contiguity check at one replica — and re-placing would not help, since no replica holds that state either. A worker→engine eviction notification would be the real fix.

## Test Result

Local, all CPU-only:

| file | result |
| --- | --- |
| `tests/engine/test_stage_pool_session_affinity.py` | 18 passed |
| `tests/diffusion/ar_diffusion/` | 148 passed |
| `tests/engine/test_orchestrator.py` + the above | 218 passed |

`ruff check` and `ruff format --check` clean on all touched files.

I do not have a GPU-capable environment for this branch, so I have not run the full Buildkite suite locally — the changed dispatch paths are exercised by the CPU tests above. Happy to iterate on anything CI surfaces.

Related: #6226 (this RFC), #6227 (umbrella realtime serving RFC), #5491 (consumer), #4707 (replica routing infrastructure), #4480 (future session residency/byte accounting).

cc @hsliuustc0106 @Gaohan123 @Jack47

