### PR TITLE
[Model] Serve OpenVLA-7B as an autoregressive robot policy

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -25,6 +25,7 @@ th {
 | `BagelForConditionalGeneration` | BAGEL (DiT-only) | `ByteDance-Seed/BAGEL-7B-MoT` | ✅︎ | ✅︎ | | ✅︎ | — |
 | `InternVLAA1Pipeline` | InternVLA-A1 | `InternRobotics/InternVLA-A1-3B` | ✅︎ | ✅︎ | | | — |
 | `Gr00tN1d7Pipeline` | GR00T N1.7 | `nvidia/GR00T-N1.7-3B` | ✅︎ | | | | — |
+| `OpenVLAForActionPrediction` | OpenVLA | `openvla/openvla-7b` | ✅︎ | | | | [Repository](https://github.com/vllm-project/vllm-omni/blob/main/recipes/OpenVLA/OpenVLA-7B.md) |
 | `HunyuanImage3ForCausalMM` | HunyuanImage3.0 (DiT-only) | `tencent/HunyuanImage-3.0`, `tencent/HunyuanImage-3.0-Instruct` | ✅︎ | ✅︎ | ✅︎ | ✅︎ | — |
 | `QwenImagePipeline` | Qwen-Image | `Qwen/Qwen-Image` | ✅︎ | | | | [Published](https://recipes.vllm.ai/Qwen/Qwen-Image) |
 | `QwenImagePipeline` | Qwen-Image-2512 | `Qwen/Qwen-Image-2512` | ✅︎ | | | | [Repository](https://github.com/vllm-project/vllm-omni/blob/main/recipes/Qwen/Qwen-Image-2512.md) |

--- a/recipes/OpenVLA/OpenVLA-7B.md
+++ b/recipes/OpenVLA/OpenVLA-7B.md
@@ -1,0 +1,153 @@
+# OpenVLA-7B
+
+> OpenVLA-7B served as an autoregressive robot policy over the OpenPI WebSocket protocol
+
+## Summary
+
+- Vendor: OpenVLA (Stanford / Google DeepMind / Toyota Research Institute)
+- Model: `openvla/openvla-7b`
+- Task: Vision-Language-Action (VLA) inference for robot manipulation
+- Mode: Online serving via the OpenPI WebSocket endpoint
+- Hardware used for the numbers below: 1x NVIDIA A800 80GB
+
+## When to use this recipe
+
+Use this when you want OpenVLA to serve more than one robot, or when the
+reference implementation's control rate is not enough. OpenVLA is the first
+robot policy in this repository whose actions come out of an autoregressive
+decoder rather than a denoiser: the seven action dimensions are seven
+discretised tokens from the tail of the Llama-2 vocabulary. That makes it an
+ordinary `LLM_AR` stage, so it gets paged KV, continuous batching and CUDA
+graphs — none of which the reference implementation has. The reference
+implementation cannot batch at all: `modeling_prismatic.py` raises
+`ValueError("Generation with batch size > 1 is not currently supported!")`.
+
+## References
+
+- Upstream model: <https://huggingface.co/openvla/openvla-7b>
+- Upstream codebase: <https://github.com/openvla/openvla>
+- OpenPI client library: <https://github.com/Physical-Intelligence/openpi>
+- Model class: upstream vLLM's `vllm.model_executor.models.openvla.OpenVLAForActionPrediction`
+- Pipeline: [`vllm_omni/model_executor/models/openvla/pipeline.py`](../../vllm_omni/model_executor/models/openvla/pipeline.py)
+- Action decode: [`vllm_omni/model_executor/models/openvla/action_decode.py`](../../vllm_omni/model_executor/models/openvla/action_decode.py)
+- Deploy config: [`vllm_omni/deploy/openvla.yaml`](../../vllm_omni/deploy/openvla.yaml)
+
+## Environment
+
+- OS: Linux
+- Python: 3.11+
+- Driver / runtime: NVIDIA CUDA
+- Hardware: 1 NVIDIA GPU. bf16 weights are 14.05 GiB; measured on an A800 80GB.
+- `timm` is required — the two vision towers are timm ViTs
+  (`vit_large_patch14_reg4_dinov2.lvd142m` and `vit_so400m_patch14_siglip_224`).
+
+## Start server
+
+```bash
+vllm serve openvla/openvla-7b \
+  --omni \
+  --host 127.0.0.1 \
+  --port 8000 \
+  --served-model-name openvla
+```
+
+The pipeline declares `openvla.yaml` as its default deploy config, so no
+`--deploy-config` flag is needed. The WebSocket endpoint is
+`ws://127.0.0.1:8000/v1/realtime/robot/openpi`.
+
+Notes:
+
+- **The handshake is derived from the checkpoint, not configured.** An
+  `LLM_AR` stage may not carry the `model_config:` block the diffusion robot
+  deploys use, so `policy_server_config` is built from the checkpoint's own
+  `norm_stats`: `action_dim`, `action_horizon: 1`, the selected `unnorm_key`,
+  and the full list of supported embodiments. By construction a fine-tuned
+  OpenVLA with a different embodiment set should advertise itself with no
+  config change, but only `openvla/openvla-7b` has been run — that is a design
+  property, not a measurement.
+- **Pick an embodiment.** `openvla-7b` ships action statistics for 25
+  datasets, so one has to be chosen. The deploy config sets
+  `hf_overrides: {unnorm_key: bridge_orig}`; a client may override it per
+  observation by putting `unnorm_key` in the observation dict.
+- The observation needs an RGB image (looked up under `image`,
+  `observation/image`, `observation.image`,
+  `observation/exterior_image_1_left`, `base_image`, `primary_image`) and a
+  language instruction (`prompt`, `instruction` or `task`). The response is a
+  `(1, 7)` float32 array — action horizon 1, seven dimensions.
+
+## Verification
+
+Numerical agreement with the reference implementation, on real
+`bridge_orig` episodes from `IPEC-COMMUNITY/bridge_orig_lerobot`:
+
+- 18 WebSocket round trips across three episodes: **17 of 18 actions
+  bit-identical** to `OpenVLAForActionPrediction.predict_action` under
+  transformers 4.40.1 on the same frames; the remaining one differs by 0.0134,
+  a single bin.
+- Offline, over 10 held-out observations (5 photographs, 5 synthetic):
+  **8/10 free-running token sequences identical**, and **69/70 teacher-forced
+  next-token argmax positions identical**. Both disagreements are on
+  synthetic-noise images at positions where the reference's own top-1/top-2
+  logprob gap is 0.0625–0.125, i.e. bf16 rounding resolution.
+
+CPU-only unit tests:
+
+```bash
+pytest tests/model_executor/models/test_openvla_action_decode.py \
+       tests/model_executor/models/test_openvla_registration.py \
+       tests/entrypoints/openai_api/test_openpi_ar_action_policy.py
+```
+
+## Performance
+
+Measured on 1x A800 80GB, bf16, TP=1, greedy, seven action tokens per step.
+
+**Measure with a distinct image per request.** vLLM caches by image hash, so a
+benchmark that reuses one frame skips the vision encoder and reports a latency
+no robot ever sees — 89 ms instead of 145 ms here, a 39% error. (The towers
+themselves are only ~24 ms of the step, so encoder-output reuse saves more than
+the towers alone; the rest is unexplained and I did not chase it.)
+
+Single-robot latency:
+
+| | reference (transformers) | offline engine | over the OpenPI endpoint |
+|---|---|---|---|
+| one robot | 206.6 ms (4.84 Hz) | 145.4 ms (6.88 Hz) | 183.4 ms (5.45 Hz) |
+
+The endpoint is what a robot actually gets; 19.1 ms of the 38 ms it adds is
+transport + msgpack + dispatch.
+
+Concurrency — N observations submitted together on one served instance. Batching
+trades per-robot control rate for fleet throughput; the reference has no batch
+axis at all, so N robots need N model copies:
+
+| N | aggregate | per robot |
+|---|---|---|
+| 1 | 6.9 actions/s | 6.88 Hz |
+| 2 | 11.5 | 5.77 Hz |
+| 4 | 17.8 | 4.44 Hz |
+| 8 | 26.0 | 3.25 Hz |
+| 16 | 32.9 | 2.06 Hz |
+
+Where a single control step goes (batch 1, distinct images):
+
+| part | time |
+|---|---|
+| vision towers (DINOv2 + SigLIP, 256 tokens each) | 14–24 ms |
+| rest of prefill | 31–38 ms |
+| 6 decode steps | 68–76 ms |
+
+## Notes
+
+- **Batch size is a real knob here.** The other robot deploys in this repo
+  (`Gr00tN1d7.yaml`, `dreamzero.yaml`, `pi0.yaml`) pin `max_num_seqs: 1`.
+  OpenVLA is a plain AR
+  stage, so `max_num_seqs` behaves normally and concurrent robots share the GPU.
+- The 256 image tokens are inserted immediately after BOS, which is where the
+  reference splices them. That means the part of the prompt that changes every
+  control step is at the *front*, so prefix caching cannot reuse anything; the
+  deploy config turns it off rather than paying for the bookkeeping.
+- The checkpoint expects a trailing empty token (id `29871`) after the prompt —
+  the reference re-inserts it in `predict_action` because the training-time
+  template ended with a space that `get_prompt()` strips. The serving path
+  builds prompt token ids directly for this reason; no chat template produces it.

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -68,6 +68,7 @@ recipes/
 | [`OpenBMB/MiniCPM-o-4_5.md`](./OpenBMB/MiniCPM-o-4_5.md) | Online serving for omni multimodal chat (text / image / audio / video → text + 24 kHz speech) | 2x A100/H100 80GB / 3x mid-tier GPU / 8x RTX 4090 24GB |
 | [`OpenBMB/VoxCPM2.md`](./OpenBMB/VoxCPM2.md) | Online + offline TTS with native AR pipeline (48 kHz, 30+ languages) | 1x RTX 4090 24GB |
 | [`OpenMOSS/MOSS-TTS.md`](./OpenMOSS/MOSS-TTS.md) | Online + offline multilingual TTS (MOSS-TTS family, 8B) | 1x H100 80GB |
+| [`OpenVLA/OpenVLA-7B.md`](./OpenVLA/OpenVLA-7B.md) | Autoregressive robot policy over the OpenPI WebSocket endpoint (7 action tokens per control step) | 1x A800 80GB |
 | [`NVIDIA/Nemotron-Labs-Audex.md`](./NVIDIA/Nemotron-Labs-Audex.md) | TTS / text-to-audio / audio understanding / cascaded S2S (Audex 2B + 30B-A3B) | 1x H100 80GB |
 | [`NVIDIA/NemotronLabs-VoiceChat.md`](./NVIDIA/NemotronLabs-VoiceChat.md) | Offline speech-to-speech voice chat (11B, frame-locked 12.5 Hz, 3-stage thinker/talker/code2wav) | 1x H100 80GB |
 | [`Qwen/Qwen-Image.md`](./Qwen/Qwen-Image.md) | Text-to-image serving with step-wise continuous batching replay and ModelOpt mixed FP8/NVFP4 | 1x A100 80GB / 2x B200 |

--- a/tests/e2e/online_serving/test_openvla_openpi.py
+++ b/tests/e2e/online_serving/test_openvla_openpi.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""End-to-end online serving test for OpenVLA-7B through the OpenPI robot endpoint.
+
+Boots ``vllm serve --omni --deploy-config openvla.yaml`` and drives the real
+msgpack websocket at ``/v1/realtime/robot/openpi`` — the wire path a robot uses.
+Unlike the other robot policies here, OpenVLA is a single autoregressive stage
+whose action *is* seven generated tokens, so this also covers the token → action
+decode that ``vllm_omni/model_executor/models/openvla/action_decode.py`` performs
+on the serving side.
+
+Deliberately no golden action vector. OpenVLA emits bin indices, and on a
+synthetic frame the model's own top-1/top-2 margin gets as low as 0.125 nat —
+inside bf16 rounding resolution — so a pinned expected action would be a
+flakiness generator rather than a correctness check. What is asserted instead
+holds whichever bin the policy picks: the returned values must land exactly on
+the action grid the checkpoint's own ``norm_stats`` define, the un-normalisation
+mask must be honoured, and the per-request ``unnorm_key`` must reach the decoder.
+The comparison against the reference implementation belongs on in-distribution
+inputs and is reported in the PR that added this model.
+
+Run it with real weights::
+
+    pytest -s -v tests/e2e/online_serving/test_openvla_openpi.py --run-level full_model
+
+The run level is not cosmetic here. ``stage_config_path_for_run_level`` adds
+``load_format: dummy`` to the deploy config for every level below
+``advanced_model``, so the default ``core_model`` serves random weights — under
+which OpenVLA emits ids outside the action range, every one of them clips onto
+the same extreme bin, and a weaker test would pass while proving nothing. The
+module refuses to run there rather than going green.
+
+Like ``test_gr00t_openpi_expansion.py`` and ``test_pi0_expansion.py``, this file
+is not wired into a Buildkite job: it needs a GPU and the 14 GiB checkpoint.
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+
+from tests.helpers.mark import hardware_test
+from tests.helpers.runtime import OmniServerParams
+from tests.helpers.stage_config import get_deploy_config_path
+
+os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+
+MODEL = "openvla/openvla-7b"
+IMAGE_SIZE = 224
+ACTION_DIM = 7
+INSTRUCTION = "put the spoon on the towel"
+
+# openvla.yaml pins bridge_orig; fractal20220817_data is a second embodiment in the
+# same checkpoint whose q01/q99 are roughly 8x wider, so the two un-normalise the
+# same bin onto visibly different numbers.
+UNNORM_KEY = "bridge_orig"
+ALT_UNNORM_KEY = "fractal20220817_data"
+
+# The 255 values a normalised action dimension can take: midpoints of 256 uniform
+# bins over [-1, 1]. This is checkpoint-independent — it follows from n_action_bins.
+_BIN_EDGES = np.linspace(-1.0, 1.0, 256)
+BIN_CENTERS = (_BIN_EDGES[:-1] + _BIN_EDGES[1:]) / 2.0
+
+pytest.importorskip("websockets")
+pytest.importorskip("openpi_client.msgpack_numpy")
+
+test_params = [
+    pytest.param(
+        OmniServerParams(
+            model=MODEL,
+            stage_config_path=get_deploy_config_path("openvla.yaml"),
+            server_args=["--disable-log-stats"],
+            env_dict={"VLLM_DISABLE_COMPILE_CACHE": "1"},
+            init_timeout=1200,
+        ),
+        id="openvla-7b-openpi",
+    )
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _require_real_weights(run_level: str) -> None:
+    """Refuse the dummy-weight run levels instead of passing on random weights."""
+    if run_level not in ("advanced_model", "full_model"):
+        pytest.skip(f"OpenVLA e2e needs real weights; pass --run-level full_model (got {run_level!r})")
+
+
+def _gradient_frame(size: int = IMAGE_SIZE) -> np.ndarray:
+    """A deterministic RGB frame — no RNG, so it is identical across runs."""
+    ys, xs = np.meshgrid(np.arange(size), np.arange(size), indexing="ij")
+    return np.stack(
+        [xs * 255 // (size - 1), ys * 255 // (size - 1), (xs + ys) % 256],
+        axis=-1,
+    ).astype(np.uint8)
+
+
+def _bars_frame(size: int = IMAGE_SIZE) -> np.ndarray:
+    ys, xs = np.meshgrid(np.arange(size), np.arange(size), indexing="ij")
+    return np.stack(
+        [((xs // 16) % 2) * 220 + 15, ((ys // 32) % 2) * 160 + 40, ((xs + ys) // 24 % 2) * 200 + 25],
+        axis=-1,
+    ).astype(np.uint8)
+
+
+def _observation(frame: np.ndarray, **extra) -> dict:
+    return {"image": frame, "prompt": INSTRUCTION, **extra}
+
+
+def _norm_stats(model_prefix: str) -> dict:
+    """The checkpoint's per-embodiment action statistics, read the way the server reads them."""
+    from vllm.transformers_utils.config import get_config
+
+    return get_config(f"{model_prefix}{MODEL}", trust_remote_code=False).norm_stats
+
+
+def _assert_on_action_grid(action: np.ndarray, stats: dict) -> None:
+    """Every dimension must be a bin centre, un-normalised iff its mask bit is set.
+
+    This is the assertion that survives a bin flip. It fails if ``q01``/``q99``
+    are taken from the wrong embodiment, if the affine un-normalisation is wrong,
+    or if the per-dimension mask is dropped — for openvla-7b the gripper's mask
+    bit is ``False`` in all 25 embodiments while its ``q01``/``q99`` are 0.0/1.0,
+    so ignoring the mask would halve that dimension and move it off the grid.
+    """
+    q01 = np.asarray(stats["q01"], dtype=np.float64)
+    q99 = np.asarray(stats["q99"], dtype=np.float64)
+    mask = np.asarray(stats["mask"], dtype=bool)
+
+    values = np.asarray(action, dtype=np.float64).ravel()
+    normalized = np.where(mask, 2.0 * (values - q01) / (q99 - q01) - 1.0, values)
+    distance = np.abs(normalized[:, None] - BIN_CENTERS[None, :]).min(axis=1)
+    assert (distance < 1e-4).all(), f"action components off the {len(BIN_CENTERS)}-bin grid: {distance.tolist()}"
+
+
+@pytest.mark.full_model
+@pytest.mark.omni
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.parametrize("omni_server", test_params, indirect=True)
+def test_openvla_openpi_online(omni_server, openai_client) -> None:
+    """Handshake, action shape, determinism, and that the action tracks the image."""
+    response = openai_client.send_robot_openpi_ws_request(
+        {
+            "operations": [
+                {"endpoint": "infer", "payload": _observation(_gradient_frame())},
+                {"endpoint": "reset", "payload": {}},
+                {"endpoint": "infer", "payload": _observation(_gradient_frame())},
+                {"endpoint": "infer", "payload": _observation(_bars_frame())},
+            ],
+        }
+    )[0]
+
+    # The handshake is derived from the checkpoint's norm_stats, not configured in
+    # the deploy yaml, so a fine-tuned OpenVLA advertises itself correctly.
+    metadata = response.server_metadata
+    for key in ("image_resolution", "needs_session_id", "action_horizon", "action_dim", "unnorm_key"):
+        assert key in metadata, f"Missing OpenVLA metadata key: {key}"
+    assert tuple(metadata["image_resolution"]) == (IMAGE_SIZE, IMAGE_SIZE)
+    assert metadata["needs_session_id"] is False
+    assert int(metadata["action_horizon"]) == 1
+    assert int(metadata["action_dim"]) == ACTION_DIM
+    assert metadata["unnorm_key"] == UNNORM_KEY
+    assert UNNORM_KEY in metadata["supported_embodiments"]
+    assert response.operation_responses[1]["status"] == "reset successful"
+
+    actions = response.action_tensors
+    assert actions is not None and len(actions) == 3
+    for index, action in enumerate(actions):
+        assert action.shape == (1, ACTION_DIM), f"action {index} shape {action.shape}"
+        assert np.isfinite(action).all(), f"action {index} is not finite"
+
+    # Greedy decoding of a stateless policy: the same frame gives the same action,
+    # across a reset as well.
+    np.testing.assert_array_equal(actions[0], actions[1])
+    # A different frame must give a different action. This is what catches the
+    # observation never reaching the model: without a usable image OpenVLA emits
+    # ids outside the action range, they all clip onto the same extreme bin, and
+    # the policy returns one constant vector for every frame.
+    assert not np.array_equal(actions[0], actions[2]), "action did not change with the observation"
+
+
+@pytest.mark.full_model
+@pytest.mark.omni
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.parametrize("omni_server", test_params, indirect=True)
+def test_openvla_openpi_unnorm_key_override(omni_server, openai_client, model_prefix) -> None:
+    """A request may pick the embodiment, and both answers land on that embodiment's grid."""
+    frame = _gradient_frame()
+    response = openai_client.send_robot_openpi_ws_request(
+        {
+            "operations": [
+                {"endpoint": "infer", "payload": _observation(frame)},
+                {"endpoint": "infer", "payload": _observation(frame, unnorm_key=ALT_UNNORM_KEY)},
+            ],
+        }
+    )[0]
+
+    actions = response.action_tensors
+    assert actions is not None and len(actions) == 2
+
+    norm_stats = _norm_stats(model_prefix)
+    _assert_on_action_grid(actions[0], norm_stats[UNNORM_KEY]["action"])
+    _assert_on_action_grid(actions[1], norm_stats[ALT_UNNORM_KEY]["action"])
+
+    # Same image, same tokens, different statistics — so the un-normalised values
+    # must differ. Equality here would mean the request's unnorm_key was ignored.
+    assert not np.allclose(actions[0], actions[1]), "per-request unnorm_key did not reach the decoder"

--- a/tests/entrypoints/openai_api/test_openpi_ar_action_policy.py
+++ b/tests/entrypoints/openai_api/test_openpi_ar_action_policy.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""L1 tests for the token-based (AR) robot policy path (CPU, no weights).
+
+Everything the OpenPI endpoint did before this assumed a diffusion pipeline:
+the handshake came from the deploy YAML, the request was an
+`OmniDiffusionRequest`, and the actions came back on `multimodal_output`. These
+tests pin the AR alternative — a policy whose actions *are* the generated
+tokens — without loading a model.
+"""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from vllm_omni.entrypoints.openpi import serving as openpi_serving
+from vllm_omni.entrypoints.openpi.adapters import resolve_robot_ar_adapter
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+_ARCH = "OpenVLAForActionPrediction"
+_VOCAB_PADDED = 32064
+_PAD_TO = 64
+_UNPADDED = _VOCAB_PADDED - _PAD_TO
+
+_STATS = {
+    "bridge_orig": {
+        "action": {
+            "q01": [-1.0] * 6 + [0.0],
+            "q99": [1.0] * 6 + [1.0],
+            "mask": [True] * 6 + [False],
+        }
+    }
+}
+
+
+class _FakeTokenizer:
+    def encode(self, text, add_special_tokens=True):
+        # Deliberately does not end in 29871, so the adapter has to add it.
+        return [1, 100, 101, 102]
+
+
+_ADAPTER = "vllm_omni.model_executor.models.openvla.robot_adapter.OpenVLARobotAdapter"
+
+
+def _openvla_engine(*, adapter=_ADAPTER, norm_stats=None, unnorm_key=None):
+    hf_config = SimpleNamespace(
+        architectures=[_ARCH],
+        norm_stats=_STATS if norm_stats is None else norm_stats,
+        n_action_bins=256,
+        pad_to_multiple_of=_PAD_TO,
+        text_config=SimpleNamespace(vocab_size=_VOCAB_PADDED),
+    )
+    if unnorm_key is not None:
+        hf_config.unnorm_key = unnorm_key
+    stage = SimpleNamespace(
+        stage_type="llm",
+        engine_args=SimpleNamespace(robot_adapter=adapter),
+    )
+    return SimpleNamespace(
+        stage_configs=[stage],
+        model_config=SimpleNamespace(hf_config=hf_config),
+    )
+
+
+def _result(token_ids):
+    return SimpleNamespace(outputs=[SimpleNamespace(token_ids=list(token_ids), cumulative_token_ids=None)])
+
+
+def test_adapter_resolves_from_the_stage_declaration():
+    assert resolve_robot_ar_adapter(_openvla_engine()) is not None
+
+
+def test_no_adapter_when_the_stage_declares_none():
+    """A diffusion policy simply does not set `robot_adapter`."""
+    assert resolve_robot_ar_adapter(_openvla_engine(adapter=None)) is None
+
+
+def test_engine_without_stage_configs_is_tolerated():
+    assert resolve_robot_ar_adapter(SimpleNamespace()) is None
+
+
+def test_handshake_is_derived_from_the_checkpoint():
+    """No deploy YAML involved: an LLM_AR stage cannot carry `model_config`."""
+    serving = openpi_serving.ServingRealtimeRobotOpenPI(engine_client=_openvla_engine(unnorm_key="bridge_orig"))
+    values = serving.policy_server_config.to_dict()
+    assert values["action_dim"] == 7
+    assert values["action_horizon"] == 1
+    assert values["unnorm_key"] == "bridge_orig"
+    assert values["supported_embodiments"] == ["bridge_orig"]
+
+
+def test_endpoint_stays_off_for_a_model_that_is_not_a_policy():
+    plain = SimpleNamespace(
+        stage_configs=[SimpleNamespace(stage_type="llm", engine_args=SimpleNamespace())],
+        model_config=SimpleNamespace(hf_config=SimpleNamespace(architectures=["LlamaForCausalLM"])),
+    )
+    assert openpi_serving.ServingRealtimeRobotOpenPI.create_policy_server(engine_client=plain) is None
+
+
+def test_request_carries_prompt_token_ids_the_image_and_a_fixed_length_decode():
+    serving = openpi_serving.ServingRealtimeRobotOpenPI(engine_client=_openvla_engine(unnorm_key="bridge_orig"))
+    obs = {
+        "prompt": "Pick Up The Red Block",
+        "image": np.zeros((224, 224, 3), dtype=np.uint8),
+    }
+    request = serving.ar_adapter.build_request(obs, tokenizer=_FakeTokenizer(), request_id="r-0")
+
+    # The checkpoint expects a trailing empty token that no chat template emits.
+    assert request.prompt["prompt_token_ids"][-1] == 29871
+    assert "image" in request.prompt["multi_modal_data"]
+    assert request.sampling_params.max_tokens == 7
+    assert request.sampling_params.min_tokens == 7
+    assert request.sampling_params.temperature == 0.0
+    assert request.sampling_params.detokenize is False
+
+
+def test_missing_image_and_missing_instruction_are_reported_clearly():
+    serving = openpi_serving.ServingRealtimeRobotOpenPI(engine_client=_openvla_engine(unnorm_key="bridge_orig"))
+    tokenizer = _FakeTokenizer()
+    with pytest.raises(ValueError, match="needs an image"):
+        serving.ar_adapter.build_request({"prompt": "go"}, tokenizer=tokenizer, request_id="r")
+    with pytest.raises(ValueError, match="language instruction"):
+        serving.ar_adapter.build_request(
+            {"image": np.zeros((224, 224, 3), dtype=np.uint8)},
+            tokenizer=tokenizer,
+            request_id="r",
+        )
+
+
+def test_generated_tokens_become_an_action_array():
+    serving = openpi_serving.ServingRealtimeRobotOpenPI(engine_client=_openvla_engine(unnorm_key="bridge_orig"))
+    token_ids = [_UNPADDED - 1, _UNPADDED - 128, _UNPADDED - 255] + [_UNPADDED - 64] * 4
+    actions = serving.ar_adapter.decode_actions(_result(token_ids))
+    assert actions.shape == (1, 7)
+    assert actions.dtype == np.float32
+    # `bin = vocab_size - token_id`, so the highest token id is the lowest bin.
+    assert actions[0][0] == pytest.approx(-1.0, abs=0.01)
+    assert actions[0][2] == pytest.approx(1.0, abs=0.01)
+
+
+def test_action_decode_falls_back_to_cumulative_token_ids():
+    serving = openpi_serving.ServingRealtimeRobotOpenPI(engine_client=_openvla_engine(unnorm_key="bridge_orig"))
+    result = SimpleNamespace(outputs=[SimpleNamespace(token_ids=[], cumulative_token_ids=[_UNPADDED - 1] * 7)])
+    assert serving.ar_adapter.decode_actions(result).shape == (1, 7)
+
+
+def test_empty_completion_is_reported_rather_than_producing_a_wrong_action():
+    serving = openpi_serving.ServingRealtimeRobotOpenPI(engine_client=_openvla_engine(unnorm_key="bridge_orig"))
+    with pytest.raises(RuntimeError, match="no action token ids"):
+        serving.ar_adapter.decode_actions(
+            SimpleNamespace(outputs=[SimpleNamespace(token_ids=[], cumulative_token_ids=[])])
+        )

--- a/tests/model_executor/models/test_openvla_action_decode.py
+++ b/tests/model_executor/models/test_openvla_action_decode.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""L1 tests for OpenVLA action de-tokenisation (CPU, no weights).
+
+OpenVLA's policy output is seven ordinary generated tokens; turning them back
+into a robot action is the half that exists in neither vLLM nor vllm-omni, and
+it is pure arithmetic, so it is fully testable here.
+"""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from vllm_omni.model_executor.models.openvla.action_decode import (
+    OPENVLA_EMPTY_TOKEN_ID,
+    OpenVLAActionDecoder,
+    build_prompt,
+    build_prompt_token_ids,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+# openvla-7b's real shape: a padded 32064-entry embedding table whose last 64
+# rows are padding, so the action bins start counting down from 32000.
+_VOCAB_PADDED = 32064
+_PAD_TO = 64
+_UNPADDED = _VOCAB_PADDED - _PAD_TO
+_N_BINS = 256
+
+# Two embodiments so the "which one?" behaviour is exercised. The mask matches
+# every embodiment in the real checkpoint: the last dimension (the gripper) is
+# never un-normalised.
+_STATS = {
+    "bridge_orig": {
+        "action": {
+            "q01": [-1.0, -2.0, 0.0],
+            "q99": [1.0, 2.0, 10.0],
+            "mask": [True, True, False],
+        }
+    },
+    "fractal": {
+        "action": {
+            "q01": [0.0, 0.0, 0.0],
+            "q99": [4.0, 4.0, 4.0],
+            "mask": [True, True, True],
+        }
+    },
+}
+
+
+def _hf_config(norm_stats=None, **overrides):
+    config = SimpleNamespace(
+        norm_stats=_STATS if norm_stats is None else norm_stats,
+        n_action_bins=_N_BINS,
+        pad_to_multiple_of=_PAD_TO,
+        text_config=SimpleNamespace(vocab_size=_VOCAB_PADDED),
+    )
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def _decoder(**kwargs):
+    return OpenVLAActionDecoder.from_hf_config(_hf_config(), **kwargs)
+
+
+def _reference_decode(token_ids, stats, vocab_size=_UNPADDED, n_bins=_N_BINS):
+    """The reference arithmetic, transcribed independently of the implementation."""
+    bins = np.linspace(-1, 1, n_bins)
+    bin_centers = (bins[:-1] + bins[1:]) / 2.0
+    discretized = np.asarray(vocab_size) - np.asarray(token_ids)
+    discretized = np.clip(discretized - 1, a_min=0, a_max=bin_centers.shape[0] - 1)
+    normalized = bin_centers[discretized]
+    q01 = np.asarray(stats["q01"])
+    q99 = np.asarray(stats["q99"])
+    mask = np.asarray(stats["mask"], dtype=bool)
+    return np.where(mask, 0.5 * (normalized + 1) * (q99 - q01) + q01, normalized)
+
+
+def test_decode_matches_the_reference_arithmetic():
+    decoder = _decoder(default_unnorm_key="bridge_orig")
+    # A high bin, the middle, and the very bottom of the action range.
+    token_ids = [_UNPADDED - 1, _UNPADDED - 128, _UNPADDED - 255]
+    got = decoder.decode(token_ids)
+    want = _reference_decode(token_ids, _STATS["bridge_orig"]["action"])
+    np.testing.assert_allclose(got, want, rtol=0, atol=1e-6)
+
+
+def test_bins_count_down_from_the_top_of_the_vocabulary():
+    """The direction is the easy thing to get backwards.
+
+    `bin = vocab_size - token_id`, so the *highest* action token id is the
+    *lowest* bin and therefore the bottom of the action range.
+    """
+    decoder = _decoder(default_unnorm_key="bridge_orig")
+    lowest_bin = decoder.decode([_UNPADDED - 1] * 3)
+    highest_bin = decoder.decode([_UNPADDED - 255] * 3)
+    assert lowest_bin[0] == pytest.approx(-1.0, abs=0.01)
+    assert highest_bin[0] == pytest.approx(1.0, abs=0.01)
+
+
+def test_masked_dimension_is_not_unnormalised():
+    """The gripper dimension comes back as a raw bin centre, inside [-1, 1]."""
+    decoder = _decoder(default_unnorm_key="bridge_orig")
+    action = decoder.decode([_UNPADDED - 1, _UNPADDED - 1, _UNPADDED - 1])
+    assert -1.0 <= action[2] <= 1.0
+    # ...while an unmasked dimension of the same token spans its own q01..q99.
+    assert action[1] == pytest.approx(-2.0, abs=0.02)
+
+
+def test_out_of_range_tokens_clip_rather_than_raise():
+    decoder = _decoder(default_unnorm_key="bridge_orig")
+    # A token far below the action range (e.g. ordinary text) and one above it.
+    low = decoder.decode([1, 1, 1])
+    high = decoder.decode([_UNPADDED + 10] * 3)
+    np.testing.assert_allclose(low, decoder.decode([_UNPADDED - 255] * 3))
+    np.testing.assert_allclose(high, decoder.decode([_UNPADDED - 1] * 3))
+
+
+def test_wrong_token_count_is_rejected():
+    decoder = _decoder(default_unnorm_key="bridge_orig")
+    with pytest.raises(ValueError, match="Expected 3 action tokens"):
+        decoder.decode([_UNPADDED - 1, _UNPADDED - 2])
+
+
+def test_unnorm_key_selects_the_embodiment():
+    decoder = _decoder(default_unnorm_key="bridge_orig")
+    token_ids = [_UNPADDED - 128] * 3
+    bridge = decoder.decode(token_ids)
+    fractal = decoder.decode(token_ids, "fractal")
+    assert not np.allclose(bridge, fractal)
+    np.testing.assert_allclose(fractal, _reference_decode(token_ids, _STATS["fractal"]["action"]), atol=1e-6)
+
+
+def test_ambiguous_embodiment_names_the_options():
+    decoder = _decoder()
+    assert decoder.default_unnorm_key is None
+    with pytest.raises(ValueError, match="bridge_orig"):
+        decoder.decode([_UNPADDED - 1] * 3)
+
+
+def test_single_embodiment_needs_no_key():
+    single = {"only": _STATS["bridge_orig"]}
+    decoder = OpenVLAActionDecoder.from_hf_config(_hf_config(norm_stats=single))
+    assert decoder.default_unnorm_key == "only"
+    assert decoder.decode([_UNPADDED - 1] * 3).shape == (3,)
+
+
+def test_unknown_embodiment_is_rejected_at_construction():
+    with pytest.raises(ValueError, match="Unknown unnorm_key"):
+        _decoder(default_unnorm_key="nope")
+
+
+def test_missing_padding_metadata_raises_instead_of_decoding_wrongly():
+    """Guards a silent failure: a wrong vocab size clips every token to bin 0."""
+    config = _hf_config()
+    del config.pad_to_multiple_of
+    with pytest.raises(ValueError, match="pad_to_multiple_of"):
+        OpenVLAActionDecoder.from_hf_config(config)
+
+
+def test_checkpoint_without_norm_stats_is_rejected():
+    with pytest.raises(ValueError, match="norm_stats"):
+        OpenVLAActionDecoder.from_hf_config(_hf_config(norm_stats={}))
+
+
+def test_prompt_matches_the_checkpoints_training_format():
+    assert build_prompt("Pick Up The Red Block") == (
+        "In: What action should the robot take to pick up the red block?\nOut:"
+    )
+
+
+class _FakeTokenizer:
+    def __init__(self, ids):
+        self._ids = ids
+        self.calls = []
+
+    def encode(self, text, add_special_tokens=True):
+        self.calls.append((text, add_special_tokens))
+        return list(self._ids)
+
+
+def test_prompt_token_ids_append_the_empty_token():
+    tokenizer = _FakeTokenizer([1, 2, 3])
+    ids = build_prompt_token_ids(tokenizer, "close the gripper")
+    assert ids == [1, 2, 3, OPENVLA_EMPTY_TOKEN_ID]
+    assert tokenizer.calls[0][1] is True
+
+
+def test_prompt_token_ids_do_not_double_append():
+    tokenizer = _FakeTokenizer([1, 2, OPENVLA_EMPTY_TOKEN_ID])
+    assert build_prompt_token_ids(tokenizer, "close the gripper") == [
+        1,
+        2,
+        OPENVLA_EMPTY_TOKEN_ID,
+    ]
+
+
+def test_policy_server_values_are_derived_from_the_checkpoint():
+    values = _decoder(default_unnorm_key="bridge_orig").policy_server_values()
+    assert values["action_dim"] == 3
+    assert values["unnorm_key"] == "bridge_orig"
+    assert values["supported_embodiments"] == ["bridge_orig", "fractal"]
+    assert values["image_resolution"] == [224, 224]

--- a/tests/model_executor/models/test_openvla_registration.py
+++ b/tests/model_executor/models/test_openvla_registration.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""L1 registration tests for OpenVLA (CPU, no weights).
+
+Without a pipeline entry, `vllm-omni serve openvla/openvla-7b` does not fall
+through to the model registry — it resolves no pipeline, takes the default
+single-stage *diffusion* config and dies in the diffusion loader. These tests
+pin the registration and the one property that makes it an AR stage.
+"""
+
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+import yaml
+
+from vllm_omni.config.pipeline_registry import OMNI_PIPELINES
+from vllm_omni.config.stage_config import StageExecutionType
+from vllm_omni.model_executor.models.openvla.pipeline import (
+    OPENVLA_ACTION_DIM,
+    OPENVLA_PIPELINE,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+_ARCH = "OpenVLAForActionPrediction"
+
+
+def test_model_type_resolves_to_the_openvla_pipeline():
+    assert OMNI_PIPELINES["openvla"] is OPENVLA_PIPELINE
+
+
+def test_topology_is_one_autoregressive_stage():
+    assert OPENVLA_PIPELINE.validate() == []
+    assert len(OPENVLA_PIPELINE.stages) == 1
+    stage = OPENVLA_PIPELINE.stages[0]
+    assert stage.execution_type is StageExecutionType.LLM_AR
+    assert stage.final_output is True
+    assert stage.final_output_type == "actions"
+    assert stage.requires_multimodal_data is True
+    assert stage.owns_tokenizer is True
+
+
+def test_engine_output_type_is_unset():
+    """`actions` is not an OutputModality; setting it crashes engine init."""
+    assert OPENVLA_PIPELINE.stages[0].engine_output_type is None
+
+
+def test_sampling_is_pinned_to_a_fixed_length_greedy_decode():
+    constraints = OPENVLA_PIPELINE.stages[0].sampling_constraints
+    assert constraints["temperature"] == 0.0
+    assert constraints["max_tokens"] == OPENVLA_ACTION_DIM
+    assert constraints["min_tokens"] == OPENVLA_ACTION_DIM
+    assert constraints["ignore_eos"] is True
+    # The tokens are bin indices, so there is nothing to detokenise.
+    assert constraints["detokenize"] is False
+
+
+def test_stage_declares_its_robot_adapter():
+    """The OpenPI endpoint finds the adapter through the stage, not a side table."""
+    from vllm_omni.model_executor.models.openvla.robot_adapter import OpenVLARobotAdapter
+
+    path = OPENVLA_PIPELINE.stages[0].robot_adapter
+    assert path == ("vllm_omni.model_executor.models.openvla.robot_adapter.OpenVLARobotAdapter")
+    module_path, attr = path.rsplit(".", 1)
+    assert getattr(import_module(module_path), attr) is OpenVLARobotAdapter
+
+
+def test_architecture_resolves_through_the_merged_model_registry():
+    """The model class itself is upstream vLLM's; we add no model code."""
+    from vllm_omni.model_executor.models.registry import OmniModelRegistry
+
+    assert _ARCH in OmniModelRegistry.get_supported_archs()
+    assert OPENVLA_PIPELINE.model_arch == _ARCH
+    assert OPENVLA_PIPELINE.stages[0].model_arch == _ARCH
+
+
+def test_deploy_config_exists_and_points_back_at_this_pipeline():
+    name = OPENVLA_PIPELINE.default_deploy_config_name
+    assert name == "openvla.yaml"
+    path = Path(__file__).resolve().parents[3] / "vllm_omni" / "deploy" / name
+    deploy = yaml.safe_load(path.read_text())
+    assert deploy["pipeline"] == "openvla"
+    # A single-stage pipeline has no next-stage processor, so chunking must be off.
+    assert deploy["async_chunk"] is False
+    assert len(deploy["stages"]) == 1

--- a/vllm_omni/config/pipeline_registry.py
+++ b/vllm_omni/config/pipeline_registry.py
@@ -95,6 +95,7 @@ from vllm_omni.model_executor.models.nemotron_voicechat.pipeline import (
     NEMOTRON_VOICECHAT_PIPELINE,
 )
 from vllm_omni.model_executor.models.omnivoice.pipeline import OMNIVOICE_PIPELINE
+from vllm_omni.model_executor.models.openvla.pipeline import OPENVLA_PIPELINE
 from vllm_omni.model_executor.models.personaplex.pipeline import PERSONAPLEX_PIPELINE
 from vllm_omni.model_executor.models.qwen2_5_omni.pipeline import (
     QWEN2_5_OMNI_PIPELINE,
@@ -141,6 +142,7 @@ OMNI_PIPELINES: dict[str, PipelineConfig | PipelineResolverFunc] = {
     "dreamzero": DREAMZERO_PIPELINE,
     "Gr00tN1d7": GR00T_N1D7_PIPELINE,
     "pi0": PI0_PIPELINE,
+    "openvla": OPENVLA_PIPELINE,
     "gepard": GEPARD_PIPELINE,
     "glm_image": GLM_IMAGE_PIPELINE,
     "hunyuan_image_3_moe": HUNYUAN_IMAGE3_PIPELINE,

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -188,6 +188,12 @@ class StagePipelineConfig:
     sampling_constraints: dict[str, Any] = field(default_factory=dict)
     custom_process_input_func: str | None = None
     custom_process_next_stage_input_func: str | None = None
+    # Dotted path to the class that bridges this stage to the OpenPI robot
+    # endpoint: observation -> prompt, generated tokens -> action array, and the
+    # handshake values. Only needed by policies whose actions are generated
+    # tokens; a diffusion policy carries its own transforms in its pipeline and
+    # returns actions on ``multimodal_output`` instead.
+    robot_adapter: str | None = None
     # Alternates picked by ``merge_pipeline_deploy`` based on ``deploy.async_chunk``.
     async_chunk_process_next_stage_input_func: str | None = None
     sync_process_input_func: str | None = None
@@ -819,6 +825,8 @@ def _build_engine_args(
         engine_args["model_subdir"] = ps.model_subdir
     if ps.tokenizer_subdir:
         engine_args["tokenizer_subdir"] = ps.tokenizer_subdir
+    if ps.robot_adapter:
+        engine_args["robot_adapter"] = ps.robot_adapter
 
     # Pipeline-wide top-level DeployConfig settings, applied to every stage.
     for name in _PIPELINE_WIDE_ENGINE_FIELDS:

--- a/vllm_omni/deploy/openvla.yaml
+++ b/vllm_omni/deploy/openvla.yaml
@@ -1,0 +1,38 @@
+# OpenVLA-7B deploy: a single autoregressive action stage.
+#
+# Topology is declared in vllm_omni/model_executor/models/openvla/pipeline.py.
+# Unlike the diffusion robot policies, this one runs on the ordinary AR engine,
+# so paged KV, continuous batching and CUDA graphs all apply and max_num_seqs
+# is a real knob rather than a hard 1.
+#
+# The OpenPI handshake is not configured here. An LLM_AR stage may not carry the
+# `model_config:` block the diffusion robot deploys use — it is a diffusion-only
+# key and the stage-override validator rejects it — so OpenVLA advertises itself
+# from the checkpoint's own norm_stats instead.
+
+pipeline: openvla
+# Single-stage pipelines have no next-stage processor, so the deploy validator
+# rejects the default async_chunk=true.
+async_chunk: false
+dtype: bfloat16
+
+stages:
+  - stage_id: 0
+    devices: "0"
+    max_num_seqs: 16
+    # 1 BOS + 256 image tokens + the instruction + 7 action tokens; 1024 leaves
+    # room for a long instruction without over-reserving KV.
+    max_model_len: 1024
+    # Unlike the diffusion robot deploys, this one does not force eager
+    # execution. Measured on one A800 with a distinct image per request, eager
+    # and CUDA graphs are within run-to-run noise at batch 1 (142-165 ms vs
+    # 144-146 ms) and graphs are consistently ahead once requests batch
+    # (38.7-39.0 ms/action vs 39.8-43.0 at batch 8).
+    enforce_eager: false
+    # The 256 image tokens sit immediately after BOS, so the part of the prompt
+    # that changes every control step is at the front and nothing is reusable.
+    enable_prefix_caching: false
+    # openvla-7b ships action statistics for 25 embodiments, so one has to be
+    # chosen; a request may still override it per observation.
+    hf_overrides:
+      unnorm_key: bridge_orig

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1177,7 +1177,13 @@ async def omni_init_app_state(
         model_name=served_model_names[0] if served_model_names else None,
         stage_configs=state.stage_configs,
     )
-    state.openai_serving_realtime_robot = None
+    # A robot policy does not have to be a diffusion pipeline: OpenVLA is an AR
+    # stage whose tokens are the action. `create_policy_server` returns None for
+    # every model that is neither, so this is a no-op for existing deployments.
+    state.openai_serving_realtime_robot = ServingRealtimeRobotOpenPI.create_policy_server(
+        engine_client=engine_client,
+        model_name=model_name,
+    )
 
     state.enable_server_load_tracking = args.enable_server_load_tracking
     state.server_load_metrics = 0

--- a/vllm_omni/entrypoints/openpi/adapters.py
+++ b/vllm_omni/entrypoints/openpi/adapters.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Resolve a stage's robot adapter for the OpenPI endpoint.
+
+Every robot policy served so far has been a diffusion pipeline, which owns its
+own observation transforms and returns `multimodal_output["actions"]`. A policy
+whose actions are generated *tokens* has no such pipeline object, so the three
+model-specific pieces — handshake values, observation → prompt, tokens → action
+array — live under `vllm_omni/model_executor/models/<name>/` and the stage
+declares the dotted path in its `StagePipelineConfig.robot_adapter`, the same
+way it declares `custom_process_input_func` or `scheduler_cls`.
+"""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from typing import Any
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+@dataclass(frozen=True)
+class RobotARRequest:
+    """The three fields `ServingRealtimeRobotOpenPI.infer` consumes."""
+
+    prompt: Any
+    sampling_params: Any
+    request_id: str
+
+
+def _load(path: str) -> Any:
+    module_path, attr = path.rsplit(".", 1)
+    return getattr(importlib.import_module(module_path), attr)
+
+
+def resolve_robot_ar_adapter(engine_client: Any) -> Any | None:
+    """A bound adapter if some stage declares one, else None."""
+    for stage_config in getattr(engine_client, "stage_configs", []) or []:
+        engine_args = getattr(stage_config, "engine_args", None)
+        path = getattr(engine_args, "robot_adapter", None)
+        if not path:
+            continue
+        adapter = _load(str(path)).from_engine_client(engine_client)
+        logger.info("Robot OpenPI serving using the AR adapter %s", path)
+        return adapter
+    return None

--- a/vllm_omni/entrypoints/openpi/serving.py
+++ b/vllm_omni/entrypoints/openpi/serving.py
@@ -4,7 +4,12 @@
 """Serving layer for robot policy inference via `/v1/realtime/robot/openpi`.
 
 Flow: raw obs → engine request → actions.
-The loaded policy model owns dataset transforms inside its pipeline.
+
+A diffusion policy owns its dataset transforms inside its pipeline, so the raw
+observation is handed straight through and the actions come back on
+`multimodal_output`. A policy whose actions are generated tokens has no such
+pipeline, so a model-owned adapter (see `adapters.py`) converts the observation
+into a prompt and the returned token ids back into an action array.
 """
 
 from __future__ import annotations
@@ -17,6 +22,8 @@ from typing import Any
 import numpy as np
 from omegaconf import OmegaConf
 from vllm.logger import init_logger
+
+from vllm_omni.entrypoints.openpi.adapters import resolve_robot_ar_adapter
 
 logger = init_logger(__name__)
 
@@ -74,8 +81,10 @@ class ServingRealtimeRobotOpenPI:
     ) -> None:
         self.engine_client = engine_client
         self.model_name = model_name
-        self.policy_server_config = self._get_policy_server_config(engine_client)
+        self.ar_adapter = resolve_robot_ar_adapter(engine_client)
+        self.policy_server_config = self._get_policy_server_config(engine_client, self.ar_adapter)
         self._request_counter = count()
+        self._ar_tokenizer: Any = None
 
     @classmethod
     def create_policy_server(
@@ -92,7 +101,7 @@ class ServingRealtimeRobotOpenPI:
             return None
 
     @staticmethod
-    def _get_policy_server_config(engine_client: Any) -> PolicyServerConfig:
+    def _get_policy_server_config(engine_client: Any, ar_adapter: Any = None) -> PolicyServerConfig:
         model_config = None
         get_od_config = getattr(engine_client, "get_diffusion_od_config", None)
         if callable(get_od_config):
@@ -112,6 +121,14 @@ class ServingRealtimeRobotOpenPI:
             od_config = getattr(engine_client, "od_config", None)
             model_config = getattr(od_config, "model_config", None)
 
+        # An AR policy has no diffusion stage and so no od_config; its handshake
+        # is derived from the checkpoint by the model-owned adapter. Falling
+        # through to the branch below would hand `from_model_config` a vLLM
+        # ModelConfig, which has neither a `policy_server_config` field nor a
+        # `__getattr__`, so the endpoint would silently stay off.
+        if model_config is None and ar_adapter is not None:
+            return PolicyServerConfig(ar_adapter.policy_server_values())
+
         if model_config is None:
             model_config = getattr(engine_client, "model_config", None)
         return PolicyServerConfig.from_model_config(model_config)
@@ -122,7 +139,16 @@ class ServingRealtimeRobotOpenPI:
     async def infer(self, obs: dict, *, session_id: str, reset: bool) -> ActionOutput:
         """raw obs → engine → actions."""
         # Build request, run inference through AsyncOmni
-        request = self._build_request(obs, session_id=session_id, reset=reset)
+        if self.ar_adapter is not None:
+            if self._ar_tokenizer is None:
+                self._ar_tokenizer = await self.engine_client.get_tokenizer()
+            request = self.ar_adapter.build_request(
+                obs,
+                tokenizer=self._ar_tokenizer,
+                request_id=self._next_request_id(session_id),
+            )
+        else:
+            request = self._build_request(obs, session_id=session_id, reset=reset)
         result = None
         # OpenPI policy serving is one request -> one action reply. AsyncOmni
         # exposes an async iterator, so consume it to completion and use the
@@ -136,6 +162,8 @@ class ServingRealtimeRobotOpenPI:
         if result is None:
             raise RuntimeError("Robot OpenPI request produced no output.")
 
+        if self.ar_adapter is not None:
+            return self.ar_adapter.decode_actions(result, obs.get("unnorm_key"))
         return self._extract_actions(result)
 
     def _next_request_id(self, session_id: str) -> str:

--- a/vllm_omni/model_executor/models/openvla/__init__.py
+++ b/vllm_omni/model_executor/models/openvla/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# NOTE: Do not import model classes in this file. Importing any
+# submodule in this package triggers __init__.py execution, and
+# both the model registry and pipeline registry import submodules
+# directly — heavy imports here would be loaded as a side effect
+# even though nothing depends on these re-exports.

--- a/vllm_omni/model_executor/models/openvla/action_decode.py
+++ b/vllm_omni/model_executor/models/openvla/action_decode.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Turn OpenVLA's generated token ids back into a robot action.
+
+OpenVLA does not have an action head. It discretises each action dimension into
+256 uniform bins and maps bin *i* onto the language-model token
+``vocab_size - 1 - i``, i.e. actions live in the last 256 ids of the Llama-2
+vocabulary. Generation therefore produces seven ordinary tokens and the policy
+output is whatever those ids decode to.
+
+Upstream vLLM runs the model but stops at the token ids: it reads
+``n_action_bins`` off the config and never uses it, and it carries no
+``norm_stats``. Everything below is the missing half, and it is pure CPU numpy
+so it is unit-testable without a GPU.
+
+The arithmetic is transcribed from ``OpenVLAForActionPrediction.predict_action``
+in the reference checkpoint (``openvla/openvla-7b``,
+``modeling_prismatic.py``); the two details that are easy to get wrong are that
+``vocab_size`` here is the *unpadded* 32000 rather than the checkpoint's 32064,
+and that ``mask`` is applied per dimension — in every one of openvla-7b's 25
+embodiments its last element is ``False``, so the gripper dimension is returned
+as a raw bin centre and is never un-normalised.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+# The SentencePiece "▁" piece. Training wrapped the assistant turn as
+# ``"In: {msg}\nOut: "`` and the prompt builder right-strips it, so inference
+# has to put the space back explicitly or the model sees a prompt it never saw
+# during training.
+OPENVLA_EMPTY_TOKEN_ID = 29871
+
+PROMPT_TEMPLATE = "In: What action should the robot take to {instruction}?\nOut:"
+
+
+def build_prompt(instruction: str) -> str:
+    """The exact inference-time prompt the checkpoint was trained for."""
+    return PROMPT_TEMPLATE.format(instruction=instruction.lower())
+
+
+def build_prompt_token_ids(tokenizer: Any, instruction: str) -> list[int]:
+    """Tokenise the action prompt and append the trailing empty token.
+
+    ``encode`` rather than ``__call__``: the tokenizer protocol guarantees
+    ``encode`` returns a flat ``list[int]``, while ``__call__`` returns a
+    backend-dependent ``BatchEncoding``.
+    """
+    token_ids = list(tokenizer.encode(build_prompt(instruction), add_special_tokens=True))
+    if not token_ids or token_ids[-1] != OPENVLA_EMPTY_TOKEN_ID:
+        token_ids.append(OPENVLA_EMPTY_TOKEN_ID)
+    return token_ids
+
+
+@dataclass(frozen=True)
+class OpenVLAActionDecoder:
+    """Decodes action token ids for one checkpoint's embodiment statistics."""
+
+    norm_stats: Mapping[str, Any]
+    bin_centers: np.ndarray
+    # Not the config's ``vocab_size``: the checkpoint pads the embedding table
+    # up to a multiple of 64, and the bin mapping was fitted before that padding.
+    vocab_size: int
+    # ``None`` when the checkpoint carries more than one embodiment and the
+    # deployment did not pick one; requests then have to name it themselves.
+    default_unnorm_key: str | None
+
+    @classmethod
+    def from_hf_config(
+        cls,
+        hf_config: Any,
+        default_unnorm_key: str | None = None,
+    ) -> OpenVLAActionDecoder:
+        norm_stats = getattr(hf_config, "norm_stats", None)
+        if not norm_stats:
+            raise ValueError(
+                "OpenVLA action decoding needs `norm_stats` on the HF config; "
+                "the checkpoint appears not to be an OpenVLA action policy."
+            )
+        n_bins = int(getattr(hf_config, "n_action_bins", 256))
+        bins = np.linspace(-1.0, 1.0, n_bins)
+        bin_centers = (bins[:-1] + bins[1:]) / 2.0
+
+        vocab_size = cls._resolve_vocab_size(hf_config)
+
+        if default_unnorm_key is None and len(norm_stats) == 1:
+            default_unnorm_key = next(iter(norm_stats))
+        elif default_unnorm_key is not None and default_unnorm_key not in norm_stats:
+            raise ValueError(f"Unknown unnorm_key {default_unnorm_key!r}; available: {sorted(norm_stats)}")
+
+        return cls(
+            norm_stats=norm_stats,
+            bin_centers=bin_centers,
+            vocab_size=vocab_size,
+            default_unnorm_key=default_unnorm_key,
+        )
+
+    @staticmethod
+    def _resolve_vocab_size(hf_config: Any) -> int:
+        """The *unpadded* vocab size, which is where the bin mapping starts.
+
+        The checkpoint pads the embedding table to a multiple of 64, but the
+        action-token mapping was fitted before that padding: for openvla-7b it
+        is 32000, not the config's 32064. Getting this wrong is not a crash —
+        using the padded value shifts every bin index by exactly the padding
+        (+64 here) and saturates the top of the range, so the policy returns a
+        systematically wrong action and reports nothing. That is why both
+        sources are required to agree rather than one being defaulted away.
+        """
+        text_config = getattr(hf_config, "text_config", None)
+        padded = int(getattr(text_config, "vocab_size", 0) or 0)
+        pad = getattr(hf_config, "pad_to_multiple_of", None)
+        if not padded or pad is None:
+            raise ValueError(
+                "Cannot derive OpenVLA's unpadded vocab size: the HF config needs "
+                "both text_config.vocab_size and pad_to_multiple_of."
+            )
+        vocab_size = padded - int(pad)
+        if vocab_size <= 0:
+            raise ValueError(f"Nonsensical OpenVLA vocab size: {padded} - {pad} = {vocab_size}.")
+        return vocab_size
+
+    def _resolve_unnorm_key(self, unnorm_key: str | None) -> str:
+        key = unnorm_key or self.default_unnorm_key
+        if key is None:
+            raise ValueError(
+                "This checkpoint carries action statistics for "
+                f"{len(self.norm_stats)} embodiments, so the request must name one "
+                f"(`unnorm_key`). Available: {sorted(self.norm_stats)}"
+            )
+        if key not in self.norm_stats:
+            raise ValueError(f"Unknown unnorm_key {key!r}; available: {sorted(self.norm_stats)}")
+        return key
+
+    @property
+    def embodiments(self) -> tuple[str, ...]:
+        return tuple(sorted(self.norm_stats))
+
+    def action_dim(self, unnorm_key: str | None = None) -> int:
+        if unnorm_key is None and self.default_unnorm_key is None:
+            dims = {len(v["action"]["q01"]) for v in self.norm_stats.values()}
+            if len(dims) == 1:
+                return dims.pop()
+        return len(self.norm_stats[self._resolve_unnorm_key(unnorm_key)]["action"]["q01"])
+
+    def decode(
+        self,
+        token_ids: Sequence[int],
+        unnorm_key: str | None = None,
+    ) -> np.ndarray:
+        """Seven token ids in, one un-normalised action vector out."""
+        key = self._resolve_unnorm_key(unnorm_key)
+        stats = self.norm_stats[key]["action"]
+        q01 = np.asarray(stats["q01"], dtype=np.float64)
+        q99 = np.asarray(stats["q99"], dtype=np.float64)
+        mask = np.asarray(stats.get("mask", np.ones_like(q01, dtype=bool)), dtype=bool)
+
+        expected = len(q01)
+        ids = np.asarray(token_ids, dtype=np.int64)
+        if ids.shape != (expected,):
+            raise ValueError(
+                f"Expected {expected} action tokens for embodiment {key!r}, got {ids.shape[0] if ids.ndim else 0}."
+            )
+
+        # Bin index counts down from the top of the vocabulary. Clipping matches
+        # the reference: a token outside the action range is folded onto the
+        # nearest bin rather than raising.
+        discretized = np.clip(self.vocab_size - ids - 1, a_min=0, a_max=self.bin_centers.shape[0] - 1)
+        normalized = self.bin_centers[discretized]
+        actions = np.where(mask, 0.5 * (normalized + 1.0) * (q99 - q01) + q01, normalized)
+        return actions.astype(np.float32)
+
+    def policy_server_values(self, image_resolution: Sequence[int] = (224, 224)) -> dict[str, Any]:
+        """Handshake payload for the OpenPI client.
+
+        Everything here is read off the checkpoint rather than configured, so a
+        fine-tuned OpenVLA with a different embodiment set advertises itself
+        correctly without touching the deploy config.
+        """
+        return {
+            "image_resolution": list(image_resolution),
+            "needs_session_id": False,
+            "action_horizon": 1,
+            "action_dim": self.action_dim(),
+            "action_space": "delta_eef_gripper",
+            "unnorm_key": self.default_unnorm_key,
+            "supported_embodiments": list(self.embodiments),
+        }

--- a/vllm_omni/model_executor/models/openvla/pipeline.py
+++ b/vllm_omni/model_executor/models/openvla/pipeline.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""OpenVLA single-stage action-policy topology.
+
+OpenVLA is the first robot policy here whose actions come out of an
+autoregressive decoder rather than a denoiser: the seven action dimensions are
+seven discretised tokens drawn from the tail of the Llama-2 vocabulary, decoded
+one per step. That makes it a plain ``LLM_AR`` stage — the model class is
+upstream vLLM's ``OpenVLAForActionPrediction``, which ``OmniModelRegistry``
+already resolves — and everything robot-specific lives in the token→action
+decode on the serving side.
+
+``engine_output_type`` is deliberately unset. ``final_output_type`` is a free
+string (GR00T already uses ``"actions"``), but ``engine_output_type`` is parsed
+by ``OutputModality.from_string``, which knows only text/image/audio/latent and
+raises on anything else.
+"""
+
+from vllm_omni.config.stage_config import (
+    PipelineConfig,
+    StageExecutionType,
+    StagePipelineConfig,
+)
+
+# One token per action dimension. Every one of the 25 embodiments in
+# openvla-7b's norm_stats has a 7-dimensional action space.
+OPENVLA_ACTION_DIM = 7
+
+OPENVLA_PIPELINE = PipelineConfig(
+    model_type="openvla",
+    default_deploy_config_name="openvla.yaml",
+    # No hf_architectures: vLLM ships an `OpenVLAConfig` for model_type
+    # "openvla", so the primary model_type match already resolves this pipeline
+    # and the architecture fallback would never be reached.
+    model_arch="OpenVLAForActionPrediction",
+    stages=(
+        StagePipelineConfig(
+            stage_id=0,
+            model_stage="ar",
+            execution_type=StageExecutionType.LLM_AR,
+            input_sources=(),
+            final_output=True,
+            final_output_type="actions",
+            owns_tokenizer=True,
+            requires_multimodal_data=True,
+            model_arch="OpenVLAForActionPrediction",
+            robot_adapter=("vllm_omni.model_executor.models.openvla.robot_adapter.OpenVLARobotAdapter"),
+            # The action head is argmax over 256 bins, so sampling is greedy and
+            # the length is fixed. ``ignore_eos`` matters because an action bin
+            # id could otherwise be cut short by an EOS, and ``detokenize`` is
+            # off because the tokens are bin indices, not text.
+            sampling_constraints={
+                "temperature": 0.0,
+                "max_tokens": OPENVLA_ACTION_DIM,
+                "min_tokens": OPENVLA_ACTION_DIM,
+                "ignore_eos": True,
+                "detokenize": False,
+            },
+        ),
+    ),
+)

--- a/vllm_omni/model_executor/models/openvla/robot_adapter.py
+++ b/vllm_omni/model_executor/models/openvla/robot_adapter.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""OpenPI robot-serving adapter for OpenVLA.
+
+Supplies the three model-specific pieces the generic OpenPI serving layer
+cannot know for a token-based action policy: what to advertise in the
+handshake, how an observation becomes a prompt, and how the generated token ids
+become an action array.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from vllm.sampling_params import RequestOutputKind, SamplingParams
+from vllm.transformers_utils.processors.openvla import to_rgb_image
+
+from vllm_omni.entrypoints.openpi.adapters import RobotARRequest
+from vllm_omni.model_executor.models.openvla.action_decode import (
+    OpenVLAActionDecoder,
+    build_prompt_token_ids,
+)
+
+# OpenPI clients are not consistent about where the policy camera lives; this
+# is a preference order, most specific first.
+_IMAGE_KEYS = (
+    "image",
+    "observation/image",
+    "observation.image",
+    "observation/exterior_image_1_left",
+    "base_image",
+    "primary_image",
+)
+_PROMPT_KEYS = ("prompt", "instruction", "task")
+
+
+def _first_present(obs: dict, keys: tuple[str, ...]) -> Any:
+    for key in keys:
+        value = obs.get(key)
+        if value is not None:
+            return value
+    return None
+
+
+def _as_text(value: Any) -> str:
+    return value.decode() if isinstance(value, bytes) else str(value)
+
+
+class OpenVLARobotAdapter:
+    """Bridges one OpenPI observation to one autoregressive OpenVLA request."""
+
+    def __init__(self, decoder: OpenVLAActionDecoder) -> None:
+        self.decoder = decoder
+
+    @classmethod
+    def from_engine_client(cls, engine_client: Any) -> OpenVLARobotAdapter:
+        model_config = getattr(engine_client, "model_config", None)
+        hf_config = getattr(model_config, "hf_config", None)
+        # openvla-7b ships statistics for 25 embodiments, so a deployment has to
+        # pick one; `hf_overrides: {unnorm_key: ...}` in the deploy config is
+        # how, and a request may still override it per observation.
+        unnorm_key = getattr(hf_config, "unnorm_key", None)
+        return cls(OpenVLAActionDecoder.from_hf_config(hf_config, unnorm_key))
+
+    def policy_server_values(self) -> dict[str, Any]:
+        return self.decoder.policy_server_values()
+
+    def build_request(self, obs: dict, *, tokenizer: Any, request_id: str) -> RobotARRequest:
+        raw_image = _first_present(obs, _IMAGE_KEYS)
+        if raw_image is None:
+            raise ValueError(
+                f"OpenVLA observation needs an image under one of {list(_IMAGE_KEYS)}; got keys {sorted(obs)}"
+            )
+        instruction = _as_text(_first_present(obs, _PROMPT_KEYS) or "")
+        if not instruction.strip():
+            raise ValueError(f"OpenVLA observation needs a language instruction under one of {list(_PROMPT_KEYS)}")
+
+        action_dim = self.decoder.action_dim(obs.get("unnorm_key"))
+        return RobotARRequest(
+            prompt={
+                # Token ids rather than text: the checkpoint expects a trailing
+                # empty token that no chat template produces.
+                "prompt_token_ids": build_prompt_token_ids(tokenizer, instruction),
+                # to_rgb_image normalises PIL / ndarray / tensor to a PIL image.
+                # Handing vLLM a bare 3-D torch tensor would be parsed as image
+                # *embeddings* instead of an image.
+                "multi_modal_data": {"image": to_rgb_image(raw_image)},
+            },
+            sampling_params=SamplingParams(
+                temperature=0.0,
+                max_tokens=action_dim,
+                min_tokens=action_dim,
+                ignore_eos=True,
+                detokenize=False,
+                output_kind=RequestOutputKind.FINAL_ONLY,
+            ),
+            request_id=request_id,
+        )
+
+    def decode_actions(self, result: Any, unnorm_key: str | None = None) -> np.ndarray:
+        outputs = getattr(result, "outputs", None) or []
+        if not outputs:
+            raise RuntimeError("OpenVLA request produced no completion output.")
+        completion = outputs[0]
+        token_ids = list(getattr(completion, "token_ids", None) or ())
+        if not token_ids:
+            # Populated on every completion output; `token_ids` is a delta under
+            # a streaming output kind.
+            token_ids = list(getattr(completion, "cumulative_token_ids", None) or ())
+        if not token_ids:
+            raise RuntimeError("OpenVLA request produced no action token ids.")
+        # (action_horizon, action_dim). OpenVLA predicts one step at a time, so
+        # the horizon is 1, but the wire shape matches the other robot policies.
+        return self.decoder.decode(token_ids, unnorm_key).reshape(1, -1)


### PR DESCRIPTION
## Purpose

Serve `openvla/openvla-7b` as a robot policy over `/v1/realtime/robot/openpi`. Follows RFC #6271.

## Propose

No model code is added — vLLM 0.27.0 already ships a registered `OpenVLAForActionPrediction` and
`OmniModelRegistry` merges `_VLLM_MODELS` wholesale, so this adds **zero** `_OMNI_MODELS` entries.
It is the robot-facing half that was missing:

(1) **Action de-tokenisation.** `bin = unpadded_vocab_size - token_id - 1` (31999, from the *unpadded*
32000, not the config's padded 32064), clip into `bin_centers`, un-normalise with the checkpoint's
per-embodiment `q01/q99` except where `mask` is False.

(2) **The trailing empty token.** Training wrapped the turn as `"In: {msg}\nOut: "`; the prompt builder
right-strips it, so `predict_action` re-inserts token id `29871`.

(3) **An AR path through the OpenPI endpoint,** which was diffusion-only.

(4) **A `robot_adapter` dotted path on `StagePipelineConfig`,** like the existing
`custom_process_input_func` / `scheduler_cls`. The generic serving layer holds no model names.

Each of those fails silently — a wrong vocab size shifts every bin by 64, a missing `29871` or an
ignored `mask` still returns a well-formed 7-vector.

## Test Plan

```bash
pytest tests/model_executor/models/test_openvla_action_decode.py \
       tests/model_executor/models/test_openvla_registration.py \
       tests/entrypoints/openai_api/test_openpi_ar_action_policy.py \
       tests/entrypoints/openai_api/test_openpi_serving.py

pytest tests/config tests/engine/test_stage_engine_args.py   # on main and on this branch

pytest -s -v tests/e2e/online_serving/test_openvla_openpi.py --run-level full_model
```

**vLLM Version:** 0.27.0

**vLLM-Omni Commit:** 170d4987

## Test Result

1x A800 80GB, bf16, TP=1, greedy.

| suite | result |
| --- | --- |
| unit tests (31 new + 14 existing) | 45 passed |
| `tests/e2e/online_serving/test_openvla_openpi.py` (new) | 2 passed in 51.29s |
| `pre-commit` | clean (`actionlint` skipped) |

Shared `stage_config.py` change, same machine both sides:

| config suites | result |
| --- | --- |
| unmodified main (`170d4987`) | 10 failed, **553 passed**, 2 skipped |
| this branch | 10 failed, **557 passed**, 2 skipped |

Identical failure sets, both non-empty, pre-existing and network-bound. The +4 are this PR's registry
parametrisations.

### agreement with the reference implementation

| check | result |
| --- | --- |
| over the real WebSocket, `bridge_orig` episodes | **17 of 18** bit-identical to `predict_action` |
| offline, 10 observations | 8/10 identical |
| offline, teacher-forced next-token argmax | 69/70 positions identical |
| the five real photographs | 5/5 identical |

Every disagreement is a one-bin flip where the reference's own top-1/top-2 logprob gap is 0.0625–0.125,
i.e. bf16 rounding resolution.

### latency, distinct image per request

vLLM caches by image hash, so reusing one frame skips the vision encoder and reports 89 ms against a
true 145 ms.

| per action | reference | offline engine | over this endpoint |
| --- | --- | --- | --- |
| one robot | 206.6 ms (4.84 Hz) | 145.4 ms (6.88 Hz) | 183.4 ms (5.45 Hz) |

### concurrency

The reference raises `ValueError("Generation with batch size > 1 is not currently supported!")`, so N
robots there need N model copies.

| N | 1 | 2 | 4 | 8 | 16 |
| --- | --- | --- | --- | --- | --- |
| aggregate | 6.9 actions/s | 11.5 | 17.8 | 26.0 | 32.9 |
| per robot | 6.88 Hz | 5.77 Hz | 4.44 Hz | 3.25 Hz | 2.06 Hz |

cc @tzhouam @gcanlin
