### PR TITLE
[Bugfix] Fix OmniRequestOutput iteration in the MOSS-TTS-Nano offline example

### DIFF
--- a/examples/offline_inference/text_to_speech/moss_tts_nano/end2end.py
+++ b/examples/offline_inference/text_to_speech/moss_tts_nano/end2end.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Offline inference example for MOSS-TTS-Nano via vLLM-Omni.
 
 Single-stage pipeline: the 0.1B AR LM and MOSS-Audio-Tokenizer-Nano codec
@@ -136,21 +136,20 @@ def main(args) -> None:
     )
     params_list = sampling_params
 
-    for stage_outputs in omni.generate(inputs, params_list):
-        for i, req_output in enumerate(stage_outputs):
-            for j, out in enumerate(req_output.outputs):
-                mm = out.multimodal_output
-                if mm is None:
-                    print(f"  [req {i}] No audio output.")
-                    continue
-                audio = mm.get("audio")
-                sr_tensor = mm.get("sr")
-                if audio is None:
-                    print(f"  [req {i}] No waveform in multimodal_output.")
-                    continue
-                sr = int(sr_tensor.item()) if sr_tensor is not None else 48000
-                out_path = str(output_dir / f"output_{i}_{j}.wav")
-                save_audio(audio.cpu(), out_path, sr)
+    for i, req_output in enumerate(omni.generate(inputs, params_list)):
+        for j, out in enumerate(req_output.outputs):
+            mm = out.multimodal_output
+            if mm is None:
+                print(f"  [req {i}] No audio output.")
+                continue
+            audio = mm.get("audio")
+            sr_tensor = mm.get("sr")
+            if audio is None:
+                print(f"  [req {i}] No waveform in multimodal_output.")
+                continue
+            sr = int(sr_tensor.item()) if sr_tensor is not None else 48000
+            out_path = str(output_dir / f"output_{i}_{j}.wav")
+            save_audio(audio.cpu(), out_path, sr)
 
     print("Done.")
 


### PR DESCRIPTION
## Purpose

Fixes #6479.

**What broke.** The MOSS-TTS-Nano offline example cannot produce audio at all. It
fails on the first yielded output with:

```
TypeError: 'OmniRequestOutput' object is not iterable
```

**Root cause.** `examples/offline_inference/text_to_speech/moss_tts_nano/end2end.py`
treated each item yielded by `Omni.generate` as a *sequence* of request outputs:

```python
for stage_outputs in omni.generate(inputs, params_list):
    for i, req_output in enumerate(stage_outputs):   # <-- TypeError
        for j, out in enumerate(req_output.outputs):
```

`Omni.generate` is annotated
`Generator[OmniRequestOutput, None, None] | list[OmniRequestOutput]`
(`vllm_omni/entrypoints/omni.py:78`), so each item it yields is already a single
`OmniRequestOutput`. That class is a dataclass over vLLM's `RequestOutput`
(`vllm_omni/outputs/__init__.py:108`) and defines neither `__iter__` nor
`__getitem__` (per the issue report, the same holds for `RequestOutput`), so the
inner `enumerate` raises.

**The fix.** Drop the middle loop and enumerate the call directly. This is the
same shape `examples/offline_inference/text_to_speech/gepard/end2end.py:89-90`
already uses, down to the `i`/`j` indices and the `[req {i}]` messages, and it is
the fix suggested in the issue. The existing `output_{i}_{j}.wav` naming is
unchanged.

On the meaning of `i`: it counts yields rather than requests, since
`_run_generation` interleaves active requests and yields once per final-output
stage. For this example that is exactly one yield, because the MOSS-TTS-Nano
pipeline declares a single `final_output=True` stage
(`vllm_omni/model_executor/models/moss_tts_nano/pipeline.py:19-40`), the example
submits one request, and non-diffusion stages are forced to `FINAL_ONLY`. So `i`
is always `0` here and no extra files appear. I kept the index rather than
switching to `request_id` so the diff stays minimal and matches gepard; happy to
move to `request_id` if you would rather these examples converge on that.

**Second hunk.** The SPDX copyright line is changed from `vLLM project` to
`vLLM-Omni project`. That is not a drive-by edit: `tools/pre_commit/check_spdx_header.py`
treats the vLLM line as `LEGACY_COPYRIGHT_TEXT` and rewrites it, exiting non-zero,
for any file it runs on. It ran because this file is in the diff.

## Test Plan

**vLLM Version:** not applicable. The defect is in example control flow, not in
any vLLM runtime path, and the fix changes no vLLM interaction.

**vLLM-Omni Commit:** `678aa258`

I do not have the MOSS-TTS-Nano weights or a GPU, so I have not generated audio
end to end. Everything below is what I did verify, and I would appreciate someone
with the model running the example once to confirm the audio path.

1. Confirmed the defect is still present on `678aa258` (lines 139-141 before this
   change).
2. Confirmed `Omni.generate` yields `OmniRequestOutput` directly, from the
   overload signatures in `vllm_omni/entrypoints/omni.py`.
3. Confirmed `OmniRequestOutput` defines neither `__iter__` nor `__getitem__`.
4. Grepped every call site under `examples/` for the same nested-`enumerate`
   shape; after this change there are none left.
5. Reproduced the exact `TypeError` with a standalone script that mirrors the real
   class shape, so it runs without weights or a GPU:

```python
from dataclasses import dataclass, field

class RequestOutput:  # stand-in for vllm.outputs.RequestOutput
    pass

@dataclass
class CompletionOutput:
    multimodal_output: dict | None = None

@dataclass
class OmniRequestOutput(RequestOutput):
    request_id: str = ""
    outputs: list = field(default_factory=list)

def generate():  # Generator[OmniRequestOutput, None, None]
    yield OmniRequestOutput("req-0", [CompletionOutput({"audio": 1, "sr": 48000})])

# before
for stage_outputs in generate():
    for i, req_output in enumerate(stage_outputs):
        for j, out in enumerate(req_output.outputs):
            print("saved", i, j)

# after
for i, req_output in enumerate(generate()):
    for j, out in enumerate(req_output.outputs):
        print(f"would write output_{i}_{j}.wav")
```

6. Ran the local gates on the changed file: `ruff-check`, `ruff-format`,
   `check-spdx-header`, `typos`, `debug-statements`, `trailing-whitespace`,
   `end-of-file-fixer`.
7. Ran the `precheck-pr` skill checks. Examples policy passes: this modifies an
   existing example and introduces no new Python example file
   (`git diff --diff-filter=ACR -- 'examples/**/*.py'` is empty).

No `tests/` file is included because examples are not covered by the test suite.
If you would like a regression test for the output-iteration contract, say where
it belongs and I will add it.

## Test Result

```
OmniRequestOutput __iter__: False | __getitem__: False

--- current example code
TypeError: 'OmniRequestOutput' object is not iterable

--- after the fix
would write output_0_0.wav
```

Pre-commit gates on the changed file (SPDX shown on re-run, after the hook
rewrote the legacy copyright line):

```
ruff check...............................................................Passed
ruff format..............................................................Passed
Check SPDX headers.......................................................Passed
typos....................................................................Passed
debug statements (python)................................................Passed
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
```
