### PR TITLE
[Bugfix] Restore FS parallel group dropped by the parallel-state refactor

### DIFF
--- a/vllm_omni/diffusion/distributed/parallel_state.py
+++ b/vllm_omni/diffusion/distributed/parallel_state.py
@@ -59,6 +59,7 @@ _SP: SequenceParallelGroupCoordinator | None = None
 _PP: PipelineGroupCoordinator | None = None
 _CFG: GroupCoordinator | None = None
 _DP: GroupCoordinator | None = None
+_FS: GroupCoordinator | None = None  # Fully Sharded (HSDP shard dimension)
 
 # Rank-layout metadata for expert parallelism. This is not a process group;
 # it is reused by platform-specific runtimes that must build companion groups
@@ -350,6 +351,12 @@ def get_data_parallel_rank():
     return get_dp_group().rank_in_group
 
 
+# FS (Fully Shard / HSDP shard dimension)
+def get_fs_group() -> GroupCoordinator:
+    assert _FS is not None, "fully shard group is not initialized"
+    return _FS
+
+
 def is_dp_last_group():
     """Return True if in the last data parallel group, False otherwise."""
     return (
@@ -445,6 +452,7 @@ def init_model_parallel_group(
         "expert",
         "sequence",
         "classifier_free_guidance",
+        "fully_shard",
     ], f"parallel_mode {parallel_mode} is not supported"
     if parallel_mode == "pipeline":
         return PipelineGroupCoordinator(
@@ -679,6 +687,7 @@ def _initialize_model_parallel(
     allgather_degree: int = 1,
     tensor_parallel_size: int = 1,
     pipeline_parallel_size: int = 1,
+    fully_shard_degree: int = 1,
     enable_expert_parallel: bool = False,
     use_hsdp: bool = False,
     backend: str | None = None,
@@ -700,6 +709,7 @@ def _initialize_model_parallel(
             (causal=False only). Mutually exclusive with ulysses/ring in v1.
         tensor_parallel_size: number of GPUs used for tensor parallelism.
         pipeline_parallel_size: number of GPUs used for pipeline parallelism.
+        fully_shard_degree: number of GPUs used for fully sharded data parallelism (HSDP shard dimension).
         backend: distributed backend of pytorch collective comm.
 
     Let's say we have a total of 16 GPUs denoted by g0 ... g15 and we
@@ -881,6 +891,28 @@ def _initialize_model_parallel(
             group_name="dp",
         )
 
+    global _FS
+    assert _FS is None, "fully shard group is already initialized"
+    if fully_shard_degree > 1:
+        if world_size % fully_shard_degree != 0:
+            raise ValueError(
+                f"WORLD size ({world_size}) must be divisible by fully_shard_degree ({fully_shard_degree})"
+            )
+        # FS groups are consecutive rank runs so that the layout matches the
+        # FSDP2 mesh built by hsdp._create_hsdp_mesh (arange(world).reshape(
+        # replicate, shard): each row is one shard group).
+        fs_group_ranks = [
+            list(range(start, start + fully_shard_degree)) for start in range(0, world_size, fully_shard_degree)
+        ]
+    else:
+        fs_group_ranks = [[rank] for rank in range(world_size)]
+    _FS = init_model_parallel_group(
+        group_ranks=fs_group_ranks,
+        local_rank=get_world_group().local_rank,
+        backend=backend,
+        parallel_mode="fully_shard",
+    )
+
     global _EXPERT_PARALLEL_GROUP_RANKS
     _EXPERT_PARALLEL_GROUP_RANKS = get_rank_groups("tp-sp-cfg-dp")
     if use_moe_parallel_mapping:
@@ -902,6 +934,7 @@ def initialize_model_parallel(
     allgather_degree: int = 1,
     tensor_parallel_size: int = 1,
     pipeline_parallel_size: int = 1,
+    fully_shard_degree: int = 1,
     enable_expert_parallel: bool = False,
     use_hsdp: bool = False,
     backend: str | None = None,
@@ -916,6 +949,7 @@ def initialize_model_parallel(
         "cfg": _CFG,
         "sp": _SP,
         "pp": _PP,
+        "fs": _FS,
         "vllm_tp": vllm_parallel_state._TP,
         "vllm_dp": vllm_parallel_state._DP,
         "vllm_pp": vllm_parallel_state._PP,
@@ -937,6 +971,7 @@ def initialize_model_parallel(
             allgather_degree=allgather_degree,
             tensor_parallel_size=tensor_parallel_size,
             pipeline_parallel_size=pipeline_parallel_size,
+            fully_shard_degree=fully_shard_degree,
             enable_expert_parallel=enable_expert_parallel,
             use_hsdp=use_hsdp,
             backend=backend,
@@ -948,7 +983,7 @@ def initialize_model_parallel(
 
 def destroy_model_parallel():
     """Set the groups to none and destroy them."""
-    global _DP, _CFG, _SP, _PP, _EXPERT_PARALLEL_GROUP_RANKS
+    global _DP, _CFG, _SP, _PP, _FS, _EXPERT_PARALLEL_GROUP_RANKS
 
     if vllm_parallel_state._DP and vllm_parallel_state._DP is not _DP:
         vllm_parallel_state._DP.destroy()
@@ -957,6 +992,10 @@ def destroy_model_parallel():
     if _DP:
         _DP.destroy()
     _DP = None
+
+    if _FS:
+        _FS.destroy()
+    _FS = None
 
     if _CFG:
         _CFG.destroy()

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -334,6 +334,7 @@ class DiffusionWorker:
                 allgather_degree=parallel_config.allgather_degree,
                 tensor_parallel_size=parallel_config.tensor_parallel_size,
                 pipeline_parallel_size=parallel_config.pipeline_parallel_size,
+                fully_shard_degree=parallel_config.hsdp_shard_size if parallel_config.use_hsdp else 1,
                 enable_expert_parallel=parallel_config.enable_expert_parallel,
                 use_hsdp=parallel_config.use_hsdp,
             )


### PR DESCRIPTION
## TLDR
Main has been red since #6307 merged (Buildkite [build 14277](https://buildkite.com/vllm/vllm-omni/builds/14277), all 6 GPU/CPU lanes failed): every diffusion-worker boot and all `tests/diffusion` collection die on

```
ImportError: cannot import name 'get_fs_group' from 'vllm_omni.diffusion.distributed.parallel_state'
```

This restores the missing symbol so #6307's topology-aware worker titles work as written.

## Root cause
#6307 was developed against the pre-#5531 `parallel_state.py`, which still exposed `get_fs_group()` and the `_FS` group. While #6307 was open, #5531's rebase rewrote `parallel_state.py` and dropped the FS group; #6307 then squash-merged on top, leaving a dangling import in `diffusion_worker.py`. Runtime impact is not test-only: `stage_diffusion_proc.py` fails at worker import, so every entrypoint/distributed/LoRA lane fails at orchestrator init.

## Fix
- Recreate `_FS` + `get_fs_group()` inside the new atomic-init architecture:
  - `fully_shard_degree > 1` → consecutive rank runs, matching the FSDP2 mesh layout built by `hsdp._create_hsdp_mesh` (`arange(world).reshape(replicate, shard)`, each row a shard group);
  - otherwise singleton groups per rank (same as pre-refactor behavior, where `get_ranks("fs", independent_ranks=True)` with `fs=1` produced singletons).
- `"fully_shard"` added to the allowed `parallel_mode` list; `_FS` covered by the already-initialized pre-check and `destroy_model_parallel`.
- `DiffusionWorker` passes `fully_shard_degree=parallel_config.hsdp_shard_size if parallel_config.use_hsdp else 1` — identical wiring to the pre-refactor worker.

No changes to #6307's new title logic or its test; the mocked `get_fs_group` now resolves against a real accessor again.

## Validation
- `py_compile` + `ruff check` / `ruff format --check` clean.
- No runnable GPU env locally — please let Buildkite judge (Simple/Diffusion, LoRA, Distributed, Entrypoints lanes).