### PR TITLE
[CI]Fix Wan DMD pipeline test alignment

### DIFF
--- a/tests/model_tests/diffusion/test_alignment.py
+++ b/tests/model_tests/diffusion/test_alignment.py
@@ -26,6 +26,7 @@ EXCLUDED_MODELS = [
     "ZImagePipeline",
     "OvisImagePipeline",
     "WanPipeline",
+    "WanDMDPipeline",
     "WanVACEPipeline",
     "LTX2TwoStagePipeline",
     "LTX2DistilledOneStagePipeline",


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Fix the diffusion pipeline alignment test failure caused by `WanDMDPipeline` being registered without being included in the excluded model list. `WanDMDPipeline` is an alias of `WanPipeline` and does not require a separate test configuration.

## Test Plan

Ran `tests/model_tests/diffusion/test_alignment.py`

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

Result: `2 passed`

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
