### PR TITLE
[diffusion][perf] PP-aware Layerwise Offloading

### DIFF
--- a/tests/diffusion/offloader/test_distributed_layerwise_backend.py
+++ b/tests/diffusion/offloader/test_distributed_layerwise_backend.py
@@ -14,6 +14,7 @@ import torch.distributed as dist
 from safetensors.torch import save_file
 from torch import nn
 from torch.distributed.tensor import DeviceMesh, DTensor, Replicate
+from vllm.model_executor.models.utils import PPMissingLayer
 
 import vllm_omni.diffusion.offloader.distributed_layerwise_backend as dist_backend_module
 from tests.helpers.runtime import get_distributed_init_method
@@ -864,6 +865,24 @@ class TestGetBlocksFromDit:
         attr_names, blocks = get_blocks_from_dit(model)
         assert attr_names == []
         assert blocks == []
+
+    def test_get_blocks_from_dit_pp_last_stage_uses_local_slice(self):
+        class _PPSplitBlockModel(nn.Module):
+            _layerwise_offload_blocks_attrs = ["blocks"]
+
+            def __init__(self):
+                super().__init__()
+                self.start_layer = 4
+                self.end_layer = 8
+                self.blocks = nn.ModuleList(
+                    [_DummyBlock() if 4 <= index < 8 else PPMissingLayer() for index in range(8)]
+                )
+
+        model = _PPSplitBlockModel()
+        _, blocks = get_blocks_from_dit(model)
+        assert len(blocks) == 4
+        assert blocks[0] is model.blocks[4]
+        assert blocks[-1] is model.blocks[7]
 
 
 class TestGetBlocksAttrNames:

--- a/tests/diffusion/offloader/test_layerwise_backend.py
+++ b/tests/diffusion/offloader/test_layerwise_backend.py
@@ -11,6 +11,7 @@ import torch
 import torch.distributed as dist
 from torch import nn
 from torch.distributed.tensor import DeviceMesh, DTensor, Replicate
+from vllm.model_executor.models.utils import PPMissingLayer
 
 import vllm_omni.diffusion.offloader.layerwise_backend as layerwise_backend_module
 from tests.helpers.runtime import get_distributed_init_method
@@ -188,6 +189,31 @@ class _NoAttrsModel(nn.Module):
         self.blocks = nn.ModuleList([_DummyBlock() for _ in range(num_blocks)])
 
 
+class _PPSplitBlockModel(nn.Module):
+    _layerwise_offload_blocks_attrs = ["blocks"]
+
+    def __init__(self, num_layers: int, start_layer: int, end_layer: int):
+        super().__init__()
+        self.start_layer = start_layer
+        self.end_layer = end_layer
+        self.blocks = nn.ModuleList(
+            [_DummyBlock() if start_layer <= index < end_layer else PPMissingLayer() for index in range(num_layers)]
+        )
+
+
+class _MultiBlockWithUnrelatedPPSlice(nn.Module):
+    """start_layer/end_layer must not slice every block container."""
+
+    _layerwise_offload_blocks_attrs = ["transformer_blocks", "single_transformer_blocks"]
+
+    def __init__(self):
+        super().__init__()
+        self.start_layer = 0
+        self.end_layer = 1
+        self.transformer_blocks = nn.ModuleList([_DummyBlock() for _ in range(2)])
+        self.single_transformer_blocks = nn.ModuleList([_DummyBlock() for _ in range(3)])
+
+
 class TestGetBlocksFromDit:
     def test_get_blocks_from_dit_single_block_attr(self):
         model = _SingleBlockModel(num_blocks=3)
@@ -228,6 +254,38 @@ class TestGetBlocksFromDit:
         attr_names, blocks = LayerWiseOffloadBackend.get_blocks_from_dit(model)
         assert attr_names == ["blocks"]
         assert len(blocks) == 2
+
+    def test_get_blocks_from_dit_pp_first_stage_uses_local_slice(self):
+        model = _PPSplitBlockModel(num_layers=8, start_layer=0, end_layer=4)
+        attr_names, blocks = LayerWiseOffloadBackend.get_blocks_from_dit(model)
+        assert attr_names == ["blocks"]
+        assert len(blocks) == 4
+        assert blocks[0] is model.blocks[0]
+        assert blocks[-1] is model.blocks[3]
+        assert all(not isinstance(block, PPMissingLayer) for block in blocks)
+
+    def test_get_blocks_from_dit_pp_last_stage_ring_wraps_local_slice(self):
+        model = _PPSplitBlockModel(num_layers=8, start_layer=4, end_layer=8)
+        _, blocks = LayerWiseOffloadBackend.get_blocks_from_dit(model)
+        assert len(blocks) == 4
+        assert blocks[0] is model.blocks[4]
+        assert blocks[-1] is model.blocks[7]
+        assert all(block is model.blocks[4 + index] for index, block in enumerate(blocks))
+
+    def test_get_blocks_from_dit_pp_missing_layers_without_start_end(self):
+        model = _PPSplitBlockModel(num_layers=6, start_layer=2, end_layer=5)
+        del model.start_layer
+        del model.end_layer
+        _, blocks = LayerWiseOffloadBackend.get_blocks_from_dit(model)
+        assert len(blocks) == 3
+        assert blocks[0] is model.blocks[2]
+        assert blocks[-1] is model.blocks[4]
+
+    def test_get_blocks_from_dit_unrelated_start_end_does_not_slice_other_attrs(self):
+        model = _MultiBlockWithUnrelatedPPSlice()
+        _, blocks = LayerWiseOffloadBackend.get_blocks_from_dit(model)
+        assert len(blocks) == 5
+        assert all(isinstance(block, _DummyBlock) for block in blocks)
 
 
 class TestGetBlocksAttrNames:

--- a/tests/diffusion/offloader/test_layerwise_backend.py
+++ b/tests/diffusion/offloader/test_layerwise_backend.py
@@ -15,6 +15,7 @@ from vllm.model_executor.models.utils import PPMissingLayer
 
 import vllm_omni.diffusion.offloader.layerwise_backend as layerwise_backend_module
 from tests.helpers.runtime import get_distributed_init_method
+from vllm_omni.diffusion.offloader.base import OffloadConfig, OffloadStrategy
 from vllm_omni.diffusion.offloader.layerwise_backend import LayerWiseOffloadBackend, LayerwiseOffloadHook
 from vllm_omni.platforms import current_omni_platform
 
@@ -201,6 +202,12 @@ class _PPSplitBlockModel(nn.Module):
         )
 
 
+class _PPSplitPipeline(nn.Module):
+    def __init__(self, num_layers: int, start_layer: int, end_layer: int):
+        super().__init__()
+        self.transformer = _PPSplitBlockModel(num_layers, start_layer, end_layer)
+
+
 class _MultiBlockWithUnrelatedPPSlice(nn.Module):
     """start_layer/end_layer must not slice every block container."""
 
@@ -212,6 +219,35 @@ class _MultiBlockWithUnrelatedPPSlice(nn.Module):
         self.end_layer = 1
         self.transformer_blocks = nn.ModuleList([_DummyBlock() for _ in range(2)])
         self.single_transformer_blocks = nn.ModuleList([_DummyBlock() for _ in range(3)])
+
+
+class TestLayerWiseOffloadBackend:
+    def test_enable_installs_hooks_only_on_local_pp_blocks_and_wraps_ring(self, patched_offload_runtime):
+        pipeline = _PPSplitPipeline(num_layers=8, start_layer=4, end_layer=8)
+        backend = LayerWiseOffloadBackend(
+            OffloadConfig(strategy=OffloadStrategy.LAYER_WISE, pin_cpu_memory=False),
+            torch.device("cpu"),
+        )
+
+        backend.enable(pipeline)
+
+        blocks = pipeline.transformer.blocks
+        hook_name = LayerwiseOffloadHook._HOOK_NAME
+        hooked_indices = [
+            index
+            for index, block in enumerate(blocks)
+            if (registry := getattr(block, "_hook_registry", None)) is not None and hook_name in registry._hooks
+        ]
+        assert hooked_indices == [4, 5, 6, 7]
+
+        first_local_hook = blocks[4]._hook_registry._hooks[hook_name]
+        last_local_hook = blocks[7]._hook_registry._hooks[hook_name]
+        assert first_local_hook.next_block is blocks[5]
+        assert last_local_hook.next_block is blocks[4]
+        assert first_local_hook._prev_hook is last_local_hook
+        assert backend._blocks == [[blocks[4], blocks[5], blocks[6], blocks[7]]]
+
+        backend.disable()
 
 
 class TestGetBlocksFromDit:

--- a/vllm_omni/diffusion/offloader/block_discovery.py
+++ b/vllm_omni/diffusion/offloader/block_discovery.py
@@ -23,33 +23,21 @@ def select_local_offload_blocks(model: nn.Module, modules: list[nn.Module]) -> l
 
     Pipeline-parallel DiTs built with vLLM ``make_layers`` store a full-length
     ``ModuleList`` and fill non-local slots with ``PPMissingLayer``. The offload
-    hook ring must cover only ``blocks[start_layer:end_layer]`` so the last
-    local layer prefetches the first local layer of the next forward.
+    hook ring must skip those placeholders so the last local layer prefetches
+    the first local layer of the next forward.
     """
     if not modules:
         return []
 
-    start = getattr(model, "start_layer", None)
-    end = getattr(model, "end_layer", None)
-    n_executable = sum(1 for module in modules if not _is_pp_missing_layer(module))
-    if (
-        isinstance(start, int)
-        and isinstance(end, int)
-        and 0 <= start < end <= len(modules)
-        and (end - start) == n_executable
-    ):
-        sliced = modules[start:end]
-        if sliced and not any(_is_pp_missing_layer(module) for module in sliced):
-            if len(sliced) != len(modules):
-                logger.info(
-                    "Restricting layerwise offload ring to local PP slice [%d, %d) (%d blocks)",
-                    start,
-                    end,
-                    len(sliced),
-                )
-            return list(sliced)
+    executable_modules = [module for module in modules if not _is_pp_missing_layer(module)]
+    if len(executable_modules) != len(modules):
+        logger.info(
+            "Filtered layerwise offload ring from %d blocks to %d executable blocks",
+            len(modules),
+            len(executable_modules),
+        )
 
-    return [module for module in modules if not _is_pp_missing_layer(module)]
+    return executable_modules
 
 
 def get_blocks_attr_names(model: nn.Module) -> list[str]:
@@ -77,9 +65,9 @@ def set_blocks_attr_names(model: nn.Module, names: list[str]) -> None:
 def get_blocks_from_dit(model: nn.Module) -> tuple[list[str], list[nn.Module]]:
     """Retrieve executable blocks and attribute names from a DiT model.
 
-    Each declared block container is reduced to this rank's local PP slice
-    before containers are concatenated, so the prefetch ring wraps inside a
-    pipeline stage rather than across ``PPMissingLayer`` placeholders.
+    Each declared block container is filtered before containers are concatenated,
+    so the prefetch ring wraps inside executable layers rather than across
+    ``PPMissingLayer`` placeholders.
     """
     blocks_attr_names = get_blocks_attr_names(model)
     if not blocks_attr_names:

--- a/vllm_omni/diffusion/offloader/block_discovery.py
+++ b/vllm_omni/diffusion/offloader/block_discovery.py
@@ -9,8 +9,47 @@ from __future__ import annotations
 
 from torch import nn
 from vllm.logger import init_logger
+from vllm.model_executor.models.utils import PPMissingLayer
 
 logger = init_logger(__name__)
+
+
+def _is_pp_missing_layer(module: nn.Module) -> bool:
+    return isinstance(module, PPMissingLayer)
+
+
+def select_local_offload_blocks(model: nn.Module, modules: list[nn.Module]) -> list[nn.Module]:
+    """Keep the blocks that actually run on this rank for the prefetch ring.
+
+    Pipeline-parallel DiTs built with vLLM ``make_layers`` store a full-length
+    ``ModuleList`` and fill non-local slots with ``PPMissingLayer``. The offload
+    hook ring must cover only ``blocks[start_layer:end_layer]`` so the last
+    local layer prefetches the first local layer of the next forward.
+    """
+    if not modules:
+        return []
+
+    start = getattr(model, "start_layer", None)
+    end = getattr(model, "end_layer", None)
+    n_executable = sum(1 for module in modules if not _is_pp_missing_layer(module))
+    if (
+        isinstance(start, int)
+        and isinstance(end, int)
+        and 0 <= start < end <= len(modules)
+        and (end - start) == n_executable
+    ):
+        sliced = modules[start:end]
+        if sliced and not any(_is_pp_missing_layer(module) for module in sliced):
+            if len(sliced) != len(modules):
+                logger.info(
+                    "Restricting layerwise offload ring to local PP slice [%d, %d) (%d blocks)",
+                    start,
+                    end,
+                    len(sliced),
+                )
+            return list(sliced)
+
+    return [module for module in modules if not _is_pp_missing_layer(module)]
 
 
 def get_blocks_attr_names(model: nn.Module) -> list[str]:
@@ -36,12 +75,16 @@ def set_blocks_attr_names(model: nn.Module, names: list[str]) -> None:
 
 
 def get_blocks_from_dit(model: nn.Module) -> tuple[list[str], list[nn.Module]]:
-    """Retrieve blocks and attribute names from provided DiT model."""
+    """Retrieve executable blocks and attribute names from a DiT model.
+
+    Each declared block container is reduced to this rank's local PP slice
+    before containers are concatenated, so the prefetch ring wraps inside a
+    pipeline stage rather than across ``PPMissingLayer`` placeholders.
+    """
     blocks_attr_names = get_blocks_attr_names(model)
     if not blocks_attr_names:
         logger.warning(
-            f"No _layerwise_offload_blocks_attrs defined for {model.__class__.__name__}, "
-            "skipping distributed layerwise offloading"
+            f"No _layerwise_offload_blocks_attrs defined for {model.__class__.__name__}, skipping layerwise offloading"
         )
         return [], []
 
@@ -54,7 +97,7 @@ def get_blocks_from_dit(model: nn.Module) -> tuple[list[str], list[nn.Module]]:
                 f"does not exist on model {model.__class__.__name__}"
             )
         try:
-            attr_iter = iter(attr)
+            collected = list(iter(attr))
         except TypeError:
             if isinstance(attr, nn.Module):
                 logger.warning(
@@ -62,21 +105,20 @@ def get_blocks_from_dit(model: nn.Module) -> tuple[list[str], list[nn.Module]]:
                     name,
                     model.__class__.__name__,
                 )
-                blocks.append(attr)
+                collected = [attr]
+            else:
+                logger.warning(
+                    "Attribute '%s' on %s is not iterable (got %s); skipping it.",
+                    name,
+                    model.__class__.__name__,
+                    type(attr).__name__,
+                )
                 continue
-
-            logger.warning(
-                "Attribute '%s' on %s is not iterable (got %s); skipping it.",
-                name,
-                model.__class__.__name__,
-                type(attr).__name__,
-            )
-        else:
-            blocks.extend(attr_iter)
+        blocks.extend(select_local_offload_blocks(model, collected))
 
     if not blocks:
         logger.warning(
-            "No blocks found in %s for %s, skipping distributed layerwise offloading",
+            "No blocks found in %s for %s, skipping layerwise offloading",
             blocks_attr_names,
             model.__class__.__name__,
         )

--- a/vllm_omni/diffusion/offloader/layerwise_backend.py
+++ b/vllm_omni/diffusion/offloader/layerwise_backend.py
@@ -14,6 +14,7 @@ from vllm_omni.diffusion.hooks import HookRegistry, ModelHook
 from vllm_omni.platforms import current_omni_platform
 
 from .base import OffloadBackend, OffloadConfig
+from .block_discovery import get_blocks_from_dit as discover_offload_blocks
 from .module_collector import ModuleDiscovery
 
 logger = init_logger(__name__)
@@ -390,9 +391,9 @@ class LayerWiseOffloadBackend(OffloadBackend):
                 if buffer is not None:
                     buffer.data = buffer.data.to(self.device, non_blocking=True)
 
-            # Pre-fetch the first layer by manually calling the hook function on the last layer;
-            # For subsequent requests, the first layer/block will be pre-fetched
-            # during the last layer compute of the previous request.
+            # Prefetch ring is local to this rank: last executable layer prefetches
+            # the first executable layer. PP placeholders are excluded by discovery
+            # so wrap-around stays inside blocks[start_layer:end_layer].
             last_block, first_block = blocks[-1], blocks[0]
             last_hook = apply_block_hook(
                 last_block,
@@ -466,61 +467,11 @@ class LayerWiseOffloadBackend(OffloadBackend):
 
     @staticmethod
     def get_blocks_from_dit(model: nn.Module) -> tuple[list[str], list[nn.Module]]:
+        """Retrieve executable blocks for the prefetch ring.
+
+        Pipeline-parallel models keep a full-length block list with
+        ``PPMissingLayer`` placeholders. Discovery returns only
+        ``blocks[start_layer:end_layer]`` so the last local layer prefetches
+        the first local layer of the next forward.
         """
-        Retrieve blocks and attribute names from provided DiT model. Blocks attribute names
-        are found by `_layerwise_offload_blocks_attrs` set to DiT models. For example,
-
-        ```
-        class WanTransformer3DModel(nn.Module):
-            _layerwise_offload_blocks_attrs = ["blocks"]
-        ```
-
-        Returns:
-            Tuple of (blocks_attr_names, blocks)
-        """
-        blocks_attr_names = LayerWiseOffloadBackend.get_blocks_attr_names(model)
-        if not blocks_attr_names:
-            logger.warning(
-                f"No _layerwise_offload_blocks_attrs defined for {model.__class__.__name__}, "
-                "skipping layerwise offloading"
-            )
-            return [], []
-
-        blocks = []
-        for name in blocks_attr_names:
-            attr = getattr(model, name, None)
-            if attr is None:
-                raise AttributeError(
-                    f"Attribute '{name}' declared in _layerwise_offload_blocks_attrs "
-                    f"does not exist on model {model.__class__.__name__}"
-                )
-            try:
-                attr_iter = iter(attr)
-            except TypeError:
-                if isinstance(attr, nn.Module):
-                    logger.warning(
-                        "Attribute '%s' on %s is not iterable; treating it as one block.",
-                        name,
-                        model.__class__.__name__,
-                    )
-                    blocks.append(attr)
-                    continue
-
-                logger.warning(
-                    "Attribute '%s' on %s is not iterable (got %s); skipping it.",
-                    name,
-                    model.__class__.__name__,
-                    type(attr).__name__,
-                )
-            else:
-                blocks.extend(attr_iter)
-
-        if not blocks:
-            logger.warning(
-                "No blocks found in %s for %s, skipping layerwise offloading",
-                blocks_attr_names,
-                model.__class__.__name__,
-            )
-            return [], []
-
-        return blocks_attr_names, blocks
+        return discover_offload_blocks(model)


### PR DESCRIPTION
## Summary

Layerwise offload built its prefetch ring over the full DiT `ModuleList`.When pipeline parallelism of DiT is enabled (e.g., pp=2), **layerwise offload prefetch ring includes`PPMissingLayer` placeholders on non-local pipeline-parallel ranks.** Those placeholders never run, so wrap-around prefetch of the first local block never fired and every PP-stage forward fell back to a synchronous first-layer H2D.

Block discovery now keeps only `blocks[start_layer:end_layer]` (and otherwise skips `PPMissingLayer`), so each PP stage's last block prefetches that stage's first block.


## Motivation

On Wan2.2 T2V-A14B, single-GPU layerwise offload was nearly free (~0.3%). The same flag on PP=2 added ~5% e2e latency because the extra H2D sat on the PP critical path twice per CFG forward.

## Performance

Wan-AI/Wan2.2-T2V-A14B-Diffusers, 40 steps, 480x832x48, bf16, regional torch.compile, CFG sequential (`cfg_parallel_size=1`). Hardware: 2x NVIDIA H800 80GB. Software: torch 2.11.0+cu129, CUDA 12.9, vLLM 0.26.0, vLLM-Omni main. 
Command:

```bash
bash examples/offline_inference/image_to_video/wan22_i2v_pp2.sh
```
<details>
<summary><code>examples/offline_inference/image_to_video/wan22_i2v_pp2.sh</code></summary>

```bash
#!/usr/bin/env bash
# SPDX-License-Identifier: Apache-2.0
# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

set -euo pipefail

SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"

MODEL_ID="${MODEL_ID:-Wan-AI/Wan2.2-T2V-A14B-Diffusers}"

PROMPT="${PROMPT:-Cherry blossoms swaying gently in the breeze, petals falling, smooth motion.}"
NEGATIVE_PROMPT="${NEGATIVE_PROMPT:-low quality, blurry}"
OUTPUT="${OUTPUT:-wan22_t2v_14b_pp2_output.mp4}"
HEIGHT="${HEIGHT:-480}"
WIDTH="${WIDTH:-832}"
NUM_FRAMES="${NUM_FRAMES:-48}"
NUM_INFERENCE_STEPS="${NUM_INFERENCE_STEPS:-40}"
GUIDANCE_SCALE="${GUIDANCE_SCALE:-5.0}"
GUIDANCE_SCALE_HIGH="${GUIDANCE_SCALE_HIGH:-6.0}"
BOUNDARY_RATIO="${BOUNDARY_RATIO:-0.875}"
FLOW_SHIFT="${FLOW_SHIFT:-12.0}"
FPS="${FPS:-16}"
SEED="${SEED:-42}"
CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-1,2}"

cd "${REPO_ROOT}"

CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES}" python examples/offline_inference/text_to_video/text_to_video.py \
  --model="${MODEL_ID}" \
  --width="${WIDTH}" \
  --height="${HEIGHT}" \
  --num-frames "${NUM_FRAMES}" \
  --guidance-scale="${GUIDANCE_SCALE}" \
  --guidance-scale-high="${GUIDANCE_SCALE_HIGH}" \
  --prompt="${PROMPT}" \
  --negative-prompt="${NEGATIVE_PROMPT}" \
  --output="${OUTPUT}" \
  --num-inference-steps "${NUM_INFERENCE_STEPS}" --seed "${SEED}" \
  --enable-diffusion-pipeline-profiler \
  --pipeline-parallel-size 2 \
  --vae-patch-parallel-size 2 \
  --vae-use-tiling \
  --enable-layerwise-offload  \
```

</details>



| Config | Generation time | Peak reserved GPU memory |
| --- | --- | --- |
| 1 GPU | 107.6415 s | 74.54 GiB |
| 1 GPU + layerwise offload | 108.0074 s (+0.3%) | 23.34 GiB |
| 2 GPU, PP=2, VAE tiling=2 | 87.7821 s | 40.20 GiB |
| 2 GPU, PP=2, VAE tiling=2 + layerwise (before this fix) | 92.3552 s (+5.2%) | 15.91 GiB |
| 2 GPU, PP=2, VAE tiling=2 + layerwise (after this fix) | 87.8882 s (+0.1%) | 15.91 GiB |

PP=2 + layerwise now matches the no-offload PP baseline on latency while keeping the ~2.5x memory reduction (40.20 GiB → 15.91 GiB).

Logging changes:

- 2 GPU, PP=2, VAE tiling=2 + layerwise (before this fix)

```bash
INFO 08-21 09:07:28 [diffusion_model_runner.py:280] Model loading took 10.8198 GiB and 56.918684 seconds
INFO 08-21 09:07:28 [diffusion_model_runner.py:286] Model runner: Model loaded successfully.
INFO 08-21 09:07:28 [diffusion_model_runner.py:311]  Enabling offloader backend: LayerWiseOffloadBackend
INFO 08-21 09:07:28 [layerwise_backend.py:347] Applying layer-wise offloading on ['transformer', 'transformer_2']
INFO 08-21 09:07:28 [layerwise_backend.py:353] Applying hooks on transformer (WanTransformer3DModel)
INFO 08-21 09:07:41 [layerwise_backend.py:425] Layer-wise offloading enabled on 40 layers (blocks)
INFO 08-21 09:07:41 [layerwise_backend.py:353] Applying hooks on transformer_2 (WanTransformer3DModel)
INFO 08-21 09:07:42 [layerwise_backend.py:425] Layer-wise offloading enabled on 40 layers (blocks)
INFO 08-21 09:07:42 [layerwise_backend.py:353] Applying hooks on transformer_2 (WanTransformer3DModel)
INFO 08-21 09:07:54 [layerwise_backend.py:425] Layer-wise offloading enabled on 40 layers (blocks)
```
- 2 GPU, PP=2, VAE tiling=2 + layerwise (after this fix)

```bash
INFO 08-21 09:32:17 [diffusion_model_runner.py:280] Model loading took 10.8198 GiB and 93.883112 seconds
INFO 08-21 09:32:17 [diffusion_model_runner.py:286] Model runner: Model loaded successfully.
INFO 08-21 09:32:17 [diffusion_model_runner.py:311]  Enabling offloader backend: LayerWiseOffloadBackend
INFO 08-21 09:32:17 [layerwise_backend.py:348] Applying layer-wise offloading on ['transformer', 'transformer_2']
INFO 08-21 09:32:17 [layerwise_backend.py:354] Applying hooks on transformer (WanTransformer3DModel)
INFO 08-21 09:32:17 [block_discovery.py:44] Restricting layerwise offload ring to local PP slice [20, 40) (20 blocks)
INFO 08-21 09:32:23 [layerwise_backend.py:426] Layer-wise offloading enabled on 20 layers (blocks)
INFO 08-21 09:32:23 [layerwise_backend.py:354] Applying hooks on transformer_2 (WanTransformer3DModel)
INFO 08-21 09:32:23 [block_discovery.py:44] Restricting layerwise offload ring to local PP slice [0, 20) (20 blocks)
INFO 08-21 09:32:28 [layerwise_backend.py:426] Layer-wise offloading enabled on 20 layers (blocks)
INFO 08-21 09:32:28 [layerwise_backend.py:354] Applying hooks on transformer_2 (WanTransformer3DModel)
INFO 08-21 09:32:28 [block_discovery.py:44] Restricting layerwise offload ring to local PP slice [20, 40) (20 blocks)
INFO 08-21 09:32:36 [layerwise_backend.py:426] Layer-wise offloading enabled on 20 layers (blocks)
```


An example of generated video ( all runs generated the same video):

https://github.com/user-attachments/assets/d8615c77-2024-491b-a97c-449bd407f4db



## Test Plan

- [x] `python -m pytest -s -v tests/diffusion/offloader/test_layerwise_backend.py tests/diffusion/offloader/test_distributed_layerwise_backend.py::TestGetBlocksFromDit -m "core_model and cpu"`
- [x] Offline Wan2.2 T2V A14B PP=2 + VAE patch parallel + layerwise offload via `examples/offline_inference/image_to_video/wan22_i2v_pp2.sh`