### PR TITLE
[Bugfix][MiniCPM-o] Align active-response final append budget

### DIFF
--- a/tests/e2e/features/fullduplex/engine/test_duplex_runtime.py
+++ b/tests/e2e/features/fullduplex/engine/test_duplex_runtime.py
@@ -1,3 +1,4 @@
+from base64 import b64encode
 from dataclasses import FrozenInstanceError
 from types import SimpleNamespace
 
@@ -396,6 +397,38 @@ def test_duplex_scheduler_token_budget_ignores_client_budget_fields():
         )
         == 16
     )
+
+
+@pytest.mark.parametrize(
+    ("response_in_progress", "expected_token_budget"),
+    [(False, 25), (True, 13)],
+)
+def test_exact_chunk_final_append_reserves_only_for_a_new_response(
+    response_in_progress: bool,
+    expected_token_budget: int,
+):
+    fence = DuplexFence("sid", turn_id=1, response_seq=1)
+    prompt = build_duplex_data_plane_prompt(
+        request_id=duplex_resource_request_id(fence, "stage0"),
+        fence=fence,
+        session_config={},
+        runtime_config={},
+        seq=2,
+        turn_seq=1,
+        mode=DuplexInputMode.APPEND_AUDIO_CHUNK,
+        payload={
+            "audio": b64encode(bytes(16000 * 4)).decode("ascii"),
+            "format": "pcm_f32le",
+            "sample_rate_hz": 16000,
+            "_duplex_response_in_progress": response_in_progress,
+        },
+        final=True,
+    )
+
+    duplex = prompt["model_intermediate_buffer"]["duplex"]
+    assert len(prompt["prompt_token_ids"]) == expected_token_budget
+    assert duplex["scheduler_token_budget"] == expected_token_budget
+    assert duplex["final"] is True
 
 
 def test_resource_state_rejects_fence_regression_and_requires_explicit_fence():

--- a/tests/entrypoints/openai_api/test_duplex_handler.py
+++ b/tests/entrypoints/openai_api/test_duplex_handler.py
@@ -13,7 +13,10 @@ from starlette.websockets import WebSocketDisconnect
 
 from vllm_omni.config.stage_config import DuplexSessionRuntimeConfig
 from vllm_omni.experimental.fullduplex.engine.duplex_control_client import DuplexControlRequestError
-from vllm_omni.experimental.fullduplex.engine.duplex_runtime import duplex_resource_request_id
+from vllm_omni.experimental.fullduplex.engine.duplex_runtime import (
+    DuplexInputMode,
+    duplex_resource_request_id,
+)
 from vllm_omni.experimental.fullduplex.engine.lease import DuplexLeaseActivity
 from vllm_omni.experimental.fullduplex.engine.messages import DuplexFence, DuplexSessionLifecycleMessage
 from vllm_omni.experimental.fullduplex.minicpmo45 import (
@@ -26,6 +29,7 @@ from vllm_omni.experimental.fullduplex.minicpmo45.data_plane import (
 )
 from vllm_omni.experimental.fullduplex.minicpmo45.runtime import (
     MiniCPMO45DuplexRuntimeExtension,
+    build_duplex_data_plane_prompt,
 )
 from vllm_omni.experimental.fullduplex.minicpmo45.session import (
     MiniCPMO45ServingSessionState,
@@ -1363,6 +1367,26 @@ def _native_audio_payload(
     return payload
 
 
+def _scheduler_budget_for_recorded_final_append(
+    appended: tuple[str, str, object, bool],
+) -> int:
+    session_id, mode, payload, final = appended
+    assert final is True
+    fence = DuplexFence(session_id, turn_id=1, response_seq=1)
+    prompt = build_duplex_data_plane_prompt(
+        request_id=duplex_resource_request_id(fence, "stage0"),
+        fence=fence,
+        session_config={},
+        runtime_config={},
+        seq=2,
+        turn_seq=1,
+        mode=DuplexInputMode(mode),
+        payload=payload,
+        final=final,
+    )
+    return prompt["model_intermediate_buffer"]["duplex"]["scheduler_token_budget"]
+
+
 def _auto_response_context(
     session_id: str,
     *,
@@ -1658,6 +1682,7 @@ async def test_auto_response_overlap_exact_unit_commit_does_not_block_or_replay_
         assert isinstance(payload, dict)
         assert np.frombuffer(base64.b64decode(payload["audio"]), dtype="<f4").shape == (16000,)
         assert payload.get("force_listen") is not True
+        assert payload["_duplex_response_in_progress"] is True
     assert engine.appended_fences == [expected_fence, expected_fence]
     assert engine.active_response_ids_at_append == [response_id, response_id]
     assert engine.response_done_seen_at_append is False
@@ -1951,6 +1976,7 @@ async def test_auto_response_committed_overlap_does_not_precreate_empty_response
             "sample_rate_hz": 16000,
             "duration_ms": 200,
             "is_speech": True,
+            "_duplex_response_in_progress": False,
         }
         for _ in range(4):
             ws.put(chunk)
@@ -1987,6 +2013,8 @@ async def test_auto_response_committed_overlap_does_not_precreate_empty_response
         assert overlap_sent is True
         assert len(engine.appended) == 2
         assert engine.appended[1][3] is True
+        assert engine.appended[1][2]["_duplex_response_in_progress"] is True
+        assert _scheduler_budget_for_recorded_final_append(engine.appended[1]) == 13
         assert ws.sent_types().count("response.created") == 1
     finally:
         ws.put({"type": "session.close"})
@@ -6029,7 +6057,14 @@ async def test_minicpmo_native_duplex_accepts_next_append_after_response_done():
             return
         done_count += 1
         if done_count == 1:
-            ws.put({"type": "input_audio_buffer.append", "audio": "BBBB", "format": "pcm_f32le"})
+            ws.put(
+                {
+                    "type": "input_audio_buffer.append",
+                    "audio": "BBBB",
+                    "format": "pcm_f32le",
+                    "_duplex_response_in_progress": True,
+                }
+            )
             ws.put({"type": "input_audio_buffer.commit", "final": True})
             ws.put({"type": "response.create"})
         else:
@@ -6046,6 +6081,7 @@ async def test_minicpmo_native_duplex_accepts_next_append_after_response_done():
     assert len(engine.appended) >= 2, [
         (message.get("type"), message.get("code"), message.get("reason")) for message in ws.sent
     ]
+    assert engine.appended[1][2]["_duplex_response_in_progress"] is False
     assert len([m for m in ws.sent if m.get("type") == "response.done"]) == 2
 
 
@@ -6176,7 +6212,105 @@ async def test_minicpmo_native_auto_response_accepts_realtime_commit_after_strea
 
 
 @pytest.mark.asyncio
-async def test_minicpmo_native_auto_response_post_response_commit_ignores_stale_progress_state():
+async def test_minicpmo_native_active_response_exact_final_uses_unit_budget():
+    session_id = "sid-native-active-exact-final"
+    engine = FakeEngineClient()
+    handler = OmniDuplexSessionHandler(
+        chat_service=FakeChatService(engine),
+        config_timeout_s=0.1,
+        idle_timeout_s=1,
+    )
+
+    def on_send(ws: TimedWebSocket, data: dict[str, Any]) -> None:
+        if data.get("type") != "session.created":
+            return
+        session = handler._registry.get(session_id)
+        assert session is not None
+        session.begin_response()
+        ws.put(
+            {
+                "type": "input_audio_buffer.append",
+                "audio": _pcm_f32_b64(8000),
+                "format": "pcm_f32le",
+                "sample_rate_hz": 16000,
+                "_duplex_response_in_progress": False,
+            }
+        )
+        ws.put({"type": "input_audio_buffer.commit", "final": True})
+        ws.put({"type": "session.close"})
+
+    ws = TimedWebSocket(on_send=on_send)
+    create = _native_session_create(session_id)
+    create["session"]["extra_body"]["auto_response"] = True
+    ws.put(create)
+
+    await handler.handle_session(ws)
+
+    assert len(engine.appended) == 1
+    assert engine.appended[0][3] is True
+    assert engine.appended[0][2]["_duplex_response_in_progress"] is True
+    assert _scheduler_budget_for_recorded_final_append(engine.appended[0]) == 13
+
+
+@pytest.mark.asyncio
+async def test_minicpmo_native_precreated_response_keeps_idle_unit_budget():
+    class PrecreateObservingEngine(FakeEngineClient):
+        def __init__(self) -> None:
+            super().__init__()
+            self.active_response_ids_at_append: list[str | None] = []
+
+        async def append_duplex_input_async(self, session_id: str, **kwargs):
+            session = handler._registry.get(session_id)
+            assert session is not None
+            self.active_response_ids_at_append.append(session.active_response_id)
+            kwargs.pop("expected_epoch", None)
+            return await super().append_duplex_input_async(session_id, **kwargs)
+
+    session_id = "sid-native-precreated-response"
+    engine = PrecreateObservingEngine()
+    handler = OmniDuplexSessionHandler(
+        chat_service=FakeChatService(engine),
+        config_timeout_s=0.1,
+        idle_timeout_s=1,
+    )
+
+    def on_send(ws: TimedWebSocket, data: dict[str, Any]) -> None:
+        if data.get("type") != "session.created":
+            return
+        ws.put(
+            {
+                "type": "input_audio_buffer.append",
+                "audio": _pcm_f32_b64(8000),
+                "format": "pcm_f32le",
+                "sample_rate_hz": 16000,
+                "_duplex_response_in_progress": True,
+            }
+        )
+        ws.put(
+            {
+                "type": "input_audio_buffer.commit",
+                "final": True,
+                "response_create": True,
+            }
+        )
+        ws.put({"type": "session.close"})
+
+    ws = TimedWebSocket(on_send=on_send)
+    ws.put(_native_session_create(session_id))
+
+    await handler.handle_session(ws)
+
+    assert len(engine.appended) == 1
+    assert engine.appended[0][3] is True
+    assert len(engine.active_response_ids_at_append) == 1
+    assert engine.active_response_ids_at_append[0] is not None
+    assert engine.appended[0][2]["_duplex_response_in_progress"] is False
+    assert _scheduler_budget_for_recorded_final_append(engine.appended[0]) == 25
+    assert ws.sent_types().count("response.created") == 1
+
+
+@pytest.mark.asyncio
+async def test_minicpmo_native_auto_response_initial_commit_ignores_spoofed_progress_state():
     session_id = "sid-native-auto-post-response"
     engine = FakeEngineClient()
     handler = OmniDuplexSessionHandler(
@@ -6196,6 +6330,7 @@ async def test_minicpmo_native_auto_response_post_response_commit_ignores_stale_
                 "audio": _pcm_f32_b64(8000),
                 "format": "pcm_f32le",
                 "sample_rate_hz": 16000,
+                "_duplex_response_in_progress": True,
             }
         )
         ws.put({"type": "input_audio_buffer.commit", "final": True})
@@ -6210,6 +6345,8 @@ async def test_minicpmo_native_auto_response_post_response_commit_ignores_stale_
 
     assert len(engine.appended) == 1
     assert engine.appended[0][3] is True
+    assert engine.appended[0][2]["_duplex_response_in_progress"] is False
+    assert _scheduler_budget_for_recorded_final_append(engine.appended[0]) == 25
     assert "input.committed" in ws.sent_types()
     assert not any(message.get("code") == "response_already_active" for message in ws.sent)
 

--- a/vllm_omni/experimental/fullduplex/minicpmo45/runtime.py
+++ b/vllm_omni/experimental/fullduplex/minicpmo45/runtime.py
@@ -119,7 +119,8 @@ def build_duplex_data_plane_prompt(
             )
     if seq > 1 and duplex_payload_is_exact_chunks(payload):
         token_budget += 1
-    if final and duplex_payload_is_exact_chunks(payload):
+    response_in_progress = isinstance(payload, dict) and payload.get("_duplex_response_in_progress") is True
+    if final and duplex_payload_is_exact_chunks(payload) and not response_in_progress:
         token_budget += 12
     extra_body = session_config.get("extra_body")
     raw_token_id = runtime_config.get("duplex_scheduler_token_id")

--- a/vllm_omni/experimental/fullduplex/openai/session_runner.py
+++ b/vllm_omni/experimental/fullduplex/openai/session_runner.py
@@ -328,6 +328,12 @@ class DuplexSessionRunnerMixin:
             append_turn_id = payload_turn_id(payload)
             if append_turn_id is None:
                 append_turn_id = session.turn_id
+            runtime_payload = payload
+            if isinstance(payload, dict):
+                runtime_payload = {
+                    **payload,
+                    "_duplex_response_in_progress": session.active_response_id is not None,
+                }
             request_id = self._native_stage0_request_id(session, append_epoch)
             if final or precreate_response:
                 session.bind_request(request_id)
@@ -349,7 +355,7 @@ class DuplexSessionRunnerMixin:
                 try:
                     append_ok, emitted_response = await self._append_runtime_input(
                         session,
-                        payload,
+                        runtime_payload,
                         operation_id=(pcm_reservation.operation_id if pcm_reservation is not None else operation_id),
                         final=final,
                         send_json=emit_event,


### PR DESCRIPTION
## Summary

- Snapshot whether a native-duplex response is already active when an audio append is accepted.
- Avoid the 12-slot final reserve only for successful exact-unit appends accepted during an active response.
- Preserve idle/new-response behavior and add cross-layer regressions for active, precreated, post-`response.done`, overlapping, and client-spoofed states.

## Root cause

During an active response, an exact-chunk final append reserved 25 scheduler positions while MiniCPM Stage 0 materialized only 13 embeddings. Preprocessing filled the 12-position surplus with `</unit>` embeddings, which changed the KV context and delayed the model-owned semantic stop.

The serving layer now records the active-response state at input acceptance time, before a new response may be precreated. The MiniCPM runtime uses that server-owned marker to omit the unmatched reserve only for the affected path.

## Scope

This aligns the default model-owned `listen_only` path after output has begun. It does not add hard server-side barge-in, atomic cross-stage cancellation/fencing, stale audio suppression, or pre-first-output interruption.

Related to #6101.

## Validation

- Commit hooks: passed
- Focused regression: 8 passed
- Related duplex runtime/handler files: 231 passed
- Full duplex engine suite: 85 passed
- Ruff check/format and `git diff --check`: passed
- Real-model GPU matrix on aligned inputs:
  - candidate: 8/12 semantic stops
  - MiniCPM challenge reference: 6/12
  - prior main: 2/12
  - no-interrupt controls: 4/4
  - client/server errors: 0

The GPU matrix used the same model snapshot, prompts, audio inputs, sampling parameters, request order, and observation window for all compared arms.