### PR TITLE
[Misc] Bump diffusers pin to 0.40.0

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -12,7 +12,7 @@
 transformers >= 5.10.1, < 5.15
 av>=14.0.0
 omegaconf>=2.3.0
-diffusers==0.38.0
+diffusers==0.40.0
 safetensors>=0.8.0
 accelerate==1.12.0
 soundfile>=0.13.1


### PR DESCRIPTION
## Purpose

Was pinned exactly to 0.38.0 because diffusers 0.38.0 required a safetensors pre-release (0.8.0rc0) that pip/uv skip by default. safetensors 0.8.0 has since shipped stable and diffusers 0.40.0 depends on it as a normal release, so that constraint no longer applies.

## Test Plan

**vLLM Version:** 0.27.0

**vLLM-Omni Commit:** ac9a41dfc60a8b098ceaff17abf48dc8db08e1f7

TBD

## Test Result

TBD
