### PR TITLE
[CI][Bugfix] Fix MiniCPM-o BF16 duplex accuracy config

### DIFF
--- a/tests/e2e/accuracy/minicpmo_4_5/test_minicpmo_4_5.py
+++ b/tests/e2e/accuracy/minicpmo_4_5/test_minicpmo_4_5.py
@@ -34,12 +34,15 @@ from tests.helpers.stage_config import get_deploy_config_path, modify_stage_conf
 
 _MODEL = os.environ.get("VLLM_TEST_MINICPMO_4_5_MODEL", "openbmb/MiniCPM-o-4_5")
 _DEPLOY_CONFIG = get_deploy_config_path("minicpmo_4_5.yaml")
-_DUPLEX_BF16_DEPLOY_CONFIG = modify_stage_config(
-    _DUPLEX_DEPLOY_CONFIG,
+_BF16_BASE_DEPLOY_CONFIG = modify_stage_config(
+    _DEPLOY_CONFIG,
     updates={
-        "base_config": _DEPLOY_CONFIG,
         "connectors.connector_of_shared_memory.extra.code2wav_bfloat16_attention_cache": True,
     },
+)
+_DUPLEX_BF16_DEPLOY_CONFIG = modify_stage_config(
+    _DUPLEX_DEPLOY_CONFIG,
+    updates={"base_config": _BF16_BASE_DEPLOY_CONFIG},
 )
 _RESULT_DIR = Path(
     os.environ.get(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

The BF16 attention-cache variant of the MiniCPM-o 4.5 duplex Seed-TTS accuracy test failed during server startup in [Buildkite build 14090](https://buildkite.com/vllm/vllm-omni/builds/14090/canvas?sid=01a03860-77a4-44f3-b1c0-8eaeeb76c6ff&tab=output), also refer to issue #6636 .  The first relevant warning was:

```text
[stage_init] Failed to load transfer config: 'name'
```

The Talker subsequently started without its sender connector role and failed because the expected TTS conditioning was absent.

The BF16 test applied a dotted connector update directly to the unresolved duplex overlay. That created a partial top-level `connectors` block containing only `extra`; deploy resolution then replaced the complete base connector, dropping its `name` and existing options.

Apply the BF16 option to the complete base deploy config first, then point the duplex overlay at that modified base. This preserves both independent accuracy variants:

- the original FP32 attention-cache test;
- the BF16 attention-cache test.

It does not change runtime code or the global deploy merge semantics.

Reproduction on an H100 test worker:

```bash
pytest -sv tests/e2e/accuracy/minicpmo_4_5/test_minicpmo_4_5.py \
  -k 'duplex_seed_tts_wer_bench and bf16'
```

## Test Plan

**vLLM Version:** 0.25.0

**vLLM-Omni Commit:** `3366e83c44f8e6510c6492dd9983e11266058566` (based on `aeb348d8f8a555f0f9e91bee49f48778744a7bc6`)

Validation was run from an isolated checkout in NVIDIA H800 :

```bash
python3 -m pytest -o addopts= --collect-only -q \
  tests/e2e/accuracy/minicpmo_4_5/test_minicpmo_4_5.py \
  -k duplex_seed_tts_wer_bench

python3 -m pytest -o addopts= -q \
  tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py \
  -k '(bfloat16 or bf16) and not ragged_dit'

python3 -m pre_commit run --files \
  tests/e2e/accuracy/minicpmo_4_5/test_minicpmo_4_5.py
```

The configuration regression check additionally resolved both generated YAMLs and asserted that the BF16 variant:

- retains `SharedMemoryConnector` and all eight existing connector extras;
- enables `code2wav_bfloat16_attention_cache`;
- resolves Stage 1 as sender and Stage 2 as receiver;
- leaves both FP32 and BF16 accuracy parameters present.

## Test Result

```text
duplex_accuracy_variants=2
param_ids=['three-stage-single-gpu', 'three-stage-single-gpu-bf16-attention-cache']
connector_name=SharedMemoryConnector
preserved_extra_keys=8
bf16_flag=true
stage_1_role=sender
stage_2_role=receiver

2/4 tests collected (2 deselected) in 2.50s
3 passed, 45 deselected, 16 warnings in 0.24s
pre-commit: all applicable hooks passed
```

Before this fix, build 14090 completed the FP32 variant with 50/50 cases and mean WER `0.0170542`; the BF16 variant stopped during startup before producing accuracy results. The affected H100 full-model job remains the end-to-end regression gate for the repaired BF16 configuration.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
