### PR TITLE
[Benchmark] Add a multi-session realtime AR-Diffusion load harness

### DIFF
--- a/benchmarks/ar_diffusion/README.md
+++ b/benchmarks/ar_diffusion/README.md
@@ -1,0 +1,97 @@
+# Realtime AR-Diffusion session benchmark
+
+Multi-session load harness for realtime AR-Diffusion serving: session arrivals,
+playout deadlines, and the metrics a streaming video deployment is actually
+gated on.
+
+## Load modes
+
+| Mode | Question it answers | Deadlines |
+|---|---|---|
+| `saturating` | How fast can this configuration go at all? Aggregate generated FPS, frames per GPU-second. | none |
+| `paced` | Does it keep up with playback? CPR, TTFC, worst-case per-chunk latency. | yes |
+
+Running only `saturating` produces a throughput number no deployment can use.
+Running only `paced` hides the ceiling, so a deadline miss cannot be attributed
+to insufficient capacity rather than to scheduling. Report both.
+
+## Load parameters
+
+Session **arrival rate** is the only valid open-loop axis. Per-session tick rate
+is not: ticks of one session are strictly ordered and state-dependent, so tick
+`k + 1` cannot be issued before chunk `k` returns and raising the rate only
+grows a queue. Concurrently active sessions are derived state, reported
+alongside every measurement as `peak_concurrent_sessions`.
+
+## Metrics
+
+Per session: `ttfc_s`, chunk latency P50/P95/P99, and
+
+```
+RTF = wall(K chunks) / (K * frames_per_chunk / target_fps)
+```
+
+Aggregate: `continuous_play_ratio` (CPR, the fraction of chunks delivered before
+their playout deadline, macro-averaged over sessions), `worst_case_chunk_latency_s`
+across all active sessions, `generated_fps`, and `frames_per_gpu_second` — the
+only unit comparable across replica counts, TP degrees and hardware.
+
+CPR is not redundant with RTF. RTF is a ratio of aggregates: a session can hold
+`RTF = 0.9` over a minute and still stutter visibly, because chunks arrive in
+bursts that individually miss their playout instants.
+
+Deadlines assume a declared playout grid. Playback starts once `--buffer-chunks`
+chunks are buffered; chunk `buffer_chunks - 1` anchors the grid and every later
+chunk is due one release period after its predecessor. Chunks inside the
+prebuffer have no deadline — their cost is start latency, which TTFC reports.
+
+## Model neutrality
+
+The chunk shape comes from the pipeline's declared `ARDiffusionKVCacheSpec`. No
+model name appears in this directory.
+
+One value is not derivable from the capability today: every frame count in the
+spec is in *latent* frames and nothing converts them to delivered frames, so the
+playout grid cannot be computed from the spec alone. Until the spec declares it,
+supply `--vae-temporal-factor` (default `1`, correct for a decoder that does not
+compress time).
+
+## Usage
+
+```bash
+# Ceiling
+python -m benchmarks.ar_diffusion.run_realtime_benchmark \
+    --model <checkpoint> --prompt "..." \
+    --num-sessions 1 --mode saturating --chunks 32 \
+    --vae-temporal-factor 4 \
+    --note "checkpoint=<...>" --note "hw=1xH200" --note "res=480x832" \
+    --note "steps=4" --output runs/n1.json
+
+# State concurrency N, execution concurrency 1
+python -m benchmarks.ar_diffusion.run_realtime_benchmark \
+    ... --num-sessions 2 --output runs/n2.json
+```
+
+At least one `--note` is required: a latency without model, checkpoint,
+resolution, denoising steps and hardware is not a result.
+
+## Reading N=1 against N=2
+
+With state concurrency `N` but execution concurrency 1, ticks serialize, so:
+
+```
+aggregate generated FPS(N)  ~=  aggregate generated FPS(1)
+per-session RTF(N)          ~=  N x RTF(1)
+```
+
+`compare_runs()` reports `generated_fps_ratio` and `per_tick_switching_cost_s`,
+the latter being latency beyond what pure queueing predicts. A measurable drop
+in aggregate FPS is per-tick switching cost — state bind/unbind, KV pool paging,
+conditioning rebuild — and that number is the baseline any cross-session
+batching work has to beat.
+
+## Tests
+
+`tests/diffusion/ar_diffusion/test_realtime_benchmark.py` drives the whole load
+model on a virtual clock against fake sessions: CPU only, no engine, no device,
+no checkpoint. `engine_binding.py` is the only module not covered.

--- a/benchmarks/ar_diffusion/README.md
+++ b/benchmarks/ar_diffusion/README.md
@@ -52,6 +52,38 @@ which TTFC reports. Walking cumulative frames rather than multiplying a constant
 period is what lets a deeper buffer grant real slack, and what keeps a causal
 decoder's shorter opening chunk from being credited with a full period.
 
+## Stage coverage: the tick time no stage claims
+
+`stage_coverage` reports the median seconds of each stage the pipeline
+profiler timed, and next to them:
+
+```
+accounted_p50_s          the stages, summed
+unaccounted_p50_s        chunk latency - accounted
+accounted_fraction_p50   accounted / latency
+instrumented_chunks      how many chunks carried any stage timing at all
+```
+
+The residual is reported because the stages do not add up to the tick and are
+not expected to. A pipeline times the work it knows it is doing -- denoising,
+VAE, text encoding -- and everything between the tick arriving and the pipeline
+being entered belongs to no stage: request parsing, multimodal decode, output
+packing, scheduling. Publishing the instrumented parts alone hides that gap,
+and the gap is precisely the part a serving layer can remove without touching
+the model.
+
+`instrumented_chunks` exists so "the profiler was off" cannot be read as "the
+profiler was on and could not explain any of the time". With no instrumented
+chunk the coverage figures are `None` rather than zero.
+
+A negative `unaccounted_p50_s` is not clamped: it means stages overlap, or are
+timed across a different span than the chunk, and that is a fault in the
+instrument rather than a result to present as perfect coverage.
+
+Stage medians treat an absent stage as zero for that chunk rather than as a
+missing sample. That is what makes a per-session cache visible: an encode that
+runs on the first tick only lands at a median of zero, not at full cost.
+
 ## Model neutrality
 
 The chunk shape comes from the pipeline's declared `ARDiffusionKVCacheSpec`. No

--- a/benchmarks/ar_diffusion/README.md
+++ b/benchmarks/ar_diffusion/README.md
@@ -41,20 +41,46 @@ CPR is not redundant with RTF. RTF is a ratio of aggregates: a session can hold
 bursts that individually miss their playout instants.
 
 Deadlines assume a declared playout grid. Playback starts once `--buffer-chunks`
-chunks are buffered; chunk `buffer_chunks - 1` anchors the grid and every later
-chunk is due one release period after its predecessor. Chunks inside the
-prebuffer have no deadline — their cost is start latency, which TTFC reports.
+chunks are buffered; from that instant the player consumes continuously, so
+
+```
+deadline(i) = t_ready(buffer_chunks - 1) + cumulative_frames(i) / target_fps
+```
+
+Chunks inside the prebuffer have no deadline — their cost is start latency,
+which TTFC reports. Walking cumulative frames rather than multiplying a constant
+period is what lets a deeper buffer grant real slack, and what keeps a causal
+decoder's shorter opening chunk from being credited with a full period.
 
 ## Model neutrality
 
 The chunk shape comes from the pipeline's declared `ARDiffusionKVCacheSpec`. No
 model name appears in this directory.
 
-One value is not derivable from the capability today: every frame count in the
-spec is in *latent* frames and nothing converts them to delivered frames, so the
-playout grid cannot be computed from the spec alone. Until the spec declares it,
-supply `--vae-temporal-factor` (default `1`, correct for a decoder that does not
+One conversion is not derivable from the capability today: every frame count in
+the spec is in *latent* frames and nothing converts them to delivered frames, so
+the playout grid cannot be computed from the spec alone. Supply
+`--vae-temporal-factor` (default `1`, correct for a decoder that does not
 compress time).
+
+**The conversion is not a multiplication.** A causal video decoder expands a
+session's first latent frame to one raw frame and every later one to the full
+factor, so `n` latent frames become `(n - 1) * factor + 1` raw frames the first
+time and `n * factor` every time after:
+
+| | latent frames | raw frames |
+|---|---|---|
+| chunk 0 | 3 | **9** |
+| chunk k > 0 | 3 | 12 |
+| K chunks | 3K | **12K − 3** |
+
+So `chunks x frames_per_chunk` over-counts every run. The profile carries
+`frames_per_first_chunk` alongside `frames_per_chunk`, and both `generated_fps`
+and `RTF` sum the per-chunk delivery. Pass `--non-causal-decoder` for a decoder
+that expands every latent frame identically.
+
+This is also why a single declared integer could not close the gap: the missing
+piece is a *mapping*, not a factor.
 
 ## Usage
 

--- a/benchmarks/ar_diffusion/__init__.py
+++ b/benchmarks/ar_diffusion/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/benchmarks/ar_diffusion/engine_binding.py
+++ b/benchmarks/ar_diffusion/engine_binding.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Wire the benchmark harness to a real AR-Diffusion engine.
+
+This is the only module here that needs a device, a checkpoint and a CUDA
+build, and therefore the only one the CPU tests cannot cover. Everything the
+benchmark actually measures -- the load model, the deadline model and every
+metric -- lives in ``realtime_harness`` and ``realtime_metrics`` and is tested
+without it.
+
+The wiring mirrors ``examples/offline_inference/diffusion/lingbot_world_v2_realtime.py``
+but drops everything model-specific: no control reducer, no action schema, no
+fixed frame count. A pipeline needing per-tick controls should extend
+``prompt_provider``/``control_reducer_factory`` rather than change the harness.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RealtimeBackend:
+    """The session manager under test, plus the capability it declared."""
+
+    manager: Any
+    spec: Any
+    engine: Any
+
+
+async def build_realtime_backend(args: argparse.Namespace) -> RealtimeBackend:
+    """Build an AsyncOmni engine and a session manager from CLI arguments."""
+    from vllm_omni.entrypoints.async_omni import AsyncOmni
+    from vllm_omni.experimental.ar_diffusion.consumer import ARDiffusionOmniTickConsumer
+    from vllm_omni.experimental.ar_diffusion.session import (
+        ARDiffusionSessionManager,
+        ARDiffusionWorkerLifecycle,
+    )
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    engine = AsyncOmni(
+        model=args.model,
+        engine_backend="vllm_omni.experimental.ar_diffusion.engine.ARDiffusionEngine",
+        enforce_eager=args.enforce_eager,
+        tensor_parallel_size=args.tensor_parallel_size,
+        max_num_seqs=1,
+        model_config={
+            "ar_diffusion_kv_config": {
+                "gpu_memory_fraction": args.gpu_memory_fraction,
+                "warmup_cudagraph": not args.enforce_eager,
+            },
+        },
+    )
+
+    sampling = OmniDiffusionSamplingParams(seed=args.seed, output_type="latent")
+
+    def prompt_provider(tick: Any) -> dict[str, Any]:
+        prompt: dict[str, Any] = {"prompt": tick.prompt or args.prompt}
+        if args.image is not None:
+            prompt["multi_modal_data"] = {"image": str(args.image)}
+        return prompt
+
+    consumer = ARDiffusionOmniTickConsumer(
+        engine,
+        prompt_provider=prompt_provider,
+        sampling_params_list=[sampling],
+        diffusion_stage_id=0,
+    )
+    manager = ARDiffusionSessionManager(
+        tick_consumer=consumer,
+        lifecycle=ARDiffusionWorkerLifecycle(engine, stage_ids=[0], timeout=180.0),
+        max_pending_events=args.max_pending_events,
+    )
+    return RealtimeBackend(manager=manager, spec=_declared_spec(engine), engine=engine)
+
+
+def _declared_spec(engine: Any) -> Any:
+    """Fetch the pipeline's declared AR-Diffusion KV spec from the engine."""
+    pipeline = getattr(getattr(engine, "engine", None), "pipeline", None)
+    spec_fn = getattr(pipeline, "ar_diffusion_kv_cache_spec", None)
+    if spec_fn is None:
+        raise RuntimeError(
+            "The selected model does not implement SupportsARDiffusionPipeline, "
+            "so its chunk shape and session capacity are not declared."
+        )
+    return spec_fn()

--- a/benchmarks/ar_diffusion/realtime_harness.py
+++ b/benchmarks/ar_diffusion/realtime_harness.py
@@ -140,16 +140,20 @@ async def _drive_session(
     session = await factory(session_id)
     events: list[ChunkEvent] = []
     lost_reason: str | None = None
-    period = config.profile.release_period_s
     gauge.enter()
     try:
         for chunk_index in range(config.chunks_per_session):
             if config.mode is LoadMode.PACED and events:
-                # A paced client consumes one chunk per release period, so the
-                # next tick is not issued before the previous chunk's playout
-                # would have finished. Falling behind never pushes the client
-                # ahead: the due time is anchored to the playout grid.
-                due = t_start + chunk_index * period
+                # Pace against the video actually delivered before this
+                # chunk.  A causal decoder's opening chunk can be shorter than
+                # steady state (LingBot/Wan: 9 frames, then 12), so multiplying
+                # every index by the steady period delays chunk 1 by 3 frames
+                # and manufactures a deadline miss.  Anchor to the first real
+                # submit so session construction time is not part of playout.
+                due = (
+                    events[0].t_submit
+                    + config.profile.cumulative_frames(chunk_index) / config.profile.target_fps
+                )
                 lag = due - clock()
                 if lag > 0:
                     await sleep(lag)

--- a/benchmarks/ar_diffusion/realtime_harness.py
+++ b/benchmarks/ar_diffusion/realtime_harness.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Multi-session driver for realtime AR-Diffusion benchmarks.
+
+The driver owns arrivals, pacing and recording. It talks to sessions through
+:class:`BenchmarkSession`, a two-method view of the realtime session API, so
+the whole load model is exercisable on CPU against a fake session and needs no
+engine, device or checkpoint.
+
+Load parameters, and why only one of them is an axis:
+
+``session arrival rate``
+    The valid open-loop parameter. Sessions arrive and depart over time.
+
+``per-session tick rate``
+    Not an axis. Ticks of one session are strictly ordered and state-dependent:
+    tick ``k + 1`` reads the state committed by tick ``k`` and cannot be issued
+    before the previous chunk returns. Raising it only grows a queue.
+
+``concurrently active sessions``
+    Derived state, not an input. Reported alongside every measurement.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import random
+import time
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from benchmarks.ar_diffusion.realtime_metrics import (
+    ChunkEvent,
+    LoadMode,
+    RunSummary,
+    SessionRecord,
+    WorkloadProfile,
+    summarize_run,
+)
+
+
+class BenchmarkSession(Protocol):
+    """The part of a realtime session the driver needs."""
+
+    async def next_chunk(self) -> Any: ...
+
+    async def close(self) -> None: ...
+
+
+SessionFactory = Callable[[str], Awaitable[BenchmarkSession]]
+
+
+@dataclass(frozen=True)
+class ArrivalPlan:
+    """When each session starts, relative to the run start."""
+
+    offsets_s: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        if any(offset < 0 for offset in self.offsets_s):
+            raise ValueError("arrival offsets must be non-negative.")
+        if list(self.offsets_s) != sorted(self.offsets_s):
+            raise ValueError("arrival offsets must be non-decreasing.")
+
+    def __len__(self) -> int:
+        return len(self.offsets_s)
+
+
+def burst_arrivals(num_sessions: int) -> ArrivalPlan:
+    """All sessions start together: the worst case for admission and memory."""
+    if num_sessions < 1:
+        raise ValueError("num_sessions must be at least 1.")
+    return ArrivalPlan(tuple(0.0 for _ in range(num_sessions)))
+
+
+def poisson_arrivals(num_sessions: int, *, rate_per_s: float, seed: int = 0) -> ArrivalPlan:
+    """Poisson session arrivals; deterministic for a given seed."""
+    if num_sessions < 1:
+        raise ValueError("num_sessions must be at least 1.")
+    if rate_per_s <= 0:
+        raise ValueError("rate_per_s must be positive.")
+    rng = random.Random(seed)
+    offsets: list[float] = []
+    clock = 0.0
+    for _ in range(num_sessions):
+        offsets.append(clock)
+        clock += rng.expovariate(rate_per_s)
+    return ArrivalPlan(tuple(offsets))
+
+
+class _ConcurrencyGauge:
+    """Tracks how many sessions were ticking at once."""
+
+    def __init__(self) -> None:
+        self.current = 0
+        self.peak = 0
+
+    def enter(self) -> None:
+        self.current += 1
+        self.peak = max(self.peak, self.current)
+
+    def exit(self) -> None:
+        self.current -= 1
+
+
+@dataclass
+class BenchmarkConfig:
+    profile: WorkloadProfile
+    mode: LoadMode
+    chunks_per_session: int
+    arrivals: ArrivalPlan
+    num_gpus: int = 1
+    events_dir: Path | None = None
+
+    def __post_init__(self) -> None:
+        if self.chunks_per_session < 1:
+            raise ValueError("chunks_per_session must be at least 1.")
+
+
+async def _drive_session(
+    session_id: str,
+    *,
+    config: BenchmarkConfig,
+    factory: SessionFactory,
+    start_at: float,
+    clock: Callable[[], float],
+    sleep: Callable[[float], Awaitable[None]],
+    gauge: _ConcurrencyGauge,
+) -> SessionRecord:
+    """Run one session to ``chunks_per_session`` chunks, or until it is lost."""
+    delay = start_at - clock()
+    if delay > 0:
+        await sleep(delay)
+
+    t_start = clock()
+    session = await factory(session_id)
+    events: list[ChunkEvent] = []
+    lost_reason: str | None = None
+    period = config.profile.release_period_s
+    gauge.enter()
+    try:
+        for chunk_index in range(config.chunks_per_session):
+            if config.mode is LoadMode.PACED and events:
+                # A paced client consumes one chunk per release period, so the
+                # next tick is not issued before the previous chunk's playout
+                # would have finished. Falling behind never pushes the client
+                # ahead: the due time is anchored to the playout grid.
+                due = t_start + chunk_index * period
+                lag = due - clock()
+                if lag > 0:
+                    await sleep(lag)
+            t_submit = clock()
+            try:
+                await session.next_chunk()
+            except Exception as exc:  # noqa: BLE001 - a lost session is a result, not a crash
+                lost_reason = f"{type(exc).__name__}: {exc}"
+                break
+            events.append(
+                ChunkEvent(
+                    session_id=session_id,
+                    chunk_index=chunk_index,
+                    t_submit=t_submit,
+                    t_ready=clock(),
+                )
+            )
+    finally:
+        gauge.exit()
+        with contextlib.suppress(Exception):
+            await session.close()
+
+    return SessionRecord(
+        session_id=session_id,
+        t_start=t_start,
+        events=tuple(events),
+        lost_reason=lost_reason,
+    )
+
+
+async def run_benchmark(
+    config: BenchmarkConfig,
+    factory: SessionFactory,
+    *,
+    clock: Callable[[], float] | None = None,
+    sleep: Callable[[float], Awaitable[None]] | None = None,
+    notes: Sequence[str] = (),
+) -> RunSummary:
+    """Run every session concurrently and reduce the result to a summary.
+
+    ``clock`` and ``sleep`` are injectable so tests can drive the whole load
+    model on a virtual clock without spending wall time.
+    """
+    resolved_clock = clock or time.perf_counter
+    resolved_sleep = sleep or asyncio.sleep
+    gauge = _ConcurrencyGauge()
+
+    t0 = resolved_clock()
+    tasks = [
+        asyncio.create_task(
+            _drive_session(
+                f"bench-{index}",
+                config=config,
+                factory=factory,
+                start_at=t0 + offset,
+                clock=resolved_clock,
+                sleep=resolved_sleep,
+                gauge=gauge,
+            )
+        )
+        for index, offset in enumerate(config.arrivals.offsets_s)
+    ]
+    records = await asyncio.gather(*tasks)
+    wall = resolved_clock() - t0
+
+    if config.events_dir is not None:
+        write_events(records, config)
+
+    return summarize_run(
+        records,
+        config.profile,
+        mode=config.mode,
+        wall_s=wall,
+        num_gpus=config.num_gpus,
+        peak_concurrent_sessions=gauge.peak,
+        notes=notes,
+    )
+
+
+def write_events(records: Sequence[SessionRecord], config: BenchmarkConfig) -> None:
+    """Write one JSONL of chunk events per session."""
+    if config.events_dir is None:
+        raise ValueError("config.events_dir must be set to write events.")
+    from benchmarks.ar_diffusion.realtime_metrics import chunk_deadlines
+
+    config.events_dir.mkdir(parents=True, exist_ok=True)
+    for record in records:
+        deadlines = chunk_deadlines(record, config.profile) if config.mode is LoadMode.PACED else {}
+        path = config.events_dir / f"{record.session_id}.jsonl"
+        with path.open("w", encoding="utf-8") as handle:
+            for event in record.events:
+                handle.write(json.dumps(event.to_dict(deadline=deadlines.get(event.chunk_index))) + "\n")

--- a/benchmarks/ar_diffusion/realtime_harness.py
+++ b/benchmarks/ar_diffusion/realtime_harness.py
@@ -28,7 +28,7 @@ import contextlib
 import json
 import random
 import time
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
@@ -121,6 +121,26 @@ class BenchmarkConfig:
             raise ValueError("chunks_per_session must be at least 1.")
 
 
+def _stage_durations(output: Any) -> dict[str, float]:
+    """Read the pipeline profiler's per-stage seconds off one tick output.
+
+    Deliberately total, never raising: stage timings are diagnostic, and a
+    pipeline that reports none, or reports them in a shape this harness does
+    not recognise, must still produce a benchmark result. What it must not do
+    is silently contribute a zero, which is why an unrecognised shape yields
+    an empty mapping and is counted as uninstrumented rather than as a tick
+    whose stages took no time.
+    """
+    durations = getattr(output, "stage_durations", None)
+    if not isinstance(durations, Mapping):
+        return {}
+    return {
+        str(name): float(seconds)
+        for name, seconds in durations.items()
+        if isinstance(seconds, (int, float)) and not isinstance(seconds, bool) and seconds >= 0
+    }
+
+
 async def _drive_session(
     session_id: str,
     *,
@@ -159,7 +179,7 @@ async def _drive_session(
                     await sleep(lag)
             t_submit = clock()
             try:
-                await session.next_chunk()
+                output = await session.next_chunk()
             except Exception as exc:  # noqa: BLE001 - a lost session is a result, not a crash
                 lost_reason = f"{type(exc).__name__}: {exc}"
                 break
@@ -169,6 +189,7 @@ async def _drive_session(
                     chunk_index=chunk_index,
                     t_submit=t_submit,
                     t_ready=clock(),
+                    stage_durations=_stage_durations(output),
                 )
             )
     finally:

--- a/benchmarks/ar_diffusion/realtime_metrics.py
+++ b/benchmarks/ar_diffusion/realtime_metrics.py
@@ -49,6 +49,7 @@ class WorkloadProfile:
     target_fps: float
     buffer_chunks: int = 1
     resident_bytes_per_session: int | None = None
+    frames_per_first_chunk: int | None = None
 
     def __post_init__(self) -> None:
         if isinstance(self.frames_per_chunk, bool) or not isinstance(self.frames_per_chunk, int):
@@ -65,11 +66,42 @@ class WorkloadProfile:
             raise ValueError("buffer_chunks must be at least 1.")
         if self.resident_bytes_per_session is not None and self.resident_bytes_per_session < 0:
             raise ValueError("resident_bytes_per_session must be non-negative.")
+        first = self.frames_per_chunk if self.frames_per_first_chunk is None else self.frames_per_first_chunk
+        if isinstance(first, bool) or not isinstance(first, int) or first <= 0:
+            raise ValueError("frames_per_first_chunk must be a positive integer.")
+        object.__setattr__(self, "frames_per_first_chunk", first)
 
     @property
     def release_period_s(self) -> float:
-        """Wall time one committed chunk is worth at the declared playout rate."""
+        """Wall time one steady-state chunk is worth at the declared playout rate.
+
+        Steady state, not the first chunk: a causal decoder expands its first
+        latent frame to a single raw frame and every later one to the full
+        temporal factor, so the opening chunk delivers less video than those
+        that follow. The playout grid is paced by the steady-state chunk, and
+        the shorter opening is accounted for in the cumulative video time that
+        :func:`chunk_deadlines` walks.
+        """
         return self.frames_per_chunk / self.target_fps
+
+    def frames_at(self, chunk_index: int) -> int:
+        """Raw frames chunk ``chunk_index`` delivers."""
+        if isinstance(chunk_index, bool) or not isinstance(chunk_index, int) or chunk_index < 0:
+            raise ValueError("chunk_index must be a non-negative integer.")
+        assert self.frames_per_first_chunk is not None  # resolved in __post_init__
+        return self.frames_per_first_chunk if chunk_index == 0 else self.frames_per_chunk
+
+    def cumulative_frames(self, chunk_count: int) -> int:
+        """Raw frames delivered by chunks ``0 .. chunk_count - 1``."""
+        if chunk_count <= 0:
+            return 0
+        assert self.frames_per_first_chunk is not None
+        return self.frames_per_first_chunk + self.frames_per_chunk * (chunk_count - 1)
+
+    @property
+    def is_causal(self) -> bool:
+        """Whether the opening chunk delivers fewer frames than later ones."""
+        return self.frames_per_first_chunk != self.frames_per_chunk
 
 
 @dataclass(frozen=True)
@@ -142,17 +174,23 @@ def percentile(values: Sequence[float], fraction: float) -> float | None:
 def chunk_deadlines(record: SessionRecord, profile: WorkloadProfile) -> dict[int, float]:
     """Playout deadline per chunk, or ``{}`` when playback never starts.
 
-    Playback begins once ``buffer_chunks`` chunks are buffered, so chunk
-    ``buffer_chunks - 1`` fixes the playout grid and every later chunk is due
-    one release period after its predecessor. Chunks inside the prebuffer have
-    no deadline: their cost is start latency, which TTFC already reports.
+    Playback begins once ``buffer_chunks`` chunks are buffered. From that
+    instant the player consumes continuously, so chunk ``i`` starts playing
+    only after chunks ``0 .. i - 1`` have played, and must be ready by then::
+
+        deadline(i) = t_ready(buffer_chunks - 1) + cumulative_frames(i) / target_fps
+
+    Walking cumulative frames rather than multiplying a constant period is what
+    lets a deeper buffer grant real slack, and what keeps a causal decoder's
+    shorter opening chunk from being credited with a full period of video.
+    Chunks inside the prebuffer have no deadline: their cost is start latency,
+    which TTFC already reports.
     """
     if len(record.events) < profile.buffer_chunks:
         return {}
     anchor = record.events[profile.buffer_chunks - 1]
-    period = profile.release_period_s
     return {
-        event.chunk_index: anchor.t_ready + (event.chunk_index - anchor.chunk_index) * period
+        event.chunk_index: anchor.t_ready + profile.cumulative_frames(event.chunk_index) / profile.target_fps
         for event in record.events[profile.buffer_chunks :]
     }
 
@@ -187,6 +225,10 @@ def summarize_session(
     events = record.events
     latencies = [event.latency_s for event in events]
     ttfc = events[0].t_ready - record.t_start if events else None
+    # Sum the per-chunk delivery rather than multiplying by a constant: with a
+    # causal decoder the opening chunk is shorter, so chunks x frames_per_chunk
+    # over-counts every run by that difference.
+    frames = sum(profile.frames_at(event.chunk_index) for event in events)
 
     rtf: float | None = None
     if events:
@@ -194,7 +236,7 @@ def summarize_session(
         # from the first submit so queueing before the session starts ticking is
         # not charged to the model.
         wall = events[-1].t_ready - events[0].t_submit
-        video_seconds = len(events) * profile.release_period_s
+        video_seconds = frames / profile.target_fps
         rtf = wall / video_seconds if video_seconds > 0 else None
 
     deadlines = chunk_deadlines(record, profile) if mode is LoadMode.PACED else {}
@@ -206,7 +248,7 @@ def summarize_session(
     return SessionSummary(
         session_id=record.session_id,
         chunks=len(events),
-        frames=len(events) * profile.frames_per_chunk,
+        frames=frames,
         ttfc_s=ttfc,
         latency_p50_s=percentile(latencies, 0.50),
         latency_p95_s=percentile(latencies, 0.95),
@@ -244,6 +286,7 @@ class RunSummary:
             "mode": self.mode.value,
             "profile": {
                 "frames_per_chunk": self.profile.frames_per_chunk,
+                "frames_per_first_chunk": self.profile.frames_per_first_chunk,
                 "target_fps": self.profile.target_fps,
                 "buffer_chunks": self.profile.buffer_chunks,
                 "release_period_s": self.profile.release_period_s,
@@ -335,11 +378,21 @@ def compare_runs(baseline: RunSummary, candidate: RunSummary) -> dict[str, Any]:
     return delta
 
 
-def load_profile_from_spec(spec: Mapping[str, Any], *, target_fps: float, buffer_chunks: int = 1) -> WorkloadProfile:
+def load_profile_from_spec(
+    spec: Mapping[str, Any],
+    *,
+    target_fps: float,
+    buffer_chunks: int = 1,
+    causal: bool = True,
+) -> WorkloadProfile:
     """Build a profile from a pipeline's declared AR-Diffusion KV spec.
 
-    Reads ``frames_per_block`` and the VAE temporal factor from the spec rather
-    than from a flag, so the harness never encodes a model's chunk shape.
+    ``frames_per_block`` is in latent frames. A causal video decoder expands
+    the very first latent frame of a session to one raw frame and every later
+    one to the full temporal factor, so an opening block of ``n`` latent frames
+    delivers ``(n - 1) * factor + 1`` raw frames while every later block
+    delivers ``n * factor``. Pass ``causal=False`` for a decoder that expands
+    every latent frame identically.
     """
     frames_per_block = spec.get("frames_per_block")
     temporal_factor = spec.get("vae_temporal_factor", 1)
@@ -347,8 +400,11 @@ def load_profile_from_spec(spec: Mapping[str, Any], *, target_fps: float, buffer
         raise ValueError("spec must declare a positive integer frames_per_block.")
     if isinstance(temporal_factor, bool) or not isinstance(temporal_factor, int) or temporal_factor <= 0:
         raise ValueError("spec vae_temporal_factor must be a positive integer.")
+    steady = frames_per_block * temporal_factor
+    first = (frames_per_block - 1) * temporal_factor + 1 if causal else steady
     return WorkloadProfile(
-        frames_per_chunk=frames_per_block * temporal_factor,
+        frames_per_chunk=steady,
+        frames_per_first_chunk=first,
         target_fps=target_fps,
         buffer_chunks=buffer_chunks,
         resident_bytes_per_session=spec.get("resident_bytes_per_session"),

--- a/benchmarks/ar_diffusion/realtime_metrics.py
+++ b/benchmarks/ar_diffusion/realtime_metrics.py
@@ -1,0 +1,355 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Metric definitions for realtime AR-Diffusion session benchmarks.
+
+Pure functions over recorded chunk events: no engine, no model, no device.
+Everything here is derived from a :class:`WorkloadProfile` so swapping the
+pipeline under test requires no change in this module.
+
+Two load modes produce different metrics, and conflating them produces a
+number no deployment can use:
+
+``saturating``
+    Each session issues its next tick as soon as the previous one returns.
+    Measures the ceiling -- aggregate generated FPS and frames per GPU-second.
+    Deadlines do not exist in this mode, so continuity metrics are ``None``.
+
+``paced``
+    Sessions consume at ``target_fps``, so a chunk is due once per release
+    period. Measures continuity -- CPR, TTFC and worst-case chunk latency.
+    SLO is only defined in this mode.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class LoadMode(str, Enum):
+    SATURATING = "saturating"
+    PACED = "paced"
+
+
+@dataclass(frozen=True)
+class WorkloadProfile:
+    """Serving-relevant shape of the pipeline under test.
+
+    ``frames_per_chunk`` is the number of raw frames one committed chunk
+    delivers, i.e. the model's latent frames per block multiplied by the VAE
+    temporal factor. It comes from the pipeline capability rather than from a
+    command-line default so the harness stays model-neutral.
+    """
+
+    frames_per_chunk: int
+    target_fps: float
+    buffer_chunks: int = 1
+    resident_bytes_per_session: int | None = None
+
+    def __post_init__(self) -> None:
+        if isinstance(self.frames_per_chunk, bool) or not isinstance(self.frames_per_chunk, int):
+            raise TypeError("frames_per_chunk must be an integer.")
+        if self.frames_per_chunk <= 0:
+            raise ValueError("frames_per_chunk must be positive.")
+        if not isinstance(self.target_fps, (int, float)) or isinstance(self.target_fps, bool):
+            raise TypeError("target_fps must be a number.")
+        if not math.isfinite(self.target_fps) or self.target_fps <= 0:
+            raise ValueError("target_fps must be a positive finite number.")
+        if isinstance(self.buffer_chunks, bool) or not isinstance(self.buffer_chunks, int):
+            raise TypeError("buffer_chunks must be an integer.")
+        if self.buffer_chunks < 1:
+            raise ValueError("buffer_chunks must be at least 1.")
+        if self.resident_bytes_per_session is not None and self.resident_bytes_per_session < 0:
+            raise ValueError("resident_bytes_per_session must be non-negative.")
+
+    @property
+    def release_period_s(self) -> float:
+        """Wall time one committed chunk is worth at the declared playout rate."""
+        return self.frames_per_chunk / self.target_fps
+
+
+@dataclass(frozen=True)
+class ChunkEvent:
+    """One committed chunk, timed against a common monotonic clock."""
+
+    session_id: str
+    chunk_index: int
+    t_submit: float
+    t_ready: float
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.session_id, str) or not self.session_id.strip():
+            raise ValueError("session_id must be a non-empty string.")
+        if isinstance(self.chunk_index, bool) or not isinstance(self.chunk_index, int) or self.chunk_index < 0:
+            raise ValueError("chunk_index must be a non-negative integer.")
+        if self.t_ready < self.t_submit:
+            raise ValueError("t_ready must not precede t_submit.")
+
+    @property
+    def latency_s(self) -> float:
+        return self.t_ready - self.t_submit
+
+    def to_dict(self, *, deadline: float | None = None) -> dict[str, Any]:
+        record: dict[str, Any] = {
+            "session_id": self.session_id,
+            "chunk_index": self.chunk_index,
+            "t_submit": self.t_submit,
+            "t_ready": self.t_ready,
+            "latency_s": self.latency_s,
+        }
+        if deadline is not None:
+            record["deadline"] = deadline
+            record["met_deadline"] = self.t_ready <= deadline
+        return record
+
+
+@dataclass(frozen=True)
+class SessionRecord:
+    """Every committed chunk of one session, plus when the session started."""
+
+    session_id: str
+    t_start: float
+    events: tuple[ChunkEvent, ...]
+    lost_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        indices = [event.chunk_index for event in self.events]
+        if indices != sorted(indices) or len(set(indices)) != len(indices):
+            raise ValueError("events must be unique and ordered by chunk_index.")
+        if any(event.session_id != self.session_id for event in self.events):
+            raise ValueError("every event must belong to this session.")
+
+
+def percentile(values: Sequence[float], fraction: float) -> float | None:
+    """Nearest-rank percentile; ``None`` for an empty sample.
+
+    Nearest-rank rather than an interpolating estimator because these samples
+    are small and a reported P99 should be a latency that actually occurred.
+    """
+    if not 0.0 < fraction <= 1.0:
+        raise ValueError("fraction must be in (0, 1].")
+    if not values:
+        return None
+    ordered = sorted(values)
+    rank = max(1, math.ceil(fraction * len(ordered)))
+    return ordered[rank - 1]
+
+
+def chunk_deadlines(record: SessionRecord, profile: WorkloadProfile) -> dict[int, float]:
+    """Playout deadline per chunk, or ``{}`` when playback never starts.
+
+    Playback begins once ``buffer_chunks`` chunks are buffered, so chunk
+    ``buffer_chunks - 1`` fixes the playout grid and every later chunk is due
+    one release period after its predecessor. Chunks inside the prebuffer have
+    no deadline: their cost is start latency, which TTFC already reports.
+    """
+    if len(record.events) < profile.buffer_chunks:
+        return {}
+    anchor = record.events[profile.buffer_chunks - 1]
+    period = profile.release_period_s
+    return {
+        event.chunk_index: anchor.t_ready + (event.chunk_index - anchor.chunk_index) * period
+        for event in record.events[profile.buffer_chunks :]
+    }
+
+
+@dataclass(frozen=True)
+class SessionSummary:
+    session_id: str
+    chunks: int
+    frames: int
+    ttfc_s: float | None
+    latency_p50_s: float | None
+    latency_p95_s: float | None
+    latency_p99_s: float | None
+    latency_max_s: float | None
+    rtf: float | None
+    deadline_chunks: int
+    deadline_misses: int
+    continuous_play_ratio: float | None
+    lost_reason: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return dict(self.__dict__)
+
+
+def summarize_session(
+    record: SessionRecord,
+    profile: WorkloadProfile,
+    *,
+    mode: LoadMode,
+) -> SessionSummary:
+    """Reduce one session's chunk events to its reported metrics."""
+    events = record.events
+    latencies = [event.latency_s for event in events]
+    ttfc = events[0].t_ready - record.t_start if events else None
+
+    rtf: float | None = None
+    if events:
+        # Steady-state generation cost against the video time produced. Measured
+        # from the first submit so queueing before the session starts ticking is
+        # not charged to the model.
+        wall = events[-1].t_ready - events[0].t_submit
+        video_seconds = len(events) * profile.release_period_s
+        rtf = wall / video_seconds if video_seconds > 0 else None
+
+    deadlines = chunk_deadlines(record, profile) if mode is LoadMode.PACED else {}
+    misses = sum(
+        1 for event in events if event.chunk_index in deadlines and event.t_ready > deadlines[event.chunk_index]
+    )
+    cpr = (len(deadlines) - misses) / len(deadlines) if deadlines else None
+
+    return SessionSummary(
+        session_id=record.session_id,
+        chunks=len(events),
+        frames=len(events) * profile.frames_per_chunk,
+        ttfc_s=ttfc,
+        latency_p50_s=percentile(latencies, 0.50),
+        latency_p95_s=percentile(latencies, 0.95),
+        latency_p99_s=percentile(latencies, 0.99),
+        latency_max_s=max(latencies) if latencies else None,
+        rtf=rtf,
+        deadline_chunks=len(deadlines),
+        deadline_misses=misses,
+        continuous_play_ratio=cpr,
+        lost_reason=record.lost_reason,
+    )
+
+
+@dataclass(frozen=True)
+class RunSummary:
+    """Aggregate view of one benchmark run, plus the per-session detail."""
+
+    mode: LoadMode
+    profile: WorkloadProfile
+    num_gpus: int
+    wall_s: float
+    sessions: tuple[SessionSummary, ...]
+    sessions_lost: int
+    generated_fps: float | None
+    frames_per_gpu_second: float | None
+    worst_case_chunk_latency_s: float | None
+    continuous_play_ratio: float | None
+    mean_chunk_latency_s: float | None
+    rtf_spread: float | None
+    peak_concurrent_sessions: int
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mode": self.mode.value,
+            "profile": {
+                "frames_per_chunk": self.profile.frames_per_chunk,
+                "target_fps": self.profile.target_fps,
+                "buffer_chunks": self.profile.buffer_chunks,
+                "release_period_s": self.profile.release_period_s,
+                "resident_bytes_per_session": self.profile.resident_bytes_per_session,
+            },
+            "num_gpus": self.num_gpus,
+            "wall_s": self.wall_s,
+            "sessions_run": len(self.sessions),
+            "sessions_lost": self.sessions_lost,
+            "peak_concurrent_sessions": self.peak_concurrent_sessions,
+            "generated_fps": self.generated_fps,
+            "frames_per_gpu_second": self.frames_per_gpu_second,
+            "mean_chunk_latency_s": self.mean_chunk_latency_s,
+            "worst_case_chunk_latency_s": self.worst_case_chunk_latency_s,
+            "continuous_play_ratio": self.continuous_play_ratio,
+            "rtf_spread": self.rtf_spread,
+            "notes": list(self.notes),
+            "per_session": [summary.to_dict() for summary in self.sessions],
+        }
+
+
+def summarize_run(
+    records: Iterable[SessionRecord],
+    profile: WorkloadProfile,
+    *,
+    mode: LoadMode,
+    wall_s: float,
+    num_gpus: int = 1,
+    peak_concurrent_sessions: int | None = None,
+    notes: Sequence[str] = (),
+) -> RunSummary:
+    """Aggregate session records into the reportable run summary."""
+    if num_gpus < 1:
+        raise ValueError("num_gpus must be at least 1.")
+    if wall_s < 0:
+        raise ValueError("wall_s must be non-negative.")
+
+    ordered = list(records)
+    summaries = tuple(summarize_session(record, profile, mode=mode) for record in ordered)
+    total_frames = sum(summary.frames for summary in summaries)
+    latencies = [event.latency_s for record in ordered for event in record.events]
+
+    # Macro-average over sessions: one lagging session is not diluted by a
+    # neighbour that produced many more chunks.
+    per_session_cpr = [s.continuous_play_ratio for s in summaries if s.continuous_play_ratio is not None]
+    rtfs = [s.rtf for s in summaries if s.rtf is not None]
+
+    return RunSummary(
+        mode=mode,
+        profile=profile,
+        num_gpus=num_gpus,
+        wall_s=wall_s,
+        sessions=summaries,
+        sessions_lost=sum(1 for s in summaries if s.lost_reason is not None),
+        generated_fps=total_frames / wall_s if wall_s > 0 else None,
+        frames_per_gpu_second=total_frames / (wall_s * num_gpus) if wall_s > 0 else None,
+        worst_case_chunk_latency_s=max(latencies) if latencies else None,
+        continuous_play_ratio=statistics.fmean(per_session_cpr) if per_session_cpr else None,
+        mean_chunk_latency_s=statistics.fmean(latencies) if latencies else None,
+        rtf_spread=max(rtfs) - min(rtfs) if len(rtfs) > 1 else None,
+        peak_concurrent_sessions=(peak_concurrent_sessions if peak_concurrent_sessions is not None else len(summaries)),
+        notes=tuple(notes),
+    )
+
+
+def compare_runs(baseline: RunSummary, candidate: RunSummary) -> dict[str, Any]:
+    """Derive the per-tick switching cost between two runs.
+
+    Aggregate generated FPS is expected to stay flat when concurrency of state
+    rises but concurrency of execution does not: ticks serialize, so the same
+    device produces the same frames. A measurable drop is per-tick switching
+    cost -- state bind/unbind, KV pool paging, conditioning rebuild -- and that
+    quantity is the baseline any cross-session batching work has to beat.
+    """
+    delta: dict[str, Any] = {
+        "baseline_sessions": len(baseline.sessions),
+        "candidate_sessions": len(candidate.sessions),
+    }
+    if baseline.generated_fps and candidate.generated_fps is not None:
+        delta["generated_fps_ratio"] = candidate.generated_fps / baseline.generated_fps
+    if baseline.mean_chunk_latency_s is not None and candidate.mean_chunk_latency_s is not None:
+        delta["mean_chunk_latency_delta_s"] = candidate.mean_chunk_latency_s - baseline.mean_chunk_latency_s
+        sessions = len(candidate.sessions) or 1
+        # With serialized ticks a candidate chunk waits behind the other
+        # resident sessions, so the expected latency is sessions x baseline.
+        # Anything beyond that expectation is switching cost, not queueing.
+        expected = baseline.mean_chunk_latency_s * sessions
+        delta["per_tick_switching_cost_s"] = candidate.mean_chunk_latency_s - expected
+    return delta
+
+
+def load_profile_from_spec(spec: Mapping[str, Any], *, target_fps: float, buffer_chunks: int = 1) -> WorkloadProfile:
+    """Build a profile from a pipeline's declared AR-Diffusion KV spec.
+
+    Reads ``frames_per_block`` and the VAE temporal factor from the spec rather
+    than from a flag, so the harness never encodes a model's chunk shape.
+    """
+    frames_per_block = spec.get("frames_per_block")
+    temporal_factor = spec.get("vae_temporal_factor", 1)
+    if isinstance(frames_per_block, bool) or not isinstance(frames_per_block, int) or frames_per_block <= 0:
+        raise ValueError("spec must declare a positive integer frames_per_block.")
+    if isinstance(temporal_factor, bool) or not isinstance(temporal_factor, int) or temporal_factor <= 0:
+        raise ValueError("spec vae_temporal_factor must be a positive integer.")
+    return WorkloadProfile(
+        frames_per_chunk=frames_per_block * temporal_factor,
+        target_fps=target_fps,
+        buffer_chunks=buffer_chunks,
+        resident_bytes_per_session=spec.get("resident_bytes_per_session"),
+    )

--- a/benchmarks/ar_diffusion/realtime_metrics.py
+++ b/benchmarks/ar_diffusion/realtime_metrics.py
@@ -18,6 +18,12 @@ number no deployment can use:
     Sessions consume at ``target_fps``, so a chunk is due once per release
     period. Measures continuity -- CPR, TTFC and worst-case chunk latency.
     SLO is only defined in this mode.
+
+Both modes additionally report ``stage_coverage``: the pipeline profiler's
+per-stage medians *and the chunk latency no stage claims*. Reporting the
+stages without the remainder is what lets a serving-layer cost stay invisible
+indefinitely -- the instrumented parts are all inside the pipeline, and the
+work of turning a tick into a pipeline call is outside every one of them.
 """
 
 from __future__ import annotations
@@ -106,12 +112,22 @@ class WorkloadProfile:
 
 @dataclass(frozen=True)
 class ChunkEvent:
-    """One committed chunk, timed against a common monotonic clock."""
+    """One committed chunk, timed against a common monotonic clock.
+
+    ``stage_durations`` is whatever the pipeline profiler reported for this
+    tick, and it is kept for one reason: **the stages never add up to the
+    tick.** A pipeline instruments the work it knows about -- denoising, VAE,
+    text encoding -- and everything between the tick arriving and the pipeline
+    being called is nobody's stage. Reporting the instrumented parts without
+    reporting the remainder makes that gap invisible, and it is the part a
+    serving layer is most able to remove.
+    """
 
     session_id: str
     chunk_index: int
     t_submit: float
     t_ready: float
+    stage_durations: Mapping[str, float] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if not isinstance(self.session_id, str) or not self.session_id.strip():
@@ -120,10 +136,50 @@ class ChunkEvent:
             raise ValueError("chunk_index must be a non-negative integer.")
         if self.t_ready < self.t_submit:
             raise ValueError("t_ready must not precede t_submit.")
+        if not isinstance(self.stage_durations, Mapping):
+            raise TypeError("stage_durations must be a mapping of stage name to seconds.")
+        for name, seconds in self.stage_durations.items():
+            if not isinstance(name, str) or not name.strip():
+                raise ValueError("stage_durations keys must be non-empty strings.")
+            if isinstance(seconds, bool) or not isinstance(seconds, (int, float)):
+                raise TypeError(f"stage duration {name!r} must be a number.")
+            if not math.isfinite(seconds) or seconds < 0:
+                raise ValueError(f"stage duration {name!r} must be finite and non-negative.")
 
     @property
     def latency_s(self) -> float:
         return self.t_ready - self.t_submit
+
+    @property
+    def instrumented(self) -> bool:
+        """Whether this chunk carries any stage timing at all.
+
+        Distinguishing "the profiler was off" from "the profiler was on and
+        could not explain the time" matters: the first reports no coverage,
+        the second reports a real gap. Collapsing them would read as 100%
+        unaccounted on every uninstrumented run.
+        """
+        return bool(self.stage_durations)
+
+    @property
+    def accounted_s(self) -> float | None:
+        """Seconds this tick's stages claim, or ``None`` if uninstrumented."""
+        if not self.instrumented:
+            return None
+        return float(sum(self.stage_durations.values()))
+
+    @property
+    def unaccounted_s(self) -> float | None:
+        """Tick latency no stage claims. Negative means the stages overlap."""
+        accounted = self.accounted_s
+        return None if accounted is None else self.latency_s - accounted
+
+    @property
+    def accounted_fraction(self) -> float | None:
+        accounted = self.accounted_s
+        if accounted is None or self.latency_s <= 0:
+            return None
+        return accounted / self.latency_s
 
     def to_dict(self, *, deadline: float | None = None) -> dict[str, Any]:
         record: dict[str, Any] = {
@@ -133,6 +189,11 @@ class ChunkEvent:
             "t_ready": self.t_ready,
             "latency_s": self.latency_s,
         }
+        if self.instrumented:
+            record["stage_durations"] = dict(self.stage_durations)
+            record["accounted_s"] = self.accounted_s
+            record["unaccounted_s"] = self.unaccounted_s
+            record["accounted_fraction"] = self.accounted_fraction
         if deadline is not None:
             record["deadline"] = deadline
             record["met_deadline"] = self.t_ready <= deadline
@@ -195,6 +256,50 @@ def chunk_deadlines(record: SessionRecord, profile: WorkloadProfile) -> dict[int
     }
 
 
+def stage_coverage(events: Sequence[ChunkEvent]) -> dict[str, Any]:
+    """Median per-stage seconds, and the tick time no stage claims.
+
+    Returns ``instrumented_chunks == 0`` rather than a fabricated 0% coverage
+    when nothing was profiled, so a run with the profiler disabled cannot be
+    read as a run whose time is entirely unexplained.
+
+    The per-stage medians are reported alongside the residual on purpose: a
+    residual is only actionable next to the stages it is being compared
+    against, and a stage that appears on some ticks but not others (a cached
+    encode, say) shows up as a median far below its own mean.
+    """
+    instrumented = [event for event in events if event.instrumented]
+    if not instrumented:
+        return {
+            "instrumented_chunks": 0,
+            "chunks": len(events),
+            "stage_p50_s": {},
+            "accounted_p50_s": None,
+            "unaccounted_p50_s": None,
+            "accounted_fraction_p50": None,
+        }
+
+    names = sorted({name for event in instrumented for name in event.stage_durations})
+    stage_p50 = {
+        # Absent means the stage did not run on that tick, which is a zero for
+        # the median rather than a missing sample -- that is precisely how a
+        # per-session cache shows up.
+        name: percentile([float(event.stage_durations.get(name, 0.0)) for event in instrumented], 0.50)
+        for name in names
+    }
+    return {
+        "instrumented_chunks": len(instrumented),
+        "chunks": len(events),
+        "stage_p50_s": stage_p50,
+        "accounted_p50_s": percentile([event.accounted_s for event in instrumented], 0.50),
+        "unaccounted_p50_s": percentile([event.unaccounted_s for event in instrumented], 0.50),
+        "accounted_fraction_p50": percentile(
+            [f for f in (event.accounted_fraction for event in instrumented) if f is not None],
+            0.50,
+        ),
+    }
+
+
 @dataclass(frozen=True)
 class SessionSummary:
     session_id: str
@@ -210,6 +315,7 @@ class SessionSummary:
     deadline_misses: int
     continuous_play_ratio: float | None
     lost_reason: str | None
+    stage_coverage: Mapping[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         return dict(self.__dict__)
@@ -259,6 +365,7 @@ def summarize_session(
         deadline_misses=misses,
         continuous_play_ratio=cpr,
         lost_reason=record.lost_reason,
+        stage_coverage=stage_coverage(events),
     )
 
 
@@ -279,6 +386,7 @@ class RunSummary:
     mean_chunk_latency_s: float | None
     rtf_spread: float | None
     peak_concurrent_sessions: int
+    stage_coverage: Mapping[str, Any] = field(default_factory=dict)
     notes: tuple[str, ...] = field(default_factory=tuple)
 
     def to_dict(self) -> dict[str, Any]:
@@ -303,6 +411,7 @@ class RunSummary:
             "worst_case_chunk_latency_s": self.worst_case_chunk_latency_s,
             "continuous_play_ratio": self.continuous_play_ratio,
             "rtf_spread": self.rtf_spread,
+            "stage_coverage": dict(self.stage_coverage),
             "notes": list(self.notes),
             "per_session": [summary.to_dict() for summary in self.sessions],
         }
@@ -348,6 +457,11 @@ def summarize_run(
         mean_chunk_latency_s=statistics.fmean(latencies) if latencies else None,
         rtf_spread=max(rtfs) - min(rtfs) if len(rtfs) > 1 else None,
         peak_concurrent_sessions=(peak_concurrent_sessions if peak_concurrent_sessions is not None else len(summaries)),
+        # Pooled over every chunk of every session rather than averaged over
+        # the per-session figures: the residual is a property of the tick path,
+        # not of a session, and pooling keeps a short session from weighing as
+        # much as a long one.
+        stage_coverage=stage_coverage([event for record in ordered for event in record.events]),
         notes=tuple(notes),
     )
 

--- a/benchmarks/ar_diffusion/run_realtime_benchmark.py
+++ b/benchmarks/ar_diffusion/run_realtime_benchmark.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CLI for the realtime AR-Diffusion multi-session benchmark.
+
+Model-neutral by construction: the chunk shape comes from the pipeline's
+declared ``ARDiffusionKVCacheSpec``, so pointing ``--model`` at another
+AR-Diffusion pipeline needs no code change.
+
+One value cannot come from the capability today. ``frames_per_block`` and every
+other frame count in the spec are in *latent* frames, and nothing in the spec
+converts them to delivered frames, so the playout grid is not derivable from
+the capability alone. Until the spec declares it, the factor arrives as
+``--vae-temporal-factor``.
+
+Every reported number must carry its conditions. ``--note`` is repeatable and
+its values are copied verbatim into the summary; the run refuses to start
+without at least one, because a latency without model, checkpoint, resolution,
+denoising steps and hardware is not a result.
+
+Examples::
+
+    # Ceiling: how fast can this device go at all?
+    python -m benchmarks.ar_diffusion.run_realtime_benchmark \
+        --model <checkpoint> --prompt "..." --num-sessions 1 \
+        --mode saturating --chunks 32 \
+        --note "checkpoint=<...>" --note "hw=1xRTX-PRO-6000" --note "res=480x832"
+
+    # Baseline: state concurrency 2, execution concurrency 1.
+    python -m benchmarks.ar_diffusion.run_realtime_benchmark \
+        --model <checkpoint> --prompt "..." --num-sessions 2 \
+        --mode saturating --chunks 32 --note ...
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from benchmarks.ar_diffusion.realtime_harness import (
+    BenchmarkConfig,
+    burst_arrivals,
+    poisson_arrivals,
+    run_benchmark,
+)
+from benchmarks.ar_diffusion.realtime_metrics import LoadMode, WorkloadProfile
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark realtime AR-Diffusion sessions.")
+    parser.add_argument("--model", required=True, help="Hugging Face model ID or local checkpoint path.")
+    parser.add_argument("--prompt", required=True, help="Initial scene prompt for every session.")
+    parser.add_argument("--image", default=None, help="Optional initial RGB image, if the pipeline needs one.")
+
+    parser.add_argument("--num-sessions", type=int, default=1, help="Sessions to run concurrently.")
+    parser.add_argument("--chunks", type=int, default=16, help="Chunks each session generates.")
+    parser.add_argument(
+        "--mode",
+        choices=[mode.value for mode in LoadMode],
+        default=LoadMode.SATURATING.value,
+        help="saturating measures the ceiling; paced measures continuity against deadlines.",
+    )
+    parser.add_argument(
+        "--target-fps",
+        type=float,
+        default=16.0,
+        help="Declared playout rate. With the chunk shape it fixes the release period.",
+    )
+    parser.add_argument(
+        "--release-period",
+        type=float,
+        default=None,
+        help="Override the release period in seconds. Defaults to frames_per_chunk / target_fps.",
+    )
+    parser.add_argument("--buffer-chunks", type=int, default=1, help="Playout buffer depth, in chunks.")
+    parser.add_argument(
+        "--arrival-rate",
+        type=float,
+        default=None,
+        help="Poisson session arrivals per second. Omit for a burst (all sessions start together).",
+    )
+    parser.add_argument("--seed", type=int, default=0, help="Seed for the arrival process.")
+    parser.add_argument(
+        "--vae-temporal-factor",
+        type=int,
+        default=1,
+        help=(
+            "Raw frames per latent frame. Supplied here because ARDiffusionKVCacheSpec "
+            "declares frames_per_block in latent frames and carries no factor that "
+            "converts it to delivered frames; see the module docstring."
+        ),
+    )
+
+    parser.add_argument("--num-gpus", type=int, default=1, help="Devices in use, for frames per GPU-second.")
+    parser.add_argument("--events-dir", type=Path, default=None, help="Directory for per-session events JSONL.")
+    parser.add_argument("--output", type=Path, default=None, help="Write the run summary JSON here.")
+    parser.add_argument(
+        "--note",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Run conditions recorded verbatim in the summary. Repeatable, and at least one is required.",
+    )
+
+    parser.add_argument("--tensor-parallel-size", type=int, default=1)
+    parser.add_argument("--gpu-memory-fraction", type=float, default=0.9)
+    parser.add_argument("--enforce-eager", action="store_true")
+    parser.add_argument("--max-pending-events", type=int, default=8)
+    return parser.parse_args(argv)
+
+
+def build_config(
+    args: argparse.Namespace, *, frames_per_chunk: int, resident_bytes: int | None = None
+) -> BenchmarkConfig:
+    """Turn parsed arguments plus the pipeline's chunk shape into a config.
+
+    ``frames_per_chunk`` is supplied by the caller after reading the pipeline
+    capability, which is what keeps this module free of model knowledge.
+    """
+    if not args.note:
+        raise ValueError(
+            "At least one --note is required: a latency without model, checkpoint, "
+            "resolution, denoising steps and hardware is not a result."
+        )
+    target_fps = args.target_fps
+    if args.release_period is not None:
+        if args.release_period <= 0:
+            raise ValueError("--release-period must be positive.")
+        # A release period override is expressed as the fps that produces it,
+        # so the profile keeps a single source of truth for the playout grid.
+        target_fps = frames_per_chunk / args.release_period
+
+    profile = WorkloadProfile(
+        frames_per_chunk=frames_per_chunk,
+        target_fps=target_fps,
+        buffer_chunks=args.buffer_chunks,
+        resident_bytes_per_session=resident_bytes,
+    )
+    arrivals = (
+        poisson_arrivals(args.num_sessions, rate_per_s=args.arrival_rate, seed=args.seed)
+        if args.arrival_rate is not None
+        else burst_arrivals(args.num_sessions)
+    )
+    return BenchmarkConfig(
+        profile=profile,
+        mode=LoadMode(args.mode),
+        chunks_per_session=args.chunks,
+        arrivals=arrivals,
+        num_gpus=args.num_gpus,
+        events_dir=args.events_dir,
+    )
+
+
+def frames_per_chunk_from_spec(spec: Any, *, vae_temporal_factor: int = 1) -> int:
+    """Raw frames one committed chunk delivers.
+
+    ``frames_per_block`` is read from the pipeline capability, which is what
+    keeps the chunk shape out of this module. ``vae_temporal_factor`` has to be
+    supplied by the caller: the spec expresses every frame count in latent
+    frames and declares nothing that converts them to delivered frames, so no
+    runtime component can compute the playout grid from the capability alone.
+    A pipeline whose decoder does not compress time uses the default of 1.
+    """
+    frames_per_block = getattr(spec, "frames_per_block", None)
+    if isinstance(frames_per_block, bool) or not isinstance(frames_per_block, int) or frames_per_block <= 0:
+        raise ValueError("The pipeline must declare a positive integer frames_per_block.")
+    if isinstance(vae_temporal_factor, bool) or not isinstance(vae_temporal_factor, int) or vae_temporal_factor <= 0:
+        raise ValueError("vae_temporal_factor must be a positive integer.")
+    return frames_per_block * vae_temporal_factor
+
+
+async def _main(args: argparse.Namespace) -> int:
+    # Imported lazily so --help and the config path stay importable without a
+    # CUDA build, which is also what lets the harness be tested on CPU.
+    from benchmarks.ar_diffusion.engine_binding import build_realtime_backend
+    from vllm_omni.experimental.ar_diffusion import ARDiffusionSessionManager
+
+    backend = await build_realtime_backend(args)
+    frames_per_chunk = frames_per_chunk_from_spec(backend.spec, vae_temporal_factor=args.vae_temporal_factor)
+    config = build_config(
+        args,
+        frames_per_chunk=frames_per_chunk,
+        # Only the model-owned term is declared; runner-owned KV bytes are not
+        # part of the spec, so this under-reports total residency.
+        resident_bytes=getattr(backend.spec, "model_owned_state_bytes_per_session", None),
+    )
+
+    manager: ARDiffusionSessionManager = backend.manager
+
+    async def factory(session_id: str):
+        return await manager.create_session(session_id)
+
+    summary = await run_benchmark(config, factory, notes=tuple(args.note))
+    payload = json.dumps(summary.to_dict(), indent=2)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload, encoding="utf-8")
+    print(payload)
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    return asyncio.run(_main(parse_args(argv)))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/ar_diffusion/run_realtime_benchmark.py
+++ b/benchmarks/ar_diffusion/run_realtime_benchmark.py
@@ -84,6 +84,11 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--seed", type=int, default=0, help="Seed for the arrival process.")
     parser.add_argument(
+        "--non-causal-decoder",
+        action="store_true",
+        help="The decoder expands every latent frame identically, so the opening chunk is full length.",
+    )
+    parser.add_argument(
         "--vae-temporal-factor",
         type=int,
         default=1,
@@ -113,7 +118,11 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 
 def build_config(
-    args: argparse.Namespace, *, frames_per_chunk: int, resident_bytes: int | None = None
+    args: argparse.Namespace,
+    *,
+    frames_per_chunk: int,
+    frames_per_first_chunk: int | None = None,
+    resident_bytes: int | None = None,
 ) -> BenchmarkConfig:
     """Turn parsed arguments plus the pipeline's chunk shape into a config.
 
@@ -135,6 +144,7 @@ def build_config(
 
     profile = WorkloadProfile(
         frames_per_chunk=frames_per_chunk,
+        frames_per_first_chunk=frames_per_first_chunk,
         target_fps=target_fps,
         buffer_chunks=args.buffer_chunks,
         resident_bytes_per_session=resident_bytes,
@@ -154,22 +164,28 @@ def build_config(
     )
 
 
-def frames_per_chunk_from_spec(spec: Any, *, vae_temporal_factor: int = 1) -> int:
-    """Raw frames one committed chunk delivers.
+def frames_per_chunk_from_spec(spec: Any, *, vae_temporal_factor: int = 1, causal: bool = True) -> tuple[int, int]:
+    """Raw frames a chunk delivers, as ``(steady_state, first_chunk)``.
 
     ``frames_per_block`` is read from the pipeline capability, which is what
     keeps the chunk shape out of this module. ``vae_temporal_factor`` has to be
     supplied by the caller: the spec expresses every frame count in latent
     frames and declares nothing that converts them to delivered frames, so no
     runtime component can compute the playout grid from the capability alone.
-    A pipeline whose decoder does not compress time uses the default of 1.
+
+    The conversion is not a plain multiplication. A causal video decoder maps
+    ``n`` latent frames to ``(n - 1) * factor + 1`` raw frames, so a session's
+    opening chunk delivers fewer frames than every chunk after it -- which is
+    also why a single declared integer could not express this mapping.
     """
     frames_per_block = getattr(spec, "frames_per_block", None)
     if isinstance(frames_per_block, bool) or not isinstance(frames_per_block, int) or frames_per_block <= 0:
         raise ValueError("The pipeline must declare a positive integer frames_per_block.")
     if isinstance(vae_temporal_factor, bool) or not isinstance(vae_temporal_factor, int) or vae_temporal_factor <= 0:
         raise ValueError("vae_temporal_factor must be a positive integer.")
-    return frames_per_block * vae_temporal_factor
+    steady = frames_per_block * vae_temporal_factor
+    first = (frames_per_block - 1) * vae_temporal_factor + 1 if causal else steady
+    return steady, first
 
 
 async def _main(args: argparse.Namespace) -> int:
@@ -179,10 +195,15 @@ async def _main(args: argparse.Namespace) -> int:
     from vllm_omni.experimental.ar_diffusion import ARDiffusionSessionManager
 
     backend = await build_realtime_backend(args)
-    frames_per_chunk = frames_per_chunk_from_spec(backend.spec, vae_temporal_factor=args.vae_temporal_factor)
+    frames_per_chunk, frames_per_first_chunk = frames_per_chunk_from_spec(
+        backend.spec,
+        vae_temporal_factor=args.vae_temporal_factor,
+        causal=not args.non_causal_decoder,
+    )
     config = build_config(
         args,
         frames_per_chunk=frames_per_chunk,
+        frames_per_first_chunk=frames_per_first_chunk,
         # Only the model-owned term is declared; runner-owned KV bytes are not
         # part of the spec, so this under-reports total residency.
         resident_bytes=getattr(backend.spec, "model_owned_state_bytes_per_session", None),

--- a/tests/diffusion/ar_diffusion/test_realtime_benchmark.py
+++ b/tests/diffusion/ar_diffusion/test_realtime_benchmark.py
@@ -593,3 +593,125 @@ def test_frames_per_chunk_needs_a_mapping_the_spec_does_not_declare() -> None:
 
     with pytest.raises(ValueError, match="frames_per_block"):
         frames_per_chunk_from_spec(NoSpec())
+
+
+# ---------------------------------------------------------------------------
+# stage coverage: the tick time no stage claims
+# ---------------------------------------------------------------------------
+def _timed_chunk(index: int, latency: float, *, session_id: str = "s0", **stages: float) -> ChunkEvent:
+    return ChunkEvent(
+        session_id=session_id,
+        chunk_index=index,
+        t_submit=float(index),
+        t_ready=index + latency,
+        stage_durations=stages,
+    )
+
+
+def test_the_residual_is_what_the_stages_do_not_explain() -> None:
+    event = _timed_chunk(0, 2.0, _generate_block=1.5, vae_decode=0.2)
+
+    assert event.accounted_s == pytest.approx(1.7)
+    assert event.unaccounted_s == pytest.approx(0.3)
+    assert event.accounted_fraction == pytest.approx(0.85)
+
+
+def test_an_uninstrumented_chunk_reports_no_coverage_rather_than_none_accounted() -> None:
+    """The distinction the whole feature exists for.
+
+    A run with the profiler off must not read as a run whose time is entirely
+    unexplained -- that would turn "we did not look" into "we looked and found
+    100% overhead".
+    """
+    event = _timed_chunk(0, 2.0)
+
+    assert event.instrumented is False
+    assert event.accounted_s is None
+    assert event.unaccounted_s is None
+    assert event.accounted_fraction is None
+    assert "accounted_s" not in event.to_dict()
+
+
+def test_overlapping_stages_report_a_negative_residual_rather_than_clamping() -> None:
+    """Stages that overlap mean the timings are wrong, and that must show.
+
+    Clamping at zero would present a broken instrument as a perfectly
+    explained tick.
+    """
+    event = _timed_chunk(0, 1.0, a=0.8, b=0.7)
+
+    assert event.unaccounted_s == pytest.approx(-0.5)
+    assert event.accounted_fraction == pytest.approx(1.5)
+
+
+def test_stage_coverage_pools_every_chunk_of_every_session() -> None:
+    records = [
+        SessionRecord(
+            session_id="s0",
+            t_start=0.0,
+            events=(
+                _timed_chunk(0, 2.0, _generate_block=1.6, other_stage=0.1),
+                _timed_chunk(1, 2.0, _generate_block=1.6, other_stage=0.1),
+            ),
+        ),
+        SessionRecord(
+            session_id="s1",
+            t_start=0.0,
+            events=(_timed_chunk(0, 2.0, session_id="s1", _generate_block=1.6, other_stage=0.1),),
+        ),
+    ]
+
+    summary = summarize_run(records, PROFILE, mode=LoadMode.SATURATING, wall_s=6.0)
+    coverage = summary.stage_coverage
+
+    assert coverage["instrumented_chunks"] == 3
+    assert coverage["chunks"] == 3
+    assert coverage["unaccounted_p50_s"] == pytest.approx(0.3)
+    assert coverage["accounted_fraction_p50"] == pytest.approx(0.85)
+    assert coverage["stage_p50_s"]["_generate_block"] == pytest.approx(1.6)
+
+
+def test_a_stage_that_runs_on_some_ticks_only_shows_up_below_its_own_mean() -> None:
+    """A per-session cache is exactly this shape, and must stay visible.
+
+    Treating an absent stage as a missing sample would report the cached
+    encode at full cost forever; treating it as zero shows the caching.
+    """
+    record = SessionRecord(
+        session_id="s0",
+        t_start=0.0,
+        events=(
+            _timed_chunk(0, 2.0, encode=0.4, _generate_block=1.5),
+            _timed_chunk(1, 2.0, _generate_block=1.5),
+            _timed_chunk(2, 2.0, _generate_block=1.5),
+        ),
+    )
+
+    coverage = summarize_session(record, PROFILE, mode=LoadMode.SATURATING).stage_coverage
+
+    assert coverage["stage_p50_s"]["encode"] == pytest.approx(0.0)
+    assert coverage["stage_p50_s"]["_generate_block"] == pytest.approx(1.5)
+
+
+def test_a_run_with_no_instrumentation_reports_zero_instrumented_chunks() -> None:
+    record = SessionRecord(
+        session_id="s0",
+        t_start=0.0,
+        events=(_timed_chunk(0, 2.0), _timed_chunk(1, 2.0)),
+    )
+
+    summary = summarize_run([record], PROFILE, mode=LoadMode.SATURATING, wall_s=4.0)
+
+    assert summary.stage_coverage["instrumented_chunks"] == 0
+    assert summary.stage_coverage["chunks"] == 2
+    assert summary.stage_coverage["unaccounted_p50_s"] is None
+    json.dumps(summary.to_dict())
+
+
+def test_stage_durations_must_be_finite_and_non_negative() -> None:
+    with pytest.raises(ValueError):
+        _timed_chunk(0, 1.0, bad=-0.1)
+    with pytest.raises(ValueError):
+        _timed_chunk(0, 1.0, bad=float("inf"))
+    with pytest.raises(TypeError):
+        ChunkEvent(session_id="s0", chunk_index=0, t_submit=0.0, t_ready=1.0, stage_durations=[("a", 1.0)])

--- a/tests/diffusion/ar_diffusion/test_realtime_benchmark.py
+++ b/tests/diffusion/ar_diffusion/test_realtime_benchmark.py
@@ -129,6 +129,7 @@ def test_profile_is_built_from_a_declared_spec() -> None:
     profile = load_profile_from_spec(
         {"frames_per_block": 3, "vae_temporal_factor": 4, "resident_bytes_per_session": 1024},
         target_fps=16.0,
+        causal=False,
     )
     assert profile.frames_per_chunk == 12
     assert profile.resident_bytes_per_session == 1024
@@ -173,12 +174,14 @@ def test_deadlines_anchor_on_the_buffer_and_skip_the_prebuffer() -> None:
     assert deadlines[2] == pytest.approx(2.50)
 
 
-def test_deeper_buffer_moves_the_playout_grid_later() -> None:
+def test_deeper_buffer_grants_real_slack() -> None:
+    """Playback starts at the anchor holding two chunks, so chunk 2 is due
+    after both have played -- not one period after the anchor arrived."""
     profile = WorkloadProfile(frames_per_chunk=12, target_fps=16.0, buffer_chunks=2)
     record = _record("s", [1.0, 1.5, 2.0])
     deadlines = chunk_deadlines(record, profile)
     assert set(deadlines) == {2}
-    assert deadlines[2] == pytest.approx(2.25)
+    assert deadlines[2] == pytest.approx(1.5 + 24 / 16.0)
 
 
 def test_cpr_counts_only_chunks_that_had_a_deadline() -> None:
@@ -203,6 +206,48 @@ def test_rtf_compares_wall_time_against_video_time() -> None:
     record = _record("s", [0.375, 0.75, 1.125, 1.5], submit_gap=0.375)
     summary = summarize_session(record, PROFILE, mode=LoadMode.SATURATING)
     assert summary.rtf == pytest.approx((1.5 - 0.0) / 3.0)
+
+
+CAUSAL = WorkloadProfile(frames_per_chunk=12, frames_per_first_chunk=9, target_fps=16.0)
+
+
+def test_causal_decoder_delivers_a_shorter_opening_chunk() -> None:
+    """(n - 1) * factor + 1 for the opening block, n * factor after it.
+
+    3 latent frames at temporal factor 4 is 9 raw frames the first time and 12
+    every time after, so K chunks deliver 12K - 3 frames, not 12K.
+    """
+    assert CAUSAL.is_causal is True
+    assert CAUSAL.frames_at(0) == 9
+    assert CAUSAL.frames_at(1) == CAUSAL.frames_at(7) == 12
+    assert CAUSAL.cumulative_frames(10) == 117  # matches the pipeline's 117-frame horizon
+    assert CAUSAL.cumulative_frames(0) == 0
+
+    summary = summarize_session(_record("s", [1.0, 2.0, 3.0]), CAUSAL, mode=LoadMode.SATURATING)
+    assert summary.frames == 9 + 12 + 12
+    # The uniform profile over-counts the same three chunks.
+    assert summarize_session(_record("s", [1.0, 2.0, 3.0]), PROFILE, mode=LoadMode.SATURATING).frames == 36
+
+
+def test_non_causal_profile_is_the_default_and_stays_uniform() -> None:
+    assert PROFILE.is_causal is False
+    assert PROFILE.frames_at(0) == PROFILE.frames_at(5) == 12
+    assert PROFILE.cumulative_frames(3) == 36
+
+
+def test_causal_opening_chunk_is_not_credited_with_a_full_period() -> None:
+    """The opening chunk buys 9/16 s of playback, so chunk 1 is due sooner."""
+    record = _record("s", [1.0, 1.5, 2.0])
+    assert chunk_deadlines(record, CAUSAL)[1] == pytest.approx(1.0 + 9 / 16.0)
+    assert chunk_deadlines(record, PROFILE)[1] == pytest.approx(1.0 + 12 / 16.0)
+
+
+def test_causal_profile_from_spec_matches_the_pipeline_geometry() -> None:
+    spec = {"frames_per_block": 3, "vae_temporal_factor": 4}
+    causal = load_profile_from_spec(spec, target_fps=16.0)
+    assert (causal.frames_per_first_chunk, causal.frames_per_chunk) == (9, 12)
+    uniform = load_profile_from_spec(spec, target_fps=16.0, causal=False)
+    assert (uniform.frames_per_first_chunk, uniform.frames_per_chunk) == (12, 12)
 
 
 def test_cpr_is_macro_averaged_so_a_lagging_session_is_not_diluted() -> None:
@@ -504,19 +549,21 @@ def test_arrival_rate_switches_to_poisson() -> None:
     assert any(offset > 0 for offset in config.arrivals.offsets_s)
 
 
-def test_frames_per_chunk_needs_a_factor_the_spec_does_not_declare() -> None:
-    """ARDiffusionKVCacheSpec counts latent frames and declares no VAE factor.
+def test_frames_per_chunk_needs_a_mapping_the_spec_does_not_declare() -> None:
+    """ARDiffusionKVCacheSpec counts latent frames and declares no conversion.
 
-    The harness therefore takes the factor from the caller instead of guessing,
-    and a pipeline whose decoder does not compress time uses the default of 1.
+    The harness takes it from the caller instead of guessing. Note the result
+    is a pair, not a scalar: the conversion is causal, so a single declared
+    integer could not express it.
     """
     from benchmarks.ar_diffusion.run_realtime_benchmark import frames_per_chunk_from_spec
 
     class Spec:
         frames_per_block = 3
 
-    assert frames_per_chunk_from_spec(Spec()) == 3
-    assert frames_per_chunk_from_spec(Spec(), vae_temporal_factor=4) == 12
+    assert frames_per_chunk_from_spec(Spec()) == (3, 3)
+    assert frames_per_chunk_from_spec(Spec(), vae_temporal_factor=4) == (12, 9)
+    assert frames_per_chunk_from_spec(Spec(), vae_temporal_factor=4, causal=False) == (12, 12)
     with pytest.raises(ValueError, match="vae_temporal_factor"):
         frames_per_chunk_from_spec(Spec(), vae_temporal_factor=0)
 

--- a/tests/diffusion/ar_diffusion/test_realtime_benchmark.py
+++ b/tests/diffusion/ar_diffusion/test_realtime_benchmark.py
@@ -318,6 +318,27 @@ async def test_paced_mode_holds_the_release_period_when_generation_is_faster() -
 
 
 @pytest.mark.asyncio
+async def test_paced_mode_uses_the_shorter_causal_opening_period() -> None:
+    clock = VirtualClock()
+    factory, _ = make_factory(clock, tick_s=0.10)
+    config = BenchmarkConfig(
+        profile=WorkloadProfile(
+            frames_per_chunk=12,
+            frames_per_first_chunk=9,
+            target_fps=16.0,
+        ),
+        mode=LoadMode.PACED,
+        chunks_per_session=3,
+        arrivals=burst_arrivals(1),
+    )
+    run = await drive(config, factory, clock)
+    # Submits land at 0, 9/16 and (9+12)/16 seconds.  Using the steady
+    # 12/16 period for chunk 1 would make this 1.60 seconds instead.
+    assert run.wall_s == pytest.approx((9 + 12) / 16.0 + 0.10)
+    assert run.sessions[0].continuous_play_ratio == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
 async def test_paced_mode_records_misses_when_generation_is_too_slow() -> None:
     clock = VirtualClock()
     factory, _ = make_factory(clock, tick_s=2.0)

--- a/tests/diffusion/ar_diffusion/test_realtime_benchmark.py
+++ b/tests/diffusion/ar_diffusion/test_realtime_benchmark.py
@@ -1,0 +1,527 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU tests for the realtime AR-Diffusion benchmark harness.
+
+The harness is driven on a virtual clock against fake sessions, so the load
+model, deadline model and metric definitions are verified without an engine,
+a device or a checkpoint.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from benchmarks.ar_diffusion.realtime_harness import (
+    ArrivalPlan,
+    BenchmarkConfig,
+    burst_arrivals,
+    poisson_arrivals,
+    run_benchmark,
+)
+from benchmarks.ar_diffusion.realtime_metrics import (
+    ChunkEvent,
+    LoadMode,
+    SessionRecord,
+    WorkloadProfile,
+    chunk_deadlines,
+    compare_runs,
+    load_profile_from_spec,
+    percentile,
+    summarize_run,
+    summarize_session,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+# 3 latent frames x VAE temporal factor 4 = 12 raw frames, 16 fps playout, so
+# one chunk is worth 750 ms. Declared here rather than imported from a model.
+PROFILE = WorkloadProfile(frames_per_chunk=12, target_fps=16.0)
+
+
+class VirtualClock:
+    """Deterministic clock that advances only when a sleeper is released."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self._waiters: list[tuple[float, asyncio.Future]] = []
+
+    def time(self) -> float:
+        return self.now
+
+    async def sleep(self, delay: float) -> None:
+        if delay <= 0:
+            return
+        loop = asyncio.get_running_loop()
+        future = loop.create_future()
+        self._waiters.append((self.now + delay, future))
+        await future
+
+    async def run_until_idle(self, task: asyncio.Task) -> None:
+        """Advance to each next wakeup until ``task`` completes."""
+        while not task.done():
+            await asyncio.sleep(0)
+            if task.done():
+                break
+            if not self._waiters:
+                await asyncio.sleep(0)
+                if not self._waiters:
+                    break
+                continue
+            self._waiters.sort(key=lambda item: item[0])
+            when, future = self._waiters.pop(0)
+            self.now = max(self.now, when)
+            if not future.done():
+                future.set_result(None)
+
+
+class FakeSession:
+    """A session whose tick takes a fixed amount of virtual time."""
+
+    def __init__(self, clock: VirtualClock, *, tick_s: float, fail_at: int | None = None) -> None:
+        self._clock = clock
+        self._tick_s = tick_s
+        self._fail_at = fail_at
+        self._calls = 0
+        self.closed = False
+
+    async def next_chunk(self) -> str:
+        if self._fail_at is not None and self._calls == self._fail_at:
+            raise RuntimeError("fake rollout lost")
+        self._calls += 1
+        await self._clock.sleep(self._tick_s)
+        return "chunk"
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def make_factory(clock: VirtualClock, *, tick_s: float, fail_at: int | None = None):
+    created: dict[str, FakeSession] = {}
+
+    async def factory(session_id: str) -> FakeSession:
+        session = FakeSession(clock, tick_s=tick_s, fail_at=fail_at)
+        created[session_id] = session
+        return session
+
+    return factory, created
+
+
+async def drive(config: BenchmarkConfig, factory, clock: VirtualClock, **kwargs):
+    task = asyncio.ensure_future(run_benchmark(config, factory, clock=clock.time, sleep=clock.sleep, **kwargs))
+    await clock.run_until_idle(task)
+    return await task
+
+
+# --------------------------------------------------------------------------
+# Metric definitions
+# --------------------------------------------------------------------------
+
+
+def test_release_period_comes_from_the_profile_not_a_flag() -> None:
+    assert PROFILE.release_period_s == pytest.approx(0.75)
+    assert WorkloadProfile(frames_per_chunk=12, target_fps=24.0).release_period_s == pytest.approx(0.5)
+
+
+def test_profile_is_built_from_a_declared_spec() -> None:
+    profile = load_profile_from_spec(
+        {"frames_per_block": 3, "vae_temporal_factor": 4, "resident_bytes_per_session": 1024},
+        target_fps=16.0,
+    )
+    assert profile.frames_per_chunk == 12
+    assert profile.resident_bytes_per_session == 1024
+    with pytest.raises(ValueError, match="frames_per_block"):
+        load_profile_from_spec({"vae_temporal_factor": 4}, target_fps=16.0)
+
+
+def test_percentile_reports_an_observed_value() -> None:
+    values = [1.0, 2.0, 3.0, 100.0]
+    assert percentile(values, 0.5) == 2.0
+    assert percentile(values, 0.99) == 100.0
+    assert percentile([], 0.5) is None
+
+
+def _record(
+    session_id: str,
+    readies: list[float],
+    *,
+    submit_gap: float = 0.0,
+    latencies: list[float] | None = None,
+) -> SessionRecord:
+    """Build a record from ready times, with per-chunk latency if needed."""
+    gaps = latencies if latencies is not None else [submit_gap] * len(readies)
+    if len(gaps) != len(readies):
+        raise ValueError("latencies must match readies.")
+    return SessionRecord(
+        session_id=session_id,
+        t_start=0.0,
+        events=tuple(
+            ChunkEvent(session_id=session_id, chunk_index=i, t_submit=t - gap, t_ready=t)
+            for i, (t, gap) in enumerate(zip(readies, gaps, strict=True))
+        ),
+    )
+
+
+def test_deadlines_anchor_on_the_buffer_and_skip_the_prebuffer() -> None:
+    record = _record("s", [1.0, 1.5, 2.0])
+    deadlines = chunk_deadlines(record, PROFILE)
+    # buffer_chunks=1: chunk 0 fixes the grid and has no deadline of its own.
+    assert 0 not in deadlines
+    assert deadlines[1] == pytest.approx(1.75)
+    assert deadlines[2] == pytest.approx(2.50)
+
+
+def test_deeper_buffer_moves_the_playout_grid_later() -> None:
+    profile = WorkloadProfile(frames_per_chunk=12, target_fps=16.0, buffer_chunks=2)
+    record = _record("s", [1.0, 1.5, 2.0])
+    deadlines = chunk_deadlines(record, profile)
+    assert set(deadlines) == {2}
+    assert deadlines[2] == pytest.approx(2.25)
+
+
+def test_cpr_counts_only_chunks_that_had_a_deadline() -> None:
+    # chunk 1 due at 1.75 arrives at 1.5 (met); chunk 2 due at 2.5 arrives at 9.0 (missed).
+    record = _record("s", [1.0, 1.5, 9.0])
+    summary = summarize_session(record, PROFILE, mode=LoadMode.PACED)
+    assert summary.deadline_chunks == 2
+    assert summary.deadline_misses == 1
+    assert summary.continuous_play_ratio == pytest.approx(0.5)
+
+
+def test_saturating_mode_reports_no_continuity_metrics() -> None:
+    """SLO is only defined under pacing; a ceiling run must not imply one."""
+    record = _record("s", [1.0, 1.5, 9.0])
+    summary = summarize_session(record, PROFILE, mode=LoadMode.SATURATING)
+    assert summary.continuous_play_ratio is None
+    assert summary.deadline_chunks == 0
+
+
+def test_rtf_compares_wall_time_against_video_time() -> None:
+    # 4 chunks x 0.75 s of video = 3.0 s; produced in 1.5 s of wall time.
+    record = _record("s", [0.375, 0.75, 1.125, 1.5], submit_gap=0.375)
+    summary = summarize_session(record, PROFILE, mode=LoadMode.SATURATING)
+    assert summary.rtf == pytest.approx((1.5 - 0.0) / 3.0)
+
+
+def test_cpr_is_macro_averaged_so_a_lagging_session_is_not_diluted() -> None:
+    """A session that produced few chunks must weigh the same as a busy one."""
+    good = _record("good", [1.0] + [1.0 + 0.75 * i for i in range(1, 21)])
+    bad = _record("bad", [1.0, 99.0])
+    run = summarize_run([good, bad], PROFILE, mode=LoadMode.PACED, wall_s=100.0)
+    # Micro-averaging over all chunks would report ~0.95; macro-averaging halves it.
+    assert run.continuous_play_ratio == pytest.approx(0.5, abs=0.02)
+
+
+def test_worst_case_latency_is_across_sessions_not_per_session() -> None:
+    run = summarize_run(
+        [
+            _record("a", [1.0, 2.0], latencies=[1.0, 1.0]),
+            _record("b", [1.0, 30.0], latencies=[1.0, 29.0]),
+        ],
+        PROFILE,
+        mode=LoadMode.SATURATING,
+        wall_s=30.0,
+    )
+    assert run.worst_case_chunk_latency_s == pytest.approx(29.0)
+
+
+def test_frames_per_gpu_second_is_normalized_by_device_count() -> None:
+    run = summarize_run([_record("a", [1.0, 2.0])], PROFILE, mode=LoadMode.SATURATING, wall_s=2.0, num_gpus=4)
+    assert run.generated_fps == pytest.approx(12.0)
+    assert run.frames_per_gpu_second == pytest.approx(3.0)
+
+
+# --------------------------------------------------------------------------
+# Load model
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_saturating_mode_issues_the_next_tick_immediately() -> None:
+    clock = VirtualClock()
+    factory, _ = make_factory(clock, tick_s=0.25)
+    config = BenchmarkConfig(
+        profile=PROFILE,
+        mode=LoadMode.SATURATING,
+        chunks_per_session=4,
+        arrivals=burst_arrivals(1),
+    )
+    run = await drive(config, factory, clock)
+    summary = run.sessions[0]
+    assert summary.chunks == 4
+    # Back to back: 4 x 0.25 s, not paced out to 4 x 0.75 s.
+    assert run.wall_s == pytest.approx(1.0)
+    assert summary.rtf == pytest.approx(1.0 / 3.0)
+
+
+@pytest.mark.asyncio
+async def test_paced_mode_holds_the_release_period_when_generation_is_faster() -> None:
+    clock = VirtualClock()
+    factory, _ = make_factory(clock, tick_s=0.25)
+    config = BenchmarkConfig(
+        profile=PROFILE,
+        mode=LoadMode.PACED,
+        chunks_per_session=4,
+        arrivals=burst_arrivals(1),
+    )
+    run = await drive(config, factory, clock)
+    # Chunk k is not submitted before k x 0.75 s, so the run spans the grid.
+    assert run.wall_s == pytest.approx(3.0 * 0.75 + 0.25)
+    assert run.sessions[0].continuous_play_ratio == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_paced_mode_records_misses_when_generation_is_too_slow() -> None:
+    clock = VirtualClock()
+    factory, _ = make_factory(clock, tick_s=2.0)
+    config = BenchmarkConfig(
+        profile=PROFILE,
+        mode=LoadMode.PACED,
+        chunks_per_session=4,
+        arrivals=burst_arrivals(1),
+    )
+    run = await drive(config, factory, clock)
+    summary = run.sessions[0]
+    assert summary.rtf > 1.0
+    assert summary.continuous_play_ratio == pytest.approx(0.0)
+    assert summary.deadline_misses == summary.deadline_chunks == 3
+
+
+@pytest.mark.asyncio
+async def test_a_lost_session_is_recorded_as_a_result_not_a_crash() -> None:
+    clock = VirtualClock()
+    factory, created = make_factory(clock, tick_s=0.25, fail_at=2)
+    config = BenchmarkConfig(
+        profile=PROFILE,
+        mode=LoadMode.SATURATING,
+        chunks_per_session=5,
+        arrivals=burst_arrivals(1),
+    )
+    run = await drive(config, factory, clock)
+    assert run.sessions_lost == 1
+    assert run.sessions[0].chunks == 2
+    assert "fake rollout lost" in run.sessions[0].lost_reason
+    # The session is still released even though its rollout was lost.
+    assert created["bench-0"].closed is True
+
+
+@pytest.mark.asyncio
+async def test_peak_concurrency_is_reported_and_reflects_arrivals() -> None:
+    clock = VirtualClock()
+    factory, _ = make_factory(clock, tick_s=0.25)
+    config = BenchmarkConfig(
+        profile=PROFILE,
+        mode=LoadMode.SATURATING,
+        chunks_per_session=2,
+        arrivals=burst_arrivals(3),
+    )
+    run = await drive(config, factory, clock)
+    assert run.peak_concurrent_sessions == 3
+    assert len(run.sessions) == 3
+
+
+@pytest.mark.asyncio
+async def test_staggered_arrivals_lower_peak_concurrency() -> None:
+    clock = VirtualClock()
+    factory, _ = make_factory(clock, tick_s=0.25)
+    # Second session arrives after the first has finished its two ticks.
+    config = BenchmarkConfig(
+        profile=PROFILE,
+        mode=LoadMode.SATURATING,
+        chunks_per_session=2,
+        arrivals=ArrivalPlan((0.0, 10.0)),
+    )
+    run = await drive(config, factory, clock)
+    assert run.peak_concurrent_sessions == 1
+
+
+def test_poisson_arrivals_are_deterministic_and_ordered() -> None:
+    first = poisson_arrivals(5, rate_per_s=1.0, seed=7)
+    assert first.offsets_s == poisson_arrivals(5, rate_per_s=1.0, seed=7).offsets_s
+    assert list(first.offsets_s) == sorted(first.offsets_s)
+    assert first.offsets_s != poisson_arrivals(5, rate_per_s=1.0, seed=8).offsets_s
+
+
+def test_arrival_plan_rejects_unordered_offsets() -> None:
+    with pytest.raises(ValueError, match="non-decreasing"):
+        ArrivalPlan((1.0, 0.0))
+
+
+# --------------------------------------------------------------------------
+# Outputs
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_events_jsonl_carries_deadlines_in_paced_mode(tmp_path) -> None:
+    clock = VirtualClock()
+    factory, _ = make_factory(clock, tick_s=0.25)
+    config = BenchmarkConfig(
+        profile=PROFILE,
+        mode=LoadMode.PACED,
+        chunks_per_session=3,
+        arrivals=burst_arrivals(1),
+        events_dir=tmp_path / "events",
+    )
+    await drive(config, factory, clock)
+    lines = (tmp_path / "events" / "bench-0.jsonl").read_text().strip().splitlines()
+    assert len(lines) == 3
+    records = [json.loads(line) for line in lines]
+    assert "deadline" not in records[0]  # prebuffer chunk
+    assert records[1]["met_deadline"] is True
+    assert set(records[0]) >= {"session_id", "chunk_index", "t_submit", "t_ready", "latency_s"}
+
+
+def test_run_summary_is_json_serializable_and_states_its_conditions() -> None:
+    run = summarize_run(
+        [_record("a", [1.0, 2.0], submit_gap=0.5)],
+        PROFILE,
+        mode=LoadMode.PACED,
+        wall_s=2.0,
+        num_gpus=2,
+        notes=("checkpoint=X", "resolution=480x832"),
+    )
+    payload = json.dumps(run.to_dict())
+    restored = json.loads(payload)
+    assert restored["mode"] == "paced"
+    assert restored["num_gpus"] == 2
+    assert restored["profile"]["release_period_s"] == pytest.approx(0.75)
+    assert restored["notes"] == ["checkpoint=X", "resolution=480x832"]
+
+
+# --------------------------------------------------------------------------
+# The N=1 vs N=2 comparison this harness exists to produce
+# --------------------------------------------------------------------------
+
+
+def test_serialized_ticks_keep_aggregate_fps_flat_and_double_rtf() -> None:
+    """The expected N=2 result when state concurrency is 2 but execution is 1.
+
+    Two sessions resident, ticks serialized: the device produces the same
+    frames per second, and each session sees twice its solo RTF.
+    """
+    # Long enough for steady state: the first chunk's head start (it meets no
+    # contention) washes out, which is why the 2x relation is asymptotic.
+    k = 20
+    tick = 0.5
+    solo = summarize_run(
+        [_record("a", [tick * (i + 1) for i in range(k)], submit_gap=tick)],
+        PROFILE,
+        mode=LoadMode.SATURATING,
+        wall_s=tick * k,
+    )
+    # Interleaved: a chunk now waits behind one other session's tick.
+    a_ready = [tick + i * 2 * tick for i in range(k)]
+    b_ready = [2 * tick + i * 2 * tick for i in range(k)]
+    pair = summarize_run(
+        [
+            _record("a", a_ready, latencies=[tick] + [2 * tick] * (k - 1)),
+            _record("b", b_ready, latencies=[2 * tick] * k),
+        ],
+        PROFILE,
+        mode=LoadMode.SATURATING,
+        wall_s=2 * tick * k,
+    )
+    assert pair.generated_fps == pytest.approx(solo.generated_fps)
+    assert pair.sessions[0].rtf == pytest.approx(solo.sessions[0].rtf * 2, rel=0.05)
+
+    delta = compare_runs(solo, pair)
+    assert delta["generated_fps_ratio"] == pytest.approx(1.0)
+    # Latency grew only by queueing behind one other session, so effectively no
+    # switching cost is left over.
+    assert abs(delta["per_tick_switching_cost_s"]) < 0.05 * tick
+
+
+def test_switching_cost_is_the_latency_beyond_pure_queueing() -> None:
+    """A measurable drop beyond queueing is the quantity batching has to beat."""
+    solo = summarize_run(
+        [_record("a", [0.5, 1.0], submit_gap=0.5)],
+        PROFILE,
+        mode=LoadMode.SATURATING,
+        wall_s=1.0,
+    )
+    # Each chunk costs 1.2 s instead of the 1.0 s pure serialization predicts.
+    pair = summarize_run(
+        [
+            _record("a", [1.2, 2.4], submit_gap=1.2),
+            _record("b", [1.2, 2.4], submit_gap=1.2),
+        ],
+        PROFILE,
+        mode=LoadMode.SATURATING,
+        wall_s=2.4,
+    )
+    delta = compare_runs(solo, pair)
+    assert delta["per_tick_switching_cost_s"] == pytest.approx(0.2)
+    assert delta["generated_fps_ratio"] < 1.0
+
+
+# --------------------------------------------------------------------------
+# CLI argument -> config path (no engine, no device)
+# --------------------------------------------------------------------------
+
+
+def _args(*argv: str):
+    from benchmarks.ar_diffusion.run_realtime_benchmark import parse_args
+
+    return parse_args(["--model", "m", "--prompt", "p", "--note", "hw=test", *argv])
+
+
+def test_cli_defaults_to_a_single_session_burst() -> None:
+    from benchmarks.ar_diffusion.run_realtime_benchmark import build_config
+
+    config = build_config(_args(), frames_per_chunk=12)
+    assert config.mode is LoadMode.SATURATING
+    assert len(config.arrivals) == 1
+    assert config.arrivals.offsets_s == (0.0,)
+    assert config.profile.release_period_s == pytest.approx(0.75)
+
+
+def test_cli_requires_run_conditions() -> None:
+    """A latency without model, hardware and resolution is not a result."""
+    from benchmarks.ar_diffusion.run_realtime_benchmark import build_config, parse_args
+
+    bare = parse_args(["--model", "m", "--prompt", "p"])
+    with pytest.raises(ValueError, match="--note is required"):
+        build_config(bare, frames_per_chunk=12)
+
+
+def test_release_period_override_keeps_one_source_of_truth() -> None:
+    from benchmarks.ar_diffusion.run_realtime_benchmark import build_config
+
+    config = build_config(_args("--release-period", "0.5"), frames_per_chunk=12)
+    assert config.profile.release_period_s == pytest.approx(0.5)
+    assert config.profile.target_fps == pytest.approx(24.0)
+
+
+def test_arrival_rate_switches_to_poisson() -> None:
+    from benchmarks.ar_diffusion.run_realtime_benchmark import build_config
+
+    config = build_config(_args("--num-sessions", "4", "--arrival-rate", "1.0"), frames_per_chunk=12)
+    assert len(config.arrivals) == 4
+    assert config.arrivals.offsets_s[0] == 0.0
+    assert any(offset > 0 for offset in config.arrivals.offsets_s)
+
+
+def test_frames_per_chunk_needs_a_factor_the_spec_does_not_declare() -> None:
+    """ARDiffusionKVCacheSpec counts latent frames and declares no VAE factor.
+
+    The harness therefore takes the factor from the caller instead of guessing,
+    and a pipeline whose decoder does not compress time uses the default of 1.
+    """
+    from benchmarks.ar_diffusion.run_realtime_benchmark import frames_per_chunk_from_spec
+
+    class Spec:
+        frames_per_block = 3
+
+    assert frames_per_chunk_from_spec(Spec()) == 3
+    assert frames_per_chunk_from_spec(Spec(), vae_temporal_factor=4) == 12
+    with pytest.raises(ValueError, match="vae_temporal_factor"):
+        frames_per_chunk_from_spec(Spec(), vae_temporal_factor=0)
+
+    class NoSpec:
+        pass
+
+    with pytest.raises(ValueError, match="frames_per_block"):
+        frames_per_chunk_from_spec(NoSpec())


### PR DESCRIPTION
## Summary

There is no way to measure realtime AR-Diffusion serving in tree today. `examples/offline_inference/diffusion/lingbot_world_v2_realtime.py` is a single-session sequential loop, and `benchmarks/` has nothing session-oriented, so none of the numbers a streaming video deployment is gated on have a baseline.

This adds `benchmarks/ar_diffusion`, the Phase 0 harness from [#6227](https://github.com/vllm-project/vllm-omni/issues/6227) (deliverables 1 and 4: *common benchmark harness* and *explicit TTFF/chunk-latency/RTF metrics*).

| Module | Needs a device? |
|---|---|
| `realtime_metrics.py` — metric definitions, pure functions | no |
| `realtime_harness.py` — load model, arrivals, pacing, recording | no |
| `run_realtime_benchmark.py` — CLI; argument-to-config path has no engine imports | no |
| `engine_binding.py` — AsyncOmni + session manager wiring | **yes** |

Only the last one needs a checkpoint. Everything the benchmark actually measures is tested on CPU.

## Design decisions worth reviewing

**Session arrival rate is the only open-loop axis.** Per-session tick rate is not one: ticks of a session are strictly ordered and state-dependent — tick `k+1` reads the state committed by tick `k` and cannot be issued before chunk `k` returns — so raising it only grows a queue. Active session count is derived state, reported as `peak_concurrent_sessions` rather than driven.

**Two load modes, both required.** `saturating` measures the ceiling and has no deadlines. `paced` measures continuity and is the only mode in which an SLO is defined. Running only the first produces a throughput number no deployment can use; running only the second hides the ceiling, so a miss cannot be attributed to capacity rather than scheduling.

**CPR is reported next to RTF, not derived from it.** RTF is a ratio of aggregates: a session can hold `RTF = 0.9` over a minute and still stutter visibly, because chunks arrive in bursts that individually miss their playout instants. CPR is macro-averaged over sessions so one lagging session is not diluted by a busier neighbour — there is a test for exactly that.

**Deadline model.** Playback starts once `--buffer-chunks` chunks are buffered; chunk `buffer_chunks - 1` anchors the grid, and every later chunk is due one release period after its predecessor. Chunks inside the prebuffer have no deadline — their cost is start latency, which TTFC already reports.

**`compare_runs()`** derives `per_tick_switching_cost_s` as the latency beyond what pure serialization predicts. With state concurrency `N` and execution concurrency 1, ticks serialize, so `aggregate FPS(N) ≈ FPS(1)` and `RTF(N) ≈ N × RTF(1)`. A measurable drop in aggregate FPS is per-tick switching cost — state bind/unbind, KV pool paging, conditioning rebuild — and that number is the baseline any cross-session batching work has to beat.

**Run conditions are mandatory.** At least one `--note` is required and the values are copied verbatim into the summary. A latency without model, checkpoint, resolution, denoising steps and hardware is not a result.

## One gap this surfaced

The harness is model-neutral: the chunk shape is read from the pipeline's declared `ARDiffusionKVCacheSpec` and no model name appears in the directory.

But **one conversion cannot come from the capability today.** `frames_per_block`, `window_frames` and `sink_frames` are all in *latent* frames, and `ARDiffusionKVCacheSpec` declares nothing that converts them to delivered frames. So no runtime component can compute the playout grid — release period, deadlines, RTF, generated FPS — from the capability alone.

**And the conversion is not a multiplication.** A causal video decoder expands a session's first latent frame to one raw frame and every later one to the full temporal factor:

| | latent frames | raw frames |
|---|---|---|
| chunk 0 | 3 | **9** |
| chunk k > 0 | 3 | 12 |
| K chunks | 3K | **12K − 3** |

The reference pipeline's own geometry confirms it — `num_latent_frames = (num_frames - 1) // factor + 1`, and its `_MAX_RAW_FRAMES = 117` horizon is exactly 10 chunks under this mapping.

I had this wrong in the first revision of this PR: the profile multiplied a constant, so every run over-counted by the difference. Fixed in `58357fc`, which also corrects the deadline model — it walked a constant release period, crediting the shorter opening chunk with a full period and giving a deeper buffer no extra slack.

The practical consequence for the spec: **the missing piece is a mapping, not a factor**, so declaring a single integer would not close it. `vae_temporal_factor` arrives as a flag (`--vae-temporal-factor`, default `1`; `--non-causal-decoder` selects the uniform mapping) and `frames_per_chunk_from_spec` returns the pair.

Worth noting how small the fix would be if the spec should carry this: `LingBotWorldCausalDMDPipeline.ar_diffusion_kv_cache_spec()` already has `self.vae_scale_factor_temporal` in scope — it uses it two lines earlier to compute `horizon_latent_frames` and `condition_channels`. Happy to add it here or separately if there is a preferred shape.

Relatedly, `resident_bytes_per_session` is reported from `model_owned_state_bytes_per_session` only; runner-owned KV bytes are not in the spec, so that field under-reports total residency.

## Test

`tests/diffusion/ar_diffusion/test_realtime_benchmark.py` — **32 tests, CPU only**, ruff check and format clean. The load model runs on a virtual clock against fake sessions, so the suite spends no wall time and needs no engine, device or checkpoint.

Coverage:

- **Causal geometry** — the opening chunk is shorter; the uniform profile stays uniform by default; the opening chunk is not credited with a full period of playback; spec derivation produces both values.
- **Metric definitions** — release period from the profile rather than a flag; nearest-rank percentiles (a reported P99 should be a latency that occurred); deadline anchoring and prebuffer exclusion; deeper buffers moving the grid; CPR counting only chunks that had a deadline; saturating mode reporting no continuity metrics; RTF; macro- vs micro-averaged CPR; worst-case latency across rather than within sessions; frames-per-GPU-second normalization.
- **Load model** — saturating issues the next tick immediately; paced holds the release period when generation is faster; paced records misses when generation is too slow; a lost session is recorded as a result and still released; peak concurrency reflects arrivals; staggered arrivals lower it; Poisson arrivals deterministic per seed.
- **Outputs** — events JSONL carries deadlines in paced mode and omits them for prebuffer chunks; the summary is JSON-serializable and carries its conditions.
- **The N=1 vs N=2 comparison** the harness exists to produce — serialized ticks keep aggregate FPS flat and double per-session RTF (asymptotically, since the first chunk meets no contention), and switching cost is the latency beyond pure queueing.

## Follow-up

This is the harness only. Producing the N=1 and N=2 numbers needs a card that holds two live sessions, which by the memory arithmetic in [#6227](https://github.com/vllm-project/vllm-omni/issues/6227#issuecomment-5364804077) is ~75 GB for the reference workload — 80 GB devices leave nothing for activations. Those numbers will be posted to the RFC once run.
