### PR TITLE
[Bugfix] Validate video references before generation

### DIFF
--- a/tests/entrypoints/openai_api/test_video_server.py
+++ b/tests/entrypoints/openai_api/test_video_server.py
@@ -700,7 +700,7 @@ def test_r5_mixed_image_video_audio_references_and_fanout(test_client, mocker: M
     )
     test_client.app.state.openai_serving_video._engine_client.model_class_name = "MiniMaxH3Pipeline"
     response = test_client.post(
-        "/v1/videos",
+        "/v1/videos/sync",
         data={
             "prompt": "Use both references.",
             "image_reference": json.dumps(
@@ -721,8 +721,6 @@ def test_r5_mixed_image_video_audio_references_and_fanout(test_client, mocker: M
     )
 
     assert response.status_code == 200
-    video_id = response.json()["id"]
-    _wait_for_status(test_client, video_id, VideoGenerationStatus.COMPLETED.value)
     engine = test_client.app.state.openai_serving_video._engine_client
     multi_modal_data = engine.captured_prompt["multi_modal_data"]
     assert len(multi_modal_data["image"]) == 2
@@ -733,6 +731,19 @@ def test_r5_mixed_image_video_audio_references_and_fanout(test_client, mocker: M
     assert b"ftyp" in engine.captured_reference_video_bytes[0][:32]
     assert isinstance(multi_modal_data["audio"], str)
     assert engine.captured_sampling_params_list[0].num_outputs_per_prompt == 2
+
+
+def test_async_video_endpoint_rejects_multiple_outputs(test_client):
+    engine = test_client.app.state.openai_serving_video._engine_client
+
+    response = test_client.post(
+        "/v1/videos",
+        data={"prompt": "fan out", "num_outputs_per_prompt": "2"},
+    )
+
+    assert response.status_code == 400
+    assert "num_outputs_per_prompt=1" in response.json()["detail"]
+    assert engine.captured_prompt is None
 
 
 @pytest.mark.parametrize("endpoint", ["/v1/videos", "/v1/videos/sync"])
@@ -1493,6 +1504,120 @@ async def test_h3_upload_limit_checks_declared_size_before_read():
             OversizedUpload(),
             max_bytes=api_server.MINIMAX_H3_MAX_REFERENCE_IMAGE_BYTES,
         )
+
+
+@pytest.mark.parametrize(
+    ("field", "items", "message"),
+    [
+        ("image_reference", [{"image_url": "https://example.com/image.png"}] * 10, "at most 9 image"),
+        ("video_reference", [{"video_url": "https://example.com/video.mp4"}] * 4, "at most 3 video"),
+        ("audio_reference", [{"audio_url": "https://example.com/audio.mp3"}] * 4, "at most 3 audio"),
+    ],
+)
+def test_h3_typed_reference_counts_are_rejected_before_decode(
+    test_client,
+    mocker: MockerFixture,
+    field: str,
+    items: list[dict[str, str]],
+    message: str,
+):
+    test_client.app.state.openai_serving_video._engine_client.model_class_name = "MiniMaxH3Pipeline"
+    decode_input = mocker.patch(
+        "vllm_omni.entrypoints.openai.api_server.decode_input_reference",
+        new=mocker.AsyncMock(side_effect=AssertionError("oversized list must not be decoded")),
+    )
+    decode_audio = mocker.patch(
+        "vllm_omni.entrypoints.openai.api_server.decode_audio_url",
+        new=mocker.AsyncMock(side_effect=AssertionError("oversized list must not be decoded")),
+    )
+
+    response = test_client.post(
+        "/v1/videos/sync",
+        data={"prompt": "too many references", field: json.dumps(items)},
+    )
+
+    assert response.status_code == 400
+    assert message in response.json()["detail"]
+    decode_input.assert_not_called()
+    decode_audio.assert_not_called()
+
+
+def test_h3_total_typed_reference_count_is_rejected_before_decode(test_client, mocker: MockerFixture):
+    test_client.app.state.openai_serving_video._engine_client.model_class_name = "MiniMaxH3Pipeline"
+    decode_input = mocker.patch(
+        "vllm_omni.entrypoints.openai.api_server.decode_input_reference",
+        new=mocker.AsyncMock(side_effect=AssertionError("oversized list must not be decoded")),
+    )
+    decode_audio = mocker.patch(
+        "vllm_omni.entrypoints.openai.api_server.decode_audio_url",
+        new=mocker.AsyncMock(side_effect=AssertionError("oversized list must not be decoded")),
+    )
+
+    response = test_client.post(
+        "/v1/videos/sync",
+        data={
+            "prompt": "too many total references",
+            "image_reference": json.dumps([{"image_url": "https://example.com/image.png"}] * 9),
+            "video_reference": json.dumps([{"video_url": "https://example.com/video.mp4"}] * 3),
+            "audio_reference": json.dumps([{"audio_url": "https://example.com/audio.mp3"}]),
+        },
+    )
+
+    assert response.status_code == 400
+    assert "at most 12 total references" in response.json()["detail"]
+    decode_input.assert_not_called()
+    decode_audio.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("field", "constant", "data_url"),
+    [
+        ("image_reference", "MINIMAX_H3_MAX_REFERENCE_IMAGE_BYTES", "data:image/png;base64,YWJjZGU="),
+        ("video_reference", "MINIMAX_H3_MAX_REFERENCE_VIDEO_BYTES", "data:video/mp4;base64,YWJjZGU="),
+        ("audio_reference", "MINIMAX_H3_MAX_REFERENCE_AUDIO_BYTES", "data:audio/mp3;base64,YWJjZGU="),
+    ],
+)
+def test_h3_typed_reference_payload_limits(
+    test_client,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    constant: str,
+    data_url: str,
+):
+    test_client.app.state.openai_serving_video._engine_client.model_class_name = "MiniMaxH3Pipeline"
+    monkeypatch.setattr(api_server, constant, 4)
+    url_field = {"image_reference": "image_url", "video_reference": "video_url", "audio_reference": "audio_url"}[field]
+
+    response = test_client.post(
+        "/v1/videos/sync",
+        data={"prompt": "oversized reference", field: json.dumps({url_field: data_url})},
+    )
+
+    assert response.status_code == 400
+    assert "size limit" in response.json()["detail"]
+
+
+def test_malformed_audio_data_url_cleans_persisted_video_reference(test_client, mocker: MockerFixture, tmp_path):
+    source_path = tmp_path / "decoded.mp4"
+    source_path.write_bytes(b"video")
+    frames = video_api_utils.VideoFrames([Image.new("RGB", (8, 6))], source_path=str(source_path))
+    mocker.patch(
+        "vllm_omni.entrypoints.openai.api_server.decode_input_reference",
+        new=mocker.AsyncMock(return_value=frames),
+    )
+
+    response = test_client.post(
+        "/v1/videos/sync",
+        data={
+            "prompt": "malformed audio",
+            "video_reference": json.dumps({"video_url": "https://example.com/video.mp4"}),
+            "audio_reference": json.dumps({"audio_url": "data:audio/mp3;base64"}),
+        },
+    )
+
+    assert response.status_code == 400
+    assert "malformed audio data URL" in response.json()["detail"]
+    assert not source_path.exists()
 
 
 def test_invalid_seconds_returns_422(test_client):

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -167,6 +167,9 @@ MINIMAX_H3_MAX_REFERENCE_IMAGE_BYTES = 30 * 1024 * 1024
 MINIMAX_H3_MAX_REFERENCE_VIDEO_BYTES = 50 * 1024 * 1024
 MINIMAX_H3_MAX_REFERENCE_AUDIO_BYTES = 15 * 1024 * 1024
 MINIMAX_H3_MAX_REFERENCE_COUNT = 12
+MINIMAX_H3_MAX_REFERENCE_IMAGE_COUNT = 9
+MINIMAX_H3_MAX_REFERENCE_VIDEO_COUNT = 3
+MINIMAX_H3_MAX_REFERENCE_AUDIO_COUNT = 3
 MINIMAX_H3_REFERENCE_IMAGE_FORMATS = frozenset({"jpeg", "png", "webp", "heic", "heif"})
 MINIMAX_H3_REFERENCE_VIDEO_SUFFIXES = frozenset({".mp4", ".mov"})
 MINIMAX_H3_REFERENCE_AUDIO_SUFFIXES = frozenset({".wav", ".mp3"})
@@ -3196,6 +3199,30 @@ async def _persist_uploaded_media_references(
     return images, videos, audios
 
 
+def _validate_minimax_h3_typed_reference_counts(
+    image_items: list[Any],
+    video_items: list[Any],
+    audio_items: list[Any],
+) -> None:
+    counts = (
+        ("image", len(image_items), MINIMAX_H3_MAX_REFERENCE_IMAGE_COUNT),
+        ("video", len(video_items), MINIMAX_H3_MAX_REFERENCE_VIDEO_COUNT),
+        ("audio", len(audio_items), MINIMAX_H3_MAX_REFERENCE_AUDIO_COUNT),
+    )
+    for kind, count, maximum in counts:
+        if count > maximum:
+            raise HTTPException(
+                status_code=HTTPStatus.BAD_REQUEST.value,
+                detail=f"MiniMax H3 accepts at most {maximum} {kind} references.",
+            )
+    total = len(image_items) + len(video_items) + len(audio_items)
+    if total > MINIMAX_H3_MAX_REFERENCE_COUNT:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST.value,
+            detail=f"MiniMax H3 accepts at most {MINIMAX_H3_MAX_REFERENCE_COUNT} total references.",
+        )
+
+
 async def _parse_video_form(
     raw_request: Request,
     prompt: str = Form(...),
@@ -3335,6 +3362,11 @@ async def _parse_video_form(
         )
 
     supports_mixed_reference_inputs = bool(getattr(handler, "supports_mixed_reference_inputs", False))
+    image_items = _reference_list(request.image_reference)
+    video_items = _reference_list(request.video_reference)
+    audio_items = _reference_list(request.audio_reference)
+    if supports_mixed_reference_inputs:
+        _validate_minimax_h3_typed_reference_counts(image_items, video_items, audio_items)
     if input_reference is not None:
         input_reference_bytes = await _read_upload_limited(
             input_reference,
@@ -3375,11 +3407,14 @@ async def _parse_video_form(
     else:
         video_paths: list[str] = []
         try:
-            image_items = _reference_list(request.image_reference)
-            video_items = _reference_list(request.video_reference)
             image_data = []
             for item in image_items:
-                media_data = await decode_input_reference(item, None, None)
+                media_data = await decode_input_reference(
+                    item,
+                    None,
+                    None,
+                    max_image_bytes=MINIMAX_H3_MAX_REFERENCE_IMAGE_BYTES if supports_mixed_reference_inputs else None,
+                )
                 if not isinstance(media_data, Image.Image):
                     raise InvalidInputReferenceError("image_reference did not decode to an image")
                 image_data.append(media_data)
@@ -3392,6 +3427,7 @@ async def _parse_video_form(
                     None,
                     max_video_frames=decode_spec.max_frames,
                     video_keep=decode_spec.keep,
+                    max_video_bytes=MINIMAX_H3_MAX_REFERENCE_VIDEO_BYTES if supports_mixed_reference_inputs else None,
                 )
                 if not isinstance(media_data, VideoFrames):
                     raise InvalidInputReferenceError("video_reference did not decode to a video")
@@ -3435,15 +3471,22 @@ async def _parse_video_form(
     audio_paths = [] if reference_audio is None else list(_reference_list(reference_audio.path))
     if request.audio_reference is not None:
         try:
-            for audio_reference in _reference_list(request.audio_reference):
-                audio_paths.append(await decode_audio_url(audio_reference.audio_url))
-        except InvalidInputReferenceError as exc:
+            for audio_reference in audio_items:
+                audio_paths.append(
+                    await decode_audio_url(
+                        audio_reference.audio_url,
+                        max_bytes=MINIMAX_H3_MAX_REFERENCE_AUDIO_BYTES if supports_mixed_reference_inputs else None,
+                    )
+                )
+        except Exception as exc:
             _cleanup_video_references(reference_video, reference_audio)
             cleanup_paths = set(() if reference_audio is None else reference_audio.cleanup_paths)
             for path in audio_paths:
                 if path not in cleanup_paths and os.path.exists(path):
                     os.unlink(path)
-            raise HTTPException(400, detail=str(exc)) from exc
+            if isinstance(exc, InvalidInputReferenceError):
+                raise HTTPException(400, detail=str(exc)) from exc
+            raise
     if audio_paths:
         cleanup_paths = (
             tuple(audio_paths)
@@ -3485,6 +3528,12 @@ async def create_video(
     persists a queued job record, and starts generation in the background.
     """
     request, handler, effective_model_name, reference_image, reference_video, reference_audio = ctx
+    if request.num_outputs_per_prompt != 1:
+        _cleanup_video_references(reference_video, reference_audio)
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST.value,
+            detail="The asynchronous video endpoint currently supports num_outputs_per_prompt=1 only.",
+        )
     ref = video_response_from_request(effective_model_name, request)
     await VIDEO_STORE.upsert(ref.id, ref)
     task = asyncio.create_task(

--- a/vllm_omni/entrypoints/openai/video_api_utils.py
+++ b/vllm_omni/entrypoints/openai/video_api_utils.py
@@ -153,10 +153,18 @@ def _decode_media_bytes(
             ) from video_exc
 
 
-def _decode_base64_image(input_reference: str, *, source: str) -> Image.Image:
+def _validate_payload_size(payload: bytes, *, max_bytes: int | None, source: str) -> None:
+    if max_bytes is not None and len(payload) > max_bytes:
+        raise InvalidInputReferenceError(f"Invalid {source}: payload exceeds the {max_bytes}-byte size limit.")
+
+
+def _decode_base64_image(input_reference: str, *, source: str, max_bytes: int | None = None) -> Image.Image:
     if input_reference:
         if input_reference.startswith("data:image"):
-            _, b64_data = input_reference.split(",", 1)
+            try:
+                _, b64_data = input_reference.split(",", 1)
+            except ValueError as exc:
+                raise InvalidInputReferenceError(f"Invalid {source}: malformed image data URL.") from exc
         else:
             b64_data = input_reference
 
@@ -164,13 +172,14 @@ def _decode_base64_image(input_reference: str, *, source: str) -> Image.Image:
             image_bytes = base64.b64decode(b64_data)
         except (binascii.Error, ValueError) as exc:  # pragma: no cover - malformed base64
             raise InvalidInputReferenceError(f"Invalid {source}: image data is not valid base64.") from exc
+        _validate_payload_size(image_bytes, max_bytes=max_bytes, source=source)
         return _decode_image_bytes(image_bytes, source=source)
     raise InvalidInputReferenceError(f"Invalid {source}: image data is empty.")
 
 
-async def decode_image_url(image_url: str) -> Image.Image:
+async def decode_image_url(image_url: str, *, max_bytes: int | None = None) -> Image.Image:
     if image_url.startswith("data:image"):
-        return _decode_base64_image(image_url, source="image_reference.image_url")
+        return _decode_base64_image(image_url, source="image_reference.image_url", max_bytes=max_bytes)
 
     if image_url.startswith(("http://", "https://")):
         allow_redirects = envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS
@@ -191,6 +200,7 @@ async def decode_image_url(image_url: str) -> Image.Image:
                 raise InvalidInputReferenceError(
                     "Invalid image_reference.image_url: failed to download image."
                 ) from exc
+        _validate_payload_size(response.content, max_bytes=max_bytes, source="image_reference.image_url")
         return _decode_image_bytes(response.content, source="image_reference.image_url")
 
     raise InvalidInputReferenceError("Invalid image_reference.image_url: must be an http(s) URL or data URL.")
@@ -203,10 +213,14 @@ def _decode_base64_video(
     max_frames: int | None = None,
     keep: Literal["first", "last"] = "first",
     source_path: str | None = None,
+    max_bytes: int | None = None,
 ) -> VideoFrames:
     if video_reference:
         if video_reference.startswith("data:video"):
-            _, b64_data = video_reference.split(",", 1)
+            try:
+                _, b64_data = video_reference.split(",", 1)
+            except ValueError as exc:
+                raise InvalidInputReferenceError(f"Invalid {source}: malformed video data URL.") from exc
         else:
             b64_data = video_reference
 
@@ -214,6 +228,7 @@ def _decode_base64_video(
             video_bytes = base64.b64decode(b64_data)
         except (binascii.Error, ValueError) as exc:  # pragma: no cover - malformed base64
             raise InvalidInputReferenceError(f"Invalid {source}: video data is not valid base64.") from exc
+        _validate_payload_size(video_bytes, max_bytes=max_bytes, source=source)
         if source_path is not None:
             with open(source_path, "wb") as output:
                 output.write(video_bytes)
@@ -232,6 +247,7 @@ async def decode_video_url(
     *,
     max_frames: int | None = None,
     keep: Literal["first", "last"] = "first",
+    max_bytes: int | None = None,
 ) -> VideoFrames:
     if video_url.startswith("data:video"):
         path = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4").name
@@ -242,6 +258,7 @@ async def decode_video_url(
                 max_frames=max_frames,
                 keep=keep,
                 source_path=path,
+                max_bytes=max_bytes,
             )
         except Exception:
             if os.path.exists(path):
@@ -257,6 +274,7 @@ async def decode_video_url(
                 raise InvalidInputReferenceError(
                     "Invalid video_reference.video_url: failed to download video."
                 ) from exc
+        _validate_payload_size(response.content, max_bytes=max_bytes, source="video_reference.video_url")
         path = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4").name
         try:
             with open(path, "wb") as output:
@@ -281,14 +299,17 @@ async def decode_video_url(
     raise InvalidInputReferenceError("Invalid video_reference.video_url: must be an http(s) URL or data URL.")
 
 
-async def decode_audio_url(audio_url: str) -> str:
+async def decode_audio_url(audio_url: str, *, max_bytes: int | None = None) -> str:
     """Decode an audio URL or data-URL to a temporary file path."""
     import tempfile
 
     audio_bytes: bytes | None = None
 
     if audio_url.startswith("data:audio"):
-        _, b64_data = audio_url.split(",", 1)
+        try:
+            _, b64_data = audio_url.split(",", 1)
+        except ValueError as exc:
+            raise InvalidInputReferenceError("Invalid audio_reference.audio_url: malformed audio data URL.") from exc
         try:
             audio_bytes = base64.b64decode(b64_data)
         except (binascii.Error, ValueError) as exc:
@@ -310,6 +331,7 @@ async def decode_audio_url(audio_url: str) -> str:
 
     if not audio_bytes:
         raise InvalidInputReferenceError("Invalid audio_reference: audio data is empty.")
+    _validate_payload_size(audio_bytes, max_bytes=max_bytes, source="audio_reference.audio_url")
 
     suffix = ".wav"
     if audio_url.startswith("data:audio/"):
@@ -335,6 +357,8 @@ async def decode_input_reference(
     *,
     max_video_frames: int | None = None,
     video_keep: Literal["first", "last"] = "first",
+    max_image_bytes: int | None = None,
+    max_video_bytes: int | None = None,
 ) -> Image.Image | VideoFrames | None:
     """Decode media input from multipart bytes, data URLs, or typed references."""
 
@@ -351,7 +375,7 @@ async def decode_input_reference(
         )
 
     if isinstance(image_reference, UrlImageReference):
-        return await decode_image_url(image_reference.image_url)
+        return await decode_image_url(image_reference.image_url, max_bytes=max_image_bytes)
     elif isinstance(image_reference, FileImageReference):
         raise InvalidInputReferenceError("Invalid image_reference: file_id is not supported yet.")
 
@@ -360,6 +384,7 @@ async def decode_input_reference(
             video_reference.video_url,
             max_frames=max_video_frames,
             keep=video_keep,
+            max_bytes=max_video_bytes,
         )
     elif isinstance(video_reference, FileVideoReference):
         raise InvalidInputReferenceError("Invalid video_reference: file_id is not supported yet.")


### PR DESCRIPTION
## Summary

- enforce MiniMax H3 typed-reference limits (9 images, 3 videos, 3 audios, 12 total) before decoding
- apply the documented byte limits to typed image/video/audio references
- normalize malformed data URLs to InvalidInputReferenceError and clean already-persisted references on every audio-loop exception
- reject num_outputs_per_prompt greater than one on the asynchronous endpoint until its storage contract can expose multiple artifacts
- retain multi-output support on the synchronous endpoint

## Validation

- 10 focused endpoint regressions passed
- changed-file pre-commit hooks passed
- git diff --check passed

## Self-review

I verified oversized typed lists never call a decoder, all three typed data-URL modalities enforce byte limits, malformed audio removes an already-persisted video, async fanout is rejected before compute, and the existing H3 mixed-reference fanout test continues through the synchronous endpoint.