### PR TITLE
[Bugfix] Build CUDA release/nightly images on vLLM 0.27 base

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=vllm/vllm-openai:v0.26.0
+ARG BASE_IMAGE=vllm/vllm-openai:v0.27.0
 FROM ${BASE_IMAGE}
 
 ARG COMMON_WORKDIR=/app


### PR DESCRIPTION
When I was digging which image works best for Minimax-H3, I found this issue on Dockerfile...

This PR are created with AI assistant... 

## Summary

- `docker/Dockerfile.cuda` (the Dockerfile built by `.buildkite/release/release-pipeline.yml` for release and nightly CUDA images) still defaults to `ARG BASE_IMAGE=vllm/vllm-openai:v0.26.0`, while the codebase was rebased onto vLLM 0.27.0 in #5976.
- Result: the published `vllm/vllm-omni:v0.27.0rc1`, `latest`, and daily `nightly` CUDA images install current vLLM-Omni — which uses vLLM 0.27-only APIs — over a vLLM 0.26.0 runtime, a combination CI never validates (`docker/Dockerfile.ci` uses `VLLM_BASE_TAG=v0.27.0`).
- This one-line change aligns the release image base with the CI image base, matching the rebase rule noted in `Dockerfile.ci` ("Keep VLLM_BASE_TAG aligned with the target vLLM release on every rebase"). The ROCm release Dockerfile was already fixed the same way in #5886.

## Evidence

- Image label inspection of the published `vllm/vllm-omni:v0.27.0rc1` via the Docker Hub registry API shows `ai.vllm.image.tag = vllm/vllm-openai:v0.26.0`. Labels are inherited from the actual build base; `Dockerfile.cuda` has no `LABEL` overrides and does not reinstall vLLM.
- Timeline: upstream `vllm/vllm-openai:v0.27.0` was published 2026-08-10, ~20h before the v0.27.0rc1 image build (2026-08-11), so a correct base was available.
- The release pipeline builds with `-f docker/Dockerfile.cuda` and passes no `--build-arg BASE_IMAGE` override, so the stale default is what ships.
- Prior attempt: #6378 (same fix, closed unmerged by its author; no maintainer objection on record).

## Test plan

- [ ] CI builds the release image with the v0.27.0 base
- [ ] Maintainers may want to rebuild/republish the nightly CUDA image after merge so it stops shipping the mismatched runtime; the `v0.27.0rc1` tag remains affected (immutable)