### PR TITLE
[Bugfix] Complete deferred engine and request cleanup

### DIFF
--- a/tests/diffusion/test_inline_stage_diffusion_client.py
+++ b/tests/diffusion/test_inline_stage_diffusion_client.py
@@ -177,6 +177,37 @@ def test_inline_shutdown_runs_after_orchestrator_premark(client, mock_engine):
     mock_engine.close.assert_called_once()
 
 
+def test_inline_shutdown_retries_deferred_engine_cleanup(client, mock_engine):
+    mock_engine._shutdown_complete = False
+
+    def close_engine():
+        mock_engine._shutdown_complete = mock_engine.close.call_count >= 2
+
+    mock_engine.close.side_effect = close_engine
+
+    client.shutdown()
+
+    assert mock_engine.close.call_count == 2
+    assert client._shutdown_complete is True
+
+
+def test_inline_shutdown_remains_retryable_while_engine_cleanup_is_deferred(client, mock_engine):
+    mock_engine._shutdown_complete = False
+
+    def close_engine():
+        mock_engine._shutdown_complete = mock_engine.close.call_count >= 3
+
+    mock_engine.close.side_effect = close_engine
+
+    client.shutdown()
+    assert mock_engine.close.call_count == 2
+    assert client._shutdown_complete is False
+
+    client.shutdown()
+    assert mock_engine.close.call_count == 3
+    assert client._shutdown_complete is True
+
+
 def test_inline_registers_executor_failure_callback(client, mock_engine):
     mock_engine.executor.register_failure_callback.assert_called_once()
 

--- a/tests/engine/test_async_omni_engine_input.py
+++ b/tests/engine/test_async_omni_engine_input.py
@@ -426,6 +426,54 @@ def test_cfg_companion_processing_failure_admits_nothing(mocker: MockerFixture):
     engine.request_queue.sync_q.put.assert_not_called()
 
 
+def test_add_request_releases_preselected_replica_when_companion_build_fails(mocker: MockerFixture):
+    engine = object.__new__(AsyncOmniEngine)
+    params = SamplingParams(max_tokens=8)
+    engine.model = "test-model"
+    engine.default_sampling_params_list = [params]
+    engine.stage_metadata = [StageRuntimeInfo(final_output=False, final_output_type=None, stage_type="llm")]
+    engine.supported_tasks = ("generate",)
+    engine.prompt_expand_func = lambda *_args: [
+        ExpandedPrompt(
+            prompt={"prompt": "negative"},
+            role="cfg_text",
+            request_id_suffix="__cfg_text",
+        )
+    ]
+    engine.request_queue = mocker.Mock()
+
+    addr0 = "tcp://host-a:1000/input"
+    addr1 = "tcp://host-b:1000/input"
+    stage_pool = StagePool(0, [_FakeStageClient(addr0), _FakeStageClient(addr1)])
+    stage_pool.attach_hub(_FakeHub([_replica(addr0), _replica(addr1)]))
+    stage_pool.attach_load_balancer(_RoundRobinLB())
+    engine.stage_pools = [stage_pool]
+    engine._ensure_stage_replica_mm_uuids = mocker.Mock()
+
+    def process_inputs(**kwargs):
+        request_id = kwargs["request_id"]
+        if request_id.endswith("__cfg_text"):
+            raise RuntimeError("companion preprocessing failed")
+        return _make_engine_core_request(request_id)
+
+    engine.input_processor = mocker.Mock()
+    engine.input_processor.process_inputs.side_effect = process_inputs
+
+    with pytest.raises(RuntimeError, match="companion preprocessing failed"):
+        engine.add_request(
+            request_id="req",
+            prompt={
+                "prompt": "positive",
+                "multi_modal_data": {"image": "same-image"},
+            },
+            sampling_params_list=[params],
+            final_stage_id=1,
+        )
+
+    assert stage_pool.get_bound_replica_id("req") is None
+    engine.request_queue.sync_q.put.assert_not_called()
+
+
 def test_cfg_companion_build_returns_messages_without_enqueueing(mocker: MockerFixture):
     """Construction and admission are separate steps."""
     engine = object.__new__(AsyncOmniEngine)

--- a/vllm_omni/diffusion/inline_stage_diffusion_client.py
+++ b/vllm_omni/diffusion/inline_stage_diffusion_client.py
@@ -314,11 +314,13 @@ class InlineStageDiffusionClient(StageClientBase):
             for task in self._tasks.values():
                 task.cancel()
 
+            engine_shutdown_complete = False
             try:
                 # Stop the engine first so any control RPC running in the thread
                 # pool can observe shutdown instead of keeping stage teardown
                 # blocked while the executor waits for that RPC.
                 self._engine.close()
+                engine_shutdown_complete = bool(getattr(self._engine, "_shutdown_complete", True))
             except Exception:
                 pass
 
@@ -326,4 +328,15 @@ class InlineStageDiffusionClient(StageClientBase):
                 self._executor.shutdown(wait=True, cancel_futures=True)
             except Exception:
                 pass
-            self._shutdown_complete = True
+
+            # DiffusionEngine.close() defers scheduler/executor teardown while
+            # a generation is still leaving its worker thread. After client
+            # tasks have joined, retry once; if it is still deferred, leave
+            # this client retryable for a later shutdown call.
+            if not engine_shutdown_complete:
+                try:
+                    self._engine.close()
+                    engine_shutdown_complete = bool(getattr(self._engine, "_shutdown_complete", True))
+                except Exception:
+                    pass
+            self._shutdown_complete = engine_shutdown_complete

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1337,7 +1337,17 @@ class AsyncOmniEngine:
             effective_spl = msg.sampling_params_list
             stage0_params = effective_spl[0] if effective_spl else None
             if stage0_params is not None:
-                companions = self._build_cfg_companions(request_id, msg.original_prompt, stage0_params, effective_spl)
+                try:
+                    companions = self._build_cfg_companions(
+                        request_id,
+                        msg.original_prompt,
+                        stage0_params,
+                        effective_spl,
+                    )
+                except Exception:
+                    if self.stage_pools:
+                        self.stage_pools[0].release_binding(request_id)
+                    raise
 
         self.request_queue.sync_q.put(msg)
         for companion in companions:


### PR DESCRIPTION
## Summary

- retry DiffusionEngine.close after inline client tasks join, and keep shutdown retryable while engine teardown remains deferred
- release a preselected stage-0 replica binding when CFG companion construction fails before admission
- add regressions for deferred worker-thread teardown and multi-replica multimodal companion failures

These are both pre-admission/shutdown ownership leaks: the current inline client marks itself complete even when DiffusionEngine deliberately defers resource teardown, while a failed companion build leaves the parent request bound to a stage-0 replica even though nothing is enqueued.

## Validation

- inline client test file: 13 passed
- focused stage-binding regression: passed
- changed-file pre-commit hooks: passed
- git diff --check: passed

## Self-review

I verified that successful/ordinary shutdown remains idempotent, deferred shutdown retries after the client executor joins and remains callable if still incomplete, and the binding release occurs only on companion construction failure before the parent is admitted.