### PR TITLE
[Perf] Fuse MiniMax H3 modulation with FP32 accumulation

### DIFF
--- a/vllm_omni/diffusion/attention/ops/minimax_h3_modulation.py
+++ b/vllm_omni/diffusion/attention/ops/minimax_h3_modulation.py
@@ -155,6 +155,9 @@ def indexed_scale_shift_(
     indices: torch.Tensor,
 ) -> torch.Tensor:
     """Apply indexed scale/shift in-place to a disposable contiguous input."""
+    if x.is_cpu:
+        x.copy_((x * (1.0 + scale.index_select(0, indices)) + shift.index_select(0, indices)).to(x.dtype))
+        return x
     rows, hidden_size = x.shape
     if rows == 0:
         return x
@@ -182,6 +185,8 @@ def indexed_gate(
     indices: torch.Tensor,
 ) -> torch.Tensor:
     """Return ``x + gate[indices] * other`` without indexed temporaries."""
+    if x.is_cpu:
+        return (x + gate.index_select(0, indices) * other).to(x.dtype)
     output = torch.empty_like(x)
     rows, hidden_size = x.shape
     if rows == 0:
@@ -213,6 +218,13 @@ def rms_norm_indexed_scale_shift(
     eps: float,
 ) -> torch.Tensor:
     """Fuse H3 RMSNorm with its indexed AdaLN affine transform."""
+    if x.is_cpu:
+        input_dtype = x.dtype
+        normalized = x.float()
+        variance = normalized.pow(2).mean(-1, keepdim=True)
+        normalized = normalized * torch.rsqrt(variance + eps)
+        normalized = (weight.float() * normalized).to(input_dtype)
+        return (normalized * (1.0 + scale.index_select(0, indices)) + shift.index_select(0, indices)).to(input_dtype)
     output = torch.empty_like(x)
     rows, hidden_size = x.shape
     if rows:
@@ -246,6 +258,17 @@ def indexed_gate_rms_norm_scale_shift(
     eps: float,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Fuse gated residual, the following RMSNorm, and AdaLN affine."""
+    if residual.is_cpu:
+        input_dtype = residual.dtype
+        residual_out = (residual + gate.index_select(0, indices) * branch).to(input_dtype)
+        normalized = residual_out.float()
+        variance = normalized.pow(2).mean(-1, keepdim=True)
+        normalized = normalized * torch.rsqrt(variance + eps)
+        normalized = (weight.float() * normalized).to(input_dtype)
+        modulated_out = (normalized * (1.0 + scale.index_select(0, indices)) + shift.index_select(0, indices)).to(
+            input_dtype
+        )
+        return residual_out, modulated_out
     residual_out = torch.empty_like(residual)
     modulated_out = torch.empty_like(residual)
     rows, hidden_size = residual.shape

--- a/vllm_omni/diffusion/attention/ops/minimax_h3_modulation.py
+++ b/vllm_omni/diffusion/attention/ops/minimax_h3_modulation.py
@@ -1,0 +1,282 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fused MiniMax H3 modulation with FP32 accumulation."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _indexed_scale_shift_kernel(
+    output_ptr,
+    x_ptr,
+    shift_ptr,
+    scale_ptr,
+    indices_ptr,
+    hidden_size,
+    stride_x_row,
+    stride_shift_row,
+    stride_scale_row,
+    stride_indices,
+    block_n: tl.constexpr,
+):
+    row = tl.program_id(0)
+    columns = tl.arange(0, block_n)
+    mask = columns < hidden_size
+    index = tl.load(indices_ptr + row * stride_indices)
+
+    x = tl.load(x_ptr + row * stride_x_row + columns, mask=mask, other=0.0).to(tl.float32)
+    shift = tl.load(shift_ptr + index * stride_shift_row + columns, mask=mask, other=0.0).to(tl.float32)
+    scale = tl.load(scale_ptr + index * stride_scale_row + columns, mask=mask, other=0.0).to(tl.float32)
+
+    tl.store(
+        output_ptr + row * stride_x_row + columns,
+        x * (1.0 + scale) + shift,
+        mask=mask,
+    )
+
+
+@triton.jit
+def _indexed_gate_kernel(
+    output_ptr,
+    x_ptr,
+    gate_ptr,
+    other_ptr,
+    indices_ptr,
+    hidden_size,
+    stride_output_row,
+    stride_x_row,
+    stride_gate_row,
+    stride_other_row,
+    stride_indices,
+    block_n: tl.constexpr,
+):
+    row = tl.program_id(0)
+    columns = tl.arange(0, block_n)
+    mask = columns < hidden_size
+    index = tl.load(indices_ptr + row * stride_indices)
+
+    x = tl.load(x_ptr + row * stride_x_row + columns, mask=mask, other=0.0).to(tl.float32)
+    gate = tl.load(gate_ptr + index * stride_gate_row + columns, mask=mask, other=0.0).to(tl.float32)
+    other = tl.load(other_ptr + row * stride_other_row + columns, mask=mask, other=0.0).to(tl.float32)
+
+    tl.store(
+        output_ptr + row * stride_output_row + columns,
+        x + gate * other,
+        mask=mask,
+    )
+
+
+@triton.jit
+def _rms_norm_indexed_scale_shift_kernel(
+    output_ptr,
+    x_ptr,
+    weight_ptr,
+    shift_ptr,
+    scale_ptr,
+    indices_ptr,
+    hidden_size: tl.constexpr,
+    eps: tl.constexpr,
+    stride_x_row,
+    stride_shift_row,
+    stride_scale_row,
+    stride_indices,
+    block_n: tl.constexpr,
+):
+    row = tl.program_id(0)
+    columns = tl.arange(0, block_n)
+    mask = columns < hidden_size
+    index = tl.load(indices_ptr + row * stride_indices)
+
+    x = tl.load(x_ptr + row * stride_x_row + columns, mask=mask, other=0.0).to(tl.float32)
+    weight = tl.load(weight_ptr + columns, mask=mask, other=0.0).to(tl.float32)
+    variance = tl.sum(x * x, axis=0) / hidden_size
+    normalized = x * tl.rsqrt(variance + eps) * weight
+
+    shift = tl.load(shift_ptr + index * stride_shift_row + columns, mask=mask, other=0.0).to(tl.float32)
+    scale = tl.load(scale_ptr + index * stride_scale_row + columns, mask=mask, other=0.0).to(tl.float32)
+    tl.store(
+        output_ptr + row * hidden_size + columns,
+        normalized * (1.0 + scale) + shift,
+        mask=mask,
+    )
+
+
+@triton.jit
+def _indexed_gate_rms_norm_scale_shift_kernel(
+    residual_out_ptr,
+    modulated_out_ptr,
+    residual_ptr,
+    gate_ptr,
+    branch_ptr,
+    weight_ptr,
+    shift_ptr,
+    scale_ptr,
+    indices_ptr,
+    hidden_size: tl.constexpr,
+    eps: tl.constexpr,
+    stride_residual_row,
+    stride_gate_row,
+    stride_branch_row,
+    stride_shift_row,
+    stride_scale_row,
+    stride_indices,
+    block_n: tl.constexpr,
+):
+    row = tl.program_id(0)
+    columns = tl.arange(0, block_n)
+    mask = columns < hidden_size
+    index = tl.load(indices_ptr + row * stride_indices)
+
+    residual = tl.load(residual_ptr + row * stride_residual_row + columns, mask=mask, other=0.0).to(tl.float32)
+    gate = tl.load(gate_ptr + index * stride_gate_row + columns, mask=mask, other=0.0).to(tl.float32)
+    branch = tl.load(branch_ptr + row * stride_branch_row + columns, mask=mask, other=0.0).to(tl.float32)
+    updated = residual + gate * branch
+    tl.store(residual_out_ptr + row * hidden_size + columns, updated, mask=mask)
+
+    weight = tl.load(weight_ptr + columns, mask=mask, other=0.0).to(tl.float32)
+    variance = tl.sum(updated * updated, axis=0) / hidden_size
+    normalized = updated * tl.rsqrt(variance + eps) * weight
+    shift = tl.load(shift_ptr + index * stride_shift_row + columns, mask=mask, other=0.0).to(tl.float32)
+    scale = tl.load(scale_ptr + index * stride_scale_row + columns, mask=mask, other=0.0).to(tl.float32)
+    tl.store(
+        modulated_out_ptr + row * hidden_size + columns,
+        normalized * (1.0 + scale) + shift,
+        mask=mask,
+    )
+
+
+def indexed_scale_shift_(
+    x: torch.Tensor,
+    shift: torch.Tensor,
+    scale: torch.Tensor,
+    indices: torch.Tensor,
+) -> torch.Tensor:
+    """Apply indexed scale/shift in-place to a disposable contiguous input."""
+    rows, hidden_size = x.shape
+    if rows == 0:
+        return x
+    _indexed_scale_shift_kernel[(rows,)](
+        x,
+        x,
+        shift,
+        scale,
+        indices,
+        hidden_size,
+        x.stride(0),
+        shift.stride(0),
+        scale.stride(0),
+        indices.stride(0),
+        block_n=triton.next_power_of_2(hidden_size),
+        num_warps=8,
+    )
+    return x
+
+
+def indexed_gate(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    other: torch.Tensor,
+    indices: torch.Tensor,
+) -> torch.Tensor:
+    """Return ``x + gate[indices] * other`` without indexed temporaries."""
+    output = torch.empty_like(x)
+    rows, hidden_size = x.shape
+    if rows == 0:
+        return output
+    _indexed_gate_kernel[(rows,)](
+        output,
+        x,
+        gate,
+        other,
+        indices,
+        hidden_size,
+        output.stride(0),
+        x.stride(0),
+        gate.stride(0),
+        other.stride(0),
+        indices.stride(0),
+        block_n=triton.next_power_of_2(hidden_size),
+        num_warps=8,
+    )
+    return output
+
+
+def rms_norm_indexed_scale_shift(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    shift: torch.Tensor,
+    scale: torch.Tensor,
+    indices: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """Fuse H3 RMSNorm with its indexed AdaLN affine transform."""
+    output = torch.empty_like(x)
+    rows, hidden_size = x.shape
+    if rows:
+        _rms_norm_indexed_scale_shift_kernel[(rows,)](
+            output,
+            x,
+            weight,
+            shift,
+            scale,
+            indices,
+            hidden_size,
+            eps,
+            x.stride(0),
+            shift.stride(0),
+            scale.stride(0),
+            indices.stride(0),
+            block_n=triton.next_power_of_2(hidden_size),
+            num_warps=8,
+        )
+    return output
+
+
+def indexed_gate_rms_norm_scale_shift(
+    residual: torch.Tensor,
+    gate: torch.Tensor,
+    branch: torch.Tensor,
+    weight: torch.Tensor,
+    shift: torch.Tensor,
+    scale: torch.Tensor,
+    indices: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fuse gated residual, the following RMSNorm, and AdaLN affine."""
+    residual_out = torch.empty_like(residual)
+    modulated_out = torch.empty_like(residual)
+    rows, hidden_size = residual.shape
+    if rows:
+        _indexed_gate_rms_norm_scale_shift_kernel[(rows,)](
+            residual_out,
+            modulated_out,
+            residual,
+            gate,
+            branch,
+            weight,
+            shift,
+            scale,
+            indices,
+            hidden_size,
+            eps,
+            residual.stride(0),
+            gate.stride(0),
+            branch.stride(0),
+            shift.stride(0),
+            scale.stride(0),
+            indices.stride(0),
+            block_n=triton.next_power_of_2(hidden_size),
+            num_warps=8,
+        )
+    return residual_out, modulated_out
+
+
+__all__ = [
+    "indexed_gate",
+    "indexed_gate_rms_norm_scale_shift",
+    "indexed_scale_shift_",
+    "rms_norm_indexed_scale_shift",
+]

--- a/vllm_omni/diffusion/cache/teacache/extractors.py
+++ b/vllm_omni/diffusion/cache/teacache/extractors.py
@@ -1259,12 +1259,11 @@ def extract_minimax_h3_context(
     preprocessing via ``_embed``, cacheable ``blocks`` loop, and
     ``final_layer`` postprocessing with row selection and update masks.
     """
+    from vllm_omni.diffusion.attention.ops.minimax_h3_modulation import indexed_scale_shift_
     from vllm_omni.diffusion.models.minimax_h3.minimax_h3_transformer import (
-        _BF16_DTYPE,
         _FORWARD_SUPPORTED_KWARGS,
         MINIMAX_H3_ADALN_MODALITY_NUM,
         _build_rope_table,
-        _modulate_scale_shift,
         _required_kwarg,
     )
 
@@ -1341,13 +1340,12 @@ def extract_minimax_h3_context(
     cu_seqlens = cu_seqlens.to(device)
 
     shift_msa, scale_msa, *_ = module.blocks[0].adaln_proj(t_emb)
-    modulated_hidden = module.blocks[0].norm1(decoder_input)
-    modulated_input = _modulate_scale_shift(
-        modulated_hidden,
+    modulated_input = module.blocks[0].norm1(decoder_input)
+    modulated_input = indexed_scale_shift_(
+        modulated_input,
         shift_msa,
         scale_msa,
         combined_indices,
-        dtype=_BF16_DTYPE,
     )
 
     def run_transformer_blocks() -> tuple[torch.Tensor, ...]:

--- a/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
+++ b/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
@@ -28,6 +28,12 @@ from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata, VideoTokenLayout
 from vllm_omni.diffusion.attention.layer import Attention
+from vllm_omni.diffusion.attention.ops.minimax_h3_modulation import (
+    indexed_gate,
+    indexed_gate_rms_norm_scale_shift,
+    indexed_scale_shift_,
+    rms_norm_indexed_scale_shift,
+)
 from vllm_omni.diffusion.cache.cachedit import CacheDiTAdapterConfig
 from vllm_omni.diffusion.distributed.sp_plan import (
     SequenceParallelInput,
@@ -187,30 +193,6 @@ def _norm(size: int, *, eps: float, dtype: torch.dtype = _BF16_DTYPE) -> RMSNorm
     # torch.nn.RMSNorm upcasts reduced-precision inputs for the variance
     # reduction, matching that accumulation semantic.
     return RMSNorm(size, eps=eps, dtype=dtype)
-
-
-def _modulate_scale_shift(
-    x: torch.Tensor,
-    shift: torch.Tensor,
-    scale: torch.Tensor,
-    indices: torch.Tensor,
-    *,
-    dtype: torch.dtype,
-) -> torch.Tensor:
-    # Apply per-index affine modulation: x * (1 + scale[idx]) + shift[idx].
-    return (x * (1.0 + scale.index_select(0, indices)) + shift.index_select(0, indices)).to(dtype)
-
-
-def _modulate_gate(
-    x: torch.Tensor,
-    gate: torch.Tensor,
-    other: torch.Tensor,
-    indices: torch.Tensor,
-    *,
-    dtype: torch.dtype,
-) -> torch.Tensor:
-    # Apply the per-index gated residual: x + gate[idx] * other.
-    return (x + gate.index_select(0, indices) * other).to(dtype)
 
 
 def _sequence_parallel_local_span(
@@ -794,8 +776,14 @@ class MiniMaxH3DiTBlock(nn.Module):
         ) = self.adaln_proj(t_emb)
 
         residual = x
-        h = self.norm1(x)
-        h = _modulate_scale_shift(h, shift_msa, scale_msa, combined_indices, dtype=_BF16_DTYPE)
+        h = rms_norm_indexed_scale_shift(
+            x,
+            self.norm1.weight,
+            shift_msa,
+            scale_msa,
+            combined_indices,
+            self.norm1.variance_epsilon,
+        )
         h = self.attn(
             h,
             rope_table=rope_table,
@@ -805,13 +793,19 @@ class MiniMaxH3DiTBlock(nn.Module):
             sp_seq_lens=sp_seq_lens,
             video_layout=video_layout,
         )
-        x = _modulate_gate(residual, gate_msa, h, combined_indices, dtype=_BF16_DTYPE)
-
+        x, h = indexed_gate_rms_norm_scale_shift(
+            residual,
+            gate_msa,
+            h,
+            self.norm2.weight,
+            shift_mlp,
+            scale_mlp,
+            combined_indices,
+            self.norm2.variance_epsilon,
+        )
         residual = x
-        h = self.norm2(x)
-        h = _modulate_scale_shift(h, shift_mlp, scale_mlp, combined_indices, dtype=_BF16_DTYPE)
         h = self.mlp(h)
-        return _modulate_gate(residual, gate_mlp, h, combined_indices, dtype=_BF16_DTYPE)
+        return indexed_gate(residual, gate_mlp, h, combined_indices)
 
 
 class MiniMaxH3FinalLayer(nn.Module):
@@ -866,7 +860,7 @@ class MiniMaxH3FinalLayer(nn.Module):
         """
         shift, scale = self.adaln_proj(t_emb)
         h = self.norm(x)
-        h = _modulate_scale_shift(h, shift, scale, inverse_indices, dtype=_BF16_DTYPE)
+        h = indexed_scale_shift_(h, shift, scale, inverse_indices)
         # Preserve full precision through both final output projections.
         h = h.to(_FP32_DTYPE)
         video, _ = self.video_out(h)


### PR DESCRIPTION
## Summary

This PR fuses the MiniMax H3 modulation operations into dedicated Triton kernels using FP32 accumulation. It removes redundant gather, elementwise, RMSNorm, and intermediate BF16 operations from each transformer block.

## Performance

Benchmarked on MiniMax H3 Ref2VA with USP=4, eager execution, a 5-second output, and 49 denoising iterations. Both configurations were warmed up before profiling and end-to-end measurement.

### End-to-End Performance

| Metric | Baseline | FP32 Fused Modulation | Improvement |
| --- | ---: | ---: | ---: |
| Engine E2E latency | 136.961 s | 134.707 s | 2.253 s / 1.65% |
| Diffusion engine execution | 134.695 s | 132.199 s | 2.496 s / 1.85% |
| Reported step latency | 2.739 s | 2.694 s | 45.1 ms / 1.65% |

### Single DiT Forward Profile

| Metric | Baseline | FP32 Fused Modulation | Improvement |
| --- | ---: | ---: | ---: |
| GPU wall time | 2,575.64 ms | 2,534.49 ms | 41.16 ms / 1.60% |
| CUDA kernel count | 1,969 | 1,234 | 735 / 37.33% |
| Total CUDA kernel duration | 2,571.83 ms | 2,531.96 ms | 39.87 ms / 1.55% |

The fusion removes 294 gather kernels, 490 BF16 elementwise kernels, 98 in-place add kernels, and 98 standalone RMSNorm kernels per DiT forward, replacing them with 147 fused modulation kernels.

## Accuracy

The implementation uses FP32 accumulation and casts the final results back to the destination tensor dtype. It is therefore not bit-exact with the baseline because intermediate BF16 rounding is removed.

| Metric | Result |
| --- | ---: |
| PSNR | 39.55 dB |
| SSIM | 0.9750 |


Before:

https://github.com/user-attachments/assets/414c48de-5db8-4757-acf6-baaa75a75246

After:

https://github.com/user-attachments/assets/e927dc58-b6e2-4d82-93e8-8fb964c70fe6




