### PR TITLE
[Perf] Fuse MiniMax H3 SwiGLU activation

### DIFF
--- a/vllm_omni/diffusion/layers/activation.py
+++ b/vllm_omni/diffusion/layers/activation.py
@@ -22,6 +22,8 @@ class SiluAndMul(CustomOp):
         return F.silu(x[..., :d]) * x[..., d:]
 
     def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
+        if x.device.type != "cuda":
+            return self.forward_native(x)
         d = x.shape[-1] // 2
         output_shape = x.shape[:-1] + (d,)
         out = torch.empty(output_shape, dtype=x.dtype, device=x.device)

--- a/vllm_omni/diffusion/layers/activation.py
+++ b/vllm_omni/diffusion/layers/activation.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Custom activation functions for diffusion models."""
+
+import torch
+import torch.nn.functional as F
+
+from vllm_omni.diffusion.layers.custom_op import CustomOp
+from vllm_omni.platforms import current_omni_platform
+
+
+class SiluAndMul(CustomOp):
+    """SwiGLU activation dispatched by the current vLLM-Omni platform."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        if current_omni_platform.is_cuda() or current_omni_platform.is_rocm() or current_omni_platform.is_musa():
+            self.op = torch.ops._C.silu_and_mul
+
+    @staticmethod
+    def forward_native(x: torch.Tensor) -> torch.Tensor:
+        d = x.shape[-1] // 2
+        return F.silu(x[..., :d]) * x[..., d:]
+
+    def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
+        d = x.shape[-1] // 2
+        output_shape = x.shape[:-1] + (d,)
+        out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
+        self.op(out, x)
+        return out
+
+    def forward_npu(self, x: torch.Tensor) -> torch.Tensor:
+        return self.forward_native(x)
+
+    def forward_xpu(self, x: torch.Tensor) -> torch.Tensor:
+        return self.forward_native(x)

--- a/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
+++ b/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
@@ -33,6 +33,7 @@ from vllm_omni.diffusion.distributed.sp_plan import (
     SequenceParallelInput,
     SequenceParallelOutput,
 )
+from vllm_omni.diffusion.layers.activation import SiluAndMul
 from vllm_omni.diffusion.layers.fused_qk_norm_rope import fused_qk_norm_rope
 from vllm_omni.diffusion.layers.norm import RMSNorm
 from vllm_omni.diffusion.layers.rope import RotaryEmbedding
@@ -586,6 +587,7 @@ class MiniMaxH3MLP(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.fc1",
         )
+        self.act_fn = SiluAndMul()
         # Chunk the fused fc1 output as [gate, up], then compute
         # silu(gate) * up.
         self.fc2 = RowParallelLinear(
@@ -600,8 +602,7 @@ class MiniMaxH3MLP(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         hidden, _ = self.fc1(x)
-        gate, up = hidden.chunk(2, dim=-1)
-        hidden = nn.functional.silu(gate) * up
+        hidden = self.act_fn(hidden)
         out, _ = self.fc2(hidden)
         return out
 


### PR DESCRIPTION
## Summary

This PR adds a local `SiluAndMul` layer under `vllm_omni.diffusion.layers` and uses it in the MiniMax H3 MLP. The implementation preserves vLLM-Omni platform dispatch through `CustomOp` and `current_omni_platform`, while the CUDA path invokes the fused `torch.ops._C.silu_and_mul` kernel. This avoids depending on the vLLM `SiluAndMul` class and prevents the diffusion configuration from falling back to the native two-kernel implementation.

## Performance

Benchmarked on MiniMax H3 Ref2VA with USP=4, eager execution, a 5-second output, and 49 denoising iterations. The existing main-branch result was reused as the baseline. The fused implementation was warmed up separately before both the 2-step profile and the 50-step end-to-end measurement.

### End-to-End Performance

| Metric | Baseline | Local Fused `SiluAndMul` | Improvement |
| --- | ---: | ---: | ---: |
| Engine E2E latency | 136.961 s | 135.104 s | 1.857 s / 1.36% |
| Diffusion engine execution | 134.695 s | 132.838 s | 1.857 s / 1.38% |
| Reported step latency | 2.739 s | 2.702 s | 37.1 ms / 1.35% |

### Single DiT Forward Profile

| Metric | Baseline | Local Fused `SiluAndMul` | Improvement |
| --- | ---: | ---: | ---: |
| GPU wall time | 2,575.64 ms | 2,546.81 ms | 28.83 ms / 1.12% |
| CUDA kernel count | 1,969 | 1,920 | 49 / 2.49% |
| Total CUDA kernel duration | 2,571.83 ms | 2,543.15 ms | 28.68 ms / 1.12% |
| MLP activation | 57.57 ms / 98 kernels | 16.26 ms / 49 kernels | 41.32 ms / 49 kernels |

The profile confirms that every MiniMax H3 transformer layer dispatches to one `vllm::act_and_mul_kernel` instead of separate native SiLU and multiplication kernels. NCCL SendRecv time was 18.85 ms higher in the optimized profile due to run-to-run variation, partially masking the activation improvement in the overall DiT forward time.

## Accuracy

The optimized 50-step output is byte-for-byte identical to the baseline. Both files have the SHA-256 digest `bc383673714d4252467549335f01f92e52f26a4376a2f41aefd4e540c3c2021b`.
