### PR TITLE
[diffusion][feature] Add LingBot-Video prompt rewriter

### DIFF
--- a/examples/online_serving/lingbot_video/README.md
+++ b/examples/online_serving/lingbot_video/README.md
@@ -17,6 +17,55 @@ substantially more GPU memory:
 MODEL=robbyant/lingbot-video-moe-30b-a3b bash run_server.sh
 ```
 
+## Prompt rewriter
+
+LingBot-Video is trained on structured JSON captions. The optional rewriter
+accepts a plain prompt and runs the official two-turn flow before text
+encoding: the base VLM first expands the prompt, then the rewriter LoRA maps
+the expansion to JSON. Prompts that already start with a JSON object pass
+through unchanged. The rewriter is disabled by default.
+
+The recommended deployment keeps the 27B rewriter outside the diffusion
+worker. Serve the base and adapter-applied mapping models behind
+OpenAI-compatible chat endpoints, then configure the diffusion stage:
+
+```bash
+MODEL=robbyant/lingbot-video-dense-1.3b bash run_server.sh --stage-overrides '{"0":{"model_config":{
+    "rewriter_url":"http://127.0.0.1:30000",
+    "rewriter_map_url":"http://127.0.0.1:30001",
+    "rewriter_expand_model":"Qwen/Qwen3.6-27B",
+    "rewriter_map_model":"lingbot-video-rewriter"
+  }}}'
+```
+
+`rewriter_map_url` may be omitted when one endpoint serves both model names.
+The mapping model must have
+`robbyant/lingbot-video-rewriter-lora` applied or merged. The request fails
+if the mapping turn does not produce parseable JSON; it does not silently run
+the diffusion model with the out-of-distribution plain prompt.
+
+For offline or tightly coupled deployments, the worker can lazily load the
+base model and PEFT adapter on the first plain-text request:
+
+```bash
+MODEL=robbyant/lingbot-video-dense-1.3b bash run_server.sh --stage-overrides '{"0":{"model_config":{
+    "rewriter_model_path":"Qwen/Qwen3.6-27B",
+    "rewriter_adapter_path":"robbyant/lingbot-video-rewriter-lora",
+    "rewriter_device_map":"auto"
+  }}}'
+```
+
+This path requires `peft` and enough memory for the rewriter in addition to
+LingBot. Configure only one of `rewriter_url` and `rewriter_model_path`.
+In distributed execution, rank 0 runs the external or in-process rewriter and
+broadcasts the resulting caption to the other ranks.
+
+Set `"rewriter_auto_negative":true` in the same `model_config` to run one
+additional base-model turn that removes negative-prompt terms which conflict
+with the generated caption. This only edits LingBot's categorized JSON
+negative prompt: free-text or malformed negative prompts pass through
+unchanged, and the model cannot add or reorder terms.
+
 ## Text to image
 
 The image endpoint selects T2I mode and always generates one frame:

--- a/tests/diffusion/models/lingbot_video/test_pipeline_lingbot_video.py
+++ b/tests/diffusion/models/lingbot_video/test_pipeline_lingbot_video.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from types import SimpleNamespace
 
@@ -24,6 +24,7 @@ def _make_pipeline():
     pipeline.device = torch.device("cpu")
     pipeline.default_negative_prompt = "default negative"
     pipeline.default_image_negative_prompt = "default image negative"
+    pipeline.prompt_rewriter = None
     pipeline.img_prompt_template = "<image>"
     pipeline.od_config = SimpleNamespace(flow_shift=None)
     return pipeline
@@ -292,6 +293,44 @@ def test_forward_prefers_shift_over_flow_shift_and_defaults_negative_prompt():
 
     assert calls[0]["shift"] == 5.0
     assert calls[0]["negative_prompt"] == "default negative"
+
+
+def test_forward_rewrites_prompt_and_negative_before_generation():
+    pipeline = _make_pipeline()
+    rewrite_calls = []
+    generate_calls = []
+
+    class FakeRewriter:
+        def rewrite_request(self, **kwargs):
+            rewrite_calls.append(kwargs)
+            return '{"caption":"rewritten"}', '{"negative":"rewritten"}'
+
+    def fake_generate(**kwargs):
+        generate_calls.append(kwargs)
+        return torch.zeros(5, 192, 192, 3)
+
+    pipeline.prompt_rewriter = FakeRewriter()
+    pipeline._generate = fake_generate
+    req = _make_request_batch(
+        {"prompt": "a robot arm", "modalities": ["video"]},
+        height=192,
+        width=192,
+        num_frames=5,
+        num_inference_steps=2,
+        guidance_scale=1.0,
+        seed=42,
+    )
+
+    pipeline.forward(req)
+
+    assert len(rewrite_calls) == 1
+    assert rewrite_calls[0]["prompt"] == "a robot arm"
+    assert rewrite_calls[0]["negative_prompt"] == "default negative"
+    assert rewrite_calls[0]["mode"].value == "t2v"
+    assert rewrite_calls[0]["num_frames"] == 5
+    assert rewrite_calls[0]["fps"] == 24
+    assert generate_calls[0]["prompt"] == '{"caption":"rewritten"}'
+    assert generate_calls[0]["negative_prompt"] == '{"negative":"rewritten"}'
 
 
 @pytest.mark.parametrize(

--- a/tests/diffusion/models/lingbot_video/test_rewriter.py
+++ b/tests/diffusion/models/lingbot_video/test_rewriter.py
@@ -1,0 +1,315 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+import json
+
+import pytest
+from PIL import Image
+
+from vllm_omni.diffusion.models.lingbot_video.auto_negative import (
+    categorized_negative,
+    prune_negative,
+)
+from vllm_omni.diffusion.models.lingbot_video.request_utils import LingBotGenerationMode
+from vllm_omni.diffusion.models.lingbot_video.rewriter import (
+    LingBotVideoRewriter,
+    build_expand_prompt,
+    build_map_prompt,
+    needs_rewrite,
+    parse_caption,
+)
+from vllm_omni.diffusion.models.lingbot_video.rewriter_backends import (
+    HTTPRewriterBackend,
+    TransformersRewriterBackend,
+    _chat_completions_url,
+    build_lingbot_rewriter,
+)
+from vllm_omni.diffusion.models.lingbot_video.rewriter_prompts import (
+    VIDEO_DURATION_EN,
+    VIDEO_DURATION_ZH,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.diffusion]
+
+
+class FakeBackend:
+    def __init__(self, replies):
+        self.replies = list(replies)
+        self.calls = []
+
+    def generate(self, text, image, use_lora):
+        self.calls.append((text, image, use_lora))
+        return self.replies.pop(0)
+
+
+def _rewrite(rewriter, prompt, *, mode=LingBotGenerationMode.T2V, image=None, negative="negative"):
+    return rewriter.rewrite_request(
+        prompt=prompt,
+        negative_prompt=negative,
+        mode=mode,
+        num_frames=121 if mode is not LingBotGenerationMode.T2I else 1,
+        fps=24,
+        input_image=image,
+    )
+
+
+def test_rewriter_uses_two_turns_and_enables_adapter_only_for_mapping():
+    backend = FakeBackend(["A red fox trots through snow.", '{"b": 2, "a": 1}'])
+    rewriter = LingBotVideoRewriter(backend)
+
+    prompt, negative = _rewrite(rewriter, "a red fox")
+
+    assert prompt == '{"b":2,"a":1}'
+    assert negative == "negative"
+    assert [use_lora for _, _, use_lora in backend.calls] == [False, True]
+    assert all(image is None for _, image, _ in backend.calls)
+    assert backend.calls[0][0].endswith(f"a red fox\n\n{VIDEO_DURATION_EN.format(duration=5)}")
+    assert "DETAILED CAPTION:\nA red fox trots through snow." in backend.calls[1][0]
+
+
+def test_ti2v_rewriter_passes_the_condition_image_to_both_turns():
+    image = Image.new("RGB", (16, 8), color="blue")
+    backend = FakeBackend(["The subject moves.", '{"caption":"mapped"}'])
+    rewriter = LingBotVideoRewriter(backend)
+
+    prompt, _ = _rewrite(
+        rewriter,
+        "the subject moves",
+        mode=LingBotGenerationMode.TI2V,
+        image=image,
+    )
+
+    assert prompt == '{"caption":"mapped"}'
+    assert [call[1] for call in backend.calls] == [image, image]
+
+
+def test_structured_caption_skips_rewriting():
+    backend = FakeBackend([])
+    rewriter = LingBotVideoRewriter(backend)
+    caption = '{"comprehensive_description":"a red fox"}'
+
+    prompt, negative = _rewrite(rewriter, caption)
+
+    assert prompt == caption
+    assert negative == "negative"
+    assert backend.calls == []
+
+
+def test_non_primary_rank_uses_broadcast_result_without_calling_backend(monkeypatch):
+    from vllm_omni.diffusion.models.lingbot_video import rewriter as module
+
+    backend = FakeBackend([])
+    rewriter = LingBotVideoRewriter(backend)
+    monkeypatch.setattr(module.dist, "is_available", lambda: True)
+    monkeypatch.setattr(module.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(module.dist, "get_rank", lambda: 1)
+
+    def fake_broadcast(objects, src):
+        assert src == 0
+        objects[0] = (True, ('{"caption":"broadcast"}', "broadcast negative"))
+
+    monkeypatch.setattr(module.dist, "broadcast_object_list", fake_broadcast)
+
+    prompt, negative = _rewrite(rewriter, "a red fox")
+
+    assert prompt == '{"caption":"broadcast"}'
+    assert negative == "broadcast negative"
+    assert backend.calls == []
+
+
+def test_rewriter_does_not_fall_back_when_mapping_is_not_json():
+    backend = FakeBackend(["expanded", "sorry, I cannot map that"])
+    rewriter = LingBotVideoRewriter(backend)
+
+    with pytest.raises(RuntimeError, match="no parseable structured caption"):
+        _rewrite(rewriter, "a red fox")
+
+
+def test_prompt_builders_select_image_and_caption_language_contracts():
+    image_expand = build_expand_prompt("t2i", "a glass of tea", 5)
+    assert "User image prompt:\na glass of tea" in image_expand
+    assert "Video Duration" not in image_expand
+    assert "DETAILED CAPTION:\nexpanded" in build_map_prompt("t2i", "expanded", 5)
+
+    chinese = build_expand_prompt("t2v", "一只狐狸在雪地里奔跑", 3)
+    assert VIDEO_DURATION_ZH.format(duration=3) in chinese
+    assert VIDEO_DURATION_EN.format(duration=3) not in chinese
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ('{"a": 1}', {"a": 1}),
+        ('```json\n{"a": 1}\n```', {"a": 1}),
+        ('Here you go: {"a": 1} hope that helps', {"a": 1}),
+        ('["not", "an", "object"]', None),
+        ("no json here", None),
+    ],
+)
+def test_parse_caption_tolerates_fences_and_prose(raw, expected):
+    assert parse_caption(raw) == expected
+
+
+def test_needs_rewrite_follows_structured_caption_shape():
+    assert needs_rewrite("a red fox")
+    assert not needs_rewrite('{"caption":"a red fox"}')
+    assert not needs_rewrite('  {"caption":"a red fox"}')
+
+
+def test_auto_negative_keeps_default_order_and_only_deletes_terms():
+    default = {
+        "universal_negative": {
+            "visual_quality": ["low quality", "underexposed", "crushed blacks"],
+            "artistic_style": ["painting", "cartoon"],
+            "temporal_and_motion_stability": ["motion blur", "warping"],
+        }
+    }
+    model_output = {
+        "universal_negative": {
+            "visual_quality": ["invented", "low quality"],
+            "artistic_style": ["cartoon", "painting"],
+            "temporal_and_motion_stability": ["warping", "motion blur"],
+        }
+    }
+
+    result = prune_negative(default, model_output, "a moody night scene with deep shadows")
+
+    assert result["universal_negative"]["visual_quality"] == ["low quality"]
+    assert result["universal_negative"]["artistic_style"] == ["painting", "cartoon"]
+    assert result["universal_negative"]["temporal_and_motion_stability"] == [
+        "motion blur",
+        "warping",
+    ]
+
+
+def test_auto_negative_runs_after_prompt_mapping_and_uses_base_model():
+    default_negative = json.dumps(
+        {
+            "universal_negative": {
+                "visual_quality": ["low quality", "underexposed"],
+                "artistic_style": ["painting"],
+            }
+        }
+    )
+    backend = FakeBackend(
+        [
+            "A night scene.",
+            '{"comprehensive_description":"a dim night scene"}',
+            '{"universal_negative":{"visual_quality":["low quality"],"artistic_style":["painting"]}}',
+        ]
+    )
+    rewriter = LingBotVideoRewriter(backend, auto_negative=True)
+
+    prompt, negative = _rewrite(
+        rewriter,
+        "a night scene",
+        negative=default_negative,
+    )
+
+    assert json.loads(prompt)["comprehensive_description"] == "a dim night scene"
+    assert json.loads(negative)["universal_negative"]["visual_quality"] == ["low quality"]
+    assert [use_lora for _, _, use_lora in backend.calls] == [False, True, False]
+
+
+@pytest.mark.parametrize(
+    "negative",
+    [
+        "blurry, low quality",
+        '{"universal_negative":[]}',
+        '{"universal_negative":{"visual_quality":"not a list"}}',
+        '{"universal_negative":{"visual_quality":[1,2]}}',
+    ],
+)
+def test_categorized_negative_rejects_unprunable_shapes(negative):
+    assert categorized_negative(negative) is None
+
+
+@pytest.mark.parametrize(
+    ("base", "expected"),
+    [
+        ("http://host:8000", "http://host:8000/v1/chat/completions"),
+        ("http://host:8000/v1", "http://host:8000/v1/chat/completions"),
+        (
+            "http://host:8000/v1/chat/completions",
+            "http://host:8000/v1/chat/completions",
+        ),
+    ],
+)
+def test_chat_completions_url_accepts_server_or_endpoint_urls(base, expected):
+    assert _chat_completions_url(base) == expected
+
+
+def test_http_backend_selects_endpoint_model_and_encodes_image(mocker):
+    response = mocker.Mock()
+    response.json.return_value = {"choices": [{"message": {"content": " mapped "}}]}
+    post = mocker.patch(
+        "vllm_omni.diffusion.models.lingbot_video.rewriter_backends.httpx.post",
+        return_value=response,
+    )
+    backend = HTTPRewriterBackend(
+        url="http://expand:8000",
+        map_url="http://map:8001/v1",
+        expand_model="base-model",
+        map_model="map-model",
+        timeout=12.0,
+    )
+
+    result = backend.generate("map this", Image.new("RGB", (2, 2)), use_lora=True)
+
+    assert result == "mapped"
+    url = post.call_args.args[0]
+    payload = post.call_args.kwargs["json"]
+    assert url == "http://map:8001/v1/chat/completions"
+    assert payload["model"] == "map-model"
+    assert payload["messages"][0]["content"][0]["image_url"]["url"].startswith("data:image/png;base64,")
+    assert payload["chat_template_kwargs"] == {"enable_thinking": False}
+    assert post.call_args.kwargs["timeout"] == 12.0
+    response.raise_for_status.assert_called_once_with()
+
+
+def test_build_rewriter_selects_backend_and_is_off_by_default():
+    assert build_lingbot_rewriter({}) is None
+
+    remote = build_lingbot_rewriter(
+        {
+            "rewriter_url": "http://host:8000",
+            "rewriter_expand_model": "base",
+            "rewriter_map_model": "mapped",
+            "rewriter_auto_negative": True,
+        }
+    )
+    assert isinstance(remote, LingBotVideoRewriter)
+    assert isinstance(remote.backend, HTTPRewriterBackend)
+    assert remote.auto_negative is True
+
+    local = build_lingbot_rewriter(
+        {
+            "rewriter_model_path": "Qwen/Qwen3.6-27B",
+            "rewriter_adapter_path": "robbyant/lingbot-video-rewriter-lora",
+        }
+    )
+    assert isinstance(local.backend, TransformersRewriterBackend)
+    assert local.backend.model is None
+
+
+@pytest.mark.parametrize(
+    ("config", "message"),
+    [
+        (
+            {"rewriter_url": "http://host", "rewriter_model_path": "model"},
+            "mutually exclusive",
+        ),
+        ({"rewriter_map_url": "http://map"}, "requires"),
+        ({"rewriter_model_path": "model"}, "requires"),
+        ({"rewriter_adapter_path": "adapter"}, "requires"),
+        ({"rewriter_auto_negative": True}, "requires"),
+        ({"rewriter_timeout": 0}, "positive"),
+        ({"rewriter_timeout": float("nan")}, "positive"),
+        ({"rewriter_max_new_tokens": 0}, "positive"),
+        ({"rewriter_max_new_tokens": 1.5}, "positive integer"),
+        ({"rewriter_auto_negative": "true"}, "boolean"),
+    ],
+)
+def test_build_rewriter_rejects_invalid_configuration(config, message):
+    with pytest.raises(ValueError, match=message):
+        build_lingbot_rewriter(config)

--- a/vllm_omni/diffusion/models/lingbot_video/__init__.py
+++ b/vllm_omni/diffusion/models/lingbot_video/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from vllm_omni.diffusion.models.lingbot_video.image_condition import (
     LingBotImageCondition,
@@ -25,14 +25,18 @@ from vllm_omni.diffusion.models.lingbot_video.request_utils import (
     resolve_lingbot_output_dimensions,
     resolve_lingbot_size,
 )
+from vllm_omni.diffusion.models.lingbot_video.rewriter import LingBotVideoRewriter
+from vllm_omni.diffusion.models.lingbot_video.rewriter_backends import build_lingbot_rewriter
 
 __all__ = [
     "LingBotGenerationMode",
     "LingBotImageCondition",
     "LingBotRequestConfig",
     "LingBotVideoPipeline",
+    "LingBotVideoRewriter",
     "LingBotVideoTransformer3DModel",
     "apply_clean_prefix",
+    "build_lingbot_rewriter",
     "caption_from_lingbot_prompt",
     "geometry_align_image",
     "get_lingbot_video_pre_process_func",

--- a/vllm_omni/diffusion/models/lingbot_video/auto_negative.py
+++ b/vllm_omni/diffusion/models/lingbot_video/auto_negative.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+# Adapted from SGLang (https://github.com/sgl-project/sglang/pull/32848).
+
+from __future__ import annotations
+
+import json
+
+import regex as re
+from PIL import Image
+
+from vllm_omni.diffusion.models.lingbot_video.rewriter import (
+    RewriterBackend,
+    parse_caption,
+)
+from vllm_omni.diffusion.models.lingbot_video.rewriter_prompts import NEGATIVE_PRUNE
+
+_ROOT = "universal_negative"
+
+
+def _hint_pattern(*hints: str) -> re.Pattern:
+    alternatives = "|".join(re.escape(hint) for hint in hints)
+    return re.compile(rf"(?<![a-z0-9])(?:{alternatives})(?![a-z0-9])")
+
+
+_BLOCK_HINTS = {
+    "physical_plausibility": _hint_pattern(
+        "fantasy",
+        "surreal",
+        "dreamlike",
+        "dream-like",
+        "magic",
+        "magical",
+        "supernatural",
+        "physics-bending",
+        "physics bending",
+        "impossible physics",
+        "anti-gravity",
+        "antigravity",
+        "zero gravity",
+        "zero-gravity",
+        "weightless",
+        "weightlessness",
+        "floating in space",
+        "outer space",
+        "astronaut",
+    ),
+    "artistic_style": _hint_pattern(
+        "painting",
+        "illustration",
+        "cartoon",
+        "drawing",
+        "sketch",
+        "cgi",
+        "3d render",
+        "3d-render",
+        "digital art",
+        "anime",
+        "stylized animation",
+        "claymation",
+        "stop motion",
+        "stop-motion",
+    ),
+}
+
+_FORCED_DELETIONS = (
+    (
+        _hint_pattern(
+            "dark",
+            "dim",
+            "dimly",
+            "low light",
+            "low-light",
+            "night",
+            "nighttime",
+            "moody",
+            "gloomy",
+            "ominous",
+            "deep shadow",
+            "deep shadows",
+            "dark shadows",
+        ),
+        ("underexposed", "subject hidden in darkness", "crushed blacks"),
+    ),
+    (
+        _hint_pattern(
+            "motion blur",
+            "motion-blur",
+            "blurred background",
+            "blurred landscape",
+            "blurred scenery",
+            "blurred surroundings",
+            "speed blur",
+            "long exposure",
+        ),
+        ("motion blur",),
+    ),
+)
+
+
+def categorized_negative(negative_prompt: str) -> dict | None:
+    """Return the shipped category shape, or ``None`` for free text."""
+
+    parsed = parse_caption(negative_prompt)
+    if not isinstance(parsed, dict):
+        return None
+    categories = parsed.get(_ROOT)
+    if not isinstance(categories, dict):
+        return None
+    for terms in categories.values():
+        if not isinstance(terms, list) or not all(isinstance(term, str) for term in terms):
+            return None
+    return {_ROOT: categories}
+
+
+def build_prune_prompt(caption: str, mode: str, default: dict) -> str:
+    return (
+        f"{NEGATIVE_PRUNE}\n\n## MODE: {mode}\n\n"
+        f"## INTENDED CONTENT (structured caption):\n```json\n{caption}\n```\n\n"
+        "## DEFAULT NEGATIVE (delete the contradicting terms, keep the rest):\n"
+        f"```json\n{json.dumps(default, ensure_ascii=False)}\n```\n\n"
+        "Output ONLY the edited negative JSON now."
+    )
+
+
+def prune_negative(default: dict, pruned: dict | None, caption: str) -> dict:
+    """Keep the default order and allow the model to delete terms only."""
+
+    kept = pruned.get(_ROOT) if isinstance(pruned, dict) else None
+    lowered = caption.lower()
+    out = {}
+    for category, terms in default[_ROOT].items():
+        survivors = kept.get(category) if isinstance(kept, dict) else None
+        if not isinstance(survivors, list):
+            out[category] = list(terms)
+            continue
+        survivor_set = set(survivors)
+        out[category] = [term for term in terms if term in survivor_set]
+        hints = _BLOCK_HINTS.get(category)
+        if not out[category] and hints is not None and not hints.search(lowered):
+            out[category] = list(terms)
+    for hints, deletions in _FORCED_DELETIONS:
+        if not hints.search(lowered):
+            continue
+        for category, terms in out.items():
+            out[category] = [term for term in terms if term not in deletions]
+    return {_ROOT: out}
+
+
+def customize_negative_prompt(
+    *,
+    backend: RewriterBackend,
+    caption: str,
+    mode: str,
+    negative_prompt: str,
+    image: Image.Image | None,
+) -> str:
+    default = categorized_negative(negative_prompt)
+    if default is None:
+        return negative_prompt
+    raw = backend.generate(
+        build_prune_prompt(caption, mode, default),
+        image,
+        use_lora=False,
+    )
+    negative = prune_negative(default, parse_caption(raw), caption)
+    return json.dumps(negative, ensure_ascii=False, separators=(",", ":"))

--- a/vllm_omni/diffusion/models/lingbot_video/pipeline_lingbot_video.py
+++ b/vllm_omni/diffusion/models/lingbot_video/pipeline_lingbot_video.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 # Adapted from LingBot-Video (https://github.com/Robbyant/lingbot-video).
 
 from __future__ import annotations
@@ -34,6 +34,7 @@ from vllm_omni.diffusion.models.lingbot_video.request_utils import (
     LingBotGenerationMode,
     normalize_lingbot_request,
 )
+from vllm_omni.diffusion.models.lingbot_video.rewriter_backends import build_lingbot_rewriter
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.models.schedulers import FlowUniPCMultistepScheduler
 from vllm_omni.diffusion.request import OmniDiffusionRequest
@@ -338,6 +339,7 @@ class LingBotVideoPipeline(
         local_files_only = os.path.exists(model)
         dtype = getattr(od_config, "dtype", torch.bfloat16)
         model_config = getattr(od_config, "model_config", None) or {}
+        self.prompt_rewriter = build_lingbot_rewriter(model_config)
         transformer_dtype = _dtype_from_name(model_config.get("transformer_dtype"), dtype)
         text_encoder_dtype = _dtype_from_name(model_config.get("text_encoder_dtype"), dtype)
         vae_dtype = _dtype_from_name(model_config.get("vae_dtype"), torch.float32)
@@ -845,11 +847,23 @@ class LingBotVideoPipeline(
         sampling.guidance_scale = request_config.guidance_scale
         sampling.output_type = request_config.output_type
 
+        prompt = request_config.prompt
+        negative_prompt = request_config.negative_prompt
+        if self.prompt_rewriter is not None:
+            prompt, negative_prompt = self.prompt_rewriter.rewrite_request(
+                prompt=prompt,
+                negative_prompt=negative_prompt,
+                mode=request_config.mode,
+                num_frames=request_config.num_frames,
+                fps=request_config.fps,
+                input_image=request_config.input_image,
+            )
+
         frames = self._generate(
-            prompt=request_config.prompt,
+            prompt=prompt,
             mode=request_config.mode,
             input_image=request_config.input_image,
-            negative_prompt=request_config.negative_prompt,
+            negative_prompt=negative_prompt,
             height=request_config.height,
             width=request_config.width,
             num_frames=request_config.num_frames,

--- a/vllm_omni/diffusion/models/lingbot_video/rewriter.py
+++ b/vllm_omni/diffusion/models/lingbot_video/rewriter.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+# Adapted from SGLang (https://github.com/sgl-project/sglang/pull/32848).
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Protocol, TypeVar
+
+import regex as re
+import torch.distributed as dist
+from PIL import Image
+
+from vllm_omni.diffusion.models.lingbot_video.request_utils import LingBotGenerationMode
+from vllm_omni.diffusion.models.lingbot_video.rewriter_prompts import (
+    IMAGE_STEP1_EXPAND,
+    IMAGE_STEP2_MAP,
+    VIDEO_DURATION_EN,
+    VIDEO_DURATION_ZH,
+    VIDEO_STEP1_EXPAND,
+    VIDEO_STEP2_MAP,
+)
+
+_CJK = re.compile(r"[　-〿㐀-䶿一-鿿＀-￯]")
+_FENCED_JSON = re.compile(r"```(?:json)?\s*(\{.*\})\s*```", re.DOTALL)
+_T = TypeVar("_T")
+
+
+class RewriterBackend(Protocol):
+    def generate(self, text: str, image: Image.Image | None, use_lora: bool) -> str: ...
+
+
+def build_expand_prompt(mode: str, prompt: str, duration: int) -> str:
+    if mode == LingBotGenerationMode.T2I.value:
+        return f"{IMAGE_STEP1_EXPAND}\n\nUser image prompt:\n{prompt}"
+    template = VIDEO_DURATION_ZH if _CJK.search(prompt) else VIDEO_DURATION_EN
+    duration_line = template.format(duration=duration)
+    return f"{VIDEO_STEP1_EXPAND}\n\n{prompt}\n\n{duration_line}"
+
+
+def build_map_prompt(mode: str, detailed: str, duration: int) -> str:
+    if mode == LingBotGenerationMode.T2I.value:
+        return f"{IMAGE_STEP2_MAP}\n\nDETAILED CAPTION:\n{detailed}"
+    return (
+        f"{VIDEO_STEP2_MAP}\n\nVideo Duration: {duration} seconds\n\n"
+        f"DETAILED CAPTION:\n{detailed}\n\nOutput the JSON now."
+    )
+
+
+def parse_caption(raw: str) -> dict | None:
+    """Parse a mapped caption while tolerating code fences and stray prose."""
+
+    text = (raw or "").strip()
+    fenced = _FENCED_JSON.search(text)
+    if fenced:
+        text = fenced.group(1)
+    start, end = text.find("{"), text.rfind("}")
+    if start < 0 or end <= start:
+        return None
+    try:
+        caption = json.loads(text[start : end + 1])
+    except json.JSONDecodeError:
+        return None
+    return caption if isinstance(caption, dict) else None
+
+
+def needs_rewrite(prompt: str) -> bool:
+    """Structured captions are already in distribution and pass through."""
+
+    return not prompt.lstrip().startswith("{")
+
+
+def _run_on_primary_rank(callback: Callable[[], _T]) -> _T:
+    """Run an external rewriter once and broadcast its result to all ranks."""
+
+    if not dist.is_available() or not dist.is_initialized():
+        return callback()
+
+    payload: tuple[bool, object] | None = None
+    if dist.get_rank() == 0:
+        try:
+            payload = (True, callback())
+        except Exception as exc:  # noqa: BLE001 - synchronize the failure to peers
+            payload = (False, (type(exc).__name__, str(exc)))
+    objects = [payload]
+    dist.broadcast_object_list(objects, src=0)
+    success, result = objects[0]
+    if not success:
+        error_type, message = result
+        raise RuntimeError(f"LingBot prompt rewriter failed on rank 0 ({error_type}): {message}")
+    return result  # type: ignore[return-value]
+
+
+class LingBotVideoRewriter:
+    """Turn free text into the structured caption expected by LingBot-Video.
+
+    The first turn expands the request with the base VLM. The second turn maps
+    that expansion to JSON with the official rewriter adapter enabled.
+    """
+
+    def __init__(self, backend: RewriterBackend, *, auto_negative: bool = False):
+        self.backend = backend
+        self.auto_negative = auto_negative
+
+    def rewrite_request(
+        self,
+        *,
+        prompt: str,
+        negative_prompt: str,
+        mode: LingBotGenerationMode,
+        num_frames: int,
+        fps: int,
+        input_image: Image.Image | None,
+    ) -> tuple[str, str]:
+        if not needs_rewrite(prompt) and not self.auto_negative:
+            return prompt, negative_prompt
+
+        mode_value = mode.value
+        image = input_image if mode is LingBotGenerationMode.TI2V else None
+        duration = max(1, round(int(num_frames) / max(int(fps), 1)))
+
+        def rewrite() -> tuple[str, str]:
+            rewritten = self._rewrite_prompt(prompt, mode_value, duration, image)
+            rewritten_negative = negative_prompt
+            if self.auto_negative:
+                from vllm_omni.diffusion.models.lingbot_video.auto_negative import (
+                    customize_negative_prompt,
+                )
+
+                rewritten_negative = customize_negative_prompt(
+                    backend=self.backend,
+                    caption=rewritten,
+                    mode=mode_value,
+                    negative_prompt=negative_prompt,
+                    image=image,
+                )
+            return rewritten, rewritten_negative
+
+        return _run_on_primary_rank(rewrite)
+
+    def _rewrite_prompt(
+        self,
+        prompt: str,
+        mode: str,
+        duration: int,
+        image: Image.Image | None,
+    ) -> str:
+        if not needs_rewrite(prompt):
+            return prompt
+        detailed = self.backend.generate(
+            build_expand_prompt(mode, prompt, duration),
+            image,
+            use_lora=False,
+        )
+        raw = self.backend.generate(
+            build_map_prompt(mode, detailed, duration),
+            image,
+            use_lora=True,
+        )
+        caption = parse_caption(raw)
+        if caption is None:
+            raise RuntimeError(
+                "Prompt rewriting produced no parseable structured caption. "
+                "Pass a structured JSON caption directly, or check the rewriter backend."
+            )
+        return json.dumps(caption, ensure_ascii=False, separators=(",", ":"))

--- a/vllm_omni/diffusion/models/lingbot_video/rewriter_backends.py
+++ b/vllm_omni/diffusion/models/lingbot_video/rewriter_backends.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+# Adapted from SGLang (https://github.com/sgl-project/sglang/pull/32848).
+
+from __future__ import annotations
+
+import io
+import math
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import pybase64 as base64
+from PIL import Image
+from vllm.logger import init_logger
+
+from vllm_omni.diffusion.models.lingbot_video.rewriter import LingBotVideoRewriter
+
+logger = init_logger(__name__)
+
+
+def _chat_completions_url(base_url: str) -> str:
+    url = base_url.rstrip("/")
+    if url.endswith("/v1/chat/completions"):
+        return url
+    if url.endswith("/v1"):
+        return f"{url}/chat/completions"
+    return f"{url}/v1/chat/completions"
+
+
+def _data_url(image: Image.Image) -> str:
+    buffer = io.BytesIO()
+    image.convert("RGB").save(buffer, format="PNG")
+    encoded = base64.b64encode(buffer.getvalue()).decode()
+    return f"data:image/png;base64,{encoded}"
+
+
+class HTTPRewriterBackend:
+    """Call OpenAI-compatible endpoints, selecting a model per turn."""
+
+    def __init__(
+        self,
+        *,
+        url: str,
+        map_url: str,
+        expand_model: str,
+        map_model: str,
+        timeout: float,
+    ):
+        self.url = _chat_completions_url(url)
+        self.map_url = _chat_completions_url(map_url)
+        self.expand_model = expand_model
+        self.map_model = map_model
+        self.timeout = timeout
+
+    def generate(self, text: str, image: Image.Image | None, use_lora: bool) -> str:
+        content: list[dict[str, Any]] = [{"type": "text", "text": text}]
+        if image is not None:
+            content.insert(0, {"type": "image_url", "image_url": {"url": _data_url(image)}})
+        response = httpx.post(
+            self.map_url if use_lora else self.url,
+            json={
+                "model": self.map_model if use_lora else self.expand_model,
+                "messages": [{"role": "user", "content": content}],
+                "temperature": 0.0,
+                "chat_template_kwargs": {"enable_thinking": False},
+            },
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        try:
+            generated = response.json()["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError, ValueError) as exc:
+            raise RuntimeError("LingBot rewriter endpoint returned an invalid chat completion payload.") from exc
+        if not isinstance(generated, str):
+            raise RuntimeError("LingBot rewriter endpoint returned non-text chat content.")
+        return generated.strip()
+
+
+class TransformersRewriterBackend:
+    """Lazily load the base VLM and official PEFT rewriter adapter."""
+
+    def __init__(
+        self,
+        *,
+        model_path: str,
+        adapter_path: str,
+        device_map: Any,
+        max_new_tokens: int,
+    ):
+        self.model_path = model_path
+        self.adapter_path = adapter_path
+        self.device_map = device_map
+        self.max_new_tokens = max_new_tokens
+        self.processor = None
+        self.model = None
+
+    def _load(self) -> None:
+        try:
+            import torch
+            from peft import PeftModel
+            from transformers import AutoModelForImageTextToText, AutoProcessor
+        except ImportError as exc:
+            raise ImportError(
+                "The in-process LingBot rewriter requires `peft` and a Transformers build "
+                "with AutoModelForImageTextToText support."
+            ) from exc
+
+        logger.info(
+            "Loading LingBot prompt rewriter model %s with adapter %s",
+            self.model_path,
+            self.adapter_path,
+        )
+        self.processor = AutoProcessor.from_pretrained(self.model_path, trust_remote_code=True)
+        base = AutoModelForImageTextToText.from_pretrained(
+            self.model_path,
+            torch_dtype=torch.bfloat16,
+            device_map=self.device_map,
+            trust_remote_code=True,
+        )
+        self.model = PeftModel.from_pretrained(base, self.adapter_path).eval()
+
+    def generate(self, text: str, image: Image.Image | None, use_lora: bool) -> str:
+        import contextlib
+
+        import torch
+
+        if self.model is None:
+            self._load()
+        content = [{"type": "image", "image": image}] if image is not None else []
+        content.append({"type": "text", "text": text})
+        chat = self.processor.apply_chat_template(
+            [{"role": "user", "content": content}],
+            tokenize=False,
+            add_generation_prompt=True,
+            enable_thinking=False,
+        )
+        inputs = self.processor(
+            text=[chat],
+            images=[image] if image is not None else None,
+            return_tensors="pt",
+        ).to(self.model.device)
+        adapter = contextlib.nullcontext() if use_lora else self.model.disable_adapter()
+        with torch.no_grad(), adapter:
+            out = self.model.generate(
+                **inputs,
+                max_new_tokens=self.max_new_tokens,
+                do_sample=False,
+            )
+        generated = out[:, inputs["input_ids"].shape[1] :]
+        return self.processor.batch_decode(generated, skip_special_tokens=True)[0].strip()
+
+
+@dataclass(frozen=True)
+class LingBotRewriterSettings:
+    url: str | None
+    map_url: str | None
+    expand_model: str
+    map_model: str
+    timeout: float
+    model_path: str | None
+    adapter_path: str | None
+    device_map: Any
+    max_new_tokens: int
+    auto_negative: bool
+
+    @classmethod
+    def from_model_config(cls, model_config: dict[str, Any]) -> LingBotRewriterSettings:
+        def optional_string(name: str) -> str | None:
+            value = model_config.get(name)
+            if value is None:
+                return None
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"LingBot `{name}` must be a non-empty string when set.")
+            return value
+
+        url = optional_string("rewriter_url")
+        map_url = optional_string("rewriter_map_url")
+        model_path = optional_string("rewriter_model_path")
+        adapter_path = optional_string("rewriter_adapter_path")
+        expand_model = optional_string("rewriter_expand_model") or "lingbot-rewriter-base"
+        map_model = optional_string("rewriter_map_model") or "lingbot-rewriter-lora"
+
+        timeout_value = model_config.get("rewriter_timeout", 300.0)
+        try:
+            timeout = float(timeout_value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("LingBot `rewriter_timeout` must be a positive number.") from exc
+        if not math.isfinite(timeout) or timeout <= 0:
+            raise ValueError("LingBot `rewriter_timeout` must be positive.")
+        max_new_tokens_value = model_config.get("rewriter_max_new_tokens", 6144)
+        try:
+            max_new_tokens = int(max_new_tokens_value)
+            numeric_max_new_tokens = float(max_new_tokens_value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("LingBot `rewriter_max_new_tokens` must be a positive integer.") from exc
+        if (
+            isinstance(max_new_tokens_value, bool)
+            or not math.isfinite(numeric_max_new_tokens)
+            or numeric_max_new_tokens != max_new_tokens
+            or max_new_tokens <= 0
+        ):
+            raise ValueError("LingBot `rewriter_max_new_tokens` must be a positive integer.")
+        auto_negative = model_config.get("rewriter_auto_negative", False)
+        if not isinstance(auto_negative, bool):
+            raise ValueError("LingBot `rewriter_auto_negative` must be a boolean.")
+
+        if url is not None and model_path is not None:
+            raise ValueError("LingBot `rewriter_url` and `rewriter_model_path` are mutually exclusive.")
+        if map_url is not None and url is None:
+            raise ValueError("LingBot `rewriter_map_url` requires `rewriter_url`.")
+        if adapter_path is not None and model_path is None:
+            raise ValueError("LingBot `rewriter_adapter_path` requires `rewriter_model_path`.")
+        if model_path is not None and adapter_path is None:
+            raise ValueError(
+                "LingBot `rewriter_model_path` requires `rewriter_adapter_path`; "
+                "the mapping turn must enable the official adapter."
+            )
+        if auto_negative and url is None and model_path is None:
+            raise ValueError("LingBot `rewriter_auto_negative` requires a configured rewriter backend.")
+
+        return cls(
+            url=url,
+            map_url=map_url,
+            expand_model=expand_model,
+            map_model=map_model,
+            timeout=timeout,
+            model_path=model_path,
+            adapter_path=adapter_path,
+            device_map=model_config.get("rewriter_device_map", "auto"),
+            max_new_tokens=max_new_tokens,
+            auto_negative=auto_negative,
+        )
+
+
+def build_lingbot_rewriter(model_config: dict[str, Any]) -> LingBotVideoRewriter | None:
+    settings = LingBotRewriterSettings.from_model_config(model_config)
+    if settings.url is not None:
+        backend = HTTPRewriterBackend(
+            url=settings.url,
+            map_url=settings.map_url or settings.url,
+            expand_model=settings.expand_model,
+            map_model=settings.map_model,
+            timeout=settings.timeout,
+        )
+    elif settings.model_path is not None:
+        assert settings.adapter_path is not None
+        backend = TransformersRewriterBackend(
+            model_path=settings.model_path,
+            adapter_path=settings.adapter_path,
+            device_map=settings.device_map,
+            max_new_tokens=settings.max_new_tokens,
+        )
+    else:
+        return None
+    return LingBotVideoRewriter(backend, auto_negative=settings.auto_negative)

--- a/vllm_omni/diffusion/models/lingbot_video/rewriter_prompts.py
+++ b/vllm_omni/diffusion/models/lingbot_video/rewriter_prompts.py
@@ -1,0 +1,339 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+# Adapted from LingBot-Video (https://github.com/Robbyant/lingbot-video).
+# ruff: noqa: E501
+"""System prompts for the two-stage LingBot-Video prompt rewriter."""
+
+VIDEO_STEP1_EXPAND = (
+    "You write ONE short, natural, standalone video caption in English from a brief user video\n"
+    "prompt — as if briefly recounting what happens in a real clip of that idea.\n"
+    "\n"
+    "INPUT: a short user prompt (and, when provided, the video's first frame as a visual anchor).\n"
+    "\n"
+    "HARD LENGTH LIMIT: the output MUST be UNDER 1000 characters. Aim for roughly 400-800\n"
+    "characters. Concise is a top priority.\n"
+    "\n"
+    "STYLE — a flowing story, NOT a checklist:\n"
+    "- Connected, natural English prose. NO headings, NO bullets, NO field labels.\n"
+    "- The MAIN THREAD is what HAPPENS — lead with the action. Do NOT march subject-by-subject\n"
+    "  listing attributes; weave the few details you keep into the action naturally.\n"
+    "- One cohesive paragraph; never pad to add length.\n"
+    "\n"
+    "WHAT TO COVER (only these):\n"
+    "- The scene in a brief phrase.\n"
+    "- Each main subject by name/what-it-is plus ONE most defining visual trait — not a full\n"
+    "  appearance list.\n"
+    "- What happens over the clip, in correct chronological order as the backbone, with an EXPLICIT\n"
+    "  timestamp in seconds on each action, distributed within the given video duration — e.g.\n"
+    '  "at 0.0s", "from 1.2s to 2.7s", "around the 3.4s mark", "finally from 4.0s to 5.0s". Span the\n'
+    "  actions from 0s up to (but never beyond) the stated duration; the last one ends at or before it.\n"
+    "  Attach a timestamp ONLY to a real action or change; mention a static/unchanging element once\n"
+    "  with NO timestamp — never put a whole-clip span on something that merely exists.\n"
+    "- A one-word shot type only if it matters; otherwise skip the camera.\n"
+    "- Named entities only if clearly implied — don't invent identities.\n"
+    "\n"
+    "FAITHFUL EXPANSION:\n"
+    "- Stay consistent with the prompt; elaborate plausibly but never contradict it. If a first\n"
+    "  frame is given, ground the scene and subject in it.\n"
+    "- Keep actions in their natural, real-world direction — never reverse them. Commit to one\n"
+    "  coherent interpretation; don't hedge with alternatives.\n"
+    "- Keep subject identities and counts consistent.\n"
+    "\n"
+    "DOMAIN NOTES (apply whichever fits):\n"
+    "- Multiple events / sequence: lay out consecutive actions in STRICT chronological order as\n"
+    "  distinct, separated steps with approximate timing — never blur them into one vague action.\n"
+    "- Robot manipulation (VLA): subjects are robotic arm(s), gripper(s) and workspace objects,\n"
+    "  NOT people — no clothing/skin/gender/expression. When two arms are present, ALWAYS keep the\n"
+    "  LEFT and RIGHT arm distinct and state which arm/gripper does each motion; never swap, merge,\n"
+    "  or leave it ambiguous. Manipulation is STRICTLY NOT reversible.\n"
+    "- First-person (EGO): a head-mounted first-person view; camera motion IS the wearer's head\n"
+    "  movement. The agent is the camera-wearer, a PERSON shown through their own hands/arms and\n"
+    "  viewpoint; never a robot or external third-person subject. Stay strictly first-person.\n"
+    "\n"
+    "Output ONLY the caption text — no preamble, no headings, no explanation.\n"
+    "\n"
+    "## EXAMPLES — one representative example per domain. When you write your own caption, match these examples' style, format, length, and timestamp convention (each action gets a numeric timestamp in seconds within the video's duration).\n"
+    "\n"
+    "### Example 1 — general\n"
+    "USER PROMPT:\n"
+    "低角度广角镜头，镜头静止。中央大型条纹热气球缓慢上升并飘移（气球呈红橙黄绿蓝条纹，底部深色），背景中多个热气球在天空漂移。地面草地上散布着正在充气的热气球，一辆红色皮卡停放在旁。随后一辆蓝色拖车进入画面并横穿前景（覆盖蓝色防水布）。饱和色彩，硬光，日光，电影质感。\n"
+    "\n"
+    "DETAILED CAPTION:\n"
+    "At a vibrant hot air balloon festival on a sunny day, a wide shot shows a grassy field under a blue sky. A large, multi-colored striped balloon dominates the center, and from the start at 0.0 seconds until 5.3 seconds, it slowly rises and drifts slightly upward and to the right. Simultaneously during the 0.0s to 5.3s period, several small background balloons drift slowly across the sky in various directions above a cluster of grounded balloons. A red pickup truck and white van sit parked near the left side, while finally, around the 4.3s mark until 5.3s, a blue trailer enters the frame from the right and moves left across the foreground.\n"
+    "\n"
+    "### Example 2 — multi-event\n"
+    "USER PROMPT:\n"
+    "Subtitle: Outdoor High-Intensity Workout — All live-action, hyper-realistic, fixed shot with slight handheld unsteadiness.\n"
+    "\n"
+    "Style: Hard daylight, high-angle wide shot, center composition, sharp shadows, athletic tension.\n"
+    "\n"
+    "1. Muscular shirtless man, black headwrap, black boxing gloves, blue digital camo pants, black combat boots. Standing on concrete surface, background includes beige wall, chain-link fence, and trash bins. Stands in a boxing stance with hands up.\n"
+    "\n"
+    "2. Drops into a deep squat, then jumps upward explosively.\n"
+    "\n"
+    "3. Lands and drops into a deep squat, repeating this explosive jump and squat landing cycle.\n"
+    "\n"
+    "4. After the final landing and squat, begins to stand up.\n"
+    "\n"
+    "Overall movements coherent and natural, high contrast lighting, focused and athletic atmosphere.\n"
+    "\n"
+    "DETAILED CAPTION:\n"
+    "In an outdoor urban setting against a beige wall, a shirtless man wearing boxing gloves performs a workout on concrete. From 0.0s to 0.6s he stands in a boxing stance with hands up. Then from 0.6s to 1.2s he drops into a deep squat, followed by the period from 1.2s to 1.8s where he jumps upward explosively. From 1.8s to 2.4s he lands and drops into a deep squat, then from 2.4s to 3.0s jumps upward explosively again. Around the 3.0s to 3.6s mark he lands and drops into a deep squat, proceeding to jump upward explosively from 3.6s to 4.2s. From 4.2s to 4.8s he lands and drops into a deep squat once more, and finally from 4.8s to 5.0s he begins to stand up.\n"
+    "\n"
+    "### Example 3 — VLA\n"
+    "USER PROMPT:\n"
+    "环境：自动化超市补货工作站，俯视视角，明亮均匀人工光，清晰功能化氛围。物体：左侧打开的棕色纸箱内含整齐堆叠的红色香肠包装，右侧白色矩形料箱内含红黄绿混合食品包装及带黑色把手的透明塑料隔板。机器人：双臂系统。左臂黑色机身银色底座黑色夹爪（全程静止悬停），右臂白色机身黑色夹爪腕部蓝色指示灯（活动主体）。动作：右臂向下向左移动伸入白色料箱，抓取隔板黑色把手，向右滑动隔板，释放把手，向上向右收回复位。左臂悬停于纸箱上方保持静止。相机：固定高角度俯视视角，全程静止镜头，宽画幅，超广角镜头，柔和人工光，极致细节。\n"
+    "\n"
+    "DETAILED CAPTION:\n"
+    "A top-down wide shot shows an automated workspace with a cardboard box of sausage packages on the left and a white bin on the right. A stationary black and silver left robotic arm hovers over the box, while a white and black right robotic arm operates above the bin containing a black handle. From 0.0s to 2.0s, the right arm moves downwards and to the left, reaching into the white bin as the handle remains still. Then from 2.0s to 6.0s, the right arm grasps the black handle and moves to the right, pulling the handle and sliding the divider across the bin. Finally from 6.0s to 9.2s, the right arm releases the handle and moves upwards and to the right, returning to a resting position while the handle stays stationary. The box and bin remain fixed throughout.\n"
+    "\n"
+    "### Example 4 — EGO\n"
+    "USER PROMPT:\n"
+    "First-person POV, brightly lit grocery store produce section, soft artificial lighting. Two rectangular bins side-by-side in front; left filled with red/yellow apples, right piled with bright orange oranges. Background shows aisles and shoppers, one in red shirt with basket. Right hand enters from bottom, reaches into right orange pile, grasps one orange, lifts it upwards and slightly left. Camera moves forward and slightly down approaching bins, then remains stable with minor panning/tilting following hand movement.\n"
+    "\n"
+    "DETAILED CAPTION:\n"
+    "From a first-person perspective in a grocery store produce section, the camera approaches display bins containing apples on the left and bright oranges on the right. In the background aisles, a shopper wearing a red shirt walks from the left side of the frame towards the right between 0.0s and 2.0s, while another shopper in a striped shirt walks away from the camera down the aisle from 0.0s to 5.0s. The operator's right hand enters the frame from the bottom from 0.0s to 2.5s, then reaches into the pile of oranges and grasps one from 2.5s to 3.5s. Finally, the hand lifts the grasped orange upwards and to the left from 3.5s to 5.0s, selecting it from the cluster."
+)
+
+VIDEO_STEP2_MAP = (
+    "You are a structuring engine. You convert a DETAILED natural-language video caption (which concisely states the scene and the full motion/timing plan) into a STRUCTURED JSON caption. Your job is FAITHFUL structural extraction ONLY: do NOT drop, alter, reorder, or re-time anything the prose states (keep every subject, every action, and every timestamp exactly), and do NOT re-plan motion; BUT the prose is brief and intentionally omits fine visual attributes and camera settings — you MUST fill those omitted fields (texture, skin tone, precise colors, relative size, pose/orientation, clothing, and all camera_info) with plausible values that stay consistent with and never contradict the prose — just map what the prose already states into the schema.\n"
+    "\n"
+    "## OUTPUT FORMAT (JSON)\n"
+    "\n"
+    "```json\n"
+    "{\n"
+    '  "comprehensive_description": {\n'
+    "    \"scene_content_description\": \"(String) A detailed description focusing on scene content, subject appearance, lighting, atmosphere, narrative, and interactions between elements. Text physically printed on visual objects should be mentioned alongside the object and detailed further in prominent_elements. For standalone OCR/text elements, briefly describe their role, relative scale, font style, color, and orientation; categorize them as 'static overlays' (like watermarks) or 'integrated scene text' (like subtitles/scrolling text); and describe their temporal behavior if they appear or disappear. Provide an exact transcription for prominent text (preserving spelling, punctuation, and capitalization), but summarize long or dense text blocks instead of transcribing them fully. **Do not describe camera movement here**. Maximum 800 words.\",\n"
+    '    "camera_movement_description": "(String) A detailed description focusing on camera behavior. Include camera movement types (Pan, Tilt, Zoom, Dolly, Truck, Roll), shooting angles (high/low/eye-level), shot size changes, and stability. Maximum 100 words. If the camera is essentially stationary, set to \'\'."\n'
+    "  },\n"
+    "\n"
+    '  "prominent_elements": [\n'
+    "    {\n"
+    "      \"name\": \"(String) Short label for the object (e.g., 'red sports car', 'elderly man')\",\n"
+    '      "description": "(String) Detailed visual description of this specific element",\n'
+    '      "actions": [\n'
+    "        {\n"
+    '          "timestamp": "(String) Time range when this action occurs, e.g., \'[0.0s - 3.0s]\'",\n'
+    '          "action": "(String) Specific action description during this time period. **Direction must be described from the observer\'s perspective**. If the element has no action throughout, the entire actions array contains only one element with action set to \'\'."\n'
+    "        }\n"
+    "      ],\n"
+    '      "location": "(String) Precise position in the frame or main area of activity (from observer\'s perspective)",\n'
+    '      "relative_size": "(String) small / medium / large / dominant",\n'
+    '      "shape_and_color": "(String) Basic geometric shape and dominant colors",\n'
+    '      "texture": "(String) e.g., smooth, rough, metallic, furry, glossy, matte",\n'
+    '      "appearance_details": "(String) Specific details such as patterns, text physically printed on the object, wear marks, or distinctive markings",\n'
+    '      "relationship": "(String) This object\'s spatial or contextual relationship with other elements in the scene. If this object obscures text, specify exactly what it covers (e.g., \'blocking the letter O in COW). If it is obscured by floating text, describe what part of the object is covered.",\n'
+    '      "orientation": "(String) e.g., upright, tilted, horizontal, facing away, diagonal",\n'
+    "      \n"
+    '      "pose": "(String) Body posture and its changes (human/humanoid only, otherwise empty)",\n'
+    '      "expression": "(String) Facial expression and emotional changes (human/humanoid only, otherwise empty)",\n'
+    '      "clothing": "(String) Clothing description, including colors and styles (human/humanoid only, otherwise empty)",\n'
+    '      "gender": "(String) Apparent gender (human/humanoid only, otherwise empty)",\n'
+    '      "skin_tone_and_texture": "(String) Skin appearance (human/humanoid only, otherwise empty)",\n'
+    "      \n"
+    '      "is_cluster": "true (only for cluster objects, omit otherwise)",\n'
+    "      \"number_of_objects\": \"(String) Exact number if countable, otherwise 'several' (3-6), 'many' (7-20), or 'numerous' (20+)\"\n"
+    "    }\n"
+    "  ],\n"
+    "\n"
+    '  "camera_info": {\n'
+    '    "color": "(String) Warm, Cool, Mixed, Saturated, Desaturated, Black and White, Red, Orange, Yellow, Green, Cyan, Blue, Magenta, or Pink",\n'
+    '    "frame_size": "(String) Extreme Wide, Wide, Medium Wide, Medium, Medium Close Up, Close Up, or Extreme Close Up",\n'
+    '    "shot_type_angle": "(String) High angle, Low angle, Dutch angle, Overhead, Aerial, or Eye level",\n'
+    '    "lens_size": "(String) Ultra Wide / Fisheye, Wide, Medium, Long Lens, or Telephoto",\n'
+    '    "composition": "(String) Center, Balanced, Symmetrical, Left heavy, Right heavy, or Short side",\n'
+    '    "lighting": "(String) Hard light, Soft light, High contrast, Low contrast, Side light, Top light, Underlight, Backlight, Edge light, or Silhouette",\n'
+    '    "lighting_type": "(String) Daylight, Sunny, Overcast, Moonlight, Artificial light, Practical light, Tungsten, Fluorescent, Firelight, or Mixed light"\n'
+    "  }\n"
+    "}\n"
+    "```\n"
+    "\n"
+    "## IMPORTANT RULES\n"
+    "\n"
+    '1.  **Think First:** Before generating the JSON, perform an internal "Let\'s think step by step" synthesis.\n'
+    "2.  **Output Only JSON:** Do not output any thinking process or Markdown text outside of the JSON code block.\n"
+    "3.  **Strict Fidelity (No Modification)**:\n"
+    '- Identity: Never alter the identity of subjects (e.g., a "real tiger" remains "real tiger").\n'
+    '- Actions: Verbs must be preserved exactly (e.g., "walking" cannot be changed to "running"). Sequence Integrity: You must preserve the complete action chain defined in the prompt. Do not summarize, skip, or merge distinct sequential steps into a single state. No Collective Summarization: Do not use summary phrases (e.g., "a sequence of...", "various movements") to cover multiple steps. If the prompt defines A -> B -> C, every step must be represented as a separate action segment. Any skipped step or summarized sequence is a CRITICAL ERROR.\n'
+    '- Quantity: If a number is specified, it must be exact. Quantifiers must be strictly preserved. "All" means all, "every" means every, "a single" means exactly 1. Do not paraphrase quantifiers into vague terms.\n'
+    '- Spatial Integrity: Relative positions (e.g., "A on the left of B") must be fixed as stated.\n'
+    "- Color & Text: Colors must be accurate; OCR text must be transcribed character-for-character (case-sensitive).\n"
+    '4.  **Creative Expansion Constraints:** When expanding a simple prompt, ensure added details (e.g., "sun-drenched oak windowsill") never contradict, replace, or occlude the user\'s explicit subject requirements.\n'
+    "5.  **Text Placement Logic:** \n"
+    "- Surface-Bound Text (Printed on objects): Must be transcribed exactly within the appearance_details field of its respective object in prominent_elements.\n"
+    "- Standalone Graphic Text (Floating/Poster text): Must NOT be an entry in prominent_elements. Describe its role, style, and exact transcription exclusively within the comprehensive_description.\n"
+    "- Dynamic Text: If the scene contains moving or updating text (e.g., a scrolling ticker or a subtitle), you must explicitly describe the text's movement path and content change frequency within the actions array of the respective prominent_elements or the comprehensive_description.\n"
+    "6.  **Occlusion & Relational Mapping:** Explicitly document overlaps. If text occludes an object, or an object occludes text, specify which character(s) or object parts are affected in both relationship and comprehensive_description.\n"
+    '7.  **Handle Missing Data:** If an attribute is not applicable to an element (e.g., pose for a mountain), set its value to "" (an empty string). Never use "N/A", "unknown", "not applicable", etc.\n'
+    '8.  **Counting:** For number_of_objects, provide an exact number if specified by the user. Otherwise, use: "several" (3-6), "many" (7-20), or "numerous" (20+).\n'
+    '9.  **Perspective:** Always describe positions (location) and directions (orientation) as "left" and "right" from the viewer\'s perspective.\n'
+    '10. **Visual Descriptive Realism:** Avoid abstract or emotional adjectives (e.g., "beautiful," "sad"). Instead, translate them into visually observable details (e.g., "soft golden-hour rim lighting," "desaturated cool blue tones with falling rain droplets").\n'
+    '11. **Clusters:** When describing a cluster (e.g., "a forest"), describe the collective appearance of the group rather than listing every individual tree.\n'
+    "12. **Attribute Consistency:** Ensure that the comprehensive_description and the individual prominent_elements are perfectly synchronized. Every element mentioned in the elements list must exist in the paragraph description and vice versa.\n"
+    '13. **Negative Constraints:** Any explicit prohibitions (e.g., "no text," "no background") must be strictly upheld. Never add elements that the user has explicitly requested to exclude.\n'
+    "14. **Subject Priority:** The primary subject specified by the user must be the anchor of the scene. Its description and prominence in the JSON must reflect its status as the most important element.\n"
+    "15. **Integrity:** Before generating JSON, you must cross-verify all keywords, actions, and states against the User Prompt; if any item is missing or any state intensity deviates from the original, you MUST regenerate the content to ensure 100% fidelity. \n"
+    '16. **Non-OCR Classification:** Do not force objects into "text" status. If a word appears in the prompt without context of "sign," "label," or "document," describe it as a physical attribute or brand marking on the object, not as OCR/Typography.\n'
+    "17. **Camera Fidelity:** The camera_info must be logically consistent with the visual scene. For example, if the scene is a vast landscape, the camera should reflect a 'Wide' or 'Ultra Wide' frame size and appropriate lens settings. Avoid contradictory pairings (e.g., 'Extreme Close Up' with a 'Wide' lens).\n"
+    "18. **Temporal Continuity:** Ensure temporal continuity for all subjects and environment settings. If an object is introduced, it must not disappear or reappear without a logical reason (e.g., leaving the frame or being occluded). Texture, color, and lighting must remain consistent across all action segments.\n"
+    "19. **Action-Camera Sync:** The camera movement must logically justify the subject's displacement. If the camera follows a subject (tracking shot), the subject's position in the frame should remain relatively stable. If the camera is static, the subject must show movement within the frame.\n"
+    "20. **Physical Logic:** All movements must respect physical laws unless the prompt specifies a surreal or fantasy context. Avoid 'gliding' motions; ensure footsteps or object interactions (e.g., picking up an item) align with the timestamped actions.\n"
+    '21. **Motion and Velocity:** Verbs must describe the process of an action, not just the result (e.g., use \'rising from the chair\' instead of just \'standing\'). Every action in the actions array must include a velocity modifier (e.g., "slowly walking," "abruptly turning," "smoothly panning," "rapidly accelerating"). Avoid generic verbs without speed or force descriptors.\n'
+    "22. **Language:** Output all JSON content in professional English, except for OCR text, which must be transcribed exactly as provided to maintain absolute fidelity.\n"
+    "23. **Audio Neglect:** The User Prompt may contain audio, music, or voiceover instructions. Strictly ignore all audio-related instructions. Do not attempt to rewrite, describe, or represent these as part of the JSON output. Focus exclusively on the visual, temporal, and narrative elements and OCR texts.\n"
+    "24. **Duration Adherence:** A target video duration is provided in the input. Every timestamp in the `actions` array MUST fall within `[0.0s, the given duration]`, and the action timeline should span up to (but never beyond) this duration. Distribute the action segments proportionally to the given length; the final segment must end at or before the given duration.\n"
+    "\n"
+    "## THIS STEP'S INPUT/OUTPUT\n"
+    "- Input: the detailed prose caption + the target video duration.\n"
+    "- The expansion/thinking is already done in the prose — preserve the stated core EXACTLY (scene, subjects, every action + timestamp, named entities); ONLY the fine visual attributes and camera fields that the brief prose omits may be completed — plausibly, consistently, never contradicting the prose.\n"
+    "- Output ONLY the JSON object (valid and parseable), following the schema and rules above."
+)
+
+VIDEO_DURATION_EN = "Video Duration: {duration} seconds"
+VIDEO_DURATION_ZH = "视频时长：{duration} 秒"
+
+IMAGE_STEP1_EXPAND = (
+    "You write ONE short, natural, standalone IMAGE caption in English from a brief user image\n"
+    "prompt — as if briefly describing a real photo of that idea.\n"
+    "\n"
+    "This is a SINGLE STILL IMAGE: there is NO motion, NO time, NO timestamps, NO camera movement.\n"
+    "Describe only what the photo shows; never invent action, sequence, or a moving camera.\n"
+    "\n"
+    "HARD LENGTH LIMIT: the output MUST be UNDER 1000 characters. Aim for roughly 400-800\n"
+    "characters. Concise is a top priority.\n"
+    "\n"
+    "STYLE — a flowing description, NOT a checklist:\n"
+    "- Connected, natural English prose. NO headings, NO bullets, NO field labels.\n"
+    "- The MAIN THREAD is the main subject and the scene — lead with WHAT THE IMAGE SHOWS. Do NOT\n"
+    "  march subject-by-subject listing attributes; weave the few details you keep into the\n"
+    "  description naturally. One cohesive paragraph; never pad to add length.\n"
+    "\n"
+    "WHAT TO COVER (only these):\n"
+    "- The scene in a brief phrase (where it is / overall vibe).\n"
+    "- Each main subject by name/what-it-is plus ONE most defining visual trait — not a full\n"
+    "  appearance list. The key spatial arrangement only if it defines the image.\n"
+    "- A one-word shot type only if it matters (e.g. close-up, wide shot, aerial); otherwise skip the camera.\n"
+    "- Named entities (real people / places / landmarks / brands) only if clearly implied — don't invent identities.\n"
+    "\n"
+    "FAITHFUL EXPANSION:\n"
+    "- Stay consistent with the prompt; elaborate plausibly but never contradict it. Commit to one\n"
+    "  coherent interpretation; don't hedge with alternatives.\n"
+    "- Keep subject identities and counts consistent.\n"
+    "\n"
+    "Output ONLY the caption text — no preamble, no headings, no explanation.\n"
+    "\n"
+    "\n"
+    "## EXAMPLES — one representative example per type. When you write your own caption, match these examples' style, format, and length (one flowing paragraph, no timestamps, no camera movement — it is a single still image).\n"
+    "\n"
+    "### Example 1 — animal / wildlife\n"
+    "USER PROMPT:\n"
+    "A leopard tortoise dominates the center of the frame, captured from a high angle with its head and front legs extended toward the left. Its domed shell displays a striking mosaic of black and tan geometric patterns, contrasting with the rough, yellowish-tan scales of its skin and sharp claws. The creature is positioned on reddish-brown sandy soil scattered with dry twigs and pebbles, illuminated by warm daylight that creates a soft shadow beneath it against a backdrop of green grass on the right.\n"
+    "\n"
+    "DETAILED CAPTION:\n"
+    "A leopard tortoise is positioned centrally in a natural outdoor setting, resting on reddish-brown sandy soil scattered with small pebbles and dry twigs. Facing toward the left with its head and front legs extended, the animal displays a domed shell marked by intricate black and tan geometric patterns reminiscent of leopard spots. Its yellowish-tan skin contrasts with the earthy ground beneath its clawed feet, while a patch of green grass and low-lying vegetation rises in the background to the right. The distinct markings of the shell stand out against the textured ground and sparse greenery, capturing the tortoise within its earthy environment.\n"
+    "\n"
+    "### Example 2 — architecture / landmark\n"
+    "USER PROMPT:\n"
+    "极度广角镜头，高角度拍摄。明亮日光，硬光，暖色调，清晰阴影。宏伟的古典风格宫殿庭院，浅色石材。中央巨大的多层拱形入口，饰有金色和蓝色装饰带，深色凹陷内部可见小金门。宽阔石阶通向圆形分层平台。两侧对称亭阁，顶部为反射金色圆顶，蓝色瓷砖拱门，装饰攀爬绿藤和粉色花朵。露台布满茂盛绿植和小花。若干穿着传统长袍（白、灰、棕、红）的小人物散布庭院以示比例。背景岩石山坡，远处建筑，晴朗明亮天空。写实建筑摄影。\n"
+    "\n"
+    "DETAILED CAPTION:\n"
+    "A grand, sun-drenched courtyard of a classical-style palace complex is dominated by a massive central building featuring a large, multi-tiered arched entrance. Wide stone stairs lead up to the structure, flanked on either side by identical pavilions topped with brilliant, reflective golden domes and blue-tiled arches. The light-colored stone complex includes various terraces filled with lush greenery, while several small figures dressed in traditional robes are scattered throughout the courtyard, providing a sense of scale against the monumental architecture. In the background, a rocky hillside rises under a clear bright sky, dotted with additional buildings and vegetation surrounding the temple-like grounds.\n"
+    "\n"
+    "### Example 3 — landscape / nature\n"
+    "USER PROMPT:\n"
+    "Make me an image of a serene coastal scene featuring a classic white lighthouse attached to a keeper's house, with a vintage red pickup truck and a small boat on a trailer parked on a dirt path nearby, set against a lush green lawn, wooden fence, and bright blue sky over calm waters.\n"
+    "\n"
+    "DETAILED CAPTION:\n"
+    "A wide aerial view captures a serene coastal scene dominated by a classic white lighthouse and its attached keeper's house. The tall cylindrical tower features a black lantern room and rises from a white residence with a brown shingled roof and green shutters. To the left, a classic red pickup truck is parked on a dirt path with a small white and red boat resting on a trailer behind it. A lush green lawn slopes down toward a rocky shoreline where a weathered wooden fence runs along the edge of the deep blue water. In the background, a calm sea stretches to the horizon, meeting a distant tree-covered coastline under a bright blue sky filled with soft clouds.\n"
+    "\n"
+    "### Example 4 — person / portrait\n"
+    "USER PROMPT:\n"
+    "A stylish woman with long wavy blonde hair and bold red lipstick stands confidently on a city sidewalk, wearing a black long-sleeved dress with sheer patterned sleeves and a ruffled waistline. She carries a small black crossbody bag with a gold Saint Laurent logo slung over her shoulder, her left arm slightly extended and right arm by her side in a high-angle medium wide shot. The background features brick buildings and a blurred crosswalk with distant pedestrians under soft daylight, creating a sophisticated urban atmosphere with a left-heavy composition.\n"
+    "\n"
+    "DETAILED CAPTION:\n"
+    "A stylish woman with long blonde hair and bold red lipstick stands on a city sidewalk, gazing directly forward in a black long-sleeved dress with sheer patterned sleeves and a ruffled waistline. A small black crossbody bag featuring a gold Saint Laurent logo hangs at her side, complementing her sophisticated look. The setting is a classic urban street scene characterized by brick buildings and a black wall-mounted lamp visible behind her. In the distance, a blurred crosswalk shows several pedestrians, adding depth to the modern atmosphere surrounding the central figure."
+)
+
+IMAGE_STEP2_MAP = (
+    "You convert a SHORT natural-language STILL-IMAGE caption (the DETAILED CAPTION) into ONE\n"
+    "structured JSON caption describing the image. Output ONLY the JSON object — no prose, no code fence.\n"
+    "\n"
+    "## TASK SEMANTICS (read carefully)\n"
+    "The detailed caption is SHORT and LOSSY: it states the scene, the main subjects, and each\n"
+    "subject's single most defining trait, but it deliberately OMITS fine attributes (exact colors,\n"
+    "texture, relative size, orientation, clothing, skin tone, pose, expression) and the camera\n"
+    "metadata. Your job:\n"
+    "- KEEP faithfully everything the prose states (scene, every named subject, named entities) — do\n"
+    "  not drop, rename, merge, or split subjects, and do not contradict the prose.\n"
+    "- REASONABLY COMPLETE the fields the prose omits (fine attributes + camera_info) with plausible,\n"
+    "  self-consistent values that do NOT contradict the prose. This is expected: the target JSON is a\n"
+    "  FULL caption, so every schema field must be filled even when the prose did not mention it.\n"
+    "- This is a STILL IMAGE: no actions, no timestamps, no camera movement anywhere.\n"
+    "\n"
+    "## OUTPUT SCHEMA (exact keys)\n"
+    "A single JSON object with EXACTLY these top-level keys:\n"
+    '- "comprehensive_description": string — one flowing prose paragraph describing the whole image\n'
+    "  (scene, subjects, their arrangement and look). No field labels inside it.\n"
+    '- "camera_info": object with EXACTLY these 7 string keys, each set to ONE value from its list:\n'
+    '  - "color": Warm | Cool | Mixed | Saturated | Desaturated | White | Green | Blue | Red | Cyan\n'
+    '  - "frame_size": Extreme Close Up | Close Up | Medium Close Up | Medium | Medium Wide | Wide | Extreme Wide\n'
+    '  - "shot_type_angle": Eye level | Low angle | High angle | Overhead | Aerial\n'
+    '  - "lens_size": Ultra Wide / Fisheye | Wide | Medium | Long Lens | Telephoto\n'
+    '  - "composition": Center | Balanced | Symmetrical | Left heavy | Right heavy\n'
+    '  - "lighting": Soft light | Hard light | Top light | Underlight | Backlight\n'
+    '  - "lighting_type": Daylight | Artificial light\n'
+    '- "world_knowledge": array of strings — named entities / real-world facts (people, places,\n'
+    "  landmarks, brands) stated or clearly implied by the prose; [] if none. NEVER invent identities.\n"
+    '- "prominent_elements": array of objects, one per notable subject/object. Each element has:\n'
+    '  - always: "name", "description", "location", "relative_size" (one of: dominant | large | medium | small),\n'
+    '    "shape_and_color", "texture", "appearance_details", "relationship", "orientation"\n'
+    '  - for a PERSON, additionally: "pose", "expression", "clothing", "gender" (male | female),\n'
+    '    "skin_tone_and_texture"\n'
+    '  - for a GROUP/crowd of like items, additionally: "is_cluster": true and "number_of_objects": "<count or range as string>"\n'
+    "\n"
+    "## RULES\n"
+    "- Output STRICT valid JSON only (double quotes, no trailing commas, no comments, no code fence).\n"
+    "- Fill EVERY field; never leave a required field empty. Values you complete must be consistent\n"
+    "  with the prose and with each other.\n"
+    "- Keep the number and identity of prominent_elements aligned with the subjects the prose names\n"
+    "  (you may add a clearly-implied background element, but do not invent unrelated subjects).\n"
+    "- Copy named entities verbatim into world_knowledge.\n"
+    "- No actions, no timestamps, no camera-movement fields — this is a still image."
+)
+
+NEGATIVE_PRUNE = (
+    "You build a per-sample negative prompt for a video / image generation model.\n"
+    "\n"
+    "You are given (1) the INTENDED content — a structured caption describing what the user wants\n"
+    "(and optionally its first frame) — and (2) a DEFAULT NEGATIVE: a deliberately over-complete JSON\n"
+    "list of generic defects, written to cover many scenarios at once, so it INTENTIONALLY contains\n"
+    'mutually contradictory terms (both "static object with sudden jump" and "motion blur", both\n'
+    '"underexposed" and "overexposed").\n'
+    "\n"
+    "A negative prompt is a CFG anchor the model is pushed AWAY from, so it must NEVER contain\n"
+    "anything the intended content legitimately wants.\n"
+    "\n"
+    "TASK: produce a customized negative for THIS sample by DELETING any term that CONTRADICTS or\n"
+    "would SUPPRESS something the intended content legitimately wants. Keep everything else.\n"
+    "\n"
+    "RULES:\n"
+    "- DELETE ONLY. Keep the surviving terms verbatim, in the SAME JSON structure. Never add,\n"
+    "  reword, or merge.\n"
+    "- Delete a term only when it clearly clashes with the intended content. When in doubt, KEEP it.\n"
+    "- Judge every category against the intent. For example: wants shot cuts or montage removes\n"
+    '  "jump cuts" and "hard cut"; an intentionally still scene removes "static object with sudden\n'
+    '  jump"; deliberate motion blur or long exposure removes "motion blur"; a dark or night scene\n'
+    '  removes "underexposed" and "subject hidden in darkness"; a painting or cartoon by design\n'
+    '  removes the matching artistic_style terms; flickering neon by design removes "flickering".\n'
+    "- Removing a WHOLE category is rare and needs explicit evidence in the caption: drop all of\n"
+    "  physical_plausibility only for fantasy, surreal, dreamlike, magical or zero-gravity content,\n"
+    "  and all of artistic_style only when a non-photoreal style is requested. Ordinary cinematic,\n"
+    "  moody, sci-fi or live-action scenes keep both.\n"
+    '- NEVER delete defects no legitimate content wants: "low quality", "worst quality", "blurry",\n'
+    '  "jpeg artifacts", "low resolution", "pixelated", "text", "watermark", "logo", "subtitles",\n'
+    '  "pillarboxed", "side bars", "warping", "morphing".\n'
+    "\n"
+    "OUTPUT: return ONLY a valid JSON object in the SAME structure as the default negative, with the\n"
+    "contradicting terms removed from their category arrays. Strict parseable JSON — double quotes,\n"
+    "no trailing commas, no comments, no code fence, no text before or after the object."
+)


### PR DESCRIPTION
## Purpose

Add the optional LingBot-Video prompt rewriter on top of the T2I/T2V/TI2V
request contract introduced by #5311.

LingBot-Video is trained on structured JSON captions. This change keeps the
rewriter disabled by default and, when configured, performs the official
two-turn flow before text encoding:

1. expand a plain prompt with the base VLM;
2. map that expansion to structured JSON with the rewriter LoRA enabled.

The integration:

- supports an OpenAI-compatible HTTP backend with separate expand/map models
  or endpoints;
- supports a lazily loaded in-process Transformers + PEFT backend;
- passes the first-frame image to both TI2V rewrite turns;
- leaves already structured JSON captions unchanged;
- runs the external/local backend on rank 0 and broadcasts the rewritten
  prompt to the other ranks;
- optionally prunes the categorized negative prompt with delete-only
  semantics;
- fails instead of silently falling back to an out-of-distribution plain
  prompt when the mapping turn does not return parseable JSON;
- documents both deployment modes and their memory requirements.

This PR does not add the Refiner, new parallelism modes, or performance/quality
claims. The HTTP backend and auto-negative path have deterministic unit
coverage; real-model serving and real auto-negative generation remain follow-up
validation.

## Test Plan

### L1 / CPU

```bash
python -m pytest -q tests/diffusion/models/lingbot_video/test_rewriter.py tests/diffusion/models/lingbot_video/test_pipeline_lingbot_video.py -m "core_model and cpu and diffusion" --run-level=core_model
```

### Changed-file pre-commit

```bash
pre-commit run --files examples/online_serving/lingbot_video/README.md tests/diffusion/models/lingbot_video/test_pipeline_lingbot_video.py tests/diffusion/models/lingbot_video/test_rewriter.py vllm_omni/diffusion/models/lingbot_video/__init__.py vllm_omni/diffusion/models/lingbot_video/auto_negative.py vllm_omni/diffusion/models/lingbot_video/pipeline_lingbot_video.py vllm_omni/diffusion/models/lingbot_video/rewriter.py vllm_omni/diffusion/models/lingbot_video/rewriter_backends.py vllm_omni/diffusion/models/lingbot_video/rewriter_prompts.py
```

### Real-model smoke

One H-series GPU, local checkpoints:

- `/data/models/lingbot-video-dense-1.3b`
- `/data/models/Qwen3.6-27B`
- `/data/models/lingbot-video-rewriter-lora`

The smoke request uses a plain prompt, local Transformers + PEFT rewriting,
320x192 T2I, one frame, two denoising steps, guidance 3.0, flow shift 3.0,
and seed 42.

**vLLM Version:** 0.27.0

**vLLM-Omni Commit:** 8cf8ad13cf71a4d25904441f8141a9846cf0da66

## Test Result

| Validation | Result |
| --- | --- |
| Rewriter + LingBot pipeline L1 suite | **56 passed**, 15 warnings in 13.18s |
| Changed-file pre-commit | **Passed**: Ruff, formatting, typos, markdownlint, mypy, SPDX, forbidden imports, pytest markers |
| Real Qwen3.6-27B + rewriter LoRA load | **Passed** |
| Dense LingBot plain-prompt T2I | **Passed**, one RGB 320x192 image |
| Real T2I initialization | 90.20s |
| Real T2I request processing | 84.05s |
| Real T2I total | 174.25s |

