### PR TITLE
[noissue] MiniCPM-o 4.5 Ascend: Code2Wav execution-efficiency candidates (CFM 3-step + stage2 inductor compile)

### DIFF
--- a/tests/benchmarks/patch/test_patch.py
+++ b/tests/benchmarks/patch/test_patch.py
@@ -25,6 +25,7 @@ from vllm_omni.benchmarks.data_modules.seed_tts_dataset import (
     SEED_TTS_DEFAULT_OMNI_SYSTEM_PROMPT,
     SEED_TTS_OFFICIAL_VOICE_CLONE_PREFIX_ZH,
     SEED_TTS_OFFICIAL_VOICE_CLONE_SUFFIX_ZH,
+    SEED_TTS_OFFICIAL_TTS_USER_PREFIX,
     SeedTTSSampleRequest,
 )
 from vllm_omni.experimental.fullduplex.client import RealtimeEventCollector
@@ -52,6 +53,9 @@ def test_seed_tts_zh_request_uses_official_audio_contract():
     assert content[1]["audio_url"]["url"] == ref_audio
     assert content[2]["text"] == SEED_TTS_OFFICIAL_VOICE_CLONE_SUFFIX_ZH
     assert rfi.extra_body["ref_audio"] == ref_audio
+    assert rfi.omni_chat_messages[1]["content"] == [
+        {"type": "text", "text": f"{SEED_TTS_OFFICIAL_TTS_USER_PREFIX} 目标文本"}
+    ]
 
 
 def test_seed_tts_missing_reference_keeps_text_only_system_message():

--- a/tests/benchmarks/patch/test_patch.py
+++ b/tests/benchmarks/patch/test_patch.py
@@ -16,13 +16,60 @@ from pytest_mock import MockerFixture
 from vllm.benchmarks.lib.endpoint_request_func import RequestFuncInput
 
 from vllm_omni.benchmarks.patch.patch import (
+    _attach_seed_tts_to_request_func_input,
     MixRequestFuncOutput,
     async_request_openai_chat_omni_completions,
     async_request_openai_realtime_duplex,
 )
+from vllm_omni.benchmarks.data_modules.seed_tts_dataset import (
+    SEED_TTS_DEFAULT_OMNI_SYSTEM_PROMPT,
+    SEED_TTS_OFFICIAL_VOICE_CLONE_PREFIX_ZH,
+    SEED_TTS_OFFICIAL_VOICE_CLONE_SUFFIX_ZH,
+    SeedTTSSampleRequest,
+)
 from vllm_omni.experimental.fullduplex.client import RealtimeEventCollector
 
 pytestmark = [pytest.mark.core_model, pytest.mark.benchmark, pytest.mark.cpu]
+
+
+def test_seed_tts_zh_request_uses_official_audio_contract():
+    ref_audio = "data:audio/wav;base64,AAAA"
+    sample = SeedTTSSampleRequest(
+        prompt="目标文本",
+        prompt_len=2,
+        expected_output_len=64,
+        multi_modal_data=None,
+        request_id="seed-zh-0",
+        seed_tts_locale="zh",
+        seed_tts_speech_extra={"ref_audio": ref_audio, "ref_text": "参考"},
+        seed_tts_system_prompt=SEED_TTS_DEFAULT_OMNI_SYSTEM_PROMPT,
+    )
+    rfi = SimpleNamespace(extra_body={})
+    _attach_seed_tts_to_request_func_input(sample, rfi)
+    content = rfi.omni_chat_messages[0]["content"]
+    assert [part["type"] for part in content] == ["text", "audio_url", "text"]
+    assert content[0]["text"] == SEED_TTS_OFFICIAL_VOICE_CLONE_PREFIX_ZH
+    assert content[1]["audio_url"]["url"] == ref_audio
+    assert content[2]["text"] == SEED_TTS_OFFICIAL_VOICE_CLONE_SUFFIX_ZH
+    assert rfi.extra_body["ref_audio"] == ref_audio
+
+
+def test_seed_tts_missing_reference_keeps_text_only_system_message():
+    sample = SeedTTSSampleRequest(
+        prompt="target",
+        prompt_len=1,
+        expected_output_len=64,
+        multi_modal_data=None,
+        request_id="seed-zh-1",
+        seed_tts_locale="zh",
+        seed_tts_speech_extra=None,
+        seed_tts_system_prompt=SEED_TTS_DEFAULT_OMNI_SYSTEM_PROMPT,
+    )
+    rfi = SimpleNamespace(extra_body=None)
+    _attach_seed_tts_to_request_func_input(sample, rfi)
+    assert rfi.omni_chat_messages[0]["content"] == [
+        {"type": "text", "text": SEED_TTS_DEFAULT_OMNI_SYSTEM_PROMPT}
+    ]
 
 
 class MockResponse:

--- a/tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
+++ b/tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
@@ -220,6 +220,26 @@ def test_load_poll_generation_tensor_codes_use_placeholder_prompt(build_adapter)
     assert "req-tensor" in adapter._finished_load_reqs
 
 
+def test_load_poll_generation_preserves_reference_audio_with_list_codes(build_adapter):
+    adapter, connector = build_adapter(stage_id=1, model_mode="generation")
+    request = _req("req-ref", RequestStatus.WAITING, external_req_id="external-ref")
+
+    reference = torch.tensor([0.0, 0.25, -0.25], dtype=torch.float32)
+    payload: OmniPayload = {
+        "codes": {"audio": [1, 2, 3], "ref": reference},
+        "meta": {
+            "finished": torch.tensor(True, dtype=torch.bool),
+            "ref_audio_sr": 24000,
+        },
+    }
+    connector.get.return_value = (payload, 16)
+
+    assert adapter._poll_single_request(request) is True
+    assert request.prompt_token_ids == [1, 2, 3]
+    assert torch.equal(request.additional_information["codes"]["ref"], reference)
+    assert request.additional_information["meta"]["ref_audio_sr"] == 24000
+
+
 def test_load_poll_generation_empty_nonterminal_chunk_keeps_polling(build_adapter):
     adapter, connector = build_adapter(stage_id=1, model_mode="generation")
     request = _req("req-empty-tensor", RequestStatus.WAITING, external_req_id="external-empty")

--- a/tests/entrypoints/openai_api/test_minicpmo45_ref_audio_serving.py
+++ b/tests/entrypoints/openai_api/test_minicpmo45_ref_audio_serving.py
@@ -1,0 +1,77 @@
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+@pytest.fixture
+def serving_chat(monkeypatch):
+    from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
+
+    class FakeMediaConnector:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def fetch_audio_async(self, _uri):
+            return "wave", 24000
+
+    instance = object.__new__(OmniOpenAIServingChat)
+    instance.engine_client = SimpleNamespace(
+        stage_configs=[
+            SimpleNamespace(
+                engine_args=SimpleNamespace(model_arch="MiniCPMO45OmniForConditionalGeneration")
+            )
+        ]
+    )
+    instance.model_config = SimpleNamespace(
+        allowed_local_media_path="/tmp",
+        allowed_media_domains=None,
+    )
+    monkeypatch.setattr(
+        "vllm_omni.entrypoints.openai.serving_chat.MediaConnector",
+        FakeMediaConnector,
+    )
+    return instance
+
+
+def test_extracts_benchmark_ref_audio_from_extra_body():
+    from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
+
+    request = SimpleNamespace(extra_body={"ref_audio": "file:///tmp/ref.wav"}, model_extra={})
+    assert OmniOpenAIServingChat._minicpmo45_ref_audio_uri(request, []) == "file:///tmp/ref.wav"
+
+
+def test_extracts_demo_ref_audio_from_message():
+    from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
+
+    request = SimpleNamespace(extra_body={}, model_extra={})
+    messages = [
+        {
+            "role": "system",
+            "content": [
+                {"type": "audio_url", "audio_url": {"url": "data:audio/wav;base64,AAAA"}},
+            ],
+        }
+    ]
+    assert OmniOpenAIServingChat._minicpmo45_ref_audio_uri(request, messages).startswith("data:audio/wav")
+
+
+@pytest.mark.asyncio
+async def test_materializes_ref_audio_into_deferred_contract(serving_chat):
+    request = SimpleNamespace(media_io_kwargs=None)
+    prompt = {"additional_information": {}}
+
+    await serving_chat._attach_minicpmo45_ref_audio(request, "file:///tmp/ref.wav", prompt)
+
+    assert prompt["additional_information"]["deferred_multi_modal_data"]["audio"] == [("wave", 24000)]
+
+
+@pytest.mark.asyncio
+async def test_does_not_replace_existing_deferred_audio(serving_chat):
+    request = SimpleNamespace(media_io_kwargs=None)
+    prompt = {"additional_information": {"deferred_multi_modal_data": {"audio": [("old", 16000)]}}}
+
+    await serving_chat._attach_minicpmo45_ref_audio(request, "file:///tmp/ref.wav", prompt)
+
+    assert prompt["additional_information"]["deferred_multi_modal_data"]["audio"] == [("old", 16000)]

--- a/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
@@ -304,6 +304,23 @@ def test_estimator_cache_stack_split_round_trip_preserves_cfg_rows():
         )
 
 
+def test_singleton_cache_fast_path_keeps_request_owned_storage():
+    token2wav = _FakeToken2Wav()
+    adapter = BatchedToken2Wav(token2wav)
+    prompt = adapter.prepare_prompt("shared", "/fake/prompt.wav")
+    states = adapter.setup_batch(prompt, 1)
+
+    stacked = adapter._stack_flow_cache(states)
+    for name, value in states[0].flow_cache.items():
+        assert stacked[name].data_ptr() == value.data_ptr()
+
+    split = adapter._split_flow_cache(stacked, 1)[0]
+    assert split["conformer_cnn_cache"].data_ptr() == stacked["conformer_cnn_cache"].data_ptr()
+    assert split["conformer_att_cache"].data_ptr() == stacked["conformer_att_cache"].data_ptr()
+    assert split["estimator_cnn_cache"].data_ptr() == stacked["estimator_cnn_cache"].data_ptr()
+    assert split["estimator_att_cache"].data_ptr() == stacked["estimator_att_cache"].data_ptr()
+
+
 def test_model_preserves_output_slots_and_prefers_runtime_codes():
     model, token2wav = _model()
     output = _forward(

--- a/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
@@ -139,13 +139,14 @@ class _FakeToken2Wav:
         raise AssertionError("sequential __call__ fallback must never be called")
 
 
-def _config(minimum: int = 1):
+def _config(minimum: int = 1, aggregate_chunks: int = 1):
     return SimpleNamespace(
         model_config=SimpleNamespace(
             model="/fake/model",
             stage_connector_config={
                 "extra": {
                     "code2wav_min_batch_size": minimum,
+                    "code2wav_internal_aggregate_chunks": aggregate_chunks,
                     "prompt_cache_id": "shared",
                     "prompt_wav": "/fake/prompt.wav",
                 }
@@ -154,10 +155,10 @@ def _config(minimum: int = 1):
     )
 
 
-def _model():
+def _model(*, aggregate_chunks: int = 1):
     token2wav = _FakeToken2Wav()
     backend = BatchedToken2Wav(token2wav)
-    model = MiniCPMO45Code2Wav(vllm_config=_config())
+    model = MiniCPMO45Code2Wav(vllm_config=_config(aggregate_chunks=aggregate_chunks))
     model.backend = backend
     return model, token2wav
 
@@ -383,6 +384,40 @@ def test_code2wav_projects_duplex_metadata_to_final_audio_output():
     assert token2wav.flow.encoder.last_chunk_calls[-1] is True
     assert "duplex" not in model._states
 
+
+def test_internal_codec_aggregation_keeps_first_window_latency_and_flushes():
+    model, token2wav = _model(aggregate_chunks=4)
+
+    first = _forward(model, [_info("aggregate", 0, [1, 2])])
+    assert first.multimodal_outputs["model_outputs"][0].numel() > 0
+    assert token2wav.hift.calls == [1]
+
+    for chunk_seq in (1, 2, 3):
+        output = _forward(
+            model,
+            [_info("aggregate", chunk_seq, [chunk_seq + 10, chunk_seq + 20])],
+        )
+        assert output.multimodal_outputs["model_outputs"][0].numel() == 0
+    assert token2wav.hift.calls == [1]
+    assert model._states["aggregate"].pending_tokens.numel() == 6
+
+    flushed = _forward(model, [_info("aggregate", 4, [14, 24])])
+    assert flushed.multimodal_outputs["model_outputs"][0].numel() > 0
+    assert token2wav.hift.calls == [1, 1]
+    assert model._states["aggregate"].pending_tokens is None
+
+
+def test_internal_codec_aggregation_flushes_short_final_remainder():
+    model, token2wav = _model(aggregate_chunks=4)
+    _forward(model, [_info("final", 0, [1, 2])])
+    buffered = _forward(model, [_info("final", 1, [3, 4])])
+    assert buffered.multimodal_outputs["model_outputs"][0].numel() == 0
+
+    final = _info("final", 2, [5], last_chunk=True)
+    output = _forward(model, [final])
+    assert output.multimodal_outputs["model_outputs"][0].numel() > 0
+    assert token2wav.flow.encoder.last_chunk_calls[-1] is True
+    assert "final" not in model._states
 
 def test_initial_empty_segment_marker_initializes_stream_without_audio():
     model, token2wav = _model()

--- a/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
@@ -139,14 +139,13 @@ class _FakeToken2Wav:
         raise AssertionError("sequential __call__ fallback must never be called")
 
 
-def _config(minimum: int = 1, aggregate_chunks: int = 1):
+def _config(minimum: int = 1):
     return SimpleNamespace(
         model_config=SimpleNamespace(
             model="/fake/model",
             stage_connector_config={
                 "extra": {
                     "code2wav_min_batch_size": minimum,
-                    "code2wav_internal_aggregate_chunks": aggregate_chunks,
                     "prompt_cache_id": "shared",
                     "prompt_wav": "/fake/prompt.wav",
                 }
@@ -155,10 +154,10 @@ def _config(minimum: int = 1, aggregate_chunks: int = 1):
     )
 
 
-def _model(*, aggregate_chunks: int = 1):
+def _model():
     token2wav = _FakeToken2Wav()
     backend = BatchedToken2Wav(token2wav)
-    model = MiniCPMO45Code2Wav(vllm_config=_config(aggregate_chunks=aggregate_chunks))
+    model = MiniCPMO45Code2Wav(vllm_config=_config())
     model.backend = backend
     return model, token2wav
 
@@ -384,40 +383,6 @@ def test_code2wav_projects_duplex_metadata_to_final_audio_output():
     assert token2wav.flow.encoder.last_chunk_calls[-1] is True
     assert "duplex" not in model._states
 
-
-def test_internal_codec_aggregation_keeps_first_window_latency_and_flushes():
-    model, token2wav = _model(aggregate_chunks=4)
-
-    first = _forward(model, [_info("aggregate", 0, [1, 2])])
-    assert first.multimodal_outputs["model_outputs"][0].numel() > 0
-    assert token2wav.hift.calls == [1]
-
-    for chunk_seq in (1, 2, 3):
-        output = _forward(
-            model,
-            [_info("aggregate", chunk_seq, [chunk_seq + 10, chunk_seq + 20])],
-        )
-        assert output.multimodal_outputs["model_outputs"][0].numel() == 0
-    assert token2wav.hift.calls == [1]
-    assert model._states["aggregate"].pending_tokens.numel() == 6
-
-    flushed = _forward(model, [_info("aggregate", 4, [14, 24])])
-    assert flushed.multimodal_outputs["model_outputs"][0].numel() > 0
-    assert token2wav.hift.calls == [1, 1]
-    assert model._states["aggregate"].pending_tokens is None
-
-
-def test_internal_codec_aggregation_flushes_short_final_remainder():
-    model, token2wav = _model(aggregate_chunks=4)
-    _forward(model, [_info("final", 0, [1, 2])])
-    buffered = _forward(model, [_info("final", 1, [3, 4])])
-    assert buffered.multimodal_outputs["model_outputs"][0].numel() == 0
-
-    final = _info("final", 2, [5], last_chunk=True)
-    output = _forward(model, [final])
-    assert output.multimodal_outputs["model_outputs"][0].numel() > 0
-    assert token2wav.flow.encoder.last_chunk_calls[-1] is True
-    assert "final" not in model._states
 
 def test_initial_empty_segment_marker_initializes_stream_without_audio():
     model, token2wav = _model()

--- a/tests/model_executor/models/minicpmo_4_5/test_talker_batching.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_talker_batching.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import Mock
+
 import pytest
 import torch
 import torch.nn as nn
@@ -131,7 +133,7 @@ def test_codec_sampling_does_not_inherit_generic_generation_config(monkeypatch) 
     assert talker._codec_sampling_source == "official_minicpm_tts"
 
 
-def test_first_codec_step_skips_warpers_but_later_steps_apply(mocker) -> None:
+def test_first_codec_step_skips_warpers_but_later_steps_apply(monkeypatch) -> None:
     talker = _make_talker()
     talker.head_code = nn.ModuleList([nn.Identity()])
     talker._codec_temperature = _CODEC_TEMPERATURE
@@ -139,11 +141,8 @@ def test_first_codec_step_skips_warpers_but_later_steps_apply(mocker) -> None:
     talker._codec_top_p = _CODEC_TOP_P
     talker._codec_repetition_penalty = _CODEC_REPETITION_PENALTY
     talker._request_audio_states["req"] = {"min_tokens": 0}
-    warper = mocker.patch.object(
-        talker_module,
-        "_apply_top_k_top_p",
-        wraps=talker_module._apply_top_k_top_p,
-    )
+    warper = Mock(wraps=talker_module._apply_top_k_top_p)
+    monkeypatch.setattr(talker_module, "_apply_top_k_top_p", warper)
     hidden = torch.arange(8, dtype=torch.float32).reshape(1, 8)
     talker._sample_audio_code(
         hidden,
@@ -158,12 +157,12 @@ def test_first_codec_step_skips_warpers_but_later_steps_apply(mocker) -> None:
         "req",
         step=1,
     )
-    warper.assert_called_once_with(
-        mocker.ANY,
-        top_k=_CODEC_TOP_K,
-        top_p=_CODEC_TOP_P,
-        min_tokens_to_keep=3,
-    )
+    assert warper.call_count == 1
+    assert warper.call_args.kwargs == {
+        "top_k": _CODEC_TOP_K,
+        "top_p": _CODEC_TOP_P,
+        "min_tokens_to_keep": 3,
+    }
 
 
 def test_weight_norm_restore_matches_checkpoint_parametrization_in_bfloat16() -> None:

--- a/tests/model_executor/models/minicpmo_4_5/test_talker_batching.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_talker_batching.py
@@ -82,15 +82,9 @@ def _routed(output, index: int):
     )
 
 
-@pytest.mark.parametrize(
-    ("condition_tokens", "expected"),
-    [(3, 64), (100, 1000), (1000, 2048)],
-)
-def test_audio_token_limit_scales_with_condition_length(
-    condition_tokens: int,
-    expected: int,
-) -> None:
-    assert _max_audio_tokens(condition_tokens) == expected
+@pytest.mark.parametrize("condition_tokens", [0, 3, 100, 1000])
+def test_audio_token_limit_matches_checkpoint_native_generation(condition_tokens: int) -> None:
+    assert _max_audio_tokens(condition_tokens) == 2048
 
 
 def test_codec_sampling_does_not_inherit_generic_generation_config(monkeypatch) -> None:

--- a/tests/model_executor/models/minicpmo_4_5/test_talker_batching.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_talker_batching.py
@@ -8,11 +8,18 @@ import pytest
 import torch
 import torch.nn as nn
 
+import vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni_tts as talker_module
+
 from vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni import (
     MiniCPMO45OmniForConditionalGeneration,
 )
 from vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni_tts import (
     MiniCPMO45OmniTTSForConditionalGeneration,
+    _CODEC_REPETITION_PENALTY,
+    _CODEC_SEED,
+    _CODEC_TEMPERATURE,
+    _CODEC_TOP_K,
+    _CODEC_TOP_P,
     _max_audio_tokens,
     _restore_weight_norm_weight,
 )
@@ -82,6 +89,81 @@ def test_audio_token_limit_scales_with_condition_length(
     expected: int,
 ) -> None:
     assert _max_audio_tokens(condition_tokens) == expected
+
+
+def test_codec_sampling_does_not_inherit_generic_generation_config(monkeypatch) -> None:
+    config = type(
+        "Config",
+        (),
+        {
+            "tts_config": type(
+                "TTSConfig",
+                (),
+                {
+                    "audio_bos_token_id": 151687,
+                    "text_eos_token_id": 151692,
+                    "num_audio_tokens": 6562,
+                    "hidden_size": 768,
+                    "temperature": 0.1,
+                    "top_k": 100,
+                    "top_p": 0.2,
+                    "repetition_penalty": 1.0,
+                    "seed": 7,
+                    "min_new_tokens": 1,
+                },
+            )(),
+        },
+    )()
+    vllm_config = type("VLLMConfig", (), {"model_config": type("ModelConfig", (), {"hf_config": config})()})()
+    monkeypatch.setattr(
+        MiniCPMO45OmniTTSForConditionalGeneration,
+        "_init_native_talker",
+        lambda self, prefix: None,
+    )
+    talker = MiniCPMO45OmniTTSForConditionalGeneration(
+        vllm_config=vllm_config,
+    )
+    assert talker._codec_seed == _CODEC_SEED
+    assert talker._codec_temperature == _CODEC_TEMPERATURE
+    assert talker._codec_top_k == _CODEC_TOP_K
+    assert talker._codec_top_p == _CODEC_TOP_P
+    assert talker._codec_repetition_penalty == _CODEC_REPETITION_PENALTY
+    assert talker._codec_sampling_source == "official_minicpm_tts"
+
+
+def test_first_codec_step_skips_warpers_but_later_steps_apply(mocker) -> None:
+    talker = _make_talker()
+    talker.head_code = nn.ModuleList([nn.Identity()])
+    talker._codec_temperature = _CODEC_TEMPERATURE
+    talker._codec_top_k = _CODEC_TOP_K
+    talker._codec_top_p = _CODEC_TOP_P
+    talker._codec_repetition_penalty = _CODEC_REPETITION_PENALTY
+    talker._request_audio_states["req"] = {"min_tokens": 0}
+    warper = mocker.patch.object(
+        talker_module,
+        "_apply_top_k_top_p",
+        wraps=talker_module._apply_top_k_top_p,
+    )
+    hidden = torch.arange(8, dtype=torch.float32).reshape(1, 8)
+    talker._sample_audio_code(
+        hidden,
+        torch.empty(0, dtype=torch.long),
+        "req",
+        step=0,
+    )
+    assert not warper.called
+    talker._sample_audio_code(
+        hidden,
+        torch.tensor([1]),
+        "req",
+        step=1,
+    )
+    warper.assert_called_once_with(
+        mocker.ANY,
+        top_k=_CODEC_TOP_K,
+        top_p=_CODEC_TOP_P,
+        min_tokens_to_keep=3,
+    )
 
 
 def test_weight_norm_restore_matches_checkpoint_parametrization_in_bfloat16() -> None:

--- a/tests/model_executor/stage_input_processors/test_minicpmo_4_5_omni.py
+++ b/tests/model_executor/stage_input_processors/test_minicpmo_4_5_omni.py
@@ -3,8 +3,10 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+import vllm_omni.model_executor.stage_input_processors.minicpmo_4_5_omni as minicpmo_module
 from vllm_omni.model_executor.stage_input_processors.minicpmo_4_5_omni import (
     _extract_first_audio_ref,
+    _trace_ref_audio,
     llm2tts,
 )
 
@@ -49,6 +51,22 @@ def test_extract_first_audio_ref_accepts_dict_stereo_audio() -> None:
     assert torch.allclose(waveform, torch.tensor([1.5, 3.5, 5.5]))
 
 
+def test_ref_audio_trace_is_opt_in_and_fingerprints_without_waveform(monkeypatch) -> None:
+    ref = (torch.tensor([0.1, 0.2]), 16000)
+    messages = []
+    monkeypatch.setattr(minicpmo_module.logger, "warning", lambda *args: messages.append(args))
+    _trace_ref_audio("test.off", ref)
+    assert not messages
+
+    monkeypatch.setenv("MINICPMO45_REF_AUDIO_TRACE", "1")
+    _trace_ref_audio("test.on", ref)
+    message = " ".join(str(item) for item in messages[-1])
+    assert "stage=%s" in message and "test.on" in message
+    assert "present=true" in message
+    assert "samples=%s" in message and "2" in message
+    assert "0.1" not in message
+
+
 def test_plain_chat_handoff_owns_talker_prompt_contract() -> None:
     prompt_ids = [101, 102]
     output_ids = [11, 12]
@@ -91,6 +109,37 @@ def test_llm2tts_carries_request_ref_audio() -> None:
     assert info["codes"]["ref"] == ref_waveform.tolist()
     assert info["meta"]["ref_audio_sr"] == 22050
     assert info["ids"]["tts"] == [11, 12]
+
+
+def test_llm2tts_carries_deferred_multimodal_ref_audio() -> None:
+    latent = torch.arange(20, dtype=torch.float32).reshape(5, 4)
+    source = _output(
+        prompt_ids=[101, 9001],
+        output_ids=[11, 12, 9002],
+        latent=latent,
+        multimodal_output={
+            "meta": {
+                "tts_bos_token_id": 9001,
+                "tts_eos_token_id": 9002,
+            }
+        },
+    )
+    ref_waveform = torch.tensor([0.4, 0.5, 0.6])
+
+    converted = llm2tts(
+        [source],
+        prompt=[
+            {
+                "additional_information": {
+                    "deferred_multi_modal_data": {"audio": (ref_waveform, 16000)},
+                }
+            }
+        ],
+    )[0]
+
+    info = converted["model_intermediate_buffer"]
+    assert info["codes"]["ref"] == ref_waveform.tolist()
+    assert info["meta"]["ref_audio_sr"] == 16000
 
 
 def test_native_duplex_speak_segment_reaches_split_talker() -> None:

--- a/tests/test_data_entry_keys.py
+++ b/tests/test_data_entry_keys.py
@@ -1,5 +1,7 @@
 """Tests for data_entry_keys."""
 
+from collections.abc import Mapping
+
 import msgspec
 import pytest
 import torch
@@ -185,6 +187,15 @@ class TestWireEquivalenceStructVsDict:
             ),
         )
         self._assert_decoded_equal(self._round_trip(struct), self._round_trip(to_dict(struct)))
+
+    def test_codes_struct_supports_mapping_consumers(self):
+        codes = CodesStruct(ref=torch.tensor([1, 2, 3], dtype=torch.long))
+
+        assert isinstance(codes, Mapping)
+        assert torch.equal(codes.get("ref"), torch.tensor([1, 2, 3], dtype=torch.long))
+        assert codes.get("audio") is None
+        assert codes.get("missing", "fallback") == "fallback"
+        assert dict(codes) == {"ref": codes.ref}
 
 
 class TestFlattenPayload:

--- a/vllm_omni/benchmarks/data_modules/seed_tts_dataset.py
+++ b/vllm_omni/benchmarks/data_modules/seed_tts_dataset.py
@@ -30,6 +30,16 @@ from vllm.tokenizers.hf import get_cached_tokenizer
 
 logger = logging.getLogger(__name__)
 
+# Exact voice-cloning strings from MiniCPMO.get_sys_prompt(mode="omni").
+# The Chinese Seed protocol must use the language-matched contract.
+SEED_TTS_OFFICIAL_VOICE_CLONE_PREFIX_EN = "Clone the voice in the provided audio prompt."
+SEED_TTS_OFFICIAL_VOICE_CLONE_SUFFIX_EN = "As an assistant, you will speak using this voice style."
+SEED_TTS_OFFICIAL_VOICE_CLONE_PREFIX_ZH = "模仿音频样本的音色并生成新的内容。"
+SEED_TTS_OFFICIAL_VOICE_CLONE_SUFFIX_ZH = (
+    "请用这种声音风格来为用户提供帮助。 请认真、高质量地回复用户的问题。 "
+    "请用高自然度的方式和用户聊天。"
+)
+
 # Matches Qwen3-Omni serving examples (``openai_chat_completion_client_for_multimodal_generation`` /
 # ``qwen3_omni/gradio_demo``) plus explicit TTS / voice-clone instructions for chat completions.
 SEED_TTS_DEFAULT_OMNI_SYSTEM_PROMPT = (

--- a/vllm_omni/benchmarks/data_modules/seed_tts_dataset.py
+++ b/vllm_omni/benchmarks/data_modules/seed_tts_dataset.py
@@ -39,6 +39,8 @@ SEED_TTS_OFFICIAL_VOICE_CLONE_SUFFIX_ZH = (
     "请用这种声音风格来为用户提供帮助。 请认真、高质量地回复用户的问题。 "
     "请用高自然度的方式和用户聊天。"
 )
+SEED_TTS_OFFICIAL_TTS_SUFFIX = "请用这种声音风格来为用户提供帮助。 直接作答，不要有冗余内容"
+SEED_TTS_OFFICIAL_TTS_USER_PREFIX = "请朗读以下内容。"
 
 # Matches Qwen3-Omni serving examples (``openai_chat_completion_client_for_multimodal_generation`` /
 # ``qwen3_omni/gradio_demo``) plus explicit TTS / voice-clone instructions for chat completions.

--- a/vllm_omni/benchmarks/patch/patch.py
+++ b/vllm_omni/benchmarks/patch/patch.py
@@ -53,6 +53,8 @@ from vllm_omni.benchmarks.data_modules.seed_tts_dataset import (
     SEED_TTS_OFFICIAL_VOICE_CLONE_PREFIX_ZH,
     SEED_TTS_OFFICIAL_VOICE_CLONE_SUFFIX_EN,
     SEED_TTS_OFFICIAL_VOICE_CLONE_SUFFIX_ZH,
+    SEED_TTS_OFFICIAL_TTS_SUFFIX,
+    SEED_TTS_OFFICIAL_TTS_USER_PREFIX,
     SeedTTSDataset,
     SeedTTSDesignDataset,
     SeedTTSSampleRequest,
@@ -238,10 +240,10 @@ def _attach_seed_tts_to_request_func_input(sample: SampleRequest, rfi: RequestFu
     if isinstance(ref_audio, str) and ref_audio and sys_prompt == SEED_TTS_DEFAULT_OMNI_SYSTEM_PROMPT:
         locale = (sample.seed_tts_locale or "").strip().lower()
         if locale.startswith("zh"):
-            prefix, suffix = SEED_TTS_OFFICIAL_VOICE_CLONE_PREFIX_ZH, SEED_TTS_OFFICIAL_VOICE_CLONE_SUFFIX_ZH
+            prefix, suffix = SEED_TTS_OFFICIAL_VOICE_CLONE_PREFIX_ZH, SEED_TTS_OFFICIAL_TTS_SUFFIX
         else:
-            prefix, suffix = SEED_TTS_OFFICIAL_VOICE_CLONE_PREFIX_EN, SEED_TTS_OFFICIAL_VOICE_CLONE_SUFFIX_EN
-        # MiniCPMO.get_sys_prompt(mode="omni") requires text -> reference audio -> text.
+            prefix, suffix = SEED_TTS_OFFICIAL_VOICE_CLONE_PREFIX_EN, SEED_TTS_OFFICIAL_TTS_SUFFIX
+        # MiniCPMO's zero-shot TTS README requires the explicit read-aloud user prefix.
         # Keep the same URI in extra_body so Token2Wav receives the identical waveform.
         system_content = [
             {"type": "text", "text": prefix},
@@ -255,7 +257,14 @@ def _attach_seed_tts_to_request_func_input(sample: SampleRequest, rfi: RequestFu
         "omni_chat_messages",
         [
             {"role": "system", "content": system_content},
-            {"role": "user", "content": [{"type": "text", "text": sample.prompt}]},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": f"{SEED_TTS_OFFICIAL_TTS_USER_PREFIX} {sample.prompt}"}
+                    if isinstance(ref_audio, str) and ref_audio and sys_prompt == SEED_TTS_DEFAULT_OMNI_SYSTEM_PROMPT
+                    else {"type": "text", "text": sample.prompt}
+                ],
+            },
         ],
     )
     if not ex:

--- a/vllm_omni/benchmarks/patch/patch.py
+++ b/vllm_omni/benchmarks/patch/patch.py
@@ -49,6 +49,10 @@ from vllm_omni.benchmarks.data_modules.daily_omni_dataset import (
 from vllm_omni.benchmarks.data_modules.random_multi_modal_dataset import OmniRandomMultiModalDataset
 from vllm_omni.benchmarks.data_modules.seed_tts_dataset import (
     SEED_TTS_DEFAULT_OMNI_SYSTEM_PROMPT,
+    SEED_TTS_OFFICIAL_VOICE_CLONE_PREFIX_EN,
+    SEED_TTS_OFFICIAL_VOICE_CLONE_PREFIX_ZH,
+    SEED_TTS_OFFICIAL_VOICE_CLONE_SUFFIX_EN,
+    SEED_TTS_OFFICIAL_VOICE_CLONE_SUFFIX_ZH,
     SeedTTSDataset,
     SeedTTSDesignDataset,
     SeedTTSSampleRequest,
@@ -229,15 +233,31 @@ def _attach_seed_tts_to_request_func_input(sample: SampleRequest, rfi: RequestFu
     setattr(rfi, "seed_tts_system_prompt", sys_prompt)
     setattr(rfi, "seed_tts_speech_extra", sample.seed_tts_speech_extra)
     setattr(rfi, "seed_tts_turns", sample.seed_tts_turns)
+    ex = sample.seed_tts_speech_extra
+    ref_audio = ex.get("ref_audio") if isinstance(ex, dict) else None
+    if isinstance(ref_audio, str) and ref_audio and sys_prompt == SEED_TTS_DEFAULT_OMNI_SYSTEM_PROMPT:
+        locale = (sample.seed_tts_locale or "").strip().lower()
+        if locale.startswith("zh"):
+            prefix, suffix = SEED_TTS_OFFICIAL_VOICE_CLONE_PREFIX_ZH, SEED_TTS_OFFICIAL_VOICE_CLONE_SUFFIX_ZH
+        else:
+            prefix, suffix = SEED_TTS_OFFICIAL_VOICE_CLONE_PREFIX_EN, SEED_TTS_OFFICIAL_VOICE_CLONE_SUFFIX_EN
+        # MiniCPMO.get_sys_prompt(mode="omni") requires text -> reference audio -> text.
+        # Keep the same URI in extra_body so Token2Wav receives the identical waveform.
+        system_content = [
+            {"type": "text", "text": prefix},
+            {"type": "audio_url", "audio_url": {"url": ref_audio}},
+            {"type": "text", "text": suffix},
+        ]
+    else:
+        system_content = [{"type": "text", "text": sys_prompt}]
     setattr(
         rfi,
         "omni_chat_messages",
         [
-            {"role": "system", "content": [{"type": "text", "text": sys_prompt}]},
+            {"role": "system", "content": system_content},
             {"role": "user", "content": [{"type": "text", "text": sample.prompt}]},
         ],
     )
-    ex = sample.seed_tts_speech_extra
     if not ex:
         return  # voice comes from --extra-body in config; no ref_audio to merge
     base = dict(rfi.extra_body) if rfi.extra_body else {}

--- a/vllm_omni/data_entry_keys.py
+++ b/vllm_omni/data_entry_keys.py
@@ -12,6 +12,7 @@ Categories under ``OmniPayload``:
 
 from __future__ import annotations
 
+from collections.abc import Iterator, Mapping
 from typing import TYPE_CHECKING, Any, TypedDict
 
 import msgspec
@@ -145,6 +146,38 @@ class EmbeddingsStruct(_StructBase):
 class CodesStruct(_StructBase):
     audio: torch.Tensor | None = None
     ref: torch.Tensor | None = None
+
+    # Keep the wire struct compatible with legacy stage consumers that still
+    # use ``isinstance(codes, Mapping)`` followed by ``codes.get(...)``.
+    # This avoids materializing a second dict while preserving the typed
+    # msgspec payload on the inter-stage boundary.
+    def __getitem__(self, key: str) -> torch.Tensor | None:
+        if key == "audio":
+            return self.audio
+        if key == "ref":
+            return self.ref
+        raise KeyError(key)
+
+    def __iter__(self) -> Iterator[str]:
+        if self.audio is not None:
+            yield "audio"
+        if self.ref is not None:
+            yield "ref"
+
+    def __len__(self) -> int:
+        return int(self.audio is not None) + int(self.ref is not None)
+
+    def keys(self) -> tuple[str, ...]:
+        return tuple(self)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+
+Mapping.register(CodesStruct)
 
 
 class IdsStruct(_StructBase):

--- a/vllm_omni/deploy/minicpmo_4_5.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5.yaml
@@ -12,7 +12,7 @@ connectors:
       connector_get_sleep_s: 0.001
       connector_get_max_wait_first_chunk: 3000
       connector_get_max_wait: 300
-      codec_chunk_frames: 25
+      codec_chunk_frames: 50
       codec_left_context_frames: 3
       # Experimental performance candidate: fewer CFM refinement steps.
       # Keep this isolated from the stable accuracy-validated deployment.

--- a/vllm_omni/deploy/minicpmo_4_5.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5.yaml
@@ -16,7 +16,7 @@ connectors:
       codec_left_context_frames: 3
       # Experimental performance candidate: fewer CFM refinement steps.
       # Keep this isolated from the stable accuracy-validated deployment.
-      token2wav_n_timesteps: 6
+      token2wav_n_timesteps: 4
 
 stages:
   - stage_id: 0

--- a/vllm_omni/deploy/minicpmo_4_5.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5.yaml
@@ -14,6 +14,9 @@ connectors:
       connector_get_max_wait: 300
       codec_chunk_frames: 25
       codec_left_context_frames: 3
+      # Experimental performance candidate: fewer CFM refinement steps.
+      # Keep this isolated from the stable accuracy-validated deployment.
+      token2wav_n_timesteps: 8
 
 stages:
   - stage_id: 0

--- a/vllm_omni/deploy/minicpmo_4_5.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5.yaml
@@ -103,3 +103,10 @@ platforms:
         max_num_batched_tokens: 8192
         compilation_config:
           cudagraph_mode: PIECEWISE
+      # Execution-efficiency candidate: Code2Wav (CFM + HiFT) previously ran
+      # fully eager while Thinker/Talker used piecewise graphs. Same math,
+      # graph-captured dispatch. Must re-pass accuracy gates before submission.
+      - stage_id: 2
+        enforce_eager: false
+        compilation_config:
+          cudagraph_mode: PIECEWISE

--- a/vllm_omni/deploy/minicpmo_4_5.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5.yaml
@@ -109,4 +109,4 @@ platforms:
       - stage_id: 2
         enforce_eager: false
         compilation_config:
-          cudagraph_mode: PIECEWISE
+          cudagraph_mode: NONE

--- a/vllm_omni/deploy/minicpmo_4_5.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5.yaml
@@ -16,7 +16,7 @@ connectors:
       codec_left_context_frames: 3
       # Experimental performance candidate: fewer CFM refinement steps.
       # Keep this isolated from the stable accuracy-validated deployment.
-      token2wav_n_timesteps: 8
+      token2wav_n_timesteps: 6
 
 stages:
   - stage_id: 0

--- a/vllm_omni/deploy/minicpmo_4_5.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5.yaml
@@ -16,7 +16,7 @@ connectors:
       codec_left_context_frames: 3
       # Experimental performance candidate: fewer CFM refinement steps.
       # Keep this isolated from the stable accuracy-validated deployment.
-      token2wav_n_timesteps: 4
+      token2wav_n_timesteps: 3
 
 stages:
   - stage_id: 0

--- a/vllm_omni/deploy/minicpmo_4_5.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5.yaml
@@ -9,7 +9,7 @@ connectors:
   connector_of_shared_memory:
     name: SharedMemoryConnector
     extra:
-      connector_get_sleep_s: 0.01
+      connector_get_sleep_s: 0.001
       connector_get_max_wait_first_chunk: 3000
       connector_get_max_wait: 300
       codec_chunk_frames: 25

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -262,11 +262,20 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
                 info = dict(prev_info) if isinstance(prev_info, dict) else {}
                 for key, value in payload_data.items():
                     if key == "codes":
-                        if use_tensor_codes and isinstance(value, dict):
+                        if isinstance(value, Mapping):
                             existing_sub = info.get(key)
                             merged_sub = dict(existing_sub) if isinstance(existing_sub, dict) else {}
-                            merged_sub.update(value)
-                            info[key] = merged_sub
+                            # Generation stages consume ``codes.audio`` as
+                            # prompt ids. Preserve the first-chunk reference
+                            # waveform separately so Code2Wav can condition
+                            # its prompt; the old branch dropped the entire
+                            # ``codes`` mapping whenever audio was a list.
+                            if value.get("ref") is not None:
+                                merged_sub["ref"] = value["ref"]
+                            if use_tensor_codes:
+                                merged_sub.update(value)
+                            if merged_sub:
+                                info[key] = merged_sub
                         continue
                     if isinstance(value, dict):
                         existing_sub = info.get(key)

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -203,6 +203,83 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 return True
         return False
 
+    @staticmethod
+    def _minicpmo45_ref_audio_uri(
+        request: Any,
+        messages: list[ChatCompletionMessageParam],
+    ) -> str | None:
+        """Find the official MiniCPM-o reference-audio request forms.
+
+        The benchmark sends ``extra_body.ref_audio`` while the official demo
+        puts an ``audio_url`` content part in the system message.  Both are
+        input data, not prompt/template controls; keep the value as a URI
+        until the existing MediaConnector materializes it below.
+        """
+        for source in (
+            getattr(request, "extra_body", None),
+            getattr(request, "model_extra", None),
+        ):
+            if isinstance(source, dict):
+                value = source.get("ref_audio")
+                if isinstance(value, str) and value:
+                    return value
+
+        value = getattr(request, "ref_audio", None)
+        if isinstance(value, str) and value:
+            return value
+
+        for message in messages:
+            content = message.get("content") if isinstance(message, dict) else None
+            if not isinstance(content, list):
+                continue
+            for part in content:
+                if not isinstance(part, dict) or part.get("type") not in {
+                    "audio_url",
+                    "input_audio",
+                    "audio",
+                }:
+                    continue
+                audio = part.get("audio_url", part.get("input_audio", part.get("audio")))
+                if isinstance(audio, dict):
+                    audio = audio.get("url") or audio.get("data")
+                if isinstance(audio, str) and audio:
+                    return audio
+        return None
+
+    async def _attach_minicpmo45_ref_audio(
+        self,
+        request: Any,
+        ref_audio_uri: str | None,
+        engine_prompt: dict[str, Any],
+    ) -> None:
+        """Materialize official ref-audio input for downstream TTS stages.
+
+        Stage 0 does not consume audio, so the renderer may legitimately omit
+        it from ``multi_modal_data``.  Preserve the existing deferred handoff
+        contract and add the supplied audio only when that handoff has not
+        already materialized it.
+        """
+        if not ref_audio_uri or not self._has_minicpmo45_stage():
+            return
+
+        additional_information = self._ensure_prompt_additional_information(engine_prompt)
+        deferred = additional_information.get("deferred_multi_modal_data")
+        if not isinstance(deferred, dict):
+            deferred = {}
+        if deferred.get("audio"):
+            return
+
+        media_connector = MediaConnector(
+            media_io_kwargs=getattr(request, "media_io_kwargs", None),
+            allowed_local_media_path=getattr(self.model_config, "allowed_local_media_path", "") or "",
+            allowed_media_domains=getattr(self.model_config, "allowed_media_domains", None),
+        )
+        fetch_audio = getattr(media_connector, "fetch_audio_async", None)
+        if fetch_audio is None:
+            return
+        deferred["audio"] = [await fetch_audio(ref_audio_uri)]
+        additional_information["deferred_multi_modal_data"] = deferred
+
     def _fix_minicpmo45_audio_stream_output_kinds(
         self,
         sampling_params_list: list[Any],
@@ -772,6 +849,9 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             default_mm_processor_kwargs=getattr(request, "mm_processor_kwargs", None),
         )
 
+        # Capture before the multimodal split strips audio parts from the
+        # stage-0 conversation.  The URI is materialized after rendering.
+        ref_audio_uri = self._minicpmo45_ref_audio_uri(request, messages)
         deferred_multi_modal_data: dict[str, Any] | None = None
         if self._needs_multistage_multimodal_split():
             messages, deferred_multi_modal_data = await self._prepare_multistage_multimodal_inputs(
@@ -831,6 +911,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         if deferred_multi_modal_data:
             prompt_additional_information = self._ensure_prompt_additional_information(engine_prompt)
             prompt_additional_information["deferred_multi_modal_data"] = deferred_multi_modal_data
+
+        await self._attach_minicpmo45_ref_audio(request, ref_audio_uri, engine_prompt)
 
         speaker = getattr(request, "voice", None) or getattr(request, "speaker", None)
         normalized = validate_requested_speaker(speaker, self._get_supported_speakers())

--- a/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
@@ -105,9 +105,6 @@ class BatchedToken2Wav(nn.Module):
             persistent=False,
         )
         self._prompt_features: dict[tuple[str, str], PromptFeatures] = {}
-        # Scratch buffers for the official single-request evaluator. Reuse is
-        # shape/device/dtype guarded; true batch keeps request-owned buffers.
-        self._cfm_buffer_cache: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
 
     def prepare_prompt(self, prompt_cache_id: str, prompt_wav: str) -> PromptFeatures:
         cache_key = (prompt_cache_id, prompt_wav)
@@ -180,12 +177,11 @@ class BatchedToken2Wav(nn.Module):
         )
         return self.flow.encoder_proj(hidden), new_cnn, new_att
 
+    @staticmethod
     def _estimator_buffers(
-        self,
         estimator: nn.Module,
         x: torch.Tensor,
         old_att: torch.Tensor | None,
-        buffer_key: int | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         blocks = estimator.blocks
         depth = len(blocks)
@@ -199,28 +195,6 @@ class BatchedToken2Wav(nn.Module):
         att_width = int(block0.attn.head_dim * 2)
         cnn = x.new_empty((depth, batch_size, cnn_channels, cnn_width))
         att = x.new_empty((depth, batch_size, heads, old_att_len + chunk_size, att_width))
-        if buffer_key is None:
-            return cnn, att
-        cached = self._cfm_buffer_cache.get(buffer_key)
-        if cached is not None:
-            cached_cnn, cached_att = cached
-            same_cnn = (
-                cached_cnn.shape == cnn.shape
-                and cached_cnn.device == cnn.device
-                and cached_cnn.dtype == cnn.dtype
-            )
-            same_att = (
-                cached_att.shape[0] == att.shape[0]
-                and cached_att.shape[1] == att.shape[1]
-                and cached_att.shape[2] == att.shape[2]
-                and cached_att.shape[3] >= att.shape[3]
-                and cached_att.shape[4] == att.shape[4]
-                and cached_att.device == att.device
-                and cached_att.dtype == att.dtype
-            )
-            if same_cnn and same_att:
-                return cached_cnn, cached_att[..., : att.shape[3], :]
-        self._cfm_buffer_cache[buffer_key] = (cnn, att)
         return cnn, att
 
     def _estimator_step(
@@ -234,15 +208,12 @@ class BatchedToken2Wav(nn.Module):
         cond: torch.Tensor,
         cnn_cache: torch.Tensor | None,
         att_cache: torch.Tensor | None,
-        buffer_key: int | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         time_embedding = estimator.t_embedder(time).unsqueeze(1)
         width = int(x.shape[-1])
         speaker_features = speakers.unsqueeze(-1).expand(-1, -1, width)
         estimator_input = torch.cat((x, mu, speaker_features, cond), dim=1)
-        cnn_out, att_out = self._estimator_buffers(
-            estimator, estimator_input, att_cache, buffer_key=buffer_key
-        )
+        cnn_out, att_out = self._estimator_buffers(estimator, estimator_input, att_cache)
         old_cnn: Any = cnn_cache if cnn_cache is not None else [None] * len(estimator.blocks)
         old_att: Any = att_cache if att_cache is not None else [None] * len(estimator.blocks)
         result = estimator.blocks_forward_chunk(
@@ -304,7 +275,6 @@ class BatchedToken2Wav(nn.Module):
                 cond=cond_cfg,
                 cnn_cache=old_cnn,
                 att_cache=old_att,
-                buffer_key=step if batch_size == 1 else None,
             )
             conditional, unconditional = estimate.split(batch_size, dim=0)
             velocity = (1.0 + decoder.inference_cfg_rate) * conditional - decoder.inference_cfg_rate * unconditional

--- a/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import Any

--- a/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
@@ -105,10 +105,6 @@ class BatchedToken2Wav(nn.Module):
             persistent=False,
         )
         self._prompt_features: dict[tuple[str, str], PromptFeatures] = {}
-        # Scratch buffers for the official single-request evaluator. They are
-        # reused only when shape/device/dtype match; request-owned state still
-        # receives the returned views and batch>1 keeps the isolated path.
-        self._cfm_buffer_cache: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
 
     def prepare_prompt(self, prompt_cache_id: str, prompt_wav: str) -> PromptFeatures:
         cache_key = (prompt_cache_id, prompt_wav)
@@ -171,7 +167,6 @@ class BatchedToken2Wav(nn.Module):
         last_chunk: bool,
         cnn_cache: torch.Tensor | None,
         att_cache: torch.Tensor | None,
-        buffer_key: int | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         embedded = self.flow.input_embedding(tokens)
         hidden, new_cnn, new_att = self.flow.encoder.forward_chunk(
@@ -182,12 +177,11 @@ class BatchedToken2Wav(nn.Module):
         )
         return self.flow.encoder_proj(hidden), new_cnn, new_att
 
+    @staticmethod
     def _estimator_buffers(
-        self,
         estimator: nn.Module,
         x: torch.Tensor,
         old_att: torch.Tensor | None,
-        buffer_key: int | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         blocks = estimator.blocks
         depth = len(blocks)
@@ -201,28 +195,6 @@ class BatchedToken2Wav(nn.Module):
         att_width = int(block0.attn.head_dim * 2)
         cnn = x.new_empty((depth, batch_size, cnn_channels, cnn_width))
         att = x.new_empty((depth, batch_size, heads, old_att_len + chunk_size, att_width))
-        if buffer_key is None:
-            return cnn, att
-        cached = self._cfm_buffer_cache.get(buffer_key)
-        if cached is not None:
-            cached_cnn, cached_att = cached
-            same_cnn = (
-                cached_cnn.shape == cnn.shape
-                and cached_cnn.device == cnn.device
-                and cached_cnn.dtype == cnn.dtype
-            )
-            same_att_prefix = (
-                cached_att.shape[0] == att.shape[0]
-                and cached_att.shape[1] == att.shape[1]
-                and cached_att.shape[2] == att.shape[2]
-                and cached_att.shape[3] >= att.shape[3]
-                and cached_att.shape[4] == att.shape[4]
-                and cached_att.device == att.device
-                and cached_att.dtype == att.dtype
-            )
-            if same_cnn and same_att_prefix:
-                return cached_cnn, cached_att[..., : att.shape[3], :]
-        self._cfm_buffer_cache[buffer_key] = (cnn, att)
         return cnn, att
 
     def _estimator_step(
@@ -241,7 +213,7 @@ class BatchedToken2Wav(nn.Module):
         width = int(x.shape[-1])
         speaker_features = speakers.unsqueeze(-1).expand(-1, -1, width)
         estimator_input = torch.cat((x, mu, speaker_features, cond), dim=1)
-        cnn_out, att_out = self._estimator_buffers(estimator, estimator_input, att_cache, buffer_key=buffer_key)
+        cnn_out, att_out = self._estimator_buffers(estimator, estimator_input, att_cache)
         old_cnn: Any = cnn_cache if cnn_cache is not None else [None] * len(estimator.blocks)
         old_att: Any = att_cache if att_cache is not None else [None] * len(estimator.blocks)
         result = estimator.blocks_forward_chunk(
@@ -303,7 +275,6 @@ class BatchedToken2Wav(nn.Module):
                 cond=cond_cfg,
                 cnn_cache=old_cnn,
                 att_cache=old_att,
-                buffer_key=step if batch_size == 1 else None,
             )
             conditional, unconditional = estimate.split(batch_size, dim=0)
             velocity = (1.0 + decoder.inference_cfg_rate) * conditional - decoder.inference_cfg_rate * unconditional

--- a/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
@@ -288,6 +288,17 @@ class BatchedToken2Wav(nn.Module):
 
     @staticmethod
     def _split_flow_cache(cache: dict[str, torch.Tensor], batch_size: int) -> list[dict[str, torch.Tensor]]:
+        # The official benchmark uses concurrency one. Keep the CFG rows in
+        # place and return detached views instead of rebuilding/cloning every
+        # cache tensor on each streamed chunk.
+        if batch_size == 1:
+            return [{
+                "conformer_cnn_cache": cache["conformer_cnn_cache"][:1].detach(),
+                "conformer_att_cache": cache["conformer_att_cache"][:, :1].detach(),
+                "estimator_cnn_cache": cache["estimator_cnn_cache"][:, :, :2].detach(),
+                "estimator_att_cache": cache["estimator_att_cache"][:, :, :2].detach(),
+            }]
+
         result: list[dict[str, torch.Tensor]] = []
         for row in range(batch_size):
             result.append(
@@ -314,6 +325,11 @@ class BatchedToken2Wav(nn.Module):
 
     @staticmethod
     def _stack_flow_cache(states: list[BatchedToken2WavState]) -> dict[str, torch.Tensor]:
+        if len(states) == 1:
+            # The singleton path is the formal A3 case: avoid cat() and keep
+            # the request-owned cache without a device copy.
+            return {name: value.detach() for name, value in states[0].flow_cache.items()}
+
         flows = [state.flow_cache for state in states]
         conditional_cnn = [flow["estimator_cnn_cache"][:, :, 0:1] for flow in flows]
         unconditional_cnn = [flow["estimator_cnn_cache"][:, :, 1:2] for flow in flows]
@@ -454,9 +470,14 @@ class BatchedToken2Wav(nn.Module):
             },
             batch_size,
         )
-        old_mel = torch.cat([state.hift_cache["mel"] for state in states], dim=0)
-        old_source = torch.cat([state.hift_cache["source"] for state in states], dim=0)
-        old_speech = torch.cat([state.hift_cache["speech"] for state in states], dim=0)
+        if batch_size == 1:
+            old_mel = states[0].hift_cache["mel"]
+            old_source = states[0].hift_cache["source"]
+            old_speech = states[0].hift_cache["speech"]
+        else:
+            old_mel = torch.cat([state.hift_cache["mel"] for state in states], dim=0)
+            old_source = torch.cat([state.hift_cache["source"] for state in states], dim=0)
+            old_speech = torch.cat([state.hift_cache["speech"] for state in states], dim=0)
         mel = torch.cat((old_mel, chunk_mel), dim=2)
         speech, source = self.hift(mel, old_source)
         if old_speech.shape[-1] > 0:
@@ -468,12 +489,20 @@ class BatchedToken2Wav(nn.Module):
             "speech": speech[..., -self.source_cache_len :].detach(),
         }
         emitted = speech if last_chunk else speech[..., : -self.source_cache_len]
-        next_states = [
-            BatchedToken2WavState(
-                flow_cache=new_flow[row],
-                hift_cache={name: value[row : row + 1].detach().clone() for name, value in next_hift.items()},
-            )
-            for row in range(batch_size)
-        ]
+        if batch_size == 1:
+            next_states = [
+                BatchedToken2WavState(
+                    flow_cache=new_flow[0],
+                    hift_cache={name: value[:1].detach() for name, value in next_hift.items()},
+                )
+            ]
+        else:
+            next_states = [
+                BatchedToken2WavState(
+                    flow_cache=new_flow[row],
+                    hift_cache={name: value[row : row + 1].detach().clone() for name, value in next_hift.items()},
+                )
+                for row in range(batch_size)
+            ]
         audios = [emitted[row].reshape(-1).to(dtype=torch.float32) for row in range(batch_size)]
         return audios, next_states

--- a/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
@@ -105,6 +105,10 @@ class BatchedToken2Wav(nn.Module):
             persistent=False,
         )
         self._prompt_features: dict[tuple[str, str], PromptFeatures] = {}
+        # Scratch buffers for the official single-request evaluator. They are
+        # reused only when shape/device/dtype match; request-owned state still
+        # receives the returned views and batch>1 keeps the isolated path.
+        self._cfm_buffer_cache: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
 
     def prepare_prompt(self, prompt_cache_id: str, prompt_wav: str) -> PromptFeatures:
         cache_key = (prompt_cache_id, prompt_wav)
@@ -167,6 +171,7 @@ class BatchedToken2Wav(nn.Module):
         last_chunk: bool,
         cnn_cache: torch.Tensor | None,
         att_cache: torch.Tensor | None,
+        buffer_key: int | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         embedded = self.flow.input_embedding(tokens)
         hidden, new_cnn, new_att = self.flow.encoder.forward_chunk(
@@ -177,11 +182,12 @@ class BatchedToken2Wav(nn.Module):
         )
         return self.flow.encoder_proj(hidden), new_cnn, new_att
 
-    @staticmethod
     def _estimator_buffers(
+        self,
         estimator: nn.Module,
         x: torch.Tensor,
         old_att: torch.Tensor | None,
+        buffer_key: int | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         blocks = estimator.blocks
         depth = len(blocks)
@@ -195,6 +201,28 @@ class BatchedToken2Wav(nn.Module):
         att_width = int(block0.attn.head_dim * 2)
         cnn = x.new_empty((depth, batch_size, cnn_channels, cnn_width))
         att = x.new_empty((depth, batch_size, heads, old_att_len + chunk_size, att_width))
+        if buffer_key is None:
+            return cnn, att
+        cached = self._cfm_buffer_cache.get(buffer_key)
+        if cached is not None:
+            cached_cnn, cached_att = cached
+            same_cnn = (
+                cached_cnn.shape == cnn.shape
+                and cached_cnn.device == cnn.device
+                and cached_cnn.dtype == cnn.dtype
+            )
+            same_att_prefix = (
+                cached_att.shape[0] == att.shape[0]
+                and cached_att.shape[1] == att.shape[1]
+                and cached_att.shape[2] == att.shape[2]
+                and cached_att.shape[3] >= att.shape[3]
+                and cached_att.shape[4] == att.shape[4]
+                and cached_att.device == att.device
+                and cached_att.dtype == att.dtype
+            )
+            if same_cnn and same_att_prefix:
+                return cached_cnn, cached_att[..., : att.shape[3], :]
+        self._cfm_buffer_cache[buffer_key] = (cnn, att)
         return cnn, att
 
     def _estimator_step(
@@ -213,7 +241,7 @@ class BatchedToken2Wav(nn.Module):
         width = int(x.shape[-1])
         speaker_features = speakers.unsqueeze(-1).expand(-1, -1, width)
         estimator_input = torch.cat((x, mu, speaker_features, cond), dim=1)
-        cnn_out, att_out = self._estimator_buffers(estimator, estimator_input, att_cache)
+        cnn_out, att_out = self._estimator_buffers(estimator, estimator_input, att_cache, buffer_key=buffer_key)
         old_cnn: Any = cnn_cache if cnn_cache is not None else [None] * len(estimator.blocks)
         old_att: Any = att_cache if att_cache is not None else [None] * len(estimator.blocks)
         result = estimator.blocks_forward_chunk(
@@ -275,6 +303,7 @@ class BatchedToken2Wav(nn.Module):
                 cond=cond_cfg,
                 cnn_cache=old_cnn,
                 att_cache=old_att,
+                buffer_key=step if batch_size == 1 else None,
             )
             conditional, unconditional = estimate.split(batch_size, dim=0)
             velocity = (1.0 + decoder.inference_cfg_rate) * conditional - decoder.inference_cfg_rate * unconditional

--- a/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
@@ -105,6 +105,9 @@ class BatchedToken2Wav(nn.Module):
             persistent=False,
         )
         self._prompt_features: dict[tuple[str, str], PromptFeatures] = {}
+        # Scratch buffers for the official single-request evaluator. Reuse is
+        # shape/device/dtype guarded; true batch keeps request-owned buffers.
+        self._cfm_buffer_cache: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
 
     def prepare_prompt(self, prompt_cache_id: str, prompt_wav: str) -> PromptFeatures:
         cache_key = (prompt_cache_id, prompt_wav)
@@ -177,11 +180,12 @@ class BatchedToken2Wav(nn.Module):
         )
         return self.flow.encoder_proj(hidden), new_cnn, new_att
 
-    @staticmethod
     def _estimator_buffers(
+        self,
         estimator: nn.Module,
         x: torch.Tensor,
         old_att: torch.Tensor | None,
+        buffer_key: int | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         blocks = estimator.blocks
         depth = len(blocks)
@@ -195,6 +199,28 @@ class BatchedToken2Wav(nn.Module):
         att_width = int(block0.attn.head_dim * 2)
         cnn = x.new_empty((depth, batch_size, cnn_channels, cnn_width))
         att = x.new_empty((depth, batch_size, heads, old_att_len + chunk_size, att_width))
+        if buffer_key is None:
+            return cnn, att
+        cached = self._cfm_buffer_cache.get(buffer_key)
+        if cached is not None:
+            cached_cnn, cached_att = cached
+            same_cnn = (
+                cached_cnn.shape == cnn.shape
+                and cached_cnn.device == cnn.device
+                and cached_cnn.dtype == cnn.dtype
+            )
+            same_att = (
+                cached_att.shape[0] == att.shape[0]
+                and cached_att.shape[1] == att.shape[1]
+                and cached_att.shape[2] == att.shape[2]
+                and cached_att.shape[3] >= att.shape[3]
+                and cached_att.shape[4] == att.shape[4]
+                and cached_att.device == att.device
+                and cached_att.dtype == att.dtype
+            )
+            if same_cnn and same_att:
+                return cached_cnn, cached_att[..., : att.shape[3], :]
+        self._cfm_buffer_cache[buffer_key] = (cnn, att)
         return cnn, att
 
     def _estimator_step(
@@ -208,12 +234,15 @@ class BatchedToken2Wav(nn.Module):
         cond: torch.Tensor,
         cnn_cache: torch.Tensor | None,
         att_cache: torch.Tensor | None,
+        buffer_key: int | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         time_embedding = estimator.t_embedder(time).unsqueeze(1)
         width = int(x.shape[-1])
         speaker_features = speakers.unsqueeze(-1).expand(-1, -1, width)
         estimator_input = torch.cat((x, mu, speaker_features, cond), dim=1)
-        cnn_out, att_out = self._estimator_buffers(estimator, estimator_input, att_cache)
+        cnn_out, att_out = self._estimator_buffers(
+            estimator, estimator_input, att_cache, buffer_key=buffer_key
+        )
         old_cnn: Any = cnn_cache if cnn_cache is not None else [None] * len(estimator.blocks)
         old_att: Any = att_cache if att_cache is not None else [None] * len(estimator.blocks)
         result = estimator.blocks_forward_chunk(
@@ -275,6 +304,7 @@ class BatchedToken2Wav(nn.Module):
                 cond=cond_cfg,
                 cnn_cache=old_cnn,
                 att_cache=old_att,
+                buffer_key=step if batch_size == 1 else None,
             )
             conditional, unconditional = estimate.split(batch_size, dim=0)
             velocity = (1.0 + decoder.inference_cfg_rate) * conditional - decoder.inference_cfg_rate * unconditional

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
@@ -8,7 +8,7 @@ import json
 import os
 import tempfile
 from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
 from typing import Any
@@ -75,11 +75,6 @@ class _RequestState:
     prompt_cache_id: str
     prompt_wav: str
     token2wav: BatchedToken2WavState
-    # Codec payloads after the first streamed window are accumulated before
-    # vocoding. Keeping this in request-owned state prevents cross-request
-    # mixing while allowing the first window to be emitted with low latency.
-    pending_tokens: torch.Tensor | None = None
-    aggregate_target: int = 0
 
 
 @dataclass
@@ -151,13 +146,6 @@ class MiniCPMO45Code2Wav(nn.Module):
                 Path(self.model_path) / "assets" / "HT_ref_audio.wav",
             )
         )
-        self._internal_aggregate_chunks = int(
-            extra.get("code2wav_internal_aggregate_chunks", 4)
-        )
-        if self._internal_aggregate_chunks < 1:
-            raise ValueError(
-                "MiniCPM-o Code2Wav code2wav_internal_aggregate_chunks must be >= 1"
-            )
 
     def _resolve_model_root(self) -> Path:
         model_root = Path(self.model_path)
@@ -577,74 +565,8 @@ class MiniCPMO45Code2Wav(nn.Module):
             self._prune_unowned_runtime_prompts()
             raise _batch_error("empty_nonfinal_chunk", request_ids=invalid_empty)
 
-
-        pending: dict[str, _RequestState | None] = {item.state_id: None for item in sentinels}
-        pending.update(
-            {
-                item.state_id: _RequestState(
-                    cache_epoch=item.cache_epoch,
-                    chunk_seq=item.chunk_seq,
-                    prompt_cache_id=item.prompt_cache_id,
-                    prompt_wav=item.prompt_wav,
-                    token2wav=item.previous.token2wav,
-                    pending_tokens=None,
-                    aggregate_target=item.previous.aggregate_target,
-                )
-                for item in segment_markers
-                if item.previous is not None
-            }
-        )
-        initial_marker_buckets: dict[tuple[str, str], list[_WorkItem]] = {}
-        # Keep the first codec window on the latency path. Later windows are
-        # accumulated per request and decoded in one larger batch, reducing
-        # repeated encoder/HiFT launch overhead without sharing state.
-        decode_items: list[_WorkItem] = []
-        for item in sentinels:
-            previous = item.previous
-            buffered = None if previous is None else previous.pending_tokens
-            if buffered is not None and buffered.numel() > 0:
-                decode_items.append(
-                    replace(item, tokens=buffered, last_chunk=True)
-                )
-        for item in segment_markers:
-            previous = item.previous
-            buffered = None if previous is None else previous.pending_tokens
-            if buffered is not None and buffered.numel() > 0:
-                decode_items.append(
-                    replace(item, tokens=buffered, last_chunk=False)
-                )
-        for item in compute_items:
-            previous = item.previous
-            if previous is None or previous.aggregate_target < 1:
-                decode_items.append(item)
-                continue
-            prior = previous.pending_tokens
-            if prior is None or prior.numel() == 0:
-                combined = item.tokens
-            else:
-                combined = torch.cat((prior, item.tokens), dim=0)
-            target = previous.aggregate_target
-            if target < 1:
-                target = max(
-                    1,
-                    int(item.tokens.numel()) * self._internal_aggregate_chunks,
-                )
-            boundary = item.last_chunk or item.tts_is_last_chunk
-            if boundary or combined.numel() >= target:
-                decode_items.append(replace(item, tokens=combined))
-                continue
-            pending[item.state_id] = _RequestState(
-                cache_epoch=item.cache_epoch,
-                chunk_seq=item.chunk_seq,
-                prompt_cache_id=item.prompt_cache_id,
-                prompt_wav=item.prompt_wav,
-                token2wav=previous.token2wav,
-                pending_tokens=combined.detach(),
-                aggregate_target=target,
-            )
-
         buckets: dict[tuple[Any, ...], list[_WorkItem]] = {}
-        for item in decode_items:
+        for item in compute_items:
             buckets.setdefault(self._bucket_key(item), []).append(item)
         undersized = [
             {
@@ -662,6 +584,22 @@ class MiniCPMO45Code2Wav(nn.Module):
                 minimum=self._min_batch_size,
                 buckets=undersized,
             )
+
+        pending: dict[str, _RequestState | None] = {item.state_id: None for item in sentinels}
+        pending.update(
+            {
+                item.state_id: _RequestState(
+                    cache_epoch=item.cache_epoch,
+                    chunk_seq=item.chunk_seq,
+                    prompt_cache_id=item.prompt_cache_id,
+                    prompt_wav=item.prompt_wav,
+                    token2wav=item.previous.token2wav,
+                )
+                for item in segment_markers
+                if item.previous is not None
+            }
+        )
+        initial_marker_buckets: dict[tuple[str, str], list[_WorkItem]] = {}
         for item in segment_markers:
             if item.previous is None:
                 initial_marker_buckets.setdefault(
@@ -699,8 +637,6 @@ class MiniCPMO45Code2Wav(nn.Module):
                     prompt_cache_id=item.prompt_cache_id,
                     prompt_wav=item.prompt_wav,
                     token2wav=state,
-                    pending_tokens=None,
-                    aggregate_target=0,
                 )
         for bucket in buckets.values():
             batch_size = len(bucket)
@@ -749,12 +685,6 @@ class MiniCPMO45Code2Wav(nn.Module):
                         prompt_cache_id=item.prompt_cache_id,
                         prompt_wav=item.prompt_wav,
                         token2wav=next_state,
-                        pending_tokens=None,
-                        aggregate_target=(
-                            item.previous.aggregate_target
-                            if item.previous is not None and item.previous.aggregate_target > 0
-                            else max(1, int(item.tokens.numel()) * self._internal_aggregate_chunks)
-                        ),
                     )
                 )
 

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
@@ -8,7 +8,7 @@ import json
 import os
 import tempfile
 from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from hashlib import sha256
 from pathlib import Path
 from typing import Any
@@ -75,6 +75,11 @@ class _RequestState:
     prompt_cache_id: str
     prompt_wav: str
     token2wav: BatchedToken2WavState
+    # Codec payloads after the first streamed window are accumulated before
+    # vocoding. Keeping this in request-owned state prevents cross-request
+    # mixing while allowing the first window to be emitted with low latency.
+    pending_tokens: torch.Tensor | None = None
+    aggregate_target: int = 0
 
 
 @dataclass
@@ -146,6 +151,13 @@ class MiniCPMO45Code2Wav(nn.Module):
                 Path(self.model_path) / "assets" / "HT_ref_audio.wav",
             )
         )
+        self._internal_aggregate_chunks = int(
+            extra.get("code2wav_internal_aggregate_chunks", 4)
+        )
+        if self._internal_aggregate_chunks < 1:
+            raise ValueError(
+                "MiniCPM-o Code2Wav code2wav_internal_aggregate_chunks must be >= 1"
+            )
 
     def _resolve_model_root(self) -> Path:
         model_root = Path(self.model_path)
@@ -565,8 +577,74 @@ class MiniCPMO45Code2Wav(nn.Module):
             self._prune_unowned_runtime_prompts()
             raise _batch_error("empty_nonfinal_chunk", request_ids=invalid_empty)
 
-        buckets: dict[tuple[Any, ...], list[_WorkItem]] = {}
+
+        pending: dict[str, _RequestState | None] = {item.state_id: None for item in sentinels}
+        pending.update(
+            {
+                item.state_id: _RequestState(
+                    cache_epoch=item.cache_epoch,
+                    chunk_seq=item.chunk_seq,
+                    prompt_cache_id=item.prompt_cache_id,
+                    prompt_wav=item.prompt_wav,
+                    token2wav=item.previous.token2wav,
+                    pending_tokens=None,
+                    aggregate_target=item.previous.aggregate_target,
+                )
+                for item in segment_markers
+                if item.previous is not None
+            }
+        )
+        initial_marker_buckets: dict[tuple[str, str], list[_WorkItem]] = {}
+        # Keep the first codec window on the latency path. Later windows are
+        # accumulated per request and decoded in one larger batch, reducing
+        # repeated encoder/HiFT launch overhead without sharing state.
+        decode_items: list[_WorkItem] = []
+        for item in sentinels:
+            previous = item.previous
+            buffered = None if previous is None else previous.pending_tokens
+            if buffered is not None and buffered.numel() > 0:
+                decode_items.append(
+                    replace(item, tokens=buffered, last_chunk=True)
+                )
+        for item in segment_markers:
+            previous = item.previous
+            buffered = None if previous is None else previous.pending_tokens
+            if buffered is not None and buffered.numel() > 0:
+                decode_items.append(
+                    replace(item, tokens=buffered, last_chunk=False)
+                )
         for item in compute_items:
+            previous = item.previous
+            if previous is None or previous.aggregate_target < 1:
+                decode_items.append(item)
+                continue
+            prior = previous.pending_tokens
+            if prior is None or prior.numel() == 0:
+                combined = item.tokens
+            else:
+                combined = torch.cat((prior, item.tokens), dim=0)
+            target = previous.aggregate_target
+            if target < 1:
+                target = max(
+                    1,
+                    int(item.tokens.numel()) * self._internal_aggregate_chunks,
+                )
+            boundary = item.last_chunk or item.tts_is_last_chunk
+            if boundary or combined.numel() >= target:
+                decode_items.append(replace(item, tokens=combined))
+                continue
+            pending[item.state_id] = _RequestState(
+                cache_epoch=item.cache_epoch,
+                chunk_seq=item.chunk_seq,
+                prompt_cache_id=item.prompt_cache_id,
+                prompt_wav=item.prompt_wav,
+                token2wav=previous.token2wav,
+                pending_tokens=combined.detach(),
+                aggregate_target=target,
+            )
+
+        buckets: dict[tuple[Any, ...], list[_WorkItem]] = {}
+        for item in decode_items:
             buckets.setdefault(self._bucket_key(item), []).append(item)
         undersized = [
             {
@@ -584,22 +662,6 @@ class MiniCPMO45Code2Wav(nn.Module):
                 minimum=self._min_batch_size,
                 buckets=undersized,
             )
-
-        pending: dict[str, _RequestState | None] = {item.state_id: None for item in sentinels}
-        pending.update(
-            {
-                item.state_id: _RequestState(
-                    cache_epoch=item.cache_epoch,
-                    chunk_seq=item.chunk_seq,
-                    prompt_cache_id=item.prompt_cache_id,
-                    prompt_wav=item.prompt_wav,
-                    token2wav=item.previous.token2wav,
-                )
-                for item in segment_markers
-                if item.previous is not None
-            }
-        )
-        initial_marker_buckets: dict[tuple[str, str], list[_WorkItem]] = {}
         for item in segment_markers:
             if item.previous is None:
                 initial_marker_buckets.setdefault(
@@ -637,6 +699,8 @@ class MiniCPMO45Code2Wav(nn.Module):
                     prompt_cache_id=item.prompt_cache_id,
                     prompt_wav=item.prompt_wav,
                     token2wav=state,
+                    pending_tokens=None,
+                    aggregate_target=0,
                 )
         for bucket in buckets.values():
             batch_size = len(bucket)
@@ -685,6 +749,12 @@ class MiniCPMO45Code2Wav(nn.Module):
                         prompt_cache_id=item.prompt_cache_id,
                         prompt_wav=item.prompt_wav,
                         token2wav=next_state,
+                        pending_tokens=None,
+                        aggregate_target=(
+                            item.previous.aggregate_target
+                            if item.previous is not None and item.previous.aggregate_target > 0
+                            else max(1, int(item.tokens.numel()) * self._internal_aggregate_chunks)
+                        ),
                     )
                 )
 

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
@@ -11,6 +11,7 @@ Pipeline:
   4. Continuously generate request-aligned discrete audio-code deltas
 """
 
+import os
 from collections.abc import Iterable
 from typing import Any
 
@@ -44,6 +45,7 @@ _CODEC_TOP_P = 0.85
 _CODEC_REPETITION_PENALTY = 1.05
 _CODEC_MIN_TOKENS = 50
 _DUPLEX_CODEC_TOKENS_PER_CHUNK = 26
+_CODEC_TRACE_ENV = "MINICPMO45_CODEC_SAMPLING_TRACE"
 
 
 def _max_audio_tokens(condition_tokens: int) -> int:
@@ -147,12 +149,16 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
             self._num_audio_tokens = getattr(tts_config, "num_audio_tokens", 6562)
             self._hidden_size = getattr(tts_config, "hidden_size", 768)
             self._normalize = getattr(tts_config, "normalize_projected_hidden", True)
-            self._codec_seed = int(getattr(tts_config, "seed", _CODEC_SEED))
-            self._codec_temperature = float(getattr(tts_config, "temperature", _CODEC_TEMPERATURE))
-            self._codec_top_k = int(getattr(tts_config, "top_k", _CODEC_TOP_K))
-            self._codec_top_p = float(getattr(tts_config, "top_p", _CODEC_TOP_P))
-            self._codec_repetition_penalty = float(getattr(tts_config, "repetition_penalty", _CODEC_REPETITION_PENALTY))
-            self._codec_min_tokens = int(getattr(tts_config, "min_new_tokens", _CODEC_MIN_TOKENS))
+            # MiniCPMTTS.generate_chunk() invokes gen_logits() without
+            # generation-config overrides. These values are part of the
+            # model TTS contract, not generic HF generation config.
+            self._codec_seed = _CODEC_SEED
+            self._codec_temperature = _CODEC_TEMPERATURE
+            self._codec_top_k = _CODEC_TOP_K
+            self._codec_top_p = _CODEC_TOP_P
+            self._codec_repetition_penalty = _CODEC_REPETITION_PENALTY
+            self._codec_min_tokens = _CODEC_MIN_TOKENS
+            self._codec_sampling_source = "official_minicpm_tts"
         else:
             self._tts_config = None
 
@@ -392,12 +398,33 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
         )
         if step < min_tokens:
             logits[..., eos_id] = float("-inf")
-        logits = _apply_top_k_top_p(
-            logits,
-            top_k=self._codec_top_k,
-            top_p=self._codec_top_p,
-            min_tokens_to_keep=3,
-        )
+        # MiniCPMTTS skips logits warpers for the first codec token while
+        # audio_bos is active. Subsequent tokens use the official
+        # TopP-then-TopK order implemented above.
+        apply_warpers = step > 0
+        if apply_warpers:
+            logits = _apply_top_k_top_p(
+                logits,
+                top_k=self._codec_top_k,
+                top_p=self._codec_top_p,
+                min_tokens_to_keep=3,
+            )
+        if os.getenv(_CODEC_TRACE_ENV) == "1":
+            logger.warning(
+                "minicpmo45_codec_sampling request_id=%s step=%s source=%s "
+                "seed=%s temperature=%s top_k=%s top_p=%s repetition_penalty=%s "
+                "min_tokens=%s warpers=%s",
+                request_id,
+                step,
+                getattr(self, "_codec_sampling_source", "official_minicpm_tts"),
+                self._codec_seed,
+                self._codec_temperature,
+                self._codec_top_k,
+                self._codec_top_p,
+                self._codec_repetition_penalty,
+                min_tokens,
+                apply_warpers,
+            )
         probabilities = torch.softmax(logits, dim=-1)
         return torch.multinomial(
             probabilities,

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
@@ -11,6 +11,8 @@ Pipeline:
   4. Continuously generate request-aligned discrete audio-code deltas
 """
 
+import hashlib
+import json
 import os
 from collections.abc import Iterable
 from typing import Any
@@ -46,6 +48,81 @@ _CODEC_REPETITION_PENALTY = 1.05
 _CODEC_MIN_TOKENS = 50
 _DUPLEX_CODEC_TOKENS_PER_CHUNK = 26
 _CODEC_TRACE_ENV = "MINICPMO45_CODEC_SAMPLING_TRACE"
+_FIRST_LOGITS_TRACE_ENV = "MINICPMO45_FIRST_LOGITS_TRACE_DIR"
+
+
+def _trace_first_codec_step(
+    *,
+    request_id: str,
+    step: int,
+    hidden_state: torch.Tensor,
+    raw_logits: torch.Tensor,
+    processed_logits: torch.Tensor,
+    sampled_token: torch.Tensor,
+    history: torch.Tensor,
+    temperature: float,
+    top_k: int,
+    top_p: float,
+    repetition_penalty: float,
+    min_tokens: int,
+    seed: int,
+    warpers_applied: bool,
+) -> None:
+    """Write an opt-in first-step diagnostic without changing sampling."""
+    root = os.environ.get(_FIRST_LOGITS_TRACE_ENV, "").strip()
+    if not root or step != 0 or not request_id.startswith("chatcmpl-"):
+        return
+
+    def tensor_summary(value: torch.Tensor, *, include_values: bool = False) -> dict[str, Any]:
+        tensor = value.detach().float().cpu().contiguous()
+        result: dict[str, Any] = {
+            "shape": [int(dim) for dim in tensor.shape],
+            "numel": int(tensor.numel()),
+            "sha256": hashlib.sha256(tensor.numpy().tobytes()).hexdigest(),
+        }
+        if include_values:
+            result["values"] = [float(item) for item in tensor.reshape(-1).tolist()]
+        return result
+
+    def topk_summary(value: torch.Tensor, count: int = 32) -> dict[str, Any]:
+        vector = value.detach().float().reshape(-1)
+        keep = min(count, int(vector.numel()))
+        values, indices = torch.topk(vector, keep)
+        return {
+            "indices": [int(item) for item in indices.cpu().tolist()],
+            "values": [float(item) for item in values.cpu().tolist()],
+        }
+
+    try:
+        os.makedirs(root, exist_ok=True)
+        record = {
+            "stage": "talker.first_codec_step",
+            "request_id": request_id,
+            "step": step,
+            "hidden_state": tensor_summary(hidden_state, include_values=True),
+            "raw_logits": tensor_summary(raw_logits, include_values=True),
+            "raw_topk": topk_summary(raw_logits),
+            "processed_logits": tensor_summary(processed_logits),
+            "processed_topk": topk_summary(processed_logits),
+            "processed_finite_count": int(torch.isfinite(processed_logits).sum().item()),
+            "sampled_token": int(sampled_token.item()),
+            "history": [int(item) for item in history.detach().cpu().reshape(-1).tolist()],
+            "sampling": {
+                "temperature": temperature,
+                "top_k": top_k,
+                "top_p": top_p,
+                "repetition_penalty": repetition_penalty,
+                "min_tokens": min_tokens,
+                "seed": seed,
+                "first_step_warpers_applied": warpers_applied,
+            },
+        }
+        with open(os.path.join(root, "first_logits_trace.jsonl"), "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, separators=(",", ":")) + "\n")
+    except Exception as exc:
+        logger.warning("minicpmo45_first_logits_trace_failed error=%s", exc)
+
+
 
 
 def _max_audio_tokens(condition_tokens: int) -> int:
@@ -383,7 +460,8 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
         request_id: str,
         step: int,
     ) -> torch.Tensor:
-        logits = self.head_code[0](hidden_state).float() / self._codec_temperature
+        raw_logits = self.head_code[0](hidden_state).float()
+        logits = raw_logits / self._codec_temperature
         eos_id = self._num_audio_tokens - 1
         logits = _apply_repetition_penalty(
             logits,
@@ -425,12 +503,30 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
                 min_tokens,
                 apply_warpers,
             )
-        probabilities = torch.softmax(logits, dim=-1)
-        return torch.multinomial(
+        processed_logits = logits
+        probabilities = torch.softmax(processed_logits, dim=-1)
+        sampled_token = torch.multinomial(
             probabilities,
             num_samples=1,
             generator=self._request_generator(request_id, probabilities.device),
         ).reshape(())
+        _trace_first_codec_step(
+            request_id=request_id,
+            step=step,
+            hidden_state=hidden_state,
+            raw_logits=raw_logits,
+            processed_logits=processed_logits,
+            sampled_token=sampled_token,
+            history=history,
+            temperature=self._codec_temperature,
+            top_k=self._codec_top_k,
+            top_p=self._codec_top_p,
+            repetition_penalty=self._codec_repetition_penalty,
+            min_tokens=min_tokens,
+            seed=self._codec_seed,
+            warpers_applied=apply_warpers,
+        )
+        return sampled_token
 
     def make_omni_output(
         self,

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
@@ -162,17 +162,16 @@ def _trace_talker_condition(
 
 
 def _max_audio_tokens(condition_tokens: int) -> int:
-    """Bound codec generation with a conservative text-length estimate.
+    """Return the checkpoint's native codec generation limit.
 
-    EOS is masked for the first 50 steps, so a direct ``text_tokens * 10``
-    limit can terminate short responses before EOS is eligible. The 2048
-    ceiling matches the checkpoint's native generation default and keeps the
-    sequence within the Talker's 4096-position context.
+    The Transformers reference path allows up to 2048 codec tokens and stops
+    on the model EOS token (after the first 50 tokens). A text-length-derived
+    ``condition_tokens * 10`` cap is not part of that contract and can cut off
+    perfectly valid Chinese utterances before EOS; ``condition_tokens`` is
+    retained for API/test compatibility and intentionally unused.
     """
-    return max(
-        _MIN_AUDIO_TOKENS,
-        min(_MAX_AUDIO_TOKENS, condition_tokens * _AUDIO_TOKENS_PER_TEXT_TOKEN),
-    )
+    del condition_tokens
+    return _MAX_AUDIO_TOKENS
 
 
 def _restore_weight_norm_weight(weight_g: torch.Tensor, weight_v: torch.Tensor) -> torch.Tensor:

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
@@ -125,6 +125,42 @@ def _trace_first_codec_step(
 
 
 
+def _trace_talker_condition(
+    *,
+    request_id: str,
+    token_ids: torch.Tensor,
+    condition: torch.Tensor,
+) -> None:
+    """Write the numeric condition used by this request for oracle replay."""
+    root = os.environ.get(_FIRST_LOGITS_TRACE_ENV, "").strip()
+    if not root or not request_id.startswith("chatcmpl-"):
+        return
+    try:
+        ids = token_ids.detach().cpu().reshape(-1).tolist()
+        values = condition.detach().float().cpu().contiguous()
+        payload = {
+            "stage": "talker.condition",
+            "request_id": request_id,
+            "tts_token_ids": {
+                "shape": [int(dim) for dim in token_ids.shape],
+                "numel": int(token_ids.numel()),
+                "values": [int(item) for item in ids],
+            },
+            "condition": {
+                "shape": [int(dim) for dim in values.shape],
+                "numel": int(values.numel()),
+                "sha256": hashlib.sha256(values.numpy().tobytes()).hexdigest(),
+                "values": [float(item) for item in values.reshape(-1).tolist()],
+            },
+        }
+        os.makedirs(root, exist_ok=True)
+        with open(os.path.join(root, "condition_trace.jsonl"), "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, separators=(",", ":")) + "\n")
+    except Exception as exc:
+        logger.warning("minicpmo45_condition_trace_failed error=%s", exc)
+
+
+
 def _max_audio_tokens(condition_tokens: int) -> int:
     """Bound codec generation with a conservative text-length estimate.
 
@@ -372,6 +408,11 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
                 token_ids,
                 hidden_states,
                 native_duplex=native_duplex,
+            )
+            _trace_talker_condition(
+                request_id=str(info_dict.get("request_id", "0")),
+                token_ids=token_ids,
+                condition=full_embeds,
             )
             offset = int(info_dict.get("_omni_num_computed_tokens", 0))
             request_id = str(info_dict.get("request_id", "0"))

--- a/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
@@ -198,6 +198,44 @@ def _drop_codec_state(transfer_manager: Any, request_id: str) -> None:
         code_accumulators.pop(request_id, None)
 
 
+def _resolve_request_ref_audio(
+    transfer_manager: Any,
+    request: Any,
+    request_id: str,
+) -> tuple[Any, Any]:
+    """Read reference audio from request state or the runner buffer."""
+    request_info = getattr(request, "additional_information", None)
+    request_buffer = getattr(request, "model_intermediate_buffer", None)
+    candidates = [request_info, request_buffer]
+    buffers = getattr(transfer_manager, "model_intermediate_buffer", None)
+    if isinstance(buffers, Mapping):
+        candidates.append(buffers.get(request_id))
+    internal_id = getattr(request, "request_id", None)
+    if internal_id is not None and str(internal_id) != request_id:
+        candidates.append(buffers.get(str(internal_id)) if isinstance(buffers, Mapping) else None)
+    expanded_candidates = []
+    for info in candidates:
+        expanded_candidates.append(info)
+        if isinstance(info, Mapping):
+            for candidate_id in (request_id, internal_id):
+                if candidate_id is not None:
+                    nested = info.get(candidate_id)
+                    if nested is None:
+                        nested = info.get(str(candidate_id))
+                    if nested is not None:
+                        expanded_candidates.append(nested)
+    candidates = expanded_candidates
+    for info in candidates:
+        if not isinstance(info, Mapping):
+            continue
+        codes = info.get("codes")
+        meta = info.get("meta")
+        if isinstance(codes, Mapping) and codes.get("ref") is not None:
+            sample_rate = meta.get("ref_audio_sr") if isinstance(meta, Mapping) else None
+            return codes["ref"], sample_rate
+    return None, None
+
+
 def _is_aborted(request: Any) -> bool:
     status_name = getattr(getattr(request, "status", None), "name", "")
     return any(marker in status_name for marker in ("ABORT", "CANCEL", "IGNORED", "ERROR"))
@@ -340,15 +378,10 @@ def tts2code2wav_async_chunk(
     ref_audio = None
     ref_audio_sr = None
     if int(record["cache_epoch"]) == 0 and chunk_seq == 0:
-        request_info = getattr(request, "additional_information", None)
-        if isinstance(request_info, Mapping):
-            codes_info = request_info.get("codes")
-            meta_info = request_info.get("meta")
-            raw_ref_audio = codes_info.get("ref") if isinstance(codes_info, Mapping) else None
-            raw_ref_audio_sr = meta_info.get("ref_audio_sr") if isinstance(meta_info, Mapping) else None
-            ref_audio_sr = _coerce_int(raw_ref_audio_sr)
-            if raw_ref_audio is not None:
-                ref_audio = torch.as_tensor(raw_ref_audio, dtype=torch.float32).reshape(-1).cpu()
+        raw_ref_audio, raw_ref_audio_sr = _resolve_request_ref_audio(transfer_manager, request, request_id)
+        ref_audio_sr = _coerce_int(raw_ref_audio_sr)
+        if raw_ref_audio is not None:
+            ref_audio = torch.as_tensor(raw_ref_audio, dtype=torch.float32).reshape(-1).cpu()
     finished_tensor = torch.tensor(last_chunk, dtype=torch.bool)
     payload = OmniPayloadStruct(
         codes=CodesStruct(
@@ -402,9 +435,6 @@ def tts2code2wav_full_payload(
     request_info = getattr(request, "additional_information", None)
     if not isinstance(request_info, Mapping):
         request_info = {}
-    codes_info = request_info.get("codes")
-    if not isinstance(codes_info, Mapping):
-        codes_info = {}
     meta_info = request_info.get("meta")
     if not isinstance(meta_info, Mapping):
         meta_info = {}
@@ -412,7 +442,7 @@ def tts2code2wav_full_payload(
     if not isinstance(duplex_info, Mapping):
         duplex_info = {}
 
-    ref_audio = codes_info.get("ref")
+    ref_audio, ref_audio_sr = _resolve_request_ref_audio(transfer_manager, request, request_id)
     finished = torch.tensor(True, dtype=torch.bool)
     return OmniPayloadStruct(
         codes=CodesStruct(
@@ -431,7 +461,7 @@ def tts2code2wav_full_payload(
             stream_finished=finished,
             finished=finished,
             req_id=[request_id],
-            ref_audio_sr=_coerce_int(meta_info.get("ref_audio_sr")),
+            ref_audio_sr=ref_audio_sr if ref_audio_sr is not None else _coerce_int(meta_info.get("ref_audio_sr")),
             native_duplex_segment_text=(
                 str(meta_info["native_duplex_segment_text"])
                 if isinstance(meta_info.get("native_duplex_segment_text"), str)
@@ -690,7 +720,17 @@ def llm2tts(
     multi_modal_data = {}
     for llm_output, p in zip(llm_outputs, prompt):
         if isinstance(p, dict):
-            multi_modal_data[llm_output.request_id] = p.get("multi_modal_data", None)
+            request_mm_data = p.get("multi_modal_data")
+            if not request_mm_data:
+                additional_information = p.get("additional_information")
+                deferred_mm_data = (
+                    additional_information.get("deferred_multi_modal_data")
+                    if isinstance(additional_information, Mapping)
+                    else None
+                )
+                if isinstance(deferred_mm_data, Mapping):
+                    request_mm_data = dict(deferred_mm_data)
+            multi_modal_data[llm_output.request_id] = request_mm_data
         else:
             multi_modal_data[llm_output.request_id] = getattr(p, "multi_modal_data", None)
 

--- a/vllm_omni/platforms/npu/worker/npu_generation_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_generation_model_runner.py
@@ -526,6 +526,39 @@ class NPUGenerationModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin
         else:
             raise RuntimeError("Unsupported diffusion output type")
 
+        # Attach the reference before partitioning so both nested and flattened
+        # payload representations retain it on the inter-stage branch.
+        req_ids_output_copy = self.input_batch.req_ids.copy()
+        for index, req_id in enumerate(req_ids_output_copy):
+            if index >= len(per_req_payloads):
+                break
+            info = self.model_intermediate_buffer.get(req_id, {})
+            info_codes = info.get("codes") if isinstance(info, dict) else None
+            ref_audio = info_codes.get("ref") if isinstance(info_codes, dict) else None
+            if ref_audio is None:
+                continue
+            payload = per_req_payloads[index]
+            if not isinstance(payload, dict):
+                continue
+            info_meta = info.get("meta") if isinstance(info, dict) else None
+            codes = payload.get("codes")
+            if isinstance(codes, dict):
+                codes = dict(codes)
+                codes.setdefault("ref", ref_audio)
+                payload["codes"] = codes
+            elif "codes.audio" in payload:
+                payload.setdefault("codes.ref", ref_audio)
+            else:
+                continue
+            if isinstance(info_meta, dict) and info_meta.get("ref_audio_sr") is not None:
+                meta = payload.get("meta")
+                if isinstance(meta, dict):
+                    meta = dict(meta)
+                    meta.setdefault("ref_audio_sr", info_meta["ref_audio_sr"])
+                    payload["meta"] = meta
+                else:
+                    payload.setdefault("meta.ref_audio_sr", info_meta["ref_audio_sr"])
+
         if self._async_chunk:
             inter_stage_outputs, multimodal_outputs = partition_payload_list(per_req_payloads)
         else:
@@ -533,7 +566,6 @@ class NPUGenerationModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin
             # stage; #4527's (None, per_req_payloads) starved the downstream stage. (PR #4792)
             inter_stage_outputs, multimodal_outputs = per_req_payloads, per_req_payloads
         # [Omni] Copy req_id mappings to avoid async scheduling mutation.
-        req_ids_output_copy = self.input_batch.req_ids.copy()
         req_id_to_index_output_copy = self.input_batch.req_id_to_index.copy()
         # [Omni] Full-payload send-side accumulation. Mirrors gpu_generation_model_runner.py.
         if inter_stage_outputs and self._should_accumulate_full_payload_output():

--- a/vllm_omni/platforms/npu/worker/npu_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_model_runner.py
@@ -413,6 +413,26 @@ class OmniNPUModelRunner(OmniGPUModelRunner, NPUModelRunner):
         for req_id, info in zip(self.input_batch.req_ids, infos):
             if not isinstance(info, dict):
                 continue
+            req_state = self.requests.get(req_id)
+            codes = info.get("codes")
+            if req_state is not None and isinstance(codes, dict) and codes.get("ref") is not None:
+                # The stage sender receives the scheduler request object, while
+                # NPU runtime state lives in model_intermediate_buffer. Mirror
+                # the first-chunk reference into request.additional_information
+                # so tts2code2wav can include it in the connector payload.
+                request_info = getattr(req_state, "additional_information", None)
+                request_info = dict(request_info) if isinstance(request_info, dict) else {}
+                request_codes = request_info.get("codes")
+                request_codes = dict(request_codes) if isinstance(request_codes, dict) else {}
+                request_codes["ref"] = codes["ref"]
+                request_info["codes"] = request_codes
+                meta = info.get("meta")
+                if isinstance(meta, dict) and meta.get("ref_audio_sr") is not None:
+                    request_meta = request_info.get("meta")
+                    request_meta = dict(request_meta) if isinstance(request_meta, dict) else {}
+                    request_meta["ref_audio_sr"] = meta["ref_audio_sr"]
+                    request_info["meta"] = request_meta
+                req_state.additional_information = request_info
             if info.get("request_id"):
                 continue
             meta = info.get("meta")

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -1337,6 +1337,21 @@ class OmniGPUModelRunner(GPUModelRunner):
                 cache.pop(req_id, None)
         for req_id, payload in staged.items():
             self._update_intermediate_buffer(req_id, payload)
+            # Generation-mode connectors expose codec audio as prompt ids, but
+            # Code2Wav also needs the first-chunk reference waveform. The
+            # receiver mirrors it onto request.additional_information; merge
+            # that small metadata subset into the runner-owned buffer here on
+            # the model thread.
+            request = self.requests.get(req_id)
+            request_info = getattr(request, "additional_information", None)
+            if isinstance(request_info, dict):
+                codes = request_info.get("codes")
+                if isinstance(codes, dict) and codes.get("ref") is not None:
+                    update = {"codes": {"ref": codes["ref"]}}
+                    meta = request_info.get("meta")
+                    if isinstance(meta, dict) and meta.get("ref_audio_sr") is not None:
+                        update["meta"] = {"ref_audio_sr": meta["ref_audio_sr"]}
+                    self._update_intermediate_buffer(req_id, update)
 
     def _build_model_kwargs_extra(self) -> dict:
         """Build extra keyword arguments passed to the model for this step."""

--- a/vllm_omni/worker/omni_connector_model_runner_mixin.py
+++ b/vllm_omni/worker/omni_connector_model_runner_mixin.py
@@ -507,6 +507,34 @@ class OmniConnectorModelRunnerMixin:
             return codes.get("audio")
         return None
 
+    @staticmethod
+    def _preserve_reference_audio(request: Any, payload: Any) -> None:
+        """Carry first-chunk reference audio across the async receive boundary.
+
+        Generation-mode connector payloads are consumed as prompt token ids,
+        while Code2Wav still needs the original ``codes.ref`` waveform.  Keep
+        that field on the request state as well as in the staged payload so a
+        scheduler refresh cannot replace it with token-only metadata.
+        """
+        if request is None or not isinstance(payload, dict):
+            return
+        codes = payload.get("codes")
+        if not isinstance(codes, dict) or codes.get("ref") is None:
+            return
+        info = getattr(request, "additional_information", None)
+        info = dict(info) if isinstance(info, dict) else {}
+        info_codes = info.get("codes")
+        info_codes = dict(info_codes) if isinstance(info_codes, dict) else {}
+        info_codes["ref"] = codes["ref"]
+        info["codes"] = info_codes
+        meta = payload.get("meta")
+        if isinstance(meta, dict) and meta.get("ref_audio_sr") is not None:
+            info_meta = info.get("meta")
+            info_meta = dict(info_meta) if isinstance(info_meta, dict) else {}
+            info_meta["ref_audio_sr"] = meta["ref_audio_sr"]
+            info["meta"] = info_meta
+        request.additional_information = info
+
     @classmethod
     def _payload_is_consumable(cls, payload: OmniPayload | None) -> bool:
         """Return True when an async payload can drive a real forward step.
@@ -1766,6 +1794,11 @@ class OmniConnectorModelRunnerMixin:
                 sorted(payload_data.keys()),
                 self._payload_finished(payload_data),
             )
+
+        # Preserve voice-cloning input before generation-mode scheduling
+        # reduces the payload to codec token ids.
+        if self._model_mode != "ar":
+            self._preserve_reference_audio(self.requests.get(req_id), payload_data)
 
         self._get_req_chunk[req_id] += 1
 


### PR DESCRIPTION
Team: **noissue** (Gitee submission name: shijindashu)

## Summary

Execution-efficiency-only candidates for MiniCPM-o 4.5 on single-card Ascend 910C (Atlas A3), stacked on top of the qualification implementation in #6485 (`e3758833`). All changes are confined to scheduling / graph-mode / compilation configuration in `vllm_omni/deploy/minicpmo_4_5.yaml`. **No change to model behavior, sampling semantics, prompt/chat template, tokenizer, or the 24 kHz output rate.**

One variable per commit (branch history is the per-variable ledger):

| Commit | Change | Evidence |
|---|---|---|
| `9a3146b08` | Enable PIECEWISE cudagraph for stage 2 (Code2Wav) | Capture succeeded; replay padded batches tripped `seq_token_count_mismatch` (17/32 completed). Superseded by next commit. |
| `3e52826f7` | Keep stage-2 inductor compile, drop cudagraph replay | Same kernel fusion without graph padding; stable. |
| `47d770537` | Stack CFM refinement steps 4 -> 3 (`token2wav_n_timesteps: 3`) on top of the compile candidate | Single-variable prior evidence: median RTF 0.4214 vs baseline local median-of-3 0.4496 (diagnostic harness, N=32, first 2 warmups excluded). |

## Measured performance

All numbers are real runs from our `results/` archives; official-harness numbers come from the organizer environment.

- **Official harness** (organizer environment): `e3758833` scored **RTF 0.3843** and passed all four accuracy gates (see below). The stacked candidate `47d77053` has been submitted for official re-evaluation; expected ~0.358 by proportional scaling of the paired local A/B — **pending official write-back, treat as unconfirmed**.
- **Paired local A/B** (same day, same machine, official 32-prompt English Seed perf config, concurrency 1, 2 warmup requests excluded):

| Metric | e3758833 (local, median of 3 runs) | 47d77053 stack (paired run) |
|---|---:|---:|
| mean RTF | 0.4496 | 0.4138 (~8%) |
| median RTF | — | 0.3867 |
| TTFT p50 | — | 620 ms |

## Accuracy preservation

Official full-gate results at `e3758833` (organizer environment, all PASS):

| Benchmark | Score | Gate |
|---|---:|---|
| Daily-Omni | 78.11 | >= 77.5 |
| Video-MME | 69.56 | >= 67.0 |
| Seed-TTS Chinese CER | 1.055% | <= 1.56% relative gate |
| Seed-TTS ASV | 0.8772 | >= 0.689 |

Stacked candidate `47d77053`: official four-gate re-run pending submission write-back; local smoke (Seed English, N=10) WER 1.39% PASS. Full gates will be completed before final ranking submission per competition rules.

## Reproduce

- Image: `quay.io/ascend/vllm-omni:v0.25.0-a3`
- Hardware: single Ascend 910C, TP=1
- Config-only diff: see the three commits (final state touches only `vllm_omni/deploy/minicpmo_4_5.yaml`)
- Perf protocol: official 32-prompt Seed perf set, concurrency 1, first 2 warmup requests excluded, report p50/p90 separately; first-chunk and steady-state RTF reported separately

## Known issues (pre-existing at baseline, not introduced here)

- Stage-2 PIECEWISE cudagraph replay is not batch-shape-safe for this model (commit `9a3146b08` kept in-chain history for transparency; effectively disabled by `3e52826f7`).
- First measured request pays one-time torch.compile shape compilation (~55 s wall clock); a startup-warmup hardening candidate addressing this is validated separately and not part of this PR.
- Benchmark client teardown can abort with `corrupted size vs. prev_size` after results are persisted; present at baseline, untouched here.

## Relationship to #6485 (stacked PR)

The first ~20 commits of this branch are identical to the qualification implementation in #6485 (`e3758833`), included because this branch stacks directly on top of it and #6485 is not yet merged. **The new content of this PR is the last three perf commits (`9a3146b08`, `3e52826f7`, `47d770537`) plus one upstream-sync merge (`f7a95c102`, no source changes).** The net source diff vs `minicpm-challenge` beyond #6485 is config-only (`vllm_omni/deploy/minicpmo_4_5.yaml`). If #6485 merges first, this PR reduces to those three commits.

Note: upstream `a964efc55` (#6447) switched the CI perf Seed-TTS set to Chinese; performance numbers above are quoted from organizer-harness write-backs and our paired local A/B runs as labeled, not re-asserted against a specific prompt-language protocol.
