### PR TITLE
[Bugfix] Isolate synchronous replica failures by request

### DIFF
--- a/tests/engine/test_orchestrator_error_handling.py
+++ b/tests/engine/test_orchestrator_error_handling.py
@@ -503,7 +503,7 @@ async def test_handle_dead_replica_fails_only_bound_requests() -> None:
         assert r0.shutdown_calls == 1
         msg = queues[1].async_q.get_nowait()
         assert isinstance(msg, ErrorMessage)
-        assert msg.fatal is True
+        assert msg.fatal is False
         assert msg.request_id == "req-0"
         assert msg.stage_id == 0
         assert "replica-0 dead" in msg.error
@@ -737,7 +737,7 @@ async def test_dispatch_death_evicts_so_subsequent_requests_reroute_to_survivor(
         assert r0.shutdown_calls == 1
         assert r1.shutdown_calls == 0
         msg = queues[1].async_q.get_nowait()
-        assert isinstance(msg, ErrorMessage) and msg.fatal is True and msg.request_id == "req-dead"
+        assert isinstance(msg, ErrorMessage) and msg.fatal is False and msg.request_id == "req-dead"
         assert queues[1].async_q.empty()
         assert "req-dead" not in orchestrator.request_states
         assert "req-live" in orchestrator.request_states and pool.get_bound_replica_id("req-live") == 1

--- a/tests/entrypoints/test_omni_entrypoints.py
+++ b/tests/entrypoints/test_omni_entrypoints.py
@@ -1183,6 +1183,40 @@ def test_omni_base_errored_false_when_stage_resources_engine_dead():
 # ───────── Omni (sync) EngineDeadError / EngineGenerateError ─────────
 
 
+def _enqueue_request_failure_or_success(engine: FakeAsyncOmniEngine, msg: dict[str, Any]) -> None:
+    if msg["prompt"] == "fail":
+        engine.output_q.put_nowait(
+            ErrorMessage(
+                request_id=msg["request_id"],
+                stage_id=0,
+                error="replica failed",
+            )
+        )
+    else:
+        _enqueue_async_diffusion_only_output(engine, msg)
+
+
+def test_sync_omni_request_error_does_not_abort_surviving_batch_request(monkeypatch: pytest.MonkeyPatch):
+    engine = FakeAsyncOmniEngine(
+        stage_metadata=[THREE_STAGE_META[-1]],
+        on_add_request=_enqueue_request_failure_or_success,
+    )
+    _patch_engine(monkeypatch, engine)
+    app = Omni("dummy-model")
+    try:
+        outputs = app.generate(["fail", "survive"], use_tqdm=False)
+    finally:
+        app.shutdown()
+
+    assert len(outputs) == 2
+    failed = next(output for output in outputs if output.error is not None)
+    succeeded = next(output for output in outputs if output.error is None)
+    assert failed.error == "replica failed"
+    assert failed.finished is True
+    assert succeeded.finished is True
+    assert engine.aborted == []
+
+
 def test_omni_propagates_engine_dead_error(monkeypatch: pytest.MonkeyPatch):
     """When the engine is dead and a stage error output arrives,
     ``Omni.generate()`` must raise ``EngineDeadError``."""

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -1098,7 +1098,7 @@ class Orchestrator:
                 await self.output_async_queue.put(
                     ErrorMessage(
                         error=str(error),
-                        fatal=True,
+                        fatal=not stage_has_live,
                         request_id=req_id,
                         stage_id=stage_id,
                     )
@@ -1202,9 +1202,10 @@ class Orchestrator:
                 dead_replica,
                 e,
             )
-            await self._fail_request_dead_stage(req_id, stage_id)
             if dead_replica is not None and dead_replica in pool.live_replica_ids():
                 await self._handle_dead_replica(stage_id, dead_replica, e)
+            else:
+                await self._fail_request_dead_stage(req_id, stage_id)
             return False
 
     # ---- Shared helpers ----

--- a/vllm_omni/entrypoints/omni.py
+++ b/vllm_omni/entrypoints/omni.py
@@ -10,7 +10,7 @@ from tqdm.auto import tqdm
 from vllm.logger import init_logger
 from vllm.sampling_params import RequestOutputKind
 
-from vllm_omni.engine.messages import OutputMessage
+from vllm_omni.engine.messages import ErrorMessage, OutputMessage
 from vllm_omni.entrypoints.client_request_state import ClientRequestState
 from vllm_omni.entrypoints.omni_base import OmniBase
 from vllm_omni.metrics.stats import OrchestratorAggregator as OrchestratorMetrics
@@ -169,6 +169,29 @@ class Omni(OmniBase):
 
             while active_reqs:
                 msg = self.engine.try_get_output()
+
+                # A request-scoped replica failure is terminal for that request,
+                # not for the shared synchronous batch. Surface it as one error
+                # output and keep consuming results from surviving replicas.
+                if (
+                    isinstance(msg, ErrorMessage)
+                    and not msg.fatal
+                    and msg.request_id is not None
+                    and msg.request_id in active_reqs
+                ):
+                    error_output = OmniRequestOutput.from_error(
+                        msg.request_id,
+                        msg.error,
+                        status_code=msg.status_code,
+                        error_type=msg.error_type,
+                    )
+                    error_output.stage_id = msg.stage_id
+                    active_reqs.discard(msg.request_id)
+                    if pbar is not None:
+                        pbar.update(1)
+                    self._log_summary_and_cleanup(msg.request_id)
+                    yield error_output
+                    continue
 
                 should_continue, req_id, stage_id, req_state = self._handle_output_message(msg)
                 if should_continue:


### PR DESCRIPTION
## Summary

- mark dead-replica errors request-scoped when the stage still has a surviving replica
- evict a replica before emitting the current dispatch failure so survivor awareness is correct
- make synchronous Omni generation turn request-scoped errors into terminal OmniRequestOutput values and continue the shared batch
- retain fatal behavior when a stage has no surviving replica

Previously a two-request synchronous batch could lose one replica and receive fatal=True for only the bound request; Omni then raised out of the shared loop, aborted the unrelated survivor, and closed the client.

## Validation

- dead-replica isolation regressions: 3 passed
- synchronous two-request survivor regression: passed
- changed-file pre-commit hooks: passed
- git diff --check: passed

## Self-review

I checked both poll-time and submit-time replica death. Requests on surviving replicas remain bound and complete, while last-replica loss remains fatal and preserves existing engine-dead behavior.