### PR TITLE
[CI/Build][MiniCPM-o] Derive duplex admission-probe limit from the deploy config

### DIFF
--- a/tests/e2e/features/fullduplex/engine/test_duplex_deploy_config.py
+++ b/tests/e2e/features/fullduplex/engine/test_duplex_deploy_config.py
@@ -8,6 +8,7 @@ from dataclasses import FrozenInstanceError
 
 import pytest
 
+from tests.helpers.stage_config import get_deploy_duplex_max_sessions
 from vllm_omni.config.stage_config import (
     DuplexSessionRuntimeConfig,
     load_deploy_config,
@@ -66,3 +67,18 @@ def test_duplex_session_runtime_rejects_non_positive_values(tmp_path, name: str,
 
     with pytest.raises(ValueError, match=rf"duplex_session\.{name} must be positive"):
         load_deploy_config(deploy_path)
+
+
+@pytest.mark.parametrize(
+    ("deploy_yaml", "expected"),
+    [
+        ("minicpmo_4_5.yaml", 4),
+        ("minicpmo_4_5_8x4090.yaml", 1),
+        ("minicpmo_4_5_3gpu_stage1_replicas.yaml", 4),
+    ],
+)
+def test_deploy_duplex_max_sessions_tracks_the_deploy_config(deploy_yaml: str, expected: int) -> None:
+    # Guards the admission probe. A capacity edit, a config that declares none,
+    # or an overlay inheriting one from its base must surface here rather than
+    # as another nightly duplex admission timeout.
+    assert get_deploy_duplex_max_sessions(deploy_yaml) == expected

--- a/tests/e2e/online_serving/helpers/minicpmo_4_5_duplex.py
+++ b/tests/e2e/online_serving/helpers/minicpmo_4_5_duplex.py
@@ -15,10 +15,11 @@ import pytest
 from huggingface_hub import snapshot_download
 
 from tests.helpers.runtime import OmniServerParams, get_model_prefix
-from tests.helpers.stage_config import get_deploy_config_path
+from tests.helpers.stage_config import get_deploy_config_path, get_deploy_duplex_max_sessions
 
 MODEL = "openbmb/MiniCPM-o-4_5"
-DEPLOY_CONFIG = get_deploy_config_path("minicpmo_4_5.yaml")
+DEPLOY_CONFIG_REL = "minicpmo_4_5.yaml"
+DEPLOY_CONFIG = get_deploy_config_path(DEPLOY_CONFIG_REL)
 ASSET_DIR = Path(__file__).resolve().parents[3] / "assets" / "minicpmo_4_5"
 RESPONSE_REQUIRED_WAV = ASSET_DIR / "response_required_16k.wav"
 RESPONSE_REQUIRED_SHA256 = "2e5fd4eb3ee434ce107ee3a0591fa624a33f7683c7462f45fe651c443c9af941"
@@ -37,6 +38,16 @@ SERVER_PARAMS = [
         id="three-stage-single-gpu",
     )
 ]
+
+
+def deploy_max_sessions() -> int:
+    """Concurrent duplex sessions the deploy config under test admits.
+
+    The admission probe has to expect the capacity the server is actually
+    started with. Hardcoding it silently drifts the moment the deploy config
+    changes its capacity, turning that change into an unrelated probe timeout.
+    """
+    return get_deploy_duplex_max_sessions(DEPLOY_CONFIG_REL)
 
 
 def validated_wav(path: Path, expected_sha256: str) -> Path:

--- a/tests/e2e/online_serving/test_minicpmo_4_5_duplex_expansion.py
+++ b/tests/e2e/online_serving/test_minicpmo_4_5_duplex_expansion.py
@@ -15,6 +15,7 @@ import pytest
 from tests.e2e.online_serving.helpers.minicpmo_4_5_duplex import (
     SERVER_PARAMS,
     SOFT_INTERRUPT_SHA256,
+    deploy_max_sessions,
     multi_session_args,
     realtime_url,
     resolve_ref_audio,
@@ -46,7 +47,7 @@ def test_duplex_admission_and_expiry_reaper(omni_server, tmp_path: Path) -> None
     args.disconnect_session_index = None
     args.takeover_session_index = None
     args.expire_session_index = 0
-    args.verify_admission_limit = 2
+    args.verify_admission_limit = deploy_max_sessions()
     result = asyncio.run(run_lifecycle_probes(args))
 
     assert result["ok"] is True, json.dumps(result, ensure_ascii=False, indent=2)

--- a/tests/helpers/stage_config.py
+++ b/tests/helpers/stage_config.py
@@ -669,6 +669,22 @@ def get_deploy_config_stage(rel_path: str, stage_id: int) -> dict[str, Any]:
     raise KeyError(f"No stage_id={stage_id} in deploy config {rel_path!r}")
 
 
+def get_deploy_duplex_max_sessions(rel_path: str, default: int = 1) -> int:
+    """Return ``duplex_session.max_sessions`` from a deploy yaml.
+
+    ``default`` mirrors ``DuplexSessionConfig.max_sessions`` so a deploy config
+    that declares no capacity resolves to the limit the server itself applies.
+    """
+    with open(get_deploy_config_path(rel_path), encoding="utf-8") as f:
+        cfg = yaml.safe_load(f) or {}
+
+    duplex_session = cfg.get("duplex_session")
+    max_sessions = duplex_session.get("max_sessions") if isinstance(duplex_session, dict) else None
+    if isinstance(max_sessions, int) and not isinstance(max_sessions, bool) and max_sessions > 0:
+        return max_sessions
+    return default
+
+
 def _stage_ids_from_deploy_yaml(stage_config_path: str) -> list[int]:
     """Return ``stage_id`` values from a new-schema deploy YAML (``stages``)."""
     with open(stage_config_path, encoding="utf-8") as f:

--- a/tests/helpers/stage_config.py
+++ b/tests/helpers/stage_config.py
@@ -674,15 +674,20 @@ def get_deploy_duplex_max_sessions(rel_path: str, default: int = 1) -> int:
 
     ``default`` mirrors ``DuplexSessionConfig.max_sessions`` so a deploy config
     that declares no capacity resolves to the limit the server itself applies.
+    A declared but invalid capacity raises instead of silently falling back to a
+    limit the server would never use, matching the runtime validation.
     """
     with open(get_deploy_config_path(rel_path), encoding="utf-8") as f:
         cfg = yaml.safe_load(f) or {}
 
     duplex_session = cfg.get("duplex_session")
-    max_sessions = duplex_session.get("max_sessions") if isinstance(duplex_session, dict) else None
-    if isinstance(max_sessions, int) and not isinstance(max_sessions, bool) and max_sessions > 0:
-        return max_sessions
-    return default
+    if not isinstance(duplex_session, dict) or "max_sessions" not in duplex_session:
+        return default
+
+    max_sessions = duplex_session["max_sessions"]
+    if not isinstance(max_sessions, int) or isinstance(max_sessions, bool) or max_sessions <= 0:
+        raise ValueError(f"duplex_session.max_sessions must be a positive int in {rel_path!r}, got {max_sessions!r}")
+    return max_sessions
 
 
 def _stage_ids_from_deploy_yaml(stage_config_path: str) -> list[int]:
@@ -750,6 +755,7 @@ def stage_config_path_for_run_level(stage_config_path: str | None, run_level: st
 __all__ = [
     "get_deploy_config_path",
     "get_deploy_config_stage",
+    "get_deploy_duplex_max_sessions",
     "get_stage_entries",
     "load_stage_ids",
     "load_stage_replica_counts",

--- a/tests/helpers/stage_config.py
+++ b/tests/helpers/stage_config.py
@@ -11,6 +11,8 @@ from typing import Any
 
 import yaml
 
+from vllm_omni.config.stage_config import load_deploy_config
+
 
 def modify_stage_config(
     yaml_path: str,
@@ -669,25 +671,14 @@ def get_deploy_config_stage(rel_path: str, stage_id: int) -> dict[str, Any]:
     raise KeyError(f"No stage_id={stage_id} in deploy config {rel_path!r}")
 
 
-def get_deploy_duplex_max_sessions(rel_path: str, default: int = 1) -> int:
-    """Return ``duplex_session.max_sessions`` from a deploy yaml.
+def get_deploy_duplex_max_sessions(rel_path: str) -> int:
+    """Return the duplex session capacity a deploy yaml admits.
 
-    ``default`` mirrors ``DuplexSessionConfig.max_sessions`` so a deploy config
-    that declares no capacity resolves to the limit the server itself applies.
-    A declared but invalid capacity raises instead of silently falling back to a
-    limit the server would never use, matching the runtime validation.
+    Loads through ``load_deploy_config`` so ``base_config`` merging and
+    ``DuplexSessionRuntimeConfig`` defaults stay in lockstep with the server
+    instead of being re-implemented here.
     """
-    with open(get_deploy_config_path(rel_path), encoding="utf-8") as f:
-        cfg = yaml.safe_load(f) or {}
-
-    duplex_session = cfg.get("duplex_session")
-    if not isinstance(duplex_session, dict) or "max_sessions" not in duplex_session:
-        return default
-
-    max_sessions = duplex_session["max_sessions"]
-    if not isinstance(max_sessions, int) or isinstance(max_sessions, bool) or max_sessions <= 0:
-        raise ValueError(f"duplex_session.max_sessions must be a positive int in {rel_path!r}, got {max_sessions!r}")
-    return max_sessions
+    return load_deploy_config(get_deploy_config_path(rel_path)).duplex_session.max_sessions
 
 
 def _stage_ids_from_deploy_yaml(stage_config_path: str) -> list[int]:


### PR DESCRIPTION
## Purpose

Fixes #6671.

`test_duplex_admission_and_expiry_reaper` times out on both CUDA and NPU:

```text
FAILED tests/e2e/online_serving/test_minicpmo_4_5_duplex_expansion.py::test_duplex_admission_and_expiry_reaper[three-stage-single-gpu] - TimeoutError
```

My read is the server is fine here and the test just carries a stale number.

The test hardcodes `verify_admission_limit = 2`, so the probe opens 2 sessions and waits for the 3rd to be rejected. #6619 repointed this test from `minicpmo_4_5_duplex.yaml`, which sets `duplex_session.max_sessions` to 2, to the shipping `minicpmo_4_5.yaml`, which sets it to 4. With room for 4 the 3rd session is admitted, no error event ever arrives, and `_receive_until` blocks until the timeout.

The capacity flows deploy yaml -> `omni_config.py:1424` -> `serving.py:916` -> `duplex_session.py:404`, and that last one only rejects once `len(_sessions) >= max_sessions`.

So this reads the limit from the deploy config the test starts the server with instead of hardcoding it. The number then lives in one place and a later capacity change can't turn into an unrelated probe timeout.

## Test Plan

**vLLM Version:** 0.27.0

**vLLM-Omni Commit:** a57246e4 (see the note under Test Result)

Served MiniCPM-o 4.5 on 1x H100 80GB from the unmodified shipping yaml, then ran the test's own `run_lifecycle_probes` admission probe at both limits:

```bash
vllm-omni serve openbmb/MiniCPM-o-4_5 --omni \
  --deploy-config vllm_omni/deploy/minicpmo_4_5.yaml \
  --trust-remote-code --host 0.0.0.0 --port 8099
```

```python
import asyncio, sys
sys.argv = ["drv", "--url", "ws://127.0.0.1:8099/v1/realtime?duplex=1",
            "--model", "openbmb/MiniCPM-o-4_5",
            "--input-wav", "tests/assets/minicpmo_4_5/response_required_16k.wav",
            "--ref-audio", "<ref_audio>.wav",
            "--verify-admission-limit", "2",   # then again with 4
            "--timeout-s", "40", "--output-dir", "/tmp/probe"]
from tests.e2e.online_serving.run_minicpmo_realtime_duplex_multi_session import (
    parse_args, run_lifecycle_probes)
print(asyncio.run(run_lifecycle_probes(parse_args())))
```

## Test Result

| probe limit | what it means | result |
| --- | --- | --- |
| 2 | what the test hardcodes today | `TimeoutError`, same as #6671 |
| 4 | what the deploy yaml configures | `ok=True`, `overflow_error_code=resource_exhausted` |

Server log at the configured capacity:

```text
open_duplex_session rejected: duplex_session_capacity_exhausted: limit=4
error: {'code': 'resource_exhausted', 'message': 'duplex_session_capacity_exhausted: limit=4', 'retryable': True}
```

`ruff check` and `ruff format --check` pass on the 3 changed files.

Two notes on how I validated this:

- I ran it on a57246e4 with vLLM 0.27.0 rather than current main, because main needs vLLM 0.28.0 and my box wasn't on it yet. The capacity check in `duplex_session.py` is identical between that commit and main, and the shipping yaml has `max_sessions: 4` in both, so I think the result carries over. Happy to rerun on main if you'd rather see that.
- The limit-4 arm needs a freshly started server. A probe that ends in a timeout leaves one accepted session alive until the reaper runs, which eats capacity and skews the next arm. That caught me the first time round.
