### PR TITLE
[Performance] Add opt-in bounded pinned staging for diffusion weight loading

### DIFF
--- a/benchmarks/diffusion/bench_pinned_weight_staging.py
+++ b/benchmarks/diffusion/bench_pinned_weight_staging.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Microbenchmark pageable versus bounded pinned diffusion weight copies."""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+
+import torch
+
+from vllm_omni.diffusion.model_loader.pinned_staging import (
+    pinned_staging_weights_iterator,
+    release_pinned_staging_cache,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--size-mib", type=int, default=256)
+    parser.add_argument("--warmups", type=int, default=2)
+    parser.add_argument("--iterations", type=int, default=10)
+    parser.add_argument("--dtype", choices=("float32", "bfloat16"), default="bfloat16")
+    parser.add_argument("--device", default="cuda")
+    return parser.parse_args()
+
+
+def _synchronize() -> None:
+    torch.accelerator.synchronize()
+
+
+def _direct_samples(
+    source: torch.Tensor,
+    target: torch.Tensor,
+    iterations: int,
+) -> list[float]:
+    samples = []
+    for _ in range(iterations):
+        started = time.perf_counter()
+        target.copy_(source)
+        _synchronize()
+        samples.append(time.perf_counter() - started)
+    return samples
+
+
+def _staged_samples(
+    source: torch.Tensor,
+    target: torch.Tensor,
+    iterations: int,
+    capacity_bytes: int,
+) -> list[float]:
+    staged = pinned_staging_weights_iterator(
+        iter((str(index), source) for index in range(iterations)),
+        capacity_bytes=capacity_bytes,
+        min_bytes=1,
+    )
+    samples = []
+    for _ in range(iterations):
+        started = time.perf_counter()
+        _, tensor = next(staged)
+        target.copy_(tensor)
+        _synchronize()
+        samples.append(time.perf_counter() - started)
+    staged.close()
+    release_pinned_staging_cache()
+    return samples
+
+
+def _summary(name: str, samples: list[float], nbytes: int) -> None:
+    mean = statistics.mean(samples)
+    deviation = statistics.stdev(samples) if len(samples) > 1 else 0.0
+    print(f"{name}: {mean * 1000:.3f} ± {deviation * 1000:.3f} ms, {nbytes / mean / (1 << 30):.2f} GiB/s")
+
+
+def main() -> None:
+    args = parse_args()
+    if args.size_mib <= 0 or args.warmups < 0 or args.iterations <= 0:
+        raise ValueError("size-mib and iterations must be positive; warmups must be non-negative")
+
+    dtype = getattr(torch, args.dtype)
+    nbytes = args.size_mib << 20
+    numel = nbytes // dtype.itemsize
+    source = torch.arange(numel, dtype=dtype)
+    target = torch.empty(numel, dtype=dtype, device=args.device)
+
+    _direct_samples(source, target, args.warmups)
+    _staged_samples(source, target, args.warmups, nbytes)
+    direct = _direct_samples(source, target, args.iterations)
+    staged = _staged_samples(source, target, args.iterations, nbytes)
+
+    assert torch.equal(target.cpu(), source)
+    _summary("pageable", direct, nbytes)
+    _summary("pinned", staged, nbytes)
+    print(f"speedup: {statistics.mean(direct) / statistics.mean(staged):.3f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/user_guide/diffusion/startup_and_loading.md
+++ b/docs/user_guide/diffusion/startup_and_loading.md
@@ -6,12 +6,51 @@ loads safetensors shards in parallel to reduce this initialization time.
 Multi-thread weight loading is enabled by default with four threads. No
 configuration is needed for the default behavior.
 
+## Pinned Weight Staging
+
+Pipelines whose `load_weights` implementation explicitly declares synchronous
+checkpoint-tensor consumption can additionally use a fixed 256 MiB pinned
+staging slab. The slab turns pageable host-to-device copies into the faster
+pinned transfer path while preserving the checkpoint iterator's order, dtype,
+shape, and values. Peak staging memory is capped at 256 MiB per eligible
+worker. The inactive host allocator cache is released after loading when the
+installed PyTorch version exposes either the current or legacy host-cache
+cleanup entry point; otherwise that bounded slab can remain cached for the
+worker lifetime. Cache release is process-wide and can also evict inactive
+pinned blocks cached by other subsystems in that worker.
+
+Pinned staging is currently available for `StableDiffusion3Pipeline` and
+`QwenImagePipeline`, and is opt-in. Other pipelines retain the existing loader
+until their `load_weights` contract is audited and opted in. Individual tensors
+larger than the slab or smaller than 64 KiB pass through unchanged.
+
+The fast path is disabled for CPU, layerwise, or distributed offload, HSDP,
+tensor parallelism, quantized loading, TorchAO safetensors loading,
+custom/diffusers pipelines, and platforms without pinned-memory support.
+Disabling multi-thread weight loading also restores the ordinary pageable path.
+Cold startup can remain storage-bound, so the largest benefit is expected when
+checkpoint pages are already resident in the operating-system page cache.
+
+```bash
+VLLM_OMNI_ENABLE_PINNED_WEIGHT_STAGING=1 \
+  vllm serve stabilityai/stable-diffusion-3.5-medium --omni
+```
+
+To measure the pageable and pinned copy paths on the target host:
+
+```bash
+python benchmarks/diffusion/bench_pinned_weight_staging.py \
+  --size-mib 256 --warmups 2 --iterations 10 --dtype bfloat16
+```
+
 ## Configuration
 
 | Parameter | CLI flag | Default | Description |
 | --- | --- | --- | --- |
 | `enable_multithread_weight_load` | `--disable-multithread-weight-load` | `True` | Pass the flag to disable multi-thread loading |
 | `num_weight_load_threads` | `--num-weight-load-threads` | `4` | Number of parallel weight-loading threads |
+
+Set `VLLM_OMNI_ENABLE_PINNED_WEIGHT_STAGING=1` to opt into pinned staging.
 
 !!! tip
 

--- a/tests/diffusion/model_loader/test_diffusers_loader.py
+++ b/tests/diffusion/model_loader/test_diffusers_loader.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 """
 Tests for the DiffusersPipelineLoader.
@@ -22,6 +22,13 @@ from vllm_omni.diffusion.model_loader.host_weight_plan import (
     TensorBinding,
 )
 from vllm_omni.diffusion.models.helios import HeliosPipeline
+from vllm_omni.diffusion.models.interface import (
+    consumes_borrowed_weight_tensors,
+    consumes_borrowed_weights_synchronously,
+)
+from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image import (
+    QwenImagePipeline,
+)
 from vllm_omni.diffusion.registry import initialize_model
 
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
@@ -124,6 +131,201 @@ def test_empty_source_prefix_keeps_full_model_strict_check():
 
     with pytest.raises(ValueError, match="vae.weight"):
         loader.load_weights(model)
+
+
+def test_qwen_image_declares_borrowed_weight_contract():
+    pipeline = object.__new__(QwenImagePipeline)
+    assert consumes_borrowed_weights_synchronously(pipeline)
+
+
+def test_pinned_staging_wraps_final_stream_before_borrowing_consumer(monkeypatch):
+    import vllm_omni.diffusion.model_loader.diffusers_loader as loader_mod
+
+    events: list[str] = []
+
+    class _BorrowingModel(_DummyPipelineModel):
+        @consumes_borrowed_weight_tensors
+        def load_weights(self, weights):
+            events.append("consume")
+            return super().load_weights(weights)
+
+    model = _BorrowingModel(source_prefix="transformer.")
+    loader = _make_loader_with_weights(["transformer.weight"])
+    loader._should_use_pinned_staging = lambda _model: True  # type: ignore[method-assign]
+    empty_host_cache_calls: list[None] = []
+
+    def _stage(weights, *, state):
+        state.allocated = True
+        events.append("stage")
+        yield from weights
+
+    monkeypatch.setattr(loader_mod, "pinned_staging_weights_iterator", _stage)
+    monkeypatch.setattr(
+        loader_mod,
+        "release_pinned_staging_cache",
+        lambda: empty_host_cache_calls.append(None),
+    )
+    loader.load_weights(model)
+
+    assert events == ["consume", "stage"]
+    assert empty_host_cache_calls == [None]
+
+
+def test_undecorated_consumer_is_not_eligible_for_pinned_staging(monkeypatch):
+    import vllm_omni.diffusion.model_loader.diffusers_loader as loader_mod
+
+    class _UndecoratedCudaModel(nn.Module):
+        def load_weights(self, weights):
+            return list(weights)
+
+        def parameters(self, recurse: bool = True):
+            del recurse
+            return iter([SimpleNamespace(device=torch.device("cuda"))])
+
+    od_config = SimpleNamespace(
+        dtype=torch.float32,
+        parallel_config=SimpleNamespace(use_hsdp=False, tensor_parallel_size=1),
+        quantization_config=None,
+        enable_multithread_weight_load=True,
+        enable_cpu_offload=False,
+        enable_layerwise_offload=False,
+        enable_distributed_layerwise_offload=False,
+    )
+    loader = DiffusersPipelineLoader(LoadConfig(), od_config)
+    monkeypatch.setattr(loader_mod, "is_pin_memory_available", lambda: True)
+    monkeypatch.setenv("VLLM_OMNI_ENABLE_PINNED_WEIGHT_STAGING", "1")
+
+    assert not loader._should_use_pinned_staging(_UndecoratedCudaModel())
+
+
+def test_pinned_staging_cleanup_runs_on_consumer_error(monkeypatch):
+    import vllm_omni.diffusion.model_loader.diffusers_loader as loader_mod
+
+    events: list[str] = []
+
+    class _FailingBorrower(_DummyPipelineModel):
+        @consumes_borrowed_weight_tensors
+        def load_weights(self, weights):
+            next(iter(weights))
+            raise RuntimeError("injected consumer failure")
+
+    def _stage(weights, *, state):
+        state.allocated = True
+        try:
+            yield from weights
+        finally:
+            events.append("closed")
+
+    model = _FailingBorrower(source_prefix="transformer.")
+    loader = _make_loader_with_weights(["transformer.weight"])
+    loader._should_use_pinned_staging = lambda _model: True  # type: ignore[method-assign]
+    monkeypatch.setattr(loader_mod, "pinned_staging_weights_iterator", _stage)
+    monkeypatch.setattr(
+        loader_mod,
+        "release_pinned_staging_cache",
+        lambda: events.append("emptied"),
+    )
+
+    with pytest.raises(RuntimeError, match="injected consumer failure"):
+        loader.load_weights(model)
+
+    assert events == ["closed", "emptied"]
+
+
+def test_pinned_staging_eligibility_requires_accelerator_and_safe_mode(monkeypatch):
+    import vllm_omni.diffusion.model_loader.diffusers_loader as loader_mod
+
+    class _CudaBorrowingModel(nn.Module):
+        @consumes_borrowed_weight_tensors
+        def load_weights(self, weights):
+            return list(weights)
+
+        def parameters(self, recurse: bool = True):
+            del recurse
+            return iter([SimpleNamespace(device=torch.device("cuda"))])
+
+    od_config = SimpleNamespace(
+        dtype=torch.float32,
+        parallel_config=SimpleNamespace(use_hsdp=False),
+        quantization_config=None,
+        enable_multithread_weight_load=True,
+        enable_cpu_offload=False,
+        enable_layerwise_offload=False,
+        enable_distributed_layerwise_offload=False,
+    )
+    loader = DiffusersPipelineLoader(LoadConfig(), od_config)
+    model = _CudaBorrowingModel()
+    monkeypatch.setattr(loader_mod, "is_pin_memory_available", lambda: True)
+    monkeypatch.setenv("VLLM_OMNI_ENABLE_PINNED_WEIGHT_STAGING", "1")
+
+    assert loader._should_use_pinned_staging(model)
+
+    monkeypatch.setenv("VLLM_OMNI_ENABLE_PINNED_WEIGHT_STAGING", "0")
+    assert not loader._should_use_pinned_staging(model)
+    monkeypatch.setenv("VLLM_OMNI_ENABLE_PINNED_WEIGHT_STAGING", "1")
+
+    loader._active_load_format = "custom_pipeline"
+    assert not loader._should_use_pinned_staging(model)
+    loader._active_load_format = "default"
+
+    od_config.enable_cpu_offload = True
+    assert not loader._should_use_pinned_staging(model)
+    od_config.enable_cpu_offload = False
+
+    od_config.enable_layerwise_offload = True
+    assert not loader._should_use_pinned_staging(model)
+    od_config.enable_layerwise_offload = False
+
+    od_config.enable_distributed_layerwise_offload = True
+    assert not loader._should_use_pinned_staging(model)
+    od_config.enable_distributed_layerwise_offload = False
+
+    od_config.parallel_config.use_hsdp = True
+    assert not loader._should_use_pinned_staging(model)
+    od_config.parallel_config.use_hsdp = False
+
+    od_config.parallel_config.tensor_parallel_size = 2
+    assert not loader._should_use_pinned_staging(model)
+    od_config.parallel_config.tensor_parallel_size = 1
+
+    loader.quant_config = object()
+    assert not loader._should_use_pinned_staging(model)
+    loader.quant_config = None
+
+    od_config.enable_multithread_weight_load = False
+    assert not loader._should_use_pinned_staging(model)
+    od_config.enable_multithread_weight_load = True
+
+    loader.host_weight_plan = HostWeightPlan(backing_kind="checkpoint_mmap", bindings={})
+    assert not loader._should_use_pinned_staging(model)
+    loader.host_weight_plan = None
+
+    loader.load_config.safetensors_load_strategy = "torchao"
+    assert not loader._should_use_pinned_staging(model)
+    loader.load_config.safetensors_load_strategy = "lazy"
+
+    monkeypatch.setattr(loader_mod, "is_pin_memory_available", lambda: False)
+    assert not loader._should_use_pinned_staging(model)
+
+
+def test_online_quant_stream_bypasses_pinned_staging(monkeypatch):
+    import vllm_omni.diffusion.model_loader.diffusers_loader as loader_mod
+
+    model = _DummyPipelineModel(source_prefix="transformer.")
+    loader = _make_loader_with_weights(["transformer.weight"])
+    loader._should_use_pinned_staging = lambda _model: True  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        loader,
+        "_stream_online_quant_weights_to_cpu",
+        lambda _model, weights: weights,
+    )
+    monkeypatch.setattr(
+        loader_mod,
+        "pinned_staging_weights_iterator",
+        lambda _weights: pytest.fail("online quant must not stage"),
+    )
+
+    loader.load_weights(model, stream_online_quant_to_cpu=True)
 
 
 def test_stream_online_quant_weights_offloads_layers_after_processing():

--- a/tests/diffusion/model_loader/test_pinned_staging.py
+++ b/tests/diffusion/model_loader/test_pinned_staging.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+import pytest
+import torch
+
+from vllm_omni.diffusion import envs as diffusion_envs
+from vllm_omni.diffusion.model_loader import pinned_staging
+from vllm_omni.diffusion.model_loader.pinned_staging import (
+    PinnedStagingState,
+    pinned_staging_weights_iterator,
+    release_pinned_staging_cache,
+)
+from vllm_omni.diffusion.models.interface import (
+    consumes_borrowed_weight_tensors,
+    consumes_borrowed_weights_synchronously,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+def _cpu_slab(nbytes: int) -> torch.Tensor:
+    return torch.empty(nbytes, dtype=torch.uint8)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [("0", False), ("1", True), ("true", True), ("YES", True), ("off", False)],
+)
+def test_pinned_staging_environment_flag(monkeypatch, raw, expected):
+    monkeypatch.setenv("VLLM_OMNI_ENABLE_PINNED_WEIGHT_STAGING", raw)
+    assert diffusion_envs.VLLM_OMNI_ENABLE_PINNED_WEIGHT_STAGING is expected
+
+
+def test_host_cache_cleanup_is_best_effort(monkeypatch):
+    monkeypatch.delattr(pinned_staging.torch.accelerator, "empty_host_cache", raising=False)
+    fallback_calls: list[None] = []
+    monkeypatch.setattr(
+        pinned_staging.torch._C,
+        "_host_emptyCache",
+        lambda: fallback_calls.append(None),
+        raising=False,
+    )
+    release_pinned_staging_cache()
+    assert fallback_calls == [None]
+
+    def _fail_cleanup():
+        raise RuntimeError("injected cleanup failure")
+
+    monkeypatch.setattr(
+        pinned_staging.torch.accelerator,
+        "empty_host_cache",
+        _fail_cleanup,
+        raising=False,
+    )
+    monkeypatch.delattr(pinned_staging.torch._C, "_host_emptyCache", raising=False)
+    release_pinned_staging_cache()
+
+
+def test_staging_preserves_order_values_and_reuses_fixed_storage(monkeypatch):
+    allocations: list[int] = []
+
+    def _allocate(nbytes: int) -> torch.Tensor:
+        allocations.append(nbytes)
+        return _cpu_slab(nbytes)
+
+    monkeypatch.setattr(pinned_staging, "_alloc_pinned", _allocate)
+    source = iter(
+        [
+            ("first", torch.arange(8, dtype=torch.float32)),
+            ("second", torch.arange(8, dtype=torch.float32) + 10),
+        ]
+    )
+    state = PinnedStagingState()
+    staged = pinned_staging_weights_iterator(
+        source,
+        capacity_bytes=64,
+        min_bytes=1,
+        state=state,
+    )
+
+    first_name, first = next(staged)
+    first_ptr = first.data_ptr()
+    assert first_name == "first"
+    assert first.shape == (8,)
+    assert first.dtype is torch.float32
+    assert first.stride() == (1,)
+    assert torch.equal(first, torch.arange(8, dtype=torch.float32))
+
+    second_name, second = next(staged)
+    assert second_name == "second"
+    assert second.data_ptr() == first_ptr
+    assert torch.equal(second, torch.arange(8, dtype=torch.float32) + 10)
+    with pytest.raises(StopIteration):
+        next(staged)
+    assert allocations == [64]
+    assert state.allocated
+
+
+def test_staging_preserves_noncanonical_singleton_strides(monkeypatch):
+    monkeypatch.setattr(pinned_staging, "_alloc_pinned", _cpu_slab)
+    source = torch.empty_strided((1, 65536), (123456, 1), dtype=torch.float32)
+    source.copy_(torch.arange(65536, dtype=torch.float32).view(1, -1))
+
+    output = list(
+        pinned_staging_weights_iterator(
+            iter([("weight", source)]),
+            capacity_bytes=1 << 20,
+            min_bytes=1,
+        )
+    )
+
+    staged = output[0][1]
+    assert staged.shape == source.shape
+    assert staged.stride() == source.stride()
+    assert torch.equal(staged, source)
+
+
+def test_unsupported_tensors_pass_through_by_identity(monkeypatch):
+    monkeypatch.setattr(pinned_staging, "_alloc_pinned", _cpu_slab)
+    small = torch.ones(1)
+    oversized = torch.ones(32)
+    non_contiguous = torch.arange(8).view(2, 4).t()
+    requires_grad = torch.ones(4, requires_grad=True)
+
+    output = list(
+        pinned_staging_weights_iterator(
+            iter(
+                [
+                    ("small", small),
+                    ("oversized", oversized),
+                    ("non_contiguous", non_contiguous),
+                    ("requires_grad", requires_grad),
+                ]
+            ),
+            capacity_bytes=64,
+            min_bytes=8,
+        )
+    )
+
+    assert [name for name, _ in output] == [
+        "small",
+        "oversized",
+        "non_contiguous",
+        "requires_grad",
+    ]
+    assert output[0][1] is small
+    assert output[1][1] is oversized
+    assert output[2][1] is non_contiguous
+    assert output[3][1] is requires_grad
+
+
+def test_empty_and_small_only_streams_do_not_allocate(monkeypatch):
+    def _unexpected_allocation(_nbytes: int) -> torch.Tensor:
+        raise AssertionError("no slab should be allocated")
+
+    monkeypatch.setattr(pinned_staging, "_alloc_pinned", _unexpected_allocation)
+    state = PinnedStagingState()
+    assert (
+        list(
+            pinned_staging_weights_iterator(
+                iter(()),
+                capacity_bytes=64,
+                min_bytes=8,
+                state=state,
+            )
+        )
+        == []
+    )
+    small = torch.ones(1)
+    assert list(
+        pinned_staging_weights_iterator(
+            iter([("small", small)]),
+            capacity_bytes=64,
+            min_bytes=8,
+            state=state,
+        )
+    ) == [("small", small)]
+    assert not state.allocated
+
+
+def test_allocation_failure_falls_back_without_losing_current_item(monkeypatch):
+    def _fail(_nbytes: int) -> torch.Tensor:
+        raise RuntimeError("memlock exhausted")
+
+    monkeypatch.setattr(pinned_staging, "_alloc_pinned", _fail)
+    first = torch.arange(8, dtype=torch.float32)
+    second = torch.arange(8, dtype=torch.float32) + 1
+    state = PinnedStagingState()
+    output = list(
+        pinned_staging_weights_iterator(
+            iter([("first", first), ("second", second)]),
+            capacity_bytes=64,
+            min_bytes=1,
+            state=state,
+        )
+    )
+
+    assert output[0] == ("first", first)
+    assert output[1] == ("second", second)
+    assert output[0][1] is first
+    assert output[1][1] is second
+    assert not state.allocated
+
+
+def test_staging_copy_error_propagates(monkeypatch):
+    monkeypatch.setattr(pinned_staging, "_alloc_pinned", lambda _nbytes: torch.empty(1, dtype=torch.uint8))
+    staged = pinned_staging_weights_iterator(
+        iter([("weight", torch.arange(8, dtype=torch.float32))]),
+        capacity_bytes=64,
+        min_bytes=1,
+    )
+
+    with pytest.raises(RuntimeError):
+        next(staged)
+
+
+def test_upstream_error_propagates(monkeypatch):
+    monkeypatch.setattr(pinned_staging, "_alloc_pinned", _cpu_slab)
+
+    def _source():
+        yield "weight", torch.ones(1)
+        raise ValueError("checkpoint corrupt")
+
+    staged = pinned_staging_weights_iterator(_source(), capacity_bytes=64, min_bytes=8)
+    assert next(staged)[0] == "weight"
+    with pytest.raises(ValueError, match="checkpoint corrupt"):
+        next(staged)
+
+
+@pytest.mark.parametrize(
+    ("capacity_bytes", "min_bytes", "message"),
+    [(0, 1, "capacity_bytes"), (1, -1, "min_bytes")],
+)
+def test_invalid_limits_rejected(capacity_bytes, min_bytes, message):
+    staged = pinned_staging_weights_iterator(
+        iter(()),
+        capacity_bytes=capacity_bytes,
+        min_bytes=min_bytes,
+    )
+    with pytest.raises(ValueError, match=message):
+        next(staged)
+
+
+def test_borrowed_weight_marker_does_not_leak_to_override():
+    class SynchronousConsumer:
+        @consumes_borrowed_weight_tensors
+        def load_weights(self, weights):
+            return list(weights)
+
+    class RetainingOverride(SynchronousConsumer):
+        def load_weights(self, weights):
+            self.retained = list(weights)
+
+    assert consumes_borrowed_weights_synchronously(SynchronousConsumer())
+    assert not consumes_borrowed_weights_synchronously(RetainingOverride())

--- a/tests/diffusion/model_loader/test_pinned_staging_cuda.py
+++ b/tests/diffusion/model_loader/test_pinned_staging_cuda.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+from vllm.config.load import LoadConfig
+
+from tests.helpers.mark import hardware_test
+from vllm_omni.diffusion.model_loader.diffusers_loader import (
+    DiffusersPipelineLoader,
+)
+from vllm_omni.diffusion.model_loader.pinned_staging import (
+    pinned_staging_weights_iterator,
+    release_pinned_staging_cache,
+)
+from vllm_omni.diffusion.models.interface import consumes_borrowed_weight_tensors
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion]
+
+
+@hardware_test(res={"cuda": "L4"})
+def test_real_pinned_slab_h2d_parity_and_reuse():
+    values = [
+        torch.arange(4 << 20, dtype=torch.float32),
+        torch.arange(4 << 20, dtype=torch.float32) + 7,
+    ]
+    staged = pinned_staging_weights_iterator(
+        iter([("first", values[0]), ("second", values[1])]),
+        capacity_bytes=32 << 20,
+        min_bytes=1,
+    )
+
+    first_name, first = next(staged)
+    first_ptr = first.data_ptr()
+    assert first_name == "first"
+    assert first.is_pinned()
+    first_device = first.to("cuda", non_blocking=True)
+    torch.accelerator.synchronize()
+    assert torch.equal(first_device.cpu(), values[0])
+
+    second_name, second = next(staged)
+    assert second_name == "second"
+    assert second.is_pinned()
+    assert second.data_ptr() == first_ptr
+    second_device = second.to("cuda", non_blocking=True)
+    torch.accelerator.synchronize()
+    assert torch.equal(second_device.cpu(), values[1])
+
+    with pytest.raises(StopIteration):
+        next(staged)
+
+
+@hardware_test(res={"cuda": "L4"})
+def test_loader_enabled_path_releases_host_cache(monkeypatch):
+    class _CudaModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = nn.Parameter(torch.empty(4 << 20, device="cuda"))
+
+        @consumes_borrowed_weight_tensors
+        def load_weights(self, weights):
+            loaded = set()
+            for name, tensor in weights:
+                self.weight.data.copy_(tensor)
+                loaded.add(name)
+            return loaded
+
+    od_config = SimpleNamespace(
+        dtype=torch.float32,
+        parallel_config=SimpleNamespace(use_hsdp=False, tensor_parallel_size=1),
+        quantization_config=None,
+        enable_multithread_weight_load=True,
+        enable_cpu_offload=False,
+        enable_layerwise_offload=False,
+        enable_distributed_layerwise_offload=False,
+    )
+    loader = DiffusersPipelineLoader(LoadConfig(), od_config)
+    source = torch.arange(4 << 20, dtype=torch.float32)
+    loader.get_all_weights = lambda _model: iter([("weight", source)])  # type: ignore[method-assign]
+    model = _CudaModel()
+    monkeypatch.setenv("VLLM_OMNI_ENABLE_PINNED_WEIGHT_STAGING", "1")
+
+    release_pinned_staging_cache()
+    before = torch.cuda.host_memory_stats()["allocated_bytes.current"]
+    loader.load_weights(model)
+    after = torch.cuda.host_memory_stats()["allocated_bytes.current"]
+
+    assert torch.equal(model.weight.cpu(), source)
+    assert after <= before

--- a/vllm_omni/diffusion/envs.py
+++ b/vllm_omni/diffusion/envs.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 # Copyright 2024 xDiT team.
 # Adapted from
 # https://github.com/xdit-project/xDiT/blob/main/xfuser/envs.py
@@ -12,6 +15,7 @@ if TYPE_CHECKING:
     MASTER_PORT: int | None = None
     CUDA_HOME: str | None = None
     LOCAL_RANK: int = 0
+    VLLM_OMNI_ENABLE_PINNED_WEIGHT_STAGING: bool = False
 
 environment_variables: dict[str, Callable[[], Any]] = {
     # ================== Runtime Env Vars ==================
@@ -25,6 +29,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # local rank of the process in the distributed setting, used to determine
     # the GPU device id
     "LOCAL_RANK": lambda: int(os.environ.get("LOCAL_RANK", "0")),
+    "VLLM_OMNI_ENABLE_PINNED_WEIGHT_STAGING": lambda: (
+        os.getenv(
+            "VLLM_OMNI_ENABLE_PINNED_WEIGHT_STAGING",
+            "0",
+        )
+        .strip()
+        .lower()
+        in {"1", "true", "yes"}
+    ),
 }
 
 

--- a/vllm_omni/diffusion/model_loader/diffusers_loader.py
+++ b/vllm_omni/diffusion/model_loader/diffusers_loader.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 import contextlib
 import dataclasses
 import glob
@@ -8,7 +8,7 @@ import re
 import time
 from collections.abc import Generator, Iterable, Sequence
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import torch
 from torch import nn
@@ -26,8 +26,10 @@ from vllm.model_executor.model_loader.weight_utils import (
 )
 from vllm.transformers_utils.repo_utils import file_exists
 from vllm.utils.import_utils import resolve_obj_by_qualname
+from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.utils.torch_utils import set_default_torch_dtype
 
+from vllm_omni.diffusion import envs as diffusion_envs
 from vllm_omni.diffusion.config import set_current_diffusion_config
 from vllm_omni.diffusion.data import OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.hsdp import HSDPInferenceConfig, apply_hsdp_to_model
@@ -39,7 +41,15 @@ from vllm_omni.diffusion.model_loader.host_weight_plan import (
     build_checkpoint_mmap_plan,
     has_online_quantization,
 )
+from vllm_omni.diffusion.model_loader.pinned_staging import (
+    PinnedStagingState,
+    pinned_staging_weights_iterator,
+    release_pinned_staging_cache,
+)
 from vllm_omni.diffusion.models.diffusers_adapter.pipeline_diffusers_adapter import DiffusersAdapterPipeline
+from vllm_omni.diffusion.models.interface import (
+    consumes_borrowed_weights_synchronously,
+)
 from vllm_omni.diffusion.offloader.module_collector import ModuleDiscovery
 from vllm_omni.diffusion.registry import initialize_model
 
@@ -141,6 +151,7 @@ class DiffusersPipelineLoader:
         self.quant_config = od_config.quantization_config
         self.parallel_config = od_config.parallel_config
         self.host_weight_plan: HostWeightPlan | None = None
+        self._active_load_format = "default"
 
     def take_host_weight_plan(self) -> HostWeightPlan | None:
         """Transfer the loader-produced plan to the offload backend."""
@@ -285,8 +296,8 @@ class DiffusersPipelineLoader:
 
     def _get_source_quant_config(self, source: "ComponentSource") -> object | None:
         quant_config = self.quant_config
-        if hasattr(quant_config, "resolve"):
-            return quant_config.resolve(source.prefix.rstrip("."))
+        if quant_config is not None and hasattr(quant_config, "resolve"):
+            return cast(Any, quant_config).resolve(source.prefix.rstrip("."))
         return quant_config
 
     def _get_checkpoint_adapter(
@@ -403,6 +414,7 @@ class DiffusersPipelineLoader:
         self.host_weight_plan = None
         if load_format is None:
             load_format = "default"
+        self._active_load_format = load_format
         # CPU offload + quantization: for offline-quantized models (e.g., AutoRound MXFP8),
         # weights are already quantized in the checkpoint — load directly on CPU.
         # For online quantization, load on device so quantization can run on accelerator,
@@ -456,19 +468,19 @@ class DiffusersPipelineLoader:
                     )
                     self.host_weight_plan = plan_result.plan
 
-                _skip_load = self.host_weight_plan is not None
+                host_weight_plan = self.host_weight_plan
 
-                if _skip_load:
+                if host_weight_plan is not None:
                     logger.info(
                         "DLO host-weight plan active (%s, %s): skipping ordinary materialization for %s",
                         "AllGather" if _use_ag and _dlo_group_size > 1 else "rank-local",
-                        self.host_weight_plan.backing_kind,
-                        sorted(self.host_weight_plan.planned_source_prefixes) or "legacy DiT sources",
+                        host_weight_plan.backing_kind,
+                        sorted(host_weight_plan.planned_source_prefixes) or "legacy DiT sources",
                     )
                     ordinary_sources = tuple(
                         source
                         for source in weight_sources
-                        if source.prefix not in self.host_weight_plan.planned_source_prefixes
+                        if source.prefix not in host_weight_plan.planned_source_prefixes
                     )
                     if ordinary_sources:
                         logger.info(
@@ -478,7 +490,7 @@ class DiffusersPipelineLoader:
                         self.load_weights(
                             model,
                             sources=ordinary_sources,
-                            planned_weights=self.host_weight_plan.bindings,
+                            planned_weights=host_weight_plan.bindings,
                         )
                 else:
                     if _dist_offload and _use_ag and _has_online_quant:
@@ -541,7 +553,7 @@ class DiffusersPipelineLoader:
         marked = 0
         for module in model.modules():
             quant_method = getattr(module, "quant_method", None)
-            if getattr(quant_method, "supports_offload_after_quant", False):
+            if quant_method is not None and getattr(quant_method, "supports_offload_after_quant", False):
                 quant_method.enable_offload_after_quant()
                 marked += 1
         return marked
@@ -682,9 +694,25 @@ class DiffusersPipelineLoader:
     ) -> None:
         weights_to_load = self._get_expected_parameter_names(model)
         weights = self.get_all_weights(model) if sources is None else self.get_all_weights(model, sources=sources)
+        staged_weights = None
+        staging_state = None
         if stream_online_quant_to_cpu:
             weights = self._stream_online_quant_weights_to_cpu(model, weights)
-        loaded_weights = model.load_weights(weights)
+        elif self._should_use_pinned_staging(model):
+            staging_state = PinnedStagingState()
+            staged_weights = pinned_staging_weights_iterator(
+                iter(weights),
+                state=staging_state,
+            )
+            weights = staged_weights
+        try:
+            loaded_weights = model.load_weights(weights)
+        finally:
+            if staged_weights is not None:
+                staged_weights.close()
+                del weights
+                if staging_state is not None and staging_state.allocated:
+                    release_pinned_staging_cache()
         if loaded_weights is not None:
             loaded_weights = set(loaded_weights).union(planned_weights)
 
@@ -713,6 +741,37 @@ class DiffusersPipelineLoader:
                 logger.warning(
                     f"Following weight_scale weights were not initialized from checkpoint: {weights_scale_not_loaded}"
                 )
+
+    def _should_use_pinned_staging(self, model: nn.Module) -> bool:
+        if self._active_load_format != "default":
+            return False
+        if not consumes_borrowed_weights_synchronously(model):
+            return False
+        if self.host_weight_plan is not None:
+            return False
+        if self.quant_config is not None:
+            return False
+        if self.load_config.safetensors_load_strategy == "torchao":
+            return False
+        if not diffusion_envs.VLLM_OMNI_ENABLE_PINNED_WEIGHT_STAGING:
+            return False
+        if not getattr(self.od_config, "enable_multithread_weight_load", False):
+            return False
+        if any(
+            getattr(self.od_config, field, False)
+            for field in (
+                "enable_cpu_offload",
+                "enable_layerwise_offload",
+                "enable_distributed_layerwise_offload",
+            )
+        ):
+            return False
+        if self.parallel_config.use_hsdp or not is_pin_memory_available():
+            return False
+        if int(getattr(self.parallel_config, "tensor_parallel_size", 1)) != 1:
+            return False
+        parameter = next(model.parameters(), None)
+        return parameter is not None and parameter.device.type == "cuda"
 
     @staticmethod
     def _is_expected_quantized_weight(name: str) -> bool:

--- a/vllm_omni/diffusion/model_loader/pinned_staging.py
+++ b/vllm_omni/diffusion/model_loader/pinned_staging.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Bounded pinned-memory staging for diffusion checkpoint tensors.
+
+The iterator copies eligible pageable CPU tensors into one fixed-size pinned
+slab before yielding them to ``load_weights``.  The slab is reused only when
+the consumer requests the next tensor, so opted-in consumers can overlap the
+driver's pinned H2D path with no unbounded pool or size-class growth.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator, Iterator
+from dataclasses import dataclass
+
+import torch
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+DEFAULT_PINNED_STAGING_CAPACITY_BYTES = 256 << 20
+DEFAULT_PINNED_STAGING_MIN_BYTES = 64 << 10
+
+
+@dataclass
+class PinnedStagingState:
+    allocated: bool = False
+
+
+def _alloc_pinned(nbytes: int) -> torch.Tensor:
+    return torch.empty(nbytes, dtype=torch.uint8, pin_memory=True)
+
+
+def release_pinned_staging_cache() -> None:
+    """Release inactive pinned blocks when the installed Torch supports it."""
+    empty_host_cache = getattr(torch.accelerator, "empty_host_cache", None)
+    if empty_host_cache is None:
+        empty_host_cache = getattr(torch._C, "_host_emptyCache", None)
+    if empty_host_cache is None:
+        logger.debug_once(
+            "Torch does not expose host-cache cleanup; the bounded staging slab may remain in the host allocator cache."
+        )
+        return
+    try:
+        empty_host_cache()
+    except Exception as exc:  # Cache cleanup must never replace the load result.
+        logger.warning("Failed to release the pinned host allocator cache: %s", exc)
+
+
+def _can_stage(tensor: torch.Tensor, *, capacity_bytes: int, min_bytes: int) -> bool:
+    nbytes = tensor.numel() * tensor.element_size()
+    return (
+        type(tensor) is torch.Tensor
+        and tensor.device.type == "cpu"
+        and tensor.layout is torch.strided
+        and tensor.is_contiguous()
+        and not tensor.requires_grad
+        and min_bytes <= nbytes <= capacity_bytes
+    )
+
+
+def pinned_staging_weights_iterator(
+    weights: Iterator[tuple[str, torch.Tensor]],
+    *,
+    capacity_bytes: int = DEFAULT_PINNED_STAGING_CAPACITY_BYTES,
+    min_bytes: int = DEFAULT_PINNED_STAGING_MIN_BYTES,
+    state: PinnedStagingState | None = None,
+) -> Generator[tuple[str, torch.Tensor], None, None]:
+    """Yield weights in order through one bounded pinned-memory slab.
+
+    The caller must guarantee that every staged tensor is consumed
+    synchronously before requesting the next item.  Unsupported and oversized
+    tensors pass through by identity.  If the initial pinned allocation fails,
+    the untouched input iterator is forwarded without staging.
+    """
+    if capacity_bytes <= 0:
+        raise ValueError("capacity_bytes must be positive")
+    if min_bytes < 0:
+        raise ValueError("min_bytes must be non-negative")
+
+    source = iter(weights)
+    slab: torch.Tensor | None = None
+    staging_available = True
+    staged_bytes = 0
+    staged_tensors = 0
+    for name, tensor in source:
+        if not staging_available or not _can_stage(
+            tensor,
+            capacity_bytes=capacity_bytes,
+            min_bytes=min_bytes,
+        ):
+            yield name, tensor
+            continue
+
+        if slab is None:
+            try:
+                slab = _alloc_pinned(capacity_bytes)
+                if state is not None:
+                    state.allocated = True
+            except (OSError, RuntimeError, TypeError, ValueError) as exc:
+                staging_available = False
+                logger.warning_once(
+                    "Pinned weight staging unavailable; using pageable weights: %s",
+                    exc,
+                )
+                yield name, tensor
+                continue
+
+        nbytes = tensor.numel() * tensor.element_size()
+        staged = (
+            slab[:nbytes]
+            .view(tensor.dtype)
+            .as_strided(
+                tensor.shape,
+                tensor.stride(),
+            )
+        )
+        staged.copy_(tensor)
+        staged_bytes += nbytes
+        staged_tensors += 1
+        yield name, staged
+
+    if staged_tensors:
+        logger.info(
+            "Pinned weight staging copied %.2f GiB across %d tensors (%.2f GiB fixed capacity).",
+            staged_bytes / (1 << 30),
+            staged_tensors,
+            capacity_bytes / (1 << 30),
+        )

--- a/vllm_omni/diffusion/models/interface.py
+++ b/vllm_omni/diffusion/models/interface.py
@@ -1,16 +1,44 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
     ClassVar,
     Literal,
+    ParamSpec,
     Protocol,
+    TypeVar,
     runtime_checkable,
 )
+
+_BORROWED_WEIGHT_CONSUMER_MARKER = "_consumes_borrowed_weight_tensors"
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+def consumes_borrowed_weight_tensors(method: Callable[_P, _R]) -> Callable[_P, _R]:
+    """Declare synchronous consumption of each ``load_weights`` tensor.
+
+    The decorated method must finish every read or copy from the current
+    checkpoint tensor, retain no aliases, and enqueue no asynchronous use
+    before requesting the next iterator item.
+
+    This is a method marker rather than a class capability so a subclass that
+    overrides ``load_weights`` must explicitly re-declare the contract.
+    """
+    setattr(method, _BORROWED_WEIGHT_CONSUMER_MARKER, True)
+    return method
+
+
+def consumes_borrowed_weights_synchronously(model: object) -> bool:
+    """Return whether the effective ``load_weights`` method declares the contract."""
+    method = getattr(type(model), "load_weights", None)
+    return bool(getattr(method, _BORROWED_WEIGHT_CONSUMER_MARKER, False))
+
 
 if TYPE_CHECKING:
     from collections.abc import Sequence

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 import copy
 import inspect
@@ -29,7 +29,10 @@ from vllm_omni.diffusion.lora.loader import QwenImageLoraLoaderMixin
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_prefetch, prefetch_subfolders
 from vllm_omni.diffusion.models.dmd2 import DMD2PipelineMixin
-from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
+from vllm_omni.diffusion.models.interface import (
+    SupportsComponentDiscovery,
+    consumes_borrowed_weight_tensors,
+)
 from vllm_omni.diffusion.models.qwen_image.cfg_parallel import (
     QwenImageCFGParallelMixin,
 )
@@ -1093,6 +1096,7 @@ class QwenImagePipeline(
             num_outputs_per_prompt=num_images_per_prompt,
         )
 
+    @consumes_borrowed_weight_tensors
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
         return loader.load_weights(weights)

--- a/vllm_omni/diffusion/models/sd3/pipeline_sd3.py
+++ b/vllm_omni/diffusion/models/sd3/pipeline_sd3.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 import inspect
 import json
 import logging
@@ -21,7 +24,10 @@ from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_prefetch, prefetch_subfolders
-from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
+from vllm_omni.diffusion.models.interface import (
+    SupportsComponentDiscovery,
+    consumes_borrowed_weight_tensors,
+)
 from vllm_omni.diffusion.models.sd3.sd3_transformer import (
     SD3Transformer2DModel,
 )
@@ -769,6 +775,7 @@ class StableDiffusion3Pipeline(nn.Module, CFGParallelMixin, DiffusionPipelinePro
             num_outputs_per_prompt=num_images_per_prompt,
         )
 
+    @consumes_borrowed_weight_tensors
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
         return loader.load_weights(weights)


### PR DESCRIPTION
# Summary

Add an opt-in, bounded pinned-memory staging path for audited diffusion weight consumers.

- Reuse one fixed 256 MiB pinned slab; preserve checkpoint order, dtype, shape, strides, and values.
- Add a method-level borrowed-tensor contract so subclasses that override `load_weights` must opt in again.
- Wrap the post-adapter stream immediately before `model.load_weights`.
- Enable the contract only for `StableDiffusion3Pipeline` and `QwenImagePipeline`.
- Opt in with `VLLM_OMNI_ENABLE_PINNED_WEIGHT_STAGING=1`.
- Fall back losslessly when pin allocation is unavailable.
- Release the inactive host allocator cache after loading through the public Torch API or the existing `torch._C._host_emptyCache` compatibility path.

This intentionally does **not** include speculative page-cache prewarm, dtype conversion, producer threads, or cooperative TP collectives.

## Eligibility and safety

The fast path requires all of the following:

- default registered loader;
- decorated synchronous `load_weights` consumer;
- TP=1 accelerator-resident model;
- multithread safetensors loading enabled;
- no quantization, CPU/layerwise/distributed offload, HSDP, DLO host plan, TorchAO strategy, or custom/diffusers loader;
- platform pinned-memory support.

Tensors smaller than 64 KiB, larger than 256 MiB, non-contiguous, non-CPU, tensor subclasses, and tensors requiring gradients pass through by identity. The slab is reused only after the consumer requests the next item.

Host-cache cleanup is process-wide and can evict other inactive pinned blocks. The feature is therefore explicit opt-in and startup-only.

## Performance

Frozen base: `bd4f9acfd30456cb8fa98af53d32f7adc34e03a0`  
Benchmarked commit: `d5e9e5b70ea7831e090a3ea06ba49e95929b68ae`  
Model revision: SD3.5-medium snapshot `b940f670f0eda2d07fbb75229e779da1ad11eb80`  
Environment: 1× NVIDIA L20X, Torch 2.13.0+cu130, vLLM 0.27.0, eager mode, fixed prompt/seed, 256×256, one inference step.

### SD3 warm checkpoint: 10-run same-commit ABBA

The exact transformer shard was confirmed 100% page-cache resident with `fincore` before the run matrix.

| Metric | staging off | staging on | result |
| --- | ---: | ---: | ---: |
| Transformer `Loading weights took` | 1.239 ± 0.111 s | 0.869 ± 0.142 s | **-29.9%, 1.43×** |
| Full model-load span | 8.581 ± 1.176 s | 7.694 ± 1.109 s | noisy; no broad claim |
| Engine initialization | 63.904 ± 22.976 s | 62.084 ± 24.078 s | host-noisy/inconclusive |

Paired loader saving: **0.370 s**, 95% CI **[0.219, 0.521] s**.

Raw loader seconds:

- off: `[1.10, 1.35, 1.28, 1.11, 1.15, 1.13, 1.33, 1.35, 1.21, 1.38]`
- on: `[1.25, 0.73, 0.84, 0.77, 0.82, 0.83, 0.90, 0.83, 0.88, 0.84]`

### Qwen-Image warm checkpoint: four full-E2E ABBA pairs

Model revision: `75e0b4be04f60ec59a75f475837eced720f823b6`. The 38.055 GiB transformer is the ordinary-loader source; staging covered 38.044 GiB across 846 tensors.

| Metric | staging off | staging on | result |
| --- | ---: | ---: | ---: |
| Transformer `Loading weights took` | 9.390 ± 0.353 s | 3.973 ± 0.156 s | **-57.7%, 2.36×** |
| Full model-load span | 17.159 ± 0.999 s | 11.893 ± 0.511 s | **-30.7%** |
| Engine initialization | 50.393 ± 1.187 s | 45.618 ± 1.122 s | **-9.5%** |

Raw loader seconds:

- off: `[9.18, 9.91, 9.31, 9.16]`
- on: `[4.07, 4.05, 3.74, 4.03]`

All eight 256×256 one-step outputs were byte-identical, SHA-256:
`3b93f26267630963185ee67d8020972faee108a7bca80db725817e4680c9955c`.

A final smoke on the exact rebased commit measured 9.39 s off versus 4.20 s on, with the same output hash.

### SD3 cold checkpoint: 3 targeted-eviction pairs

Before each process, only the exact SD3 transformer shard was evicted with `POSIX_FADV_DONTNEED`; `fincore` confirmed zero resident bytes.

| Metric | staging off | staging on | result |
| --- | ---: | ---: | ---: |
| Transformer loader | 3.787 ± 0.284 s | 3.777 ± 0.580 s | neutral/inconclusive |

Raw loader seconds:

- off: `[3.98, 3.92, 3.46]`
- on: `[4.36, 3.77, 3.20]`

Cold startup remains storage-bound; this PR does not claim a cold-load improvement.

### Copy microbenchmark

```bash
python benchmarks/diffusion/bench_pinned_weight_staging.py \
  --size-mib 256 --warmups 2 --iterations 10 --dtype bfloat16
```

| path | latency | effective bandwidth |
| --- | ---: | ---: |
| pageable | 34.552 ± 0.931 ms | 7.24 GiB/s |
| pinned, including CPU staging copy | 13.336 ± 0.379 ms | 18.75 GiB/s |

Speedup: **2.59×**.

## Correctness and resource validation

- All 20 SD3 warm and 6 valid SD3 cold outputs had identical PNG SHA-256:
  `13b207fc3de931c5cf942e5f1887d43892a4561b1e228f9143dd1b0fe45e808c`.
- TP2 was measured before rollout: duplicated staging regressed, so the final code disables staging for TP>1. The gated TP2 path matched main and produced identical output.
- Peak GPU memory was unchanged at 16.19 GiB in the controlled SD3 smoke runs.
- The real CUDA loader test asserts pinned allocator bytes return to their pre-load level.
- Torch 2.11 fallback cleanup was independently verified with `torch._C._host_emptyCache` (16 MiB allocated → 0 after cleanup).

## Additional model evaluation

Two other requested families were audited and tested but are **not** enabled:

- **Wan2.2-TI2V-5B:** four warm full-E2E pairs were byte-identical, but staging regressed loader time from `2.825 ± 0.247 s` to `3.535 ± 0.507 s` (**+25.1%**). The first cold/warm pair looked positive and was excluded once the warm matrix exposed the regression.
- **MiniMax-H3 FL2VA:** staging covered 81.81 GiB, but loader time was effectively neutral (`24.85 → 24.58 s`) and full model load regressed (`59.19 → 61.74 s`). Both two-step requests produced identical frame/audio shapes and the same 130666 MiB peak GPU memory.

These results support model-specific opt-in rather than broad activation.

## Tests

```text
62 passed:
  tests/diffusion/model_loader/test_diffusers_loader.py
  tests/diffusion/model_loader/test_hub_prefetch.py
  tests/diffusion/model_loader/test_modelopt_fp8_adapter.py
  tests/diffusion/model_loader/test_pinned_staging.py
  tests/diffusion/models/sd3/test_sd3_pipeline.py
  tests/diffusion/models/qwen_image/test_qwen_image_max_sequence_length.py

2 passed on real CUDA:
  tests/diffusion/model_loader/test_pinned_staging_cuda.py
```

Also passed:

- complete pre-commit suite on every changed file;
- Ruff check/format;
- Python 3.10 mypy hook;
- markdownlint and SPDX checks;
- `git diff --check`.

## Scope

This is deliberately a narrow first integration: opt-in, SD3 and Qwen-Image, TP1, full precision. Other diffusion pipelines can adopt the method contract after their transitive weight consumers are audited and benchmarked.