### PR TITLE
[Bugfix] Use dedicated WORLD group for distributed VAE communication

### DIFF
--- a/tests/diffusion/distributed/test_distributed_vae_executor.py
+++ b/tests/diffusion/distributed/test_distributed_vae_executor.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from types import SimpleNamespace
 
 import pytest
@@ -58,6 +59,11 @@ class E2EOperator:
         return torch.cat(tiles, dim=0)
 
 
+@dataclass
+class FakeWorldGroup:
+    device_group: object
+
+
 class DummyMixin(DistributedVaeMixin):
     def __init__(self):
         self.use_tiling = True
@@ -75,6 +81,16 @@ def mock_dist(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.fixture(autouse=True)
+def mock_world_group(monkeypatch: pytest.MonkeyPatch):
+    group = object()
+    monkeypatch.setattr(
+        "vllm_omni.diffusion.distributed.autoencoders.distributed_vae_executor.get_world_group",
+        lambda: FakeWorldGroup(device_group=group),
+    )
+    return group
+
+
+@pytest.fixture(autouse=True)
 def mock_dist_vae_executor(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(DistributedVaeExecutor, "gather_tensors", lambda self, x: [x])
     monkeypatch.setattr(DistributedVaeExecutor, "broadcast_tensor", lambda self, x: x)
@@ -83,6 +99,11 @@ def mock_dist_vae_executor(monkeypatch: pytest.MonkeyPatch):
 # ============================
 # Unitest
 # ============================
+
+
+def test_uses_dedicated_world_device_group(mock_world_group):
+    executor = DistributedVaeExecutor()
+    assert executor.group is mock_world_group
 
 
 def test_balance_tasks():

--- a/vllm_omni/diffusion/distributed/autoencoders/distributed_vae_executor.py
+++ b/vllm_omni/diffusion/distributed/autoencoders/distributed_vae_executor.py
@@ -9,6 +9,8 @@ import torch
 import torch.distributed as dist
 from vllm.logger import init_logger
 
+from vllm_omni.diffusion.distributed.parallel_state import get_world_group
+
 logger = init_logger(__name__)
 
 
@@ -43,10 +45,10 @@ class DistributedVaeExecutor:
     """
 
     def __init__(self):
-        # VAE tiles are scheduled across the complete worker WORLD.
-        self.group = None
-        self.world_size = dist.get_world_size()
-        self.rank = dist.get_rank()
+        # Use a dedicated process group spanning the complete worker WORLD.
+        self.group = get_world_group().device_group
+        self.world_size = dist.get_world_size(self.group)
+        self.rank = dist.get_rank(self.group)
         self.parallel_size = 1
         self.parallel_mode = "tile"
 


### PR DESCRIPTION
## Purpose

Fixes #6396.

### What broke

`tests/diffusion/distributed/test_wan_spatial_shard.py::test_spatial_shard_decode_matches_reference` exceeded the `0.03` tolerance in nightly CI. The reported H100 height-shard maximum difference was `0.8535`. I reproduced the failure on 2× NVIDIA B300 SXM6 with maximum differences of `0.941174` for height sharding and `0.808351` for width sharding.

### Root cause

Bisecting identified `14bd8f8772dfb2b6ccb2117d6b9078bbb2edbe66` (#5531) as the first bad commit. That refactor changed `DistributedVaeExecutor` from a dedicated process group to the default WORLD communicator (`group=None`). Wan spatial sharding interleaves halo point-to-point exchange with collectives, and sharing the default communicator corrupts shard-boundary data.

### Fix

Reuse `get_world_group().device_group`, which is the existing dedicated device process group spanning the complete worker WORLD, for distributed VAE communication. Add a regression test asserting that `DistributedVaeExecutor` selects this group.

## Test Plan

CPU unit tests:

```bash
/home/zjy/code/david/.venv/bin/python -m pytest tests/diffusion/distributed/test_distributed_vae_executor.py tests/diffusion/distributed/test_wan_spatial_shard.py -m 'core_model and cpu' -q
```

Two-GPU numeric regression:

```bash
CUDA_VISIBLE_DEVICES=0,1 /home/zjy/code/david/.venv/bin/python -m pytest 'tests/diffusion/distributed/test_wan_spatial_shard.py::test_spatial_shard_decode_matches_reference' -q -s
```

Targeted repository checks:

```bash
/home/zjy/code/david/.venv/bin/pre-commit run --files tests/diffusion/distributed/test_distributed_vae_executor.py vllm_omni/diffusion/distributed/autoencoders/distributed_vae_executor.py
```

**vLLM Version:** 0.27.0

**vLLM-Omni Commit:** 47b18936766ea8ca97e030dce9c70f2e79315fa1

## Test Result

- CPU tests: `30 passed, 2 deselected`
- Two-GPU spatial-shard tests: `2 passed`
- Height sharding after fix: max `0.003235161`, mean `8.231217e-05`
- Width sharding after fix: max `0.002082229`, mean `8.231189e-05`
- Targeted pre-commit hooks: all passed
- `git diff --check`: passed

The local GPU validation used 2× NVIDIA B300 SXM6. The original H100 nightly configuration remains to be confirmed by CI.
