### PR TITLE
[Bugfix] Avoid eager pi0 runtime import in pipeline registry

### DIFF
--- a/tests/config/test_config_import_cycle.py
+++ b/tests/config/test_config_import_cycle.py
@@ -93,3 +93,27 @@ if DiffusionOutput is None or LoRAConfig is None:
     raise SystemExit("expected LoRAConfig and DiffusionOutput")
 """
     )
+
+
+def test_pipeline_registry_does_not_import_pi0_runtime() -> None:
+    """Resolving the pi0 topology must not import its runtime pipeline.
+
+    ``pipeline_pi0`` imports ``diffusion.data``. Importing it while
+    ``diffusion.data`` is only partially initialized closes the Ascend plugin's
+    circular-import loop, so the registry must depend only on a lightweight
+    pipeline-config module.
+    """
+    _assert_isolated_import_succeeds(
+        """
+import sys
+
+from vllm_omni.config.pipeline_registry import resolve_pipeline_config
+
+if "vllm_omni.diffusion.models.pi0.pipeline_pi0" in sys.modules:
+    raise SystemExit("pipeline_registry imported the pi0 runtime pipeline")
+
+pipeline = resolve_pipeline_config("pi0")
+if pipeline is None or pipeline.model_type != "pi0":
+    raise SystemExit("expected the registered pi0 pipeline config")
+"""
+    )

--- a/vllm_omni/config/pipeline_registry.py
+++ b/vllm_omni/config/pipeline_registry.py
@@ -33,7 +33,7 @@ from vllm.logger import init_logger
 from vllm_omni.config.stage_config import (
     PipelineConfig,
 )
-from vllm_omni.diffusion.models.pi0.pipeline_pi0 import PI0_PIPELINE
+from vllm_omni.diffusion.models.pi0_pipeline_config import PI0_PIPELINE
 from vllm_omni.model_executor.models.audex.pipeline import (
     AUDEX_S2S_PIPELINE,
     AUDEX_THINKER_ONLY_PIPELINE,

--- a/vllm_omni/diffusion/models/pi0/pipeline_pi0.py
+++ b/vllm_omni/diffusion/models/pi0/pipeline_pi0.py
@@ -22,15 +22,11 @@ import torch
 from torch import nn
 from vllm.logger import init_logger
 
-from vllm_omni.config.stage_config import (
-    PipelineConfig,
-    StageExecutionType,
-    StagePipelineConfig,
-)
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.models.pi0.config import Pi0Config
 from vllm_omni.diffusion.models.pi0.modeling_pi0 import Pi0ForActionPrediction
 from vllm_omni.diffusion.models.pi0.processor_pi0 import build_model_inputs
+from vllm_omni.diffusion.models.pi0_pipeline_config import PI0_PIPELINE as PI0_PIPELINE
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 
 logger = init_logger(__name__)
@@ -52,32 +48,6 @@ def get_pi0_post_process_func(od_config: OmniDiffusionConfig):
     """
     del od_config
     return _pi0_post_process
-
-
-# Single-stage diffusion topology for online OpenPI serving.
-#
-# π0 is one diffusion stage (robot observation -> action chunk via flow
-# matching). It is registered in ``OMNI_PIPELINES`` (rather than relying on the
-# default single-stage fallback) because π0 is *online-served* via
-# ``vllm serve --deploy-config pi0.yaml``; that path
-# (``OmniStagePipelineFactory._create_from_registry``) requires a registered
-# pipeline so the deploy yaml's ``policy_server_config`` reaches the OpenPI
-# websocket layer. Offline-only models (e.g. ``internvla_a1``) need no topology.
-PI0_PIPELINE = PipelineConfig(
-    model_type="pi0",
-    model_arch="Pi0Pipeline",
-    stages=(
-        StagePipelineConfig(
-            stage_id=0,
-            model_stage="diffusion",
-            execution_type=StageExecutionType.DIFFUSION,
-            input_sources=(),
-            final_output=True,
-            final_output_type="action",
-            model_arch="Pi0Pipeline",
-        ),
-    ),
-)
 
 
 class Pi0Pipeline(nn.Module):

--- a/vllm_omni/diffusion/models/pi0_pipeline_config.py
+++ b/vllm_omni/diffusion/models/pi0_pipeline_config.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Lightweight pipeline topology for π0 (Pi-Zero)."""
+
+from vllm_omni.config.stage_config import (
+    PipelineConfig,
+    StageExecutionType,
+    StagePipelineConfig,
+)
+
+# π0 is one diffusion stage (robot observation -> action chunk via flow
+# matching). It is registered in ``OMNI_PIPELINES`` because π0 is online-served
+# via ``vllm serve --deploy-config pi0.yaml``. Keep this topology outside the
+# ``pi0`` package: importing a package submodule executes ``pi0.__init__``,
+# which imports the runtime pipeline and ``diffusion.data``.
+PI0_PIPELINE = PipelineConfig(
+    model_type="pi0",
+    model_arch="Pi0Pipeline",
+    stages=(
+        StagePipelineConfig(
+            stage_id=0,
+            model_stage="diffusion",
+            execution_type=StageExecutionType.DIFFUSION,
+            input_sources=(),
+            final_output=True,
+            final_output_type="action",
+            model_arch="Pi0Pipeline",
+        ),
+    ),
+)


### PR DESCRIPTION
## Purpose

Importing `vllm_omni` on Ascend can fail with a partially initialized
`vllm_omni.diffusion.data` module. The NPU patch/config import chain reaches
`pipeline_registry`, which eagerly imports the pi0 runtime pipeline; that
runtime imports `DiffusionOutput` from `diffusion.data` and closes the circular
import.

## What changed

- Move the static `PI0_PIPELINE` topology into a lightweight module outside the
  `pi0` package.
- Make `pipeline_registry` import only that topology instead of the runtime
  `pipeline_pi0` module.
- Re-export `PI0_PIPELINE` from `pipeline_pi0` to preserve its existing import
  path.
- Add an isolated-process regression test proving registry resolution keeps the
  pi0 runtime module unloaded and still returns the registered topology.

This is an alternative to #6314 that keeps the registry entry as a plain
`PipelineConfig`, so direct consumers and the callable-resolver contract remain
unchanged.

## Validation

- `pytest -q tests/config/test_config_import_cycle.py tests/config/test_config_factory.py::TestPipelineConfigResolvers::test_all_resolvers_reject_bad_types tests/config/test_pipeline_registry.py` — 10 passed
- `pytest -q tests/diffusion/models/pi0/test_pi0_units.py` — 44 passed, 2 skipped
- `pre-commit run --files tests/config/test_config_import_cycle.py vllm_omni/config/pipeline_registry.py vllm_omni/diffusion/models/pi0_pipeline_config.py vllm_omni/diffusion/models/pi0/pipeline_pi0.py` — passed
