### PR TITLE
[Bugfix][Attention] Gate SAGE_ATTN_3 on the architectures it builds for

### DIFF
--- a/docs/user_guide/diffusion/attention_backends/sage.md
+++ b/docs/user_guide/diffusion/attention_backends/sage.md
@@ -54,8 +54,22 @@ python -c "import sageattn3; print(sageattn3.__file__)"
 vllm-omni serve <model> --diffusion-attention-backend SAGE_ATTN_3
 ```
 
-`SAGE_ATTN_3` requires CUDA, an importable `sageattn3`, and a Blackwell-class
-GPU. Its kernel assumes the query-head count equals the key/value-head count.
+`SAGE_ATTN_3` requires CUDA, an importable `sageattn3`, and one of the
+architectures the kernel is built for. `sageattention3_blackwell/setup.py`
+emits one gencode per supported compute capability and rejects anything else:
+
+| Compute capability | Gencode | Example GPUs |
+| --- | --- | --- |
+| 10.0 | `sm_100a` | B200, GB200 |
+| 12.0 | `sm_120a` | RTX PRO 6000, RTX 50-series |
+| 12.1 | `sm_121a` | Consumer Blackwell refresh |
+
+Not every Blackwell GPU qualifies. `sm_103` (B300 / GB300) is absent by
+design: the kernel takes the SM120 warp-level `mma.sync` path, while SM103
+requires the tcgen05 implementation. Selecting `SAGE_ATTN_3` on an
+unsupported GPU logs a warning and falls back to `TORCH_SDPA`.
+
+Its kernel also assumes the query-head count equals the key/value-head count.
 GQA and MQA diffusion calls therefore fall back to PyTorch SDPA for
 correctness.
 

--- a/tests/diffusion/attention/test_sage_attn3.py
+++ b/tests/diffusion/attention/test_sage_attn3.py
@@ -115,19 +115,80 @@ def test_cuda_platform_selects_sage_attn3_alias(monkeypatch: pytest.MonkeyPatch)
 
 
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="sage_attn3 tests require CUDA platform")
-def test_cuda_platform_falls_back_when_sage_attn3_gpu_is_unsupported(monkeypatch: pytest.MonkeyPatch):
+@pytest.mark.parametrize(
+    "capability",
+    [
+        pytest.param((12, 0), id="sm_120-rtx-pro-6000-and-rtx-50-series"),
+        pytest.param((12, 1), id="sm_121-consumer-blackwell-refresh"),
+    ],
+)
+def test_cuda_platform_selects_sage_attn3_on_supported_blackwell(
+    monkeypatch: pytest.MonkeyPatch, capability: tuple[int, int]
+):
+    """Every architecture sageattention3_blackwell builds for must route to the backend."""
     from vllm.platforms.interface import DeviceCapability
 
     from vllm_omni.diffusion.attention.backends.registry import DiffusionAttentionBackendEnum
     from vllm_omni.diffusion.envs import PACKAGES_CHECKER
+    from vllm_omni.platforms.cuda import platform as cuda_platform_module
     from vllm_omni.platforms.cuda.platform import CudaOmniPlatform
+
+    original_import_module = importlib.import_module
 
     monkeypatch.setattr(
         CudaOmniPlatform,
         "get_device_capability",
-        classmethod(lambda cls, device_id=0: DeviceCapability(9, 0)),
+        classmethod(lambda cls, device_id=0: DeviceCapability(*capability)),
     )
     monkeypatch.setattr(PACKAGES_CHECKER, "get_packages_info", lambda: {"has_flash_attn": False})
+    monkeypatch.setattr(
+        cuda_platform_module.importlib,
+        "import_module",
+        lambda module_name: object() if module_name == "sageattn3" else original_import_module(module_name),
+    )
+
+    backend_path = CudaOmniPlatform.get_diffusion_attn_backend_cls("SAGE_ATTN_3", head_size=64)
+
+    assert backend_path == DiffusionAttentionBackendEnum.SAGE_ATTN_3.get_path()
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="sage_attn3 tests require CUDA platform")
+@pytest.mark.parametrize(
+    "capability",
+    [
+        pytest.param((9, 0), id="sm_90-hopper"),
+        pytest.param((8, 9), id="sm_89-ada"),
+        # sm_103 is the regression this gate protects: ``major >= 10`` used to
+        # admit B300 / GB300, where the failure only surfaced inside the kernel.
+        pytest.param((10, 3), id="sm_103-b300-not-a-build-target"),
+        pytest.param((11, 0), id="sm_110-unknown-future-variant"),
+    ],
+)
+def test_cuda_platform_falls_back_when_sage_attn3_gpu_is_unsupported(
+    monkeypatch: pytest.MonkeyPatch, capability: tuple[int, int]
+):
+    from vllm.platforms.interface import DeviceCapability
+
+    from vllm_omni.diffusion.attention.backends.registry import DiffusionAttentionBackendEnum
+    from vllm_omni.diffusion.envs import PACKAGES_CHECKER
+    from vllm_omni.platforms.cuda import platform as cuda_platform_module
+    from vllm_omni.platforms.cuda.platform import CudaOmniPlatform
+
+    original_import_module = importlib.import_module
+
+    monkeypatch.setattr(
+        CudaOmniPlatform,
+        "get_device_capability",
+        classmethod(lambda cls, device_id=0: DeviceCapability(*capability)),
+    )
+    monkeypatch.setattr(PACKAGES_CHECKER, "get_packages_info", lambda: {"has_flash_attn": False})
+    # Importable sageattn3 so the assertion isolates the architecture gate: an
+    # unsupported GPU must fall back even when the package is present.
+    monkeypatch.setattr(
+        cuda_platform_module.importlib,
+        "import_module",
+        lambda module_name: object() if module_name == "sageattn3" else original_import_module(module_name),
+    )
 
     backend_path = CudaOmniPlatform.get_diffusion_attn_backend_cls("SAGE_ATTN_3", head_size=64)
 

--- a/vllm_omni/platforms/cuda/platform.py
+++ b/vllm_omni/platforms/cuda/platform.py
@@ -16,6 +16,17 @@ from vllm_omni.platforms.interface import OmniPlatform, OmniPlatformEnum
 
 logger = init_logger(__name__)
 
+# Compute capabilities that SageAttention3 actually builds kernels for.
+# ``sageattention3_blackwell/setup.py`` matches (major, minor) exactly and
+# raises "Unsupported GPU" otherwise, emitting one gencode per entry:
+#   (10, 0) -> sm_100a   B200 / GB200
+#   (12, 0) -> sm_120a   RTX PRO 6000, RTX 50-series
+#   (12, 1) -> sm_121a   consumer Blackwell refresh
+# sm_103 (B300 / GB300) is deliberately absent: the kernel takes the SM120
+# warp-level mma.sync path, while SM103 requires the tcgen05 implementation,
+# so an sm_103a build reaches CUTLASS invalid-control-path guards at runtime.
+_SAGE_ATTN3_SUPPORTED_SMS = frozenset({(10, 0), (12, 0), (12, 1)})
+
 
 class CudaOmniPlatform(OmniPlatform, CudaPlatformBase):
     """CUDA/GPU implementation of OmniPlatform (default).
@@ -171,11 +182,22 @@ class CudaOmniPlatform(OmniPlatform, CudaPlatformBase):
                 logger.debug("Defaulting to diffusion attention backend SDPA")
                 return DiffusionAttentionBackendEnum.TORCH_SDPA.get_path()
             if backend_upper == "SAGE_ATTN_3":
-                sage_attn3_supported = compute_capability is not None and compute_capability.major >= 10
+                # Match the kernel's own build targets exactly. A ``major >= 10``
+                # test also admits sm_103, where the import succeeds and the
+                # failure only surfaces inside the kernel.
+                sage_attn3_supported = (
+                    compute_capability is not None
+                    and (compute_capability.major, compute_capability.minor) in _SAGE_ATTN3_SUPPORTED_SMS
+                )
                 if not sage_attn3_supported:
+                    supported_sms = ", ".join(
+                        f"sm_{major}{minor}" for major, minor in sorted(_SAGE_ATTN3_SUPPORTED_SMS)
+                    )
                     logger.warning(
-                        "SageAttention3 requires a Blackwell-class GPU with compute capability >= 10.0. "
-                        "Falling back to TORCH_SDPA backend."
+                        "SageAttention3 does not build kernels for %s; it supports %s only. "
+                        "Falling back to TORCH_SDPA backend.",
+                        sm_str or "an unknown GPU",
+                        supported_sms,
                     )
                     return DiffusionAttentionBackendEnum.TORCH_SDPA.get_path()
                 try:


### PR DESCRIPTION
## Purpose

The `SAGE_ATTN_3` selection guard admits any GPU with `compute_capability.major >= 10`, which is broader than the set of architectures the kernel is compiled for.

`sageattention3_blackwell/setup.py` matches `(major, minor)` exactly and raises `"Unsupported GPU"` otherwise, emitting one gencode per supported capability:

```text
(10, 0) -> -gencode arch=compute_100a,code=sm_100a     B200 / GB200
(12, 0) -> -gencode arch=compute_120a,code=sm_120a     RTX PRO 6000, RTX 50-series
(12, 1) -> -gencode arch=compute_121a,code=sm_121a     consumer Blackwell refresh
otherwise -> "Unsupported GPU"
```

`sm_103` (B300 / GB300) is not among them. Under the current guard it passes platform routing, the `sageattn3` import can succeed, and the failure only surfaces inside the kernel: a native `sm_103a` build reaches CUTLASS invalid-control-path guards because SM103 requires the tcgen05 implementation rather than the SM120 warp-level `mma.sync` path. `major >= 10` also admits hypothetical 11.x parts the kernel has never been built for.

This was reported by @mo-ke-ke while qualifying packed `SAGE_ATTN_3` on an 8x B300 node in #5700.

This PR gates on the exact `{(10,0), (12,0), (12,1)}` set instead, and names both the detected architecture and the supported list in the fallback warning, so an unsupported GPU degrades to `TORCH_SDPA` at selection time with an actionable message rather than failing later inside the kernel.

`TRTLLM_ATTN` immediately below already gates precisely on SM100/SM103 and raises a specific error, so this removes an inconsistency in the same function rather than introducing a new policy. It also moves one step toward the single internal CUDA architecture classification proposed in #5631, which notes that datacenter `sm_10x` and workstation/consumer `sm_12x` intentionally support different optimized providers.

Docs gain the per-capability support table, since "a Blackwell-class GPU" is not a sufficient description of the requirement.

## Test Plan

```bash
pytest tests/diffusion/attention/ -q
```

`tests/diffusion/attention/test_sage_attn3.py` is extended with two parametrized tests:

- supported architectures route to the backend: `(10, 0)` (pre-existing case), `(12, 0)`, `(12, 1)`;
- unsupported architectures fall back to `TORCH_SDPA`: `(9, 0)`, `(8, 9)`, `(10, 3)`, `(11, 0)`.

In the negative cases `sageattn3` is monkeypatched to be importable, so the assertion isolates the architecture gate from package availability. The pre-existing negative test used `(9, 0)` with the package absent, which conflated the two conditions and could not have caught this.

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** 73b623f2f7db092053c1c86fe796bed89eb3dc71

## Test Result

Target file:

```text
tests/diffusion/attention/test_sage_attn3.py
9 passed in 0.12s
```

Regression check — reverting only the gate to `major >= 10` and keeping the new tests:

```text
.......FF                                                        [100%]
FAILED test_cuda_platform_falls_back_when_sage_attn3_gpu_is_unsupported[sm_103-b300-not-a-build-target]
FAILED test_cuda_platform_falls_back_when_sage_attn3_gpu_is_unsupported[sm_110-unknown-future-variant]
2 failed, 7 passed
```

Exactly the two cases this change targets fail under the old guard; the other seven still pass. The assertion message is that `SageAttention3Backend` was returned where `SDPABackend` was expected.

Full attention directory:

```text
tests/diffusion/attention/
6 failed, 188 passed, 16 skipped in 33.95s
```

The 6 failures are pre-existing on this machine and unrelated to this change. On `73b623f2` without this patch, the same two files produce the same 6 failures:

```text
tests/diffusion/attention/test_kernels_hub.py tests/diffusion/attention/test_trtllm_attn.py
6 failed, 30 passed, 4 skipped in 1.86s
```

They are environment limitations: `test_kernels_hub_execution` needs the HuggingFace `kernels` package, and the five `test_trtllm_attn.py` cases need a datacenter Blackwell GPU with flashinfer trtllm-gen. The test host is `sm_120`.

No GPU-specific behavior is exercised by the new tests — `get_device_capability` is monkeypatched throughout, so they run anywhere the CUDA platform is selected.
