### PR TITLE
[Bugfix] Restore aspect-preserving letterbox for reference images in serving_video

### DIFF
--- a/vllm_omni/entrypoints/openai/serving_video.py
+++ b/vllm_omni/entrypoints/openai/serving_video.py
@@ -190,6 +190,7 @@ class OmniOpenAIServingVideo:
         ):
             target_size = (vp.width, vp.height)
             image_items = input_image if isinstance(input_image, list) else [input_image]
+
             def _letterbox(image: Image.Image, size: tuple[int, int]) -> Image.Image:
                 # Scale to fit and pad instead of stretching: a plain resize to
                 # the output canvas distorts reference aspect ratios (e.g. a
@@ -205,8 +206,7 @@ class OmniOpenAIServingVideo:
                 return canvas
 
             resized_images = [
-                _letterbox(image, target_size) if image.size != target_size else image
-                for image in image_items
+                _letterbox(image, target_size) if image.size != target_size else image for image in image_items
             ]
             input_image = resized_images if isinstance(input_image, list) else resized_images[0]
         multi_modal_data: dict[str, Any] = {}

--- a/vllm_omni/entrypoints/openai/serving_video.py
+++ b/vllm_omni/entrypoints/openai/serving_video.py
@@ -190,8 +190,22 @@ class OmniOpenAIServingVideo:
         ):
             target_size = (vp.width, vp.height)
             image_items = input_image if isinstance(input_image, list) else [input_image]
+            def _letterbox(image: Image.Image, size: tuple[int, int]) -> Image.Image:
+                # Scale to fit and pad instead of stretching: a plain resize to
+                # the output canvas distorts reference aspect ratios (e.g. a
+                # landscape identity reference squeezed into a portrait canvas
+                # yields systematically elongated subjects in Ref2VA).
+                tw, th = size
+                scale = min(tw / image.width, th / image.height)
+                nw = max(1, round(image.width * scale))
+                nh = max(1, round(image.height * scale))
+                resized = image.resize((nw, nh), Image.Resampling.LANCZOS)
+                canvas = Image.new("RGB", (tw, th), (255, 255, 255))
+                canvas.paste(resized, ((tw - nw) // 2, (th - nh) // 2))
+                return canvas
+
             resized_images = [
-                image.resize(target_size, Image.Resampling.LANCZOS) if image.size != target_size else image
+                _letterbox(image, target_size) if image.size != target_size else image
                 for image in image_items
             ]
             input_image = resized_images if isinstance(input_image, list) else resized_images[0]


### PR DESCRIPTION
## Purpose

Between v0.26.0 and the v0.27 line (verified on 0.27.0rc2.dev109 and dev128; still present on current main), the OpenAI serving layer's reference-image pre-resize changed from **letterbox (aspect-preserving pad)** to a plain `image.resize(target_size)` whenever `preserves_reference_image_size` is False.

MiniMax-H3 has no `reference_image_size_resolver` registered, so every Ref2VA request whose reference images differ in aspect ratio from the output canvas gets its references non-uniformly stretched. The model faithfully reproduces the distorted proportions: with landscape refs (e.g. 1536x1024 character sheets) and a portrait canvas (768x1344), generated characters come out systematically tall/thin ("elongated"). No error is raised; generation succeeds — a silent quality regression.

This PR restores the v0.26 letterbox behavior (scale to fit + center-pad on white canvas, LANCZOS) for pipelines without `preserves_reference_image_size`.

An alternative would be registering a `reference_image_size_resolver` for MiniMax-H3 (its pipeline already does its own aspect-preserving `_reference_image_shape` sizing), but a plain stretch-resize is arguably never correct for identity references, so this restores letterbox as the safe default. Happy to rework if maintainers prefer the resolver route.

## Test Plan

Ref2VA on MiniMax-H3, 8x RTX 5090, identical prompt/refs/seed/steps across runs:

1. Same request rendered on v0.26 vs v0.27: v0.26 normal proportions, v0.27 elongated (blind-judged; reproduced across two independent projects).
2. Numeric probe at the Qwen3VL text-encoder boundary (dumps of `encode_ids` inputs): token ids and `image_grid_thw` bit-identical, but `pixel_values` cosine ~0.52 / maxAbsDiff 2.0 — same grid, different pixel content, so the divergence is in serving-layer image prep, not in the model.
3. Ruled out before locating it (all negative, because the bug is outside the model dir): eager vs compile, SAGE attention on/off, full v0.26 DiT transplant, usp 4 -> 1, scheduler config, output resolution.

## Test Result

With this patch applied on v0.27 (dev128), same-seed A/B vs v0.26:

- `pixel_values` entering the text encoder: **bit-identical to v0.26** (maxAbsDiff = 0.0)
- text-encoder output cosine vs v0.26: 0.61 -> 0.99
- same-seed generated-frame similarity vs the v0.26 render: 0.80 -> 0.92
- subject proportions back to normal (human-verified on multiple clips)

**vLLM Version:** bundled with vllm-omni nightly (CUDA 13)
**vLLM-Omni Commit:** 0.27.0rc2.dev109+g38cf9adc3 and dev128 nightly images (both affected)