### PR TITLE
[AR-Diffusion][DreamZero] Size the KV pool from active CFG branches and reachable block demand

### DIFF
--- a/tests/diffusion/ar_diffusion/test_capability.py
+++ b/tests/diffusion/ar_diffusion/test_capability.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU contracts for model-declared AR-Diffusion capabilities."""
+
+import pytest
+
+from vllm_omni.experimental.ar_diffusion.capability import cfg_kv_branches
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+@pytest.mark.parametrize(
+    ("cfg_enabled", "cfg_parallel_world_size", "expected"),
+    [
+        (False, 1, (("positive", 0),)),
+        (False, 2, (("positive", 0),)),
+        (True, 1, (("positive", 0), ("negative", 1))),
+        (True, 2, (("positive", 0), ("negative", 0))),
+    ],
+)
+def test_cfg_kv_branches_matches_active_cfg_topology(
+    cfg_enabled: bool,
+    cfg_parallel_world_size: int,
+    expected: tuple[tuple[str, int], ...],
+) -> None:
+    branches = cfg_kv_branches(
+        cfg_enabled=cfg_enabled,
+        cfg_parallel_world_size=cfg_parallel_world_size,
+    )
+
+    assert tuple((branch.name, branch.local_index) for branch in branches) == expected
+
+
+def test_cfg_kv_branches_preserves_model_branch_names() -> None:
+    branches = cfg_kv_branches(
+        cfg_enabled=True,
+        cfg_parallel_world_size=1,
+        positive_name="conditional",
+        negative_name="unconditional",
+    )
+
+    assert tuple(branch.name for branch in branches) == ("conditional", "unconditional")

--- a/tests/diffusion/ar_diffusion/test_capability_runner.py
+++ b/tests/diffusion/ar_diffusion/test_capability_runner.py
@@ -15,6 +15,7 @@ from vllm_omni.experimental.ar_diffusion.capability import (
     ARDiffusionCrossAttentionKVSpec,
     ARDiffusionKVBranchSpec,
     ARDiffusionKVCacheSpec,
+    cfg_kv_branches,
 )
 from vllm_omni.experimental.ar_diffusion.kv_cache import ARDiffusionKVConfig
 from vllm_omni.experimental.ar_diffusion.runner import ARDiffusionModelRunner
@@ -43,7 +44,12 @@ def lingbot_like_spec(*, capacity: int = 2) -> ARDiffusionKVCacheSpec:
     )
 
 
-def dreamzero_like_spec(*, capacity: int = 2) -> ARDiffusionKVCacheSpec:
+def dreamzero_like_spec(
+    *,
+    capacity: int = 2,
+    cfg_enabled: bool = True,
+    cfg_parallel_world_size: int = 1,
+) -> ARDiffusionKVCacheSpec:
     return ARDiffusionKVCacheSpec(
         num_layers=2,
         num_kv_heads=4,
@@ -51,7 +57,10 @@ def dreamzero_like_spec(*, capacity: int = 2) -> ARDiffusionKVCacheSpec:
         tokens_per_frame=BLOCK,
         frames_per_block=4,
         window_frames=6,
-        kv_branches=(ARDiffusionKVBranchSpec(POS, 0), ARDiffusionKVBranchSpec(NEG, 1)),
+        kv_branches=cfg_kv_branches(
+            cfg_enabled=cfg_enabled,
+            cfg_parallel_world_size=cfg_parallel_world_size,
+        ),
         session_capacity=capacity,
         cross_attention=(ARDiffusionCrossAttentionKVSpec("text", 8),),
     )
@@ -287,6 +296,17 @@ def test_dreamzero_like_two_branches_are_independent():
     state = commit_one_frame(runner, "s1", POS)
     assert len(kv.window_block_ids(state.adapter(POS))) == 1
     assert kv.window_block_ids(state.adapter(NEG)) == []
+
+
+def test_dreamzero_like_cfg_off_does_not_expose_negative_branch():
+    runner = make_runner(CapablePipeline(dreamzero_like_spec(cfg_enabled=False)))
+    kv = runner.kv_cache
+    assert kv is not None and kv.num_local_kv_branches == 1
+    state = runner._get_or_create_session("s1")
+
+    assert state.kv_branch_names == (POS,)
+    with pytest.raises(KeyError, match="Unknown AR-Diffusion KV branch 'negative'"):
+        state.adapter(NEG)
 
 
 def test_lru_eviction_releases_blocks_and_notifies_pipeline():

--- a/tests/diffusion/ar_diffusion/test_kv_cache.py
+++ b/tests/diffusion/ar_diffusion/test_kv_cache.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Unit tests for the AR-Diffusion KV cache helpers (Phase 1, PR-2).
 
 Covers the request adapter, the chunk-window spec/manager (registration + the
@@ -207,10 +208,13 @@ def test_cross_attn_pool_deducted_from_self_attn_budget():
     page_bytes = kv.spec.page_size_bytes * 2
     scratch_bytes = kv.scratch_num_blocks * page_bytes
     expected = (int(avail * 0.5) - cross_bytes - scratch_bytes) // page_bytes
-    assert kv.num_blocks == expected
+    assert kv.budget_limited_blocks == expected
     assert kv.cross_attention_reserved_bytes == cross_bytes
     assert (kv.num_blocks_total * page_bytes) + cross_bytes <= int(avail * 0.5)
-    assert expected > 1 * (2 + 1) + 2  # above the local-slot minimum, so the cross deduction is what's tested
+    # The pool tracks reachable demand, so the surplus this budget could afford
+    # stays unallocated; the cross deduction is visible in budget_limited_blocks.
+    assert kv.num_blocks == 1 * (2 + 1) + 2
+    assert expected > kv.num_blocks  # above the local-slot minimum, so the cross deduction is what's tested
 
 
 def _make_tiny_capacity_kv(
@@ -353,7 +357,9 @@ def _make_kv(
     num_frame_per_block=2,
     window_chunks=9,
     max_scratch_tokens_per_branch=0,
+    available_bytes=None,
 ):
+    """DreamZero-like CFG geometry. ``available_bytes`` defaults to an exact fit."""
     kv_branches = (
         (ARDiffusionKVBranchSpec("positive", 0), ARDiffusionKVBranchSpec("negative", 0))
         if local_branches == 1
@@ -363,6 +369,8 @@ def _make_kv(
     declared_scratch_blocks = (max_scratch_tokens_per_branch + BLOCK - 1) // BLOCK
     scratch_blocks = local_branches * (num_frame_per_block + declared_scratch_blocks)
     managed_blocks = local_branches * (window_chunks + num_frame_per_block) + 2
+    if available_bytes is None:
+        available_bytes = (managed_blocks + scratch_blocks) * page_bytes
     return ARDiffusionKVCache(
         ARDiffusionKVConfig(
             enable=True,
@@ -376,7 +384,7 @@ def _make_kv(
         dtype=torch.float32,
         block_size=BLOCK,
         max_model_len=4096,
-        available_bytes=(managed_blocks + scratch_blocks) * page_bytes,
+        available_bytes=available_bytes,
         device=torch.device("cpu"),
         kv_branches=kv_branches,
         session_capacity=1,
@@ -397,6 +405,51 @@ def test_pool_floor_is_branch_aware():
     assert two.scratch_num_blocks == 2 * two.scratch_blocks_per_kv_branch
     assert one.scratch_blocks_per_kv_branch == 2
     assert one.num_blocks_total == 13 + one.scratch_blocks_per_kv_branch
+
+
+ROOMY = 1 << 24  # ~32x the exact fit for the _make_kv geometry
+
+
+def test_surplus_budget_does_not_enlarge_the_managed_pool():
+    """The pool tracks reachable demand, so a bigger budget buys no extra blocks."""
+    tight = _make_kv(local_branches=1)
+    roomy = _make_kv(local_branches=1, available_bytes=ROOMY)
+
+    assert tight.managed_num_blocks == roomy.managed_num_blocks == 1 * (9 + 2) + 2
+    assert tight.session_capacity == roomy.session_capacity == 1
+    # The surplus the budget could afford is reported, not allocated.
+    assert tight.budget_limited_blocks == tight.managed_num_blocks
+    assert roomy.budget_limited_blocks > roomy.managed_num_blocks
+
+
+def test_fewer_local_branches_shrink_the_managed_pool_at_equal_budget():
+    """A model declaring fewer active branches allocates a smaller pool."""
+    one = _make_kv(local_branches=1, available_bytes=ROOMY)
+    two = _make_kv(local_branches=2, available_bytes=ROOMY)
+
+    assert one.managed_num_blocks == 1 * (9 + 2) + 2
+    assert two.managed_num_blocks == 2 * (9 + 2) + 2
+    assert one.num_blocks_total < two.num_blocks_total
+    # Shrinking the managed pool moves the scratch region down with it; the two
+    # must stay adjacent and disjoint.
+    for kv in (one, two):
+        assert kv.scratch_block_ids("positive", 0, 1) == [kv.managed_num_blocks]
+        assert max(kv.scratch_block_ids("positive", 0, kv.scratch_blocks_per_kv_branch)) < kv.num_blocks_total
+    # Same budget, and both leave surplus: branch count is what sized the pool.
+    assert one.memory_budget_bytes == two.memory_budget_bytes
+    assert one.budget_limited_blocks > one.managed_num_blocks
+    assert two.budget_limited_blocks > two.managed_num_blocks
+
+
+def test_resident_capacity_still_scales_the_managed_pool():
+    """Clamping must not collapse the pool to a single session's requirement."""
+    one = _make_tiny_capacity_kv(requested_capacity=1, available_bytes=1 << 13)
+    three = _make_tiny_capacity_kv(requested_capacity=3, available_bytes=1 << 13)
+
+    assert one.session_capacity == 1
+    assert three.session_capacity == 3
+    assert one.managed_num_blocks == 1 * (1 * 6 + 3) + 2
+    assert three.managed_num_blocks == 1 * (3 * 6 + 3) + 2
 
 
 def test_scratch_capacity_is_derived_from_declared_geometry(monkeypatch):

--- a/tests/diffusion/ar_diffusion/test_paged_attention.py
+++ b/tests/diffusion/ar_diffusion/test_paged_attention.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Tests for AR-Diffusion paged self-attention contexts."""
 
 from __future__ import annotations
@@ -32,7 +33,15 @@ POS = "positive"
 NEG = "negative"
 
 
-def make_state(*, num_layers=1, window_chunks=2, dtype=torch.float32, device=torch.device("cpu")):
+def make_state(
+    *,
+    num_layers=1,
+    window_chunks=2,
+    frames_per_block=3,
+    dtype=torch.float32,
+    device=torch.device("cpu"),
+):
+    """``frames_per_block`` must cover the widest span the test commits at once."""
     cfg = ARDiffusionKVConfig(enable=True, chunk_size=BLOCK, window_chunks=window_chunks)
     kv = ARDiffusionKVCache(
         cfg,
@@ -45,7 +54,7 @@ def make_state(*, num_layers=1, window_chunks=2, dtype=torch.float32, device=tor
         available_bytes=1 << 26,
         kv_branches=(ARDiffusionKVBranchSpec(POS, 0), ARDiffusionKVBranchSpec(NEG, 1)),
         session_capacity=2,
-        frames_per_block=2,
+        frames_per_block=frames_per_block,
         max_scratch_tokens_per_branch=BLOCK,
         device=device,
     )

--- a/tests/diffusion/ar_diffusion/test_pipeline_bridge.py
+++ b/tests/diffusion/ar_diffusion/test_pipeline_bridge.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Tests for the ARDiffusionKVState paged-attention pipeline bridge."""
 
 import pytest
@@ -22,7 +23,14 @@ POS = "positive"
 NEG = "negative"
 
 
-def make_state(num_layers=1, window_chunks=4, cross_attn_length=0, shared_local_index=False):
+def make_state(
+    num_layers=1,
+    window_chunks=4,
+    cross_attn_length=0,
+    shared_local_index=False,
+    frames_per_block=3,
+):
+    """``frames_per_block`` must cover the widest span the test commits at once."""
     cfg = ARDiffusionKVConfig(enable=True, chunk_size=BLOCK, window_chunks=window_chunks)
     kv = ARDiffusionKVCache(
         cfg,
@@ -39,6 +47,7 @@ def make_state(num_layers=1, window_chunks=4, cross_attn_length=0, shared_local_
         ),
         session_capacity=2,
         cross_attention_lengths={"text": cross_attn_length} if cross_attn_length else None,
+        frames_per_block=frames_per_block,
         device=torch.device("cpu"),
     )
     pos = kv.begin_request("r-pos")

--- a/tests/diffusion/ar_diffusion/test_runner_device.py
+++ b/tests/diffusion/ar_diffusion/test_runner_device.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""CPU contracts for AR-Diffusion runner device resolution (platform-neutral KV sizing)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from vllm_omni.experimental.ar_diffusion import runner as runner_mod
+from vllm_omni.experimental.ar_diffusion.runner import ARDiffusionModelRunner
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+FREE = 7 << 30
+
+
+def make_runner(device: str | None) -> ARDiffusionModelRunner:
+    runner = object.__new__(ARDiffusionModelRunner)
+    runner.device = None if device is None else torch.device(device)
+    return runner
+
+
+@pytest.fixture
+def platform_free_memory(monkeypatch):
+    """Record the device the platform layer is asked about, and answer with FREE."""
+    seen: list[torch.device] = []
+
+    class FakePlatform:
+        @staticmethod
+        def get_free_memory(device=None):
+            seen.append(device)
+            return FREE
+
+    monkeypatch.setattr(runner_mod, "current_omni_platform", FakePlatform)
+    return seen
+
+
+@pytest.mark.parametrize("device", ["xpu:0", "cuda:0"])
+def test_available_memory_delegates_to_the_platform_layer(platform_free_memory, device: str) -> None:
+    assert make_runner(device)._available_memory_bytes() == FREE
+    assert platform_free_memory == [torch.device(device)]
+
+
+def test_available_memory_requires_a_device(platform_free_memory) -> None:
+    with pytest.raises(RuntimeError, match="requires a device"):
+        make_runner(None)._available_memory_bytes()
+
+    assert platform_free_memory == []
+
+
+def test_available_memory_rejects_cpu(platform_free_memory) -> None:
+    """Widening the gate to accelerators must not widen it to cpu.
+
+    ``get_free_memory`` is ``NotImplementedError`` on the platform base, so without
+    this guard a cpu device surfaces that instead of a message naming the problem.
+    """
+    with pytest.raises(RuntimeError, match="got cpu"):
+        make_runner("cpu")._available_memory_bytes()
+
+    assert platform_free_memory == []
+
+
+@pytest.mark.parametrize("kind", ["xpu", "cuda"])
+def test_accelerator_device_matches_the_active_accelerator(monkeypatch, kind: str) -> None:
+    monkeypatch.setattr(torch.accelerator, "current_accelerator", lambda: torch.device(kind))
+
+    assert make_runner(f"{kind}:0")._accelerator_device() == torch.device(f"{kind}:0")
+    assert make_runner("cpu")._accelerator_device() is None
+
+
+def test_accelerator_device_is_none_without_an_accelerator(monkeypatch) -> None:
+    monkeypatch.setattr(torch.accelerator, "current_accelerator", lambda: None)
+
+    assert make_runner("xpu:0")._accelerator_device() is None

--- a/tests/diffusion/models/dreamzero/test_pipeline_state.py
+++ b/tests/diffusion/models/dreamzero/test_pipeline_state.py
@@ -21,22 +21,9 @@ def _empty_pipeline() -> DreamZeroPipeline:
     return pipeline
 
 
-def test_dreamzero_pipeline_state_is_session_keyed() -> None:
-    pipeline = _empty_pipeline()
-
-    session_a = pipeline._get_or_create_state("session-a")
-    session_b = pipeline._get_or_create_state("session-b")
-    session_a.call_count = 7
-    session_b.call_count = 3
-
-    assert pipeline._get_or_create_state("session-a") is session_a
-    assert pipeline._get_or_create_state("session-b") is session_b
-    assert session_a.call_count == 7
-    assert session_b.call_count == 3
-
-
-def test_dreamzero_kv_spec_accounts_for_model_owned_cuda_state(monkeypatch) -> None:
+def _kv_spec_pipeline(cfg_scale: float) -> DreamZeroPipeline:
     pipeline = DreamZeroPipeline.__new__(DreamZeroPipeline)
+    pipeline.cfg_scale = cfg_scale
     pipeline.transformer = SimpleNamespace(
         frame_seqlen=16,
         blocks=[
@@ -56,6 +43,25 @@ def test_dreamzero_kv_spec_accounts_for_model_owned_cuda_state(monkeypatch) -> N
         num_action_per_block=2,
         num_state_per_block=1,
     )
+    return pipeline
+
+
+def test_dreamzero_pipeline_state_is_session_keyed() -> None:
+    pipeline = _empty_pipeline()
+
+    session_a = pipeline._get_or_create_state("session-a")
+    session_b = pipeline._get_or_create_state("session-b")
+    session_a.call_count = 7
+    session_b.call_count = 3
+
+    assert pipeline._get_or_create_state("session-a") is session_a
+    assert pipeline._get_or_create_state("session-b") is session_b
+    assert session_a.call_count == 7
+    assert session_b.call_count == 3
+
+
+def test_dreamzero_kv_spec_accounts_for_model_owned_cuda_state(monkeypatch) -> None:
+    pipeline = _kv_spec_pipeline(cfg_scale=1.0)
     monkeypatch.setattr(
         "vllm_omni.diffusion.models.dreamzero.pipeline_dreamzero.get_classifier_free_guidance_world_size",
         lambda: 1,
@@ -64,6 +70,34 @@ def test_dreamzero_kv_spec_accounts_for_model_owned_cuda_state(monkeypatch) -> N
     spec = pipeline.ar_diffusion_kv_cache_spec()
 
     assert spec.model_owned_state_bytes_per_session == DREAMZERO_MODEL_OWNED_STATE_BYTES_PER_SESSION
+
+
+@pytest.mark.parametrize(
+    ("cfg_scale", "cfg_world_size", "expected_branches", "expected_local_branches"),
+    [
+        (1.0, 1, (("positive", 0),), 1),
+        (1.0, 2, (("positive", 0),), 1),
+        (5.0, 1, (("positive", 0), ("negative", 1)), 2),
+        (5.0, 2, (("positive", 0), ("negative", 0)), 1),
+    ],
+)
+def test_dreamzero_kv_spec_declares_only_active_cfg_branches(
+    monkeypatch,
+    cfg_scale: float,
+    cfg_world_size: int,
+    expected_branches: tuple[tuple[str, int], ...],
+    expected_local_branches: int,
+) -> None:
+    pipeline = _kv_spec_pipeline(cfg_scale)
+    monkeypatch.setattr(
+        "vllm_omni.diffusion.models.dreamzero.pipeline_dreamzero.get_classifier_free_guidance_world_size",
+        lambda: cfg_world_size,
+    )
+
+    spec = pipeline.ar_diffusion_kv_cache_spec()
+
+    assert tuple((branch.name, branch.local_index) for branch in spec.kv_branches) == expected_branches
+    assert spec.num_local_kv_branches == expected_local_branches
 
 
 def test_dreamzero_pipeline_state_follows_runner_lifecycle_notifications() -> None:

--- a/tools/pre_commit/check_torch_cuda.py
+++ b/tools/pre_commit/check_torch_cuda.py
@@ -50,7 +50,6 @@ ALLOWED_FILES = {
     "vllm_omni/diffusion/models/nextstep_1_1/pipeline_nextstep_1_1.py",
     "vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py",
     "vllm_omni/distributed/omni_connectors/connectors/mori_transfer_engine_connector.py",
-    "vllm_omni/experimental/ar_diffusion/runner.py",
     "vllm_omni/model_executor/models/moss_tts/cuda_graph_streaming_decoder_wrapper.py",
     "vllm_omni/model_executor/models/moss_tts_nano/modeling_moss_tts_nano.py",
     "vllm_omni/model_executor/models/qwen3_tts/cuda_graph_decoder_wrapper.py",

--- a/vllm_omni/diffusion/models/dreamzero/pipeline_dreamzero.py
+++ b/vllm_omni/diffusion/models/dreamzero/pipeline_dreamzero.py
@@ -58,8 +58,8 @@ from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 from vllm_omni.experimental.ar_diffusion.capability import (
     ARDiffusionCrossAttentionKVSpec,
-    ARDiffusionKVBranchSpec,
     ARDiffusionKVCacheSpec,
+    cfg_kv_branches,
 )
 from vllm_omni.experimental.world_models.adapters.state_dreamzero_adapter import DreamZeroStateAdapter
 from vllm_omni.experimental.world_models.session_state import (
@@ -132,7 +132,6 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         frame_tokens = int(transformer.frame_seqlen)
         max_attention_tokens = int(transformer.blocks[0].self_attn.max_attention_size)
         cfg_world = int(get_classifier_free_guidance_world_size())
-        negative_local_index = 0 if cfg_world >= 2 else 1
         cross_attention = [
             ARDiffusionCrossAttentionKVSpec("text", int(transformer.text_len)),
         ]
@@ -145,9 +144,11 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
             tokens_per_frame=frame_tokens,
             frames_per_block=int(transformer.num_frame_per_block),
             window_frames=max_attention_tokens // frame_tokens,
-            kv_branches=(
-                ARDiffusionKVBranchSpec(self._POSITIVE_BRANCH, 0),
-                ARDiffusionKVBranchSpec(self._NEGATIVE_BRANCH, negative_local_index),
+            kv_branches=cfg_kv_branches(
+                cfg_enabled=self.cfg_scale > 1.0,
+                cfg_parallel_world_size=cfg_world,
+                positive_name=self._POSITIVE_BRANCH,
+                negative_name=self._NEGATIVE_BRANCH,
             ),
             session_capacity=MAX_DREAMZERO_SESSIONS,
             cross_attention=tuple(cross_attention),

--- a/vllm_omni/experimental/ar_diffusion/__init__.py
+++ b/vllm_omni/experimental/ar_diffusion/__init__.py
@@ -12,6 +12,7 @@ from vllm_omni.experimental.ar_diffusion.capability import (
     ARDiffusionKVCacheSpec,
     SupportsARDiffusionPipeline,
     SupportsARDiffusionWarmup,
+    cfg_kv_branches,
 )
 from vllm_omni.experimental.ar_diffusion.consumer import ARDiffusionOmniTickConsumer
 from vllm_omni.experimental.ar_diffusion.engine import ARDiffusionEngine
@@ -42,4 +43,5 @@ __all__ = [
     "ARDiffusionKVCacheSpec",
     "SupportsARDiffusionPipeline",
     "SupportsARDiffusionWarmup",
+    "cfg_kv_branches",
 ]

--- a/vllm_omni/experimental/ar_diffusion/capability.py
+++ b/vllm_omni/experimental/ar_diffusion/capability.py
@@ -33,6 +33,24 @@ class ARDiffusionKVBranchSpec:
             raise ValueError(f"AR-Diffusion KV branch local_index must be non-negative, got {self.local_index}")
 
 
+def cfg_kv_branches(
+    *,
+    cfg_enabled: bool,
+    cfg_parallel_world_size: int,
+    positive_name: str = "positive",
+    negative_name: str = "negative",
+) -> tuple[ARDiffusionKVBranchSpec, ...]:
+    """Describe the active KV branches for a two-branch CFG model."""
+    if not cfg_enabled:
+        return (ARDiffusionKVBranchSpec(positive_name, 0),)
+
+    negative_local_index = 0 if cfg_parallel_world_size >= 2 else 1
+    return (
+        ARDiffusionKVBranchSpec(positive_name, 0),
+        ARDiffusionKVBranchSpec(negative_name, negative_local_index),
+    )
+
+
 @dataclass(frozen=True)
 class ARDiffusionCrossAttentionKVSpec:
     """A fixed-length, per-layer cross-attention KV allocation."""

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/manager.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/manager.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Engine-level KV cache orchestration for AR-Diffusion models.
 
 This is the *body* of AR-Diffusion's KV management: it owns a vLLM ``KVCacheManager`` (a
@@ -182,6 +183,13 @@ class ARDiffusionKVCache:
             raise ValueError("Phase 1 requires a bounded window (window_chunks)")
         if config.chunk_size <= 0:
             raise ValueError("ARDiffusionKVConfig.chunk_size must be set (> 0)")
+        if block_size != config.chunk_size:
+            # The managed-block requirement counts resident *chunks* as pool
+            # *blocks*, and ChunkWindowManager indexes the sink in chunks too.
+            raise ValueError(
+                "ARDiffusionKVCache requires block_size == chunk_size, got "
+                f"block_size={block_size}, chunk_size={config.chunk_size}"
+            )
         if not kv_branches:
             raise ValueError("ARDiffusionKVCache requires at least one KV branch")
         if session_capacity <= 0:
@@ -254,9 +262,11 @@ class ARDiffusionKVCache:
 
         # The self-attention pool, scratch pool, and lazily materialized
         # cross-attention caches share one hard memory budget. Select the largest
-        # feasible resident-session count rather than raising a block-count floor
-        # past that budget. All resident sessions need a complete sink + window;
-        # only one request can be in flight, so frames_per_block is counted once.
+        # feasible resident-session count, then allocate exactly the managed
+        # blocks that count can address. All resident sessions need a complete
+        # sink + window; the in-flight frames_per_block span is counted once per
+        # worker-local branch, since sequential CFG runs every local branch
+        # within one forward.
         page_size_bytes = self.spec.page_size_bytes * num_layers
         self.available_memory_bytes = available_bytes
         self.configured_memory_budget_bytes = int(available_bytes * config.gpu_memory_fraction)
@@ -273,6 +283,13 @@ class ARDiffusionKVCache:
         )
 
         def _required_managed_blocks(capacity: int) -> int:
+            """Managed blocks the selected capacity can address — the pool size.
+
+            Any new managed-allocation site must be accounted for here. ``+ 2``
+            pays for ``BlockPool``'s null block, which permanently leaves the
+            free queue, plus one spare; with a single worker-local branch that
+            spare is the only slack over peak demand, so do not shrink it.
+            """
             resident_per_session = config.sink_chunks + config.window_chunks
             return self.num_local_kv_branches * (capacity * resident_per_session + self.frames_per_block) + 2
 
@@ -319,8 +336,26 @@ class ARDiffusionKVCache:
             - self.cross_attention_reserved_bytes
             - self.model_owned_state_reserved_bytes
         )
-        num_blocks = self_attn_budget_bytes // page_size_bytes
-        assert num_blocks >= required_managed_blocks
+        # The budget bounds the pool from above, but nothing above
+        # ``_required_managed_blocks`` is addressable: per-branch residency is
+        # capped at sink + window by chunk-window eviction and only one request
+        # is in flight, so surplus blocks would sit in the free queue forever.
+        # Allocate the reachable demand for the capacity just selected.
+        budget_limited_blocks = self_attn_budget_bytes // page_size_bytes
+        assert budget_limited_blocks >= required_managed_blocks
+        self.budget_limited_blocks = budget_limited_blocks
+        num_blocks = required_managed_blocks
+        _log.info(
+            "AR-Diffusion managed KV: required=%d budget_limit=%d allocated=%d "
+            "local_kv_branches=%d resident_capacity=%d page=%d B pool=%.1f MiB",
+            required_managed_blocks,
+            budget_limited_blocks,
+            num_blocks,
+            self.num_local_kv_branches,
+            effective_capacity,
+            page_size_bytes,
+            (num_blocks + self.scratch_num_blocks) * page_size_bytes / (1024 * 1024),
+        )
         if effective_capacity < session_capacity:
             _log.warning(
                 "AR-Diffusion resident session capacity reduced from %d to %d by the KV memory budget",
@@ -513,6 +548,14 @@ class ARDiffusionKVCache:
     # -- request lifecycle ---------------------------------------------------
 
     def begin_request(self, request_id: str, *, prefill_prefix_tokens: int = 0) -> ARDiffusionRequestAdapter:
+        if prefill_prefix_tokens % self.spec.chunk_size:
+            # Chunk-window eviction snaps the skip count down to a chunk
+            # boundary, so an unaligned prefix leaves one extra resident block
+            # per adapter — beyond what the pool is sized for.
+            raise ValueError(
+                f"AR-Diffusion prefill_prefix_tokens must be chunk-aligned (chunk_size="
+                f"{self.spec.chunk_size}), got {prefill_prefix_tokens}"
+            )
         adapter = ARDiffusionRequestAdapter(
             request_id,
             chunk_size=self.spec.chunk_size,
@@ -558,6 +601,15 @@ class ARDiffusionKVCache:
         """Allocate managed blocks for an in-flight video span without committing it."""
         if num_tokens <= 0:
             raise ValueError(f"num_tokens must be positive, got {num_tokens}")
+        max_in_flight_tokens = self.frames_per_block * self.block_size
+        if num_tokens > max_in_flight_tokens:
+            # The pool holds exactly one frames_per_block span per branch, so a
+            # wider span would exhaust it instead of silently borrowing surplus.
+            raise ValueError(
+                f"AR-Diffusion in-flight span of {num_tokens} tokens exceeds the pooled bound "
+                f"frames_per_block * block_size = {max_in_flight_tokens}; the model's declared "
+                "frames_per_block no longer matches its request geometry"
+            )
         blocks = self.manager.allocate_slots(adapter, num_new_tokens=num_tokens)
         if blocks is None:
             raise RuntimeError("AR-Diffusion KV pool exhausted while allocating paged attention slots")

--- a/vllm_omni/experimental/ar_diffusion/runner.py
+++ b/vllm_omni/experimental/ar_diffusion/runner.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 from __future__ import annotations
 
 import dataclasses
@@ -22,6 +23,7 @@ from vllm_omni.experimental.ar_diffusion.kv_cache.config import ARDiffusionKVCon
 from vllm_omni.experimental.ar_diffusion.kv_cache.manager import ARDiffusionKVCache
 from vllm_omni.experimental.ar_diffusion.kv_cache.state import ARDiffusionKVState
 from vllm_omni.experimental.ar_diffusion.tick_protocol import ARDiffusionTickRequest
+from vllm_omni.platforms import current_omni_platform
 
 logger = init_logger(__name__)
 
@@ -83,10 +85,30 @@ class ARDiffusionModelRunner(DiffusionModelRunner):
         if not self.od_config.enforce_eager and self.ar_diffusion_kv_config.warmup_cudagraph:
             self._warmup_ar_rollout()
 
+    def _accelerator_device(self) -> torch.device | None:
+        """This runner's device when it is the active accelerator, else ``None``.
+
+        Keeps the KV pool platform-neutral: CUDA, XPU, and any other backend
+        ``torch.accelerator`` exposes are handled by the same code path.
+        """
+        if self.device is None:
+            return None
+        device = torch.device(self.device)
+        accelerator = torch.accelerator.current_accelerator()
+        return device if accelerator is not None and device.type == accelerator.type else None
+
     def _available_memory_bytes(self) -> int:
-        if self.device is None or torch.device(self.device).type != "cuda":
-            raise RuntimeError("AR-Diffusion KV preallocation currently requires a CUDA device")
-        return int(torch.cuda.mem_get_info(self.device)[0])
+        # Dispatch through the platform layer, which routes to
+        # torch.{cuda,xpu,npu,musa}.mem_get_info -- all of them share CUDA's
+        # (free, total) contract -- so KV preallocation is not pinned to one
+        # backend. The cpu rejection is kept: this widens the gate to
+        # accelerators, it does not remove it.
+        if self.device is None:
+            raise RuntimeError("AR-Diffusion KV preallocation requires a device")
+        device = torch.device(self.device)
+        if device.type == "cpu":
+            raise RuntimeError("AR-Diffusion KV preallocation requires an accelerator device, got cpu")
+        return int(current_omni_platform.get_free_memory(device))
 
     def _preallocate_kv_cache(self, *, available_bytes: int | None = None) -> None:
         """Build pools solely from the pipeline capability and runner config."""
@@ -261,8 +283,9 @@ class ARDiffusionModelRunner(DiffusionModelRunner):
         try:
             with capability.bind_ar_diffusion_state(session_id, state):
                 output = super().execute_model(req, kv_prefetch_job=kv_prefetch_job)
-            if self.device is not None and torch.device(self.device).type == "cuda":
-                torch.accelerator.synchronize(self.device)
+            accelerator_device = self._accelerator_device()
+            if accelerator_device is not None:
+                torch.accelerator.synchronize(accelerator_device)
         except Exception:
             self._release_session(
                 session_id,


### PR DESCRIPTION
## Purpose

With CFG disabled (`cfg_scale <= 1.0`), `DreamZeroPipeline.ar_diffusion_kv_cache_spec()` still declared a `negative` KV branch unconditionally. That branch is never populated in a CFG-off rollout, but it is charged for at allocation time: `ARDiffusionKVCache` sizes the scratch pool, the managed self-attention pool and the per-session cross-attention reservation from the declared topology. A CFG-off run paid for a two-branch KV pool while using one.

This PR makes the declaration match what the configuration runs:

- Add `cfg_kv_branches()` to `experimental/ar_diffusion/capability.py`, returning only the branches active for the current configuration; export it from `experimental/ar_diffusion/__init__.py`.
- Use it in `DreamZeroPipeline`, keyed on `self.cfg_scale > 1.0` and the CFG-parallel world size, replacing the unconditional two-branch tuple.

CFG-on behaviour is unchanged: the positive/negative pair and the `negative_local_index` rule (`0` when CFG-parallel world size >= 2, else `1`) are preserved exactly. Only the CFG-off path changes, and only in what it declares — no attention, scheduling or numerics are touched.

## Test Plan

**vLLM Version:** 0.26.0 for the XPU hardware run (see note). The PR's merge base targets vLLM 0.28.0.

**vLLM-Omni Commit:** PR head `00f88b9cadc3149702f2b44200fbf642667101e5`, merge base `5e4daaf1970ef230c50d6fb2c7ef8ed4895545f8`.

Unit coverage added in this PR:

- `tests/diffusion/ar_diffusion/test_capability.py` — `cfg_kv_branches()` topology across the four (CFG on/off) x (world size 1/2) combinations.
- `tests/diffusion/ar_diffusion/test_capability_runner.py` — the runner consumes a single-branch spec correctly.
- `tests/diffusion/models/dreamzero/test_pipeline_state.py` — DreamZero declares the expected topology for its configured `cfg_scale`.

Hardware A/B on Intel XPU, to confirm the declaration change actually removes the allocation:

- Node `aicf-jf-cicd-10`, 8x Intel B70 (Battlemage, 32.5 GB each); DiT on **TP=4 over physical cards 4,5,6,7** (`ZE_AFFINITY_MASK=4,5,6,7`).
- **DiT-only residency**: the UMT5 text encoder, CLIP image encoder and Wan VAE are neither constructed nor loaded; their outputs are replayed from a captured artifact set at the encoder→DiT boundary, so the KV-pool delta is not buried under encoder/VAE residency. Replay is per TP rank and asserts the captured `current_start_frame` matches the live rollout, so a cadence mismatch fails the run instead of silently pairing the wrong conditioning.
- Model `GEAR-Dreams/DreamZero-DROID`, bfloat16, 16 denoise steps, `max_num_seqs=1`, `enforce_eager`, `TORCH_SDPA`, `gpu_memory_fraction=0.10`, 20 requests per run.
- **The arms differ only by the three files this PR touches.** Both are worktrees of the same commit with the PR diff applied to one; each touched file was verified byte-identical (`cmp`) to `git show` of PR head / merge base, and `diff -rq` over `vllm_omni/` shows no other difference. Same image, kernels, replayed artifacts and `cfg_scale=1.0`; arms alternated across 2 repetitions each.

Note on the base commit: the only XPU image on this node with working `torch-xpu` and a paged-attention kernel accepting `block_size=880` ships vLLM 0.26.0, which cannot import the 0.28.0 APIs (`CoreEngineLaunch`) that `[Rebase] Rebase to vllm 0.28.0 (#6606)` moved main to. The A/B therefore runs on `da4a08b6`, the last main commit before that rebase; the three files this PR touches are byte-identical between `da4a08b6` and the merge base. Two environment-only shims were applied **identically to both arms** and cancel out: a `current_omni_platform.get_free_memory` dispatch for `_available_memory_bytes()` (upstream hard-raises on non-CUDA devices, so neither arm would allocate a KV pool at all), and the DiT-only residency/probe patch.

## Test Result

All four runs completed 20/20 requests with `status=success` and finite outputs. All four TP ranks agree on every allocation-deciding key in both arms, and both arms reproduce bit-identically across repetitions in KV accounting and per-card peak memory.

Branch topology, CFG-off — the bug and the fix:

| | before (main) | after (this PR) |
|---|---|---|
| `kv_branches` | `[('positive', 0), ('negative', 1)]` | `[('positive', 0)]` |
| local KV branches | 2 | 1 |
| managed blocks | 24 | 13 |
| scratch blocks | 6 | 3 |

Memory, per rank (page = 0.18 GB, all 40 layers):

| Quantity | before | after | saved |
|---|---:|---:|---:|
| eager KV pool (managed + scratch) | 5.41 GB | 2.88 GB | **2.52 GB (47%)** |
| cross-attention reservation | 0.315 GB | 0.157 GB | 0.157 GB |
| total KV reservation | 5.72 GB | 3.04 GB | **2.68 GB** |

Measured device memory, not just accounting:

| Metric | before | after | saved |
|---|---:|---:|---:|
| peak device memory per card (`xpu-smi`) | 21.9 GB | 19.4 GB | **2.52 GB (12%)** |
| torch peak allocated (max over ranks) | 16.2 GB | 13.7 GB | 2.53 GB |
| torch peak reserved (max over ranks) | 18.4 GB | 15.9 GB | 2.52 GB |
| after KV pool creation (M3, allocated) | 14.2 GB | 11.7 GB | 2.52 GB |

At TP=4 the aggregate KV reservation saved is **10.7 GB**. DiT weights are identical in both arms (8.78 GB at M1/M2), so the delta is entirely KV allocation.

Latency is unchanged, as expected for an allocation-only change: steady-state mean 3.82 / 3.86 s (before) vs 3.91 / 3.86 s (after), ratio **1.01** — within run-to-run spread. CFG-off already skipped the negative branch's compute; this PR stops paying for its memory.

**Scope of the memory claim.** The saving is a real reduction in allocated device memory here because the one-session floor binds: `ARDiffusionKVCache` uses `memory_budget_bytes = max(configured_budget, one_session_bytes)`, and at `gpu_memory_fraction=0.10` on a 32.5 GB card the configured budget (~2.34 GB/rank) is below one session, so the budget is raised to exactly `_required_bytes(1)` — logged as `raised the configured memory budget from ... to ...`, **6.35 GB before vs 3.67 GB after**. That floor scales with branch count through scratch, managed blocks and cross-attention simultaneously, so removing the dead branch shrinks the real allocation. With a large enough `gpu_memory_fraction` for the configured budget to bind instead, `num_blocks` would absorb the freed bytes and the same fix would deliver resident-session headroom rather than a lower peak. Either way the dead branch stops being charged for.


---

# Added: P1 — clamp the managed pool to reachable block demand

`[AR-Diffusion] Clamp the managed KV pool to reachable block demand` (commit 2)

## Why this belongs with the change above

The A/B above was run at `gpu_memory_fraction=0.10`, and at that setting the
configured budget is **below** one session's requirement — so
`memory_budget_bytes = max(configured, one_session_bytes)` pins the budget *to* the
requirement, and `num_blocks = self_attn_budget_bytes // page_size_bytes` lands on
it. That is why declaring one branch instead of two moved managed blocks 24 → 13:
in this regime the allocator is already demand-sized, and the branch count feeds
`one_session_bytes` directly. (The run will have logged *"raised the configured
memory budget … to admit one session"*, which is the tell for that regime.)

**Raise the budget and the saving disappears.** With a roomy
`gpu_memory_fraction`, `num_blocks` is budget-derived and independent of the
requirement — it is only `assert`ed to be at least as large. Freed branch demand is
then immediately re-spent on blocks nothing can address: per-branch residency is
capped at sink + window by chunk-window eviction, and only one request is in
flight, so the surplus sits in the free queue for the process lifetime.

P1 allocates the reachable demand for the resident capacity actually selected, and
reports what the budget could have afforded as `budget_limited_blocks`. The
CFG-off saving then holds at any budget rather than only at a budget tight enough
to have already forced it.

## The three preconditions it comes with

An exact-fit pool is only safe if the assumptions the formula relies on are
enforced, so P1 adds them as hard errors rather than comments:

| Precondition | Why |
|---|---|
| `block_size == chunk_size` | the managed-block requirement counts resident *chunks* as pool *blocks*, and `ChunkWindowManager` indexes the sink in chunks too |
| `prefill_prefix_tokens` chunk-aligned | chunk-window eviction snaps the skip count down to a chunk boundary, so an unaligned prefix leaves one extra resident block per adapter |
| in-flight span ≤ `frames_per_block * block_size` | the pool holds exactly one such span per branch; a wider one would exhaust it instead of silently borrowing surplus |

The first two already hold at every call site in the tree (`runner.py` passes
`chunk_size=block_size=spec.tokens_per_frame`; nothing calls `begin_request` with a
non-zero `prefill_prefix_tokens`). The third is the one with teeth: it makes two
existing fixtures state the widest span they commit at once, which previously
leaned on surplus blocks that no longer exist.

## Test Plan — P1

| Test | Asserts |
|---|---|
| `test_surplus_budget_does_not_enlarge_the_managed_pool` | a ~32× budget buys no extra managed blocks; `budget_limited_blocks` reports the surplus instead |
| `test_fewer_local_branches_shrink_the_managed_pool_at_equal_budget` | **at equal, roomy budget**, one declared branch allocates a smaller pool than two — this is the assertion that P0's saving now survives a generous budget |
| `test_resident_capacity_still_scales_the_managed_pool` | clamping does not collapse the pool to a single session's requirement |
| `test_kv_pool_budget_accounting` (updated) | the cross-attention deduction is now visible in `budget_limited_blocks`, and `num_blocks` tracks demand |
| `test_paged_attention.py`, `test_pipeline_bridge.py` (fixtures) | `frames_per_block` made an explicit parameter covering the widest committed span |

```bash
pytest -q tests/diffusion/ar_diffusion/ tests/diffusion/models/dreamzero/test_pipeline_state.py
```

## Test Result — P1

Lint gates for all four P1 files, run locally against this commit:

```
check-spdx-header, check-mark, check-torch-cuda-call,
check-forbidden-imports, ruff check, ruff format, py_compile  — all pass
```

**The P1 tests have not been executed.** The machine this commit was prepared on has
no working `torch` and cannot install `vllm`, so the three new cases and the two
fixture changes are written-and-unrun. The `manager.py` change itself applied with
**zero drift** — the pre-change file is byte-identical to current `main` — and every
attribute the new tests read (`managed_num_blocks`, `budget_limited_blocks`,
`memory_budget_bytes`, `scratch_blocks_per_kv_branch`) exists in the tree, but that
is not a substitute for a run. Reviewer CI settles it.

**No new hardware measurement.** The numbers above are P0's A/B and are unchanged by
P1: at `gpu_memory_fraction=0.10` both arms were already demand-sized, so P1 does not
move that measurement. What P1 changes is the regime where the budget is larger than
the requirement, and **that regime was not benchmarked** — its evidence is the unit
test, not a device run. No latency change is claimed for either commit.


---

# Added: P2 — platform-neutral KV preallocation and post-forward sync

`[AR-Diffusion] Make KV preallocation and the post-forward sync platform-neutral` (commit 3)

## Why this belongs here rather than in a follow-up

**It is what makes the A/B above reproducible from a clean checkout.** That measurement
ran with a `get_free_memory` dispatch shim applied identically to both arms, because
`_available_memory_bytes()` hard-raises on non-CUDA devices and neither arm would
otherwise have allocated a KV pool at all. Without this commit the PR reports numbers
from a configuration upstream cannot run. Landing the dispatch turns the shim into
shipped code.

## Two CUDA-only gates, both before any attention call

**1. `_available_memory_bytes()`** raised `"currently requires a CUDA device"` and then
called `torch.cuda.mem_get_info`. It now dispatches through the platform layer: every
platform implements `get_free_memory` over `torch.{cuda,xpu,npu,musa}.mem_get_info` with
the same `(free, total)` contract.

The `cpu` rejection is **kept**. This widens the gate to accelerators, it does not remove
it — `get_free_memory` is `NotImplementedError` on the platform base, so a cpu device
would otherwise surface that instead of a message naming the actual problem.

**2. `execute_model()`'s post-forward `torch.accelerator.synchronize`** was guarded by
`device.type == "cuda"`, so on any other accelerator the synchronize was **skipped
entirely** rather than dispatched. It is now gated on a new `_accelerator_device()`
helper, which returns this runner's device only when it is the active accelerator
(`torch.accelerator.current_accelerator()`), and `None` otherwise.

That second gate is easy to miss — it is 175 lines away from the first and reads as a
CUDA-graph nicety rather than a portability bug.

## Ratchet tightened

`runner.py` no longer contains any `torch.cuda` call site, so it is removed from
`check_torch_cuda.py`'s grandfathered `ALLOWED_FILES` (that hook's own comment directs:
*"Remove a path after migrating it to `current_omni_platform` / `OmniPlatform`"*). The
hook passes with the exemption gone.

## Test Plan — P2

New file `tests/diffusion/ar_diffusion/test_runner_device.py`, 7 cases after
parametrization, CPU only. The runner is built with `object.__new__` and only `.device`
set, so nothing is loaded; the platform layer is replaced with a fake that records which
device it was asked about.

| Test | Asserts |
|---|---|
| `test_available_memory_delegates_to_the_platform_layer[xpu:0\|cuda:0]` | both delegate, and the exact device object is forwarded |
| `test_available_memory_requires_a_device` | `device is None` raises; the platform is never consulted |
| `test_available_memory_rejects_cpu` | a cpu device raises naming cpu; the platform is never consulted |
| `test_accelerator_device_matches_the_active_accelerator[xpu\|cuda]` | matches the active accelerator; `"cpu"` gives `None` |
| `test_accelerator_device_is_none_without_an_accelerator` | no accelerator gives `None`, so the sync is skipped rather than misdispatched |

```bash
pytest -q tests/diffusion/ar_diffusion/test_runner_device.py
```

## Test Result — P2

Lint gates against this commit, all pass locally:

```
check-spdx-header, check-mark, check-torch-cuda-call (with runner.py no longer exempt),
check-forbidden-imports, ruff check, ruff format, py_compile
```

**The P2 tests have not been executed** — same constraint as P1: no working `torch` and no
installable `vllm` on the machine this was prepared on. `runner.py` applied with **zero
drift** (its pre-change state is byte-identical to current `main`).

**No new hardware measurement**, and none is claimed. P2 changes no sizing arithmetic; it
changes which devices are allowed to reach it. Its effect on the numbers above is to make
them obtainable without a local shim.

## File overlap

Checked against every other branch in flight: **`runner.py` and
`test_runner_device.py` are touched by no other open PR**, and `test_runner_device.py`
does not exist upstream. The three commits here are file-disjoint from each other too —
P0 in `pipeline_dreamzero.py`/`capability.py`, P1 in `kv_cache/manager.py`, P2 in
`runner.py`.


---

# Follow-up measurement — compiled, and in the disaggregated topology (2026-09-05)

The A/B above ran `enforce_eager` with the encoders replaced by replay. This run answers the
open question — does the saving survive with inductor on? — on the same node with the real
3-stage pipeline (#7073), denoise TP=4 on cards 4-7, encode+decode on card 3, 16 denoise steps,
20 requests over 4 DROID scenes, `cfg_parallel_size: 1`, `cfg_scale=1.0`. `status: success`,
20/20, `rc=0`.

**It survives, at the same magnitude.** The manager's own log line, with the arithmetic checking
out at `(13 + 3) × 171.875 MiB`:

| per denoise rank | before | after | saved |
|---|---:|---:|---:|
| `kv_branches` | `positive`, `negative` | **`positive`** | −1 branch |
| managed / scratch blocks | 24 / 6 | **13 / 3** | −11 / −3 |
| **KV pool** | 5,156.2 MiB = **5.41 GB** | 2,750.0 MiB = **2.88 GB** | **2.52 GB (47 %)** |

Identical to the eager figure, which stands to reason — the pool is sized from the capability
spec and the CFG configuration, both independent of the compile path. `required=13
budget_limit=13 allocated=13` confirms the pool is limited by *demand*, so the reduction is real
rather than an artefact of a budget ceiling.

**One caveat this topology exposes.** In-worker torch peaks on the denoise ranks drop by roughly
1.4-1.9 GB/rank (reserved 15.12 → 14.75-14.96 GiB, allocated 14.00 → 12.11-12.65 GiB), but the
**whole-device peak moves only 0.18-0.41 GB** (174-389 MiB per card) — so here the 2.52 GB
becomes unused headroom rather than a lower card peak. That is the regime distinction P1
describes, seen from the other side: in the eager DiT-only A/B the one-session floor bound and
the peak fell by the full 2.52 GB. Whether the headroom is worth anything depends on what you
want to fit next to it. Read as indicative rather than controlled: the card-peak deltas compare
against a different run (different harness, step-cache setting and prompt scheme); the KV pool
numbers themselves are exact.

**Latency unchanged**, as the PR states — no measurable effect in either direction.

**Commit 3 is confirmed load-bearing on XPU, by observation.** The same baseline series without
this PR fails at model load on all four denoise ranks:

```
File "vllm_omni/experimental/ar_diffusion/runner.py", in _preallocate_kv_cache
    available_bytes=self._available_memory_bytes() ...
RuntimeError: AR-Diffusion KV preallocation currently requires a CUDA device
```

rc=1, 11 tracebacks, one card never loaded. So on XPU this PR is a prerequisite for running
AR-Diffusion at all, not only a memory optimisation — worth weighing when scheduling it against
the other DreamZero PRs in flight.
