### PR TITLE
[Bugfix][Model] Fix BAGEL ViT processing, SigLIP layout, RoPE bug, and image limts

### DIFF
--- a/tests/diffusion/models/bagel/test_siglip_navit_wrapper.py
+++ b/tests/diffusion/models/bagel/test_siglip_navit_wrapper.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import numpy as np
+import torch
+from PIL import Image
+from transformers import SiglipVisionConfig, SiglipVisionModel
+
+from vllm_omni.diffusion.models.bagel.bagel_transformer import patchify
+from vllm_omni.diffusion.models.bagel.pipeline_bagel import SiglipNaViTWrapper, bagel_image_size, bagel_vit_transform
+
+
+def test_wrapper_matches_hf_siglip_forward():
+    torch.manual_seed(0)
+    config = SiglipVisionConfig(
+        hidden_size=32, intermediate_size=64, num_hidden_layers=2, num_attention_heads=4, image_size=8, patch_size=2
+    )
+    model = SiglipVisionModel(config).eval()
+    pixels = torch.randn(1, 3, 8, 8)
+    ref = model(pixel_values=pixels).last_hidden_state[0]
+
+    packed = patchify(pixels, 2)[0]
+    pos_ids = torch.arange(packed.shape[0])
+    cu_seqlens = torch.tensor([0, packed.shape[0]], dtype=torch.int32)
+    out = SiglipNaViTWrapper(model)(packed, pos_ids, cu_seqlens, packed.shape[0])
+    torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-4)
+
+
+def test_bagel_image_size_keeps_aspect_and_stride():
+    assert bagel_image_size(2000, 1500, 980, 224, 14) == (980, 728)
+    w, h = bagel_image_size(300, 3000, 980, 224, 14)
+    assert max(w, h) <= 980 and w % 14 == 0 and h % 14 == 0
+
+
+def test_bagel_vit_transform_resizes_and_normalizes():
+    img = Image.effect_noise((2000, 1500), 64).convert("RGB")
+    out = bagel_vit_transform(img)
+    ref = torch.from_numpy(np.array(img.resize((980, 728), Image.BICUBIC))).permute(2, 0, 1)
+    assert out.shape == (3, 728, 980)
+    torch.testing.assert_close(out, (ref.float() / 255 - 0.5) / 0.5)  # ToTensor + Normalize(0.5, 0.5)

--- a/tests/model_executor/models/bagel/test_img2img_batch_routing.py
+++ b/tests/model_executor/models/bagel/test_img2img_batch_routing.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Only the request whose own rows hold the <|fim_middle|> placeholder is img2img: its VAE patches go
+through the generation expert, while the text, img2text and decode requests batched with it -- or
+running after it -- keep the understanding expert whatever their length or order. The rows of each
+request come from prepare_runner_inputs; a chunked prefill keeps its block start per request, and a
+request whose image the encoder cache served (a CFG companion, a resumed request) is matched to the
+same size seen before."""
+
+import pytest
+import torch
+from vllm.multimodal.inputs import MultiModalFeatureSpec, PlaceholderRange
+
+from vllm_omni.model_executor.models.bagel.bagel import OmniBagelForConditionalGeneration
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+FIM, PAD, TEXT = 7, 5, 1  # <|fim_middle|>, <|image_pad|>, a text token
+
+
+def make_model():
+    model = OmniBagelForConditionalGeneration.__new__(OmniBagelForConditionalGeneration)
+    model._img2img_token_id = FIM
+    model._ropes_pending = []
+    model._ropes_metadata = {}
+    model._reset_img2img_state()
+    return model
+
+
+def mrope(ids, features):
+    return OmniBagelForConditionalGeneration.get_mrope_input_positions(None, ids, features)[0][0].tolist()
+
+
+def feature(modality, offset, length, is_embed=None):
+    return MultiModalFeatureSpec(
+        data=None,
+        modality=modality,
+        identifier="x",
+        mm_position=PlaceholderRange(offset=offset, length=length, is_embed=is_embed),
+    )
+
+
+class Req:
+    """One request's prompt: token ids, RoPE positions, the prompt rows of its VAE patches and the
+    (num_vae, num_vit, H, W) its encoder run reports."""
+
+    def __init__(self, req_id, ids, pos, vae_rows=(), info=None):
+        self.req_id, self.ids, self.pos, self.vae_rows, self.info = req_id, ids, pos, set(vae_rows), info
+
+
+def text_req(req_id, n):
+    return Req(req_id, [TEXT] * n, list(range(n)))
+
+
+def img2text_req(req_id, num_patches, pre=1, post=1):
+    ids = [TEXT] * pre + [PAD] * (num_patches + 2) + [TEXT] * post
+    return Req(req_id, ids, mrope(ids, [feature("image", pre, num_patches + 2)]))
+
+
+def img2img_req(req_id, num_vae=8, num_vit=6, size=(64, 48), pre=0, post=1):
+    """text, [<VS> VAE patches <VE> | separator | <VS> ViT patches <VE>], text: num_vae / num_vit count
+    the markers, as _process_img2img_input reports them."""
+    block = num_vae + 1 + num_vit
+    ids = [TEXT] * pre + [FIM] * block + [TEXT] * post
+    is_embed = torch.tensor([True] * num_vae + [False] + [True] * num_vit)
+    pos = mrope(ids, [feature("img2img", pre, block, is_embed)])
+    return Req(req_id, ids, pos, range(pre + 1, pre + num_vae - 1), (num_vae, num_vit, *size))
+
+
+def run_step(model, chunks, pending=(), padding=0):
+    """One model step over ``chunks`` = [(req, tokens computed before, tokens scheduled now)], rows in
+    that order, plus ``padding`` stale <|fim_middle|> rows past the batch (CUDA-graph padding).
+    Returns (MoT used, rows marked as VAE patches, queued rope metadata per request)."""
+    ids, pos = [], []
+    for req, computed, n in chunks:
+        ids += req.ids[computed : computed + n]
+        pos += req.pos[computed : computed + n]
+    ids += [FIM] * padding
+    pos += [0] * padding
+    input_ids, positions = torch.tensor(ids), torch.tensor(pos)
+    for info in pending:
+        model._register_img2img_info(info)  # what _process_img2img_input does per image
+    restored, _ = model.prepare_runner_inputs(
+        None,
+        positions,
+        torch.zeros(len(ids), 1),
+        req_ids=[c[0].req_id for c in chunks],
+        num_computed_tokens=[c[1] for c in chunks],
+        num_scheduled_tokens=[c[2] for c in chunks],
+        input_ids_buffer=input_ids,
+    )
+    use_mot = model._route_img2img(restored, positions)
+    mask = model._vae_token_mask
+    rows = set(mask.nonzero().flatten().tolist()) if mask is not None else set()
+    metas, model._ropes_pending = model._ropes_pending, []
+    return use_mot, rows, metas
+
+
+def expected_rows(chunks):
+    """Batch rows of the VAE patches every chunk brings in."""
+    rows, row0 = set(), 0
+    for req, computed, n in chunks:
+        rows |= {row0 + r - computed for r in req.vae_rows if computed <= r < computed + n}
+        row0 += n
+    return rows
+
+
+def full(req):
+    return req, 0, len(req.ids)
+
+
+@pytest.mark.parametrize("neighbour", ["text", "img2text"])
+@pytest.mark.parametrize("img2img_first", [True, False])
+def test_long_neighbour_in_the_same_batch_keeps_the_understanding_expert(neighbour, img2img_first):
+    img = img2img_req("img")
+    other = text_req("other", 60) if neighbour == "text" else img2text_req("other", 40)
+    assert len(other.ids) > len(img.ids)  # long enough for the old length-based gate to misroute it
+    chunks = [full(img), full(other)] if img2img_first else [full(other), full(img)]
+
+    model = make_model()
+    use_mot, rows, metas = run_step(model, chunks, pending=[img.info])
+
+    assert use_mot and rows == expected_rows(chunks)
+    assert model._pending_img2img_info == []
+    img_meta, other_meta = (metas[0], metas[1]) if img2img_first else (metas[1], metas[0])
+    assert img_meta["image_shape"] == [64, 48] and img_meta["prefill_position_count"] == len(img.ids)
+    assert img_meta["ropes"] == [img.pos[-1] + 1]
+    assert other_meta == {"ropes": [other.pos[-1] + 1]}, "a neighbour must not inherit the img2img metadata"
+
+
+def test_requests_after_an_img2img_one_keep_the_understanding_expert():
+    model = make_model()
+    img = img2img_req("img")
+    assert run_step(model, [full(img)], pending=[img.info])[0]
+
+    for req in (text_req("t", 80), img2text_req("i", 60)):
+        use_mot, rows, metas = run_step(model, [full(req)])
+        assert not use_mot and rows == set() and metas == []
+
+
+def test_decode_neighbours_get_their_own_metadata():
+    a, b, img = text_req("a", 501), text_req("b", 601), img2img_req("img")
+    chunks = [(a, 500, 1), (b, 600, 1), full(img)]
+
+    use_mot, rows, metas = run_step(make_model(), chunks, pending=[img.info])
+
+    assert use_mot and rows == expected_rows(chunks)
+    assert metas[0] == {"ropes": [501]} and metas[1] == {"ropes": [601]}
+    assert metas[2]["image_shape"] == [64, 48]
+
+
+@pytest.mark.parametrize(
+    "cuts", [(3,), (7,), (12,), (13,), (14,), (17,), (20,), (5,), (3, 9), (7, 15), (13, 14), (6, 21)]
+)
+def test_chunked_prefill_marks_the_same_rows_as_one_chunk(cuts):
+    # rows: text 0-4, <VS> 5, patches 6-11, <VE> 12, separator 13, ViT 14-19, text 20-23
+    img = img2img_req("img", num_vae=8, num_vit=6, pre=5, post=4)
+    bounds = (0, *cuts, len(img.ids))
+    model, seen = make_model(), set()
+    for computed, end in zip(bounds, bounds[1:]):
+        n = end - computed
+        neighbour = text_req(f"t{computed}", 30)
+        chunk = (img, computed, n)
+        # the encoder runs in the step whose chunk brings in the block's first row
+        pending = [img.info] if computed <= 5 < end else []
+        use_mot, rows, metas = run_step(model, [full(neighbour), chunk], pending=pending)
+
+        assert rows == expected_rows([full(neighbour), chunk])
+        assert use_mot == bool(rows)
+        seen |= {r - 30 + computed for r in rows}
+        if FIM not in img.ids[computed:end]:
+            assert metas == [], "a chunk without block rows is an ordinary forward"
+            continue
+        assert metas[0] == {"ropes": [30]}
+        assert metas[1]["image_shape"] == [64, 48] and metas[1]["prefill_position_count"] == end
+        assert metas[1]["ropes"] == [img.pos[end - 1] + 1]
+    assert seen == img.vae_rows
+
+
+def test_companion_served_by_the_encoder_cache_finds_its_size():
+    model = make_model()
+    parent = img2img_req("p", pre=3)
+    assert run_step(model, [full(parent)], pending=[parent.info])[0]
+
+    # same image, no encoder run: cfg_text keeps the image and drops the text
+    companion = img2img_req("p__cfg_text", pre=0, post=2)
+    use_mot, rows, metas = run_step(model, [full(companion), full(text_req("t", 50))])
+    assert use_mot and rows == expected_rows([full(companion), full(text_req("t", 50))])
+    assert metas[0]["image_shape"] == [64, 48] and metas[1] == {"ropes": [50]}
+
+
+def test_encoder_outputs_match_by_size_not_order():
+    small = img2img_req("small", num_vae=8, num_vit=6, size=(64, 48))
+    large = img2img_req("large", num_vae=12, num_vit=10, size=(96, 64))
+    chunks = [full(small), full(large)]
+
+    use_mot, rows, metas = run_step(make_model(), chunks, pending=[large.info, small.info])
+
+    assert use_mot and rows == expected_rows(chunks)
+    assert metas[0]["image_shape"] == [64, 48] and metas[1]["image_shape"] == [96, 64]
+
+
+def test_stale_encoder_output_does_not_leak_onto_a_text_batch():
+    model = make_model()
+    img = img2img_req("img")
+    use_mot, rows, metas = run_step(model, [full(text_req("t", 40))], pending=[img.info])
+    assert not use_mot and rows == set() and metas == []
+    assert model._pending_img2img_info == []
+
+
+def test_padding_rows_past_the_batch_are_ignored():
+    model = make_model()
+    img = img2img_req("img")
+    assert run_step(model, [full(img)], pending=[img.info])[0]
+
+    use_mot, rows, _ = run_step(model, [full(text_req("t", 40))], padding=6)
+    assert not use_mot and rows == set()
+
+    chunks = [full(img2img_req("img2"))]
+    use_mot, rows, _ = run_step(model, chunks, padding=6)
+    assert use_mot and rows == expected_rows(chunks)
+
+
+def test_a_request_prefilled_again_starts_over():
+    model = make_model()
+    img = img2img_req("img", pre=2)
+    use_mot, rows, _ = run_step(model, [(img, 0, 6)], pending=[img.info])  # cut inside the VAE block
+    assert use_mot and rows == expected_rows([(img, 0, 6)])
+
+    # preempted and resumed from scratch; the encoder cache still holds the image
+    use_mot, rows, metas = run_step(model, [full(img)])
+    assert use_mot and rows == expected_rows([full(img)])
+    assert metas[0]["prefill_position_count"] == len(img.ids)
+
+
+def test_dummy_runs_without_a_layout_neither_route_nor_touch_the_inputs():
+    """Profiling and CUDA-graph capture call forward without prepare_runner_inputs; reading input_ids
+    or positions there would sync the device inside a graph capture."""
+    model = make_model()
+    img = img2img_req("img")
+    model._register_img2img_info(img.info)  # the profiling run embeds dummy img2img data
+
+    class Untouchable:
+        def __getitem__(self, _):
+            raise AssertionError("input_ids must not be read on a dummy run")
+
+    assert not model._route_img2img(Untouchable(), Untouchable())
+    assert model._pending_img2img_info == [] and model._vae_token_mask is None and model._ropes_pending == []

--- a/tests/model_executor/models/bagel/test_two_stage_vit_path.py
+++ b/tests/model_executor/models/bagel/test_two_stage_vit_path.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""The two-stage Thinker runs SigLIP as NaViT (Bagel/modeling/bagel/siglip_navit.py): each image is
+one sequence, position ids index the 2-D table by (row, col) without stretching to a square, and
+post_layernorm is applied. Compare against the HF modules with the same weights."""
+
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+from transformers import SiglipVisionConfig
+from transformers import SiglipVisionModel as HFSiglipVisionModel
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.model_executor.models.siglip import SiglipVisionModel
+
+from vllm_omni.diffusion.distributed.parallel_state import (
+    destroy_distributed_env,
+    init_distributed_environment,
+    initialize_model_parallel,
+    model_parallel_is_initialized,
+)
+from vllm_omni.model_executor.models.bagel.bagel import OmniBagelForConditionalGeneration
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="vLLM's SigLIP needs a GPU attention backend")
+SIDE = 4  # 4x4 position table -> images up to 56x56 at patch 14
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _single_rank_env():
+    for k, v in {
+        "RANK": "0",
+        "LOCAL_RANK": "0",
+        "WORLD_SIZE": "1",
+        "MASTER_ADDR": "127.0.0.1",
+        "MASTER_PORT": "29511",
+    }.items():
+        os.environ.setdefault(k, v)
+    if not torch.distributed.is_initialized():
+        init_distributed_environment(world_size=1, rank=0, local_rank=0)
+    if not model_parallel_is_initialized():
+        initialize_model_parallel(1, 1, 1, 1, 1, 1, 1)
+    yield
+    destroy_distributed_env()
+
+
+def navit_reference(hf, img):
+    core = getattr(hf, "vision_model", hf)  # transformers 5 flattens SiglipVisionModel
+    ids = OmniBagelForConditionalGeneration.get_flattened_position_ids(None, *img.shape[-2:], 14, SIDE).to(img.device)
+    x = core.embeddings.patch_embedding(img[None]).flatten(2).transpose(1, 2) + core.embeddings.position_embedding(ids)
+    return core.post_layernorm(core.encoder(inputs_embeds=x).last_hidden_state)[0]
+
+
+def test_two_stage_vit_path_matches_hf_navit():
+    torch.manual_seed(0)
+    cfg = SiglipVisionConfig(
+        hidden_size=64, intermediate_size=128, num_hidden_layers=2, num_attention_heads=4, image_size=56, patch_size=14
+    )
+    cfg.vision_use_head = False
+    hf = HFSiglipVisionModel(cfg).cuda().eval()
+    with set_current_vllm_config(VllmConfig()):
+        vit = SiglipVisionModel(cfg).cuda()
+    vit.vision_model.load_weights((k.removeprefix("vision_model."), v) for k, v in hf.state_dict().items())
+
+    model = OmniBagelForConditionalGeneration.__new__(OmniBagelForConditionalGeneration)
+    nn.Module.__init__(model)
+    model.vit_model, model.connector, model.vit_pos_embed = (
+        vit,
+        nn.Identity(),
+        lambda ids: torch.zeros((), device=ids.device),
+    )
+    model.config = SimpleNamespace(vit_config=cfg, vit_max_num_patch_per_side=SIDE)
+
+    square, wide = torch.randn(3, 56, 56, device="cuda"), torch.randn(3, 28, 42, device="cuda")
+    with torch.no_grad():
+        assert torch.allclose(
+            navit_reference(hf, square), hf(pixel_values=square[None]).last_hidden_state[0], atol=1e-5
+        )
+        for img in (square, wide):
+            torch.testing.assert_close(model._vit_embeddings([img])[0], navit_reference(hf, img), atol=1e-4, rtol=1e-4)

--- a/tests/model_executor/models/bagel/test_vit_rope_positions.py
+++ b/tests/model_executor/models/bagel/test_vit_rope_positions.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""BAGEL packs an image block -- <|vision_start|>, the ViT patches and <|vision_end|> -- at a single
+RoPE position and continues the text at the next one (Bagel/modeling/bagel/bagel.py,
+prepare_vit_images); an img2img input is a VAE block, a separator and a ViT block at two positions.
+vLLM's default is one position per token; the Thinker provides its own via get_mrope_input_positions."""
+
+import torch
+from vllm.multimodal.inputs import MultiModalFeatureSpec, PlaceholderRange
+
+from vllm_omni.model_executor.models.bagel.bagel import OmniBagelForConditionalGeneration
+
+
+def feature(modality, offset, length, is_embed=None):
+    return MultiModalFeatureSpec(
+        data=None,
+        modality=modality,
+        identifier="x",
+        mm_position=PlaceholderRange(offset=offset, length=length, is_embed=is_embed),
+    )
+
+
+def positions(num_tokens, features):
+    pos, delta = OmniBagelForConditionalGeneration.get_mrope_input_positions(None, [0] * num_tokens, features)
+    assert pos.shape == (3, num_tokens) and torch.equal(pos[0], pos[1]) and torch.equal(pos[0], pos[2])
+    return pos[0].tolist(), delta
+
+
+def test_image_block_shares_one_position():
+    # T [VS P P P P VE] T T
+    pos, delta = positions(9, [feature("image", 1, 6)])
+    assert pos == [0, 1, 1, 1, 1, 1, 1, 2, 3], "ViT tokens must not get one position per token"
+    assert delta == 4 - 9  # the first decoded token continues at position 4
+
+
+def test_two_images_and_text_only():
+    pos, _ = positions(8, [feature("image", 1, 3), feature("image", 4, 3)])
+    assert pos == [0, 1, 1, 1, 2, 2, 2, 3]
+    assert positions(4, [])[0] == [0, 1, 2, 3]
+
+
+def test_interleaved_text_and_images():
+    # T T [VS P P VE] T T [VS P P VE] T
+    pos, delta = positions(13, [feature("image", 2, 4), feature("image", 8, 4)])
+    assert pos == [0, 1, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 6]
+    assert delta == 7 - 13
+
+
+def test_img2img_vae_separator_vit_layout():
+    # T T [VAE block | separator | ViT block] T : VAE block and separator at 2, ViT block at 3, text from 4
+    is_embed = torch.tensor([True] * 3 + [False] + [True] * 3)
+    pos, delta = positions(10, [feature("img2img", 2, 7, is_embed)])
+    assert pos == [0, 1, 2, 2, 2, 2, 3, 3, 3, 4]
+    assert delta == 5 - 10

--- a/vllm_omni/deploy/bagel.yaml
+++ b/vllm_omni/deploy/bagel.yaml
@@ -10,6 +10,10 @@ async_chunk: false
 
 stages:
   - stage_id: 0
+    # vLLM only asks the model for RoPE positions (get_mrope_input_positions) when the config declares mrope_section
+    hf_overrides:
+      rope_parameters: {rope_type: default, mrope_section: [16, 24, 24]}
+    limit_mm_per_prompt: {image: 4}
     max_num_batched_tokens: 32768
     max_num_seqs: 3
     gpu_memory_utilization: 0.45

--- a/vllm_omni/diffusion/models/bagel/pipeline_bagel.py
+++ b/vllm_omni/diffusion/models/bagel/pipeline_bagel.py
@@ -122,6 +122,28 @@ def default_ae_params() -> AutoEncoderParams:
     )
 
 
+def bagel_image_size(
+    width: int, height: int, max_size: int, min_size: int, stride: int, max_pixels: int = 14 * 14 * 9 * 1024
+):
+    """Target (width, height) of BAGEL's aspect-preserving, stride-aligned ImageTransform (same algorithm as #4345)."""
+
+    def fit(w, h, s):
+        return tuple(max(stride, int(round(round(v * s) / stride) * stride)) for v in (w, h))
+
+    w, h = fit(width, height, max(min(max_size / max(width, height), 1.0), min_size / min(width, height)))
+    if w * h > max_pixels:
+        w, h = fit(w, h, max_pixels / (w * h))
+    if max(w, h) > max_size:
+        w, h = fit(w, h, max_size / max(w, h))
+    return w, h
+
+
+def bagel_vit_transform(img: Image.Image) -> torch.Tensor:
+    """BAGEL's ImageTransform(980, 224, 14): resize, ToTensor, Normalize(mean=0.5, std=0.5) -> (3, H, W)."""
+    img = img.convert("RGB").resize(bagel_image_size(*img.size, 980, 224, 14), Image.BICUBIC)
+    return torch.from_numpy(np.array(img)).float().permute(2, 0, 1) / 127.5 - 1.0
+
+
 class SiglipNaViTWrapper(nn.Module):
     def __init__(self, vision_model):
         super().__init__()
@@ -147,7 +169,7 @@ class SiglipNaViTWrapper(nn.Module):
             mask[..., start:end, start:end] = 0.0
 
         outputs = self.vision_model.encoder(inputs_embeds=hidden_states, attention_mask=mask)
-        return outputs.last_hidden_state.squeeze(0)
+        return self.vision_model.post_layernorm(outputs.last_hidden_state).squeeze(0)
 
 
 class BagelPipeline(nn.Module, SupportsComponentDiscovery, DiffusionPipelineProfilerMixin):
@@ -483,178 +505,113 @@ class BagelPipeline(nn.Module, SupportsComponentDiscovery, DiffusionPipelineProf
             if image_input:
                 image_input = [Image.open(image) if isinstance(image, str) else image for image in image_input]
 
-            if image_input:
-                # If we have an image, we prefill with it
-                if self.image_processor and self.vae:
+            stride = self.bagel.latent_downsample
+            max_img_size = int(self.bagel.max_latent_size * stride)
 
-                    def vit_transforms(img):
-                        return self.image_processor(images=img, return_tensors="pt").pixel_values[0]
+            def _resize_to_stride(img):
+                if img.mode != "RGB":
+                    img = img.convert("RGB")
+                w, h = img.size
+                scale = min(max_img_size / max(w, h), 1.0)
+                min_img_size = min(256, max_img_size)
+                scale = max(scale, min_img_size / min(w, h))
+                new_w = max(stride, int(round(w * scale / stride) * stride))
+                new_h = max(stride, int(round(h * scale / stride) * stride))
+                new_w = min(new_w, max_img_size)
+                new_h = min(new_h, max_img_size)
+                if new_w != w or new_h != h:
+                    img = img.resize((new_w, new_h), Image.BICUBIC)
+                return img
 
-                    stride = self.bagel.latent_downsample
-                    max_img_size = int(self.bagel.max_latent_size * stride)
+            def vae_transforms(img):
+                return torch.from_numpy(np.array(img.convert("RGB"))).float().permute(2, 0, 1) / 127.5 - 1.0
 
-                    def _resize_to_stride(img):
-                        if img.mode != "RGB":
-                            img = img.convert("RGB")
-                        w, h = img.size
-                        # Scale down if longest edge exceeds max
-                        scale = min(max_img_size / max(w, h), 1.0)
-                        # Scale up if shortest edge is too small (min 256)
-                        min_img_size = min(256, max_img_size)
-                        scale = max(scale, min_img_size / min(w, h))
-                        new_w = max(stride, int(round(w * scale / stride) * stride))
-                        new_h = max(stride, int(round(h * scale / stride) * stride))
-                        # Clamp to max
-                        new_w = min(new_w, max_img_size)
-                        new_h = min(new_h, max_img_size)
-                        if new_w != w or new_h != h:
-                            img = img.resize((new_w, new_h), Image.BICUBIC)
-                        return img
+            def to_device(inputs):
+                return {k: v.to(self.device) if torch.is_tensor(v) else v for k, v in inputs.items()}
 
-                    image_input = [_resize_to_stride(img) for img in image_input]
-
-                    resized_w, resized_h = image_input[0].size
-                    image_shape = (resized_h, resized_w)
-                    logger.info(f"img2img: resized image to {resized_w}x{resized_h}")
-
-                    def vae_transforms(img):
-                        if img.mode != "RGB":
-                            img = img.convert("RGB")
-                        # Convert to [-1, 1] tensor (H, W, C) -> (C, H, W)
-                        arr = torch.from_numpy(np.array(img)).float() / 127.5 - 1.0
-                        return arr.permute(2, 0, 1)
-
-                    # Update gen_context with image (VAE + ViT)
-                    gen_input_vae, newlens_vae, new_rope_vae = self.bagel.prepare_vae_images(
-                        curr_kvlens=gen_context["kv_lens"],
-                        curr_rope=gen_context["ropes"],
-                        images=image_input,
-                        transforms=vae_transforms,
-                        new_token_ids=self.new_token_ids,
-                    )
-                    for k, v in gen_input_vae.items():
-                        if torch.is_tensor(v):
-                            gen_input_vae[k] = v.to(self.device)
-                    with torch.autocast(
-                        device_type=self.device.type,
-                        enabled=self.device.type != "cpu",
-                        dtype=self.od_config.dtype,
-                    ):
-                        gen_context["past_key_values"] = self.bagel.forward_cache_update_vae(
-                            self.vae, gen_context["past_key_values"], **gen_input_vae
-                        )
-                    gen_context["kv_lens"] = newlens_vae
-                    gen_context["ropes"] = new_rope_vae
-
-                    gen_input_img, newlens_img, new_rope_img = self.bagel.prepare_vit_images(
-                        curr_kvlens=gen_context["kv_lens"],
-                        curr_rope=gen_context["ropes"],
-                        images=image_input,
-                        transforms=vit_transforms,
-                        new_token_ids=self.new_token_ids,
-                    )
-                    for k, v in gen_input_img.items():
-                        if torch.is_tensor(v):
-                            gen_input_img[k] = v.to(self.device)
-                    for k in ("packed_indexes", "packed_key_value_indexes", "key_values_lens"):
-                        gen_input_img.pop(k, None)
-                    with torch.autocast(
-                        device_type=self.device.type,
-                        enabled=self.device.type != "cpu",
-                        dtype=self.od_config.dtype,
-                    ):
-                        gen_context["past_key_values"] = self.bagel.forward_cache_update_vit(
-                            gen_context["past_key_values"], **gen_input_img
-                        )
-                    gen_context["kv_lens"] = newlens_img
-                    gen_context["ropes"] = new_rope_img
-
-                    cfg_text_context = deepcopy(gen_context)
-
-            # Strip <|im_start|>/<|im_end|> wrappers that end2end.py may have
-            # already added, so prepare_prompts doesn't double-add bos/eos.
-            clean_prompt = prompt.removeprefix("<|im_start|>").removesuffix("<|im_end|>")
-
-            # Update gen_context with text prompt
-            generation_input, newlens, new_rope = self.bagel.prepare_prompts(
-                curr_kvlens=gen_context["kv_lens"],
-                curr_rope=gen_context["ropes"],
-                prompts=[clean_prompt],
-                tokenizer=self.tokenizer,
-                new_token_ids=self.new_token_ids,
+            autocast = torch.autocast(
+                device_type=self.device.type, enabled=self.device.type != "cpu", dtype=self.od_config.dtype
             )
-            # Fail fast with a clear error instead of CUDA gather OOB.
-            max_tid = int(generation_input["packed_text_ids"].max().item())
-            emb_n = int(self.language_model.vocab_size)
-            if max_tid >= emb_n:
-                raise ValueError(
-                    "Tokenizer/model vocab mismatch: max token id "
-                    f"{max_tid} >= embed_tokens size {emb_n}. "
-                    "This usually means you're not using the tokenizer shipped with the Bagel checkpoint, "
-                    "or llm_config.vocab_size is smaller than the tokenizer vocab."
-                )
-            for k, v in generation_input.items():
-                if torch.is_tensor(v):
-                    generation_input[k] = v.to(self.device)
-            with torch.autocast(
-                device_type=self.device.type,
-                enabled=self.device.type != "cpu",
-                dtype=self.od_config.dtype,
-            ):
-                gen_context["past_key_values"] = self.bagel.forward_cache_update_text(
-                    gen_context["past_key_values"], **generation_input
-                )
-            gen_context["kv_lens"] = newlens
-            gen_context["ropes"] = new_rope
 
-            # cfg_text_context: update with negative prompt (no text condition).
-            # When empty, keep cfg_text_context as-is (kv_lens=0) to match
-            # original BAGEL.
-            prompt_negative = first_prompt.get("negative_prompt") if isinstance(first_prompt, dict) else None
-            neg_prompt = prompt_negative if prompt_negative is not None else extra_args.get("negative_prompt", "")
-            if neg_prompt:
-                neg_input, neg_newlens, neg_rope = self.bagel.prepare_prompts(
-                    curr_kvlens=cfg_text_context["kv_lens"],
-                    curr_rope=cfg_text_context["ropes"],
-                    prompts=[neg_prompt],
+            def add_text(context, text):
+                text_input, context["kv_lens"], context["ropes"] = self.bagel.prepare_prompts(
+                    curr_kvlens=context["kv_lens"],
+                    curr_rope=context["ropes"],
+                    prompts=[text],
                     tokenizer=self.tokenizer,
                     new_token_ids=self.new_token_ids,
                 )
-                for k, v in neg_input.items():
-                    if torch.is_tensor(v):
-                        neg_input[k] = v.to(self.device)
-                with torch.autocast(
-                    device_type=self.device.type,
-                    enabled=self.device.type != "cpu",
-                    dtype=self.od_config.dtype,
-                ):
-                    cfg_text_context["past_key_values"] = self.bagel.forward_cache_update_text(
-                        cfg_text_context["past_key_values"], **neg_input
+                max_tid = int(text_input["packed_text_ids"].max().item())
+                emb_n = int(self.language_model.vocab_size)
+                if max_tid >= emb_n:
+                    raise ValueError(
+                        "Tokenizer/model vocab mismatch: max token id "
+                        f"{max_tid} >= embed_tokens size {emb_n}. "
+                        "This usually means you're not using the tokenizer shipped with the Bagel checkpoint, "
+                        "or llm_config.vocab_size is smaller than the tokenizer vocab."
                     )
-                cfg_text_context["kv_lens"] = neg_newlens
-                cfg_text_context["ropes"] = neg_rope
+                with autocast:
+                    context["past_key_values"] = self.bagel.forward_cache_update_text(
+                        context["past_key_values"], **to_device(text_input)
+                    )
 
-            # cfg_img_context: update with text prompt (no image condition)
-            cfg_img_generation_input, cfg_img_newlens, cfg_img_new_rope = self.bagel.prepare_prompts(
-                curr_kvlens=cfg_img_context["kv_lens"],
-                curr_rope=cfg_img_context["ropes"],
-                prompts=[clean_prompt],
-                tokenizer=self.tokenizer,
-                new_token_ids=self.new_token_ids,
-            )
-            for k, v in cfg_img_generation_input.items():
-                if torch.is_tensor(v):
-                    cfg_img_generation_input[k] = v.to(self.device)
-            with torch.autocast(
-                device_type=self.device.type,
-                enabled=self.device.type != "cpu",
-                dtype=self.od_config.dtype,
-            ):
-                cfg_img_context["past_key_values"] = self.bagel.forward_cache_update_text(
-                    cfg_img_context["past_key_values"], **cfg_img_generation_input
+            def add_image(img):
+                """A context image is a clean VAE block followed by a ViT block (BAGEL update_context_image)."""
+                img = _resize_to_stride(img)
+                vae_input, gen_context["kv_lens"], gen_context["ropes"] = self.bagel.prepare_vae_images(
+                    curr_kvlens=gen_context["kv_lens"],
+                    curr_rope=gen_context["ropes"],
+                    images=[img],
+                    transforms=vae_transforms,
+                    new_token_ids=self.new_token_ids,
                 )
-            cfg_img_context["kv_lens"] = cfg_img_newlens
-            cfg_img_context["ropes"] = cfg_img_new_rope
+                with autocast:
+                    gen_context["past_key_values"] = self.bagel.forward_cache_update_vae(
+                        self.vae, gen_context["past_key_values"], **to_device(vae_input)
+                    )
+                vit_input, gen_context["kv_lens"], gen_context["ropes"] = self.bagel.prepare_vit_images(
+                    curr_kvlens=gen_context["kv_lens"],
+                    curr_rope=gen_context["ropes"],
+                    images=[img],
+                    transforms=bagel_vit_transform,
+                    new_token_ids=self.new_token_ids,
+                )
+                for k in ("packed_indexes", "packed_key_value_indexes", "key_values_lens"):
+                    vit_input.pop(k, None)
+                with autocast:
+                    gen_context["past_key_values"] = self.bagel.forward_cache_update_vit(
+                        gen_context["past_key_values"], **to_device(vit_input)
+                    )
+                return img.size[::-1]
+
+            # Pack text and images in prompt order (BAGEL interleave_inference): the chat template puts one
+            # <|image_pad|> per image; without matching placeholders the images go first, then the prompt.
+            images = image_input if image_input and self.image_processor and self.vae else []
+            clean_prompt = prompt.removeprefix("<|im_start|>").removesuffix("<|im_end|>")
+            segments = clean_prompt.split("<|image_pad|>")
+            if len(segments) != len(images) + 1:
+                if images and len(segments) > 1:
+                    logger.warning(
+                        "%d <|image_pad|> placeholder(s) for %d image(s); image positions are "
+                        "ambiguous, packing all images before the prompt.",
+                        len(segments) - 1,
+                        len(images),
+                    )
+                segments = [""] * len(images) + ["".join(segments)]
+            for i, text in enumerate(segments):
+                if text.strip():
+                    cfg_text_context = deepcopy(gen_context)
+                    add_text(gen_context, text)
+                if i < len(images):
+                    image_shape = add_image(images[i])
+                    cfg_text_context = deepcopy(gen_context)
+            prompt_negative = first_prompt.get("negative_prompt") if isinstance(first_prompt, dict) else None
+            neg_prompt = prompt_negative if prompt_negative is not None else extra_args.get("negative_prompt", "")
+            if neg_prompt:
+                add_text(cfg_text_context, neg_prompt)
+            for text in segments:  # the image-free CFG branch sees the text only
+                if text.strip():
+                    add_text(cfg_img_context, text)
 
         # ---- Detect output modality and think mode ----
         modalities = first_prompt.get("modalities", []) if isinstance(first_prompt, dict) else []
@@ -995,12 +952,12 @@ class BagelPipeline(nn.Module, SupportsComponentDiscovery, DiffusionPipelineProf
                                     break
                             # Handle flattened patch embedding for SigLIP
                             if cand.endswith("embeddings.patch_embedding.weight") and tensor.ndim == 2:
-                                # Checkpoint has (Hidden, C*P*P), model expects (Hidden, C, P, P)
                                 if shapes.get(cand) is not None:
                                     target_shape = shapes[cand]
                                     if tensor.numel() == torch.prod(torch.tensor(target_shape)):
-                                        # Reshape tensor to match target
-                                        tensor = tensor.view(target_shape)
+                                        # Bagel stores this as a Linear with (P, Q, C) columns
+                                        out_ch, in_ch, p, q = target_shape
+                                        tensor = tensor.view(out_ch, p, q, in_ch).permute(0, 3, 1, 2).contiguous()
                                         picked = cand
                                         break
 

--- a/vllm_omni/model_executor/models/bagel/bagel.py
+++ b/vllm_omni/model_executor/models/bagel/bagel.py
@@ -660,6 +660,7 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration, SupportsM
         vit = self.vit_model.vision_model
         patch, side = self.config.vit_config.patch_size, self.config.vit_max_num_patch_per_side
         out = []
+        assert len(images) > 0
         for img in images:
             ids = self.get_flattened_position_ids(img.shape[-2], img.shape[-1], patch, side).to(img.device)
             x = vit.embeddings.patch_embedding(img[None].to(vit.embeddings.patch_embedding.weight.dtype))

--- a/vllm_omni/model_executor/models/bagel/bagel.py
+++ b/vllm_omni/model_executor/models/bagel/bagel.py
@@ -15,7 +15,7 @@ from vllm.model_executor.layers.linear import (
 )
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.bagel import BagelForConditionalGeneration
-from vllm.model_executor.models.interfaces import MultiModalEmbeddings
+from vllm.model_executor.models.interfaces import MultiModalEmbeddings, SupportsMRoPE
 from vllm.model_executor.models.qwen2 import Qwen2DecoderLayer, Qwen2MLP
 from vllm.model_executor.models.utils import AutoWeightsLoader
 from vllm.multimodal import MULTIMODAL_REGISTRY
@@ -49,7 +49,7 @@ from vllm_omni.diffusion.models.bagel.bagel_transformer import (
     PositionEmbedding,
     TimestepEmbedder,
 )
-from vllm_omni.diffusion.models.bagel.pipeline_bagel import default_ae_params
+from vllm_omni.diffusion.models.bagel.pipeline_bagel import bagel_image_size, bagel_vit_transform, default_ae_params
 
 
 class OmniBagelProcessor(BagelProcessor):
@@ -63,12 +63,12 @@ class OmniBagelProcessor(BagelProcessor):
     def __call__(self, text=None, images=None, **kwargs):
         is_img2img = kwargs.pop("is_img2img", False)
 
+        from vllm.transformers_utils.processors.bagel import BagelProcessorKwargs
+
         if is_img2img and images is not None:
             # transformers>=5.0 enforces strict kwarg typing on image
             # processors, so split generic kwargs into text/image buckets
             # via the standard ProcessorMixin helper before dispatch.
-            from vllm.transformers_utils.processors.bagel import BagelProcessorKwargs
-
             output_kwargs = self._merge_kwargs(
                 BagelProcessorKwargs,
                 tokenizer_init_kwargs=self.tokenizer.init_kwargs,
@@ -93,12 +93,19 @@ class OmniBagelProcessor(BagelProcessor):
             else:
                 return BatchFeature({})
 
+        if images is not None:
+            output_kwargs = self._merge_kwargs(
+                BagelProcessorKwargs, tokenizer_init_kwargs=self.tokenizer.init_kwargs, **kwargs
+            )
+            pixel_values = [bagel_vit_transform(img) for img in (images if isinstance(images, list) else [images])]
+            text_inputs = dict(self.tokenizer(text, **output_kwargs["text_kwargs"])) if text is not None else {}
+            return BatchFeature({"pixel_values": pixel_values, **text_inputs})
         return super().__call__(text, images, **kwargs)
 
 
 class OmniBagelProcessingInfo(BaseProcessingInfo):
     def get_supported_mm_limits(self) -> Mapping[str, int | None]:
-        return {"image": 1, "img2img": 1}
+        return {"image": None, "img2img": 1}
 
     def get_hf_processor(self, **kwargs: object):
         return self.ctx.get_hf_processor(OmniBagelProcessor, **kwargs)
@@ -313,12 +320,20 @@ class OmniBagelMultiModalProcessor(BaseMultiModalProcessor[OmniBagelProcessingIn
 
         replacements: list[PromptReplacement] = []
 
+        vit_config = hf_config.vit_config
+        image_size, patch_size = vit_config.image_size, vit_config.patch_size
+
+        def num_vit_tokens(width: int, height: int) -> int:
+            """<|vision_start|> + patches of the aspect-preserving resize + <|vision_end|>."""
+            w, h = bagel_image_size(width, height, image_size, 224, patch_size)
+            return (h // patch_size) * (w // patch_size) + 2
+
         image_token_id = tokenizer.get_vocab().get("<|image_pad|>")
         if image_token_id is not None:
-            num_patches = hf_config.vit_max_num_patch_per_side**2
 
             def get_image_replacement(item_idx: int):
-                return [image_token_id] * num_patches
+                size = mm_items.get_items("image", ImageProcessorItems).get_image_size(item_idx)
+                return [image_token_id] * num_vit_tokens(size.width, size.height)
 
             replacements.append(
                 PromptReplacement(
@@ -330,10 +345,6 @@ class OmniBagelMultiModalProcessor(BaseMultiModalProcessor[OmniBagelProcessingIn
 
         img2img_token_id = tokenizer.get_vocab().get("<|fim_middle|>")
         if img2img_token_id is not None:
-            vit_config = hf_config.vit_config
-            image_size = vit_config.image_size
-            num_vit_patches = (image_size // vit_config.patch_size) ** 2
-
             latent_patch_size = getattr(hf_config, "latent_patch_size", 2)
             downsample = hf_config.vae_config.get("downsample", 8)
             latent_downsample = downsample * latent_patch_size
@@ -359,7 +370,7 @@ class OmniBagelMultiModalProcessor(BaseMultiModalProcessor[OmniBagelProcessingIn
 
                 num_vae_patches = (new_h // latent_downsample) * (new_w // latent_downsample)
                 num_vae_total = num_vae_patches + 2
-                num_vit_total = num_vit_patches + 2
+                num_vit_total = num_vit_tokens(w, h)
                 # +1 separator between VAE and ViT blocks so that
                 # extract_embeds_range() produces two distinct mm_prefix_range
                 # entries, preventing VAE tokens from attending to ViT.
@@ -411,7 +422,7 @@ class VAEEncoder(nn.Module):
     info=OmniBagelProcessingInfo,
     dummy_inputs=OmniBagelDummyInputsBuilder,
 )
-class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
+class OmniBagelForConditionalGeneration(BagelForConditionalGeneration, SupportsMRoPE):
     """
     Omni version of BagelForConditionalGeneration.
 
@@ -419,13 +430,12 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
     both VAE latents and ViT features within the AR stage, producing a
     combined KV cache that is then transferred to the DiT stage.
 
-    Position IDs are adjusted so that:
-      - VAE tokens all share position 0
-      - ViT tokens all share position 1
-      - Text tokens use sequential positions starting from 2
-    This matches the position scheme used by the single-stage DiT pipeline,
-    ensuring the transferred KV cache + ropes are directly compatible with
-    the DiT's denoising loop.
+    RoPE positions follow BAGEL (modeling/bagel/bagel.py): every image block --
+    <|vision_start|> + ViT patches + <|vision_end|>, or the VAE / ViT block of
+    img2img -- occupies one position and the text continues from the next one,
+    so the KV cache + ropes handed to the DiT stage match the single-stage
+    pipeline. They are computed per request in get_mrope_input_positions (the
+    LLM itself uses plain 1-D RoPE; the three rows are identical).
     """
 
     # LoRA packed→sublayer mapping for both standard Qwen2 projections
@@ -477,7 +487,7 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         self._img2img_token_id = int(_tok.convert_tokens_to_ids("<|fim_middle|>"))
         self._vae_token_mask: torch.Tensor | None = None
         # Whether the current request packs any VAE / non-VAE tokens, refreshed
-        # in _adjust_positions_for_img2img. Cached as plain bools so the per-layer
+        # in _prepare_img2img. Cached as plain bools so the per-layer
         # MoT routing can branch without calling .any() (which forces a device sync).
         self._has_vae_tokens: bool = False
         self._has_non_vae_tokens: bool = True
@@ -592,12 +602,25 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         num_scheduled_tokens: Sequence[int],
         input_ids_buffer: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
-        """Restore input_ids so _adjust_positions_for_img2img can locate
+        """Restore input_ids so _prepare_img2img can locate
         the <|fim_middle|> placeholder for thinking-mode pre_text_len
         detection."""
         if inputs_embeds is not None and input_ids is None and input_ids_buffer is not None:
             input_ids = input_ids_buffer
         return input_ids, positions
+
+    def get_mrope_input_positions(self, input_tokens: list[int], mm_features: list) -> tuple[torch.Tensor, int]:
+        """One RoPE position per image block (BAGEL prepare_vit_images / prepare_vae_images: markers and
+        patches share it): a token advances the position unless it continues a multimodal placeholder;
+        a placeholder's second embedded range (img2img's ViT block after its VAE block) starts a new one,
+        and the plain <|vision_end|> that closes the VAE block keeps that block's position."""
+        step = torch.ones(len(input_tokens), dtype=torch.long)
+        for f in mm_features:
+            step[f.mm_position.offset + 1 : f.mm_position.offset + f.mm_position.length] = 0
+            for start, _ in f.mm_position.extract_embeds_range()[1:]:
+                step[start] = 1
+        positions = step.cumsum(0) - 1
+        return positions.unsqueeze(0).repeat(3, 1), int(positions[-1]) + 1 - len(input_tokens)
 
     def flush_pending_metadata(self, req_ids: Sequence[str]) -> None:
         """Map pending metadata (batch order) to req_ids after forward().
@@ -618,6 +641,32 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
                 if ropes:
                     meta["ropes"] = [int(r.item()) if isinstance(r, torch.Tensor) else r for r in ropes]
                 self._ropes_metadata[rid] = meta
+
+    def _parse_and_validate_image_input(self, **kwargs: object) -> dict | None:
+        pixel_values = kwargs.pop("pixel_values", None)
+        return None if pixel_values is None else {"type": "pixel_values", "pixel_values": pixel_values}
+
+    @staticmethod
+    def _image_list(pixel_values) -> list[torch.Tensor]:
+        """(N, 3, H, W) / (B, N, 3, H, W) tensors, or lists of them for mixed sizes -> one (3, H, W) per image."""
+        if not isinstance(pixel_values, (list, tuple)):
+            pixel_values = [pixel_values]
+        return [img for t in pixel_values for img in t.reshape(-1, *t.shape[-3:])]
+
+    def _vit_embeddings(self, images: list[torch.Tensor]) -> list[torch.Tensor]:
+        """SigLIP NaViT as in modeling/bagel/siglip_navit.py: each image is its own sequence with
+        2-D position ids into the 70x70 table, then post_layernorm, connector and BAGEL's sin-cos
+        position embedding on the same grid."""
+        vit = self.vit_model.vision_model
+        patch, side = self.config.vit_config.patch_size, self.config.vit_max_num_patch_per_side
+        out = []
+        for img in images:
+            ids = self.get_flattened_position_ids(img.shape[-2], img.shape[-1], patch, side).to(img.device)
+            x = vit.embeddings.patch_embedding(img[None].to(vit.embeddings.patch_embedding.weight.dtype))
+            x = x.flatten(2).transpose(1, 2) + vit.embeddings.position_embedding(ids)
+            x = vit.maybe_layer_norm_and_apply_head(vit.encoder(inputs_embeds=x, return_all_hidden_states=False))
+            out.append(self.connector(x[0]) + self.vit_pos_embed(ids).to(x.device))
+        return out
 
     def _parse_and_validate_multimodal_inputs(self, **kwargs: object) -> dict:
         mm_input_by_modality = {}
@@ -658,45 +707,40 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         pos_ids = (coords_h[:, None] * max_num_patches_per_side + coords_w).flatten()
         return pos_ids
 
-    def _process_img2text_input(self, multimodal_input):
-        return self._process_image_input(multimodal_input)
+    def _process_img2text_input(self, multimodal_input) -> tuple[torch.Tensor, ...]:
+        images = self._image_list(multimodal_input["pixel_values"])
+        marker_ids = torch.tensor([self._start_of_image_id, self._end_of_image_id], device=images[0].device)
+        start, end = self.language_model.model.embed_tokens(marker_ids).split(1)
+        return tuple(torch.cat([start.to(e.dtype), e, end.to(e.dtype)]) for e in self._vit_embeddings(images))
 
     def _process_img2img_input(self, multimodal_input):
-        pixel_values = multimodal_input["pixel_values"]
-        if pixel_values.ndim == 5:
-            b, n, c, h, w = pixel_values.shape
-            pixel_values = pixel_values.reshape(b * n, c, h, w)
-
-        num_images = pixel_values.shape[0]
-        image_size = self.config.vit_config.image_size
+        pixel_values = self._image_list(multimodal_input["pixel_values"])
+        num_images = len(pixel_values)
+        image_size, patch_size = self.config.vit_config.image_size, self.config.vit_config.patch_size
         p = self.latent_patch_size
         timestep = 0
 
         if self._ropes_pending:
             self._ropes_pending.clear()
 
-        vit_pixel_values = torch.nn.functional.interpolate(
-            pixel_values,
-            size=(image_size, image_size),
-            mode="bicubic",
-            align_corners=False,
+        vit_embeddings_tuple = self._vit_embeddings(
+            [
+                torch.nn.functional.interpolate(
+                    pv[None],
+                    size=bagel_image_size(pv.shape[-1], pv.shape[-2], image_size, 224, patch_size)[::-1],
+                    mode="bicubic",
+                    align_corners=False,
+                )[0]
+                for pv in pixel_values
+            ]
         )
-
-        vit_embeddings_tuple = self._process_image_input({"pixel_values": vit_pixel_values})
-
-        marker_ids = torch.tensor(
-            [self._start_of_image_id, self._end_of_image_id],
-            device=pixel_values.device,
-            dtype=torch.long,
-        )
-        marker_embeds = self.language_model.model.embed_tokens(marker_ids)
-        start_embed = marker_embeds[0:1]
-        end_embed = marker_embeds[1:2]
+        marker_ids = torch.tensor([self._start_of_image_id, self._end_of_image_id], device=pixel_values[0].device)
+        start_embed, end_embed = self.language_model.model.embed_tokens(marker_ids).split(1)
 
         results = []
 
         for i in range(num_images):
-            single_pv = pixel_values[i : i + 1]
+            single_pv = pixel_values[i][None]
             single_pv = self._resize_to_stride(single_pv)
             H, W = single_pv.shape[2:]
 
@@ -744,20 +788,30 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         **kwargs: object,
     ) -> torch.Tensor:
         use_mot = False
+        if positions.ndim == 2:
+            positions = positions[0]
         seq_len = inputs_embeds.shape[0] if inputs_embeds is not None else positions.shape[0]
 
+        has_img2img = (self._pending_img2img_info or self._last_img2img_info is not None) and (
+            input_ids is not None and bool((input_ids == self._img2img_token_id).any())
+        )
+        if self._pending_img2img_info and not has_img2img:
+            # img2img state left over from a concurrently processed request must not
+            # leak onto a batch that carries no img2img placeholder tokens.
+            self._pending_img2img_info.clear()
+
         if self._pending_img2img_info:
-            positions = self._adjust_positions_for_img2img(positions, input_ids)
+            positions = self._prepare_img2img(positions, input_ids)
             use_mot = True
 
-        elif self._last_img2img_info is not None:
+        elif self._last_img2img_info is not None and has_img2img:
             info = self._last_img2img_info
             num_vae, num_vit, _, _ = info
-            num_img2img = num_vae + 1 + num_vit
+            num_img2img = num_vae + 1 + num_vit  # +1 separator
 
             if seq_len >= num_img2img:
                 self._pending_img2img_info = [info]
-                positions = self._adjust_positions_for_img2img(positions, input_ids)
+                positions = self._prepare_img2img(positions, input_ids)
                 use_mot = True
             else:
                 rope = positions[seq_len - 1] + 1
@@ -767,24 +821,15 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
             return self._mot_forward(input_ids, positions, intermediate_tensors, inputs_embeds, **kwargs)
         return super().forward(input_ids, positions, intermediate_tensors, inputs_embeds, **kwargs)
 
-    def _adjust_positions_for_img2img(
+    def _prepare_img2img(
         self,
         positions: torch.Tensor,
         input_ids: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        """Rewrite position IDs for img2img.
-
-        Supports an optional ``pre_text_len`` prefix (thinking-mode) detected
-        via the ``<|fim_middle|>`` token in *input_ids*:
-
-            pre_text -> 0 .. M-1
-            VAE      -> M       (all share)
-            separator-> M
-            ViT      -> M+1     (all share)
-            post_text-> M+2, M+3, ...
-
-        When M=0 (standard img2img) this reduces to VAE->0, ViT->1, text->2..
-        """
+        """Locate the VAE patches of each img2img request for MoT routing and
+        record the rope the DiT stage continues from (positions themselves come
+        from get_mrope_input_positions); ``pre_text_len`` (thinking mode) is
+        detected via the ``<|fim_middle|>`` token in *input_ids*."""
         info_list = self._pending_img2img_info
         self._pending_img2img_info = []
 
@@ -803,15 +848,14 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
                 boundaries.append(i)
         boundaries.append(len(pos_list))
 
-        num_requests = len(boundaries) - 1
-        new_positions = positions.clone()
         vae_mask = torch.zeros(len(positions), dtype=torch.bool, device=positions.device)
 
         img2img_idx = 0
-        for req_idx in range(num_requests):
+        for req_idx in range(len(boundaries) - 1):
             start = boundaries[req_idx]
             end = boundaries[req_idx + 1]
             req_len = end - start
+            rope = pos_list[end - 1] + 1
 
             if img2img_idx < len(info_list):
                 cur_info = info_list[img2img_idx]
@@ -832,35 +876,12 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
                         if indices.numel() > 0:
                             pre_text_len = int(indices[0].item())
 
-                    M = pre_text_len
-                    img_start = start + M
-                    post_text_start = img_start + num_img2img
-
-                    if M > 0:
-                        new_positions[start:img_start] = torch.arange(
-                            0, M, device=positions.device, dtype=positions.dtype
-                        )
-
-                    new_positions[img_start : img_start + num_vae] = M
-                    new_positions[img_start + num_vae] = M  # separator
-                    vit_start = img_start + num_vae + 1
-                    new_positions[vit_start : vit_start + num_vit] = M + 1
-
-                    num_post_text = end - post_text_start
-                    if num_post_text > 0:
-                        new_positions[post_text_start:end] = torch.arange(
-                            M + 2,
-                            M + 2 + num_post_text,
-                            device=positions.device,
-                            dtype=positions.dtype,
-                        )
-
+                    img_start = start + pre_text_len
                     vae_patches_start = img_start + 1
                     vae_patches_end = img_start + num_vae - 1
                     if vae_patches_end > vae_patches_start:
                         vae_mask[vae_patches_start:vae_patches_end] = True
 
-                    rope = M + 2 + num_post_text
                     self._ropes_pending.append(
                         {
                             "ropes": [rope],
@@ -871,7 +892,6 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
                     img2img_idx += 1
                     continue
 
-            rope = int(new_positions[end - 1].item()) + 1
             self._ropes_pending.append({"ropes": [rope]})
 
         # Resolve mask occupancy once here (the only .any() syncs on this path)
@@ -881,7 +901,7 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         self._vae_token_mask = vae_mask if has_vae else None
         self._has_vae_tokens = has_vae
         self._has_non_vae_tokens = bool((~vae_mask).any()) if has_vae else True
-        return new_positions
+        return positions
 
     # ------------------------------------------------------------------
     # MoT (Mixture-of-Transformers) forward path

--- a/vllm_omni/model_executor/models/bagel/bagel.py
+++ b/vllm_omni/model_executor/models/bagel/bagel.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 from collections.abc import Iterable, Mapping, Sequence
 from math import isqrt
 from typing import Any
@@ -8,6 +11,7 @@ from transformers import BatchFeature
 from vllm.config import VllmConfig
 from vllm.config.multimodal import BaseDummyOptions
 from vllm.inputs import ModalityData, MultiModalDataDict
+from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import RMSNorm as VllmRMSNorm
 from vllm.model_executor.layers.linear import (
     QKVParallelLinear,
@@ -50,6 +54,12 @@ from vllm_omni.diffusion.models.bagel.bagel_transformer import (
     TimestepEmbedder,
 )
 from vllm_omni.diffusion.models.bagel.pipeline_bagel import bagel_image_size, bagel_vit_transform, default_ae_params
+
+logger = init_logger(__name__)
+
+# One img2img image: tokens of its VAE and ViT blocks including the <|vision_start|> / <|vision_end|>
+# markers, and the stride-aligned (H, W) the DiT stage generates at.
+Img2ImgInfo = tuple[int, int, int, int]
 
 
 class OmniBagelProcessor(BagelProcessor):
@@ -470,10 +480,9 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration, SupportsM
         self.latent_pos_embed = PositionEmbedding(self.max_latent_size, hidden_size)
         self.time_embedder = TimestepEmbedder(hidden_size)
 
-        self._pending_img2img_info: list[tuple[int, int, int, int]] = []
         self._ropes_pending: list[dict[str, Any]] = []
         self._ropes_metadata: dict[str, dict[str, Any]] = {}
-        self._last_img2img_info: tuple[int, int, int, int] | None = None
+        self._reset_img2img_state()
 
         from transformers import AutoTokenizer
 
@@ -485,12 +494,6 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration, SupportsM
         self._start_of_image_id = int(_tok.convert_tokens_to_ids("<|vision_start|>"))
         self._end_of_image_id = int(_tok.convert_tokens_to_ids("<|vision_end|>"))
         self._img2img_token_id = int(_tok.convert_tokens_to_ids("<|fim_middle|>"))
-        self._vae_token_mask: torch.Tensor | None = None
-        # Whether the current request packs any VAE / non-VAE tokens, refreshed
-        # in _prepare_img2img. Cached as plain bools so the per-layer
-        # MoT routing can branch without calling .any() (which forces a device sync).
-        self._has_vae_tokens: bool = False
-        self._has_non_vae_tokens: bool = True
         self.device = get_local_device()
         self._install_mot_modules(config)
 
@@ -563,13 +566,30 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration, SupportsM
             )
         return pixel_values
 
+    def _reset_img2img_state(self) -> None:
+        """img2img bookkeeping, see _route_img2img."""
+        # Each img2img image the encoder embedded in the current step, in encoder order.
+        self._pending_img2img_info: list[Img2ImgInfo] = []
+        # The same keyed by (num_vae, num_vit), most recent last, for requests whose image the encoder
+        # cache already held: a CFG companion shares its parent's image, a resumed request its own.
+        self._img2img_info_by_size: dict[tuple[int, int], Img2ImgInfo] = {}
+        # (block start in the prompt, info) per request, so every chunk of a chunked prefill routes
+        # the same tokens through the generation expert.
+        self._img2img_by_req: dict[str, tuple[int, Img2ImgInfo]] = {}
+        # (req_id, first row, end row, tokens computed before this step) per request of the batch
+        # about to run, recorded by prepare_runner_inputs; None on dummy runs.
+        self._batch_layout: list[tuple[str, int, int, int]] | None = None
+        # VAE patches of the batch about to run (None: none) and, as plain bools so the per-layer MoT
+        # routing branches without a device sync, whether it holds any VAE / non-VAE rows.
+        self._vae_token_mask: torch.Tensor | None = None
+        self._has_vae_tokens: bool = False
+        self._has_non_vae_tokens: bool = True
+
     def _clear_warmup_state(self):
         """Clear stale state accumulated during warmup/profiling runs."""
         self._ropes_pending.clear()
         self._ropes_metadata.clear()
-        self._pending_img2img_info.clear()
-        self._last_img2img_info = None
-        self._vae_token_mask = None
+        self._reset_img2img_state()
 
     def get_kv_transfer_metadata(
         self,
@@ -578,6 +598,7 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration, SupportsM
         num_computed_tokens: int | None = None,
     ) -> dict[str, Any] | None:
         # NOTE: num_computed_tokens will not include async placeholders
+        self._img2img_by_req.pop(req_id, None)
         meta = self._ropes_metadata.pop(req_id, None)
         if meta is None:
             return None
@@ -602,11 +623,17 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration, SupportsM
         num_scheduled_tokens: Sequence[int],
         input_ids_buffer: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
-        """Restore input_ids so _prepare_img2img can locate
-        the <|fim_middle|> placeholder for thinking-mode pre_text_len
-        detection."""
+        """Restore input_ids (the runner hands a multimodal batch over as embeddings only) so that
+        _route_img2img sees the <|fim_middle|> placeholders, and record which rows of the batch
+        belong to which request."""
         if inputs_embeds is not None and input_ids is None and input_ids_buffer is not None:
             input_ids = input_ids_buffer
+        layout: list[tuple[str, int, int, int]] = []
+        start = 0
+        for req_id, computed, scheduled in zip(req_ids, num_computed_tokens, num_scheduled_tokens):
+            layout.append((req_id, start, start + int(scheduled), int(computed)))
+            start += int(scheduled)
+        self._batch_layout = layout
         return input_ids, positions
 
     def get_mrope_input_positions(self, input_tokens: list[int], mm_features: list) -> tuple[torch.Tensor, int]:
@@ -774,11 +801,18 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration, SupportsM
 
             num_vae = h * w + 2  # +2 for start/end markers
             num_vit = vit_emb.shape[0] + 2
-            info = (num_vae, num_vit, int(H), int(W))
-            self._pending_img2img_info.append(info)
-            self._last_img2img_info = info
+            self._register_img2img_info((num_vae, num_vit, int(H), int(W)))
 
         return tuple(results)
+
+    def _register_img2img_info(self, info: Img2ImgInfo) -> None:
+        """Record one encoder run for this step's routing and, by size, for the requests the encoder
+        cache serves later."""
+        self._pending_img2img_info.append(info)
+        key = (info[0], info[1])
+        # most recent last: _match_img2img_info prefers it when several sizes fit a cut block
+        self._img2img_info_by_size.pop(key, None)
+        self._img2img_info_by_size[key] = info
 
     def forward(
         self,
@@ -788,121 +822,167 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration, SupportsM
         inputs_embeds: torch.Tensor | None = None,
         **kwargs: object,
     ) -> torch.Tensor:
-        use_mot = False
         if positions.ndim == 2:
             positions = positions[0]
-        seq_len = inputs_embeds.shape[0] if inputs_embeds is not None else positions.shape[0]
-
-        has_img2img = (self._pending_img2img_info or self._last_img2img_info is not None) and (
-            input_ids is not None and bool((input_ids == self._img2img_token_id).any())
-        )
-        if self._pending_img2img_info and not has_img2img:
-            # img2img state left over from a concurrently processed request must not
-            # leak onto a batch that carries no img2img placeholder tokens.
-            self._pending_img2img_info.clear()
-
-        if self._pending_img2img_info:
-            positions = self._prepare_img2img(positions, input_ids)
-            use_mot = True
-
-        elif self._last_img2img_info is not None and has_img2img:
-            info = self._last_img2img_info
-            num_vae, num_vit, _, _ = info
-            num_img2img = num_vae + 1 + num_vit  # +1 separator
-
-            if seq_len >= num_img2img:
-                self._pending_img2img_info = [info]
-                positions = self._prepare_img2img(positions, input_ids)
-                use_mot = True
-            else:
-                rope = positions[seq_len - 1] + 1
-                self._ropes_pending.append({"ropes": [rope]})
-
-        if use_mot:
+        if self._route_img2img(input_ids, positions):
             return self._mot_forward(input_ids, positions, intermediate_tensors, inputs_embeds, **kwargs)
         return super().forward(input_ids, positions, intermediate_tensors, inputs_embeds, **kwargs)
+
+    def _route_img2img(self, input_ids: torch.Tensor | None, positions: torch.Tensor) -> bool:
+        """Set up the MoT routing of this batch; True when it holds VAE patches for the generation
+        expert. Gated per request on the <|fim_middle|> placeholder in the request's own rows of
+        *input_ids*, so a text or img2text request batched with an img2img one, or running after it,
+        keeps the understanding expert. Only batches the runner described through
+        prepare_runner_inputs are inspected: a dummy run (profiling, CUDA-graph capture) carries no
+        layout and must not sync the device."""
+        layout = self._batch_layout
+        self._batch_layout = None
+        self._vae_token_mask = None
+        self._has_vae_tokens = False
+        self._has_non_vae_tokens = True
+        is_img2img = None
+        if (
+            layout
+            and input_ids is not None
+            and (self._pending_img2img_info or self._img2img_info_by_size or self._img2img_by_req)
+        ):
+            # Rows past the batch's own are CUDA-graph padding; the buffer still holds earlier tokens there.
+            is_img2img = input_ids[: layout[-1][2]] == self._img2img_token_id
+            if not bool(is_img2img.any()):
+                is_img2img = None
+        if is_img2img is None:
+            # Encoder output no request of this batch consumes (profiling, an aborted request) must
+            # not leak onto a later batch.
+            self._pending_img2img_info.clear()
+            return False
+        self._prepare_img2img(positions, is_img2img, layout)
+        return self._has_vae_tokens
 
     def _prepare_img2img(
         self,
         positions: torch.Tensor,
-        input_ids: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        """Locate the VAE patches of each img2img request for MoT routing and
-        record the rope the DiT stage continues from (positions themselves come
-        from get_mrope_input_positions); ``pre_text_len`` (thinking mode) is
-        detected via the ``<|fim_middle|>`` token in *input_ids*."""
-        info_list = self._pending_img2img_info
+        is_img2img: torch.Tensor,
+        layout: list[tuple[str, int, int, int]],
+    ) -> None:
+        """Per request of the batch (``layout``: req_id, first row, end row, tokens computed before
+        this step): mark its VAE patches in ``_vae_token_mask`` and queue the rope the DiT stage
+        continues from. A request is img2img only where *is_img2img* marks its own rows. Its
+        ``(num_vae, num_vit, H, W)`` is this step's encoder output matched on the block layout the
+        rows show -- exact once the block is complete, a lower bound while a chunk cuts it -- or,
+        when the encoder cache served the image, the same size seen before; the block start is kept
+        per request so later chunks of the same prefill mark the right rows."""
+        pending = self._pending_img2img_info
         self._pending_img2img_info = []
+        num_tokens = layout[-1][2]
+        # Two host copies for the batch instead of a device sync per request.
+        pos_list = positions[:num_tokens].tolist()
+        tok_list = is_img2img.tolist()
 
-        if not info_list:
-            self._vae_token_mask = None
-            self._has_vae_tokens = False
-            self._has_non_vae_tokens = True
-            return positions
+        # [req_id, first row, end row, computed, (block start, info) | None]
+        slices: list[list[Any]] = []
+        fresh: list[tuple[int, tuple[int, int, bool, int, bool]]] = []
+        for req_id, start, end, computed in layout:
+            state = self._img2img_by_req.get(req_id)
+            if state is not None and computed == 0:
+                # prefilled again from scratch (preemption): the earlier prefill's block is gone
+                del self._img2img_by_req[req_id]
+                state = None
+            slices.append([req_id, start, end, computed, state])
+            if state is None:
+                block = self._visible_img2img_block(tok_list[start:end], pos_list[start:end])
+                if block is not None:
+                    fresh.append((len(slices) - 1, block))
 
-        boundaries = [0]
-        # Copy positions to the host once: indexing the CUDA tensor element by
-        # element in the loop below would sync the device on every iteration.
-        pos_list = positions.tolist()
-        for i in range(1, len(pos_list)):
-            if pos_list[i] < pos_list[i - 1]:
-                boundaries.append(i)
-        boundaries.append(len(pos_list))
+        # Complete blocks match their encoder output exactly and go first; a block a chunk cuts
+        # only bounds its size and takes what is left.
+        for idx, block in sorted(fresh, key=lambda item: not (item[1][2] and item[1][4])):
+            req_id, _, _, computed, _ = slices[idx]
+            info = self._match_img2img_info(block, pending)
+            if info is None:
+                info = self._provisional_img2img_info(block)
+                logger.warning(
+                    "No encoder output matches the img2img block of request %s (visible layout %s); "
+                    "routing its visible VAE rows and leaving the DiT image size to the request",
+                    req_id,
+                    block,
+                )
+            state = (computed + block[0], info)
+            slices[idx][4] = state
+            self._img2img_by_req[req_id] = state
+        if pending:
+            logger.debug("Dropping %d img2img encoder outputs no request of this batch consumed", len(pending))
 
-        vae_mask = torch.zeros(len(positions), dtype=torch.bool, device=positions.device)
-
-        img2img_idx = 0
-        for req_idx in range(len(boundaries) - 1):
-            start = boundaries[req_idx]
-            end = boundaries[req_idx + 1]
-            req_len = end - start
+        vae_mask = torch.zeros(positions.shape[0], dtype=torch.bool, device=positions.device)
+        num_vae_rows = 0
+        for req_id, start, end, computed, state in slices:
             rope = pos_list[end - 1] + 1
+            if state is None:
+                self._ropes_pending.append({"ropes": [rope]})
+                continue
+            block_start, (num_vae, _, img_h, img_w) = state
+            # the VAE block without its markers, clipped to this step's chunk of the request
+            lo = max(block_start + 1, computed)
+            hi = min(block_start + num_vae - 1, computed + end - start)
+            if hi > lo:
+                vae_mask[start + lo - computed : start + hi - computed] = True
+                num_vae_rows += hi - lo
+            meta: dict[str, Any] = {"ropes": [rope], "prefill_position_count": computed + end - start}
+            if img_h and img_w:
+                meta["image_shape"] = [img_h, img_w]
+            self._ropes_pending.append(meta)
 
-            if img2img_idx < len(info_list):
-                cur_info = info_list[img2img_idx]
-            elif self._last_img2img_info is not None:
-                cur_info = self._last_img2img_info
-            else:
-                cur_info = None
+        self._has_vae_tokens = num_vae_rows > 0
+        self._has_non_vae_tokens = num_vae_rows < positions.shape[0]
+        self._vae_token_mask = vae_mask if self._has_vae_tokens else None
 
-            if cur_info is not None:
-                num_vae, num_vit, img_H, img_W = cur_info
-                num_img2img = num_vae + 1 + num_vit  # +1 separator
+    @staticmethod
+    def _visible_img2img_block(tok: list[bool], pos: list[int]) -> tuple[int, int, bool, int, bool] | None:
+        """Layout of the img2img block that starts in these rows, or None: (first row, rows of the VAE
+        group, whether it is complete, rows of the ViT group, whether it is complete). The VAE block
+        and its separator share one RoPE position and the ViT block takes the next
+        (get_mrope_input_positions), which tells the groups apart; a group is complete when the rows
+        continue past it."""
+        if True not in tok:
+            return None
+        first = tok.index(True)
+        n = len(tok)
+        i = first
+        while i < n and tok[i] and pos[i] == pos[first]:
+            i += 1
+        j = i
+        while j < n and tok[j] and pos[j] == pos[first] + 1:
+            j += 1
+        return first, i - first, i < n, j - i, j < n
 
-                if req_len >= num_img2img:
-                    pre_text_len = 0
-                    if input_ids is not None:
-                        req_ids_slice = input_ids[start:end]
-                        indices = (req_ids_slice == self._img2img_token_id).nonzero(as_tuple=True)[0]
-                        if indices.numel() > 0:
-                            pre_text_len = int(indices[0].item())
+    def _match_img2img_info(
+        self, block: tuple[int, int, bool, int, bool], pending: list[Img2ImgInfo]
+    ) -> Img2ImgInfo | None:
+        """The encoder output describing *block*: one of this step's, else the same size seen before
+        (the encoder cache serves a CFG companion, which shares its parent's image, and a resumed
+        request without running the encoder again). A complete group must match exactly, a cut one
+        bounds the size."""
+        _, n_vae, vae_done, n_vit, vit_done = block
 
-                    img_start = start + pre_text_len
-                    vae_patches_start = img_start + 1
-                    vae_patches_end = img_start + num_vae - 1
-                    if vae_patches_end > vae_patches_start:
-                        vae_mask[vae_patches_start:vae_patches_end] = True
+        def fits(info: Img2ImgInfo) -> bool:
+            vae_rows, vit_rows = info[0] + 1, info[1]  # the VAE group also holds the separator
+            return (vae_rows == n_vae if vae_done else vae_rows >= n_vae) and (
+                vit_rows == n_vit if vit_done else vit_rows >= n_vit
+            )
 
-                    self._ropes_pending.append(
-                        {
-                            "ropes": [rope],
-                            "image_shape": [img_H, img_W],
-                            "prefill_position_count": req_len,
-                        }
-                    )
-                    img2img_idx += 1
-                    continue
+        for i, info in enumerate(pending):
+            if fits(info):
+                return pending.pop(i)
+        for info in reversed(self._img2img_info_by_size.values()):
+            if fits(info):
+                return info
+        return None
 
-            self._ropes_pending.append({"ropes": [rope]})
-
-        # Resolve mask occupancy once here (the only .any() syncs on this path)
-        # and cache it; the per-layer routing reads these flags instead of
-        # re-checking the mask on every decoder layer.
-        has_vae = bool(vae_mask.any())
-        self._vae_token_mask = vae_mask if has_vae else None
-        self._has_vae_tokens = has_vae
-        self._has_non_vae_tokens = bool((~vae_mask).any()) if has_vae else True
-        return positions
+    @staticmethod
+    def _provisional_img2img_info(block: tuple[int, int, bool, int, bool]) -> Img2ImgInfo:
+        """Best guess from the visible rows alone: every VAE-group row after the start marker is a
+        patch, so a cut group is read as ending right after its last visible row; no image size."""
+        _, n_vae, vae_done, n_vit, _ = block
+        return (n_vae - 1 if vae_done else n_vae + 1), n_vit, 0, 0
 
     # ------------------------------------------------------------------
     # MoT (Mixture-of-Transformers) forward path


### PR DESCRIPTION
<!-- markdownlint-disable -->
Bugs fixed:

`vllm_omni/diffusion/models/bagel/pipeline_bagel.py` (single-stage):
1. `BagelPipeline.load_weights`: the checkpoint's `[1152, 588]` SigLIP patch-embedding weight is viewed into the Conv2d with the wrong `(C, P, Q)` layout.
2. `SiglipNaViTWrapper.forward`: SigLIP's `post_layernorm` is skipped.
3. `vit_transforms` in `BagelPipeline.forward`: every image is stretched to 980×980 instead of BAGEL's aspect-preserving resize.
4. `BagelPipeline.forward`: text and images are not packed in the prompt's order, and the `<|image_pad|>` placeholders stay in the text as stray tokens.

`vllm_omni/model_executor/models/bagel/bagel.py` (two-stage Thinker):

5. ViT input (`OmniBagelProcessor.__call__`, `OmniBagelMultiModalProcessor._get_prompt_updates`, `_process_img2img_input`): the same 980×980 stretch with a fixed 70×70 position grid, no `<|vision_start|>` / `<|vision_end|>` in the image block, and `pixel_values` crashes when images have different sizes.
6. `OmniBagelForConditionalGeneration.forward`: for img2text the ViT tokens get incrementing RoPE positions instead of the one position shared by the whole image block.
7. `OmniBagelForConditionalGeneration.forward`: after any img2img request, later unrelated requests are misrouted through the img2img MoT path and answer with an empty string.
8. `OmniBagelProcessingInfo.get_supported_mm_limits`: hard cap of one image per request that no configuration can raise.

## Purpose

### 1. Patch-embedding weight loaded with the wrong layout

- **Where**: `BagelPipeline.load_weights` (`pipeline_bagel.py`).
- **Bug**: the checkpoint stores `patch_embedding.weight` as an already-converted Linear of shape `[1152, 588]` whose 588 columns are ordered `(P, Q, C)` — P/Q the row/column inside the 14×14 patch, C the RGB channel (column index `p*14*3 + q*3 + c`). The loader turned it into the Conv2d shape with a raw `view`, which reads the columns as `(C, P, Q)` (`c*14*14 + p*14 + q`), so every patch vector is multiplied by a permuted weight matrix. All single-stage modes that see images are affected.
- **Fix**: convert with `view(out, P, Q, C).permute(0, 3, 1, 2)` — the inverse of the reference's Conv2d→Linear conversion, and the same conversion vllm-core's two-stage loader already does (`vllm/model_executor/models/bagel.py`).
- **Reference**: the reference converts the Conv2d to a Linear with `weight.permute(0, 2, 3, 1)` at model build time, so checkpoints are saved in that layout: [`siglip_navit.py#L167-L176`](https://github.com/ByteDance-Seed/Bagel/blob/a2fa77dd8caeefc41e6607ae0ec17408d3f4ee9f/modeling/bagel/siglip_navit.py#L167-L176), [`pretrain_unified_navit.py#L526`](https://github.com/ByteDance-Seed/Bagel/blob/a2fa77dd8caeefc41e6607ae0ec17408d3f4ee9f/train/pretrain_unified_navit.py#L526).

### 2. `post_layernorm` skipped

- **Where**: `SiglipNaViTWrapper.forward` (`pipeline_bagel.py`).
- **Bug**: the wrapper calls `vision_model.encoder(...)` and returns `last_hidden_state` directly; `SiglipEncoder` has no `post_layernorm`, so SigLIP's final LayerNorm is silently dropped. (The wrapper cannot use the HF `SiglipVisionModel.forward`, which applies it, because that only accepts 4-D images with fixed position ids, not packed NaViT patches.)
- **Fix**: apply `vision_model.post_layernorm` to the encoder output before returning.
- **Reference**: the reference runs the full `SiglipVisionTransformer.forward` — embeddings → encoder → `post_layernorm`: [`siglip_navit.py#L370`](https://github.com/ByteDance-Seed/Bagel/blob/a2fa77dd8caeefc41e6607ae0ec17408d3f4ee9f/modeling/bagel/siglip_navit.py#L370).

### 3. ViT input stretched to 980×980

- **Where**: the `vit_transforms` closure in `BagelPipeline.forward` (`pipeline_bagel.py`).
- **Bug**: it ran images through `SiglipImageProcessor` (fixed `size` 980×980), so a non-square photo is anisotropically stretched and always becomes a 70×70 patch grid.
- **Fix**: `bagel_vit_transform` — resize with BAGEL's algorithm (keep aspect ratio, round both sides to multiples of 14, long edge ≤ 980, short edge ≥ 224, pixel cap), then `ToTensor` + `Normalize(0.5, 0.5)` (`x / 127.5 − 1`). `prepare_vit_images` already derives position ids from the tensor size, so only the transform changes.
- **Reference**: `ImageTransform(980, 224, 14)`: [`app.py#L72`](https://github.com/ByteDance-Seed/Bagel/blob/a2fa77dd8caeefc41e6607ae0ec17408d3f4ee9f/app.py#L72), algorithm in [`data/transforms.py#L15`](https://github.com/ByteDance-Seed/Bagel/blob/a2fa77dd8caeefc41e6607ae0ec17408d3f4ee9f/data/transforms.py#L15).

### 4. Text and images not packed in prompt order; `<|image_pad|>` left in the text as ordinary tokens

- **Where**: `BagelPipeline.forward` (`pipeline_bagel.py`).
- **Bug**: two defects in one place. (a) Every image (VAE + ViT blocks) is encoded first and the whole prompt is appended after them, so for a "text, image, text, image, text" interleaved prompt the order is not correct. (b) The `<|image_pad|>` placeholders that the chat layer inserts to mark the image positions are never consumed, they are tokenized into the prompt and fed to the model as ordinary tokens.
- **Fix**: split the prompt at the placeholders and pack text segments and images in order, with the reference's CFG bookkeeping (`cfg_text` = context before the last text, `cfg_img` = text only). Without one placeholder per image (img2img prompts use `<|fim_middle|>`) the positions are unknown, so the old images-first order is kept, but the stray placeholders are now always stripped from the text, and a warning is logged when the count was ambiguous.
- **Reference**: `InterleaveInferencer.interleave_inference` packs the input list in order: [`inferencer.py#L208`](https://github.com/ByteDance-Seed/Bagel/blob/a2fa77dd8caeefc41e6607ae0ec17408d3f4ee9f/inferencer.py#L208).

### 5. Two-stage code's ViT input bugs: stretch, fixed grid, no markers, stacked-only `pixel_values`

- **Where**: `OmniBagelProcessor.__call__`, `OmniBagelMultiModalProcessor._get_prompt_updates` and `_process_img2img_input` (`model_executor/models/bagel/bagel.py`), plus the inherited vllm-core `_process_image_input`.
- **Bug**: img2text images were resized to 980×980 by `SiglipImageProcessor`, the prompt always got 4900 placeholders, vllm-core's `_process_image_input` added position embeddings for a full 70×70 grid, and `_process_img2img_input` interpolated its ViT input to 980×980 and assumed `pixel_values` is one stacked `(N, 3, H, W)` tensor — vLLM can only stack images of identical size and otherwise delivers a list of `(3, H, W)` tensors, on which `.ndim` raises `AttributeError`. The prompt also had no `<|vision_start|>` / `<|vision_end|>` around the image.
- **Fix**: the processor uses `bagel_vit_transform` (one tensor per image, so `pixel_values` may arrive as a list); `_get_prompt_updates` emits `h/14 · w/14 + 2` placeholders per image; `_vit_embeddings` runs vLLM's SigLIP modules as NaViT (patch embedding → 2-D position ids into the 70×70 table → encoder → `post_layernorm` → connector → BAGEL's sin-cos position embedding) and puts the marker embeddings inside the image block, for img2text and img2img. vLLM already applies bidirectional attention inside image placeholder ranges for BAGEL (`is_mm_prefix_lm`), so the whole block behaves like the reference `full` block. One residual: img2img keeps its existing `<|fim_middle|>` separator between the VAE and ViT blocks (a token BAGEL does not have) — replacing it with the VAE block's `<|vision_end|>` reproducibly broke the DiT's image generation into noise.
- **Reference**: NaViT patching and per-block markers sharing the block's RoPE position: [`siglip_navit.py`](https://github.com/ByteDance-Seed/Bagel/blob/a2fa77dd8caeefc41e6607ae0ec17408d3f4ee9f/modeling/bagel/siglip_navit.py), [`bagel.py#L321-L352`](https://github.com/ByteDance-Seed/Bagel/blob/a2fa77dd8caeefc41e6607ae0ec17408d3f4ee9f/modeling/bagel/bagel.py#L321-L352), [`#L440-L474`](https://github.com/ByteDance-Seed/Bagel/blob/a2fa77dd8caeefc41e6607ae0ec17408d3f4ee9f/modeling/bagel/bagel.py#L440-L474).

### 6. Incrementing RoPE positions for VAE block in img2text

- **Where**: `OmniBagelForConditionalGeneration.forward` (`model_executor/models/bagel/bagel.py`).
- **Bug**: positions were rewritten after the fact for img2img only (VAE block → M, ViT block → M+1, text → M+2…); img2text kept vLLM's default per-token positions (0, 1, 2, …), so a N-patch image spanned N positions.
- **Fix**: implement vLLM's `SupportsMRoPE` interface (`get_mrope_input_positions`), so vLLM's existing M-RoPE machinery computes the positions once per request from the multimodal placeholders (chunked prefill, decode and preemption included): a placeholder advances the position once, its second embedded range (img2img's ViT block) once more, and its separator keeps the VAE block's position. The three rows are identical and `forward` uses row 0 — the LLM keeps 1-D RoPE; `_prepare_img2img` (formerly `_adjust_positions_for_img2img`) keeps only the MoT routing mask and the rope handed to the DiT stage. vLLM only calls the hook when the config declares `mrope_section`, so `bagel.yaml` sets it via `hf_overrides` for stage 0 (`bagel_think.yaml` inherits it).
- **Reference**: an image block — markers and patches — shares one position and the sequence continues at the next one: [`bagel.py#L349`](https://github.com/ByteDance-Seed/Bagel/blob/a2fa77dd8caeefc41e6607ae0ec17408d3f4ee9f/modeling/bagel/bagel.py#L349) (`packed_position_ids.extend([curr_position_id] * (num_img_tokens + 2))`).

### 7. Later requests misrouted through the img2img MoT path

- **Where**: the `self._last_img2img_info` fallback in `OmniBagelForConditionalGeneration.forward` (`model_executor/models/bagel/bagel.py`).
- **Bug**: neither img2img branch checks that the batch actually contains img2img tokens, so state left by a previous img2img request misroutes later requests through the MoT generation expert with a wrong VAE mask, and they answer with an empty string. Two triggers: (a) the fallback treats any later forward with `seq_len >= num_img2img` (the last img2img block's length) as img2img, so every request at least that long is hit and only shorter ones escape; (b) an img2img request's CFG companion requests and concurrent batches can leave unconsumed `_pending_img2img_info` entries, which the first branch applies to whatever request comes next, regardless of its length. Reproducible on `v0.28.0rc1`: an img2text request right after a single img2img returns an empty string.
- **Fix**: both img2img branches additionally require the `<|fim_middle|>` placeholder to be present in the batch's `input_ids`, and stale pending state is dropped.

### 8. Hard cap of one image per request

- **Where**: `OmniBagelProcessingInfo.get_supported_mm_limits` (`model_executor/models/bagel/bagel.py`).
- **Bug**: it returned `{"image": 1}` — the model's supported maximum image number, which vLLM combines with the user setting as `min(limit_mm_per_prompt, supported)` — so a request with two images failed with `500: At most 1 image(s) may be provided in one prompt.` no matter how `limit_mm_per_prompt` was configured.
- **Fix**: return `None` for `image` (vllm-core's value: the deployment config decides); `bagel.yaml` sets `limit_mm_per_prompt: {image: 4}`. `img2img` stays at 1 — the DiT handoff supports one generation image per request.

## Changes

- `vllm_omni/diffusion/models/bagel/pipeline_bagel.py`: `bagel_image_size` / `bagel_vit_transform` (BAGEL's `ImageTransform`); loader converts the patch weight with `view(out, P, Q, C).permute(0, 3, 1, 2)`; `SiglipNaViTWrapper.forward` applies `post_layernorm`; `forward` packs text and images in prompt order.
- `vllm_omni/model_executor/models/bagel/bagel.py`: `OmniBagelProcessor` uses `bagel_vit_transform`; per-image placeholder counts; `_vit_embeddings` NaViT path with marker embeddings and list-form `pixel_values`; `get_mrope_input_positions`; `_prepare_img2img`; the img2img paths gated on the placeholder token actually being present; image limit `None`.
- `vllm_omni/deploy/bagel.yaml`: `hf_overrides.rope_parameters.mrope_section` and `limit_mm_per_prompt` for stage 0.
- Tests: `tests/diffusion/models/bagel/test_siglip_navit_wrapper.py` (wrapper vs HF forward — fails on `main` with max|diff| = 2.18; `bagel_image_size`; `bagel_vit_transform`), `tests/model_executor/models/bagel/test_vit_rope_positions.py` (`[VS, P×4, VE]` → `[0, 1, 1, 1, 1, 1, 1, 2, 3]`, two images, text interleaved with two images, img2img layout, decode delta), `tests/model_executor/models/bagel/test_two_stage_vit_path.py` (GPU: `_vit_embeddings` vs HF NaViT on square and non-square images).

## Test Plan

Samples: the first V*Bench sample image (2000×1500, a street food stall; ViT input 980×728 = 3640 patches); synthetic 2000×400, left half red, right half blue (ViT input 70×14 patches). Reference tensors come from the reference `siglip_navit` on the photo with `ByteDance-Seed/BAGEL-7B-MoT`.

```bash
pytest tests/diffusion/models/bagel/ tests/model_executor/models/bagel/ -q
```
- `bagel_vit_transform(photo)` vs the reference `ImageTransform(980, 224, 14)` tensor.
- ViT output vs reference on the photo (bf16, 26 layers): single-stage `SiglipNaViTWrapper` and two-stage `_vit_embeddings`.
- Single-stage serving (`bagel_single_stage.yaml`): img2text on both samples, interleaved text/image layouts, text2img and img2img.
- Two-stage serving (`bagel.yaml`): 22 concurrent img2img requests with mixed sizes first, then img2text on both samples, one request with both images, interleaved text/image layouts, an img2img sample checked visually, text2img.

**vLLM Version:** vllm 0.28.0

**vLLM-Omni Commit:** v0.28.0rc1

## Test Result

- Unit tests: 70 passed (on `main`: wrapper test fails with max|diff| = 2.18, position tests with `AttributeError: get_mrope_input_positions`).
- Preprocessing: `bagel_vit_transform(photo)` = `3×728×980`, equal to the reference tensor (max|diff| = 0.0); before: `3×980×980`.
- ViT output vs reference (cosine mean / min, rel. L2). "weight layout" = raw `view` vs the `(P, Q, C)`-aware conversion; "post_layernorm" = applied or not.

  | path | weight layout | post_layernorm | cosine | rel. L2 |
  |---|---|---|---|---|
  | single-stage, before (`main`) | raw view | missing | 0.096 / −0.045 | 339 |
  | single-stage, layout fix only | fixed | missing | 0.249 / 0.064 | 390 |
  | single-stage, post_layernorm only | raw view | applied | 0.426 / −0.065 | 1.09 |
  | single-stage, after | fixed | applied | 0.9997 / 0.978 | 0.025 |
  | two-stage _vit_embeddings, after | vllm-core loader | applied | 0.9997 / 0.959 |  0.026 |