### PR TITLE
[Docs] Fix broken star history chart link

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Feel free to ask questions, provide feedbacks and discuss with fellow users of v
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=vllm-project/vllm-omni&type=date&legend=top-left)](https://www.star-history.com/#vllm-project/vllm-omni&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=vllm-project/vllm-omni&type=date&legend=top-left)](https://star-history.dera.page/#vllm-project/vllm-omni&type=date&legend=top-left)
 
 ## License
 


### PR DESCRIPTION
The star history chart in the README is currently broken because GitHub restricted the stargazer API used to generate it. Switch to a working instance that uses an alternative data source requiring no API token, so the chart renders correctly again.

Keeping the rest of the README unchanged.