### PR TITLE
[Test] Reduce IPC lifecycle test process overhead

### DIFF
--- a/tests/diffusion/test_diffusion_ipc.py
+++ b/tests/diffusion/test_diffusion_ipc.py
@@ -40,7 +40,16 @@ def _cleanup_shm_handle(value: object) -> None:
 
 def _result_queue_worker(connection, rank: int) -> None:
     """Send one nested NumPy result through a worker-owned MessageQueue."""
-    result_mq = MessageQueue(n_reader=1, n_local_reader=1, local_reader_ranks=[0])
+    # The payload itself is small because the large arrays travel through
+    # separate shared-memory handles. Avoid the 240 MiB MessageQueue default
+    # per worker so this lifecycle test also fits in constrained CI /dev/shm.
+    result_mq = MessageQueue(
+        n_reader=1,
+        n_local_reader=1,
+        local_reader_ranks=[0],
+        max_chunk_bytes=1024 * 1024,
+        max_chunks=2,
+    )
     try:
         connection.send(result_mq.export_handle())
         assert connection.recv() == "reader-ready"
@@ -70,7 +79,9 @@ def _result_queue_worker(connection, rank: int) -> None:
 
 def test_per_worker_result_queues_release_nested_numpy_shm_and_processes() -> None:
     """Exercise the production per-worker queue/pump/SHM lifecycle."""
-    ctx = mp.get_context("spawn")
+    # This test covers queue/pump/SHM cleanup rather than process bootstrap.
+    # Fork avoids re-importing the pytest runner in every constrained CI child.
+    ctx = mp.get_context("fork")
     parent_connections = []
     processes = []
     result_mqs = []


### PR DESCRIPTION
## Summary

- run the queue/pump/shared-memory lifecycle test with Linux fork rather than re-importing the pytest runner in spawned children
- bound the test-owned MessageQueue rings, reducing them from about 480 MiB total to 4 MiB total
- keep production process startup and queue sizing unchanged

This test validates two per-worker result queues, pump threads, nested NumPy shared-memory materialization, worker shutdown, and leak cleanup. It does not validate production process bootstrap. Using spawn makes each child re-import the pytest runner and its dependency graph before the target runs, which fails on constrained CPU test agents before the queue lifecycle is reached.

The large NumPy arrays are packed into separate shared-memory segments before enqueue, so the MessageQueue payload contains only small handles and does not require vLLM default 240 MiB rings.

## Validation

- tests/diffusion/test_diffusion_ipc.py: 15 passed in 3.12s
- changed-file pre-commit hooks: passed
- git diff --check: passed

## Self-review

I verified that the same packed DiffusionOutput still traverses both per-worker pumps and that nested NumPy unpacking, process shutdown, and leak checks remain exercised. The change is test-only.