### PR TITLE
[Bugfix] Harden MiniCPM-o Code2Wav batching

### DIFF
--- a/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
@@ -12,6 +12,7 @@ import torch
 import torch.nn as nn
 
 import vllm_omni.model_executor.models.minicpmo_4_5.batched_token2wav as batched_token2wav_module
+import vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_code2wav as code2wav_module
 from vllm_omni.model_executor.models.minicpmo_4_5.batched_token2wav import (
     BatchedToken2Wav,
     _token2wav_sdpa_context,
@@ -153,14 +154,13 @@ class _FakeToken2Wav:
         raise AssertionError("sequential __call__ fallback must never be called")
 
 
-def _config(minimum: int = 1, initial: int = 0):
+def _config(minimum: int = 1):
     return SimpleNamespace(
         model_config=SimpleNamespace(
             model="/fake/model",
             stage_connector_config={
                 "extra": {
                     "code2wav_min_batch_size": minimum,
-                    "code2wav_initial_batch_size": initial,
                     "prompt_cache_id": "shared",
                     "prompt_wav": "/fake/prompt.wav",
                 }
@@ -169,13 +169,50 @@ def _config(minimum: int = 1, initial: int = 0):
     )
 
 
-def _model(initial: int = 0, minimum: int = 1):
+def _model(minimum: int = 1):
     token2wav = _FakeToken2Wav()
     backend = BatchedToken2Wav(token2wav)
     _enable_fake_ragged_kernel(backend)
-    model = MiniCPMO45Code2Wav(vllm_config=_config(minimum=minimum, initial=initial))
+    model = MiniCPMO45Code2Wav(vllm_config=_config(minimum=minimum))
     model.backend = backend
     return model, token2wav
+
+
+@pytest.mark.parametrize("value", ["false", "0", "off", "no"])
+def test_build_backend_treats_false_like_bfloat16_cache_values_as_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    value: str,
+):
+    from vllm_omni.model_executor.models.minicpmo_4_5 import minicpmo_4_5_token2wav as token2wav_module
+
+    config = _config()
+    config.model_config.stage_connector_config["extra"]["code2wav_bfloat16_attention_cache"] = value
+    model = MiniCPMO45Code2Wav(vllm_config=config)
+
+    token2wav_dir = tmp_path / "assets" / "token2wav"
+    token2wav_dir.mkdir(parents=True)
+    prompt_wav = tmp_path / "prompt.wav"
+    prompt_wav.touch()
+    model.model_path = str(tmp_path)
+    model._prompt_wav_override = str(prompt_wav)
+
+    captured: dict[str, object] = {}
+
+    class _BackendToken2Wav:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    def _capture_backend(token2wav, **kwargs):
+        captured.update(kwargs)
+        return token2wav
+
+    monkeypatch.setattr(token2wav_module, "MiniCPMO45Token2wav", _BackendToken2Wav)
+    monkeypatch.setattr(code2wav_module, "BatchedToken2Wav", _capture_backend)
+
+    model._build_backend()
+
+    assert captured["bfloat16_attention_cache"] is False
 
 
 def _enable_fake_ragged_kernel(adapter: BatchedToken2Wav) -> None:
@@ -888,28 +925,6 @@ def test_initial_empty_segment_marker_initializes_stream_without_audio():
     assert "duplex" in model._states
 
 
-def test_initial_empty_segment_markers_respect_initial_batch_limit():
-    model, token2wav = _model(initial=2)
-    names = ["a", "b", "c", "d", "e"]
-    boundaries = []
-    for name in names:
-        boundary = _info(name, 0, [])
-        boundary["meta"].update(
-            {
-                "code_flat_numel": 0,
-                "tts_is_last_chunk": True,
-                "turn_end": False,
-            }
-        )
-        boundaries.append(boundary)
-
-    output = _forward(model, boundaries)
-
-    assert token2wav.flow.encoder.calls == [2, 2, 1]
-    assert [audio.numel() for audio in output.multimodal_outputs["model_outputs"]] == [0] * len(names)
-    assert set(model._states) == set(names)
-
-
 def test_shared_runtime_prompt_recreates_missing_file_before_second_owner(tmp_path, monkeypatch):
     monkeypatch.setattr("tempfile.gettempdir", lambda: str(tmp_path))
     model, _ = _model()
@@ -1166,49 +1181,9 @@ def test_singleton_and_mixed_shape_buckets_use_same_batched_backend_without_fall
     output = _forward(model, [_info("a", 1, [5, 6]), _info("b", 1, [7, 8, 9])])
 
     assert len(output.multimodal_outputs["model_outputs"]) == 2
-    # Exact-shape buckets execute independently but both use the same vectorized
-    # adapter; there is no Token2wav.stream/__call__ fallback.
+    # Mixed token lengths share ragged diffusion while HiFT keeps compatible
+    # encoder groups; neither path falls back to Token2wav.stream/__call__.
     assert token2wav.hift.calls[-2:] == [1, 1]
-
-
-def test_initial_batch_limit_allows_later_full_batch():
-    model, token2wav = _model(initial=4)
-    names = [f"request-{index}" for index in range(8)]
-
-    for chunk_seq in (0, 1):
-        infos = [_info(name, chunk_seq, [1, 2]) for name in names]
-        _forward(model, infos)
-        assert token2wav.hift.calls[-2:] == [4, 4]
-
-    token2wav.hift.calls.clear()
-    _forward(model, [_info(name, 2, [1, 2]) for name in names])
-    assert token2wav.hift.calls == [8]
-
-
-def test_initial_batch_partition_preserves_minimum():
-    model, token2wav = _model(initial=4, minimum=3)
-    names = [f"request-{index}" for index in range(6)]
-
-    _forward(model, [_info(name, 0, [1, 2]) for name in names])
-
-    assert token2wav.hift.calls == [3, 3]
-
-
-def test_initial_batch_partition_rejects_impossible_remainder():
-    model, _ = _model(initial=4, minimum=3)
-    names = [f"request-{index}" for index in range(5)]
-
-    with pytest.raises(RuntimeError, match="initial_batch_partition_below_minimum"):
-        _forward(model, [_info(name, 0, [1, 2]) for name in names])
-
-
-@pytest.mark.parametrize("chunk_seqs", [[0, 2, 2, 2], [0, 0, 0, 2]])
-def test_initial_steady_partition_rejects_undersized_wave(chunk_seqs):
-    model, _ = _model(initial=4, minimum=3)
-    bucket = [SimpleNamespace(chunk_seq=chunk_seq) for chunk_seq in chunk_seqs]
-
-    with pytest.raises(RuntimeError, match="decode_wave_below_minimum"):
-        list(model._iter_decode_batches([bucket]))
 
 
 def test_backend_failure_does_not_commit_any_request_state(monkeypatch):

--- a/tests/platforms/npu/test_graph_tools.py
+++ b/tests/platforms/npu/test_graph_tools.py
@@ -225,7 +225,7 @@ def test_code2wav_patch_reads_stage_additional_config(
         assert model.backend not in code2wav_patch._backend_graph_runners
 
 
-@pytest.mark.parametrize("value", [True, "true", "false", "0", "off"])
+@pytest.mark.parametrize("value", [True, 1, "true", "1", "yes", "on"])
 def test_code2wav_patch_rejects_bfloat16_attention_cache(monkeypatch, value):
     built = False
 
@@ -246,7 +246,7 @@ def test_code2wav_patch_rejects_bfloat16_attention_cache(monkeypatch, value):
     assert not built
 
 
-@pytest.mark.parametrize("value", [False, None, 0, ""])
+@pytest.mark.parametrize("value", [False, None, 0, "", "false", "0", "off", "no"])
 def test_code2wav_patch_allows_disabled_bfloat16_attention_cache(monkeypatch, value):
     built = False
 
@@ -362,6 +362,15 @@ def test_code2wav_platform_wraps_flow_execution_context(monkeypatch):
             flush_encoder,
         ),
     )
+    monkeypatch.setattr(
+        code2wav_patch,
+        "_original_decode_ragged_batch",
+        lambda instance, tokens, features, states, *, last_chunks: (
+            "ragged",
+            last_chunks,
+        ),
+        raising=False,
+    )
     features = SimpleNamespace(speech_tokens=torch.zeros(1))
 
     assert code2wav_patch._patched_setup_batch(backend, features, 3) == ("setup", 3)
@@ -372,4 +381,71 @@ def test_code2wav_platform_wraps_flow_execution_context(monkeypatch):
         [],
         last_chunk=True,
     ) == ("decode", True, False)
-    assert entered == [(torch.device("cpu"), True), (torch.device("cpu"), True)]
+    assert code2wav_patch._patched_decode_ragged_batch(
+        backend,
+        [torch.zeros(1), torch.zeros(2)],
+        features,
+        [],
+        last_chunks=[False, True],
+    ) == ("ragged", [False, True])
+    assert entered == [
+        (torch.device("cpu"), True),
+        (torch.device("cpu"), True),
+        (torch.device("cpu"), True),
+    ]
+
+
+def test_code2wav_patch_installs_ragged_flow_context(monkeypatch):
+    from vllm_omni.model_executor.models.minicpmo_4_5.batched_token2wav import (
+        BatchedToken2Wav,
+    )
+    from vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_code2wav import (
+        MiniCPMO45Code2Wav,
+    )
+
+    entered = []
+
+    @contextmanager
+    def flow_context(device, *, require_math):
+        entered.append((device, require_math))
+        yield
+
+    def original_ragged(instance, tokens, features, states, *, last_chunks):
+        return ("installed-ragged", last_chunks)
+
+    for target, name in (
+        (MiniCPMO45Code2Wav, "_build_backend"),
+        (BatchedToken2Wav, "_estimator_step"),
+        (BatchedToken2Wav, "setup_batch"),
+        (BatchedToken2Wav, "decode_batch"),
+        (BatchedToken2Wav, "decode_ragged_batch"),
+    ):
+        monkeypatch.setattr(target, name, getattr(target, name))
+
+    for name in (
+        "_PATCHED",
+        "_original_build_backend",
+        "_original_estimator_step",
+        "_original_setup_batch",
+        "_original_decode_batch",
+        "_original_decode_ragged_batch",
+    ):
+        monkeypatch.setattr(code2wav_patch, name, getattr(code2wav_patch, name))
+
+    monkeypatch.setattr(BatchedToken2Wav, "decode_ragged_batch", original_ragged)
+    monkeypatch.setattr(code2wav_patch, "_flow_execution_context", flow_context)
+    monkeypatch.setattr(code2wav_patch, "_PATCHED", False)
+    code2wav_patch.apply_minicpmo_4_5_code2wav_patch()
+
+    backend = object.__new__(BatchedToken2Wav)
+    features = SimpleNamespace(speech_tokens=torch.zeros(1))
+    result = backend.decode_ragged_batch(
+        [torch.zeros(1), torch.zeros(2)],
+        features,
+        [],
+        last_chunks=[False, True],
+    )
+
+    assert result == ("installed-ragged", [False, True])
+    assert BatchedToken2Wav.decode_ragged_batch is code2wav_patch._patched_decode_ragged_batch
+    assert entered == [(torch.device("cpu"), False)]

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
@@ -49,6 +49,14 @@ def _batch_error(reason: str, **details: Any) -> RuntimeError:
     return RuntimeError(f"MiniCPMO45Code2WavBatchError {json.dumps(payload, sort_keys=True)}")
 
 
+def _config_bool(value: object, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
 def _scalar(value: Any, default: Any = None) -> Any:
     if isinstance(value, torch.Tensor):
         return value.reshape(-1)[0].item() if value.numel() else default
@@ -184,11 +192,6 @@ class MiniCPMO45Code2Wav(nn.Module):
         self._min_batch_size = int(extra.get("code2wav_min_batch_size", 1))
         if self._min_batch_size < 1:
             raise ValueError("MiniCPM-o Code2Wav code2wav_min_batch_size must be >= 1")
-        self._initial_batch_size = int(extra.get("code2wav_initial_batch_size", 0))
-        if self._initial_batch_size < 0:
-            raise ValueError("MiniCPM-o Code2Wav code2wav_initial_batch_size must be >= 0")
-        if self._initial_batch_size and self._initial_batch_size < self._min_batch_size:
-            raise ValueError("MiniCPM-o Code2Wav code2wav_initial_batch_size must be 0 or >= code2wav_min_batch_size")
         self._default_prompt_id = str(extra.get("prompt_cache_id", "HT_ref_audio"))
         self._prompt_wav_override = extra.get("prompt_wav")
 
@@ -491,59 +494,6 @@ class MiniCPMO45Code2Wav(nn.Module):
             item.cache_epoch,
         )
 
-    def _iter_limited_batches(
-        self,
-        buckets: Iterable[list[_WorkItem]],
-        *,
-        maximum: int,
-    ) -> Iterable[list[_WorkItem]]:
-        for bucket in buckets:
-            if not bucket:
-                continue
-            if not maximum:
-                yield bucket
-                continue
-            batch_count = (len(bucket) + maximum - 1) // maximum
-            if len(bucket) < batch_count * self._min_batch_size:
-                raise _batch_error(
-                    "initial_batch_partition_below_minimum",
-                    size=len(bucket),
-                    minimum=self._min_batch_size,
-                    maximum=maximum,
-                )
-            batch_size, larger_batches = divmod(len(bucket), batch_count)
-            start = 0
-            for batch_index in range(batch_count):
-                stop = start + batch_size + (batch_index < larger_batches)
-                yield bucket[start:stop]
-                start = stop
-
-    def _iter_decode_batches(
-        self,
-        buckets: Iterable[list[_WorkItem]],
-    ) -> Iterable[list[_WorkItem]]:
-        for bucket in buckets:
-            if not self._initial_batch_size:
-                yield bucket
-                continue
-            initial = [item for item in bucket if item.chunk_seq <= 1]
-            steady = [item for item in bucket if item.chunk_seq > 1]
-
-            undersized = [
-                {"wave": wave, "size": len(items)}
-                for wave, items in (("initial", initial), ("steady", steady))
-                if items and len(items) < self._min_batch_size
-            ]
-            if undersized:
-                raise _batch_error(
-                    "decode_wave_below_minimum",
-                    minimum=self._min_batch_size,
-                    waves=undersized,
-                )
-            yield from self._iter_limited_batches([initial], maximum=self._initial_batch_size)
-            if steady:
-                yield steady
-
     @torch.inference_mode()
     def forward(
         self,
@@ -679,10 +629,7 @@ class MiniCPMO45Code2Wav(nn.Module):
                     (item.prompt_cache_id, item.prompt_wav),
                     [],
                 ).append(item)
-        for bucket in self._iter_limited_batches(
-            initial_marker_buckets.values(),
-            maximum=self._initial_batch_size,
-        ):
+        for bucket in initial_marker_buckets.values():
             try:
                 features = self.backend.prepare_prompt(
                     bucket[0].prompt_cache_id,
@@ -714,7 +661,7 @@ class MiniCPMO45Code2Wav(nn.Module):
                     prompt_wav=item.prompt_wav,
                     token2wav=state,
                 )
-        for bucket in self._iter_decode_batches(buckets.values()):
+        for bucket in buckets.values():
             batch_size = len(bucket)
             try:
                 features = self.backend.prepare_prompt(
@@ -890,5 +837,5 @@ class MiniCPMO45Code2Wav(nn.Module):
             connector_config=self._connector_config,
             hift_graph_config=self._hift_graph_config,
             cfm_graph_config=self._cfm_graph_config,
-            bfloat16_attention_cache=bool(extra.get("code2wav_bfloat16_attention_cache", False)),
+            bfloat16_attention_cache=_config_bool(extra.get("code2wav_bfloat16_attention_cache")),
         )

--- a/vllm_omni/platforms/npu/models/minicpmo_4_5_code2wav.py
+++ b/vllm_omni/platforms/npu/models/minicpmo_4_5_code2wav.py
@@ -22,6 +22,7 @@ _original_build_backend = None
 _original_estimator_step = None
 _original_setup_batch = None
 _original_decode_batch = None
+_original_decode_ragged_batch = None
 _backend_graph_runners: WeakKeyDictionary[object, NPUExactGraphRunner] = WeakKeyDictionary()
 _ENABLE_KEY = "code2wav_enable_npu_graph"
 _MAX_GRAPHS_KEY = "code2wav_max_npu_graphs"
@@ -206,12 +207,35 @@ def _patched_decode_batch(
         )
 
 
+def _patched_decode_ragged_batch(
+    self,
+    tokens,
+    features,
+    states,
+    *,
+    last_chunks,
+):
+    assert _original_decode_ragged_batch is not None
+    device = tokens[0].device if tokens else features.speech_tokens.device
+    with _flow_execution_context(
+        device,
+        require_math=self in _backend_graph_runners,
+    ):
+        return _original_decode_ragged_batch(
+            self,
+            tokens,
+            features,
+            states,
+            last_chunks=last_chunks,
+        )
+
+
 def _patched_build_backend(self) -> None:
     if self.backend is not None:
         return
 
     extra = self._extra_config()
-    if bool(extra.get(_BF16_ATTENTION_CACHE_KEY, False)):
+    if _config_bool(extra.get(_BF16_ATTENTION_CACHE_KEY), False):
         raise ValueError(
             "MiniCPM-o Code2Wav code2wav_bfloat16_attention_cache is "
             "currently supported only on CUDA; leave it unset or false on NPU."
@@ -257,7 +281,8 @@ def _patched_build_backend(self) -> None:
 def apply_minicpmo_4_5_code2wav_patch() -> None:
     """Patch the generic Code2Wav backend builder with Ascend acceleration."""
     global _PATCHED, _original_build_backend
-    global _original_decode_batch, _original_estimator_step, _original_setup_batch
+    global _original_decode_batch, _original_decode_ragged_batch
+    global _original_estimator_step, _original_setup_batch
     if _PATCHED:
         return
 
@@ -272,10 +297,12 @@ def apply_minicpmo_4_5_code2wav_patch() -> None:
     _original_estimator_step = BatchedToken2Wav._estimator_step
     _original_setup_batch = BatchedToken2Wav.setup_batch
     _original_decode_batch = BatchedToken2Wav.decode_batch
+    _original_decode_ragged_batch = BatchedToken2Wav.decode_ragged_batch
 
     MiniCPMO45Code2Wav._build_backend = _patched_build_backend  # type: ignore[method-assign]
     BatchedToken2Wav._estimator_step = _patched_estimator_step  # type: ignore[method-assign]
     BatchedToken2Wav.setup_batch = _patched_setup_batch  # type: ignore[method-assign]
     BatchedToken2Wav.decode_batch = _patched_decode_batch  # type: ignore[method-assign]
+    BatchedToken2Wav.decode_ragged_batch = _patched_decode_ragged_batch  # type: ignore[method-assign]
     _PATCHED = True
     logger.debug("Applied NPU patch for MiniCPM-o 4.5 Code2Wav")


### PR DESCRIPTION
## Purpose

This is a follow-up to [PR #6021](https://github.com/vllm-project/vllm-omni/pull/6021),
which introduced configurable concurrent MiniCPM-o duplex sessions. It addresses
the post-merge Code2Wav and NPU hardening items identified during review.
Specifically, it:

- runs ragged decoding inside the same NPU flow execution context used by
  setup and exact-shape decoding, covering the encoder, CFM, and HiFT work;
- parses string-valued `code2wav_bfloat16_attention_cache` settings consistently
  in the common backend and NPU guard, so values such as `false`, `0`, `off`,
  and `no` remain disabled;
- removes the unused `code2wav_initial_batch_size` option and its partitioning
  helpers, restoring direct marker/decode bucket traversal.

The existing `code2wav_min_batch_size` behavior is preserved. This change does
not add scheduler coalescing, a steady-state batch cap, or any default deploy
configuration change. No repository YAML or documentation uses the removed
initial-batch option; out-of-tree configurations should stop setting it.

## Test Plan

```bash
CUDA_VISIBLE_DEVICES='' python -m pytest -q \
  tests/platforms/npu/test_graph_tools.py \
  tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py

CUDA_VISIBLE_DEVICES='' python -m pytest -q \
  tests/platforms/npu/test_graph_tools.py \
  tests/platforms/npu/test_minicpmo_code2wav_npugraph.py \
  tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py

pre-commit run --files \
  tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py \
  tests/platforms/npu/test_graph_tools.py \
  vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py \
  vllm_omni/platforms/npu/models/minicpmo_4_5_code2wav.py
```

**vLLM Version:**

0.27.0

**vLLM-Omni Commit:**

- Base: `bae58f84b86a8e683f87ffabdce3bd3c80e4e788`
- PR: `be0cb8d126f3dce592ec4c485509818dcbad3ec9`

## Test Result

- Final-consumer false-like string regression before the fix: `4 failed`.
- Final-consumer false-like string regression after the fix: `4 passed`.
- NPU guard/context/install-path regressions: `16 passed`.
- Affected Code2Wav and NPU tests: `73 passed, 14 warnings`.
- Expanded run: `73 passed, 1 skipped, 14 warnings`; the NPUGraph module was
  skipped because this CUDA environment does not provide `vllm_ascend`.
- Changed-file pre-commit, mypy, DCO sign-off, and `git diff --check` passed.

Physical Ascend/NPU execution was not available in this environment. The CPU
regressions verify patch routing, execution-context entry, and configuration
parsing; physical NPU validation remains a follow-up hardware gate.
