### PR TITLE
[Bugfix] Fix Qwen3-Omni fastsafetensors load OOM

### DIFF
--- a/tests/model_executor/models/qwen3_omni/test_qwen3_omni_load_weights.py
+++ b/tests/model_executor/models/qwen3_omni/test_qwen3_omni_load_weights.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Iterable, Iterator
+
+import pytest
+import torch
+from torch import nn
+
+from vllm_omni.model_executor.models.qwen3_omni.qwen3_omni import (
+    Qwen3OmniMoeForConditionalGeneration,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class _WeightLoader(nn.Module):
+    def __init__(self, events: list[str]):
+        super().__init__()
+        self.events = events
+        self.names: list[str] = []
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        self.events.append("load")
+        self.names = [name for name, _ in weights]
+        return set()
+
+
+def test_load_weights_streams_the_active_stage():
+    events: list[str] = []
+
+    def weight_source() -> Iterator[tuple[str, torch.Tensor]]:
+        for name in ("thinker.layer.weight", "talker.layer.weight"):
+            events.append("yield")
+            yield name, torch.empty(0)
+
+    model = object.__new__(Qwen3OmniMoeForConditionalGeneration)
+    nn.Module.__init__(model)
+    model.model_stage = "thinker"
+    model.thinker = _WeightLoader(events)
+    model.talker = None
+    model.code2wav = None
+
+    model.load_weights(weight_source())
+
+    assert events[0] == "load"
+    assert model.thinker.names == ["thinker.layer.weight"]

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -1362,38 +1362,28 @@ class Qwen3OmniMoeForConditionalGeneration(
         )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        """Load weights for all components of the omni model."""
+        """Stream weights into the active component of the omni model."""
         loaded_weights = set()
-        thinker_weights = []
-        talker_weights = []
-        code2wav_weights = []
+        known_prefixes = ("thinker.", "talker.", "code2wav.")
 
-        # Separate weights by component
-        for k, v in weights:
-            if k.startswith("thinker."):
-                thinker_weights.append((k, v))
-            elif k.startswith("talker."):
-                talker_weights.append((k, v))
-            elif k.startswith("code2wav."):
-                code2wav_weights.append((k, v))
-            else:
-                logger.warning(f"Unknown weight prefix: {k}")
-        # Load thinker weights
-        if self.thinker and thinker_weights:
-            thinker_loaded = self.thinker.load_weights(thinker_weights)
+        def stage_weights(prefix: str) -> Iterable[tuple[str, torch.Tensor]]:
+            for name, weight in weights:
+                if name.startswith(prefix):
+                    yield name, weight
+                elif not name.startswith(known_prefixes):
+                    logger.warning(f"Unknown weight prefix: {name}")
+
+        if self.thinker:
+            thinker_loaded = self.thinker.load_weights(stage_weights("thinker."))
             thinker_loaded = add_prefix_to_loaded_weights(thinker_loaded, "thinker")
             loaded_weights.update(thinker_loaded)
-
-        # Load talker weights
-        if self.talker and talker_weights:
-            talker_loaded = self.talker.load_weights(talker_weights)
+        elif self.talker:
+            talker_loaded = self.talker.load_weights(stage_weights("talker."))
             talker_loaded = add_prefix_to_loaded_weights(talker_loaded, "talker")
             loaded_weights.update(talker_loaded)
             loaded_weights.update(self._init_special_tokens_embeddings())
-
-        # Load code2wav weights
-        if self.code2wav and code2wav_weights:
-            code2wav_loaded = self.code2wav.load_weights(code2wav_weights)
+        elif self.code2wav:
+            code2wav_loaded = self.code2wav.load_weights(stage_weights("code2wav."))
             code2wav_loaded = add_prefix_to_loaded_weights(code2wav_loaded, "code2wav")
             loaded_weights.update(code2wav_loaded)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Qwen3-Omni currently collects the complete weight iterator into separate component lists before loading the active stage. With fastsafetensors, those tensors can retain GPU-backed shard storage, so each stage can accumulate the whole checkpoint on its GPU and run out of memory before loading completes.

Stream only the active component weights into its loader instead. This follows vLLM's single-pass weight-loading pattern and avoids retaining weights for inactive components in temporary lists.

## Test Plan

```
vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omn --port 8091 --load-format fastsafetensors --enforce-eager
```

```
python3 examples/online_serving/openai_chat_completion_client_for_multimodal_generation.py --model Qwen/Qwen3-Omni-30B-A3B-Instruct --query-type use_audio --audio-path mary_had_lamb.ogg --modalities text,audio  --stream --host localhost --port 8091
```

Also added a CPU regression test that verifies the active loader starts before the source iterator is consumed and receives only weights matching its prefix.

**vLLM Version:**
cdb8545a91be16f2b80234e0801458ad2a18cf1b

**vLLM-Omni Commit:**
dev/vllm-align (09ed2df28680aaf966b74d751471b45c8980f0ad)

## Test Result

```
INFO 08-20 07:28:48 [patch.py:252] NVFP4 W4A4 weight_scale NaN-clamp: installed.                                                                                                                                                                                                                                              
INFO 08-20 07:28:49 [patch.py:503] inductor factorable-divisibility patch: installed.                                                                                                                                                                                                                                         
INFO 08-20 07:28:49 [patch.py:568] [cumem-cuda] CuMemAllocator._python_free_callback patched: asleep guard extended to all platforms.                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                              
content:The audio contains a man reciting the nursery rhyme "Mary Had a Little Lamb." He begins by saying, "The first words I spoke in the original phonograph," before reciting the rhyme:                                                                                                                                   
                                                                                                                                                                                                                                                                                                                              
"Mary had a little lamb, its fleece was white as snow. And everywhere that Mary went, the                                                                      
Audio saved to audio_chatcmpl-880aae1c959d8c73_0.wav                                                                                                                                                                                                                                                                          
 lamb was sure to go."                                                                                                                                                                                                                                                                                                        
Audio saved to audio_chatcmpl-880aae1c959d8c73_1.wav                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                              
Audio saved to audio_chatcmpl-880aae1c959d8c73_2.wav                                                                                                                                                                                                                                                                          
                                                                                                                                                               
Audio saved to audio_chatcmpl-880aae1c959d8c73_3.wav                                                                                                           
                                                                                                                                                               
Audio saved to audio_chatcmpl-880aae1c959d8c73_4.wav                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                              
Audio saved to audio_chatcmpl-880aae1c959d8c73_5.wav                                                                                                           
                                                                                                                                                                                                                                                                                                                              
Audio saved to audio_chatcmpl-880aae1c959d8c73_6.wav                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                              
Audio saved to audio_chatcmpl-880aae1c959d8c73_7.wav                                                                                                           
                                                                                                                                                                                                                                                                                                                              
Audio saved to audio_chatcmpl-880aae1c959d8c73_8.wav                                                                                                           
                                                                                                                                                                                                                                                                                                                              
Audio saved to audio_chatcmpl-880aae1c959d8c73_9.wav
```

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
