### PR TITLE
[Perf] Pack MiniMax-H3 QKV directly into DLO staging

### DIFF
--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_parallel.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_parallel.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 import pytest
 import torch
@@ -10,6 +10,7 @@ pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.diffusion]
 
 def test_grouped_qkv_checkpoint_reorder():
     from vllm_omni.diffusion.models.minimax_h3.minimax_h3_transformer import (
+        _pack_grouped_qkv_to_qkv,
         _reorder_grouped_qkv_to_qkv,
     )
 
@@ -23,6 +24,42 @@ def test_grouped_qkv_checkpoint_reorder():
     )
 
     assert reordered[:, 0].tolist() == [0, 3, 1, 4, 2, 5]
+
+    destination = torch.empty_like(grouped)
+    _pack_grouped_qkv_to_qkv(
+        grouped,
+        destination,
+        num_query_groups=2,
+        heads_per_group=1,
+        head_dim=1,
+    )
+    assert torch.equal(destination, reordered)
+
+
+def test_grouped_qkv_direct_pack_matches_reorder_with_multiple_query_heads():
+    from vllm_omni.diffusion.models.minimax_h3.minimax_h3_transformer import (
+        _pack_grouped_qkv_to_qkv,
+        _reorder_grouped_qkv_to_qkv,
+    )
+
+    source = torch.arange(2 * 4 * 3 * 5, dtype=torch.float32).reshape(24, 5)
+    expected = _reorder_grouped_qkv_to_qkv(
+        source,
+        num_query_groups=2,
+        heads_per_group=2,
+        head_dim=3,
+    )
+    destination = torch.empty_like(source)
+
+    _pack_grouped_qkv_to_qkv(
+        source,
+        destination,
+        num_query_groups=2,
+        heads_per_group=2,
+        head_dim=3,
+    )
+
+    assert torch.equal(destination, expected)
 
 
 def test_transformer_declares_cache_sp_layerwise_offload_and_hsdp():

--- a/tests/diffusion/offloader/test_distributed_layerwise_backend.py
+++ b/tests/diffusion/offloader/test_distributed_layerwise_backend.py
@@ -496,6 +496,47 @@ class TestDistributedLayerwiseOffloadHook:
         assert next_block.weight.stride() == (1, 2)
         assert torch.equal(source, torch.arange(4, dtype=torch.float32).view(2, 2))
 
+    def test_rank_local_mmap_packer_bypasses_runtime_transform(self, dist_group, patched_offload_runtime):
+        current_block = nn.Linear(2, 2, bias=False)
+        next_block = nn.Linear(2, 2, bias=False)
+        next_block.weight.data.copy_(torch.arange(4, dtype=torch.float32).view(2, 2))
+        transform_calls = 0
+        pack_calls = 0
+
+        def transform(tensor):
+            nonlocal transform_calls
+            transform_calls += 1
+            return tensor.t()
+
+        def pack_into(source, destination):
+            nonlocal pack_calls
+            pack_calls += 1
+            destination.copy_(source.t())
+
+        hook = DistributedLayerwiseOffloadHook(
+            next_block=next_block,
+            device=torch.device("cpu"),
+            dp_group=None,
+            dp_size=1,
+            rank=0,
+            pin_memory=False,
+            rank_local_mmap=True,
+            tensor_transforms={id(next_block.weight): transform},
+            tensor_packers={id(next_block.weight): pack_into},
+        )
+        hook.initialize_hook(current_block)
+        assert transform_calls == 1  # One metadata validation during setup.
+
+        hook.cpu_staging_buffers = [
+            {torch.float32: torch.empty(4)},
+            {torch.float32: torch.empty(4)},
+        ]
+        hook.prefetch_layer(slot=0, non_blocking=False)
+
+        assert pack_calls == 1
+        assert transform_calls == 1
+        assert torch.equal(next_block.weight, torch.tensor([[0.0, 2.0], [1.0, 3.0]]))
+
     def test_rank_local_mmap_staging_is_bounded_by_largest_block(self, patched_offload_runtime):
         hooks = []
         for size in (4, 9):

--- a/vllm_omni/diffusion/model_loader/checkpoint_adapters/direct_mmap.py
+++ b/vllm_omni/diffusion/model_loader/checkpoint_adapters/direct_mmap.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Loader-side adapters for proven direct-checkpoint mmap layouts."""
 
 from __future__ import annotations
@@ -19,6 +19,7 @@ class DirectMmapTensorPolicy:
 
     allow_custom_loader: bool = False
     transform: Callable[[torch.Tensor], torch.Tensor] | None = None
+    pack_into: Callable[[torch.Tensor, torch.Tensor], None] | None = None
 
 
 class DirectMmapAdapter(Protocol):
@@ -42,10 +43,12 @@ class _MiniMaxH3DirectMmapAdapter:
     ) -> DirectMmapTensorPolicy:
         del target
         transform = None
+        pack_into = None
         suffix = ".qkv_proj.weight"
         if runtime_name.endswith(suffix):
             from vllm_omni.diffusion.models.minimax_h3.minimax_h3_transformer import (
                 MiniMaxH3Attention,
+                _pack_grouped_qkv_to_qkv,
                 _reorder_grouped_qkv_to_qkv,
             )
 
@@ -62,9 +65,16 @@ class _MiniMaxH3DirectMmapAdapter:
                 heads_per_group=1,
                 head_dim=attention.head_dim,
             )
+            pack_into = partial(
+                _pack_grouped_qkv_to_qkv,
+                num_query_groups=attention.total_num_heads,
+                heads_per_group=1,
+                head_dim=attention.head_dim,
+            )
         return DirectMmapTensorPolicy(
             allow_custom_loader=True,
             transform=transform,
+            pack_into=pack_into,
         )
 
 

--- a/vllm_omni/diffusion/model_loader/host_weight_plan.py
+++ b/vllm_omni/diffusion/model_loader/host_weight_plan.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from vllm_omni.host_weight_runtime import HostWeightLeaseCarrier
 
 TensorTransform = Callable[[torch.Tensor], torch.Tensor]
+TensorPacker = Callable[[torch.Tensor, torch.Tensor], None]
 
 
 @dataclass(frozen=True)
@@ -35,6 +36,7 @@ class TensorBinding:
     checkpoint_key: str
     file_path: str
     transform: TensorTransform | None = None
+    pack_into: TensorPacker | None = None
 
 
 @dataclass(frozen=True)
@@ -336,6 +338,7 @@ def build_checkpoint_mmap_plan(
                 checkpoint_key=checkpoint_key,
                 file_path=file_path,
                 transform=policy.transform if policy is not None else None,
+                pack_into=policy.pack_into if policy is not None else None,
             )
 
         _validate_source_metadata(required, bindings)

--- a/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
+++ b/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
@@ -215,6 +215,45 @@ def _reorder_grouped_qkv_to_qkv(
     )
 
 
+def _pack_grouped_qkv_to_qkv(
+    source: torch.Tensor,
+    destination: torch.Tensor,
+    *,
+    num_query_groups: int,
+    heads_per_group: int,
+    head_dim: int,
+) -> None:
+    """Pack grouped checkpoint QKV directly into a Q/K/V-major buffer."""
+    per_group = (heads_per_group + 2) * head_dim
+    expected_out = num_query_groups * per_group
+    if source.shape[0] != expected_out:
+        raise ValueError(
+            "qkv weight has incompatible output dim for grouped checkpoint layout: "
+            f"got {tuple(source.shape)}, expected first dim {expected_out}."
+        )
+    if destination.dtype != source.dtype or destination.shape != source.shape:
+        raise ValueError(
+            "qkv pack destination must match source metadata: "
+            f"source dtype={source.dtype}, shape={tuple(source.shape)}; "
+            f"destination dtype={destination.dtype}, shape={tuple(destination.shape)}"
+        )
+
+    rest_shape = source.shape[1:]
+    q_rows_per_group = heads_per_group * head_dim
+    grouped = source.reshape(num_query_groups, per_group, *rest_shape)
+    q, k, v = torch.split(
+        grouped,
+        [q_rows_per_group, head_dim, head_dim],
+        dim=1,
+    )
+    q_rows = num_query_groups * heads_per_group * head_dim
+    kv_rows = num_query_groups * head_dim
+    q_out, k_out, v_out = torch.split(destination, [q_rows, kv_rows, kv_rows], dim=0)
+    q_out.reshape(num_query_groups, q_rows_per_group, *rest_shape).copy_(q)
+    k_out.reshape(num_query_groups, head_dim, *rest_shape).copy_(k)
+    v_out.reshape(num_query_groups, head_dim, *rest_shape).copy_(v)
+
+
 def _norm(size: int, *, eps: float, dtype: torch.dtype = _BF16_DTYPE) -> RMSNorm:
     # RMSNorm uses fp32 accumulation with bf16 inputs and outputs.
     # torch.nn.RMSNorm upcasts reduced-precision inputs for the variance
@@ -1472,4 +1511,5 @@ __all__ = [
     "MINIMAX_H3_FP32_PARAM_NAMES",
     "MiniMaxH3DiTModel",
     "_reorder_grouped_qkv_to_qkv",
+    "_pack_grouped_qkv_to_qkv",
 ]

--- a/vllm_omni/diffusion/offloader/distributed_layerwise_backend.py
+++ b/vllm_omni/diffusion/offloader/distributed_layerwise_backend.py
@@ -31,6 +31,8 @@ from vllm.logger import init_logger
 from vllm_omni.diffusion.hooks import HookRegistry, ModelHook
 from vllm_omni.diffusion.model_loader.host_weight_plan import (
     HostWeightPlan,
+    TensorPacker,
+    TensorTransform,
 )
 from vllm_omni.host_weight_runtime import HostWeightLease
 from vllm_omni.platforms import current_omni_platform
@@ -123,7 +125,8 @@ class DistributedLayerwiseOffloadHook(ModelHook):
         pin_memory: bool = True,
         shared_buffers: list[dict[torch.dtype, torch.Tensor] | None] | None = None,
         rank_local_mmap: bool = False,
-        tensor_transforms: dict[int, Any] | None = None,
+        tensor_transforms: dict[int, TensorTransform] | None = None,
+        tensor_packers: dict[int, TensorPacker] | None = None,
     ):
         assert isinstance(next_block, nn.Module), "transformer block must be type `torch.nn.Module`"
 
@@ -136,6 +139,7 @@ class DistributedLayerwiseOffloadHook(ModelHook):
         self.rank_local_mmap = rank_local_mmap
         self.registered_mmap = False
         self.tensor_transforms = tensor_transforms or {}
+        self.tensor_packers = tensor_packers or {}
 
         self.copy_stream = copy_stream or current_omni_platform.Stream()
         self.comm_stream = comm_stream or current_omni_platform.Stream()
@@ -222,6 +226,7 @@ class DistributedLayerwiseOffloadHook(ModelHook):
                 self.next_block_parameters,
                 self.next_block_buffers,
                 self.tensor_transforms,
+                self.tensor_packers,
             )
         else:
             # Shard next block's weights and store local shard in pinned CPU memory.
@@ -277,7 +282,8 @@ class DistributedLayerwiseOffloadHook(ModelHook):
     def _collect_mmap_sources(
         params: dict[str, nn.Parameter],
         bufs: dict[str, torch.Tensor],
-        tensor_transforms: dict[int, Any] | None = None,
+        tensor_transforms: dict[int, TensorTransform] | None = None,
+        tensor_packers: dict[int, TensorPacker] | None = None,
     ) -> tuple[dict[torch.dtype, list[dict[str, Any]]], dict[torch.dtype, list[dict[str, Any]]]]:
         """Retain file-backed tensors and replace module storage with placeholders.
 
@@ -299,6 +305,7 @@ class DistributedLayerwiseOffloadHook(ModelHook):
             dtype = source.dtype
             offset = offsets.get(dtype, 0)
             transform = (tensor_transforms or {}).get(id(target))
+            pack_into = (tensor_packers or {}).get(id(target))
             runtime_source = transform(source) if callable(transform) else source
             if runtime_source.dtype != dtype or runtime_source.shape != source.shape:
                 raise ValueError(
@@ -318,6 +325,7 @@ class DistributedLayerwiseOffloadHook(ModelHook):
                     "name": name,
                     "tensor": source.detach(),
                     "transform": transform,
+                    "pack_into": pack_into,
                 }
             )
             metadata.setdefault(dtype, []).append(
@@ -344,7 +352,7 @@ class DistributedLayerwiseOffloadHook(ModelHook):
         dp_size: int,
         rank: int,
         pin_memory: bool,
-        tensor_transforms: dict[int, Any] | None = None,
+        tensor_transforms: dict[int, TensorTransform] | None = None,
     ) -> tuple[dict[torch.dtype, torch.Tensor], dict[torch.dtype, list[dict[str, Any]]]]:
         """Flatten params+buffers by dtype, split into DP shards, store local shard.
 
@@ -518,9 +526,18 @@ class DistributedLayerwiseOffloadHook(ModelHook):
             destination = slot_buffers[dtype][:total_numel]
             sources = cpu_sources[dtype]
             for source_info, meta in zip(sources, metas, strict=True):
-                source = DistributedLayerwiseOffloadHook._resolve_mmap_source(source_info, meta, dtype)
                 start = meta["offset"]
                 physical_storage = destination[start : start + meta["numel"]]
+                pack_into = source_info.get("pack_into")
+                if callable(pack_into):
+                    runtime_destination = torch.as_strided(
+                        physical_storage,
+                        size=meta["shape"],
+                        stride=meta["stride"],
+                    )
+                    pack_into(source_info["tensor"], runtime_destination)
+                    continue
+                source = DistributedLayerwiseOffloadHook._resolve_mmap_source(source_info, meta, dtype)
                 if source.is_contiguous():
                     physical_storage.copy_(source.flatten())
                 else:
@@ -759,7 +776,8 @@ def apply_distributed_block_hook(
     pin_memory: bool = True,
     shared_buffers: list[dict[torch.dtype, torch.Tensor] | None] | None = None,
     rank_local_mmap: bool = False,
-    tensor_transforms: dict[int, Any] | None = None,
+    tensor_transforms: dict[int, TensorTransform] | None = None,
+    tensor_packers: dict[int, TensorPacker] | None = None,
 ) -> DistributedLayerwiseOffloadHook:
     """Register a DistributedLayerwiseOffloadHook on *module*."""
     registry = HookRegistry.get_or_create(module)
@@ -775,6 +793,7 @@ def apply_distributed_block_hook(
         shared_buffers=shared_buffers,
         rank_local_mmap=rank_local_mmap,
         tensor_transforms=tensor_transforms,
+        tensor_packers=tensor_packers,
     )
     registry.register_hook(DistributedLayerwiseOffloadHook._HOOK_NAME, hook)
     return hook
@@ -815,7 +834,8 @@ class PinnedResidentLayerGroup:
         pin_memory: bool,
         rank_local_mmap: bool = False,
         defer_staging: bool = False,
-        tensor_transforms: dict[int, Any] | None = None,
+        tensor_transforms: dict[int, TensorTransform] | None = None,
+        tensor_packers: dict[int, TensorPacker] | None = None,
     ) -> None:
         self.device = device
         self.copy_stream = copy_stream
@@ -835,6 +855,7 @@ class PinnedResidentLayerGroup:
                     params,
                     bufs,
                     tensor_transforms,
+                    tensor_packers,
                 )
                 cpu_shards = {}
             else:
@@ -1001,7 +1022,8 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
         self.host_weight_plan = host_weight_plan
         self._host_weight_lease: HostWeightLease | None = None
         self._host_registration: HostRegistration | None = None
-        self._mmap_transforms_by_tensor_id: dict[int, Any] = {}
+        self._mmap_transforms_by_tensor_id: dict[int, TensorTransform] = {}
+        self._mmap_packers_by_tensor_id: dict[int, TensorPacker] = {}
 
     def load_resident_layers(self) -> None:
         """Load the model-declared leading blocks for the denoise stage."""
@@ -1301,8 +1323,9 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
         # submodule), so associate deferred bounded transforms with the final
         # runtime tensor objects rather than the initial mmap replacements.
         self._mmap_transforms_by_tensor_id.clear()
+        self._mmap_packers_by_tensor_id.clear()
         for runtime_name, binding in plan.bindings.items():
-            if binding.transform is None:
+            if binding.transform is None and binding.pack_into is None:
                 continue
             parent_path, _, leaf_name = runtime_name.rpartition(".")
             parent = pipeline.get_submodule(parent_path)
@@ -1313,7 +1336,10 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
                 raise RuntimeError(
                     f"Host-weight transform target {runtime_name!r} no longer exists after post-load processing"
                 )
-            self._mmap_transforms_by_tensor_id[id(target)] = binding.transform
+            if binding.transform is not None:
+                self._mmap_transforms_by_tensor_id[id(target)] = binding.transform
+            if binding.pack_into is not None:
+                self._mmap_packers_by_tensor_id[id(target)] = binding.pack_into
 
         remaining_meta: list[str] = []
         for dit_name, dit_module in zip(modules.dit_names, modules.dits):
@@ -1526,6 +1552,7 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
             shared_buffers=[None, None],
             rank_local_mmap=self._using_rank_local_mmap,
             tensor_transforms=self._mmap_transforms_by_tensor_id,
+            tensor_packers=self._mmap_packers_by_tensor_id,
         )
         sub_hooks = [last_hook]
         for i, block in enumerate(blocks[:-1]):
@@ -1543,6 +1570,7 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
                 shared_buffers=[None, None],
                 rank_local_mmap=self._using_rank_local_mmap,
                 tensor_transforms=self._mmap_transforms_by_tensor_id,
+                tensor_packers=self._mmap_packers_by_tensor_id,
             )
             sub_hooks.append(hook)
 
@@ -1828,6 +1856,7 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
                 shared_buffers=[None, None],
                 rank_local_mmap=self._using_rank_local_mmap,
                 tensor_transforms=self._mmap_transforms_by_tensor_id,
+                tensor_packers=self._mmap_packers_by_tensor_id,
             )
 
             block_hooks: list[DistributedLayerwiseOffloadHook] = [last_hook]
@@ -1846,6 +1875,7 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
                     shared_buffers=[None, None],
                     rank_local_mmap=self._using_rank_local_mmap,
                     tensor_transforms=self._mmap_transforms_by_tensor_id,
+                    tensor_packers=self._mmap_packers_by_tensor_id,
                 )
                 block_hooks.append(hook)
 
@@ -1877,6 +1907,7 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
                 rank_local_mmap=self._using_rank_local_mmap,
                 defer_staging=bool(self._all_hook_groups),
                 tensor_transforms=self._mmap_transforms_by_tensor_id,
+                tensor_packers=self._mmap_packers_by_tensor_id,
             )
             pipeline._dlo_residency_controller = self
 
@@ -1982,6 +2013,7 @@ class DistributedLayerwiseOffloadBackend(OffloadBackend):
         if self._host_registration is not None:
             raise HostRegistrationCleanupError("cannot close HWR mappings while host registration is still active")
         self._mmap_transforms_by_tensor_id.clear()
+        self._mmap_packers_by_tensor_id.clear()
         if hasattr(self, "_mmap_file_cache"):
             self._mmap_file_cache.clear()
             del self._mmap_file_cache


### PR DESCRIPTION
## Summary

MiniMax-H3 checkpoints store attention QKV weights in grouped order, while DLO staging expects Q-major, K-major, V-major order.

Before this change, every rank-local block prefetch created a full reordered CPU tensor and then copied it into pinned staging:

    mmap QKV -> full reordered CPU tensor -> pinned staging -> H2D

This PR adds an optional destination-aware mmap packer. MiniMax-H3 now copies Q, K, and V slices directly into their final staging offsets:

    mmap QKV -> direct pack into pinned staging -> H2D

The existing transform path remains unchanged for other checkpoint bindings.

## Performance

Configuration:

- 4 x NVIDIA B300 SXM6 AC, 275040 MiB each; driver 610.43.02
- torch 2.13.0+cu130, CUDA 13.0, vLLM 0.27.0
- MiniMax-H3 BF16 FL2VA
- TP1, Ulysses4, NCCL
- distributed layerwise offload with no AllGather and 0 resident layers
- eager mode
- 1344x768, 5 seconds, 24 fps, 5 inference steps, seed 1101
- one warmup followed by three measured single-request runs

The baseline and direct-pack columns use the worker default OMP thread count of 1. The last column adds OMP_NUM_THREADS=4 as a runtime tuning on top of this PR; it is reported separately and is not attributed solely to the code change.

| Metric | Before, OMP=1 | Direct pack, OMP=1 | Direct pack, OMP=4 |
| --- | ---: | ---: | ---: |
| E2E mean | 55.493 s | 21.857 s | 15.440 s |
| E2E runs | 55.06 / 55.15 / 56.27 s | 21.81 / 21.82 / 21.94 s | 15.42 / 15.45 / 15.45 s |
| Speedup vs before | 1.00x | 2.54x | 3.59x |
| CPU pack | 50.752 s | 17.511 s | 10.905 s |
| CPU pack reduction | - | 65.5% | 78.5% |
| Steady-state peak GPU memory | 26752 MiB | 26750 MiB | 26750 MiB |

### Detailed runtime breakdown

| Component | Before, OMP=1 | Direct pack, OMP=1 | Direct pack, OMP=4 |
| --- | ---: | ---: | ---: |
| E2E | 55.493 s | 21.857 s | 15.440 s |
| DiT forward | 51.810 s | 18.297 s | 11.902 s |
| Streaming block compute | 45.371 s | 9.623 s | 10.539 s |
| CPU pack | 50.752 s | 17.511 s | 10.905 s |
| H2D | 4.854 s | 5.312 s | 7.219 s |
| DLO prefetch exposed wait | 1.444 s | 1.807 s | 3.371 s |
| Staging reuse wait | 2.160 s | 0.294 s | 0.931 s |
| Ulysses mode0 pack | 0.108 s | 0.111 s | 0.116 s |
| Ulysses mode0 A2A | 43.026 s | 7.156 s | 8.112 s |
| Ulysses mode0 unpack | 0.011 s | 0.016 s | 0.018 s |
| Ulysses mode1 pack | 0.038 s | 0.040 s | 0.041 s |
| Ulysses mode1 A2A | 0.114 s | 0.161 s | 0.173 s |
| Ulysses mode1 unpack | 0.035 s | 0.037 s | 0.038 s |
| DLO overlap | 70.26% | 65.99% | 53.30% |

These timers overlap and must not be added together. In particular, the A2A timers include rank arrival skew and therefore are not pure network-transfer latency. With OMP=4, CPU packing falls further, while H2D and exposed prefetch wait increase from CPU-memory and PCIe contention.

This reports single-request latency; no throughput or concurrency scaling claim is made.

<details>
<summary>Server command</summary>

    CUDA_VISIBLE_DEVICES=4,5,6,7 vllm serve /path/to/MiniMax-H3/FL2VA --omni --host 127.0.0.1 --port 8095 --trust-remote-code --task-type fl2va --num-gpus 4 --tensor-parallel-size 1 --usp 4 --ring 1 --text-encoder-tp-size 4 --vae-patch-parallel-size 4 --vae-parallel-mode tile --vae-use-tiling --diffusion-attention-backend CUDNN_ATTN --enable-diffusion-pipeline-profiler --enable-distributed-layerwise-offload --dlo-no-use-allgather --dlo-resident-layers 0 --enforce-eager --stage-init-timeout 1800 --init-timeout 1800

Request parameters: width 1344, height 768, fps 24, 5 inference steps, flow shift 12, seed 1101, task t2va, duration 5.0, audio flow shift 3.0.

For the OMP=4 run, OMP_NUM_THREADS=4 was exported before launching the same command.

</details>

## Correctness and tests

- Generated video frame MD5 outputs are byte-identical across baseline, direct-pack OMP=1, and direct-pack OMP=4.
- Generated audio frame MD5 outputs are byte-identical across all three configurations.
- Video frame-MD5 SHA256: 0f1e0977423bfc2907300478df89ebd4fd93c4d997c4e0969ce6362c9a8e9671
- Audio frame-MD5 SHA256: 6ed7d2aba890ecad3e6362232a36a78946bee2e903761070807d9c4038335525
- Focused tests: 99 passed, 15 warnings in 5.07 s.
- Ruff check and format checks passed.
- SPDX and remaining pre-commit hooks passed.
- LSY deterministic precheck passed.
- The eight mypy findings in the changed offloader file reproduce unchanged on upstream main.

Focused test command:

    pytest -q tests/diffusion/models/minimax_h3/test_minimax_h3_parallel.py tests/diffusion/offloader/test_distributed_layerwise_backend.py tests/diffusion/profiler/test_runtime_timing.py
