### PR TITLE
fix(worker): an NVML PID lookup miss is absence, not 0 bytes (#6243)

### DIFF
--- a/tests/worker/test_process_gpu_memory.py
+++ b/tests/worker/test_process_gpu_memory.py
@@ -66,7 +66,7 @@ class TestGetProcessGpuMemory:
         tensor = torch.zeros(1000, 1000, device=device)
 
         memory = get_process_gpu_memory(0)
-        assert memory >= 0
+        assert memory is not None and memory > 0
 
         del tensor
         torch.accelerator.empty_cache()

--- a/tests/worker/test_process_gpu_memory.py
+++ b/tests/worker/test_process_gpu_memory.py
@@ -57,10 +57,18 @@ class TestGetProcessGpuMemory:
     def test_returns_memory_for_current_process(self):
         import torch
 
+        from vllm_omni.entrypoints.utils import detect_pid_host
         from vllm_omni.worker.gpu_memory_utils import get_process_gpu_memory
 
         if not torch.cuda.is_available():
             pytest.skip("CUDA not available")
+        if not detect_pid_host():
+            # NVML reports host PIDs. In an isolated PID namespace this
+            # process's PID cannot appear in the compute-process list, so a
+            # miss here is the environment rather than a regression -- and it
+            # is the same condition determine_available_memory() checks before
+            # it trusts a per-process reading at all.
+            pytest.skip("per-process NVML accounting needs the host PID namespace")
 
         device = torch.device("cuda:0")
         tensor = torch.zeros(1000, 1000, device=device)

--- a/tests/worker/test_process_gpu_memory.py
+++ b/tests/worker/test_process_gpu_memory.py
@@ -1,6 +1,7 @@
 """Tests for process-scoped GPU memory accounting."""
 
 import os
+from types import SimpleNamespace
 
 import pytest
 from pytest_mock import MockerFixture
@@ -80,7 +81,13 @@ class TestGetProcessGpuMemory:
         with pytest.raises(RuntimeError, match="Invalid GPU device"):
             get_process_gpu_memory(5)
 
-    def test_returns_zero_when_process_not_found(self, mocker: MockerFixture):
+    def test_returns_none_when_process_not_found(self, mocker: MockerFixture):
+        """A PID lookup miss is absence, not zero.
+
+        Returning 0 here reads to callers as "this process holds no device
+        memory", which sizes the KV cache as if the weights were free. None
+        routes them to their conservative fallback instead.
+        """
         from vllm_omni.worker.gpu_memory_utils import get_process_gpu_memory
 
         mocker.patch("vllm_omni.worker.gpu_memory_utils.nvmlInit")
@@ -88,6 +95,30 @@ class TestGetProcessGpuMemory:
         mocker.patch("vllm.third_party.pynvml.nvmlDeviceGetCount", return_value=8)
         mocker.patch("vllm_omni.worker.gpu_memory_utils.nvmlDeviceGetHandleByIndex")
         mocker.patch("vllm_omni.worker.gpu_memory_utils.nvmlDeviceGetComputeRunningProcesses", return_value=[])
+
+        memory = get_process_gpu_memory(0)
+        assert memory is None
+
+    def test_returns_zero_when_process_found_holding_nothing(self, mocker: MockerFixture):
+        """A *found* record reporting 0 bytes is a measurement and is kept as 0.
+
+        This pins the distinction the fix rests on: the change is about the PID
+        being absent from the list, not about the value 0 being suspicious.
+        """
+        from vllm_omni.worker.gpu_memory_utils import get_process_gpu_memory
+
+        mocker.patch("vllm_omni.worker.gpu_memory_utils.nvmlInit")
+        mocker.patch("vllm_omni.worker.gpu_memory_utils.nvmlShutdown")
+        mocker.patch("vllm.third_party.pynvml.nvmlDeviceGetCount", return_value=8)
+        mocker.patch("vllm_omni.worker.gpu_memory_utils.nvmlDeviceGetHandleByIndex")
+        # A co-tenant is listed ahead of us: a shared GPU rarely lists us first.
+        mocker.patch(
+            "vllm_omni.worker.gpu_memory_utils.nvmlDeviceGetComputeRunningProcesses",
+            return_value=[
+                SimpleNamespace(pid=os.getpid() + 1, usedGpuMemory=5 * 1024**3),
+                SimpleNamespace(pid=os.getpid(), usedGpuMemory=0),
+            ],
+        )
 
         memory = get_process_gpu_memory(0)
         assert memory == 0
@@ -102,11 +133,20 @@ class TestGetProcessGpuMemory:
         mocker.patch("vllm_omni.worker.gpu_memory_utils.nvmlInit")
         mocker.patch("vllm_omni.worker.gpu_memory_utils.nvmlShutdown")
         mock_by_uuid = mocker.patch("vllm.third_party.pynvml.nvmlDeviceGetHandleByUUID", return_value=mock_handle)
-        mocker.patch("vllm_omni.worker.gpu_memory_utils.nvmlDeviceGetComputeRunningProcesses", return_value=[])
+        # Scan a handle that carries this process, so the assertion below is about
+        # the UUID path returning a real reading rather than about miss behaviour.
+        mock_procs = mocker.patch(
+            "vllm_omni.worker.gpu_memory_utils.nvmlDeviceGetComputeRunningProcesses",
+            return_value=[
+                SimpleNamespace(pid=os.getpid() + 1, usedGpuMemory=8192),
+                SimpleNamespace(pid=os.getpid(), usedGpuMemory=4096),
+            ],
+        )
 
         memory = get_process_gpu_memory(0)
-        assert memory == 0
+        assert memory == 4096
         mock_by_uuid.assert_called_once_with(uuid)
+        mock_procs.assert_called_once_with(mock_handle)
 
     def test_raises_on_invalid_uuid(self, mocker: MockerFixture):
         from vllm_omni.worker.gpu_memory_utils import get_process_gpu_memory

--- a/tests/worker/test_worker_base.py
+++ b/tests/worker/test_worker_base.py
@@ -11,6 +11,7 @@ Workers are constructed via ``object.__new__`` with only the attributes each
 method reads; module-level collaborators are monkeypatched. Pure CPU.
 """
 
+import os
 from contextlib import contextmanager, nullcontext
 from types import SimpleNamespace
 
@@ -83,6 +84,80 @@ def test_determine_available_memory_profiling_fallback_arm(monkeypatch):
 
     profiled = 10 * GIB + 2 * GIB + 1 * GIB
     assert out == 30 * GIB - profiled
+
+
+def test_determine_available_memory_falls_back_when_pid_not_visible(monkeypatch):
+    """NVML answers None (PID lookup miss) -> profiling fallback, not the full budget.
+
+    Regression guard for the case where the two gates below both pass -- NVML is
+    up and the container check believes PIDs are comparable -- but the PID is
+    still absent from the compute-process list. Before the fix that arm returned
+    0 and the KV budget came out equal to ``requested_memory``, as if weights,
+    activations and non-Torch memory were free.
+    """
+    worker = _make_worker(requested_memory=30 * GIB, model_memory_usage=10 * GIB)
+    monkeypatch.setattr(base, "memory_profiling", _fake_memory_profiling(non_torch=1 * GIB, torch_peak=2 * GIB))
+    monkeypatch.setattr(base, "is_process_scoped_memory_available", lambda: True)
+    monkeypatch.setattr(base, "detect_pid_host", lambda: True)
+    monkeypatch.setattr(base, "get_process_gpu_memory", lambda local_rank: None)
+
+    out = OmniGPUWorkerBase.determine_available_memory(worker)
+
+    profiled = 10 * GIB + 2 * GIB + 1 * GIB
+    assert out == 30 * GIB - profiled
+    # The specific regression: never hand back the whole requested budget.
+    assert out < worker.requested_memory
+
+
+def test_determine_available_memory_survives_nvml_pid_lookup_miss(monkeypatch):
+    """End-to-end across the seam: the real ``get_process_gpu_memory``, PID not listed.
+
+    The test above stubs ``get_process_gpu_memory`` and so only covers this
+    module's half. The defect lived in the seam -- each half was individually
+    defensible -- so this one drives the real lookup against a device that lists
+    a co-tenant but not us, and checks the budget that comes out the other side.
+    """
+    from vllm_omni.worker import gpu_memory_utils as gmu
+
+    worker = _make_worker(requested_memory=30 * GIB, model_memory_usage=10 * GIB)
+    monkeypatch.setattr(base, "memory_profiling", _fake_memory_profiling(non_torch=1 * GIB, torch_peak=2 * GIB))
+    monkeypatch.setattr(base, "is_process_scoped_memory_available", lambda: True)
+    monkeypatch.setattr(base, "detect_pid_host", lambda: True)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")  # take the explicit-device path
+    monkeypatch.setattr(gmu, "nvmlInit", lambda: None)
+    monkeypatch.setattr(gmu, "nvmlShutdown", lambda: None)
+    monkeypatch.setattr(gmu, "nvmlDeviceGetHandleByIndex", lambda index: object())
+    # Someone else's PID is on the device; ours is not visible.
+    monkeypatch.setattr(
+        gmu,
+        "nvmlDeviceGetComputeRunningProcesses",
+        lambda handle: [SimpleNamespace(pid=os.getpid() + 1, usedGpuMemory=5 * GIB)],
+    )
+
+    out = OmniGPUWorkerBase.determine_available_memory(worker)
+
+    assert out == 30 * GIB - (10 * GIB + 2 * GIB + 1 * GIB)
+    assert out != worker.requested_memory  # the pre-fix answer
+
+
+def test_determine_available_memory_keeps_a_truthful_zero_on_the_nvml_arm(monkeypatch):
+    """A measured 0 stays on the NVML arm; only absence (None) falls back.
+
+    Pins the ``is not None`` test rather than a truthiness test. The two differ
+    exactly at 0, which is the value this fix is about: 0 from a *found* record
+    is a reading and must be subtracted as one, while a missing record is not a
+    reading at all. Swapping the check for ``if process_memory:`` silently
+    reroutes the former to the profiling arm.
+    """
+    worker = _make_worker(requested_memory=30 * GIB, model_memory_usage=10 * GIB)
+    monkeypatch.setattr(base, "memory_profiling", _fake_memory_profiling(non_torch=1 * GIB, torch_peak=2 * GIB))
+    monkeypatch.setattr(base, "is_process_scoped_memory_available", lambda: True)
+    monkeypatch.setattr(base, "detect_pid_host", lambda: True)
+    monkeypatch.setattr(base, "get_process_gpu_memory", lambda local_rank: 0)
+
+    out = OmniGPUWorkerBase.determine_available_memory(worker)
+
+    assert out == 30 * GIB  # requested - 0, not requested - profiled
 
 
 def test_determine_available_memory_falls_back_when_not_pid_host(monkeypatch):

--- a/vllm_omni/worker/gpu_memory_utils.py
+++ b/vllm_omni/worker/gpu_memory_utils.py
@@ -72,7 +72,16 @@ def get_process_gpu_memory(local_rank: int) -> int | None:
     Supports CUDA_VISIBLE_DEVICES with integer indices, UUIDs, or MIG IDs.
 
     Returns:
-        Memory in bytes used by this process, or None if NVML unavailable.
+        Memory in bytes used by this process, or None when NVML cannot answer.
+
+        None covers two cases: NVML is unavailable, and this process's PID is
+        absent from the device's compute-process list. The miss is reported as
+        None rather than 0 because NVML cannot distinguish "this process holds
+        no device memory" from "this process is not visible to NVML" -- a PID
+        namespace mismatch is the usual cause, and only the caller knows whether
+        a device context is expected to exist by this point. Callers read a
+        returned int as an authoritative measurement, so 0 would size budgets as
+        though the process were empty; None routes them to their own fallback.
 
     Raises:
         RuntimeError: If device validation fails (invalid index or UUID).
@@ -111,7 +120,14 @@ def get_process_gpu_memory(local_rank: int) -> int | None:
         for proc in nvmlDeviceGetComputeRunningProcesses(handle):
             if proc.pid == my_pid:
                 return proc.usedGpuMemory
-        return 0
+        logger.warning(
+            "PID %d is not in the NVML compute-process list for GPU %d, so per-process "
+            "memory cannot be measured (a PID namespace mismatch is the usual cause); "
+            "will use profiling fallback.",
+            my_pid,
+            local_rank,
+        )
+        return None
     except RuntimeError:
         raise
     except Exception as e:

--- a/vllm_omni/worker/gpu_memory_utils.py
+++ b/vllm_omni/worker/gpu_memory_utils.py
@@ -122,8 +122,7 @@ def get_process_gpu_memory(local_rank: int) -> int | None:
                 return proc.usedGpuMemory
         logger.warning(
             "PID %d is not in the NVML compute-process list for GPU %d, so per-process "
-            "memory cannot be measured (a PID namespace mismatch is the usual cause); "
-            "will use profiling fallback.",
+            "memory cannot be measured (a PID namespace mismatch is the usual cause).",
             my_pid,
             local_rank,
         )


### PR DESCRIPTION
Closes #6243.

`get_process_gpu_memory()` returns `None` when this process's PID is absent from the
device's compute-process list, instead of `0`. Everything else about the function is
unchanged.

Against `baba7d1`.

### Why absence cannot be reported as zero

NVML cannot distinguish *"this process holds no device memory"* from *"this process is not
visible to NVML"*. Only the caller knows which is possible at that point, and at the caller
that matters it is never the former: `determine_available_memory()` calls this **after**
`self.model_runner.profile_run()` has run inside `memory_profiling(...)`, so a device
context provably exists and an empty result can only be a lookup miss. Returning `0` hands
that miss to the caller as a measurement.

### What it costs today

Driving `determine_available_memory()` with `requested=30GiB`, `weights=10GiB`,
`torch_peak=2GiB`, `non_torch=1GiB` — truthful KV budget 17 GiB:

| NVML sees our PID | `get_process_gpu_memory()` | KV budget | vs truth |
|---|---|---|---|
| yes | `13958643712` | 17.00 GiB | +0.0% |
| **no (miss)** — on `main` | **`0`** | **30.00 GiB** | **+76.5%** |
| no (miss) — with this patch | `None` | 17.00 GiB | +0.0% |

The miss does not scale the error, it removes the subtraction entirely: `available` comes
out equal to `requested_memory` whatever the model's real footprint is. The overshoot *is*
the process's footprint.

### The prescription in the issue names one test that pins the `0`. There are two.

`test_returns_zero_when_process_not_found` is the one linked, and
`test_uses_uuid_when_provided` also asserts `memory == 0` off an empty process list.
Running the **unedited** upstream `tests/worker/test_process_gpu_memory.py` against the
patched source:

```
FAILED TestGetProcessGpuMemory::test_returns_zero_when_process_not_found
FAILED TestGetProcessGpuMemory::test_uses_uuid_when_provided
2 failed, 10 passed, 1 skipped
```

The first becomes `test_returns_none_when_process_not_found`. The second is not re-pointed
at `None` — it is given a process list that **contains** this PID, so it asserts the UUID
path returns a real reading (`4096`) and that the scan ran against the handle the UUID
produced. With an empty list it could not tell "looked this PID up through the UUID handle
and missed" from "fetched a handle and never used it", and it no longer encodes the miss
policy at a second site at all.

### The seam

Item 4 of the prescription stubs `get_process_gpu_memory` and so covers only `base.py`'s
half. Both halves were individually defensible — `0` is a plausible "no memory" answer, and
`is not None` is a plausible "did NVML answer" test — and the budget went wrong where they
met. `test_determine_available_memory_survives_nvml_pid_lookup_miss` therefore drives the
real lookup end to end, against a device that lists a co-tenant and not us, and asserts the
budget that comes out the far side. It is the test that is red on `main`.

Two tests guard the other direction, one per side, because `if process_memory:` and
`if process_memory is not None:` differ at exactly the value this change is about: a
*found* record reporting 0 bytes is a reading and is still subtracted as one.

### Verification

Patched: **27 passed, 1 skipped** across `tests/worker/test_process_gpu_memory.py` and
`tests/worker/test_worker_base.py`. Baseline on unmodified `main` was **23 passed, 1
skipped** — 24 collected, matching the 13 + 11 reported in the issue thread, with the
GPU-only case skipped here.

Two of the new tests are **red on pristine `main`**:
`test_returns_none_when_process_not_found` and
`test_determine_available_memory_survives_nvml_pid_lookup_miss`.

**Eight mutants, each a complete plausible implementation, no survivors:** miss returns `0`
(the original); miss returns `-1`; miss raises; miss logs but still returns `0`; bail on
the first non-matching record; never return a reading at all; a found `0` also becomes
absence; and the caller testing `if process_memory:` instead of `is not None`. Two of those
— the record-ordering one and the caller-truthiness one — **survived the first pass, and
both were defects in my own tests rather than in the patch**: no test listed a co-tenant
ahead of us, and no test drove the NVML arm with a truthful `0`. Both are now covered.

`ruff check` clean, `ruff format --check` clean (0.14.10, the pinned pre-commit rev),
`typos` clean.

**What was not run, and why.** This box has no GPU, no CUDA and cannot host `torch` or
`vllm`, so the suite was run against stand-ins for the four vLLM symbols these two modules
import — `init_logger`, the `vllm.third_party.pynvml` re-exports, `format_gib` /
`memory_profiling`, and the `Worker` base class. Three of those four are already replaced
by mocks in the upstream tests themselves, and the code under test touches nothing else, so
the fidelity is high — but it is not a real `vllm` import and the CI run is the real check.
The GPU-gated `test_returns_memory_for_current_process` was skipped, not run. No other test
directory was executed, and `mypy` was not run.

### The second call site, checked and deliberately not changed

`vllm_omni/diffusion/worker/diffusion_worker.py:384` is the only other consumer. It is
log-only and already guards with `if process_memory is not None`, so no budget depends on
it. Today, under this failure, it logs a confident `Process-scoped GPU memory after model
loading: 0.00 GiB`; after this change it logs nothing, which is the better of the two. It
needs no edit — but note it calls `get_process_gpu_memory` with **no**
`is_process_scoped_memory_available()` / `detect_pid_host()` guard in front of it, unlike
`base.py`, which is worth knowing if that value is ever used for more than a log line.

### Two findings out of scope here, measured and left alone

Neither is touched by this PR. Both are about the guard in front of the NVML arm, and I
would rather publish the numbers than fold them into a fix for something else.

**1. `detect_pid_host()` can be bypassed entirely, which is how the reported case reaches
the `0` at all.** `in_container()` is an allowlist: `/.dockerenv`, plus five substrings in
`/proc/1/cgroup` (`docker`, `containerd`, `kubepods`, `libpod`, `podman`). When it returns
`False`, `detect_pid_host()` returns `True` **without ever calling `has_pid_host()` at all**.
So a sandbox with an isolated PID namespace that publishes none of those markers is trusted
unconditionally:

| environment | `in_container()` | `detect_pid_host()` | NVML PIDs trusted |
|---|---|---|---|
| docker, isolated pid ns | True | False | no |
| k8s, isolated pid ns | True | False | no |
| bare metal host | False | True | yes (correct) |
| **no marker, no `/.dockerenv`, isolated pid ns** | **False** | **True** | **yes — wrong** |

That is the argument for fixing this at the point of measurement rather than by improving
the detector: the detector is a heuristic, and every miss it has lands on the `return 0`.

**2. `has_pid_host()`'s fallback ladder uses kernel-thread names that are stale on modern
kernels.** If `/proc/2` is unreadable it checks `/proc/3` for `rcu_gp` and `/proc/4` for
`rcu_par_gp`. Measured on this host (Linux 6.8, genuine host PID namespace, `/proc/2` =
`kthreadd` so the real answer is `True`): `/proc/3` is `pool_workqueue_release` and
`/proc/4` is `kworker/R-rcu_g`. With `/proc/2` unreadable the ladder returns `False` on a
real host. The direction is conservative — `False` routes to the profiling fallback and a
smaller KV cache — so it is a performance nit, not a correctness bug. Separately,
`has_pid_host()` is annotated `-> bool | None` and its docstring documents
`None -> cannot determine`, but no path returns `None`.

Happy to send either as its own PR if wanted; neither belongs in this one.

<details>
<summary>AI-assisted</summary>

This patch was written by an autonomous agent. Every number above was produced on the
machine that wrote it; the "not run" list is what that box could not run, not what was
skipped. No human reviewed the diff before it was opened.

</details>


---

*Added 2026-08-30, after this was opened: this pull request should have carried the line below from the start and did not. A contributor on another project had to work it out for himself, which is the opposite of disclosing it. Back-filled here rather than left to be discovered.*

---

*Opened by an autonomous AI agent. I wrote and tested this change end to end; a human principal stands behind the work and is accountable for it. Said up front because you should be able to weigh it before reading the diff, not discover it afterwards — and because some projects would rather not take AI contributions at all, which is a legitimate position: say so and I will close this and stop.*