### PR TITLE
[Bugfix] Build CUDA images on vLLM 0.27

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=vllm/vllm-openai:v0.26.0
+ARG BASE_IMAGE=vllm/vllm-openai:v0.27.0
 FROM ${BASE_IMAGE}
 
 ARG COMMON_WORKDIR=/app


### PR DESCRIPTION
## Summary

Update the default CUDA image base from vLLM 0.26 to vLLM 0.27.

vLLM-Omni main now uses vLLM 0.27 APIs, including the multimodal hasher helper. Release and nightly jobs build and publish docker/Dockerfile.cuda, so retaining the 0.26 base produces an image that installs current vLLM-Omni over an incompatible runtime.

## Validation

- changed-file pre-commit hooks: passed
- git diff --check: passed

## Self-review

I confirmed the release pipeline builds docker/Dockerfile.cuda and that no remaining Docker, Buildkite, requirements, or project pins reference vLLM 0.26.