### PR TITLE
[Perf][MiniCPM-o] Drop the full-vocab bincount from the Talker penalty

### DIFF
--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
@@ -76,7 +76,8 @@ def _apply_repetition_penalty(
     if penalty == 1.0 or history.numel() == 0:
         return logits
     recent = history.reshape(-1)[-window_size:].to(device=logits.device, dtype=torch.long)
-    frequencies = torch.bincount(recent, minlength=logits.shape[-1]).to(dtype=logits.dtype)
+    frequencies = torch.zeros(logits.shape[-1], device=logits.device, dtype=logits.dtype)
+    frequencies.scatter_add_(0, recent, torch.ones_like(recent, dtype=logits.dtype))
     alpha = torch.pow(torch.as_tensor(penalty, device=logits.device, dtype=logits.dtype), frequencies)
     return torch.where(logits < 0, logits * alpha, logits / alpha)
 


### PR DESCRIPTION
## Purpose

Swap `torch.bincount` for `scatter_add_` in `_apply_repetition_penalty`. One-line change, frequency vector is elementwise identical.

`torch.bincount` output length is data-dependent — dispatches to AI_CPU on Ascend, forces a device sync on CUDA even with `minlength`.

vLLM upstream already avoids it in three places for the same reason:

1. `vllm/v1/attention/backends/utils.py` — the v1 metadata builder:
   > Avoid `torch.bincount` here - on CUDA it forces a sync to determine the output size (even with `minlength`, the kernel must confirm no value exceeds the bound). `scatter_add_` into a preallocated buffer is equivalent and stays async.

2. `vllm/model_executor/layers/utils.py` — `get_token_bin_counts_and_mask` uses `scatter_add_` for token histograms.

3. `vllm/v1/worker/gpu/sample/penalties.py` — v1 GPU sampler ships a hand-written Triton `_bincount_kernel` to avoid ATen bincount entirely.

## Test Results

910B, vocab 6562, 16-token window, median of 400 calls:

| config | before | after |
|---|---|---|
| f32, 1 row | 334–366 µs | 167–168 µs |
| f32, 4 rows | 344–348 µs | 171–177 µs |
| bf16, 1 row | 324–327 µs | 170–172 µs |
| bf16, 4 rows | 335–345 µs | 177 µs |