### PR TITLE
[Diffusion] Support resident layers with DLO AllGather

### DIFF
--- a/docs/user_guide/diffusion/offloader/distributed_layerwise_offload.md
+++ b/docs/user_guide/diffusion/offloader/distributed_layerwise_offload.md
@@ -62,7 +62,7 @@ omni = Omni(
 | `--data-parallel-size N` | DP ranks and AllGather weight-sharding group | `1` |
 | `--dlo-use-allgather` | Shard host weights and reconstruct with AllGather | `true` |
 | `--dlo-no-use-allgather` | Stream complete rank-local blocks without a DLO weight collective | `false` |
-| `--dlo-resident-layers N` | Keep N leading main-DiT blocks on device; requires no-AllGather and model-declared resident paths | `0` |
+| `--dlo-resident-layers N` | Keep N leading main-DiT blocks on device for the denoise stage; requires model-declared resident paths | `0` |
 | `--host-weight-runtime-mode {disabled,preferred,required}` | HWR policy: no interaction, populate on a miss, or require an exact hit | `disabled` |
 | `--host-weight-runtime-root PATH` | Writable node-local HWR store shared by workers in one storage domain; required for `preferred` and `required` | unset |
 | `--dlo-host-registration-limit-gib N` | Optional per-worker ceiling for registering an HWR mmap; zero adds no ceiling | `0` |
@@ -266,8 +266,10 @@ must enter each collective.
   complete FP8 model in host memory before DLO retains only its shard. Other
   online quantization methods require no-AllGather until their runtime layouts
   are validated.
-- Resident leading layers require `--dlo-no-use-allgather` and a model
-  `OffloadPlan` that declares eligible `resident_dit_paths`.
+- Resident leading layers require a model `OffloadPlan` that declares eligible
+  `resident_dit_paths`. In AllGather mode, each rank keeps only its host shard
+  and reconstructs resident layers once when the denoise stage starts; all
+  denoise steps then reuse the full device weights.
 - DP concurrency requires an explicit, identical inference-step count.
 
 Sharing quantized or otherwise unvalidated transformed layouts through a

--- a/tests/diffusion/offloader/test_distributed_layerwise_backend.py
+++ b/tests/diffusion/offloader/test_distributed_layerwise_backend.py
@@ -532,6 +532,62 @@ class TestDistributedLayerwiseOffloadHook:
 
 
 class TestPinnedResidentLayerGroup:
+    def test_allgather_reconstructs_once_per_denoise_stage(
+        self,
+        patched_offload_runtime,
+        monkeypatch,
+    ):
+        blocks = [nn.Linear(3, 2, bias=False), nn.Linear(3, 2, bias=False)]
+        expected = []
+        for index, block in enumerate(blocks):
+            block.weight.data.copy_(torch.arange(6, dtype=torch.float32).reshape(2, 3) + index * 10)
+            expected.append(block.weight.detach().clone())
+
+        process_group = object()
+        gathered = []
+
+        def fake_allgather(output, local_shard, *, group):
+            expected_weight = expected[len(gathered) % len(expected)].flatten()
+            assert group is process_group
+            assert torch.equal(local_shard, expected_weight[:3])
+            output.copy_(expected_weight)
+            gathered.append(output.detach().clone())
+
+        monkeypatch.setattr(torch.distributed, "all_gather_into_tensor", fake_allgather)
+        group = PinnedResidentLayerGroup(
+            blocks,
+            device=torch.device("cpu"),
+            copy_stream=DummyStream(),
+            comm_stream=DummyStream(),
+            pin_memory=False,
+            shard_group=process_group,
+            shard_world_size=2,
+            shard_rank=0,
+        )
+
+        assert all(block.weight.numel() == 0 for block in blocks)
+        assert all(state["cpu_shards"][torch.float32].numel() == 3 for state in group._states)
+
+        group.load()
+        assert len(gathered) == 2
+        for block, expected_weight in zip(blocks, expected):
+            assert torch.equal(block.weight, expected_weight)
+
+        # Repeated denoise steps reuse the reconstructed device weights.
+        group.load()
+        assert len(gathered) == 2
+
+        group.offload()
+        assert all(block.weight.numel() == 0 for block in blocks)
+        assert group._gpu_shard_buffers == []
+
+        # A new denoise stage reconstructs resident weights once again.
+        group.load()
+        assert len(gathered) == 4
+        for block, expected_weight in zip(blocks, expected):
+            assert torch.equal(block.weight, expected_weight)
+        group.offload()
+
     def test_load_offload_reuses_pinned_master_weights(self, patched_offload_runtime):
         blocks = [nn.Linear(2, 2), nn.Linear(2, 2)]
         expected = []
@@ -1997,7 +2053,7 @@ class TestConfigValidation:
         assert config.dp_size == 1  # forced to 1 when no AllGather
         assert config.dlo_resident_layers == 20
 
-    def test_resident_layers_with_allgather_rejected(self):
+    def test_resident_layers_with_allgather_preserve_shard_group(self):
         class FakePC:
             data_parallel_size = 2
             use_hsdp = False
@@ -2013,8 +2069,10 @@ class TestConfigValidation:
             parallel_config = FakePC()
             model = "/fake/path"
 
-        with pytest.raises(ValueError, match="requires --dlo-no-use-allgather"):
-            OffloadConfig.from_od_config(FakeODConfig())
+        config = OffloadConfig.from_od_config(FakeODConfig())
+        assert config.dp_size == 2
+        assert config.dlo_use_allgather
+        assert config.dlo_resident_layers == 20
 
     def test_num_inference_steps_none_rejected(self):
         """DP multi-concurrency should reject None num_inference_steps."""

--- a/vllm_omni/diffusion/offloader/base.py
+++ b/vllm_omni/diffusion/offloader/base.py
@@ -133,12 +133,6 @@ class OffloadConfig:
         )
         if dlo_resident_layers < 0:
             raise ValueError(f"dlo_resident_layers must be >= 0, got {dlo_resident_layers}")
-        if dlo_resident_layers and dlo_use_allgather:
-            raise ValueError(
-                "dlo_resident_layers currently requires --dlo-no-use-allgather so "
-                "resident blocks use weights prepared by the standard TP-aware loader"
-            )
-
         # If dlo_use_allgather=False, force dp_size=1 (each rank independent)
         if enable_distributed_layerwise_offload and not dlo_use_allgather:
             dp_size = 1

--- a/vllm_omni/diffusion/offloader/distributed_layerwise_backend.py
+++ b/vllm_omni/diffusion/offloader/distributed_layerwise_backend.py
@@ -91,6 +91,42 @@ def _forget_active_hwr_registration(
         ]
 
 
+def _stage_shards_and_allgather(
+    *,
+    cpu_shards: dict[torch.dtype, torch.Tensor],
+    gpu_shard_buffers: dict[torch.dtype, torch.Tensor],
+    full_gpu_buffers: dict[torch.dtype, torch.Tensor],
+    copy_stream: Any,
+    comm_stream: Any,
+    shard_group: torch.distributed.ProcessGroup,
+    shard_world_size: int,
+    non_blocking: bool,
+) -> Any:
+    """Copy local weight shards to device and reconstruct full buffers."""
+    local_gpu_shards: dict[torch.dtype, torch.Tensor] = {}
+    with current_omni_platform.stream(copy_stream):
+        for dtype, cpu_shard in cpu_shards.items():
+            local_gpu_shard = gpu_shard_buffers[dtype][: cpu_shard.numel()]
+            local_gpu_shard.copy_(
+                cpu_shard,
+                non_blocking=non_blocking,
+            )
+            local_gpu_shards[dtype] = local_gpu_shard
+
+    ready = current_omni_platform.Event()
+    comm_stream.wait_stream(copy_stream)
+    with current_omni_platform.stream(comm_stream):
+        for dtype, local_gpu_shard in local_gpu_shards.items():
+            output_numel = local_gpu_shard.numel() * shard_world_size
+            torch.distributed.all_gather_into_tensor(
+                full_gpu_buffers[dtype][:output_numel],
+                local_gpu_shard,
+                group=shard_group,
+            )
+        ready.record(comm_stream)
+    return ready
+
+
 # Threshold (in MB) for deciding whether a non-block DiT submodule should
 # use layerwise offload (streaming hooks) or be moved to GPU as a resident
 # module.  Submodules larger than this are offloaded to save HBM; smaller
@@ -260,16 +296,6 @@ class DistributedLayerwiseOffloadHook(ModelHook):
                         )
                     )
             self._cached_repoint.append(repoint)
-
-        # Pre-compute AG output sizes (avoid sum() per layer).
-        self._ag_output_sizes: dict[torch.dtype, int] = {}
-        for dtype, metas in self.metadata.items():
-            total_numel = sum(m["numel"] for m in metas)
-            if self.rank_local_mmap:
-                self._ag_output_sizes[dtype] = total_numel
-            else:
-                shard_numel = self.cpu_shards[dtype].numel()
-                self._ag_output_sizes[dtype] = shard_numel * self.dp_size if self.dp_size > 1 else total_numel
 
         return module
 
@@ -586,11 +612,11 @@ class DistributedLayerwiseOffloadHook(ModelHook):
         """
         self.copy_stream.wait_stream(current_omni_platform.current_stream())
 
-        evt = current_omni_platform.Event()
         gpu_weights = self.gpu_buffers[slot]
         assert gpu_weights is not None, f"gpu_buffers[{slot}] not allocated"
 
         if self.dp_size <= 1 or self.dp_group is None:
+            evt = current_omni_platform.Event()
             if self.rank_local_mmap and self.registered_mmap:
                 with current_omni_platform.stream(self.copy_stream):
                     self._copy_mmap_sources_to_device(
@@ -613,33 +639,18 @@ class DistributedLayerwiseOffloadHook(ModelHook):
                     # finished.  The shared event protects reuse by another hook.
                     self.cpu_staging_events[slot] = evt
         else:
-            gpu_shards: dict[torch.dtype, torch.Tensor] = {}
             shard_bufs = self.gpu_shard_buffers[slot]
             assert shard_bufs is not None, f"gpu_shard_buffers[{slot}] not allocated"
-            with current_omni_platform.stream(self.copy_stream):
-                for dtype, cpu_shard in self.cpu_shards.items():
-                    gpu_shard = shard_bufs[dtype][: cpu_shard.numel()]
-                    gpu_shard.copy_(cpu_shard, non_blocking=non_blocking)
-                    gpu_shards[dtype] = gpu_shard
-
-            self.comm_stream.wait_stream(self.copy_stream)
-            with current_omni_platform.stream(self.comm_stream):
-                for dtype, local_shard in gpu_shards.items():
-                    # Slice the shared (max-sized) output buffer down to this
-                    # block's actual AllGather output size. The buffers are
-                    # sized to the *largest* block across all groups, so for any
-                    # smaller block the full buffer would violate the
-                    # all_gather_into_tensor contract
-                    # (output.numel() == world_size * input.numel()).
-                    # Repoint offsets are relative to the block's flattened
-                    # buffer, so a prefix slice is safe.
-                    gw = gpu_weights[dtype][: self._ag_output_sizes[dtype]]
-                    torch.distributed.all_gather_into_tensor(
-                        gw,
-                        local_shard,
-                        group=self.dp_group,
-                    )
-                evt.record(self.comm_stream)
+            evt = _stage_shards_and_allgather(
+                cpu_shards=self.cpu_shards,
+                gpu_shard_buffers=shard_bufs,
+                full_gpu_buffers=gpu_weights,
+                copy_stream=self.copy_stream,
+                comm_stream=self.comm_stream,
+                shard_group=self.dp_group,
+                shard_world_size=self.dp_size,
+                non_blocking=non_blocking,
+            )
 
         self.ready_events[slot] = evt
         self._prefetch_done = evt
@@ -802,9 +813,11 @@ class PinnedResidentLayerGroup:
     leaving it only restores zero-sized placeholders and releases the device
     buffers.  This lets the following VAE stage reuse the same HBM.
 
-    The resident path is intentionally local-shard only.  With tensor
-    parallelism, the regular model loader has already produced each rank's TP
-    shard, so no DP AllGather is required or desirable here.
+    In no-AllGather mode, the regular model loader has already produced each
+    rank's complete rank-local tensors.  In AllGather mode, each rank keeps
+    only its DLO shard on host and reconstructs the selected layers once when
+    the denoise stage starts.  The full device weights are then reused by all
+    denoise steps and released before the following stage.
     """
 
     def __init__(
@@ -813,18 +826,32 @@ class PinnedResidentLayerGroup:
         device: torch.device,
         copy_stream: Any,
         pin_memory: bool,
+        shard_group: torch.distributed.ProcessGroup | None = None,
+        shard_world_size: int = 1,
+        shard_rank: int = 0,
+        comm_stream: Any | None = None,
         rank_local_mmap: bool = False,
         defer_staging: bool = False,
         tensor_transforms: dict[int, Any] | None = None,
     ) -> None:
         self.device = device
         self.copy_stream = copy_stream
+        self.comm_stream = comm_stream or current_omni_platform.Stream()
+        self.shard_group = shard_group
+        self.shard_world_size = shard_world_size
+        self.shard_rank = shard_rank
         self.loaded = False
         self.rank_local_mmap = rank_local_mmap
         self.registered_mmap = False
         self.pin_memory = pin_memory
         self._states: list[dict[str, Any]] = []
         self._gpu_buffers: list[dict[torch.dtype, torch.Tensor]] = []
+        self._gpu_shard_buffers: list[dict[torch.dtype, torch.Tensor]] = []
+
+        if rank_local_mmap and shard_world_size > 1:
+            raise ValueError("rank-local mmap resident layers do not support DLO AllGather")
+        if shard_world_size > 1 and shard_group is None:
+            raise ValueError("resident-layer AllGather requires a process group")
 
         for block in blocks:
             params = dict(block.named_parameters())
@@ -841,8 +868,8 @@ class PinnedResidentLayerGroup:
                 cpu_shards, metadata = DistributedLayerwiseOffloadHook._shard_and_pin(
                     params,
                     bufs,
-                    dp_size=1,
-                    rank=0,
+                    dp_size=shard_world_size,
+                    rank=shard_rank,
                     pin_memory=pin_memory,
                     tensor_transforms=tensor_transforms,
                 )
@@ -855,6 +882,12 @@ class PinnedResidentLayerGroup:
                     "metadata": metadata,
                 }
             )
+
+        logger.info(
+            "Prepared %d resident block(s) with %s",
+            len(self._states),
+            "stage-entry AllGather from DLO host shards" if self.shard_world_size > 1 else "rank-local host weights",
+        )
 
         self._cpu_staging_buffers: list[dict[torch.dtype, torch.Tensor]] = []
         self._cpu_staging_events: list[Any | None] = [None, None]
@@ -885,13 +918,51 @@ class PinnedResidentLayerGroup:
             block_buffers: dict[torch.dtype, torch.Tensor] = {}
             for dtype, metas in state["metadata"].items():
                 total = sum(meta["numel"] for meta in metas)
+                if self.shard_world_size > 1:
+                    total = state["cpu_shards"][dtype].numel() * self.shard_world_size
                 block_buffers[dtype] = torch.empty(total, dtype=dtype, device=self.device)
             gpu_buffers.append(block_buffers)
 
+        gpu_shard_buffers: list[dict[torch.dtype, torch.Tensor]] = []
+        if self.shard_world_size > 1:
+            max_shard_sizes: dict[torch.dtype, int] = {}
+            for state in self._states:
+                for dtype, shard in state["cpu_shards"].items():
+                    max_shard_sizes[dtype] = max(max_shard_sizes.get(dtype, 0), shard.numel())
+            for _ in range(min(2, len(self._states))):
+                gpu_shard_buffers.append(
+                    {
+                        dtype: torch.empty(numel, dtype=dtype, device=self.device)
+                        for dtype, numel in max_shard_sizes.items()
+                    }
+                )
+
         self.copy_stream.wait_stream(current_omni_platform.current_stream())
-        ready = current_omni_platform.Event()
-        with current_omni_platform.stream(self.copy_stream):
-            for index, (state, block_buffers) in enumerate(zip(self._states, gpu_buffers)):
+        ready: Any | None = None
+        slot_events: list[Any | None] = [None] * len(gpu_shard_buffers)
+        for index, (state, block_buffers) in enumerate(zip(self._states, gpu_buffers)):
+            if self.shard_world_size > 1:
+                slot = index % len(gpu_shard_buffers)
+                previous_gather = slot_events[slot]
+                if previous_gather is not None:
+                    self.copy_stream.wait_event(previous_gather)
+                if self.shard_group is None:
+                    raise RuntimeError("resident-layer AllGather process group is unavailable")
+                ready = _stage_shards_and_allgather(
+                    cpu_shards=state["cpu_shards"],
+                    gpu_shard_buffers=gpu_shard_buffers[slot],
+                    full_gpu_buffers=block_buffers,
+                    copy_stream=self.copy_stream,
+                    comm_stream=self.comm_stream,
+                    shard_group=self.shard_group,
+                    shard_world_size=self.shard_world_size,
+                    non_blocking=self.pin_memory,
+                )
+                slot_events[slot] = ready
+                continue
+
+            ready = current_omni_platform.Event()
+            with current_omni_platform.stream(self.copy_stream):
                 if self.rank_local_mmap and self.registered_mmap:
                     DistributedLayerwiseOffloadHook._copy_mmap_sources_to_device(
                         state["cpu_sources"],
@@ -899,34 +970,34 @@ class PinnedResidentLayerGroup:
                         block_buffers,
                         non_blocking=True,
                     )
-                    continue
-                if self.rank_local_mmap:
-                    slot = index % 2
-                    previous_copy = self._cpu_staging_events[slot]
-                    if previous_copy is not None:
-                        synchronize = getattr(previous_copy, "synchronize", None)
-                        if callable(synchronize):
-                            synchronize()
-                        else:
-                            current_omni_platform.synchronize()
-                    cpu_weights = DistributedLayerwiseOffloadHook._pack_mmap_sources(
-                        state["cpu_sources"],
-                        state["metadata"],
-                        self._cpu_staging_buffers[slot],
-                    )
                 else:
-                    cpu_weights = state["cpu_shards"]
+                    if self.rank_local_mmap:
+                        slot = index % 2
+                        previous_copy = self._cpu_staging_events[slot]
+                        if previous_copy is not None:
+                            synchronize = getattr(previous_copy, "synchronize", None)
+                            if callable(synchronize):
+                                synchronize()
+                            else:
+                                current_omni_platform.synchronize()
+                        cpu_weights = DistributedLayerwiseOffloadHook._pack_mmap_sources(
+                            state["cpu_sources"],
+                            state["metadata"],
+                            self._cpu_staging_buffers[slot],
+                        )
+                    else:
+                        cpu_weights = state["cpu_shards"]
 
-                for dtype, cpu_weight in cpu_weights.items():
-                    block_buffers[dtype].copy_(
-                        cpu_weight,
-                        non_blocking=cpu_weight.is_pinned(),
-                    )
-                if self.rank_local_mmap:
+                    for dtype, cpu_weight in cpu_weights.items():
+                        block_buffers[dtype].copy_(
+                            cpu_weight,
+                            non_blocking=cpu_weight.is_pinned(),
+                        )
+                if self.rank_local_mmap and not self.registered_mmap:
                     slot_ready = current_omni_platform.Event()
                     slot_ready.record(self.copy_stream)
                     self._cpu_staging_events[slot] = slot_ready
-            ready.record(self.copy_stream)
+                ready.record(self.copy_stream)
 
         for state, block_buffers in zip(self._states, gpu_buffers):
             targets = state["targets"]
@@ -942,8 +1013,10 @@ class PinnedResidentLayerGroup:
                         ),
                     )
 
-        current_omni_platform.current_stream().wait_event(ready)
+        if ready is not None:
+            current_omni_platform.current_stream().wait_event(ready)
         self._gpu_buffers = gpu_buffers
+        self._gpu_shard_buffers = gpu_shard_buffers
         self.loaded = True
 
     def offload(self) -> None:
@@ -958,6 +1031,7 @@ class PinnedResidentLayerGroup:
             for target in state["targets"].values():
                 set_tensor_storage(target, make_offload_placeholder(target))
         self._gpu_buffers.clear()
+        self._gpu_shard_buffers.clear()
         self.loaded = False
 
 
@@ -1874,6 +1948,10 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
                 self.device,
                 self.copy_stream,
                 self.config.pin_cpu_memory,
+                shard_group=self.dp_group,
+                shard_world_size=self.dp_size,
+                shard_rank=self.rank,
+                comm_stream=self.comm_stream,
                 rank_local_mmap=self._using_rank_local_mmap,
                 defer_staging=bool(self._all_hook_groups),
                 tensor_transforms=self._mmap_transforms_by_tensor_id,
@@ -1885,8 +1963,10 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
 
         if not self._all_hook_groups:
             self.enabled = bool(self._resident_blocks)
-            if self._using_mmap and not self.enabled:
+            if self._using_mmap and (not self.enabled or not self._using_rank_local_mmap):
                 self._release_mmap_handles()
+            if self.enabled:
+                self._cleanup_after_loading()
             return
 
         # Unified allocation: 2 shared output buffers + 2 shared shard buffers


### PR DESCRIPTION
## Purpose

Distributed layerwise offload previously rejected `dlo_resident_layers > 0` when DLO AllGather was enabled. This prevented Ulysses deployments from keeping a small number of leading DiT blocks resident while retaining sharded host storage.

This PR enables the combination by:

- retaining only the rank-local `1 / group_size` CPU shard for each resident block;
- reconstructing full resident weights once at denoise-stage entry with H2D plus AllGather;
- reusing those full device weights across every denoise step in that stage;
- releasing the full buffers before the following stage so VAE/decode can reuse HBM; and
- bounding temporary device shard storage to two rotating staging slots.

The existing no-AllGather resident path is unchanged.
