### PR TITLE
[CI/Build] Make benchmark CLI test hermetic

### DIFF
--- a/tests/benchmarks/test_serve_cli.py
+++ b/tests/benchmarks/test_serve_cli.py
@@ -239,6 +239,19 @@ def test_bench_serve_cli_mocks_http_request(tmp_path: Path):
                 async def close(self):
                     return None
 
+            class MockTokenizer:
+                vocab_size = 256
+                all_special_ids = []
+
+                def num_special_tokens_to_add(self, *args, **kwargs):
+                    return 0
+
+                def decode(self, token_ids, *args, **kwargs):
+                    return " ".join(str(token_id) for token_id in token_ids)
+
+                def encode(self, text, *args, **kwargs):
+                    return [int(token_id) for token_id in text.split()]
+
             # Patch globally so modules loaded after this also see the mock
             import aiohttp
             aiohttp.ClientSession = MockClientSession
@@ -248,6 +261,11 @@ def test_bench_serve_cli_mocks_http_request(tmp_path: Path):
             import vllm_omni.benchmarks.patch.patch as patch_mod
             patch_mod.aiohttp.ClientSession = MockClientSession
             patch_mod.aiohttp.TCPConnector = lambda *args, **kwargs: object()
+
+            # This test exercises CLI and HTTP routing, not model tokenization.
+            # Keep its subprocess independent of hub access and model caches.
+            import vllm.benchmarks.serve as benchmark_serve
+            benchmark_serve.get_tokenizer = lambda *args, **kwargs: MockTokenizer()
 
             calls_file = os.environ.get("VLLM_OMNI_TEST_POST_CALLS_FILE")
 
@@ -265,6 +283,9 @@ def test_bench_serve_cli_mocks_http_request(tmp_path: Path):
     env = os.environ.copy()
     env["PYTHONPATH"] = str(tmp_path) + os.pathsep + env.get("PYTHONPATH", "")
     env["VLLM_OMNI_TEST_POST_CALLS_FILE"] = str(calls_path)
+    env["HF_HOME"] = str(tmp_path / "hf-cache")
+    env["HF_HUB_OFFLINE"] = "1"
+    env["TRANSFORMERS_OFFLINE"] = "1"
 
     cmd = [
         "vllm",


### PR DESCRIPTION
Fixes #6336.

## Purpose

### What broke

`tests/benchmarks/test_serve_cli.py::test_bench_serve_cli_mocks_http_request` mocks benchmark HTTP traffic but still initialized the tokenizer for `Qwen/Qwen2.5-Omni-7B`. A clean CPU environment therefore needed Hugging Face access or a pre-populated cache even though the test is marked `core_model`, `cpu`, and `benchmark`.

Reproduce on `main` with an empty cache:

```bash
export HF_HOME="$(mktemp -d)"
export HF_HUB_OFFLINE=1
export TRANSFORMERS_OFFLINE=1
pytest -q tests/benchmarks/test_serve_cli.py::test_bench_serve_cli_mocks_http_request
```

The CLI subprocess failed in `vllm.benchmarks.serve.main_async()` while `get_tokenizer()` attempted to load the remote model tokenizer.

### Root cause

The existing subprocess `sitecustomize.py` replaced `aiohttp`, but not the tokenizer lookup used before the random dataset is generated. `--skip-tokenizer-init` is not suitable because vLLM's random dataset requires a tokenizer.

### Fix

- Supply a deterministic, test-local tokenizer at the subprocess boundary.
- Force an empty `HF_HOME` and offline hub/transformers modes so future regressions fail deterministically.
- Preserve the real `vllm bench serve --omni` process, random-dataset generation, HTTP routing, result-file generation, and request-count checks.

This is test-only and does not change production benchmark behavior.

## Test Plan

The regression is L1 (`core_model and cpu`) and requires no GPU, model weights, Hugging Face token, or network access.

```bash
# Focused regression
pytest -q tests/benchmarks/test_serve_cli.py::test_bench_serve_cli_mocks_http_request

# Whole test module
pytest -q tests/benchmarks/test_serve_cli.py

# CI-like benchmark L1 suite
pytest -q tests/benchmarks -m "core_model and cpu"

# Static checks
ruff check tests/benchmarks/test_serve_cli.py
ruff format --check tests/benchmarks/test_serve_cli.py
python tools/pre_commit/check_test_marks.py tests/benchmarks/test_serve_cli.py
```

**vLLM Version:** 0.27.0

**vLLM-Omni Commit:** based on `b4b907e7b60086c6428145f8dbab687314971dea`

## Test Result

- TDD RED: focused test failed on the base implementation with an empty offline cache at `get_tokenizer("Qwen/Qwen2.5-Omni-7B")`.
- TDD GREEN: focused regression: `1 passed`.
- Whole module: `18 passed`.
- Benchmark L1 CPU suite: `127 passed`.
- Ruff check, Ruff format check, and test-marker validation passed.
- Full `precheck-pr` author review: 0 blockers, 0 warnings.
