### PR TITLE
[Bugfix] Fix vLLM serve error response imports

### DIFF
--- a/vllm_omni/config/endpoint_policy.py
+++ b/vllm_omni/config/endpoint_policy.py
@@ -8,7 +8,8 @@ from typing import NamedTuple
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
-from vllm.entrypoints.serve.utils.error_response import create_error_response
+from starlette.routing import Route
+from vllm.entrypoints.serve import create_error_response
 
 
 class RouteTarget(NamedTuple):
@@ -51,6 +52,16 @@ def build_rejection_handler(reason: str):
     return rejection_handler
 
 
+def _remove_route_from_app(app: FastAPI, path: str, methods: frozenset[str]) -> None:
+    routes_to_remove = [
+        route
+        for route in app.routes
+        if isinstance(route, Route) and route.path == path and route.methods & methods
+    ]
+    for route in routes_to_remove:
+        app.routes.remove(route)
+
+
 def shutdown_unsupported_routes(
     app: FastAPI,
     endpoint_restrictions: tuple[EndpointRestriction, ...],
@@ -58,8 +69,6 @@ def shutdown_unsupported_routes(
     """Given an initialized FastAPI server instance and a set of model specific endpoint
     restrictions, remove the restricted routes and patch a handler that returns 400.
     """
-    from vllm_omni.entrypoints.openai.api_server import _remove_route_from_app
-
     for end_restrict in endpoint_restrictions:
         capability = end_restrict.capability
         # Remove the route from the app

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -64,6 +64,7 @@ from vllm.entrypoints.pooling.embed.serving import ServingEmbedding as OpenAISer
 from vllm.entrypoints.pooling.pooling.serving import ServingPooling
 from vllm.entrypoints.pooling.scoring.serving import ServingScores
 from vllm.entrypoints.scale_out.token_in_token_out.serving import ServingTokens
+from vllm.entrypoints.serve import create_error_response
 
 # vLLM moved `base` from openai.basic.api_router to serve.instrumentator.basic.
 # Keep a fallback for older/newer upstream layouts during rebase windows.
@@ -75,7 +76,6 @@ from vllm.entrypoints.serve.utils.api_utils import (
     validate_json_request,
     with_cancellation,
 )
-from vllm.entrypoints.serve.utils.error_response import create_error_response
 from vllm.entrypoints.serve.utils.orca_metrics import metrics_header
 from vllm.entrypoints.serve.utils.request_logger import RequestLogger
 from vllm.entrypoints.serve.utils.server_utils import get_uvicorn_log_config


### PR DESCRIPTION
Fixes #6705.

## Purpose

Use vLLM's public `create_error_response` export instead of its removed private module path. Keep endpoint-policy configuration independent of the full OpenAI API server when replacing restricted routes.

## Test Plan

- `pytest -q tests/config/test_endpoint_policy.py`
- `ruff check vllm_omni/config/endpoint_policy.py vllm_omni/entrypoints/openai/api_server.py`
- `git diff --check`

**vLLM Version:** `0.27.2rc1.dev187+gcdb8545a9` (official CUDA 13 wheel pinned by this Omni revision)

**vLLM-Omni Commit:** `5045ab321bae7a5c6e29c8a7367d8bcedb85a01c`

## Test Result

`4 passed` — endpoint-policy suite executed in WSL on the RTX 3050 using the exact CI-pinned vLLM wheel.
