### PR TITLE
[CI/Build] Match perf warmups to benchmark concurrency

### DIFF
--- a/tests/dfx/conftest.py
+++ b/tests/dfx/conftest.py
@@ -653,6 +653,7 @@ def run_benchmark(
     random_input_len: Any | None = None,
     random_output_len: Any | None = None,
     resource_label: str | None = None,
+    num_warmups: int = 2,
 ) -> dict[str, Any]:
     """Run one ``vllm bench serve --omni`` iteration and return parsed metrics.
 
@@ -677,7 +678,7 @@ def run_benchmark(
         + args
         + [
             "--num-warmups",
-            "2",
+            str(num_warmups),
             "--save-result",
             "--result-dir",
             os.environ.get("BENCHMARK_DIR", "tests"),

--- a/tests/dfx/perf/scripts/run_benchmark.py
+++ b/tests/dfx/perf/scripts/run_benchmark.py
@@ -279,5 +279,6 @@ def test_performance_benchmark(omni_server, benchmark_params):
             random_input_len=params.get("random_input_len"),
             random_output_len=params.get("random_output_len"),
             resource_label=resource_label,
+            num_warmups=max(2, int(concurrency)),
         )
         assert_result(result, params, num_prompt)


### PR DESCRIPTION
## Purpose

Fix the inflated MiniCPM-o 4.5 H100 `mean_audio_ttfp_ms` measurement at `c=4, n=64`.

The failing run reported `2065.3798 ms` versus the `1615.6591 ms` baseline. Its first four measured Stage 2 TTFPs were approximately `17062 / 17061 / 17061 / 16985 ms`, while subsequent requests stabilized near `1.1 s`.

Incident: [Buildkite nightly #13783](https://buildkite.com/vllm/vllm-omni/builds/13783#01a01754-d4d2-4bbe-9389-0e58969b35d1).

### Root cause

The benchmark helper always passed `--num-warmups 2`, including concurrency sweeps larger than 2. [vLLM v0.27.0 runs warmup requests concurrently under `max_concurrency`](https://github.com/vllm-project/vllm/blob/v0.27.0/vllm/benchmarks/serve.py#L876-L895), so two requests do not warm a complete `c=4` batch before measurement.

### Change

For concurrency sweeps, pass `num_warmups=max(2, max_concurrency)`. The helper keeps its existing default of 2, so request-rate sweeps and `c=1` behavior are unchanged.

This PR only changes the shared benchmark command construction. It does not modify baselines, model code, tests, or Buildkite configuration.

## Test Plan

- [x] `python3 -m py_compile tests/dfx/conftest.py tests/dfx/perf/scripts/run_benchmark.py`
- [x] Ruff check and format check on both changed files
- [ ] H100 MiniCPM-o 4.5 benchmark; expected `c=4` log: `Warming up with 4 requests...`

**vLLM Version:** v0.27.0

**vLLM-Omni Commit:** based on `8dc3d504d8bae73bd6a627b4b759a4dbe6cd35fb`

## Test Result

Syntax and static checks passed locally. Full H100 validation is pending CI/nightly.
