### PR TITLE
[Test] Support TOML parsing on Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
 [project.optional-dependencies]
 
 dev = [
+    "tomli>=2.0.0; python_version < '3.11'",
     "pytest==9.1.1",
     "pytest-asyncio==1.4.0",
     "pytest-cov==7.1.0",

--- a/tests/test_indextts2_optional_dependencies.py
+++ b/tests/test_indextts2_optional_dependencies.py
@@ -9,8 +9,12 @@ import types
 from pathlib import Path
 
 import pytest
-import tomllib
 from packaging.requirements import Requirement
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 


### PR DESCRIPTION
## Summary

- fall back to tomli when tomllib is unavailable on Python 3.10
- declare the conditional Python 3.10 development dependency

The project advertises Python 3.10 support, but the new IndexTTS2 optional-dependency test imported the Python 3.11-only tomllib module during collection.

## Validation

- IndexTTS2 optional-dependency tests: 6 passed
- changed-file pre-commit hooks: passed
- git diff --check: passed

## Self-review

I matched the existing conditional import pattern in tests/helpers/mark.py and scoped tomli to development installs on Python versions below 3.11.