### PR TITLE
[Bugfix] Don't shutdown Engine on py_generator=True

### DIFF
--- a/tests/entrypoints/test_omni_entrypoints.py
+++ b/tests/entrypoints/test_omni_entrypoints.py
@@ -701,7 +701,7 @@ def test_omni_generate_py_generator_yields_final_outputs_for_each_request(monkey
         f"{engine.submitted[1]['request_id']}-stage0-0",
         f"{engine.submitted[1]['request_id']}-stage2-final",
     ]
-    assert engine.shutdown_called is True
+    assert engine.shutdown_called is not True
 
 
 def test_omni_generate_returns_list_when_not_using_generator(monkeypatch: pytest.MonkeyPatch):
@@ -747,7 +747,7 @@ def test_omni_generate_diffusion_only_yields_single_image_per_request(monkeypatc
         [f"{engine.submitted[0]['request_id']}-image"],
         [f"{engine.submitted[1]['request_id']}-image"],
     ]
-    assert engine.shutdown_called is True
+    assert engine.shutdown_called is not True
 
 
 def test_omni_generate_llm_diffusion_yields_final_text_then_image_per_request(
@@ -780,7 +780,7 @@ def test_omni_generate_llm_diffusion_yields_final_text_then_image_per_request(
         [f"{engine.submitted[1]['request_id']}-image"],
     ]
     assert engine.submitted[0]["sampling_params_list"][0].output_kind == RequestOutputKind.FINAL_ONLY
-    assert engine.shutdown_called is True
+    assert engine.shutdown_called is not True
 
 
 def test_omni_abort_forwards_to_engine(monkeypatch: pytest.MonkeyPatch):
@@ -1254,3 +1254,31 @@ def test_omni_errored_property_dead_stage(monkeypatch: pytest.MonkeyPatch):
         assert app.errored is False
     finally:
         app.shutdown()
+
+
+def test_omni_pygenerator_does_not_kill_engine(monkeypatch: pytest.MonkeyPatch):
+    engine = FakeAsyncOmniEngine(
+        stage_metadata=THREE_STAGE_META,
+        on_add_request=_enqueue_async_three_stage_outputs,
+    )
+
+    _patch_engine(monkeypatch, engine)
+
+    app = Omni("dummy-model")
+    # Evaluating the generator should not shut down the engine
+    list(app.generate(["hello"], py_generator=True))
+    assert not engine.shutdown_called
+
+
+def test_del_shutsdown_engine(monkeypatch: pytest.MonkeyPatch):
+    engine = FakeAsyncOmniEngine(
+        stage_metadata=THREE_STAGE_META,
+        on_add_request=_enqueue_async_three_stage_outputs,
+    )
+
+    _patch_engine(monkeypatch, engine)
+
+    app = Omni("dummy-model")
+    assert not engine.shutdown_called
+    del app
+    assert engine.shutdown_called

--- a/vllm_omni/entrypoints/omni.py
+++ b/vllm_omni/entrypoints/omni.py
@@ -99,11 +99,11 @@ class Omni(OmniBase):
         sampling_params_list: Sequence[OmniSamplingParams],
         use_tqdm: bool | Callable[..., tqdm] = True,
     ) -> Generator[OmniRequestOutput, None, None]:
-        gen = self._run_generation(prompts, sampling_params_list, use_tqdm)
-        try:
-            yield from gen
-        finally:
-            self.close()
+        yield from self._run_generation(
+            prompts,
+            sampling_params_list,
+            use_tqdm,
+        )
 
     def _run_generation(
         self,


### PR DESCRIPTION
## Purpose
Currently, running generator with `py_generator=True` shuts down the engine when we evaluate the generator. I.e.,

```python
import os

os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"

from vllm_omni.entrypoints.omni import Omni

if __name__ == "__main__":
    omni = Omni(model="Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice", trust_remote_code=True, log_stats=False)
    prompt = {
        "prompt_token_ids": [0] * 50,
        "additional_information": {
            "task_type": ["CustomVoice"],
            "text": ["Hello."],
            "language": ["English"],
            "speaker": ["Vivian"],
            "instruct": [""],
            "max_new_tokens": [256],
        },
    }

    list(omni.generate([prompt], py_generator=True))
    list(omni.generate([prompt], py_generator=True))
```

the second generate call will blow up because we unconditionally close + shut down the engine when `py_generator=True`.

```
Traceback (most recent call last):
  File "/home/alex-jw-brooks/scratch/repro_omni_close_on_generator.py", line 27, in <module>
    list(omni.generate([prompt], py_generator=True))
  File "/home/alex-jw-brooks/vllm-omni/vllm_omni/entrypoints/omni.py", line 104, in _run_generation_with_generator
    yield from gen
  File "/home/alex-jw-brooks/vllm-omni/vllm_omni/entrypoints/omni.py", line 153, in _run_generation
    self.engine.add_request(
  File "/home/alex-jw-brooks/vllm-omni/vllm_omni/engine/async_omni_engine.py", line 1335, in add_request
    self.request_queue.sync_q.put(msg)
  File "/home/alex-jw-brooks/venvs/omni/lib64/python3.12/site-packages/janus/__init__.py", line 372, in put
    raise SyncQueueShutDown
janus.ShutDown
```

We also hold a weakref to the engine and shut it down through that, so added a couple of tests to ensure calling generate with a generator doesn't shut down the engine