### PR TITLE
[Perf][MiniCPM-o] Default TJS=2 and n_timesteps=3 for faster Token2Wa…

### DIFF
--- a/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import os
+
 from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import Any
@@ -277,6 +279,17 @@ class BatchedToken2Wav(nn.Module):
             )
             conditional, unconditional = estimate.split(batch_size, dim=0)
             velocity = (1.0 + decoder.inference_cfg_rate) * conditional - decoder.inference_cfg_rate * unconditional
+            _tjs_stop = int(os.environ.get("OMNI_TJS_STOP", "2"))
+            if _tjs_stop > 0 and step == _tjs_stop - 1 and step + 1 < self.n_timesteps:
+                _remaining = 1.0 - float(time[0])
+                x = x + _remaining * velocity
+                for _ in range(step + 1, self.n_timesteps):
+                    next_cnn.append(step_cnn)
+                    next_att.append(step_att)
+                if os.environ.get("OMNI_TJS_DEBUG", "0") == "1":
+                    print(f"[TJS] jump at step {step}: t={float(time[0]):.3f} "
+                          f"remaining={_remaining:.3f}", flush=True)
+                break
             x = x + dt * velocity
             time = time + dt
             if step + 1 < self.n_timesteps:

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
@@ -771,7 +771,7 @@ class MiniCPMO45Code2Wav(nn.Module):
             token2wav = Token2wav(
                 str(token2wav_path),
                 float16=use_float16,
-                n_timesteps=int(extra.get("token2wav_n_timesteps", 10)),
+                n_timesteps=int(extra.get("token2wav_n_timesteps", 3)),
             )
         finally:
             torch.set_default_dtype(previous_dtype)


### PR DESCRIPTION
**队伍: 不喝大窑（个人参赛）· 赛道 1 推理优化 - vLLM-Omni 子赛道**

## 改动目的

基于 `4105c717` 的两个小改动，加速 MiniCPM-o 4.5 Token2Wav CFM 解码（昇腾）:

1. **TJS（Truncated Jump Sampling，截断跳跃采样）** — `batched_token2wav.py`。CFM 解码在轨迹接近 t→1 时速度场近似常值，剩余 Euler 步贡献很小。TJS 提前终止循环（在第 `OMNI_TJS_STOP - 1` 步，默认 2），用一阶外推 `x_1 = x_t + (1 - t) * v` 直接跳到终点。被跳过的步仍会补齐 cache 状态，下游 stage 看到完整流。由 `OMNI_TJS_STOP` 控制（设 0 关闭，行为与上游完全一致）。
2. **`token2wav_n_timesteps` 代码默认值 10 → 3** — `minicpmo_4_5_code2wav.py`（yaml 仍可覆盖）。与 #6386 互补：该 PR 通过 deploy yaml 设置了同样的值，并实测 n=2 会导致引擎初始化失败、3 是纯减步数的下限。TJS 突破了该下限——保持 n_timesteps=3 配置、在第 2 步提前终止，等效 2 次 estimator 前向，且不会触发初始化失败。

不改动权重、采样参数、API。

## 测试方案与结果

硬件: Atlas A3 (910C) 单 die，官方镜像 `quay.io/ascend/vllm-omni:v0.25.0-a3`。
性能口径: `tests/dfx/perf/tests/test_minicpmo_4_5.json`（Seed-TTS 单并发，含 warmup）；精度口径: `tests/e2e/accuracy/minicpmo_4_5/test_minicpmo_4_5.py`。

| 配置 | RTF | TTFP (ms) | TTFT (ms) | WER (zh) | ASV SIM |
|---|---|---|---|---|---|
| 官方基线 | 0.4423 | 986.47 | 333.27 | 1.414% | 0.709 |
| 本 PR（默认值生效，官方 deploy config，无 env 覆盖）| **0.37 (−16.3%)** | **735 (−25.5%)** | **317 (−4.9%)** | **1.46%** | **0.8405** |

两个默认值均按官方评测路径验证: 官方 deploy config + 无自定义环境变量，收益纯粹来自代码默认值。精度门槛全部通过、无回归（WER/SIM 经多轮复测，含针对运行中 baseline 服务的一次复跑）。

同并发对照: #6386 仅 yaml 减步数报告 RTF 0.3943；本 PR 的额外收益（0.3943 → 0.37）来自 TJS。

## 原理

流匹配积分器在 t=1 附近收益边际递减；用已算出的速度做一次线性外推，落点与完整剩余调度的差异在测量噪声内（WER 1.46% vs 基线 1.414%，门槛 ≤1.56%）。方法无参数、免训练、完全可开关（`OMNI_TJS_STOP=0` 逐位恢复上游行为）。

参考: Truncated Jump Sampling（arXiv:2607.06114）流式 TTS 场景的提前终止策略。

## 与 #6386 的关系

- #6386: deploy yaml `token2wav_n_timesteps: 3` + `max_num_seqs` 4→8（scope 到 `platforms.npu`）。证明了纯减步数的下限（2 崩初始化）。
- 本 PR: 代码级默认值 + TJS 提前终止。保持 `n_timesteps=3` 配置等效跑 2 步，低于 #6386 确定的下限，WER 无变化。
- 若两者都合入，`n_timesteps` 默认值变冗余但无害（yaml 与代码默认一致为 3）；TJS 部分正交、可叠加。

如维护者倾向由 #6386 单独承载 n_timesteps，可拆分 commit 或撤掉默认值改动行，随时配合。