### PR TITLE
[Test] Stabilize MiniMax-H3 reference accuracy compile

### DIFF
--- a/tests/e2e/accuracy/minimax_h3/test_minimax_h3_i2va_ref2va_similarity.py
+++ b/tests/e2e/accuracy/minimax_h3/test_minimax_h3_i2va_ref2va_similarity.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from __future__ import annotations
 
@@ -119,6 +119,9 @@ def _model_name(model_env_var: str = MODEL_ENV_VAR, component: str = "FL2VA") ->
 def _server_args() -> list[str]:
     return [
         "--trust-remote-code",
+        # Both official-reference requests use fixed shapes. Keep regional
+        # compilation static so cold Inductor codegen is stable across CI nodes.
+        "--no-diffusion-compile-dynamic",
         "--num-gpus",
         "4",
         "--usp",


### PR DESCRIPTION
## Purpose

The MiniMax-H3 I2VA official-reference result depends on how the regional DiT graph is compiled. After the nightly environment moved from vLLM 0.27 to vLLM 0.28, a cold dynamic Inductor compile can fall below the unchanged accuracy thresholds:

- Build 14213 on H100: SSIM 0.967466, PSNR 32.661558 dB
- Local main with vLLM 0.28 and a clean Inductor cache: SSIM 0.969453, PSNR 33.489017 dB

The same checkout can pass when it reuses an older compiled cache, which made the failure look commit-dependent.

## Bisect result

I bisected the three-day first-parent range from 29e3165bb to 030fccb2b with the full 4-GPU I2VA test and continuous SSIM/PSNR values. The tested intermediate commits were:

- 6639c82a: 0.974087 / 35.076255 dB
- 5de6f7c37: 0.976242 / 36.769885 dB
- 7439ed41c: 0.976242 / 36.769885 dB
- 816335cb4: 0.976242 / 36.769885 dB

Git initially named 030fccb2b as the first bad commit, but that commit only adds a test file and Buildkite YAML and has no runtime or dependency changes. Re-running the exact same commit changed from 0.969453 / 33.489017 dB to 0.976242 / 36.769885 dB. This disproves a causal vLLM-Omni commit in that range and identifies shared/cold compiled state as the missing bisect variable.

The public nightly logs also show the environment transition: build 14090 used vLLM 0.27 and passed on the same H100 bus group later used by build 14213, while build 14213 used vLLM 0.28 and failed.

- Good build 14090: https://buildkite.com/vllm/vllm-omni/builds/14090
- Mixed retry build 14152: https://buildkite.com/vllm/vllm-omni/builds/14152
- Failing build 14213: https://buildkite.com/vllm/vllm-omni/builds/14213

## Fix

Both official-reference requests have fixed shapes. Run their regional compile with dynamic shapes disabled by adding --no-diffusion-compile-dynamic to the shared test server arguments.

This keeps the compiled production path covered while removing the cold dynamic-codegen precision drift. It does not change the attention backend, cuDNN settings, model implementation, or SSIM/PSNR thresholds.

## Test plan

Environment: 4x NVIDIA B300 SXM6 AC, vLLM 0.28.0, PyTorch 2.13.0+cu130.

- I2VA, clean static Inductor cache: SSIM 0.972637, PSNR 35.074233 dB — passed
- Ref2VA, static regional compile: SSIM 0.980578, PSNR 42.650344 dB — passed
- Eager control: SSIM 0.971440, PSNR 34.672483 dB — passed
- Changed-file pre-commit hooks — passed

Thresholds remain SSIM >= 0.970000 and PSNR >= 34.000000 dB.