### PR TITLE
[Bugfix] Scope MiniMax-H3 cuDNN SDPA state

### DIFF
--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_encoder_sdpa.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_encoder_sdpa.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from collections.abc import Iterator
+
+import pytest
+import torch
+import torch.nn as nn
+
+from vllm_omni.diffusion.models.minimax_h3.encoder import MiniMaxH3Qwen3VLEncoder
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.diffusion]
+
+
+@pytest.fixture(autouse=True)
+def restore_cudnn_sdp_state() -> Iterator[None]:
+    original = torch.backends.cuda.cudnn_sdp_enabled()
+    try:
+        yield
+    finally:
+        torch.backends.cuda.enable_cudnn_sdp(original)
+
+
+def _encoder_without_weights() -> MiniMaxH3Qwen3VLEncoder:
+    encoder = MiniMaxH3Qwen3VLEncoder("unused", device=torch.device("cpu"), load_model=False)
+    encoder.text_model = nn.Linear(1, 1)
+    return encoder
+
+
+@pytest.mark.parametrize("initial_state", [False, True])
+def test_encode_ids_restores_cudnn_sdp_after_success(monkeypatch: pytest.MonkeyPatch, initial_state: bool) -> None:
+    encoder = _encoder_without_weights()
+    expected = torch.tensor([1.0])
+
+    def encode(*args, **kwargs):
+        assert torch.backends.cuda.cudnn_sdp_enabled()
+        return expected
+
+    monkeypatch.setattr(encoder, "_encode", encode)
+    torch.backends.cuda.enable_cudnn_sdp(initial_state)
+
+    actual = encoder.encode_ids(torch.tensor([1]))
+
+    torch.testing.assert_close(actual, expected)
+    assert torch.backends.cuda.cudnn_sdp_enabled() is initial_state
+
+
+@pytest.mark.parametrize("initial_state", [False, True])
+def test_encode_ids_restores_cudnn_sdp_after_failure(monkeypatch: pytest.MonkeyPatch, initial_state: bool) -> None:
+    encoder = _encoder_without_weights()
+
+    def fail(*args, **kwargs):
+        assert torch.backends.cuda.cudnn_sdp_enabled()
+        raise RuntimeError("encode failed")
+
+    monkeypatch.setattr(encoder, "_encode", fail)
+    torch.backends.cuda.enable_cudnn_sdp(initial_state)
+
+    with pytest.raises(RuntimeError, match="encode failed"):
+        encoder.encode_ids(torch.tensor([1]))
+
+    assert torch.backends.cuda.cudnn_sdp_enabled() is initial_state

--- a/vllm_omni/diffusion/models/minimax_h3/encoder.py
+++ b/vllm_omni/diffusion/models/minimax_h3/encoder.py
@@ -1464,15 +1464,19 @@ class MiniMaxH3Qwen3VLEncoder(nn.Module):
         if next(self.parameters()).device.type != self.device_target.type:
             raise RuntimeError("call load_to_device() before encode_ids()")
 
+        cudnn_sdp_enabled = torch.backends.cuda.cudnn_sdp_enabled()
         torch.backends.cuda.enable_cudnn_sdp(True)
-        hidden = self._encode(
-            input_ids,
-            pixel_values=pixel_values,
-            image_grid_thw=image_grid_thw,
-            pixel_values_videos=pixel_values_videos,
-            video_grid_thw=video_grid_thw,
-        )
-        return hidden.cpu()
+        try:
+            hidden = self._encode(
+                input_ids,
+                pixel_values=pixel_values,
+                image_grid_thw=image_grid_thw,
+                pixel_values_videos=pixel_values_videos,
+                video_grid_thw=video_grid_thw,
+            )
+            return hidden.cpu()
+        finally:
+            torch.backends.cuda.enable_cudnn_sdp(cudnn_sdp_enabled)
 
     def forward(
         self,


### PR DESCRIPTION
Fixes #6566

## What broke

`MiniMaxH3Qwen3VLEncoder.encode_ids()` enabled process-global cuDNN SDPA for
text encoding and never restored the previous state. That mutation outlived
the text encoder and changed the backend policy seen by later components in
the same worker process.

This is conclusively observable inside one normal sequence-parallel request;
it does not depend on submitting duplicate prompts to data-parallel replicas.

## Conclusive single-request SP2 reproduction

Run two DiT/SP ranks, but place the text encoder on rank 0 only. Keep the video
VAE patch-parallel across both ranks:

```bash
MODEL=/path/to/MiniMax-H3/FL2VA

vllm serve "$MODEL" \
  --omni \
  --trust-remote-code \
  --model-class-name MiniMaxH3Pipeline \
  --task-type fl2va \
  --num-gpus 2 \
  --data-parallel-size 1 \
  --tensor-parallel-size 1 \
  --usp 2 \
  --ring 1 \
  --text-encoder-tp-size 1 \
  --vae-patch-parallel-size 2 \
  --vae-parallel-mode tile \
  --vae-use-tiling \
  --max-num-seqs 1 \
  --diffusion-attention-backend CUDNN_ATTN \
  --enable-distributed-layerwise-offload \
  --dlo-no-use-allgather \
  --dlo-resident-layers 20 \
  --enforce-eager
```

Submit exactly one T2VA request. A temporary diagnostic probe at the video VAE
entry produced the following lines on unmodified `main` at `04b97a592`:

```text
SP group details for rank 1: sp_group=[0, 1], ulysses_group=[0, 1]
SP group details for rank 0: sp_group=[0, 1], ulysses_group=[0, 1]
MiniMax H3 Qwen3-VL encoder: text_encoder_tp_size=1
ISSUE6566_SP_PROBE rank=0 parallel_size=2 cudnn_sdp=True  vae_sdpa_override=auto
ISSUE6566_SP_PROBE rank=1 parallel_size=2 cudnn_sdp=False vae_sdpa_override=auto
```

This is the bug independently of which VAE backend is preferred: rank 0 and
rank 1 are executing the same request and the same distributed video VAE, but
they enter it with different process-global SDPA state solely because rank 0
ran the text encoder. The request completed as a valid 1024x576, 5.17-second
audio/video MP4, so the mismatch is silent rather than an immediate failure.

## Why this fix is the right scope

This PR does **not** prescribe Flash or cuDNN for the video VAE. It balances a
text-encoder-local global mutation:

1. read the caller/platform's existing cuDNN SDPA state;
2. enable cuDNN for the text encoder's `_encode()` call;
3. restore the exact previous value in `finally`.

That contract is correct whether the previous value is enabled or disabled and
also on exceptions. If the video VAE should use cuDNN in a given deployment,
that should be selected explicitly and symmetrically for every VAE rank; it
should not depend on whether a rank happened to execute the text encoder.

As supporting causality evidence, changing only the VAE SDPA selection changes
the generated video while leaving decoded audio identical. This establishes
that the leaked state is observable, without treating either backend's output
as an external precision oracle.

## Validation

Environment: 2x NVIDIA H200, vLLM server 0.28.0, eager execution, SP2,
VAE patch parallelism 2, rank-local DLO.

- Single-request `SP2 + text_encoder_tp_size=1 + VAE PP2`: reproduced the
  `rank 0 cuDNN enabled / rank 1 cuDNN disabled` split shown above.
- Fixed SP2 run: all participating VAE ranks retained the same pre-encoder
  SDPA state.
- `pytest -n 0 -q tests/diffusion/models/minimax_h3/test_minimax_h3_encoder_sdpa.py`:
  `4 passed` (normal and exception paths, with the initial state both disabled
  and enabled).
- `HF_HUB_OFFLINE=0 pytest -n 0 -q tests/diffusion/models/minimax_h3 -m 'core_model and cpu'`:
  `246 passed, 40 deselected`.
- `pre-commit run --files vllm_omni/diffusion/models/minimax_h3/encoder.py tests/diffusion/models/minimax_h3/test_minimax_h3_encoder_sdpa.py`:
  passed.
