### PR TITLE
[LingBot World] Enable serialized NVFP4 transformer loading

### DIFF
--- a/tests/diffusion/models/lingbot_world/test_lingbot_world_attention.py
+++ b/tests/diffusion/models/lingbot_world/test_lingbot_world_attention.py
@@ -78,7 +78,12 @@ def _install_vllm_stubs() -> None:
             **kwargs,
         ) -> None:
             super().__init__()
-            del kwargs
+            # Record what the model hands the quantization dispatch. The stub
+            # cannot resolve a quant method, so tests assert on the plumbing:
+            # every quantizable projection must receive the config and a
+            # prefix rooted the way checkpoint exclusion lists are.
+            self.quant_config = kwargs.get("quant_config")
+            self.quant_prefix = kwargs.get("prefix", "")
             self.return_bias = return_bias
             self.weight = nn.Parameter(torch.empty(output_size, input_size))
             self.bias = nn.Parameter(torch.empty(output_size)) if bias else None
@@ -108,7 +113,8 @@ def _install_vllm_stubs() -> None:
             **kwargs,
         ) -> None:
             super().__init__()
-            del kwargs
+            self.quant_config = kwargs.get("quant_config")
+            self.quant_prefix = kwargs.get("prefix", "")
             self.num_heads = total_num_heads
             self.num_kv_heads = total_num_kv_heads or total_num_heads
             output_size = (self.num_heads + 2 * self.num_kv_heads) * head_size

--- a/tests/diffusion/models/lingbot_world/test_lingbot_world_quantization.py
+++ b/tests/diffusion/models/lingbot_world/test_lingbot_world_quantization.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Quantization contract for LingBot World, against real vLLM machinery.
+
+The other LingBot tests run with vLLM's linear layers stubbed out, which is
+right for shape and plumbing but cannot verify the two facts the quantized
+path actually depends on: how an exclusion list is matched against a prefix,
+and what a fused QKV does with per-projection scales. Both are vLLM's
+behaviour, not ours, and getting either wrong is silent.
+
+Neither needs a GPU: ``ModelOptNvFp4Config`` resolves its methods and creates
+its parameters on CPU.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+@pytest.fixture(autouse=True)
+def _distributed():
+    from vllm.config import VllmConfig, set_current_vllm_config
+    from vllm.distributed.parallel_state import (
+        cleanup_dist_env_and_memory,
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+
+    os.environ.setdefault("MASTER_ADDR", "localhost")
+    os.environ.setdefault("MASTER_PORT", "29517")
+    with set_current_vllm_config(VllmConfig()):
+        init_distributed_environment(
+            world_size=1, rank=0, local_rank=0, distributed_init_method="env://", backend="gloo"
+        )
+        initialize_model_parallel(1, 1)
+        yield
+    cleanup_dist_env_and_memory()
+
+
+@pytest.fixture(autouse=True)
+def _bfloat16_default():
+    """Quantized linears expect a half-precision default, restored afterwards.
+
+    ``torch.set_default_dtype`` is process-global: leaving it set makes every
+    later test in the session build bfloat16 tensors where it expected float32.
+    """
+    previous = torch.get_default_dtype()
+    torch.set_default_dtype(torch.bfloat16)
+    try:
+        yield
+    finally:
+        torch.set_default_dtype(previous)
+
+
+def _nvfp4_config(exclude_modules):
+    from vllm.model_executor.layers.quantization.modelopt import ModelOptNvFp4Config
+
+    return ModelOptNvFp4Config(
+        quant_method="NVFP4",
+        is_checkpoint_nvfp4_serialized=True,
+        exclude_modules=list(exclude_modules),
+        group_size=16,
+    )
+
+
+def test_wildcard_exclusions_do_not_survive_a_namespaced_prefix():
+    """Why the pipeline hands the transformer ``prefix=""``.
+
+    ModelOpt checkpoints spell their exclusion list from the transformer's own
+    root -- ``blocks.N...``, ``head``, ``patch_embedding``. vLLM matches a
+    plain pattern by substring, so a namespaced prefix survives that case by
+    luck, but a wildcard pattern is matched with ``fullmatch`` and does not.
+
+    The public LingBot export happens to enumerate every module by plain name
+    *in addition* to its wildcards, so both roots work on it today. The
+    unnamespaced root is the one that does not depend on that accident, and it
+    is what every other diffusion transformer in tree already uses.
+
+    A missed exclusion is not an error at construction: the layer is built
+    quantized and fails much later on a scale tensor it has no parameter for.
+    """
+    config = _nvfp4_config(["blocks.0*", "c2ws_hidden_states_layer1"])
+
+    assert config.is_layer_excluded("blocks.0.self_attn.q") is True
+    assert config.is_layer_excluded("c2ws_hidden_states_layer1") is True
+
+    # A plain pattern still matches under a namespace, by substring...
+    assert config.is_layer_excluded("transformer.c2ws_hidden_states_layer1") is True
+    # ...but a wildcard one does not.
+    assert config.is_layer_excluded("transformer.blocks.0.self_attn.q") is False
+
+
+def test_a_fused_qkv_collapses_per_projection_weight_scales():
+    """Why self-attention stops fusing Q/K/V once a quant config is present.
+
+    A fused layer holds one ``weight_scale_2`` slot per shard but resolves them
+    to a single scalar by taking the maximum. Each projection's FP8 block
+    scales were normalised by its *own* global scale -- in the public LingBot
+    NVFP4 export all three saturate at 448.0 -- so applying another
+    projection's global scale rescales that projection's entire output by the
+    ratio between them. Those ratios reach 3.5x in that checkpoint.
+
+    vLLM warns about this rather than refusing, so nothing downstream would
+    stop a fused build from producing confidently wrong frames.
+    """
+    from vllm.model_executor.layers.linear import QKVParallelLinear
+
+    layer = QKVParallelLinear(512, 64, 8, bias=True, quant_config=_nvfp4_config([]), prefix="blocks.5.self_attn.qkv")
+    params = dict(layer.named_parameters())
+
+    # One slot per shard, exactly as a per-projection checkpoint supplies.
+    assert params["weight_scale_2"].shape == (3,)
+    assert params["input_scale"].shape == (3,)
+
+    globals_ = {"q": 4.79562e-05, "k": 8.53766e-05, "v": 5.4859e-05}  # real block-5 values
+    for shard, value in globals_.items():
+        params["weight"].weight_loader(params["weight"], torch.full((512, 256), 0x44, dtype=torch.uint8), shard)
+        params["weight_scale"].weight_loader(
+            params["weight_scale"], torch.full((512, 32), 448.0).to(torch.float8_e4m3fn), shard
+        )
+        # float32 explicitly: the default dtype here is bfloat16, whose 8-bit
+        # mantissa would round these scales enough to blur the comparison.
+        params["weight_scale_2"].weight_loader(
+            params["weight_scale_2"], torch.tensor(value, dtype=torch.float32), shard
+        )
+        params["input_scale"].weight_loader(params["input_scale"], torch.tensor(3.0e-3, dtype=torch.float32), shard)
+        params["bias"].weight_loader(params["bias"], torch.zeros(512, dtype=torch.bfloat16), shard)
+
+    layer.quant_method.process_weights_after_loading(layer)
+
+    # The three globals became one, and it is the largest.
+    assert float(layer.weight_global_scale) == pytest.approx(max(globals_.values()))
+    # Which means q and v would dequantize this much too large.
+    assert max(globals_.values()) / globals_["q"] == pytest.approx(1.78, abs=0.01)
+    assert max(globals_.values()) / globals_["v"] == pytest.approx(1.56, abs=0.01)
+
+
+def test_the_lingbot_transformer_does_not_build_a_fused_qkv_when_quantized():
+    """The consequence of the two facts above, asserted on the real model."""
+    from vllm_omni.diffusion.models.lingbot_world.transformer import (
+        CausalLingBotWorldTransformer3DModel,
+    )
+
+    model = CausalLingBotWorldTransformer3DModel(
+        patch_size=(1, 2, 2),
+        num_attention_heads=2,
+        attention_head_dim=64,
+        in_channels=36,
+        out_channels=2,
+        text_dim=6,
+        freq_dim=4,
+        ffn_dim=8,
+        num_layers=1,
+        rope_max_seq_len=16,
+        sink_size=1,
+        num_frames_per_block=1,
+        sliding_window_num_frames=3,
+        quant_config=_nvfp4_config(["blocks.0*", "head*"]),
+        prefix="",
+    )
+
+    attention = model.blocks[0].self_attn
+    assert attention.fused_qkv is False
+    assert {"q", "k", "v"} <= set(dict(attention.named_children()))
+    assert "qkv" not in dict(attention.named_children())

--- a/tests/diffusion/models/lingbot_world/test_lingbot_world_quantization.py
+++ b/tests/diffusion/models/lingbot_world/test_lingbot_world_quantization.py
@@ -24,7 +24,7 @@ pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
 
 @pytest.fixture(autouse=True)
 def _distributed():
-    from vllm.config import VllmConfig, set_current_vllm_config
+    from vllm.config import DeviceConfig, VllmConfig, set_current_vllm_config
     from vllm.distributed.parallel_state import (
         cleanup_dist_env_and_memory,
         init_distributed_environment,
@@ -33,7 +33,11 @@ def _distributed():
 
     os.environ.setdefault("MASTER_ADDR", "localhost")
     os.environ.setdefault("MASTER_PORT", "29517")
-    with set_current_vllm_config(VllmConfig()):
+    # These contract tests are deliberately CPU-only.  Do not rely on vLLM's
+    # auto platform detection: a CPU CI worker has no accelerator plugin from
+    # which ``DeviceConfig(device="auto")`` can infer a device type.
+    config = VllmConfig(device_config=DeviceConfig(device="cpu"))
+    with set_current_vllm_config(config):
         init_distributed_environment(
             world_size=1, rank=0, local_rank=0, distributed_init_method="env://", backend="gloo"
         )

--- a/tests/diffusion/models/lingbot_world/test_lingbot_world_transformer.py
+++ b/tests/diffusion/models/lingbot_world/test_lingbot_world_transformer.py
@@ -465,30 +465,21 @@ def test_constructor_rejects_non_null_image_embedding_fields(field: str) -> None
         module.CausalLingBotWorldTransformer3DModel(**{field: 4})
 
 
-class _RecordingQuantConfig:
-    """Minimal stand-in for a vLLM ``QuantizationConfig``.
+def _quantizable_projections(model) -> dict[str, object]:
+    """Map every projection that reached the quant dispatch to its config.
 
-    ``LinearBase`` only calls ``get_quant_method(layer, prefix=...)``, so the
-    stub records the prefix each parallel linear presents and hands back the
-    unquantized method. That makes the recorded set an exact map of which
-    modules a real checkpoint's exclusion list would be matched against.
+    Keyed by the prefix the projection presented, which is the string a
+    checkpoint's exclusion list is matched against.
     """
-
-    def __init__(self) -> None:
-        self.prefixes: list[str] = []
-
-    def get_quant_method(self, layer, prefix: str = ""):
-        from vllm.model_executor.layers.linear import UnquantizedLinearMethod
-
-        self.prefixes.append(prefix)
-        return UnquantizedLinearMethod()
+    return {module.quant_prefix: module.quant_config for module in model.modules() if hasattr(module, "quant_prefix")}
 
 
 def test_quant_config_reaches_every_parallel_linear_with_checkpoint_rooted_prefixes() -> None:
     module = attention_tests._load_module()
-    quant_config = _RecordingQuantConfig()
+    quant_config = object()
 
-    _tiny_model(module, num_layers=2, quant_config=quant_config)
+    model = _tiny_model(module, num_layers=2, quant_config=quant_config)
+    presented = _quantizable_projections(model)
 
     per_block = {
         "self_attn.qkv",
@@ -505,22 +496,32 @@ def test_quant_config_reaches_every_parallel_linear_with_checkpoint_rooted_prefi
     expected = {"c2ws_hidden_states_layer1", "c2ws_hidden_states_layer2"} | {
         f"blocks.{index}.{name}" for index in range(2) for name in per_block
     }
-    assert set(quant_config.prefixes) == expected
-    # Every prefix is presented exactly once; a duplicate would mean two modules
-    # share a name and would silently collide in an exclusion list.
-    assert len(quant_config.prefixes) == len(expected)
+    assert set(presented) == expected
+    # A prefix appearing twice would mean two modules collide in an exclusion
+    # list; the dict would silently hide that, so count the modules too.
+    assert sum(1 for m in model.modules() if hasattr(m, "quant_prefix")) == len(expected)
+    assert all(config is quant_config for config in presented.values())
 
 
 def test_precision_sensitive_projections_stay_out_of_the_quant_dispatch() -> None:
     module = attention_tests._load_module()
-    quant_config = _RecordingQuantConfig()
 
-    _tiny_model(module, num_layers=2, quant_config=quant_config)
+    model = _tiny_model(module, num_layers=2, quant_config=object())
+    presented = set(_quantizable_projections(model))
 
-    # Modulation, embedding and head projections are plain ``nn.Linear`` and must
-    # never be handed to a quantization method, regardless of the checkpoint.
+    # Modulation, embedding and head projections produce precision-sensitive
+    # values, are plain ``nn.Linear``, and must never reach a quant method.
     for name in ("cam_scale_layer", "cam_shift_layer", "head", "text_embedding", "time_embedding", "time_projection"):
-        assert not any(prefix.endswith(name) or f".{name}." in prefix for prefix in quant_config.prefixes), name
+        assert not any(prefix.endswith(name) or f".{name}." in prefix for prefix in presented), name
+
+
+def test_an_unquantized_model_hands_no_projection_a_quant_config() -> None:
+    module = attention_tests._load_module()
+
+    model = _tiny_model(module, num_layers=1)
+
+    assert set(_quantizable_projections(model))
+    assert all(config is None for config in _quantizable_projections(model).values())
 
 
 def test_orphaned_quantization_scale_reports_the_exclusion_mismatch() -> None:

--- a/tests/diffusion/models/lingbot_world/test_lingbot_world_transformer.py
+++ b/tests/diffusion/models/lingbot_world/test_lingbot_world_transformer.py
@@ -482,7 +482,10 @@ def test_quant_config_reaches_every_parallel_linear_with_checkpoint_rooted_prefi
     presented = _quantizable_projections(model)
 
     per_block = {
-        "self_attn.qkv",
+        # Q/K/V stay separate under quantization; see the fused_qkv comment.
+        "self_attn.q",
+        "self_attn.k",
+        "self_attn.v",
         "self_attn.o",
         "cross_attn.q",
         "cross_attn.k",
@@ -501,6 +504,45 @@ def test_quant_config_reaches_every_parallel_linear_with_checkpoint_rooted_prefi
     # list; the dict would silently hide that, so count the modules too.
     assert sum(1 for m in model.modules() if hasattr(m, "quant_prefix")) == len(expected)
     assert all(config is quant_config for config in presented.values())
+
+
+def test_quantized_self_attention_keeps_q_k_and_v_separate() -> None:
+    """Fusing them would break a ModelOpt NVFP4 checkpoint, not just degrade it.
+
+    Each projection's FP8 block scales are normalised by its own global weight
+    scale -- all three saturate at 448.0 in the public export -- while vLLM's
+    fused path carries one scalar alpha and resolves the three globals by
+    taking their maximum. On that checkpoint they differ by up to 3.5x, so two
+    of the three projections would dequantize to the wrong magnitude.
+    """
+    module = attention_tests._load_module()
+
+    quantized = _tiny_model(module, num_layers=1, quant_config=object())
+    unquantized = _tiny_model(module, num_layers=1)
+
+    assert quantized.blocks[0].self_attn.fused_qkv is False
+    assert not hasattr(quantized.blocks[0].self_attn, "qkv")
+    for name in ("q", "k", "v"):
+        assert hasattr(quantized.blocks[0].self_attn, name)
+
+    # The unquantized path is unchanged: fusion is still the default.
+    assert unquantized.blocks[0].self_attn.fused_qkv is True
+    assert hasattr(unquantized.blocks[0].self_attn, "qkv")
+
+
+def test_a_quantized_model_loads_q_k_v_under_their_checkpoint_names() -> None:
+    """The fused rename must not fire when there is no fused parameter."""
+    module = attention_tests._load_module()
+    model = _tiny_model(module, num_layers=1, quant_config=object())
+
+    names = dict(model.named_parameters())
+    assert "blocks.0.self_attn.q.weight" in names
+    assert "blocks.0.self_attn.qkv.weight" not in names
+
+    loaded = model.load_weights(
+        [("blocks.0.self_attn.q.weight", torch.zeros_like(names["blocks.0.self_attn.q.weight"]))]
+    )
+    assert "blocks.0.self_attn.q.weight" in loaded
 
 
 def test_precision_sensitive_projections_stay_out_of_the_quant_dispatch() -> None:

--- a/tests/diffusion/models/lingbot_world/test_lingbot_world_transformer.py
+++ b/tests/diffusion/models/lingbot_world/test_lingbot_world_transformer.py
@@ -32,6 +32,7 @@ def _tiny_model(
     num_layers: int = 2,
     num_frames_per_block: int = 1,
     sliding_window_num_frames: int = 3,
+    quant_config=None,
 ):
     return module.CausalLingBotWorldTransformer3DModel(
         patch_size=(1, 2, 2),
@@ -50,6 +51,7 @@ def _tiny_model(
         num_frames_per_block=num_frames_per_block,
         sliding_window_num_frames=sliding_window_num_frames,
         local_attn_size=-1,
+        quant_config=quant_config,
     )
 
 
@@ -463,11 +465,101 @@ def test_constructor_rejects_non_null_image_embedding_fields(field: str) -> None
         module.CausalLingBotWorldTransformer3DModel(**{field: 4})
 
 
-def test_constructor_rejects_unsupported_quantization_with_runtime_error() -> None:
+class _RecordingQuantConfig:
+    """Minimal stand-in for a vLLM ``QuantizationConfig``.
+
+    ``LinearBase`` only calls ``get_quant_method(layer, prefix=...)``, so the
+    stub records the prefix each parallel linear presents and hands back the
+    unquantized method. That makes the recorded set an exact map of which
+    modules a real checkpoint's exclusion list would be matched against.
+    """
+
+    def __init__(self) -> None:
+        self.prefixes: list[str] = []
+
+    def get_quant_method(self, layer, prefix: str = ""):
+        from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+
+        self.prefixes.append(prefix)
+        return UnquantizedLinearMethod()
+
+
+def test_quant_config_reaches_every_parallel_linear_with_checkpoint_rooted_prefixes() -> None:
+    module = attention_tests._load_module()
+    quant_config = _RecordingQuantConfig()
+
+    _tiny_model(module, num_layers=2, quant_config=quant_config)
+
+    per_block = {
+        "self_attn.qkv",
+        "self_attn.o",
+        "cross_attn.q",
+        "cross_attn.k",
+        "cross_attn.v",
+        "cross_attn.o",
+        "ffn.0",
+        "ffn.2",
+        "cam_injector_layer1",
+        "cam_injector_layer2",
+    }
+    expected = {"c2ws_hidden_states_layer1", "c2ws_hidden_states_layer2"} | {
+        f"blocks.{index}.{name}" for index in range(2) for name in per_block
+    }
+    assert set(quant_config.prefixes) == expected
+    # Every prefix is presented exactly once; a duplicate would mean two modules
+    # share a name and would silently collide in an exclusion list.
+    assert len(quant_config.prefixes) == len(expected)
+
+
+def test_precision_sensitive_projections_stay_out_of_the_quant_dispatch() -> None:
+    module = attention_tests._load_module()
+    quant_config = _RecordingQuantConfig()
+
+    _tiny_model(module, num_layers=2, quant_config=quant_config)
+
+    # Modulation, embedding and head projections are plain ``nn.Linear`` and must
+    # never be handed to a quantization method, regardless of the checkpoint.
+    for name in ("cam_scale_layer", "cam_shift_layer", "head", "text_embedding", "time_embedding", "time_projection"):
+        assert not any(prefix.endswith(name) or f".{name}." in prefix for prefix in quant_config.prefixes), name
+
+
+def test_orphaned_quantization_scale_reports_the_exclusion_mismatch() -> None:
+    module = attention_tests._load_module()
+    model = _tiny_model(module, num_layers=1)
+
+    # An unquantized build receiving a scale tensor is the exact symptom of an
+    # exclusion list whose root does not match the module prefixes.
+    with pytest.raises(KeyError, match="without a quantization method"):
+        model.load_weights([("blocks.0.ffn.0.weight_scale", torch.zeros(1))])
+
+    with pytest.raises(KeyError, match="Unexpected LingBot model weight name"):
+        model.load_weights([("blocks.0.nonexistent.weight", torch.zeros(1))])
+
+
+def test_from_config_adopts_the_quantization_config_declared_by_the_checkpoint() -> None:
     module = attention_tests._load_module()
 
-    with pytest.raises(RuntimeError, match="quant_config.*not supported"):
-        module.CausalLingBotWorldTransformer3DModel(quant_config=object())
+    class ConfigProbe(module.CausalLingBotWorldTransformer3DModel):
+        def __init__(self, **kwargs) -> None:
+            self.received_kwargs = kwargs
+
+    disk_quant_config = {"quant_method": "modelopt", "quant_algo": "NVFP4"}
+    built = object()
+    calls: list[tuple] = []
+
+    import vllm_omni.quantization.factory as factory
+
+    original = factory.resolve_quant_config_from_disk
+    factory.resolve_quant_config_from_disk = lambda active, disk: (calls.append((active, disk)), built)[1]
+    try:
+        probe = ConfigProbe.from_config(
+            {"_class_name": "CausalLingBotWorldTransformer3DModel", "quantization_config": disk_quant_config}
+        )
+    finally:
+        factory.resolve_quant_config_from_disk = original
+
+    assert calls == [(None, disk_quant_config)]
+    assert probe.received_kwargs["quant_config"] is built
 
 
 def test_from_config_accepts_diffusers_metadata_and_normalizes_patch_size() -> None:

--- a/tests/diffusion/models/lingbot_world/test_pipeline_lingbot_world.py
+++ b/tests/diffusion/models/lingbot_world/test_pipeline_lingbot_world.py
@@ -586,7 +586,10 @@ def test_component_discovery_uses_official_checkpoint_contract() -> None:
     assert pipeline.weights_sources == [
         module.DiffusersPipelineLoader.ComponentSource("checkpoint", "transformer", None, "transformer.", True)
     ]
-    assert _FakeTransformerFactory.last_call[1:] == (None, "transformer")
+    # The weight-loader prefix ("transformer.") addresses ``self.transformer``
+    # from the pipeline; the transformer's own quantization prefix is rooted at
+    # its module tree so it lines up with checkpoint exclusion lists.
+    assert _FakeTransformerFactory.last_call[1:] == (None, "")
     assert pipeline.scheduler.config.shift == 5.0
     assert pipeline.scheduler.config.num_train_timesteps == 1000
     assert module._loader_state.prefetch_calls == [("checkpoint", ("tokenizer", "text_encoder", "vae"), False)]
@@ -614,13 +617,13 @@ def test_unsupported_parallel_modes_fail_before_component_loading(field: str, va
     assert module._loader_state.prefetch_calls == []
 
 
-def test_unsupported_quantization_fails_before_component_loading() -> None:
+def test_quantization_config_is_forwarded_to_the_transformer() -> None:
     module = _load_pipeline_module()
+    quant_config = object()
 
-    with pytest.raises(NotImplementedError, match="quantization"):
-        module.LingBotWorldCausalDMDPipeline(od_config=_od_config(quantization_config=object()))
+    module.LingBotWorldCausalDMDPipeline(od_config=_od_config(quantization_config=quant_config))
 
-    assert module._loader_state.prefetch_calls == []
+    assert _FakeTransformerFactory.last_call[1:] == (quant_config, "")
 
 
 def test_official_scheduler_config_matches_fixed_dmd_contract() -> None:

--- a/tests/quantization/test_check_quantized_dispatch.py
+++ b/tests/quantization/test_check_quantized_dispatch.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the quantization dispatch check.
+
+The tool exists because a mismatch between a checkpoint's exclusion list and a
+model's prefixes does not raise at construction. These tests drive each way the
+two can disagree, since a checker that reports agreement no matter what would
+be worse than no checker at all.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vllm_omni.quantization.tools.check_quantized_dispatch import (
+    checkpoint_linear_modules,
+    checkpoint_quantized_modules,
+    compare,
+    format_report,
+    load_index,
+    summarise_checkpoint,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _index(quantized=("a.q", "a.k"), plain=("a.norm", "b.ffn")):
+    """A checkpoint where *quantized* modules carry scales and *plain* do not."""
+    names: dict[str, str] = {}
+    for module in quantized:
+        for suffix in ("weight", "weight_scale", "weight_scale_2", "input_scale", "bias"):
+            names[f"{module}.{suffix}"] = "shard-0"
+    for module in plain:
+        for suffix in ("weight", "bias"):
+            names[f"{module}.{suffix}"] = "shard-0"
+    return names
+
+
+def test_a_module_is_quantized_exactly_when_it_carries_scales():
+    index = _index()
+    assert checkpoint_quantized_modules(index) == {"a.q", "a.k"}
+    assert checkpoint_linear_modules(index) == {"a.q", "a.k", "a.norm", "b.ffn"}
+
+
+def test_a_bias_or_weight_alone_is_not_mistaken_for_a_scale():
+    assert checkpoint_quantized_modules({"a.q.weight": "s", "a.q.bias": "s"}) == set()
+
+
+def test_agreement_is_reported_when_the_two_match():
+    index = _index()
+    report = compare(
+        checkpoint_index=index,
+        model_quantized={"a.q", "a.k"},
+        model_unquantized={"a.norm", "b.ffn"},
+    )
+    assert report.agrees
+    assert report.quantized_in_both == {"a.q", "a.k"}
+    assert "VERDICT: dispatch matches the checkpoint" in format_report(report)
+
+
+def test_an_exclusion_that_matched_too_little_is_caught():
+    """The model quantized a layer the checkpoint left alone.
+
+    This is the shape of a prefix-rooting bug: every exclusion pattern missed,
+    so layers meant to stay full-width were built quantized.
+    """
+    report = compare(
+        checkpoint_index=_index(),
+        model_quantized={"a.q", "a.k", "a.norm"},
+        model_unquantized={"b.ffn"},
+    )
+    assert report.quantized_without_scales == {"a.norm"}
+    assert not report.agrees
+    text = format_report(report)
+    assert "QUANTIZED BUT THE CHECKPOINT HAS NO SCALES" in text
+    assert "a.norm" in text
+
+
+def test_an_exclusion_that_matched_too_much_is_caught():
+    """The checkpoint quantized a layer the model built full-width.
+
+    Its scale tensors then have nowhere to load, which surfaces far from the
+    cause unless something says so here.
+    """
+    report = compare(
+        checkpoint_index=_index(),
+        model_quantized={"a.q"},
+        model_unquantized={"a.k", "a.norm", "b.ffn"},
+    )
+    assert report.scales_without_a_quantized_layer == {"a.k"}
+    assert "CHECKPOINT SCALES WITH NO QUANTIZED LAYER" in format_report(report)
+
+
+def test_a_fused_projection_shows_up_on_both_sides_until_it_is_ignored():
+    """Fusion is a legitimate mismatch, so it must be declared, not assumed.
+
+    A fused qkv has no checkpoint counterpart and the checkpoint's q/k/v have
+    no model counterpart. Silently tolerating that would also hide a genuinely
+    missing layer, so the caller names it.
+    """
+    index = _index(quantized=("a.q", "a.k", "a.v"), plain=())
+    noisy = compare(checkpoint_index=index, model_quantized={"a.qkv"}, model_unquantized=set())
+    assert noisy.missing_from_model == {"a.q", "a.k", "a.v"}
+    assert noisy.missing_from_checkpoint == {"a.qkv"}
+
+    quiet = compare(
+        checkpoint_index=index,
+        model_quantized={"a.qkv"},
+        model_unquantized=set(),
+        ignore=("a.q", "a.k", "a.v", "a.qkv"),
+    )
+    assert quiet.agrees
+
+
+def test_ignore_patterns_accept_wildcards():
+    index = _index(quantized=("blocks.0.q", "blocks.1.q"), plain=())
+    report = compare(
+        checkpoint_index=index,
+        model_quantized=set(),
+        model_unquantized=set(),
+        ignore=("blocks.*",),
+    )
+    assert report.agrees
+
+
+def test_the_report_leads_with_disagreement_not_with_totals():
+    report = compare(
+        checkpoint_index=_index(),
+        model_quantized={"a.q", "a.k", "a.norm"},
+        model_unquantized={"b.ffn"},
+    )
+    text = format_report(report)
+    assert text.index("QUANTIZED BUT") < text.index("agreed:")
+    assert "VERDICT: DISAGREEMENT" in text
+
+
+def test_an_index_is_read_from_disk(tmp_path):
+    index = _index()
+    (tmp_path / "model.safetensors.index.json").write_text(json.dumps({"weight_map": index}), encoding="utf-8")
+    assert load_index(tmp_path) == index
+
+
+def test_a_directory_without_a_checkpoint_says_so(tmp_path):
+    with pytest.raises(FileNotFoundError, match="neither a safetensors index nor any shard"):
+        load_index(tmp_path)
+
+
+def test_summarising_a_checkpoint_counts_both_kinds():
+    text = summarise_checkpoint(_index())
+    assert "quantized:            2" in text
+    assert "unquantized:          2" in text

--- a/vllm_omni/diffusion/models/lingbot_world/pipeline.py
+++ b/vllm_omni/diffusion/models/lingbot_world/pipeline.py
@@ -165,8 +165,6 @@ def _validate_scheduler_config(config: dict[str, Any]) -> None:
 
 
 def _validate_parallel_config(od_config: OmniDiffusionConfig) -> None:
-    if getattr(od_config, "quantization_config", None) is not None:
-        raise NotImplementedError("LingBot World v1 does not support quantization.")
     parallel_config = getattr(od_config, "parallel_config", None)
     if parallel_config is None:
         return
@@ -450,10 +448,15 @@ class LingBotWorldCausalDMDPipeline(
             self.vae = self.vae.to(self.device)
 
         transformer_config = load_transformer_config(model, "transformer", local_files_only)
+        # The quantization prefix is rooted at the transformer's own module tree
+        # (``blocks.N.…``, ``head``, ``patch_embedding``) because that is how
+        # ModelOpt/compressed-tensors checkpoints spell their exclusion lists.
+        # It is unrelated to the ``"transformer."`` prefix the pipeline weight
+        # loader uses, which addresses ``self.transformer`` from the pipeline.
         self.transformer = CausalLingBotWorldTransformer3DModel.from_config(
             transformer_config,
             quant_config=getattr(od_config, "quantization_config", None),
-            prefix="transformer",
+            prefix="",
         )
 
         scheduler_config = _load_json(model, "scheduler/scheduler_config.json", local_files_only)

--- a/vllm_omni/diffusion/models/lingbot_world/transformer.py
+++ b/vllm_omni/diffusion/models/lingbot_world/transformer.py
@@ -182,15 +182,44 @@ class LingBotSelfAttention(nn.Module):
         self.dim = dim
         self.num_heads = num_heads
         self.head_dim = dim // num_heads
-        self.qkv = QKVParallelLinear(
-            hidden_size=dim,
-            head_size=self.head_dim,
-            total_num_heads=num_heads,
-            bias=True,
-            quant_config=quant_config,
-            prefix=_projection_prefix(prefix, "qkv"),
-        )
-        self.num_local_heads = self.qkv.num_heads
+
+        # Q/K/V are fused into one GEMM only when the weights are not
+        # quantized. A ModelOpt NVFP4 checkpoint stores one global weight
+        # scale per projection, and vLLM's fused path keeps a single scalar
+        # ``alpha`` for the merged layer, resolving the three by taking their
+        # maximum. Because each projection's FP8 block scales were normalised
+        # by *its own* global scale -- every one of them saturates at 448.0 --
+        # substituting another projection's scale rescales that projection's
+        # whole output. On the public LingBot NVFP4 export the three differ by
+        # up to 3.5x, so fusing would not degrade the model, it would break it.
+        # Keeping them separate also matches how the checkpoint is stored.
+        self.fused_qkv = quant_config is None
+        if self.fused_qkv:
+            self.qkv = QKVParallelLinear(
+                hidden_size=dim,
+                head_size=self.head_dim,
+                total_num_heads=num_heads,
+                bias=True,
+                quant_config=quant_config,
+                prefix=_projection_prefix(prefix, "qkv"),
+            )
+            self.num_local_heads = self.qkv.num_heads
+        else:
+            for name in ("q", "k", "v"):
+                setattr(
+                    self,
+                    name,
+                    ColumnParallelLinear(
+                        dim,
+                        dim,
+                        bias=True,
+                        gather_output=False,
+                        return_bias=False,
+                        quant_config=quant_config,
+                        prefix=_projection_prefix(prefix, name),
+                    ),
+                )
+            self.num_local_heads = num_heads // tp_size
         self.tp_inner_dim = self.num_local_heads * self.head_dim
         self.o = RowParallelLinear(
             dim,
@@ -309,8 +338,11 @@ class LingBotSelfAttention(nn.Module):
     ) -> torch.Tensor:
         # Project logical [B, S, D] tokens into TP-local
         # [B, S, num_local_heads, head_dim].
-        qkv, _ = self.qkv(hidden_states)
-        query, key, value = qkv.split((self.tp_inner_dim, self.tp_inner_dim, self.tp_inner_dim), dim=-1)
+        if self.fused_qkv:
+            qkv, _ = self.qkv(hidden_states)
+            query, key, value = qkv.split((self.tp_inner_dim, self.tp_inner_dim, self.tp_inner_dim), dim=-1)
+        else:
+            query, key, value = self.q(hidden_states), self.k(hidden_states), self.v(hidden_states)
         query = self.norm_q(query)
         key = self.norm_k(key)
 
@@ -1228,7 +1260,9 @@ class CausalLingBotWorldTransformer3DModel(nn.Module):
 
         params = dict(self.named_parameters())
         loaded: set[str] = set()
-        qkv_mapping = (("q", "q"), ("k", "k"), ("v", "v"))
+        # Only rewrite Q/K/V into a fused parameter when one was actually
+        # built; a quantized model keeps the checkpoint's own three.
+        qkv_mapping = (("q", "q"), ("k", "k"), ("v", "v")) if self.blocks[0].self_attn.fused_qkv else ()
         for checkpoint_name, loaded_weight in weights:
             name = checkpoint_name
             shard_id = None

--- a/vllm_omni/diffusion/models/lingbot_world/transformer.py
+++ b/vllm_omni/diffusion/models/lingbot_world/transformer.py
@@ -8,7 +8,7 @@ import math
 from collections.abc import Iterable
 from dataclasses import dataclass
 from types import SimpleNamespace
-from typing import Any, Self, cast
+from typing import TYPE_CHECKING, Any, Self, cast
 
 import torch
 import torch.nn as nn
@@ -32,6 +32,9 @@ from vllm_omni.experimental.ar_diffusion.kv_cache.paged_attention import (
     ar_diffusion_paged_attention,
     paged_write_attn,
 )
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
 
 
 @dataclass
@@ -127,6 +130,35 @@ def _projection_prefix(prefix: str, name: str) -> str:
     return f"{prefix}.{name}" if prefix else name
 
 
+# Scale tensors a quantized checkpoint carries alongside each packed weight.
+_QUANT_SCALE_SUFFIXES = ("weight_scale", "weight_scale_2", "input_scale", "weight_global_scale", "input_global_scale")
+
+
+def _missing_parameter_message(checkpoint_name: str, name: str, params: dict[str, torch.Tensor]) -> str:
+    """Explain an unmatched checkpoint tensor, naming the likely cause.
+
+    A quantized checkpoint whose exclusion list did not match this model's
+    module prefixes produces exactly one symptom: the layer was built
+    unquantized, so it has a ``weight`` but none of the scale parameters the
+    checkpoint ships. Say that outright instead of reporting a bare unknown
+    name, because the fix (aligning the exclusion list root with the module
+    tree) is not guessable from the tensor name alone.
+    """
+    for suffix in _QUANT_SCALE_SUFFIXES:
+        if not name.endswith(f".{suffix}"):
+            continue
+        module = name[: -len(suffix) - 1]
+        if f"{module}.weight" in params:
+            return (
+                f"{checkpoint_name} is a quantization scale for {module}, but that layer was built "
+                "without a quantization method. Either the checkpoint's quantization_config was not "
+                "picked up, or its exclusion list does not match this model's module prefixes, which "
+                "are rooted at the transformer itself (blocks.N.…, head, patch_embedding)."
+            )
+        break
+    return f"Unexpected LingBot model weight name: {checkpoint_name}"
+
+
 class LingBotSelfAttention(nn.Module):
     """Block-causal self-attention over retained history and one full chunk."""
 
@@ -136,6 +168,7 @@ class LingBotSelfAttention(nn.Module):
         num_heads: int,
         *,
         eps: float = 1e-6,
+        quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ) -> None:
         super().__init__()
@@ -154,6 +187,7 @@ class LingBotSelfAttention(nn.Module):
             head_size=self.head_dim,
             total_num_heads=num_heads,
             bias=True,
+            quant_config=quant_config,
             prefix=_projection_prefix(prefix, "qkv"),
         )
         self.num_local_heads = self.qkv.num_heads
@@ -164,6 +198,7 @@ class LingBotSelfAttention(nn.Module):
             bias=True,
             input_is_parallel=True,
             return_bias=False,
+            quant_config=quant_config,
             prefix=_projection_prefix(prefix, "o"),
         )
         self.norm_q = _LingBotRMSNorm(self.tp_inner_dim, eps)
@@ -359,6 +394,7 @@ class LingBotCrossAttention(nn.Module):
         num_heads: int,
         *,
         eps: float = 1e-6,
+        quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ) -> None:
         super().__init__()
@@ -381,6 +417,7 @@ class LingBotCrossAttention(nn.Module):
             bias=True,
             gather_output=False,
             return_bias=False,
+            quant_config=quant_config,
             prefix=_projection_prefix(prefix, "q"),
         )
         self.k = ColumnParallelLinear(
@@ -389,6 +426,7 @@ class LingBotCrossAttention(nn.Module):
             bias=True,
             gather_output=False,
             return_bias=False,
+            quant_config=quant_config,
             prefix=_projection_prefix(prefix, "k"),
         )
         self.v = ColumnParallelLinear(
@@ -397,6 +435,7 @@ class LingBotCrossAttention(nn.Module):
             bias=True,
             gather_output=False,
             return_bias=False,
+            quant_config=quant_config,
             prefix=_projection_prefix(prefix, "v"),
         )
         self.o = RowParallelLinear(
@@ -405,6 +444,7 @@ class LingBotCrossAttention(nn.Module):
             bias=True,
             input_is_parallel=True,
             return_bias=False,
+            quant_config=quant_config,
             prefix=_projection_prefix(prefix, "o"),
         )
         self.norm_q = _LingBotRMSNorm(self.tp_inner_dim, eps)
@@ -466,6 +506,7 @@ class LingBotAttentionBlock(nn.Module):
         ffn_dim: int | None = None,
         cross_attn_norm: bool = True,
         eps: float = 1e-6,
+        quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ) -> None:
         super().__init__()
@@ -476,12 +517,14 @@ class LingBotAttentionBlock(nn.Module):
             dim,
             num_heads,
             eps=eps,
+            quant_config=quant_config,
             prefix=_projection_prefix(prefix, "self_attn"),
         )
         self.cross_attn = LingBotCrossAttention(
             dim,
             num_heads,
             eps=eps,
+            quant_config=quant_config,
             prefix=_projection_prefix(prefix, "cross_attn"),
         )
         self.norm2 = LayerNorm(dim, eps=eps, elementwise_affine=False)
@@ -493,6 +536,7 @@ class LingBotAttentionBlock(nn.Module):
                 bias=True,
                 gather_output=False,
                 return_bias=False,
+                quant_config=quant_config,
                 prefix=_projection_prefix(prefix, "ffn.0"),
             ),
             nn.GELU(approximate="tanh"),
@@ -502,16 +546,22 @@ class LingBotAttentionBlock(nn.Module):
                 bias=True,
                 input_is_parallel=True,
                 return_bias=False,
+                quant_config=quant_config,
                 prefix=_projection_prefix(prefix, "ffn.2"),
             ),
         )
         self.modulation = nn.Parameter(torch.randn(1, 6, dim) / math.sqrt(dim))
+        # The camera-conditioning projections stay in the quant dispatch path so
+        # that a checkpoint which *does* quantize them still loads; every public
+        # LingBot World NVFP4 export so far lists them in ``ignore``, in which
+        # case the dispatch resolves back to an unquantized method.
         self.cam_injector_layer1 = ColumnParallelLinear(
             dim,
             dim,
             bias=True,
             gather_output=False,
             return_bias=False,
+            quant_config=quant_config,
             prefix=_projection_prefix(prefix, "cam_injector_layer1"),
         )
         self.cam_injector_layer2 = RowParallelLinear(
@@ -520,8 +570,11 @@ class LingBotAttentionBlock(nn.Module):
             bias=True,
             input_is_parallel=True,
             return_bias=False,
+            quant_config=quant_config,
             prefix=_projection_prefix(prefix, "cam_injector_layer2"),
         )
+        # cam_scale/cam_shift produce precision-sensitive modulation values and
+        # are plain ``nn.Linear``; they never enter the quant dispatch path.
         self.cam_scale_layer = nn.Linear(dim, dim)
         self.cam_shift_layer = nn.Linear(dim, dim)
 
@@ -701,7 +754,7 @@ class CausalLingBotWorldTransformer3DModel(nn.Module):
         num_frames_per_block: int = 3,
         sliding_window_num_frames: int = 18,
         local_attn_size: int = -1,
-        quant_config: object | None = None,
+        quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ) -> None:
         super().__init__()
@@ -731,10 +784,6 @@ class CausalLingBotWorldTransformer3DModel(nn.Module):
         ):
             if field_value is not None:
                 raise ValueError(f"{field_name} must be None because LingBot World v2 has no image embedding path.")
-        if quant_config is not None:
-            raise RuntimeError(
-                "quant_config is not supported by the LingBot World transformer; construct the unquantized model."
-            )
 
         dim = num_attention_heads * attention_head_dim
         self.dim = dim
@@ -774,6 +823,7 @@ class CausalLingBotWorldTransformer3DModel(nn.Module):
             bias=True,
             gather_output=False,
             return_bias=False,
+            quant_config=quant_config,
             prefix=_projection_prefix(prefix, "c2ws_hidden_states_layer1"),
         )
         self.c2ws_hidden_states_layer2 = RowParallelLinear(
@@ -782,6 +832,7 @@ class CausalLingBotWorldTransformer3DModel(nn.Module):
             bias=True,
             input_is_parallel=True,
             return_bias=False,
+            quant_config=quant_config,
             prefix=_projection_prefix(prefix, "c2ws_hidden_states_layer2"),
         )
         self.text_embedding = nn.Sequential(
@@ -806,6 +857,7 @@ class CausalLingBotWorldTransformer3DModel(nn.Module):
                     ffn_dim=ffn_dim,
                     cross_attn_norm=cross_attn_norm,
                     eps=eps,
+                    quant_config=quant_config,
                     prefix=_projection_prefix(prefix, f"blocks.{index}"),
                 )
                 for index in range(num_layers)
@@ -831,7 +883,7 @@ class CausalLingBotWorldTransformer3DModel(nn.Module):
         cls,
         config: dict[str, Any],
         *,
-        quant_config: Any | None = None,
+        quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ) -> Self:
         checkpoint_contract = {
@@ -868,6 +920,10 @@ class CausalLingBotWorldTransformer3DModel(nn.Module):
             actual = kwargs.get(name, expected)
             if actual != expected:
                 raise ValueError(f"LingBot checkpoint config {name} must be {expected!r}, got {actual!r}.")
+        if "quantization_config" in config:
+            from vllm_omni.quantization.factory import resolve_quant_config_from_disk
+
+            quant_config = resolve_quant_config_from_disk(quant_config, config["quantization_config"])
         return cls(**kwargs, quant_config=quant_config, prefix=prefix)
 
     def allocate_cache(
@@ -1183,7 +1239,7 @@ class CausalLingBotWorldTransformer3DModel(nn.Module):
                     shard_id = projection_shard
                     break
             if name not in params:
-                raise KeyError(f"Unexpected LingBot model weight name: {checkpoint_name}")
+                raise KeyError(_missing_parameter_message(checkpoint_name, name, params))
             param = params[name]
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
             if shard_id is None:

--- a/vllm_omni/quantization/tools/check_quantized_dispatch.py
+++ b/vllm_omni/quantization/tools/check_quantized_dispatch.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Check that every layer got the quantization method its checkpoint expects.
+
+A quantized checkpoint and a built model agree on which layers are quantized
+only by convention: the checkpoint ships an exclusion list, the model presents
+prefixes, and a quantization config matches one against the other. When that
+match is wrong the model still builds. A layer that should have been excluded
+is created quantized and then fails on a scale tensor it has no parameter for;
+worse, a layer whose scales are merged incorrectly loads cleanly and produces
+confidently wrong output that no latency or memory metric can detect.
+
+So compare the two directly. The checkpoint's own index says which modules
+carry scale tensors -- that is ground truth for "this module is quantized" --
+and the built model says which modules resolved to a quantized method. Any
+disagreement is reported per module.
+
+This reads the safetensors *index* only, never the shards, so it costs a few
+kilobytes of I/O regardless of model size.
+
+Usage::
+
+    # Inspect a checkpoint. Reads the index only, so it needs no device and
+    # no shard download.
+    python -m vllm_omni.quantization.tools.check_quantized_dispatch \\
+        --checkpoint /path/to/quantized-transformer
+
+    # Compare against a model you have already built:
+    from vllm_omni.quantization.tools.check_quantized_dispatch import (
+        checkpoint_quantized_modules, model_quantized_modules, compare,
+    )
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Suffixes ModelOpt / compressed-tensors ship alongside a packed weight. A
+# module carrying any of them was quantized by whoever produced the checkpoint.
+SCALE_SUFFIXES = (
+    "weight_scale",
+    "weight_scale_2",
+    "weight_global_scale",
+    "input_scale",
+    "input_global_scale",
+    "weight_scale_inv",
+)
+
+
+def _strip_scale_suffix(name: str) -> str | None:
+    """Return the module a scale tensor belongs to, or None if it is not one."""
+    for suffix in SCALE_SUFFIXES:
+        if name.endswith(f".{suffix}"):
+            return name[: -len(suffix) - 1]
+    return None
+
+
+def checkpoint_quantized_modules(index: dict[str, str] | Iterable[str]) -> set[str]:
+    """Modules the checkpoint quantized, from its tensor names alone."""
+    names = index.keys() if isinstance(index, dict) else index
+    modules = set()
+    for name in names:
+        module = _strip_scale_suffix(name)
+        if module is not None:
+            modules.add(module)
+    return modules
+
+
+def checkpoint_linear_modules(index: dict[str, str] | Iterable[str]) -> set[str]:
+    """Every module carrying a ``.weight``, quantized or not."""
+    names = index.keys() if isinstance(index, dict) else index
+    return {name[: -len(".weight")] for name in names if name.endswith(".weight")}
+
+
+def load_index(checkpoint: Path) -> dict[str, str]:
+    """Read a safetensors index, or synthesise one from a single-file model."""
+    for candidate in sorted(checkpoint.glob("*.safetensors.index.json")):
+        return json.loads(candidate.read_text(encoding="utf-8"))["weight_map"]
+
+    shards = sorted(checkpoint.glob("*.safetensors"))
+    if not shards:
+        raise FileNotFoundError(f"{checkpoint} contains neither a safetensors index nor any shard")
+    from safetensors import safe_open
+
+    index: dict[str, str] = {}
+    for shard in shards:
+        with safe_open(str(shard), framework="pt") as handle:
+            for key in handle.keys():
+                index[key] = shard.name
+    return index
+
+
+def model_quantized_modules(model, *, prefix: str = "") -> tuple[set[str], set[str]]:
+    """Split a built model's linear modules into quantized and unquantized.
+
+    Membership is decided by the resolved ``quant_method``, which is what the
+    kernel will actually run -- not by whether a config was passed in.
+    """
+    from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+
+    quantized: set[str] = set()
+    unquantized: set[str] = set()
+    for name, module in model.named_modules():
+        method = getattr(module, "quant_method", None)
+        if method is None or not hasattr(module, "weight"):
+            continue
+        target = quantized if not isinstance(method, UnquantizedLinearMethod) else unquantized
+        target.add(f"{prefix}{name}" if prefix else name)
+    return quantized, unquantized
+
+
+@dataclass
+class DispatchReport:
+    """Where the model and the checkpoint disagree about what is quantized."""
+
+    quantized_in_both: set[str] = field(default_factory=set)
+    unquantized_in_both: set[str] = field(default_factory=set)
+    # The model quantized it; the checkpoint shipped no scales for it. This
+    # fails at load on a missing parameter, or silently uses uninitialised
+    # scales if the loader is permissive.
+    quantized_without_scales: set[str] = field(default_factory=set)
+    # The checkpoint quantized it; the model built it unquantized. Its scale
+    # tensors have nowhere to go -- an exclusion list that matched too much.
+    scales_without_a_quantized_layer: set[str] = field(default_factory=set)
+    # Present in the checkpoint but absent from the model, or the reverse.
+    missing_from_model: set[str] = field(default_factory=set)
+    missing_from_checkpoint: set[str] = field(default_factory=set)
+
+    @property
+    def agrees(self) -> bool:
+        return not (
+            self.quantized_without_scales
+            or self.scales_without_a_quantized_layer
+            or self.missing_from_model
+            or self.missing_from_checkpoint
+        )
+
+
+def compare(
+    *,
+    checkpoint_index: dict[str, str] | Iterable[str],
+    model_quantized: Iterable[str],
+    model_unquantized: Iterable[str],
+    ignore: Sequence[str] = (),
+) -> DispatchReport:
+    """Compare a built model's dispatch against the checkpoint's own tensors.
+
+    ``ignore`` accepts glob-ish patterns for modules the model legitimately
+    does not build one-to-one -- a fused projection, for instance, has no
+    single checkpoint counterpart.
+    """
+    patterns = [re.compile(re.escape(p).replace(r"\*", ".*")) for p in ignore]
+
+    def skipped(name: str) -> bool:
+        return any(pattern.fullmatch(name) for pattern in patterns)
+
+    ckpt_quantized = {m for m in checkpoint_quantized_modules(checkpoint_index) if not skipped(m)}
+    ckpt_linear = {m for m in checkpoint_linear_modules(checkpoint_index) if not skipped(m)}
+    quantized = {m for m in model_quantized if not skipped(m)}
+    unquantized = {m for m in model_unquantized if not skipped(m)}
+    built = quantized | unquantized
+
+    return DispatchReport(
+        quantized_in_both=quantized & ckpt_quantized,
+        unquantized_in_both=unquantized & (ckpt_linear - ckpt_quantized),
+        quantized_without_scales=quantized - ckpt_quantized,
+        scales_without_a_quantized_layer=ckpt_quantized - quantized,
+        missing_from_model=ckpt_linear - built,
+        missing_from_checkpoint=built - ckpt_linear,
+    )
+
+
+def format_report(report: DispatchReport, *, limit: int = 12) -> str:
+    """Render the comparison, leading with disagreement rather than totals."""
+
+    def block(title: str, names: set[str], explanation: str) -> list[str]:
+        if not names:
+            return []
+        lines = [f"{title}: {len(names)}", f"  {explanation}"]
+        for name in sorted(names)[:limit]:
+            lines.append(f"    {name}")
+        if len(names) > limit:
+            lines.append(f"    ... and {len(names) - limit} more")
+        return [*lines, ""]
+
+    lines: list[str] = []
+    lines += block(
+        "QUANTIZED BUT THE CHECKPOINT HAS NO SCALES",
+        report.quantized_without_scales,
+        "The exclusion list did not match these prefixes. They will fail on a missing scale.",
+    )
+    lines += block(
+        "CHECKPOINT SCALES WITH NO QUANTIZED LAYER",
+        report.scales_without_a_quantized_layer,
+        "The exclusion list matched too much, or the module was fused away.",
+    )
+    lines += block(
+        "IN THE CHECKPOINT, NOT IN THE MODEL",
+        report.missing_from_model,
+        "Fused projections land here legitimately; pass --ignore for those.",
+    )
+    lines += block(
+        "IN THE MODEL, NOT IN THE CHECKPOINT",
+        report.missing_from_checkpoint,
+        "A fused parameter, or a module the checkpoint does not carry.",
+    )
+
+    lines.append(f"agreed: {len(report.quantized_in_both)} quantized, {len(report.unquantized_in_both)} unquantized")
+    lines.append("VERDICT: dispatch matches the checkpoint" if report.agrees else "VERDICT: DISAGREEMENT, see above")
+    return "\n".join(lines)
+
+
+def summarise_checkpoint(index: dict[str, str]) -> str:
+    """Describe a checkpoint's quantization without building anything."""
+    quantized = checkpoint_quantized_modules(index)
+    linear = checkpoint_linear_modules(index)
+    scales = sum(1 for name in index if _strip_scale_suffix(name) is not None)
+    lines = [
+        f"tensors:            {len(index)}",
+        f"modules with weight:{len(linear):>5}",
+        f"  quantized:        {len(quantized):>5}",
+        f"  unquantized:      {len(linear - quantized):>5}",
+        f"scale tensors:      {scales:>5}",
+    ]
+    grouped: dict[str, int] = {}
+    for module in sorted(quantized):
+        head = module.split(".")[0]
+        grouped[head] = grouped.get(head, 0) + 1
+    lines.append("quantized modules by top-level group:")
+    for head, count in sorted(grouped.items()):
+        lines.append(f"  {head:<28} {count}")
+    return "\n".join(lines)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Check quantization dispatch against a checkpoint.")
+    parser.add_argument("--checkpoint", type=Path, required=True, help="Directory holding the quantized transformer.")
+    parser.add_argument("--output", type=Path, default=None, help="Also write the report here.")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Describe a checkpoint's quantization. Needs no device.
+
+    Comparing against a *built* model needs a pipeline, so that half is a
+    library call: import :func:`model_quantized_modules` and :func:`compare`
+    from wherever the model already exists.
+    """
+    args = parse_args(argv)
+    text = summarise_checkpoint(load_index(args.checkpoint))
+    print(text)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vllm_omni/quantization/tools/check_quantized_dispatch.py
+++ b/vllm_omni/quantization/tools/check_quantized_dispatch.py
@@ -36,10 +36,11 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
+
+import regex as re
 
 # Suffixes ModelOpt / compressed-tensors ship alongside a packed weight. A
 # module carrying any of them was quantized by whoever produced the checkpoint.


### PR DESCRIPTION
## Summary

- enable quantization config plumbing through the LingBot World pipeline and transformer
- pass `quant_config` to supported vLLM parallel linear layers with checkpoint-aligned prefixes
- keep Q/K/V separate for quantized checkpoints so projection-specific ModelOpt global scales remain correct
- add a lightweight checkpoint-index dispatch auditor and CPU contract tests

## Why

LingBot World rejected every non-null quantization config, and its linear layers did not participate in vLLM's quantization dispatch. Simply removing those guards is not sufficient: the public ModelOpt NVFP4 export stores a different global scale for Q, K, and V, while the fused `QKVParallelLinear` path retains one merged scalar. On the public checkpoint those scales differ by up to 3.5x, so fusing the projections silently changes the model rather than merely reducing precision.

The unquantized path remains fused. The quantized path constructs separate Q/K/V projections matching the checkpoint layout and routes all supported parallel linears through the existing vLLM quantization kernels. Plain modulation `nn.Linear` layers remain unchanged.

## Validation

- checkpoint index audit: 340 quantized layers, 430 unquantized weights, and 1020 scale tensors, matching the model card
- real checkpoint dispatch selected `CutlassNvFp4LinearKernel`
- 768x480 single-session generation: BF16 eager 4.058 s, NVFP4 eager 3.348 s
- with the compiled-KV fix in #6463: BF16 compile 3.626 s, NVFP4 compile 2.845 s
- generated chunks remained finite in the real-checkpoint smoke test

## Tests

```text
167 CPU tests passed in the combined LingBot/dispatch suite
3 distributed CPU contract tests passed with a localhost Gloo group
```

Automatic reconstruction of the checkpoint's ModelOpt algorithm is submitted in #6531; without that companion change the same config can still be supplied explicitly.

Part of #6227's runtime optimization track.
