### PR TITLE
Qwen-image nightly-CI

### DIFF
--- a/refactor/00_refactor_work_rules.md
+++ b/refactor/00_refactor_work_rules.md
@@ -1,0 +1,154 @@
+# vLLM-Omni Refactor 講解／寫作規則
+
+本文件由 `example/example1.md`、`example/example2.md`、`example/example3.md` 抽出，作為 `refactor/` 分析文件嘅工作規則。  
+用途：**講解「點寫」**；具體領域內容見對應 analysis（例如 `omni_coordinator_analysis.md`）。
+
+---
+
+## 1. 目的同邊界
+
+1. 文件層級係 **analysis / RFC**，唔係最終 implementation design。
+2. Target path、draft class／function、mermaid 分層圖，一律標明 **draft only**——用嚟幫 reviewer 睇 ownership 邊界，唔係承諾最終目錄名。
+3. 唔好喺 analysis 度 silently 改行為；若問題牽涉行為變更，要寫清楚「reorganization」vs「behavior change」。
+4. Out-of-scope 但會影響本區嘅檔案，另開一節（學 example3 嘅 *OUT of the Scope Directory but Relevant*），唔好 silently 膨脹 scope。
+
+---
+
+## 2. Front matter（每份 analysis 必備）
+
+| 欄位 | 要求 |
+|------|------|
+| Title | 建議 `[Analysis] <area> …`（對齊 example2） |
+| Disclaimer | 開頭聲明：analysis-level；proposed paths／draft code 非最終設計 |
+| Area | Primary area + Primary file + Adjacent files |
+| Proposed Priority | 例如 P0／P1，附一句 reason |
+| Owner | GitHub handle 或 TBD |
+| Code base | Branch + Commit SHA + Commit title（對齊 example1） |
+
+可選但強烈建議：
+
+- **Goal / Scope**（example3）：Focus bullets + 目錄清單 + rename／delete 意圖
+- **Potential Path Impact Summary**（example2）：PR → current path(s) → target path(s, draft) → main problem
+
+---
+
+## 3. 必寫現況
+
+順序固定：
+
+1. **Current Responsibility** — 而家呢個檔／套件實際擁有咩（唔係「應該擁有咩」）
+2. **Main Code Paths** — startup → runtime → shutdown；可用 ASCII 或 mermaid
+3. **Related files** — 主檔 + 測試 + design doc（如有）
+4. （可選）**File inventory** — 粗略行數，方便後面估 PR LOC
+
+路徑圖規則：
+
+- 標清入口（CLI／HTTP／engine）同關鍵物件名
+- 標 file path（必要時加行號）
+- 多路徑時用表對照（學 example1 嘅 Path／Request object 表）
+
+---
+
+## 4. 問題寫法（Problems Observed）
+
+每個 Problem 必須有呢四段（可改名，但資訊唔好缺）：
+
+1. **Current evidence** — path:line 或精簡 snippet（唔好淨係口號）
+2. **Draft direction** — draft-only 介面／目錄／偽代碼
+3. **How this helps** — 對 review、測試、ownership 有咩具體好處
+4. **Relevant PR** — 對應邊個 PR（可多個）
+
+可選：
+
+- **Coordinator / PIC**（example1）— 邊個跟進
+- **Why now** — 同其他 RFC（例如 stage rename）嘅依賴關係
+
+問題選擇準則：
+
+- 優先寫 **ownership 分裂、雙通道、god-file、可測性缺口、跨 modality／跨 family 依賴**
+- 唔好堆純 naming bike-shed；rename 要服務於 ownership 或刪冗余
+- AI 生成、過長 if-else、命名不清亦可以寫，但要附 evidence（example1 Problem 2）
+
+---
+
+## 5. PR 拆法
+
+1. **高風險組裝面先 PR0 guardrails**（route map、app-state、membership／LB 不變式、關鍵 golden behavior）。純加測試、唔搬邏輯。
+2. 之後每個 PR 只搬 **一個 ownership 邊界**（一個 family／一個合併／一層 startup）。
+3. 每份 analysis 要有：
+   - **Potential Path Impact Summary** 表
+   - **PR Breakdown**（focus files）
+   - （可選）粗略 +/- LOC；強調 reorganization、logic 行數大致持平（example2）
+4. 標明同相鄰 RFC 嘅銜接（例如 Coordinator PR2 ↔ Stage RFC PR2），避免兩邊各自改同一介面。
+
+禁止：
+
+- 一個大 PR 同時 rename + merge + 行為變更 + 刪測試
+- 未有 guardrail 就拆 public serving／distributed membership 熱路徑
+
+---
+
+## 6. 邊界同依賴規則
+
+1. 寫清 **dependency direction**：邊啲套件可以 import 邊啲；邊啲永遠唔好互相 import serving／client 層。
+2. Cross-boundary 服務呼叫用 **Protocol／注入**，唔好 module-level 互相 import（example2 `ImageChatBridge` 精神）。
+3. Split 原則要講清楚係 **endpoint-family / ownership**，定係 pure modality／pure rename——唔好混稱。
+4. 若文件畫嘅 mermaid 同正文目標有張力，**以正文合併／刪除意圖為準**，並喺文內點名（避免 reviewer 跟錯圖）。
+
+---
+
+## 7. Draft interface 寫法
+
+1. 只展示 **public surface** 同關鍵建構參數，唔要貼成個檔。
+2. 標 `# draft only` 或說明 “Just a draft, not the final design”。
+3. Delete／rename 用清晰箭頭：`old.py -> delete`、`a.py -> b.py`。
+4. 合併類（例如 Master + Coordinator）要列：
+   - 接收邊啲舊參數
+   - 對外保留邊啲 hub／master API
+   - TCP vs IPC（或同等 transport）規則
+
+---
+
+## 8. 語言同交付位置
+
+| 文件 | 語言 | 位置 |
+|------|------|------|
+| 講解規則（本檔） | 繁體中文 | `refactor/00_refactor_work_rules.md` |
+| 可上 GitHub 嘅 analysis／RFC | 英文（對齊 example1–3） | `refactor/<area>_analysis.md` |
+| 閱讀用對照版（可選） | 繁體中文 | `refactor/<area>_analysis.zh.md` |
+| 參考樣例 | 英文 | `example/example1.md` … `example3.md` |
+
+講解建議順序：
+
+1. 先用本檔講「點寫／點拆 PR」
+2. 再用對應 analysis 講「呢個 area 寫咗啲咩問題同目標」
+
+---
+
+## 9. 完成檢查清單（寫完 analysis 自檢）
+
+- [ ] 已 pin branch + commit
+- [ ] Area／Adjacent／Owner／Priority 齊
+- [ ] 有 Current Responsibility + Main Code Paths
+- [ ] 每個 Problem 有 evidence → draft → helps → PR
+- [ ] 有 PR0（或說明點解唔需要）同後續細 PR
+- [ ] Target path／interface 標 draft only
+- [ ] Out-of-scope-but-relevant 已分隔
+- [ ] 同相鄰 RFC 嘅銜接已寫一句
+- [ ] 無承諾未驗證嘅行為／精度數字
+
+---
+
+## 10. 三份 example 對照（速查）
+
+| 能力 | example1 | example2 | example3 |
+|------|----------|----------|----------|
+| Pin commit | ✓ | （issue 風格） | （RFC 風格） |
+| 路徑圖 | ✓ ASCII | ✓ 步驟 | ✓ mermaid layers |
+| Problem + snippet | ✓ | ✓ | 改為 per-file proposed changes |
+| PR 路徑表 + LOC | | ✓ | ✓ breakdown |
+| Rename／delete 清單 | | | ✓ |
+| Out-of-scope relevant | | 部分 | ✓ |
+| Dependency direction | | ✓ | 部分（介面草圖） |
+
+**本專案預設混合模板**：example2 骨架 + example1 evidence 密度 + example3 Goal／rename／delete／PR Breakdown。

--- a/refactor/omni_coordinator_analysis.md
+++ b/refactor/omni_coordinator_analysis.md
@@ -1,0 +1,468 @@
+# [Analysis] OmniCoordinator package system analysis
+
+> Simplified Chinese (canonical for CN reviewers): [`omni_coordinator_analysis.zh.md`](omni_coordinator_analysis.zh.md)  
+> Per-function audit (zh): [`omni_coordinator_code_audit.zh.md`](omni_coordinator_code_audit.zh.md)  
+> Level: **analysis** (current state + risks); not final design.
+
+**Scope:** all 7 files under `vllm_omni/distributed/omni_coordinator/`  
+**Code base:** `main` @ `c27623c2`
+
+---
+
+## 1. Architecture and sequencing
+
+**When it starts:** only under `DistStageRuntime` (`--stage-id` + master). Ordinary in-process multi-stage does **not** start the Coordinator.
+
+### 1.1 Current structure
+
+`DistStageRuntime` → `OmniCoordinatorRuntime` → `OmniCoordinator` (Runtime on Head; Coord in a child process).
+
+```mermaid
+flowchart LR
+  subgraph L["Head"]
+    direction TB
+    DSR[DistStageRuntime]
+    RT[OmniCoordinatorRuntime]
+    Master[OmniMasterServer]
+    Mem[MembershipController]
+    Hub[OmniCoordClientForHub]
+    Pool[StagePool]
+    LB[LoadBalancer]
+    DSR --> RT
+    DSR --> Master
+    DSR --> Mem
+    Mem -->|owns| Hub
+    Hub -.->|snapshot| Mem
+    Mem --> Pool
+    Hub -.->|snapshot| Pool
+    Pool --> LB
+  end
+
+  subgraph C["OmniCoordinator"]
+    OC[OmniCoordinator]
+  end
+
+  subgraph R["Stage"]
+    SC[OmniCoordClientForStage]
+  end
+
+  RT -->|starts| OC
+  Master -.->|router_addr| SC
+  SC -->|DEALER| OC
+  OC -->|PUB| Hub
+
+  L ~~~ C ~~~ R
+```
+
+| Component | Role |
+|-----------|------|
+| `OmniCoordinatorRuntime` | Start/stop Coord; expose router／pub only |
+| `OmniCoordinator` | In-memory registry + ROUTER／PUB |
+| `OmniMasterServer` | Allocates handshake／I／O addresses on register; echoes router_addr |
+| `OmniCoordClientForHub` | SUB cache; owned by Mem; Mem／Pool read snapshot |
+| `StagePool` + `LoadBalancer` | Replica pick (LB ownership: §3 P2) |
+| `OmniCoordClientForStage` | update／heartbeat → Coord |
+
+### 1.2 Startup sequence (current)
+
+Order: **Head starts Master + Coord first, then launches／waits for replicas; register is the rendezvous-address RPC.**
+
+`router_addr`／`pub_addr` from `OmniCoordinatorRuntime` **are** the ROUTER／PUB endpoints bound by `OmniCoordinator`.
+
+| Address | Who binds | Who uses |
+|---------|-----------|----------|
+| `router_addr` | Coord ROUTER | Master forwards to Stage; Stage DEALER (update／heartbeat) |
+| `pub_addr` | Coord PUB | Head: Mem → Hub SUB |
+
+Master register reply (`stage_engine_startup.py:645-652`):
+
+| Field | Purpose |
+|-------|---------|
+| `handshake_address` | Engine-core ↔ Head HELLO／READY (Head binds ROUTER; engine connects) |
+| `input_address`／`output_address` | Request／response data-plane ZMQ |
+| `replica_id` | Confirmed or auto-assigned replica id |
+| `coordinator_router_address` | Echo of Coord ROUTER for `OmniCoordClientForStage` |
+
+handshake／input／output do **not** go through Coord; Coord only owns membership.
+
+| Path | Who registers | After |
+|------|---------------|-------|
+| Head-local replica | Head launch helper | Head **binds** handshake from the same allocation, then spawns engine |
+| Headless | Headless process | **Connects** to Head-owned sockets; uses router to reach Coord |
+
+```mermaid
+sequenceDiagram
+  participant Head as DistStageRuntime
+  participant RT as OmniCoordinatorRuntime
+  participant OC as OmniCoordinator
+  participant Master as OmniMasterServer
+  participant Stage as Stage
+  participant SC as OmniCoordClientForStage
+  participant Mem as MembershipController
+  participant Hub as OmniCoordClientForHub
+
+  Note over Head,Master: Infrastructure
+  Head->>RT: new
+  RT->>OC: start
+  OC-->>RT: ready
+  RT-->>Head: router_addr pub_addr
+  Head->>Master: start with router_addr
+
+  Note over Head,Stage: Launch and register
+  Head->>Stage: init local or wait headless
+  Stage->>Master: register
+  Master-->>Stage: handshake input output replica_id router_addr
+  Note over Head,Stage: Head bind HS/IO; Stage or engine connect
+  Stage->>SC: new with router_addr
+  SC->>OC: DEALER update
+
+  Note over Head,Hub: Membership
+  Head->>Mem: new with pub_addr
+  Mem->>Hub: SUB pub_addr
+  OC-->>Hub: PUB ReplicaList
+```
+
+### 1.3 Runtime sequence (current)
+
+Three decoupled paths — **not** “every heartbeat immediately PUBs”:
+
+| Path | Actor | Behavior |
+|------|-------|----------|
+| Heartbeat | `OmniCoordClientForStage` | DEALER `heartbeat`; Coord updates memory; broadcast only when queue changes or ERROR→UP |
+| Periodic flush | `OmniCoordinator` | Timeout check + coalesced PUB; Hub caches |
+| Pick | `StagePool` + `LoadBalancer` | Read Hub snapshot → `select` (no direct causal link to a single heartbeat) |
+
+```mermaid
+sequenceDiagram
+  participant SC as OmniCoordClientForStage
+  participant OC as OmniCoordinator
+  participant Hub as OmniCoordClientForHub
+  participant Pool as StagePool
+  participant LB as LoadBalancer
+
+  loop Stage heartbeat_loop
+    SC->>OC: DEALER heartbeat
+    OC->>OC: refresh last_hb queue
+  end
+
+  loop Coord periodic_loop
+    OC->>OC: timeout check plus schedule
+    OC-->>Hub: PUB ReplicaList if pending
+    Hub->>Hub: cache snapshot
+  end
+
+  Pool->>Hub: get_replicas_for_stage
+  Hub-->>Pool: snapshot
+  Pool->>LB: select
+  LB-->>Pool: index
+```
+
+**Dynamic headless (current):** After the service is up, additional headless replicas can attach — Master `on_register` → Orchestrator → `MembershipController` attach → `StagePool`. Manual dynamic attach exists; **no** autoscaler／`scale to N` API.
+
+---
+
+## 2. P0: Is OmniCoordinator a single point of failure?
+
+**Yes.** One Coord child process per head; in-memory registry only; no HA／failover. After Coord dies, the membership／LB hot path has no standby; distributed `StagePool.pick` fails or spins empty. The HTTP serve process may not crash immediately; Master handshake can still run independently. This outranks structural merge work.
+
+**Mitigation ladder (not HA):**
+
+| Measure | Effect |
+|---------|--------|
+| Process watchdog restarts Coord | Process can self-heal; registry still empty — Stages must re-register／update reliably (needs R1／R2) |
+| Persist／cold-start snapshot | Shortens the empty window; still a single live Coord |
+| Merge Master (PR2) | Clears ownership; **can still be** a SPOF |
+| True HA (multi-Coord／leader election, etc.) | Separate effort; **out of scope** for this refactor |
+
+> Merge ≠ fix SPOF. Watchdog ≠ HA.
+
+---
+
+## 3. Graded issues
+
+For this refactor effort: **two P1 rows** — reliability and Master merge are peer priority; merge is the main refactor deliverable.
+
+| Priority | Category | Summary |
+|----------|----------|---------|
+| **P0** | Availability／architecture | Coord **SPOF** (in-memory registry, no HA) |
+| **P1** | **Reliability** | Register／heartbeat／PUB／close can silently fail or desync |
+| **P1** | **Refactor: merge Master into Coord** | Remove dual owners for handshake vs membership (see §6 PR2) — **mainline of this task** |
+| **P2** | Package structure／ownership | Module boundaries (e.g. LB placement), dead APIs, dual paths, custom LB |
+
+### P1 (reliability)
+
+| # | Issue | Impact | Direction |
+|---|-------|--------|-----------|
+| R1 | Stage registration drops on `zmq.Again` | Never enters registry | Reliable registration delivery |
+| R2 | Heartbeat for unknown `input_addr` ignored | Lost first update → permanent absence | Upsert or registration ack |
+| R3 | PUB／send `NOBLOCK` best-effort | Stale Hub／Pool view | Document SLA; consider ack／snapshot on critical path |
+| R4 | Runtime `terminate`／`kill` vs close semantics | Unpredictable shutdown; child skips `coordinator.close()` | Graceful + idempotent close |
+| R5 | `_parse_replica_event` does not force `queue_length` to `int` | Diverges from dataclass／LB assumptions | Force int／default 0 |
+
+### P1 (refactor: merge Master)
+
+| # | Issue | Impact | Direction |
+|---|-------|--------|-----------|
+| M1 | `OmniMasterServer` parallel to `OmniCoordinator` | Split entrypoints; address echo vs registry | Fold into Coord; one owner for register／update |
+| M2 | Hub＋`MembershipController` indirection | Fragmented Head ownership | Pool reads Coord directly (with the merge) |
+
+> P0 = “only one Coord”; P1 reliability = “path not reliable enough”; P1 refactor = “Master／Coord dual ownership must collapse” (refactor mainline).
+
+### P2 — Package structure
+
+| File | Relation to Coord core service |
+|------|--------------------------------|
+| `omni_coordinator.py`／`runtime.py` | **Core:** registry process |
+| `omni_coord_client_for_stage.py` | **Required client:** ROUTER |
+| `omni_coord_client_for_hub.py` | **Required client:** PUB subscribe |
+| `messages.py` | **Required contract:** wire／domain types |
+| `load_balancer.py` | **No ownership link:** pure pick helper; no Coord ZMQ; used by Head `StagePool` |
+| `__init__.py` | Re-exports everything → blurrier boundary |
+
+On `LoadBalancer`:
+
+- Inputs `list[ReplicaInfo]` + `Task`, outputs index — routing helper
+- Real owner is **Head／`StagePool.pick`**, not the Coord process
+- Living under `distributed/omni_coordinator/` implies it is part of membership; it only shares `ReplicaInfo`
+- **Suggestion:** move closer to ownership, or explicitly mark Head／Pool-owned; short-term keep as structural debt
+
+Other structure items:
+
+| # | Issue | Notes |
+|---|-------|-------|
+| S1 | LB package ownership | See above |
+| S2 | Dead public APIs | `add_new_replica`／`update_replica_info`／`remove_replica`; stage `update_info` tests-only |
+| S3 | LLM／Diffusion dual registration | Public factory vs private `_on_heartbeat` |
+| S4 | fork／spawn TODO | `runtime.py:66-67` |
+| S5 | Custom LB policy | Only three built-in enums today; custom injection in §6 PR2 |
+
+Per-function verdicts: [`omni_coordinator_code_audit.zh.md`](omni_coordinator_code_audit.zh.md).
+
+---
+
+## 4. Package file inventory
+
+| File | Lines | Role | Structure note |
+|------|------:|------|----------------|
+| `omni_coordinator.py` | 369 | registry + ROUTER/PUB | Core |
+| `runtime.py` | 159 | Child-process wrapper | Core |
+| `omni_coord_client_for_stage.py` | 259 | Stage DEALER | Core client |
+| `omni_coord_client_for_hub.py` | 164 | Hub SUB cache | Core client |
+| `messages.py` | 61 | wire types | Core contract |
+| `load_balancer.py` | 131 | Pick policy | P2: consider move |
+| `__init__.py` | 37 | re-exports | Currently exports LB too |
+
+Severity order: **P0 SPOF → two P1s (reliability＋Master merge) → P2 boundary／dead code／custom LB**.
+
+---
+
+## 5. Close semantics matrix
+
+| API | Second close | Production shutdown |
+|-----|--------------|---------------------|
+| `OmniCoordinatorRuntime.close` | idempotent | `terminate`／`kill` child |
+| `OmniCoordinator.close` | raise | **Not called in production** |
+| `OmniCoordClientForStage.close` | raise | finally + often suppressed |
+| `OmniCoordClientForHub.close` | raise | MembershipController.shutdown |
+
+---
+
+## 6. Proposed PR split (two PRs)
+
+| PR | Theme | Maps to |
+|----|-------|---------|
+| **PR1** | Coord reliability + small cleanup | P0 docs／expectations + **P1 reliability** + P2 dead APIs／LB ownership (**no** custom LB, **no** Master merge) |
+| **PR2** | **Merge Master into Coord** + user-custom LB | **P1 refactor (mainline)** + P2 custom LB |
+
+**Refactor mainline is PR2 (Master merge).** Prefer landing PR1 first to lock SPOF／registration tests and cut PR2 regression risk; PR2 does not remove the SPOF.
+
+---
+
+### PR1 — Reliability and structure cleanup
+
+**Goal:** Predictable distributed membership; no silent register／heartbeat loss; clearer package boundaries.
+
+| Block | Content |
+|-------|---------|
+| **P0** | Docs／tests lock SPOF expectations after Coord kill |
+| **P1 R1–R5** | Reliable registration; heartbeat upsert／ack; PUB／SLA; graceful Runtime close; force `queue_length` int |
+| **P2** | Remove／narrow dead public APIs; unify LLM／Diffusion registration; clarify or move LB — **built-in policies only** |
+
+**Out of scope:** Merging `OmniMasterServer`; deleting Hub／MembershipController; custom LB (→ PR2).
+
+**Acceptance (draft):**
+
+- Clear pick failure／empty behavior + tests after Coord kill  
+- First `update` not permanently lost on `Again`  
+- Built-in `random`／`round-robin`／`least-queue-length` still work  
+- Production path + tests green after dead-API cleanup  
+
+**Focus files (draft):**  
+`omni_coordinator.py`, `runtime.py`, `omni_coord_client_for_stage.py`, `omni_coord_client_for_hub.py`, `messages.py`, `load_balancer.py`, `stage_pool.py`, `membership_controller.py`, `stage_runtime.py`, related tests.
+
+---
+
+### PR2 — Merge OmniMasterServer into OmniCoordinator + custom LB
+
+**Target shape:** No parallel standalone `OmniMasterServer`. `OmniCoordinator` owns both **handshake／I／O address allocation** and **membership registry**; `StagePool` queries Coord directly; users may inject a custom `LoadBalancer`.
+
+| Block | Content |
+|-------|---------|
+| Merge | Fold `OmniMasterServer` into `OmniCoordinator` |
+| Simplify Head | Delete `OmniCoordClientForHub`, `MembershipController`; `StagePool` reads Coord directly |
+| Startup | `DistStageRuntime`／headless talk only to Coord |
+| **Custom LB** | `--omni-lb-policy=mypkg:MyBalancer` dotted path (below); `StagePool.pick` still only calls `LoadBalancer.select` |
+
+**Out of scope:** Full HA (still a single in-memory registry). **Depends on:** PR1. Current state: §1.1.
+
+#### Delete／merge map (keep existing class names)
+
+| Today | After PR2 |
+|-------|-----------|
+| `OmniMasterServer` | **Merged into** `OmniCoordinator` |
+| `OmniCoordinator` | **Keep:** registry＋heartbeat; also register |
+| `OmniCoordinatorRuntime` | **Keep** |
+| `OmniCoordClientForHub` | **Delete** |
+| `MembershipController` | **Delete** |
+| `StagePool` | **Keep**; query Coord directly |
+| `LoadBalancer` | **Keep**; add custom-policy injection |
+| `OmniCoordClientForStage` | **Keep** |
+
+#### Target static structure
+
+```mermaid
+flowchart LR
+  subgraph L["Head"]
+    direction TB
+    DSR[DistStageRuntime]
+    RT[OmniCoordinatorRuntime]
+    Pool[StagePool]
+    LB[LoadBalancer]
+    DSR --> RT
+    DSR --> Pool
+    Pool --> LB
+  end
+
+  subgraph C["OmniCoordinator"]
+    OC["OmniCoordinator\nports plus registry"]
+  end
+
+  subgraph R["Stage"]
+    SC[OmniCoordClientForStage]
+  end
+
+  RT -->|starts| OC
+  SC -->|register update heartbeat| OC
+  Pool -->|direct query| OC
+
+  L ~~~ C ~~~ R
+```
+
+#### Target startup sequence
+
+```mermaid
+sequenceDiagram
+  participant Head as DistStageRuntime
+  participant RT as OmniCoordinatorRuntime
+  participant OC as OmniCoordinator
+  participant Stage as Stage
+  participant SC as OmniCoordClientForStage
+  participant Pool as StagePool
+
+  Note over Head,OC: Start Coord only (includes former Master duties)
+  Head->>RT: new
+  RT->>OC: start
+  OC-->>RT: ready
+  RT-->>Head: addresses
+
+  Note over Head,Stage: Register with Coord after init
+  Head->>Stage: init local or wait headless
+  Stage->>OC: register
+  OC-->>Stage: handshake input output replica_id
+  Note over Head,Stage: Head bind HS/IO; engine connect
+
+  Note over Stage,Pool: Membership direct
+  Stage->>SC: new
+  SC->>OC: DEALER update
+  Head->>Pool: ready
+  Pool->>OC: direct query
+```
+
+#### Target runtime sequence
+
+| Path | Actor | Behavior |
+|------|-------|----------|
+| Heartbeat | `OmniCoordClientForStage` | DEALER heartbeat → Coord |
+| Registry | `OmniCoordinator` | Refresh liveness／queue |
+| Pick | `StagePool` + `LoadBalancer` | Direct snapshot → `select` (custom allowed) |
+
+```mermaid
+sequenceDiagram
+  participant SC as OmniCoordClientForStage
+  participant OC as OmniCoordinator
+  participant Pool as StagePool
+  participant LB as LoadBalancer
+
+  loop Stage heartbeat_loop
+    SC->>OC: DEALER heartbeat
+    OC->>OC: refresh registry
+  end
+
+  Pool->>OC: query replicas
+  OC-->>Pool: ReplicaInfo list
+  Pool->>LB: select
+  LB-->>Pool: index
+```
+
+#### Custom LoadBalancer (dotted path)
+
+Upstream vLLM core has **no** Omni-style cross-stage-replica `LoadBalancer`; cross-engine routing lives in the production-stack router. For Omni custom policies, **use a dotted import path** (same spirit as production-stack `callbacks: module.Class`).
+
+| Method | Example | Guidance |
+|--------|---------|----------|
+| Dotted import path | `--omni-lb-policy=mypkg:MyBalancer` | **Primary** |
+| Built-in enum name | `--omni-lb-policy=random` (also `round-robin`／`least-queue-length`) | Keep for compatibility |
+| Inject factory via constructor | `AsyncOmniEngine(..., load_balancer_factory=MyBalancer)` | Optional: libraries／tests |
+
+**Primary behavior (draft):**
+
+| Step | Approach |
+|------|----------|
+| Interface | Subclass `LoadBalancer`; implement `select(task, replicas) -> int` |
+| CLI／config | `--omni-lb-policy=mypkg.sub:MyBalancer` (`module:Class` or `module.Class`) |
+| Resolve | `_build_load_balancer_factory`: built-in enum → current path; else `importlib` load class, require `LoadBalancer` subclass, use as factory |
+| Wire-up | Unchanged: `load_balancer_factory` → `StagePool.attach_load_balancer` |
+
+User example:
+
+```python
+# mypkg/lb.py
+from vllm_omni.distributed.omni_coordinator import LoadBalancer, Task, ReplicaInfo
+
+class MyBalancer(LoadBalancer):
+    def select(self, task: Task, replicas: list[ReplicaInfo]) -> int:
+        return 0
+```
+
+```bash
+# mypkg on PYTHONPATH or pip-installed
+vllm serve ... --omni-lb-policy=mypkg.lb:MyBalancer
+```
+
+Do not require `entry_points`／`LoadBalancerRegistry` as the primary path (named aliases can come later). Matches production-stack dotted callbacks: install the user package into the environment and point the flag at it.
+
+**Acceptance (draft):**
+
+- Headless／local register still completes handshake and HELLO／READY  
+- Pick ≥ PR1 baseline; `--omni-lb-policy=mypkg:MyBalancer` loads and selects  
+- Production path no longer depends on standalone Master／Hub／MembershipController  
+
+**Focus files (draft):**  
+`stage_engine_startup.py`, `omni_coordinator.py`, `runtime.py`, `stage_runtime.py`, `membership_controller.py`, `omni_coord_client_for_hub.py`, `stage_pool.py`, `load_balancer.py`, `_build_load_balancer_factory` (`stage_runtime.py`／CLI validation), headless startup.
+
+---
+
+## Related links
+
+- Per-function I／O／dead code (zh): [`omni_coordinator_code_audit.zh.md`](omni_coordinator_code_audit.zh.md)
+- Writing rules: [`00_refactor_work_rules.md`](00_refactor_work_rules.md)

--- a/refactor/omni_coordinator_analysis.md
+++ b/refactor/omni_coordinator_analysis.md
@@ -2,7 +2,9 @@
 
 > Simplified Chinese (canonical for CN reviewers): [`omni_coordinator_analysis.zh.md`](omni_coordinator_analysis.zh.md)  
 > Per-function audit (zh): [`omni_coordinator_code_audit.zh.md`](omni_coordinator_code_audit.zh.md)  
-> Level: **analysis** (current state + risks); not final design.
+> Talk notes (internal, zh): [`omni_coordinator_talk.zh.md`](omni_coordinator_talk.zh.md)  
+> Level: **analysis** (current state + risks); not final design.  
+> **PR2 Decision B:** `OmniCoordClientForStage` owns `register`＋`update`／`heartbeat`; delete `OmniCoordClientForHub`／`MembershipController`.
 
 **Scope:** all 7 files under `vllm_omni/distributed/omni_coordinator/`  
 **Code base:** `main` @ `c27623c2`
@@ -203,7 +205,7 @@ For this refactor effort: **two P1 rows** — reliability and Master merge are p
 
 | # | Issue | Impact | Direction |
 |---|-------|--------|-----------|
-| M1 | `OmniMasterServer` parallel to `OmniCoordinator` | Split entrypoints; address echo vs registry | Fold into Coord; one owner for register／update |
+| M1 | `OmniMasterServer` parallel to `OmniCoordinator` | Split entrypoints; address echo vs registry | Fold into Coord; Stage uses `ClientForStage` for register／update (one client＋one Coord owner) |
 | M2 | Hub＋`MembershipController` indirection | Fragmented Head ownership | Pool reads Coord directly (with the merge) |
 
 > P0 = “only one Coord”; P1 reliability = “path not reliable enough”; P1 refactor = “Master／Coord dual ownership must collapse” (refactor mainline).
@@ -304,29 +306,30 @@ Severity order: **P0 SPOF → two P1s (reliability＋Master merge) → P2 bounda
 
 ### PR2 — Merge OmniMasterServer into OmniCoordinator + custom LB
 
-**Target shape:** No parallel standalone `OmniMasterServer`. `OmniCoordinator` owns both **handshake／I／O address allocation** and **membership registry**; `StagePool` queries Coord directly; users may inject a custom `LoadBalancer`.
+**Target shape:** No parallel standalone `OmniMasterServer`. `OmniCoordinator` owns both **handshake／I／O address allocation** and **membership registry**; on the Stage side, **`OmniCoordClientForStage` (rename optional) owns `register`＋`update`／`heartbeat`**; on the Head side, **delete Hub／MembershipController** and let `StagePool` query Coord directly; users may inject a custom `LoadBalancer`.
 
 | Block | Content |
 |-------|---------|
 | Merge | Fold `OmniMasterServer` into `OmniCoordinator` |
-| Simplify Head | Delete `OmniCoordClientForHub`, `MembershipController`; `StagePool` reads Coord directly |
+| Stage client | Extend `OmniCoordClientForStage`: `register` (HS／IO allocation)＋existing `update`／`heartbeat`; Coord address known at startup (Head／env／CLI — no Master reply echoing router) |
+| Simplify Head | **Delete** `OmniCoordClientForHub`, `MembershipController` (no PUB／SUB hop); `StagePool` reads Coord directly |
 | Startup | `DistStageRuntime`／headless talk only to Coord |
 | **Custom LB** | `--omni-lb-policy=mypkg:MyBalancer` dotted path (below); `StagePool.pick` still only calls `LoadBalancer.select` |
 
-**Out of scope:** Full HA (still a single in-memory registry). **Depends on:** PR1. Current state: §1.1.
+**Out of scope:** Full HA (still a single in-memory registry). **Depends on:** PR1 landing first. Current state: §1.1.
 
-#### Delete／merge map (keep existing class names)
+#### Delete／merge map (keep existing class names; Stage client may rename later)
 
 | Today | After PR2 |
 |-------|-----------|
 | `OmniMasterServer` | **Merged into** `OmniCoordinator` |
-| `OmniCoordinator` | **Keep:** registry＋heartbeat; also register |
+| `OmniCoordinator` | **Keep:** registry＋heartbeat; also register (server side) |
 | `OmniCoordinatorRuntime` | **Keep** |
-| `OmniCoordClientForHub` | **Delete** |
+| `OmniCoordClientForHub` | **Delete** (Pool no longer uses SUB cache) |
 | `MembershipController` | **Delete** |
 | `StagePool` | **Keep**; query Coord directly |
 | `LoadBalancer` | **Keep**; add custom-policy injection |
-| `OmniCoordClientForStage` | **Keep** |
+| `OmniCoordClientForStage` | **Keep and extend**: `register`＋`update`／`heartbeat` (rename optional) |
 
 #### Target static structure
 
@@ -348,7 +351,7 @@ flowchart LR
   end
 
   subgraph R["Stage"]
-    SC[OmniCoordClientForStage]
+    SC["OmniCoordClientForStage\nregister plus update HB"]
   end
 
   RT -->|starts| OC
@@ -357,6 +360,9 @@ flowchart LR
 
   L ~~~ C ~~~ R
 ```
+
+> **Decision B:** Stage talks to Coord **only via** `OmniCoordClientForStage` (or one renamed client): `register` first for handshake／input／output／replica_id, then the same connection for `update`／`heartbeat`.  
+> **`OmniCoordClientForHub` is deleted in the target** — no PUB→SUB→Hub cache; `StagePool` queries Coord directly.
 
 #### Target startup sequence
 
@@ -373,16 +379,17 @@ sequenceDiagram
   Head->>RT: new
   RT->>OC: start
   OC-->>RT: ready
-  RT-->>Head: addresses
+  RT-->>Head: coord addresses
 
-  Note over Head,Stage: Register with Coord after init
+  Note over Head,Stage: Stage already knows Coord addr; register via ClientForStage
   Head->>Stage: init local or wait headless
-  Stage->>OC: register
-  OC-->>Stage: handshake input output replica_id
+  Stage->>SC: new with coord addr
+  SC->>OC: register
+  OC-->>SC: handshake input output replica_id
+  SC-->>Stage: addresses
   Note over Head,Stage: Head bind HS/IO; engine connect
 
-  Note over Stage,Pool: Membership direct
-  Stage->>SC: new
+  Note over Stage,Pool: Same client continues membership; no Hub
   SC->>OC: DEALER update
   Head->>Pool: ready
   Pool->>OC: direct query
@@ -394,7 +401,7 @@ sequenceDiagram
 |------|-------|----------|
 | Heartbeat | `OmniCoordClientForStage` | DEALER heartbeat → Coord |
 | Registry | `OmniCoordinator` | Refresh liveness／queue |
-| Pick | `StagePool` + `LoadBalancer` | Direct snapshot → `select` (custom allowed) |
+| Pick | `StagePool` + `LoadBalancer` | **Direct Coord** snapshot → `select` (custom allowed; **no Hub**) |
 
 ```mermaid
 sequenceDiagram
@@ -453,9 +460,9 @@ Do not require `entry_points`／`LoadBalancerRegistry` as the primary path (name
 
 **Acceptance (draft):**
 
-- Headless／local register still completes handshake and HELLO／READY  
+- Headless／local path completes handshake and HELLO／READY via `OmniCoordClientForStage.register`  
 - Pick ≥ PR1 baseline; `--omni-lb-policy=mypkg:MyBalancer` loads and selects  
-- Production path no longer depends on standalone Master／Hub／MembershipController  
+- Production path no longer depends on standalone Master／`OmniCoordClientForHub`／MembershipController  
 
 **Focus files (draft):**  
 `stage_engine_startup.py`, `omni_coordinator.py`, `runtime.py`, `stage_runtime.py`, `membership_controller.py`, `omni_coord_client_for_hub.py`, `stage_pool.py`, `load_balancer.py`, `_build_load_balancer_factory` (`stage_runtime.py`／CLI validation), headless startup.

--- a/refactor/omni_coordinator_analysis.zh.md
+++ b/refactor/omni_coordinator_analysis.zh.md
@@ -1,0 +1,470 @@
+# [Analysis] OmniCoordinator 套件系统分析
+
+> 简体中文。英文对照：[`omni_coordinator_analysis.md`](omni_coordinator_analysis.md)  
+> 逐函数审计：[`omni_coordinator_code_audit.zh.md`](omni_coordinator_code_audit.zh.md)  
+> 层级：**analysis**（现状与风险）；不是最终 design。
+
+**审查范围：** `vllm_omni/distributed/omni_coordinator/` 全部 7 个文件  
+**代码基准：** `main` @ `c27623c2`
+
+---
+
+## 1. 架构与时序
+
+**何时启动：** 仅 `DistStageRuntime`（`--stage-id` + master）。普通 in-process multi-stage **不会**启动 Coordinator。
+
+### 1.1 现状结构
+
+`DistStageRuntime` → `OmniCoordinatorRuntime` → `OmniCoordinator`（Runtime 在 Head；Coord 在独立进程）。
+
+```mermaid
+flowchart LR
+  subgraph L["Head"]
+    direction TB
+    DSR[DistStageRuntime]
+    RT[OmniCoordinatorRuntime]
+    Master[OmniMasterServer]
+    Mem[MembershipController]
+    Hub[OmniCoordClientForHub]
+    Pool[StagePool]
+    LB[LoadBalancer]
+    DSR --> RT
+    DSR --> Master
+    DSR --> Mem
+    Mem -->|owns| Hub
+    Hub -.->|snapshot| Mem
+    Mem --> Pool
+    Hub -.->|snapshot| Pool
+    Pool --> LB
+  end
+
+  subgraph C["OmniCoordinator"]
+    OC[OmniCoordinator]
+  end
+
+  subgraph R["Stage"]
+    SC[OmniCoordClientForStage]
+  end
+
+  RT -->|starts| OC
+  Master -.->|router_addr| SC
+  SC -->|DEALER| OC
+  OC -->|PUB| Hub
+
+  L ~~~ C ~~~ R
+```
+
+| 组件 | 职责 |
+|------|------|
+| `OmniCoordinatorRuntime` | 启停 Coord；只暴露 router／pub 地址 |
+| `OmniCoordinator` | 内存 registry + ROUTER／PUB |
+| `OmniMasterServer` | 注册时分配握手／I／O 地址，并回传 router_addr |
+| `OmniCoordClientForHub` | SUB 缓存；由 Mem 持有；Mem／Pool 读 snapshot |
+| `StagePool` + `LoadBalancer` | 选副本（LB 归属见 §3 P2） |
+| `OmniCoordClientForStage` | update／heartbeat → Coord |
+
+### 1.2 建立时序（现状）
+
+顺序是：**Head 先启动 Master 与 Coord，再 launch／等待 replica；register 用于获取汇合地址。**
+
+`OmniCoordinatorRuntime` 返回的 `router_addr`／`pub_addr` **即** `OmniCoordinator` 绑定的 ROUTER／PUB。
+
+| 地址 | 谁 bind | 谁使用 |
+|------|---------|--------|
+| `router_addr` | Coord ROUTER | Master 转发给 Stage；Stage DEALER（update／heartbeat） |
+| `pub_addr` | Coord PUB | Head：Mem → Hub SUB |
+
+Master register 回复（`stage_engine_startup.py:645-652`）：
+
+| 字段 | 用途 |
+|------|------|
+| `handshake_address` | Engine-core 与 Head 做 HELLO／READY（Head bind ROUTER，engine connect） |
+| `input_address`／`output_address` | 请求／响应数据面 ZMQ |
+| `replica_id` | 确认或自动分配的副本编号 |
+| `coordinator_router_address` | 回传 Coord ROUTER，供 Stage 创建 `OmniCoordClientForStage` |
+
+handshake／input／output **不经过** Coord；Coord 只维护 membership。
+
+| 路径 | 谁发起 register | 之后 |
+|------|-----------------|------|
+| Head 本地 replica | Head launch helper | Head 按同一份分配 **bind** handshake，再 spawn engine |
+| Headless | Headless 进程自行 register | **connect** 到 Head 侧 socket，并用 router 连 Coord |
+
+```mermaid
+sequenceDiagram
+  participant Head as DistStageRuntime
+  participant RT as OmniCoordinatorRuntime
+  participant OC as OmniCoordinator
+  participant Master as OmniMasterServer
+  participant Stage as Stage
+  participant SC as OmniCoordClientForStage
+  participant Mem as MembershipController
+  participant Hub as OmniCoordClientForHub
+
+  Note over Head,Master: 基础设施
+  Head->>RT: new
+  RT->>OC: start
+  OC-->>RT: ready
+  RT-->>Head: router_addr pub_addr
+  Head->>Master: start with router_addr
+
+  Note over Head,Stage: launch 与 register
+  Head->>Stage: init local or wait headless
+  Stage->>Master: register
+  Master-->>Stage: handshake input output replica_id router_addr
+  Note over Head,Stage: Head bind HS/IO；Stage or engine connect
+  Stage->>SC: new with router_addr
+  SC->>OC: DEALER update
+
+  Note over Head,Hub: membership
+  Head->>Mem: new with pub_addr
+  Mem->>Hub: SUB pub_addr
+  OC-->>Hub: PUB ReplicaList
+```
+
+### 1.3 使用时序（现状）
+
+三条路径解耦，**不是**「每次 heartbeat 立即 PUB」：
+
+| 路径 | 执行方 | 行为 |
+|------|--------|------|
+| 心跳 | `OmniCoordClientForStage` | DEALER `heartbeat`；Coord 更新内存；queue 变化或 ERROR→UP 时才 schedule 广播 |
+| 周期刷新 | `OmniCoordinator` | 超时检查 + 合并后的 PUB；Hub 缓存 |
+| 选路 | `StagePool` + `LoadBalancer` | 读 Hub snapshot → `select`（与单次 heartbeat 无直接因果） |
+
+```mermaid
+sequenceDiagram
+  participant SC as OmniCoordClientForStage
+  participant OC as OmniCoordinator
+  participant Hub as OmniCoordClientForHub
+  participant Pool as StagePool
+  participant LB as LoadBalancer
+
+  loop Stage heartbeat_loop
+    SC->>OC: DEALER heartbeat
+    OC->>OC: refresh last_hb queue
+  end
+
+  loop Coord periodic_loop
+    OC->>OC: timeout check plus schedule
+    OC-->>Hub: PUB ReplicaList if pending
+    Hub->>Hub: cache snapshot
+  end
+
+  Pool->>Hub: get_replicas_for_stage
+  Hub-->>Pool: snapshot
+  Pool->>LB: select
+  LB-->>Pool: index
+```
+
+**动态 headless（现状）：** 服务已拉起后可再挂 headless——Master `on_register` → Orchestrator → `MembershipController` attach → `StagePool`。有手动动态挂上；**无** autoscaler／`scale to N` API。
+
+---
+
+## 2. P0：OmniCoordinator 是否单点故障？
+
+**是。** 每个 head 仅一个 Coord 子进程；registry 仅在内存；无 HA／failover。Coord 宕机后，membership／负载均衡热路径没有备援，distributed 下 `StagePool.pick` 会失败或空转。HTTP serve 进程未必立即退出；Master 握手仍可独立进行。
+
+**缓解阶梯（不是 HA）：**
+
+| 手段 | 效果 |
+|------|------|
+| 进程 watchdog 重拉 Coord | 进程可自愈；registry 仍空，需 Stage 可靠重注册／update（依赖 R1／R2） |
+| 持久化／冷启动快照 | 缩短空窗；仍是单活 Coord |
+| 合并 Master（PR2） | 清 ownership；**仍然可以是**单点 |
+| 真 HA（多 Coord／选主等） | 另案；本 refactor **不做** |
+
+> 合并 ≠ 解决单点。Watchdog ≠ HA。
+
+---
+
+## 3. 问题分级
+
+本 refactor 任务下：**P1 分两行**——可靠性与「合并 Master」同级；后者是重构主交付。
+
+| 优先级 | 类别 | 说明 |
+|--------|------|------|
+| **P0** | 可用性／架构 | Coord **单点**（内存 registry、无 HA） |
+| **P1** | **可靠性** | 注册／心跳／PUB／关闭可能静默失败或状态不一致 |
+| **P1** | **重构：合并 Master 与 Coord** | 消除「握手」与「membership」双 owner（见 §6 PR2）——**本任务主线** |
+| **P2** | 套件结构／ownership | 模块边界（如 LB 是否应在本套件）、死 API、双路径、自定义 LB |
+
+### P1（可靠性）
+
+| # | 问题 | 后果 | 建议方向 |
+|---|------|------|----------|
+| R1 | Stage registration 遇 `zmq.Again` 静默丢弃 | 永不进入 registry | 注册必须可靠送达 |
+| R2 | 对未知 `input_addr` 的 heartbeat 直接忽略 | 首次 update 丢失则永久缺席 | upsert 或 registration ack |
+| R3 | PUB／send `NOBLOCK` best-effort | Hub／Pool 视图陈旧 | 明确 SLA；关键路径考虑 ack／snapshot |
+| R4 | Runtime `terminate`／`kill` 与 close 语义不一致 | 关闭行为难预期；子进程不走 `coordinator.close()` | 优雅关闭 + idempotent close |
+| R5 | `_parse_replica_event` 未强制 `queue_length` 为 `int` | 与 dataclass／LB 假设不一致 | 强制 int／缺省 0 |
+
+### P1（重构：合并 Master）
+
+| # | 问题 | 后果 | 建议方向 |
+|---|------|------|----------|
+| M1 | `OmniMasterServer` 与 `OmniCoordinator` 并列 | 两套入口、地址回传与 registry 分裂 | 并入 Coord；Stage register／update 同一 owner |
+| M2 | Hub＋`MembershipController` 间接层 | Head 侧 ownership 碎 | Pool 直读 Coord（随合并落地） |
+
+> P0 =「只有一个 Coord」；P1 可靠性 =「路径不够可靠」；P1 重构 =「Master／Coord 双 owner 必须收束」（refactor 主线）。
+
+### P2 — 套件结构
+
+现状套件内容：
+
+| 文件 | 与 Coord 主体服务关系 |
+|------|----------------------|
+| `omni_coordinator.py`／`runtime.py` | **核心**：registry 服务进程 |
+| `omni_coord_client_for_stage.py` | **必要 client**：对接 ROUTER |
+| `omni_coord_client_for_hub.py` | **必要 client**：订阅 PUB |
+| `messages.py` | **必要契约**：wire／domain types |
+| `load_balancer.py` | **无主属关系**：纯选路策略；不连接 Coord ZMQ；由 Head 侧 `StagePool` 使用 |
+| `__init__.py` | 一并 re-export，边界更模糊 |
+
+关于 `LoadBalancer`：
+
+- 输入为 `list[ReplicaInfo]` + `Task`，输出为 index——routing helper
+- 实际所有者是 **Head／`StagePool.pick`**，不是 Coord 子进程
+- 放在 `distributed/omni_coordinator/` 易被误解为 membership 服务的一部分
+- **建议：** 迁到更贴近 ownership 的位置，或明确标注为 Head／Pool 侧组件；短期可保留，但计为结构债
+
+其他结构项：
+
+| # | 问题 | 说明 |
+|---|------|------|
+| S1 | LB 套件归属 | 见上 |
+| S2 | 死公共 API | `add_new_replica`／`update_replica_info`／`remove_replica`；stage `update_info` 仅测试使用 |
+| S3 | LLM／Diffusion 注册双路径 | 公开 factory vs 手写 private `_on_heartbeat` |
+| S4 | fork／spawn 进程模型 TODO | `runtime.py:66-67` |
+| S5 | LB 自定义策略 | 目前仅内置三种枚举策略；自定义注入见 §6 PR2 |
+
+逐函数判定见 [`omni_coordinator_code_audit.zh.md`](omni_coordinator_code_audit.zh.md)。
+
+---
+
+## 4. 套件文件一览
+
+| 文件 | 行数 | 角色 | 结构备注 |
+|------|------:|------|----------|
+| `omni_coordinator.py` | 369 | registry + ROUTER/PUB | 核心 |
+| `runtime.py` | 159 | 子进程 wrapper | 核心 |
+| `omni_coord_client_for_stage.py` | 259 | Stage DEALER | 核心 client |
+| `omni_coord_client_for_hub.py` | 164 | Hub SUB 缓存 | 核心 client |
+| `messages.py` | 61 | wire types | 核心契约 |
+| `load_balancer.py` | 131 | 选路策略 | P2：宜考虑迁出 |
+| `__init__.py` | 37 | re-exports | 当前一并 export LB |
+
+痛点层次：**P0 单点 → 两个 P1（可靠性＋合并 Master）→ P2 边界／死码／自定义 LB**。
+
+---
+
+## 5. Close 语义矩阵
+
+| API | 二次 close | 生产 shutdown |
+|-----|------------|---------------|
+| `OmniCoordinatorRuntime.close` | idempotent | `terminate`／`kill` 子进程 |
+| `OmniCoordinator.close` | raise | **生产路径不调用** |
+| `OmniCoordClientForStage.close` | raise | finally + 常 suppress |
+| `OmniCoordClientForHub.close` | raise | MembershipController.shutdown |
+
+---
+
+## 6. 建议拆分的两个 PR
+
+| PR | 主题 | 对应优先级 |
+|----|------|------------|
+| **PR1** | Coord 可靠性与小结构清理 | P0 文档／预期 + **P1 可靠性** + P2 死码／LB 归属（**不含**自定义策略、**不含**合并 Master） |
+| **PR2** | **将 Master 并入 Coord** + 用户自定义 LB | **P1 重构（主线）** + P2 自定义 LB |
+
+**Refactor 主线是 PR2（合并 Master）。** PR1 仍建议先合，用测试锁住 SPOF／注册行为，降低 PR2 回归风险；PR2 不消除单点本身。
+
+---
+
+### PR1 — 可靠性与结构整理
+
+**目标：** distributed membership 路径行为可预期；注册／心跳不静默丢失；套件边界清晰。
+
+| 块 | 内容 |
+|----|------|
+| **P0** | 文档与测试锁定 SPOF 预期：Coord 被杀后 Hub／`StagePool.pick` 行为 |
+| **P1 R1–R5** | 注册可靠送达；未知 addr heartbeat upsert／ack；PUB／SLA；Runtime 优雅关闭与 close 语义统一；`queue_length` 强制 `int` |
+| **P2** | 删除／收窄死公共 API；统一 LLM／Diffusion 注册路径；明确或迁移 LB 归属——**仍仅内置三种策略** |
+
+**不做：** 合并 `OmniMasterServer`；删除 Hub／MembershipController；用户自定义 LB（→ PR2）。
+
+**验收（草案）：**
+
+- Coord 被杀后 pick 失败／空转有明确行为与测试  
+- 首次 `update` 不因 `Again` 永久缺席  
+- 内置 `random`／`round-robin`／`least-queue-length` 仍可用  
+- 死 API 清理后生产路径与测试通过  
+
+**涉及文件（草案）：**  
+`omni_coordinator.py`、`runtime.py`、`omni_coord_client_for_stage.py`、`omni_coord_client_for_hub.py`、`messages.py`、`load_balancer.py`、`stage_pool.py`、`membership_controller.py`、`stage_runtime.py`、相关 tests。
+
+---
+
+### PR2 — 将 OmniMasterServer 并入 OmniCoordinator，并支持自定义 LB
+
+**目标形态：** 不再并行独立的 `OmniMasterServer`。由 `OmniCoordinator` 同时负责：**分配 handshake／I／O 地址**与 **membership registry**；`StagePool` 直读 Coord；支持用户注入自定义 `LoadBalancer`。
+
+| 块 | 内容 |
+|----|------|
+| 合并 | `OmniMasterServer` 职责并入 `OmniCoordinator` |
+| 简化 Head | 删除 `OmniCoordClientForHub`、`MembershipController`；`StagePool` 直读 Coord |
+| Startup | `DistStageRuntime`／headless 只对接 Coord |
+| **自定义 LB** | `--omni-lb-policy=mypkg:MyBalancer` dotted path（见下）；`StagePool.pick` 仍只调 `LoadBalancer.select` |
+
+**不做：** 完整 HA（合并后仍可以是单点内存 registry）。**依赖：** PR1 先合并。现状对照见 §1.1。
+
+#### 删除／合并对照（沿用现有类名）
+
+| 现状 | PR2 之后 |
+|------|----------|
+| `OmniMasterServer` | **并入** `OmniCoordinator` |
+| `OmniCoordinator` | **保留**：registry＋heartbeat；兼做 register |
+| `OmniCoordinatorRuntime` | **保留** |
+| `OmniCoordClientForHub` | **删除** |
+| `MembershipController` | **删除** |
+| `StagePool` | **保留**；改为直读 Coord |
+| `LoadBalancer` | **保留**；增加自定义策略注入 |
+| `OmniCoordClientForStage` | **保留** |
+
+#### 目标静态结构
+
+```mermaid
+flowchart LR
+  subgraph L["Head"]
+    direction TB
+    DSR[DistStageRuntime]
+    RT[OmniCoordinatorRuntime]
+    Pool[StagePool]
+    LB[LoadBalancer]
+    DSR --> RT
+    DSR --> Pool
+    Pool --> LB
+  end
+
+  subgraph C["OmniCoordinator"]
+    OC["OmniCoordinator\nports plus registry"]
+  end
+
+  subgraph R["Stage"]
+    SC[OmniCoordClientForStage]
+  end
+
+  RT -->|starts| OC
+  SC -->|register update heartbeat| OC
+  Pool -->|direct query| OC
+
+  L ~~~ C ~~~ R
+```
+
+#### 目标建立时序
+
+```mermaid
+sequenceDiagram
+  participant Head as DistStageRuntime
+  participant RT as OmniCoordinatorRuntime
+  participant OC as OmniCoordinator
+  participant Stage as Stage
+  participant SC as OmniCoordClientForStage
+  participant Pool as StagePool
+
+  Note over Head,OC: 只启动 Coord（含原 Master 职责）
+  Head->>RT: new
+  RT->>OC: start
+  OC-->>RT: ready
+  RT-->>Head: addresses
+
+  Note over Head,Stage: init 后向 Coord register
+  Head->>Stage: init local or wait headless
+  Stage->>OC: register
+  OC-->>Stage: handshake input output replica_id
+  Note over Head,Stage: Head bind HS/IO；engine connect
+
+  Note over Stage,Pool: membership 直连
+  Stage->>SC: new
+  SC->>OC: DEALER update
+  Head->>Pool: ready
+  Pool->>OC: direct query
+```
+
+#### 目标使用时序
+
+| 路径 | 执行方 | 行为 |
+|------|--------|------|
+| 心跳 | `OmniCoordClientForStage` | DEALER heartbeat → Coord |
+| 注册表 | `OmniCoordinator` | 更新存活与 queue |
+| 选路 | `StagePool` + `LoadBalancer` | 直读 snapshot → `select`（可自定义） |
+
+```mermaid
+sequenceDiagram
+  participant SC as OmniCoordClientForStage
+  participant OC as OmniCoordinator
+  participant Pool as StagePool
+  participant LB as LoadBalancer
+
+  loop Stage heartbeat_loop
+    SC->>OC: DEALER heartbeat
+    OC->>OC: refresh registry
+  end
+
+  Pool->>OC: query replicas
+  OC-->>Pool: ReplicaInfo list
+  Pool->>LB: select
+  LB-->>Pool: index
+```
+
+#### 自定义 LoadBalancer（dotted path）
+
+上游 vLLM core **没有** Omni 这种跨 stage replica 的 `LoadBalancer`；跨 engine 分流在 production-stack router。Omni 侧自定义策略 **定案用 dotted path**（对齐 production-stack `callbacks: module.Class`）。
+
+| 方式 | 例子 | 建议 |
+|------|------|------|
+| 字符串指向可 import 路径 | `--omni-lb-policy=mypkg:MyBalancer` | **主路径** |
+| 内置枚举名 | `--omni-lb-policy=random`（及 `round-robin`／`least-queue-length`） | 保留兼容 |
+| 入口参数注入 factory | `AsyncOmniEngine(..., load_balancer_factory=MyBalancer)` | 可选：库／测试 |
+
+**主路径行为（草案）：**
+
+| 步骤 | 做法 |
+|------|------|
+| 接口 | 用户子类化 `LoadBalancer`，实现 `select(task, replicas) -> int` |
+| CLI／配置 | `--omni-lb-policy=mypkg.sub:MyBalancer`（`module:Class` 或 `module.Class`） |
+| 解析 | `_build_load_balancer_factory`：若值为内置枚举则走现逻辑；否则 `importlib` 加载类，校验为 `LoadBalancer` 子类后作 factory |
+| 注入点 | 不变：`load_balancer_factory` → `StagePool.attach_load_balancer` |
+
+用户示例：
+
+```python
+# mypkg/lb.py
+from vllm_omni.distributed.omni_coordinator import LoadBalancer, Task, ReplicaInfo
+
+class MyBalancer(LoadBalancer):
+    def select(self, task: Task, replicas: list[ReplicaInfo]) -> int:
+        return 0
+```
+
+```bash
+# 保证 mypkg 在 PYTHONPATH／已 pip install
+vllm serve ... --omni-lb-policy=mypkg.lb:MyBalancer
+```
+
+不做强制 `entry_points`／`LoadBalancerRegistry` 作为主路径（可后续再加命名别名）；与 production-stack 的 dotted callback 一致，部署时把用户包装进环境即可。
+
+**验收（草案）：**
+
+- Headless／本地 register 仍能完成握手与 HELLO／READY  
+- pick 不低于 PR1 基线；`--omni-lb-policy=mypkg:MyBalancer` 可加载并选中  
+- 生产路径不再依赖独立 `OmniMasterServer`／Hub／`MembershipController`  
+
+**涉及文件（草案）：**  
+`stage_engine_startup.py`、`omni_coordinator.py`、`runtime.py`、`stage_runtime.py`、`membership_controller.py`、`omni_coord_client_for_hub.py`、`stage_pool.py`、`load_balancer.py`、`_build_load_balancer_factory`（`stage_runtime.py`／CLI 校验）、headless startup。
+
+---
+
+## 相关链接
+
+- 逐函数 I／O／废码：[`omni_coordinator_code_audit.zh.md`](omni_coordinator_code_audit.zh.md)
+- 写作规则：[`00_refactor_work_rules.md`](00_refactor_work_rules.md)

--- a/refactor/omni_coordinator_analysis.zh.md
+++ b/refactor/omni_coordinator_analysis.zh.md
@@ -2,7 +2,9 @@
 
 > 简体中文。英文对照：[`omni_coordinator_analysis.md`](omni_coordinator_analysis.md)  
 > 逐函数审计：[`omni_coordinator_code_audit.zh.md`](omni_coordinator_code_audit.zh.md)  
-> 层级：**analysis**（现状与风险）；不是最终 design。
+> 讲稿（内部）：[`omni_coordinator_talk.zh.md`](omni_coordinator_talk.zh.md)  
+> 层级：**analysis**（现状与风险）；不是最终 design。  
+> **PR2 定案 B：** `OmniCoordClientForStage` 兼 `register`＋`update`／`heartbeat`；删除 `OmniCoordClientForHub`／`MembershipController`。
 
 **审查范围：** `vllm_omni/distributed/omni_coordinator/` 全部 7 个文件  
 **代码基准：** `main` @ `c27623c2`
@@ -203,7 +205,7 @@ sequenceDiagram
 
 | # | 问题 | 后果 | 建议方向 |
 |---|------|------|----------|
-| M1 | `OmniMasterServer` 与 `OmniCoordinator` 并列 | 两套入口、地址回传与 registry 分裂 | 并入 Coord；Stage register／update 同一 owner |
+| M1 | `OmniMasterServer` 与 `OmniCoordinator` 并列 | 两套入口、地址回传与 registry 分裂 | 并入 Coord；Stage 侧经 `ClientForStage` 做 register／update（同一 client＋同一 Coord owner） |
 | M2 | Hub＋`MembershipController` 间接层 | Head 侧 ownership 碎 | Pool 直读 Coord（随合并落地） |
 
 > P0 =「只有一个 Coord」；P1 可靠性 =「路径不够可靠」；P1 重构 =「Master／Coord 双 owner 必须收束」（refactor 主线）。
@@ -306,29 +308,30 @@ sequenceDiagram
 
 ### PR2 — 将 OmniMasterServer 并入 OmniCoordinator，并支持自定义 LB
 
-**目标形态：** 不再并行独立的 `OmniMasterServer`。由 `OmniCoordinator` 同时负责：**分配 handshake／I／O 地址**与 **membership registry**；`StagePool` 直读 Coord；支持用户注入自定义 `LoadBalancer`。
+**目标形态：** 不再并行独立的 `OmniMasterServer`。由 `OmniCoordinator` 同时负责：**分配 handshake／I／O 地址**与 **membership registry**；Stage 侧由 **`OmniCoordClientForStage`（可改名）兼做 `register`＋`update`／`heartbeat`**；Head 侧 **删除 Hub／MembershipController**，`StagePool` 直读 Coord；支持用户注入自定义 `LoadBalancer`。
 
 | 块 | 内容 |
 |----|------|
 | 合并 | `OmniMasterServer` 职责并入 `OmniCoordinator` |
-| 简化 Head | 删除 `OmniCoordClientForHub`、`MembershipController`；`StagePool` 直读 Coord |
+| Stage client | `OmniCoordClientForStage` 扩展：`register`（派 HS／IO）＋既有 `update`／`heartbeat`；启动时已知 Coord 地址（Head／env／CLI，不再靠 Master reply 回传 router） |
+| 简化 Head | **删除** `OmniCoordClientForHub`、`MembershipController`（无 PUB／SUB 中转）；`StagePool` 直读 Coord |
 | Startup | `DistStageRuntime`／headless 只对接 Coord |
 | **自定义 LB** | `--omni-lb-policy=mypkg:MyBalancer` dotted path（见下）；`StagePool.pick` 仍只调 `LoadBalancer.select` |
 
-**不做：** 完整 HA（合并后仍可以是单点内存 registry）。**依赖：** PR1 先合并。现状对照见 §1.1。
+**不做：** 完整 HA（合并后仍可以是单点内存 registry）。**依赖：** PR1 先落地。现状对照见 §1.1。
 
-#### 删除／合并对照（沿用现有类名）
+#### 删除／合并对照（沿用现有类名；Stage client 可后续改名）
 
 | 现状 | PR2 之后 |
 |------|----------|
 | `OmniMasterServer` | **并入** `OmniCoordinator` |
-| `OmniCoordinator` | **保留**：registry＋heartbeat；兼做 register |
+| `OmniCoordinator` | **保留**：registry＋heartbeat；兼做 register（对端） |
 | `OmniCoordinatorRuntime` | **保留** |
-| `OmniCoordClientForHub` | **删除** |
+| `OmniCoordClientForHub` | **删除**（Pool 不再经 SUB 缓存） |
 | `MembershipController` | **删除** |
 | `StagePool` | **保留**；改为直读 Coord |
 | `LoadBalancer` | **保留**；增加自定义策略注入 |
-| `OmniCoordClientForStage` | **保留** |
+| `OmniCoordClientForStage` | **保留并扩展**：`register`＋`update`／`heartbeat`（类名可再收敛） |
 
 #### 目标静态结构
 
@@ -350,7 +353,7 @@ flowchart LR
   end
 
   subgraph R["Stage"]
-    SC[OmniCoordClientForStage]
+    SC["OmniCoordClientForStage\nregister plus update HB"]
   end
 
   RT -->|starts| OC
@@ -359,6 +362,9 @@ flowchart LR
 
   L ~~~ C ~~~ R
 ```
+
+> **定案 B：** Stage 对 Coord **只经** `OmniCoordClientForStage`（或改名后的同一 client）：先 `register` 取 handshake／input／output／replica_id，再同一连接做 `update`／`heartbeat`。  
+> **`OmniCoordClientForHub` 目标中删除**——不再 PUB→SUB→Hub cache；`StagePool` 直读 Coord。
 
 #### 目标建立时序
 
@@ -375,16 +381,17 @@ sequenceDiagram
   Head->>RT: new
   RT->>OC: start
   OC-->>RT: ready
-  RT-->>Head: addresses
+  RT-->>Head: coord addresses
 
-  Note over Head,Stage: init 后向 Coord register
+  Note over Head,Stage: Stage 已知 Coord 地址；经 ClientForStage 注册
   Head->>Stage: init local or wait headless
-  Stage->>OC: register
-  OC-->>Stage: handshake input output replica_id
+  Stage->>SC: new with coord addr
+  SC->>OC: register
+  OC-->>SC: handshake input output replica_id
+  SC-->>Stage: addresses
   Note over Head,Stage: Head bind HS/IO；engine connect
 
-  Note over Stage,Pool: membership 直连
-  Stage->>SC: new
+  Note over Stage,Pool: 同一 client 继续 membership；无 Hub
   SC->>OC: DEALER update
   Head->>Pool: ready
   Pool->>OC: direct query
@@ -396,7 +403,7 @@ sequenceDiagram
 |------|--------|------|
 | 心跳 | `OmniCoordClientForStage` | DEALER heartbeat → Coord |
 | 注册表 | `OmniCoordinator` | 更新存活与 queue |
-| 选路 | `StagePool` + `LoadBalancer` | 直读 snapshot → `select`（可自定义） |
+| 选路 | `StagePool` + `LoadBalancer` | **直读 Coord** snapshot → `select`（可自定义；**无 Hub**） |
 
 ```mermaid
 sequenceDiagram
@@ -455,9 +462,9 @@ vllm serve ... --omni-lb-policy=mypkg.lb:MyBalancer
 
 **验收（草案）：**
 
-- Headless／本地 register 仍能完成握手与 HELLO／READY  
+- Headless／本地经 `OmniCoordClientForStage.register` 仍能完成握手与 HELLO／READY  
 - pick 不低于 PR1 基线；`--omni-lb-policy=mypkg:MyBalancer` 可加载并选中  
-- 生产路径不再依赖独立 `OmniMasterServer`／Hub／`MembershipController`  
+- 生产路径不再依赖独立 `OmniMasterServer`／`OmniCoordClientForHub`／`MembershipController`  
 
 **涉及文件（草案）：**  
 `stage_engine_startup.py`、`omni_coordinator.py`、`runtime.py`、`stage_runtime.py`、`membership_controller.py`、`omni_coord_client_for_hub.py`、`stage_pool.py`、`load_balancer.py`、`_build_load_balancer_factory`（`stage_runtime.py`／CLI 校验）、headless startup。

--- a/refactor/omni_coordinator_code_audit.zh.md
+++ b/refactor/omni_coordinator_code_audit.zh.md
@@ -1,0 +1,337 @@
+# OmniCoordinator Code Audit（逐 function）
+
+> 配套系統分析：`[omni_coordinator_analysis.zh.md](omni_coordinator_analysis.zh.md)`  
+> 範圍：`vllm_omni/distributed/omni_coordinator/` 全部 7 檔  
+> 基準：`main` @ `c27623c2`  
+> 判定：`keep`｜`fix`｜`delete_or_privatize`｜`test_only`
+
+呼叫者欄：「生產」= `vllm_omni/` 非 test；「僅 test」= `tests/`；「內部」= 套件內。
+
+---
+
+## 0. 各組件公開 API
+
+只列**對外／公開**表面（`__all__` 或無 `_` 前綴嘅方法／屬性）。私有 `_` 方法見後文逐檔表。
+
+### 0.1 `OmniCoordinatorRuntime`（`runtime.py`）
+
+對外只有呢個 class（`__all__` 有 export）。
+
+| API | 簽名／形狀 | 用途 |
+|-----|------------|------|
+| `__init__` | `(*, host: str, heartbeat_timeout: float)` | 起 Coord 子進程；暴露地址 |
+| `router_address` | `str` | ROUTER 地址 |
+| `pub_address` | `str` | PUB 地址 |
+| `close` | `() -> None` | 停子進程（idempotent） |
+
+（`run_omni_coordinator_proc`／`_get_*`／`_shutdown_proc` 非對外 API → 見 §5）
+
+### 0.2 `OmniCoordinator`（`omni_coordinator.py`）
+
+| API | 簽名／形狀 | 用途 |
+|-----|------------|------|
+| `__init__` | `(router_zmq_addr, pub_zmq_addr, heartbeat_timeout=30.0)` | bind ROUTER／PUB，起 recv／periodic thread |
+| `get_active_replicas` | `() -> ReplicaList` | 只含 UP 嘅列表 |
+| `add_new_replica` | `(event: ReplicaEvent) -> None` | 公開 mutator（生產實際唔經呢度） |
+| `update_replica_info` | `(event: ReplicaEvent) -> None` | 同上 |
+| `remove_replica` | `(event: ReplicaEvent) -> None` | 同上 |
+| `publish_replica_list_update` | `() -> bool` | PUB 當前 active list |
+| `close` | `() -> None` | 停 loop、關 socket |
+| `wait_for_shutdown` | `() -> None` | 等 stop／join threads |
+
+### 0.3 `OmniCoordClientForStage`（`omni_coord_client_for_stage.py`）
+
+| API | 簽名／形狀 | 用途 |
+|-----|------------|------|
+| `__init__` | `(coord_zmq_addr, input_address, output_address, stage_id, *, replica_id=0)` | DEALER connect；首發 `update`；起 heartbeat thread |
+| `update_info` | `(status=None, queue_length=None) -> None` | 發 `update`（生產少用；多靠 heartbeat hook） |
+| `close` | `() -> None` | 發 DOWN、停 heartbeat、關 socket |
+
+工廠：
+
+| API | 簽名／形狀 | 用途 |
+|-----|------------|------|
+| `create_stage_coord_client` | `(..., *, get_queue_length: Callable[[], int] \| None = None) -> OmniCoordClientForStage` | 建 client 並可掛 `_on_heartbeat` 刷新 queue |
+
+### 0.4 `OmniCoordClientForHub`（`omni_coord_client_for_hub.py`）
+
+| API | 簽名／形狀 | 用途 |
+|-----|------------|------|
+| `__init__` | `(coord_zmq_addr: str)` | SUB connect；起 recv thread |
+| `get_replica_list` | `() -> ReplicaList` | 最新全量 cache（可空列表） |
+| `get_replicas_for_stage` | `(stage_id: int) -> ReplicaList` | 按 stage 過濾 |
+| `close` | `() -> None` | 停 thread、關 socket |
+
+### 0.5 `LoadBalancer` 家族（`load_balancer.py`）
+
+| API | 簽名／形狀 | 用途 |
+|-----|------------|------|
+| `LoadBalancingPolicy` | enum：`random`／`round-robin`／`least-queue-length` | CLI／factory 策略名 |
+| `Task` | TypedDict：`request_id`／`engine_inputs`／`sampling_params` | `select` 任務上下文 |
+| `LoadBalancer.select` | `(task: Task, replicas: list[ReplicaInfo]) -> int` | 抽象：回 `replicas` 下標 |
+| `RandomBalancer` | `select(...)` | 均勻隨機 |
+| `RoundRobinBalancer` | `__init__(start_index=0)`；`select(...)` | 輪詢 |
+| `LeastQueueLengthBalancer` | `select(...)` | 最小 `queue_length`（並列隨機） |
+
+### 0.6 Messages（`messages.py`）
+
+| 型別 | 欄位／成員 | 用途 |
+|------|------------|------|
+| `ReplicaStatus` | `UP`／`DOWN`／`ERROR` | 副本狀態 |
+| `ReplicaEvent` | `input_addr, output_addr, stage_id, event_type, status, queue_length` | Stage→Coord wire |
+| `ReplicaInfo` | Event 欄位 + `last_heartbeat, registered_at` | registry／PUB 條目 |
+| `ReplicaList` | `replicas: list[ReplicaInfo], timestamp` | Coord→Hub 快照 |
+
+### 0.7 套件根 export（`__init__.py`）
+
+`OmniCoordinator`、`OmniCoordinatorRuntime`、`OmniCoordClientForStage`、`create_stage_coord_client`、`OmniCoordClientForHub`、`ReplicaStatus`、`ReplicaEvent`、`ReplicaInfo`、`ReplicaList`、`Task`、`LoadBalancer`、`LoadBalancingPolicy`、`RandomBalancer`、`RoundRobinBalancer`、`LeastQueueLengthBalancer`。
+
+---
+
+## 1. 廢碼／清理總表（先睇）
+
+
+| 項目                                     | 位置                                   | 判定                    | 理由                                           |
+| -------------------------------------- | ------------------------------------ | --------------------- | -------------------------------------------- |
+| `OmniCoordinator.add_new_replica`      | `omni_coordinator.py:87`             | `delete_or_privatize` | 生產／recv 唔呼叫；只經 `_handle_event` → `_*_locked` |
+| `OmniCoordinator.update_replica_info`  | `:93`                                | `delete_or_privatize` | 同上                                           |
+| `OmniCoordinator.remove_replica`       | `:99`                                | `delete_or_privatize` | 同上                                           |
+| `OmniCoordinator.get_active_replicas`  | `:81`                                | `keep`（可改 private）    | 僅 `publish_replica_list_update` 用；無套件外呼叫     |
+| `OmniCoordClientForStage.update_info`  | `omni_coord_client_for_stage.py:157` | `test_only`           | 生產路徑唔用；僅 tests                               |
+| `ReplicaEvent` 根 export                | `__init__.py`                        | `keep` 或收窄 export     | 套件外幾乎唔 import；wire 內部用                       |
+| `Task.engine_inputs`／`sampling_params` | `load_balancer.py:15-24`             | `keep`（標預留）           | 現有 policy 唔讀                                 |
+| Diffusion 手寫 `_on_heartbeat`           | `stage_diffusion_proc.py:626-636`    | `fix`（套件外）            | 應改 `create_stage_coord_client`               |
+
+
+**必須修（行為／可靠性）：**
+
+
+| 項目                                                      | 位置                                       | 判定    |
+| ------------------------------------------------------- | ---------------------------------------- | ----- |
+| `_send_event` 對 `zmq.Again` 靜默 drop（含首次 registration）   | `omni_coord_client_for_stage.py:139-141` | `fix` |
+| heartbeat 對未知 `input_addr` 忽略                           | `omni_coordinator.py:299-314`            | `fix` |
+| `_parse_replica_event`：`queue_length` 未 `int()`         | `omni_coordinator.py:211`                | `fix` |
+| Runtime `terminate`／`kill` 唔走 `OmniCoordinator.close()` | `runtime.py:74-81,153-159`               | `fix` |
+| close 語意不統一                                             | 見各檔                                      | `fix` |
+
+
+---
+
+
+
+## 2. `__init__.py`
+
+**用途：** 公開 API re-export。
+
+
+| 符號                               | 生產根 import？                   | 判定                |
+| -------------------------------- | ----------------------------- | ----------------- |
+| `OmniCoordinatorRuntime`         | 係（`stage_runtime`）            | `keep`            |
+| `OmniCoordinator`                | 主要 tests；生產經 `runtime` 子模組    | `keep`            |
+| `create_stage_coord_client`      | 係（LLM proc）                   | `keep`            |
+| `OmniCoordClientForStage`        | 係（Diffusion 直接用）              | `keep`            |
+| `OmniCoordClientForHub`          | Membership 多從子模組 import       | `keep`            |
+| `LoadBalancingPolicy`／LB classes | 係                             | `keep`            |
+| `ReplicaStatus`／`ReplicaInfo`    | 係                             | `keep`            |
+| `ReplicaList`                    | 少；tests／內部                    | `keep`            |
+| `ReplicaEvent`                   | 套件外幾乎無                        | `keep` 或唔再 export |
+| `Task`                           | 常從 `load_balancer` 子模組 import | `keep`            |
+
+
+無函式。無廢函式。
+
+---
+
+
+
+## 3. `messages.py`
+
+**用途：** wire／domain dataclass；無 I／O。
+
+
+| 名稱              | 輸入／欄位                                                      | 輸出           | 呼叫者                              | I／O 合理？                  | 判定                |
+| --------------- | ---------------------------------------------------------- | ------------ | -------------------------------- | ------------------------ | ----------------- |
+| `ReplicaStatus` | enum UP／DOWN／ERROR                                         | —            | 全套件＋pool／membership              | 係                        | `keep`            |
+| `ReplicaEvent`  | addrs, stage_id, event_type, status, **queue_length: int** | wire payload | stage client + coordinator parse | 欄位標 int，但 parse 端可塞 None | `keep` + 上游 `fix` |
+| `ReplicaInfo`   | 同上 + heartbeats                                            | registry／PUB | coordinator, hub, LB, pool       | 係                        | `keep`            |
+| `ReplicaList`   | replicas + timestamp                                       | PUB／cache    | coordinator, hub                 | 係                        | `keep`            |
+
+
+**可清理：** 無廢 type。注意 `ReplicaEvent.queue_length: int` 同 parse 行為不一致。
+
+---
+
+
+
+## 4. `load_balancer.py`
+
+
+| 名稱                                | 簽名            | 輸入             | 輸出／副作用               | 呼叫者                             | 合理？                               | 判定     |
+| --------------------------------- | ------------- | -------------- | -------------------- | ------------------------------- | --------------------------------- | ------ |
+| `Task`                            | TypedDict     | request_id 等   | —                    | `stage_pool.pick` 只填 request_id | 額外欄位預留                            | `keep` |
+| `LoadBalancingPolicy`             | Enum          | —              | —                    | serve CLI、stage_runtime factory | 係                                 | `keep` |
+| `LoadBalancer.select`             | abstract      | task, replicas | index                | 子類                              | 係                                 | `keep` |
+| `RandomBalancer.select`           |               | replicas 非空    | random index         | 生產                              | 空 list raise OK                   | `keep` |
+| `RoundRobinBalancer.__init__`     | start_index=0 | —              | counter+Lock         | factory／tests                   | 係                                 | `keep` |
+| `RoundRobinBalancer.select`       |               | replicas       | RR index             | 生產                              | 順序敏感（doc 已寫）                      | `keep` |
+| `LeastQueueLengthBalancer.select` |               | replicas       | min queue；tie random | 生產                              | 負 queue raise OK；依賴 heartbeat 新鮮度 | `keep` |
+
+
+**可清理：** 無廢 function。`Task` 多餘欄位可註明 unused-by-current-policies。
+
+**結構備註（P2）：** 本檔**無 ZMQ、唔識 Coord 進程**；生產由 `StagePool.pick` 擁有。放喺 `omni_coordinator/` 只係歷史打包＋共用 `ReplicaInfo`。功能 `keep`；**套件歸屬宜另議遷出**（見 analysis §3 P2）。
+
+---
+
+
+
+## 5. `runtime.py`
+
+
+| 名稱                                | 簽名                               | 輸入      | 輸出／副作用                                                | 呼叫者                 | 合理？             | 判定                     |
+| --------------------------------- | -------------------------------- | ------- | ----------------------------------------------------- | ------------------- | --------------- | ---------------------- |
+| `run_omni_coordinator_proc`       | router, pub, timeout, ready_pipe | pipe    | 建 OC → ready → `wait_for_shutdown`；**永遠唔 call close** | Process target      | 子進程只靠殺          | `fix`（應可 signal→close） |
+| `_get_coordinator_mp_context`     | ()                               | —       | fork 優先 else spawn                                    | Runtime.**init**    | TODO spawn-safe | `keep` + 跟進 TODO       |
+| `_shutdown_proc`                  | proc                             | Process | terminate→join→kill                                   | close／finalizer     | 粗暴但明確           | `fix`（配優雅關閉）           |
+| `OmniCoordinatorRuntime.__init__` | host, heartbeat_timeout          | 校驗      | 配 port、spawn daemon、等 ready 30s                       | `stage_runtime:929` | 單實例＝SPOF 根源     | `keep`（行為需文件化）         |
+| `OmniCoordinatorRuntime.close`    | ()                               | —       | **idempotent**；kill 子進程                               | `stage_runtime:848` | 同其他 close 語意唔齊  | `fix`                  |
+
+
+**可刪：** 無。  
+**必須修：** 關閉路徑應觸發 `OmniCoordinator.close()`；daemon／單實例寫入系統風險文件（已完成）。
+
+---
+
+
+
+## 6. `omni_coordinator.py`
+
+
+
+### 5.1 Public
+
+
+| 名稱                            | 輸入                       | 輸出／副作用                             | 呼叫者                                 | 合理？                  | 判定                             |
+| ----------------------------- | ------------------------ | ---------------------------------- | ----------------------------------- | -------------------- | ------------------------------ |
+| `__init__`                    | router／pub addr, timeout | bind；起 recv＋periodic threads       | runtime, tests                      | 建構即開線程，難測但現況可用       | `keep`                         |
+| `get_active_replicas`         | —                        | ReplicaList(UP only)               | **僅** `publish_replica_list_update` | OK                   | `keep`→可 `_` 私有                |
+| `add_new_replica`             | ReplicaEvent             | 鎖＋schedule broadcast               | **無**（生產／recv 都唔用）                  | 同 `_handle_event` 重複 | `delete_or_privatize`          |
+| `update_replica_info`         | ReplicaEvent             | 同上                                 | **無**                               | 重複                   | `delete_or_privatize`          |
+| `remove_replica`              | ReplicaEvent             | mark DOWN＋broadcast                | **無**                               | 重複                   | `delete_or_privatize`          |
+| `publish_replica_list_update` | —                        | PUB JSON NOBLOCK；bool              | `_periodic_loop`                    | drop 靜默＝best-effort  | `keep`；文件化 P1                  |
+| `close`                       | —                        | join threads；關 socket；**二次 raise** | 幾乎僅 tests                           | 生產 Runtime 唔叫        | `fix`（idempotent + Runtime 接通） |
+| `wait_for_shutdown`           | —                        | block `_stop_event`                | runtime child                       | OK                   | `keep`                         |
+
+
+
+
+### 5.2 Private
+
+
+| 名稱                            | 輸入           | 輸出／副作用                            | 呼叫者           | 合理？                                                    | 判定                    |
+| ----------------------------- | ------------ | --------------------------------- | ------------- | ------------------------------------------------------ | --------------------- |
+| `_schedule_broadcast`         | —            | set pending flag                  | 多處            | OK coalesce                                            | `keep`                |
+| `_mark_replica_error_locked`  | info         | status=ERROR                      | timeout check | OK                                                     | `keep`                |
+| `_check_heartbeat_timeouts`   | —            | UP→ERROR；DOWN／ERROR 600s GC       | periodic      | OK                                                     | `keep`                |
+| `_parse_replica_event`        | dict         | ReplicaEvent｜None                 | recv          | `queue_length=data.get(...)` 可 None，同 dataclass int 衝突 | `fix`                 |
+| `_recv_loop`                  | —            | ROUTER recv→handle                | daemon thread | Again continue OK                                      | `keep`                |
+| `_periodic_loop`              | —            | timeout＋keepalive PUB             | daemon thread | keepalive 設計合理                                         | `keep`                |
+| `_handle_event`               | ReplicaEvent | 分派 heartbeat／register／update／down | recv          | **heartbeat 未知 addr 忽略**（L303-314）                     | `fix`                 |
+| `_add_new_replica_locked`     | event        | 寫 `_replicas`                     | handle        | 校驗 input_addr／stage_id                                 | `keep`                |
+| `_update_replica_info_locked` | event        | 改 status／queue                    | handle        | OK                                                     | `keep`                |
+| `_remove_replica_locked`      | event        | status=DOWN（唔即刪）                  | handle        | 靠 GC；同「remove」字面略偏                                     | `keep`（可改名 mark_down） |
+
+
+**可刪／收窄：** 三個 public mutator。  
+**必須修：** parse queue_length；heartbeat upsert 或明確 log。
+
+---
+
+
+
+## 7. `omni_coord_client_for_stage.py`
+
+
+| 名稱                          | 輸入                                | 輸出／副作用                                           | 呼叫者                              | 合理？                         | 判定                |
+| --------------------------- | --------------------------------- | ------------------------------------------------ | -------------------------------- | --------------------------- | ----------------- |
+| `__init__`                  | coord addr, in／out addr, stage_id | connect；`_send_event("update")`；起 heartbeat      | factory／Diffusion／tests          | **首次 update 可被 Again drop** | `fix`             |
+| `_reconnect`                | max_retries=3, interval=5         | 重建 DEALER                                        | `_send_event`                    | 有限次；長期 down 後放棄             | `keep`（可調）        |
+| `_send_event`               | event_type                        | NOBLOCK send；Again→**drop return**；其他錯→reconnect | init／update／hb／close             | **P1 不可靠**                  | `fix`             |
+| `update_info`               | status? queue_length?             | 改本地＋send update                                  | **僅 tests**                      | API 合理但生產唔用                 | `test_only`       |
+| `_heartbeat_loop`           | —                                 | 每 5s hook＋heartbeat                              | daemon                           | hook 例外被吞（應有）               | `keep`            |
+| `close`                     | —                                 | stop；DOWN update；關 socket；**二次 raise**           | LLM／Diff finally                 | DOWN 亦可能 Again drop         | `fix`（idempotent） |
+| `create_stage_coord_client` | + optional queue_length_getter    | 建 client＋掛 `_on_heartbeat`                       | LLM `stage_engine_core_proc:162` | 正確公開入口                      | `keep`            |
+
+
+**可清理：** 鼓勵刪／標記 `update_info` 為 test helper；Diffusion 改用 factory。  
+**必須修：** registration／critical update 唔可 Again 靜默成功返回。
+
+---
+
+
+
+## 8. `omni_coord_client_for_hub.py`
+
+
+| 名稱                       | 輸入       | 輸出／副作用                              | 呼叫者                  | 合理？                     | 判定                |
+| ------------------------ | -------- | ----------------------------------- | -------------------- | ----------------------- | ----------------- |
+| `__init__`               | pub addr | 起 thread；等 init 5s；失敗 raise         | MembershipController | fail-fast OK            | `keep`            |
+| `_decode_replica_list`   | dict     | ReplicaList                         | recv                 | `int(queue_length)` 嚴格  | `keep`            |
+| `_recv_loop`             | —        | SUB connect／recv／reconnect；更新 cache | daemon               | Coord 長期 down 時 1s 空轉   | `keep`            |
+| `get_replica_list`       | —        | 最新 cache 或空 list                    | membership watcher   | OK                      | `keep`            |
+| `get_replicas_for_stage` | stage_id | filter                              | StagePool            | OK                      | `keep`            |
+| `close`                  | —        | stop＋join 1s；**二次 raise**           | Membership.shutdown  | join timeout 後仍標 closed | `fix`（idempotent） |
+
+
+**可刪：** 無廢 function。  
+**可收窄：** 無同步 snapshot RPC（系統層 P1／設計項，唔係廢碼）。
+
+---
+
+
+
+## 9. 跨檔 I／O 合理性摘要
+
+
+| 路徑                         | 問題                               | 嚴重度          |
+| -------------------------- | -------------------------------- | ------------ |
+| Stage → Coord registration | `Again` drop 當成功                 | P1           |
+| Stage heartbeat → Coord    | 未知 addr 忽略                       | P1           |
+| Coord → Hub PUB            | NOBLOCK drop；靠 keepalive 補       | P1／可接受若有 SLA |
+| Parse queue_length         | 可 None 入 int 欄位                  | P2           |
+| Runtime shutdown           | kill 唔 close                     | P1           |
+| Hub decode                 | 嚴格 int — 同 coordinator parse 不對稱 | P2           |
+
+
+---
+
+
+
+## 10. 建議 cleanup PR 切分（審計導向）
+
+
+| PR  | 內容                                                                    | 風險            |
+| --- | --------------------------------------------------------------------- | ------------- |
+| A   | 文件：SPOF＋本 audit（無碼）                                                   | 無             |
+| B   | 刪／私有化 dead public mutators；`update_info` 標 test-only 或留並加註            | 低（測要改 import） |
+| C   | `_parse_replica_event` 強制 int／缺省 0；heartbeat 未知 addr upsert 或 warning | 中（行為變）        |
+| D   | Stage registration 可靠送達（Again retry／blocking）                         | 中             |
+| E   | Runtime graceful close + 統一 idempotent close                          | 中             |
+| F   | Diffusion 改 `create_stage_coord_client`                               | 低             |
+
+
+**唔**把 example3 合併 Master 塞入上表必做項。
+
+---
+
+
+
+## 11. 覆蓋檢查清單
+
+- [x] `__init__.py`
+- [x] `messages.py`
+- [x] `load_balancer.py`（全部 select／**init**）
+- [x] `runtime.py`（全部 top-level + Runtime）
+- [x] `omni_coordinator.py`（全部 public／private）
+- [x] `omni_coord_client_for_stage.py`
+- [x] `omni_coord_client_for_hub.py`

--- a/refactor/omni_coordinator_code_audit.zh.md
+++ b/refactor/omni_coordinator_code_audit.zh.md
@@ -1,9 +1,10 @@
 # OmniCoordinator Code Audit（逐 function）
 
-> 配套系統分析：`[omni_coordinator_analysis.zh.md](omni_coordinator_analysis.zh.md)`  
+> 配套系統分析：[`omni_coordinator_analysis.zh.md`](omni_coordinator_analysis.zh.md)／[`omni_coordinator_analysis.md`](omni_coordinator_analysis.md)  
+> 講稿：[`omni_coordinator_talk.zh.md`](omni_coordinator_talk.zh.md)  
 > 範圍：`vllm_omni/distributed/omni_coordinator/` 全部 7 檔  
 > 基準：`main` @ `c27623c2`  
-> 判定：`keep`｜`fix`｜`delete_or_privatize`｜`test_only`
+> 判定：`keep`｜`fix`｜`delete_or_privatize`｜`test_only`（**現状**；目標見 analysis §6 **定案 B**）
 
 呼叫者欄：「生產」= `vllm_omni/` 非 test；「僅 test」= `tests/`；「內部」= 套件內。
 
@@ -41,6 +42,9 @@
 
 ### 0.3 `OmniCoordClientForStage`（`omni_coord_client_for_stage.py`）
 
+**現状：** 只做 membership（`update`／heartbeat）；**無** bootstrap `register`（仍走 `OmniMasterServer`）。  
+**目標（analysis §6 定案 B）：** 擴展為 `register`＋`update`／`heartbeat`（類名可再收斂）；啟動時已知 Coord 地址。
+
 | API | 簽名／形狀 | 用途 |
 |-----|------------|------|
 | `__init__` | `(coord_zmq_addr, input_address, output_address, stage_id, *, replica_id=0)` | DEALER connect；首發 `update`；起 heartbeat thread |
@@ -54,6 +58,9 @@
 | `create_stage_coord_client` | `(..., *, get_queue_length: Callable[[], int] \| None = None) -> OmniCoordClientForStage` | 建 client 並可掛 `_on_heartbeat` 刷新 queue |
 
 ### 0.4 `OmniCoordClientForHub`（`omni_coord_client_for_hub.py`）
+
+**現状：** Head SUB 缓存；Mem／Pool 讀 snapshot。  
+**目標（analysis §6）：** **刪除**——`StagePool` 直讀 Coord；唔再經 PUB／SUB／Hub。
 
 | API | 簽名／形狀 | 用途 |
 |-----|------------|------|
@@ -129,8 +136,8 @@
 | `OmniCoordinatorRuntime`         | 係（`stage_runtime`）            | `keep`            |
 | `OmniCoordinator`                | 主要 tests；生產經 `runtime` 子模組    | `keep`            |
 | `create_stage_coord_client`      | 係（LLM proc）                   | `keep`            |
-| `OmniCoordClientForStage`        | 係（Diffusion 直接用）              | `keep`            |
-| `OmniCoordClientForHub`          | Membership 多從子模組 import       | `keep`            |
+| `OmniCoordClientForStage`        | 係（Diffusion 直接用）              | `keep`（目標擴 `register`） |
+| `OmniCoordClientForHub`          | Membership 多從子模組 import       | `keep`（目標 **刪除**） |
 | `LoadBalancingPolicy`／LB classes | 係                             | `keep`            |
 | `ReplicaStatus`／`ReplicaInfo`    | 係                             | `keep`            |
 | `ReplicaList`                    | 少；tests／內部                    | `keep`            |
@@ -307,20 +314,16 @@
 
 
 
-## 10. 建議 cleanup PR 切分（審計導向）
+## 10. 建議 PR 切分（對齊 analysis §6）
 
+系統級切分以 analysis 為準（唔用本節舊 A–F 字母，避免同「定案 B」撞名）：
 
-| PR  | 內容                                                                    | 風險            |
-| --- | --------------------------------------------------------------------- | ------------- |
-| A   | 文件：SPOF＋本 audit（無碼）                                                   | 無             |
-| B   | 刪／私有化 dead public mutators；`update_info` 標 test-only 或留並加註            | 低（測要改 import） |
-| C   | `_parse_replica_event` 強制 int／缺省 0；heartbeat 未知 addr upsert 或 warning | 中（行為變）        |
-| D   | Stage registration 可靠送達（Again retry／blocking）                         | 中             |
-| E   | Runtime graceful close + 統一 idempotent close                          | 中             |
-| F   | Diffusion 改 `create_stage_coord_client`                               | 低             |
+| PR | 內容 | 對應 |
+|----|------|------|
+| **PR1** | SPOF／註冊測試；R1–R5；死 API；統一 LLM／Diff 路徑；LB 歸屬（仍只內建三策略） | P0＋P1 可靠性＋P2 小清理 |
+| **PR2** | Master→Coord；**ClientForStage 兼 `register`**；**刪 Hub／Mem**；Pool 直讀；dotted-path 自訂 LB | P1 重構主線＋自訂 LB |
 
-
-**唔**把 example3 合併 Master 塞入上表必做項。
+本 audit 逐項修復（Again／upsert／close／int／dead API）優先落入 **PR1**。
 
 ---
 

--- a/refactor/omni_coordinator_talk.zh.md
+++ b/refactor/omni_coordinator_talk.zh.md
@@ -70,8 +70,9 @@ handshake／input／output **唔經** Coord；Coord 只維護 membership。
 
 ### 1.4 `OmniCoordClientForStage` 邊個 new？
 
-**唔係 Master。** Master 只回 `coordinator_router_address`（analysis 回覆欄位表）。  
-Stage 進程自己起：LLM 用 `create_stage_coord_client`；Diffusion 直接 ctor（P2 S3 雙路徑）。
+**現状：** 唔係 Master new。Master 只回 `coordinator_router_address`；Stage 自己起 client（只做 update／HB；**唔做** bootstrap register）。LLM：`create_stage_coord_client`；Diffusion：直接 ctor（P2 S3）。  
+
+**目標 B：** Stage 已知 Coord 地址 → `new ClientForStage` → **`register`＋update／HB**；**Hub 刪除**。
 
 ---
 
@@ -180,18 +181,19 @@ Stage 進程自己起：LLM 用 `create_stage_coord_client`；Diffusion 直接 c
 
 | # | 痛點 | 方向 |
 |---|------|------|
-| M1 | Master 同 Coord **並列** | 併入 Coord；register／update 同一 owner |
+| M1 | Master 同 Coord **並列** | 併入 Coord；Stage 經 ClientForStage 做 register／update |
 | M2 | Hub＋Mem 間接層 | Pool **直讀** Coord（隨合併落地） |
 
-目標形狀（投影 analysis §6 目標圖）：
+目標形狀（投影 analysis §6 目標圖；**定案 B**）：
 
-- **刪除**獨立 Master／Hub／`MembershipController`（唔係「收窄」）  
-- Coord 兼做 register（派 HS／IO）＋ registry  
-- `StagePool` **直讀** Coord；class **沿用舊名**  
+- **刪除**獨立 Master、**`OmniCoordClientForHub`**、`MembershipController`  
+- Coord 兼做 register（對端）＋ registry  
+- Stage 側：`OmniCoordClientForStage`（可改名）**兼做** `register`＋`update`／`heartbeat`  
+- `StagePool` **直讀** Coord（**唔經 Hub**）；class **沿用舊名**  
 
 金句：
 
-> 兩個 P1 同級；**refactor 真正要交嘅係合併 Master（PR2）**。
+> 兩個 P1 同級；**refactor 真正要交嘅係合併 Master（PR2）**。Hub 目標刪除。
 
 ### 4.3 P2（對齊 analysis S1–S5）
 
@@ -228,7 +230,7 @@ Stage 進程自己起：LLM 用 `create_stage_coord_client`；Diffusion 直接 c
 | | **PR1** | **PR2（主線）** |
 |--|---------|-----------------|
 | 對應 | P0 預期＋**P1 可靠性**＋P2 小清理 | **P1 重構**＋自訂 LB |
-| 做 | SPOF／註冊測試；R1–R5；死 API；**統一 LLM／Diff 路徑**；LB 歸屬（仍只內建三策略） | Master→Coord；**刪除** Hub／Mem；Pool 直讀；dotted-path 自訂 LB |
+| 做 | SPOF／註冊測試；R1–R5；死 API；**統一 LLM／Diff 路徑**；LB 歸屬（仍只內建三策略） | Master→Coord；ClientForStage **兼 register**；**刪除** Hub／Mem；Pool 直讀；自訂 LB |
 | 唔做 | 合併 Master；自訂 LB；刪 Hub／Mem | 完整 HA |
 | 順序 | **建議先**（鎖行為、降回歸） | refactor **主交付**；依賴 PR1 先落地 |
 
@@ -245,10 +247,12 @@ vllm serve ... --omni-lb-policy=mypkg.lb:MyBalancer
 字串傳到 `_build_load_balancer_factory` 先 `importlib`；內建 `random`／`round-robin`／`least-queue-length` 保留。  
 上游 core **冇**呢個跨 stage `LoadBalancer`；風格近 production-stack dotted callback。
 
-### PR2 目標時序（對照現状／analysis §6）
+### PR2 目標時序（對照現状／analysis §6；定案 B）
 
-- 只起 Coord（含舊 Master 職責）→ Stage **向 Coord register** → client update → Pool **直讀** Coord  
-- 使用期：heartbeat／registry／pick 三線，**唔經 Hub**  
+- 只起 Coord → Stage **已知 Coord 地址** → `new ClientForStage` → **`register`（HS／IO）** → 同一 client `update`／heartbeat → Pool **直讀** Coord  
+- **`ClientForHub` 冇咗**（刪除）；使用期唔經 PUB／SUB／Hub  
+
+**Q&A 預答：** 點解唔再要 Hub？——合併後 Head 唔使訂閱 Coord PUB 做缓存；Pool 直問 Coord，少一層 stale／ownership。
 
 ---
 
@@ -279,7 +283,10 @@ A：算緩解。registry 仍空，要可靠重註冊。真 HA 另案。（analys
 A：係。PR2 清 ownership，唔消除單點。
 
 **Q：`OmniCoordClientForStage` 係咪 Master new？**  
-A：唔係。Master 只回 router 字串；Stage 自己起。
+A：現状唔係（Master 只回 router）。**目標 B**：Stage 已知 Coord 地址，自己 `new` client，再 `register`。
+
+**Q：目標仲有冇 `ClientForHub`？**  
+A：**冇。** PR2 刪除；Pool 直讀 Coord。
 
 **Q：Runtime 公開 API 係咪好多？**  
 A：唔多。對外就建構＋兩個地址＋`close`。

--- a/refactor/omni_coordinator_talk.zh.md
+++ b/refactor/omni_coordinator_talk.zh.md
@@ -1,0 +1,310 @@
+# OmniCoordinator 講稿（工程師場）
+
+配合投影（**以 analysis 為準**；講稿只係口述節奏）：
+
+| 文件 | 用途 |
+|------|------|
+| [`omni_coordinator_analysis.zh.md`](omni_coordinator_analysis.zh.md)／[`.md`](omni_coordinator_analysis.md) | 對外系統分析（簡體／英文）；架構、分級、PR |
+| [`omni_coordinator_code_audit.zh.md`](omni_coordinator_code_audit.zh.md) | 公開 API＋逐 function 審計 |
+
+語氣：講**碼上事實**；分開「已證實」同「草案」。對外 analysis **唔講**內部討論過程（例如方案代號）。  
+建議時長：**約 15–20 分鐘**＋ Q&A。
+
+---
+
+## 0. 開場（1 分鐘）
+
+今日主題：`vllm_omni/distributed/omni_coordinator` **全套件**（7 個檔）——先講清邊個做咩，再答**係咪單點**（analysis §2），再分級／PR。
+
+**三句定調（建議照念；由淺入深）：**
+
+1. **唔係每次 serve 都起 Coord**——只有 `DistStageRuntime`（`--stage-id` + master）。普通 in-process multi-stage **冇** Coord。（analysis §1 開首）  
+2. **第一條大問題：Coord 係咪單點？**——一個子進程＋記憶體 registry、無 HA（細節：**講稿 §3／analysis §2**）。  
+3. **Refactor 主線**係 **合併 Master 入 Coord**（P1；PR2）——同單點係兩件事；單點講完先再講「合併救唔救 SPOF」。
+
+今日要聽眾帶走：
+
+- Master 同 Coord 邊個做咩  
+- 點解話 P0 單點；緩解同真 HA 點分  
+- 可靠性縫＋合併主線；交 PR 時邊條係主交付  
+
+---
+
+## 1. 架構：邊個喺邊（3 分鐘）
+
+（投影 analysis §1.1 結構圖＋組件表）
+
+### 1.1 組件一句（對齊 analysis §1.1 表）
+
+| 組件 | 一句 |
+|------|------|
+| `OmniCoordinatorRuntime` | 啟停 Coord；**只露** router／pub 地址 |
+| `OmniCoordinator` | 記憶體 registry + ROUTER／PUB |
+| `OmniMasterServer` | 註冊時派握手／I／O 地址，並回傳 router_addr |
+| `OmniCoordClientForHub` | SUB 缓存；Mem 持有；Mem／Pool 讀 snapshot |
+| `StagePool` + `LoadBalancer` | 選副本（LB 歸屬見 §3 P2） |
+| `OmniCoordClientForStage` | update／heartbeat → Coord |
+
+### 1.2 兩個地址（analysis §1.2）
+
+| 地址 | 邊個 bind | 邊個用 |
+|------|-----------|--------|
+| `router_addr` | **Coord** ROUTER | Master **轉發字串**；Stage DEALER |
+| `pub_addr` | **Coord** PUB | Head：Mem → Hub SUB |
+
+handshake／input／output **唔經** Coord；Coord 只維護 membership。  
+→ Runtime 報嘅地址 **即** Coord bind 嘅 socket。
+
+### 1.3 Master ≠ Coord（必講清楚）
+
+| | Master | Coord |
+|--|--------|-------|
+| 時機 | register **一次**（bootstrap） | 持續 update／heartbeat／PUB |
+| 做乜 | 派握手／資料面 ZMQ 地址（handshake／input／output）＋ echo router | membership／活死人／queue 視圖 |
+| 唔做乜 | 唔管 heartbeat、唔做 LB／pick | 唔派 handshake／IO port |
+
+現場金句（注意：**pick 唔喺 Coord 入面做**）：
+
+> Master 負責「點樣入場」；Coord 負責「入場之後邊個仲活」。  
+> **Pick** 係 Head 側 `StagePool`＋`LoadBalancer` 讀 Hub snapshot。
+
+### 1.4 `OmniCoordClientForStage` 邊個 new？
+
+**唔係 Master。** Master 只回 `coordinator_router_address`（analysis 回覆欄位表）。  
+Stage 進程自己起：LLM 用 `create_stage_coord_client`；Diffusion 直接 ctor（P2 S3 雙路徑）。
+
+---
+
+## 2. 時序（3 分鐘）
+
+（投影 analysis §1.2／§1.3）
+
+### 2.1 建立（現状）
+
+口頭對齊 sequenceDiagram，唔使讀完表：
+
+1. Head：`OmniCoordinatorRuntime` → child `OmniCoordinator` ready（router／pub）  
+2. Head：起 `OmniMasterServer`（帶 router 字串）  
+3. Head init／等 Stage（本地或 headless）  
+4. Stage／launch → Master：**register** → 回 HS／IO／replica_id／router  
+5. Head bind HS／IO；engine connect  
+6. Stage 起 client → Coord：**DEALER update**  
+7. Head：Mem＋Hub SUB pub → 之後可 pick  
+
+強調：**Head 先起齊 Master＋Coord**，先至 launch／等 replica；register 攞匯合地址。
+
+本地 vs headless（analysis 路徑表）：本地由 Head launch helper register、Head **bind** HS；headless 自行 register、**connect**。
+
+### 2.2 使用：三條線（唔好講錯因果）
+
+| 線 | 邊個 | 做乜（對齊 analysis §1.3） |
+|----|------|---------------------------|
+| A | Stage client | DEALER heartbeat；Coord 改記憶體；**queue 變或 ERROR→UP** 先 schedule 廣播 |
+| B | Coord periodic | timeout＋合併後 PUB；Hub 收 cache |
+| C | Pool＋LB | 讀 Hub snapshot → `select` |
+
+金句：
+
+> **唔係每次 heartbeat 即 PUB**；pick 同單次 heartbeat **無直接因果**。
+
+### 2.3 動態 headless（analysis §1.3 末）
+
+服務拉起後可以再加 headless：Master `on_register` → Orchestrator → `MembershipController` attach → Pool。  
+**有手動動態掛上；冇 autoscaler。**
+
+---
+
+## 3. P0：單點？（2 分鐘）
+
+（投影 analysis §2）
+
+**結論：係 availability SPOF。**
+
+證據：
+
+- 每個 head **一個** Coord 子進程  
+- registry **只在記憶體**  
+- **無** HA／failover  
+
+掛咗之後：
+
+- membership／LB 熱路徑冇備援；`StagePool.pick` 失敗或空轉  
+- HTTP serve **未必**即死；Master handshake **仍可**獨立  
+
+**單點講清之後，先好講呢句（開場唔好提早丟；analysis §2 緩解表）：**
+
+> **合併 ≠ 解決單點**——清嘅係 ownership；記憶體 registry、無 HA 仍然係 P0。  
+> **Watchdog ≠ HA**——只係緩解；registry 仍空，要可靠重註冊（R1／R2）；快照另論。
+
+| 手段 | 效果 |
+|------|------|
+| Watchdog 重拉 Coord | 進程可自愈；registry 仍空 |
+| 持久化／冷啟動快照 | 縮短空窗；仍係單活 |
+| 合併 Master（PR2） | 清 ownership；**仍然可以係**單點 |
+| 真 HA | 另案；本 refactor **唔做** |
+
+現場問句（可留白）：
+
+> 若我哋 kill Coord 子進程，pool 預期點樣？——應用測試鎖住答案（PR1）。
+
+---
+
+## 4. 分級：兩個 P1（3 分鐘）
+
+（投影 analysis §3）
+
+| 優先 | 類別 | 講法 |
+|------|------|------|
+| **P0** | 可用性 | 只有一個 Coord（記憶體 registry、無 HA） |
+| **P1** | **可靠性** | 註冊／心跳／PUB／關閉靜默失敗或狀態唔齊（R1–R5） |
+| **P1** | **重構：合併 Master** | 雙 owner 必須收束——**本任務主線 → PR2** |
+| **P2** | 套件結構 | LB 歸屬、死 API、雙路徑、自訂 LB |
+
+分級金句（analysis）：
+
+> P0＝只有一個 Coord；P1 可靠性＝路徑唔夠可靠；P1 重構＝Master／Coord 雙 owner 必須收束。
+
+### 4.1 P1 可靠性（R1–R5）
+
+| # | 一句 |
+|---|------|
+| R1 | Stage registration 遇 `zmq.Again` **靜默 drop** → 永不進 registry |
+| R2 | 未知 `input_addr` 嘅 heartbeat **直接忽略** → 首次 update 丟就永久缺席 |
+| R3 | PUB／send `NOBLOCK` best-effort → Hub／Pool 視圖陳舊 |
+| R4 | Runtime `terminate`／`kill`；子進程唔走 `coordinator.close()`（見 analysis §5 close 矩陣） |
+| R5 | `queue_length` parse 未強制 `int` |
+
+三者疊加（R1＋R2＋R3）：cold start／Coord 重啟後，Stage「以為註冊咗」，Hub／Pool 睇唔到。
+
+### 4.2 P1 重構（M1／M2；主線多講）
+
+| # | 痛點 | 方向 |
+|---|------|------|
+| M1 | Master 同 Coord **並列** | 併入 Coord；register／update 同一 owner |
+| M2 | Hub＋Mem 間接層 | Pool **直讀** Coord（隨合併落地） |
+
+目標形狀（投影 analysis §6 目標圖）：
+
+- **刪除**獨立 Master／Hub／`MembershipController`（唔係「收窄」）  
+- Coord 兼做 register（派 HS／IO）＋ registry  
+- `StagePool` **直讀** Coord；class **沿用舊名**  
+
+金句：
+
+> 兩個 P1 同級；**refactor 真正要交嘅係合併 Master（PR2）**。
+
+### 4.3 P2（對齊 analysis S1–S5）
+
+- **S1 LB 歸屬**：純 `select`；擁有者 Head／`StagePool`；放喺套件係結構債  
+- **S2 死 API**：`add_new_replica` 等；stage `update_info` 僅 tests  
+- **S3** LLM／Diffusion 註冊雙路徑  
+- **S4** fork／spawn 進程模型 TODO（`runtime.py`）  
+- **S5 自訂 LB**：PR2；`--omni-lb-policy=mypkg.lb:MyBalancer`（或 `mypkg:MyBalancer`）
+
+---
+
+## 5. Code audit 速覽（2–3 分鐘）
+
+（翻 audit §0 公開 API → §1 廢碼表；必要時 analysis §4 檔案一覽、§5 close）
+
+### 5.1 公開面要細
+
+`OmniCoordinatorRuntime` **對外只有**：`__init__(host, heartbeat_timeout)`、`router_address`、`pub_address`、`close`。
+
+`OmniCoordinator` 公開 mutator（`add_new_replica` 等）**生產唔用**——走 `_handle_event`。
+
+### 5.2 可清理 vs 必須修
+
+**可清理（P2／PR1）：** 死公開 mutator；`update_info` 僅 tests；可收窄 `get_active_replicas` 等。  
+
+**必須修（P1 可靠性／PR1）：** R1–R5（Again drop、未知 addr HB、PUB／SLA、優雅 close、`queue_length` int）。
+
+---
+
+## 6. 兩個 PR（2 分鐘）
+
+（投影 analysis §6 總表＋PR2 目標圖）
+
+| | **PR1** | **PR2（主線）** |
+|--|---------|-----------------|
+| 對應 | P0 預期＋**P1 可靠性**＋P2 小清理 | **P1 重構**＋自訂 LB |
+| 做 | SPOF／註冊測試；R1–R5；死 API；**統一 LLM／Diff 路徑**；LB 歸屬（仍只內建三策略） | Master→Coord；**刪除** Hub／Mem；Pool 直讀；dotted-path 自訂 LB |
+| 唔做 | 合併 Master；自訂 LB；刪 Hub／Mem | 完整 HA |
+| 順序 | **建議先**（鎖行為、降回歸） | refactor **主交付**；依賴 PR1 先落地 |
+
+金句（analysis）：
+
+> Refactor 主線係 PR2。PR1 建議先合。**PR2 唔消除單點本身。**
+
+### PR2 自訂 LB（口頭 20 秒）
+
+```bash
+vllm serve ... --omni-lb-policy=mypkg.lb:MyBalancer
+```
+
+字串傳到 `_build_load_balancer_factory` 先 `importlib`；內建 `random`／`round-robin`／`least-queue-length` 保留。  
+上游 core **冇**呢個跨 stage `LoadBalancer`；風格近 production-stack dotted callback。
+
+### PR2 目標時序（對照現状／analysis §6）
+
+- 只起 Coord（含舊 Master 職責）→ Stage **向 Coord register** → client update → Pool **直讀** Coord  
+- 使用期：heartbeat／registry／pick 三線，**唔經 Hub**  
+
+---
+
+## 7. 收束（1 分鐘）
+
+帶走三點：
+
+1. **Coord 係 membership／LB 熱路徑 SPOF**；serve 未必即死；watchdog≠HA  
+2. **兩個 P1**：可靠性縫 ＋ **合併 Master（refactor 主線）**  
+3. 落地：**PR1（建議）→ PR2（主交付）**；今日講分析，唔強制落 code  
+
+投影收尾：analysis §3 分級表 ＋ §6 PR 表。
+
+---
+
+## 附：可能 Q&A
+
+**Q：單進程 multi-stage 有冇 Coord？**  
+A：冇。普通 `StageRuntime` 唔起；只有 `DistStageRuntime`。
+
+**Q：Coord 掛會唔會令整個 vllm serve crash？**  
+A：唔保證即 crash；distributed membership／pick 會壞。Master 仍可能握手。
+
+**Q：加 watchdog 算唔算解決 P0？**  
+A：算緩解。registry 仍空，要可靠重註冊。真 HA 另案。（analysis §2）
+
+**Q：合併 Master 之後仲係唔係單點？**  
+A：係。PR2 清 ownership，唔消除單點。
+
+**Q：`OmniCoordClientForStage` 係咪 Master new？**  
+A：唔係。Master 只回 router 字串；Stage 自己起。
+
+**Q：Runtime 公開 API 係咪好多？**  
+A：唔多。對外就建構＋兩個地址＋`close`。
+
+**Q：vLLM 上游有冇同樣嘅 LoadBalancer？**  
+A：core 冇跨 stage replica 呢個 class；DP 有內建 queue／prefix LB。跨 engine 分流喺 production-stack。Omni 自訂用 dotted path。
+
+**Q：刪 dead API 會唔會破 test？**  
+A：可能要改 test；生產唔依賴呢啲 public mutator。
+
+**Q：自訂 LB 同合併 Master 可唔可以拆開？**  
+A：而家一齊放 PR2。太大可拆 PR2a 合併、PR2b dotted-path LB。
+
+**Q：動態擴縮容有冇？**  
+A：有手動 headless 動態掛上；冇 autoscaler。（analysis §1.3）
+
+---
+
+## 附：投影檢查清單（對齊 analysis 章節）
+
+- [ ] §1.1 現状結構圖＋組件表  
+- [ ] §1.2 建立時序（含地址／回覆欄位）  
+- [ ] §1.3 使用三線＋動態 headless  
+- [ ] §2 P0＋緩解階梯  
+- [ ] §3 兩個 P1＋R／M／S  
+- [ ] §5 close 矩陣（若問 shutdown）  
+- [ ] §6 PR1／PR2＋PR2 目標結構／時序  
+- [ ] audit §0／§1（若問 API／廢碼）  


### PR DESCRIPTION
# Qwen-Image 每晚 Nightly CI 用例盤點與減負建議

> 範圍：**Qwen-Image / Qwen-Image-2512（T2I）**。不含 Qwen-Image-Edit、Qwen-Image-Edit-2511、Qwen-Image-Layered。  
> 真實對照：Buildkite [vllm-omni #13862](https://buildkite.com/vllm/vllm-omni/builds/13862/canvas)（`Scheduled nightly build`，commit `10906e3a`，2026-08-20）。  
> 用例數以 **pytest nodeid** 為準；Perf 另列內部 sweep 點。

---

## 結論（先講數字）

在 **#13862 當日的 Nightly YAML**（`test-nightly.yml` @ `10906e3a`）裡，Qwen-Image 家族每晚大約：

| 計數方式 | 數量 | 說明 |
|---|---:|---|
| **pytest 用例（建議用這個）** | **32** | Function 18 + Doc 2 + Accuracy 3 + Perf 8 + Distributed 1 |
| Perf 內部實際跑的 benchmark 點 | 11 | 其中 high-concurrency 1 個 pytest 內掃 4 檔並發 |
| 會 **冷啟動完整權重 server** 的次數（數量級） | ~30+ | 幾乎每個 feature / 每個 accuracy arm 都是一次 load |
| Nightly X2I **job 數**（含 Hunyuan） | **7 / 7** | 與 #13862 List「Diffusion X2I(&A&T) Model Test 7/7」對齊 |
| 其中 **Qwen-Image 相關 job** | **6** | 扣掉 HunyuanImage3 Accuracy |

另外：同一個 scheduled build **也會 Upload Ready + Merge**。Ready 再跑 1 條 core smoke（#13862 Table：`Diffusion · Qwen Image Test`，約 **3m 30s**）。這條 **不是** Nightly YAML 裡的 expansion grid，但會佔同一晚 GPU。

```mermaid
pie title Nightly pytest 用例分佈（Qwen-Image T2I，n=32）
    "Function H100 單卡" : 8
    "Function H100 多卡" : 10
    "Doc examples" : 2
    "Accuracy" : 3
    "Perf" : 8
    "Distributed VAE PP" : 1
```

```mermaid
pie title 建議重要性（n=32）
    "高：必須每晚留" : 3
    "中：可隔日／縮頻" : 8
    "低：可移出 Nightly" : 21
```

**減負最有證據的方向：** Function grid 把 **Qwen-Image-2512 的 9 條 feature 全複製一遍**（18 裡的 9 條），加上 Doc 50-step、Perf high-concurrency、以及「同一條 VAE PP 路徑測三次」。這幾類對 **正確性門檻** 貢獻低、對 **H100 佔用** 貢獻高。

---

## 32 條各自做甚麼（按類 + 高／中／低）

只數 pytest：**32 = 18 Function + 2 Doc + 3 Accuracy + 8 Perf + 1 Distributed**。

類別小計：

| 類 | 條數 | 實際在做咩 | 高 | 中 | 低 |
|---|---:|---|---:|---:|---:|
| Function | 18 | 起完整權重 serving，512²、**2 steps**，確認該加速／並行 flag 能出圖 | 1 | 3 | 14 |
| Doc | 2 | 跑 README 嘅 curl／Python client（1024²、**50 steps**） | 0 | 0 | 2 |
| Accuracy | 3 | 同 HuggingFace Diffusers 對圖（SSIM／像素差） | 1 | 1 | 1 |
| Perf | 8 | 量 QPS／延遲，對 JSON 裡嘅 H100 baseline | 1 | 3 | 4 |
| Distributed | 1 | TP=2 下 VAE patch-parallel=1 vs 2，比像素差 | 0 | 1 | 0 |
| **合計** | **32** | | **3** | **8** | **21** |

### Function（18）— `test_qwen_image_expansion.py`

同一套 9 個 server 旗標，對 `Qwen/Qwen-Image` 同 `Qwen/Qwen-Image-2512` 各跑一次。

| # | pytest | 實際做咩 | 重要性 |
|---:|---|---|---|
| 1 | `test_qwen_image[cpu_offload]` | `--enable-cpu-offload` 出一張 512² | 低 |
| 2 | `test_qwen_image[step_execution]` | `--step-execution` 出一張 512² | 低 |
| 3 | `test_qwen_image[cache_tea_cache]` | TeaCache 出一張 512² | 中 |
| 4 | `test_qwen_image[layerwise_offload]` | Cache-DiT + layerwise offload 出一張 512² | 中 |
| 5 | `test_qwen_image[ulysses_2]` | 2 卡 Ulysses SP 出一張 512² | **高** |
| 6 | `test_qwen_image[ring_2]` | 2 卡 Ring attention 出一張 512² | 低 |
| 7 | `test_qwen_image[cfg_parallel_2]` | 2 卡 CFG-parallel 出一張 512² | 中 |
| 8 | `test_qwen_image[vae_patch_parallel_2]` | TP=2 + VAE PP=2 + FP8 出一張 512² | 中 |
| 9 | `test_qwen_image[parallel_hsdp]` | 2 卡 HSDP 出一張 512² | 低 |
| 10–18 | `test_qwen_image_2512[同上 9 個 id]` | **同一套旗標**再對 2512 各出一張 | 低（9 條） |

### Doc（2）— `tests/examples/online_serving/test_text_to_image.py`

| # | pytest | 實際做咩 | 重要性 |
|---:|---|---|---|
| 19 | `test_api_calls_001` | curl 打 chat completions，1024²、50 steps | 低 |
| 20 | `test_api_calls_002` | Python `openai_chat_client.py` 再打一次（共用同一 server） | 低 |

### Accuracy（3）

| # | pytest | 實際做咩 | 重要性 |
|---:|---|---|---|
| 21 | `test_qwen_image_matches_diffusers` | Omni vs Diffusers，512²、20 steps，SSIM≥0.94 / PSNR≥27 | **高** |
| 22 | `test_qwen_image_2512_matches_diffusers_pixelwise` | Omni vs Diffusers，1664×928、50 steps，mean/p99 像素差 | 中 |
| 23 | `test_diffusers_backend_t2i_matches_diffusers` | 再開一次 Omni（diffusers backend）對 Diffusers + latency | 低 |

### Perf（8）— `test_qwen_image_vllm_omni.json`

| # | pytest | 實際做咩 | 重要性 |
|---:|---|---|---|
| 24 | `…single_device-512x512_steps20` | 單卡 baseline，10 張，對 QPS/延遲 | **高** |
| 25 | `…single_device-1536x1536_steps35` | 單卡大圖 10 張 | 中 |
| 26 | `…step_execution-512x512_steps20` | 單卡 + `--step-execution`，512² 10 張 | 低 |
| 27 | `…step_execution-1536x1536_steps35` | 同上，1536² | 低 |
| 28 | `…ulysses2_cfg2_vae_patch4-1536x1536_steps35` | 4 卡 Ulysses+CFG+VAE PP，大圖 10 張 | 中 |
| 29 | `…ulysses2_cfg2_cache_dit-512x512_steps20` | 4 卡 + Cache-DiT，512² 10 張 | 中 |
| 30 | `…ulysses2_cfg2_cache_dit-1536x1536_steps35` | 同上，1536² | 低 |
| 31 | `…high_concurrency-512x512_steps20_high_concurrency` | 單卡 step-execution，並發 1/2/4/8 掃一輪 | 低 |

### Distributed（1）

| # | pytest | 實際做咩 | 重要性 |
|---:|---|---|---|
| 32 | `test_vae_patch_parallel_tp2[qwen_image]` | 同一 seed 跑 VAE PP=1 同 PP=2，比 mean/p99 像素差（1152²、2 steps） | 中 |

---


## 證據來源

| 來源 | 用嚟證明咩 |
|---|---|
| [#13862 Canvas / List](https://buildkite.com/vllm/vllm-omni/builds/13862/canvas) | 真實 nightly：X2I 組 **7/7 steps**；總 build 約 1h 59m（jobs 並行，唔等於 GPU 分鐘加總） |
| [GitHub `test-nightly.yml` @ 10906e3a](https://github.com/vllm-project/vllm-omni/blob/10906e3a6db947290581b88dc4b6f35bd2a26b41/.buildkite/cuda/test-nightly.yml) | 當日實際 pytest 指令（**比本機 `HEAD` 少** edit/layered/bagel 等後加 job） |
| 同 commit 的 `test_qwen_image_expansion.py` / `test_qwen_image.py` / `test_qwen_image_vllm_omni.json` | 用例展開（parametrize / benchmark_params） |
| 本機 `/home/wtk/vllm-omni/.buildkite/cuda/test-nightly.yml` | **之後** 的 YAML：Accuracy 改咗 `test_qwen_image*.py` glob（會把 edit/layered 一齊 sweep）；Function 單卡 job 亦夾咗 edit/layered expansion。**減負提案應以 #13862 為基線，並注意 HEAD 已更肥。** |

#13862 JSON（公開）：`jobs_count=65`，`steps_passed=60`，`steps_failed=3`，`source=schedule`。Canvas 預設 filter「State is Failed」會睇唔到 X2I；要清 filter。Table 係 virtualized，X2I 行要 search「X2I」先穩。

---

## Nightly 實際跑邊啲 job（#13862 YAML）

X2I 組 7 步（與 List **7/7** 一致）：

1. `Diffusion X2I · Function Test with H100 · Single-GPU` — **只** `test_qwen_image_expansion.py` + `not distributed_cuda`
2. `Diffusion X2I · Function Test with H100 · Multi-GPU Qwen-Image` — 同上檔 + `distributed_cuda`
3. `Diffusion X2I · Function Test with L4` — `tests/e2e/` 闊 sweep；Qwen-Image **full 權重** 用例 **0**（見下）
4. `Diffusion X2I · Doc Test` — `tests/examples/*/test_text_to_image.py`
5. `Diffusion X2I · Accuracy Test` — **只** `tests/e2e/accuracy/test_qwen_image.py` + backend similarity `-k 2i_matches_diffusers`
6. `HunyuanImage3-DIT · Accuracy Test` — **唔計**
7. `Diffusion X2I · Perf Test · Qwen-Image` — `test_qwen_image_vllm_omni.json`，`h100_4`，timeout 180m

其他 Nightly 組裡、仍用 **Qwen/Qwen-Image 完整權重** 的：

- `Diffusion · Distributed Test with H100`：`test_vae_decode_parallelism.py::test_vae_patch_parallel_tp2[qwen_image]`（同 job 仲有 Wan）

**唔計入 32**（隨機權重 / 非 nightly marker / skip）：

- Ready `test_qwen_image.py -m core_model`（#13862 有跑，~3.5 min）
- Merge `advanced_model` smoke
- `riverclouds/qwen_image_random`（SP / offloader / FP8 L4）
- `test_quantization_quality[fp8_qwen_image]`：**顯式 skip**
- Tiny model nightly：`QwenImagePipeline` 無 `extra_test_groups` → 無 `full_model` 多卡 tiny case
- AutoRound W4A16：L4 但 **冇** `full_model` → 闊 sweep 揀唔中

```mermaid
flowchart LR
  subgraph scheduled["#13862 Scheduled nightly"]
    R[Upload Ready]
    M[Upload Merge]
    N[Upload Nightly]
  end
  R --> Rs["Ready: Qwen Image Test\n1 pytest / ~3.5min"]
  M --> Ms["Merge: advanced smoke\n2 pytest"]
  N --> F1["Function 1GPU x8"]
  N --> F2["Function 2GPU x10"]
  N --> D["Doc x2"]
  N --> A["Accuracy x3"]
  N --> P["Perf x8"]
  N --> V["VAE PP x1"]
```

---

## 逐條用例：重要性（高 / 中 / 低）

評分準則（寫明，避免口號）：

- **高**：唯一（或接近唯一）的 **對 Diffusers 數值門檻**、或 Nightly email **吞吐/延遲 baseline**；Ready/Merge **冇** 覆蓋。
- **中**：有獨立產品面（2512、Cache-DiT、大分辨率），但可用更短設定或週頻。
- **低**：同路徑已有另一條測過；2-step smoke 複製成 9×2 矩陣；examples 再打一次 API。

### A. Function（18）— `test_qwen_image_expansion.py`

每個 case：獨立 `OmniServer` + 512² + **2 steps**。貴在 **18 次完整權重 load**，唔在 denoising。

| pytest id | GPU | 重要性 | 證據 |
|---|---|---|---|
| `test_qwen_image[cpu_offload]` | 1×H100 | **低** | 同檔已有 `layerwise_offload`（cache_dit + layerwise）。CPU offload 係另一開關，但 Ready 已有 serving smoke；2-step 幾乎測唔到 offload 正確性。 |
| `test_qwen_image[step_execution]` | 1×H100 | **低** | Perf 已有 `single_device_step_execution`（20/35 steps、有 QPS 門檻）。Function 2-step 重疊。 |
| `test_qwen_image[cache_tea_cache]` | 1×H100 | **中** | 唯一 TeaCache **serving smoke**（Perf 用 cache_dit，唔用 tea）。可留 **一條**。 |
| `test_qwen_image[layerwise_offload]` | 1×H100 | **中** | Cache-DiT + layerwise 組合；同 tea 可二揀一留 nightly。 |
| `test_qwen_image[ulysses_2]` | 2×H100 | **高** | 多卡 SP 主路徑；Ready/Merge 單卡。建議 **留 Qwen-Image 一條**。 |
| `test_qwen_image[ring_2]` | 2×H100 | **低** | 同係 SP，與 Ulysses 平行；2-step 對 ring 數值幾乎無 gate。 |
| `test_qwen_image[cfg_parallel_2]` | 2×H100 | **中** | CFG-parallel 獨立維度；Perf 4 卡 combo 已含 `cfg-parallel-size=2`。Nightly 可留 function **或** perf，唔使兩套都滿。 |
| `test_qwen_image[vae_patch_parallel_2]` | 2×H100 | **中** | 同路徑仲有 Distributed `vae_patch_parallel_tp2[qwen_image]`（有 mean/p99 數值）+ Perf `vae-patch-parallel-size=4`。Function 2-step **最弱**。 |
| `test_qwen_image[parallel_hsdp]` | 2×H100 | **低** | HSDP 無對應 accuracy/perf gate；tiny/unit 層已有 HSDP 計劃測試。 |
| `test_qwen_image_2512[*]` ×9 | 同上 | **低**（整組） | **同一套 `_get_diffusion_feature_cases`** 複製到 2512。Pipeline 與 Qwen-Image 同家族；2512 差異應由 **Accuracy pixelwise** 守，唔使 nightly 再 9 次 load。 |

```mermaid
bar title Function：18 次 server 冷啟動（2 models × 9 features）
    cpu_offload : 2
    step_execution : 2
    tea_cache : 2
    layerwise : 2
    ulysses_2 : 2
    ring_2 : 2
    cfg_parallel_2 : 2
    vae_pp_2 : 2
    hsdp : 2
```

（每條 bar = Qwen-Image + 2512 各 1。）

### B. Doc（2）— `tests/examples/online_serving/test_text_to_image.py`

| pytest | 重要性 | 證據 |
|---|---|---|
| `test_api_calls_001`（curl，1024²，**50 steps**） | **低** | 同 Function 一樣打 `/v1/chat/completions`；但 **50 steps × 1024**，比 function 2-step 貴一個數量級。`h100_2` 配額對單卡 examples 過大。 |
| `test_api_calls_002`（Python client，同 server） | **低** | 同 module fixture，边际成本較 001 細，但仍係 examples 回歸，適合 **PR 改 examples 時** 而唔係每晚。 |
| `test_api_calls_003` | 唔跑 | `@pytest.mark.skip` Gradio |

### C. Accuracy（3）

| pytest | 設定 | 重要性 | 證據 |
|---|---|---|---|
| `test_qwen_image_matches_diffusers` | 512²，20 steps，SSIM≥0.94 / PSNR≥27 | **高** | 檔內註解寫明 H100 nightly 穩定落在 ~0.958 / 27.8（#5734 / #5963）。**唯一** 對官方 Diffusers 的圖像質量門檻。 |
| `test_qwen_image_2512_matches_diffusers_pixelwise` | **1664×928，50 steps**，mean/p99 abs | **中** | 守 2512 權重；極貴。可改少 steps／較細 size 做 nightly，完整 50-step 放 weekly。 |
| `test_diffusers_backend_t2i_matches_diffusers[Qwen/Qwen-Image]` | 再對一次 Diffusers + latency | **低～中** | 同模型再 load omni+diffusers；正確性與上一條高度重疊。Latency 門檻係 warmed median，**唔係** DFX perf JSON。可 weekly。 |

### D. Perf（8 pytest / 11 跑點）— `test_qwen_image_vllm_omni.json`

Job **整份 `h100_4`**：單卡 baseline 都佔 4 卡，呢個係 **配額浪費**，同用例多少無關。

| pytest / 跑點 | 重要性 | 證據 |
|---|---|---|
| `single_device` 512×512 steps20，10 prompts | **高** | 有 H100 baseline QPS 0.4153 / latency 2.41s；Nightly email 主曲線。 |
| `single_device` 1536×1536 steps35 | **中** | 容量/記憶體；QPS 0.0423，單點就 ~4 min 量級 ×10 prompts。可隔日。 |
| `step_execution` 512 同 1536 | **低** | 與 `single_device` 幾乎同一 baseline（QPS 0.4175 vs 0.4153）。證明 step path 無回歸即可 **只留 512** 或週頻。 |
| `ulysses2_cfg2_vae_patch4` 1536 | **中** | 唯一 4 卡並行吞吐門檻（QPS 0.1214 vs 單卡 0.0423）。值得留，但 **唔使** 再加 function VAE smoke。 |
| `ulysses2_cfg2_cache_dit` 512 + 1536 | **中** | Cache-DiT 加速宣稱（512 QPS 0.559 vs 0.415）。512 夠；1536 可 weekly。 |
| `high_concurrency` 512，concurrency 1/2/4/8（**4 跑點**，prompts 20–160） | **低** | 服務容量曲線；最食時間。移 **weekly** 足夠。JSON 自己都寫係 sweep。 |

```mermaid
flowchart TB
  subgraph keepH["高：每晚"]
    A1[Accuracy Qwen-Image SSIM]
    P1[Perf single 512x20]
    F1[Function ulysses_2 × Qwen-Image]
  end
  subgraph keepM["中：可縮"]
    A2[Accuracy 2512 pixelwise]
    P2[Perf 1536 或 Cache-DiT 512]
    F2[tea_cache 或 layerwise ×1]
  end
  subgraph drop["低：建議移出 Nightly"]
    G2512[Function 2512 ×9]
    Ring[ring / hsdp / cpu_offload / step_fn]
    Doc[Doc 50-step ×2]
    Be[backend similarity]
    HC[Perf high-concurrency ×4]
    SE[Perf step_execution 1536]
  end
```

### E. Distributed VAE（1）

| pytest | 重要性 | 證據 |
|---|---|---|
| `test_vae_patch_parallel_tp2[qwen_image]` | **中** | **有** mean/p99 像素門檻（比 function 2-step 強）。但 Function + Perf 已覆蓋 VAE PP。三選一：建議 **留呢條、砍 function `vae_patch_parallel_2`**。H100×4 + 兩次 generate（pp=1 vs 2），1152²。 |

---

## 估 GPU 負載（相對，非 wall-clock 謊報）

#13862 總時長 ~2h 係 **關鍵路徑**，Qwen jobs **並行**。減負要睇 **GPU-分鐘**（卡數 × job 時長），唔係睇 build 綠勾時間。

粗相對成本（同「一次 512² 2-step serving smoke」比）：

```mermaid
xychart-beta
    title "相對成本（示意，以 Function 單卡 2-step = 1）"
    x-axis ["Fn 2-step", "Doc 50-step", "Acc 20-step", "Acc 2512 50-step", "Perf 512x10", "Perf 1536x10", "HC sweep"]
    y-axis "相對單位" 0 --> 40
    bar [1, 15, 12, 35, 10, 25, 30]
```

依據：Doc/Accuracy/Perf 用 **真實 steps×分辨率×prompts**；Function 幾乎全係 **load 時間**。18 條 Function 加埋，load 次數往往超過 1 條 Acc 20-step。

**最肥、又最冇獨立門檻：**

1. Function **2512 × 9**（+ Qwen-Image 可砍嘅 ring/hsdp/cpu/step）→ 一次少 ~9–14 次 20B load  
2. Perf **high-concurrency** + 重複嘅 **step_execution 1536**  
3. Doc **50-step 1024**  
4. Perf job **鎖 4×H100** 跑單卡 case（改 shard：1 卡 job / 4 卡 job）

---

## 建議 Nightly 保留集（可執行）

目標：正確性唔跌、GPU 明顯降。

**每晚留（高 + 少量中）≈ 8 pytest：**

1. Accuracy：`test_qwen_image_matches_diffusers`  
2. Accuracy：`test_qwen_image_2512_matches_diffusers_pixelwise`（可改細；暫保留）  
3. Function：`test_qwen_image[cache_tea_cache]`  
4. Function：`test_qwen_image[ulysses_2]`  
5. Function：`test_qwen_image[cfg_parallel_2]`（若砍 Perf 4 卡 combo 則必須留）  
6. Perf：`single_device` 512×20  
7. Perf：`ulysses2_cfg2_cache_dit` 512 **或** `ulysses2_cfg2_vae_patch4` 1536（二揀一）  
8. Distributed：`test_vae_patch_parallel_tp2[qwen_image]` **或** Function `vae_patch_parallel_2`（二揀一）

**移 weekly / PR-label `diffusion-x2iat-test`：**

- Function 2512 全矩陣、ring、hsdp、cpu_offload、step_execution  
- Doc examples  
- backend similarity  
- Perf high-concurrency、step_execution 雙分辨率、Cache-DiT 1536  

粗算：18+2+3+8+1=32 → **~8**，Function 冷啟動 18→3。Ready 已有 `test_batch_001`，唔使 nightly 再加 default serving。

**唔好做嘅「假減負」：** 只減 `--num-warmups` 或把 2-step 改 1-step——load 仍在。要減就係 **少開 server**。

---

## 本機 HEAD 相對 #13862 的漂移（避免減錯檔）

`/home/wtk/vllm-omni/.buildkite/cuda/test-nightly.yml` 而家：

- Function 單卡 pytest **一次列** expansion + **edit** + **layered** + bagel/krea…  
- Accuracy：`test_qwen_image*.py` glob → 會跑 **edit / layered accuracy**  
- 獨立 Perf jobs：edit、edit-2511、layered  

減 Qwen-Image T2I 時 **唔好** 誤刪 edit/layered job；要用 **檔名 / `-k`** 收窄，而唔係刪成個 X2I group。

---

## 檔案位置索引

| 路徑 | 角色 |
|---|---|
| `/home/wtk/vllm-omni/docs/ci/QWEN_IMAGE_NIGHTLY_CI_LOAD.md` | **本報告** |
| `/home/wtk/vllm-omni/.buildkite/cuda/test-nightly.yml` | 本機 Nightly 定義（已比 10906e3a 更肥） |
| `https://github.com/vllm-project/vllm-omni/blob/10906e3a6db947290581b88dc4b6f35bd2a26b41/.buildkite/cuda/test-nightly.yml` | #13862 真實 Nightly |
| `/home/wtk/vllm-omni/.buildkite/cuda/test-ready.yml` | Ready：`Diffusion · Qwen Image Test` → `tests/e2e/online_serving/test_qwen_image.py` |
| `/home/wtk/vllm-omni/.buildkite/cuda/test-merge.yml` | Merge：`advanced_model` 同檔 |
| `/home/wtk/vllm-omni/.buildkite/cuda/test-weekly.yml` | Weekly（可靠性等；Qwen-Image T2I expansion **唔喺** 呢度） |
| `/home/wtk/vllm-omni/tests/e2e/online_serving/test_qwen_image_expansion.py` | Function 9×2 |
| `/home/wtk/vllm-omni/tests/e2e/online_serving/test_qwen_image.py` | Ready/Merge smoke（`test_text_to_image_001` / `test_batch_001`） |
| `/home/wtk/vllm-omni/tests/e2e/accuracy/test_qwen_image.py` | Diffusers SSIM + 2512 pixelwise |
| `/home/wtk/vllm-omni/tests/e2e/accuracy/test_diffusers_backend_similarity.py` | backend T2I（`-k 2i_matches_diffusers`） |
| `/home/wtk/vllm-omni/tests/examples/online_serving/test_text_to_image.py` | Doc curl/client |
| `/home/wtk/vllm-omni/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json` | Perf 配置 |
| `/home/wtk/vllm-omni/tests/dfx/perf/scripts/run_diffusion_benchmark.py` | Perf pytest 入口 |
| `/home/wtk/vllm-omni/tests/diffusion/distributed/test_vae_decode_parallelism.py` | VAE PP 數值 |
| `/home/wtk/vllm-omni/tests/diffusion/quantization/test_quantization_quality.py` | `fp8_qwen_image` **skip** |
| `/home/wtk/vllm-omni/tests/diffusion/quantization/test_quantization_fp8.py` | L4 random FP8 |
| `/home/wtk/vllm-omni/tests/e2e/offline_inference/test_qwen_image_autoround_w4a16_expansion.py` | L4，無 `full_model` → nightly 闊 sweep 唔跑 |
| `/home/wtk/vllm-omni/tests/model_tests/diffusion/model_settings.py` | Tiny `QwenImagePipeline` |
| `/home/wtk/vllm-omni/tests/dfx/stability/tests/test_qwen_image.json` | 穩定性 86400s（**唔喺** nightly YAML） |
| `https://buildkite.com/vllm/vllm-omni/builds/13862` | List / Table / Canvas |
| `https://buildkite.com/vllm/vllm-omni/builds/13862.json` | 公開統計（jobs 列表要登入 API） |

以下檔案屬 **Edit / Layered**，本報告刻意排除，但 HEAD nightly 可能仍會跑：

| 路徑 |
|---|
| `/home/wtk/vllm-omni/tests/e2e/online_serving/test_qwen_image_edit_expansion.py` |
| `/home/wtk/vllm-omni/tests/e2e/online_serving/test_qwen_image_layered_expansion.py` |
| `/home/wtk/vllm-omni/tests/e2e/accuracy/test_qwen_image_edit.py` |
| `/home/wtk/vllm-omni/tests/e2e/accuracy/test_qwen_image_layered.py` |
| `/home/wtk/vllm-omni/tests/dfx/perf/tests/test_qwen_image_edit_vllm_omni.json` |
| `/home/wtk/vllm-omni/tests/dfx/perf/tests/test_qwen_image_edit_2511_vllm_omni.json` |
| `/home/wtk/vllm-omni/tests/dfx/perf/tests/test_qwen_image_layered_vllm_omni.json` |
