### PR TITLE
[bugfix][diffusion] Enable request-level batching via online entrypoint for diffusion models

### DIFF
--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -177,7 +177,12 @@ class OmniBase(PDDisaggregationMixin):
         # override the deploy YAML's ``async_chunk: true`` default.
         async_chunk = kwargs.get("async_chunk")
         output_modalities = kwargs.pop("output_modalities", None)
-        diffusion_batch_size: int = kwargs.pop("diffusion_batch_size", 1)
+        # Stage init overwrites ``od_config.max_num_seqs`` with this value.
+        # ``vllm serve --omni --max-num-seqs N`` is the documented request-batch
+        # knob; use it when ``diffusion_batch_size`` is not passed explicitly.
+        explicit_batch = kwargs.pop("diffusion_batch_size", None)
+        max_num_seqs = kwargs.get("max_num_seqs") or 1
+        diffusion_batch_size = int(explicit_batch if explicit_batch is not None else max_num_seqs)
 
         if "log_requests" in kwargs:
             raise TypeError("`log_requests` has been removed in Omni/AsyncOmni. Use `log_stats`.")


### PR DESCRIPTION


## Summary

This PR makes `vllm serve --omni --max-num-seqs N` correctly control the default diffusion request batch size when `--diffusion-batch-size` is not explicitly provided (BTW, `--diffusion-batch-size` is not a valid CLI argument for `vllm serve`).

Previously, even if users started omni serving with:

```bash
vllm serve ... --omni --max-num-seqs N
```

the diffusion model could still run with `diffusion_batch_size=1`, so the documented request batching knob did not actually take effect for diffusion workloads.

While using `AsyncOmni(diffusion_batch_size=N)` is working correctly, this PR wants to enable diffusion batching currently for online entrypoint.

## Motivation

During diffusion stage initialization, `od_config.max_num_seqs` is overwritten by the resolved diffusion batch size:

```python
od_config.max_num_seqs = batch_size
```

Because of this, the effective diffusion batching capacity is determined by `diffusion_batch_size`.

Before this change, when `diffusion_batch_size` was not explicitly provided, it defaulted to `1`. This caused the following behavior:

- `--max-num-seqs N` was accepted by the server configuration.
- Diffusion stage startup later overwrote `od_config.max_num_seqs` with `diffusion_batch_size`.
- Since `diffusion_batch_size` was still `1`, diffusion request batching remained effectively limited to batch size `1`.
- Users had to pass an extra diffusion-specific batch size option even though `--max-num-seqs` is the documented request batching knob. 

## What Changed

This PR changes omni engine argument handling so that `diffusion_batch_size` is resolved from `max_num_seqs` when it is not explicitly set:

```python
explicit_batch = kwargs.pop("diffusion_batch_size", None)
max_num_seqs = kwargs.get("max_num_seqs") or 1
diffusion_batch_size = int(
    explicit_batch if explicit_batch is not None else max_num_seqs
)
```

The new behavior is:

- If `diffusion_batch_size` is explicitly provided, it still takes precedence.
- If `diffusion_batch_size` is not provided, it defaults to `max_num_seqs`.
- If neither value is provided, the fallback remains `1`.

## Effect After This Change

After this PR, users can configure diffusion request batching with the standard serving option:

```bash
vllm serve ... --omni --max-num-seqs 4
```

In this case, the diffusion model will use an effective batch size of `4`, unless `--diffusion-batch-size` is explicitly set to another value. An example output is:
```bash
INFO 08-20 08:58:55 [diffusion_pipeline_profiler.py:32] [DiffusionPipelineProfiler] Wan22Pipeline.text_encoder.forward took 0.087888s
INFO 08-20 08:58:55 [diffusion_pipeline_profiler.py:32] [DiffusionPipelineProfiler] Wan22Pipeline.text_encoder.forward took 0.087681s
INFO 08-20 08:58:56 [diffusion_pipeline_profiler.py:32] [DiffusionPipelineProfiler] Wan22Pipeline.text_encoder.forward took 0.087087s
INFO 08-20 08:58:56 [diffusion_pipeline_profiler.py:32] [DiffusionPipelineProfiler] Wan22Pipeline.text_encoder.forward took 0.087135s
100%|███████████████████████████████████████████████████████████████████████████████████████████| 50/50 [02:33<00:00,  3.07s/it]
INFO 08-20 09:01:29 [diffusion_pipeline_profiler.py:32] [DiffusionPipelineProfiler] Wan22Pipeline.diffuse took 153.415677s
INFO 08-20 09:01:29 [diffusion_pipeline_profiler.py:32] [DiffusionPipelineProfiler] Wan22Pipeline.diffuse took 153.415595s
INFO 08-20 09:01:45 [diffusion_pipeline_profiler.py:32] [DiffusionPipelineProfiler] Wan22Pipeline.vae.decode took 16.236813s
INFO 08-20 09:01:45 [diffusion_pipeline_profiler.py:32] [DiffusionPipelineProfiler] Wan22Pipeline.forward took 169.843718s
INFO 08-20 09:01:45 [diffusion_pipeline_profiler.py:32] [DiffusionPipelineProfiler] Wan22Pipeline.vae.decode took 16.306176s
INFO 08-20 09:01:45 [diffusion_pipeline_profiler.py:32] [DiffusionPipelineProfiler] Wan22Pipeline.forward took 169.917127s
(APIServer pid=543700) INFO 08-20 09:01:45 [diffusion_engine.py:578] [RequestBatch] admission wait done waiting=4 max_batch=4 waited_ms=0.0
```

`[RequestBatch] admission wait done waiting=4 max_batch=4 waited_ms=0.0` shows the effective batch size. Before this change, when the effective batch size is 1, the `Wan22Pipeline.diffuse` took around 37s.

This makes omni serving behavior match user expectations and avoids a silent mismatch where `--max-num-seqs` appears configured but diffusion execution still runs with batch size `1`.

## Backward Compatibility

This change preserves existing behavior for users who explicitly set `diffusion_batch_size`.

The only behavior change is for the implicit/default case: diffusion serving now follows the documented `--max-num-seqs` batching setting instead of silently falling back to `1`.