### PR TITLE
[Bugfix][Hardware][Ascend] Fix repeated MiniMax-H3 FL2VA request OOM

### DIFF
--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
@@ -5,7 +5,7 @@ import json
 import sys
 from multiprocessing.reduction import ForkingPickler
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 import numpy as np
 import pytest
@@ -1006,7 +1006,7 @@ def test_text_encoder_linear_delegates_quantization_to_vllm_factory():
     quant_config.get_quant_method.assert_called_once_with(linear, prefix=prefix)
 
 
-def test_no_offload_keeps_text_encoder_resident():
+def test_no_offload_keeps_text_encoder_resident(monkeypatch):
     from vllm_omni.diffusion.models.minimax_h3 import MiniMaxH3Pipeline
 
     pipeline = object.__new__(MiniMaxH3Pipeline)
@@ -1019,12 +1019,15 @@ def test_no_offload_keeps_text_encoder_resident():
     expected = torch.ones(2, 3)
     pipeline.text_encoder.encode_ids.return_value = expected
     input_ids = torch.tensor([1, 2])
+    empty_cache = Mock()
+    monkeypatch.setattr(torch.accelerator, "empty_cache", empty_cache)
 
     actual = pipeline._encode_text_hidden(input_ids, {})
 
     assert actual is expected
     pipeline.text_encoder.load_to_device.assert_called_once_with()
     pipeline.text_encoder.offload_to_cpu.assert_not_called()
+    empty_cache.assert_not_called()
 
 
 def test_model_offload_uses_hooked_text_encoder_call():
@@ -1052,7 +1055,7 @@ def test_model_offload_uses_hooked_text_encoder_call():
     "offload_flag",
     ["enable_layerwise_offload", "enable_distributed_layerwise_offload"],
 )
-def test_layerwise_offload_releases_text_encoder(offload_flag):
+def test_layerwise_offload_releases_text_encoder(monkeypatch, offload_flag):
     from vllm_omni.diffusion.models.minimax_h3 import MiniMaxH3Pipeline
 
     pipeline = object.__new__(MiniMaxH3Pipeline)
@@ -1063,15 +1066,73 @@ def test_layerwise_offload_releases_text_encoder(offload_flag):
         enable_distributed_layerwise_offload=False,
     )
     setattr(pipeline.od_config, offload_flag, True)
+    pipeline.device = torch.device("cpu")
+    pipeline.video_vae = Mock()
     pipeline.text_encoder = Mock()
     expected = torch.ones(2, 3)
-    pipeline.text_encoder.encode_ids.return_value = expected
+    calls = []
+    pipeline.video_vae.to.side_effect = lambda device: calls.append(("video_vae.to", device))
+    monkeypatch.setattr(
+        torch.accelerator,
+        "empty_cache",
+        lambda: calls.append(("empty_cache", None)),
+    )
+    pipeline.text_encoder.load_to_device.side_effect = lambda: calls.append(("text_encoder.load", None))
+    pipeline.text_encoder.encode_ids.side_effect = lambda *_args, **_kwargs: (
+        calls.append(("text_encoder.encode", None)) or expected
+    )
+    pipeline.text_encoder.offload_to_cpu.side_effect = lambda: calls.append(("text_encoder.offload", None))
 
     actual = pipeline._encode_text_hidden(torch.tensor([1, 2]), {})
 
     assert actual is expected
+    expected_calls = [
+        ("text_encoder.load", None),
+        ("text_encoder.encode", None),
+        ("text_encoder.offload", None),
+    ]
+    if offload_flag == "enable_layerwise_offload":
+        expected_calls = [
+            ("video_vae.to", "cpu"),
+            ("empty_cache", None),
+            *expected_calls,
+            ("video_vae.to", pipeline.device),
+        ]
+    assert calls == expected_calls
     pipeline.text_encoder.load_to_device.assert_called_once_with()
     pipeline.text_encoder.offload_to_cpu.assert_called_once_with()
+
+
+@pytest.mark.parametrize("failure_stage", ["load", "encode", "offload"])
+def test_layerwise_offload_restores_video_vae_on_failure(monkeypatch, failure_stage):
+    from vllm_omni.diffusion.data import OmniDiffusionConfig
+    from vllm_omni.diffusion.models.minimax_h3 import MiniMaxH3Pipeline
+
+    pipeline = object.__new__(MiniMaxH3Pipeline)
+    torch.nn.Module.__init__(pipeline)
+    pipeline.od_config = Mock(spec=OmniDiffusionConfig)
+    pipeline.od_config.enable_cpu_offload = False
+    pipeline.od_config.enable_layerwise_offload = True
+    pipeline.od_config.enable_distributed_layerwise_offload = False
+    pipeline.device = torch.device("cpu")
+    pipeline.video_vae = Mock()
+    pipeline.text_encoder = Mock()
+    monkeypatch.setattr(torch.accelerator, "empty_cache", Mock())
+
+    if failure_stage == "load":
+        pipeline.text_encoder.load_to_device.side_effect = RuntimeError("load failed")
+    elif failure_stage == "encode":
+        pipeline.text_encoder.encode_ids.side_effect = RuntimeError("encode failed")
+    else:
+        pipeline.text_encoder.offload_to_cpu.side_effect = RuntimeError("offload failed")
+
+    with pytest.raises(RuntimeError, match=f"{failure_stage} failed"):
+        pipeline._encode_text_hidden(torch.tensor([1, 2]), {})
+
+    assert pipeline.video_vae.to.call_args_list == [
+        call("cpu"),
+        call(pipeline.device),
+    ]
 
 
 def test_distributed_layerwise_offload_releases_text_encoder():

--- a/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
+++ b/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
@@ -1140,12 +1140,25 @@ class MiniMaxH3Pipeline(
             self.od_config, "enable_distributed_layerwise_offload", False
         ):
             # Layerwise DiT offload already provides the low-residency encoder
-            # phase used by the checkpoint reference.
-            self.text_encoder.load_to_device()
+            # phase used by the checkpoint reference. The video VAE is not
+            # needed during text encoding and must not overlap the on-demand
+            # encoder on memory-constrained devices.
+            stage_video_vae = self.od_config.enable_layerwise_offload
+            if stage_video_vae:
+                self.video_vae.to("cpu")
             try:
+                if stage_video_vae:
+                    # Release the VAE's inactive allocations before loading the
+                    # encoder. Keep this out of other offload modes.
+                    torch.accelerator.empty_cache()
+                self.text_encoder.load_to_device()
                 return self.text_encoder.encode_ids(input_ids, **vision_kwargs)
             finally:
-                self.text_encoder.offload_to_cpu()
+                try:
+                    self.text_encoder.offload_to_cpu()
+                finally:
+                    if stage_video_vae:
+                        self.video_vae.to(self.device)
 
         # Keep both Qwen and DiT resident across requests. Moving either model
         # here makes encoder latency include a tens-of-gigabytes PCIe transfer,


### PR DESCRIPTION
Fixes #6400.

## Purpose

### What broke

With MiniMax-H3 FL2VA on eight Ascend 910-class NPUs and
`--enable-layerwise-offload`, the first `/v1/videos/sync` request completed,
but the second request failed while `text_encoder.load_to_device()` moved the
text model back to rank 0. The reported failure was a 502 MiB allocation with
only about 156-212 MiB free on the 60.96 GiB device.

### Reproduction

Start the server with the same relevant topology and offload settings:

```bash
vllm serve /path/to/MiniMax-H3/FL2VA \
  --host 0.0.0.0 \
  --port 9098 \
  --num-gpus 8 \
  --usp 1 \
  --ring 1 \
  --vae-patch-parallel-size 8 \
  --vae-parallel-mode tile \
  --vae-use-tiling \
  --tensor-parallel-size 8 \
  --enable-layerwise-offload
```

Then run this request twice:

```bash
export FIRST_FRAME=/path/to/first_frame.jpeg
curl --fail-with-body -m 3600 \
  -o fl2va-out.mp4 \
  http://127.0.0.1:9098/v1/videos/sync \
  -F 'prompt=A little girl grows up.' \
  -F 'width=1024' \
  -F 'height=576' \
  -F 'fps=24' \
  -F 'num_inference_steps=50' \
  -F 'seed=2101' \
  -F 'extra_params={"task":"fl2va","duration":5.0,"audio_flow_shift":3.0}' \
  -F "input_reference=@${FIRST_FRAME};type=image/jpeg"
```

### Root cause

Layerwise DiT offload kept the video VAE resident while the large text encoder
was loaded on demand. The VAE is not used during text encoding, so the second
request unnecessarily overlapped both components on rank 0 and exhausted NPU
memory.

### Fix

For regular layerwise offload, move the video VAE to CPU before loading the
text encoder, release the inactive allocator cache, and restore the VAE after
text encoding. Nested `finally` blocks restore the VAE even if encoder loading,
encoding, or cleanup fails.

The resident no-offload path and the newer distributed layerwise-offload path
remain unchanged. Regression tests cover the successful phase order, all three
failure points, and the unaffected modes.

## Test Plan

- Send two consecutive 50-step FL2VA requests with the eight-NPU configuration
  above and verify that both return HTTP 200 with decodable MP4 output.
- Run the MiniMax-H3 contract tests.
- Let CI validate the patch against the current `main` dependency set.

**vLLM Version:** 0.26.0+empty (local reproduction image package metadata)

**vLLM-Omni Commit:** Runtime reproduction and full NPU validation used v0.26.0
`a4ea67a21b20054dacc6e83952f9bd407e8ee4e7`; this PR is based on upstream
`main` commit `ea0a24465b6ee2d01c87c9b035fa6bc147151b0f`.

## Test Result

- Before: request 1 returned HTTP 200; request 2 returned HTTP 500 after about
  7.65 seconds with an NPU OOM in `text_model.to()`.
- After: two consecutive requests returned HTTP 200 in 189.19 seconds and
  153.19 seconds.
- Both outputs were valid 5.207-second, 2,122,880-byte MP4 files and had the
  same SHA256:
  `a1d801518c5349a89843bcf11ca5ee96c5734a8628feadb65066825d54c38ae2`.
- MiniMax-H3 contract tests on the validated v0.26.0 source: `19 passed`.
- The current-main adaptation passed Python compilation, focused Ruff fatal
  checks, and direct execution checks for resident, regular layerwise,
  distributed layerwise, and load/encode/offload failure paths.

The available machine reports `Ascend910_9382`; it was not independently
confirmed as the exact 910B4 SKU from the issue. The issue-specific PR image
was unavailable locally, so current-main CI remains the final compatibility
check.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
