### PR TITLE
[Bugfix] Support concurrent batched ti2i for HunyuanImage3

### DIFF
--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -1720,7 +1720,7 @@ class HunyuanImage3Pipeline(
             [state.prompt] if state.prompt is not None else [],
             getattr(sampling, "extra_args", {}) or {},
             request_id=state.request_id,
-            allow_cond_image=False,
+            allow_cond_image=True,
         )
         cot_text = (
             [request_layout_utils.normalize_hunyuan_cot_text(text) for text in cot_text_list]


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

Enable concurrent, batched image-editing (ti2i) requests for HunyuanImage-3.0
in step-execution mode.

`prepare_hunyuan_layout` already passed `allow_cond_image=True`, but the
step-execution `prepare_encode` path still used `allow_cond_image=False`. As a
result, any `/v1/images/edits` request carrying a reference image was rejected
at encode time with:

ValueError: HunyuanImage3 step execution does not support image editing requests yet.

This one-line change flips the flag to `True`, so `batch_cond_image_info` is
propagated into the model inputs)Skip. With `max_num_seqs > 1`, the serving
engine can now group concurrent ti2i requests into a batch instead of
rejecting them.

Compared with fully serial execution, batched processing improves end-to-end
latency by ~13%.

## Test Plan

**vLLM Version:** 0.27.0+cu130

**vLLM-Omni Commit:** e6cb7820 (branch `vllm-omni-ti2i`, base `ffd11c18`)

## Test Result

Environment: NVIDIA A100-SXM4-80GB x4, TP=4, devices `1,3,5,6`,
`max_num_seqs=8`, model `/data/HunyuanImage-3.0`.

- All 4 concurrent requests returned valid 512x512 RGB output images.
- Batched processing of 4 concurrent requests achieves ~13% E2E latency
  improvement over fully serial execution.
- t2i (`/v1/images/generations`) behavior is unaffected.