### PR TITLE
[Feature] Support MiniMax-H3 FlashGen native LoRA with the legacy manager

### DIFF
--- a/docs/upstream/PR_h3_native_lora.md
+++ b/docs/upstream/PR_h3_native_lora.md
@@ -1,0 +1,50 @@
+# MiniMax-H3 native LoRA runtime loading
+
+Draft upstream PR text for vllm-project/vllm-omni.
+
+## Motivation and scope
+
+MiniMax-H3 FlashGen ships a native-layout distilled LoRA trained on Ascend NPU.
+Unlike LightX2V Turbo, it keeps fused `qkv_proj`, includes `adaln_proj.linear`,
+uses rank 64, and declares a non-uniform rectified-flow schedule. PR #6476 added
+Turbo support on the legacy `DiffusionLoRAManager`; this PR extends the same
+model-owned loader hook with a second contract keyed by
+`key_format=minimax-h3-native`.
+
+This complements PR #5991: checkpoint-pinned `base_schedule` covers merged
+releases, while adapter metadata covers runtime LoRA activation.
+
+## Changes
+
+- Add a native H3 LoRA loader beside the existing Turbo loader in
+  `vllm_omni/diffusion/models/minimax_h3/lora.py`.
+- Reorder fused `qkv_proj` LoRA rows with the existing
+  `_reorder_grouped_qkv_to_qkv` helper, then emit model-owned
+  `PackedLoRALayerWeights` for Q/K/V and gate/up slices.
+- Parse adapter-declared `base_schedule` from safetensors metadata through
+  `DMD2SigmaSchedule.from_safetensors_metadata`.
+- Extend `MiniMaxH3Pipeline` with native adapter classification, schedule
+  precedence, T2VA-only task validation, and interval-count request validation.
+- Leave `DiffusionLoRAManager` unchanged.
+
+## Validation
+
+- CPU tests in `tests/diffusion/models/minimax_h3/test_minimax_h3_native_lora.py`
+  and `tests/diffusion/sched/test_dmd2_sigma_schedule.py`.
+- Turbo regression suite remains unchanged.
+- NPU validation script: `scripts/npu_validate_native_lora.sh`.
+
+## Known limitations
+
+- Dynamic execution only; no prefusion or DLO.
+- Only one LoRA active at a time.
+- Formal support is limited to the published FlashGen v1.0 native artifact on T2VA.
+- Rejects model-level, layerwise, and distributed layerwise offload.
+- Rejects activation on checkpoints that already pin `base_schedule`.
+
+## Related work
+
+- Issue #5700: MiniMax-H3 follow-up roadmap
+- PR #6476: Turbo legacy LoRA loader (merged)
+- PR #5991: checkpoint-pinned DMD2 schedules (merged)
+- PR #6544, #6550, #6565: watch for generic LoRA manager changes

--- a/docs/upstream/issue_5700_native_lora_note.md
+++ b/docs/upstream/issue_5700_native_lora_note.md
@@ -1,0 +1,30 @@
+# Issue #5700 design note (draft)
+
+Post this comment on https://github.com/vllm-project/vllm-omni/issues/5700 before opening the PR.
+
+---
+
+## MiniMax-H3 FlashGen native LoRA (runtime loading)
+
+Follow-up to merged #6476 (Turbo) and #5991 (checkpoint-pinned schedules).
+
+**Scope**
+
+- Add `key_format=minimax-h3-native` beside existing `minimax-h3-diffusers` Turbo loading.
+- Keep `DiffusionLoRAManager` unchanged; loader emits model-owned `PackedLoRALayerWeights`.
+- Reuse `_reorder_grouped_qkv_to_qkv` for fused `qkv_proj` LoRA `lora_B` rows, then pack Q/K/V slices.
+- Adapter metadata declares `base_schedule`; pipeline precedence is adapter > checkpoint > uniform.
+- v1.0 artifact is T2VA-only, rank 64, grouped qkv, no gate/up swap on fc1.
+
+**Conflict watch**
+
+- #6544: silent LoRA no-op — NPU validation uses Base/LoRA SHA256 toggling.
+- #6550: Turbo pipeline refactor — native state kept incremental (`_native_lora_adapter_ids`, `_lora_sigma_schedules`).
+- #6565: mixed-rank packed slices — native qkv splits preserve rank 64 per slice.
+
+**Validation**
+
+- CPU: `tests/diffusion/models/minimax_h3/test_minimax_h3_native_lora.py`
+- NPU: `scripts/npu_validate_native_lora.sh`
+
+PR body template: `docs/upstream/PR_h3_native_lora.md`

--- a/docs/upstream/npu_native_lora_validation.md
+++ b/docs/upstream/npu_native_lora_validation.md
@@ -1,0 +1,51 @@
+# NPU end-to-end validation: MiniMax-H3 FlashGen native LoRA
+
+Run on Ascend NPU with vLLM-Omni built from this branch, the official
+`MiniMaxAI/MiniMax-H3` base checkpoint, and the repacked FlashGen artifact:
+
+```text
+Beidouqixing/minimax-h3-4step-lora-flashgen/minimax_h3_t2va_flashgen_4step_v1.0_768p_bf16.safetensors
+```
+
+## Preconditions
+
+1. Base weights downloaded and approved on Hugging Face.
+2. FlashGen LoRA downloaded to a local path (`FLASHGEN_LORA`).
+3. Server started **without** model-level, layerwise, or DLO offload.
+4. `--task-type fl2va --lora-backend peft --lora-path "${FLASHGEN_LORA}"`.
+
+## Binding check
+
+On adapter activation, logs should report **259/259** native targets bound,
+including `adaln_proj.linear` and `final_layer.adaln_proj.linear`.
+
+## Decode stream SHA256 matrix
+
+Use `scripts/npu_validate_native_lora.sh` or equivalent curl requests:
+
+| Run | LoRA scale | Expected |
+| --- | ---: | --- |
+| base | 0.0 | SHA256 A |
+| lora | 1.0 | SHA256 B (B ≠ A) |
+| base2 | 0.0 | SHA256 A (same as base) |
+| lora2 | 1.0 | SHA256 B (same as lora) |
+
+Pass criteria:
+
+- Each state is deterministic across repeats.
+- Base and LoRA hashes differ (guards against #6544-style silent no-op).
+- `num_inference_steps=4` succeeds; `num_inference_steps=5` returns client error.
+
+## Request contract
+
+```bash
+-F 'num_inference_steps=4' \
+-F 'extra_params={"task":"t2va","duration":5.2}' \
+-F "lora={\"name\":\"h3-flashgen\",\"path\":\"${FLASHGEN_LORA}\",\"scale\":1.0}"
+```
+
+Rejections to spot-check:
+
+- `task=fl2va` or `ref2va` with active native LoRA
+- `--enable-cpu-offload`, layerwise offload, or DLO
+- merged checkpoint with pinned `base_schedule` in `model_index.json`

--- a/docs/user_guide/diffusion/lora.md
+++ b/docs/user_guide/diffusion/lora.md
@@ -12,15 +12,17 @@ LoRA adapters are lightweight, model-specific fine-tuning weights that can be ap
 ## LoRA Adapter Format
 
 ### PEFT (Parameter-Efficient Fine-Tuning) format (default)
+
 A typical PEFT-format LoRA adapter directory structure:
 
-```
+```text
 lora_adapter/
 ├── adapter_config.json
 └── adapter_model.safetensors
 ```
 
 The `adapter_config.json` file contains metadata about the LoRA adapter, including:
+
 - `r`: LoRA rank
 - `lora_alpha`: LoRA alpha scaling factor
 - `target_modules`: List of module names to apply LoRA to
@@ -67,7 +69,7 @@ For distilled few-step LoRAs, pass `lora_backend="distill"` together with one or
 For Qwen-Image and Wan pipelines, the distill backend calls `pipeline.load_lora_weights(...)` during worker initialization.
 
 | Pipeline | Supported distilled LoRA repo | Notes |
-|----------|--------------------------------|-------|
+| ---------- | -------------------------------- | ------- |
 | `QwenImagePipeline` | `lightx2v/Qwen-Image-2512-Lightning` | Used with Qwen-Image-2512 Lightning-style few-step inference. |
 | `Wan22Pipeline` | `lightx2v/Wan2.1-Distill-Loras`, `lightx2v/Wan2.2-Distill-Loras` | Wan2.1 uses one LoRA file. For dual-transformer Wan2.2 MoE, pass high-noise then low-noise LoRA files. |
 | `Wan22I2VPipeline` | `lightx2v/Wan2.2-Distill-Loras` | For dual-transformer Wan2.2 MoE, pass high-noise then low-noise LoRA files. |
@@ -240,6 +242,25 @@ Notes:
 - Output quality and speed depend on the replacement checkpoints and sampling params you choose.
 - If you only need to fuse distilled LoRAs into a Wan2.2 checkpoint at load time (without the full LightX2V convert + assemble pipeline), you can instead pass them directly via `--lora-backend distill --lora-path <high>.safetensors <low>.safetensors`. See the [Distill backend](#distill-backend-fuse-distilled-lora-at-init) section above.
 
+## MiniMax-H3 adapter-declared schedules
+
+MiniMax-H3 supports two few-step mechanisms that must not be conflated:
+
+- **Checkpoint-pinned schedule**: a merged release writes `base_schedule` into
+  `model_index.json`. Requests must pass `num_inference_steps` as the interval
+  count (for example `4` for `[1.0, 0.7, 0.4, 0.15, 0.0]`).
+- **Runtime Turbo LoRA**: LightX2V Turbo artifacts request five sigma points and
+  enforce `flow_shift=6`, `audio_flow_shift=3`.
+- **Runtime native LoRA**: FlashGen-style artifacts declare
+  `key_format=minimax-h3-native` and embed `base_schedule` in safetensors
+  metadata. When active, the adapter schedule overrides the base checkpoint and
+  requests must use the interval-count contract (`num_inference_steps=4` or
+  omitted).
+
+Native artifacts also declare `qkv_layout=grouped`. The H3 loader reorders fused
+`qkv_proj` LoRA rows with the same `_reorder_grouped_qkv_to_qkv` helper used for
+base-weight loading, then binds the packed Q/K/V slices through the legacy PEFT
+manager without modifying `DiffusionLoRAManager`.
 
 ## See Also
 

--- a/recipes/MiniMaxAI/MiniMax-H3.md
+++ b/recipes/MiniMaxAI/MiniMax-H3.md
@@ -859,6 +859,43 @@ the legacy dynamic LoRA tensors do not participate in those weight lifecycles.
 The five requested sigma points produce the four denoiser evaluations expected
 by the Turbo artifact.
 
+### FlashGen native LoRA
+
+The FlashGen 4-step T2VA artifact uses the native MiniMax-H3 module layout and
+declares its distilled sigma schedule in safetensors metadata:
+
+```text
+Beidouqixing/minimax-h3-4step-lora-flashgen/minimax_h3_t2va_flashgen_4step_v1.0_768p_bf16.safetensors
+```
+
+Download only that file:
+
+```bash
+export FLASHGEN_DIR=/path/to/minimax-h3-flashgen-lora
+export FLASHGEN_FILE=minimax_h3_t2va_flashgen_4step_v1.0_768p_bf16.safetensors
+hf download Beidouqixing/minimax-h3-4step-lora-flashgen "${FLASHGEN_FILE}" --local-dir "${FLASHGEN_DIR}"
+export FLASHGEN_LORA="${FLASHGEN_DIR}/${FLASHGEN_FILE}"
+```
+
+Start from a non-offloaded FL2VA server command and add
+`--task-type fl2va --lora-backend peft --lora-path "${FLASHGEN_LORA}"`.
+Each request must use T2VA and the distilled interval-count contract:
+
+```bash
+-F 'num_inference_steps=4' \
+-F 'extra_params={"task":"t2va","duration":5.2}' \
+-F "lora={\"name\":\"h3-flashgen-v1.0\",\"path\":\"${FLASHGEN_LORA}\",\"scale\":1.0}"
+```
+
+This path rejects Ref2VA, model-level/layerwise offload, and checkpoints that
+already pin `base_schedule` in `model_index.json`. The adapter metadata carries
+`base_schedule=1.0,0.7,0.4,0.15,0.0`, so `num_inference_steps=4` means four
+denoiser evaluations, not five sigma points.
+
+Ascend NPU validation (259/259 binding, Base/LoRA SHA256 toggling) is documented
+in [`docs/upstream/npu_native_lora_validation.md`](../../docs/upstream/npu_native_lora_validation.md)
+with helper script [`scripts/npu_validate_native_lora.sh`](../../scripts/npu_validate_native_lora.sh).
+
 ## Key parameters
 
 | Parameter | Recommended value | Notes |

--- a/scripts/npu_validate_native_lora.sh
+++ b/scripts/npu_validate_native_lora.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+# Validate MiniMax-H3 FlashGen native LoRA on Ascend NPU.
+# Run on a machine with MiniMax-H3 base weights, vllm-omni, and NPU drivers.
+
+set -euo pipefail
+
+: "${MODEL_ROOT:?Set MODEL_ROOT to the MiniMax-H3 base directory}"
+: "${FLASHGEN_LORA:?Set FLASHGEN_LORA to minimax_h3_t2va_flashgen_4step_v1.0_768p_bf16.safetensors}"
+
+API_URL="${API_URL:-http://127.0.0.1:8000/v1/images/generations}"
+PROMPT="${PROMPT:-A cinematic sunrise over a calm ocean, gentle waves, stereo ambience.}"
+SEED="${SEED:-1101}"
+
+run_case() {
+  local label="$1"
+  local lora_json="$2"
+  local out="/tmp/h3_native_${label}.mp4"
+  curl -sS -X POST "${API_URL}" \
+    -F "prompt=${PROMPT}" \
+    -F "seed=${SEED}" \
+    -F 'num_inference_steps=4' \
+    -F 'aspect_ratio=16:9' \
+    -F 'extra_params={"task":"t2va","duration":5.2}' \
+    -F "lora=${lora_json}" \
+    -o "${out}"
+  ffprobe -v error -select_streams v:0 -show_entries stream=width,height,nb_frames -of csv=p=0 "${out}"
+  sha256sum "${out}"
+}
+
+echo "Base control (scale 0)"
+run_case base '{"name":"h3-flashgen","path":"'"${FLASHGEN_LORA}"'","scale":0.0}'
+
+echo "FlashGen native LoRA active"
+run_case lora '{"name":"h3-flashgen","path":"'"${FLASHGEN_LORA}"'","scale":1.0}'
+
+echo "Repeat base and LoRA to verify determinism"
+run_case base2 '{"name":"h3-flashgen","path":"'"${FLASHGEN_LORA}"'","scale":0.0}'
+run_case lora2 '{"name":"h3-flashgen","path":"'"${FLASHGEN_LORA}"'","scale":1.0}'

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_native_lora.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_native_lora.py
@@ -1,0 +1,506 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from safetensors.torch import save_file
+from vllm.lora.lora_weights import PackedLoRALayerWeights
+
+from vllm_omni.diffusion.lora.manager import DiffusionLoRAManager
+from vllm_omni.diffusion.models.minimax_h3 import lora as lora_module
+from vllm_omni.diffusion.models.minimax_h3.lora import load_minimax_h3_native_lora
+from vllm_omni.diffusion.sched.sigma_schedule import DMD2SigmaSchedule
+from vllm_omni.errors import OmniClientError
+from vllm_omni.lora.request import LoRARequest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+_TINY_HIDDEN = 2
+_TINY_INNER = 3
+_TINY_FFN = 2
+_TINY_TIME = 2
+_TINY_BLOCK_ADALN = 4
+_TINY_FINAL_ADALN = 3
+_TINY_RANK = 4
+_TINY_NUM_QUERY_GROUPS = 2
+_TINY_HEADS_PER_GROUP = 1
+_TINY_HEAD_DIM = 1
+_TINY_QKV_SLICE = _TINY_NUM_QUERY_GROUPS * _TINY_HEADS_PER_GROUP * _TINY_HEAD_DIM
+
+
+@pytest.fixture(autouse=True)
+def _use_tiny_native_dimensions(monkeypatch):
+    monkeypatch.setattr(lora_module, "_NATIVE_RANK", _TINY_RANK)
+    monkeypatch.setattr(lora_module, "_NATIVE_ALPHA", _TINY_RANK)
+    monkeypatch.setattr(lora_module, "_NATIVE_HIDDEN_SIZE", _TINY_HIDDEN)
+    monkeypatch.setattr(lora_module, "_NATIVE_ATTENTION_INNER_SIZE", _TINY_INNER)
+    monkeypatch.setattr(lora_module, "_NATIVE_FFN_HIDDEN_SIZE", _TINY_FFN)
+    monkeypatch.setattr(lora_module, "_NATIVE_TIME_EMBED_DIM", _TINY_TIME)
+    monkeypatch.setattr(lora_module, "_NATIVE_BLOCK_ADALN_OUT", _TINY_BLOCK_ADALN)
+    monkeypatch.setattr(lora_module, "_NATIVE_FINAL_ADALN_OUT", _TINY_FINAL_ADALN)
+    monkeypatch.setattr(lora_module, "_NATIVE_NUM_QUERY_GROUPS", _TINY_NUM_QUERY_GROUPS)
+    monkeypatch.setattr(lora_module, "_NATIVE_HEADS_PER_GROUP", _TINY_HEADS_PER_GROUP)
+    monkeypatch.setattr(lora_module, "_NATIVE_HEAD_DIM", _TINY_HEAD_DIM)
+    monkeypatch.setattr(lora_module, "_NATIVE_QKV_SLICE", _TINY_QKV_SLICE)
+    monkeypatch.setattr(
+        lora_module,
+        "_NATIVE_TARGET_DIMS",
+        {
+            "attn.qkv_proj": (_TINY_HIDDEN, 3 * _TINY_INNER),
+            "attn.out_proj": (_TINY_INNER, _TINY_HIDDEN),
+            "mlp.fc1": (_TINY_HIDDEN, 2 * _TINY_FFN),
+            "mlp.fc2": (_TINY_FFN, _TINY_HIDDEN),
+            "adaln_proj.linear": (_TINY_TIME, _TINY_BLOCK_ADALN),
+        },
+    )
+    monkeypatch.setattr(lora_module, "_NATIVE_FINAL_ADALN_DIMS", (_TINY_TIME, _TINY_FINAL_ADALN))
+    monkeypatch.setattr(
+        lora_module,
+        "_NATIVE_EXPECTED_TARGETS",
+        frozenset(
+            [
+                *(
+                    f"blocks.{block_index}.{suffix}"
+                    for block_index in range(50)
+                    for suffix in lora_module._NATIVE_TARGET_SUFFIXES
+                )
+            ]
+            + [
+                *(
+                    f"token_refiner.blocks.{block_index}.{suffix}"
+                    for block_index in range(2)
+                    for suffix in lora_module._NATIVE_TOKEN_REFINER_SUFFIXES
+                )
+            ]
+            + ["final_layer.adaln_proj.linear"]
+        ),
+    )
+
+
+def _request(path) -> LoRARequest:
+    return LoRARequest(
+        lora_name="flashgen",
+        lora_int_id=7,
+        lora_path=str(path),
+    )
+
+
+def _write_tiny_native(
+    path,
+    *,
+    omit_target: str | None = None,
+    shape_overrides: dict[str, tuple[int, int]] | None = None,
+    metadata: dict[str, str] | None = None,
+) -> None:
+    rank = _TINY_RANK
+    tensors = {}
+    overrides = shape_overrides or {}
+    for target in sorted(lora_module._NATIVE_EXPECTED_TARGETS):
+        if target == omit_target:
+            continue
+        input_dim, output_dim = lora_module._native_target_dims(target)
+        raw_target = f"transformer.{target}"
+        a_name = f"{raw_target}.lora_A.default.weight"
+        b_name = f"{raw_target}.lora_B.default.weight"
+        tensors[a_name] = torch.ones(overrides.get(a_name, (rank, input_dim)))
+        if target.endswith(".attn.qkv_proj"):
+            grouped_rows = []
+            for group in range(_TINY_NUM_QUERY_GROUPS):
+                grouped_rows.extend(
+                    [
+                        torch.full((1, rank), float(group * 10 + 1)),
+                        torch.full((1, rank), float(group * 10 + 2)),
+                        torch.full((1, rank), float(group * 10 + 3)),
+                    ]
+                )
+            tensors[b_name] = torch.cat(grouped_rows, dim=0)
+        elif target.endswith(".mlp.fc1"):
+            tensors[b_name] = torch.cat(
+                (
+                    torch.full((output_dim // 2, rank), 2.0),
+                    torch.full((output_dim // 2, rank), 1.0),
+                ),
+                dim=0,
+            )
+        else:
+            tensors[b_name] = torch.ones(overrides.get(b_name, (output_dim, rank)))
+    save_file(
+        tensors,
+        str(path),
+        metadata=metadata
+        or {
+            "format": "pt",
+            "key_format": "minimax-h3-native",
+            "qkv_layout": "grouped",
+            "lora_rank": str(rank),
+            "lora_alpha": str(rank),
+            "base_schedule": "1.0,0.7,0.4,0.15,0.0",
+            "tasks": "t2va",
+        },
+    )
+
+
+def test_h3_native_loads_and_packs_qkv_and_fc1(tmp_path):
+    path = tmp_path / "minimax_h3_t2va_flashgen_4step_v1.0_768p_bf16.safetensors"
+    _write_tiny_native(path)
+
+    loaded = load_minimax_h3_native_lora(
+        partition="fl2va",
+        lora_request=_request(path),
+        lora_path=path,
+        dtype=torch.float32,
+    )
+
+    assert loaded is not None
+    lora_model, peft_helper, schedule = loaded
+    assert peft_helper.r == _TINY_RANK
+    assert schedule.num_inference_steps == 4
+    assert len(lora_model.loras) == 259
+    assert "blocks.0.adaln_proj.linear" in lora_model.loras
+    assert "final_layer.adaln_proj.linear" in lora_model.loras
+
+    qkv = lora_model.get_lora("blocks.0.attn.qkv_proj")
+    assert isinstance(qkv, PackedLoRALayerWeights)
+    torch.testing.assert_close(qkv.lora_b[0], torch.tensor([[10.0], [11.0]]))
+    torch.testing.assert_close(qkv.lora_b[1], torch.tensor([[12.0], [22.0]]))
+    torch.testing.assert_close(qkv.lora_b[2], torch.tensor([[13.0], [23.0]]))
+
+    fc1 = lora_model.get_lora("blocks.0.mlp.fc1")
+    assert isinstance(fc1, PackedLoRALayerWeights)
+    torch.testing.assert_close(fc1.lora_b[0], torch.full((1, _TINY_RANK), 2.0))
+    torch.testing.assert_close(fc1.lora_b[1], torch.full((1, _TINY_RANK), 1.0))
+
+
+def test_h3_native_rejects_bad_metadata_and_ref2va(tmp_path):
+    path = tmp_path / "minimax_h3_t2va_flashgen_4step_v1.0_768p_bf16.safetensors"
+    _write_tiny_native(path, metadata={"key_format": "minimax-h3-native", "qkv_layout": "runtime"})
+    with pytest.raises(ValueError, match="qkv_layout='grouped'"):
+        load_minimax_h3_native_lora(
+            partition="fl2va",
+            lora_request=_request(path),
+            lora_path=path,
+            dtype=torch.float32,
+        )
+
+    valid = tmp_path / "valid.safetensors"
+    _write_tiny_native(valid)
+    with pytest.raises(ValueError, match="supports T2VA only"):
+        load_minimax_h3_native_lora(
+            partition="ref2va",
+            lora_request=_request(valid),
+            lora_path=valid,
+            dtype=torch.float32,
+        )
+
+
+def test_h3_native_rejects_truncated_artifact(tmp_path):
+    path = tmp_path / "minimax_h3_t2va_flashgen_4step_v1.0_768p_bf16.safetensors"
+    _write_tiny_native(path, omit_target="blocks.49.mlp.fc2")
+    with pytest.raises(ValueError, match="target set does not match"):
+        load_minimax_h3_native_lora(
+            partition="fl2va",
+            lora_request=_request(path),
+            lora_path=path,
+            dtype=torch.float32,
+        )
+
+
+def test_h3_native_declared_file_fails_closed_on_invalid_metadata(tmp_path):
+    path = tmp_path / "minimax_h3_t2va_flashgen_4step_v1.0_768p_bf16.safetensors"
+    _write_tiny_native(path, metadata={"key_format": "other"})
+    with pytest.raises(ValueError, match="requires safetensors metadata"):
+        load_minimax_h3_native_lora(
+            partition="fl2va",
+            lora_request=_request(path),
+            lora_path=path,
+            dtype=torch.float32,
+        )
+
+
+def test_pipeline_native_schedule_and_task_validation(monkeypatch):
+    from vllm_omni.diffusion.models.minimax_h3 import MiniMaxH3Pipeline
+
+    pipeline = object.__new__(MiniMaxH3Pipeline)
+    torch.nn.Module.__init__(pipeline)
+    pipeline.partition = "fl2va"
+    pipeline.supported_tasks = frozenset({"t2va", "fl2va", "ref2va"})
+    pipeline._turbo_lora_adapter_ids = set()
+    pipeline._native_lora_adapter_ids = {7}
+    pipeline._lora_sigma_schedules = {7: DMD2SigmaSchedule.from_positions([1.0, 0.7, 0.4, 0.15, 0.0])}
+    pipeline._base_schedule_by_partition = {"fl2va": None}
+
+    sampling = SimpleNamespace(
+        lora_request=LoRARequest("flashgen", 7, "/tmp/native.safetensors"),
+        lora_scale=1.0,
+        num_inference_steps=4,
+        extra_args={},
+    )
+    assert pipeline._sigma_schedule_for_request(sampling, "t2va").num_inference_steps == 4
+    with pytest.raises(OmniClientError, match="num_inference_steps must be 4"):
+        pipeline._validate_native_sampling(
+            SimpleNamespace(lora_request=sampling.lora_request, num_inference_steps=5),
+            task="t2va",
+        )
+    with pytest.raises(OmniClientError, match="supports T2VA requests only"):
+        pipeline._resolve_task(
+            "fl2va",
+            {},
+            has_turbo_lora=False,
+            has_native_lora=True,
+        )
+
+    pipeline._base_schedule_by_partition = {"fl2va": DMD2SigmaSchedule.from_positions([1.0, 0.5, 0.0])}
+    with pytest.raises(OmniClientError, match="already pins base_schedule"):
+        pipeline._sigma_schedule_for_request(sampling, "t2va")
+
+
+def test_pipeline_replaces_native_classification_after_reload(monkeypatch, tmp_path):
+    from vllm_omni.diffusion.models.minimax_h3 import MiniMaxH3Pipeline
+    from vllm_omni.diffusion.models.minimax_h3 import pipeline_minimax_h3 as pipeline_module
+
+    path = tmp_path / "minimax_h3_t2va_flashgen_4step_v1.0_768p_bf16.safetensors"
+    _write_tiny_native(path)
+    request = _request(path)
+
+    pipeline = object.__new__(MiniMaxH3Pipeline)
+    torch.nn.Module.__init__(pipeline)
+    pipeline.partition = "fl2va"
+    pipeline.od_config = SimpleNamespace(
+        enable_cpu_offload=False,
+        enable_layerwise_offload=False,
+        enable_distributed_layerwise_offload=False,
+    )
+    pipeline._turbo_lora_adapter_ids = set()
+    pipeline._native_lora_adapter_ids = set()
+    pipeline._lora_sigma_schedules = {}
+
+    loaded = pipeline._load_diffusion_lora_adapter(
+        lora_request=request,
+        lora_path=path,
+        dtype=torch.float32,
+    )
+    assert loaded is not None
+    assert request.lora_int_id in pipeline._native_lora_adapter_ids
+    assert request.lora_int_id in pipeline._lora_sigma_schedules
+
+    monkeypatch.setattr(pipeline_module, "load_minimax_h3_turbo_lora", lambda **_: None)
+    monkeypatch.setattr(pipeline_module, "load_minimax_h3_native_lora", lambda **_: None)
+    assert pipeline._load_diffusion_lora_adapter(lora_request=request, lora_path=path, dtype=torch.float32) is None
+    assert request.lora_int_id not in pipeline._native_lora_adapter_ids
+    assert request.lora_int_id not in pipeline._lora_sigma_schedules
+
+
+def test_h3_native_qkv_reorder_matches_base_loader_contract():
+    from vllm_omni.diffusion.models.minimax_h3.minimax_h3_transformer import _reorder_grouped_qkv_to_qkv
+
+    num_query_groups = 56
+    heads_per_group = 1
+    head_dim = 128
+    grouped = torch.arange(num_query_groups * (heads_per_group + 2) * head_dim, dtype=torch.float32)
+    grouped = grouped.reshape(num_query_groups, (heads_per_group + 2) * head_dim)
+    reordered = _reorder_grouped_qkv_to_qkv(
+        grouped.reshape(-1, 1),
+        num_query_groups=num_query_groups,
+        heads_per_group=heads_per_group,
+        head_dim=head_dim,
+    ).reshape(-1)
+    q_size = num_query_groups * heads_per_group * head_dim
+    k_size = num_query_groups * head_dim
+    q, k, v = torch.split(reordered, [q_size, k_size, k_size])
+    assert q.reshape(num_query_groups, head_dim)[0, 0] == grouped[0, 0]
+    assert k.reshape(num_query_groups, head_dim)[0, 0] == grouped[0, head_dim]
+    assert v.reshape(num_query_groups, head_dim)[0, 0] == grouped[0, 2 * head_dim]
+
+
+def test_legacy_manager_uses_native_loader(tmp_path):
+    path = tmp_path / "minimax_h3_t2va_flashgen_4step_v1.0_768p_bf16.safetensors"
+    _write_tiny_native(path)
+
+    class _Pipeline:
+        def _load_diffusion_lora_adapter(self, **kwargs):
+            from vllm_omni.diffusion.models.minimax_h3.pipeline_minimax_h3 import (
+                MiniMaxH3Pipeline,
+            )
+
+            pipeline = object.__new__(MiniMaxH3Pipeline)
+            pipeline.partition = "fl2va"
+            pipeline.od_config = SimpleNamespace(
+                enable_cpu_offload=False,
+                enable_layerwise_offload=False,
+                enable_distributed_layerwise_offload=False,
+            )
+            pipeline._turbo_lora_adapter_ids = set()
+            pipeline._native_lora_adapter_ids = set()
+            pipeline._lora_sigma_schedules = {}
+            return pipeline._load_diffusion_lora_adapter(**kwargs)
+
+    manager = object.__new__(DiffusionLoRAManager)
+    manager.pipeline = _Pipeline()
+    manager.dtype = torch.float32
+    manager._expected_lora_modules = {"qkv_proj", "fc1", "adaln_proj.linear"}
+
+    lora_model, peft_helper = manager._load_adapter(_request(path))
+    assert lora_model.id == 7
+    assert peft_helper.lora_alpha == _TINY_RANK
+    assert len(lora_model.loras) == 259
+
+
+def test_pipeline_schedule_inactive_when_scale_zero():
+    from vllm_omni.diffusion.models.minimax_h3 import MiniMaxH3Pipeline
+
+    pipeline = object.__new__(MiniMaxH3Pipeline)
+    torch.nn.Module.__init__(pipeline)
+    pipeline.partition = "fl2va"
+    pipeline._turbo_lora_adapter_ids = set()
+    pipeline._native_lora_adapter_ids = {7}
+    pipeline._lora_sigma_schedules = {7: DMD2SigmaSchedule.from_positions([1.0, 0.7, 0.4, 0.15, 0.0])}
+    pipeline._base_schedule_by_partition = {"fl2va": None}
+
+    sampling = SimpleNamespace(
+        lora_request=LoRARequest("flashgen", 7, "/tmp/native.safetensors"),
+        lora_scale=0.0,
+        num_inference_steps=4,
+    )
+    assert pipeline._sigma_schedule_for_request(sampling, "t2va") is None
+    assert not pipeline._has_active_native_lora(sampling)
+
+
+def test_pipeline_schedule_falls_back_after_eviction(monkeypatch, tmp_path):
+    from vllm_omni.diffusion.models.minimax_h3 import MiniMaxH3Pipeline
+    from vllm_omni.diffusion.models.minimax_h3 import pipeline_minimax_h3 as pipeline_module
+
+    path = tmp_path / "minimax_h3_t2va_flashgen_4step_v1.0_768p_bf16.safetensors"
+    _write_tiny_native(path)
+    request = _request(path)
+
+    pipeline = object.__new__(MiniMaxH3Pipeline)
+    torch.nn.Module.__init__(pipeline)
+    pipeline.partition = "fl2va"
+    pipeline.od_config = SimpleNamespace(
+        enable_cpu_offload=False,
+        enable_layerwise_offload=False,
+        enable_distributed_layerwise_offload=False,
+    )
+    pipeline._turbo_lora_adapter_ids = set()
+    pipeline._native_lora_adapter_ids = set()
+    pipeline._lora_sigma_schedules = {}
+    pipeline._base_schedule_by_partition = {"fl2va": None}
+
+    loaded = pipeline._load_diffusion_lora_adapter(
+        lora_request=request,
+        lora_path=path,
+        dtype=torch.float32,
+    )
+    assert loaded is not None
+    assert request.lora_int_id in pipeline._lora_sigma_schedules
+
+    monkeypatch.setattr(pipeline_module, "load_minimax_h3_turbo_lora", lambda **_: None)
+    monkeypatch.setattr(pipeline_module, "load_minimax_h3_native_lora", lambda **_: None)
+    assert pipeline._load_diffusion_lora_adapter(lora_request=request, lora_path=path, dtype=torch.float32) is None
+    assert request.lora_int_id not in pipeline._lora_sigma_schedules
+
+    sampling = SimpleNamespace(
+        lora_request=request,
+        lora_scale=1.0,
+        num_inference_steps=4,
+    )
+    assert pipeline._sigma_schedule_for_request(sampling, "t2va") is None
+
+
+def test_native_packed_qkv_slices_are_tp2_divisible():
+    assert lora_module._NATIVE_QKV_SLICE % 2 == 0
+    assert lora_module._NATIVE_FFN_HIDDEN_SIZE % 2 == 0
+
+
+def test_lora_manager_activates_native_packed_qkv(tmp_path):
+    path = tmp_path / "minimax_h3_t2va_flashgen_4step_v1.0_768p_bf16.safetensors"
+    _write_tiny_native(path)
+    loaded = load_minimax_h3_native_lora(
+        partition="fl2va",
+        lora_request=_request(path),
+        lora_path=path,
+        dtype=torch.float32,
+    )
+    assert loaded is not None
+    lora_model, _, _ = loaded
+    packed = lora_model.get_lora("blocks.0.attn.qkv_proj")
+    assert isinstance(packed, PackedLoRALayerWeights)
+    assert len(packed.lora_b) == 3
+    assert all(b.shape[0] == _TINY_QKV_SLICE for b in packed.lora_b)
+
+    class _DummyLoRALayer:
+        def __init__(self):
+            self.n_slices = 3
+            self.output_slices = (_TINY_QKV_SLICE, _TINY_QKV_SLICE, _TINY_QKV_SLICE)
+            self.set_calls: list[tuple[list, list]] = []
+            self.reset_calls = 0
+
+        def reset_lora(self, index: int):
+            self.reset_calls += 1
+
+        def set_lora(self, index: int, lora_a, lora_b):
+            self.set_calls.append((lora_a, lora_b))
+
+    layer = _DummyLoRALayer()
+    manager = object.__new__(DiffusionLoRAManager)
+    manager.pipeline = torch.nn.Module()
+    manager._lora_modules = {"blocks.0.attn.qkv_proj": layer}
+    manager._registered_adapters = {
+        lora_model.id: lora_model,
+    }
+    manager._activate_adapter(lora_model.id, scale=0.5)
+
+    assert len(layer.set_calls) == 1
+    lora_a_list, lora_b_list = layer.set_calls[0]
+    assert len(lora_a_list) == 3
+    assert len(lora_b_list) == 3
+    torch.testing.assert_close(lora_b_list[0], packed.lora_b[0] * 0.5)
+    torch.testing.assert_close(lora_b_list[1], packed.lora_b[1] * 0.5)
+    torch.testing.assert_close(lora_b_list[2], packed.lora_b[2] * 0.5)
+
+
+def test_lora_manager_tp2_splits_native_packed_qkv_per_rank():
+    """Each Q/K/V slice must be divisible by TP2 so rank-local layers can shard rows."""
+
+    tp_size = 2
+    slice_rows = lora_module._NATIVE_QKV_SLICE
+    assert slice_rows % tp_size == 0
+    local_rows = slice_rows // tp_size
+
+    class _TpQkvLoRALayer:
+        def __init__(self, tp_rank: int):
+            self.tp_rank = tp_rank
+            self.n_slices = 3
+            self.output_slices = (local_rows, local_rows, local_rows)
+            self.set_calls: list[tuple[list, list]] = []
+
+        def reset_lora(self, index: int):
+            return
+
+        def set_lora(self, index: int, lora_a, lora_b):
+            self.set_calls.append((lora_a, lora_b))
+
+    for tp_rank in range(tp_size):
+        layer = _TpQkvLoRALayer(tp_rank)
+        start = tp_rank * local_rows
+        end = start + local_rows
+        full_packed = PackedLoRALayerWeights(
+            module_name="blocks.0.attn.qkv_proj",
+            rank=lora_module._NATIVE_RANK,
+            lora_alphas=[64, 64, 64],
+            lora_a=[torch.ones(lora_module._NATIVE_RANK, lora_module._NATIVE_HIDDEN_SIZE)] * 3,
+            lora_b=[torch.full((slice_rows, lora_module._NATIVE_RANK), float(i + 1)) for i in range(3)],
+            scaling=[1.0, 1.0, 1.0],
+        )
+        local_b = [b[start:end].contiguous() for b in full_packed.lora_b]
+        layer.set_lora(0, full_packed.lora_a, local_b)
+        assert len(layer.set_calls) == 1
+        _, lora_b_list = layer.set_calls[0]
+        assert all(b.shape[0] == local_rows for b in lora_b_list)
+        assert lora_b_list[0][0, 0].item() == 1.0
+        assert lora_b_list[1][0, 0].item() == 2.0
+        assert lora_b_list[2][0, 0].item() == 3.0

--- a/tests/diffusion/sched/test_dmd2_sigma_schedule.py
+++ b/tests/diffusion/sched/test_dmd2_sigma_schedule.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 import pytest
 
 from vllm_omni.diffusion.sched import DMD2SigmaSchedule
@@ -50,3 +50,10 @@ def test_absent_metadata_key_means_undistilled_but_empty_is_malformed():
     assert DMD2SigmaSchedule.from_metadata({"base_schedule": [1.0, 0.5, 0.0]}).base_schedule == (1.0, 0.5, 0.0)
     with pytest.raises(ValueError):
         DMD2SigmaSchedule.from_metadata({"base_schedule": []})
+
+
+def test_safetensors_metadata_parses_comma_separated_schedule():
+    schedule = DMD2SigmaSchedule.from_safetensors_metadata({"base_schedule": "1.0,0.7,0.4,0.15,0.0"})
+
+    assert schedule is not None
+    assert schedule.num_inference_steps == 4

--- a/vllm_omni/diffusion/models/minimax_h3/lora.py
+++ b/vllm_omni/diffusion/models/minimax_h3/lora.py
@@ -257,9 +257,9 @@ _NATIVE_EXPECTED_TARGETS = frozenset(
     + ["final_layer.adaln_proj.linear"]
 )
 _NATIVE_TARGET_PATTERN = (
-    r"^(?:blocks\.\d+\.(?:attn\.(?:qkv_proj|out_proj)|mlp\.(?:fc1|fc2)|adaln_proj\.linear)"
-    r"|token_refiner\.blocks\.\d+\.(?:attn\.(?:qkv_proj|out_proj)|mlp\.(?:fc1|fc2))"
-    r"|final_layer\.adaln_proj\.linear)$"
+    r"^(?:transformer\.blocks\.\d+\.(?:attn\.(?:qkv_proj|out_proj)|mlp\.(?:fc1|fc2)|adaln_proj\.linear)"
+    r"|transformer\.token_refiner\.blocks\.\d+\.(?:attn\.(?:qkv_proj|out_proj)|mlp\.(?:fc1|fc2))"
+    r"|transformer\.final_layer\.adaln_proj\.linear)$"
 )
 _NATIVE_WEIGHTS_MAPPER = WeightsMapper(
     orig_to_new_substr={

--- a/vllm_omni/diffusion/models/minimax_h3/lora.py
+++ b/vllm_omni/diffusion/models/minimax_h3/lora.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Mapping
 from pathlib import Path
 
 import torch
@@ -13,7 +14,10 @@ from vllm.lora.lora_weights import PackedLoRALayerWeights
 from vllm.lora.peft_helper import PEFTHelper
 from vllm.model_executor.models.utils import WeightsMapper
 
+from vllm_omni.diffusion.sched.sigma_schedule import DMD2SigmaSchedule
 from vllm_omni.lora.request import LoRARequest
+
+from .minimax_h3_transformer import _reorder_grouped_qkv_to_qkv
 
 _TURBO_RANK = 128
 _TURBO_ALPHA = 128
@@ -203,3 +207,247 @@ def load_minimax_h3_turbo_lora(
     )
     _pack_h3_turbo_fc1(lora_model)
     return lora_model, peft_helper
+
+
+_NATIVE_RANK = 64
+_NATIVE_ALPHA = 64
+_NATIVE_HIDDEN_SIZE = 5376
+_NATIVE_ATTENTION_INNER_SIZE = 7168
+_NATIVE_FFN_HIDDEN_SIZE = 14336
+_NATIVE_TIME_EMBED_DIM = 2688
+_NATIVE_BLOCK_ADALN_OUT = 96768
+_NATIVE_FINAL_ADALN_OUT = 10752
+_NATIVE_NUM_QUERY_GROUPS = 56
+_NATIVE_HEADS_PER_GROUP = 1
+_NATIVE_HEAD_DIM = 128
+_NATIVE_QKV_SLICE = _NATIVE_ATTENTION_INNER_SIZE
+_NATIVE_KEY_FORMAT = "minimax-h3-native"
+_NATIVE_QKV_LAYOUT = "grouped"
+_NATIVE_FILENAME = "minimax_h3_t2va_flashgen_4step_v1.0_768p_bf16.safetensors"
+_NATIVE_TARGET_SUFFIXES = (
+    "attn.qkv_proj",
+    "attn.out_proj",
+    "mlp.fc1",
+    "mlp.fc2",
+    "adaln_proj.linear",
+)
+_NATIVE_TOKEN_REFINER_SUFFIXES = (
+    "attn.qkv_proj",
+    "attn.out_proj",
+    "mlp.fc1",
+    "mlp.fc2",
+)
+_NATIVE_TARGET_DIMS = {
+    "attn.qkv_proj": (_NATIVE_HIDDEN_SIZE, 3 * _NATIVE_ATTENTION_INNER_SIZE),
+    "attn.out_proj": (_NATIVE_ATTENTION_INNER_SIZE, _NATIVE_HIDDEN_SIZE),
+    "mlp.fc1": (_NATIVE_HIDDEN_SIZE, 2 * _NATIVE_FFN_HIDDEN_SIZE),
+    "mlp.fc2": (_NATIVE_FFN_HIDDEN_SIZE, _NATIVE_HIDDEN_SIZE),
+    "adaln_proj.linear": (_NATIVE_TIME_EMBED_DIM, _NATIVE_BLOCK_ADALN_OUT),
+}
+_NATIVE_FINAL_ADALN_DIMS = (_NATIVE_TIME_EMBED_DIM, _NATIVE_FINAL_ADALN_OUT)
+_NATIVE_EXPECTED_TARGETS = frozenset(
+    [*(f"blocks.{block_index}.{suffix}" for block_index in range(50) for suffix in _NATIVE_TARGET_SUFFIXES)]
+    + [
+        *(
+            f"token_refiner.blocks.{block_index}.{suffix}"
+            for block_index in range(2)
+            for suffix in _NATIVE_TOKEN_REFINER_SUFFIXES
+        )
+    ]
+    + ["final_layer.adaln_proj.linear"]
+)
+_NATIVE_TARGET_PATTERN = (
+    r"^(?:blocks\.\d+\.(?:attn\.(?:qkv_proj|out_proj)|mlp\.(?:fc1|fc2)|adaln_proj\.linear)"
+    r"|token_refiner\.blocks\.\d+\.(?:attn\.(?:qkv_proj|out_proj)|mlp\.(?:fc1|fc2))"
+    r"|final_layer\.adaln_proj\.linear)$"
+)
+_NATIVE_WEIGHTS_MAPPER = WeightsMapper(
+    orig_to_new_substr={
+        "transformer.": "",
+        ".lora_A.default.": ".lora_A.",
+        ".lora_B.default.": ".lora_B.",
+    }
+)
+
+
+def _select_native_file(artifact_path: str | Path) -> Path | None:
+    path = Path(artifact_path)
+    if path.is_file():
+        return path if path.suffix == ".safetensors" else None
+    if not path.is_dir():
+        return None
+
+    candidate = path / _NATIVE_FILENAME
+    return candidate if candidate.is_file() else None
+
+
+def _native_target_dims(target: str) -> tuple[int, int]:
+    if target == "final_layer.adaln_proj.linear":
+        return _NATIVE_FINAL_ADALN_DIMS
+    if target.endswith("adaln_proj.linear"):
+        return _NATIVE_TARGET_DIMS["adaln_proj.linear"]
+    for suffix in ("attn.qkv_proj", "attn.out_proj", "mlp.fc1", "mlp.fc2"):
+        if target.endswith(suffix):
+            return _NATIVE_TARGET_DIMS[suffix]
+    raise ValueError(f"Unsupported MiniMax-H3 native target: {target!r}")
+
+
+def _validate_native_metadata(metadata: Mapping[str, str]) -> DMD2SigmaSchedule:
+    if metadata.get("key_format") != _NATIVE_KEY_FORMAT:
+        raise ValueError(f"MiniMax-H3 native LoRA requires safetensors metadata key_format={_NATIVE_KEY_FORMAT!r}")
+    if metadata.get("qkv_layout") != _NATIVE_QKV_LAYOUT:
+        raise ValueError(f"MiniMax-H3 native LoRA requires safetensors metadata qkv_layout={_NATIVE_QKV_LAYOUT!r}")
+    try:
+        rank = int(metadata.get("lora_rank", ""))
+        alpha = float(metadata.get("lora_alpha", ""))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("MiniMax-H3 native LoRA metadata lora_rank/lora_alpha must be numeric") from exc
+    if rank != _NATIVE_RANK:
+        raise ValueError(f"MiniMax-H3 native LoRA requires lora_rank={_NATIVE_RANK}, got {rank!r}")
+    if alpha != _NATIVE_ALPHA:
+        raise ValueError(f"MiniMax-H3 native LoRA requires lora_alpha={_NATIVE_ALPHA}, got {alpha!r}")
+    tasks = {part.strip().lower() for part in str(metadata.get("tasks", "")).split(",") if part.strip()}
+    if tasks != {"t2va"}:
+        raise ValueError("MiniMax-H3 native LoRA v1.0 supports tasks=t2va only")
+    schedule = DMD2SigmaSchedule.from_safetensors_metadata(metadata)
+    if schedule is None:
+        raise ValueError("MiniMax-H3 native LoRA requires safetensors metadata base_schedule")
+    return schedule
+
+
+def _validate_native_tensors(checkpoint) -> dict[str, torch.Tensor]:
+    tensors: dict[str, torch.Tensor] = {}
+    pairs: dict[str, set[str]] = {}
+    raw_targets: set[str] = set()
+    for name in checkpoint.keys():
+        if name.endswith(_LORA_A_SUFFIX):
+            raw_target = name[: -len(_LORA_A_SUFFIX)]
+            side = "a"
+        elif name.endswith(_LORA_B_SUFFIX):
+            raw_target = name[: -len(_LORA_B_SUFFIX)]
+            side = "b"
+        else:
+            raise ValueError(f"Unconsumed MiniMax-H3 native tensor: {name!r}")
+        if not raw_target.startswith("transformer."):
+            raise ValueError(f"MiniMax-H3 native LoRA tensors must use transformer.* keys, got {name!r}")
+        mapped_target = raw_target.removeprefix("transformer.")
+        raw_targets.add(mapped_target)
+
+        target_sides = pairs.setdefault(mapped_target, set())
+        if side in target_sides:
+            raise ValueError(f"Duplicate MiniMax-H3 native tensor for {mapped_target}.{side}")
+        target_sides.add(side)
+
+        tensor = checkpoint.get_tensor(name)
+        if tensor.ndim != 2:
+            raise ValueError(f"MiniMax-H3 native LoRA tensors must be matrices, got {name}={tuple(tensor.shape)}")
+        input_dim, output_dim = _native_target_dims(mapped_target)
+        expected_shape = (_NATIVE_RANK, input_dim) if side == "a" else (output_dim, _NATIVE_RANK)
+        if tuple(tensor.shape) != expected_shape:
+            raise ValueError(
+                f"MiniMax-H3 native tensor has invalid global shape: {name}={tuple(tensor.shape)}, "
+                f"expected={expected_shape}"
+            )
+        tensors[name] = tensor
+
+    incomplete = sorted(target for target, sides in pairs.items() if sides != {"a", "b"})
+    if incomplete:
+        raise ValueError(f"Incomplete MiniMax-H3 native LoRA pairs: {incomplete}")
+    missing = sorted(_NATIVE_EXPECTED_TARGETS - raw_targets)
+    unexpected = sorted(raw_targets - _NATIVE_EXPECTED_TARGETS)
+    if missing or unexpected:
+        raise ValueError(
+            "MiniMax-H3 native target set does not match the supported v1.0 artifact: "
+            f"missing={len(missing)} {missing[:5]}, unexpected={len(unexpected)} {unexpected[:5]}"
+        )
+    return tensors
+
+
+def _pack_h3_native_fc1(lora_model: LoRAModel) -> None:
+    for module_name, weights in tuple(lora_model.loras.items()):
+        if not module_name.endswith(".mlp.fc1"):
+            continue
+        gate_b, up_b = weights.lora_b.chunk(2, dim=0)
+        lora_model.loras[module_name] = PackedLoRALayerWeights(
+            module_name=module_name,
+            rank=weights.rank,
+            lora_alphas=[weights.lora_alpha, weights.lora_alpha],
+            lora_a=[weights.lora_a, weights.lora_a],
+            lora_b=[gate_b.contiguous(), up_b.contiguous()],
+            scaling=[weights.scaling, weights.scaling],
+        )
+
+
+def _pack_h3_native_qkv(lora_model: LoRAModel) -> None:
+    for module_name, weights in tuple(lora_model.loras.items()):
+        if not module_name.endswith(".attn.qkv_proj"):
+            continue
+        reordered_b = _reorder_grouped_qkv_to_qkv(
+            weights.lora_b,
+            num_query_groups=_NATIVE_NUM_QUERY_GROUPS,
+            heads_per_group=_NATIVE_HEADS_PER_GROUP,
+            head_dim=_NATIVE_HEAD_DIM,
+        )
+        q_b, k_b, v_b = torch.split(
+            reordered_b,
+            [_NATIVE_QKV_SLICE, _NATIVE_QKV_SLICE, _NATIVE_QKV_SLICE],
+            dim=0,
+        )
+        lora_model.loras[module_name] = PackedLoRALayerWeights(
+            module_name=module_name,
+            rank=weights.rank,
+            lora_alphas=[weights.lora_alpha, weights.lora_alpha, weights.lora_alpha],
+            lora_a=[weights.lora_a, weights.lora_a, weights.lora_a],
+            lora_b=[q_b.contiguous(), k_b.contiguous(), v_b.contiguous()],
+            scaling=[weights.scaling, weights.scaling, weights.scaling],
+        )
+
+
+def load_minimax_h3_native_lora(
+    *,
+    partition: str,
+    lora_request: LoRARequest,
+    lora_path: str | Path,
+    dtype: torch.dtype,
+    unsupported_offload_mode: str | None = None,
+) -> tuple[LoRAModel, PEFTHelper, DMD2SigmaSchedule] | None:
+    """Load a native-layout MiniMax-H3 distilled LoRA through the legacy manager."""
+
+    lora_file = _select_native_file(lora_path)
+    if lora_file is None:
+        return None
+    with safe_open(lora_file, framework="pt", device="cpu") as checkpoint:
+        metadata = checkpoint.metadata() or {}
+        if metadata.get("key_format") != _NATIVE_KEY_FORMAT:
+            if lora_file.name == _NATIVE_FILENAME:
+                raise ValueError(
+                    f"MiniMax-H3 native LoRA requires safetensors metadata key_format={_NATIVE_KEY_FORMAT!r}"
+                )
+            return None
+        if lora_file.name != _NATIVE_FILENAME:
+            raise ValueError(f"MiniMax-H3 native LoRA supports only {_NATIVE_FILENAME!r}, got {lora_file.name!r}")
+        sigma_schedule = _validate_native_metadata(metadata)
+        if partition == "ref2va":
+            raise ValueError("MiniMax-H3 native LoRA supports T2VA only")
+        if unsupported_offload_mode is not None:
+            raise ValueError(f"MiniMax-H3 native dynamic LoRA does not support {unsupported_offload_mode}")
+        tensors = _validate_native_tensors(checkpoint)
+
+    peft_helper = PEFTHelper.from_dict(
+        {
+            "r": _NATIVE_RANK,
+            "lora_alpha": _NATIVE_ALPHA,
+            "target_modules": _NATIVE_TARGET_PATTERN,
+        }
+    )
+    lora_model = LoRAModel.from_lora_tensors(
+        lora_model_id=lora_request.lora_int_id,
+        tensors=tensors,
+        peft_helper=peft_helper,
+        device="cpu",
+        dtype=dtype,
+        weights_mapper=_NATIVE_WEIGHTS_MAPPER,
+    )
+    _pack_h3_native_qkv(lora_model)
+    _pack_h3_native_fc1(lora_model)
+    return lora_model, peft_helper, sigma_schedule

--- a/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
+++ b/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
@@ -81,7 +81,7 @@ from .denoise_loop import (
     minimax_h3_publish_denoise_progress,
 )
 from .encoder import MiniMaxH3Qwen3VLEncoder
-from .lora import load_minimax_h3_turbo_lora
+from .lora import load_minimax_h3_native_lora, load_minimax_h3_turbo_lora
 from .minimax_h3_transformer import (
     MiniMaxH3Attention,
     MiniMaxH3DiTModel,
@@ -717,6 +717,8 @@ class MiniMaxH3Pipeline(
         # A cache eviction may be followed by a different adapter reusing the
         # same client-supplied ID. Every real load replaces the classification.
         self._turbo_lora_adapter_ids.discard(lora_request.lora_int_id)
+        self._native_lora_adapter_ids.discard(lora_request.lora_int_id)
+        self._lora_sigma_schedules.pop(lora_request.lora_int_id, None)
         od_config = getattr(self, "od_config", None)
         offload_modes = []
         if getattr(od_config, "enable_cpu_offload", False):
@@ -734,7 +736,21 @@ class MiniMaxH3Pipeline(
         )
         if loaded is not None:
             self._turbo_lora_adapter_ids.add(lora_request.lora_int_id)
-        return loaded
+            return loaded
+
+        native_loaded = load_minimax_h3_native_lora(
+            partition=self.partition,
+            lora_request=lora_request,
+            lora_path=lora_path,
+            dtype=dtype,
+            unsupported_offload_mode=" or ".join(offload_modes) or None,
+        )
+        if native_loaded is not None:
+            lora_model, peft_helper, sigma_schedule = native_loaded
+            self._native_lora_adapter_ids.add(lora_request.lora_int_id)
+            self._lora_sigma_schedules[lora_request.lora_int_id] = sigma_schedule
+            return lora_model, peft_helper
+        return None
 
     def _validate_diffusion_lora_binding(
         self,
@@ -742,12 +758,20 @@ class MiniMaxH3Pipeline(
         lora_model: LoRAModel,
         bound_lora_names: frozenset[str],
     ) -> None:
-        if lora_model.id not in self._turbo_lora_adapter_ids:
+        if lora_model.id in self._turbo_lora_adapter_ids:
+            missing = sorted(set(lora_model.loras) - bound_lora_names)
+            if missing:
+                raise ValueError(
+                    "MiniMax-H3 Turbo LoRA binding is incomplete: "
+                    f"bound={len(bound_lora_names)}/{len(lora_model.loras)}, missing={missing[:5]}"
+                )
+            return
+        if lora_model.id not in self._native_lora_adapter_ids:
             return
         missing = sorted(set(lora_model.loras) - bound_lora_names)
         if missing:
             raise ValueError(
-                "MiniMax-H3 Turbo LoRA binding is incomplete: "
+                "MiniMax-H3 native LoRA binding is incomplete: "
                 f"bound={len(bound_lora_names)}/{len(lora_model.loras)}, missing={missing[:5]}"
             )
 
@@ -758,6 +782,44 @@ class MiniMaxH3Pipeline(
             and not math.isclose(0.0, float(sampling.lora_scale))
             and lora_request.lora_int_id in self._turbo_lora_adapter_ids
         )
+
+    def _has_active_native_lora(self, sampling: Any) -> bool:
+        lora_request = sampling.lora_request
+        return (
+            lora_request is not None
+            and not math.isclose(0.0, float(sampling.lora_scale))
+            and lora_request.lora_int_id in self._native_lora_adapter_ids
+        )
+
+    def _validate_native_sampling(self, sampling: Any, *, task: str) -> None:
+        if task != "t2va":
+            raise OmniClientError("MiniMax-H3 native LoRA supports T2VA requests only")
+        sigma_steps = sampling.num_inference_steps
+        if sigma_steps == 5:
+            raise OmniClientError(
+                "MiniMax-H3 native LoRA uses the distilled interval-count contract; "
+                "num_inference_steps must be 4 or omitted, not 5"
+            )
+        if sigma_steps is not None and int(sigma_steps) != 4:
+            raise OmniClientError(
+                "MiniMax-H3 native LoRA requires num_inference_steps=4 (four denoiser evaluations) or omitted"
+            )
+
+    def _sigma_schedule_for_request(self, sampling: Any, task: str) -> DMD2SigmaSchedule | None:
+        lora_request = sampling.lora_request
+        if (
+            lora_request is not None
+            and not math.isclose(0.0, float(sampling.lora_scale))
+            and lora_request.lora_int_id in self._lora_sigma_schedules
+        ):
+            adapter_schedule = self._lora_sigma_schedules[lora_request.lora_int_id]
+            checkpoint_schedule = self._base_schedule_for_task(task)
+            if checkpoint_schedule is not None:
+                raise OmniClientError(
+                    "MiniMax-H3 native LoRA cannot be activated on a checkpoint that already pins base_schedule"
+                )
+            return adapter_schedule
+        return self._base_schedule_for_task(task)
 
     def _validate_turbo_sampling(self, sampling: Any) -> None:
         extra = sampling.extra_args or {}
@@ -812,6 +874,8 @@ class MiniMaxH3Pipeline(
             str(od_config.model),
         )
         self._turbo_lora_adapter_ids: set[int] = set()
+        self._native_lora_adapter_ids: set[int] = set()
+        self._lora_sigma_schedules: dict[int, DMD2SigmaSchedule] = {}
         model_root = _resolve_minimax_h3_model_root(
             str(od_config.model),
             od_config.revision,
@@ -1006,6 +1070,7 @@ class MiniMaxH3Pipeline(
         multi_modal_data: dict[str, Any],
         *,
         has_turbo_lora: bool = False,
+        has_native_lora: bool = False,
     ) -> str:
         if requested is None:
             # A Ref2VA-only startup has no FL2VA transformer; preserve its
@@ -1025,6 +1090,8 @@ class MiniMaxH3Pipeline(
             )
         if task == "ref2va" and has_turbo_lora:
             raise OmniClientError("MiniMax-H3 Turbo LoRA supports T2VA/FL2VA requests only")
+        if has_native_lora and task != "t2va":
+            raise OmniClientError("MiniMax-H3 native LoRA supports T2VA requests only")
         return task
 
     def _resolve_shape(
@@ -1978,13 +2045,17 @@ class MiniMaxH3Pipeline(
         logger.debug("MiniMax H3 request quality=%s", quality)
         extra = sampling.extra_args or {}
         has_turbo_lora = self._has_active_turbo_lora(sampling)
+        has_native_lora = self._has_active_native_lora(sampling)
         task = self._resolve_task(
             extra.get("task"),
             multi_modal_data,
             has_turbo_lora=has_turbo_lora,
+            has_native_lora=has_native_lora,
         )
         if has_turbo_lora:
             self._validate_turbo_sampling(sampling)
+        if has_native_lora:
+            self._validate_native_sampling(sampling, task=task)
 
         raw_image = multi_modal_data.get("image")
         raw_videos = multi_modal_data.get("video")
@@ -2179,7 +2250,7 @@ class MiniMaxH3Pipeline(
                     ref_audio_t = audio_lengths[0]
 
         seed = int(sampling.seed if sampling.seed is not None else 42)
-        sigma_schedule = self._base_schedule_for_task(task)
+        sigma_schedule = self._sigma_schedule_for_request(sampling, task)
         if sigma_schedule is None:
             base_schedule = None
             num_steps = int(sampling.num_inference_steps or 50)

--- a/vllm_omni/diffusion/sched/sigma_schedule.py
+++ b/vllm_omni/diffusion/sched/sigma_schedule.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from __future__ import annotations
 
@@ -9,6 +9,17 @@ from dataclasses import dataclass
 from typing import Any
 
 BASE_SCHEDULE_KEY = "base_schedule"
+
+
+def _coerce_schedule_positions(raw: Any) -> list[float]:
+    if isinstance(raw, str):
+        parts = [part.strip() for part in raw.split(",") if part.strip()]
+        if not parts:
+            raise ValueError("DMD2 base_schedule must not be empty")
+        return [float(part) for part in parts]
+    if isinstance(raw, Mapping):
+        raise ValueError("DMD2 base_schedule must be a sequence, not a mapping")
+    return [float(value) for value in raw]
 
 
 @dataclass(frozen=True)
@@ -62,7 +73,20 @@ class DMD2SigmaSchedule:
         raw = metadata.get(key)
         if raw is None:
             return None
-        return cls.from_positions(raw)
+        return cls.from_positions(_coerce_schedule_positions(raw))
+
+    @classmethod
+    def from_safetensors_metadata(
+        cls,
+        metadata: Mapping[str, str],
+        *,
+        key: str = BASE_SCHEDULE_KEY,
+    ) -> DMD2SigmaSchedule | None:
+        """Read a comma-separated schedule from safetensors string metadata."""
+        raw = metadata.get(key)
+        if raw is None:
+            return None
+        return cls.from_positions(_coerce_schedule_positions(raw))
 
     @property
     def num_inference_steps(self) -> int:


### PR DESCRIPTION
## Motivation and scope

MiniMax-H3 FlashGen ships a native-layout distilled LoRA trained on Ascend NPU.
Unlike LightX2V Turbo, it keeps fused `qkv_proj`, includes `adaln_proj.linear`,
uses rank 64, and declares a non-uniform rectified-flow schedule. PR #6476 added
Turbo support on the legacy `DiffusionLoRAManager`; this PR extends the same
model-owned loader hook with a second contract keyed by
`key_format=minimax-h3-native`.

This complements PR #5991: checkpoint-pinned `base_schedule` covers merged
releases, while adapter metadata covers runtime LoRA activation.

## Changes

- Add a native H3 LoRA loader beside the existing Turbo loader in
  `vllm_omni/diffusion/models/minimax_h3/lora.py`.
- Reorder fused `qkv_proj` LoRA rows with the existing
  `_reorder_grouped_qkv_to_qkv` helper, then emit model-owned
  `PackedLoRALayerWeights` for Q/K/V and gate/up slices.
- Parse adapter-declared `base_schedule` from safetensors metadata through
  `DMD2SigmaSchedule.from_safetensors_metadata`.
- Extend `MiniMaxH3Pipeline` with native adapter classification, schedule
  precedence, T2VA-only task validation, and interval-count request validation.
- Leave `DiffusionLoRAManager` unchanged.

The model-specific dynamic loader is parallel to the prefusion integrations
added by #2783. This PR does not add another prefusion path.

## Validation

- CPU tests in `tests/diffusion/models/minimax_h3/test_minimax_h3_native_lora.py`
  and `tests/diffusion/sched/test_dmd2_sigma_schedule.py`, including native
  offload fail-closed and DLO acceptance.
- Turbo regression suite remains unchanged.
- NPU validation script: `scripts/npu_validate_native_lora.sh`.
- NPU validation uses the published FlashGen v1.0 native artifact:
  <https://modelscope.cn/models/FlashGen/Minimax-H3-4step-lora-flashgen>

## T2VA demo

https://github.com/user-attachments/assets/721e3d14-2f71-4bea-babf-23bae821c91c

https://github.com/user-attachments/assets/f8c69032-441c-4432-9fb8-47388178c30a


https://github.com/user-attachments/assets/41a41760-a142-4084-9f92-b65c9c90c564


https://github.com/user-attachments/assets/838c4301-af19-4d0f-9f80-5e1c3193672b



## Known limitations

- Dynamic execution only; no prefusion.
- Only one LoRA active at a time.
- Formal support is limited to the published FlashGen v1.0 native artifact on T2VA.
- Rejects model-level CPU offload and standard layerwise offload. DLO is
  supported through the resident LoRA sidecars from #6550, which trades a fixed
  per-rank adapter footprint for request-switchable activation.
- Rejects activation on checkpoints that already pin `base_schedule`.
- Host Weight Runtime remains ineligible for deployments that set `lora_path`.

## Related work

- Issue #5700: MiniMax-H3 follow-up roadmap
- PR #6476: Turbo legacy LoRA loader (merged)
- PR #5991: checkpoint-pinned DMD2 schedules (merged)
- PR #6550: resident LoRA sidecars for DLO (merged); this PR builds on it
- PR #6544, #6565: watch for generic LoRA manager changes

