### PR TITLE
[Benchmark] Measure and overlap AR-Diffusion RGB delivery

### DIFF
--- a/benchmarks/ar_diffusion/README.md
+++ b/benchmarks/ar_diffusion/README.md
@@ -1,0 +1,97 @@
+# Realtime AR-Diffusion session benchmark
+
+Multi-session load harness for realtime AR-Diffusion serving: session arrivals,
+playout deadlines, and the metrics a streaming video deployment is actually
+gated on.
+
+## Load modes
+
+| Mode | Question it answers | Deadlines |
+|---|---|---|
+| `saturating` | How fast can this configuration go at all? Aggregate generated FPS, frames per GPU-second. | none |
+| `paced` | Does it keep up with playback? CPR, TTFC, worst-case per-chunk latency. | yes |
+
+Running only `saturating` produces a throughput number no deployment can use.
+Running only `paced` hides the ceiling, so a deadline miss cannot be attributed
+to insufficient capacity rather than to scheduling. Report both.
+
+## Load parameters
+
+Session **arrival rate** is the only valid open-loop axis. Per-session tick rate
+is not: ticks of one session are strictly ordered and state-dependent, so tick
+`k + 1` cannot be issued before chunk `k` returns and raising the rate only
+grows a queue. Concurrently active sessions are derived state, reported
+alongside every measurement as `peak_concurrent_sessions`.
+
+## Metrics
+
+Per session: `ttfc_s`, chunk latency P50/P95/P99, and
+
+```
+RTF = wall(K chunks) / (K * frames_per_chunk / target_fps)
+```
+
+Aggregate: `continuous_play_ratio` (CPR, the fraction of chunks delivered before
+their playout deadline, macro-averaged over sessions), `worst_case_chunk_latency_s`
+across all active sessions, `generated_fps`, and `frames_per_gpu_second` — the
+only unit comparable across replica counts, TP degrees and hardware.
+
+CPR is not redundant with RTF. RTF is a ratio of aggregates: a session can hold
+`RTF = 0.9` over a minute and still stutter visibly, because chunks arrive in
+bursts that individually miss their playout instants.
+
+Deadlines assume a declared playout grid. Playback starts once `--buffer-chunks`
+chunks are buffered; chunk `buffer_chunks - 1` anchors the grid and every later
+chunk is due one release period after its predecessor. Chunks inside the
+prebuffer have no deadline — their cost is start latency, which TTFC reports.
+
+## Model neutrality
+
+The chunk shape comes from the pipeline's declared `ARDiffusionKVCacheSpec`. No
+model name appears in this directory.
+
+One value is not derivable from the capability today: every frame count in the
+spec is in *latent* frames and nothing converts them to delivered frames, so the
+playout grid cannot be computed from the spec alone. Until the spec declares it,
+supply `--vae-temporal-factor` (default `1`, correct for a decoder that does not
+compress time).
+
+## Usage
+
+```bash
+# Ceiling
+python -m benchmarks.ar_diffusion.run_realtime_benchmark \
+    --model <checkpoint> --prompt "..." \
+    --num-sessions 1 --mode saturating --chunks 32 \
+    --vae-temporal-factor 4 \
+    --note "checkpoint=<...>" --note "hw=1xH200" --note "res=480x832" \
+    --note "steps=4" --output runs/n1.json
+
+# State concurrency N, execution concurrency 1
+python -m benchmarks.ar_diffusion.run_realtime_benchmark \
+    ... --num-sessions 2 --output runs/n2.json
+```
+
+At least one `--note` is required: a latency without model, checkpoint,
+resolution, denoising steps and hardware is not a result.
+
+## Reading N=1 against N=2
+
+With state concurrency `N` but execution concurrency 1, ticks serialize, so:
+
+```
+aggregate generated FPS(N)  ~=  aggregate generated FPS(1)
+per-session RTF(N)          ~=  N x RTF(1)
+```
+
+`compare_runs()` reports `generated_fps_ratio` and `per_tick_switching_cost_s`,
+the latter being latency beyond what pure queueing predicts. A measurable drop
+in aggregate FPS is per-tick switching cost — state bind/unbind, KV pool paging,
+conditioning rebuild — and that number is the baseline any cross-session
+batching work has to beat.
+
+## Tests
+
+`tests/diffusion/ar_diffusion/test_realtime_benchmark.py` drives the whole load
+model on a virtual clock against fake sessions: CPU only, no engine, no device,
+no checkpoint. `engine_binding.py` is the only module not covered.

--- a/benchmarks/ar_diffusion/README.md
+++ b/benchmarks/ar_diffusion/README.md
@@ -52,6 +52,26 @@ which TTFC reports. Walking cumulative frames rather than multiplying a constant
 period is what lets a deeper buffer grant real slack, and what keeps a causal
 decoder's shorter opening chunk from being credited with a full period.
 
+## The vertical path
+
+A session's tick returns latents, which nothing can watch. `DecodingSession`
+wraps a latent-producing session so each tick also decodes its chunk
+incrementally, which puts three things inside the measurement:
+
+- **TTFF rather than time-to-first-chunk.** The gate this RFC proposes is time
+  to first *frame*, so the decode has to be on the measured path.
+- **`decode_share`**, the fraction of chunk wall time spent decoding. With
+  generation and decode serialized this is the headroom overlapping them can
+  recover; once they overlap it is the number that has to shrink. Overlap work
+  without this baseline has nothing to beat.
+- **`resident_decoder_bytes_per_session`**, which admission needs and which no
+  other part of the run reports.
+
+Delivered frames then come from the decoder rather than from the profile, so
+the harness *measures* the temporal geometry instead of assuming it. Sessions
+that only produce latents keep working: the stage split is reported as `None`
+and the profile supplies the frame counts.
+
 ## Model neutrality
 
 The chunk shape comes from the pipeline's declared `ARDiffusionKVCacheSpec`. No

--- a/benchmarks/ar_diffusion/README.md
+++ b/benchmarks/ar_diffusion/README.md
@@ -41,20 +41,46 @@ CPR is not redundant with RTF. RTF is a ratio of aggregates: a session can hold
 bursts that individually miss their playout instants.
 
 Deadlines assume a declared playout grid. Playback starts once `--buffer-chunks`
-chunks are buffered; chunk `buffer_chunks - 1` anchors the grid and every later
-chunk is due one release period after its predecessor. Chunks inside the
-prebuffer have no deadline — their cost is start latency, which TTFC reports.
+chunks are buffered; from that instant the player consumes continuously, so
+
+```
+deadline(i) = t_ready(buffer_chunks - 1) + cumulative_frames(i) / target_fps
+```
+
+Chunks inside the prebuffer have no deadline — their cost is start latency,
+which TTFC reports. Walking cumulative frames rather than multiplying a constant
+period is what lets a deeper buffer grant real slack, and what keeps a causal
+decoder's shorter opening chunk from being credited with a full period.
 
 ## Model neutrality
 
 The chunk shape comes from the pipeline's declared `ARDiffusionKVCacheSpec`. No
 model name appears in this directory.
 
-One value is not derivable from the capability today: every frame count in the
-spec is in *latent* frames and nothing converts them to delivered frames, so the
-playout grid cannot be computed from the spec alone. Until the spec declares it,
-supply `--vae-temporal-factor` (default `1`, correct for a decoder that does not
+One conversion is not derivable from the capability today: every frame count in
+the spec is in *latent* frames and nothing converts them to delivered frames, so
+the playout grid cannot be computed from the spec alone. Supply
+`--vae-temporal-factor` (default `1`, correct for a decoder that does not
 compress time).
+
+**The conversion is not a multiplication.** A causal video decoder expands a
+session's first latent frame to one raw frame and every later one to the full
+factor, so `n` latent frames become `(n - 1) * factor + 1` raw frames the first
+time and `n * factor` every time after:
+
+| | latent frames | raw frames |
+|---|---|---|
+| chunk 0 | 3 | **9** |
+| chunk k > 0 | 3 | 12 |
+| K chunks | 3K | **12K − 3** |
+
+So `chunks x frames_per_chunk` over-counts every run. The profile carries
+`frames_per_first_chunk` alongside `frames_per_chunk`, and both `generated_fps`
+and `RTF` sum the per-chunk delivery. Pass `--non-causal-decoder` for a decoder
+that expands every latent frame identically.
+
+This is also why a single declared integer could not close the gap: the missing
+piece is a *mapping*, not a factor.
 
 ## Usage
 

--- a/benchmarks/ar_diffusion/__init__.py
+++ b/benchmarks/ar_diffusion/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/benchmarks/ar_diffusion/decoding_session.py
+++ b/benchmarks/ar_diffusion/decoding_session.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Join a latent-producing realtime session to incremental decode.
+
+An AR-Diffusion session returns latents. Turning those into delivered frames
+is what the benchmark actually has to time, for two reasons:
+
+* **Time to first frame, not first chunk.** A session's first latent chunk is
+  not something a viewer can see. The gate this RFC proposes is TTFF, so the
+  decode has to be inside the measured path.
+* **The generate/decode split is the quantity overlapping them can recover.**
+  With the two serialized, ``decode_share`` is the headroom; once they overlap
+  it is what has to be shown shrinking. Without the split measured first,
+  overlap work has no baseline to beat.
+
+The wrapper also reports the delivered frame count from the decoder rather
+than from a configured constant, so the harness measures the decoder's
+temporal geometry instead of assuming it -- which matters because that
+geometry is not declared anywhere the runtime can read.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+
+class LatentSession(Protocol):
+    """A realtime session whose ticks produce latents."""
+
+    async def next_chunk(self) -> Any: ...
+
+    async def close(self) -> None: ...
+
+
+class ChunkDecoder(Protocol):
+    """The streaming-decode surface this wrapper needs."""
+
+    def new_decode_state(self, session_id: str) -> Any: ...
+
+    def decode_chunk(self, latent: Any, state: Any) -> Any: ...
+
+    def release(self, state: Any) -> None: ...
+
+
+@dataclass
+class StageTiming:
+    """Per-chunk split of one tick, filled in by :class:`DecodingSession`."""
+
+    generate_s: float | None = None
+    decode_s: float | None = None
+    frames: int | None = None
+    resident_decoder_bytes: int | None = None
+
+
+@dataclass
+class DecodingSession:
+    """Wraps a latent session so each tick returns delivered frames.
+
+    ``latent_of`` extracts the latent tensor from whatever the inner session
+    returns, keeping this free of any engine's output type.
+    """
+
+    inner: LatentSession
+    decoder: ChunkDecoder
+    session_id: str
+    latent_of: Callable[[Any], Any] = lambda output: output
+    clock: Callable[[], float] = time.perf_counter
+    last: StageTiming = field(default_factory=StageTiming)
+
+    def __post_init__(self) -> None:
+        self._state = self.decoder.new_decode_state(self.session_id)
+
+    @property
+    def decode_state(self) -> Any:
+        return self._state
+
+    async def next_chunk(self) -> Any:
+        t0 = self.clock()
+        output = await self.inner.next_chunk()
+        t1 = self.clock()
+        frames = self.decoder.decode_chunk(self.latent_of(output), self._state)
+        t2 = self.clock()
+
+        nbytes = getattr(self._state, "nbytes", None)
+        self.last = StageTiming(
+            generate_s=t1 - t0,
+            decode_s=t2 - t1,
+            frames=int(frames.shape[2]) if hasattr(frames, "shape") and len(frames.shape) >= 3 else None,
+            resident_decoder_bytes=nbytes() if callable(nbytes) else None,
+        )
+        return frames
+
+    async def close(self) -> None:
+        # Decoder state and session state are released together: the cache has
+        # no recompute source, so a session that ends must not leave it behind.
+        try:
+            self.decoder.release(self._state)
+        finally:
+            await self.inner.close()

--- a/benchmarks/ar_diffusion/decoding_session.py
+++ b/benchmarks/ar_diffusion/decoding_session.py
@@ -21,6 +21,7 @@ geometry is not declared anywhere the runtime can read.
 
 from __future__ import annotations
 
+import asyncio
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -47,12 +48,14 @@ class ChunkDecoder(Protocol):
 
 @dataclass
 class StageTiming:
-    """Per-chunk split of one tick, filled in by :class:`DecodingSession`."""
+    """Per-chunk split of one tick, filled in by the session wrappers."""
 
     generate_s: float | None = None
     decode_s: float | None = None
     frames: int | None = None
     resident_decoder_bytes: int | None = None
+    overlap_s: float | None = None
+    backpressure_s: float | None = None
 
 
 @dataclass
@@ -96,6 +99,96 @@ class DecodingSession:
     async def close(self) -> None:
         # Decoder state and session state are released together: the cache has
         # no recompute source, so a session that ends must not leave it behind.
+        try:
+            self.decoder.release(self._state)
+        finally:
+            await self.inner.close()
+
+
+@dataclass
+class OverlappedDecodingSession:
+    """Decode chunk ``N`` while chunk ``N + 1`` is already being generated.
+
+    Serialized, a tick costs ``generate + decode``. The generate call is a
+    request to the worker rather than local compute, so the decode of the
+    chunk just returned can run while the next one is in flight, and a tick
+    costs ``max(generate, decode)`` instead.
+
+    The session keeps at most ``lookahead`` generations outstanding. That bound
+    is the backpressure mechanism as well as the memory bound: a consumer that
+    stops taking chunks stops the prefetch with it, rather than letting
+    generation run ahead into memory nothing is reading. Time spent waiting on
+    that bound is reported as ``backpressure_s`` so a slow consumer is visible
+    in the results instead of silently inflating chunk latency.
+
+    ``overlap_s`` is how much generate time was hidden behind decode, which is
+    what "VAE/DiT overlap efficiency" has to be computed from.
+    """
+
+    inner: LatentSession
+    decoder: ChunkDecoder
+    session_id: str
+    latent_of: Callable[[Any], Any] = lambda output: output
+    clock: Callable[[], float] = time.perf_counter
+    lookahead: int = 1
+    last: StageTiming = field(default_factory=StageTiming)
+
+    def __post_init__(self) -> None:
+        if self.lookahead < 1:
+            raise ValueError("lookahead must be at least 1.")
+        self._state = self.decoder.new_decode_state(self.session_id)
+        self._pending: asyncio.Task | None = None
+        self._pending_started: float | None = None
+        self._closed = False
+
+    @property
+    def decode_state(self) -> Any:
+        return self._state
+
+    def _start_generation(self) -> None:
+        if self._pending is None and not self._closed:
+            self._pending_started = self.clock()
+            self._pending = asyncio.ensure_future(self.inner.next_chunk())
+
+    async def next_chunk(self) -> Any:
+        t0 = self.clock()
+        # A prefetch issued during the previous tick has been running while the
+        # caller was away, so only the part still outstanding is charged here.
+        self._start_generation()
+        pending, started = self._pending, self._pending_started
+        self._pending, self._pending_started = None, None
+        output = await pending
+        t1 = self.clock()
+        generate_s = t1 - (started if started is not None else t0)
+        waited_s = t1 - t0
+        overlap_s = max(0.0, generate_s - waited_s)
+
+        # Issue the next generation before decoding, so the two overlap.
+        self._start_generation()
+
+        frames = self.decoder.decode_chunk(self.latent_of(output), self._state)
+        t2 = self.clock()
+
+        nbytes = getattr(self._state, "nbytes", None)
+        self.last = StageTiming(
+            generate_s=generate_s,
+            decode_s=t2 - t1,
+            frames=int(frames.shape[2]) if hasattr(frames, "shape") and len(frames.shape) >= 3 else None,
+            resident_decoder_bytes=nbytes() if callable(nbytes) else None,
+            overlap_s=overlap_s,
+            backpressure_s=0.0,
+        )
+        return frames
+
+    async def close(self) -> None:
+        self._closed = True
+        if self._pending is not None:
+            self._pending.cancel()
+            try:
+                await self._pending
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001 - shutdown must not mask close
+                pass
+            self._pending = None
         try:
             self.decoder.release(self._state)
         finally:

--- a/benchmarks/ar_diffusion/decoding_session.py
+++ b/benchmarks/ar_diffusion/decoding_session.py
@@ -22,6 +22,7 @@ geometry is not declared anywhere the runtime can read.
 from __future__ import annotations
 
 import asyncio
+import collections
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -55,7 +56,7 @@ class StageTiming:
     frames: int | None = None
     resident_decoder_bytes: int | None = None
     overlap_s: float | None = None
-    backpressure_s: float | None = None
+    outstanding_generations: int | None = None
 
 
 @dataclass
@@ -115,11 +116,16 @@ class OverlappedDecodingSession:
     costs ``max(generate, decode)`` instead.
 
     The session keeps at most ``lookahead`` generations outstanding. That bound
-    is the backpressure mechanism as well as the memory bound: a consumer that
-    stops taking chunks stops the prefetch with it, rather than letting
-    generation run ahead into memory nothing is reading. Time spent waiting on
-    that bound is reported as ``backpressure_s`` so a slow consumer is visible
-    in the results instead of silently inflating chunk latency.
+    is the backpressure: a consumer that stops taking chunks stops generation
+    with it, rather than letting it run ahead into memory nothing is reading.
+    ``outstanding_generations`` reports how many were in flight, so the bound
+    is observable rather than asserted in a comment.
+
+    Note what this is not. Because the caller drives ``next_chunk``, nothing
+    ever *waits* on the bound from inside this class -- backpressure here is a
+    ceiling on lookahead, not a measured stall. Timing a stall would need
+    generation to run as its own producer task, which is a larger change and
+    is not attempted here.
 
     ``overlap_s`` is how much generate time was hidden behind decode, which is
     what "VAE/DiT overlap efficiency" has to be computed from.
@@ -137,34 +143,39 @@ class OverlappedDecodingSession:
         if self.lookahead < 1:
             raise ValueError("lookahead must be at least 1.")
         self._state = self.decoder.new_decode_state(self.session_id)
-        self._pending: asyncio.Task | None = None
-        self._pending_started: float | None = None
+        self._pending: collections.deque[tuple[asyncio.Task, float]] = collections.deque()
         self._closed = False
 
     @property
     def decode_state(self) -> Any:
         return self._state
 
-    def _start_generation(self) -> None:
-        if self._pending is None and not self._closed:
-            self._pending_started = self.clock()
-            self._pending = asyncio.ensure_future(self.inner.next_chunk())
+    def _fill_lookahead(self) -> None:
+        """Keep the prefetch topped up to the bound, and never past it."""
+        while not self._closed and len(self._pending) < self.lookahead:
+            self._pending.append((asyncio.ensure_future(self.inner.next_chunk()), self.clock()))
 
     async def next_chunk(self) -> Any:
         t0 = self.clock()
         # A prefetch issued during the previous tick has been running while the
         # caller was away, so only the part still outstanding is charged here.
-        self._start_generation()
-        pending, started = self._pending, self._pending_started
-        self._pending, self._pending_started = None, None
-        output = await pending
+        self._fill_lookahead()
+        task, started = self._pending.popleft()
+        output = await task
         t1 = self.clock()
-        generate_s = t1 - (started if started is not None else t0)
-        waited_s = t1 - t0
-        overlap_s = max(0.0, generate_s - waited_s)
+        generate_s = t1 - started
+        overlap_s = max(0.0, generate_s - (t1 - t0))
 
         # Issue the next generation before decoding, so the two overlap.
-        self._start_generation()
+        self._fill_lookahead()
+        outstanding = len(self._pending)
+        # ensure_future only *schedules* the task. Decode is synchronous and
+        # blocks the event loop for its whole duration, so without handing
+        # control back first the prefetch never starts and the overlap is
+        # nominal: the request would not leave until decode had already
+        # finished. One yield is enough -- the task only has to get as far as
+        # issuing its request before it awaits.
+        await asyncio.sleep(0)
 
         frames = self.decoder.decode_chunk(self.latent_of(output), self._state)
         t2 = self.clock()
@@ -176,19 +187,19 @@ class OverlappedDecodingSession:
             frames=int(frames.shape[2]) if hasattr(frames, "shape") and len(frames.shape) >= 3 else None,
             resident_decoder_bytes=nbytes() if callable(nbytes) else None,
             overlap_s=overlap_s,
-            backpressure_s=0.0,
+            outstanding_generations=outstanding,
         )
         return frames
 
     async def close(self) -> None:
         self._closed = True
-        if self._pending is not None:
-            self._pending.cancel()
+        while self._pending:
+            task, _ = self._pending.popleft()
+            task.cancel()
             try:
-                await self._pending
+                await task
             except (asyncio.CancelledError, Exception):  # noqa: BLE001 - shutdown must not mask close
                 pass
-            self._pending = None
         try:
             self.decoder.release(self._state)
         finally:

--- a/benchmarks/ar_diffusion/engine_binding.py
+++ b/benchmarks/ar_diffusion/engine_binding.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Wire the benchmark harness to a real AR-Diffusion engine.
+
+This is the only module here that needs a device, a checkpoint and a CUDA
+build, and therefore the only one the CPU tests cannot cover. Everything the
+benchmark actually measures -- the load model, the deadline model and every
+metric -- lives in ``realtime_harness`` and ``realtime_metrics`` and is tested
+without it.
+
+The wiring mirrors ``examples/offline_inference/diffusion/lingbot_world_v2_realtime.py``
+but drops everything model-specific: no control reducer, no action schema, no
+fixed frame count. A pipeline needing per-tick controls should extend
+``prompt_provider``/``control_reducer_factory`` rather than change the harness.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RealtimeBackend:
+    """The session manager under test, plus the capability it declared."""
+
+    manager: Any
+    spec: Any
+    engine: Any
+
+
+async def build_realtime_backend(args: argparse.Namespace) -> RealtimeBackend:
+    """Build an AsyncOmni engine and a session manager from CLI arguments."""
+    from vllm_omni.entrypoints.async_omni import AsyncOmni
+    from vllm_omni.experimental.ar_diffusion.consumer import ARDiffusionOmniTickConsumer
+    from vllm_omni.experimental.ar_diffusion.session import (
+        ARDiffusionSessionManager,
+        ARDiffusionWorkerLifecycle,
+    )
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    engine = AsyncOmni(
+        model=args.model,
+        engine_backend="vllm_omni.experimental.ar_diffusion.engine.ARDiffusionEngine",
+        enforce_eager=args.enforce_eager,
+        tensor_parallel_size=args.tensor_parallel_size,
+        max_num_seqs=1,
+        model_config={
+            "ar_diffusion_kv_config": {
+                "gpu_memory_fraction": args.gpu_memory_fraction,
+                "warmup_cudagraph": not args.enforce_eager,
+            },
+        },
+    )
+
+    sampling = OmniDiffusionSamplingParams(seed=args.seed, output_type="latent")
+
+    def prompt_provider(tick: Any) -> dict[str, Any]:
+        prompt: dict[str, Any] = {"prompt": tick.prompt or args.prompt}
+        if args.image is not None:
+            prompt["multi_modal_data"] = {"image": str(args.image)}
+        return prompt
+
+    consumer = ARDiffusionOmniTickConsumer(
+        engine,
+        prompt_provider=prompt_provider,
+        sampling_params_list=[sampling],
+        diffusion_stage_id=0,
+    )
+    manager = ARDiffusionSessionManager(
+        tick_consumer=consumer,
+        lifecycle=ARDiffusionWorkerLifecycle(engine, stage_ids=[0], timeout=180.0),
+        max_pending_events=args.max_pending_events,
+    )
+    return RealtimeBackend(manager=manager, spec=_declared_spec(engine), engine=engine)
+
+
+def _declared_spec(engine: Any) -> Any:
+    """Fetch the pipeline's declared AR-Diffusion KV spec from the engine."""
+    pipeline = getattr(getattr(engine, "engine", None), "pipeline", None)
+    spec_fn = getattr(pipeline, "ar_diffusion_kv_cache_spec", None)
+    if spec_fn is None:
+        raise RuntimeError(
+            "The selected model does not implement SupportsARDiffusionPipeline, "
+            "so its chunk shape and session capacity are not declared."
+        )
+    return spec_fn()

--- a/benchmarks/ar_diffusion/realtime_harness.py
+++ b/benchmarks/ar_diffusion/realtime_harness.py
@@ -140,16 +140,20 @@ async def _drive_session(
     session = await factory(session_id)
     events: list[ChunkEvent] = []
     lost_reason: str | None = None
-    period = config.profile.release_period_s
     gauge.enter()
     try:
         for chunk_index in range(config.chunks_per_session):
             if config.mode is LoadMode.PACED and events:
-                # A paced client consumes one chunk per release period, so the
-                # next tick is not issued before the previous chunk's playout
-                # would have finished. Falling behind never pushes the client
-                # ahead: the due time is anchored to the playout grid.
-                due = t_start + chunk_index * period
+                # Pace against the video actually delivered before this
+                # chunk.  A causal decoder's opening chunk can be shorter than
+                # steady state (LingBot/Wan: 9 frames, then 12), so multiplying
+                # every index by the steady period delays chunk 1 by 3 frames
+                # and manufactures a deadline miss.  Anchor to the first real
+                # submit so session construction time is not part of playout.
+                due = (
+                    events[0].t_submit
+                    + config.profile.cumulative_frames(chunk_index) / config.profile.target_fps
+                )
                 lag = due - clock()
                 if lag > 0:
                     await sleep(lag)

--- a/benchmarks/ar_diffusion/realtime_harness.py
+++ b/benchmarks/ar_diffusion/realtime_harness.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Multi-session driver for realtime AR-Diffusion benchmarks.
+
+The driver owns arrivals, pacing and recording. It talks to sessions through
+:class:`BenchmarkSession`, a two-method view of the realtime session API, so
+the whole load model is exercisable on CPU against a fake session and needs no
+engine, device or checkpoint.
+
+Load parameters, and why only one of them is an axis:
+
+``session arrival rate``
+    The valid open-loop parameter. Sessions arrive and depart over time.
+
+``per-session tick rate``
+    Not an axis. Ticks of one session are strictly ordered and state-dependent:
+    tick ``k + 1`` reads the state committed by tick ``k`` and cannot be issued
+    before the previous chunk returns. Raising it only grows a queue.
+
+``concurrently active sessions``
+    Derived state, not an input. Reported alongside every measurement.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import random
+import time
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from benchmarks.ar_diffusion.realtime_metrics import (
+    ChunkEvent,
+    LoadMode,
+    RunSummary,
+    SessionRecord,
+    WorkloadProfile,
+    summarize_run,
+)
+
+
+class BenchmarkSession(Protocol):
+    """The part of a realtime session the driver needs."""
+
+    async def next_chunk(self) -> Any: ...
+
+    async def close(self) -> None: ...
+
+
+SessionFactory = Callable[[str], Awaitable[BenchmarkSession]]
+
+
+@dataclass(frozen=True)
+class ArrivalPlan:
+    """When each session starts, relative to the run start."""
+
+    offsets_s: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        if any(offset < 0 for offset in self.offsets_s):
+            raise ValueError("arrival offsets must be non-negative.")
+        if list(self.offsets_s) != sorted(self.offsets_s):
+            raise ValueError("arrival offsets must be non-decreasing.")
+
+    def __len__(self) -> int:
+        return len(self.offsets_s)
+
+
+def burst_arrivals(num_sessions: int) -> ArrivalPlan:
+    """All sessions start together: the worst case for admission and memory."""
+    if num_sessions < 1:
+        raise ValueError("num_sessions must be at least 1.")
+    return ArrivalPlan(tuple(0.0 for _ in range(num_sessions)))
+
+
+def poisson_arrivals(num_sessions: int, *, rate_per_s: float, seed: int = 0) -> ArrivalPlan:
+    """Poisson session arrivals; deterministic for a given seed."""
+    if num_sessions < 1:
+        raise ValueError("num_sessions must be at least 1.")
+    if rate_per_s <= 0:
+        raise ValueError("rate_per_s must be positive.")
+    rng = random.Random(seed)
+    offsets: list[float] = []
+    clock = 0.0
+    for _ in range(num_sessions):
+        offsets.append(clock)
+        clock += rng.expovariate(rate_per_s)
+    return ArrivalPlan(tuple(offsets))
+
+
+class _ConcurrencyGauge:
+    """Tracks how many sessions were ticking at once."""
+
+    def __init__(self) -> None:
+        self.current = 0
+        self.peak = 0
+
+    def enter(self) -> None:
+        self.current += 1
+        self.peak = max(self.peak, self.current)
+
+    def exit(self) -> None:
+        self.current -= 1
+
+
+@dataclass
+class BenchmarkConfig:
+    profile: WorkloadProfile
+    mode: LoadMode
+    chunks_per_session: int
+    arrivals: ArrivalPlan
+    num_gpus: int = 1
+    events_dir: Path | None = None
+
+    def __post_init__(self) -> None:
+        if self.chunks_per_session < 1:
+            raise ValueError("chunks_per_session must be at least 1.")
+
+
+async def _drive_session(
+    session_id: str,
+    *,
+    config: BenchmarkConfig,
+    factory: SessionFactory,
+    start_at: float,
+    clock: Callable[[], float],
+    sleep: Callable[[float], Awaitable[None]],
+    gauge: _ConcurrencyGauge,
+) -> SessionRecord:
+    """Run one session to ``chunks_per_session`` chunks, or until it is lost."""
+    delay = start_at - clock()
+    if delay > 0:
+        await sleep(delay)
+
+    t_start = clock()
+    session = await factory(session_id)
+    events: list[ChunkEvent] = []
+    lost_reason: str | None = None
+    period = config.profile.release_period_s
+    gauge.enter()
+    try:
+        for chunk_index in range(config.chunks_per_session):
+            if config.mode is LoadMode.PACED and events:
+                # A paced client consumes one chunk per release period, so the
+                # next tick is not issued before the previous chunk's playout
+                # would have finished. Falling behind never pushes the client
+                # ahead: the due time is anchored to the playout grid.
+                due = t_start + chunk_index * period
+                lag = due - clock()
+                if lag > 0:
+                    await sleep(lag)
+            t_submit = clock()
+            try:
+                await session.next_chunk()
+            except Exception as exc:  # noqa: BLE001 - a lost session is a result, not a crash
+                lost_reason = f"{type(exc).__name__}: {exc}"
+                break
+            events.append(
+                ChunkEvent(
+                    session_id=session_id,
+                    chunk_index=chunk_index,
+                    t_submit=t_submit,
+                    t_ready=clock(),
+                )
+            )
+    finally:
+        gauge.exit()
+        with contextlib.suppress(Exception):
+            await session.close()
+
+    return SessionRecord(
+        session_id=session_id,
+        t_start=t_start,
+        events=tuple(events),
+        lost_reason=lost_reason,
+    )
+
+
+async def run_benchmark(
+    config: BenchmarkConfig,
+    factory: SessionFactory,
+    *,
+    clock: Callable[[], float] | None = None,
+    sleep: Callable[[float], Awaitable[None]] | None = None,
+    notes: Sequence[str] = (),
+) -> RunSummary:
+    """Run every session concurrently and reduce the result to a summary.
+
+    ``clock`` and ``sleep`` are injectable so tests can drive the whole load
+    model on a virtual clock without spending wall time.
+    """
+    resolved_clock = clock or time.perf_counter
+    resolved_sleep = sleep or asyncio.sleep
+    gauge = _ConcurrencyGauge()
+
+    t0 = resolved_clock()
+    tasks = [
+        asyncio.create_task(
+            _drive_session(
+                f"bench-{index}",
+                config=config,
+                factory=factory,
+                start_at=t0 + offset,
+                clock=resolved_clock,
+                sleep=resolved_sleep,
+                gauge=gauge,
+            )
+        )
+        for index, offset in enumerate(config.arrivals.offsets_s)
+    ]
+    records = await asyncio.gather(*tasks)
+    wall = resolved_clock() - t0
+
+    if config.events_dir is not None:
+        write_events(records, config)
+
+    return summarize_run(
+        records,
+        config.profile,
+        mode=config.mode,
+        wall_s=wall,
+        num_gpus=config.num_gpus,
+        peak_concurrent_sessions=gauge.peak,
+        notes=notes,
+    )
+
+
+def write_events(records: Sequence[SessionRecord], config: BenchmarkConfig) -> None:
+    """Write one JSONL of chunk events per session."""
+    if config.events_dir is None:
+        raise ValueError("config.events_dir must be set to write events.")
+    from benchmarks.ar_diffusion.realtime_metrics import chunk_deadlines
+
+    config.events_dir.mkdir(parents=True, exist_ok=True)
+    for record in records:
+        deadlines = chunk_deadlines(record, config.profile) if config.mode is LoadMode.PACED else {}
+        path = config.events_dir / f"{record.session_id}.jsonl"
+        with path.open("w", encoding="utf-8") as handle:
+            for event in record.events:
+                handle.write(json.dumps(event.to_dict(deadline=deadlines.get(event.chunk_index))) + "\n")

--- a/benchmarks/ar_diffusion/realtime_harness.py
+++ b/benchmarks/ar_diffusion/realtime_harness.py
@@ -173,6 +173,8 @@ async def _drive_session(
                     frames=getattr(timing, "frames", None),
                     generate_s=getattr(timing, "generate_s", None),
                     decode_s=getattr(timing, "decode_s", None),
+                    overlap_s=getattr(timing, "overlap_s", None),
+                    backpressure_s=getattr(timing, "backpressure_s", None),
                 )
             )
             resident = getattr(timing, "resident_decoder_bytes", None)

--- a/benchmarks/ar_diffusion/realtime_harness.py
+++ b/benchmarks/ar_diffusion/realtime_harness.py
@@ -174,7 +174,7 @@ async def _drive_session(
                     generate_s=getattr(timing, "generate_s", None),
                     decode_s=getattr(timing, "decode_s", None),
                     overlap_s=getattr(timing, "overlap_s", None),
-                    backpressure_s=getattr(timing, "backpressure_s", None),
+                    outstanding_generations=getattr(timing, "outstanding_generations", None),
                 )
             )
             resident = getattr(timing, "resident_decoder_bytes", None)

--- a/benchmarks/ar_diffusion/realtime_harness.py
+++ b/benchmarks/ar_diffusion/realtime_harness.py
@@ -139,6 +139,7 @@ async def _drive_session(
     t_start = clock()
     session = await factory(session_id)
     events: list[ChunkEvent] = []
+    decoder_bytes: list[int] = []
     lost_reason: str | None = None
     period = config.profile.release_period_s
     gauge.enter()
@@ -159,14 +160,24 @@ async def _drive_session(
             except Exception as exc:  # noqa: BLE001 - a lost session is a result, not a crash
                 lost_reason = f"{type(exc).__name__}: {exc}"
                 break
+            # A session that decodes its own chunks reports the generate/decode
+            # split and the frames it actually delivered; one that returns
+            # latents leaves these None and the profile supplies the geometry.
+            timing = getattr(session, "last", None)
             events.append(
                 ChunkEvent(
                     session_id=session_id,
                     chunk_index=chunk_index,
                     t_submit=t_submit,
                     t_ready=clock(),
+                    frames=getattr(timing, "frames", None),
+                    generate_s=getattr(timing, "generate_s", None),
+                    decode_s=getattr(timing, "decode_s", None),
                 )
             )
+            resident = getattr(timing, "resident_decoder_bytes", None)
+            if resident is not None:
+                decoder_bytes.append(resident)
     finally:
         gauge.exit()
         with contextlib.suppress(Exception):
@@ -177,6 +188,9 @@ async def _drive_session(
         t_start=t_start,
         events=tuple(events),
         lost_reason=lost_reason,
+        # Peak rather than last: the cache is bounded, so these agree in steady
+        # state, and a peak is what admission has to reserve against.
+        resident_decoder_bytes=max(decoder_bytes) if decoder_bytes else None,
     )
 
 
@@ -214,6 +228,8 @@ async def run_benchmark(
     ]
     records = await asyncio.gather(*tasks)
     wall = resolved_clock() - t0
+    reported = [r.resident_decoder_bytes for r in records if r.resident_decoder_bytes is not None]
+    resident_decoder_bytes = max(reported) if reported else None
 
     if config.events_dir is not None:
         write_events(records, config)
@@ -225,6 +241,7 @@ async def run_benchmark(
         wall_s=wall,
         num_gpus=config.num_gpus,
         peak_concurrent_sessions=gauge.peak,
+        resident_decoder_bytes_per_session=resident_decoder_bytes,
         notes=notes,
     )
 

--- a/benchmarks/ar_diffusion/realtime_harness.py
+++ b/benchmarks/ar_diffusion/realtime_harness.py
@@ -151,10 +151,7 @@ async def _drive_session(
                 # every index by the steady period delays chunk 1 by 3 frames
                 # and manufactures a deadline miss.  Anchor to the first real
                 # submit so session construction time is not part of playout.
-                due = (
-                    events[0].t_submit
-                    + config.profile.cumulative_frames(chunk_index) / config.profile.target_fps
-                )
+                due = events[0].t_submit + config.profile.cumulative_frames(chunk_index) / config.profile.target_fps
                 lag = due - clock()
                 if lag > 0:
                     await sleep(lag)

--- a/benchmarks/ar_diffusion/realtime_metrics.py
+++ b/benchmarks/ar_diffusion/realtime_metrics.py
@@ -49,6 +49,7 @@ class WorkloadProfile:
     target_fps: float
     buffer_chunks: int = 1
     resident_bytes_per_session: int | None = None
+    frames_per_first_chunk: int | None = None
 
     def __post_init__(self) -> None:
         if isinstance(self.frames_per_chunk, bool) or not isinstance(self.frames_per_chunk, int):
@@ -65,11 +66,42 @@ class WorkloadProfile:
             raise ValueError("buffer_chunks must be at least 1.")
         if self.resident_bytes_per_session is not None and self.resident_bytes_per_session < 0:
             raise ValueError("resident_bytes_per_session must be non-negative.")
+        first = self.frames_per_chunk if self.frames_per_first_chunk is None else self.frames_per_first_chunk
+        if isinstance(first, bool) or not isinstance(first, int) or first <= 0:
+            raise ValueError("frames_per_first_chunk must be a positive integer.")
+        object.__setattr__(self, "frames_per_first_chunk", first)
 
     @property
     def release_period_s(self) -> float:
-        """Wall time one committed chunk is worth at the declared playout rate."""
+        """Wall time one steady-state chunk is worth at the declared playout rate.
+
+        Steady state, not the first chunk: a causal decoder expands its first
+        latent frame to a single raw frame and every later one to the full
+        temporal factor, so the opening chunk delivers less video than those
+        that follow. The playout grid is paced by the steady-state chunk, and
+        the shorter opening is accounted for in the cumulative video time that
+        :func:`chunk_deadlines` walks.
+        """
         return self.frames_per_chunk / self.target_fps
+
+    def frames_at(self, chunk_index: int) -> int:
+        """Raw frames chunk ``chunk_index`` delivers."""
+        if isinstance(chunk_index, bool) or not isinstance(chunk_index, int) or chunk_index < 0:
+            raise ValueError("chunk_index must be a non-negative integer.")
+        assert self.frames_per_first_chunk is not None  # resolved in __post_init__
+        return self.frames_per_first_chunk if chunk_index == 0 else self.frames_per_chunk
+
+    def cumulative_frames(self, chunk_count: int) -> int:
+        """Raw frames delivered by chunks ``0 .. chunk_count - 1``."""
+        if chunk_count <= 0:
+            return 0
+        assert self.frames_per_first_chunk is not None
+        return self.frames_per_first_chunk + self.frames_per_chunk * (chunk_count - 1)
+
+    @property
+    def is_causal(self) -> bool:
+        """Whether the opening chunk delivers fewer frames than later ones."""
+        return self.frames_per_first_chunk != self.frames_per_chunk
 
 
 @dataclass(frozen=True)
@@ -142,17 +174,23 @@ def percentile(values: Sequence[float], fraction: float) -> float | None:
 def chunk_deadlines(record: SessionRecord, profile: WorkloadProfile) -> dict[int, float]:
     """Playout deadline per chunk, or ``{}`` when playback never starts.
 
-    Playback begins once ``buffer_chunks`` chunks are buffered, so chunk
-    ``buffer_chunks - 1`` fixes the playout grid and every later chunk is due
-    one release period after its predecessor. Chunks inside the prebuffer have
-    no deadline: their cost is start latency, which TTFC already reports.
+    Playback begins once ``buffer_chunks`` chunks are buffered. From that
+    instant the player consumes continuously, so chunk ``i`` starts playing
+    only after chunks ``0 .. i - 1`` have played, and must be ready by then::
+
+        deadline(i) = t_ready(buffer_chunks - 1) + cumulative_frames(i) / target_fps
+
+    Walking cumulative frames rather than multiplying a constant period is what
+    lets a deeper buffer grant real slack, and what keeps a causal decoder's
+    shorter opening chunk from being credited with a full period of video.
+    Chunks inside the prebuffer have no deadline: their cost is start latency,
+    which TTFC already reports.
     """
     if len(record.events) < profile.buffer_chunks:
         return {}
     anchor = record.events[profile.buffer_chunks - 1]
-    period = profile.release_period_s
     return {
-        event.chunk_index: anchor.t_ready + (event.chunk_index - anchor.chunk_index) * period
+        event.chunk_index: anchor.t_ready + profile.cumulative_frames(event.chunk_index) / profile.target_fps
         for event in record.events[profile.buffer_chunks :]
     }
 
@@ -187,6 +225,10 @@ def summarize_session(
     events = record.events
     latencies = [event.latency_s for event in events]
     ttfc = events[0].t_ready - record.t_start if events else None
+    # Sum the per-chunk delivery rather than multiplying by a constant: with a
+    # causal decoder the opening chunk is shorter, so chunks x frames_per_chunk
+    # over-counts every run by that difference.
+    frames = sum(profile.frames_at(event.chunk_index) for event in events)
 
     rtf: float | None = None
     if events:
@@ -194,7 +236,7 @@ def summarize_session(
         # from the first submit so queueing before the session starts ticking is
         # not charged to the model.
         wall = events[-1].t_ready - events[0].t_submit
-        video_seconds = len(events) * profile.release_period_s
+        video_seconds = frames / profile.target_fps
         rtf = wall / video_seconds if video_seconds > 0 else None
 
     deadlines = chunk_deadlines(record, profile) if mode is LoadMode.PACED else {}
@@ -206,7 +248,7 @@ def summarize_session(
     return SessionSummary(
         session_id=record.session_id,
         chunks=len(events),
-        frames=len(events) * profile.frames_per_chunk,
+        frames=frames,
         ttfc_s=ttfc,
         latency_p50_s=percentile(latencies, 0.50),
         latency_p95_s=percentile(latencies, 0.95),
@@ -244,6 +286,7 @@ class RunSummary:
             "mode": self.mode.value,
             "profile": {
                 "frames_per_chunk": self.profile.frames_per_chunk,
+                "frames_per_first_chunk": self.profile.frames_per_first_chunk,
                 "target_fps": self.profile.target_fps,
                 "buffer_chunks": self.profile.buffer_chunks,
                 "release_period_s": self.profile.release_period_s,
@@ -335,11 +378,21 @@ def compare_runs(baseline: RunSummary, candidate: RunSummary) -> dict[str, Any]:
     return delta
 
 
-def load_profile_from_spec(spec: Mapping[str, Any], *, target_fps: float, buffer_chunks: int = 1) -> WorkloadProfile:
+def load_profile_from_spec(
+    spec: Mapping[str, Any],
+    *,
+    target_fps: float,
+    buffer_chunks: int = 1,
+    causal: bool = True,
+) -> WorkloadProfile:
     """Build a profile from a pipeline's declared AR-Diffusion KV spec.
 
-    Reads ``frames_per_block`` and the VAE temporal factor from the spec rather
-    than from a flag, so the harness never encodes a model's chunk shape.
+    ``frames_per_block`` is in latent frames. A causal video decoder expands
+    the very first latent frame of a session to one raw frame and every later
+    one to the full temporal factor, so an opening block of ``n`` latent frames
+    delivers ``(n - 1) * factor + 1`` raw frames while every later block
+    delivers ``n * factor``. Pass ``causal=False`` for a decoder that expands
+    every latent frame identically.
     """
     frames_per_block = spec.get("frames_per_block")
     temporal_factor = spec.get("vae_temporal_factor", 1)
@@ -347,8 +400,11 @@ def load_profile_from_spec(spec: Mapping[str, Any], *, target_fps: float, buffer
         raise ValueError("spec must declare a positive integer frames_per_block.")
     if isinstance(temporal_factor, bool) or not isinstance(temporal_factor, int) or temporal_factor <= 0:
         raise ValueError("spec vae_temporal_factor must be a positive integer.")
+    steady = frames_per_block * temporal_factor
+    first = (frames_per_block - 1) * temporal_factor + 1 if causal else steady
     return WorkloadProfile(
-        frames_per_chunk=frames_per_block * temporal_factor,
+        frames_per_chunk=steady,
+        frames_per_first_chunk=first,
         target_fps=target_fps,
         buffer_chunks=buffer_chunks,
         resident_bytes_per_session=spec.get("resident_bytes_per_session"),

--- a/benchmarks/ar_diffusion/realtime_metrics.py
+++ b/benchmarks/ar_diffusion/realtime_metrics.py
@@ -116,7 +116,7 @@ class ChunkEvent:
     generate_s: float | None = None
     decode_s: float | None = None
     overlap_s: float | None = None
-    backpressure_s: float | None = None
+    outstanding_generations: int | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.session_id, str) or not self.session_id.strip():
@@ -129,7 +129,7 @@ class ChunkEvent:
             raise TypeError("frames must be an integer when provided.")
         if self.frames is not None and self.frames <= 0:
             raise ValueError("frames must be positive when provided.")
-        for name in ("generate_s", "decode_s", "overlap_s", "backpressure_s"):
+        for name in ("generate_s", "decode_s", "overlap_s"):
             value = getattr(self, name)
             if value is not None and value < 0:
                 raise ValueError(f"{name} must be non-negative.")
@@ -146,7 +146,7 @@ class ChunkEvent:
             "t_ready": self.t_ready,
             "latency_s": self.latency_s,
         }
-        for name in ("frames", "generate_s", "decode_s", "overlap_s", "backpressure_s"):
+        for name in ("frames", "generate_s", "decode_s", "overlap_s", "outstanding_generations"):
             value = getattr(self, name)
             if value is not None:
                 record[name] = value
@@ -239,7 +239,7 @@ class SessionSummary:
     decode_share: float | None = None
     overlap_s_total: float | None = None
     overlap_efficiency: float | None = None
-    backpressure_s_total: float | None = None
+    peak_outstanding_generations: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return dict(self.__dict__)
@@ -279,7 +279,7 @@ def summarize_session(
     generate_total = _optional_sum(event.generate_s for event in events)
     decode_total = _optional_sum(event.decode_s for event in events)
     overlap_total = _optional_sum(event.overlap_s for event in events)
-    backpressure_total = _optional_sum(event.backpressure_s for event in events)
+    outstanding = [e.outstanding_generations for e in events if e.outstanding_generations is not None]
     latency_total = sum(latencies)
     return SessionSummary(
         session_id=record.session_id,
@@ -309,7 +309,7 @@ def summarize_session(
             if overlap_total is not None and generate_total is not None and generate_total > 0
             else None
         ),
-        backpressure_s_total=backpressure_total,
+        peak_outstanding_generations=max(outstanding) if outstanding else None,
     )
 
 

--- a/benchmarks/ar_diffusion/realtime_metrics.py
+++ b/benchmarks/ar_diffusion/realtime_metrics.py
@@ -115,6 +115,8 @@ class ChunkEvent:
     frames: int | None = None
     generate_s: float | None = None
     decode_s: float | None = None
+    overlap_s: float | None = None
+    backpressure_s: float | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.session_id, str) or not self.session_id.strip():
@@ -127,7 +129,7 @@ class ChunkEvent:
             raise TypeError("frames must be an integer when provided.")
         if self.frames is not None and self.frames <= 0:
             raise ValueError("frames must be positive when provided.")
-        for name in ("generate_s", "decode_s"):
+        for name in ("generate_s", "decode_s", "overlap_s", "backpressure_s"):
             value = getattr(self, name)
             if value is not None and value < 0:
                 raise ValueError(f"{name} must be non-negative.")
@@ -144,7 +146,7 @@ class ChunkEvent:
             "t_ready": self.t_ready,
             "latency_s": self.latency_s,
         }
-        for name in ("frames", "generate_s", "decode_s"):
+        for name in ("frames", "generate_s", "decode_s", "overlap_s", "backpressure_s"):
             value = getattr(self, name)
             if value is not None:
                 record[name] = value
@@ -235,6 +237,9 @@ class SessionSummary:
     generate_s_total: float | None = None
     decode_s_total: float | None = None
     decode_share: float | None = None
+    overlap_s_total: float | None = None
+    overlap_efficiency: float | None = None
+    backpressure_s_total: float | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return dict(self.__dict__)
@@ -273,6 +278,8 @@ def summarize_session(
 
     generate_total = _optional_sum(event.generate_s for event in events)
     decode_total = _optional_sum(event.decode_s for event in events)
+    overlap_total = _optional_sum(event.overlap_s for event in events)
+    backpressure_total = _optional_sum(event.backpressure_s for event in events)
     latency_total = sum(latencies)
     return SessionSummary(
         session_id=record.session_id,
@@ -294,6 +301,15 @@ def summarize_session(
         # decode serialized this is the headroom overlapping them can recover;
         # once they overlap it is what the measurement has to show shrinking.
         decode_share=(decode_total / latency_total if decode_total is not None and latency_total > 0 else None),
+        overlap_s_total=overlap_total,
+        # Fraction of generate time hidden behind decode. 0 when the two are
+        # serialized, approaching 1 as generation is fully covered.
+        overlap_efficiency=(
+            overlap_total / generate_total
+            if overlap_total is not None and generate_total is not None and generate_total > 0
+            else None
+        ),
+        backpressure_s_total=backpressure_total,
     )
 
 
@@ -315,6 +331,7 @@ class RunSummary:
     rtf_spread: float | None
     peak_concurrent_sessions: int
     decode_share: float | None = None
+    overlap_efficiency: float | None = None
     resident_decoder_bytes_per_session: int | None = None
     notes: tuple[str, ...] = field(default_factory=tuple)
 
@@ -341,6 +358,7 @@ class RunSummary:
             "continuous_play_ratio": self.continuous_play_ratio,
             "rtf_spread": self.rtf_spread,
             "decode_share": self.decode_share,
+            "overlap_efficiency": self.overlap_efficiency,
             "resident_decoder_bytes_per_session": self.resident_decoder_bytes_per_session,
             "notes": list(self.notes),
             "per_session": [summary.to_dict() for summary in self.sessions],
@@ -374,6 +392,7 @@ def summarize_run(
     per_session_cpr = [s.continuous_play_ratio for s in summaries if s.continuous_play_ratio is not None]
     rtfs = [s.rtf for s in summaries if s.rtf is not None]
     decode_shares = [s.decode_share for s in summaries if s.decode_share is not None]
+    overlaps = [s.overlap_efficiency for s in summaries if s.overlap_efficiency is not None]
 
     return RunSummary(
         mode=mode,
@@ -390,6 +409,7 @@ def summarize_run(
         rtf_spread=max(rtfs) - min(rtfs) if len(rtfs) > 1 else None,
         peak_concurrent_sessions=(peak_concurrent_sessions if peak_concurrent_sessions is not None else len(summaries)),
         decode_share=statistics.fmean(decode_shares) if decode_shares else None,
+        overlap_efficiency=statistics.fmean(overlaps) if overlaps else None,
         resident_decoder_bytes_per_session=resident_decoder_bytes_per_session,
         notes=tuple(notes),
     )

--- a/benchmarks/ar_diffusion/realtime_metrics.py
+++ b/benchmarks/ar_diffusion/realtime_metrics.py
@@ -1,0 +1,355 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Metric definitions for realtime AR-Diffusion session benchmarks.
+
+Pure functions over recorded chunk events: no engine, no model, no device.
+Everything here is derived from a :class:`WorkloadProfile` so swapping the
+pipeline under test requires no change in this module.
+
+Two load modes produce different metrics, and conflating them produces a
+number no deployment can use:
+
+``saturating``
+    Each session issues its next tick as soon as the previous one returns.
+    Measures the ceiling -- aggregate generated FPS and frames per GPU-second.
+    Deadlines do not exist in this mode, so continuity metrics are ``None``.
+
+``paced``
+    Sessions consume at ``target_fps``, so a chunk is due once per release
+    period. Measures continuity -- CPR, TTFC and worst-case chunk latency.
+    SLO is only defined in this mode.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class LoadMode(str, Enum):
+    SATURATING = "saturating"
+    PACED = "paced"
+
+
+@dataclass(frozen=True)
+class WorkloadProfile:
+    """Serving-relevant shape of the pipeline under test.
+
+    ``frames_per_chunk`` is the number of raw frames one committed chunk
+    delivers, i.e. the model's latent frames per block multiplied by the VAE
+    temporal factor. It comes from the pipeline capability rather than from a
+    command-line default so the harness stays model-neutral.
+    """
+
+    frames_per_chunk: int
+    target_fps: float
+    buffer_chunks: int = 1
+    resident_bytes_per_session: int | None = None
+
+    def __post_init__(self) -> None:
+        if isinstance(self.frames_per_chunk, bool) or not isinstance(self.frames_per_chunk, int):
+            raise TypeError("frames_per_chunk must be an integer.")
+        if self.frames_per_chunk <= 0:
+            raise ValueError("frames_per_chunk must be positive.")
+        if not isinstance(self.target_fps, (int, float)) or isinstance(self.target_fps, bool):
+            raise TypeError("target_fps must be a number.")
+        if not math.isfinite(self.target_fps) or self.target_fps <= 0:
+            raise ValueError("target_fps must be a positive finite number.")
+        if isinstance(self.buffer_chunks, bool) or not isinstance(self.buffer_chunks, int):
+            raise TypeError("buffer_chunks must be an integer.")
+        if self.buffer_chunks < 1:
+            raise ValueError("buffer_chunks must be at least 1.")
+        if self.resident_bytes_per_session is not None and self.resident_bytes_per_session < 0:
+            raise ValueError("resident_bytes_per_session must be non-negative.")
+
+    @property
+    def release_period_s(self) -> float:
+        """Wall time one committed chunk is worth at the declared playout rate."""
+        return self.frames_per_chunk / self.target_fps
+
+
+@dataclass(frozen=True)
+class ChunkEvent:
+    """One committed chunk, timed against a common monotonic clock."""
+
+    session_id: str
+    chunk_index: int
+    t_submit: float
+    t_ready: float
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.session_id, str) or not self.session_id.strip():
+            raise ValueError("session_id must be a non-empty string.")
+        if isinstance(self.chunk_index, bool) or not isinstance(self.chunk_index, int) or self.chunk_index < 0:
+            raise ValueError("chunk_index must be a non-negative integer.")
+        if self.t_ready < self.t_submit:
+            raise ValueError("t_ready must not precede t_submit.")
+
+    @property
+    def latency_s(self) -> float:
+        return self.t_ready - self.t_submit
+
+    def to_dict(self, *, deadline: float | None = None) -> dict[str, Any]:
+        record: dict[str, Any] = {
+            "session_id": self.session_id,
+            "chunk_index": self.chunk_index,
+            "t_submit": self.t_submit,
+            "t_ready": self.t_ready,
+            "latency_s": self.latency_s,
+        }
+        if deadline is not None:
+            record["deadline"] = deadline
+            record["met_deadline"] = self.t_ready <= deadline
+        return record
+
+
+@dataclass(frozen=True)
+class SessionRecord:
+    """Every committed chunk of one session, plus when the session started."""
+
+    session_id: str
+    t_start: float
+    events: tuple[ChunkEvent, ...]
+    lost_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        indices = [event.chunk_index for event in self.events]
+        if indices != sorted(indices) or len(set(indices)) != len(indices):
+            raise ValueError("events must be unique and ordered by chunk_index.")
+        if any(event.session_id != self.session_id for event in self.events):
+            raise ValueError("every event must belong to this session.")
+
+
+def percentile(values: Sequence[float], fraction: float) -> float | None:
+    """Nearest-rank percentile; ``None`` for an empty sample.
+
+    Nearest-rank rather than an interpolating estimator because these samples
+    are small and a reported P99 should be a latency that actually occurred.
+    """
+    if not 0.0 < fraction <= 1.0:
+        raise ValueError("fraction must be in (0, 1].")
+    if not values:
+        return None
+    ordered = sorted(values)
+    rank = max(1, math.ceil(fraction * len(ordered)))
+    return ordered[rank - 1]
+
+
+def chunk_deadlines(record: SessionRecord, profile: WorkloadProfile) -> dict[int, float]:
+    """Playout deadline per chunk, or ``{}`` when playback never starts.
+
+    Playback begins once ``buffer_chunks`` chunks are buffered, so chunk
+    ``buffer_chunks - 1`` fixes the playout grid and every later chunk is due
+    one release period after its predecessor. Chunks inside the prebuffer have
+    no deadline: their cost is start latency, which TTFC already reports.
+    """
+    if len(record.events) < profile.buffer_chunks:
+        return {}
+    anchor = record.events[profile.buffer_chunks - 1]
+    period = profile.release_period_s
+    return {
+        event.chunk_index: anchor.t_ready + (event.chunk_index - anchor.chunk_index) * period
+        for event in record.events[profile.buffer_chunks :]
+    }
+
+
+@dataclass(frozen=True)
+class SessionSummary:
+    session_id: str
+    chunks: int
+    frames: int
+    ttfc_s: float | None
+    latency_p50_s: float | None
+    latency_p95_s: float | None
+    latency_p99_s: float | None
+    latency_max_s: float | None
+    rtf: float | None
+    deadline_chunks: int
+    deadline_misses: int
+    continuous_play_ratio: float | None
+    lost_reason: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return dict(self.__dict__)
+
+
+def summarize_session(
+    record: SessionRecord,
+    profile: WorkloadProfile,
+    *,
+    mode: LoadMode,
+) -> SessionSummary:
+    """Reduce one session's chunk events to its reported metrics."""
+    events = record.events
+    latencies = [event.latency_s for event in events]
+    ttfc = events[0].t_ready - record.t_start if events else None
+
+    rtf: float | None = None
+    if events:
+        # Steady-state generation cost against the video time produced. Measured
+        # from the first submit so queueing before the session starts ticking is
+        # not charged to the model.
+        wall = events[-1].t_ready - events[0].t_submit
+        video_seconds = len(events) * profile.release_period_s
+        rtf = wall / video_seconds if video_seconds > 0 else None
+
+    deadlines = chunk_deadlines(record, profile) if mode is LoadMode.PACED else {}
+    misses = sum(
+        1 for event in events if event.chunk_index in deadlines and event.t_ready > deadlines[event.chunk_index]
+    )
+    cpr = (len(deadlines) - misses) / len(deadlines) if deadlines else None
+
+    return SessionSummary(
+        session_id=record.session_id,
+        chunks=len(events),
+        frames=len(events) * profile.frames_per_chunk,
+        ttfc_s=ttfc,
+        latency_p50_s=percentile(latencies, 0.50),
+        latency_p95_s=percentile(latencies, 0.95),
+        latency_p99_s=percentile(latencies, 0.99),
+        latency_max_s=max(latencies) if latencies else None,
+        rtf=rtf,
+        deadline_chunks=len(deadlines),
+        deadline_misses=misses,
+        continuous_play_ratio=cpr,
+        lost_reason=record.lost_reason,
+    )
+
+
+@dataclass(frozen=True)
+class RunSummary:
+    """Aggregate view of one benchmark run, plus the per-session detail."""
+
+    mode: LoadMode
+    profile: WorkloadProfile
+    num_gpus: int
+    wall_s: float
+    sessions: tuple[SessionSummary, ...]
+    sessions_lost: int
+    generated_fps: float | None
+    frames_per_gpu_second: float | None
+    worst_case_chunk_latency_s: float | None
+    continuous_play_ratio: float | None
+    mean_chunk_latency_s: float | None
+    rtf_spread: float | None
+    peak_concurrent_sessions: int
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mode": self.mode.value,
+            "profile": {
+                "frames_per_chunk": self.profile.frames_per_chunk,
+                "target_fps": self.profile.target_fps,
+                "buffer_chunks": self.profile.buffer_chunks,
+                "release_period_s": self.profile.release_period_s,
+                "resident_bytes_per_session": self.profile.resident_bytes_per_session,
+            },
+            "num_gpus": self.num_gpus,
+            "wall_s": self.wall_s,
+            "sessions_run": len(self.sessions),
+            "sessions_lost": self.sessions_lost,
+            "peak_concurrent_sessions": self.peak_concurrent_sessions,
+            "generated_fps": self.generated_fps,
+            "frames_per_gpu_second": self.frames_per_gpu_second,
+            "mean_chunk_latency_s": self.mean_chunk_latency_s,
+            "worst_case_chunk_latency_s": self.worst_case_chunk_latency_s,
+            "continuous_play_ratio": self.continuous_play_ratio,
+            "rtf_spread": self.rtf_spread,
+            "notes": list(self.notes),
+            "per_session": [summary.to_dict() for summary in self.sessions],
+        }
+
+
+def summarize_run(
+    records: Iterable[SessionRecord],
+    profile: WorkloadProfile,
+    *,
+    mode: LoadMode,
+    wall_s: float,
+    num_gpus: int = 1,
+    peak_concurrent_sessions: int | None = None,
+    notes: Sequence[str] = (),
+) -> RunSummary:
+    """Aggregate session records into the reportable run summary."""
+    if num_gpus < 1:
+        raise ValueError("num_gpus must be at least 1.")
+    if wall_s < 0:
+        raise ValueError("wall_s must be non-negative.")
+
+    ordered = list(records)
+    summaries = tuple(summarize_session(record, profile, mode=mode) for record in ordered)
+    total_frames = sum(summary.frames for summary in summaries)
+    latencies = [event.latency_s for record in ordered for event in record.events]
+
+    # Macro-average over sessions: one lagging session is not diluted by a
+    # neighbour that produced many more chunks.
+    per_session_cpr = [s.continuous_play_ratio for s in summaries if s.continuous_play_ratio is not None]
+    rtfs = [s.rtf for s in summaries if s.rtf is not None]
+
+    return RunSummary(
+        mode=mode,
+        profile=profile,
+        num_gpus=num_gpus,
+        wall_s=wall_s,
+        sessions=summaries,
+        sessions_lost=sum(1 for s in summaries if s.lost_reason is not None),
+        generated_fps=total_frames / wall_s if wall_s > 0 else None,
+        frames_per_gpu_second=total_frames / (wall_s * num_gpus) if wall_s > 0 else None,
+        worst_case_chunk_latency_s=max(latencies) if latencies else None,
+        continuous_play_ratio=statistics.fmean(per_session_cpr) if per_session_cpr else None,
+        mean_chunk_latency_s=statistics.fmean(latencies) if latencies else None,
+        rtf_spread=max(rtfs) - min(rtfs) if len(rtfs) > 1 else None,
+        peak_concurrent_sessions=(peak_concurrent_sessions if peak_concurrent_sessions is not None else len(summaries)),
+        notes=tuple(notes),
+    )
+
+
+def compare_runs(baseline: RunSummary, candidate: RunSummary) -> dict[str, Any]:
+    """Derive the per-tick switching cost between two runs.
+
+    Aggregate generated FPS is expected to stay flat when concurrency of state
+    rises but concurrency of execution does not: ticks serialize, so the same
+    device produces the same frames. A measurable drop is per-tick switching
+    cost -- state bind/unbind, KV pool paging, conditioning rebuild -- and that
+    quantity is the baseline any cross-session batching work has to beat.
+    """
+    delta: dict[str, Any] = {
+        "baseline_sessions": len(baseline.sessions),
+        "candidate_sessions": len(candidate.sessions),
+    }
+    if baseline.generated_fps and candidate.generated_fps is not None:
+        delta["generated_fps_ratio"] = candidate.generated_fps / baseline.generated_fps
+    if baseline.mean_chunk_latency_s is not None and candidate.mean_chunk_latency_s is not None:
+        delta["mean_chunk_latency_delta_s"] = candidate.mean_chunk_latency_s - baseline.mean_chunk_latency_s
+        sessions = len(candidate.sessions) or 1
+        # With serialized ticks a candidate chunk waits behind the other
+        # resident sessions, so the expected latency is sessions x baseline.
+        # Anything beyond that expectation is switching cost, not queueing.
+        expected = baseline.mean_chunk_latency_s * sessions
+        delta["per_tick_switching_cost_s"] = candidate.mean_chunk_latency_s - expected
+    return delta
+
+
+def load_profile_from_spec(spec: Mapping[str, Any], *, target_fps: float, buffer_chunks: int = 1) -> WorkloadProfile:
+    """Build a profile from a pipeline's declared AR-Diffusion KV spec.
+
+    Reads ``frames_per_block`` and the VAE temporal factor from the spec rather
+    than from a flag, so the harness never encodes a model's chunk shape.
+    """
+    frames_per_block = spec.get("frames_per_block")
+    temporal_factor = spec.get("vae_temporal_factor", 1)
+    if isinstance(frames_per_block, bool) or not isinstance(frames_per_block, int) or frames_per_block <= 0:
+        raise ValueError("spec must declare a positive integer frames_per_block.")
+    if isinstance(temporal_factor, bool) or not isinstance(temporal_factor, int) or temporal_factor <= 0:
+        raise ValueError("spec vae_temporal_factor must be a positive integer.")
+    return WorkloadProfile(
+        frames_per_chunk=frames_per_block * temporal_factor,
+        target_fps=target_fps,
+        buffer_chunks=buffer_chunks,
+        resident_bytes_per_session=spec.get("resident_bytes_per_session"),
+    )

--- a/benchmarks/ar_diffusion/realtime_metrics.py
+++ b/benchmarks/ar_diffusion/realtime_metrics.py
@@ -112,6 +112,9 @@ class ChunkEvent:
     chunk_index: int
     t_submit: float
     t_ready: float
+    frames: int | None = None
+    generate_s: float | None = None
+    decode_s: float | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.session_id, str) or not self.session_id.strip():
@@ -120,6 +123,14 @@ class ChunkEvent:
             raise ValueError("chunk_index must be a non-negative integer.")
         if self.t_ready < self.t_submit:
             raise ValueError("t_ready must not precede t_submit.")
+        if self.frames is not None and (isinstance(self.frames, bool) or not isinstance(self.frames, int)):
+            raise TypeError("frames must be an integer when provided.")
+        if self.frames is not None and self.frames <= 0:
+            raise ValueError("frames must be positive when provided.")
+        for name in ("generate_s", "decode_s"):
+            value = getattr(self, name)
+            if value is not None and value < 0:
+                raise ValueError(f"{name} must be non-negative.")
 
     @property
     def latency_s(self) -> float:
@@ -133,6 +144,10 @@ class ChunkEvent:
             "t_ready": self.t_ready,
             "latency_s": self.latency_s,
         }
+        for name in ("frames", "generate_s", "decode_s"):
+            value = getattr(self, name)
+            if value is not None:
+                record[name] = value
         if deadline is not None:
             record["deadline"] = deadline
             record["met_deadline"] = self.t_ready <= deadline
@@ -147,6 +162,7 @@ class SessionRecord:
     t_start: float
     events: tuple[ChunkEvent, ...]
     lost_reason: str | None = None
+    resident_decoder_bytes: int | None = None
 
     def __post_init__(self) -> None:
         indices = [event.chunk_index for event in self.events]
@@ -154,6 +170,12 @@ class SessionRecord:
             raise ValueError("events must be unique and ordered by chunk_index.")
         if any(event.session_id != self.session_id for event in self.events):
             raise ValueError("every event must belong to this session.")
+
+
+def _optional_sum(values: Iterable[float | None]) -> float | None:
+    """Sum values, or ``None`` when nothing reported a value."""
+    collected = [value for value in values if value is not None]
+    return sum(collected) if collected else None
 
 
 def percentile(values: Sequence[float], fraction: float) -> float | None:
@@ -210,6 +232,9 @@ class SessionSummary:
     deadline_misses: int
     continuous_play_ratio: float | None
     lost_reason: str | None
+    generate_s_total: float | None = None
+    decode_s_total: float | None = None
+    decode_share: float | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return dict(self.__dict__)
@@ -225,10 +250,11 @@ def summarize_session(
     events = record.events
     latencies = [event.latency_s for event in events]
     ttfc = events[0].t_ready - record.t_start if events else None
-    # Sum the per-chunk delivery rather than multiplying by a constant: with a
-    # causal decoder the opening chunk is shorter, so chunks x frames_per_chunk
-    # over-counts every run by that difference.
-    frames = sum(profile.frames_at(event.chunk_index) for event in events)
+    # Prefer what the decoder actually delivered. Falling back on the profile
+    # is an assumption about the decoder's temporal geometry; a measured count
+    # is not, which matters precisely because that geometry is not declared
+    # anywhere the runtime can read.
+    frames = sum(event.frames if event.frames is not None else profile.frames_at(event.chunk_index) for event in events)
 
     rtf: float | None = None
     if events:
@@ -245,6 +271,9 @@ def summarize_session(
     )
     cpr = (len(deadlines) - misses) / len(deadlines) if deadlines else None
 
+    generate_total = _optional_sum(event.generate_s for event in events)
+    decode_total = _optional_sum(event.decode_s for event in events)
+    latency_total = sum(latencies)
     return SessionSummary(
         session_id=record.session_id,
         chunks=len(events),
@@ -259,6 +288,12 @@ def summarize_session(
         deadline_misses=misses,
         continuous_play_ratio=cpr,
         lost_reason=record.lost_reason,
+        generate_s_total=generate_total,
+        decode_s_total=decode_total,
+        # The fraction of chunk wall time spent decoding. With generation and
+        # decode serialized this is the headroom overlapping them can recover;
+        # once they overlap it is what the measurement has to show shrinking.
+        decode_share=(decode_total / latency_total if decode_total is not None and latency_total > 0 else None),
     )
 
 
@@ -279,6 +314,8 @@ class RunSummary:
     mean_chunk_latency_s: float | None
     rtf_spread: float | None
     peak_concurrent_sessions: int
+    decode_share: float | None = None
+    resident_decoder_bytes_per_session: int | None = None
     notes: tuple[str, ...] = field(default_factory=tuple)
 
     def to_dict(self) -> dict[str, Any]:
@@ -303,6 +340,8 @@ class RunSummary:
             "worst_case_chunk_latency_s": self.worst_case_chunk_latency_s,
             "continuous_play_ratio": self.continuous_play_ratio,
             "rtf_spread": self.rtf_spread,
+            "decode_share": self.decode_share,
+            "resident_decoder_bytes_per_session": self.resident_decoder_bytes_per_session,
             "notes": list(self.notes),
             "per_session": [summary.to_dict() for summary in self.sessions],
         }
@@ -316,6 +355,7 @@ def summarize_run(
     wall_s: float,
     num_gpus: int = 1,
     peak_concurrent_sessions: int | None = None,
+    resident_decoder_bytes_per_session: int | None = None,
     notes: Sequence[str] = (),
 ) -> RunSummary:
     """Aggregate session records into the reportable run summary."""
@@ -333,6 +373,7 @@ def summarize_run(
     # neighbour that produced many more chunks.
     per_session_cpr = [s.continuous_play_ratio for s in summaries if s.continuous_play_ratio is not None]
     rtfs = [s.rtf for s in summaries if s.rtf is not None]
+    decode_shares = [s.decode_share for s in summaries if s.decode_share is not None]
 
     return RunSummary(
         mode=mode,
@@ -348,6 +389,8 @@ def summarize_run(
         mean_chunk_latency_s=statistics.fmean(latencies) if latencies else None,
         rtf_spread=max(rtfs) - min(rtfs) if len(rtfs) > 1 else None,
         peak_concurrent_sessions=(peak_concurrent_sessions if peak_concurrent_sessions is not None else len(summaries)),
+        decode_share=statistics.fmean(decode_shares) if decode_shares else None,
+        resident_decoder_bytes_per_session=resident_decoder_bytes_per_session,
         notes=tuple(notes),
     )
 

--- a/benchmarks/ar_diffusion/run_realtime_benchmark.py
+++ b/benchmarks/ar_diffusion/run_realtime_benchmark.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CLI for the realtime AR-Diffusion multi-session benchmark.
+
+Model-neutral by construction: the chunk shape comes from the pipeline's
+declared ``ARDiffusionKVCacheSpec``, so pointing ``--model`` at another
+AR-Diffusion pipeline needs no code change.
+
+One value cannot come from the capability today. ``frames_per_block`` and every
+other frame count in the spec are in *latent* frames, and nothing in the spec
+converts them to delivered frames, so the playout grid is not derivable from
+the capability alone. Until the spec declares it, the factor arrives as
+``--vae-temporal-factor``.
+
+Every reported number must carry its conditions. ``--note`` is repeatable and
+its values are copied verbatim into the summary; the run refuses to start
+without at least one, because a latency without model, checkpoint, resolution,
+denoising steps and hardware is not a result.
+
+Examples::
+
+    # Ceiling: how fast can this device go at all?
+    python -m benchmarks.ar_diffusion.run_realtime_benchmark \
+        --model <checkpoint> --prompt "..." --num-sessions 1 \
+        --mode saturating --chunks 32 \
+        --note "checkpoint=<...>" --note "hw=1xRTX-PRO-6000" --note "res=480x832"
+
+    # Baseline: state concurrency 2, execution concurrency 1.
+    python -m benchmarks.ar_diffusion.run_realtime_benchmark \
+        --model <checkpoint> --prompt "..." --num-sessions 2 \
+        --mode saturating --chunks 32 --note ...
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from benchmarks.ar_diffusion.realtime_harness import (
+    BenchmarkConfig,
+    burst_arrivals,
+    poisson_arrivals,
+    run_benchmark,
+)
+from benchmarks.ar_diffusion.realtime_metrics import LoadMode, WorkloadProfile
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark realtime AR-Diffusion sessions.")
+    parser.add_argument("--model", required=True, help="Hugging Face model ID or local checkpoint path.")
+    parser.add_argument("--prompt", required=True, help="Initial scene prompt for every session.")
+    parser.add_argument("--image", default=None, help="Optional initial RGB image, if the pipeline needs one.")
+
+    parser.add_argument("--num-sessions", type=int, default=1, help="Sessions to run concurrently.")
+    parser.add_argument("--chunks", type=int, default=16, help="Chunks each session generates.")
+    parser.add_argument(
+        "--mode",
+        choices=[mode.value for mode in LoadMode],
+        default=LoadMode.SATURATING.value,
+        help="saturating measures the ceiling; paced measures continuity against deadlines.",
+    )
+    parser.add_argument(
+        "--target-fps",
+        type=float,
+        default=16.0,
+        help="Declared playout rate. With the chunk shape it fixes the release period.",
+    )
+    parser.add_argument(
+        "--release-period",
+        type=float,
+        default=None,
+        help="Override the release period in seconds. Defaults to frames_per_chunk / target_fps.",
+    )
+    parser.add_argument("--buffer-chunks", type=int, default=1, help="Playout buffer depth, in chunks.")
+    parser.add_argument(
+        "--arrival-rate",
+        type=float,
+        default=None,
+        help="Poisson session arrivals per second. Omit for a burst (all sessions start together).",
+    )
+    parser.add_argument("--seed", type=int, default=0, help="Seed for the arrival process.")
+    parser.add_argument(
+        "--vae-temporal-factor",
+        type=int,
+        default=1,
+        help=(
+            "Raw frames per latent frame. Supplied here because ARDiffusionKVCacheSpec "
+            "declares frames_per_block in latent frames and carries no factor that "
+            "converts it to delivered frames; see the module docstring."
+        ),
+    )
+
+    parser.add_argument("--num-gpus", type=int, default=1, help="Devices in use, for frames per GPU-second.")
+    parser.add_argument("--events-dir", type=Path, default=None, help="Directory for per-session events JSONL.")
+    parser.add_argument("--output", type=Path, default=None, help="Write the run summary JSON here.")
+    parser.add_argument(
+        "--note",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Run conditions recorded verbatim in the summary. Repeatable, and at least one is required.",
+    )
+
+    parser.add_argument("--tensor-parallel-size", type=int, default=1)
+    parser.add_argument("--gpu-memory-fraction", type=float, default=0.9)
+    parser.add_argument("--enforce-eager", action="store_true")
+    parser.add_argument("--max-pending-events", type=int, default=8)
+    return parser.parse_args(argv)
+
+
+def build_config(
+    args: argparse.Namespace, *, frames_per_chunk: int, resident_bytes: int | None = None
+) -> BenchmarkConfig:
+    """Turn parsed arguments plus the pipeline's chunk shape into a config.
+
+    ``frames_per_chunk`` is supplied by the caller after reading the pipeline
+    capability, which is what keeps this module free of model knowledge.
+    """
+    if not args.note:
+        raise ValueError(
+            "At least one --note is required: a latency without model, checkpoint, "
+            "resolution, denoising steps and hardware is not a result."
+        )
+    target_fps = args.target_fps
+    if args.release_period is not None:
+        if args.release_period <= 0:
+            raise ValueError("--release-period must be positive.")
+        # A release period override is expressed as the fps that produces it,
+        # so the profile keeps a single source of truth for the playout grid.
+        target_fps = frames_per_chunk / args.release_period
+
+    profile = WorkloadProfile(
+        frames_per_chunk=frames_per_chunk,
+        target_fps=target_fps,
+        buffer_chunks=args.buffer_chunks,
+        resident_bytes_per_session=resident_bytes,
+    )
+    arrivals = (
+        poisson_arrivals(args.num_sessions, rate_per_s=args.arrival_rate, seed=args.seed)
+        if args.arrival_rate is not None
+        else burst_arrivals(args.num_sessions)
+    )
+    return BenchmarkConfig(
+        profile=profile,
+        mode=LoadMode(args.mode),
+        chunks_per_session=args.chunks,
+        arrivals=arrivals,
+        num_gpus=args.num_gpus,
+        events_dir=args.events_dir,
+    )
+
+
+def frames_per_chunk_from_spec(spec: Any, *, vae_temporal_factor: int = 1) -> int:
+    """Raw frames one committed chunk delivers.
+
+    ``frames_per_block`` is read from the pipeline capability, which is what
+    keeps the chunk shape out of this module. ``vae_temporal_factor`` has to be
+    supplied by the caller: the spec expresses every frame count in latent
+    frames and declares nothing that converts them to delivered frames, so no
+    runtime component can compute the playout grid from the capability alone.
+    A pipeline whose decoder does not compress time uses the default of 1.
+    """
+    frames_per_block = getattr(spec, "frames_per_block", None)
+    if isinstance(frames_per_block, bool) or not isinstance(frames_per_block, int) or frames_per_block <= 0:
+        raise ValueError("The pipeline must declare a positive integer frames_per_block.")
+    if isinstance(vae_temporal_factor, bool) or not isinstance(vae_temporal_factor, int) or vae_temporal_factor <= 0:
+        raise ValueError("vae_temporal_factor must be a positive integer.")
+    return frames_per_block * vae_temporal_factor
+
+
+async def _main(args: argparse.Namespace) -> int:
+    # Imported lazily so --help and the config path stay importable without a
+    # CUDA build, which is also what lets the harness be tested on CPU.
+    from benchmarks.ar_diffusion.engine_binding import build_realtime_backend
+    from vllm_omni.experimental.ar_diffusion import ARDiffusionSessionManager
+
+    backend = await build_realtime_backend(args)
+    frames_per_chunk = frames_per_chunk_from_spec(backend.spec, vae_temporal_factor=args.vae_temporal_factor)
+    config = build_config(
+        args,
+        frames_per_chunk=frames_per_chunk,
+        # Only the model-owned term is declared; runner-owned KV bytes are not
+        # part of the spec, so this under-reports total residency.
+        resident_bytes=getattr(backend.spec, "model_owned_state_bytes_per_session", None),
+    )
+
+    manager: ARDiffusionSessionManager = backend.manager
+
+    async def factory(session_id: str):
+        return await manager.create_session(session_id)
+
+    summary = await run_benchmark(config, factory, notes=tuple(args.note))
+    payload = json.dumps(summary.to_dict(), indent=2)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload, encoding="utf-8")
+    print(payload)
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    return asyncio.run(_main(parse_args(argv)))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/ar_diffusion/run_realtime_benchmark.py
+++ b/benchmarks/ar_diffusion/run_realtime_benchmark.py
@@ -84,6 +84,11 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--seed", type=int, default=0, help="Seed for the arrival process.")
     parser.add_argument(
+        "--non-causal-decoder",
+        action="store_true",
+        help="The decoder expands every latent frame identically, so the opening chunk is full length.",
+    )
+    parser.add_argument(
         "--vae-temporal-factor",
         type=int,
         default=1,
@@ -113,7 +118,11 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 
 def build_config(
-    args: argparse.Namespace, *, frames_per_chunk: int, resident_bytes: int | None = None
+    args: argparse.Namespace,
+    *,
+    frames_per_chunk: int,
+    frames_per_first_chunk: int | None = None,
+    resident_bytes: int | None = None,
 ) -> BenchmarkConfig:
     """Turn parsed arguments plus the pipeline's chunk shape into a config.
 
@@ -135,6 +144,7 @@ def build_config(
 
     profile = WorkloadProfile(
         frames_per_chunk=frames_per_chunk,
+        frames_per_first_chunk=frames_per_first_chunk,
         target_fps=target_fps,
         buffer_chunks=args.buffer_chunks,
         resident_bytes_per_session=resident_bytes,
@@ -154,22 +164,28 @@ def build_config(
     )
 
 
-def frames_per_chunk_from_spec(spec: Any, *, vae_temporal_factor: int = 1) -> int:
-    """Raw frames one committed chunk delivers.
+def frames_per_chunk_from_spec(spec: Any, *, vae_temporal_factor: int = 1, causal: bool = True) -> tuple[int, int]:
+    """Raw frames a chunk delivers, as ``(steady_state, first_chunk)``.
 
     ``frames_per_block`` is read from the pipeline capability, which is what
     keeps the chunk shape out of this module. ``vae_temporal_factor`` has to be
     supplied by the caller: the spec expresses every frame count in latent
     frames and declares nothing that converts them to delivered frames, so no
     runtime component can compute the playout grid from the capability alone.
-    A pipeline whose decoder does not compress time uses the default of 1.
+
+    The conversion is not a plain multiplication. A causal video decoder maps
+    ``n`` latent frames to ``(n - 1) * factor + 1`` raw frames, so a session's
+    opening chunk delivers fewer frames than every chunk after it -- which is
+    also why a single declared integer could not express this mapping.
     """
     frames_per_block = getattr(spec, "frames_per_block", None)
     if isinstance(frames_per_block, bool) or not isinstance(frames_per_block, int) or frames_per_block <= 0:
         raise ValueError("The pipeline must declare a positive integer frames_per_block.")
     if isinstance(vae_temporal_factor, bool) or not isinstance(vae_temporal_factor, int) or vae_temporal_factor <= 0:
         raise ValueError("vae_temporal_factor must be a positive integer.")
-    return frames_per_block * vae_temporal_factor
+    steady = frames_per_block * vae_temporal_factor
+    first = (frames_per_block - 1) * vae_temporal_factor + 1 if causal else steady
+    return steady, first
 
 
 async def _main(args: argparse.Namespace) -> int:
@@ -179,10 +195,15 @@ async def _main(args: argparse.Namespace) -> int:
     from vllm_omni.experimental.ar_diffusion import ARDiffusionSessionManager
 
     backend = await build_realtime_backend(args)
-    frames_per_chunk = frames_per_chunk_from_spec(backend.spec, vae_temporal_factor=args.vae_temporal_factor)
+    frames_per_chunk, frames_per_first_chunk = frames_per_chunk_from_spec(
+        backend.spec,
+        vae_temporal_factor=args.vae_temporal_factor,
+        causal=not args.non_causal_decoder,
+    )
     config = build_config(
         args,
         frames_per_chunk=frames_per_chunk,
+        frames_per_first_chunk=frames_per_first_chunk,
         # Only the model-owned term is declared; runner-owned KV bytes are not
         # part of the spec, so this under-reports total residency.
         resident_bytes=getattr(backend.spec, "model_owned_state_bytes_per_session", None),

--- a/examples/offline_inference/diffusion/ar_diffusion_streaming_decode.py
+++ b/examples/offline_inference/diffusion/ar_diffusion_streaming_decode.py
@@ -151,10 +151,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     ]
     plateaued = all(len(set(series[1:])) <= 1 for series in per_session_bytes if len(series) > 1)
 
-    # Isolation: each session's streamed output must equal its solo decode.
+    # Isolation: each interleaved session must equal a solo, single-call run
+    # through the same per-frame path.  Do not use ``vae._decode`` as the
+    # oracle: it applies post_quant_conv to the whole tensor and can select a
+    # different BF16 CUDA kernel, measuring that numerical artifact instead of
+    # whether chunking or session interleaving changed the result.
     isolated = True
     for session in range(args.sessions):
-        solo = vae._decode(latents[session], return_dict=False)[0]
+        solo_state = decoder.new_decode_state(f"solo-{session}")
+        solo = decoder.decode_chunk(latents[session], solo_state)
         streamed = torch.cat(emitted[session], dim=2)
         if streamed.shape != solo.shape or not torch.equal(streamed, solo):
             isolated = False
@@ -181,7 +186,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(f"decoder state/session: {summary['resident_decoder_bytes_per_session'][0] / 2**20:.2f} MiB")
     print()
     print(f"bounded state (plateaued)            : {plateaued}")
-    print(f"streamed output == whole-clip decode : {isolated}")
+    print(f"streamed output == solo single call  : {isolated}")
     print(f"sessions produced distinct video     : {distinct}")
 
     if args.output_dir is not None:

--- a/examples/offline_inference/diffusion/ar_diffusion_streaming_decode.py
+++ b/examples/offline_inference/diffusion/ar_diffusion_streaming_decode.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Incremental decode for realtime AR-Diffusion sessions, end to end.
+
+Demonstrates the vertical path a realtime video session needs: several
+concurrent sessions, each advancing chunk by chunk, with frames emitted as
+soon as their chunk commits rather than after a whole-clip barrier.
+
+Runs on CPU with no checkpoint by default -- it builds a small Wan autoencoder
+from a config so the *protocol* can be exercised anywhere. Point ``--vae`` at a
+real checkpoint to run the shipped decoder instead; nothing else changes.
+
+What it shows
+
+* frames are delivered per chunk, so time-to-first-frame is one chunk's decode
+  rather than the whole session's;
+* resident decoder state plateaus -- the temporal cache is bounded by
+  construction, not by how long the session has run;
+* two interleaved sessions keep independent temporal context, checked against
+  a solo recording rather than assumed;
+* a session's opening chunk is shorter, because a causal decoder expands the
+  first latent frame to a single raw frame.
+
+Examples::
+
+    python examples/offline_inference/diffusion/ar_diffusion_streaming_decode.py \
+        --sessions 2 --chunks 6 --output-dir /tmp/stream-demo
+
+    python examples/offline_inference/diffusion/ar_diffusion_streaming_decode.py \
+        --vae <checkpoint> --height 480 --width 832 --sessions 1 --chunks 4
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from collections.abc import Sequence
+from pathlib import Path
+
+import torch
+
+from vllm_omni.experimental.ar_diffusion.streaming_decode import WanStreamingDecoder
+
+# A small Wan autoencoder: same causal structure as the shipped checkpoint,
+# narrower so the demo runs on a laptop CPU.
+_DEMO_VAE_CONFIG = {
+    "base_dim": 8,
+    "z_dim": 4,
+    "dim_mult": [1, 2],
+    "num_res_blocks": 1,
+    "temperal_downsample": [True],
+    "attn_scales": [],
+    "dropout": 0.0,
+}
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--vae", default=None, help="VAE checkpoint or path. Omit for the built-in demo config.")
+    parser.add_argument("--sessions", type=int, default=2, help="Concurrent sessions, ticking round-robin.")
+    parser.add_argument("--chunks", type=int, default=6, help="Chunks each session generates.")
+    parser.add_argument("--latent-frames", type=int, default=3, help="Latent frames per chunk.")
+    parser.add_argument("--height", type=int, default=32, help="Output height in pixels.")
+    parser.add_argument("--width", type=int, default=32, help="Output width in pixels.")
+    parser.add_argument("--target-fps", type=float, default=16.0, help="Declared playout rate.")
+    parser.add_argument("--output-dir", type=Path, default=None, help="Write per-chunk frames and a summary here.")
+    parser.add_argument("--seed", type=int, default=0)
+    return parser.parse_args(argv)
+
+
+def build_vae(args: argparse.Namespace):
+    from diffusers import AutoencoderKLWan
+
+    if args.vae is not None:
+        return AutoencoderKLWan.from_pretrained(args.vae).eval()
+    torch.manual_seed(args.seed)
+    return AutoencoderKLWan(**_DEMO_VAE_CONFIG).eval()
+
+
+def spatial_ratio(vae) -> int:
+    return int(getattr(vae.config, "scale_factor_spatial", 8))
+
+
+@torch.no_grad()
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    vae = build_vae(args)
+    for parameter in vae.parameters():
+        parameter.requires_grad_(False)
+    decoder = WanStreamingDecoder(vae)
+
+    ratio = spatial_ratio(vae)
+    latent_h, latent_w = args.height // ratio, args.width // ratio
+    if latent_h < 1 or latent_w < 1:
+        raise SystemExit(f"--height/--width must be at least the VAE spatial ratio ({ratio}).")
+
+    print(f"decoder causal convolutions : {decoder.num_causal_convs}")
+    print(f"output                      : {args.width}x{args.height} (latent {latent_w}x{latent_h})")
+    print(f"sessions                    : {args.sessions}, {args.chunks} chunks each")
+    print()
+
+    generator = torch.Generator().manual_seed(args.seed)
+    # One distinct latent stream per session: distinct inputs are what make the
+    # isolation check at the end discriminating rather than vacuous.
+    latents = [
+        torch.randn(1, vae.config.z_dim, args.chunks * args.latent_frames, latent_h, latent_w, generator=generator)
+        for _ in range(args.sessions)
+    ]
+
+    states = [decoder.new_decode_state(f"session-{i}") for i in range(args.sessions)]
+    emitted: list[list[torch.Tensor]] = [[] for _ in range(args.sessions)]
+    records: list[dict] = []
+    t_start = time.perf_counter()
+    first_frame_at: list[float | None] = [None] * args.sessions
+
+    for chunk_index in range(args.chunks):
+        for session in range(args.sessions):
+            window = slice(chunk_index * args.latent_frames, (chunk_index + 1) * args.latent_frames)
+            t0 = time.perf_counter()
+            frames = decoder.decode_chunk(latents[session][:, :, window], states[session])
+            latency = time.perf_counter() - t0
+            if first_frame_at[session] is None:
+                first_frame_at[session] = time.perf_counter() - t_start
+            emitted[session].append(frames)
+
+            record = {
+                "session": session,
+                "chunk_index": chunk_index,
+                "frames": int(frames.shape[2]),
+                "latency_s": latency,
+                "resident_decoder_bytes": states[session].nbytes(),
+            }
+            records.append(record)
+            print(
+                f"  session {session}  chunk {chunk_index}  "
+                f"{record['frames']:>2} frames  {latency * 1e3:7.1f} ms  "
+                f"decoder state {record['resident_decoder_bytes'] / 2**20:7.2f} MiB"
+            )
+            if args.output_dir is not None:
+                path = args.output_dir / f"session-{session}"
+                path.mkdir(parents=True, exist_ok=True)
+                torch.save(frames, path / f"chunk_{chunk_index:03d}.pt")
+        print()
+
+    wall = time.perf_counter() - t_start
+
+    # Boundedness: resident state must plateau, not grow with session length.
+    per_session_bytes = [
+        [r["resident_decoder_bytes"] for r in records if r["session"] == s] for s in range(args.sessions)
+    ]
+    plateaued = all(len(set(series[1:])) <= 1 for series in per_session_bytes if len(series) > 1)
+
+    # Isolation: each session's streamed output must equal its solo decode.
+    isolated = True
+    for session in range(args.sessions):
+        solo = vae._decode(latents[session], return_dict=False)[0]
+        streamed = torch.cat(emitted[session], dim=2)
+        if streamed.shape != solo.shape or not torch.equal(streamed, solo):
+            isolated = False
+    distinct = args.sessions < 2 or not torch.equal(torch.cat(emitted[0], dim=2), torch.cat(emitted[1], dim=2))
+
+    total_frames = sum(r["frames"] for r in records)
+    video_seconds = total_frames / args.target_fps
+    summary = {
+        "sessions": args.sessions,
+        "chunks_per_session": args.chunks,
+        "total_frames": total_frames,
+        "wall_s": wall,
+        "time_to_first_frame_s": first_frame_at,
+        "generated_fps": total_frames / wall if wall > 0 else None,
+        "rtf": wall / video_seconds if video_seconds > 0 else None,
+        "resident_decoder_bytes_per_session": [series[-1] for series in per_session_bytes],
+        "state_plateaued": plateaued,
+        "matches_solo_decode": isolated,
+        "sessions_produced_distinct_video": distinct,
+    }
+
+    print(f"time to first frame : {[f'{t:.3f}s' for t in first_frame_at]}")
+    print(f"total frames        : {total_frames} in {wall:.3f}s  ({summary['generated_fps']:.1f} fps)")
+    print(f"decoder state/session: {summary['resident_decoder_bytes_per_session'][0] / 2**20:.2f} MiB")
+    print()
+    print(f"bounded state (plateaued)            : {plateaued}")
+    print(f"streamed output == whole-clip decode : {isolated}")
+    print(f"sessions produced distinct video     : {distinct}")
+
+    if args.output_dir is not None:
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        (args.output_dir / "summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+        (args.output_dir / "chunks.jsonl").write_text("".join(json.dumps(r) + "\n" for r in records), encoding="utf-8")
+        print(f"\nwrote {args.output_dir}")
+
+    return 0 if (plateaued and isolated and distinct) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/offline_inference/diffusion/ar_diffusion_streaming_decode.py
+++ b/examples/offline_inference/diffusion/ar_diffusion_streaming_decode.py
@@ -27,7 +27,8 @@ Examples::
         --sessions 2 --chunks 6 --output-dir /tmp/stream-demo
 
     python examples/offline_inference/diffusion/ar_diffusion_streaming_decode.py \
-        --vae <checkpoint> --height 480 --width 832 --sessions 1 --chunks 4
+        --vae <checkpoint>/vae --device cuda --dtype bf16 \
+        --height 480 --width 832 --sessions 1 --chunks 4
 """
 
 from __future__ import annotations
@@ -58,6 +59,8 @@ _DEMO_VAE_CONFIG = {
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--vae", default=None, help="VAE checkpoint or path. Omit for the built-in demo config.")
+    parser.add_argument("--device", default="cpu", help="Torch device for the VAE and latent inputs.")
+    parser.add_argument("--dtype", choices=("fp32", "bf16", "fp16"), default="fp32")
     parser.add_argument("--sessions", type=int, default=2, help="Concurrent sessions, ticking round-robin.")
     parser.add_argument("--chunks", type=int, default=6, help="Chunks each session generates.")
     parser.add_argument("--latent-frames", type=int, default=3, help="Latent frames per chunk.")
@@ -72,10 +75,17 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 def build_vae(args: argparse.Namespace):
     from diffusers import AutoencoderKLWan
 
+    dtype = {
+        "fp32": torch.float32,
+        "bf16": torch.bfloat16,
+        "fp16": torch.float16,
+    }[args.dtype]
     if args.vae is not None:
-        return AutoencoderKLWan.from_pretrained(args.vae).eval()
-    torch.manual_seed(args.seed)
-    return AutoencoderKLWan(**_DEMO_VAE_CONFIG).eval()
+        vae = AutoencoderKLWan.from_pretrained(args.vae, torch_dtype=dtype)
+    else:
+        torch.manual_seed(args.seed)
+        vae = AutoencoderKLWan(**_DEMO_VAE_CONFIG)
+    return vae.to(device=args.device, dtype=dtype).eval()
 
 
 def spatial_ratio(vae) -> int:
@@ -100,11 +110,20 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(f"sessions                    : {args.sessions}, {args.chunks} chunks each")
     print()
 
-    generator = torch.Generator().manual_seed(args.seed)
+    generator = torch.Generator(device=args.device).manual_seed(args.seed)
     # One distinct latent stream per session: distinct inputs are what make the
     # isolation check at the end discriminating rather than vacuous.
     latents = [
-        torch.randn(1, vae.config.z_dim, args.chunks * args.latent_frames, latent_h, latent_w, generator=generator)
+        torch.randn(
+            1,
+            vae.config.z_dim,
+            args.chunks * args.latent_frames,
+            latent_h,
+            latent_w,
+            generator=generator,
+            device=args.device,
+            dtype=next(vae.parameters()).dtype,
+        )
         for _ in range(args.sessions)
     ]
 

--- a/tests/diffusion/ar_diffusion/test_realtime_benchmark.py
+++ b/tests/diffusion/ar_diffusion/test_realtime_benchmark.py
@@ -129,6 +129,7 @@ def test_profile_is_built_from_a_declared_spec() -> None:
     profile = load_profile_from_spec(
         {"frames_per_block": 3, "vae_temporal_factor": 4, "resident_bytes_per_session": 1024},
         target_fps=16.0,
+        causal=False,
     )
     assert profile.frames_per_chunk == 12
     assert profile.resident_bytes_per_session == 1024
@@ -173,12 +174,14 @@ def test_deadlines_anchor_on_the_buffer_and_skip_the_prebuffer() -> None:
     assert deadlines[2] == pytest.approx(2.50)
 
 
-def test_deeper_buffer_moves_the_playout_grid_later() -> None:
+def test_deeper_buffer_grants_real_slack() -> None:
+    """Playback starts at the anchor holding two chunks, so chunk 2 is due
+    after both have played -- not one period after the anchor arrived."""
     profile = WorkloadProfile(frames_per_chunk=12, target_fps=16.0, buffer_chunks=2)
     record = _record("s", [1.0, 1.5, 2.0])
     deadlines = chunk_deadlines(record, profile)
     assert set(deadlines) == {2}
-    assert deadlines[2] == pytest.approx(2.25)
+    assert deadlines[2] == pytest.approx(1.5 + 24 / 16.0)
 
 
 def test_cpr_counts_only_chunks_that_had_a_deadline() -> None:
@@ -203,6 +206,48 @@ def test_rtf_compares_wall_time_against_video_time() -> None:
     record = _record("s", [0.375, 0.75, 1.125, 1.5], submit_gap=0.375)
     summary = summarize_session(record, PROFILE, mode=LoadMode.SATURATING)
     assert summary.rtf == pytest.approx((1.5 - 0.0) / 3.0)
+
+
+CAUSAL = WorkloadProfile(frames_per_chunk=12, frames_per_first_chunk=9, target_fps=16.0)
+
+
+def test_causal_decoder_delivers_a_shorter_opening_chunk() -> None:
+    """(n - 1) * factor + 1 for the opening block, n * factor after it.
+
+    3 latent frames at temporal factor 4 is 9 raw frames the first time and 12
+    every time after, so K chunks deliver 12K - 3 frames, not 12K.
+    """
+    assert CAUSAL.is_causal is True
+    assert CAUSAL.frames_at(0) == 9
+    assert CAUSAL.frames_at(1) == CAUSAL.frames_at(7) == 12
+    assert CAUSAL.cumulative_frames(10) == 117  # matches the pipeline's 117-frame horizon
+    assert CAUSAL.cumulative_frames(0) == 0
+
+    summary = summarize_session(_record("s", [1.0, 2.0, 3.0]), CAUSAL, mode=LoadMode.SATURATING)
+    assert summary.frames == 9 + 12 + 12
+    # The uniform profile over-counts the same three chunks.
+    assert summarize_session(_record("s", [1.0, 2.0, 3.0]), PROFILE, mode=LoadMode.SATURATING).frames == 36
+
+
+def test_non_causal_profile_is_the_default_and_stays_uniform() -> None:
+    assert PROFILE.is_causal is False
+    assert PROFILE.frames_at(0) == PROFILE.frames_at(5) == 12
+    assert PROFILE.cumulative_frames(3) == 36
+
+
+def test_causal_opening_chunk_is_not_credited_with_a_full_period() -> None:
+    """The opening chunk buys 9/16 s of playback, so chunk 1 is due sooner."""
+    record = _record("s", [1.0, 1.5, 2.0])
+    assert chunk_deadlines(record, CAUSAL)[1] == pytest.approx(1.0 + 9 / 16.0)
+    assert chunk_deadlines(record, PROFILE)[1] == pytest.approx(1.0 + 12 / 16.0)
+
+
+def test_causal_profile_from_spec_matches_the_pipeline_geometry() -> None:
+    spec = {"frames_per_block": 3, "vae_temporal_factor": 4}
+    causal = load_profile_from_spec(spec, target_fps=16.0)
+    assert (causal.frames_per_first_chunk, causal.frames_per_chunk) == (9, 12)
+    uniform = load_profile_from_spec(spec, target_fps=16.0, causal=False)
+    assert (uniform.frames_per_first_chunk, uniform.frames_per_chunk) == (12, 12)
 
 
 def test_cpr_is_macro_averaged_so_a_lagging_session_is_not_diluted() -> None:
@@ -504,19 +549,21 @@ def test_arrival_rate_switches_to_poisson() -> None:
     assert any(offset > 0 for offset in config.arrivals.offsets_s)
 
 
-def test_frames_per_chunk_needs_a_factor_the_spec_does_not_declare() -> None:
-    """ARDiffusionKVCacheSpec counts latent frames and declares no VAE factor.
+def test_frames_per_chunk_needs_a_mapping_the_spec_does_not_declare() -> None:
+    """ARDiffusionKVCacheSpec counts latent frames and declares no conversion.
 
-    The harness therefore takes the factor from the caller instead of guessing,
-    and a pipeline whose decoder does not compress time uses the default of 1.
+    The harness takes it from the caller instead of guessing. Note the result
+    is a pair, not a scalar: the conversion is causal, so a single declared
+    integer could not express it.
     """
     from benchmarks.ar_diffusion.run_realtime_benchmark import frames_per_chunk_from_spec
 
     class Spec:
         frames_per_block = 3
 
-    assert frames_per_chunk_from_spec(Spec()) == 3
-    assert frames_per_chunk_from_spec(Spec(), vae_temporal_factor=4) == 12
+    assert frames_per_chunk_from_spec(Spec()) == (3, 3)
+    assert frames_per_chunk_from_spec(Spec(), vae_temporal_factor=4) == (12, 9)
+    assert frames_per_chunk_from_spec(Spec(), vae_temporal_factor=4, causal=False) == (12, 12)
     with pytest.raises(ValueError, match="vae_temporal_factor"):
         frames_per_chunk_from_spec(Spec(), vae_temporal_factor=0)
 

--- a/tests/diffusion/ar_diffusion/test_realtime_benchmark.py
+++ b/tests/diffusion/ar_diffusion/test_realtime_benchmark.py
@@ -59,22 +59,30 @@ class VirtualClock:
         self._waiters.append((self.now + delay, future))
         await future
 
-    async def run_until_idle(self, task: asyncio.Task) -> None:
-        """Advance to each next wakeup until ``task`` completes."""
-        while not task.done():
-            await asyncio.sleep(0)
+    async def run_until_idle(self, task: asyncio.Task, *, max_steps: int = 100_000) -> None:
+        """Advance to each next wakeup until ``task`` completes.
+
+        Each step pumps the loop several times before deciding it is idle:
+        a sleeper inside a prefetch task is two hops from the driver, so a
+        single yield is not enough to settle the chain.
+        """
+        for _ in range(max_steps):
             if task.done():
-                break
-            if not self._waiters:
+                return
+            for _ in range(8):
                 await asyncio.sleep(0)
-                if not self._waiters:
+                if self._waiters or task.done():
                     break
-                continue
+            if task.done():
+                return
+            if not self._waiters:
+                return
             self._waiters.sort(key=lambda item: item[0])
             when, future = self._waiters.pop(0)
             self.now = max(self.now, when)
             if not future.done():
                 future.set_result(None)
+        raise AssertionError("virtual clock did not settle; the session under test is not making progress")
 
 
 class FakeSession:
@@ -621,7 +629,10 @@ class FakeLatentSession:
         self.closed = False
 
     async def next_chunk(self):
-        self._clock.now += self._generate_s
+        # A real await, not a clock bump: generation is a request to the
+        # worker, so it must be able to interleave with local decode work.
+        # Advancing the clock synchronously would make overlap unobservable.
+        await self._clock.sleep(self._generate_s)
         return {"latent_frames": self._latent_frames}
 
     async def close(self) -> None:
@@ -732,3 +743,139 @@ async def test_a_latent_only_session_still_works_and_falls_back_to_the_profile()
     assert summary.generate_s_total is None
     assert summary.frames == 36
     assert run.resident_decoder_bytes_per_session is None
+
+
+# --------------------------------------------------------------------------
+# Overlap: is the pipelining real, or only claimed?
+# --------------------------------------------------------------------------
+
+
+def _overlapped_factory(clock: VirtualClock, *, generate_s: float, decode_s: float, lookahead: int = 1):
+    from benchmarks.ar_diffusion.decoding_session import OverlappedDecodingSession
+
+    decoder = FakeChunkDecoder(clock, decode_s=decode_s)
+    inner: dict[str, FakeLatentSession] = {}
+
+    async def factory(session_id: str):
+        session = FakeLatentSession(clock, generate_s=generate_s)
+        inner[session_id] = session
+        return OverlappedDecodingSession(
+            inner=session,
+            decoder=decoder,
+            session_id=session_id,
+            clock=clock.time,
+            lookahead=lookahead,
+        )
+
+    return factory, decoder, inner
+
+
+@pytest.mark.asyncio
+async def test_overlapped_ticks_cost_max_not_sum() -> None:
+    """The whole point: a tick must cost max(generate, decode), not the sum.
+
+    Serialized, K chunks cost K * (generate + decode). Pipelined, generation of
+    chunk N+1 runs during decode of chunk N, so the run costs one generate to
+    prime plus K * max(generate, decode).
+    """
+    generate_s, decode_s, chunks = 0.4, 0.1, 5
+    clock = VirtualClock()
+    serial_factory, _, _ = _decoding_factory(clock, generate_s=generate_s, decode_s=decode_s)
+    config = BenchmarkConfig(
+        profile=PROFILE, mode=LoadMode.SATURATING, chunks_per_session=chunks, arrivals=burst_arrivals(1)
+    )
+    serial = await drive(config, serial_factory, clock)
+
+    clock2 = VirtualClock()
+    over_factory, _, _ = _overlapped_factory(clock2, generate_s=generate_s, decode_s=decode_s)
+    overlapped = await drive(config, over_factory, clock2)
+
+    # Assert on chunk latency rather than wall time. A lookahead pipeline holds
+    # one generation the consumer never asks for, cancelled at close; charging
+    # that teardown to the measurement would compare two different things.
+    assert serial.sessions[0].latency_p50_s == pytest.approx(generate_s + decode_s)
+    # Steady state: the next generation is already in flight, so a chunk costs
+    # the slower stage rather than the sum. The first chunk still pays both,
+    # because there was nothing to prime the pipeline with.
+    assert overlapped.sessions[0].latency_p50_s == pytest.approx(max(generate_s, decode_s))
+    assert overlapped.sessions[0].latency_max_s == pytest.approx(generate_s + decode_s)
+    assert overlapped.sessions[0].latency_p50_s < serial.sessions[0].latency_p50_s
+
+
+@pytest.mark.asyncio
+async def test_overlap_efficiency_is_zero_serialized_and_positive_pipelined() -> None:
+    """The metric has to distinguish the two, or it measures nothing."""
+    clock = VirtualClock()
+    serial_factory, _, _ = _decoding_factory(clock, generate_s=0.4, decode_s=0.1)
+    config = BenchmarkConfig(
+        profile=PROFILE, mode=LoadMode.SATURATING, chunks_per_session=4, arrivals=burst_arrivals(1)
+    )
+    serial = await drive(config, serial_factory, clock)
+    assert serial.overlap_efficiency is None  # serialized sessions report no overlap
+
+    clock2 = VirtualClock()
+    over_factory, _, _ = _overlapped_factory(clock2, generate_s=0.4, decode_s=0.1)
+    overlapped = await drive(config, over_factory, clock2)
+    # Decode covers 0.1s of each 0.4s generation after the first chunk.
+    assert 0.0 < overlapped.overlap_efficiency < 1.0
+    assert overlapped.sessions[0].overlap_s_total == pytest.approx(3 * 0.1)
+
+
+@pytest.mark.asyncio
+async def test_generation_never_runs_further_ahead_than_the_lookahead_bound() -> None:
+    """Backpressure here is a ceiling on lookahead, so assert the ceiling.
+
+    Without it a consumer that stops taking chunks would let generation run
+    ahead into memory nothing reads.
+    """
+    for lookahead in (1, 2, 3):
+        clock = VirtualClock()
+        factory, _, _ = _overlapped_factory(clock, generate_s=0.2, decode_s=0.3, lookahead=lookahead)
+        config = BenchmarkConfig(
+            profile=PROFILE, mode=LoadMode.SATURATING, chunks_per_session=5, arrivals=burst_arrivals(1)
+        )
+        run = await drive(config, factory, clock)
+        assert run.sessions[0].peak_outstanding_generations == lookahead
+
+
+@pytest.mark.asyncio
+async def test_a_consumer_that_stops_leaves_no_generation_running() -> None:
+    """Closing mid-session must cancel the prefetch, not leak it.
+
+    A lookahead pipeline always holds generations the consumer has not asked
+    for; on close they have to be cancelled rather than left to complete into
+    a session that no longer exists.
+    """
+    clock = VirtualClock()
+    factory, decoder, inner = _overlapped_factory(clock, generate_s=0.2, decode_s=0.1, lookahead=2)
+
+    async def scenario():
+        session = await factory("s")
+        await session.next_chunk()
+        assert session._pending, "the prefetch must be outstanding before close"
+        await session.close()
+        return session
+
+    task = asyncio.ensure_future(scenario())
+    await clock.run_until_idle(task)
+    session = await task
+
+    assert decoder.released, "decoder state must be released with the session"
+    assert inner["s"].closed
+    assert not session._pending
+
+
+@pytest.mark.asyncio
+async def test_overlapping_does_not_change_what_is_delivered() -> None:
+    """Pipelining is a scheduling change; the frames must be identical."""
+    config = BenchmarkConfig(
+        profile=PROFILE, mode=LoadMode.SATURATING, chunks_per_session=4, arrivals=burst_arrivals(1)
+    )
+    clock = VirtualClock()
+    serial = await drive(config, _decoding_factory(clock, generate_s=0.3, decode_s=0.2)[0], clock)
+    clock2 = VirtualClock()
+    overlapped = await drive(config, _overlapped_factory(clock2, generate_s=0.3, decode_s=0.2)[0], clock2)
+
+    assert overlapped.sessions[0].frames == serial.sessions[0].frames
+    assert overlapped.sessions[0].chunks == serial.sessions[0].chunks
+    assert [e for e in overlapped.sessions[0].to_dict() if e] == [e for e in serial.sessions[0].to_dict() if e]

--- a/tests/diffusion/ar_diffusion/test_realtime_benchmark.py
+++ b/tests/diffusion/ar_diffusion/test_realtime_benchmark.py
@@ -572,3 +572,163 @@ def test_frames_per_chunk_needs_a_mapping_the_spec_does_not_declare() -> None:
 
     with pytest.raises(ValueError, match="frames_per_block"):
         frames_per_chunk_from_spec(NoSpec())
+
+
+# --------------------------------------------------------------------------
+# Vertical path: latents -> incremental decode -> delivered frames
+# --------------------------------------------------------------------------
+
+
+class FakeDecodeState:
+    """Bounded cache stand-in: grows once, then plateaus."""
+
+    def __init__(self) -> None:
+        self.chunks = 0
+
+    def nbytes(self) -> int:
+        return 0 if self.chunks == 0 else 4096
+
+
+class FakeChunkDecoder:
+    """Applies the causal geometry the real decoder has, without torch."""
+
+    def __init__(self, clock: VirtualClock, *, decode_s: float, factor: int = 4) -> None:
+        self._clock = clock
+        self._decode_s = decode_s
+        self._factor = factor
+        self.released: list[FakeDecodeState] = []
+
+    def new_decode_state(self, session_id: str) -> FakeDecodeState:
+        return FakeDecodeState()
+
+    def decode_chunk(self, latent, state: FakeDecodeState):
+        n = latent["latent_frames"]
+        frames = (n - 1) * self._factor + 1 if state.chunks == 0 else n * self._factor
+        state.chunks += 1
+        # Charge decode time on the same virtual clock the driver reads.
+        self._clock.now += self._decode_s
+        return type("Frames", (), {"shape": (1, 3, frames, 8, 8)})()
+
+    def release(self, state: FakeDecodeState) -> None:
+        self.released.append(state)
+
+
+class FakeLatentSession:
+    def __init__(self, clock: VirtualClock, *, generate_s: float, latent_frames: int = 3) -> None:
+        self._clock = clock
+        self._generate_s = generate_s
+        self._latent_frames = latent_frames
+        self.closed = False
+
+    async def next_chunk(self):
+        self._clock.now += self._generate_s
+        return {"latent_frames": self._latent_frames}
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _decoding_factory(clock: VirtualClock, *, generate_s: float, decode_s: float):
+    from benchmarks.ar_diffusion.decoding_session import DecodingSession
+
+    decoder = FakeChunkDecoder(clock, decode_s=decode_s)
+    inner: dict[str, FakeLatentSession] = {}
+
+    async def factory(session_id: str):
+        session = FakeLatentSession(clock, generate_s=generate_s)
+        inner[session_id] = session
+        return DecodingSession(
+            inner=session,
+            decoder=decoder,
+            session_id=session_id,
+            clock=clock.time,
+        )
+
+    return factory, decoder, inner
+
+
+@pytest.mark.asyncio
+async def test_ttfc_covers_decode_because_a_latent_is_not_a_frame() -> None:
+    """The gate is time to first *frame*, so decode is inside the measured path."""
+    clock = VirtualClock()
+    factory, _, _ = _decoding_factory(clock, generate_s=0.4, decode_s=0.1)
+    config = BenchmarkConfig(
+        profile=PROFILE, mode=LoadMode.SATURATING, chunks_per_session=3, arrivals=burst_arrivals(1)
+    )
+    run = await drive(config, factory, clock)
+    assert run.sessions[0].ttfc_s == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+async def test_decode_share_is_the_headroom_overlap_can_recover() -> None:
+    clock = VirtualClock()
+    factory, _, _ = _decoding_factory(clock, generate_s=0.4, decode_s=0.1)
+    config = BenchmarkConfig(
+        profile=PROFILE, mode=LoadMode.SATURATING, chunks_per_session=4, arrivals=burst_arrivals(1)
+    )
+    run = await drive(config, factory, clock)
+    summary = run.sessions[0]
+    assert summary.generate_s_total == pytest.approx(4 * 0.4)
+    assert summary.decode_s_total == pytest.approx(4 * 0.1)
+    assert summary.decode_share == pytest.approx(0.2)
+    assert run.decode_share == pytest.approx(0.2)
+
+
+@pytest.mark.asyncio
+async def test_delivered_frames_are_measured_not_assumed() -> None:
+    """The decoder's temporal geometry is not declared, so it is measured.
+
+    The profile here is the uniform one, which would report 12 frames for every
+    chunk; the decoder actually delivers 9 then 12, and the summary must follow
+    the decoder.
+    """
+    clock = VirtualClock()
+    factory, _, _ = _decoding_factory(clock, generate_s=0.1, decode_s=0.05)
+    config = BenchmarkConfig(
+        profile=PROFILE, mode=LoadMode.SATURATING, chunks_per_session=3, arrivals=burst_arrivals(1)
+    )
+    run = await drive(config, factory, clock)
+    assert run.sessions[0].frames == 9 + 12 + 12
+    assert PROFILE.cumulative_frames(3) == 36  # what assuming would have given
+
+
+@pytest.mark.asyncio
+async def test_resident_decoder_bytes_reach_the_summary() -> None:
+    """Admission needs this term, and nothing else in the run reports it."""
+    clock = VirtualClock()
+    factory, _, _ = _decoding_factory(clock, generate_s=0.1, decode_s=0.05)
+    config = BenchmarkConfig(
+        profile=PROFILE, mode=LoadMode.SATURATING, chunks_per_session=3, arrivals=burst_arrivals(2)
+    )
+    run = await drive(config, factory, clock)
+    assert run.resident_decoder_bytes_per_session == 4096
+    assert json.loads(json.dumps(run.to_dict()))["resident_decoder_bytes_per_session"] == 4096
+
+
+@pytest.mark.asyncio
+async def test_closing_a_session_releases_decoder_state_with_it() -> None:
+    """The cache has no recompute source, so it must not outlive the session."""
+    clock = VirtualClock()
+    factory, decoder, inner = _decoding_factory(clock, generate_s=0.1, decode_s=0.05)
+    config = BenchmarkConfig(
+        profile=PROFILE, mode=LoadMode.SATURATING, chunks_per_session=2, arrivals=burst_arrivals(2)
+    )
+    await drive(config, factory, clock)
+    assert len(decoder.released) == 2
+    assert all(session.closed for session in inner.values())
+
+
+@pytest.mark.asyncio
+async def test_a_latent_only_session_still_works_and_falls_back_to_the_profile() -> None:
+    """Sessions without decode report no split, and the profile fills in frames."""
+    clock = VirtualClock()
+    factory, _ = make_factory(clock, tick_s=0.25)
+    config = BenchmarkConfig(
+        profile=PROFILE, mode=LoadMode.SATURATING, chunks_per_session=3, arrivals=burst_arrivals(1)
+    )
+    run = await drive(config, factory, clock)
+    summary = run.sessions[0]
+    assert summary.decode_share is None
+    assert summary.generate_s_total is None
+    assert summary.frames == 36
+    assert run.resident_decoder_bytes_per_session is None

--- a/tests/diffusion/ar_diffusion/test_realtime_benchmark.py
+++ b/tests/diffusion/ar_diffusion/test_realtime_benchmark.py
@@ -318,6 +318,27 @@ async def test_paced_mode_holds_the_release_period_when_generation_is_faster() -
 
 
 @pytest.mark.asyncio
+async def test_paced_mode_uses_the_shorter_causal_opening_period() -> None:
+    clock = VirtualClock()
+    factory, _ = make_factory(clock, tick_s=0.10)
+    config = BenchmarkConfig(
+        profile=WorkloadProfile(
+            frames_per_chunk=12,
+            frames_per_first_chunk=9,
+            target_fps=16.0,
+        ),
+        mode=LoadMode.PACED,
+        chunks_per_session=3,
+        arrivals=burst_arrivals(1),
+    )
+    run = await drive(config, factory, clock)
+    # Submits land at 0, 9/16 and (9+12)/16 seconds.  Using the steady
+    # 12/16 period for chunk 1 would make this 1.60 seconds instead.
+    assert run.wall_s == pytest.approx((9 + 12) / 16.0 + 0.10)
+    assert run.sessions[0].continuous_play_ratio == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
 async def test_paced_mode_records_misses_when_generation_is_too_slow() -> None:
     clock = VirtualClock()
     factory, _ = make_factory(clock, tick_s=2.0)

--- a/tests/diffusion/ar_diffusion/test_realtime_benchmark.py
+++ b/tests/diffusion/ar_diffusion/test_realtime_benchmark.py
@@ -1,0 +1,527 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU tests for the realtime AR-Diffusion benchmark harness.
+
+The harness is driven on a virtual clock against fake sessions, so the load
+model, deadline model and metric definitions are verified without an engine,
+a device or a checkpoint.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from benchmarks.ar_diffusion.realtime_harness import (
+    ArrivalPlan,
+    BenchmarkConfig,
+    burst_arrivals,
+    poisson_arrivals,
+    run_benchmark,
+)
+from benchmarks.ar_diffusion.realtime_metrics import (
+    ChunkEvent,
+    LoadMode,
+    SessionRecord,
+    WorkloadProfile,
+    chunk_deadlines,
+    compare_runs,
+    load_profile_from_spec,
+    percentile,
+    summarize_run,
+    summarize_session,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+# 3 latent frames x VAE temporal factor 4 = 12 raw frames, 16 fps playout, so
+# one chunk is worth 750 ms. Declared here rather than imported from a model.
+PROFILE = WorkloadProfile(frames_per_chunk=12, target_fps=16.0)
+
+
+class VirtualClock:
+    """Deterministic clock that advances only when a sleeper is released."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self._waiters: list[tuple[float, asyncio.Future]] = []
+
+    def time(self) -> float:
+        return self.now
+
+    async def sleep(self, delay: float) -> None:
+        if delay <= 0:
+            return
+        loop = asyncio.get_running_loop()
+        future = loop.create_future()
+        self._waiters.append((self.now + delay, future))
+        await future
+
+    async def run_until_idle(self, task: asyncio.Task) -> None:
+        """Advance to each next wakeup until ``task`` completes."""
+        while not task.done():
+            await asyncio.sleep(0)
+            if task.done():
+                break
+            if not self._waiters:
+                await asyncio.sleep(0)
+                if not self._waiters:
+                    break
+                continue
+            self._waiters.sort(key=lambda item: item[0])
+            when, future = self._waiters.pop(0)
+            self.now = max(self.now, when)
+            if not future.done():
+                future.set_result(None)
+
+
+class FakeSession:
+    """A session whose tick takes a fixed amount of virtual time."""
+
+    def __init__(self, clock: VirtualClock, *, tick_s: float, fail_at: int | None = None) -> None:
+        self._clock = clock
+        self._tick_s = tick_s
+        self._fail_at = fail_at
+        self._calls = 0
+        self.closed = False
+
+    async def next_chunk(self) -> str:
+        if self._fail_at is not None and self._calls == self._fail_at:
+            raise RuntimeError("fake rollout lost")
+        self._calls += 1
+        await self._clock.sleep(self._tick_s)
+        return "chunk"
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def make_factory(clock: VirtualClock, *, tick_s: float, fail_at: int | None = None):
+    created: dict[str, FakeSession] = {}
+
+    async def factory(session_id: str) -> FakeSession:
+        session = FakeSession(clock, tick_s=tick_s, fail_at=fail_at)
+        created[session_id] = session
+        return session
+
+    return factory, created
+
+
+async def drive(config: BenchmarkConfig, factory, clock: VirtualClock, **kwargs):
+    task = asyncio.ensure_future(run_benchmark(config, factory, clock=clock.time, sleep=clock.sleep, **kwargs))
+    await clock.run_until_idle(task)
+    return await task
+
+
+# --------------------------------------------------------------------------
+# Metric definitions
+# --------------------------------------------------------------------------
+
+
+def test_release_period_comes_from_the_profile_not_a_flag() -> None:
+    assert PROFILE.release_period_s == pytest.approx(0.75)
+    assert WorkloadProfile(frames_per_chunk=12, target_fps=24.0).release_period_s == pytest.approx(0.5)
+
+
+def test_profile_is_built_from_a_declared_spec() -> None:
+    profile = load_profile_from_spec(
+        {"frames_per_block": 3, "vae_temporal_factor": 4, "resident_bytes_per_session": 1024},
+        target_fps=16.0,
+    )
+    assert profile.frames_per_chunk == 12
+    assert profile.resident_bytes_per_session == 1024
+    with pytest.raises(ValueError, match="frames_per_block"):
+        load_profile_from_spec({"vae_temporal_factor": 4}, target_fps=16.0)
+
+
+def test_percentile_reports_an_observed_value() -> None:
+    values = [1.0, 2.0, 3.0, 100.0]
+    assert percentile(values, 0.5) == 2.0
+    assert percentile(values, 0.99) == 100.0
+    assert percentile([], 0.5) is None
+
+
+def _record(
+    session_id: str,
+    readies: list[float],
+    *,
+    submit_gap: float = 0.0,
+    latencies: list[float] | None = None,
+) -> SessionRecord:
+    """Build a record from ready times, with per-chunk latency if needed."""
+    gaps = latencies if latencies is not None else [submit_gap] * len(readies)
+    if len(gaps) != len(readies):
+        raise ValueError("latencies must match readies.")
+    return SessionRecord(
+        session_id=session_id,
+        t_start=0.0,
+        events=tuple(
+            ChunkEvent(session_id=session_id, chunk_index=i, t_submit=t - gap, t_ready=t)
+            for i, (t, gap) in enumerate(zip(readies, gaps, strict=True))
+        ),
+    )
+
+
+def test_deadlines_anchor_on_the_buffer_and_skip_the_prebuffer() -> None:
+    record = _record("s", [1.0, 1.5, 2.0])
+    deadlines = chunk_deadlines(record, PROFILE)
+    # buffer_chunks=1: chunk 0 fixes the grid and has no deadline of its own.
+    assert 0 not in deadlines
+    assert deadlines[1] == pytest.approx(1.75)
+    assert deadlines[2] == pytest.approx(2.50)
+
+
+def test_deeper_buffer_moves_the_playout_grid_later() -> None:
+    profile = WorkloadProfile(frames_per_chunk=12, target_fps=16.0, buffer_chunks=2)
+    record = _record("s", [1.0, 1.5, 2.0])
+    deadlines = chunk_deadlines(record, profile)
+    assert set(deadlines) == {2}
+    assert deadlines[2] == pytest.approx(2.25)
+
+
+def test_cpr_counts_only_chunks_that_had_a_deadline() -> None:
+    # chunk 1 due at 1.75 arrives at 1.5 (met); chunk 2 due at 2.5 arrives at 9.0 (missed).
+    record = _record("s", [1.0, 1.5, 9.0])
+    summary = summarize_session(record, PROFILE, mode=LoadMode.PACED)
+    assert summary.deadline_chunks == 2
+    assert summary.deadline_misses == 1
+    assert summary.continuous_play_ratio == pytest.approx(0.5)
+
+
+def test_saturating_mode_reports_no_continuity_metrics() -> None:
+    """SLO is only defined under pacing; a ceiling run must not imply one."""
+    record = _record("s", [1.0, 1.5, 9.0])
+    summary = summarize_session(record, PROFILE, mode=LoadMode.SATURATING)
+    assert summary.continuous_play_ratio is None
+    assert summary.deadline_chunks == 0
+
+
+def test_rtf_compares_wall_time_against_video_time() -> None:
+    # 4 chunks x 0.75 s of video = 3.0 s; produced in 1.5 s of wall time.
+    record = _record("s", [0.375, 0.75, 1.125, 1.5], submit_gap=0.375)
+    summary = summarize_session(record, PROFILE, mode=LoadMode.SATURATING)
+    assert summary.rtf == pytest.approx((1.5 - 0.0) / 3.0)
+
+
+def test_cpr_is_macro_averaged_so_a_lagging_session_is_not_diluted() -> None:
+    """A session that produced few chunks must weigh the same as a busy one."""
+    good = _record("good", [1.0] + [1.0 + 0.75 * i for i in range(1, 21)])
+    bad = _record("bad", [1.0, 99.0])
+    run = summarize_run([good, bad], PROFILE, mode=LoadMode.PACED, wall_s=100.0)
+    # Micro-averaging over all chunks would report ~0.95; macro-averaging halves it.
+    assert run.continuous_play_ratio == pytest.approx(0.5, abs=0.02)
+
+
+def test_worst_case_latency_is_across_sessions_not_per_session() -> None:
+    run = summarize_run(
+        [
+            _record("a", [1.0, 2.0], latencies=[1.0, 1.0]),
+            _record("b", [1.0, 30.0], latencies=[1.0, 29.0]),
+        ],
+        PROFILE,
+        mode=LoadMode.SATURATING,
+        wall_s=30.0,
+    )
+    assert run.worst_case_chunk_latency_s == pytest.approx(29.0)
+
+
+def test_frames_per_gpu_second_is_normalized_by_device_count() -> None:
+    run = summarize_run([_record("a", [1.0, 2.0])], PROFILE, mode=LoadMode.SATURATING, wall_s=2.0, num_gpus=4)
+    assert run.generated_fps == pytest.approx(12.0)
+    assert run.frames_per_gpu_second == pytest.approx(3.0)
+
+
+# --------------------------------------------------------------------------
+# Load model
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_saturating_mode_issues_the_next_tick_immediately() -> None:
+    clock = VirtualClock()
+    factory, _ = make_factory(clock, tick_s=0.25)
+    config = BenchmarkConfig(
+        profile=PROFILE,
+        mode=LoadMode.SATURATING,
+        chunks_per_session=4,
+        arrivals=burst_arrivals(1),
+    )
+    run = await drive(config, factory, clock)
+    summary = run.sessions[0]
+    assert summary.chunks == 4
+    # Back to back: 4 x 0.25 s, not paced out to 4 x 0.75 s.
+    assert run.wall_s == pytest.approx(1.0)
+    assert summary.rtf == pytest.approx(1.0 / 3.0)
+
+
+@pytest.mark.asyncio
+async def test_paced_mode_holds_the_release_period_when_generation_is_faster() -> None:
+    clock = VirtualClock()
+    factory, _ = make_factory(clock, tick_s=0.25)
+    config = BenchmarkConfig(
+        profile=PROFILE,
+        mode=LoadMode.PACED,
+        chunks_per_session=4,
+        arrivals=burst_arrivals(1),
+    )
+    run = await drive(config, factory, clock)
+    # Chunk k is not submitted before k x 0.75 s, so the run spans the grid.
+    assert run.wall_s == pytest.approx(3.0 * 0.75 + 0.25)
+    assert run.sessions[0].continuous_play_ratio == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_paced_mode_records_misses_when_generation_is_too_slow() -> None:
+    clock = VirtualClock()
+    factory, _ = make_factory(clock, tick_s=2.0)
+    config = BenchmarkConfig(
+        profile=PROFILE,
+        mode=LoadMode.PACED,
+        chunks_per_session=4,
+        arrivals=burst_arrivals(1),
+    )
+    run = await drive(config, factory, clock)
+    summary = run.sessions[0]
+    assert summary.rtf > 1.0
+    assert summary.continuous_play_ratio == pytest.approx(0.0)
+    assert summary.deadline_misses == summary.deadline_chunks == 3
+
+
+@pytest.mark.asyncio
+async def test_a_lost_session_is_recorded_as_a_result_not_a_crash() -> None:
+    clock = VirtualClock()
+    factory, created = make_factory(clock, tick_s=0.25, fail_at=2)
+    config = BenchmarkConfig(
+        profile=PROFILE,
+        mode=LoadMode.SATURATING,
+        chunks_per_session=5,
+        arrivals=burst_arrivals(1),
+    )
+    run = await drive(config, factory, clock)
+    assert run.sessions_lost == 1
+    assert run.sessions[0].chunks == 2
+    assert "fake rollout lost" in run.sessions[0].lost_reason
+    # The session is still released even though its rollout was lost.
+    assert created["bench-0"].closed is True
+
+
+@pytest.mark.asyncio
+async def test_peak_concurrency_is_reported_and_reflects_arrivals() -> None:
+    clock = VirtualClock()
+    factory, _ = make_factory(clock, tick_s=0.25)
+    config = BenchmarkConfig(
+        profile=PROFILE,
+        mode=LoadMode.SATURATING,
+        chunks_per_session=2,
+        arrivals=burst_arrivals(3),
+    )
+    run = await drive(config, factory, clock)
+    assert run.peak_concurrent_sessions == 3
+    assert len(run.sessions) == 3
+
+
+@pytest.mark.asyncio
+async def test_staggered_arrivals_lower_peak_concurrency() -> None:
+    clock = VirtualClock()
+    factory, _ = make_factory(clock, tick_s=0.25)
+    # Second session arrives after the first has finished its two ticks.
+    config = BenchmarkConfig(
+        profile=PROFILE,
+        mode=LoadMode.SATURATING,
+        chunks_per_session=2,
+        arrivals=ArrivalPlan((0.0, 10.0)),
+    )
+    run = await drive(config, factory, clock)
+    assert run.peak_concurrent_sessions == 1
+
+
+def test_poisson_arrivals_are_deterministic_and_ordered() -> None:
+    first = poisson_arrivals(5, rate_per_s=1.0, seed=7)
+    assert first.offsets_s == poisson_arrivals(5, rate_per_s=1.0, seed=7).offsets_s
+    assert list(first.offsets_s) == sorted(first.offsets_s)
+    assert first.offsets_s != poisson_arrivals(5, rate_per_s=1.0, seed=8).offsets_s
+
+
+def test_arrival_plan_rejects_unordered_offsets() -> None:
+    with pytest.raises(ValueError, match="non-decreasing"):
+        ArrivalPlan((1.0, 0.0))
+
+
+# --------------------------------------------------------------------------
+# Outputs
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_events_jsonl_carries_deadlines_in_paced_mode(tmp_path) -> None:
+    clock = VirtualClock()
+    factory, _ = make_factory(clock, tick_s=0.25)
+    config = BenchmarkConfig(
+        profile=PROFILE,
+        mode=LoadMode.PACED,
+        chunks_per_session=3,
+        arrivals=burst_arrivals(1),
+        events_dir=tmp_path / "events",
+    )
+    await drive(config, factory, clock)
+    lines = (tmp_path / "events" / "bench-0.jsonl").read_text().strip().splitlines()
+    assert len(lines) == 3
+    records = [json.loads(line) for line in lines]
+    assert "deadline" not in records[0]  # prebuffer chunk
+    assert records[1]["met_deadline"] is True
+    assert set(records[0]) >= {"session_id", "chunk_index", "t_submit", "t_ready", "latency_s"}
+
+
+def test_run_summary_is_json_serializable_and_states_its_conditions() -> None:
+    run = summarize_run(
+        [_record("a", [1.0, 2.0], submit_gap=0.5)],
+        PROFILE,
+        mode=LoadMode.PACED,
+        wall_s=2.0,
+        num_gpus=2,
+        notes=("checkpoint=X", "resolution=480x832"),
+    )
+    payload = json.dumps(run.to_dict())
+    restored = json.loads(payload)
+    assert restored["mode"] == "paced"
+    assert restored["num_gpus"] == 2
+    assert restored["profile"]["release_period_s"] == pytest.approx(0.75)
+    assert restored["notes"] == ["checkpoint=X", "resolution=480x832"]
+
+
+# --------------------------------------------------------------------------
+# The N=1 vs N=2 comparison this harness exists to produce
+# --------------------------------------------------------------------------
+
+
+def test_serialized_ticks_keep_aggregate_fps_flat_and_double_rtf() -> None:
+    """The expected N=2 result when state concurrency is 2 but execution is 1.
+
+    Two sessions resident, ticks serialized: the device produces the same
+    frames per second, and each session sees twice its solo RTF.
+    """
+    # Long enough for steady state: the first chunk's head start (it meets no
+    # contention) washes out, which is why the 2x relation is asymptotic.
+    k = 20
+    tick = 0.5
+    solo = summarize_run(
+        [_record("a", [tick * (i + 1) for i in range(k)], submit_gap=tick)],
+        PROFILE,
+        mode=LoadMode.SATURATING,
+        wall_s=tick * k,
+    )
+    # Interleaved: a chunk now waits behind one other session's tick.
+    a_ready = [tick + i * 2 * tick for i in range(k)]
+    b_ready = [2 * tick + i * 2 * tick for i in range(k)]
+    pair = summarize_run(
+        [
+            _record("a", a_ready, latencies=[tick] + [2 * tick] * (k - 1)),
+            _record("b", b_ready, latencies=[2 * tick] * k),
+        ],
+        PROFILE,
+        mode=LoadMode.SATURATING,
+        wall_s=2 * tick * k,
+    )
+    assert pair.generated_fps == pytest.approx(solo.generated_fps)
+    assert pair.sessions[0].rtf == pytest.approx(solo.sessions[0].rtf * 2, rel=0.05)
+
+    delta = compare_runs(solo, pair)
+    assert delta["generated_fps_ratio"] == pytest.approx(1.0)
+    # Latency grew only by queueing behind one other session, so effectively no
+    # switching cost is left over.
+    assert abs(delta["per_tick_switching_cost_s"]) < 0.05 * tick
+
+
+def test_switching_cost_is_the_latency_beyond_pure_queueing() -> None:
+    """A measurable drop beyond queueing is the quantity batching has to beat."""
+    solo = summarize_run(
+        [_record("a", [0.5, 1.0], submit_gap=0.5)],
+        PROFILE,
+        mode=LoadMode.SATURATING,
+        wall_s=1.0,
+    )
+    # Each chunk costs 1.2 s instead of the 1.0 s pure serialization predicts.
+    pair = summarize_run(
+        [
+            _record("a", [1.2, 2.4], submit_gap=1.2),
+            _record("b", [1.2, 2.4], submit_gap=1.2),
+        ],
+        PROFILE,
+        mode=LoadMode.SATURATING,
+        wall_s=2.4,
+    )
+    delta = compare_runs(solo, pair)
+    assert delta["per_tick_switching_cost_s"] == pytest.approx(0.2)
+    assert delta["generated_fps_ratio"] < 1.0
+
+
+# --------------------------------------------------------------------------
+# CLI argument -> config path (no engine, no device)
+# --------------------------------------------------------------------------
+
+
+def _args(*argv: str):
+    from benchmarks.ar_diffusion.run_realtime_benchmark import parse_args
+
+    return parse_args(["--model", "m", "--prompt", "p", "--note", "hw=test", *argv])
+
+
+def test_cli_defaults_to_a_single_session_burst() -> None:
+    from benchmarks.ar_diffusion.run_realtime_benchmark import build_config
+
+    config = build_config(_args(), frames_per_chunk=12)
+    assert config.mode is LoadMode.SATURATING
+    assert len(config.arrivals) == 1
+    assert config.arrivals.offsets_s == (0.0,)
+    assert config.profile.release_period_s == pytest.approx(0.75)
+
+
+def test_cli_requires_run_conditions() -> None:
+    """A latency without model, hardware and resolution is not a result."""
+    from benchmarks.ar_diffusion.run_realtime_benchmark import build_config, parse_args
+
+    bare = parse_args(["--model", "m", "--prompt", "p"])
+    with pytest.raises(ValueError, match="--note is required"):
+        build_config(bare, frames_per_chunk=12)
+
+
+def test_release_period_override_keeps_one_source_of_truth() -> None:
+    from benchmarks.ar_diffusion.run_realtime_benchmark import build_config
+
+    config = build_config(_args("--release-period", "0.5"), frames_per_chunk=12)
+    assert config.profile.release_period_s == pytest.approx(0.5)
+    assert config.profile.target_fps == pytest.approx(24.0)
+
+
+def test_arrival_rate_switches_to_poisson() -> None:
+    from benchmarks.ar_diffusion.run_realtime_benchmark import build_config
+
+    config = build_config(_args("--num-sessions", "4", "--arrival-rate", "1.0"), frames_per_chunk=12)
+    assert len(config.arrivals) == 4
+    assert config.arrivals.offsets_s[0] == 0.0
+    assert any(offset > 0 for offset in config.arrivals.offsets_s)
+
+
+def test_frames_per_chunk_needs_a_factor_the_spec_does_not_declare() -> None:
+    """ARDiffusionKVCacheSpec counts latent frames and declares no VAE factor.
+
+    The harness therefore takes the factor from the caller instead of guessing,
+    and a pipeline whose decoder does not compress time uses the default of 1.
+    """
+    from benchmarks.ar_diffusion.run_realtime_benchmark import frames_per_chunk_from_spec
+
+    class Spec:
+        frames_per_block = 3
+
+    assert frames_per_chunk_from_spec(Spec()) == 3
+    assert frames_per_chunk_from_spec(Spec(), vae_temporal_factor=4) == 12
+    with pytest.raises(ValueError, match="vae_temporal_factor"):
+        frames_per_chunk_from_spec(Spec(), vae_temporal_factor=0)
+
+    class NoSpec:
+        pass
+
+    with pytest.raises(ValueError, match="frames_per_block"):
+        frames_per_chunk_from_spec(NoSpec())

--- a/tests/diffusion/ar_diffusion/test_streaming_decode.py
+++ b/tests/diffusion/ar_diffusion/test_streaming_decode.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Streaming VAE decode against the real Wan autoencoder, on CPU.
+
+The autoencoder is built from a config rather than a checkpoint -- weights are
+random, only shapes and the temporal cache protocol matter -- so these run
+without a device or a download.
+
+The load-bearing test is equivalence: decoding a session chunk by chunk must
+produce exactly what decoding the whole clip produces. Everything else about
+streaming is worthless if that does not hold.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from vllm_omni.experimental.ar_diffusion.streaming_decode import (
+    StreamingDecodeState,
+    SupportsStreamingDecode,
+    WanStreamingDecoder,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+# Small enough to decode on CPU in a test, same architecture as the shipped
+# checkpoint: base_dim 96 / dim_mult [1,2,4,4] would be far too slow, so the
+# widths are scaled down while the causal structure is unchanged.
+VAE_CONFIG = {
+    "base_dim": 8,
+    "z_dim": 4,
+    "dim_mult": [1, 2],
+    "num_res_blocks": 1,
+    "temperal_downsample": [True],
+    "attn_scales": [],
+    "dropout": 0.0,
+}
+LATENT_H = LATENT_W = 4
+
+
+@pytest.fixture(scope="module")
+def vae():
+    diffusers = pytest.importorskip("diffusers")
+    torch.manual_seed(0)
+    model = diffusers.AutoencoderKLWan(**VAE_CONFIG).eval()
+    for parameter in model.parameters():
+        parameter.requires_grad_(False)
+    return model
+
+
+@pytest.fixture(scope="module")
+def decoder(vae):
+    return WanStreamingDecoder(vae)
+
+
+def _latent(num_frames: int, *, seed: int = 0) -> torch.Tensor:
+    generator = torch.Generator().manual_seed(seed)
+    return torch.randn(1, VAE_CONFIG["z_dim"], num_frames, LATENT_H, LATENT_W, generator=generator)
+
+
+@torch.no_grad()
+def _decode_whole(vae, latent: torch.Tensor) -> torch.Tensor:
+    """The non-streaming reference: one call, cache cleared at both ends."""
+    return vae._decode(latent, return_dict=False)[0]
+
+
+# --------------------------------------------------------------------------
+# Equivalence: the property that makes streaming worth doing at all
+# --------------------------------------------------------------------------
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("chunk_sizes", [(3, 3, 3), (1, 1, 1, 1, 1), (2, 4, 3), (9,)])
+def test_streaming_chunks_reproduce_the_whole_clip_decode(vae, decoder, chunk_sizes) -> None:
+    """Chunked decode must equal one-shot decode, for any chunking."""
+    total = sum(chunk_sizes)
+    latent = _latent(total)
+    reference = _decode_whole(vae, latent)
+
+    state = decoder.new_decode_state("s")
+    pieces = []
+    offset = 0
+    for size in chunk_sizes:
+        pieces.append(decoder.decode_chunk(latent[:, :, offset : offset + size], state))
+        offset += size
+    streamed = torch.cat(pieces, dim=2)
+
+    assert streamed.shape == reference.shape
+    torch.testing.assert_close(streamed, reference, rtol=0, atol=0)
+
+
+@torch.no_grad()
+def test_a_restarted_stream_does_not_match_a_continued_one(vae, decoder) -> None:
+    """Negative control: the equivalence test above must be discriminating.
+
+    Clearing state between chunks -- what the non-streaming path does on every
+    call -- has to produce a different result, otherwise the temporal cache
+    carries nothing and the assertion above is vacuous.
+    """
+    latent = _latent(6)
+    reference = _decode_whole(vae, latent)
+
+    restarted = torch.cat(
+        [
+            decoder.decode_chunk(latent[:, :, :3], decoder.new_decode_state("a")),
+            decoder.decode_chunk(latent[:, :, 3:], decoder.new_decode_state("b")),
+        ],
+        dim=2,
+    )
+    assert restarted.shape != reference.shape or not torch.equal(restarted, reference)
+
+
+# --------------------------------------------------------------------------
+# Cross-session isolation: the failure that timing metrics cannot see
+# --------------------------------------------------------------------------
+
+
+@torch.no_grad()
+def test_interleaved_sessions_keep_independent_temporal_context(vae, decoder) -> None:
+    """Two sessions ticking alternately must each match their solo decode.
+
+    A session that reads another's temporal cache produces a perfectly
+    plausible but wrong video, and every latency metric stays green, so this
+    has to be asserted against a recorded solo run rather than inferred.
+    """
+    latent_a = _latent(6, seed=1)
+    latent_b = _latent(6, seed=2)
+    solo_a = _decode_whole(vae, latent_a)
+    solo_b = _decode_whole(vae, latent_b)
+    assert not torch.equal(solo_a, solo_b), "negative control: the two sessions must differ"
+
+    state_a = decoder.new_decode_state("a")
+    state_b = decoder.new_decode_state("b")
+    out_a, out_b = [], []
+    for start in (0, 3):
+        window = slice(start, start + 3)
+        out_a.append(decoder.decode_chunk(latent_a[:, :, window], state_a))
+        out_b.append(decoder.decode_chunk(latent_b[:, :, window], state_b))
+
+    torch.testing.assert_close(torch.cat(out_a, dim=2), solo_a, rtol=0, atol=0)
+    torch.testing.assert_close(torch.cat(out_b, dim=2), solo_b, rtol=0, atol=0)
+
+
+@torch.no_grad()
+def test_the_module_cache_is_untouched_so_sessions_can_share_one_decoder(vae, decoder) -> None:
+    vae.clear_cache()
+    before = [entry for entry in vae._feat_map]
+    decoder.decode_chunk(_latent(3), decoder.new_decode_state("s"))
+    assert vae._feat_map == before, "streaming decode must not write the module-owned cache"
+
+
+# --------------------------------------------------------------------------
+# Causal geometry and boundedness
+# --------------------------------------------------------------------------
+
+
+@torch.no_grad()
+def test_opening_chunk_is_shorter_and_later_chunks_are_full_length(vae, decoder) -> None:
+    """(n - 1) * factor + 1 for the opening chunk, n * factor after it."""
+    factor = 2 ** sum(VAE_CONFIG["temperal_downsample"])
+    state = decoder.new_decode_state("s")
+    first = decoder.decode_chunk(_latent(3), state)
+    second = decoder.decode_chunk(_latent(3, seed=5), state)
+
+    assert first.shape[2] == (3 - 1) * factor + 1
+    assert second.shape[2] == 3 * factor
+    assert state.chunks_decoded == 2
+    assert state.frames_decoded == 6
+
+
+@torch.no_grad()
+def test_resident_state_does_not_grow_with_session_length(vae, decoder) -> None:
+    """Each causal convolution retains at most CACHE_T temporal slices."""
+    state = decoder.new_decode_state("s")
+    decoder.decode_chunk(_latent(3), state)
+    baseline = state.nbytes()
+    assert baseline > 0
+
+    for step in range(8):
+        decoder.decode_chunk(_latent(3, seed=step + 10), state)
+        assert state.nbytes() == baseline
+
+    assert sum(state.nbytes_by_device().values()) == baseline
+
+
+@torch.no_grad()
+def test_release_returns_the_session_to_its_pre_stream_state(vae, decoder) -> None:
+    state = decoder.new_decode_state("s")
+    decoder.decode_chunk(_latent(3), state)
+    assert state.started and state.nbytes() > 0
+
+    decoder.release(state)
+    assert state.nbytes() == 0
+    assert not state.started
+    assert state.chunks_decoded == 0
+
+    # A released session restarts rather than resumes, so its first chunk is
+    # short again -- the same semantics reset() has for AR KV.
+    factor = 2 ** sum(VAE_CONFIG["temperal_downsample"])
+    assert decoder.decode_chunk(_latent(3), state).shape[2] == (3 - 1) * factor + 1
+
+
+# --------------------------------------------------------------------------
+# Contract
+# --------------------------------------------------------------------------
+
+
+def test_wan_decoder_satisfies_the_protocol(decoder) -> None:
+    assert isinstance(decoder, SupportsStreamingDecode)
+
+
+def test_state_from_another_decoder_is_rejected(decoder) -> None:
+    foreign = StreamingDecodeState(session_id="s", feat_map=[None])
+    with pytest.raises(ValueError, match="does not belong to this decoder"):
+        decoder.decode_chunk(_latent(1), foreign)
+
+
+def test_a_non_wan_module_is_rejected() -> None:
+    with pytest.raises(TypeError, match="Wan-family autoencoder"):
+        WanStreamingDecoder(object())
+
+
+def test_empty_and_malformed_latents_are_rejected(decoder) -> None:
+    state = decoder.new_decode_state("s")
+    with pytest.raises(ValueError, match=r"\[B, C, T, H, W\]"):
+        decoder.decode_chunk(torch.zeros(1, 4, 4, 4), state)
+    with pytest.raises(ValueError, match="at least one frame"):
+        decoder.decode_chunk(torch.zeros(1, 4, 0, LATENT_H, LATENT_W), state)
+
+
+def test_session_id_must_be_meaningful(decoder) -> None:
+    with pytest.raises(ValueError, match="session_id"):
+        decoder.new_decode_state("  ")
+
+
+def test_declared_state_bytes_scales_with_area_and_dtype(decoder) -> None:
+    # Measured for the shipped checkpoint: 37832 KiB of fp32 cache at 64x64.
+    decoder._bytes_per_pixel_fp32 = 37832 * 1024 / (64 * 64)
+    fp32 = decoder.declared_state_bytes(height=480, width=832, dtype=torch.float32)
+    bf16 = decoder.declared_state_bytes(height=480, width=832, dtype=torch.bfloat16)
+    half_area = decoder.declared_state_bytes(height=240, width=832, dtype=torch.float32)
+    assert bf16 == fp32 // 2
+    assert half_area == fp32 // 2
+    assert fp32 / 2**20 == pytest.approx(3602.0, abs=5.0)

--- a/tests/diffusion/ar_diffusion/test_streaming_decode.py
+++ b/tests/diffusion/ar_diffusion/test_streaming_decode.py
@@ -70,24 +70,61 @@ def _decode_whole(vae, latent: torch.Tensor) -> torch.Tensor:
 # --------------------------------------------------------------------------
 
 
-@torch.no_grad()
-@pytest.mark.parametrize("chunk_sizes", [(3, 3, 3), (1, 1, 1, 1, 1), (2, 4, 3), (9,)])
-def test_streaming_chunks_reproduce_the_whole_clip_decode(vae, decoder, chunk_sizes) -> None:
-    """Chunked decode must equal one-shot decode, for any chunking."""
-    total = sum(chunk_sizes)
-    latent = _latent(total)
-    reference = _decode_whole(vae, latent)
-
-    state = decoder.new_decode_state("s")
-    pieces = []
-    offset = 0
+def _stream(decoder, latent: torch.Tensor, chunk_sizes, *, session_id: str = "s") -> torch.Tensor:
+    state = decoder.new_decode_state(session_id)
+    pieces, offset = [], 0
     for size in chunk_sizes:
         pieces.append(decoder.decode_chunk(latent[:, :, offset : offset + size], state))
         offset += size
-    streamed = torch.cat(pieces, dim=2)
+    return torch.cat(pieces, dim=2)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("chunk_sizes", [(3, 3, 3), (1, 1, 1, 1, 1), (2, 4, 3)])
+def test_chunking_is_neutral(vae, decoder, chunk_sizes) -> None:
+    """Splitting a session into chunks must change nothing about its output.
+
+    This is the property streaming actually introduces, so it is the one
+    asserted exactly. The control is the same session decoded in a single
+    call through the same code path -- not ``_decode`` -- because ``_decode``
+    differs in a way that has nothing to do with chunking; see
+    ``test_distance_from_the_one_shot_path_is_a_post_quant_conv_artifact``.
+    """
+    total = sum(chunk_sizes)
+    latent = _latent(total)
+    reference = _stream(decoder, latent, (total,), session_id="ref")
+    streamed = _stream(decoder, latent, chunk_sizes)
 
     assert streamed.shape == reference.shape
     torch.testing.assert_close(streamed, reference, rtol=0, atol=0)
+
+
+@torch.no_grad()
+def test_distance_from_the_one_shot_path_is_a_post_quant_conv_artifact(vae, decoder) -> None:
+    """Explain, and bound, the gap against diffusers' ``_decode``.
+
+    ``_decode`` applies ``post_quant_conv`` to the whole latent at once; the
+    tiled path in this repo, and this decoder, apply it per frame. It is a
+    1x1x1 convolution, so the two are mathematically identical -- but they can
+    select different kernels, and on bf16 CUDA that difference is real and is
+    amplified by the causal convolutions downstream.
+
+    Asserting equality with ``_decode`` would therefore pin a kernel-selection
+    coincidence rather than a property of streaming. Assert instead that the
+    gap is entirely explained by where ``post_quant_conv`` runs.
+    """
+    latent = _latent(6)
+    per_frame_pq = torch.cat([vae.post_quant_conv(latent[:, :, k : k + 1]) for k in range(latent.shape[2])], dim=2)
+    whole_pq = vae.post_quant_conv(latent)
+
+    streamed = _stream(decoder, latent, (3, 3))
+    one_shot = _decode_whole(vae, latent)
+
+    # Same inputs to the decoder => same output, whatever the backend does.
+    if torch.equal(whole_pq, per_frame_pq):
+        torch.testing.assert_close(streamed, one_shot, rtol=0, atol=0)
+    else:  # pragma: no cover - backend dependent
+        pytest.skip("backend batches post_quant_conv differently; the gap is that, not chunking")
 
 
 @torch.no_grad()
@@ -111,6 +148,29 @@ def test_a_restarted_stream_does_not_match_a_continued_one(vae, decoder) -> None
     assert restarted.shape != reference.shape or not torch.equal(restarted, reference)
 
 
+@torch.no_grad()
+def test_isolation_is_checked_against_each_session_decoded_alone(vae, decoder) -> None:
+    """Interleaved sessions must each match their own solo stream.
+
+    Solo streams, not ``_decode``: the control has to differ from the run under
+    test only in interleaving, or the assertion measures two things at once.
+    """
+    latent_a, latent_b = _latent(6, seed=11), _latent(6, seed=12)
+    solo_a = _stream(decoder, latent_a, (6,), session_id="solo-a")
+    solo_b = _stream(decoder, latent_b, (6,), session_id="solo-b")
+    assert not torch.equal(solo_a, solo_b), "negative control: the sessions must differ"
+
+    state_a, state_b = decoder.new_decode_state("a"), decoder.new_decode_state("b")
+    out_a, out_b = [], []
+    for start in (0, 3):
+        window = slice(start, start + 3)
+        out_a.append(decoder.decode_chunk(latent_a[:, :, window], state_a))
+        out_b.append(decoder.decode_chunk(latent_b[:, :, window], state_b))
+
+    torch.testing.assert_close(torch.cat(out_a, dim=2), solo_a, rtol=0, atol=0)
+    torch.testing.assert_close(torch.cat(out_b, dim=2), solo_b, rtol=0, atol=0)
+
+
 # --------------------------------------------------------------------------
 # Cross-session isolation: the failure that timing metrics cannot see
 # --------------------------------------------------------------------------
@@ -126,8 +186,8 @@ def test_interleaved_sessions_keep_independent_temporal_context(vae, decoder) ->
     """
     latent_a = _latent(6, seed=1)
     latent_b = _latent(6, seed=2)
-    solo_a = _decode_whole(vae, latent_a)
-    solo_b = _decode_whole(vae, latent_b)
+    solo_a = _stream(decoder, latent_a, (6,), session_id="solo-a")
+    solo_b = _stream(decoder, latent_b, (6,), session_id="solo-b")
     assert not torch.equal(solo_a, solo_b), "negative control: the two sessions must differ"
 
     state_a = decoder.new_decode_state("a")

--- a/vllm_omni/experimental/ar_diffusion/streaming_decode.py
+++ b/vllm_omni/experimental/ar_diffusion/streaming_decode.py
@@ -21,6 +21,12 @@ most ``CACHE_T`` temporal slices, so the cache is a function of resolution and
 never of session length. It is not free -- see :meth:`StreamingDecodeState.nbytes`,
 which is the quantity session admission has to account for.
 
+Measured on the reference checkpoint at 832x480 in bf16, on one RTX PRO 6000:
+streaming a session chunk by chunk reproduces the whole-clip decode with a
+maximum absolute error of 0, resident decoder state holds at 1801 MiB across
+every chunk, and time to first frame drops from 2.271 s -- the whole-clip
+barrier -- to 0.370 s, without the session costing more in total.
+
 Only ``torch`` is imported here so the contract can be exercised without a
 device, a checkpoint, or the distributed VAE stack.
 """

--- a/vllm_omni/experimental/ar_diffusion/streaming_decode.py
+++ b/vllm_omni/experimental/ar_diffusion/streaming_decode.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Session-owned streaming VAE decode for realtime AR-Diffusion.
+
+A causal video decoder already decodes one latent frame at a time, carrying a
+bounded temporal cache between frames. What it does not do today is carry that
+cache *between requests*: every decode call clears it, so a chunk can only be
+decoded as part of a whole clip.
+
+This module moves the cache from the decoder module to the session, which is
+the entire difference between "decode a clip" and "stream a session":
+
+* the cache becomes :class:`StreamingDecodeState`, threaded in and out by the
+  caller, so two concurrent sessions cannot overwrite each other's temporal
+  context -- a failure that produces a plausible but wrong video while every
+  timing metric stays green;
+* ``first_chunk`` becomes a property of the session's first frame rather than
+  of the call, which is what makes chunk ``N + 1`` continue chunk ``N``.
+
+Resident state is bounded by construction: each causal convolution retains at
+most ``CACHE_T`` temporal slices, so the cache is a function of resolution and
+never of session length. It is not free -- see :meth:`StreamingDecodeState.nbytes`,
+which is the quantity session admission has to account for.
+
+Only ``torch`` is imported here so the contract can be exercised without a
+device, a checkpoint, or the distributed VAE stack.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+import torch
+
+
+@dataclass
+class StreamingDecodeState:
+    """One session's temporal decoder cache.
+
+    ``feat_map`` holds one entry per causal convolution. Entries are tensors,
+    ``None`` before that convolution has run, or a non-tensor sentinel the
+    decoder uses for its first upsample step, so byte accounting must skip
+    anything that is not a tensor.
+
+    The cache has **no recompute source**: it is the compressed tail of every
+    frame decoded so far and cannot be rebuilt from the prompt or the latents.
+    Releasing it ends the stream; there is no partial eviction.
+    """
+
+    session_id: str
+    feat_map: list[Any]
+    conv_idx: list[int] = field(default_factory=lambda: [0])
+    frames_decoded: int = 0
+    chunks_decoded: int = 0
+
+    def nbytes(self) -> int:
+        """Resident bytes of the cache, skipping non-tensor entries."""
+        return sum(t.numel() * t.element_size() for t in self.feat_map if torch.is_tensor(t))
+
+    def nbytes_by_device(self) -> dict[str, int]:
+        """Resident bytes grouped by device, for admission accounting."""
+        totals: dict[str, int] = {}
+        for tensor in self.feat_map:
+            if torch.is_tensor(tensor):
+                key = str(tensor.device)
+                totals[key] = totals.get(key, 0) + tensor.numel() * tensor.element_size()
+        return totals
+
+    @property
+    def started(self) -> bool:
+        return self.frames_decoded > 0
+
+    def release(self) -> None:
+        """Drop the cache and return the session to its pre-stream state."""
+        self.feat_map = [None] * len(self.feat_map)
+        self.conv_idx = [0]
+        self.frames_decoded = 0
+        self.chunks_decoded = 0
+
+
+@runtime_checkable
+class SupportsStreamingDecode(Protocol):
+    """A decoder that can emit a session's chunks incrementally.
+
+    The lifecycle mirrors the AR session's: ``new_decode_state`` at session
+    creation, ``decode_chunk`` per committed chunk, and ``release`` on reset or
+    close, so decoder state and KV state are released together rather than
+    through two independent lifecycles.
+    """
+
+    def new_decode_state(self, session_id: str) -> StreamingDecodeState:
+        """Create empty decoder state for a new session."""
+        ...
+
+    def decode_chunk(self, latent: torch.Tensor, state: StreamingDecodeState) -> torch.Tensor:
+        """Decode one committed chunk, advancing ``state`` in place."""
+        ...
+
+    def declared_state_bytes(self, *, height: int, width: int, dtype: torch.dtype) -> int:
+        """Upper bound on resident decoder bytes per session at this shape."""
+        ...
+
+
+class WanStreamingDecoder:
+    """Streaming decode over a Wan-family causal autoencoder.
+
+    Wraps any module exposing ``decoder``, ``post_quant_conv`` and the cached
+    causal-convolution counts. It never touches the module's own ``_feat_map``,
+    so a module shared by several sessions stays stateless between calls.
+    """
+
+    def __init__(self, vae: Any) -> None:
+        for attribute in ("decoder", "post_quant_conv"):
+            if not hasattr(vae, attribute):
+                raise TypeError(f"Streaming decode requires a Wan-family autoencoder exposing {attribute!r}.")
+        self._vae = vae
+
+    @property
+    def num_causal_convs(self) -> int:
+        counts = getattr(self._vae, "_cached_conv_counts", None)
+        if not isinstance(counts, dict) or "decoder" not in counts:
+            raise TypeError("The autoencoder does not expose cached decoder convolution counts.")
+        return int(counts["decoder"])
+
+    def new_decode_state(self, session_id: str) -> StreamingDecodeState:
+        if not isinstance(session_id, str) or not session_id.strip():
+            raise ValueError("session_id must be a non-empty string.")
+        return StreamingDecodeState(session_id=session_id, feat_map=[None] * self.num_causal_convs)
+
+    def decode_chunk(self, latent: torch.Tensor, state: StreamingDecodeState) -> torch.Tensor:
+        """Decode ``latent`` as the continuation of ``state``'s session.
+
+        ``latent`` is ``[B, C, T, H, W]`` in latent space, already rescaled by
+        the pipeline's latent statistics. Frames are decoded one at a time, the
+        same loop the non-streaming path runs, with the cache carried across
+        calls instead of cleared. The returned tensor is ``[B, 3, T', H', W']``
+        where ``T'`` is smaller for a session's first chunk: the opening latent
+        frame expands to a single raw frame and every later one to the full
+        temporal factor.
+        """
+        if latent.ndim != 5:
+            raise ValueError(f"latent must be [B, C, T, H, W]; got shape {tuple(latent.shape)}.")
+        if len(state.feat_map) != self.num_causal_convs:
+            raise ValueError(
+                "Decoder state does not belong to this decoder: "
+                f"{len(state.feat_map)} cache slots against {self.num_causal_convs} causal convolutions."
+            )
+        num_frames = int(latent.shape[2])
+        if num_frames == 0:
+            raise ValueError("latent must carry at least one frame.")
+
+        decoded_frames = []
+        for index in range(num_frames):
+            state.conv_idx[0] = 0
+            frame = self._vae.post_quant_conv(latent[:, :, index : index + 1])
+            # first_chunk marks the session's opening frame, not the call's:
+            # that is what makes chunk N + 1 continue chunk N rather than
+            # restart the causal expansion.
+            decoded_frames.append(
+                self._vae.decoder(
+                    frame,
+                    feat_cache=state.feat_map,
+                    feat_idx=state.conv_idx,
+                    first_chunk=(state.frames_decoded == 0),
+                )
+            )
+            state.frames_decoded += 1
+
+        out = torch.cat(decoded_frames, dim=2)
+        patch_size = getattr(getattr(self._vae, "config", None), "patch_size", None)
+        if patch_size is not None:
+            from diffusers.models.autoencoders.autoencoder_kl_wan import unpatchify
+
+            out = unpatchify(out, patch_size=patch_size)
+        out = torch.clamp(out, min=-1.0, max=1.0)
+        state.chunks_decoded += 1
+        return out
+
+    def release(self, state: StreamingDecodeState) -> None:
+        state.release()
+
+    def declared_state_bytes(self, *, height: int, width: int, dtype: torch.dtype) -> int:
+        """Resident decoder bytes per session at this output shape.
+
+        Every cached tensor is ``[B, C_l, <= CACHE_T, H_l, W_l]`` with ``H_l``
+        and ``W_l`` fixed fractions of the output, so the total scales exactly
+        with ``height * width``. Callers that need the constant should measure
+        it once for their checkpoint; this helper scales a measured constant so
+        admission does not have to re-measure per resolution.
+        """
+        constant = getattr(self, "_bytes_per_pixel_fp32", None)
+        if constant is None:
+            raise RuntimeError(
+                "declared_state_bytes needs a measured bytes-per-pixel constant for this checkpoint; "
+                "set _bytes_per_pixel_fp32 from a one-off measurement."
+            )
+        element_ratio = torch.empty((), dtype=dtype).element_size() / 4
+        return int(constant * height * width * element_ratio)

--- a/vllm_omni/experimental/ar_diffusion/streaming_decode.py
+++ b/vllm_omni/experimental/ar_diffusion/streaming_decode.py
@@ -21,11 +21,22 @@ most ``CACHE_T`` temporal slices, so the cache is a function of resolution and
 never of session length. It is not free -- see :meth:`StreamingDecodeState.nbytes`,
 which is the quantity session admission has to account for.
 
-Measured on the reference checkpoint at 832x480 in bf16, on one RTX PRO 6000:
-streaming a session chunk by chunk reproduces the whole-clip decode with a
-maximum absolute error of 0, resident decoder state holds at 1801 MiB across
-every chunk, and time to first frame drops from 2.271 s -- the whole-clip
-barrier -- to 0.370 s, without the session costing more in total.
+Measured on the reference checkpoint at 832x480 in bf16, on one RTX PRO 6000
+with torch 2.11: chunking is neutral -- a session decoded in four chunks is
+bit-identical to the same session decoded in one call -- resident decoder
+state holds at 1801 MiB across every chunk, and time to first frame drops
+from 1.9 s, the whole-clip barrier, to 0.31 s without the session costing more
+in total.
+
+Note what "neutral" is measured against. ``AutoencoderKLWan._decode`` applies
+``post_quant_conv`` to the whole latent at once, while the tiled path in this
+repo -- and this decoder -- apply it per frame. It is a 1x1x1 convolution, so
+the two are mathematically identical, but they can select different kernels;
+on bf16 CUDA that seeds a 0.004 difference which the causal convolutions
+downstream amplify to 0.047. Comparing against ``_decode`` therefore measures
+where ``post_quant_conv`` runs, not anything about streaming, and the result
+moves with the torch version. The control that isolates chunking is the same
+session decoded in a single call through this same path.
 
 Only ``torch`` is imported here so the contract can be exercised without a
 device, a checkpoint, or the distributed VAE stack.


### PR DESCRIPTION
## Draft / stacked dependencies

This PR is intentionally a draft. It depends on:

- #6444 for the multi-session realtime harness
- #6533 for session-owned streaming VAE decode

The current diff temporarily includes both prerequisite branches. I will rebase it onto `main` after they land so that the final review contains only the vertical-path changes.

## Summary

- extend the realtime benchmark from latent readiness to actual RGB delivery
- add `DecodingSession` and report decoder time/share, delivered frame geometry, and resident decoder bytes per session
- add `OverlappedDecodingSession` with an explicit bounded generation lookahead
- overlap DiT generation for chunk N+1 with VAE decode for chunk N
- report outstanding generations instead of a `backpressure_s` metric that could never become nonzero in the caller-driven API

## Why

The existing harness ends when a latent chunk is ready, but users cannot display latent tensors. Its TTFF/RTF therefore omit VAE decode and do not describe RGB delivery. The omission becomes more important as TP reduces generation time while the single-device decoder remains a floor.

The first overlap implementation used `ensure_future()`, but synchronous decode immediately blocked the event loop, so the generation request was never sent until decode completed. The corrected path yields control after filling the lookahead, and the tests assert the actual event ordering rather than only the final duration.

`lookahead=1` is both the overlap window and the backpressure/memory bound: generation cannot run arbitrarily far ahead of the RGB consumer.

## Tests

```text
pytest -q \
  tests/diffusion/ar_diffusion/test_realtime_benchmark.py \
  tests/diffusion/ar_diffusion/test_streaming_decode.py
61 passed
```

## Follow-up validation

The CPU tests use a deterministic fake clock and assert ordering, bounds, frame accounting, and lifecycle behavior. End-to-end H200 generation/decode overlap remains a required hardware validation item under #6227; until that run is complete, `max(generation, decode)` is a target, not a claimed measured result.

Part of #6227 Phase 1.
