### PR TITLE
[Model] MiniCPM-o 4.5: cache prompt-conditioned Code2Wav state

### DIFF
--- a/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
@@ -139,7 +139,12 @@ class _FakeToken2Wav:
         raise AssertionError("sequential __call__ fallback must never be called")
 
 
-def _config(minimum: int = 1):
+def _config(
+    minimum: int = 1,
+    *,
+    runtime_prompt_cache_size: int = 4,
+    setup_cache_size: int = 1,
+):
     return SimpleNamespace(
         model_config=SimpleNamespace(
             model="/fake/model",
@@ -148,16 +153,26 @@ def _config(minimum: int = 1):
                     "code2wav_min_batch_size": minimum,
                     "prompt_cache_id": "shared",
                     "prompt_wav": "/fake/prompt.wav",
+                    "token2wav_runtime_prompt_cache_size": runtime_prompt_cache_size,
+                    "token2wav_setup_cache_size": setup_cache_size,
                 }
             },
         )
     )
 
 
-def _model():
+def _model(*, runtime_prompt_cache_size: int = 4, setup_cache_size: int = 1):
     token2wav = _FakeToken2Wav()
-    backend = BatchedToken2Wav(token2wav)
-    model = MiniCPMO45Code2Wav(vllm_config=_config())
+    backend = BatchedToken2Wav(
+        token2wav,
+        setup_cache_size=setup_cache_size,
+    )
+    model = MiniCPMO45Code2Wav(
+        vllm_config=_config(
+            runtime_prompt_cache_size=runtime_prompt_cache_size,
+            setup_cache_size=setup_cache_size,
+        )
+    )
     model.backend = backend
     return model, token2wav
 
@@ -263,6 +278,55 @@ def test_adapter_runs_true_batch_cfg_and_splits_request_caches():
     assert cache0.data_ptr() != cache1.data_ptr()
     assert cache0[0, 0, 0, 0, 0].item() == 10
     assert cache1[0, 0, 0, 0, 0].item() == 20
+
+
+def test_setup_cache_reuses_read_only_state_for_the_same_exact_batch():
+    token2wav = _FakeToken2Wav()
+    adapter = BatchedToken2Wav(token2wav, setup_cache_size=2)
+    prompt = adapter.prepare_prompt("shared", "/fake/prompt.wav")
+
+    first = adapter.setup_batch(prompt, 1)
+    encoder_calls = list(token2wav.flow.encoder.calls)
+    snapshots = {name: tensor.clone() for name, tensor in {**first[0].flow_cache, **first[0].hift_cache}.items()}
+    second = adapter.setup_batch(prompt, 1)
+
+    assert first is not second
+    assert first[0] is second[0]
+    assert token2wav.flow.encoder.calls == encoder_calls
+
+    adapter.decode_batch(
+        torch.tensor([[10, 11]]),
+        prompt,
+        second,
+        last_chunk=False,
+    )
+    for name, expected in snapshots.items():
+        cache = first[0].flow_cache if name in first[0].flow_cache else first[0].hift_cache
+        torch.testing.assert_close(cache[name], expected)
+
+
+def test_setup_cache_keys_batch_size_and_evicts_least_recent_entry():
+    token2wav = _FakeToken2Wav()
+    adapter = BatchedToken2Wav(token2wav, setup_cache_size=1)
+    prompt = adapter.prepare_prompt("shared", "/fake/prompt.wav")
+
+    adapter.setup_batch(prompt, 1)
+    adapter.setup_batch(prompt, 2)
+    adapter.setup_batch(prompt, 1)
+
+    assert token2wav.flow.encoder.calls == [1, 2, 1]
+    assert list(adapter._setup_cache) == [(prompt.cache_key, 1)]
+
+
+def test_evict_prompt_clears_features_and_setup_state():
+    token2wav = _FakeToken2Wav()
+    adapter = BatchedToken2Wav(token2wav, setup_cache_size=2)
+    first = adapter.prepare_prompt("first", "/fake/first.wav")
+    adapter.setup_batch(first, 1)
+
+    adapter.evict_prompt("first", "/fake/first.wav")
+    assert ("first", "/fake/first.wav") not in adapter._prompt_features
+    assert all(key[0] != first.cache_key for key in adapter._setup_cache)
 
 
 def test_fade_in_out_limits_overlap_to_available_previous_audio():
@@ -397,7 +461,7 @@ def test_initial_empty_segment_marker_initializes_stream_without_audio():
 
 def test_shared_runtime_prompt_recreates_missing_file_before_second_owner(tmp_path, monkeypatch):
     monkeypatch.setattr("tempfile.gettempdir", lambda: str(tmp_path))
-    model, _ = _model()
+    model, _ = _model(runtime_prompt_cache_size=0)
     reference = torch.tensor([0.0, 0.25, -0.25, 0.0])
 
     first = _info("voice-a", 0, [10, 11])
@@ -453,8 +517,8 @@ def test_runtime_prompt_write_failure_does_not_publish_partial_file(tmp_path, mo
 
 def test_runtime_prompt_files_are_isolated_between_model_instances(tmp_path, monkeypatch):
     monkeypatch.setattr("tempfile.gettempdir", lambda: str(tmp_path))
-    first_model, _ = _model()
-    second_model, _ = _model()
+    first_model, _ = _model(runtime_prompt_cache_size=0)
+    second_model, _ = _model(runtime_prompt_cache_size=0)
     reference = torch.tensor([0.0, 0.25, -0.25, 0.0])
 
     def runtime_ref_info(request_id: str):
@@ -482,6 +546,86 @@ def test_runtime_prompt_files_are_isolated_between_model_instances(tmp_path, mon
 
     second_model.on_requests_finished(["internal-b"])
     assert not second_path.exists()
+
+
+def test_runtime_prompt_and_setup_are_reused_across_sequential_requests(tmp_path, monkeypatch):
+    monkeypatch.setattr("tempfile.gettempdir", lambda: str(tmp_path))
+    model, token2wav = _model(runtime_prompt_cache_size=2, setup_cache_size=1)
+    reference = torch.tensor([0.0, 0.25, -0.25, 0.0])
+
+    def runtime_ref_info(request_id: str):
+        info = _info(request_id, 0, [10, 11])
+        info["codes"]["ref"] = reference
+        info["meta"]["ref_audio_sr"] = 16000
+        info["meta"].pop("prompt_cache_id")
+        return info
+
+    first = _forward(
+        model,
+        [runtime_ref_info("voice-a")],
+        request_ids=["internal-a"],
+    )
+    prompt_key = model._request_prompt_keys["internal-a"]
+    prompt_path = Path(model._runtime_prompts[prompt_key].path)
+    model.on_requests_finished(["internal-a"])
+    encoder_calls = len(token2wav.flow.encoder.calls)
+
+    second = _forward(
+        model,
+        [runtime_ref_info("voice-b")],
+        request_ids=["internal-b"],
+    )
+
+    assert token2wav.prompt_calls == 1
+    # A setup miss and a decode each call the encoder; a setup hit only decodes.
+    assert len(token2wav.flow.encoder.calls) == encoder_calls + 1
+    torch.testing.assert_close(
+        first.multimodal_outputs["model_outputs"][0],
+        second.multimodal_outputs["model_outputs"][0],
+    )
+    assert model._request_prompt_keys["internal-b"] == prompt_key
+    model.on_requests_finished(["internal-b"])
+    assert prompt_path.is_file()
+    assert model._runtime_prompts[prompt_key].owners == set()
+
+
+def test_runtime_prompt_lru_evicts_only_unowned_entries(tmp_path, monkeypatch):
+    monkeypatch.setattr("tempfile.gettempdir", lambda: str(tmp_path))
+    model, _ = _model(runtime_prompt_cache_size=1, setup_cache_size=2)
+
+    def runtime_ref_info(request_id: str, reference: torch.Tensor):
+        info = _info(request_id, 0, [10, 11])
+        info["codes"]["ref"] = reference
+        info["meta"]["ref_audio_sr"] = 16000
+        info["meta"].pop("prompt_cache_id")
+        return info
+
+    _forward(
+        model,
+        [runtime_ref_info("voice-a", torch.tensor([0.0, 0.1, 0.0]))],
+        request_ids=["internal-a"],
+    )
+    first_key = model._request_prompt_keys["internal-a"]
+    first_prompt = model._runtime_prompts[first_key]
+    first_path = Path(first_prompt.path)
+
+    _forward(
+        model,
+        [runtime_ref_info("voice-b", torch.tensor([0.0, 0.2, 0.0]))],
+        request_ids=["internal-b"],
+    )
+    second_key = model._request_prompt_keys["internal-b"]
+    assert set(model._runtime_prompts) == {first_key, second_key}
+
+    model.on_requests_finished(["internal-a"])
+    assert first_key not in model._runtime_prompts
+    assert not first_path.exists()
+    assert (first_prompt.cache_id, first_prompt.path) not in model.backend._prompt_features
+    assert all(key[0] != (first_prompt.cache_id, first_prompt.path) for key in model.backend._setup_cache)
+
+    model.on_requests_finished(["internal-b"])
+    assert list(model._runtime_prompts) == [second_key]
+    assert model._runtime_prompts[second_key].owners == set()
 
 
 def test_mixed_final_exact_buckets_keep_order_and_release_only_final_states():
@@ -707,7 +851,7 @@ def test_cleanup_uses_generation_runner_internal_request_ids():
 
 
 def test_reference_voice_and_duplex_metadata_follow_request_lifecycle():
-    model, _ = _model()
+    model, _ = _model(runtime_prompt_cache_size=0)
     first = _info("voice-a", 0, [1, 2])
     first["codes"]["ref"] = torch.linspace(-0.1, 0.1, 160)
     segment_text_utf8 = torch.tensor(list(b"hello"), dtype=torch.uint8)

--- a/vllm_omni/deploy/minicpmo_4_5.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5.yaml
@@ -14,6 +14,9 @@ connectors:
       connector_get_max_wait: 300
       codec_chunk_frames: 25
       codec_left_context_frames: 3
+      # Retain reusable prompt features and one prompt-conditioned CFM state.
+      token2wav_runtime_prompt_cache_size: 4
+      token2wav_setup_cache_size: 1
 
 stages:
   - stage_id: 0

--- a/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from collections import OrderedDict
 from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import Any
@@ -41,6 +42,7 @@ def state_shape_signature(state: BatchedToken2WavState) -> tuple[Any, ...]:
 
 @dataclass(frozen=True)
 class PromptFeatures:
+    cache_key: tuple[str, str]
     speech_tokens: torch.Tensor
     speaker_embedding: torch.Tensor
     mels: torch.Tensor
@@ -60,8 +62,15 @@ class BatchedToken2Wav(nn.Module):
     asset loader and prompt feature extractor.
     """
 
-    def __init__(self, token2wav: Any):
+    def __init__(
+        self,
+        token2wav: Any,
+        *,
+        setup_cache_size: int = 1,
+    ):
         super().__init__()
+        if setup_cache_size < 0:
+            raise ValueError("setup_cache_size must be >= 0")
         self._token2wav = token2wav
         self.flow = token2wav.flow
         self.hift = token2wav.hift
@@ -103,7 +112,12 @@ class BatchedToken2Wav(nn.Module):
             token2wav.speech_window.detach().clone(),
             persistent=False,
         )
+        self._setup_cache_size = setup_cache_size
         self._prompt_features: dict[tuple[str, str], PromptFeatures] = {}
+        self._setup_cache: OrderedDict[
+            tuple[tuple[str, str], int],
+            tuple[BatchedToken2WavState, ...],
+        ] = OrderedDict()
 
     def prepare_prompt(self, prompt_cache_id: str, prompt_wav: str) -> PromptFeatures:
         cache_key = (prompt_cache_id, prompt_wav)
@@ -120,6 +134,7 @@ class BatchedToken2Wav(nn.Module):
             finally:
                 torch.set_default_dtype(previous_dtype)
             cached = PromptFeatures(
+                cache_key=cache_key,
                 speech_tokens=values[0],
                 speaker_embedding=values[2],
                 mels=values[3],
@@ -128,8 +143,12 @@ class BatchedToken2Wav(nn.Module):
         return cached
 
     def evict_prompt(self, prompt_cache_id: str, prompt_wav: str) -> None:
-        """Release request-owned prompt features after stream completion."""
-        self._prompt_features.pop((prompt_cache_id, prompt_wav), None)
+        """Release all cached artifacts associated with one prompt."""
+        prompt_key = (prompt_cache_id, prompt_wav)
+        self._prompt_features.pop(prompt_key, None)
+        for setup_key in list(self._setup_cache):
+            if setup_key[0] == prompt_key:
+                self._setup_cache.pop(setup_key)
 
     @staticmethod
     def _repeat_prompt(features: PromptFeatures, batch_size: int) -> tuple[torch.Tensor, ...]:
@@ -325,7 +344,7 @@ class BatchedToken2Wav(nn.Module):
             "estimator_att_cache": torch.cat((*conditional_att, *unconditional_att), dim=2),
         }
 
-    def setup_batch(
+    def _create_initial_states(
         self,
         features: PromptFeatures,
         batch_size: int,
@@ -370,6 +389,31 @@ class BatchedToken2Wav(nn.Module):
             )
             for row in split
         ]
+
+    def setup_batch(
+        self,
+        features: PromptFeatures,
+        batch_size: int,
+    ) -> list[BatchedToken2WavState]:
+        """Return prompt-conditioned initial states for an exact batch shape.
+
+        ``decode_batch`` treats these states as read-only and materializes new
+        per-request tensors, so cache hits do not need a device-to-device copy.
+        The batch size remains part of the key because CFM setup is batched and
+        its cache shapes depend on that size.
+        """
+        cache_key = (features.cache_key, batch_size)
+        cached = self._setup_cache.get(cache_key)
+        if cached is not None:
+            self._setup_cache.move_to_end(cache_key)
+            return list(cached)
+
+        states = self._create_initial_states(features, batch_size)
+        if self._setup_cache_size > 0:
+            self._setup_cache[cache_key] = tuple(states)
+            while len(self._setup_cache) > self._setup_cache_size:
+                self._setup_cache.popitem(last=False)
+        return states
 
     @staticmethod
     def _fade_in_out(

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+from collections import OrderedDict
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from hashlib import sha256
@@ -129,7 +130,7 @@ class MiniCPMO45Code2Wav(nn.Module):
         self.model_path = str(vllm_config.model_config.model)
         self.backend: BatchedToken2Wav | None = None
         self._states: dict[str, _RequestState] = {}
-        self._runtime_prompts: dict[str, _RuntimePrompt] = {}
+        self._runtime_prompts: OrderedDict[str, _RuntimePrompt] = OrderedDict()
         self._request_prompt_keys: dict[str, str] = {}
         self._runtime_prompt_dir = tempfile.TemporaryDirectory(
             prefix="minicpmo45-runtime-prompts-",
@@ -138,6 +139,12 @@ class MiniCPMO45Code2Wav(nn.Module):
         self._min_batch_size = int(extra.get("code2wav_min_batch_size", 1))
         if self._min_batch_size < 1:
             raise ValueError("MiniCPM-o Code2Wav code2wav_min_batch_size must be >= 1")
+        self._runtime_prompt_cache_size = int(extra.get("token2wav_runtime_prompt_cache_size", 4))
+        self._setup_cache_size = int(extra.get("token2wav_setup_cache_size", 1))
+        if self._runtime_prompt_cache_size < 0:
+            raise ValueError("MiniCPM-o Code2Wav token2wav_runtime_prompt_cache_size must be >= 0")
+        if self._setup_cache_size < 0:
+            raise ValueError("MiniCPM-o Code2Wav token2wav_setup_cache_size must be >= 0")
         self._default_prompt_id = str(extra.get("prompt_cache_id", "HT_ref_audio"))
         self._prompt_wav_explicit = "prompt_wav" in extra
         self._default_prompt_wav = str(
@@ -214,6 +221,8 @@ class MiniCPMO45Code2Wav(nn.Module):
         if entry is None:
             entry = _RuntimePrompt(cache_id=cache_id, path=path, owners=set())
             self._runtime_prompts[cache_key] = entry
+        else:
+            self._runtime_prompts.move_to_end(cache_key)
         prompt_path = Path(entry.path)
         if not prompt_path.is_file():
             with tempfile.NamedTemporaryFile(
@@ -271,8 +280,9 @@ class MiniCPMO45Code2Wav(nn.Module):
         if entry is None:
             return
         entry.owners.discard(state_id)
-        if entry.owners:
-            return
+        self._trim_runtime_prompts()
+
+    def _evict_runtime_prompt(self, cache_key: str, entry: _RuntimePrompt) -> None:
         if self.backend is not None:
             self.backend.evict_prompt(entry.cache_id, entry.path)
         Path(entry.path).unlink(missing_ok=True)
@@ -284,21 +294,29 @@ class MiniCPMO45Code2Wav(nn.Module):
             if cache_key is None:
                 continue
             previous_key = self._request_prompt_keys.get(item.state_id)
-            if previous_key != cache_key:
-                self._release_request_prompt(item.state_id)
             entry = self._runtime_prompts.get(cache_key)
-            if entry is not None:
-                entry.owners.add(item.state_id)
-                self._request_prompt_keys[item.state_id] = cache_key
-
-    def _prune_unowned_runtime_prompts(self) -> None:
-        for cache_key, entry in list(self._runtime_prompts.items()):
-            if entry.owners:
+            if entry is None:
                 continue
-            if self.backend is not None:
-                self.backend.evict_prompt(entry.cache_id, entry.path)
-            Path(entry.path).unlink(missing_ok=True)
-            self._runtime_prompts.pop(cache_key, None)
+            if previous_key != cache_key:
+                previous = self._runtime_prompts.get(previous_key) if previous_key is not None else None
+                if previous is not None:
+                    previous.owners.discard(item.state_id)
+            entry.owners.add(item.state_id)
+            self._request_prompt_keys[item.state_id] = cache_key
+            self._runtime_prompts.move_to_end(cache_key)
+        self._trim_runtime_prompts()
+
+    def _trim_runtime_prompts(self) -> None:
+        """Evict least-recent unowned prompts until the cache is in bounds."""
+        while len(self._runtime_prompts) > self._runtime_prompt_cache_size:
+            victim = next(
+                ((cache_key, entry) for cache_key, entry in self._runtime_prompts.items() if not entry.owners),
+                None,
+            )
+            if victim is None:
+                # Active requests may temporarily exceed the configured bound.
+                return
+            self._evict_runtime_prompt(*victim)
 
     @staticmethod
     def _split_segments(input_ids: torch.Tensor, counts: Any) -> list[torch.Tensor]:
@@ -544,11 +562,11 @@ class MiniCPMO45Code2Wav(nn.Module):
                     )
                 items.append(self._parse_item(index, str(state_id), segment, info))
         except Exception:
-            self._prune_unowned_runtime_prompts()
+            self._trim_runtime_prompts()
             raise
         state_ids = [item.state_id for item in items]
         if len(state_ids) != len(set(state_ids)):
-            self._prune_unowned_runtime_prompts()
+            self._trim_runtime_prompts()
             raise _batch_error("duplicate_request_in_forward", request_ids=state_ids)
         outputs = [empty for _ in segments]
         sentinels = [item for item in items if item.last_chunk and item.tokens.numel() == 0]
@@ -562,7 +580,7 @@ class MiniCPMO45Code2Wav(nn.Module):
             if item.has_payload and not item.last_chunk and not item.tts_is_last_chunk and item.tokens.numel() == 0
         ]
         if invalid_empty:
-            self._prune_unowned_runtime_prompts()
+            self._trim_runtime_prompts()
             raise _batch_error("empty_nonfinal_chunk", request_ids=invalid_empty)
 
         buckets: dict[tuple[Any, ...], list[_WorkItem]] = {}
@@ -578,7 +596,7 @@ class MiniCPMO45Code2Wav(nn.Module):
             if len(bucket) < self._min_batch_size
         ]
         if undersized:
-            self._prune_unowned_runtime_prompts()
+            self._trim_runtime_prompts()
             raise _batch_error(
                 "exact_shape_bucket_below_minimum",
                 minimum=self._min_batch_size,
@@ -614,7 +632,7 @@ class MiniCPMO45Code2Wav(nn.Module):
                 )
                 states = self.backend.setup_batch(features, len(bucket))
             except Exception as exc:
-                self._prune_unowned_runtime_prompts()
+                self._trim_runtime_prompts()
                 if isinstance(exc, RuntimeError) and str(exc).startswith("MiniCPMO45Code2WavBatchError "):
                     raise
                 raise _batch_error(
@@ -624,7 +642,7 @@ class MiniCPMO45Code2Wav(nn.Module):
                     error=str(exc),
                 ) from exc
             if len(states) != len(bucket):
-                self._prune_unowned_runtime_prompts()
+                self._trim_runtime_prompts()
                 raise _batch_error(
                     "backend_result_size_mismatch",
                     expected=len(bucket),
@@ -657,7 +675,7 @@ class MiniCPMO45Code2Wav(nn.Module):
                     last_chunk=bucket[0].last_chunk,
                 )
             except Exception as exc:
-                self._prune_unowned_runtime_prompts()
+                self._trim_runtime_prompts()
                 if isinstance(exc, RuntimeError) and str(exc).startswith("MiniCPMO45Code2WavBatchError "):
                     raise
                 raise _batch_error(
@@ -667,7 +685,7 @@ class MiniCPMO45Code2Wav(nn.Module):
                     error=str(exc),
                 ) from exc
             if len(audios) != batch_size or len(next_states) != batch_size:
-                self._prune_unowned_runtime_prompts()
+                self._trim_runtime_prompts()
                 raise _batch_error(
                     "backend_result_size_mismatch",
                     expected=batch_size,
@@ -775,4 +793,7 @@ class MiniCPMO45Code2Wav(nn.Module):
             )
         finally:
             torch.set_default_dtype(previous_dtype)
-        self.backend = BatchedToken2Wav(token2wav)
+        self.backend = BatchedToken2Wav(
+            token2wav,
+            setup_cache_size=self._setup_cache_size,
+        )


### PR DESCRIPTION
参赛队伍：EVA

## Purpose

MiniCPM-o 4.5 Code2Wav currently drops request-provided reference-prompt
artifacts as soon as the last owner finishes. A following request with the
same reference audio therefore repeats both prompt feature extraction and the
prompt-conditioned CFM setup, even though neither depends on generated codec
tokens.

This PR adds two bounded, output-preserving caches:

- an owner-aware LRU for content-addressed runtime prompts; active prompts are
  never evicted, and the cache is trimmed as owners finish;
- an exact-shape setup-state LRU keyed by prompt identity and batch size.

`decode_batch` treats cached setup states as read-only and creates new request
state, so a hit needs no device-to-device clone. Eviction removes the WAV,
prompt features, and matching setup states together. The two capacities are
independently configurable; setting both to zero restores the previous
lifecycle. The shipped MiniCPM-o 4.5 deploy config uses runtime/setup capacities
of `4/1`.

This does not change model weights, sampling, CFM step count, codec chunking,
prompt text, or generated audio length.

## Test Plan

Unit and lint:

```bash
pytest -q tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
pre-commit run --files \
  tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py \
  vllm_omni/deploy/minicpmo_4_5.yaml \
  vllm_omni/model_executor/models/minicpmo_4_5/batched_token2wav.py \
  vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
```

The tests cover exact-batch hits, batch-size keys, LRU replacement, read-only
state preservation, explicit prompt eviction, sequential-reference reuse,
owner-safe capacity overflow, and output identity.

910B benchmark server:

```bash
vllm serve /models/MiniCPM-o-4_5 --omni \
  --host 0.0.0.0 --port 18131 \
  --deploy-config vllm_omni/deploy/minicpmo_4_5.yaml \
  --trust-remote-code \
  --served-model-name openbmb/MiniCPM-o-4_5
```

Benchmark command:

```bash
vllm bench serve --omni --trust-remote-code \
  --host 127.0.0.1 --port 18131 \
  --model openbmb/MiniCPM-o-4_5 \
  --tokenizer /models/MiniCPM-o-4_5 \
  --backend openai-chat-omni \
  --endpoint /v1/chat/completions \
  --dataset-name seed-tts \
  --dataset-path /workspace/datasets/seed-tts-eval \
  --seed-tts-locale zh --no-oversample --disable-shuffle \
  --num-prompts 32 --num-warmups 2 \
  --max-concurrency 1 --request-rate inf \
  --extra-body '{"chat_template_kwargs":{"use_tts_template":true,"enable_thinking":false},"modalities":["text","audio"]}' \
  --metric-percentiles 0,50,99 \
  --percentile-metrics ttft,e2el,audio_rtf,audio_ttfp,audio_duration \
  --save-result --save-detailed --result-dir <result-dir>
```

The baseline and candidate used the same source commit and deploy config. The
only A/B change was
`token2wav_runtime_prompt_cache_size/token2wav_setup_cache_size = 0/0`
versus `4/1`. Each arm ran two measured rounds; every round had two warmup
requests. A final baseline restart/run was added as a B-O-B order check.

**vLLM Version:** `0.1.dev1+ge5588e49b.empty`

**vLLM-Omni Commit:** `34e2f50cfddba10656ab4297704754c508d206ee`

## Test Result

Environment: 1x Ascend 910B3 (64 GiB HBM), Python 3.12.13, CANN 9.0.0
(`V100R001C10SPC001B250`), torch 2.10.0+cpu package build, torch-npu
2.10.0, and vllm-ascend `0.19.1rc2.dev1014+g8092d3f66`.

Two-round mean, with the per-round range in parentheses:

| Metric | Cache off (`0/0`) | Cache on (`4/1`) | Change |
| --- | ---: | ---: | ---: |
| Mean audio RTF | 1.0186 (0.9173-1.1199) | 0.7838 (0.7758-0.7917) | -23.1% |
| Mean audio TTFP | 2193.5 ms (1961.5-2425.6) | 1456.3 ms (1445.3-1467.4) | -33.6% |
| Benchmark duration | 135.61 s (122.51-148.72) | 105.21 s (104.24-106.17) | -22.4% |
| Successful requests | 64/64 | 64/64 | no failures |
| Observed HBM | 44,046 MB | 44,926 MB | +880 MB (+2.0%) |

The post-candidate baseline recheck measured mean RTF `0.9538` and mean audio
TTFP `1991.8 ms`, confirming the gain after reversing arm order. Across all
five measured runs, generated text, input/output token lengths, total audio
frames (`3,255,360` per run), and total audio duration (`135.64 s` per run)
were identical; streaming continuity was 100%.

- Pytest: `32 passed, 15 warnings in 0.37s`.
- All applicable pre-commit hooks passed, including YAML, ruff check/format,
  typos, test marks, and pickle-import checks.
- `git diff --check` passed; the branch is based directly on the current
  `minicpm-challenge` head.


## Workload dependence and 910C follow-up

The cache benefit depends on reference-prompt reuse. The ranked benchmark reads the first 32 rows of `seedtts_testset/zh/meta.lst` with `disable_shuffle: true`; those rows contain 16 distinct prompt WAVs, each appearing twice, so roughly half of the requests hit the cache. With all-distinct references, the cache contribution converges toward zero; with one reference reused across a session, the benefit is larger.

A follow-up reproduction on an Atlas A3 (910C) used the same `ecd9d99da` source for both arms, with this PR (including its two YAML defaults) as the only difference. Across two die-swapped rounds, all 32 requests succeeded and TTFP improved by 169.4 ms and 192.7 ms (mean about 180 ms); the RTF delta changed sign when the dies were swapped, so it is not treated as a stable signal. The reproduction also produced 435 output tokens and 135.64 s of audio in every arm.
