### PR TITLE
Revert "[bugfix][MiniCPM-o] Fix offline_inference/test_minicpmo_4_5.py and online_serving/ one"

### DIFF
--- a/tests/model_executor/models/minicpmo_4_5/test_pipeline.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_pipeline.py
@@ -229,14 +229,6 @@ class TestDeployTopology:
             "vllm_omni.model_executor.stage_input_processors.minicpmo_4_5_omni.tts2code2wav_token_only"
         )
 
-    def test_no_async_chunk_selects_full_payload_processor(self) -> None:
-        deploy = load_deploy_config(_DEPLOY_DIR / "minicpmo_4_5.yaml")
-        deploy.async_chunk = False
-        stages = merge_pipeline_deploy(OMNI_PIPELINES[_PIPELINE_KEY], deploy)
-
-        assert stages[1].yaml_engine_args["async_chunk"] is False
-        assert stages[1].yaml_engine_args["custom_process_next_stage_input_func"].endswith(".tts2code2wav_full_payload")
-
 
 def test_code2wav_model_is_lazily_registered() -> None:
     assert _OMNI_MODELS["MiniCPMO45Code2Wav"] == (

--- a/tests/model_executor/stage_input_processors/test_minicpmo_4_5_async_chunk.py
+++ b/tests/model_executor/stage_input_processors/test_minicpmo_4_5_async_chunk.py
@@ -72,16 +72,6 @@ def _codes(payload) -> list[int]:
     return payload.codes.audio.tolist()
 
 
-def test_empty_full_payload_releases_consumer_wait_gate() -> None:
-    payload = tts2code2wav_full_payload(_manager(), None, _request("req"))
-
-    assert _codes(payload) == []
-    assert payload.meta.code_flat_numel == 0
-    assert payload.meta.left_context_size == 0
-    assert payload.meta.last_chunk is True
-    assert payload.meta.finished.item() is True
-
-
 @pytest.mark.parametrize(("count", "emitted"), [(24, False), (25, True), (26, True)])
 def test_first_chunk_threshold_is_25_generated_codes(count: int, emitted: bool) -> None:
     manager = _manager()


### PR DESCRIPTION
Reverts vllm-project/vllm-omni#5464 due to CI failure: https://buildkite.com/vllm/vllm-omni/builds/14300/canvas . Please check it, Thanks. @ZacheryAU @amy-why-3459 