### PR TITLE
[Test][Doc] MiniCPM-o 4.5 encoder-cache regression coverage + caching

### DIFF
--- a/.buildkite/cuda/test-ready.yml
+++ b/.buildkite/cuda/test-ready.yml
@@ -164,6 +164,7 @@ steps:
       - label: "Omni · MiniCPM-o 4.5 Offline Test"
         source_file_dependencies:
           - tests/e2e/offline_inference/test_minicpmo_4_5.py
+          - tests/helpers/assertions.py
           - vllm_omni/deploy/minicpmo_4_5.yaml
         commands:
           - |

--- a/docs/design/feature/prefix_caching.md
+++ b/docs/design/feature/prefix_caching.md
@@ -162,3 +162,22 @@ Because we have multimodal data in a scheduled span that isn't fully precomputed
 When we pass our multimodal tensors to the language model component in the same stage, we'll then expect the same outputs, because the prefix caching behaviors in vLLM-Omni / vLLM match, so the LLM will use vLLM's KV cache manager's prefix caching to correctly handle the attention information for `Block 1` while calculating the outputs for `Block 2`, giving us the correct results for processing `Block 2` with the context of `Block 1`.
 
 Finally, we look up the output hidden states/multimodal tensors corresponding to the prefix cache hit `Block 1` and concatenate it with the forward pass result to get the final result, which is expected to be identical to the full hidden states when prefix caching is disabled.
+
+### Caveat: `mm_processor_cache_gb: 0` silently disables encoder-output reuse
+
+The encoder cache described above is keyed by a **content hash** of each multimodal item (`mm_hash`), and it has no dedicated on/off switch — it is expected to work whenever the same image/audio/video reappears across requests.
+
+However, upstream vLLM skips computing content hashes entirely when **both** of the following hold (`vllm/renderers/base.py`, `_process_mm_uuids`):
+
+- `mm_processor_cache_gb: 0` (the multimodal processor cache is explicitly disabled), **and**
+- `enable_prefix_caching: false` on the stage.
+
+In that configuration, multimodal identifiers degrade to per-request counter IDs (`renderer0-mm-<N>-<modality>-<i>`), overriding even user-provided UUIDs. Since no two requests ever share an identifier, the encoder cache can never match across requests: **every** occurrence of the same image or audio is re-encoded, including byte-identical repeats — with no warning logged.
+
+This matters for omni pipelines because many deploy configs (for example every MiniCPM-o 4.5 layout) ship with `enable_prefix_caching: false`, so one half of the condition is already true by default. Setting `mm_processor_cache_gb: 0` on such a stage to save host memory therefore silently forfeits **all** cross-request encoder reuse for every modality. If you need the processor cache off but still want encoder-output reuse, keep prefix caching enabled on that stage, or accept the re-encoding cost knowingly.
+
+Upstream treats this as intended semantics ("both caches off means no reuse is wanted"); it is documented here because the coupling between a host-memory knob and GPU-side encoder reuse is easy to miss. See [vllm-project/vllm-omni#5069](https://github.com/vllm-project/vllm-omni/issues/5069) for the evaluation that surfaced it.
+
+### Caveat: cached encoder outputs are batch-composition dependent
+
+A separate property, also surfaced in [#5069](https://github.com/vllm-project/vllm-omni/issues/5069): encoders that pad a batch of multimodal items to the batch maximum (as the MiniCPM-o SigLIP and Whisper paths do) produce slightly different outputs for the *same* item depending on which other items shared its encoder batch — a bf16 accumulation-order effect, not a masking bug. Because the encoder cache is keyed by content hash alone, it permanently serves whichever batch-composition variant was computed first; a cache hit is therefore not bit-identical to a fresh encode under a different composition, and under greedy decoding this can occasionally change generated text. This is an accuracy/determinism consideration to weigh when reasoning about repeated-multimodal workloads, and it exists with prefix caching disabled as well.

--- a/recipes/OpenBMB/MiniCPM-o-4_5.md
+++ b/recipes/OpenBMB/MiniCPM-o-4_5.md
@@ -255,6 +255,21 @@ vllm serve openbmb/MiniCPM-o-4_5 --omni \
 
 ## Notes (applies to all layouts)
 
+- **Multimodal caching**: repeated identical images/audios are served from
+  vLLM's content-addressed encoder cache (always on, keyed by `mm_hash`) —
+  the vision/audio encoder is skipped on a hit and only missing items in a
+  mixed request are encoded. Two caveats:
+  - Do **not** set `mm_processor_cache_gb: 0` on stage 0. All MiniCPM-o
+    layouts ship `enable_prefix_caching: false`, and with both settings off
+    upstream vLLM replaces content hashes with per-request counter IDs, which
+    silently disables **all** cross-request encoder reuse (every repeat is
+    re-encoded, no warning is logged). Details:
+    [`docs/design/feature/prefix_caching.md`](../../docs/design/feature/prefix_caching.md).
+  - Keep `enable_prefix_caching: false` (the shipped default): output parity
+    with the prefix-cache path has not been established for this model —
+    tracked in
+    [vllm-project/vllm-omni#5069](https://github.com/vllm-project/vllm-omni/issues/5069).
+
 - **Code2Wav dependency**: Stage 2 loads `Token2wav` from the
   MiniCPM-o-flavored
   vocoder (PyPI package `stepaudio2-minicpmo` — NOT the upstream

--- a/tests/core/test_mm_block_hash_minicpmo.py
+++ b/tests/core/test_mm_block_hash_minicpmo.py
@@ -1,0 +1,292 @@
+"""L1 — CPU-only unit coverage for the two hashing layers the MM prefix-cache
+eval (#5069) depends on.
+
+Covers, for the MiniCPM-o 4.5 placeholder geometry (64 mm tokens per image via
+``query_num``, interleaved Daily-Omni-style packs):
+
+  L1.1/L1.2  mm_hash determinism and discrimination (MultiModalHasher)
+  L1.3/L1.4  block-hash extra keys: straddling items, two items in one block,
+             interleaved ordering, and the (identifier, offset-in-block) key
+             that keeps same-item-different-position blocks distinct
+  L1.5       OmniTensorPrefixCache round-trip: the merged hidden states for a
+             prefix-cache hit must equal the full-forward reference (the CPU
+             proxy for hypothesis H2 in probe_mm_cache/README.md)
+
+Run:
+    pytest tests/core/test_mm_block_hash_minicpmo.py -q
+"""
+
+import hashlib
+
+import numpy as np
+import pytest
+import torch
+from vllm.multimodal.hasher import MultiModalHasher
+from vllm.multimodal.inputs import MultiModalFeatureSpec, PlaceholderRange
+from vllm.v1.core.kv_cache_utils import generate_block_hash_extra_keys
+
+from vllm_omni.core.prefix_cache import OmniTensorPrefixCache
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+# MiniCPM-o 4.5: each image resolves to query_num=64 embedding tokens; audio
+# items vary with duration. Block size 16 divides 64, so a single image spans
+# exactly 4 full blocks when aligned — the straddle cases below deliberately
+# misalign it.
+MM_LEN = 64
+BLOCK = 16
+
+
+class _Req:
+    """The minimal Request surface generate_block_hash_extra_keys touches."""
+
+    def __init__(self, mm_features):
+        self.mm_features = mm_features
+        self.lora_request = None
+        self.cache_salt = None
+        self.prompt_embeds = None
+
+
+def _feat(identifier: str, offset: int, length: int = MM_LEN, modality: str = "image"):
+    return MultiModalFeatureSpec(
+        data=None,
+        modality=modality,
+        identifier=identifier,
+        mm_position=PlaceholderRange(offset=offset, length=length),
+    )
+
+
+def _img(seed: int, w: int = 8, h: int = 8) -> np.ndarray:
+    rng = np.random.RandomState(seed)
+    return rng.randint(0, 255, (h, w, 3), dtype=np.uint8)
+
+
+# ---------------------------------------------------------------------------
+# L1.1 / L1.2 — mm_hash
+# ---------------------------------------------------------------------------
+
+
+def test_mm_hash_deterministic_within_and_across_calls():
+    a1 = MultiModalHasher.hash_kwargs(image=_img(0))
+    a2 = MultiModalHasher.hash_kwargs(image=_img(0))
+    assert a1 == a2
+
+
+def test_mm_hash_discriminates_content_and_kwarg_name():
+    base = MultiModalHasher.hash_kwargs(image=_img(0))
+    assert MultiModalHasher.hash_kwargs(image=_img(1)) != base
+    # Same bytes under a different modality kwarg must not collide.
+    assert MultiModalHasher.hash_kwargs(audio=_img(0)) != base
+
+
+def test_mm_hash_discriminates_dtype_and_shape():
+    img = _img(0)
+    base = MultiModalHasher.hash_kwargs(image=img)
+    assert MultiModalHasher.hash_kwargs(image=img.astype(np.int32)) != base
+    assert MultiModalHasher.hash_kwargs(image=img.reshape(8, 8 * 3)) != base
+    # Audio analogue: same samples at a different sample rate must differ once
+    # the rate participates in the hashed kwargs.
+    wav = np.zeros(1600, dtype=np.float32)
+    assert MultiModalHasher.hash_kwargs(audio=(wav, 16000)) != MultiModalHasher.hash_kwargs(audio=(wav, 24000))
+
+
+# ---------------------------------------------------------------------------
+# L1.3 — block-hash extra keys, single items
+# ---------------------------------------------------------------------------
+
+
+def test_extra_keys_absent_for_text_only_block():
+    req = _Req([_feat("h1", offset=100)])
+    keys, nxt = generate_block_hash_extra_keys(req, 0, BLOCK, 0)
+    assert keys is None
+    assert nxt == 0
+
+
+def test_extra_keys_mm_item_at_offset_zero():
+    req = _Req([_feat("h1", offset=0)])
+    keys, _ = generate_block_hash_extra_keys(req, 0, BLOCK, 0)
+    assert keys == (("h1", 0),)
+
+
+def test_extra_keys_mm_item_straddles_block_boundary():
+    # Item occupies [10, 74): blocks 0..4 all intersect it. The extra key is
+    # (identifier, item_offset - block_start), so continuation blocks carry a
+    # NEGATIVE in-block offset — deterministic, and distinct per block.
+    req = _Req([_feat("h1", offset=10)])
+
+    keys0, n0 = generate_block_hash_extra_keys(req, 0, BLOCK, 0)
+    assert keys0 == (("h1", 10),)  # starts inside block 0 at in-block offset 10
+    assert n0 == 0  # item not finished -> same mm idx
+
+    keys1, n1 = generate_block_hash_extra_keys(req, BLOCK, 2 * BLOCK, n0)
+    assert keys1 == (("h1", 10 - BLOCK),)  # continuation: negative offset
+    assert n1 == 0
+
+    keys4, n4 = generate_block_hash_extra_keys(req, 4 * BLOCK, 5 * BLOCK, n0)
+    assert keys4 == (("h1", 10 - 4 * BLOCK),)  # tail [64, 74) lands in block 4
+    assert n4 == 1  # item ends inside this block -> advance
+
+    keys5, _ = generate_block_hash_extra_keys(req, 5 * BLOCK, 6 * BLOCK, n4)
+    assert keys5 is None
+
+
+def test_extra_keys_offset_disambiguates_same_item_at_different_positions():
+    """Two requests place the SAME image at different in-block offsets; the
+    blocks' extra keys must differ or the prefix cache would alias them."""
+    req_a = _Req([_feat("h1", offset=4)])
+    req_b = _Req([_feat("h1", offset=8)])
+    keys_a, _ = generate_block_hash_extra_keys(req_a, 0, BLOCK, 0)
+    keys_b, _ = generate_block_hash_extra_keys(req_b, 0, BLOCK, 0)
+    assert keys_a != keys_b
+
+
+def test_extra_keys_two_items_share_one_block():
+    # Short audio items: [0, 6) and [6, 12) both inside block 0.
+    req = _Req(
+        [
+            _feat("a1", offset=0, length=6, modality="audio"),
+            _feat("a2", offset=6, length=6, modality="audio"),
+        ]
+    )
+    keys, nxt = generate_block_hash_extra_keys(req, 0, BLOCK, 0)
+    assert keys == (("a1", 0), ("a2", 6))
+    assert nxt == 2
+
+
+# ---------------------------------------------------------------------------
+# L1.4 — interleaved image/audio pack (Daily-Omni shape)
+# ---------------------------------------------------------------------------
+
+
+def test_extra_keys_interleaved_pack_orders_and_advances():
+    """image(64) audio(10) image(64) audio(10) with 2-token text gaps, walked
+    block by block the way the scheduler does; keys must appear in prompt
+    order and every item must be visited exactly once."""
+    feats = []
+    pos = 0
+    for i in range(2):
+        feats.append(_feat(f"img{i}", offset=pos))
+        pos += MM_LEN + 2
+        feats.append(_feat(f"aud{i}", offset=pos, length=10, modality="audio"))
+        pos += 10 + 2
+
+    req = _Req(feats)
+    total_blocks = (pos + BLOCK - 1) // BLOCK
+    seen: list[str] = []
+    mm_idx = 0
+    for b in range(total_blocks):
+        keys, mm_idx = generate_block_hash_extra_keys(req, b * BLOCK, (b + 1) * BLOCK, mm_idx)
+        for ident, _off in keys or ():
+            if not seen or seen[-1] != ident:
+                seen.append(ident)
+    assert seen == ["img0", "aud0", "img1", "aud1"]
+    assert mm_idx == 4
+
+
+# ---------------------------------------------------------------------------
+# L1.5 — OmniTensorPrefixCache round-trip (H2, CPU proxy)
+# ---------------------------------------------------------------------------
+
+NUM_BLOCKS = 8
+HIDDEN = 4
+
+
+class _BlockTableStub:
+    """What the merge path touches: ``.block_tables`` (hybrid-cache guard) and
+    ``[0].block_table.cpu[req_idx, :n]`` (cached block lookup)."""
+
+    def __init__(self, table: torch.Tensor):
+        class _T:
+            pass
+
+        wrap = _T()
+        wrap.cpu = table
+        self.block_table = wrap
+        self.block_tables = [wrap]
+
+    def __getitem__(self, idx):
+        assert idx == 0
+        return self
+
+
+class _InputBatchStub:
+    def __init__(self, req_ids, num_computed, table):
+        self.req_ids = req_ids
+        self.req_id_to_index = {r: i for i, r in enumerate(req_ids)}
+        self.num_computed_tokens_cpu = num_computed
+        self.block_table = _BlockTableStub(table)
+
+
+def _hs(num_tokens: int, base: float) -> torch.Tensor:
+    return torch.arange(num_tokens * HIDDEN, dtype=torch.float32).reshape(num_tokens, HIDDEN) + base
+
+
+def test_omni_prefix_cache_round_trip_equals_full_forward():
+    """Write a request's full prompt through the cache in one step, then replay
+    it as a prefix-cache hit (only the tail scheduled) and require the merged
+    hidden states to equal the original full-forward tensor exactly."""
+    cache = OmniTensorPrefixCache(num_blocks=NUM_BLOCKS, block_size=BLOCK, hidden_size=HIDDEN, hs_dtype=torch.float32)
+
+    prompt_len = 40  # 2.5 blocks
+    full_hidden = _hs(prompt_len, base=100.0)
+    # Blocks 1,2,3 belong to this request; slots follow vLLM's block*size+off.
+    blocks = [1, 2, 3]
+    slots = torch.tensor([blocks[t // BLOCK] * BLOCK + (t % BLOCK) for t in range(prompt_len)], dtype=torch.int64)
+
+    cache.update_omni_tensor_prefix_cache(
+        hidden_states=full_hidden,
+        multimodal_outputs={},
+        num_tokens_unpadded=prompt_len,
+        slot_mapping=slots,
+        num_tokens_padded=prompt_len,
+    )
+
+    # Replay: 32 of 40 tokens are cache hits; 8 are scheduled fresh.
+    num_cached = 2 * BLOCK
+    num_new = prompt_len - num_cached
+    new_tail = full_hidden[num_cached:]
+
+    cache.add_prefix_cached_new_req_id("req1")
+    table = torch.zeros((1, NUM_BLOCKS), dtype=torch.int64)
+    table[0, : len(blocks)] = torch.tensor(blocks)
+    input_batch = _InputBatchStub(["req1"], np.array([num_cached]), table)
+
+    merged = cache.get_merged_hidden_states(
+        query_start_loc=[0],
+        input_batch=input_batch,
+        hidden_states=new_tail.clone(),
+        num_scheduled_tokens={"req1": num_new},
+    )
+
+    assert torch.equal(merged["req1"], full_hidden), (
+        "prefix-cache merge does not reproduce the full-forward hidden states"
+    )
+
+
+def test_omni_prefix_cache_partial_block_tail_is_not_served_stale():
+    """A request whose prompt ends mid-block writes that partial block's slots;
+    a second write for the same slots (e.g. after eviction/reuse) must win."""
+    cache = OmniTensorPrefixCache(num_blocks=NUM_BLOCKS, block_size=BLOCK, hidden_size=HIDDEN, hs_dtype=torch.float32)
+    slots = torch.arange(BLOCK, dtype=torch.int64)  # block 0
+
+    first = _hs(BLOCK, base=0.0)
+    second = _hs(BLOCK, base=999.0)
+    for hidden in (first, second):
+        cache.update_omni_tensor_prefix_cache(
+            hidden_states=hidden,
+            multimodal_outputs={},
+            num_tokens_unpadded=BLOCK,
+            slot_mapping=slots,
+            num_tokens_padded=BLOCK,
+        )
+
+    assert torch.equal(cache.hidden_states_cache[0], second), "stale slot content survived an overwrite"
+
+
+def test_sha256_stability_reference():
+    """Guard against the hashing backend silently changing representation:
+    the digest of a fixed byte string must be stable across runs/processes."""
+    assert (
+        hashlib.sha256(b"minicpmo-4_5-mm-cache-probe").hexdigest()
+        == "57166a59ebec2ff45f3872c73ccb7e0370c2e9a1a76a2ff48d42d727372561c5"
+    )

--- a/tests/e2e/offline_inference/test_minicpmo_4_5.py
+++ b/tests/e2e/offline_inference/test_minicpmo_4_5.py
@@ -116,3 +116,76 @@ def test_video_to_audio(omni_runner, omni_runner_handler) -> None:
     video = generate_synthetic_video(24, 24, 20)["np_array"]
     request_config = {"prompts": get_question("video"), "videos": video, "modalities": ["audio"]}
     omni_runner_handler.send_omni_request(request_config)
+
+
+def _cache_probe_audio(phrase: str):
+    """Synthetic audio with a phrase-unique mm_hash.
+
+    Each distinct phrase yields distinct waveform bytes, so the encoder-cache
+    tests below control exactly which items are warm: they never collide with
+    the default-phrase audio used by the other tests in this module.
+    """
+    audio = generate_synthetic_audio(1, 1, 16000, phrase_text=phrase)["np_array"]
+    if len(audio.shape) == 2:
+        audio = audio.squeeze()
+    return (audio, 16000)
+
+
+@pytest.mark.full_model
+@pytest.mark.omni
+@pytest.mark.cache
+@hardware_test(res={"cuda": "H100", "npu": "A2"}, num_cards=1)
+@pytest.mark.parametrize("omni_runner", test_params, indirect=True)
+def test_audio_encoder_cache_warm_repeat_parity(omni_runner, omni_runner_handler) -> None:
+    """Repeating an identical audio request must reproduce the same text.
+
+    Regression for the audio half of the #5069 encoder-cache evaluation: the
+    first request encodes the audio cold; the byte-identical second request is
+    served from vLLM's content-addressed encoder cache (mm_hash) without
+    re-entering the Whisper encoder. Both paths consume the same cached
+    embedding tensor, so greedy text must match exactly. A divergence here
+    means cached encoder outputs are corrupted or misapplied on the hit path.
+    """
+    from tests.helpers.assertions import assert_omni_text_responses_identical
+
+    audio = _cache_probe_audio("encoder cache warm repeat probe")
+    request_config = {"prompts": get_question("audio"), "audios": audio, "modalities": ["text"]}
+    responses = [omni_runner_handler.send_omni_request(request_config) for _ in range(2)]
+    assert_omni_text_responses_identical(responses, context="audio warm repeat")
+
+
+@pytest.mark.full_model
+@pytest.mark.omni
+@pytest.mark.cache
+@hardware_test(res={"cuda": "H100", "npu": "A2"}, num_cards=1)
+@pytest.mark.parametrize("omni_runner", test_params, indirect=True)
+def test_audio_encoder_cache_mixed_hit_partition_parity(omni_runner, omni_runner_handler) -> None:
+    """Mixed hit/miss and fully-cached paths must agree, item order preserved.
+
+    Regression for the #5069 audio attribution probe. Sequence:
+      1. warm item A alone (fills its encoder-cache entry);
+      2. request [A, C]: A is a cache hit, C is encoded live — the encoder
+         receives only the missing item;
+      3. repeat [A, C] byte-identically: both items are now cache hits and the
+         encoder is not entered at all.
+    Requests 2 and 3 consume identical embedding tensors, so their greedy text
+    must match exactly. A divergence means cached embeddings were placed into
+    the wrong placeholder positions (ordering) or partial-hit partitioning
+    corrupted the batch.
+    """
+    from tests.helpers.assertions import assert_omni_text_responses_identical
+
+    audio_a = _cache_probe_audio("encoder cache mixed probe alpha")
+    audio_c = _cache_probe_audio("encoder cache mixed probe charlie")
+
+    # Step 1: make A warm so step 2 exercises the partial-hit partition.
+    omni_runner_handler.send_omni_request({"prompts": get_question("audio"), "audios": audio_a, "modalities": ["text"]})
+
+    mixed_config = {
+        "prompts": "Are these two audio clips the same?",
+        # Nested list: one prompt carrying two audio items (two placeholders).
+        "audios": [[audio_a, audio_c]],
+        "modalities": ["text"],
+    }
+    responses = [omni_runner_handler.send_omni_request(mixed_config) for _ in range(2)]
+    assert_omni_text_responses_identical(responses, context="audio mixed hit/miss vs fully cached")

--- a/tests/helpers/assertions.py
+++ b/tests/helpers/assertions.py
@@ -880,6 +880,35 @@ def assert_http_error(
     return payload
 
 
+def assert_omni_text_responses_identical(responses: Any, context: str = "") -> None:
+    """Assert that every response in the sequence produced byte-identical text.
+
+    Special assert for cache-path parity tests: the same prompt served through
+    different cache states (cold encode vs encoder-cache hit) must yield the
+    same text under greedy decoding, since both paths consume the identical
+    cached embedding tensor.
+
+    Args:
+        responses: Sequence of OmniResponse objects (>= 2).
+
+    Raises:
+        AssertionError: When any response failed or texts differ.
+    """
+    assert len(responses) >= 2, "Need at least two responses to compare"
+    texts = []
+    for i, response in enumerate(responses):
+        assert response.success, f"Request {i} failed{': ' + context if context else ''}."
+        assert response.text_content is not None, f"Request {i} produced no text output."
+        texts.append(response.text_content)
+    baseline = texts[0]
+    for i, text in enumerate(texts[1:], start=1):
+        assert text == baseline, (
+            f"Text output diverged between request 0 and request {i}"
+            f"{' (' + context + ')' if context else ''}:\n"
+            f"  request 0: {baseline!r}\n  request {i}: {text!r}"
+        )
+
+
 __all__ = [
     "assert_audio_diffusion_response",
     "assert_audio_speech_response",
@@ -889,6 +918,7 @@ __all__ = [
     "assert_image_diffusion_response",
     "assert_image_valid",
     "assert_omni_response",
+    "assert_omni_text_responses_identical",
     "assert_video_diffusion_response",
     "assert_video_valid",
     "assert_audio_valid",


### PR DESCRIPTION

## Purpose

Probe-first deliverable for the **audio-encoder reuse** slice of #5069, following the acceptance criteria set in [this comment](https://github.com/vllm-project/vllm-omni/issues/5069#issuecomment-<amy-2026-08-09>): verify the existing mm_hash / `EncoderCacheManager` behavior for repeated and mixed audio inputs first, and — since the generic cache turns out to cover MiniCPM-o audio correctly — limit the contribution to focused regression coverage + docs, with **no model-local cache**.

This PR contains no functional changes: tests and documentation only.

## What was verified before writing this PR

All experiments ran on current `main`, vLLM 0.26.0, with temporary print probes at `EncoderCacheManager.check_and_update_cache` and around the live `get_audio_hidden_states` call (reverted afterwards; not part of this PR). Requests were strictly sequential so hit/miss attribution is not blurred by batching. Hardware: 8x RTX 4090 probe profile (stage-0 TP=2, `enforce_eager`) — numbers are within-box only, not comparable to H100 baselines.

### 1. Attribution / call counts / ordering / latency / memory (cold, warm, mixed)

A, B, C = distinct 3 s audios; D = 7 s. One fresh server, default `mm_processor_cache_gb`:

| phase | request | cache check | encoder entered? | items encoded | encoder ms |
|---|---|---|---|---|---|
| cold | A alone | MISS | yes | 1 | 66 (first call; steady-state below) |
| warm | A again | **HIT** | **no** | — | — |
| cold | B alone | MISS | yes | 1 | 17 |
| mixed | [A (seen), C (new)] | HIT, MISS | yes ×1 | **1 (C only)** | 17 |
| warm-reorder | [C, A] (both seen) | HIT, HIT | no | — | — |
| warm-repeat | [A, C] again | HIT, HIT | no | — | — |
| cold | D alone (7 s) | MISS | yes | 1 | 23 |

- `mm_hash` is content-determined and stable — A's hash was identical across all four requests containing it; in the reordered request the two hashes tracked their items, not their positions.
- **Ordering**: the warm-repeat request (both items from cache, encoder never entered) produced byte-identical text to the mixed request (one item encoded live) — cached embeddings land in the right placeholder positions.
- Peak stage-0 memory moved 20 252 → 20 256 MiB over the whole workload; steady-state audio-encoder time is ~17 ms (3 s) / ~23 ms (7 s), computed redundantly per TP rank.
- Honest value note: at these audio lengths the reuse saves ~17–23 ms of TTFT — much smaller than the image-side win.

### 2. Finding: a cache hit is not numerically equivalent to a fresh encode

Loading only `apm` + `audio_projection_layer` (and separately `vpm` + resampler) standalone with checkpoint weights, and binding the *production* `get_audio_hidden_states` / `_process_image_input` methods (no code copy), shows that both encoders produce slightly different outputs for the **same item** depending on which other items shared its encoder batch — with a bitwise-clean determinism floor (same batch composition twice → identical):

| comparison (bf16, serving dtype) | max\|Δ\| | cosine |
|---|---|---|
| audio A alone vs A alone, re-run (floor) | 0 (bitwise) | 1.0000000 |
| audio A vs [A, B] same length | 0.125 | 0.99974 |
| audio A vs [A, B] longer companion | 0.125 | 0.99978 |
| audio A vs A zero-padded to B's length | 0.094 | 0.99979 |
| image X alone vs [X, X] (identical companion!) | 1.31 | 0.99917 |

Normalised against each tensor's own spread: Whisper tower up to 7.3σ (0.62σ on the final audio embedding); SigLIP tower up to 8.4σ (2.5σ on the final image embedding). fp32 shrinks everything by 2–4 orders of magnitude — this is bf16 accumulation-order sensitivity in the pad-to-batch-max design (the `[X, X]` row shows batch-size-dependent reduction order, not just padding), not a masking bug. Results are bit-identical across two independent torch builds/GPUs.

Because the encoder cache is content-addressed by mm_hash alone, it permanently serves whichever batch-composition variant was computed first. An image-side end-to-end check (prefix caching off; encoder cache primed with `[P, Q]` vs `P` alone; measured request byte-identical and submitted alone, batch of 1) flipped greedy text in **1 of 8** pairs, while the cached-solo vs fresh-solo control was 8/8 identical — so the cache mechanism itself is sound; what varies is which variant it stores. The audio-side end-to-end flip test has not been run (final-embedding delta is smaller there, 0.62σ vs 2.5σ).

This is modality-general and exists with prefix caching disabled, so it is **documented** here (design doc) and proposed for tracking as its own bounded issue rather than folded into this slice. The e2e regressions in this PR are deliberately designed **not** to depend on it: they compare paths that consume the identical cached embedding tensor, so they are deterministic in CI.

### 3. Finding: `mm_processor_cache_gb: 0` silently disables all encoder reuse

With `mm_processor_cache_gb: 0` **and** `enable_prefix_caching: false` (the shipped MiniCPM-o default), upstream vLLM replaces content mm_hashes with per-request counter IDs (`renderer0-mm-<N>-<modality>-<i>`; `vllm/renderers/base.py`, `_process_mm_uuids`), overriding even user-provided UUIDs. Measured effect: **100 % MISS including byte-identical repeats**, with the encoder re-entered every time and no warning logged. This is upstream-intended semantics ("both caches off ⇒ no reuse wanted"), but since every MiniCPM-o layout ships `enable_prefix_caching: false`, zeroing the processor cache to save host memory silently forfeits all cross-request encoder reuse. Now documented in the design doc + recipe.

## Changes

**Tests**

- `tests/core/test_mm_block_hash_minicpmo.py` (new, L1 `core_model + cpu`, 12 cases): mm_hash determinism/discrimination (content, modality kwarg, dtype, shape, sample rate); block-hash mm extra-key contract for the MiniCPM-o placeholder geometry — items straddling block boundaries carry deterministic negative in-block offsets, two items per block, same-item-different-offset disambiguation, interleaved image/audio packs keep prompt order; `OmniTensorPrefixCache` round-trip (merged hidden states on a prefix hit equal the full forward; stale-slot overwrite).
- `tests/e2e/offline_inference/test_minicpmo_4_5.py` (2 new tests, L4 `full_model + omni + cache`):
  - `test_audio_encoder_cache_warm_repeat_parity` — cold encode vs encoder-cache hit must produce identical greedy text;
  - `test_audio_encoder_cache_mixed_hit_partition_parity` — `[warm A, cold C]` vs its fully-cached byte-identical repeat must agree, guarding placeholder ordering and partial-hit partitioning.
- `tests/helpers/assertions.py`: `assert_omni_text_responses_identical` (shared cache-path parity assert, per the helpers convention).

**Docs**

- `docs/design/feature/prefix_caching.md`: two new caveat sections — the `mm_processor_cache_gb: 0` identifier-degradation trap, and the batch-composition dependence of cached encoder outputs.
- `recipes/OpenBMB/MiniCPM-o-4_5.md`: "Multimodal caching" note (do not zero `mm_processor_cache_gb` on stage 0; keep `enable_prefix_caching: false` until the #5069 parity work lands).

**CI**

- L1 tests are collected by the existing "Simple · Other Test" sweep (`tests/ -m 'core_model and cpu'`).
- The new e2e tests are collected by the existing nightly `full_model and H100 and omni` sweep — no nightly YAML change needed.
- `.buildkite/cuda/test-ready.yml`: added `tests/helpers/assertions.py` to the MiniCPM-o 4.5 Offline Test step's `source_file_dependencies`.

## Test Plan

```bash
# L1 — CPU only
cd tests
pytest -s -v core/test_mm_block_hash_minicpmo.py -m "core_model and cpu"

# L4 e2e — requires H100 (or A2) + openbmb/MiniCPM-o-4_5 weights cached
pytest -s -v e2e/offline_inference/test_minicpmo_4_5.py \
  -m "full_model and omni and cache" --run-level full_model
```

## Test Result

- L1: **12/12 passed** locally (CPU).
- L4 e2e: collected successfully (9 tests in the module, including the 2 new ones); not executed locally — the probe box's GPU layout differs from the CI single-H100 profile. The assertions mirror behavior measured directly by the attribution probe above.

## Related

- RFC #5069 (audio-encoder reuse slice; also corrects the RFC's "MRoPE correctness is the blocker" line — MiniCPM-o 4.5 does not use MRoPE, `uses_mrope() == False`; the actual blocker is output parity).
- Prior art: image-side attribution probe in the A.2 discussion; #5587 (streaming audio-encoder memory — deliberately not touched here).