### PR TITLE
[Bugfix] Make diffusion video client timeout configurable

### DIFF
--- a/benchmarks/diffusion/README.md
+++ b/benchmarks/diffusion/README.md
@@ -139,6 +139,9 @@ Traffic / concurrency flags:
 
 - `--request-rate`: Target request rate (requests/second). If set to `inf`, the script sends all requests immediately.
 - `--max-concurrency`: Max number of in-flight requests (default: `1`). This can hard-cap the achieved QPS: if it is too small, requests will queue behind the semaphore, and both achieved throughput and observed SLO attainment can be skewed.
+- `--client-timeout`: Maximum seconds to wait for an asynchronous `/v1/videos`
+  job (default: `600`). Increase this for long-running video shapes so client-side
+  timeouts are not reported as generation failures.
 
 ### Batched warmup note
 

--- a/benchmarks/diffusion/backends.py
+++ b/benchmarks/diffusion/backends.py
@@ -12,6 +12,7 @@ import aiohttp
 from tqdm import tqdm
 
 DEFAULT_EDITS_BOT_TASK = "think"
+DEFAULT_VIDEO_CLIENT_TIMEOUT_S = 600.0
 
 
 def _is_minimax_h3_mixed_reference(model: str) -> bool:
@@ -38,6 +39,7 @@ class RequestFuncInput:
     fps: int | None = None
     timestamp: float | None = None
     slo_ms: float | None = None
+    client_timeout: float = DEFAULT_VIDEO_CLIENT_TIMEOUT_S
     extra_body: dict[str, Any] = field(default_factory=dict)
     image_paths: list[str] | None = None
     video_paths: list[str] | None = None
@@ -406,8 +408,7 @@ async def async_request_v1_videos(
 
         # invoke a poll request (GET /v1/videos/{video_id})
         poll_interval = 2.0  # Unit(s)
-        timeout_seconds = 600.0
-        deadline = time.perf_counter() + timeout_seconds
+        deadline = time.perf_counter() + input.client_timeout
         job_url = f"{input.api_url}/{job_id}"
 
         while job_status not in {"completed", "failed"}:
@@ -423,7 +424,7 @@ async def async_request_v1_videos(
                 job_status = poll_json.get("status")
 
                 if time.perf_counter() >= deadline:
-                    output.error = f"Timed out waiting for video job {job_id} to complete."
+                    output.error = f"Timed out waiting {input.client_timeout:g}s for video job {job_id} to complete."
                     output.success = False
                     return output
 

--- a/benchmarks/diffusion/diffusion_benchmark_serving.py
+++ b/benchmarks/diffusion/diffusion_benchmark_serving.py
@@ -87,6 +87,7 @@ import base64
 import glob
 import json
 import logging
+import math
 import os
 import random
 import tempfile
@@ -101,6 +102,7 @@ import aiohttp
 import numpy as np
 import requests
 from backends import (
+    DEFAULT_VIDEO_CLIENT_TIMEOUT_S,
     RequestFuncInput,
     RequestFuncOutput,
     backends_function_mapping,
@@ -113,6 +115,13 @@ logger = logging.getLogger(__name__)
 
 _STAGE_METRICS_ENDPOINTS = {"/v1/chat/completions"}
 _RETURN_STAGE_METRICS_FIELD = "return_stage_metrics"
+
+
+def positive_seconds(value: str) -> float:
+    seconds = float(value)
+    if not math.isfinite(seconds) or seconds <= 0:
+        raise argparse.ArgumentTypeError("must be a finite number greater than zero")
+    return seconds
 
 
 class BaseDataset(ABC):
@@ -1311,6 +1320,8 @@ async def benchmark(args):
 
     print("Loading requests...")
     requests_list = dataset.get_requests()
+    for request in requests_list:
+        request.client_timeout = args.client_timeout
     print(f"Prepared {len(requests_list)} requests from {args.dataset} dataset.")
 
     if args.return_stage_metrics and args.endpoint in _STAGE_METRICS_ENDPOINTS:
@@ -1493,6 +1504,12 @@ if __name__ == "__main__":
         "to execute at a time. This means that when used in combination, the "
         "actual request rate may be lower than specified with --request-rate, "
         "if the server is not processing requests fast enough to keep up.",
+    )
+    parser.add_argument(
+        "--client-timeout",
+        type=positive_seconds,
+        default=DEFAULT_VIDEO_CLIENT_TIMEOUT_S,
+        help="Seconds to wait for an asynchronous /v1/videos job (default: 600).",
     )
     parser.add_argument(
         "--request-rate",

--- a/tests/benchmarks/test_diffusion_backends_metrics.py
+++ b/tests/benchmarks/test_diffusion_backends_metrics.py
@@ -1,8 +1,13 @@
+import subprocess
+import sys
+from pathlib import Path
+
 import pytest
 
 from benchmarks.diffusion.backends import (
     RequestFuncInput,
     async_request_chat_completions,
+    async_request_v1_videos,
     endpoint_filename_token,
     normalize_endpoint,
 )
@@ -32,6 +37,23 @@ class _MockSession:
 
     def post(self, *args, **kwargs):
         return _MockResponse(self._payload)
+
+
+class _MockVideoSession:
+    def __init__(self):
+        self.get_calls = 0
+        self.delete_calls = 0
+
+    def post(self, *args, **kwargs):
+        return _MockResponse({"id": "job-1", "status": "queued"})
+
+    def get(self, *args, **kwargs):
+        self.get_calls += 1
+        return _MockResponse({"status": "in_progress"})
+
+    def delete(self, *args, **kwargs):
+        self.delete_calls += 1
+        return _MockResponse({})
 
 
 @pytest.mark.core_model
@@ -136,3 +158,71 @@ async def test_chat_completions_metrics_message_level_takes_precedence():
     assert output.success is True
     assert output.stage_durations == {"message_stage": 0.7}
     assert output.peak_memory_mb == 1234.0
+
+
+@pytest.mark.core_model
+@pytest.mark.benchmark
+@pytest.mark.cpu
+@pytest.mark.asyncio
+async def test_video_job_uses_request_client_timeout(mocker):
+    session = _MockVideoSession()
+    clock = iter([0.0, 0.0, 1.0, 601.0])
+    mocker.patch(
+        "benchmarks.diffusion.backends.time.perf_counter",
+        side_effect=lambda: next(clock),
+    )
+    mocker.patch(
+        "benchmarks.diffusion.backends.asyncio.sleep",
+        new=mocker.AsyncMock(),
+    )
+
+    output = await async_request_v1_videos(
+        RequestFuncInput(
+            prompt="generate a video",
+            api_url="http://test.local/v1/videos",
+            model="test-model",
+            client_timeout=0.5,
+        ),
+        session=session,
+    )
+
+    assert output.success is False
+    assert output.error == "Timed out waiting 0.5s for video job job-1 to complete."
+    assert session.get_calls == 1
+    assert session.delete_calls == 1
+
+
+@pytest.mark.core_model
+@pytest.mark.benchmark
+@pytest.mark.cpu
+def test_video_job_client_timeout_default_is_backward_compatible():
+    request = RequestFuncInput(
+        prompt="generate a video",
+        api_url="http://test.local/v1/videos",
+        model="test-model",
+    )
+
+    assert request.client_timeout == 600.0
+
+
+@pytest.mark.core_model
+@pytest.mark.benchmark
+@pytest.mark.cpu
+def test_diffusion_benchmark_cli_exposes_positive_client_timeout():
+    script = Path(__file__).resolve().parents[2] / "benchmarks" / "diffusion" / "diffusion_benchmark_serving.py"
+
+    help_result = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert help_result.returncode == 0, help_result.stderr
+    assert "--client-timeout CLIENT_TIMEOUT" in help_result.stdout
+
+    invalid_result = subprocess.run(
+        [sys.executable, str(script), "--client-timeout", "0"],
+        capture_output=True,
+        text=True,
+    )
+    assert invalid_result.returncode == 2
+    assert "must be a finite number greater than zero" in invalid_result.stderr


### PR DESCRIPTION
## Purpose

### What broke

The diffusion serving benchmark always stopped polling asynchronous `/v1/videos` jobs after 600 seconds. Valid long-running video requests were therefore recorded as failures, which could understate completed-request throughput.

### Reproduction

Run the regression cases against the base implementation:

```bash
pytest -q tests/benchmarks/test_diffusion_backends_metrics.py -k client_timeout
```

With the proposed tests applied to base `b4b907e7`, all three cases fail: the request input rejects `client_timeout`, the default field is absent, and the CLI does not expose `--client-timeout`.

### Root cause

`async_request_v1_videos()` constructed its polling deadline from a local `600.0` literal, so the benchmark CLI had no way to configure the wait.

### Fix

- Add a validated positive `--client-timeout` option.
- Preserve 600 seconds as the backward-compatible default.
- Propagate the value to both measured and warmup requests and use it for video-job polling.
- Keep timeout cleanup intact and include the configured duration in the error.
- Document the option in the diffusion benchmark guide.

Fixes #5923

## Test Plan

```bash
pytest -q tests/benchmarks/test_diffusion_backends_metrics.py
pytest -q tests/benchmarks -m "core_model and cpu" -k "not test_bench_serve_cli_mocks_http_request"
ruff check benchmarks/diffusion/backends.py benchmarks/diffusion/diffusion_benchmark_serving.py tests/benchmarks/test_diffusion_backends_metrics.py
ruff format --check benchmarks/diffusion/backends.py benchmarks/diffusion/diffusion_benchmark_serving.py tests/benchmarks/test_diffusion_backends_metrics.py
python tools/pre_commit/check_test_marks.py tests/benchmarks/test_diffusion_backends_metrics.py
```

**vLLM Version:** 0.27.0

**vLLM-Omni Commit:** `4b8487f972a77511e1018885bb9079fb76c18172`

Environment: Python 3.12.3, PyTorch 2.12.1+cu126, Linux 5.4.250. Tests are CPU-only; no GPU path is changed.

## Test Result

- Base `b4b907e7` with the proposed regression tests: `3 failed, 5 deselected` (expected RED).
- Head focused file: `8 passed`.
- Related CPU benchmark suite: `129 passed, 1 deselected`. The deselected existing CLI test requires an uncached `Qwen/Qwen2.5-Omni-7B` tokenizer, while this server cannot reach Hugging Face.
- Ruff check: passed.
- Ruff format check: passed.
- Test marker check: passed.

No throughput or latency improvement is claimed; this change makes the client deadline configurable so long-running benchmark results can complete accurately.