### PR TITLE
[Kernel] Add shared gated residual op for video DiTs

### DIFF
--- a/benchmarks/kernels/gated_residual_benchmarks.py
+++ b/benchmarks/kernels/gated_residual_benchmarks.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Microbenchmark the shared diffusion gated-residual operator.
+
+Example:
+    python benchmarks/kernels/gated_residual_benchmarks.py \
+        --batch-size 2 --tokens 32760 --hidden-size 5120 --gate-layout batch
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+from collections.abc import Callable
+
+import torch
+
+from vllm_omni.diffusion.layers.gated_residual import gated_residual
+
+
+def _measure_ms(
+    function: Callable[[], torch.Tensor],
+    *,
+    warmup: int,
+    iterations: int,
+    repeats: int,
+) -> list[float]:
+    for _ in range(warmup):
+        function()
+    torch.accelerator.synchronize()
+
+    samples = []
+    for _ in range(repeats):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(iterations):
+            function()
+        end.record()
+        end.synchronize()
+        samples.append(start.elapsed_time(end) / iterations)
+    return samples
+
+
+def _gate_shape(layout: str, batch_size: int, tokens: int, hidden_size: int) -> tuple[int, ...]:
+    if layout == "global":
+        return (hidden_size,)
+    if layout == "batch":
+        return (batch_size, 1, hidden_size)
+    return (batch_size, tokens, hidden_size)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--tokens", type=int, default=32760)
+    parser.add_argument("--hidden-size", type=int, default=5120)
+    parser.add_argument("--gate-layout", choices=("global", "batch", "token"), default="batch")
+    parser.add_argument("--dtype", choices=("float16", "bfloat16"), default="bfloat16")
+    parser.add_argument("--warmup", type=int, default=25)
+    parser.add_argument("--iterations", type=int, default=100)
+    parser.add_argument("--repeats", type=int, default=20)
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("This benchmark requires a CUDA GPU")
+    dtype = getattr(torch, args.dtype)
+    shape = (args.batch_size, args.tokens, args.hidden_size)
+    gate_shape = _gate_shape(args.gate_layout, *shape)
+    residual = torch.randn(shape, device="cuda", dtype=dtype)
+    branch = torch.randn(shape, device="cuda", dtype=dtype)
+    gate = torch.randn(gate_shape, device="cuda", dtype=dtype)
+
+    def eager() -> torch.Tensor:
+        return residual + branch * gate
+
+    def fused() -> torch.Tensor:
+        return gated_residual(residual, branch, gate)
+
+    torch.testing.assert_close(fused(), eager(), rtol=0, atol=0)
+
+    for name, function in (("eager", eager), ("fused", fused)):
+        samples = _measure_ms(
+            function,
+            warmup=args.warmup,
+            iterations=args.iterations,
+            repeats=args.repeats,
+        )
+        mean = statistics.mean(samples)
+        stddev = statistics.pstdev(samples)
+        print(f"{name:>5}: {mean:.4f} ms ± {stddev:.4f} ms")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/diffusion/layers/test_gated_residual.py
+++ b/tests/diffusion/layers/test_gated_residual.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+from vllm.triton_utils import HAS_TRITON
+
+from vllm_omni.diffusion.layers.gated_residual import gated_residual
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion]
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize(
+    ("shape", "gate_shape"),
+    [
+        ((2, 7, 16), (16,)),
+        ((2, 7, 16), (2, 1, 16)),
+        ((2, 3, 7, 16), (2, 1, 1, 16)),
+        ((2, 7, 16), (2, 7, 16)),
+        ((2, 3, 7, 16), (1, 3, 1, 16)),
+        ((2, 7, 16), (2, 7, 1)),
+        ((2, 7, 16), ()),
+    ],
+)
+def test_gated_residual_cpu_matches_eager(shape, gate_shape):
+    torch.manual_seed(11)
+    residual = torch.randn(shape)
+    branch = torch.randn(shape)
+    gate = torch.randn(gate_shape)
+
+    expected = residual + branch * gate
+    actual = gated_residual(residual, branch, gate)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.cpu
+def test_gated_residual_noncontiguous_fallback():
+    residual = torch.randn(2, 16, 5).transpose(1, 2)
+    branch = torch.randn(2, 16, 5).transpose(1, 2)
+    gate = torch.randn(2, 1, 16)
+
+    actual = gated_residual(residual, branch, gate)
+
+    torch.testing.assert_close(actual, residual + branch * gate, rtol=0, atol=0)
+
+
+@pytest.mark.cpu
+def test_gated_residual_rejects_invalid_shapes():
+    residual = torch.randn(2, 7, 16)
+    branch = torch.randn(2, 7, 8)
+    gate = torch.randn(2, 1, 16)
+
+    with pytest.raises(ValueError, match="same shape"):
+        gated_residual(residual, branch, gate)
+    with pytest.raises(ValueError, match="not broadcastable"):
+        gated_residual(residual, residual, torch.randn(3, 16))
+
+
+@pytest.mark.cuda
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.skipif(not HAS_TRITON, reason="Triton required")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("gate_shape", [(4096,), (2, 1, 4096), (2, 257, 4096)])
+def test_gated_residual_cuda_matches_eager(dtype, gate_shape):
+    torch.manual_seed(17)
+    shape = (2, 257, 4096)
+    residual = torch.randn(shape, device="cuda", dtype=dtype)
+    branch = torch.randn(shape, device="cuda", dtype=dtype)
+    gate = torch.randn(gate_shape, device="cuda", dtype=dtype)
+
+    expected = residual + branch * gate
+    actual = gated_residual(residual, branch, gate)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.cuda
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.skipif(not HAS_TRITON, reason="Triton required")
+def test_gated_residual_supports_torch_compile():
+    compiled = torch.compile(gated_residual, fullgraph=True)
+    residual = torch.randn(2, 17, 128, device="cuda", dtype=torch.bfloat16)
+    branch = torch.randn_like(residual)
+    gate = torch.randn(2, 1, 128, device="cuda", dtype=torch.bfloat16)
+
+    actual = compiled(residual, branch, gate)
+
+    torch.testing.assert_close(actual, residual + branch * gate, rtol=0, atol=0)
+
+
+@pytest.mark.cuda
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.skipif(not HAS_TRITON, reason="Triton required")
+def test_gated_residual_supports_strided_modulation_gate():
+    residual = torch.randn(2, 17, 128, device="cuda", dtype=torch.bfloat16)
+    branch = torch.randn_like(residual)
+    gate_storage = torch.randn(2, 17, 3, 128, device="cuda", dtype=torch.bfloat16)
+    gate = gate_storage[:, :, 1, :]
+    assert not gate.is_contiguous()
+
+    actual = gated_residual(residual, branch, gate)
+
+    torch.testing.assert_close(actual, residual + branch * gate, rtol=0, atol=0)

--- a/vllm_omni/diffusion/layers/gated_residual.py
+++ b/vllm_omni/diffusion/layers/gated_residual.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Shared gated-residual operator for diffusion transformer blocks."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+from torch.library import Library
+from vllm.platforms import current_platform
+from vllm.triton_utils import HAS_TRITON, tl, triton
+from vllm.utils.torch_utils import direct_register_custom_op
+
+_GLOBAL_GATE = 0
+_BATCH_GATE = 1
+_ROW_GATE = 2
+_EAGER_GATE = -1
+_MAX_FUSED_HIDDEN_SIZE = 16384
+
+
+if HAS_TRITON:
+
+    @triton.jit
+    def _gated_residual_kernel(
+        residual_ptr,
+        branch_ptr,
+        gate_ptr,
+        output_ptr,
+        hidden_size: tl.constexpr,
+        rows_per_batch: tl.constexpr,
+        gate_row_stride: tl.constexpr,
+        gate_mode: tl.constexpr,
+        product_dtype: tl.constexpr,
+        block_size: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        columns = tl.arange(0, block_size)
+        offsets = row * hidden_size + columns
+        mask = columns < hidden_size
+
+        if gate_mode == 0:
+            gate_row = 0
+        elif gate_mode == 1:
+            gate_row = row // rows_per_batch
+        else:
+            gate_row = row
+
+        gate_offsets = gate_row * gate_row_stride + columns
+        residual = tl.load(residual_ptr + offsets, mask=mask).to(tl.float32)
+        branch = tl.load(branch_ptr + offsets, mask=mask).to(tl.float32)
+        gate = tl.load(gate_ptr + gate_offsets, mask=mask).to(tl.float32)
+
+        # Match ``branch * gate`` followed by the residual add. The explicit
+        # cast preserves the intermediate rounding of eager fp16/bf16 math.
+        gated_branch = (branch * gate).to(product_dtype).to(tl.float32)
+        tl.store(output_ptr + offsets, residual + gated_branch, mask=mask)
+
+
+def _eager_gated_residual(
+    residual: torch.Tensor,
+    branch: torch.Tensor,
+    gate: torch.Tensor,
+    gate_mode: int,
+    rows_per_batch: int,
+    gate_row_stride: int,
+) -> torch.Tensor:
+    del gate_mode, rows_per_batch, gate_row_stride
+    return residual + branch * gate
+
+
+def _fused_cuda_supported(
+    residual: torch.Tensor,
+    branch: torch.Tensor,
+    gate: torch.Tensor,
+    gate_mode: int,
+) -> bool:
+    return (
+        HAS_TRITON
+        and current_platform.is_cuda()
+        and residual.is_cuda
+        and branch.is_cuda
+        and gate.is_cuda
+        and residual.dtype in (torch.float16, torch.bfloat16)
+        and branch.dtype == residual.dtype
+        and gate.dtype == residual.dtype
+        and residual.device == branch.device == gate.device
+        and residual.is_contiguous()
+        and branch.is_contiguous()
+        and gate.ndim > 0
+        and gate.stride(-1) == 1
+        and gate_mode != _EAGER_GATE
+        and gate.shape[-1] == residual.shape[-1]
+        and 0 < residual.shape[-1] <= _MAX_FUSED_HIDDEN_SIZE
+    )
+
+
+def _gated_residual_impl(
+    residual: torch.Tensor,
+    branch: torch.Tensor,
+    gate: torch.Tensor,
+    gate_mode: int,
+    rows_per_batch: int,
+    gate_row_stride: int,
+) -> torch.Tensor:
+    if not _fused_cuda_supported(residual, branch, gate, gate_mode):
+        return _eager_gated_residual(residual, branch, gate, gate_mode, rows_per_batch, gate_row_stride)
+
+    output = torch.empty_like(residual)
+    rows = residual.numel() // residual.shape[-1]
+    if rows == 0:
+        return output
+
+    product_dtype = tl.float16 if residual.dtype == torch.float16 else tl.bfloat16
+    block_size = triton.next_power_of_2(residual.shape[-1])
+    _gated_residual_kernel[(rows,)](
+        residual,
+        branch,
+        gate,
+        output,
+        hidden_size=residual.shape[-1],
+        rows_per_batch=rows_per_batch,
+        gate_row_stride=gate_row_stride,
+        gate_mode=gate_mode,
+        product_dtype=product_dtype,
+        block_size=block_size,
+        num_warps=8,
+    )
+    return output
+
+
+def _gated_residual_fake(
+    residual: torch.Tensor,
+    branch: torch.Tensor,
+    gate: torch.Tensor,
+    gate_mode: int,
+    rows_per_batch: int,
+    gate_row_stride: int,
+) -> torch.Tensor:
+    del branch, gate, gate_mode, rows_per_batch, gate_row_stride
+    return torch.empty_like(residual)
+
+
+_OMNI_OP_LIB = Library("vllm_omni", "FRAGMENT")
+if not hasattr(torch.ops.vllm_omni, "gated_residual"):
+    direct_register_custom_op(
+        op_name="gated_residual",
+        op_func=_gated_residual_impl,
+        fake_impl=_gated_residual_fake,
+        mutates_args=[],
+        target_lib=_OMNI_OP_LIB,
+    )
+
+
+def _row_stride(gate: torch.Tensor) -> int | None:
+    if gate.ndim == 1:
+        return gate.shape[-1]
+    row_stride = gate.stride(-2)
+    rows = 1
+    for dimension in range(gate.ndim - 2, -1, -1):
+        if gate.shape[dimension] != 1 and gate.stride(dimension) != rows * row_stride:
+            return None
+        rows *= gate.shape[dimension]
+    return row_stride
+
+
+def _gate_layout(residual: torch.Tensor, gate: torch.Tensor) -> tuple[int, int, int]:
+    if gate.ndim > residual.ndim:
+        return _EAGER_GATE, 1, 0
+
+    padded_shape = (1,) * (residual.ndim - gate.ndim) + tuple(gate.shape)
+    leading_shape = padded_shape[:-1]
+    residual_leading_shape = tuple(residual.shape[:-1])
+    if all(size == 1 for size in leading_shape):
+        return _GLOBAL_GATE, 1, 0
+    if residual.ndim >= 3 and leading_shape[0] == residual.shape[0] and all(size == 1 for size in leading_shape[1:]):
+        return _BATCH_GATE, math.prod(residual.shape[1:-1]), gate.stride(0)
+    if leading_shape == residual_leading_shape:
+        row_stride = _row_stride(gate)
+        if row_stride is not None:
+            return _ROW_GATE, 1, row_stride
+    return _EAGER_GATE, 1, 0
+
+
+def gated_residual(
+    residual: torch.Tensor,
+    branch: torch.Tensor,
+    gate: torch.Tensor,
+) -> torch.Tensor:
+    """Return ``residual + branch * gate`` with a fused CUDA fast path.
+
+    The fast path supports fp16 and bf16 activations with a gate shared
+    globally, per batch item, or per token. Other broadcastable layouts use
+    the eager reference implementation.
+    """
+    if residual.shape != branch.shape:
+        raise ValueError(f"residual and branch must have the same shape, got {residual.shape} and {branch.shape}")
+    if residual.ndim == 0:
+        raise ValueError("residual and branch must have at least one dimension")
+    if not residual.is_floating_point() or not branch.is_floating_point() or not gate.is_floating_point():
+        raise TypeError("gated_residual requires floating-point tensors")
+
+    try:
+        broadcast_shape = torch.broadcast_shapes(tuple(residual.shape), tuple(gate.shape))
+    except RuntimeError as error:
+        raise ValueError(f"gate shape {gate.shape} is not broadcastable to residual shape {residual.shape}") from error
+    if broadcast_shape != tuple(residual.shape):
+        raise ValueError(f"gate shape {gate.shape} broadcasts beyond residual shape {residual.shape}")
+
+    gate_mode, rows_per_batch, gate_row_stride = _gate_layout(residual, gate)
+    if not _fused_cuda_supported(residual, branch, gate, gate_mode):
+        return _gated_residual_impl(residual, branch, gate, gate_mode, rows_per_batch, gate_row_stride)
+    return torch.ops.vllm_omni.gated_residual(
+        residual,
+        branch,
+        gate,
+        gate_mode,
+        rows_per_batch,
+        gate_row_stride,
+    )
+
+
+__all__ = ["gated_residual"]

--- a/vllm_omni/diffusion/models/hunyuan_video/hunyuan_video_15_transformer.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/hunyuan_video_15_transformer.py
@@ -30,6 +30,7 @@ from vllm_omni.diffusion.distributed.parallel_state import get_sequence_parallel
 from vllm_omni.diffusion.distributed.sp_plan import SequenceParallelInput, SequenceParallelOutput
 from vllm_omni.diffusion.distributed.sp_sharding import sp_shard_with_padding
 from vllm_omni.diffusion.forward_context import get_forward_context
+from vllm_omni.diffusion.layers.gated_residual import gated_residual
 from vllm_omni.diffusion.layers.rope import RotaryEmbedding
 from vllm_omni.diffusion.models.flux.flux_transformer import FeedForward
 
@@ -180,10 +181,10 @@ class HunyuanVideo15IndividualTokenRefinerBlock(nn.Module):
         )
 
         gate_msa, gate_mlp = self.norm_out(temb)
-        hidden_states = hidden_states + attn_output * gate_msa
+        hidden_states = gated_residual(hidden_states, attn_output, gate_msa)
 
         ff_output = self.ff(self.norm2(hidden_states))
-        hidden_states = hidden_states + ff_output * gate_mlp
+        hidden_states = gated_residual(hidden_states, ff_output, gate_mlp)
 
         return hidden_states
 
@@ -567,8 +568,8 @@ class HunyuanVideo15TransformerBlock(nn.Module):
             hidden_states_mask=hidden_states_mask,
         )
 
-        hidden_states = hidden_states + attn_output * gate_msa.unsqueeze(1)
-        encoder_hidden_states = encoder_hidden_states + context_attn_output * c_gate_msa.unsqueeze(1)
+        hidden_states = gated_residual(hidden_states, attn_output, gate_msa.unsqueeze(1))
+        encoder_hidden_states = gated_residual(encoder_hidden_states, context_attn_output, c_gate_msa.unsqueeze(1))
 
         norm_hidden_states = self.norm2(hidden_states)
         norm_encoder_hidden_states = self.norm2_context(encoder_hidden_states)
@@ -579,8 +580,8 @@ class HunyuanVideo15TransformerBlock(nn.Module):
         ff_output = self.ff(norm_hidden_states)
         context_ff_output = self.ff_context(norm_encoder_hidden_states)
 
-        hidden_states = hidden_states + gate_mlp.unsqueeze(1) * ff_output
-        encoder_hidden_states = encoder_hidden_states + c_gate_mlp.unsqueeze(1) * context_ff_output
+        hidden_states = gated_residual(hidden_states, ff_output, gate_mlp.unsqueeze(1))
+        encoder_hidden_states = gated_residual(encoder_hidden_states, context_ff_output, c_gate_mlp.unsqueeze(1))
 
         return hidden_states, encoder_hidden_states
 

--- a/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
@@ -49,6 +49,7 @@ from vllm_omni.diffusion.cache.cachedit import CacheDiTAdapterConfig
 from vllm_omni.diffusion.distributed.hsdp_utils import is_transformer_block_module
 from vllm_omni.diffusion.distributed.sp_plan import SequenceParallelInput, SequenceParallelOutput
 from vllm_omni.diffusion.forward_context import get_forward_context, is_forward_context_available
+from vllm_omni.diffusion.layers.gated_residual import gated_residual
 
 logger = init_logger(__name__)
 
@@ -1064,7 +1065,7 @@ class LTX2VideoTransformerBlock(nn.Module):
             attention_mask=self_attention_mask,
             perturbation_mask=video_self_attention_perturbation_mask,
         )
-        hidden_states = hidden_states + attn_hidden_states * gate_msa
+        hidden_states = gated_residual(hidden_states, attn_hidden_states, gate_msa)
 
         # 1.2. Audio Self-Attention
         audio_ada_params = self.get_mod_params(self.audio_scale_shift_table, temb_audio, batch_size)
@@ -1084,7 +1085,7 @@ class LTX2VideoTransformerBlock(nn.Module):
             attention_mask=audio_self_attention_mask,
             perturbation_mask=audio_self_attention_perturbation_mask,
         )
-        audio_hidden_states = audio_hidden_states + attn_audio_hidden_states * audio_gate_msa
+        audio_hidden_states = gated_residual(audio_hidden_states, attn_audio_hidden_states, audio_gate_msa)
 
         # 2. Video and Audio Cross-Attention with text embeddings (Q: Video/Audio; K,V: Text)
         if self.cross_attn_adaln:
@@ -1190,7 +1191,7 @@ class LTX2VideoTransformerBlock(nn.Module):
                 )
                 if a2v_cross_attention_perturbation_mask is not None:
                     a2v_attn_hidden_states = a2v_attn_hidden_states * a2v_cross_attention_perturbation_mask
-                hidden_states = hidden_states + a2v_gate * a2v_attn_hidden_states
+                hidden_states = gated_residual(hidden_states, a2v_attn_hidden_states, a2v_gate)
 
             # 3.3. Video-to-Audio Cross Attention: Q: Audio; K,V: Video
             if use_v2a_cross_attention:
@@ -1210,16 +1211,16 @@ class LTX2VideoTransformerBlock(nn.Module):
                 )
                 if v2a_cross_attention_perturbation_mask is not None:
                     v2a_attn_hidden_states = v2a_attn_hidden_states * v2a_cross_attention_perturbation_mask
-                audio_hidden_states = audio_hidden_states + v2a_gate * v2a_attn_hidden_states
+                audio_hidden_states = gated_residual(audio_hidden_states, v2a_attn_hidden_states, v2a_gate)
 
         # 4. Feedforward
         norm_hidden_states = self.norm3(hidden_states) * (1 + scale_mlp) + shift_mlp
         ff_output = self.ff(norm_hidden_states)
-        hidden_states = hidden_states + ff_output * gate_mlp
+        hidden_states = gated_residual(hidden_states, ff_output, gate_mlp)
 
         norm_audio_hidden_states = self.audio_norm3(audio_hidden_states) * (1 + audio_scale_mlp) + audio_shift_mlp
         audio_ff_output = self.audio_ff(norm_audio_hidden_states)
-        audio_hidden_states = audio_hidden_states + audio_ff_output * audio_gate_mlp
+        audio_hidden_states = gated_residual(audio_hidden_states, audio_ff_output, audio_gate_mlp)
 
         return hidden_states, audio_hidden_states
 

--- a/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
+++ b/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
@@ -42,6 +42,7 @@ from vllm_omni.diffusion.distributed.sp_plan import (
 )
 from vllm_omni.diffusion.forward_context import build_local_sp_padding_mask, get_forward_context
 from vllm_omni.diffusion.layers.adalayernorm import AdaLayerNorm
+from vllm_omni.diffusion.layers.gated_residual import gated_residual
 from vllm_omni.diffusion.layers.norm import LayerNorm, RMSNorm
 from vllm_omni.diffusion.layers.rope import RotaryEmbeddingWan
 from vllm_omni.platforms import current_omni_platform
@@ -731,7 +732,7 @@ class WanTransformerBlock(nn.Module):
         norm_hidden_states = self.norm1(hidden_states, scale_msa, shift_msa).type_as(hidden_states)
         self_attn_metadata = AttentionMetadata(attn_mask=hidden_states_mask)
         attn_output = self.attn1(norm_hidden_states, rotary_emb, self_attn_metadata)
-        hidden_states = (hidden_states + attn_output * gate_msa).type_as(hidden_states)
+        hidden_states = gated_residual(hidden_states, attn_output, gate_msa).type_as(hidden_states)
 
         # 2. Cross-attention
         norm_hidden_states = self.norm2(hidden_states).type_as(hidden_states)
@@ -741,7 +742,7 @@ class WanTransformerBlock(nn.Module):
         # 3. Feed-forward
         norm_hidden_states = self.norm3(hidden_states, c_scale_msa, c_shift_msa).type_as(hidden_states)
         ff_output = self.ffn(norm_hidden_states)
-        hidden_states = (hidden_states + ff_output * c_gate_msa).type_as(hidden_states)
+        hidden_states = gated_residual(hidden_states, ff_output, c_gate_msa).type_as(hidden_states)
 
         return hidden_states
 


### PR DESCRIPTION
## Purpose

Video diffusion transformer blocks repeatedly execute the same gated residual pattern:

```python
residual + branch * gate
```

This PR introduces a shared `gated_residual(residual, branch, gate)` operator so model implementations can use one acceleration contract instead of carrying model-specific pointwise sequences.

The operator:

- uses a Triton CUDA fast path for fp16/bf16 activations;
- supports global, per-batch, and per-token gates, including strided modulation views produced by `chunk`/`unbind`;
- preserves eager's intermediate fp16/bf16 multiplication rounding before the residual add;
- registers a `torch.library` custom op with a fake implementation for `torch.compile`;
- falls back to the exact eager expression for unsupported devices, dtypes, layouts, hidden sizes, and general broadcast patterns.

The common interface is integrated at 14 hot-path call sites across:

- Wan2.2;
- HunyuanVideo 1.5;
- LTX-2 video/audio transformer blocks.

A standalone CUDA microbenchmark is included under `benchmarks/kernels/`.

This is intentionally a **Draft** because the implementation environment is CPU-only. CUDA exactness, compile coverage, and the reproducible benchmark are checked in, but NVIDIA GPU latency/VRAM results still need to be collected before marking ready.

## Test Plan

CPU contract and fallback coverage:

```bash
pytest -q tests/diffusion/layers/test_gated_residual.py -m "core_model and cpu"
```

CUDA numerical, strided-gate, and compile coverage:

```bash
pytest -q tests/diffusion/layers/test_gated_residual.py -m "core_model and cuda"
```

Reproducible kernel A/B (example Wan-shaped workload):

```bash
python benchmarks/kernels/gated_residual_benchmarks.py \
  --batch-size 1 \
  --tokens 32760 \
  --hidden-size 5120 \
  --gate-layout batch \
  --dtype bfloat16 \
  --warmup 25 \
  --iterations 100 \
  --repeats 20
```

Static and repository checks:

```bash
pre-commit run --files \
  benchmarks/kernels/gated_residual_benchmarks.py \
  tests/diffusion/layers/test_gated_residual.py \
  vllm_omni/diffusion/layers/gated_residual.py \
  vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py \
  vllm_omni/diffusion/models/hunyuan_video/hunyuan_video_15_transformer.py \
  vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
```

**vLLM Version:** GPU runtime validation pending

**vLLM-Omni Commit:** `c3f80502e00b564d7b74d43a5e21fbc6b9da2aed`

## Test Result

- Focused CPU contract tests: **9 passed**.
- Full staged pre-commit suite: **passed** (Ruff check/format, typos, test marks, file hygiene).
- `git diff --check`: **passed**.
- CUDA numerical and `torch.compile` tests: **not run locally; NVIDIA GPU required**.
- Kernel latency, end-to-end video latency, and peak VRAM A/B: **pending before ready-for-review**.
- Branch freshness at push: live upstream `main=c3f80502`, **0 behind / 1 ahead**.

## AI assistance disclosure

OpenAI Codex assisted with implementation, testing, and review. The commit includes a `Co-authored-by` trailer.