### PR TITLE
[Docs] Restore the Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ Feel free to ask questions, provide feedbacks and discuss with fellow users of v
 
 <a href="https://www.star-history.com/?repos=vllm-project%2Fvllm-omni&type=date&legend=top-left">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=vllm-project/vllm-omni&type=date&theme=dark&legend=top-left&sealed_token=YosRwXCLgU-t-aDKUqbEZsAbZUrLZuvCpnqhCF1S7EZH4lP-RPjrvwKho2Een0dG-mBaZhD6jjyZs2Wu7taedUYGCGcdG5IdfzANWO9YHBNUZSH66u31eb0LhVtIPQp29XKRBf7s9crq5_3IXKosc42uf5GUq5jaAQyKPglvVeLyxuMvQTYFv13LEn9B" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=vllm-project/vllm-omni&type=date&legend=top-left&sealed_token=YosRwXCLgU-t-aDKUqbEZsAbZUrLZuvCpnqhCF1S7EZH4lP-RPjrvwKho2Een0dG-mBaZhD6jjyZs2Wu7taedUYGCGcdG5IdfzANWO9YHBNUZSH66u31eb0LhVtIPQp29XKRBf7s9crq5_3IXKosc42uf5GUq5jaAQyKPglvVeLyxuMvQTYFv13LEn9B" />
-    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=vllm-project/vllm-omni&type=date&legend=top-left&sealed_token=YosRwXCLgU-t-aDKUqbEZsAbZUrLZuvCpnqhCF1S7EZH4lP-RPjrvwKho2Een0dG-mBaZhD6jjyZs2Wu7taedUYGCGcdG5IdfzANWO9YHBNUZSH66u31eb0LhVtIPQp29XKRBf7s9crq5_3IXKosc42uf5GUq5jaAQyKPglvVeLyxuMvQTYFv13LEn9B" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=vllm-project/vllm-omni&type=date&theme=dark&legend=top-left&sealed_token=ExgLDZJoQEg27Zfhhut2LqN0GYO6Fw2PWLwPE6JYBUp2BgM3hmsYlwaIVopnUEfbRXidQ4nisumrTdKYydiKhy1SZXipw47qY2_tiUDhCpsPXeXtPuEVKVzBwKs3pw0tiHsJgtSfwXx5yjHXck0Y2SblzFWeJYCkTe1WLGTbUAOIETjXXQJjyCGZvKz5" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=vllm-project/vllm-omni&type=date&legend=top-left&sealed_token=ExgLDZJoQEg27Zfhhut2LqN0GYO6Fw2PWLwPE6JYBUp2BgM3hmsYlwaIVopnUEfbRXidQ4nisumrTdKYydiKhy1SZXipw47qY2_tiUDhCpsPXeXtPuEVKVzBwKs3pw0tiHsJgtSfwXx5yjHXck0Y2SblzFWeJYCkTe1WLGTbUAOIETjXXQJjyCGZvKz5" />
+    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=vllm-project/vllm-omni&type=date&legend=top-left&sealed_token=ExgLDZJoQEg27Zfhhut2LqN0GYO6Fw2PWLwPE6JYBUp2BgM3hmsYlwaIVopnUEfbRXidQ4nisumrTdKYydiKhy1SZXipw47qY2_tiUDhCpsPXeXtPuEVKVzBwKs3pw0tiHsJgtSfwXx5yjHXck0Y2SblzFWeJYCkTe1WLGTbUAOIETjXXQJjyCGZvKz5" />
   </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,13 @@ Feel free to ask questions, provide feedbacks and discuss with fellow users of v
 
 ## Star History
 
-> [!NOTE]
-> The Star History chart is temporarily unavailable due to
-> [GitHub's Stargazer API restrictions](https://star-history.com/blog/github-stargazer-api-restriction).
+<a href="https://www.star-history.com/?repos=vllm-project%2Fvllm-omni&type=date&legend=top-left">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=vllm-project/vllm-omni&type=date&theme=dark&legend=top-left&sealed_token=YosRwXCLgU-t-aDKUqbEZsAbZUrLZuvCpnqhCF1S7EZH4lP-RPjrvwKho2Een0dG-mBaZhD6jjyZs2Wu7taedUYGCGcdG5IdfzANWO9YHBNUZSH66u31eb0LhVtIPQp29XKRBf7s9crq5_3IXKosc42uf5GUq5jaAQyKPglvVeLyxuMvQTYFv13LEn9B" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=vllm-project/vllm-omni&type=date&legend=top-left&sealed_token=YosRwXCLgU-t-aDKUqbEZsAbZUrLZuvCpnqhCF1S7EZH4lP-RPjrvwKho2Een0dG-mBaZhD6jjyZs2Wu7taedUYGCGcdG5IdfzANWO9YHBNUZSH66u31eb0LhVtIPQp29XKRBf7s9crq5_3IXKosc42uf5GUq5jaAQyKPglvVeLyxuMvQTYFv13LEn9B" />
+    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=vllm-project/vllm-omni&type=date&legend=top-left&sealed_token=YosRwXCLgU-t-aDKUqbEZsAbZUrLZuvCpnqhCF1S7EZH4lP-RPjrvwKho2Een0dG-mBaZhD6jjyZs2Wu7taedUYGCGcdG5IdfzANWO9YHBNUZSH66u31eb0LhVtIPQp29XKRBf7s9crq5_3IXKosc42uf5GUq5jaAQyKPglvVeLyxuMvQTYFv13LEn9B" />
+  </picture>
+</a>
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Easy, fast, and cheap omni-modality model serving for everyone
 | <a href="https://vllm-omni.readthedocs.io/en/latest/"><b>Documentation</b></a> | <a href="https://deepwiki.com/vllm-project/vllm-omni"><b>DeepWiki</b></a> | <a href="https://discuss.vllm.ai"><b>User Forum</b></a> | <a href="https://slack.vllm.ai"><b>Developer Slack</b></a> | <a href="docs/assets/WeChat.jpg"><b>WeChat</b></a> | <a href="https://arxiv.org/abs/2602.02204"><b>Paper</b></a> | <a href="https://docs.google.com/presentation/d/1aPj0OGl_-ZVoib-Qne5dGDAlrRFB-PdHl6E-EE99g8E/edit?usp=sharing"><b>Slides</b></a> |
 </p>
 
-
 ---
 
 *Latest News* 🔥
+
 - [2026/08] [VeRL-Omni](https://github.com/verl-project/verl-omni) `v0.2.0` is released: faster diffusion RL powered by vLLM-Omni (request-level/step-wise batching with FA3), rebuilt Qwen3-Omni multimodal training (DPO & GSPO), plus LTX-2.3, Qwen-Image-Edit support and more. See the [release notes](https://github.com/verl-project/verl-omni/releases/tag/v0.2.0).
 - [2026/08] We released [0.26.0](https://github.com/vllm-project/vllm-omni/releases/tag/v0.26.0) - aligned with the vLLM 0.26 release line, featuring [MiniMax H3](recipes/MiniMaxAI/MiniMax-H3.md) joint video/audio generation, an experimental full-duplex realtime runtime for [MiniCPM-o 4.5](recipes/OpenBMB/MiniCPM-o-4_5.md), distributed layerwise diffusion offload, and broader model, hardware, streaming, TTS, and quantization support.
 - [2026/07] We released [0.24.0](https://github.com/vllm-project/vllm-omni/releases/tag/v0.24.0) - aligned with the vLLM 0.24 release line, expanding production-ready coverage across TTS, speech, diffusion, image/video generation, and robot-policy serving, with major Omni stage runtime refactoring, diffusion request-level batching, async output materialization, quantization/cache/memory improvements, and broad CUDA/ROCm/XPU/NPU support.
@@ -89,6 +89,7 @@ If you use vLLM-Omni for your research, please cite our [paper](https://arxiv.or
 ```
 
 ## Join the Community
+
 Feel free to ask questions, provide feedbacks and discuss with fellow users of vLLM-Omni in `#sig-omni` slack channel at [slack.vllm.ai](https://slack.vllm.ai) or vLLM user forum at [discuss.vllm.ai](https://discuss.vllm.ai).
 
 ## Star History

--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ Feel free to ask questions, provide feedbacks and discuss with fellow users of v
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=vllm-project/vllm-omni&type=date&legend=top-left)](https://www.star-history.com/#vllm-project/vllm-omni&type=date&legend=top-left)
+> [!NOTE]
+> The Star History chart is temporarily unavailable due to
+> [GitHub's Stargazer API restrictions](https://star-history.com/blog/github-stargazer-api-restriction).
 
 ## License
 


### PR DESCRIPTION
## Summary

- restore the live Star History chart in the README
- use a sealed GitHub token so Star History can access the repository's stargazer data under GitHub's API restrictions
- support light and dark color schemes

## Testing

- `env npm_config_cache=/private/tmp/codex-vllm-omni-npm-cache pre-commit run --files README.md`
- `git diff --check`
- verified the chart endpoint returns HTTP 200 with `image/svg+xml`