### PR TITLE
[Bugfix][Qwen3-Omni] Stabilize thinker MRoPE compilation

### DIFF
--- a/tests/config/test_config_factory.py
+++ b/tests/config/test_config_factory.py
@@ -2226,6 +2226,28 @@ class TestPlatformOverrides:
         assert rocm.stages[0].enforce_eager is None
         assert rocm.stages[1].enforce_eager is True
 
+    def test_qwen3_omni_cuda_uses_thinker_rotary_custom_op(self):
+        deploy_path = Path(get_deploy_config_path("qwen3_omni_moe.yaml"))
+        pipeline = resolve_pipeline_config(
+            "qwen3_omni_moe",
+            Q3_OMNI_ALL_STAGES_HF_CONFIG,
+        )
+        assert isinstance(pipeline, PipelineConfig)
+
+        cuda = _apply_platform_overrides(load_deploy_config(deploy_path), platform="cuda")
+        cuda_stages = merge_pipeline_deploy(pipeline, cuda)
+        expected = {"custom_ops": ["+rotary_embedding"]}
+        assert cuda_stages[0].yaml_engine_args["compilation_config"] == expected
+        assert all("compilation_config" not in stage.yaml_engine_args for stage in cuda_stages[1:])
+
+        for platform in ("cpu", "musa", "npu", "rocm", "xpu"):
+            deploy = _apply_platform_overrides(
+                load_deploy_config(deploy_path),
+                platform=platform,
+            )
+            config = deploy.stages[0].compilation_config or {}
+            assert "+rotary_embedding" not in config.get("custom_ops", [])
+
     def test_minicpmo_4_5_cuda_caps_talker_kv_cache(self):
         pipeline = resolve_pipeline_config("minicpmo_4_5")
         assert isinstance(pipeline, PipelineConfig)

--- a/vllm_omni/deploy/qwen3_omni_moe.yaml
+++ b/vllm_omni/deploy/qwen3_omni_moe.yaml
@@ -69,6 +69,15 @@ stages:
       repetition_penalty: 1.1
 
 platforms:
+  # vLLM 0.27's compiled native MRoPE path can vertically fuse the thinker's
+  # Q/K RMSNorm reductions into the rotary operations and materially change
+  # Qwen3-Omni audio output (#6090). Keep MRoPE on its CUDA path instead.
+  cuda:
+    stages:
+      - stage_id: 0
+        compilation_config:
+          custom_ops: ["+rotary_embedding"]
+
   # The supported Qwen3-Omni ModelOpt checkpoint quantizes the thinker only. Clear the
   # checkpoint-level metadata for the BF16 audio stages on the verified MUSA
   # profile before vLLM performs its normal quantization auto-detection.


### PR DESCRIPTION
Fixes #6090.

## Summary

- keep Qwen3-Omni thinker MRoPE on the CUDA custom-op path
- preserve the graph boundary between the Q/K RMSNorm reductions and MRoPE while retaining compiled execution
- scope the override to CUDA stage 0 and cover the unaffected stages/platforms with a config regression test

## Root cause

With a fixed seed and sampler, the v0.26 and v0.27 eager paths matched exactly across thinker token IDs/hidden states, talker logits, and codec IDs. The v0.27 compiled path first diverged at thinker token 0 (layer-24 hidden state at token 1), then at talker argmax step 1 and codec frame 1. Running only stage 0 with `enforce_eager=true` while leaving stage 1 compiled removed the downstream divergence, isolating the problem to thinker compilation.

The v0.27 native MRoPE path lets Inductor vertically fuse through the Q/K RMSNorm reductions, which changes the numerics enough to alter the autoregressive trajectory. Adding `+rotary_embedding` to the thinker compilation config keeps MRoPE behind the CUDA/Triton custom-op boundary. The captured graph contains no `fused_qk_norm_rope`, so this uses the narrow boundary override instead of enabling the broader QK-norm/RoPE fusion flag.

Two repeated fixed-seed runs with this override matched exactly for thinker token IDs/hidden states, talker logits, and codec IDs. Against the eager oracle, thinker IDs, talker argmax IDs, and codec IDs matched, and all eight generated WAV chunks were byte-for-byte identical.

## Relation to #6432 and #6438

Those PRs change the sampling/test acceptance behavior. This PR fixes the model execution path and preserves the existing five-request audio-quality gate.

## Validation

- Original failed node on 2x NVIDIA L20X (vLLM 0.27.0): `1 passed, 15 warnings in 411.41s (0:06:51)`
  - all five requests passed with similarities `0.975978`, `1.0`, `0.976989`, `0.980277`, and `0.979241`
- Config factory suite after rebasing onto `main`: `307 passed, 15 warnings in 18.79s`
- All changed-file pre-commit hooks passed, including Ruff, mypy (Python 3.10), pytest markers, SPDX, and YAML checks

The exact failed test is already part of the existing `full_model` + `omni` two-GPU nightly coverage; no CI test-list change is needed.
