### PR TITLE
[WIP][Refactor] Converge stage-init model path resolution onto shared weight util

### DIFF
--- a/tests/model_executor/model_loader/test_resolve_model_path.py
+++ b/tests/model_executor/model_loader/test_resolve_model_path.py
@@ -68,6 +68,19 @@ def test_cache_miss_propagates(paths):
     paths.download.assert_not_called()
 
 
+@pytest.mark.parametrize("allow_download", [False, True])
+def test_non_strict_falls_back_to_input(paths, allow_download):
+    """With strict=False a failed resolution degrades into the raw reference.
+
+    This is the best-effort contract stage init relies on for
+    model_subdir/tokenizer_subdir indirection.
+    """
+    paths.cache_only.side_effect = LocalEntryNotFoundError("cold cache")
+    paths.download.side_effect = OSError("offline")
+
+    assert resolve_model_to_local_path(REPO_ID, allow_download=allow_download, strict=False) == REPO_ID
+
+
 @pytest.mark.parametrize(
     ("kwargs", "allow_patterns"),
     [

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -47,6 +47,7 @@ from vllm_omni.entrypoints.stage_utils import _to_dict, set_stage_devices
 from vllm_omni.entrypoints.utils import filter_dataclass_kwargs, resolve_model_config_path
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniSamplingParams
 from vllm_omni.inputs.preprocess import OmniInputPreprocessor
+from vllm_omni.model_executor.model_loader.weight_utils import resolve_model_to_local_path
 from vllm_omni.outputs.output_processor import MultimodalOutputProcessor
 from vllm_omni.platforms import current_omni_platform
 from vllm_omni.quantization.inc_config import OmniINCConfig
@@ -79,24 +80,6 @@ class LogicalStageInitPlan:
     replicas: list[ReplicaInitPlan]
 
 
-def _resolve_model_to_local_path(model: str) -> str:
-    """Resolve an HF Hub model ID to a local cache path."""
-    if os.path.isdir(model):
-        return model
-
-    try:
-        from huggingface_hub import snapshot_download
-
-        # Keep init path resolution offline-friendly.
-        return snapshot_download(model, local_files_only=True)
-    except Exception:
-        logger.warning(
-            "[stage_init] Could not resolve %s to local snapshot; using as-is",
-            model,
-        )
-        return model
-
-
 def _resolve_model_tokenizer_paths(model: str, engine_args: dict[str, Any]) -> str:
     """Apply model_subdir/tokenizer_subdir indirections from stage engine args."""
     model_subdir = engine_args.pop("model_subdir", None)
@@ -104,7 +87,7 @@ def _resolve_model_tokenizer_paths(model: str, engine_args: dict[str, Any]) -> s
     if model_subdir is None and tokenizer_subdir is None:
         return model
 
-    resolved_base = _resolve_model_to_local_path(model)
+    resolved_base = resolve_model_to_local_path(model, strict=False)
 
     if model_subdir:
         model = os.path.join(resolved_base, model_subdir)

--- a/vllm_omni/model_executor/model_loader/weight_utils.py
+++ b/vllm_omni/model_executor/model_loader/weight_utils.py
@@ -111,8 +111,8 @@ def resolve_model_to_local_path(
             best-effort callers (e.g. stage init path indirection).
 
     Returns:
-        Path to a local directory containing the model files, or *model*
-        itself when ``strict=False`` and resolution fails.
+        Path to a local directory containing the model files,
+        or **model** itself when strict=False and resolution fails.
     """
     if os.path.isdir(model):
         return model

--- a/vllm_omni/model_executor/model_loader/weight_utils.py
+++ b/vllm_omni/model_executor/model_loader/weight_utils.py
@@ -94,9 +94,9 @@ def resolve_model_to_local_path(
     allow_download: bool = False,
     allow_patterns: list[str] | None = None,
     cache_dir: str | None = None,
+    strict: bool = True,
 ) -> str:
     """Resolve a model reference to a local directory.
-    Failure is always raised: whether a failure is fatal is the caller's decision.
 
     Args:
         model: A local directory or an HF Hub repo ID.
@@ -105,27 +105,38 @@ def resolve_model_to_local_path(
         allow_patterns: Restrict the fetch to these glob patterns.
             Defaults to the whole repository. Ignored when model is already a directory.
         cache_dir: Download cache location; None uses the HF default.
+        strict: When True (default), resolution failures propagate to the
+            caller, which decides whether they are fatal. When False, a
+            failure is logged and *model* is returned unchanged, for
+            best-effort callers (e.g. stage init path indirection).
 
     Returns:
-        Path to a local directory containing the model files.
+        Path to a local directory containing the model files, or *model*
+        itself when ``strict=False`` and resolution fails.
     """
     if os.path.isdir(model):
         return model
 
-    if allow_download:
-        return download_weights_from_hf_specific(
-            model_name_or_path=model,
-            cache_dir=cache_dir,
-            allow_patterns=allow_patterns or ["*"],
-            require_all=True,
-        )
+    try:
+        if allow_download:
+            return download_weights_from_hf_specific(
+                model_name_or_path=model,
+                cache_dir=cache_dir,
+                allow_patterns=allow_patterns or ["*"],
+                require_all=True,
+            )
 
-    # Cache-only lookups stay on huggingface_hub even under VLLM_USE_MODELSCOPE:
-    # ModelScope's snapshot_download has no local_files_only equivalent,
-    # so a ModelScope deployment that needs resolution here must pass allow_download.
-    return huggingface_hub.snapshot_download(
-        model,
-        cache_dir=cache_dir,
-        allow_patterns=allow_patterns,
-        local_files_only=True,
-    )
+        # Cache-only lookups stay on huggingface_hub even under VLLM_USE_MODELSCOPE:
+        # ModelScope's snapshot_download has no local_files_only equivalent,
+        # so a ModelScope deployment that needs resolution here must pass allow_download.
+        return huggingface_hub.snapshot_download(
+            model,
+            cache_dir=cache_dir,
+            allow_patterns=allow_patterns,
+            local_files_only=True,
+        )
+    except Exception:
+        if strict:
+            raise
+        logger.warning("Could not resolve %s to a local snapshot; using it as-is", model)
+        return model


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

A simple cleanup: this PR utilized weight-util `resolve_model_to_local_path` in stage init, to replace its private and specific helper function.

## Test Plan

Model loading tests with different types of loading model; I'll add later


**vLLM Version:** 0.27.0

**vLLM-Omni Commit:** `a630b0c2`

## Test Result

To add later


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
