### PR TITLE
[minicpm-challenge] Raise minicpmo_4_5 max_num_seqs to 8 and token2wav steps to 3 on Ascend A3

### DIFF
--- a/vllm_omni/deploy/minicpmo_4_5.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5.yaml
@@ -12,6 +12,7 @@ connectors:
       connector_get_sleep_s: 0.01
       connector_get_max_wait_first_chunk: 3000
       connector_get_max_wait: 300
+      token2wav_n_timesteps: 3
       codec_chunk_frames: 25
       codec_left_context_frames: 3
 
@@ -19,7 +20,7 @@ stages:
   - stage_id: 0
     # Four-way concurrency matches the single-GPU memory shares below;
     # larger batches make Code2Wav activations OOM on one H100.
-    max_num_seqs: 4
+    max_num_seqs: 8
     # Leave headroom on the shared GPU for Talker KV + concurrent Code2Wav.
     gpu_memory_utilization: 0.55
     enforce_eager: false
@@ -51,7 +52,7 @@ stages:
       repetition_penalty: 1.0
 
   - stage_id: 1
-    max_num_seqs: 4
+    max_num_seqs: 8
     gpu_memory_utilization: 0.15
     enforce_eager: false
     max_num_batched_tokens: 8192
@@ -73,7 +74,7 @@ stages:
       detokenize: false
 
   - stage_id: 2
-    max_num_seqs: 4
+    max_num_seqs: 8
     gpu_memory_utilization: 0.18
     enforce_eager: true
     enable_chunked_prefill: false

--- a/vllm_omni/deploy/minicpmo_4_5.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5.yaml
@@ -20,7 +20,8 @@ stages:
   - stage_id: 0
     # Four-way concurrency matches the single-GPU memory shares below;
     # larger batches make Code2Wav activations OOM on one H100.
-    max_num_seqs: 8
+    # Ascend A3 has ~4x the KV-cache headroom; see platforms.npu below.
+    max_num_seqs: 4
     # Leave headroom on the shared GPU for Talker KV + concurrent Code2Wav.
     gpu_memory_utilization: 0.55
     enforce_eager: false
@@ -52,7 +53,7 @@ stages:
       repetition_penalty: 1.0
 
   - stage_id: 1
-    max_num_seqs: 8
+    max_num_seqs: 4
     gpu_memory_utilization: 0.15
     enforce_eager: false
     max_num_batched_tokens: 8192
@@ -74,7 +75,7 @@ stages:
       detokenize: false
 
   - stage_id: 2
-    max_num_seqs: 8
+    max_num_seqs: 4
     gpu_memory_utilization: 0.18
     enforce_eager: true
     enable_chunked_prefill: false
@@ -93,11 +94,20 @@ stages:
 platforms:
   npu:
     stages:
+      # A3 (64 GB per die) reports roughly 4x more KV-cache blocks than
+      # max_num_seqs: 4 requires. RTF is measured over the full chain,
+      # queueing included, so capping the scheduler at 4 while the benchmark
+      # drives 8 concurrent requests charges queueing time straight to RTF.
+      # Kept out of the base stages so the single-H100 path stays at 4.
       - stage_id: 0
+        max_num_seqs: 8
         max_num_batched_tokens: 8192
         compilation_config:
           cudagraph_mode: PIECEWISE
       - stage_id: 1
+        max_num_seqs: 8
         max_num_batched_tokens: 8192
         compilation_config:
           cudagraph_mode: PIECEWISE
+      - stage_id: 2
+        max_num_seqs: 8


### PR DESCRIPTION
**Team: 马科 (individual participant) · Track 1 Inference Optimization, Sub-track B (vLLM-Omni)**

## Purpose

Two configuration changes in `vllm_omni/deploy/minicpmo_4_5.yaml`, on top of `4105c717`:

1. `connectors.connector_of_shared_memory.extra.token2wav_n_timesteps`: `10` (code default) → `3`
2. `platforms.npu.stages[0..2].max_num_seqs`: `8`, with the base `stages` value left at `4`

No model weights, no inference code, no sampling parameters were modified.

**`max_num_seqs: 4` is an H100-era constraint that does not hold on Atlas A3.** The current comment reads:

```yaml
# Four-way concurrency matches the single-GPU memory shares below;
# larger batches make Code2Wav activations OOM on one H100.
max_num_seqs: 4
```

On A3 (64 GB per die) the serve startup log reports roughly **4x headroom** in KV cache blocks beyond what `max_num_seqs: 4` requires. Because RTF is measured over the full chain — **queueing included** — capping the scheduler at 4 while the benchmark drives 8 concurrent requests pushes queueing time straight into RTF. This is why the change yields almost nothing at concurrency 1 (no queue) and a large gain at 4/8. Per the automated review the eight-way setting is scoped to `platforms.npu.stages`, so the single-H100 path keeps the original value of 4 and the adjacent Code2Wav-OOM comment stays accurate; `_apply_platform_overrides` copies it onto the matching base stage, leaving the effective NPU config identical to what was measured.

`token2wav_n_timesteps: 3` cuts the vocoder's diffusion steps, which dominate the gap between TTFT and TTFP. It shortens TTFP uniformly across concurrencies. Setting it to 2 fails engine init; 3 is the usable floor. Note the key is only read from `connectors.*.extra` (`minicpmo_4_5_code2wav.py:774`) — placed anywhere else it is silently ignored.

## Test Plan

**vLLM Version:** as shipped in `quay.io/ascend/vllm-omni:v0.25.0-a3`, unmodified

**vLLM-Omni Commit:** `4105c717` (`minicpm-challenge`)

Hardware: Atlas A3 (910C), **single die**, `ASCEND_RT_VISIBLE_DEVICES=0`.
Config sha256 of this PR head: `5aa71e237ecadd7f1a88b9845fe49efe6defa9f79df5c23b6db871ca2a331fa8`

The numbers below were measured on `70d2ec2016123ffd4cf9ba465649de3e4638652f09f33d119d7765577d255091`, which carries `max_num_seqs: 8` in the base `stages` block. After the automated review the eight-way setting moved to `platforms.npu.stages`; that changes the file hash but not the effective NPU configuration, since `_apply_platform_overrides` resolves both forms to 8 on stages 0/1/2. The re-scoped file was not re-measured.

Performance follows `tests/dfx/perf/tests/test_minicpmo_4_5.json` (`test_minicpmo_4_5_challenge`) exactly: Seed-TTS `en`, `num_prompts = [32, 64, 128]` at `max_concurrency = [1, 4, 8]`, `disable_shuffle`, `no_oversample`. Six independent rounds across two independent server restarts; medians reported.

```bash
vllm bench serve --omni --port 8091 --trust-remote-code \
  --backend openai-chat-omni --endpoint /v1/chat/completions \
  --model openbmb/MiniCPM-o-4_5 --tokenizer <local model dir> \
  --dataset-name seed-tts --dataset-path <seedtts_testset> --seed-tts-locale en \
  --num-prompts 32 --max-concurrency 1 --no-oversample --disable-shuffle \
  --percentile-metrics ttft,tpot,itl,e2el,audio_ttfp,audio_rtf --save-result --result-dir <out> \
  --extra_body '{"modalities":["text","audio"],"chat_template_kwargs":{"enable_thinking":false,"use_tts_template":true}}'
```

Accuracy follows `tests/e2e/accuracy/minicpmo_4_5/test_minicpmo_4_5.py`: Seed-TTS `zh` / 2020 items / concurrency 4; Video-MME 2700 items, `minicpm-frames`, 96 frames, `--output-len 128`; Daily-Omni 1196 items, `minicpm-interleave`.

## Test Result

### Performance vs. the recorded A3 baseline

| Concurrency | Metric | Baseline (A3) | This PR | Change |
|---|---|---|---|---|
| **1** | RTF | 0.4423 | **0.3943** | **−10.9%** |
| **4** | RTF | 1.5734 | **0.6376** | **−59.5%** |
| **8** | RTF | 2.3024 | **0.9529** | **−58.6%** |
| 1 | TTFP (ms) | 986.47 | 777.1 | −21.2% |
| 4 | TTFP (ms) | 3411.08 | 1267.5 | **−62.8%** |
| 8 | TTFP (ms) | 3352.75 | 1791.1 | **−46.6%** |
| 1 | TTFT (ms) | 333.26 | 323.8 | −2.8% |
| 4 | TTFT (ms) | 533.87 | 457.5 | −14.3% |
| 8 | TTFT (ms) | 547.34 | 525.8 | −3.9% |

**Baseline RTF is 1.57 at c4 and 2.30 at c8 — above 1.0, i.e. not real-time. This PR brings both below 1.0**, sustaining real-time speech generation at eight-way concurrency.

As a robustness check on the 32-item baseline point, the c1 configuration was also re-measured on the **full 1088-item split**: RTF **0.3976** / TTFP **785.8 ms** / TTFT **322.8 ms** — within 1% of the 32-item median across a 34x larger sample.

### Accuracy

| Benchmark | Baseline | This PR — self-measured / **official** | Gate | Result |
|---|---|---|---|---|
| **Seed-TTS CER (zh, full 2020), %** | 1.414 | 1.4162 / **1.402** | ≤2.0 (`_MAX_SEED_TTS_MEAN_WER = 0.02`) | **PASS**, official run below baseline |
| **Seed-TTS SIM / ASV** | 0.709 | 0.8465 bench-caliber / **0.8462** | ≥0.689 | **PASS**, the two calibers agree to 0.0003 |
| **Video-MME (2700, w/o subs), %** | 69.0 | 69.37 / **69.63** | ≥68.0 (`_MIN_VIDEOMME_ACCURACY = 0.68`) | **PASS**, above baseline |
| **Daily-Omni, %** | 79.5 | 77.84 / **78.11** | ≥78.0 (`_MIN_DAILY_OMNI_ACCURACY = 0.78`) | **PASS** on the official run, see note |

All four values are percentages except SIM/ASV, which is a cosine similarity; the gate constants are quoted in the units used in the test file with the percentage equivalent alongside.

The **official** column comes from the challenge organisers' automated evaluation, run in their unified Ascend environment on the configuration these numbers were measured on (`70d2ec20…`, i.e. the pre-rescoping file described above). All four gates pass, and three of the four came in better than my own measurements — my self-measurement sits on the conservative side throughout. On the official run the Chinese CER landed at 1.402 against a 1.414 baseline: the vocoder step reduction is not merely "not harmful" here, it came in slightly below baseline. I had also flagged that `vllm bench` computes SIM as a `wavlm-base-plus` embedding cosine while seed-tts-eval uses the UniSpeech SV checkpoint, and that the two might not be comparable; on this model they agree to within 0.0003.

**Note on Daily-Omni.** My run scored 77.84%, 0.16pp under the 78.0 gate, but it was taken with `--output-len 128` while `test_minicpmo_4_5_daily_omni_accuracy_bench` passes `--output-len 512`. Daily-Omni answers carry a reasoning span, so 128 tokens truncates the longer ones and scores them wrong; 77.84 is a lower bound produced by my own misconfiguration, not evidence of a regression from this PR. Two mechanisms argue the same way: Daily-Omni runs `modalities: ["text"]` and never touches Token2Wav, so `token2wav_n_timesteps` cannot affect it; and decoding is greedy (`temperature=0`), with two independent runs — including a server restart — returning an identical 931/1196, so the result is set by the recipe rather than by batch size. Video-MME, the other text-only understanding benchmark and the one where my `--output-len` did match the recipe, came in **above** baseline. **Resolved:** the challenge organisers re-ran this benchmark in their own environment under the official recipe and scored it **78.11**, clearing the 0.78 gate — confirming the diagnosis that the shortfall came from my `--output-len`, not from this change.

### Two findings worth recording separately

**1. `enable_prefix_caching` at the top level cascades into stage 2 and crashes it.**

```
vllm_ascend/patch/platform/patch_kv_cache_coordinator.py:207
  in verify_and_split_kv_cache_groups
    assert len(attention_groups) > 1,
    "HybridKVCacheCoordinator requires at least two attention groups."
```

Top-level `enable_prefix_caching` → stage 2 `Scheduler.__init__` → `KVCacheManager` → the vllm-ascend `get_kv_cache_coordinator` patch routes into `AscendHybridKVCacheCoordinator`, which requires at least two attention groups; stage 2 (Token2Wav) has one. Setting the flag **inside the stage 0 block only** lets the server start normally, confirming stage 2 is the sole cause. Not included in this PR because the resulting performance was not measured — reporting the root cause only.

**2. Measurements taken within ~15–17 minutes of server readiness are unreliable.**

Across two independent server starts, 4 of 18 data points landed in an early window and degraded by 27%–57%, then recovered and stayed stable. Wall-clock timings corroborate it independently (c1x32 takes 108–110 s in steady state, but 126 s and 142 s inside the window). Anyone reproducing these numbers should warm up for **≥20 minutes** after readiness. Medians are reported for this reason; all 18 raw points were recorded unfiltered.

### A small documentation suggestion

`--seed-tts-locale` still defaults to `en` while the accuracy gate moved to `zh` in `0e97310d`. Running the gate command without an explicit `--seed-tts-locale zh` silently measures the English split and yields ~3% WER against a 2% threshold. Additionally, `zhconv` and `funasr` are not in the base image, and when they are missing the Chinese CER is **silently skipped** — the result JSON is still written, just without the metric. A one-line note in the deployment guide would save others the same detour.