### PR TITLE
[Model] Per-branch TeaCache for N-branch CFG and SenseNova-U1

### DIFF
--- a/docs/design/feature/teacache.md
+++ b/docs/design/feature/teacache.md
@@ -31,18 +31,17 @@ vLLM-omni provides a **hook-based** TeaCache system that requires **zero changes
 The TeaCache system consists of three main components:
 
 | Component | Purpose | Location |
-|-----------|---------|----------|
+| ----------- | --------- | ---------- |
 | [`CacheContext`](https://docs.vllm.ai/projects/vllm-omni/en/latest/api/vllm_omni/diffusion/cache/#vllm_omni.diffusion.cache.CacheContext) | Dataclass containing model-specific information for caching | `vllm_omni/diffusion/cache/teacache/context.py` |
 | [`EXTRACTOR_REGISTRY`](https://docs.vllm.ai/projects/vllm-omni/en/latest/api/vllm_omni/diffusion/cache/teacache/extractors/#vllm_omni.diffusion.cache.teacache.extractors.EXTRACTOR_REGISTRY) | Maps transformer class names to extractor functions | `vllm_omni/diffusion/cache/teacache/extractors.py` |
 | [`TeaCacheConfig`](https://docs.vllm.ai/projects/vllm-omni/en/latest/api/vllm_omni/diffusion/cache/#vllm_omni.diffusion.cache.TeaCacheConfig) | Configuration including thresholds and polynomial coefficients | `vllm_omni/diffusion/cache/teacache/config.py` |
 
 The hook handles all caching logic automatically, including:
 
-- CFG-aware state management (separate states for positive/negative branches)
+- CFG-aware state management (separate cache state per branch)
 - CFG-parallel compatibility
 - L1 distance computation with polynomial rescaling
 - Residual caching and reuse
-
 
 ---
 
@@ -57,6 +56,7 @@ To add TeaCache support for a new model, you need to:
 ### Step 1: Model-Specific Preprocessing
 
 Extract and process model inputs. This typically involves:
+
 - Embedding image/latent inputs
 - Processing text encoder outputs (if dual-stream)
 - Creating timestep embeddings
@@ -196,14 +196,14 @@ Package all information into a `CacheContext` object.
 **CacheContext Fields:**
 
 | Field | Type | Purpose |
-|-------|------|---------|
+| ------- | ------ | --------- |
 | `modulated_input` | `torch.Tensor` | Tensor used for cache decision (similarity comparison) |
 | `hidden_states` | `torch.Tensor` | Current hidden states (will be modified by caching) |
-| `encoder_hidden_states` | `torch.Tensor | None` | Encoder states for dual-stream models, `None` for single-stream |
+| `encoder_hidden_states` | `torch.Tensor \| None` | Encoder states for dual-stream models, `None` for single-stream |
 | `temb` | `torch.Tensor` | Timestep embedding tensor |
 | `run_transformer_blocks` | `Callable[[], tuple]` | Executes transformer blocks, returns `(hidden_states, [encoder_hidden_states])` |
 | `postprocess` | `Callable[[torch.Tensor], Any]` | Applies final transformations to produce model output |
-| `extra_states` | `dict | None` | Optional dict for additional model-specific state |
+| `extra_states` | `dict \| None` | Optional dict for additional model-specific state |
 
 ### Step 6: Register the Extractor
 
@@ -239,7 +239,6 @@ _MODEL_COEFFICIENTS = {
 }
 ```
 
-
 **Initial approach:** Start with coefficients from a similar model architecture, then tune empirically following [Customization](#customization) section.
 
 ---
@@ -258,10 +257,10 @@ The polynomial coefficients rescale L1 distances between consecutive modulated i
 - Training data characteristics
 - Noise prediction behavior across timesteps
 
-| Approach | Performance | Effort |
-|----------|-------------|--------|
-| Using defaults from similar model | Within 5-10% of optimal | Low |
-| Estimating custom coefficients | Best performance | Medium |
+| Approach                          | Performance             | Effort |
+| --------------------------------- | ----------------------- | ------ |
+| Using defaults from similar model | Within 5-10% of optimal | Low    |
+| Estimating custom coefficients    | Best performance        | Medium |
 
 #### Implement Data Collection Adapter
 
@@ -330,6 +329,7 @@ print(f"Estimated coefficients: {coeffs}")
 ```
 
 Note: some models may require the vLLM context and config to be initialized to initialize vLLM modules. To this end, you may need a workaround like the following to be able to run coefficient estimation.
+
 ```python
 from vllm_omni.diffusion.forward_context import set_forward_context
 from vllm_omni.diffusion.distributed.parallel_state import (
@@ -360,11 +360,10 @@ if __name__ == "__main__":
         <create the estimator + run estimation here>
 ```
 
-
 **Data Statistics Guide:**
 
 | Metric | Good Range | Warning Signs |
-|--------|------------|---------------|
+| -------- | ------------ | --------------- |
 | **Count** | 2000-5000+ | < 1000: too few prompts |
 | **Input Diffs (x)** | 0.01-0.10 | Very small (<0.001): model may not modulate properly |
 | **Output Diffs (y)** | Should correlate with x | No correlation: check extractor |
@@ -418,6 +417,7 @@ See more detailed examples in [user guide for teacache](../../user_guide/diffusi
 **Problem:** The transformer class name doesn't exist in `EXTRACTOR_REGISTRY`.
 
 **Solution:** Check the class name and add to registry:
+
 ```python
 # Check transformer class name
 print(pipeline.transformer.__class__.__name__)
@@ -439,6 +439,7 @@ EXTRACTOR_REGISTRY["YourTransformer2DModel"] = extract_your_context
 - **Missing coefficients in config:**
 
 **Solution:** Add coefficients to `_MODEL_COEFFICIENTS` in `config.py`, or pass custom coefficients:
+
 ```python
 omni = Omni(
     model="your-model",
@@ -458,6 +459,7 @@ omni = Omni(
 **Problem:** `rel_l1_thresh` is too aggressive, causing cache reuse when outputs differ significantly.
 
 **Solution:** Lower the threshold:
+
 ```python
 cache_config={"rel_l1_thresh": 0.1}  # Try 0.1-0.2
 ```
@@ -473,7 +475,7 @@ cache_config={"rel_l1_thresh": 0.1}  # Try 0.1-0.2
 Complete examples in the codebase:
 
 | Model | Path | Pattern | Notes |
-|-------|------|---------|-------|
+| ------- | ------ | --------- | ------- |
 | **Qwen-Image** | `vllm_omni/diffusion/cache/teacache/extractors.py` | Dual-stream | `extract_qwen_context` |
 | **Bagel** | `vllm_omni/diffusion/cache/teacache/extractors.py` | Omni model | `extract_bagel_context` |
 | **TeaCache Core** | `vllm_omni/diffusion/cache/teacache/` | Base implementation | Hook and config |

--- a/tests/diffusion/distributed/test_cfg_parallel.py
+++ b/tests/diffusion/distributed/test_cfg_parallel.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Tests for CFG (Classifier-Free Guidance) parallel functionality.
 
 CPU tests mock the CFG process group and validate mixin logic without GPUs.
@@ -10,6 +10,7 @@ real multi-GPU CFG parallel under fixed seeds.
 from __future__ import annotations
 
 import os
+from contextlib import contextmanager
 from typing import Any
 
 import pytest
@@ -25,6 +26,7 @@ from vllm_omni.diffusion.distributed.parallel_state import (
     init_distributed_environment,
     initialize_model_parallel,
 )
+from vllm_omni.diffusion.forward_context import get_forward_context, is_forward_context_available, set_forward_context
 from vllm_omni.platforms import current_omni_platform
 
 _L4_TWO_GPU = hardware_marks(res={"cuda": "L4"}, num_cards=2)
@@ -345,6 +347,7 @@ def _run_multi_branch_cfg_parallel_mock(
         branch_preds=branch_preds,
     )
 
+    assignments = _dispatch_branches(len(branches_kwargs), cfg_world_size)
     outputs: list[torch.Tensor] = []
     for cfg_rank in range(cfg_world_size):
         fake_group = FakeMultiBranchCfgGroup(
@@ -353,13 +356,15 @@ def _run_multi_branch_cfg_parallel_mock(
             slots_per_rank=slots_per_rank,
         )
         _patch_cfg_state(monkeypatch, world_size=cfg_world_size, rank=cfg_rank, fake_group=fake_group)
-        with torch.no_grad():
+        assigned = assignments[cfg_rank]
+        with set_forward_context(), torch.no_grad(), _record_cfg_branch_ids(pipeline) as branch_ids:
             output = pipeline.predict_noise_with_multi_branch_cfg(
                 do_true_cfg=True,
                 true_cfg_scale=true_cfg_scale,
                 branches_kwargs=branches_kwargs,
                 cfg_normalize=cfg_normalize,
             )
+        assert branch_ids == (assigned if assigned else [None])
         assert output is not None
         outputs.append(output)
 
@@ -386,6 +391,23 @@ def _build_pipeline_on_device(
     pipeline.transformer = pipeline.transformer.to(device=device, dtype=dtype)
     pipeline.transformer.eval()
     return pipeline
+
+
+@contextmanager
+def _record_cfg_branch_ids(pipeline: CFGParallelMixin):
+    """Record ForwardContext.cfg_branch_id for each predict_noise call."""
+    seen: list[int | None] = []
+    original = pipeline.predict_noise
+
+    def _predict_noise(*args: Any, **kwargs: Any):
+        seen.append(get_forward_context().cfg_branch_id if is_forward_context_available() else None)
+        return original(*args, **kwargs)
+
+    pipeline.predict_noise = _predict_noise  # type: ignore[method-assign]
+    try:
+        yield seen
+    finally:
+        del pipeline.predict_noise
 
 
 # ---------------------------------------------------------------------------
@@ -424,7 +446,7 @@ def test_predict_noise_with_cfg(
         rank=0,
         fake_group=FakeCfgGroup(world_size=1, rank_in_group=0, rank_tensors=[]),
     )
-    with torch.no_grad():
+    with set_forward_context(), torch.no_grad(), _record_cfg_branch_ids(pipeline) as branch_ids:
         baseline = pipeline.predict_noise_maybe_with_cfg(
             do_true_cfg=True,
             true_cfg_scale=7.5,
@@ -433,6 +455,7 @@ def test_predict_noise_with_cfg(
             cfg_normalize=cfg_normalize,
             kwargs=extra_kwargs,
         )
+    assert branch_ids == [0, 1]
 
     parallel = _run_two_branch_cfg_parallel_mock(
         pipeline,
@@ -470,7 +493,7 @@ def test_predict_noise_without_cfg():
         input_seed=123,
     )
 
-    with torch.no_grad():
+    with set_forward_context(), torch.no_grad(), _record_cfg_branch_ids(pipeline) as branch_ids:
         noise_pred = pipeline.predict_noise_maybe_with_cfg(
             do_true_cfg=False,
             true_cfg_scale=7.5,
@@ -478,6 +501,7 @@ def test_predict_noise_without_cfg():
             negative_kwargs=None,
             cfg_normalize=False,
         )
+    assert branch_ids == [0]
 
     assert noise_pred is not None
     assert noise_pred.shape == (1, 4, 16, 16)
@@ -488,7 +512,7 @@ def test_predict_noise_without_cfg():
 @pytest.mark.cpu
 @pytest.mark.parametrize(
     "cfg_parallel_size,n_branches",
-    [(2, 2), (2, 3), (3, 3), (2, 4)],
+    [(2, 2), (2, 3), (3, 2), (3, 3), (2, 4)],
 )
 @pytest.mark.parametrize("batch_size", [2])
 @pytest.mark.parametrize("cfg_normalize", [False, True])
@@ -526,13 +550,14 @@ def test_predict_noise_with_multi_branch_cfg(
         rank=0,
         fake_group=FakeCfgGroup(world_size=1, rank_in_group=0, rank_tensors=[]),
     )
-    with torch.no_grad():
+    with set_forward_context(), torch.no_grad(), _record_cfg_branch_ids(pipeline) as branch_ids:
         baseline = pipeline.predict_noise_with_multi_branch_cfg(
             do_true_cfg=True,
             true_cfg_scale=cfg_scale,
             branches_kwargs=branches_kwargs,
             cfg_normalize=cfg_normalize,
         )
+    assert branch_ids == list(range(n_branches))
 
     parallel = _run_multi_branch_cfg_parallel_mock(
         pipeline,
@@ -578,13 +603,14 @@ def test_multi_branch_without_cfg():
         input_seed=123,
     )
 
-    with torch.no_grad():
+    with set_forward_context(), torch.no_grad(), _record_cfg_branch_ids(pipeline) as branch_ids:
         noise_pred = pipeline.predict_noise_with_multi_branch_cfg(
             do_true_cfg=False,
             true_cfg_scale=5.0,
             branches_kwargs=branches_kwargs,
             cfg_normalize=False,
         )
+    assert branch_ids == [0]
 
     assert noise_pred is not None
     assert noise_pred.shape == (1, 4, 16, 16)

--- a/vllm_omni/diffusion/cache/teacache/hook.py
+++ b/vllm_omni/diffusion/cache/teacache/hook.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 """
 Hook-based TeaCache implementation for vLLM-Omni.
@@ -12,6 +12,7 @@ to support new models.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -24,6 +25,7 @@ from vllm_omni.diffusion.distributed.parallel_state import (
     get_classifier_free_guidance_rank,
     get_classifier_free_guidance_world_size,
 )
+from vllm_omni.diffusion.forward_context import get_forward_context, is_forward_context_available
 from vllm_omni.diffusion.hooks import HookRegistry, ModelHook, StateManager
 
 
@@ -37,7 +39,7 @@ class TeaCacheHook(ModelHook):
 
     Key features:
     - Zero changes to model code
-    - CFG-aware with separate states for positive/negative branches
+    - CFG-aware with separate state per branch (N-branch via ForwardContext)
     - CFG-parallel compatible: properly detects branch identity across ranks
     - Model-specific polynomial rescaling
     - Auto-detection of model types
@@ -62,7 +64,7 @@ class TeaCacheHook(ModelHook):
         self.config = config
         self.rescale_func = np.poly1d(config.coefficients)
         self.state_manager = StateManager(TeaCacheState)
-        self.extractor_fn = None
+        self.extractor_fn: Callable[..., Any] | None = None
         self._forward_cnt = 0
 
     def initialize_hook(self, module: torch.nn.Module) -> torch.nn.Module:
@@ -112,23 +114,29 @@ class TeaCacheHook(ModelHook):
         """
         # Get model-specific context from extractor
         # The extractor encapsulates ALL model-specific logic
+        if self.extractor_fn is None:
+            raise RuntimeError("TeaCacheHook.initialize_hook must be called before forward")
         ctx = self.extractor_fn(module, *args, **kwargs)
 
         # ============================================================================
         # GENERIC CACHING LOGIC (works for all models)
         # ============================================================================
-        # Set context based on CFG branch for separate state tracking
-        # With CFG-parallel, each rank processes only one branch:
-        #   - cfg_rank 0: positive branch
-        #   - cfg_rank > 0: negative branch
-        # Without CFG-parallel, branches alternate within a single rank
-        if getattr(module, "do_true_cfg", False):
+        # Prefer an explicit CFG branch id from ForwardContext (set by
+        # sequential CFG mixin dispatch / denoise loops). This supports
+        # N-branch CFG without assuming module layout. Untagged models fall
+        # back to the legacy heuristic.
+        branch_id = None
+        if is_forward_context_available():
+            branch_id = get_forward_context().cfg_branch_id
+
+        if branch_id is not None:
+            cache_branch = f"branch_{branch_id}"
+        elif getattr(module, "do_true_cfg", False):
             cfg_parallel_size = get_classifier_free_guidance_world_size()
             if cfg_parallel_size > 1:
                 cfg_rank = get_classifier_free_guidance_rank()
-                cache_branch = "negative" if cfg_rank > 0 else "positive"
+                cache_branch = f"branch_rank_{cfg_rank}"
             else:
-                # No CFG-parallel: use forward counter to alternate branches
                 cache_branch = "negative" if self._forward_cnt % 2 == 1 else "positive"
         else:
             cache_branch = "positive"

--- a/vllm_omni/diffusion/distributed/cfg_parallel.py
+++ b/vllm_omni/diffusion/distributed/cfg_parallel.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 """
 Base pipeline class for Diffusion models with shared CFG functionality.
@@ -17,6 +17,7 @@ from vllm_omni.diffusion.distributed.parallel_state import (
     get_classifier_free_guidance_rank,
     get_classifier_free_guidance_world_size,
 )
+from vllm_omni.diffusion.forward_context import use_cfg_branch_id
 
 logger = init_logger(__name__)
 
@@ -105,6 +106,8 @@ class CFGParallelMixin(metaclass=ABCMeta):
             logic and set self.scheduler to a composite scheduler.
         """
         if do_true_cfg:
+            if negative_kwargs is None:
+                raise ValueError("negative_kwargs is required when do_true_cfg is True")
             # Automatically detect CFG parallel configuration
             cfg_parallel_ready = get_classifier_free_guidance_world_size() > 1
 
@@ -138,8 +141,10 @@ class CFGParallelMixin(metaclass=ABCMeta):
                 )
             else:
                 # Sequential CFG: compute both positive and negative
-                positive_noise_pred = _wrap(self.predict_noise(**positive_kwargs))
-                negative_noise_pred = _wrap(self.predict_noise(**negative_kwargs))
+                with use_cfg_branch_id(0):
+                    positive_noise_pred = _wrap(self.predict_noise(**positive_kwargs))
+                with use_cfg_branch_id(1):
+                    negative_noise_pred = _wrap(self.predict_noise(**negative_kwargs))
 
                 if output_slice is not None:
                     positive_noise_pred = _slice_pred(positive_noise_pred, output_slice)
@@ -154,7 +159,8 @@ class CFGParallelMixin(metaclass=ABCMeta):
                 )
         else:
             # No CFG: only compute positive/conditional prediction
-            pred = self.predict_noise(**positive_kwargs)
+            with use_cfg_branch_id(0):
+                pred = self.predict_noise(**positive_kwargs)
             if output_slice is not None:
                 pred = _unwrap(_slice_pred(_wrap(pred), output_slice))
             return pred
@@ -268,15 +274,17 @@ class CFGParallelMixin(metaclass=ABCMeta):
             else:
                 # Sequential: run all N branches on single device
                 preds: list[torch.Tensor | tuple[torch.Tensor, ...]] = []
-                for kw in branches_kwargs:
-                    pred = _wrap(self.predict_noise(**kw))
+                for bid, kw in enumerate(branches_kwargs):
+                    with use_cfg_branch_id(bid):
+                        pred = _wrap(self.predict_noise(**kw))
                     if output_slice is not None:
                         pred = _slice_pred(pred, output_slice)
                     preds.append(_unwrap(pred))
                 return self.combine_multi_branch_cfg_noise(preds, true_cfg_scale, cfg_normalize)
         else:
             # No CFG: only compute positive/conditional prediction
-            pred = self.predict_noise(**branches_kwargs[0])
+            with use_cfg_branch_id(0):
+                pred = self.predict_noise(**branches_kwargs[0])
             if output_slice is not None:
                 pred = _unwrap(_slice_pred(_wrap(pred), output_slice))
             return pred
@@ -307,10 +315,11 @@ class CFGParallelMixin(metaclass=ABCMeta):
         my_branch_ids = assignments[cfg_rank]
         max_per_rank = max(len(a) for a in assignments)
 
-        # Run assigned branches
+        # Run assigned branches. Tag by branch id.
         my_preds: list[tuple[torch.Tensor, ...]] = []
         for bid in my_branch_ids:
-            pred = _wrap(self.predict_noise(**branches_kwargs[bid]))
+            with use_cfg_branch_id(bid):
+                pred = _wrap(self.predict_noise(**branches_kwargs[bid]))
             if output_slice is not None:
                 pred = _slice_pred(pred, output_slice)
             my_preds.append(pred)
@@ -395,7 +404,7 @@ class CFGParallelMixin(metaclass=ABCMeta):
             Non-last Pipeline Parallel stages return `IntermediateTensors`
             instead of final noise tensors wrapped in a tuple.
         """
-        result = self.transformer(*args, **kwargs)
+        result = self.transformer(*args, **kwargs)  # type: ignore
         return result if isinstance(result, IntermediateTensors) else result[0]
 
     def diffuse(

--- a/vllm_omni/diffusion/forward_context.py
+++ b/vllm_omni/diffusion/forward_context.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 from __future__ import annotations
 
 from contextlib import contextmanager
@@ -36,6 +39,10 @@ class ForwardContext:
     denoise_timestep: float | None = None
     # Per-request reference latent for img2img DiT models (e.g. Ming)
     ref_latent: torch.Tensor | None = None
+    # Active CFG branch id for the current predict_noise / DiT forward.
+    # Set by CFG dispatch (or model denoise loops) so caches like TeaCache can
+    # keep independent state per branch without assuming module layout.
+    cfg_branch_id: int | None = None
     # whether to split the text embed in sequence parallel, if True, the text embed will be split in sequence parallel
 
     # Sequence Parallel padding support
@@ -285,3 +292,17 @@ def set_forward_context_ref_latent(ref_latent: torch.Tensor | None) -> None:
     """
     if _forward_context is not None:
         _forward_context.ref_latent = ref_latent
+
+
+@contextmanager
+def use_cfg_branch_id(branch_id: int | None):
+    """Temporarily tag the current forward with a CFG branch id."""
+    if _forward_context is None:
+        yield
+        return
+    prev = _forward_context.cfg_branch_id
+    _forward_context.cfg_branch_id = branch_id
+    try:
+        yield
+    finally:
+        _forward_context.cfg_branch_id = prev

--- a/vllm_omni/diffusion/models/sensenova_u1/pipeline_sensenova_u1.py
+++ b/vllm_omni/diffusion/models/sensenova_u1/pipeline_sensenova_u1.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """SenseNova-U1 Pipeline for vLLM-Omni.
 
 SenseNova-U1 is a unified Qwen3-based model that uses Mixture-of-Tokenizers
@@ -667,8 +667,7 @@ class SenseNovaU1Pipeline(nn.Module, SupportsComponentDiscovery, DiffusionPipeli
         **_kw,
     ):
         B, L = z.shape[0], z.shape[1]
-        denoising_model = self.language_model if cache_dit_skip else self.denoising_transformer
-        outputs = denoising_model(
+        outputs = self.denoising_transformer(
             inputs_embeds=input_embeds,
             image_gen_indicators=torch.ones(
                 (input_embeds.shape[0], input_embeds.shape[1]), dtype=torch.bool, device=input_embeds.device
@@ -1044,25 +1043,21 @@ class SenseNovaU1Pipeline(nn.Module, SupportsComponentDiscovery, DiffusionPipeli
 
     def _denoise(self, image_prediction, ns, t, z, image_embeds, caches, p, step_i, is_it2i):
         if not is_it2i:
-            has_cached_partner = t >= p.cfg_interval[0] and t <= p.cfg_interval[1] and p.cfg_scale > 1
+            do_true_cfg = t >= p.cfg_interval[0] and t <= p.cfg_interval[1] and p.cfg_scale > 1
             cond_kwargs = self._get_cfg_kwargs(
-                caches, image_embeds, t, z, ns, p, branch="cond", cache_dit_skip=not has_cached_partner
+                caches, image_embeds, t, z, ns, p, branch="cond", cache_dit_skip=not do_true_cfg
             )
-
-            in_interval = t >= p.cfg_interval[0] and t <= p.cfg_interval[1]
-            if not (in_interval and p.cfg_scale > 1):
-                return self.predict_noise(**cond_kwargs)
-
-            uncond_kwargs = self._get_cfg_kwargs(caches, image_embeds, t, z, ns, p, branch="uncond")
-            noise_pred = self.predict_noise_maybe_with_cfg(
-                do_true_cfg=True,
+            uncond_kwargs = (
+                self._get_cfg_kwargs(caches, image_embeds, t, z, ns, p, branch="uncond") if do_true_cfg else None
+            )
+            return self.predict_noise_maybe_with_cfg(
+                do_true_cfg=do_true_cfg,
                 true_cfg_scale=p.cfg_scale,
                 positive_kwargs=cond_kwargs,
                 negative_kwargs=uncond_kwargs,
                 cfg_normalize=p.cfg_norm,
                 kwargs={"step_i": step_i, "is_it2i": is_it2i},
             )
-            return noise_pred
         else:
             use_cfg = (t > p.cfg_interval[0] and t < p.cfg_interval[1]) or p.cfg_interval[0] == 0
             needs_cfg = p.cfg_scale != 1 or p.img_cfg_scale != 1
@@ -1072,7 +1067,12 @@ class SenseNovaU1Pipeline(nn.Module, SupportsComponentDiscovery, DiffusionPipeli
             )
 
             if not use_cfg or not needs_cfg:
-                return self.predict_noise(**cond_kwargs)
+                return self.predict_noise_maybe_with_cfg(
+                    do_true_cfg=False,
+                    true_cfg_scale=1.0,
+                    positive_kwargs=cond_kwargs,
+                    negative_kwargs=None,
+                )
 
             cfg_norm = p.cfg_norm if (p.cfg_scale > 1 or p.img_cfg_scale > 1) else None
             if p.img_cfg_scale == 1:
@@ -1096,6 +1096,8 @@ class SenseNovaU1Pipeline(nn.Module, SupportsComponentDiscovery, DiffusionPipeli
                     kwargs={"is_it2i": is_it2i},
                 )
             else:
+                # CacheDiT still cannot track 3-way CFG; skip that backend on
+                # img_cond. TeaCache is tagged per branch and caches all three.
                 image_cond_kwargs = self._get_cfg_kwargs(
                     caches, image_embeds, t, z, ns, p, branch="img_cond", cache_dit_skip=True
                 )


### PR DESCRIPTION
## Purpose

- Implements [#2371](https://github.com/vllm-project/vllm-omni/issues/2371): tag each DiT forward with `ForwardContext.cfg_branch_id` from sequential `CFGParallelMixin` dispatch so TeaCache keeps independent state per branch. Tagging limited to multi-branch CFG cases, so existing paths remain unchanged and is backward compatible.
- SenseNova: route denoise through the CFG mixin so IT2I 3-branch CFG (`cond` / `img_cond` / `uncond`) is tagged; TeaCache covers all three branches.

Related:

- [#5287](https://github.com/vllm-project/vllm-omni/pull/5287) also implements [#2371](https://github.com/vllm-project/vllm-omni/issues/2371) by tagging `transformer._teacache_branch_id`. This PR tags `ForwardContext` instead so models without a `transformer` attr still work. This PR also wires SenseNova I2I to demonstrate the potential performance gains

## Test Plan

**vLLM Version:** 0.27.1

**vLLM-Omni Commit:** 5b1a976ec3a7e7ea31ad85e57a15fa5a1be5aeab

- Unit: `tests/diffusion/distributed/test_cfg_parallel.py` (CPU) — N-branch CFG-parallel parity; sequential `cfg_branch_id` tagging.
- E2E: SenseNova-U1 T2I/I2I, `none` vs `tea_cache`, plus I2I `--cfg-parallel-size 3`.

## Test Result

Unit tests in `test_cfg_parallel.py` passed.

E2E vs `main` on SenseNova-U1 (same 10 eval seeds) on H100. **T2I** is 2-branch CFG; **I2I** is 3-branch CFG (`cond` / `img_cond` / `uncond`). `cfgp=1` is sequential; `cfgp=3` splits CFG branches across 3 GPUs. Test script: https://gist.github.com/yzong-rh/327fb9e53dee2acae62b1f26deb94446

| Mode | Cache | cfgp | Latency (main -> this) | Quality |
|---|---|---|---|---|
| T2I | none | 1 | 18.49s -> 18.49s  | pixel-identical to `main` |
| T2I | tea_cache | 1 | 7.87s -> 7.88s  | pixel-identical to `main` |
| I2I | none | 1 | 34.53s -> 34.54s  | pixel-identical to `main` |
| I2I | tea_cache | 1 | **22.85s -> 16.27s**  | not pixel-identical but close uncached |
| I2I | none | 3 | 34.02s  -> 33.60s | pixel-identical to `main` |
| I2I | tea_cache | 3 | **20.34s -> 14.58s**  | pixel-identical to sequential teacache |

I2I No Teacache:
<img width="8192" height="6144" alt="grid" src="https://github.com/user-attachments/assets/d0459155-f1a0-4843-8d59-a3b29216d511" />

I2I Teacache
<img width="8192" height="6144" alt="grid_cache" src="https://github.com/user-attachments/assets/2de4b161-5a21-47c3-a477-ffefb579de19" />



**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
