### PR TITLE
[Bugfix] Honor stage selection in online profiler endpoints

### DIFF
--- a/tests/entrypoints/openai/test_profiler_endpoints.py
+++ b/tests/entrypoints/openai/test_profiler_endpoints.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_omni.entrypoints.openai import api_server
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+@pytest.mark.parametrize(
+    ("path", "engine_method"),
+    [
+        ("/start_profile", "start_profile"),
+        ("/stop_profile", "stop_profile"),
+    ],
+)
+def test_profiler_endpoint_forwards_selected_stages(path: str, engine_method: str) -> None:
+    engine_client = SimpleNamespace(
+        start_profile=AsyncMock(),
+        stop_profile=AsyncMock(),
+    )
+
+    app = FastAPI()
+    app.include_router(api_server.profiler_router)
+    app.state.engine_client = engine_client
+
+    response = TestClient(app).post(path, json={"stages": [1]})
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "SUCCESS"}
+    getattr(engine_client, engine_method).assert_awaited_once_with(stages=[1])

--- a/tests/entrypoints/openai_api/test_api_server_guards.py
+++ b/tests/entrypoints/openai_api/test_api_server_guards.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """API-server surface guards for the OpenAI Omni entrypoint.
 
 Purpose
@@ -20,8 +20,8 @@ Common wrong changes these tests are meant to catch
 * Route accidentally removed, renamed, method-changed, or double-registered
   after a move (census / assembled-app checks).
 * OpenAPI drops an Omni HTTP path while the router still has it (or the reverse).
-* Assembly forgets to strip upstream ``/v1/chat/completions`` (batch) /
-  ``/v1/models``, or also deletes unrelated upstream routes.
+* Assembly forgets to strip overridden upstream chat / models / profiler
+  routes, or also deletes unrelated upstream routes.
 * Profiler / Omni router not mounted; storage not started; Omni engine
   exception handlers not registered.
 * Timestamp middleware stops stamping HTTP, or starts mutating WebSocket scopes.
@@ -351,9 +351,10 @@ def test_router_openapi_paths_cover_http_manifest() -> None:
 async def test_api_server_assembly_replaces_upstream_routes_and_mounts_omni_router(monkeypatch) -> None:
     """Lock worker assembly: override, mount, storage, handlers, full census.
 
-    Fails if assembly stops replacing upstream chat/batch/models, deletes
-    unrelated upstream routes, forgets Omni/profiler mounts, skips storage
-    start, or drops Omni ``EngineDeadError`` / ``EngineGenerateError`` handlers.
+    Fails if assembly stops replacing upstream chat/batch/models/profiler,
+    deletes unrelated upstream routes, forgets Omni/profiler mounts, skips
+    storage start, or drops Omni ``EngineDeadError`` / ``EngineGenerateError``
+    handlers.
     """
     captured: dict[str, object] = {}
 
@@ -370,6 +371,14 @@ async def test_api_server_assembly_replaces_upstream_routes_and_mounts_omni_rout
 
         @app.get("/v1/models")
         async def upstream_models():
+            return {"owner": "upstream"}
+
+        @app.post("/start_profile")
+        async def upstream_start_profile():
+            return {"owner": "upstream"}
+
+        @app.post("/stop_profile")
+        async def upstream_stop_profile():
             return {"owner": "upstream"}
 
         @app.get("/v1/upstream-only")
@@ -437,6 +446,8 @@ async def test_api_server_assembly_replaces_upstream_routes_and_mounts_omni_rout
         is api_server.create_batch_chat_completion
     )
     assert _single_http_route(routes, "GET", "/v1/models").endpoint is api_server.show_available_models
+    assert _single_http_route(routes, "POST", "/start_profile").endpoint is api_server.start_profile
+    assert _single_http_route(routes, "POST", "/stop_profile").endpoint is api_server.stop_profile
 
     # Assembled app includes Omni router HTTP/WS surface + profiler.
     for item in _EXPECTED_ROUTER_ROUTES:

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 import asyncio
 import base64
 import dataclasses
@@ -540,6 +540,8 @@ async def omni_run_server_worker(listen_address, sock, args, client_config=None,
         stage_configs = engine_client.stage_configs if hasattr(engine_client, "stage_configs") else None
         if _should_enable_profiler_endpoints(stage_configs):
             logger.warning("Profiler endpoints are enabled. This should ONLY be used for local development!")
+            _remove_route_from_app(app, "/start_profile", frozenset({"POST"}))
+            _remove_route_from_app(app, "/stop_profile", frozenset({"POST"}))
             app.include_router(profiler_router)
 
         vllm_config = await _get_vllm_config(engine_client)


### PR DESCRIPTION
## Purpose

### Problem

`build_openai_app()` registers the upstream vLLM profiler endpoints:

- `POST /start_profile`
- `POST /stop_profile`

vLLM-Omni then includes its own profiler router using the same method and path
pairs. This leaves duplicate routes in the assembled FastAPI application.

Because Starlette dispatches to the first matching route, requests containing
an Omni stage selection can reach the upstream vLLM handler instead:

```bash
curl -sS \
  -X POST http://127.0.0.1:8091/start_profile \
  -H 'Content-Type: application/json' \
  -d '{"stages":[1]}'
```

The `stages` selection is consequently not forwarded to `AsyncOmni`.

### Root Cause

Including a FastAPI router does not replace an existing route with the same
method and path. Both routes remain registered, and the upstream route is
matched first.

### Fix

Remove the upstream profiler routes before including the Omni profiler router.

This follows the existing route-replacement pattern used for chat completions
and model-list endpoints.

The API server assembly test now:

- registers fake upstream profiler endpoints;
- rejects duplicate method/path registrations;
- verifies that the surviving endpoints are the Omni profiler handlers.

## Test Plan

Run the focused regression test:

```bash
pytest -q \
  tests/entrypoints/openai_api/test_api_server_guards.py::test_api_server_assembly_replaces_upstream_routes_and_mounts_omni_router
```

Without the production fix, the test reports duplicate registrations for
`POST /start_profile` and `POST /stop_profile`.

With the fix, the assembled application contains one route for each endpoint,
and both resolve to the vLLM-Omni handlers.

For serving validation:

1. Start profiling with `{"stages":[1]}`.
2. Send one request through a multi-stage Omni deployment.
3. Stop profiling.
4. Check the generated profiler artifacts.

**vLLM Version:** `0.1.dev1+ge5588e49b`

**vLLM-Omni Commit:** `1a90227c6c83859f68248890fe5e3b7dcd2e6510`

## Test Result

Manual selective-profiling validation on a three-stage Omni deployment:

```text
stage 0: no trace
stage 1: trace generated
stage 2: no trace
```

The focused regression test reached and passed its route uniqueness and handler
ownership assertions.

Additional checks passed:

- `check-spdx-header`
- `check-test-ci-coverage`
- `check-forbidden-imports`
- `check-torch-cuda-call`
- `typos`
- `py_compile`
- `git diff --check`
