### PR TITLE
[Bugfix] Warn that VLLM_TORCH_PROFILER_DIR was removed and is ignored

### DIFF
--- a/docs/contributing/profiling.md
+++ b/docs/contributing/profiling.md
@@ -201,7 +201,7 @@ When `profiler_config.profiler` is set for a diffusion model, the server exposes
 - `POST /start_profile`
 - `POST /stop_profile`
 
-> **Note:** `VLLM_TORCH_PROFILER_DIR` does not enable these endpoints on the `--omni` path. vLLM-Omni registers them from `profiler_config` only, so setting that variable alone leaves `/start_profile` unregistered and logs a warning at startup. Use `--profiler-config` as shown below, or a `profiler_config` block in the stage YAML. `--profiler-config` is a nested config flag, so it does not appear in `vllm serve --help`.
+> **Note:** `VLLM_TORCH_PROFILER_DIR` was removed in vLLM v0.16.0 when profiling moved to `ProfilerConfig`, and nothing reads it any more. A stale value does not enable these endpoints; the server logs a migration warning at startup and leaves `/start_profile` unregistered. Use `--profiler-config` as shown below, or a `profiler_config` block in the stage YAML. `--profiler-config` is a nested config flag, so it is listed under `vllm serve --help=all` or `vllm serve --help=VllmConfig` rather than in the default `--help` output.
 
 ### Start the server
 

--- a/docs/contributing/profiling.md
+++ b/docs/contributing/profiling.md
@@ -201,6 +201,8 @@ When `profiler_config.profiler` is set for a diffusion model, the server exposes
 - `POST /start_profile`
 - `POST /stop_profile`
 
+> **Note:** `VLLM_TORCH_PROFILER_DIR` does not enable these endpoints on the `--omni` path. vLLM-Omni registers them from `profiler_config` only, so setting that variable alone leaves `/start_profile` unregistered and logs a warning at startup. Use `--profiler-config` as shown below, or a `profiler_config` block in the stage YAML. `--profiler-config` is a nested config flag, so it does not appear in `vllm serve --help`.
+
 ### Start the server
 
 Single-stage diffusion serving with torch profiler:

--- a/tests/entrypoints/openai_api/test_api_server_guards.py
+++ b/tests/entrypoints/openai_api/test_api_server_guards.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 
@@ -347,6 +348,46 @@ def test_router_openapi_paths_cover_http_manifest() -> None:
         assert method.lower() in paths[path], f"missing OpenAPI method {method} {path}"
 
 
+@pytest.mark.parametrize(
+    ("stage_configs", "expected"),
+    [
+        (None, False),
+        ([], False),
+        ([{}], False),
+        ([{"engine_args": None}], False),
+        ([{"engine_args": {}}], False),
+        ([{"engine_args": {"profiler_config": None}}], False),
+        ([{"engine_args": {"profiler_config": {}}}], False),
+        ([{"engine_args": {"profiler_config": {"profiler": None}}}], False),
+        ([{"engine_args": {"profiler_config": {"profiler": "torch"}}}], True),
+        ([{"engine_args": {"profiler_config": {"profiler": "cuda"}}}], True),
+        # Attribute-style stage/engine_args/profiler_config, not just dicts.
+        (
+            [SimpleNamespace(engine_args=SimpleNamespace(profiler_config=SimpleNamespace(profiler="torch")))],
+            True,
+        ),
+        (
+            [SimpleNamespace(engine_args=SimpleNamespace(profiler_config=None))],
+            False,
+        ),
+        # Any stage enabling the profiler is enough.
+        (
+            [{"engine_args": {}}, {"engine_args": {"profiler_config": {"profiler": "torch"}}}],
+            True,
+        ),
+    ],
+)
+def test_should_enable_profiler_endpoints_matches_stage_config(stage_configs, expected: bool) -> None:
+    """Lock the gate that decides whether /start_profile is registered.
+
+    vLLM-Omni enables the profiler endpoints from the stage config, not from
+    ``VLLM_TORCH_PROFILER_DIR``. Fails if the gate starts accepting a stage that
+    only half-declares ``profiler_config`` (present but with no ``profiler``),
+    stops supporting attribute-style configs, or stops scanning every stage.
+    """
+    assert api_server._should_enable_profiler_endpoints(stage_configs) is expected
+
+
 @pytest.mark.asyncio
 async def test_api_server_assembly_replaces_upstream_routes_and_mounts_omni_router(monkeypatch) -> None:
     """Lock worker assembly: override, mount, storage, handlers, full census.
@@ -452,6 +493,62 @@ async def test_api_server_assembly_replaces_upstream_routes_and_mounts_omni_rout
     assert "/v1/chat/completions" in openapi_paths
     assert "/v1/models" in openapi_paths
     assert "/health" in openapi_paths
+
+
+@pytest.mark.asyncio
+async def test_profiler_env_var_without_stage_config_warns_and_skips_routes(monkeypatch, caplog) -> None:
+    """Lock the not-silent behavior when only ``VLLM_TORCH_PROFILER_DIR`` is set.
+
+    vLLM registers /start_profile from that environment variable; vLLM-Omni
+    registers it from the stage config. Without the warning the mismatch looks
+    identical to a working setup: server starts, nothing logged, /start_profile
+    404s. Fails if the routes get mounted from the env var alone, or if the
+    startup warning stops being emitted.
+    """
+
+    def fake_build_openai_app(args, supported_tasks):
+        return FastAPI()
+
+    @asynccontextmanager
+    async def fake_build_async_omni(*_args, **_kwargs):
+        # No stage declares profiler_config, so the gate must stay closed.
+        yield _FakeEngineClient(
+            stage_configs=[{"engine_args": {}}],
+            vllm_config=SimpleNamespace(parallel_config=SimpleNamespace(_api_process_rank=0)),
+        )
+
+    async def fake_omni_init_app_state(engine_client, state, args):
+        state.engine_client = engine_client
+
+    captured: dict[str, object] = {}
+
+    async def fake_serve_http(app, **_kwargs):
+        captured["served_app"] = app
+        task = asyncio.create_task(asyncio.sleep(0))
+        await asyncio.sleep(0)
+        return task
+
+    monkeypatch.setenv("VLLM_TORCH_PROFILER_DIR", "/tmp/omni-profiler-traces")
+    monkeypatch.setattr(api_server, "build_openai_app", fake_build_openai_app)
+    monkeypatch.setattr(api_server, "build_async_omni", fake_build_async_omni)
+    monkeypatch.setattr(api_server, "omni_init_app_state", fake_omni_init_app_state)
+    monkeypatch.setattr(api_server, "shutdown_unsupported_routes", lambda app, restrictions: None)
+
+    async def fake_storage_start():
+        captured["storage_started"] = True
+
+    monkeypatch.setattr(api_server, "STORAGE_MANAGER", SimpleNamespace(start=fake_storage_start))
+    monkeypatch.setattr(api_server, "serve_http", fake_serve_http)
+
+    with caplog.at_level(logging.WARNING):
+        await api_server.omni_run_server_worker("127.0.0.1:8000", _FakeSocket(), _minimal_args())
+
+    served_app = captured["served_app"]._inner  # type: ignore[attr-defined]
+    manifest = _route_manifest(served_app.routes)
+    assert ("POST", "/start_profile") not in manifest
+    assert ("POST", "/stop_profile") not in manifest
+    assert "VLLM_TORCH_PROFILER_DIR" in caplog.text
+    assert "profiler_config" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/openai_api/test_api_server_guards.py
+++ b/tests/entrypoints/openai_api/test_api_server_guards.py
@@ -380,8 +380,8 @@ def test_router_openapi_paths_cover_http_manifest() -> None:
 def test_should_enable_profiler_endpoints_matches_stage_config(stage_configs, expected: bool) -> None:
     """Lock the gate that decides whether /start_profile is registered.
 
-    vLLM-Omni enables the profiler endpoints from the stage config, not from
-    ``VLLM_TORCH_PROFILER_DIR``. Fails if the gate starts accepting a stage that
+    vLLM-Omni enables the profiler endpoints from the stage config, matching
+    upstream vLLM v0.16.0+. Fails if the gate starts accepting a stage that
     only half-declares ``profiler_config`` (present but with no ``profiler``),
     stops supporting attribute-style configs, or stops scanning every stage.
     """
@@ -499,11 +499,12 @@ async def test_api_server_assembly_replaces_upstream_routes_and_mounts_omni_rout
 async def test_profiler_env_var_without_stage_config_warns_and_skips_routes(monkeypatch, caplog) -> None:
     """Lock the not-silent behavior when only ``VLLM_TORCH_PROFILER_DIR`` is set.
 
-    vLLM registers /start_profile from that environment variable; vLLM-Omni
-    registers it from the stage config. Without the warning the mismatch looks
-    identical to a working setup: server starts, nothing logged, /start_profile
-    404s. Fails if the routes get mounted from the env var alone, or if the
-    startup warning stops being emitted.
+    That variable was removed in vLLM v0.16.0 when profiling moved to
+    ``ProfilerConfig``, so nothing reads it any more. A stale value left in an
+    environment or script is inert, and without this warning it looks identical
+    to a working setup: server starts, nothing logged, /start_profile 404s.
+    Fails if the routes get mounted from the env var alone, or if the migration
+    warning stops being emitted.
     """
 
     def fake_build_openai_app(args, supported_tasks):

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -541,6 +541,19 @@ async def omni_run_server_worker(listen_address, sock, args, client_config=None,
         if _should_enable_profiler_endpoints(stage_configs):
             logger.warning("Profiler endpoints are enabled. This should ONLY be used for local development!")
             app.include_router(profiler_router)
+        elif os.environ.get("VLLM_TORCH_PROFILER_DIR"):
+            # vLLM enables /start_profile from this environment variable, but
+            # vLLM-Omni gates the endpoints on the stage config instead. Without
+            # this warning the mismatch is silent and looks like a working setup.
+            logger.warning(
+                "VLLM_TORCH_PROFILER_DIR is set, but no stage declares "
+                "engine_args.profiler_config.profiler, so /start_profile and "
+                "/stop_profile were NOT registered. vLLM-Omni enables profiling "
+                "through profiler_config, not this environment variable: pass "
+                '--profiler-config \'{"profiler": "torch", "torch_profiler_dir": "..."}\' '
+                "to `vllm serve`, or add a profiler_config block to a stage in "
+                "your deploy YAML. See docs/contributing/profiling.md."
+            )
 
         vllm_config = await _get_vllm_config(engine_client)
 

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -542,17 +542,19 @@ async def omni_run_server_worker(listen_address, sock, args, client_config=None,
             logger.warning("Profiler endpoints are enabled. This should ONLY be used for local development!")
             app.include_router(profiler_router)
         elif os.environ.get("VLLM_TORCH_PROFILER_DIR"):
-            # vLLM enables /start_profile from this environment variable, but
-            # vLLM-Omni gates the endpoints on the stage config instead. Without
-            # this warning the mismatch is silent and looks like a working setup.
+            # Migration diagnostic, not a compatibility path. Profiling moved to
+            # ProfilerConfig in vllm-project/vllm#29912 and this variable was
+            # removed in vllm-project/vllm#33536 (vLLM v0.16.0), so nothing reads
+            # it any more. A stale value in an environment or script is silently
+            # inert; point the operator at the setting that replaced it.
             logger.warning(
-                "VLLM_TORCH_PROFILER_DIR is set, but no stage declares "
-                "engine_args.profiler_config.profiler, so /start_profile and "
-                "/stop_profile were NOT registered. vLLM-Omni enables profiling "
-                "through profiler_config, not this environment variable: pass "
-                '--profiler-config \'{"profiler": "torch", "torch_profiler_dir": "..."}\' '
-                "to `vllm serve`, or add a profiler_config block to a stage in "
-                "your deploy YAML. See docs/contributing/profiling.md."
+                "VLLM_TORCH_PROFILER_DIR is set but is ignored: it was removed in "
+                "vLLM v0.16.0 when profiling moved to ProfilerConfig. Profiler "
+                "endpoints are registered from engine_args.profiler_config.profiler, "
+                "and no stage declares it, so /start_profile and /stop_profile were "
+                'NOT registered. Use --profiler-config \'{"profiler": "torch", '
+                '"torch_profiler_dir": "..."}\' or add a profiler_config block to a '
+                "stage in your deploy YAML. See docs/contributing/profiling.md."
             )
 
         vllm_config = await _get_vllm_config(engine_client)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Addresses #5925.

`VLLM_TORCH_PROFILER_DIR` was removed from vLLM in vllm-project/vllm#33536 (v0.16.0), after profiling moved to `ProfilerConfig` in vllm-project/vllm#29912. Nothing reads it any more, in vLLM or in vLLM-Omni. Profiler endpoints are registered from `engine_args.profiler_config.profiler`, which matches upstream.

A stale value left in an environment or script is therefore silently inert. The gate at `vllm_omni/entrypoints/openai/api_server.py:541` had no `else` branch, so the server started normally, nothing was logged, and `/start_profile` returned 404 with nothing explaining why. As the reporter put it, the behavior was indistinguishable from success.

This adds a migration diagnostic: when the removed variable is set and no stage enables the profiler, log a warning naming the removal and pointing at `--profiler-config`. It is not a compatibility path and does not make the variable functional.

Two offline examples in this repo still gate on the removed variable (`examples/offline_inference/text_to_speech/cosyvoice3/end2end.py:152`, `examples/offline_inference/qwen2_5_omni/end2end.py:381`). Tracked as follow-up rather than folded in here, since they need a real opt-in flag rather than a rename.

`--profiler-config` works on the omni serve path and is listed under `vllm serve --help=all` or `--help=VllmConfig`. `docs/contributing/profiling.md` section 4 already documents it with a worked example; this adds a note there recording the removal.

Also adds parametrized coverage for `_should_enable_profiler_endpoints`, which had none.

## Test Plan

CPU-only, no GPU required.

```bash
pytest tests/entrypoints/openai_api/test_api_server_guards.py
```

New coverage:

- 13 parametrized cases for `_should_enable_profiler_endpoints`: missing and empty stage configs, `profiler_config` present but with no `profiler` key, attribute-style configs, and multi-stage scanning.
- One test driving `omni_run_server_worker` with `VLLM_TORCH_PROFILER_DIR` set and no `profiler_config`, asserting the warning is emitted and that `/start_profile` and `/stop_profile` are not registered.

**vLLM Version:** 0.27.0

**vLLM-Omni Commit:** b6028e2a2c9e8eeb6cdb9f6fabaf8acf17f1a003

## Test Result

`33 passed` (19 pre-existing + 14 new) at b6028e2a.

a2c8fc99 changes only the warning text, code comment, docstrings, and docs note, so runtime behavior is unchanged. The two `caplog` assertions still match the reworded message.

Lint and type gates checked against a `main` baseline rather than absolute counts:

| Gate | main | this branch |
|---|---|---|
| ruff check / ruff format | clean | clean |
| typos | clean | clean |
| markdownlint | 14 | 14, none added |
| mypy 3.12 | 5 | 5, none added |

Environment: Python 3.12.3, torch 2.13.0+cu132, Ubuntu 24.04.
