### PR TITLE
[AR-Diffusion] Report a lost rollout distinctly from other inactive states

### DIFF
--- a/tests/diffusion/ar_diffusion/test_consumer.py
+++ b/tests/diffusion/ar_diffusion/test_consumer.py
@@ -11,6 +11,7 @@ from vllm_omni.experimental.ar_diffusion.consumer import ARDiffusionOmniTickCons
 from vllm_omni.experimental.ar_diffusion.session import (
     ARDiffusionSession,
     ARDiffusionSessionEvent,
+    ARDiffusionTickExecutionError,
 )
 from vllm_omni.experimental.ar_diffusion.tick_protocol import (
     ARDiffusionChunkMetadata,
@@ -229,3 +230,23 @@ async def test_session_commits_only_after_standard_engine_output_metadata() -> N
     assert session.chunk_index == 1
     assert session.pending_event_count == 0
     assert client.calls[0]["request_id"] == "world-1-chunk-0"
+
+
+@pytest.mark.asyncio
+async def test_engine_reported_failure_raises_the_typed_tick_error() -> None:
+    """The engine boundary must raise a typed error, not a bare RuntimeError.
+
+    Every other failure in this module is typed; an untyped RuntimeError here
+    forces callers to match on message text to tell an engine failure apart
+    from a bug in their own code.
+    """
+    consumer = ARDiffusionOmniTickConsumer(
+        FakeGenerateClient(include_metadata=False, output_error="model failed"),
+        prompt_provider=lambda tick: tick.prompt or "",
+        sampling_params_list=[OmniDiffusionSamplingParams()],
+        diffusion_stage_id=0,
+    )
+    with pytest.raises(ARDiffusionTickExecutionError, match="model failed"):
+        await consumer.execute_tick(make_tick())
+    # Still a RuntimeError, so existing handlers keep working.
+    assert issubclass(ARDiffusionTickExecutionError, RuntimeError)

--- a/tests/diffusion/ar_diffusion/test_session.py
+++ b/tests/diffusion/ar_diffusion/test_session.py
@@ -12,6 +12,7 @@ from vllm_omni.experimental.ar_diffusion.session import (
     ARDiffusionEventAcceptanceStatus,
     ARDiffusionEventQueueFullError,
     ARDiffusionPreparedControls,
+    ARDiffusionRolloutLostError,
     ARDiffusionSession,
     ARDiffusionSessionError,
     ARDiffusionSessionEvent,
@@ -503,3 +504,49 @@ async def test_worker_lifecycle_rejects_unsupported_stage_result() -> None:
 
     with pytest.raises(ARDiffusionSessionError, match="not an AR stage"):
         await lifecycle.close_session("world-1")
+
+
+@pytest.mark.asyncio
+async def test_lost_rollout_is_reported_distinctly_from_other_inactive_states() -> None:
+    """A retry after a failed tick must say the rollout is gone, not just "failed".
+
+    The worker released KV and model-owned state during the failed forward, so
+    the retried tick can never succeed against the state it assumes. The client
+    has to learn that from the error it gets on retry.
+    """
+    consumer = FakeTickConsumer()
+    consumer.failures_remaining = 1
+    lifecycle = FakeLifecycle()
+    session, _, _ = make_session(consumer=consumer, lifecycle=lifecycle)
+
+    assert session.rollout_lost is None
+    with pytest.raises(RuntimeError, match="fake tick failed"):
+        await session.next_chunk()
+
+    # The reason is retained and names the originating failure.
+    assert session.rollout_lost == "RuntimeError: fake tick failed"
+
+    with pytest.raises(ARDiffusionRolloutLostError, match="cannot be retried") as excinfo:
+        await session.next_chunk()
+    # Still a state error, so existing handlers keep working.
+    assert isinstance(excinfo.value, ARDiffusionSessionStateError)
+    assert "restart from chunk 0" in str(excinfo.value)
+
+    # reset() restarts rather than resumes, and clears the terminal reason.
+    await session.reset()
+    assert session.rollout_lost is None
+    assert session.chunk_index == 0
+    assert session.status is ARDiffusionSessionStatus.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_non_rollout_inactive_states_keep_the_generic_state_error() -> None:
+    """close() did not destroy a rollout mid-tick, so it must not report one."""
+    session, _, lifecycle = make_session()
+    await session.close()
+
+    assert session.rollout_lost is None
+    with pytest.raises(ARDiffusionSessionStateError) as excinfo:
+        await session.next_chunk()
+    assert not isinstance(excinfo.value, ARDiffusionRolloutLostError)
+    assert "is closed" in str(excinfo.value)

--- a/vllm_omni/experimental/ar_diffusion/__init__.py
+++ b/vllm_omni/experimental/ar_diffusion/__init__.py
@@ -16,8 +16,10 @@ from vllm_omni.experimental.ar_diffusion.capability import (
 from vllm_omni.experimental.ar_diffusion.consumer import ARDiffusionOmniTickConsumer
 from vllm_omni.experimental.ar_diffusion.engine import ARDiffusionEngine
 from vllm_omni.experimental.ar_diffusion.session import (
+    ARDiffusionRolloutLostError,
     ARDiffusionSession,
     ARDiffusionSessionManager,
+    ARDiffusionTickExecutionError,
     ARDiffusionWorkerLifecycle,
 )
 from vllm_omni.experimental.ar_diffusion.tick_protocol import (
@@ -32,8 +34,10 @@ __all__ = [
     "ARDiffusionCrossAttentionKVSpec",
     "ARDiffusionEngine",
     "ARDiffusionOmniTickConsumer",
+    "ARDiffusionRolloutLostError",
     "ARDiffusionSession",
     "ARDiffusionSessionManager",
+    "ARDiffusionTickExecutionError",
     "ARDiffusionWorkerLifecycle",
     "AR_DIFFUSION_TICK_KEY",
     "ARDiffusionChunkMetadata",

--- a/vllm_omni/experimental/ar_diffusion/consumer.py
+++ b/vllm_omni/experimental/ar_diffusion/consumer.py
@@ -7,6 +7,7 @@ import copy
 from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from typing import Any, Protocol
 
+from vllm_omni.experimental.ar_diffusion.session import ARDiffusionTickExecutionError
 from vllm_omni.experimental.ar_diffusion.tick_protocol import (
     ARDiffusionChunkMetadata,
     ARDiffusionTickRequest,
@@ -151,12 +152,12 @@ class ARDiffusionOmniTickConsumer:
                 final_output = output
 
         if final_output is None:
-            raise RuntimeError(
+            raise ARDiffusionTickExecutionError(
                 f"AR-Diffusion tick {tick.request_id!r} completed without a final "
                 f"output from stage {self._diffusion_stage_id}."
             )
         if final_output.error:
-            raise RuntimeError(f"AR-Diffusion tick {tick.request_id!r} failed: {final_output.error}")
+            raise ARDiffusionTickExecutionError(f"AR-Diffusion tick {tick.request_id!r} failed: {final_output.error}")
         if final_output.request_id != tick.request_id:
             raise ValueError("AR-Diffusion output request_id does not match the submitted tick request_id.")
         # Parse here so malformed/missing standard metadata fails at the engine

--- a/vllm_omni/experimental/ar_diffusion/session.py
+++ b/vllm_omni/experimental/ar_diffusion/session.py
@@ -42,6 +42,19 @@ class ARDiffusionChunkMetadataError(ARDiffusionSessionError):
     """Raised when a tick consumer returns metadata for a different chunk."""
 
 
+class ARDiffusionTickExecutionError(ARDiffusionSessionError):
+    """Raised when the engine reports a failed or incomplete tick execution."""
+
+
+class ARDiffusionRolloutLostError(ARDiffusionSessionStateError):
+    """Raised when a tick is attempted against a destroyed rollout.
+
+    A failed tick releases worker-side KV and model-owned state, so the
+    accumulated rollout history is gone. Retrying the tick cannot succeed;
+    ``reset()`` restarts the session from chunk 0 rather than resuming it.
+    """
+
+
 class ARDiffusionEventAcceptanceStatus(str, Enum):
     ACCEPTED = "accepted"
     DUPLICATE = "duplicate"
@@ -257,12 +270,19 @@ class ARDiffusionSession(Generic[TickOutputT]):
         self._prompt: str | None = None
         self._controls: dict[str, ARDiffusionControlInput] = {}
 
+        self._rollout_lost: str | None = None
+
         self._state_lock = asyncio.Lock()
         self._tick_lock = asyncio.Lock()
 
     @property
     def status(self) -> ARDiffusionSessionStatus:
         return self._status
+
+    @property
+    def rollout_lost(self) -> str | None:
+        """Why the rollout was destroyed, or ``None`` while it is intact."""
+        return self._rollout_lost
 
     @property
     def chunk_index(self) -> int:
@@ -273,8 +293,19 @@ class ARDiffusionSession(Generic[TickOutputT]):
         return len(self._pending_events)
 
     def _require_active(self) -> None:
-        if self._status is not ARDiffusionSessionStatus.ACTIVE:
-            raise ARDiffusionSessionStateError(f"AR-Diffusion session {self.session_id!r} is {self._status.value}.")
+        if self._status is ARDiffusionSessionStatus.ACTIVE:
+            return
+        # A failed tick already released worker KV and model-owned state, so
+        # this is not a retryable tick error: distinguish it from the other
+        # non-active states, which merely reject the operation.
+        if self._status is ARDiffusionSessionStatus.FAILED and self._rollout_lost:
+            raise ARDiffusionRolloutLostError(
+                f"AR-Diffusion session {self.session_id!r} lost its rollout "
+                f"({self._rollout_lost}); worker KV and model-owned state were "
+                "released, so this tick cannot be retried. Call reset() to "
+                "restart from chunk 0, or close() and open a new session."
+            )
+        raise ARDiffusionSessionStateError(f"AR-Diffusion session {self.session_id!r} is {self._status.value}.")
 
     def _require_resettable(self) -> None:
         if self._status not in {
@@ -410,6 +441,7 @@ class ARDiffusionSession(Generic[TickOutputT]):
         async with self._state_lock:
             self._inflight_event_floor = None
             self._status = ARDiffusionSessionStatus.FAILED
+            self._rollout_lost = f"{type(tick_error).__name__}: {tick_error}"
         try:
             # A model forward may already have released its state. This
             # idempotent close also covers successful forwards whose metadata
@@ -466,7 +498,11 @@ class ARDiffusionSession(Generic[TickOutputT]):
             return output
 
     async def reset(self) -> None:
-        """Reset worker state and discard queued/current transport state."""
+        """Reset worker state and discard queued/current transport state.
+
+        This restarts the session at chunk 0; it never resumes a rollout whose
+        worker-side state was released.
+        """
         async with self._tick_lock:
             async with self._state_lock:
                 self._require_resettable()
@@ -487,6 +523,7 @@ class ARDiffusionSession(Generic[TickOutputT]):
                     self._control_reducer.reset()
                 self._inflight_event_floor = None
                 self._chunk_index = 0
+                self._rollout_lost = None
                 self._status = ARDiffusionSessionStatus.ACTIVE
 
     async def close(self) -> None:


### PR DESCRIPTION
## Summary

A failed AR-Diffusion tick releases worker-side KV and model-owned state:

```python
# vllm_omni/experimental/ar_diffusion/runner.py
except Exception:
    self._release_session(session_id, reset_model=False,
                          reason="forward_exception", suppress_errors=True)
    raise
```

The session layer handles this correctly — it moves to `FAILED`, closes the worker session, and `reset()` restarts at chunk 0 rather than resuming. **The state machine is not changed by this PR.**

What was missing is that the client could not learn any of it from the error it received. Retrying `next_chunk()` raised the generic state error:

```
AR-Diffusion session 'world-1' is failed.
```

That message does not distinguish *"this operation is invalid right now"* from *"the state this tick depends on no longer exists"*. A client seeing a tick failure will reasonably retry the tick — against state that was already released, so the retry cannot succeed.

## Changes

- **`ARDiffusionRolloutLostError`** — raised when a tick is attempted after a failed tick. Subclasses `ARDiffusionSessionStateError`, so existing handlers and `except` clauses keep working. The message names the originating failure and states the recovery:

  ```
  AR-Diffusion session 'world-1' lost its rollout (RuntimeError: fake tick failed);
  worker KV and model-owned state were released, so this tick cannot be retried.
  Call reset() to restart from chunk 0, or close() and open a new session.
  ```

- **`ARDiffusionSession.rollout_lost`** — the reason the rollout was destroyed, or `None` while it is intact. Cleared by `reset()`.

- **`reset()` docstring** now states that it restarts at chunk 0 and never resumes a rollout whose worker state was released.

- **Typed engine boundary.** `consumer.py` raised bare `RuntimeError` both for an engine-reported failure and for a missing final output, forcing callers to match on message text to tell an engine failure apart from a bug in their own code. Both now raise **`ARDiffusionTickExecutionError`**, still a `RuntimeError` subclass, with unchanged messages.

No control flow changes: the same operations fail at the same points, with the same worker-side cleanup.

## Why not automatic recovery

Deliberately not rebuild or rebind. AR KV is the accumulated result of every prior chunk and — unlike LLM prefix KV — is not recomputable from the prompt, so "rebuild" means replaying the session from chunk 0 at a cost that misses the per-chunk deadline by orders of magnitude. Rebind requires state migration. This PR makes the existing fail-closed behavior legible rather than replacing it.

This also gives replica-failure semantics a signal to reuse: a lost replica can surface the same terminal error for the same reason, with no new client-side handling.

Context: [#6227 Open Question 5](https://github.com/vllm-project/vllm-omni/issues/6227#issuecomment-5364886150).

## Test

`tests/diffusion/ar_diffusion/test_session.py`, `tests/diffusion/ar_diffusion/test_consumer.py` — 22 passed, ruff check and format clean.

Three added:

- `test_lost_rollout_is_reported_distinctly_from_other_inactive_states` — asserts `rollout_lost` starts `None`, is set to the originating failure, that the retry raises `ARDiffusionRolloutLostError` and is still an `ARDiffusionSessionStateError`, and that `reset()` clears it and returns `chunk_index` to 0.
- `test_non_rollout_inactive_states_keep_the_generic_state_error` — negative control: a closed session must **not** report a lost rollout, so the new error is discriminating rather than raised for every inactive state.
- `test_engine_reported_failure_raises_the_typed_tick_error` — engine-reported failure raises the typed error and remains a `RuntimeError` subclass.

The existing `test_failed_tick_closes_worker_and_requires_reset` passes unchanged, which is the compatibility check for the subclassing.
