### PR TITLE
[Bugfix][MiniCPM-o] Fix Code2Wav NPU test and resolve review follow-ups

### DIFF
--- a/tests/model_executor/models/minicpmo_4_5/test_streaming_audio_cache.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_streaming_audio_cache.py
@@ -4,11 +4,10 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 import pytest
 import torch
 from torch import nn
+from transformers.cache_utils import DynamicCache, EncoderDecoderCache
 from transformers.models.whisper.modeling_whisper import WhisperConfig
 
 from vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni_llm import (
@@ -77,8 +76,10 @@ def test_whisper_attention_preserves_streaming_cache(
 
 
 def test_audio_cache_length_uses_current_cache_api() -> None:
-    dynamic_cache = SimpleNamespace(get_seq_length=lambda: 7)
-    encoder_decoder_cache = SimpleNamespace(self_attention_cache=dynamic_cache)
+    key = torch.zeros(1, 1, 7, 2)
+    self_attention_cache = DynamicCache()
+    self_attention_cache.update(key, torch.zeros_like(key), 0)
+    encoder_decoder_cache = EncoderDecoderCache(self_attention_cache, DynamicCache())
 
     assert _get_audio_cache_length(encoder_decoder_cache) == 7
 

--- a/tests/platforms/npu/test_minicpmo_code2wav_npugraph.py
+++ b/tests/platforms/npu/test_minicpmo_code2wav_npugraph.py
@@ -29,9 +29,17 @@ pytestmark = [
 ]
 
 
+class _Encoder(nn.Module):
+    """``BatchedToken2Wav`` requires ``flow.encoder`` at construction time."""
+
+    def forward_chunk(self, xs, last_chunk=False, cnn_cache=None, att_cache=None):
+        raise AssertionError("CFM estimator NPUGraph test must not run the flow encoder")
+
+
 class _Flow(nn.Module):
     def __init__(self, estimator: nn.Module):
         super().__init__()
+        self.encoder = _Encoder()
         self.decoder = SimpleNamespace(estimator=estimator)
 
 

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py
@@ -2506,7 +2506,9 @@ def _in_projection(
     return linear(q, w_q, b_q), linear(k, w_k, b_k), linear(v, w_v, b_v)
 
 
-def _get_audio_cache_length(past_key_values: Any) -> int:
+def _get_audio_cache_length(
+    past_key_values: EncoderDecoderCache | DynamicCache | tuple[tuple[torch.Tensor, ...], ...],
+) -> int:
     cache = getattr(past_key_values, "self_attention_cache", past_key_values)
     get_seq_length = getattr(cache, "get_seq_length", None)
     if callable(get_seq_length):


### PR DESCRIPTION
## Purpose

#6274 moved the first access of `flow.encoder` into `BatchedToken2Wav.__init__`
(`_undecorate_dynamo(self.flow.encoder, "forward_chunk")`). The NPUGraph
estimator test builds a `_Flow` double that only declares `decoder`, so
constructing the adapter now raises
`AttributeError: '_Flow' object has no attribute 'encoder'` and NPU Ready CI
fails. Real inference is unaffected — an actual `cosyvoice2` flow always
exposes `encoder`, which `_encode_chunk` has always required.

And resolve left comments mentioned in PR #6274

## Test Plan

- NPU Ready CI: `tests/platforms/npu/test_minicpmo_code2wav_npugraph.py::test_minicpmo_cfm_estimator_npugraph_matches_eager`
  (the failing case)
- CPU regression, covers the same `BatchedToken2Wav.__init__` path with a full flow double:
  `pytest tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py`

## Test Result

WIP