### PR TITLE
[CI] Gate qwen3-omni no-async-chunk perf on mean_audio_rtf

### DIFF
--- a/tests/dfx/perf/tests/test_qwen3_omni_async_chunk.json
+++ b/tests/dfx/perf/tests/test_qwen3_omni_async_chunk.json
@@ -46,9 +46,6 @@
         "percentile-metrics": "ttft,tpot,itl,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
           "H100": {
-            "mean_e2el_ms": [
-              3646.797
-            ],
             "mean_audio_rtf": [
               0.1098
             ]
@@ -82,9 +79,6 @@
         "percentile-metrics": "ttft,tpot,itl,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
           "H100": {
-            "mean_e2el_ms": [
-              4059.0878
-            ],
             "mean_audio_rtf": [
               0.1335
             ]
@@ -120,9 +114,6 @@
         "percentile-metrics": "ttft,tpot,itl,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
           "H100": {
-            "mean_e2el_ms": [
-              5639.5769
-            ],
             "mean_audio_rtf": [
               0.1798
             ]

--- a/tests/dfx/perf/tests/test_qwen3_omni_no_async_chunk.json
+++ b/tests/dfx/perf/tests/test_qwen3_omni_no_async_chunk.json
@@ -80,9 +80,6 @@
         "percentile-metrics": "ttft,tpot,itl,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
           "H100": {
-            "mean_e2el_ms": [
-              4556.4347
-            ],
             "mean_audio_rtf": [
               0.138
             ]
@@ -116,9 +113,6 @@
         "percentile-metrics": "ttft,tpot,itl,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
           "H100": {
-            "mean_e2el_ms": [
-              4768.0972
-            ],
             "mean_audio_rtf": [
               0.1609
             ]
@@ -154,9 +148,6 @@
         "percentile-metrics": "ttft,tpot,itl,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
           "H100": {
-            "mean_e2el_ms": [
-              6395.3517
-            ],
             "mean_audio_rtf": [
               0.2048
             ]

--- a/tests/dfx/perf/tests/test_qwen3_omni_no_async_chunk.json
+++ b/tests/dfx/perf/tests/test_qwen3_omni_no_async_chunk.json
@@ -45,13 +45,6 @@
         "percentile-metrics": "ttft,tpot,itl,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
           "H100": {
-            "mean_e2el_ms": [
-              15793.1209,
-              30658.6632,
-              37463.4943,
-              47990.5839,
-              64980.2199
-            ],
             "mean_audio_rtf": [
               0.169,
               0.2041,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Implements option 1 from #6668, as agreed by @Gaohan123. Scope widened after
review — e2el gating is now dropped from all six qwen3-omni audio cells across
both files, not just `data=random`.

`mean_e2el_ms` here is speed × generated audio length. The thinker is pinned to
900 tokens by `ignore_eos: true`, but the talker free-runs to
`stop_token_ids: [2150]`, so audio duration swings ~3x between nightlies with
no code change. Per @psv666's data, audio length correlates with e2el at
r=0.9855, and at c=1/n=4 the spread is 27.6% CV — you can't gate that at 10%.

This drops the `mean_e2el_ms` baselines and keeps `mean_audio_rtf`, which is
speed-normalized and already collected in every affected block.
`test_qwen3_omni_multi_replicas.json`, `test_higgs_audio_v3.json` and
`test_voxcpm2.json` already do this.

Three things worth flagging:

- It can't be scoped to c=1. All five concurrency points in the `data=random`
  sweep share one baseline dict and `resolve_baseline_for_sweep` indexes by
  sweep position, so e2el gating goes away at c=4/8/16/32 too. Audio length is
  uncontrolled at every concurrency, so those cells were passing because the
  spread averages out, not because e2el measures speed.
- Text-only blocks keep their e2el baselines — `modalities: ["text"]` in
  `test_qwen3_omni_async_chunk.json`, and `test_qwen3_omni_vllm_text.json`.
  No talker there, so e2el is real latency. `percentile-metrics` is unchanged
  everywhere, so e2el is still collected, just not gated.
- This is half of option 1. The 15% threshold isn't in this repo (details in
  my issue comment). Without it, RTF at c=1 has 11% CV against a 10% gate —
  the same setup as #5966. Better than e2el's 20.9%, but this cell may still
  flake.

## Test Plan

Config-only, 25 deletions across two files. Not locally verifiable: the
nightly step just runs `run_benchmark.py` and does
`buildkite-agent artifact upload`, so the baseline comparison happens
downstream.

Checked both files still parse as JSON, and that every block I touched already
had a `mean_audio_rtf` baseline so nothing ends up ungated.

**vLLM Version:** 0.27.0

**vLLM-Omni Commit:** e256d0a5

## Test Result

Needs a few nightlies on the affected cells to confirm.

Related to #6668