### PR TITLE
[BugFix]: CosyVoice3 STFT window device mismatch

### DIFF
--- a/vllm_omni/model_executor/models/cosyvoice3/code2wav_core/hifigan.py
+++ b/vllm_omni/model_executor/models/cosyvoice3/code2wav_core/hifigan.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 # Adopted from https://github.com/FunAudioLLM/CosyVoice/tree/main/cosyvoice/hifigan
 # Copyright (c) 2024 Alibaba Inc (authors: Xiang Lyu, Kai Hu)
 
@@ -696,7 +696,11 @@ class CausalHiFTGenerator(HiFTGenerator):
         self.ups.apply(init_weights)
         self.conv_post.apply(init_weights)
         self.reflection_pad = nn.ReflectionPad1d((1, 0))
-        self.stft_window = torch.from_numpy(get_window("hann", istft_params["n_fft"], fftbins=True).astype(np.float32))
+        self.register_buffer(
+            "stft_window",
+            torch.from_numpy(get_window("hann", istft_params["n_fft"], fftbins=True).astype(np.float32)),
+            persistent=False,
+        )
         self.conv_pre_look_right = conv_pre_look_right
         self.f0_predictor = f0_predictor
 


### PR DESCRIPTION
## Purpose

#6455 
`stft_window `was stored as a regular CPU tensor. Therefore, calling `model.cuda()`did not move it to the GPU, while the STFT input was on CUDA.

## Test Plan
```
vllm serve FunAudioLLM/Fun-CosyVoice3-0.5B-2512 \
  --omni \
  --port 8091 \
  --trust-remote-code
```

```
python examples/online_serving/text_to_speech/cosyvoice3/speech_client.py \
  --text "你好，这是一次端到端测试。" \
  --ref-audio tests/assets/cosyvoice3/zero_shot_prompt.wav \
  --ref-text "希望你以后能够做的比我还好呦。" \
  --stream \
  --output /tmp/cosyvoice3-repro.pcm
```

## Result

```text
(StageEngineCoreProc_stage1_replica0 pid=99343) INFO 08-21 09:25:46 [parallel_state.py:1640] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://10.0.32.58:42245 backend=nccl
(StageEngineCoreProc_stage1_replica0 pid=99343) INFO 08-21 09:25:46 [parallel_state.py:1977] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
(StageEngineCoreProc_stage1_replica0 pid=99343) WARNING 08-21 09:25:47 [gpu_generation_worker.py:99] OMNI GPUGenerationWorker forces v1 model runner for omni hooks.
(StageEngineCoreProc_stage1_replica0 pid=99343) INFO 08-21 09:25:47 [topk_topp_sampler.py:62] Using FlashInfer for top-p & top-k sampling.
(StageEngineCoreProc_stage1_replica0 pid=99343) WARNING 08-21 09:25:48 [cosyvoice3.py:162] CosyVoice3: TensorRT campplus build failed (No module named 'tensorrt'); falling back to ONNX-Runtime speaker embedding
(StageEngineCoreProc_stage1_replica0 pid=99343) INFO 08-21 09:25:48 [speaker_cache.py:242] Speaker cache ready (max_bytes=536870912)
(StageEngineCoreProc_stage1_replica0 pid=99343) INFO 08-21 09:25:56 [factory.py:46] Created connector: SharedMemoryConnector
(StageEngineCoreProc_stage1_replica0 pid=99343) WARNING 08-21 09:25:56 [base.py:193] [LLM Worker 0] Sleep Mode DISABLED.
(StageEngineCoreProc_stage1_replica0 pid=99343) WARNING 08-21 09:25:56 [base.py:193] [LLM Worker 0] Sleep Mode DISABLED.
(StageEngineCoreProc_stage1_replica0 pid=99343) INFO 08-21 09:25:56 [gpu_model_runner.py:5308] Starting to load model /proj-tango-pvc/users/zhipeng.wang/models/Fun-CosyVoice3-0.5B-2512...
(StageEngineCoreProc_stage1_replica0 pid=99343) INFO 08-21 09:25:57 [platform.py:221] Defaulting to diffusion attention backend CUDNN_ATTN (Blackwell sm_103, cuDNN 92000)
(StageEngineCoreProc_stage1_replica0 pid=99343) INFO 08-21 09:25:57 [selector.py:89] Resolved diffusion attention backend 'CUDNN_ATTN' for role='self' via platform default
(StageEngineCoreProc_stage1_replica0 pid=99343) INFO 08-21 09:25:57 [cfm.py:274] input frame rate=25
(StageEngineCoreProc_stage1_replica0 pid=99343) INFO 08-21 09:25:59 [cosyvoice3_code2wav.py:310] Loaded flow weights from /proj-tango-pvc/users/zhipeng.wang/models/Fun-CosyVoice3-0.5B-2512/flow.pt
(StageEngineCoreProc_stage1_replica0 pid=99343) INFO 08-21 09:26:00 [cosyvoice3_code2wav.py:319] Loaded hift weights from /proj-tango-pvc/users/zhipeng.wang/models/Fun-CosyVoice3-0.5B-2512/hift.pt
(StageEngineCoreProc_stage1_replica0 pid=99343) INFO 08-21 09:26:00 [default_loader.py:430] Loading weights took 350910.71 seconds
(StageEngineCoreProc_stage1_replica0 pid=99343) INFO 08-21 09:26:01 [gpu_model_runner.py:5405] Model loading took 0.83 GiB memory and 3.714601 seconds
(StageEngineCoreProc_stage1_replica0 pid=99343) WARNING 08-21 09:26:01 [base.py:193] [LLM Worker 0] Sleep Mode DISABLED.
(StageEngineCoreProc_stage1_replica0 pid=99343) INFO 08-21 09:26:02 [kernel_warmup.py:256] Using FlashInfer autotune cache file: /root/.cache/vllm/flashinfer_autotune_cache/0.6.16.post3/103a/47dd92ae1cebed28777e61a67fee8cbcf06915f1a57d9374cc076eedeec6d8c8/autotune_configs.json
(StageEngineCoreProc_stage1_replica0 pid=99343) 2026-08-21 09:26:02,818 - INFO - autotuner.py:829 - flashinfer.jit: [Autotuner]: Autotuning process starts ...
Fetching 1 files: 100%|████████████████████████| 1/1 [00:00<00:00, 1093.41it/s]
Download complete: :                                       |  0.00B            (StageEngineCoreProc_stage1_replica0 pid=99343) WARNING 08-21 09:26:03 [cosyvoice3.py:959] CosyVoice3 code2wav: TensorRT estimator build failed (No module named 'tensorrt'); keeping torch estimator
Download complete: :                                       |  0.00B            
Reconstruction complete: |                        |  0.00B /  0.00B            
(StageEngineCoreProc_stage1_replica0 pid=99343) 2026-08-21 09:26:03,042 - INFO - autotuner.py:852 - flashinfer.jit: [Autotuner]: Autotuning process ends
(StageEngineCoreProc_stage1_replica0 pid=99343) 2026-08-21 09:26:03,048 - INFO - autotuner.py:2269 - flashinfer.jit: [Autotuner]: Saved 0 configs to /root/.cache/vllm/flashinfer_autotune_cache/0.6.16.post3/103a/47dd92ae1cebed28777e61a67fee8cbcf06915f1a57d9374cc076eedeec6d8c8/autotune_configs.json (0 new, 0 from previous config)
(StageEngineCoreProc_stage1_replica0 pid=99343) WARNING 08-21 09:26:03 [gpu_generation_model_runner.py:577] Dummy sampler run is not implemented for generation model
(StageEngineCoreProc_stage1_replica0 pid=99343) INFO 08-21 09:26:03 [jit_monitor.py:79] Kernel JIT monitor activated; monitored JIT compilations during inference will use mode=warn.
(StageEngineCoreProc_stage1_replica0 pid=99343) INFO 08-21 09:26:04 [core.py:355] init engine (profile, create kv cache, warmup model) took 2.24 s
(StageEngineCoreProc_stage1_replica0 pid=99343) WARNING 08-21 09:26:04 [scheduler.py:182] Using custom scheduler class vllm_omni.core.sched.omni_generation_scheduler.OmniGenerationScheduler. This scheduler interface is not public and compatibility may not be maintained. If you have subclassed Scheduler instead of AsyncScheduler, you will see degraded performance due to async scheduling being disabled.
(StageEngineCoreProc_stage1_replica0 pid=99343) WARNING 08-21 09:26:04 [core.py:153] Disabling chunked prefill for model without KVCache
(StageEngineCoreProc_stage1_replica0 pid=99343) INFO 08-21 09:26:04 [factory.py:46] Created connector: SharedMemoryConnector
(StageEngineCoreProc_stage1_replica0 pid=99343) WARNING 08-21 09:26:04 [vllm.py:1194] Enforce eager set, disabling torch.compile and CUDAGraphs. This is equivalent to setting -cc.mode=none -cc.cudagraph_mode=none
(StageEngineCoreProc_stage1_replica0 pid=99343) WARNING 08-21 09:26:04 [vllm.py:1247] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(APIServer pid=97591) INFO 08-21 09:26:04 [stage_runtime.py:595] [StageRuntime] Stage 1 engine startup completed
(APIServer pid=97591) INFO 08-21 09:26:04 [stage_engine_core_client.py:157] [StageEngineCoreClient] stage-1 [rep-0] initializing EngineCore
(StageEngineCoreProc_stage1_replica0 pid=99343) INFO 08-21 09:26:04 [kernel.py:306] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['vllm_c', 'native'], fused_add_rms_norm=['vllm_c', 'native'])
(StageEngineCoreProc_stage1_replica0 pid=99343) INFO 08-21 09:26:04 [vllm.py:1426] Cudagraph is disabled under eager mode
(StageEngineCoreProc_stage1_replica0 pid=99343) INFO 08-21 09:26:04 [compilation.py:329] Enabled custom fusions: norm_quant, act_quant
(APIServer pid=97591) INFO 08-21 09:26:04 [stage_engine_core_client.py:213] [StageEngineCoreClient] stage-1 [rep-0] EngineCore running
(APIServer pid=97591) INFO 08-21 09:26:04 [stage_runtime.py:610] [StageRuntime] Stage 1 initialized
(APIServer pid=97591) WARNING 08-21 09:26:07 [cosyvoice3.py:162] CosyVoice3: TensorRT campplus build failed (No module named 'tensorrt'); falling back to ONNX-Runtime speaker embedding
(APIServer pid=97591) INFO 08-21 09:26:07 [speaker_cache.py:242] Speaker cache ready (max_bytes=536870912)
(APIServer pid=97591) INFO 08-21 09:26:15 [orchestrator.py:527] [Orchestrator] Starting event loop
(APIServer pid=97591) INFO 08-21 09:26:15 [async_omni_engine.py:268] [AsyncOmniEngine] Orchestrator ready with 2 stages
(APIServer pid=97591) INFO 08-21 09:26:15 [omni_base.py:213] [AsyncOmni] AsyncOmniEngine initialized in 127.81 seconds
(APIServer pid=97591) INFO 08-21 09:26:15 [omni_base.py:233] [AsyncOmni] Initialized with 2 stages for model /proj-tango-pvc/users/zhipeng.wang/models/Fun-CosyVoice3-0.5B-2512
(APIServer pid=97591) INFO 08-21 09:26:15 [api_server.py:853] Supported tasks: {'generate', 'speech'}
(APIServer pid=97591) INFO 08-21 09:26:16 [hf.py:540] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
(APIServer pid=97591) INFO 08-21 09:26:17 [base.py:235] Multi-modal warmup completed in 0.632s
(APIServer pid=97591) INFO 08-21 09:26:17 [serving_speech.py:320] Speaker storage: dir=/root/.cache/vllm-omni/speakers, max_speakers=1000, restored=0
(APIServer pid=97591) INFO 08-21 09:26:17 [serving_speech.py:479] No built-in speakers configured; only 'default' and uploaded voices are available
(APIServer pid=97591) WARNING 08-21 09:26:17 [serving_speech.py:650] Failed to load codec frame rate from speech tokenizer config: /proj-tango-pvc/users/zhipeng.wang/models/Fun-CosyVoice3-0.5B-2512 does not appear to have a file named speech_tokenizer/config.json. Checkout 'https://huggingface.co//proj-tango-pvc/users/zhipeng.wang/models/Fun-CosyVoice3-0.5B-2512/tree/main' for available files.
(APIServer pid=97591) INFO 08-21 09:26:17 [serving_speech.py:507] Resolved TTS serving adapter: CosyVoice3Adapter
(APIServer pid=97591) INFO 08-21 09:26:17 [serving.py:45] OpenAIServingRealtime initialized for task: realtime
(APIServer pid=97591) INFO 08-21 09:26:17 [api_server.py:565] Starting vLLM API server 0 on http://127.0.0.1:8091
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:37] Available routes are:
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /openapi.json, Methods: GET, HEAD
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /docs, Methods: GET, HEAD
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /docs/oauth2-redirect, Methods: GET, HEAD
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /redoc, Methods: GET, HEAD
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /load, Methods: GET
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /version, Methods: GET
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /metrics, Methods: GET
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /tokenize, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /detokenize, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /ping, Methods: GET
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /ping, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/responses, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/completions, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/messages, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/messages/count_tokens, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /generative_scoring, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/chat/completions/render, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/completions/render, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/chat/completions/derender, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/completions/derender, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /inference/v1/generate, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/chat/completions, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/chat/completions/batch, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/audio/speech, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/audio/speech/batch, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/audio/generate, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/audio/voices, Methods: GET
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/audio/voices, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/audio/voices/{name}, Methods: DELETE
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/models, Methods: GET
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/images/generations, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/images/edits, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/videos, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/videos/sync, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/videos, Methods: GET
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/videos/{video_id}, Methods: GET
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/videos/{video_id}, Methods: DELETE
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/videos/{video_id}/content, Methods: GET
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/omni/sleep, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:46] Route: /v1/omni/wakeup, Methods: POST
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:57] Route: /v1/audio/speech/stream, Endpoint: streaming_speech
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:57] Route: /v1/video/chat/stream, Endpoint: streaming_video_chat
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:57] Route: /v1/realtime/video, Endpoint: streaming_video_output
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:57] Route: /v1/realtime, Endpoint: realtime_websocket
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:57] Route: /v1/realtime/robot/openpi, Endpoint: realtime_robot_openpi
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:57] Route: /v1/duplex, Endpoint: duplex_websocket
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:99] API server: waiting for HTTP server to start
(APIServer pid=97591) INFO:     Started server process [97591]
(APIServer pid=97591) INFO:     Waiting for application startup.
(APIServer pid=97591) INFO:     Application startup complete.
(APIServer pid=97591) INFO 08-21 09:26:17 [launcher.py:105] API server: HTTP server started
(APIServer pid=97591) ERROR 08-21 09:26:48 [serving_speech.py:3545] Error with model error=ErrorInfo(message='The model `FunAudioLLM/Fun-CosyVoice3-0.5B-2512` does not exist.', type='NotFoundError', param='model', code=404)
(APIServer pid=97591) INFO:     127.0.0.1:50834 - "POST /v1/audio/speech HTTP/1.1" 404 Not Found
(APIServer pid=97591) INFO 08-21 09:27:24 [serving_speech.py:3083] TTS speech request speech-acb2165de0e70e42: model=cosyvoice3
(APIServer pid=97591) INFO 08-21 09:27:24 [cosyvoice3.py:108] CosyVoice3 dynamic tokens: text_tokens=13, min_tokens=26, max_tokens=260
(APIServer pid=97591) INFO:     127.0.0.1:39602 - "POST /v1/audio/speech HTTP/1.1" 200 OK
(APIServer pid=97591) WARNING 08-21 09:27:24 [input_processor.py:291] Passing raw prompts to InputProcessor is deprecated and will be removed in v0.18. You should instead pass the outputs of Renderer.render_cmpl() or Renderer.render_chat().
(StageEngineCoreProc_stage1_replica0 pid=99343) WARNING 08-21 09:27:26 [jit_monitor.py:135] Triton kernel JIT compilation during inference: SnakeBeta._init_triton.<locals>._kernel. This causes a latency spike; consider extending warmup to cover this shape/config.
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:776] 
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:776] [Overall Summary]
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:776] +-----------------------------+-----------+
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:776] | Field                       |     Value |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:776] +-----------------------------+-----------+
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:776] | e2e_requests                |         1 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:776] | e2e_wall_time_ms            | 2,938.887 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:776] | e2e_total_tokens            |       211 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:776] | e2e_avg_time_per_request_ms | 2,938.887 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:776] | e2e_avg_tokens_per_s        |    71.796 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:776] | input_preprocess_time_ms    |   135.477 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:776] | e2e_stage_0_wall_time_ms    |   452.645 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:776] | e2e_stage_1_wall_time_ms    | 2,801.328 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:776] +-----------------------------+-----------+
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:802] 
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:802] [RequestE2EStats [request_id=speech-acb2165de0e70e42-b06abe2c]]
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:802] +------------------+-----------+
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:802] | Field            |     Value |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:802] +------------------+-----------+
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:802] | e2e_total_ms     | 2,802.783 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:802] | e2e_total_tokens |       211 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:802] +------------------+-----------+
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:843] [OmniTiming] req=speech-acb2165de0e70e42-b06abe2c total=2.80s preprocess=0.14s engine=2.67s stages=[0:0.45s,1:2.80s] transfers=[0->1=0.00ms]
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] 
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] [StageRequestStats [request_id=speech-acb2165de0e70e42-b06abe2c]]
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] +---------------------------------+--------------+---------------+
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] | Field                           |            0 |             1 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] +---------------------------------+--------------+---------------+
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] | audio_duration_s                |        0.000 |         3.440 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] | audio_generated_frames          |            0 |        82,560 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] | audio_sample_rate               |            0 |        24,000 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] | batch_id                        |            1 |             1 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] | batch_size                      |            1 |             1 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] | inter_output_latencies_ms       | 3.525 (n=86) | 388.464 (n=2) |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] | inter_output_latency_ms         |        3.525 |       388.464 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] | num_tokens_in                   |          124 |             0 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] | num_tokens_out                  |           87 |             0 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] | output_unit_count               |           87 |        40,320 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] | output_unit_type                |       stream |         audio |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] | serving_time_to_first_output_ms |      284.858 |     2,160.672 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] | stage_gen_time_ms               |      451.688 |     2,800.195 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] | time_per_output_unit_ms         |        3.526 |         0.000 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] | vllm_itl_ms                     |        3.533 |       388.537 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] | vllm_itls_ms                    | 3.533 (n=86) | 388.537 (n=2) |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] | vllm_tpot_ms                    |        3.533 |         0.000 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] | vllm_ttft_ms                    |      284.403 |     2,022.617 |
(APIServer pid=97591) INFO 08-21 09:27:27 [stats.py:885] +---------------------------------+--------------+---------------+
(APIServer pid=97591) INFO 08-21 09:27:27 [serving_speech.py:2333] [SpeechE2E] request_id=speech-acb2165de0e70e42 stream=true status=ok total_ms=2981.68 first_chunk_ms=2180.89
```

