### PR TITLE
[CI] Fix response_format json_schema error expectation

### DIFF
--- a/tests/dfx/reliability/invalid_param_test/test_invalid_omni_chat.py
+++ b/tests/dfx/reliability/invalid_param_test/test_invalid_omni_chat.py
@@ -119,7 +119,7 @@ def _chat_completions_request_without_expectations(omni_server: OmniServer, case
         pytest.param(
             "response_format_json_schema_incomplete",
             400,
-            ("response_format", "value_error", "json_schema"),
+            ("response_format", "BadRequestError", "json_schema"),
             id="invalid_response_format_json_schema",
         ),
         pytest.param("logprobs_wrong_type", 400, "logprobs", id="logprobs_wrong_type", marks=_SKIP_ISSUE_3649),


### PR DESCRIPTION
<!-- markdownlint-disable -->

Fixes #6248

## Purpose

Update the Qwen3-Omni invalid request test for an incomplete `response_format={"type": "json_schema"}` request.

vLLM validates this case by raising `VLLMValidationError` for the missing `json_schema` field, which is surfaced by the API as a `400 BadRequestError` with `param="response_format"`.

The test was still expecting the older Pydantic-style `value_error` token, causing the weekly CI failure. This updates the expected error text to match the current vLLM API error contract.

## Test Plan

- `git diff --check`
- `python3 -m py_compile tests/dfx/reliability/invalid_param_test/test_invalid_omni_chat.py`
- Full test requires the configured 2-GPU H100/MI325 hardware environment and will be validated by CI.

**vLLM Version:** 0.27.0

**vLLM-Omni Commit:** f0c30d70

## Test Result

Local syntax and diff checks pass. Full hardware test not run locally.