### PR TITLE
[CI/Build] Skip gated Krea-2 Raw doc example

### DIFF
--- a/tests/examples/offline_inference/test_text_to_image.py
+++ b/tests/examples/offline_inference/test_text_to_image.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 """
 Offline inference tests: text-to-image.
 See examples/offline_inference/text_to_image/README.md
@@ -26,6 +29,8 @@ EXAMPLE_OUTPUT_SUBFOLDER = "example_offline_t2i"
 def _skip_readme_snippet(language: str, code: str, h2_title: str) -> tuple[bool, str]:
     if h2_title == "Web UI Demo":
         return True, f"README section '{h2_title}' is intentionally excluded for examples tests"
+    if "krea/Krea-2-Raw" in code:
+        return True, "krea/Krea-2-Raw requires gated Hugging Face access unavailable in CI"
     return False, ""
 
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
Skip only the gated Krea-2 Raw runnable-doc example while keeping the public Turbo example covered.

Fixes #6511

## Purpose

### What broke

The nightly text-to-image doc shard executes the `krea/Krea-2-Raw` README command and receives `403 GatedRepoError` because the CI Hugging Face token is not authorized for that checkpoint.

### Reproduction

```bash
pytest -s -v tests/examples/offline_inference/test_text_to_image.py \
  -k more_cli_examples_007 --run-level=full_model
```

### Root cause

The dynamic README extractor treated both Krea-2 commands as runnable, although the Raw checkpoint is gated and cannot be accessed reliably by CI.

### Fix

Return a specific skip reason when a README snippet targets `krea/Krea-2-Raw`. The public `krea/Krea-2-Turbo` example remains runnable.

## Test Plan

- Extract the README snippets with the production helper and verify `more_cli_examples_007` is skipped while `more_cli_examples_006` is not.
- Run all pre-commit hooks applicable to the changed test file.
- Let the H100 nightly doc shard verify the skip in its full environment.

**vLLM Version:** 0.27.0 (environment reported in #6511)

**vLLM-Omni Commit:** `2e096788a6337b0bf7ac22c30bb9afa2afb8f3d4` + this PR

## Test Result

- PASS: README extraction check (`more_cli_examples_007` skipped; `more_cli_examples_006` runnable).
- PASS: `pre-commit run --files tests/examples/offline_inference/test_text_to_image.py`.
- Not run locally: the full H100/model test; this macOS host does not provide H100 hardware or the vLLM/PyTorch runtime.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
