### PR TITLE
[NPU][Quant] Reuse MindIE-SD fp8_rotate_quant_fa_op for KV quant attention

### DIFF
--- a/tests/diffusion/attention/test_flash_attn.py
+++ b/tests/diffusion/attention/test_flash_attn.py
@@ -398,6 +398,47 @@ def _npu_impl(causal: bool = False) -> FlashAttentionImpl:
     return FlashAttentionImpl(num_heads=2, head_size=4, softmax_scale=0.5, causal=causal)
 
 
+@pytest.mark.parametrize(
+    "qkv_layout,input_shape,expected_layout",
+    [
+        (None, (1, 8, 2, 4), "BSND"),
+        ("BSND", (1, 8, 2, 4), "BSND"),
+        ("BNSD", (1, 2, 8, 4), "BNSD"),
+    ],
+)
+def test_npu_fp8_quant_preserves_declared_qkv_layout(monkeypatch, qkv_layout, input_shape, expected_layout):
+    captured = {}
+
+    def fake_fp8_rotate_quant_fa(query, key, value, **kwargs):
+        captured["args"] = (query, key, value)
+        captured["kwargs"] = kwargs
+        return torch.ones_like(query)
+
+    fake_quant = SimpleNamespace(fp8_rotate_quant_fa=fake_fp8_rotate_quant_fa)
+    monkeypatch.setitem(sys.modules, "vllm_omni.platforms.npu.quant.kv_quant_npu", fake_quant)
+
+    impl = FlashAttentionImpl(
+        num_heads=2,
+        head_size=4,
+        softmax_scale=0.5,
+        causal=False,
+        qkv_layout=qkv_layout,
+    )
+    query = torch.randn(input_shape)
+    key = torch.randn(input_shape)
+    value = torch.randn(input_shape)
+
+    out = impl.forward_fa_quant_npu(query, key, value)
+
+    op_query, op_key, op_value = captured["args"]
+    assert op_query is query
+    assert op_key is key
+    assert op_value is value
+    assert captured["kwargs"]["layout"] == expected_layout
+    assert captured["kwargs"]["softmax_scale"] == 0.5
+    assert out.shape == query.shape
+
+
 def _fake_mindiesd(monkeypatch, *, attention_forward=None, attention_forward_varlen=None):
     """Install a stub ``mindiesd`` so local ``from mindiesd import ...`` works.
 

--- a/tests/platforms/npu/quant/test_kv_quant_npu.py
+++ b/tests/platforms/npu/quant/test_kv_quant_npu.py
@@ -99,7 +99,7 @@ class TestKVQuantNPUUnit:
     def fake_quant_ops(self, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
         captured: dict[str, Any] = {
             "fa_calls": [],
-            "npu_kwargs": None,
+            "mindiesd_kwargs": None,
             "out_shape": None,
         }
 
@@ -107,11 +107,15 @@ class TestKVQuantNPUUnit:
             float8_e4m3fn = "fp8_marker"
 
             @staticmethod
-            def npu_fused_infer_attention_score_v2(q, k, v, **kwargs):
-                del q, k, v
-                captured["npu_kwargs"] = kwargs
-                out_shape = captured["out_shape"]
-                return (torch.ones(out_shape, dtype=torch.float32),)
+            def npu_fused_infer_attention_score_v2(*args, **kwargs):
+                del args, kwargs
+                raise AssertionError("the removed CANN FP8 per-block FA path must not be called")
+
+        def fake_mindiesd_fused_infer_attention_score_v2(q, k, v, **kwargs):
+            del q, k, v
+            captured["mindiesd_kwargs"] = kwargs
+            out_shape = captured["out_shape"]
+            return (torch.ones(out_shape, dtype=torch.float32), torch.empty(0))
 
         def fake_fa_block_quant_preprocess(x, block_size, dst_type, layout):
             captured["fa_calls"].append(
@@ -135,7 +139,13 @@ class TestKVQuantNPUUnit:
         monkeypatch.setattr(
             kv_quant_npu,
             "_load_quant_ops",
-            lambda: (FakeTorchNPU, fake_fa_block_quant_preprocess, fake_qua_rot_mode, fake_create_rot),
+            lambda: (
+                FakeTorchNPU,
+                fake_fa_block_quant_preprocess,
+                fake_mindiesd_fused_infer_attention_score_v2,
+                fake_qua_rot_mode,
+                fake_create_rot,
+            ),
         )
 
         return captured
@@ -151,7 +161,8 @@ class TestKVQuantNPUUnit:
         "layout,input_shape,out_shape,softmax_scale,expected_scale",
         [
             ("BNSD", (2, 3, 4, 8), (2, 3, 6, 8), None, 1.0 / math.sqrt(8)),
-            ("BSND", (2, 4, 3, 8), (2, 6, 3, 8), 0.125, 0.125),
+            # MindIE-SD block preprocessing normalizes BSND input to BNSD.
+            ("BSND", (2, 4, 3, 8), (2, 3, 6, 8), 0.125, 0.125),
         ],
     )
     def test_fp8_rotate_quant_fa_layouts_scale_and_crop(
@@ -170,11 +181,11 @@ class TestKVQuantNPUUnit:
 
         assert out.shape == query.shape
         assert out.dtype == query.dtype
-        assert fake_quant_ops["npu_kwargs"]["input_layout"] == layout
+        assert fake_quant_ops["mindiesd_kwargs"]["input_layout"] == "BNSD"
         # BNSD: shape[1]==heads, BSND: shape[2]==heads.
         expected_heads = input_shape[1] if layout == "BNSD" else input_shape[2]
-        assert fake_quant_ops["npu_kwargs"]["num_query_heads"] == expected_heads
-        assert fake_quant_ops["npu_kwargs"]["softmax_scale"] == pytest.approx(expected_scale)
+        assert fake_quant_ops["mindiesd_kwargs"]["num_query_heads"] == expected_heads
+        assert fake_quant_ops["mindiesd_kwargs"]["softmax_scale"] == pytest.approx(expected_scale)
         assert [call["block_size"] for call in fake_quant_ops["fa_calls"]] == [128, 256, 256]
 
     def test_fp8_rotate_quant_fa_invalid_layout_raises(self, fake_quant_ops) -> None:

--- a/tests/platforms/npu/quant/test_kv_quant_npu.py
+++ b/tests/platforms/npu/quant/test_kv_quant_npu.py
@@ -10,7 +10,6 @@ the test module itself does not ``import vllm_omni`` (which would pull
 from __future__ import annotations
 
 import importlib.util
-import math
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any
@@ -98,36 +97,14 @@ class TestKVQuantNPUUnit:
     @pytest.fixture
     def fake_quant_ops(self, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
         captured: dict[str, Any] = {
-            "fa_calls": [],
-            "mindiesd_kwargs": None,
-            "out_shape": None,
+            "op_args": None,
+            "op_kwargs": None,
         }
 
-        class FakeTorchNPU:
-            float8_e4m3fn = "fp8_marker"
-
-            @staticmethod
-            def npu_fused_infer_attention_score_v2(*args, **kwargs):
-                del args, kwargs
-                raise AssertionError("the removed CANN FP8 per-block FA path must not be called")
-
-        def fake_mindiesd_fused_infer_attention_score_v2(q, k, v, **kwargs):
-            del q, k, v
-            captured["mindiesd_kwargs"] = kwargs
-            out_shape = captured["out_shape"]
-            return (torch.ones(out_shape, dtype=torch.float32), torch.empty(0))
-
-        def fake_fa_block_quant_preprocess(x, block_size, dst_type, layout):
-            captured["fa_calls"].append(
-                {
-                    "block_size": block_size,
-                    "layout": layout,
-                    "dst_type": dst_type,
-                    "shape": tuple(x.shape),
-                }
-            )
-            scale = torch.full((1,), float(block_size), dtype=torch.float32)
-            return x, scale
+        def fake_fp8_op(q, k, v, **kwargs):
+            captured["op_args"] = (q, k, v)
+            captured["op_kwargs"] = kwargs
+            return torch.ones_like(q)
 
         fake_qua_rot_mode = SimpleNamespace(HADAMARD="hadamard")
 
@@ -138,14 +115,8 @@ class TestKVQuantNPUUnit:
 
         monkeypatch.setattr(
             kv_quant_npu,
-            "_load_quant_ops",
-            lambda: (
-                FakeTorchNPU,
-                fake_fa_block_quant_preprocess,
-                fake_mindiesd_fused_infer_attention_score_v2,
-                fake_qua_rot_mode,
-                fake_create_rot,
-            ),
+            "_load_sd_ops",
+            lambda: (fake_fp8_op, fake_qua_rot_mode, fake_create_rot),
         )
 
         return captured
@@ -158,41 +129,41 @@ class TestKVQuantNPUUnit:
         return query, key, value
 
     @pytest.mark.parametrize(
-        "layout,input_shape,out_shape,softmax_scale,expected_scale",
+        "layout,input_shape,softmax_scale",
         [
-            ("BNSD", (2, 3, 4, 8), (2, 3, 6, 8), None, 1.0 / math.sqrt(8)),
-            # MindIE-SD block preprocessing normalizes BSND input to BNSD.
-            ("BSND", (2, 4, 3, 8), (2, 3, 6, 8), 0.125, 0.125),
+            ("BNSD", (2, 3, 4, 8), None),
+            ("BSND", (2, 4, 3, 8), 0.125),
         ],
     )
-    def test_fp8_rotate_quant_fa_layouts_scale_and_crop(
+    def test_fp8_rotate_quant_fa_forwards_layout_scale_and_rotation(
         self,
         fake_quant_ops: dict[str, Any],
         layout: str,
         input_shape: tuple[int, int, int, int],
-        out_shape: tuple[int, int, int, int],
         softmax_scale: float | None,
-        expected_scale: float,
     ) -> None:
         query, key, value = self._make_qkv(input_shape)
-        fake_quant_ops["out_shape"] = out_shape
 
         out = kv_quant_npu.fp8_rotate_quant_fa(query, key, value, layout=layout, softmax_scale=softmax_scale)
 
         assert out.shape == query.shape
         assert out.dtype == query.dtype
-        assert fake_quant_ops["mindiesd_kwargs"]["input_layout"] == "BNSD"
-        # BNSD: shape[1]==heads, BSND: shape[2]==heads.
-        expected_heads = input_shape[1] if layout == "BNSD" else input_shape[2]
-        assert fake_quant_ops["mindiesd_kwargs"]["num_query_heads"] == expected_heads
-        assert fake_quant_ops["mindiesd_kwargs"]["softmax_scale"] == pytest.approx(expected_scale)
-        assert [call["block_size"] for call in fake_quant_ops["fa_calls"]] == [128, 256, 256]
+        op_query, op_key, op_value = fake_quant_ops["op_args"]
+        assert op_query is query
+        assert op_key is key
+        assert op_value is value
+        assert fake_quant_ops["op_kwargs"]["layout"] == layout
+        assert fake_quant_ops["op_kwargs"]["softmax_scale"] == softmax_scale
+        q_rot = fake_quant_ops["op_kwargs"]["q_rot"]
+        k_rot = fake_quant_ops["op_kwargs"]["k_rot"]
+        assert q_rot is k_rot
+        assert q_rot.shape == (input_shape[-1], input_shape[-1])
+        assert q_rot.dtype == query.dtype
 
     def test_fp8_rotate_quant_fa_invalid_layout_raises(self, fake_quant_ops) -> None:
         query = torch.randn(1, 2, 3, 4, dtype=torch.float32)
         key = torch.randn(1, 2, 3, 4, dtype=torch.float32)
         value = torch.randn(1, 2, 3, 4, dtype=torch.float32)
-        fake_quant_ops["out_shape"] = (1, 2, 3, 4)
 
         with pytest.raises(ValueError, match="unsupported layout"):
             kv_quant_npu.fp8_rotate_quant_fa(query, key, value, layout="INVALID")
@@ -204,8 +175,8 @@ class TestKVQuantNPUSmoke:
 
     def test_fp8_rotate_quant_fa_real_npu_shape_contract(self):
         try:
-            kv_quant_npu._load_quant_ops.cache_clear()
-            kv_quant_npu._load_quant_ops()
+            kv_quant_npu._load_sd_ops.cache_clear()
+            kv_quant_npu._load_sd_ops()
         except ImportError:
             pytest.skip("NPU quant dependencies are not fully installed.")
 

--- a/vllm_omni/diffusion/attention/backends/flash_attn.py
+++ b/vllm_omni/diffusion/attention/backends/flash_attn.py
@@ -399,16 +399,14 @@ class FlashAttentionImpl(AttentionImpl):
     ) -> torch.Tensor:
         from vllm_omni.platforms.npu.quant.kv_quant_npu import fp8_rotate_quant_fa
 
-        layout = self.qkv_layout or "BNSD"
-        # Models pass (B, S, H, D); NPU fused op expects (B, N, S, D).
-        out = fp8_rotate_quant_fa(
-            query.transpose(1, 2),
-            key.transpose(1, 2),
-            value.transpose(1, 2),
+        layout = self.qkv_layout or "BSND"
+        return fp8_rotate_quant_fa(
+            query,
+            key,
+            value,
             layout=layout,
             softmax_scale=self.softmax_scale,
         )
-        return out.transpose(1, 2)
 
     def forward_fa_npu(
         self,

--- a/vllm_omni/platforms/npu/quant/kv_quant_npu.py
+++ b/vllm_omni/platforms/npu/quant/kv_quant_npu.py
@@ -32,6 +32,9 @@ def is_quantized_kv_cache(kv_cache_dtype: str | None) -> bool:
 def _load_quant_ops():
     try:
         import torch_npu
+        from mindiesd.layers.flash_attn.fused_infer_attention_score import (
+            fused_infer_attention_score_v2,
+        )
         from mindiesd.layers.quant.block_quant import fa_block_quant_preprocess
         from msmodelslim.processor.quarot.common.quarot_utils import QuaRotMode, create_rot
     except ImportError as e:
@@ -39,7 +42,7 @@ def _load_quant_ops():
             "fp8_rotate_quant_fa requires torch_npu, MindIE-SD (mindiesd), and MSModelSlim. "
             "See https://gitcode.com/Ascend/MindIE-SD and https://gitcode.com/Ascend/msmodelslim"
         ) from e
-    return torch_npu, fa_block_quant_preprocess, QuaRotMode, create_rot
+    return torch_npu, fa_block_quant_preprocess, fused_infer_attention_score_v2, QuaRotMode, create_rot
 
 
 def _get_rot_matrix(
@@ -72,13 +75,13 @@ def fp8_rotate_quant_fa(
         query: Query tensor in ``layout`` order (default BNSD: batch, heads, seq, dim).
         key: Key tensor in ``layout`` order (default BNSD: batch, heads, seq, dim).
         value: Value tensor in ``layout`` order (default BNSD: batch, heads, seq, dim).
-        layout: ``BNSD`` or ``BSND`` for ``npu_fused_infer_attention_score_v2``.
+        layout: Input/output tensor layout, either ``BNSD`` or ``BSND``.
         softmax_scale: If None, uses ``1 / sqrt(head_dim)``.
 
     Returns:
         Attention output in the same layout as inputs.
     """
-    torch_npu, fa_block_quant_preprocess, qua_rot_mode, create_rot = _load_quant_ops()
+    torch_npu, fa_block_quant_preprocess, fused_infer_attention_score_v2, qua_rot_mode, create_rot = _load_quant_ops()
 
     out_dtype = query.dtype
     device = query.device
@@ -100,11 +103,14 @@ def fp8_rotate_quant_fa(
 
     scale = softmax_scale if softmax_scale is not None else 1.0 / math.sqrt(d)
 
-    out = torch_npu.npu_fused_infer_attention_score_v2(
+    # fa_block_quant_preprocess normalizes both supported input layouts to
+    # BNSD. Use MindIE-SD's Eagle FIA op because the corresponding CANN FIA
+    # path no longer accepts FP8 per-block full quantization (mode 7).
+    out = fused_infer_attention_score_v2(
         q,
         k,
         v,
-        input_layout=layout,
+        input_layout="BNSD",
         num_query_heads=n,
         softmax_scale=scale,
         pre_tokens=2147483647,  # INT32_MAX: no left-context truncation.
@@ -119,9 +125,9 @@ def fp8_rotate_quant_fa(
     )[0]
 
     if out.shape[2] != s:
-        if layout == "BNSD":
-            out = out[:, :, :s, :]
-        elif layout == "BSND":
-            out = out[:, :s, :, :]
+        out = out[:, :, :s, :]
+
+    if layout == "BSND":
+        out = out.transpose(1, 2)
 
     return out

--- a/vllm_omni/platforms/npu/quant/kv_quant_npu.py
+++ b/vllm_omni/platforms/npu/quant/kv_quant_npu.py
@@ -9,7 +9,6 @@ computed fresh each forward pass (no persistent KV cache).
 
 from __future__ import annotations
 
-import math
 import threading
 from functools import lru_cache
 
@@ -29,20 +28,17 @@ def is_quantized_kv_cache(kv_cache_dtype: str | None) -> bool:
 
 
 @lru_cache(maxsize=1)
-def _load_quant_ops():
+def _load_sd_ops():
     try:
-        import torch_npu
-        from mindiesd.layers.flash_attn.fused_infer_attention_score import (
-            fused_infer_attention_score_v2,
-        )
-        from mindiesd.layers.quant.block_quant import fa_block_quant_preprocess
+        import torch_npu  # noqa: F401  # availability check: registers NPU ops
+        from mindiesd.quantization.layer import fp8_rotate_quant_fa_op
         from msmodelslim.processor.quarot.common.quarot_utils import QuaRotMode, create_rot
     except ImportError as e:
         raise ImportError(
             "fp8_rotate_quant_fa requires torch_npu, MindIE-SD (mindiesd), and MSModelSlim. "
             "See https://gitcode.com/Ascend/MindIE-SD and https://gitcode.com/Ascend/msmodelslim"
         ) from e
-    return torch_npu, fa_block_quant_preprocess, fused_infer_attention_score_v2, QuaRotMode, create_rot
+    return fp8_rotate_quant_fa_op, QuaRotMode, create_rot
 
 
 def _get_rot_matrix(
@@ -81,9 +77,7 @@ def fp8_rotate_quant_fa(
     Returns:
         Attention output in the same layout as inputs.
     """
-    torch_npu, fa_block_quant_preprocess, fused_infer_attention_score_v2, qua_rot_mode, create_rot = _load_quant_ops()
-
-    out_dtype = query.dtype
+    fp8_op, qua_rot_mode, create_rot = _load_sd_ops()
     device = query.device
 
     if layout == "BNSD":
@@ -94,40 +88,5 @@ def fp8_rotate_quant_fa(
         raise ValueError(f"fp8_rotate_quant_fa: unsupported layout {layout!r}, expected BNSD or BSND")
 
     rot = _get_rot_matrix(device, query.dtype, d, qua_rot_mode, create_rot)
-    q_f = torch.matmul(query, rot)
-    k_f = torch.matmul(key, rot)
 
-    q, q_scale = fa_block_quant_preprocess(q_f, block_size=128, dst_type=torch_npu.float8_e4m3fn, layout=layout)
-    k, k_scale = fa_block_quant_preprocess(k_f, block_size=256, dst_type=torch_npu.float8_e4m3fn, layout=layout)
-    v, v_scale = fa_block_quant_preprocess(value, block_size=256, dst_type=torch_npu.float8_e4m3fn, layout=layout)
-
-    scale = softmax_scale if softmax_scale is not None else 1.0 / math.sqrt(d)
-
-    # fa_block_quant_preprocess normalizes both supported input layouts to
-    # BNSD. Use MindIE-SD's Eagle FIA op because the corresponding CANN FIA
-    # path no longer accepts FP8 per-block full quantization (mode 7).
-    out = fused_infer_attention_score_v2(
-        q,
-        k,
-        v,
-        input_layout="BNSD",
-        num_query_heads=n,
-        softmax_scale=scale,
-        pre_tokens=2147483647,  # INT32_MAX: no left-context truncation.
-        next_tokens=2147483647,  # INT32_MAX: no right-context truncation.
-        query_quant_mode=7,  # NPU mode id for block FP8 dequant path.
-        key_quant_mode=7,  # Same quant mode as query branch.
-        value_quant_mode=7,  # Same quant mode as key/query branches.
-        dequant_scale_query=q_scale,
-        dequant_scale_key=k_scale,
-        dequant_scale_value=v_scale,
-        out_dtype=out_dtype,
-    )[0]
-
-    if out.shape[2] != s:
-        out = out[:, :, :s, :]
-
-    if layout == "BSND":
-        out = out.transpose(1, 2)
-
-    return out
+    return fp8_op(query, key, value, q_rot=rot, k_rot=rot, layout=layout, softmax_scale=softmax_scale)


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
Migrate the NPU FP8 KV-quantization attention path off the removed CANN FP8 per-block fused attention operator, and onto MindIE-SD's public `fp8_rotate_quant_fa_op` API.

**Background:** the CANN fused-infer-attention path no longer accepts FP8 per-block full quantization (quant mode 7), which broke quantized KV-cache attention on NPU. This PR:

1. **Replaces the locally assembled pipeline** (`fa_block_quant_preprocess` + `fused_infer_attention_score_v2`, previously assembled inside vllm-omni) with MindIE-SD's public `fp8_rotate_quant_fa_op` — the same kernels, now maintained in one place upstream
2. **Passes BSND layout straight through** to the fused op instead of transposing Q/K/V around the call in `flash_attn.py`, removing two transposes per forward
3. **Adds `softmax_scale` pass-through** so callers control the scale instead of the implicit `1/sqrt(d)` default
4. Updates unit tests for both `kv_quant_npu` and `flash_attn` to match


## Test Plan
**vLLM-Omni Commit:** 33c5f85d (feat/npu-kv-quant-mindiesd-fa)

- [x] Unit tests: `pytest tests/platforms/npu/quant/test_kv_quant_npu.py tests/diffusion/attention/test_flash_attn.py`
- [x] ruff check / format (0.14.10, per pre-commit config)
- [x] Local hooks: test-marks check, pickle-import check
- [ ] NPU end-to-end: quantized KV-cache inference on Atlas test machine (in progress)


**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
