### PR TITLE
[Gepard] Drop default seed to keep requests on the batched sampling path

### DIFF
--- a/tests/model_executor/models/test_gepard_default_seed.py
+++ b/tests/model_executor/models/test_gepard_default_seed.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Gepard deploy configs must not pin a default ``seed``.
+
+Gepard samples all 32 FSQ heads inside ``forward`` and #5666 threads the
+request seed into a per-request ``torch.Generator``, so a ``seed`` in a
+stage's ``default_sampling_params`` routes *every* request onto vLLM's
+seeded sampling path (per-row ``torch.multinomial``) instead of the batched
+path -- the throughput regression PR #4970 removed for ``qwen3_tts.yaml``
+(issue #6178). Determinism is unaffected: a caller that wants it still passes
+a per-request seed, which reaches the in-model sampler.
+
+The cost only shows up under concurrency in slow GPU serving benchmarks, so
+guard the config on CPU here instead.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.helpers.stage_config import get_deploy_config_path
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+DEPLOY_DIR = Path(get_deploy_config_path("gepard.yaml")).parent
+
+
+def _gepard_stages() -> list[tuple[str, int, dict]]:
+    stages = []
+    for name in sorted(path.name for path in DEPLOY_DIR.glob("gepard*.yaml")):
+        config = yaml.safe_load(Path(get_deploy_config_path(name)).read_text())
+        for index, stage in enumerate(config.get("stages") or []):
+            stages.append((name, index, stage))
+    return stages
+
+
+def test_gepard_deploy_configs_exist() -> None:
+    assert _gepard_stages(), f"no Gepard deploy configs found under {DEPLOY_DIR}"
+
+
+@pytest.mark.parametrize(
+    ("config_name", "stage_index", "stage"),
+    _gepard_stages(),
+    ids=lambda value: value if isinstance(value, str) else None,
+)
+def test_gepard_stage_has_no_default_seed(config_name: str, stage_index: int, stage: dict) -> None:
+    params = stage.get("default_sampling_params") or {}
+    assert "seed" not in params, (
+        f"{config_name} stage {stage_index} pins default_sampling_params.seed="
+        f"{params.get('seed')!r}; a default seed forces every request onto the "
+        "per-request seeded sampling path (see #6178, precedent #4970). Callers "
+        "that want determinism should pass a per-request seed instead."
+    )

--- a/vllm_omni/deploy/gepard.yaml
+++ b/vllm_omni/deploy/gepard.yaml
@@ -36,5 +36,4 @@ stages:
       # 40-420 frames -- but a load-bearing one, because this checkpoint's stop
       # head does not fire on every batched trajectory.
       max_tokens: 1000
-      seed: 42
       detokenize: false


### PR DESCRIPTION
## Summary

`vllm_omni/deploy/gepard.yaml` stage 0 pins `seed: 42` in `default_sampling_params`, so it is applied to **every** request that doesn't override it. Since #5666 threads the request seed into a per-request `torch.Generator`, a default seed routes all Gepard traffic onto vLLM's per-request seeded sampling path (per-row `torch.multinomial`) instead of the batched path — the same throughput regression #4970 removed from `qwen3_tts.yaml`.Gepard runs `temperature: 0.0` in the YAML, which drives vLLM's outer sampler to argmax the token that Gepard's `forward` has already chosen. The actual audio-code sampling happens **in-model** via Gumbel-max noise using `self.temperature` from the model config (default ~0.3), which is independent of the YAML `temperature`:```pythonheads = (gathered / self.temperature + self._gumbel_noise(gathered, generators)).argmax(dim=-1)```Dropping the default `seed: 42` therefore **does** change default behavior for callers that don't pass their own `seed`: previously every request rode a fixed seeded stochastic path (`seed=42` → per-request generator), now unset seeds fall to the global RNG, so default output is no longer byte-identical between runs. This is the trade-off #6178 asks about. Per-request reproducibility is unaffected — a caller that wants a deterministic run still passes an explicit `seed` and it reaches the in-model Gumbel-max sampler through #5666's per-request generator.The perf benefit (routing traffic back onto the batched sampling path) is inferred from the merged Qwen3-TTS precedent #4970 rather than measured on Gepard; this PR does not claim a verified Gepard speedup and a concurrency perf smoke would be a good follow-up.Fixes #6178. Mirrors merged precedent #4970. Related: #5666 (per-request generator), #4889 (kept seeded batches batched via per-row generators).## Changes- `vllm_omni/deploy/gepard.yaml`: remove `seed: 42` from stage 0 `default_sampling_params` (one line).- `tests/model_executor/models/test_gepard_default_seed.py`: new CPU deploy-config guard asserting `gepard*.yaml` stages don't pin a default `seed`, so this can't silently regress. Mirrors the existing `tests/diffusion/models/dreamzero/test_deploy_configs.py` pattern (#4970 shipped without a test; this adds one).## TestCPU regression guard, red before / green after the config change:- **Before** removing the line: `test_gepard_stage_has_no_default_seed[gepard.yaml-0-stage0]` **FAILED** — `AssertionError: gepard.yaml stage 0 pins default_sampling_params.seed=42 ...` (`1 failed, 1 passed`).- **After**: `2 passed`.```$ PYTHONPATH=$PWD python -m pytest tests/model_executor/models/test_gepard_default_seed.py -q2 passed, 15 warnings in 0.04s```Note: the ~40% audio_throughput / ~2x TTFP/RTF figures in #6178 are from Qwen3-TTS, not Gepard. This PR is the config-consistency change and does not claim a measured Gepard speedup; a Gepard concurrency perf smoke is tracked as a follow-up.---## Gepard sampling-path A/B (per @hsliuustc0106's review)@hsliuustc0106 correctly pointed out that #4970's numbers are for Qwen3-TTS's vLLM outer-sampler path (`torch.multinomial`), which is **not** where Gepard consumes the seed. Gepard samples its audio codes in-model via Gumbel-max noise in `_gumbel_noise` (`gepard_talker.py`), where the two paths are:- **unseeded** → `torch.rand_like(ref)` — a single kernel launch for the whole batch.- **seeded** (per-request `torch.Generator` from #5666) → `torch.stack([torch.rand(shape, generator=g_i, ...) for g_i in generators])` — one `torch.rand` kernel launch per row.So a pinned default `seed` forces every request onto the per-row path. I benchmarked that path directly.### Caveat on scopeI could not run a full end-to-end serve A/B: the NanoCodec NeMo checkpoint (`nvidia/nemo-nano-codec-22khz-1.89kbps-21.5fps`) was not fetchable in my environment, so TTFP/RTF/audio_throughput are not measured. Instead I benchmarked the disputed function itself — `_gumbel_noise` at Gepard's exact call-site shapes — plus a shape-matched Qwen3.5 decode-step to convert the noise cost into a per-frame percentage. This is the only code path #6398 changes, so it's the most precise measurement of the actual behavior change.### `_gumbel_noise` A/BH200 SXM 141GB, torch 2.11.0+cu130, CUDA 13.0, float32 (the function casts input to fp32 before `-log(-log(rand))`). 500 timed iters + 50 warmup, `cuda.synchronize()` bracketed. Two call-site shapes: `(B, 31, 8)` (heads 1–31) and `(B, 4096)` (head0).| Shape | Batch | Batched p95 (ms) | Seeded p95 (ms) | Slowdown ||-------|------:|-----------------:|----------------:|---------:|| (B, 31, 8) | 8 | 0.042 | 0.125 | 3.0× || (B, 31, 8) | 32 | 0.042 | 0.368 | 8.8× || (B, 4096) | 8 | 0.041 | 0.126 | 3.1× || (B, 4096) | 32 | 0.041 | 0.366 | 8.8× |The batched path is O(1) up to memory bandwidth (one kernel launch); the seeded path scales linearly with batch size because each row is a separate small `torch.rand` launch, so kernel-launch overhead dominates at concurrency.### Per-frame end-to-end estimateShape-matched Qwen3.5 decode step (14 layers × 1024 hidden × 3584 ffn × 8Q/2KV heads × head_dim 256, from `gepard-1.0/config.json`) at KV prefix = 200 frames, bf16, gives the denominator. `_sample_frame` calls `_gumbel_noise` twice per frame (heads 1–31 + head0):| Batch | Path | Frame p95 (ms) | Δ vs batched ||------:|------|---------------:|-------------:|| 8 | batched | 3.73 | — || 8 | seeded | 3.90 | +4.5% || 32 | batched | 4.77 | — || 32 | seeded | 5.42 | **+13.6%** |The backbone step is a shape-clone estimate (real serving adds paged-attn/scheduler overhead, which only grows the denominator's non-sampling part — it does not shrink the absolute ~0.65 ms/frame seeded overhead).### ConclusionAt concurrency=32 the pinned default seed adds **+13.6% p95 per frame**; at concurrency=8 it's +4.5%. This matches #6178's claim that the regression is negligible at low concurrency and significant at high concurrency, and confirms the same batched-vs-per-row mechanism #4970 addressed for Qwen3-TTS — just via Gepard's in-model Gumbel path rather than the outer vLLM sampler. Dropping the default `seed: 42` routes traffic back onto the batched path; per-request reproducibility is unaffected since an explicit `seed` still reaches the in-model sampler via #5666.