### PR TITLE
[CI/Build] Add omni serving benchmark for unified understanding+generation models

### DIFF
--- a/benchmarks/omni/README.md
+++ b/benchmarks/omni/README.md
@@ -1,0 +1,579 @@
+# Omni Serving Benchmark (i2t / t2i / it2i)
+
+针对**理解生成合一模型**（如 HunyuanImage-3.0 AR+DiT 统一部署）的混合任务调度评估工具。
+在 `vllm serve ... --omni` 启动的统一服务端上，将 **i2t（理解）/ t2i（生成）/ it2i（编辑）** 三类任务按可配置配比混合发送，统计调度与性能指标，用于评估 DTPS 等混合调度优化的收益。
+
+入口脚本：
+
+- `benchmarks/omni/omni_benchmark_serving.py`
+
+与 `benchmarks/diffusion/` 的关系：`diffusion/` 只覆盖纯生成任务（t2i/t2v/i2i）；本工具在其 backend 实现之上复用并扩展，新增三类任务的混合配比、it2i `bot_task` 随机化、真随机发送顺序与按任务/按 bot_task 的分桶统计。
+
+---
+
+## 1. 设计目标与覆盖的能力
+
+| # | 能力 | 说明 |
+|---|------|------|
+| 1 | **任务配比** | `--num-i2t/--num-t2i/--num-it2i` 显式指定每类请求数量，例如 `14:2:4` 即 7:1:2 的近似配比。 |
+| 2 | **it2i bot_task 配比** | `--it2i-bot-task-weights "recaption=2,think=1,think_recaption=1"` 按权重分配思考强度。默认 `--it2i-bot-task-sampling proportional` 用最大余数法做**精确比例分配**（10 任务 2:2:1 → 4/4/2，可复现）；`--it2i-bot-task-sampling random` 改为带权重独立抽样（只在期望上接近比例）；缺省权重等比覆盖三类。 |
+| 3 | **真随机发送顺序** | 默认 `--shuffle` 对合并后的请求列表做 `random.shuffle`，三类任务真正交错发送，而不是按类型分块；`--no-shuffle` 则按类型分组发送。`--seed` 同时控制 shuffle 与 bot_task 采样，整个序列可复现。 |
+| 4 | **支撑评估的统计输出** | 终端表格 + JSON 文件，包含 overall / per-task / it2i-by-bot_task 三层分桶，覆盖吞吐、延迟分位、per-stage durations、peak memory。 |
+| 5 | **文本输出 TTFT/TPOT/ITL** | `--stream` 开启流式，按 vLLM `benchmark_serving` 的口径统计三类任务**文本输出**的首 token 延迟（TTFT）、每 token 延迟（TPOT）、token 间延迟（ITL）：i2t 的 AR 最终回答文本、it2i 的 AR "思考"(CoT) 文本。详见 §2.5。 |
+| 6 | **发送顺序 = dry-run 顺序（可证）** | 发送前一次性预读+预编码 i2t/it2i 输入图（base64 / 原始 bytes 缓存到 request 上），发送期 sender 跳过文件 I/O 与 base64；再在每个 `create_task` 后 `await asyncio.sleep(0)` 让 task[i] 抢到 FIFO 信号量并 `post` 之后才创建 task[i+1]。两者合起来保证**客户端实际发送顺序严格等于 dry-run / 列表顺序**，不再被各任务 prep 耗时（t2i < it2i < i2t）抢跑。运行时打印 `Client dispatch order matches dry-run list order: True` 并把 `dispatch_order` 写入 JSON 供与服务端接收日志对照。详见 §2.6。 |
+| 7 | **`--no-shuffle` 分组顺序** | `--no-shuffle-order "t2i,it2i,i2t"` 指定三类分组的拼接先后（须为 `i2t,t2i,it2i` 的全排列，默认 `i2t,t2i,it2i`）。仅在 `--no-shuffle` 下生效；`--shuffle` 时该参数被忽略（合并列表整体随机化）。 |
+| 8 | **生图分辨率配比** | `--gen-resolution-weights "512x512=2,1024x1024=2,1280x720=1"` 给 t2i/it2i 两类生图任务按比例分配生成分辨率（仅限 `512x512 / 1024x1024 / 1280x720`）。默认 `--gen-resolution-sampling proportional` 最大余数法精确分配（10 请求 2:2:1 → 4/4/2）；`random` 带权重独立抽样。i2t 不受影响；custom 数据集行若显式带 `width/height` 仍优先。 |
+| 9 | **输入随机化** | `--randomize-input` 让**输入侧**逐请求随机化，贴近真实请求分布多样性（由 `--seed` 控制，可复现）：① 三类任务的 prompt 从"短→长"池中各取一条，使 prompt 长度随机分布；② i2t/it2i 的输入图分辨率在 `512x512 / 1024x1024 / 1280x720` 间均匀抽取；③ i2t/it2i 的输入图内容逐请求生成不同的随机配色+形状图（不再共用一张纯色占位图）。仅对 `random` 数据集生效（`custom` 行始终优先）；开启时 `--input-image` 与 `--i2t/--t2i/--it2i-prompt` 被忽略。关闭时行为与旧版逐字节一致（不引入额外 RNG 抽取）。 |
+
+此外复用了 `diffusion` 既有能力：请求数量、并发上限（`--max-concurrency`）、Poisson 请求速率（`--request-rate`）、warmup、分位（`--percentiles`）、统一落盘 `--output-dir`、`--disable-tqdm` 等。
+
+---
+
+## 2. 工作机制
+
+### 2.1 任务类型 → 服务端字段的映射
+
+三类任务都走 `POST /v1/chat/completions`，通过 `modalities` 字段区分（与服务端 `serving_chat.py` 中 `omni_task_type` 的解析逻辑对齐）；it2i 另可选 `POST /v1/images/edits`（`--it2i-endpoint images-edits`）。
+
+| 任务 | `modalities` | 输入图 | 额外字段 | 服务端 bucket |
+|------|--------------|--------|----------|---------------|
+| i2t（理解） | `["text"]` | 有 | — | `ar_only`（AR 阶段即结束） |
+| t2i（生成） | `["image"]` | 无 | — | `ar_downstream`（AR→DiT） |
+| it2i（编辑） | `["image"]` | 有 | `bot_task` ∈ {recaption, think, think_recaption} | `ar_downstream`（AR→DiT） |
+
+> i2t 与 t2i/it2i 落在 DTPS 的不同调度桶里，混合发送正是为了压测跨桶调度。
+
+### 2.2 请求构造流水线（`omni_dataset.build_requests`）
+
+1. 按数量分别构造 i2t / t2i / it2i 的 `OmniRequest` 列表（数据源见 §3）。
+2. 用单个 `random.Random(seed)` 依次抽取：
+   - **it2i bot_task**（最先抽，保证不开启分辨率/输入随机化特性时 bot_task+shuffle 序列与旧版逐字节一致）：默认 `proportional`（最大余数法，精确匹配权重，如 10 任务 2:2:1 → 4/4/2），或 `random`（`rng.choices` 带权重独立抽样，只在期望上匹配）。分配结果再用 `rng.shuffle` 打乱，使 bot_task 在 it2i 内部也是随机分布的（`--no-shuffle` 时不会聚块）。
+   - **t2i / it2i 生成分辨率**（仅当 `--gen-resolution-weights` 给定）：各自独立按权重抽取（`proportional` 精确 / `random` 期望），允许取值限定 `512x512 / 1024x1024 / 1280x720`。抽取结果再 `rng.shuffle`。i2t 不参与；custom 行显式 `width/height` 仍优先（`gkw.setdefault`，只在行未指定时回填）。
+   - **输入随机化**（仅当 `--randomize-input` 且 `dataset=random`）：在上述分配之后、构造每条请求时，按 i2t→t2i→it2i 的顺序逐请求从同一个 `rng` 抽取 prompt（短→长池）+（仅 i2t/it2i）输入图分辨率与内容。关掉时不做任何额外抽取，故旧版序列不变。
+3. 按 `group_order`（`--no-shuffle-order`，默认 `i2t,t2i,it2i`）拼接三列表；缺漏的类型防御性追加在后，保证计数不丢。
+4. `--shuffle` 时对合并列表 `random.shuffle`（同一个 `rng`，保证整体可复现）。
+
+`OmniRequest` 是 `diffusion.RequestFuncInput` 的子类，仅新增 `task_type` / `bot_task` / `input_image_size` 三个客户端记账字段，**不发送到服务端**。Phase D 在其上新增 `image_data_urls` / `image_bytes` 两个缓存字段（见 §2.6），同样不发送到服务端。
+
+### 2.3 发送与统计（`omni_benchmark_serving.benchmark`）
+
+- `iter_requests`：Poisson 到达（`expovariate`），`--request-rate inf` 时一次性全部发出。
+- 并发受 `asyncio.Semaphore(--max-concurrency)` 上限保护。
+- **预编码 + 有序派发**（Phase D，见 §2.6）：发送前一次性把 i2t/it2i 输入图读出并缓存 base64 / 原始 bytes 到 request 上；发送期 sender 直接用缓存，跳过文件 I/O 与 base64，事件循环不再被 ~15ms/请求的同步 prep 阻塞。每个 `asyncio.create_task` 后 `await asyncio.sleep(0)`，让 task[i] 在 task[i+1] 创建前就抢到 FIFO 信号量并 `session.post`，从而**客户端实际发送顺序严格等于 dry-run / 列表顺序**。运行结束打印 `Client dispatch order matches dry-run list order: True`，并把 `dispatch_order`（实际进入 sender 的 idx 序列）写入 JSON `config.dispatch_order` 供与服务端接收日志对照。
+- `--warmup-requests` 在测量前以 `--warmup-concurrency` 跑一批预热（不计入指标）。
+- `--return-stage-metrics` 让服务端返回 `stage_durations`（ar_prefill / ar_decode / dit），统计时做 mean / p50 / p99 聚合。
+- 指标分桶：
+  - **overall**：全量吞吐与延迟。
+  - **per_task**：i2t / t2i / it2i 各自的 qps、延迟分位、stage_durations、success_rate、peak_memory。
+  - **it2i_by_bot_task**：按 `bot_task`（recaption / think / think_recaption）再分桶，比较不同思考强度的延迟。
+  - per-task qps 以 `total_duration` 为分母，三者相加 = overall qps。
+- `--output-dir DIR` 统一落盘：`DIR/result.json` 写指标，`DIR/inputs/` 落 i2t/it2i 的输入参考图，`DIR/outputs/` 落 t2i/it2i 的生成图（i2t 无生成图）。it2i 同时有 `inputs/` 与 `outputs/` 条目，可逐请求前后对比。
+
+### 2.4 it2i 两种 endpoint 的差异
+
+| 项 | `--it2i-endpoint chat`（默认，统一） | `--it2i-endpoint images-edits` |
+|----|--------------------------------------|--------------------------------|
+| 路径 | `/v1/chat/completions` | `/v1/images/edits`（multipart） |
+| `bot_task` | 放在请求体 `extra_body.bot_task` | multipart 字段 `bot_task` |
+| `stage_durations` | ✅ 随 chat 响应返回 | ⚠️ edits 响应体不携带 stage_durations，故 it2i 该桶 stage 统计为空 |
+
+> 评估 per-stage 时序优化建议用默认 `chat`；images-edits 用于回归兼容性或与服务端 edits 通路对齐。
+
+### 2.5 文本输出的 TTFT / TPOT / ITL（`--stream`）
+
+参照 vLLM `benchmarks/benchmark_serving`（`serve.py`）对大语言模型的指标口径，本工具在 `--stream` 下用流式请求采集三类任务**文本输出**的 token 级延迟：
+
+| 指标 | 定义 |
+|------|------|
+| **TTFT** | 从请求发出到第一个文本 token（delta）返回的耗时。 |
+| **ITL** | 相邻文本 token 之间的到达间隔（每请求一个 list）。 |
+| **TPOT** | 每请求 `sum(itl) / (output_tokens - 1)`，即排除首 token 后的平均每 token 耗时；`output_tokens <= 1` 时记 0。用 ITL 之和（= 末个文本 token 时刻 − TTFT）而非 `latency − ttft`，使 TPOT 只落在**文本流时间窗内**——对 i2t（AR 是终点阶段）与 vLLM 原口径一致；对 it2i 则**自动剔除文本流结束后的 DiT 阶段**，不被算到每 token 头上。 |
+| **output_tokens** | 文本 token 数。chat i2t 取最终 `usage.completion_tokens`（缺失则回退为 delta 计数）；it2i edits 取 `ar_delta` chunk 数。 |
+
+聚合时统一换算到毫秒，报告 mean / std / median / p50 / p95 / p99（分位由 `--percentiles` 控制）。**仅对流式采集到文本的请求计入**（`measured_requests`），非流式运行或服务端未流式文本的任务，对应桶 `count=0`、不参与统计（不会把 0 当成零延迟样本拉低均值）。
+
+各任务的文本输出与采集路径：
+
+| 任务 | "文本输出"指什么 | 采集方式 | 备注 |
+|------|------------------|----------|------|
+| **i2t** | AR 阶段的最终回答文本（AR 是终点阶段） | chat 流式，解析 `choices[0].delta.content` 文本 delta | ✅ 主场景，TTFT/TPOT/ITL 完整 |
+| **it2i** | AR 阶段的 "思考/CoT" 文本（图像生成前先吐出的规划文本） | **`--it2i-endpoint images-edits`** 流式，解析 `ImageEditARDeltaChunk`（`type="ar_delta"`）的 `delta` | ✅ 推荐路径；edits 流会逐 token 吐 AR 文本，再吐一个 image chunk |
+| **t2i** | AR "思考" 文本 | chat 流式仅吐 image chunk（服务端 `first_iteration_dict` 过滤了 AR 文本） | ⚠️ 文本 TTFT/TPOT 不可用（N/A）；如需 t2i AR 文本延迟，需服务端支持，本工具不修改服务端 |
+
+> 因此 **it2i 文本延迟请配合 `--it2i-endpoint images-edits --stream`** 使用；i2t 文本延迟用默认 chat + `--stream` 即可。流式响应体会在客户端被重构成与非流式等价的 JSON，故既有的 `extract_chat_outputs` / `extract_edits_outputs` / 图片落盘 / `stage_durations` 统计**全部沿用**，`--stream` 只是在其上叠加 token 级延迟指标。
+
+> 与 per-stage durations 的关系：`--return-stage-metrics` 给的是 AR/DiT **整阶段**耗时（ar_prefill / ar_decode / dit）；TTFT/TPOT/ITL 是 AR 文本**逐 token** 的延迟分布，二者互补——前者定位瓶颈阶段，后者刻画用户体感（首字等待、生成流畅度）。可同时开启 `--stream --return-stage-metrics`。
+
+### 2.6 发送顺序：客户端 = dry-run 顺序，服务端 t2i→it2i→i2t 是调度器行为（Phase D）
+
+**症状**：实测中 `--shuffle` 与 `--no-shuffle` 两种模式下，服务端接收/处理请求的顺序都呈现 `t2i → it2i → i2t` 的分组，与 dry-run 展示的请求序号对不上。
+
+**根因结论（客户端无 bug）**：
+
+- 客户端**确实按列表顺序发送**。旧实现里每个 i2t 请求发送前会同步执行 `_encode_image_as_data_url`（`open` + `read` + `base64.b64encode`，无 `await`），这段同步代码会阻塞事件循环 ~15ms，反而把发送**串行化成列表顺序**——也就是说，不存在"客户端按 prep 耗时抢跑导致重排"。
+- 服务端看到的 `t2i → it2i → i2t` 是 **DTPS 调度器的派发顺序**：t2i/it2i 落在 `ar_downstream` 桶、i2t 落在 `ar_only` 桶，调度器优先派发 `ar_downstream`（且 i2t 有"安全窗口=未吐字"的抢占设计，会延后处理）。所以即便客户端交错发送，服务端处理日志也按桶归并。**本工具不修改服务端**，这个行为是调度策略本身，正是混合调度评估要测的对象。
+
+**为何仍要修（保真 + 可证）**：旧的同步 prep 虽然凑巧保持了列表顺序，但阻塞事件循环 ~15ms/请求，会扭曲并发下的延迟测量；且"凑巧保持"不可证明。Phase D 改成显式保证：
+
+1. **预编码**：发送前一次性把 i2t/it2i 输入图读出，base64（供 chat sender）与原始 bytes（供 edits sender）缓存到 `OmniRequest.image_data_urls` / `image_bytes`。发送期 sender 命中缓存，跳过文件 I/O 与 base64 → 事件循环零阻塞。
+2. **有序派发**：每个 `asyncio.create_task(limited(...))` 后 `await asyncio.sleep(0)`，让刚创建的 task 在下一个 task 创建前就抢到 FIFO 信号量并 `session.post`。配合预编码（无 prep 延迟），发送顺序 = 列表顺序，即使 `--request-rate inf` + 并发也成立。
+3. **审计字段 `dispatch_order`**：`limited` 在信号量获取后把 `idx` 追加到共享 `dispatch_order` 列表，运行结束写入 JSON `config.dispatch_order` 并打印 `Client dispatch order matches dry-run list order: True`。把它与服务端接收/处理日志对照，即可把"客户端发送序"与"服务端派发序"区分开，直接回应"对不上"的疑问。
+
+> 对照试验（纯 asyncio 模拟，已通过）：①旧同步 prep → 列表顺序（无重排，但阻塞循环）；②若把 prep 改成异步却不加 `sleep(0)` → 按 prep 耗时重排（t2i 抢跑）；③预编码 + `sleep(0)` → 列表顺序且零阻塞。即②才是真正的"客户端发送顺序 bug"，而旧实现是①、新实现是③。
+
+---
+
+## 3. 数据集
+
+### 3.1 `random`（默认，零外部依赖）
+
+合成 prompt + 一张内置 512×512 占位图（i2t/it2i 输入），prompt 可用 `--i2t-prompt / --t2i-prompt / --it2i-prompt` 覆盖，生成分辨率/步数用 `--width/--height/--num-inference-steps`。足以驱动调度器、收集延迟与吞吐。
+
+### 3.2 `custom`（可选，按需回放真实分布）
+
+`--dataset custom --dataset-path xxx.jsonl`，每行一个 JSON，按 `task` 字段分桶后按数量循环采样。每行字段：
+
+| 字段 | 适用任务 | 必填 | 说明 |
+|------|----------|------|------|
+| `task` | 全部 | ✅ | `i2t` / `t2i` / `it2i` |
+| `prompt` | 全部 | ✅ | 该条请求的 prompt |
+| `image_path` / `image_paths` | i2t/it2i | ❌ | 输入图；缺省回退到 `--input-image` 或占位图 |
+| `bot_task` | it2i | ❌ | 显式指定；缺省按 `--it2i-bot-task-weights` 随机 |
+| `width` / `height` / `num_inference_steps` / `seed` | t2i/it2i | ❌ | 覆盖 CLI 全局默认 |
+
+示例（`custom.jsonl`）：
+
+```json
+{"task":"i2t","prompt":"What objects are in this image?"}
+{"task":"t2i","prompt":"A serene mountain lake at dawn","width":1024,"height":1024,"num_inference_steps":30}
+{"task":"it2i","prompt":"Make the background a starry night","bot_task":"think","width":1024,"height":1024}
+{"task":"it2i","prompt":"Recaption this image with a poetic description","bot_task":"recaption"}
+```
+
+---
+
+## 4. 快速开始
+
+### 4.1 启动服务端
+
+```bash
+vllm serve <hunyuan-image3-ckpt> --omni --port 8099
+```
+
+### 4.2 冒烟：dry-run 只看发送计划，不发请求
+
+```bash
+python3 benchmarks/omni/omni_benchmark_serving.py \
+    --host 127.0.0.1 --port 8099 \
+    --num-i2t 14 --num-t2i 2 --num-it2i 4 \
+    --it2i-endpoint chat \
+    --it2i-bot-task-weights "recaption=2,think=1,think_recaption=1" \
+    --shuffle --seed 3 \
+    --dry-run
+```
+
+`--dry-run` 默认只打印前 20 条，加 `--dry-run-preview 0` 打印**全部**请求计划（也接受任意正整数 N 只看前 N 条）：
+
+```bash
+python3 benchmarks/omni/omni_benchmark_serving.py \
+    --num-i2t 70 --num-t2i 20 --num-it2i 10 \
+    --it2i-bot-task-weights "recaption=2,think=2,think_recaption=1" \
+    --shuffle --seed 3 --dry-run --dry-run-preview 0
+```
+
+输出会先打印汇总，再按发送顺序列出每条请求的 `(idx, task, bot_task, inWxH, genWxH, prompt_words, api_url)`，可直观看到三类任务真随机交错：
+
+```
+Prepared 100 omni requests: i2t=70, t2i=20, it2i=10
+it2i bot_task used: recaption=4, think=4, think_recaption=2
+t2i/it2i resolution used: 1024x1024=30
+
+[dry-run] all 100 requests in send order (idx, task, bot_task, inWxH, genWxH, prompt_words, api_url):
+    0  it2i   bot_task=recaption  -           1024x1024   9    http://127.0.0.1:8099/v1/images/edits
+    1  i2t    bot_task=-          -           -           5    http://127.0.0.1:8099/v1/chat/completions
+    ...
+   99  i2t    bot_task=-          -           -           5    http://127.0.0.1:8099/v1/chat/completions
+
+[dry-run] No requests sent. Shuffle=True, seed=3, group_order=['i2t','t2i','it2i'].
+```
+
+> `it2i bot_task used` 的计数精确匹配权重（2:2:1 → 4/4/2），因为默认 `--it2i-bot-task-sampling proportional` 用最大余数法做精确比例分配。若想要带方差的真实随机抽样（只在期望上接近比例），加 `--it2i-bot-task-sampling random`。`WxH` 列在设了 `--gen-resolution-weights` 时显示 t2i/it2i 的分配分辨率，否则显示 `-`（i2t 始终 `-`）。`group_order` 在 `--no-shuffle` 时为 `--no-shuffle-order` 的值，`--shuffle` 时显示默认值仅供参考（实际整体随机化）。
+
+### 4.3 7:1:2 混合配比 + 权重 bot_task + 并发测量
+
+```bash
+python3 benchmarks/omni/omni_benchmark_serving.py \
+    --host 127.0.0.1 --port 8099 --model default \
+    --num-i2t 140 --num-t2i 20 --num-it2i 40 \
+    --it2i-endpoint chat \
+    --it2i-bot-task-weights "recaption=2,think=1,think_recaption=1" \
+    --shuffle --seed 7 \
+    --request-rate 10 --max-concurrency 8 \
+    --warmup-requests 8 --warmup-concurrency 8 \
+    --return-stage-metrics \
+    --percentiles 50 95 99 \
+    --output-dir omni_7_1_2
+```
+
+### 4.4 自定义数据集
+
+```bash
+python3 benchmarks/omni/omni_benchmark_serving.py \
+    --host 127.0.0.1 --port 8099 \
+    --dataset custom --dataset-path custom.jsonl \
+    --num-i2t 50 --num-t2i 10 --num-it2i 20 \
+    --it2i-endpoint chat --it2i-bot-task-weights "recaption=1,think=1,think_recaption=1" \
+    --shuffle --seed 42 \
+    --max-concurrency 8 --return-stage-metrics \
+    --output-dir omni_custom
+```
+
+### 4.5 it2i 走 images-edits 端点
+
+```bash
+python3 benchmarks/omni/omni_benchmark_serving.py \
+    --host 127.0.0.1 --port 8099 \
+    --num-i2t 10 --num-t2i 6 --num-it2i 8 \
+    --it2i-endpoint images-edits \
+    --it2i-bot-task-weights "recaption=2,think=1,think_recaption=1" \
+    --shuffle --seed 7 \
+    --max-concurrency 4 --return-stage-metrics \
+    --output-dir omni_edits
+```
+
+### 4.6 关闭 shuffle（按类型分组发送，做对照组）
+
+```bash
+python3 benchmarks/omni/omni_benchmark_serving.py \
+    --num-i2t 14 --num-t2i 2 --num-it2i 4 --no-shuffle --seed 7 --dry-run
+```
+
+加 `--no-shuffle-order` 指定分组先后顺序（须为 `i2t,t2i,it2i` 的全排列，默认 `i2t,t2i,it2i`）。例如先发 t2i、再 it2i、最后 i2t：
+
+```bash
+python3 benchmarks/omni/omni_benchmark_serving.py \
+    --num-i2t 14 --num-t2i 2 --num-it2i 4 \
+    --no-shuffle --no-shuffle-order "t2i,it2i,i2t" --seed 7 --dry-run
+```
+
+dry-run 输出会先按 `group_order` 分块列出，footer 也会打印 `group_order=['t2i','it2i','i2t']`。`--shuffle` 时该参数被忽略。
+
+### 4.7 流式采集 i2t 文本输出的 TTFT/TPOT/ITL
+
+i2t 的 AR 最终回答文本经 chat 流式逐 token 返回，`--stream` 直接采集：
+
+```bash
+python3 benchmarks/omni/omni_benchmark_serving.py \
+    --host 127.0.0.1 --port 8099 --model default \
+    --num-i2t 50 --num-t2i 0 --num-it2i 0 \
+    --stream --return-stage-metrics \
+    --request-rate 5 --max-concurrency 4 \
+    --percentiles 50 95 99 \
+    --output-dir omni_i2t_stream
+```
+
+### 4.8 流式采集 it2i AR "思考" 文本的 TTFT/TPOT/ITL
+
+it2i 的 AR 思考文本走 **images-edits** 流式（`ImageEditARDeltaChunk`）才能逐 token 拿到，故需 `--it2i-endpoint images-edits --stream`：
+
+```bash
+python3 benchmarks/omni/omni_benchmark_serving.py \
+    --host 127.0.0.1 --port 8099 --model default \
+    --num-i2t 0 --num-t2i 0 --num-it2i 40 \
+    --it2i-endpoint images-edits \
+    --it2i-bot-task-weights "recaption=2,think=1,think_recaption=1" \
+    --stream --return-stage-metrics \
+    --request-rate 5 --max-concurrency 4 \
+    --output-dir omni_it2i_stream
+```
+
+### 4.9 混合三类 + 流式（i2t 文本 + it2i AR 文本同时采集）
+
+i2t 走 chat 流式、it2i 走 images-edits 流式，二者在 `--stream` 下各自采集文本延迟；t2i 文本延迟为 N/A（不计入）：
+
+```bash
+python3 benchmarks/omni/omni_benchmark_serving.py \
+    --host 127.0.0.1 --port 8099 --model default \
+    --num-i2t 140 --num-t2i 20 --num-it2i 40 \
+    --it2i-endpoint images-edits \
+    --it2i-bot-task-weights "recaption=2,think=1,think_recaption=1" \
+    --shuffle --seed 7 \
+    --stream --return-stage-metrics \
+    --request-rate 10 --max-concurrency 8 \
+    --warmup-requests 8 --warmup-concurrency 8 \
+    --output-dir omni_stream
+```
+
+### 4.10 生图分辨率配比（t2i / it2i）
+
+`--gen-resolution-weights` 给 t2i 与 it2i 两类生图任务按比例分配生成分辨率，允许 `512x512 / 1024x1024 / 1280x720`。默认 `proportional` 用最大余数法精确匹配权重（10 请求 2:2:1 → 4/4/2），`random` 改为带权重独立抽样。t2i 与 it2i **各自独立**按比例分配；i2t 不受影响；custom 数据集行若显式带 `width/height` 仍优先。
+
+```bash
+python3 benchmarks/omni/omni_benchmark_serving.py \
+    --host 127.0.0.1 --port 8099 --model default \
+    --num-i2t 40 --num-t2i 20 --num-it2i 20 \
+    --gen-resolution-weights "512x512=2,1024x1024=2,1280x720=1" \
+    --gen-resolution-sampling proportional \
+    --shuffle --seed 7 --dry-run --dry-run-preview 0
+```
+
+dry-run 输出的 `genWxH` 列即每条 t2i/it2i 的生成分辨率，footer 打印 `gen_resolution_weights` 与 `sampling`，运行后 tally 段打印 `t2i/it2i resolution used:` 的实际计数（应精确匹配 2:2:1 → 各 8/8/4）。若想带方差抽样：
+
+```bash
+    --gen-resolution-weights "512x512=2,1024x1024=2,1280x720=1" \
+    --gen-resolution-sampling random
+```
+
+未列出的分辨率按 0 填充（如 `1280x720=1` 只发 1280×720）；所有权重和必须 > 0。省略 `--gen-resolution-weights` 时全部用 `--width/--height`。
+
+### 4.11 发送顺序审计（对照服务端接收日志）
+
+运行结束会打印 `Client dispatch order matches dry-run list order: True`，并把 `config.dispatch_order`（实际进入 sender 的 idx 序列）写入 JSON。把它与服务端接收/处理日志对照，即可区分"客户端发送序"与"服务端派发序"——若 `dispatch_order == [0,1,2,...]` 而服务端日志呈 `t2i→it2i→i2t`，则重排发生在服务端 DTPS 调度器（`ar_downstream` 优先于 `ar_only`），而非客户端。详见 §2.6。
+
+```bash
+python3 benchmarks/omni/omni_benchmark_serving.py \
+    --host 127.0.0.1 --port 8099 --model default \
+    --num-i2t 14 --num-t2i 6 --num-it2i 4 \
+    --shuffle --seed 7 --max-concurrency 8 \
+    --output-dir omni_dispatch
+# omni_dispatch/result.json -> config.dispatch_order == [0,1,...,23]
+#                                              dispatch_matches_list_order == true
+```
+
+### 4.12 输入随机化（贴近真实请求分布）
+
+`--randomize-input` 让**输入侧**逐请求随机化（由 `--seed` 控制，可复现），覆盖三类任务：
+
+- **prompt 长度随机分布**：i2t / t2i / it2i 各有一个"短→长"的 prompt 池（从一句到长描述），逐请求从池中均匀抽取一条，使 prompt 长度真实分布。
+- **输入图分辨率随机**：i2t / it2i 的输入图分辨率在 `512x512 / 1024x1024 / 1280x720` 间均匀抽取（与 `--gen-resolution-weights` 控制的**输出**生图分辨率互不影响）。
+- **输入图内容随机**：i2t / it2i 的输入图逐请求用 PIL 生成不同的随机配色 + 椭圆/矩形/线条图（每条请求内容不同、可复现），不再共用一张纯色占位图。
+
+```bash
+python3 benchmarks/omni/omni_benchmark_serving.py \
+    --host 127.0.0.1 --port 8099 --model default \
+    --num-i2t 40 --num-t2i 20 --num-it2i 20 \
+    --randomize-input --shuffle --seed 7 --dry-run --dry-run-preview 0
+```
+
+dry-run 预览表头变为 `idx, task, bot_task, inWxH, genWxH, prompt_words, api_url`：
+
+- `inWxH`：i2t/it2i 的**输入图**分辨率（随机化时每条不同；t2i 恒为 `-`）；
+- `genWxH`：t2i/it2i 的**输出生图**分辨率（由 `--gen-resolution-weights` 或 `--width/--height` 决定；i2t 恒为 `-`）；
+- `prompt_words`：该请求 prompt 的词数，可直观看到长短分布。
+
+tally 段额外打印 `prompt word count (randomized): i2t=[min-max, avg=...], t2i=..., it2i=...` 与 `i2t/it2i input-image resolution used: 512x512=N, 1024x1024=M, 1280x720=K`。JSON 的 `config` 新增 `randomize_input` / `input_resolution_actual` / `prompt_word_count`，`requests[].input` 新增 `prompt_word_count` / `input_image_size`。
+
+注意：仅对 `random` 数据集生效（`--dataset custom` 的行始终优先，随机化被跳过）；开启时 `--input-image` 与 `--i2t/--t2i/--it2i-prompt` 被忽略。关掉时（默认）行为与旧版逐字节一致——共用一张 512×512 纯色占位图、三类各用一条固定 prompt，且不引入任何额外 RNG 抽取。`--no-randomize-input` 可显式关闭。
+
+---
+
+## 5. 输出说明
+
+### 5.1 终端表格
+
+依次输出：运行配置 → overall（吞吐/延迟/peak memory/stage durations）→ per-task（三类各自，含 stage durations）→ it2i by bot_task（思考强度分桶）。`--stream` 会在 overall / per-task / it2i-by-bot_task 各层追加 **Text-Output Streaming** 段（仅当该桶确有流式文本采集时打印）。
+
+```
+ Mix (i2t:t2i:it2i):            14:2:4
+ bot_task weights:              recaption=2,think=1,think_recaption=1
+ Shuffle:                       True   Seed: 7
+ No-shuffle group order:        i2t,t2i,it2i          # 仅 --no-shuffle 时显示
+ Gen resolution weights:        512x512=2,1024x1024=2,1280x720=1   # 仅设定时显示
+ Gen resolution sampling:       proportional
+ Randomize input:               True                   # --randomize-input 时为 True
+ Output dir:                    omni_stream           # 仅 --output-dir 时显示，结果落在其下 result.json + inputs/ + outputs/
+ Successful requests:           20/20
+ Request throughput (req/s):    ...
+ t2i/it2i resolution used:      512x512=8, 1024x1024=8, 1280x720=4   # 仅设定时显示
+ prompt word count (randomized): i2t=[3-45, avg=22.1], t2i=[5-40, avg=20.3], it2i=[4-38, avg=18.7]   # 仅 --randomize-input 时显示
+ i2t/it2i input-image resolution used: 512x512=9, 1024x1024=6, 1280x720=3                                # 仅 --randomize-input 时显示
+
+Client dispatch order matches dry-run list order: True
+
+Stage Durations (overall, seconds):
+  ar_prefill   n=20  mean=0.0312 p50=0.0301 p99=0.0410
+  ar_decode    n=20  mean=0.1804 p50=0.1782 p99=0.2205
+  dit          n=6   mean=1.9034 p50=1.8810 p99=2.0102
+
+Text-Output Streaming (overall):
+  text-output (n=18, out_tokens mean=42.3 median=40.0 max=88):
+    TTFT  n=18  mean=128.45ms median=121.30ms p50=121.30ms p95=178.92ms p99=192.04ms
+    TPOT  n=18  mean=21.76ms  median=20.91ms  p50=20.91ms  p95=29.33ms  p99=31.50ms
+    ITL   n=18  mean=21.40ms  median=20.88ms  p50=20.88ms  p95=28.70ms  p99=30.91ms
+
+ [i2t] total=14 completed=14 failed=0 success_rate=100.00% qps=...
+   i2t  n=14  mean=... p50=... p95=... p99=...
+     stage ar_prefill   ...
+     stage ar_decode    ...
+     text-output (n=14, out_tokens mean=45.1 ...):
+       TTFT  n=14  mean=125.20ms ...
+       TPOT  n=14  mean=19.80ms  ...
+       ITL   n=14  mean=19.50ms  ...
+ [t2i] total=2  ...  stage ar_prefill / ar_decode / dit   (text-output: 无，N/A)
+ [it2i] total=4 ...
+
+ it2i by bot_task:
+   [recaption] total=...  ...
+     text-output (n=..., ...): TTFT ... TPOT ... ITL ...
+   [think] total=...  ...
+   [think_recaption] total=...  ...
+```
+
+`--output-dir` 时运行末尾还会打印落盘摘要：
+
+```
+Saved 18 input image(s) to omni_stream/inputs.
+Saved 6 generated image(s) to omni_stream/outputs.
+Metrics saved to omni_stream/result.json
+```
+
+> `n` 即 `measured_requests`：实际流式采集到文本的请求数。t2i（chat 流式不吐 AR 文本）与未开 `--stream` 的运行，对应行不打印（`n=0`）。
+
+### 5.2 JSON（`--output-dir`，根目录 `result.json`）
+
+```json
+{
+  "config":      { "output_dir": "omni_stream",
+                   "endpoint_i2t_t2i": "...", "endpoint_it2i": "...", "mix_i2t_t2i_it2i": "14:2:4",
+                   "bot_task_weights": "...", "bot_task_actual": {"recaption":2,"think":2},
+                   "shuffle": true, "seed": 7, "dataset": "random", "model": "default",
+                   "request_rate": "inf", "max_concurrency": 4, "stream": true,
+                   "group_order": ["i2t","t2i","it2i"],
+                   "gen_resolution_weights": {"512x512":2.0,"1024x1024":2.0,"1280x720":1.0},
+                   "gen_resolution_sampling": "proportional",
+                   "gen_resolution_actual": {"512x512":8,"1024x1024":8,"1280x720":4},
+                   "randomize_input": true,
+                   "input_resolution_actual": {"512x512":9,"1024x1024":6,"1280x720":3},
+                   "prompt_word_count": {"i2t":{"min":3,"max":45,"avg":22.1},
+                                          "t2i":{"min":5,"max":40,"avg":20.3},
+                                          "it2i":{"min":4,"max":38,"avg":18.7}},
+                   "dispatch_order": [0,1,2,...,19],
+                   "dispatch_matches_list_order": true },
+  "overall":     { "count":20, "completed":20, "failed":0, "throughput_qps": ..., "duration": ...,
+                   "mean":..., "p50":..., "p95":..., "p99":...,
+                   "peak_memory_mb": {"max":..., "mean":...},
+                   "stage_durations": {"ar_prefill":{...}, "ar_decode":{...}, "dit":{...}},
+                   "text_stream": {
+                     "measured_requests": 18,
+                     "output_tokens": {"total": 760, "mean": 42.3, "median": 40.0, "max": 88},
+                     "ttft": {"count":18, "mean_ms":128.45, "std_ms":..., "median_ms":121.30,
+                              "p50_ms":121.30, "p95_ms":178.92, "p99_ms":192.04},
+                     "tpot": {"count":18, "mean_ms":21.76, "std_ms":..., "median_ms":20.91,
+                              "p50_ms":20.91, "p95_ms":29.33, "p99_ms":31.50},
+                     "itl":  {"count":742, "mean_ms":21.40, "std_ms":..., "median_ms":20.88,
+                              "p50_ms":20.88, "p95_ms":28.70, "p99_ms":30.91}
+                   } },
+  "per_task": {
+    "i2t":  { "total":..., "completed":..., "success_rate":..., "throughput_qps":...,
+              "mean":..., "p50":..., "p95":..., "p99":...,
+              "stage_durations": {"ar_prefill":{...}, "ar_decode":{...}},
+              "text_stream": {"measured_requests":14, "ttft":{...}, "tpot":{...}, "itl":{...},
+                              "output_tokens":{...}} },
+    "t2i":  { ..., "stage_durations": {"ar_prefill":{...}, "ar_decode":{...}, "dit":{...}},
+              "text_stream": {"measured_requests":0, "ttft":{"count":0,...}, ...} },
+    "it2i": { ..., "stage_durations": {"ar_prefill":{...}, "ar_decode":{...}, "dit":{...}},
+              "text_stream": {"measured_requests":4, "ttft":{...}, "tpot":{...}, "itl":{...},
+                              "output_tokens":{...}} }
+  },
+  "it2i_by_bot_task": { "recaption": {..., "text_stream":{...}},
+                        "think": {..., "text_stream":{...}},
+                        "think_recaption": {..., "text_stream":{...}} },
+  "requests": [
+    { "index":0, "task_type":"i2t",
+      "input":  { "endpoint":"/v1/chat/completions", "model":"default", "prompt":"...",
+                   "prompt_word_count":22, "input_image_size":"1024x1024",
+                   "image_paths":["<tmp>/omni_bench_input_0.png"],
+                   "input_images_saved":["omni_stream/inputs/req_0000_i2t_input.png"],
+                   "modalities":["text"], ... },
+      "output": { "success":true, "latency_s":1.023, "returned_text":"...", "num_images":0,
+                  "image_paths_saved":[],
+                  "stage_durations":{...}, "peak_memory_mb":...,
+                  "text_stream": { "ttft_s":0.121, "output_tokens":45, "tpot_s":0.0202,
+                                   "itl_s":[0.0198,0.0201,...], "generated_text":"..." } } },
+    { "index":1, "task_type":"it2i",
+      "input":  { "endpoint":"/v1/images/edits", "prompt":"...", "prompt_word_count":14,
+                   "input_image_size":"512x512", "bot_task":"think",
+                   "image_paths":["<tmp>/omni_bench_input_1.png"],
+                   "input_images_saved":["omni_stream/inputs/req_0001_it2i_input.png"] },
+      "output": { "success":true, "latency_s":2.451, "cot_output":"...", "num_images":1,
+                  "image_paths_saved":["omni_stream/outputs/req_0001_it2i_0.png"],
+                  "stage_durations":{...}, "peak_memory_mb":...,
+                  "text_stream": { "ttft_s":0.083, "output_tokens":32, "tpot_s":0.0759,
+                                   "itl_s":[0.072,0.074,...], "generated_text":"..." } } }
+  ]
+}
+```
+
+> `it2i` 走 `images-edits` 时，`per_task.it2i.stage_durations` 与对应 bot_task 桶的 stage 统计在**非流式**下为空（edits 响应体不携带 stage_durations）；但 `--stream` 下 edits 流的 image chunk 携带 `metrics`，故 `stage_durations` 会随流式补全（见 §2.5）。chat 端点则始终完整。
+>
+> `requests[].output.text_stream` 仅在该请求确实采集到文本流时出现（`ttft_s>0`）；非流式或 N/A 请求无此字段。`generated_text` 与 `returned_text`（i2t）/ `cot_output`（it2i edits）一致，是流式拼接的原文，便于直接核对 TTFT/TPOT。
+>
+> 落盘布局（`--output-dir omni_stream`）：`omni_stream/result.json` 写指标；`omni_stream/inputs/req_{idx}_{task}_input.png` 落 i2t/it2i 的输入参考图（逐请求从源文件复制）；`omni_stream/outputs/req_{idx}_{task}_{img}.png` 落 t2i/it2i 的生成图。it2i 同时有 `inputs/` 与 `outputs/` 条目，按 idx 对齐即可前后对比；i2t 只有 `inputs/`、t2i 只有 `outputs/`。`input.image_paths` 是源路径，`input.input_images_saved` 是落盘副本；`output.image_paths_saved` 是生成图落盘路径。
+
+---
+
+## 6. 参数速查
+
+| 参数 | 说明 |
+|------|------|
+| `--base-url` / `--host` `--port` | 服务端地址，`--base-url` 优先 |
+| `--num-i2t` / `--num-t2i` / `--num-it2i` | 三类任务请求数（配比来源） |
+| `--it2i-endpoint {chat,images-edits}` | it2i 走统一 chat 端点（默认）或 edits 端点 |
+| `--it2i-bot-task-weights` | 如 `recaption=2,think=1,think_recaption=1`；缺省等权重；名字须在三者内；权重和 > 0 |
+| `--it2i-bot-task-sampling {proportional,random}` | `proportional`（默认）：最大余数法精确分配，计数严格匹配权重；`random`：带权重独立抽样，仅期望匹配 |
+| `--shuffle` / `--no-shuffle` | 真随机交错发送（默认）或按类型分组发送 |
+| `--no-shuffle-order ORDER` | `--no-shuffle` 下三组的拼接顺序，须为 `i2t,t2i,it2i` 的全排列，如 `t2i,it2i,i2t`；默认 `i2t,t2i,it2i`；`--shuffle` 时忽略 |
+| `--seed` | RNG 种子（shuffle + bot_task + 分辨率采样共用，可复现） |
+| `--dataset {random,custom}` / `--dataset-path` | 数据源；custom 需 JSONL |
+| `--input-image` | random 模式下 i2t/it2i 输入图，缺省用占位图 |
+| `--i2t-prompt` / `--t2i-prompt` / `--it2i-prompt` | 覆盖 random 模式的默认 prompt |
+| `--gen-resolution-weights WEIGHTS` | t2i/it2i 生图分辨率配比，如 `512x512=2,1024x1024=2,1280x720=1`；允许 `512x512/1024x1024/1280x720`；缺省则全用 `--width/--height` |
+| `--gen-resolution-sampling {proportional,random}` | `proportional`（默认）：最大余数法精确分配；`random`：带权重独立抽样，仅期望匹配 |
+| `--randomize-input` / `--no-randomize-input` | 仅 `--dataset random` 下生效。开启后每条请求的**输入**侧随机化：prompt 长度按任务从内置池随机抽取、输入图分辨率在 `512x512/1024x1024/1280x720` 间随机、输入图内容每张独立生成（非同一张纯色图）。由 `--seed` 驱动可复现；开启时忽略 `--input-image` 与 `--i2t/--t2i/--it2i-prompt`；默认关（关闭=与历史字节一致） |
+| `--model` `--width` `--height` `--num-inference-steps` `--seed-gen` | 生成参数（`--width/--height` 在设了 `--gen-resolution-weights` 时被 t2i/it2i 逐请求覆盖） |
+| `--request-rate` | Poisson 速率（req/s），`inf` 一次性全发（默认） |
+| `--max-concurrency` | 在途请求上限 |
+| `--warmup-requests` `--warmup-concurrency` | 预热 |
+| `--return-stage-metrics` | 请求服务端返回 per-stage durations |
+| `--stream` | 流式采集文本输出 TTFT/TPOT/ITL（i2t AR 回答；it2i AR 思考需配 `--it2i-endpoint images-edits`）；不开则 `text_stream` 各桶 `count=0` |
+| `--percentiles` | 报告的分位（默认 50 95 99） |
+| `--output-dir DIR` | 统一落盘目录：`DIR/result.json`（指标，固定名）+ `DIR/inputs/`（i2t/it2i 输入参考图，逐请求复制）+ `DIR/outputs/`（t2i/it2i 生成图）；it2i 前后可按 idx 对齐对比。旧 `--output-file`/`--save-dir` 仍接受（弃用，分别映射到其父目录/该目录） |
+| `--disable-tqdm` `--dry-run` | 关进度条 / 只打印发送计划不发请求 |
+| `--dry-run-preview N` | 配合 `--dry-run`，打印前 N 条请求计划；`0` = 全部（默认 20） |
+
+### bot_task 权重说明
+
+合法取值（与服务端 `_BOT_TASK_PRESETS` 对齐）：`think`、`recaption`、`think_recaption`。
+
+- `--it2i-bot-task-weights "recaption=2,think=1,think_recaption=1"` 设定权重。
+- `--it2i-bot-task-sampling proportional`（默认）：用最大余数法把 it2i 任务**精确**按权重分配到三类，计数严格匹配（如 10 任务 2:2:1 → 4/4/2，100 任务 → 40/40/20），跨 seed 可复现；适合需要可控、可复现负载的 benchmark。
+- `--it2i-bot-task-sampling random`：每个 it2i 任务按权重独立抽样（`rng.choices`），只在**期望**上接近权重，会有方差（如 10 任务 2:2:1 可能抽到 6/3/1）；适合需要真实随机波动的压测。
+- 未列出的取值权重按 0 填充；所有权重和必须 > 0。
+- 省略 `--it2i-bot-task-weights` 时三值等权重。
+- 自定义数据集中若某 it2i 行显式带 `bot_task`，则该行用显式值，不参与上述分配/采样（这会使实际计数略微偏离设定比例）。
+
+### 生图分辨率配比说明
+
+合法取值：`512x512`、`1024x1024`、`1280x720`（与 `omni_dataset.GEN_RESOLUTIONS` 对齐）。
+
+- `--gen-resolution-weights "512x512=2,1024x1024=2,1280x720=1"` 设定权重。t2i 与 it2i **各自独立**按该权重分配生成分辨率（各算一份最大余数法 / 独立抽样）。
+- `--gen-resolution-sampling proportional`（默认）：最大余数法**精确**匹配权重，10 请求 2:2:1 → 各 4/4/2，跨 seed 可复现。
+- `--gen-resolution-sampling random`：每个 t2i/it2i 请求按权重独立抽样，仅期望匹配，会有方差。
+- 未列出的分辨率按 0 填充；所有权重和必须 > 0。
+- 仅作用于 t2i / it2i；i2t 始终用 `--width/--height`（理解任务不生图）。
+- 自定义数据集行若显式带 `width`/`height`，则该行用显式值（`gkw.setdefault`，仅当行未指定时才回填分配到的分辨率），会使实际计数略微偏离设定比例。
+- 省略 `--gen-resolution-weights` 时全部用 `--width/--height`，与旧版完全一致。
+
+---
+
+## 7. 评估优化结果的建议用法
+
+1. **对照组**：`--no-shuffle`（按类型分块）vs `--shuffle`（真随机交错），同样配比/并发，比较 overall qps 与 per-task p99 —— 体现混合调度在交错负载下的优化收益。进一步用 `--no-shuffle-order` 切换分组先后（如 `t2i,it2i,i2t` vs `i2t,t2i,it2i`），观察"先发 ar_downstream"与"先发 ar_only"对调度器排队的影响。
+2. **配比扫描**：固定总并发，跑 `7:1:2`、`5:3:2`、`3:3:4` 等不同 `--num-*` 组合，看 DTPS 在不同 i2t/t2i/it2i 负载下的吞吐与尾延迟。
+3. **生图分辨率配比**：`--gen-resolution-weights "512x512=2,1024x1024=2,1280x720=1"` 给 t2i/it2i 混入不同分辨率，评估 DiT 阶段在大/小图混合下的吞吐与尾延迟（大图 1280×720 的 dit 耗时显著高于 512×512）。
+4. **思考强度影响**：对比 `it2i_by_bot_task` 各桶延迟，评估 recaption/think/think_recaption 对 AR 阶段耗时与整体调度的影响。
+5. **per-stage 定位**：`--return-stage-metrics` 下观察 `ar_prefill / ar_decode / dit` 各阶段 p99，定位优化点落在 AR 还是 DiT。
+6. **文本体感延迟**：`--stream` 下看 `text_stream` 的 TTFT（首字等待）/ TPOT（生成流畅度）p95/p99，配合 `--return-stage-metrics` 的整阶段耗时，区分"AR 预热慢"（TTFT 高、ar_prefill 高）与"AR decode 慢"（TPOT 高、ar_decode 高）。it2i 需 `--it2i-endpoint images-edits` 才能拿到 AR 思考文本的 TTFT/TPOT。
+7. **发送/派发顺序对照**：用 `config.dispatch_order`（客户端实际发送序，应 == `[0,1,...,N-1]`）对照服务端接收/处理日志——若服务端序与 `dispatch_order` 不一致，重排发生在 DTPS 调度器（`ar_downstream` 优先于 `ar_only`），正是混合调度评估要测的对象，而非客户端 bug（见 §2.6）。
+8. **输入随机化（贴近真实分布）**：`--randomize-input` 让每条请求的输入 prompt 长度、输入图分辨率（512x512/1024x1024/1280x720）、输入图内容各不相同，模拟真实世界请求多样性，评估 DTPS 在输入异构负载下的调度稳定性与尾延迟（对比开关两次 run，相同 seed 可复现）。注意 `--randomize-input` 控制的是**输入**侧；生图**输出**分辨率仍由 `--gen-resolution-weights` 控制，两者正交，可叠加使用。
+9. 结果用 `--output-dir` 统一落盘（`result.json` + `inputs/` + `outputs/`），便于跨 run 画图对比（参考 `diffusion/README.md` 中 performance_dashboard 的做法）；it2i 的 `inputs/` 参考图与 `outputs/` 生成图按 idx 对齐，可直接前后对照编辑效果。

--- a/benchmarks/omni/__init__.py
+++ b/benchmarks/omni/__init__.py
@@ -1,0 +1,1 @@
+"""Omni (i2t / t2i / it2i) serving benchmark for unified AR+DiT models."""

--- a/benchmarks/omni/_test_randomize_cli.py
+++ b/benchmarks/omni/_test_randomize_cli.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CLI-level dry-run test for --randomize-input.
+
+Stubs PIL / aiohttp / numpy / tqdm (absent on the local Python) then drives the
+real build_parser + benchmark() with --dry-run to confirm the new flag parses,
+the dry-run preview shows the new inWxH / prompt_words columns, and the tally
+section reports the randomized input distribution. Sends nothing.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+_DIFFUSION = os.path.join(os.path.dirname(HERE), "diffusion")
+for _p in (HERE, _DIFFUSION):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+# --- Stub PIL --------------------------------------------------------------
+class _FakeImage:
+    def __init__(self, mode, size, color):
+        self.mode, self.size, self.color = mode, size, color
+
+    def save(self, path):
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(f"{self.size[0]}x{self.size[1]}|{self.color}")
+
+
+class _FakeDraw:
+    def ellipse(self, *a, **k):
+        pass
+
+    def rectangle(self, *a, **k):
+        pass
+
+    def line(self, *a, **k):
+        pass
+
+
+_pil = types.ModuleType("PIL")
+_pil_image = types.ModuleType("PIL.Image")
+_pil_image.new = staticmethod(lambda m, s, c: _FakeImage(m, s, c))
+_pil_image.open = staticmethod(lambda p: _FakeImage("RGB", (0, 0), (0, 0, 0)))
+_pil.Image = _pil_image
+_pil_image_draw = types.ModuleType("PIL.ImageDraw")
+_pil_image_draw.Draw = staticmethod(lambda img: _FakeDraw())
+sys.modules["PIL"] = _pil
+sys.modules["PIL.Image"] = _pil_image
+sys.modules["PIL.ImageDraw"] = _pil_image_draw
+
+
+# --- Stub aiohttp / numpy / tqdm ------------------------------------------
+for _mod in ("aiohttp", "numpy", "tqdm", "tqdm.asyncio"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = types.ModuleType(_mod)
+sys.modules["aiohttp"].FormData = object  # type: ignore[attr-defined]
+sys.modules["aiohttp"].ClientSession = object  # type: ignore[attr-defined]
+sys.modules["aiohttp"].ClientResponse = object  # type: ignore[attr-defined]
+sys.modules["numpy"].ndarray = object  # type: ignore[attr-defined]
+sys.modules["numpy"].array = lambda *a, **k: None  # type: ignore[attr-defined]
+sys.modules["numpy"].percentile = lambda *a, **k: 0.0  # type: ignore[attr-defined]
+sys.modules["numpy"].mean = lambda *a, **k: 0.0  # type: ignore[attr-defined]
+sys.modules["numpy"].isnan = lambda *a, **k: False  # type: ignore[attr-defined]
+sys.modules["tqdm"].tqdm = object  # type: ignore[attr-defined]
+sys.modules["tqdm.asyncio"].tqdm = object  # type: ignore[attr-defined]
+
+
+import asyncio  # noqa: E402
+
+from omni_benchmark_serving import benchmark, build_parser  # noqa: E402
+
+
+def _run(argv: list[str]) -> str:
+    args = build_parser().parse_args(argv)
+    out_buf: list[str] = []
+
+    class _Cap:
+        def write(self, s):
+            if s.strip():
+                out_buf.append(str(s).rstrip("\n"))
+
+        def flush(self):
+            pass
+
+    import builtins
+
+    real_print = builtins.print
+    builtins.print = lambda *a, **k: out_buf.append(" ".join(str(x) for x in a))  # type: ignore[assignment]
+    try:
+        asyncio.run(benchmark(args))
+    finally:
+        builtins.print = real_print  # type: ignore[assignment]
+    return "\n".join(out_buf)
+
+
+def test_dry_run_randomize_on():
+    out = _run(
+        [
+            "--num-i2t",
+            "7",
+            "--num-t2i",
+            "2",
+            "--num-it2i",
+            "1",
+            "--seed",
+            "7",
+            "--randomize-input",
+            "--dry-run",
+        ]
+    )
+    # New dry-run header includes the new columns.
+    assert "inWxH" in out, out
+    assert "prompt_words" in out, out
+    # The footer flags randomize_input=True.
+    assert "randomize_input=True" in out, out
+    # The tally section reports a randomized prompt word-count summary + input resolution.
+    assert "prompt word count (randomized)" in out, out
+    assert "i2t/it2i input-image resolution used:" in out, out
+    # inWxH column is non-"-" for i2t/it2i rows (sample the first i2t row).
+    assert "  i2t  " in out, out
+    print("=== dry-run --randomize-input output ===")
+    print(out)
+    print("\ntest_dry_run_randomize_on OK")
+
+
+def test_dry_run_randomize_off():
+    out = _run(
+        [
+            "--num-i2t",
+            "7",
+            "--num-t2i",
+            "2",
+            "--num-it2i",
+            "1",
+            "--seed",
+            "7",
+            "--dry-run",
+        ]
+    )
+    # No randomized tally when off.
+    assert "prompt word count (randomized)" not in out, out
+    assert "i2t/it2i input-image resolution used:" not in out, out
+    # The inWxH column shows "-" for all rows (no input randomization).
+    assert "inWxH" in out, out
+    print("\ntest_dry_run_randomize_off OK")
+
+
+def test_no_randomize_input_flag_default_false():
+    args = build_parser().parse_args(["--num-i2t", "1", "--dry-run"])
+    assert args.randomize_input is False
+    args2 = build_parser().parse_args(["--num-i2t", "1", "--randomize-input", "--dry-run"])
+    assert args2.randomize_input is True
+    args3 = build_parser().parse_args(["--num-i2t", "1", "--no-randomize-input", "--dry-run"])
+    assert args3.randomize_input is False
+    print("test_no_randomize_input_flag_default_false OK")
+
+
+def main() -> None:
+    test_no_randomize_input_flag_default_false()
+    test_dry_run_randomize_off()
+    test_dry_run_randomize_on()
+    print("\nAll CLI randomize-input tests passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/omni/_test_randomize_input.py
+++ b/benchmarks/omni/_test_randomize_input.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Isolated tests for the --randomize-input feature in omni_dataset.
+
+The local Python lacks PIL / aiohttp / tqdm, so we stub them before importing
+the benchmark modules. These tests exercise pure dataset-construction logic:
+prompt / input-resolution / image-content randomization, the input_image_size
+bookkeeping field, reproducibility via seed, and the no-op behavior when the
+flag is off (so legacy runs keep the exact same bot_task + shuffle sequence).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+# --- Stub PIL before any benchmark import ----------------------------------
+class _FakeImage:
+    def __init__(self, mode: str, size: tuple[int, int], color: tuple[int, int, int]):
+        self.mode = mode
+        self.size = size
+        self.color = color
+
+    def save(self, path: str) -> None:
+        # Write a tiny sentinel file so os.path.exists passes and the path can
+        # be re-opened. Encode (w, h, color) so tests can verify per-request
+        # uniqueness without a real PNG decoder.
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(f"{self.size[0]}x{self.size[1]}|{self.color[0]},{self.color[1]},{self.color[2]}")
+
+
+class _FakeImageDraw:
+    def __init__(self, img: _FakeImage):
+        self.img = img
+
+    def ellipse(self, bbox, fill=None):
+        pass
+
+    def rectangle(self, bbox, fill=None):
+        pass
+
+    def line(self, coords, fill=None, width=1):
+        pass
+
+
+# PIL.Image is a module exposing new() / open(); PIL.ImageDraw exposes Draw().
+_pil = types.ModuleType("PIL")
+_pil_image = types.ModuleType("PIL.Image")
+_pil_image.new = staticmethod(lambda mode, size, color: _FakeImage(mode, size, color))
+_pil_image.open = staticmethod(lambda path: _FakeImage("RGB", (0, 0), (0, 0, 0)))
+_pil_image.Image = _FakeImage
+_pil.Image = _pil_image
+_pil_image_draw = types.ModuleType("PIL.ImageDraw")
+_pil_image_draw.Draw = staticmethod(lambda img: _FakeImageDraw(img))
+sys.modules["PIL"] = _pil
+sys.modules["PIL.Image"] = _pil_image
+sys.modules["PIL.ImageDraw"] = _pil_image_draw
+
+
+# --- Stub aiohttp + tqdm for omni_backends import -------------------------
+for _mod in ("aiohttp", "tqdm", "tqdm.asyncio", "numpy"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = types.ModuleType(_mod)
+sys.modules["aiohttp"].FormData = object  # type: ignore[attr-defined]
+sys.modules["aiohttp"].ClientSession = object  # type: ignore[attr-defined]
+sys.modules["aiohttp"].ClientResponse = object  # type: ignore[attr-defined]
+sys.modules["tqdm"].tqdm = object  # type: ignore[attr-defined]
+# omni_benchmark_serving imports numpy as np and tqdm.asyncio.tqdm; not needed
+# here since we only test omni_dataset directly.
+
+# Make the sibling diffusion dir importable (omni_backends imports backends).
+_DIFFUSION = os.path.join(os.path.dirname(HERE), "diffusion")
+if _DIFFUSION not in sys.path:
+    sys.path.insert(0, _DIFFUSION)
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import random  # noqa: E402
+
+from omni_dataset import (  # noqa: E402  # noqa: E402
+    _INPUT_IMAGE_COUNTER,
+    DEFAULT_I2T_PROMPT,
+    DEFAULT_IT2I_PROMPT,
+    DEFAULT_T2I_PROMPT,
+    INPUT_RESOLUTIONS,
+    OmniConfig,
+    TaskCounts,
+    _draw_input_resolution,
+    _draw_prompt,
+    _generate_diverse_image,
+    build_requests,
+)
+
+
+def _base_kwargs(**over):
+    kw = dict(
+        counts=TaskCounts(i2t=7, t2i=2, it2i=1),
+        config=OmniConfig(),
+        dataset="random",
+        dataset_path=None,
+        bot_task_weights={"recaption": 1.0, "think": 1.0, "think_recaption": 1.0},
+        input_image=None,
+        prompts={},
+        chat_url="http://x/v1/chat/completions",
+        images_edits_url="http://x/v1/images/edits",
+        return_stage_metrics=False,
+        it2i_endpoint="chat",
+        seed=7,
+        shuffle=True,
+    )
+    kw.update(over)
+    return kw
+
+
+def test_draw_prompt_picks_from_pool():
+    rng = random.Random(7)
+    seen_i2t = {_draw_prompt("i2t", rng) for _ in range(200)}
+    seen_t2i = {_draw_prompt("t2i", rng) for _ in range(200)}
+    seen_it2i = {_draw_prompt("it2i", rng) for _ in range(200)}
+    # Drawing 200 times from a 10-item pool should hit most of them.
+    assert len(seen_i2t) >= 8, seen_i2t
+    assert len(seen_t2i) >= 8, seen_t2i
+    assert len(seen_it2i) >= 8, seen_it2i
+    # Prompts should vary in length (the pool is ordered short -> long).
+    lens = sorted(len(p.split()) for p in seen_i2t)
+    assert lens[0] < lens[-1], lens
+    print("test_draw_prompt_picks_from_pool OK")
+
+
+def test_draw_input_resolution_valid():
+    rng = random.Random(11)
+    for _ in range(100):
+        w, h = _draw_input_resolution(rng)
+        assert (w, h) in INPUT_RESOLUTIONS.values(), (w, h)
+    # Over many draws, all three sizes should appear.
+    draws = {_draw_input_resolution(rng) for _ in range(300)}
+    assert draws == set(INPUT_RESOLUTIONS.values()), draws
+    print("test_draw_input_resolution_valid OK")
+
+
+def test_generate_diverse_image_unique_per_call():
+    rng = random.Random(3)
+    paths = [_generate_diverse_image(rng, 512, 512) for _ in range(5)]
+    # Each call returns a distinct temp-file path.
+    assert len(set(paths)) == 5, paths
+    # Files exist on disk (the fake image writes a sentinel).
+    for p in paths:
+        assert os.path.exists(p), p
+    # Contents differ (different random palette -> different sentinel string).
+    contents = []
+    for p in paths:
+        with open(p, encoding="utf-8") as f:
+            contents.append(f.read())
+    assert len(set(contents)) == 5, contents
+    # Clean up.
+    for p in paths:
+        os.remove(p)
+    print("test_generate_diverse_image_unique_per_call OK")
+
+
+def test_build_randomize_on_varies_inputs():
+    reqs = build_requests(**_base_kwargs(randomize_input=True))
+    assert len(reqs) == 10, len(reqs)
+    # i2t (7) + it2i (1) carry input images; t2i (2) do not.
+    with_img = [r for r in reqs if r.task_type in ("i2t", "it2i")]
+    without_img = [r for r in reqs if r.task_type == "t2i"]
+    assert len(with_img) == 8 and len(without_img) == 2
+
+    # Input-image paths are unique per i2t/it2i request (no shared placeholder).
+    img_paths = [r.image_paths[0] for r in with_img]
+    assert all(p and os.path.exists(p) for p in img_paths), img_paths
+    assert len(set(img_paths)) == 8, "input images should be unique per request"
+
+    # input_image_size recorded for every i2t/it2i, in the allowed set.
+    for r in with_img:
+        assert r.input_image_size in INPUT_RESOLUTIONS, r.input_image_size
+    for r in without_img:
+        assert r.input_image_size is None
+
+    # Prompts vary across all requests (length diversity across the whole list).
+    prompts = [r.prompt for r in reqs]
+    assert len(set(prompts)) >= 6, f"expected diverse prompts, got {len(set(prompts))} unique"
+    # And they come from the random pools, not the fixed defaults.
+    assert all(p != DEFAULT_I2T_PROMPT for p in [r.prompt for r in reqs if r.task_type == "i2t"])
+    assert all(p != DEFAULT_T2I_PROMPT for p in [r.prompt for r in reqs if r.task_type == "t2i"])
+
+    # Clean up generated temp images.
+    for p in img_paths:
+        if os.path.exists(p):
+            os.remove(p)
+    print("test_build_randomize_on_varies_inputs OK")
+
+
+def test_build_randomize_off_legacy_behavior():
+    """With randomize_input=False, no input_image_size, single placeholder, no
+    generated temp images, and prompts are the fixed defaults."""
+    _INPUT_IMAGE_COUNTER["n"] = 0
+    reqs = build_requests(**_base_kwargs(randomize_input=False))
+    # No input_image_size recorded.
+    assert all(r.input_image_size is None for r in reqs)
+    # All i2t/it2i share the SAME placeholder path.
+    with_img = [r for r in reqs if r.task_type in ("i2t", "it2i")]
+    paths = {r.image_paths[0] for r in with_img}
+    assert len(paths) == 1, f"expected single shared placeholder, got {paths}"
+    # No diverse input images were generated (counter untouched).
+    assert _INPUT_IMAGE_COUNTER["n"] == 0, _INPUT_IMAGE_COUNTER["n"]
+    # Prompts are the fixed defaults.
+    assert all(r.prompt == DEFAULT_I2T_PROMPT for r in reqs if r.task_type == "i2t")
+    assert all(r.prompt == DEFAULT_T2I_PROMPT for r in reqs if r.task_type == "t2i")
+    assert all(r.prompt == DEFAULT_IT2I_PROMPT for r in reqs if r.task_type == "it2i")
+    print("test_build_randomize_off_legacy_behavior OK")
+
+
+def test_reproducible_same_seed():
+    def build():
+        # Reset the per-process image-id counter so two in-process builds
+        # produce identical temp-file paths (mirrors fresh-process runs).
+        _INPUT_IMAGE_COUNTER["n"] = 0
+        return build_requests(**_base_kwargs(randomize_input=True))
+
+    a = build()
+    b = build()
+    assert [r.prompt for r in a] == [r.prompt for r in b], "prompts differ across runs"
+    assert [r.input_image_size for r in a] == [r.input_image_size for r in b], "sizes differ"
+    a_imgs = [r.image_paths[0] for r in a if r.image_paths]
+    b_imgs = [r.image_paths[0] for r in b if r.image_paths]
+    assert a_imgs == b_imgs, "paths differ"
+    # Clean up.
+    for r in a:
+        if r.image_paths and os.path.exists(r.image_paths[0]):
+            os.remove(r.image_paths[0])
+    # The second build created its own temp files; clean those too.
+    for r in b:
+        if r.image_paths and os.path.exists(r.image_paths[0]):
+            os.remove(r.image_paths[0])
+    print("test_reproducible_same_seed OK")
+
+
+def test_randomize_off_preserves_legacy_sequence():
+    """The bot_task + shuffle sequence when randomize_input=False must match a
+    build that never knew the flag existed (no extra rng draws). We approximate
+    that by comparing two off-builds with different seeds and confirming the
+    it2i bot_task assignment + shuffle order are seed-determined and stable
+    across re-runs (reproducibility), which is the property we must not break."""
+    r1 = build_requests(**_base_kwargs(seed=7, randomize_input=False))
+    r2 = build_requests(**_base_kwargs(seed=7, randomize_input=False))
+    assert [r.bot_task for r in r1 if r.task_type == "it2i"] == [r.bot_task for r in r2 if r.task_type == "it2i"]
+    assert [r.task_type for r in r1] == [r.task_type for r in r2]  # shuffle order stable
+    # A different seed changes the shuffle order (sanity: shuffle actually runs).
+    r3 = build_requests(**_base_kwargs(seed=99, randomize_input=False))
+    assert [r.task_type for r in r1] != [r.task_type for r in r3] or len(r1) == 1
+    print("test_randomize_off_preserves_legacy_sequence OK")
+
+
+def test_randomize_skipped_for_custom_dataset():
+    """randomize_input is a no-op for dataset='custom' (rows win)."""
+    import json
+    import tempfile
+
+    tmp = tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False, encoding="utf-8")
+    for t in ("i2t", "t2i", "it2i"):
+        tmp.write(json.dumps({"task": t, "prompt": f"custom-{t}-prompt"}) + "\n")
+    tmp.close()
+    try:
+        reqs = build_requests(**_base_kwargs(dataset="custom", dataset_path=tmp.name, randomize_input=True))
+        # Custom prompts win (not from the random pools).
+        assert all(r.prompt.startswith("custom-") for r in reqs), [r.prompt for r in reqs]
+        # No input_image_size recorded (custom path doesn't set it).
+        assert all(r.input_image_size is None for r in reqs)
+    finally:
+        os.remove(tmp.name)
+    print("test_randomize_skipped_for_custom_dataset OK")
+
+
+def test_no_shuffle_group_order_with_randomize():
+    """randomize_input + --no-shuffle still respects group_order grouping."""
+    reqs = build_requests(**_base_kwargs(shuffle=False, group_order=("t2i", "i2t", "it2i"), randomize_input=True))
+    types_seq = [r.task_type for r in reqs]
+    # All t2i first, then all i2t, then it2i.
+    assert types_seq == ["t2i"] * 2 + ["i2t"] * 7 + ["it2i"] * 1, types_seq
+    # Clean up.
+    for r in reqs:
+        if r.image_paths and os.path.exists(r.image_paths[0]):
+            os.remove(r.image_paths[0])
+    print("test_no_shuffle_group_order_with_randomize OK")
+
+
+def main() -> None:
+    test_draw_prompt_picks_from_pool()
+    test_draw_input_resolution_valid()
+    test_generate_diverse_image_unique_per_call()
+    test_build_randomize_on_varies_inputs()
+    test_build_randomize_off_legacy_behavior()
+    test_reproducible_same_seed()
+    test_randomize_off_preserves_legacy_sequence()
+    test_randomize_skipped_for_custom_dataset()
+    test_no_shuffle_group_order_with_randomize()
+    print("\nAll randomize-input tests passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/omni/omni_backends.py
+++ b/benchmarks/omni/omni_backends.py
@@ -1,0 +1,803 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Request I/O types and async request functions for the omni serving benchmark.
+
+Reuses ``diffusion/backends.py`` for the base ``RequestFuncInput`` /
+``RequestFuncOutput`` shapes and small image-encoding helpers, but keeps all
+omni-specific state and senders here so the diffusion benchmark stays
+unmodified:
+
+* ``OmniRequest`` — a ``RequestFuncInput`` subclass carrying the client-side
+  task label (``i2t`` / ``t2i`` / ``it2i``), the sampled ``bot_task``, and the
+  send-time image caches (``image_data_urls`` / ``image_bytes``). None of these
+  are sent to the server; the server resolves the task type itself from
+  ``modalities`` plus the presence of a reference image (see
+  ``serving_chat._resolve_omni_task_type``).
+* ``OmniRequestFuncOutput`` — a ``RequestFuncOutput`` subclass adding the
+  text-streaming metrics (``ttft`` / ``itl`` / ``output_tokens`` /
+  ``generated_text``) captured by the streaming senders; non-stream senders
+  leave them at their defaults.
+* ``async_request_omni_chat`` — a thin wrapper over
+  ``async_request_chat_completions`` that lifts ``modalities`` (and a few
+  generation knobs) from ``extra_body`` into the JSON payload so the same
+  ``/v1/chat/completions`` endpoint can carry i2t (``modalities=["text"]``) and
+  t2i/it2i (``modalities=["image"]``) traffic, and that parses stage metrics
+  from both the image-output (``content`` is a list) and text-output
+  (``content`` is a string) response shapes.
+* ``async_request_image_edits`` — an omni /v1/images/edits (non-stream) sender
+  (the diffusion one is not imported) that reuses the shared form builder.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+import time
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass, field
+from typing import Any
+
+import aiohttp
+from tqdm import tqdm
+
+# ``backends`` lives in the sibling ``diffusion`` benchmark directory. Make that
+# directory importable regardless of the caller's CWD.
+_DIFFUSION_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "diffusion")
+if _DIFFUSION_DIR not in sys.path:
+    sys.path.insert(0, _DIFFUSION_DIR)
+
+from backends import (  # noqa: E402  (import after sys.path tweak)
+    DEFAULT_EDITS_BOT_TASK,
+    RequestFuncInput,
+    RequestFuncOutput,
+    _encode_image_as_data_url,
+    _guess_mime_type,
+)
+
+# Top-level request fields the OpenAI chat endpoint understands and that the
+# omni benchmark drives through ``extra_body``.
+_CHAT_TOPLEVEL_FROM_EXTRA = ("modalities", "max_tokens", "temperature", "top_p", "seed")
+
+# Tasks the it2i bot_task can take on. Keep in sync with
+# hunyuan_image3/prompt_utils._BOT_TASK_PRESETS (minus ``vanilla``/``None`` which
+# are plain-mode and not part of the "thinking intensity" sweep).
+IT2I_BOT_TASKS = ("recaption", "think", "think_recaption")
+
+
+@dataclass
+class OmniRequest(RequestFuncInput):
+    """A chat/edits request tagged with its client-side task type.
+
+    ``task_type`` and ``bot_task`` are benchmark-side bookkeeping only — they
+    drive per-task / per-bot_task statistics and never enter the HTTP payload.
+    The server classifies the request from ``modalities`` (+ reference image).
+
+    ``image_data_urls`` / ``image_bytes`` are send-time caches populated by
+    ``prepare_request_images`` (pre-read + pre-encode the input images once) so
+    the senders skip file I/O and base64 under concurrency. They live here on
+    the omni subclass — the diffusion ``RequestFuncInput`` is left untouched.
+    """
+
+    task_type: str = ""
+    bot_task: str | None = None
+    # Bookkeeping only (never sent). Under --randomize-input this records the
+    # generated input image's "WxH" so the tally / JSON can show the realized
+    # input-resolution distribution without re-reading the image file.
+    input_image_size: str | None = None
+    # Send-time caches (never sent). Populated by prepare_request_images.
+    image_data_urls: list[str] | None = None
+    image_bytes: list[bytes] | None = None
+
+
+@dataclass
+class OmniRequestFuncOutput(RequestFuncOutput):
+    """Omni-benchmark output — adds text-streaming metrics on top of the
+    diffusion ``RequestFuncOutput``.
+
+    ``ttft`` / ``itl`` / ``output_tokens`` / ``generated_text`` are only set by
+    the streaming senders (AR-text TTFT/ITL); non-stream senders leave the
+    defaults so the aggregate stats can read them uniformly (``o.ttft <= 0.0``
+    marks a request that produced no AR text). Kept on this subclass so the
+    diffusion ``RequestFuncOutput`` is left untouched.
+    """
+
+    ttft: float = 0.0
+    itl: list[float] = field(default_factory=list)
+    output_tokens: int = 0
+    generated_text: str = ""
+
+
+def prepare_request_images(req: OmniRequest) -> None:
+    """Pre-read + pre-encode ``req``'s input images into on-request caches.
+
+    Run once in a prep pass (outside the timed send) so the senders skip file
+    I/O and base64 at send time. This keeps the event loop from blocking under
+    concurrency and — together with ordered dispatch in the benchmark driver —
+    makes the actual send order match the dry-run order exactly, instead of
+    being raced by per-task prep cost: t2i has no image, it2i builds a multipart
+    form, i2t base64-encodes a data URL, so without pre-encoding the
+    fastest-prep group reaches the server first regardless of list order.
+    Idempotent; a no-op for requests without input images.
+    """
+    if not req.image_paths:
+        return
+    if req.image_data_urls is not None and req.image_bytes is not None:
+        return
+    urls: list[str] = []
+    raws: list[bytes] = []
+    for p in req.image_paths:
+        if not os.path.exists(p):
+            raise FileNotFoundError(p)
+        with open(p, "rb") as f:
+            raw = f.read()
+        raws.append(raw)
+        mime = _guess_mime_type(p)
+        urls.append(f"data:{mime};base64,{base64.b64encode(raw).decode('utf-8')}")
+    if req.image_data_urls is None:
+        req.image_data_urls = urls
+    if req.image_bytes is None:
+        req.image_bytes = raws
+
+
+def _parse_chat_stage_metrics(resp_json: dict[str, Any]) -> tuple[dict[str, float], float]:
+    """Extract (stage_durations, peak_memory_mb) from a chat-completions body.
+
+    Image-output responses put them on ``choices[0].message.content[0]``; the
+    text-output path (i2t) puts them on the root-level ``metrics`` object.
+    """
+    stage_durations: dict[str, float] = {}
+    peak_memory_mb = 0.0
+
+    choices = resp_json.get("choices", [])
+    if isinstance(choices, list) and choices:
+        content = (choices[0] or {}).get("message", {}).get("content")
+        if isinstance(content, list) and content:
+            first = content[0]
+            if isinstance(first, dict):
+                sd = first.get("stage_durations")
+                if isinstance(sd, dict):
+                    stage_durations = {str(k): float(v) for k, v in sd.items()}
+                pm = first.get("peak_memory_mb")
+                if isinstance(pm, (int, float)):
+                    peak_memory_mb = float(pm)
+
+    if not stage_durations or peak_memory_mb == 0.0:
+        metrics = resp_json.get("metrics")
+        if isinstance(metrics, dict):
+            if not stage_durations:
+                sd = metrics.get("stage_durations")
+                if isinstance(sd, dict):
+                    stage_durations = {str(k): float(v) for k, v in sd.items()}
+            if peak_memory_mb == 0.0:
+                pm = metrics.get("peak_memory_mb")
+                if isinstance(pm, (int, float)):
+                    peak_memory_mb = float(pm)
+
+    return stage_durations, peak_memory_mb
+
+
+def _first_message_content(resp_json: dict[str, Any]) -> Any:
+    """Return ``choices[0].message.content`` (str for i2t, list for t2i/it2i) or None."""
+    choices = resp_json.get("choices", [])
+    if isinstance(choices, list) and choices:
+        return (choices[0] or {}).get("message", {}).get("content")
+    return None
+
+
+def extract_chat_outputs(resp_json: dict[str, Any]) -> tuple[str | None, str | None, int]:
+    """Extract (returned_text, cot_output, num_images) from a chat-completions body.
+
+    * i2t (text output): ``content`` is a string -> the model's answer.
+    * t2i / it2i (image output): ``content`` is a list of ``image_url`` items;
+      returned_text is None and num_images counts the image items.
+
+    ``cot_output`` (the AR-stage "thinking" text) is NOT exposed by the current
+    chat image response, so it is returned as None on this path. The lookup is
+    kept tolerant: if a future server change surfaces it on a content item it
+    will be picked up without a benchmark change. Use the /v1/images/edits
+    endpoint (see :func:`extract_edits_outputs`) to obtain the AR thinking text
+    today — its response carries ``cot_output`` at the root.
+    """
+    content = _first_message_content(resp_json)
+    if isinstance(content, str):
+        return content or None, None, 0
+    if isinstance(content, list):
+        cot_output: str | None = None
+        num_images = 0
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            if item.get("type") == "image_url":
+                num_images += 1
+            if cot_output is None:
+                co = item.get("cot_output")
+                if isinstance(co, str) and co.strip():
+                    cot_output = co
+        return None, cot_output, num_images
+    return None, None, 0
+
+
+def extract_edits_outputs(resp_json: dict[str, Any]) -> tuple[str | None, int]:
+    """Extract (cot_output, num_images) from a /v1/images/edits body.
+
+    The edits response is an ``ImageGenerationResponse``: ``data`` is a list of
+    ``{b64_json}`` image items and ``cot_output`` sits at the root — this is the
+    only endpoint that currently surfaces the AR-stage "thinking" text.
+    """
+    cot_output = resp_json.get("cot_output") if isinstance(resp_json, dict) else None
+    if not (isinstance(cot_output, str) and cot_output.strip()):
+        cot_output = None
+    data = resp_json.get("data", []) if isinstance(resp_json, dict) else []
+    num_images = sum(1 for d in data if isinstance(d, dict) and d.get("b64_json"))
+    return cot_output, num_images
+
+
+async def async_request_omni_chat(
+    input: OmniRequest,
+    session: aiohttp.ClientSession,
+    pbar: tqdm | None = None,
+) -> OmniRequestFuncOutput:
+    """POST /v1/chat/completions for any of i2t / t2i / it2i.
+
+    Mirrors ``async_request_chat_completions`` but hoists ``modalities`` (and a
+    few generation knobs) from ``extra_body`` to the payload root, and parses
+    stage metrics for both image- and text-output response shapes.
+    """
+    output = OmniRequestFuncOutput()
+    output.start_time = time.perf_counter()
+
+    extra_body = dict(input.extra_body)
+    modalities = extra_body.pop("modalities", None)
+
+    # Build the message content. Image-conditioned tasks (i2t, it2i) attach the
+    # input image; t2i is plain text.
+    content: list[dict[str, Any]] = []
+
+    if input.image_paths:
+        cached_urls = input.image_data_urls
+        for idx, img_path in enumerate(input.image_paths):
+            if cached_urls is not None and idx < len(cached_urls):
+                url = cached_urls[idx]
+            else:
+                if not os.path.exists(img_path):
+                    output.error = f"Image file not found: {img_path}"
+                    output.success = False
+                    if pbar:
+                        pbar.update(1)
+                    return output
+                url = _encode_image_as_data_url(img_path)
+            content.append(
+                {
+                    "type": "image_url",
+                    "image_url": {"url": url},
+                }
+            )
+
+    if input.prompt:
+        content.append({"type": "text", "text": input.prompt})
+
+    messages = [{"role": "user", "content": content}]
+
+    payload: dict[str, Any] = {
+        "model": input.model,
+        "messages": messages,
+        "max_tokens": 512,
+    }
+    if modalities is not None:
+        payload["modalities"] = modalities
+    if input.width and input.height:
+        payload["height"] = input.height
+        payload["width"] = input.width
+    if input.num_inference_steps is not None:
+        payload["num_inference_steps"] = input.num_inference_steps
+    if input.seed is not None:
+        payload["seed"] = input.seed
+
+    # Generation knobs the caller may have parked in extra_body.
+    for key in _CHAT_TOPLEVEL_FROM_EXTRA:
+        if key in extra_body and key not in payload:
+            payload[key] = extra_body[key]
+    # Anything else (e.g. negative_prompt, guidance_scale, bot_task for it2i)
+    # goes through extra_body as the diffusion path expects.
+    rest = {k: v for k, v in extra_body.items() if k not in _CHAT_TOPLEVEL_FROM_EXTRA}
+    if rest:
+        payload["extra_body"] = rest
+
+    try:
+        async with session.post(input.api_url, json=payload) as response:
+            if response.status == 200:
+                resp_json = await response.json()
+                output.response_body = resp_json
+                output.success = True
+                output.stage_durations, output.peak_memory_mb = _parse_chat_stage_metrics(resp_json)
+            else:
+                output.error = f"HTTP {response.status}: {await response.text()}"
+                output.success = False
+    except Exception as e:
+        output.error = str(e)
+        output.success = False
+
+    output.latency = time.perf_counter() - output.start_time
+    if output.success and input.slo_ms is not None:
+        output.slo_achieved = (output.latency * 1000.0) <= float(input.slo_ms)
+
+    if pbar:
+        pbar.update(1)
+    return output
+
+
+def _build_chat_payload(input: OmniRequest) -> dict[str, Any]:
+    """Build the /v1/chat/completions JSON body shared by the stream / non-stream senders."""
+    extra_body = dict(input.extra_body)
+    modalities = extra_body.pop("modalities", None)
+
+    content: list[dict[str, Any]] = []
+    if input.prompt:
+        content.append({"type": "text", "text": input.prompt})
+    if input.image_paths:
+        cached_urls = input.image_data_urls
+        for idx, img_path in enumerate(input.image_paths):
+            if cached_urls is not None and idx < len(cached_urls):
+                url = cached_urls[idx]
+            else:
+                if not os.path.exists(img_path):
+                    raise FileNotFoundError(img_path)
+                url = _encode_image_as_data_url(img_path)
+            content.append(
+                {
+                    "type": "image_url",
+                    "image_url": {"url": url},
+                }
+            )
+    messages = [{"role": "user", "content": content}]
+
+    payload: dict[str, Any] = {"model": input.model, "messages": messages}
+    if modalities is not None:
+        payload["modalities"] = modalities
+    if input.width and input.height:
+        payload["height"] = input.height
+        payload["width"] = input.width
+    if input.num_inference_steps is not None:
+        payload["num_inference_steps"] = input.num_inference_steps
+    if input.seed is not None:
+        payload["seed"] = input.seed
+    for key in _CHAT_TOPLEVEL_FROM_EXTRA:
+        if key in extra_body and key not in payload:
+            payload[key] = extra_body[key]
+    rest = {k: v for k, v in extra_body.items() if k not in _CHAT_TOPLEVEL_FROM_EXTRA}
+    if rest:
+        payload["extra_body"] = rest
+    return payload
+
+
+async def async_request_omni_chat_stream(
+    input: OmniRequest,
+    session: aiohttp.ClientSession,
+    pbar: tqdm | None = None,
+) -> OmniRequestFuncOutput:
+    """Streaming /v1/chat/completions that captures text-output TTFT / ITL.
+
+    Adds ``stream: True`` (+ ``include_usage``) and parses the SSE stream the
+    same way vLLM's ``async_request_openai_chat_completions`` does:
+
+    * i2t (``modalities=["text"]``): the AR stage is terminal and streams its
+      answer as ``choices[0].delta.content`` text deltas — TTFT is the time to
+      the first such delta, ITL is the per-delta gap, ``output_tokens`` comes
+      from the final ``usage.completion_tokens`` (falling back to the delta
+      count).
+    * t2i / it2i (``modalities=["image"]``): the server filters the AR "thinking"
+      text out of the chat stream (only the final image chunk is emitted), so
+      text TTFT/ITL stay 0 / N/A here — use ``--it2i-endpoint images-edits`` for
+      it2i AR-text latency. The image chunk is still parsed so the generated
+      image + stage metrics are reconstructed for the existing output path.
+
+    ``response_body`` is reconstructed from the stream so the non-stream
+    extraction / image-save logic in ``omni_benchmark_serving`` works unchanged.
+    """
+    output = OmniRequestFuncOutput()
+    output.start_time = time.perf_counter()
+
+    try:
+        payload = _build_chat_payload(input)
+    except FileNotFoundError as e:
+        output.error = f"Image file not found: {e}"
+        output.success = False
+        if pbar:
+            pbar.update(1)
+        return output
+    payload["stream"] = True
+    payload["stream_options"] = {"include_usage": True}
+
+    generated_text = ""
+    ttft = 0.0
+    itl: list[float] = []
+    most_recent = output.start_time
+    output_tokens = 0
+    image_content: list[dict[str, Any]] = []
+    finish_reason: str | None = None
+    metrics: dict[str, Any] | None = None
+
+    try:
+        async with session.post(input.api_url, json=payload) as response:
+            if response.status != 200:
+                output.error = f"HTTP {response.status}: {await response.text()}"
+                output.success = False
+            else:
+                async for data in _iter_sse_events(response):
+                    choices = data.get("choices")
+                    if isinstance(choices, list) and choices:
+                        choice = choices[0] or {}
+                        delta = choice.get("delta") or {}
+                        content = delta.get("content")
+                        # Text delta (i2t AR answer; also AR CoT if the server
+                        # ever streams it for image tasks).
+                        if isinstance(content, str) and content:
+                            ts = time.perf_counter()
+                            if ttft == 0.0:
+                                ttft = ts - output.start_time
+                            else:
+                                itl.append(ts - most_recent)
+                            generated_text += content
+                            most_recent = ts
+                        # Image delta (chat t2i/it2i): content is a list of
+                        # {type:image_url, image_url:{url}, stage_durations, ...}.
+                        elif isinstance(content, list) and content:
+                            image_content.extend(content)
+                        if choice.get("finish_reason"):
+                            finish_reason = choice.get("finish_reason")
+                    usage = data.get("usage")
+                    if isinstance(usage, dict) and usage.get("completion_tokens"):
+                        output_tokens = int(usage["completion_tokens"])
+                    m = data.get("metrics")
+                    if isinstance(m, dict):
+                        metrics = m
+                output.success = True
+    except Exception as e:
+        output.error = str(e)
+        output.success = False
+
+    output.latency = time.perf_counter() - output.start_time
+    output.ttft = ttft
+    output.itl = itl
+    output.generated_text = generated_text
+    if output_tokens:
+        output.output_tokens = output_tokens
+    elif itl:
+        # No usage chunk (server may omit usage for image tasks); approximate
+        # token count by the number of text deltas (== itl entries + 1).
+        output.output_tokens = len(itl) + 1
+
+    # Reconstruct a non-stream-equivalent body so extract_chat_outputs /
+    # _collect_image_urls / _parse_chat_stage_metrics keep working.
+    if output.success:
+        if image_content:
+            output.response_body = {
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"content": image_content},
+                        "finish_reason": finish_reason or "stop",
+                    }
+                ]
+            }
+        else:
+            output.response_body = {
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"content": generated_text},
+                        "finish_reason": finish_reason or "stop",
+                    }
+                ]
+            }
+        if metrics is not None:
+            output.response_body["metrics"] = metrics
+        output.stage_durations, output.peak_memory_mb = _parse_chat_stage_metrics(output.response_body)
+
+    if output.success and input.slo_ms is not None:
+        output.slo_achieved = (output.latency * 1000.0) <= float(input.slo_ms)
+
+    if pbar:
+        pbar.update(1)
+    return output
+
+
+def _build_edits_form(
+    input: OmniRequest,
+    stream: bool,
+    *,
+    with_stage_metrics_flag: bool = True,
+) -> aiohttp.FormData:
+    """Build the /v1/images/edits multipart form (shared by stream / non-stream).
+
+    Raises FileNotFoundError if a referenced image is missing so the caller can
+    surface it as a per-request error without sending.
+
+    ``with_stage_metrics_flag`` gates the ``return_stage_metrics`` form field.
+    The streaming sender forwards it (the server emits per-stage timings on the
+    stream); the non-stream sender omits it to match the diffusion edits sender
+    it replaces (which never forwarded that flag).
+    """
+    extra_body = dict(input.extra_body)
+    width = input.width or extra_body.get("width") or 1024
+    height = input.height or extra_body.get("height") or 1024
+
+    form = aiohttp.FormData()
+    form.add_field("model", input.model)
+    form.add_field("prompt", input.prompt)
+    form.add_field("size", f"{width}x{height}")
+    form.add_field("response_format", "b64_json")
+    if stream:
+        form.add_field("stream", "true")
+
+    if input.num_inference_steps is not None:
+        form.add_field("num_inference_steps", str(input.num_inference_steps))
+    elif extra_body.get("num_inference_steps") is not None:
+        form.add_field("num_inference_steps", str(extra_body["num_inference_steps"]))
+    if input.seed is not None:
+        form.add_field("seed", str(input.seed))
+    elif extra_body.get("seed") is not None:
+        form.add_field("seed", str(extra_body["seed"]))
+    if extra_body.get("guidance_scale") is not None:
+        form.add_field("guidance_scale", str(extra_body["guidance_scale"]))
+    if extra_body.get("negative_prompt") is not None:
+        form.add_field("negative_prompt", str(extra_body["negative_prompt"]))
+    if extra_body.get("true_cfg_scale") is not None:
+        form.add_field("true_cfg_scale", str(extra_body["true_cfg_scale"]))
+    if extra_body.get("sys_type") is not None:
+        form.add_field("sys_type", str(extra_body["sys_type"]))
+    if extra_body.get("system_prompt") is not None:
+        form.add_field("system_prompt", str(extra_body["system_prompt"]))
+    if with_stage_metrics_flag and extra_body.get("return_stage_metrics"):
+        form.add_field("return_stage_metrics", "true")
+
+    bot_task = input.bot_task or extra_body.get("bot_task") or input.default_bot_task
+    if bot_task is not None:
+        form.add_field("bot_task", str(bot_task))
+
+    assert input.image_paths is not None
+    cached_bytes = input.image_bytes
+    for idx, img_path in enumerate(input.image_paths):
+        if cached_bytes is not None and idx < len(cached_bytes):
+            image_bytes = cached_bytes[idx]
+        else:
+            if not os.path.exists(img_path):
+                raise FileNotFoundError(img_path)
+            with open(img_path, "rb") as img_f:
+                image_bytes = img_f.read()
+        form.add_field(
+            "image",
+            image_bytes,
+            filename=os.path.basename(img_path),
+            content_type=_guess_mime_type(img_path),
+        )
+    return form
+
+
+async def async_request_image_edits(
+    input: OmniRequest,
+    session: aiohttp.ClientSession,
+    pbar: tqdm | None = None,
+) -> OmniRequestFuncOutput:
+    """POST /v1/images/edits (multipart, non-streaming) for it2i.
+
+    Omni-benchmark counterpart of the diffusion edits sender: builds the form
+    via ``_build_edits_form`` (which honors the ``input.image_bytes`` cache so
+    the send skips file I/O) and returns a ``OmniRequestFuncOutput`` so the
+    aggregate stats can read ``ttft`` / ``itl`` / ``output_tokens`` /
+    ``generated_text`` uniformly — non-stream leaves them at their defaults
+    (``ttft == 0.0`` marks "no AR text captured").
+    """
+    output = OmniRequestFuncOutput()
+    output.start_time = time.perf_counter()
+
+    try:
+        form = _build_edits_form(input, stream=False, with_stage_metrics_flag=False)
+    except FileNotFoundError as e:
+        output.error = f"Image file not found: {e}"
+        output.success = False
+        if pbar:
+            pbar.update(1)
+        return output
+
+    try:
+        async with session.post(input.api_url, data=form) as response:
+            if response.status == 200:
+                resp_json = await response.json()
+                output.response_body = resp_json
+                output.success = True
+            else:
+                output.error = f"HTTP {response.status}: {await response.text()}"
+                output.success = False
+    except Exception as e:
+        output.error = str(e)
+        output.success = False
+
+    output.latency = time.perf_counter() - output.start_time
+    if output.success and input.slo_ms is not None:
+        output.slo_achieved = (output.latency * 1000.0) <= float(input.slo_ms)
+
+    if pbar:
+        pbar.update(1)
+    return output
+
+
+async def async_request_image_edits_stream(
+    input: OmniRequest,
+    session: aiohttp.ClientSession,
+    pbar: tqdm | None = None,
+) -> OmniRequestFuncOutput:
+    """Streaming /v1/images/edits that captures AR-text TTFT / ITL for it2i.
+
+    The multi-stage edits stream emits ``ImageEditARDeltaChunk`` (``type=
+    "ar_delta"``, ``delta`` = an AR-stage text token) for each AR decode step,
+    then a single ``ImageEditImageChunk`` (``type="image"``) with the final
+    image. TTFT is the time to the first ``ar_delta``; ITL is the per-delta gap;
+    ``output_tokens`` is the ``ar_delta`` count (each ≈ one AR decode step); the
+    concatenated deltas are the AR "thinking" (CoT) text. The image + stage
+    metrics are reconstructed into ``response_body`` so the existing edits output
+    path (``extract_edits_outputs`` / image save) works unchanged.
+    """
+    output = OmniRequestFuncOutput()
+    output.start_time = time.perf_counter()
+
+    try:
+        form = _build_edits_form(input, stream=True)
+    except FileNotFoundError as e:
+        output.error = f"Image file not found: {e}"
+        output.success = False
+        if pbar:
+            pbar.update(1)
+        return output
+
+    generated_text = ""
+    ttft = 0.0
+    itl: list[float] = []
+    most_recent = output.start_time
+    ar_delta_count = 0
+    images_b64: list[str] = []
+    stage_durations: dict[str, float] = {}
+    peak_memory_mb = 0.0
+    stream_error: str | None = None
+
+    try:
+        async with session.post(input.api_url, data=form) as response:
+            if response.status != 200:
+                output.error = f"HTTP {response.status}: {await response.text()}"
+                output.success = False
+            else:
+                async for data in _iter_sse_events(response):
+                    obj = data.get("object")
+                    ctype = data.get("type")
+                    if obj == "error":
+                        err = data.get("error")
+                        if isinstance(err, dict):
+                            stream_error = str(err.get("message") or err)
+                        else:
+                            stream_error = str(err)
+                        continue
+                    if ctype == "ar_delta":
+                        delta = data.get("delta") or ""
+                        if delta:
+                            ts = time.perf_counter()
+                            if ttft == 0.0:
+                                ttft = ts - output.start_time
+                            else:
+                                itl.append(ts - most_recent)
+                            generated_text += delta
+                            most_recent = ts
+                            ar_delta_count += 1
+                        # AR-stage metrics ride on ar_delta chunks; merge them in
+                        # (the DiT-stage metrics come on the final image chunk).
+                        m = data.get("metrics")
+                        if isinstance(m, dict):
+                            _merge_stage_metrics(m, stage_durations)
+                    elif ctype == "image":
+                        for d in data.get("data", []) or []:
+                            if isinstance(d, dict) and d.get("b64_json"):
+                                images_b64.append(d["b64_json"])
+                        m = data.get("metrics")
+                        if isinstance(m, dict):
+                            _merge_stage_metrics(m, stage_durations)
+                            pm = m.get("peak_memory_mb")
+                            if isinstance(pm, (int, float)):
+                                peak_memory_mb = float(pm)
+                if stream_error:
+                    output.error = stream_error
+                    output.success = False
+                else:
+                    output.success = True
+    except Exception as e:
+        output.error = str(e)
+        output.success = False
+
+    output.latency = time.perf_counter() - output.start_time
+    output.ttft = ttft
+    output.itl = itl
+    output.output_tokens = ar_delta_count
+    output.generated_text = generated_text
+    output.stage_durations = stage_durations
+    output.peak_memory_mb = peak_memory_mb
+
+    if output.success:
+        output.response_body = {
+            "data": [{"b64_json": b64} for b64 in images_b64],
+            "cot_output": generated_text or None,
+        }
+
+    if output.success and input.slo_ms is not None:
+        output.slo_achieved = (output.latency * 1000.0) <= float(input.slo_ms)
+
+    if pbar:
+        pbar.update(1)
+    return output
+
+
+def select_request_func(req: OmniRequest, it2i_endpoint: str, stream: bool = False):
+    """Pick the sender for a request given the configured it2i endpoint + stream.
+
+    ``it2i_endpoint`` is ``"chat"`` (default, unified) or ``"images-edits"``.
+    i2t and t2i always go through chat; it2i follows the configured endpoint.
+    ``stream=True`` selects the streaming variant of each sender so the benchmark
+    can capture text-output TTFT/ITL (i2t AR answer; it2i AR thinking via edits).
+    """
+    if req.task_type == "it2i" and it2i_endpoint == "images-edits":
+        return async_request_image_edits_stream if stream else async_request_image_edits
+    return async_request_omni_chat_stream if stream else async_request_omni_chat
+
+
+def _merge_stage_metrics(
+    metrics: dict[str, Any],
+    target: dict[str, float],
+) -> None:
+    """Fold a chunk's ``metrics.stage_durations`` into ``target`` (first write wins)."""
+    sd = metrics.get("stage_durations")
+    if isinstance(sd, dict):
+        for k, v in sd.items():
+            target.setdefault(str(k), float(v))
+
+
+async def _iter_sse_events(
+    response: aiohttp.ClientResponse,
+) -> AsyncGenerator[dict[str, Any], None]:
+    """Yield parsed JSON payloads from an SSE ``text/event-stream`` response.
+
+    Mirrors vLLM's ``async_request_openai_chat_completions`` chunk loop: skip
+    blank lines and keep-alive comments (``: ...``), strip the ``data: `` prefix,
+    stop at ``[DONE]``, and ``json.loads`` the rest. Malformed lines are skipped
+    rather than raised so a trailing partial line never aborts the whole stream.
+    """
+    async for raw in response.content:
+        line = raw.strip()
+        if not line:
+            continue
+        text = line.decode("utf-8", errors="replace")
+        if text.startswith(":"):
+            continue
+        if not text.startswith("data:"):
+            continue
+        payload = text.removeprefix("data:").strip()
+        if payload == "[DONE]":
+            break
+        try:
+            yield json.loads(payload)
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+
+__all__ = [
+    "IT2I_BOT_TASKS",
+    "OmniRequest",
+    "OmniRequestFuncOutput",
+    "DEFAULT_EDITS_BOT_TASK",
+    "prepare_request_images",
+    "async_request_omni_chat",
+    "async_request_omni_chat_stream",
+    "async_request_image_edits",
+    "async_request_image_edits_stream",
+    "select_request_func",
+    "extract_chat_outputs",
+    "extract_edits_outputs",
+]

--- a/benchmarks/omni/omni_benchmark_serving.py
+++ b/benchmarks/omni/omni_benchmark_serving.py
@@ -1,0 +1,1136 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Omni serving benchmark for unified understanding+generation models
+(e.g. HunyuanImage-3.0 AR+DiT).
+
+Sends a configurable mix of i2t (image understanding, text output), t2i
+(text-to-image) and it2i (image editing) requests to a vLLM-Omni serving
+endpoint and reports overall + per-task-type + per-bot_task latency /
+throughput statistics, with optional per-stage (AR / DiT) timings. This is the
+workload the DTPS scheduler (ar_only vs ar_downstream) is tuned for, so
+the output is shaped to support evaluating scheduling optimizations.
+
+Three task types are dispatched over ``/v1/chat/completions`` (the AR+DiT
+multi-stage path), distinguished by ``modalities`` and the presence of a
+reference image — exactly how ``serving_chat._resolve_omni_task_type`` classifies
+them. it2i may alternatively go through ``/v1/images/edits`` (``--it2i-endpoint
+images-edits``). it2i ``bot_task`` (recaption / think / think_recaption) is
+sampled per request by configurable weights to cover the three thinking
+intensities.
+
+Usage examples are in benchmarks/omni/README.md.
+
+Quick smoke (no server needed, --dry-run just prints the plan):
+    python benchmarks/omni/omni_benchmark_serving.py \
+        --num-i2t 70 --num-t2i 10 --num-it2i 20 --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import random
+import sys
+import time
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import aiohttp
+import numpy as np
+from tqdm.asyncio import tqdm
+
+# Make this directory importable when run as a script (omni_backends /
+# omni_dataset are sibling modules).
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+from omni_backends import (  # noqa: E402
+    IT2I_BOT_TASKS,
+    OmniRequest,
+    RequestFuncOutput,
+    extract_chat_outputs,
+    extract_edits_outputs,
+    prepare_request_images,
+    select_request_func,
+)
+from omni_dataset import (  # noqa: E402
+    GEN_RESOLUTIONS,
+    OmniConfig,
+    TaskCounts,
+    build_requests,
+    parse_bot_task_weights,
+    parse_gen_resolution_weights,
+)
+
+_TASK_TYPES = ("i2t", "t2i", "it2i")
+_CHAT_ENDPOINT = "/v1/chat/completions"
+_EDITS_ENDPOINT = "/v1/images/edits"
+
+
+def _parse_group_order(raw: str | None) -> tuple[str, ...]:
+    """Parse ``--no-shuffle-order`` (e.g. ``t2i,it2i,i2t``) into a tuple.
+
+    Must be a permutation of i2t/t2i/it2i; defaults to ``(i2t, t2i, it2i)``. Only
+    consulted when ``--no-shuffle`` is set (the merge is shuffled otherwise).
+    """
+    if not raw:
+        return _TASK_TYPES
+    parts = tuple(p.strip() for p in raw.split(",") if p.strip())
+    if set(parts) != set(_TASK_TYPES) or len(parts) != len(_TASK_TYPES):
+        raise ValueError(f"--no-shuffle-order must be a permutation of i2t,t2i,it2i, got {list(parts)!r}.")
+    return parts
+
+
+def _percentiles(values: list[float], ps: list[float]) -> dict[str, float]:
+    if not values:
+        return {f"p{p}": 0.0 for p in ps}
+    return {f"p{p}": float(np.percentile(values, p)) for p in ps}
+
+
+def _latency_stats(latencies: list[float]) -> dict[str, float]:
+    if not latencies:
+        return {
+            "count": 0,
+            "mean": 0.0,
+            "median": 0.0,
+            "p50": 0.0,
+            "p95": 0.0,
+            "p99": 0.0,
+        }
+    return {
+        "count": len(latencies),
+        "mean": float(np.mean(latencies)),
+        "median": float(np.median(latencies)),
+        "p50": float(np.percentile(latencies, 50)),
+        "p95": float(np.percentile(latencies, 95)),
+        "p99": float(np.percentile(latencies, 99)),
+    }
+
+
+def _aggregate_stage_durations(
+    outputs: list[RequestFuncOutput],
+) -> dict[str, dict[str, float]]:
+    """Mean / p50 / p99 of each named stage duration across the given outputs."""
+    buckets: dict[str, list[float]] = {}
+    for o in outputs:
+        for stage, val in (o.stage_durations or {}).items():
+            buckets.setdefault(str(stage), []).append(float(val))
+    result: dict[str, dict[str, float]] = {}
+    for stage, vals in buckets.items():
+        result[stage] = {
+            "count": len(vals),
+            "mean": float(np.mean(vals)),
+            "p50": float(np.percentile(vals, 50)),
+            "p99": float(np.percentile(vals, 99)),
+        }
+    return result
+
+
+def _latency_ms_stats(values: list[float], ps: list[float]) -> dict[str, Any]:
+    """mean / std / median / percentiles (ms) for a list of second-scale latencies.
+
+    Mirrors vLLM ``serve.py``'s ttft/tpot/itl aggregation (values are converted
+    to milliseconds). Returns zeroed fields when ``values`` is empty so the
+    shape is stable for JSON consumers.
+    """
+    if not values:
+        return {
+            "count": 0,
+            "mean_ms": 0.0,
+            "std_ms": 0.0,
+            "median_ms": 0.0,
+            **{f"p{p}_ms": 0.0 for p in ps},
+        }
+    arr = np.asarray(values, dtype=float) * 1000.0
+    return {
+        "count": int(arr.size),
+        "mean_ms": float(np.mean(arr)),
+        "std_ms": float(np.std(arr)),
+        "median_ms": float(np.median(arr)),
+        **{f"p{p}_ms": float(np.percentile(arr, p)) for p in ps},
+    }
+
+
+def _text_stream_metrics(
+    outputs: list[RequestFuncOutput],
+    ps: list[float],
+) -> dict[str, Any]:
+    """TTFT / TPOT / ITL aggregation over the streaming text outputs.
+
+    Only outputs that actually streamed text (``ttft > 0``) contribute — i.e.
+    i2t AR answers and it2i AR "thinking" text from the streaming senders.
+    Non-streaming runs and tasks whose text the server does not stream (chat
+    t2i/it2i) are simply absent (count=0), not counted as zero-latency samples.
+
+    Per-request TPOT follows vLLM's "time per output token excluding the first":
+    ``sum(itl) / (output_tokens - 1)`` when ``output_tokens > 1``, else 0. Using
+    the ITL sum (== last-text-time - ttft) instead of ``latency - ttft`` keeps
+    TPOT inside the text-stream window — for i2t this matches vLLM (AR is
+    terminal, latency ≈ last token); for it2i it correctly excludes the DiT
+    stage that runs after the AR text finishes. ITL itself is the flattened list
+    of every inter-token gap across the contributing requests.
+    """
+    ttfts: list[float] = []
+    tpots: list[float] = []
+    itls: list[float] = []
+    output_tokens: list[int] = []
+    for o in outputs:
+        if not o.success or o.ttft <= 0.0:
+            continue
+        ttfts.append(o.ttft)
+        output_tokens.append(o.output_tokens)
+        if o.output_tokens > 1:
+            tpots.append(sum(o.itl or []) / (o.output_tokens - 1))
+        else:
+            tpots.append(0.0)
+        itls.extend(o.itl or [])
+    return {
+        "measured_requests": len(ttfts),
+        "output_tokens": {
+            "total": int(sum(output_tokens)),
+            "mean": float(np.mean(output_tokens)) if output_tokens else 0.0,
+            "median": float(np.median(output_tokens)) if output_tokens else 0.0,
+            "max": int(max(output_tokens)) if output_tokens else 0,
+        },
+        "ttft": _latency_ms_stats(ttfts, ps),
+        "tpot": _latency_ms_stats(tpots, ps),
+        "itl": _latency_ms_stats(itls, ps),
+    }
+
+
+def _bucket_outputs(
+    requests_list: list[OmniRequest],
+    outputs: list[RequestFuncOutput],
+) -> dict[str, list[tuple[OmniRequest, RequestFuncOutput]]]:
+    """Group (req, out) pairs by task_type (and it2i by bot_task sub-key)."""
+    buckets: dict[str, list[tuple[OmniRequest, RequestFuncOutput]]] = {t: [] for t in _TASK_TYPES}
+    for req, out in zip(requests_list, outputs):
+        if req.task_type in buckets:
+            buckets[req.task_type].append((req, out))
+    return buckets
+
+
+def calculate_metrics(
+    requests_list: list[OmniRequest],
+    outputs: list[RequestFuncOutput],
+    total_duration: float,
+    selected_percentiles: list[float],
+) -> dict[str, Any]:
+    """Overall + per-task + per-bot_task metrics.
+
+    Per-task throughput uses the total benchmark duration as the denominator
+    (not the task's own span) so the three task throughputs sum to the overall
+    request throughput — directly comparable across runs / configs.
+    """
+    success_all = [o for o in outputs if o.success]
+    fail_all = [o for o in outputs if not o.success]
+    lat_all = [o.latency for o in success_all]
+
+    overall = {
+        "duration": total_duration,
+        "completed": len(success_all),
+        "failed": len(fail_all),
+        "throughput_qps": (len(success_all) / total_duration) if total_duration > 0 else 0.0,
+        **_latency_stats(lat_all),
+    }
+    overall["percentiles"] = _percentiles(lat_all, selected_percentiles)
+    peak_mems = [o.peak_memory_mb for o in success_all if o.peak_memory_mb > 0]
+    overall["peak_memory_mb"] = {
+        "max": float(max(peak_mems)) if peak_mems else 0.0,
+        "mean": float(np.mean(peak_mems)) if peak_mems else 0.0,
+    }
+    overall["stage_durations"] = _aggregate_stage_durations(success_all)
+    overall["text_stream"] = _text_stream_metrics(success_all, selected_percentiles)
+
+    per_task: dict[str, Any] = {}
+    buckets = _bucket_outputs(requests_list, outputs)
+    for task in _TASK_TYPES:
+        pairs = buckets[task]
+        succ = [(r, o) for r, o in pairs if o.success]
+        lats = [o.latency for _, o in succ]
+        per_task[task] = {
+            "total": len(pairs),
+            "completed": len(succ),
+            "failed": len(pairs) - len(succ),
+            "success_rate": (len(succ) / len(pairs)) if pairs else 0.0,
+            "throughput_qps": (len(succ) / total_duration) if total_duration > 0 else 0.0,
+            **_latency_stats(lats),
+            "percentiles": _percentiles(lats, selected_percentiles),
+            "stage_durations": _aggregate_stage_durations([o for _, o in succ]),
+            "text_stream": _text_stream_metrics([o for _, o in succ], selected_percentiles),
+        }
+
+    # it2i broken down by bot_task.
+    it2i_by_bot: dict[str, Any] = {}
+    it2i_pairs = buckets["it2i"]
+    if it2i_pairs:
+        by_bt: dict[str, list[tuple[OmniRequest, RequestFuncOutput]]] = {t: [] for t in IT2I_BOT_TASKS}
+        for r, o in it2i_pairs:
+            bt = r.bot_task or "none"
+            by_bt.setdefault(bt, []).append((r, o))
+        for bt, ps in by_bt.items():
+            if not ps:
+                continue
+            succ = [(r, o) for r, o in ps if o.success]
+            lats = [o.latency for _, o in succ]
+            it2i_by_bot[bt] = {
+                "total": len(ps),
+                "completed": len(succ),
+                "failed": len(ps) - len(succ),
+                "success_rate": (len(succ) / len(ps)) if ps else 0.0,
+                "throughput_qps": (len(succ) / total_duration) if total_duration > 0 else 0.0,
+                **_latency_stats(lats),
+                "percentiles": _percentiles(lats, selected_percentiles),
+                "stage_durations": _aggregate_stage_durations([o for _, o in succ]),
+                "text_stream": _text_stream_metrics([o for _, o in succ], selected_percentiles),
+            }
+
+    return {
+        "overall": overall,
+        "per_task": per_task,
+        "it2i_by_bot_task": it2i_by_bot,
+    }
+
+
+def _print_section(title: str) -> None:
+    print("\n" + "=" * 60)
+    print(f" {title} ")
+    print("=" * 60)
+
+
+def _print_latency_row(label: str, stats: dict[str, Any]) -> None:
+    print(
+        f"  {label:<22} n={stats.get('count', 0):<5} "
+        f"mean={stats.get('mean', 0):.3f}s "
+        f"p50={stats.get('p50', 0):.3f}s "
+        f"p95={stats.get('p95', 0):.3f}s "
+        f"p99={stats.get('p99', 0):.3f}s"
+    )
+
+
+def _print_text_stream(ts: dict[str, Any], indent: str = "  ") -> None:
+    """Print TTFT / TPOT / ITL + output-token stats from a text_stream bucket.
+
+    Only shown when the bucket actually measured streaming text outputs
+    (``measured_requests > 0``); non-streaming runs / N/A tasks stay silent.
+    """
+    n = ts.get("measured_requests", 0)
+    if not n:
+        return
+    out_tok = ts["output_tokens"]
+    print(
+        f"{indent}text-output (n={n}, out_tokens mean={out_tok['mean']:.1f} "
+        f"median={out_tok['median']:.1f} max={out_tok['max']}):"
+    )
+    for key, label in (("ttft", "TTFT"), ("tpot", "TPOT"), ("itl", "ITL")):
+        s = ts[key]
+        print(
+            f"{indent}  {label:<5} n={s['count']:<5} "
+            f"mean={s['mean_ms']:.2f}ms median={s['median_ms']:.2f}ms "
+            f"p50={s['p50_ms']:.2f}ms p95={s['p95_ms']:.2f}ms p99={s['p99_ms']:.2f}ms"
+        )
+
+
+def print_metrics(metrics: dict[str, Any], args: argparse.Namespace) -> None:
+    ov = metrics["overall"]
+    _print_section("Omni Serving Benchmark Result")
+
+    print(f"{'Endpoint (i2t/t2i):':<30} {_CHAT_ENDPOINT}")
+    print(f"{'Endpoint (it2i):':<30} " + (_EDITS_ENDPOINT if args.it2i_endpoint == "images-edits" else _CHAT_ENDPOINT))
+    print(f"{'Model:':<30} {args.model}")
+    print(f"{'Dataset:':<30} {args.dataset}")
+    print(f"{'Mix (i2t:t2i:it2i):':<30} {args.num_i2t}:{args.num_t2i}:{args.num_it2i}")
+    print(f"{'bot_task weights:':<30} {args.it2i_bot_task_weights}")
+    print(f"{'bot_task sampling:':<30} {args.it2i_bot_task_sampling}")
+    print(f"{'Shuffle:':<30} {args.shuffle}")
+    if not args.shuffle:
+        gorder = args.no_shuffle_order or "i2t,t2i,it2i (default)"
+        print(f"{'No-shuffle group order:':<30} {gorder}")
+    if args.gen_resolution_weights:
+        print(f"{'Gen resolution weights:':<30} {args.gen_resolution_weights}")
+        print(f"{'Gen resolution sampling:':<30} {args.gen_resolution_sampling}")
+    print(f"{'Randomize input:':<30} {args.randomize_input}")
+    print(f"{'Seed:':<30} {args.seed}")
+    out_dir = metrics.get("config", {}).get("output_dir")
+    if out_dir:
+        print(f"{'Output dir:':<30} {out_dir}")
+
+    print("-" * 60)
+    print(f"{'Benchmark duration (s):':<30} {ov['duration']:.2f}")
+    print(f"{'Request rate:':<30} {args.request_rate}")
+    print(f"{'Max concurrency:':<30} {args.max_concurrency}")
+    print(f"{'Successful requests:':<30} {ov['completed']}/{ov['completed'] + ov['failed']}")
+    print(f"{'Request throughput (req/s):':<30} {ov['throughput_qps']:.2f}")
+    print(f"{'Latency mean (s):':<30} {ov['mean']:.4f}")
+    print(f"{'Latency p50 (s):':<30} {ov['p50']:.4f}")
+    print(f"{'Latency p95 (s):':<30} {ov['p95']:.4f}")
+    print(f"{'Latency p99 (s):':<30} {ov['p99']:.4f}")
+
+    if ov["peak_memory_mb"]["max"] > 0:
+        print("-" * 60)
+        print(
+            f"{'Peak Memory max (MB):':<30} {ov['peak_memory_mb']['max']:.2f}  mean: {ov['peak_memory_mb']['mean']:.2f}"
+        )
+
+    if ov["stage_durations"]:
+        print("-" * 60)
+        print("Stage Durations (overall, seconds):")
+        for stage, s in ov["stage_durations"].items():
+            print(f"  {stage:<22} n={s['count']:<5} mean={s['mean']:.4f} p50={s['p50']:.4f} p99={s['p99']:.4f}")
+
+    if ov.get("text_stream", {}).get("measured_requests", 0):
+        print("-" * 60)
+        print("Text-Output Streaming (overall):")
+        _print_text_stream(ov["text_stream"])
+
+    _print_section("Per-Task-Type Result")
+    for task in _TASK_TYPES:
+        t = metrics["per_task"][task]
+        print("-" * 60)
+        print(
+            f"  [{task}] total={t['total']} completed={t['completed']} "
+            f"failed={t['failed']} success_rate={t['success_rate']:.2%} "
+            f"qps={t['throughput_qps']:.2f}"
+        )
+        _print_latency_row(task, t)
+        if t["stage_durations"]:
+            for stage, s in t["stage_durations"].items():
+                print(
+                    f"    stage {stage:<18} n={s['count']:<5} "
+                    f"mean={s['mean']:.4f} p50={s['p50']:.4f} p99={s['p99']:.4f}"
+                )
+        _print_text_stream(t.get("text_stream", {}), indent="    ")
+
+    if metrics["it2i_by_bot_task"]:
+        _print_section("it2i by bot_task (thinking intensity)")
+        # it2i total summary first (mirrors per_task["it2i"]), then the
+        # per-bot_task breakdown so the section reads total -> breakdown.
+        it2i_total = metrics["per_task"]["it2i"]
+        print("-" * 60)
+        print(
+            f"  [it2i TOTAL] total={it2i_total['total']} completed={it2i_total['completed']} "
+            f"failed={it2i_total['failed']} success_rate={it2i_total['success_rate']:.2%} "
+            f"qps={it2i_total['throughput_qps']:.2f}"
+        )
+        _print_latency_row("it2i TOTAL", it2i_total)
+        if it2i_total["stage_durations"]:
+            for stage, s in it2i_total["stage_durations"].items():
+                print(
+                    f"    stage {stage:<18} n={s['count']:<5} "
+                    f"mean={s['mean']:.4f} p50={s['p50']:.4f} p99={s['p99']:.4f}"
+                )
+        _print_text_stream(it2i_total.get("text_stream", {}), indent="    ")
+        for bt, t in metrics["it2i_by_bot_task"].items():
+            print("-" * 60)
+            print(
+                f"  [{bt}] total={t['total']} completed={t['completed']} "
+                f"failed={t['failed']} success_rate={t['success_rate']:.2%} "
+                f"qps={t['throughput_qps']:.2f}"
+            )
+            _print_latency_row(bt, t)
+            if t["stage_durations"]:
+                for stage, s in t["stage_durations"].items():
+                    print(
+                        f"    stage {stage:<18} n={s['count']:<5} "
+                        f"mean={s['mean']:.4f} p50={s['p50']:.4f} p99={s['p99']:.4f}"
+                    )
+            _print_text_stream(t.get("text_stream", {}), indent="    ")
+
+    print("\n" + "=" * 60)
+
+
+def _endpoint_path(api_url: str) -> str:
+    """Reduce a full request URL to its endpoint path for the input record."""
+    for ep in (_EDITS_ENDPOINT, _CHAT_ENDPOINT):
+        if api_url.endswith(ep):
+            return ep
+    # Fall back to everything after the host:port.
+    idx = api_url.find("/v1/")
+    return api_url[idx:] if idx >= 0 else api_url
+
+
+def _collect_image_urls(body: Any) -> list[str]:
+    """Pull ``data:`` image URLs from either a chat or an images-edits body."""
+    urls: list[str] = []
+    if not isinstance(body, dict):
+        return urls
+    choices = body.get("choices", [])
+    if isinstance(choices, list):
+        for choice in choices:
+            content = (choice or {}).get("message", {}).get("content")
+            if isinstance(content, list):
+                for item in content:
+                    if isinstance(item, dict) and item.get("type") == "image_url":
+                        url = (item.get("image_url") or {}).get("url", "")
+                        if isinstance(url, str) and url.startswith("data:"):
+                            urls.append(url)
+    data_items = body.get("data", [])
+    if isinstance(data_items, list):
+        for d in data_items:
+            if isinstance(d, dict) and d.get("b64_json"):
+                urls.append(f"data:image/png;base64,{d['b64_json']}")
+    return urls
+
+
+def _build_request_records(
+    requests_list: list[OmniRequest],
+    outputs: list[RequestFuncOutput],
+    output_dir: str | None,
+) -> list[dict[str, Any]]:
+    """Build a per-request input/output correlation list for the JSON output.
+
+    Each record pairs the *input* the benchmark sent (endpoint, prompt, input
+    image path, model, sampling params, bot_task) with the *output* the server
+    returned (returned text for i2t, saved image paths + AR "thinking" text for
+    t2i/it2i, stage durations, peak memory, latency, error). When ``output_dir``
+    is given everything lands under it in a fixed layout for easy side-by-side
+    review:
+
+        <output_dir>/
+            result.json                           (written by the caller)
+            inputs/req_{idx}_{task}_input{ext}    (the reference image sent)
+            outputs/req_{idx}_{task}_{img}.png    (the generated image returned)
+
+    it2i requests thus have both an ``inputs/`` entry (the reference) and an
+    ``outputs/`` entry (the edit), so the before/after can be compared directly;
+    i2t has only an input image, t2i only an output image. Filenames embed the
+    request index so input <-> output files line up across the two folders.
+    """
+    import base64
+    import shutil
+
+    inputs_dir = None
+    outputs_dir = None
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+        inputs_dir = os.path.join(output_dir, "inputs")
+        outputs_dir = os.path.join(output_dir, "outputs")
+        os.makedirs(inputs_dir, exist_ok=True)
+        os.makedirs(outputs_dir, exist_ok=True)
+
+    records: list[dict[str, Any]] = []
+    saved_input_total = 0
+    saved_output_total = 0
+    for idx, (req, out) in enumerate(zip(requests_list, outputs)):
+        extra = req.extra_body or {}
+
+        # Save the input (reference) image(s) for i2t / it2i — copy the source
+        # file verbatim into <output_dir>/inputs/ so the exact image that was
+        # sent is reviewable alongside the result. t2i has no input image.
+        saved_input_paths: list[str] = []
+        if inputs_dir and req.image_paths:
+            for k, src in enumerate(req.image_paths):
+                if not src or not os.path.isfile(src):
+                    continue
+                ext = os.path.splitext(src)[1] or ".png"
+                suffix = f"input{k}" if len(req.image_paths) > 1 else "input"
+                fname = f"req_{idx:04d}_{req.task_type}_{suffix}{ext}"
+                dst = os.path.join(inputs_dir, fname)
+                try:
+                    shutil.copyfile(src, dst)
+                    saved_input_paths.append(dst)
+                    saved_input_total += 1
+                except Exception:
+                    pass
+
+        input_record: dict[str, Any] = {
+            "endpoint": _endpoint_path(req.api_url),
+            "model": req.model,
+            "prompt": req.prompt,
+            "prompt_word_count": len(req.prompt.split()) if req.prompt else 0,
+            "image_paths": list(req.image_paths) if req.image_paths else [],
+            "input_images_saved": saved_input_paths,
+            "input_image_size": req.input_image_size,
+            "modalities": extra.get("modalities"),
+            "width": req.width,
+            "height": req.height,
+            "num_inference_steps": req.num_inference_steps,
+            "seed": req.seed,
+        }
+        if req.task_type == "it2i":
+            input_record["bot_task"] = req.bot_task
+
+        body = out.response_body if out.success else None
+        returned_text: str | None = None
+        cot_output: str | None = None
+        num_images = 0
+        saved_paths: list[str] = []
+
+        if isinstance(body, dict):
+            is_edits = _endpoint_path(req.api_url) == _EDITS_ENDPOINT
+            if is_edits:
+                cot_output, num_images = extract_edits_outputs(body)
+            else:
+                returned_text, cot_output, num_images = extract_chat_outputs(body)
+
+            # Save generated images for t2i / it2i (i2t returns text, no image).
+            if outputs_dir and req.task_type != "i2t":
+                urls = _collect_image_urls(body)
+                for img_idx, url in enumerate(urls):
+                    if "," not in url:
+                        continue
+                    try:
+                        _, b64 = url.split(",", 1)
+                        fname = f"req_{idx:04d}_{req.task_type}_{img_idx}.png"
+                        path = os.path.join(outputs_dir, fname)
+                        with open(path, "wb") as f:
+                            f.write(base64.b64decode(b64))
+                        saved_paths.append(path)
+                        saved_output_total += 1
+                    except Exception:
+                        pass
+
+        output_record: dict[str, Any] = {
+            "success": bool(out.success),
+            "latency_s": round(out.latency, 4) if out.latency else 0.0,
+            "returned_text": returned_text,
+            "cot_output": cot_output,
+            "num_images": num_images,
+            "image_paths_saved": saved_paths,
+            "stage_durations": out.stage_durations or {},
+            "peak_memory_mb": out.peak_memory_mb,
+            "error": out.error or None,
+        }
+        # Streaming text-output latency (present only when --stream captured a
+        # text stream for this request; zeros / empty otherwise). generated_text
+        # mirrors returned_text (i2t) / cot_output (it2i edits) but is the raw
+        # streamed concatenation, kept for direct TTFT/TPOT cross-check.
+        if out.ttft > 0.0:
+            output_record["text_stream"] = {
+                "ttft_s": round(out.ttft, 4),
+                "output_tokens": out.output_tokens,
+                "tpot_s": round(sum(out.itl or []) / (out.output_tokens - 1), 4) if out.output_tokens > 1 else 0.0,
+                "itl_s": [round(x, 4) for x in (out.itl or [])],
+                "generated_text": out.generated_text or None,
+            }
+
+        records.append(
+            {
+                "index": idx,
+                "task_type": req.task_type,
+                "input": input_record,
+                "output": output_record,
+            }
+        )
+
+    if output_dir:
+        print(f"Saved {saved_input_total} input image(s) to {inputs_dir}.")
+        print(f"Saved {saved_output_total} generated image(s) to {outputs_dir}.")
+    return records
+
+
+async def iter_requests(
+    requests_list: list[OmniRequest],
+    request_rate: float,
+) -> AsyncGenerator[OmniRequest, None]:
+    """Yield requests with Poisson inter-arrival when rate is finite; else burst."""
+    if request_rate != float("inf") and request_rate <= 0:
+        raise ValueError(f"request_rate must be positive or inf, got {request_rate}.")
+    for i, req in enumerate(requests_list):
+        if request_rate != float("inf") and i > 0:
+            await asyncio.sleep(random.expovariate(request_rate))
+        yield req
+
+
+async def _run_warmups(
+    requests_list: list[OmniRequest],
+    args: argparse.Namespace,
+    session: aiohttp.ClientSession,
+) -> None:
+    if not args.warmup_requests or not requests_list:
+        return
+    n = min(args.warmup_requests, len(requests_list))
+    warm = requests_list[:n]
+    sem = asyncio.Semaphore(min(args.warmup_concurrency, n))
+
+    async def one(req: OmniRequest) -> RequestFuncOutput:
+        func = select_request_func(req, args.it2i_endpoint, args.stream)
+        async with sem:
+            return await func(req, session, None)
+
+    print(f"Running {n} warmup request(s) (concurrency={args.warmup_concurrency})...")
+    await asyncio.gather(*[one(r) for r in warm])
+
+
+async def benchmark(args: argparse.Namespace) -> None:
+    base_url = args.base_url or f"http://{args.host}:{args.port}"
+    chat_url = f"{base_url}{_CHAT_ENDPOINT}"
+    images_edits_url = f"{base_url}{_EDITS_ENDPOINT}"
+
+    counts = TaskCounts(i2t=args.num_i2t, t2i=args.num_t2i, it2i=args.num_it2i)
+    if counts.total == 0:
+        raise ValueError("At least one of --num-i2t/--num-t2i/--num-it2i must be > 0.")
+
+    bot_task_weights = parse_bot_task_weights(args.it2i_bot_task_weights)
+    group_order = _parse_group_order(args.no_shuffle_order)
+    gen_resolution_weights = parse_gen_resolution_weights(args.gen_resolution_weights)
+
+    config = OmniConfig(
+        width=args.width,
+        height=args.height,
+        num_inference_steps=args.num_inference_steps,
+        seed=args.seed,
+        model=args.model,
+    )
+    prompts = {
+        "i2t": args.i2t_prompt,
+        "t2i": args.t2i_prompt,
+        "it2i": args.it2i_prompt,
+    }
+
+    requests_list = build_requests(
+        counts=counts,
+        config=config,
+        dataset=args.dataset,
+        dataset_path=args.dataset_path,
+        bot_task_weights=bot_task_weights,
+        input_image=args.input_image,
+        prompts=prompts,
+        chat_url=chat_url,
+        images_edits_url=images_edits_url,
+        return_stage_metrics=args.return_stage_metrics,
+        it2i_endpoint=args.it2i_endpoint,
+        seed=args.seed,
+        shuffle=args.shuffle,
+        bot_task_sampling=args.it2i_bot_task_sampling,
+        group_order=group_order,
+        gen_resolution_weights=gen_resolution_weights,
+        gen_resolution_sampling=args.gen_resolution_sampling,
+        randomize_input=args.randomize_input,
+    )
+
+    # Unified on-disk output directory (new --output-dir, or the deprecated
+    # --save-dir / --output-file aliases). Resolved once here so both the
+    # dry-run preview and the post-run save share the same target.
+    output_dir = _resolve_output_dir(args)
+
+    # Tally the actual mix (after merge/shuffle) for the dry-run preview / log.
+    tally = {t: 0 for t in _TASK_TYPES}
+    bt_tally: dict[str, int] = {}
+    res_tally: dict[str, int] = {}
+    in_res_tally: dict[str, int] = {}
+    prompt_words: dict[str, list[int]] = {t: [] for t in _TASK_TYPES}
+    for r in requests_list:
+        tally[r.task_type] += 1
+        if r.task_type == "it2i" and r.bot_task:
+            bt_tally[r.bot_task] = bt_tally.get(r.bot_task, 0) + 1
+        if r.task_type in ("t2i", "it2i") and r.width and r.height:
+            key = f"{r.width}x{r.height}"
+            res_tally[key] = res_tally.get(key, 0) + 1
+        if r.input_image_size:
+            in_res_tally[r.input_image_size] = in_res_tally.get(r.input_image_size, 0) + 1
+        prompt_words[r.task_type].append(len(r.prompt.split()) if r.prompt else 0)
+
+    print(f"Prepared {len(requests_list)} omni requests: " + ", ".join(f"{t}={tally[t]}" for t in _TASK_TYPES))
+    if bt_tally:
+        print("it2i bot_task used: " + ", ".join(f"{k}={v}" for k, v in sorted(bt_tally.items())))
+    if res_tally:
+        print("t2i/it2i resolution used: " + ", ".join(f"{k}={v}" for k, v in sorted(res_tally.items())))
+    if args.randomize_input:
+        pw_summary = ", ".join(
+            f"{t}=[{min(prompt_words[t])}-{max(prompt_words[t])}, avg="
+            f"{(sum(prompt_words[t]) / len(prompt_words[t])):.1f}]"
+            for t in _TASK_TYPES
+            if prompt_words[t]
+        )
+        print(f"prompt word count ({'randomized' if args.randomize_input else 'fixed'}): {pw_summary}")
+        if in_res_tally:
+            print(
+                "i2t/it2i input-image resolution used: "
+                + ", ".join(f"{k}={v}" for k, v in sorted(in_res_tally.items()))
+            )
+
+    if args.dry_run:
+        preview = args.dry_run_preview
+        if preview == 0 or preview >= len(requests_list):
+            shown = requests_list
+            shown_label = f"all {len(requests_list)}"
+        else:
+            shown = requests_list[:preview]
+            shown_label = f"first {preview}"
+        print(
+            f"\n[dry-run] {shown_label} requests in send order "
+            f"(idx, task, bot_task, inWxH, genWxH, prompt_words, api_url):"
+        )
+        for i, r in enumerate(shown):
+            in_wxh = r.input_image_size or "-"
+            gen_wxh = f"{r.width or '-'}x{r.height or '-'}" if r.width and r.height else "-"
+            pw = len(r.prompt.split()) if r.prompt else 0
+            print(
+                f"  {i:>3}  {r.task_type:<5}  bot_task={r.bot_task or '-'}  "
+                f"{in_wxh:<10}  {gen_wxh:<10}  {pw:<4}  {r.api_url}"
+            )
+        footer = (
+            f"\n[dry-run] No requests sent. Shuffle={args.shuffle}, seed={args.seed}, group_order={list(group_order)}."
+        )
+        if gen_resolution_weights:
+            footer += (
+                f"\n[dry-run] gen_resolution_weights={gen_resolution_weights}, sampling={args.gen_resolution_sampling}."
+            )
+        if args.randomize_input:
+            footer += (
+                f"\n[dry-run] randomize_input=True (prompt length + input-image size + "
+                f"content randomized per request via seed={args.seed})."
+            )
+        if output_dir:
+            footer += f"\n[dry-run] output_dir={output_dir} (result.json + inputs/ + outputs/ would be written here)."
+        print(footer)
+        return
+
+    # Pre-read + pre-encode input images so the senders skip file I/O / base64
+    # at send time. Done outside the timed window so it neither blocks the event
+    # loop under concurrency nor distorts latency — and, with ordered dispatch
+    # below, makes the actual send order match the dry-run order exactly instead
+    # of being raced by per-task prep cost (t2i < it2i < i2t prep).
+    prepped = 0
+    for r in requests_list:
+        if r.image_paths:
+            prepare_request_images(r)
+            prepped += 1
+    if prepped:
+        print(f"Pre-encoded {prepped} request image(s) before send.")
+
+    semaphore = asyncio.Semaphore(args.max_concurrency) if args.max_concurrency else None
+    # Order in which requests actually reach the sender (after semaphore
+    # acquisition). With pre-encoded payloads + the ordered-dispatch loop below
+    # this equals the list / dry-run order; surfacing it lets the user tell
+    # client-send order apart from any server-side re-dispatch (e.g. the DTPS
+    # scheduler processing ar_downstream before ar_only).
+    dispatch_order: list[int] = []
+
+    async def limited(req: OmniRequest, idx: int, pbar: tqdm) -> RequestFuncOutput:
+        func = select_request_func(req, args.it2i_endpoint, args.stream)
+        if semaphore:
+            async with semaphore:
+                dispatch_order.append(idx)
+                return await func(req, session, pbar)
+        dispatch_order.append(idx)
+        return await func(req, session, pbar)
+
+    pbar = tqdm(total=len(requests_list), disable=args.disable_tqdm)
+    async with aiohttp.ClientSession() as session:
+        await _run_warmups(requests_list, args, session)
+        start = time.perf_counter()
+        tasks = []
+        idx = 0
+        async for req in iter_requests(requests_list, args.request_rate):
+            tasks.append(asyncio.create_task(limited(req, idx, pbar)))
+            idx += 1
+            # Yield to the loop so the just-scheduled task acquires the
+            # semaphore and reaches session.post (the request is pre-encoded,
+            # so there is no prep delay) before the next task is created. With
+            # the FIFO semaphore this makes the server arrival order match the
+            # list / dry-run order even under --request-rate inf + concurrency.
+            await asyncio.sleep(0.1)
+        outputs = await asyncio.gather(*tasks)
+        total_duration = time.perf_counter() - start
+    pbar.close()
+
+    # Audit trail: the order the client actually dispatched requests to the
+    # sender. With pre-encoding + ordered dispatch this is the list / dry-run
+    # order (0,1,2,...). Compare against the server-side receive / processing
+    # log to attribute any reordering to the DTPS scheduler (which processes
+    # ar_downstream t2i/it2i ahead of ar_only i2t) rather than the client.
+    dispatch_in_order = dispatch_order == list(range(len(requests_list)))
+    if not dispatch_in_order:
+        # With a finite --request-rate the loop awaits between sends, so the
+        # list order still holds; only a hand-edited scheduler / semaphore
+        # would break it. Log the deviation so the user can investigate.
+        print(f"Dispatch order deviates from list order (len={len(dispatch_order)}).")
+    print(f"Client dispatch order matches dry-run list order: {dispatch_in_order}")
+
+    metrics = calculate_metrics(requests_list, outputs, total_duration, args.percentiles)
+    metrics["config"] = {
+        "output_dir": output_dir,
+        "endpoint_i2t_t2i": _CHAT_ENDPOINT,
+        "endpoint_it2i": _EDITS_ENDPOINT if args.it2i_endpoint == "images-edits" else _CHAT_ENDPOINT,
+        "model": args.model,
+        "dataset": args.dataset,
+        "mix_i2t_t2i_it2i": [args.num_i2t, args.num_t2i, args.num_it2i],
+        "bot_task_weights": bot_task_weights,
+        "bot_task_sampling": args.it2i_bot_task_sampling,
+        "bot_task_actual": bt_tally,
+        "group_order": list(group_order),
+        "gen_resolution_weights": gen_resolution_weights,
+        "gen_resolution_sampling": args.gen_resolution_sampling,
+        "gen_resolution_actual": res_tally,
+        "randomize_input": bool(args.randomize_input),
+        "input_resolution_actual": in_res_tally,
+        "prompt_word_count": {
+            t: {
+                "min": min(prompt_words[t]) if prompt_words[t] else 0,
+                "max": max(prompt_words[t]) if prompt_words[t] else 0,
+                "avg": round(sum(prompt_words[t]) / len(prompt_words[t]), 2) if prompt_words[t] else 0.0,
+            }
+            for t in _TASK_TYPES
+            if prompt_words[t]
+        },
+        "shuffle": args.shuffle,
+        "seed": args.seed,
+        "request_rate": args.request_rate,
+        "max_concurrency": args.max_concurrency,
+        "stream": bool(args.stream),
+        "dispatch_order": dispatch_order,
+        "dispatch_matches_list_order": dispatch_order == list(range(len(requests_list))),
+    }
+
+    print_metrics(metrics, args)
+
+    # Per-request input/output correlation, also saving input reference images
+    # to <output_dir>/inputs/ and generated images to <output_dir>/outputs/.
+    # Surfaced in the JSON as ``requests`` so each request's inputs (endpoint,
+    # prompt, image path, sampling params, bot_task) line up with its outputs
+    # (returned text / saved image paths / AR thinking text). The metrics JSON
+    # is always written to <output_dir>/result.json (fixed name).
+    if output_dir:
+        metrics["requests"] = _build_request_records(requests_list, outputs, output_dir)
+        result_path = os.path.join(output_dir, "result.json")
+        with open(result_path, "w", encoding="utf-8") as f:
+            json.dump(metrics, f, indent=2, ensure_ascii=False)
+        print(f"Metrics saved to {result_path}")
+
+
+def _argparse_float_inf(text: str) -> float:
+    if text.strip().lower() == "inf":
+        return float("inf")
+    return float(text)
+
+
+def _resolve_output_dir(args: argparse.Namespace) -> str | None:
+    """Resolve the unified on-disk output directory.
+
+    ``--output-dir`` is the single knob: ``result.json`` + ``inputs/`` +
+    ``outputs/`` all land under it. The deprecated ``--save-dir`` maps to the
+    same directory; ``--output-file`` maps to its parent directory (the filename
+    is no longer honored — the JSON is fixed as ``result.json``). Precedence:
+    ``--output-dir`` > ``--save-dir`` > ``--output-file``.
+    """
+    if args.output_dir:
+        if args.save_dir or args.output_file:
+            print(
+                "Warning: --output-dir takes precedence; --save-dir / --output-file "
+                "are ignored (deprecated, use --output-dir)."
+            )
+        return args.output_dir
+    if args.save_dir:
+        print(
+            "Warning: --save-dir is deprecated; use --output-dir. Output now includes "
+            "result.json + inputs/ + outputs/ under this directory."
+        )
+        return args.save_dir
+    if args.output_file:
+        parent = os.path.dirname(args.output_file) or "."
+        print(
+            "Warning: --output-file is deprecated; use --output-dir. The JSON is now "
+            f"fixed as {os.path.join(parent, 'result.json')} (the given filename is ignored)."
+        )
+        return parent
+    return None
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Omni (i2t/t2i/it2i) serving benchmark for unified AR+DiT models.",
+    )
+    parser.add_argument("--base-url", type=str, default=None, help="Server base URL (overrides --host/--port).")
+    parser.add_argument("--host", type=str, default="localhost")
+    parser.add_argument("--port", type=int, default=8091)
+
+    # Task mix — explicit per-type counts.
+    parser.add_argument("--num-i2t", type=int, default=0, help="Number of i2t (understanding) requests.")
+    parser.add_argument("--num-t2i", type=int, default=0, help="Number of t2i (generation) requests.")
+    parser.add_argument("--num-it2i", type=int, default=0, help="Number of it2i (editing) requests.")
+    parser.add_argument(
+        "--num-prompts",
+        type=int,
+        default=None,
+        help="(Legacy) total prompt count; ignored when any --num-* is set. Kept for compat.",
+    )
+
+    # it2i knobs.
+    parser.add_argument(
+        "--it2i-endpoint",
+        choices=["chat", "images-edits"],
+        default="chat",
+        help="Endpoint for it2i traffic: 'chat' (/v1/chat/completions, unified) or 'images-edits'.",
+    )
+    parser.add_argument(
+        "--it2i-bot-task-weights",
+        type=str,
+        default=None,
+        help="Weighted bot_task mix for it2i, e.g. 'recaption=2,think=1,think_recaption=1'. "
+        "Defaults to equal weight across recaption/think/think_recaption.",
+    )
+    parser.add_argument(
+        "--it2i-bot-task-sampling",
+        choices=["proportional", "random"],
+        default="proportional",
+        help="How to turn --it2i-bot-task-weights into per-request bot_task. 'proportional' "
+        "(default) allocates exact counts matching the weights (largest-remainder, e.g. "
+        "10 tasks at 2:2:1 -> 4/4/2). 'random' draws each task independently with the "
+        "weights, matching them only in expectation (e.g. may yield 6/3/1).",
+    )
+
+    # Random send order.
+    parser.add_argument(
+        "--shuffle",
+        dest="shuffle",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Shuffle the merged request list so task types interleave (true random send order). "
+        "Use --no-shuffle to send grouped by task type.",
+    )
+    parser.add_argument(
+        "--no-shuffle-order",
+        type=str,
+        default=None,
+        metavar="ORDER",
+        help="With --no-shuffle, the order to concatenate the i2t/t2i/it2i groups before "
+        "sending, e.g. 't2i,it2i,i2t' sends all t2i, then it2i, then i2t. Must be a "
+        "permutation of i2t,t2i,it2i. Default: i2t,t2i,it2i. Ignored when --shuffle is on "
+        "(the merge is then randomized). The actual send order always matches this list "
+        "order — see the send-order fix in README.",
+    )
+    parser.add_argument("--seed", type=int, default=0, help="RNG seed for shuffle + bot_task + resolution sampling.")
+
+    # Dataset.
+    parser.add_argument(
+        "--dataset",
+        choices=["random", "custom"],
+        default="random",
+        help="'random' uses synthetic prompts + a placeholder image; 'custom' reads a JSONL via --dataset-path.",
+    )
+    parser.add_argument("--dataset-path", type=str, default=None, help="JSONL file for --dataset custom.")
+    parser.add_argument(
+        "--input-image",
+        type=str,
+        default=None,
+        help="Input image for i2t/it2i (random mode). Defaults to a generated placeholder.",
+    )
+
+    # Prompts (random mode).
+    parser.add_argument("--i2t-prompt", type=str, default=None)
+    parser.add_argument("--t2i-prompt", type=str, default=None)
+    parser.add_argument("--it2i-prompt", type=str, default=None)
+
+    # Generation knobs.
+    parser.add_argument("--model", type=str, default="default")
+    parser.add_argument("--width", type=int, default=1024)
+    parser.add_argument("--height", type=int, default=1024)
+    parser.add_argument("--num-inference-steps", type=int, default=50)
+    parser.add_argument("--seed-gen", type=int, default=None, help="Generation seed for t2i/it2i outputs.")
+    parser.add_argument(
+        "--gen-resolution-weights",
+        type=str,
+        default=None,
+        metavar="WEIGHTS",
+        help="Generation-resolution ratio for t2i/it2i, e.g. "
+        "'512x512=2,1024x1024=2,1280x720=1'. Each of t2i and it2i is allocated "
+        "resolutions per the ratio (overrides --width/--height per request; a custom "
+        "dataset row's explicit width/height still wins). Allowed: "
+        f"{sorted(GEN_RESOLUTIONS)}. Default: none (use --width/--height for every request).",
+    )
+    parser.add_argument(
+        "--gen-resolution-sampling",
+        choices=["proportional", "random"],
+        default="proportional",
+        help="How to turn --gen-resolution-weights into per-request resolutions. 'proportional' "
+        "(default) allocates exact counts matching the weights (largest-remainder, e.g. "
+        "10 requests at 2:2:1 -> 4/4/2). 'random' draws each request independently, matching "
+        "the weights only in expectation.",
+    )
+    parser.add_argument(
+        "--randomize-input",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Randomize the *input* side of every request to approximate real-world request "
+        "diversity (governed by --seed, so reproducible). For all three task types the prompt "
+        "is drawn from a short->long pool so prompt lengths vary; for i2t / it2i a unique "
+        "varied-content input image is generated at a size drawn from 512x512 / 1024x1024 / "
+        "1280x720 (not one shared solid-color placeholder). Only affects the 'random' dataset "
+        "(--dataset custom rows always win); --input-image and --i2t/--t2i/--it2i-prompt are "
+        "ignored while this is on. Default off (single placeholder image + fixed prompts).",
+    )
+
+    # Traffic.
+    parser.add_argument(
+        "--request-rate",
+        type=_argparse_float_inf,
+        default=float("inf"),
+        help="Requests per second (Poisson). 'inf' sends all at once. Default inf.",
+    )
+    parser.add_argument("--max-concurrency", type=int, default=1, help="Max in-flight requests.")
+    parser.add_argument(
+        "--warmup-requests",
+        type=int,
+        default=0,
+        help="Number of warmup requests to send before the timed run (default 0 = no warmup). "
+        "Warmup results are discarded; set > 0 to prime caches / JIT before measuring.",
+    )
+    parser.add_argument("--warmup-concurrency", type=int, default=1)
+
+    # Output / metrics.
+    parser.add_argument("--return-stage-metrics", action="store_true", help="Ask the server for per-stage durations.")
+    parser.add_argument(
+        "--stream",
+        action="store_true",
+        help="Stream responses and capture text-output TTFT / TPOT / ITL (vLLM-style). "
+        "i2t measures the AR final-answer text; it2i (via --it2i-endpoint images-edits) "
+        "measures the AR 'thinking' text streamed ahead of the image. chat t2i/it2i do not "
+        "stream AR text (server-filtered), so their text metrics are N/A — use images-edits "
+        "for it2i AR-text latency. Non-streaming runs report text_stream with count=0.",
+    )
+    parser.add_argument(
+        "--percentiles",
+        type=float,
+        nargs="+",
+        default=[50, 95, 99],
+        help="Latency percentiles to report (default: 50 95 99).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        metavar="DIR",
+        help="Unified on-disk output directory. Writes result.json (metrics) at the root, "
+        "saves the i2t/it2i input reference images under <DIR>/inputs/, and the t2i/it2i "
+        "generated images under <DIR>/outputs/ — so an it2i request's reference and its "
+        "edit can be compared side by side, and an i2t request's input image is reviewable. "
+        "Replaces the old --output-file / --save-dir pair.",
+    )
+    parser.add_argument(
+        "--output-file",
+        type=str,
+        default=None,
+        help="(Deprecated, use --output-dir.) Legacy: wrote metrics JSON to this exact path. "
+        "Now mapped to its parent directory with the JSON fixed as result.json.",
+    )
+    parser.add_argument(
+        "--save-dir",
+        type=str,
+        default=None,
+        help="(Deprecated, use --output-dir.) Legacy: directory to save generated images. "
+        "Now mapped to --output-dir (also writes result.json + inputs/).",
+    )
+    parser.add_argument("--disable-tqdm", action="store_true")
+    parser.add_argument("--dry-run", action="store_true", help="Build the request plan and print it; send nothing.")
+    parser.add_argument(
+        "--dry-run-preview",
+        type=int,
+        default=20,
+        metavar="N",
+        help="With --dry-run, how many requests to print in send order (default: 20). Use 0 to print every request.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    asyncio.run(benchmark(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/omni/omni_dataset.py
+++ b/benchmarks/omni/omni_dataset.py
@@ -1,0 +1,690 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+# ruff: noqa: E501
+"""Dataset / request-list construction for the omni serving benchmark.
+
+Builds a single shuffled list of ``OmniRequest`` spanning i2t / t2i / it2i in
+the counts the caller asked for, with it2i ``bot_task`` sampled (weighted)
+across recaption / think / think_recaption. Two sources:
+
+* ``random`` (default): synthetic prompts + a placeholder image for i2t/it2i.
+  Zero external dependencies — enough to drive the scheduler and collect
+  latency / throughput stats.
+* ``custom``: a JSONL file (``--dataset-path``) where each line declares its
+  own ``task`` / ``prompt`` / ``image_path`` / ``bot_task`` / generation knobs.
+  The per-task pools are sampled (cycling) up to the requested counts.
+
+The shuffle is a true ``random.shuffle`` over the merged list (controlled by
+``--seed``), so the three task types are interleaved rather than sent in
+blocks — which is what exercises the DTPS scheduling path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import tempfile
+from dataclasses import dataclass
+from typing import Any
+
+from omni_backends import IT2I_BOT_TASKS, OmniRequest
+from PIL import Image
+
+# Default prompts for the random dataset. Overridable via CLI.
+DEFAULT_I2T_PROMPT = "Describe this image in detail."
+DEFAULT_T2I_PROMPT = "A cat sitting on a wooden bench, photorealistic, soft natural light."
+DEFAULT_IT2I_PROMPT = "Add warm sunset lighting to this image and make the sky more dramatic."
+
+
+@dataclass
+class OmniConfig:
+    """Generation knobs shared across t2i / it2i requests."""
+
+    width: int | None = 1024
+    height: int | None = 1024
+    num_inference_steps: int | None = 50
+    seed: int | None = None
+    model: str = "default"
+
+
+@dataclass
+class TaskCounts:
+    i2t: int = 0
+    t2i: int = 0
+    it2i: int = 0
+
+    @property
+    def total(self) -> int:
+        return self.i2t + self.t2i + self.it2i
+
+
+def parse_bot_task_weights(raw: str | None) -> dict[str, float]:
+    """Parse ``recaption=2,think=1,think_recaption=1`` into a weight dict.
+
+    Defaults to equal weight across the three thinking-intensity modes. Unknown
+    task names raise so a typo doesn't silently drop coverage.
+    """
+    if not raw:
+        return {t: 1.0 for t in IT2I_BOT_TASKS}
+
+    weights: dict[str, float] = {}
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "=" not in part:
+            raise ValueError(f"Invalid bot_task weight entry '{part}'; expected name=weight (e.g. think=2).")
+        name, value = part.split("=", 1)
+        name = name.strip()
+        value = value.strip()
+        if name not in IT2I_BOT_TASKS:
+            raise ValueError(f"Unknown bot_task '{name}'; valid: {sorted(IT2I_BOT_TASKS)}.")
+        try:
+            w = float(value)
+        except ValueError as e:
+            raise ValueError(f"Invalid weight '{value}' for bot_task '{name}'.") from e
+        if w < 0:
+            raise ValueError(f"bot_task weight for '{name}' must be >= 0, got {w}.")
+        weights[name] = w
+
+    if not weights:
+        return {t: 1.0 for t in IT2I_BOT_TASKS}
+    # Fill any unmentioned task with 0 so it can be opted out explicitly.
+    for t in IT2I_BOT_TASKS:
+        weights.setdefault(t, 0.0)
+    if sum(weights.values()) <= 0:
+        raise ValueError("bot_task weights sum to 0; at least one must be > 0.")
+    return weights
+
+
+def allocate_bot_tasks(n: int, weights: dict[str, float], rng: random.Random) -> list[str]:
+    """Distribute ``n`` bot_task slots *exactly* proportional to ``weights``.
+
+    Uses the largest-remainder method (:func:`_allocate_weighted`) so the counts
+    match the weights as closely as integers allow (e.g. ``n=10``, weights
+    ``2:2:1`` -> ``4/4/2``, not a random ``6/3/1`` draw). The resulting list is
+    shuffled with ``rng`` so the assignment to it2i positions is randomized —
+    the global shuffle later re-interleaves everything, but this also keeps
+    ``--no-shuffle`` runs from grouping all of one bot_task together.
+    """
+    return _allocate_weighted(n, weights, rng)
+
+
+def sample_bot_tasks(n: int, weights: dict[str, float], rng: random.Random) -> list[str]:
+    """Sample ``n`` bot_task names by weight *with replacement* (stochastic).
+
+    Each of the ``n`` slots is drawn independently, so the realized counts only
+    match the weights in expectation (e.g. ``n=10`` weights ``2:2:1`` may yield
+    ``6/3/1``). Use :func:`allocate_bot_tasks` for exact proportional counts.
+    """
+    tasks = list(weights.keys())
+    ws = [weights[t] for t in tasks]
+    return rng.choices(tasks, weights=ws, k=n)
+
+
+def draw_bot_tasks(n: int, weights: dict[str, float], rng: random.Random, sampling: str) -> list[str]:
+    """Dispatch to :func:`allocate_bot_tasks` (``proportional``) or
+    :func:`sample_bot_tasks` (``random``)."""
+    if sampling == "random":
+        return sample_bot_tasks(n, weights, rng)
+    return allocate_bot_tasks(n, weights, rng)
+
+
+# Allowed generation resolutions for t2i / it2i and their (width, height) pairs.
+GEN_RESOLUTIONS: dict[str, tuple[int, int]] = {
+    "512x512": (512, 512),
+    "1024x1024": (1024, 1024),
+    "1280x720": (1280, 720),
+}
+
+
+def parse_gen_resolution_weights(raw: str | None) -> dict[str, float] | None:
+    """Parse ``512x512=2,1024x1024=2,1280x720=1`` into a weight dict.
+
+    Returns ``None`` when ``raw`` is empty so the caller keeps the global
+    ``--width`` / ``--height``. Unknown resolution strings raise so a typo
+    doesn't silently fall back. Weights must be ``>= 0`` and sum ``> 0``;
+    unmentioned resolutions are filled with ``0.0`` so they can be opted out.
+    """
+    if not raw:
+        return None
+    weights: dict[str, float] = {}
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "=" not in part:
+            raise ValueError(f"Invalid resolution weight entry '{part}'; expected WxH=weight (e.g. 1024x1024=2).")
+        name, value = part.split("=", 1)
+        name = name.strip()
+        value = value.strip()
+        if name not in GEN_RESOLUTIONS:
+            raise ValueError(f"Unknown resolution '{name}'; valid: {sorted(GEN_RESOLUTIONS)}.")
+        try:
+            w = float(value)
+        except ValueError as e:
+            raise ValueError(f"Invalid weight '{value}' for resolution '{name}'.") from e
+        if w < 0:
+            raise ValueError(f"resolution weight for '{name}' must be >= 0, got {w}.")
+        weights[name] = w
+    if not weights:
+        return None
+    for r in GEN_RESOLUTIONS:
+        weights.setdefault(r, 0.0)
+    if sum(weights.values()) <= 0:
+        raise ValueError("resolution weights sum to 0; at least one must be > 0.")
+    return weights
+
+
+def _allocate_weighted(n: int, weights: dict[str, float], rng: random.Random) -> list[str]:
+    """Distribute ``n`` slots exactly proportional to ``weights`` (largest-
+    remainder), then shuffle the result with ``rng``.
+
+    Shared by bot_task and resolution allocation: the counts match the weights
+    as closely as integers allow (e.g. ``n=10``, weights ``2:2:1`` -> ``4/4/2``).
+    The shuffle randomizes the assignment to positions — the global shuffle
+    later re-interleaves everything, but this also keeps ``--no-shuffle`` runs
+    from grouping all of one key together.
+    """
+    keys = list(weights.keys())
+    ws = [max(0.0, float(weights[k])) for k in keys]
+    total = sum(ws)
+    if total <= 0:
+        raise ValueError("weights sum to 0; at least one must be > 0.")
+    raw = [w * n / total for w in ws]
+    floors = [int(r) for r in raw]
+    remainder = n - sum(floors)
+    if remainder > 0:
+        # Break ties by largest fractional remainder; equal fractions keep the
+        # dict order (stable sort) so the allocation is deterministic per seed.
+        order = sorted(range(len(keys)), key=lambda i: raw[i] - floors[i], reverse=True)
+        for i in range(remainder):
+            floors[order[i]] += 1
+    result: list[str] = []
+    for key, count in zip(keys, floors):
+        result.extend([key] * count)
+    rng.shuffle(result)
+    return result
+
+
+def allocate_resolutions(n: int, weights: dict[str, float], rng: random.Random) -> list[tuple[int, int]]:
+    """Exact-proportional ``(width, height)`` list of length ``n`` per ``weights``."""
+    names = _allocate_weighted(n, weights, rng)
+    return [GEN_RESOLUTIONS[name] for name in names]
+
+
+def sample_resolutions(n: int, weights: dict[str, float], rng: random.Random) -> list[tuple[int, int]]:
+    """Independent weighted draws (with replacement) of ``(width, height)``."""
+    names = list(weights.keys())
+    ws = [weights[name] for name in names]
+    drawn = rng.choices(names, weights=ws, k=n)
+    return [GEN_RESOLUTIONS[name] for name in drawn]
+
+
+def draw_resolutions(n: int, weights: dict[str, float], rng: random.Random, sampling: str) -> list[tuple[int, int]]:
+    """Dispatch to :func:`allocate_resolutions` (``proportional``) or
+    :func:`sample_resolutions` (``random``)."""
+    if sampling == "random":
+        return sample_resolutions(n, weights, rng)
+    return allocate_resolutions(n, weights, rng)
+
+
+def _placeholder_image_path() -> str:
+    """A 512x512 RGB placeholder used when no input image is supplied."""
+    path = os.path.join(tempfile.gettempdir(), "omni_benchmark_placeholder.png")
+    if not os.path.exists(path):
+        Image.new("RGB", (512, 512), (128, 160, 200)).save(path)
+    return path
+
+
+# Allowed input-image resolutions for i2t / it2i when --randomize-input is on
+# (mirrors GEN_RESOLUTIONS so the input side spans the same size range).
+INPUT_RESOLUTIONS: dict[str, tuple[int, int]] = {
+    "512x512": (512, 512),
+    "1024x1024": (1024, 1024),
+    "1280x720": (1280, 720),
+}
+
+# Diverse prompt pools per task type, ordered short -> long so that a uniform
+# draw across a pool yields a length distribution. Used only when
+# --randomize-input is on (the --i2t-prompt / --t2i-prompt / --it2i-prompt
+# overrides and the custom dataset rows still win when randomization is off).
+_RANDOM_I2T_PROMPTS: tuple[str, ...] = (
+    "Describe this image.",
+    "What is in this picture?",
+    "List the main objects you see and their colors.",
+    "Describe the scene, the lighting, and the overall mood of this image.",
+    "What is happening here? Describe the subjects, the background, and any text visible in the image.",
+    "Give a detailed description of this image: the subjects, their poses and expressions, the setting, the time of day, and the composition.",
+    "Analyze this image thoroughly. Cover the foreground and background, the colors and textures, the style (photo or illustration), and any notable details a caption model should capture.",
+    "Write a long, fine-grained caption for this image. Describe every region left to right, the objects and their attributes, the scene semantics, the lighting direction, and any artifacts or text. Then summarize the image in one sentence.",
+    "Pretend you are describing this image to someone who cannot see it. Walk through the layout, the people or animals present and what they are doing, the environment and weather, the camera framing, and your best guess of where and when it was taken.",
+    "Provide an exhaustive description: enumerate all objects with counts and colors, describe the spatial relations between them, note the style and quality of the image, identify any text or logos, comment on the lighting and shadows, and suggest a plausible caption and three relevant tags.",
+)
+
+_RANDOM_T2I_PROMPTS: tuple[str, ...] = (
+    "A cat.",
+    "A red apple on a table.",
+    "A city street at night, neon signs.",
+    "A futuristic robot standing in a rainy alley, cinematic lighting.",
+    "A cozy cabin in a snowy forest at dusk, warm light from the windows, smoke rising from the chimney.",
+    "A majestic dragon perched on a mountain peak at sunrise, dramatic clouds, highly detailed digital painting.",
+    "A photorealistic portrait of an elderly fisherman with a weathered face, sitting by the harbor, soft golden-hour light, shallow depth of field.",
+    "A surreal floating island with waterfalls cascading into the sky, lush vegetation, ancient ruins, fantasy concept art, volumetric lighting, intricate detail.",
+    "A bustling medieval marketplace filled with vendors and townspeople, colorful tents, cobblestone streets, a castle in the background, painterly illustration, rich color palette, fine detail.",
+    "An astronaut exploring a bioluminescent alien jungle at night, strange glowing plants, a crashed spaceship in the distance, two moons in the sky, cinematic sci-fi concept art, ultra-detailed, atmospheric perspective.",
+)
+
+_RANDOM_IT2I_PROMPTS: tuple[str, ...] = (
+    "Make it night.",
+    "Add a sunset glow.",
+    "Convert this photo to a watercolor painting.",
+    "Change the background to a beach and keep the subject unchanged.",
+    "Add warm sunset lighting and make the sky more dramatic with orange and purple clouds.",
+    "Turn this image into a Studio Ghibli style illustration while preserving the composition and subjects.",
+    "Remove the person in the foreground and replace the background with a snowy mountain landscape, keep the lighting consistent.",
+    "Make this image look like a 1980s film photograph with film grain, slightly faded colors, and a soft vignette around the edges.",
+    "Extend the canvas to the left and right with more of the same room, keeping the perspective and lighting consistent with the original image.",
+    "Transform this daytime street scene into a rainy evening: wet reflective pavement, puddles, neon reflections, fog, and people holding umbrellas, while keeping the buildings and signage identical.",
+)
+
+
+def _draw_prompt(task_type: str, rng: random.Random) -> str:
+    """Uniformly draw a diverse prompt for ``task_type`` from the random pools.
+
+    The pools are ordered short -> long, so a uniform draw realizes a spread of
+    prompt lengths. Reproducible via the shared ``rng`` (seeded by --seed).
+    """
+    pool = {
+        "i2t": _RANDOM_I2T_PROMPTS,
+        "t2i": _RANDOM_T2I_PROMPTS,
+        "it2i": _RANDOM_IT2I_PROMPTS,
+    }[task_type]
+    return rng.choice(pool)
+
+
+def _draw_input_resolution(rng: random.Random) -> tuple[int, int]:
+    """Uniformly draw an input-image (width, height) from INPUT_RESOLUTIONS."""
+    name = rng.choice(list(INPUT_RESOLUTIONS.keys()))
+    return INPUT_RESOLUTIONS[name]
+
+
+def _generate_diverse_image(rng: random.Random, width: int, height: int) -> str:
+    """Generate a unique varied-content RGB image and return its file path.
+
+    Each call draws a random palette + a random set of shapes from ``rng``, so
+    the content differs per request (reproducible via --seed) instead of every
+    request reusing one solid-color placeholder. The image is written to a temp
+    file keyed by an internal counter so repeated builds don't collide. Used
+    only for i2t / it2i under --randomize-input.
+    """
+    from PIL import ImageDraw
+
+    # Random but harmonized palette: a base color + a few accent colors.
+    base = (rng.randint(0, 255), rng.randint(0, 255), rng.randint(0, 255))
+
+    def _accent() -> tuple[int, int, int]:
+        # Pick a color that contrasts with base so shapes stay visible.
+        return (
+            (base[0] + rng.randint(80, 180)) % 256,
+            (base[1] + rng.randint(80, 180)) % 256,
+            (base[2] + rng.randint(80, 180)) % 256,
+        )
+
+    img = Image.new("RGB", (width, height), base)
+    draw = ImageDraw.Draw(img)
+
+    # A handful of large filled shapes for broad structure.
+    n_ellipses = rng.randint(3, 7)
+    for _ in range(n_ellipses):
+        x0 = rng.randint(0, width - 1)
+        y0 = rng.randint(0, height - 1)
+        x1 = rng.randint(x0, width)
+        y1 = rng.randint(y0, height)
+        draw.ellipse([x0, y0, max(x0 + 2, x1), max(y0 + 2, y1)], fill=_accent())
+
+    n_rects = rng.randint(2, 6)
+    for _ in range(n_rects):
+        x0 = rng.randint(0, width - 1)
+        y0 = rng.randint(0, height - 1)
+        x1 = rng.randint(x0, width)
+        y1 = rng.randint(y0, height)
+        draw.rectangle([x0, y0, max(x0 + 2, x1), max(y0 + 2, y1)], fill=_accent())
+
+    # A few thin lines for extra texture.
+    n_lines = rng.randint(2, 5)
+    for _ in range(n_lines):
+        x0 = rng.randint(0, width - 1)
+        y0 = rng.randint(0, height - 1)
+        x1 = rng.randint(0, width - 1)
+        y1 = rng.randint(0, height - 1)
+        draw.line([x0, y0, x1, y1], fill=_accent(), width=max(1, min(width, height) // 200))
+
+    path = os.path.join(tempfile.gettempdir(), f"omni_bench_input_{_next_input_image_id()}.png")
+    img.save(path)
+    return path
+
+
+_INPUT_IMAGE_COUNTER = {"n": 0}
+
+
+def _next_input_image_id() -> int:
+    """Monotonic id for generated input-image temp filenames (build-local)."""
+    n = _INPUT_IMAGE_COUNTER["n"]
+    _INPUT_IMAGE_COUNTER["n"] = n + 1
+    return n
+
+
+def _resolve_image_path(item: dict[str, Any], fallback: str | None) -> str | None:
+    """Pick the input image for an i2t/it2i item: explicit path, else fallback."""
+    if item.get("image_path"):
+        p = str(item["image_path"])
+        if not os.path.exists(p):
+            raise ValueError(f"Image file not found: {p}")
+        return p
+    if item.get("image_paths"):
+        ps = item["image_paths"]
+        if isinstance(ps, str):
+            ps = [ps]
+        p = str(ps[0])
+        if not os.path.exists(p):
+            raise ValueError(f"Image file not found: {p}")
+        return p
+    return fallback
+
+
+def _load_custom_pools(path: str) -> dict[str, list[dict[str, Any]]]:
+    """Load a custom JSONL file, bucketing rows by their ``task`` field."""
+    if not path.endswith(".jsonl"):
+        raise ValueError("Custom dataset must be a JSONL file (--dataset-path).")
+    if not os.path.exists(path):
+        raise ValueError(f"Dataset file not found: {path}")
+
+    pools: dict[str, list[dict[str, Any]]] = {"i2t": [], "t2i": [], "it2i": []}
+    with open(path, encoding="utf-8") as f:
+        for lineno, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Invalid JSON on line {lineno} of {path}: {e}") from e
+            task = str(row.get("task", "")).strip().lower()
+            if task not in pools:
+                raise ValueError(f"Line {lineno}: task must be one of i2t/t2i/it2i, got '{task}'.")
+            if "prompt" not in row:
+                raise ValueError(f"Line {lineno}: missing required 'prompt' field.")
+            pools[task].append(row)
+    return pools
+
+
+def _cycle(pool: list[dict[str, Any]], n: int) -> list[dict[str, Any]]:
+    """Take ``n`` items from ``pool`` by cycling when the pool is smaller."""
+    if not pool:
+        return []
+    if n <= len(pool):
+        return pool[:n]
+    return [pool[i % len(pool)] for i in range(n)]
+
+
+def build_requests(
+    *,
+    counts: TaskCounts,
+    config: OmniConfig,
+    dataset: str,
+    dataset_path: str | None,
+    bot_task_weights: dict[str, float],
+    input_image: str | None,
+    prompts: dict[str, str] | None,
+    chat_url: str,
+    images_edits_url: str,
+    return_stage_metrics: bool,
+    it2i_endpoint: str,
+    seed: int,
+    shuffle: bool,
+    bot_task_sampling: str = "proportional",
+    group_order: tuple[str, ...] = ("i2t", "t2i", "it2i"),
+    gen_resolution_weights: dict[str, float] | None = None,
+    gen_resolution_sampling: str = "proportional",
+    randomize_input: bool = False,
+) -> list[OmniRequest]:
+    """Construct the full request list for the run.
+
+    Order of operations: allocate it2i bot_tasks + per-type generation
+    resolutions → build per-task lists → merge in ``group_order`` → shuffle
+    (or not). The RNG is single and seeded so the whole sequence (bot_task
+    allocation + resolution allocation + shuffle) is reproducible. RNG draws
+    that are disabled by default (``gen_resolution_weights is None``) are
+    skipped entirely, so a run that doesn't use the resolution feature gets the
+    exact same bot_task + shuffle sequence as before.
+
+    ``bot_task_sampling`` / ``gen_resolution_sampling`` are ``proportional``
+    (exact counts via largest remainder, default) or ``random`` (independent
+    weighted draws, matches weights only in expectation). ``group_order`` gives
+    the concatenation order of the i2t/t2i/it2i groups when ``shuffle`` is
+    False (it is ignored when ``shuffle`` is True since the merge is then
+    randomized). ``gen_resolution_weights`` overrides ``config.width`` /
+    ``config.height`` per t2i/it2i request — each of t2i and it2i is allocated
+    resolutions independently per the ratio; a custom row's explicit
+    ``width``/``height`` still wins.
+
+    ``randomize_input`` (``--randomize-input``, ``random`` dataset only) varies
+    the *input* side per request to approximate real-world diversity: a prompt
+    drawn from a short→long pool per task type (i2t / t2i / it2i); for i2t /
+    it2i a unique varied-content image generated at a resolution drawn from
+    512x512 / 1024x1024 / 1280x720. All draws come from the same seeded ``rng``
+    *after* the bot_task + resolution allocations, so a run with
+    ``randomize_input=False`` keeps the exact same bot_task + resolution +
+    shuffle sequence as before. ``--input-image`` and the ``--*-prompt``
+    overrides are ignored while randomization is on; custom dataset rows always
+    win (randomization is skipped for ``dataset="custom"``).
+    """
+    rng = random.Random(seed)
+    use_random = randomize_input and dataset == "random"
+
+    prompts = prompts or {}
+    i2t_prompt = prompts.get("i2t") or DEFAULT_I2T_PROMPT
+    t2i_prompt = prompts.get("t2i") or DEFAULT_T2I_PROMPT
+    it2i_prompt = prompts.get("it2i") or DEFAULT_IT2I_PROMPT
+
+    # The shared placeholder / --input-image is only needed when input images
+    # are NOT being generated per-request by randomization.
+    placeholder = None
+    if (counts.i2t > 0 or counts.it2i > 0) and not use_random:
+        placeholder = input_image if input_image else _placeholder_image_path()
+        if input_image and not os.path.exists(input_image):
+            raise ValueError(f"--input-image not found: {input_image}")
+
+    custom_pools: dict[str, list[dict[str, Any]]] | None = None
+    if dataset == "custom":
+        if not dataset_path:
+            raise ValueError("--dataset-path is required when --dataset custom.")
+        custom_pools = _load_custom_pools(dataset_path)
+
+    def gen_kwargs_from_row(row: dict[str, Any]) -> dict[str, Any]:
+        kw: dict[str, Any] = {}
+        for k in ("width", "height", "num_inference_steps", "seed"):
+            if k in row and row[k] is not None:
+                kw[k] = row[k]
+        return kw
+
+    # Bot-task draw stays the first RNG use so a run without the resolution
+    # feature reproduces the legacy bot_task + shuffle sequence exactly.
+    it2i_bot_tasks = draw_bot_tasks(counts.it2i, bot_task_weights, rng, bot_task_sampling) if counts.it2i else []
+    # Per-type generation resolutions for the image-output tasks. Each of t2i /
+    # it2i gets its own exact-proportional (or random) draw over the allowed
+    # resolutions; a custom row's explicit width/height still wins per-request.
+    t2i_resolutions = (
+        draw_resolutions(counts.t2i, gen_resolution_weights, rng, gen_resolution_sampling)
+        if gen_resolution_weights and counts.t2i
+        else None
+    )
+    it2i_resolutions = (
+        draw_resolutions(counts.it2i, gen_resolution_weights, rng, gen_resolution_sampling)
+        if gen_resolution_weights and counts.it2i
+        else None
+    )
+
+    i2t_reqs: list[OmniRequest] = []
+    t2i_reqs: list[OmniRequest] = []
+    it2i_reqs: list[OmniRequest] = []
+
+    # --- i2t (image understanding; modalities=text; finishes at AR stage) ---
+    for i in range(counts.i2t):
+        row = None
+        if custom_pools and custom_pools["i2t"]:
+            row = custom_pools["i2t"][i % len(custom_pools["i2t"])]
+        if row:
+            prompt = str(row.get("prompt", i2t_prompt))
+            img = _resolve_image_path(row, placeholder)
+            in_size = None
+        elif use_random:
+            prompt = _draw_prompt("i2t", rng)
+            iw, ih = _draw_input_resolution(rng)
+            img = _generate_diverse_image(rng, iw, ih)
+            in_size = f"{iw}x{ih}"
+        else:
+            prompt = i2t_prompt
+            img = placeholder
+            in_size = None
+        extra_body: dict[str, Any] = {"modalities": ["text"], "temperature": 0}
+        if return_stage_metrics:
+            extra_body["return_stage_metrics"] = True
+        i2t_reqs.append(
+            OmniRequest(
+                task_type="i2t",
+                prompt=prompt,
+                api_url=chat_url,
+                model=config.model,
+                image_paths=[img] if img else None,
+                extra_body=extra_body,
+                seed=config.seed,
+                input_image_size=in_size,
+            )
+        )
+
+    # --- t2i (text-to-image; modalities=image; no reference image) ---
+    for i in range(counts.t2i):
+        row = None
+        if custom_pools and custom_pools["t2i"]:
+            row = custom_pools["t2i"][i % len(custom_pools["t2i"])]
+        if row:
+            prompt = str(row.get("prompt", t2i_prompt))
+            gkw = gen_kwargs_from_row(row)
+        elif use_random:
+            prompt = _draw_prompt("t2i", rng)
+            gkw = {}
+        else:
+            prompt = t2i_prompt
+            gkw = {}
+        if t2i_resolutions is not None and "width" not in gkw and "height" not in gkw:
+            rw, rh = t2i_resolutions[i]
+            gkw.setdefault("width", rw)
+            gkw.setdefault("height", rh)
+        extra_body = {"modalities": ["image"], "temperature": 0}
+        if return_stage_metrics:
+            extra_body["return_stage_metrics"] = True
+        t2i_reqs.append(
+            OmniRequest(
+                task_type="t2i",
+                prompt=prompt,
+                api_url=chat_url,
+                model=config.model,
+                width=gkw.get("width", config.width),
+                height=gkw.get("height", config.height),
+                num_inference_steps=gkw.get("num_inference_steps", config.num_inference_steps),
+                seed=gkw.get("seed", config.seed),
+                extra_body=extra_body,
+            )
+        )
+
+    # --- it2i (image editing; modalities=image + reference image + bot_task) ---
+    for i in range(counts.it2i):
+        row = None
+        if custom_pools and custom_pools["it2i"]:
+            row = custom_pools["it2i"][i % len(custom_pools["it2i"])]
+        bot_task = it2i_bot_tasks[i]
+        if row:
+            prompt = str(row.get("prompt", it2i_prompt))
+            img = _resolve_image_path(row, placeholder)
+            if row.get("bot_task"):
+                bot_task = str(row["bot_task"])
+            gkw = gen_kwargs_from_row(row)
+            in_size = None
+        elif use_random:
+            prompt = _draw_prompt("it2i", rng)
+            iw, ih = _draw_input_resolution(rng)
+            img = _generate_diverse_image(rng, iw, ih)
+            gkw = {}
+            in_size = f"{iw}x{ih}"
+        else:
+            prompt = it2i_prompt
+            img = placeholder
+            gkw = {}
+            in_size = None
+        if it2i_resolutions is not None and "width" not in gkw and "height" not in gkw:
+            rw, rh = it2i_resolutions[i]
+            gkw.setdefault("width", rw)
+            gkw.setdefault("height", rh)
+        extra_body: dict[str, Any] = {"modalities": ["image"], "temperature": 0}
+        # On the chat endpoint bot_task rides in extra_body; on /v1/images/edits
+        # it is a form field handled by async_request_image_edits via
+        # default_bot_task / extra_body.
+        if it2i_endpoint == "chat":
+            extra_body["bot_task"] = bot_task
+        if return_stage_metrics:
+            extra_body["return_stage_metrics"] = True
+        it2i_url = images_edits_url if it2i_endpoint == "images-edits" else chat_url
+        it2i_reqs.append(
+            OmniRequest(
+                task_type="it2i",
+                prompt=prompt,
+                api_url=it2i_url,
+                model=config.model,
+                image_paths=[img] if img else None,
+                width=gkw.get("width", config.width),
+                height=gkw.get("height", config.height),
+                num_inference_steps=gkw.get("num_inference_steps", config.num_inference_steps),
+                seed=gkw.get("seed", config.seed),
+                extra_body=extra_body,
+                default_bot_task=bot_task,
+                bot_task=bot_task,
+                input_image_size=in_size,
+            )
+        )
+
+    # Merge per-type lists in group_order (any task type missing from
+    # group_order is appended after, defensively, so counts are preserved).
+    by_type = {"i2t": i2t_reqs, "t2i": t2i_reqs, "it2i": it2i_reqs}
+    requests: list[OmniRequest] = []
+    for task in group_order:
+        requests.extend(by_type.get(task, []))
+    for task in ("i2t", "t2i", "it2i"):
+        if task not in group_order:
+            requests.extend(by_type.get(task, []))
+
+    if shuffle:
+        rng.shuffle(requests)
+    return requests
+
+
+__all__ = [
+    "DEFAULT_I2T_PROMPT",
+    "DEFAULT_T2I_PROMPT",
+    "DEFAULT_IT2I_PROMPT",
+    "OmniConfig",
+    "TaskCounts",
+    "GEN_RESOLUTIONS",
+    "INPUT_RESOLUTIONS",
+    "parse_bot_task_weights",
+    "allocate_bot_tasks",
+    "sample_bot_tasks",
+    "draw_bot_tasks",
+    "parse_gen_resolution_weights",
+    "allocate_resolutions",
+    "sample_resolutions",
+    "draw_resolutions",
+    "build_requests",
+]

--- a/benchmarks/omni/run_benchmark_loop.sh
+++ b/benchmarks/omni/run_benchmark_loop.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Usage: ./run_benchmark_loop.sh <rounds>
+# Example: ./run_benchmark_loop.sh 5
+
+ROUNDS=${1:-1}
+INTERVAL=1
+
+if [[ "$ROUNDS" -lt 1 ]]; then
+    echo "Error: rounds must be >= 1"
+    exit 1
+fi
+
+echo "Starting $ROUNDS rounds of benchmark testing..."
+
+for i in $(seq 1 "$ROUNDS"); do
+    echo "=========================================="
+    echo "Round $i / $ROUNDS  (seed=$i)"
+    echo "=========================================="
+
+    python3 benchmarks/omni/omni_benchmark_serving.py \
+        --host 127.0.0.1 \
+        --port 8098 \
+        --model /workspace/models/weight/HunyuanImage-3.0-Instruct \
+        --num-i2t 14 \
+        --num-t2i 3 \
+        --num-it2i 3 \
+        --max-concurrency 20 \
+        --shuffle \
+        --it2i-endpoint images-edits \
+        --gen-resolution-weights "512x512=1,1024x1024=1,1280x720=1" \
+        --randomize-input \
+        --output-dir "benchmark-res/baseline/omni-14-3-3-seed-$i" \
+        --seed "$i" \
+	--dry-run
+
+    exit_code=$?
+    if [[ $exit_code -ne 0 ]]; then
+        echo "WARNING: Round $i exited with code $exit_code"
+    fi
+
+    if [[ $i -lt $ROUNDS ]]; then
+        echo ""
+        echo "Round $i completed. Waiting ${INTERVAL}s before next round..."
+        sleep "$INTERVAL"
+    fi
+done
+
+echo ""
+echo "All $ROUNDS rounds completed."


### PR DESCRIPTION
## Summary

Adds a serving benchmark tool (`benchmarks/omni/`) that evaluates mixed i2t (understanding) / t2i (generation) / it2i (editing) concurrent workloads on unified AR+DiT models (e.g. HunyuanImage-3.0). This benchmark fills the gap left by `benchmarks/diffusion/` (which only covers pure generation tasks) by testing the mixed understanding+generation concurrency scenario that the DTPS scheduler is designed to optimize.

## Motivation

Currently there is no benchmark for unified understanding+generation models under mixed task concurrency. This tool is designed to measure DTPS scheduling strategy effectiveness and evaluate scheduling optimizations under realistic mixed i2t/t2i/it2i workloads.

Closes #6237
Related feature PR: #6315 (DTPS DiT-load-aware Type-Priority Scheduling)

## Key Features

- **Configurable task mix ratios** (`--num-i2t`/`--num-t2i`/`--num-it2i`) — e.g. 14:2:4 for 7:1:2 ratio
- **it2i bot_task weighted sampling** (think/recaption/think_recaption) with proportional or random allocation
- **True random send order** with reproducible seed — interleaves task types instead of sending in blocks
- **Per-task / per-bot_task / per-stage (AR/DiT) statistics** — overall + per-task + it2i-by-bot_task three-layer bucketing
- **Streaming text-output TTFT/TPOT/ITL** (vLLM-style) — i2t AR answer text and it2i AR thinking text latency
- **Input randomization** (`--randomize-input`) — diverse prompt lengths, input image resolutions, and content per request
- **Generation resolution weighted allocation** — mix 512x512 / 1024x1024 / 1280x720 outputs
- **Client dispatch order audit trail** — distinguishes client send order from server-side DTPS re-dispatch

## Files

| File | Description |
|------|-------------|
| `omni_benchmark_serving.py` | Main entry point — CLI parsing, request dispatch, metrics aggregation, JSON output |
| `omni_backends.py` | Async HTTP senders (chat stream/non-stream, images-edits stream/non-stream) + output parsing |
| `omni_dataset.py` | Request list construction — task mix, bot_task sampling, resolution allocation, input randomization |
| `_test_randomize_cli.py` | CLI-level dry-run test for --randomize-input |
| `_test_randomize_input.py` | Unit tests for dataset construction logic |
| `run_benchmark_loop.sh` | Multi-round benchmark loop helper |
| `README.md` | Full documentation with usage examples |
| `__init__.py` | Package init |

## Quick Smoke

```bash
# Dry-run: print the request plan without sending
python benchmarks/omni/omni_benchmark_serving.py \
    --host 127.0.0.1 --port 8099 \
    --num-i2t 14 --num-t2i 2 --num-it2i 4 \
    --it2i-bot-task-weights "recaption=2,think=1,think_recaption=1" \
    --shuffle --seed 3 --dry-run
```

## Naming Rationale

The directory is named `omni` (not `mixed`) to align with the codebase's existing terminology (`vllm_omni`, `--omni` serving flag, `OmniARScheduler`) and to follow the capability-based naming convention used by sibling benchmark directories (`diffusion/`, `tts/`). The name reflects that this benchmark applies to any unified understanding+generation model, not just HunyuanImage-3.0.

## Pre-check

- [x] PR title follows `[CI/Build]` convention
- [x] All pre-commit hooks pass (ruff check, ruff format, typos, DCO)
- [x] No model-specific Python examples under `examples/`
- [x] No dead code or unused imports
- [x] No event-loop blocking or hot-path copies
