### PR TITLE
[NPU] Right-size Wan2.2 I2V nightly perf job to 2 cards

### DIFF
--- a/.buildkite/npu/test-npu-nightly.yml
+++ b/.buildkite/npu/test-npu-nightly.yml
@@ -244,7 +244,7 @@ steps:
       - label: ":full_moon: Diffusion X2V · Perf Test"
         key: nightly-diffusion-x2v-performance
         timeout_in_minutes: 180
-        mirror_hardwares: a3_npu_4
+        mirror_hardwares: a3_npu_2
         env:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
           VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"


### PR DESCRIPTION
The Wan2.2 I2V nightly job was reserving four NPUs even though the current benchmark cases use at most two. This switches the runner from `a3_npu_4` to `a3_npu_2`, so the job stops holding two idle cards during the run. It does not change the benchmark cases or coverage.

Partially addresses #6510.

Validation: pre-commit and the docs build pass. I have not run the NPU workload locally.
