### PR TITLE
[CI] Reduce Qwen-Image Function and share step-execution perf server

### DIFF
--- a/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
@@ -74,13 +74,14 @@
       "full_model",
       "diffusion"
     ],
-    "description": "Single-device baseline (no parallelism) with step execution",
+    "description": "Single-device step execution: sequential 512/1536 plus 512 concurrency sweep. One server (max-num-seqs 8).",
     "server_type": "vllm-omni",
     "server_params": {
       "model": "Qwen/Qwen-Image",
       "serve_args": {
         "enable-diffusion-pipeline-profiler": true,
-        "step-execution": true
+        "step-execution": true,
+        "max-num-seqs": 8
       }
     },
     "benchmark_params": [
@@ -117,6 +118,27 @@
             "throughput_qps": 0.0423,
             "latency_mean": 23.5768,
             "peak_memory_mb_mean": 64500.0
+          }
+        }
+      },
+      {
+        "name": "512x512_steps20_high_concurrency",
+        "dataset": "random",
+        "task": "t2i",
+        "width": 512,
+        "height": 512,
+        "num-inference-steps": 20,
+        "num-prompts": [20, 40, 80, 160],
+        "max-concurrency": [1, 2, 4, 8],
+        "warmup-requests": 8,
+        "warmup-concurrency": 8,
+        "warmup-num-inference-steps": 20,
+        "enable-negative-prompt": true,
+        "baseline": {
+          "H100": {
+            "throughput_qps": [0.3937, 0.6606, 0.6188, 0.7752],
+            "latency_mean": [2.5466, 3.0235, 6.3948, 10.1944],
+            "peak_memory_mb_mean": [55149.0, 55150.0, 55153.1458, 55156.325]
           }
         }
       }
@@ -240,54 +262,6 @@
             "latency_mean": 5.2022,
             "peak_memory_mb_mean": 64750.0
           }
-        }
-      }
-    ]
-  },
-  {
-    "test_name": "test_qwen_image_single_device_step_execution_high_concurrency",
-    "mark": [
-      {
-        "hardware_marks": {
-          "res": {
-            "cuda": "H100"
-          },
-          "num_cards": 1
-        }
-      },
-      "full_model",
-      "diffusion"
-    ],
-    "description": "Single-device Qwen-Image step-level execution benchmark at 512x512, 20 steps, concurrency sweep",
-    "server_type": "vllm-omni",
-    "server_params": {
-      "model": "Qwen/Qwen-Image",
-      "serve_args": {
-        "enable-diffusion-pipeline-profiler": true,
-        "step-execution": true,
-        "max-num-seqs": 8
-      }
-    },
-    "benchmark_params": [
-      {
-        "name": "512x512_steps20_high_concurrency",
-        "dataset": "random",
-        "task": "t2i",
-        "width": 512,
-        "height": 512,
-        "num-inference-steps": 20,
-        "num-prompts": [20, 40, 80, 160],
-        "max-concurrency": [1, 2, 4, 8],
-        "warmup-requests": 8,
-        "warmup-concurrency": 8,
-        "warmup-num-inference-steps": 20,
-        "enable-negative-prompt": true,
-        "baseline": {
-            "H100": {
-                "throughput_qps": [0.3937, 0.6606, 0.6188, 0.7752],
-                "latency_mean": [2.5466, 3.0235, 6.3948, 10.1944],
-                "peak_memory_mb_mean": [55149.0, 55150.0, 55153.1458, 55156.325]
-            }
         }
       }
     ]

--- a/tests/e2e/online_serving/test_qwen_image_expansion.py
+++ b/tests/e2e/online_serving/test_qwen_image_expansion.py
@@ -8,9 +8,8 @@ and are supported by the following text-to-image models:
 - Qwen-Image-2512
 
 One feature per test case, matching the Test Plan in PR #1682 (Qwen-Image-Edit).
-Supported features for Qwen-Image series: TeaCache, Cache-DiT, Ulysses-SP, Ring-Attention,
-CFG-Parallel, Tensor-Parallel, VAE-Patch-Parallel, CPU offload (layerwise).
-See docs/user_guide/diffusion_acceleration.md.
+Nightly covers each feature once, alternating models (5× Qwen-Image, 4× Qwen-Image-2512).
+Ulysses stays on Qwen-Image. See docs/user_guide/diffusion_acceleration.md.
 """
 
 import pytest
@@ -25,141 +24,116 @@ NEGATIVE_PROMPT = "blurry, low quality"
 SINGLE_CARD_FEATURE_MARKS = hardware_marks(res={"cuda": "H100"})
 PARALLEL_FEATURE_MARKS = hardware_marks(res={"cuda": "H100"}, num_cards=2)
 
+MODEL_IMAGE = "Qwen/Qwen-Image"
+MODEL_2512 = "Qwen/Qwen-Image-2512"
 
-def _get_diffusion_feature_cases(model: str):
-    return [
-        pytest.param(
-            OmniServerParams(
-                model=model,
-                server_args=["--enable-cpu-offload"],
-            ),
-            id="cpu_offload",
-            marks=SINGLE_CARD_FEATURE_MARKS,
+# One server per feature. Alternate models; keep feature pytest ids unchanged.
+FEATURE_CASES = [
+    pytest.param(
+        OmniServerParams(
+            model=MODEL_IMAGE,
+            server_args=["--enable-cpu-offload"],
         ),
-        pytest.param(
-            OmniServerParams(model=model, server_args=["--step-execution"]),
-            id="step_execution",
-            marks=SINGLE_CARD_FEATURE_MARKS,
+        id="cpu_offload",
+        marks=SINGLE_CARD_FEATURE_MARKS,
+    ),
+    pytest.param(
+        OmniServerParams(model=MODEL_2512, server_args=["--step-execution"]),
+        id="step_execution",
+        marks=SINGLE_CARD_FEATURE_MARKS,
+    ),
+    pytest.param(
+        OmniServerParams(model=MODEL_IMAGE, server_args=["--cache-backend", "tea_cache"]),
+        id="cache_tea_cache",
+        marks=SINGLE_CARD_FEATURE_MARKS,
+    ),
+    pytest.param(
+        OmniServerParams(
+            model=MODEL_2512,
+            server_args=[
+                "--cache-backend",
+                "cache_dit",
+                "--enable-layerwise-offload",
+            ],
         ),
-        pytest.param(
-            OmniServerParams(model=model, server_args=["--cache-backend", "tea_cache"]),
-            id="cache_tea_cache",
-            marks=SINGLE_CARD_FEATURE_MARKS,
+        id="layerwise_offload",
+        marks=SINGLE_CARD_FEATURE_MARKS,
+    ),
+    pytest.param(
+        OmniServerParams(
+            model=MODEL_IMAGE,
+            server_args=[
+                "--cache-backend",
+                "cache_dit",
+                "--ulysses-degree",
+                "2",
+            ],
         ),
-        pytest.param(
-            OmniServerParams(
-                model=model,
-                server_args=[
-                    "--cache-backend",
-                    "cache_dit",
-                    "--enable-layerwise-offload",
-                ],
-            ),
-            id="layerwise_offload",
-            marks=SINGLE_CARD_FEATURE_MARKS,
+        id="ulysses_2",
+        marks=PARALLEL_FEATURE_MARKS,
+    ),
+    pytest.param(
+        OmniServerParams(
+            model=MODEL_2512,
+            server_args=[
+                "--cache-backend",
+                "cache_dit",
+                "--ring",
+                "2",
+            ],
         ),
-        pytest.param(
-            OmniServerParams(
-                model=model,
-                server_args=[
-                    "--cache-backend",
-                    "cache_dit",
-                    "--ulysses-degree",
-                    "2",
-                ],
-            ),
-            id="ulysses_2",
-            marks=PARALLEL_FEATURE_MARKS,
+        id="ring_2",
+        marks=PARALLEL_FEATURE_MARKS,
+    ),
+    pytest.param(
+        OmniServerParams(
+            model=MODEL_IMAGE,
+            server_args=[
+                "--cache-backend",
+                "tea_cache",
+                "--cfg-parallel-size",
+                "2",
+            ],
         ),
-        pytest.param(
-            OmniServerParams(
-                model=model,
-                server_args=[
-                    "--cache-backend",
-                    "cache_dit",
-                    "--ring",
-                    "2",
-                ],
-            ),
-            id="ring_2",
-            marks=PARALLEL_FEATURE_MARKS,
+        id="cfg_parallel_2",
+        marks=PARALLEL_FEATURE_MARKS,
+    ),
+    pytest.param(
+        OmniServerParams(
+            model=MODEL_2512,
+            server_args=[
+                "--cache-backend",
+                "cache_dit",
+                "--tensor-parallel-size",
+                "2",
+                "--vae-patch-parallel-size",
+                "2",
+                "--vae-use-tiling",
+                "--diffusion-quantization-config",
+                '{"method":"fp8"}',
+            ],
         ),
-        pytest.param(
-            OmniServerParams(
-                model=model,
-                server_args=[
-                    "--cache-backend",
-                    "tea_cache",
-                    "--cfg-parallel-size",
-                    "2",
-                ],
-            ),
-            id="cfg_parallel_2",
-            marks=PARALLEL_FEATURE_MARKS,
+        id="vae_patch_parallel_2",
+        marks=PARALLEL_FEATURE_MARKS,
+    ),
+    pytest.param(
+        OmniServerParams(
+            model=MODEL_IMAGE,
+            server_args=[
+                "--use-hsdp",
+                "--hsdp-shard-size",
+                "2",
+            ],
         ),
-        pytest.param(
-            OmniServerParams(
-                model=model,
-                server_args=[
-                    "--cache-backend",
-                    "cache_dit",
-                    "--tensor-parallel-size",
-                    "2",
-                    "--vae-patch-parallel-size",
-                    "2",
-                    "--vae-use-tiling",
-                    "--diffusion-quantization-config",
-                    '{"method":"fp8"}',
-                ],
-            ),
-            id="vae_patch_parallel_2",
-            marks=PARALLEL_FEATURE_MARKS,
-        ),
-        pytest.param(
-            OmniServerParams(
-                model=model,
-                server_args=[
-                    "--use-hsdp",
-                    "--hsdp-shard-size",
-                    "2",
-                ],
-            ),
-            id="parallel_hsdp",
-            marks=PARALLEL_FEATURE_MARKS,
-        ),
-    ]
+        id="parallel_hsdp",
+        marks=PARALLEL_FEATURE_MARKS,
+    ),
+]
 
 
-@pytest.mark.parametrize(
-    "omni_server",
-    _get_diffusion_feature_cases("Qwen/Qwen-Image"),
-    indirect=True,
-)
+@pytest.mark.parametrize("omni_server", FEATURE_CASES, indirect=True)
 def test_qwen_image(omni_server: OmniServer, online_client: OnlineOmniClient):
-    """Test each diffusion feature with Qwen-Image (text-to-image), one feature per case."""
-    messages = dummy_messages_from_mix_data(content_text=T2I_PROMPT)
-    request_config = {
-        "model": omni_server.model,
-        "messages": messages,
-        "extra_body": {
-            "height": 512,
-            "width": 512,
-            "num_inference_steps": 2,
-            "negative_prompt": NEGATIVE_PROMPT,
-            "true_cfg_scale": 4.0,
-            "seed": 42,
-        },
-    }
-    online_client.send_diffusion_request(request_config)
-
-
-@pytest.mark.parametrize(
-    "omni_server",
-    _get_diffusion_feature_cases("Qwen/Qwen-Image-2512"),
-    indirect=True,
-)
-def test_qwen_image_2512(omni_server: OmniServer, online_client: OnlineOmniClient):
-    """Test each diffusion feature with Qwen-Image-2512 (text-to-image), one feature per case."""
+    """One diffusion feature per case; model is chosen in FEATURE_CASES."""
     messages = dummy_messages_from_mix_data(content_text=T2I_PROMPT)
     request_config = {
         "model": omni_server.model,


### PR DESCRIPTION

## Summary

**`Qwen/Qwen-Image` and `Qwen/Qwen-Image-2512` share the same architecture; only the weights differ.** Nightly Function was running the same 9 serving flags twice—once per checkpoint—so 18 full-weight loads were testing the same code paths twice. Feature gates (CPU offload, step-execution, TeaCache, Ulysses, …) do not depend on which of these two checkpoints is loaded. Dropping the duplicate grid is therefore a coverage cut of **weights**, not of **features**.

Two nightly-cost cuts in one change:

1. **Function 18→9.** Keep all 9 serving features, **one model per feature** (5× Qwen-Image, 4× Qwen-Image-2512, alternating) so both weight files still cold-start every night. Ulysses stays on Qwen-Image. Numeric 2512 weight checks stay on Accuracy (`test_qwen_image_2512_matches_diffusers_pixelwise`).

2. **Perf: one step-execution server.** Merge `test_qwen_image_single_device_step_execution` and `…_high_concurrency` the same way `single_device` already shares 512 + 1536: **one `test_name`, one `serve_args`, several `benchmark_params`**. Shared CLI is profiler + `--step-execution` + **`--max-num-seqs 8`**. Sequential `c=1` / 10 prompts remains valid on capacity 8.

## Function map (18 → 9)

| Feature id | Model |
|---|---|
| `cpu_offload` | Qwen-Image |
| `step_execution` | Qwen-Image-2512 |
| `cache_tea_cache` | Qwen-Image |
| `layerwise_offload` | Qwen-Image-2512 |
| `ulysses_2` | Qwen-Image |
| `ring_2` | Qwen-Image-2512 |
| `cfg_parallel_2` | Qwen-Image |
| `vae_patch_parallel_2` | Qwen-Image-2512 |
| `parallel_hsdp` | Qwen-Image |

Single-GPU vs 2-GPU marks unchanged. Pytest ids stay `cpu_offload`, `ulysses_2`, … so `-k` still works. `test_qwen_image_2512` is removed; model is on each `OmniServerParams`.

## Perf map

`test_qwen_image_single_device_step_execution` now has three `benchmark_params` on one server:

- `512x512_steps20` (c=1, n=10)
- `1536x1536_steps35` (c=1, n=10)
- `512x512_steps20_high_concurrency` (c=1/2/4/8 sweep)

H100 baselines are unchanged. After `--max-num-seqs 8` on the sequential 512 case, expect ~no QPS change at c=1; first nightly may need a baseline refresh if the gate is tight.

## Cost

- Function cold starts **18 → 9**.
- Step-execution perf cold starts **2 → 1** (sequential + high-concurrency share one load).
