### PR TITLE
[Core] Preserve configured diffusion batch size

### DIFF
--- a/tests/engine/test_async_omni_engine_stage_init.py
+++ b/tests/engine/test_async_omni_engine_stage_init.py
@@ -399,11 +399,20 @@ def test_initialize_local_llm_replica_scopes_runtime_env(monkeypatch):
     assert os.environ[runtime_env_var] == "parent-value"
 
 
-def test_initialize_diffusion_stage_applies_client_batch_size_to_engine(monkeypatch):
+@pytest.mark.parametrize(
+    ("configured_batch_size", "client_batch_size", "effective_batch_size"),
+    [(1, 4, 4), (4, 1, 4)],
+)
+def test_initialize_diffusion_stage_merges_configured_and_client_batch_sizes(
+    monkeypatch,
+    configured_batch_size,
+    client_batch_size,
+    effective_batch_size,
+):
     import vllm_omni.diffusion.stage_diffusion_client as client_mod
     import vllm_omni.engine.stage_init_utils as init_mod
 
-    od_config = types.SimpleNamespace(max_num_seqs=1)
+    od_config = types.SimpleNamespace(max_num_seqs=configured_batch_size)
     captured: dict[str, object] = {}
     monkeypatch.setattr(init_mod, "build_diffusion_config", lambda *args: od_config)
 
@@ -427,27 +436,39 @@ def test_initialize_diffusion_stage_applies_client_batch_size_to_engine(monkeypa
         types.SimpleNamespace(),
         metadata,
         stage_init_timeout=12,
-        batch_size=4,
+        batch_size=client_batch_size,
         use_inline=True,
     )
 
-    assert od_config.max_num_seqs == 4
+    assert od_config.max_num_seqs == effective_batch_size
     assert captured == {
         "model": "dummy-model",
         "config": od_config,
         "metadata": metadata,
         "stage_init_timeout": 12,
-        "batch_size": 4,
+        "batch_size": effective_batch_size,
         "use_inline": True,
     }
 
 
-def test_launch_diffusion_stage_replica_applies_batch_size_to_config(monkeypatch):
+@pytest.mark.parametrize(
+    ("configured_batch_size", "client_batch_size", "effective_batch_size"),
+    [(1, 4, 4), (4, 1, 4)],
+)
+def test_launch_diffusion_stage_replica_merges_configured_and_client_batch_sizes(
+    monkeypatch,
+    configured_batch_size,
+    client_batch_size,
+    effective_batch_size,
+):
     import vllm_omni.diffusion.stage_diffusion_client as client_mod
     import vllm_omni.diffusion.stage_diffusion_proc as proc_mod
     import vllm_omni.engine.stage_engine_startup as startup_mod
 
-    od_config = types.SimpleNamespace(max_num_seqs=1, parallel_config=types.SimpleNamespace(world_size=1))
+    od_config = types.SimpleNamespace(
+        max_num_seqs=configured_batch_size,
+        parallel_config=types.SimpleNamespace(world_size=1),
+    )
     monkeypatch.setattr(startup_mod, "build_diffusion_config", lambda *args: od_config)
     monkeypatch.setattr(startup_mod, "acquire_device_locks", lambda *args: [])
     monkeypatch.setattr(
@@ -484,13 +505,13 @@ def test_launch_diffusion_stage_replica_applies_batch_size_to_config(monkeypatch
         stage_config=types.SimpleNamespace(),
         metadata=types.SimpleNamespace(stage_id=0),
         stage_init_timeout=12,
-        batch_size=4,
+        batch_size=client_batch_size,
         use_inline=False,
         omni_master_server=omni_master_server,
     )
 
     assert result is sentinel_client
-    assert od_config.max_num_seqs == 4
+    assert od_config.max_num_seqs == effective_batch_size
     assert resources.manager is proc_manager
 
 

--- a/vllm_omni/diffusion/stage_diffusion_client.py
+++ b/vllm_omni/diffusion/stage_diffusion_client.py
@@ -126,6 +126,7 @@ class StageDiffusionClient(StageClientBase):
         batch_size: int,
     ) -> None:
         self._set_stage_metadata(metadata)
+        self.batch_size = batch_size
         self._proc_manager = proc_manager
         self._connect_transport(request_address, response_address)
 
@@ -144,7 +145,7 @@ class StageDiffusionClient(StageClientBase):
             self.stage_id,
             self.replica_id,
             self._proc_manager is not None,
-            batch_size,
+            self.batch_size,
         )
 
     def _set_stage_metadata(self, metadata: StageMetadata) -> None:

--- a/vllm_omni/engine/stage_engine_startup.py
+++ b/vllm_omni/engine/stage_engine_startup.py
@@ -36,6 +36,7 @@ from vllm_omni.engine.stage_init_utils import (
     build_diffusion_config,
     initialize_diffusion_stage,
     release_device_locks,
+    resolve_diffusion_batch_size,
 )
 from vllm_omni.entrypoints.utils import inject_omni_kv_config
 from vllm_omni.platforms import current_omni_platform
@@ -1558,6 +1559,7 @@ def launch_diffusion_stage_replica(
     from vllm_omni.diffusion.stage_diffusion_client import StageDiffusionClient
 
     od_config = build_diffusion_config(model, stage_config, metadata)
+    batch_size = resolve_diffusion_batch_size(od_config, batch_size)
     od_config.max_num_seqs = batch_size
     parallel_config = getattr(od_config, "parallel_config", None)
     world_size = getattr(parallel_config, "world_size", 1)

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -1417,6 +1417,19 @@ def build_diffusion_config(
     return od_config
 
 
+def resolve_diffusion_batch_size(od_config: Any, client_batch_size: int) -> int:
+    """Merge legacy client capacity with the per-stage scheduler capacity.
+
+    ``diffusion_batch_size`` predates deploy-YAML ``max_num_seqs`` and is still
+    used by programmatic ``AsyncOmni`` callers.  Server launches, however, rely
+    on the per-stage value.  Preserve either source when it requests more
+    capacity instead of replacing the stage configuration with the legacy
+    default of one.
+    """
+    configured_batch_size = int(getattr(od_config, "max_num_seqs", 1) or 1)
+    return max(1, int(client_batch_size), configured_batch_size)
+
+
 def initialize_diffusion_stage(
     stage_id: int,
     model: str,
@@ -1441,6 +1454,7 @@ def initialize_diffusion_stage(
     from vllm_omni.diffusion.stage_diffusion_client import create_diffusion_client
 
     od_config = build_diffusion_config(model, stage_cfg, metadata)
+    batch_size = resolve_diffusion_batch_size(od_config, batch_size)
     od_config.max_num_seqs = batch_size
     return create_diffusion_client(model, od_config, metadata, stage_init_timeout, batch_size, use_inline)
 

--- a/vllm_omni/engine/stage_runtime.py
+++ b/vllm_omni/engine/stage_runtime.py
@@ -670,7 +670,7 @@ class StageRuntime:
                 "[StageRuntime] Stage %s replica %s initialized (diffusion, batch_size=%d)",
                 plan.metadata.stage_id,
                 plan.replica_id,
-                self._diffusion_batch_size,
+                getattr(client, "batch_size", self._diffusion_batch_size),
             )
             return client
         except Exception:


### PR DESCRIPTION
## Summary

- preserve a diffusion stage's configured `max_num_seqs` when the legacy client batch size is smaller
- use the same effective batch size for inline and multiprocess stage startup
- report the effective capacity in diffusion stage initialization logs

## Motivation

Server launches still pass the legacy `diffusion_batch_size` default of one. That value currently overwrites a larger per-stage `max_num_seqs` from the deploy YAML, so the diffusion scheduler cannot accept the configured number of concurrent requests.

## Tests

```text
pytest -q tests/engine/test_async_omni_engine_stage_init.py \
  -k "merges_configured_and_client_batch_sizes"

4 passed, 34 deselected
```
