### PR TITLE
[Bugfix][Qwen3-Omni] Keep parent quantization off audio stages

### DIFF
--- a/tests/config/test_config_factory.py
+++ b/tests/config/test_config_factory.py
@@ -2367,10 +2367,8 @@ class TestBaseConfigInheritance:
         assert deploy.stages[0].gpu_memory_utilization == 0.9
 
 
-class TestPlatformOverrides:
-    """Test platform-specific deploy config overrides."""
-
-    def test_qwen3_omni_musa_clears_parent_quantization_for_audio_stages(self):
+class TestQuantizationInheritance:
+    def test_qwen3_omni_audio_stages_do_not_inherit_checkpoint_quantization(self):
         pipeline = resolve_pipeline_config(
             "qwen3_omni_moe",
             Q3_OMNI_ALL_STAGES_HF_CONFIG,
@@ -2379,14 +2377,19 @@ class TestPlatformOverrides:
         deploy_path = Path(get_deploy_config_path("qwen3_omni_moe.yaml"))
 
         base_stages = merge_pipeline_deploy(pipeline, load_deploy_config(deploy_path))
-        assert "hf_overrides" not in base_stages[1].yaml_engine_args
-        assert "hf_overrides" not in base_stages[2].yaml_engine_args
-
-        musa = _apply_platform_overrides(load_deploy_config(deploy_path), platform="musa")
-        musa_stages = merge_pipeline_deploy(pipeline, musa)
         expected = {"quantization_config": None}
-        assert musa_stages[1].yaml_engine_args["hf_overrides"] == expected
-        assert musa_stages[2].yaml_engine_args["hf_overrides"] == expected
+        assert "hf_overrides" not in base_stages[0].yaml_engine_args
+        assert base_stages[1].yaml_engine_args["hf_overrides"] == expected
+        assert base_stages[2].yaml_engine_args["hf_overrides"] == expected
+
+        explicit = load_deploy_config(deploy_path)
+        explicit.quantization = "fp8"
+        explicit_stages = merge_pipeline_deploy(pipeline, explicit)
+        assert all("hf_overrides" not in stage.yaml_engine_args for stage in explicit_stages)
+
+
+class TestPlatformOverrides:
+    """Test platform-specific deploy config overrides."""
 
     def test_qwen3_tts_rocm_disables_code2wav_outer_cudagraph(self):
         deploy_path = Path(get_deploy_config_path("qwen3_tts.yaml"))

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -217,6 +217,8 @@ class StagePipelineConfig:
     owns_tokenizer: bool = False
     requires_multimodal_data: bool = False
     hf_config_name: str | None = None
+    # Whether this stage inherits quantization_config from its parent HF config.
+    inherit_parent_quantization: bool = True
     engine_output_type: str | None = None
     model_arch: str | None = None
     # The model keeps per-request execution state while awaiting the next
@@ -901,6 +903,10 @@ def _build_engine_args(
                 continue
             engine_args[k] = v
         engine_args.update(ds.engine_extras)
+    if not ps.inherit_parent_quantization and engine_args.get("quantization") is None:
+        hf_overrides = engine_args.setdefault("hf_overrides", {})
+        if isinstance(hf_overrides, dict):
+            hf_overrides.setdefault("quantization_config", None)
     # Materialize the resolved pipeline-wide async_chunk value into every
     # stage so explicit False overrides do not get lost downstream.
     engine_args["async_chunk"] = bool(deploy.async_chunk)

--- a/vllm_omni/deploy/qwen3_omni_moe.yaml
+++ b/vllm_omni/deploy/qwen3_omni_moe.yaml
@@ -78,18 +78,6 @@ platforms:
         compilation_config:
           custom_ops: ["+rotary_embedding"]
 
-  # The supported Qwen3-Omni ModelOpt checkpoint quantizes the thinker only. Clear the
-  # checkpoint-level metadata for the BF16 audio stages on the verified MUSA
-  # profile before vLLM performs its normal quantization auto-detection.
-  musa:
-    stages:
-      - stage_id: 1
-        hf_overrides:
-          quantization_config: null
-      - stage_id: 2
-        hf_overrides:
-          quantization_config: null
-
   npu:
     stages:
       - stage_id: 0

--- a/vllm_omni/model_executor/models/qwen3_omni/pipeline.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/pipeline.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Qwen3-Omni-MoE pipeline topology (frozen).
 
 Stage 0: Thinker — multimodal understanding + text generation
@@ -51,6 +51,7 @@ QWEN3_OMNI_PIPELINE = PipelineConfig(
             execution_type=StageExecutionType.LLM_AR,
             input_sources=(0,),
             hf_config_name="talker_config",
+            inherit_parent_quantization=False,
             engine_output_type="latent",
             sync_process_input_func=f"{_PROC}.thinker2talker_token_only",
             custom_process_next_stage_input_func=(f"{_PROC}.talker2code2wav_full_payload"),
@@ -69,6 +70,7 @@ QWEN3_OMNI_PIPELINE = PipelineConfig(
             final_output=True,
             final_output_type="audio",
             hf_config_name="thinker_config",
+            inherit_parent_quantization=False,
             engine_output_type="audio",
             sampling_constraints={"detokenize": True},
             requires_full_payload_input=True,


### PR DESCRIPTION
## Purpose

Fixes #6708.

The Qwen3-Omni ModelOpt NVFP4 checkpoint quantizes the Thinker, while the Talker and Code2Wav stages use BF16 weights. The audio stages nevertheless inherited the root checkpoint quantization metadata, causing vLLM to initialize them through the ModelOpt NVFP4 path.

This change adds a default-compatible stage capability controlling inheritance of the parent HF quantization config. Qwen3-Omni disables that inheritance for Talker and Code2Wav, and the stage config builder translates the declaration through the existing `hf_overrides` interface before vLLM creates ModelConfig. Explicit user quantization and existing stage overrides retain precedence.

The previous MUSA-only YAML workaround is removed because the pipeline declaration now applies consistently across platforms.

## Test Plan

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** fedfac0b6cf3529da73c649057ce2d812a61fec6

- Run all changed-file pre-commit hooks.
- Verify the resolved Qwen3-Omni stage configs keep root quantization for Thinker and clear it for Talker and Code2Wav.
- Verify explicit quantization is preserved.
- Use the existing Qwen3-Omni ModelOpt NVFP4 CI case for end-to-end validation.

## Test Result

- Changed-file pre-commit checks passed, including Ruff, Ruff format, mypy, YAML validation, SPDX, forbidden imports, and project policy checks.
- The resolved config assertions cover Thinker, Talker, Code2Wav, and explicit quantization precedence.
- Full model inference was not run locally because the exact CUDA/vLLM 0.28 runtime was unavailable; the existing GPU CI test provides the final end-to-end coverage.