### PR TITLE
[Model] GR00T-N1.7: support request-level batching

### DIFF
--- a/recipes/NVIDIA/GR00T-N1.7.md
+++ b/recipes/NVIDIA/GR00T-N1.7.md
@@ -49,11 +49,11 @@ vllm serve nvidia/GR00T-N1.7-3B \
 
 Notes:
 
-- Only `max_num_seqs: 1` is supported (configured in the deploy YAML). The
-  policy is markovian (`state_history_length=1`, `reset()` returns `{}`) — the
-  reason for the cap is that `Gr00tPolicy` does its own per-sample
-  (un)batching inside `get_action` and is not integrated with vLLM's
-  continuous batching path.
+- The deploy YAML defaults to `max_num_seqs: 1`, serving one request at a
+  time. The policy is markovian (`state_history_length=1`, `reset()` returns
+  `{}`), and `Gr00tN1d7Pipeline` implements the request-batch contract, so
+  raising `max_num_seqs` in an overlay batches concurrent sessions into one
+  policy call — see "Optional: batch concurrent sessions" below.
 - This pipeline is a thin wrapper around the upstream HF policy
   (`AutoModel.from_pretrained` + `enforce_eager`, `tensor_parallel_size=1`,
   pipeline `load_weights` is a no-op). The standard diffusion accelerators
@@ -90,6 +90,55 @@ The test sends a synthetic two-frame DROID observation and checks:
 - Action shapes: `eef_9d (1,40,9)`, `gripper_position (1,40,1)`, `joint_position (1,40,7)`
 - All action values are finite float32
 - Reset response is `"reset successful"`
+
+## Optional: batch concurrent sessions
+
+The bundled deploy config serves one request at a time (`max_num_seqs: 1`):
+with N robots connected, every observation waits for the requests ahead of it,
+so latency grows linearly with N while throughput stays flat.
+`Gr00tN1d7Pipeline` supports request-level batching — the scheduler groups
+in-flight requests into one wave and the pipeline serves the whole wave with a
+single `Gr00tPolicy.get_action()` call. Opt in with an overlay:
+
+```yaml
+# gr00t_batch.yaml
+base_config: vllm_omni/deploy/Gr00tN1d7.yaml
+stages:
+  - stage_id: 0
+    max_num_seqs: 8
+```
+
+```bash
+vllm serve nvidia/GR00T-N1.7-3B --omni --deploy-config gr00t_batch.yaml
+```
+
+Measured on 1xA30 (eager, DP=1, 30 requests/client after 20 warmup requests),
+closed-loop OpenPI WebSocket clients:
+
+| concurrent sessions | `max_num_seqs: 1` (default) | `max_num_seqs: 8` |
+| --- | --- | --- |
+| 1 | 6.56 req/s, 152 ms | 6.76 req/s, 148 ms |
+| 2 | 6.68 req/s, 297 ms | 6.94 req/s, 286 ms |
+| 4 | 6.71 req/s, 589 ms | 10.89 req/s, 366 ms |
+| 8 | 6.77 req/s, 1165 ms | 13.84 req/s, 576 ms |
+
+Notes:
+
+- Batches form opportunistically: requests that arrive while a wave is running
+  are grouped into the next wave, so a single client is served exactly as
+  before (wave size 1, no added wait). `request_batch_max_wait_ms` (default 0)
+  can trade first-request latency for fuller waves.
+- Actions for a request depend only on that request's observation — a
+  neighbor's content never leaks into your actions. Batched execution does
+  change bf16 kernel shapes, which shifts actions on the order of 5e-2 versus
+  a solo run (1e-5 when the same comparison is done in fp32) — well inside the
+  policy's own seed-to-seed sampling spread (~8e-1). With a fixed
+  `GR00T_NOISE_SEED`, per-request noise additionally depends on the wave size,
+  so bit-exact reproducibility holds per wave shape, not across load levels.
+  The single-session golden test is unaffected (wave size 1).
+- Batching grows the per-wave activation footprint only modestly: waves of 7
+  peak at ~6.4 GiB reserved vs ~5.9 GiB for single-request serving on A30
+  (the model dominates; per-observation activations are small).
 
 ## Notes
 

--- a/tests/diffusion/models/gr00t/test_pipeline.py
+++ b/tests/diffusion/models/gr00t/test_pipeline.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 from types import SimpleNamespace
 
 import numpy as np
@@ -6,18 +9,19 @@ import pytest
 from vllm_omni.diffusion.models.gr00t import pipeline_gr00t
 from vllm_omni.diffusion.models.gr00t.pipeline_gr00t import Gr00tN1d7Pipeline
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 
 class FakeGr00tPolicy:
-    instances = []
+    instances: list["FakeGr00tPolicy"] = []
 
     def __init__(self, **kwargs):
         self.kwargs = kwargs
         self.reset_calls = 0
-        self.seen_obs = None
+        self.calls = []
         self.embodiment_tag = SimpleNamespace(value="fake_embodiment")
         self.language_key = "annotation.language.language_instruction"
         self.modality_configs = {
@@ -41,11 +45,14 @@ class FakeGr00tPolicy:
         FakeGr00tPolicy.instances.append(self)
 
     def get_action(self, obs):
-        self.seen_obs = obs
-        return {
-            "arm": np.array([[[1.0, 2.0]]], dtype=np.float64),
-            "gripper": [[[3.0]]],
-        }, {"latency_ms": 1.0}
+        self.calls.append(obs)
+        batch_size = len(next(iter(obs["video"].values())))
+        # Echo each sample's state marker into its actions so tests can check
+        # that batched outputs are sliced back to the right request.
+        marker = np.asarray(obs["state"]["joint"], dtype=np.float64)[:, 0, 0]
+        arm = np.broadcast_to(marker[:, None, None], (batch_size, 2, 2)).copy()
+        gripper = np.broadcast_to(marker[:, None, None], (batch_size, 2, 1)).tolist()
+        return {"arm": arm, "gripper": gripper}, {"latency_ms": 1.0}
 
     def reset(self):
         self.reset_calls += 1
@@ -70,6 +77,26 @@ def _pipeline():
     return Gr00tN1d7Pipeline(od_config=od_config)
 
 
+def _robot_request(
+    request_id: str, *, marker: float, prompt: str = "pick the cube", side: int = 8, reset: bool = False
+):
+    return OmniDiffusionRequest(
+        prompt="pick",
+        request_id=request_id,
+        sampling_params=OmniDiffusionSamplingParams(
+            extra_args={
+                "robot_obs": {
+                    "images": {"cam": np.full((1, 1, side, side, 3), int(marker), dtype=np.uint8)},
+                    "state": {"joint": np.full((1, 1, 2), marker, dtype=np.float32)},
+                    "prompt": prompt,
+                    "session_id": f"session-{request_id}",
+                },
+                "reset": reset,
+            }
+        ),
+    )
+
+
 def test_pipeline_initializes_local_policy():
     pipeline = _pipeline()
 
@@ -79,40 +106,135 @@ def test_pipeline_initializes_local_policy():
     assert policy.kwargs["strict"] is False
     assert pipeline.weights_sources == ()
     assert pipeline.load_weights(iter(())) == set()
+    assert Gr00tN1d7Pipeline.supports_request_batch is True
 
 
 def test_forward_returns_dict_actions_in_output():
     pipeline = _pipeline()
-    req = OmniDiffusionRequest(
-        prompt="pick",
-        request_id="req",
-        sampling_params=OmniDiffusionSamplingParams(
-            extra_args={
-                "robot_obs": {
-                    "images": {"cam": np.zeros((1, 1, 8, 8, 3), dtype=np.uint8)},
-                    "state": {"joint": np.zeros((1, 1, 2), dtype=np.float32)},
-                    "prompt": "pick the cube",
-                    "session_id": "session-a",
-                },
-                "reset": True,
-            }
-        ),
-    )
+    batch = DiffusionRequestBatch(requests=[_robot_request("req", marker=1.0, reset=True)])
 
-    output = pipeline.forward(req)
+    outputs = pipeline.forward(batch)
 
+    assert len(outputs) == 1
+    output = outputs[0]
     assert output.error is None
     actions = output.output["actions"]
     assert set(actions) == {"arm", "gripper"}
     assert actions["arm"].dtype == np.float32
-    np.testing.assert_allclose(actions["arm"], np.array([[[1.0, 2.0]]], dtype=np.float32))
+    np.testing.assert_allclose(actions["arm"], np.ones((1, 2, 2), dtype=np.float32))
     policy = FakeGr00tPolicy.instances[0]
-    assert "video" in policy.seen_obs
-    assert policy.seen_obs["language"] == {"annotation.language.language_instruction": [["pick the cube"]]}
-    assert "images" not in policy.seen_obs
-    assert "prompt" not in policy.seen_obs
-    assert "session_id" not in policy.seen_obs
+    seen_obs = policy.calls[0]
+    assert "video" in seen_obs
+    assert seen_obs["language"] == {"annotation.language.language_instruction": [["pick the cube"]]}
+    assert "images" not in seen_obs
+    assert "prompt" not in seen_obs
+    assert "session_id" not in seen_obs
     assert policy.reset_calls == 1
+
+
+def test_forward_merges_wave_into_single_policy_call():
+    pipeline = _pipeline()
+    batch = DiffusionRequestBatch(
+        requests=[
+            _robot_request("req-a", marker=1.0, prompt="pick the cube"),
+            _robot_request("req-b", marker=2.0, prompt="open the drawer"),
+        ]
+    )
+
+    outputs = pipeline.forward(batch)
+
+    policy = FakeGr00tPolicy.instances[0]
+    assert len(policy.calls) == 1
+    merged_obs = policy.calls[0]
+    assert merged_obs["video"]["cam"].shape == (2, 1, 8, 8, 3)
+    assert merged_obs["state"]["joint"].shape == (2, 1, 2)
+    assert merged_obs["language"] == {
+        "annotation.language.language_instruction": [["pick the cube"], ["open the drawer"]]
+    }
+
+    assert [output.error for output in outputs] == [None, None]
+    np.testing.assert_allclose(outputs[0].output["actions"]["arm"], np.ones((1, 2, 2), dtype=np.float32))
+    np.testing.assert_allclose(outputs[1].output["actions"]["arm"], np.full((1, 2, 2), 2.0, dtype=np.float32))
+    for output in outputs:
+        assert output.output["actions"]["gripper"].shape == (1, 2, 1)
+        assert output.output["actions"]["gripper"].dtype == np.float32
+
+
+def test_forward_wave_isolates_malformed_request():
+    pipeline = _pipeline()
+    bad_request = OmniDiffusionRequest(
+        prompt="pick",
+        request_id="req-bad",
+        sampling_params=OmniDiffusionSamplingParams(extra_args={"robot_obs": "not-a-dict"}),
+    )
+    batch = DiffusionRequestBatch(requests=[_robot_request("req-a", marker=3.0), bad_request])
+
+    outputs = pipeline.forward(batch)
+
+    assert outputs[0].error is None
+    np.testing.assert_allclose(outputs[0].output["actions"]["arm"], np.full((1, 2, 2), 3.0, dtype=np.float32))
+    assert "robot_obs must be a dict" in outputs[1].error
+    # The valid request still runs through the single-observation path.
+    assert len(FakeGr00tPolicy.instances[0].calls) == 1
+
+
+def test_forward_wave_serves_dummy_and_real_requests():
+    pipeline = _pipeline()
+    dummy = OmniDiffusionRequest(
+        prompt="dummy run",
+        request_id="dummy_req_id",
+        sampling_params=OmniDiffusionSamplingParams(num_inference_steps=1),
+    )
+    batch = DiffusionRequestBatch(requests=[dummy, _robot_request("req-a", marker=4.0)])
+
+    outputs = pipeline.forward(batch)
+
+    dummy_actions = outputs[0].output["actions"]
+    assert dummy_actions["arm"].shape == (1, 2, 2)
+    assert not dummy_actions["arm"].any()
+    np.testing.assert_allclose(outputs[1].output["actions"]["arm"], np.full((1, 2, 2), 4.0, dtype=np.float32))
+
+
+def test_forward_wave_survives_garbage_modality():
+    pipeline = _pipeline()
+    garbage = OmniDiffusionRequest(
+        prompt="pick",
+        request_id="req-garbage",
+        sampling_params=OmniDiffusionSamplingParams(
+            extra_args={
+                "robot_obs": {
+                    "images": {"cam": np.zeros((1, 1, 8, 8, 3), dtype=np.uint8)},
+                    "state": 5,
+                    "prompt": "pick",
+                }
+            }
+        ),
+    )
+    batch = DiffusionRequestBatch(requests=[_robot_request("req-a", marker=6.0), garbage])
+
+    outputs = pipeline.forward(batch)
+
+    assert outputs[0].error is None
+    np.testing.assert_allclose(outputs[0].output["actions"]["arm"], np.full((1, 2, 2), 6.0, dtype=np.float32))
+    assert "GR00T policy inference failed" in outputs[1].error
+
+
+def test_forward_wave_falls_back_on_incompatible_observations():
+    pipeline = _pipeline()
+    batch = DiffusionRequestBatch(
+        requests=[
+            _robot_request("req-a", marker=1.0, side=8),
+            _robot_request("req-b", marker=2.0, side=4),
+        ]
+    )
+
+    outputs = pipeline.forward(batch)
+
+    # Video shapes cannot be concatenated, so each request gets its own call.
+    assert len(FakeGr00tPolicy.instances[0].calls) == 2
+    assert [output.error for output in outputs] == [None, None]
+    np.testing.assert_allclose(outputs[0].output["actions"]["arm"], np.ones((1, 2, 2), dtype=np.float32))
+    np.testing.assert_allclose(outputs[1].output["actions"]["arm"], np.full((1, 2, 2), 2.0, dtype=np.float32))
 
 
 def test_dummy_warmup_returns_shape_correct_zero_actions():
@@ -123,15 +245,16 @@ def test_dummy_warmup_returns_shape_correct_zero_actions():
         sampling_params=OmniDiffusionSamplingParams(num_inference_steps=1),
     )
 
-    output = pipeline.forward(req)
+    outputs = pipeline.forward(DiffusionRequestBatch(requests=[req]))
 
-    assert output.error is None
-    actions = output.output["actions"]
+    assert len(outputs) == 1
+    assert outputs[0].error is None
+    actions = outputs[0].output["actions"]
     assert set(actions) == {"arm", "gripper"}
     assert actions["arm"].shape == (1, 2, 2)
     assert actions["gripper"].shape == (1, 2, 1)
     assert not actions["arm"].any()
-    assert FakeGr00tPolicy.instances[0].seen_obs is None
+    assert FakeGr00tPolicy.instances[0].calls == []
 
 
 def test_reset_delegates_to_policy():

--- a/tests/engine/test_async_omni_engine_stage_init.py
+++ b/tests/engine/test_async_omni_engine_stage_init.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 import concurrent.futures
 import contextlib
 import importlib
@@ -511,6 +514,39 @@ def test_initialize_diffusion_stage_applies_client_batch_size_to_engine(monkeypa
         "batch_size": 4,
         "use_inline": True,
     }
+
+
+def test_initialize_diffusion_stage_default_batch_size_keeps_yaml_max_num_seqs(monkeypatch):
+    """The default batch_size (1) must not clobber the deploy YAML's max_num_seqs.
+
+    Online serving never passes diffusion_batch_size, so the stage YAML is its
+    only way to enable request batching.
+    """
+    import vllm_omni.diffusion.stage_diffusion_client as client_mod
+    import vllm_omni.engine.stage_init_utils as init_mod
+
+    od_config = types.SimpleNamespace(max_num_seqs=8)
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(init_mod, "build_diffusion_config", lambda *args: od_config)
+
+    def _capture_client(model, config, metadata, stage_init_timeout, batch_size, use_inline):
+        captured.update(batch_size=batch_size)
+        return object()
+
+    monkeypatch.setattr(client_mod, "create_diffusion_client", _capture_client)
+
+    init_mod.initialize_diffusion_stage(
+        0,
+        "dummy-model",
+        types.SimpleNamespace(),
+        _make_diffusion_metadata(0),
+        stage_init_timeout=12,
+        batch_size=1,
+        use_inline=True,
+    )
+
+    assert od_config.max_num_seqs == 8
+    assert captured["batch_size"] == 8
 
 
 def test_launch_diffusion_stage_replica_applies_batch_size_to_config(monkeypatch):

--- a/vllm_omni/deploy/Gr00tN1d7.yaml
+++ b/vllm_omni/deploy/Gr00tN1d7.yaml
@@ -10,6 +10,10 @@ async_chunk: false
 
 stages:
   - stage_id: 0
+    # Kept at 1 so the default deployment serves one request at a time.
+    # Gr00tN1d7Pipeline supports request-level batching, so raising this in an
+    # overlay lets concurrent OpenPI sessions share one policy forward.
+    # Opt-in instructions are in recipes/NVIDIA/GR00T-N1.7.md.
     max_num_seqs: 1
     enforce_eager: true
     model_class_name: Gr00tN1d7Pipeline

--- a/vllm_omni/diffusion/models/gr00t/pipeline_gr00t.py
+++ b/vllm_omni/diffusion/models/gr00t/pipeline_gr00t.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from collections.abc import Iterable, Mapping
 from typing import Any
@@ -11,7 +11,6 @@ from vllm.logger import init_logger
 
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.models.gr00t.policy import Gr00tPolicy
-from vllm_omni.diffusion.request import DUMMY_DIFFUSION_REQUEST_ID
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 
 logger = init_logger(__name__)
@@ -31,6 +30,13 @@ class Gr00tN1d7Pipeline(nn.Module):
     `sampling_params.extra_args["robot_obs"]`, this pipeline runs GR00T policy
     inference, and actions are returned through `DiffusionOutput.output["actions"]`.
     """
+
+    # forward() consumes the whole DiffusionRequestBatch: per-request
+    # observations are concatenated along the batch axis and served by one
+    # Gr00tPolicy.get_action() call. The scheduler only builds waves larger
+    # than one request when the stage's max_num_seqs allows it, so the
+    # bundled deploy config (max_num_seqs: 1) keeps one-request waves.
+    supports_request_batch = True
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = "") -> None:
         super().__init__()
@@ -108,21 +114,88 @@ class Gr00tN1d7Pipeline(nn.Module):
         return actions
 
     @torch.inference_mode()
-    def forward(self, req: DiffusionRequestBatch, **kwargs) -> DiffusionOutput:
+    def forward(self, req: DiffusionRequestBatch, **kwargs) -> list[DiffusionOutput]:
+        """Run one policy inference for every request in the wave.
+
+        Returns one DiffusionOutput per request, in ``req.requests`` order.
+        Malformed requests fail individually; they never take the rest of the
+        wave down with them. ``reset`` is honoured before inference — the
+        policy is process-wide, so a reset requested by any session applies to
+        all of them (Gr00tPolicy.reset() is stateless today, see reset()).
+        """
         del kwargs
-        extra_args = req.sampling_params.extra_args or {}
-        robot_obs = extra_args.get("robot_obs")
-        if robot_obs is None:
-            if req.request_id == DUMMY_DIFFUSION_REQUEST_ID:
-                return DiffusionOutput(output={"actions": self._dummy_actions()})
-            return DiffusionOutput(error="Gr00tN1d7Pipeline.forward expects sampling_params.extra_args['robot_obs'].")
-        if not isinstance(robot_obs, Mapping):
-            return DiffusionOutput(error=f"robot_obs must be a dict, got {type(robot_obs).__name__}.")
+        outputs: list[DiffusionOutput | None] = [None] * req.num_reqs
+        pending: list[tuple[int, dict[str, Any]]] = []
 
-        if extra_args.get("reset"):
-            self.reset()
+        for idx, request in enumerate(req.requests):
+            extra_args = request.sampling_params.extra_args or {}
+            robot_obs = extra_args.get("robot_obs")
+            if robot_obs is None:
+                if request.is_dummy_run_request_id(request.request_id):
+                    outputs[idx] = DiffusionOutput(output={"actions": self._dummy_actions()})
+                else:
+                    outputs[idx] = DiffusionOutput(
+                        error="Gr00tN1d7Pipeline.forward expects sampling_params.extra_args['robot_obs']."
+                    )
+                continue
+            if not isinstance(robot_obs, Mapping):
+                outputs[idx] = DiffusionOutput(error=f"robot_obs must be a dict, got {type(robot_obs).__name__}.")
+                continue
+            if extra_args.get("reset"):
+                self.reset()
+            pending.append((idx, _normalize_observation(robot_obs, language_key=self.policy.language_key)))
 
-        policy_obs = _normalize_observation(robot_obs, language_key=self.policy.language_key)
+        if pending:
+            policy_outputs = self._policy_outputs([obs for _, obs in pending])
+            for (idx, _), output in zip(pending, policy_outputs):
+                outputs[idx] = output
+
+        assert all(output is not None for output in outputs)
+        return outputs  # type: ignore[return-value]
+
+    def _policy_outputs(self, obs_list: list[dict[str, Any]]) -> list[DiffusionOutput]:
+        """Serve normalized observations, batched into one policy call when possible.
+
+        A single observation takes the direct path, byte-for-byte the previous
+        single-request behavior (exceptions propagate to the runner). Multiple
+        observations are concatenated along the batch axis for one
+        ``get_action`` call; if they are not structurally compatible, or the
+        batched call fails, each observation falls back to its own call so a
+        poisoned request only fails itself.
+        """
+        if len(obs_list) == 1:
+            return [self._forward_one(obs_list[0])]
+
+        merged = _merge_observations(obs_list)
+        if merged is not None:
+            batched_obs, sizes = merged
+            logger.debug("GR00T request batch: %d observations in one policy call.", len(obs_list))
+            try:
+                result = self.policy.get_action(batched_obs)
+                actions = result[0] if isinstance(result, tuple) else result
+                if isinstance(actions, Mapping):
+                    per_request = _split_actions(_to_float32_action_dict(actions), sizes)
+                    return [DiffusionOutput(output={"actions": actions_i}) for actions_i in per_request]
+                logger.warning(
+                    "GR00T batched get_action returned %s; falling back to per-request inference.",
+                    type(actions).__name__,
+                )
+            except Exception:
+                logger.warning(
+                    "GR00T batched get_action failed for %d observations; falling back to per-request inference.",
+                    len(obs_list),
+                    exc_info=True,
+                )
+
+        outputs = []
+        for obs in obs_list:
+            try:
+                outputs.append(self._forward_one(obs))
+            except Exception as exc:
+                outputs.append(DiffusionOutput(error=f"GR00T policy inference failed: {exc}"))
+        return outputs
+
+    def _forward_one(self, policy_obs: dict[str, Any]) -> DiffusionOutput:
         result = self.policy.get_action(policy_obs)
         actions = result[0] if isinstance(result, tuple) else result
         if not isinstance(actions, Mapping):
@@ -130,6 +203,69 @@ class Gr00tN1d7Pipeline(nn.Module):
         # Return actions via output.output (like the DreamZero OpenPI policy) so the engine's
         # empty-output guard passes.
         return DiffusionOutput(output={"actions": _to_float32_action_dict(actions)})
+
+
+def _merge_observations(
+    obs_list: list[dict[str, Any]],
+) -> tuple[dict[str, Any], list[int]] | None:
+    """Concatenate normalized observations along the batch axis.
+
+    Mirrors ``Gr00tPolicy._unbatch_observation``: every array modality carries
+    a leading batch dimension, language is a per-sample list. Returns the
+    merged observation and each observation's batch size, or ``None`` when the
+    observations are not structurally compatible (different modality or
+    per-modality keys, missing video, mismatched trailing shapes) — the caller
+    then serves each observation individually.
+    """
+    try:
+        first = obs_list[0]
+        if any(set(obs) != set(first) for obs in obs_list[1:]):
+            return None
+        for modality in first:
+            if not all(isinstance(obs[modality], Mapping) for obs in obs_list):
+                return None
+            if any(set(obs[modality]) != set(first[modality]) for obs in obs_list[1:]):
+                return None
+
+        sizes: list[int] = []
+        for obs in obs_list:
+            video = obs.get("video")
+            if not isinstance(video, Mapping) or not video:
+                return None
+            sizes.append(len(next(iter(video.values()))))
+
+        merged: dict[str, Any] = {}
+        for modality, first_value in first.items():
+            if modality == "language":
+                merged[modality] = {
+                    key: [sample for obs in obs_list for sample in obs[modality][key]] for key in first_value
+                }
+                continue
+            merged[modality] = {
+                key: np.concatenate([np.asarray(obs[modality][key]) for obs in obs_list], axis=0) for key in first_value
+            }
+    except (TypeError, ValueError):
+        # Malformed or mismatched observations must not take the wave down;
+        # the per-observation fallback surfaces the error on the culprit only.
+        return None
+    return merged, sizes
+
+
+def _split_actions(actions: dict[str, np.ndarray], sizes: list[int]) -> list[dict[str, np.ndarray]]:
+    """Slice a batched action dict back into per-request action dicts."""
+    total = sum(sizes)
+    for key, value in actions.items():
+        if value.shape[0] != total:
+            raise RuntimeError(
+                f"GR00T policy returned action '{key}' with batch size {value.shape[0]} "
+                f"for a request batch of total size {total}."
+            )
+    per_request: list[dict[str, np.ndarray]] = []
+    offset = 0
+    for size in sizes:
+        per_request.append({key: value[offset : offset + size] for key, value in actions.items()})
+        offset += size
+    return per_request
 
 
 def _normalize_observation(robot_obs: Mapping[str, Any], *, language_key: str) -> dict[str, Any]:

--- a/vllm_omni/engine/stage_engine_startup.py
+++ b/vllm_omni/engine/stage_engine_startup.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 """Helpers for launching and handshaking omni engine cores."""
 
 from __future__ import annotations
@@ -1558,7 +1561,10 @@ def launch_diffusion_stage_replica(
     from vllm_omni.diffusion.stage_diffusion_client import StageDiffusionClient
 
     od_config = build_diffusion_config(model, stage_config, metadata)
-    od_config.max_num_seqs = batch_size
+    # See initialize_diffusion_stage: the default batch_size (1) must not
+    # clobber a max_num_seqs configured in the stage's deploy YAML.
+    if batch_size > 1:
+        od_config.max_num_seqs = batch_size
     parallel_config = getattr(od_config, "parallel_config", None)
     world_size = getattr(parallel_config, "world_size", 1)
     try:

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 """
 Stage initialization helpers for vLLM-Omni multi-stage runtime.
 
@@ -1514,8 +1517,13 @@ def initialize_diffusion_stage(
     from vllm_omni.diffusion.stage_diffusion_client import create_diffusion_client
 
     od_config = build_diffusion_config(model, stage_cfg, metadata)
-    od_config.max_num_seqs = batch_size
-    return create_diffusion_client(model, od_config, metadata, stage_init_timeout, batch_size, use_inline)
+    # An explicit AsyncOmni-level diffusion_batch_size wins, but its default
+    # (1) must not clobber a max_num_seqs configured in the stage's deploy
+    # YAML: online serving has no way to pass diffusion_batch_size, so the
+    # YAML value is the only batching knob it has.
+    if batch_size > 1:
+        od_config.max_num_seqs = batch_size
+    return create_diffusion_client(model, od_config, metadata, stage_init_timeout, od_config.max_num_seqs, use_inline)
 
 
 def _stage_declares_cfg_pairs(model_config: Any) -> bool:


### PR DESCRIPTION
## Purpose

GR00T serving handles exactly one request at a time. `Gr00tN1d7Pipeline` never implemented the request-batch contract, so `max_num_seqs` is pinned to 1 and N connected robots just queue behind each other: throughput stays at ~6.6 req/s while latency grows linearly with N. The policy underneath doesn't have this limitation — `Gr00tPolicy.get_action` was written for batched `(B, ...)` observations from the start (unbatch, per-sample preprocess, collate, one model forward). This PR connects the two.

`forward()` now takes the whole scheduler wave, concatenates the observations along the batch axis, runs one `get_action()` call, and splits the actions back per request. Declaring `supports_request_batch = True` lets the engine accept `max_num_seqs > 1`. The bundled YAML keeps `max_num_seqs: 1`, so the default deployment is unchanged; opting in is an overlay:

```yaml
base_config: vllm_omni/deploy/Gr00tN1d7.yaml
stages:
  - stage_id: 0
    max_num_seqs: 8
```

A malformed request in a wave fails alone instead of failing its neighbors, observations that cannot be concatenated (mismatched shapes) fall back to per-request calls, and a single-request wave takes the exact old code path.

The first commit fixes a plumbing problem the overlay would otherwise hit: since #5676, stage init overwrites the YAML's `max_num_seqs` with `diffusion_batch_size` (default 1), and `vllm serve --omni` has no way to set `diffusion_batch_size`, so the overlay reaches the engine as `max_num_seqs=1`. The fix is two guarded lines plus a regression test. I'm aware #6405 and #6484 touch the same area — happy to drop that commit and rebase on whichever lands first; the GR00T commit stands on its own.

## Test Plan

**vLLM Version:** 0.26.0+cu129

**vLLM-Omni Commit:** based on `0e4b28f4`

1xA30, DP=1, eager, closed-loop OpenPI WebSocket clients, 30 requests/client after 20 warmup, `GR00T_NOISE_SEED=42`. Actions were checked against the reference values in `tests/e2e/online_serving/test_gr00t_openpi_expansion.py` (atol 1e-2) before each sweep. Unit tests: `tests/diffusion/models/gr00t/test_pipeline.py`, `tests/engine/test_async_omni_engine_stage_init.py`.

Because batching changes what actually runs on the GPU, I also checked at the policy level (real checkpoint) that a request's actions do not depend on its batch neighbors: swap one observation's neighbor for a completely different one (images, state, prompt length) and the fixed row's actions come back bit-identical. Solo vs batched differs by up to 5.5e-2 in bf16 and by 1.0e-5 when the same comparison is re-run in fp32 — batch-size-dependent kernel rounding amplified by the 4 denoise steps, not a masking bug. For scale, one noise-seed step (42 to 43) moves the same actions by 7.9e-1.

## Test Result

Bundled YAML on this branch: reference check passes (eef_9d 3.9e-3, gripper 3.9e-3, joint 7.5e-3) and the sweep reproduces main's serial behavior:

```
clients:      1      2      4      8
req/s:      6.56   6.68   6.71   6.77
mean ms:  152.3  296.9  589.2 1164.5
```

With the overlay (`max_num_seqs: 8`), reference check still passes on a single session, and:

```
clients:      1      2      4      8
req/s:      6.76   6.94  10.89  13.84
mean ms:  148.0  285.9  365.5  575.8
```

At 8 clients that is 2.0x the throughput at half the mean latency. A separate debug-logging run under the same 8-client load shows waves of 7 observations dominating (10 of 14 batched waves). Policy-level ceiling for reference: 6.97 obs/s at B=1, 16.74 obs/s at B=8.

## Notes

- Waves only form from requests that queued while a forward was running (`request_batch_max_wait_ms` defaults to 0), so a single robot's latency is untouched — and two closed-loop clients still ping-pong at wave size 1, which is why the gain only shows from 4 clients up.
- With a fixed `GR00T_NOISE_SEED`, CUDA's seeded `randn((B, ...))` does not reproduce the `(1, ...)` draw row by row, so bit-exact reproducibility holds per wave shape, not across load levels. Production serving runs unseeded. The CI golden test runs one session (wave size 1) and is unaffected.
- If this and #6450 both land, the compile path's `dynamic=False` would recompile per distinct wave size; whichever lands second should switch batched deployments to `dynamic=None`. The recipe keeps the two opt-ins separate for now.
