### PR TITLE
[CI] Resume AR admission after sleep-mode wake

### DIFF
--- a/tests/entrypoints/test_omni_sleep_mode.py
+++ b/tests/entrypoints/test_omni_sleep_mode.py
@@ -371,6 +371,8 @@ class TestOmniDiffusionSleepMode:
             # --- wake + VRAM restore to initial (±3 GiB) ---
             logger.info("Waking up (Reloading Weights)...")
             await diffusion_engine.wake_up(stage_ids=[0])
+            # AR stages keep the frontend admission gate held after wake.
+            await diffusion_engine.resume_generation(stage_ids=[0])
             await asyncio.sleep(2.0)
             gc.collect()
             get_vram_info(device_id)


### PR DESCRIPTION
## Summary

- Resume AR admission after waking stage 0 in the shared BAGEL sleep/wake entrypoint test.
- Prevent the post-wake generate call from blocking indefinitely.

## Root cause

After the AR-stage sleep/wake contract change, `wake_up()` restores the engine but intentionally keeps the frontend admission gate paused until `resume_generation()`. The test called `wake_up()` and then `generate()` without resuming admission, causing the H100 jobs in [Build 14034](https://buildkite.com/vllm/vllm-omni/builds/14034/canvas?sid=01a033db-d0f6-49d8-bb19-d217302e4cdd&tab=output) and [Build 14038](https://buildkite.com/vllm/vllm-omni/builds/14038/canvas?sid=01a033e6-bf53-47b1-b3c2-9f39bec490b6&tab=output) to time out.

## Test results

`pytest -q -o addopts='' tests/entrypoints/test_async_omni_pause_sleep_routing.py`

```
13 passed, 17 warnings in 8.56s
```

`ruff check tests/entrypoints/test_omni_sleep_mode.py`

```
All checks passed!
```

`pytest -q -o addopts='' tests/entrypoints/test_omni_sleep_mode.py --collect-only`

```
10 tests collected in 4.42s
```

The H100 E2E test was not run locally; it requires reserved GPU CI infrastructure.