### PR TITLE
[Diffusion] Add model-declared LoRA runtime with MiniMax-H3 Turbo

### DIFF
--- a/.claude/skills/add-diffusion-model/SKILL.md
+++ b/.claude/skills/add-diffusion-model/SKILL.md
@@ -260,6 +260,8 @@ Preprocessing for custom models is typically done **inside `forward()`** rather 
 
 ## Common Steps (Both Paths)
 
+If the model supports LoRA, follow the [Diffusion LoRA Runtime design](../../../docs/design/feature/diffusion_lora_runtime.md) for its model-declared loading and application hooks.
+
 ### Step 4: Register Model in registry.py
 
 Edit `vllm_omni/diffusion/registry.py`:

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -147,6 +147,7 @@ nav:
           - Distributed Layerwise: design/feature/offloader/distributed_layerwise_offload.md
         - Cache-DiT: design/feature/cache_dit.md
         - TeaCache: design/feature/teacache.md
+        - Diffusion LoRA Runtime: design/feature/diffusion_lora_runtime.md
         - Diffusion Continuous Batching: design/feature/diffusion_continuous_batching.md
     - Infrastructure and Performance:
       - Prometheus Metrics: design/metrics.md

--- a/docs/design/feature/diffusion_lora_runtime.md
+++ b/docs/design/feature/diffusion_lora_runtime.md
@@ -7,7 +7,8 @@ request-level LoRA selection. It is introduced in parallel with the legacy
 diffusion LoRA facilities. Existing models, examples, and request fields keep
 their legacy behavior until they are migrated explicitly.
 
-The first integration is MiniMax-H3 FL2VA Turbo. This initial scope supports:
+The first integration is MiniMax-H3 FL2VA, led by its Turbo deployment. This
+initial scope supports:
 
 - dynamic low-rank updates;
 - immutable startup registration;
@@ -75,6 +76,24 @@ admission. An empty or omitted composition selects the base model.
 The registry is not a default composition: registering an adapter makes it
 available but does not activate it automatically.
 
+Checkpoint format and adapter identity are independent. A model selects a
+decoder from checkpoint metadata and validates the tensors; it never selects a
+decoder from the user-provided deployment name. Multiple registered adapters
+may therefore share one format decoder while retaining distinct names, weight
+banks, and request scales.
+
+For example, a service can register two model-compatible adapters and compose
+them by name at request time:
+
+```bash
+--diffusion-lora '{"name":"fast","path":"/models/fast.safetensors"}' \
+--diffusion-lora '{"name":"style","path":"/models/style.safetensors"}'
+```
+
+```json
+{"loras":[{"name":"fast","scale":1.0},{"name":"style","scale":0.7}]}
+```
+
 ## Composition and execution
 
 For a base linear transform `W` and selected low-rank updates `(A_i, B_i)`, the
@@ -124,10 +143,12 @@ The first implementation has the following feature boundaries:
 
 ## MiniMax-H3 integration
 
-MiniMax-H3 owns the LightX2V Turbo v1.0 conversion. Its loader validates the
-rank-128, alpha-128 contract, maps Diffusers targets to native H3 modules,
-binds Q/K/V updates to packed QKV projections, and swaps the Diffusers FFN
-`lora_B` row order from `[value; gate]` to native `[gate; up]`.
+MiniMax-H3 owns both the LightX2V Turbo v1.0 conversion and normalization of
+the native H3 FL2VA fused-QKV layout. The Turbo path validates its rank-128,
+alpha-128 contract and swaps the Diffusers FFN `lora_B` row order from
+`[value; gate]` to native `[gate; up]`; the native path reads its declared rank
+and splits fused QKV updates into logical Q/K/V bindings. This format support
+does not endorse or register a specific third-party adapter.
 
 Sampling steps, flow shifts, task selection, and other recipe behavior remain
 pipeline/request concerns. Installing a Turbo adapter does not silently change

--- a/docs/design/feature/diffusion_lora_runtime.md
+++ b/docs/design/feature/diffusion_lora_runtime.md
@@ -1,0 +1,151 @@
+# Diffusion LoRA Runtime
+
+## Status and scope
+
+The Diffusion LoRA Runtime is a model-declared, startup-loaded backend for
+request-level LoRA selection. It is introduced in parallel with the legacy
+diffusion LoRA facilities. Existing models, examples, and request fields keep
+their legacy behavior until they are migrated explicitly.
+
+The first integration is MiniMax-H3 FL2VA Turbo. This initial scope supports:
+
+- dynamic low-rank updates;
+- immutable startup registration;
+- request selection by registered name and scale;
+- weighted compositions of multiple registered adapters;
+- request and step batching;
+- tensor-parallel linear layers; and
+- eager and regional `torch.compile` execution.
+
+It intentionally does not provide prefusion, request-time downloads, mutable
+adapter caches, runtime add/remove/pin operations, image API integration, or
+CPU and layerwise offload.
+
+## Motivation
+
+Diffusion LoRA publications are not uniform. Models may use different key
+layouts, packed projections, tensor row orders, intrinsic scales, and update
+semantics. Treating those differences as branches in one generic checkpoint
+converter makes model correctness and feature compatibility difficult to
+review.
+
+The runtime therefore standardizes lifecycle and request behavior while each
+model owns interpretation of its published checkpoint.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    D[Startup declarations] --> L[Model-owned loader]
+    L --> U[Normalized updates]
+    U --> B[Binding plan]
+    B --> E[Fixed executor banks]
+    R[Request names and scales] --> A[Engine admission]
+    A --> S[Composition-aware scheduler]
+    S --> E
+    E --> M[Model execution]
+```
+
+Each model declares a `DiffusionLoRASupport` with three extension points:
+
+1. **Loader factory:** reads the model's publication format and emits
+   `LowRankUpdate` objects.
+2. **Binding plan:** allowlists pipeline components and logical target modules,
+   including mappings from logical projections to packed physical modules.
+3. **Executor factory:** installs and applies the normalized updates. The
+   default executor supports common replicated, column-parallel,
+   row-parallel, merged-column, and packed-QKV linear layers. A model can
+   provide another executor when its update math is genuinely different.
+
+The common runtime does not guess checkpoint semantics from model names or
+tensor shapes. A pipeline that does not declare support fails startup when the
+new runtime is enabled.
+
+## Deployment and request contracts
+
+`--enable-diffusion-lora` enables the new runtime. Each repeatable
+`--diffusion-lora` value registers one immutable `{name, path}` deployment.
+The path is resolved and loaded during worker startup.
+
+Requests contain only `{name, scale}` selections. They cannot supply paths or
+IDs and therefore cannot download or replace weights while the service is
+running. The engine rejects disabled or unknown selections before scheduler
+admission. An empty or omitted composition selects the base model.
+
+The registry is not a default composition: registering an adapter makes it
+available but does not activate it automatically.
+
+## Composition and execution
+
+For a base linear transform `W` and selected low-rank updates `(A_i, B_i)`, the
+default executor computes
+
+$$
+y = Wx + \sum_i s_i B_i(A_i x).
+$$
+
+Intrinsic checkpoint scaling is folded into each adapter's runtime scale.
+Duplicate request entries with the same name are combined, zero totals are
+removed, and the result is sorted by name to form the canonical composition.
+
+All startup adapters are concatenated into fixed-shape banks. Requests mutate
+only device-resident scale buffers. This keeps the module graph and tensor
+shapes stable for compilation while preserving request-level activation.
+
+The canonical composition is part of both request-batch and step-batch
+compatibility keys. One scheduled batch therefore cannot mix different LoRA
+states.
+
+## Lifecycle and feature boundaries
+
+Initialization order is:
+
+1. load the base pipeline;
+2. load and bind immutable LoRA banks;
+3. install compile and cache wrappers; and
+4. serve name-only selections.
+
+Pipeline replacement releases both legacy and new LoRA runtime references
+before deleting the old pipeline, allowing its parameters and buffers to be
+reclaimed before the replacement is loaded.
+
+The first implementation has the following feature boundaries:
+
+| Feature | Contract |
+| --- | --- |
+| `torch.compile` | Supported because bank capacity and graph shape are fixed at startup. |
+| Tensor parallelism | Supported by the default executor for its declared linear layer types. |
+| Request/step batching | Supported; composition participates in scheduler identity. |
+| Runtime add/remove/list/pin | Rejected; the deployment registry is immutable. |
+| CPU/layerwise/DLO offload | Rejected at startup. |
+| Legacy LoRA flags and requests | Preserved for unmigrated models, but cannot be combined with the new runtime. |
+| Image API | Not part of the MiniMax-H3-first integration. |
+| Prefix-KV publication | A future cache identity must include the canonical composition before cross-request reuse is allowed. |
+
+## MiniMax-H3 integration
+
+MiniMax-H3 owns the LightX2V Turbo v1.0 conversion. Its loader validates the
+rank-128, alpha-128 contract, maps Diffusers targets to native H3 modules,
+binds Q/K/V updates to packed QKV projections, and swaps the Diffusers FFN
+`lora_B` row order from `[value; gate]` to native `[gate; up]`.
+
+Sampling steps, flow shifts, task selection, and other recipe behavior remain
+pipeline/request concerns. Installing a Turbo adapter does not silently change
+the execution plan.
+
+## Validation
+
+The runtime requires tests for:
+
+- exact single- and multi-adapter low-rank math;
+- startup parsing and immutable registration;
+- disabled and unknown request rejection before scheduler admission;
+- composition-aware request and step batching;
+- model-specific checkpoint conversion and rejection paths;
+- TP localization for every supported packed or parallel layer type;
+- pipeline replacement cleanup; and
+- eager and compiled end-to-end generation for each integrated model.
+
+Migration of existing models and examples is deliberately separate work. Each
+migration must preserve its legacy behavior until its model-owned loader,
+binding plan, execution semantics, and compatibility tests are complete.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -22,6 +22,7 @@ implementation contract; it is not, by itself, a general support claim.
 - [Async Chunk](feature/async_chunk.md)
 - [Async Diffusion Output](feature/async_diffusion_output.md)
 - [Async Omni Output Materialization](feature/omni_async_output_materialization.md)
+- [Diffusion LoRA Runtime](feature/diffusion_lora_runtime.md)
 - [Automatic Prefix Caching in Omni Models](feature/prefix_caching.md)
 - [Realtime AR-Diffusion Sessions](feature/realtime_ar_diffusion.md)
 

--- a/docs/user_guide/diffusion_features.md
+++ b/docs/user_guide/diffusion_features.md
@@ -215,7 +215,7 @@ The following tables show which models support each feature:
 | **💾CPU Offloading (Module-wise)** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❓ | ❓ | ❌ | | | | | |
 | **💾VAE Patch Parallel** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | | | | |
 | **💾FP8 Quant** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❓ | ❓ | ✅ | ✅ | ✅ | | | |
-| **🔧LoRA Inference** | ❓ | ❓ | ❓ | ❓ | ❓ | ❓ | ❓ | ❓ | ❓ | ❓ | ❓ | ❓ | | |
+| **🔧LoRA Inference** | ❓ | ❓ | ✅ | ❓ | ❓ | ✅ | ❓ | ❓ | ❌ | ❌ | ✅ | ❓ | | |
 | **🔄Step Execution** | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❓ | ❓ | ✅ | ❓ | ✅ | ✅ | ✅ | |
 
 !!! info
@@ -229,7 +229,14 @@ The following tables show which models support each feature:
        Multi-device Distributed Layerwise Offload has a separate topology and
        compatibility matrix in the [Distributed Layerwise Offloading guide](diffusion/offloader/distributed_layerwise_offload.md).
     5. The compatibility matrix uses FP8 as the representative quantization method.
-    6. Step Execution is not compatible with any diffusion cache backend. LoRA is supported, but each scheduled batch must use a single adapter (requests with different `lora_request` or `lora_scale` are kept in separate batches).
+    6. Step Execution is not compatible with any diffusion cache backend. LoRA
+       is supported, but a scheduled batch must use one LoRA state. The legacy
+       backend separates requests by `lora_request` and `lora_scale`; the
+       model-declared Diffusion LoRA Runtime separates them by the canonical
+       `loras` composition. The legacy and new request fields cannot be mixed.
+    7. LoRA support is model- and backend-specific. The verified combinations
+       in this matrix include the model-declared Diffusion LoRA Runtime; consult
+       the model recipe before enabling it.
 
 
 ## Multi-Thread Weight Loading

--- a/recipes/MiniMaxAI/MiniMax-H3.md
+++ b/recipes/MiniMaxAI/MiniMax-H3.md
@@ -541,6 +541,48 @@ functional-correctness validations, not tuned throughput; the first request
 includes lazy regional compilation. MI325X (gfx942) and other MI355X SKUs are not
 listed until their own evidence is added.
 
+## FL2VA LoRA runtime
+
+MiniMax-H3 supports the model-declared Diffusion LoRA Runtime for its FL2VA
+transformer. Register immutable adapters when a no-offload FL2VA service starts;
+requests then select registered names and scales without supplying paths. For
+example, append these flags to the four-GPU service command above and change it
+to an FL2VA-only service:
+
+```bash
+--task-type fl2va \
+--enable-diffusion-lora \
+--diffusion-lora '{"name":"turbo","path":"lightx2v/Minimax-h3-Turbo"}'
+```
+
+Select Turbo explicitly in a T2VA or FL2VA request:
+
+```bash
+curl -sS -X POST "http://127.0.0.1:${PORT}/v1/videos/sync" \
+  -F 'prompt=A singer performs on an open-air stage with synchronized vocals.' \
+  -F 'width=1344' \
+  -F 'height=768' \
+  -F 'fps=24' \
+  -F 'num_inference_steps=5' \
+  -F 'flow_shift=6' \
+  -F 'seed=42' \
+  -F 'loras=[{"name":"turbo","scale":1.0}]' \
+  -F 'extra_params={"task":"t2va","duration":4.5,"audio_flow_shift":3.0}' \
+  -o h3_turbo.mp4
+```
+
+Five sigma points produce the four Transformer evaluations expected by this
+Turbo checkpoint. LoRA selection does not change steps, flow shifts, or other
+sampling parameters. Omitting `loras` (or sending `[]`) uses the base model. To
+compose adapters, repeat `--diffusion-lora` at startup and list their registered
+names in `loras`; all selected checkpoints must use an H3-supported publication
+format.
+
+This runtime uses `--enable-diffusion-lora`, repeatable `--diffusion-lora`, and
+the request field `loras`. Do not combine them with legacy `--lora-path` or the
+legacy request field `lora`. CPU, layerwise, and distributed layerwise offload
+are not supported in the initial runtime.
+
 ## HTTP API examples
 
 The following requests use the synchronous endpoint so the returned body can

--- a/tests/diffusion/lora_runtime/test_integration.py
+++ b/tests/diffusion/lora_runtime/test_integration.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.sched.base_scheduler import BaseScheduler
+from vllm_omni.diffusion.sched.request_scheduler import (
+    build_request_batch_sampling_params_key,
+)
+from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
+from vllm_omni.entrypoints.cli.serve import OmniServeCommand
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+from vllm_omni.utils.tracking_parser import TrackingArgumentParser
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+class _StepScheduler(BaseScheduler):
+    def update_from_output(self, sched_output, output) -> set[str]:
+        del sched_output, output
+        return set()
+
+
+def _request(name: str, scale: float) -> OmniDiffusionRequest:
+    return OmniDiffusionRequest(
+        prompt="prompt",
+        request_id=name,
+        sampling_params=OmniDiffusionSamplingParams(
+            num_inference_steps=4,
+            diffusion_loras=({"name": name, "scale": scale},),
+        ),
+    )
+
+
+def test_composition_is_part_of_both_batching_keys():
+    turbo = _request("turbo", 1.0)
+    style = _request("style", 0.5)
+
+    assert build_request_batch_sampling_params_key(turbo) != build_request_batch_sampling_params_key(style)
+    scheduler = _StepScheduler()
+    assert scheduler._build_sampling_params_key(turbo) != scheduler._build_sampling_params_key(style)
+
+
+def test_serve_cli_forwards_runtime_deployments():
+    parser = TrackingArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    OmniServeCommand().subparser_init(subparsers)
+    args = parser.parse_args(
+        [
+            "serve",
+            "MiniMaxAI/MiniMax-H3",
+            "--omni",
+            "--enable-diffusion-lora",
+            "--diffusion-lora",
+            '{"name":"turbo","path":"lightx2v/Minimax-h3-Turbo"}',
+        ]
+    )
+
+    explicit = args.get_explicit_kwargs_dict()
+    engine_args = AsyncOmniEngine._create_default_diffusion_stage_cfg(explicit)[0]["engine_args"]
+    assert engine_args["enable_diffusion_lora"] is True
+    assert engine_args["diffusion_lora"] == ['{"name":"turbo","path":"lightx2v/Minimax-h3-Turbo"}']
+
+
+def test_runtime_config_rejects_legacy_lora_path():
+    from vllm_omni.diffusion.data import OmniDiffusionConfig
+
+    with pytest.raises(ValueError, match="legacy --lora-path"):
+        OmniDiffusionConfig(
+            model="MiniMaxAI/MiniMax-H3",
+            enable_diffusion_lora=True,
+            diffusion_lora=['{"name":"turbo","path":"adapter"}'],
+            lora_path="legacy",
+            parallel_config=SimpleNamespace(world_size=1),
+        )

--- a/tests/diffusion/lora_runtime/test_integration.py
+++ b/tests/diffusion/lora_runtime/test_integration.py
@@ -5,13 +5,16 @@ from types import SimpleNamespace
 
 import pytest
 
+from vllm_omni.diffusion.diffusion_engine import DiffusionEngine
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.sched.base_scheduler import BaseScheduler
 from vllm_omni.diffusion.sched.request_scheduler import (
     build_request_batch_sampling_params_key,
 )
+from vllm_omni.diffusion.worker.diffusion_worker import DiffusionWorker
 from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
 from vllm_omni.entrypoints.cli.serve import OmniServeCommand
+from vllm_omni.errors import OmniClientError
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 from vllm_omni.utils.tracking_parser import TrackingArgumentParser
 
@@ -76,3 +79,36 @@ def test_runtime_config_rejects_legacy_lora_path():
             lora_path="legacy",
             parallel_config=SimpleNamespace(world_size=1),
         )
+
+
+def test_engine_rejects_unavailable_lora_before_admission(mocker):
+    engine = object.__new__(DiffusionEngine)
+    engine.od_config = SimpleNamespace(enable_diffusion_lora=True)
+    engine._registered_diffusion_lora_names = frozenset({"turbo"})
+    engine.pre_process_func = mocker.Mock()
+    engine._diffusion_kv_profile_limits = None
+
+    with pytest.raises(OmniClientError, match="Unknown diffusion LoRA"):
+        engine._prepare_request_for_admission(_request("unknown", 1.0))
+    engine.pre_process_func.assert_not_called()
+
+    engine.od_config.enable_diffusion_lora = False
+    with pytest.raises(OmniClientError, match="did not enable"):
+        engine._prepare_request_for_admission(_request("turbo", 1.0))
+    engine.pre_process_func.assert_not_called()
+
+
+def test_new_runtime_rejects_legacy_lora_management(mocker):
+    worker = object.__new__(DiffusionWorker)
+    worker.diffusion_lora_runtime = object()
+    worker.lora_manager = None
+
+    calls = (
+        ("add_lora", (mocker.Mock(),)),
+        ("remove_lora", (1,)),
+        ("list_loras", ()),
+        ("pin_lora", (1,)),
+    )
+    for method_name, args in calls:
+        with pytest.raises(NotImplementedError, match="immutable after startup"):
+            getattr(worker, method_name)(*args)

--- a/tests/diffusion/lora_runtime/test_runtime.py
+++ b/tests/diffusion/lora_runtime/test_runtime.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from pathlib import Path
+
+import pytest
+import torch
+import torch.nn as nn
+
+from vllm_omni.diffusion.lora_runtime import (
+    DiffusionLoRABindingPlan,
+    DiffusionLoRADeployment,
+    DiffusionLoRARuntime,
+    DiffusionLoRASelection,
+    DiffusionLoRASupport,
+    LoadedDiffusionLoRA,
+    LowRankUpdate,
+    create_low_rank_executor,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+class _StaticLoader:
+    def __init__(self, updates: dict[str, LowRankUpdate]) -> None:
+        self.updates = updates
+
+    def load(self, deployment: DiffusionLoRADeployment, artifact_path: Path) -> LoadedDiffusionLoRA:
+        assert artifact_path.is_file()
+        return LoadedDiffusionLoRA(deployment.name, (self.updates[deployment.name],))
+
+
+class _TinyPipeline(nn.Module):
+    def __init__(self, updates: dict[str, LowRankUpdate]) -> None:
+        super().__init__()
+        self.transformer = nn.Module()
+        self.transformer.proj = nn.Linear(2, 3, bias=False)
+        self.transformer.proj.weight.data.copy_(torch.arange(6, dtype=torch.float32).reshape(3, 2))
+        self.diffusion_lora_support = DiffusionLoRASupport(
+            loader_factory=lambda pipeline: _StaticLoader(updates),
+            binding_plan=DiffusionLoRABindingPlan(
+                component_names=("transformer",),
+                target_modules=("proj",),
+            ),
+            executor_factory=create_low_rank_executor,
+            supports_composition=True,
+        )
+
+
+def test_default_executor_composes_two_adapters_without_duplicate_weight_bank(tmp_path):
+    artifact = tmp_path / "adapter.safetensors"
+    artifact.touch()
+    updates = {
+        "a": LowRankUpdate(
+            "transformer",
+            "proj",
+            torch.tensor([[1.0, 2.0]]),
+            torch.tensor([[3.0], [4.0], [5.0]]),
+        ),
+        "b": LowRankUpdate(
+            "transformer",
+            "proj",
+            torch.tensor([[2.0, -1.0]]),
+            torch.tensor([[1.0], [2.0], [3.0]]),
+            intrinsic_scale=0.5,
+        ),
+    }
+    pipeline = _TinyPipeline(updates)
+    base_weight = pipeline.transformer.proj.weight.detach().clone()
+    runtime = DiffusionLoRARuntime(
+        pipeline,
+        [
+            DiffusionLoRADeployment("a", str(artifact)),
+            DiffusionLoRADeployment("b", str(artifact)),
+        ],
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+    )
+    runtime.activate([DiffusionLoRASelection("a", 0.5), DiffusionLoRASelection("b", 2.0)])
+
+    x = torch.tensor([[1.0, 2.0]])
+    expected = x @ base_weight.T
+    expected += 0.5 * ((x @ updates["a"].lora_a.T) @ updates["a"].lora_b.T)
+    expected += (2.0 * 0.5) * ((x @ updates["b"].lora_a.T) @ updates["b"].lora_b.T)
+    torch.testing.assert_close(pipeline.transformer.proj(x), expected)
+
+    layer = pipeline.transformer.proj
+    assert len(layer.banks) == 1
+    assert layer.banks[0].lora_a.shape[0] == 2
+    assert layer.banks[0].lora_b.shape[1] == 2
+
+    with pytest.raises(ValueError, match="Unknown diffusion LoRA"):
+        runtime.activate([DiffusionLoRASelection("not-deployed")])
+
+
+def test_model_must_explicitly_declare_support(tmp_path):
+    artifact = tmp_path / "adapter.safetensors"
+    artifact.touch()
+    with pytest.raises(ValueError, match="does not declare"):
+        DiffusionLoRARuntime(
+            nn.Module(),
+            [DiffusionLoRADeployment("a", str(artifact))],
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+        )

--- a/tests/diffusion/lora_runtime/test_types.py
+++ b/tests/diffusion/lora_runtime/test_types.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+import pytest
+
+from vllm_omni.diffusion.lora_runtime.types import (
+    DiffusionLoRASelection,
+    diffusion_lora_composition_key,
+    normalize_diffusion_lora_composition,
+    parse_diffusion_lora_deployments,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+def test_parse_deployments_is_name_only_and_deterministic():
+    deployments = parse_diffusion_lora_deployments(
+        [
+            '{"name":"style","path":"/models/style.safetensors"}',
+            {"name": "turbo", "path": "org/turbo"},
+        ]
+    )
+    assert [(item.name, item.path) for item in deployments] == [
+        ("style", "/models/style.safetensors"),
+        ("turbo", "org/turbo"),
+    ]
+
+    with pytest.raises(ValueError, match="unknown fields"):
+        parse_diffusion_lora_deployments([{"name": "turbo", "path": "x", "int_id": 1}])
+    with pytest.raises(ValueError, match="Duplicate"):
+        parse_diffusion_lora_deployments(
+            [
+                {"name": "turbo", "path": "a"},
+                {"name": "turbo", "path": "b"},
+            ]
+        )
+
+
+def test_composition_combines_by_name_and_rejects_paths():
+    composition = normalize_diffusion_lora_composition(
+        [
+            {"name": "turbo", "scale": 0.75},
+            DiffusionLoRASelection("style", 0.5),
+            {"name": "turbo", "scale": 0.25},
+        ]
+    )
+    assert composition == (
+        DiffusionLoRASelection("style", 0.5),
+        DiffusionLoRASelection("turbo", 1.0),
+    )
+    assert diffusion_lora_composition_key(composition) == (("style", 0.5), ("turbo", 1.0))
+
+    with pytest.raises(ValueError, match="unknown fields"):
+        normalize_diffusion_lora_composition([{"name": "turbo", "path": "/tmp/turbo"}])

--- a/tests/diffusion/lora_runtime/test_types.py
+++ b/tests/diffusion/lora_runtime/test_types.py
@@ -3,6 +3,7 @@
 
 import pytest
 
+from vllm_omni.diffusion.lora_runtime.loader import resolve_diffusion_lora_artifact
 from vllm_omni.diffusion.lora_runtime.types import (
     DiffusionLoRASelection,
     diffusion_lora_composition_key,
@@ -52,3 +53,16 @@ def test_composition_combines_by_name_and_rejects_paths():
 
     with pytest.raises(ValueError, match="unknown fields"):
         normalize_diffusion_lora_composition([{"name": "turbo", "path": "/tmp/turbo"}])
+
+
+def test_local_artifact_keeps_hf_snapshot_symlink_name(tmp_path):
+    blob = tmp_path / "extensionless-blob"
+    blob.touch()
+    published = tmp_path / "adapter.safetensors"
+    published.symlink_to(blob)
+
+    resolved = resolve_diffusion_lora_artifact(
+        parse_diffusion_lora_deployments([{"name": "turbo", "path": str(published)}])[0]
+    )
+    assert resolved == published.absolute()
+    assert resolved.suffix == ".safetensors"

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_lora_runtime.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_lora_runtime.py
@@ -9,14 +9,16 @@ from safetensors.torch import save_file
 
 from vllm_omni.diffusion.lora_runtime import DiffusionLoRADeployment
 from vllm_omni.diffusion.models.minimax_h3.lora_runtime import (
-    MiniMaxH3TurboLoRALoader,
+    MiniMaxH3LoRALoader,
 )
 
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
 
 
-def _write_tiny_h3_lora(path, *, alpha: str = "128") -> None:
+def _write_tiny_h3_lora(path, *, alpha: str = "128", extra_metadata: dict[str, str] | None = None) -> None:
     rank = 128
+    metadata = {"alpha": alpha, "key_format": "minimax-h3-diffusers"}
+    metadata.update(extra_metadata or {})
     save_file(
         {
             "transformer_blocks.0.ff.net.0.proj.lora_A.default.weight": torch.ones(rank, 2),
@@ -27,14 +29,14 @@ def _write_tiny_h3_lora(path, *, alpha: str = "128") -> None:
             "transformer_blocks.0.attn.to_q.lora_B.default.weight": torch.ones(4, rank),
         },
         str(path),
-        metadata={"alpha": alpha, "key_format": "minimax-h3-diffusers"},
+        metadata=metadata,
     )
 
 
 def test_h3_loader_normalizes_keys_alpha_and_ffn_layout(tmp_path):
     path = tmp_path / "minimax_h3_fl2v_turbo_4step_v1.0.safetensors"
     _write_tiny_h3_lora(path)
-    loaded = MiniMaxH3TurboLoRALoader(SimpleNamespace(partition="fl2va")).load(
+    loaded = MiniMaxH3LoRALoader(SimpleNamespace(partition="fl2va")).load(
         DiffusionLoRADeployment("turbo", str(path)),
         path,
     )
@@ -51,9 +53,61 @@ def test_h3_loader_normalizes_keys_alpha_and_ffn_layout(tmp_path):
 def test_h3_loader_rejects_non_v1_alpha_and_ref2va(tmp_path):
     path = tmp_path / "turbo.safetensors"
     _write_tiny_h3_lora(path, alpha="8")
-    loader = MiniMaxH3TurboLoRALoader(SimpleNamespace(partition="fl2va"))
+    loader = MiniMaxH3LoRALoader(SimpleNamespace(partition="fl2va"))
     with pytest.raises(ValueError, match="requires alpha=128"):
         loader.load(DiffusionLoRADeployment("turbo", str(path)), path)
 
-    with pytest.raises(ValueError, match="Ref2VA-only"):
-        MiniMaxH3TurboLoRALoader(SimpleNamespace(partition="ref2va"))
+    with pytest.raises(ValueError, match="supports FL2VA only"):
+        MiniMaxH3LoRALoader(SimpleNamespace(partition="ref2va"))
+
+
+def test_h3_loader_rejects_unknown_and_ambiguous_formats(tmp_path):
+    loader = MiniMaxH3LoRALoader(SimpleNamespace(partition="fl2va"))
+
+    unknown = tmp_path / "unknown.safetensors"
+    _write_tiny_h3_lora(unknown, extra_metadata={"key_format": "unknown"})
+    with pytest.raises(ValueError, match="Unsupported MiniMax-H3 LoRA metadata"):
+        loader.load(DiffusionLoRADeployment("any-name", str(unknown)), unknown)
+
+    ambiguous = tmp_path / "ambiguous.safetensors"
+    _write_tiny_h3_lora(
+        ambiguous,
+        extra_metadata={"base_model": "minimax-h3-fl2va", "lora_rank": "128"},
+    )
+    with pytest.raises(ValueError, match="Ambiguous MiniMax-H3 LoRA format"):
+        loader.load(DiffusionLoRADeployment("still-just-an-alias", str(ambiguous)), ambiguous)
+
+
+def test_h3_loader_splits_native_fused_qkv(tmp_path):
+    path = tmp_path / "native.safetensors"
+    rank = 2
+    lora_a = torch.arange(rank * 3, dtype=torch.float32).reshape(rank, 3)
+    lora_b = torch.arange(12 * rank, dtype=torch.float32).reshape(12, rank)
+    out_b = torch.ones(3, rank)
+    save_file(
+        {
+            "diffusion_model.token_refiner.blocks.0.attn.qkv_proj.lora_A.weight": lora_a,
+            "diffusion_model.token_refiner.blocks.0.attn.qkv_proj.lora_B.weight": lora_b,
+            "diffusion_model.token_refiner.blocks.0.attn.out_proj.lora_A.weight": lora_a.clone(),
+            "diffusion_model.token_refiner.blocks.0.attn.out_proj.lora_B.weight": out_b,
+        },
+        str(path),
+        metadata={"base_model": "minimax-h3-fl2va", "lora_rank": str(rank)},
+    )
+
+    loaded = MiniMaxH3LoRALoader(SimpleNamespace(partition="fl2va")).load(
+        DiffusionLoRADeployment("native", str(path)),
+        path,
+    )
+    updates = {update.logical_target: update for update in loaded.updates}
+    assert set(updates) == {
+        "token_refiner.blocks.0.attn.to_q",
+        "token_refiner.blocks.0.attn.to_k",
+        "token_refiner.blocks.0.attn.to_v",
+        "token_refiner.blocks.0.attn.out_proj",
+    }
+    for index, name in enumerate(("to_q", "to_k", "to_v")):
+        update = updates[f"token_refiner.blocks.0.attn.{name}"]
+        torch.testing.assert_close(update.lora_a, lora_a)
+        torch.testing.assert_close(update.lora_b, lora_b.chunk(3, dim=0)[index])
+        assert update.intrinsic_scale == 1.0

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_lora_runtime.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_lora_runtime.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from vllm_omni.diffusion.lora_runtime import DiffusionLoRADeployment
+from vllm_omni.diffusion.models.minimax_h3.lora_runtime import (
+    MiniMaxH3TurboLoRALoader,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+def _write_tiny_h3_lora(path, *, alpha: str = "128") -> None:
+    rank = 128
+    save_file(
+        {
+            "transformer_blocks.0.ff.net.0.proj.lora_A.default.weight": torch.ones(rank, 2),
+            "transformer_blocks.0.ff.net.0.proj.lora_B.default.weight": torch.cat(
+                (torch.ones(2, rank), torch.full((2, rank), 2.0)), dim=0
+            ),
+            "transformer_blocks.0.attn.to_q.lora_A.default.weight": torch.ones(rank, 2),
+            "transformer_blocks.0.attn.to_q.lora_B.default.weight": torch.ones(4, rank),
+        },
+        str(path),
+        metadata={"alpha": alpha, "key_format": "minimax-h3-diffusers"},
+    )
+
+
+def test_h3_loader_normalizes_keys_alpha_and_ffn_layout(tmp_path):
+    path = tmp_path / "minimax_h3_fl2v_turbo_4step_v1.0.safetensors"
+    _write_tiny_h3_lora(path)
+    loaded = MiniMaxH3TurboLoRALoader(SimpleNamespace(partition="fl2va")).load(
+        DiffusionLoRADeployment("turbo", str(path)),
+        path,
+    )
+    updates = {update.logical_target: update for update in loaded.updates}
+    assert set(updates) == {"blocks.0.mlp.fc1", "blocks.0.attn.to_q"}
+    assert updates["blocks.0.mlp.fc1"].rank == 128
+    assert updates["blocks.0.mlp.fc1"].intrinsic_scale == 1.0
+    torch.testing.assert_close(
+        updates["blocks.0.mlp.fc1"].lora_b,
+        torch.cat((torch.full((2, 128), 2.0), torch.ones(2, 128)), dim=0),
+    )
+
+
+def test_h3_loader_rejects_non_v1_alpha_and_ref2va(tmp_path):
+    path = tmp_path / "turbo.safetensors"
+    _write_tiny_h3_lora(path, alpha="8")
+    loader = MiniMaxH3TurboLoRALoader(SimpleNamespace(partition="fl2va"))
+    with pytest.raises(ValueError, match="requires alpha=128"):
+        loader.load(DiffusionLoRADeployment("turbo", str(path)), path)
+
+    with pytest.raises(ValueError, match="Ref2VA-only"):
+        MiniMaxH3TurboLoRALoader(SimpleNamespace(partition="ref2va"))

--- a/tests/diffusion/test_worker_wrapper_base.py
+++ b/tests/diffusion/test_worker_wrapper_base.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 """
 Unit tests for WorkerWrapperBase class.
@@ -13,6 +13,7 @@ This module tests the WorkerWrapperBase implementation:
 """
 
 from typing import Any
+from weakref import ref
 
 import pytest
 from pytest_mock import MockerFixture
@@ -405,6 +406,43 @@ class TestCustomPipelineWorkerExtension:
         # Verify cleanup was performed
         mock_gc_collect.assert_called_once()
         mock_empty_cache.assert_called_once()
+
+    def test_re_init_pipeline_releases_lora_pipeline_references(self, mocker: MockerFixture, mock_od_config):
+        """LoRA runtime references must not retain the replaced pipeline."""
+        mocker.patch("torch.accelerator.empty_cache")
+        mocker.patch.object(DiffusionWorker, "__init__", return_value=None)
+
+        wrapper = WorkerWrapperBase(
+            gpu_id=0,
+            od_config=mock_od_config,
+            base_worker_class=DiffusionWorker,
+            worker_extension_cls=CustomPipelineWorkerExtension,
+        )
+
+        class PipelineHolder:
+            def __init__(self, pipeline):
+                self.pipeline = pipeline
+
+        old_pipeline = MockCustomPipeline()
+        old_pipeline_ref = ref(old_pipeline)
+        runtime = PipelineHolder(old_pipeline)
+        manager = PipelineHolder(old_pipeline)
+        mock_model_runner = mocker.Mock()
+        mock_model_runner.pipeline = old_pipeline
+        mock_model_runner.diffusion_lora_runtime = runtime
+        wrapper.worker.model_runner = mock_model_runner
+        wrapper.worker.diffusion_lora_runtime = runtime
+        wrapper.worker.lora_manager = manager
+        wrapper.worker.init_lora_manager = mocker.Mock()
+        wrapper.worker.load_model = mocker.Mock()
+
+        del old_pipeline, runtime, manager
+        wrapper.worker.re_init_pipeline({"pipeline_class": "MockCustomPipeline"})
+
+        assert old_pipeline_ref() is None
+        assert wrapper.worker.diffusion_lora_runtime is None
+        assert wrapper.worker.lora_manager is None
+        assert mock_model_runner.diffusion_lora_runtime is None
 
     def test_re_init_pipeline_none_pipeline(self, mocker: MockerFixture, mock_od_config):
         """Test re_init_pipeline when pipeline is None."""

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Structured vLLM-Omni configuration classes.
 
 This module is additive for Phase 2 of RFC #4021.
@@ -689,6 +689,8 @@ class _DiffusionConfigProjection:
     lora_scale: float = 1.0
     lora_backend: str = "peft"
     max_cpu_loras: int | None = None
+    enable_diffusion_lora: bool = False
+    diffusion_lora: list[str] | None = None
     output_type: str = "pil"
     enable_cpu_offload: bool = False
     enable_layerwise_offload: bool = False
@@ -823,6 +825,13 @@ class _DiffusionConfigProjection:
             self.max_cpu_loras = 1
         elif self.max_cpu_loras < 1:
             raise ValueError("max_cpu_loras must be >= 1 for diffusion LoRA")
+
+        if self.diffusion_lora and not self.enable_diffusion_lora:
+            raise ValueError("--diffusion-lora requires --enable-diffusion-lora")
+        if self.enable_diffusion_lora and not self.diffusion_lora:
+            raise ValueError("--enable-diffusion-lora requires at least one --diffusion-lora")
+        if self.enable_diffusion_lora and self.lora_path:
+            raise ValueError("The new Diffusion LoRA Runtime cannot be combined with legacy --lora-path")
 
         if self.diffusion_load_format != "diffusers" and (self.diffusers_load_kwargs or self.diffusers_call_kwargs):
             raise ValueError(

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Stage configuration system for vLLM-Omni."""
 
 from __future__ import annotations
@@ -352,6 +352,8 @@ class StageDeployConfig:
     lora_path: str | list[str] | None = None
     lora_backend: str | None = None
     lora_scale: float | None = None
+    enable_diffusion_lora: bool | None = None
+    diffusion_lora: list[str] | None = None
     diffusers_load_kwargs: dict[str, Any] | None = None
     diffusers_call_kwargs: dict[str, Any] | None = None
     diffusion_quantization_config: str | None = None

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -1,6 +1,6 @@
 # adapted from sglang and fastvideo
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 import copy
 import math
 import os
@@ -736,6 +736,8 @@ class OmniDiffusionConfig:
     lora_scale: float | list[float] = 1.0
     lora_backend: LoRABackend = LoRABackend.PEFT  # available choices: ["peft", "distill"]
     max_cpu_loras: int | None = None
+    enable_diffusion_lora: bool = False
+    diffusion_lora: list[str] | None = None
 
     output_type: str = "pil"
 
@@ -1121,6 +1123,13 @@ class OmniDiffusionConfig:
             self.max_cpu_loras = 1
         elif self.max_cpu_loras < 1:
             raise ValueError("max_cpu_loras must be >= 1 for diffusion LoRA")
+
+        if self.diffusion_lora and not self.enable_diffusion_lora:
+            raise ValueError("--diffusion-lora requires --enable-diffusion-lora")
+        if self.enable_diffusion_lora and not self.diffusion_lora:
+            raise ValueError("--enable-diffusion-lora requires at least one --diffusion-lora")
+        if self.enable_diffusion_lora and self.lora_path:
+            raise ValueError("The new Diffusion LoRA Runtime cannot be combined with legacy --lora-path")
 
         if self.diffusion_load_format != "diffusers" and (self.diffusers_load_kwargs or self.diffusers_call_kwargs):
             raise ValueError(

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from __future__ import annotations
 
@@ -39,6 +39,10 @@ from vllm_omni.diffusion.io_support import (
     supports_audio_output,
     supports_multimodal_input,
 )
+from vllm_omni.diffusion.lora_runtime.types import (
+    normalize_diffusion_lora_composition,
+    parse_diffusion_lora_deployments,
+)
 from vllm_omni.diffusion.output_formatter import (
     format_diffusion_outputs,
     format_empty_diffusion_outputs,
@@ -53,7 +57,7 @@ from vllm_omni.diffusion.request import DUMMY_DIFFUSION_REQUEST_ID, OmniDiffusio
 from vllm_omni.diffusion.sched import BaseScheduler, RequestScheduler, StepScheduler
 from vllm_omni.diffusion.sched.interface import DiffusionRequestStatus
 from vllm_omni.diffusion.worker.utils import BaseRunnerOutput, BatchRunnerOutput, RunnerOutput
-from vllm_omni.errors import client_error_from_metadata, is_client_error_status
+from vllm_omni.errors import OmniClientError, client_error_from_metadata, is_client_error_status
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniTextPrompt
 
 if TYPE_CHECKING:
@@ -190,6 +194,12 @@ class DiffusionEngine:
                 from the resolved execution mode.
         """
         self.od_config = od_config
+        deployments = (
+            parse_diffusion_lora_deployments(getattr(od_config, "diffusion_lora", None))
+            if getattr(od_config, "enable_diffusion_lora", False)
+            else ()
+        )
+        self._registered_diffusion_lora_names = frozenset(deployment.name for deployment in deployments)
         # Set after the paged-KV profile request has gone through model-owned
         # preprocessing. Real requests are admitted only within this measured
         # activation envelope: (max execution sequences, max seq_len,
@@ -749,11 +759,25 @@ class DiffusionEngine:
     def _prepare_request_for_admission(self, request: OmniDiffusionRequest) -> OmniDiffusionRequest:
         """Run model-owned preprocessing once, before entering Engine locks."""
 
+        self._validate_diffusion_lora_request(request)
         pre_process_func = getattr(self, "pre_process_func", None)
         if pre_process_func is not None:
             request = pre_process_func(request)
         self._validate_diffusion_kv_profile_limits(request)
         return request
+
+    def _validate_diffusion_lora_request(self, request: OmniDiffusionRequest) -> None:
+        composition = normalize_diffusion_lora_composition(getattr(request.sampling_params, "diffusion_loras", ()))
+        if not composition:
+            return
+        if not getattr(self.od_config, "enable_diffusion_lora", False):
+            raise OmniClientError(
+                "Request selected diffusion LoRAs, but the service did not enable Diffusion LoRA Runtime"
+            )
+        registered = getattr(self, "_registered_diffusion_lora_names", frozenset())
+        unknown = sorted({selection.name for selection in composition} - registered)
+        if unknown:
+            raise OmniClientError(f"Unknown diffusion LoRA selection(s) {unknown}; deployed={sorted(registered)}")
 
     def _validate_diffusion_kv_profile_limits(self, request: OmniDiffusionRequest) -> None:
         """Keep admitted paged-KV requests within the profiled activation shape."""

--- a/vllm_omni/diffusion/lora_runtime/__init__.py
+++ b/vllm_omni/diffusion/lora_runtime/__init__.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from .executors import LowRankLinearExecutor, create_low_rank_executor
+from .runtime import DiffusionLoRARuntime
+from .support import (
+    DiffusionLoRABindingPlan,
+    DiffusionLoRAExecutor,
+    DiffusionLoRALoader,
+    DiffusionLoRASupport,
+)
+from .types import (
+    DiffusionLoRAComposition,
+    DiffusionLoRADeployment,
+    DiffusionLoRASelection,
+    LoadedDiffusionLoRA,
+    LowRankUpdate,
+    diffusion_lora_composition_key,
+    normalize_diffusion_lora_composition,
+    parse_diffusion_lora_deployments,
+)
+
+__all__ = [
+    "DiffusionLoRABindingPlan",
+    "DiffusionLoRAComposition",
+    "DiffusionLoRADeployment",
+    "DiffusionLoRAExecutor",
+    "DiffusionLoRALoader",
+    "DiffusionLoRARuntime",
+    "DiffusionLoRASelection",
+    "DiffusionLoRASupport",
+    "LoadedDiffusionLoRA",
+    "LowRankLinearExecutor",
+    "LowRankUpdate",
+    "create_low_rank_executor",
+    "diffusion_lora_composition_key",
+    "normalize_diffusion_lora_composition",
+    "parse_diffusion_lora_deployments",
+]

--- a/vllm_omni/diffusion/lora_runtime/bindings.py
+++ b/vllm_omni/diffusion/lora_runtime/bindings.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import torch.nn as nn
+
+from .support import DiffusionLoRABindingPlan
+from .types import LoadedDiffusionLoRA, LowRankUpdate
+
+
+@dataclass(frozen=True)
+class ResolvedLoRABinding:
+    component_name: str
+    module_name: str
+    module: nn.Module
+    logical_targets: tuple[str, ...]
+    updates: Mapping[str, tuple[LowRankUpdate | None, ...]]
+
+    @property
+    def full_module_name(self) -> str:
+        return f"{self.component_name}.{self.module_name}"
+
+
+def _resolve_update_target(
+    component: nn.Module,
+    update: LowRankUpdate,
+    plan: DiffusionLoRABindingPlan,
+) -> tuple[str, tuple[str, ...]]:
+    leaf = update.logical_target.rsplit(".", 1)[-1]
+    if leaf not in plan.target_modules:
+        raise ValueError(f"LoRA target {update.component}.{update.logical_target} is not allowed by the model plan")
+
+    try:
+        component.get_submodule(update.logical_target)
+    except AttributeError:
+        pass
+    else:
+        return update.logical_target, (update.logical_target,)
+
+    prefix, separator, logical_leaf = update.logical_target.rpartition(".")
+    for packed_leaf, logical_leaves in plan.packed_modules_mapping.items():
+        logical_tuple = tuple(logical_leaves)
+        if logical_leaf not in logical_tuple:
+            continue
+        physical_target = f"{prefix}.{packed_leaf}" if separator else packed_leaf
+        try:
+            component.get_submodule(physical_target)
+        except AttributeError:
+            continue
+        targets = tuple(f"{prefix}.{name}" if separator else name for name in logical_tuple)
+        return physical_target, targets
+
+    raise ValueError(f"LoRA target {update.component}.{update.logical_target} does not resolve to a model module")
+
+
+def resolve_lora_bindings(
+    pipeline: nn.Module,
+    plan: DiffusionLoRABindingPlan,
+    loras: Mapping[str, LoadedDiffusionLoRA],
+) -> tuple[ResolvedLoRABinding, ...]:
+    """Resolve every normalized update exactly once against model modules."""
+
+    allowed_components = set(plan.component_names)
+    components: dict[str, nn.Module] = {}
+    for component_name in plan.component_names:
+        component = getattr(pipeline, component_name, None)
+        if not isinstance(component, nn.Module):
+            raise ValueError(f"Diffusion LoRA component {component_name!r} is not present on the pipeline")
+        components[component_name] = component
+
+    grouped: dict[tuple[str, str], dict[str, dict[str, LowRankUpdate]]] = defaultdict(lambda: defaultdict(dict))
+    binding_targets: dict[tuple[str, str], tuple[str, ...]] = {}
+    for lora_name, loaded in loras.items():
+        seen: set[tuple[str, str]] = set()
+        for update in loaded.updates:
+            if update.component not in allowed_components:
+                raise ValueError(
+                    f"LoRA {lora_name!r} targets undeclared component {update.component!r}; "
+                    f"allowed={sorted(allowed_components)}"
+                )
+            identity = (update.component, update.logical_target)
+            if identity in seen:
+                raise ValueError(f"LoRA {lora_name!r} contains duplicate target {identity!r}")
+            seen.add(identity)
+            physical_name, logical_targets = _resolve_update_target(
+                components[update.component],
+                update,
+                plan,
+            )
+            binding_key = (update.component, physical_name)
+            previous_targets = binding_targets.setdefault(binding_key, logical_targets)
+            if previous_targets != logical_targets:
+                raise ValueError(
+                    f"LoRA target {binding_key!r} mixes direct and packed update layouts: "
+                    f"{previous_targets!r} != {logical_targets!r}"
+                )
+            grouped[binding_key][lora_name][update.logical_target] = update
+
+    bindings: list[ResolvedLoRABinding] = []
+    for (component_name, module_name), adapter_updates in sorted(grouped.items()):
+        logical_targets = binding_targets[(component_name, module_name)]
+        updates: dict[str, tuple[LowRankUpdate | None, ...]] = {}
+        for lora_name in sorted(loras):
+            by_target = adapter_updates.get(lora_name, {})
+            updates[lora_name] = tuple(by_target.get(target) for target in logical_targets)
+        bindings.append(
+            ResolvedLoRABinding(
+                component_name=component_name,
+                module_name=module_name,
+                module=components[component_name].get_submodule(module_name),
+                logical_targets=logical_targets,
+                updates=updates,
+            )
+        )
+    if not bindings:
+        raise ValueError("The deployed diffusion LoRAs did not resolve to any model modules")
+    return tuple(bindings)

--- a/vllm_omni/diffusion/lora_runtime/executors/__init__.py
+++ b/vllm_omni/diffusion/lora_runtime/executors/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from .low_rank import LowRankLinearExecutor, create_low_rank_executor
+
+__all__ = ["LowRankLinearExecutor", "create_low_rank_executor"]

--- a/vllm_omni/diffusion/lora_runtime/executors/low_rank.py
+++ b/vllm_omni/diffusion/lora_runtime/executors/low_rank.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+import torch
+import torch.nn as nn
+
+from ..bindings import ResolvedLoRABinding
+from ..layers import DynamicLoRALinear
+from ..types import DiffusionLoRAComposition, LoadedDiffusionLoRA
+
+
+def _replace_submodule(root: nn.Module, path: str, module: nn.Module) -> None:
+    parent_path, separator, child_name = path.rpartition(".")
+    parent = root.get_submodule(parent_path) if separator else root
+    if isinstance(parent, (nn.ModuleList, nn.Sequential)) and child_name.isdigit():
+        parent[int(child_name)] = module
+    else:
+        setattr(parent, child_name, module)
+
+
+class LowRankLinearExecutor:
+    """Default ``Wx + B(Ax)`` executor for diffusion linear layers."""
+
+    def __init__(self, pipeline: nn.Module, device: torch.device, dtype: torch.dtype) -> None:
+        self.pipeline = pipeline
+        self.device = device
+        self.dtype = dtype
+        self._layers: dict[str, DynamicLoRALinear] = {}
+        self._finalized = False
+
+    def install(
+        self,
+        loras: Mapping[str, LoadedDiffusionLoRA],
+        bindings: Sequence[object],
+    ) -> None:
+        if self._finalized:
+            raise RuntimeError("Diffusion LoRA executor is already finalized")
+        for untyped_binding in bindings:
+            if not isinstance(untyped_binding, ResolvedLoRABinding):
+                raise TypeError(f"Expected ResolvedLoRABinding, got {type(untyped_binding)!r}")
+            binding = untyped_binding
+            if binding.full_module_name in self._layers:
+                raise ValueError(f"Duplicate diffusion LoRA binding {binding.full_module_name!r}")
+            wrapper = DynamicLoRALinear(
+                binding,
+                loras,
+                device=self.device,
+                dtype=self.dtype,
+            )
+            component = getattr(self.pipeline, binding.component_name)
+            _replace_submodule(component, binding.module_name, wrapper)
+            self._layers[binding.full_module_name] = wrapper
+
+    def activate(self, composition: DiffusionLoRAComposition) -> None:
+        if not self._finalized:
+            raise RuntimeError("Diffusion LoRA executor must be finalized before activation")
+        for layer in self._layers.values():
+            layer.activate(composition)
+
+    def finalize(self) -> None:
+        if not self._layers:
+            raise ValueError("Diffusion LoRA executor installed no layers")
+        self._finalized = True
+
+
+def create_low_rank_executor(
+    pipeline: nn.Module,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> LowRankLinearExecutor:
+    return LowRankLinearExecutor(pipeline, device, dtype)

--- a/vllm_omni/diffusion/lora_runtime/layers/__init__.py
+++ b/vllm_omni/diffusion/lora_runtime/layers/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from .linear import DynamicLoRALinear
+
+__all__ = ["DynamicLoRALinear"]

--- a/vllm_omni/diffusion/lora_runtime/layers/linear.py
+++ b/vllm_omni/diffusion/lora_runtime/layers/linear.py
@@ -1,0 +1,291 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from vllm.distributed.communication_op import tensor_model_parallel_all_reduce
+from vllm.distributed.utils import split_tensor_along_last_dim
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    ReplicatedLinear,
+    RowParallelLinear,
+)
+
+from ..bindings import ResolvedLoRABinding
+from ..types import DiffusionLoRAComposition, LoadedDiffusionLoRA, LowRankUpdate
+
+
+def _validate_update(update: LowRankUpdate, *, expected_input: int, expected_output: int) -> None:
+    if update.lora_a.ndim != 2 or update.lora_b.ndim != 2:
+        raise ValueError(
+            f"LoRA matrices for {update.component}.{update.logical_target} must be two-dimensional, "
+            f"got A={tuple(update.lora_a.shape)}, B={tuple(update.lora_b.shape)}"
+        )
+    if update.rank <= 0 or update.lora_b.shape[1] != update.rank:
+        raise ValueError(
+            f"LoRA rank mismatch for {update.component}.{update.logical_target}: "
+            f"A={tuple(update.lora_a.shape)}, B={tuple(update.lora_b.shape)}"
+        )
+    if update.lora_a.shape[1] != expected_input or update.lora_b.shape[0] != expected_output:
+        raise ValueError(
+            f"LoRA shape mismatch for {update.component}.{update.logical_target}: "
+            f"expected A=({update.rank}, {expected_input}), B=({expected_output}, {update.rank}); "
+            f"got A={tuple(update.lora_a.shape)}, B={tuple(update.lora_b.shape)}"
+        )
+
+
+def _shard_column_b(module: ColumnParallelLinear, tensor: torch.Tensor) -> torch.Tensor:
+    shard_size = tensor.shape[0] // module.tp_size
+    if shard_size * module.tp_size != tensor.shape[0]:
+        raise ValueError(f"LoRA output dimension {tensor.shape[0]} is not divisible by TP size {module.tp_size}")
+    return tensor.narrow(0, module.tp_rank * shard_size, shard_size)
+
+
+def _shard_merged_b(module: MergedColumnParallelLinear, tensor: torch.Tensor) -> torch.Tensor:
+    pieces = tensor.split(module.output_sizes, dim=0)
+    return torch.cat([_shard_column_b(module, piece) for piece in pieces], dim=0)
+
+
+def _qkv_global_sizes(module: QKVParallelLinear) -> tuple[int, int, int]:
+    return (
+        module.total_num_heads * module.head_size,
+        module.total_num_kv_heads * module.head_size,
+        module.total_num_kv_heads * module.v_head_size,
+    )
+
+
+def _shard_qkv_piece(module: QKVParallelLinear, tensor: torch.Tensor, slice_index: int) -> torch.Tensor:
+    shard_ids = ("q", "k", "v")
+    shard_id = shard_ids[slice_index]
+    local_size = module._get_shard_size_mapping(shard_id)
+    if local_size is None:
+        raise ValueError(f"Unable to resolve QKV LoRA slice {shard_id!r}")
+    shard_rank = module.tp_rank if shard_id == "q" else module.tp_rank // module.num_kv_head_replicas
+    return tensor.narrow(0, shard_rank * local_size, local_size)
+
+
+def _localize_update(
+    module: nn.Module,
+    update: LowRankUpdate,
+    *,
+    slice_index: int,
+    slice_count: int,
+) -> tuple[torch.Tensor, torch.Tensor, bool]:
+    """Return rank-local A/B and whether shrink results require TP reduction."""
+
+    if isinstance(module, QKVParallelLinear):
+        global_sizes = _qkv_global_sizes(module)
+        expected_output = global_sizes[slice_index] if slice_count == 3 else sum(global_sizes)
+        _validate_update(update, expected_input=module.input_size, expected_output=expected_output)
+        if slice_count == 3:
+            local_b = _shard_qkv_piece(module, update.lora_b, slice_index)
+        else:
+            local_b = torch.cat(
+                [
+                    _shard_qkv_piece(module, piece, index)
+                    for index, piece in enumerate(update.lora_b.split(global_sizes, dim=0))
+                ],
+                dim=0,
+            )
+        return update.lora_a, local_b, False
+
+    if isinstance(module, MergedColumnParallelLinear):
+        if slice_count == len(module.output_sizes):
+            expected_output = module.output_sizes[slice_index]
+            _validate_update(update, expected_input=module.input_size, expected_output=expected_output)
+            local_b = _shard_column_b(module, update.lora_b)
+        else:
+            expected_output = sum(module.output_sizes)
+            _validate_update(update, expected_input=module.input_size, expected_output=expected_output)
+            local_b = _shard_merged_b(module, update.lora_b)
+        if module.gather_output and module.tp_size > 1:
+            raise NotImplementedError("Dynamic diffusion LoRA does not support gathered ColumnParallel output")
+        return update.lora_a, local_b, False
+
+    if isinstance(module, ColumnParallelLinear):
+        _validate_update(update, expected_input=module.input_size, expected_output=module.output_size)
+        if module.gather_output and module.tp_size > 1:
+            raise NotImplementedError("Dynamic diffusion LoRA does not support gathered ColumnParallel output")
+        return update.lora_a, _shard_column_b(module, update.lora_b), False
+
+    if isinstance(module, RowParallelLinear):
+        _validate_update(update, expected_input=module.input_size, expected_output=module.output_size)
+        if not module.reduce_results and module.tp_size > 1:
+            raise NotImplementedError("Dynamic diffusion LoRA requires reduced RowParallel output")
+        shard_size = module.input_size_per_partition
+        local_a = update.lora_a.narrow(1, module.tp_rank * shard_size, shard_size)
+        return local_a, update.lora_b, module.tp_size > 1
+
+    if isinstance(module, ReplicatedLinear):
+        _validate_update(update, expected_input=module.input_size, expected_output=module.output_size)
+        return update.lora_a, update.lora_b, False
+
+    if isinstance(module, nn.Linear):
+        _validate_update(update, expected_input=module.in_features, expected_output=module.out_features)
+        return update.lora_a, update.lora_b, False
+
+    raise TypeError(
+        f"Default diffusion LoRA executor cannot wrap {type(module).__name__}; the model must provide a custom executor"
+    )
+
+
+class _LowRankBank(nn.Module):
+    """Fixed-shape concatenated A/B bank with request-mutable rank scales."""
+
+    def __init__(
+        self,
+        entries: Sequence[tuple[str, LowRankUpdate, torch.Tensor, torch.Tensor]],
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+        reduce_rank: bool,
+    ) -> None:
+        super().__init__()
+        self.reduce_rank = reduce_rank
+        self._slots: dict[str, tuple[int, int, float]] = {}
+        offset = 0
+        lora_as: list[torch.Tensor] = []
+        lora_bs: list[torch.Tensor] = []
+        for name, update, local_a, local_b in entries:
+            rank = update.rank
+            self._slots[name] = (offset, rank, float(update.intrinsic_scale))
+            offset += rank
+            lora_as.append(local_a.to(device=device, dtype=dtype))
+            lora_bs.append(local_b.to(device=device, dtype=dtype))
+        self.register_buffer("lora_a", torch.cat(lora_as, dim=0), persistent=False)
+        self.register_buffer("lora_b", torch.cat(lora_bs, dim=1), persistent=False)
+        self.register_buffer("active_rank_scales", torch.zeros(offset, device=device, dtype=dtype), persistent=False)
+
+    @property
+    def output_size(self) -> int:
+        return int(self.lora_b.shape[0])
+
+    def activate(self, composition: DiffusionLoRAComposition) -> None:
+        self.active_rank_scales.zero_()
+        for selection in composition:
+            slot = self._slots.get(selection.name)
+            if slot is None:
+                continue
+            offset, rank, intrinsic_scale = slot
+            self.active_rank_scales.narrow(0, offset, rank).fill_(selection.scale * intrinsic_scale)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        hidden = F.linear(x, self.lora_a)
+        if self.reduce_rank:
+            hidden = tensor_model_parallel_all_reduce(hidden)
+        hidden = hidden * self.active_rank_scales
+        return F.linear(hidden, self.lora_b)
+
+
+class DynamicLoRALinear(nn.Module):
+    """Signature-transparent dynamic LoRA wrapper around one linear layer."""
+
+    def __init__(
+        self,
+        binding: ResolvedLoRABinding,
+        loras: Mapping[str, LoadedDiffusionLoRA],
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> None:
+        super().__init__()
+        self.base_layer = binding.module
+        self._bank_indices: list[int | None] = []
+        self._slice_output_sizes = self._resolve_slice_output_sizes(
+            binding.module,
+            len(binding.logical_targets),
+        )
+        self.banks = nn.ModuleList()
+        slice_count = len(binding.logical_targets)
+        for slice_index in range(slice_count):
+            entries: list[tuple[str, LowRankUpdate, torch.Tensor, torch.Tensor]] = []
+            reduce_rank: bool | None = None
+            for lora_name in sorted(loras):
+                update = binding.updates[lora_name][slice_index]
+                if update is None:
+                    continue
+                local_a, local_b, update_reduce_rank = _localize_update(
+                    binding.module,
+                    update,
+                    slice_index=slice_index,
+                    slice_count=slice_count,
+                )
+                if reduce_rank is not None and reduce_rank != update_reduce_rank:
+                    raise ValueError(f"LoRA TP behavior differs within binding {binding.full_module_name}")
+                reduce_rank = update_reduce_rank
+                entries.append((lora_name, update, local_a, local_b))
+            if not entries:
+                self._bank_indices.append(None)
+                continue
+            self._bank_indices.append(len(self.banks))
+            self.banks.append(
+                _LowRankBank(
+                    entries,
+                    device=device,
+                    dtype=dtype,
+                    reduce_rank=bool(reduce_rank),
+                )
+            )
+
+    @staticmethod
+    def _resolve_slice_output_sizes(module: nn.Module, slice_count: int) -> tuple[int, ...]:
+        if isinstance(module, QKVParallelLinear) and slice_count == 3:
+            sizes = tuple(module._get_shard_size_mapping(name) for name in ("q", "k", "v"))
+            if any(size is None for size in sizes):
+                raise ValueError("Unable to resolve QKV LoRA output slices")
+            return tuple(int(size) for size in sizes if size is not None)
+        if isinstance(module, MergedColumnParallelLinear) and slice_count == len(module.output_sizes):
+            return tuple(int(size // module.tp_size) for size in module.output_sizes)
+        if slice_count != 1:
+            raise ValueError(f"Unsupported packed LoRA binding for {type(module).__name__}")
+        if isinstance(module, ColumnParallelLinear):
+            return (int(module.output_size_per_partition),)
+        if isinstance(module, (RowParallelLinear, ReplicatedLinear)):
+            return (int(module.output_size),)
+        if isinstance(module, nn.Linear):
+            return (int(module.out_features),)
+        raise TypeError(f"Default diffusion LoRA executor cannot wrap {type(module).__name__}")
+
+    def activate(self, composition: DiffusionLoRAComposition) -> None:
+        for bank in self.banks:
+            bank.activate(composition)
+
+    def _lora_input(self, x: torch.Tensor) -> torch.Tensor:
+        if isinstance(self.base_layer, RowParallelLinear) and not self.base_layer.input_is_parallel:
+            return split_tensor_along_last_dim(x, self.base_layer.tp_size)[self.base_layer.tp_rank].contiguous()
+        return x
+
+    def forward(self, x: torch.Tensor, *args, **kwargs):
+        result = self.base_layer(x, *args, **kwargs)
+        output = result[0] if isinstance(result, tuple) else result
+        lora_input = self._lora_input(x)
+        deltas: list[torch.Tensor] = []
+        for bank_index, output_size in zip(self._bank_indices, self._slice_output_sizes, strict=True):
+            if bank_index is None:
+                deltas.append(output.new_zeros((*output.shape[:-1], output_size)))
+            else:
+                deltas.append(self.banks[bank_index](lora_input))
+        delta = deltas[0] if len(deltas) == 1 else torch.cat(deltas, dim=-1)
+        output = output + delta
+        if not isinstance(result, tuple):
+            return output
+        return (output, *result[1:])
+
+    def __getattr__(self, name: str):
+        try:
+            return super().__getattr__(name)
+        except AttributeError as exc:
+            base_layer = object.__getattribute__(self, "_modules").get("base_layer")
+            if base_layer is None:
+                raise exc
+            try:
+                return getattr(base_layer, name)
+            except AttributeError:
+                raise exc

--- a/vllm_omni/diffusion/lora_runtime/loader.py
+++ b/vllm_omni/diffusion/lora_runtime/loader.py
@@ -17,7 +17,10 @@ def resolve_diffusion_lora_artifact(deployment: DiffusionLoRADeployment) -> Path
 
     local_path = Path(deployment.path).expanduser()
     if local_path.exists():
-        return local_path.resolve()
+        # Keep the snapshot-facing filename. Hugging Face cache files are
+        # symlinks to extensionless blobs, while model loaders may use the
+        # published suffix to select and validate the checkpoint format.
+        return local_path.absolute()
 
     resolved = download_weights_from_hf_specific(
         deployment.path,

--- a/vllm_omni/diffusion/lora_runtime/loader.py
+++ b/vllm_omni/diffusion/lora_runtime/loader.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from vllm_omni.model_executor.model_loader.weight_utils import (
+    download_weights_from_hf_specific,
+)
+
+from .types import DiffusionLoRADeployment
+
+
+def resolve_diffusion_lora_artifact(deployment: DiffusionLoRADeployment) -> Path:
+    """Resolve a deployment path once during worker startup."""
+
+    local_path = Path(deployment.path).expanduser()
+    if local_path.exists():
+        return local_path.resolve()
+
+    resolved = download_weights_from_hf_specific(
+        deployment.path,
+        cache_dir=None,
+        allow_patterns=["*.safetensors"],
+    )
+    return Path(resolved)

--- a/vllm_omni/diffusion/lora_runtime/runtime.py
+++ b/vllm_omni/diffusion/lora_runtime/runtime.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import torch
+import torch.nn as nn
+from vllm.logger import init_logger
+
+from .bindings import resolve_lora_bindings
+from .loader import resolve_diffusion_lora_artifact
+from .support import DiffusionLoRAExecutor, DiffusionLoRASupport
+from .types import (
+    DiffusionLoRAComposition,
+    DiffusionLoRADeployment,
+    DiffusionLoRASelection,
+    LoadedDiffusionLoRA,
+    normalize_diffusion_lora_composition,
+)
+
+logger = init_logger(__name__)
+
+
+class DiffusionLoRARuntime:
+    """Immutable startup registry plus request-scoped LoRA activation."""
+
+    def __init__(
+        self,
+        pipeline: nn.Module,
+        deployments: Sequence[DiffusionLoRADeployment],
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> None:
+        support = getattr(pipeline, "diffusion_lora_support", None)
+        if not isinstance(support, DiffusionLoRASupport):
+            raise ValueError(f"{type(pipeline).__name__} does not declare Diffusion LoRA Runtime support")
+        if not deployments:
+            raise ValueError("Diffusion LoRA Runtime requires at least one --diffusion-lora deployment")
+
+        by_name: dict[str, LoadedDiffusionLoRA] = {}
+        loader = support.loader_factory(pipeline)
+        for deployment in sorted(deployments, key=lambda item: item.name):
+            if deployment.name in by_name:
+                raise ValueError(f"Duplicate diffusion LoRA deployment name: {deployment.name!r}")
+            artifact_path = resolve_diffusion_lora_artifact(deployment)
+            logger.info("Loading diffusion LoRA %s from %s", deployment.name, artifact_path)
+            loaded = loader.load(deployment, artifact_path)
+            if loaded.name != deployment.name:
+                raise ValueError(f"Model loader renamed diffusion LoRA {deployment.name!r} to {loaded.name!r}")
+            if not loaded.updates:
+                raise ValueError(f"Diffusion LoRA {deployment.name!r} contains no low-rank updates")
+            loaded.update_map()
+            by_name[deployment.name] = loaded
+
+        bindings = resolve_lora_bindings(pipeline, support.binding_plan, by_name)
+        executor = support.executor_factory(pipeline, device, dtype)
+        executor.install(by_name, bindings)
+        executor.finalize()
+
+        self._support = support
+        self._registered_names = tuple(by_name)
+        self._executor: DiffusionLoRAExecutor = executor
+        self._active: DiffusionLoRAComposition = ()
+        self.activate(())
+
+    @property
+    def registered_names(self) -> tuple[str, ...]:
+        return self._registered_names
+
+    @property
+    def active_composition(self) -> DiffusionLoRAComposition:
+        return self._active
+
+    def activate(
+        self,
+        composition: Sequence[DiffusionLoRASelection | dict] | None,
+    ) -> None:
+        normalized = normalize_diffusion_lora_composition(composition)
+        unknown = [selection.name for selection in normalized if selection.name not in self._registered_names]
+        if unknown:
+            raise ValueError(f"Unknown diffusion LoRA selection(s) {unknown}; deployed={list(self._registered_names)}")
+        if len(normalized) > 1 and not self._support.supports_composition:
+            raise ValueError(f"{type(self._executor).__name__} does not support multi-LoRA composition")
+        if normalized == self._active:
+            return
+        self._executor.activate(normalized)
+        self._active = normalized

--- a/vllm_omni/diffusion/lora_runtime/support.py
+++ b/vllm_omni/diffusion/lora_runtime/support.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol, TypeAlias
+
+import torch
+import torch.nn as nn
+
+from .types import (
+    DiffusionLoRAComposition,
+    DiffusionLoRADeployment,
+    LoadedDiffusionLoRA,
+)
+
+
+@dataclass(frozen=True)
+class DiffusionLoRABindingPlan:
+    """Model-owned allowlist for logical-to-physical LoRA binding."""
+
+    component_names: tuple[str, ...]
+    target_modules: tuple[str, ...]
+    packed_modules_mapping: Mapping[str, Sequence[str]] = field(default_factory=dict)
+
+
+class DiffusionLoRALoader(Protocol):
+    def load(
+        self,
+        deployment: DiffusionLoRADeployment,
+        artifact_path: Path,
+    ) -> LoadedDiffusionLoRA: ...
+
+
+class DiffusionLoRAExecutor(Protocol):
+    def install(
+        self,
+        loras: Mapping[str, LoadedDiffusionLoRA],
+        bindings: Sequence[object],
+    ) -> None: ...
+
+    def activate(self, composition: DiffusionLoRAComposition) -> None: ...
+
+    def finalize(self) -> None: ...
+
+
+LoRALoaderFactory: TypeAlias = Callable[[nn.Module], DiffusionLoRALoader]
+LoRAExecutorFactory: TypeAlias = Callable[[nn.Module, torch.device, torch.dtype], DiffusionLoRAExecutor]
+
+
+@dataclass(frozen=True)
+class DiffusionLoRASupport:
+    """Complete model-owned contract consumed by the common runtime."""
+
+    loader_factory: LoRALoaderFactory
+    binding_plan: DiffusionLoRABindingPlan
+    executor_factory: LoRAExecutorFactory
+    supports_composition: bool = False

--- a/vllm_omni/diffusion/lora_runtime/types.py
+++ b/vllm_omni/diffusion/lora_runtime/types.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, TypeAlias
+
+import torch
+
+
+@dataclass(frozen=True)
+class DiffusionLoRADeployment:
+    """One immutable startup-time adapter definition."""
+
+    name: str
+    path: str
+
+
+@dataclass(frozen=True)
+class DiffusionLoRASelection:
+    """One request-time selection of a deployment-owned adapter."""
+
+    name: str
+    scale: float = 1.0
+
+
+DiffusionLoRAComposition: TypeAlias = tuple[DiffusionLoRASelection, ...]
+DiffusionLoRACompositionKey: TypeAlias = tuple[tuple[str, float], ...]
+
+
+@dataclass(frozen=True)
+class LowRankUpdate:
+    """Model-normalized low-rank update for one logical module."""
+
+    component: str
+    logical_target: str
+    lora_a: torch.Tensor
+    lora_b: torch.Tensor
+    intrinsic_scale: float = 1.0
+
+    @property
+    def rank(self) -> int:
+        return int(self.lora_a.shape[0])
+
+
+@dataclass(frozen=True)
+class LoadedDiffusionLoRA:
+    """Canonical output of a model-owned loader."""
+
+    name: str
+    updates: tuple[LowRankUpdate, ...]
+
+    def update_map(self) -> dict[tuple[str, str], LowRankUpdate]:
+        result: dict[tuple[str, str], LowRankUpdate] = {}
+        for update in self.updates:
+            key = (update.component, update.logical_target)
+            if key in result:
+                raise ValueError(f"LoRA {self.name!r} contains duplicate update {key!r}")
+            result[key] = update
+        return result
+
+
+_DEPLOYMENT_FIELDS = frozenset({"name", "path"})
+_SELECTION_FIELDS = frozenset({"name", "scale"})
+
+
+def _parse_json_object(value: str, *, label: str) -> Mapping[str, Any]:
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{label} must be a JSON object: {exc.msg}") from exc
+    if not isinstance(parsed, Mapping):
+        raise ValueError(f"{label} must be a JSON object")
+    return parsed
+
+
+def parse_diffusion_lora_deployments(
+    values: Sequence[str | Mapping[str, Any]] | None,
+) -> tuple[DiffusionLoRADeployment, ...]:
+    """Parse repeatable startup definitions without assigning hidden IDs."""
+
+    if not values:
+        return ()
+    deployments: list[DiffusionLoRADeployment] = []
+    seen: set[str] = set()
+    for raw_value in values:
+        value = _parse_json_object(raw_value, label="--diffusion-lora") if isinstance(raw_value, str) else raw_value
+        unknown = set(value) - _DEPLOYMENT_FIELDS
+        if unknown:
+            raise ValueError(f"--diffusion-lora contains unknown fields: {sorted(unknown)}")
+        name = value.get("name")
+        path = value.get("path")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("--diffusion-lora requires a non-empty string name")
+        if not isinstance(path, str) or not path.strip():
+            raise ValueError("--diffusion-lora requires a non-empty string path")
+        name = name.strip()
+        if name in seen:
+            raise ValueError(f"Duplicate diffusion LoRA deployment name: {name!r}")
+        seen.add(name)
+        deployments.append(DiffusionLoRADeployment(name=name, path=path.strip()))
+    return tuple(sorted(deployments, key=lambda item: item.name))
+
+
+def normalize_diffusion_lora_composition(
+    values: Sequence[DiffusionLoRASelection | Mapping[str, Any]] | None,
+) -> DiffusionLoRAComposition:
+    """Return a deterministic name/scale composition for scheduling."""
+
+    if not values:
+        return ()
+    combined: dict[str, float] = {}
+    for raw_value in values:
+        if isinstance(raw_value, DiffusionLoRASelection):
+            selection = raw_value
+        elif isinstance(raw_value, Mapping):
+            unknown = set(raw_value) - _SELECTION_FIELDS
+            if unknown:
+                raise ValueError(f"Diffusion LoRA selection contains unknown fields: {sorted(unknown)}")
+            name = raw_value.get("name")
+            if not isinstance(name, str) or not name.strip():
+                raise ValueError("Diffusion LoRA selection requires a non-empty string name")
+            selection = DiffusionLoRASelection(name=name.strip(), scale=float(raw_value.get("scale", 1.0)))
+        else:
+            raise TypeError(f"Expected a diffusion LoRA selection object, got {type(raw_value)!r}")
+
+        name = selection.name.strip()
+        scale = float(selection.scale)
+        if not name:
+            raise ValueError("Diffusion LoRA selection name must not be empty")
+        if not math.isfinite(scale):
+            raise ValueError(f"Diffusion LoRA scale must be finite, got {scale!r}")
+        combined[name] = combined.get(name, 0.0) + scale
+
+    return tuple(
+        DiffusionLoRASelection(name=name, scale=scale) for name, scale in sorted(combined.items()) if scale != 0.0
+    )
+
+
+def diffusion_lora_composition_key(
+    composition: Sequence[DiffusionLoRASelection | Mapping[str, Any]] | None,
+) -> DiffusionLoRACompositionKey:
+    return tuple((item.name, item.scale) for item in normalize_diffusion_lora_composition(composition))

--- a/vllm_omni/diffusion/models/minimax_h3/lora_runtime.py
+++ b/vllm_omni/diffusion/models/minimax_h3/lora_runtime.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+from safetensors import safe_open
+
+from vllm_omni.diffusion.lora_runtime import (
+    DiffusionLoRABindingPlan,
+    DiffusionLoRADeployment,
+    DiffusionLoRASupport,
+    LoadedDiffusionLoRA,
+    LowRankUpdate,
+    create_low_rank_executor,
+)
+
+_H3_TURBO_RANK = 128
+_H3_TURBO_ALPHA = 128.0
+_LORA_A_SUFFIX = ".lora_A.default.weight"
+_LORA_B_SUFFIX = ".lora_B.default.weight"
+_H3_LOGICAL_TARGETS = frozenset({"to_q", "to_k", "to_v", "out_proj", "fc1", "fc2"})
+
+MINIMAX_H3_LORA_BINDING_PLAN = DiffusionLoRABindingPlan(
+    component_names=("transformer",),
+    target_modules=("to_q", "to_k", "to_v", "out_proj", "fc1", "fc2"),
+    packed_modules_mapping={"qkv_proj": ("to_q", "to_k", "to_v")},
+)
+
+
+def _normalize_h3_target(raw_target: str) -> str:
+    if raw_target.startswith("transformer_blocks."):
+        target = "blocks." + raw_target.removeprefix("transformer_blocks.")
+    elif raw_target.startswith("token_refiner.refiner_blocks."):
+        target = "token_refiner.blocks." + raw_target.removeprefix("token_refiner.refiner_blocks.")
+    else:
+        raise ValueError(f"Unsupported MiniMax-H3 Turbo LoRA target prefix: {raw_target!r}")
+
+    replacements = (
+        (".attn.to_out.0", ".attn.out_proj"),
+        (".ff.net.0.proj", ".mlp.fc1"),
+        (".ff.net.2", ".mlp.fc2"),
+    )
+    for old, new in replacements:
+        target = target.replace(old, new)
+    leaf = target.rsplit(".", 1)[-1]
+    if leaf not in _H3_LOGICAL_TARGETS:
+        raise ValueError(f"Unsupported MiniMax-H3 Turbo LoRA logical target: {target!r}")
+    return target
+
+
+def _select_h3_turbo_file(artifact_path: Path) -> Path:
+    if artifact_path.is_file():
+        if artifact_path.suffix != ".safetensors":
+            raise ValueError(f"MiniMax-H3 Turbo LoRA must be a safetensors file, got {artifact_path}")
+        return artifact_path
+    if not artifact_path.is_dir():
+        raise ValueError(f"MiniMax-H3 Turbo LoRA artifact does not exist: {artifact_path}")
+
+    candidates = sorted(artifact_path.glob("*v1.0*.safetensors"))
+    if not candidates:
+        candidates = sorted(artifact_path.glob("*.safetensors"))
+    if len(candidates) != 1:
+        raise ValueError(
+            f"MiniMax-H3 Turbo LoRA artifact must resolve to exactly one v1.0 safetensors file, "
+            f"found {[path.name for path in candidates]}"
+        )
+    return candidates[0]
+
+
+class MiniMaxH3TurboLoRALoader:
+    """Interpret the LightX2V v1.0 FL2VA Turbo release."""
+
+    def __init__(self, pipeline: nn.Module) -> None:
+        partition = getattr(pipeline, "partition", None)
+        if partition == "ref2va":
+            raise ValueError("MiniMax-H3 FL2VA Turbo LoRA is not supported by a Ref2VA-only service")
+
+    def load(
+        self,
+        deployment: DiffusionLoRADeployment,
+        artifact_path: Path,
+    ) -> LoadedDiffusionLoRA:
+        lora_file = _select_h3_turbo_file(artifact_path)
+        paired: dict[str, dict[str, torch.Tensor]] = {}
+        with safe_open(lora_file, framework="pt", device="cpu") as checkpoint:
+            metadata = checkpoint.metadata() or {}
+            if metadata.get("key_format") != "minimax-h3-diffusers":
+                raise ValueError(
+                    f"Unsupported MiniMax-H3 Turbo key format {metadata.get('key_format')!r}; "
+                    "expected 'minimax-h3-diffusers'"
+                )
+            raw_alpha = metadata.get("alpha")
+            try:
+                alpha = float(raw_alpha) if raw_alpha is not None else math.nan
+            except ValueError as exc:
+                raise ValueError(f"MiniMax-H3 Turbo alpha must be numeric, got {raw_alpha!r}") from exc
+            if alpha != _H3_TURBO_ALPHA:
+                raise ValueError(f"MiniMax-H3 Turbo v1.0 requires alpha={_H3_TURBO_ALPHA:g}, got {raw_alpha!r}")
+
+            for key in checkpoint.keys():
+                if key.endswith(_LORA_A_SUFFIX):
+                    raw_target = key[: -len(_LORA_A_SUFFIX)]
+                    side = "a"
+                elif key.endswith(_LORA_B_SUFFIX):
+                    raw_target = key[: -len(_LORA_B_SUFFIX)]
+                    side = "b"
+                else:
+                    raise ValueError(f"Unconsumed MiniMax-H3 Turbo tensor: {key!r}")
+                target = _normalize_h3_target(raw_target)
+                target_pair = paired.setdefault(target, {})
+                if side in target_pair:
+                    raise ValueError(f"Duplicate MiniMax-H3 Turbo tensor for {target}.{side}")
+                tensor = checkpoint.get_tensor(key)
+                if side == "b" and target.endswith(".mlp.fc1"):
+                    if tensor.shape[0] % 2:
+                        raise ValueError(
+                            f"MiniMax-H3 Turbo fc1 lora_B rows must split evenly, got {tuple(tensor.shape)}"
+                        )
+                    value, gate = tensor.chunk(2, dim=0)
+                    tensor = torch.cat((gate, value), dim=0).contiguous()
+                target_pair[side] = tensor
+
+        updates: list[LowRankUpdate] = []
+        for target, tensors in sorted(paired.items()):
+            if set(tensors) != {"a", "b"}:
+                raise ValueError(f"Incomplete MiniMax-H3 Turbo LoRA pair for {target}: {sorted(tensors)}")
+            lora_a = tensors["a"]
+            lora_b = tensors["b"]
+            if lora_a.ndim != 2 or lora_b.ndim != 2 or lora_a.shape[0] != _H3_TURBO_RANK:
+                raise ValueError(
+                    f"MiniMax-H3 Turbo v1.0 requires rank {_H3_TURBO_RANK}, "
+                    f"got A={tuple(lora_a.shape)}, B={tuple(lora_b.shape)} for {target}"
+                )
+            if lora_b.shape[1] != _H3_TURBO_RANK:
+                raise ValueError(f"MiniMax-H3 Turbo B rank mismatch for {target}: {tuple(lora_b.shape)}")
+            updates.append(
+                LowRankUpdate(
+                    component="transformer",
+                    logical_target=target,
+                    lora_a=lora_a,
+                    lora_b=lora_b,
+                    intrinsic_scale=alpha / _H3_TURBO_RANK,
+                )
+            )
+        if not updates:
+            raise ValueError(f"MiniMax-H3 Turbo LoRA {lora_file} contains no supported updates")
+        return LoadedDiffusionLoRA(name=deployment.name, updates=tuple(updates))
+
+
+def create_minimax_h3_lora_loader(pipeline: nn.Module) -> MiniMaxH3TurboLoRALoader:
+    return MiniMaxH3TurboLoRALoader(pipeline)
+
+
+MINIMAX_H3_DIFFUSION_LORA_SUPPORT = DiffusionLoRASupport(
+    loader_factory=create_minimax_h3_lora_loader,
+    binding_plan=MINIMAX_H3_LORA_BINDING_PLAN,
+    executor_factory=create_low_rank_executor,
+    supports_composition=True,
+)

--- a/vllm_omni/diffusion/models/minimax_h3/lora_runtime.py
+++ b/vllm_omni/diffusion/models/minimax_h3/lora_runtime.py
@@ -4,7 +4,10 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import torch
 import torch.nn as nn
@@ -21,9 +24,25 @@ from vllm_omni.diffusion.lora_runtime import (
 
 _H3_TURBO_RANK = 128
 _H3_TURBO_ALPHA = 128.0
-_LORA_A_SUFFIX = ".lora_A.default.weight"
-_LORA_B_SUFFIX = ".lora_B.default.weight"
+_DIFFUSERS_LORA_A_SUFFIX = ".lora_A.default.weight"
+_DIFFUSERS_LORA_B_SUFFIX = ".lora_B.default.weight"
+_NATIVE_LORA_A_SUFFIX = ".lora_A.weight"
+_NATIVE_LORA_B_SUFFIX = ".lora_B.weight"
 _H3_LOGICAL_TARGETS = frozenset({"to_q", "to_k", "to_v", "out_proj", "fc1", "fc2"})
+
+
+@dataclass(frozen=True)
+class _MiniMaxH3LoRAFormat:
+    """One checkpoint publication format, not one deployed LoRA identity.
+
+    Multiple adapters may share a format and decoder. The common runtime keeps
+    those weight instances separate by ``DiffusionLoRADeployment.name``;
+    format matching never inspects that user-provided name or artifact path.
+    """
+
+    format_id: str
+    matches_metadata: Callable[[Mapping[str, str]], bool]
+    decode_checkpoint: Callable[[Any, dict[str, str]], list[LowRankUpdate]]
 
 MINIMAX_H3_LORA_BINDING_PLAN = DiffusionLoRABindingPlan(
     component_names=("transformer",),
@@ -53,107 +72,237 @@ def _normalize_h3_target(raw_target: str) -> str:
     return target
 
 
-def _select_h3_turbo_file(artifact_path: Path) -> Path:
+def _select_h3_lora_file(artifact_path: Path) -> Path:
     if artifact_path.is_file():
         if artifact_path.suffix != ".safetensors":
-            raise ValueError(f"MiniMax-H3 Turbo LoRA must be a safetensors file, got {artifact_path}")
+            raise ValueError(f"MiniMax-H3 LoRA must be a safetensors file, got {artifact_path}")
         return artifact_path
     if not artifact_path.is_dir():
-        raise ValueError(f"MiniMax-H3 Turbo LoRA artifact does not exist: {artifact_path}")
+        raise ValueError(f"MiniMax-H3 LoRA artifact does not exist: {artifact_path}")
 
     candidates = sorted(artifact_path.glob("*v1.0*.safetensors"))
     if not candidates:
         candidates = sorted(artifact_path.glob("*.safetensors"))
     if len(candidates) != 1:
         raise ValueError(
-            f"MiniMax-H3 Turbo LoRA artifact must resolve to exactly one v1.0 safetensors file, "
+            f"MiniMax-H3 LoRA artifact must resolve to exactly one safetensors file, "
             f"found {[path.name for path in candidates]}"
         )
     return candidates[0]
 
 
-class MiniMaxH3TurboLoRALoader:
-    """Interpret the LightX2V v1.0 FL2VA Turbo release."""
+def _collect_pairs(
+    checkpoint,
+    *,
+    a_suffix: str,
+    b_suffix: str,
+) -> dict[str, dict[str, torch.Tensor]]:
+    paired: dict[str, dict[str, torch.Tensor]] = {}
+    for key in checkpoint.keys():
+        if key.endswith(a_suffix):
+            target = key[: -len(a_suffix)]
+            side = "a"
+        elif key.endswith(b_suffix):
+            target = key[: -len(b_suffix)]
+            side = "b"
+        else:
+            raise ValueError(f"Unconsumed MiniMax-H3 LoRA tensor: {key!r}")
+        target_pair = paired.setdefault(target, {})
+        if side in target_pair:
+            raise ValueError(f"Duplicate MiniMax-H3 LoRA tensor for {target}.{side}")
+        target_pair[side] = checkpoint.get_tensor(key)
+    return paired
 
-    def __init__(self, pipeline: nn.Module) -> None:
-        partition = getattr(pipeline, "partition", None)
-        if partition == "ref2va":
-            raise ValueError("MiniMax-H3 FL2VA Turbo LoRA is not supported by a Ref2VA-only service")
 
-    def load(
-        self,
-        deployment: DiffusionLoRADeployment,
-        artifact_path: Path,
-    ) -> LoadedDiffusionLoRA:
-        lora_file = _select_h3_turbo_file(artifact_path)
-        paired: dict[str, dict[str, torch.Tensor]] = {}
-        with safe_open(lora_file, framework="pt", device="cpu") as checkpoint:
-            metadata = checkpoint.metadata() or {}
-            if metadata.get("key_format") != "minimax-h3-diffusers":
-                raise ValueError(
-                    f"Unsupported MiniMax-H3 Turbo key format {metadata.get('key_format')!r}; "
-                    "expected 'minimax-h3-diffusers'"
+def _validate_pair(
+    target: str,
+    tensors: dict[str, torch.Tensor],
+    *,
+    expected_rank: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if set(tensors) != {"a", "b"}:
+        raise ValueError(f"Incomplete MiniMax-H3 LoRA pair for {target}: {sorted(tensors)}")
+    lora_a = tensors["a"]
+    lora_b = tensors["b"]
+    if lora_a.ndim != 2 or lora_b.ndim != 2 or lora_a.shape[0] != expected_rank:
+        raise ValueError(
+            f"MiniMax-H3 LoRA rank must be {expected_rank}, "
+            f"got A={tuple(lora_a.shape)}, B={tuple(lora_b.shape)} for {target}"
+        )
+    if lora_b.shape[1] != expected_rank:
+        raise ValueError(f"MiniMax-H3 LoRA B rank mismatch for {target}: {tuple(lora_b.shape)}")
+    return lora_a, lora_b
+
+
+def _load_turbo_updates(checkpoint, metadata: dict[str, str]) -> list[LowRankUpdate]:
+    raw_alpha = metadata.get("alpha")
+    try:
+        alpha = float(raw_alpha) if raw_alpha is not None else math.nan
+    except ValueError as exc:
+        raise ValueError(f"MiniMax-H3 Turbo alpha must be numeric, got {raw_alpha!r}") from exc
+    if alpha != _H3_TURBO_ALPHA:
+        raise ValueError(f"MiniMax-H3 Turbo v1.0 requires alpha={_H3_TURBO_ALPHA:g}, got {raw_alpha!r}")
+
+    paired: dict[str, dict[str, torch.Tensor]] = {}
+    for raw_target, tensors in _collect_pairs(
+        checkpoint,
+        a_suffix=_DIFFUSERS_LORA_A_SUFFIX,
+        b_suffix=_DIFFUSERS_LORA_B_SUFFIX,
+    ).items():
+        target = _normalize_h3_target(raw_target)
+        if target in paired:
+            raise ValueError(f"Duplicate normalized MiniMax-H3 LoRA target: {target}")
+        if target.endswith(".mlp.fc1") and "b" in tensors:
+            tensor = tensors["b"]
+            if tensor.shape[0] % 2:
+                raise ValueError(f"MiniMax-H3 Turbo fc1 lora_B rows must split evenly, got {tuple(tensor.shape)}")
+            value, gate = tensor.chunk(2, dim=0)
+            tensors["b"] = torch.cat((gate, value), dim=0).contiguous()
+        paired[target] = tensors
+
+    updates: list[LowRankUpdate] = []
+    for target, tensors in sorted(paired.items()):
+        lora_a, lora_b = _validate_pair(target, tensors, expected_rank=_H3_TURBO_RANK)
+        updates.append(
+            LowRankUpdate(
+                component="transformer",
+                logical_target=target,
+                lora_a=lora_a,
+                lora_b=lora_b,
+                intrinsic_scale=alpha / _H3_TURBO_RANK,
+            )
+        )
+    return updates
+
+
+def _load_native_updates(checkpoint, metadata: dict[str, str]) -> list[LowRankUpdate]:
+    if metadata.get("base_model") != "minimax-h3-fl2va":
+        raise ValueError(
+            f"Unsupported native MiniMax-H3 LoRA base model {metadata.get('base_model')!r}; expected 'minimax-h3-fl2va'"
+        )
+    raw_rank = metadata.get("lora_rank")
+    try:
+        rank = int(raw_rank) if raw_rank is not None else 0
+    except ValueError as exc:
+        raise ValueError(f"MiniMax-H3 LoRA rank must be an integer, got {raw_rank!r}") from exc
+    if rank <= 0:
+        raise ValueError(f"MiniMax-H3 LoRA rank must be positive, got {raw_rank!r}")
+    raw_alpha = metadata.get("lora_alpha", metadata.get("alpha"))
+    try:
+        intrinsic_scale = float(raw_alpha) / rank if raw_alpha is not None else 1.0
+    except ValueError as exc:
+        raise ValueError(f"MiniMax-H3 LoRA alpha must be numeric, got {raw_alpha!r}") from exc
+    if not math.isfinite(intrinsic_scale) or intrinsic_scale <= 0:
+        raise ValueError(f"MiniMax-H3 LoRA intrinsic scale must be positive and finite, got {intrinsic_scale!r}")
+
+    updates: list[LowRankUpdate] = []
+    for raw_target, tensors in sorted(
+        _collect_pairs(
+            checkpoint,
+            a_suffix=_NATIVE_LORA_A_SUFFIX,
+            b_suffix=_NATIVE_LORA_B_SUFFIX,
+        ).items()
+    ):
+        if not raw_target.startswith(("diffusion_model.blocks.", "diffusion_model.token_refiner.blocks.")):
+            raise ValueError(f"Unsupported native MiniMax-H3 LoRA target prefix: {raw_target!r}")
+        target = raw_target.removeprefix("diffusion_model.")
+        lora_a, lora_b = _validate_pair(target, tensors, expected_rank=rank)
+        leaf = target.rsplit(".", 1)[-1]
+        if leaf == "qkv_proj":
+            if lora_b.shape[0] % 3:
+                raise ValueError(f"MiniMax-H3 qkv_proj lora_B rows must split evenly, got {tuple(lora_b.shape)}")
+            prefix = target.rsplit(".", 1)[0]
+            for logical_leaf, piece in zip(("to_q", "to_k", "to_v"), lora_b.chunk(3, dim=0), strict=True):
+                updates.append(
+                    LowRankUpdate(
+                        component="transformer",
+                        logical_target=f"{prefix}.{logical_leaf}",
+                        lora_a=lora_a,
+                        lora_b=piece,
+                        intrinsic_scale=intrinsic_scale,
+                    )
                 )
-            raw_alpha = metadata.get("alpha")
-            try:
-                alpha = float(raw_alpha) if raw_alpha is not None else math.nan
-            except ValueError as exc:
-                raise ValueError(f"MiniMax-H3 Turbo alpha must be numeric, got {raw_alpha!r}") from exc
-            if alpha != _H3_TURBO_ALPHA:
-                raise ValueError(f"MiniMax-H3 Turbo v1.0 requires alpha={_H3_TURBO_ALPHA:g}, got {raw_alpha!r}")
-
-            for key in checkpoint.keys():
-                if key.endswith(_LORA_A_SUFFIX):
-                    raw_target = key[: -len(_LORA_A_SUFFIX)]
-                    side = "a"
-                elif key.endswith(_LORA_B_SUFFIX):
-                    raw_target = key[: -len(_LORA_B_SUFFIX)]
-                    side = "b"
-                else:
-                    raise ValueError(f"Unconsumed MiniMax-H3 Turbo tensor: {key!r}")
-                target = _normalize_h3_target(raw_target)
-                target_pair = paired.setdefault(target, {})
-                if side in target_pair:
-                    raise ValueError(f"Duplicate MiniMax-H3 Turbo tensor for {target}.{side}")
-                tensor = checkpoint.get_tensor(key)
-                if side == "b" and target.endswith(".mlp.fc1"):
-                    if tensor.shape[0] % 2:
-                        raise ValueError(
-                            f"MiniMax-H3 Turbo fc1 lora_B rows must split evenly, got {tuple(tensor.shape)}"
-                        )
-                    value, gate = tensor.chunk(2, dim=0)
-                    tensor = torch.cat((gate, value), dim=0).contiguous()
-                target_pair[side] = tensor
-
-        updates: list[LowRankUpdate] = []
-        for target, tensors in sorted(paired.items()):
-            if set(tensors) != {"a", "b"}:
-                raise ValueError(f"Incomplete MiniMax-H3 Turbo LoRA pair for {target}: {sorted(tensors)}")
-            lora_a = tensors["a"]
-            lora_b = tensors["b"]
-            if lora_a.ndim != 2 or lora_b.ndim != 2 or lora_a.shape[0] != _H3_TURBO_RANK:
-                raise ValueError(
-                    f"MiniMax-H3 Turbo v1.0 requires rank {_H3_TURBO_RANK}, "
-                    f"got A={tuple(lora_a.shape)}, B={tuple(lora_b.shape)} for {target}"
-                )
-            if lora_b.shape[1] != _H3_TURBO_RANK:
-                raise ValueError(f"MiniMax-H3 Turbo B rank mismatch for {target}: {tuple(lora_b.shape)}")
+        elif leaf in _H3_LOGICAL_TARGETS:
             updates.append(
                 LowRankUpdate(
                     component="transformer",
                     logical_target=target,
                     lora_a=lora_a,
                     lora_b=lora_b,
-                    intrinsic_scale=alpha / _H3_TURBO_RANK,
+                    intrinsic_scale=intrinsic_scale,
                 )
             )
+        else:
+            raise ValueError(f"Unsupported native MiniMax-H3 LoRA logical target: {target!r}")
+    return updates
+
+
+def _is_turbo_v1_format(metadata: Mapping[str, str]) -> bool:
+    return metadata.get("key_format") == "minimax-h3-diffusers"
+
+
+def _is_native_fl2va_format(metadata: Mapping[str, str]) -> bool:
+    return metadata.get("base_model") == "minimax-h3-fl2va" and "lora_rank" in metadata
+
+
+# This is the complete H3 checkpoint-format declaration. Add a new entry when
+# another H3 publication requires different loading semantics; do not add one
+# merely for another adapter that already uses an existing format.
+MINIMAX_H3_LORA_FORMATS = (
+    _MiniMaxH3LoRAFormat(
+        format_id="lightx2v-turbo-v1",
+        matches_metadata=_is_turbo_v1_format,
+        decode_checkpoint=_load_turbo_updates,
+    ),
+    _MiniMaxH3LoRAFormat(
+        format_id="native-fl2va",
+        matches_metadata=_is_native_fl2va_format,
+        decode_checkpoint=_load_native_updates,
+    ),
+)
+
+
+def _select_h3_lora_format(metadata: Mapping[str, str]) -> _MiniMaxH3LoRAFormat:
+    """Select exactly one decoder from metadata, independent of adapter name."""
+
+    matched_formats = tuple(
+        format_spec for format_spec in MINIMAX_H3_LORA_FORMATS if format_spec.matches_metadata(metadata)
+    )
+    if not matched_formats:
+        supported = [format_spec.format_id for format_spec in MINIMAX_H3_LORA_FORMATS]
+        raise ValueError(f"Unsupported MiniMax-H3 LoRA metadata keys: {sorted(metadata)}; supported formats={supported}")
+    if len(matched_formats) != 1:
+        raise ValueError(
+            f"Ambiguous MiniMax-H3 LoRA format: {[format_spec.format_id for format_spec in matched_formats]}"
+        )
+    return matched_formats[0]
+
+
+class MiniMaxH3LoRALoader:
+    """Interpret supported Diffusers and native-layout H3 FL2VA LoRAs."""
+
+    def __init__(self, pipeline: nn.Module) -> None:
+        partition = getattr(pipeline, "partition", None)
+        if partition == "ref2va":
+            raise ValueError("MiniMax-H3 diffusion LoRA runtime currently supports FL2VA only")
+
+    def load(
+        self,
+        deployment: DiffusionLoRADeployment,
+        artifact_path: Path,
+    ) -> LoadedDiffusionLoRA:
+        lora_file = _select_h3_lora_file(artifact_path)
+        with safe_open(lora_file, framework="pt", device="cpu") as checkpoint:
+            metadata = checkpoint.metadata() or {}
+            format_spec = _select_h3_lora_format(metadata)
+            updates = format_spec.decode_checkpoint(checkpoint, metadata)
         if not updates:
-            raise ValueError(f"MiniMax-H3 Turbo LoRA {lora_file} contains no supported updates")
+            raise ValueError(f"MiniMax-H3 LoRA {lora_file} contains no supported updates")
         return LoadedDiffusionLoRA(name=deployment.name, updates=tuple(updates))
 
 
-def create_minimax_h3_lora_loader(pipeline: nn.Module) -> MiniMaxH3TurboLoRALoader:
-    return MiniMaxH3TurboLoRALoader(pipeline)
+def create_minimax_h3_lora_loader(pipeline: nn.Module) -> MiniMaxH3LoRALoader:
+    return MiniMaxH3LoRALoader(pipeline)
 
 
 MINIMAX_H3_DIFFUSION_LORA_SUPPORT = DiffusionLoRASupport(

--- a/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
+++ b/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """vLLM-Omni pipeline for MiniMax H3 FL2VA and Ref2VA partitions."""
 
 from __future__ import annotations
@@ -74,6 +75,7 @@ from .condition_noise import (
 )
 from .denoise_loop import MiniMaxH3DenoiseBranch, minimax_h3_denoise_loop
 from .encoder import MiniMaxH3Qwen3VLEncoder
+from .lora_runtime import MINIMAX_H3_DIFFUSION_LORA_SUPPORT
 from .minimax_h3_transformer import MiniMaxH3DiTModel
 from .packed_sequence import (
     minimax_h3_packed_sequence,
@@ -558,6 +560,14 @@ class MiniMaxH3Pipeline(
     # Only distilled releases pin a schedule, so the default keeps the legacy
     # uniform path available to partially constructed pipelines.
     _base_schedule_by_partition: ClassVar[Mapping[str, DMD2SigmaSchedule | None]] = {}
+
+    @property
+    def diffusion_lora_support(self):
+        """Expose FL2VA LoRA semantics without enabling Ref2VA adapters."""
+
+        if self.partition == "ref2va":
+            return None
+        return MINIMAX_H3_DIFFUSION_LORA_SUPPORT
 
     def adopt_cache_dit_backend(self, backend: CacheDiTBackend) -> None:
         """Adopt runner-installed generic Cache-DiT for request transitions."""

--- a/vllm_omni/diffusion/sched/base_scheduler.py
+++ b/vllm_omni/diffusion/sched/base_scheduler.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from __future__ import annotations
 
@@ -15,6 +15,7 @@ from vllm_omni.diffusion.data import OmniDiffusionConfig
 from vllm_omni.diffusion.diffusion_kv.config import DiffusionKVCacheMode
 from vllm_omni.diffusion.diffusion_kv.manager import DiffusionKVAdmissionError, DiffusionKVCacheManager
 from vllm_omni.diffusion.diffusion_kv.metadata import DiffusionKVMetadata
+from vllm_omni.diffusion.lora_runtime.types import diffusion_lora_composition_key
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.sched.interface import (
     CachedRequestData,
@@ -36,7 +37,8 @@ BatchSamplingParamsKey = StepBatchSamplingParamsKey | RequestBatchSamplingParams
 # LoRA identity is derived from `sampling.lora_request`, not a same-named field
 # on sampling params, so it must be resolved separately from the bulk lookup.
 _STEP_BATCH_SAMPLING_PARAMS_KEY_FIELD_NAMES = frozenset(field.name for field in fields(StepBatchSamplingParamsKey)) - {
-    "lora_int_id"
+    "diffusion_lora_composition",
+    "lora_int_id",
 }
 
 
@@ -423,6 +425,7 @@ class BaseScheduler(ABC):
         # LoRA identity is optional on sampling params (and on test stubs).
         lora_request = getattr(sampling, "lora_request", None)
         return StepBatchSamplingParamsKey(
+            diffusion_lora_composition=diffusion_lora_composition_key(getattr(sampling, "diffusion_loras", ())),
             lora_int_id=lora_request.lora_int_id if lora_request is not None else None,
             **{name: getattr(sampling, name) for name in _STEP_BATCH_SAMPLING_PARAMS_KEY_FIELD_NAMES},
         )

--- a/vllm_omni/diffusion/sched/interface.py
+++ b/vllm_omni/diffusion/sched/interface.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from __future__ import annotations
 
@@ -81,6 +81,7 @@ class StepBatchSamplingParamsKey:
     # separate batches so the worker can activate exactly one adapter per step.
     lora_int_id: int | None = None
     lora_scale: float = 1.0
+    diffusion_lora_composition: tuple[tuple[str, float], ...] = ()
 
 
 @dataclass(frozen=True, eq=True)
@@ -145,6 +146,7 @@ class RequestBatchSamplingParamsKey:
     # LoRA identity.
     lora_int_id: int | None = None
     lora_scale: float = 1.0
+    diffusion_lora_composition: tuple[tuple[str, float], ...] = ()
 
 
 @dataclass

--- a/vllm_omni/diffusion/sched/request_scheduler.py
+++ b/vllm_omni/diffusion/sched/request_scheduler.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from __future__ import annotations
 
 from dataclasses import fields
 from typing import TYPE_CHECKING
 
+from vllm_omni.diffusion.lora_runtime.types import diffusion_lora_composition_key
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.sched.base_scheduler import BaseScheduler
 from vllm_omni.diffusion.sched.interface import (
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
 # on sampling params, so it must be resolved separately from the bulk lookup.
 _REQUEST_BATCH_SAMPLING_PARAMS_KEY_FIELD_NAMES = frozenset(
     field.name for field in fields(RequestBatchSamplingParamsKey)
-) - {"condition_key", "flow_shift", "lora_int_id", "sample_solver"}
+) - {"condition_key", "diffusion_lora_composition", "flow_shift", "lora_int_id", "sample_solver"}
 
 
 def _normalize_explicit_sample_solver(value: object | None) -> str | None:
@@ -53,6 +54,7 @@ def build_request_batch_sampling_params_key(request: OmniDiffusionRequest) -> Re
     key_kwargs["flow_shift"] = _normalize_explicit_flow_shift(extra_args.get("flow_shift"))
     key_kwargs["condition_key"] = getattr(request, "batch_compatibility_key", None)
     key_kwargs["lora_int_id"] = lora_request.lora_int_id if lora_request is not None else None
+    key_kwargs["diffusion_lora_composition"] = diffusion_lora_composition_key(getattr(sampling, "diffusion_loras", ()))
     return RequestBatchSamplingParamsKey(**key_kwargs)
 
 

--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """
 Diffusion Model Runner for vLLM-Omni.
 
@@ -139,6 +139,7 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
         self.od_config = od_config
         self.device = device
         self.pipeline: Any | None = None
+        self.diffusion_lora_runtime: Any | None = None
         self.cache_backend: Any | None = None
         self.offload_backend: Any | None = None
         self.prompt_embed_cache: Any | None = None
@@ -220,6 +221,37 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
             compile_dynamic,
         )
 
+    def _init_diffusion_lora_runtime(self) -> None:
+        if not getattr(self.od_config, "enable_diffusion_lora", False):
+            self.diffusion_lora_runtime = None
+            return
+        if not isinstance(self.pipeline, torch.nn.Module):
+            raise ValueError("Diffusion LoRA Runtime requires an nn.Module pipeline")
+        incompatible = [
+            name
+            for name in (
+                "enable_cpu_offload",
+                "enable_layerwise_offload",
+                "enable_distributed_layerwise_offload",
+            )
+            if getattr(self.od_config, name, False)
+        ]
+        if incompatible:
+            raise ValueError(f"Diffusion LoRA Runtime first release does not support offload; disable {incompatible}")
+
+        from vllm_omni.diffusion.lora_runtime import (
+            DiffusionLoRARuntime,
+            parse_diffusion_lora_deployments,
+        )
+
+        deployments = parse_diffusion_lora_deployments(self.od_config.diffusion_lora)
+        self.diffusion_lora_runtime = DiffusionLoRARuntime(
+            self.pipeline,
+            deployments,
+            device=self.device,
+            dtype=getattr(self.od_config, "dtype", torch.bfloat16),
+        )
+
     def load_model(
         self,
         memory_pool_context_fn: Callable[[str], AbstractContextManager[Any]] | None = None,
@@ -275,6 +307,9 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
                     custom_pipeline_name=custom_pipeline_name,
                     device=self.device,
                 )
+                # Install immutable LoRA banks before offload, compile, and
+                # cache wrappers so those systems see the final module graph.
+                self._init_diffusion_lora_runtime()
         time_after_load = time.perf_counter()
 
         logger.info(

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 """
 Diffusion Worker for vLLM-Omni.
@@ -183,10 +183,12 @@ class DiffusionWorker:
         self.requested_memory: int | None = None
         self._sleep_saved_buffers: dict[str, torch.Tensor] = {}
         self.lora_manager: DiffusionLoRAManager | None = None
+        self.diffusion_lora_runtime: Any | None = None
         # Worker-side cache of (lora_request, lora_scale) per scheduled
         # request id. Used by step mode to recover LoRA identity for cached
         # requests, which only carry their request_id in subsequent ticks.
         self._step_lora_state: dict[str, tuple[LoRARequest | None, float]] = {}
+        self._step_diffusion_lora_state: dict[str, tuple[Any, ...]] = {}
         self.stage_id = getattr(od_config, "stage_id", 0)
         self.init_device()
         # Create model runner — one decision chain, in precedence order:
@@ -447,6 +449,11 @@ class DiffusionWorker:
         if self.model_runner.pipeline is None:
             return
 
+        self.diffusion_lora_runtime = self.model_runner.diffusion_lora_runtime
+        if getattr(self, "diffusion_lora_runtime", None) is not None:
+            self.lora_manager = None
+            return
+
         lora_path = self.od_config.lora_path
         if isinstance(lora_path, list) and len(lora_path) == 1:
             lora_path = lora_path[0]
@@ -471,6 +478,28 @@ class DiffusionWorker:
                 logger.warning("Pipeline does not support loading distilled LoRA weights for now.")
         else:
             raise ValueError(f"Unknown LoRA backend: {lora_backend}. Available choices: {LoRABackend.__members__}")
+
+    def _activate_lora_state(
+        self,
+        lora_request: LoRARequest | None,
+        lora_scale: float,
+        diffusion_loras: tuple[Any, ...],
+    ) -> None:
+        if getattr(self, "diffusion_lora_runtime", None) is not None:
+            if lora_request is not None:
+                raise ValueError("Legacy request LoRA cannot be combined with Diffusion LoRA Runtime")
+            self.diffusion_lora_runtime.activate(diffusion_loras)
+            return
+        if diffusion_loras:
+            raise ValueError("Request selected diffusion LoRAs, but the service did not enable Diffusion LoRA Runtime")
+        if self.lora_manager is None:
+            return
+        try:
+            self.lora_manager.set_active_adapter(lora_request, lora_scale)
+        except Exception as exc:
+            if lora_request is not None:
+                raise
+            logger.warning("LoRA activation skipped: %s", exc)
 
     def profile(self, is_start: bool = True, profile_prefix: str | None = None) -> None:
         """Start or stop profiling for this GPU worker.
@@ -547,13 +576,12 @@ class DiffusionWorker:
             req = new_req.req
             diffusion_kv_metadata = new_req.diffusion_kv_metadata
 
-        if self.lora_manager is not None:
-            try:
-                self.lora_manager.set_active_adapter(req.sampling_params.lora_request, req.sampling_params.lora_scale)
-            except Exception as exc:
-                if req.sampling_params.lora_request is not None:
-                    raise
-                logger.warning("LoRA activation skipped: %s", exc)
+        sampling = req.sampling_params
+        self._activate_lora_state(
+            sampling.lora_request,
+            sampling.lora_scale,
+            getattr(sampling, "diffusion_loras", ()),
+        )
         profiler = self._get_profiler()
         ctx = profiler.annotate_context_manager("diffusion_forward") if profiler else nullcontext()
         with ctx:
@@ -579,14 +607,13 @@ class DiffusionWorker:
         """Batch forward: LoRA activate once, delegate to model runner."""
         assert self.model_runner is not None, "Model runner not initialized"
         # LoRA: same adapter/scale within batch guaranteed by RequestBatchSamplingParamsKey.
-        if self.lora_manager is not None and scheduler_output.scheduled_new_reqs:
+        if scheduler_output.scheduled_new_reqs:
             sp = scheduler_output.scheduled_new_reqs[0].req.sampling_params
-            try:
-                self.lora_manager.set_active_adapter(sp.lora_request, sp.lora_scale)
-            except Exception as exc:
-                if sp.lora_request is not None:
-                    raise
-                logger.warning("LoRA activation skipped: %s", exc)
+            self._activate_lora_state(
+                sp.lora_request,
+                sp.lora_scale,
+                getattr(sp, "diffusion_loras", ()),
+            )
         profiler = self._get_profiler()
         ctx = profiler.annotate_context_manager("diffusion_forward_batch") if profiler else nullcontext()
         with ctx:
@@ -618,6 +645,7 @@ class DiffusionWorker:
         """
         for request_id in scheduler_output.finished_req_ids:
             self._step_lora_state.pop(request_id, None)
+            getattr(self, "_step_diffusion_lora_state", {}).pop(request_id, None)
 
         for new_req in scheduler_output.scheduled_new_reqs:
             sampling = new_req.req.sampling_params
@@ -625,24 +653,23 @@ class DiffusionWorker:
                 sampling.lora_request,
                 sampling.lora_scale,
             )
+            if getattr(self, "diffusion_lora_runtime", None) is not None:
+                self._step_diffusion_lora_state[new_req.request_id] = getattr(sampling, "diffusion_loras", ())
 
-        if self.lora_manager is None:
+        if self.lora_manager is None and getattr(self, "diffusion_lora_runtime", None) is None:
             return
 
         lora_request: LoRARequest | None = None
         lora_scale = 1.0
+        diffusion_loras: tuple[Any, ...] = ()
         for request_id in scheduler_output.scheduled_request_ids:
             entry = self._step_lora_state.get(request_id)
             if entry is not None:
                 lora_request, lora_scale = entry
+                diffusion_loras = getattr(self, "_step_diffusion_lora_state", {}).get(request_id, ())
                 break
 
-        try:
-            self.lora_manager.set_active_adapter(lora_request, lora_scale)
-        except Exception as exc:
-            if lora_request is not None:
-                raise
-            logger.warning("LoRA activation skipped: %s", exc)
+        self._activate_lora_state(lora_request, lora_scale, diffusion_loras)
 
     def remove_lora(self, adapter_id: int) -> bool:
         return self.lora_manager.remove_adapter(adapter_id)

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -679,12 +679,12 @@ class DiffusionWorker:
         self._activate_lora_state(lora_request, lora_scale, diffusion_loras)
 
     def remove_lora(self, adapter_id: int) -> bool:
-        return self.lora_manager.remove_adapter(adapter_id)
+        return self._require_legacy_lora_manager("remove_lora").remove_adapter(adapter_id)
 
     def add_lora(self, lora_request: LoRARequest) -> bool:
         # NOTE (Alex): We have not implemented the API routing
         # for the frontend server yet.
-        return self.lora_manager.add_adapter(lora_request)
+        return self._require_legacy_lora_manager("add_lora").add_adapter(lora_request)
 
     def submit_interaction(
         self,
@@ -696,10 +696,19 @@ class DiffusionWorker:
         self.model_runner.submit_interaction(request_id, interaction)
 
     def list_loras(self) -> list[int]:
-        return self.lora_manager.list_adapters()
+        return self._require_legacy_lora_manager("list_loras").list_adapters()
 
     def pin_lora(self, adapter_id: int) -> bool:
-        return self.lora_manager.pin_adapter(adapter_id)
+        return self._require_legacy_lora_manager("pin_lora").pin_adapter(adapter_id)
+
+    def _require_legacy_lora_manager(self, operation: str) -> DiffusionLoRAManager:
+        if getattr(self, "diffusion_lora_runtime", None) is not None:
+            raise NotImplementedError(
+                f"{operation} is not supported by Diffusion LoRA Runtime; adapters are immutable after startup"
+            )
+        if self.lora_manager is None:
+            raise RuntimeError("Legacy diffusion LoRA manager is not initialized")
+        return self.lora_manager
 
     def sleep(self, level: int = 1) -> int:
         """

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -479,6 +479,13 @@ class DiffusionWorker:
         else:
             raise ValueError(f"Unknown LoRA backend: {lora_backend}. Available choices: {LoRABackend.__members__}")
 
+    def _release_lora_runtime_references(self) -> None:
+        """Drop references that can keep the current pipeline alive."""
+        self.lora_manager = None
+        self.diffusion_lora_runtime = None
+        if self.model_runner is not None:
+            self.model_runner.diffusion_lora_runtime = None
+
     def _activate_lora_state(
         self,
         lora_request: LoRARequest | None,
@@ -900,6 +907,10 @@ class CustomPipelineWorkerExtension:
         Args:
             custom_pipeline_args: Dictionary of arguments for custom pipeline initialization
         """
+
+        # LoRA managers and executors retain wrapped modules. Release them
+        # before deleting the pipeline so the old checkpoint can be reclaimed.
+        self._release_lora_runtime_references()
 
         # Clean up old pipeline
         if self.model_runner.pipeline is not None:

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 import argparse
 import json
 import os
@@ -521,6 +524,8 @@ class OrchestratorArgs:
     lora_path: list[str] | None = None
     lora_backend: str | None = None
     lora_scale: float | None = None
+    enable_diffusion_lora: bool = False
+    diffusion_lora: list[str] | None = None
     diffusers_load_kwargs: str = "{}"
     diffusers_call_kwargs: str = "{}"
     ulysses_degree: int | None = None

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 """
 Async Omni Engine for vLLM-Omni multi-stage runtime.
 
@@ -1062,6 +1065,8 @@ class AsyncOmniEngine:
             "lora_path": kwargs.get("lora_path", None),
             "lora_scale": kwargs.get("lora_scale", 1.0),
             "lora_backend": kwargs.get("lora_backend", "peft"),
+            "enable_diffusion_lora": kwargs.get("enable_diffusion_lora", False),
+            "diffusion_lora": kwargs.get("diffusion_lora", None),
             "custom_pipeline_args": kwargs.get("custom_pipeline_args", None),
             "worker_extension_cls": kwargs.get("worker_extension_cls", None),
             "trust_remote_code": (False if kwargs.get("trust_remote_code") is None else kwargs["trust_remote_code"]),
@@ -1222,6 +1227,15 @@ class AsyncOmniEngine:
                 if kwargs.get("lora_backend") is not None:
                     if not hasattr(cfg.engine_args, "lora_backend") or cfg.engine_args.lora_backend is None:
                         cfg.engine_args.lora_backend = kwargs["lora_backend"]
+                if kwargs.get("enable_diffusion_lora"):
+                    if (
+                        not hasattr(cfg.engine_args, "enable_diffusion_lora")
+                        or cfg.engine_args.enable_diffusion_lora is None
+                    ):
+                        cfg.engine_args.enable_diffusion_lora = True
+                if kwargs.get("diffusion_lora") is not None:
+                    if not hasattr(cfg.engine_args, "diffusion_lora") or cfg.engine_args.diffusion_lora is None:
+                        cfg.engine_args.diffusion_lora = kwargs["diffusion_lora"]
                 if (
                     kwargs.get("diffusion_attention_config") is not None
                     or kwargs.get("diffusion_attention_backend") is not None

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 """
 Omni serve command for vLLM-Omni.
 
@@ -465,6 +468,23 @@ class OmniServeCommand(CLISubcommand):
             type=float,
             default=None,
             help="Scale for a startup PEFT LoRA. Distilled LoRAs are fused at their checkpoint scale.",
+        )
+        omni_config_group.add_argument(
+            "--enable-diffusion-lora",
+            action=argparse.BooleanOptionalAction,
+            default=False,
+            help="Enable the model-declared Diffusion LoRA Runtime.",
+        )
+        omni_config_group.add_argument(
+            "--diffusion-lora",
+            action="append",
+            default=None,
+            metavar="JSON",
+            help=(
+                "Register one immutable startup LoRA as JSON, for example "
+                '\'{"name":"turbo","path":"lightx2v/Minimax-h3-Turbo"}\'. '
+                "May be repeated."
+            ),
         )
         omni_config_group.add_argument(
             "--diffusion-compile-granularity",

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 import asyncio
 import base64
 import dataclasses
@@ -3238,6 +3238,7 @@ async def _parse_video_form(
     frame_interpolation_scale: float | None = Form(default=None, gt=0.0),
     frame_interpolation_model_path: str | None = Form(default=None),
     lora: str | None = Form(default=None),
+    loras: str | None = Form(default=None),
     extra_params: str | None = Form(default=None),
 ) -> tuple[
     VideoGenerationRequest,
@@ -3307,6 +3308,7 @@ async def _parse_video_form(
         "frame_interpolation_scale": frame_interpolation_scale,
         "frame_interpolation_model_path": frame_interpolation_model_path,
         "lora": _parse_form_json(lora, expected_type=dict),
+        "loras": _parse_form_json(loras, expected_type=list),
         "extra_params": _parse_form_json(extra_params, expected_type=dict),
     }
     request_data = {k: v for k, v in request_data.items() if v is not None}

--- a/vllm_omni/entrypoints/openai/protocol/videos.py
+++ b/vllm_omni/entrypoints/openai/protocol/videos.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """
 OpenAI-compatible protocol definitions for video generation.
 
@@ -260,6 +260,13 @@ class VideoGenerationRequest(BaseModel):
             "{name/path/scale/int_id}. Field names are flexible "
             "(e.g. name|lora_name|adapter, path|lora_path|local_path, "
             "scale|lora_scale, int_id|lora_int_id)."
+        ),
+    )
+    loras: list[dict[str, Any]] | None = Field(
+        default=None,
+        description=(
+            "Optional name-only Diffusion LoRA Runtime composition. Each item accepts "
+            "only {name, scale}; adapters must be registered when the service starts."
         ),
     )
 

--- a/vllm_omni/entrypoints/openai/serving_video.py
+++ b/vllm_omni/entrypoints/openai/serving_video.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from __future__ import annotations
 
@@ -17,6 +17,7 @@ from PIL import Image
 from vllm.engine.protocol import EngineClient
 from vllm.logger import init_logger
 
+from vllm_omni.diffusion.lora_runtime.types import normalize_diffusion_lora_composition
 from vllm_omni.diffusion.model_metadata import get_diffusion_model_metadata
 from vllm_omni.entrypoints.async_omni import AsyncOmni
 from vllm_omni.entrypoints.openai.protocol.videos import (
@@ -286,6 +287,7 @@ class OmniOpenAIServingVideo:
             logger.info("Applied extra_params: %s", loggable)
 
         self._apply_lora(request.lora, gen_params)
+        self._apply_diffusion_loras(request.loras, gen_params)
 
         logger.info(
             "Video sampling params: steps=%s guidance=%s guidance_2=%s seed=%s",
@@ -463,6 +465,23 @@ class OmniOpenAIServingVideo:
         gen_params.lora_request = lora_request
         if lora_scale is not None:
             gen_params.lora_scale = lora_scale
+
+    @staticmethod
+    def _apply_diffusion_loras(loras_body: Any, gen_params: OmniDiffusionSamplingParams) -> None:
+        if loras_body is None:
+            return
+        if gen_params.lora_request is not None:
+            raise HTTPException(
+                status_code=HTTPStatus.BAD_REQUEST.value,
+                detail="Request cannot combine legacy lora with name-only loras.",
+            )
+        try:
+            gen_params.diffusion_loras = normalize_diffusion_lora_composition(loras_body)
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(
+                status_code=HTTPStatus.BAD_REQUEST.value,
+                detail=str(exc),
+            ) from exc
 
     async def _run_generation(
         self,

--- a/vllm_omni/entrypoints/openai/serving_video_output_stream.py
+++ b/vllm_omni/entrypoints/openai/serving_video_output_stream.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """WebSocket handler for streaming generated video chunks.
 
 Protocol:
@@ -44,6 +44,7 @@ from PIL import Image
 from pydantic import ValidationError
 from vllm.logger import init_logger
 
+from vllm_omni.diffusion.lora_runtime.types import normalize_diffusion_lora_composition
 from vllm_omni.entrypoints.async_omni import AsyncOmni
 from vllm_omni.entrypoints.openai.errors import InvalidInputReferenceError
 from vllm_omni.entrypoints.openai.protocol.videos import VideoGenerationRequest, VideoParams
@@ -559,6 +560,7 @@ class OmniStreamingVideoOutputHandler:
             gen_params.extra_args.update(request.extra_params)
 
         self._apply_lora(request.lora, gen_params)
+        self._apply_diffusion_loras(request.loras, gen_params)
         return prompt, gen_params, vp
 
     @staticmethod
@@ -601,6 +603,23 @@ class OmniStreamingVideoOutputHandler:
         gen_params.lora_request = lora_request
         if lora_scale is not None:
             gen_params.lora_scale = lora_scale
+
+    @staticmethod
+    def _apply_diffusion_loras(loras_body: Any, gen_params: OmniDiffusionSamplingParams) -> None:
+        if loras_body is None:
+            return
+        if gen_params.lora_request is not None:
+            raise HTTPException(
+                status_code=HTTPStatus.BAD_REQUEST.value,
+                detail="Request cannot combine legacy lora with name-only loras.",
+            )
+        try:
+            gen_params.diffusion_loras = normalize_diffusion_lora_composition(loras_body)
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(
+                status_code=HTTPStatus.BAD_REQUEST.value,
+                detail=str(exc),
+            ) from exc
 
     async def _iter_generation_outputs(
         self,

--- a/vllm_omni/inputs/data.py
+++ b/vllm_omni/inputs/data.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 import copy
 import pprint
 from dataclasses import asdict, dataclass, field
@@ -9,6 +12,10 @@ from vllm.inputs import EmbedsPrompt, PromptType, TextPrompt, TokensPrompt
 from vllm.inputs.engine import TokensInput
 from vllm.sampling_params import SamplingParams
 
+from vllm_omni.diffusion.lora_runtime.types import (
+    DiffusionLoRAComposition,
+    normalize_diffusion_lora_composition,
+)
 from vllm_omni.lora.request import LoRARequest
 
 DIFFUSION_QUALITY_LEVELS: tuple[str, ...] = ("lossless", "high")
@@ -319,6 +326,7 @@ class OmniDiffusionSamplingParams:
     # LoRA
     lora_request: LoRARequest | None = None
     lora_scale: float = 1.0
+    diffusion_loras: DiffusionLoRAComposition = ()
 
     # STA parameters
     STA_param: list | None = None
@@ -346,6 +354,9 @@ class OmniDiffusionSamplingParams:
     def __post_init__(self) -> None:
         if self.quality is not None and self.quality not in DIFFUSION_QUALITY_LEVELS:
             raise ValueError(f"quality must be one of {list(DIFFUSION_QUALITY_LEVELS)}, got {self.quality!r}")
+        self.diffusion_loras = normalize_diffusion_lora_composition(self.diffusion_loras)
+        if self.diffusion_loras and self.lora_request is not None:
+            raise ValueError("Legacy lora_request cannot be combined with diffusion_loras")
 
     @property
     def batch_size(self):


### PR DESCRIPTION
## Motivation and scope

Diffusion models publish LoRA adapters with model-specific checkpoint layouts, packed modules, and application semantics. The existing diffusion LoRA paths do not provide a clean model-owned contract for these differences, and combining their migration with MiniMax-H3 Turbo made the change difficult to review.

This draft therefore starts a parallel, deliberately small **Diffusion LoRA Runtime**:

- dynamic LoRA only; no prefusion, LRU, or request-time download;
- adapters are registered and fully loaded at service startup;
- requests select registered adapters by name and scale only;
- one immutable fixed-shape bank supports weighted multi-LoRA composition;
- the scheduler separates batches by canonical composition;
- existing diffusion LoRA facilities and their models are not migrated in this PR.

MiniMax-H3 FL2VA Turbo v1.0 is the first model integration. Sampling steps, flow shifts, and the H3 execution plan remain request/pipeline concerns; the LoRA runtime only installs and activates weight updates.

## Design

Each supported model explicitly provides three pieces:

1. a loader that consumes its publication format and emits normalized low-rank updates;
2. a binding plan that allowlists components and maps logical targets to physical or packed modules;
3. an executor factory, with a default TP-aware `Wx + B(Ax)` linear executor and an extension point for genuinely different model math.

The H3 loader validates the LightX2V v1.0 rank/alpha contract, maps Diffusers keys to native H3 modules, restores the native FFN row order, binds Q/K/V to packed QKV, and rejects Ref2VA-only deployment.

Example deployment:

```bash
vllm serve MiniMaxAI/MiniMax-H3 \
  --omni \
  --task-type fl2va \
  --enable-diffusion-lora \
  --diffusion-lora \
    '{"name":"turbo","path":"lightx2v/Minimax-h3-Turbo"}'
```

Request selection is name-only:

```json
{
  "loras": [
    {"name": "turbo", "scale": 1.0}
  ]
}
```

## Current validation

- 22 targeted CPU and regression tests pass.
- The generic executor is checked against the exact two-adapter reference formula.
- Startup parsing, immutable registration, unknown-name rejection, batching identity, CLI propagation, and legacy-path conflict rejection are covered.
- The real LightX2V v1.0 checkpoint is parsed into 312 normalized H3 updates with rank 128 and alpha 128.
- Ruff, formatting, typos, SPDX, forbidden-import, and CUDA-call hooks pass; the new runtime package is mypy-clean.
- Four-H200 smoke tests pass with eager and regional compile under both USP4/Ring1 and TP4 at 768×1344, 107 frames, and 4 NFE. In the same server and with the same prompt/seed, the Base and Turbo requests produce different raw video and PCM-audio hashes (video SSIM about 0.50), confirming request-level activation. Compiled Turbo Stage 0 was 10.124 s with USP4 and 9.915 s with TP4; switching from Base to Turbo did not incur another compile pause.

This PR intentionally remains a draft while review and broader validation continue.

This is a smaller replacement direction for the broad experiment in #6017 and builds on the model-adapter motivation demonstrated by #2783. Thanks to everyone who reviewed and discussed those implementations.
