### PR TITLE
[Bugfix][Diffusion] Drop aborted request's orphaned async output (fix #6413)

### DIFF
--- a/tests/diffusion/test_diffusion_engine_cleanup.py
+++ b/tests/diffusion/test_diffusion_engine_cleanup.py
@@ -334,3 +334,35 @@ def test_close_defers_resource_shutdown_until_worker_thread_stops() -> None:
     engine.executor.shutdown.assert_called_once()
     assert engine._shutdown_complete is True
     assert engine._loop_started is False
+
+def test_finalize_aborted_request_drops_pending_async_output() -> None:
+    """An aborted request with a pending async output must be drained (#6413).
+
+    The aborted branch of _finalize_finished_request returns before the
+    async_output_id branch, so without draining, the worker's late OUTPUT_READY
+    is cached in the executor's _completed_outputs forever. The engine must tell
+    the executor to drop that output id.
+    """
+    engine = _make_engine()
+    engine.executor = SimpleNamespace(drop_output=Mock())
+    request_id = engine.scheduler.add_request(_make_request("aborted-async"))
+    engine.scheduler.finish_requests(request_id, DiffusionRequestStatus.FINISHED_ABORTED)
+
+    runner_output = SimpleNamespace(result=None, async_output_id="aid-async-1")
+    output = engine._finalize_finished_request(request_id, runner_output)
+
+    assert output.aborted is True
+    engine.executor.drop_output.assert_called_once_with("aid-async-1")
+
+
+def test_finalize_aborted_request_without_async_output_skips_drop() -> None:
+    """No async output pending -> nothing to drop; drop_output not called."""
+    engine = _make_engine()
+    engine.executor = SimpleNamespace(drop_output=Mock())
+    request_id = engine.scheduler.add_request(_make_request("aborted-plain"))
+    engine.scheduler.finish_requests(request_id, DiffusionRequestStatus.FINISHED_ABORTED)
+
+    output = engine._finalize_finished_request(request_id)
+
+    assert output.aborted is True
+    engine.executor.drop_output.assert_not_called()

--- a/tests/diffusion/test_diffusion_engine_cleanup.py
+++ b/tests/diffusion/test_diffusion_engine_cleanup.py
@@ -335,6 +335,7 @@ def test_close_defers_resource_shutdown_until_worker_thread_stops() -> None:
     assert engine._shutdown_complete is True
     assert engine._loop_started is False
 
+
 def test_finalize_aborted_request_drops_pending_async_output() -> None:
     """An aborted request with a pending async output must be drained (#6413).
 

--- a/tests/diffusion/test_diffusion_engine_cleanup.py
+++ b/tests/diffusion/test_diffusion_engine_cleanup.py
@@ -379,3 +379,35 @@ def test_close_defers_resource_shutdown_until_worker_thread_stops() -> None:
     engine.executor.shutdown.assert_called_once()
     assert engine._shutdown_complete is True
     assert engine._loop_started is False
+
+def test_finalize_aborted_request_drops_pending_async_output() -> None:
+    """An aborted request with a pending async output must be drained (#6413).
+
+    The aborted branch of _finalize_finished_request returns before the
+    async_output_id branch, so without draining, the worker's late OUTPUT_READY
+    is cached in the executor's _completed_outputs forever. The engine must tell
+    the executor to drop that output id.
+    """
+    engine = _make_engine()
+    engine.executor = SimpleNamespace(drop_output=Mock())
+    request_id = engine.scheduler.add_request(_make_request("aborted-async"))
+    engine.scheduler.finish_requests(request_id, DiffusionRequestStatus.FINISHED_ABORTED)
+
+    runner_output = SimpleNamespace(result=None, async_output_id="aid-async-1")
+    output = engine._finalize_finished_request(request_id, runner_output)
+
+    assert output.aborted is True
+    engine.executor.drop_output.assert_called_once_with("aid-async-1")
+
+
+def test_finalize_aborted_request_without_async_output_skips_drop() -> None:
+    """No async output pending -> nothing to drop; drop_output not called."""
+    engine = _make_engine()
+    engine.executor = SimpleNamespace(drop_output=Mock())
+    request_id = engine.scheduler.add_request(_make_request("aborted-plain"))
+    engine.scheduler.finish_requests(request_id, DiffusionRequestStatus.FINISHED_ABORTED)
+
+    output = engine._finalize_finished_request(request_id)
+
+    assert output.aborted is True
+    engine.executor.drop_output.assert_not_called()

--- a/tests/diffusion/test_diffusion_engine_cleanup.py
+++ b/tests/diffusion/test_diffusion_engine_cleanup.py
@@ -380,6 +380,7 @@ def test_close_defers_resource_shutdown_until_worker_thread_stops() -> None:
     assert engine._shutdown_complete is True
     assert engine._loop_started is False
 
+
 def test_finalize_aborted_request_drops_pending_async_output() -> None:
     """An aborted request with a pending async output must be drained (#6413).
 

--- a/tests/diffusion/test_diffusion_ipc.py
+++ b/tests/diffusion/test_diffusion_ipc.py
@@ -6,6 +6,7 @@ import multiprocessing as mp
 import queue
 import threading
 import time
+from collections import OrderedDict
 from multiprocessing import shared_memory
 from multiprocessing.connection import Connection
 
@@ -108,6 +109,7 @@ def test_per_worker_result_queues_release_nested_numpy_shm_and_processes() -> No
         executor._rpc_futures = {}
         executor._output_futures = {}
         executor._completed_outputs = {}
+        executor._dropped_output_ids = OrderedDict()
         executor._batch_split_map = {}
         executor._start_result_pump()
 

--- a/tests/diffusion/test_multiproc_shutdown_race.py
+++ b/tests/diffusion/test_multiproc_shutdown_race.py
@@ -18,6 +18,7 @@ after shutdown still has to be unpacked (just never cached).
 import queue
 import threading
 import time
+from collections import OrderedDict
 from unittest.mock import MagicMock
 
 import pytest
@@ -47,6 +48,7 @@ def _make_executor():
     executor._rpc_futures = {}
     executor._output_futures = {}
     executor._completed_outputs = {}
+    executor._dropped_output_ids = OrderedDict()
     executor._batch_split_map = {}
     executor._futures_lock = threading.RLock()
     executor._pump_running = False

--- a/tests/diffusion/test_multiproc_shutdown_race.py
+++ b/tests/diffusion/test_multiproc_shutdown_race.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for MultiprocDiffusionExecutor shutdown / delayed-pump race.
+
+Reproduces hsliuustc0106's #6439 review finding: `shutdown()` joins each result
+pump thread with a 2s timeout and only warns if it survives. A pump blocked
+inside `unpack_diffusion_output_shm` can resume AFTER `_completed_outputs` was
+cleared and repopulate the dictionary, reintroducing the leak this PR was meant
+to close.
+
+Both single-output and batch-split code paths must discard deliveries once
+`_closed` is set; `drop_output()` must be a no-op after shutdown.
+"""
+
+import queue
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm_omni.diffusion.data import (
+    AsyncDiffusionOutput,
+    AsyncOutputKind,
+    DiffusionOutput,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _make_executor():
+    """Minimal MultiprocDiffusionExecutor-like object; mirrors test_result_pump helper."""
+    from vllm_omni.diffusion.executor.multiproc_executor import (
+        MultiprocDiffusionExecutor,
+    )
+
+    od_config = MagicMock()
+    od_config.step_execution = False
+
+    executor = object.__new__(MultiprocDiffusionExecutor)
+    executor.od_config = od_config
+    executor._rpc_id_counter = 0
+    executor._rpc_id_lock = threading.Lock()
+    executor._rpc_futures = {}
+    executor._output_futures = {}
+    executor._completed_outputs = {}
+    executor._batch_split_map = {}
+    executor._futures_lock = threading.RLock()
+    executor._pump_running = False
+    executor._pump_stop = threading.Event()
+    executor._sync_result_buffer = queue.Queue()
+    executor._result_mq = MagicMock()
+    executor._result_mqs = []
+    executor._broadcast_mq = MagicMock()
+    executor._closed = False
+    executor._is_failed = False
+    executor._finalizer = MagicMock()
+    executor._shutdown_cleaner = None
+    executor._processes = []
+    return executor
+
+
+class _FakeBatchOutput:
+    """Batch-level output exposing per-request results (mirrors test_result_pump helper)."""
+
+    def __init__(self, results):
+        self._results = results
+
+    def get_request_output(self, req_id):
+        result = self._results.get(req_id)
+        if result is None:
+            return None
+        return MagicMock(result=result)
+
+
+def _run_pump_blocked_until_shutdown(executor, msg, unpack_gate):
+    """Drive the pump thread with one *msg*.
+
+    The pump enters `unpack_diffusion_output_shm` and blocks on *unpack_gate*.
+    Caller is expected to close the executor, then release the gate. Returns
+    the pump thread so the test can join it.
+    """
+    call_count = [0]
+
+    def mock_dequeue(timeout=None):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return msg
+        # After the single msg, block until pump_stop is set so the pump
+        # loops out cleanly (mirrors _feed_one_msg_to_pump behaviour).
+        while not executor._pump_stop.is_set():
+            time.sleep(0.02)
+        raise TimeoutError
+
+    executor._result_mq.dequeue = mock_dequeue
+    t = threading.Thread(target=executor._result_pump, daemon=True)
+    t.start()
+    # Give the pump time to dequeue and reach unpack_gate.wait().
+    time.sleep(0.1)
+    return t
+
+
+class TestResultPumpDelayedAfterShutdown:
+    """Reproduce hsliuustc0106's finding: a pump blocked inside SHM unpack can
+    resume after shutdown clears `_completed_outputs` and repopulate it.
+
+    Without gating, the assertions here fail (leak reintroduced through the
+    late-write path). With gating on `_closed`, deliveries after shutdown are
+    discarded.
+    """
+
+    def test_result_pump_delayed_after_shutdown_single(self, mocker):
+        """Single-output pump path: late unpack must not repopulate the dict."""
+        executor = _make_executor()
+
+        unpack_gate = threading.Event()
+
+        def _blocked_unpack(*_args, **_kwargs):
+            unpack_gate.wait(timeout=10.0)
+
+        mocker.patch(
+            "vllm_omni.diffusion.executor.multiproc_executor.unpack_diffusion_output_shm",
+            side_effect=_blocked_unpack,
+        )
+
+        async_output_id = "abc-single"
+        msg = AsyncDiffusionOutput(
+            kind=AsyncOutputKind.OUTPUT_READY,
+            async_output_id=async_output_id,
+            output=DiffusionOutput(output="late"),
+        )
+
+        pump_thread = _run_pump_blocked_until_shutdown(executor, msg, unpack_gate)
+
+        # Simulate shutdown() clearing state while the pump is still stuck
+        # inside unpack. `_closed = True` mirrors shutdown()'s first line.
+        executor._closed = True
+        with executor._futures_lock:
+            executor._completed_outputs.clear()
+
+        # Release the pump: it resumes past unpack and tries to write into
+        # _completed_outputs. Without the gate, this reintroduces the leak.
+        unpack_gate.set()
+
+        # Give the pump time to finish delivering and hit the gate.
+        time.sleep(0.2)
+        executor._pump_stop.set()
+        pump_thread.join(timeout=2.0)
+        assert not pump_thread.is_alive(), "pump thread did not exit"
+
+        # The core assertion: the delayed pump must not have repopulated
+        # `_completed_outputs` after shutdown cleared it.
+        assert executor._completed_outputs == {}, (
+            f"delayed pump repopulated dict after shutdown: "
+            f"{list(executor._completed_outputs)}"
+        )
+
+    def test_result_pump_delayed_after_shutdown_batch_split(self, mocker):
+        """Batch-split pump path: late unpack must not repopulate the dict."""
+        executor = _make_executor()
+
+        unpack_gate = threading.Event()
+
+        def _blocked_unpack(*_args, **_kwargs):
+            unpack_gate.wait(timeout=10.0)
+
+        mocker.patch(
+            "vllm_omni.diffusion.executor.multiproc_executor.unpack_diffusion_output_shm",
+            side_effect=_blocked_unpack,
+        )
+
+        batch_id = "batch-delayed"
+        # Pre-populate batch split map so pump goes down the batch path,
+        # WITHOUT registering per-request waiters (they are the ones aborted).
+        with executor._futures_lock:
+            executor._batch_split_map[batch_id] = {
+                f"{batch_id}/r-a": "r-a",
+                f"{batch_id}/r-b": "r-b",
+            }
+
+        outputs = {
+            "r-a": DiffusionOutput(output="late-a"),
+            "r-b": DiffusionOutput(output="late-b"),
+        }
+        msg = AsyncDiffusionOutput(
+            kind=AsyncOutputKind.OUTPUT_READY,
+            async_output_id=batch_id,
+            output=_FakeBatchOutput(outputs),
+        )
+
+        pump_thread = _run_pump_blocked_until_shutdown(executor, msg, unpack_gate)
+
+        # Simulate shutdown during unpack.
+        executor._closed = True
+        with executor._futures_lock:
+            executor._completed_outputs.clear()
+
+        # Release the pump so it enters _deliver_batch_split with no waiters
+        # registered; without gating, both per-request results land in
+        # _completed_outputs.
+        unpack_gate.set()
+
+        time.sleep(0.2)
+        executor._pump_stop.set()
+        pump_thread.join(timeout=2.0)
+        assert not pump_thread.is_alive(), "pump thread did not exit"
+
+        assert executor._completed_outputs == {}, (
+            f"delayed batch-split pump repopulated dict after shutdown: "
+            f"{list(executor._completed_outputs)}"
+        )
+
+
+class TestDropOutputAfterShutdown:
+    """`drop_output()` runs from the abort path and must be a no-op once the
+    executor has entered shutdown, so it does not race the pump into an
+    already-torn-down `_output_futures` / `_completed_outputs`.
+    """
+
+    def test_drop_output_after_shutdown_is_noop(self):
+        executor = _make_executor()
+        executor._closed = True
+
+        # Before the gate, `drop_output` would register a placeholder waiter
+        # in `_output_futures`. After shutdown, that would leak past teardown.
+        executor.drop_output("abc-abort")
+
+        assert executor._output_futures == {}, (
+            f"drop_output registered waiter after shutdown: "
+            f"{list(executor._output_futures)}"
+        )
+        assert executor._completed_outputs == {}

--- a/tests/diffusion/test_multiproc_shutdown_race.py
+++ b/tests/diffusion/test_multiproc_shutdown_race.py
@@ -151,8 +151,7 @@ class TestResultPumpDelayedAfterShutdown:
         # The core assertion: the delayed pump must not have repopulated
         # `_completed_outputs` after shutdown cleared it.
         assert executor._completed_outputs == {}, (
-            f"delayed pump repopulated dict after shutdown: "
-            f"{list(executor._completed_outputs)}"
+            f"delayed pump repopulated dict after shutdown: {list(executor._completed_outputs)}"
         )
 
     def test_result_pump_delayed_after_shutdown_batch_split(self, mocker):
@@ -206,8 +205,7 @@ class TestResultPumpDelayedAfterShutdown:
         assert not pump_thread.is_alive(), "pump thread did not exit"
 
         assert executor._completed_outputs == {}, (
-            f"delayed batch-split pump repopulated dict after shutdown: "
-            f"{list(executor._completed_outputs)}"
+            f"delayed batch-split pump repopulated dict after shutdown: {list(executor._completed_outputs)}"
         )
 
 
@@ -226,7 +224,6 @@ class TestDropOutputAfterShutdown:
         executor.drop_output("abc-abort")
 
         assert executor._output_futures == {}, (
-            f"drop_output registered waiter after shutdown: "
-            f"{list(executor._output_futures)}"
+            f"drop_output registered waiter after shutdown: {list(executor._output_futures)}"
         )
         assert executor._completed_outputs == {}

--- a/tests/diffusion/test_multiproc_shutdown_race.py
+++ b/tests/diffusion/test_multiproc_shutdown_race.py
@@ -9,7 +9,10 @@ cleared and repopulate the dictionary, reintroducing the leak this PR was meant
 to close.
 
 Both single-output and batch-split code paths must discard deliveries once
-`_closed` is set; `drop_output()` must be a no-op after shutdown.
+`_closed` is set; `drop_output()` must be a no-op after shutdown. Discarding
+must NOT skip SHM unpack: `unpack_diffusion_output_shm()` is the only
+receive-side path that unlinks named SHM segments, so an OUTPUT_READY dequeued
+after shutdown still has to be unpacked (just never cached).
 """
 
 import queue
@@ -73,12 +76,14 @@ class _FakeBatchOutput:
         return MagicMock(result=result)
 
 
-def _run_pump_blocked_until_shutdown(executor, msg, unpack_gate):
+def _run_pump_with_one_msg(executor, msg):
     """Drive the pump thread with one *msg*.
 
-    The pump enters `unpack_diffusion_output_shm` and blocks on *unpack_gate*.
-    Caller is expected to close the executor, then release the gate. Returns
-    the pump thread so the test can join it.
+    After the single msg, dequeue blocks until ``_pump_stop`` is set so the
+    pump loops out cleanly. Returns the pump thread. The caller finishes the
+    pump with ``_finish_pump``; the message's delivery completes before the
+    second dequeue call, so joining the thread is a deterministic barrier for
+    "delivery handled".
     """
     call_count = [0]
 
@@ -86,8 +91,6 @@ def _run_pump_blocked_until_shutdown(executor, msg, unpack_gate):
         call_count[0] += 1
         if call_count[0] == 1:
             return msg
-        # After the single msg, block until pump_stop is set so the pump
-        # loops out cleanly (mirrors _feed_one_msg_to_pump behaviour).
         while not executor._pump_stop.is_set():
             time.sleep(0.02)
         raise TimeoutError
@@ -95,9 +98,13 @@ def _run_pump_blocked_until_shutdown(executor, msg, unpack_gate):
     executor._result_mq.dequeue = mock_dequeue
     t = threading.Thread(target=executor._result_pump, daemon=True)
     t.start()
-    # Give the pump time to dequeue and reach unpack_gate.wait().
-    time.sleep(0.1)
     return t
+
+
+def _finish_pump(executor, pump_thread):
+    executor._pump_stop.set()
+    pump_thread.join(timeout=5.0)
+    assert not pump_thread.is_alive(), "pump thread did not exit"
 
 
 class TestResultPumpDelayedAfterShutdown:
@@ -106,16 +113,20 @@ class TestResultPumpDelayedAfterShutdown:
 
     Without gating, the assertions here fail (leak reintroduced through the
     late-write path). With gating on `_closed`, deliveries after shutdown are
-    discarded.
+    discarded. `entered_unpack` proves the pump is inside the mocked unpack
+    BEFORE `_closed` is set, so the post-unpack race path is really exercised
+    (a fixed sleep could let the pump take the early closed gate instead).
     """
 
     def test_result_pump_delayed_after_shutdown_single(self, mocker):
         """Single-output pump path: late unpack must not repopulate the dict."""
         executor = _make_executor()
 
+        entered_unpack = threading.Event()
         unpack_gate = threading.Event()
 
         def _blocked_unpack(*_args, **_kwargs):
+            entered_unpack.set()
             unpack_gate.wait(timeout=10.0)
 
         mocker.patch(
@@ -130,7 +141,11 @@ class TestResultPumpDelayedAfterShutdown:
             output=DiffusionOutput(output="late"),
         )
 
-        pump_thread = _run_pump_blocked_until_shutdown(executor, msg, unpack_gate)
+        pump_thread = _run_pump_with_one_msg(executor, msg)
+
+        # The pump must be INSIDE unpack (past the early closed gate) before
+        # shutdown starts, otherwise the post-unpack race is not exercised.
+        assert entered_unpack.wait(timeout=5.0), "pump never reached SHM unpack"
 
         # Simulate shutdown() clearing state while the pump is still stuck
         # inside unpack. `_closed = True` mirrors shutdown()'s first line.
@@ -142,11 +157,9 @@ class TestResultPumpDelayedAfterShutdown:
         # _completed_outputs. Without the gate, this reintroduces the leak.
         unpack_gate.set()
 
-        # Give the pump time to finish delivering and hit the gate.
-        time.sleep(0.2)
-        executor._pump_stop.set()
-        pump_thread.join(timeout=2.0)
-        assert not pump_thread.is_alive(), "pump thread did not exit"
+        # Joining the pump is a deterministic barrier: the delivery is fully
+        # handled before the pump blocks on the second dequeue and exits.
+        _finish_pump(executor, pump_thread)
 
         # The core assertion: the delayed pump must not have repopulated
         # `_completed_outputs` after shutdown cleared it.
@@ -158,9 +171,11 @@ class TestResultPumpDelayedAfterShutdown:
         """Batch-split pump path: late unpack must not repopulate the dict."""
         executor = _make_executor()
 
+        entered_unpack = threading.Event()
         unpack_gate = threading.Event()
 
         def _blocked_unpack(*_args, **_kwargs):
+            entered_unpack.set()
             unpack_gate.wait(timeout=10.0)
 
         mocker.patch(
@@ -187,7 +202,9 @@ class TestResultPumpDelayedAfterShutdown:
             output=_FakeBatchOutput(outputs),
         )
 
-        pump_thread = _run_pump_blocked_until_shutdown(executor, msg, unpack_gate)
+        pump_thread = _run_pump_with_one_msg(executor, msg)
+
+        assert entered_unpack.wait(timeout=5.0), "pump never reached SHM unpack"
 
         # Simulate shutdown during unpack.
         executor._closed = True
@@ -199,14 +216,45 @@ class TestResultPumpDelayedAfterShutdown:
         # _completed_outputs.
         unpack_gate.set()
 
-        time.sleep(0.2)
-        executor._pump_stop.set()
-        pump_thread.join(timeout=2.0)
-        assert not pump_thread.is_alive(), "pump thread did not exit"
+        _finish_pump(executor, pump_thread)
 
         assert executor._completed_outputs == {}, (
             f"delayed batch-split pump repopulated dict after shutdown: {list(executor._completed_outputs)}"
         )
+
+    def test_output_ready_after_shutdown_still_unpacks_shm(self, mocker):
+        """An OUTPUT_READY dequeued after `_closed` is set must still go
+        through `unpack_diffusion_output_shm` (the only receive-side path that
+        unlinks named SHM segments) while writing nothing into the caches.
+        Discarding it before unpack would leak the segments in /dev/shm for
+        the lifetime of the parent process.
+        """
+        executor = _make_executor()
+
+        unpack_calls = []
+        mocker.patch(
+            "vllm_omni.diffusion.executor.multiproc_executor.unpack_diffusion_output_shm",
+            side_effect=lambda output: unpack_calls.append(output),
+        )
+
+        # Shutdown completed BEFORE the pump dequeues the message.
+        executor._closed = True
+        with executor._futures_lock:
+            executor._completed_outputs.clear()
+
+        output = DiffusionOutput(output="late-shm")
+        msg = AsyncDiffusionOutput(
+            kind=AsyncOutputKind.OUTPUT_READY,
+            async_output_id="abc-shm",
+            output=output,
+        )
+
+        pump_thread = _run_pump_with_one_msg(executor, msg)
+        _finish_pump(executor, pump_thread)
+
+        assert unpack_calls == [output], "closed-time discard skipped SHM unpack/unlink"
+        assert executor._completed_outputs == {}
+        assert executor._output_futures == {}
 
 
 class TestDropOutputAfterShutdown:

--- a/tests/diffusion/test_result_pump.py
+++ b/tests/diffusion/test_result_pump.py
@@ -285,7 +285,10 @@ class TestResultPumpDispatch:
         assert fut.done()
         assert fut.result(timeout=1.0) is output
         assert async_output_id not in executor._output_futures
-        assert async_output_id not in executor._completed_outputs
+        # The resolved future is cached in _completed_outputs so a late
+        # wait_output_ready (drop → pump → wait) can still retrieve it;
+        # wait_output_ready.pop cleans it on actual consumption.
+        assert executor._completed_outputs.get(async_output_id) is fut
 
 
 class _FakeBatchOutput:
@@ -592,8 +595,12 @@ class TestDropOutput:
         _feed_one_msg_to_pump(executor, msg)
 
         with executor._futures_lock:
-            assert "aid-2" not in executor._completed_outputs
+            # The resolved placeholder is now cached in _completed_outputs
+            # for a potential late wait_output_ready (drop → pump → wait);
+            # it is not in _output_futures (popped by the pump).
             assert "aid-2" not in executor._output_futures
+            cached = executor._completed_outputs.get("aid-2")
+            assert cached is not None and cached.done()
 
     def test_leaves_real_waiter_untouched(self):
         executor = _make_executor()
@@ -604,6 +611,40 @@ class TestDropOutput:
         with executor._futures_lock:
             # A genuine waiter still drains via the normal path.
             assert executor._output_futures.get("aid-3") is real
+
+    def test_drop_then_pump_then_wait_reuses_placeholder(self):
+        """drop_output → pump resolves placeholder → wait_output_ready must
+        return the already-resolved placeholder, not a fresh never-completed
+        Future. This is the verl-omni fully-async abort ordering that hangs
+        without the reuse fix."""
+        executor = _make_executor()
+
+        # 1. Abort registers a placeholder.
+        executor.drop_output("aid-dpw")
+
+        # 2. Pump delivers OUTPUT_READY, resolving the placeholder.
+        output = DiffusionOutput(output="resolved")
+        msg = AsyncDiffusionOutput(
+            kind=AsyncOutputKind.OUTPUT_READY,
+            async_output_id="aid-dpw",
+            output=output,
+        )
+        _feed_one_msg_to_pump(executor, msg)
+
+        # 3. Late consumer waits → must get the resolved future.
+        fut = executor.wait_output_ready("aid-dpw")
+        assert fut.done(), "wait_output_ready returned a never-completed future after drop+pump"
+
+    def test_drop_then_wait_share_same_future(self):
+        """drop_output → wait_output_ready (before pump) must return the same
+        placeholder so both paths agree on one future."""
+        executor = _make_executor()
+
+        executor.drop_output("aid-dw")
+        fut = executor.wait_output_ready("aid-dw")
+
+        with executor._futures_lock:
+            assert executor._output_futures.get("aid-dw") is fut
 
 
 class TestShutdownClearsCompletedOutputs:

--- a/tests/diffusion/test_result_pump.py
+++ b/tests/diffusion/test_result_pump.py
@@ -6,6 +6,7 @@ import concurrent.futures
 import queue
 import threading
 import time
+from collections import OrderedDict
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -30,6 +31,7 @@ def _make_executor(step_execution=False):
     executor._rpc_futures = {}
     executor._output_futures = {}
     executor._completed_outputs = {}
+    executor._dropped_output_ids = OrderedDict()
     executor._batch_split_map = {}
     executor._futures_lock = threading.RLock()
     executor._pump_running = False
@@ -285,10 +287,7 @@ class TestResultPumpDispatch:
         assert fut.done()
         assert fut.result(timeout=1.0) is output
         assert async_output_id not in executor._output_futures
-        # The resolved future is cached in _completed_outputs so a late
-        # wait_output_ready (drop → pump → wait) can still retrieve it;
-        # wait_output_ready.pop cleans it on actual consumption.
-        assert executor._completed_outputs.get(async_output_id) is fut
+        assert async_output_id not in executor._completed_outputs
 
 
 class _FakeBatchOutput:
@@ -595,12 +594,8 @@ class TestDropOutput:
         _feed_one_msg_to_pump(executor, msg)
 
         with executor._futures_lock:
-            # The resolved placeholder is now cached in _completed_outputs
-            # for a potential late wait_output_ready (drop → pump → wait);
-            # it is not in _output_futures (popped by the pump).
+            assert "aid-2" not in executor._completed_outputs
             assert "aid-2" not in executor._output_futures
-            cached = executor._completed_outputs.get("aid-2")
-            assert cached is not None and cached.done()
 
     def test_leaves_real_waiter_untouched(self):
         executor = _make_executor()
@@ -612,39 +607,131 @@ class TestDropOutput:
             # A genuine waiter still drains via the normal path.
             assert executor._output_futures.get("aid-3") is real
 
-    def test_drop_then_pump_then_wait_reuses_placeholder(self):
-        """drop_output → pump resolves placeholder → wait_output_ready must
-        return the already-resolved placeholder, not a fresh never-completed
-        Future. This is the verl-omni fully-async abort ordering that hangs
-        without the reuse fix."""
+    def test_drop_then_pump_then_late_wait_fails_fast_without_caching(self):
+        """drop_output → OUTPUT_READY → late wait_output_ready.
+
+        The aborted output's tensors must NOT be retained anywhere, and the
+        late waiter must get a completed (failed) Future rather than a fresh
+        one that never resolves — the verl-omni fully-async abort ordering.
+        """
         executor = _make_executor()
 
-        # 1. Abort registers a placeholder.
         executor.drop_output("aid-dpw")
-
-        # 2. Pump delivers OUTPUT_READY, resolving the placeholder.
-        output = DiffusionOutput(output="resolved")
         msg = AsyncDiffusionOutput(
             kind=AsyncOutputKind.OUTPUT_READY,
             async_output_id="aid-dpw",
-            output=output,
+            output=DiffusionOutput(output="discarded"),
         )
         _feed_one_msg_to_pump(executor, msg)
 
-        # 3. Late consumer waits → must get the resolved future.
-        fut = executor.wait_output_ready("aid-dpw")
-        assert fut.done(), "wait_output_ready returned a never-completed future after drop+pump"
+        with executor._futures_lock:
+            assert "aid-dpw" not in executor._completed_outputs
+            assert "aid-dpw" not in executor._output_futures
 
-    def test_drop_then_wait_share_same_future(self):
-        """drop_output → wait_output_ready (before pump) must return the same
-        placeholder so both paths agree on one future."""
+        fut = executor.wait_output_ready("aid-dpw")
+        assert fut.done(), "late wait after drop returned a never-completing future"
+        with pytest.raises(RuntimeError, match="was dropped"):
+            fut.result(timeout=0)
+        # Terminal: the dropped-id record is consumed by the wait.
+        with executor._futures_lock:
+            assert "aid-dpw" not in executor._dropped_output_ids
+
+    def test_drop_then_wait_share_placeholder_and_fail_on_delivery(self):
+        """drop_output → wait_output_ready (before pump) share one Future, and
+        delivery terminates it with the dropped error instead of the tensors."""
         executor = _make_executor()
 
         executor.drop_output("aid-dw")
         fut = executor.wait_output_ready("aid-dw")
-
         with executor._futures_lock:
             assert executor._output_futures.get("aid-dw") is fut
+        assert not fut.done()
+
+        msg = AsyncDiffusionOutput(
+            kind=AsyncOutputKind.OUTPUT_READY,
+            async_output_id="aid-dw",
+            output=DiffusionOutput(output="discarded"),
+        )
+        _feed_one_msg_to_pump(executor, msg)
+
+        assert fut.done()
+        with pytest.raises(RuntimeError, match="was dropped"):
+            fut.result(timeout=0)
+        with executor._futures_lock:
+            assert "aid-dw" not in executor._completed_outputs
+            assert "aid-dw" not in executor._output_futures
+
+    def test_drop_after_cached_then_late_wait_fails_fast(self):
+        """Result already cached → drop_output → late wait must not hang."""
+        executor = _make_executor()
+        fut = concurrent.futures.Future()
+        fut.set_result(DiffusionOutput(output="cached"))
+        with executor._futures_lock:
+            executor._completed_outputs["aid-cd"] = fut
+
+        executor.drop_output("aid-cd")
+        late = executor.wait_output_ready("aid-cd")
+        assert late.done()
+        with pytest.raises(RuntimeError, match="was dropped"):
+            late.result(timeout=0)
+
+    def test_dropped_ids_memory_is_bounded(self, monkeypatch):
+        from vllm_omni.diffusion.executor import multiproc_executor as mpe
+
+        cap = 8
+        monkeypatch.setattr(mpe, "_DROPPED_OUTPUT_IDS_MAX", cap)
+        executor = _make_executor()
+        n = cap + 5
+        for i in range(n):
+            executor.drop_output(f"aid-b{i}")
+            executor._pump_stop.clear()
+            _feed_one_msg_to_pump(
+                executor,
+                AsyncDiffusionOutput(
+                    kind=AsyncOutputKind.OUTPUT_READY,
+                    async_output_id=f"aid-b{i}",
+                    output=DiffusionOutput(output=i),
+                ),
+            )
+        with executor._futures_lock:
+            assert len(executor._dropped_output_ids) == cap
+            # Oldest evicted, newest kept; no tensors retained anywhere.
+            assert "aid-b0" not in executor._dropped_output_ids
+            assert f"aid-b{n - 1}" in executor._dropped_output_ids
+            assert executor._completed_outputs == {}
+            assert executor._output_futures == {}
+
+    def test_batch_split_drop_placeholder_discards_member(self):
+        """_deliver_batch_split applies the same contract: a dropped member is
+        discarded (never cached), a live member is resolved directly."""
+        executor = _make_executor()
+        live = executor.wait_output_ready("batch-d/r-live")
+        executor.drop_output("batch-d/r-dropped")
+        with executor._futures_lock:
+            executor._batch_split_map["batch-d"] = {
+                "batch-d/r-dropped": "r-dropped",
+                "batch-d/r-live": "r-live",
+            }
+        outputs = {
+            "r-dropped": DiffusionOutput(output="discarded"),
+            "r-live": DiffusionOutput(output="ok"),
+        }
+        _feed_one_msg_to_pump(
+            executor,
+            AsyncDiffusionOutput(
+                kind=AsyncOutputKind.OUTPUT_READY,
+                async_output_id="batch-d",
+                output=_FakeBatchOutput(outputs),
+            ),
+        )
+        assert live.result(timeout=1.0) is outputs["r-live"]
+        with executor._futures_lock:
+            assert executor._completed_outputs == {}
+            assert executor._output_futures == {}
+        late = executor.wait_output_ready("batch-d/r-dropped")
+        assert late.done()
+        with pytest.raises(RuntimeError, match="was dropped"):
+            late.result(timeout=0)
 
 
 class TestShutdownClearsCompletedOutputs:

--- a/tests/diffusion/test_result_pump.py
+++ b/tests/diffusion/test_result_pump.py
@@ -465,6 +465,7 @@ class TestResultPumpCancelledFutureRace:
         _feed_one_msg_to_pump(executor, msg)
 
         assert fut.cancelled()
+        assert executor._completed_outputs == {}
 
     def test_batch_split_racing_cancel_does_not_crash_pump(self):
         executor = _make_executor()
@@ -492,6 +493,67 @@ class TestResultPumpCancelledFutureRace:
         assert cancelled_fut.cancelled()
         assert healthy_fut.done()
         assert healthy_fut.result(timeout=1.0) is outputs["r-healthy"]
+        assert executor._completed_outputs == {}
+
+
+class TestResultPumpDiscardsDoneFuture:
+    """A registered future that is already cancelled/done must have its late
+    OUTPUT_READY result discarded, not re-cached into _completed_outputs.
+
+    rahul-steiger-nv (#6439 review): the old `else` branch cached the result
+    whenever `pending.done()` was true, so a genuinely cancelled waiter (the
+    common abort case) leaked the late result back into the cache. The pump
+    must distinguish "no waiter registered" (cache) from "waiter registered
+    but done/cancelled" (discard).
+    """
+
+    def test_single_output_discards_for_cancelled_future(self):
+        executor = _make_executor()
+        fut: concurrent.futures.Future = concurrent.futures.Future()
+        fut.cancel()
+        assert fut.cancelled() and fut.done()
+        with executor._futures_lock:
+            executor._output_futures["aid-x"] = fut
+
+        msg = AsyncDiffusionOutput(
+            kind=AsyncOutputKind.OUTPUT_READY,
+            async_output_id="aid-x",
+            output=DiffusionOutput(output="late"),
+        )
+        _feed_one_msg_to_pump(executor, msg)
+
+        assert executor._completed_outputs == {}
+        assert "aid-x" not in executor._output_futures
+
+    def test_batch_split_discards_for_cancelled_member(self):
+        executor = _make_executor()
+        cancelled_fut: concurrent.futures.Future = concurrent.futures.Future()
+        cancelled_fut.cancel()
+        assert cancelled_fut.cancelled() and cancelled_fut.done()
+        healthy_fut: concurrent.futures.Future = concurrent.futures.Future()
+        with executor._futures_lock:
+            executor._output_futures["batch-9/r-aborted"] = cancelled_fut
+            executor._output_futures["batch-9/r-healthy"] = healthy_fut
+            executor._batch_split_map["batch-9"] = {
+                "batch-9/r-aborted": "r-aborted",
+                "batch-9/r-healthy": "r-healthy",
+            }
+
+        outputs = {
+            "r-aborted": DiffusionOutput(output="late"),
+            "r-healthy": DiffusionOutput(output="ok"),
+        }
+        msg = AsyncDiffusionOutput(
+            kind=AsyncOutputKind.OUTPUT_READY,
+            async_output_id="batch-9",
+            output=_FakeBatchOutput(outputs),
+        )
+        _feed_one_msg_to_pump(executor, msg)
+
+        # Aborted member's result is discarded, healthy member still delivered.
+        assert healthy_fut.done()
+        assert healthy_fut.result(timeout=1.0) is outputs["r-healthy"]
+        assert executor._completed_outputs == {}
 
 
 class TestDropOutput:

--- a/tests/diffusion/test_result_pump.py
+++ b/tests/diffusion/test_result_pump.py
@@ -492,3 +492,68 @@ class TestResultPumpCancelledFutureRace:
         assert cancelled_fut.cancelled()
         assert healthy_fut.done()
         assert healthy_fut.result(timeout=1.0) is outputs["r-healthy"]
+
+
+class TestDropOutput:
+    """drop_output drains an aborted request's async output so it cannot leak.
+
+    An aborted request never calls wait_output_ready, so a late OUTPUT_READY is
+    unpacked and cached in _completed_outputs forever (issue #6413). drop_output
+    evicts it, handling both arrival orderings.
+    """
+
+    def test_drops_already_cached_output(self):
+        executor = _make_executor()
+        fut = concurrent.futures.Future()
+        fut.set_result(DiffusionOutput(output="leaked"))
+        with executor._futures_lock:
+            executor._completed_outputs["aid-1"] = fut
+
+        executor.drop_output("aid-1")
+
+        with executor._futures_lock:
+            assert "aid-1" not in executor._completed_outputs
+
+    def test_prevents_caching_when_output_not_yet_arrived(self):
+        executor = _make_executor()
+
+        # Abort finalized before OUTPUT_READY: register a placeholder waiter.
+        executor.drop_output("aid-2")
+
+        # The late result now resolves into the placeholder instead of caching.
+        output = DiffusionOutput(output="late")
+        msg = AsyncDiffusionOutput(
+            kind=AsyncOutputKind.OUTPUT_READY,
+            async_output_id="aid-2",
+            output=output,
+        )
+        _feed_one_msg_to_pump(executor, msg)
+
+        with executor._futures_lock:
+            assert "aid-2" not in executor._completed_outputs
+            assert "aid-2" not in executor._output_futures
+
+    def test_leaves_real_waiter_untouched(self):
+        executor = _make_executor()
+        real = executor.wait_output_ready("aid-3")
+
+        executor.drop_output("aid-3")
+
+        with executor._futures_lock:
+            # A genuine waiter still drains via the normal path.
+            assert executor._output_futures.get("aid-3") is real
+
+
+class TestShutdownClearsCompletedOutputs:
+    """shutdown() must release cached async outputs (issue #6413)."""
+
+    def test_shutdown_clears_completed_outputs(self):
+        executor = _make_executor()
+        fut = concurrent.futures.Future()
+        fut.set_result(DiffusionOutput(output="cached"))
+        with executor._futures_lock:
+            executor._completed_outputs["aid-4"] = fut
+
+        executor.shutdown()
+
+        assert executor._completed_outputs == {}

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -1255,9 +1255,7 @@ class DiffusionEngine:
             # would be cached forever by the executor result pump (issue #6413).
             # Tell the executor to drop it before returning the aborted result.
             if runner_output is not None and runner_output.async_output_id is not None:
-                drop_output = getattr(self.executor, "drop_output", None)
-                if drop_output is not None:
-                    drop_output(runner_output.async_output_id)
+                self.executor.drop_output(runner_output.async_output_id)
             # Preserve runner-provided abort details when available.
             if runner_output is not None and runner_output.result is not None and runner_output.result.aborted:
                 return runner_output.result

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -1251,6 +1251,13 @@ class DiffusionEngine:
             raise RuntimeError(f"Diffusion scheduler lost state for request {request_id}.")
 
         if state.status == DiffusionRequestStatus.FINISHED_ABORTED:
+            # An aborted request is never waited on, so a pending async output
+            # would be cached forever by the executor result pump (issue #6413).
+            # Tell the executor to drop it before returning the aborted result.
+            if runner_output is not None and runner_output.async_output_id is not None:
+                drop_output = getattr(self.executor, "drop_output", None)
+                if drop_output is not None:
+                    drop_output(runner_output.async_output_id)
             # Preserve runner-provided abort details when available.
             if runner_output is not None and runner_output.result is not None and runner_output.result.aborted:
                 return runner_output.result

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -1352,6 +1352,13 @@ class DiffusionEngine:
             raise RuntimeError(f"Diffusion scheduler lost state for request {request_id}.")
 
         if state.status == DiffusionRequestStatus.FINISHED_ABORTED:
+            # An aborted request is never waited on, so a pending async output
+            # would be cached forever by the executor result pump (issue #6413).
+            # Tell the executor to drop it before returning the aborted result.
+            if runner_output is not None and runner_output.async_output_id is not None:
+                drop_output = getattr(self.executor, "drop_output", None)
+                if drop_output is not None:
+                    drop_output(runner_output.async_output_id)
             # Preserve runner-provided abort details when available.
             if runner_output is not None and runner_output.result is not None and runner_output.result.aborted:
                 return runner_output.result

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -1356,9 +1356,7 @@ class DiffusionEngine:
             # would be cached forever by the executor result pump (issue #6413).
             # Tell the executor to drop it before returning the aborted result.
             if runner_output is not None and runner_output.async_output_id is not None:
-                drop_output = getattr(self.executor, "drop_output", None)
-                if drop_output is not None:
-                    drop_output(runner_output.async_output_id)
+                self.executor.drop_output(runner_output.async_output_id)
             # Preserve runner-provided abort details when available.
             if runner_output is not None and runner_output.result is not None and runner_output.result.aborted:
                 return runner_output.result

--- a/vllm_omni/diffusion/executor/abstract.py
+++ b/vllm_omni/diffusion/executor/abstract.py
@@ -126,6 +126,16 @@ class DiffusionExecutor(ABC):
         """
         return None
 
+    def drop_output(self, async_output_id: str) -> None:
+        """Reclaim an async output that will never be waited on (e.g. an
+        aborted request).
+
+        Only executors with an async output path (result pump) cache outputs
+        that a consumer must later claim; executors without one have nothing to
+        reclaim and can keep the default no-op implementation.
+        """
+        return None
+
     def get_kv_cache_specs(self) -> list[dict[str, KVCacheSpec]]:
         """Collect rank-local native specs after every Worker loads its model."""
 

--- a/vllm_omni/diffusion/executor/abstract.py
+++ b/vllm_omni/diffusion/executor/abstract.py
@@ -117,6 +117,16 @@ class DiffusionExecutor(ABC):
         """
         return None
 
+    def drop_output(self, async_output_id: str) -> None:
+        """Reclaim an async output that will never be waited on (e.g. an
+        aborted request).
+
+        Only executors with an async output path (result pump) cache outputs
+        that a consumer must later claim; executors without one have nothing to
+        reclaim and can keep the default no-op implementation.
+        """
+        return None
+
     def get_kv_cache_specs(self) -> list[dict[str, KVCacheSpec]]:
         """Collect rank-local native specs after every Worker loads its model."""
 

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -967,6 +967,28 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
             self._output_futures[async_output_id] = fut
         return fut
 
+    def drop_output(self, async_output_id: str) -> None:
+        """Discard an async output that will never be waited on.
+
+        An aborted request never calls :meth:`wait_output_ready`, so a late
+        ``OUTPUT_READY`` would be unpacked and cached in ``_completed_outputs``
+        forever (issue #6413). Draining it here keeps engine-process memory
+        bounded under abort traffic. Handles both arrival orderings:
+
+        * result already arrived -> pop and drop the cached future;
+        * result not yet arrived -> register a placeholder waiter so the pump
+          resolves into it (and lets it be freed) instead of caching.
+
+        A genuine waiter that is already registered is left untouched so it can
+        drain through the normal path.
+        """
+        with self._futures_lock:
+            if self._completed_outputs.pop(async_output_id, None) is not None:
+                return
+            if async_output_id in self._output_futures:
+                return
+            self._output_futures[async_output_id] = concurrent.futures.Future()
+
     def check_health(self) -> None:
         if self._is_failed:
             raise EngineDeadError()
@@ -1004,5 +1026,8 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                 self._rpc_futures.clear()
                 self._output_futures.clear()
                 self._batch_split_map.clear()
+                # Cached async outputs hold unpacked tensors; drop them so they
+                # do not survive shutdown (issue #6413).
+                self._completed_outputs.clear()
             self._shutdown_cleaner = None
             self._processes = []

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -899,18 +899,22 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                     if batch_id:
                         with self._futures_lock:
                             pending = self._output_futures.pop(batch_id, None)
-                            if pending is not None and not pending.done():
-                                if exc is not None:
-                                    try_set_exception(pending, exc)
-                                else:
-                                    try_set_result(pending, output_result)
-                            else:
+                            if pending is None:
+                                # No waiter registered yet: cache for a later
+                                # wait_output_ready().
                                 fut = concurrent.futures.Future()
                                 if exc is not None:
                                     fut.set_exception(exc)
                                 else:
                                     fut.set_result(output_result)
                                 self._completed_outputs[batch_id] = fut
+                            elif not pending.done():
+                                if exc is not None:
+                                    try_set_exception(pending, exc)
+                                else:
+                                    try_set_result(pending, output_result)
+                            # else: waiter registered but already cancelled/done
+                            # (e.g. aborted request) -> discard, do not re-cache.
 
     def _deliver_batch_split(
         self,
@@ -930,12 +934,16 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                 per_req_result = DiffusionOutput(error="No output result for batch request")
             with self._futures_lock:
                 pending = self._output_futures.pop(per_req_id, None)
-                if pending is not None and not pending.done():
-                    try_set_result(pending, per_req_result)
-                else:
+                if pending is None:
+                    # No waiter registered yet: cache for a later
+                    # wait_output_ready().
                     fut: concurrent.futures.Future = concurrent.futures.Future()
                     fut.set_result(per_req_result)
                     self._completed_outputs[per_req_id] = fut
+                elif not pending.done():
+                    try_set_result(pending, per_req_result)
+                # else: waiter registered but already cancelled/done -> discard,
+                # do not re-cache.
 
     def describe_pending_state(self, async_output_id: str | None = None) -> str:
         """Summarize async-output bookkeeping for diagnosing stuck waits."""

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -12,6 +12,7 @@ import queue
 import threading
 import time
 import weakref
+from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from multiprocessing.synchronize import Event
@@ -47,6 +48,24 @@ _WORKER_SHUTDOWN_GRACE_S = 15.0
 _WORKER_TERMINATE_GRACE_S = 5.0
 _WORKER_KILL_GRACE_S = 5.0
 _RESULT_PUMP_JOIN_TIMEOUT_S = 2.0
+# Upper bound on remembered dropped async_output_ids (see drop_output).
+_DROPPED_OUTPUT_IDS_MAX = 4096
+
+
+class _DropPlaceholder(concurrent.futures.Future):
+    """Placeholder registered by :meth:`MultiprocDiffusionExecutor.drop_output`.
+
+    Distinguishes "abort said nobody wants this output" from a genuine
+    ``wait_output_ready`` waiter, so the result pump can discard the tensors
+    for the former while still resolving the latter directly.
+    """
+
+
+def _dropped_output_error(async_output_id: str) -> RuntimeError:
+    return RuntimeError(
+        f"async output {async_output_id} was dropped: the request was aborted "
+        "before its output was claimed; retry with a new request."
+    )
 
 
 def _is_empty_dp_prompt(prompt: object) -> bool:
@@ -190,6 +209,9 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
         self._output_futures: dict[str, concurrent.futures.Future[DiffusionOutput]] = {}
         self._completed_outputs: dict[str, concurrent.futures.Future[DiffusionOutput]] = {}
         self._batch_split_map: dict[str, dict[str, str]] = {}  # batch_id -> {per_req_id: request_id}
+        # Bounded memory of ids drained by drop_output() so a late
+        # wait_output_ready() fails fast instead of hanging on a new Future.
+        self._dropped_output_ids: OrderedDict[str, None] = OrderedDict()
         self._futures_lock = threading.RLock()
         self._pump_running = False
         self._pump_stop = threading.Event()
@@ -971,29 +993,47 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                                 # shutdown() cleared _completed_outputs while
                                 # we were unpacking; drop this delivery.
                                 continue
-                            pending = self._output_futures.pop(batch_id, None)
-                            if pending is None:
-                                # No waiter registered yet: cache for a later
-                                # wait_output_ready().
-                                fut = concurrent.futures.Future()
-                                if exc is not None:
-                                    fut.set_exception(exc)
-                                else:
-                                    fut.set_result(output_result)
-                                self._completed_outputs[batch_id] = fut
-                            elif not pending.done():
-                                if exc is not None:
-                                    try_set_exception(pending, exc)
-                                else:
-                                    try_set_result(pending, output_result)
-                                # Cache if the resolve succeeded so a late
-                                # wait_output_ready (drop → pump → wait) can
-                                # still retrieve the result. Skip if a racing
-                                # cancel won the set (pending.cancelled()).
-                                if pending.done() and not pending.cancelled():
-                                    self._completed_outputs[batch_id] = pending
-                            # else: waiter registered but already cancelled/done
-                            # (e.g. aborted request) -> discard, do not re-cache.
+                            self._finish_output(batch_id, output_result, exc)
+
+    def _finish_output(
+        self,
+        async_output_id: str,
+        result: DiffusionOutput | None,
+        exc: BaseException | None,
+    ) -> None:
+        """Hand one delivered async output to its waiter. Caller holds ``_futures_lock``.
+
+        * no waiter registered -> cache for a later ``wait_output_ready()``;
+        * :class:`_DropPlaceholder` (request aborted) -> discard the tensors:
+          terminate the placeholder with an error so a caller that already
+          reused it via ``wait_output_ready()`` wakes up, and remember the id
+          (bounded) so a later wait fails fast instead of hanging;
+        * genuine pending waiter -> resolve it directly, never cache;
+        * waiter already cancelled/done -> discard, do not re-cache.
+        """
+        pending = self._output_futures.pop(async_output_id, None)
+        if pending is None:
+            fut: concurrent.futures.Future = concurrent.futures.Future()
+            if exc is not None:
+                fut.set_exception(exc)
+            else:
+                fut.set_result(result)
+            self._completed_outputs[async_output_id] = fut
+        elif isinstance(pending, _DropPlaceholder):
+            try_set_exception(pending, _dropped_output_error(async_output_id))
+            self._remember_dropped(async_output_id)
+        elif not pending.done():
+            if exc is not None:
+                try_set_exception(pending, exc)
+            else:
+                try_set_result(pending, result)
+
+    def _remember_dropped(self, async_output_id: str) -> None:
+        dropped = self._dropped_output_ids
+        dropped[async_output_id] = None
+        dropped.move_to_end(async_output_id)
+        while len(dropped) > _DROPPED_OUTPUT_IDS_MAX:
+            dropped.popitem(last=False)
 
     def _deliver_batch_split(
         self,
@@ -1019,17 +1059,7 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                     # Belt-and-braces: re-check under the lock so a shutdown
                     # that started mid-loop cannot repopulate the cleared dict.
                     return
-                pending = self._output_futures.pop(per_req_id, None)
-                if pending is None:
-                    # No waiter registered yet: cache for a later
-                    # wait_output_ready().
-                    fut: concurrent.futures.Future = concurrent.futures.Future()
-                    fut.set_result(per_req_result)
-                    self._completed_outputs[per_req_id] = fut
-                elif not pending.done():
-                    try_set_result(pending, per_req_result)
-                # else: waiter registered but already cancelled/done -> discard,
-                # do not re-cache.
+                self._finish_output(per_req_id, per_req_result, None)
 
     def describe_pending_state(self, async_output_id: str | None = None) -> str:
         """Summarize async-output bookkeeping for diagnosing stuck waits."""
@@ -1052,17 +1082,26 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
             return str(self._rpc_id_counter)
 
     def wait_output_ready(self, async_output_id: str) -> concurrent.futures.Future[DiffusionOutput]:
-        """Return a Future that resolves when the async output is ready."""
+        """Return a Future that resolves when the async output is ready.
+
+        After :meth:`drop_output` has drained an id, the output is gone for
+        good: a wait on that id returns an already-failed Future instead of a
+        fresh one that would never complete.
+        """
         with self._futures_lock:
             cached = self._completed_outputs.pop(async_output_id, None)
             if cached is not None:
                 return cached
-            # Reuse an existing entry (e.g. a drop_output placeholder that the
-            # pump may have already resolved) instead of clobbering it with a
-            # new Future that would never complete.
+            # Share an already-registered Future (a genuine waiter or a
+            # drop_output placeholder) rather than clobbering it.
             existing = self._output_futures.get(async_output_id)
             if existing is not None:
                 return existing
+            if async_output_id in self._dropped_output_ids:
+                del self._dropped_output_ids[async_output_id]
+                dropped: concurrent.futures.Future = concurrent.futures.Future()
+                dropped.set_exception(_dropped_output_error(async_output_id))
+                return dropped
             fut: concurrent.futures.Future = concurrent.futures.Future()
             self._output_futures[async_output_id] = fut
         return fut
@@ -1076,11 +1115,13 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
         bounded under abort traffic. Handles both arrival orderings:
 
         * result already arrived -> pop and drop the cached future;
-        * result not yet arrived -> register a placeholder waiter so the pump
-          resolves into it (and lets it be freed) instead of caching.
+        * result not yet arrived -> register a :class:`_DropPlaceholder` so the
+          pump discards the tensors instead of caching them.
 
-        A genuine waiter that is already registered is left untouched so it can
-        drain through the normal path.
+        Either way the id is remembered (bounded) so a late
+        :meth:`wait_output_ready` fails fast rather than hanging. A genuine
+        waiter that is already registered is left untouched so it can drain
+        through the normal path.
         """
         with self._futures_lock:
             if self._closed:
@@ -1088,10 +1129,11 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                 # cleared state (issue #6413 / #6439 review).
                 return
             if self._completed_outputs.pop(async_output_id, None) is not None:
+                self._remember_dropped(async_output_id)
                 return
             if async_output_id in self._output_futures:
                 return
-            self._output_futures[async_output_id] = concurrent.futures.Future()
+            self._output_futures[async_output_id] = _DropPlaceholder()
 
     def check_health(self) -> None:
         if self._is_failed:
@@ -1137,6 +1179,7 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                 # Cached async outputs hold unpacked tensors; drop them so they
                 # do not survive shutdown (issue #6413).
                 self._completed_outputs.clear()
+                self._dropped_output_ids.clear()
             self._processes = (cleaner.processes or []) if cleaner is not None else []
             if not self._processes:
                 self._shutdown_cleaner = None

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -922,6 +922,12 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                 self._sync_result_buffer.put(msg)
                 continue
 
+            # If shutdown started while we were dequeuing / unpacking, drop
+            # this delivery so it cannot repopulate _completed_outputs after
+            # shutdown() cleared it (issue #6413 / #6439 review).
+            if self._closed:
+                continue
+
             if msg.kind in (AsyncOutputKind.RPC_RESULT, AsyncOutputKind.COMPUTE_DONE):
                 with self._futures_lock:
                     fut = self._rpc_futures.pop(msg.rpc_id, None) if msg.rpc_id else None
@@ -957,6 +963,10 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
 
                     if batch_id:
                         with self._futures_lock:
+                            if self._closed:
+                                # shutdown() cleared _completed_outputs while
+                                # we were unpacking; drop this delivery.
+                                continue
                             pending = self._output_futures.pop(batch_id, None)
                             if pending is None:
                                 # No waiter registered yet: cache for a later
@@ -982,6 +992,9 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
         error: str | None = None,
     ) -> None:
         """Resolve per-request futures from one batch-level output."""
+        if self._closed:
+            # shutdown() has taken over; do not touch _completed_outputs.
+            return
         for per_req_id, req_id in per_req_map.items():
             req_output = batch_output.get_request_output(req_id) if batch_output is not None else None
             per_req_result: DiffusionOutput
@@ -992,6 +1005,10 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
             else:
                 per_req_result = DiffusionOutput(error="No output result for batch request")
             with self._futures_lock:
+                if self._closed:
+                    # Belt-and-braces: re-check under the lock so a shutdown
+                    # that started mid-loop cannot repopulate the cleared dict.
+                    return
                 pending = self._output_futures.pop(per_req_id, None)
                 if pending is None:
                     # No waiter registered yet: cache for a later
@@ -1050,6 +1067,10 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
         drain through the normal path.
         """
         with self._futures_lock:
+            if self._closed:
+                # Executor is torn down; abort path must not repopulate the
+                # cleared state (issue #6413 / #6439 review).
+                return
             if self._completed_outputs.pop(async_output_id, None) is not None:
                 return
             if async_output_id in self._output_futures:

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -1026,6 +1026,28 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
             self._output_futures[async_output_id] = fut
         return fut
 
+    def drop_output(self, async_output_id: str) -> None:
+        """Discard an async output that will never be waited on.
+
+        An aborted request never calls :meth:`wait_output_ready`, so a late
+        ``OUTPUT_READY`` would be unpacked and cached in ``_completed_outputs``
+        forever (issue #6413). Draining it here keeps engine-process memory
+        bounded under abort traffic. Handles both arrival orderings:
+
+        * result already arrived -> pop and drop the cached future;
+        * result not yet arrived -> register a placeholder waiter so the pump
+          resolves into it (and lets it be freed) instead of caching.
+
+        A genuine waiter that is already registered is left untouched so it can
+        drain through the normal path.
+        """
+        with self._futures_lock:
+            if self._completed_outputs.pop(async_output_id, None) is not None:
+                return
+            if async_output_id in self._output_futures:
+                return
+            self._output_futures[async_output_id] = concurrent.futures.Future()
+
     def check_health(self) -> None:
         if self._is_failed:
             raise EngineDeadError()
@@ -1067,6 +1089,9 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                 self._rpc_futures.clear()
                 self._output_futures.clear()
                 self._batch_split_map.clear()
+                # Cached async outputs hold unpacked tensors; drop them so they
+                # do not survive shutdown (issue #6413).
+                self._completed_outputs.clear()
             self._processes = (cleaner.processes or []) if cleaner is not None else []
             if not self._processes:
                 self._shutdown_cleaner = None

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -958,18 +958,22 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                     if batch_id:
                         with self._futures_lock:
                             pending = self._output_futures.pop(batch_id, None)
-                            if pending is not None and not pending.done():
-                                if exc is not None:
-                                    try_set_exception(pending, exc)
-                                else:
-                                    try_set_result(pending, output_result)
-                            else:
+                            if pending is None:
+                                # No waiter registered yet: cache for a later
+                                # wait_output_ready().
                                 fut = concurrent.futures.Future()
                                 if exc is not None:
                                     fut.set_exception(exc)
                                 else:
                                     fut.set_result(output_result)
                                 self._completed_outputs[batch_id] = fut
+                            elif not pending.done():
+                                if exc is not None:
+                                    try_set_exception(pending, exc)
+                                else:
+                                    try_set_result(pending, output_result)
+                            # else: waiter registered but already cancelled/done
+                            # (e.g. aborted request) -> discard, do not re-cache.
 
     def _deliver_batch_split(
         self,
@@ -989,12 +993,16 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                 per_req_result = DiffusionOutput(error="No output result for batch request")
             with self._futures_lock:
                 pending = self._output_futures.pop(per_req_id, None)
-                if pending is not None and not pending.done():
-                    try_set_result(pending, per_req_result)
-                else:
+                if pending is None:
+                    # No waiter registered yet: cache for a later
+                    # wait_output_ready().
                     fut: concurrent.futures.Future = concurrent.futures.Future()
                     fut.set_result(per_req_result)
                     self._completed_outputs[per_req_id] = fut
+                elif not pending.done():
+                    try_set_result(pending, per_req_result)
+                # else: waiter registered but already cancelled/done -> discard,
+                # do not re-cache.
 
     def describe_pending_state(self, async_output_id: str | None = None) -> str:
         """Summarize async-output bookkeeping for diagnosing stuck waits."""

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -986,6 +986,12 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                                     try_set_exception(pending, exc)
                                 else:
                                     try_set_result(pending, output_result)
+                                # Cache if the resolve succeeded so a late
+                                # wait_output_ready (drop → pump → wait) can
+                                # still retrieve the result. Skip if a racing
+                                # cancel won the set (pending.cancelled()).
+                                if pending.done() and not pending.cancelled():
+                                    self._completed_outputs[batch_id] = pending
                             # else: waiter registered but already cancelled/done
                             # (e.g. aborted request) -> discard, do not re-cache.
 
@@ -1051,6 +1057,12 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
             cached = self._completed_outputs.pop(async_output_id, None)
             if cached is not None:
                 return cached
+            # Reuse an existing entry (e.g. a drop_output placeholder that the
+            # pump may have already resolved) instead of clobbering it with a
+            # new Future that would never complete.
+            existing = self._output_futures.get(async_output_id)
+            if existing is not None:
+                return existing
             fut: concurrent.futures.Future = concurrent.futures.Future()
             self._output_futures[async_output_id] = fut
         return fut

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -922,10 +922,14 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                 self._sync_result_buffer.put(msg)
                 continue
 
-            # If shutdown started while we were dequeuing / unpacking, drop
-            # this delivery so it cannot repopulate _completed_outputs after
-            # shutdown() cleared it (issue #6413 / #6439 review).
-            if self._closed:
+            # If shutdown started while we were dequeuing, drop this delivery
+            # so it cannot repopulate _completed_outputs after shutdown()
+            # cleared it (issue #6413 / #6439 review). OUTPUT_READY must still
+            # flow through the dispatch below: unpack_diffusion_output_shm()
+            # is the only receive-side path that unlinks named SHM segments,
+            # and the closed-time re-checks under _futures_lock already
+            # prevent any cache write after unpack.
+            if self._closed and msg.kind != AsyncOutputKind.OUTPUT_READY:
                 continue
 
             if msg.kind in (AsyncOutputKind.RPC_RESULT, AsyncOutputKind.COMPUTE_DONE):


### PR DESCRIPTION
## Summary

Fixes #6413.

Request-mode diffusion with the multiproc executor uses an **async output path**: the worker finishes the forward, replies `COMPUTE_DONE` with a fresh `async_output_id`, and a background D2H/SHM thread later sends `OUTPUT_READY` carrying the tensors. The consumer is expected to call `wait_output_ready(async_output_id)` to receive them.

When a request is **aborted** mid-generation (client cancel / API abort — the common case for 10–80 s generations), that contract breaks and the output leaks:

1. `_abort_requests` sets the scheduler status to `FINISHED_ABORTED`.
2. On the next step, `_finalize_finished_request` hits the `FINISHED_ABORTED` branch and returns a synthetic aborted `DiffusionOutput` **before** the `async_output_id` branch, so the pending id is silently dropped.
3. Because the returned aborted output has no id, the consumer **never calls `wait_output_ready`** — no waiter is ever registered (and in the common abort case the consumer coroutine is already gone).
4. The worker's background thread still sends `OUTPUT_READY`. In the result pump, with no pending future, the tensors are unpacked and a completed `Future` is cached in `self._completed_outputs[async_output_id]`.
5. Nothing ever evicts it: `_completed_outputs` is only popped by `wait_output_ready` (never called for this id) and the early-batch pop. `shutdown()` clears `_rpc_futures` / `_output_futures` / `_batch_split_map` but **not** `_completed_outputs`.

Result: unbounded engine-process growth proportional to abort traffic (unpacked image/video frame tensors), for the process lifetime; the cache also survives shutdown.

## Fix

Host-side bookkeeping only, minimal and scoped to avoid the contested `OUTPUT_READY` caching block that other in-flight pump PRs touch:

- **`MultiprocDiffusionExecutor.drop_output(async_output_id)`** (new): under `_futures_lock`, drains an async output that will never be waited on, handling both arrival orderings —
  - result already arrived → pop and drop the cached future from `_completed_outputs`;
  - result not yet arrived → register a placeholder `Future` in `_output_futures` so the pump resolves *into it* (and lets it be freed) instead of caching;
  - a genuine already-registered waiter is left untouched (drains normally).
- **`shutdown()`** also `self._completed_outputs.clear()` inside the `_futures_lock` block, so cached tensors do not survive shutdown.
- **`_finalize_finished_request()`**: in the `FINISHED_ABORTED` branch, if `runner_output.async_output_id` is set, call `self.executor.drop_output(...)` (guarded via `getattr`, since non-multiproc executors like UniProc do not have it) *before* returning the aborted output. This is the root-cause fix: the engine stops silently dropping the id and instead tells the executor to reclaim it.

## Test

CPU-only unit tests on the exact host-side bookkeeping where the leak lives (uses the existing `object.__new__` executor scaffold — no process spawn, no GPU):

- `tests/diffusion/test_result_pump.py`: `TestDropOutput` (already-cached drop; not-yet-arrived placeholder prevents caching; genuine waiter untouched) and `TestShutdownClearsCompletedOutputs`.
- `tests/diffusion/test_diffusion_engine_cleanup.py`: aborted-request finalize drops the pending async output (asserts `drop_output` called with the id) + negative guard when there is no async output.

Results:
- **RED** (source reverted, tests only): `5 failed, 1 passed` — the 5 new positive assertions fail (`drop_output` missing / not called / cache not cleared).
- **GREEN** (with fix): `test_result_pump.py` + `test_diffusion_engine_cleanup.py` → **40 passed**.
- Surrounding regression: `test_diffusion_engine.py` + `test_async_output_worker.py` → **49 passed, 1 failed**; the single failure is `test_move_tensor_tree_moves_nested_cuda_tensors_to_cpu` (`@hardware_test(res={"cuda":"L4"})`, "Torch not compiled with CUDA enabled") — pre-existing GPU-only, unrelated to this change.
- `ruff check` on all changed files → clean.

The runtime RSS-growth reproduction (serve a request-mode diffusion model with `distributed_executor_backend: mp`, abort in a loop, watch RSS) needs GPU + weights and was **not** run here, so no measured MB figure is claimed; the fix is validated by the unit tests on the host-side bookkeeping that actually leaks.


## Abort contract (added per review)

After a request is aborted — either its `wait_output_ready()` waiter was cancelled, or the abort path called `drop_output(async_output_id)` — that `async_output_id` is terminal: its late `OUTPUT_READY` is unpacked (so SHM segments are unlinked) and then discarded, never cached. A later `wait_output_ready()` on the same id does not hang and does not return the old tensors; it returns an already-failed Future (`RuntimeError: ... was dropped ...`). Clients that abort must therefore treat the abort as a whole-sample retry with a new request (e.g. verl-omni fully-async / `partial_rollout` cannot merge pixels from the aborted generation). Dropped ids are remembered in a bounded LRU (`_DROPPED_OUTPUT_IDS_MAX`) so this fail-fast behavior does not itself grow unbounded under abort traffic.