### PR TITLE
[Chore] Rename ar_stop_token_ids to autoregressive_stop_token_ids (#4007)

### DIFF
--- a/examples/offline_inference/hunyuan_image3/end2end.py
+++ b/examples/offline_inference/hunyuan_image3/end2end.py
@@ -233,11 +233,12 @@ def main():
         ar_image_size = f"{args.width}x{args.height}"
     else:
         ar_image_size = None
-    ar_stop_token_ids = resolve_stop_token_ids(
+    autoregressive_stop_token_ids = resolve_stop_token_ids(
         task=task, bot_task=bot_task, tokenizer=tokenizer, image_size=ar_image_size
     )
     print(
-        f"[AR Config] task={task}, bot_task={bot_task}, image_size={ar_image_size}, stop_token_ids={ar_stop_token_ids}"
+        f"[AR Config] task={task}, bot_task={bot_task}, "
+        f"image_size={ar_image_size}, stop_token_ids={autoregressive_stop_token_ids}"
     )
     for sp in params_list:
         if isinstance(sp, OmniDiffusionSamplingParams):
@@ -250,7 +251,7 @@ def main():
                 sp.height = args.height
                 sp.width = args.width
         elif hasattr(sp, "stop_token_ids"):
-            sp.stop_token_ids = ar_stop_token_ids
+            sp.stop_token_ids = autoregressive_stop_token_ids
             # When --stream is set, request DELTA output from the AR stage
             # so we can display CoT text token-by-token in real time.
             if args.stream and hasattr(sp, "output_kind"):

--- a/tests/e2e/accuracy/test_hunyuan_image3.py
+++ b/tests/e2e/accuracy/test_hunyuan_image3.py
@@ -298,7 +298,7 @@ def _run_offline(deploy_config_path: str, output_path: Path) -> tuple[Image.Imag
     token_ids = result.token_ids
     system_prompt_type = result.system_prompt_type
 
-    ar_stop_token_ids = resolve_stop_token_ids(task="it2i", bot_task="think_recaption", tokenizer=tokenizer)
+    autoregressive_stop_token_ids = resolve_stop_token_ids(task="it2i", bot_task="think_recaption", tokenizer=tokenizer)
     with OmniRunner(MODEL_PATH, deploy_config=deploy_config_path, trust_remote_code=True) as runner:
         params_list = list(runner.omni.default_sampling_params_list)
         for sp in params_list:
@@ -308,7 +308,7 @@ def _run_offline(deploy_config_path: str, output_path: Path) -> tuple[Image.Imag
                 sp.seed = SEED
                 sp.generator = torch.Generator(device=current_omni_platform.device_type or "cuda").manual_seed(SEED)
             elif hasattr(sp, "stop_token_ids"):
-                sp.stop_token_ids = ar_stop_token_ids
+                sp.stop_token_ids = autoregressive_stop_token_ids
 
         images = download_images(TEST_IMAGE_URLS)
         prompts: list[OmniPromptType] = [

--- a/tests/entrypoints/openai_api/test_serving_chat_multistage_generation.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_multistage_generation.py
@@ -439,7 +439,7 @@ def test_build_multistage_generation_inputs_custom_system_prompt(serving_chat):
     )
 
 
-def test_build_multistage_generation_inputs_sets_ar_stop_token_ids_with_explicit_size(serving_chat):
+def test_build_multistage_generation_inputs_sets_autoregressive_stop_token_ids_with_explicit_size(serving_chat):
     """When height+width are provided with bot_task, the AR (llm) stage
     must receive stop_token_ids from resolve_stop_token_ids so AR stops
     at the correct terminator instead of generating until max_tokens.
@@ -504,7 +504,7 @@ def test_build_multistage_generation_inputs_no_stop_token_ids_without_size(servi
     This still assigns stop_token_ids, but the set is the ratio range,
     not the terminator.
 
-    Without bot_task at all, ar_stop_token_ids stays None and
+    Without bot_task at all, autoregressive_stop_token_ids stays None and
     stop_token_ids is not set on any stage.
     """
     from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
@@ -521,7 +521,7 @@ def test_build_multistage_generation_inputs_no_stop_token_ids_without_size(servi
     )
     images = [Image.new("RGB", (32, 32), color="red")]
 
-    # No height/width, no bot_task -> ar_stop_token_ids=None ->
+    # No height/width, no bot_task -> autoregressive_stop_token_ids=None ->
     # stop_token_ids not set on any stage.
     _, sampling_params_list = OmniOpenAIServingChat._build_multistage_generation_inputs(
         serving_chat,

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -2976,7 +2976,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         prompt_token_ids: list[int] | None = None
         system_prompt_type: str | None = None
         build_kwargs: dict[str, Any] = {}
-        ar_stop_token_ids: list[int] | None = None
+        autoregressive_stop_token_ids: list[int] | None = None
 
         if bot_task is not None or use_system_prompt is not None or custom_system_prompt is not None:
             from vllm_omni.diffusion.models.hunyuan_image3.prompt_utils import (
@@ -3017,7 +3017,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             ar_image_size: str | None = None
             if height is not None and width is not None:
                 ar_image_size = f"{width}x{height}"
-            ar_stop_token_ids = resolve_stop_token_ids(
+            autoregressive_stop_token_ids = resolve_stop_token_ids(
                 task=ar_task,
                 bot_task=bot_task,
                 tokenizer=tokenizer,
@@ -3073,8 +3073,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
 
             # AR stop tokens: use stage_type=="llm" instead of comprehension_idx
             # (None for DictConfig where is_comprehension is nested in engine_args).
-            if stage_type == "llm" and ar_stop_token_ids is not None:
-                default_stage_params.stop_token_ids = ar_stop_token_ids
+            if stage_type == "llm" and autoregressive_stop_token_ids is not None:
+                default_stage_params.stop_token_ids = autoregressive_stop_token_ids
 
             if (
                 comprehension_idx is not None


### PR DESCRIPTION
## Summary
Renames the ambiguous `ar_stop_token_ids` field/parameter to the full, self-documenting name `autoregressive_stop_token_ids` across all 4 usage sites in the codebase.

Fixes #4007

## Motivation
The abbreviated prefix `ar_` is overloaded — it could be confused with audio-related fields or other `ar_`-prefixed parameters in this multimodal codebase. The full name `autoregressive_` eliminates ambiguity at zero runtime cost.

## Changes
| File | Change |
|------|--------|
| `vllm_omni/entrypoints/openai/serving_chat.py` | Field declaration + 3 usages renamed |
| `tests/e2e/accuracy/test_hunyuan_image3.py` | Test assignment + assertion renamed |
| `examples/offline_inference/hunyuan_image3/end2end.py` | Example assignment + log string renamed |
| `tests/entrypoints/openai_api/test_serving_chat_multistage_generation.py` | Test function name + comment renamed |

**Stats:** 4 files changed, +13 −12

## Notes
- **Supersedes PR #4012**, which addressed the same issue but was incomplete (only 2 of 4 files changed) and has been stalled since 2026-07-17 with failing DCO checks and no human review activity.
- All changes are pure identifier rename — no logic modified.
- `ruff format --check` and `ruff check` both pass cleanly on all 4 files.
- One f-string log line in `end2end.py` was split to stay within the 120-char line-length limit after rename.
- DCO sign-off included (`git commit -s`).