### PR TITLE
[CI][Diffusion] Add acceleration test groups for SD3 and Flux2

### DIFF
--- a/tests/model_tests/diffusion/diff_model_builders.py
+++ b/tests/model_tests/diffusion/diff_model_builders.py
@@ -129,6 +129,28 @@ def tiny_flux_kontext_builder() -> str:
     )
 
 
+def _shrink_sd3_transformer(config: dict) -> dict:
+    config["num_layers"] = 2
+    config["attention_head_dim"] = 32
+    config["num_attention_heads"] = 4
+    config["caption_projection_dim"] = 128
+    config["dual_attention_layers"] = [0]
+    return config
+
+
+def tiny_sd3_builder() -> str:
+    return build_tiny_from_configs(
+        "StableDiffusion3Pipeline",
+        "stabilityai/stable-diffusion-3.5-medium",
+        transform={
+            "text_encoder": _shrink_flux_clip_text_encoder,
+            "text_encoder_2": _shrink_flux_clip_text_encoder,
+            "text_encoder_3": _shrink_flux_t5_text_encoder,
+            "transformer": _shrink_sd3_transformer,
+        },
+    )
+
+
 def tiny_flux2_builder() -> str:
     def shrink_text_encoder(config: dict) -> dict:
         # The real checkpoint ships language_model.lm_head.weight as its own

--- a/tests/model_tests/diffusion/model_settings.py
+++ b/tests/model_tests/diffusion/model_settings.py
@@ -84,4 +84,9 @@ DIFFUSION_TEST_SETTINGS = {
         builder=diff_model_builders.tiny_qwen_image_edit_plus_builder,
         supported_tasks=[DiffusionTasks.IMAGE_TO_IMAGE],
     ),
+    "StableDiffusion3Pipeline": DiffusionModelTestOpts(
+        model="stabilityai/stable-diffusion-3.5-medium",
+        builder=diff_model_builders.tiny_sd3_builder,
+        supported_tasks=[DiffusionTasks.TEXT_TO_IMAGE],
+    ),
 }

--- a/tests/model_tests/diffusion/model_settings.py
+++ b/tests/model_tests/diffusion/model_settings.py
@@ -73,6 +73,11 @@ DIFFUSION_TEST_SETTINGS = {
         model="black-forest-labs/FLUX.2-dev",
         builder=diff_model_builders.tiny_flux2_builder,
         supported_tasks=[DiffusionTasks.TEXT_TO_IMAGE],
+        extra_test_groups=[
+            [DiffusionAccs.HSDP, DiffusionAccs.CACHE_DIT],
+            [DiffusionAccs.SEQUENCE_PARALLEL, DiffusionAccs.CACHE_DIT, DiffusionAccs.LAYERWISE_OFFLOAD],
+            [DiffusionAccs.CFG_PARALLEL, DiffusionAccs.TENSOR_PARALLEL, DiffusionAccs.CPU_OFFLOAD],
+        ],
     ),
     "QwenImageEditPipeline": DiffusionModelTestOpts(
         model="Qwen/Qwen-Image-Edit",
@@ -88,5 +93,9 @@ DIFFUSION_TEST_SETTINGS = {
         model="stabilityai/stable-diffusion-3.5-medium",
         builder=diff_model_builders.tiny_sd3_builder,
         supported_tasks=[DiffusionTasks.TEXT_TO_IMAGE],
+        extra_test_groups=[
+            [DiffusionAccs.CACHE_DIT, DiffusionAccs.LAYERWISE_OFFLOAD],
+            [DiffusionAccs.CFG_PARALLEL, DiffusionAccs.TENSOR_PARALLEL, DiffusionAccs.CPU_OFFLOAD],
+        ],
     ),
 }

--- a/tests/model_tests/diffusion/test_alignment.py
+++ b/tests/model_tests/diffusion/test_alignment.py
@@ -48,7 +48,6 @@ EXCLUDED_MODELS = [
     "MingImagePipeline",
     "InternVLAA1Pipeline",
     "LongCatImageEditPipeline",
-    "StableDiffusion3Pipeline",
     "HunyuanImage3ForCausalMM",
     "ErnieImagePipeline",
     "NextStep11Pipeline",


### PR DESCRIPTION
## Summary

- Add `extra_test_groups` to `StableDiffusion3Pipeline` to smoke-test Cache-DiT, Layerwise Offload, CFG Parallel, Tensor Parallel, and CPU Offload
- Add `extra_test_groups` to `Flux2Pipeline` to smoke-test all 7 accelerations (HSDP, Cache-DiT, Sequence Parallel, Layerwise Offload, CFG Parallel, Tensor Parallel, CPU Offload)

## Test Groups

**SD3** (2 groups):
- `[cache_dit, layerwise_offload]` — 1 GPU
- `[cfg_parallel, tensor_parallel, cpu_offload]` — 4 GPUs

**Flux2** (3 groups):
- `[hsdp, cache_dit]` — 2 GPUs
- `[sequence_parallel, cache_dit, layerwise_offload]` — 2 GPUs
- `[cfg_parallel, tensor_parallel, cpu_offload]` — 4 GPUs

## Test Plan

```bash
pytest tests/model_tests/diffusion/test_alignment.py -v
pytest tests/model_tests/diffusion/test_common_offline.py -k "StableDiffusion3Pipeline" -v
pytest tests/model_tests/diffusion/test_common_offline.py -k "Flux2Pipeline" -v
```

All tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)