### PR TITLE
[Perf][PersonaPlex] Capture the per-frame steps into CUDA graphs

### DIFF
--- a/tests/benchmarks/benchmark_personaplex_duplex.py
+++ b/tests/benchmarks/benchmark_personaplex_duplex.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""A/B benchmark driver for the PersonaPlex duplex server.
+
+Streams a 24 kHz mono WAV to ``/api/chat`` at realtime pace (official Moshi
+protocol, the same wire path as
+``examples/online_serving/personaplex/duplex_client.py``) and measures how much
+reply audio has arrived by the time the input finishes. A server that generates
+slower than realtime delivers less audio than the input's duration and the
+deficit accumulates for the whole call, so delivered seconds (and ``rate``,
+delivered divided by the input duration) are the headline numbers.
+
+Start the server once per side, then point the driver at it:
+
+    python -m vllm_omni.experimental.fullduplex.personaplex.serving.server   # eager
+    python -m vllm_omni.experimental.fullduplex.personaplex.serving.server --cuda-graphs
+
+    python tests/benchmarks/benchmark_personaplex_duplex.py \
+        --url ws://localhost:8124/api/chat --input user_40s.wav --runs 3
+
+Per run: ready latency, reply seconds received inside the input window, the
+realtime rate, the largest receive gap, and (with ``--gpu-index``) peak GPU
+memory polled from ``nvidia-smi``. The summary prints mean and sample stddev
+across runs. Each run's reply audio is saved for offline quality checks such
+as whisper transcription.
+
+Deps: ``websockets``, ``sphn``, ``soundfile``, ``numpy``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import statistics
+import subprocess
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+import sphn
+
+SR = 24000  # PersonaPlex / Mimi codec rate
+FRAME = 1920  # 80 ms at 24 kHz
+
+
+@dataclass
+class RunMetrics:
+    ready_s: float
+    in_window_out_s: float
+    total_out_s: float
+    rate: float
+    max_gap_s: float
+    peak_gpu_mib: int | None
+
+
+class _GpuPoller:
+    """Polls ``nvidia-smi`` for used memory so the bench needs no server hooks."""
+
+    def __init__(self, gpu_index: int, interval_s: float = 0.5):
+        self._index = gpu_index
+        self._interval = interval_s
+        self._stop = threading.Event()
+        self.peak_mib = 0
+        self._thread = threading.Thread(target=self._loop, daemon=True)
+
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                out = subprocess.run(
+                    ["nvidia-smi", f"--id={self._index}", "--query-gpu=memory.used", "--format=csv,noheader,nounits"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                self.peak_mib = max(self.peak_mib, int(out.stdout.strip().splitlines()[0]))
+            except (subprocess.SubprocessError, ValueError, IndexError):
+                pass
+            self._stop.wait(self._interval)
+
+    def __enter__(self) -> _GpuPoller:
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._stop.set()
+        self._thread.join(timeout=5)
+
+
+async def _run_once(url: str, pcm: np.ndarray, tail_s: float) -> tuple[RunMetrics, np.ndarray, str]:
+    import websockets
+
+    reader = sphn.OpusStreamReader(SR)
+    writer = sphn.OpusStreamWriter(SR)
+    ready = asyncio.Event()
+    chunks: list[np.ndarray] = []
+    text: list[str] = []
+    recv_times: list[float] = []
+    last = {"t": 0.0}
+    loop = asyncio.get_event_loop()
+
+    async with websockets.connect(url, max_size=None) as ws:
+
+        async def receive() -> None:
+            while True:
+                try:
+                    msg = await ws.recv()
+                except Exception:
+                    return
+                if not isinstance(msg, (bytes, bytearray)) or not msg:
+                    continue
+                tag, payload = msg[0], msg[1:]
+                if tag == 0:
+                    ready.set()
+                elif tag == 1:
+                    # sphn 0.2.x returns PCM straight from append_bytes; 0.1.x
+                    # buffers and needs a read_pcm drain (same split server.py handles).
+                    out = reader.append_bytes(bytes(payload))
+                    if out is None and hasattr(reader, "read_pcm"):
+                        out = reader.read_pcm()
+                    if out is not None and np.asarray(out).shape[-1] > 0:
+                        chunks.append(np.asarray(out, dtype=np.float32))
+                        recv_times.append(loop.time())
+                    last["t"] = loop.time()
+                elif tag == 2:
+                    text.append(payload.decode("utf8", errors="replace"))
+
+        recv_task = asyncio.create_task(receive())
+        t_connect = loop.time()
+        await asyncio.wait_for(ready.wait(), timeout=300)  # system-prompt prefill
+        t_ready = loop.time()
+
+        for i in range(0, len(pcm), FRAME):
+            chunk = pcm[i : i + FRAME]
+            if len(chunk) < FRAME:
+                chunk = np.concatenate([chunk, np.zeros(FRAME - len(chunk), dtype=np.float32)])
+            data = writer.append_pcm(chunk)
+            if data is None and hasattr(writer, "read_bytes"):
+                data = writer.read_bytes()
+            if data:
+                await ws.send(b"\x01" + bytes(data))
+            await asyncio.sleep(FRAME / SR)  # realtime pacing
+        in_window_samples = int(sum(c.shape[-1] for c in chunks))
+
+        last["t"] = loop.time()
+        while loop.time() - last["t"] < tail_s:
+            await asyncio.sleep(0.1)
+        recv_task.cancel()
+
+    audio = np.concatenate(chunks) if chunks else np.zeros(0, dtype=np.float32)
+    gaps = [b - a for a, b in zip(recv_times, recv_times[1:])]
+    in_window_out_s = in_window_samples / SR
+    return (
+        RunMetrics(
+            ready_s=t_ready - t_connect,
+            in_window_out_s=in_window_out_s,
+            total_out_s=audio.shape[-1] / SR,
+            rate=in_window_out_s / (len(pcm) / SR),
+            max_gap_s=max(gaps) if gaps else 0.0,
+            peak_gpu_mib=None,
+        ),
+        audio,
+        "".join(text),
+    )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--url", default="ws://localhost:8124/api/chat")
+    ap.add_argument("--input", required=True, help="24 kHz mono WAV streamed as the user turn")
+    ap.add_argument("--runs", type=int, default=3, help="measured runs (after the discarded warmup run)")
+    ap.add_argument("--no-warmup-run", action="store_true", help="do not run and discard an unmeasured first run")
+    ap.add_argument("--tail", type=float, default=2.5, help="silence (s) that ends the drain after the input")
+    ap.add_argument("--gpu-index", type=int, default=None, help="poll nvidia-smi on this GPU for peak memory")
+    ap.add_argument("--out-dir", default="pplex_bench_out", help="reply WAVs are written here, one per run")
+    args = ap.parse_args()
+
+    wav, sr = sf.read(args.input, dtype="float32")
+    if wav.ndim > 1:
+        wav = wav.mean(axis=1)
+    if sr != SR:
+        raise SystemExit(f"input must be {SR} Hz mono, got {sr} Hz (resample it first)")
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    results: list[RunMetrics] = []
+    total_runs = args.runs if args.no_warmup_run else args.runs + 1
+    for i in range(total_runs):
+        measured = args.no_warmup_run or i > 0
+        poller = _GpuPoller(args.gpu_index) if (args.gpu_index is not None and measured) else None
+        if poller:
+            with poller:
+                metrics, audio, reply_text = asyncio.run(_run_once(args.url, wav, args.tail))
+            metrics.peak_gpu_mib = poller.peak_mib
+        else:
+            metrics, audio, reply_text = asyncio.run(_run_once(args.url, wav, args.tail))
+        label = f"run {i}" if measured else "warmup (discarded)"
+        gpu = f"  peak_gpu={metrics.peak_gpu_mib} MiB" if metrics.peak_gpu_mib is not None else ""
+        print(
+            f"{label}: ready={metrics.ready_s:.2f}s  out_in_window={metrics.in_window_out_s:.2f}s"
+            f"  total_out={metrics.total_out_s:.2f}s  rate={metrics.rate:.3f}x  max_gap={metrics.max_gap_s:.2f}s{gpu}"
+        )
+        if reply_text:
+            print(f"  text: {reply_text[:160]}")
+        if measured:
+            results.append(metrics)
+            sf.write(out_dir / f"reply_run{i}.wav", audio, SR)
+            (out_dir / f"reply_run{i}.txt").write_text(reply_text)
+
+    rates = [m.rate for m in results]
+    outs = [m.in_window_out_s for m in results]
+    stddev = statistics.stdev(rates) if len(rates) > 1 else 0.0
+    print(
+        f"\nsummary over {len(results)} runs: rate mean={statistics.mean(rates):.3f}x stddev={stddev:.3f}"
+        f"  out_in_window mean={statistics.mean(outs):.2f}s"
+    )
+    peaks = [m.peak_gpu_mib for m in results if m.peak_gpu_mib is not None]
+    if peaks:
+        print(f"peak GPU memory across runs: {max(peaks)} MiB")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/features/fullduplex/test_personaplex_cudagraphs.py
+++ b/tests/e2e/features/fullduplex/test_personaplex_cudagraphs.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Tests for the PersonaPlex CUDA-graph wrapper (``graph_capture``).
+
+Verifies the properties the streaming runtime depends on: graphed replay is
+numerically identical to eager including in-place streaming-state updates,
+argument divergence falls back to eager instead of replaying stale baked-in
+values, and a capture failure returns the original callable.
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from tests.helpers.mark import hardware_marks
+from vllm_omni.experimental.fullduplex.personaplex.cuda_graphs import (
+    _GraphedCallable,
+    graph_capture,
+)
+
+pytestmark = [
+    pytest.mark.core_model,
+    *hardware_marks(res={"cuda": "L4"}, num_cards=1),
+]
+DEVICE = torch.device("cuda:0")
+HIDDEN = 32
+WARMUP_TICKS = 3
+
+
+# ---------------------------------------------------------------------------
+# Synthetic streaming step
+# ---------------------------------------------------------------------------
+
+
+class SyntheticStreamingStep(nn.Module):
+    """Minimal stand-in for the per-frame temporal step.
+
+    The forward both reads and mutates persistent state in place (like a KV
+    cache write), the property that makes PersonaPlex capture delicate: a
+    phantom warmup forward would corrupt a live session, and a replay must
+    apply the state update exactly as eager execution would.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Linear(HIDDEN, HIDDEN)
+        self.register_buffer("state", torch.zeros(HIDDEN))
+
+    def forward(self, x: torch.Tensor, scale: float = 1.0) -> torch.Tensor:
+        self.state.add_(x.mean(dim=0) * scale)
+        return self.proj(x) + self.state
+
+
+def _twin_models() -> tuple[SyntheticStreamingStep, SyntheticStreamingStep]:
+    """Two models with identical weights and state (eager reference + capture target)."""
+    torch.manual_seed(0)
+    ref = SyntheticStreamingStep().to(DEVICE).eval()
+    torch.manual_seed(0)
+    target = SyntheticStreamingStep().to(DEVICE).eval()
+    return ref, target
+
+
+def _frame(seed: int, batch: int = 1) -> torch.Tensor:
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    return torch.randn(batch, HIDDEN, generator=g).to(DEVICE)
+
+
+# ---------------------------------------------------------------------------
+# 1. Graphed replay is identical to eager, including streaming state
+# ---------------------------------------------------------------------------
+
+
+def test_graphed_matches_eager_with_state():
+    ref, target = _twin_models()
+
+    # Warmup ticks run eagerly on both, mirroring the runtime's arming phase.
+    with torch.no_grad():
+        for i in range(WARMUP_TICKS):
+            x = _frame(i)
+            ref(x)
+            target(x)
+
+    x = _frame(WARMUP_TICKS)
+    graphed = graph_capture(target.forward, (x,), label="synthetic")
+    assert isinstance(graphed, _GraphedCallable), "capture must succeed, not fall back"
+
+    # Capture only records; state must be untouched by it.
+    torch.testing.assert_close(target.state, ref.state, atol=0, rtol=0)
+
+    with torch.no_grad():
+        for i in range(WARMUP_TICKS, WARMUP_TICKS + 5):
+            x = _frame(i)
+            want = ref(x)
+            got = graphed(x)
+            torch.testing.assert_close(got, want, atol=0, rtol=0)
+
+    torch.testing.assert_close(target.state, ref.state, atol=0, rtol=0)
+
+
+# ---------------------------------------------------------------------------
+# 2. Divergent arguments fall back to eager, never replay stale values
+# ---------------------------------------------------------------------------
+
+
+def test_shape_divergence_falls_back_to_eager():
+    ref, target = _twin_models()
+    x = _frame(0)
+    with torch.no_grad():
+        ref(x)
+        target(x)
+    graphed = graph_capture(target.forward, (x,), label="synthetic")
+    assert isinstance(graphed, _GraphedCallable)
+
+    wide = _frame(1, batch=2)
+    with torch.no_grad():
+        want = ref(wide)
+        got = graphed(wide)
+    torch.testing.assert_close(got, want, atol=0, rtol=0)
+
+    # A matching-shape call afterwards still replays correctly.
+    x2 = _frame(2)
+    with torch.no_grad():
+        want = ref(x2)
+        got = graphed(x2)
+    torch.testing.assert_close(got, want, atol=0, rtol=0)
+
+
+def test_non_tensor_arg_divergence_falls_back_to_eager():
+    ref, target = _twin_models()
+    x = _frame(0)
+    with torch.no_grad():
+        ref(x, scale=1.0)
+        target(x, scale=1.0)
+    graphed = graph_capture(target.forward, (x,), {"scale": 1.0}, label="synthetic")
+    assert isinstance(graphed, _GraphedCallable)
+
+    # scale=2.0 was not captured; replaying would bake in scale=1.0.
+    x2 = _frame(1)
+    with torch.no_grad():
+        want = ref(x2, scale=2.0)
+        got = graphed(x2, scale=2.0)
+    torch.testing.assert_close(got, want, atol=0, rtol=0)
+    torch.testing.assert_close(target.state, ref.state, atol=0, rtol=0)
+
+
+# ---------------------------------------------------------------------------
+# 3. Capture failure returns the original callable
+# ---------------------------------------------------------------------------
+
+
+def test_capture_failure_stays_eager():
+    def bad_step(x: torch.Tensor) -> torch.Tensor:
+        raise RuntimeError("not capturable")
+
+    out = graph_capture(bad_step, (torch.ones(1, HIDDEN, device=DEVICE),), label="bad")
+    assert out is bad_step

--- a/vllm_omni/experimental/fullduplex/personaplex/config.py
+++ b/vllm_omni/experimental/fullduplex/personaplex/config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Configuration for the PersonaPlex full-duplex backend.
 
 PersonaPlex (``nvidia/personaplex-7b-v1``) is a Moshi finetune: a pure-lockstep
@@ -40,6 +40,11 @@ class PersonaPlexConfig:
         batch_size: Concurrent conversation slots sharing one engine. ``1`` is
             the single-session path; ``> 1`` enables elastic batching with
             per-slot recycle for new callers.
+        cuda_graphs: Capture the per-frame model steps into CUDA graphs at load
+            time, before any caller connects (see ``cuda_graphs.py``). Off by
+            default; capture failure falls back to eager.
+        graph_temporal: With ``cuda_graphs``, also graph the 7B temporal step
+            (not just the depformer). Ignored when ``cuda_graphs`` is off.
 
     Note: the native stepper decodes greedily (argmax) for both the text head
     and the depformer, so there are no sampling knobs here yet. Temperature /
@@ -54,6 +59,9 @@ class PersonaPlexConfig:
     cpu_offload: bool = False
 
     batch_size: int = 1
+
+    cuda_graphs: bool = False
+    graph_temporal: bool = True
 
     @property
     def sample_rate(self) -> int:

--- a/vllm_omni/experimental/fullduplex/personaplex/cuda_graphs.py
+++ b/vllm_omni/experimental/fullduplex/personaplex/cuda_graphs.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Replay the PersonaPlex per-frame model steps from CUDA graphs.
+
+The lockstep tick issues ~100 tiny kernels (7B temporal step, then a 16-step
+depformer over 6 layers). On an H100 80GB that is launch-bound, not
+compute-bound: the per-frame step measures 77.5 ms of the 80 ms budget eager
+vs 30.2 ms graphed, so with serving overhead on top the eager server falls
+behind realtime, a deficit full duplex never recovers. Shapes are static
+every tick, so the steps capture cleanly into CUDA graphs and replay with
+one launch.
+
+Opt-in via ``PersonaPlexConfig.cuda_graphs``; capture failure falls back to
+eager.
+
+Capture discipline (matching torch's own machinery and the production
+implementations in vLLM / TensorRT-LLM / TGI / moshi):
+
+* No warmup executions here. The runtime drives throwaway frames through the
+  real serving path at load time, before any caller connects, so JIT/autotune
+  has fired and the recorded example call has steady-state shapes. It then
+  wipes every streaming buffer in place, which preserves the addresses these
+  graphs are welded to.
+* Capture itself only records; the recorded kernels do not execute.
+* All graphs capture into the platform-global memory pool (the same pool
+  vLLM's own runners use), in the order they replay.
+* Replay validates arity, tensor shapes, and non-tensor argument equality
+  against capture time; a mismatch logs once and runs that call eagerly
+  rather than silently replaying with stale baked-in values. Replay inside an
+  active outer stream capture also falls back to eager, so a wrapping graph
+  (e.g. vLLM FULL graph mode) is never corrupted.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+from vllm.platforms import current_platform
+
+logger = logging.getLogger(__name__)
+
+
+class _GraphedCallable:
+    def __init__(self, fn, sample_args: tuple, sample_kwargs: dict):
+        self._fn = fn
+        self._warned = False
+        self._static_args = tuple(a.clone() if isinstance(a, torch.Tensor) else a for a in sample_args)
+        self._static_kwargs = {k: (v.clone() if isinstance(v, torch.Tensor) else v) for k, v in sample_kwargs.items()}
+        self._graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(self._graph, pool=current_platform.get_global_graph_pool()):
+            self._static_out = fn(*self._static_args, **self._static_kwargs)
+        torch.accelerator.synchronize()
+
+    def _matches(self, args, kwargs) -> bool:
+        if len(args) != len(self._static_args) or set(kwargs) != set(self._static_kwargs):
+            return False
+        for dst, src in zip(self._static_args, args):
+            if isinstance(dst, torch.Tensor) != isinstance(src, torch.Tensor):
+                return False
+            if isinstance(dst, torch.Tensor):
+                if dst.shape != src.shape or dst.dtype != src.dtype:
+                    return False
+            elif dst != src:
+                return False
+        for k, dst in self._static_kwargs.items():
+            src = kwargs.get(k)
+            if isinstance(dst, torch.Tensor) != isinstance(src, torch.Tensor):
+                return False
+            if isinstance(dst, torch.Tensor):
+                if dst.shape != src.shape or dst.dtype != src.dtype:
+                    return False
+            elif dst != src:
+                return False
+        return True
+
+    def __call__(self, *args, **kwargs):
+        # Replaying inside an active stream capture would corrupt the outer
+        # graph; run eagerly so the caller can complete its capture.
+        if torch.cuda.is_current_stream_capturing():
+            return self._fn(*args, **kwargs)
+        if not self._matches(args, kwargs):
+            if not self._warned:
+                self._warned = True
+                logger.warning("[cudagraph] replay args diverged from capture; running eagerly")
+            return self._fn(*args, **kwargs)
+        for dst, src in zip(self._static_args, args):
+            if isinstance(dst, torch.Tensor) and isinstance(src, torch.Tensor):
+                dst.copy_(src, non_blocking=True)
+        for k, dst in self._static_kwargs.items():
+            src = kwargs.get(k)
+            if isinstance(dst, torch.Tensor) and isinstance(src, torch.Tensor):
+                dst.copy_(src, non_blocking=True)
+        self._graph.replay()
+        out = self._static_out
+        # The clone keeps outputs safe to hold across ticks; production servers
+        # return the static buffer and require consumption before next replay.
+        if isinstance(out, torch.Tensor):
+            return out.clone()
+        if isinstance(out, tuple):
+            return tuple(o.clone() if isinstance(o, torch.Tensor) else o for o in out)
+        return out
+
+
+def graph_capture(fn, sample_args=(), sample_kwargs=None, label="step"):
+    """Return a graphed version of fn, or fn itself if capture is not possible."""
+    sample_kwargs = sample_kwargs or {}
+    try:
+        with torch.inference_mode(False), torch.no_grad():
+            g = _GraphedCallable(fn, sample_args, sample_kwargs)
+        logger.info("[cudagraph] captured %s", label)
+        return g
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[cudagraph] capture failed for %s (%s); staying eager", label, exc)
+        return fn

--- a/vllm_omni/experimental/fullduplex/personaplex/runtime.py
+++ b/vllm_omni/experimental/fullduplex/personaplex/runtime.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Moshi-free PersonaPlex lockstep engine (native temporal + depformer + Mimi).
 
 This is the real-time duplex backend built entirely from vllm-omni-native
@@ -165,6 +165,8 @@ class PersonaPlexEngine:
 
         self._load_voice(cfg.voice_prompt)
         self._loaded = True
+        if cfg.cuda_graphs:
+            self.warmup_and_capture()
         return self
 
     def _load_voice(self, voice: str) -> None:
@@ -389,6 +391,86 @@ class PersonaPlexEngine:
         codes run-order dependent (valid but not reproducible token-for-token).
         """
         return self._step_from_codes(user_codes.to(self.config.device).long(), prefill)
+
+    # Throwaway frames driven before any caller connects: enough to clear the
+    # cold-start tick and the delay-line warmup gates, so the recorded example
+    # call has steady-state shapes and JIT/autotune have already fired.
+    _GRAPH_WARMUP_TICKS = 8
+
+    def _pplex_record_calls(self):
+        """Wrap the hot per-frame modules so the latest call's arguments are kept."""
+        import torch
+
+        state = self._pplex_graphs = {"rec": {}, "orig": {}}
+        orig_dep, orig_step = self._dep, self._temporal.step
+        state["orig"] = {"dep": orig_dep, "step": orig_step}
+
+        def rec_dep(*a, **k):
+            state["rec"]["dep"] = (
+                tuple(x.clone() if torch.is_tensor(x) else x for x in a),
+                {kk: (v.clone() if torch.is_tensor(v) else v) for kk, v in k.items()},
+            )
+            return orig_dep(*a, **k)
+
+        def rec_step(*a, **k):
+            state["rec"]["step"] = (
+                tuple(x.clone() if torch.is_tensor(x) else x for x in a),
+                {kk: (v.clone() if torch.is_tensor(v) else v) for kk, v in k.items()},
+            )
+            return orig_step(*a, **k)
+
+        self._dep, self._temporal.step = rec_dep, rec_step
+
+    def _pplex_restore_eager(self):
+        state = getattr(self, "_pplex_graphs", None)
+        if state and state.get("orig"):
+            self._dep = state["orig"]["dep"]
+            self._temporal.step = state["orig"]["step"]
+
+    def _pplex_capture_graphs(self):
+        """Swap the hot per-frame modules for CUDA-graph replays (see cuda_graphs.py)."""
+        from vllm_omni.experimental.fullduplex.personaplex.cuda_graphs import graph_capture
+
+        state = self._pplex_graphs
+        if "dep" not in state["rec"]:
+            logger.warning("[cudagraph] warmup recorded no depformer call; staying eager")
+            self._pplex_restore_eager()
+            return
+
+        # Capture in replay order (temporal step runs before the depformer in
+        # every tick); both graphs share the platform-global memory pool.
+        if self.config.graph_temporal and "step" in state["rec"]:
+            a, k = state["rec"]["step"]
+            self._temporal.step = graph_capture(state["orig"]["step"], a, k, label="temporal")
+        else:
+            self._temporal.step = state["orig"]["step"]
+        a, k = state["rec"]["dep"]
+        self._dep = graph_capture(state["orig"]["dep"], a, k, label="depformer")
+
+    def warmup_and_capture(self) -> None:
+        """Capture the per-frame CUDA graphs at load, before any caller connects.
+
+        Drives throwaway silence frames through the real serving path so the
+        recorded example call is steady-state shaped, then captures and wipes
+        every streaming buffer. The wipe is in place, so the captured graphs
+        stay welded to buffers the sessions that follow will use.
+        """
+        B = self.config.batch_size
+        silence = self._silence.view(1, 8).expand(B, 8)
+        try:
+            self._reset_all_streaming()
+            self._pplex_record_calls()
+            for _ in range(self._GRAPH_WARMUP_TICKS):
+                self._step_from_codes(silence.clone(), None)
+            self._pplex_capture_graphs()
+        except Exception:
+            logger.exception("[cudagraph] boot capture failed; serving eager", stack_info=True)
+            self._pplex_restore_eager()
+        finally:
+            # Whatever happened above, no fabricated frame may survive into a
+            # real session: rewind every offset and refill the staging ring.
+            self._reset_all_streaming()
+            self.last_out_tokens = None
 
     def _step_from_codes(self, codes, prefill):
         import torch

--- a/vllm_omni/experimental/fullduplex/personaplex/serving/server.py
+++ b/vllm_omni/experimental/fullduplex/personaplex/serving/server.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """PersonaPlex full-duplex server, compatible with the OFFICIAL Moshi web client.
 
 Serves the official PersonaPlex web UI (``dist.tgz`` from ``nvidia/personaplex-7b-v1``,
@@ -525,11 +525,17 @@ def main() -> None:
         default=1,
         help="Concurrent conversation slots on one engine (elastic batching when > 1).",
     )
+    ap.add_argument(
+        "--cuda-graphs",
+        action="store_true",
+        help="Capture the per-frame model steps into CUDA graphs (closes the eager realtime deficit on H100).",
+    )
     args = ap.parse_args()
     logging.basicConfig(level=logging.INFO)
     cfg = PersonaPlexConfig(
         voice_prompt=args.voice,
         batch_size=args.batch_size,
+        cuda_graphs=args.cuda_graphs,
         **({"persona": args.persona} if args.persona else {}),
     )
     web.run_app(create_app(cfg), host=args.host, port=args.port)


### PR DESCRIPTION
## Purpose

The PersonaPlex lockstep tick launches about 100 small kernels per 80 ms frame: one step of the 7B temporal transformer, then a 16-step depformer over 6 layers. On an H100 80GB this is launch-bound rather than compute-bound. The per-frame model step alone measures 77.5 ms of the 80 ms budget, so with serving overhead on top the eager server cannot hold realtime: it delivers about 38.9 s of agent audio per 40 s of call, and in full duplex that deficit only accumulates, so the reply stream drifts further behind for the whole call.

Shapes are identical every tick, so this PR captures the two hot modules into CUDA graphs and replays them with one launch each. The per-frame step drops to 30.2 ms (2.6x) and the deficit disappears.

Capture happens at engine load, before any caller connects. `warmup_and_capture()` drives 8 throwaway silence frames through the real serving path so autotune has fired and the recorded call has steady-state shapes, captures both modules, then resets all streaming state. The reset is fully in place (offsets rewind, the staging ring is refilled), so no buffer address moves and the graphs stay tied to the buffers real sessions use. Nothing from the warmup frames survives into a session, and a capture failure surfaces at startup instead of mid-conversation.

Off by default. Opt in with `PersonaPlexConfig.cuda_graphs` or `--cuda-graphs` on the duplex server. `graph_temporal=False` graphs only the depformer. Every failure path ends in eager: capture failure keeps the original callables, argument divergence from capture time runs that call eagerly (logged once), and replay inside an outer stream capture falls back so a wrapping graph is never corrupted.

This follows the existing per-model graph wrappers (`moss_tts/moss_codec_cudagraph.py`, `indextts2/dit_cuda_graph.py`): platform-global graph pool, config opt-in defaulting off, eager fallback, and a synthetic-model equivalence test.

## Test Plan

**vLLM Version:** 0.27.1

**vLLM-Omni Commit:** bae58f84 (branch point, benchmarked with this PR applied on top)

Hardware: 1x H100 80GB (GCP a3-highgpu-1g), driver 580.173.02, torch 2.13.0 (CUDA 13.0 runtime).

- Unit: `tests/e2e/features/fullduplex/test_personaplex_cudagraphs.py` checks graphed replay is numerically identical to eager including the in-place streaming state updates, that shape and non-tensor divergence fall back to eager, and that a capture failure returns the original callable. Marked `core_model` with an L4 hardware mark so CI collects it.
- Per-tick timing: `_step_from_codes` in a timed loop, 10 warmup ticks then 250 measured, `torch.accelerator.synchronize()` around each, eager and graphed in separate processes.
- End-to-end A/B: the checked-in driver (`tests/benchmarks/benchmark_personaplex_duplex.py`) streams a 40 s WAV at realtime pace over the official Moshi websocket protocol and measures reply audio delivered by the time the input ends, ready latency, largest receive gap, the model's text output, and peak GPU memory (nvidia-smi 0.5 s polling). Same build, `--cuda-graphs` toggled, server restarted per side, one discarded warmup call then 3 measured runs per side. Single session, `batch_size=1`. Input: any 24 kHz mono WAV. Ours was a 5 s spoken question padded with silence to 40 s.

```
python -m vllm_omni.experimental.fullduplex.personaplex.serving.server [--cuda-graphs]
python tests/benchmarks/benchmark_personaplex_duplex.py \
    --url ws://localhost:8124/api/chat --input user_40s.wav --runs 3 --gpu-index 0
```

- Quality: byte-compare of the reply audio across sides, whisper transcription, and the model's text tokens.

## Test Result

Unit tests on the H100:

```
tests/e2e/features/fullduplex/test_personaplex_cudagraphs.py::test_graphed_matches_eager_with_state PASSED
tests/e2e/features/fullduplex/test_personaplex_cudagraphs.py::test_shape_divergence_falls_back_to_eager PASSED
tests/e2e/features/fullduplex/test_personaplex_cudagraphs.py::test_non_tensor_arg_divergence_falls_back_to_eager PASSED
tests/e2e/features/fullduplex/test_personaplex_cudagraphs.py::test_capture_failure_stays_eager PASSED
4 passed, 15 warnings in 0.33s
```

Per-frame step time (250 ticks, warmup excluded):

| build | mean | stddev | p95 |
| --- | ---: | ---: | ---: |
| eager | 77.5 ms | 0.8 | 78.7 ms |
| this PR | **30.2 ms** | 0.2 | 30.6 ms |

End-to-end A/B, audio delivered by the time the 40 s input ends (mean of 3 runs, per-run values in parentheses):

| build | delivered | ready latency | peak GPU |
| --- | ---: | ---: | ---: |
| eager | 38.85 s (38.64 / 38.96 / 38.96) | 5.53 s | 18787 MiB |
| this PR | **40.00 s (all runs)** | **1.94 s** | 19053 MiB |

- Eager falls about 1.2 s behind per 40 s of call and full duplex has no way to catch up (one tick emits one 80 ms frame), so over a 10 minute call the reply stream falls roughly 17 s behind real time. Graphs deliver the full 40.00 s on every run: the deficit is gone.
- Session prefill (the same per-frame steps, unpaced) drops from 5.53 s to 1.94 s, consistent with the 2.6x per-tick measurement. Every caller connects 3.6 s sooner.
- Memory cost of both graphs: about +270 MiB (nvidia-smi 0.5 s polling, process level).
- Largest receive gap is 0.09 s on both sides (no stutter introduced).

Quality is bit-identical. The stepper decodes greedily, and with the same input the graphed and eager builds produced byte-identical reply audio on all 3 run pairs (960000 samples each, max abs diff 0.0), identical text tokens ("It was built for the 1889 World's Fair in Paris..."), and identical whisper transcripts.

Capture ordering: both graphs are captured after model load and before the server announces ready, so no session ever runs an eager tick.

```
[cudagraph] captured temporal
[cudagraph] captured depformer
PersonaPlex duplex server: ready (official web: True)
```

No eager fallback was hit anywhere: zero `replay args diverged` / `staying eager` / `capture failed` lines across boot, session prefill, and all benchmark runs. The divergence guard logs once per callable on first mismatch, so zero lines means every call replayed its graph. One thing this settled: prefill-shaped calls replay the steady-state graphs without divergence, so the "record the latest call, not the first" rule is defensive rather than load-bearing.

**Correction to the initial description.** The first version of this PR quoted a larger eager deficit (0.77x realtime, 92 ms per frame) from an earlier ad-hoc probe on a pre-rebase build that had extra per-tick instrumentation applied. Controlled reruns with the checked-in driver do not reproduce it: clean eager delivers 37.8/40 s at the old branch point and 38.9-39.3/40 s on current main (the instrumentation patch accounts for part of the gap: 36.4/40 s with it applied). All numbers above are from the reproducible driver and timed loop on a clean build, and the module docstring and flag help carry the corrected numbers.

Not measured: concurrency above `batch_size=1` (the graphs are captured at the configured batch size, and the 2.6x tick headroom is what makes multi-slot serving plausible). Happy to add if useful.
