### PR TITLE
[CI][Diffusion] Add tiny model builder for StableDiffusion3Pipeline

### DIFF
--- a/tests/model_tests/diffusion/diff_model_builders.py
+++ b/tests/model_tests/diffusion/diff_model_builders.py
@@ -129,6 +129,28 @@ def tiny_flux_kontext_builder() -> str:
     )
 
 
+def _shrink_sd3_transformer(config: dict) -> dict:
+    config["num_layers"] = 2
+    config["attention_head_dim"] = 32
+    config["num_attention_heads"] = 4
+    config["caption_projection_dim"] = 128
+    config["dual_attention_layers"] = [0]
+    return config
+
+
+def tiny_sd3_builder() -> str:
+    return build_tiny_from_configs(
+        "StableDiffusion3Pipeline",
+        "stabilityai/stable-diffusion-3.5-medium",
+        transform={
+            "text_encoder": _shrink_flux_clip_text_encoder,
+            "text_encoder_2": _shrink_flux_clip_text_encoder,
+            "text_encoder_3": _shrink_flux_t5_text_encoder,
+            "transformer": _shrink_sd3_transformer,
+        },
+    )
+
+
 def tiny_flux2_builder() -> str:
     def shrink_text_encoder(config: dict) -> dict:
         # The real checkpoint ships language_model.lm_head.weight as its own

--- a/tests/model_tests/diffusion/model_settings.py
+++ b/tests/model_tests/diffusion/model_settings.py
@@ -84,4 +84,9 @@ DIFFUSION_TEST_SETTINGS = {
         builder=diff_model_builders.tiny_qwen_image_edit_plus_builder,
         supported_tasks=[DiffusionTasks.IMAGE_TO_IMAGE],
     ),
+    "StableDiffusion3Pipeline": DiffusionModelTestOpts(
+        model="stabilityai/stable-diffusion-3.5-medium",
+        builder=diff_model_builders.tiny_sd3_builder,
+        supported_tasks=[DiffusionTasks.TEXT_TO_IMAGE],
+    ),
 }

--- a/tests/model_tests/diffusion/test_alignment.py
+++ b/tests/model_tests/diffusion/test_alignment.py
@@ -48,7 +48,6 @@ EXCLUDED_MODELS = [
     "MingImagePipeline",
     "InternVLAA1Pipeline",
     "LongCatImageEditPipeline",
-    "StableDiffusion3Pipeline",
     "HunyuanImage3ForCausalMM",
     "ErnieImagePipeline",
     "NextStep11Pipeline",


### PR DESCRIPTION
## Summary
- Add a tiny model builder for `StableDiffusion3Pipeline` so it gets CI test coverage
- Reuses existing `_shrink_flux_clip_text_encoder` and `_shrink_flux_t5_text_encoder` functions; only adds a new `_shrink_sd3_transformer` (reduces layers to 2, heads to 4, head_dim to 32)
- Uses `build_tiny_from_configs` since SD3 classes are in diffusers
- Removes `StableDiffusion3Pipeline` from `EXCLUDED_MODELS` in alignment tests

## Test plan
- [x] `pytest tests/model_tests/diffusion/test_alignment.py -v` — both alignment tests pass
- [x] `pytest tests/model_tests/diffusion/test_common_offline.py -k "StableDiffusion3Pipeline" -v` — text-to-image, determinism, and multi-output subtests all pass
