### PR TITLE
[video][bugfix] Accept semantic video output in offline examples

### DIFF
--- a/examples/offline_inference/image_to_video/image_to_video.py
+++ b/examples/offline_inference/image_to_video/image_to_video.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 """
 Image-to-Video generation example using Wan2.2 I2V/TI2V models, LTX2/LTX-2.3,
@@ -109,6 +109,13 @@ def build_image_to_video_prompt(
     if negative_prompt is not None:
         result["negative_prompt"] = negative_prompt
     return result
+
+
+def _validate_video_output_type(output_type: str) -> None:
+    if output_type not in {"image", "video"}:
+        raise ValueError(
+            f"Unexpected output type '{output_type}', expected 'video' or legacy 'image' for video generation."
+        )
 
 
 def parse_args() -> argparse.Namespace:
@@ -665,10 +672,7 @@ def main():
         frames = frames[0] if frames else None
 
     if isinstance(frames, OmniRequestOutput):
-        if frames.final_output_type != "image":
-            raise ValueError(
-                f"Unexpected output type '{frames.final_output_type}', expected 'image' for video generation."
-            )
+        _validate_video_output_type(frames.final_output_type)
         if frames.multimodal_output and "audio" in frames.multimodal_output:
             audio = frames.multimodal_output["audio"]
             audio_sample_rate = frames.multimodal_output.get("audio_sample_rate", audio_sample_rate)

--- a/examples/offline_inference/text_to_video/text_to_video.py
+++ b/examples/offline_inference/text_to_video/text_to_video.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 import argparse
 import json
@@ -172,6 +172,13 @@ def build_text_to_video_prompt(prompt: str, negative_prompt: str | None) -> dict
     if negative_prompt is not None:
         result["negative_prompt"] = negative_prompt
     return result
+
+
+def _validate_video_output_type(output_type: str) -> None:
+    if output_type not in {"image", "video"}:
+        raise ValueError(
+            f"Unexpected output type '{output_type}', expected 'video' or legacy 'image' for video generation."
+        )
 
 
 def _normalize_float_tensor(tensor: torch.Tensor, source_range: str) -> torch.Tensor:
@@ -620,10 +627,7 @@ def main():
         frames = frames[0] if frames else None
 
     if isinstance(frames, OmniRequestOutput):
-        if frames.final_output_type != "image":
-            raise ValueError(
-                f"Unexpected output type '{frames.final_output_type}', expected 'image' for video generation."
-            )
+        _validate_video_output_type(frames.final_output_type)
         if frames.multimodal_output and "audio" in frames.multimodal_output:
             audio = frames.multimodal_output["audio"]
             audio_sample_rate = frames.multimodal_output.get("audio_sample_rate", audio_sample_rate)

--- a/tests/examples/offline_inference/test_image_task_prompts.py
+++ b/tests/examples/offline_inference/test_image_task_prompts.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from __future__ import annotations
 
@@ -65,3 +65,38 @@ def test_image_to_video_builds_canonical_prompt() -> None:
         "multi_modal_data": {"image": image},
         "negative_prompt": "flicker",
     }
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "module_name"),
+    [
+        ("offline_inference/text_to_video/text_to_video.py", "text_to_video_output_example"),
+        ("offline_inference/image_to_video/image_to_video.py", "image_to_video_output_example"),
+    ],
+)
+@pytest.mark.parametrize("output_type", ["video", "image"])
+def test_video_examples_accept_semantic_and_legacy_output_types(
+    relative_path: str,
+    module_name: str,
+    output_type: str,
+) -> None:
+    mod = _load_example_module(relative_path, module_name)
+
+    mod._validate_video_output_type(output_type)
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "module_name"),
+    [
+        ("offline_inference/text_to_video/text_to_video.py", "text_to_video_invalid_output_example"),
+        ("offline_inference/image_to_video/image_to_video.py", "image_to_video_invalid_output_example"),
+    ],
+)
+def test_video_examples_reject_unrelated_output_types(
+    relative_path: str,
+    module_name: str,
+) -> None:
+    mod = _load_example_module(relative_path, module_name)
+
+    with pytest.raises(ValueError, match="Unexpected output type 'audio'"):
+        mod._validate_video_output_type("audio")


### PR DESCRIPTION
## Purpose

### What broke

Scheduled build #14290 failed the shared text-to-video and image-to-video examples with `ValueError: Unexpected output type video, expected image for video generation.` The last healthy scheduled build was #14213 at commit `c6df39e`.

### Reproduction

On affected GPU CI workers, this command reproduces the image-to-video failure on main:

```bash
.venv/bin/python -m pytest -v "tests/examples/offline_inference/test_image_to_video.py::test_image_to_video[quick_start_002]"
```

The HunyuanVideo text-to-video reference test failed through the same shared consumer path.

### Root cause

The regression window is `c6df39e..d5aced9`. Commit `b6a4baa` from #5885 correctly made known video diffusion pipelines report the semantic final modality `video` through `OmniRequestOutput`. The two offline video examples still enforced the legacy `image` tag because video frames remain stored in the historical `images` payload field. They therefore rejected valid video output before export.

### Fix

Accept semantic `video` outputs in both shared offline examples while preserving compatibility with legacy or unknown pipelines that still use the `image` tag. Unrelated modalities continue to fail loudly. CPU regression tests cover both consumers, both supported tags, and rejection of `audio`.

### Duplicate check

No open PR was found by searching `6732 in:body` or the video output validation keywords. #6477 and #6615 concern device-side media preparation and transport contracts; neither fixes the stale offline example validation in this PR.

Fixes #6732

## Test Plan

```bash
.venv/bin/python -m pytest -q \
  tests/examples/offline_inference/test_image_task_prompts.py \
  tests/examples/offline_inference/test_text_to_video_prompts.py

pre-commit run --files \
  examples/offline_inference/text_to_video/text_to_video.py \
  examples/offline_inference/image_to_video/image_to_video.py \
  tests/examples/offline_inference/test_image_task_prompts.py
```

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** base `bbb3ae01a`, candidate `15126fdfa`

## Test Result

- Pytest: `26 passed, 16 warnings in 0.86s`
- Applicable pre-commit hooks: passed, including ruff check/format, mypy, SPDX, forbidden imports, and pytest marker validation
- Model evaluation: not applicable; this changes only consumer modality validation and does not alter generated tensors, frames, postprocessing, or encoding

## AI assistance

AI assistance was used for regression-window analysis, implementation, test authoring, and PR drafting. The human submitter must review every changed line and validate the reported results before merge.