### PR TITLE
[Feature][Diffusion] Scheduler registry and injection seam for diffusion pipelines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,11 @@ vllm-omni = "vllm_omni.entrypoints.cli.main:main"
 [project.entry-points."vllm.general_plugins"]
 vllm_omni_register_models = "vllm_omni.engine.arg_utils:register_omni_models_to_vllm"
 
+# External packages (e.g. verl-omni) advertise diffusion scheduler classes
+# under this group; vllm_omni.diffusion.models.schedulers.resolve_scheduler_cls
+# picks them up by name. Declared empty here so the group is owned by vllm-omni.
+[project.entry-points."vllm_omni.schedulers"]
+
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/diffusion/models/schedulers/test_registry.py
+++ b/tests/diffusion/models/schedulers/test_registry.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the diffusion scheduler registry and construction seam.
+
+Covers ``vllm_omni.diffusion.models.schedulers.registry``: name registration
+(direct + decorator), class resolution (registry / entry points / dotted
+path), the ``build_pipeline_scheduler`` resolution order, kwargs merging, the
+bit-identical default fallback, and the documented injected-scheduler
+contract.
+"""
+
+import copy
+import importlib.metadata
+import inspect
+from types import SimpleNamespace
+from typing import Any, ClassVar
+from unittest.mock import Mock
+
+import pytest
+
+import vllm_omni.diffusion.models.schedulers.registry as registry_mod
+from vllm_omni.diffusion.models.schedulers import (
+    FlowMatchEulerDiscreteScheduler,
+    build_pipeline_scheduler,
+    register_scheduler,
+    resolve_scheduler_cls,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class RecordingMockScheduler:
+    """Minimal scheduler satisfying the documented injection contract.
+
+    Records every ``from_pretrained`` call in the class-level ``constructed``
+    list so tests can inspect the exact construction arguments.
+    """
+
+    constructed: ClassVar[list[dict[str, Any]]] = []
+
+    def __init__(self, **config: Any) -> None:
+        self.config = dict(config)
+        self.timesteps: list[int] = []
+        self._begin_index = 0
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model: str,
+        subfolder: str | None = None,
+        local_files_only: bool = False,
+        **kwargs: Any,
+    ) -> "RecordingMockScheduler":
+        cls.constructed.append(
+            {
+                "model": model,
+                "subfolder": subfolder,
+                "local_files_only": local_files_only,
+                "kwargs": kwargs,
+            }
+        )
+        return cls(**kwargs)
+
+    def step(self, noise_pred, t, latents, return_dict=False, generator=None):
+        return (latents,)
+
+    def set_timesteps(self, num_inference_steps: int, device=None) -> None:
+        self.timesteps = list(range(num_inference_steps))
+
+    def set_begin_index(self, begin_index: int = 0) -> None:
+        self._begin_index = begin_index
+
+
+class OtherMockScheduler(RecordingMockScheduler):
+    """Second registrable class, distinguished by type."""
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry(monkeypatch):
+    """Snapshot the module-global registry and skip real entry-point scans."""
+    snapshot = dict(registry_mod._SCHEDULER_REGISTRY)
+    monkeypatch.setattr(registry_mod, "_entry_points_loaded", True)
+    RecordingMockScheduler.constructed.clear()
+    yield
+    registry_mod._SCHEDULER_REGISTRY.clear()
+    registry_mod._SCHEDULER_REGISTRY.update(snapshot)
+
+
+def _od_config(**overrides) -> SimpleNamespace:
+    """Stub OmniDiffusionConfig (duck-typed; the factory only uses getattr)."""
+    base = {
+        "model": "stub-model",
+        "scheduler": None,
+        "scheduler_kwargs": None,
+        "local_files_only": False,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def assert_scheduler_contract(scheduler: Any) -> None:
+    """Validate the documented injected-scheduler contract (registry.py docstring)."""
+    sig = inspect.signature(scheduler.step)
+    positional = [
+        p
+        for p in sig.parameters.values()
+        if p.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    ]
+    assert len(positional) >= 3, "step() must accept (noise_pred, t, latents) positionally"
+    assert "return_dict" in sig.parameters, "step() must accept return_dict"
+    assert "generator" in sig.parameters, "step() must accept generator"
+    assert callable(getattr(scheduler, "set_timesteps", None)), "set_timesteps() required"
+    assert callable(getattr(scheduler, "set_begin_index", None)), "set_begin_index() required"
+    assert hasattr(scheduler, "config"), ".config attribute required"
+    copy.deepcopy(scheduler)  # must be deepcopy-safe
+
+
+class TestRegisterAndResolve:
+    def test_register_direct_call(self):
+        register_scheduler("mock_direct", RecordingMockScheduler)
+        assert resolve_scheduler_cls("mock_direct") is RecordingMockScheduler
+
+    def test_register_decorator(self):
+        @register_scheduler("mock_decorated")
+        class DecoratedScheduler(RecordingMockScheduler):
+            pass
+
+        assert resolve_scheduler_cls("mock_decorated") is DecoratedScheduler
+
+    def test_resolve_none_passthrough(self):
+        assert resolve_scheduler_cls(None) is None
+
+    def test_resolve_class_passthrough(self):
+        assert resolve_scheduler_cls(RecordingMockScheduler) is RecordingMockScheduler
+
+    def test_resolve_by_dotted_path(self):
+        ref = (
+            "vllm_omni.diffusion.models.schedulers.scheduling_flow_match_euler_discrete.FlowMatchEulerDiscreteScheduler"
+        )
+        assert resolve_scheduler_cls(ref) is FlowMatchEulerDiscreteScheduler
+
+    def test_resolve_unknown_bare_name_raises_keyerror(self):
+        register_scheduler("mock_known", RecordingMockScheduler)
+        with pytest.raises(KeyError, match="Unknown scheduler 'nope'.*mock_known"):
+            resolve_scheduler_cls("nope")
+
+    def test_resolve_unknown_dotted_path_raises(self):
+        with pytest.raises(ModuleNotFoundError):
+            resolve_scheduler_cls("no.such.module.Scheduler")
+
+
+class _FakeEntryPoint:
+    def __init__(self, name: str, cls: type) -> None:
+        self.name = name
+        self._cls = cls
+
+    def load(self) -> type:
+        return self._cls
+
+
+class TestEntryPoints:
+    def _patch_entry_points(self, monkeypatch, eps: list[_FakeEntryPoint]) -> None:
+        monkeypatch.setattr(importlib.metadata, "entry_points", lambda group=None: eps)
+        monkeypatch.setattr(registry_mod, "_entry_points_loaded", False)
+
+    def test_entry_point_registered_and_resolvable(self, monkeypatch):
+        self._patch_entry_points(monkeypatch, [_FakeEntryPoint("ep_scheduler", RecordingMockScheduler)])
+        assert resolve_scheduler_cls("ep_scheduler") is RecordingMockScheduler
+
+    def test_entry_points_loaded_only_once(self, monkeypatch):
+        calls = []
+
+        def _fake_entry_points(group=None):
+            calls.append(group)
+            return [_FakeEntryPoint("ep_scheduler", RecordingMockScheduler)]
+
+        monkeypatch.setattr(importlib.metadata, "entry_points", _fake_entry_points)
+        monkeypatch.setattr(registry_mod, "_entry_points_loaded", False)
+        resolve_scheduler_cls("ep_scheduler")
+        resolve_scheduler_cls("ep_scheduler")
+        assert calls == [registry_mod.SCHEDULER_ENTRY_POINT_GROUP]
+
+    def test_direct_registration_wins_over_entry_point(self, monkeypatch):
+        register_scheduler("ep_scheduler", OtherMockScheduler)
+        self._patch_entry_points(monkeypatch, [_FakeEntryPoint("ep_scheduler", RecordingMockScheduler)])
+        assert resolve_scheduler_cls("ep_scheduler") is OtherMockScheduler
+
+
+class TestBuildPipelineScheduler:
+    def test_explicit_arg_beats_config(self):
+        register_scheduler("config_sched", RecordingMockScheduler)
+        od_config = _od_config(scheduler="config_sched")
+        result = build_pipeline_scheduler(od_config, scheduler_cls=OtherMockScheduler)
+        assert isinstance(result, OtherMockScheduler)
+
+    def test_config_beats_default_builder(self):
+        register_scheduler("config_sched", RecordingMockScheduler)
+        default_builder = Mock(return_value=object())
+        result = build_pipeline_scheduler(_od_config(scheduler="config_sched"), default_builder=default_builder)
+        assert isinstance(result, RecordingMockScheduler)
+        default_builder.assert_not_called()
+
+    def test_default_fallback_bit_identical(self):
+        sentinel = object()
+        default_builder = Mock(return_value=sentinel)
+        result = build_pipeline_scheduler(_od_config(), default_builder=default_builder)
+        assert result is sentinel, "default path must pass the builder's return value through untouched"
+        default_builder.assert_called_once_with()
+        assert RecordingMockScheduler.constructed == []
+
+    def test_construction_args_match_stock_sites(self):
+        register_scheduler("config_sched", RecordingMockScheduler)
+        od_config = _od_config(scheduler="config_sched", model="/local/model", local_files_only=True)
+        build_pipeline_scheduler(od_config)
+        assert RecordingMockScheduler.constructed == [
+            {
+                "model": "/local/model",
+                "subfolder": "scheduler",
+                "local_files_only": True,
+                "kwargs": {},
+            }
+        ]
+
+    def test_kwargs_merging_explicit_over_config(self):
+        register_scheduler("config_sched", RecordingMockScheduler)
+        od_config = _od_config(
+            scheduler="config_sched",
+            scheduler_kwargs={"shift": 1.0, "num_train_timesteps": 1000},
+        )
+        result = build_pipeline_scheduler(od_config, scheduler_kwargs={"shift": 3.0})
+        assert RecordingMockScheduler.constructed[-1]["kwargs"] == {"shift": 3.0, "num_train_timesteps": 1000}
+        assert result.config == {"shift": 3.0, "num_train_timesteps": 1000}
+
+    def test_config_accepts_dotted_path(self):
+        od_config = _od_config(scheduler=f"{__name__}.RecordingMockScheduler")
+        default_builder = Mock()
+        result = build_pipeline_scheduler(od_config, default_builder=default_builder)
+        assert isinstance(result, RecordingMockScheduler)
+        default_builder.assert_not_called()
+
+
+class TestSchedulerContract:
+    def test_mock_satisfies_contract(self):
+        scheduler = RecordingMockScheduler(num_train_timesteps=1000)
+        assert_scheduler_contract(scheduler)
+
+    def test_mock_step_and_timesteps_behavior(self):
+        scheduler = RecordingMockScheduler()
+        scheduler.set_timesteps(4)
+        assert scheduler.timesteps == [0, 1, 2, 3]
+        scheduler.set_begin_index(1)
+        assert scheduler._begin_index == 1
+        latents = object()
+        assert scheduler.step("noise", 0, latents, return_dict=False) == (latents,)
+
+    def test_deepcopy_gives_independent_state(self):
+        scheduler = RecordingMockScheduler()
+        scheduler.set_timesteps(4)
+        clone = copy.deepcopy(scheduler)
+        clone.set_timesteps(2)
+        assert scheduler.timesteps == [0, 1, 2, 3]
+        assert clone.timesteps == [0, 1]
+
+    def test_stock_flow_match_scheduler_satisfies_contract(self):
+        # The vendored stock scheduler must keep satisfying the contract that
+        # injected schedulers are held to (it is deep-copied per request in
+        # step-wise execution).
+        assert_scheduler_contract(FlowMatchEulerDiscreteScheduler())

--- a/tests/e2e/features/helpers/custom_scheduler.py
+++ b/tests/e2e/features/helpers/custom_scheduler.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Test double for the scheduler-injection E2E tests.
+
+``FlowMatchEulerDiscreteSchedulerForTest`` subclasses the vendored
+``FlowMatchEulerDiscreteScheduler`` and records construction/timestepping/
+stepping by appending marker lines to the file named by the
+``VLLM_OMNI_CUSTOM_SCHEDULER_MARKER`` environment variable. Diffusion workers
+run in subprocesses, so in-process counters are not observable from the test
+process; the env var is inherited by child processes, making the marker file
+a cross-process observable.
+"""
+
+from __future__ import annotations
+
+import os
+
+from vllm_omni.diffusion.models.schedulers import FlowMatchEulerDiscreteScheduler
+
+MARKER_ENV_VAR = "VLLM_OMNI_CUSTOM_SCHEDULER_MARKER"
+
+
+class FlowMatchEulerDiscreteSchedulerForTest(FlowMatchEulerDiscreteScheduler):
+    """Stock flow-match Euler scheduler that proves it was used via a marker file."""
+
+    @staticmethod
+    def _mark(event: str) -> None:
+        path = os.environ.get(MARKER_ENV_VAR)
+        if path:
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(f"{event}\n")
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        cls._mark("constructed")
+        return super().from_pretrained(*args, **kwargs)
+
+    def set_timesteps(self, *args, **kwargs):
+        type(self)._mark("set_timesteps")
+        return super().set_timesteps(*args, **kwargs)
+
+    def step(self, *args, **kwargs):
+        type(self)._mark("stepped")
+        return super().step(*args, **kwargs)

--- a/tests/e2e/features/scheduler_injection/test_scheduler_injection.py
+++ b/tests/e2e/features/scheduler_injection/test_scheduler_injection.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""E2E tests for diffusion scheduler injection (``OmniDiffusionConfig.scheduler``).
+
+Validates that setting ``scheduler`` to a dotted scheduler class path injects
+that scheduler into the stock pipeline — no ``custom_pipeline_args`` needed —
+and that omitting it keeps the pipeline's default scheduler (the default
+construction path must stay bit-identical).
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import ExitStack
+
+import numpy as np
+import pytest
+
+from tests.e2e.features.helpers.custom_scheduler import MARKER_ENV_VAR
+from tests.helpers.mark import hardware_test
+from vllm_omni.entrypoints.async_omni import AsyncOmni
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+from vllm_omni.outputs import OmniRequestOutput
+
+INJECTED_SCHEDULER = "tests.e2e.features.helpers.custom_scheduler.FlowMatchEulerDiscreteSchedulerForTest"
+
+# Same tiny random model as the custom_pipeline e2e tests.
+MODEL = "tiny-random/Qwen-Image"
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion]
+
+
+def _sampling_params(*, seed: int = 42) -> OmniDiffusionSamplingParams:
+    return OmniDiffusionSamplingParams(
+        num_inference_steps=2,
+        guidance_scale=0.0,
+        height=256,
+        width=256,
+        seed=seed,
+    )
+
+
+async def _generate_once(
+    engine: AsyncOmni,
+    *,
+    request_id: str,
+    sampling_params: OmniDiffusionSamplingParams,
+) -> OmniRequestOutput:
+    last_output = None
+    async for output in engine.generate(
+        prompt="a beautiful sunset over the ocean with vibrant orange and purple clouds "
+        "reflecting on the calm water surface near a rocky coastline",
+        request_id=request_id,
+        sampling_params_list=[sampling_params],
+        output_modalities=["image"],
+    ):
+        last_output = output
+
+    assert last_output is not None
+    assert isinstance(last_output, OmniRequestOutput)
+    return last_output
+
+
+def _assert_valid_image_output(output: OmniRequestOutput) -> None:
+    assert output.final_output_type == "image"
+    assert output.images, "Expected at least one generated image"
+
+    image = output.images[0]
+    arr = np.asarray(image, dtype=np.float32) / 255.0
+
+    assert arr.ndim == 3 and arr.shape[2] == 3, f"Expected HWC RGB image, got shape={arr.shape}"
+    assert arr.shape[0] > 0 and arr.shape[1] > 0
+    assert 0.0 <= float(arr[0, 0, 0]) <= 1.0
+
+
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.asyncio
+async def test_scheduler_injection_uses_injected_scheduler(tmp_path, monkeypatch):
+    """``scheduler=<dotted path>`` must construct and step the injected class."""
+    marker = tmp_path / "scheduler_events.txt"
+    monkeypatch.setenv(MARKER_ENV_VAR, str(marker))
+
+    with ExitStack() as after:
+        engine = AsyncOmni(
+            model=MODEL,
+            scheduler=INJECTED_SCHEDULER,
+            enforce_eager=True,
+            max_num_seqs=1,
+        )
+        after.callback(engine.shutdown)
+
+        output = await _generate_once(
+            engine,
+            request_id=f"test_injected_{uuid.uuid4().hex[:8]}",
+            sampling_params=_sampling_params(seed=42),
+        )
+
+        _assert_valid_image_output(output)
+
+    assert marker.exists(), "injected scheduler never wrote its marker file"
+    events = marker.read_text(encoding="utf-8").splitlines()
+    assert "constructed" in events, f"injected scheduler was not constructed: {events}"
+    assert "stepped" in events, f"injected scheduler never stepped: {events}"
+
+
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.asyncio
+async def test_default_scheduler_path_without_injection(tmp_path, monkeypatch):
+    """Control run: without ``scheduler``, the pipeline default is used and the
+    injected test class is never touched."""
+    marker = tmp_path / "scheduler_events.txt"
+    monkeypatch.setenv(MARKER_ENV_VAR, str(marker))
+
+    with ExitStack() as after:
+        engine = AsyncOmni(
+            model=MODEL,
+            enforce_eager=True,
+            max_num_seqs=1,
+        )
+        after.callback(engine.shutdown)
+
+        output = await _generate_once(
+            engine,
+            request_id=f"test_default_{uuid.uuid4().hex[:8]}",
+            sampling_params=_sampling_params(seed=42),
+        )
+
+        _assert_valid_image_output(output)
+
+    assert not marker.exists(), "default path must not construct/step the injected scheduler"

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -611,6 +611,8 @@ class _DiffusionConfigProjection:
     override_transformer_cls_name: str | None = None
     worker_extension_cls: str | None = None
     custom_pipeline_args: dict[str, Any] | None = None
+    scheduler: str | None = None
+    scheduler_kwargs: dict[str, Any] | None = None
     additional_config: dict[str, Any] = field(default_factory=dict)
     enable_stage_verification: bool = True
     prompt_file_path: str | None = None

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -755,6 +755,13 @@ class OmniDiffusionConfig:
     # Custom pipeline arguments for custom pipelines
     custom_pipeline_args: dict[str, Any] | None = None
 
+    # Scheduler injection: registry name (see vllm_omni.diffusion.models.schedulers)
+    # or dotted class path of a scheduler class to use instead of the pipeline's
+    # default scheduler. Constructed via cls.from_pretrained(model, subfolder="scheduler").
+    scheduler: str | None = None
+    # Extra kwargs forwarded to the injected scheduler's from_pretrained().
+    scheduler_kwargs: dict[str, Any] | None = None
+
     # Diffusion model loading format
     # "default", "custom_pipeline", "dummy", "diffusers" (HF diffusers adapter)
     diffusion_load_format: str = "default"

--- a/vllm_omni/diffusion/models/flux/pipeline_flux.py
+++ b/vllm_omni/diffusion/models/flux/pipeline_flux.py
@@ -29,6 +29,7 @@ from vllm_omni.diffusion.models.dmd2 import DMD2PipelineMixin
 from vllm_omni.diffusion.models.flux import FluxTransformer2DModel
 from vllm_omni.diffusion.models.flux.flux_pipeline_mixin import FluxPipelineMixin
 from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.models.t5_encoder import T5EncoderModel
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
@@ -106,8 +107,11 @@ class FluxPipeline(
         # Check if model is a local path
         local_files_only = os.path.exists(model)
 
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-            model, subfolder="scheduler", local_files_only=local_files_only
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
+                model, subfolder="scheduler", local_files_only=local_files_only
+            ),
         )
         self.text_encoder = CLIPTextModel.from_pretrained(
             model, subfolder="text_encoder", local_files_only=local_files_only

--- a/vllm_omni/diffusion/models/ltx2/ltx2_components.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_components.py
@@ -30,6 +30,7 @@ from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_ltx2 import Dis
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_prefetch, prefetch_subfolders
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.offloader.module_collector import ModuleDiscovery
 
 if TYPE_CHECKING:
@@ -512,10 +513,13 @@ def initialize_pipeline_components(pipeline: Any, od_config: Any) -> None:
     quant_config = getattr(od_config, "quantization_config", None)
     pipeline.transformer = create_transformer_from_config(transformer_config, quant_config=quant_config)
     _place_aux_components(pipeline)
-    pipeline.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-        model,
-        subfolder="scheduler",
-        local_files_only=local_files_only,
+    pipeline.scheduler = build_pipeline_scheduler(
+        od_config,
+        default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
+            model,
+            subfolder="scheduler",
+            local_files_only=local_files_only,
+        ),
     )
     expected_checkpoint_kind: LTXCheckpointKind | None = None
     if pipeline.pipeline_kind == "two_stage":

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -37,6 +37,7 @@ from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
     QwenImageTransformer2DModel,
 )
 from vllm_omni.diffusion.models.qwen_image.rope_utils import txt_seq_lens_from_embeds
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.utils.prompt_utils import (
     validate_prompt_sequence_lengths,
@@ -310,8 +311,11 @@ class QwenImagePipeline(
             qwen_subfolders,
         )
 
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-            model, subfolder="scheduler", local_files_only=local_files_only
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
+                model, subfolder="scheduler", local_files_only=local_files_only
+            ),
         )
         # ``from_pretrained_with_prefetch`` re-prefetches and retries on a
         # half-written cache (missing-shard ``OSError`` and the default

--- a/vllm_omni/diffusion/models/schedulers/__init__.py
+++ b/vllm_omni/diffusion/models/schedulers/__init__.py
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from vllm_omni.diffusion.models.schedulers.registry import (
+    build_pipeline_scheduler,
+    register_scheduler,
+    resolve_scheduler_cls,
+)
 from vllm_omni.diffusion.models.schedulers.scheduling_dmd2_euler import DMD2EulerScheduler
 from vllm_omni.diffusion.models.schedulers.scheduling_flow_match_euler_discrete import (
     FlowMatchEulerDiscreteScheduler,
@@ -13,4 +18,7 @@ __all__ = [
     "DMD2EulerScheduler",
     "FlowMatchEulerDiscreteScheduler",
     "FlowUniPCMultistepScheduler",
+    "build_pipeline_scheduler",
+    "register_scheduler",
+    "resolve_scheduler_cls",
 ]

--- a/vllm_omni/diffusion/models/schedulers/registry.py
+++ b/vllm_omni/diffusion/models/schedulers/registry.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Scheduler registry and construction seam for diffusion pipelines.
+
+This module lets external packages (e.g. RL frameworks such as verl-omni)
+inject their own scheduler classes into vllm-omni's diffusion pipelines
+without editing any denoise loop. A scheduler class can be registered under
+a name via :func:`register_scheduler` or advertised through the
+``vllm_omni.schedulers`` entry-point group, and is then selected engine-wide
+via ``OmniDiffusionConfig.scheduler`` (registry name or dotted class path)
+with constructor overrides from ``OmniDiffusionConfig.scheduler_kwargs``.
+
+Injected scheduler classes must satisfy the same contract the stock
+pipelines already rely on (diffusers-style):
+
+* ``step(noise_pred, t, latents, return_dict=False, generator=None)`` —
+  called only through ``CFGParallelMixin.scheduler_step[_maybe_with_cfg]``;
+  with ``return_dict=False`` it must return a tuple whose first element is
+  the stepped latents. ``generator`` is only passed when not ``None``.
+* ``set_timesteps(num_inference_steps, device=...)`` and expose
+  ``.timesteps`` afterwards.
+* ``set_begin_index(...)`` for pipeline-parallel timestep slicing.
+* a ``.config`` attribute (diffusers ``ConfigMixin``-style) carrying at
+  least ``num_train_timesteps``.
+* deepcopy-safe: step-wise execution deep-copies the scheduler per request.
+
+Injected classes are constructed with
+``cls.from_pretrained(od_config.model, subfolder="scheduler",
+local_files_only=od_config.local_files_only, **scheduler_kwargs)``,
+matching how the stock schedulers are loaded. When no scheduler is
+configured, :func:`build_pipeline_scheduler` falls through to the calling
+pipeline's own ``default_builder`` so the default path stays bit-identical.
+
+This module must stay importable without torch/diffusers and must not
+import ``OmniDiffusionConfig`` at runtime (duck typing only) to avoid
+import cycles.
+"""
+
+import importlib
+import importlib.metadata
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from vllm_omni.diffusion.data import OmniDiffusionConfig
+
+SCHEDULER_ENTRY_POINT_GROUP = "vllm_omni.schedulers"
+
+_SCHEDULER_REGISTRY: dict[str, type] = {}
+_entry_points_loaded = False
+
+
+def register_scheduler(name: str, cls: type | None = None):
+    """Register a scheduler class under ``name``.
+
+    Usable as a direct call (``register_scheduler("flow_match_sde", MyScheduler)``)
+    or as a decorator (``@register_scheduler("flow_match_sde")``).
+    """
+
+    def _do(c: type) -> type:
+        _SCHEDULER_REGISTRY[name] = c
+        return c
+
+    return _do(cls) if cls is not None else _do
+
+
+def _load_entry_points() -> None:
+    global _entry_points_loaded
+    if _entry_points_loaded:
+        return
+    for ep in importlib.metadata.entry_points(group=SCHEDULER_ENTRY_POINT_GROUP):
+        _SCHEDULER_REGISTRY.setdefault(ep.name, ep.load())
+    _entry_points_loaded = True
+
+
+def resolve_scheduler_cls(ref: str | type | None) -> type | None:
+    """Resolve a scheduler reference to a class.
+
+    ``None`` and class objects pass through unchanged. Strings resolve
+    against the registry (including lazily loaded ``vllm_omni.schedulers``
+    entry points) first, then fall back to a dotted import path. A bare
+    unknown name raises ``KeyError`` listing the registered names.
+    """
+    if ref is None or isinstance(ref, type):
+        return ref
+    _load_entry_points()
+    if ref in _SCHEDULER_REGISTRY:
+        return _SCHEDULER_REGISTRY[ref]
+    module, _, attr = ref.rpartition(".")  # dotted-path fallback
+    if not module:
+        raise KeyError(f"Unknown scheduler '{ref}'. Registered: {sorted(_SCHEDULER_REGISTRY)}")
+    return getattr(importlib.import_module(module), attr)
+
+
+def build_pipeline_scheduler(
+    od_config: "OmniDiffusionConfig",
+    scheduler_cls: str | type | None = None,
+    scheduler_kwargs: dict[str, Any] | None = None,
+    default_builder: Callable[[], Any] | None = None,
+):
+    """Single construction seam replacing hardcoded scheduler ``from_pretrained`` sites.
+
+    Resolution order: explicit ``scheduler_cls`` arg > ``od_config.scheduler``
+    > pipeline default. When no scheduler is configured, ``default_builder``
+    is invoked and its return value is passed through untouched, preserving
+    the pipeline's existing construction bit-for-bit.
+    """
+    cls = resolve_scheduler_cls(scheduler_cls) or resolve_scheduler_cls(getattr(od_config, "scheduler", None))
+    if cls is None:
+        assert default_builder is not None
+        return default_builder()
+    kwargs = dict(getattr(od_config, "scheduler_kwargs", None) or {})
+    kwargs.update(scheduler_kwargs or {})
+    return cls.from_pretrained(
+        od_config.model,
+        subfolder="scheduler",
+        local_files_only=getattr(od_config, "local_files_only", False),
+        **kwargs,
+    )

--- a/vllm_omni/diffusion/models/sd3/pipeline_sd3.py
+++ b/vllm_omni/diffusion/models/sd3/pipeline_sd3.py
@@ -22,6 +22,7 @@ from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_prefetch, prefetch_subfolders
 from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.models.sd3.sd3_transformer import (
     SD3Transformer2DModel,
 )
@@ -197,8 +198,11 @@ class StableDiffusion3Pipeline(nn.Module, CFGParallelMixin, DiffusionPipelinePro
         # don't carry weights and therefore don't take ``torch_dtype``.
         dtype = od_config.dtype
 
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-            model, subfolder="scheduler", local_files_only=local_files_only
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
+                model, subfolder="scheduler", local_files_only=local_files_only
+            ),
         )
         self.tokenizer = CLIPTokenizer.from_pretrained(model, subfolder="tokenizer", local_files_only=local_files_only)
         self.tokenizer_2 = CLIPTokenizer.from_pretrained(

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
@@ -31,7 +31,7 @@ from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_p
 from vllm_omni.diffusion.models.dmd2 import DMD2PipelineMixin
 from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin, _is_rank_zero
-from vllm_omni.diffusion.models.schedulers import FlowUniPCMultistepScheduler
+from vllm_omni.diffusion.models.schedulers import FlowUniPCMultistepScheduler, build_pipeline_scheduler
 from vllm_omni.diffusion.models.wan2_2.scheduling_wan_euler import WanEulerScheduler
 from vllm_omni.diffusion.models.wan2_2.wan2_2_transformer import WanTransformer3DModel
 from vllm_omni.diffusion.postprocess import interpolate_video_tensor
@@ -427,7 +427,10 @@ class Wan22Pipeline(
 
         self._sample_solver = "unipc"
         self._flow_shift = od_config.flow_shift if od_config.flow_shift is not None else 5.0
-        self.scheduler = build_wan_scheduler(self._sample_solver, self._flow_shift)
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: build_wan_scheduler(self._sample_solver, self._flow_shift),
+        )
 
         self.vae_scale_factor_temporal = self.vae.config.scale_factor_temporal if getattr(self, "vae", None) else 4
         self.vae_scale_factor_spatial = self.vae.config.scale_factor_spatial if getattr(self, "vae", None) else 8
@@ -660,9 +663,20 @@ class Wan22Pipeline(
         sample_solver = resolve_wan_sample_solver(req, default=self._sample_solver)
         flow_shift = resolve_wan_flow_shift(req, self.od_config)
         if sample_solver != self._sample_solver or abs(flow_shift - self._flow_shift) > 1e-6:
-            self.scheduler = build_wan_scheduler(sample_solver, flow_shift)
-            self._sample_solver = sample_solver
-            self._flow_shift = flow_shift
+            if self.od_config.scheduler is not None:
+                # An injected scheduler owns stepping; rebuilding from
+                # per-request sample_solver/flow_shift would replace it.
+                logger.warning(
+                    "Ignoring per-request sample_solver=%s/flow_shift=%s: an injected scheduler "
+                    "(od_config.scheduler=%r) is active and is left untouched.",
+                    sample_solver,
+                    flow_shift,
+                    self.od_config.scheduler,
+                )
+            else:
+                self.scheduler = build_wan_scheduler(sample_solver, flow_shift)
+                self._sample_solver = sample_solver
+                self._flow_shift = flow_shift
 
         # Timesteps
         self.scheduler.set_timesteps(num_steps, device=device)

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -174,6 +174,10 @@ class OmniEngineArgs(EngineArgs):
         custom_pipeline_args: Dictionary of arguments for custom pipeline
             initialization (e.g., ``{"pipeline_class": "my.Module"}``).
             Passed through to the diffusion stage engine.
+        scheduler: Optional registry name or dotted class path of a diffusion
+            scheduler class to inject instead of the pipeline default.
+        scheduler_kwargs: Optional extra kwargs forwarded to the injected
+            scheduler's ``from_pretrained()``.
     """
 
     stage_id: int = 0
@@ -231,6 +235,11 @@ class OmniEngineArgs(EngineArgs):
     output_modalities: list[str] | None = None
     log_stats: bool = False
     custom_pipeline_args: dict[str, Any] | None = None
+    # Diffusion scheduler injection (forwarded to OmniDiffusionConfig). No CLI
+    # flags are added for these (same as custom_pipeline_args); set them via
+    # the Python API or a deploy YAML's engine args.
+    scheduler: str | None = None
+    scheduler_kwargs: dict[str, Any] | None = None
     has_sampling_extra_args: bool = False
 
     def __post_init__(self) -> None:

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1015,6 +1015,8 @@ class AsyncOmniEngine:
             "lora_scale": kwargs.get("lora_scale", 1.0),
             "lora_backend": kwargs.get("lora_backend", "peft"),
             "custom_pipeline_args": kwargs.get("custom_pipeline_args", None),
+            "scheduler": kwargs.get("scheduler", None),
+            "scheduler_kwargs": kwargs.get("scheduler_kwargs", None),
             "worker_extension_cls": kwargs.get("worker_extension_cls", None),
             "trust_remote_code": (False if kwargs.get("trust_remote_code") is None else kwargs["trust_remote_code"]),
             "distributed_executor_backend": (


### PR DESCRIPTION
## Summary
- Add `vllm_omni/diffusion/models/schedulers/registry.py`: `register_scheduler` / `resolve_scheduler_cls` (registry name, dotted path, or class) / `build_pipeline_scheduler`, with lazy `vllm_omni.schedulers` entry-point loading so external packages (e.g. verl-omni) can inject custom schedulers without modifying vllm-omni.
- Add `OmniDiffusionConfig.scheduler` / `scheduler_kwargs` (also threaded through `OmniEngineArgs` and the deploy-YAML config projection, mirroring `custom_pipeline_args`).
- Swap the 5 hardcoded scheduler construction sites (flux, qwen_image, sd3, ltx2, wan2_2) to the factory; each keeps its existing construction as `default_builder`, so the default path is bit-identical. wan2_2's per-request solver/shift rebuild is skipped (with a warning) when an injected scheduler is active.

## Design
- Motivating RFC: https://github.com/verl-project/verl-omni/issues/391 (stable rollout interface for diffusion RL; this PR is Seam 1 — scheduler injection — only).
- Invariants: no denoise-loop edits (loops keep routing through `scheduler_step_maybe_with_cfg`); default path bit-identical; injected-class contract documented in `registry.py` (diffusers-style `step(..., return_dict=False, generator=None)`, `set_begin_index`, `set_timesteps`, `.config`, deepcopy-safe).
- Scope note: the 5 swapped sites are the RFC-targeted ones; ~25 other pipelines keep hardcoded construction and can adopt the seam incrementally.
- Known gap: no `--scheduler`/`--scheduler-kwargs` CLI flags (no established pattern for dict-typed omni CLI args; `custom_pipeline_args` has none either). Settable via `AsyncOmni(scheduler=..., scheduler_kwargs=...)` and deploy-YAML engine args.

## Test plan
- [x] 18 CPU unit tests added (`tests/diffusion/models/schedulers/test_registry.py`): registration, resolution order, kwargs merging, KeyError message, entry-point loading, contract conformance, bit-identical fallback
- [x] Local verification: py_compile all touched files, ruff check + format clean, torch-free functional smoke of the factory
- [ ] CI: run the unit suite (local dev box has no torch/pytest)
- [ ] CI: new e2e `tests/e2e/features/scheduler_injection/test_scheduler_injection.py` on tiny-random/Qwen-Image (L4-gated, same markers as the custom_pipeline e2e): injected-scheduler run asserts marker events + successful generation; control run asserts default path untouched
