### PR TITLE
[Bugfix] Prevent premature resume of duplex sender stages

### DIFF
--- a/tests/core/sched/test_omni_ar_scheduler_streaming.py
+++ b/tests/core/sched/test_omni_ar_scheduler_streaming.py
@@ -450,7 +450,10 @@ def test_chunk_segment_cleanup_keeps_requeued_resumable_receiver() -> None:
     sched.waiting = queue()
     sched.skipped_waiting = queue(session)
     sched.num_waiting_for_streaming_input = 1
-    sched.chunk_transfer_adapter = SimpleNamespace(segment_finished_requests={session.request_id})
+    sched.chunk_transfer_adapter = SimpleNamespace(
+        receives_chunks=True,
+        segment_finished_requests={session.request_id},
+    )
 
     sched._resume_downstream_chunk_receiver(session)
     sched._remove_stopped_requests_from_queues(set(), {session})
@@ -460,3 +463,24 @@ def test_chunk_segment_cleanup_keeps_requeued_resumable_receiver() -> None:
     assert session not in sched.skipped_waiting.requests
     assert sched.num_waiting_for_streaming_input == 0
     assert session.request_id not in sched.chunk_transfer_adapter.segment_finished_requests
+
+
+def test_chunk_segment_cleanup_does_not_resume_sender() -> None:
+    """A sender-only stage must wait for its orchestrated streaming update."""
+    session = _make_request()
+    session.resumable = True
+    session.status = RequestStatus.WAITING_FOR_STREAMING_REQ
+
+    segment_finished_requests = {session.request_id}
+    sched = OmniARScheduler.__new__(OmniARScheduler)
+    sched.num_waiting_for_streaming_input = 1
+    sched.chunk_transfer_adapter = SimpleNamespace(
+        receives_chunks=False,
+        segment_finished_requests=segment_finished_requests,
+    )
+
+    sched._resume_downstream_chunk_receiver(session)
+
+    assert session.status == RequestStatus.WAITING_FOR_STREAMING_REQ
+    assert sched.num_waiting_for_streaming_input == 1
+    assert segment_finished_requests == {session.request_id}

--- a/vllm_omni/core/sched/omni_scheduler_mixin.py
+++ b/vllm_omni/core/sched/omni_scheduler_mixin.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 from __future__ import annotations
 
 import math
@@ -590,6 +593,10 @@ class OmniSchedulerMixin:
     def _resume_downstream_chunk_receiver(self, request: Request) -> None:
         """Resume connector polling without waiting for an external update."""
         adapter = self.chunk_transfer_adapter
+        # Sender-only stages receive the next segment from the orchestrator;
+        # requeueing them here would run without a new connector payload.
+        if adapter is None or not adapter.receives_chunks:
+            return
         adapter.segment_finished_requests.discard(request.request_id)
         if request.status != RequestStatus.WAITING_FOR_STREAMING_REQ:
             return


### PR DESCRIPTION
## Purpose

Fixes #6669.

MiniCPM-o 4.5 native duplex serving could fail in the three-stage pipeline with a CUDA device-side assertion after a resumable segment stopped. The scheduler unconditionally resumed every downstream stage after segment cleanup, even when the stage was connector-sender-only. That requeued the Talker before the orchestrator delivered its next payload, so an asynchronous `-1` placeholder could reach the codec-token path.

Gate `_resume_downstream_chunk_receiver()` on the adapter's receiver role. Actual chunk receivers retain the existing resume behavior; sender-only stages remain parked until their orchestrated streaming update arrives.

The regression test covers both sides of the contract: a chunk receiver is requeued, while a sender-only stage remains in `WAITING_FOR_STREAMING_REQ`.

## Test Plan

Reproduce the affected model path with:

```bash
pytest -s -v --run-level advanced_model \
  'tests/e2e/online_serving/test_minicpmo_4_5_duplex.py::test_duplex_single_session_response_required[three-stage-single-gpu]'
```

Run the focused scheduler regression with:

```bash
pytest -o addopts="" -s -v \
  tests/core/sched/test_omni_ar_scheduler_streaming.py::test_chunk_segment_cleanup_keeps_requeued_resumable_receiver \
  tests/core/sched/test_omni_ar_scheduler_streaming.py::test_chunk_segment_cleanup_does_not_resume_sender \
  -m "core_model and cpu"
```

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** c6df39e9f7ad8a12fd61bc2c5007103c6a62076a

## Test Result

- A800-SXM4-80GB (GPU 2), vLLM 0.28.0, real MiniCPM-o 4.5 weights: `1 passed, 15 warnings in 317.22s (0:05:17)`; wall-clock time `5m29.390s`
- A800-SXM4-80GB (GPU 2), focused scheduler regression: `2 passed, 15 warnings in 0.06s`
- Diff-scoped pre-commit hooks passed. The repository's existing mypy baseline reports 51 errors on `main` and 50 with this change, so mypy was excluded from the signed commit hook run.
- `git diff --check` passed.

<!-- markdownlint-disable -->
