### PR TITLE
[Diffusion] Release streaming video on the media timeline

### DIFF
--- a/tests/diffusion/test_media_time_pacer.py
+++ b/tests/diffusion/test_media_time_pacer.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the media-time release schedule.
+
+Every case drives an injected clock, so nothing here sleeps and nothing depends
+on how fast the test machine is.
+"""
+
+import pytest
+
+from vllm_omni.diffusion.media_time_pacer import MediaTimePacer
+
+FPS = 16.0
+CHUNK = 12  # frames, i.e. 0.75 s of media
+CHUNK_SECONDS = CHUNK / FPS
+
+
+class FakeClock:
+    """Monotonic clock the test moves by hand."""
+
+    def __init__(self, now: float = 1000.0) -> None:
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def test_rejects_a_nonsense_configuration():
+    with pytest.raises(ValueError):
+        MediaTimePacer(0)
+    with pytest.raises(ValueError):
+        MediaTimePacer(FPS, lead_seconds=-1.0)
+    with pytest.raises(ValueError):
+        MediaTimePacer(FPS, max_lag_seconds=-1.0)
+    with pytest.raises(ValueError):
+        MediaTimePacer(FPS).delay_before_release(-1)
+
+
+def test_the_first_chunk_is_never_held():
+    # The viewer's clock starts when the viewer gets something to watch. Holding
+    # the opening chunk would add latency to the one place a user can see it.
+    clock = FakeClock()
+    pacer = MediaTimePacer(FPS, clock=clock)
+    assert pacer.delay_before_release(CHUNK) == 0.0
+
+
+def test_generation_faster_than_real_time_is_held_to_the_schedule():
+    clock = FakeClock()
+    pacer = MediaTimePacer(FPS, clock=clock)
+    pacer.delay_before_release(CHUNK)
+
+    # Produced in a quarter of the time it takes to watch.
+    clock.advance(CHUNK_SECONDS / 4)
+    delay = pacer.delay_before_release(CHUNK)
+    assert delay == pytest.approx(CHUNK_SECONDS * 3 / 4)
+
+    # Honouring the delay puts the next deadline exactly one chunk later.
+    clock.advance(delay + CHUNK_SECONDS / 4)
+    assert pacer.delay_before_release(CHUNK) == pytest.approx(CHUNK_SECONDS * 3 / 4)
+
+
+def test_generation_slower_than_real_time_is_never_delayed():
+    # A session already missing its deadlines must not be slowed further; the
+    # pacer has to cost nothing in the case that needs the time most.
+    clock = FakeClock()
+    pacer = MediaTimePacer(FPS, clock=clock)
+    pacer.delay_before_release(CHUNK)
+    for _ in range(10):
+        clock.advance(CHUNK_SECONDS * 3)
+        assert pacer.delay_before_release(CHUNK) == 0.0
+
+
+def test_lead_releases_early_by_exactly_the_lead():
+    clock = FakeClock()
+    lead = 0.25
+    pacer = MediaTimePacer(FPS, lead_seconds=lead, clock=clock)
+    pacer.delay_before_release(CHUNK)
+    assert pacer.delay_before_release(CHUNK) == pytest.approx(CHUNK_SECONDS - lead)
+
+
+def test_the_schedule_does_not_drift_over_a_long_session():
+    # Deadlines are absolute against one origin rather than accumulated per
+    # chunk, so per-chunk rounding cannot pile up.
+    clock = FakeClock()
+    pacer = MediaTimePacer(FPS, clock=clock)
+    origin = clock.now
+    pacer.delay_before_release(CHUNK)
+    for index in range(1, 400):
+        clock.advance(0.01)
+        delay = pacer.delay_before_release(CHUNK)
+        clock.advance(delay)
+        assert clock.now == pytest.approx(origin + index * CHUNK_SECONDS)
+    assert pacer.released_frames == 400 * CHUNK
+
+
+def test_a_stall_is_written_off_rather_than_repaid_as_a_burst():
+    # The behaviour this guard exists for: after a long stall a fixed origin
+    # leaves every later deadline in the past, so the session would dump its
+    # backlog at full speed -- exactly the run-ahead the pacer prevents.
+    clock = FakeClock()
+    pacer = MediaTimePacer(FPS, max_lag_seconds=1.0, clock=clock)
+    pacer.delay_before_release(CHUNK)
+
+    clock.advance(30.0)  # a stall far beyond the allowance
+    assert pacer.delay_before_release(CHUNK) == 0.0
+    assert pacer.rebases == 1
+
+    # Back on schedule immediately, not after catching up 30 s of debt.
+    clock.advance(CHUNK_SECONDS / 4)
+    assert pacer.delay_before_release(CHUNK) == pytest.approx(CHUNK_SECONDS * 3 / 4)
+
+
+def test_without_a_lag_allowance_the_debt_is_kept():
+    # The opposite policy, for a caller that wants catch-up: the origin never
+    # moves, so the session runs flat out until it is level with the schedule.
+    clock = FakeClock()
+    pacer = MediaTimePacer(FPS, max_lag_seconds=None, clock=clock)
+    pacer.delay_before_release(CHUNK)
+
+    clock.advance(30.0)
+    for _ in range(20):
+        assert pacer.delay_before_release(CHUNK) == 0.0
+    assert pacer.rebases == 0
+
+
+def test_accounting_is_independent_of_whether_the_caller_waits():
+    # A caller that drops a chunk or ignores the delay still gets a correct
+    # schedule afterwards, because frames are counted at call time.
+    clock = FakeClock()
+    honoured = MediaTimePacer(FPS, clock=clock)
+    honoured.delay_before_release(CHUNK)
+    honoured.delay_before_release(CHUNK)
+    assert honoured.released_frames == 2 * CHUNK
+    assert honoured.released_media_seconds == pytest.approx(2 * CHUNK_SECONDS)
+
+
+def test_variable_chunk_sizes_follow_the_frames_not_the_chunks():
+    # The opening chunk of a causal video model is shorter than the rest, so a
+    # per-chunk schedule would be wrong from the first tick onwards.
+    clock = FakeClock()
+    pacer = MediaTimePacer(FPS, clock=clock)
+    pacer.delay_before_release(9)  # opening chunk
+    assert pacer.delay_before_release(CHUNK) == pytest.approx(9 / FPS)
+    assert pacer.released_frames == 9 + CHUNK

--- a/tests/entrypoints/openai_api/test_serving_video_output_stream.py
+++ b/tests/entrypoints/openai_api/test_serving_video_output_stream.py
@@ -7,12 +7,13 @@ from __future__ import annotations
 import asyncio
 import json
 from collections.abc import AsyncGenerator, Callable
+from http import HTTPStatus
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
-from fastapi import FastAPI, WebSocket
+from fastapi import FastAPI, HTTPException, WebSocket
 from pytest_mock import MockerFixture
 from starlette.testclient import TestClient
 
@@ -953,3 +954,51 @@ class TestStreamingVideoOutputPromptUpdate:
                 "transition_chunks": 2,
             },
         )
+
+
+class TestMediaTimePacing:
+    """`_build_pacer` decides whether a session runs on a release schedule."""
+
+    @staticmethod
+    def _request(**extra_params) -> VideoGenerationRequest:
+        return VideoGenerationRequest(
+            prompt="a person walking forward through a sunlit forest path",
+            extra_params=extra_params or None,
+        )
+
+    def test_sending_as_produced_is_the_default(self):
+        # Pacing changes when an existing client receives its bytes, so it is a
+        # decision the caller makes rather than something a version bump does.
+        assert OmniStreamingVideoOutputHandler._build_pacer(self._request(), 16.0) is None
+        assert OmniStreamingVideoOutputHandler._build_pacer(self._request(pace_to_media_time=False), 16.0) is None
+
+    def test_pacing_uses_the_stream_frame_rate(self):
+        pacer = OmniStreamingVideoOutputHandler._build_pacer(self._request(pace_to_media_time=True), 16.0)
+        assert pacer is not None
+        pacer.delay_before_release(16)
+        assert pacer.released_media_seconds == pytest.approx(1.0)
+
+    def test_lead_and_lag_come_from_the_request(self):
+        pacer = OmniStreamingVideoOutputHandler._build_pacer(
+            self._request(pace_to_media_time=True, pacing_lead_seconds=0.5, pacing_max_lag_seconds=None),
+            16.0,
+        )
+        assert pacer is not None
+        assert pacer._lead_seconds == pytest.approx(0.5)
+        assert pacer._max_lag_seconds is None
+
+    def test_a_bad_pacing_parameter_is_a_client_error(self):
+        # Not a 500: the value came from the request body.
+        with pytest.raises(HTTPException) as raised:
+            OmniStreamingVideoOutputHandler._build_pacer(
+                self._request(pace_to_media_time=True, pacing_lead_seconds="soon"),
+                16.0,
+            )
+        assert raised.value.status_code == HTTPStatus.BAD_REQUEST.value
+
+    def test_a_negative_lead_is_refused_rather_than_silently_clamped(self):
+        with pytest.raises(HTTPException):
+            OmniStreamingVideoOutputHandler._build_pacer(
+                self._request(pace_to_media_time=True, pacing_lead_seconds=-1.0),
+                16.0,
+            )

--- a/vllm_omni/diffusion/media_time_pacer.py
+++ b/vllm_omni/diffusion/media_time_pacer.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Release generated media on the timeline a viewer plays it at.
+
+A streaming diffusion session produces video in chunks and, today, hands each
+chunk on the moment it is finished. For an offline render that is right. For an
+*interactive* session it is not, because generation and playback then run on
+different clocks and drift apart.
+
+Say a chunk is 12 frames at 16 fps -- 0.75 s of video -- and generation runs at
+twice real time::
+
+    wall 0.0s -> chunk 1 produced, covering video 0.00-0.75s
+    wall 0.4s -> chunk 2 produced, covering video 0.75-1.50s
+    wall 4.0s -> generation has reached video second 10
+
+The viewer is watching second 4 while the generator is at second 10. A control
+input that arrives now has no good home: applied at second 10 it appears to do
+nothing for six seconds, and applied at second 4 it invalidates six seconds of
+finished work. The gap itself is the bug, so the fix is to not open it.
+
+This class computes how long to hold a chunk so that it leaves at the moment its
+first frame is due to play. Generation faster than real time waits; generation
+slower than real time is never delayed, so the pacer costs nothing on a session
+that is already struggling to keep up.
+
+It deliberately does not implement consumer backlog or admission signalling.
+Those are a separate policy with their own protocol surface, and a release
+schedule is useful without them.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+
+__all__ = ["MediaTimePacer"]
+
+
+class MediaTimePacer:
+    """Media-time release schedule for one streaming session.
+
+    Args:
+        fps: Frame rate the produced media is meant to play at. Must be positive.
+        lead_seconds: How far *ahead* of the play-out deadline a chunk may be
+            released. Zero schedules every chunk just-in-time: it leaves exactly
+            when its first frame is due, so the consumer's buffer runs down to
+            nothing between arrivals and any jitter on the link shows up as an
+            underrun. A client with its own jitter buffer is fine with that;
+            otherwise set this to a chunk or two of media duration and the
+            server keeps that much slack in hand.
+        max_lag_seconds: How far behind schedule the session may fall before the
+            schedule is re-based on the present. Without this, a session that
+            stalls builds up a debt against a fixed origin and then releases
+            everything it owes back to back once it recovers -- a burst, which
+            is the behaviour the pacer exists to prevent. ``None`` disables
+            re-basing and keeps the original origin forever.
+        clock: Monotonic time source, injectable for tests.
+
+    The pacer is not thread-safe and is not shared between sessions: it holds one
+    session's origin.
+    """
+
+    def __init__(
+        self,
+        fps: float,
+        *,
+        lead_seconds: float = 0.0,
+        max_lag_seconds: float | None = 5.0,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if not fps > 0:
+            raise ValueError(f"fps must be positive, got {fps!r}")
+        if lead_seconds < 0:
+            raise ValueError(f"lead_seconds must not be negative, got {lead_seconds!r}")
+        if max_lag_seconds is not None and max_lag_seconds < 0:
+            raise ValueError(f"max_lag_seconds must not be negative, got {max_lag_seconds!r}")
+        self._fps = float(fps)
+        self._lead_seconds = float(lead_seconds)
+        self._max_lag_seconds = max_lag_seconds
+        self._clock = clock
+        self._origin: float | None = None
+        self._released_frames = 0
+        self._rebases = 0
+
+    @property
+    def released_frames(self) -> int:
+        """Frames handed out so far, including the chunk of the last call."""
+        return self._released_frames
+
+    @property
+    def released_media_seconds(self) -> float:
+        """Media duration handed out so far."""
+        return self._released_frames / self._fps
+
+    @property
+    def rebases(self) -> int:
+        """How often the schedule has been re-based after falling behind."""
+        return self._rebases
+
+    def delay_before_release(self, num_frames: int) -> float:
+        """Seconds to wait before releasing a chunk of ``num_frames`` frames.
+
+        Call once per chunk, immediately before sending it, and sleep for the
+        returned duration. The frames are accounted at call time whether or not
+        the caller honours the delay, so a caller that chooses to skip the wait
+        still gets a correct schedule for the chunks after it.
+        """
+        if num_frames < 0:
+            raise ValueError(f"num_frames must not be negative, got {num_frames!r}")
+        now = self._clock()
+
+        # The viewer's clock starts when the viewer gets something to watch, not
+        # when generation was requested: the first chunk is never held back.
+        if self._origin is None:
+            self._origin = now
+            self._released_frames = num_frames
+            return 0.0
+
+        due_at = self._origin + self.released_media_seconds - self._lead_seconds
+        self._released_frames += num_frames
+
+        delay = due_at - now
+        if delay >= 0.0:
+            return delay
+        if self._max_lag_seconds is not None and -delay > self._max_lag_seconds:
+            # Behind by more than the allowance. Move the origin so "now" is
+            # exactly on schedule; the debt is written off rather than repaid in
+            # a burst.
+            self._origin = now - self.released_media_seconds + num_frames / self._fps + self._lead_seconds
+            self._rebases += 1
+        return 0.0

--- a/vllm_omni/entrypoints/openai/serving_video_output_stream.py
+++ b/vllm_omni/entrypoints/openai/serving_video_output_stream.py
@@ -44,6 +44,7 @@ from PIL import Image
 from pydantic import ValidationError
 from vllm.logger import init_logger
 
+from vllm_omni.diffusion.media_time_pacer import MediaTimePacer
 from vllm_omni.entrypoints.async_omni import AsyncOmni
 from vllm_omni.entrypoints.openai.errors import InvalidInputReferenceError
 from vllm_omni.entrypoints.openai.protocol.videos import VideoGenerationRequest, VideoParams
@@ -67,6 +68,10 @@ from vllm_omni.outputs import OmniRequestOutput
 from vllm_omni.outputs.output_metadata import DiffusionPayloadValue
 
 logger = init_logger(__name__)
+
+_PACING_PARAM = "pace_to_media_time"
+_PACING_LEAD_PARAM = "pacing_lead_seconds"
+_PACING_MAX_LAG_PARAM = "pacing_max_lag_seconds"
 
 _DEFAULT_STALL_TIMEOUT = 60.0
 _DEFAULT_START_TIMEOUT = 10.0
@@ -471,6 +476,7 @@ class OmniStreamingVideoOutputHandler:
             fps=output_fps,
             video_codec_options=video_codec_options,
         )
+        pacer = self._build_pacer(request, output_fps)
         completed = False
         try:
             async for result in self._iter_generation_outputs(prompt, gen_params, request_id, progress):
@@ -480,13 +486,22 @@ class OmniStreamingVideoOutputHandler:
                 for video in videos:
                     chunk = encoder.encode(video)
                     if chunk:
+                        num_frames = self._num_video_frames(video)
+                        if pacer is not None:
+                            # Held here rather than in handle_session so the
+                            # trailer, which carries no media time, is never
+                            # paced, and so the wait happens before the encoded
+                            # bytes are handed to the transport.
+                            delay = pacer.delay_before_release(num_frames)
+                            if delay > 0:
+                                await asyncio.sleep(delay)
                         yield (
                             chunk,
                             self._build_chunk_metadata(
                                 request_id=request_id,
                                 kind="media",
                                 byte_length=len(chunk),
-                                num_frames=self._num_video_frames(video),
+                                num_frames=num_frames,
                                 stream_metadata=self._extract_stream_metadata(result),
                             ),
                         )
@@ -507,6 +522,28 @@ class OmniStreamingVideoOutputHandler:
         finally:
             if not completed:
                 encoder.close()
+
+    @staticmethod
+    def _build_pacer(request: VideoGenerationRequest, output_fps: float) -> MediaTimePacer | None:
+        """Build this session's release schedule, or ``None`` to send as produced.
+
+        Off unless asked for. Turning it on changes when an existing client
+        receives its bytes, which is the sort of thing that should be a decision
+        rather than an upgrade.
+        """
+        extra = request.extra_params if isinstance(request.extra_params, dict) else {}
+        if not extra.get(_PACING_PARAM):
+            return None
+        try:
+            lead = float(extra.get(_PACING_LEAD_PARAM, 0.0))
+            max_lag_raw = extra.get(_PACING_MAX_LAG_PARAM, 5.0)
+            max_lag = None if max_lag_raw is None else float(max_lag_raw)
+            return MediaTimePacer(output_fps, lead_seconds=lead, max_lag_seconds=max_lag)
+        except (TypeError, ValueError) as error:
+            raise HTTPException(
+                status_code=HTTPStatus.BAD_REQUEST.value,
+                detail=f"Invalid media-time pacing parameters: {error}",
+            ) from error
 
     async def _build_prompt_and_sampling_params(
         self,


### PR DESCRIPTION
## Why

A streaming session hands each chunk to the transport the moment it is finished. For an offline render that is right. For an **interactive** session it lets generation and playback drift onto different clocks.

A chunk of 12 frames at 16 fps is 0.75 s of video. At twice real time:

```
wall 0.0s -> chunk 1 produced, covering video 0.00-0.75s
wall 0.4s -> chunk 2 produced, covering video 0.75-1.50s
wall 4.0s -> generation has reached video second 10
```

The viewer is watching second 4 while the generator is at second 10. A control input arriving now has no good home: applied at second 10 it appears dead for six seconds, and applied at second 4 it invalidates six seconds of finished work. The gap itself is the bug, so this holds it shut.

Two things follow from the same schedule: a single session cannot run ahead into work a later input may invalidate, and on a shared device a session that races ahead stops taking time away from one that has a real deadline right now.

This is the piece agreed on in #6227 — a media-time release schedule first, with consumer backlog and admission left as a separate, optional policy.

## What

`MediaTimePacer` (`vllm_omni/diffusion/media_time_pacer.py`) computes how long to hold a chunk so it leaves when its first frame is due to play. Pure logic, injectable clock, no I/O.

- Faster than real time waits; **slower than real time is never delayed**, so a session already missing its deadlines pays nothing for this.
- **Accounted in frames, not chunks.** A causal video model's opening chunk is shorter than the rest, so a per-chunk schedule is wrong from the first tick.
- **Deadlines are absolute against one origin**, not accumulated per chunk, so per-chunk rounding cannot pile up over a long session.
- **A stall longer than an allowance re-bases the origin instead of being repaid as a burst.** Without this, a fixed origin leaves every later deadline in the past after a stall and the session dumps its backlog at full speed — precisely the run-ahead this exists to prevent. `pacing_max_lag_seconds: null` keeps the debt for a caller that wants catch-up.

Wired into `_stream_video_bytes` rather than `handle_session`, so the trailer — which carries no media time — is never paced, and the wait happens before the encoded bytes reach the transport.

## Scope held deliberately

- **No consumer backlog or admission signalling.** Separate policy, its own protocol surface, and a release schedule is useful without it.
- **`.generate()` is untouched.** No entrypoint becomes one-step-only.

## One decision I would rather not make alone

**Pacing is off by default here**, enabled per request with `extra_params.pace_to_media_time`.

The endpoint is named `realtime`, but I do not know whether anyone is currently using it as a fast bulk producer. If they are, turning pacing on by default means a 4-minute video takes at least 4 minutes of wall clock — a real behaviour change for them, not a bug fix.

My suggestion is to land the mechanism off and decide the default separately, because one PR adding a mechanism *and* changing an endpoint's contract is harder to review and harder to roll back than two. But the default is a question about who uses this endpoint, which you are better placed to answer than I am — happy to flip it in this PR if you would rather.

## Testing

```
tests/diffusion/test_media_time_pacer.py                          10 passed
tests/entrypoints/openai_api/test_serving_video_output_stream.py  27 passed
```

All CPU, no GPU. Every case drives an injected clock, so nothing sleeps and nothing depends on machine speed — the suite runs in 0.03 s.

Covered: the opening chunk is never held; faster-than-real-time is held to the schedule; slower-than-real-time is never delayed; lead releases early by exactly the lead; no drift over 400 chunks; a stall is written off rather than repaid as a burst; `max_lag_seconds=None` keeps the debt instead; variable chunk sizes follow frames; bad pacing parameters are a 400 rather than a 500.

## Related

- #6227 — the RFC this comes from
- #6294 — `InteractionCoordinator`; camera/action admission builds on that, and this does not depend on it
