### PR TITLE
[Bugfix] Stabilize Qwen3-Omni audio quality checks

### DIFF
--- a/tests/e2e/online_serving/test_qwen3_omni_expansion.py
+++ b/tests/e2e/online_serving/test_qwen3_omni_expansion.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """
 E2E Online tests for Qwen3-Omni model.
 """
@@ -33,6 +33,16 @@ LONG_VIDEO_FRAMES = 3600
 LARGE_IMAGE_WIDTH = 1920
 LARGE_IMAGE_HEIGHT = 1080
 LONG_AUDIO_DURATION_SEC = 120
+
+# Qwen3-Omni's talker samples at temperature 0.9, so transcript and preset-voice
+# quality are distributions rather than deterministic per-request properties. Keep
+# these full-pipeline checks as catastrophic-regression gates: only sampled quality
+# mismatches consume the budget; serving, media, and keyword failures still fail fast.
+# The public H100 logs linked from issue #6090 bottom out at 34/40 successes for a
+# fully observed run. A five-success margin accounts for sampling noise while still
+# limiting tolerated quality failures to 11/40.
+SAMPLED_QUALITY_REQUESTS = 40
+SAMPLED_QUALITY_MIN_SUCCESSES = 29
 
 
 def get_batch_token_config(default_path):
@@ -248,7 +258,12 @@ def test_text_audio_to_text_audio_002(omni_server, openai_client) -> None:
         "key_words": {"audio": AUDIO_KEY},
     }
 
-    openai_client.send_omni_request(request_config, request_num=get_max_batch_size())
+    openai_client.send_omni_request(
+        request_config,
+        request_num=SAMPLED_QUALITY_REQUESTS,
+        min_successes=SAMPLED_QUALITY_MIN_SUCCESSES,
+        max_concurrency=get_max_batch_size(),
+    )
 
 
 @hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=2)
@@ -300,7 +315,12 @@ def test_large_image_to_text_audio_001(omni_server, openai_client) -> None:
         "key_words": {"image": IMAGE_KEY},
     }
 
-    openai_client.send_omni_request(request_config, request_num=get_max_batch_size())
+    openai_client.send_omni_request(
+        request_config,
+        request_num=SAMPLED_QUALITY_REQUESTS,
+        min_successes=SAMPLED_QUALITY_MIN_SUCCESSES,
+        max_concurrency=get_max_batch_size(),
+    )
 
 
 @hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=2)
@@ -499,7 +519,10 @@ def test_one_word_prompt_001(omni_server, openai_client) -> None:
     # on tighter cards, since each judge loads whisper on the same device as the talker and
     # code2wav stages.
     openai_client.send_omni_request(
-        request_config, request_num=40, min_successes=29, max_concurrency=get_max_batch_size()
+        request_config,
+        request_num=SAMPLED_QUALITY_REQUESTS,
+        min_successes=SAMPLED_QUALITY_MIN_SUCCESSES,
+        max_concurrency=get_max_batch_size(),
     )
 
 
@@ -550,17 +573,12 @@ def test_speaker_002(omni_server, openai_client) -> None:
         "key_words": {"text": ["beijing"]},
     }
 
-    # Retry only when assert_omni_response fails on preset voice gender (see tests/helpers/assertions.py).
-    _gender_assert_substr = "estimated gender"
-    _max_retries = 10
-    for attempt in range(_max_retries):
-        try:
-            openai_client.send_omni_request(request_config, request_num=get_max_batch_size())
-            break
-        except AssertionError as e:
-            if _gender_assert_substr not in str(e) or attempt == _max_retries - 1:
-                raise
-            print(f"Gender assertion failed, retrying {attempt + 2}/{_max_retries}: {e!r}")
+    openai_client.send_omni_request(
+        request_config,
+        request_num=SAMPLED_QUALITY_REQUESTS,
+        min_successes=SAMPLED_QUALITY_MIN_SUCCESSES,
+        max_concurrency=get_max_batch_size(),
+    )
 
 
 @hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=2)


### PR DESCRIPTION
## Purpose

### Problem

Fixes #6090.

The Qwen3-Omni nightly full-model tests intermittently fail with:

```text
AssertionError: The audio content is not same as the text
```

The affected cases are `test_text_audio_to_text_audio_002`, `test_large_image_to_text_audio_001`, and `test_speaker_002`. The failing case changes across retries, and the public H100 logs linked from #6090 show a worst fully observed run of 34 successful quality checks out of 40.

### Reproduction

The failure is stochastic. The targeted batch-token case can be exercised repeatedly with:

```bash
export HF_HOME=/workspace/models
for attempt in {1..8}; do
  pytest -vv -s \
    'tests/e2e/online_serving/test_qwen3_omni_expansion.py::test_large_image_to_text_audio_001[batch_token_64]' \
    --run-level=full_model || break
done
```

The original H100 nightly command is:

```bash
pytest -sv tests/e2e --run-level full_model \
  -m 'full_model and H100 and omni' \
  --ignore=tests/e2e/accuracy \
  --ignore=tests/e2e/online_serving/test_qwen3_omni_multi_replicas.py \
  --ignore=tests/e2e/online_serving/test_minicpmo_4_5_duplex_expansion.py
```

### Root cause

The Qwen3-Omni talker samples with `temperature: 0.9`, `top_k: 50`, and no fixed seed. Audio transcript and preset-speaker quality are therefore distributions, but these tests treated every individual request as deterministic: one sampled mismatch in a five-request batch failed the entire test. `test_speaker_002` additionally retried whole batches only for gender mismatches, which produced a variable and biased sample size while still failing immediately on the equivalent audio-text quality mismatch.

### Fix

- Run a fixed 40-request sample for the affected stochastic quality checks.
- Require at least 29 successes, leaving a five-success margin below the worst fully observed H100 run while limiting tolerated quality failures to 11/40.
- Reuse the existing success-rate helper so only audio-text or preset-gender quality mismatches consume the budget; serving, transport, missing-media, and keyword failures still fail immediately.
- Replace the speaker-specific whole-batch retry loop with the same fixed sample contract.
- Share the established request-count and minimum-success constants with the existing one-word quality gate.

## Test Plan

1. Run the success-rate helper unit tests.
2. Collect all eight affected default, async-chunk, and batch-token parameterizations.
3. Run pre-commit on the changed test module.
4. Run a real-weight Qwen3-Omni full-model test with `HF_HOME=/workspace/models` on two NVIDIA L20X GPUs.

**vLLM Version:** `0.27.0`

**vLLM-Omni Commit:** `96ff6348144bf138885d69ef82e4c40826a5c626` (rebased on `73b623f2f7db092053c1c86fe796bed89eb3dc71`)

Environment used for the full-model run: Python 3.12.13, PyTorch 2.13.0+cu129, CUDA 12.9, 2 x NVIDIA L20X, `HF_HOME=/workspace/models`.

## Test Result

Success-rate helper tests on the final rebased tree:

```text
$ pytest -q tests/helpers/tests/test_success_rate_helpers.py
Running 8 items in this shard
........                                                                 [100%]
--- Running Summary
8 passed, 14 warnings in 0.12s
```

Affected-node collection on the final rebased tree:

```text
$ pytest -q --collect-only \
    tests/e2e/online_serving/test_qwen3_omni_expansion.py::test_text_audio_to_text_audio_002 \
    tests/e2e/online_serving/test_qwen3_omni_expansion.py::test_large_image_to_text_audio_001 \
    tests/e2e/online_serving/test_qwen3_omni_expansion.py::test_speaker_002 \
    --run-level=full_model
--- Running Summary
8 tests collected in 16.48s
```

Local pre-commit result:

```text
ruff check............................................................Passed
ruff format...........................................................Passed
typos.................................................................Passed
Run mypy for Python 3.10..............................................Passed
Ensure test files have pytestmarks....................................Passed
Check SPDX headers....................................................Passed
Check forbidden imports...............................................Passed
Prevent new torch.cuda API calls......................................Passed
Suggestion............................................................Passed
```

Real-weight full-model result:

```text
$ HF_HOME=/workspace/models CUDA_VISIBLE_DEVICES=0,1 pytest -vv -s \
    'tests/e2e/online_serving/test_qwen3_omni_expansion.py::test_large_image_to_text_audio_001[batch_token_64]' \
    --run-level=full_model
--- Running Summary
================== 1 passed, 14 warnings in 547.85s (0:09:07) ==================
```

The real-weight log above was collected on the same patch before the final conflict-free rebase, when the branch base was `b3270dec`. A final-base rerun could not start because the shared host had only one free GPU; the other three GPUs were occupied by unrelated users. The unit, collection, pre-commit, and diff checks were rerun successfully after rebasing to `73b623f2`.
