### PR TITLE
[Perf][Qwen3-TTS] Enable chunk ramp by default

### DIFF
--- a/tests/config/test_config_factory.py
+++ b/tests/config/test_config_factory.py
@@ -1854,6 +1854,18 @@ class TestQwen3TTSPipeline:
         # Stage 1 uses its per-stage override
         assert stages[1].yaml_engine_args["model_arch"] == "Qwen3TTSCode2Wav"
 
+    @pytest.mark.parametrize(
+        "deploy_name",
+        ["qwen3_tts.yaml", "qwen3_tts_high_concurrency.yaml"],
+    )
+    def test_default_async_deploy_enables_chunk_ramp(self, deploy_name):
+        deploy = load_deploy_config(Path(get_deploy_config_path(deploy_name)))
+
+        assert deploy.async_chunk is True
+        assert deploy.connectors is not None
+        extra = deploy.connectors["connector_of_shared_memory"]["extra"]
+        assert extra["codec_chunk_ramp"] == [4, 4, 8, 16, 25]
+
     def test_subtalker_sampling_params_deep_merge_preserves_base_keys(self):
         """Verify subtalker sampling params participate in stage deep-merge."""
         base = {

--- a/vllm_omni/deploy/qwen3_tts.yaml
+++ b/vllm_omni/deploy/qwen3_tts.yaml
@@ -26,13 +26,14 @@ connectors:
       codec_left_context_frames: 72
       # Emit only the first audio chunk early, then return to codec_chunk_frames.
       initial_codec_chunk_frames: 1
-      # Chunk ramp (opt-in): gradual size increase for first N chunks to
-      # eliminate the IC→steady cliff (1→25). Uncomment to enable.
+      # Gradual size increase for the first N chunks eliminates the
+      # IC-to-steady cliff (1->25) and improves streaming continuity.
       # Each entry is the size of that chunk index; indices past the table
-      # fall back to codec_chunk_frames. When enabled, ramp overrides
-      # initial_codec_chunk_frames (including the per-request API field).
-      # Example:
-      #   codec_chunk_ramp: [4, 4, 8, 16, 25]
+      # fall back to codec_chunk_frames. Ramp overrides
+      # initial_codec_chunk_frames, including the per-request API field.
+      # Set this to null in a deployment overlay to restore the legacy
+      # initial_codec_chunk_frames behavior.
+      codec_chunk_ramp: [4, 4, 8, 16, 25]
       # Decoder CUDA Graph sizing:
       #   * async_chunk=true derives all stateful ICL/xvec shapes from
       #     codec_chunk_ramp when enabled, otherwise from

--- a/vllm_omni/deploy/qwen3_tts_high_concurrency.yaml
+++ b/vllm_omni/deploy/qwen3_tts_high_concurrency.yaml
@@ -31,13 +31,14 @@ connectors:
       ref_code_context_frames: 72
       # Emit only the first audio chunk early, then return to codec_chunk_frames.
       initial_codec_chunk_frames: 1
-      # Chunk ramp (opt-in): gradual size increase for first N chunks to
-      # eliminate the IC→steady cliff (1→25). Uncomment to enable.
+      # Gradual size increase for the first N chunks eliminates the
+      # IC-to-steady cliff (1->25) and improves streaming continuity.
       # Each entry is the size of that chunk index; indices past the table
-      # fall back to codec_chunk_frames. When enabled, ramp overrides
-      # initial_codec_chunk_frames (including the per-request API field).
-      # Example:
-      #   codec_chunk_ramp: [4, 4, 8, 16, 25]
+      # fall back to codec_chunk_frames. Ramp overrides
+      # initial_codec_chunk_frames, including the per-request API field.
+      # Set this to null in a deployment overlay to restore the legacy
+      # initial_codec_chunk_frames behavior.
+      codec_chunk_ramp: [4, 4, 8, 16, 25]
       # async_chunk derives stateful ICL/xvec graph shapes from the ramp when
       # enabled, otherwise from the fixed chunk settings above, and ignores
       # decode_cudagraph_capture_sizes. Keep B>1


### PR DESCRIPTION
## Summary

- Enable `codec_chunk_ramp: [4, 4, 8, 16, 25]` by default for the Qwen3-TTS async deployment profiles.
- Apply the same default to `qwen3_tts.yaml` and `qwen3_tts_high_concurrency.yaml`.
- Add a configuration regression test for both profiles.

## Motivation

PR #5152 added the ramp as an opt-in feature to avoid the `1 -> 25` initial-to-steady chunk cliff. Our matched H200 run on the `seed-tts-eval` English workload (64 fixed requests, Stage 0/1 on separate H200 GPUs) showed the expected trade-off at concurrency 8:

| Configuration | p99 TTFP | p99 underrun | Request throughput |
| --- | ---: | ---: | ---: |
| Legacy `[1, 25, ...]` | 98 ms | 124 ms | 14.01 req/s |
| Ramp `[4, 4, 8, 16, 25]` | 160 ms | 68 ms | 14.10 req/s |

The ramp improves playback continuity without reducing measured throughput in this run, at the cost of a higher first-packet tail latency.

The default can be reverted in a deployment overlay with `codec_chunk_ramp: null`.

## Validation

- `git diff --check`
- YAML parsing verified for both modified deployment files
- H200 benchmark completed for baseline, ramp, initial chunk, and Stage 0/Stage 1 eager controls
- Full pytest was not runnable locally because the project dependency resolver currently rejects the existing Python 3.13 `transformers`/`qwen-asr` constraint combination; the targeted remote retry was unavailable due to intermittent SSH disconnects.