### PR TITLE
Fix diffusion queue metrics

### DIFF
--- a/tests/entrypoints/test_omni_base_queue_metrics.py
+++ b/tests/entrypoints/test_omni_base_queue_metrics.py
@@ -1,0 +1,39 @@
+from vllm_omni.engine.messages import DiffusionQueueStatsMessage
+from vllm_omni.entrypoints.omni_base import OmniBase
+
+
+class _PrometheusRecorder:
+    def __init__(self) -> None:
+        self.waiting: int | None = None
+        self.running: int | None = None
+
+    def set_waiting(self, value: int) -> None:
+        self.waiting = value
+
+    def set_running(self, value: int) -> None:
+        self.running = value
+
+
+def test_diffusion_scheduler_backlog_is_pipeline_waiting() -> None:
+    omni = object.__new__(OmniBase)
+    omni.request_states = {f"req-{index}": object() for index in range(10)}
+    omni.prom_metrics = prom = _PrometheusRecorder()
+
+    omni._process_diffusion_queue_stats_message(
+        DiffusionQueueStatsMessage(stage_id=0, replica_id=0, waiting=9, running=1)
+    )
+
+    assert prom.waiting == 9
+    assert prom.running == 1
+
+
+def test_diffusion_queue_stats_aggregate_replicas_without_overcounting() -> None:
+    omni = object.__new__(OmniBase)
+    omni.request_states = {f"req-{index}": object() for index in range(3)}
+    omni.prom_metrics = prom = _PrometheusRecorder()
+
+    omni._process_diffusion_queue_stats_message(DiffusionQueueStatsMessage(stage_id=0, replica_id=0, waiting=2, running=1))
+    omni._process_diffusion_queue_stats_message(DiffusionQueueStatsMessage(stage_id=0, replica_id=1, waiting=2, running=0))
+
+    assert prom.waiting == 3
+    assert prom.running == 0

--- a/vllm_omni/diffusion/stage_diffusion_client.py
+++ b/vllm_omni/diffusion/stage_diffusion_client.py
@@ -240,6 +240,8 @@ class StageDiffusionClient(StageClientBase):
 
             if msg_type == "result":
                 self._output_queue.put_nowait(msg["output"])
+            elif msg_type == "queue_stats":
+                self._scheduler_stats = (int(msg["waiting"]), int(msg["running"]))
             elif msg_type == "rpc_result":
                 self._rpc_results[msg["rpc_id"]] = msg["result"]
             elif msg_type == "error":
@@ -384,6 +386,11 @@ class StageDiffusionClient(StageClientBase):
                     return None
                 raise EngineDeadError(f"StageDiffusionProc died unexpectedly (exit code {exitcode})")
             return None
+
+    def get_scheduler_stats(self) -> tuple[int, int] | None:
+        """Return the latest scheduler (waiting, running) snapshot."""
+        self._drain_responses()
+        return getattr(self, "_scheduler_stats", None)
 
     async def abort_requests_async(self, request_ids: list[str]) -> None:
         self._request_socket.send(

--- a/vllm_omni/diffusion/stage_diffusion_proc.py
+++ b/vllm_omni/diffusion/stage_diffusion_proc.py
@@ -331,6 +331,31 @@ class StageDiffusionProc:
         fatal_event = asyncio.Event()
         self._fatal_event = fatal_event
 
+        async def _report_scheduler_stats() -> None:
+            """Push scheduler occupancy whenever it changes.
+
+            The worker thread owns scheduling, so the subprocess event loop
+            polls under the engine condition lock rather than trying to emit
+            ZMQ frames from that thread.
+            """
+            last_stats: tuple[int, int] | None = None
+            while True:
+                engine = self._engine
+                if engine is not None:
+                    with engine._cv:
+                        stats = (
+                            engine.scheduler.num_waiting_requests(),
+                            engine.scheduler.num_running_requests(),
+                        )
+                    if stats != last_stats:
+                        await response_socket.send(
+                            encoder.encode({"type": "queue_stats", "waiting": stats[0], "running": stats[1]})
+                        )
+                        last_stats = stats
+                await asyncio.sleep(0.01)
+
+        scheduler_stats_task = asyncio.create_task(_report_scheduler_stats())
+
         async def _dispatch_request(
             request_id: str,
             prompt: Any,
@@ -487,6 +512,8 @@ class StageDiffusionProc:
             if tasks:
                 await asyncio.gather(*tasks.values(), return_exceptions=True)
 
+            scheduler_stats_task.cancel()
+            await asyncio.gather(scheduler_stats_task, return_exceptions=True)
             self._active_tasks = None
             self._fatal_event = None
             request_socket.close()

--- a/vllm_omni/engine/messages.py
+++ b/vllm_omni/engine/messages.py
@@ -107,6 +107,16 @@ class StageMetricsMessage(EngineQueueMessage, kw_only=True):
     stage_submit_ts: float | None = None
 
 
+class DiffusionQueueStatsMessage(EngineQueueMessage, kw_only=True):
+    """Latest scheduler occupancy reported by a diffusion stage replica."""
+
+    type: Literal["diffusion_queue_stats"] = "diffusion_queue_stats"
+    stage_id: int
+    replica_id: int
+    waiting: int
+    running: int
+
+
 class CollectiveRPCResultMessage(EngineQueueMessage, kw_only=True):
     type: Literal["collective_rpc_result"] = "collective_rpc_result"
     rpc_id: str

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -40,6 +40,7 @@ from vllm_omni.engine.messages import (
     CollectiveRPCRequestMessage,
     CollectiveRPCResultMessage,
     EngineQueueMessage,
+    DiffusionQueueStatsMessage,
     ErrorMessage,
     InteractionMessage,
     OutputMessage,
@@ -950,6 +951,18 @@ class Orchestrator:
                     # evicted rather than tearing down every stage (#4285).
                     try:
                         if pool.stage_type == "diffusion":
+                            queue_stats = pool.poll_diffusion_scheduler_stats(replica_id)
+                            if queue_stats is not None:
+                                waiting, running = queue_stats
+                                await self.output_async_queue.put(
+                                    DiffusionQueueStatsMessage(
+                                        stage_id=stage_id,
+                                        replica_id=replica_id,
+                                        waiting=waiting,
+                                        running=running,
+                                    )
+                                )
+                                idle = False
                             diffusion_output = pool.poll_diffusion_output(replica_id)
                             if diffusion_output is None:
                                 continue

--- a/vllm_omni/engine/stage_pool.py
+++ b/vllm_omni/engine/stage_pool.py
@@ -1173,6 +1173,16 @@ class StagePool:
             return None
         return cast(StagePoolDiffusionClient, raw_client).get_diffusion_output_nowait()
 
+    def poll_diffusion_scheduler_stats(self, replica_id: int) -> tuple[int, int] | None:
+        """Return the latest (waiting, running) diffusion scheduler snapshot."""
+        if not self.is_replica_available(replica_id):
+            return None
+        raw_client = self.clients[replica_id]
+        if raw_client is None:
+            return None
+        get_stats = getattr(raw_client, "get_scheduler_stats", None)
+        return get_stats() if get_stats is not None else None
+
     # ---- Stage-local control plane ----
 
     async def abort_requests(self, request_ids: list[str]) -> None:

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -20,6 +20,7 @@ from vllm_omni.engine.messages import (
     EngineQueueMessage,
     ErrorMessage,
     OutputMessage,
+    DiffusionQueueStatsMessage,
     StageMetricsMessage,
 )
 from vllm_omni.entrypoints.client_request_state import ClientRequestState
@@ -221,6 +222,7 @@ class OmniBase(PDDisaggregationMixin):
 
         self.request_states: dict[str, ClientRequestState] = {}
         self._consumed_metric_messages: dict[str, set[int]] = {}
+        self._diffusion_queue_stats: dict[tuple[int, int], tuple[int, int]] = {}
         self.prom_metrics = OmniPrometheusMetrics(model_name=model, log_stats=log_stats)
         self.mod_metrics = OmniModalityMetrics(model_name=model, log_stats=log_stats)
 
@@ -466,12 +468,31 @@ class OmniBase(PDDisaggregationMixin):
             req_state.metrics.stage_first_ts[stage_id] = submit_ts if submit_ts is not None else now
         req_state.metrics.stage_last_ts[stage_id] = max(req_state.metrics.stage_last_ts[stage_id] or 0.0, now)
 
+    def _process_diffusion_queue_stats_message(self, msg: DiffusionQueueStatsMessage) -> None:
+        """Publish pipeline gauges using queue depth reported by diffusion schedulers."""
+        snapshots = getattr(self, "_diffusion_queue_stats", None)
+        if snapshots is None:
+            snapshots = self._diffusion_queue_stats = {}
+        snapshots[(msg.stage_id, msg.replica_id)] = (msg.waiting, msg.running)
+
+        total = len(self.request_states)
+        # A request handed to a diffusion replica is not running until that
+        # replica's scheduler admits it. Keep the global invariant intact by
+        # subtracting the scheduler-owned waiting backlog from pipeline total.
+        waiting = min(total, sum(snapshot[0] for snapshot in snapshots.values()))
+        self.prom_metrics.set_waiting(waiting)
+        self.prom_metrics.set_running(total - waiting)
+
     def _handle_output_message(
         self,
         msg: EngineQueueMessage | None,
     ) -> OutputMessageHandleResult:
         """Handle one Orchestrator output-queue message."""
         if msg is None:
+            return True, None, None, None
+
+        if isinstance(msg, DiffusionQueueStatsMessage):
+            self._process_diffusion_queue_stats_message(msg)
             return True, None, None, None
 
         if isinstance(msg, StageMetricsMessage):


### PR DESCRIPTION
## Purpose

Correct the pipeline-level Prometheus request gauges when a diffusion stage scheduler queues requests internally. The stage now reports per-replica waiting and running occupancy through the existing ZMQ response path, and the frontend uses the queued backlog for vllm_omni:num_requests_waiting.

## Test Plan

- Added unit coverage for the reported ten-request backlog and multi-replica aggregation.
- Ran the focused pytest regression test.

## Test Result

- 2 passed