### PR TITLE
[Benchmark][MiniCPM-o] Add Omni-DuplexEval generation

### DIFF
--- a/examples/online_serving/minicpmo/README_omni_duplex_eval.md
+++ b/examples/online_serving/minicpmo/README_omni_duplex_eval.md
@@ -1,0 +1,17 @@
+# Omni-DuplexEval
+
+This runner generates official-shaped response artifacts through the native
+MiniCPM-o duplex WebSocket. It does not change serving defaults or require the
+upstream benchmark checkout at runtime.
+
+```bash
+python examples/online_serving/minicpmo/run_omni_duplex_eval.py generate \
+  --url ws://127.0.0.1:8099/v1/realtime?duplex=1 \
+  --model /models/MiniCPM-o-4_5 --ref-audio /data/ref.wav \
+  --dataset Hothan/Omni-DuplexEval --family all \
+  --response-root /data/duplex/responses
+
+```
+
+`--pace as-fast-as-possible` writes `clock=invalid`. Use `--limit 1` for a
+smoke test. Evaluation and summarization are added by the follow-up scoring PR.

--- a/examples/online_serving/minicpmo/run_omni_duplex_eval.py
+++ b/examples/online_serving/minicpmo/run_omni_duplex_eval.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Generate Omni-DuplexEval response artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from vllm_omni.benchmarks.duplex.omni_duplex_eval_dataset import (  # noqa: E402
+    DEFAULT_DATASET,
+    load_samples,
+)
+from vllm_omni.benchmarks.duplex.omni_duplex_eval_runner import generate_sample  # noqa: E402
+
+
+def _common(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--dataset", default=DEFAULT_DATASET)
+    parser.add_argument("--split", default="all")
+    parser.add_argument("--family", choices=["all", "rtd", "pr"], default="all")
+    parser.add_argument("--media-root")
+    parser.add_argument("--limit", type=int)
+    parser.add_argument("--ids", nargs="*")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    generate = sub.add_parser("generate")
+    _common(generate)
+    generate.add_argument("--url", default="ws://localhost:8099/v1/realtime?duplex=1")
+    generate.add_argument("--model", required=True)
+    generate.add_argument("--ref-audio", required=True)
+    generate.add_argument("--response-root", required=True)
+    generate.add_argument("--fps", type=float, default=1.0)
+    generate.add_argument("--mix", default="question")
+    generate.add_argument("--pace", default="realtime")
+    generate.add_argument("--clock", default="media")
+    generate.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+    samples = load_samples(
+        args.dataset, split=args.split, family=args.family, media_root=args.media_root, limit=args.limit, ids=args.ids
+    )
+    if args.command == "generate":
+
+        async def run() -> None:
+            for sample in samples:
+                await generate_sample(
+                    sample,
+                    url=args.url,
+                    model=args.model,
+                    ref_audio=args.ref_audio,
+                    output_root=args.response_root,
+                    fps=args.fps,
+                    mix=args.mix,
+                    pace=args.pace,
+                    clock=args.clock,
+                    overwrite=args.overwrite,
+                )
+
+        asyncio.run(run())
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmarks/duplex/test_omni_duplex_eval.py
+++ b/tests/benchmarks/duplex/test_omni_duplex_eval.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vllm_omni.benchmarks.duplex.omni_duplex_eval_clock import normalize_response_items, split_text, validate_clock
+from vllm_omni.benchmarks.duplex.omni_duplex_eval_dataset import (
+    canonical_task_type,
+    family_for_split,
+    load_samples,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_dataset_mapping_and_manifest(tmp_path):
+    manifest = tmp_path / "samples.json"
+    manifest.write_text(json.dumps([{"id": "a", "split": "RTD_OCR", "video": "clip.mp4"}]), encoding="utf-8")
+    sample = load_samples(manifest, media_root=tmp_path)[0]
+    assert sample.family == "rtd"
+    assert sample.video == str(tmp_path / "clip.mp4")
+    assert family_for_split("PR_event_reminder") == "pr"
+    assert canonical_task_type("post-event-reminder") == "post_event_reminder"
+
+
+def test_response_aliases_and_clock_guard():
+    assert split_text("One. Two!") == ["One.", "Two!"]
+    assert normalize_response_items({"chunks": [{"text": "x", "current_time": 1}]}) == [
+        {"sentence": "x", "start": 1.0, "end": 1.0}
+    ]
+    with pytest.raises(ValueError, match="clock=invalid"):
+        validate_clock({"clock": "invalid"})
+    validate_clock({"clock": "invalid"}, allow_invalid=True)

--- a/vllm_omni/benchmarks/duplex/__init__.py
+++ b/vllm_omni/benchmarks/duplex/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""CPU-friendly Omni-DuplexEval generation helpers."""
+
+from .omni_duplex_eval_dataset import DuplexSample, load_samples
+
+__all__ = ["DuplexSample", "load_samples"]

--- a/vllm_omni/benchmarks/duplex/omni_duplex_eval_clock.py
+++ b/vllm_omni/benchmarks/duplex/omni_duplex_eval_clock.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""Media-clock sentence extraction and response JSON normalization."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+import regex as re
+
+_TERMINAL = re.compile(r"(.+?[.!?。！？]+)(?:\s+|$)", re.S)
+
+
+@dataclass
+class TimedSentence:
+    sentence: str
+    start: float
+    end: float
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"sentence": self.sentence, "start": round(self.start, 3), "end": round(self.end, 3)}
+
+
+def split_text(text: str) -> list[str]:
+    text = str(text or "").strip()
+    if not text:
+        return []
+    parts: list[str] = []
+    position = 0
+    for match in _TERMINAL.finditer(text):
+        parts.append(match.group(1).strip())
+        position = match.end()
+    tail = text[position:].strip()
+    if tail:
+        parts.append(tail)
+    return [part for part in parts if part]
+
+
+def extract_timed_sentences(events: Iterable[dict[str, Any]], *, clock: str = "media") -> list[TimedSentence]:
+    """Split output deltas while anchoring text to input ``audio_end_ms``."""
+    sentences: list[TimedSentence] = []
+    pending = ""
+    start: float | None = None
+    last: float | None = None
+    for event in events:
+        event_type = event.get("type")
+        if event_type not in {"response.output_text.delta", "response.audio_transcript.delta", "response.text.delta"}:
+            continue
+        delta = event.get("delta")
+        if not isinstance(delta, str) or not delta.strip():
+            continue
+        timestamp = event.get("audio_end_ms")
+        if timestamp is None:
+            timestamp = event.get("_media_clock_ms", event.get("current_time_ms", 0.0))
+        try:
+            now = float(timestamp) / 1000.0 if float(timestamp) > 1000 else float(timestamp)
+        except (TypeError, ValueError):
+            now = last or 0.0
+        pending += delta
+        start = now if start is None else start
+        last = now
+        pieces = split_text(pending)
+        complete = pieces if pieces and re.search(r"[.!?。！？]$", pending.strip()) else pieces[:-1]
+        if complete:
+            for piece in complete:
+                sentences.append(TimedSentence(piece, start, max(start, now)))
+            consumed = " ".join(complete)
+            pending = pending[len(consumed) :].strip()
+            start = now if pending else None
+    if pending.strip():
+        sentences.append(TimedSentence(pending.strip(), start or last or 0.0, last or start or 0.0))
+    return sentences
+
+
+def normalize_response_items(raw: Any) -> list[dict[str, Any]]:
+    if isinstance(raw, dict):
+        items = raw.get("sentences", raw.get("chunks"))
+    else:
+        items = raw
+    if not isinstance(items, list):
+        raise ValueError("response JSON must be a list or contain sentences/chunks")
+    normalized = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        text = item.get("sentence", item.get("text", item.get("content", "")))
+        if not isinstance(text, str) or not text.strip():
+            continue
+        try:
+            start = float(item.get("start", item.get("current_time", item.get("time", 0.0))) or 0.0)
+            end = float(item.get("end", item.get("current_time", item.get("time", start))) or start)
+        except (TypeError, ValueError):
+            continue
+        normalized.append({"sentence": text.strip(), "start": start, "end": max(start, end)})
+    return normalized
+
+
+def validate_clock(meta: dict[str, Any], *, allow_invalid: bool = False) -> None:
+    if meta.get("clock") == "invalid" and not allow_invalid:
+        raise ValueError("generate artifact has clock=invalid; pass --allow-invalid-clock to score it")

--- a/vllm_omni/benchmarks/duplex/omni_duplex_eval_dataset.py
+++ b/vllm_omni/benchmarks/duplex/omni_duplex_eval_dataset.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""Dataset and split normalization for Omni-DuplexEval.
+
+The loader accepts a Hugging Face dataset id, a JSON/JSONL manifest, or an
+already materialized iterable.  Media is deliberately resolved at use time so
+the benchmark remains usable in air-gapped environments.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_DATASET = "Hothan/Omni-DuplexEval"
+RTD_SPLITS = frozenset(
+    {
+        "RTD_world_knowledge",
+        "RTD_counting",
+        "RTD_fine_grained_movement",
+        "RTD_interaction_relation",
+        "RTD_OCR",
+        "RTD_Omni",
+    }
+)
+PR_SPLITS = frozenset({"PR_correction", "PR_event_reminder", "PR_post_event_reminder"})
+_TASK_ALIASES = {
+    "correction": "correction",
+    "pr_correction": "correction",
+    "event_reminder": "proactive_reminder",
+    "pr_event_reminder": "proactive_reminder",
+    "proactive_reminder": "proactive_reminder",
+    "post_event_reminder": "post_event_reminder",
+    "pr_post_event_reminder": "post_event_reminder",
+}
+
+
+def canonical_task_type(value: str) -> str:
+    key = str(value).strip().lower().replace("-", "_").replace(" ", "_")
+    if key not in _TASK_ALIASES:
+        raise ValueError(f"unsupported Omni-DuplexEval task type: {value!r}")
+    return _TASK_ALIASES[key]
+
+
+def family_for_split(split: str, task_type: str | None = None) -> str:
+    if split in RTD_SPLITS or str(split).upper().startswith("RTD"):
+        return "rtd"
+    if split in PR_SPLITS or str(split).upper().startswith("PR"):
+        return "pr"
+    if task_type:
+        return "rtd" if str(task_type).lower().startswith("rtd") else "pr"
+    raise ValueError(f"cannot infer benchmark family from split {split!r}")
+
+
+def _value(row: dict[str, Any], *keys: str, default: Any = None) -> Any:
+    for key in keys:
+        if key in row and row[key] is not None:
+            return row[key]
+    return default
+
+
+def _float(value: Any, default: float | None = None) -> float | None:
+    try:
+        return None if value is None else float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+@dataclass(frozen=True)
+class DuplexSample:
+    id: str
+    split: str
+    family: str
+    task_type: str | None
+    video: Any
+    question_audio: Any = None
+    question_text: str = ""
+    answer1: str = ""
+    answer2: str = ""
+    reminder1: Any = None
+    reminder2: Any = None
+    video_duration: float | None = None
+    video_type: str = ""
+    raw: dict[str, Any] | None = None
+
+    @classmethod
+    def from_row(cls, row: dict[str, Any], *, split: str | None = None, media_root: Path | None = None) -> DuplexSample:
+        chosen_split = str(split or _value(row, "split", "subset", "config", default=""))
+        task_value = _value(row, "task_type", "task", "type")
+        family = str(_value(row, "family", default="") or family_for_split(chosen_split, task_value))
+        task = None
+        if family == "pr" and task_value:
+            task = canonical_task_type(str(task_value))
+        sample_id = str(_value(row, "id", "sample_id", "uid", "name", default=""))
+        video = _value(row, "video", "video_path", "video_file")
+        audio = _value(row, "question_audio", "audio", "question_wav")
+        if media_root:
+
+            def resolve(value: Any) -> Any:
+                if not isinstance(value, str):
+                    return value
+                candidate = Path(value).expanduser()
+                return str(candidate if candidate.is_absolute() else media_root / candidate)
+
+            video, audio = resolve(video), resolve(audio)
+        return cls(
+            id=sample_id,
+            split=chosen_split,
+            family=family,
+            task_type=task,
+            video=video,
+            question_audio=audio,
+            question_text=str(_value(row, "question_text", "question", "instruction", default="") or ""),
+            answer1=str(_value(row, "answer1", "answer", "ground_answer", default="") or ""),
+            answer2=str(_value(row, "answer2", default="") or ""),
+            reminder1=_value(row, "reminder1", "reminder_1"),
+            reminder2=_value(row, "reminder2", "reminder_2"),
+            video_duration=_float(_value(row, "video_duration", "duration")),
+            video_type=str(_value(row, "video_type", default="") or ""),
+            raw=dict(row),
+        )
+
+
+def _read_manifest(path: Path) -> list[dict[str, Any]]:
+    if path.suffix.lower() == ".jsonl":
+        return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, dict):
+        payload = payload.get("data", payload.get("samples", [payload]))
+    if not isinstance(payload, list):
+        raise ValueError("manifest must contain a JSON list")
+    return payload
+
+
+def load_samples(
+    dataset: str | Path | Iterable[dict[str, Any]] = DEFAULT_DATASET,
+    *,
+    split: str | None = None,
+    family: str = "all",
+    media_root: str | Path | None = None,
+    limit: int | None = None,
+    ids: Iterable[str] | None = None,
+) -> list[DuplexSample]:
+    if isinstance(dataset, (str, Path)) and Path(str(dataset)).exists():
+        rows = _read_manifest(Path(str(dataset)))
+    elif not isinstance(dataset, (str, Path)):
+        rows = list(dataset)
+    else:
+        try:
+            from datasets import load_dataset
+        except ImportError as exc:
+            raise RuntimeError("datasets is required for Hugging Face loading; use a local manifest instead") from exc
+        kwargs: dict[str, Any] = {}
+        if split and split != "all":
+            kwargs["split"] = split
+        loaded = load_dataset(str(dataset), **kwargs)
+        if isinstance(loaded, dict):
+            rows = []
+            for name, table in loaded.items():
+                rows.extend({**dict(row), "split": name} for row in table)
+        else:
+            rows = [dict(row) for row in loaded]
+    wanted = set(str(item) for item in ids) if ids else None
+    root = Path(media_root).expanduser() if media_root else None
+    result = []
+    for row in rows:
+        sample = DuplexSample.from_row(row, split=None if split in (None, "all") else split, media_root=root)
+        if split and split != "all" and sample.split != split:
+            continue
+        if family != "all" and sample.family != family:
+            continue
+        if wanted is not None and sample.id not in wanted:
+            continue
+        result.append(sample)
+    if limit is not None:
+        result = result[: max(0, limit)]
+    return result

--- a/vllm_omni/benchmarks/duplex/omni_duplex_eval_media.py
+++ b/vllm_omni/benchmarks/duplex/omni_duplex_eval_media.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""Small ffmpeg-backed media helpers used by the duplex runner and judge."""
+
+from __future__ import annotations
+
+import subprocess
+import wave
+from collections.abc import Iterator
+from pathlib import Path
+
+from vllm_omni.experimental.fullduplex.client import PCM16_BYTES_PER_SAMPLE, PCM16_SAMPLE_RATE
+
+
+def _run_ffmpeg(args: list[str]) -> bytes:
+    result = subprocess.run(["ffmpeg", "-hide_banner", "-loglevel", "error", *args], capture_output=True, check=True)
+    return result.stdout
+
+
+def video_duration(path: str | Path) -> float:
+    result = subprocess.run(
+        ["ffprobe", "-v", "error", "-show_entries", "format=duration", "-of", "default=nw=1:nk=1", str(path)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return max(0.0, float(result.stdout.strip()))
+
+
+def extract_jpeg(path: str | Path, *, timestamp: float, quality: int = 3) -> bytes:
+    return _run_ffmpeg(
+        [
+            "-ss",
+            f"{max(0.0, timestamp):.3f}",
+            "-i",
+            str(path),
+            "-frames:v",
+            "1",
+            "-q:v",
+            str(quality),
+            "-f",
+            "image2",
+            "pipe:1",
+        ]
+    )
+
+
+def iter_jpegs(
+    path: str | Path, *, fps: float = 1.0, duration: float | None = None, quality: int = 3
+) -> Iterator[tuple[float, bytes]]:
+    end = duration if duration is not None else video_duration(path)
+    step = 1.0 / fps
+    timestamp = 0.0
+    while timestamp < end:
+        try:
+            frame = extract_jpeg(path, timestamp=timestamp, quality=quality)
+        except (OSError, subprocess.CalledProcessError):
+            break
+        if frame:
+            yield timestamp, frame
+        timestamp += step
+
+
+def read_audio_pcm16(path: str | Path) -> bytes:
+    source = Path(path)
+    if source.suffix.lower() == ".wav":
+        with wave.open(str(source), "rb") as wav_file:
+            if (
+                wav_file.getnchannels() != 1
+                or wav_file.getsampwidth() != 2
+                or wav_file.getframerate() != PCM16_SAMPLE_RATE
+            ):
+                raise ValueError("question_audio WAV must be mono PCM16 at 16 kHz")
+            return wav_file.readframes(wav_file.getnframes())
+    return _run_ffmpeg(["-i", str(source), "-f", "s16le", "-ac", "1", "-ar", str(PCM16_SAMPLE_RATE), "pipe:1"])
+
+
+def iter_av_units(
+    audio_pcm16: bytes, frames: Iterator[tuple[float, bytes]], *, unit_ms: int = 1000
+) -> Iterator[tuple[bytes, bytes | None]]:
+    unit_bytes = PCM16_SAMPLE_RATE * PCM16_BYTES_PER_SAMPLE * unit_ms // 1000
+    frame_iter = iter(frames)
+    next_frame = next(frame_iter, None)
+    for offset in range(0, len(audio_pcm16), unit_bytes):
+        timestamp = offset / (PCM16_SAMPLE_RATE * PCM16_BYTES_PER_SAMPLE)
+        frame = None
+        if next_frame is not None and next_frame[0] <= timestamp + unit_ms / 1000:
+            frame = next_frame[1]
+            next_frame = next(frame_iter, None)
+        yield audio_pcm16[offset : offset + unit_bytes], frame

--- a/vllm_omni/benchmarks/duplex/omni_duplex_eval_runner.py
+++ b/vllm_omni/benchmarks/duplex/omni_duplex_eval_runner.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""Single-sample MiniCPM-o native-duplex generation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pybase64 as base64
+
+from vllm_omni.experimental.fullduplex.client import RealtimeDuplexClient, build_realtime_url
+
+from .omni_duplex_eval_clock import extract_timed_sentences
+from .omni_duplex_eval_media import iter_av_units, iter_jpegs, read_audio_pcm16, video_duration
+
+
+def _ref_audio(path: str | Path) -> str:
+    value = Path(path).expanduser().read_bytes()
+    return "data:audio/wav;base64," + base64.b64encode(value).decode("ascii")
+
+
+async def generate_sample(
+    sample: Any,
+    *,
+    url: str,
+    model: str,
+    ref_audio: str | Path,
+    output_root: str | Path,
+    fps: float = 1.0,
+    mix: str = "question",
+    pace: str = "realtime",
+    clock: str = "media",
+    overwrite: bool = False,
+    unit_ms: int = 1000,
+) -> Path:
+    output = Path(output_root) / sample.split / f"{sample.id}.json"
+    meta_path = output.with_name(output.stem + ".meta.json")
+    if output.exists() and not overwrite:
+        return output
+    if mix != "question":
+        raise NotImplementedError("v1 supports mix=question; soundtrack mixing is reserved for P1")
+    pcm = read_audio_pcm16(sample.question_audio)
+    duration = sample.video_duration or video_duration(sample.video)
+    frames = iter_jpegs(sample.video, fps=fps, duration=duration)
+    realtime = pace == "realtime"
+    if pace not in {"realtime", "as-fast-as-possible"}:
+        raise ValueError("pace must be realtime or as-fast-as-possible")
+    client = RealtimeDuplexClient(build_realtime_url(url, model, autostart=False))
+    async with client:
+        await client.configure(model, ref_audio=_ref_audio(ref_audio), instructions="Streaming Omni Conversation.")
+        await client.stream_av_units(iter_av_units(pcm, frames, unit_ms=unit_ms), realtime=realtime)
+        await client.commit()
+        # Give the server a bounded drain period; close_session waits for a clean ack.
+        try:
+            await client.close_session(timeout_s=max(20.0, duration + 20.0))
+        except TimeoutError:
+            pass
+        events = list(client.events.events)
+    timed = [sentence.as_dict() for sentence in extract_timed_sentences(events, clock=clock)]
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(timed, ensure_ascii=False, indent=2), encoding="utf-8")
+    meta = {
+        "id": sample.id,
+        "split": sample.split,
+        "clock": clock if realtime else "invalid",
+        "pace": pace,
+        "mix": mix,
+        "fps": fps,
+        "unit_ms": unit_ms,
+        "model": model,
+        "ref_audio_sha256": hashlib.sha256(Path(ref_audio).read_bytes()).hexdigest(),
+    }
+    meta_path.write_text(json.dumps(meta, indent=2), encoding="utf-8")
+    return output

--- a/vllm_omni/experimental/fullduplex/client.py
+++ b/vllm_omni/experimental/fullduplex/client.py
@@ -435,6 +435,7 @@ class RealtimeDuplexClient:
         self.events = RealtimeEventCollector()
         self._ws: Any = None
         self._reader_task: asyncio.Task[None] | None = None
+        self._media_clock_ms = 0
 
     async def __aenter__(self) -> RealtimeDuplexClient:
         self._ws = await websockets.connect(
@@ -463,6 +464,7 @@ class RealtimeDuplexClient:
                     continue
                 event = json.loads(raw)
                 if isinstance(event, dict):
+                    event.setdefault("_media_clock_ms", self._media_clock_ms)
                     self.events.add(event)
         except ConnectionClosed:
             return
@@ -559,21 +561,36 @@ class RealtimeDuplexClient:
             PCM16_SAMPLE_RATE * PCM16_BYTES_PER_SAMPLE * chunk_ms // 1000,
             PCM16_BYTES_PER_SAMPLE,
         )
+        await self.stream_av_units(
+            ((pcm16[offset : offset + chunk_bytes], None) for offset in range(0, len(pcm16), chunk_bytes)),
+            realtime=realtime,
+        )
+
+    async def stream_av_units(
+        self,
+        units: Any,
+        *,
+        realtime: bool = True,
+    ) -> None:
+        """Stream PCM16 units, optionally attaching a JPEG to each unit."""
         audio_end_ms = 0
-        for offset in range(0, len(pcm16), chunk_bytes):
-            chunk = pcm16[offset : offset + chunk_bytes]
+        for chunk, frame in units:
+            if not chunk:
+                continue
             duration_ms = len(chunk) * 1000 // (PCM16_SAMPLE_RATE * PCM16_BYTES_PER_SAMPLE)
             audio_end_ms += duration_ms
-            await self.send(
-                {
-                    "type": "input_audio_buffer.append",
-                    "audio": base64.b64encode(chunk).decode("ascii"),
-                    "input_audio_format": "pcm16",
-                    "sample_rate_hz": PCM16_SAMPLE_RATE,
-                    "duration_ms": duration_ms,
-                    "audio_end_ms": audio_end_ms,
-                }
-            )
+            self._media_clock_ms = audio_end_ms
+            event: dict[str, object] = {
+                "type": "input_audio_buffer.append",
+                "audio": base64.b64encode(chunk).decode("ascii"),
+                "input_audio_format": "pcm16",
+                "sample_rate_hz": PCM16_SAMPLE_RATE,
+                "duration_ms": duration_ms,
+                "audio_end_ms": audio_end_ms,
+            }
+            if frame is not None:
+                event["video_frames"] = [base64.b64encode(frame).decode("ascii") if isinstance(frame, bytes) else frame]
+            await self.send(event)
             if realtime:
                 await asyncio.sleep(duration_ms / 1000)
 


### PR DESCRIPTION
## Summary

- add Omni-DuplexEval dataset and local manifest loading
- stream one-second PCM16 units with optional JPEG frames through the existing MiniCPM-o duplex client
- export official-shaped timed response artifacts on the media clock
- add the generate CLI, documentation, and CPU tests

This is the first of two review-sized PRs for #6603. Judge-based RTD/PR scoring will follow separately after this generation layer.

## Validation

- pre-commit (ruff, format, mypy, typos, SPDX, import and test-mark checks)
- Python compileall for the new benchmark modules and CLI