### PR TITLE
[ROCm] [CI] Fix cpu test on rocm

### DIFF
--- a/vllm_omni/diffusion/models/ltx2/ltx2_phase_adapter.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_phase_adapter.py
@@ -203,6 +203,11 @@ def _apply_unquantized_gemm_with_weight(
     weight: torch.Tensor,
     bias: torch.Tensor | None,
 ) -> torch.Tensor:
+    # GEMM dispatch is selected from the host platform, not the tensor device.
+    # In CPU tests on a ROCm host that selects rocm_unquantized_gemm, which has
+    # no CPU kernel. Keep that combination on PyTorch's portable implementation.
+    if current_platform.is_rocm() and input_.device.type == "cpu":
+        return F.linear(input_, weight, bias)
     if envs.VLLM_BATCH_INVARIANT and current_platform.is_cuda_alike():
         return linear_batch_invariant(input_, weight, bias)
     return dispatch_unquantized_gemm()(layer, input_, weight, bias)


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Fix the failing test https://buildkite.com/vllm/vllm-omni-amd-ci/builds/10649/list?jid=01a00e2f-07aa-4910-bfc9-2585da41a43c&tab=output

`vllm::rocm_unquantized_gemm` does not run on cpu. So fallback to torch.nn.linear on ROCm CPU.

## Test Plan

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

passes: https://buildkite.com/vllm/vllm-omni-amd-ci/builds/10650/list?jid=01a00e4a-ede7-4ba1-a812-3a66e9017008&tab=output 

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
