### PR TITLE
[Perf] Enable async schedule for MOSS-TTS

### DIFF
--- a/tests/entrypoints/openai_api/test_tts_adapter.py
+++ b/tests/entrypoints/openai_api/test_tts_adapter.py
@@ -22,6 +22,10 @@ from vllm_omni.entrypoints.openai.tts_adapters.indextts2 import (
     IndexTTS25Adapter,
     indextts2_conditioning_cache_salt,
 )
+from vllm_omni.entrypoints.openai.tts_adapters.moss_tts import (
+    MossTTSAdapter,
+    MossTTSNanoAdapter,
+)
 from vllm_omni.entrypoints.openai.tts_adapters.qwen3_tts import Qwen3TTSAdapter
 from vllm_omni.model_executor.models.indextts2 import prompt_utils
 from vllm_omni.model_executor.models.indextts2.tokenizer_v2_5 import (
@@ -92,6 +96,20 @@ def test_all_adapters_are_ar_or_diffusion():
     for cls in TTS_ADAPTER_REGISTRY.values():
         assert issubclass(cls, (ARTTSAdapter, DiffusionTTSAdapter))
         assert cls.backend in ("ar", "diffusion")
+
+
+@pytest.mark.parametrize("adapter_cls", [MossTTSAdapter, MossTTSNanoAdapter])
+def test_moss_tts_applies_request_max_new_tokens(adapter_cls):
+    adapter = adapter_cls(SimpleNamespace(server=object()))
+    stage_defaults = [SimpleNamespace(max_tokens=4096)]
+
+    overridden = adapter.apply_sampling_overrides(
+        stage_defaults,
+        SimpleNamespace(max_new_tokens=512),
+    )
+
+    assert overridden[0].max_tokens == 512
+    assert stage_defaults[0].max_tokens == 4096
 
 
 def test_qwen3_tts_metadata():

--- a/tests/model_executor/models/moss_tts/test_compact_topk.py
+++ b/tests/model_executor/models/moss_tts/test_compact_topk.py
@@ -10,8 +10,7 @@ from vllm_omni.model_executor.models.moss_tts import modeling_moss_tts_local
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.tts]
 
 
-def test_compact_topk_only_samples_retained_candidates(monkeypatch) -> None:
-    monkeypatch.setattr(modeling_moss_tts_local, "_USE_COMPACT_TOPK", True)
+def test_compact_topk_only_samples_retained_candidates() -> None:
     logits = torch.randn(32, 1024, generator=torch.Generator().manual_seed(7))
 
     sampled = modeling_moss_tts_local._sample_token(
@@ -27,8 +26,7 @@ def test_compact_topk_only_samples_retained_candidates(monkeypatch) -> None:
     assert torch.all((retained == sampled.unsqueeze(-1)).any(dim=-1))
 
 
-def test_compact_topk_tiny_nucleus_selects_argmax(monkeypatch) -> None:
-    monkeypatch.setattr(modeling_moss_tts_local, "_USE_COMPACT_TOPK", True)
+def test_compact_topk_tiny_nucleus_selects_argmax() -> None:
     logits = torch.randn(32, 1024, generator=torch.Generator().manual_seed(17))
 
     sampled = modeling_moss_tts_local._sample_token(
@@ -38,64 +36,6 @@ def test_compact_topk_tiny_nucleus_selects_argmax(monkeypatch) -> None:
         top_p=1e-9,
         do_sample=True,
         generator=torch.Generator().manual_seed(42),
-    )
-
-    torch.testing.assert_close(sampled, logits.argmax(dim=-1))
-
-
-def test_compact_topk_is_repeatable_for_its_own_seed(monkeypatch) -> None:
-    monkeypatch.setattr(modeling_moss_tts_local, "_USE_COMPACT_TOPK", True)
-    logits = torch.randn(64, 1024, generator=torch.Generator().manual_seed(23))
-
-    def sample() -> torch.Tensor:
-        return modeling_moss_tts_local._sample_token(
-            logits,
-            temperature=1.7,
-            top_k=25,
-            top_p=0.8,
-            do_sample=True,
-            generator=torch.Generator().manual_seed(42),
-        )
-
-    torch.testing.assert_close(sample(), sample())
-
-
-@pytest.mark.parametrize("top_k", [0, 1024, 2048])
-def test_compact_toggle_does_not_change_non_compact_cases(monkeypatch, top_k: int) -> None:
-    logits = torch.randn(32, 1024, generator=torch.Generator().manual_seed(31))
-
-    monkeypatch.setattr(modeling_moss_tts_local, "_USE_COMPACT_TOPK", False)
-    expected = modeling_moss_tts_local._sample_token(
-        logits,
-        temperature=1.7,
-        top_k=top_k,
-        top_p=0.8,
-        do_sample=True,
-        generator=torch.Generator().manual_seed(42),
-    )
-    monkeypatch.setattr(modeling_moss_tts_local, "_USE_COMPACT_TOPK", True)
-    actual = modeling_moss_tts_local._sample_token(
-        logits,
-        temperature=1.7,
-        top_k=top_k,
-        top_p=0.8,
-        do_sample=True,
-        generator=torch.Generator().manual_seed(42),
-    )
-
-    torch.testing.assert_close(actual, expected)
-
-
-def test_compact_toggle_does_not_change_greedy_sampling(monkeypatch) -> None:
-    monkeypatch.setattr(modeling_moss_tts_local, "_USE_COMPACT_TOPK", True)
-    logits = torch.randn(32, 1024, generator=torch.Generator().manual_seed(37))
-
-    sampled = modeling_moss_tts_local._sample_token(
-        logits,
-        temperature=1.7,
-        top_k=25,
-        top_p=0.8,
-        do_sample=False,
     )
 
     torch.testing.assert_close(sampled, logits.argmax(dim=-1))

--- a/tests/model_executor/models/moss_tts/test_compact_topk.py
+++ b/tests/model_executor/models/moss_tts/test_compact_topk.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU regression tests for MOSS-TTS compact top-k sampling."""
+
+import pytest
+import torch
+
+from vllm_omni.model_executor.models.moss_tts import modeling_moss_tts_local
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.tts]
+
+
+def test_compact_topk_only_samples_retained_candidates(monkeypatch) -> None:
+    monkeypatch.setattr(modeling_moss_tts_local, "_USE_COMPACT_TOPK", True)
+    logits = torch.randn(32, 1024, generator=torch.Generator().manual_seed(7))
+
+    sampled = modeling_moss_tts_local._sample_token(
+        logits,
+        temperature=1.7,
+        top_k=25,
+        top_p=0.8,
+        do_sample=True,
+        generator=torch.Generator().manual_seed(42),
+    )
+
+    retained = logits.topk(25, dim=-1).indices
+    assert torch.all((retained == sampled.unsqueeze(-1)).any(dim=-1))
+
+
+def test_compact_topk_tiny_nucleus_selects_argmax(monkeypatch) -> None:
+    monkeypatch.setattr(modeling_moss_tts_local, "_USE_COMPACT_TOPK", True)
+    logits = torch.randn(32, 1024, generator=torch.Generator().manual_seed(17))
+
+    sampled = modeling_moss_tts_local._sample_token(
+        logits,
+        temperature=1.7,
+        top_k=25,
+        top_p=1e-9,
+        do_sample=True,
+        generator=torch.Generator().manual_seed(42),
+    )
+
+    torch.testing.assert_close(sampled, logits.argmax(dim=-1))
+
+
+def test_compact_topk_is_repeatable_for_its_own_seed(monkeypatch) -> None:
+    monkeypatch.setattr(modeling_moss_tts_local, "_USE_COMPACT_TOPK", True)
+    logits = torch.randn(64, 1024, generator=torch.Generator().manual_seed(23))
+
+    def sample() -> torch.Tensor:
+        return modeling_moss_tts_local._sample_token(
+            logits,
+            temperature=1.7,
+            top_k=25,
+            top_p=0.8,
+            do_sample=True,
+            generator=torch.Generator().manual_seed(42),
+        )
+
+    torch.testing.assert_close(sample(), sample())
+
+
+@pytest.mark.parametrize("top_k", [0, 1024, 2048])
+def test_compact_toggle_does_not_change_non_compact_cases(monkeypatch, top_k: int) -> None:
+    logits = torch.randn(32, 1024, generator=torch.Generator().manual_seed(31))
+
+    monkeypatch.setattr(modeling_moss_tts_local, "_USE_COMPACT_TOPK", False)
+    expected = modeling_moss_tts_local._sample_token(
+        logits,
+        temperature=1.7,
+        top_k=top_k,
+        top_p=0.8,
+        do_sample=True,
+        generator=torch.Generator().manual_seed(42),
+    )
+    monkeypatch.setattr(modeling_moss_tts_local, "_USE_COMPACT_TOPK", True)
+    actual = modeling_moss_tts_local._sample_token(
+        logits,
+        temperature=1.7,
+        top_k=top_k,
+        top_p=0.8,
+        do_sample=True,
+        generator=torch.Generator().manual_seed(42),
+    )
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_compact_toggle_does_not_change_greedy_sampling(monkeypatch) -> None:
+    monkeypatch.setattr(modeling_moss_tts_local, "_USE_COMPACT_TOPK", True)
+    logits = torch.randn(32, 1024, generator=torch.Generator().manual_seed(37))
+
+    sampled = modeling_moss_tts_local._sample_token(
+        logits,
+        temperature=1.7,
+        top_k=25,
+        top_p=0.8,
+        do_sample=False,
+    )
+
+    torch.testing.assert_close(sampled, logits.argmax(dim=-1))

--- a/tests/model_executor/models/moss_tts/test_local_depth_rope_cache.py
+++ b/tests/model_executor/models/moss_tts/test_local_depth_rope_cache.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU parity tests for MOSS-TTS Local Depth RoPE caching."""
+
+import pytest
+import torch
+from transformers import GPT2Config
+
+from vllm_omni.model_executor.models.moss_tts.modeling_moss_tts_local_depth import (
+    MossTTSLocalDepthTransformer,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.tts]
+
+
+def _test_config() -> GPT2Config:
+    return GPT2Config(
+        n_embd=32,
+        n_head=4,
+        n_inner=64,
+        layer_norm_epsilon=1e-6,
+        rope_base=10000.0,
+    )
+
+
+def test_rope_cache_matches_reference_and_reuses_storage() -> None:
+    model = MossTTSLocalDepthTransformer(_test_config()).eval()
+    attn = model.h[0].attn
+    device = torch.device("cpu")
+
+    attn.prepare_rope_cache(12, device, torch.float32)
+    cache_ptr = attn._rope_cos_cache.data_ptr()
+    cos, sin = attn._rope_cos_sin(4, device, torch.float32)
+
+    positions = torch.arange(4, dtype=torch.float32)
+    freqs = torch.einsum("s,d->sd", positions, attn.inv_freq.float())
+    expected_cos = freqs.cos().repeat_interleave(2, dim=-1).view(1, 4, 1, attn.head_dim)
+    expected_sin = freqs.sin().repeat_interleave(2, dim=-1).view(1, 4, 1, attn.head_dim)
+    torch.testing.assert_close(cos, expected_cos)
+    torch.testing.assert_close(sin, expected_sin)
+
+    # Smaller slices retain the fixed allocation used by CUDA Graph.
+    attn.prepare_rope_cache(6, device, torch.float32)
+    assert attn._rope_cos_cache.data_ptr() == cache_ptr
+
+
+def test_rope_cache_disabled_matches_uncached_values(monkeypatch) -> None:
+    monkeypatch.setenv("MOSS_TTS_LOCAL_DEPTH_ROPE_CACHE", "0")
+    model = MossTTSLocalDepthTransformer(_test_config()).eval()
+    attn = model.h[0].attn
+
+    cos, sin = attn._rope_cos_sin(4, torch.device("cpu"), torch.float32)
+    positions = torch.arange(4, dtype=torch.float32)
+    freqs = torch.einsum("s,d->sd", positions, attn.inv_freq.float())
+
+    assert attn._rope_cos_cache.numel() == 0
+    torch.testing.assert_close(cos[0, :, 0], freqs.cos().repeat_interleave(2, dim=-1))
+    torch.testing.assert_close(sin[0, :, 0], freqs.sin().repeat_interleave(2, dim=-1))

--- a/tests/model_executor/models/moss_tts/test_local_depth_rope_cache.py
+++ b/tests/model_executor/models/moss_tts/test_local_depth_rope_cache.py
@@ -42,17 +42,3 @@ def test_rope_cache_matches_reference_and_reuses_storage() -> None:
     # Smaller slices retain the fixed allocation used by CUDA Graph.
     attn.prepare_rope_cache(6, device, torch.float32)
     assert attn._rope_cos_cache.data_ptr() == cache_ptr
-
-
-def test_rope_cache_disabled_matches_uncached_values(monkeypatch) -> None:
-    monkeypatch.setenv("MOSS_TTS_LOCAL_DEPTH_ROPE_CACHE", "0")
-    model = MossTTSLocalDepthTransformer(_test_config()).eval()
-    attn = model.h[0].attn
-
-    cos, sin = attn._rope_cos_sin(4, torch.device("cpu"), torch.float32)
-    positions = torch.arange(4, dtype=torch.float32)
-    freqs = torch.einsum("s,d->sd", positions, attn.inv_freq.float())
-
-    assert attn._rope_cos_cache.numel() == 0
-    torch.testing.assert_close(cos[0, :, 0], freqs.cos().repeat_interleave(2, dim=-1))
-    torch.testing.assert_close(sin[0, :, 0], freqs.sin().repeat_interleave(2, dim=-1))

--- a/tests/model_executor/models/moss_tts/test_talker_logits_processor.py
+++ b/tests/model_executor/models/moss_tts/test_talker_logits_processor.py
@@ -23,6 +23,11 @@ class _RecordingLogitsProcessor:
         return torch.zeros((1, 4))
 
 
+class _EmbeddingBackbone(nn.Module):
+    def embed_tokens(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return input_ids.to(dtype=torch.float32).unsqueeze(-1).repeat(1, 4)
+
+
 def test_moss_tts_delay_compute_logits_does_not_forward_sampling_metadata() -> None:
     from vllm_omni.model_executor.models.moss_tts.modeling_moss_tts_talker import (
         MossTTSDelayTalkerForGeneration,
@@ -76,6 +81,70 @@ def test_moss_tts_local_keeps_fixed_shape_pad_rows_for_cpu_filtering() -> None:
     # talker2codec raw async-chunk processor drops all-pad rows on CPU.
     torch.testing.assert_close(audio[1], stopped)
     assert model._batch_should_continue.tolist() == [True, False]
+
+
+def test_moss_tts_local_fixed_rows_drive_mixed_batch_stop_logits() -> None:
+    from vllm_omni.model_executor.models.moss_tts.modeling_moss_tts_talker import (
+        MossTTSLocalTalkerForGeneration,
+    )
+
+    model = MossTTSLocalTalkerForGeneration.__new__(MossTTSLocalTalkerForGeneration)
+    nn.Module.__init__(model)
+    model.audio_pad_token_id = 1024
+    model.audio_assistant_slot_token_id = 2
+    model.im_end_token_id = 3
+    model.text_vocab_size = 8
+    model.n_vq = 4
+    model._batch_state = None
+    model._batch_state_spans = None
+    model._batch_should_continue = None
+
+    valid = torch.tensor([[1, 2, 3, 4]], dtype=torch.long)
+    stopped = torch.full((1, 4), model.audio_pad_token_id, dtype=torch.long)
+    infos = [
+        {"audio_state": {}, "audio_codes": {"current": valid}},
+        {"audio_state": {}, "audio_codes": {"current": stopped}},
+    ]
+    spans = [(0, 3), (3, 4)]
+
+    model.make_omni_output(
+        torch.randn(4, 8),
+        model_intermediate_buffer=infos,
+        request_token_spans=spans,
+    )
+    logits = model.compute_logits(torch.randn(4, 8))
+
+    assert logits is not None
+    assert logits.argmax(dim=-1).tolist() == [2, 2, 2, 3]
+
+
+def test_moss_tts_local_single_token_prefill_does_not_advance_audio() -> None:
+    from vllm_omni.model_executor.models.moss_tts.modeling_moss_tts_talker import (
+        MossTTSLocalTalkerForGeneration,
+    )
+
+    model = MossTTSLocalTalkerForGeneration.__new__(MossTTSLocalTalkerForGeneration)
+    nn.Module.__init__(model)
+    model.model = _EmbeddingBackbone()
+    model.max_audio_frames = 3
+    model.n_vq = 4
+
+    input_ids = torch.tensor([7], dtype=torch.long)
+    _, embeds, update = model.preprocess(
+        input_ids,
+        None,
+        _omni_is_prefill=True,
+        audio_state={"is_stopping": False, "step": 2, "max_new_frames": 3},
+        max_new_frames=[3],
+        ref_offset=5,
+    )
+
+    torch.testing.assert_close(embeds, torch.full((1, 4), 7.0))
+    assert update == {
+        "audio_state": {"is_stopping": False, "step": 0, "max_new_frames": 3},
+        "ref_offset": 6,
+    }
+    assert "mtp_inputs" not in update
 
 
 def test_moss_tts_local_audio_frame_budget_clamps_request_and_forces_stop() -> None:

--- a/tests/model_executor/models/moss_tts/test_talker_logits_processor.py
+++ b/tests/model_executor/models/moss_tts/test_talker_logits_processor.py
@@ -41,3 +41,75 @@ def test_moss_tts_delay_compute_logits_does_not_forward_sampling_metadata() -> N
     assert logits.shape == (1, 4)
     assert model.logits_processor.args == (model.text_lm_head, hidden_states)
     assert model.logits_processor.kwargs == {}
+
+
+def test_moss_tts_local_keeps_fixed_shape_pad_rows_for_cpu_filtering() -> None:
+    from vllm_omni.model_executor.models.moss_tts.modeling_moss_tts_talker import (
+        MossTTSLocalTalkerForGeneration,
+    )
+
+    model = MossTTSLocalTalkerForGeneration.__new__(MossTTSLocalTalkerForGeneration)
+    nn.Module.__init__(model)
+    model.audio_pad_token_id = 1024
+    model.n_vq = 4
+    model._batch_state = None
+    model._batch_state_spans = None
+    model._batch_should_continue = None
+
+    valid = torch.tensor([[1, 2, 3, 4]], dtype=torch.long)
+    stopped = torch.full((1, 4), model.audio_pad_token_id, dtype=torch.long)
+    infos = [
+        {"audio_state": {}, "audio_codes": {"current": valid}},
+        {"audio_state": {}, "audio_codes": {"current": stopped}},
+    ]
+
+    output = model.make_omni_output(
+        torch.randn(2, 8),
+        model_intermediate_buffer=infos,
+        request_token_spans=[(0, 1), (1, 2)],
+    )
+
+    audio = output.multimodal_outputs["codes"]["audio"]
+    assert len(audio) == 2
+    torch.testing.assert_close(audio[0], valid)
+    # Keeping this row avoids CUDA boolean-index shape discovery; the
+    # talker2codec raw async-chunk processor drops all-pad rows on CPU.
+    torch.testing.assert_close(audio[1], stopped)
+    assert model._batch_should_continue.tolist() == [True, False]
+
+
+def test_moss_tts_local_audio_frame_budget_clamps_request_and_forces_stop() -> None:
+    from vllm_omni.model_executor.models.moss_tts.modeling_moss_tts_talker import (
+        MossTTSLocalTalkerForGeneration,
+    )
+
+    model = MossTTSLocalTalkerForGeneration.__new__(MossTTSLocalTalkerForGeneration)
+    nn.Module.__init__(model)
+    model.max_audio_frames = 3
+
+    state = model._new_audio_state({"max_new_frames": [4096]})
+    assert state == {
+        "is_stopping": False,
+        "step": 0,
+        "max_new_frames": 3,
+    }
+    assert [model._advance_audio_frame_budget(state) for _ in range(4)] == [True, True, True, False]
+    assert state["step"] == 3
+    assert state["is_stopping"] is True
+    assert state["stop_reason"] == "max_new_frames"
+
+
+def test_moss_tts_local_audio_frame_budget_honors_smaller_request_limit() -> None:
+    from vllm_omni.model_executor.models.moss_tts.modeling_moss_tts_talker import (
+        MossTTSLocalTalkerForGeneration,
+    )
+
+    model = MossTTSLocalTalkerForGeneration.__new__(MossTTSLocalTalkerForGeneration)
+    nn.Module.__init__(model)
+    model.max_audio_frames = 512
+
+    assert model._new_audio_state({"max_new_frames": [128]})["max_new_frames"] == 128
+    assert model._new_audio_state({})["max_new_frames"] == 512
+
+    model.max_audio_frames = 0
+    assert model._new_audio_state({})["max_new_frames"] == 0

--- a/tests/model_executor/models/moss_tts/test_talker_logits_processor.py
+++ b/tests/model_executor/models/moss_tts/test_talker_logits_processor.py
@@ -48,42 +48,7 @@ def test_moss_tts_delay_compute_logits_does_not_forward_sampling_metadata() -> N
     assert model.logits_processor.kwargs == {}
 
 
-def test_moss_tts_local_keeps_fixed_shape_pad_rows_for_cpu_filtering() -> None:
-    from vllm_omni.model_executor.models.moss_tts.modeling_moss_tts_talker import (
-        MossTTSLocalTalkerForGeneration,
-    )
-
-    model = MossTTSLocalTalkerForGeneration.__new__(MossTTSLocalTalkerForGeneration)
-    nn.Module.__init__(model)
-    model.audio_pad_token_id = 1024
-    model.n_vq = 4
-    model._batch_state = None
-    model._batch_state_spans = None
-    model._batch_should_continue = None
-
-    valid = torch.tensor([[1, 2, 3, 4]], dtype=torch.long)
-    stopped = torch.full((1, 4), model.audio_pad_token_id, dtype=torch.long)
-    infos = [
-        {"audio_state": {}, "audio_codes": {"current": valid}},
-        {"audio_state": {}, "audio_codes": {"current": stopped}},
-    ]
-
-    output = model.make_omni_output(
-        torch.randn(2, 8),
-        model_intermediate_buffer=infos,
-        request_token_spans=[(0, 1), (1, 2)],
-    )
-
-    audio = output.multimodal_outputs["codes"]["audio"]
-    assert len(audio) == 2
-    torch.testing.assert_close(audio[0], valid)
-    # Keeping this row avoids CUDA boolean-index shape discovery; the
-    # talker2codec raw async-chunk processor drops all-pad rows on CPU.
-    torch.testing.assert_close(audio[1], stopped)
-    assert model._batch_should_continue.tolist() == [True, False]
-
-
-def test_moss_tts_local_fixed_rows_drive_mixed_batch_stop_logits() -> None:
+def test_moss_tts_local_keeps_fixed_shape_rows_and_routes_stop_logits() -> None:
     from vllm_omni.model_executor.models.moss_tts.modeling_moss_tts_talker import (
         MossTTSLocalTalkerForGeneration,
     )
@@ -107,11 +72,20 @@ def test_moss_tts_local_fixed_rows_drive_mixed_batch_stop_logits() -> None:
     ]
     spans = [(0, 3), (3, 4)]
 
-    model.make_omni_output(
+    output = model.make_omni_output(
         torch.randn(4, 8),
         model_intermediate_buffer=infos,
         request_token_spans=spans,
     )
+
+    audio = output.multimodal_outputs["codes"]["audio"]
+    assert len(audio) == 2
+    torch.testing.assert_close(audio[0], valid)
+    # Keeping this row avoids CUDA boolean-index shape discovery; the
+    # talker2codec raw async-chunk processor drops all-pad rows on CPU.
+    torch.testing.assert_close(audio[1], stopped)
+    assert model._batch_should_continue.tolist() == [True, False]
+
     logits = model.compute_logits(torch.randn(4, 8))
 
     assert logits is not None
@@ -126,7 +100,6 @@ def test_moss_tts_local_single_token_prefill_does_not_advance_audio() -> None:
     model = MossTTSLocalTalkerForGeneration.__new__(MossTTSLocalTalkerForGeneration)
     nn.Module.__init__(model)
     model.model = _EmbeddingBackbone()
-    model.max_audio_frames = 3
     model.n_vq = 4
 
     input_ids = torch.tensor([7], dtype=torch.long)
@@ -134,51 +107,13 @@ def test_moss_tts_local_single_token_prefill_does_not_advance_audio() -> None:
         input_ids,
         None,
         _omni_is_prefill=True,
-        audio_state={"is_stopping": False, "step": 2, "max_new_frames": 3},
-        max_new_frames=[3],
+        audio_state={"is_stopping": True},
         ref_offset=5,
     )
 
     torch.testing.assert_close(embeds, torch.full((1, 4), 7.0))
     assert update == {
-        "audio_state": {"is_stopping": False, "step": 0, "max_new_frames": 3},
+        "audio_state": {"is_stopping": False},
         "ref_offset": 6,
     }
     assert "mtp_inputs" not in update
-
-
-def test_moss_tts_local_audio_frame_budget_clamps_request_and_forces_stop() -> None:
-    from vllm_omni.model_executor.models.moss_tts.modeling_moss_tts_talker import (
-        MossTTSLocalTalkerForGeneration,
-    )
-
-    model = MossTTSLocalTalkerForGeneration.__new__(MossTTSLocalTalkerForGeneration)
-    nn.Module.__init__(model)
-    model.max_audio_frames = 3
-
-    state = model._new_audio_state({"max_new_frames": [4096]})
-    assert state == {
-        "is_stopping": False,
-        "step": 0,
-        "max_new_frames": 3,
-    }
-    assert [model._advance_audio_frame_budget(state) for _ in range(4)] == [True, True, True, False]
-    assert state["step"] == 3
-    assert state["is_stopping"] is True
-    assert state["stop_reason"] == "max_new_frames"
-
-
-def test_moss_tts_local_audio_frame_budget_honors_smaller_request_limit() -> None:
-    from vllm_omni.model_executor.models.moss_tts.modeling_moss_tts_talker import (
-        MossTTSLocalTalkerForGeneration,
-    )
-
-    model = MossTTSLocalTalkerForGeneration.__new__(MossTTSLocalTalkerForGeneration)
-    nn.Module.__init__(model)
-    model.max_audio_frames = 512
-
-    assert model._new_audio_state({"max_new_frames": [128]})["max_new_frames"] == 128
-    assert model._new_audio_state({})["max_new_frames"] == 512
-
-    model.max_audio_frames = 0
-    assert model._new_audio_state({})["max_new_frames"] == 0

--- a/vllm_omni/deploy/moss_tts_local.yaml
+++ b/vllm_omni/deploy/moss_tts_local.yaml
@@ -3,11 +3,6 @@
 # Codec: OpenMOSS-Team/MOSS-Audio-Tokenizer-v2 (48 kHz, stereo, channel-interleaved RVQ)
 # Uses a 1-layer GPT2-style local depth transformer (no delay warm-up), reset every
 # frame — same per-frame timing (80 ms/frame, 12.5 fps) as MOSS-TTS-Realtime.
-# Optional process-level tuning:
-# - MOSS_TTS_LOCAL_DEPTH_COMPACT_TOPK=1 keeps top-p/softmax/multinomial at width
-#   top_k. It improves high-concurrency throughput but is not seed/bit equivalent.
-# - MOSS_TTS_LOCAL_DEPTH_ROPE_CACHE=0 disables the exact, default-on RoPE cache.
-# - MOSS_TTS_LOCAL_MAX_AUDIO_FRAMES=0 disables the default 512-frame safety cap.
 async_chunk: true
 
 connectors:

--- a/vllm_omni/deploy/moss_tts_local.yaml
+++ b/vllm_omni/deploy/moss_tts_local.yaml
@@ -3,6 +3,11 @@
 # Codec: OpenMOSS-Team/MOSS-Audio-Tokenizer-v2 (48 kHz, stereo, channel-interleaved RVQ)
 # Uses a 1-layer GPT2-style local depth transformer (no delay warm-up), reset every
 # frame — same per-frame timing (80 ms/frame, 12.5 fps) as MOSS-TTS-Realtime.
+# Optional process-level tuning:
+# - MOSS_TTS_LOCAL_DEPTH_COMPACT_TOPK=1 keeps top-p/softmax/multinomial at width
+#   top_k. It improves high-concurrency throughput but is not seed/bit equivalent.
+# - MOSS_TTS_LOCAL_DEPTH_ROPE_CACHE=0 disables the exact, default-on RoPE cache.
+# - MOSS_TTS_LOCAL_MAX_AUDIO_FRAMES=0 disables the default 512-frame safety cap.
 async_chunk: true
 
 connectors:

--- a/vllm_omni/entrypoints/openai/tts_adapters/moss_tts.py
+++ b/vllm_omni/entrypoints/openai/tts_adapters/moss_tts.py
@@ -10,7 +10,12 @@ from typing import TYPE_CHECKING
 from vllm.inputs import tokens_input
 
 from vllm_omni.entrypoints.openai.tts_adapters import register_tts_adapter
-from vllm_omni.entrypoints.openai.tts_adapters.base import ARTTSAdapter, PreparedRequest, conditioning_cache_salt
+from vllm_omni.entrypoints.openai.tts_adapters.base import (
+    ARTTSAdapter,
+    PreparedRequest,
+    apply_max_new_tokens,
+    conditioning_cache_salt,
+)
 
 if TYPE_CHECKING:
     from vllm_omni.entrypoints.openai.protocol.audio import OpenAICreateSpeechRequest
@@ -103,6 +108,15 @@ class _MossTTSAdapterBase(ARTTSAdapter):
         prompt["additional_information"] = tts_params
         prompt["cache_salt"] = conditioning_cache_salt(request, tts_params)
         return PreparedRequest(prompt=prompt, tts_params=tts_params, model_type=self.name)
+
+    def apply_sampling_overrides(
+        self,
+        sampling_params_list: list,
+        request: "OpenAICreateSpeechRequest",
+        prompt: dict | None = None,
+        request_id: str | None = None,
+    ) -> list:
+        return apply_max_new_tokens(sampling_params_list, request)
 
 
 @register_tts_adapter

--- a/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_local.py
+++ b/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_local.py
@@ -23,8 +23,6 @@ previous KV-cache loop -- causal attention, only the last position is read.
 
 from __future__ import annotations
 
-import os
-
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -35,8 +33,6 @@ from vllm_omni.model_executor.models.common.qwen3_code_predictor import (
 from vllm_omni.model_executor.models.moss_tts.configuration_moss_tts import (
     MossTTSLocalTransformerConfig,
 )
-
-_USE_COMPACT_TOPK = os.getenv("MOSS_TTS_LOCAL_DEPTH_COMPACT_TOPK", "0") == "1"
 
 
 class MossTTSRealtimeLocalTransformer(nn.Module):
@@ -134,9 +130,9 @@ def _sample_token(
 ) -> torch.Tensor:
     """Top-k + top-p sampling for the upstream inference branch.
 
-    The compact path evaluates nucleus filtering and multinomial sampling only
-    on the retained top-k candidates, then maps the result back to the original
-    vocabulary. It preserves the categorical distribution when the top-k
+    Nucleus filtering and multinomial sampling operate only on the retained
+    top-k candidates before the result is mapped back to the original
+    vocabulary. This preserves the categorical distribution when the top-k
     boundary has no ties, but it is not seed/bit equivalent to multinomial over
     a full-vocabulary tensor because random-number mapping depends on width.
     """
@@ -147,32 +143,24 @@ def _sample_token(
     compact_indices = None
     if top_k and top_k > 0 and top_k < logits.shape[-1]:
         top_vals, top_indices = torch.topk(logits, top_k, dim=-1, sorted=True)
-        if _USE_COMPACT_TOPK:
-            # topk is already descending: keep the following nucleus filter,
-            # softmax, and multinomial at width k instead of the full vocab.
-            logits = top_vals
-            compact_indices = top_indices
-        else:
-            thresh = top_vals[..., -1:].expand_as(logits)
-            logits = torch.where(logits < thresh, torch.full_like(logits, float("-inf")), logits)
+        # topk is already descending: keep the following nucleus filter,
+        # softmax, and multinomial at width k instead of the full vocab.
+        logits = top_vals
+        compact_indices = top_indices
 
     if 0.0 < top_p < 1.0:
+        sorted_indices = None
         if compact_indices is None:
-            sorted_logits, sorted_idx = torch.sort(logits, descending=True, dim=-1)
-        else:
-            sorted_logits = logits
-            sorted_idx = None
-        probs = F.softmax(sorted_logits, dim=-1)
+            logits, sorted_indices = torch.sort(logits, descending=True, dim=-1)
+        probs = F.softmax(logits, dim=-1)
         cum = probs.cumsum(dim=-1)
         # Drop tail beyond top_p (keep at least one token).
         drop = cum > top_p
         drop[..., 1:] = drop[..., :-1].clone()
         drop[..., 0] = False
-        sorted_logits = sorted_logits.masked_fill(drop, float("-inf"))
-        if sorted_idx is None:
-            logits = sorted_logits
-        else:
-            logits = torch.full_like(logits, float("-inf")).scatter_(-1, sorted_idx, sorted_logits)
+        logits = logits.masked_fill(drop, float("-inf"))
+        if sorted_indices is not None:
+            logits = torch.full_like(logits, float("-inf")).scatter_(-1, sorted_indices, logits)
 
     probs = F.softmax(logits, dim=-1)
     flat = probs.reshape(-1, probs.shape[-1])

--- a/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_local.py
+++ b/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_local.py
@@ -23,6 +23,8 @@ previous KV-cache loop -- causal attention, only the last position is read.
 
 from __future__ import annotations
 
+import os
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -33,6 +35,8 @@ from vllm_omni.model_executor.models.common.qwen3_code_predictor import (
 from vllm_omni.model_executor.models.moss_tts.configuration_moss_tts import (
     MossTTSLocalTransformerConfig,
 )
+
+_USE_COMPACT_TOPK = os.getenv("MOSS_TTS_LOCAL_DEPTH_COMPACT_TOPK", "0") == "1"
 
 
 class MossTTSRealtimeLocalTransformer(nn.Module):
@@ -128,20 +132,36 @@ def _sample_token(
     do_sample: bool,
     generator: torch.Generator | None = None,
 ) -> torch.Tensor:
-    """Top-k + top-p sampling (matches upstream's ``sample_token`` for the
-    inference branch).
+    """Top-k + top-p sampling for the upstream inference branch.
+
+    The compact path evaluates nucleus filtering and multinomial sampling only
+    on the retained top-k candidates, then maps the result back to the original
+    vocabulary. It preserves the categorical distribution when the top-k
+    boundary has no ties, but it is not seed/bit equivalent to multinomial over
+    a full-vocabulary tensor because random-number mapping depends on width.
     """
     if not do_sample or temperature <= 0:
         return logits.argmax(dim=-1)
 
     logits = logits / max(temperature, 1e-6)
+    compact_indices = None
     if top_k and top_k > 0 and top_k < logits.shape[-1]:
-        top_vals, _ = torch.topk(logits, top_k, dim=-1)
-        thresh = top_vals[..., -1:].expand_as(logits)
-        logits = torch.where(logits < thresh, torch.full_like(logits, float("-inf")), logits)
+        top_vals, top_indices = torch.topk(logits, top_k, dim=-1, sorted=True)
+        if _USE_COMPACT_TOPK:
+            # topk is already descending: keep the following nucleus filter,
+            # softmax, and multinomial at width k instead of the full vocab.
+            logits = top_vals
+            compact_indices = top_indices
+        else:
+            thresh = top_vals[..., -1:].expand_as(logits)
+            logits = torch.where(logits < thresh, torch.full_like(logits, float("-inf")), logits)
 
     if 0.0 < top_p < 1.0:
-        sorted_logits, sorted_idx = torch.sort(logits, descending=True, dim=-1)
+        if compact_indices is None:
+            sorted_logits, sorted_idx = torch.sort(logits, descending=True, dim=-1)
+        else:
+            sorted_logits = logits
+            sorted_idx = None
         probs = F.softmax(sorted_logits, dim=-1)
         cum = probs.cumsum(dim=-1)
         # Drop tail beyond top_p (keep at least one token).
@@ -149,11 +169,16 @@ def _sample_token(
         drop[..., 1:] = drop[..., :-1].clone()
         drop[..., 0] = False
         sorted_logits = sorted_logits.masked_fill(drop, float("-inf"))
-        logits = torch.full_like(logits, float("-inf")).scatter_(-1, sorted_idx, sorted_logits)
+        if sorted_idx is None:
+            logits = sorted_logits
+        else:
+            logits = torch.full_like(logits, float("-inf")).scatter_(-1, sorted_idx, sorted_logits)
 
     probs = F.softmax(logits, dim=-1)
     flat = probs.reshape(-1, probs.shape[-1])
     sampled = torch.multinomial(flat, num_samples=1, generator=generator).reshape(probs.shape[:-1])
+    if compact_indices is not None:
+        return compact_indices.gather(-1, sampled.unsqueeze(-1)).squeeze(-1)
     return sampled
 
 

--- a/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_local_depth.py
+++ b/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_local_depth.py
@@ -19,6 +19,8 @@ checkpoint 1:1 so ``load_weights()`` needs no remapping.
 
 from __future__ import annotations
 
+import os
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -52,10 +54,51 @@ class _MossTTSLocalAttention(nn.Module):
         self.c_proj = nn.Linear(hidden_size, hidden_size, bias=True)
         inv_freq = 1.0 / (rope_base ** (torch.arange(0, self.head_dim, 2, dtype=torch.float32) / self.head_dim))
         self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.register_buffer("_rope_cos_cache", torch.empty(0), persistent=False)
+        self.register_buffer("_rope_sin_cache", torch.empty(0), persistent=False)
+        self.use_rope_cache = os.getenv("MOSS_TTS_LOCAL_DEPTH_ROPE_CACHE", "1") != "0"
+
+    def prepare_rope_cache(
+        self,
+        max_seq_len: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> None:
+        """Materialize frame-local RoPE values once per device/dtype.
+
+        Local Depth positions always restart at zero and never exceed the
+        number of RVQ codebooks (12 for MOSS-TTS Local v1.5).  Building
+        arange/einsum/cos/sin inside every one of the 12 depth steps creates
+        many tiny kernels and also bloats the enclosing talker CUDA graph.
+        Keep one non-persistent cache and slice it for prefix execution.
+        """
+        if not self.use_rope_cache or max_seq_len <= 0:
+            return
+        cache = self._rope_cos_cache
+        if cache.numel() > 0 and cache.device == device and cache.dtype == dtype and int(cache.shape[1]) >= max_seq_len:
+            return
+
+        position_ids = torch.arange(max_seq_len, device=device, dtype=torch.float32)
+        inv_freq = self.inv_freq.to(device=device, dtype=torch.float32)
+        freqs = torch.einsum("s,d->sd", position_ids, inv_freq)
+        cos = freqs.cos().repeat_interleave(2, dim=-1).to(dtype)
+        sin = freqs.sin().repeat_interleave(2, dim=-1).to(dtype)
+        self._rope_cos_cache = cos.view(1, max_seq_len, 1, self.head_dim)
+        self._rope_sin_cache = sin.view(1, max_seq_len, 1, self.head_dim)
 
     def _rope_cos_sin(
-        self, seq_len: int, device: torch.device, dtype: torch.dtype
+        self,
+        seq_len: int,
+        device: torch.device,
+        dtype: torch.dtype,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.use_rope_cache:
+            self.prepare_rope_cache(seq_len, device, dtype)
+            return (
+                self._rope_cos_cache[:, :seq_len],
+                self._rope_sin_cache[:, :seq_len],
+            )
+
         position_ids = torch.arange(seq_len, device=device, dtype=torch.float32)
         freqs = torch.einsum("s,d->sd", position_ids, self.inv_freq.to(device=device))
         cos = freqs.cos().repeat_interleave(2, dim=-1).to(dtype)
@@ -200,9 +243,15 @@ class MossTTSLocalDepthTransformer(nn.Module):
         batch_size = backbone_last_hidden.shape[0]
         dtype = self.ln_f.weight.dtype
 
+        # Populate the complete [0, n_vq) table before torch.compile traces
+        # _forward_prefix or the runner captures talker_mtp.  The compiled /
+        # captured body then contains only fixed-address cache slices rather
+        # than cache construction or buffer replacement.
+        for block in self.h:
+            block.attn.prepare_rope_cache(n_vq, backbone_last_hidden.device, dtype)
+
         embeds = backbone_last_hidden.new_zeros((batch_size, n_vq, self.hidden_size), dtype=dtype)
         embeds[:, 0, :] = backbone_last_hidden.to(dtype)
-
         hidden = self._run_prefix(embeds[:, :1, :])
         local_hidden = hidden[:, 0, :]
 

--- a/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_local_depth.py
+++ b/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_local_depth.py
@@ -19,8 +19,6 @@ checkpoint 1:1 so ``load_weights()`` needs no remapping.
 
 from __future__ import annotations
 
-import os
-
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -56,7 +54,6 @@ class _MossTTSLocalAttention(nn.Module):
         self.register_buffer("inv_freq", inv_freq, persistent=False)
         self.register_buffer("_rope_cos_cache", torch.empty(0), persistent=False)
         self.register_buffer("_rope_sin_cache", torch.empty(0), persistent=False)
-        self.use_rope_cache = os.getenv("MOSS_TTS_LOCAL_DEPTH_ROPE_CACHE", "1") != "0"
 
     def prepare_rope_cache(
         self,
@@ -72,7 +69,7 @@ class _MossTTSLocalAttention(nn.Module):
         many tiny kernels and also bloats the enclosing talker CUDA graph.
         Keep one non-persistent cache and slice it for prefix execution.
         """
-        if not self.use_rope_cache or max_seq_len <= 0:
+        if max_seq_len <= 0:
             return
         cache = self._rope_cos_cache
         if cache.numel() > 0 and cache.device == device and cache.dtype == dtype and int(cache.shape[1]) >= max_seq_len:
@@ -92,18 +89,11 @@ class _MossTTSLocalAttention(nn.Module):
         device: torch.device,
         dtype: torch.dtype,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if self.use_rope_cache:
-            self.prepare_rope_cache(seq_len, device, dtype)
-            return (
-                self._rope_cos_cache[:, :seq_len],
-                self._rope_sin_cache[:, :seq_len],
-            )
-
-        position_ids = torch.arange(seq_len, device=device, dtype=torch.float32)
-        freqs = torch.einsum("s,d->sd", position_ids, self.inv_freq.to(device=device))
-        cos = freqs.cos().repeat_interleave(2, dim=-1).to(dtype)
-        sin = freqs.sin().repeat_interleave(2, dim=-1).to(dtype)
-        return cos.view(1, seq_len, 1, self.head_dim), sin.view(1, seq_len, 1, self.head_dim)
+        self.prepare_rope_cache(seq_len, device, dtype)
+        return (
+            self._rope_cos_cache[:, :seq_len],
+            self._rope_sin_cache[:, :seq_len],
+        )
 
     @staticmethod
     def _rotate_half(x: torch.Tensor) -> torch.Tensor:

--- a/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_talker.py
+++ b/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_talker.py
@@ -6,7 +6,8 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import Iterable, Sequence
+import os
+from collections.abc import Iterable, Mapping, Sequence
 from typing import Any
 
 import torch
@@ -1268,6 +1269,8 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
     has_preprocess: bool = True
     has_postprocess: bool = True
 
+    _DEFAULT_MAX_AUDIO_FRAMES = 512
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
         super().__init__()
         self.vllm_config = vllm_config
@@ -1283,6 +1286,25 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
 
         self.audio_assistant_slot_token_id: int = int(self.config.audio_assistant_slot_token_id)
         self.im_end_token_id: int = int(self.config.im_end_token_id)
+
+        max_audio_frames_raw = os.getenv(
+            "MOSS_TTS_LOCAL_MAX_AUDIO_FRAMES",
+            str(self._DEFAULT_MAX_AUDIO_FRAMES),
+        ).strip()
+        try:
+            self.max_audio_frames = int(max_audio_frames_raw)
+        except ValueError as exc:
+            raise ValueError(
+                f"MOSS_TTS_LOCAL_MAX_AUDIO_FRAMES must be a non-negative integer, got {max_audio_frames_raw!r}"
+            ) from exc
+        if self.max_audio_frames < 0:
+            raise ValueError(
+                "MOSS_TTS_LOCAL_MAX_AUDIO_FRAMES must be non-negative; use 0 to disable the server-side safety cap"
+            )
+        logger.info(
+            "MOSS-TTS Local server-side audio-frame safety cap: %s",
+            self.max_audio_frames or "disabled",
+        )
 
         # Qwen3 backbone. get_text_config() is sufficient for vLLM to size
         # KV cache / heads correctly, as long as AutoConfig resolves to the
@@ -1323,7 +1345,11 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
         self.mtp_hidden_size = hidden_size
         self.talker_mtp_graph_safe = True
         self.talker_mtp_output_key = ("audio_codes", "current")
-        self.use_async_omni_output = False
+        # ``make_omni_output`` keeps code rows fixed-shape and performs all
+        # state updates eagerly, so the runner can safely pack/snapshot them
+        # before CUDA-graph buffers are reused.  This moves the pinned D2H and
+        # output materialization off the Stage-0 execution thread.
+        self.use_async_omni_output = True
         self.eager_omni_postprocess_before_async_output = True
         self.omni_pooler_payload_include_hidden = False
         self.postprocess_uses_multimodal_outputs = False
@@ -1339,6 +1365,57 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
     # ------------------------------------------------------------------
     # vLLM hooks
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _coerce_max_new_frames(value: object) -> int:
+        if isinstance(value, (list, tuple)):
+            value = value[0] if value else None
+        if value is None:
+            return 0
+        try:
+            value = int(value)
+        except (TypeError, ValueError):
+            return 0
+        return max(0, value)
+
+    def _new_audio_state(self, info_dict: Mapping[str, object]) -> dict[str, object]:
+        """Create Local-v1.5 decode state with an effective frame budget.
+
+        The HTTP speech endpoint forwards ``max_new_tokens`` as
+        ``max_new_frames`` for MOSS-TTS, but Local-v1.5 previously ignored
+        that field and could therefore run until the generic 4096-token
+        Stage-0 limit (~328 seconds at 12.5 Hz).  Clamp the request budget by
+        a service-side guard so a missing or excessively large request limit
+        cannot monopolize a decode slot indefinitely.
+        """
+        request_limit = self._coerce_max_new_frames(info_dict.get("max_new_frames"))
+        limits = [limit for limit in (request_limit, self.max_audio_frames) if limit > 0]
+        effective_limit = min(limits) if limits else 0
+        return {
+            "is_stopping": False,
+            "step": 0,
+            "max_new_frames": effective_limit,
+        }
+
+    @staticmethod
+    def _advance_audio_frame_budget(state: dict[str, Any]) -> bool:
+        """Reserve one output frame, or mark the request for forced EOS."""
+        if bool(state.get("is_stopping")):
+            return False
+        step = max(0, int(state.get("step", 0)))
+        max_new_frames = max(0, int(state.get("max_new_frames", 0)))
+        if max_new_frames > 0 and step >= max_new_frames:
+            state["is_stopping"] = True
+            state["stop_reason"] = "max_new_frames"
+            if not bool(state.get("_max_new_frames_warned")):
+                logger.warning(
+                    "MOSS-TTS Local reached the %d-frame safety limit; forcing im_end_token_id",
+                    max_new_frames,
+                )
+                state["_max_new_frames_warned"] = True
+            return False
+        state["step"] = step + 1
+        return True
 
     def embed_input_ids(self, input_ids: torch.Tensor, **_: Any) -> torch.Tensor:
         return self.model.embed_tokens(input_ids)
@@ -1474,8 +1551,9 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
         span_len = int(input_ids.shape[0])
         audio_state = info_dict.get("audio_state")
         is_first_call = not isinstance(audio_state, dict)
+        is_prefill = bool(info_dict.get("_omni_is_prefill", False))
 
-        if span_len > 1 or is_first_call:
+        if span_len > 1 or is_first_call or is_prefill:
             embeds = self.model.embed_tokens(input_ids)
 
             ref_codes = (info_dict.get("codes", {}) or {}).get("ref")
@@ -1491,7 +1569,7 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
                         embeds = embeds + self._audio_embed(codes)
 
             info_update: dict[str, Any] = {
-                "audio_state": {"is_stopping": False},
+                "audio_state": self._new_audio_state(info_dict),
                 "ref_offset": ref_offset + span_len,
             }
             return input_ids, embeds, info_update
@@ -1508,10 +1586,17 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
         else:
             mtp_hidden = torch.zeros((1, self.hidden_size), device=device, dtype=text_embed.dtype)
         state = info_dict.get("audio_state", {}) or {}
-        active = isinstance(state, dict) and not bool(state.get("is_stopping"))
+        active = isinstance(state, dict) and self._advance_audio_frame_budget(state)
         mtp_control = torch.zeros_like(mtp_hidden)
         mtp_control[:, :1] = 1.0 if active else 0.0
-        return input_ids, text_embed, {"mtp_inputs": (mtp_hidden, mtp_control)}
+        return (
+            input_ids,
+            text_embed,
+            {
+                "mtp_inputs": (mtp_hidden, mtp_control),
+                "audio_state": state,
+            },
+        )
 
     def preprocess_decode_batch(
         self,
@@ -1549,7 +1634,7 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
                 hidden_rows.append(text_embeds.new_zeros((1, self.hidden_size)))
 
             state = info.get("audio_state", {}) or {}
-            active_rows.append(isinstance(state, dict) and not bool(state.get("is_stopping")))
+            active_rows.append(isinstance(state, dict) and self._advance_audio_frame_budget(state))
 
         last_talker_hidden = torch.cat(hidden_rows, dim=0)
         text_step = torch.zeros_like(last_talker_hidden)
@@ -1563,7 +1648,7 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
             text_embeds,
             last_talker_hidden,
             text_step,
-            [{} for _ in range(batch_size)],
+            [{"audio_state": info.get("audio_state", {}) or {}} for info in req_infos],
         )
 
     def postprocess(self, hidden_states: torch.Tensor, **_: Any) -> dict[str, Any]:
@@ -1650,7 +1735,7 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
 
         for info in info_dicts:
             if isinstance(info, dict) and not isinstance(info.get("audio_state"), dict):
-                info["audio_state"] = {"is_stopping": False}
+                info["audio_state"] = self._new_audio_state(info)
 
         self._batch_state = [(info["audio_state"] if isinstance(info, dict) else {}) for info in info_dicts]
         self._batch_state_spans = kwargs.get("request_token_spans")
@@ -1668,9 +1753,14 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
                 should_continue = codes.ne(self.audio_pad_token_id).any(dim=-1)
                 should_values.append(should_continue.reshape(-1)[:1])
                 have_mtp_output = True
-                emitted_codes = codes[should_continue]
-                per_req_codes.append(emitted_codes)
-                have_codes = have_codes or emitted_codes.numel() > 0
+                # Do not boolean-index a CUDA tensor here.  Even for the
+                # common single-row case, ``codes[should_continue]`` must
+                # discover a dynamic output size on the host and therefore
+                # synchronizes the CUDA stream once per request.  Keep the
+                # fixed-shape row (including an all-pad stop row); the async
+                # chunk processor already filters all-pad rows on CPU.
+                per_req_codes.append(codes)
+                have_codes = True
             else:
                 should_values.append(torch.ones((1,), device=hidden.device, dtype=torch.bool))
                 per_req_codes.append(hidden.new_empty((0, self.n_vq), dtype=torch.long))

--- a/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_talker.py
+++ b/vllm_omni/model_executor/models/moss_tts/modeling_moss_tts_talker.py
@@ -6,8 +6,7 @@
 from __future__ import annotations
 
 import copy
-import os
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Iterable, Sequence
 from typing import Any
 
 import torch
@@ -1269,8 +1268,6 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
     has_preprocess: bool = True
     has_postprocess: bool = True
 
-    _DEFAULT_MAX_AUDIO_FRAMES = 512
-
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
         super().__init__()
         self.vllm_config = vllm_config
@@ -1286,25 +1283,6 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
 
         self.audio_assistant_slot_token_id: int = int(self.config.audio_assistant_slot_token_id)
         self.im_end_token_id: int = int(self.config.im_end_token_id)
-
-        max_audio_frames_raw = os.getenv(
-            "MOSS_TTS_LOCAL_MAX_AUDIO_FRAMES",
-            str(self._DEFAULT_MAX_AUDIO_FRAMES),
-        ).strip()
-        try:
-            self.max_audio_frames = int(max_audio_frames_raw)
-        except ValueError as exc:
-            raise ValueError(
-                f"MOSS_TTS_LOCAL_MAX_AUDIO_FRAMES must be a non-negative integer, got {max_audio_frames_raw!r}"
-            ) from exc
-        if self.max_audio_frames < 0:
-            raise ValueError(
-                "MOSS_TTS_LOCAL_MAX_AUDIO_FRAMES must be non-negative; use 0 to disable the server-side safety cap"
-            )
-        logger.info(
-            "MOSS-TTS Local server-side audio-frame safety cap: %s",
-            self.max_audio_frames or "disabled",
-        )
 
         # Qwen3 backbone. get_text_config() is sufficient for vLLM to size
         # KV cache / heads correctly, as long as AutoConfig resolves to the
@@ -1365,57 +1343,6 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
     # ------------------------------------------------------------------
     # vLLM hooks
     # ------------------------------------------------------------------
-
-    @staticmethod
-    def _coerce_max_new_frames(value: object) -> int:
-        if isinstance(value, (list, tuple)):
-            value = value[0] if value else None
-        if value is None:
-            return 0
-        try:
-            value = int(value)
-        except (TypeError, ValueError):
-            return 0
-        return max(0, value)
-
-    def _new_audio_state(self, info_dict: Mapping[str, object]) -> dict[str, object]:
-        """Create Local-v1.5 decode state with an effective frame budget.
-
-        The HTTP speech endpoint forwards ``max_new_tokens`` as
-        ``max_new_frames`` for MOSS-TTS, but Local-v1.5 previously ignored
-        that field and could therefore run until the generic 4096-token
-        Stage-0 limit (~328 seconds at 12.5 Hz).  Clamp the request budget by
-        a service-side guard so a missing or excessively large request limit
-        cannot monopolize a decode slot indefinitely.
-        """
-        request_limit = self._coerce_max_new_frames(info_dict.get("max_new_frames"))
-        limits = [limit for limit in (request_limit, self.max_audio_frames) if limit > 0]
-        effective_limit = min(limits) if limits else 0
-        return {
-            "is_stopping": False,
-            "step": 0,
-            "max_new_frames": effective_limit,
-        }
-
-    @staticmethod
-    def _advance_audio_frame_budget(state: dict[str, Any]) -> bool:
-        """Reserve one output frame, or mark the request for forced EOS."""
-        if bool(state.get("is_stopping")):
-            return False
-        step = max(0, int(state.get("step", 0)))
-        max_new_frames = max(0, int(state.get("max_new_frames", 0)))
-        if max_new_frames > 0 and step >= max_new_frames:
-            state["is_stopping"] = True
-            state["stop_reason"] = "max_new_frames"
-            if not bool(state.get("_max_new_frames_warned")):
-                logger.warning(
-                    "MOSS-TTS Local reached the %d-frame safety limit; forcing im_end_token_id",
-                    max_new_frames,
-                )
-                state["_max_new_frames_warned"] = True
-            return False
-        state["step"] = step + 1
-        return True
 
     def embed_input_ids(self, input_ids: torch.Tensor, **_: Any) -> torch.Tensor:
         return self.model.embed_tokens(input_ids)
@@ -1543,7 +1470,7 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
     ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
         """Build per-step input embeddings (text + audio additive fusion).
 
-        Prefill: initialise the per-request ``{is_stopping, step}`` state.
+        Prefill: initialise the per-request ``{is_stopping}`` state.
         Decode: combine the forced text token (from ``compute_logits``) with
         the audio codes the local transformer produced last step.
         """
@@ -1569,7 +1496,7 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
                         embeds = embeds + self._audio_embed(codes)
 
             info_update: dict[str, Any] = {
-                "audio_state": self._new_audio_state(info_dict),
+                "audio_state": {"is_stopping": False},
                 "ref_offset": ref_offset + span_len,
             }
             return input_ids, embeds, info_update
@@ -1586,17 +1513,10 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
         else:
             mtp_hidden = torch.zeros((1, self.hidden_size), device=device, dtype=text_embed.dtype)
         state = info_dict.get("audio_state", {}) or {}
-        active = isinstance(state, dict) and self._advance_audio_frame_budget(state)
+        active = isinstance(state, dict) and not bool(state.get("is_stopping"))
         mtp_control = torch.zeros_like(mtp_hidden)
         mtp_control[:, :1] = 1.0 if active else 0.0
-        return (
-            input_ids,
-            text_embed,
-            {
-                "mtp_inputs": (mtp_hidden, mtp_control),
-                "audio_state": state,
-            },
-        )
+        return input_ids, text_embed, {"mtp_inputs": (mtp_hidden, mtp_control)}
 
     def preprocess_decode_batch(
         self,
@@ -1634,7 +1554,7 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
                 hidden_rows.append(text_embeds.new_zeros((1, self.hidden_size)))
 
             state = info.get("audio_state", {}) or {}
-            active_rows.append(isinstance(state, dict) and self._advance_audio_frame_budget(state))
+            active_rows.append(isinstance(state, dict) and not bool(state.get("is_stopping")))
 
         last_talker_hidden = torch.cat(hidden_rows, dim=0)
         text_step = torch.zeros_like(last_talker_hidden)
@@ -1648,7 +1568,7 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
             text_embeds,
             last_talker_hidden,
             text_step,
-            [{"audio_state": info.get("audio_state", {}) or {}} for info in req_infos],
+            [{} for _ in range(batch_size)],
         )
 
     def postprocess(self, hidden_states: torch.Tensor, **_: Any) -> dict[str, Any]:
@@ -1735,7 +1655,7 @@ class MossTTSLocalTalkerForGeneration(nn.Module):
 
         for info in info_dicts:
             if isinstance(info, dict) and not isinstance(info.get("audio_state"), dict):
-                info["audio_state"] = self._new_audio_state(info)
+                info["audio_state"] = {"is_stopping": False}
 
         self._batch_state = [(info["audio_state"] if isinstance(info, dict) else {}) for info in info_dicts]
         self._batch_state_spans = kwargs.get("request_token_spans")


### PR DESCRIPTION
## Purpose

Improve `OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5` serving throughput while keeping the implementation confined to MOSS-TTS Local model code, and keep request-level sampling overrides in the MOSS adapter by reusing the existing generic helper.

This PR:

- Keeps Stage-0 code rows fixed-shape, avoiding CUDA boolean-index output-shape synchronization, and opts this model into the existing asynchronous Omni output snapshot path.
- Reuses the shared `apply_max_new_tokens` helper from the MOSS adapter so an explicit speech request `max_new_tokens` is honored without adding a branch to the central serving module.
- Preserves prefill behavior when the scheduler presents a one-token prompt chunk.
- Precomputes and reuses the Local Depth RoPE values for positions `0..11`.
- Runs nucleus filtering, softmax, and multinomial over the retained `top_k` candidates, then maps the sample back to the 1024-token vocabulary.

The RoPE cache and compact sampler are direct implementation paths, not process-level feature switches. Compact top-k preserves the intended categorical distribution when the top-k boundary has no ties, but it is not seed- or bit-equivalent to sampling a width-1024 tensor because multinomial maps the same RNG state differently at width 25 and finite-precision boundary ties can select a different retained set.

## Test Plan

### Environment and provenance

- GPU: 1x NVIDIA H200, Stage 0 and Stage 1 colocated
- Driver: 580.173.02
- CUDA: 13.0
- PyTorch: 2.13.0+cu130
- vLLM: 0.27.0
- vLLM-Omni package version: 0.26.0
- Base commit: `baba7d1e2ef9d326486493146b43157f7cd4f8d0`
- Measured optimization commit: `1797c7290c5797eebd033b13947a54dc875eec4e`
- Current PR commit: `226762e2fc62478d25796c8258e8d335d95b973c`
- Current PR tree: `97b335fe856bf7fe8bfc75db55dd9f92b5026ef0`
- Model revision: `be7766a6735b98bd793f7c79fb720b4d0f5d13b8`
- Offline loading: `HF_HUB_OFFLINE=1`, `TRANSFORMERS_OFFLINE=1`

The measured service enabled compact top-k, used the default-on RoPE cache, and sent `--output-len 512`. The current head makes those optimized paths direct and replaces the model-local frame counter with the MOSS adapter's use of the generic `max_new_tokens` helper requested in review. The saved end-to-end table below is retained as optimization evidence rather than relabeled as an exact-current-tree rerun.

The vLLM-Omni 0.26 / vLLM 0.27 compatibility warning was present on both A/B services.

### Throughput command

The 64-row Seed-TTS EN subset was repeated eight times. A separate 512-request c64 pass first warmed reference codes. The measured pass used 2048 requests at c64 with streaming 48 kHz stereo output.

```bash
HF_HUB_OFFLINE=1 \
TRANSFORMERS_OFFLINE=1 \
SEED_TTS_EVAL_DEVICE=cpu \
VLLM_OMNI_BENCH_AUDIO_SAMPLE_RATE=48000 \
VLLM_OMNI_BENCH_AUDIO_CHANNELS=2 \
python benchmarks/tts/bench_tts.py \
  --host 127.0.0.1 \
  --port 8123 \
  --model OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5 \
  --task voice_clone \
  --locale en \
  --dataset-path /root/vllm-omni-workspace/profile-data/seed64x8 \
  --num-prompts 2048 \
  --concurrency 64 \
  --output-len 512 \
  --output-dir /tmp/moss-tts-c64
```

### Focused validation on the current tree

```text
MOSS model tests: 6 passed, 14 warnings in 0.09s
MOSS adapter tests: 2 passed, 23 deselected, 15 warnings in 1.14s
ruff check: passed
ruff format --check: passed
git diff --check: passed
custom pre-commit checks: passed
```

The focused tests cover fixed-shape output and mixed-batch stop routing, one-token prefill behavior, RoPE numerical parity and storage reuse, and compact top-k candidate constraints.

### Paired quality gate

A full Seed-TTS EN paired gate evaluated 1088 utterances with the original and compact samplers.

| Metric | Original sampler | Compact sampler |
|---|---:|---:|
| WER | 3.8522% | 3.3838% |
| WavLM SIM | 0.867135 | 0.867457 |
| UTMOS | 3.360601 | 3.359941 |
| Mean audio duration | 4.3746 s | 4.3283 s |
| Requests evaluated | 1088/1088 | 1088/1088 |
| PCM / ASR / evaluator failures | 0 | 0 |

Paired bootstrap 95% confidence intervals for WER, SIM, UTMOS, duration, RMS, peak amplitude, and clipping all include zero. Neither side produced duplicate PCM groups, streaming discontinuities, or frame-cap-length output.

## Test Result

### End-to-end c64 A/B

| **H200 Configuration** | **Concurrency** | **Baseline req/s** | **Current req/s** | **req/s Improvement** | **Baseline audio-s/s** | **Current audio-s/s** | **Audio Improvement** | **RTF Baseline → Current** | **WER Baseline → Current** |
|---|---:|---:|---:|---:|---:|---:|---:|---|---|
| 1 GPU | 1 | 1.860 | 2.119 | **+13.9%** | 7.860 | 9.171 | **+16.7%** | 0.130 → 0.112 (**-13.8%**) | 3.14% → 3.20% (**+0.06 pp**) |
| 1 GPU | 8 | 8.430 | 11.075 | **+31.4%** | 36.400 | 47.688 | **+31.0%** | 0.220 → 0.169 (**-23.2%**) | 3.14% → 2.67% (**-0.47 pp**) |
| 1 GPU | 16 | 12.370 | 16.968 | **+37.2%** | 52.840 | 72.152 | **+36.5%** | 0.300 → 0.224 (**-25.3%**) | 3.06% → 3.19% (**+0.13 pp**) |
| 1 GPU | 32 | 16.410 | 25.374 | **+54.6%** | 70.220 | 109.342 | **+55.7%** | 0.460 → 0.294 (**-36.1%**) | 4.25% → 3.99% (**-0.26 pp**) |
| 1 GPU | 64 | 21.880 | 34.239 | **+56.5%** | 93.020 | 149.684 | **+60.9%** | 0.680 → 0.418 (**-38.5%**) | 4.28% → 3.05% (**-1.23 pp**) |

### Isolated compact-sampler profile

With the other MOSS runtime fixes held constant, compact sampling improved request throughput by 6.95% and audio throughput by 6.06%:

- Stage-0 kernel time: 5.440 s -> 4.575 s (-15.9%)
- Local sort kernels: 242.0 ms -> 103.5 ms
- Softmax kernels: 137.1 ms -> 42.3 ms
- Multinomial/scan kernels: 116.9 ms -> 57.5 ms
- Steady allocated GPU memory: 105971 MiB -> 106135 MiB (+164 MiB, +0.15%)

## Scope decisions

The following experiments remain excluded:

- Reference singleflight and persistence: no steady-state benefit and broader cache-identity risk.
- Local Depth incremental KV cache: slower at the production shape.
- Stage-1 asynchronous D2H and batched waveform: broader shared-path changes with lower measured throughput.
- Dynamic Local Depth compilation: normalized audio-throughput gain below 5% without the same paired quality closure.
- Stage-1 arbitrary-mask attention rewrites: FlashAttention rejects the current mask, while chronological repacking was slower.


