### PR TITLE
[Bugfix][Qwen3-Omni] Handle missing packed modules mapping

### DIFF
--- a/tests/model_executor/models/qwen3_omni/test_qwen3_omni_quantization.py
+++ b/tests/model_executor/models/qwen3_omni/test_qwen3_omni_quantization.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Regression tests for nested Qwen3-Omni quantization config mapping."""
+
+from dataclasses import dataclass
+
+import pytest
+
+from vllm_omni.model_executor.models.qwen3_omni.quantization import (
+    _OUTER_MAPPING_APPLIED,
+    apply_nested_quant_config_mapping,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+@dataclass
+class _QuantConfig:
+    packed_modules_mapping: dict[str, list[str]]
+
+
+@dataclass
+class _NestedModel:
+    quant_config: _QuantConfig | None
+
+
+@dataclass
+class _NestedModelWithPackedModules(_NestedModel):
+    packed_modules_mapping: dict[str, list[str]]
+
+
+def _mapped_quant_config(**packed_modules_mapping):
+    quant_config = _QuantConfig(packed_modules_mapping=packed_modules_mapping)
+    setattr(quant_config, _OUTER_MAPPING_APPLIED, True)
+    return quant_config
+
+
+def test_nested_mapping_ignores_missing_quant_config():
+    apply_nested_quant_config_mapping(_NestedModel(quant_config=None))
+
+
+def test_nested_mapping_allows_model_without_packed_modules_mapping():
+    quant_config = _mapped_quant_config(existing=["module"])
+
+    apply_nested_quant_config_mapping(_NestedModel(quant_config=quant_config))
+
+    assert quant_config.packed_modules_mapping == {"existing": ["module"]}
+
+
+def test_nested_mapping_merges_packed_modules_mapping():
+    quant_config = _mapped_quant_config(existing=["module"])
+    model = _NestedModelWithPackedModules(
+        quant_config=quant_config,
+        packed_modules_mapping={"qkv_proj": ["q_proj", "k_proj", "v_proj"]},
+    )
+
+    apply_nested_quant_config_mapping(model)
+
+    assert quant_config.packed_modules_mapping == {
+        "existing": ["module"],
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+    }

--- a/vllm_omni/model_executor/models/qwen3_omni/quantization.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/quantization.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Quantization mapping helpers for nested Qwen3-Omni stages."""
 
 from vllm.model_executor.models.interfaces import SupportsQuant
@@ -25,8 +25,8 @@ def apply_nested_quant_config_mapping(model: SupportsQuant) -> None:
 
     # The outer model maps names, while the nested model still contributes
     # fused-module metadata needed by quantization scheme matching.
-    if model.packed_modules_mapping is not None:
-        quant_config.packed_modules_mapping.update(model.packed_modules_mapping)
+    if packed_modules_mapping := getattr(model, "packed_modules_mapping", None):
+        quant_config.packed_modules_mapping.update(packed_modules_mapping)
 
 
 class Qwen3OmniNestedSupportsQuant(SupportsQuant):


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Closes #6708.

### What broke

The full Qwen3-Omni NVFP4 W4A4 checkpoint failed while initializing the Stage 1 Talker:

```text
AttributeError: 'Qwen3OmniMoeTalkerForConditionalGeneration' object has no attribute 'packed_modules_mapping'
```

### Reproduction

On `main`, this minimal reproducer raises the same `AttributeError`; on this branch it exits successfully:

```bash
uv run --no-sync --project . python - <<'PY'
from types import SimpleNamespace

from vllm_omni.model_executor.models.qwen3_omni.quantization import (
    _OUTER_MAPPING_APPLIED,
    apply_nested_quant_config_mapping,
)

quant_config = SimpleNamespace(packed_modules_mapping={})
setattr(quant_config, _OUTER_MAPPING_APPLIED, True)
apply_nested_quant_config_mapping(SimpleNamespace(quant_config=quant_config))
PY
```

### Root cause

The nested Qwen3-Omni quantization helper directly accessed `model.packed_modules_mapping` after the outer mapping had been applied. That metadata is optional: the Thinker defines it, but the Talker does not. vLLM's default `SupportsQuant` implementation already handles this contract with `getattr(..., None)`.

### Fix

Use the same optional-attribute access as vLLM before merging packed-module metadata. Add CPU regression coverage for:

- a missing quantization config;
- a nested model without `packed_modules_mapping`;
- a nested model that contributes packed-module metadata.

## Test Plan

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** bf3d7f505f1bc50661ba6b78ea1f94bd43018da0

Test environment: 2x NVIDIA L20X (143771 MiB each), driver 570.133.20, CUDA 13.0, Python 3.12, Transformers 5.14.1.

```bash
uv run --no-sync --project . pre-commit run --files \
  vllm_omni/model_executor/models/qwen3_omni/quantization.py \
  tests/model_executor/models/qwen3_omni/test_qwen3_omni_quantization.py

uv run --no-sync --project . pytest -q \
  tests/model_executor/models/qwen3_omni/test_qwen3_omni_quantization.py \
  tests/model_executor/models/qwen3_omni/test_qwen3_omni_forward_contract.py \
  --run-level core_model

uv run --no-sync --project . pytest -sv \
  tests/e2e/offline_inference/test_qwen3_omni_modelopt_nvfp4_w4a4.py::test_marlin_fallback_no_nan_collapse \
  --run-level full_model
```

Runtime: CPU tests ~0.4 seconds; full-model test ~6 minutes 43 seconds.

## Test Result

- Pre-commit: all hooks passed.
- Qwen3-Omni CPU tests: `11 passed, 14 warnings in 0.36s`.
- Full NVFP4 Marlin fallback E2E: `1 passed, 14 warnings in 403.55s`.
- Thinker, Talker, and Code2Wav all initialized; the request completed without NaN output collapse.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
