### PR TITLE
[Bugfix] Honor request seed in Voxtral TTS

### DIFF
--- a/tests/entrypoints/openai_api/test_serving_speech.py
+++ b/tests/entrypoints/openai_api/test_serving_speech.py
@@ -3995,6 +3995,25 @@ class TestTTSAsyncOffloading:
         asyncio.run(voxtral_server._prepare_speech_generation(request))
         voxtral_server._build_voxtral_prompt_async.assert_awaited_once()
 
+    def test_prepare_speech_generation_voxtral_seed_sets_tts_local_seed(self, voxtral_server, mocker: MockerFixture):
+        voxtral_server.engine_client.default_sampling_params_list = [
+            SimpleNamespace(max_tokens=2048, seed=None, extra_args=None)
+        ]
+        voxtral_server._build_voxtral_prompt_async = mocker.AsyncMock(
+            return_value={
+                "prompt_token_ids": [1, 2, 3],
+                "additional_information": {"voice": ["test"]},
+            }
+        )
+        request = OpenAICreateSpeechRequest(input="hello", voice="test", seed=42)
+
+        asyncio.run(voxtral_server._prepare_speech_generation(request))
+
+        stage0_params = voxtral_server.engine_client.generate.call_args.kwargs["sampling_params_list"][0]
+        assert stage0_params.seed == 42
+        assert stage0_params.extra_args["tts_local_seed"] == 42
+        assert voxtral_server.engine_client.default_sampling_params_list[0].extra_args is None
+
     def test_prepare_speech_generation_awaits_qwen3_tts_async(self, qwen3_tts_server, mocker: MockerFixture):
         """Qwen3 TTS path should call _estimate_prompt_len_async."""
         qwen3_tts_server._adapter.validate = mocker.MagicMock(return_value=None)

--- a/tests/entrypoints/openai_api/test_serving_speech.py
+++ b/tests/entrypoints/openai_api/test_serving_speech.py
@@ -3996,9 +3996,9 @@ class TestTTSAsyncOffloading:
         voxtral_server._build_voxtral_prompt_async.assert_awaited_once()
 
     def test_prepare_speech_generation_voxtral_seed_sets_tts_local_seed(self, voxtral_server, mocker: MockerFixture):
-        voxtral_server.engine_client.default_sampling_params_list = [
-            SimpleNamespace(max_tokens=2048, seed=None, extra_args=None)
-        ]
+        default_params = voxtral_server.engine_client.default_sampling_params_list[0]
+        default_params.seed = None
+        default_params.extra_args = None
         voxtral_server._build_voxtral_prompt_async = mocker.AsyncMock(
             return_value={
                 "prompt_token_ids": [1, 2, 3],

--- a/tests/model_executor/models/voxtral_tts/test_cuda_graph_acoustic_transformer.py
+++ b/tests/model_executor/models/voxtral_tts/test_cuda_graph_acoustic_transformer.py
@@ -112,6 +112,7 @@ class SyntheticModel(nn.Module):
         self,
         hidden_states: torch.Tensor,
         cfg_alpha: torch.Tensor,
+        noise: torch.Tensor | None = None,
     ):
         """Eager fallback path: replicate what the wrapper does."""
         _, AudioSpecialTokens = _voxtral_cudagraph_deps()
@@ -130,7 +131,11 @@ class SyntheticModel(nn.Module):
 
         # Flow matching Euler ODE
         should_decode = semantic_code.squeeze(1) != end_audio_id
-        x = torch.randn(B, at.model_args.n_acoustic_codebook, device=hidden_states.device, dtype=hidden_states.dtype)
+        x = (
+            torch.randn(B, at.model_args.n_acoustic_codebook, device=hidden_states.device, dtype=hidden_states.dtype)
+            if noise is None
+            else noise
+        )
         hidden_zero = torch.zeros_like(hidden_states)
         timesteps = torch.linspace(0, 1, 16, device=hidden_states.device, dtype=hidden_states.dtype)
 
@@ -324,3 +329,75 @@ def test_deterministic_across_calls(model, wrapper):
         eos2, codes2 = _unpack_audio_codes(wrapper(hidden, cfg_alpha=alpha))
     torch.testing.assert_close(eos1, eos2, atol=0, rtol=0)
     torch.testing.assert_close(codes1, codes2, atol=0, rtol=0)
+
+
+def test_explicit_noise_is_reused_across_graph_replays(wrapper):
+    hidden = _random_hidden(4)
+    alpha = _cfg_alpha(4)
+    noise = torch.randn((4, N_ACOUSTIC_CODEBOOK), device=DEVICE, dtype=torch.bfloat16)
+
+    with torch.no_grad():
+        eos1, codes1 = _unpack_audio_codes(wrapper(hidden, cfg_alpha=alpha, noise=noise))
+        torch.randn((4096,), device=DEVICE)
+        eos2, codes2 = _unpack_audio_codes(wrapper(hidden, cfg_alpha=alpha, noise=noise))
+
+    torch.testing.assert_close(eos1, eos2, atol=0, rtol=0)
+    torch.testing.assert_close(codes1, codes2, atol=0, rtol=0)
+
+
+def test_different_explicit_noise_changes_graph_output(wrapper):
+    hidden = _random_hidden(4)
+    alpha = _cfg_alpha(4)
+    noise_a = torch.full((4, N_ACOUSTIC_CODEBOOK), -0.75, device=DEVICE, dtype=torch.bfloat16)
+    noise_b = torch.full((4, N_ACOUSTIC_CODEBOOK), 0.75, device=DEVICE, dtype=torch.bfloat16)
+
+    with torch.no_grad():
+        _, codes_a = _unpack_audio_codes(wrapper(hidden, cfg_alpha=alpha, noise=noise_a))
+        _, codes_b = _unpack_audio_codes(wrapper(hidden, cfg_alpha=alpha, noise=noise_b))
+
+    assert not torch.equal(codes_a[:, 1:], codes_b[:, 1:])
+
+
+def test_explicit_noise_clears_padded_graph_rows(wrapper):
+    hidden = _random_hidden(3)
+    alpha = _cfg_alpha(3)
+    noise = torch.randn((3, N_ACOUSTIC_CODEBOOK), device=DEVICE, dtype=torch.bfloat16)
+
+    with torch.no_grad():
+        eos1, codes1 = _unpack_audio_codes(wrapper(hidden, cfg_alpha=alpha, noise=noise))
+        wrapper.static_noise[4][3:].fill_(100)
+        eos2, codes2 = _unpack_audio_codes(wrapper(hidden, cfg_alpha=alpha, noise=noise))
+
+    torch.testing.assert_close(eos1, eos2, atol=0, rtol=0)
+    torch.testing.assert_close(codes1, codes2, atol=0, rtol=0)
+    torch.testing.assert_close(wrapper.static_noise[4][3:], torch.zeros_like(wrapper.static_noise[4][3:]))
+
+
+@pytest.mark.parametrize("fallback", ["disabled", "capturing", "oversized", "missing_graph"])
+def test_eager_fallback_forwards_explicit_noise(model, wrapper, fallback, monkeypatch):
+    batch_size = 4 if fallback == "disabled" else 33
+    if fallback in {"capturing", "missing_graph"}:
+        batch_size = 4
+    hidden = _random_hidden(batch_size)
+    alpha = _cfg_alpha(batch_size)
+    noise = torch.randn((batch_size, N_ACOUSTIC_CODEBOOK), device=DEVICE, dtype=torch.bfloat16)
+    was_enabled = wrapper.enabled
+    removed_graph = None
+    if fallback == "disabled":
+        wrapper.enabled = False
+    elif fallback == "capturing":
+        monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+    elif fallback == "missing_graph":
+        removed_graph = wrapper.graphs.pop(4)
+
+    try:
+        with torch.no_grad():
+            eager_eos, eager_codes = _unpack_audio_codes(model.compute_mm_logits(hidden, cfg_alpha=alpha, noise=noise))
+            graph_eos, graph_codes = _unpack_audio_codes(wrapper(hidden, cfg_alpha=alpha, noise=noise))
+    finally:
+        wrapper.enabled = was_enabled
+        if removed_graph is not None:
+            wrapper.graphs[4] = removed_graph
+
+    torch.testing.assert_close(graph_eos, eager_eos, atol=0, rtol=0)
+    torch.testing.assert_close(graph_codes, eager_codes, atol=0, rtol=0)

--- a/tests/model_executor/models/voxtral_tts/test_seeded_acoustic_noise.py
+++ b/tests/model_executor/models/voxtral_tts/test_seeded_acoustic_noise.py
@@ -1,0 +1,360 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import functools
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Protocol
+
+import pytest
+import torch
+import torch.nn as nn
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+N_ACOUSTIC_CODEBOOK = 3
+
+
+class _GeneratorWithDevice(Protocol):
+    @property
+    def device(self) -> torch.device: ...
+
+
+@dataclass(frozen=True)
+class _ModelArgsStub:
+    n_acoustic_codebook: int = N_ACOUSTIC_CODEBOOK
+    semantic_codebook_size: int = 2
+
+
+@dataclass(frozen=True)
+class _SamplingMetadataStub:
+    generators: Mapping[int, _GeneratorWithDevice]
+
+
+@dataclass(frozen=True)
+class _GeneratorDeviceStub:
+    device: torch.device
+
+
+@functools.lru_cache(maxsize=1)
+def _voxtral_classes():
+    from tests.model_executor.helpers import bootstrap_vllm_layer_custom_op_modules
+
+    bootstrap_vllm_layer_custom_op_modules()
+    import vllm.model_executor.models.utils  # noqa: F401
+
+    from vllm_omni.model_executor.models.voxtral_tts.voxtral_tts import (
+        VoxtralTTSForConditionalGeneration,
+    )
+    from vllm_omni.model_executor.models.voxtral_tts.voxtral_tts_audio_generation import (
+        AudioSpecialTokens,
+        FlowMatchingAudioTransformer,
+        VoxtralTTSAudioGenerationForConditionalGeneration,
+    )
+
+    return (
+        VoxtralTTSForConditionalGeneration,
+        VoxtralTTSAudioGenerationForConditionalGeneration,
+        FlowMatchingAudioTransformer,
+        AudioSpecialTokens,
+    )
+
+
+class _CaptureAcousticTransformer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.model_args = _ModelArgsStub()
+        self.calls: list[dict[str, torch.Tensor | None]] = []
+
+    def forward(self, llm_hidden, cfg_alpha, noise=None):
+        self.calls.append(
+            {
+                "hidden_states": llm_hidden.clone(),
+                "cfg_alpha": cfg_alpha.clone(),
+                "noise": None if noise is None else noise.clone(),
+            }
+        )
+        semantic = torch.zeros((llm_hidden.shape[0], 1), dtype=torch.long, device=llm_hidden.device)
+        acoustic = torch.zeros(
+            (llm_hidden.shape[0], N_ACOUSTIC_CODEBOOK),
+            dtype=torch.long,
+            device=llm_hidden.device,
+        )
+        return torch.cat([semantic, acoustic], dim=1)
+
+
+class _CaptureAudioGeneration(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.acoustic_transformer = _CaptureAcousticTransformer()
+        self.calls: list[dict[str, torch.Tensor | None]] = []
+
+    def compute_mm_logits(self, hidden_states, cfg_alpha, noise=None):
+        self.calls.append(
+            {
+                "hidden_states": hidden_states.clone(),
+                "cfg_alpha": cfg_alpha.clone(),
+                "noise": None if noise is None else noise.clone(),
+            }
+        )
+        fake_eos = torch.zeros(hidden_states.shape[0], dtype=hidden_states.dtype)
+        return fake_eos, {"codes": {"audio": []}}
+
+
+class _CaptureAcousticGraph:
+    def __init__(self):
+        self.calls: list[dict[str, torch.Tensor | None]] = []
+
+    def __call__(self, hidden_states, cfg_alpha, noise=None):
+        self.calls.append(
+            {
+                "hidden_states": hidden_states.clone(),
+                "cfg_alpha": cfg_alpha.clone(),
+                "noise": None if noise is None else noise.clone(),
+            }
+        )
+        fake_eos = torch.zeros(hidden_states.shape[0], dtype=hidden_states.dtype)
+        return fake_eos, {"codes": {"audio": []}}
+
+
+def _make_voxtral_model():
+    model_cls, _, _, _ = _voxtral_classes()
+    model = model_cls.__new__(model_cls)
+    nn.Module.__init__(model)
+    model.model_stage = "audio_generation"
+    model.model = _CaptureAudioGeneration()
+    model._cudagraph_acoustic_transformer = None
+    return model
+
+
+def _generator(seed: int) -> torch.Generator:
+    return torch.Generator(device="cpu").manual_seed(seed)
+
+
+def _sampling_metadata(generators: Mapping[int, _GeneratorWithDevice]) -> _SamplingMetadataStub:
+    return _SamplingMetadataStub(generators=generators)
+
+
+def test_same_seed_produces_identical_multi_frame_noise_streams():
+    model = _make_voxtral_model()
+    hidden = torch.zeros((1, 4))
+    metadata_a = _sampling_metadata({0: _generator(42)})
+    metadata_b = _sampling_metadata({0: _generator(42)})
+
+    frames_a = [model._make_acoustic_noise(hidden, metadata_a) for _ in range(3)]
+    frames_b = [model._make_acoustic_noise(hidden, metadata_b) for _ in range(3)]
+
+    for frame_a, frame_b in zip(frames_a, frames_b):
+        assert frame_a is not None
+        assert frame_b is not None
+        torch.testing.assert_close(frame_a, frame_b, atol=0, rtol=0)
+    assert not torch.equal(frames_a[0], frames_a[1])
+
+
+def test_different_seeds_produce_different_noise():
+    model = _make_voxtral_model()
+    hidden = torch.zeros((1, 4))
+
+    noise_a = model._make_acoustic_noise(hidden, _sampling_metadata({0: _generator(1)}))
+    noise_b = model._make_acoustic_noise(hidden, _sampling_metadata({0: _generator(2)}))
+
+    assert noise_a is not None
+    assert noise_b is not None
+    assert not torch.equal(noise_a, noise_b)
+
+
+def test_row_reordering_does_not_change_request_noise():
+    model = _make_voxtral_model()
+    hidden = torch.zeros((2, 4))
+
+    noise_ab = model._make_acoustic_noise(
+        hidden,
+        _sampling_metadata({0: _generator(11), 1: _generator(22)}),
+    )
+    noise_ba = model._make_acoustic_noise(
+        hidden,
+        _sampling_metadata({0: _generator(22), 1: _generator(11)}),
+    )
+
+    assert noise_ab is not None
+    assert noise_ba is not None
+    torch.testing.assert_close(noise_ab[0], noise_ba[1], atol=0, rtol=0)
+    torch.testing.assert_close(noise_ab[1], noise_ba[0], atol=0, rtol=0)
+
+
+def test_seeded_row_is_independent_of_unseeded_batch_rows():
+    model = _make_voxtral_model()
+    standalone = model._make_acoustic_noise(
+        torch.zeros((1, 4)),
+        _sampling_metadata({0: _generator(7)}),
+    )
+    batched = model._make_acoustic_noise(
+        torch.zeros((3, 4)),
+        _sampling_metadata({1: _generator(7)}),
+    )
+
+    assert standalone is not None
+    assert batched is not None
+    torch.testing.assert_close(standalone[0], batched[1], atol=0, rtol=0)
+
+
+def test_missing_active_generator_uses_legacy_noise_path():
+    model = _make_voxtral_model()
+
+    assert model._make_acoustic_noise(torch.zeros((2, 4)), None) is None
+    assert model._make_acoustic_noise(torch.zeros((2, 4)), _sampling_metadata({})) is None
+    assert model._make_acoustic_noise(torch.zeros((2, 4)), _sampling_metadata({4: _generator(3)})) is None
+
+
+def test_generator_device_mismatch_fails_with_row_context():
+    model = _make_voxtral_model()
+    incompatible_generator = _GeneratorDeviceStub(device=torch.device("cuda:1"))
+
+    with pytest.raises(RuntimeError, match=r"row 0.*cuda:1.*cpu"):
+        model._make_acoustic_noise(
+            torch.zeros((1, 4)),
+            _sampling_metadata({0: incompatible_generator}),
+        )
+
+
+@pytest.mark.parametrize("use_cuda_graph", [False, True])
+def test_make_omni_output_maps_generators_to_selected_rows(use_cuda_graph):
+    model = _make_voxtral_model()
+    graph = _CaptureAcousticGraph() if use_cuda_graph else None
+    model._cudagraph_acoustic_transformer = graph
+    hidden_states = torch.arange(20, dtype=torch.float32).view(5, 4)
+    original_hidden_states = hidden_states.clone()
+    logits_index = torch.tensor([1, 4])
+    generators = {0: _generator(31), 1: _generator(47)}
+
+    model.make_omni_output(
+        hidden_states,
+        logits_index=logits_index,
+        sampling_metadata=_sampling_metadata(generators),
+        sampling_extra_args=[{}, {}],
+    )
+
+    calls = graph.calls if graph is not None else model.model.calls
+    assert len(calls) == 1
+    torch.testing.assert_close(calls[0]["hidden_states"], original_hidden_states[logits_index])
+    expected_row_0 = torch.empty(N_ACOUSTIC_CODEBOOK).normal_(generator=_generator(31))
+    expected_row_1 = torch.empty(N_ACOUSTIC_CODEBOOK).normal_(generator=_generator(47))
+    torch.testing.assert_close(calls[0]["noise"][0], expected_row_0, atol=0, rtol=0)
+    torch.testing.assert_close(calls[0]["noise"][1], expected_row_1, atol=0, rtol=0)
+
+
+def test_compute_mm_logits_forwards_explicit_noise():
+    _, audio_generation_cls, _, _ = _voxtral_classes()
+    model = audio_generation_cls.__new__(audio_generation_cls)
+    nn.Module.__init__(model)
+    model.acoustic_transformer = _CaptureAcousticTransformer()
+    model._fake_eos_consts = {}
+    model._end_audio_token_id = -1
+    hidden = torch.zeros((2, 4))
+    cfg_alpha = torch.tensor([1.1, 1.3])
+    noise = torch.randn((2, N_ACOUSTIC_CODEBOOK))
+
+    model.compute_mm_logits(hidden, cfg_alpha=cfg_alpha, noise=noise)
+
+    calls = model.acoustic_transformer.calls
+    assert len(calls) == 1
+    torch.testing.assert_close(calls[0]["noise"], noise, atol=0, rtol=0)
+
+
+def test_flow_matching_forward_forwards_explicit_noise():
+    _, _, flow_cls, audio_special_tokens = _voxtral_classes()
+    hidden = torch.zeros((2, 4))
+    cfg_alpha = torch.tensor([1.1, 1.3])
+    noise = torch.randn((2, N_ACOUSTIC_CODEBOOK))
+    captured = {}
+
+    class SemanticProjection:
+        def __call__(self, value):
+            return torch.zeros((value.shape[0], len(audio_special_tokens) + 2))
+
+    def decode_one_frame(semantic_code, llm_hidden, cfg_alpha, noise=None):
+        captured["noise"] = noise
+        return torch.zeros((llm_hidden.shape[0], N_ACOUSTIC_CODEBOOK), dtype=torch.long)
+
+    transformer = flow_cls.__new__(flow_cls)
+    nn.Module.__init__(transformer)
+    transformer.semantic_codebook_output = SemanticProjection()
+    transformer._empty_audio_token_id = 1
+    transformer.model_args = _ModelArgsStub()
+    transformer.decode_one_frame = decode_one_frame
+
+    flow_cls.forward(transformer, hidden, cfg_alpha=cfg_alpha, noise=noise)
+
+    assert captured["noise"] is noise
+
+
+def _make_minimal_flow_transformer():
+    _, _, flow_cls, audio_special_tokens = _voxtral_classes()
+    transformer = flow_cls.__new__(flow_cls)
+    nn.Module.__init__(transformer)
+    transformer.model_args = _ModelArgsStub(n_acoustic_codebook=2)
+    transformer._end_audio_token_id = -1
+    transformer._empty_audio_token_id = audio_special_tokens.id(audio_special_tokens.empty_audio)
+    transformer._noise_scale = 0.5
+    transformer._timesteps_cache = {}
+    transformer._timesteps = torch.tensor([0.0, 1.0])
+    transformer.time_embedding = nn.Identity()
+    transformer.time_projection = nn.Identity()
+    transformer.llm_projection = nn.Identity()
+    transformer.acoustic_embeddings_levels = 5
+
+    def zero_velocity(
+        *,
+        x_t: torch.Tensor,
+        llm_proj: torch.Tensor,
+        t_proj: torch.Tensor,
+    ) -> torch.Tensor:
+        del llm_proj, t_proj
+        return torch.zeros_like(x_t)
+
+    transformer._predict_velocity = zero_velocity
+    return transformer
+
+
+def test_decode_one_frame_uses_supplied_noise_without_global_randn(monkeypatch):
+    transformer = _make_minimal_flow_transformer()
+    _, _, _, audio_special_tokens = _voxtral_classes()
+    noise = torch.tensor([[-0.5, 0.5]])
+
+    def fail_randn(*shape: int, dtype: torch.dtype, device: torch.device) -> torch.Tensor:
+        del shape, dtype, device
+        pytest.fail("global torch.randn was called")
+
+    monkeypatch.setattr(torch, "randn", fail_randn)
+
+    output = transformer.decode_one_frame(
+        semantic_code=torch.tensor([0]),
+        llm_hidden=torch.zeros((1, 2)),
+        cfg_alpha=torch.tensor([1.2]),
+        noise=noise,
+    )
+
+    sampled = transformer._noise_scale * noise
+    expected = (((sampled + 1) / 2) * (transformer.acoustic_embeddings_levels - 1)).round().long()
+    expected += len(audio_special_tokens)
+    torch.testing.assert_close(output, expected, atol=0, rtol=0)
+
+
+def test_decode_one_frame_without_noise_retains_global_randn_fallback(monkeypatch):
+    transformer = _make_minimal_flow_transformer()
+    calls: list[tuple[tuple[int, ...], torch.dtype, torch.device]] = []
+
+    def fake_randn(*shape: int, dtype: torch.dtype, device: torch.device) -> torch.Tensor:
+        calls.append((shape, dtype, device))
+        return torch.zeros(shape, dtype=dtype, device=device)
+
+    monkeypatch.setattr(torch, "randn", fake_randn)
+
+    transformer.decode_one_frame(
+        semantic_code=torch.tensor([0]),
+        llm_hidden=torch.zeros((1, 2)),
+        cfg_alpha=torch.tensor([1.2]),
+    )
+
+    assert len(calls) == 1
+    assert calls[0][0] == (1, 2)

--- a/tests/worker/test_omni_gpu_model_runner.py
+++ b/tests/worker/test_omni_gpu_model_runner.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-from vllm.sampling_params import SamplingType
+from vllm.sampling_params import SamplingParams, SamplingType
 from vllm.v1.cudagraph_dispatcher import CUDAGraphMode
 
 from vllm_omni.worker.gpu_ar_model_runner import GPUARModelRunner
@@ -213,20 +213,28 @@ def test_filter_mrope_kwargs_preserves_flexible_model_kwargs():
     assert _filter_mrope_kwargs_for_model(FlexibleMRoPEModel(), kwargs) is kwargs
 
 
+class _RequestGeneratorModelStub:
+    def __init__(self, *, requires_tts_local_generator: bool):
+        self.requires_tts_local_generator = requires_tts_local_generator
+
+
 def _runner_for_request_generator(*, requires_tts_local_generator: bool) -> OmniGPUModelRunner:
     runner = object.__new__(OmniGPUModelRunner)
     runner.device = torch.device("cpu")
-    runner.model = SimpleNamespace(requires_tts_local_generator=requires_tts_local_generator)
+    runner.model = _RequestGeneratorModelStub(
+        requires_tts_local_generator=requires_tts_local_generator,
+    )
     return runner
 
 
 def test_greedy_tts_local_seed_creates_request_generator():
     runner = _runner_for_request_generator(requires_tts_local_generator=True)
-    sampling_params = SimpleNamespace(
-        sampling_type=SamplingType.GREEDY,
+    sampling_params = SamplingParams(
+        temperature=0.0,
         seed=42,
         extra_args={"tts_local_seed": 42},
     )
+    assert sampling_params.sampling_type == SamplingType.GREEDY
 
     generator = OmniGPUModelRunner._create_request_generator(runner, sampling_params)
 
@@ -238,33 +246,35 @@ def test_greedy_tts_local_seed_creates_request_generator():
 
 def test_greedy_tts_default_seed_without_marker_stays_unseeded():
     runner = _runner_for_request_generator(requires_tts_local_generator=True)
-    sampling_params = SimpleNamespace(
-        sampling_type=SamplingType.GREEDY,
+    sampling_params = SamplingParams(
+        temperature=0.0,
         seed=42,
         extra_args={},
     )
+    assert sampling_params.sampling_type == SamplingType.GREEDY
 
     assert OmniGPUModelRunner._create_request_generator(runner, sampling_params) is None
 
 
 def test_non_opted_in_greedy_model_ignores_tts_local_seed():
     runner = _runner_for_request_generator(requires_tts_local_generator=False)
-    sampling_params = SimpleNamespace(
-        sampling_type=SamplingType.GREEDY,
+    sampling_params = SamplingParams(
+        temperature=0.0,
         seed=42,
         extra_args={"tts_local_seed": 42},
     )
+    assert sampling_params.sampling_type == SamplingType.GREEDY
 
     assert OmniGPUModelRunner._create_request_generator(runner, sampling_params) is None
 
 
 def test_random_seed_request_generator_behavior_is_preserved():
     runner = _runner_for_request_generator(requires_tts_local_generator=False)
-    sampling_params = SimpleNamespace(
-        sampling_type=SamplingType.RANDOM_SEED,
+    sampling_params = SamplingParams(
         seed=17,
         extra_args=None,
     )
+    assert sampling_params.sampling_type == SamplingType.RANDOM_SEED
 
     generator = OmniGPUModelRunner._create_request_generator(runner, sampling_params)
 

--- a/tests/worker/test_omni_gpu_model_runner.py
+++ b/tests/worker/test_omni_gpu_model_runner.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from vllm.sampling_params import SamplingType
 from vllm.v1.cudagraph_dispatcher import CUDAGraphMode
 
 from vllm_omni.worker.gpu_ar_model_runner import GPUARModelRunner
@@ -210,6 +211,67 @@ def test_filter_mrope_kwargs_preserves_flexible_model_kwargs():
     }
 
     assert _filter_mrope_kwargs_for_model(FlexibleMRoPEModel(), kwargs) is kwargs
+
+
+def _runner_for_request_generator(*, requires_tts_local_generator: bool) -> OmniGPUModelRunner:
+    runner = object.__new__(OmniGPUModelRunner)
+    runner.device = torch.device("cpu")
+    runner.model = SimpleNamespace(requires_tts_local_generator=requires_tts_local_generator)
+    return runner
+
+
+def test_greedy_tts_local_seed_creates_request_generator():
+    runner = _runner_for_request_generator(requires_tts_local_generator=True)
+    sampling_params = SimpleNamespace(
+        sampling_type=SamplingType.GREEDY,
+        seed=42,
+        extra_args={"tts_local_seed": 42},
+    )
+
+    generator = OmniGPUModelRunner._create_request_generator(runner, sampling_params)
+
+    assert generator is not None
+    expected = torch.empty(8).normal_(generator=torch.Generator(device="cpu").manual_seed(42))
+    actual = torch.empty(8).normal_(generator=generator)
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+def test_greedy_tts_default_seed_without_marker_stays_unseeded():
+    runner = _runner_for_request_generator(requires_tts_local_generator=True)
+    sampling_params = SimpleNamespace(
+        sampling_type=SamplingType.GREEDY,
+        seed=42,
+        extra_args={},
+    )
+
+    assert OmniGPUModelRunner._create_request_generator(runner, sampling_params) is None
+
+
+def test_non_opted_in_greedy_model_ignores_tts_local_seed():
+    runner = _runner_for_request_generator(requires_tts_local_generator=False)
+    sampling_params = SimpleNamespace(
+        sampling_type=SamplingType.GREEDY,
+        seed=42,
+        extra_args={"tts_local_seed": 42},
+    )
+
+    assert OmniGPUModelRunner._create_request_generator(runner, sampling_params) is None
+
+
+def test_random_seed_request_generator_behavior_is_preserved():
+    runner = _runner_for_request_generator(requires_tts_local_generator=False)
+    sampling_params = SimpleNamespace(
+        sampling_type=SamplingType.RANDOM_SEED,
+        seed=17,
+        extra_args=None,
+    )
+
+    generator = OmniGPUModelRunner._create_request_generator(runner, sampling_params)
+
+    assert generator is not None
+    expected = torch.empty(8).normal_(generator=torch.Generator(device="cpu").manual_seed(17))
+    actual = torch.empty(8).normal_(generator=generator)
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
 
 
 def _make_runner(req_ids=("r1", "r2"), hidden_size=4):

--- a/vllm_omni/model_executor/models/voxtral_tts/cuda_graph_acoustic_transformer_wrapper.py
+++ b/vllm_omni/model_executor/models/voxtral_tts/cuda_graph_acoustic_transformer_wrapper.py
@@ -232,6 +232,7 @@ class CUDAGraphAcousticTransformerWrapper:
         self,
         hidden_states: torch.Tensor,
         cfg_alpha: torch.Tensor,
+        noise: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, dict[str, list[torch.Tensor]] | None]:
         """
         Drop-in replacement for model.compute_mm_logits().
@@ -242,16 +243,27 @@ class CUDAGraphAcousticTransformerWrapper:
         """
         actual_size = hidden_states.shape[0]
 
+        if noise is not None:
+            expected_shape = (actual_size, self.n_acoustic_codebook)
+            if noise.shape != expected_shape:
+                raise ValueError(f"Expected acoustic noise shape {expected_shape}, got {tuple(noise.shape)}")
+            if noise.device != hidden_states.device or noise.dtype != hidden_states.dtype:
+                raise ValueError(
+                    "Acoustic noise must match hidden_states device and dtype: "
+                    f"noise=({noise.device}, {noise.dtype}), "
+                    f"hidden_states=({hidden_states.device}, {hidden_states.dtype})"
+                )
+
         if not self.enabled or not self._warmed_up:
-            return self.model.compute_mm_logits(hidden_states, cfg_alpha=cfg_alpha)
+            return self.model.compute_mm_logits(hidden_states, cfg_alpha=cfg_alpha, noise=noise)
 
         # Inner graph replay is illegal during an outer stream capture.
         if torch.cuda.is_current_stream_capturing():
-            return self.model.compute_mm_logits(hidden_states, cfg_alpha=cfg_alpha)
+            return self.model.compute_mm_logits(hidden_states, cfg_alpha=cfg_alpha, noise=noise)
 
         padded_size = self._get_padded_size(actual_size)
         if padded_size is None or padded_size not in self.graphs:
-            return self.model.compute_mm_logits(hidden_states, cfg_alpha=cfg_alpha)
+            return self.model.compute_mm_logits(hidden_states, cfg_alpha=cfg_alpha, noise=noise)
 
         # Zero static input, then copy actual data
         self.static_inputs[padded_size].zero_()
@@ -261,9 +273,13 @@ class CUDAGraphAcousticTransformerWrapper:
         self.static_cfg_alpha[padded_size].fill_(1.2)
         self.static_cfg_alpha[padded_size][:actual_size, 0] = cfg_alpha
 
-        # Fill noise buffer with fresh random values before replay so the
-        # flow-matching ODE starts from different initial noise each time.
-        self.static_noise[padded_size].normal_()
+        # Explicit request-local noise is a mutable graph input. Clear padded
+        # rows before copying so they cannot retain data from a previous replay.
+        if noise is None:
+            self.static_noise[padded_size].normal_()
+        else:
+            self.static_noise[padded_size].zero_()
+            self.static_noise[padded_size][:actual_size].copy_(noise)
 
         # Replay captured graph
         self.graphs[padded_size].replay()

--- a/vllm_omni/model_executor/models/voxtral_tts/voxtral_tts.py
+++ b/vllm_omni/model_executor/models/voxtral_tts/voxtral_tts.py
@@ -390,7 +390,11 @@ class VoxtralTTSForConditionalGeneration(
         return noise
 
     def make_omni_output(
-        self, model_outputs: torch.Tensor | OmniOutput | tuple, logits_index: int | None = None, **kwargs
+        self,
+        model_outputs: torch.Tensor | OmniOutput | tuple,
+        logits_index: int | None = None,
+        sampling_metadata: SamplingMetadata | None = None,
+        **kwargs,
     ) -> OmniOutput:
         if isinstance(model_outputs, torch.Tensor):
             if self.model_stage == "audio_generation":
@@ -400,7 +404,7 @@ class VoxtralTTSForConditionalGeneration(
                 cfg_alpha = self._extract_cfg_alpha(input_hidden_states, **kwargs)
                 noise = self._make_acoustic_noise(
                     input_hidden_states,
-                    kwargs.get("sampling_metadata"),
+                    sampling_metadata,
                 )
                 if self._cudagraph_acoustic_transformer is not None:
                     fake_eos, multimodal_outputs = self._cudagraph_acoustic_transformer(

--- a/vllm_omni/model_executor/models/voxtral_tts/voxtral_tts.py
+++ b/vllm_omni/model_executor/models/voxtral_tts/voxtral_tts.py
@@ -100,6 +100,10 @@ class VoxtralTTSForConditionalGeneration(
     SupportsMultiModal,
     CustomProcessMixin,
 ):
+    # Voxtral consumes request-local randomness outside the vLLM token sampler,
+    # including when stage-0 token sampling is greedy.
+    requires_tts_local_generator = True
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         config = vllm_config.model_config.hf_config
@@ -339,6 +343,52 @@ class VoxtralTTSForConditionalGeneration(
             dtype=input_hidden_states.dtype,
         )
 
+    def _make_acoustic_noise(
+        self,
+        input_hidden_states: torch.Tensor,
+        sampling_metadata: SamplingMetadata | None,
+    ) -> torch.Tensor | None:
+        """Build row-local acoustic noise from active request generators.
+
+        Returning ``None`` preserves the legacy batched/global RNG path when
+        none of the active rows has a request-owned generator.
+        """
+        generators = getattr(sampling_metadata, "generators", None)
+        if not generators:
+            return None
+
+        batch_size = input_hidden_states.shape[0]
+        row_generators = [generators.get(row_idx) for row_idx in range(batch_size)]
+        if not any(generator is not None for generator in row_generators):
+            return None
+
+        n_acoustic_codebook = self.model.acoustic_transformer.model_args.n_acoustic_codebook
+        noise = torch.empty(
+            (batch_size, n_acoustic_codebook),
+            device=input_hidden_states.device,
+            dtype=input_hidden_states.dtype,
+        )
+        for row_idx, generator in enumerate(row_generators):
+            if generator is None:
+                noise[row_idx].normal_()
+                continue
+
+            generator_device = torch.device(generator.device)
+            output_device = noise.device
+            same_device_index = (
+                generator_device.index is None
+                or output_device.index is None
+                or generator_device.index == output_device.index
+            )
+            if generator_device.type != output_device.type or not same_device_index:
+                raise RuntimeError(
+                    "Request-local acoustic generator for row "
+                    f"{row_idx} is on {generator_device}, but acoustic noise is on {output_device}."
+                )
+            noise[row_idx].normal_(generator=generator)
+
+        return noise
+
     def make_omni_output(
         self, model_outputs: torch.Tensor | OmniOutput | tuple, logits_index: int | None = None, **kwargs
     ) -> OmniOutput:
@@ -348,13 +398,21 @@ class VoxtralTTSForConditionalGeneration(
                 assert logits_index is not None
                 input_hidden_states = hidden_states[logits_index]
                 cfg_alpha = self._extract_cfg_alpha(input_hidden_states, **kwargs)
+                noise = self._make_acoustic_noise(
+                    input_hidden_states,
+                    kwargs.get("sampling_metadata"),
+                )
                 if self._cudagraph_acoustic_transformer is not None:
                     fake_eos, multimodal_outputs = self._cudagraph_acoustic_transformer(
-                        input_hidden_states, cfg_alpha=cfg_alpha
+                        input_hidden_states,
+                        cfg_alpha=cfg_alpha,
+                        noise=noise,
                     )
                 else:
                     fake_eos, multimodal_outputs = self.model.compute_mm_logits(
-                        input_hidden_states, cfg_alpha=cfg_alpha
+                        input_hidden_states,
+                        cfg_alpha=cfg_alpha,
+                        noise=noise,
                     )
                 hidden_states[logits_index, 0] = fake_eos
                 return OmniOutput(

--- a/vllm_omni/model_executor/models/voxtral_tts/voxtral_tts_audio_generation.py
+++ b/vllm_omni/model_executor/models/voxtral_tts/voxtral_tts_audio_generation.py
@@ -510,14 +510,32 @@ class FlowMatchingAudioTransformer(nn.Module):
         semantic_code: torch.Tensor,
         llm_hidden: torch.Tensor,
         cfg_alpha: torch.Tensor,
+        noise: torch.Tensor | None = None,
     ) -> torch.Tensor:
         B = semantic_code.shape[0]
 
         # Skip decoding if codebook 0 is [END_AUDIO] token.
         should_decode = semantic_code != self._end_audio_token_id
 
-        # acoustic_codes starts from x_0; generate directly on device to skip H2D.
-        x_0 = torch.randn(B, self.model_args.n_acoustic_codebook, dtype=llm_hidden.dtype, device=llm_hidden.device)
+        # acoustic_codes starts from x_0. Request-aware callers provide noise;
+        # direct/internal callers retain the legacy device-global RNG path.
+        if noise is None:
+            x_0 = torch.randn(
+                B,
+                self.model_args.n_acoustic_codebook,
+                dtype=llm_hidden.dtype,
+                device=llm_hidden.device,
+            )
+        else:
+            expected_shape = (B, self.model_args.n_acoustic_codebook)
+            if noise.shape != expected_shape:
+                raise ValueError(f"Expected acoustic noise shape {expected_shape}, got {tuple(noise.shape)}")
+            if noise.device != llm_hidden.device or noise.dtype != llm_hidden.dtype:
+                raise ValueError(
+                    "Acoustic noise must match llm_hidden device and dtype: "
+                    f"noise=({noise.device}, {noise.dtype}), llm_hidden=({llm_hidden.device}, {llm_hidden.dtype})"
+                )
+            x_0 = noise
         x_0 = self._noise_scale * x_0
 
         # Build the schedule constants once per dtype and reuse them every frame.
@@ -598,6 +616,7 @@ class FlowMatchingAudioTransformer(nn.Module):
         self,
         llm_hidden: torch.Tensor,
         cfg_alpha: torch.Tensor,
+        noise: torch.Tensor | None = None,
     ) -> torch.Tensor:
         # llm_hidden: BxD
         semantic_logit = self.semantic_codebook_output(llm_hidden).float()
@@ -611,6 +630,7 @@ class FlowMatchingAudioTransformer(nn.Module):
             semantic_code.squeeze(1),
             llm_hidden,
             cfg_alpha=cfg_alpha,
+            noise=noise,
         )
 
         audio_codes = torch.concatenate(
@@ -1061,10 +1081,12 @@ class VoxtralTTSAudioGenerationForConditionalGeneration(nn.Module, SupportsMulti
         self,
         hidden_states: torch.Tensor,
         cfg_alpha: torch.Tensor,
+        noise: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         audio_codes = self.acoustic_transformer(
             llm_hidden=hidden_states,
             cfg_alpha=cfg_alpha,
+            noise=noise,
         )
         # Cache device-resident 1.0/0.0 scalars to avoid a per-call H2D transfer.
         consts = self._fake_eos_consts.get(audio_codes.device)

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -1,6 +1,6 @@
 import contextlib
 import inspect
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any, cast
 
@@ -311,6 +311,28 @@ class OmniGPUModelRunner(GPUModelRunner):
             return sampling_metadata
         return replace(sampling_metadata, output_token_ids=output_token_ids)
 
+    def _create_request_generator(self, sampling_params: Any | None) -> torch.Generator | None:
+        """Create the request-owned RNG used by sampling and opted-in TTS models."""
+        if sampling_params is None:
+            return None
+
+        seed = None
+        if sampling_params.sampling_type == SamplingType.RANDOM_SEED:
+            # Preserve native vLLM request-seeded sampling behavior.
+            seed = sampling_params.seed
+        elif getattr(self.model, "requires_tts_local_generator", False):
+            # Greedy TTS requests normally have no vLLM sampler generator. An
+            # explicit speech seed still needs one for model-local stochastic
+            # work such as Voxtral's flow-matching acoustic noise.
+            extra_args = getattr(sampling_params, "extra_args", None)
+            if isinstance(extra_args, Mapping):
+                seed = extra_args.get("tts_local_seed")
+
+        if seed is None:
+            return None
+
+        return torch.Generator(device=self.device).manual_seed(int(seed))
+
     def _init_mrope_positions(self, req_state: CachedRequestState):
         """Initialize M-RoPE positions for multimodal inputs.
 
@@ -557,11 +579,7 @@ class OmniGPUModelRunner(GPUModelRunner):
             sampling_params = new_req_data.sampling_params
             pooling_params = new_req_data.pooling_params
 
-            if sampling_params and sampling_params.sampling_type == SamplingType.RANDOM_SEED:
-                generator = torch.Generator(device=self.device)
-                generator.manual_seed(sampling_params.seed)
-            else:
-                generator = None
+            generator = self._create_request_generator(sampling_params)
 
             if self.is_pooling_model:
                 assert pooling_params is not None

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -12,7 +12,7 @@ from vllm.forward_context import set_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.models.interfaces import supports_mrope
 from vllm.model_executor.models.interfaces_base import VllmModelForPooling
-from vllm.sampling_params import SamplingType
+from vllm.sampling_params import SamplingParams, SamplingType
 from vllm.sequence import IntermediateTensors
 from vllm.tracing import instrument
 from vllm.utils.import_utils import LazyLoader
@@ -311,7 +311,7 @@ class OmniGPUModelRunner(GPUModelRunner):
             return sampling_metadata
         return replace(sampling_metadata, output_token_ids=output_token_ids)
 
-    def _create_request_generator(self, sampling_params: Any | None) -> torch.Generator | None:
+    def _create_request_generator(self, sampling_params: SamplingParams | None) -> torch.Generator | None:
         """Create the request-owned RNG used by sampling and opted-in TTS models."""
         if sampling_params is None:
             return None


### PR DESCRIPTION
  <!-- markdownlint-disable -->

  Fixes #6309.

  ## Purpose

  Voxtral TTS accepted `seed` through `/v1/audio/speech`, but the seed did not control flow-matching acoustic noise.
  Because stage 0 uses greedy sampling, it did not receive a request-scoped generator, while both the eager and CUDA
  graph paths drew acoustic noise from the process-global RNG.

  As a result, identical requests using the same seed could produce different acoustic codes, durations, and decoded
  PCM.

  This change:

  - creates the existing request-owned generator for opted-in greedy TTS requests carrying `tts_local_seed`, while
  preserving native random-sampling behavior;
  - generates acoustic noise per active request from `SamplingMetadata.generators`;
  - keeps each seeded acoustic-noise stream independent of batch order and unseeded batch members;
  - threads explicit acoustic noise through the eager Voxtral flow-matching path;
  - copies explicit noise into the CUDA graph's existing static input buffer and forwards it through every eager
  fallback;
  - preserves the existing stochastic behavior for unseeded and direct callers.

  No public API or request-schema changes are introduced.

  The original failure and HTTP reproducer are documented in #6309.

  ## Test Plan

  Regression coverage verifies:

  - propagation of the speech API seed to stage-0 `seed` and `tts_local_seed`;
  - request generator creation for greedy Voxtral TTS without changing non-opted-in models or unmarked requests;
  - same-seed determinism and different-seed variation;
  - independence from row ordering and mixed seeded/unseeded batches;
  - legacy global-RNG fallback and generator-device validation;
  - explicit-noise propagation through eager flow matching;
  - explicit-noise CUDA graph replay, padded-row isolation, and all eager fallbacks.

  **vLLM Version:** `0.27.0`

  **vLLM-Omni Commit:** `05cba66bb4c6611fa3f59e10f80fda1f3fb4145b`

  ## Test Result

  RunPod environment:

  - NVIDIA RTX 2000 Ada Generation
  - NVIDIA driver `580.159.04`
  - Python `3.12.3`
  - PyTorch `2.13.0+cu132`
  - vLLM `0.27.0`
  - editable vLLM-Omni installation from the commit above

  CPU tests:

  ```bash
  pytest -sv \
    tests/model_executor/models/voxtral_tts/test_seeded_acoustic_noise.py \
    tests/worker/test_omni_gpu_model_runner.py \
    tests/entrypoints/openai_api/test_serving_speech.py \
    -m "core_model and cpu"
  ```

  ```text
  265 passed, 15 warnings in 8.19s
  ```

  GPU tests:

  ```bash
  pytest -sv \
    tests/model_executor/models/voxtral_tts/test_cuda_graph_acoustic_transformer.py \
    -m "core_model and cuda" \
    --run-level core_model
  ```

  ```text
  34 passed, 14 warnings in 0.72s
  ```

  A CUDA tensor smoke test also passed.
