### PR TITLE
[ci][bugfix] Fix MiniMax-H3 FP8 quality test OOM

### DIFF
--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_quantization_quality.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_quantization_quality.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from pathlib import Path
 
@@ -187,6 +187,8 @@ def test_minimax_h3_quantization_quality(config: QualityTestConfig):
         "model": model_ref,
         "enforce_eager": True,
         "tensor_parallel_size": 2,
+        # The fused BF16 baseline only fits on H100-80GB with encoder TP.
+        "text_encoder_tp_size": 2,
         "vae_use_tiling": True,
     }
 


### PR DESCRIPTION
## Purpose

Closes #6735.

### What broke

The nightly `MiniMax H3 FP8 Quality Test with H100 · 2-GPU` fails during the fused BF16 baseline initialization, before the FP8 quality comparison starts:

```text
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 500.00 MiB.
GPU 0 has 94.25 MiB free and 79.08 GiB in use.
```

### Reproduction

On vLLM-Omni `d5aced92966e6f12134fe9a30679fdeab07e4bb9`, vLLM `0.28.0`, and 2 x H100 80GB:

```bash
pytest -sv tests/diffusion/models/minimax_h3/test_minimax_h3_quantization_quality.py \
  -m "full_model and cuda and H100" --run-level full_model
```

Buildkite failure: https://buildkite.com/vllm/vllm-omni/builds/14290#01a047d3-ab06-4e51-ad73-845ead9fe758

### Root cause

#5885 accidentally removed `text_encoder_tp_size=2` from this fused quality test. The option still controls the colocated MiniMax-H3 text encoder. Without it, the default TP size is 1, so rank 0 constructs the full text encoder and exhausts an H100-80GB during layer initialization.

The prior successful build `14213` at `c6df39e9` logged `text_encoder_tp_size=2` and loaded 65.8259 GiB per worker. The failing build defaults to TP1 and reaches 79.08 GiB before the next 500 MiB allocation.

### Fix

Restore `text_encoder_tp_size=2` for the two-GPU quality test and document that encoder sharding is required for the fused BF16 H100 baseline. The touched file copyright header is also normalized to the repository SPDX form required by pre-commit.

## Test Plan

**vLLM Version:** `0.28.0`

**vLLM-Omni Commit:** `04a699df32c7932c0fedda4d6f13d9caba909dad`

Local validation used 2 x NVIDIA B300, PyTorch `2.13.0+cu130`, and the cached canonical MiniMax-H3 FL2VA snapshot.

```bash
CUDA_VISIBLE_DEVICES=4,5 /home/zjy/code/david/.venv/bin/python -m pytest -sv \
  tests/diffusion/models/minimax_h3/test_minimax_h3_quantization_quality.py \
  -m "full_model and cuda and H100" --run-level full_model
```

```text
1 passed, 2 deselected, 18 warnings in 263.41s
LPIPS: 0.1201 (threshold: 0.2)
Audio cosine: 0.9878 (threshold: 0.8)
BF16 memory: 64.37 GiB
Quant memory: 49.27 GiB (23% reduction)
```

```bash
/home/zjy/code/david/.venv/bin/pre-commit run --files \
  tests/diffusion/models/minimax_h3/test_minimax_h3_quantization_quality.py
```

All applicable hooks passed, including Ruff, Ruff format, mypy, test marks, SPDX, forbidden imports, and the CUDA API guard.

## Duplicate check and AI assistance

No open PR references #6735, and a MiniMax-H3 FP8 OOM search found no competing fix. OpenAI Codex was used to compare Buildkite logs, identify the regressing commit, prepare the minimal patch, and run validation. The submitter reviewed every changed line and the test evidence above.