### PR TITLE
[Bugfix][Diffusion] Aggregate async RPC completion across worker ranks

### DIFF
--- a/tests/diffusion/test_async_output_worker.py
+++ b/tests/diffusion/test_async_output_worker.py
@@ -164,6 +164,27 @@ class TestReturnResultAsyncPath:
         proc._return_result(DiffusionOutput())
         # No crash, no enqueue attempted
 
+    def test_non_output_rank_acknowledges_successful_async_rpc(self):
+        proc = _make_worker_proc(step_execution=False)
+        proc.recv_message = MagicMock(
+            side_effect=[
+                {
+                    "type": "rpc",
+                    "method": "execute_model",
+                    "rpc_id": "rpc-1",
+                },
+                {"type": "shutdown"},
+            ]
+        )
+        proc._execute_rpc = MagicMock(return_value=(None, False))
+
+        proc._worker_busy_loop()
+
+        ack = proc.result_mq.enqueue.call_args.args[0]
+        assert ack.kind == AsyncOutputKind.RPC_RESULT
+        assert ack.rpc_id == "rpc-1"
+        assert ack.error is None
+
 
 class TestReturnResultSyncPath:
     """Test _return_result in step-execution mode (sync)."""

--- a/tests/diffusion/test_result_pump.py
+++ b/tests/diffusion/test_result_pump.py
@@ -22,12 +22,15 @@ def _make_executor(step_execution=False):
 
     od_config = MagicMock()
     od_config.step_execution = step_execution
+    od_config.num_gpus = 1
 
     executor = object.__new__(MultiprocDiffusionExecutor)
     executor.od_config = od_config
     executor._rpc_id_counter = 0
     executor._rpc_id_lock = threading.Lock()
     executor._rpc_futures = {}
+    executor._rpc_expected_replies = {}
+    executor._rpc_replies = {}
     executor._output_futures = {}
     executor._completed_outputs = {}
     executor._batch_split_map = {}
@@ -200,6 +203,8 @@ class TestResultPumpDispatch:
         fut = concurrent.futures.Future()
         with executor._futures_lock:
             executor._rpc_futures[rpc_id] = fut
+            executor._rpc_expected_replies[rpc_id] = 1
+            executor._rpc_replies[rpc_id] = []
 
         msg = AsyncDiffusionOutput(
             kind=AsyncOutputKind.COMPUTE_DONE,
@@ -211,6 +216,33 @@ class TestResultPumpDispatch:
         assert fut.done()
         result = fut.result(timeout=1.0)
         assert result.kind == AsyncOutputKind.COMPUTE_DONE
+
+    @pytest.mark.parametrize("error_first", [False, True])
+    def test_async_rpc_prioritizes_nonzero_rank_error(self, error_first):
+        executor = _make_executor()
+        rpc_id = "two-rank"
+        fut = concurrent.futures.Future()
+        with executor._futures_lock:
+            executor._rpc_futures[rpc_id] = fut
+            executor._rpc_expected_replies[rpc_id] = 2
+            executor._rpc_replies[rpc_id] = []
+
+        compute_done = AsyncDiffusionOutput(
+            kind=AsyncOutputKind.COMPUTE_DONE,
+            rpc_id=rpc_id,
+            async_output_id="output-id",
+        )
+        rank_error = AsyncDiffusionOutput(
+            kind=AsyncOutputKind.RPC_RESULT,
+            rpc_id=rpc_id,
+            error="rank 1 failed",
+        )
+        messages = [rank_error, compute_done] if error_first else [compute_done, rank_error]
+        for message in messages:
+            executor._dispatch_async_rpc_result(message)
+
+        with pytest.raises(RuntimeError, match="rank 1 failed"):
+            fut.result(timeout=1.0)
 
     def test_output_ready_routes_to_output_future(self):
         executor = _make_executor()

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -133,6 +133,8 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
         self._rpc_id_counter = 0
         self._rpc_id_lock = threading.Lock()
         self._rpc_futures: dict[str, concurrent.futures.Future[AsyncDiffusionOutput]] = {}
+        self._rpc_expected_replies: dict[str, int] = {}
+        self._rpc_replies: dict[str, list[AsyncDiffusionOutput]] = {}
         self._output_futures: dict[str, concurrent.futures.Future[DiffusionOutput]] = {}
         self._completed_outputs: dict[str, concurrent.futures.Future[DiffusionOutput]] = {}
         self._batch_split_map: dict[str, dict[str, str]] = {}  # batch_id -> {per_req_id: request_id}
@@ -722,12 +724,16 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
             fut: concurrent.futures.Future = concurrent.futures.Future()
             with self._futures_lock:
                 self._rpc_futures[rpc_id] = fut
+                self._rpc_expected_replies[rpc_id] = int(self.od_config.num_gpus) if execute_all_ranks else 1
+                self._rpc_replies[rpc_id] = []
             self._broadcast_mq.enqueue(rpc_request)  # pyright: ignore[reportOptionalMemberAccess] MQ is not None before shutdown
             try:
                 return fut.result(timeout=timeout)
             except concurrent.futures.TimeoutError:
                 with self._futures_lock:
                     self._rpc_futures.pop(rpc_id, None)
+                    self._rpc_expected_replies.pop(rpc_id, None)
+                    self._rpc_replies.pop(rpc_id, None)
                 raise TimeoutError(f"RPC call to {method} timed out.")
 
         # ── Path 2: step-execution or other non-execute_model RPCs ──
@@ -864,13 +870,7 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                 continue
 
             if msg.kind in (AsyncOutputKind.RPC_RESULT, AsyncOutputKind.COMPUTE_DONE):
-                with self._futures_lock:
-                    fut = self._rpc_futures.pop(msg.rpc_id, None) if msg.rpc_id else None
-                if fut is not None and not fut.done():
-                    if msg.error:
-                        try_set_exception(fut, RuntimeError(msg.error))
-                    else:
-                        try_set_result(fut, msg)
+                self._dispatch_async_rpc_result(msg)
             elif msg.kind == AsyncOutputKind.OUTPUT_READY:
                 batch_id = msg.async_output_id
                 with self._futures_lock:
@@ -911,6 +911,32 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                                 else:
                                     fut.set_result(output_result)
                                 self._completed_outputs[batch_id] = fut
+
+    def _dispatch_async_rpc_result(self, msg: AsyncDiffusionOutput) -> None:
+        rpc_id = msg.rpc_id
+        if rpc_id is None:
+            return
+        with self._futures_lock:
+            fut = self._rpc_futures.get(rpc_id)
+            if fut is None or fut.done():
+                return
+            replies = self._rpc_replies.setdefault(rpc_id, [])
+            replies.append(msg)
+            expected = self._rpc_expected_replies.get(rpc_id, 1)
+            if msg.error:
+                self._rpc_futures.pop(rpc_id, None)
+                self._rpc_expected_replies.pop(rpc_id, None)
+                self._rpc_replies.pop(rpc_id, None)
+                try_set_exception(fut, RuntimeError(msg.error))
+            elif len(replies) >= expected:
+                compute_done = next(
+                    (reply for reply in replies if reply.kind == AsyncOutputKind.COMPUTE_DONE),
+                    replies[-1],
+                )
+                self._rpc_futures.pop(rpc_id, None)
+                self._rpc_expected_replies.pop(rpc_id, None)
+                self._rpc_replies.pop(rpc_id, None)
+                try_set_result(fut, compute_done)
 
     def _deliver_batch_split(
         self,
@@ -1002,6 +1028,8 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                     if not fut.done():
                         try_set_exception(fut, RuntimeError("Executor shut down"))
                 self._rpc_futures.clear()
+                self._rpc_expected_replies.clear()
+                self._rpc_replies.clear()
                 self._output_futures.clear()
                 self._batch_split_map.clear()
             self._shutdown_cleaner = None

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -1251,6 +1251,17 @@ class WorkerProc:
                     result, should_reply = self._execute_rpc(msg)
                     if should_reply:
                         self._return_result(result, rpc_id=rpc_id)
+                    elif rpc_id is not None and self.result_mq is not None:
+                        # Async RPC futures resolve only after every executing
+                        # rank has either acknowledged success or reported an
+                        # error. This prevents rank-zero COMPUTE_DONE from
+                        # racing ahead of a non-output-rank failure.
+                        self._enqueue_result(
+                            AsyncDiffusionOutput(
+                                kind=AsyncOutputKind.RPC_RESULT,
+                                rpc_id=rpc_id,
+                            )
+                        )
                 except Exception as e:
                     logger.error(f"Error processing RPC: {e}", exc_info=True)
                     # Apply the same reply gate as the success path so


### PR DESCRIPTION
## Summary

Fix a race in request-mode multiprocess diffusion RPCs where rank 0 can publish `COMPUTE_DONE` before another worker publishes an `RPC_RESULT` error. The first result pump previously popped the shared future, so a rank-zero success could silently hide the worker failure.

- successful non-output ranks now acknowledge async RPC completion;
- the executor waits for all executing ranks before resolving success;
- any rank error resolves the caller with an exception immediately;
- timeout and shutdown paths clear the new reply bookkeeping.

## Test Plan

- `pytest -q tests/diffusion/test_result_pump.py tests/diffusion/test_async_output_worker.py`
- 40 passed
- Added both success-first and error-first two-rank regression coverage.

Signed-off-by: Binh Tang <binht@netflix.com>
