### PR TITLE
[Core][Diffusion] Propagate RPC policy and support packed LoRA targets

### DIFF
--- a/tests/diffusion/lora/test_lora_manager.py
+++ b/tests/diffusion/lora/test_lora_manager.py
@@ -185,6 +185,51 @@ def test_lora_manager_replaces_packed_layer_when_targeting_sublayers(monkeypatch
     assert replace_calls == ["to_qkv"]
 
 
+def test_lora_manager_uses_declared_mapping_and_component_relative_target(monkeypatch):
+    import vllm_omni.diffusion.lora.manager as manager_mod
+
+    monkeypatch.setattr(manager_mod, "BaseLayerWithLoRA", _DummyBaseLayerWithLoRA)
+    monkeypatch.setattr(
+        manager_mod,
+        "from_layer_diffusion",
+        lambda *, layer, **_kwargs: _DummyBaseLayerWithLoRA(layer),
+    )
+    replace_calls: list[str] = []
+    monkeypatch.setattr(
+        manager_mod,
+        "replace_submodule",
+        lambda root, name, module: fake_replace_submodule(root, name, module, replace_calls),
+    )
+
+    pipeline = torch.nn.Module()
+    pipeline.packed_modules_mapping = {"qkv_proj": ["to_q", "to_k", "to_v"]}
+    pipeline.transformer = torch.nn.Module()
+    pipeline.transformer.blocks = torch.nn.ModuleList([torch.nn.Module()])
+    pipeline.transformer.blocks[0].attn = torch.nn.Module()
+    pipeline.transformer.blocks[0].attn.qkv_proj = _FakeLinearBase()
+
+    manager = DiffusionLoRAManager(
+        pipeline=pipeline,
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+        max_cached_adapters=1,
+    )
+    monkeypatch.setattr(manager, "_get_packed_modules_list", lambda _module: ["q", "k", "v"])
+
+    peft_helper = type(
+        "_PH",
+        (),
+        {
+            "r": 1,
+            "target_modules": r"^blocks\.(?:.*\.)?attn\.to_q$",
+        },
+    )()
+    manager._replace_layers_with_lora(peft_helper)
+
+    assert manager._packed_modules_mapping["qkv_proj"] == ["to_q", "to_k", "to_v"]
+    assert replace_calls == ["blocks.0.attn.qkv_proj"]
+
+
 def test_lora_manager_activates_fused_lora_on_packed_layer():
     manager = DiffusionLoRAManager(
         pipeline=torch.nn.Module(),

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
@@ -15,6 +15,15 @@ import torch.nn as nn
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.diffusion]
 
 
+def test_h3_declares_logical_sublayers_for_packed_lora():
+    from vllm_omni.diffusion.models.minimax_h3.minimax_h3_transformer import MiniMaxH3DiTModel
+
+    assert MiniMaxH3DiTModel.packed_modules_mapping == {
+        "qkv_proj": ["to_q", "to_k", "to_v"],
+        "fc1": ["gate_proj", "up_proj"],
+    }
+
+
 def test_h3_prepares_resolved_cache_state_immediately_before_denoise():
     from vllm_omni.diffusion.models.minimax_h3 import MiniMaxH3Pipeline
     from vllm_omni.diffusion.request import OmniDiffusionRequest

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
@@ -1697,8 +1697,10 @@ def test_ref2va_probe_counts_frames_only_when_metadata_is_missing(monkeypatch):
     monkeypatch.setattr(
         reference_video_module.subprocess,
         "run",
-        lambda command, **kwargs: calls.append((command, kwargs))
-        or SimpleNamespace(stdout=json.dumps(first_probe if len(calls) == 1 else second_probe)),
+        lambda command, **kwargs: (
+            calls.append((command, kwargs))
+            or SimpleNamespace(stdout=json.dumps(first_probe if len(calls) == 1 else second_probe))
+        ),
     )
 
     metadata = reference_video_module._probe_video("prepared.mp4")

--- a/tests/diffusion/test_diffusion_engine_rpc_routing.py
+++ b/tests/diffusion/test_diffusion_engine_rpc_routing.py
@@ -80,6 +80,7 @@ class _ConcurrencyTrackingExecutor:
                     "args": args,
                     "kwargs": kwargs,
                     "unique_reply_rank": unique_reply_rank,
+                    "exec_all_ranks": exec_all_ranks,
                     "thread": threading.get_ident(),
                 }
             )
@@ -225,6 +226,27 @@ async def test_executor_only_called_from_busy_loop_thread():
         f"executor.collective_rpc must run only on the busy-loop thread "
         f"(expected {{{busy_tid}}}, got {engine.executor.thread_ids})"
     )
+
+
+@pytest.mark.asyncio
+async def test_collective_rpc_forwards_worker_rank_policy():
+    """Queued RPCs preserve all-rank execution and unique-reply routing."""
+    loop = asyncio.get_running_loop()
+    engine = _make_engine_with_loop(loop)
+    try:
+        result = await engine.async_collective_rpc(
+            "mutate_workers",
+            args=("payload",),
+            unique_reply_rank=2,
+            exec_all_ranks=True,
+        )
+        assert result.error == "rpc_result_for_payload"
+    finally:
+        _stop_engine(engine)
+
+    call = next(call for call in engine.executor.calls if call["method"] == "mutate_workers")
+    assert call["unique_reply_rank"] == 2
+    assert call["exec_all_ranks"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/diffusion/test_prompt_update.py
+++ b/tests/diffusion/test_prompt_update.py
@@ -562,8 +562,8 @@ class TestPromptUpdateIntegration:
                 )
             ]
 
-        def collective_rpc(self, method, timeout, args, kwargs, unique_reply_rank):
-            del timeout, kwargs, unique_reply_rank
+        def collective_rpc(self, method, timeout, args, kwargs, unique_reply_rank, exec_all_ranks=False):
+            del timeout, kwargs, unique_reply_rank, exec_all_ranks
             if method == "submit_interaction":
                 request_id, interaction = args
                 self._runner.submit_interaction(request_id, interaction)

--- a/tests/engine/test_async_omni_engine_outputs.py
+++ b/tests/engine/test_async_omni_engine_outputs.py
@@ -462,6 +462,13 @@ def test_collective_and_duplex_results_share_router_without_swapping(mocker: Moc
     engine._correlated_rpc_client.close()
 
 
+@pytest.mark.parametrize("rank", [True, -1, 1.5])
+def test_collective_rpc_rejects_invalid_unique_reply_rank(rank):
+    engine = object.__new__(AsyncOmniEngine)
+    with pytest.raises(ValueError, match="unique_reply_rank"):
+        engine.collective_rpc("health", unique_reply_rank=rank)
+
+
 def test_collective_rpc_preserves_request_queue_backpressure(mocker: MockerFixture):
     class SignallingQueue(queue.Queue):
         def __init__(self) -> None:

--- a/tests/engine/test_orchestrator.py
+++ b/tests/engine/test_orchestrator.py
@@ -173,9 +173,7 @@ class FakeStageClient:
         exec_all_ranks: bool = False,
     ) -> Any:
         normalized_kwargs = dict(kwargs or {})
-        self.collective_rpc_calls.append(
-            (method, timeout, args, normalized_kwargs, unique_reply_rank, exec_all_ranks)
-        )
+        self.collective_rpc_calls.append((method, timeout, args, normalized_kwargs, unique_reply_rank, exec_all_ranks))
         return {
             "supported": False,
             "todo": True,
@@ -231,9 +229,7 @@ class FakeCollectiveRpcStageClient(FakeStageClient):
         exec_all_ranks: bool = False,
     ) -> Any:
         normalized_kwargs = dict(kwargs or {})
-        self.collective_rpc_calls.append(
-            (method, timeout, args, normalized_kwargs, unique_reply_rank, exec_all_ranks)
-        )
+        self.collective_rpc_calls.append((method, timeout, args, normalized_kwargs, unique_reply_rank, exec_all_ranks))
         return self.rpc_result
 
 

--- a/tests/engine/test_orchestrator.py
+++ b/tests/engine/test_orchestrator.py
@@ -130,9 +130,7 @@ class FakeStageClient:
         self._kv_sender_info = dict(kv_sender_info) if kv_sender_info is not None else None
         self.add_request_calls: list[tuple] = []
         self.abort_calls: list[list[str]] = []
-        self.collective_rpc_calls: list[
-            tuple[str, float | None, tuple[Any, ...], dict[str, Any], int | None, bool]
-        ] = []
+        self.collective_rpc_calls: list[tuple[str, float | None, tuple[Any, ...], dict[str, Any], int | None]] = []
         self.shutdown_calls = 0
         self._engine_core_outputs = queue.Queue()
         self._diffusion_outputs = queue.Queue()
@@ -170,10 +168,9 @@ class FakeStageClient:
         args: tuple[Any, ...] = (),
         kwargs: dict[str, Any] | None = None,
         unique_reply_rank: int | None = None,
-        exec_all_ranks: bool = False,
     ) -> Any:
         normalized_kwargs = dict(kwargs or {})
-        self.collective_rpc_calls.append((method, timeout, args, normalized_kwargs, unique_reply_rank, exec_all_ranks))
+        self.collective_rpc_calls.append((method, timeout, args, normalized_kwargs, unique_reply_rank))
         return {
             "supported": False,
             "todo": True,
@@ -226,10 +223,9 @@ class FakeCollectiveRpcStageClient(FakeStageClient):
         args: tuple[Any, ...] = (),
         kwargs: dict[str, Any] | None = None,
         unique_reply_rank: int | None = None,
-        exec_all_ranks: bool = False,
     ) -> Any:
         normalized_kwargs = dict(kwargs or {})
-        self.collective_rpc_calls.append((method, timeout, args, normalized_kwargs, unique_reply_rank, exec_all_ranks))
+        self.collective_rpc_calls.append((method, timeout, args, normalized_kwargs, unique_reply_rank))
         return self.rpc_result
 
 
@@ -2097,7 +2093,6 @@ async def test_collective_rpc_ignores_invalid_stage_ids(orchestrator_factory, ca
                     kwargs={},
                     stage_ids=[99, 1],
                     unique_reply_rank=2,
-                    exec_all_ranks=True,
                 )
             )
 
@@ -2112,7 +2107,7 @@ async def test_collective_rpc_ignores_invalid_stage_ids(orchestrator_factory, ca
         assert msg.results == [{"stage": 1}]
         assert not stage0.collective_rpc_calls
         assert len(stage1.collective_rpc_calls) == 1
-        assert stage1.collective_rpc_calls[0][-2:] == (2, True)
+        assert stage1.collective_rpc_calls[0][-1] == 2
         assert "collective_rpc: ignoring invalid stage_id 99" in caplog.text
     finally:
         await _shutdown_orchestrator(orchestrator_fixture)

--- a/tests/engine/test_orchestrator.py
+++ b/tests/engine/test_orchestrator.py
@@ -130,7 +130,9 @@ class FakeStageClient:
         self._kv_sender_info = dict(kv_sender_info) if kv_sender_info is not None else None
         self.add_request_calls: list[tuple] = []
         self.abort_calls: list[list[str]] = []
-        self.collective_rpc_calls: list[tuple[str, float | None, tuple[Any, ...], dict[str, Any]]] = []
+        self.collective_rpc_calls: list[
+            tuple[str, float | None, tuple[Any, ...], dict[str, Any], int | None, bool]
+        ] = []
         self.shutdown_calls = 0
         self._engine_core_outputs = queue.Queue()
         self._diffusion_outputs = queue.Queue()
@@ -167,9 +169,13 @@ class FakeStageClient:
         timeout: float | None = None,
         args: tuple[Any, ...] = (),
         kwargs: dict[str, Any] | None = None,
+        unique_reply_rank: int | None = None,
+        exec_all_ranks: bool = False,
     ) -> Any:
         normalized_kwargs = dict(kwargs or {})
-        self.collective_rpc_calls.append((method, timeout, args, normalized_kwargs))
+        self.collective_rpc_calls.append(
+            (method, timeout, args, normalized_kwargs, unique_reply_rank, exec_all_ranks)
+        )
         return {
             "supported": False,
             "todo": True,
@@ -221,9 +227,13 @@ class FakeCollectiveRpcStageClient(FakeStageClient):
         timeout: float | None = None,
         args: tuple[Any, ...] = (),
         kwargs: dict[str, Any] | None = None,
+        unique_reply_rank: int | None = None,
+        exec_all_ranks: bool = False,
     ) -> Any:
         normalized_kwargs = dict(kwargs or {})
-        self.collective_rpc_calls.append((method, timeout, args, normalized_kwargs))
+        self.collective_rpc_calls.append(
+            (method, timeout, args, normalized_kwargs, unique_reply_rank, exec_all_ranks)
+        )
         return self.rpc_result
 
 
@@ -2090,6 +2100,8 @@ async def test_collective_rpc_ignores_invalid_stage_ids(orchestrator_factory, ca
                     args=(),
                     kwargs={},
                     stage_ids=[99, 1],
+                    unique_reply_rank=2,
+                    exec_all_ranks=True,
                 )
             )
 
@@ -2104,6 +2116,7 @@ async def test_collective_rpc_ignores_invalid_stage_ids(orchestrator_factory, ca
         assert msg.results == [{"stage": 1}]
         assert not stage0.collective_rpc_calls
         assert len(stage1.collective_rpc_calls) == 1
+        assert stage1.collective_rpc_calls[0][-2:] == (2, True)
         assert "collective_rpc: ignoring invalid stage_id 99" in caplog.text
     finally:
         await _shutdown_orchestrator(orchestrator_fixture)

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -153,6 +153,7 @@ class _RpcTask:
     kwargs: dict | None
     deadline: float | None
     unique_reply_rank: int | None
+    exec_all_ranks: bool = False
     future: concurrent.futures.Future = field(default_factory=concurrent.futures.Future)
 
 
@@ -613,6 +614,7 @@ class DiffusionEngine:
                     args=task.args,
                     kwargs=task.kwargs,
                     unique_reply_rank=task.unique_reply_rank,
+                    exec_all_ranks=task.exec_all_ranks,
                 )
             except BaseException as exc:  # noqa: BLE001 - propagate to caller
                 # The future may have been cancelled (e.g. by a sync timeout
@@ -1060,6 +1062,7 @@ class DiffusionEngine:
         args: tuple,
         kwargs: dict | None,
         unique_reply_rank: int | None,
+        exec_all_ranks: bool = False,
     ) -> _RpcTask:
         assert isinstance(method, str), "Only string method names are supported for now"
         deadline = None if timeout is None else time.monotonic() + timeout
@@ -1069,6 +1072,7 @@ class DiffusionEngine:
             kwargs=kwargs,
             deadline=deadline,
             unique_reply_rank=unique_reply_rank,
+            exec_all_ranks=bool(exec_all_ranks),
         )
         with self._cv:
             self._rpc_queue.put(task)
@@ -1082,6 +1086,7 @@ class DiffusionEngine:
         args: tuple = (),
         kwargs: dict | None = None,
         unique_reply_rank: int | None = None,
+        exec_all_ranks: bool = False,
     ) -> Any:
         """Call a method on worker processes and get results immediately.
 
@@ -1095,6 +1100,7 @@ class DiffusionEngine:
             args: Positional arguments for the method
             kwargs: Keyword arguments for the method
             unique_reply_rank: If set, only get reply from this rank
+            exec_all_ranks: Execute on every rank while keeping a unique reply
 
         Returns:
             Single result if unique_reply_rank is provided, otherwise list of results
@@ -1119,9 +1125,10 @@ class DiffusionEngine:
                         args=args,
                         kwargs=kwargs,
                         unique_reply_rank=unique_reply_rank,
+                        exec_all_ranks=exec_all_ranks,
                     )
 
-        task = self._submit_rpc(method, timeout, args, kwargs, unique_reply_rank)
+        task = self._submit_rpc(method, timeout, args, kwargs, unique_reply_rank, exec_all_ranks)
         try:
             return task.future.result(timeout=timeout)
         except concurrent.futures.TimeoutError as exc:
@@ -1135,6 +1142,7 @@ class DiffusionEngine:
         args: tuple = (),
         kwargs: dict | None = None,
         unique_reply_rank: int | None = None,
+        exec_all_ranks: bool = False,
     ) -> Any:
         """Async variant of :meth:`collective_rpc` for event-loop callers.
 
@@ -1142,7 +1150,7 @@ class DiffusionEngine:
         blocking the loop.
         """
         await self._check_and_start_background_loop()
-        task = self._submit_rpc(method, timeout, args, kwargs, unique_reply_rank)
+        task = self._submit_rpc(method, timeout, args, kwargs, unique_reply_rank, exec_all_ranks)
         aio_fut = asyncio.wrap_future(task.future)
         try:
             if timeout is None:

--- a/vllm_omni/diffusion/inline_stage_diffusion_client.py
+++ b/vllm_omni/diffusion/inline_stage_diffusion_client.py
@@ -211,6 +211,8 @@ class InlineStageDiffusionClient(StageClientBase):
         timeout: float | None = None,
         args: tuple[Any, ...] = (),
         kwargs: dict[str, Any] | None = None,
+        unique_reply_rank: int | None = None,
+        exec_all_ranks: bool = False,
     ) -> Any:
         loop = asyncio.get_running_loop()
 
@@ -226,7 +228,7 @@ class InlineStageDiffusionClient(StageClientBase):
                 profile_prefix,
             )
 
-        kwargs = kwargs or {}
+        kwargs = dict(kwargs or {})
 
         # LoRA methods
         if method == "add_lora":
@@ -238,7 +240,8 @@ class InlineStageDiffusionClient(StageClientBase):
                 timeout,
                 (),
                 {"lora_request": lora_request},
-                None,
+                unique_reply_rank,
+                exec_all_ranks,
             )
             return all(results) if isinstance(results, list) else results
 
@@ -250,7 +253,8 @@ class InlineStageDiffusionClient(StageClientBase):
                 timeout,
                 args,
                 kwargs,
-                None,
+                unique_reply_rank,
+                exec_all_ranks,
             )
             return all(results) if isinstance(results, list) else results
 
@@ -262,7 +266,8 @@ class InlineStageDiffusionClient(StageClientBase):
                 timeout,
                 (),
                 {},
-                None,
+                unique_reply_rank,
+                exec_all_ranks,
             )
             if not isinstance(results, list):
                 return results or []
@@ -280,7 +285,8 @@ class InlineStageDiffusionClient(StageClientBase):
                 timeout,
                 (),
                 {"adapter_id": lora_id},
-                None,
+                unique_reply_rank,
+                exec_all_ranks,
             )
             return all(results) if isinstance(results, list) else results
 
@@ -291,7 +297,8 @@ class InlineStageDiffusionClient(StageClientBase):
             timeout,
             args,
             kwargs,
-            None,
+            unique_reply_rank,
+            exec_all_ranks,
         )
 
     def check_health(self) -> None:

--- a/vllm_omni/diffusion/inline_stage_diffusion_client.py
+++ b/vllm_omni/diffusion/inline_stage_diffusion_client.py
@@ -212,7 +212,6 @@ class InlineStageDiffusionClient(StageClientBase):
         args: tuple[Any, ...] = (),
         kwargs: dict[str, Any] | None = None,
         unique_reply_rank: int | None = None,
-        exec_all_ranks: bool = False,
     ) -> Any:
         loop = asyncio.get_running_loop()
 
@@ -229,6 +228,7 @@ class InlineStageDiffusionClient(StageClientBase):
             )
 
         kwargs = dict(kwargs or {})
+        exec_all_ranks = unique_reply_rank is not None
 
         # LoRA methods
         if method == "add_lora":

--- a/vllm_omni/diffusion/lora/manager.py
+++ b/vllm_omni/diffusion/lora/manager.py
@@ -177,6 +177,13 @@ class DiffusionLoRAManager:
 
         mapping: dict[str, list[str]] = {}
         for module in self.pipeline.modules():
+            declared = getattr(module, "packed_modules_mapping", None)
+            if isinstance(declared, dict):
+                for packed_name, sub_names in declared.items():
+                    if isinstance(packed_name, str) and isinstance(sub_names, (list, tuple)):
+                        values = [str(name) for name in sub_names]
+                        if values:
+                            mapping.setdefault(packed_name, values)
             derived = _derive_from_stacked_params_mapping(getattr(module, "stacked_params_mapping", None))
             for packed_name, sub_names in derived.items():
                 if not isinstance(packed_name, str) or not packed_name:
@@ -412,14 +419,24 @@ class DiffusionLoRAManager:
 
                 packed_modules_list = self._get_packed_modules_list(module)
                 if target_modules_pattern is not None or target_modules_list is not None:
-                    should_replace = _matches_target(full_module_name)
+                    # PEFT targets are relative to the denoiser component
+                    # (e.g. ``^transformer_blocks...``), while manager keys
+                    # include the pipeline component prefix
+                    # (``transformer.transformer_blocks...``). Accept either
+                    # spelling so an anchored target does not silently wrap
+                    # zero layers.
+                    should_replace = _matches_target(module_name) or _matches_target(full_module_name)
                     if not should_replace and len(packed_modules_list) > 1:
                         prefix, _, packed_suffix = full_module_name.rpartition(".")
+                        relative_prefix, _, _ = module_name.rpartition(".")
                         sub_suffixes = self._get_packed_sublayer_suffixes(packed_suffix, len(packed_modules_list))
                         if sub_suffixes is not None:
                             for sub_suffix in sub_suffixes:
                                 sub_full_name = f"{prefix}.{sub_suffix}" if prefix else sub_suffix
-                                if _matches_target(sub_full_name):
+                                sub_relative_name = (
+                                    f"{relative_prefix}.{sub_suffix}" if relative_prefix else sub_suffix
+                                )
+                                if _matches_target(sub_relative_name) or _matches_target(sub_full_name):
                                     should_replace = True
                                     break
 

--- a/vllm_omni/diffusion/lora/manager.py
+++ b/vllm_omni/diffusion/lora/manager.py
@@ -433,9 +433,7 @@ class DiffusionLoRAManager:
                         if sub_suffixes is not None:
                             for sub_suffix in sub_suffixes:
                                 sub_full_name = f"{prefix}.{sub_suffix}" if prefix else sub_suffix
-                                sub_relative_name = (
-                                    f"{relative_prefix}.{sub_suffix}" if relative_prefix else sub_suffix
-                                )
+                                sub_relative_name = f"{relative_prefix}.{sub_suffix}" if relative_prefix else sub_suffix
                                 if _matches_target(sub_relative_name) or _matches_target(sub_full_name):
                                     should_replace = True
                                     break

--- a/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
+++ b/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
@@ -938,11 +938,13 @@ class MiniMaxH3DiTModel(nn.Module):
         },
         "sp_gather": SequenceParallelOutput(gather_dim=0, expected_dims=2),
     }
-    # The checkpoint already stores qkv and the MLP gate/up as single tensors
-    # (see the reordering in load_weights), so there are no unfused names for
-    # quantization or LoRA to map onto. Address the fused layers directly, e.g.
-    # ignored_layers=["blocks.0.attn.qkv_proj"].
-    packed_modules_mapping = {}
+    # Online trainer LoRA uses the unfused Diffusers names. The serving port
+    # keeps qkv and SwiGLU gate/up fused, so expose their logical sublayers to
+    # vLLM's packed-LoRA loader.
+    packed_modules_mapping = {
+        "qkv_proj": ["to_q", "to_k", "to_v"],
+        "fc1": ["gate_proj", "up_proj"],
+    }
 
     def _validate_tp_config(self, *, arch: MiniMaxH3DiTArchConfig, tp_size: int) -> None:
         if tp_size < 1:

--- a/vllm_omni/diffusion/stage_diffusion_client.py
+++ b/vllm_omni/diffusion/stage_diffusion_client.py
@@ -415,7 +415,6 @@ class StageDiffusionClient(StageClientBase):
         args: tuple[Any, ...] = (),
         kwargs: dict[str, Any] | None = None,
         unique_reply_rank: int | None = None,
-        exec_all_ranks: bool = False,
     ) -> Any:
         """Forward control RPCs to the diffusion subprocess."""
         if self._engine_dead:
@@ -448,7 +447,6 @@ class StageDiffusionClient(StageClientBase):
                     "args": list(args),
                     "kwargs": kwargs,
                     "unique_reply_rank": unique_reply_rank,
-                    "exec_all_ranks": bool(exec_all_ranks),
                 }
             )
         )

--- a/vllm_omni/diffusion/stage_diffusion_client.py
+++ b/vllm_omni/diffusion/stage_diffusion_client.py
@@ -414,6 +414,8 @@ class StageDiffusionClient(StageClientBase):
         timeout: float | None = None,
         args: tuple[Any, ...] = (),
         kwargs: dict[str, Any] | None = None,
+        unique_reply_rank: int | None = None,
+        exec_all_ranks: bool = False,
     ) -> Any:
         """Forward control RPCs to the diffusion subprocess."""
         if self._engine_dead:
@@ -445,6 +447,8 @@ class StageDiffusionClient(StageClientBase):
                     "timeout": timeout,
                     "args": list(args),
                     "kwargs": kwargs,
+                    "unique_reply_rank": unique_reply_rank,
+                    "exec_all_ranks": bool(exec_all_ranks),
                 }
             )
         )

--- a/vllm_omni/diffusion/stage_diffusion_proc.py
+++ b/vllm_omni/diffusion/stage_diffusion_proc.py
@@ -209,6 +209,8 @@ class StageDiffusionProc:
         timeout: float | None,
         args: tuple,
         kwargs: dict,
+        unique_reply_rank: int | None,
+        exec_all_ranks: bool,
     ) -> Any:
         """Dispatch collective RPC calls to DiffusionEngine.
 
@@ -242,7 +244,8 @@ class StageDiffusionProc:
                 timeout,
                 (),
                 {"lora_request": lora_request},
-                None,
+                unique_reply_rank,
+                exec_all_ranks,
             )
             return all(results) if isinstance(results, list) else results
 
@@ -254,7 +257,8 @@ class StageDiffusionProc:
                 timeout,
                 args,
                 kwargs or {},
-                None,
+                unique_reply_rank,
+                exec_all_ranks,
             )
             return all(results) if isinstance(results, list) else results
 
@@ -266,7 +270,8 @@ class StageDiffusionProc:
                 timeout,
                 (),
                 {},
-                None,
+                unique_reply_rank,
+                exec_all_ranks,
             )
             if not isinstance(results, list):
                 return results or []
@@ -284,7 +289,8 @@ class StageDiffusionProc:
                 timeout,
                 (),
                 {"adapter_id": lora_id},
-                None,
+                unique_reply_rank,
+                exec_all_ranks,
             )
             return all(results) if isinstance(results, list) else results
 
@@ -297,7 +303,8 @@ class StageDiffusionProc:
             timeout,
             args,
             kwargs or {},
-            None,
+            unique_reply_rank,
+            exec_all_ranks,
         )
 
     # ------------------------------------------------------------------
@@ -439,6 +446,8 @@ class StageDiffusionProc:
                             msg.get("timeout"),
                             tuple(msg.get("args", ())),
                             msg.get("kwargs", {}),
+                            msg.get("unique_reply_rank"),
+                            bool(msg.get("exec_all_ranks", False)),
                         )
                         await response_socket.send(
                             encoder.encode(

--- a/vllm_omni/diffusion/stage_diffusion_proc.py
+++ b/vllm_omni/diffusion/stage_diffusion_proc.py
@@ -210,7 +210,6 @@ class StageDiffusionProc:
         args: tuple,
         kwargs: dict,
         unique_reply_rank: int | None,
-        exec_all_ranks: bool,
     ) -> Any:
         """Dispatch collective RPC calls to DiffusionEngine.
 
@@ -218,6 +217,7 @@ class StageDiffusionProc:
         the contract that ``AsyncOmni`` provides.
         """
         loop = asyncio.get_running_loop()
+        exec_all_ranks = unique_reply_rank is not None
 
         if method == "profile":
             is_start = args[0] if args else True
@@ -447,7 +447,6 @@ class StageDiffusionProc:
                             tuple(msg.get("args", ())),
                             msg.get("kwargs", {}),
                             msg.get("unique_reply_rank"),
-                            bool(msg.get("exec_all_ranks", False)),
                         )
                         await response_socket.send(
                             encoder.encode(

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1765,13 +1765,16 @@ class AsyncOmniEngine:
         kwargs: dict[str, Any] | None = None,
         stage_ids: list[int] | None = None,
         unique_reply_rank: int | None = None,
-        exec_all_ranks: bool = False,
     ) -> list[Any]:
         """Send a control RPC to the Orchestrator and wait for aggregated results.
 
         This uses a dedicated RPC output queue so control-plane messages do not
         race with the normal request output polling loop.
         """
+        if unique_reply_rank is not None and (
+            isinstance(unique_reply_rank, bool) or not isinstance(unique_reply_rank, int) or unique_reply_rank < 0
+        ):
+            raise ValueError(f"unique_reply_rank must be a non-negative integer or None, got {unique_reply_rank!r}")
         rpc_id = uuid.uuid4().hex
         msg = CollectiveRPCRequestMessage(
             rpc_id=rpc_id,
@@ -1781,7 +1784,6 @@ class AsyncOmniEngine:
             kwargs=kwargs or {},
             stage_ids=stage_ids,
             unique_reply_rank=unique_reply_rank,
-            exec_all_ranks=bool(exec_all_ranks),
         )
 
         transport = self._correlated_rpc_client
@@ -1806,7 +1808,6 @@ class AsyncOmniEngine:
         kwargs: dict[str, Any] | None = None,
         stage_ids: list[int] | None = None,
         unique_reply_rank: int | None = None,
-        exec_all_ranks: bool = False,
     ) -> list[Any]:
         """Async wrapper around collective_rpc()."""
         loop = asyncio.get_running_loop()
@@ -1819,7 +1820,6 @@ class AsyncOmniEngine:
                 kwargs=kwargs,
                 stage_ids=stage_ids,
                 unique_reply_rank=unique_reply_rank,
-                exec_all_ranks=exec_all_ranks,
             ),
         )
 

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1764,6 +1764,8 @@ class AsyncOmniEngine:
         args: tuple[Any, ...] = (),
         kwargs: dict[str, Any] | None = None,
         stage_ids: list[int] | None = None,
+        unique_reply_rank: int | None = None,
+        exec_all_ranks: bool = False,
     ) -> list[Any]:
         """Send a control RPC to the Orchestrator and wait for aggregated results.
 
@@ -1778,6 +1780,8 @@ class AsyncOmniEngine:
             args=tuple(args),
             kwargs=kwargs or {},
             stage_ids=stage_ids,
+            unique_reply_rank=unique_reply_rank,
+            exec_all_ranks=bool(exec_all_ranks),
         )
 
         transport = self._correlated_rpc_client
@@ -1801,6 +1805,8 @@ class AsyncOmniEngine:
         args: tuple[Any, ...] = (),
         kwargs: dict[str, Any] | None = None,
         stage_ids: list[int] | None = None,
+        unique_reply_rank: int | None = None,
+        exec_all_ranks: bool = False,
     ) -> list[Any]:
         """Async wrapper around collective_rpc()."""
         loop = asyncio.get_running_loop()
@@ -1812,6 +1818,8 @@ class AsyncOmniEngine:
                 args=args,
                 kwargs=kwargs,
                 stage_ids=stage_ids,
+                unique_reply_rank=unique_reply_rank,
+                exec_all_ranks=exec_all_ranks,
             ),
         )
 

--- a/vllm_omni/engine/messages.py
+++ b/vllm_omni/engine/messages.py
@@ -59,7 +59,6 @@ class CollectiveRPCRequestMessage(EngineQueueMessage, kw_only=True):
     kwargs: dict[str, object]
     stage_ids: list[int] | None
     unique_reply_rank: int | None = None
-    exec_all_ranks: bool = False
 
 
 class ShutdownRequestMessage(EngineQueueMessage, kw_only=True):

--- a/vllm_omni/engine/messages.py
+++ b/vllm_omni/engine/messages.py
@@ -58,6 +58,8 @@ class CollectiveRPCRequestMessage(EngineQueueMessage, kw_only=True):
     args: tuple[object, ...]
     kwargs: dict[str, object]
     stage_ids: list[int] | None
+    unique_reply_rank: int | None = None
+    exec_all_ranks: bool = False
 
 
 class ShutdownRequestMessage(EngineQueueMessage, kw_only=True):

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -877,7 +877,6 @@ class Orchestrator:
         kwargs = dict(msg.kwargs or {})
         requested_stage_ids = msg.stage_ids
         unique_reply_rank = msg.unique_reply_rank
-        exec_all_ranks = bool(msg.exec_all_ranks)
 
         target_pools: list[StagePool] = []
         if requested_stage_ids is None:
@@ -900,7 +899,6 @@ class Orchestrator:
                     args=args,
                     kwargs=kwargs,
                     unique_reply_rank=unique_reply_rank,
-                    exec_all_ranks=exec_all_ranks,
                 )
                 stage_ids.append(pool.stage_id)
                 results.append(stage_result)

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -876,6 +876,8 @@ class Orchestrator:
         args = tuple(msg.args)
         kwargs = dict(msg.kwargs or {})
         requested_stage_ids = msg.stage_ids
+        unique_reply_rank = msg.unique_reply_rank
+        exec_all_ranks = bool(msg.exec_all_ranks)
 
         target_pools: list[StagePool] = []
         if requested_stage_ids is None:
@@ -897,6 +899,8 @@ class Orchestrator:
                     timeout=timeout,
                     args=args,
                     kwargs=kwargs,
+                    unique_reply_rank=unique_reply_rank,
+                    exec_all_ranks=exec_all_ranks,
                 )
                 stage_ids.append(pool.stage_id)
                 results.append(stage_result)

--- a/vllm_omni/engine/stage_client.py
+++ b/vllm_omni/engine/stage_client.py
@@ -67,6 +67,8 @@ class StagePoolClient(StageClient, Protocol):
         timeout: float | None = None,
         args: tuple[Any, ...] = (),
         kwargs: dict[str, Any] | None = None,
+        unique_reply_rank: int | None = None,
+        exec_all_ranks: bool = False,
     ) -> Any: ...
 
 

--- a/vllm_omni/engine/stage_client.py
+++ b/vllm_omni/engine/stage_client.py
@@ -68,7 +68,6 @@ class StagePoolClient(StageClient, Protocol):
         args: tuple[Any, ...] = (),
         kwargs: dict[str, Any] | None = None,
         unique_reply_rank: int | None = None,
-        exec_all_ranks: bool = False,
     ) -> Any: ...
 
 

--- a/vllm_omni/engine/stage_engine_core_client.py
+++ b/vllm_omni/engine/stage_engine_core_client.py
@@ -418,6 +418,8 @@ class StageEngineCoreClientBase(StageClientBase):
         timeout: float | None = None,
         args: tuple[Any, ...] = (),
         kwargs: dict[str, Any] | None = None,
+        unique_reply_rank: int | None = None,
+        exec_all_ranks: bool = False,
     ) -> Any:
         """Forward control RPCs to the underlying AsyncMPClient stage engine.
 
@@ -425,6 +427,10 @@ class StageEngineCoreClientBase(StageClientBase):
         control operations should be executed here and then fanned in-core
         across the workers managed by this EngineCore client.
         """
+        if unique_reply_rank is not None or exec_all_ranks:
+            raise NotImplementedError(
+                "worker-rank collective RPC routing is currently supported only by diffusion stages"
+            )
         return await super().collective_rpc_async(
             method=method,
             timeout=timeout,

--- a/vllm_omni/engine/stage_engine_core_client.py
+++ b/vllm_omni/engine/stage_engine_core_client.py
@@ -419,7 +419,6 @@ class StageEngineCoreClientBase(StageClientBase):
         args: tuple[Any, ...] = (),
         kwargs: dict[str, Any] | None = None,
         unique_reply_rank: int | None = None,
-        exec_all_ranks: bool = False,
     ) -> Any:
         """Forward control RPCs to the underlying AsyncMPClient stage engine.
 
@@ -427,7 +426,7 @@ class StageEngineCoreClientBase(StageClientBase):
         control operations should be executed here and then fanned in-core
         across the workers managed by this EngineCore client.
         """
-        if unique_reply_rank is not None or exec_all_ranks:
+        if unique_reply_rank is not None:
             raise NotImplementedError(
                 "worker-rank collective RPC routing is currently supported only by diffusion stages"
             )

--- a/vllm_omni/engine/stage_pool.py
+++ b/vllm_omni/engine/stage_pool.py
@@ -1213,7 +1213,6 @@ class StagePool:
         args: tuple[Any, ...] = (),
         kwargs: dict[str, Any] | None = None,
         unique_reply_rank: int | None = None,
-        exec_all_ranks: bool = False,
     ) -> dict[str, Any] | Any:
         """Dispatch a stage-scoped control-plane RPC to one physical route."""
         kwargs = dict(kwargs or {})
@@ -1230,7 +1229,6 @@ class StagePool:
                 args=args,
                 kwargs=kwargs,
                 unique_reply_rank=unique_reply_rank,
-                exec_all_ranks=exec_all_ranks,
             )
         except Exception as exc:
             logger.exception(

--- a/vllm_omni/engine/stage_pool.py
+++ b/vllm_omni/engine/stage_pool.py
@@ -1212,6 +1212,8 @@ class StagePool:
         timeout: float | None = None,
         args: tuple[Any, ...] = (),
         kwargs: dict[str, Any] | None = None,
+        unique_reply_rank: int | None = None,
+        exec_all_ranks: bool = False,
     ) -> dict[str, Any] | Any:
         """Dispatch a stage-scoped control-plane RPC to one physical route."""
         kwargs = dict(kwargs or {})
@@ -1227,6 +1229,8 @@ class StagePool:
                 timeout=timeout,
                 args=args,
                 kwargs=kwargs,
+                unique_reply_rank=unique_reply_rank,
+                exec_all_ranks=exec_all_ranks,
             )
         except Exception as exc:
             logger.exception(

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -980,7 +980,6 @@ class AsyncOmni(EngineClient, OmniBase):
         kwargs: dict[str, Any] | None = None,
         stage_ids: list[int] | None = None,
         unique_reply_rank: int | None = None,
-        exec_all_ranks: bool = False,
     ) -> list[Any]:
         """Execute a best-effort control RPC on selected stages.
 
@@ -995,7 +994,6 @@ class AsyncOmni(EngineClient, OmniBase):
             kwargs=kwargs,
             stage_ids=stage_ids,
             unique_reply_rank=unique_reply_rank,
-            exec_all_ranks=exec_all_ranks,
         )
 
         unsupported_stage_ids: list[int] = []

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -979,6 +979,8 @@ class AsyncOmni(EngineClient, OmniBase):
         args: tuple[Any, ...] = (),
         kwargs: dict[str, Any] | None = None,
         stage_ids: list[int] | None = None,
+        unique_reply_rank: int | None = None,
+        exec_all_ranks: bool = False,
     ) -> list[Any]:
         """Execute a best-effort control RPC on selected stages.
 
@@ -992,6 +994,8 @@ class AsyncOmni(EngineClient, OmniBase):
             args=args,
             kwargs=kwargs,
             stage_ids=stage_ids,
+            unique_reply_rank=unique_reply_rank,
+            exec_all_ranks=exec_all_ranks,
         )
 
         unsupported_stage_ids: list[int] = []

--- a/vllm_omni/entrypoints/omni.py
+++ b/vllm_omni/entrypoints/omni.py
@@ -4,7 +4,7 @@ import copy
 import time
 import uuid
 from collections.abc import Callable, Generator, Iterable, Sequence
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 from tqdm.auto import tqdm
 from vllm.logger import init_logger
@@ -24,6 +24,26 @@ logger = init_logger(__name__)
 
 class Omni(OmniBase):
     """Synchronous entrypoint for offline generation."""
+
+    def collective_rpc(
+        self,
+        method: str,
+        timeout: float | None = None,
+        args: tuple[Any, ...] = (),
+        kwargs: dict[str, Any] | None = None,
+        stage_ids: list[int] | None = None,
+        *,
+        unique_reply_rank: int | None = None,
+    ) -> list[Any]:
+        """Execute a stage-scoped control RPC through the public sync entrypoint."""
+        return self.engine.collective_rpc(
+            method=method,
+            timeout=timeout,
+            args=args,
+            kwargs=kwargs,
+            stage_ids=stage_ids,
+            unique_reply_rank=unique_reply_rank,
+        )
 
     def _maybe_force_final_only_for_llm_stages(
         self,


### PR DESCRIPTION
## Summary
- expose `unique_reply_rank` as a first-class control-plane option from synchronous/asynchronous Omni entrypoints through stage routing to diffusion clients
- keep all-rank execution internal to diffusion: selecting one reply executes every worker without the status gather, while AR stages reject unsupported rank routing
- honor component-relative PEFT targets and model-declared packed-module mappings in the diffusion LoRA manager
- declare MiniMax-H3's fused QKV and SwiGLU logical sublayers for standard LoRA checkpoints

## Motivation
The diffusion executor already supports executing a mutation on every worker while collecting one selected reply, but this routing policy was dropped by the engine and Omni layers. Packed diffusion models also need a canonical way to map standard PEFT sublayer names onto fused serving projections.

## Test plan
- [x] rebase onto current `main` (`8dc3d504` at the latest refresh)
- [x] `ruff check`, `ruff format --check`, `git diff --check`, and `python -m compileall`
- [x] add CPU coverage for queued RPC policy, orchestrator routing, invalid reply ranks, component-relative packed targets, and MiniMax-H3 mappings
- [ ] run focused CPU tests in the vLLM 0.27 / Torch 2.13 cu130 environment
- [ ] run the 4-GPU MiniMax-H3 grouped-LoRA gate after the frozen-stack experiment completes