### PR TITLE
[Doc] Document ROCm validation on AMD gfx1151 (Strix Halo)

### DIFF
--- a/docs/getting_started/installation/gpu/rocm.inc.md
+++ b/docs/getting_started/installation/gpu/rocm.inc.md
@@ -1,6 +1,6 @@
 # --8<-- [start:requirements]
 
-- GPU: Validated on gfx942 (It should be supported on the AMD GPUs that are supported by vLLM.)
+- GPU: Validated on gfx942 and gfx1151 (AMD Ryzen AI Max / Strix Halo).
 
 # --8<-- [end:requirements]
 # --8<-- [start:set-up-using-python]
@@ -109,6 +109,28 @@ docker run --rm -it \
 --entrypoint bash \
 vllm-omni-rocm
 ```
+
+#### gfx1151
+
+For gfx1151, set `VLLM_ROCM_USE_AITER=0` before running vLLM-Omni. When using
+Docker, pass the setting into the container:
+
+```bash
+docker run --rm \
+  --group-add=video \
+  --ipc=host \
+  --cap-add=SYS_PTRACE \
+  --security-opt seccomp=unconfined \
+  --device /dev/kfd \
+  --device /dev/dri \
+  --env VLLM_ROCM_USE_AITER=0 \
+  -p 8091:8091 \
+  vllm-omni-rocm \
+  --model <model> --port 8091
+```
+
+gfx1151 systems use unified memory. Adjust the VRAM allocation and
+`gpu_memory_utilization` settings for the memory available on the system.
 
 # --8<-- [end:build-docker]
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

- document gfx1151 (AMD Ryzen AI Max / Strix Halo) as a validated ROCm GPU
- document `VLLM_ROCM_USE_AITER=0` for running vLLM-Omni on gfx1151
- note that unified-memory systems may require VRAM and `gpu_memory_utilization` tuning

## Test Plan

Test environment:

- Hardware: AMD Ryzen AI Max+ 395 / Radeon 8060S (`gfx1151`), with 128 GiB unified memory configured as 96 GiB VRAM and 32 GiB system memory
- ROCm: 7.2.x
- Container runtime: Podman 4.9.3 with crun 1.14.1
- Model: `thomasip/Qwen3-Omni-30B-A3B-Instruct-GPTQ-4bit`
- Runtime: `VLLM_ROCM_USE_AITER=0`, Triton linear backend, and eager execution for all stages

The image was built with:

```bash
podman build \
  -f docker/Dockerfile.rocm \
  --target test \
  --build-arg ARG_PYTORCH_ROCM_ARCH=gfx1151 \
  -t vllm-omni-rocm:gfx1151 .
```

The service was started with:

```bash
MODEL_DIR=/path/to/Qwen3-Omni-30B-A3B-Instruct-GPTQ-4bit
CRUN=/path/to/crun-1.14.1
STAGE_OVERRIDES='{
  "0":{"devices":"0","gpu_memory_utilization":0.42,"max_num_seqs":4,"max_num_batched_tokens":4096,"max_model_len":4096,"enforce_eager":true},
  "1":{"devices":"0","gpu_memory_utilization":0.14,"max_num_seqs":4,"max_num_batched_tokens":4096,"max_model_len":4096,"enforce_eager":true,"hf_overrides":{"quantization_config":null}},
  "2":{"devices":"0","gpu_memory_utilization":0.06,"max_num_seqs":4,"max_num_batched_tokens":8192,"max_model_len":8192,"enforce_eager":true,"hf_overrides":{"quantization_config":null}}
}'

podman --runtime="${CRUN}" run -d \
  --name vllm-omni-gfx1151 \
  --network=host \
  --ipc=host \
  --device=/dev/kfd \
  --device=/dev/dri \
  --group-add keep-groups \
  --security-opt=label=disable \
  -e VLLM_ROCM_USE_AITER=0 \
  -e HF_HUB_OFFLINE=1 \
  -e TRANSFORMERS_OFFLINE=1 \
  -e PYTHONUNBUFFERED=1 \
  -v "${MODEL_DIR}:/models/qwen3-omni:ro" \
  vllm-omni-rocm:gfx1151 \
  vllm-omni serve /models/qwen3-omni \
  --omni \
  --host 127.0.0.1 \
  --port 8091 \
  --served-model-name qwen3-omni-gptq \
  --linear-backend triton \
  --stage-init-timeout 900 \
  --init-timeout 1800 \
  --stage-overrides "${STAGE_OVERRIDES}"
```

**vLLM Version:** 0.27.0

**vLLM-Omni Commit:** `baba7d1e`

## Test Result

The server health endpoint returned HTTP 200 before the benchmarks. Peak observed VRAM usage was 69.56 GiB.

### Text benchmark

Each workload used 20 requests with fixed 512-token inputs and 128-token outputs.

| Metric | Concurrency 1 | Concurrency 4 |
|---|---:|---:|
| Successful requests | 20/20 | 20/20 |
| Request throughput | 0.241 req/s | 0.378 req/s |
| Output throughput | 30.90 tok/s | 48.35 tok/s |
| Mean E2E latency | 4.14 s | 10.59 s |
| Mean TTFT | 327.65 ms | 855.78 ms |
| Mean TPOT | 30.04 ms | 76.62 ms |

### Multimodal validation

| Input/output path | Successful requests | Mean latency | P95 latency |
|---|---:|---:|---:|
| Image → text | 3/3 | 1.077 s | 1.100 s |
| Audio → text | 3/3 | 0.354 s | 0.370 s |
| Video → text | 3/3 | 0.744 s | 0.753 s |
| Image + audio + video → text | 3/3 | 1.768 s | 1.775 s |
| Text → text + audio | 5/5 | 15.302 s | 32.822 s |
| Image → text + audio | 3/3 | 28.807 s | 32.904 s |

All 40 text requests and all 20 multimodal requests completed successfully.

