### PR TITLE
[Bugfix] Keep the diffusion result pump alive and make its death visible

### DIFF
--- a/docs/design/feature/async_diffusion_output.md
+++ b/docs/design/feature/async_diffusion_output.md
@@ -117,7 +117,7 @@ After (async D2H):
 
 ### Batch Split
 
-When `execute_model_batch` returns a `COMPUTE_DONE` with a single `async_output_id` for the entire batch, the executor splits it into per-request `async_output_id`s (format `{batch_id}/{request_id}`) via `_batch_split_map`. When `OUTPUT_READY` arrives, the pump extracts per-request results from the batch output and resolves each request's output future independently. If `OUTPUT_READY` arrives before `execute_batch` registers the split map, `execute_batch` directly adopts the early output.
+When `execute_model_batch` returns a `COMPUTE_DONE` with a single `async_output_id` for the entire batch, the executor splits it into per-request `async_output_id`s (format `{batch_id}/{request_id}`) via `_batch_split_map`. When `OUTPUT_READY` arrives, the pump extracts per-request results from the batch output and resolves each request's output future independently. If `OUTPUT_READY` arrives before `execute_batch` registers the split map, `execute_batch` directly adopts the early output. Per-request extraction is contained: a request whose result cannot be read from the batch output is resolved with a `DiffusionOutput(error=...)` of its own, so the rest of the batch still completes.
 
 ### Reliability, Lifecycle & Timeout Behavior
 
@@ -133,6 +133,9 @@ When `execute_model_batch` returns a `COMPUTE_DONE` with a single `async_output_
 
 4. **Storage-Aware IPC Packing**:
    `pack_diffusion_output_shm()` evaluates `max(view_bytes, storage_bytes)` against `_SHM_TENSOR_THRESHOLD` (1 MB) to ensure that per-request slices sharing a large batch storage are moved to POSIX shared memory rather than serialized through pickle over the MessageQueue inline buffer.
+
+5. **Pump Fault Containment & Liveness**:
+   A pump thread is the sole reader of its worker's result queue, so anything escaping it costs every later result rather than one message. Dispatch of each dequeued message is therefore wrapped: a bad message is logged with its traceback and dropped, and the pump keeps draining. Within a batch split the containment is per request, because the split map is popped before delivery starts. Outputs whose waiter has already been cancelled or aborted are dropped instead of cached, since nobody will ever collect them and `_completed_outputs` has no TTL or abort cleanup (a decoded video would stay pinned until shutdown). Finally, `check_health()` treats a dead pump thread as `EngineDeadError`: the processes are all alive and the GPU work still runs, so without that check the engine reports healthy forever while no result ever comes back. Intentional shutdown is excluded, since `shutdown()` sets the stop event before joining.
 
 ## Model Coverage
 

--- a/tests/diffusion/test_result_pump.py
+++ b/tests/diffusion/test_result_pump.py
@@ -3,6 +3,7 @@
 """Unit tests for MultiprocDiffusionExecutor async result pump and wait_output_ready."""
 
 import concurrent.futures
+import logging
 import queue
 import threading
 import time
@@ -612,6 +613,23 @@ class TestResultPumpDropsOutputForAbandonedWaiter:
         assert executor._completed_outputs == {}
         assert healthy.done()
         assert healthy.result(timeout=1.0) is outputs["r-healthy"]
+
+    def test_output_ready_without_an_id_is_logged_not_silently_dropped(self, caplog):
+        """async_output_id is what routes a result back to its waiter, so a
+        message without one strands its request; it must not pass unnoticed.
+        """
+        executor = _make_executor()
+        msg = AsyncDiffusionOutput(
+            kind=AsyncOutputKind.OUTPUT_READY,
+            async_output_id=None,
+            output=DiffusionOutput(output="unroutable"),
+        )
+        with caplog.at_level(logging.ERROR):
+            pump = _feed_one_msg_to_pump(executor, msg)
+
+        assert not pump.is_alive()
+        assert executor._completed_outputs == {}
+        assert "no async_output_id" in caplog.text
 
     def test_output_with_no_waiter_is_still_cached(self):
         """The pre-existing early-arrival path must keep working."""

--- a/tests/diffusion/test_result_pump.py
+++ b/tests/diffusion/test_result_pump.py
@@ -298,12 +298,19 @@ class TestResultPumpDispatch:
 
 
 class _FakeBatchOutput:
-    """Batch-level output exposing per-request results."""
+    """Batch-level output exposing per-request results.
 
-    def __init__(self, results):
+    *raise_for* names request ids whose extraction blows up, standing in for a
+    corrupt entry in an otherwise healthy batch.
+    """
+
+    def __init__(self, results, raise_for=()):
         self._results = results
+        self._raise_for = set(raise_for)
 
     def get_request_output(self, req_id):
+        if req_id in self._raise_for:
+            raise RuntimeError(f"corrupt batch entry for {req_id}")
         result = self._results.get(req_id)
         if result is None:
             return None
@@ -535,13 +542,9 @@ class TestResultPumpDispatchIsGuarded:
     def test_batch_split_failure_does_not_kill_the_pump(self):
         executor = _make_executor()
 
-        class _ExplodingBatchOutput:
-            def get_request_output(self, req_id):
-                raise RuntimeError("corrupt batch output")
-
         with executor._futures_lock:
             executor._batch_split_map["batch-1"] = {"batch-1/r-0": "r-0"}
-        doomed = executor.wait_output_ready("batch-1/r-0")
+        corrupt = executor.wait_output_ready("batch-1/r-0")
 
         fut = executor.wait_output_ready("abc123")
         output = DiffusionOutput(output="after the bad batch")
@@ -549,7 +552,7 @@ class TestResultPumpDispatchIsGuarded:
             AsyncDiffusionOutput(
                 kind=AsyncOutputKind.OUTPUT_READY,
                 async_output_id="batch-1",
-                output=_ExplodingBatchOutput(),
+                output=_FakeBatchOutput({}, raise_for=["r-0"]),
             ),
             AsyncDiffusionOutput(
                 kind=AsyncOutputKind.OUTPUT_READY,
@@ -560,9 +563,40 @@ class TestResultPumpDispatchIsGuarded:
         pump = _feed_msgs_to_pump(executor, msgs)
 
         assert not pump.is_alive()
-        assert not doomed.done()  # that one message is lost, as expected
+        assert corrupt.done(), "the corrupt request must be failed, not left hanging"
+        assert corrupt.result(timeout=1.0).error
         assert fut.done(), "one corrupt batch must not wedge the queue"
         assert fut.result(timeout=1.0) is output
+
+    def test_one_corrupt_request_does_not_drop_its_batch_siblings(self):
+        """The split map is popped before delivery starts, so an exception
+        escaping mid-loop leaves every later request in the batch with no
+        output and no way to get one. Siblings are unrelated to the corrupt
+        entry and must still complete.
+        """
+        executor = _make_executor()
+
+        req_ids = ["r-0", "r-1", "r-2"]
+        with executor._futures_lock:
+            executor._batch_split_map["batch-1"] = {f"batch-1/{rid}": rid for rid in req_ids}
+        waiters = {rid: executor.wait_output_ready(f"batch-1/{rid}") for rid in req_ids}
+
+        outputs = {rid: DiffusionOutput(output=f"img-{rid}") for rid in req_ids}
+        msg = AsyncDiffusionOutput(
+            kind=AsyncOutputKind.OUTPUT_READY,
+            async_output_id="batch-1",
+            output=_FakeBatchOutput(outputs, raise_for=["r-1"]),
+        )
+        pump = _feed_msgs_to_pump(executor, [msg])
+
+        assert not pump.is_alive()
+        for rid in req_ids:
+            assert waiters[rid].done(), f"{rid} was dropped by a sibling's failure"
+        # r-2 is delivered after the corrupt r-1, which is the ordering that used to break.
+        assert waiters["r-0"].result(timeout=1.0) is outputs["r-0"]
+        assert waiters["r-2"].result(timeout=1.0) is outputs["r-2"]
+        failed = waiters["r-1"].result(timeout=1.0)
+        assert "r-1" in failed.error
 
 
 class TestResultPumpDropsOutputForAbandonedWaiter:

--- a/tests/diffusion/test_result_pump.py
+++ b/tests/diffusion/test_result_pump.py
@@ -46,14 +46,16 @@ def _make_executor(step_execution=False):
     return executor
 
 
-def _feed_one_msg_to_pump(executor, msg):
-    """Run _result_pump in a daemon thread, feed one *msg*, then stop."""
-    call_count = [0]
+def _feed_msgs_to_pump(executor, msgs):
+    """Run _result_pump in a daemon thread, feed *msgs* in order, then stop.
+
+    Returns the pump thread so callers can assert it survived.
+    """
+    pending = list(msgs)
 
     def mock_dequeue(timeout=None):
-        call_count[0] += 1
-        if call_count[0] == 1:
-            return msg
+        if pending:
+            return pending.pop(0)
         executor._pump_stop.set()
         time.sleep(0.05)
         raise TimeoutError
@@ -62,6 +64,12 @@ def _feed_one_msg_to_pump(executor, msg):
     t = threading.Thread(target=executor._result_pump, daemon=True)
     t.start()
     t.join(timeout=2.0)
+    return t
+
+
+def _feed_one_msg_to_pump(executor, msg):
+    """Run _result_pump in a daemon thread, feed one *msg*, then stop."""
+    return _feed_msgs_to_pump(executor, [msg])
 
 
 @pytest.fixture(autouse=True)
@@ -492,3 +500,177 @@ class TestResultPumpCancelledFutureRace:
         assert cancelled_fut.cancelled()
         assert healthy_fut.done()
         assert healthy_fut.result(timeout=1.0) is outputs["r-healthy"]
+
+
+class TestResultPumpDispatchIsGuarded:
+    """A pump thread is the sole reader of its worker's result queue, so an
+    exception escaping the dispatch half costs every later result, not just the
+    message that caused it. One bad message must cost one message.
+    """
+
+    def test_dispatch_failure_does_not_kill_the_pump(self):
+        executor = _make_executor()
+
+        exploding_buffer = MagicMock()
+        exploding_buffer.put.side_effect = RuntimeError("sync buffer exploded")
+        executor._sync_result_buffer = exploding_buffer
+
+        fut = executor.wait_output_ready("abc123")
+        output = DiffusionOutput(output="after the bad message")
+        good = AsyncDiffusionOutput(
+            kind=AsyncOutputKind.OUTPUT_READY,
+            async_output_id="abc123",
+            output=output,
+        )
+
+        # SimpleNamespace is not an AsyncDiffusionOutput, so it takes the
+        # sync-buffer path and raises there.
+        pump = _feed_msgs_to_pump(executor, [SimpleNamespace(bad=True), good])
+
+        assert not pump.is_alive()
+        assert fut.done(), "pump died on the bad message and never delivered the next one"
+        assert fut.result(timeout=1.0) is output
+
+    def test_batch_split_failure_does_not_kill_the_pump(self):
+        executor = _make_executor()
+
+        class _ExplodingBatchOutput:
+            def get_request_output(self, req_id):
+                raise RuntimeError("corrupt batch output")
+
+        with executor._futures_lock:
+            executor._batch_split_map["batch-1"] = {"batch-1/r-0": "r-0"}
+        doomed = executor.wait_output_ready("batch-1/r-0")
+
+        fut = executor.wait_output_ready("abc123")
+        output = DiffusionOutput(output="after the bad batch")
+        msgs = [
+            AsyncDiffusionOutput(
+                kind=AsyncOutputKind.OUTPUT_READY,
+                async_output_id="batch-1",
+                output=_ExplodingBatchOutput(),
+            ),
+            AsyncDiffusionOutput(
+                kind=AsyncOutputKind.OUTPUT_READY,
+                async_output_id="abc123",
+                output=output,
+            ),
+        ]
+        pump = _feed_msgs_to_pump(executor, msgs)
+
+        assert not pump.is_alive()
+        assert not doomed.done()  # that one message is lost, as expected
+        assert fut.done(), "one corrupt batch must not wedge the queue"
+        assert fut.result(timeout=1.0) is output
+
+
+class TestResultPumpDropsOutputForAbandonedWaiter:
+    """_completed_outputs exists for results that arrive before the caller asks
+    for them. A caller that has already cancelled will never ask, so caching for
+    it pins the unpacked output — a decoded video, for a t2va request — for the
+    lifetime of the process.
+    """
+
+    def test_cancelled_waiter_output_is_not_cached(self):
+        executor = _make_executor()
+        fut = executor.wait_output_ready("abc123")
+        assert fut.cancel()
+        assert fut.cancelled()
+
+        msg = AsyncDiffusionOutput(
+            kind=AsyncOutputKind.OUTPUT_READY,
+            async_output_id="abc123",
+            output=DiffusionOutput(output="nobody is waiting for this"),
+        )
+        _feed_one_msg_to_pump(executor, msg)
+
+        assert executor._completed_outputs == {}
+        assert executor._output_futures == {}
+
+    def test_cancelled_waiter_batch_split_output_is_not_cached(self):
+        executor = _make_executor()
+        with executor._futures_lock:
+            executor._batch_split_map["batch-1"] = {
+                "batch-1/r-aborted": "r-aborted",
+                "batch-1/r-healthy": "r-healthy",
+            }
+        aborted = executor.wait_output_ready("batch-1/r-aborted")
+        healthy = executor.wait_output_ready("batch-1/r-healthy")
+        assert aborted.cancel()
+
+        outputs = {
+            "r-aborted": DiffusionOutput(output="dropped"),
+            "r-healthy": DiffusionOutput(output="ok"),
+        }
+        msg = AsyncDiffusionOutput(
+            kind=AsyncOutputKind.OUTPUT_READY,
+            async_output_id="batch-1",
+            output=_FakeBatchOutput(outputs),
+        )
+        _feed_one_msg_to_pump(executor, msg)
+
+        assert executor._completed_outputs == {}
+        assert healthy.done()
+        assert healthy.result(timeout=1.0) is outputs["r-healthy"]
+
+    def test_output_with_no_waiter_is_still_cached(self):
+        """The pre-existing early-arrival path must keep working."""
+        executor = _make_executor()
+        output = DiffusionOutput(output="arrived early")
+        msg = AsyncDiffusionOutput(
+            kind=AsyncOutputKind.OUTPUT_READY,
+            async_output_id="abc123",
+            output=output,
+        )
+        _feed_one_msg_to_pump(executor, msg)
+
+        assert executor.wait_output_ready("abc123").result(timeout=1.0) is output
+
+
+class TestCheckHealthDetectsDeadPump:
+    """Regression for the zombie-server half of #5793/#5821: when a pump thread
+    dies, every process is alive and every request still runs on the GPU, so
+    /health stayed 200 while no request could ever return again.
+    """
+
+    @staticmethod
+    def _dead_thread():
+        t = threading.Thread(target=lambda: None, name="DiffusionResultPump-0")
+        t.start()
+        t.join()
+        assert not t.is_alive()
+        return t
+
+    def test_dead_pump_thread_marks_engine_dead(self):
+        from vllm.v1.engine.exceptions import EngineDeadError
+
+        executor = _make_executor()
+        executor._pump_running = True
+        executor._result_pump_threads = [self._dead_thread()]
+
+        with pytest.raises(EngineDeadError, match="DiffusionResultPump-0"):
+            executor.check_health()
+        assert executor._is_failed
+
+    def test_live_pump_thread_is_healthy(self):
+        executor = _make_executor()
+        executor._pump_running = True
+        pump = threading.Thread(target=executor._pump_stop.wait, name="DiffusionResultPump-0")
+        pump.start()
+        executor._result_pump_threads = [pump]
+        try:
+            executor.check_health()
+            assert not executor._is_failed
+        finally:
+            executor._pump_stop.set()
+            pump.join(timeout=2.0)
+
+    def test_stopped_pump_is_not_reported_dead(self):
+        """Shutdown stops the pump on purpose; that is not an engine failure."""
+        executor = _make_executor()
+        executor._pump_running = True
+        executor._pump_stop.set()
+        executor._result_pump_threads = [self._dead_thread()]
+
+        executor.check_health()
+        assert not executor._is_failed

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -948,14 +948,22 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
     ) -> None:
         """Resolve per-request futures from one batch-level output."""
         for per_req_id, req_id in per_req_map.items():
-            req_output = batch_output.get_request_output(req_id) if batch_output is not None else None
             per_req_result: DiffusionOutput
-            if req_output is not None and req_output.result is not None:
-                per_req_result = req_output.result
-            elif error:
-                per_req_result = DiffusionOutput(error=error)
-            else:
-                per_req_result = DiffusionOutput(error="No output result for batch request")
+            try:
+                req_output = batch_output.get_request_output(req_id) if batch_output is not None else None
+                if req_output is not None and req_output.result is not None:
+                    per_req_result = req_output.result
+                elif error:
+                    per_req_result = DiffusionOutput(error=error)
+                else:
+                    per_req_result = DiffusionOutput(error="No output result for batch request")
+            except Exception as e:
+                # The split map has already been popped, so an exception escaping
+                # here would take every request later in this batch with it: they
+                # would never be resolved and would hang until their own timeout.
+                # One corrupt request costs one request.
+                logger.exception("Failed to extract batch output for request %s", req_id)
+                per_req_result = DiffusionOutput(error=f"Failed to extract batch output for request {req_id}: {e}")
             with self._futures_lock:
                 pending = self._output_futures.pop(per_req_id, None)
                 if pending is not None and not pending.done():

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -884,8 +884,15 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                     try_set_result(fut, msg)
         elif msg.kind == AsyncOutputKind.OUTPUT_READY:
             batch_id = msg.async_output_id
+            if not batch_id:
+                # async_output_id is what routes the result back to its waiter.
+                # Without it there is nobody to resolve and nothing to cache, so
+                # the request hangs until its own timeout — say so rather than
+                # dropping the message silently.
+                logger.error("Dropping OUTPUT_READY with no async_output_id; its request cannot be resolved")
+                return
             with self._futures_lock:
-                per_req_map = self._batch_split_map.pop(batch_id, None) if batch_id else None
+                per_req_map = self._batch_split_map.pop(batch_id, None)
             if per_req_map is not None:
                 # Batch result: split into per-request DiffusionOutputs.
                 try:
@@ -907,32 +914,31 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                         logger.exception("SHM unpack failed in result pump")
                         exc = e
 
-                if batch_id:
-                    with self._futures_lock:
-                        pending = self._output_futures.pop(batch_id, None)
-                        if pending is not None and not pending.done():
-                            if exc is not None:
-                                try_set_exception(pending, exc)
-                            else:
-                                try_set_result(pending, output_result)
-                        elif pending is not None:
-                            # The waiter resolved itself first — cancelled by an
-                            # inter-output timeout, or aborted. Nothing will ever
-                            # collect a cached copy for it, so drop the result
-                            # instead of pinning the unpacked output (a whole
-                            # decoded video, for a t2va request) until shutdown.
-                            logger.debug(
-                                "Dropping output for %s: waiter already %s",
-                                batch_id,
-                                "cancelled" if pending.cancelled() else "resolved",
-                            )
+                with self._futures_lock:
+                    pending = self._output_futures.pop(batch_id, None)
+                    if pending is not None and not pending.done():
+                        if exc is not None:
+                            try_set_exception(pending, exc)
                         else:
-                            fut = concurrent.futures.Future()
-                            if exc is not None:
-                                fut.set_exception(exc)
-                            else:
-                                fut.set_result(output_result)
-                            self._completed_outputs[batch_id] = fut
+                            try_set_result(pending, output_result)
+                    elif pending is not None:
+                        # The waiter resolved itself first — cancelled by an
+                        # inter-output timeout, or aborted. Nothing will ever
+                        # collect a cached copy for it, so drop the result
+                        # instead of pinning the unpacked output (a whole
+                        # decoded video, for a t2va request) until shutdown.
+                        logger.debug(
+                            "Dropping output for %s: waiter already %s",
+                            batch_id,
+                            "cancelled" if pending.cancelled() else "resolved",
+                        )
+                    else:
+                        fut = concurrent.futures.Future()
+                        if exc is not None:
+                            fut.set_exception(exc)
+                        else:
+                            fut.set_result(output_result)
+                        self._completed_outputs[batch_id] = fut
 
     def _deliver_batch_split(
         self,

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -857,60 +857,82 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                     break
                 continue
 
-            if not isinstance(msg, AsyncDiffusionOutput):
-                # Non-async message: place into the sync buffer for
-                # collective_rpc() to consume via Path 2.
-                self._sync_result_buffer.put(msg)
-                continue
+            # This thread is the only reader of result_mq, so an escaping
+            # exception costs the whole queue, not just this message: every
+            # later result goes undelivered while the server keeps reporting
+            # healthy. Contain the blast radius to one message.
+            try:
+                self._dispatch_result(msg)
+            except Exception:
+                logger.exception("Result pump failed to dispatch a message; dropping it")
 
-            if msg.kind in (AsyncOutputKind.RPC_RESULT, AsyncOutputKind.COMPUTE_DONE):
-                with self._futures_lock:
-                    fut = self._rpc_futures.pop(msg.rpc_id, None) if msg.rpc_id else None
-                if fut is not None and not fut.done():
-                    if msg.error:
-                        try_set_exception(fut, RuntimeError(msg.error))
-                    else:
-                        try_set_result(fut, msg)
-            elif msg.kind == AsyncOutputKind.OUTPUT_READY:
-                batch_id = msg.async_output_id
-                with self._futures_lock:
-                    per_req_map = self._batch_split_map.pop(batch_id, None) if batch_id else None
-                if per_req_map is not None:
-                    # Batch result: split into per-request DiffusionOutputs.
+    def _dispatch_result(self, msg: object) -> None:
+        """Route one dequeued message to whoever is waiting for it."""
+        if not isinstance(msg, AsyncDiffusionOutput):
+            # Non-async message: place into the sync buffer for
+            # collective_rpc() to consume via Path 2.
+            self._sync_result_buffer.put(msg)
+            return
+
+        if msg.kind in (AsyncOutputKind.RPC_RESULT, AsyncOutputKind.COMPUTE_DONE):
+            with self._futures_lock:
+                fut = self._rpc_futures.pop(msg.rpc_id, None) if msg.rpc_id else None
+            if fut is not None and not fut.done():
+                if msg.error:
+                    try_set_exception(fut, RuntimeError(msg.error))
+                else:
+                    try_set_result(fut, msg)
+        elif msg.kind == AsyncOutputKind.OUTPUT_READY:
+            batch_id = msg.async_output_id
+            with self._futures_lock:
+                per_req_map = self._batch_split_map.pop(batch_id, None) if batch_id else None
+            if per_req_map is not None:
+                # Batch result: split into per-request DiffusionOutputs.
+                try:
+                    unpack_diffusion_output_shm(msg.output)
+                except Exception:
+                    logger.exception("SHM unpack failed for batch %s", batch_id)
+                self._deliver_batch_split(per_req_map, msg.output, msg.error)
+            else:
+                # Single-request result: unpack SHM first, then resolve or cache atomically.
+                output_result: DiffusionOutput | None = None
+                exc: Exception | None = None
+                if msg.error:
+                    exc = RuntimeError(msg.error)
+                else:
                     try:
                         unpack_diffusion_output_shm(msg.output)
-                    except Exception:
-                        logger.exception("SHM unpack failed for batch %s", batch_id)
-                    self._deliver_batch_split(per_req_map, msg.output, msg.error)
-                else:
-                    # Single-request result: unpack SHM first, then resolve or cache atomically.
-                    output_result: DiffusionOutput | None = None
-                    exc: Exception | None = None
-                    if msg.error:
-                        exc = RuntimeError(msg.error)
-                    else:
-                        try:
-                            unpack_diffusion_output_shm(msg.output)
-                            output_result = msg.output
-                        except Exception as e:
-                            logger.exception("SHM unpack failed in result pump")
-                            exc = e
+                        output_result = msg.output
+                    except Exception as e:
+                        logger.exception("SHM unpack failed in result pump")
+                        exc = e
 
-                    if batch_id:
-                        with self._futures_lock:
-                            pending = self._output_futures.pop(batch_id, None)
-                            if pending is not None and not pending.done():
-                                if exc is not None:
-                                    try_set_exception(pending, exc)
-                                else:
-                                    try_set_result(pending, output_result)
+                if batch_id:
+                    with self._futures_lock:
+                        pending = self._output_futures.pop(batch_id, None)
+                        if pending is not None and not pending.done():
+                            if exc is not None:
+                                try_set_exception(pending, exc)
                             else:
-                                fut = concurrent.futures.Future()
-                                if exc is not None:
-                                    fut.set_exception(exc)
-                                else:
-                                    fut.set_result(output_result)
-                                self._completed_outputs[batch_id] = fut
+                                try_set_result(pending, output_result)
+                        elif pending is not None:
+                            # The waiter resolved itself first — cancelled by an
+                            # inter-output timeout, or aborted. Nothing will ever
+                            # collect a cached copy for it, so drop the result
+                            # instead of pinning the unpacked output (a whole
+                            # decoded video, for a t2va request) until shutdown.
+                            logger.debug(
+                                "Dropping output for %s: waiter already %s",
+                                batch_id,
+                                "cancelled" if pending.cancelled() else "resolved",
+                            )
+                        else:
+                            fut = concurrent.futures.Future()
+                            if exc is not None:
+                                fut.set_exception(exc)
+                            else:
+                                fut.set_result(output_result)
+                            self._completed_outputs[batch_id] = fut
 
     def _deliver_batch_split(
         self,
@@ -932,6 +954,13 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                 pending = self._output_futures.pop(per_req_id, None)
                 if pending is not None and not pending.done():
                     try_set_result(pending, per_req_result)
+                elif pending is not None:
+                    # Waiter gave up (cancelled/aborted); see _dispatch_result.
+                    logger.debug(
+                        "Dropping batch-split output for %s: waiter already %s",
+                        per_req_id,
+                        "cancelled" if pending.cancelled() else "resolved",
+                    )
                 else:
                     fut: concurrent.futures.Future = concurrent.futures.Future()
                     fut.set_result(per_req_result)
@@ -975,6 +1004,15 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
             if not p.is_alive():
                 self._is_failed = True
                 raise EngineDeadError(f"Worker process {p.name} is dead")
+        # A pump thread is the sole reader of its worker's result queue. If one
+        # dies, every process is still alive and every request still runs on the
+        # GPU — the results simply never come back. Without this check the
+        # engine reports healthy forever and only a restart recovers it.
+        if self._pump_running and not self._pump_stop.is_set():
+            for thread in getattr(self, "_result_pump_threads", []):
+                if not thread.is_alive():
+                    self._is_failed = True
+                    raise EngineDeadError(f"Result pump thread {thread.name} is dead")
 
     def shutdown(self) -> None:
         self._closed = True


### PR DESCRIPTION
## Purpose

A `DiffusionResultPump` thread is the sole reader of one worker's result queue. #5983 fixed the `InvalidStateError` that was killing it, and that fix is correct — but it left three gaps around itself, all of which were raised in #5793 / #5821 and none of which are on `main` today.

**1. Only the dequeue half of the pump loop is guarded.** `_result_pump` wraps `dequeue` in `try/except`; everything after it runs unguarded, and `_start_result_pump` passes `target=self._result_pump` with no wrapper. So anything raised while dispatching still escapes and kills the thread — and because the thread is the only reader of that queue, the cost is not one message but every message after it. `_deliver_batch_split`'s `batch_output.get_request_output()` and the `_sync_result_buffer.put()` path are both live examples. This PR extracts the dispatch body into `_dispatch_result()` and wraps the call, so one bad message costs one message.

**2. `check_health()` never looked at the pump.** This is the part that makes the failure so unpleasant operationally: when a pump thread dies, every worker process is still alive and every request still runs to completion on the GPU — the results simply never come back. `/health` and `/v1/models` answer 200 throughout, so an operator's only signal is noticing that requests stopped completing. Now a dead pump is reported as `EngineDeadError`, the same as a dead worker process. Guarded on `_pump_running and not _pump_stop.is_set()` so a deliberate shutdown isn't reported as a failure.

**3. A result whose waiter had already cancelled was cached forever.** `_completed_outputs` exists for the race where a result arrives before the caller asks for it. A caller that cancelled — an inter-output timeout, or an abort — never asks, so the entry is never popped: `_completed_outputs` is only drained by `wait_output_ready()` and the early-arrival adopt path, and there is no TTL and no abort-side cleanup. The pinned value is the *unpacked* output, which for a `t2va` request is a whole decoded video. Dropping it is also what the `elif` makes explicit; the `pending is None` early-arrival path is untouched.

The broad `except Exception` added in (1) is deliberate rather than an oversight: it sits at a top-level thread boundary, and it logs the full traceback via `logger.exception` instead of swallowing. Per the code-quality guidance, that is the sanctioned form at such a boundary — the alternative is the status quo, where the thread dies.

Most of the diff is the dedent from extracting `_dispatch_result()`. The logic change is the three points above; reviewing with whitespace ignored makes that much clearer.

Reported in #5793 and #5821. #6255 covers the other still-open item from those reports — the hardcoded 30 s `_ASYNC_OUTPUT_TIMEOUT` that triggers the cancellation in the first place. The two are independent and can land in either order.

## Test Plan

Added three test classes to `tests/diffusion/test_result_pump.py` (CPU-only, no GPU), and generalized the existing `_feed_one_msg_to_pump` helper into `_feed_msgs_to_pump` so a test can feed a bad message followed by a good one and assert the good one still lands.

- `TestResultPumpDispatchIsGuarded` — a message that raises during dispatch (sync-buffer path, and a corrupt batch output) must not stop the next message from being delivered by the same pump thread.
- `TestResultPumpDropsOutputForAbandonedWaiter` — a cancelled waiter leaves `_completed_outputs` empty, in both the single-request and batch-split paths, while a result with no waiter at all is still cached as before.
- `TestCheckHealthDetectsDeadPump` — a dead pump thread raises `EngineDeadError` and sets `_is_failed`; a live one is healthy; a stopped one (shutdown) is not reported as dead.

**vLLM Version:** 0.26.1rc1.dev608+g99a10304d

**vLLM-Omni Commit:** baba7d1e2ef9d326486493146b43157f7cd4f8d0

## Test Result

```
tests/diffusion/test_result_pump.py                   29 passed
tests/diffusion/test_multiproc_engine_concurrency.py  \
tests/diffusion/test_diffusion_engine_cleanup.py       > 81 passed
tests/diffusion/test_diffusion_engine_rpc_routing.py  /
```

With the `multiproc_executor.py` change reverted and the tests kept, the five tests that assert the new behaviour fail and the three that assert preserved behaviour still pass:

```
FAILED TestResultPumpDispatchIsGuarded::test_dispatch_failure_does_not_kill_the_pump
FAILED TestResultPumpDispatchIsGuarded::test_batch_split_failure_does_not_kill_the_pump
FAILED TestResultPumpDropsOutputForAbandonedWaiter::test_cancelled_waiter_output_is_not_cached
FAILED TestResultPumpDropsOutputForAbandonedWaiter::test_cancelled_waiter_batch_split_output_is_not_cached
FAILED TestCheckHealthDetectsDeadPump::test_dead_pump_thread_marks_engine_dead
5 failed, 24 passed
```

`ruff check` and `ruff format --check` pass on both changed files.
