### PR TITLE
[Fix][SenseNova-U1] Restore model-config compatibility for U1.5

### DIFF
--- a/tests/diffusion/test_diffusion_worker.py
+++ b/tests/diffusion/test_diffusion_worker.py
@@ -81,6 +81,7 @@ def test_diffusion_vllm_model_config_supplies_dtype_for_quant_methods():
     model_config = _make_diffusion_vllm_model_config(od_config)
 
     assert model_config.dtype is torch.bfloat16
+    assert model_config.head_dtype is model_config.dtype
     assert model_config.quantization == "modelopt"
     assert model_config.quantization_config is od_config.quantization_config
     assert model_config.is_quantized()

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -90,6 +90,10 @@ class _DiffusionVllmModelConfig:
     enable_return_routed_experts: bool = False
     is_moe: bool = False
 
+    @property
+    def head_dtype(self) -> torch.dtype:
+        return self.dtype
+
     def is_quantized(self) -> bool:
         return self.quantization is not None
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fixes #5795.

vLLM 0.26 reads `model_config.head_dtype` when initializing
`LogitsProcessor`. Diffusion workers replace the regular vLLM model config
with `_DiffusionVllmModelConfig`, which did not expose this property.

As a result, SenseNova-U1.5 workers failed during model initialization with:

```text
AttributeError: '_DiffusionVllmModelConfig' object has no attribute 'head_dtype'
```

Although the issue reports the failure with four tensor-parallel workers, the
exception occurs independently in each worker while constructing the model.
It is therefore reproducible with a single GPU and does not require tensor
parallelism.

This change adds a `head_dtype` property to the diffusion model config adapter
and returns the model dtype. This matches vLLM's default behavior for
generation models and avoids unnecessary dtype conversion.

A regression assertion is included to ensure that the diffusion model config
continues to expose the expected head dtype.

## Test Plan

1. Run the targeted diffusion worker regression test.
2. Run Ruff lint and format checks on the changed files.
3. Start an OpenAI-compatible server with
   `SenseNova/SenseNova-U1.5-8B-MoT-Preview` on one GPU without tensor
   parallelism.
4. Send a text-to-image request and verify that a valid image is generated.

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** `15d6b85dfefab334acae7060e3ae07460e6d6718`

## Test Result

Targeted regression test:

```bash
python -m pytest -s -v \
  tests/diffusion/test_diffusion_worker.py::test_diffusion_vllm_model_config_supplies_dtype_for_quant_methods
```

Result:

```text
1 passed
```

Static checks:

```bash
ruff check \
  vllm_omni/diffusion/worker/diffusion_worker.py \
  tests/diffusion/test_diffusion_worker.py

ruff format --check \
  vllm_omni/diffusion/worker/diffusion_worker.py \
  tests/diffusion/test_diffusion_worker.py
```

Result:

```text
All checks passed.
2 files already formatted.
```

SenseNova-U1.5 online serving:

```bash
vllm serve /path/to/SenseNova-U1.5-8B-MoT-Preview \
  --omni \
  --host 0.0.0.0 \
  --port 8091
```

Text-to-image smoke test:

```bash
python examples/online_serving/sensenova_u1/openai_chat_client.py \
  --server http://127.0.0.1:8091 \
  --prompt "A realistic orange cat sitting by a window in soft natural light" \
  --modality text2img \
  --height 1024 \
  --width 1024 \
  --num-steps 10 \
  --cfg-scale 4.0 \
  --cfg-norm global \
  --timestep-shift 3.0 \
  --think \
  --output test_output.png
```

Result:

```text
Server initialized successfully and generated a valid 1024x1024 PNG image.
```

The model-serving smoke test was performed on a single GPU. The four-GPU
tensor-parallel configuration from #5795 was not tested locally.

The full diffusion CPU L1 suite did not complete in the local environment
because test collection encountered an unrelated HunyuanImage3 import error:

```text
ImportError: cannot import name 'FusedMoEFactory'
from vllm.model_executor.layers.fused_moe
```

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
