### PR TITLE
[Core] Add opt-in periodic prefill admission for VoxCPM2

### DIFF
--- a/docs/user_guide/examples/online_serving/text_to_speech.md
+++ b/docs/user_guide/examples/online_serving/text_to_speech.md
@@ -472,6 +472,17 @@ vllm serve openbmb/VoxCPM2 --omni --host 0.0.0.0 --port 8000
 ```
 Deploy config auto-loads from `vllm_omni/deploy/voxcpm2.yaml`. Pass `--deploy-config <path>` to override or `--stage-N-<field> <value>` for per-stage runtime tweaks.
 
+For latency-oriented serving, `unified_decode_graph_prefill_interval=N` admits
+waiting prefills for one scheduler iteration after every `N` decode-only
+iterations. The default `0` keeps decode-first admission. Positive values can
+reduce TTFP under concurrent load at the cost of peak throughput, so tune the
+interval for the target workload:
+
+```bash
+vllm serve openbmb/VoxCPM2 --omni \
+    --hf-overrides '{"voxcpm2_runtime_config":{"unified_decode_graph_prefill_interval":6}}'
+```
+
 ### Sending requests
 ```bash
 # Zero-shot synthesis

--- a/tests/core/sched/test_omni_ar_scheduler_unified_decode_deferral.py
+++ b/tests/core/sched/test_omni_ar_scheduler_unified_decode_deferral.py
@@ -7,6 +7,7 @@ from vllm.v1.request import RequestStatus
 
 import vllm_omni.core.sched.omni_ar_scheduler as scheduler_mod
 import vllm_omni.model_executor.models.voxcpm2.scheduler as voxcpm2_scheduler_mod
+from vllm_omni.model_executor.models.voxcpm2.runtime_config import _VoxCPM2RuntimeConfig
 from vllm_omni.model_executor.models.voxcpm2.scheduler import VoxCPM2OmniARAsyncScheduler
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
@@ -28,6 +29,12 @@ class _MockQueue:
     def add_request(self, request) -> None:
         self._items.append(request)
 
+    def pop_request(self):
+        return self._items.pop(0)
+
+    def prepend_request(self, request) -> None:
+        self._items.insert(0, request)
+
     def prepend_requests(self, requests) -> None:
         self._items = list(requests) + self._items
 
@@ -47,6 +54,7 @@ class _MockRequest:
         self.num_prompt_tokens = num_prompt_tokens
         self.num_computed_tokens = num_computed_tokens
         self.num_output_placeholders = num_output_placeholders
+        self._all_token_ids = list(range(num_computed_tokens))
 
     def is_finished(self) -> bool:
         return RequestStatus.is_finished(self.status)
@@ -62,6 +70,7 @@ def _make_scheduler(
     enable_unified_decode_graph: bool | None = True,
     deterministic_cfm_noise: bool = False,
     runtime_config_on_model_config: bool = False,
+    prefill_interval: int = 6,
 ) -> VoxCPM2OmniARAsyncScheduler:
     sched = VoxCPM2OmniARAsyncScheduler.__new__(VoxCPM2OmniARAsyncScheduler)
     hf_config = SimpleNamespace()
@@ -70,12 +79,18 @@ def _make_scheduler(
         runtime_config = SimpleNamespace(
             enable_unified_decode_graph=True if enable_unified_decode_graph is None else enable_unified_decode_graph,
             deterministic_cfm_noise=deterministic_cfm_noise,
+            unified_decode_graph_prefill_interval=prefill_interval,
         )
         if runtime_config_on_model_config:
             model_config.voxcpm2_runtime_config = runtime_config
         else:
             hf_config.voxcpm2_runtime_config = runtime_config
     sched.vllm_config = SimpleNamespace(model_config=model_config)
+    sched._decode_steps_since_prefill = 0
+    sched._temporarily_unscheduled_req_ids = set()
+    sched.max_num_running_reqs = 8
+    sched.num_waiting_for_streaming_input = 0
+    sched.requests = {}
     return sched
 
 
@@ -134,6 +149,87 @@ def test_voxcpm2_unified_decode_graph_does_not_defer_without_cuda_graph(monkeypa
     scheduler.waiting = _MockQueue([_MockRequest("prefill", status=RequestStatus.WAITING)])
 
     assert not scheduler._should_defer_waiting_for_unified_decode_graph()
+
+
+def test_voxcpm2_periodically_schedules_prefill_only_admission() -> None:
+    scheduler = _make_scheduler(prefill_interval=3)
+    scheduler.running = [_MockRequest("decode")]
+    scheduler.waiting = _MockQueue([_MockRequest("prefill", status=RequestStatus.WAITING)])
+
+    assert not scheduler._should_run_prefill_only_admission()
+    assert not scheduler._should_run_prefill_only_admission()
+    assert scheduler._should_run_prefill_only_admission()
+    assert scheduler._decode_steps_since_prefill == 0
+
+
+def test_voxcpm2_periodic_prefill_admission_is_opt_in() -> None:
+    scheduler = _make_scheduler(prefill_interval=0)
+    scheduler.running = [_MockRequest("decode")]
+    scheduler.waiting = _MockQueue([_MockRequest("prefill", status=RequestStatus.WAITING)])
+
+    for _ in range(12):
+        assert not scheduler._should_run_prefill_only_admission()
+    assert scheduler._decode_steps_since_prefill == 0
+
+
+def test_voxcpm2_prefill_interval_clamps_negative_values() -> None:
+    assert _VoxCPM2RuntimeConfig._coerce_value("unified_decode_graph_prefill_interval", -1, 0) == 0
+
+
+def test_voxcpm2_prefill_only_admission_waits_for_a_free_slot() -> None:
+    scheduler = _make_scheduler(prefill_interval=2)
+    scheduler.running = [_MockRequest(f"decode-{i}") for i in range(8)]
+    scheduler.waiting = _MockQueue([_MockRequest("prefill", status=RequestStatus.WAITING)])
+
+    assert not scheduler._should_run_prefill_only_admission()
+    assert not scheduler._should_run_prefill_only_admission()
+    assert scheduler._decode_steps_since_prefill == 1
+
+    scheduler.running.pop()
+    assert scheduler._should_run_prefill_only_admission()
+
+
+def test_temporarily_unscheduled_request_gets_async_resume_tokens() -> None:
+    scheduler = _make_scheduler()
+    request = _MockRequest("decode", num_computed_tokens=6)
+    scheduler.requests = {request.request_id: request}
+    scheduler._temporarily_unscheduled_req_ids = {request.request_id}
+    cached_reqs = SimpleNamespace(req_ids=[request.request_id], all_token_ids={})
+    scheduler_output = SimpleNamespace(scheduled_cached_reqs=cached_reqs)
+
+    scheduler._restore_temporarily_unscheduled_metadata(scheduler_output)
+
+    assert cached_reqs.all_token_ids == {request.request_id: request._all_token_ids}
+    assert not scheduler._temporarily_unscheduled_req_ids
+
+
+def test_prefill_only_admission_pauses_decode_and_restores_queues(monkeypatch) -> None:
+    scheduler = _make_scheduler(prefill_interval=1)
+    decode = _MockRequest("decode")
+    prefill = _MockRequest("prefill", status=RequestStatus.WAITING)
+    scheduler.running = [decode]
+    scheduler.waiting = _MockQueue([prefill])
+    scheduler.policy = "fcfs"
+    scheduler.chunk_transfer_adapter = None
+    scheduler.input_coordinator = None
+    scheduler._consume_pending_connector_output = lambda model_mode: None
+
+    monkeypatch.setattr(scheduler_mod, "create_request_queue", lambda _policy: _MockQueue())
+
+    def fake_upstream_schedule(self, throttle_prefills: bool = False):
+        assert not self.running
+        assert self.waiting._items == [prefill]
+        self.running.append(self.waiting.pop_request())
+        raise RuntimeError("stop after prefill admission")
+
+    monkeypatch.setattr(scheduler_mod.VLLMScheduler, "schedule", fake_upstream_schedule)
+
+    with pytest.raises(RuntimeError, match="stop after prefill admission"):
+        scheduler.schedule()
+
+    assert scheduler.running == [decode, prefill]
+    assert not scheduler.waiting
+    assert scheduler._temporarily_unscheduled_req_ids == {decode.request_id}
 
 
 def test_unified_decode_graph_deferral_restores_waiting_queue(monkeypatch) -> None:

--- a/tests/model_executor/models/voxcpm2/test_runner_assisted_unified_graph_static.py
+++ b/tests/model_executor/models/voxcpm2/test_runner_assisted_unified_graph_static.py
@@ -207,6 +207,7 @@ def test_voxcpm2_deploy_defaults_to_full_unified_graph_only():
     assert "max_num_seqs: 8" in source
     assert "enable_unified_decode_graph: true" in source
     assert "unified_decode_graph_max_batch_size: 8" in source
+    assert "unified_decode_graph_prefill_interval: 0" in source
     assert "unified_decode_graph_pre_capture_sizes" not in source
     assert "enable_runner_assisted_unified_decode_graph" not in source
     assert "allow_unified_decode_graph_batch_attention" not in source

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -107,6 +107,8 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         self._init_omni_io_scheduling_state()
         # Snapshot prompt length for each streaming input update
         self._new_prompt_len_snapshot: dict[str, int] = {}
+        # Requests paused for a prefill-only iteration.
+        self._temporarily_unscheduled_req_ids: set[str] = set()
 
     def _get_confirmed_num_computed_tokens(self, request: Request) -> int:
         """num_computed_tokens minus async placeholders (KV actually on GPU)."""
@@ -147,6 +149,26 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
 
     def _should_defer_waiting_admission(self) -> bool:
         return False
+
+    def _should_run_prefill_only_admission(self) -> bool:
+        """Whether this iteration should pause decode and admit prefills."""
+        return False
+
+    def _restore_temporarily_unscheduled_metadata(self, scheduler_output: SchedulerOutput) -> None:
+        """Attach async runner metadata when a paused request runs again."""
+        paused_req_ids = self._temporarily_unscheduled_req_ids
+        if not paused_req_ids:
+            return
+
+        cached_reqs = scheduler_output.scheduled_cached_reqs
+        resumed_req_ids = paused_req_ids.intersection(cached_reqs.req_ids)
+        for req_id in resumed_req_ids:
+            request = self.requests.get(req_id)
+            if request is not None:
+                cached_reqs.all_token_ids[req_id] = request._all_token_ids
+
+        paused_req_ids.difference_update(resumed_req_ids)
+        paused_req_ids.intersection_update(self.requests)
 
     def _process_kv_transfer_trigger(self, request: Request, new_token_ids: list[int]) -> bool:
         """
@@ -230,7 +252,28 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         self._process_pending_omni_inputs(model_mode="ar")
 
         original_waiting = None
-        if self._should_defer_waiting_admission():
+        paused_running = None
+        if self._should_run_prefill_only_admission():
+            original_running = self.running
+            paused_running = [
+                request
+                for request in original_running
+                if self._get_confirmed_num_computed_tokens(request) >= request.num_prompt_tokens
+            ]
+            prefill_running = [request for request in original_running if request not in paused_running]
+
+            original_waiting = self.waiting
+            self.waiting = create_request_queue(self.policy)
+            free_slots = max(
+                0,
+                self.max_num_running_reqs - len(original_running) - getattr(self, "num_waiting_for_streaming_input", 0),
+            )
+            for _ in range(min(free_slots, len(original_waiting))):
+                self.waiting.add_request(original_waiting.pop_request())
+
+            self.running = prefill_running
+            self._temporarily_unscheduled_req_ids.update(request.request_id for request in paused_running)
+        elif self._should_defer_waiting_admission():
             original_waiting = self.waiting
             self.waiting = create_request_queue(self.policy)
 
@@ -242,8 +285,11 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 if deferred_waiting:
                     original_waiting.prepend_requests(deferred_waiting)
                 self.waiting = original_waiting
+            if paused_running is not None:
+                self.running = paused_running + self.running
             self._restore_omni_wait_queues()
 
+        self._restore_temporarily_unscheduled_metadata(scheduler_output)
         self._postprocess_omni_schedule_output(
             scheduler_output,
             include_cached_payloads=True,

--- a/vllm_omni/deploy/voxcpm2.yaml
+++ b/vllm_omni/deploy/voxcpm2.yaml
@@ -43,7 +43,6 @@ stages:
           enable_loc_dit_reduce_overhead_no_cg: true
           enable_unified_decode_graph: true
           unified_decode_graph_max_batch_size: 8
-          # Positive values prioritize TTFA at a possible throughput cost.
           unified_decode_graph_prefill_interval: 0
     default_sampling_params:
       temperature: 0.0

--- a/vllm_omni/deploy/voxcpm2.yaml
+++ b/vllm_omni/deploy/voxcpm2.yaml
@@ -43,6 +43,8 @@ stages:
           enable_loc_dit_reduce_overhead_no_cg: true
           enable_unified_decode_graph: true
           unified_decode_graph_max_batch_size: 8
+          # Positive values prioritize TTFA at a possible throughput cost.
+          unified_decode_graph_prefill_interval: 0
     default_sampling_params:
       temperature: 0.0
       top_p: 1.0

--- a/vllm_omni/model_executor/models/voxcpm2/runtime_config.py
+++ b/vllm_omni/model_executor/models/voxcpm2/runtime_config.py
@@ -42,7 +42,6 @@ class _VoxCPM2RuntimeConfig:
     enable_batched_prefill_tail: bool = False
     enable_unified_decode_graph: bool = True
     unified_decode_graph_max_batch_size: int = 64
-    # Zero keeps decode-first scheduling; positive values prioritize TTFA.
     unified_decode_graph_prefill_interval: int = 0
 
     @classmethod

--- a/vllm_omni/model_executor/models/voxcpm2/runtime_config.py
+++ b/vllm_omni/model_executor/models/voxcpm2/runtime_config.py
@@ -42,6 +42,8 @@ class _VoxCPM2RuntimeConfig:
     enable_batched_prefill_tail: bool = False
     enable_unified_decode_graph: bool = True
     unified_decode_graph_max_batch_size: int = 64
+    # Zero keeps decode-first scheduling; positive values prioritize TTFA.
+    unified_decode_graph_prefill_interval: int = 0
 
     @classmethod
     def from_vllm_config(cls, vllm_config: Any) -> _VoxCPM2RuntimeConfig:
@@ -111,7 +113,13 @@ class _VoxCPM2RuntimeConfig:
             return bool(value)
         if isinstance(default, int) and not isinstance(default, bool):
             value = int(value)
-            if key in {"audio_emit_every", "vae_decode_every", "batched_fsq_fusion_max_batch"}:
+            if key == "unified_decode_graph_prefill_interval":
+                return max(0, value)
+            if key in {
+                "audio_emit_every",
+                "vae_decode_every",
+                "batched_fsq_fusion_max_batch",
+            }:
                 return max(1, value)
             return value
         if isinstance(default, float):

--- a/vllm_omni/model_executor/models/voxcpm2/scheduler.py
+++ b/vllm_omni/model_executor/models/voxcpm2/scheduler.py
@@ -21,6 +21,10 @@ class VoxCPM2OmniARAsyncScheduler(OmniARAsyncScheduler):
     scheduler rule.
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._decode_steps_since_prefill = 0
+
     def _unified_decode_graph_enabled(self) -> bool:
         runtime_config = _VoxCPM2RuntimeConfig.from_vllm_config(self.vllm_config)
         return runtime_config.unified_decode_graph_available(use_cuda_graph=current_omni_platform.is_cuda())
@@ -40,3 +44,24 @@ class VoxCPM2OmniARAsyncScheduler(OmniARAsyncScheduler):
 
     def _should_defer_waiting_admission(self) -> bool:
         return self._should_defer_waiting_for_unified_decode_graph()
+
+    def _should_run_prefill_only_admission(self) -> bool:
+        if not self._should_defer_waiting_for_unified_decode_graph():
+            self._decode_steps_since_prefill = 0
+            return False
+
+        runtime_config = _VoxCPM2RuntimeConfig.from_vllm_config(self.vllm_config)
+        interval = runtime_config.unified_decode_graph_prefill_interval
+        if interval <= 0:
+            return False
+        self._decode_steps_since_prefill += 1
+        if self._decode_steps_since_prefill < interval:
+            return False
+
+        occupied_slots = len(self.running) + getattr(self, "num_waiting_for_streaming_input", 0)
+        if occupied_slots >= self.max_num_running_reqs:
+            self._decode_steps_since_prefill = interval - 1
+            return False
+
+        self._decode_steps_since_prefill = 0
+        return True


### PR DESCRIPTION
## Purpose

VoxCPM2's unified decode graph currently defers waiting requests whenever a
decode-ready request is running. This preserves pure decode batches, but an
open-loop TTS workload can build substantial queue time while
`max_num_seqs` still has free slots. This is the behavior reported in #6365.

This PR adds an opt-in latency policy for that case. When
`unified_decode_graph_prefill_interval` is positive, the VoxCPM2 scheduler
pauses decode scheduling for one iteration after the configured number of
decode-only iterations and uses that iteration to admit waiting prefills. The
paused requests keep their request and KV-cache state and resume on the next
iteration.

The default is `0`, so existing deployments keep the current decode-first
behavior. A value of `6` was evaluated as a latency-oriented setting in the workload
below. This is intentionally a configuration knob rather than a new default:
periodic prefill admission reduces first-packet latency below saturation, but it also reduces
peak throughput.

## Test Plan

Unit tests were run against current `main` at
`c3f80502e00b564d7b74d43a5e21fbc6b9da2aed`:

```text
21 passed: focused VoxCPM2 scheduler/config tests
40 passed: tests/core/sched/test_omni_ar_scheduler*.py
```

The GPU A/B used a source-equivalent backport of this scheduler change because
the available host has a CUDA 12.9 PyTorch runtime, while current `main` targets
vLLM 0.27.0/CUDA 13.

- one NVIDIA H100 PCIe 80 GB; 24 vCPU; 36 GiB host RAM
- vLLM 0.26.0 and vLLM-Omni 0.26.0; BF16; FlashAttention 3
- `max_num_seqs=8`, `max_num_batched_tokens=4096`, `max_model_len=4096`
- `vae_decode_every=3`, `audio_emit_every=1`
- five Russian texts, 140–151 characters
- open-loop arrivals, 30 seconds per RPS level, `burstiness=100`
- eight warmup requests before every measured level
- raw PCM16 mono at 48 kHz (`stream=true`, `stream_format=audio`)

The benchmark is the repository's `openai-audio-speech` backend. It forces raw
PCM streaming and records `AUDIO_TTFP` on the first non-empty response-body
chunk, after HTTP headers. `AUDIO_RTF` is request wall time divided by generated
audio duration. Audio throughput is generated audio seconds divided by the
complete benchmark window.

The five-row dataset was stored as `$DATASET_ROOT/en/meta.lst`:

```text
ru001|||Здравствуйте! Ваш заказ уже собран и скоро будет передан курьеру. Пожалуйста, проверьте адрес доставки и оставайтесь на связи в течение дня.
ru002|||Добрый день! Напоминаем, что сегодня заканчивается срок хранения вашей посылки. Заберите её до закрытия пункта или продлите хранение в приложении.
ru003|||Уважаемый продавец, новый заказ ожидает подтверждения. Проверьте наличие товара, подготовьте упаковку и передайте отправление в ближайший пункт приёма.
ru004|||Ваша встреча назначена на завтра, на половину одиннадцатого утра. Если планы изменились, пожалуйста, выберите другое удобное время в личном кабинете.
ru005|||Платёж успешно принят, электронный чек уже доступен в приложении. Сохраните его до получения заказа и обратитесь в поддержку, если заметите ошибку.
```

The server used the same command for both runs; only the final interval changed
between `0` (stock) and `6`:

```bash
vllm-omni serve "$MODEL" --omni \
  --host :: --port 8000 --served-model-name voxcpm2 \
  --max-num-seqs 8 --max-num-batched-tokens 4096 \
  --gpu-memory-utilization 0.9 --max-model-len 4096 \
  --hf-overrides '{"voxcpm2_runtime_config":{"vae_decode_every":3,"audio_emit_every":1,"unified_decode_graph_prefill_interval":6}}'
```

The sweep used the checked-in Omni serving benchmark. `num_prompts = RPS * 30`
keeps the offered-load window at 30 seconds:

```bash
export VLLM_OMNI_BENCH_AUDIO_SAMPLE_RATE=48000

for rps in 1 2 3 4 5 6; do
  n=$((rps * 30))
  vllm-omni bench serve --omni \
    --backend openai-audio-speech \
    --base-url http://[::1]:8000 --endpoint /v1/audio/speech \
    --model "$MODEL" --served-model-name voxcpm2 --tokenizer "$MODEL" \
    --trust-remote-code \
    --dataset-name seed-tts-text --dataset-path "$DATASET_ROOT" \
    --seed-tts-locale en --disable-shuffle \
    --num-prompts "$n" --num-warmups 8 \
    --extra-body '{"voice":"default"}' \
    --request-rate "$rps" --burstiness 100 --max-concurrency 100 \
    --metric-percentiles 50,95 \
    --percentile-metrics audio_ttfp,audio_rtf,audio_duration,audio_underrun \
    --temperature 0 --seed 0 --disable-tqdm --save-result --save-detailed
done
```

## Test Result

The full sweep used `unified_decode_graph_prefill_interval=6` for the patched
run. Values are p50/p95; all requests completed without errors.

| RPS | stock TTFP, ms | interval 6 TTFP, ms | stock RTF | interval 6 RTF | stock audio throughput, s/s | interval 6 audio throughput, s/s |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 215 / 612 | 156 / 191 | 0.12 / 0.16 | 0.11 / 0.12 | 9.34 | 9.53 |
| 2 | 636 / 1142 | 199 / 209 | 0.17 / 0.22 | 0.13 / 0.14 | 18.38 | 18.77 |
| 3 | 687 / 1195 | 214 / 232 | 0.18 / 0.24 | 0.15 / 0.16 | 28.03 | 28.24 |
| 4 | 779 / 1451 | 237 / 249 | 0.20 / 0.27 | 0.18 / 0.19 | 37.42 | 37.43 |
| 5 | 876 / 1611 | 1656 / 2975 | 0.22 / 0.30 | 0.34 / 0.47 | 45.89 | 43.02 |
| 6 | 2658 / 4553 | 4727 / 8899 | 0.40 / 0.61 | 0.64 / 1.07 | 49.34 | 43.17 |

A separate PCM sanity check looked for the first 20 ms window with RMS above
100. At 4 RPS its median first-body-byte time was 257–258 ms and median audible
time was 261 ms, so the first packet is audio rather than an HTTP/SSE artifact.

The result is a latency/throughput trade-off, not a universal improvement. At
4 RPS the policy cuts TTFP p50 by 70% and p95 by 83% with equivalent audio
throughput. Above saturation, stock decode-first scheduling reaches about 49
audio-seconds/s, while interval 6 reaches about 43. That is why this PR leaves
the policy disabled by default.

Related: #6365
