### PR TITLE
[CI][MiniCPM-o] Add NPU Video-MME accuracy nightly as a standalone job

### DIFF
--- a/.buildkite/npu/test-npu-nightly.yml
+++ b/.buildkite/npu/test-npu-nightly.yml
@@ -86,12 +86,27 @@ steps:
           - export SEED_TTS_WER_EVAL=1
           - export SEED_TTS_SIM_EVAL=1
           - export SEED_TTS_EVAL_DEVICE=npu:1
+          - |
+            set +e
+            pytest -s -v tests/e2e/accuracy/minicpmo_4_5/test_minicpmo_4_5.py -k "not videomme" -m "full_model and npu and A3" --run-level full_model
+            EXIT=$$?
+            buildkite-agent artifact upload "tests/e2e/accuracy/minicpmo_4_5/results/*.json"
+            exit $$EXIT
+      - label: ":full_moon: Omni · MiniCPM-o 4.5 · Video-MME Accuracy Test"
+        key: nightly-omni-accuracy-minicpmo-4-5-videomme-npu
+        timeout_in_minutes: 180
+        mirror_hardwares: a3_npu_2
+        env:
+          VLLM_WORKER_MULTIPROC_METHOD: spawn
+          VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
+          HF_TOKEN: "${HF_TOKEN}"
+        commands:
           # Video-MME needs no repo override here: the NPU runners pre-stage the dataset under
           # the lmms-eval mirror, which is now VIDEOMME_DEFAULT_HF_REPO, so snapshot_download
           # resolves it straight out of the hub cache.
           - |
             set +e
-            pytest -s -v tests/e2e/accuracy/minicpmo_4_5/test_minicpmo_4_5.py -m "full_model and npu and A3" --run-level full_model
+            pytest -s -v tests/e2e/accuracy/minicpmo_4_5/test_minicpmo_4_5.py -k videomme -m "full_model and npu and A3" --run-level full_model
             EXIT=$$?
             buildkite-agent artifact upload "tests/e2e/accuracy/minicpmo_4_5/results/*.json"
             exit $$EXIT

--- a/tests/e2e/accuracy/minicpmo_4_5/test_minicpmo_4_5.py
+++ b/tests/e2e/accuracy/minicpmo_4_5/test_minicpmo_4_5.py
@@ -216,7 +216,7 @@ def test_minicpmo_4_5_daily_omni_accuracy_bench(omni_server) -> None:
     assert _acc_bench.run_acc_benchmark(_acc_bench.parse_acc_benchmark_args(argv)) == 0
 
 
-@hardware_test(res={"cuda": "H100"}, num_cards=1)
+@hardware_test(res={"cuda": "H100", "npu": "A3"}, num_cards=1)
 @pytest.mark.parametrize("omni_server", videomme_test_params, indirect=True)
 def test_minicpmo_4_5_videomme_accuracy_bench(omni_server) -> None:
     """Gate MiniCPM-o 4.5 Video-MME (w/o subs) overall accuracy at the OmniEvalKit recipe."""


### PR DESCRIPTION
## Purpose

Enable MiniCPM-o 4.5 Video-MME accuracy on NPU nightly and run it as its own job so it no longer shares the Daily-Omni / Seed-TTS accuracy timeout.

- Mark `test_minicpmo_4_5_videomme_accuracy_bench` for NPU A3 (same 1-card recipe as CUDA H100).
- Keep the existing NPU accuracy job on Daily-Omni + Seed-TTS (`-k "not videomme"`).
- Add `nightly-omni-accuracy-minicpmo-4-5-videomme-npu` on `a3_npu_2` (180 min) to run only `-k videomme`.

CUDA nightly is unchanged: Video-MME still runs in the combined MiniCPM-o accuracy job.

## Test Plan

**vLLM Version:**

**vLLM-Omni Commit:**

- [ ] NPU nightly: `Omni · MiniCPM-o 4.5 · Accuracy Test` still runs Daily-Omni + Seed-TTS only
- [ ] NPU nightly: `Omni · MiniCPM-o 4.5 · Video-MME Accuracy Test` collects and gates Video-MME
- [ ] Video-MME artifacts upload from `tests/e2e/accuracy/minicpmo_4_5/results/*.json`
- [ ] CUDA accuracy job still includes Video-MME

## Test Result
