### PR TITLE
[WIP][Bugfix] Fix diffusion INT8 tensor-parallel scales and enable ROCm

### DIFF
--- a/docs/user_guide/quantization/int8.md
+++ b/docs/user_guide/quantization/int8.md
@@ -2,16 +2,14 @@
 
 ## Overview
 
-Int8 quantization supports W8A8 diffusion transformer inference on CUDA and
-Ascend NPU. It can quantize BF16/FP16 weights at load time, or load serialized
-Int8 checkpoints that already contain quantized weights and scales.
+Int8 quantization supports W8A8 diffusion transformer inference on CUDA and Ascend NPU. ROCm is wired to the same upstream vLLM path as CUDA, but it is not yet verified on AMD hardware. Int8 can quantize BF16/FP16 weights at load time, or load serialized Int8 checkpoints that already contain quantized weights and scales.
 
 Only online activation scaling is currently supported.
 
 ## Hardware Support
 
 | Device | Support |
-|--------|---------|
+| -------- | --------- |
 | NVIDIA Blackwell GPU (SM 100+) | ✅ |
 | NVIDIA Ada/Hopper GPU (SM 89+) | ✅ |
 | NVIDIA Ampere GPU (SM 80+) | ✅ |
@@ -27,7 +25,7 @@ guide.
 ### Diffusion Model (Qwen-Image, Wan2.2)
 
 | Model | HF models | CUDA | Ascend NPU | Mode | Recommendation |
-|-------|-----------|:----:|:----------:|------|----------------|
+| ------- | ----------- | :----: | :----------: | ------ | ---------------- |
 | Qwen-Image | `Qwen/Qwen-Image`, `Qwen/Qwen-Image-2512` | Yes | Yes | Online W8A8 | All layers |
 | Wan2.2 | Wan2.2 diffusion pipelines | Not validated | Not validated | Online W8A8 | Validate before enabling in docs |
 | Z-Image | `Tongyi-MAI/Z-Image-Turbo` | Yes | Yes | Online W8A8 | All layers |
@@ -37,16 +35,16 @@ layers, but they are not validated in this guide.
 
 ### Multi-Stage Omni/TTS Model (Qwen3-Omni, Qwen3-TTS)
 
-| Model | Scope | Status | Notes |
-|-------|-------|--------|-------|
+| Model      | Scope                        | Status        | Notes                                                       |
+|------------|------------------------------|---------------|-------------------------------------------------------------|
 | Qwen3-Omni | Thinker language-model stage | Not validated | Prefer checkpoint-supported ModelOpt FP8 or AutoRound paths |
-| Qwen3-TTS | TTS language-model stage | Not validated | No Int8 TTS stage support is documented |
+| Qwen3-TTS  | TTS language-model stage     | Not validated | No Int8 TTS stage support is documented                     |
 
 ### Multi-Stage Diffusion Model (BAGEL, GLM-Image)
 
-| Model | Scope | Status | Notes |
-|-------|-------|--------|-------|
-| BAGEL | Stage-specific transformer or DiT module | Not validated | Requires explicit stage routing |
+| Model     | Scope                                    | Status        | Notes                                 |
+|-----------|------------------------------------------|---------------|---------------------------------------|
+| BAGEL     | Stage-specific transformer or DiT module | Not validated | Requires explicit stage routing       |
 | GLM-Image | Stage-specific transformer or DiT module | Not validated | Requires quality comparison with BF16 |
 
 ## Configuration
@@ -84,7 +82,7 @@ vllm serve <your-model> --omni --quantization int8
 ## Parameters
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
+| ----------- | ------ | --------- | ------------- |
 | `method` | str | - | Quantization method (`"int8"`) |
 | `activation_scheme` | str | `"dynamic"` | `"dynamic"` selects online activation scaling; static is not supported |
 | `ignored_layers` | list[str] | `[]` | Layer name patterns to keep in BF16/FP16 |

--- a/rocm_int8_verification/.gitignore
+++ b/rocm_int8_verification/.gitignore
@@ -1,0 +1,3 @@
+cache/
+results/
+runtime/

--- a/rocm_int8_verification/README.md
+++ b/rocm_int8_verification/README.md
@@ -1,0 +1,78 @@
+# ROCm INT8 verification
+
+Use `run_all.sh` from an AMD Docker container to verify the online INT8 changes on ROCm. The script uses the container's active `python`, so it does not require a virtual environment.
+
+The script runs the following checks:
+
+1. It confirms that PyTorch and vLLM-Omni detect ROCm and at least two GPUs.
+2. It runs the affected INT8, BitsAndBytes, MiniMax, and BAGEL test files.
+3. It checks the Triton INT8 kernel on one GPU.
+4. It checks the AITER INT8 kernel when AITER is installed or explicitly requested.
+5. It checks exact full weight and two rank sharded weight parity.
+6. It runs MiniMax with DiT TP2 and text encoder TP2.
+7. It runs BAGEL single stage image generation with TP2.
+
+## Run the checks
+
+Run the script from the repository root. Set the MiniMax FL2VA checkpoint path before starting.
+
+```bash
+VLLM_TEST_MINIMAX_H3_FL2VA_MODEL=/models/MiniMax-H3/FL2VA \
+bash rocm_int8_verification/run_all.sh
+```
+
+The script stops on the first failed check. It prints the result directory when it starts and when it exits.
+
+## AITER selection
+
+`RUN_AITER=auto` is the default. The script runs the AITER check when Python can find the `aiter` package.
+
+Use the following command when the production container must use AITER:
+
+```bash
+VLLM_TEST_MINIMAX_H3_FL2VA_MODEL=/models/MiniMax-H3/FL2VA \
+RUN_AITER=1 \
+VLLM_ROCM_USE_AITER=1 \
+VLLM_ROCM_USE_AITER_LINEAR=1 \
+bash rocm_int8_verification/run_all.sh
+```
+
+Use `RUN_AITER=0` when the container does not include AITER.
+
+## Optional settings
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `GPU_IDS` | `0,1` | Two logical AMD GPU IDs used by the tests and model runs |
+| `BAGEL_MODEL` | `ByteDance-Seed/BAGEL-7B-MoT` | BAGEL model ID or local checkpoint path |
+| `RUN_AITER` | `auto` | Run the AITER kernel check with `auto`, `1`, or `0` |
+| `ROCM_VERIFY_RUN_ID` | UTC timestamp and process ID | Name of the result directory |
+
+## Output locations
+
+The script keeps generated files under `rocm_int8_verification`:
+
+```text
+rocm_int8_verification/
+├── cache/
+│   ├── huggingface/
+│   ├── torch_extensions/
+│   ├── torchinductor/
+│   ├── triton/
+│   ├── vllm/
+│   └── xdg/
+├── runtime/
+│   └── run-<random-id>/
+└── results/
+    └── <run-id>/
+        ├── pytest-cache/
+        ├── pytest-temp/
+        ├── bagel-int8-tp2.png
+        ├── minimax-int8-tp2-output.npz
+        ├── run-all.log
+        └── step logs
+```
+
+The script sets `TMPDIR`, `TMP`, and `TEMP` to a short directory under `rocm_int8_verification/runtime`. vLLM creates Unix sockets under this path, so keeping it short avoids the 107 character Unix socket path limit. The script also passes a result directory to pytest through `--basetemp` and `cache_dir`. Model downloads, runtime files, and compiler caches stay in the verification folder.
+
+The model runs are smoke tests. A quality claim still requires a fixed seed BF16 and INT8 comparison with a recorded threshold.

--- a/rocm_int8_verification/minimax_int8_tp2.py
+++ b/rocm_int8_verification/minimax_int8_tp2.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+from vllm_omni.entrypoints.omni import Omni
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the MiniMax-H3 INT8 TP2 smoke test.")
+    parser.add_argument("--model", required=True, help="Path to the MiniMax-H3 FL2VA checkpoint.")
+    parser.add_argument("--output", type=Path, required=True, help="Path for the generated NumPy archive.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    omni = Omni(
+        model=args.model,
+        quantization_config={
+            "transformer": {"method": "int8"},
+            "text_encoder": {"method": "int8"},
+            "video_vae": None,
+            "audio_vae": None,
+        },
+        tensor_parallel_size=2,
+        text_encoder_tp_size=2,
+        trust_remote_code=True,
+        vae_use_tiling=True,
+        enforce_eager=True,
+    )
+
+    try:
+        outputs = omni.generate(
+            "A quiet cinematic night scene with matching ambient sound.",
+            OmniDiffusionSamplingParams(
+                height=256,
+                width=448,
+                num_frames=29,
+                fps=24,
+                num_inference_steps=2,
+                seed=42,
+                output_type="np",
+                extra_args={
+                    "task": "t2va",
+                    "duration": 4.0,
+                    "aspect_ratio": "16:9",
+                    "flow_shift": 12.0,
+                    "audio_flow_shift": 3.0,
+                },
+            ),
+            use_tqdm=False,
+        )
+
+        assert len(outputs) == 1
+        frames = np.asarray(outputs[0].images[0])
+        multimodal = outputs[0].multimodal_output
+        assert frames.size > 0
+        assert multimodal is not None
+        audio = np.asarray(multimodal["audio"])
+        assert audio.size > 0
+
+        np.savez_compressed(args.output, video=frames, audio=audio)
+        assert args.output.stat().st_size > 0
+
+        print("MiniMax INT8 TP2 passed")
+        print("Video shape:", frames.shape)
+        print("Audio shape:", audio.shape)
+        print("Saved:", args.output)
+    finally:
+        omni.shutdown()
+
+
+# vLLM uses multiprocessing spawn for the TP workers. The guard lets each
+# worker import this file without constructing another Omni engine.
+if __name__ == "__main__":
+    main()

--- a/rocm_int8_verification/run_all.sh
+++ b/rocm_int8_verification/run_all.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+RUN_ID="${ROCM_VERIFY_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
+RESULT_DIR="$SCRIPT_DIR/results/$RUN_ID"
+CACHE_DIR="$SCRIPT_DIR/cache"
+RUNTIME_ROOT="$SCRIPT_DIR/runtime"
+GPU_IDS="${GPU_IDS:-0,1}"
+SINGLE_GPU_ID="${GPU_IDS%%,*}"
+BAGEL_MODEL="${BAGEL_MODEL:-ByteDance-Seed/BAGEL-7B-MoT}"
+RUN_AITER="${RUN_AITER:-auto}"
+
+if [[ "$GPU_IDS" != *,* ]]; then
+    echo "GPU_IDS must contain at least two comma separated GPU IDs, for example 0,1." >&2
+    exit 2
+fi
+
+if [[ -z "${VLLM_TEST_MINIMAX_H3_FL2VA_MODEL:-}" ]]; then
+    echo "Set VLLM_TEST_MINIMAX_H3_FL2VA_MODEL to the MiniMax-H3 FL2VA checkpoint path." >&2
+    exit 2
+fi
+
+mkdir -p \
+    "$RESULT_DIR/pytest-cache" \
+    "$RESULT_DIR/pytest-temp" \
+    "$CACHE_DIR/huggingface" \
+    "$CACHE_DIR/torch_extensions" \
+    "$CACHE_DIR/torchinductor" \
+    "$CACHE_DIR/triton" \
+    "$CACHE_DIR/vllm" \
+    "$CACHE_DIR/xdg" \
+    "$RUNTIME_ROOT"
+
+# vLLM creates Unix sockets under TMPDIR. Keep the runtime path short enough
+# for the 107-character sockaddr_un limit while retaining it in this folder.
+RUNTIME_DIR="$(mktemp -d "$RUNTIME_ROOT/run-XXXXXXXX")"
+
+export ROCM_VERIFY_DIR="$RESULT_DIR"
+export PYTHONPATH="$REPO_ROOT${PYTHONPATH:+:$PYTHONPATH}"
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export HIP_VISIBLE_DEVICES="$GPU_IDS"
+export CUDA_VISIBLE_DEVICES="$GPU_IDS"
+export TMPDIR="$RUNTIME_DIR"
+export TMP="$TMPDIR"
+export TEMP="$TMPDIR"
+export HF_HOME="$CACHE_DIR/huggingface"
+export TORCH_EXTENSIONS_DIR="$CACHE_DIR/torch_extensions"
+export TORCHINDUCTOR_CACHE_DIR="$CACHE_DIR/torchinductor"
+export TRITON_CACHE_DIR="$CACHE_DIR/triton"
+export VLLM_CACHE_ROOT="$CACHE_DIR/vllm"
+export XDG_CACHE_HOME="$CACHE_DIR/xdg"
+
+cd "$REPO_ROOT"
+
+exec > >(tee -a "$RESULT_DIR/run-all.log") 2>&1
+
+finish() {
+    local status=$1
+    if [[ $status -eq 0 ]]; then
+        echo "ROCm INT8 verification passed."
+    else
+        echo "ROCm INT8 verification failed with status $status."
+    fi
+    echo "Results: $RESULT_DIR"
+    return "$status"
+}
+trap 'finish "$?"' EXIT
+
+run_logged() {
+    local name=$1
+    shift
+    echo
+    echo "Running $name"
+    "$@" 2>&1 | tee "$RESULT_DIR/$name.log"
+}
+
+run_pytest() {
+    local name=$1
+    shift
+    run_logged "$name" \
+        "$@" \
+        -o addopts='' \
+        -o "cache_dir=$RESULT_DIR/pytest-cache/$name" \
+        --basetemp="$RESULT_DIR/pytest-temp/$name" \
+        --run-level advanced_model
+}
+
+check_environment() {
+    python - <<'PY'
+import os
+import subprocess
+
+import torch
+import vllm
+import vllm_omni
+
+from vllm_omni.platforms import current_omni_platform
+
+print("PyTorch:", torch.__version__)
+print("HIP:", torch.version.hip)
+print("vLLM:", vllm.__version__)
+print("vLLM-Omni source:", vllm_omni.__file__)
+print("Git commit:", subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip())
+print("Device type:", current_omni_platform.device_type)
+print("Device count:", current_omni_platform.get_device_count())
+print("ROCm platform:", current_omni_platform.is_rocm())
+print("Verification directory:", os.environ["ROCM_VERIFY_DIR"])
+print("Python temporary directory:", os.environ["TMPDIR"])
+print("vLLM cache:", os.environ["VLLM_CACHE_ROOT"])
+
+assert torch.version.hip is not None
+assert current_omni_platform.is_rocm()
+assert current_omni_platform.get_device_count() >= 2
+assert vllm_omni.__file__.startswith(os.getcwd())
+PY
+}
+
+aiter_is_installed() {
+    python - <<'PY'
+import importlib.util
+
+raise SystemExit(0 if importlib.util.find_spec("aiter") is not None else 1)
+PY
+}
+
+run_minimax() {
+    python "$SCRIPT_DIR/minimax_int8_tp2.py" \
+        --model "$VLLM_TEST_MINIMAX_H3_FL2VA_MODEL" \
+        --output "$RESULT_DIR/minimax-int8-tp2-output.npz"
+}
+
+run_bagel() {
+    local bagel_config="$RESULT_DIR/bagel-int8-tp2.yaml"
+    cp vllm_omni/deploy/bagel_single_stage.yaml "$bagel_config"
+    sed -i 's/devices: "0"/devices: "0,1"/' "$bagel_config"
+    grep -q 'devices: "0,1"' "$bagel_config"
+
+    python examples/offline_inference/text_to_image/text_to_image.py \
+        --model "$BAGEL_MODEL" \
+        --deploy-config "$bagel_config" \
+        --quantization int8 \
+        --tensor-parallel-size 2 \
+        --enforce-eager \
+        --prompt "A futuristic city skyline at twilight" \
+        --height 512 \
+        --width 512 \
+        --num-inference-steps 2 \
+        --seed 42 \
+        --extra-body '{"timestep_shift":3.0,"cfg_text_scale":4.0,"cfg_img_scale":1.5,"cfg_interval":[0.4,1.0],"cfg_renorm_type":"global","cfg_renorm_min":0.0}' \
+        --output "$RESULT_DIR/bagel-int8-tp2.png"
+
+    test -s "$RESULT_DIR/bagel-int8-tp2.png"
+    echo "BAGEL INT8 TP2 passed"
+    echo "Saved: $RESULT_DIR/bagel-int8-tp2.png"
+}
+
+echo "Repository: $REPO_ROOT"
+echo "Results: $RESULT_DIR"
+echo "GPUs: $GPU_IDS"
+echo "MiniMax model: $VLLM_TEST_MINIMAX_H3_FL2VA_MODEL"
+echo "BAGEL model: $BAGEL_MODEL"
+echo "AITER check: $RUN_AITER"
+
+run_logged environment check_environment
+python -m pip freeze > "$RESULT_DIR/python-packages.txt"
+
+run_pytest affected-suite \
+    python -m pytest \
+    tests/diffusion/quantization/test_int8_config.py \
+    tests/diffusion/quantization/test_bitsandbytes_config.py \
+    tests/diffusion/models/minimax_h3/test_minimax_h3_quantization.py \
+    tests/diffusion/models/bagel/test_bagel_quantization.py \
+    -m core_model \
+    -vv -s -rs
+
+run_pytest triton-kernel \
+    env \
+    HIP_VISIBLE_DEVICES="$SINGLE_GPU_ID" \
+    CUDA_VISIBLE_DEVICES="$SINGLE_GPU_ID" \
+    VLLM_ROCM_USE_AITER=0 \
+    python -m pytest \
+    tests/diffusion/quantization/test_int8_config.py::TestGPUInt8Smoke \
+    -m 'core_model and rocm' \
+    -vv -s -rs
+grep -q 'Selected TritonInt8ScaledMMLinearKernel' "$RESULT_DIR/triton-kernel.log"
+
+case "$RUN_AITER" in
+    1 | true | yes)
+        run_aiter=1
+        ;;
+    0 | false | no)
+        run_aiter=0
+        ;;
+    auto)
+        if aiter_is_installed; then
+            run_aiter=1
+        else
+            run_aiter=0
+            echo "AITER is not installed, so the AITER kernel check is skipped."
+        fi
+        ;;
+    *)
+        echo "RUN_AITER must be auto, 1, or 0." >&2
+        exit 2
+        ;;
+esac
+
+if [[ $run_aiter -eq 1 ]]; then
+    run_pytest aiter-kernel \
+        env \
+        HIP_VISIBLE_DEVICES="$SINGLE_GPU_ID" \
+        CUDA_VISIBLE_DEVICES="$SINGLE_GPU_ID" \
+        VLLM_ROCM_USE_AITER=1 \
+        VLLM_ROCM_USE_AITER_LINEAR=1 \
+        python -m pytest \
+        tests/diffusion/quantization/test_int8_config.py::TestGPUInt8Smoke \
+        -m 'core_model and rocm' \
+        -vv -s -rs
+    grep -q 'Selected AiterInt8ScaledMMLinearKernel' "$RESULT_DIR/aiter-kernel.log"
+fi
+
+run_pytest two-gpu-parity \
+    env \
+    HIP_VISIBLE_DEVICES="$GPU_IDS" \
+    CUDA_VISIBLE_DEVICES="$GPU_IDS" \
+    VLLM_WORKER_MULTIPROC_METHOD=spawn \
+    python -m pytest \
+    tests/diffusion/quantization/test_int8_config.py::test_shared_quantizer_matches_native_kernel_on_two_gpus \
+    -m 'core_model and rocm' \
+    -vv -s -rs
+
+run_logged minimax-int8-tp2 run_minimax
+run_logged bagel-int8-tp2 run_bagel
+
+printf '%s\n' \
+    "ROCm INT8 verification passed." \
+    "Git commit: $(git rev-parse HEAD)" \
+    "Results: $RESULT_DIR" \
+    > "$RESULT_DIR/SUMMARY.txt"
+
+echo
+echo "Verification artifacts"
+ls -lh "$RESULT_DIR"

--- a/tests/diffusion/models/bagel/test_bagel_quantization.py
+++ b/tests/diffusion/models/bagel/test_bagel_quantization.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch.nn import Module
+from vllm.config import DeviceConfig, VllmConfig, set_current_vllm_config
+from vllm.model_executor.layers.linear import LinearBase
+
+import vllm_omni.quantization.int8_config as int8_config
+from vllm_omni.diffusion.layers.mot.mot_qkv_parallel_linear import (
+    MoTQKVParallelLinear,
+)
+from vllm_omni.diffusion.layers.mot.mot_row_parallel_linear import (
+    MoTRowParallelLinear,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.diffusion]
+
+
+def _cpu_vllm_config() -> VllmConfig:
+    return VllmConfig(device_config=DeviceConfig(device="cpu"))
+
+
+def _patch_online_int8(mocker, tp_size: int) -> int8_config.DiffusionInt8Config:
+    mocker.patch("vllm.model_executor.layers.linear.get_tensor_model_parallel_rank", return_value=0)
+    mocker.patch("vllm.model_executor.layers.linear.get_tensor_model_parallel_world_size", return_value=tp_size)
+    mocker.patch("vllm.model_executor.parameter.get_tensor_model_parallel_rank", return_value=0)
+    mocker.patch("vllm.model_executor.parameter.get_tensor_model_parallel_world_size", return_value=tp_size)
+    mocker.patch.object(int8_config.current_omni_platform, "is_cuda", return_value=True)
+    mocker.patch.object(int8_config.current_omni_platform, "is_npu", return_value=False)
+
+    kernel = mocker.Mock()
+    kernel.layer_param_names = (
+        "weight",
+        "weight_scale",
+        "input_scale",
+        "input_zero_point",
+        "azp_adj",
+    )
+    mocker.patch.object(int8_config, "init_int8_linear_kernel", return_value=kernel)
+    return int8_config.DiffusionInt8Config()
+
+
+def test_bagel_row_secondary_expert_uses_shared_full_row_scale(mocker):
+    quant_config = _patch_online_int8(mocker, tp_size=2)
+    native_quant = mocker.patch.object(int8_config.ops, "scaled_int8_quant")
+    tp_group = mocker.sentinel.tp_group
+    mocker.patch.object(
+        int8_config,
+        "get_tp_group",
+        return_value=SimpleNamespace(device_group=tp_group),
+    )
+
+    full_weight = torch.tensor(
+        [[1, -2, 8, -64], [2, -3, 7, -56]],
+        dtype=torch.bfloat16,
+    )
+    full_amax = full_weight.abs().amax(dim=1, keepdim=True).float()
+
+    def max_reduce(row_amax, op, group):
+        assert op is torch.distributed.ReduceOp.MAX
+        assert group is tp_group
+        row_amax.copy_(full_amax)
+
+    all_reduce = mocker.patch("torch.distributed.all_reduce", side_effect=max_reduce)
+
+    with set_current_vllm_config(_cpu_vllm_config()):
+        layer = MoTRowParallelLinear(
+            input_size=4,
+            output_size=2,
+            bias=False,
+            vae_bias=False,
+            quant_config=quant_config,
+            prefix="bagel.o_proj",
+        )
+
+    assert type(layer.gen_exp) is Module
+    assert not isinstance(layer.gen_exp, LinearBase)
+    assert layer.input_size == layer.gen_exp.input_size == 4
+    assert layer.input_size_per_partition == layer.gen_exp.input_size_per_partition == 2
+
+    layer.weight.weight_loader(layer.weight, full_weight)
+    layer.gen_exp.weight.weight_loader(layer.gen_exp.weight, full_weight)
+
+    inv_scale = torch.iinfo(torch.int8).max / full_amax
+    expected = full_weight.float().mul(inv_scale).round().clamp(-127, 127).to(torch.int8)
+    assert all_reduce.call_count == 2
+    native_quant.assert_not_called()
+    assert torch.equal(layer.weight.t(), expected[:, :2])
+    assert torch.equal(layer.gen_exp.weight.t(), expected[:, :2])
+    expected_scale = full_amax / torch.iinfo(torch.int8).max
+    assert torch.equal(layer.weight_scale, expected_scale)
+    assert torch.equal(layer.gen_exp.weight_scale, expected_scale)
+
+
+def test_bagel_qkv_secondary_expert_uses_native_quantization_without_reduce(mocker):
+    quant_config = _patch_online_int8(mocker, tp_size=2)
+    captured_weight = None
+    expected_qweight = torch.arange(24, dtype=torch.int8).reshape(6, 4)
+    expected_scale = torch.arange(1, 7, dtype=torch.float32).reshape(6, 1)
+
+    def native_quant(weight, scale):
+        nonlocal captured_weight
+        assert scale is None
+        captured_weight = weight.detach().clone()
+        return expected_qweight, expected_scale, None
+
+    scaled_int8_quant = mocker.patch.object(
+        int8_config.ops,
+        "scaled_int8_quant",
+        side_effect=native_quant,
+    )
+    get_tp_group = mocker.patch.object(int8_config, "get_tp_group")
+    all_reduce = mocker.patch("torch.distributed.all_reduce")
+
+    with set_current_vllm_config(_cpu_vllm_config()):
+        layer = MoTQKVParallelLinear(
+            hidden_size=4,
+            head_size=2,
+            total_num_heads=2,
+            total_num_kv_heads=2,
+            bias=False,
+            vae_bias=False,
+            quant_config=quant_config,
+            prefix="bagel.qkv_proj",
+        )
+
+    assert type(layer.gen_exp) is Module
+    assert not isinstance(layer.gen_exp, LinearBase)
+    assert layer.gen_exp.input_size == 4
+    assert layer.gen_exp.input_size_per_partition == 4
+
+    full_weight = torch.arange(48, dtype=torch.bfloat16).reshape(12, 4)
+    layer.gen_exp.weight.weight_loader(layer.gen_exp.weight, full_weight)
+
+    expected_local = torch.cat((full_weight[0:2], full_weight[4:6], full_weight[8:10]))
+    assert captured_weight is not None
+    assert torch.equal(captured_weight, expected_local)
+    scaled_int8_quant.assert_called_once()
+    get_tp_group.assert_not_called()
+    all_reduce.assert_not_called()
+    assert torch.equal(layer.gen_exp.weight, expected_qweight.t())
+    assert torch.equal(layer.gen_exp.weight_scale, expected_scale)
+
+
+def test_bagel_tp1_row_secondary_expert_keeps_full_input_dimension(mocker):
+    quant_config = _patch_online_int8(mocker, tp_size=1)
+
+    with set_current_vllm_config(_cpu_vllm_config()):
+        layer = MoTRowParallelLinear(
+            input_size=4,
+            output_size=2,
+            bias=False,
+            vae_bias=False,
+            quant_config=quant_config,
+            prefix="bagel.o_proj",
+        )
+
+    assert layer.gen_exp.input_size == 4
+    assert layer.gen_exp.input_size_per_partition == 4

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_quantization.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_quantization.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from types import SimpleNamespace
 from unittest.mock import Mock
@@ -6,6 +7,11 @@ from unittest.mock import Mock
 import pytest
 import torch
 import torch.nn as nn
+
+import vllm_omni.quantization.int8_config as int8_config
+from vllm_omni.diffusion.models.minimax_h3.encoder import (
+    MiniMaxH3Qwen3VLRowParallelLinear,
+)
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.diffusion]
 
@@ -64,6 +70,98 @@ def _small_od_config():
         tf_model_config=arch,
         parallel_config=SimpleNamespace(ulysses_degree=1),
     )
+
+
+def _make_text_encoder_int8_row(mocker, world_size):
+    mocker.patch("vllm.model_executor.parameter.get_tensor_model_parallel_rank", return_value=0)
+    mocker.patch("vllm.model_executor.parameter.get_tensor_model_parallel_world_size", return_value=1)
+    mocker.patch.object(int8_config.current_omni_platform, "is_cuda", return_value=True)
+    mocker.patch.object(int8_config.current_omni_platform, "is_npu", return_value=False)
+
+    kernel = mocker.Mock()
+    kernel.layer_param_names = (
+        "weight",
+        "weight_scale",
+        "input_scale",
+        "input_zero_point",
+        "azp_adj",
+    )
+    mocker.patch.object(int8_config, "init_int8_linear_kernel", return_value=kernel)
+
+    device_group = mocker.sentinel.minimax_text_encoder_group
+    group = SimpleNamespace(rank_in_group=0, world_size=world_size, device_group=device_group)
+    quant_config = int8_config.DiffusionInt8Config()
+
+    layer = MiniMaxH3Qwen3VLRowParallelLinear(
+        group=group,
+        input_size=4,
+        output_size=2,
+        dtype=torch.bfloat16,
+        quant_config=quant_config,
+    )
+    return layer, device_group
+
+
+def test_text_encoder_int8_scale_uses_encoder_tp_group(mocker):
+    layer, device_group = _make_text_encoder_int8_row(mocker, world_size=2)
+    full_weight = torch.tensor(
+        [[1, -2, 8, -64], [2, -3, 7, -56]],
+        dtype=torch.bfloat16,
+    )
+    full_amax = full_weight.abs().amax(dim=1, keepdim=True).float()
+    layer.weight = nn.Parameter(full_weight[:, :2], requires_grad=False)
+
+    get_tp_group = mocker.patch.object(int8_config, "get_tp_group")
+    native_quant = mocker.patch.object(int8_config.ops, "scaled_int8_quant")
+
+    def max_reduce(row_amax, op, group):
+        assert op is torch.distributed.ReduceOp.MAX
+        assert group is device_group
+        row_amax.copy_(full_amax)
+
+    all_reduce = mocker.patch("torch.distributed.all_reduce", side_effect=max_reduce)
+
+    layer.quant_method.process_weights_after_loading(layer)
+
+    assert isinstance(layer.quant_method, int8_config.Int8OnlineLinearMethod)
+    # LinearBase sees default TP disabled; the separate encoder group is TP2.
+    assert layer.tp_size == 1
+    assert layer.input_size == 4
+    assert layer.input_size_per_partition == 2
+    assert layer._int8_scale_tp_group is device_group
+    get_tp_group.assert_not_called()
+    native_quant.assert_not_called()
+    all_reduce.assert_called_once()
+
+    inv_scale = torch.iinfo(torch.int8).max / full_amax
+    expected = full_weight.float().mul(inv_scale).round().clamp(-127, 127).to(torch.int8)
+    assert torch.equal(layer.weight.t(), expected[:, :2])
+    assert torch.equal(layer.weight_scale, full_amax / torch.iinfo(torch.int8).max)
+
+
+def test_text_encoder_tp1_int8_uses_native_quantization(mocker):
+    layer, device_group = _make_text_encoder_int8_row(mocker, world_size=1)
+    weight = torch.tensor([[1, -2, 8, -64], [2, -3, 7, -56]], dtype=torch.bfloat16)
+    layer.weight = nn.Parameter(weight, requires_grad=False)
+    original_weight = layer.weight
+    qweight = torch.ones_like(weight, dtype=torch.int8)
+    weight_scale = torch.ones((weight.shape[0], 1), dtype=torch.float32)
+
+    native_quant = mocker.patch.object(
+        int8_config.ops,
+        "scaled_int8_quant",
+        return_value=(qweight, weight_scale, None),
+    )
+    get_tp_group = mocker.patch.object(int8_config, "get_tp_group")
+    all_reduce = mocker.patch("torch.distributed.all_reduce")
+
+    layer.quant_method.process_weights_after_loading(layer)
+
+    assert layer.input_size == layer.input_size_per_partition == 4
+    assert layer._int8_scale_tp_group is device_group
+    native_quant.assert_called_once_with(original_weight, scale=None)
+    get_tp_group.assert_not_called()
+    all_reduce.assert_not_called()
 
 
 def test_fp8_scope_and_prefix_propagation(monkeypatch):

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_qwen3vl_swiglu.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_qwen3vl_swiglu.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import pytest
 import torch
@@ -7,7 +10,34 @@ import torch.nn.functional as F
 
 from vllm_omni.platforms import current_omni_platform
 
-pytestmark = [pytest.mark.core_model, pytest.mark.diffusion]
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.npu]
+
+
+@pytest.mark.skipif(not current_omni_platform.is_npu(), reason="requires Ascend NPU")
+def test_qwen3_vl_npu_mlp_uses_projection_module() -> None:
+    from vllm_omni.platforms.npu.models.minimax_h3 import (
+        _forward_minimax_h3_qwen3vl_text_mlp_npu,
+    )
+
+    x = Mock()
+    gate_up = Mock()
+    activated = Mock()
+    output = Mock()
+    mlp = SimpleNamespace(
+        gate_up_proj=Mock(return_value=gate_up),
+        down_proj=Mock(return_value=output),
+    )
+
+    with patch(
+        "vllm_omni.platforms.npu.models.minimax_h3.npu_swiglu_from_packed",
+        return_value=activated,
+    ) as swiglu:
+        result = _forward_minimax_h3_qwen3vl_text_mlp_npu(mlp, x)
+
+    mlp.gate_up_proj.assert_called_once_with(x)
+    swiglu.assert_called_once_with(gate_up)
+    mlp.down_proj.assert_called_once_with(activated)
+    assert result is output
 
 
 @pytest.mark.skipif(not current_omni_platform.is_npu(), reason="requires Ascend NPU")

--- a/tests/diffusion/quantization/test_int8_config.py
+++ b/tests/diffusion/quantization/test_int8_config.py
@@ -1,13 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Unit tests for Int8 quantization config."""
+
+import os
 
 import pytest
 import torch
+import torch.distributed as dist
 from pytest_mock import MockerFixture
 from torch.nn import Module, Parameter
-from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+from vllm.model_executor.layers.linear import (
+    LinearBase,
+    UnquantizedLinearMethod,
+)
 
+import vllm_omni.quantization.int8_config as int8_config
+from tests.helpers.mark import hardware_test
 from vllm_omni.platforms import current_omni_platform
 from vllm_omni.quantization import build_quant_config
 from vllm_omni.quantization.factory import SUPPORTED_QUANTIZATION_METHODS
@@ -16,7 +24,94 @@ pytestmark = [pytest.mark.core_model, pytest.mark.diffusion]
 
 npu_available = pytest.mark.skipif(not current_omni_platform.is_npu(), reason="NPU platform not available.")
 
-cuda_available = pytest.mark.skipif(not current_omni_platform.is_cuda(), reason="GPU platform not available.")
+gpu_available = pytest.mark.skipif(
+    not (current_omni_platform.is_cuda() or current_omni_platform.is_rocm()),
+    reason="CUDA or ROCm platform not available.",
+)
+
+
+def _make_int8_layer(weight, *, input_size=None, scale_tp_group=None):
+    layer = Module()
+    layer.weight = Parameter(weight, requires_grad=False)
+    layer.input_size = weight.shape[1] if input_size is None else input_size
+    layer.input_size_per_partition = weight.shape[1]
+    if scale_tp_group is not None:
+        layer._int8_scale_tp_group = scale_tp_group
+    return layer
+
+
+def _distributed_int8_quant_worker(rank: int, init_method: str) -> None:
+    # FileStore still asks Gloo for a local interface. Use loopback so this
+    # regression does not depend on the host name being resolvable in CI.
+    os.environ["GLOO_SOCKET_IFNAME"] = "lo"
+    dist.init_process_group(
+        "gloo",
+        init_method=init_method,
+        rank=rank,
+        world_size=2,
+    )
+    try:
+        full_weight = torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 0.0],
+                [-1.3984375, 2.796875, -2.0, 1.0],
+            ],
+            dtype=torch.bfloat16,
+        )
+        local_weight = full_weight.chunk(2, dim=1)[rank].contiguous()
+        layer = _make_int8_layer(
+            local_weight,
+            input_size=full_weight.shape[1],
+            scale_tp_group=dist.group.WORLD,
+        )
+
+        qweight, scale = int8_config._quantize_input_sharded_weight(layer)
+
+        full_amax = full_weight.abs().amax(dim=1, keepdim=True).float()
+        inv_scale = torch.where(
+            full_amax == 0,
+            torch.zeros_like(full_amax),
+            torch.iinfo(torch.int8).max / full_amax,
+        )
+        expected = full_weight.float().mul(inv_scale).round().clamp(-127, 127).to(torch.int8)
+        assert torch.equal(qweight, expected.chunk(2, dim=1)[rank])
+        assert torch.equal(scale, full_amax / torch.iinfo(torch.int8).max)
+    finally:
+        dist.destroy_process_group()
+
+
+def _distributed_accelerator_int8_quant_worker(rank: int, init_method: str) -> None:
+    device = torch.device(current_omni_platform.device_type, rank)
+    current_omni_platform.set_device(device)
+    dist.init_process_group(
+        "nccl",
+        init_method=init_method,
+        rank=rank,
+        world_size=2,
+    )
+    try:
+        full_weight = torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 0.0],
+                [-1.3984375, 2.796875, -2.0, 1.0],
+            ],
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        full_qweight, full_scale, _ = int8_config.ops.scaled_int8_quant(full_weight, scale=None)
+        local_weight = full_weight.chunk(2, dim=1)[rank].contiguous()
+        layer = _make_int8_layer(
+            local_weight,
+            input_size=full_weight.shape[1],
+            scale_tp_group=dist.group.WORLD,
+        )
+
+        qweight, scale = int8_config._quantize_input_sharded_weight(layer)
+
+        assert torch.equal(qweight, full_qweight.chunk(2, dim=1)[rank])
+        assert torch.equal(scale, full_scale)
+    finally:
+        dist.destroy_process_group()
 
 
 def test_int8_config_creation():
@@ -100,9 +195,13 @@ def test_quantization_config_string_and_dict_equivalent():
     assert config_str.quantization_config.activation_scheme == config_dict.quantization_config.activation_scheme
 
 
-def test_get_quant_method(mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch):
-    """Test for get_quant_method method for GPU"""
-    from vllm_omni.quantization.int8_config import Int8OnlineLinearMethod
+@pytest.mark.parametrize("platform", ["cuda", "rocm"])
+def test_get_gpu_quant_method(mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch, platform):
+    """CUDA and ROCm share vLLM's upstream INT8 linear method."""
+    from vllm_omni.quantization.int8_config import (
+        Int8LinearMethod,
+        Int8OnlineLinearMethod,
+    )
 
     config = build_quant_config("int8")
 
@@ -111,14 +210,19 @@ def test_get_quant_method(mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
 
     layer = mocker.Mock(spec=LinearBase)
     mocker.patch.object(Int8OnlineLinearMethod, "__init__", _fake_init)
+    mocker.patch.object(Int8LinearMethod, "__init__", _fake_init)
 
     prefix = "test_layer"
 
-    # Mock the platform to be GPU
-    monkeypatch.setattr(current_omni_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(current_omni_platform, "is_cuda", lambda: platform == "cuda")
+    monkeypatch.setattr(current_omni_platform, "is_rocm", lambda: platform == "rocm")
     monkeypatch.setattr(current_omni_platform, "is_npu", lambda: False)
     method = config.get_quant_method(layer, prefix)
     assert isinstance(method, Int8OnlineLinearMethod)
+
+    config.is_checkpoint_int8_serialized = True
+    method = config.get_quant_method(layer, prefix)
+    assert isinstance(method, Int8LinearMethod)
 
     # Test skipping quantization for a layer
     config.ignored_layers = [prefix]
@@ -137,6 +241,7 @@ def test_get_npu_quant_method(mocker: MockerFixture, monkeypatch: pytest.MonkeyP
 
     # Mock the platform to be NPU
     monkeypatch.setattr(current_omni_platform, "is_cuda", lambda: False)
+    monkeypatch.setattr(current_omni_platform, "is_rocm", lambda: False)
     monkeypatch.setattr(current_omni_platform, "is_npu", lambda: True)
     method = config.get_quant_method(layer, prefix)
     assert isinstance(method, NPUInt8OnlineLinearMethod)
@@ -156,6 +261,7 @@ def test_fused_layer_can_be_ignored_by_its_prefix(monkeypatch: pytest.MonkeyPatc
     from vllm_omni.quantization.int8_config import NPUInt8OnlineLinearMethod
 
     monkeypatch.setattr(current_omni_platform, "is_cuda", lambda: False)
+    monkeypatch.setattr(current_omni_platform, "is_rocm", lambda: False)
     monkeypatch.setattr(current_omni_platform, "is_npu", lambda: True)
     config = build_quant_config("int8", ignored_layers=["blocks.0.attn.qkv_proj"])
     layer = mocker.Mock(spec=LinearBase)
@@ -280,7 +386,9 @@ class TestInt8LinearMethod:
     def mock_kernel(self, mocker):
         kernel = mocker.Mock()
         kernel.process_weights_after_loading = mocker.Mock()
-        kernel.apply_weights = mocker.Mock(return_value=torch.randn(1, 10))
+        kernel.apply_weights = mocker.Mock(
+            side_effect=lambda layer, x, bias: torch.empty(x.shape[0], 10, dtype=x.dtype)
+        )
         return kernel
 
     @pytest.fixture
@@ -310,18 +418,29 @@ class TestInt8LinearMethod:
         method.process_weights_after_loading(layer)
         patch_deps.process_weights_after_loading.assert_called_once_with(layer)
 
-    def test_apply(self, patch_deps, mock_quant_config):
+    @pytest.mark.parametrize(
+        ("input_shape", "kernel_input_shape", "output_shape"),
+        [
+            ((1, 128), (1, 128), (1, 10)),
+            ((2, 16, 128), (32, 128), (2, 16, 10)),
+        ],
+    )
+    def test_apply(self, patch_deps, mock_quant_config, input_shape, kernel_input_shape, output_shape):
         from vllm_omni.quantization.int8_config import Int8LinearMethod
 
         method = Int8LinearMethod(mock_quant_config)
         layer = Module()
-        x = torch.randn(1, 128)
-        bias = torch.randn(128)
+        x = torch.randn(input_shape)
+        bias = torch.randn(10)
 
         output = method.apply(layer, x, bias)
 
-        patch_deps.apply_weights.assert_called_once_with(layer, x, bias)
-        assert isinstance(output, torch.Tensor)
+        kernel_input = patch_deps.apply_weights.call_args.args[1]
+        assert kernel_input.shape == kernel_input_shape
+        assert patch_deps.apply_weights.call_args.args[0] is layer
+        assert patch_deps.apply_weights.call_args.args[2] is bias
+        assert output.shape == output_shape
+        assert output.dtype == x.dtype
 
 
 class TestInt8OnlineLinearMethod:
@@ -349,10 +468,199 @@ class TestInt8OnlineLinearMethod:
         from vllm_omni.quantization.int8_config import Int8OnlineLinearMethod
 
         method = Int8OnlineLinearMethod(mock_quant_config)
-        layer = Module()
-        layer.weight = Parameter(torch.randn(128, 64))
+        layer = _make_int8_layer(torch.randn(128, 64))
         method.process_weights_after_loading(layer)
         mock_deps["quant"].assert_called_once_with(layer.weight, scale=None)
+
+
+@pytest.mark.cpu
+class TestInt8OnlineTensorParallelScales:
+    @staticmethod
+    def _make_method(mocker, method_name):
+        kernel = mocker.Mock()
+        kernel.layer_param_names = ("weight", "weight_scale", "input_scale", "input_zero_point", "azp_adj")
+        mocker.patch.object(int8_config, "init_int8_linear_kernel", return_value=kernel)
+        return getattr(int8_config, method_name)(mocker.Mock())
+
+    @pytest.mark.parametrize(
+        ("input_size_per_partition", "expected"),
+        [(2, True), (4, False)],
+    )
+    def test_create_weights_records_full_and_local_input_sizes(self, mocker, input_size_per_partition, expected):
+        mocker.patch("vllm.model_executor.parameter.get_tensor_model_parallel_rank", return_value=0)
+        mocker.patch("vllm.model_executor.parameter.get_tensor_model_parallel_world_size", return_value=1)
+        layer = Module()
+        method = self._make_method(mocker, "Int8OnlineLinearMethod")
+
+        method.create_weights(
+            layer,
+            input_size_per_partition=input_size_per_partition,
+            output_partition_sizes=[2],
+            input_size=4,
+            output_size=2,
+            params_dtype=torch.bfloat16,
+            weight_loader=mocker.Mock(),
+        )
+
+        assert layer.input_size == 4
+        assert layer.input_size_per_partition == input_size_per_partition
+        assert (layer.input_size != layer.input_size_per_partition) is expected
+
+    @pytest.mark.parametrize("method_name", ["Int8OnlineLinearMethod", "NPUInt8OnlineLinearMethod"])
+    def test_bare_input_sharded_weight_matches_unsharded_quantization(self, mocker, method_name):
+        full_weight = torch.tensor(
+            [[1, -2, 8, -64], [2, -3, 7, -56]],
+            dtype=torch.bfloat16,
+        )
+        int8_max = torch.iinfo(torch.int8).max
+        full_amax = full_weight.abs().amax(dim=1, keepdim=True).float()
+        full_scale = full_amax / int8_max
+        full_inv_scale = int8_max / full_amax
+        full_qweight = full_weight.float().mul(full_inv_scale).round().clamp(-int8_max, int8_max).to(torch.int8)
+
+        # BAGEL's gen_exp is a plain Module that owns an input-sharded weight.
+        local_layer = _make_int8_layer(full_weight[:, :2], input_size=full_weight.shape[1])
+        local_amax = local_layer.weight.abs().amax(dim=1, keepdim=True).float()
+        local_scale = local_amax / int8_max
+        local_qweight = (
+            local_layer.weight.float().mul(int8_max / local_amax).round().clamp(-int8_max, int8_max).to(torch.int8)
+        )
+        if method_name == "Int8OnlineLinearMethod":
+            native_quant = mocker.patch.object(
+                int8_config.ops,
+                "scaled_int8_quant",
+                return_value=(local_qweight, local_scale, None),
+            )
+        else:
+            torch_npu = mocker.Mock()
+            native_quant = torch_npu.npu_dynamic_quant
+            native_quant.return_value = (local_qweight, local_scale.squeeze(-1))
+            mocker.patch.object(int8_config, "torch_npu", torch_npu)
+
+        tp_group = mocker.Mock()
+        tp_group.device_group = mocker.sentinel.tp_group
+        mocker.patch("vllm_omni.quantization.int8_config.get_tp_group", return_value=tp_group)
+
+        def max_reduce(row_amax, op, group):
+            assert op is torch.distributed.ReduceOp.MAX
+            assert group is tp_group.device_group
+            row_amax.copy_(full_amax)
+
+        all_reduce = mocker.patch("torch.distributed.all_reduce", side_effect=max_reduce)
+
+        method = self._make_method(mocker, method_name)
+        method.process_weights_after_loading(local_layer)
+
+        all_reduce.assert_called_once()
+        native_quant.assert_not_called()
+        assert torch.equal(local_layer.weight.t(), full_qweight[:, :2])
+        expected_scale = full_scale if method_name == "Int8OnlineLinearMethod" else full_scale.squeeze(-1)
+        assert torch.equal(local_layer.weight_scale, expected_scale)
+
+    @pytest.mark.parametrize("method_name", ["Int8OnlineLinearMethod", "NPUInt8OnlineLinearMethod"])
+    def test_input_sharded_weight_uses_explicit_group(self, mocker, method_name):
+        weight = torch.tensor([[1, -2]], dtype=torch.bfloat16)
+        scale_tp_group = mocker.sentinel.minimax_text_encoder_group
+        layer = _make_int8_layer(weight, input_size=4, scale_tp_group=scale_tp_group)
+
+        if method_name == "Int8OnlineLinearMethod":
+            native_quant = mocker.patch.object(int8_config.ops, "scaled_int8_quant")
+        else:
+            torch_npu = mocker.Mock()
+            native_quant = torch_npu.npu_dynamic_quant
+            mocker.patch.object(int8_config, "torch_npu", torch_npu)
+
+        get_tp_group = mocker.patch("vllm_omni.quantization.int8_config.get_tp_group")
+        all_reduce = mocker.patch("torch.distributed.all_reduce")
+
+        method = self._make_method(mocker, method_name)
+        method.process_weights_after_loading(layer)
+
+        get_tp_group.assert_not_called()
+        native_quant.assert_not_called()
+        all_reduce.assert_called_once()
+        assert all_reduce.call_args.kwargs["group"] is scale_tp_group
+
+    @pytest.mark.parametrize("method_name", ["Int8OnlineLinearMethod", "NPUInt8OnlineLinearMethod"])
+    def test_non_input_sharded_weight_does_not_reduce(self, mocker, method_name):
+        local_weight = torch.tensor([[1, -2, 8, -64]], dtype=torch.bfloat16)
+        layer = _make_int8_layer(local_weight)
+        qweight = torch.ones_like(local_weight, dtype=torch.int8)
+        weight_scale = torch.ones((1, 1), dtype=torch.float32)
+
+        if method_name == "Int8OnlineLinearMethod":
+            native_quant = mocker.patch.object(
+                int8_config.ops,
+                "scaled_int8_quant",
+                return_value=(qweight, weight_scale, None),
+            )
+        else:
+            weight_scale = weight_scale.squeeze(-1)
+            torch_npu = mocker.Mock()
+            native_quant = torch_npu.npu_dynamic_quant
+            native_quant.return_value = (qweight, weight_scale)
+            mocker.patch.object(int8_config, "torch_npu", torch_npu)
+
+        all_reduce = mocker.patch("torch.distributed.all_reduce")
+        method = self._make_method(mocker, method_name)
+        original_weight = layer.weight
+        method.process_weights_after_loading(layer)
+
+        if method_name == "Int8OnlineLinearMethod":
+            native_quant.assert_called_once_with(original_weight, scale=None)
+        else:
+            native_quant.assert_called_once_with(original_weight)
+        all_reduce.assert_not_called()
+
+    def test_shared_quantizer_matches_native_rounding_and_zero_row(self, mocker):
+        weight = torch.tensor(
+            [
+                [0.0, 0.0],
+                [-1.3984375, 2.796875],
+            ],
+            dtype=torch.bfloat16,
+        )
+        layer = _make_int8_layer(
+            weight,
+            input_size=4,
+            scale_tp_group=mocker.sentinel.tp_group,
+        )
+        mocker.patch("torch.distributed.all_reduce")
+
+        qweight, scale = int8_config._quantize_input_sharded_weight(layer)
+
+        assert torch.equal(
+            qweight,
+            torch.tensor([[0, 0], [-64, 127]], dtype=torch.int8),
+        )
+        assert torch.equal(
+            scale,
+            torch.tensor([[0.0], [2.796875 / 127]], dtype=torch.float32),
+        )
+
+    def test_shared_quantizer_runs_real_two_rank_collective(self, tmp_path):
+        init_method = f"file://{tmp_path / 'int8-gloo-init'}"
+        torch.multiprocessing.spawn(
+            _distributed_int8_quant_worker,
+            args=(init_method,),
+            nprocs=2,
+            join=True,
+        )
+
+
+@hardware_test(
+    res={"cuda": "L4", "rocm": "MI325"},
+    num_cards=2,
+)
+@pytest.mark.skipif(current_omni_platform.get_device_count() < 2, reason="Test requires two GPUs.")
+def test_shared_quantizer_matches_native_kernel_on_two_gpus(tmp_path):
+    init_method = f"file://{tmp_path / 'int8-accelerator-init'}"
+    torch.multiprocessing.spawn(
+        _distributed_accelerator_int8_quant_worker,
+        args=(init_method,),
+        nprocs=2,
+        join=True,
+    )
 
 
 @npu_available
@@ -432,11 +740,7 @@ class TestNPUInt8Smoke:
     @pytest.fixture
     def real_layer(self):
         """Create a real linear layer with fp16 weights on NPU"""
-        layer = torch.nn.Module()
-        layer.weight = torch.nn.Parameter(
-            torch.randn(128, 64, dtype=torch.float16, device="npu"),
-            requires_grad=False,
-        )
+        layer = _make_int8_layer(torch.randn(128, 64, dtype=torch.float16, device="npu"))
         layer.logical_widths = [128]
         layer.input_size_per_partition = 64
         layer.output_size_per_partition = 128
@@ -468,6 +772,31 @@ class TestNPUInt8Smoke:
         assert hasattr(real_layer, "weight_scale")
         assert real_layer.weight_scale.shape == (128,)
 
+    def test_real_npu_shared_quantizer_matches_dynamic_quant(self, mocker):
+        """The shared-scale arithmetic must match the vendor dynamic quantizer."""
+        import torch_npu
+
+        weight = torch.tensor(
+            [
+                [0.0, 0.0],
+                [-1.3984375, 2.796875],
+            ],
+            dtype=torch.bfloat16,
+            device="npu",
+        )
+        native_qweight, native_scale = torch_npu.npu_dynamic_quant(weight)
+        layer = _make_int8_layer(
+            weight,
+            input_size=4,
+            scale_tp_group=mocker.sentinel.npu_tp_group,
+        )
+        mocker.patch("torch.distributed.all_reduce")
+
+        qweight, scale = int8_config._quantize_input_sharded_weight(layer)
+
+        assert torch.equal(qweight, native_qweight)
+        assert torch.equal(scale.squeeze(-1), native_scale)
+
     def test_real_npu_int8_apply_forward(self, quant_config):
         """Smoke test: forward pass with real npu_quant_matmul."""
         import torch_npu
@@ -491,37 +820,34 @@ class TestNPUInt8Smoke:
         assert output.dtype == torch.float16
 
 
-@cuda_available
-class TestCudaInt8Smoke:
-    """Smoke tests using real CUDA kernels, only on CUDA"""
+@gpu_available
+@hardware_test(res={"cuda": "L4", "rocm": "MI325"})
+class TestGPUInt8Smoke:
+    """Smoke tests using real upstream INT8 kernels on CUDA or ROCm."""
 
     @pytest.fixture
     def real_layer(self):
-        """Create a real linear layer with fp16 weights on CUDA"""
-        layer = torch.nn.Module()
-        layer.weight = torch.nn.Parameter(
-            torch.randn(128, 64, dtype=torch.float16, device="cuda"),
-            requires_grad=False,
-        )
+        """Create a real linear layer with fp16 weights on the GPU."""
+        layer = _make_int8_layer(torch.randn(128, 64, dtype=torch.float16, device=current_omni_platform.device_type))
         layer.logical_widths = [128]
         layer.input_size_per_partition = 64
         layer.output_size_per_partition = 128
         layer.orig_dtype = torch.float16
         return layer
 
-    def test_real_cuda_scaled_int8_quant_shape_contract(self, quant_config):
+    def test_real_gpu_scaled_int8_quant_shape_contract(self, quant_config):
         """Smoke test: verify scaled_int8_quant returns correct shapes."""
         from vllm import _custom_ops as ops
 
-        weight = torch.randn(128, 64, dtype=torch.float16, device="cuda")
+        weight = torch.randn(128, 64, dtype=torch.float16, device=current_omni_platform.device_type)
         qweight, scale, _ = ops.scaled_int8_quant(weight, scale=None)
 
         assert qweight.shape == weight.shape
         assert qweight.dtype == torch.int8
         assert scale.shape == (weight.shape[0], 1)
 
-    def test_real_cuda_online_process_weights_after_loading(self, quant_config, real_layer):
-        """Smoke test: full process_weights_after_loading with real CUDA ops."""
+    def test_real_gpu_online_process_weights_after_loading(self, quant_config, real_layer):
+        """Smoke test: process weights with real upstream GPU ops."""
         from vllm_omni.quantization.int8_config import Int8OnlineLinearMethod
 
         method = Int8OnlineLinearMethod(quant_config)
@@ -532,8 +858,8 @@ class TestCudaInt8Smoke:
         assert real_layer.weight.dtype == torch.int8
         assert hasattr(real_layer, "weight_scale")
 
-    def test_real_cuda_int8_apply_forward(self, quant_config):
-        """Smoke test: forward pass with real CUDA int8 kernel."""
+    def test_real_gpu_int8_apply_forward(self, quant_config):
+        """Smoke test: forward pass with a real upstream GPU kernel."""
         from vllm import _custom_ops as ops
 
         from vllm_omni.quantization.int8_config import Int8LinearMethod
@@ -542,7 +868,7 @@ class TestCudaInt8Smoke:
 
         # Create layer with pre-processed weights
         layer = torch.nn.Module()
-        weight_fp16 = torch.randn(128, 64, dtype=torch.float16, device="cuda")
+        weight_fp16 = torch.randn(128, 64, dtype=torch.float16, device=current_omni_platform.device_type)
         qweight, scale, _ = ops.scaled_int8_quant(weight_fp16, scale=None)
         layer.weight = torch.nn.Parameter(qweight.t(), requires_grad=False)
         layer.weight_scale = torch.nn.Parameter(scale, requires_grad=False)
@@ -553,7 +879,7 @@ class TestCudaInt8Smoke:
         layer.azp_adj = None
 
         # Forward pass
-        x = torch.randn(2, 16, 64, dtype=torch.float16, device="cuda")
+        x = torch.randn(2, 16, 64, dtype=torch.float16, device=current_omni_platform.device_type)
         output = method.apply(layer, x)
 
         assert output.shape == (2, 16, 128)

--- a/tmp_int8_tp_pr.md
+++ b/tmp_int8_tp_pr.md
@@ -1,0 +1,132 @@
+<!-- markdownlint-disable -->
+<!-- Proposed title: [WIP][Bugfix] Fix diffusion INT8 tensor-parallel scales and enable ROCm -->
+
+Fixes #6584
+
+## Purpose
+
+Online diffusion INT8 quantized each input-sharded tensor-parallel weight independently. Each rank derived its per-output-row scale from only its local input shard, so TP2 did not use the same quantized weight representation as TP1. BAGEL also stores secondary expert weights on a plain module, and MiniMax-H3 can use a text encoder TP group that is independent from the DiT TP group.
+
+This change follows the scale-sharing design in upstream vLLM PR [#49764](https://github.com/vllm-project/vllm/pull/49764). It records the global and local input dimensions, detects input sharding from those dimensions, computes the row maximum across the correct process group, and packs each local shard with the shared row scale. Standard layers use vLLM's default TP group. MiniMax-H3 provides an override only for its independent text encoder group.
+
+ROCm now uses vLLM's existing INT8 linear kernel selection. vLLM-Omni does not add or fork a matrix multiplication kernel. The linear wrapper only flattens diffusion hidden states to the rank-2 input required by the upstream Triton and AITER kernels, then restores the original leading dimensions.
+
+The files under `rocm_int8_verification/` are a temporary test-only harness included in the draft PR so maintainers can reproduce the AMD checks. They keep model downloads, compiler caches, temporary files, and results under that folder. They are not runtime code and will be removed before the PR is marked ready for review or merged. The current draft branch is squashed to one commit with the harness included. The branch will receive one final cleanup squash after maintainers finish using it.
+
+This PR does not claim BF16 versus INT8 output-quality parity. The MiniMax-H3 and BAGEL runs are execution smoke tests. The exact quantized-weight tests cover the TP scale correctness claim.
+
+## Test Plan
+
+```bash
+python -m pytest \
+  tests/diffusion/quantization/test_int8_config.py \
+  tests/diffusion/models/minimax_h3/test_minimax_h3_quantization.py \
+  tests/diffusion/models/bagel/test_bagel_quantization.py \
+  --run-level advanced_model \
+  -m core_model
+```
+
+On a two-GPU ROCm container:
+
+```bash
+ROCM_VERIFY_RUN_ID=<run-id> \
+VLLM_TEST_MINIMAX_H3_FL2VA_MODEL="$PWD/rocm_int8_verification/models/MiniMax-H3/FL2VA" \
+RUN_AITER=1 \
+VLLM_ROCM_USE_AITER=1 \
+VLLM_ROCM_USE_AITER_LINEAR=1 \
+bash "$PWD/rocm_int8_verification/run_all.sh"
+```
+
+The `rocm_int8_verification/` command is available while the PR is in draft. After maintainers finish reproducing the results, remove that temporary folder, rerun the remaining checks, and perform the final cleanup squash without the harness.
+
+### Help requested for CUDA and NPU validation
+
+Upstream vLLM PR [#49764](https://github.com/vllm-project/vllm/pull/49764) tested the same TP-invariant packing rule by replacing the collective with the full unsharded `amax`, then checking exact packed-weight and scale equality for dense and MoE shards. The PR reports `6 passed, 16 warnings` on an NVIDIA GB200, followed by TP4 CUDA model-load and generation smoke tests. It did not report NPU validation.
+
+The equivalent vLLM-Omni CUDA checks use the real upstream INT8 kernel and a real two-process NCCL collective. Help running this exact command on two NVIDIA GPUs would be appreciated:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1 \
+python -m pytest \
+  tests/diffusion/quantization/test_int8_config.py::TestGPUInt8Smoke \
+  tests/diffusion/quantization/test_int8_config.py::test_shared_quantizer_matches_native_kernel_on_two_gpus \
+  --run-level advanced_model \
+  -m 'core_model and cuda' \
+  -vv -s -rs
+```
+
+Expected result: the three real CUDA kernel smoke tests and the two-GPU exact TP parity test pass. The parity test must not skip.
+
+The current NPU checks compare the shared quantizer with the real `torch_npu.npu_dynamic_quant` result and run a real `npu_quant_matmul` forward. Help running this exact command on an Ascend NPU would be appreciated:
+
+```bash
+ASCEND_RT_VISIBLE_DEVICES=0 \
+python -m pytest \
+  tests/diffusion/quantization/test_int8_config.py::TestNPUInt8Smoke \
+  --run-level advanced_model \
+  -m core_model \
+  -vv -s -rs
+```
+
+Expected result: all four real NPU smoke tests pass. This covers native packing equivalence and the vendor matmul, but not a real two-NPU collective. The existing two-accelerator parity worker is intentionally CUDA and ROCm only and uses NCCL. Guidance or access from an NPU maintainer is requested for an equivalent two-NPU HCCL parity run. Until that is completed, NPU TP2 remains unverified.
+
+Run the diff-scoped pre-commit hooks after the final rebase and squash:
+
+```bash
+pre-commit run --files \
+  docs/user_guide/quantization/int8.md \
+  rocm_int8_verification/.gitignore \
+  rocm_int8_verification/README.md \
+  rocm_int8_verification/minimax_int8_tp2.py \
+  rocm_int8_verification/run_all.sh \
+  tests/diffusion/models/bagel/test_bagel_quantization.py \
+  tests/diffusion/models/minimax_h3/test_minimax_h3_quantization.py \
+  tests/diffusion/quantization/test_int8_config.py \
+  vllm_omni/diffusion/models/minimax_h3/encoder.py \
+  vllm_omni/quantization/int8_config.py
+```
+
+**vLLM Version:** `0.27.0`
+
+**vLLM-Omni Commit:** `ef5324668a75400cbe2cb5cd826582eed9f3daf3`
+
+## Test Result
+
+Local targeted suite:
+
+```text
+45 passed, 8 skipped, 14 warnings in 17.85s
+```
+
+Two-GPU ROCm results with PyTorch `2.11.0+gitd0c8b1f`, HIP `7.2.53211`, vLLM `0.27.0`, and vLLM-Omni `e20bcd5231f2f8ffb10fe6e337c303305cde9118`:
+
+```text
+Affected INT8, BitsAndBytes, MiniMax-H3, and BAGEL tests:
+54 passed, 10 skipped, 14 warnings in 55.74s
+
+Triton INT8 kernel:
+3 passed, 14 warnings in 0.76s
+
+AITER INT8 kernel:
+3 passed, 14 warnings in 1.10s
+
+Two-GPU exact TP1 versus TP2 quantized-weight parity:
+1 passed, 14 warnings in 32.52s
+
+MiniMax-H3 INT8 with DiT TP2 and text encoder TP2:
+Passed and saved nonempty video and audio arrays
+
+BAGEL INT8 TP2:
+Passed in a standalone rerun and saved a nonempty PNG
+```
+
+The AMD runs were completed before the history-only rebase and squash. The contents of every file changed by this PR are identical between tested commit `e20bcd5231f2f8ffb10fe6e337c303305cde9118` and current commit `ef5324668a75400cbe2cb5cd826582eed9f3daf3`.
+
+CUDA reviewer validation: requested and pending.
+
+NPU reviewer validation: requested and pending. Real one-NPU packing and matmul tests exist; real two-NPU HCCL TP parity is not yet covered.
+
+The diff-scoped pre-commit run passed every available hook. The shellcheck hook could not run because the local machine does not have the `shellcheck` binary. This must be resolved before submission.
+
+**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
+(anything written below this line will be removed by GitHub Actions)

--- a/tmp_int8_tp_row_scale_issue.md
+++ b/tmp_int8_tp_row_scale_issue.md
@@ -1,0 +1,100 @@
+## Your current environment
+
+<details>
+<summary>The output of <code>python collect_env.py</code></summary>
+
+```text
+The full `collect_env.py` output was not saved in the AMD container. The ROCm verification runner recorded these values:
+PyTorch: 2.11.0+gitd0c8b1f
+HIP: 7.2.53211
+vLLM: 0.27.0
+vLLM-Omni commit: e20bcd5231f2f8ffb10fe6e337c303305cde9118
+ROCm platform: True
+Device count: 2
+GPU architecture: gfx942
+```
+
+</details>
+
+## Your code version
+
+<details>
+<summary>The commit id or version of vLLM</summary>
+
+```text
+v0.27.0
+```
+</details>
+
+<details>
+<summary>The commit id or version of vLLM-Omni</summary>
+
+```text
+The bug is present on current upstream main at 678aa25864334286d778fb3853b3c34f4b2ef0a6.
+The proposed fix is currently squashed at ef5324668a75400cbe2cb5cd826582eed9f3daf3.
+The AMD validation was run before the history-only rebase and squash at e20bcd5231f2f8ffb10fe6e337c303305cde9118. Every file changed by the fix has identical contents at both commits.
+```
+</details>
+
+## 🐛 Describe the bug
+
+Online diffusion INT8 has three related problems on current main.
+
+First, `DiffusionInt8Config.get_quant_method()` accepts CUDA and NPU but rejects ROCm, even though vLLM 0.27.0 provides the ROCm Triton and AITER INT8 linear kernels through `init_int8_linear_kernel()`.
+
+Second, `Int8OnlineLinearMethod.process_weights_after_loading()` calls `ops.scaled_int8_quant(layer.weight, scale=None)` independently on every tensor-parallel rank. For a row-parallel layer, each rank owns only part of the input dimension. The kernel therefore computes a different per-output-row scale from each local shard. TP2 then represents a different quantized weight and can produce different output from TP1 for reasons beyond the expected parallel reduction order.
+
+The following minimal example simulates two input shards on one ROCm GPU. It does not need a model checkpoint.
+
+```python
+import torch
+from vllm import _custom_ops as ops
+
+weight = torch.tensor(
+    [[1, -2, 8, -64], [2, -3, 7, -56]],
+    dtype=torch.bfloat16,
+    device="cuda",
+)
+
+full_qweight, full_scale, _ = ops.scaled_int8_quant(weight, scale=None)
+rank0_qweight, rank0_scale, _ = ops.scaled_int8_quant(
+    weight[:, :2].contiguous(),
+    scale=None,
+)
+
+print("full scale:", full_scale.cpu())
+print("rank 0 scale:", rank0_scale.cpu())
+print("full rank 0 shard:", full_qweight[:, :2].cpu())
+print("rank 0 local quantization:", rank0_qweight.cpu())
+
+assert torch.equal(rank0_scale, full_scale)
+assert torch.equal(rank0_qweight, full_qweight[:, :2])
+```
+
+Observed result:
+
+```text
+full scale: tensor([[0.5039], [0.4409]])
+rank 0 scale: tensor([[0.0157], [0.0236]])
+full rank 0 shard: tensor([[ 2, -4], [ 5, -7]], dtype=torch.int8)
+rank 0 local quantization: tensor([[ 64, -127], [ 85, -127]], dtype=torch.int8)
+AssertionError
+```
+
+Expected result:
+
+Every input shard for one output row must use the scale derived from the maximum absolute value across the complete unsharded row. TP1 and TP2 must therefore produce identical quantized weight shards and scales.
+
+This affects more than standard `RowParallelLinear` instances. BAGEL stores secondary expert weights on a plain `Module`, so an `isinstance` check misses them. MiniMax-H3 uses a text encoder TP group that is independent from the DiT TP group, so reducing through the default vLLM TP group is also incorrect for that path.
+
+Third, diffusion layers can pass rank-3 hidden states to the linear method. The ROCm Triton and AITER INT8 kernels accept a rank-2 matrix, so the common linear wrapper must flatten the leading dimensions before calling the upstream kernel and restore them afterward.
+
+The proposed design is to keep the vLLM kernel selection and matrix multiplication unchanged. Upstream vLLM PR [#49764, Share online weight scales across TP](https://github.com/vllm-project/vllm/pull/49764), merged as commit `8170c23c4f`, fixes the same invariant for online FP8 and INT8 MoE. It detects whether the weight is sharded along a reduced dimension, computes the local maximum, and uses a `MAX` all-reduce before quantization.
+
+vLLM-Omni still needs a small local adaptation because its diffusion linear path is not the upstream MoE path. The supplied static INT8 kernel accepts one scale, not one scale per output row, and MiniMax-H3 can use an independent text encoder TP group. The local code should therefore provide only the missing per-row packing and optional process-group override. Standard layers should continue to use vLLM's default TP group and all kernel selection and matrix multiplication should remain upstream-owned.
+
+Validation on two ROCm GPUs with vLLM 0.27.0 covered the Triton kernel, the AITER kernel, exact TP1 versus TP2 quantized weight parity, MiniMax-H3 INT8 TP2 generation, and BAGEL INT8 TP2 generation. These were execution and kernel-correctness checks. They were not BF16 versus INT8 output-quality comparisons.
+
+`VLLM_OMNI_LOGGING_LEVEL=DEBUG` was enabled for the recorded runs. There is no crash traceback because the scale defect produces incorrect numerical behavior rather than an exception.
+
+The original diffusion INT8 implementation was added by @yjb767868009 in #1470. The unified quantization framework was added by @lishunyang12 in #1764. I am tagging them for context.

--- a/vllm_omni/diffusion/models/minimax_h3/encoder.py
+++ b/vllm_omni/diffusion/models/minimax_h3/encoder.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """MiniMax H3 Qwen3-VL layer-50 text/vision encoder.
 
 The encoder is reimplemented on top of vLLM-style tensor-parallel building
@@ -329,6 +330,10 @@ class MiniMaxH3Qwen3VLRowParallelLinear(LinearBase):
             params_dtype=dtype,
             weight_loader=self.weight_loader,
         )
+        # INT8 per-row scales must be reduced over the ranks that own these
+        # input shards. The text encoder group is independent from the DiT
+        # tensor-parallel group returned by vLLM's get_tp_group().
+        self._int8_scale_tp_group = self.group.device_group
         self._tp_rank = tp_rank
         self._tp_size = tp_size
 

--- a/vllm_omni/platforms/npu/models/minimax_h3.py
+++ b/vllm_omni/platforms/npu/models/minimax_h3.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 """NPU patches for the MiniMax H3 Qwen3-VL text encoder."""
 
@@ -8,7 +8,6 @@ from __future__ import annotations
 from typing import Any
 
 import torch
-import torch.nn.functional as F
 import torch_npu
 from vllm.logger import init_logger
 
@@ -55,7 +54,7 @@ def npu_swiglu_from_packed(gate_up: torch.Tensor) -> torch.Tensor:
 
 def _forward_minimax_h3_qwen3vl_text_mlp_npu(self: Any, x: torch.Tensor) -> torch.Tensor:
     """Run the Qwen3-VL MLP with one packed GEMM and fused SwiGLU."""
-    gate_up = F.linear(x, self.gate_up_proj.weight)
+    gate_up = self.gate_up_proj(x)
     return self.down_proj(npu_swiglu_from_packed(gate_up))
 
 
@@ -67,5 +66,5 @@ def apply_minimax_h3_qwen3vl_swiglu_patch() -> None:
 
     from vllm_omni.diffusion.models.minimax_h3 import encoder
 
-    encoder.MiniMaxH3Qwen3VLTextMLP.forward = _forward_minimax_h3_qwen3vl_text_mlp_npu
+    encoder.MiniMaxH3Qwen3VLTextMLP.forward = _forward_minimax_h3_qwen3vl_text_mlp_npu  # type: ignore[method-assign]
     _SWIGLU_PATCHED = True

--- a/vllm_omni/quantization/int8_config.py
+++ b/vllm_omni/quantization/int8_config.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """INT8 quantization config for diffusion transformers.
 
 Supports both online (dynamic) and offline (checkpoint) INT8 quantization
-on CUDA and NPU platforms.
+on CUDA, ROCm, and NPU platforms.
 """
 
 from collections.abc import Callable
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Optional
 import torch
 from torch.nn import Module
 from vllm import _custom_ops as ops
+from vllm.distributed.parallel_state import get_tp_group
 from vllm.logger import init_logger
 from vllm.model_executor.kernels.linear import (
     init_int8_linear_kernel,
@@ -59,6 +60,49 @@ ACTIVATION_SCHEMES = ["dynamic"]
 NPU_QUANT_MATMUL_MAX_OUT_FEATURES = 65535
 
 logger = init_logger(__name__)
+
+_INT8_MAX = torch.iinfo(torch.int8).max
+# Keep the fp32 quantization temporary below roughly 64 MiB.
+_QUANT_CHUNK_ELEMS = 16 * 1024 * 1024
+
+
+def _quantize_input_sharded_weight(layer: Module) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize an input-sharded weight with one scale per full row."""
+    row_min, row_max = layer.weight.aminmax(dim=1, keepdim=True)
+    row_amax = torch.maximum(row_min.abs(), row_max.abs()).float()
+
+    # MiniMax's text encoder has a TP group independent from the DiT TP group.
+    # Standard vLLM layers and BAGEL's secondary expert weights use the default
+    # TP group, so only the MiniMax path needs to provide an override.
+    scale_tp_group = getattr(layer, "_int8_scale_tp_group", None)
+    if scale_tp_group is None:
+        scale_tp_group = get_tp_group().device_group
+    torch.distributed.all_reduce(
+        row_amax,
+        op=torch.distributed.ReduceOp.MAX,
+        group=scale_tp_group,
+    )
+
+    weight_scale = row_amax / _INT8_MAX
+    # Match vLLM's dynamic INT8 kernel exactly. It multiplies by
+    # 127 / absmax and maps an all-zero row to an all-zero INT8 row. Dividing
+    # by absmax / 127 is mathematically equivalent, but fp32 rounding differs
+    # at some half-way values and can make TP=1 and TP>1 weights disagree.
+    inv_scale = torch.where(
+        row_amax == 0,
+        torch.zeros_like(row_amax),
+        _INT8_MAX / row_amax,
+    )
+    qweight = torch.empty_like(layer.weight, dtype=torch.int8)
+    # vLLM's scaled_int8_quant accepts one supplied static scale, not one scale
+    # per row. Keep the missing per-row operation local until vLLM provides it.
+    chunk_rows = max(1, _QUANT_CHUNK_ELEMS // layer.weight.shape[1])
+    for start in range(0, layer.weight.shape[0], chunk_rows):
+        rows = slice(start, start + chunk_rows)
+        qweight[rows] = (
+            layer.weight[rows].float().mul_(inv_scale[rows]).round_().clamp_(-_INT8_MAX, _INT8_MAX).to(torch.int8)
+        )
+    return qweight, weight_scale
 
 
 def _fell_back_to_unquantized_npu(
@@ -128,7 +172,7 @@ class DiffusionInt8Config(QuantizationConfig):
 
     Supports online (dynamic) quantization from BF16/FP16 checkpoints
     and offline quantization from serialized INT8 checkpoints.
-    Works on both CUDA and NPU platforms.
+    Works on CUDA, ROCm, and NPU platforms.
     """
 
     def __init__(
@@ -195,7 +239,10 @@ class DiffusionInt8Config(QuantizationConfig):
             ):
                 return UnquantizedLinearMethod()
             if not self.is_checkpoint_int8_serialized:
-                if current_omni_platform.is_cuda():
+                # ROCm uses the same upstream vLLM INT8 quantization and
+                # scaled-matmul interfaces as CUDA. Keep only the NPU-specific
+                # weight layout and operators in the separate method below.
+                if current_omni_platform.is_cuda() or current_omni_platform.is_rocm():
                     online_method = Int8OnlineLinearMethod(self)
                 elif current_omni_platform.is_npu():
                     online_method = NPUInt8OnlineLinearMethod(self)
@@ -203,7 +250,7 @@ class DiffusionInt8Config(QuantizationConfig):
                     raise NotImplementedError("The current platform is not supported int8 online quant.")
                 return online_method
             else:
-                if current_omni_platform.is_cuda():
+                if current_omni_platform.is_cuda() or current_omni_platform.is_rocm():
                     offline_method = Int8LinearMethod(self)
                 elif current_omni_platform.is_npu():
                     offline_method = NPUInt8LinearMethod(self)
@@ -308,6 +355,11 @@ class LazyWeightMixin:
         output_size_per_partition = sum(output_partition_sizes)
         weight_loader = extra_weight_attrs.get("weight_loader")
         layer.logical_widths = output_partition_sizes
+        # Some model wrappers, such as BAGEL's secondary expert, use a bare
+        # Module as the weight owner. Keep the full size beside the local size
+        # so online INT8 can use vLLM's structural row-parallel contract instead
+        # of relying on a concrete linear class.
+        layer.input_size = input_size
         layer.input_size_per_partition = input_size_per_partition
         layer.output_size_per_partition = output_size_per_partition
         layer.orig_dtype = params_dtype
@@ -345,7 +397,7 @@ class LazyWeightMixin:
             # process_weights_after_loading
             target_loaded_numel = layer.weight.numel()
             if layer._loaded_numel == target_loaded_numel:
-                self.process_weights_after_loading(layer)
+                self.process_weights_after_loading(layer)  # type: ignore[attr-defined]
 
                 # Prevent the usual `process_weights_after_loading` call from doing
                 # anything
@@ -408,7 +460,12 @@ class Int8LinearMethod(BaseInt8LinearMethod):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        return self.int8_linear.apply_weights(layer, x, bias)
+        original_shape = x.shape
+        # Diffusion layers can pass batched hidden states, but vLLM's ROCm
+        # Triton and AITER INT8 kernels accept only a two-dimensional matrix.
+        x = x.reshape(-1, original_shape[-1])
+        output = self.int8_linear.apply_weights(layer, x, bias)
+        return output.reshape(*original_shape[:-1], -1)
 
 
 class NPUInt8LinearMethod(BaseInt8LinearMethod):
@@ -478,7 +535,14 @@ class Int8OnlineLinearMethod(LazyWeightMixin, Int8LinearMethod):
             initialize_single_dummy_weight(layer.weight)
 
         w_q_name, w_s_name, i_s_name, i_zp_name, azp_adj_name = self.int8_linear.layer_param_names
-        qweight, weight_scale, _ = ops.scaled_int8_quant(layer.weight, scale=None)
+        # Per-row scales reduce the input dimension, so follow upstream vLLM's
+        # full-size versus local-size check. Do not also check layer.tp_size:
+        # MiniMax disables the default TP group in LinearBase and shards with a
+        # separate encoder group, leaving the inherited tp_size equal to 1.
+        if layer.input_size != layer.input_size_per_partition:
+            qweight, weight_scale = _quantize_input_sharded_weight(layer)
+        else:
+            qweight, weight_scale, _ = ops.scaled_int8_quant(layer.weight, scale=None)
 
         # Update layer with new values.
         replace_parameter(layer, w_q_name, torch.nn.Parameter(qweight.t().data, requires_grad=False))
@@ -520,8 +584,11 @@ class NPUInt8OnlineLinearMethod(LazyWeightMixin, NPUInt8LinearMethod):
             layer.register_parameter("weight", weight)
             initialize_single_dummy_weight(layer.weight)
 
-        weight = layer.weight
-        qweight, weight_scale = torch_npu.npu_dynamic_quant(weight)
+        if layer.input_size != layer.input_size_per_partition:
+            qweight, weight_scale = _quantize_input_sharded_weight(layer)
+            weight_scale = weight_scale.squeeze(-1)
+        else:
+            qweight, weight_scale = torch_npu.npu_dynamic_quant(layer.weight)
 
         qweight = qweight.t().contiguous()
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!-- Proposed title: [WIP][Bugfix] Fix diffusion INT8 tensor-parallel scales and enable ROCm -->

Fixes #6584

## Purpose

Online diffusion INT8 quantized each input-sharded tensor-parallel weight independently. Each rank derived its per-output-row scale from only its local input shard, so TP2 did not use the same quantized weight representation as TP1. BAGEL also stores secondary expert weights on a plain module, and MiniMax-H3 can use a text encoder TP group that is independent from the DiT TP group.

This change follows the scale-sharing design in upstream vLLM PR [#49764](https://github.com/vllm-project/vllm/pull/49764). It records the global and local input dimensions, detects input sharding from those dimensions, computes the row maximum across the correct process group, and packs each local shard with the shared row scale. Standard layers use vLLM's default TP group. MiniMax-H3 provides an override only for its independent text encoder group.

ROCm now uses vLLM's existing INT8 linear kernel selection. vLLM-Omni does not add or fork a matrix multiplication kernel. The linear wrapper only flattens diffusion hidden states to the rank-2 input required by the upstream Triton and AITER kernels, then restores the original leading dimensions.

The files under `rocm_int8_verification/` are a temporary test-only harness included in the draft PR so maintainers can reproduce the AMD checks. They keep model downloads, compiler caches, temporary files, and results under that folder. They are not runtime code and will be removed before the PR is marked ready for review or merged. 

This PR does not claim BF16 versus INT8 output-quality parity. The MiniMax-H3 and BAGEL runs are execution smoke tests. The exact quantized-weight tests cover the TP scale correctness claim.

## Test Plan

```bash
python -m pytest \
  tests/diffusion/quantization/test_int8_config.py \
  tests/diffusion/models/minimax_h3/test_minimax_h3_quantization.py \
  tests/diffusion/models/bagel/test_bagel_quantization.py \
  --run-level advanced_model \
  -m core_model
```

On a two-GPU ROCm container:

```bash
ROCM_VERIFY_RUN_ID=<run-id> \
VLLM_TEST_MINIMAX_H3_FL2VA_MODEL="$PWD/rocm_int8_verification/models/MiniMax-H3/FL2VA" \
RUN_AITER=1 \
VLLM_ROCM_USE_AITER=1 \
VLLM_ROCM_USE_AITER_LINEAR=1 \
bash "$PWD/rocm_int8_verification/run_all.sh"
```

The `rocm_int8_verification/` command is available while the PR is in draft. After maintainers finish reproducing the results, remove that temporary folder, rerun the remaining checks, and perform the final cleanup squash without the harness.

### Help requested for CUDA and NPU validation

Upstream vLLM PR [#49764](https://github.com/vllm-project/vllm/pull/49764) tested the same TP-invariant packing rule by replacing the collective with the full unsharded `amax`, then checking exact packed-weight and scale equality for dense and MoE shards.\

The equivalent vLLM-Omni CUDA checks use the real upstream INT8 kernel and a real two-process NCCL collective. Help running this exact command on two NVIDIA GPUs would be appreciated:

```bash
CUDA_VISIBLE_DEVICES=0,1 \
python -m pytest \
  tests/diffusion/quantization/test_int8_config.py::TestGPUInt8Smoke \
  tests/diffusion/quantization/test_int8_config.py::test_shared_quantizer_matches_native_kernel_on_two_gpus \
  --run-level advanced_model \
  -m 'core_model and cuda' \
  -vv -s -rs
```



The current NPU checks compare the shared quantizer with the real `torch_npu.npu_dynamic_quant` result and run a real `npu_quant_matmul` forward. Help running this exact command on an Ascend NPU would be appreciated:

```bash
ASCEND_RT_VISIBLE_DEVICES=0 \
python -m pytest \
  tests/diffusion/quantization/test_int8_config.py::TestNPUInt8Smoke \
  --run-level advanced_model \
  -m core_model \
  -vv -s -rs
```



Run the diff-scoped pre-commit hooks after the final rebase and squash:

```bash
pre-commit run --files \
  docs/user_guide/quantization/int8.md \
  rocm_int8_verification/.gitignore \
  rocm_int8_verification/README.md \
  rocm_int8_verification/minimax_int8_tp2.py \
  rocm_int8_verification/run_all.sh \
  tests/diffusion/models/bagel/test_bagel_quantization.py \
  tests/diffusion/models/minimax_h3/test_minimax_h3_quantization.py \
  tests/diffusion/quantization/test_int8_config.py \
  vllm_omni/diffusion/models/minimax_h3/encoder.py \
  vllm_omni/quantization/int8_config.py
```

**vLLM Version:** `0.27.0`

**vLLM-Omni Commit:** `ef5324668a75400cbe2cb5cd826582eed9f3daf3`

## Test Result

Local targeted suite:

```text
45 passed, 8 skipped, 14 warnings in 17.85s
```

Two-GPU ROCm results with PyTorch `2.11.0+gitd0c8b1f`, HIP `7.2.53211`, vLLM `0.27.0`, and vLLM-Omni `e20bcd5231f2f8ffb10fe6e337c303305cde9118`:

```text
Affected INT8, BitsAndBytes, MiniMax-H3, and BAGEL tests:
54 passed, 10 skipped, 14 warnings in 55.74s

Triton INT8 kernel:
3 passed, 14 warnings in 0.76s

AITER INT8 kernel:
3 passed, 14 warnings in 1.10s

Two-GPU exact TP1 versus TP2 quantized-weight parity:
1 passed, 14 warnings in 32.52s

MiniMax-H3 INT8 with DiT TP2 and text encoder TP2:
Passed and saved nonempty video and audio arrays

BAGEL INT8 TP2:
Passed in a standalone rerun and saved a nonempty PNG
```

The AMD runs were completed before the history-only rebase and squash. The contents of every file changed by this PR are identical between tested commit `e20bcd5231f2f8ffb10fe6e337c303305cde9118` and current commit `ef5324668a75400cbe2cb5cd826582eed9f3daf3`.

CUDA reviewer validation: requested and pending.

NPU reviewer validation: requested and pending. Real one-NPU packing and matmul tests exist; real two-NPU HCCL TP parity is not yet covered.



**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
