### PR TITLE
[AR-Diffusion] Page in kernel-legal blocks so the default resolution can run

### DIFF
--- a/tests/diffusion/ar_diffusion/test_capability_runner.py
+++ b/tests/diffusion/ar_diffusion/test_capability_runner.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """CPU contracts for capability-driven AR-Diffusion sessions."""
 
 from __future__ import annotations

--- a/tests/diffusion/ar_diffusion/test_capability_runner.py
+++ b/tests/diffusion/ar_diffusion/test_capability_runner.py
@@ -314,10 +314,17 @@ def test_lru_eviction_releases_blocks_and_notifies_pipeline():
 
 def test_budget_reduced_capacity_drives_runner_lru():
     pipeline = CapablePipeline(tiny_spec(capacity=2))
-    # One tiny LingBot-like session requires 128 bytes; two require 192.
+    # One tiny LingBot-like session requires 1,808 bytes; two require 2,592.
+    #
+    # These read 128 and 192 while the paging unit was the frame. tiny_spec
+    # declares one token per frame, so it used to page a single token at a
+    # time -- a block size no attention kernel accepts. Paging at 16 makes
+    # each page sixteen times larger. The block *counts* are unchanged, and
+    # so is what this test is about: a budget that fits fewer sessions than
+    # the pipeline asked for must drive the runner's LRU.
     runner = make_runner(
         pipeline,
-        available_bytes=128,
+        available_bytes=2048,
         gpu_memory_fraction=1.0,
     )
     kv = runner.kv_cache
@@ -456,3 +463,30 @@ def test_pipeline_without_warmup_provider_is_safely_skipped(monkeypatch):
     monkeypatch.setattr(runner, "execute_model", fail_if_called)
     runner._warmup_ar_rollout()
     assert execute.called is False
+
+
+# ── paging unit vs eviction unit ────────────────────────────────────────────
+
+
+def test_a_frame_that_is_already_a_legal_block_keeps_its_paging():
+    """Every resolution that runs today must page exactly as it does today."""
+    from vllm_omni.experimental.ar_diffusion.runner import paging_block_size
+
+    for tokens_per_frame in (16, 320, 1440, 4096):
+        assert tokens_per_frame % 16 == 0
+        assert paging_block_size(tokens_per_frame) == tokens_per_frame
+
+
+def test_a_frame_the_kernel_would_reject_pages_at_the_finest_legal_unit():
+    """832x480 is the checkpoint's own default and the kernel rejects it.
+
+    (480/16) x (832/16) = 1560 tokens per frame, and 1560 % 16 == 8, so a
+    frame-sized block is not something FlashAttention's paged kernel accepts.
+    """
+    from vllm_omni.experimental.ar_diffusion.runner import paging_block_size
+
+    assert 1560 % 16 == 8
+    assert paging_block_size(1560) == 16
+    # And whatever it returns is always something the kernel takes.
+    for tokens_per_frame in range(1, 200):
+        assert paging_block_size(tokens_per_frame) % 16 == 0

--- a/tests/diffusion/ar_diffusion/test_capability_runner.py
+++ b/tests/diffusion/ar_diffusion/test_capability_runner.py
@@ -491,3 +491,79 @@ def test_a_frame_the_kernel_would_reject_pages_at_the_finest_legal_unit():
     # And whatever it returns is always something the kernel takes.
     for tokens_per_frame in range(1, 200):
         assert paging_block_size(tokens_per_frame) % 16 == 0
+
+
+# ── the kernel's constraint is data, not a constant ─────────────────────────
+
+
+def _multiple_of(base):
+    from vllm.v1.attention.backend import MultipleOf
+
+    return MultipleOf(base)
+
+
+def test_the_dispatching_module_answers_in_vllms_own_vocabulary():
+    """AR-Diffusion calls flash_attn itself, so no backend can be asked.
+
+    The answer has to come from the module that picks the kernel, and it has to
+    have the shape vLLM uses, so the policy that consumes it does not care
+    where it came from.
+    """
+    from vllm.v1.attention.backend import MultipleOf
+
+    from vllm_omni.experimental.ar_diffusion.kv_cache.paged_attention import supported_kernel_block_sizes
+
+    advertised = supported_kernel_block_sizes()
+    assert advertised, "a kernel that accepts nothing cannot be paged for"
+    for entry in advertised:
+        assert isinstance(entry, int | MultipleOf)
+
+
+def test_a_kernel_that_takes_one_fixed_size_gets_that_size():
+    """hpc_attn advertises [64] -- not a multiple, a single legal value.
+
+    A frame of 1560 tokens is not 64, and 1560 % 64 == 24, so the frame cannot
+    be the block and the only thing left to page at is 64. Assuming multiples
+    of 16 here would hand the kernel a block size it rejects.
+    """
+    from vllm_omni.experimental.ar_diffusion.runner import paging_block_size
+
+    assert 1560 % 64 == 24
+    assert paging_block_size(1560, [64]) == 64
+    assert paging_block_size(64, [64]) == 64
+    assert paging_block_size(128, [64]) == 64  # a legal multiple is still not the advertised size
+
+
+def test_a_kernel_with_large_pages_still_keeps_a_whole_frame_when_it_fits():
+    """FlashInfer offers 128-and-up pages on Blackwell and not on Hopper.
+
+    The same checkpoint on the two cards must therefore page differently, which
+    is exactly what a constant cannot express.
+    """
+    from vllm_omni.experimental.ar_diffusion.runner import paging_block_size
+
+    hopper = [_multiple_of(16)]
+    blackwell = [_multiple_of(16), 128, 256]
+    assert paging_block_size(1440, hopper) == 1440  # a legal multiple of 16
+    assert paging_block_size(1440, blackwell) == 1440
+    assert paging_block_size(1560, hopper) == 16
+    assert paging_block_size(1560, blackwell) == 16  # finest legal unit, not the largest
+
+
+def test_whatever_comes_back_is_always_something_the_kernel_accepts():
+    from vllm_omni.experimental.ar_diffusion.runner import paging_block_size
+
+    for advertised, check in (
+        ([_multiple_of(16)], lambda n: n % 16 == 0),
+        ([64], lambda n: n == 64),
+        ([_multiple_of(32), 48], lambda n: n % 32 == 0 or n == 48),
+    ):
+        for tokens_per_frame in range(1, 300):
+            assert check(paging_block_size(tokens_per_frame, advertised))
+
+
+def test_a_kernel_that_advertises_nothing_is_an_error_not_a_guess():
+    from vllm_omni.experimental.ar_diffusion.runner import paging_block_size
+
+    with pytest.raises(ValueError, match="no legal block size"):
+        paging_block_size(1560, [])

--- a/tests/diffusion/ar_diffusion/test_capability_runner.py
+++ b/tests/diffusion/ar_diffusion/test_capability_runner.py
@@ -693,3 +693,79 @@ def test_a_frame_the_kernel_would_reject_pages_at_the_finest_legal_unit():
     # And whatever it returns is always something the kernel takes.
     for tokens_per_frame in range(1, 200):
         assert paging_block_size(tokens_per_frame) % 16 == 0
+
+
+# ── the kernel's constraint is data, not a constant ─────────────────────────
+
+
+def _multiple_of(base):
+    from vllm.v1.attention.backend import MultipleOf
+
+    return MultipleOf(base)
+
+
+def test_the_dispatching_module_answers_in_vllms_own_vocabulary():
+    """AR-Diffusion calls flash_attn itself, so no backend can be asked.
+
+    The answer has to come from the module that picks the kernel, and it has to
+    have the shape vLLM uses, so the policy that consumes it does not care
+    where it came from.
+    """
+    from vllm.v1.attention.backend import MultipleOf
+
+    from vllm_omni.experimental.ar_diffusion.kv_cache.paged_attention import supported_kernel_block_sizes
+
+    advertised = supported_kernel_block_sizes()
+    assert advertised, "a kernel that accepts nothing cannot be paged for"
+    for entry in advertised:
+        assert isinstance(entry, int | MultipleOf)
+
+
+def test_a_kernel_that_takes_one_fixed_size_gets_that_size():
+    """hpc_attn advertises [64] -- not a multiple, a single legal value.
+
+    A frame of 1560 tokens is not 64, and 1560 % 64 == 24, so the frame cannot
+    be the block and the only thing left to page at is 64. Assuming multiples
+    of 16 here would hand the kernel a block size it rejects.
+    """
+    from vllm_omni.experimental.ar_diffusion.runner import paging_block_size
+
+    assert 1560 % 64 == 24
+    assert paging_block_size(1560, [64]) == 64
+    assert paging_block_size(64, [64]) == 64
+    assert paging_block_size(128, [64]) == 64  # a legal multiple is still not the advertised size
+
+
+def test_a_kernel_with_large_pages_still_keeps_a_whole_frame_when_it_fits():
+    """FlashInfer offers 128-and-up pages on Blackwell and not on Hopper.
+
+    The same checkpoint on the two cards must therefore page differently, which
+    is exactly what a constant cannot express.
+    """
+    from vllm_omni.experimental.ar_diffusion.runner import paging_block_size
+
+    hopper = [_multiple_of(16)]
+    blackwell = [_multiple_of(16), 128, 256]
+    assert paging_block_size(1440, hopper) == 1440  # a legal multiple of 16
+    assert paging_block_size(1440, blackwell) == 1440
+    assert paging_block_size(1560, hopper) == 16
+    assert paging_block_size(1560, blackwell) == 16  # finest legal unit, not the largest
+
+
+def test_whatever_comes_back_is_always_something_the_kernel_accepts():
+    from vllm_omni.experimental.ar_diffusion.runner import paging_block_size
+
+    for advertised, check in (
+        ([_multiple_of(16)], lambda n: n % 16 == 0),
+        ([64], lambda n: n == 64),
+        ([_multiple_of(32), 48], lambda n: n % 32 == 0 or n == 48),
+    ):
+        for tokens_per_frame in range(1, 300):
+            assert check(paging_block_size(tokens_per_frame, advertised))
+
+
+def test_a_kernel_that_advertises_nothing_is_an_error_not_a_guess():
+    from vllm_omni.experimental.ar_diffusion.runner import paging_block_size
+
+    with pytest.raises(ValueError, match="no legal block size"):
+        paging_block_size(1560, [])

--- a/tests/diffusion/ar_diffusion/test_capability_runner.py
+++ b/tests/diffusion/ar_diffusion/test_capability_runner.py
@@ -370,10 +370,17 @@ def test_lru_eviction_releases_blocks_and_notifies_pipeline():
 
 def test_budget_reduced_capacity_drives_runner_lru():
     pipeline = CapablePipeline(tiny_spec(capacity=2))
-    # One tiny LingBot-like session requires 128 bytes; two require 192.
+    # One tiny LingBot-like session requires 1,808 bytes; two require 2,592.
+    #
+    # These read 128 and 192 while the paging unit was the frame. tiny_spec
+    # declares one token per frame, so it used to page a single token at a
+    # time -- a block size no attention kernel accepts. Paging at 16 makes
+    # each page sixteen times larger. The block *counts* are unchanged, and
+    # so is what this test is about: a budget that fits fewer sessions than
+    # the pipeline asked for must drive the runner's LRU.
     runner = make_runner(
         pipeline,
-        available_bytes=128,
+        available_bytes=2048,
         gpu_memory_fraction=1.0,
     )
     kv = runner.kv_cache
@@ -659,3 +666,30 @@ def test_pipeline_without_warmup_provider_is_safely_skipped(monkeypatch):
     monkeypatch.setattr(runner, "execute_model", fail_if_called)
     runner._warmup_ar_rollout()
     assert execute.called is False
+
+
+# ── paging unit vs eviction unit ────────────────────────────────────────────
+
+
+def test_a_frame_that_is_already_a_legal_block_keeps_its_paging():
+    """Every resolution that runs today must page exactly as it does today."""
+    from vllm_omni.experimental.ar_diffusion.runner import paging_block_size
+
+    for tokens_per_frame in (16, 320, 1440, 4096):
+        assert tokens_per_frame % 16 == 0
+        assert paging_block_size(tokens_per_frame) == tokens_per_frame
+
+
+def test_a_frame_the_kernel_would_reject_pages_at_the_finest_legal_unit():
+    """832x480 is the checkpoint's own default and the kernel rejects it.
+
+    (480/16) x (832/16) = 1560 tokens per frame, and 1560 % 16 == 8, so a
+    frame-sized block is not something FlashAttention's paged kernel accepts.
+    """
+    from vllm_omni.experimental.ar_diffusion.runner import paging_block_size
+
+    assert 1560 % 16 == 8
+    assert paging_block_size(1560) == 16
+    # And whatever it returns is always something the kernel takes.
+    for tokens_per_frame in range(1, 200):
+        assert paging_block_size(tokens_per_frame) % 16 == 0

--- a/tests/diffusion/ar_diffusion/test_kv_cache.py
+++ b/tests/diffusion/ar_diffusion/test_kv_cache.py
@@ -588,3 +588,71 @@ def test_non_contiguous_branch_indices_rejected():
             kv_branches=(ARDiffusionKVBranchSpec("main", 1),),
             session_capacity=1,
         )
+
+
+# --- eviction against the block table ---------------------------------------
+
+
+class _RecordingManager(ChunkWindowManager):
+    """Capture the block range eviction asks for, without a real block pool.
+
+    ``remove_skipped_blocks`` reads three attributes and calls one method. A
+    pool would add nothing: the bug under test is the conversion from the
+    spec's units into the block table's, and that is entirely visible here.
+    """
+
+    def __init__(self, spec):
+        self.kv_cache_spec = spec
+        self.sliding_window = spec.sliding_window
+        self.block_size = spec.block_size
+        self.freed: tuple[int, int] | None = None
+
+    def _remove_blocks_in_range(self, request_id, first_block, last_block):
+        self.freed = (first_block, last_block)
+
+
+def test_sink_is_preserved_when_a_frame_spans_many_blocks():
+    # The shipped geometry: 832x480 is 1560 tokens per frame, 1560 % 16 == 8 is
+    # not a legal block size, so paging falls back to 16 and a frame spans 98
+    # blocks. Every other eviction test uses chunk_size == BLOCK, where a frame
+    # is a block and a sink counted in frames indexes the block table correctly
+    # by accident -- which is why this went unnoticed.
+    chunk_size, sink_chunks, window_chunks = 1560, 9, 9
+    spec = ChunkWindowSpec(
+        block_size=16,
+        num_kv_heads=4,
+        head_size=64,
+        dtype=torch.float16,
+        sliding_window=window_chunks * chunk_size,
+        chunk_size=chunk_size,
+        window_chunks=window_chunks,
+        sink_chunks=sink_chunks,
+    )
+    manager = _RecordingManager(spec)
+
+    # Far enough past sink + window that eviction has definitely started.
+    manager.remove_skipped_blocks("req", total_computed_tokens=30 * chunk_size)
+    assert manager.freed is not None
+    first_freed, last_freed = manager.freed
+
+    # The assertion is on the token boundary rather than a block count, so it
+    # stays meaningful if the paging unit changes again.
+    sink_tokens = sink_chunks * chunk_size
+    assert first_freed * spec.block_size >= sink_tokens, (
+        f"eviction starts at token {first_freed * spec.block_size}, inside the {sink_tokens}-token sink"
+    )
+    # And it must not over-protect: at most one straddling block beyond the sink.
+    assert (first_freed - 1) * spec.block_size < sink_tokens
+    # Only wholly-skipped blocks are released.
+    skipped = manager.get_num_skipped_tokens(30 * chunk_size)
+    assert last_freed * spec.block_size <= sink_tokens + skipped
+
+
+def test_sink_conversion_is_identity_when_a_frame_is_a_block():
+    # Every geometry that paged one frame per block must be untouched.
+    spec = make_spec(chunk_size=BLOCK, window_chunks=2, sink_chunks=1)
+    manager = _RecordingManager(spec)
+    manager.remove_skipped_blocks("req", total_computed_tokens=8 * BLOCK)
+    assert manager.freed is not None
+    first_freed, _ = manager.freed
+    assert first_freed == spec.sink_chunks

--- a/tests/diffusion/ar_diffusion/test_paged_attention.py
+++ b/tests/diffusion/ar_diffusion/test_paged_attention.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Tests for AR-Diffusion paged self-attention contexts."""
 
 from __future__ import annotations
@@ -49,9 +50,7 @@ def make_state(
     """Build a cache. ``chunk_size`` defaults to the block size, but the two are
     independent -- the shipped 832x480 gives 1560 tokens per frame against
     16-token blocks, so a frame is 97.5 blocks."""
-    cfg = ARDiffusionKVConfig(
-        enable=True, chunk_size=chunk_size, window_chunks=window_chunks, sink_chunks=sink_chunks
-    )
+    cfg = ARDiffusionKVConfig(enable=True, chunk_size=chunk_size, window_chunks=window_chunks, sink_chunks=sink_chunks)
     kv = ARDiffusionKVCache(
         cfg,
         num_layers=num_layers,
@@ -1071,9 +1070,7 @@ def test_a_ragged_scratch_chunk_is_physically_continuous_with_its_history():
     """
     device = torch.device("cpu")
     kv, st = make_state(device=device, window_chunks=2, chunk_size=RAGGED_CHUNK)
-    _commit_video_span(
-        kv, st, kv_branch=POS, n_chunks=1, dtype=torch.float32, device=device, chunk_size=RAGGED_CHUNK
-    )
+    _commit_video_span(kv, st, kv_branch=POS, n_chunks=1, dtype=torch.float32, device=device, chunk_size=RAGGED_CHUNK)
 
     ctx = st.get_kv_caches(POS, seq_len=RAGGED_CHUNK, commit_current=False)[0].forward_ctx
     ctx.ensure_video_slots(device)

--- a/tests/diffusion/ar_diffusion/test_paged_attention.py
+++ b/tests/diffusion/ar_diffusion/test_paged_attention.py
@@ -648,9 +648,21 @@ def test_batch_paged_metadata_matches_the_single_sequence_builder():
 # contexts instead, which is what a coalesced tick will do.
 
 
-def make_sessions(count: int, *, window_chunks=8, dtype=torch.float32, device=torch.device("cpu"), num_layers=1):
-    """Several sessions sharing one KV pool, each with its own adapter."""
-    cfg = ARDiffusionKVConfig(enable=True, chunk_size=BLOCK, window_chunks=window_chunks)
+def make_sessions(
+    count: int,
+    *,
+    window_chunks=8,
+    dtype=torch.float32,
+    device=torch.device("cpu"),
+    num_layers=1,
+    scratch_slots=1,
+):
+    """Several sessions sharing one KV pool, each with its own adapter.
+
+    ``scratch_slots`` defaults to 1, matching deployments that never coalesce;
+    sessions then all address scratch region 0.
+    """
+    cfg = ARDiffusionKVConfig(enable=True, chunk_size=BLOCK, window_chunks=window_chunks, scratch_slots=scratch_slots)
     kv = ARDiffusionKVCache(
         cfg,
         num_layers=num_layers,
@@ -667,7 +679,13 @@ def make_sessions(count: int, *, window_chunks=8, dtype=torch.float32, device=to
         device=device,
     )
     sessions = [
-        ARDiffusionKVState(kv, f"s{index}", {POS: kv.begin_request(f"r{index}")}, num_layers=num_layers)
+        ARDiffusionKVState(
+            kv,
+            f"s{index}",
+            {POS: kv.begin_request(f"r{index}")},
+            num_layers=num_layers,
+            scratch_slot=index % max(scratch_slots, 1),
+        )
         for index in range(count)
     ]
     return kv, sessions
@@ -875,3 +893,79 @@ def test_uncommitted_sessions_on_one_branch_are_refused_not_silently_merged():
 
     with pytest.raises(ValueError, match="overlapping KV slots"):
         CoalescedPagedForward.merge(contexts).layer_inputs(0)
+
+
+def test_scratch_slots_give_uncommitted_sessions_disjoint_write_targets():
+    """The fix for the collision the refusal above documents.
+
+    With one region per session, two sessions preparing uncommitted chunks
+    address different blocks, so a coalesced forward writes each session's K/V
+    where only that session reads it.
+    """
+    device, dtype = torch.device("cpu"), torch.float32
+    kv, sessions = make_sessions(2, dtype=dtype, device=device, scratch_slots=2)
+
+    contexts = [
+        _prepared_context(kv, session, history_chunks=1, dtype=dtype, device=device, commit_current=False)
+        for session in sessions
+    ]
+
+    assert set(contexts[0].current_video_block_ids).isdisjoint(contexts[1].current_video_block_ids)
+    merged = CoalescedPagedForward.merge(contexts)
+    assert merged.video_slots.numel() == sum(c.current_video_slot_mapping.numel() for c in contexts)
+
+
+def test_coalesced_uncommitted_sessions_match_running_them_one_at_a_time():
+    """Equivalence for the case that actually dominates: the noisy steps.
+
+    Four of every five forwards per block are non-committing, so this is the
+    path coalescing has to be correct on, not the committing one.
+    """
+    torch.manual_seed(11)
+    device, dtype = torch.device("cpu"), torch.float32
+    kv, sessions = make_sessions(2, dtype=dtype, device=device, scratch_slots=2)
+
+    contexts = [
+        _prepared_context(kv, sessions[0], history_chunks=1, dtype=dtype, device=device, commit_current=False),
+        _prepared_context(kv, sessions[1], history_chunks=3, dtype=dtype, device=device, commit_current=False),
+    ]
+    assert contexts[0].kv_len != contexts[1].kv_len, "sessions must differ or the test is vacuous"
+
+    queries = [torch.randn(BLOCK, N_HEADS, HEAD_DIM, dtype=dtype, device=device) for _ in contexts]
+    keys = [torch.randn(BLOCK, N_HEADS, HEAD_DIM, dtype=dtype, device=device) for _ in contexts]
+    values = [torch.randn(BLOCK, N_HEADS, HEAD_DIM, dtype=dtype, device=device) for _ in contexts]
+
+    alone = [
+        paged_write_attn(ctx.layer_inputs(0), queries[i], keys[i], values[i], None, None, HEAD_DIM**-0.5)
+        for i, ctx in enumerate(contexts)
+    ]
+    coalesced = paged_write_attn(
+        CoalescedPagedForward.merge(contexts).layer_inputs(0),
+        torch.cat(queries, dim=0),
+        torch.cat(keys, dim=0),
+        torch.cat(values, dim=0),
+        None,
+        None,
+        HEAD_DIM**-0.5,
+    )
+
+    torch.testing.assert_close(coalesced, torch.cat(alone, dim=0), rtol=1e-5, atol=1e-5)
+
+
+def test_a_session_cannot_claim_a_slot_the_cache_did_not_reserve():
+    """Sizing and addressing must not drift apart silently."""
+    kv, _ = make_sessions(1, scratch_slots=1)
+    with pytest.raises(ValueError, match="scratch_slot must be in"):
+        ARDiffusionKVState(kv, "extra", {POS: kv.begin_request("r-extra")}, num_layers=1, scratch_slot=1)
+
+    with pytest.raises(ValueError, match="scratch slot must be in"):
+        kv.scratch_block_ids(POS, 0, 1, slot=1)
+
+
+def test_reserving_more_slots_costs_proportionally_more_scratch():
+    """The memory price of coalescing is explicit, not hidden."""
+    one, _ = make_sessions(1, scratch_slots=1)
+    three, _ = make_sessions(1, scratch_slots=3)
+
+    assert three.scratch_blocks_per_slot == one.scratch_blocks_per_slot
+    assert three.scratch_num_blocks == 3 * one.scratch_num_blocks

--- a/tests/diffusion/ar_diffusion/test_paged_attention.py
+++ b/tests/diffusion/ar_diffusion/test_paged_attention.py
@@ -1214,3 +1214,44 @@ def test_the_shipped_resolution_geometry_matches_dense_attention():
         torch.cat([history_v, current_v], dim=1),
     )
     torch.testing.assert_close(paged, ref, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.skipif(not _gpu_flash_attn_usable(), reason="usable GPU FlashAttention is required")
+@pytest.mark.parametrize("commit_current", [False, True])
+def test_the_shipped_resolution_geometry_on_the_real_kernel(commit_current):
+    """The shipped 832x480 geometry through FlashAttention's paged kernel.
+
+    The CPU test above proves the addressing is right against a dense
+    reference. This one proves the real kernel agrees, at the real 1560
+    tokens per frame, through the production path -- host prep followed by
+    the fused write+attend op, which is what a forward actually calls.
+    """
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    dtype = torch.float16
+    tokens_per_frame = (480 // 16) * (832 // 16)
+    assert tokens_per_frame == 1560
+
+    kv, st = make_state(dtype=dtype, device=device, window_chunks=2, chunk_size=tokens_per_frame)
+    history_k, history_v = _commit_video_span(
+        kv, st, kv_branch=POS, n_chunks=1, dtype=dtype, device=device, chunk_size=tokens_per_frame
+    )
+
+    layer_ctx = st.get_kv_caches(POS, seq_len=tokens_per_frame, commit_current=commit_current)[0]
+    ctx = layer_ctx.forward_ctx
+    current_k = torch.randn(1, tokens_per_frame, N_HEADS, HEAD_DIM, dtype=dtype, device=device)
+    current_v = torch.randn(1, tokens_per_frame, N_HEADS, HEAD_DIM, dtype=dtype, device=device)
+    query = torch.randn(1, tokens_per_frame, N_HEADS, HEAD_DIM, dtype=dtype, device=device)
+
+    ctx.prepare(device=device, action_len=0, query_len=tokens_per_frame)
+    assert ctx.start_offset == 8, "1560 % 16 == 8 is the whole reason this case exists"
+    assert kv.block_size == 16
+
+    inputs = layer_ctx.to_layer_inputs()
+    paged = paged_write_attn(inputs, query[0], current_k[0], current_v[0], None, None, HEAD_DIM**-0.5).unsqueeze(0)
+
+    new_k = torch.cat([history_k, current_k], dim=1)[:, -kv.spec.sliding_window :]
+    new_v = torch.cat([history_v, current_v], dim=1)[:, -kv.spec.sliding_window :]
+    ref = _dense_attention(query, new_k, new_v)
+
+    torch.testing.assert_close(paged, ref, rtol=2e-2, atol=2e-2)

--- a/tests/diffusion/ar_diffusion/test_paged_attention.py
+++ b/tests/diffusion/ar_diffusion/test_paged_attention.py
@@ -37,8 +37,21 @@ POS = "positive"
 NEG = "negative"
 
 
-def make_state(*, num_layers=1, window_chunks=2, dtype=torch.float32, device=torch.device("cpu")):
-    cfg = ARDiffusionKVConfig(enable=True, chunk_size=BLOCK, window_chunks=window_chunks)
+def make_state(
+    *,
+    num_layers=1,
+    window_chunks=2,
+    chunk_size=BLOCK,
+    sink_chunks=0,
+    dtype=torch.float32,
+    device=torch.device("cpu"),
+):
+    """Build a cache. ``chunk_size`` defaults to the block size, but the two are
+    independent -- the shipped 832x480 gives 1560 tokens per frame against
+    16-token blocks, so a frame is 97.5 blocks."""
+    cfg = ARDiffusionKVConfig(
+        enable=True, chunk_size=chunk_size, window_chunks=window_chunks, sink_chunks=sink_chunks
+    )
     kv = ARDiffusionKVCache(
         cfg,
         num_layers=num_layers,
@@ -107,11 +120,13 @@ def _commit_video_span(
     n_chunks: int,
     dtype: torch.dtype,
     device: torch.device,
+    chunk_size: int = BLOCK,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    ctx = st.get_kv_caches(kv_branch, seq_len=n_chunks * BLOCK, commit_current=True)[0].forward_ctx
+    span = n_chunks * chunk_size
+    ctx = st.get_kv_caches(kv_branch, seq_len=span, commit_current=True)[0].forward_ctx
     ctx.ensure_video_slots(device)
-    k = torch.randn(1, n_chunks * BLOCK, N_HEADS, HEAD_DIM, dtype=dtype, device=device)
-    v = torch.randn(1, n_chunks * BLOCK, N_HEADS, HEAD_DIM, dtype=dtype, device=device)
+    k = torch.randn(1, span, N_HEADS, HEAD_DIM, dtype=dtype, device=device)
+    v = torch.randn(1, span, N_HEADS, HEAD_DIM, dtype=dtype, device=device)
     kv._k_pools[0][ctx.current_video_slot_mapping] = k[0]
     kv._v_pools[0][ctx.current_video_slot_mapping] = v[0]
     st.commit_paged_context(kv_branch)
@@ -969,3 +984,233 @@ def test_reserving_more_slots_costs_proportionally_more_scratch():
 
     assert three.scratch_blocks_per_slot == one.scratch_blocks_per_slot
     assert three.scratch_num_blocks == 3 * one.scratch_num_blocks
+
+
+# ── a frame that is not a whole number of blocks ────────────────────────────
+
+# 24 tokens per chunk against 16-token blocks leaves 8 over, the same remainder
+# the shipped 832x480 produces (1560 % 16 == 8). Every fixture above holds
+# chunk_size == BLOCK, so nothing there can reach this path.
+RAGGED_CHUNK = 24
+
+
+@pytest.mark.parametrize("commit_current", [False, True])
+@pytest.mark.parametrize("action_len", [0, 3])
+def test_a_ragged_chunk_still_matches_the_dense_reference(commit_current, action_len):
+    """Attention reads a sequence, not a set of blocks.
+
+    With one committed chunk of 24 tokens the history stops 8 slots into its
+    last block. The committing path writes straight after it and is fine. The
+    scratch path used to restart at slot zero of a fresh region, which left
+    those 8 slots unwritten -- and since the kernel consumes the block table as
+    one contiguous run, it read them as if they were tokens and shifted every
+    token after them by 8. Shapes stayed correct throughout, so only the values
+    showed it.
+    """
+    torch.manual_seed(0)
+    device = torch.device("cpu")
+    dtype = torch.float32
+    # window_chunks=2 with one chunk of history keeps the whole sequence
+    # resident, so the window does not also round up here; that case is
+    # test_a_ragged_window_keeps_the_block_table_a_fixed_shape below.
+    kv, st = make_state(dtype=dtype, device=device, window_chunks=2, chunk_size=RAGGED_CHUNK)
+
+    history_k, history_v = _commit_video_span(
+        kv, st, kv_branch=POS, n_chunks=1, dtype=dtype, device=device, chunk_size=RAGGED_CHUNK
+    )
+
+    ctx = st.get_kv_caches(POS, seq_len=RAGGED_CHUNK, commit_current=commit_current)[0].forward_ctx
+    ctx.ensure_video_slots(device)
+    assert ctx.start_offset == RAGGED_CHUNK % BLOCK == 8
+
+    current_k = torch.randn(1, RAGGED_CHUNK, N_HEADS, HEAD_DIM, dtype=dtype, device=device)
+    current_v = torch.randn(1, RAGGED_CHUNK, N_HEADS, HEAD_DIM, dtype=dtype, device=device)
+    kv._k_pools[0][ctx.current_video_slot_mapping] = current_k[0]
+    kv._v_pools[0][ctx.current_video_slot_mapping] = current_v[0]
+
+    action_k = action_v = None
+    if action_len:
+        ctx.ensure_action_slots(action_len, device)
+        action_k = torch.randn(1, action_len, N_HEADS, HEAD_DIM, dtype=dtype, device=device)
+        action_v = torch.randn(1, action_len, N_HEADS, HEAD_DIM, dtype=dtype, device=device)
+        kv._k_pools[0][ctx.action_slot_mapping] = action_k[0]
+        kv._v_pools[0][ctx.action_slot_mapping] = action_v[0]
+
+    query = torch.randn(1, RAGGED_CHUNK + action_len, N_HEADS, HEAD_DIM, dtype=dtype, device=device)
+    block_table, query_start_loc, seq_lens, max_query_len, max_seq_len = ctx.build_block_table(
+        action_len=action_len, query_len=query.shape[1], device=device
+    )
+    paged = ar_diffusion_paged_attention(
+        query,
+        kv.key_cache(0),
+        kv.value_cache(0),
+        block_table=block_table,
+        query_start_loc=query_start_loc,
+        seq_lens=seq_lens,
+        max_query_len=max_query_len,
+        max_seq_len=max_seq_len,
+        softmax_scale=HEAD_DIM**-0.5,
+        causal=False,
+    )
+
+    new_k = torch.cat([history_k, current_k], dim=1)
+    new_v = torch.cat([history_v, current_v], dim=1)
+    if action_len:
+        new_k = torch.cat([new_k, action_k], dim=1)
+        new_v = torch.cat([new_v, action_v], dim=1)
+    ref = _dense_attention(query, new_k, new_v)
+
+    torch.testing.assert_close(paged, ref, rtol=1e-5, atol=1e-5)
+
+
+def test_a_ragged_scratch_chunk_is_physically_continuous_with_its_history():
+    """The write targets themselves must leave no hole.
+
+    This is the property the values above depend on, asserted directly so a
+    regression names the cause rather than showing a numeric mismatch.
+    """
+    device = torch.device("cpu")
+    kv, st = make_state(device=device, window_chunks=2, chunk_size=RAGGED_CHUNK)
+    _commit_video_span(
+        kv, st, kv_branch=POS, n_chunks=1, dtype=torch.float32, device=device, chunk_size=RAGGED_CHUNK
+    )
+
+    ctx = st.get_kv_caches(POS, seq_len=RAGGED_CHUNK, commit_current=False)[0].forward_ctx
+    ctx.ensure_video_slots(device)
+
+    history_tail_block = ctx.history_block_ids[-1]
+    # The chunk starts inside the history's own last block, not at a fresh one.
+    assert ctx.current_video_block_ids[0] == history_tail_block
+    first_slot = int(ctx.current_video_slot_mapping[0])
+    assert first_slot == history_tail_block * BLOCK + 8
+
+    # And the action region must not be charged for that managed block.
+    ctx.ensure_action_slots(3, device)
+    assert ctx._scratch_blocks_used == len(ctx.current_video_block_ids) - 1
+    assert ctx.action_scratch_block_ids[0] not in ctx.current_video_block_ids
+
+
+def test_a_ragged_window_keeps_the_block_table_a_fixed_shape():
+    """The table's shape must not track how full the window is.
+
+    With a sink the visible window is 2*24 + 24 = 72 tokens, which is 4.5
+    blocks. Deriving the width by flooring that would understate the capacity,
+    the max() against the live block count would take over, and the shape would
+    change as the window filled -- recompiling the graph. The same floor would
+    also let max_seq_len come out under the kv_len actually passed.
+    """
+    device = torch.device("cpu")
+    kv, st = make_state(device=device, window_chunks=2, sink_chunks=1, chunk_size=RAGGED_CHUNK)
+    # The window is deliberately not a whole number of blocks.
+    max_video_tokens = kv.spec.sliding_window + kv.spec.sink_chunks * kv.spec.chunk_size
+    assert max_video_tokens % BLOCK != 0
+
+    widths: set[int] = set()
+    kv_lens: list[int] = []
+    for _ in range(6):
+        ctx = st.get_kv_caches(POS, seq_len=RAGGED_CHUNK, commit_current=True)[0].forward_ctx
+        ctx.ensure_video_slots(device)
+        block_table, _, seq_lens, _, max_seq_len = ctx.build_block_table(
+            action_len=0, query_len=RAGGED_CHUNK, device=device
+        )
+        widths.add(int(block_table.shape[1]))
+        # A bound handed to the kernel has to actually bound the sequence.
+        assert int(seq_lens[0]) <= max_seq_len
+        kv_lens.append(int(seq_lens[0]))
+        st.commit_paged_context(POS)
+
+    assert len(widths) == 1, f"block table width varied across ticks: {sorted(widths)}"
+    # The window has to have actually filled, or none of the above was tested.
+    assert max(kv_lens) > min(kv_lens)
+    # Rounding up keeps at most one block more than the token window asks for.
+    assert max(kv_lens) <= ctx.max_video_blocks * BLOCK
+    assert max(kv_lens) < max_video_tokens + BLOCK
+
+
+def test_the_checkpoints_own_default_resolution_can_build_a_cache():
+    """832x480 is what LingBot World v2 ships as its default, and it could not run.
+
+    A frame-sized block made the resolution a kernel-compatibility question:
+    1560 tokens per frame is not a multiple of 16, so FlashAttention's paged
+    kernel rejected it and the default resolution had no realtime path at all.
+    """
+    from vllm_omni.experimental.ar_diffusion.runner import paging_block_size
+
+    tokens_per_frame = (480 // 16) * (832 // 16)
+    assert tokens_per_frame == 1560
+    assert tokens_per_frame % 16 == 8, "the whole point is that a frame is not a legal block"
+
+    block_size = paging_block_size(tokens_per_frame)
+    cfg = ARDiffusionKVConfig(enable=True, chunk_size=tokens_per_frame, window_chunks=2)
+    kv = ARDiffusionKVCache(
+        cfg,
+        num_layers=1,
+        num_kv_heads=N_HEADS,
+        head_size=HEAD_DIM,
+        dtype=torch.float32,
+        block_size=block_size,
+        max_model_len=1 << 16,
+        available_bytes=1 << 28,
+        kv_branches=(ARDiffusionKVBranchSpec(POS, 0),),
+        session_capacity=1,
+        frames_per_block=2,
+        max_scratch_tokens_per_branch=block_size,
+        device=torch.device("cpu"),
+    )
+
+    assert kv.block_size % 16 == 0
+    # The eviction unit is still the frame; only the paging unit changed.
+    assert kv.spec.chunk_size == tokens_per_frame
+    assert kv.blocks_per_frame == -(-tokens_per_frame // block_size) == 98
+
+
+def test_the_shipped_resolution_geometry_matches_dense_attention():
+    """The real number, not a scaled-down stand-in: 1560 tokens per frame.
+
+    This is the case the issue reported failing at ~4e-02 on the scratch path.
+    It runs on CPU because the reference is dense attention, not a kernel.
+    """
+    torch.manual_seed(0)
+    device = torch.device("cpu")
+    dtype = torch.float32
+    tokens_per_frame = (480 // 16) * (832 // 16)
+    assert tokens_per_frame == 1560
+
+    kv, st = make_state(dtype=dtype, device=device, window_chunks=2, chunk_size=tokens_per_frame)
+    history_k, history_v = _commit_video_span(
+        kv, st, kv_branch=POS, n_chunks=1, dtype=dtype, device=device, chunk_size=tokens_per_frame
+    )
+
+    # The non-committing path is the one that was wrong: four of the five
+    # forwards per generated block take it.
+    ctx = st.get_kv_caches(POS, seq_len=tokens_per_frame, commit_current=False)[0].forward_ctx
+    ctx.ensure_video_slots(device)
+    assert ctx.start_offset == 8, "1560 % 16 == 8 is the whole reason this case exists"
+
+    current_k = torch.randn(1, tokens_per_frame, N_HEADS, HEAD_DIM, dtype=dtype, device=device)
+    current_v = torch.randn(1, tokens_per_frame, N_HEADS, HEAD_DIM, dtype=dtype, device=device)
+    kv._k_pools[0][ctx.current_video_slot_mapping] = current_k[0]
+    kv._v_pools[0][ctx.current_video_slot_mapping] = current_v[0]
+
+    query = torch.randn(1, tokens_per_frame, N_HEADS, HEAD_DIM, dtype=dtype, device=device)
+    block_table, query_start_loc, seq_lens, max_query_len, max_seq_len = ctx.build_block_table(
+        action_len=0, query_len=tokens_per_frame, device=device
+    )
+    paged = ar_diffusion_paged_attention(
+        query,
+        kv.key_cache(0),
+        kv.value_cache(0),
+        block_table=block_table,
+        query_start_loc=query_start_loc,
+        seq_lens=seq_lens,
+        max_query_len=max_query_len,
+        max_seq_len=max_seq_len,
+        softmax_scale=HEAD_DIM**-0.5,
+        causal=False,
+    )
+    ref = _dense_attention(
+        query,
+        torch.cat([history_k, current_k], dim=1),
+        torch.cat([history_v, current_v], dim=1),
+    )
+    torch.testing.assert_close(paged, ref, rtol=1e-5, atol=1e-5)

--- a/tests/diffusion/ar_diffusion/test_paged_attention.py
+++ b/tests/diffusion/ar_diffusion/test_paged_attention.py
@@ -20,6 +20,10 @@ from vllm_omni.experimental.ar_diffusion.kv_cache import (
     ar_diffusion_paged_attention,
     paged_write_attn,
 )
+from vllm_omni.experimental.ar_diffusion.kv_cache.paged_attention import (
+    PagedSequenceMetadata,
+    batch_paged_metadata,
+)
 from vllm_omni.experimental.ar_diffusion.kv_cache.state import ARDiffusionKVState
 
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
@@ -419,3 +423,218 @@ def test_custom_op_compiles_fullgraph_without_recompile_on_value_change():
         # Leave a clean dynamo state for later suites in the same pytest process
         # (e.g. model_executor transformers models).
         torch._dynamo.reset()
+
+
+# ---------------------------------------------------------------------------
+# Cross-session batching: is the attention path already varlen-capable?
+#
+# Coalescing several sessions' chunks into one forward is only a plumbing
+# change if the attention path already handles a batch of sequences with
+# different KV lengths. These tests establish that against the same dense
+# reference the single-sequence tests use, so the claim rests on a measurement
+# rather than on reading the code.
+# ---------------------------------------------------------------------------
+
+
+def _write_sequence(kv, *, blocks, kv_len, dtype, device):
+    """Fill ``kv_len`` tokens across ``blocks``, returning the dense K/V written."""
+    k = torch.randn(1, kv_len, N_HEADS, HEAD_DIM, dtype=dtype, device=device)
+    v = torch.randn(1, kv_len, N_HEADS, HEAD_DIM, dtype=dtype, device=device)
+    positions = torch.arange(kv_len, device=device)
+    logical = torch.div(positions, BLOCK, rounding_mode="floor")
+    offsets = positions % BLOCK
+    physical = torch.tensor(blocks, device=device)[logical]
+    slots = physical * BLOCK + offsets
+    kv._k_pools[0][slots] = k[0]
+    kv._v_pools[0][slots] = v[0]
+    return k, v
+
+
+def _batch_metadata(sequences, *, width, device):
+    """Build batch metadata through the primitive the runtime would use."""
+    table, starts, lens, _, _ = batch_paged_metadata(
+        [PagedSequenceMetadata(block_ids=tuple(b), kv_len=k, query_len=q) for b, k, q in sequences],
+        block_size=BLOCK,
+        device=device,
+        width=width,
+    )
+    return table, starts, lens
+
+
+def _run_paged(kv, query_flat, table, starts, lens, *, max_seq_len):
+    return ar_diffusion_paged_attention(
+        query_flat,
+        kv.key_cache(0),
+        kv.value_cache(0),
+        block_table=table,
+        query_start_loc=starts,
+        seq_lens=lens,
+        max_query_len=int((starts[1:] - starts[:-1]).max().item()),
+        max_seq_len=max_seq_len,
+        softmax_scale=HEAD_DIM**-0.5,
+        causal=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        # (blocks, kv_len, query_len) per sequence. Unequal KV lengths are the
+        # point: equal lengths would pass even for a batch-oblivious path.
+        [((1, 2), 32, 16), ((3, 4, 5), 40, 8)],
+        [((1,), 5, 3), ((2, 3), 27, 11), ((4, 5, 6), 48, 16)],
+    ],
+)
+def test_batched_sequences_match_running_them_one_at_a_time(spec):
+    """A coalesced batch must equal the same sequences run separately.
+
+    This is the load-bearing question for cross-session chunk batching: if it
+    holds, coalescing needs new metadata construction and nothing else in the
+    attention path.
+    """
+    torch.manual_seed(0)
+    device, dtype = torch.device("cpu"), torch.float32
+    kv, _ = make_state(dtype=dtype, device=device, window_chunks=8)
+
+    queries = []
+    for blocks, kv_len, query_len in spec:
+        _write_sequence(kv, blocks=blocks, kv_len=kv_len, dtype=dtype, device=device)
+        queries.append(torch.randn(query_len, N_HEADS, HEAD_DIM, dtype=dtype, device=device))
+
+    width = max(len(blocks) for blocks, _, _ in spec)
+    max_seq_len = width * BLOCK
+    table, starts, lens = _batch_metadata(spec, width=width, device=device)
+    batched = _run_paged(kv, torch.cat(queries, dim=0), table, starts, lens, max_seq_len=max_seq_len)
+
+    alone = []
+    for index, (blocks, kv_len, _) in enumerate(spec):
+        one = _batch_metadata([(blocks, kv_len, queries[index].shape[0])], width=width, device=device)
+        alone.append(_run_paged(kv, queries[index], *one, max_seq_len=max_seq_len))
+
+    expected = torch.cat(alone, dim=0)
+    assert batched.shape == expected.shape
+    torch.testing.assert_close(batched, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_each_batched_sequence_matches_the_dense_reference():
+    """Anchor the batch against dense attention, not only against itself.
+
+    Comparing a batch to per-sequence paged calls would pass even if both
+    shared a bug, so each member is also checked against plain attention over
+    the exact K/V it should see.
+    """
+    torch.manual_seed(1)
+    device, dtype = torch.device("cpu"), torch.float32
+    kv, _ = make_state(dtype=dtype, device=device, window_chunks=8)
+
+    spec = [((1, 2), 32, 16), ((3, 4, 5), 40, 8)]
+    dense_kv, queries = [], []
+    for blocks, kv_len, query_len in spec:
+        dense_kv.append(_write_sequence(kv, blocks=blocks, kv_len=kv_len, dtype=dtype, device=device))
+        queries.append(torch.randn(query_len, N_HEADS, HEAD_DIM, dtype=dtype, device=device))
+
+    width = max(len(blocks) for blocks, _, _ in spec)
+    table, starts, lens = _batch_metadata(spec, width=width, device=device)
+    batched = _run_paged(kv, torch.cat(queries, dim=0), table, starts, lens, max_seq_len=width * BLOCK)
+
+    offset = 0
+    for index, (_, _, query_len) in enumerate(spec):
+        k, v = dense_kv[index]
+        ref = _dense_attention(queries[index].unsqueeze(0), k, v)[0]
+        torch.testing.assert_close(batched[offset : offset + query_len], ref, rtol=1e-5, atol=1e-5)
+        offset += query_len
+
+
+def test_batching_is_not_vacuous_because_the_sequences_differ():
+    """Negative control for the two tests above.
+
+    If both members produced the same output, an implementation that ignored
+    the per-sequence block table entirely would still pass.
+    """
+    torch.manual_seed(2)
+    device, dtype = torch.device("cpu"), torch.float32
+    kv, _ = make_state(dtype=dtype, device=device, window_chunks=8)
+
+    spec = [((1, 2), 32, 8), ((3, 4), 32, 8)]
+    for blocks, kv_len, _ in spec:
+        _write_sequence(kv, blocks=blocks, kv_len=kv_len, dtype=dtype, device=device)
+    query = torch.randn(8, N_HEADS, HEAD_DIM, dtype=dtype, device=device)
+
+    table, starts, lens = _batch_metadata(spec, width=2, device=device)
+    batched = _run_paged(kv, torch.cat([query, query], dim=0), table, starts, lens, max_seq_len=2 * BLOCK)
+
+    # Same query, different KV: the two halves must differ.
+    assert not torch.allclose(batched[:8], batched[8:], rtol=1e-3, atol=1e-3)
+
+
+def test_padding_beyond_seq_len_is_never_read():
+    """A short sequence in a wide batch must ignore its padded block slots.
+
+    Coalescing pads every session's table to the widest member, so a session
+    reading past its own KV would silently mix in another session's blocks --
+    a plausible but wrong result that no timing metric can detect.
+    """
+    torch.manual_seed(3)
+    device, dtype = torch.device("cpu"), torch.float32
+    kv, _ = make_state(dtype=dtype, device=device, window_chunks=8)
+
+    short_len = 12
+    k, v = _write_sequence(kv, blocks=(1,), kv_len=short_len, dtype=dtype, device=device)
+    _write_sequence(kv, blocks=(3, 4, 5), kv_len=40, dtype=dtype, device=device)
+    query = torch.randn(6, N_HEADS, HEAD_DIM, dtype=dtype, device=device)
+
+    # Pad the short sequence's table with blocks holding real, different data.
+    table = torch.tensor([[1, 3, 4]], dtype=torch.int32, device=device)
+    starts = torch.tensor([0, 6], dtype=torch.int32, device=device)
+    lens = torch.tensor([short_len], dtype=torch.int32, device=device)
+    out = _run_paged(kv, query, table, starts, lens, max_seq_len=3 * BLOCK)
+
+    ref = _dense_attention(query.unsqueeze(0), k, v)[0]
+    torch.testing.assert_close(out, ref, rtol=1e-5, atol=1e-5)
+
+
+def test_batch_paged_metadata_rejects_tables_too_small_for_their_kv():
+    """Silently truncating a session's KV is the failure to avoid here."""
+    with pytest.raises(ValueError, match="needs 3 blocks"):
+        batch_paged_metadata(
+            [PagedSequenceMetadata(block_ids=(1, 2), kv_len=40, query_len=4)],
+            block_size=BLOCK,
+            device=torch.device("cpu"),
+        )
+
+
+def test_batch_paged_metadata_pads_every_row_to_the_widest_member():
+    table, starts, lens, max_query_len, max_seq_len = batch_paged_metadata(
+        [
+            PagedSequenceMetadata(block_ids=(1,), kv_len=10, query_len=4),
+            PagedSequenceMetadata(block_ids=(2, 3, 4), kv_len=40, query_len=9),
+        ],
+        block_size=BLOCK,
+        device=torch.device("cpu"),
+    )
+    assert table.shape == (2, 3)
+    assert table[0].tolist() == [1, 0, 0]
+    assert starts.tolist() == [0, 4, 13]
+    assert lens.tolist() == [10, 40]
+    assert (max_query_len, max_seq_len) == (9, 3 * BLOCK)
+
+
+def test_batch_paged_metadata_matches_the_single_sequence_builder():
+    """One sequence through the batch primitive equals the existing path."""
+    device, dtype = torch.device("cpu"), torch.float32
+    kv, st = make_state(dtype=dtype, device=device, window_chunks=2)
+    ctx = st.get_kv_caches(POS, seq_len=BLOCK, commit_current=False)[0].forward_ctx
+    ctx.ensure_video_slots(device)
+    single = ctx.build_block_table(action_len=0, query_len=BLOCK, device=device)
+
+    blocks, _ = ctx.video_block_table(device)
+    batched = batch_paged_metadata(
+        [PagedSequenceMetadata(block_ids=tuple(blocks), kv_len=ctx.kv_len, query_len=BLOCK)],
+        block_size=BLOCK,
+        device=device,
+        width=single[0].shape[1],
+    )
+    torch.testing.assert_close(batched[0], single[0])
+    torch.testing.assert_close(batched[1], single[1])
+    torch.testing.assert_close(batched[2], single[2])
+    assert batched[3] == single[3]

--- a/tests/diffusion/ar_diffusion/test_paged_attention.py
+++ b/tests/diffusion/ar_diffusion/test_paged_attention.py
@@ -21,6 +21,7 @@ from vllm_omni.experimental.ar_diffusion.kv_cache import (
     paged_write_attn,
 )
 from vllm_omni.experimental.ar_diffusion.kv_cache.paged_attention import (
+    CoalescedPagedForward,
     PagedSequenceMetadata,
     batch_paged_metadata,
 )
@@ -638,3 +639,239 @@ def test_batch_paged_metadata_matches_the_single_sequence_builder():
     torch.testing.assert_close(batched[1], single[1])
     torch.testing.assert_close(batched[2], single[2])
     assert batched[3] == single[3]
+
+
+# ── Coalescing real session contexts ───────────────────────────────────────
+#
+# The tests above establish that the attention path is varlen-capable given
+# hand-built metadata. These build the metadata from actual per-session forward
+# contexts instead, which is what a coalesced tick will do.
+
+
+def make_sessions(count: int, *, window_chunks=8, dtype=torch.float32, device=torch.device("cpu"), num_layers=1):
+    """Several sessions sharing one KV pool, each with its own adapter."""
+    cfg = ARDiffusionKVConfig(enable=True, chunk_size=BLOCK, window_chunks=window_chunks)
+    kv = ARDiffusionKVCache(
+        cfg,
+        num_layers=num_layers,
+        num_kv_heads=N_HEADS,
+        head_size=HEAD_DIM,
+        dtype=dtype,
+        block_size=BLOCK,
+        max_model_len=4096,
+        available_bytes=1 << 26,
+        kv_branches=(ARDiffusionKVBranchSpec(POS, 0),),
+        session_capacity=count,
+        frames_per_block=2,
+        max_scratch_tokens_per_branch=BLOCK,
+        device=device,
+    )
+    sessions = [
+        ARDiffusionKVState(kv, f"s{index}", {POS: kv.begin_request(f"r{index}")}, num_layers=num_layers)
+        for index in range(count)
+    ]
+    return kv, sessions
+
+
+def _prepared_context(kv, session, *, history_chunks, dtype, device, commit_current=False):
+    """Give a session some committed history, then prepare its current chunk."""
+    for _ in range(history_chunks):
+        ctx = session.get_kv_caches(POS, seq_len=BLOCK, commit_current=True)[0].forward_ctx
+        ctx.ensure_video_slots(device)
+        kv._k_pools[0][ctx.current_video_slot_mapping] = torch.randn(
+            BLOCK, N_HEADS, HEAD_DIM, dtype=dtype, device=device
+        )
+        kv._v_pools[0][ctx.current_video_slot_mapping] = torch.randn(
+            BLOCK, N_HEADS, HEAD_DIM, dtype=dtype, device=device
+        )
+        session.commit_paged_context(POS)
+
+    ctx = session.get_kv_caches(POS, seq_len=BLOCK, commit_current=commit_current)[0].forward_ctx
+    ctx.prepare(device, 0, BLOCK)
+    return ctx
+
+
+def test_a_single_context_through_the_batch_primitive_is_unchanged():
+    """The one-session case must be bit-identical to the existing path.
+
+    Coalescing has to be free when there is nothing to coalesce, otherwise
+    enabling it would change single-session results.
+    """
+    device, dtype = torch.device("cpu"), torch.float32
+    kv, (session,) = make_sessions(1, dtype=dtype, device=device)
+    ctx = _prepared_context(kv, session, history_chunks=2, dtype=dtype, device=device)
+
+    alone = ctx.layer_inputs(0)
+    batched = CoalescedPagedForward.merge([ctx]).layer_inputs(0)
+
+    for field in ARDiffusionPagedLayerInputs._fields:
+        left, right = getattr(alone, field), getattr(batched, field)
+        if isinstance(left, torch.Tensor):
+            torch.testing.assert_close(left, right, rtol=0, atol=0)
+        else:
+            assert left == right, field
+
+
+def test_coalesced_sessions_equal_the_same_sessions_run_one_at_a_time():
+    """The load-bearing test: two sessions in one forward vs. two forwards.
+
+    Sessions are given different history depths on purpose, so their KV lengths
+    and block tables differ. Equal-length sessions would pass even for an
+    implementation that ignored the per-session metadata entirely.
+    """
+    torch.manual_seed(7)
+    device, dtype = torch.device("cpu"), torch.float32
+    kv, sessions = make_sessions(2, dtype=dtype, device=device)
+
+    contexts = [
+        _prepared_context(kv, sessions[0], history_chunks=1, dtype=dtype, device=device, commit_current=True),
+        _prepared_context(kv, sessions[1], history_chunks=3, dtype=dtype, device=device, commit_current=True),
+    ]
+    assert contexts[0].kv_len != contexts[1].kv_len, "sessions must differ or the test is vacuous"
+
+    queries, keys, values = [], [], []
+    for _ in contexts:
+        queries.append(torch.randn(BLOCK, N_HEADS, HEAD_DIM, dtype=dtype, device=device))
+        keys.append(torch.randn(BLOCK, N_HEADS, HEAD_DIM, dtype=dtype, device=device))
+        values.append(torch.randn(BLOCK, N_HEADS, HEAD_DIM, dtype=dtype, device=device))
+
+    alone = [
+        paged_write_attn(ctx.layer_inputs(0), queries[i], keys[i], values[i], None, None, HEAD_DIM**-0.5)
+        for i, ctx in enumerate(contexts)
+    ]
+
+    coalesced = paged_write_attn(
+        CoalescedPagedForward.merge(contexts).layer_inputs(0),
+        torch.cat(queries, dim=0),
+        torch.cat(keys, dim=0),
+        torch.cat(values, dim=0),
+        None,
+        None,
+        HEAD_DIM**-0.5,
+    )
+
+    torch.testing.assert_close(coalesced, torch.cat(alone, dim=0), rtol=1e-5, atol=1e-5)
+
+
+def test_a_coalesced_session_does_not_see_its_neighbour_kv():
+    """The failure that timing cannot detect.
+
+    If the shallow session read the deeper one's blocks it would still produce
+    a plausible tensor. Anchor it against dense attention over exactly the K/V
+    that session should see -- its own committed history plus its own chunk.
+    """
+    torch.manual_seed(8)
+    device, dtype = torch.device("cpu"), torch.float32
+    kv, sessions = make_sessions(2, dtype=dtype, device=device)
+
+    shallow = _prepared_context(kv, sessions[0], history_chunks=1, dtype=dtype, device=device, commit_current=True)
+    deep = _prepared_context(kv, sessions[1], history_chunks=3, dtype=dtype, device=device, commit_current=True)
+
+    queries = [torch.randn(BLOCK, N_HEADS, HEAD_DIM, dtype=dtype, device=device) for _ in range(2)]
+    keys = [torch.randn(BLOCK, N_HEADS, HEAD_DIM, dtype=dtype, device=device) for _ in range(2)]
+    values = [torch.randn(BLOCK, N_HEADS, HEAD_DIM, dtype=dtype, device=device) for _ in range(2)]
+
+    coalesced = paged_write_attn(
+        CoalescedPagedForward.merge([shallow, deep]).layer_inputs(0),
+        torch.cat(queries, dim=0),
+        torch.cat(keys, dim=0),
+        torch.cat(values, dim=0),
+        None,
+        None,
+        HEAD_DIM**-0.5,
+    )
+
+    # Rebuild what the shallow session should have attended over, straight from
+    # the pool via its own block table.
+    live_blocks = shallow.block_table[0, : -(-shallow.kv_len // BLOCK)].tolist()
+    slots = torch.tensor(
+        [block * BLOCK + offset for block in live_blocks for offset in range(BLOCK)][: shallow.kv_len],
+        dtype=torch.long,
+    )
+    expected = _dense_attention(
+        queries[0].unsqueeze(0),
+        kv._k_pools[0][slots].unsqueeze(0),
+        kv._v_pools[0][slots].unsqueeze(0),
+    )[0]
+
+    torch.testing.assert_close(coalesced[:BLOCK], expected, rtol=1e-5, atol=1e-5)
+
+
+def test_coalescing_keeps_the_block_table_width_fixed_as_the_window_grows():
+    """Shapes must not drift with history, or the compiled graph recompiles.
+
+    The single-session builder pads to a fixed capacity for this reason; the
+    coalesced table has to inherit that rather than sizing itself to whichever
+    sessions happen to be live.
+    """
+    device, dtype = torch.device("cpu"), torch.float32
+    # Four sessions, not two reused: a session may not prepare a second managed
+    # chunk while its first is still pending.
+    kv, sessions = make_sessions(4, dtype=dtype, device=device, window_chunks=4)
+
+    shallow = CoalescedPagedForward.merge(
+        [
+            _prepared_context(kv, session, history_chunks=0, dtype=dtype, device=device, commit_current=True)
+            for session in sessions[:2]
+        ]
+    ).layer_inputs(0)
+    deep = CoalescedPagedForward.merge(
+        [
+            _prepared_context(kv, session, history_chunks=3, dtype=dtype, device=device, commit_current=True)
+            for session in sessions[2:]
+        ]
+    ).layer_inputs(0)
+
+    assert shallow.block_table.shape == deep.block_table.shape
+    assert shallow.max_seq_len == deep.max_seq_len
+    # ...while the values genuinely changed, so the check is not vacuous.
+    assert not torch.equal(shallow.seq_lens, deep.seq_lens)
+
+
+def test_merge_rejects_unprepared_and_foreign_contexts():
+    device, dtype = torch.device("cpu"), torch.float32
+    kv, sessions = make_sessions(2, dtype=dtype, device=device)
+
+    ready = _prepared_context(kv, sessions[0], history_chunks=1, dtype=dtype, device=device, commit_current=True)
+    raw = sessions[1].get_kv_caches(POS, seq_len=BLOCK, commit_current=False)[0].forward_ctx
+
+    with pytest.raises(RuntimeError, match="before prepare"):
+        CoalescedPagedForward.merge([ready, raw]).layer_inputs(0)
+
+    with pytest.raises(ValueError, match="at least one session"):
+        CoalescedPagedForward.merge([])
+
+    other_kv, (other_session,) = make_sessions(1, dtype=dtype, device=device)
+    foreign = _prepared_context(
+        other_kv, other_session, history_chunks=1, dtype=dtype, device=device, commit_current=True
+    )
+    with pytest.raises(ValueError, match="share one KV pool"):
+        CoalescedPagedForward.merge([ready, foreign]).layer_inputs(0)
+
+
+def test_uncommitted_sessions_on_one_branch_are_refused_not_silently_merged():
+    """Scratch blocks are per KV branch, so two uncommitted sessions collide.
+
+    Every noisy denoise step prepares its chunk with ``commit_current=False``
+    and therefore lands on its branch's scratch blocks, which carry no session
+    index. Coalescing two such sessions would have each overwrite the other's
+    current K/V -- a wrong result that still looks like a video. Refusing is
+    the only safe answer until scratch is indexed per session.
+    """
+    device, dtype = torch.device("cpu"), torch.float32
+    kv, sessions = make_sessions(2, dtype=dtype, device=device)
+
+    contexts = [
+        _prepared_context(kv, session, history_chunks=1, dtype=dtype, device=device, commit_current=False)
+        for session in sessions
+    ]
+    # The collision is real, not hypothetical: the write targets are identical.
+    torch.testing.assert_close(
+        contexts[0].current_video_slot_mapping,
+        contexts[1].current_video_slot_mapping,
+        rtol=0,
+        atol=0,
+    )
+
+    with pytest.raises(ValueError, match="overlapping KV slots"):
+        CoalescedPagedForward.merge(contexts).layer_inputs(0)

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/config.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/config.py
@@ -32,6 +32,13 @@ class ARDiffusionKVConfig:
     warmup_cudagraph: bool = True
     # Also capture the post-window-boundary (reset-cycle) forward during warm-up.
     warmup_capture_reset: bool = False
+    # Independent scratch regions per KV branch. A non-committing forward
+    # writes its current chunk to scratch, and scratch is addressed per branch,
+    # so two sessions preparing an uncommitted chunk on one branch would share
+    # blocks and overwrite each other. One region per session that may be in
+    # flight together makes coalesced forwards legal, at one region's memory
+    # each. The default of 1 is exactly today's behaviour and costs nothing.
+    scratch_slots: int = 1
 
     @property
     def sliding_window(self) -> int | None:

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/config.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/config.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Configuration for AR-Diffusion engine-level KV cache management."""
 
 from __future__ import annotations

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/manager.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/manager.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Engine-level KV cache orchestration for AR-Diffusion models.
 
 This is the *body* of AR-Diffusion's KV management: it owns a vLLM ``KVCacheManager`` (a

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/manager.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/manager.py
@@ -249,8 +249,18 @@ class ARDiffusionKVCache:
         if override_blocks < 0:
             raise ValueError("AR_DIFFUSION_KV_SCRATCH_BLOCKS_PER_BRANCH must be non-negative")
         scratch_per_kv_branch = max(minimum_scratch_blocks, override_blocks)
-        self.scratch_blocks_per_kv_branch = scratch_per_kv_branch
-        self.scratch_num_blocks = self.num_local_kv_branches * scratch_per_kv_branch
+        # One independent region per slot. Scratch is where a non-committing
+        # forward writes its current chunk, so sessions that may be in flight
+        # together need regions of their own or they overwrite each other --
+        # silently, since the shapes stay right. Slots default to 1, which is
+        # a single region per branch and costs exactly what it did before.
+        scratch_slots = int(getattr(config, "scratch_slots", 1) or 1)
+        if scratch_slots < 1:
+            raise ValueError(f"ARDiffusionKVConfig.scratch_slots must be at least 1, got {scratch_slots}")
+        self.scratch_slots = scratch_slots
+        self.scratch_blocks_per_slot = scratch_per_kv_branch
+        self.scratch_blocks_per_kv_branch = scratch_per_kv_branch * scratch_slots
+        self.scratch_num_blocks = self.num_local_kv_branches * self.scratch_blocks_per_kv_branch
 
         # The self-attention pool, scratch pool, and lazily materialized
         # cross-attention caches share one hard memory budget. Select the largest
@@ -575,19 +585,25 @@ class ARDiffusionKVCache:
             self.block_size,
         )
 
-    def scratch_block_ids(self, kv_branch: str, start: int, count: int) -> list[int]:
-        """Return KV-branch-local scratch block ids outside manager ownership."""
+    def scratch_block_ids(self, kv_branch: str, start: int, count: int, *, slot: int = 0) -> list[int]:
+        """Return scratch block ids for one (KV branch, slot) region.
+
+        Regions are disjoint by construction, which is what lets two sessions
+        prepare uncommitted chunks in the same coalesced forward.
+        """
         if count < 0 or start < 0:
             raise ValueError(f"scratch start/count must be non-negative, got start={start}, count={count}")
-        if start + count > self.scratch_blocks_per_kv_branch:
+        if not 0 <= slot < self.scratch_slots:
+            raise ValueError(f"scratch slot must be in [0, {self.scratch_slots}), got {slot}")
+        if start + count > self.scratch_blocks_per_slot:
             raise RuntimeError(
                 "AR-Diffusion paged attention scratch blocks exhausted: "
-                f"need [{start}, {start + count}) of {self.scratch_blocks_per_kv_branch}. "
+                f"need [{start}, {start + count}) of {self.scratch_blocks_per_slot}. "
                 "Declare max_scratch_tokens_per_branch in the pipeline capability "
                 "or increase AR_DIFFUSION_KV_SCRATCH_BLOCKS_PER_BRANCH."
             )
-        kv_branch_offset = self.scratch_blocks_per_kv_branch * self._kv_branch_index(kv_branch)
-        base = self.managed_num_blocks + kv_branch_offset + start
+        region = self._kv_branch_index(kv_branch) * self.scratch_slots + slot
+        base = self.managed_num_blocks + region * self.scratch_blocks_per_slot + start
         return list(range(base, base + count))
 
     def key_cache(self, layer_idx: int) -> torch.Tensor:

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/manager.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/manager.py
@@ -243,7 +243,12 @@ class ARDiffusionKVCache:
         # forward needs one block per current frame plus space for any
         # model-declared action/state tokens that coexist with video KV.
         declared_scratch_blocks = (max_scratch_tokens_per_branch + block_size - 1) // block_size
-        minimum_scratch_blocks = self.frames_per_block + declared_scratch_blocks
+        # frames_per_block counts *frames*; convert to blocks rather than
+        # assuming one block per frame. A frame spans ceil(chunk_size /
+        # block_size) blocks once the two sizes are allowed to differ.
+        blocks_per_frame = -(-config.chunk_size // block_size)
+        self.blocks_per_frame = blocks_per_frame
+        minimum_scratch_blocks = self.frames_per_block * blocks_per_frame + declared_scratch_blocks
         override = os.environ.get("AR_DIFFUSION_KV_SCRATCH_BLOCKS_PER_BRANCH")
         override_blocks = int(override) if override is not None else 0
         if override_blocks < 0:
@@ -283,8 +288,23 @@ class ARDiffusionKVCache:
         )
 
         def _required_managed_blocks(capacity: int) -> int:
-            resident_per_session = config.sink_chunks + config.window_chunks
-            return self.num_local_kv_branches * (capacity * resident_per_session + self.frames_per_block) + 2
+            """Managed blocks needed to hold ``capacity`` resident sessions.
+
+            Every term here counts *frames*, so each is converted to blocks.
+            Before block size and frame size were allowed to differ this
+            conversion was the identity and the frame counts could be used
+            directly; they cannot once a frame spans several blocks.
+
+            Converting rather than rewriting keeps the budget the same number
+            of *tokens* it always was, so a finer block size does not inflate
+            the requirement -- it only stops the final block of each term from
+            rounding up a whole frame's worth of memory.
+            """
+            resident_frames = config.sink_chunks + config.window_chunks
+            per_session_blocks = resident_frames * self.blocks_per_frame
+            in_flight_blocks = self.frames_per_block * self.blocks_per_frame
+            headroom_blocks = 2 * self.blocks_per_frame
+            return self.num_local_kv_branches * (capacity * per_session_blocks + in_flight_blocks) + headroom_blocks
 
         def _required_bytes(capacity: int) -> int:
             return (

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/manager.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/manager.py
@@ -244,7 +244,12 @@ class ARDiffusionKVCache:
         # forward needs one block per current frame plus space for any
         # model-declared action/state tokens that coexist with video KV.
         declared_scratch_blocks = (max_scratch_tokens_per_branch + block_size - 1) // block_size
-        minimum_scratch_blocks = self.frames_per_block + declared_scratch_blocks
+        # frames_per_block counts *frames*; convert to blocks rather than
+        # assuming one block per frame. A frame spans ceil(chunk_size /
+        # block_size) blocks once the two sizes are allowed to differ.
+        blocks_per_frame = -(-config.chunk_size // block_size)
+        self.blocks_per_frame = blocks_per_frame
+        minimum_scratch_blocks = self.frames_per_block * blocks_per_frame + declared_scratch_blocks
         override = os.environ.get("AR_DIFFUSION_KV_SCRATCH_BLOCKS_PER_BRANCH")
         override_blocks = int(override) if override is not None else 0
         if override_blocks < 0:
@@ -284,8 +289,23 @@ class ARDiffusionKVCache:
         )
 
         def _required_managed_blocks(capacity: int) -> int:
-            resident_per_session = config.sink_chunks + config.window_chunks
-            return self.num_local_kv_branches * (capacity * resident_per_session + self.frames_per_block) + 2
+            """Managed blocks needed to hold ``capacity`` resident sessions.
+
+            Every term here counts *frames*, so each is converted to blocks.
+            Before block size and frame size were allowed to differ this
+            conversion was the identity and the frame counts could be used
+            directly; they cannot once a frame spans several blocks.
+
+            Converting rather than rewriting keeps the budget the same number
+            of *tokens* it always was, so a finer block size does not inflate
+            the requirement -- it only stops the final block of each term from
+            rounding up a whole frame's worth of memory.
+            """
+            resident_frames = config.sink_chunks + config.window_chunks
+            per_session_blocks = resident_frames * self.blocks_per_frame
+            in_flight_blocks = self.frames_per_block * self.blocks_per_frame
+            headroom_blocks = 2 * self.blocks_per_frame
+            return self.num_local_kv_branches * (capacity * per_session_blocks + in_flight_blocks) + headroom_blocks
 
         def _required_bytes(capacity: int) -> int:
             return (

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/manager.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/manager.py
@@ -250,8 +250,18 @@ class ARDiffusionKVCache:
         if override_blocks < 0:
             raise ValueError("AR_DIFFUSION_KV_SCRATCH_BLOCKS_PER_BRANCH must be non-negative")
         scratch_per_kv_branch = max(minimum_scratch_blocks, override_blocks)
-        self.scratch_blocks_per_kv_branch = scratch_per_kv_branch
-        self.scratch_num_blocks = self.num_local_kv_branches * scratch_per_kv_branch
+        # One independent region per slot. Scratch is where a non-committing
+        # forward writes its current chunk, so sessions that may be in flight
+        # together need regions of their own or they overwrite each other --
+        # silently, since the shapes stay right. Slots default to 1, which is
+        # a single region per branch and costs exactly what it did before.
+        scratch_slots = int(getattr(config, "scratch_slots", 1) or 1)
+        if scratch_slots < 1:
+            raise ValueError(f"ARDiffusionKVConfig.scratch_slots must be at least 1, got {scratch_slots}")
+        self.scratch_slots = scratch_slots
+        self.scratch_blocks_per_slot = scratch_per_kv_branch
+        self.scratch_blocks_per_kv_branch = scratch_per_kv_branch * scratch_slots
+        self.scratch_num_blocks = self.num_local_kv_branches * self.scratch_blocks_per_kv_branch
 
         # The self-attention pool, scratch pool, and lazily materialized
         # cross-attention caches share one hard memory budget. Select the largest
@@ -578,19 +588,25 @@ class ARDiffusionKVCache:
             self.block_size,
         )
 
-    def scratch_block_ids(self, kv_branch: str, start: int, count: int) -> list[int]:
-        """Return KV-branch-local scratch block ids outside manager ownership."""
+    def scratch_block_ids(self, kv_branch: str, start: int, count: int, *, slot: int = 0) -> list[int]:
+        """Return scratch block ids for one (KV branch, slot) region.
+
+        Regions are disjoint by construction, which is what lets two sessions
+        prepare uncommitted chunks in the same coalesced forward.
+        """
         if count < 0 or start < 0:
             raise ValueError(f"scratch start/count must be non-negative, got start={start}, count={count}")
-        if start + count > self.scratch_blocks_per_kv_branch:
+        if not 0 <= slot < self.scratch_slots:
+            raise ValueError(f"scratch slot must be in [0, {self.scratch_slots}), got {slot}")
+        if start + count > self.scratch_blocks_per_slot:
             raise RuntimeError(
                 "AR-Diffusion paged attention scratch blocks exhausted: "
-                f"need [{start}, {start + count}) of {self.scratch_blocks_per_kv_branch}. "
+                f"need [{start}, {start + count}) of {self.scratch_blocks_per_slot}. "
                 "Declare max_scratch_tokens_per_branch in the pipeline capability "
                 "or increase AR_DIFFUSION_KV_SCRATCH_BLOCKS_PER_BRANCH."
             )
-        kv_branch_offset = self.scratch_blocks_per_kv_branch * self._kv_branch_index(kv_branch)
-        base = self.managed_num_blocks + kv_branch_offset + start
+        region = self._kv_branch_index(kv_branch) * self.scratch_slots + slot
+        base = self.managed_num_blocks + region * self.scratch_blocks_per_slot + start
         return list(range(base, base + count))
 
     def key_cache(self, layer_idx: int) -> torch.Tensor:

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/paged.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/paged.py
@@ -203,17 +203,32 @@ class ChunkWindowManager(SlidingWindowManager):
         total_computed_tokens: int,
         num_prompt_tokens: int | None = None,
     ) -> None:
-        """Free the middle gap while preserving the leading attention sink."""
+        """Free the middle gap while preserving the leading attention sink.
+
+        ``sink_chunks`` counts frames while the block table is indexed in
+        blocks, so the sink is converted before it is used as an index. The two
+        were interchangeable while a frame was a block; this commit is what
+        separates them.
+
+        Neither boundary is guaranteed to land on a block edge -- 832x480 is
+        1560 tokens per frame against a 16-token block -- so a block can hold
+        the end of one frame and the start of the next. The sink end rounds up
+        so a straddling block stays protected, and the freed range ends on a
+        rounded-down boundary so only wholly-skipped blocks are released. Both
+        are exact when the sizes divide, which is every geometry that paged one
+        frame per block before.
+        """
         del num_prompt_tokens
         num_skipped_tokens = self.get_num_skipped_tokens(total_computed_tokens)
         if num_skipped_tokens <= 0:
             return
-        sink_blocks = self.kv_cache_spec.sink_chunks
-        num_skipped_blocks = num_skipped_tokens // self.block_size
+        sink_tokens = self.kv_cache_spec.sink_chunks * self.kv_cache_spec.chunk_size
+        first_live_block = -(-sink_tokens // self.block_size)
+        last_freed_block = (sink_tokens + num_skipped_tokens) // self.block_size
         self._remove_blocks_in_range(
             request_id,
-            sink_blocks,
-            sink_blocks + num_skipped_blocks,
+            first_live_block,
+            last_freed_block,
         )
 
 

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Paged self-attention helpers for AR-Diffusion KV reuse."""
 
 from __future__ import annotations

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
@@ -7,11 +7,14 @@ from __future__ import annotations
 import itertools
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Any, ClassVar, NamedTuple
+from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
 
 import torch
 
 from vllm_omni.experimental.ar_diffusion.kv_cache.paged import compute_slot_mapping
+
+if TYPE_CHECKING:
+    from vllm.v1.attention.backend import MultipleOf
 
 _LAYER_IDX_TENSORS: dict[int, torch.Tensor] = {}
 
@@ -679,6 +682,29 @@ def _resolve_fa_version(head_size: int) -> int:
             version = 2
         _FA_VERSION_BY_HEAD_SIZE[head_size] = version
     return version
+
+
+def supported_kernel_block_sizes() -> list[int | MultipleOf]:
+    """Block sizes the kernel this module dispatches to will accept.
+
+    Same shape as vLLM's ``AttentionBackend.get_supported_kernel_block_sizes``
+    -- a plain int is that exact size, ``MultipleOf(b)`` is any positive
+    multiple of ``b`` -- but answered here rather than read off a backend,
+    because AR-Diffusion does not go through backend selection. It calls
+    ``flash_attn_varlen_func`` itself, choosing between vLLM's CUDA build and
+    ROCm's AITER a few lines below, and only this module knows which.
+
+    It lives next to that choice so there is one place to change. The
+    constraint is a property of the kernel, not of the card, and the kernels
+    reachable from here agree on 16 today: vLLM's CUDA FlashAttention, ROCm
+    AITER, and upstream ``flash_attn`` all advertise ``MultipleOf(16)``. Other
+    backends in the same tree do not -- ``hpc_attn`` accepts only 64, and
+    FlashInfer advertises pages of 128 or more solely on Blackwell -- so a
+    caller must treat this as data to be queried, never as the number 16.
+    """
+    from vllm.v1.attention.backend import MultipleOf
+
+    return [MultipleOf(16)]
 
 
 def _rocm_flash_attn_varlen_func():

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
@@ -63,6 +63,10 @@ class ARDiffusionPagedForwardContext:
     seq_len: int
     commit_current: bool
     max_video_tokens: int
+    # Which scratch region this session's uncommitted chunk writes to. Sessions
+    # that may be coalesced into one forward must differ here or they overwrite
+    # each other's current K/V.
+    scratch_slot: int = 0
     current_video_block_ids: list[int] = field(default_factory=list)
     current_video_slot_mapping: torch.Tensor | None = None
     action_scratch_block_ids: list[int] = field(default_factory=list)
@@ -108,7 +112,9 @@ class ARDiffusionPagedForwardContext:
             positions = torch.arange(start, start + self.seq_len, dtype=torch.long)
             self.current_video_slot_mapping = compute_slot_mapping(table, positions, self.block_size).to(device=device)
         else:
-            self.current_video_block_ids = self.kv_cache.scratch_block_ids(self.kv_branch, 0, n_blocks)
+            self.current_video_block_ids = self.kv_cache.scratch_block_ids(
+                self.kv_branch, 0, n_blocks, slot=self.scratch_slot
+            )
             positions = torch.arange(self.seq_len, dtype=torch.long)
             self.current_video_slot_mapping = compute_slot_mapping(
                 self.current_video_block_ids,
@@ -135,6 +141,7 @@ class ARDiffusionPagedForwardContext:
             self.kv_branch,
             scratch_offset,
             action_blocks,
+            slot=self.scratch_slot,
         )
         positions = torch.arange(action_len, dtype=torch.long)
         self.action_slot_mapping = compute_slot_mapping(

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
@@ -73,6 +73,17 @@ class ARDiffusionPagedForwardContext:
     action_slot_mapping: torch.Tensor | None = None
     query_len: int = 0
     kv_len: int = 0
+    # Tokens already committed when this forward began. Recorded rather than
+    # derived from the block count: the last block of the history is only
+    # partly written when a chunk is not a whole number of blocks, so
+    # blocks * block_size overstates it and would make attention read past
+    # what was written.
+    _history_tokens: int = 0
+    # Scratch blocks the current video tokens occupy. Not the same as
+    # len(current_video_block_ids): when the history ends mid-block, the first
+    # entry there is the history's own tail block, which is managed, not
+    # scratch. Action K/V is placed after this, so it must not count it.
+    _scratch_blocks_used: int = 0
     _allocated_video: bool = False
     _committed: bool = False
     _action_len: int = 0
@@ -89,13 +100,47 @@ class ARDiffusionPagedForwardContext:
         return int(self.kv_cache.block_size)
 
     @property
+    def chunk_size(self) -> int:
+        """Tokens in one chunk -- one latent frame. The eviction unit."""
+        return int(self.kv_cache.spec.chunk_size)
+
+    @property
+    def start_offset(self) -> int:
+        """Where in its first block this forward's tokens begin.
+
+        Non-zero exactly when the committed history does not end on a block
+        boundary, which is the normal case once a frame is not a whole number
+        of blocks: 1560 tokens per frame against 16-token blocks leaves the
+        history 8 slots into its last block on every odd-numbered chunk.
+        """
+        return int(self.adapter.num_computed_tokens) % self.block_size
+
+    @property
+    def max_video_blocks(self) -> int:
+        """Blocks the visible window spans, rounded up.
+
+        Rounding up is what keeps the block table a fixed shape: the window is
+        a token count, and flooring it would understate the capacity whenever
+        it is not a whole number of blocks.
+        """
+        return -(-self.max_video_tokens // self.block_size)
+
+    @property
     def num_current_video_blocks(self) -> int:
-        if self.seq_len % self.block_size != 0:
-            raise AssertionError(
-                "AR-Diffusion paged attention expects frame-aligned seq_len "
-                f"(multiple of block_size={self.block_size}), got {self.seq_len}"
-            )
-        return self.seq_len // self.block_size
+        """Blocks this forward's tokens occupy, counted from where they start.
+
+        A chunk need not be a whole number of blocks, so the count depends on
+        the offset it begins at, not only on its length: thirty tokens
+        starting at position thirty span three sixteen-token blocks, not two.
+        Rounding up leaves the tail of the last block unwritten, which is only
+        safe because nothing reads past ``kv_len`` -- see
+        :meth:`video_block_table`.
+
+        Both paths count the same way. The committing path writes straight
+        after the history; the scratch path is made to line up with it by
+        :meth:`ensure_video_slots`.
+        """
+        return -(-(self.start_offset + self.seq_len) // self.block_size)
 
     def ensure_video_slots(self, device: torch.device) -> None:
         """Allocate/write targets for the current video tokens, once per KV branch."""
@@ -103,6 +148,7 @@ class ARDiffusionPagedForwardContext:
             return
 
         n_blocks = self.num_current_video_blocks
+        self._history_tokens = int(self.adapter.num_computed_tokens)
         if self.commit_current:
             start = int(self.adapter.num_computed_tokens)
             self.kv_cache.allocate_token_slots(self.adapter, self.seq_len)
@@ -112,10 +158,28 @@ class ARDiffusionPagedForwardContext:
             positions = torch.arange(start, start + self.seq_len, dtype=torch.long)
             self.current_video_slot_mapping = compute_slot_mapping(table, positions, self.block_size).to(device=device)
         else:
-            self.current_video_block_ids = self.kv_cache.scratch_block_ids(
-                self.kv_branch, 0, n_blocks, slot=self.scratch_slot
+            # The scratch region cannot simply start at slot zero. The kernel
+            # reads the history and this chunk as one contiguous run, so if the
+            # history stopped mid-block, starting here at zero would leave the
+            # rest of that block unwritten and the kernel would read those dead
+            # slots as if they were tokens, shifting the whole sequence.
+            #
+            # Instead the chunk begins where the history left off, spilling its
+            # first few tokens into the free tail of the history's own last
+            # block. That block is already this session's -- blocks are
+            # allocated whole -- and those slots hold nothing yet; the
+            # committing forward overwrites the same slots with the clean K/V
+            # later, so the committed state is unchanged either way.
+            # A history whose tail block is no longer resident has nothing to
+            # spill into; the window then starts at this chunk and zero is right.
+            offset = self.start_offset if self.history_block_ids else 0
+            self._scratch_blocks_used = n_blocks - (1 if offset else 0)
+            scratch_ids = self.kv_cache.scratch_block_ids(
+                self.kv_branch, 0, self._scratch_blocks_used, slot=self.scratch_slot
             )
-            positions = torch.arange(self.seq_len, dtype=torch.long)
+            tail_block = [self.history_block_ids[-1]] if offset else []
+            self.current_video_block_ids = tail_block + scratch_ids
+            positions = torch.arange(offset, offset + self.seq_len, dtype=torch.long)
             self.current_video_slot_mapping = compute_slot_mapping(
                 self.current_video_block_ids,
                 positions,
@@ -136,7 +200,9 @@ class ARDiffusionPagedForwardContext:
             return
 
         action_blocks = (action_len + self.block_size - 1) // self.block_size
-        scratch_offset = 0 if self.commit_current else len(self.current_video_block_ids)
+        # Count scratch blocks, not entries: the video list may lead with the
+        # history's tail block, which lives in the managed pool.
+        scratch_offset = 0 if self.commit_current else self._scratch_blocks_used
         self.action_scratch_block_ids = self.kv_cache.scratch_block_ids(
             self.kv_branch,
             scratch_offset,
@@ -152,23 +218,47 @@ class ARDiffusionPagedForwardContext:
         self._action_len = action_len
 
     def video_block_table(self, device: torch.device) -> tuple[list[int], int]:
+        """Blocks the attention may read, and how many of their tokens are live.
+
+        The window is expressed in tokens and converted to blocks here, rather
+        than assuming one block per frame. Both boundaries round *up*: a sink
+        of nine frames whose tokens do not fill a whole number of blocks keeps
+        the block that straddles the boundary, so the window can retain up to
+        ``block_size - 1`` tokens more than it strictly needs. That is
+        deliberate -- rounding down would drop tokens the window is supposed to
+        keep, and a slightly wider window is a far smaller error than a
+        truncated one.
+
+        The returned length is what the kernel treats as this sequence's KV
+        length, so it must never exceed the tokens actually written. The tail
+        of the final block is unwritten whenever a chunk is not a whole number
+        of blocks, and reading it would mix uninitialised memory into the
+        attention.
+        """
         self.ensure_video_slots(device)
-        if self.max_video_tokens % self.block_size != 0:
-            raise AssertionError(
-                "AR-Diffusion paged attention requires max_video_tokens to be block-aligned, "
-                f"got max_video_tokens={self.max_video_tokens}, block_size={self.block_size}"
-            )
-        all_video_blocks = self.history_block_ids + self.current_video_block_ids
-        max_video_blocks = self.max_video_tokens // self.block_size
-        sink_blocks = int(self.kv_cache.spec.sink_chunks)
+        # Order-preserving union, not concatenation. When a chunk is not a
+        # whole number of blocks, the block holding the end of the history also
+        # holds the start of this chunk, so it appears in both lists. Reading
+        # it twice would feed those tokens to attention twice and drop the same
+        # number from the end -- silently, since the shapes stay right.
+        all_video_blocks = list(dict.fromkeys(self.history_block_ids + self.current_video_block_ids))
+        max_video_blocks = self.max_video_blocks
+        sink_blocks = -(-(int(self.kv_cache.spec.sink_chunks) * self.chunk_size) // self.block_size)
+
+        # What was actually written: committed history, capped by whatever the
+        # window still holds, plus this forward's own tokens.
+        resident_history = min(self._history_tokens, len(self.history_block_ids) * self.block_size)
         if len(all_video_blocks) <= max_video_blocks:
             visible_video_blocks = all_video_blocks
+            live_tokens = resident_history + self.seq_len
         else:
-            tail_blocks = max_video_blocks - sink_blocks
+            tail_blocks = max(max_video_blocks - sink_blocks, 0)
             visible_video_blocks = all_video_blocks[:sink_blocks]
             if tail_blocks:
                 visible_video_blocks += all_video_blocks[-tail_blocks:]
-        video_len = len(visible_video_blocks) * self.block_size
+            live_tokens = min(resident_history + self.seq_len, len(visible_video_blocks) * self.block_size)
+
+        video_len = min(live_tokens, len(visible_video_blocks) * self.block_size)
         return visible_video_blocks, video_len
 
     def build_block_table(
@@ -195,12 +285,19 @@ class ARDiffusionPagedForwardContext:
 
         # Fixed capacity: full visible video window + one action-capacity block.
         action_capacity_blocks = max(1, (action_len + self.block_size - 1) // self.block_size)
-        width = max(self.max_video_tokens // self.block_size + action_capacity_blocks, len(block_ids))
+        # Both of these count in blocks. Deriving them from the token count by
+        # flooring would understate the capacity whenever the window is not a
+        # whole number of blocks: the width would fall back on len(block_ids)
+        # and start tracking how full the window is -- the exact shape churn
+        # the fixed width exists to prevent -- and max_seq_len could come out
+        # below the kv_len actually being passed, by up to block_size - 1.
+        capacity_blocks = self.max_video_blocks + action_capacity_blocks
+        width = max(capacity_blocks, len(block_ids))
         padded = block_ids + [0] * (width - len(block_ids))
 
         self.query_len = int(query_len)
         self.kv_len = int(video_len + action_len)
-        max_seq_len = int(self.max_video_tokens + action_capacity_blocks * self.block_size)
+        max_seq_len = int(capacity_blocks * self.block_size)
         block_table = torch.tensor([padded], dtype=torch.int32, device=device)
         query_start_loc = torch.tensor([0, self.query_len], dtype=torch.int32, device=device)
         seq_lens = torch.tensor([self.kv_len], dtype=torch.int32, device=device)

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, NamedTuple
 
@@ -301,6 +302,79 @@ class ARDiffusionPagedLayerContext:
     def to_layer_inputs(self) -> ARDiffusionPagedLayerInputs:
         """Compiled-region payload; requires ``forward_ctx.prepare()`` first."""
         return self.forward_ctx.layer_inputs(self.layer_idx)
+
+
+@dataclass(frozen=True)
+class PagedSequenceMetadata:
+    """One sequence's contribution to a coalesced forward.
+
+    ``block_ids`` are the physical blocks holding its KV in visit order,
+    ``kv_len`` how many of those tokens are live, and ``query_len`` how many
+    query tokens it contributes to the batch.
+    """
+
+    block_ids: tuple[int, ...]
+    kv_len: int
+    query_len: int
+
+    def __post_init__(self) -> None:
+        if not self.block_ids:
+            raise ValueError("A paged sequence needs at least one block.")
+        if self.kv_len <= 0 or self.query_len <= 0:
+            raise ValueError("kv_len and query_len must be positive.")
+
+
+def batch_paged_metadata(
+    sequences: Sequence[PagedSequenceMetadata],
+    *,
+    block_size: int,
+    device: torch.device,
+    width: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int, int]:
+    """Merge per-sequence tables into one varlen batch.
+
+    Returns the same five values ``build_block_table`` returns for a single
+    sequence, so a coalesced forward reaches the attention kernel through the
+    identical path -- the kernel already consumes ``block_table`` per row and
+    ``seq_lens`` per sequence.
+
+    Every row is padded to the widest member. Padding is never read: the
+    kernel dereferences only ``ceil(seq_lens / block_size)`` entries, which is
+    what keeps a short session from mixing in a neighbour's blocks. That is
+    asserted in ``tests/diffusion/ar_diffusion/test_paged_attention.py`` rather
+    than assumed, because the failure it prevents -- one session reading
+    another's KV -- produces a plausible but wrong result that no timing metric
+    can detect.
+    """
+    if not sequences:
+        raise ValueError("A coalesced batch needs at least one sequence.")
+    if block_size <= 0:
+        raise ValueError("block_size must be positive.")
+    for sequence in sequences:
+        needed = -(-sequence.kv_len // block_size)
+        if needed > len(sequence.block_ids):
+            raise ValueError(
+                f"kv_len={sequence.kv_len} needs {needed} blocks but only {len(sequence.block_ids)} were supplied."
+            )
+
+    resolved_width = max(len(sequence.block_ids) for sequence in sequences)
+    if width is not None:
+        if width < resolved_width:
+            raise ValueError(f"width={width} is narrower than the widest sequence ({resolved_width}).")
+        resolved_width = width
+
+    table = torch.tensor(
+        [list(s.block_ids) + [0] * (resolved_width - len(s.block_ids)) for s in sequences],
+        dtype=torch.int32,
+        device=device,
+    )
+    starts = [0]
+    for sequence in sequences:
+        starts.append(starts[-1] + sequence.query_len)
+    query_start_loc = torch.tensor(starts, dtype=torch.int32, device=device)
+    seq_lens = torch.tensor([s.kv_len for s in sequences], dtype=torch.int32, device=device)
+    max_query_len = max(s.query_len for s in sequences)
+    return table, query_start_loc, seq_lens, max_query_len, resolved_width * block_size
 
 
 def is_ar_diffusion_paged_context(value: object) -> bool:

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import itertools
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, NamedTuple
@@ -375,6 +376,150 @@ def batch_paged_metadata(
     seq_lens = torch.tensor([s.kv_len for s in sequences], dtype=torch.int32, device=device)
     max_query_len = max(s.query_len for s in sequences)
     return table, query_start_loc, seq_lens, max_query_len, resolved_width * block_size
+
+
+def _reject_overlapping_writes(video_slots: torch.Tensor, action_slots: torch.Tensor, num_sessions: int) -> None:
+    """Refuse a batch whose sessions would write to the same pool slots.
+
+    Scratch blocks are handed out per KV branch, not per session
+    (``ARDiffusionKVCache.scratch_block_ids`` offsets by branch index only), so
+    two sessions preparing an uncommitted chunk on the same branch receive the
+    *same* scratch blocks. Coalescing them would make each overwrite the
+    other's current K/V and then attend over the survivor.
+
+    That failure is invisible downstream -- the shapes are right, the kernel
+    succeeds, and the output is a plausible tensor -- so it is checked here
+    rather than left to whoever reads the frames. Session-indexed scratch is
+    what makes such a batch legal; until then, refuse it.
+    """
+    if num_sessions < 2:
+        return
+    slots = torch.cat((video_slots, action_slots), dim=0)
+    if slots.numel() and torch.unique(slots).numel() != slots.numel():
+        raise ValueError(
+            "Coalesced sessions write to overlapping KV slots. Sessions preparing an uncommitted "
+            "chunk share their KV branch's scratch blocks, so they cannot be batched until scratch "
+            "is indexed per session as well as per branch."
+        )
+
+
+@dataclass(frozen=True)
+class CoalescedPagedForward:
+    """Several sessions' prepared contexts merged into one forward's metadata.
+
+    Mirrors :class:`ARDiffusionPagedForwardContext`: :meth:`merge` does the
+    host-side work once per forward and :meth:`layer_inputs` hands each layer a
+    payload that only swaps in that layer's pools. Merging inside
+    ``layer_inputs`` instead would repeat the concatenations and the overlap
+    check once per DiT block.
+
+    Sessions are laid out along the *sequence* dimension, not the batch
+    dimension, so a coalesced forward still runs at ``batch_size=1`` with
+    ``query_start_loc`` marking the boundaries. That is forced rather than
+    chosen: the rotary layer documents that "all batch elements share the same
+    rotary position encoding", so sessions sitting at different chunk indices
+    cannot be stacked along the batch dimension without changing it, while
+    concatenating along the sequence dimension needs no change at all -- each
+    session's own cos/sin table simply concatenates too.
+    """
+
+    kv_cache: Any
+    block_size: int
+    seq_len: int
+    video_slots: torch.Tensor
+    action_slots: torch.Tensor
+    block_table: torch.Tensor
+    query_start_loc: torch.Tensor
+    seq_lens: torch.Tensor
+    max_query_len: int
+    max_seq_len: int
+
+    @classmethod
+    def merge(cls, contexts: Sequence[ARDiffusionPagedForwardContext]) -> CoalescedPagedForward:
+        """Merge prepared contexts in batch order.
+
+        Slot mappings concatenate in that same order, which must be the order
+        the caller concatenates K/V rows in -- the fused write op indexes the
+        pool with one flat slot tensor.
+
+        The already-built per-session tables are merged rather than rebuilt
+        from block ids through :func:`batch_paged_metadata`. Rebuilding would
+        re-derive the padded width from the *live* blocks, so the table would
+        grow as each session's window fills and the compiled graph would see
+        changing shapes. Every context has already padded itself to a fixed
+        capacity; taking the widest of those keeps the shape stable for exactly
+        as long as the single-session path does.
+        """
+        if not contexts:
+            raise ValueError("A coalesced forward needs at least one session context.")
+        tables: list[torch.Tensor] = []
+        starts: list[torch.Tensor] = []
+        for context in contexts:
+            table, start = context.block_table, context.query_start_loc
+            if not getattr(context, "_prepared", False) or table is None or start is None:
+                raise RuntimeError("CoalescedPagedForward.merge() before prepare() on every context")
+            tables.append(table)
+            starts.append(start)
+
+        first = contexts[0]
+        block_size = int(first.kv_cache.block_size)
+        for context in contexts[1:]:
+            if context.kv_cache is not first.kv_cache:
+                raise ValueError("Coalesced sessions must share one KV pool; got two different allocations.")
+            if int(context.kv_cache.block_size) != block_size:
+                raise ValueError("Coalesced sessions must share one block_size.")
+
+        width = max(int(table.shape[1]) for table in tables)
+        block_table = torch.cat(
+            [torch.nn.functional.pad(table, (0, width - int(table.shape[1]))) for table in tables],
+            dim=0,
+        )
+
+        query_lens = [int(context.query_len) for context in contexts]
+        query_start_loc = torch.tensor(
+            [0, *itertools.accumulate(query_lens)],
+            dtype=starts[0].dtype,
+            device=starts[0].device,
+        )
+        max_seq_len = max(int(context.max_seq_len) for context in contexts)
+        if width * block_size < max_seq_len:
+            raise AssertionError(
+                f"Coalesced block table holds {width * block_size} tokens but max_seq_len is {max_seq_len}."
+            )
+
+        video_slots = torch.cat([context.current_video_slot_mapping for context in contexts], dim=0)
+        action_slots = torch.cat([context.action_slot_mapping for context in contexts], dim=0)
+        _reject_overlapping_writes(video_slots, action_slots, len(contexts))
+
+        return cls(
+            kv_cache=first.kv_cache,
+            block_size=block_size,
+            seq_len=sum(int(context.seq_len) for context in contexts),
+            video_slots=video_slots,
+            action_slots=action_slots,
+            block_table=block_table,
+            query_start_loc=query_start_loc,
+            seq_lens=torch.cat([context.seq_lens for context in contexts], dim=0),
+            max_query_len=max(query_lens),
+            max_seq_len=max_seq_len,
+        )
+
+    def layer_inputs(self, layer_idx: int) -> ARDiffusionPagedLayerInputs:
+        """Compiled-region payload for one layer of the coalesced forward."""
+        return ARDiffusionPagedLayerInputs(
+            layer_idx=_layer_idx_tensor(layer_idx),
+            key_pool=self.kv_cache._k_pools[layer_idx],
+            value_pool=self.kv_cache._v_pools[layer_idx],
+            block_size=self.block_size,
+            seq_len=self.seq_len,
+            video_slots=self.video_slots,
+            action_slots=self.action_slots,
+            block_table=self.block_table,
+            query_start_loc=self.query_start_loc,
+            seq_lens=self.seq_lens,
+            max_query_len=self.max_query_len,
+            max_seq_len=self.max_seq_len,
+        )
 
 
 def is_ar_diffusion_paged_context(value: object) -> bool:

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/state.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/state.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Model-facing session state backed by paged AR-Diffusion KV storage."""
 
 from __future__ import annotations

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/state.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/state.py
@@ -39,6 +39,7 @@ class ARDiffusionKVState:
         adapters: Mapping[str, ARDiffusionRequestAdapter],
         *,
         num_layers: int,
+        scratch_slot: int = 0,
     ) -> None:
         expected = tuple(kv_branch.name for kv_branch in kv_cache.kv_branches)
         if set(adapters) != set(expected):
@@ -46,10 +47,17 @@ class ARDiffusionKVState:
                 "AR-Diffusion session adapters must match the configured KV branches; "
                 f"expected {expected}, got {tuple(adapters)}"
             )
+        slots = getattr(kv_cache, "scratch_slots", 1)
+        if not 0 <= scratch_slot < slots:
+            raise ValueError(
+                f"scratch_slot must be in [0, {slots}) for this KV cache, got {scratch_slot}. "
+                "Raise ARDiffusionKVConfig.scratch_slots to run more sessions in one forward."
+            )
         self.kv_cache = kv_cache
         self.session_id = session_id
         self.adapters = dict(adapters)
         self.num_layers = num_layers
+        self.scratch_slot = int(scratch_slot)
         self._committed: dict[str, int] = dict.fromkeys(expected, 0)
         self._paged_pending: dict[str, ARDiffusionPagedForwardContext | None] = dict.fromkeys(expected)
         self._closed = False
@@ -109,6 +117,7 @@ class ARDiffusionKVState:
             max_video_tokens=int(
                 self.kv_cache.spec.sliding_window + self.kv_cache.spec.sink_chunks * self.kv_cache.spec.chunk_size
             ),
+            scratch_slot=self.scratch_slot,
         )
         self._paged_pending[kv_branch] = forward_ctx
         _log.debug(

--- a/vllm_omni/experimental/ar_diffusion/runner.py
+++ b/vllm_omni/experimental/ar_diffusion/runner.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import dataclasses
 import time
 from collections import OrderedDict
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import torch
 from vllm.logger import init_logger
@@ -24,15 +26,13 @@ from vllm_omni.experimental.ar_diffusion.kv_cache.manager import ARDiffusionKVCa
 from vllm_omni.experimental.ar_diffusion.kv_cache.state import ARDiffusionKVState
 from vllm_omni.experimental.ar_diffusion.tick_protocol import ARDiffusionTickRequest
 
+if TYPE_CHECKING:
+    from vllm.v1.attention.backend import MultipleOf
+
 logger = init_logger(__name__)
 
 
-# FlashAttention's paged kernel accepts only block sizes that are multiples of
-# 16 (`vllm/v1/attention/backends/flash_attn.py`, get_supported_kernel_block_sizes).
-KERNEL_BLOCK_MULTIPLE = 16
-
-
-def paging_block_size(tokens_per_frame: int) -> int:
+def paging_block_size(tokens_per_frame: int, supported: Sequence[int | MultipleOf] | None = None) -> int:
     """Choose the paging unit, which is not the eviction unit.
 
     AR-Diffusion evicts by frame; the attention kernel tiles by a fixed number
@@ -48,10 +48,37 @@ def paging_block_size(tokens_per_frame: int) -> int:
     the finest legal unit, which costs a longer block table and gives back the
     rounding waste of a block one whole frame wide -- at 832x480 that block is
     over a gigabyte.
+
+    What counts as legal is asked, not assumed. ``supported`` carries vLLM's
+    own vocabulary: a plain int is that exact size, ``MultipleOf(b)`` is any
+    positive multiple of ``b``. The kernels AR-Diffusion reaches agree on
+    multiples of 16, but others in the same tree do not -- ``hpc_attn`` takes
+    only 64, and FlashInfer offers pages of 128 and up on Blackwell alone. A
+    constant here would be a silently wrong block size on the first machine
+    whose kernel differs, and a wrong block size is not an error: it is a
+    kernel reading tokens that were never written.
     """
-    if tokens_per_frame % KERNEL_BLOCK_MULTIPLE == 0:
+    if supported is None:
+        # Imported here, not at module scope: paged_attention registers a
+        # custom op on import, and the tests that pop it from sys.modules to
+        # re-import it depend on nothing else holding it first.
+        from vllm_omni.experimental.ar_diffusion.kv_cache.paged_attention import supported_kernel_block_sizes
+
+        supported = supported_kernel_block_sizes()
+    if not supported:
+        raise ValueError("The attention kernel advertises no legal block size.")
+
+    def legal(size: int) -> bool:
+        return size > 0 and any(
+            size == entry if isinstance(entry, int) else size % entry.base == 0 for entry in supported
+        )
+
+    if legal(tokens_per_frame):
         return tokens_per_frame
-    return KERNEL_BLOCK_MULTIPLE
+    finest = min(entry if isinstance(entry, int) else entry.base for entry in supported)
+    if not legal(finest):
+        raise ValueError(f"No legal paging unit among {supported!r}.")
+    return finest
 
 
 def resolve_ar_diffusion_kv_config(od_config: OmniDiffusionConfig) -> ARDiffusionKVConfig:

--- a/vllm_omni/experimental/ar_diffusion/runner.py
+++ b/vllm_omni/experimental/ar_diffusion/runner.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 from __future__ import annotations
 
 import dataclasses

--- a/vllm_omni/experimental/ar_diffusion/runner.py
+++ b/vllm_omni/experimental/ar_diffusion/runner.py
@@ -26,6 +26,33 @@ from vllm_omni.experimental.ar_diffusion.tick_protocol import ARDiffusionTickReq
 logger = init_logger(__name__)
 
 
+# FlashAttention's paged kernel accepts only block sizes that are multiples of
+# 16 (`vllm/v1/attention/backends/flash_attn.py`, get_supported_kernel_block_sizes).
+KERNEL_BLOCK_MULTIPLE = 16
+
+
+def paging_block_size(tokens_per_frame: int) -> int:
+    """Choose the paging unit, which is not the eviction unit.
+
+    AR-Diffusion evicts by frame; the attention kernel tiles by a fixed number
+    of tokens. Using the frame as the block binds every output resolution to
+    that kernel constraint, so the resolutions that run today do so by
+    arithmetic accident -- and the LingBot World v2 checkpoint's own default
+    832x480 is not one of them:
+
+        (480/16) x (832/16) = 30 x 52 = 1560 tokens per frame, 1560 % 16 = 8
+
+    A frame that is already a legal block stays one, so every resolution that
+    works today keeps precisely the paging it has now. Anything else pages at
+    the finest legal unit, which costs a longer block table and gives back the
+    rounding waste of a block one whole frame wide -- at 832x480 that block is
+    over a gigabyte.
+    """
+    if tokens_per_frame % KERNEL_BLOCK_MULTIPLE == 0:
+        return tokens_per_frame
+    return KERNEL_BLOCK_MULTIPLE
+
+
 def resolve_ar_diffusion_kv_config(od_config: OmniDiffusionConfig) -> ARDiffusionKVConfig:
     """Resolve optional deployment overrides and enable AR-Diffusion KV."""
     raw = getattr(od_config, "ar_diffusion_kv_config", None)
@@ -129,7 +156,7 @@ class ARDiffusionModelRunner(DiffusionModelRunner):
             num_kv_heads=spec.num_kv_heads,
             head_size=spec.head_size,
             dtype=self.od_config.dtype,
-            block_size=spec.tokens_per_frame,
+            block_size=paging_block_size(spec.tokens_per_frame),
             max_model_len=spec.max_model_len,
             available_bytes=self._available_memory_bytes() if available_bytes is None else available_bytes,
             kv_branches=spec.kv_branches,

--- a/vllm_omni/experimental/ar_diffusion/runner.py
+++ b/vllm_omni/experimental/ar_diffusion/runner.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import dataclasses
 import time
 from collections import OrderedDict
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
+from typing import TYPE_CHECKING
 
 import torch
 from vllm.logger import init_logger
@@ -28,15 +29,13 @@ from vllm_omni.experimental.ar_diffusion.kv_cache.state import ARDiffusionKVStat
 from vllm_omni.experimental.ar_diffusion.tick_protocol import ARDiffusionTickRequest
 from vllm_omni.platforms import current_omni_platform
 
+if TYPE_CHECKING:
+    from vllm.v1.attention.backend import MultipleOf
+
 logger = init_logger(__name__)
 
 
-# FlashAttention's paged kernel accepts only block sizes that are multiples of
-# 16 (`vllm/v1/attention/backends/flash_attn.py`, get_supported_kernel_block_sizes).
-KERNEL_BLOCK_MULTIPLE = 16
-
-
-def paging_block_size(tokens_per_frame: int) -> int:
+def paging_block_size(tokens_per_frame: int, supported: Sequence[int | MultipleOf] | None = None) -> int:
     """Choose the paging unit, which is not the eviction unit.
 
     AR-Diffusion evicts by frame; the attention kernel tiles by a fixed number
@@ -52,10 +51,37 @@ def paging_block_size(tokens_per_frame: int) -> int:
     the finest legal unit, which costs a longer block table and gives back the
     rounding waste of a block one whole frame wide -- at 832x480 that block is
     over a gigabyte.
+
+    What counts as legal is asked, not assumed. ``supported`` carries vLLM's
+    own vocabulary: a plain int is that exact size, ``MultipleOf(b)`` is any
+    positive multiple of ``b``. The kernels AR-Diffusion reaches agree on
+    multiples of 16, but others in the same tree do not -- ``hpc_attn`` takes
+    only 64, and FlashInfer offers pages of 128 and up on Blackwell alone. A
+    constant here would be a silently wrong block size on the first machine
+    whose kernel differs, and a wrong block size is not an error: it is a
+    kernel reading tokens that were never written.
     """
-    if tokens_per_frame % KERNEL_BLOCK_MULTIPLE == 0:
+    if supported is None:
+        # Imported here, not at module scope: paged_attention registers a
+        # custom op on import, and the tests that pop it from sys.modules to
+        # re-import it depend on nothing else holding it first.
+        from vllm_omni.experimental.ar_diffusion.kv_cache.paged_attention import supported_kernel_block_sizes
+
+        supported = supported_kernel_block_sizes()
+    if not supported:
+        raise ValueError("The attention kernel advertises no legal block size.")
+
+    def legal(size: int) -> bool:
+        return size > 0 and any(
+            size == entry if isinstance(entry, int) else size % entry.base == 0 for entry in supported
+        )
+
+    if legal(tokens_per_frame):
         return tokens_per_frame
-    return KERNEL_BLOCK_MULTIPLE
+    finest = min(entry if isinstance(entry, int) else entry.base for entry in supported)
+    if not legal(finest):
+        raise ValueError(f"No legal paging unit among {supported!r}.")
+    return finest
 
 
 def resolve_ar_diffusion_kv_config(od_config: OmniDiffusionConfig) -> ARDiffusionKVConfig:

--- a/vllm_omni/experimental/ar_diffusion/runner.py
+++ b/vllm_omni/experimental/ar_diffusion/runner.py
@@ -31,6 +31,33 @@ from vllm_omni.platforms import current_omni_platform
 logger = init_logger(__name__)
 
 
+# FlashAttention's paged kernel accepts only block sizes that are multiples of
+# 16 (`vllm/v1/attention/backends/flash_attn.py`, get_supported_kernel_block_sizes).
+KERNEL_BLOCK_MULTIPLE = 16
+
+
+def paging_block_size(tokens_per_frame: int) -> int:
+    """Choose the paging unit, which is not the eviction unit.
+
+    AR-Diffusion evicts by frame; the attention kernel tiles by a fixed number
+    of tokens. Using the frame as the block binds every output resolution to
+    that kernel constraint, so the resolutions that run today do so by
+    arithmetic accident -- and the LingBot World v2 checkpoint's own default
+    832x480 is not one of them:
+
+        (480/16) x (832/16) = 30 x 52 = 1560 tokens per frame, 1560 % 16 = 8
+
+    A frame that is already a legal block stays one, so every resolution that
+    works today keeps precisely the paging it has now. Anything else pages at
+    the finest legal unit, which costs a longer block table and gives back the
+    rounding waste of a block one whole frame wide -- at 832x480 that block is
+    over a gigabyte.
+    """
+    if tokens_per_frame % KERNEL_BLOCK_MULTIPLE == 0:
+        return tokens_per_frame
+    return KERNEL_BLOCK_MULTIPLE
+
+
 def resolve_ar_diffusion_kv_config(od_config: OmniDiffusionConfig) -> ARDiffusionKVConfig:
     """Resolve optional deployment overrides and enable AR-Diffusion KV."""
     raw = getattr(od_config, "ar_diffusion_kv_config", None)
@@ -138,7 +165,7 @@ class ARDiffusionModelRunner(DiffusionModelRunner):
             num_kv_heads=spec.num_kv_heads,
             head_size=spec.head_size,
             dtype=self.od_config.dtype,
-            block_size=spec.tokens_per_frame,
+            block_size=paging_block_size(spec.tokens_per_frame),
             max_model_len=spec.max_model_len,
             available_bytes=self._available_memory_bytes() if available_bytes is None else available_bytes,
             kv_branches=spec.kv_branches,


### PR DESCRIPTION
Fixes #6475.

## What was wrong

The AR-Diffusion paged KV cache used one latent frame as one cache block, so
`runner.py` passed the same value as both the eviction unit and the paging
unit. These are independent concerns -- AR-Diffusion evicts by frame,
FlashAttention tiles by 16 tokens -- and binding them made every output
resolution a kernel-compatibility question.

The resolutions that work today work by arithmetic accident. The one the
LingBot World v2 checkpoint ships as its default does not:

    832x480 -> (480/16) x (832/16) = 1560 tokens per frame, 1560 % 16 = 8

It failed with `Paged KV cache block size must be divisible by 16`, which
names neither the resolution nor the frame geometry that produced it.

## What changed

**`runner.py`** picks the paging unit separately from the eviction unit. A
frame that is already a legal block stays one, so every resolution that runs
today keeps precisely the paging it has; anything else pages at 16. What counts
as legal is asked of the module that dispatches the kernel,
`supported_kernel_block_sizes()`, which answers `MultipleOf(16)`. FA4's
head-size-256 kernel pages at 128, but it is not reachable from this call path:
vLLM selects it only when the caller passes `supports_fa4_hd256=True`, which the
AR-Diffusion call does not, so that head size falls back to FA2.

**`paged_attention.py`** stops assuming a chunk is a whole number of blocks:

- `num_current_video_blocks` counts from the offset the chunk starts at. Thirty
  tokens starting at position thirty span three 16-token blocks, not two.
- `video_block_table()` places each block by the token positions it holds and
  keeps the blocks that hold a sink token or one of the window's recent
  tokens; the length it returns counts the slots actually written. When a
  chunk is not block-aligned, the block holding the end of the history also
  holds the start of the current chunk, and it is listed once. Listing it
  twice made the kernel read those tokens twice and drop as many from the end,
  with correct shapes throughout. Only the block-table indices of the sink and
  of the recent window are read, straight from the block manager's list without
  copying the table: the table keeps a null entry for every evicted position and
  grows with the session, so reading all of it would cost more on every tick of a
  long session. How the window is converted to blocks was itself
  wrong in an earlier revision of this branch; see *Fixed before merge*.
- `build_block_table()` derives the table width and `max_seq_len` from a block
  count, not a token count. Flooring a token count understated the capacity
  whenever the window was not a whole number of blocks: the width fell back on
  the live block count and began tracking how full the window was -- the shape
  churn the fixed width exists to prevent -- and `max_seq_len` could come out
  below the `kv_len` actually passed, by up to `block_size - 1`.

**The scratch path** is the interesting one. Four of the five forwards per
generated block are non-committing and write the current chunk into a separate
region, which assumed the history ended on a block boundary. It does not: at
1560 tokens per frame the history stops 8 slots into its last block on every
odd chunk, and since the kernel consumes the block table as one contiguous
run, it read those 8 unwritten slots as tokens and shifted everything after.

Rather than copy the history's partial tail block into scratch -- a cross-layer
copy on a hot path -- the chunk now simply begins where the history left off,
spilling its first few tokens into the free tail of the history's own last
block. That block is already this session's (blocks are allocated whole), the
slots hold nothing yet, and the committing forward overwrites the same slots
with clean K/V later, so the committed state is identical either way. No copy,
no new work per forward.

**`manager.py`** converts the capacity formula's terms from frames to blocks.
Each term counted frames and was used directly as a block count, which was the
identity only while the two were the same thing. Converting keeps the budget
the same number of *tokens* it always was.

## Fixed before merge

Separating the paging unit from the frame broke two things further down, both
on this branch only. `main` cannot run 832x480 at all, so neither reached it.

### The attention sink was indexed in frames

`remove_skipped_blocks` kept the first `sink_chunks` entries of the block table,
but `sink_chunks` counts frames and the table is indexed in blocks. The two were
interchangeable while a frame was a block. At 832x480 a frame spans 98 blocks,
so the configured 9-frame sink held 9 blocks -- 144 tokens instead of 14040 --
and eviction began inside frame 0, deleting from the region the sink exists to
protect. The sink end now rounds up to a block and the freed range ends on a
rounded-down boundary, so a straddling block stays protected; both are exact
when a frame is a whole number of blocks.

Measured on one RTX PRO 6000 (sm_120), bf16, 832x480, seed 0, same scene and
prompt, this change alone. Chroma high-frequency energy relative to each run's
own first ten ticks:

| session time | before | after |
| ---: | ---: | ---: |
| 15 s | 1.46x | 0.88x |
| 30 s | 1.94x | 0.97x |
| 45 s | 2.50x | 1.23x |
| 52 s | 4.47x | 1.24x |

This is the size of a regression the branch introduced, not an improvement over
`main`. The unfixed run is visually unusable by 45 s; the fixed run is still
coherent at 56 s, with mild magenta on the ground from 42 s, so long-session
degradation is not removed by this.

### The window read the wrong blocks once it slid

Reported in review on this PR. `video_block_table()` counted blocks off the ends
of the resident list and capped the table width at the window's token count
rounded up once. The sink and the recent window are separate token ranges, and
each can straddle a block edge on its own; when both did, the width was a block
short, the block holding the window's first tokens was the one left out, and the
returned length -- capped by a block count rather than counted from what was
written -- ran past the last written slot.

At 832x480 with the checkpoint's own 9-frame sink and 9-frame window, both
boundaries sit 8 tokens past an edge while their sum, 28080 tokens, is a whole
number of blocks. Once the window filled, every tick needed 1756 blocks against a
width of 1755: 8 or 16 of the window's tokens were never attended, and every
other tick read 8 unwritten slots.

Blocks are now placed by position, as described above. The width is the sink's
blocks plus the recent range's, where the recent range starts a whole number of
chunks in and so sits at most `block_size - gcd(chunk_size, block_size)` tokens
past an edge. That is zero for a chunk that is a whole number of blocks, so every
frame-aligned geometry keeps exactly the width it had; at 832x480 the width is
1756, exactly what the window needs. Whole blocks are still read, so each
boundary can contribute up to `block_size - 1` tokens the window has already let
go of; they are real K/V at their own positions.

### Action tokens after a partly written video block are refused

Action K/V is listed after the video blocks and the kernel reads the table as one
run, so a video run that ends part way through a block made the kernel read that
block's unwritten slots as the first action tokens and never reach the last ones.
On CPU the output came back NaN-poisoned and no longer matched dense attention,
on both the scratch and committing paths. This now raises. A frame that is a
whole number of blocks always ends on an edge, so only geometries that could not
page before this PR are refused.

## Verification

Against vllm 0.29.0, `tests/diffusion/ar_diffusion`,
`tests/diffusion/models/lingbot_world` and `tests/diffusion/models/dreamzero`
pass on this branch (427 passed) and merged into current `main` (470 passed,
3 skipped). Every existing test of the aligned path passes
unchanged, including the fixed-width test: a frame that is already a legal block
still pages as one block, and its window keeps the width it had.

New CPU regression tests, each comparing against dense attention over the
exact K/V the sequence should see:

| case | result |
| --- | --- |
| 1560 tokens/frame, block 16, non-committing path | matches to 1e-5 |
| 24 tokens/frame, block 16 (same remainder of 8), with and without action K/V | matches to 1e-5 |
| ragged window over 6 consecutive ticks | table width constant, `max_seq_len >= kv_len` throughout |
| 832x480 spec | builds a cache, 98 blocks per frame, eviction still by frame |
| sink at 1560 tokens/frame | eviction starts outside the 14040-token sink |
| attention after eviction: 24 tokens/frame with sink/window of (1, 2), (0, 2), (1, 3) chunks and a reset-at-boundary window, scratch and committing forwards, every unwritten slot poisoned | matches to 1e-5 |
| 832x480 with the checkpoint's 9-frame sink and window, 12 ticks | every slot read holds the token its position implies; width constant |
| action tokens after a partly written video block | refused on both paths |
| reading the window after 60 chunks, when the table is over ten times the window | no more block ids leave vLLM's block manager than the window's width |

The first row is the case this issue reported at ~4e-02. It runs on CPU
because the reference is dense attention rather than a kernel, so it is a
normal part of the suite rather than GPU-gated.

Every existing fixture holds `chunk_size == block_size`, so none of them
could reach this path; `chunk_size=24` against 16-token blocks reproduces
the shipped resolution's remainder of 8 at a size that runs quickly.

These tests are not vacuous. Reverting only the scratch-path change fails
exactly the two `commit_current=False` cases and the continuity assertion,
while both `commit_current=True` cases still pass -- the same split between
the committing and scratch paths the issue describes. Reverting the sink
conversion fails the sink test with `eviction starts at token 144, inside the
14040-token sink`. Reverting the window fix fails the three sliding-window
geometries, the 832x480 test and both action-refusal cases; the
reset-at-boundary case passes either way and guards the skipping of blocks a
reset has freed.

Copying the whole block table again fails the last row: 90 block ids read for a
6-block window. The count is taken at vLLM's `get_blocks`, so a copy is caught
even when only the window's entries are indexed afterwards.

The new tests run on the CPU reference path. The FlashAttention kernel reads
the block table the same way, but it is not exercised by them.

## Scope

An earlier revision of this branch also carried cross-session coalescing
primitives (`CoalescedPagedForward`, `batch_paged_metadata` and per-session
scratch regions). Nothing called them -- the AR-Diffusion runner serves one
request at a time -- so they were moved out of this PR. The commit history shows
them added and then removed; the diff against `main` does not include them.

## Behaviour changes

For a frame that is not a whole number of blocks, the block table is wider by
the room each window boundary can need -- 1756 blocks instead of 1755 at
832x480. Frame-aligned geometries keep their width.

Action tokens are refused after a video run that ends part way through a block,
as described above.

`test_budget_reduced_capacity_drives_runner_lru` had its byte figures updated
from 128/192 to 1,808/2,592. `tiny_spec` declares one token per frame, so it
used to page a single token at a time -- a block size no attention kernel
accepts. Paging at 16 makes each page sixteen times larger; the block *counts*
are unchanged, as is what the test is about.


