### PR TITLE
[Boogu-Image] Fuse QKV/FFN projections + switch to diffusion RMSNorm

### DIFF
--- a/tests/diffusion/models/boogu_image/test_boogu_image_transformer.py
+++ b/tests/diffusion/models/boogu_image/test_boogu_image_transformer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 import logging
 import os
@@ -286,29 +286,58 @@ def test_transformer_rejects_prompt_tuning():
         BooguImageTransformer2DModel(od_config=_tiny_od_config(prompt_tuning_configs={"use_prompt_tuning": True}))
 
 
-def _native_to_checkpoint_name(name: str) -> str:
-    """Inverse of ``load_weights`` remapping: native param name -> diffusers name.
+_QKV_FANOUT = {
+    "to_qkv": ("to_q", "to_k", "to_v"),
+    "img_to_qkv": ("img_to_q", "img_to_k", "img_to_v"),
+    "instruct_to_qkv": ("instruct_to_q", "instruct_to_k", "instruct_to_v"),
+}
+
+
+def _native_to_checkpoint_weights(name: str, param: torch.Tensor) -> list[tuple[str, torch.Tensor]]:
+    """Inverse of ``load_weights`` remapping: native param -> diffusers weights.
+
+    The diffusers checkpoint stores fused projections as separate matrices, so a
+    single merged native param (QKV or FFN gate/up) fans out into several
+    checkpoint weights. Returns ``(diffusers_name, value)`` pairs whose values,
+    when fed through ``load_weights``, reassemble into the original ``param``.
 
     - ``.to_out.<suffix>`` -> ``.to_out.0.<suffix>`` (diffusers ModuleList wrap).
     - promoted joint-attention projections move back under ``.processor.``.
     """
+    q_size = NUM_HEADS * HEAD_DIM
+    kv_size = NUM_KV_HEADS * HEAD_DIM
+
+    # Fused QKV projections split back into per-matrix q/k/v weights.
+    for token, (q_name, k_name, v_name) in _QKV_FANOUT.items():
+        marker = f".{token}."
+        if marker in name:
+            q, k, v = param[:q_size], param[q_size : q_size + kv_size], param[q_size + kv_size :]
+            results = []
+            for sub_name, value in ((q_name, q), (k_name, k), (v_name, v)):
+                ckpt_name = name.replace(marker, f".{sub_name}.")
+                if token != "to_qkv":
+                    # Joint-attention projections live under `.processor.` upstream.
+                    ckpt_name = ckpt_name.replace(".img_instruct_attn.", ".img_instruct_attn.processor.")
+                results.append((ckpt_name, value))
+            return results
+
+    # Fused FFN gate/up splits into linear_1 (gate) / linear_3 (input).
+    if ".gate_up_proj." in name:
+        inner = param.shape[0] // 2
+        return [
+            (name.replace(".gate_up_proj.", ".linear_1."), param[:inner]),
+            (name.replace(".gate_up_proj.", ".linear_3."), param[inner:]),
+        ]
+
+    # Default: 1:1 with the existing diffusers name promotions.
     if ".to_out." in name:
         name = name.replace(".to_out.", ".to_out.0.")
-    for proj in (
-        "img_to_q",
-        "img_to_k",
-        "img_to_v",
-        "instruct_to_q",
-        "instruct_to_k",
-        "instruct_to_v",
-        "instruct_out",
-        "img_out",
-    ):
+    for proj in ("instruct_out", "img_out"):
         token = f".img_instruct_attn.{proj}."
         if token in name:
             name = name.replace(token, f".img_instruct_attn.processor.{proj}.")
             break
-    return name
+    return [(name, param)]
 
 
 def test_transformer_load_weights_round_trip():
@@ -319,24 +348,29 @@ def test_transformer_load_weights_round_trip():
     model = BooguImageTransformer2DModel(od_config=_tiny_od_config())
     native_params = dict(model.named_parameters())
 
-    # Build synthetic diffusers-named weights (one per native parameter).
-    checkpoint_weights = {}
+    # Build synthetic diffusers-named weights. Fused native projections fan out
+    # into the separate matrices the diffusers checkpoint stores.
+    expected: dict[str, torch.Tensor] = {}
+    checkpoint_weights: dict[str, torch.Tensor] = {}
     for native_name, param in native_params.items():
-        checkpoint_weights[_native_to_checkpoint_name(native_name)] = torch.randn_like(param)
+        full = torch.randn_like(param)
+        expected[native_name] = full
+        for ckpt_name, value in _native_to_checkpoint_weights(native_name, full):
+            checkpoint_weights[ckpt_name] = value
 
-    # The remapping must be a bijection over the parameter set.
-    assert len(checkpoint_weights) == len(native_params)
+    # Every checkpoint name is unique; merged params fan out to >=1 weight.
+    assert len(checkpoint_weights) >= len(native_params)
 
     loaded = model.load_weights(list(checkpoint_weights.items()))
 
     # No missing / unexpected parameters.
     assert loaded == set(native_params.keys())
 
-    # Values landed on the right parameters (TP=1: weight_loader copies verbatim).
+    # Values landed on the right parameters (TP=1: weight_loader copies verbatim;
+    # fused shards are placed at their q/k/v / gate/up offsets).
     reloaded = dict(model.named_parameters())
     for native_name in native_params:
-        expected = checkpoint_weights[_native_to_checkpoint_name(native_name)]
-        assert torch.allclose(reloaded[native_name], expected)
+        assert torch.allclose(reloaded[native_name], expected[native_name])
 
 
 def test_transformer_load_weights_warns_for_unexpected_and_unloaded():
@@ -360,11 +394,13 @@ def test_transformer_load_weights_warns_for_unexpected_and_unloaded():
         model = BooguImageTransformer2DModel(od_config=_tiny_od_config())
         native_params = dict(model.named_parameters())
         loaded_name = next(iter(native_params))
-        checkpoint_name = _native_to_checkpoint_name(loaded_name)
+        # For fused projections, load just one of the fan-out checkpoint matrices.
+        (checkpoint_name, checkpoint_value), *_ = _native_to_checkpoint_weights(loaded_name, native_params[loaded_name])
+        checkpoint_value = torch.randn_like(checkpoint_value)
 
         loaded = model.load_weights(
             [
-                (checkpoint_name, torch.randn_like(native_params[loaded_name])),
+                (checkpoint_name, checkpoint_value),
                 ("unexpected.weight", torch.ones(1)),
             ]
         )

--- a/vllm_omni/diffusion/models/boogu_image/boogu_image_transformer.py
+++ b/vllm_omni/diffusion/models/boogu_image/boogu_image_transformer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 #
 # Native vLLM-Omni port of the Boogu-Image transformer.
 #
@@ -23,9 +23,9 @@ import torch.nn.functional as F
 from diffusers.models.embeddings import Timesteps, get_1d_rotary_pos_embed
 from einops import rearrange, repeat
 from vllm.logger import init_logger
-from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
-    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
 )
@@ -34,6 +34,7 @@ from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.layer import Attention
 from vllm_omni.diffusion.data import OmniDiffusionConfig
+from vllm_omni.diffusion.layers.norm import RMSNorm
 
 logger = init_logger(__name__)
 
@@ -111,7 +112,14 @@ class LuminaLayerNormContinuous(nn.Module):
 
 
 class LuminaFeedForward(nn.Module):
-    """SwiGLU feed-forward with tensor-parallel projections."""
+    """SwiGLU feed-forward with tensor-parallel projections.
+
+    The ``gate`` and ``input`` projections are fused into a single
+    ``MergedColumnParallelLinear`` (one GEMM instead of two), matching the
+    ``gate_up_proj`` convention used by the Hunyuan Image 3 port. The SwiGLU
+    activation keeps its float32 computation for numerical parity with
+    upstream.
+    """
 
     def __init__(
         self,
@@ -125,13 +133,16 @@ class LuminaFeedForward(nn.Module):
             inner_dim = int(ffn_dim_multiplier * inner_dim)
         inner_dim = multiple_of * ((inner_dim + multiple_of - 1) // multiple_of)
 
-        self.linear_1 = ColumnParallelLinear(dim, inner_dim, bias=False)  # gate
-        self.linear_3 = ColumnParallelLinear(dim, inner_dim, bias=False)  # input
+        self.gate_up_proj = MergedColumnParallelLinear(
+            input_size=dim,
+            output_sizes=[inner_dim, inner_dim],
+            bias=False,
+        )
         self.linear_2 = RowParallelLinear(inner_dim, dim, bias=False)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        h1, _ = self.linear_1(x)
-        h2, _ = self.linear_3(x)
+        gate_up, _ = self.gate_up_proj(x)
+        h1, h2 = gate_up.chunk(2, dim=-1)
         out, _ = self.linear_2(swiglu(h1, h2))
         return out
 
@@ -389,17 +400,22 @@ class BooguImageSelfAttention(nn.Module):
     def __init__(self, dim: int, num_attention_heads: int, num_kv_heads: int) -> None:
         super().__init__()
         self.head_dim = dim // num_attention_heads
-        kv_dim = self.head_dim * num_kv_heads
 
-        self.to_q = ColumnParallelLinear(dim, dim, bias=False)
-        self.to_k = ColumnParallelLinear(dim, kv_dim, bias=False)
-        self.to_v = ColumnParallelLinear(dim, kv_dim, bias=False)
+        self.to_qkv = QKVParallelLinear(
+            hidden_size=dim,
+            head_size=self.head_dim,
+            total_num_heads=num_attention_heads,
+            total_num_kv_heads=num_kv_heads,
+            bias=False,
+        )
         self.norm_q = RMSNorm(self.head_dim, eps=1e-5)
         self.norm_k = RMSNorm(self.head_dim, eps=1e-5)
         self.to_out = RowParallelLinear(dim, dim, bias=False)
 
-        self.num_local_heads = self.to_q.output_size_per_partition // self.head_dim
-        self.num_local_kv_heads = self.to_k.output_size_per_partition // self.head_dim
+        self.num_local_heads = self.to_qkv.num_heads
+        self.num_local_kv_heads = self.to_qkv.num_kv_heads
+        self.q_size = self.num_local_heads * self.head_dim
+        self.kv_size = self.num_local_kv_heads * self.head_dim
 
         self.attn = Attention(
             num_heads=self.num_local_heads,
@@ -417,9 +433,8 @@ class BooguImageSelfAttention(nn.Module):
     ) -> torch.Tensor:
         dtype = hidden_states.dtype
 
-        query, _ = self.to_q(hidden_states)
-        key, _ = self.to_k(hidden_states)
-        value, _ = self.to_v(hidden_states)
+        qkv, _ = self.to_qkv(hidden_states)
+        query, key, value = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
         query = query.unflatten(-1, (self.num_local_heads, self.head_dim))
         key = key.unflatten(-1, (self.num_local_kv_heads, self.head_dim))
@@ -454,15 +469,21 @@ class BooguImageJointAttention(nn.Module):
     def __init__(self, dim: int, num_attention_heads: int, num_kv_heads: int) -> None:
         super().__init__()
         self.head_dim = dim // num_attention_heads
-        kv_dim = self.head_dim * num_kv_heads
 
-        self.img_to_q = ColumnParallelLinear(dim, dim, bias=False)
-        self.img_to_k = ColumnParallelLinear(dim, kv_dim, bias=False)
-        self.img_to_v = ColumnParallelLinear(dim, kv_dim, bias=False)
-
-        self.instruct_to_q = ColumnParallelLinear(dim, dim, bias=False)
-        self.instruct_to_k = ColumnParallelLinear(dim, kv_dim, bias=False)
-        self.instruct_to_v = ColumnParallelLinear(dim, kv_dim, bias=False)
+        self.img_to_qkv = QKVParallelLinear(
+            hidden_size=dim,
+            head_size=self.head_dim,
+            total_num_heads=num_attention_heads,
+            total_num_kv_heads=num_kv_heads,
+            bias=False,
+        )
+        self.instruct_to_qkv = QKVParallelLinear(
+            hidden_size=dim,
+            head_size=self.head_dim,
+            total_num_heads=num_attention_heads,
+            total_num_kv_heads=num_kv_heads,
+            bias=False,
+        )
 
         self.norm_q = RMSNorm(self.head_dim, eps=1e-5)
         self.norm_k = RMSNorm(self.head_dim, eps=1e-5)
@@ -474,8 +495,10 @@ class BooguImageJointAttention(nn.Module):
         # Final joint projection applied to the merged full-dim sequence.
         self.to_out = ReplicatedLinear(dim, dim, bias=False)
 
-        self.num_local_heads = self.img_to_q.output_size_per_partition // self.head_dim
-        self.num_local_kv_heads = self.img_to_k.output_size_per_partition // self.head_dim
+        self.num_local_heads = self.img_to_qkv.num_heads
+        self.num_local_kv_heads = self.img_to_qkv.num_kv_heads
+        self.q_size = self.num_local_heads * self.head_dim
+        self.kv_size = self.num_local_kv_heads * self.head_dim
 
         self.attn = Attention(
             num_heads=self.num_local_heads,
@@ -497,13 +520,13 @@ class BooguImageJointAttention(nn.Module):
         dtype = img_hidden_states.dtype
         batch_size = img_hidden_states.shape[0]
 
-        img_query, _ = self.img_to_q(img_hidden_states)
-        img_key, _ = self.img_to_k(img_hidden_states)
-        img_value, _ = self.img_to_v(img_hidden_states)
+        img_qkv, _ = self.img_to_qkv(img_hidden_states)
+        img_query, img_key, img_value = img_qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
-        instruct_query, _ = self.instruct_to_q(instruct_hidden_states)
-        instruct_key, _ = self.instruct_to_k(instruct_hidden_states)
-        instruct_value, _ = self.instruct_to_v(instruct_hidden_states)
+        instruct_qkv, _ = self.instruct_to_qkv(instruct_hidden_states)
+        instruct_query, instruct_key, instruct_value = instruct_qkv.split(
+            [self.q_size, self.kv_size, self.kv_size], dim=-1
+        )
 
         query, key, value = _concat_instruction_image_features(
             [img_query, img_key, img_value],
@@ -798,6 +821,47 @@ def _cal_preprocessed_instruction_feat_dim(instruction_feature_configs: dict) ->
         return instruction_feat_dim
     else:
         raise ValueError(f"Invalid reduce_type: {reduce_type}")
+
+
+_QKV_PROJ_MERGES: dict[str, tuple[str, str]] = {
+    "img_to_q": ("img_to_qkv", "q"),
+    "img_to_k": ("img_to_qkv", "k"),
+    "img_to_v": ("img_to_qkv", "v"),
+    "instruct_to_q": ("instruct_to_qkv", "q"),
+    "instruct_to_k": ("instruct_to_qkv", "k"),
+    "instruct_to_v": ("instruct_to_qkv", "v"),
+    "to_q": ("to_qkv", "q"),
+    "to_k": ("to_qkv", "k"),
+    "to_v": ("to_qkv", "v"),
+}
+
+
+def _remap_fused_weight(name: str) -> tuple[str, str | int | None]:
+    """Map a diffusers checkpoint weight name onto the fused native parameter.
+
+    The diffusers checkpoint stores Q/K/V and FFN gate/input projections as
+    separate matrices; the native port fuses them into ``QKVParallelLinear``
+    and ``MergedColumnParallelLinear``. Returns ``(param_name, shard_id)`` where
+    ``shard_id`` is the shard the fused weight loader uses to place the matrix
+    (``"q"/"k"/"v"`` for QKV, ``0/1`` for gate/up), or ``(name, None)`` when the
+    weight is not fused.
+    """
+    parts = name.split(".")
+    leaf = parts[-2] if len(parts) >= 2 else ""
+    parent = parts[-3] if len(parts) >= 3 else ""
+
+    if leaf in _QKV_PROJ_MERGES:
+        new_leaf, shard_id = _QKV_PROJ_MERGES[leaf]
+        parts[-2] = new_leaf
+        return ".".join(parts), shard_id
+
+    # FFN gate/input: ``feed_forward`` / ``img_feed_forward`` /
+    # ``instruct_feed_forward`` all share the same fused ``gate_up_proj``.
+    if leaf in ("linear_1", "linear_3") and parent.endswith("feed_forward"):
+        parts[-2] = "gate_up_proj"
+        return ".".join(parts), 0 if leaf == "linear_1" else 1
+
+    return name, None
 
 
 class BooguImageTransformer2DModel(nn.Module):
@@ -1336,7 +1400,7 @@ class BooguImageTransformer2DModel(nn.Module):
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         """Load diffusers-named checkpoint weights into the native module.
 
-        Two name promotions relative to upstream (see step 8/10 findings):
+        Name promotions relative to upstream (see step 8/10 findings):
 
         - ``*.img_instruct_attn.processor.{img,instruct}_{to_q,to_k,to_v}`` /
           ``{instruct,img}_out`` -> drop ``.processor`` (upstream keeps the
@@ -1345,6 +1409,9 @@ class BooguImageTransformer2DModel(nn.Module):
         - ``*.to_out.0.weight`` -> ``*.to_out.weight`` (diffusers wraps the
           output projection in a ``ModuleList``; the native module uses a plain
           linear).
+        - Separate Q/K/V and FFN gate/input matrices are fused into
+          ``QKVParallelLinear`` / ``MergedColumnParallelLinear`` (handled by
+          :func:`_remap_fused_weight`).
         """
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
@@ -1356,13 +1423,18 @@ class BooguImageTransformer2DModel(nn.Module):
             if ".to_out.0." in name:
                 name = name.replace(".to_out.0.", ".to_out.")
 
+            name, shard_id = _remap_fused_weight(name)
+
             if name not in params_dict:
                 logger.warning("Skipping unexpected checkpoint weight %s", original_name)
                 continue
 
             param = params_dict[name]
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
-            weight_loader(param, loaded_weight)
+            if shard_id is not None:
+                weight_loader(param, loaded_weight, shard_id)
+            else:
+                weight_loader(param, loaded_weight)
             loaded_params.add(name)
 
         unloaded_params = sorted(params_dict.keys() - loaded_params)


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
Three kernel-level optimizations to the native `BooguImagePipeline` transformer
(`vllm_omni/diffusion/models/boogu_image/boogu_image_transformer.py`), mirroring the
approach already used by `HunyuanImage3`:

1. **Fuse QKV projections** — `to_q`/`to_k`/`to_v` (self-attention) and
   `img_to_q/k/v` + `instruct_to_q/k/v` (joint attention) are replaced by a single
   `QKVParallelLinear` per projection set. One GEMM instead of three (or two) per
   attention module.
2. **Fuse FFN gate/up** — `linear_1` (gate) + `linear_3` (up) in `LuminaFeedForward`
   are replaced by a single `MergedColumnParallelLinear` (`gate_up_proj`), the same
   `gate_up_proj` convention as `HunYuanMLP`.
3. **Diffusion RMSNorm** — `RMSNorm` is switched from
   `vllm.model_executor.layers.layernorm` to `vllm_omni.diffusion.layers.norm`, the
   fused diffusion-layer implementation used by `HunyuanImage3`.

The diffusers checkpoint stores these projections as separate matrices, so
`load_weights` gains a `_remap_fused_weight` step that routes the individual
`to_q/to_k/to_v` / `linear_1/linear_3` checkpoint tensors onto the fused parameters
via shard-id weight loading (`"q"/"k"/"v"` for QKV, `0/1` for gate/up). The FFN
activation keeps the original float32 `swiglu` for numerical parity (no
`SiluAndMul`).
## Test Plan
1. Performance bench
2. Accuracy
**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result
### Performance
| | qps | latency | p99 | generation time | peak memory |
| --- | ---: | ---: | ---: | ---: | ---: |
| before | 0.2391 | 4.18 s | 4.24 s | 4099.4 ms | 36764 MB |
| after | 0.2480 | 4.03 s | 4.11 s | 3955.6 ms | 36590 MB |
| Δ | **+3.73%** | **−3.60%** | −3.00% | −3.51% | −174 MB |

### Accuracy
before:
<img width="512" height="512" alt="gen_before" src="https://github.com/user-attachments/assets/8a8be2d9-32a7-43c1-8571-eda1550a9865" />
after:
<img width="512" height="512" alt="gen_after" src="https://github.com/user-attachments/assets/8bfcb167-8989-4f1b-a31a-93ef7610528d" />

| Metric | Value |
| --- | --- |
| Mean absolute diff | 3.52 / 255 (1.38%) |
| Max absolute diff | 209 / 255 (sparse pixels) |
| PSNR | 29.1 dB |
| Pixels exactly equal | ~7% |

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
