### PR TITLE
[BugFix][TTS] Move user input from INFO to DEBUG in TTS/audio log lines

### DIFF
--- a/tests/entrypoints/openai_api/test_serving_speech.py
+++ b/tests/entrypoints/openai_api/test_serving_speech.py
@@ -4059,9 +4059,7 @@ class TestTTSAsyncOffloading:
 
         assert adapter_model_type != legacy_tts_model_type
         assert any(
-            call.args
-            and call.args[0] == "TTS speech request %s: text=%r, model=%s"
-            and call.args[3] == adapter_model_type
+            call.args and call.args[0] == "TTS speech request %s: model=%s" and call.args[2] == adapter_model_type
             for call in log_info.call_args_list
         )
 

--- a/vllm_omni/entrypoints/openai/serving_audio_generate.py
+++ b/vllm_omni/entrypoints/openai/serving_audio_generate.py
@@ -95,11 +95,14 @@ class OmniOpenAIServingAudioGenerate(OpenAIServing, AudioMixin):
                     "audio_end_in_s": audio_end_in_s,
                 }
 
-            logger.info(
-                "Audio generation request %s: prompt=%r",
-                request_id,
-                request.input[:50] + "..." if len(request.input) > 50 else request.input,
-            )
+            logger.info("Audio generation request %s", request_id)
+            _rl = getattr(self, "request_logger", None)
+            if _rl:
+                base_len = len(f"Audio generation request {request_id}: prompt=")
+                raw_max = getattr(_rl, "max_log_len", None)
+                cap = raw_max if isinstance(raw_max, int) else 200
+                text = request.input[: max(cap - base_len, 0)]
+                logger.debug("Audio generation request %s: prompt=%r", request_id, text)
 
             generator = self.engine_client.generate(
                 prompt=prompt,

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -3528,12 +3528,18 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 return self._create_error_response(str(exc), status_code=400)
 
             logger.info(
-                "Diffusion chat request %s: prompt=%r, ref_images=%d, params=%s",
+                "Diffusion chat request %s: ref_images=%d, params=%s",
                 request_id,
-                prompt[:50] + "..." if len(prompt) > 50 else prompt,
                 len(reference_images),
                 {key: value for key, value in extra_body.items() if value is not None},
             )
+            _rl = getattr(self, "request_logger", None)
+            if _rl:
+                base_len = len(f"Diffusion chat request {request_id}: prompt=")
+                raw_max = getattr(_rl, "max_log_len", None)
+                cap = raw_max if isinstance(raw_max, int) else 200
+                text = prompt[: max(cap - base_len, 0)]
+                logger.debug("Diffusion chat request %s: prompt=%r", request_id, text)
 
             # Decode reference images if provided
             pil_images: list[Image.Image] = []

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -3080,12 +3080,14 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
                 model_type = tts_params.get("task_type", ["unknown"])[0]
             else:
                 model_type = "generic"
-        logger.info(
-            "TTS speech request %s: text=%r, model=%s",
-            request_id,
-            request.input[:50] + "..." if len(request.input) > 50 else request.input,
-            model_type,
-        )
+        logger.info("TTS speech request %s: model=%s", request_id, model_type)
+        _rl = getattr(self, "request_logger", None)
+        if _rl:
+            base_len = len(f"TTS speech request {request_id}: text=")
+            raw_max = getattr(_rl, "max_log_len", None)
+            cap = raw_max if isinstance(raw_max, int) else 200
+            text = request.input[: max(cap - base_len, 0)]
+            logger.debug("TTS speech request %s: text=%r", request_id, text)
 
         # Apply model-specific extra parameters
         if request.extra_params is not None and sampling_params_list:
@@ -3393,11 +3395,17 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
                 prompt["instruct"] = request.instructions
 
             logger.info(
-                "Diffusion TTS speech request %s: text=%r, voice_clone=%s",
+                "Diffusion TTS speech request %s: voice_clone=%s",
                 request_id,
-                request.input[:50] + "..." if len(request.input) > 50 else request.input,
                 "ref_audio" in prompt,
             )
+            _rl = getattr(self, "request_logger", None)
+            if _rl:
+                base_len = len(f"Diffusion TTS speech request {request_id}: text=")
+                raw_max = getattr(_rl, "max_log_len", None)
+                cap = raw_max if isinstance(raw_max, int) else 200
+                text = request.input[: max(cap - base_len, 0)]
+                logger.debug("Diffusion TTS speech request %s: text=%r", request_id, text)
             if request.extra_params is not None and not isinstance(request.extra_params, dict):
                 raise ValueError("extra_params must be a JSON object/dict.")
             extra = dict(request.extra_params or {})


### PR DESCRIPTION
## Summary

- TTS, audio generation, and diffusion chat serving paths log verbatim user input at INFO level, which can expose sensitive information (names, phone numbers, financial details) in centralized log aggregators
- The standard `/v1/chat/completions` and `/v1/completions` endpoints already handle this correctly — `RequestLogger` gates prompt content behind `--enable-log-requests` at DEBUG level and respects `--max-log-len` truncation
- The TTS/audio/diffusion paths bypass `RequestLogger` entirely and unconditionally emit user text at INFO — this PR aligns them with the established pattern

## Changes

For each of the 4 affected log sites across 3 files:

- **INFO** now logs request metadata only (request_id, model type, voice_clone, ref_images, params)
- **User content** moves to `logger.debug`, gated on `self.request_logger` (set when `--enable-log-requests` is passed) and truncated by `--max-log-len`

**Files:**
- `serving_speech.py` — TTS speech request + Diffusion TTS speech request
- `serving_audio_generate.py` — Audio generation request
- `serving_chat.py` — Diffusion chat request
- `test_serving_speech.py` — Updated log format assertion to match new metadata-only INFO line

## Test plan

- [ ] Verify INFO logs no longer contain `text=` or `prompt=` fields
- [ ] Verify DEBUG logs emit user content when `--enable-log-requests` is set
- [ ] Verify `--max-log-len` truncation is respected in DEBUG output
- [ ] Existing test suite passes (`test_serving_speech.py` assertion updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)