### PR TITLE
[MUSA] Fix SwiGLU to use fused op

### DIFF
--- a/vllm_omni/diffusion/layers/activation.py
+++ b/vllm_omni/diffusion/layers/activation.py
@@ -22,7 +22,7 @@ class SiluAndMul(CustomOp):
         return F.silu(x[..., :d]) * x[..., d:]
 
     def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
-        if x.device.type != "cuda":
+        if x.device.type == "cpu":
             return self.forward_native(x)
         d = x.shape[-1] // 2
         output_shape = x.shape[:-1] + (d,)


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
Allow SwiGLU on MUSA to use the fused op.

## Test Plan

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

### Fair A/B Comparison: Baseline → Final

Version | TP8 Median | Throughput Improvement
-- | -- | --
Baseline | 105.351 s | —
#6281 only | 101.492 s | +3.802%
#6283 + #6364 | 104.801 s | +0.525%
Final combined | 101.811 s | +3.477%

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
