### PR TITLE
Quark W4A8 SVDQuant Support

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -54,6 +54,7 @@ nav:
       - BitsAndBytes W4: user_guide/quantization/bitsandbytes.md
       - MXFP8 W8A8: user_guide/quantization/mxfp8.md
       - MXFP4 W4A4: user_guide/quantization/mxfp4.md
+      - W4A8 on MI355X: user_guide/quantization/w4a8_rocm.md
       - ModelOpt: user_guide/quantization/modelopt.md
       - AutoRound: user_guide/quantization/autoround.md
       - msModelSlim: user_guide/quantization/msmodelslim.md

--- a/docs/user_guide/quantization/overview.md
+++ b/docs/user_guide/quantization/overview.md
@@ -48,7 +48,7 @@ otherwise.
 | ModelOpt | [ModelOpt](modelopt.md) | Pre-quantized FP8 checkpoints | Qwen-Image, Z-Image, FLUX.2, HunyuanImage-3.0 | Validated for ModelOpt FP8 diffusion checkpoints |
 | MXFP8 W8A8 | [MXFP8](mxfp8.md) | Online W8A8 or offline pre-quantized | Wan2.2-T2V-A14B, I2V-A14B, TI2V-5B | Ascend NPU only; validated for Wan2.2 |
 | MXFP4 W4A4 | [MXFP4](mxfp4.md) | `mxfp4`: online single-scale only; `mxfp4_dualscale`: online or offline dual-scale (offline recommended) | Wan2.2-T2V-A14B, I2V-A14B | Ascend NPU only; validated for Wan2.2 A14B cascade models; TI2V-5B not supported; offline `mxfp4_dualscale` uses calibrated `mul_scale` for best accuracy |
-| W4A8 | [W4A8 on MI355X](w4a8_rocm.md) | `quark_w4a8`: online MXFP4 weight + dynamic MXFP8 activation; `quark_svdquant` adds a low-rank correction branch | Wan2.2-TI2V-5B, T2V-A14B | AMD gfx950 only; no checkpoint prep needed; `quark_svdquant` has no exporter yet |
+| W4A8 | [W4A8 on MI355X](w4a8_rocm.md) | Three tiers: plain W4A8 (RTN) via `quark_w4a8`; online / calibrated W4A8 SVD via `quark_svdquant` (low-rank correction, calibrated when served from an offline export) | Wan2.2-TI2V-5B, T2V-A14B | AMD gfx950 only; MXFP4 weight + dynamic MXFP8 activation; plain and online SVD need no checkpoint prep, calibrated SVD needs one offline export |
 | AutoRound | [AutoRound](autoround.md) | Pre-quantized W4A16 checkpoints | FLUX.1-dev; Qwen-Image/Wan2.2 not validated | Checkpoint-driven |
 | msModelSlim | [msModelSlim](msmodelslim.md) | Pre-quantized Ascend checkpoints | Wan2.2 recipe; HunyuanImage-3.0 inference target | Ascend/NPU path |
 

--- a/docs/user_guide/quantization/overview.md
+++ b/docs/user_guide/quantization/overview.md
@@ -11,24 +11,25 @@ For the internal architecture and backend extension points, see the
 ## Quantization Modes
 
 | Mode | Guide | Description | Methods |
-|------|-------|-------------|---------|
-| Online quantization | [Online Quantization](online.md) | vLLM-Omni computes quantized weights and scales while loading the model. | FP8 W8A8, Int8 W8A8, BitsAndBytes W4, MXFP8 W8A8, MXFP4 W4A4 |
+| ------ | ------- | ------------- | --------- |
+| Online quantization | [Online Quantization](online.md) | vLLM-Omni computes quantized weights and scales while loading the model. | FP8 W8A8, Int8 W8A8, BitsAndBytes W4, MXFP8 W8A8, MXFP4 W4A4, W4A8 |
 | Runtime attention quantization | [Quantized KV Cache](quantized_kvcache.md) | vLLM-Omni dynamically quantizes eligible diffusion Flash Attention tensors during inference. | FP8 FA |
 | Pre-quantized checkpoints | Method-specific guides | The checkpoint or an offline quantizer provides quantized weights and scales before serving. | ModelOpt, AutoRound, msModelSlim, serialized Int8, offline MXFP8, offline MXFP4 DualScale |
 
 ## Hardware Support
 
-| Device | FP8 W8A8 | Int8 W8A8 | BitsAndBytes W4 | ModelOpt | MXFP8 W8A8 | MXFP4 W4A4 | AutoRound | msModelSlim |
-|--------|----------|-----------|------------------|----------|------------|------------|-----------|-------------|
-| NVIDIA Blackwell GPU (SM 100+) | ✅ | ✅ | ✅ | ✅ | ⭕ | ⭕ | ✅ | ❌ |
-| NVIDIA Ada/Hopper GPU (SM 89+) | ✅ | ✅ | ✅ | ✅ | ⭕ | ⭕ | ✅ | ❌ |
-| NVIDIA Ampere GPU (SM 80+) | ✅ | ✅ | ✅ | ⭕ | ⭕ | ⭕ | ✅ | ❌ |
-| AMD ROCm | ⭕ | ⭕ | ❌ | ⭕ | ⭕ | ✅ | ⭕ | ❌ |
-| Intel XPU | ⭕ | ⭕ | ❌ | ⭕ | ⭕ | ⭕ | ✅ | ❌ |
-| Ascend NPU | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ |
+| Device | FP8 W8A8 | Int8 W8A8 | BitsAndBytes W4 | ModelOpt | MXFP8 W8A8 | MXFP4 W4A4 | W4A8 | AutoRound | msModelSlim |
+| -------- | ---------- | ----------- | ------------------ | ---------- | ------------ | ------------ | ------ | ----------- | ------------- |
+| NVIDIA Blackwell GPU (SM 100+) | ✅ | ✅ | ✅ | ✅ | ⭕ | ⭕ | ❌ | ✅ | ❌ |
+| NVIDIA Ada/Hopper GPU (SM 89+) | ✅ | ✅ | ✅ | ✅ | ⭕ | ⭕ | ❌ | ✅ | ❌ |
+| NVIDIA Ampere GPU (SM 80+) | ✅ | ✅ | ✅ | ⭕ | ⭕ | ⭕ | ❌ | ✅ | ❌ |
+| AMD ROCm | ⭕ | ⭕ | ❌ | ⭕ | ⭕ | ✅ | ✅ | ⭕ | ❌ |
+| Intel XPU | ⭕ | ⭕ | ❌ | ⭕ | ⭕ | ⭕ | ❌ | ✅ | ❌ |
+| Ascend NPU | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ |
 
 Legend: `✅` supported, `❌` unsupported, `⭕` not verified in this
-guide. FP8 on Ampere may use a weight-only path where available.
+guide. FP8 on Ampere may use a weight-only path where available. W4A8 and
+MXFP4 W4A4 on ROCm both require CDNA4 scaled MFMA, so gfx950 (MI355X) only.
 
 ## Model Type Support
 
@@ -40,13 +41,14 @@ encoder, and VAE stay on the base checkpoint unless a method guide says
 otherwise.
 
 | Method | Guide | Mode | Example models | Status |
-|--------|-------|------|----------------|--------|
+| -------- | ------- | ------ | ---------------- | -------- |
 | FP8 W8A8 | [FP8](fp8.md) | Online W8A8 or checkpoint FP8 | Qwen-Image; Wan2.2 is not validated | Validated for Qwen-Image family and other DiT models |
 | Int8 W8A8 | [Int8](int8.md) | Online or serialized W8A8 | Qwen-Image; Wan2.2 is not validated | Validated for Qwen-Image and Z-Image |
 | BitsAndBytes W4 | [BitsAndBytes](bitsandbytes.md) | Online W4 weight-only | Z-Image-Turbo; Qwen-Image/Wan2.2 not validated | Validated for Z-Image-Turbo |
 | ModelOpt | [ModelOpt](modelopt.md) | Pre-quantized FP8 checkpoints | Qwen-Image, Z-Image, FLUX.2, HunyuanImage-3.0 | Validated for ModelOpt FP8 diffusion checkpoints |
 | MXFP8 W8A8 | [MXFP8](mxfp8.md) | Online W8A8 or offline pre-quantized | Wan2.2-T2V-A14B, I2V-A14B, TI2V-5B | Ascend NPU only; validated for Wan2.2 |
 | MXFP4 W4A4 | [MXFP4](mxfp4.md) | `mxfp4`: online single-scale only; `mxfp4_dualscale`: online or offline dual-scale (offline recommended) | Wan2.2-T2V-A14B, I2V-A14B | Ascend NPU only; validated for Wan2.2 A14B cascade models; TI2V-5B not supported; offline `mxfp4_dualscale` uses calibrated `mul_scale` for best accuracy |
+| W4A8 | [W4A8 on MI355X](w4a8_rocm.md) | `quark_w4a8`: online MXFP4 weight + dynamic MXFP8 activation; `quark_svdquant` adds a low-rank correction branch | Wan2.2-TI2V-5B, T2V-A14B | AMD gfx950 only; no checkpoint prep needed; `quark_svdquant` has no exporter yet |
 | AutoRound | [AutoRound](autoround.md) | Pre-quantized W4A16 checkpoints | FLUX.1-dev; Qwen-Image/Wan2.2 not validated | Checkpoint-driven |
 | msModelSlim | [msModelSlim](msmodelslim.md) | Pre-quantized Ascend checkpoints | Wan2.2 recipe; HunyuanImage-3.0 inference target | Ascend/NPU path |
 
@@ -58,7 +60,7 @@ checkpoint contains a supported `quantization_config`; the non-AR stages stay
 in BF16 unless the model guide explicitly adds support.
 
 | Method | Guide | Scope | Example models | Status |
-|--------|-------|-------|----------------|--------|
+| -------- | ------- | ------- | ---------------- | -------- |
 | ModelOpt | [ModelOpt](modelopt.md) | Thinker or language-model checkpoint config | Qwen3-Omni thinker | ModelOpt checkpoint path |
 | Int8 | [Int8](int8.md) | Not currently validated for omni/TTS stages | Qwen3-Omni, Qwen3-TTS | Not validated |
 | BitsAndBytes | [BitsAndBytes](bitsandbytes.md) | Not currently validated for omni/TTS stages | Qwen3-Omni, Qwen3-TTS | Not validated |
@@ -73,7 +75,7 @@ These models split generation across multiple stages. Quantization must be
 attached to the intended stage rather than applied globally.
 
 | Method | Guide | Scope | Example models | Status |
-|--------|-------|-------|----------------|--------|
+| -------- | ------- | ------- | ---------------- | -------- |
 | FP8 | [FP8](fp8.md) | Stage-specific DiT or transformer module | BAGEL, GLM-Image | Requires model-specific validation |
 | Int8 | [Int8](int8.md) | Stage-specific DiT or transformer module | BAGEL, GLM-Image | Requires model-specific validation |
 | BitsAndBytes | [BitsAndBytes](bitsandbytes.md) | Stage-specific transformer or DiT module | BAGEL, GLM-Image | Not validated |
@@ -105,7 +107,7 @@ config = build_quant_config({
 ```
 
 | Component | Default quantized? | Notes |
-|-----------|--------------------|-------|
+| ----------- | -------------------- | ------- |
 | Diffusion transformer | Yes | Primary target for FP8, Int8, BitsAndBytes, ModelOpt, MXFP8, MXFP4, AutoRound, and msModelSlim |
 | Text encoder | No | Keep BF16 unless a method-specific guide documents support |
 | VAE | No | Keep BF16; storage-only paths are method-specific |
@@ -114,7 +116,7 @@ config = build_quant_config({
 ### Multi-Stage Omni/TTS Model (Qwen3-Omni, Qwen3-TTS)
 
 | Component | Default quantized? | Notes |
-|-----------|--------------------|-------|
+| ----------- | -------------------- | ------- |
 | Thinker or AR language model | Yes, when checkpoint config is supported | ModelOpt FP8/NVFP4 or AutoRound checkpoint config |
 | Audio encoder | No | BF16 |
 | Vision encoder | No | BF16 |
@@ -124,7 +126,7 @@ config = build_quant_config({
 ### Multi-Stage Diffusion Model (BAGEL, GLM-Image)
 
 | Component | Default quantized? | Notes |
-|-----------|--------------------|-------|
+| ----------- | -------------------- | ------- |
 | Selected diffusion or transformer stage | Method-specific | Must be routed to the intended stage |
 | Other generation stages | No | Keep BF16 unless separately validated |
 | VAE, tokenizer, scheduler | No | Loaded from the base checkpoint |
@@ -204,7 +206,7 @@ The output JSON includes `output_metrics`, `reference_generation`, and
 `candidate_generation`.
 
 | Metric | Direction | Meaning |
-|--------|-----------|---------|
+| -------- | ----------- | --------- |
 | `cosine_similarity` | Higher is better | Vector direction similarity between output pixels or frames. Useful as a broad sanity check. |
 | `mae` | Lower is better | Mean absolute pixel or frame error. For decoded outputs, values are in uint8 pixel units. |
 | `mse` / `rmse` | Lower is better | Squared error and its square root. These penalize localized large differences more than `mae`. |
@@ -217,7 +219,7 @@ The output JSON includes `output_metrics`, `reference_generation`, and
 Recommended starting thresholds for same-seed diffusion comparisons:
 
 | Metric | Smoke threshold | Stricter target | Notes |
-|--------|-----------------|-----------------|-------|
+| -------- | ----------------- | ----------------- | ------- |
 | `psnr_db` | `>= 20.0` | `>= 25.0` | Good for quick image or frame regression checks. |
 | `mae` | `<= 12.0` | `<= 6.0` | Interpreted in decoded uint8 pixel units. |
 | `cosine_similarity` | `>= 0.98` | `>= 0.995` | Less sensitive to global scale than L2-style metrics. |

--- a/docs/user_guide/quantization/w4a8_rocm.md
+++ b/docs/user_guide/quantization/w4a8_rocm.md
@@ -173,10 +173,10 @@ Notes:
 - **Self-attention QKV is pre-fused in the exporter.** Wan fuses `to_q/k/v` into
   `to_qkv`, so the factors are emitted fused: `proj_down` stacked to rank
   `3 x svd_rank`, `proj_up` block-diagonal. The runtime needs no special handling.
-- **`--variant plain`** writes a portable pre-quantized artifact, but it is
-  RTN-equivalent to the online plain path — smoothing folds back to identity
-  without a low-rank branch. Genuine plain calibration would need `--gptq`
-  (residual GPTQ), which today is only wired for `--variant svdquant`.
+- **`--variant plain`** writes a portable pre-quantized artifact, but it is the
+  RTN tier — always uncalibrated, RTN-equivalent to the online plain path
+  (smoothing folds back to identity without a low-rank branch). `--gptq` (which
+  GPTQ-quantizes the SVD residual) applies only to `--variant svdquant`.
 - **SVD convention.** Quark places all singular values in `proj_down` (`L1`) and
   keeps `proj_up` (`L2`) orthonormal — the opposite of the online path's
   `sqrt(S)` split. The loader consumes them verbatim; do not rebalance.

--- a/docs/user_guide/quantization/w4a8_rocm.md
+++ b/docs/user_guide/quantization/w4a8_rocm.md
@@ -227,10 +227,14 @@ capability answer, not an error.
 ## Limitations
 
 - **Tensor parallelism** requires an `--pack-format unshuffled` checkpoint (the
-  preshuffled/BF16 paths raise on `tp_size > 1`). Plain W4A8 supports column- and
-  row-parallel; `quark_svdquant` supports **column-parallel only** — row-parallel
-  needs an all-reduce of the low-rank term and raises for now. TP>1 is wired but
-  **unvalidated on multi-GPU** (the dev box has one GPU); TP=1 is verified
+  preshuffled/BF16 paths raise on `tp_size > 1`). Both plain W4A8 and
+  `quark_svdquant` support **column- and row-parallel**; the SVD low-rank term
+  needs no extra collective — by linearity its per-rank partial `d_p @ proj_up.T`
+  rides the layer's existing output all-reduce (`proj_up` shares the N axis and is
+  sharded/replicated with it; `proj_down` shares K). The sharding math is verified
+  on gfx950 (`test_flydsl_w4a8_tp_rocm.py` decomposition tests), but the end-to-end
+  multi-GPU run is **unvalidated** (the dev box has one GPU) — run
+  `test_svd_row_parallel_end_to_end_multigpu` on a ≥ 2-GPU server. TP=1 is
   bit-identical to the single-GPU path.
 - **Load time.** `quark_svdquant` runs a randomized truncated SVD per layer at
   load. It is O(rank) work, not a full decomposition, but it is not free on a

--- a/docs/user_guide/quantization/w4a8_rocm.md
+++ b/docs/user_guide/quantization/w4a8_rocm.md
@@ -1,0 +1,261 @@
+# W4A8 Quantization on AMD MI355X
+
+## Overview
+
+W4A8 quantizes diffusion transformer weights to MXFP4 (`float4_e2m1fn_x2`,
+groups of 32 K-dimension elements sharing one `float8_e8m0fnu` exponent) and
+quantizes activations to MXFP8 **dynamically inside the kernel**. Nothing about
+the activation side is stored in the checkpoint.
+
+The GEMM comes from AMD Quark's FlyDSL kernels and needs CDNA4 scaled MFMA, so
+it runs on **gfx950 (MI355X) only**. CDNA3 (gfx942 / MI325X) has neither scaled
+MFMA nor native FP4.
+
+Two methods share one implementation:
+
+| Method | Computes | Checkpoint needed | Status |
+| --- | --- | --- | --- |
+| `quark_w4a8` | `y = Q(x) @ Q(W).T + bias` | Stock BF16 | Ready |
+| `quark_svdquant` | `y = Q(x) @ Q(Wr).T + (x @ L1.T) @ L2.T + bias` | Stock BF16 (online) or calibrated export | Ready; online uncalibrated, offline calibrated (see below) |
+
+`quark_svdquant` adds a rank-R BF16 correction branch. `Wr = W - L2 @ L1` is the
+4-bit residual and the up-projection `d @ L2.T` is fused into the GEMM epilogue,
+so both methods are a single kernel launch. The low-rank branch absorbs the
+weight's dominant singular directions, leaving a residual with a narrower
+dynamic range that quantizes more accurately.
+
+Both methods can read a **stock BF16 checkpoint** and do all their work at load
+time (the *online* path). For the SVD variant they can also read a **calibrated
+serialized checkpoint** produced offline — see [Offline calibrated
+export](#offline-calibrated-export).
+
+!!! warning "The online `quark_svdquant` is an uncalibrated weight SVD"
+    The published SVDQuant method derives `L1` / `L2` from calibration
+    activations, which also migrates activation outliers into the low-rank
+    branch. The **online** path instead takes a randomized truncated SVD of the
+    weight alone (`torch.svd_lowrank`), so you get the low-rank correction and
+    none of the outlier migration. Treat its accuracy as a floor.
+
+    The **offline** path (`is_checkpoint_w4a8_serialized`) closes that gap: it
+    runs Quark's `SVDQuantProcessor` (SmoothQuant smoothing + exact SVD on the
+    smoothed weight) and ships the calibrated factors in the checkpoint.
+
+## Hardware Support
+
+| Device | Support |
+| --- | --- |
+| AMD ROCm (gfx950 / MI355X) | ✅ |
+| AMD ROCm (gfx942 / MI325X) | ❌ no CDNA4 scaled MFMA |
+| NVIDIA / Intel XPU / Ascend NPU | ❌ |
+
+An unsupported device raises `NotImplementedError` at model build. It does not
+fall back to BF16 — a whole-model silent fallback looks exactly like a
+successful quantized run.
+
+## Requirements
+
+- ROCm with a gfx950 device
+- AMD Quark from PR
+  [#6079](https://gitenterprise.xilinx.com/AMDNeuralOpt/Quark/pull/6079)
+  (branch `xiaoyu/svd-quant-flydsl`), installed from source. It vendors the
+  FlyDSL A8W4 kernels
+  (`quark.torch.quantization.nn.modules.flydsl_a8w4_inference_linear`) and the
+  SVDQuant algorithm; the released `amd-quark` wheel ships **neither**.
+- `aiter` (used for the MXFP4 pack and the `(16, 16)` weight shuffle)
+
+Quark is imported lazily: `import vllm_omni.quantization` does not pull it in.
+It loads the first time a W4A8 linear layer is constructed.
+
+## Configuration
+
+No preprocessing step. BF16 weights are read from the stock checkpoint and
+packed to MXFP4 one layer at a time as they load; the BF16 copy is freed
+immediately, so peak load memory stays close to the quantized footprint.
+
+```python
+from vllm_omni import Omni
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+omni = Omni(model="Wan-AI/Wan2.2-TI2V-5B-Diffusers", quantization="quark_w4a8")
+outputs = omni.generate(
+    "A cat sitting on a windowsill",
+    OmniDiffusionSamplingParams(num_inference_steps=50),
+)
+```
+
+```bash
+python text_to_video.py --model <your-model> --quantization quark_w4a8
+
+vllm serve <your-model> --omni --quantization quark_w4a8
+```
+
+Ready-made deploy configs:
+
+- `vllm_omni/deploy/wan2_2_ti2v_w4a8.yaml`
+- `vllm_omni/deploy/wan2_2_t2v_a14b_w4a8.yaml`
+
+`quark-w4a8` is accepted as an alias. The bare name `svdquant` is deliberately
+not claimed; it belongs to Nunchaku upstream.
+
+### Options
+
+| Key | Default | Meaning |
+| --- | --- | --- |
+| `svd_rank` (alias `rank`) | `None`, or `32` under `quark_svdquant` | Rank of the low-rank correction branch. Absent selects the plain variant. |
+| `ignored_layers` (alias `modules_to_not_convert`) | `[]` | Layer prefixes to keep in BF16. |
+
+### Model support
+
+| Model | `quark_w4a8` | Notes |
+| --- | --- | --- |
+| Wan2.2-TI2V-5B | ✅ | Single transformer |
+| Wan2.2-T2V-A14B | ✅ | Dual-expert cascade; `transformer/` and `transformer_2/` both quantized |
+| Wan2.2-I2V-A14B | ⭕ | Not validated; the image-conditioning linears have their own shapes |
+
+## Offline calibrated export
+
+The online path is convenient but sees only the raw weight. To get the published
+SVDQuant accuracy — activation-aware smoothing plus an exact SVD — export a
+calibrated checkpoint once with `examples/quantization/export_quark_svdquant_w4a8.py`
+and serve it with `is_checkpoint_w4a8_serialized`.
+
+```bash
+# One-time offline export (needs Quark + a gfx950 GPU; ~tens of minutes on A14B).
+python examples/quantization/export_quark_svdquant_w4a8.py \
+    --model /path/to/Wan2.2-TI2V-5B-Diffusers --variant svdquant \
+    --svd_rank 32 --n_calib_prompts 2 --n_calib_steps 20 \
+    --output_dir /path/to/wan5b-w4a8-svd
+```
+
+This runs Quark's `SVDQuantProcessor` (SmoothQuant smoothing folded into the
+weights, then exact SVD on the smoothed weight) and writes, per transformer:
+
+```text
+<output_dir>/<comp>/diffusion_pytorch_model.safetensors
+<output_dir>/<comp>/quant_config.json      # {"quantization_config": {...}}
+```
+
+where `<comp>` is `transformer` (plus `transformer_2` for the A14B cascade).
+Weights are stored **unpacked BF16** (residual under `weight`, factors under
+`proj_down`/`proj_up`) and packed to the MXFP4 kernel layout at load. Copy or
+symlink the non-transformer pipeline components (`vae`, `text_encoder`,
+`scheduler`, `model_index.json`) into `<output_dir>` to make it directly
+loadable, then serve it exactly like a stock model:
+
+```bash
+vllm serve /path/to/wan5b-w4a8-svd --omni --quantization quark_w4a8
+```
+
+The `quantization_config` stanza carries `is_checkpoint_w4a8_serialized: true` and
+`svd_rank`, so the loader selects the serialized SVD path automatically.
+
+Notes:
+
+- **Self-attention QKV is pre-fused in the exporter.** Wan fuses `to_q/k/v` into
+  `to_qkv`, so the factors are emitted fused: `proj_down` stacked to rank
+  `3 x svd_rank`, `proj_up` block-diagonal. The runtime needs no special handling.
+- **`--variant plain`** writes a portable pre-quantized artifact, but it is
+  RTN-equivalent to the online plain path — smoothing folds back to identity
+  without a low-rank branch. Genuine plain calibration would need `--gptq`
+  (residual GPTQ), which today is only wired for `--variant svdquant`.
+- **SVD convention.** Quark places all singular values in `proj_down` (`L1`) and
+  keeps `proj_up` (`L2`) orthonormal — the opposite of the online path's
+  `sqrt(S)` split. The loader consumes them verbatim; do not rebalance.
+- **`--pack` (compact format).** By default the residual is stored unpacked BF16
+  and packed to the kernel layout at load. `--pack` instead stores it already
+  packed (`weight_shuffle`/`weight_scale` uint8, `quark_export_format:
+  "mxfp4_packed"` in the config): **~4× smaller** on disk and no per-layer pack at
+  load. The low-rank factors stay BF16. The trade-off is portability — the packed
+  layout is tied to the kernel's pack version, so keep unpacked BF16 as the
+  archival format and use `--pack` for a fast-loading deployment copy.
+
+## Layers that stay in BF16
+
+Routing falls back to `UnquantizedLinearMethod` and logs a warning when a layer
+cannot be tiled. The two variants have **different** limits:
+
+| Variant | Requirement on `in_features` / `out_features` |
+| --- | --- |
+| `quark_w4a8` | `in_features` `>= 256` and a multiple of 256; `out_features` a multiple of 32 |
+| `quark_svdquant` | both `>= 256` **and** a multiple of 256 |
+
+`in_features` is the strict one even for the plain variant: it is the GEMM's K,
+and Quark validates `K >= 256 and K % 256 == 0` outright, because below 256 the
+MXFP4 packer emits an *unshuffled* layout that the preshuffle kernel cannot
+read. `out_features` only has to divide the smallest `tile_n`, which is 32.
+
+The SVD epilogue's 256 floor is stricter because of the preshuffled B layout.
+Wan's `proj_out` (`out_features=192`) is the motivating case: Quark refuses it
+rather than emitting garbage, so under `quark_svdquant` that layer runs in BF16
+while under `quark_w4a8` it is quantized normally.
+
+## Selecting the kernel provider
+
+`VLLM_OMNI_SVDQUANT_PROVIDER` picks the backend:
+
+| Value | Meaning |
+| --- | --- |
+| `auto` (default) | Prefer upstream FlyDSL, fall back to Quark's vendored kernels |
+| `quark` | Force Quark's vendored kernels |
+| `flydsl` | Force upstream FlyDSL — currently always fails; the released wheel is the compiler only, with no kernels |
+
+An unrecognised value raises `ValueError`. A missing provider is reported as a
+capability answer, not an error.
+
+## Limitations
+
+- **TP=1 only.** Tensor parallelism is unvalidated. `quark_svdquant` additionally
+  has no defined sharding for the rank dimension of `proj_down` / `proj_up`, so
+  both variants raise on `tp_size > 1`.
+- **Load time.** `quark_svdquant` runs a randomized truncated SVD per layer at
+  load. It is O(rank) work, not a full decomposition, but it is not free on a
+  28B dual-expert model.
+- **No MXFP4-packed checkpoints.** Serialized checkpoints store **unpacked BF16**
+  weights (packed to the kernel layout at load), because the shuffled MXFP4
+  layout is kernel-specific rather than a stable on-disk format. See
+  [Offline calibrated export](#offline-calibrated-export).
+- **BF16 activations only.** The kernel emits BF16 and quantizes its own inputs;
+  accepting FP16 would silently round-trip through BF16.
+
+## Accuracy
+
+Measured on gfx950 at the Wan prefill token count (M = 4680, deliberately not
+tile-aligned so the ragged-M padding path is exercised), cosine similarity of the
+layer output against an unquantized BF16 reference:
+
+| Shape (N x K) | `quark_w4a8` | `quark_svdquant`, rank 32 |
+| --- | --- | --- |
+| 3072 x 3072 | 0.9897 | 0.9962 |
+| 5120 x 5120 | 0.9897 | 0.9962 |
+
+The SVDQuant figures use a weight with a decaying singular spectrum, which is
+what the low-rank branch is designed for. On i.i.d. Gaussian weights, where
+there is no dominant subspace to extract, it offers no benefit.
+
+Reproduce with:
+
+```bash
+pytest tests/diffusion/quantization/test_flydsl_w4a8_rocm.py
+```
+
+The test file gates on a runtime `gfx950` check as well as the `MI355` marker, so
+it skips cleanly on other hardware.
+
+### End to end
+
+Wan2.2, t2v, 832x480, 49 frames, seed 42, prompt "a cat walks on the grass,
+realistic style", against the BF16 pipeline:
+
+| Model | Variant | Cosine | PSNR (dB) | Peak memory |
+| --- | --- | --- | --- | --- |
+| TI2V-5B, 30 steps | `quark_w4a8` | 0.932 | 14.4 | 55.1 GB vs 62.4 GB BF16 |
+| TI2V-5B, 30 steps | `quark_svdquant` r32 | 0.945 | 15.5 | 55.5 GB |
+| T2V-A14B, 20 steps | `quark_w4a8` | 0.885 | 14.5 | 37.3 GB vs 76.6 GB BF16 |
+| T2V-A14B, 20 steps | `quark_svdquant` r32 | 0.879 | 13.5 | 38.1 GB |
+
+**Read those numbers as drift, not as quality.** Every one of these outputs is a
+sharp, prompt-faithful video; 4-bit weights perturb the sampler trajectory into a
+*different* valid sample rather than degrading the current one, and per-pixel
+metrics score that as catastrophic. Use them as a regression tripwire — a sudden
+drop means something broke — and judge quality with a distributional benchmark
+such as VBench.

--- a/docs/user_guide/quantization/w4a8_rocm.md
+++ b/docs/user_guide/quantization/w4a8_rocm.md
@@ -11,32 +11,50 @@ The GEMM comes from AMD Quark's FlyDSL kernels and needs CDNA4 scaled MFMA, so
 it runs on **gfx950 (MI355X) only**. CDNA3 (gfx942 / MI325X) has neither scaled
 MFMA nor native FP4.
 
-Two methods share one implementation:
+Three accuracy tiers across two `--quantization` methods (all one kernel launch):
 
-| Method | Computes | Checkpoint needed | Status |
+| Tier | `--quantization` | Correction branch | Offline setup |
 | --- | --- | --- | --- |
-| `quark_w4a8` | `y = Q(x) @ Q(W).T + bias` | Stock BF16 | Ready |
-| `quark_svdquant` | `y = Q(x) @ Q(Wr).T + (x @ L1.T) @ L2.T + bias` | Stock BF16 (online) or calibrated export | Ready; online uncalibrated, offline calibrated (see below) |
+| **plain W4A8 (RTN)** | `quark_w4a8` | none | none |
+| **online W4A8 SVD** | `quark_svdquant` | low-rank, derived at load (uncalibrated) | none |
+| **calibrated W4A8 SVD** | `quark_svdquant` | low-rank, activation-calibrated | one export |
 
-`quark_svdquant` adds a rank-R BF16 correction branch. `Wr = W - L2 @ L1` is the
-4-bit residual and the up-projection `d @ L2.T` is fused into the GEMM epilogue,
-so both methods are a single kernel launch. The low-rank branch absorbs the
-weight's dominant singular directions, leaving a residual with a narrower
-dynamic range that quantizes more accurately.
+### How each tier works
 
-Both methods can read a **stock BF16 checkpoint** and do all their work at load
-time (the *online* path). For the SVD variant they can also read a **calibrated
-serialized checkpoint** produced offline — see [Offline calibrated
-export](#offline-calibrated-export).
+All three share one runtime: at inference the BF16 activation is quantized to
+**MXFP8 inside the kernel**, then multiplied against the **MXFP4 weight** on the
+CDNA4 scaled-MFMA GEMM — one kernel launch, BF16 out plus bias. They differ only
+in how the weight (and, for SVD, the correction) is prepared:
 
-!!! warning "The online `quark_svdquant` is an uncalibrated weight SVD"
+- **plain W4A8 (RTN)** — each BF16 weight is round-to-nearest quantized to MXFP4
+  and packed at load; the BF16 copy is freed. No correction branch:
+  `y = Q(x) @ Q(W).T + bias`.
+- **online W4A8 SVD** — same, plus a rank-R branch derived from the weight *at
+  load* with `torch.svd_lowrank`. Only the residual `Wr = W - L2·L1` is 4-bit;
+  `L1`/`L2` stay BF16 and `d @ L2.T` is fused into the GEMM epilogue. Zero setup,
+  but uncalibrated (sees the weight only).
+- **calibrated W4A8 SVD** — the residual and `L1`/`L2` come from an offline Quark
+  calibration (SmoothQuant + exact SVD on the smoothed weight) and are read from
+  the checkpoint. Same runtime as online SVD, higher accuracy.
+
+The SVD tiers are the **same method** (`quark_svdquant`); the checkpoint
+(`is_checkpoint_w4a8_serialized`) picks online vs calibrated. Their low-rank branch
+absorbs the weight's dominant singular directions, leaving a residual with a
+narrower dynamic range that quantizes more accurately.
+
+**plain W4A8 (RTN)** and **online W4A8 SVD** read a stock BF16 checkpoint and do all
+their work at load — no offline step. **calibrated W4A8 SVD** reads a serialized
+checkpoint produced offline (see [Offline calibrated
+export](#offline-calibrated-export)).
+
+!!! warning "online W4A8 SVD is an uncalibrated weight SVD"
     The published SVDQuant method derives `L1` / `L2` from calibration
     activations, which also migrates activation outliers into the low-rank
-    branch. The **online** path instead takes a randomized truncated SVD of the
+    branch. **online W4A8 SVD** instead takes a randomized truncated SVD of the
     weight alone (`torch.svd_lowrank`), so you get the low-rank correction and
     none of the outlier migration. Treat its accuracy as a floor.
 
-    The **offline** path (`is_checkpoint_w4a8_serialized`) closes that gap: it
+    **calibrated W4A8 SVD** (`is_checkpoint_w4a8_serialized`) closes that gap: it
     runs Quark's `SVDQuantProcessor` (SmoothQuant smoothing + exact SVD on the
     smoothed weight) and ships the calibrated factors in the checkpoint.
 
@@ -114,10 +132,11 @@ not claimed; it belongs to Nunchaku upstream.
 
 ## Offline calibrated export
 
-The online path is convenient but sees only the raw weight. To get the published
-SVDQuant accuracy — activation-aware smoothing plus an exact SVD — export a
-calibrated checkpoint once with `examples/quantization/export_quark_svdquant_w4a8.py`
-and serve it with `is_checkpoint_w4a8_serialized`.
+**online W4A8 SVD** is convenient but sees only the raw weight. **calibrated W4A8
+SVD** gets the published SVDQuant accuracy — activation-aware smoothing plus an
+exact SVD — by exporting a checkpoint once with
+`examples/quantization/export_quark_svdquant_w4a8.py` and serving it with
+`is_checkpoint_w4a8_serialized`.
 
 ```bash
 # One-time offline export (needs Quark + a gfx950 GPU; ~tens of minutes on A14B).

--- a/docs/user_guide/quantization/w4a8_rocm.md
+++ b/docs/user_guide/quantization/w4a8_rocm.md
@@ -161,13 +161,16 @@ Notes:
 - **SVD convention.** Quark places all singular values in `proj_down` (`L1`) and
   keeps `proj_up` (`L2`) orthonormal — the opposite of the online path's
   `sqrt(S)` split. The loader consumes them verbatim; do not rebalance.
-- **`--pack` (compact format).** By default the residual is stored unpacked BF16
-  and packed to the kernel layout at load. `--pack` instead stores it already
-  packed (`weight_shuffle`/`weight_scale` uint8, `quark_export_format:
-  "mxfp4_packed"` in the config): **~4× smaller** on disk and no per-layer pack at
-  load. The low-rank factors stay BF16. The trade-off is portability — the packed
-  layout is tied to the kernel's pack version, so keep unpacked BF16 as the
-  archival format and use `--pack` for a fast-loading deployment copy.
+- **`--pack-format` (compact 4-bit formats).** By default (`bf16`) the residual is
+  stored unpacked and packed at load. Two opt-in 4-bit formats are **~4× smaller**
+  on disk (low-rank factors stay BF16); both couple the checkpoint to the kernel's
+  pack version, so keep a BF16 copy as the archival format.
+    - `--pack-format packed`: preshuffled into the kernel layout
+      (`weight_shuffle`/`weight_scale`) — fastest load, but **TP=1 only** (the
+      shuffle bakes in K/N).
+    - `--pack-format unshuffled`: natural-order MXFP4 (`weight_packed`/
+      `weight_scale`) that vLLM can shard for **TP>1**; each rank shuffles its
+      shard at load. TP=1 output is bit-identical to `packed`.
 
 ## Layers that stay in BF16
 
@@ -204,9 +207,12 @@ capability answer, not an error.
 
 ## Limitations
 
-- **TP=1 only.** Tensor parallelism is unvalidated. `quark_svdquant` additionally
-  has no defined sharding for the rank dimension of `proj_down` / `proj_up`, so
-  both variants raise on `tp_size > 1`.
+- **Tensor parallelism** requires an `--pack-format unshuffled` checkpoint (the
+  preshuffled/BF16 paths raise on `tp_size > 1`). Plain W4A8 supports column- and
+  row-parallel; `quark_svdquant` supports **column-parallel only** — row-parallel
+  needs an all-reduce of the low-rank term and raises for now. TP>1 is wired but
+  **unvalidated on multi-GPU** (the dev box has one GPU); TP=1 is verified
+  bit-identical to the single-GPU path.
 - **Load time.** `quark_svdquant` runs a randomized truncated SVD per layer at
   load. It is O(rank) work, not a full decomposition, but it is not free on a
   28B dual-expert model.

--- a/examples/offline_inference/text_to_video/text_to_video.py
+++ b/examples/offline_inference/text_to_video/text_to_video.py
@@ -316,8 +316,8 @@ def parse_args() -> argparse.Namespace:
         "--quantization",
         type=str,
         default=None,
-        choices=["fp8", "mxfp8", "mxfp4", "mxfp4_dualscale", "int8"],
-        help="Quantization method for the transformer. mxfp8: W8A8 MXFP8 (NPU). mxfp4: W4A4 MXFP4 (NPU). mxfp4_dualscale: W4A4 MXFP4 dual-scale + BF16 fallback mixed (NPU). fp8: online FP8 (GPU).",
+        choices=["fp8", "mxfp8", "mxfp4", "mxfp4_dualscale", "int8", "quark_w4a8", "quark_svdquant"],
+        help="Quantization method for the transformer. mxfp8: W8A8 MXFP8 (NPU). mxfp4: W4A4 MXFP4 (NPU). mxfp4_dualscale: W4A4 MXFP4 dual-scale + BF16 fallback mixed (NPU). fp8: online FP8 (GPU). quark_w4a8: W4A8 MXFP4+MXFP8 RTN (ROCm gfx950). quark_svdquant: W4A8 with SVDQuant low-rank correction (ROCm gfx950).",
     )
 
     # Distributed and parallel execution

--- a/examples/quantization/export_quark_svdquant_w4a8.py
+++ b/examples/quantization/export_quark_svdquant_w4a8.py
@@ -9,14 +9,19 @@ Two variants, both consumed by ``quantization="quark_w4a8"`` with
   smoothing + exact SVD on the smoothed weight), emitting the BF16 residual ``R``
   plus low-rank factors ``proj_down`` (=L1) / ``proj_up`` (=L2). This is the
   *calibrated* counterpart to vLLM-Omni's online ``torch.svd_lowrank`` path, which
-  sees only the raw weight.
-* ``plain`` -- a portable pre-quantized artifact carrying the stock BF16 weights.
-  RTN-equivalent to the online plain path unless ``--gptq`` (residual GPTQ, only
-  meaningful with ``svdquant``); smoothing alone folds back to identity without a
-  low-rank branch, so it is *not* applied to plain.
+  sees only the raw weight. ``--gptq`` additionally quantizes the residual with
+  Hessian-based GPTQ (using the calibration data) instead of RTN.
+* ``plain`` -- the **RTN tier** (round-to-nearest MXFP4 weight; no low-rank branch,
+  no calibration -- always uncalibrated). The export just copies the stock weights;
+  vLLM-Omni RTN-quantizes them to MXFP4 at load, exactly as the *online* plain path
+  does -- so a default-format plain export is the stock checkpoint round-tripped,
+  useful only as a portable/reproducible artifact. "BF16" here is the on-disk
+  storage, not the served precision.
 
-Weights are written **unpacked BF16**; vLLM-Omni packs them to the FlyDSL MXFP4
-layout at load. Self-attention ``to_q/to_k/to_v`` are pre-fused into ``to_qkv``
+By default (``--pack-format bf16``) the residual is written **unpacked BF16** and
+vLLM-Omni RTN-packs it to the FlyDSL MXFP4 layout at load; ``--pack-format
+packed``/``unshuffled`` instead store the residual already MXFP4-packed (~4x
+smaller). Self-attention ``to_q/to_k/to_v`` are pre-fused into ``to_qkv``
 here (residual concatenated, ``proj_down`` stacked, ``proj_up`` block-diagonal)
 because the fused layer's low-rank factors cannot be reassembled by the runtime
 shard loader the way a plain weight can.
@@ -214,13 +219,11 @@ def quantize_component(pipe, comp: str, args: argparse.Namespace) -> dict[str, t
     transformer = getattr(pipe, comp)
     print(f"[export] {comp}: {type(transformer).__name__}")
 
-    if args.variant == "plain" and not args.gptq:
+    if args.variant == "plain":
         # A portable pre-quant artifact; RTN happens at load. Smoothing is a
         # no-op without a low-rank branch, so nothing calibrated to do here.
+        # (--gptq + plain is rejected at parse time.)
         return build_omni_state_dict(transformer, variant="plain", fuse_qkv=False)
-
-    if args.variant == "plain" and args.gptq:
-        raise SystemExit("--gptq is only supported with --variant svdquant in this version.")
 
     from quark.torch.algorithm.svdquant.svdquant import SVDQuantProcessor
     from quark.torch.quantization.config.config import SVDQuantConfig
@@ -315,7 +318,12 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--width", type=int, default=448)
     p.add_argument("--guidance_scale", type=float, default=5.0)
     p.add_argument("--output_dir", required=True)
-    return p.parse_args()
+    args = p.parse_args()
+    # GPTQ acts on the SVD residual; plain has no residual. Reject at parse time
+    # so it fails before the pipeline loads, not tens of minutes into calibration.
+    if args.gptq and args.variant == "plain":
+        p.error("--gptq requires --variant svdquant (plain has no residual to quantize)")
+    return args
 
 
 def main() -> int:

--- a/examples/quantization/export_quark_svdquant_w4a8.py
+++ b/examples/quantization/export_quark_svdquant_w4a8.py
@@ -61,6 +61,23 @@ DEFAULT_CALIB_PROMPTS = [
     "A hot air balloon drifting over a patchwork of autumn fields.",
 ]
 
+
+def _load_calib_prompts(args: argparse.Namespace) -> list[str]:
+    """Calibration prompts: from --prompts_file if given, else the built-in defaults.
+
+    The file is either a JSON list of strings, or a dict with a --prompts_key
+    (default "train") holding a list of strings (e.g. the VBench prompts_split.json).
+    """
+    if not getattr(args, "prompts_file", None):
+        return DEFAULT_CALIB_PROMPTS
+    with open(args.prompts_file) as handle:
+        data = json.load(handle)
+    prompts = data if isinstance(data, list) else data[args.prompts_key]
+    if not prompts or not all(isinstance(p, str) for p in prompts):
+        raise ValueError(f"--prompts_file {args.prompts_file} did not yield a list of strings")
+    return prompts
+
+
 # Quark's SVDQuant exclude set for Wan (input/output embedders and the tiny
 # out-projection that the FlyDSL SVD epilogue refuses anyway).
 WAN_SVDQUANT_EXCLUDE = [
@@ -141,7 +158,13 @@ def _fuse_qkv(sd: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
 
 
 def build_omni_state_dict(model: torch.nn.Module, variant: str, fuse_qkv: bool) -> dict[str, torch.Tensor]:
-    """Remap a (post-``apply()``) model's state_dict into vLLM-Omni's layout."""
+    """Remap a (post-``apply()``) model's state_dict into vLLM-Omni's layout.
+
+    Quark's SVDQuant already folds the SmoothQuant factor ``1/s`` into the residual
+    and ``L1`` at ``apply()`` time (``ErrorCorrectedModule`` is built with
+    ``smooth_factor=None``), so the exported factors are self-contained and need no
+    runtime activation scaling -- nothing to do here for smoothing.
+    """
     sd: dict[str, torch.Tensor] = {}
     for key, value in model.state_dict().items():
         if not isinstance(value, torch.Tensor):
@@ -229,7 +252,8 @@ def quantize_component(pipe, comp: str, args: argparse.Namespace) -> dict[str, t
     from quark.torch.quantization.config.config import SVDQuantConfig
     from quark.torch.utils.diffusers.calibration import get_calib_dataloader
 
-    prompts = DEFAULT_CALIB_PROMPTS[: args.n_calib_prompts]
+    prompts = _load_calib_prompts(args)[: args.n_calib_prompts]
+    print(f"[export] {comp}: calibrating on {len(prompts)} prompts")
     t0 = time.time()
     dataloader = get_calib_dataloader(
         pipe,
@@ -289,6 +313,19 @@ def write_component(out_dir: str, comp: str, sd: dict[str, torch.Tensor], args: 
         quant_config["packing"] = "flydsl_a8w4_preshuffle"
     if args.variant == "svdquant":
         quant_config["svd_rank"] = args.svd_rank
+
+    # vLLM-Omni discovers the quant config from the ``quantization_config`` key inside
+    # the transformer's config.json (diffusers ConfigMixin config), not a standalone
+    # file -- embed it there so the exported directory is directly loadable. A copy is
+    # also written to quant_config.json for human reference.
+    base_config: dict = {}
+    src_config = os.path.join(args.model, comp, "config.json")
+    if os.path.exists(src_config):
+        with open(src_config) as handle:
+            base_config = json.load(handle)
+    base_config["quantization_config"] = quant_config
+    with open(os.path.join(comp_dir, "config.json"), "w") as handle:
+        json.dump(base_config, handle, indent=2)
     with open(os.path.join(comp_dir, "quant_config.json"), "w") as handle:
         json.dump({"quantization_config": quant_config}, handle, indent=2)
 
@@ -311,6 +348,8 @@ def parse_args() -> argparse.Namespace:
         "packed: preshuffled MXFP4 (~4x smaller, fastest load, TP=1 only). "
         "unshuffled: natural-order MXFP4 (~4x smaller, shardable for TP>1, shuffled per shard at load).",
     )
+    p.add_argument("--prompts_file", default=None, help="JSON list of prompts, or a dict keyed by --prompts_key.")
+    p.add_argument("--prompts_key", default="train", help="Key into --prompts_file when it is a dict.")
     p.add_argument("--n_calib_prompts", type=int, default=2)
     p.add_argument("--n_calib_steps", type=int, default=20)
     p.add_argument("--num_frames", type=int, default=17)
@@ -347,11 +386,16 @@ def main() -> int:
             sd = _pack_residuals(sd, unshuffled=args.pack_format == "unshuffled")
         write_component(args.output_dir, comp, sd, args)
 
-    print(f"[export] DONE -> {args.output_dir}")
-    print(
-        "[export] copy/symlink the non-transformer pipeline components "
-        "(vae, text_encoder, scheduler, model_index.json) into the output dir to make it loadable."
-    )
+    # Symlink the non-transformer pipeline components so --output_dir is directly
+    # loadable (the transformer dirs are the quantized exports we just wrote).
+    for entry in os.listdir(args.model):
+        if entry in comps:
+            continue
+        dst = os.path.join(args.output_dir, entry)
+        if not os.path.exists(dst):
+            os.symlink(os.path.join(args.model, entry), dst)
+
+    print(f"[export] DONE -> {args.output_dir} (loadable; non-transformer components symlinked)")
     return 0
 
 

--- a/examples/quantization/export_quark_svdquant_w4a8.py
+++ b/examples/quantization/export_quark_svdquant_w4a8.py
@@ -70,6 +70,9 @@ WAN_SVDQUANT_EXCLUDE = [
 # match); these layers stay BF16 at load.
 _IGNORED_TOKENS = ["time_embedder", "patch_embedding", "condition_embedder", "norm_out", "proj_out"]
 
+# CLI --pack-format -> quark_export_format written into the checkpoint config.
+_EXPORT_FORMAT = {"bf16": "bf16", "packed": "mxfp4_packed", "unshuffled": "mxfp4_unshuffled"}
+
 # ErrorCorrectedModule state_dict -> vLLM-Omni canonical key. Order matters: the
 # correction/layer suffixes are checked before the bare ``.weight`` they contain.
 _ECM_REMAP = (
@@ -169,15 +172,20 @@ def _fold_unsupported_factors(sd: dict[str, torch.Tensor]) -> dict[str, torch.Te
     return sd
 
 
-def _pack_residuals(sd: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
-    """Pre-pack each quantized residual weight to the FlyDSL MXFP4 kernel layout.
+def _pack_residuals(sd: dict[str, torch.Tensor], unshuffled: bool) -> dict[str, torch.Tensor]:
+    """Pre-pack each quantized residual weight to MXFP4 on disk.
 
-    ``X.weight`` (N, K) -> ``X.weight_shuffle`` (N, K/2) + ``X.weight_scale``
-    (N, K/32), both uint8, dropping the BF16 copy. ~4x smaller on disk and no
-    per-layer pack at load. Only weights that the loader will actually quantize
-    are packed -- ignored/untileable layers stay BF16 and load unquantized.
-    Low-rank ``proj_down``/``proj_up`` stay BF16. See the packing caveat in the
-    module docstring: this couples the checkpoint to the kernel's pack version.
+    ``packed`` (``unshuffled=False``): ``X.weight`` -> ``X.weight_shuffle`` (N, K/2)
+    + ``X.weight_scale`` (N, K/32), preshuffled into the kernel layout. Fastest
+    load, but the shuffle bakes in K/N so it is **TP=1 only**.
+
+    ``unshuffled`` (``unshuffled=True``): ``X.weight`` -> ``X.weight_packed`` (N, K/2)
+    + ``X.weight_scale`` (N, K/32) in *natural* order, so vLLM can shard it for
+    **TP>1**; each rank shuffles its shard at load.
+
+    Both are ~4x smaller than BF16. Only weights the loader will quantize are
+    packed; ignored/untileable layers stay BF16. Low-rank ``proj_down``/``proj_up``
+    stay BF16. Either format couples the checkpoint to the kernel's pack version.
     """
     from vllm_omni.quantization import flydsl_w4a8
 
@@ -190,9 +198,13 @@ def _pack_residuals(sd: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
             and not any(tok in base for tok in _IGNORED_TOKENS)
             and _omni_plain_ok(value.shape[0], value.shape[1])
         ):
-            packed, scale = flydsl_w4a8.pack_weight(value.to("cuda"))
-            out[f"{base}.weight_shuffle"] = packed.cpu().contiguous()
-            out[f"{base}.weight_scale"] = scale.cpu().contiguous()
+            if unshuffled:
+                w_q, w_s = flydsl_w4a8.pack_weight_unshuffled(value.to("cuda"))
+                out[f"{base}.weight_packed"] = w_q.cpu().contiguous()
+            else:
+                w_q, w_s = flydsl_w4a8.pack_weight(value.to("cuda"))
+                out[f"{base}.weight_shuffle"] = w_q.cpu().contiguous()
+            out[f"{base}.weight_scale"] = w_s.cpu().contiguous()
         else:
             out[key] = value
     return out
@@ -259,9 +271,9 @@ def write_component(out_dir: str, comp: str, sd: dict[str, torch.Tensor], args: 
         "is_checkpoint_w4a8_serialized": True,
         "producer": "quark",
         "variant": args.variant,
-        # "mxfp4_packed": residual pre-packed to the kernel layout (weight_shuffle +
-        # weight_scale). Absent/"bf16": unpacked BF16 residual, packed at load.
-        "quark_export_format": "mxfp4_packed" if args.pack else "bf16",
+        # bf16: unpacked residual (packed at load). mxfp4_packed: preshuffled on
+        # disk (TP=1). mxfp4_unshuffled: natural-order MXFP4 on disk (shardable, TP>1).
+        "quark_export_format": _EXPORT_FORMAT[args.pack_format],
         "ignored_layers": list(_IGNORED_TOKENS),
         "algo": {
             "svdquant": args.variant == "svdquant",
@@ -270,7 +282,7 @@ def write_component(out_dir: str, comp: str, sd: dict[str, torch.Tensor], args: 
             "gptq": args.gptq,
         },
     }
-    if args.pack:
+    if args.pack_format != "bf16":
         quant_config["packing"] = "flydsl_a8w4_preshuffle"
     if args.variant == "svdquant":
         quant_config["svd_rank"] = args.svd_rank
@@ -288,10 +300,13 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--gptq", action="store_true", help="Residual GPTQ (svdquant only).")
     p.add_argument("--no_fuse_qkv", action="store_true", help="Debug: emit separate attn1 to_q/k/v.")
     p.add_argument(
-        "--pack",
-        action="store_true",
-        help="Pre-pack residual weights to the MXFP4 kernel layout on disk (~4x smaller, "
-        "faster load), instead of unpacked BF16. Couples the checkpoint to the kernel pack version.",
+        "--pack-format",
+        dest="pack_format",
+        default="bf16",
+        choices=["bf16", "packed", "unshuffled"],
+        help="On-disk residual format. bf16: unpacked, packed at load (default). "
+        "packed: preshuffled MXFP4 (~4x smaller, fastest load, TP=1 only). "
+        "unshuffled: natural-order MXFP4 (~4x smaller, shardable for TP>1, shuffled per shard at load).",
     )
     p.add_argument("--n_calib_prompts", type=int, default=2)
     p.add_argument("--n_calib_steps", type=int, default=20)
@@ -320,8 +335,8 @@ def main() -> int:
     os.makedirs(args.output_dir, exist_ok=True)
     for comp in comps:
         sd = quantize_component(pipe, comp, args)
-        if args.pack:
-            sd = _pack_residuals(sd)
+        if args.pack_format != "bf16":
+            sd = _pack_residuals(sd, unshuffled=args.pack_format == "unshuffled")
         write_component(args.output_dir, comp, sd, args)
 
     print(f"[export] DONE -> {args.output_dir}")

--- a/examples/quantization/export_quark_svdquant_w4a8.py
+++ b/examples/quantization/export_quark_svdquant_w4a8.py
@@ -1,0 +1,336 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Offline W4A8 export: a Quark-calibrated Wan2.2 checkpoint for vLLM-Omni.
+
+Two variants, both consumed by ``quantization="quark_w4a8"`` with
+``is_checkpoint_w4a8_serialized=True``:
+
+* ``svdquant`` -- runs Quark's ``SVDQuantProcessor`` (activation-aware SmoothQuant
+  smoothing + exact SVD on the smoothed weight), emitting the BF16 residual ``R``
+  plus low-rank factors ``proj_down`` (=L1) / ``proj_up`` (=L2). This is the
+  *calibrated* counterpart to vLLM-Omni's online ``torch.svd_lowrank`` path, which
+  sees only the raw weight.
+* ``plain`` -- a portable pre-quantized artifact carrying the stock BF16 weights.
+  RTN-equivalent to the online plain path unless ``--gptq`` (residual GPTQ, only
+  meaningful with ``svdquant``); smoothing alone folds back to identity without a
+  low-rank branch, so it is *not* applied to plain.
+
+Weights are written **unpacked BF16**; vLLM-Omni packs them to the FlyDSL MXFP4
+layout at load. Self-attention ``to_q/to_k/to_v`` are pre-fused into ``to_qkv``
+here (residual concatenated, ``proj_down`` stacked, ``proj_up`` block-diagonal)
+because the fused layer's low-rank factors cannot be reassembled by the runtime
+shard loader the way a plain weight can.
+
+Layout mirrors ``quantize_wan2_2_quark_mxfp4.py`` (PR #5693):
+
+    <output_dir>/<comp>/diffusion_pytorch_model.safetensors
+    <output_dir>/<comp>/quant_config.json      # {"quantization_config": {...}}
+
+where ``<comp>`` is ``transformer`` (+ ``transformer_2`` for the A14B cascade).
+
+Usage:
+
+    python examples/quantization/export_quark_svdquant_w4a8.py \\
+        --model /workspace/Wan2.2-TI2V-5B-Diffusers --variant svdquant \\
+        --svd_rank 32 --n_calib_prompts 2 --n_calib_steps 20 \\
+        --output_dir /path/to/wan5b-w4a8-svd
+
+Requires an AMD Quark checkout with the SVDQuant algorithm and a GPU (this box's
+torch has no CPU LAPACK, so ``torch.linalg.svd`` must run on device).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import time
+
+import torch
+
+DEFAULT_CALIB_PROMPTS = [
+    "A cinematic shot of a serene mountain lake at sunrise, low mist over the water.",
+    "A golden retriever running across a green meadow, realistic style.",
+    "Neon city street at night in the rain, reflections on the asphalt.",
+    "A hot air balloon drifting over a patchwork of autumn fields.",
+]
+
+# Quark's SVDQuant exclude set for Wan (input/output embedders and the tiny
+# out-projection that the FlyDSL SVD epilogue refuses anyway).
+WAN_SVDQUANT_EXCLUDE = [
+    "*time_embedder*",
+    "*patch_embedding*",
+    "*condition_embedder*",
+    "*norm_out*",
+    "*proj_out*",
+]
+
+# Bare tokens for the checkpoint's ignored_layers (is_layer_skipped substring
+# match); these layers stay BF16 at load.
+_IGNORED_TOKENS = ["time_embedder", "patch_embedding", "condition_embedder", "norm_out", "proj_out"]
+
+# ErrorCorrectedModule state_dict -> vLLM-Omni canonical key. Order matters: the
+# correction/layer suffixes are checked before the bare ``.weight`` they contain.
+_ECM_REMAP = (
+    (".correction.l1.weight", ".proj_down"),
+    (".correction.l2.weight", ".proj_up"),
+    (".layer.weight", ".weight"),
+    (".layer.bias", ".bias"),
+)
+
+_QKV_RE = re.compile(r"^(.*\.attn1\.)to_q\.(weight|bias|proj_down|proj_up)$")
+
+# Mirrors of flydsl_w4a8.supports_svd_shape / supports_shape -- kept local so the
+# state-dict shaping needs no vLLM import. K (in_features) is the strict axis: the
+# kernel requires K >= 256 and a multiple of 256, which also makes the packed E8M0
+# scale exactly (N, K/32) with no padding, so the packed loader can use clean shapes.
+_SVD_DIM_MULTIPLE = 256
+_TILE_N_MULTIPLE = 32
+
+
+def _omni_svd_ok(out_features: int, in_features: int) -> bool:
+    return (
+        out_features >= _SVD_DIM_MULTIPLE
+        and in_features >= _SVD_DIM_MULTIPLE
+        and out_features % _SVD_DIM_MULTIPLE == 0
+        and in_features % _SVD_DIM_MULTIPLE == 0
+    )
+
+
+def _omni_plain_ok(out_features: int, in_features: int) -> bool:
+    return (
+        in_features >= _SVD_DIM_MULTIPLE
+        and in_features % _SVD_DIM_MULTIPLE == 0
+        and out_features % _TILE_N_MULTIPLE == 0
+    )
+
+
+def _remap_key(key: str) -> str:
+    for suffix, canonical in _ECM_REMAP:
+        if key.endswith(suffix):
+            return key[: -len(suffix)] + canonical
+    return key
+
+
+def _fuse_qkv(sd: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    """Pre-fuse self-attention to_q/to_k/to_v into a single to_qkv.
+
+    residual/bias/proj_down concatenate along dim 0; proj_up is block-diagonal so
+    each head's correction only feeds its own output slice. Verified equal to the
+    three independent corrections summed.
+    """
+    prefixes = {m.group(1) for k in sd if (m := _QKV_RE.match(k))}
+    for prefix in sorted(prefixes):
+        for sub in ("weight", "bias", "proj_down", "proj_up"):
+            keys = [f"{prefix}to_{x}.{sub}" for x in ("q", "k", "v")]
+            if not all(k in sd for k in keys):
+                continue
+            parts = [sd.pop(k) for k in keys]
+            fused = torch.block_diag(*parts) if sub == "proj_up" else torch.cat(parts, dim=0)
+            sd[f"{prefix}to_qkv.{sub}"] = fused.contiguous()
+    return sd
+
+
+def build_omni_state_dict(model: torch.nn.Module, variant: str, fuse_qkv: bool) -> dict[str, torch.Tensor]:
+    """Remap a (post-``apply()``) model's state_dict into vLLM-Omni's layout."""
+    sd: dict[str, torch.Tensor] = {}
+    for key, value in model.state_dict().items():
+        if not isinstance(value, torch.Tensor):
+            continue
+        tensor = value.detach().to("cpu")
+        if tensor.is_floating_point():
+            tensor = tensor.to(torch.bfloat16)
+        sd[_remap_key(key)] = tensor.contiguous()
+    if variant == "svdquant" and fuse_qkv:
+        sd = _fuse_qkv(sd)
+    if variant == "svdquant":
+        sd = _fold_unsupported_factors(sd)
+    return sd
+
+
+def _fold_unsupported_factors(sd: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    """Reconstruct the full weight for any SVD layer the vLLM-Omni gate rejects.
+
+    Keeps the invariant *factors present iff the (fused) shape passes
+    ``supports_svd_shape``* -- otherwise the loader would route the layer to a
+    non-SVD method and silently drop the correction, leaving a residual-only
+    weight. Wan's dims are 256-aligned so this normally folds nothing.
+    """
+    prefixes = {k[: -len(".proj_down")] for k in sd if k.endswith(".proj_down")}
+    for prefix in sorted(prefixes):
+        proj_down = sd[f"{prefix}.proj_down"]
+        proj_up = sd[f"{prefix}.proj_up"]
+        if _omni_svd_ok(proj_up.shape[0], proj_down.shape[1]):
+            continue
+        weight = sd[f"{prefix}.weight"]
+        sd[f"{prefix}.weight"] = (weight + proj_up @ proj_down).contiguous()
+        del sd[f"{prefix}.proj_down"], sd[f"{prefix}.proj_up"]
+    return sd
+
+
+def _pack_residuals(sd: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    """Pre-pack each quantized residual weight to the FlyDSL MXFP4 kernel layout.
+
+    ``X.weight`` (N, K) -> ``X.weight_shuffle`` (N, K/2) + ``X.weight_scale``
+    (N, K/32), both uint8, dropping the BF16 copy. ~4x smaller on disk and no
+    per-layer pack at load. Only weights that the loader will actually quantize
+    are packed -- ignored/untileable layers stay BF16 and load unquantized.
+    Low-rank ``proj_down``/``proj_up`` stay BF16. See the packing caveat in the
+    module docstring: this couples the checkpoint to the kernel's pack version.
+    """
+    from vllm_omni.quantization import flydsl_w4a8
+
+    out: dict[str, torch.Tensor] = {}
+    for key, value in sd.items():
+        base = key[: -len(".weight")] if key.endswith(".weight") else None
+        if (
+            base is not None
+            and value.ndim == 2
+            and not any(tok in base for tok in _IGNORED_TOKENS)
+            and _omni_plain_ok(value.shape[0], value.shape[1])
+        ):
+            packed, scale = flydsl_w4a8.pack_weight(value.to("cuda"))
+            out[f"{base}.weight_shuffle"] = packed.cpu().contiguous()
+            out[f"{base}.weight_scale"] = scale.cpu().contiguous()
+        else:
+            out[key] = value
+    return out
+
+
+def quantize_component(pipe, comp: str, args: argparse.Namespace) -> dict[str, torch.Tensor]:
+    transformer = getattr(pipe, comp)
+    print(f"[export] {comp}: {type(transformer).__name__}")
+
+    if args.variant == "plain" and not args.gptq:
+        # A portable pre-quant artifact; RTN happens at load. Smoothing is a
+        # no-op without a low-rank branch, so nothing calibrated to do here.
+        return build_omni_state_dict(transformer, variant="plain", fuse_qkv=False)
+
+    if args.variant == "plain" and args.gptq:
+        raise SystemExit("--gptq is only supported with --variant svdquant in this version.")
+
+    from quark.torch.algorithm.svdquant.svdquant import SVDQuantProcessor
+    from quark.torch.quantization.config.config import SVDQuantConfig
+    from quark.torch.utils.diffusers.calibration import get_calib_dataloader
+
+    prompts = DEFAULT_CALIB_PROMPTS[: args.n_calib_prompts]
+    t0 = time.time()
+    dataloader = get_calib_dataloader(
+        pipe,
+        transformer,
+        prompts,
+        n_steps=args.n_calib_steps,
+        height=args.height,
+        width=args.width,
+        num_frames=args.num_frames,
+        guidance_scale=args.guidance_scale,
+    )
+    print(f"[export] {comp}: captured calibration in {time.time() - t0:.0f}s")
+
+    cfg = SVDQuantConfig(
+        name="svdquant",
+        svd_rank=args.svd_rank,
+        smooth_alpha=args.smooth_alpha,
+        search_alpha=args.search_alpha,
+        exclude_patterns=list(WAN_SVDQUANT_EXCLUDE),
+        min_layer_size=256,
+        use_gptq=args.gptq,
+    )
+    t0 = time.time()
+    SVDQuantProcessor(model=transformer, quant_algo_config=cfg, calib_data=dataloader).apply()
+    print(f"[export] {comp}: SVDQuant apply() in {time.time() - t0:.0f}s")
+
+    return build_omni_state_dict(transformer, variant="svdquant", fuse_qkv=not args.no_fuse_qkv)
+
+
+def write_component(out_dir: str, comp: str, sd: dict[str, torch.Tensor], args: argparse.Namespace) -> None:
+    from safetensors.torch import save_file
+
+    comp_dir = os.path.join(out_dir, comp)
+    os.makedirs(comp_dir, exist_ok=True)
+    path = os.path.join(comp_dir, "diffusion_pytorch_model.safetensors")
+    save_file(sd, path)
+    size_gb = os.path.getsize(path) / 1e9
+    print(f"[export] {comp}: wrote {len(sd)} tensors ({size_gb:.2f} GB) -> {path}")
+
+    quant_config: dict = {
+        "quant_method": "quark_w4a8",
+        "is_checkpoint_w4a8_serialized": True,
+        "producer": "quark",
+        "variant": args.variant,
+        # "mxfp4_packed": residual pre-packed to the kernel layout (weight_shuffle +
+        # weight_scale). Absent/"bf16": unpacked BF16 residual, packed at load.
+        "quark_export_format": "mxfp4_packed" if args.pack else "bf16",
+        "ignored_layers": list(_IGNORED_TOKENS),
+        "algo": {
+            "svdquant": args.variant == "svdquant",
+            "smooth_alpha": args.smooth_alpha,
+            "search_alpha": args.search_alpha,
+            "gptq": args.gptq,
+        },
+    }
+    if args.pack:
+        quant_config["packing"] = "flydsl_a8w4_preshuffle"
+    if args.variant == "svdquant":
+        quant_config["svd_rank"] = args.svd_rank
+    with open(os.path.join(comp_dir, "quant_config.json"), "w") as handle:
+        json.dump({"quantization_config": quant_config}, handle, indent=2)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--model", required=True, help="Path to a diffusers Wan2.2 model directory.")
+    p.add_argument("--variant", default="svdquant", choices=["svdquant", "plain"])
+    p.add_argument("--svd_rank", type=int, default=32)
+    p.add_argument("--smooth_alpha", type=float, default=0.5)
+    p.add_argument("--search_alpha", action="store_true", help="Per-layer alpha search (slow).")
+    p.add_argument("--gptq", action="store_true", help="Residual GPTQ (svdquant only).")
+    p.add_argument("--no_fuse_qkv", action="store_true", help="Debug: emit separate attn1 to_q/k/v.")
+    p.add_argument(
+        "--pack",
+        action="store_true",
+        help="Pre-pack residual weights to the MXFP4 kernel layout on disk (~4x smaller, "
+        "faster load), instead of unpacked BF16. Couples the checkpoint to the kernel pack version.",
+    )
+    p.add_argument("--n_calib_prompts", type=int, default=2)
+    p.add_argument("--n_calib_steps", type=int, default=20)
+    p.add_argument("--num_frames", type=int, default=17)
+    p.add_argument("--height", type=int, default=256)
+    p.add_argument("--width", type=int, default=448)
+    p.add_argument("--guidance_scale", type=float, default=5.0)
+    p.add_argument("--output_dir", required=True)
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    print("[export] args:", vars(args))
+
+    from diffusers import DiffusionPipeline
+
+    pipe = DiffusionPipeline.from_pretrained(args.model, torch_dtype=torch.bfloat16)
+    pipe.to("cuda")
+
+    comps = ["transformer"]
+    if getattr(pipe, "transformer_2", None) is not None:
+        comps.append("transformer_2")
+    print(f"[export] components: {comps}")
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    for comp in comps:
+        sd = quantize_component(pipe, comp, args)
+        if args.pack:
+            sd = _pack_residuals(sd)
+        write_component(args.output_dir, comp, sd, args)
+
+    print(f"[export] DONE -> {args.output_dir}")
+    print(
+        "[export] copy/symlink the non-transformer pipeline components "
+        "(vae, text_encoder, scheduler, model_index.json) into the output dir to make it loadable."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,6 +270,7 @@ markers = [
     "L4: [hardware-resource] Tests that require L4 GPU",
     "B200: [hardware-resource] Tests that require B200 GPU",
     "MI325: [hardware-resource] Tests that require MI325 GPU (AMD/ROCm)",
+    "MI355: [hardware-resource] Tests that require MI355 GPU (AMD/ROCm, gfx950)",
     "B60: [hardware-resource] Tests that require Intel Arc Pro B60 XPU",
     "S5000: [hardware-resource] Tests that require S5000 GPU (Moore Threads/MUSA)",
     "A2: [hardware-resource] Tests that require A2 NPU",

--- a/tests/diffusion/quantization/test_export_quark_svdquant.py
+++ b/tests/diffusion/quantization/test_export_quark_svdquant.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""CPU tests for the offline W4A8 exporter's key remap and QKV pre-fusion.
+
+The exporter (``examples/quantization/export_quark_svdquant_w4a8.py``) runs Quark
++ a GPU at export time, but its state-dict shaping is pure tensor logic and must
+be correct without either. These tests exercise that logic directly.
+"""
+
+import importlib.util
+import os
+
+import pytest
+import torch
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+_EXPORTER = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "..",
+    "examples",
+    "quantization",
+    "export_quark_svdquant_w4a8.py",
+)
+
+
+def _load_exporter():
+    spec = importlib.util.spec_from_file_location("export_quark_svdquant_w4a8", os.path.abspath(_EXPORTER))
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_remap_keys():
+    mod = _load_exporter()
+    assert mod._remap_key("b.0.attn2.to_q.layer.weight") == "b.0.attn2.to_q.weight"
+    assert mod._remap_key("b.0.attn2.to_q.layer.bias") == "b.0.attn2.to_q.bias"
+    assert mod._remap_key("b.0.attn2.to_q.correction.l1.weight") == "b.0.attn2.to_q.proj_down"
+    assert mod._remap_key("b.0.attn2.to_q.correction.l2.weight") == "b.0.attn2.to_q.proj_up"
+    # A plain param (not an ErrorCorrectedModule) is untouched.
+    assert mod._remap_key("b.0.norm.weight") == "b.0.norm.weight"
+
+
+def test_qkv_fuse_roundtrip():
+    """The fused residual + block-diagonal correction must equal the three
+    separate per-head linear outputs concatenated."""
+    mod = _load_exporter()
+    torch.manual_seed(0)
+    k, rank = 64, 4
+    sizes = {"q": 48, "k": 48, "v": 16}
+    x = torch.randn(5, k)
+    prefix = "blocks.0.attn1."
+
+    sd, refs = {}, {}
+    for name, n in sizes.items():
+        weight = torch.randn(n, k)
+        l2 = torch.randn(n, rank)
+        l1 = torch.randn(rank, k)
+        residual = weight - l2 @ l1
+        sd[f"{prefix}to_{name}.weight"] = residual
+        sd[f"{prefix}to_{name}.proj_down"] = l1
+        sd[f"{prefix}to_{name}.proj_up"] = l2
+        refs[name] = x @ weight.T
+
+    mod._fuse_qkv(sd)
+
+    n_total = sum(sizes.values())
+    assert {k for k in sd if "attn1" in k} == {
+        f"{prefix}to_qkv.weight",
+        f"{prefix}to_qkv.proj_down",
+        f"{prefix}to_qkv.proj_up",
+    }
+    fused_w = sd[f"{prefix}to_qkv.weight"]
+    proj_down = sd[f"{prefix}to_qkv.proj_down"]
+    proj_up = sd[f"{prefix}to_qkv.proj_up"]
+    assert fused_w.shape == (n_total, k)
+    assert proj_down.shape == (3 * rank, k)
+    assert proj_up.shape == (n_total, 3 * rank)
+
+    out = x @ fused_w.T + (x @ proj_down.T) @ proj_up.T
+    ref = torch.cat([refs["q"], refs["k"], refs["v"]], dim=1)
+    assert torch.allclose(out, ref, atol=1e-4)
+
+    # proj_up is block-diagonal: the q rows (0:48) only touch the q rank block (0:rank).
+    assert torch.count_nonzero(proj_up[: sizes["q"], rank:]) == 0
+
+
+def test_fold_unsupported_factors_folds_small_layer():
+    """A layer the vLLM-Omni SVD gate rejects has its correction folded back into
+    the weight so no orphan factor keys reach the checkpoint."""
+    mod = _load_exporter()
+    torch.manual_seed(0)
+    k, rank, n = 64, 4, 48  # n=48 < 256 -> not SVD-tileable
+    weight = torch.randn(n, k)
+    l2 = torch.randn(n, rank)
+    l1 = torch.randn(rank, k)
+    sd = {"x.weight": weight - l2 @ l1, "x.proj_down": l1, "x.proj_up": l2}
+
+    mod._fold_unsupported_factors(sd)
+
+    assert "x.proj_down" not in sd and "x.proj_up" not in sd
+    assert torch.allclose(sd["x.weight"], weight, atol=1e-4)
+
+
+def test_fold_unsupported_factors_keeps_aligned_layer():
+    mod = _load_exporter()
+    k, rank, n = 256, 4, 256  # both 256-aligned -> kept
+    sd = {
+        "y.weight": torch.randn(n, k),
+        "y.proj_down": torch.randn(rank, k),
+        "y.proj_up": torch.randn(n, rank),
+    }
+    mod._fold_unsupported_factors(sd)
+    assert "y.proj_down" in sd and "y.proj_up" in sd

--- a/tests/diffusion/quantization/test_flydsl_w4a8_cudagraph_rocm.py
+++ b/tests/diffusion/quantization/test_flydsl_w4a8_cudagraph_rocm.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""CUDA-graph capture/replay of the W4A8 fused ops on gfx950.
+
+The FlyDSL A8W4 GEMM must be capturable so the Wan transformer can be replayed
+per denoising step. With the default heuristic config (``QUARK_A8W4_AUTOTUNE``
+unset) the op does no host sync on the hot path and the JIT compile is host-side,
+so after a warm-up capture succeeds and replay is bit-identical to eager. The
+opt-in timing autotune (``QUARK_A8W4_AUTOTUNE=1``, which synchronizes the device)
+would abort capture -- these tests assert it is off and that replay is exact.
+
+See ``/workspace/vllm_omni_svd/cuda_graph_w4a8_instructions.md`` for the full
+recipe and how to wire a per-shape graph runner around the Wan core.
+"""
+
+import pytest
+import torch
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.rocm, pytest.mark.MI355]
+
+
+def _gcn_arch() -> str:
+    if not (torch.cuda.is_available() and torch.version.hip):
+        return ""
+    return torch.cuda.get_device_properties(torch.accelerator.current_device_index()).gcnArchName
+
+
+requires_gfx950 = pytest.mark.skipif(
+    "gfx950" not in _gcn_arch(),
+    reason=f"W4A8 requires CDNA4 scaled MFMA (gfx950); detected {_gcn_arch() or 'no ROCm device'}",
+)
+pytestmark.append(requires_gfx950)
+
+
+@pytest.fixture(autouse=True)
+def _cuda_default_device_no_autotune(monkeypatch):
+    # The timing autotune syncs and would abort capture; keep the heuristic path.
+    monkeypatch.delenv("QUARK_A8W4_AUTOTUNE", raising=False)
+    torch.set_default_device("cuda")
+    yield
+    torch.set_default_device("cpu")
+
+
+def _capture(call):
+    """Warm up on a side stream (fills the compile caches), then capture ``call``.
+
+    Returns the captured graph and its static output tensor. ``call`` reads from
+    the caller's static input buffers, so replay = copy new input in + graph.replay().
+    """
+    side = torch.cuda.Stream()
+    side.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side):
+        for _ in range(3):
+            call()
+    torch.cuda.current_stream().wait_stream(side)
+    torch.accelerator.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        static_out = call()
+    return graph, static_out
+
+
+def test_plain_w4a8_cudagraph_replay_is_exact():
+    from vllm_omni.quantization import flydsl_w4a8
+
+    flydsl_w4a8.register_ops()
+    n = k = 5120
+    m = 4736  # tile-aligned
+    torch.manual_seed(0)
+    weight = (torch.randn(n, k, dtype=torch.bfloat16) * 0.1).contiguous()
+    kernel_weight, kernel_scale = flydsl_w4a8.pack_weight(weight)
+    bias = (torch.randn(n, dtype=torch.bfloat16) * 0.05).contiguous()
+    static_x = (torch.randn(m, k, dtype=torch.bfloat16) * 0.5).contiguous()
+
+    op = torch.ops.vllm_omni.flydsl_w4a8_gemm
+    graph, static_out = _capture(lambda: op(static_x, kernel_weight, kernel_scale, bias, n))
+
+    for seed in (1, 2):
+        torch.manual_seed(seed)
+        new_x = (torch.randn(m, k, dtype=torch.bfloat16) * 0.5).contiguous()
+        static_x.copy_(new_x)
+        graph.replay()
+        torch.accelerator.synchronize()
+        eager = op(new_x, kernel_weight, kernel_scale, bias, n)
+        # Replay executes the exact recorded kernel, so it must match eager bit-for-bit.
+        assert torch.equal(static_out, eager)
+
+
+def test_svdquant_w4a8_cudagraph_replay_is_exact():
+    """The SVD op additionally computes ``d = x @ proj_down.T`` in torch and hits
+    the ragged-M padding path -- both must be capture-safe."""
+    from vllm_omni.quantization import flydsl_w4a8
+
+    flydsl_w4a8.register_ops()
+    n = k = 5120
+    rank = 32
+    m = 4680  # ragged M -> exercises the padding path under capture
+    torch.manual_seed(0)
+    weight = (torch.randn(n, k, dtype=torch.bfloat16) * 0.1).contiguous()
+    kernel_weight, kernel_scale = flydsl_w4a8.pack_weight(weight)
+    proj_down = (torch.randn(rank, k, dtype=torch.bfloat16) * 0.05).contiguous()
+    proj_up = (torch.randn(n, rank, dtype=torch.bfloat16) * 0.05).contiguous()
+    static_x = (torch.randn(m, k, dtype=torch.bfloat16) * 0.5).contiguous()
+
+    op = torch.ops.vllm_omni.flydsl_w4a8_svd_gemm
+    graph, static_out = _capture(lambda: op(static_x, kernel_weight, kernel_scale, proj_down, proj_up, None, n))
+
+    for seed in (1, 2):
+        torch.manual_seed(seed)
+        new_x = (torch.randn(m, k, dtype=torch.bfloat16) * 0.5).contiguous()
+        static_x.copy_(new_x)
+        graph.replay()
+        torch.accelerator.synchronize()
+        eager = op(new_x, kernel_weight, kernel_scale, proj_down, proj_up, None, n)
+        assert torch.equal(static_out, eager)

--- a/tests/diffusion/quantization/test_flydsl_w4a8_rocm.py
+++ b/tests/diffusion/quantization/test_flydsl_w4a8_rocm.py
@@ -435,3 +435,96 @@ def test_svdquant_packed_matches_bf16_at_load():
 
     out, _ = layer(x)
     assert torch.equal(out, ref_out)
+
+
+# ---------------------------------------------------------------------------
+# Unshuffled serialized checkpoints (TP-capable format; TP=1 equivalence here)
+# ---------------------------------------------------------------------------
+
+
+def test_pack_unshuffled_then_shuffle_equals_packed():
+    """The provider split must reproduce the whole-weight pack: shuffle_for_kernel
+    of the unshuffled quant == pack_weight, byte-for-byte."""
+    from vllm_omni.quantization import flydsl_w4a8
+
+    torch.manual_seed(0)
+    w = (torch.randn(5120, 5120, device="cuda", dtype=torch.bfloat16) * 0.1).contiguous()
+    kw_p, ks_p = flydsl_w4a8.pack_weight(w)
+    wq, ws = flydsl_w4a8.pack_weight_unshuffled(w)
+    assert wq.shape == (5120, 2560) and ws.shape == (5120, 160)
+    kw_u, ks_u = flydsl_w4a8.shuffle_for_kernel(wq, ws)
+    assert torch.equal(kw_u, kw_p) and torch.equal(ks_u, ks_p)
+
+
+def test_plain_unshuffled_matches_packed_at_tp1():
+    from vllm_omni.quantization import flydsl_w4a8
+    from vllm_omni.quantization.quark_w4a8_config import (
+        DiffusionQuarkW4A8Config,
+        QuarkW4A8UnshuffledLinearMethod,
+    )
+
+    in_features = out_features = 5120
+    torch.manual_seed(0)
+    weight = (torch.randn(out_features, in_features, device="cuda", dtype=torch.bfloat16) * 0.1).contiguous()
+    x = torch.randn(M_RAGGED, in_features, device="cuda", dtype=torch.bfloat16) * 0.5
+
+    ref = _make_layer(
+        DiffusionQuarkW4A8Config(is_checkpoint_w4a8_serialized=True), in_features, out_features, bias=False
+    )
+    ref.weight.weight_loader(ref.weight, weight)
+    ref_out, _ = ref(x)
+
+    wq, ws = flydsl_w4a8.pack_weight_unshuffled(weight)
+    cfg = DiffusionQuarkW4A8Config(is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_unshuffled")
+    layer = _make_layer(cfg, in_features, out_features, bias=False)
+    assert isinstance(layer.quant_method, QuarkW4A8UnshuffledLinearMethod)
+    layer.weight_packed.data.copy_(wq)
+    layer.weight_scale.data.copy_(ws)
+    layer.quant_method.process_weights_after_loading(layer)
+
+    out, _ = layer(x)
+    assert torch.equal(out, ref_out)
+
+
+def test_svdquant_unshuffled_matches_packed_at_tp1():
+    from vllm_omni.quantization import flydsl_w4a8
+    from vllm_omni.quantization.quark_w4a8_config import (
+        DiffusionQuarkW4A8Config,
+        QuarkW4A8SVDUnshuffledLinearMethod,
+    )
+
+    in_features = out_features = 5120
+    rank = 32
+    torch.manual_seed(0)
+    weight, proj_up, proj_down = _spectral_weight(out_features, in_features, rank)
+    residual = (weight - proj_up @ proj_down).to(torch.bfloat16).contiguous()
+    proj_down = proj_down.to(torch.bfloat16).contiguous()
+    proj_up = proj_up.to(torch.bfloat16).contiguous()
+    x = torch.randn(M_RAGGED, in_features, device="cuda", dtype=torch.bfloat16) * 0.5
+
+    ref = _make_layer(
+        DiffusionQuarkW4A8Config(svd_rank=rank, is_checkpoint_w4a8_serialized=True),
+        in_features,
+        out_features,
+        bias=False,
+    )
+    ref.weight.data.copy_(residual)
+    ref.proj_down.data.copy_(proj_down)
+    ref.proj_up.data.copy_(proj_up)
+    ref.quant_method.process_weights_after_loading(ref)
+    ref_out, _ = ref(x)
+
+    wq, ws = flydsl_w4a8.pack_weight_unshuffled(residual)
+    cfg = DiffusionQuarkW4A8Config(
+        svd_rank=rank, is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_unshuffled"
+    )
+    layer = _make_layer(cfg, in_features, out_features, bias=False)
+    assert isinstance(layer.quant_method, QuarkW4A8SVDUnshuffledLinearMethod)
+    layer.weight_packed.data.copy_(wq)
+    layer.weight_scale.data.copy_(ws)
+    layer.proj_down.data.copy_(proj_down)
+    layer.proj_up.data.copy_(proj_up)
+    layer.quant_method.process_weights_after_loading(layer)
+
+    out, _ = layer(x)
+    assert torch.equal(out, ref_out)

--- a/tests/diffusion/quantization/test_flydsl_w4a8_rocm.py
+++ b/tests/diffusion/quantization/test_flydsl_w4a8_rocm.py
@@ -263,7 +263,7 @@ def test_svdquant_keeps_projections_after_packing():
     assert layer.weight is None
     assert layer.proj_down is not None
     assert layer.proj_up is not None
-    assert layer.svd_rank == 32
+    assert layer.quant_method.quant_config.svd_rank == 32
     # Derived at load from a BF16 checkpoint, so they are not checkpoint keys.
     assert "proj_down" not in layer.state_dict()
     assert "proj_up" not in layer.state_dict()
@@ -303,7 +303,7 @@ def test_plain_serialized_checkpoint_matches_bf16():
     it at load, exactly like the online path (which it subclasses)."""
     from vllm_omni.quantization.quark_w4a8_config import (
         DiffusionQuarkW4A8Config,
-        QuarkW4A8CheckpointLinearMethod,
+        QuarkW4A8LinearMethod,
     )
 
     in_features = out_features = 5120
@@ -314,7 +314,8 @@ def test_plain_serialized_checkpoint_matches_bf16():
     layer = _make_layer(
         DiffusionQuarkW4A8Config(is_checkpoint_w4a8_serialized=True), in_features, out_features, bias=False
     )
-    assert isinstance(layer.quant_method, QuarkW4A8CheckpointLinearMethod)
+    assert type(layer.quant_method) is QuarkW4A8LinearMethod
+    assert layer.quant_method.storage.name == "bf16"
     layer.weight.weight_loader(layer.weight, weight)  # lazy pack triggers here
 
     out, _ = layer(x)
@@ -328,7 +329,7 @@ def test_svdquant_serialized_checkpoint_matches_bf16():
     them) and its fused output must track the full-precision weight."""
     from vllm_omni.quantization.quark_w4a8_config import (
         DiffusionQuarkW4A8Config,
-        QuarkW4A8SVDCheckpointLinearMethod,
+        QuarkW4A8SVDLinearMethod,
     )
 
     in_features = out_features = 5120
@@ -340,7 +341,8 @@ def test_svdquant_serialized_checkpoint_matches_bf16():
 
     cfg = DiffusionQuarkW4A8Config(svd_rank=rank, is_checkpoint_w4a8_serialized=True)
     layer = _make_layer(cfg, in_features, out_features, bias=False)
-    assert isinstance(layer.quant_method, QuarkW4A8SVDCheckpointLinearMethod)
+    assert isinstance(layer.quant_method, QuarkW4A8SVDLinearMethod)
+    assert layer.quant_method.storage.name == "bf16"
 
     # Serialized create_weights registers real (non-meta) params; fill from "disk".
     layer.weight.data.copy_(residual)
@@ -365,7 +367,7 @@ def test_plain_packed_matches_bf16_at_load():
     from vllm_omni.quantization import flydsl_w4a8
     from vllm_omni.quantization.quark_w4a8_config import (
         DiffusionQuarkW4A8Config,
-        QuarkW4A8PackedLinearMethod,
+        QuarkW4A8LinearMethod,
     )
 
     in_features = out_features = 5120
@@ -382,7 +384,8 @@ def test_plain_packed_matches_bf16_at_load():
     packed, scale = flydsl_w4a8.pack_weight(weight)
     cfg = DiffusionQuarkW4A8Config(is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_packed")
     layer = _make_layer(cfg, in_features, out_features, bias=False)
-    assert isinstance(layer.quant_method, QuarkW4A8PackedLinearMethod)
+    assert type(layer.quant_method) is QuarkW4A8LinearMethod
+    assert layer.quant_method.storage.name == "mxfp4_packed"
     layer.weight_shuffle.data.copy_(packed)
     layer.weight_scale.data.copy_(scale)
     layer.quant_method.process_weights_after_loading(layer)
@@ -397,7 +400,7 @@ def test_svdquant_packed_matches_bf16_at_load():
     from vllm_omni.quantization import flydsl_w4a8
     from vllm_omni.quantization.quark_w4a8_config import (
         DiffusionQuarkW4A8Config,
-        QuarkW4A8SVDPackedLinearMethod,
+        QuarkW4A8SVDLinearMethod,
     )
 
     in_features = out_features = 5120
@@ -426,7 +429,8 @@ def test_svdquant_packed_matches_bf16_at_load():
         svd_rank=rank, is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_packed"
     )
     layer = _make_layer(cfg, in_features, out_features, bias=False)
-    assert isinstance(layer.quant_method, QuarkW4A8SVDPackedLinearMethod)
+    assert isinstance(layer.quant_method, QuarkW4A8SVDLinearMethod)
+    assert layer.quant_method.storage.name == "mxfp4_packed"
     layer.weight_shuffle.data.copy_(packed)
     layer.weight_scale.data.copy_(scale)
     layer.proj_down.data.copy_(proj_down)
@@ -460,7 +464,7 @@ def test_plain_unshuffled_matches_packed_at_tp1():
     from vllm_omni.quantization import flydsl_w4a8
     from vllm_omni.quantization.quark_w4a8_config import (
         DiffusionQuarkW4A8Config,
-        QuarkW4A8UnshuffledLinearMethod,
+        QuarkW4A8LinearMethod,
     )
 
     in_features = out_features = 5120
@@ -477,7 +481,8 @@ def test_plain_unshuffled_matches_packed_at_tp1():
     wq, ws = flydsl_w4a8.pack_weight_unshuffled(weight)
     cfg = DiffusionQuarkW4A8Config(is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_unshuffled")
     layer = _make_layer(cfg, in_features, out_features, bias=False)
-    assert isinstance(layer.quant_method, QuarkW4A8UnshuffledLinearMethod)
+    assert type(layer.quant_method) is QuarkW4A8LinearMethod
+    assert layer.quant_method.storage.name == "mxfp4_unshuffled"
     layer.weight_packed.data.copy_(wq)
     layer.weight_scale.data.copy_(ws)
     layer.quant_method.process_weights_after_loading(layer)
@@ -490,7 +495,7 @@ def test_svdquant_unshuffled_matches_packed_at_tp1():
     from vllm_omni.quantization import flydsl_w4a8
     from vllm_omni.quantization.quark_w4a8_config import (
         DiffusionQuarkW4A8Config,
-        QuarkW4A8SVDUnshuffledLinearMethod,
+        QuarkW4A8SVDLinearMethod,
     )
 
     in_features = out_features = 5120
@@ -519,7 +524,8 @@ def test_svdquant_unshuffled_matches_packed_at_tp1():
         svd_rank=rank, is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_unshuffled"
     )
     layer = _make_layer(cfg, in_features, out_features, bias=False)
-    assert isinstance(layer.quant_method, QuarkW4A8SVDUnshuffledLinearMethod)
+    assert isinstance(layer.quant_method, QuarkW4A8SVDLinearMethod)
+    assert layer.quant_method.storage.name == "mxfp4_unshuffled"
     layer.weight_packed.data.copy_(wq)
     layer.weight_scale.data.copy_(ws)
     layer.proj_down.data.copy_(proj_down)

--- a/tests/diffusion/quantization/test_flydsl_w4a8_rocm.py
+++ b/tests/diffusion/quantization/test_flydsl_w4a8_rocm.py
@@ -1,0 +1,437 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""gfx950 numerics for W4A8, plain and SVDQuant, through a real vLLM linear layer.
+
+Shapes are the production Wan2.2 TI2V-5B and T2V-A14B linear dimensions at the
+diffusion prefill token count (M ~ 4.7k). M is deliberately not a multiple of
+tile_m: the FlyDSL kernel does not mask ragged rows, so Quark pads M internally
+and slices back, and that padding is a correctness requirement rather than an
+optimization.
+
+Config routing and the capability gate are covered on CPU in
+test_quark_w4a8_config.py.
+"""
+
+import pytest
+import torch
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.rocm, pytest.mark.MI355]
+
+
+def _gcn_arch() -> str:
+    if not (torch.cuda.is_available() and torch.version.hip):
+        return ""
+    return torch.cuda.get_device_properties(torch.accelerator.current_device_index()).gcnArchName
+
+
+# Runtime gate, not just the MI355 marker: the marker only filters CI lanes, and
+# a local run on gfx942 would otherwise fail inside the MLIR backend.
+requires_gfx950 = pytest.mark.skipif(
+    "gfx950" not in _gcn_arch(),
+    reason=f"W4A8 requires CDNA4 scaled MFMA (gfx950); detected {_gcn_arch() or 'no ROCm device'}",
+)
+
+# Wan diffusion prefill is ~4.7k tokens. 4680 is not a multiple of 32 or 64, so
+# every case exercises the ragged-M padding path.
+M_RAGGED = 4680
+M_ALIGNED = 4736  # 74 * 64
+
+SHAPES_5B = [(3072, 3072), (3072, 14336), (14336, 3072), (4096, 3072)]
+SHAPES_A14B = [(5120, 5120), (5120, 13824), (13824, 5120), (4096, 5120)]
+
+pytestmark.append(requires_gfx950)
+
+
+@pytest.fixture(autouse=True)
+def _cuda_default_device():
+    """vLLM sets the accelerator as the default device before building a model.
+    _LazyWeightMixin captures torch.get_default_device() to materialise the
+    weight, so without this the BF16 copy lands on CPU and the kernel rejects it.
+    """
+    torch.set_default_device("cuda")
+    yield
+    torch.set_default_device("cpu")
+
+
+@pytest.fixture(autouse=True)
+def _patch_tp_state(monkeypatch):
+    """ModelWeightParameter reads the global TP rank in __init__. Patching it is
+    cheaper than standing up a process group for a single-device test."""
+    monkeypatch.setattr("vllm.model_executor.parameter.get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr("vllm.model_executor.parameter.get_tensor_model_parallel_world_size", lambda: 1)
+
+
+def _cos(a: torch.Tensor, b: torch.Tensor) -> float:
+    return torch.nn.functional.cosine_similarity(a.flatten().float(), b.flatten().float(), dim=0).item()
+
+
+def _make_layer(cfg, in_features: int, out_features: int, bias: bool = True):
+    from vllm.config import VllmConfig, set_current_vllm_config
+    from vllm.model_executor.layers.linear import ReplicatedLinear
+
+    with set_current_vllm_config(VllmConfig()):
+        return ReplicatedLinear(
+            input_size=in_features,
+            output_size=out_features,
+            bias=bias,
+            params_dtype=torch.bfloat16,
+            quant_config=cfg,
+            prefix="transformer.blocks.0.attn.to_q",
+            disable_tp=True,
+        )
+
+
+def _spectral_weight(out_features: int, in_features: int, rank: int, decay: float = 64.0):
+    """A weight with a decaying singular spectrum, plus its exact rank-R factors.
+
+    SVDQuant only helps when the top-R subspace carries real energy, which holds
+    for trained transformer weights and not for i.i.d. Gaussian noise. Building
+    ``U diag(s) V.T`` directly keeps the factors exact and avoids a second SVD.
+
+    Returns ``(W, L2, L1)`` with ``W ~= L2 @ L1 + residual``.
+    """
+    r = min(out_features, in_features)
+    u, _ = torch.linalg.qr(torch.randn(out_features, r, device="cuda", dtype=torch.float32))
+    v, _ = torch.linalg.qr(torch.randn(in_features, r, device="cuda", dtype=torch.float32))
+    s = torch.exp(-torch.arange(r, device="cuda", dtype=torch.float32) / decay)
+    w = (u * s) @ v.T
+    scale = 0.1 / w.std()
+    return w * scale, u[:, :rank] * s[:rank] * scale, v[:, :rank].T
+
+
+# ---------------------------------------------------------------------------
+# Plain W4A8
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shape", SHAPES_5B + SHAPES_A14B, ids=lambda s: f"{s[1]}x{s[0]}")
+@pytest.mark.parametrize("m", [M_RAGGED, M_ALIGNED], ids=["ragged", "aligned"])
+def test_plain_w4a8_matches_bf16(shape, m):
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    in_features, out_features = shape
+    torch.manual_seed(0)
+    weight = (torch.randn(out_features, in_features, device="cuda", dtype=torch.bfloat16) * 0.1).contiguous()
+    bias = (torch.randn(out_features, device="cuda", dtype=torch.bfloat16) * 0.05).contiguous()
+    x = torch.randn(m, in_features, device="cuda", dtype=torch.bfloat16) * 0.5
+
+    layer = _make_layer(DiffusionQuarkW4A8Config(), in_features, out_features)
+    layer.weight.weight_loader(layer.weight, weight)
+    layer.bias.data.copy_(bias)
+
+    out, _ = layer(x)
+    reference = torch.nn.functional.linear(x.float(), weight.float(), bias.float())
+
+    assert out.shape == (m, out_features)
+    assert out.dtype == torch.bfloat16
+    assert torch.isfinite(out).all()
+    assert _cos(out, reference) > 0.98
+
+
+def test_plain_w4a8_applies_bias():
+    """The bias must reach the GEMM epilogue, not just the call signature.
+
+    Quark's entrypoint gates the bias operand on ``bias is not None and
+    epilogue != "none"``, so handing it a bias without also asking for the bias
+    epilogue drops it silently. A small bias hides inside the cosine tolerance
+    of the shape sweep above -- this compares the two calls directly instead,
+    with a bias large enough to dominate, which is what a diffusion
+    transformer's modulation projections actually look like.
+    """
+    from vllm_omni.quantization import flydsl_w4a8
+
+    flydsl_w4a8.register_ops()
+    in_features, out_features, m = 3072, 3072, M_ALIGNED
+    torch.manual_seed(0)
+    weight = (torch.randn(out_features, in_features, device="cuda", dtype=torch.bfloat16) * 0.1).contiguous()
+    bias = torch.randn(out_features, device="cuda", dtype=torch.bfloat16).contiguous()
+    x = torch.randn(m, in_features, device="cuda", dtype=torch.bfloat16) * 0.5
+    packed, scale = flydsl_w4a8.pack_weight(weight)
+
+    with_bias = torch.ops.vllm_omni.flydsl_w4a8_gemm(x, packed, scale, bias, out_features)
+    without_bias = torch.ops.vllm_omni.flydsl_w4a8_gemm(x, packed, scale, None, out_features)
+
+    # The only difference between the two calls is the bias row-broadcast, so
+    # their difference must be the bias itself. Both outputs are separately
+    # rounded to bf16 (8 mantissa bits), so allow two ULPs at the output scale.
+    delta = (with_bias.float() - without_bias.float()) - bias.float()
+    tolerance = with_bias.abs().max().item() * 2**-7
+    assert delta.abs().max().item() < tolerance
+
+    reference = torch.nn.functional.linear(x.float(), weight.float(), bias.float())
+    assert _cos(with_bias, reference) > 0.98
+    assert _cos(without_bias, reference) < 0.95
+
+
+def test_plain_w4a8_frees_bf16_weight():
+    """A14B holds both experts resident, so the BF16 copy must go at load time,
+    and the kernel buffers must stay out of the state dict."""
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    layer = _make_layer(DiffusionQuarkW4A8Config(), 5120, 5120)
+    assert layer.weight.device.type == "meta"
+
+    layer.weight.weight_loader(layer.weight, torch.randn(5120, 5120, device="cuda", dtype=torch.bfloat16) * 0.1)
+
+    assert layer.weight is None
+    assert layer._kernel_weight.dtype == torch.uint8
+    assert layer._kernel_scale.dtype == torch.uint8
+    assert "_kernel_weight" not in layer.state_dict()
+    assert "_kernel_scale" not in layer.state_dict()
+
+
+def test_plain_w4a8_reshapes_3d_activations():
+    """Diffusion activations arrive as (B, T, K); the reshape lives in
+    MXFPLinearMethodBase.apply() and must not change the result."""
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    torch.manual_seed(0)
+    layer = _make_layer(DiffusionQuarkW4A8Config(), 3072, 3072)
+    layer.weight.weight_loader(layer.weight, torch.randn(3072, 3072, device="cuda", dtype=torch.bfloat16) * 0.1)
+    x = torch.randn(M_RAGGED, 3072, device="cuda", dtype=torch.bfloat16) * 0.5
+
+    out_2d, _ = layer(x)
+    out_3d, _ = layer(x.view(6, M_RAGGED // 6, 3072))
+
+    assert out_3d.shape == (6, M_RAGGED // 6, 3072)
+    assert torch.equal(out_3d.reshape(M_RAGGED, 3072), out_2d)
+
+
+def test_plain_w4a8_is_deterministic():
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    torch.manual_seed(0)
+    layer = _make_layer(DiffusionQuarkW4A8Config(), 5120, 5120)
+    layer.weight.weight_loader(layer.weight, torch.randn(5120, 5120, device="cuda", dtype=torch.bfloat16) * 0.1)
+    x = torch.randn(M_RAGGED, 5120, device="cuda", dtype=torch.bfloat16) * 0.5
+
+    first, _ = layer(x)
+    for _ in range(2):
+        again, _ = layer(x)
+        assert torch.equal(first, again)
+
+
+# ---------------------------------------------------------------------------
+# SVDQuant W4A8
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shape", [(3072, 3072), (5120, 5120), (5120, 13824)], ids=lambda s: f"{s[1]}x{s[0]}")
+@pytest.mark.parametrize("rank", [16, 32])
+def test_svdquant_beats_plain_w4a8(shape, rank):
+    """The low-rank branch exists to absorb the weight's dominant directions, so
+    it must be at least as accurate as quantizing the full weight outright."""
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    in_features, out_features = shape
+    torch.manual_seed(0)
+    w32, _, _ = _spectral_weight(out_features, in_features, rank)
+    weight = w32.to(torch.bfloat16).contiguous()
+    bias = (torch.randn(out_features, device="cuda", dtype=torch.bfloat16) * 0.05).contiguous()
+    x = torch.randn(M_RAGGED, in_features, device="cuda", dtype=torch.bfloat16) * 0.5
+
+    # Both variants are handed the same full BF16 weight; the SVD variant splits
+    # off its own low-rank term at load, exactly as it does from a checkpoint.
+    svd_layer = _make_layer(DiffusionQuarkW4A8Config(svd_rank=rank), in_features, out_features)
+    svd_layer.weight.weight_loader(svd_layer.weight, weight)
+    svd_layer.bias.data.copy_(bias)
+    assert svd_layer.proj_down.shape == (rank, in_features)
+    assert svd_layer.proj_up.shape == (out_features, rank)
+
+    plain_layer = _make_layer(DiffusionQuarkW4A8Config(), in_features, out_features)
+    plain_layer.weight.weight_loader(plain_layer.weight, weight)
+    plain_layer.bias.data.copy_(bias)
+
+    reference = torch.nn.functional.linear(x.float(), weight.float(), bias.float())
+    svd_out, _ = svd_layer(x)
+    plain_out, _ = plain_layer(x)
+
+    assert torch.isfinite(svd_out).all()
+    svd_cos, plain_cos = _cos(svd_out, reference), _cos(plain_out, reference)
+    assert svd_cos > 0.98
+    assert svd_cos >= plain_cos, f"svd={svd_cos:.5f} plain={plain_cos:.5f}"
+
+
+def test_svdquant_keeps_projections_after_packing():
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    torch.manual_seed(0)
+    weight = (torch.randn(5120, 5120, device="cuda", dtype=torch.bfloat16) * 0.1).contiguous()
+    layer = _make_layer(DiffusionQuarkW4A8Config(svd_rank=32), 5120, 5120)
+    layer.weight.weight_loader(layer.weight, weight)
+
+    assert layer.weight is None
+    assert layer.proj_down is not None
+    assert layer.proj_up is not None
+    assert layer.svd_rank == 32
+    # Derived at load from a BF16 checkpoint, so they are not checkpoint keys.
+    assert "proj_down" not in layer.state_dict()
+    assert "proj_up" not in layer.state_dict()
+
+
+def test_svdquant_fused_matches_unfused():
+    """QUARK_SVDQUANT_FUSED is not consulted here; instead compare the fused
+    epilogue against plain-GEMM-plus-low-rank-add computed in torch."""
+    from vllm_omni.quantization import flydsl_w4a8
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    in_features = out_features = 5120
+    rank = 32
+    torch.manual_seed(0)
+    weight, _, _ = _spectral_weight(out_features, in_features, rank)
+    x = torch.randn(M_RAGGED, in_features, device="cuda", dtype=torch.bfloat16) * 0.5
+
+    layer = _make_layer(DiffusionQuarkW4A8Config(svd_rank=rank), in_features, out_features, bias=False)
+    layer.weight.weight_loader(layer.weight, weight.to(torch.bfloat16).contiguous())
+
+    fused, _ = layer(x)
+    flydsl_w4a8.register_ops()
+    unfused = torch.ops.vllm_omni.flydsl_w4a8_gemm(
+        x, layer._kernel_weight, layer._kernel_scale, None, out_features
+    ).float() + (torch.nn.functional.linear(x, layer.proj_down).float() @ layer.proj_up.float().T)
+
+    assert _cos(fused, unfused) > 0.999
+
+
+# ---------------------------------------------------------------------------
+# Serialized checkpoints (offline calibrated export)
+# ---------------------------------------------------------------------------
+
+
+def test_plain_serialized_checkpoint_matches_bf16():
+    """A plain serialized checkpoint loads a real BF16 weight from disk and packs
+    it at load, exactly like the online path (which it subclasses)."""
+    from vllm_omni.quantization.quark_w4a8_config import (
+        DiffusionQuarkW4A8Config,
+        QuarkW4A8CheckpointLinearMethod,
+    )
+
+    in_features = out_features = 5120
+    torch.manual_seed(0)
+    weight = (torch.randn(out_features, in_features, device="cuda", dtype=torch.bfloat16) * 0.1).contiguous()
+    x = torch.randn(M_RAGGED, in_features, device="cuda", dtype=torch.bfloat16) * 0.5
+
+    layer = _make_layer(
+        DiffusionQuarkW4A8Config(is_checkpoint_w4a8_serialized=True), in_features, out_features, bias=False
+    )
+    assert isinstance(layer.quant_method, QuarkW4A8CheckpointLinearMethod)
+    layer.weight.weight_loader(layer.weight, weight)  # lazy pack triggers here
+
+    out, _ = layer(x)
+    reference = torch.nn.functional.linear(x.float(), weight.float())
+    assert torch.isfinite(out).all()
+    assert _cos(out, reference) > 0.98
+
+
+def test_svdquant_serialized_checkpoint_matches_bf16():
+    """The SVD checkpoint method loads on-disk proj_down/proj_up (does NOT derive
+    them) and its fused output must track the full-precision weight."""
+    from vllm_omni.quantization.quark_w4a8_config import (
+        DiffusionQuarkW4A8Config,
+        QuarkW4A8SVDCheckpointLinearMethod,
+    )
+
+    in_features = out_features = 5120
+    rank = 32
+    torch.manual_seed(0)
+    weight, proj_up, proj_down = _spectral_weight(out_features, in_features, rank)
+    residual = (weight - proj_up @ proj_down).to(torch.bfloat16).contiguous()
+    x = torch.randn(M_RAGGED, in_features, device="cuda", dtype=torch.bfloat16) * 0.5
+
+    cfg = DiffusionQuarkW4A8Config(svd_rank=rank, is_checkpoint_w4a8_serialized=True)
+    layer = _make_layer(cfg, in_features, out_features, bias=False)
+    assert isinstance(layer.quant_method, QuarkW4A8SVDCheckpointLinearMethod)
+
+    # Serialized create_weights registers real (non-meta) params; fill from "disk".
+    layer.weight.data.copy_(residual)
+    layer.proj_down.data.copy_(proj_down.to(torch.bfloat16))
+    layer.proj_up.data.copy_(proj_up.to(torch.bfloat16))
+    layer.quant_method.process_weights_after_loading(layer)
+
+    assert layer.weight is None  # residual packed and dropped
+    assert layer.proj_down.shape == (rank, in_features)
+    assert layer.proj_up.shape == (out_features, rank)
+
+    out, _ = layer(x)
+    reference = torch.nn.functional.linear(x.float(), weight.float())
+    assert torch.isfinite(out).all()
+    assert _cos(out, reference) > 0.98
+
+
+def test_plain_packed_matches_bf16_at_load():
+    """A pre-packed checkpoint stores exactly what pack_weight emits, and the
+    bf16-at-load path calls the same pack_weight at load, so the two are
+    bit-identical."""
+    from vllm_omni.quantization import flydsl_w4a8
+    from vllm_omni.quantization.quark_w4a8_config import (
+        DiffusionQuarkW4A8Config,
+        QuarkW4A8PackedLinearMethod,
+    )
+
+    in_features = out_features = 5120
+    torch.manual_seed(0)
+    weight = (torch.randn(out_features, in_features, device="cuda", dtype=torch.bfloat16) * 0.1).contiguous()
+    x = torch.randn(M_RAGGED, in_features, device="cuda", dtype=torch.bfloat16) * 0.5
+
+    ref_layer = _make_layer(
+        DiffusionQuarkW4A8Config(is_checkpoint_w4a8_serialized=True), in_features, out_features, bias=False
+    )
+    ref_layer.weight.weight_loader(ref_layer.weight, weight)  # packs at load
+    ref_out, _ = ref_layer(x)
+
+    packed, scale = flydsl_w4a8.pack_weight(weight)
+    cfg = DiffusionQuarkW4A8Config(is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_packed")
+    layer = _make_layer(cfg, in_features, out_features, bias=False)
+    assert isinstance(layer.quant_method, QuarkW4A8PackedLinearMethod)
+    layer.weight_shuffle.data.copy_(packed)
+    layer.weight_scale.data.copy_(scale)
+    layer.quant_method.process_weights_after_loading(layer)
+
+    out, _ = layer(x)
+    assert torch.equal(out, ref_out)
+
+
+def test_svdquant_packed_matches_bf16_at_load():
+    """The packed SVD path loads the packed residual + BF16 factors and must equal
+    the bf16-at-load serialized SVD path on the same tensors."""
+    from vllm_omni.quantization import flydsl_w4a8
+    from vllm_omni.quantization.quark_w4a8_config import (
+        DiffusionQuarkW4A8Config,
+        QuarkW4A8SVDPackedLinearMethod,
+    )
+
+    in_features = out_features = 5120
+    rank = 32
+    torch.manual_seed(0)
+    weight, proj_up, proj_down = _spectral_weight(out_features, in_features, rank)
+    residual = (weight - proj_up @ proj_down).to(torch.bfloat16).contiguous()
+    proj_down = proj_down.to(torch.bfloat16).contiguous()
+    proj_up = proj_up.to(torch.bfloat16).contiguous()
+    x = torch.randn(M_RAGGED, in_features, device="cuda", dtype=torch.bfloat16) * 0.5
+
+    ref = _make_layer(
+        DiffusionQuarkW4A8Config(svd_rank=rank, is_checkpoint_w4a8_serialized=True),
+        in_features,
+        out_features,
+        bias=False,
+    )
+    ref.weight.data.copy_(residual)
+    ref.proj_down.data.copy_(proj_down)
+    ref.proj_up.data.copy_(proj_up)
+    ref.quant_method.process_weights_after_loading(ref)
+    ref_out, _ = ref(x)
+
+    packed, scale = flydsl_w4a8.pack_weight(residual)
+    cfg = DiffusionQuarkW4A8Config(
+        svd_rank=rank, is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_packed"
+    )
+    layer = _make_layer(cfg, in_features, out_features, bias=False)
+    assert isinstance(layer.quant_method, QuarkW4A8SVDPackedLinearMethod)
+    layer.weight_shuffle.data.copy_(packed)
+    layer.weight_scale.data.copy_(scale)
+    layer.proj_down.data.copy_(proj_down)
+    layer.proj_up.data.copy_(proj_up)
+    layer.quant_method.process_weights_after_loading(layer)
+
+    out, _ = layer(x)
+    assert torch.equal(out, ref_out)

--- a/tests/diffusion/quantization/test_flydsl_w4a8_tp_rocm.py
+++ b/tests/diffusion/quantization/test_flydsl_w4a8_tp_rocm.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Tensor-parallel correctness for W4A8 SVDQuant on gfx950.
+
+Two layers of testing:
+
+* **Decomposition tests** (single GPU): simulate TP by manually splitting a
+  layer's K (row-parallel) or N (column-parallel) and driving the fused
+  ``flydsl_w4a8_svd_gemm`` per shard, then reduce/concatenate. This proves the
+  linearity claim behind row-parallel SVD -- the per-rank partial
+  ``d_p @ proj_up.T`` sums with the residual under the output all-reduce -- with
+  no process group, so it runs on the dev box.
+
+* **Multi-GPU test** (>= 2 GPUs): spawns a real TP group and runs a
+  ``RowParallelLinear`` end to end. Skipped unless ``torch.accelerator.device_count()
+  >= 2``; run it on a multi-GPU server. Set ``W4A8_TP_SIZE`` to override the
+  world size (default 2).
+"""
+
+import os
+
+import pytest
+import torch
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.rocm, pytest.mark.MI355]
+
+
+def _gcn_arch() -> str:
+    if not (torch.cuda.is_available() and torch.version.hip):
+        return ""
+    return torch.cuda.get_device_properties(torch.accelerator.current_device_index()).gcnArchName
+
+
+requires_gfx950 = pytest.mark.skipif(
+    "gfx950" not in _gcn_arch(),
+    reason=f"W4A8 requires CDNA4 scaled MFMA (gfx950); detected {_gcn_arch() or 'no ROCm device'}",
+)
+pytestmark.append(requires_gfx950)
+
+M_RAGGED = 4680
+
+
+def _cos(a: torch.Tensor, b: torch.Tensor) -> float:
+    return torch.nn.functional.cosine_similarity(a.flatten().float(), b.flatten().float(), dim=0).item()
+
+
+def _spectral_factors(out_features: int, in_features: int, rank: int, decay: float = 64.0):
+    """A weight with a decaying spectrum plus its exact rank-R factors.
+
+    Returns ``(W, proj_up (N, R), proj_down (R, K))`` with ``W = proj_up @ proj_down + residual``.
+    """
+    r = min(out_features, in_features)
+    u, _ = torch.linalg.qr(torch.randn(out_features, r, device="cuda", dtype=torch.float32))
+    v, _ = torch.linalg.qr(torch.randn(in_features, r, device="cuda", dtype=torch.float32))
+    s = torch.exp(-torch.arange(r, device="cuda", dtype=torch.float32) / decay)
+    w = (u * s) @ v.T
+    scale = 0.1 / w.std()
+    return w * scale, (u[:, :rank] * s[:rank] * scale).contiguous(), v[:, :rank].T.contiguous()
+
+
+# ---------------------------------------------------------------------------
+# Single-GPU decomposition tests (prove the sharding math)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tp", [2, 4])
+def test_svd_row_parallel_decomposition_matches_full(tp):
+    """Row-parallel (K sharded): each rank runs the fused op on its (Wr_p, L1_p)
+    shard with a *replicated* proj_up, and the sum of partials (the output
+    all-reduce) equals the un-sharded fused result. K/tp is a multiple of 32, so
+    per-shard MXFP8 activation quant matches the full one exactly."""
+    from vllm_omni.quantization import flydsl_w4a8
+
+    flydsl_w4a8.register_ops()
+    in_features = out_features = 5120
+    rank = 32
+    torch.manual_seed(0)
+    weight, proj_up, proj_down = _spectral_factors(out_features, in_features, rank)
+    residual = (weight - proj_up @ proj_down).to(torch.bfloat16).contiguous()
+    proj_up = proj_up.to(torch.bfloat16)  # replicated across ranks
+    proj_down = proj_down.to(torch.bfloat16)
+    x = torch.randn(M_RAGGED, in_features, device="cuda", dtype=torch.bfloat16) * 0.5
+
+    kw, ks = flydsl_w4a8.pack_weight(residual)
+    full = torch.ops.vllm_omni.flydsl_w4a8_svd_gemm(x, kw, ks, proj_down, proj_up, None, out_features)
+
+    ksz = in_features // tp
+    summed = torch.zeros(M_RAGGED, out_features, device="cuda", dtype=torch.float32)
+    for p in range(tp):
+        sl = slice(p * ksz, (p + 1) * ksz)
+        kw_p, ks_p = flydsl_w4a8.pack_weight(residual[:, sl].contiguous())
+        y_p = torch.ops.vllm_omni.flydsl_w4a8_svd_gemm(
+            x[:, sl].contiguous(),
+            kw_p,
+            ks_p,
+            proj_down[:, sl].contiguous(),  # L1 sharded on K
+            proj_up,  # L2 replicated
+            None,
+            out_features,
+        )
+        summed += y_p.float()
+
+    assert torch.isfinite(summed).all()
+    assert _cos(summed, full) > 0.999
+
+
+@pytest.mark.parametrize("tp", [2, 4])
+def test_svd_column_parallel_decomposition_matches_full(tp):
+    """Column-parallel (N sharded): each rank runs the fused op on its (Wr_n, L2_n)
+    shard with a *replicated* proj_down, and concatenating the partials along N
+    equals the un-sharded fused result."""
+    from vllm_omni.quantization import flydsl_w4a8
+
+    flydsl_w4a8.register_ops()
+    in_features = out_features = 5120
+    rank = 32
+    torch.manual_seed(0)
+    weight, proj_up, proj_down = _spectral_factors(out_features, in_features, rank)
+    residual = (weight - proj_up @ proj_down).to(torch.bfloat16).contiguous()
+    proj_up = proj_up.to(torch.bfloat16)
+    proj_down = proj_down.to(torch.bfloat16)  # replicated across ranks
+    x = torch.randn(M_RAGGED, in_features, device="cuda", dtype=torch.bfloat16) * 0.5
+
+    kw, ks = flydsl_w4a8.pack_weight(residual)
+    full = torch.ops.vllm_omni.flydsl_w4a8_svd_gemm(x, kw, ks, proj_down, proj_up, None, out_features)
+
+    nsz = out_features // tp
+    parts = []
+    for p in range(tp):
+        sl = slice(p * nsz, (p + 1) * nsz)
+        kw_n, ks_n = flydsl_w4a8.pack_weight(residual[sl, :].contiguous())
+        y_n = torch.ops.vllm_omni.flydsl_w4a8_svd_gemm(
+            x,
+            kw_n,
+            ks_n,
+            proj_down,  # L1 replicated
+            proj_up[sl, :].contiguous(),  # L2 sharded on N
+            None,
+            nsz,
+        )
+        parts.append(y_n)
+
+    cat = torch.cat(parts, dim=1)
+    assert cat.shape == (M_RAGGED, out_features)
+    assert _cos(cat, full) > 0.999
+
+
+# ---------------------------------------------------------------------------
+# Real multi-GPU test (run on a >= 2 GPU server)
+# ---------------------------------------------------------------------------
+
+
+def _row_parallel_tp_worker(rank: int, world_size: int, port: int, return_dict) -> None:
+    """Build a RowParallelLinear (quark_svdquant + mxfp4_unshuffled) at the given
+    TP rank, load a sharded checkpoint, run forward, and record the output.
+
+    Runs in a spawned process. The full reference weight is reproduced identically
+    on every rank from a fixed seed, decomposed + packed unshuffled, then loaded
+    through the layer's own weight_loaders (which slice per rank on the K axis for
+    row-parallel). ``process_weights_after_loading`` shuffles each rank's shard.
+    """
+    from vllm.config import VllmConfig, set_current_vllm_config
+    from vllm.distributed import init_distributed_environment, initialize_model_parallel
+    from vllm.model_executor.layers.linear import RowParallelLinear
+
+    from vllm_omni.quantization import flydsl_w4a8
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    torch.accelerator.set_device_index(rank)
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    init_distributed_environment(world_size=world_size, rank=rank, local_rank=rank, backend="nccl")
+    initialize_model_parallel(tensor_model_parallel_size=world_size)
+
+    in_features = out_features = 5120
+    svd_rank = 32
+    torch.manual_seed(0)  # identical full weight on every rank
+    weight, proj_up, proj_down = _spectral_factors(out_features, in_features, svd_rank)
+    residual = (weight - proj_up @ proj_down).to(torch.bfloat16).contiguous()
+    w_q, w_s = flydsl_w4a8.pack_weight_unshuffled(residual)  # full, natural-order
+
+    cfg = DiffusionQuarkW4A8Config(
+        svd_rank=svd_rank, is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_unshuffled"
+    )
+    with set_current_vllm_config(VllmConfig()):
+        layer = RowParallelLinear(
+            input_size=in_features,
+            output_size=out_features,
+            bias=False,
+            input_is_parallel=True,
+            params_dtype=torch.bfloat16,
+            quant_config=cfg,
+            prefix="transformer.blocks.0.ffn.net_2",
+        )
+
+    # Load the full tensors through each param's weight_loader; RowParallelLinear
+    # slices the input (K) axis for this rank. proj_up replicates, proj_down shards.
+    layer.weight_packed.weight_loader(layer.weight_packed, w_q)
+    layer.weight_scale.weight_loader(layer.weight_scale, w_s)
+    layer.proj_up.weight_loader(layer.proj_up, proj_up.to(torch.bfloat16))
+    layer.proj_down.weight_loader(layer.proj_down, proj_down.to(torch.bfloat16))
+    layer.quant_method.process_weights_after_loading(layer)
+
+    torch.manual_seed(1234)  # identical input on every rank
+    x_full = torch.randn(M_RAGGED, in_features, device="cuda", dtype=torch.bfloat16) * 0.5
+    ksz = in_features // world_size
+    x_shard = x_full[:, rank * ksz : (rank + 1) * ksz].contiguous()
+
+    out, _ = layer(x_shard)  # RowParallelLinear all-reduces internally
+    if rank == 0:
+        reference = torch.nn.functional.linear(x_full.float(), weight.float())
+        return_dict["cos"] = _cos(out, reference)
+        return_dict["finite"] = bool(torch.isfinite(out).all())
+        return_dict["shape"] = tuple(out.shape)
+
+
+@pytest.mark.skipif(
+    torch.accelerator.device_count() < 2,
+    reason="real TP test needs >= 2 GPUs; run on a multi-GPU server",
+)
+def test_svd_row_parallel_end_to_end_multigpu():
+    """End-to-end row-parallel SVD through a real RowParallelLinear + TP group.
+
+    Compares the reduced quantized output against the full-precision BF16 result;
+    a broken all-reduce or wrongly sharded factor would produce garbage (cos far below
+    the quant-error budget), so cos > 0.95 is a meaningful integration check.
+    """
+    import torch.multiprocessing as mp
+
+    world_size = int(os.environ.get("W4A8_TP_SIZE", "2"))
+    if torch.accelerator.device_count() < world_size:
+        pytest.skip(f"need {world_size} GPUs, have {torch.accelerator.device_count()}")
+
+    manager = mp.get_context("spawn").Manager()
+    return_dict = manager.dict()
+    mp.spawn(
+        _row_parallel_tp_worker,
+        args=(world_size, 29517, return_dict),
+        nprocs=world_size,
+        join=True,
+    )
+
+    assert return_dict.get("finite") is True
+    assert return_dict.get("shape") == (M_RAGGED, 5120)
+    assert return_dict.get("cos", 0.0) > 0.95, f"row-parallel TP cos={return_dict.get('cos')}"

--- a/tests/diffusion/quantization/test_quark_w4a8_config.py
+++ b/tests/diffusion/quantization/test_quark_w4a8_config.py
@@ -1,0 +1,449 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""CPU tests for the W4A8 (MXFP4 weight / MXFP8 activation) quantization config.
+
+Numerics live in test_flydsl_w4a8_rocm.py, which needs a gfx950 device. Here we
+cover config parsing, factory registration, layer routing and the capability
+gate — all of which must behave sanely on a machine with no AMD GPU at all.
+"""
+
+import pytest
+import torch
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+@pytest.fixture(autouse=True)
+def _patch_tp_state(monkeypatch):
+    """Patch TP rank/world_size so ModelWeightParameter can be instantiated on CPU
+    without an initialized distributed group.  Returns TP=1 rank=0 for all tests."""
+    monkeypatch.setattr("vllm.model_executor.parameter.get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr("vllm.model_executor.parameter.get_tensor_model_parallel_world_size", lambda: 1)
+
+
+@pytest.fixture(autouse=True)
+def _clear_backend_caches():
+    """supports() and _provider() are lru_cached; a stale entry would leak the
+    real machine's capability answer into tests that patch it."""
+    from vllm_omni.quantization import flydsl_w4a8
+
+    flydsl_w4a8.supports.cache_clear()
+    flydsl_w4a8._provider.cache_clear()
+    yield
+    flydsl_w4a8.supports.cache_clear()
+    flydsl_w4a8._provider.cache_clear()
+
+
+def _fake_linear(in_features: int, out_features: int):
+    """A LinearBase instance without running __init__.
+
+    LinearBase.__init__ calls get_quant_method() itself, so it cannot be used to
+    build the input to a get_quant_method() test. Only input_size/output_size are
+    read during routing.
+    """
+    from vllm.model_executor.layers.linear import ReplicatedLinear
+
+    layer = object.__new__(ReplicatedLinear)
+    layer.input_size = in_features
+    layer.output_size = out_features
+    return layer
+
+
+@pytest.fixture
+def _supported(monkeypatch):
+    """Pretend the machine is a gfx950 with a working kernel provider."""
+    from vllm_omni.quantization import flydsl_w4a8
+
+    monkeypatch.setattr(flydsl_w4a8, "supports", lambda: (True, ""))
+
+
+# ---------------------------------------------------------------------------
+# DiffusionQuarkW4A8Config parsing
+# ---------------------------------------------------------------------------
+
+
+def test_get_name():
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    assert DiffusionQuarkW4A8Config.get_name() == "quark_w4a8"
+
+
+def test_from_config_defaults():
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    cfg = DiffusionQuarkW4A8Config.from_config({})
+    assert cfg.svd_rank is None
+    assert cfg.ignored_layers == []
+    assert cfg.is_checkpoint_w4a8_serialized is False
+
+
+@pytest.mark.parametrize("key", ["svd_rank", "rank"])
+def test_from_config_svd_rank_keys(key):
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    assert DiffusionQuarkW4A8Config.from_config({key: 16}).svd_rank == 16
+
+
+@pytest.mark.parametrize("key", ["ignored_layers", "modules_to_not_convert"])
+def test_from_config_ignored_layer_keys(key):
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    assert DiffusionQuarkW4A8Config.from_config({key: ["proj_out"]}).ignored_layers == ["proj_out"]
+
+
+def test_from_config_ignores_unknown_keys():
+    """Checkpoint config.json carries keys this scheme does not consume."""
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    cfg = DiffusionQuarkW4A8Config.from_config({"quant_algo": "MXFP4", "producer": {"name": "quark"}})
+    assert cfg.svd_rank is None
+
+
+@pytest.mark.parametrize("bad", [0, -1])
+def test_non_positive_svd_rank_rejected(bad):
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    with pytest.raises(ValueError, match="positive integer"):
+        DiffusionQuarkW4A8Config(svd_rank=bad)
+
+
+def test_act_dtypes_bf16_only():
+    """The kernel emits bf16 and quantizes its own activations; accepting fp16
+    would silently round-trip through bf16."""
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    assert DiffusionQuarkW4A8Config.get_supported_act_dtypes() == [torch.bfloat16]
+
+
+def test_apply_vllm_mapper_rewrites_ignored_layers():
+    from vllm.model_executor.models.utils import WeightsMapper
+
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    cfg = DiffusionQuarkW4A8Config(ignored_layers=["blocks.0.proj_out"])
+    cfg.apply_vllm_mapper(WeightsMapper(orig_to_new_prefix={"blocks.": "layers."}))
+    assert cfg.ignored_layers == ["layers.0.proj_out"]
+
+
+# ---------------------------------------------------------------------------
+# Factory registration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("method", "expected_rank"),
+    [("quark_w4a8", None), ("quark-w4a8", None), ("quark_svdquant", 32)],
+)
+def test_build_quant_config(method, expected_rank):
+    from vllm_omni.quantization import build_quant_config
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    cfg = build_quant_config(method)
+    assert isinstance(cfg, DiffusionQuarkW4A8Config)
+    assert cfg.svd_rank == expected_rank
+
+
+def test_quark_svdquant_respects_explicit_rank():
+    from vllm_omni.quantization import build_quant_config
+
+    cfg = build_quant_config({"method": "quark_svdquant", "svd_rank": 16})
+    assert cfg.svd_rank == 16
+
+
+def test_methods_registered():
+    from vllm_omni.quantization import SUPPORTED_QUANTIZATION_METHODS
+
+    assert "quark_w4a8" in SUPPORTED_QUANTIZATION_METHODS
+    assert "quark_svdquant" in SUPPORTED_QUANTIZATION_METHODS
+
+
+def test_bare_svdquant_name_not_claimed():
+    """Upstream vLLM PR #3830 uses "svdquant" for Nunchaku; taking it here would
+    shadow that method once it lands."""
+    from vllm_omni.quantization.factory import _OVERRIDES
+
+    assert "svdquant" not in _OVERRIDES
+
+
+def test_importing_quantization_package_does_not_import_quark():
+    """Quark is an optional, heavy dependency. It must only load on gfx950 when a
+    W4A8 layer is actually constructed."""
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import sys, vllm_omni.quantization; print('quark' in sys.modules)"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip().endswith("False"), result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Capability gate
+# ---------------------------------------------------------------------------
+
+
+def test_supports_returns_reason_off_rocm(monkeypatch):
+    from vllm_omni.quantization import flydsl_w4a8
+
+    monkeypatch.setattr(flydsl_w4a8, "current_omni_platform", None, raising=False)
+    monkeypatch.setattr("vllm_omni.platforms.current_omni_platform.is_rocm", lambda: False)
+
+    usable, reason = flydsl_w4a8.supports()
+    assert usable is False
+    assert "ROCm" in reason
+
+
+def test_unknown_provider_is_a_config_error(monkeypatch):
+    """A typo in VLLM_OMNI_SVDQUANT_PROVIDER is misconfiguration, not a missing
+    capability, so it must raise rather than silently disable the backend."""
+    from vllm_omni.quantization import flydsl_w4a8
+
+    monkeypatch.setenv("VLLM_OMNI_SVDQUANT_PROVIDER", "nope")
+    with pytest.raises(ValueError, match="VLLM_OMNI_SVDQUANT_PROVIDER"):
+        flydsl_w4a8._provider()
+
+
+def test_flydsl_provider_not_available_yet(monkeypatch):
+    from vllm_omni.quantization import flydsl_w4a8
+
+    monkeypatch.setenv("VLLM_OMNI_SVDQUANT_PROVIDER", "flydsl")
+    with pytest.raises(ImportError, match="does not package its kernels"):
+        flydsl_w4a8._provider()
+
+
+@pytest.mark.parametrize(
+    ("in_f", "out_f", "plain", "svd"),
+    [
+        (5120, 5120, True, True),
+        (3072, 3072, True, True),
+        (3072, 192, True, False),  # Wan proj_out: tileable at 32, refused by SVD
+        (5120, 13824, True, True),  # A14B ffn up: 13824 == 54 * 256
+        (3072, 100, False, False),
+        (100, 3072, False, False),
+        # K carries the packed-scale constraint, not just a tiling one: Quark's
+        # _validate_a8w4_inputs raises below 256, and _pack_weight_asm quietly
+        # emits an unshuffled layout the preshuffle kernel cannot read.
+        (128, 3072, False, False),
+        (1152, 3072, False, False),  # 1152 % 32 == 0 but 1152 % 256 == 128
+        (256, 3072, True, True),
+    ],
+)
+def test_shape_gates(in_f, out_f, plain, svd):
+    from vllm_omni.quantization import flydsl_w4a8
+
+    assert flydsl_w4a8.supports_shape(in_f, out_f) is plain
+    assert flydsl_w4a8.supports_svd_shape(in_f, out_f) is svd
+
+
+# ---------------------------------------------------------------------------
+# get_quant_method routing
+# ---------------------------------------------------------------------------
+
+
+def test_non_linear_layer_returns_none():
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    assert DiffusionQuarkW4A8Config().get_quant_method(torch.nn.LayerNorm(8), "norm") is None
+
+
+def test_plain_routes_to_online_method(_supported):
+    from vllm_omni.quantization.quark_w4a8_config import (
+        DiffusionQuarkW4A8Config,
+        QuarkW4A8OnlineLinearMethod,
+    )
+
+    method = DiffusionQuarkW4A8Config().get_quant_method(_fake_linear(5120, 5120), "to_q")
+    assert isinstance(method, QuarkW4A8OnlineLinearMethod)
+
+
+def test_svd_routes_to_svd_method(_supported):
+    from vllm_omni.quantization.quark_w4a8_config import (
+        DiffusionQuarkW4A8Config,
+        QuarkW4A8SVDLinearMethod,
+    )
+
+    method = DiffusionQuarkW4A8Config(svd_rank=32).get_quant_method(_fake_linear(5120, 5120), "to_q")
+    assert isinstance(method, QuarkW4A8SVDLinearMethod)
+
+
+def test_ignored_layer_routes_to_bf16(_supported):
+    from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    cfg = DiffusionQuarkW4A8Config(ignored_layers=["blocks.0.to_q"])
+    assert isinstance(cfg.get_quant_method(_fake_linear(5120, 5120), "blocks.0.to_q"), UnquantizedLinearMethod)
+
+
+def test_svd_rejects_wan_proj_out_shape_loudly(_supported, caplog):
+    """out_features=192 is below the SVD epilogue's 256 floor. Quark produces
+    garbage rather than failing, so routing must fall back to BF16 and say so."""
+    from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    cfg = DiffusionQuarkW4A8Config(svd_rank=32)
+    with caplog.at_level("WARNING"):
+        method = cfg.get_quant_method(_fake_linear(3072, 192), "proj_out")
+    assert isinstance(method, UnquantizedLinearMethod)
+    assert "proj_out" in caplog.text
+
+
+def test_untileable_shape_falls_back_to_bf16(_supported):
+    from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    method = DiffusionQuarkW4A8Config().get_quant_method(_fake_linear(3072, 100), "odd")
+    assert isinstance(method, UnquantizedLinearMethod)
+
+
+def test_serialized_svd_routes_to_svd_checkpoint(_supported):
+    from vllm_omni.quantization.quark_w4a8_config import (
+        DiffusionQuarkW4A8Config,
+        QuarkW4A8SVDCheckpointLinearMethod,
+    )
+
+    cfg = DiffusionQuarkW4A8Config(svd_rank=32, is_checkpoint_w4a8_serialized=True)
+    method = cfg.get_quant_method(_fake_linear(5120, 5120), "to_q")
+    assert isinstance(method, QuarkW4A8SVDCheckpointLinearMethod)
+
+
+def test_serialized_plain_routes_to_checkpoint(_supported):
+    from vllm_omni.quantization.quark_w4a8_config import (
+        DiffusionQuarkW4A8Config,
+        QuarkW4A8CheckpointLinearMethod,
+    )
+
+    cfg = DiffusionQuarkW4A8Config(is_checkpoint_w4a8_serialized=True)
+    method = cfg.get_quant_method(_fake_linear(5120, 5120), "to_q")
+    assert isinstance(method, QuarkW4A8CheckpointLinearMethod)
+
+
+def test_serialized_svd_shape_not_svd_falls_back_to_plain(_supported):
+    """A serialized SVD checkpoint folds the correction back into any layer the
+    SVD gate rejects, so such a layer must route to the plain checkpoint method."""
+    from vllm_omni.quantization.quark_w4a8_config import (
+        DiffusionQuarkW4A8Config,
+        QuarkW4A8CheckpointLinearMethod,
+    )
+
+    cfg = DiffusionQuarkW4A8Config(svd_rank=32, is_checkpoint_w4a8_serialized=True)
+    # 1152 % 32 == 0 (plain-tileable) but 1152 % 256 != 0 (not SVD-tileable).
+    method = cfg.get_quant_method(_fake_linear(3072, 1152), "ffn")
+    assert isinstance(method, QuarkW4A8CheckpointLinearMethod)
+
+
+def test_serialized_untileable_falls_back_to_bf16(_supported):
+    from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    cfg = DiffusionQuarkW4A8Config(svd_rank=32, is_checkpoint_w4a8_serialized=True)
+    method = cfg.get_quant_method(_fake_linear(3072, 100), "odd")
+    assert isinstance(method, UnquantizedLinearMethod)
+
+
+@pytest.mark.parametrize(
+    ("output_partition_sizes", "expected_rank"),
+    [([1024, 1024, 1024], 96), ([5120], 32)],
+)
+def test_svd_checkpoint_create_weights_rank_from_shards(_supported, output_partition_sizes, expected_rank):
+    """rank_eff = svd_rank * len(output_partition_sizes): 3*R for a fused to_qkv
+    (three shards), R for a single-shard linear."""
+    from vllm_omni.quantization.quark_w4a8_config import (
+        DiffusionQuarkW4A8Config,
+        QuarkW4A8SVDCheckpointLinearMethod,
+    )
+
+    cfg = DiffusionQuarkW4A8Config(svd_rank=32, is_checkpoint_w4a8_serialized=True)
+    method = QuarkW4A8SVDCheckpointLinearMethod(cfg)
+    layer = torch.nn.Module()
+    out = sum(output_partition_sizes)
+    method.create_weights(
+        layer,
+        input_size_per_partition=3072,
+        output_partition_sizes=output_partition_sizes,
+        input_size=3072,
+        output_size=out,
+        params_dtype=torch.bfloat16,
+        weight_loader=lambda *a, **k: None,
+    )
+    assert layer.weight.shape == (out, 3072)
+    assert layer.proj_down.shape == (expected_rank, 3072)
+    assert layer.proj_up.shape == (out, expected_rank)
+
+
+# ---------------------------------------------------------------------------
+# Pre-packed serialized checkpoints (mxfp4_packed)
+# ---------------------------------------------------------------------------
+
+
+def test_from_config_parses_export_format():
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    cfg = DiffusionQuarkW4A8Config.from_config({"quark_export_format": "mxfp4_packed"})
+    assert cfg.quark_export_format == "mxfp4_packed"
+    assert DiffusionQuarkW4A8Config.from_config({}).quark_export_format is None
+
+
+def test_serialized_packed_svd_routes_to_packed_method(_supported):
+    from vllm_omni.quantization.quark_w4a8_config import (
+        DiffusionQuarkW4A8Config,
+        QuarkW4A8SVDPackedLinearMethod,
+    )
+
+    cfg = DiffusionQuarkW4A8Config(svd_rank=32, is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_packed")
+    method = cfg.get_quant_method(_fake_linear(5120, 5120), "to_q")
+    assert isinstance(method, QuarkW4A8SVDPackedLinearMethod)
+
+
+def test_serialized_packed_plain_routes_to_packed_method(_supported):
+    from vllm_omni.quantization.quark_w4a8_config import (
+        DiffusionQuarkW4A8Config,
+        QuarkW4A8PackedLinearMethod,
+    )
+
+    cfg = DiffusionQuarkW4A8Config(is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_packed")
+    method = cfg.get_quant_method(_fake_linear(5120, 5120), "to_q")
+    assert isinstance(method, QuarkW4A8PackedLinearMethod)
+
+
+def test_packed_create_weights_registers_uint8_shapes(_supported):
+    """weight_shuffle is (N, K/2) and weight_scale (N, K/32), both uint8; K%256==0
+    guarantees the scale needs no padding."""
+    from vllm_omni.quantization.quark_w4a8_config import (
+        DiffusionQuarkW4A8Config,
+        QuarkW4A8SVDPackedLinearMethod,
+    )
+
+    cfg = DiffusionQuarkW4A8Config(svd_rank=32, is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_packed")
+    method = QuarkW4A8SVDPackedLinearMethod(cfg)
+    layer = torch.nn.Module()
+    method.create_weights(
+        layer,
+        input_size_per_partition=3072,
+        output_partition_sizes=[1024, 1024, 1024],
+        input_size=3072,
+        output_size=3072,
+        params_dtype=torch.bfloat16,
+        weight_loader=lambda *a, **k: None,
+    )
+    assert layer.weight_shuffle.shape == (3072, 1536) and layer.weight_shuffle.dtype == torch.uint8
+    assert layer.weight_scale.shape == (3072, 96) and layer.weight_scale.dtype == torch.uint8
+    assert layer.proj_down.shape == (96, 3072)  # 3 * svd_rank on the fused to_qkv
+    assert layer.proj_up.shape == (3072, 96)
+
+
+def test_unsupported_hardware_raises(monkeypatch):
+    """Silently falling back to BF16 for the whole model would look like a
+    successful quantized run, so an unusable backend must be an error."""
+    from vllm_omni.quantization import flydsl_w4a8
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    monkeypatch.setattr(flydsl_w4a8, "supports", lambda: (False, "requires gfx950, detected gfx942"))
+    with pytest.raises(NotImplementedError, match="gfx942"):
+        DiffusionQuarkW4A8Config().get_quant_method(_fake_linear(5120, 5120), "to_q")

--- a/tests/diffusion/quantization/test_quark_w4a8_config.py
+++ b/tests/diffusion/quantization/test_quark_w4a8_config.py
@@ -249,14 +249,15 @@ def test_non_linear_layer_returns_none():
     assert DiffusionQuarkW4A8Config().get_quant_method(torch.nn.LayerNorm(8), "norm") is None
 
 
-def test_plain_routes_to_online_method(_supported):
+def test_plain_routes_to_bf16_storage(_supported):
     from vllm_omni.quantization.quark_w4a8_config import (
         DiffusionQuarkW4A8Config,
-        QuarkW4A8OnlineLinearMethod,
+        QuarkW4A8LinearMethod,
     )
 
     method = DiffusionQuarkW4A8Config().get_quant_method(_fake_linear(5120, 5120), "to_q")
-    assert isinstance(method, QuarkW4A8OnlineLinearMethod)
+    assert type(method) is QuarkW4A8LinearMethod
+    assert method.storage.name == "bf16"
 
 
 def test_svd_routes_to_svd_method(_supported):
@@ -267,6 +268,8 @@ def test_svd_routes_to_svd_method(_supported):
 
     method = DiffusionQuarkW4A8Config(svd_rank=32).get_quant_method(_fake_linear(5120, 5120), "to_q")
     assert isinstance(method, QuarkW4A8SVDLinearMethod)
+    assert method.storage.name == "bf16"
+    assert method.derive_factors is True
 
 
 def test_ignored_layer_routes_to_bf16(_supported):
@@ -301,40 +304,58 @@ def test_untileable_shape_falls_back_to_bf16(_supported):
     assert isinstance(method, UnquantizedLinearMethod)
 
 
-def test_serialized_svd_routes_to_svd_checkpoint(_supported):
+def test_serialized_svd_routes_to_svd_bf16_loaded(_supported):
     from vllm_omni.quantization.quark_w4a8_config import (
         DiffusionQuarkW4A8Config,
-        QuarkW4A8SVDCheckpointLinearMethod,
+        QuarkW4A8SVDLinearMethod,
     )
 
     cfg = DiffusionQuarkW4A8Config(svd_rank=32, is_checkpoint_w4a8_serialized=True)
     method = cfg.get_quant_method(_fake_linear(5120, 5120), "to_q")
-    assert isinstance(method, QuarkW4A8SVDCheckpointLinearMethod)
+    assert isinstance(method, QuarkW4A8SVDLinearMethod)
+    assert method.storage.name == "bf16"
+    assert method.derive_factors is False
 
 
-def test_serialized_plain_routes_to_checkpoint(_supported):
+def test_serialized_plain_routes_to_bf16(_supported):
     from vllm_omni.quantization.quark_w4a8_config import (
         DiffusionQuarkW4A8Config,
-        QuarkW4A8CheckpointLinearMethod,
+        QuarkW4A8LinearMethod,
     )
 
     cfg = DiffusionQuarkW4A8Config(is_checkpoint_w4a8_serialized=True)
     method = cfg.get_quant_method(_fake_linear(5120, 5120), "to_q")
-    assert isinstance(method, QuarkW4A8CheckpointLinearMethod)
+    assert type(method) is QuarkW4A8LinearMethod
+    assert method.storage.name == "bf16"
 
 
 def test_serialized_svd_shape_not_svd_falls_back_to_plain(_supported):
     """A serialized SVD checkpoint folds the correction back into any layer the
-    SVD gate rejects, so such a layer must route to the plain checkpoint method."""
+    SVD gate rejects, so such a layer must route to the plain method (not BF16 --
+    the checkpoint carries a plain 4-bit weight there)."""
     from vllm_omni.quantization.quark_w4a8_config import (
         DiffusionQuarkW4A8Config,
-        QuarkW4A8CheckpointLinearMethod,
+        QuarkW4A8LinearMethod,
+        QuarkW4A8SVDLinearMethod,
     )
 
     cfg = DiffusionQuarkW4A8Config(svd_rank=32, is_checkpoint_w4a8_serialized=True)
     # 1152 % 32 == 0 (plain-tileable) but 1152 % 256 != 0 (not SVD-tileable).
     method = cfg.get_quant_method(_fake_linear(3072, 1152), "ffn")
-    assert isinstance(method, QuarkW4A8CheckpointLinearMethod)
+    assert type(method) is QuarkW4A8LinearMethod
+    assert not isinstance(method, QuarkW4A8SVDLinearMethod)
+    assert method.storage.name == "bf16"
+
+
+def test_online_svd_shape_not_svd_falls_back_to_bf16(_supported):
+    """Online svdquant (no serialized checkpoint) on an SVD-rejected shape has no
+    folded plain weight, so it must go to BF16 -- unlike the serialized case."""
+    from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+
+    from vllm_omni.quantization.quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    method = DiffusionQuarkW4A8Config(svd_rank=32).get_quant_method(_fake_linear(3072, 1152), "ffn")
+    assert isinstance(method, UnquantizedLinearMethod)
 
 
 def test_serialized_untileable_falls_back_to_bf16(_supported):
@@ -351,16 +372,17 @@ def test_serialized_untileable_falls_back_to_bf16(_supported):
     ("output_partition_sizes", "expected_rank"),
     [([1024, 1024, 1024], 96), ([5120], 32)],
 )
-def test_svd_checkpoint_create_weights_rank_from_shards(_supported, output_partition_sizes, expected_rank):
+def test_svd_serialized_create_weights_rank_from_shards(_supported, output_partition_sizes, expected_rank):
     """rank_eff = svd_rank * len(output_partition_sizes): 3*R for a fused to_qkv
     (three shards), R for a single-shard linear."""
     from vllm_omni.quantization.quark_w4a8_config import (
+        _STORAGES,
         DiffusionQuarkW4A8Config,
-        QuarkW4A8SVDCheckpointLinearMethod,
+        QuarkW4A8SVDLinearMethod,
     )
 
     cfg = DiffusionQuarkW4A8Config(svd_rank=32, is_checkpoint_w4a8_serialized=True)
-    method = QuarkW4A8SVDCheckpointLinearMethod(cfg)
+    method = QuarkW4A8SVDLinearMethod(cfg, _STORAGES["bf16"], derive_factors=False)
     layer = torch.nn.Module()
     out = sum(output_partition_sizes)
     method.create_weights(
@@ -390,38 +412,41 @@ def test_from_config_parses_export_format():
     assert DiffusionQuarkW4A8Config.from_config({}).quark_export_format is None
 
 
-def test_serialized_packed_svd_routes_to_packed_method(_supported):
+def test_serialized_packed_svd_routes(_supported):
     from vllm_omni.quantization.quark_w4a8_config import (
         DiffusionQuarkW4A8Config,
-        QuarkW4A8SVDPackedLinearMethod,
+        QuarkW4A8SVDLinearMethod,
     )
 
     cfg = DiffusionQuarkW4A8Config(svd_rank=32, is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_packed")
     method = cfg.get_quant_method(_fake_linear(5120, 5120), "to_q")
-    assert isinstance(method, QuarkW4A8SVDPackedLinearMethod)
+    assert isinstance(method, QuarkW4A8SVDLinearMethod)
+    assert method.storage.name == "mxfp4_packed"
 
 
-def test_serialized_packed_plain_routes_to_packed_method(_supported):
+def test_serialized_packed_plain_routes(_supported):
     from vllm_omni.quantization.quark_w4a8_config import (
         DiffusionQuarkW4A8Config,
-        QuarkW4A8PackedLinearMethod,
+        QuarkW4A8LinearMethod,
     )
 
     cfg = DiffusionQuarkW4A8Config(is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_packed")
     method = cfg.get_quant_method(_fake_linear(5120, 5120), "to_q")
-    assert isinstance(method, QuarkW4A8PackedLinearMethod)
+    assert type(method) is QuarkW4A8LinearMethod
+    assert method.storage.name == "mxfp4_packed"
 
 
 def test_packed_create_weights_registers_uint8_shapes(_supported):
     """weight_shuffle is (N, K/2) and weight_scale (N, K/32), both uint8; K%256==0
     guarantees the scale needs no padding."""
     from vllm_omni.quantization.quark_w4a8_config import (
+        _STORAGES,
         DiffusionQuarkW4A8Config,
-        QuarkW4A8SVDPackedLinearMethod,
+        QuarkW4A8SVDLinearMethod,
     )
 
     cfg = DiffusionQuarkW4A8Config(svd_rank=32, is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_packed")
-    method = QuarkW4A8SVDPackedLinearMethod(cfg)
+    method = QuarkW4A8SVDLinearMethod(cfg, _STORAGES["mxfp4_packed"], derive_factors=False)
     layer = torch.nn.Module()
     method.create_weights(
         layer,
@@ -446,23 +471,27 @@ def test_packed_create_weights_registers_uint8_shapes(_supported):
 def test_serialized_unshuffled_plain_routes(_supported):
     from vllm_omni.quantization.quark_w4a8_config import (
         DiffusionQuarkW4A8Config,
-        QuarkW4A8UnshuffledLinearMethod,
+        QuarkW4A8LinearMethod,
     )
 
     cfg = DiffusionQuarkW4A8Config(is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_unshuffled")
-    assert isinstance(cfg.get_quant_method(_fake_linear(5120, 5120), "to_q"), QuarkW4A8UnshuffledLinearMethod)
+    method = cfg.get_quant_method(_fake_linear(5120, 5120), "to_q")
+    assert type(method) is QuarkW4A8LinearMethod
+    assert method.storage.name == "mxfp4_unshuffled"
 
 
 def test_serialized_unshuffled_svd_routes(_supported):
     from vllm_omni.quantization.quark_w4a8_config import (
         DiffusionQuarkW4A8Config,
-        QuarkW4A8SVDUnshuffledLinearMethod,
+        QuarkW4A8SVDLinearMethod,
     )
 
     cfg = DiffusionQuarkW4A8Config(
         svd_rank=32, is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_unshuffled"
     )
-    assert isinstance(cfg.get_quant_method(_fake_linear(5120, 5120), "to_q"), QuarkW4A8SVDUnshuffledLinearMethod)
+    method = cfg.get_quant_method(_fake_linear(5120, 5120), "to_q")
+    assert isinstance(method, QuarkW4A8SVDLinearMethod)
+    assert method.storage.name == "mxfp4_unshuffled"
 
 
 def test_unshuffled_plain_create_weights_shardable_params(_supported):
@@ -471,12 +500,13 @@ def test_unshuffled_plain_create_weights_shardable_params(_supported):
     from vllm.model_executor.parameter import GroupQuantScaleParameter, PackedvLLMParameter
 
     from vllm_omni.quantization.quark_w4a8_config import (
+        _STORAGES,
         DiffusionQuarkW4A8Config,
-        QuarkW4A8UnshuffledLinearMethod,
+        QuarkW4A8LinearMethod,
     )
 
     cfg = DiffusionQuarkW4A8Config(is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_unshuffled")
-    method = QuarkW4A8UnshuffledLinearMethod(cfg)
+    method = QuarkW4A8LinearMethod(cfg, _STORAGES["mxfp4_unshuffled"])
     layer = torch.nn.Module()
     method.create_weights(
         layer,
@@ -499,14 +529,15 @@ def test_unshuffled_svd_create_weights_replicates_proj_down(_supported):
     from vllm.model_executor.parameter import BasevLLMParameter, ModelWeightParameter
 
     from vllm_omni.quantization.quark_w4a8_config import (
+        _STORAGES,
         DiffusionQuarkW4A8Config,
-        QuarkW4A8SVDUnshuffledLinearMethod,
+        QuarkW4A8SVDLinearMethod,
     )
 
     cfg = DiffusionQuarkW4A8Config(
         svd_rank=32, is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_unshuffled"
     )
-    method = QuarkW4A8SVDUnshuffledLinearMethod(cfg)
+    method = QuarkW4A8SVDLinearMethod(cfg, _STORAGES["mxfp4_unshuffled"], derive_factors=False)
     layer = torch.nn.Module()
     method.create_weights(
         layer,
@@ -524,14 +555,15 @@ def test_unshuffled_svd_create_weights_replicates_proj_down(_supported):
 def test_unshuffled_svd_rejects_row_parallel_tp(_supported):
     """Row-parallel SVD needs an all-reduce of the low-rank term; refuse it."""
     from vllm_omni.quantization.quark_w4a8_config import (
+        _STORAGES,
         DiffusionQuarkW4A8Config,
-        QuarkW4A8SVDUnshuffledLinearMethod,
+        QuarkW4A8SVDLinearMethod,
     )
 
     cfg = DiffusionQuarkW4A8Config(
         svd_rank=32, is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_unshuffled"
     )
-    method = QuarkW4A8SVDUnshuffledLinearMethod(cfg)
+    method = QuarkW4A8SVDLinearMethod(cfg, _STORAGES["mxfp4_unshuffled"], derive_factors=False)
     layer = torch.nn.Module()
     layer.tp_size = 2
     with pytest.raises(NotImplementedError, match="row-parallel"):

--- a/tests/diffusion/quantization/test_quark_w4a8_config.py
+++ b/tests/diffusion/quantization/test_quark_w4a8_config.py
@@ -523,10 +523,11 @@ def test_unshuffled_plain_create_weights_shardable_params(_supported):
     assert layer.weight_scale.shape == (5120, 96) and layer.weight_scale.dtype == torch.uint8
 
 
-def test_unshuffled_svd_create_weights_replicates_proj_down(_supported):
-    """proj_up shards on N (ModelWeightParameter, output_dim=0); proj_down is a
-    replicated BasevLLMParameter (K full under column-parallel)."""
-    from vllm.model_executor.parameter import BasevLLMParameter, ModelWeightParameter
+def test_unshuffled_svd_factor_param_axes(_supported):
+    """proj_up on the output axis (_ColumnvLLMParameter, shards N column-parallel);
+    proj_down on the input axis (RowvLLMParameter, shards K row-parallel). Each
+    replicates on the other parallelism, so both directions work with no branch."""
+    from vllm.model_executor.parameter import RowvLLMParameter, _ColumnvLLMParameter
 
     from vllm_omni.quantization.quark_w4a8_config import (
         _STORAGES,
@@ -548,12 +549,14 @@ def test_unshuffled_svd_create_weights_replicates_proj_down(_supported):
         params_dtype=torch.bfloat16,
         weight_loader=lambda *a, **k: None,
     )
-    assert layer.proj_up.shape == (3072, 96) and isinstance(layer.proj_up, ModelWeightParameter)
-    assert layer.proj_down.shape == (96, 3072) and isinstance(layer.proj_down, BasevLLMParameter)
+    assert layer.proj_up.shape == (3072, 96) and isinstance(layer.proj_up, _ColumnvLLMParameter)
+    assert layer.proj_down.shape == (96, 3072) and isinstance(layer.proj_down, RowvLLMParameter)
 
 
-def test_unshuffled_svd_rejects_row_parallel_tp(_supported):
-    """Row-parallel SVD needs an all-reduce of the low-rank term; refuse it."""
+def test_unshuffled_svd_accepts_row_parallel_tp(_supported):
+    """Row-parallel SVD is supported on the unshuffled storage: proj_down shards
+    on K (input dim), proj_up replicates, and the correction rides the layer's
+    output all-reduce -- so create_weights must not raise."""
     from vllm_omni.quantization.quark_w4a8_config import (
         _STORAGES,
         DiffusionQuarkW4A8Config,
@@ -566,12 +569,37 @@ def test_unshuffled_svd_rejects_row_parallel_tp(_supported):
     method = QuarkW4A8SVDLinearMethod(cfg, _STORAGES["mxfp4_unshuffled"], derive_factors=False)
     layer = torch.nn.Module()
     layer.tp_size = 2
-    with pytest.raises(NotImplementedError, match="row-parallel"):
+    method.create_weights(
+        layer,
+        input_size_per_partition=1536,  # < input_size -> input (K) sharded = row-parallel
+        output_partition_sizes=[5120],
+        input_size=3072,
+        output_size=5120,
+        params_dtype=torch.bfloat16,
+        weight_loader=lambda *a, **k: None,
+    )
+    assert layer.proj_down.shape == (32, 1536)  # sharded on K
+    assert layer.proj_up.shape == (5120, 32)  # replicated
+
+
+def test_bf16_svd_still_rejects_tp(_supported):
+    """A non-shardable storage (bf16/packed) still refuses TP>1 in either direction."""
+    from vllm_omni.quantization.quark_w4a8_config import (
+        _STORAGES,
+        DiffusionQuarkW4A8Config,
+        QuarkW4A8SVDLinearMethod,
+    )
+
+    cfg = DiffusionQuarkW4A8Config(svd_rank=32, is_checkpoint_w4a8_serialized=True)
+    method = QuarkW4A8SVDLinearMethod(cfg, _STORAGES["bf16"], derive_factors=False)
+    layer = torch.nn.Module()
+    layer.tp_size = 2
+    with pytest.raises(NotImplementedError, match="cannot be sharded"):
         method.create_weights(
             layer,
-            input_size_per_partition=1536,  # < input_size -> input (K) sharded = row-parallel
+            input_size_per_partition=5120,
             output_partition_sizes=[5120],
-            input_size=3072,
+            input_size=5120,
             output_size=5120,
             params_dtype=torch.bfloat16,
             weight_loader=lambda *a, **k: None,

--- a/tests/diffusion/quantization/test_quark_w4a8_config.py
+++ b/tests/diffusion/quantization/test_quark_w4a8_config.py
@@ -438,6 +438,114 @@ def test_packed_create_weights_registers_uint8_shapes(_supported):
     assert layer.proj_up.shape == (3072, 96)
 
 
+# ---------------------------------------------------------------------------
+# Unshuffled serialized checkpoints (mxfp4_unshuffled, TP>1)
+# ---------------------------------------------------------------------------
+
+
+def test_serialized_unshuffled_plain_routes(_supported):
+    from vllm_omni.quantization.quark_w4a8_config import (
+        DiffusionQuarkW4A8Config,
+        QuarkW4A8UnshuffledLinearMethod,
+    )
+
+    cfg = DiffusionQuarkW4A8Config(is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_unshuffled")
+    assert isinstance(cfg.get_quant_method(_fake_linear(5120, 5120), "to_q"), QuarkW4A8UnshuffledLinearMethod)
+
+
+def test_serialized_unshuffled_svd_routes(_supported):
+    from vllm_omni.quantization.quark_w4a8_config import (
+        DiffusionQuarkW4A8Config,
+        QuarkW4A8SVDUnshuffledLinearMethod,
+    )
+
+    cfg = DiffusionQuarkW4A8Config(
+        svd_rank=32, is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_unshuffled"
+    )
+    assert isinstance(cfg.get_quant_method(_fake_linear(5120, 5120), "to_q"), QuarkW4A8SVDUnshuffledLinearMethod)
+
+
+def test_unshuffled_plain_create_weights_shardable_params(_supported):
+    """weight_packed is a PackedvLLMParameter (shards K via packed_dim) and
+    weight_scale a GroupQuantScaleParameter — the classes that let vLLM shard for TP."""
+    from vllm.model_executor.parameter import GroupQuantScaleParameter, PackedvLLMParameter
+
+    from vllm_omni.quantization.quark_w4a8_config import (
+        DiffusionQuarkW4A8Config,
+        QuarkW4A8UnshuffledLinearMethod,
+    )
+
+    cfg = DiffusionQuarkW4A8Config(is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_unshuffled")
+    method = QuarkW4A8UnshuffledLinearMethod(cfg)
+    layer = torch.nn.Module()
+    method.create_weights(
+        layer,
+        input_size_per_partition=3072,
+        output_partition_sizes=[5120],
+        input_size=3072,
+        output_size=5120,
+        params_dtype=torch.bfloat16,
+        weight_loader=lambda *a, **k: None,
+    )
+    assert isinstance(layer.weight_packed, PackedvLLMParameter)
+    assert isinstance(layer.weight_scale, GroupQuantScaleParameter)
+    assert layer.weight_packed.shape == (5120, 1536) and layer.weight_packed.dtype == torch.uint8
+    assert layer.weight_scale.shape == (5120, 96) and layer.weight_scale.dtype == torch.uint8
+
+
+def test_unshuffled_svd_create_weights_replicates_proj_down(_supported):
+    """proj_up shards on N (ModelWeightParameter, output_dim=0); proj_down is a
+    replicated BasevLLMParameter (K full under column-parallel)."""
+    from vllm.model_executor.parameter import BasevLLMParameter, ModelWeightParameter
+
+    from vllm_omni.quantization.quark_w4a8_config import (
+        DiffusionQuarkW4A8Config,
+        QuarkW4A8SVDUnshuffledLinearMethod,
+    )
+
+    cfg = DiffusionQuarkW4A8Config(
+        svd_rank=32, is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_unshuffled"
+    )
+    method = QuarkW4A8SVDUnshuffledLinearMethod(cfg)
+    layer = torch.nn.Module()
+    method.create_weights(
+        layer,
+        input_size_per_partition=3072,
+        output_partition_sizes=[1024, 1024, 1024],
+        input_size=3072,
+        output_size=3072,
+        params_dtype=torch.bfloat16,
+        weight_loader=lambda *a, **k: None,
+    )
+    assert layer.proj_up.shape == (3072, 96) and isinstance(layer.proj_up, ModelWeightParameter)
+    assert layer.proj_down.shape == (96, 3072) and isinstance(layer.proj_down, BasevLLMParameter)
+
+
+def test_unshuffled_svd_rejects_row_parallel_tp(_supported):
+    """Row-parallel SVD needs an all-reduce of the low-rank term; refuse it."""
+    from vllm_omni.quantization.quark_w4a8_config import (
+        DiffusionQuarkW4A8Config,
+        QuarkW4A8SVDUnshuffledLinearMethod,
+    )
+
+    cfg = DiffusionQuarkW4A8Config(
+        svd_rank=32, is_checkpoint_w4a8_serialized=True, quark_export_format="mxfp4_unshuffled"
+    )
+    method = QuarkW4A8SVDUnshuffledLinearMethod(cfg)
+    layer = torch.nn.Module()
+    layer.tp_size = 2
+    with pytest.raises(NotImplementedError, match="row-parallel"):
+        method.create_weights(
+            layer,
+            input_size_per_partition=1536,  # < input_size -> input (K) sharded = row-parallel
+            output_partition_sizes=[5120],
+            input_size=3072,
+            output_size=5120,
+            params_dtype=torch.bfloat16,
+            weight_loader=lambda *a, **k: None,
+        )
+
+
 def test_unsupported_hardware_raises(monkeypatch):
     """Silently falling back to BF16 for the whole model would look like a
     successful quantized run, so an unusable backend must be an error."""

--- a/vllm_omni/deploy/wan2_2_t2v_a14b_w4a8.yaml
+++ b/vllm_omni/deploy/wan2_2_t2v_a14b_w4a8.yaml
@@ -1,0 +1,25 @@
+# Wan2.2 T2V-A14B deploy with W4A8 quantization (MXFP4 weights, MXFP8 activations).
+#
+# Requires AMD MI355X (gfx950); see wan2_2_ti2v_w4a8.yaml for the hardware note.
+#
+# A14B is a dual-expert cascade: `transformer/` (high noise) and `transformer_2/`
+# (low noise) are selected by the timestep boundary. Both are quantized with this
+# same config, and both are resident at once — expect roughly double the load
+# time and peak host memory of TI2V-5B. The weights are ~14B x 2 in BF16 on disk
+# and are packed to MXFP4 one layer at a time as they load.
+async_chunk: false
+trust_remote_code: true
+distributed_executor_backend: mp
+
+stages:
+  - stage_id: 0
+    devices: "0"
+    max_num_seqs: 1
+    # W4A8 has only been validated at TP=1. A14B in BF16 normally wants TP>1 for
+    # capacity; at 4 bits it fits on one MI355X, which is the point of this config.
+    tensor_parallel_size: 1
+    enforce_eager: true
+    quantization: quark_w4a8
+    vae_use_tiling: true
+    default_sampling_params:
+      seed: 42

--- a/vllm_omni/deploy/wan2_2_ti2v_w4a8.yaml
+++ b/vllm_omni/deploy/wan2_2_ti2v_w4a8.yaml
@@ -1,0 +1,25 @@
+# Wan2.2 TI2V-5B deploy with W4A8 quantization (MXFP4 weights, MXFP8 activations).
+#
+# Requires AMD MI355X (gfx950): the GEMM uses CDNA4 scaled MFMA, which CDNA3
+# (gfx942 / MI325X) does not have. On any other device the run fails at model
+# build with an explicit NotImplementedError rather than falling back silently.
+#
+# No checkpoint preparation is needed — BF16 weights are packed to MXFP4 at load
+# time. Swap `quantization` to `quark_svdquant` once an SVDQuant checkpoint with
+# proj_down/proj_up is available; see docs/user_guide/quantization/w4a8_rocm.md.
+async_chunk: false
+trust_remote_code: true
+distributed_executor_backend: mp
+
+stages:
+  - stage_id: 0
+    devices: "0"
+    max_num_seqs: 1
+    # W4A8 has only been validated at TP=1.
+    tensor_parallel_size: 1
+    enforce_eager: true
+    quantization: quark_w4a8
+    # Keep VAE tiling on by default for higher resolutions / longer clips.
+    vae_use_tiling: true
+    default_sampling_params:
+      seed: 42

--- a/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
+++ b/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
@@ -1118,7 +1118,12 @@ class WanTransformer3DModel(nn.Module):
             # Pre-fused to_qkv tensors (from offline MXFP8 merged checkpoint) fall
             # through to the else branch and are loaded directly.
             for param_name, weight_name, shard_id in stacked_params_mapping:
-                if weight_name not in original_name:
+                # Match a full path segment (trailing dot): ``.attn1.to_q.`` must not
+                # match a pre-fused ``.attn1.to_qkv.`` key -- otherwise the fused
+                # to_qkv weight/proj_down/proj_up enter the shard branch, build a
+                # garbage lookup name (to_qkv->to_qkvkv), miss params_dict, and break
+                # out unloaded, leaving the layer at uninitialized garbage.
+                if (weight_name + ".") not in original_name:
                     continue
                 lookup_name = original_name.replace(weight_name, param_name)
                 # Skip weights that belong to PP stages other than this one

--- a/vllm_omni/quantization/factory.py
+++ b/vllm_omni/quantization/factory.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Factory for building quantization configs.
 
 build_quant_config() delegates to vLLM's quantization registry.
@@ -125,6 +125,36 @@ def _build_mxfp4_dualscale(**kw: Any) -> QuantizationConfig:
     return DiffusionMXFP4DualScaleMixedConfig(**kw)
 
 
+# Matches Quark's SVDQuantConfig default.
+_DEFAULT_SVD_RANK = 32
+
+
+def _build_quark_w4a8(**kw: Any) -> QuantizationConfig:
+    """Lazy import for W4A8 MXFP4-weight / MXFP8-activation config (ROCm gfx950 only).
+
+    Routed through from_config() rather than __init__ so that checkpoint keys
+    that this scheme does not consume (e.g. quant_algo) are ignored instead of
+    raising TypeError.
+    """
+    from .quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    return DiffusionQuarkW4A8Config.from_config(kw)
+
+
+def _build_quark_svdquant(**kw: Any) -> QuantizationConfig:
+    """W4A8 with the SVDQuant low-rank correction branch enabled by default.
+
+    Not an alias of quark_w4a8: it differs precisely in defaulting svd_rank, and
+    silently falling back to the plain variant when the name says svdquant would
+    be a quiet accuracy regression.
+    """
+    from .quark_w4a8_config import DiffusionQuarkW4A8Config
+
+    if kw.get("svd_rank") is None and kw.get("rank") is None:
+        kw = {**kw, "svd_rank": _DEFAULT_SVD_RANK}
+    return DiffusionQuarkW4A8Config.from_config(kw)
+
+
 def _build_inc(**kw: Any) -> QuantizationConfig:
     """Lazy import for INC/AutoRound config with checkpoint kwarg normalization."""
     from .inc_config import OmniINCConfig
@@ -145,6 +175,11 @@ _OVERRIDES: dict[str, Callable[..., QuantizationConfig]] = {
     "mxfp8": _build_mxfp8,
     "mxfp4": _build_mxfp4,
     "mxfp4_dualscale": _build_mxfp4_dualscale,
+    # "quark_w4a8" is canonical; "quark-w4a8" normalizes onto it. Deliberately
+    # not claiming the bare "svdquant" name, which upstream vLLM PR #3830 uses
+    # for Nunchaku.
+    "quark_w4a8": _build_quark_w4a8,
+    "quark_svdquant": _build_quark_svdquant,
     "inc": _build_inc,
     "auto-round": _build_inc,
     "auto_round": _build_inc,

--- a/vllm_omni/quantization/flydsl_w4a8.py
+++ b/vllm_omni/quantization/flydsl_w4a8.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""FlyDSL-backed W4A8 GEMM for diffusion transformers on ROCm gfx950.
+
+Two variants, both MXFP4 weights with E8M0 per-32 scales and *dynamically*
+quantized MXFP8 activations:
+
+  plain  y = Q(x) @ Q(W).T + bias
+  svd    y = Q(x) @ Q(W).T + (x @ L1.T) @ L2.T + bias
+
+The low-rank up-projection of the ``svd`` variant is fused into the GEMM
+epilogue, so both variants are a single kernel launch. ``d = x @ L1.T`` is
+computed in bf16 by torch inside the custom op.
+
+The kernel is reached through a single provider interface so the underlying
+source can move without changes to the linear methods:
+
+    quark  -> quark.torch.quantization.nn.modules.flydsl_a8w4_inference_linear
+    flydsl -> upstream FlyDSL, once it ships the SVD epilogue in a released wheel
+
+Selection is automatic (prefer ``flydsl`` when it exposes the epilogue, else
+``quark``) and overridable with ``VLLM_OMNI_SVDQUANT_PROVIDER=quark|flydsl``.
+
+Note on the Quark provider: it currently binds *private* Quark symbols
+(``_gemm_flydsl_a8w4`` / ``_gemm_flydsl_svdquant``) because Quark exposes no
+public alias for them yet. That coupling is deliberately confined to
+``_load_quark_provider`` so promoting it to a public ``quark.flydsl`` namespace
+is a one-line change here.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+from collections.abc import Callable
+from typing import NamedTuple
+
+import torch
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+# The kernel multiplies MXFP4 operands with CDNA4 scaled MFMA, which CDNA3
+# (gfx942 / MI325X) does not have. Quark's kernel factory raises on non-gfx950
+# too; this gate exists so the user sees an actionable message instead of an
+# MLIR backend stack trace.
+_SUPPORTED_ARCHS = ("gfx950",)
+
+# The preshuffle GEMM does not mask N/K tiles that overrun the matrix, and the
+# SVD epilogue additionally requires both dimensions to be tileable at >=256.
+# Layers violating this must fall back to BF16 rather than emit garbage.
+_SVD_DIM_MULTIPLE = 256
+
+# Smallest tile_n the plain a8w4 path falls back to (Quark tries 128, 64, 32 in
+# order). It is also the MXFP4 scale group size, so N must be a multiple of it
+# regardless of tiling.
+_DIM_MULTIPLE = 32
+
+# The plain a8w4 kernel validates K itself and *raises* below this
+# (``_validate_a8w4_inputs``: "requires K >= 256 and divisible by 256"), because
+# the preshuffled B operand carries a padded scale layout of eight groups. Screen
+# for it here so such layers fall back to BF16 instead of aborting generation.
+_K_MULTIPLE = 256
+
+
+def _arch() -> str:
+    index = torch.accelerator.current_device_index()
+    return torch.cuda.get_device_properties(index).gcnArchName
+
+
+@functools.lru_cache(maxsize=1)
+def supports() -> tuple[bool, str]:
+    """Return ``(usable, reason)``.
+
+    A missing provider is a capability answer, not an error. An unknown value of
+    ``VLLM_OMNI_SVDQUANT_PROVIDER`` is user misconfiguration and propagates as
+    ``ValueError``.
+    """
+    from vllm_omni.platforms import current_omni_platform
+
+    if not current_omni_platform.is_rocm():
+        return False, "FlyDSL W4A8 backend requires ROCm"
+    if not torch.cuda.is_available():
+        return False, "FlyDSL W4A8 backend requires an available GPU"
+    arch = _arch()
+    if not any(a in arch for a in _SUPPORTED_ARCHS):
+        return False, f"requires one of {_SUPPORTED_ARCHS}, detected {arch}"
+    try:
+        provider = _provider()
+    except ImportError as exc:
+        return False, f"no FlyDSL W4A8 kernel provider available: {exc}"
+    logger.info("FlyDSL W4A8 kernel provider: %s", provider.name)
+    return True, ""
+
+
+def supports_shape(in_features: int, out_features: int) -> bool:
+    """Whether the plain W4A8 kernel can run this layer's shape.
+
+    Two independent constraints:
+
+    * K (``in_features``) must be >= 256 and a multiple of 256 -- Quark's
+      ``_validate_a8w4_inputs`` raises otherwise, and ``_pack_weight_asm``
+      silently switches to an *unshuffled* layout below 256 that the preshuffle
+      kernel cannot read.
+    * N (``out_features``) must be a multiple of 32, the smallest tile_n Quark
+      falls back to; a non-dividing N makes the grid overrun the matrix.
+    """
+    return in_features >= _K_MULTIPLE and in_features % _K_MULTIPLE == 0 and out_features % _DIM_MULTIPLE == 0
+
+
+def supports_svd_shape(in_features: int, out_features: int) -> bool:
+    """Whether the fused SVD epilogue can run this layer's shape.
+
+    Quark refuses in/out features below 256 or not a multiple of 256 because the
+    preshuffle B layout plus the E8M0 256-K scale granularity produce garbage
+    otherwise (Wan's ``proj_out``, out=192, is the motivating case). Callers must
+    route rejected layers to an unquantized method.
+    """
+    return (
+        in_features >= _SVD_DIM_MULTIPLE
+        and out_features >= _SVD_DIM_MULTIPLE
+        and in_features % _SVD_DIM_MULTIPLE == 0
+        and out_features % _SVD_DIM_MULTIPLE == 0
+    )
+
+
+# --- provider resolution -----------------------------------------------------
+
+
+class _Provider(NamedTuple):
+    name: str
+    gemm: Callable[..., torch.Tensor]
+    svd_gemm: Callable[..., torch.Tensor]
+    pack_weight: Callable[..., tuple[torch.Tensor, torch.Tensor]]
+
+
+@functools.lru_cache(maxsize=1)
+def _provider() -> _Provider:
+    requested = os.environ.get("VLLM_OMNI_SVDQUANT_PROVIDER", "auto").lower()
+    loaders = {"quark": _load_quark_provider, "flydsl": _load_flydsl_provider}
+
+    if requested in loaders:
+        return loaders[requested]()
+    if requested != "auto":
+        raise ValueError(f"unknown VLLM_OMNI_SVDQUANT_PROVIDER={requested!r}")
+
+    errors = []
+    for name in ("flydsl", "quark"):
+        try:
+            return loaders[name]()
+        except ImportError as exc:
+            errors.append(f"{name}: {exc}")
+    raise ImportError("; ".join(errors))
+
+
+def _load_quark_provider() -> _Provider:
+    """Phase 1 provider, backed by Quark's vendored FlyDSL kernels."""
+    try:
+        from quark.torch.quantization.nn.modules.aiter_fp4_inference_linear import _pack_weight_asm
+        from quark.torch.quantization.nn.modules.flydsl_a8w4_inference_linear import (
+            _gemm_flydsl_a8w4,
+            _gemm_flydsl_svdquant,
+        )
+    except ImportError as exc:
+        raise ImportError(
+            f"Quark with vendored FlyDSL a8w4 kernels is required ({exc}). The released "
+            f"amd-quark wheel does not ship them; install Quark PR #6079 "
+            f"(branch xiaoyu/svd-quant-flydsl) from source."
+        ) from exc
+
+    return _Provider(
+        name="quark",
+        gemm=_gemm_flydsl_a8w4,
+        svd_gemm=_gemm_flydsl_svdquant,
+        pack_weight=_pack_weight_asm,
+    )
+
+
+def _load_flydsl_provider() -> _Provider:
+    """Phase 3 provider. The released flydsl wheel ships the compiler only.
+
+    Note that a top-level ``kernels`` module from an unrelated project is
+    importable in the ROCm image, so this must not probe ``kernels.gemm``
+    directly -- it would resolve to the wrong package and fail confusingly.
+    """
+    raise ImportError("upstream FlyDSL does not package its kernels yet; use the quark provider")
+
+
+# --- weight preparation (load time) ------------------------------------------
+
+
+def pack_weight(weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize a BF16/FP16 weight to MXFP4 and shuffle it into kernel layout.
+
+    Returns ``(packed_weight, packed_scale)`` as uint8 views, ready to hand to
+    the GEMM entrypoints below.
+    """
+    packed, scale = _provider().pack_weight(weight)
+    return packed.view(torch.uint8), scale.view(torch.uint8)
+
+
+# --- custom ops --------------------------------------------------------------
+# The GEMM must sit behind a torch.compile-opaque custom op with a correct
+# register_fake, mirroring vllm_omni::rocm_mxfp4_gemm in mxfp4_config.py.
+
+
+def register_ops() -> None:
+    """Register the W4A8 custom ops. Idempotent."""
+    if hasattr(torch.ops.vllm_omni, "flydsl_w4a8_gemm"):
+        return
+
+    @torch.library.custom_op("vllm_omni::flydsl_w4a8_gemm", mutates_args=())
+    def _flydsl_w4a8_gemm(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        weight_scale: torch.Tensor,
+        bias: torch.Tensor | None,
+        out_features: int,
+    ) -> torch.Tensor:
+        del out_features
+        # Activations are quantized to MXFP8 inside the Quark entrypoint.
+        #
+        # ``epilogue`` is not optional when a bias exists: the entrypoint gates
+        # the bias operand on ``bias is not None and epilogue != "none"``, so
+        # passing bias alone drops it on the floor without any error.
+        if bias is None:
+            return _provider().gemm(x, weight, weight_scale, torch.bfloat16)
+        return _provider().gemm(x, weight, weight_scale, torch.bfloat16, bias=bias, epilogue="bias")
+
+    @_flydsl_w4a8_gemm.register_fake
+    def _flydsl_w4a8_gemm_fake(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        weight_scale: torch.Tensor,
+        bias: torch.Tensor | None,
+        out_features: int,
+    ) -> torch.Tensor:
+        del weight, weight_scale, bias
+        return torch.empty(x.shape[0], out_features, dtype=torch.bfloat16, device=x.device)
+
+    @torch.library.custom_op("vllm_omni::flydsl_w4a8_svd_gemm", mutates_args=())
+    def _flydsl_w4a8_svd_gemm(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        weight_scale: torch.Tensor,
+        proj_down: torch.Tensor,
+        proj_up: torch.Tensor,
+        bias: torch.Tensor | None,
+        out_features: int,
+    ) -> torch.Tensor:
+        del out_features
+        # d = x @ L1.T, (M, rank) in bf16; the kernel fuses d @ L2.T (+ bias).
+        d = torch.nn.functional.linear(x, proj_down)
+        return _provider().svd_gemm(x, weight, weight_scale, d, proj_up, torch.bfloat16, bias=bias)
+
+    @_flydsl_w4a8_svd_gemm.register_fake
+    def _flydsl_w4a8_svd_gemm_fake(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        weight_scale: torch.Tensor,
+        proj_down: torch.Tensor,
+        proj_up: torch.Tensor,
+        bias: torch.Tensor | None,
+        out_features: int,
+    ) -> torch.Tensor:
+        del weight, weight_scale, proj_down, proj_up, bias
+        return torch.empty(x.shape[0], out_features, dtype=torch.bfloat16, device=x.device)

--- a/vllm_omni/quantization/flydsl_w4a8.py
+++ b/vllm_omni/quantization/flydsl_w4a8.py
@@ -132,6 +132,10 @@ class _Provider(NamedTuple):
     gemm: Callable[..., torch.Tensor]
     svd_gemm: Callable[..., torch.Tensor]
     pack_weight: Callable[..., tuple[torch.Tensor, torch.Tensor]]
+    # Split of pack_weight for TP: quantize to MXFP4 in *natural* (shardable)
+    # order, then shuffle a per-rank shard into the kernel layout at load.
+    pack_weight_unshuffled: Callable[..., tuple[torch.Tensor, torch.Tensor]]
+    shuffle_for_kernel: Callable[..., tuple[torch.Tensor, torch.Tensor]]
 
 
 @functools.lru_cache(maxsize=1)
@@ -156,10 +160,13 @@ def _provider() -> _Provider:
 def _load_quark_provider() -> _Provider:
     """Phase 1 provider, backed by Quark's vendored FlyDSL kernels."""
     try:
+        import aiter
+        from aiter.ops.shuffle import shuffle_weight
         from quark.torch.quantization.nn.modules.aiter_fp4_inference_linear import _pack_weight_asm
         from quark.torch.quantization.nn.modules.flydsl_a8w4_inference_linear import (
             _gemm_flydsl_a8w4,
             _gemm_flydsl_svdquant,
+            _shuffle_e8m0_scale,
         )
     except ImportError as exc:
         raise ImportError(
@@ -168,11 +175,28 @@ def _load_quark_provider() -> _Provider:
             f"(branch xiaoyu/svd-quant-flydsl) from source."
         ) from exc
 
+    _quant = aiter.get_triton_quant(aiter.QuantType.per_1x32)
+
+    def _pack_unshuffled(weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        # Natural (N, K/2) MXFP4 + (N, K/32) E8M0 -- no weight/scale shuffle, so a
+        # per-rank slice along N or K is still a valid sub-matrix.
+        w_q, w_s = _quant(weight, shuffle=False)
+        return w_q.view(torch.uint8), w_s.view(torch.uint8)
+
+    def _shuffle_for_kernel(w_q: torch.Tensor, w_s: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        # Applied to a per-rank shard at load: shuffle_weight + _shuffle_e8m0_scale
+        # reproduce _pack_weight_asm's preshuffled layout exactly (verified equal).
+        kernel_w = shuffle_weight(w_q, layout=(16, 16)).view(torch.uint8).contiguous()
+        kernel_s = _shuffle_e8m0_scale(w_s.view(torch.uint8)).view(torch.uint8).contiguous()
+        return kernel_w, kernel_s
+
     return _Provider(
         name="quark",
         gemm=_gemm_flydsl_a8w4,
         svd_gemm=_gemm_flydsl_svdquant,
         pack_weight=_pack_weight_asm,
+        pack_weight_unshuffled=_pack_unshuffled,
+        shuffle_for_kernel=_shuffle_for_kernel,
     )
 
 
@@ -197,6 +221,26 @@ def pack_weight(weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     """
     packed, scale = _provider().pack_weight(weight)
     return packed.view(torch.uint8), scale.view(torch.uint8)
+
+
+def pack_weight_unshuffled(weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize to MXFP4 in *natural* order (no kernel shuffle), for TP.
+
+    Returns ``(weight_packed (N, K/2), weight_scale (N, K/32))`` uint8. Unlike
+    :func:`pack_weight`, a per-rank slice of these along N (output) or K (input)
+    is still a valid sub-matrix, so vLLM can shard them; each rank then calls
+    :func:`shuffle_for_kernel` on its local shard.
+    """
+    return _provider().pack_weight_unshuffled(weight)
+
+
+def shuffle_for_kernel(weight_packed: torch.Tensor, weight_scale: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Shuffle an unshuffled MXFP4 shard into the GEMM's preshuffled layout.
+
+    Run per rank on the local shard. Reproduces :func:`pack_weight`'s bytes
+    exactly, so at TP=1 the result is bit-identical to packing the whole weight.
+    """
+    return _provider().shuffle_for_kernel(weight_packed, weight_scale)
 
 
 # --- custom ops --------------------------------------------------------------

--- a/vllm_omni/quantization/quark_w4a8_config.py
+++ b/vllm_omni/quantization/quark_w4a8_config.py
@@ -1,0 +1,762 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""W4A8 quantization for diffusion transformers on ROCm gfx950 (MI355X).
+
+MXFP4 weights (groups of 32 K-elements sharing one ``float8_e8m0fnu`` exponent)
+multiplied against MXFP8 activations that are quantized *dynamically* inside the
+kernel. Two variants share this config, selected by ``svd_rank``:
+
+  ``svd_rank`` absent   plain      ``y = Q(x) @ Q(W).T + bias``
+  ``svd_rank`` present  SVDQuant   ``y = Q(x) @ Q(Wr).T + (x @ L1.T) @ L2.T + bias``
+
+where ``Wr = W - L2 @ L1`` is the 4-bit residual and the low-rank up-projection
+is fused into the GEMM epilogue, so both variants are one kernel launch.
+
+Checkpoint contract
+-------------------
+Two load modes, chosen by ``is_checkpoint_w4a8_serialized``:
+
+**Online (default, stock BF16 checkpoint).** Both variants read a stock BF16
+checkpoint and do all their work at load time -- no export step, nothing extra in
+the state dict. ``plain`` packs each weight to MXFP4 (RTN) as it loads; ``SVDQuant``
+additionally derives ``proj_down`` (R, K) / ``proj_up`` (N, R) from the weight with
+``torch.svd_lowrank`` and quantizes only the residual, keeping the factors as
+non-persistent buffers. This online SVD is a *weight* SVD, not the activation-aware
+smoothing the paper describes (see ``_low_rank_split``).
+
+**Serialized (calibrated checkpoint).** A checkpoint produced offline by
+``examples/quantization/export_quark_svdquant_w4a8.py`` (Quark's
+``SVDQuantProcessor``: SmoothQuant smoothing + exact SVD on the smoothed weight)
+carries the BF16 residual under ``weight`` and the calibrated factors under
+``proj_down`` / ``proj_up`` as ordinary checkpoint keys. Self-attention QKV is
+pre-fused in the exporter, so a fused ``to_qkv`` layer's factors have rank
+``3 * svd_rank``. :class:`QuarkW4A8SVDCheckpointLinearMethod` loads the factors
+instead of deriving them; :class:`QuarkW4A8CheckpointLinearMethod` handles the plain
+serialized case. The on-disk weights are unpacked BF16 (packed to the kernel layout
+at load), because the shuffled MXFP4 layout is kernel-specific rather than a stable
+format.
+
+An opt-in ``quark_export_format="mxfp4_packed"`` checkpoint instead stores the
+residual already packed (``weight_shuffle``/``weight_scale`` uint8) -- ~4x smaller
+and no pack at load, handled by :class:`QuarkW4A8PackedLinearMethod` /
+:class:`QuarkW4A8SVDPackedLinearMethod`. This trades portability for size/speed: the
+packed layout is tied to the kernel's pack version.
+
+Both variants only support TP=1 today; see ``_reject_tp`` below.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+from torch.nn import Module
+from vllm.logger import init_logger
+from vllm.model_executor.layers.linear import (
+    LinearBase,
+    UnquantizedLinearMethod,
+)
+from vllm.model_executor.layers.quantization import QuantizationMethods
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizationConfig,
+    QuantizeMethodBase,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import is_layer_skipped
+from vllm.model_executor.model_loader.weight_utils import initialize_single_dummy_weight
+from vllm.model_executor.parameter import ModelWeightParameter
+
+from vllm_omni.quantization import flydsl_w4a8
+from vllm_omni.quantization._copy_missing_attrs import (
+    copy_missing_attrs as _copy_missing_attrs,
+)
+from vllm_omni.quantization.mxfp8_config import (
+    MXFPLinearMethodBase,
+    _LazyWeightMixin,
+)
+
+if TYPE_CHECKING:
+    from vllm.model_executor.models.utils import WeightsMapper
+
+logger = init_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+class DiffusionQuarkW4A8Config(QuantizationConfig):
+    """MXFP4-weight / MXFP8-activation config, with or without SVDQuant.
+
+    Args:
+        svd_rank: rank of the low-rank correction branch. ``None`` selects the
+            plain variant.
+        ignored_layers: layer name patterns to leave in BF16.
+        is_checkpoint_w4a8_serialized: load a calibrated serialized checkpoint
+            (BF16 residual + on-disk ``proj_down``/``proj_up`` factors) instead of
+            quantizing a stock BF16 checkpoint at load. See the module docstring.
+        quark_export_format: on-disk residual format of a serialized checkpoint.
+            ``"mxfp4_packed"`` = residual pre-packed to the kernel layout
+            (``weight_shuffle``/``weight_scale``); ``None``/``"bf16"`` = unpacked
+            BF16 residual packed at load.
+    """
+
+    def __init__(
+        self,
+        svd_rank: int | None = None,
+        ignored_layers: list[str] | None = None,
+        is_checkpoint_w4a8_serialized: bool = False,
+        quark_export_format: str | None = None,
+    ) -> None:
+        super().__init__()
+        if svd_rank is not None and svd_rank <= 0:
+            raise ValueError(f"svd_rank must be a positive integer, got {svd_rank!r}")
+        self.svd_rank = svd_rank
+        self.ignored_layers = ignored_layers or []
+        self.is_checkpoint_w4a8_serialized = is_checkpoint_w4a8_serialized
+        self.quark_export_format = quark_export_format
+
+    @classmethod
+    def get_name(cls) -> QuantizationMethods:
+        # Not a member of vllm's QuantizationMethods Literal; vllm-omni registers
+        # out-of-tree method names through the quantization factory, exactly as
+        # DiffusionMXFP4DualScaleMixedConfig does for "mxfp4_dualscale".
+        return "quark_w4a8"  # type: ignore[return-value]
+
+    @classmethod
+    def get_supported_act_dtypes(cls) -> list[torch.dtype]:
+        # The kernel returns bf16 and quantizes its own activations; fp16 in
+        # would silently round-trip through bf16.
+        return [torch.bfloat16]
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        # Only consulted on CUDA. ROCm gating happens in flydsl_w4a8.supports().
+        return 80
+
+    @classmethod
+    def get_config_filenames(cls) -> list[str]:
+        return []
+
+    def apply_vllm_mapper(self, hf_to_vllm_mapper: WeightsMapper) -> None:
+        if self.ignored_layers:
+            self.ignored_layers = hf_to_vllm_mapper.apply_list(self.ignored_layers)
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> DiffusionQuarkW4A8Config:
+        svd_rank = cls.get_from_keys_or(config, ["svd_rank", "rank"], None)
+        ignored_layers = cls.get_from_keys_or(config, ["ignored_layers"], None)
+        if not ignored_layers:
+            ignored_layers = cls.get_from_keys_or(config, ["modules_to_not_convert"], None)
+        is_serialized = cls.get_from_keys_or(config, ["is_checkpoint_w4a8_serialized"], False)
+        export_format = cls.get_from_keys_or(config, ["quark_export_format"], None)
+        return cls(
+            svd_rank=svd_rank,
+            ignored_layers=ignored_layers,
+            is_checkpoint_w4a8_serialized=is_serialized,
+            quark_export_format=export_format,
+        )
+
+    def get_quant_method(
+        self,
+        layer: torch.nn.Module,
+        prefix: str,
+    ) -> QuantizeMethodBase | None:
+        if not isinstance(layer, LinearBase):
+            return None
+
+        if is_layer_skipped(
+            prefix=prefix,
+            ignored_layers=self.ignored_layers,
+            fused_mapping=self.packed_modules_mapping,
+        ):
+            return UnquantizedLinearMethod()
+
+        usable, reason = flydsl_w4a8.supports()
+        if not usable:
+            raise NotImplementedError(f"quantization='quark_w4a8' is unavailable: {reason}")
+
+        in_features, out_features = layer.input_size, layer.output_size
+
+        if self.is_checkpoint_w4a8_serialized:
+            # Serialized checkpoint (exported by export_quark_svdquant_w4a8.py): BF16
+            # residual + optional low-rank factors on disk, packed to MXFP4 at load.
+            # The exporter guarantees factors exist iff the fused shape passes
+            # supports_svd_shape, so shape routing here stays consistent with what
+            # the checkpoint actually carries.
+            packed = self.quark_export_format == "mxfp4_packed"
+            if self.svd_rank is not None and flydsl_w4a8.supports_svd_shape(in_features, out_features):
+                return (QuarkW4A8SVDPackedLinearMethod if packed else QuarkW4A8SVDCheckpointLinearMethod)(self)
+            if flydsl_w4a8.supports_shape(in_features, out_features):
+                return (QuarkW4A8PackedLinearMethod if packed else QuarkW4A8CheckpointLinearMethod)(self)
+            logger.warning(
+                "quark_w4a8 (serialized): %s has shape (out=%d, in=%d), which the kernel "
+                "cannot tile; keeping this layer in BF16.",
+                prefix,
+                out_features,
+                in_features,
+            )
+            return UnquantizedLinearMethod()
+
+        if self.svd_rank is None:
+            if not flydsl_w4a8.supports_shape(in_features, out_features):
+                logger.warning(
+                    "quark_w4a8: %s has shape (out=%d, in=%d), which the W4A8 kernel cannot "
+                    "tile; keeping this layer in BF16.",
+                    prefix,
+                    out_features,
+                    in_features,
+                )
+                return UnquantizedLinearMethod()
+            return QuarkW4A8OnlineLinearMethod(self)
+
+        if not flydsl_w4a8.supports_svd_shape(in_features, out_features):
+            # Quark refuses these shapes outright rather than emitting garbage
+            # (flydsl_svdquant_inference_linear.py:115-126). Wan's proj_out,
+            # out=192, is the motivating case.
+            logger.warning(
+                "quark_w4a8(svd_rank=%d): %s has shape (out=%d, in=%d); the fused SVD epilogue "
+                "requires both >= 256 and a multiple of 256. Keeping this layer in BF16.",
+                self.svd_rank,
+                prefix,
+                out_features,
+                in_features,
+            )
+            return UnquantizedLinearMethod()
+        return QuarkW4A8SVDOnlineLinearMethod(self)
+
+
+# ---------------------------------------------------------------------------
+# Linear methods
+# ---------------------------------------------------------------------------
+
+
+def _reject_tp(layer: Module, variant: str) -> None:
+    """Refuse TP>1 rather than silently sharding the weight wrongly.
+
+    Plain W4A8 shards like any BF16 weight (each rank packs its own slice), but
+    it is untested here; the SVD branch additionally has no defined sharding for
+    ``proj_down``/``proj_up``, whose rank dimension is replicated.
+    """
+    tp_size = getattr(layer, "tp_size", 1)
+    if tp_size > 1:
+        raise NotImplementedError(f"quark_w4a8 ({variant}) has only been validated at TP=1, got tp_size={tp_size}.")
+
+
+class QuarkW4A8LinearMethod(MXFPLinearMethodBase):
+    """Plain W4A8: MXFP4 weight, dynamically quantized MXFP8 activation.
+
+    Load-time buffers, after ``process_weights_after_loading``:
+
+      ``_kernel_weight`` : MXFP4 e2m1, packed and shuffled for the FlyDSL GEMM
+      ``_kernel_scale``  : per-group-of-32 E8M0 exponents, same layout
+
+    Both are ``persistent=False``: they are derived from the BF16 checkpoint at
+    load and are tied to a specific kernel layout, so they must not leak into a
+    ``state_dict``. This mirrors Quark's own inference linear.
+
+    Forward path:
+      ``_quantize_activation`` passes through — activation quantization happens
+      inside the custom op, so that torch.compile sees one opaque node.
+    """
+
+    def __init__(self, quant_config: DiffusionQuarkW4A8Config) -> None:
+        self.quant_config = quant_config
+        self.out_dtype = torch.get_default_dtype()
+        flydsl_w4a8.register_ops()
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        _reject_tp(layer, "plain")
+        output_size_per_partition = sum(output_partition_sizes)
+
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+        layer.orig_dtype = params_dtype
+        layer.weight_block_size = None
+
+        layer.register_parameter(
+            "weight",
+            ModelWeightParameter(
+                data=torch.empty(
+                    output_size_per_partition,
+                    input_size_per_partition,
+                    dtype=params_dtype,
+                ),
+                input_dim=1,
+                output_dim=0,
+                weight_loader=extra_weight_attrs.get("weight_loader"),
+            ),
+        )
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        if getattr(layer, "_already_called_process_weights_after_loading", False):
+            return
+
+        packed, scale = flydsl_w4a8.pack_weight(layer.weight.data)
+        layer.register_buffer("_kernel_weight", packed, persistent=False)
+        layer.register_buffer("_kernel_scale", scale, persistent=False)
+
+        # Drop the BF16 copy immediately; on A14B the two experts are resident
+        # at once and the transient doubles peak load memory otherwise.
+        if isinstance(getattr(layer, "weight", None), torch.nn.Parameter):
+            delattr(layer, "weight")
+            layer.register_parameter("weight", None)
+
+        layer._already_called_process_weights_after_loading = True
+
+    def _quantize_activation(self, x: torch.Tensor) -> tuple[torch.Tensor, None]:
+        # Activation quantization to MXFP8 is inside the custom op called by
+        # _quant_matmul, so pass the raw activation through here.
+        return x, None
+
+    def _quant_matmul(
+        self,
+        x_q: torch.Tensor,
+        x_scale: torch.Tensor | None,
+        layer: torch.nn.Module,
+        bias: torch.Tensor | None,
+        ori_dtype: torch.dtype,
+    ) -> torch.Tensor:
+        output = torch.ops.vllm_omni.flydsl_w4a8_gemm(
+            x_q,
+            layer._kernel_weight,
+            layer._kernel_scale,
+            bias,
+            layer.output_size_per_partition,
+        )
+        if output.dtype != ori_dtype:
+            output = output.to(ori_dtype)
+        return output
+
+
+class QuarkW4A8OnlineLinearMethod(_LazyWeightMixin, QuarkW4A8LinearMethod):
+    """Plain W4A8 against a stock BF16 checkpoint.
+
+    MRO: QuarkW4A8OnlineLinearMethod -> _LazyWeightMixin -> QuarkW4A8LinearMethod
+         -> MXFPLinearMethodBase -> LinearMethodBase
+
+      create_weights  : _LazyWeightMixin  (meta device + patched loader, so the
+                        BF16 weight is materialised one layer at a time)
+      process_weights : here (meta -> materialise), then the base packs it
+      apply / ops     : QuarkW4A8LinearMethod / MXFPLinearMethodBase
+    """
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        _reject_tp(layer, "plain")
+        _LazyWeightMixin.create_weights(
+            self,
+            layer,
+            input_size_per_partition,
+            output_partition_sizes,
+            input_size,
+            output_size,
+            params_dtype,
+            **extra_weight_attrs,
+        )
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        if getattr(layer, "_already_called_process_weights_after_loading", False):
+            return
+
+        if layer.weight is not None and layer.weight.device == torch.device("meta"):
+            weight = ModelWeightParameter(
+                data=torch.empty_like(layer.weight, device=layer._load_device),
+                input_dim=1,
+                output_dim=0,
+                weight_loader=layer.weight.weight_loader,
+            )
+            _copy_missing_attrs(layer.weight, weight)
+            layer.register_parameter("weight", weight)
+            initialize_single_dummy_weight(layer.weight)
+
+        QuarkW4A8LinearMethod.process_weights_after_loading(self, layer)
+
+
+class QuarkW4A8SVDLinearMethod(QuarkW4A8LinearMethod):
+    """W4A8 plus a rank-R low-rank correction fused into the GEMM epilogue.
+
+    The quantized operand is the residual ``Wr = W - L2 @ L1``; the correction
+    is carried by two unquantized BF16 tensors:
+
+      ``proj_down`` : (R, K)  — ``L1``, applied as ``d = x @ L1.T`` in BF16
+      ``proj_up``   : (N, R)  — ``L2``, fused into the epilogue as ``d @ L2.T``
+
+    This class holds only the forward path. Where the factors come from is the
+    subclass's business, and today the only answer is
+    :class:`QuarkW4A8SVDOnlineLinearMethod`, which derives them from the BF16
+    weight at load time -- see its docstring for why there is no checkpoint
+    variant.
+    """
+
+    def _quant_matmul(
+        self,
+        x_q: torch.Tensor,
+        x_scale: torch.Tensor | None,
+        layer: torch.nn.Module,
+        bias: torch.Tensor | None,
+        ori_dtype: torch.dtype,
+    ) -> torch.Tensor:
+        output = torch.ops.vllm_omni.flydsl_w4a8_svd_gemm(
+            x_q,
+            layer._kernel_weight,
+            layer._kernel_scale,
+            layer.proj_down,
+            layer.proj_up,
+            bias,
+            layer.output_size_per_partition,
+        )
+        if output.dtype != ori_dtype:
+            output = output.to(ori_dtype)
+        return output
+
+
+def _low_rank_split(weight: torch.Tensor, rank: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Split ``W`` into ``L2 @ L1 + residual`` using its top-``rank`` subspace.
+
+    Returns ``(residual, proj_up, proj_down)`` with ``proj_up`` (N, R) and
+    ``proj_down`` (R, K), both carrying ``sqrt(s)`` so neither factor has a
+    wildly different dynamic range from the other.
+
+    ``svd_lowrank`` (randomized range finding) rather than a full SVD: only the
+    leading R directions are wanted, and a full decomposition of a 13824x5120
+    weight per layer would dominate model load time.
+
+    Note this is a *plain* weight SVD, not the activation-aware smoothing that
+    the SVDQuant paper describes -- that needs calibration data this path does
+    not have. It captures the low-rank term of the method and none of the
+    outlier migration, so treat its accuracy as a floor, not the published
+    result.
+    """
+    w = weight.float()
+    q = min(rank + 8, *w.shape)
+    u, s, v = torch.svd_lowrank(w, q=q, niter=4)
+    root = s[:rank].sqrt()
+    proj_up = u[:, :rank] * root
+    proj_down = root.unsqueeze(1) * v[:, :rank].T
+    residual = w - proj_up @ proj_down
+    return (
+        residual.to(weight.dtype),
+        proj_up.to(weight.dtype).contiguous(),
+        proj_down.to(weight.dtype).contiguous(),
+    )
+
+
+class QuarkW4A8SVDOnlineLinearMethod(_LazyWeightMixin, QuarkW4A8SVDLinearMethod):
+    """SVD-corrected W4A8 against a stock BF16 checkpoint.
+
+    The factors are derived from the weight at load time instead of read from
+    disk, for the same reason the plain variant quantizes at load time: no
+    exporter emits them. ``proj_down``/``proj_up`` are therefore registered as
+    non-persistent *buffers* in ``process_weights_after_loading`` rather than as
+    parameters in ``create_weights`` -- if they were parameters they would be
+    checkpoint keys that no checkpoint has.
+
+    MRO: -> _LazyWeightMixin -> QuarkW4A8SVDLinearMethod -> QuarkW4A8LinearMethod
+         -> MXFPLinearMethodBase -> LinearMethodBase
+    """
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        _reject_tp(layer, "svd")
+        _LazyWeightMixin.create_weights(
+            self,
+            layer,
+            input_size_per_partition,
+            output_partition_sizes,
+            input_size,
+            output_size,
+            params_dtype,
+            **extra_weight_attrs,
+        )
+        layer.svd_rank = self.quant_config.svd_rank
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        if getattr(layer, "_already_called_process_weights_after_loading", False):
+            return
+
+        if layer.weight is not None and layer.weight.device == torch.device("meta"):
+            weight = ModelWeightParameter(
+                data=torch.empty_like(layer.weight, device=layer._load_device),
+                input_dim=1,
+                output_dim=0,
+                weight_loader=layer.weight.weight_loader,
+            )
+            _copy_missing_attrs(layer.weight, weight)
+            layer.register_parameter("weight", weight)
+            initialize_single_dummy_weight(layer.weight)
+
+        residual, proj_up, proj_down = _low_rank_split(layer.weight.data, layer.svd_rank)
+        layer.register_buffer("proj_down", proj_down, persistent=False)
+        layer.register_buffer("proj_up", proj_up, persistent=False)
+        layer.weight.data = residual
+
+        QuarkW4A8LinearMethod.process_weights_after_loading(self, layer)
+
+
+# ---------------------------------------------------------------------------
+# Serialized-checkpoint linear methods (offline calibrated export)
+# ---------------------------------------------------------------------------
+
+
+class QuarkW4A8CheckpointLinearMethod(QuarkW4A8OnlineLinearMethod):
+    """Plain W4A8 from a serialized checkpoint.
+
+    Mechanically identical to the online plain method -- a BF16 weight is loaded
+    one layer at a time and packed to MXFP4 -- the only difference being the
+    weight is real calibrated/stock data from disk rather than dummy-initialized.
+    Reusing the online method keeps the lazy per-layer pack (no whole-model BF16
+    transient at load).
+    """
+
+
+def _swap_param_to_buffer(layer: Module, name: str, tensor: torch.Tensor) -> None:
+    if name in layer._parameters:
+        del layer._parameters[name]
+    layer.register_buffer(name, tensor.contiguous(), persistent=False)
+
+
+class QuarkW4A8SVDCheckpointLinearMethod(QuarkW4A8SVDLinearMethod):
+    """SVD-corrected W4A8 from a serialized checkpoint.
+
+    The residual ``weight`` and the ``proj_down`` / ``proj_up`` factors are all
+    read from disk (unlike :class:`QuarkW4A8SVDOnlineLinearMethod`, which derives
+    the factors from the weight at load). The exporter pre-fuses self-attention
+    QKV, so a fused ``to_qkv`` layer carries rank ``3 * svd_rank``; the per-layer
+    rank is recovered from ``len(output_partition_sizes)``.
+
+    Not lazy: all three tensors must be loaded before packing, and their load
+    order in the checkpoint is not guaranteed, so packing waits for vLLM's
+    post-load ``process_weights_after_loading`` call.
+    """
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        _reject_tp(layer, "svd")
+        weight_loader = extra_weight_attrs.get("weight_loader")
+        output_size_per_partition = sum(output_partition_sizes)
+
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+        layer.orig_dtype = params_dtype
+        layer.weight_block_size = None
+
+        # rank_eff is 3*svd_rank on a fused to_qkv (three output shards) and
+        # svd_rank on a single-shard linear -- matching the exporter's fusion.
+        # svd_rank is always set here: routing only picks this method when it is.
+        assert self.quant_config.svd_rank is not None
+        rank_eff = self.quant_config.svd_rank * len(output_partition_sizes)
+
+        layer.register_parameter(
+            "weight",
+            ModelWeightParameter(
+                data=torch.empty(output_size_per_partition, input_size_per_partition, dtype=params_dtype),
+                input_dim=1,
+                output_dim=0,
+                weight_loader=weight_loader,
+            ),
+        )
+        layer.register_parameter(
+            "proj_down",
+            ModelWeightParameter(
+                data=torch.empty(rank_eff, input_size_per_partition, dtype=params_dtype),
+                input_dim=1,
+                output_dim=0,
+                weight_loader=weight_loader,
+            ),
+        )
+        layer.register_parameter(
+            "proj_up",
+            ModelWeightParameter(
+                data=torch.empty(output_size_per_partition, rank_eff, dtype=params_dtype),
+                input_dim=1,
+                output_dim=0,
+                weight_loader=weight_loader,
+            ),
+        )
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        if getattr(layer, "_already_called_process_weights_after_loading", False):
+            return
+        proj_down = layer.proj_down.data
+        proj_up = layer.proj_up.data
+        # Packs the residual into _kernel_weight/_kernel_scale and drops the BF16
+        # weight. Deliberately skips _low_rank_split -- the factors are on disk.
+        QuarkW4A8LinearMethod.process_weights_after_loading(self, layer)
+        _swap_param_to_buffer(layer, "proj_down", proj_down)
+        _swap_param_to_buffer(layer, "proj_up", proj_up)
+        layer._already_called_process_weights_after_loading = True
+
+
+# ---------------------------------------------------------------------------
+# Pre-packed serialized checkpoints (--pack export: residual already in the
+# MXFP4 kernel layout on disk, no packing at load)
+# ---------------------------------------------------------------------------
+
+
+def _register_packed_weight(
+    layer: Module, input_size_per_partition: int, output_size_per_partition: int, weight_loader
+) -> None:
+    """Register the on-disk packed residual: ``weight_shuffle`` (N, K/2) and
+    ``weight_scale`` (N, K/32), both uint8.
+
+    K is always a multiple of 256 for a quantized layer (the shape gate enforces
+    it), so K/32 is a multiple of 8 and the E8M0 scale needs no padding -- the
+    shapes are exact. ``input_dim=None`` keeps the packed K axis unsharded;
+    ``output_dim=0`` lets the QKV/MLP shard loaders place row-slices (TP=1 only).
+    """
+    layer.register_parameter(
+        "weight_shuffle",
+        ModelWeightParameter(
+            data=torch.empty(output_size_per_partition, input_size_per_partition // 2, dtype=torch.uint8),
+            input_dim=None,
+            output_dim=0,
+            weight_loader=weight_loader,
+        ),
+    )
+    layer.register_parameter(
+        "weight_scale",
+        ModelWeightParameter(
+            data=torch.empty(output_size_per_partition, input_size_per_partition // 32, dtype=torch.uint8),
+            input_dim=None,
+            output_dim=0,
+            weight_loader=weight_loader,
+        ),
+    )
+
+
+def _install_packed_kernel_buffers(layer: Module) -> None:
+    """Hand the loaded packed bytes straight to the kernel buffers, no packing.
+
+    The GEMM op already consumes the uint8 views, so ``weight_shuffle`` /
+    ``weight_scale`` become ``_kernel_weight`` / ``_kernel_scale`` verbatim.
+    """
+    kernel_weight = layer.weight_shuffle.data
+    kernel_scale = layer.weight_scale.data
+    for name in ("weight_shuffle", "weight_scale"):
+        if name in layer._parameters:
+            del layer._parameters[name]
+    layer.register_buffer("_kernel_weight", kernel_weight, persistent=False)
+    layer.register_buffer("_kernel_scale", kernel_scale, persistent=False)
+
+
+class QuarkW4A8PackedLinearMethod(QuarkW4A8LinearMethod):
+    """Plain W4A8 from a pre-packed serialized checkpoint (``mxfp4_packed``)."""
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        _reject_tp(layer, "plain")
+        output_size_per_partition = sum(output_partition_sizes)
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+        layer.orig_dtype = params_dtype
+        layer.weight_block_size = None
+        _register_packed_weight(
+            layer, input_size_per_partition, output_size_per_partition, extra_weight_attrs.get("weight_loader")
+        )
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        if getattr(layer, "_already_called_process_weights_after_loading", False):
+            return
+        _install_packed_kernel_buffers(layer)
+        layer._already_called_process_weights_after_loading = True
+
+
+class QuarkW4A8SVDPackedLinearMethod(QuarkW4A8SVDLinearMethod):
+    """SVD W4A8 from a pre-packed serialized checkpoint: packed residual on disk,
+    BF16 ``proj_down`` / ``proj_up`` factors alongside it."""
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        _reject_tp(layer, "svd")
+        weight_loader = extra_weight_attrs.get("weight_loader")
+        output_size_per_partition = sum(output_partition_sizes)
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+        layer.orig_dtype = params_dtype
+        layer.weight_block_size = None
+        _register_packed_weight(layer, input_size_per_partition, output_size_per_partition, weight_loader)
+
+        assert self.quant_config.svd_rank is not None
+        rank_eff = self.quant_config.svd_rank * len(output_partition_sizes)
+        layer.register_parameter(
+            "proj_down",
+            ModelWeightParameter(
+                data=torch.empty(rank_eff, input_size_per_partition, dtype=params_dtype),
+                input_dim=1,
+                output_dim=0,
+                weight_loader=weight_loader,
+            ),
+        )
+        layer.register_parameter(
+            "proj_up",
+            ModelWeightParameter(
+                data=torch.empty(output_size_per_partition, rank_eff, dtype=params_dtype),
+                input_dim=1,
+                output_dim=0,
+                weight_loader=weight_loader,
+            ),
+        )
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        if getattr(layer, "_already_called_process_weights_after_loading", False):
+            return
+        proj_down = layer.proj_down.data
+        proj_up = layer.proj_up.data
+        _install_packed_kernel_buffers(layer)
+        _swap_param_to_buffer(layer, "proj_down", proj_down)
+        _swap_param_to_buffer(layer, "proj_up", proj_up)
+        layer._already_called_process_weights_after_loading = True

--- a/vllm_omni/quantization/quark_w4a8_config.py
+++ b/vllm_omni/quantization/quark_w4a8_config.py
@@ -36,13 +36,22 @@ serialized case. The on-disk weights are unpacked BF16 (packed to the kernel lay
 at load), because the shuffled MXFP4 layout is kernel-specific rather than a stable
 format.
 
-An opt-in ``quark_export_format="mxfp4_packed"`` checkpoint instead stores the
-residual already packed (``weight_shuffle``/``weight_scale`` uint8) -- ~4x smaller
-and no pack at load, handled by :class:`QuarkW4A8PackedLinearMethod` /
-:class:`QuarkW4A8SVDPackedLinearMethod`. This trades portability for size/speed: the
-packed layout is tied to the kernel's pack version.
+Two opt-in on-disk 4-bit formats (``quark_export_format``), both ~4x smaller than
+BF16 and tied to the kernel's pack version:
 
-Both variants only support TP=1 today; see ``_reject_tp`` below.
+* ``mxfp4_packed`` -- residual *preshuffled* into the kernel layout
+  (``weight_shuffle``/``weight_scale``), fastest load, **TP=1 only** (the shuffle
+  bakes in K/N). :class:`QuarkW4A8PackedLinearMethod` / ...SVD variant.
+* ``mxfp4_unshuffled`` -- residual in *natural* order (``weight_packed``/
+  ``weight_scale``), shardable for **TP>1**; each rank shuffles its shard at load
+  via ``flydsl_w4a8.shuffle_for_kernel``. :class:`QuarkW4A8UnshuffledLinearMethod`
+  (plain, column- and row-parallel) / :class:`QuarkW4A8SVDUnshuffledLinearMethod`
+  (SVD, column-parallel only -- row-parallel needs an all-reduce of the low-rank
+  term, not yet wired).
+
+TP support: only the ``mxfp4_unshuffled`` methods allow TP>1; every other path
+calls ``_reject_tp``. TP>1 is wired but unvalidated on multi-GPU (dev box has 1
+GPU); TP=1 is bit-identical to the packed path.
 """
 
 from __future__ import annotations
@@ -63,7 +72,12 @@ from vllm.model_executor.layers.quantization.base_config import (
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import is_layer_skipped
 from vllm.model_executor.model_loader.weight_utils import initialize_single_dummy_weight
-from vllm.model_executor.parameter import ModelWeightParameter
+from vllm.model_executor.parameter import (
+    BasevLLMParameter,
+    GroupQuantScaleParameter,
+    ModelWeightParameter,
+    PackedvLLMParameter,
+)
 
 from vllm_omni.quantization import flydsl_w4a8
 from vllm_omni.quantization._copy_missing_attrs import (
@@ -96,9 +110,9 @@ class DiffusionQuarkW4A8Config(QuantizationConfig):
             (BF16 residual + on-disk ``proj_down``/``proj_up`` factors) instead of
             quantizing a stock BF16 checkpoint at load. See the module docstring.
         quark_export_format: on-disk residual format of a serialized checkpoint.
-            ``"mxfp4_packed"`` = residual pre-packed to the kernel layout
-            (``weight_shuffle``/``weight_scale``); ``None``/``"bf16"`` = unpacked
-            BF16 residual packed at load.
+            ``None``/``"bf16"`` = unpacked BF16, packed at load; ``"mxfp4_packed"``
+            = preshuffled MXFP4 (TP=1); ``"mxfp4_unshuffled"`` = natural-order
+            MXFP4, shardable for TP>1 (shuffled per shard at load).
     """
 
     def __init__(
@@ -184,11 +198,19 @@ class DiffusionQuarkW4A8Config(QuantizationConfig):
             # The exporter guarantees factors exist iff the fused shape passes
             # supports_svd_shape, so shape routing here stays consistent with what
             # the checkpoint actually carries.
-            packed = self.quark_export_format == "mxfp4_packed"
+            fmt = self.quark_export_format
             if self.svd_rank is not None and flydsl_w4a8.supports_svd_shape(in_features, out_features):
-                return (QuarkW4A8SVDPackedLinearMethod if packed else QuarkW4A8SVDCheckpointLinearMethod)(self)
+                if fmt == "mxfp4_unshuffled":
+                    return QuarkW4A8SVDUnshuffledLinearMethod(self)
+                if fmt == "mxfp4_packed":
+                    return QuarkW4A8SVDPackedLinearMethod(self)
+                return QuarkW4A8SVDCheckpointLinearMethod(self)
             if flydsl_w4a8.supports_shape(in_features, out_features):
-                return (QuarkW4A8PackedLinearMethod if packed else QuarkW4A8CheckpointLinearMethod)(self)
+                if fmt == "mxfp4_unshuffled":
+                    return QuarkW4A8UnshuffledLinearMethod(self)
+                if fmt == "mxfp4_packed":
+                    return QuarkW4A8PackedLinearMethod(self)
+                return QuarkW4A8CheckpointLinearMethod(self)
             logger.warning(
                 "quark_w4a8 (serialized): %s has shape (out=%d, in=%d), which the kernel "
                 "cannot tile; keeping this layer in BF16.",
@@ -757,6 +779,167 @@ class QuarkW4A8SVDPackedLinearMethod(QuarkW4A8SVDLinearMethod):
         proj_down = layer.proj_down.data
         proj_up = layer.proj_up.data
         _install_packed_kernel_buffers(layer)
+        _swap_param_to_buffer(layer, "proj_down", proj_down)
+        _swap_param_to_buffer(layer, "proj_up", proj_up)
+        layer._already_called_process_weights_after_loading = True
+
+
+# ---------------------------------------------------------------------------
+# Unshuffled serialized checkpoints (--pack-format unshuffled): natural-order
+# MXFP4 on disk, shardable for TP>1; each rank shuffles its shard at load.
+# ---------------------------------------------------------------------------
+
+
+def _register_unshuffled_weight(
+    layer: Module, input_size_per_partition: int, output_size_per_partition: int, weight_loader
+) -> None:
+    """Register the shardable unshuffled MXFP4 residual.
+
+    ``weight_packed`` (N, K/2) as a ``PackedvLLMParameter`` (packed 2-per-byte on
+    K) and ``weight_scale`` (N, K/32) as a ``GroupQuantScaleParameter`` -- the
+    standard vLLM classes that shard a packed weight and a per-group scale along
+    the TP dim. Column-parallel shards N (``output_dim=0``); row-parallel shards
+    K (``input_dim=1``). K is always a multiple of 256, so a K-shard stays a
+    multiple of 256 (kernel) and 32 (scale group).
+    """
+    layer.register_parameter(
+        "weight_packed",
+        PackedvLLMParameter(
+            data=torch.empty(output_size_per_partition, input_size_per_partition // 2, dtype=torch.uint8),
+            input_dim=1,
+            output_dim=0,
+            packed_dim=1,
+            packed_factor=2,
+            weight_loader=weight_loader,
+        ),
+    )
+    layer.register_parameter(
+        "weight_scale",
+        GroupQuantScaleParameter(
+            data=torch.empty(output_size_per_partition, input_size_per_partition // 32, dtype=torch.uint8),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        ),
+    )
+
+
+def _install_unshuffled_kernel_buffers(layer: Module) -> None:
+    """Shuffle this rank's local shard into the kernel layout and drop the params.
+
+    Runs per rank after its shard is loaded, so the shuffle is applied to the
+    sharded (N/tp or K/tp) sub-matrix -- which is exactly what the per-rank GEMM
+    needs. At TP=1 this equals packing the whole weight (bytes verified equal).
+    """
+    kernel_weight, kernel_scale = flydsl_w4a8.shuffle_for_kernel(layer.weight_packed.data, layer.weight_scale.data)
+    for name in ("weight_packed", "weight_scale"):
+        if name in layer._parameters:
+            del layer._parameters[name]
+    layer.register_buffer("_kernel_weight", kernel_weight, persistent=False)
+    layer.register_buffer("_kernel_scale", kernel_scale, persistent=False)
+
+
+class QuarkW4A8UnshuffledLinearMethod(QuarkW4A8LinearMethod):
+    """Plain W4A8 from an unshuffled serialized checkpoint. TP>1 capable.
+
+    Both column-parallel (shard N) and row-parallel (shard K) work: vLLM shards
+    the natural-order ``weight_packed`` / ``weight_scale``, and each rank shuffles
+    its own shard into the kernel layout. Activations are quantized inside the
+    kernel per shard, so row-parallel needs no extra handling for the main GEMM.
+    """
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        output_size_per_partition = sum(output_partition_sizes)
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+        layer.orig_dtype = params_dtype
+        layer.weight_block_size = None
+        _register_unshuffled_weight(
+            layer, input_size_per_partition, output_size_per_partition, extra_weight_attrs.get("weight_loader")
+        )
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        if getattr(layer, "_already_called_process_weights_after_loading", False):
+            return
+        _install_unshuffled_kernel_buffers(layer)
+        layer._already_called_process_weights_after_loading = True
+
+
+class QuarkW4A8SVDUnshuffledLinearMethod(QuarkW4A8SVDLinearMethod):
+    """SVD W4A8 from an unshuffled serialized checkpoint, column-parallel TP.
+
+    Column-parallel (QKV, gate/up): ``proj_up`` (N, R) shards on N, ``proj_down``
+    (R, K) is **replicated** (K full), so the low-rank term needs no communication
+    -- ``d = x @ proj_down.T`` is identical on every rank and the fused epilogue
+    runs per shard. Row-parallel (K shard) is refused: it would need an all-reduce
+    of the (M, R) low-rank intermediate before ``proj_up``, which is not yet wired.
+    """
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        weight_loader = extra_weight_attrs.get("weight_loader")
+        output_size_per_partition = sum(output_partition_sizes)
+        tp_size = getattr(layer, "tp_size", 1)
+        # Row-parallel shards the input dim, so input_size_per_partition < input_size.
+        if tp_size > 1 and input_size_per_partition != input_size:
+            raise NotImplementedError(
+                "quark_w4a8 (svd) supports column-parallel TP only; row-parallel needs "
+                "an all-reduce of the low-rank term (not yet implemented). Got input "
+                f"sharded to {input_size_per_partition} of {input_size}."
+            )
+
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+        layer.orig_dtype = params_dtype
+        layer.weight_block_size = None
+        _register_unshuffled_weight(layer, input_size_per_partition, output_size_per_partition, weight_loader)
+
+        assert self.quant_config.svd_rank is not None
+        rank_eff = self.quant_config.svd_rank * len(output_partition_sizes)
+        # proj_up (N, rank_eff): shards on N with the output (column-parallel).
+        layer.register_parameter(
+            "proj_up",
+            ModelWeightParameter(
+                data=torch.empty(output_size_per_partition, rank_eff, dtype=params_dtype),
+                input_dim=1,
+                output_dim=0,
+                weight_loader=weight_loader,
+            ),
+        )
+        # proj_down (rank_eff, K): replicated -- K is full under column-parallel.
+        layer.register_parameter(
+            "proj_down",
+            BasevLLMParameter(
+                data=torch.empty(rank_eff, input_size_per_partition, dtype=params_dtype),
+                weight_loader=weight_loader,
+            ),
+        )
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        if getattr(layer, "_already_called_process_weights_after_loading", False):
+            return
+        proj_down = layer.proj_down.data
+        proj_up = layer.proj_up.data
+        _install_unshuffled_kernel_buffers(layer)
         _swap_param_to_buffer(layer, "proj_down", proj_down)
         _swap_param_to_buffer(layer, "proj_up", proj_up)
         layer._already_called_process_weights_after_loading = True

--- a/vllm_omni/quantization/quark_w4a8_config.py
+++ b/vllm_omni/quantization/quark_w4a8_config.py
@@ -4,27 +4,32 @@
 
 MXFP4 weights (groups of 32 K-elements sharing one ``float8_e8m0fnu`` exponent)
 multiplied against MXFP8 activations that are quantized *dynamically* inside the
-kernel. Two variants share this config, selected by ``svd_rank``:
+kernel. Three accuracy tiers, selected by ``svd_rank`` and the checkpoint:
 
-  ``svd_rank`` absent   plain      ``y = Q(x) @ Q(W).T + bias``
-  ``svd_rank`` present  SVDQuant   ``y = Q(x) @ Q(Wr).T + (x @ L1.T) @ L2.T + bias``
+  **plain W4A8 (RTN)**       ``svd_rank`` absent   ``y = Q(x) @ Q(W).T + bias``
+  **online W4A8 SVD**        ``svd_rank`` present, stock BF16 checkpoint
+  **calibrated W4A8 SVD**    ``svd_rank`` present, serialized checkpoint
+
+  SVD tiers: ``y = Q(x) @ Q(Wr).T + (x @ L1.T) @ L2.T + bias``
 
 where ``Wr = W - L2 @ L1`` is the 4-bit residual and the low-rank up-projection
-is fused into the GEMM epilogue, so both variants are one kernel launch.
+is fused into the GEMM epilogue, so every tier is one kernel launch.
 
 Checkpoint contract
 -------------------
 Two load modes, chosen by ``is_checkpoint_w4a8_serialized``:
 
-**Online (default, stock BF16 checkpoint).** Both variants read a stock BF16
-checkpoint and do all their work at load time -- no export step, nothing extra in
-the state dict. ``plain`` packs each weight to MXFP4 (RTN) as it loads; ``SVDQuant``
-additionally derives ``proj_down`` (R, K) / ``proj_up`` (N, R) from the weight with
-``torch.svd_lowrank`` and quantizes only the residual, keeping the factors as
-non-persistent buffers. This online SVD is a *weight* SVD, not the activation-aware
-smoothing the paper describes (see ``_low_rank_split``).
+**Online (default, stock BF16 checkpoint)** -- *plain W4A8 (RTN)* and *online W4A8
+SVD*. Both read a stock BF16 checkpoint and do all their work at load time -- no
+export step, nothing extra in the state dict. ``plain`` packs each weight to MXFP4
+(RTN) as it loads; the SVD tier additionally derives ``proj_down`` (R, K) /
+``proj_up`` (N, R) from the weight with ``torch.svd_lowrank`` and quantizes only
+the residual, keeping the factors as non-persistent buffers. This online SVD is a
+*weight* SVD, not the activation-aware smoothing the paper describes (see
+``_low_rank_split``).
 
-**Serialized (calibrated checkpoint).** A checkpoint produced offline by
+**Serialized (calibrated checkpoint)** -- *calibrated W4A8 SVD*. A checkpoint
+produced offline by
 ``examples/quantization/export_quark_svdquant_w4a8.py`` (Quark's
 ``SVDQuantProcessor``: SmoothQuant smoothing + exact SVD on the smoothed weight)
 carries the BF16 residual under ``weight`` and the calibrated factors under

--- a/vllm_omni/quantization/quark_w4a8_config.py
+++ b/vllm_omni/quantization/quark_w4a8_config.py
@@ -29,34 +29,30 @@ the residual, keeping the factors as non-persistent buffers. This online SVD is 
 ``_low_rank_split``).
 
 **Serialized (calibrated checkpoint)** -- *calibrated W4A8 SVD*. A checkpoint
-produced offline by
-``examples/quantization/export_quark_svdquant_w4a8.py`` (Quark's
-``SVDQuantProcessor``: SmoothQuant smoothing + exact SVD on the smoothed weight)
-carries the BF16 residual under ``weight`` and the calibrated factors under
-``proj_down`` / ``proj_up`` as ordinary checkpoint keys. Self-attention QKV is
-pre-fused in the exporter, so a fused ``to_qkv`` layer's factors have rank
-``3 * svd_rank``. :class:`QuarkW4A8SVDCheckpointLinearMethod` loads the factors
-instead of deriving them; :class:`QuarkW4A8CheckpointLinearMethod` handles the plain
-serialized case. The on-disk weights are unpacked BF16 (packed to the kernel layout
-at load), because the shuffled MXFP4 layout is kernel-specific rather than a stable
-format.
+produced offline by ``examples/quantization/export_quark_svdquant_w4a8.py``
+(Quark's ``SVDQuantProcessor``: SmoothQuant smoothing + exact SVD on the smoothed
+weight) carries the residual under ``weight`` and the calibrated factors under
+``proj_down`` / ``proj_up``. Self-attention QKV is pre-fused in the exporter, so a
+fused ``to_qkv`` layer's factors have rank ``3 * svd_rank``.
 
-Two opt-in on-disk 4-bit formats (``quark_export_format``), both ~4x smaller than
-BF16 and tied to the kernel's pack version:
+Implementation: two linear methods -- :class:`QuarkW4A8LinearMethod` (plain) and
+:class:`QuarkW4A8SVDLinearMethod` (adds the fused low-rank branch) -- delegate the
+residual's storage to a ``_Storage`` strategy, selected by ``quark_export_format``
+(a bad value is a ``KeyError`` at lookup, not a silent fallback):
 
-* ``mxfp4_packed`` -- residual *preshuffled* into the kernel layout
+* ``bf16`` (default) -- residual is BF16 on disk (or a stock weight), packed to
+  MXFP4 at load. **TP=1 only.**
+* ``mxfp4_packed`` -- residual *preshuffled* into the kernel layout on disk
   (``weight_shuffle``/``weight_scale``), fastest load, **TP=1 only** (the shuffle
-  bakes in K/N). :class:`QuarkW4A8PackedLinearMethod` / ...SVD variant.
+  bakes in K/N).
 * ``mxfp4_unshuffled`` -- residual in *natural* order (``weight_packed``/
   ``weight_scale``), shardable for **TP>1**; each rank shuffles its shard at load
-  via ``flydsl_w4a8.shuffle_for_kernel``. :class:`QuarkW4A8UnshuffledLinearMethod`
-  (plain, column- and row-parallel) / :class:`QuarkW4A8SVDUnshuffledLinearMethod`
-  (SVD, column-parallel only -- row-parallel needs an all-reduce of the low-rank
-  term, not yet wired).
+  via ``flydsl_w4a8.shuffle_for_kernel``.
 
-TP support: only the ``mxfp4_unshuffled`` methods allow TP>1; every other path
-calls ``_reject_tp``. TP>1 is wired but unvalidated on multi-GPU (dev box has 1
-GPU); TP=1 is bit-identical to the packed path.
+TP: ``_check_parallelism`` allows TP>1 only on the shardable (unshuffled) storage,
+and refuses row-parallel for the SVD method (the low-rank term would need an
+all-reduce). TP>1 is wired but unvalidated on multi-GPU (dev box has 1 GPU); TP=1
+is bit-identical to the packed path.
 """
 
 from __future__ import annotations
@@ -197,50 +193,22 @@ class DiffusionQuarkW4A8Config(QuantizationConfig):
 
         in_features, out_features = layer.input_size, layer.output_size
 
-        if self.is_checkpoint_w4a8_serialized:
-            # Serialized checkpoint (exported by export_quark_svdquant_w4a8.py): BF16
-            # residual + optional low-rank factors on disk, packed to MXFP4 at load.
-            # The exporter guarantees factors exist iff the fused shape passes
-            # supports_svd_shape, so shape routing here stays consistent with what
-            # the checkpoint actually carries.
-            fmt = self.quark_export_format
-            if self.svd_rank is not None and flydsl_w4a8.supports_svd_shape(in_features, out_features):
-                if fmt == "mxfp4_unshuffled":
-                    return QuarkW4A8SVDUnshuffledLinearMethod(self)
-                if fmt == "mxfp4_packed":
-                    return QuarkW4A8SVDPackedLinearMethod(self)
-                return QuarkW4A8SVDCheckpointLinearMethod(self)
-            if flydsl_w4a8.supports_shape(in_features, out_features):
-                if fmt == "mxfp4_unshuffled":
-                    return QuarkW4A8UnshuffledLinearMethod(self)
-                if fmt == "mxfp4_packed":
-                    return QuarkW4A8PackedLinearMethod(self)
-                return QuarkW4A8CheckpointLinearMethod(self)
-            logger.warning(
-                "quark_w4a8 (serialized): %s has shape (out=%d, in=%d), which the kernel "
-                "cannot tile; keeping this layer in BF16.",
-                prefix,
-                out_features,
-                in_features,
-            )
-            return UnquantizedLinearMethod()
+        # Residual storage: BF16 (packed at load) online, or the serialized
+        # checkpoint's on-disk format. An unknown quark_export_format is a clear
+        # KeyError here rather than a silent bf16 fallback.
+        storage = (
+            _STORAGES[self.quark_export_format or "bf16"] if self.is_checkpoint_w4a8_serialized else _STORAGES["bf16"]
+        )
 
-        if self.svd_rank is None:
-            if not flydsl_w4a8.supports_shape(in_features, out_features):
-                logger.warning(
-                    "quark_w4a8: %s has shape (out=%d, in=%d), which the W4A8 kernel cannot "
-                    "tile; keeping this layer in BF16.",
-                    prefix,
-                    out_features,
-                    in_features,
-                )
-                return UnquantizedLinearMethod()
-            return QuarkW4A8OnlineLinearMethod(self)
+        if self.svd_rank is not None and flydsl_w4a8.supports_svd_shape(in_features, out_features):
+            # Derive factors online (stock BF16); load them from a serialized checkpoint.
+            return QuarkW4A8SVDLinearMethod(self, storage, derive_factors=not self.is_checkpoint_w4a8_serialized)
 
-        if not flydsl_w4a8.supports_svd_shape(in_features, out_features):
-            # Quark refuses these shapes outright rather than emitting garbage
-            # (flydsl_svdquant_inference_linear.py:115-126). Wan's proj_out,
-            # out=192, is the motivating case.
+        if self.svd_rank is not None and not self.is_checkpoint_w4a8_serialized:
+            # Online svdquant on an SVD-rejected shape stays BF16 (the fused epilogue
+            # needs both dims >= 256 and a multiple of 256). A *serialized* checkpoint
+            # instead carries a plain 4-bit weight here -- the exporter folds the
+            # factors back into it -- so it falls through to the plain method below.
             logger.warning(
                 "quark_w4a8(svd_rank=%d): %s has shape (out=%d, in=%d); the fused SVD epilogue "
                 "requires both >= 256 and a multiple of 256. Keeping this layer in BF16.",
@@ -250,210 +218,69 @@ class DiffusionQuarkW4A8Config(QuantizationConfig):
                 in_features,
             )
             return UnquantizedLinearMethod()
-        return QuarkW4A8SVDOnlineLinearMethod(self)
+
+        if not flydsl_w4a8.supports_shape(in_features, out_features):
+            logger.warning(
+                "quark_w4a8: %s has shape (out=%d, in=%d), which the W4A8 kernel cannot "
+                "tile; keeping this layer in BF16.",
+                prefix,
+                out_features,
+                in_features,
+            )
+            return UnquantizedLinearMethod()
+        return QuarkW4A8LinearMethod(self, storage)
 
 
 # ---------------------------------------------------------------------------
 # Linear methods
+#
+# Three orthogonal axes -- residual storage (bf16 / packed / unshuffled MXFP4),
+# factor provenance (none / derived / loaded), forward op (plain / svd) --
+# expressed as two linear-method classes delegating storage to a ``_Storage``
+# strategy, rather than one class per combination. Mirrors upstream vLLM's
+# CompressedTensorsLinearMethod + CompressedTensorsScheme split.
 # ---------------------------------------------------------------------------
 
 
-def _reject_tp(layer: Module, variant: str) -> None:
-    """Refuse TP>1 rather than silently sharding the weight wrongly.
+def _init_layer_meta(
+    layer: Module,
+    input_size_per_partition: int,
+    output_partition_sizes: list[int],
+    params_dtype: torch.dtype,
+) -> None:
+    layer.logical_widths = output_partition_sizes
+    layer.input_size_per_partition = input_size_per_partition
+    layer.output_size_per_partition = sum(output_partition_sizes)
+    layer.orig_dtype = params_dtype
+    layer.weight_block_size = None
 
-    Plain W4A8 shards like any BF16 weight (each rank packs its own slice), but
-    it is untested here; the SVD branch additionally has no defined sharding for
-    ``proj_down``/``proj_up``, whose rank dimension is replicated.
-    """
-    tp_size = getattr(layer, "tp_size", 1)
-    if tp_size > 1:
-        raise NotImplementedError(f"quark_w4a8 ({variant}) has only been validated at TP=1, got tp_size={tp_size}.")
 
-
-class QuarkW4A8LinearMethod(MXFPLinearMethodBase):
-    """Plain W4A8: MXFP4 weight, dynamically quantized MXFP8 activation.
-
-    Load-time buffers, after ``process_weights_after_loading``:
-
-      ``_kernel_weight`` : MXFP4 e2m1, packed and shuffled for the FlyDSL GEMM
-      ``_kernel_scale``  : per-group-of-32 E8M0 exponents, same layout
-
-    Both are ``persistent=False``: they are derived from the BF16 checkpoint at
-    load and are tied to a specific kernel layout, so they must not leak into a
-    ``state_dict``. This mirrors Quark's own inference linear.
-
-    Forward path:
-      ``_quantize_activation`` passes through — activation quantization happens
-      inside the custom op, so that torch.compile sees one opaque node.
-    """
-
-    def __init__(self, quant_config: DiffusionQuarkW4A8Config) -> None:
-        self.quant_config = quant_config
-        self.out_dtype = torch.get_default_dtype()
-        flydsl_w4a8.register_ops()
-
-    def create_weights(
-        self,
-        layer: torch.nn.Module,
-        input_size_per_partition: int,
-        output_partition_sizes: list[int],
-        input_size: int,
-        output_size: int,
-        params_dtype: torch.dtype,
-        **extra_weight_attrs,
-    ) -> None:
-        _reject_tp(layer, "plain")
-        output_size_per_partition = sum(output_partition_sizes)
-
-        layer.logical_widths = output_partition_sizes
-        layer.input_size_per_partition = input_size_per_partition
-        layer.output_size_per_partition = output_size_per_partition
-        layer.orig_dtype = params_dtype
-        layer.weight_block_size = None
-
-        layer.register_parameter(
-            "weight",
-            ModelWeightParameter(
-                data=torch.empty(
-                    output_size_per_partition,
-                    input_size_per_partition,
-                    dtype=params_dtype,
-                ),
-                input_dim=1,
-                output_dim=0,
-                weight_loader=extra_weight_attrs.get("weight_loader"),
-            ),
+def _materialize_meta_weight(layer: Module) -> None:
+    """Meta -> real device for the lazy bf16 path when no real weight loaded
+    (dummy-weight init). A no-op once a checkpoint chunk has materialized it."""
+    if layer.weight is not None and layer.weight.device == torch.device("meta"):
+        weight = ModelWeightParameter(
+            data=torch.empty_like(layer.weight, device=layer._load_device),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=layer.weight.weight_loader,
         )
-
-    def process_weights_after_loading(self, layer: Module) -> None:
-        if getattr(layer, "_already_called_process_weights_after_loading", False):
-            return
-
-        packed, scale = flydsl_w4a8.pack_weight(layer.weight.data)
-        layer.register_buffer("_kernel_weight", packed, persistent=False)
-        layer.register_buffer("_kernel_scale", scale, persistent=False)
-
-        # Drop the BF16 copy immediately; on A14B the two experts are resident
-        # at once and the transient doubles peak load memory otherwise.
-        if isinstance(getattr(layer, "weight", None), torch.nn.Parameter):
-            delattr(layer, "weight")
-            layer.register_parameter("weight", None)
-
-        layer._already_called_process_weights_after_loading = True
-
-    def _quantize_activation(self, x: torch.Tensor) -> tuple[torch.Tensor, None]:
-        # Activation quantization to MXFP8 is inside the custom op called by
-        # _quant_matmul, so pass the raw activation through here.
-        return x, None
-
-    def _quant_matmul(
-        self,
-        x_q: torch.Tensor,
-        x_scale: torch.Tensor | None,
-        layer: torch.nn.Module,
-        bias: torch.Tensor | None,
-        ori_dtype: torch.dtype,
-    ) -> torch.Tensor:
-        output = torch.ops.vllm_omni.flydsl_w4a8_gemm(
-            x_q,
-            layer._kernel_weight,
-            layer._kernel_scale,
-            bias,
-            layer.output_size_per_partition,
-        )
-        if output.dtype != ori_dtype:
-            output = output.to(ori_dtype)
-        return output
+        _copy_missing_attrs(layer.weight, weight)
+        layer.register_parameter("weight", weight)
+        initialize_single_dummy_weight(layer.weight)
 
 
-class QuarkW4A8OnlineLinearMethod(_LazyWeightMixin, QuarkW4A8LinearMethod):
-    """Plain W4A8 against a stock BF16 checkpoint.
-
-    MRO: QuarkW4A8OnlineLinearMethod -> _LazyWeightMixin -> QuarkW4A8LinearMethod
-         -> MXFPLinearMethodBase -> LinearMethodBase
-
-      create_weights  : _LazyWeightMixin  (meta device + patched loader, so the
-                        BF16 weight is materialised one layer at a time)
-      process_weights : here (meta -> materialise), then the base packs it
-      apply / ops     : QuarkW4A8LinearMethod / MXFPLinearMethodBase
-    """
-
-    def create_weights(
-        self,
-        layer: torch.nn.Module,
-        input_size_per_partition: int,
-        output_partition_sizes: list[int],
-        input_size: int,
-        output_size: int,
-        params_dtype: torch.dtype,
-        **extra_weight_attrs,
-    ) -> None:
-        _reject_tp(layer, "plain")
-        _LazyWeightMixin.create_weights(
-            self,
-            layer,
-            input_size_per_partition,
-            output_partition_sizes,
-            input_size,
-            output_size,
-            params_dtype,
-            **extra_weight_attrs,
-        )
-
-    def process_weights_after_loading(self, layer: Module) -> None:
-        if getattr(layer, "_already_called_process_weights_after_loading", False):
-            return
-
-        if layer.weight is not None and layer.weight.device == torch.device("meta"):
-            weight = ModelWeightParameter(
-                data=torch.empty_like(layer.weight, device=layer._load_device),
-                input_dim=1,
-                output_dim=0,
-                weight_loader=layer.weight.weight_loader,
-            )
-            _copy_missing_attrs(layer.weight, weight)
-            layer.register_parameter("weight", weight)
-            initialize_single_dummy_weight(layer.weight)
-
-        QuarkW4A8LinearMethod.process_weights_after_loading(self, layer)
+def _drop_bf16_weight(layer: Module) -> None:
+    # A14B holds both experts resident, so free the BF16 copy at load.
+    if isinstance(getattr(layer, "weight", None), torch.nn.Parameter):
+        delattr(layer, "weight")
+        layer.register_parameter("weight", None)
 
 
-class QuarkW4A8SVDLinearMethod(QuarkW4A8LinearMethod):
-    """W4A8 plus a rank-R low-rank correction fused into the GEMM epilogue.
-
-    The quantized operand is the residual ``Wr = W - L2 @ L1``; the correction
-    is carried by two unquantized BF16 tensors:
-
-      ``proj_down`` : (R, K)  — ``L1``, applied as ``d = x @ L1.T`` in BF16
-      ``proj_up``   : (N, R)  — ``L2``, fused into the epilogue as ``d @ L2.T``
-
-    This class holds only the forward path. Where the factors come from is the
-    subclass's business, and today the only answer is
-    :class:`QuarkW4A8SVDOnlineLinearMethod`, which derives them from the BF16
-    weight at load time -- see its docstring for why there is no checkpoint
-    variant.
-    """
-
-    def _quant_matmul(
-        self,
-        x_q: torch.Tensor,
-        x_scale: torch.Tensor | None,
-        layer: torch.nn.Module,
-        bias: torch.Tensor | None,
-        ori_dtype: torch.dtype,
-    ) -> torch.Tensor:
-        output = torch.ops.vllm_omni.flydsl_w4a8_svd_gemm(
-            x_q,
-            layer._kernel_weight,
-            layer._kernel_scale,
-            layer.proj_down,
-            layer.proj_up,
-            bias,
-            layer.output_size_per_partition,
-        )
-        if output.dtype != ori_dtype:
-            output = output.to(ori_dtype)
-        return output
+def _swap_param_to_buffer(layer: Module, name: str, tensor: torch.Tensor) -> None:
+    if name in layer._parameters:
+        del layer._parameters[name]
+    layer.register_buffer(name, tensor.contiguous(), persistent=False)
 
 
 def _low_rank_split(weight: torch.Tensor, rank: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -487,19 +314,155 @@ def _low_rank_split(weight: torch.Tensor, rank: int) -> tuple[torch.Tensor, torc
     )
 
 
-class QuarkW4A8SVDOnlineLinearMethod(_LazyWeightMixin, QuarkW4A8SVDLinearMethod):
-    """SVD-corrected W4A8 against a stock BF16 checkpoint.
+# ---------------------------------------------------------------------------
+# Storage strategies: where the 4-bit operand comes from, how it reaches the
+# kernel buffers, and whether the on-disk tensors may be sharded for TP.
+# ---------------------------------------------------------------------------
 
-    The factors are derived from the weight at load time instead of read from
-    disk, for the same reason the plain variant quantizes at load time: no
-    exporter emits them. ``proj_down``/``proj_up`` are therefore registered as
-    non-persistent *buffers* in ``process_weights_after_loading`` rather than as
-    parameters in ``create_weights`` -- if they were parameters they would be
-    checkpoint keys that no checkpoint has.
 
-    MRO: -> _LazyWeightMixin -> QuarkW4A8SVDLinearMethod -> QuarkW4A8LinearMethod
-         -> MXFPLinearMethodBase -> LinearMethodBase
+class _Storage:
+    name: str
+    shardable: bool
+
+    def register(self, owner, layer, in_part, out_parts, in_size, out_size, dtype, extra) -> None:
+        raise NotImplementedError
+
+    def materialize(self, layer: Module) -> None:
+        pass
+
+    def install(self, layer: Module) -> tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError
+
+
+class Bf16Storage(_Storage):
+    """BF16 residual (stock weight or serialized bf16), quantized to MXFP4 at load.
+
+    Lazy (meta device + per-layer pack) when factors are derived or absent;
+    non-lazy when a serialized checkpoint also carries proj_down/proj_up, because
+    their load order relative to the weight is not guaranteed. Not shardable in
+    this build -- the per-rank pack is only validated at TP=1.
     """
+
+    name = "bf16"
+    shardable = False
+
+    def register(self, owner, layer, in_part, out_parts, in_size, out_size, dtype, extra) -> None:
+        if getattr(owner, "derive_factors", True):
+            _LazyWeightMixin.create_weights(owner, layer, in_part, out_parts, in_size, out_size, dtype, **extra)
+        else:
+            layer.register_parameter(
+                "weight",
+                ModelWeightParameter(
+                    data=torch.empty(sum(out_parts), in_part, dtype=dtype),
+                    input_dim=1,
+                    output_dim=0,
+                    weight_loader=extra.get("weight_loader"),
+                ),
+            )
+
+    def materialize(self, layer: Module) -> None:
+        _materialize_meta_weight(layer)
+
+    def install(self, layer: Module) -> tuple[torch.Tensor, torch.Tensor]:
+        packed, scale = flydsl_w4a8.pack_weight(layer.weight.data)
+        _drop_bf16_weight(layer)
+        return packed, scale
+
+
+class Mxfp4Storage(_Storage):
+    """4-bit residual on disk: (N, K/2) e2m1 pairs + (N, K/32) E8M0 scales.
+
+    ``shuffled=True`` is already in the GEMM's 16x16 tile layout: zero work at
+    load, but a logical slice is not a byte slice, so it is unshardable.
+    ``False`` is natural (N, K) order that each rank shards then shuffles -- what
+    enables TP>1. The two use different checkpoint keys so pointing the wrong
+    format at a checkpoint fails as a missing key instead of loading a permuted
+    tensor as natural-order and silently emitting garbage.
+    """
+
+    def __init__(self, shuffled: bool) -> None:
+        self.shuffled = shuffled
+        self.name = "mxfp4_packed" if shuffled else "mxfp4_unshuffled"
+        self.weight_key = "weight_shuffle" if shuffled else "weight_packed"
+        self.shardable = not shuffled
+
+    def register(self, owner, layer, in_part, out_parts, in_size, out_size, dtype, extra) -> None:
+        n, k, loader = sum(out_parts), in_part, extra.get("weight_loader")
+        # K is a multiple of 256 for any quantized layer (shape gate), so K/32 is
+        # a multiple of 8 and the E8M0 scale needs no padding -- shapes are exact.
+        if self.shuffled:
+            weight: ModelWeightParameter | PackedvLLMParameter = ModelWeightParameter(
+                data=torch.empty(n, k // 2, dtype=torch.uint8),
+                input_dim=None,
+                output_dim=0,
+                weight_loader=loader,
+            )
+            scale: ModelWeightParameter | GroupQuantScaleParameter = ModelWeightParameter(
+                data=torch.empty(n, k // 32, dtype=torch.uint8),
+                input_dim=None,
+                output_dim=0,
+                weight_loader=loader,
+            )
+        else:
+            weight = PackedvLLMParameter(
+                data=torch.empty(n, k // 2, dtype=torch.uint8),
+                input_dim=1,
+                output_dim=0,
+                packed_dim=1,
+                packed_factor=2,
+                weight_loader=loader,
+            )
+            scale = GroupQuantScaleParameter(
+                data=torch.empty(n, k // 32, dtype=torch.uint8),
+                input_dim=1,
+                output_dim=0,
+                weight_loader=loader,
+            )
+        layer.register_parameter(self.weight_key, weight)
+        layer.register_parameter("weight_scale", scale)
+
+    def install(self, layer: Module) -> tuple[torch.Tensor, torch.Tensor]:
+        weight = getattr(layer, self.weight_key).data
+        scale = layer.weight_scale.data
+        for name in (self.weight_key, "weight_scale"):
+            layer._parameters.pop(name, None)
+        if self.shuffled:
+            # The GEMM op consumes the uint8 views directly.
+            return weight, scale
+        # Shuffle this rank's local shard into the kernel layout (TP=1 -> identical
+        # bytes to packing the whole weight; verified equal on gfx950).
+        return flydsl_w4a8.shuffle_for_kernel(weight, scale)
+
+
+_STORAGES: dict[str, _Storage] = {
+    "bf16": Bf16Storage(),
+    "mxfp4_packed": Mxfp4Storage(shuffled=True),
+    "mxfp4_unshuffled": Mxfp4Storage(shuffled=False),
+}
+
+
+# ---------------------------------------------------------------------------
+# Linear methods: lifecycle skeleton; storage + factor hooks fill in the rest.
+# ---------------------------------------------------------------------------
+
+
+class QuarkW4A8LinearMethod(MXFPLinearMethodBase):
+    """Plain W4A8: MXFP4 weight, dynamically quantized MXFP8 activation.
+
+    After ``process_weights_after_loading`` the layer holds ``_kernel_weight`` /
+    ``_kernel_scale`` (non-persistent uint8 buffers in the FlyDSL GEMM layout);
+    where those bytes come from is the ``storage``'s business.
+    ``_quantize_activation`` passes through -- activation quantization is inside
+    the custom op, so torch.compile sees one opaque node.
+    """
+
+    row_parallel_ok = True
+
+    def __init__(self, quant_config: DiffusionQuarkW4A8Config, storage: _Storage) -> None:
+        self.quant_config = quant_config
+        self.storage = storage
+        self.out_dtype = torch.get_default_dtype()
+        flydsl_w4a8.register_ops()
 
     def create_weights(
         self,
@@ -511,8 +474,9 @@ class QuarkW4A8SVDOnlineLinearMethod(_LazyWeightMixin, QuarkW4A8SVDLinearMethod)
         params_dtype: torch.dtype,
         **extra_weight_attrs,
     ) -> None:
-        _reject_tp(layer, "svd")
-        _LazyWeightMixin.create_weights(
+        self._check_parallelism(layer, input_size_per_partition, input_size)
+        _init_layer_meta(layer, input_size_per_partition, output_partition_sizes, params_dtype)
+        self.storage.register(
             self,
             layer,
             input_size_per_partition,
@@ -520,431 +484,167 @@ class QuarkW4A8SVDOnlineLinearMethod(_LazyWeightMixin, QuarkW4A8SVDLinearMethod)
             input_size,
             output_size,
             params_dtype,
-            **extra_weight_attrs,
+            extra_weight_attrs,
         )
-        layer.svd_rank = self.quant_config.svd_rank
+        self._register_factors(
+            layer,
+            input_size_per_partition,
+            output_partition_sizes,
+            params_dtype,
+            extra_weight_attrs.get("weight_loader"),
+        )
 
     def process_weights_after_loading(self, layer: Module) -> None:
         if getattr(layer, "_already_called_process_weights_after_loading", False):
             return
+        self.storage.materialize(layer)
+        # Before install: may rewrite layer.weight (online SVD) or swap loaded
+        # factor params to buffers.
+        self._prepare_factors(layer)
+        kernel_weight, kernel_scale = self.storage.install(layer)
+        layer.register_buffer("_kernel_weight", kernel_weight, persistent=False)
+        layer.register_buffer("_kernel_scale", kernel_scale, persistent=False)
+        layer._already_called_process_weights_after_loading = True
 
-        if layer.weight is not None and layer.weight.device == torch.device("meta"):
-            weight = ModelWeightParameter(
-                data=torch.empty_like(layer.weight, device=layer._load_device),
-                input_dim=1,
-                output_dim=0,
-                weight_loader=layer.weight.weight_loader,
-            )
-            _copy_missing_attrs(layer.weight, weight)
-            layer.register_parameter("weight", weight)
-            initialize_single_dummy_weight(layer.weight)
-
-        residual, proj_up, proj_down = _low_rank_split(layer.weight.data, layer.svd_rank)
-        layer.register_buffer("proj_down", proj_down, persistent=False)
-        layer.register_buffer("proj_up", proj_up, persistent=False)
-        layer.weight.data = residual
-
-        QuarkW4A8LinearMethod.process_weights_after_loading(self, layer)
-
-
-# ---------------------------------------------------------------------------
-# Serialized-checkpoint linear methods (offline calibrated export)
-# ---------------------------------------------------------------------------
-
-
-class QuarkW4A8CheckpointLinearMethod(QuarkW4A8OnlineLinearMethod):
-    """Plain W4A8 from a serialized checkpoint.
-
-    Mechanically identical to the online plain method -- a BF16 weight is loaded
-    one layer at a time and packed to MXFP4 -- the only difference being the
-    weight is real calibrated/stock data from disk rather than dummy-initialized.
-    Reusing the online method keeps the lazy per-layer pack (no whole-model BF16
-    transient at load).
-    """
-
-
-def _swap_param_to_buffer(layer: Module, name: str, tensor: torch.Tensor) -> None:
-    if name in layer._parameters:
-        del layer._parameters[name]
-    layer.register_buffer(name, tensor.contiguous(), persistent=False)
-
-
-class QuarkW4A8SVDCheckpointLinearMethod(QuarkW4A8SVDLinearMethod):
-    """SVD-corrected W4A8 from a serialized checkpoint.
-
-    The residual ``weight`` and the ``proj_down`` / ``proj_up`` factors are all
-    read from disk (unlike :class:`QuarkW4A8SVDOnlineLinearMethod`, which derives
-    the factors from the weight at load). The exporter pre-fuses self-attention
-    QKV, so a fused ``to_qkv`` layer carries rank ``3 * svd_rank``; the per-layer
-    rank is recovered from ``len(output_partition_sizes)``.
-
-    Not lazy: all three tensors must be loaded before packing, and their load
-    order in the checkpoint is not guaranteed, so packing waits for vLLM's
-    post-load ``process_weights_after_loading`` call.
-    """
-
-    def create_weights(
+    def _register_factors(
         self,
-        layer: torch.nn.Module,
+        layer: Module,
         input_size_per_partition: int,
         output_partition_sizes: list[int],
-        input_size: int,
-        output_size: int,
         params_dtype: torch.dtype,
-        **extra_weight_attrs,
+        weight_loader,
     ) -> None:
-        _reject_tp(layer, "svd")
-        weight_loader = extra_weight_attrs.get("weight_loader")
-        output_size_per_partition = sum(output_partition_sizes)
+        pass
 
-        layer.logical_widths = output_partition_sizes
-        layer.input_size_per_partition = input_size_per_partition
-        layer.output_size_per_partition = output_size_per_partition
-        layer.orig_dtype = params_dtype
-        layer.weight_block_size = None
+    def _prepare_factors(self, layer: Module) -> None:
+        pass
 
+    def _check_parallelism(self, layer: Module, input_size_per_partition: int, input_size: int) -> None:
+        tp_size = getattr(layer, "tp_size", 1)
+        if tp_size > 1 and not self.storage.shardable:
+            raise NotImplementedError(
+                f"quark_w4a8: the {self.storage.name} residual format cannot be sharded; got tp_size={tp_size}."
+            )
+        # Row-parallel shards the input dim, so input_size_per_partition < input_size.
+        if tp_size > 1 and input_size_per_partition != input_size and not self.row_parallel_ok:
+            raise NotImplementedError(
+                "quark_w4a8 (svd): row-parallel TP needs an all-reduce of the low-rank term "
+                f"(not yet implemented). Got input sharded to {input_size_per_partition} of {input_size}."
+            )
+
+    def _quantize_activation(self, x: torch.Tensor) -> tuple[torch.Tensor, None]:
+        # Activation quantization to MXFP8 is inside the custom op called by
+        # _quant_matmul, so pass the raw activation through here.
+        return x, None
+
+    def _quant_matmul(
+        self,
+        x_q: torch.Tensor,
+        x_scale: torch.Tensor | None,
+        layer: torch.nn.Module,
+        bias: torch.Tensor | None,
+        ori_dtype: torch.dtype,
+    ) -> torch.Tensor:
+        output = torch.ops.vllm_omni.flydsl_w4a8_gemm(
+            x_q,
+            layer._kernel_weight,
+            layer._kernel_scale,
+            bias,
+            layer.output_size_per_partition,
+        )
+        if output.dtype != ori_dtype:
+            output = output.to(ori_dtype)
+        return output
+
+
+class QuarkW4A8SVDLinearMethod(QuarkW4A8LinearMethod):
+    """W4A8 plus a rank-R low-rank correction fused into the GEMM epilogue.
+
+    The 4-bit operand is the residual ``Wr = W - L2 @ L1``; ``proj_down`` (R, K)
+    and ``proj_up`` (N, R) stay BF16. ``derive_factors`` picks the provenance:
+    online (``svd_lowrank`` at load) vs loaded from a serialized checkpoint.
+    Row-parallel TP is refused -- the low-rank term would need an all-reduce.
+    """
+
+    row_parallel_ok = False
+
+    def __init__(self, quant_config: DiffusionQuarkW4A8Config, storage: _Storage, derive_factors: bool) -> None:
+        super().__init__(quant_config, storage)
+        self.derive_factors = derive_factors
+
+    def _register_factors(
+        self,
+        layer: Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        params_dtype: torch.dtype,
+        weight_loader,
+    ) -> None:
+        if self.derive_factors:
+            return  # derived in _prepare_factors and registered as buffers
         # rank_eff is 3*svd_rank on a fused to_qkv (three output shards) and
         # svd_rank on a single-shard linear -- matching the exporter's fusion.
-        # svd_rank is always set here: routing only picks this method when it is.
-        assert self.quant_config.svd_rank is not None
-        rank_eff = self.quant_config.svd_rank * len(output_partition_sizes)
-
-        layer.register_parameter(
-            "weight",
-            ModelWeightParameter(
-                data=torch.empty(output_size_per_partition, input_size_per_partition, dtype=params_dtype),
-                input_dim=1,
-                output_dim=0,
-                weight_loader=weight_loader,
-            ),
-        )
-        layer.register_parameter(
-            "proj_down",
-            ModelWeightParameter(
-                data=torch.empty(rank_eff, input_size_per_partition, dtype=params_dtype),
-                input_dim=1,
-                output_dim=0,
-                weight_loader=weight_loader,
-            ),
-        )
+        rank = self.quant_config.svd_rank
+        assert rank is not None
+        rank_eff = rank * len(output_partition_sizes)
         layer.register_parameter(
             "proj_up",
             ModelWeightParameter(
-                data=torch.empty(output_size_per_partition, rank_eff, dtype=params_dtype),
+                data=torch.empty(sum(output_partition_sizes), rank_eff, dtype=params_dtype),
                 input_dim=1,
                 output_dim=0,
                 weight_loader=weight_loader,
             ),
         )
-
-    def process_weights_after_loading(self, layer: Module) -> None:
-        if getattr(layer, "_already_called_process_weights_after_loading", False):
-            return
-        proj_down = layer.proj_down.data
-        proj_up = layer.proj_up.data
-        # Packs the residual into _kernel_weight/_kernel_scale and drops the BF16
-        # weight. Deliberately skips _low_rank_split -- the factors are on disk.
-        QuarkW4A8LinearMethod.process_weights_after_loading(self, layer)
-        _swap_param_to_buffer(layer, "proj_down", proj_down)
-        _swap_param_to_buffer(layer, "proj_up", proj_up)
-        layer._already_called_process_weights_after_loading = True
-
-
-# ---------------------------------------------------------------------------
-# Pre-packed serialized checkpoints (--pack export: residual already in the
-# MXFP4 kernel layout on disk, no packing at load)
-# ---------------------------------------------------------------------------
-
-
-def _register_packed_weight(
-    layer: Module, input_size_per_partition: int, output_size_per_partition: int, weight_loader
-) -> None:
-    """Register the on-disk packed residual: ``weight_shuffle`` (N, K/2) and
-    ``weight_scale`` (N, K/32), both uint8.
-
-    K is always a multiple of 256 for a quantized layer (the shape gate enforces
-    it), so K/32 is a multiple of 8 and the E8M0 scale needs no padding -- the
-    shapes are exact. ``input_dim=None`` keeps the packed K axis unsharded;
-    ``output_dim=0`` lets the QKV/MLP shard loaders place row-slices (TP=1 only).
-    """
-    layer.register_parameter(
-        "weight_shuffle",
-        ModelWeightParameter(
-            data=torch.empty(output_size_per_partition, input_size_per_partition // 2, dtype=torch.uint8),
-            input_dim=None,
-            output_dim=0,
-            weight_loader=weight_loader,
-        ),
-    )
-    layer.register_parameter(
-        "weight_scale",
-        ModelWeightParameter(
-            data=torch.empty(output_size_per_partition, input_size_per_partition // 32, dtype=torch.uint8),
-            input_dim=None,
-            output_dim=0,
-            weight_loader=weight_loader,
-        ),
-    )
-
-
-def _install_packed_kernel_buffers(layer: Module) -> None:
-    """Hand the loaded packed bytes straight to the kernel buffers, no packing.
-
-    The GEMM op already consumes the uint8 views, so ``weight_shuffle`` /
-    ``weight_scale`` become ``_kernel_weight`` / ``_kernel_scale`` verbatim.
-    """
-    kernel_weight = layer.weight_shuffle.data
-    kernel_scale = layer.weight_scale.data
-    for name in ("weight_shuffle", "weight_scale"):
-        if name in layer._parameters:
-            del layer._parameters[name]
-    layer.register_buffer("_kernel_weight", kernel_weight, persistent=False)
-    layer.register_buffer("_kernel_scale", kernel_scale, persistent=False)
-
-
-class QuarkW4A8PackedLinearMethod(QuarkW4A8LinearMethod):
-    """Plain W4A8 from a pre-packed serialized checkpoint (``mxfp4_packed``)."""
-
-    def create_weights(
-        self,
-        layer: torch.nn.Module,
-        input_size_per_partition: int,
-        output_partition_sizes: list[int],
-        input_size: int,
-        output_size: int,
-        params_dtype: torch.dtype,
-        **extra_weight_attrs,
-    ) -> None:
-        _reject_tp(layer, "plain")
-        output_size_per_partition = sum(output_partition_sizes)
-        layer.logical_widths = output_partition_sizes
-        layer.input_size_per_partition = input_size_per_partition
-        layer.output_size_per_partition = output_size_per_partition
-        layer.orig_dtype = params_dtype
-        layer.weight_block_size = None
-        _register_packed_weight(
-            layer, input_size_per_partition, output_size_per_partition, extra_weight_attrs.get("weight_loader")
-        )
-
-    def process_weights_after_loading(self, layer: Module) -> None:
-        if getattr(layer, "_already_called_process_weights_after_loading", False):
-            return
-        _install_packed_kernel_buffers(layer)
-        layer._already_called_process_weights_after_loading = True
-
-
-class QuarkW4A8SVDPackedLinearMethod(QuarkW4A8SVDLinearMethod):
-    """SVD W4A8 from a pre-packed serialized checkpoint: packed residual on disk,
-    BF16 ``proj_down`` / ``proj_up`` factors alongside it."""
-
-    def create_weights(
-        self,
-        layer: torch.nn.Module,
-        input_size_per_partition: int,
-        output_partition_sizes: list[int],
-        input_size: int,
-        output_size: int,
-        params_dtype: torch.dtype,
-        **extra_weight_attrs,
-    ) -> None:
-        _reject_tp(layer, "svd")
-        weight_loader = extra_weight_attrs.get("weight_loader")
-        output_size_per_partition = sum(output_partition_sizes)
-        layer.logical_widths = output_partition_sizes
-        layer.input_size_per_partition = input_size_per_partition
-        layer.output_size_per_partition = output_size_per_partition
-        layer.orig_dtype = params_dtype
-        layer.weight_block_size = None
-        _register_packed_weight(layer, input_size_per_partition, output_size_per_partition, weight_loader)
-
-        assert self.quant_config.svd_rank is not None
-        rank_eff = self.quant_config.svd_rank * len(output_partition_sizes)
-        layer.register_parameter(
-            "proj_down",
-            ModelWeightParameter(
-                data=torch.empty(rank_eff, input_size_per_partition, dtype=params_dtype),
-                input_dim=1,
-                output_dim=0,
-                weight_loader=weight_loader,
-            ),
-        )
-        layer.register_parameter(
-            "proj_up",
-            ModelWeightParameter(
-                data=torch.empty(output_size_per_partition, rank_eff, dtype=params_dtype),
-                input_dim=1,
-                output_dim=0,
-                weight_loader=weight_loader,
-            ),
-        )
-
-    def process_weights_after_loading(self, layer: Module) -> None:
-        if getattr(layer, "_already_called_process_weights_after_loading", False):
-            return
-        proj_down = layer.proj_down.data
-        proj_up = layer.proj_up.data
-        _install_packed_kernel_buffers(layer)
-        _swap_param_to_buffer(layer, "proj_down", proj_down)
-        _swap_param_to_buffer(layer, "proj_up", proj_up)
-        layer._already_called_process_weights_after_loading = True
-
-
-# ---------------------------------------------------------------------------
-# Unshuffled serialized checkpoints (--pack-format unshuffled): natural-order
-# MXFP4 on disk, shardable for TP>1; each rank shuffles its shard at load.
-# ---------------------------------------------------------------------------
-
-
-def _register_unshuffled_weight(
-    layer: Module, input_size_per_partition: int, output_size_per_partition: int, weight_loader
-) -> None:
-    """Register the shardable unshuffled MXFP4 residual.
-
-    ``weight_packed`` (N, K/2) as a ``PackedvLLMParameter`` (packed 2-per-byte on
-    K) and ``weight_scale`` (N, K/32) as a ``GroupQuantScaleParameter`` -- the
-    standard vLLM classes that shard a packed weight and a per-group scale along
-    the TP dim. Column-parallel shards N (``output_dim=0``); row-parallel shards
-    K (``input_dim=1``). K is always a multiple of 256, so a K-shard stays a
-    multiple of 256 (kernel) and 32 (scale group).
-    """
-    layer.register_parameter(
-        "weight_packed",
-        PackedvLLMParameter(
-            data=torch.empty(output_size_per_partition, input_size_per_partition // 2, dtype=torch.uint8),
-            input_dim=1,
-            output_dim=0,
-            packed_dim=1,
-            packed_factor=2,
-            weight_loader=weight_loader,
-        ),
-    )
-    layer.register_parameter(
-        "weight_scale",
-        GroupQuantScaleParameter(
-            data=torch.empty(output_size_per_partition, input_size_per_partition // 32, dtype=torch.uint8),
-            input_dim=1,
-            output_dim=0,
-            weight_loader=weight_loader,
-        ),
-    )
-
-
-def _install_unshuffled_kernel_buffers(layer: Module) -> None:
-    """Shuffle this rank's local shard into the kernel layout and drop the params.
-
-    Runs per rank after its shard is loaded, so the shuffle is applied to the
-    sharded (N/tp or K/tp) sub-matrix -- which is exactly what the per-rank GEMM
-    needs. At TP=1 this equals packing the whole weight (bytes verified equal).
-    """
-    kernel_weight, kernel_scale = flydsl_w4a8.shuffle_for_kernel(layer.weight_packed.data, layer.weight_scale.data)
-    for name in ("weight_packed", "weight_scale"):
-        if name in layer._parameters:
-            del layer._parameters[name]
-    layer.register_buffer("_kernel_weight", kernel_weight, persistent=False)
-    layer.register_buffer("_kernel_scale", kernel_scale, persistent=False)
-
-
-class QuarkW4A8UnshuffledLinearMethod(QuarkW4A8LinearMethod):
-    """Plain W4A8 from an unshuffled serialized checkpoint. TP>1 capable.
-
-    Both column-parallel (shard N) and row-parallel (shard K) work: vLLM shards
-    the natural-order ``weight_packed`` / ``weight_scale``, and each rank shuffles
-    its own shard into the kernel layout. Activations are quantized inside the
-    kernel per shard, so row-parallel needs no extra handling for the main GEMM.
-    """
-
-    def create_weights(
-        self,
-        layer: torch.nn.Module,
-        input_size_per_partition: int,
-        output_partition_sizes: list[int],
-        input_size: int,
-        output_size: int,
-        params_dtype: torch.dtype,
-        **extra_weight_attrs,
-    ) -> None:
-        output_size_per_partition = sum(output_partition_sizes)
-        layer.logical_widths = output_partition_sizes
-        layer.input_size_per_partition = input_size_per_partition
-        layer.output_size_per_partition = output_size_per_partition
-        layer.orig_dtype = params_dtype
-        layer.weight_block_size = None
-        _register_unshuffled_weight(
-            layer, input_size_per_partition, output_size_per_partition, extra_weight_attrs.get("weight_loader")
-        )
-
-    def process_weights_after_loading(self, layer: Module) -> None:
-        if getattr(layer, "_already_called_process_weights_after_loading", False):
-            return
-        _install_unshuffled_kernel_buffers(layer)
-        layer._already_called_process_weights_after_loading = True
-
-
-class QuarkW4A8SVDUnshuffledLinearMethod(QuarkW4A8SVDLinearMethod):
-    """SVD W4A8 from an unshuffled serialized checkpoint, column-parallel TP.
-
-    Column-parallel (QKV, gate/up): ``proj_up`` (N, R) shards on N, ``proj_down``
-    (R, K) is **replicated** (K full), so the low-rank term needs no communication
-    -- ``d = x @ proj_down.T`` is identical on every rank and the fused epilogue
-    runs per shard. Row-parallel (K shard) is refused: it would need an all-reduce
-    of the (M, R) low-rank intermediate before ``proj_up``, which is not yet wired.
-    """
-
-    def create_weights(
-        self,
-        layer: torch.nn.Module,
-        input_size_per_partition: int,
-        output_partition_sizes: list[int],
-        input_size: int,
-        output_size: int,
-        params_dtype: torch.dtype,
-        **extra_weight_attrs,
-    ) -> None:
-        weight_loader = extra_weight_attrs.get("weight_loader")
-        output_size_per_partition = sum(output_partition_sizes)
-        tp_size = getattr(layer, "tp_size", 1)
-        # Row-parallel shards the input dim, so input_size_per_partition < input_size.
-        if tp_size > 1 and input_size_per_partition != input_size:
-            raise NotImplementedError(
-                "quark_w4a8 (svd) supports column-parallel TP only; row-parallel needs "
-                "an all-reduce of the low-rank term (not yet implemented). Got input "
-                f"sharded to {input_size_per_partition} of {input_size}."
+        # Under column-parallel TP (shardable storage) proj_down (rank_eff, K) is
+        # replicated because K stays full, so it carries no shard metadata.
+        if self.storage.shardable:
+            layer.register_parameter(
+                "proj_down",
+                BasevLLMParameter(
+                    data=torch.empty(rank_eff, input_size_per_partition, dtype=params_dtype),
+                    weight_loader=weight_loader,
+                ),
+            )
+        else:
+            layer.register_parameter(
+                "proj_down",
+                ModelWeightParameter(
+                    data=torch.empty(rank_eff, input_size_per_partition, dtype=params_dtype),
+                    input_dim=1,
+                    output_dim=0,
+                    weight_loader=weight_loader,
+                ),
             )
 
-        layer.logical_widths = output_partition_sizes
-        layer.input_size_per_partition = input_size_per_partition
-        layer.output_size_per_partition = output_size_per_partition
-        layer.orig_dtype = params_dtype
-        layer.weight_block_size = None
-        _register_unshuffled_weight(layer, input_size_per_partition, output_size_per_partition, weight_loader)
+    def _prepare_factors(self, layer: Module) -> None:
+        if self.derive_factors:
+            assert self.quant_config.svd_rank is not None
+            residual, proj_up, proj_down = _low_rank_split(layer.weight.data, self.quant_config.svd_rank)
+            layer.weight.data = residual
+            layer.register_buffer("proj_down", proj_down, persistent=False)
+            layer.register_buffer("proj_up", proj_up, persistent=False)
+        else:
+            _swap_param_to_buffer(layer, "proj_down", layer.proj_down.data)
+            _swap_param_to_buffer(layer, "proj_up", layer.proj_up.data)
 
-        assert self.quant_config.svd_rank is not None
-        rank_eff = self.quant_config.svd_rank * len(output_partition_sizes)
-        # proj_up (N, rank_eff): shards on N with the output (column-parallel).
-        layer.register_parameter(
-            "proj_up",
-            ModelWeightParameter(
-                data=torch.empty(output_size_per_partition, rank_eff, dtype=params_dtype),
-                input_dim=1,
-                output_dim=0,
-                weight_loader=weight_loader,
-            ),
+    def _quant_matmul(
+        self,
+        x_q: torch.Tensor,
+        x_scale: torch.Tensor | None,
+        layer: torch.nn.Module,
+        bias: torch.Tensor | None,
+        ori_dtype: torch.dtype,
+    ) -> torch.Tensor:
+        output = torch.ops.vllm_omni.flydsl_w4a8_svd_gemm(
+            x_q,
+            layer._kernel_weight,
+            layer._kernel_scale,
+            layer.proj_down,
+            layer.proj_up,
+            bias,
+            layer.output_size_per_partition,
         )
-        # proj_down (rank_eff, K): replicated -- K is full under column-parallel.
-        layer.register_parameter(
-            "proj_down",
-            BasevLLMParameter(
-                data=torch.empty(rank_eff, input_size_per_partition, dtype=params_dtype),
-                weight_loader=weight_loader,
-            ),
-        )
-
-    def process_weights_after_loading(self, layer: Module) -> None:
-        if getattr(layer, "_already_called_process_weights_after_loading", False):
-            return
-        proj_down = layer.proj_down.data
-        proj_up = layer.proj_up.data
-        _install_unshuffled_kernel_buffers(layer)
-        _swap_param_to_buffer(layer, "proj_down", proj_down)
-        _swap_param_to_buffer(layer, "proj_up", proj_up)
-        layer._already_called_process_weights_after_loading = True
+        if output.dtype != ori_dtype:
+            output = output.to(ori_dtype)
+        return output

--- a/vllm_omni/quantization/quark_w4a8_config.py
+++ b/vllm_omni/quantization/quark_w4a8_config.py
@@ -49,10 +49,11 @@ residual's storage to a ``_Storage`` strategy, selected by ``quark_export_format
   ``weight_scale``), shardable for **TP>1**; each rank shuffles its shard at load
   via ``flydsl_w4a8.shuffle_for_kernel``.
 
-TP: ``_check_parallelism`` allows TP>1 only on the shardable (unshuffled) storage,
-and refuses row-parallel for the SVD method (the low-rank term would need an
-all-reduce). TP>1 is wired but unvalidated on multi-GPU (dev box has 1 GPU); TP=1
-is bit-identical to the packed path.
+TP: ``_check_parallelism`` allows TP>1 only on the shardable (unshuffled) storage.
+Plain and SVD both support column- and row-parallel; the SVD low-rank term needs
+no new collective -- its per-rank partial ``d_p @ proj_up.T`` rides the layer's
+existing output all-reduce. TP>1 is wired but unvalidated on multi-GPU (dev box has
+1 GPU); TP=1 is bit-identical to the packed path.
 """
 
 from __future__ import annotations
@@ -74,10 +75,11 @@ from vllm.model_executor.layers.quantization.base_config import (
 from vllm.model_executor.layers.quantization.utils.quant_utils import is_layer_skipped
 from vllm.model_executor.model_loader.weight_utils import initialize_single_dummy_weight
 from vllm.model_executor.parameter import (
-    BasevLLMParameter,
     GroupQuantScaleParameter,
     ModelWeightParameter,
     PackedvLLMParameter,
+    RowvLLMParameter,
+    _ColumnvLLMParameter,
 )
 
 from vllm_omni.quantization import flydsl_w4a8
@@ -563,10 +565,15 @@ class QuarkW4A8SVDLinearMethod(QuarkW4A8LinearMethod):
     The 4-bit operand is the residual ``Wr = W - L2 @ L1``; ``proj_down`` (R, K)
     and ``proj_up`` (N, R) stay BF16. ``derive_factors`` picks the provenance:
     online (``svd_lowrank`` at load) vs loaded from a serialized checkpoint.
-    Row-parallel TP is refused -- the low-rank term would need an all-reduce.
+
+    Column- and row-parallel both work on a shardable storage: each factor is
+    registered on the layer axis it shares (``proj_up`` on N, ``proj_down`` on K),
+    so vLLM shards it for the matching parallelism and replicates it otherwise.
+    Row-parallel needs no new collective -- by linearity the per-rank partial
+    ``d_p @ proj_up.T`` rides the layer's existing output all-reduce.
     """
 
-    row_parallel_ok = False
+    row_parallel_ok = True
 
     def __init__(self, quant_config: DiffusionQuarkW4A8Config, storage: _Storage, derive_factors: bool) -> None:
         super().__init__(quant_config, storage)
@@ -587,35 +594,28 @@ class QuarkW4A8SVDLinearMethod(QuarkW4A8LinearMethod):
         rank = self.quant_config.svd_rank
         assert rank is not None
         rank_eff = rank * len(output_partition_sizes)
+        # Each factor shares exactly one of the layer's axes, so register it on
+        # that axis with a single-axis parameter class: vLLM shards it for the
+        # matching parallelism and replicates it for the other. No row/column
+        # branch, and row-parallel needs no new collective.
+        #   proj_up   (N, rank_eff) -> output axis N (column shards, row replicates)
+        #   proj_down (rank_eff, K) -> input axis K  (row shards, column replicates)
         layer.register_parameter(
             "proj_up",
-            ModelWeightParameter(
+            _ColumnvLLMParameter(
                 data=torch.empty(sum(output_partition_sizes), rank_eff, dtype=params_dtype),
-                input_dim=1,
                 output_dim=0,
                 weight_loader=weight_loader,
             ),
         )
-        # Under column-parallel TP (shardable storage) proj_down (rank_eff, K) is
-        # replicated because K stays full, so it carries no shard metadata.
-        if self.storage.shardable:
-            layer.register_parameter(
-                "proj_down",
-                BasevLLMParameter(
-                    data=torch.empty(rank_eff, input_size_per_partition, dtype=params_dtype),
-                    weight_loader=weight_loader,
-                ),
-            )
-        else:
-            layer.register_parameter(
-                "proj_down",
-                ModelWeightParameter(
-                    data=torch.empty(rank_eff, input_size_per_partition, dtype=params_dtype),
-                    input_dim=1,
-                    output_dim=0,
-                    weight_loader=weight_loader,
-                ),
-            )
+        layer.register_parameter(
+            "proj_down",
+            RowvLLMParameter(
+                data=torch.empty(rank_eff, input_size_per_partition, dtype=params_dtype),
+                input_dim=1,
+                weight_loader=weight_loader,
+            ),
+        )
 
     def _prepare_factors(self, layer: Module) -> None:
         if self.derive_factors:

--- a/vllm_omni/quantization/tools/compare_diffusion_trajectory_similarity.py
+++ b/vllm_omni/quantization/tools/compare_diffusion_trajectory_similarity.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Compare diffusion quantization quality with final output metrics.
 
 This tool runs a reference diffusion configuration and a candidate
@@ -221,14 +221,44 @@ def compute_uint8_image_metrics(lhs: Any, rhs: Any) -> dict[str, float]:
     return metrics
 
 
+def _frame_to_uint8_rgb(frame: Any) -> np.ndarray:
+    """Return an (H, W, 3) uint8 array for one generated frame.
+
+    t2i pipelines hand back PIL images, but t2v pipelines hand back raw
+    ``torch.Tensor``/``np.ndarray`` frames in [0, 1] (channels first or last),
+    so both have to be accepted here.
+    """
+    if hasattr(frame, "convert"):  # PIL.Image
+        return np.asarray(frame.convert("RGB"))
+
+    if isinstance(frame, torch.Tensor):
+        array = frame.detach().cpu().float().numpy()
+    else:
+        array = np.asarray(frame)
+
+    if array.ndim == 3 and array.shape[0] in (1, 3, 4) and array.shape[-1] not in (1, 3, 4):
+        array = np.transpose(array, (1, 2, 0))
+    if array.ndim == 2:
+        array = array[..., None]
+
+    if not np.issubdtype(array.dtype, np.integer):
+        array = np.clip(array.astype(np.float32), 0.0, 1.0) * 255.0
+        array = array.round()
+    array = np.clip(array, 0, 255).astype(np.uint8)
+
+    if array.shape[-1] == 1:
+        array = np.repeat(array, 3, axis=-1)
+    return array[..., :3]
+
+
 def summarize_output_frame_metrics(reference_frames: list[Any], candidate_frames: list[Any]) -> dict[str, Any]:
     if len(reference_frames) != len(candidate_frames):
         raise ValueError(f"Output frame count mismatch: {len(reference_frames)} vs {len(candidate_frames)}")
     if not reference_frames:
         raise ValueError("No output frames available for comparison.")
 
-    ref_stack = np.stack([np.asarray(frame.convert("RGB")) for frame in reference_frames], axis=0)
-    cand_stack = np.stack([np.asarray(frame.convert("RGB")) for frame in candidate_frames], axis=0)
+    ref_stack = np.stack([_frame_to_uint8_rgb(frame) for frame in reference_frames], axis=0)
+    cand_stack = np.stack([_frame_to_uint8_rgb(frame) for frame in candidate_frames], axis=0)
 
     frame0_metrics = compute_uint8_image_metrics(ref_stack[0], cand_stack[0])
     mid_index = len(reference_frames) // 2
@@ -424,6 +454,22 @@ def _get_output_frames(result: Any) -> list[Any]:
     images = list(getattr(result, "images", []) or [])
     if len(images) == 1 and isinstance(images[0], list):
         return list(images[0])
+    if len(images) == 1 and not hasattr(images[0], "convert"):
+        # t2v pipelines return the whole clip as one (T, H, W, C) array or an
+        # extra-batched (1, T, H, W, C) one, rather than a list of PIL frames.
+        # Unroll it so every downstream metric is per-frame.
+        clip = images[0]
+        if isinstance(clip, torch.Tensor):
+            clip = clip.detach().cpu()
+        ndim = getattr(clip, "ndim", 0)
+        if ndim == 5:
+            clip = clip[0]
+            ndim = 4
+        if ndim == 4:
+            if clip.shape[0] in (1, 3, 4) and clip.shape[-1] not in (1, 3, 4):
+                # channels-first (C, T, H, W)
+                clip = clip.permute(1, 2, 3, 0) if isinstance(clip, torch.Tensor) else np.transpose(clip, (1, 2, 3, 0))
+            return list(clip)
     return images
 
 
@@ -436,13 +482,15 @@ def _save_outputs(result: Any, output_dir: Path, label: str, task: str, fps: int
     variant_dir.mkdir(parents=True, exist_ok=True)
     if task == "t2v":
         from diffusers.utils import export_to_video
+        from PIL import Image
 
+        rgb = [_frame_to_uint8_rgb(frame) for frame in frames]
         video_path = variant_dir / "video.mp4"
-        export_to_video(frames, str(video_path), fps=fps)
+        export_to_video([Image.fromarray(frame) for frame in rgb], str(video_path), fps=fps)
         saved.append(str(video_path))
-        for idx in (0, len(frames) // 2, len(frames) - 1):
+        for idx in (0, len(rgb) // 2, len(rgb) - 1):
             path = variant_dir / f"frame_{idx}.png"
-            frames[idx].save(path)
+            Image.fromarray(rgb[idx]).save(path)
             saved.append(str(path))
         return saved
     for idx, image in enumerate(frames):


### PR DESCRIPTION
## Purpose
Adds **W4A8** quantization for Wan2.2 diffusion transformers on ROCm/gfx950 (MI355X): MXFP4 weights + dynamically-quantized MXFP8 activat>

**Three accuracy tiers, two `--quantization` methods** (all one kernel launch):

| Tier | `--quantization` | Correction | Offline setup |
| --- | --- | --- | --- |
| plain W4A8 (RTN) | `quark_w4a8` | none | none |
| online W4A8 SVD | `quark_svdquant` | low-rank, derived at load (uncalibrated) | none |
| calibrated W4A8 SVD | `quark_svdquant` | low-rank, activation-calibrated | one export |

The two SVD tiers are the same method; the checkpoint (`is_checkpoint_w4a8_serialized`) selects online vs calibrated.

- **Online** (stock BF16): plain RTN; SVD derives `L1`/`L2` with `torch.svd_lowrank` (an accuracy floor  ^`^t uncalibrated).
- **Offline** (`examples/quantization/export_quark_svdquant_w4a8.py`): runs Quark's calibrated `SVDQuantProcessor` (SmoothQuant + exact S>
- **On-disk formats** (`--pack-format`): `bf16` (default), `mxfp4_packed` (preshuffled, TP=1, fastest load), `mxfp4_unshuffled` (natural->
- **Tensor parallelism** on `mxfp4_unshuffled`: plain and SVD both support column- and row-parallel. Row-parallel SVD needs **no extra co>

gfx950-only, loud BF16 fallback for untileable layers. Quark is imported lazily, so the serve path stays Quark-free.

> **Requires** AMD Quark PR [#6079](https://gitenterprise.xilinx.com/AMDNeuralOpt/Quark/pull/6079) (branch `xiaoyu/svd-quant-flydsl`)


## Test Plan

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
