### PR TITLE
[Bugfix][MiniCPM-o][NPU] Skip Code2Wav dynamo unwrap when flow.encode…

### DIFF
--- a/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
@@ -101,7 +101,9 @@ class BatchedToken2Wav(nn.Module):
         self._trt_stepper = trt_stepper
         self.flow = token2wav.flow
         self.hift = token2wav.hift
-        _undecorate_dynamo(self.flow.encoder, "forward_chunk")
+        encoder = getattr(self.flow, "encoder", None)
+        if encoder is not None:
+            _undecorate_dynamo(encoder, "forward_chunk")
         hift_parameter = next(self.hift.parameters(), None)
         if hift_parameter is not None and hift_parameter.device.type == "cuda":
             # Prime the CUDA state used by HiFT during backend construction.


### PR DESCRIPTION
## Summary
Fix: https://github.com/vllm-project/vllm-omni/issues/6366
- `BatchedToken2Wav` now unwraps TorchDynamo on `flow.encoder.forward_chunk` only when that encoder exists.
- The NPU Code2Wav graph test builds a decoder/estimator-only `_Flow` mock. After the dynamo unwrap landed, constructing `BatchedToken2Wav` raised `AttributeError: '_Flow' object has no attribute 'encoder'` before any graph capture ran.
- Real CosyVoice flows still unwrap `UpsampleConformerEncoderV2.forward_chunk`. Estimator-only fixtures and other encoder-less flows skip that step.

## Test plan
- [ ] `tests/platforms/npu/test_minicpmo_code2wav_npugraph.py::test_minicpmo_cfm_estimator_npugraph_matches_eager` on A3
- [ ] MiniCPM-o 4.5 Code2Wav still loads on CUDA (encoder present; dynamo unwrap still applies)

```
INFO 08-20 06:13:17 [cosyvoice2_dit_attn.py:149] Disabled torch.compile on CosyVoice2 UpsampleConformerEncoderV2.forward_chunk (Ascend eager)
INFO 08-20 06:13:17 [cosyvoice2_dit_attn.py:172] Applied CosyVoice2 DiT Attention NPU patch (expand attn_mask to Bx1xSxS for aclnnFlashAttentionScore)
INFO 08-20 06:13:18 [graph_tools.py:176] device graph captured NPUGraph 1/4 for cfm_estimator
INFO 08-20 06:13:18 [graph_tools.py:147] device graph started NPUGraph replay
INFO 08-20 06:13:18 [graph_tools.py:176] device graph captured NPUGraph 2/4 for cfm_estimator
PASSED

================================================================================================= warnings summary =================================================================================================
../../../../../usr/local/python3.12.13/lib/python3.12/site-packages/torch/jit/_script.py:362: 14 warnings
  /usr/local/python3.12.13/lib/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

tests/platforms/npu/test_minicpmo_code2wav_npugraph.py::test_minicpmo_cfm_estimator_npugraph_matches_eager
  /usr/local/python3.12.13/lib/python3.12/site-packages/torch/nn/functional.py:2415: UserWarning: Cannot create tensor with interal format while allow_internel_format=False, tensor will be created with base format. (Triggered internally at ../torch_npu/csrc/aten/common/TensorFactories.cpp:423.)
    return torch._C._nn.mish(input)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--- Running Summary
========================================================================================== 1 passed, 15 warnings in 0.97s ==========================================================================================
```
