### PR TITLE
[Bugfix] Bound distributed diffusion runtime resources

### DIFF
--- a/tests/diffusion/ar_diffusion/test_capability_runner.py
+++ b/tests/diffusion/ar_diffusion/test_capability_runner.py
@@ -144,6 +144,23 @@ def make_runner(
     return runner
 
 
+def test_tp_available_memory_uses_minimum_rank_budget(monkeypatch):
+    runner = object.__new__(ARDiffusionModelRunner)
+    runner.device = torch.device("cpu")
+    tp_group = SimpleNamespace(world_size=2, device_group=object())
+    monkeypatch.setattr("vllm_omni.experimental.ar_diffusion.runner.dist.is_initialized", lambda: True)
+    monkeypatch.setattr("vllm_omni.experimental.ar_diffusion.runner.get_tp_group", lambda: tp_group)
+
+    def reduce_min(tensor, *, op, group):
+        assert op is torch.distributed.ReduceOp.MIN
+        assert group is tp_group.device_group
+        tensor.fill_(128)
+
+    monkeypatch.setattr("vllm_omni.experimental.ar_diffusion.runner.dist.all_reduce", reduce_min)
+
+    assert runner._minimum_tp_available_memory_bytes(256) == 128
+
+
 def commit_one_frame(runner: ARDiffusionModelRunner, session_id: str, kv_branch: str):
     state = runner._get_or_create_session(session_id)
     ctx = state.get_kv_caches(kv_branch, seq_len=BLOCK, commit_current=True)[0].forward_ctx

--- a/tests/diffusion/model_loader/test_diffusers_loader.py
+++ b/tests/diffusion/model_loader/test_diffusers_loader.py
@@ -477,6 +477,42 @@ def test_dlo_allgather_rejects_unvalidated_online_quant_method(monkeypatch):
         loader.load_model(load_device="cpu")
 
 
+def test_rank_local_dlo_allows_unvalidated_online_quant_method(monkeypatch):
+    import vllm_omni.diffusion.model_loader.diffusers_loader as loader_mod
+
+    class UnsupportedOnlineMethod:
+        uses_meta_device = True
+
+    od_config = _make_dlo_online_quant_config()
+    od_config.parallel_config.data_parallel_size = 1
+    loader = DiffusersPipelineLoader(LoadConfig(), od_config)
+    model = nn.Module()
+    model.transformer = nn.Linear(2, 2, bias=False)
+    model.transformer.quant_method = UnsupportedOnlineMethod()
+    calls: list[object] = []
+
+    loader._init_from_load_format = lambda *_args, **_kwargs: model  # type: ignore[method-assign]
+    loader._request_offload_after_quant = lambda _model: 1  # type: ignore[method-assign]
+    loader.load_weights = (  # type: ignore[method-assign]
+        lambda _model, *, stream_online_quant_to_cpu=False: calls.append(("load", stream_online_quant_to_cpu))
+    )
+    loader._process_weights_after_loading = lambda *_args: calls.append("process")  # type: ignore[method-assign]
+    loader._apply_skip_softmax_calibration = lambda _model: None  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        loader_mod,
+        "build_checkpoint_mmap_plan",
+        lambda *_args, **_kwargs: HostWeightPlanResult(None, "online quantization requires the ordinary loader"),
+    )
+    monkeypatch.setattr(
+        loader,
+        "_unsupported_dlo_allgather_online_quant_methods",
+        lambda _model: pytest.fail("rank-local DLO must not run the AllGather allowlist"),
+    )
+
+    assert loader.load_model(load_device="cpu", device=torch.device("cpu")) is model
+    assert calls == [("load", True), "process"]
+
+
 def test_hsdp_processes_quantized_weights_before_sharding(mocker):
     import vllm_omni.diffusion.model_loader.diffusers_loader as loader_mod
     from vllm_omni.diffusion.offloader.module_collector import PipelineModules

--- a/tests/diffusion/test_async_output_worker.py
+++ b/tests/diffusion/test_async_output_worker.py
@@ -37,6 +37,23 @@ def _make_worker_proc(step_execution=False):
     return proc
 
 
+def test_worker_result_queue_uses_bounded_ring(mocker):
+    proc = object.__new__(WorkerProc)
+    proc.gpu_id = 3
+    mq_cls = mocker.patch("vllm_omni.diffusion.worker.diffusion_worker.MessageQueue")
+
+    proc._init_result_mq()
+
+    mq_cls.assert_called_once_with(
+        n_reader=1,
+        n_local_reader=1,
+        local_reader_ranks=[0],
+        max_chunk_bytes=4 * 1024 * 1024,
+        max_chunks=4,
+    )
+    assert proc.result_mq_handle is mq_cls.return_value.export_handle.return_value
+
+
 class _OverlapDetectingQueue:
     """Fails if two threads are inside enqueue() at the same time.
 

--- a/vllm_omni/diffusion/model_loader/diffusers_loader.py
+++ b/vllm_omni/diffusion/model_loader/diffusers_loader.py
@@ -481,7 +481,7 @@ class DiffusersPipelineLoader:
                             planned_weights=self.host_weight_plan.bindings,
                         )
                 else:
-                    if _dist_offload and _use_ag and _has_online_quant:
+                    if _dist_offload and _use_ag and _dlo_group_size > 1 and _has_online_quant:
                         unsupported_methods = self._unsupported_dlo_allgather_online_quant_methods(model)
                         if unsupported_methods:
                             raise ValueError(

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -72,6 +72,9 @@ from vllm_omni.worker.gpu_memory_utils import get_process_gpu_memory
 
 logger = init_logger(__name__)
 
+_RESULT_QUEUE_MAX_CHUNK_BYTES = 4 * 1024 * 1024
+_RESULT_QUEUE_MAX_CHUNKS = 4
+
 _ASYNC_OUTPUT_THREAD_JOIN_TIMEOUT_S = 10.0
 # Maximum time (in seconds) to wait for pending background D2H / SHM packing
 # to drain before the worker executes memory-releasing lifecycle tasks
@@ -916,12 +919,7 @@ class WorkerProc:
         self.result_mq = None
         self.result_mq_handle = None
 
-        # Each worker creates its own result MessageQueue (as writer).
-        # The executor creates one reader per worker to collect responses.
-        # This supports DP multi-concurrency where all ranks reply independently.
-        self.result_mq = MessageQueue(n_reader=1, n_local_reader=1, local_reader_ranks=[0])
-        self.result_mq_handle = self.result_mq.export_handle()
-        logger.info(f"Worker {gpu_id} created result MessageQueue")
+        self._init_result_mq()
 
         assert od_config.master_port is not None
 
@@ -950,6 +948,18 @@ class WorkerProc:
     @staticmethod
     def _generate_async_output_id() -> str:
         return uuid.uuid4().hex
+
+    def _init_result_mq(self) -> None:
+        """Create a bounded per-worker queue for small SHM-handle envelopes."""
+        self.result_mq = MessageQueue(
+            n_reader=1,
+            n_local_reader=1,
+            local_reader_ranks=[0],
+            max_chunk_bytes=_RESULT_QUEUE_MAX_CHUNK_BYTES,
+            max_chunks=_RESULT_QUEUE_MAX_CHUNKS,
+        )
+        self.result_mq_handle = self.result_mq.export_handle()
+        logger.info("Worker %s created result MessageQueue", self.gpu_id)
 
     def _create_worker(
         self,

--- a/vllm_omni/experimental/ar_diffusion/runner.py
+++ b/vllm_omni/experimental/ar_diffusion/runner.py
@@ -6,6 +6,8 @@ import time
 from collections import OrderedDict
 
 import torch
+import torch.distributed as dist
+from vllm.distributed.parallel_state import get_tp_group
 from vllm.logger import init_logger
 
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
@@ -88,6 +90,17 @@ class ARDiffusionModelRunner(DiffusionModelRunner):
             raise RuntimeError("AR-Diffusion KV preallocation currently requires a CUDA device")
         return int(torch.cuda.mem_get_info(self.device)[0])
 
+    def _minimum_tp_available_memory_bytes(self, available_bytes: int) -> int:
+        """Use one conservative KV budget across every tensor-parallel rank."""
+        if not dist.is_initialized():
+            return available_bytes
+        tp_group = get_tp_group()
+        if tp_group.world_size <= 1:
+            return available_bytes
+        budget = torch.tensor(available_bytes, dtype=torch.int64, device=self.device)
+        dist.all_reduce(budget, op=dist.ReduceOp.MIN, group=tp_group.device_group)
+        return int(budget.item())
+
     def _preallocate_kv_cache(self, *, available_bytes: int | None = None) -> None:
         """Build pools solely from the pipeline capability and runner config."""
         if bool(getattr(self.od_config, "step_execution", False)):
@@ -123,6 +136,9 @@ class ARDiffusionModelRunner(DiffusionModelRunner):
         self.ar_diffusion_kv_config = config
         self._ar_diffusion_capability = capability
         self._ar_diffusion_kv_cache_spec = spec
+        effective_available_bytes = self._available_memory_bytes() if available_bytes is None else available_bytes
+        if available_bytes is None:
+            effective_available_bytes = self._minimum_tp_available_memory_bytes(effective_available_bytes)
         self.kv_cache = ARDiffusionKVCache(
             config,
             num_layers=spec.num_layers,
@@ -131,7 +147,7 @@ class ARDiffusionModelRunner(DiffusionModelRunner):
             dtype=self.od_config.dtype,
             block_size=spec.tokens_per_frame,
             max_model_len=spec.max_model_len,
-            available_bytes=self._available_memory_bytes() if available_bytes is None else available_bytes,
+            available_bytes=effective_available_bytes,
             kv_branches=spec.kv_branches,
             session_capacity=spec.session_capacity,
             cross_attention_lengths=spec.cross_attention_lengths,


### PR DESCRIPTION
## Summary

- bound each worker-owned result MessageQueue to a 16 MiB ring instead of vLLM default 240 MiB
- skip DLO AllGather online-quant allowlist rejection when the effective DLO group has one rank
- reduce AR-Diffusion available memory with MIN across the tensor-parallel group before sizing resident sessions
- add focused regressions for all three contracts

Large diffusion tensors already travel through separate shared-memory handles above the 1 MB packing threshold, so result queues carry small envelopes. Rank-local DLO has no collective layout restriction, and AR-Diffusion TP ranks must use the same session capacity to keep eviction and collective order synchronized.

## Validation

- three new focused regressions: 4 passed
- changed-file pre-commit hooks: passed
- git diff --check: passed

## Self-review

I verified the queue budget remains four chunks with 4 MiB per envelope, existing multi-rank DLO rejection remains covered, explicit AR test budgets are unchanged, and only production auto-detected AR memory is synchronized across TP ranks.