### PR TITLE
[diffusion][bugfix] Skip native Wan I2V postprocess for Diffusers

### DIFF
--- a/tests/diffusion/models/wan2_2/test_wan22_i2v_pipeline.py
+++ b/tests/diffusion/models/wan2_2/test_wan22_i2v_pipeline.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 import torch
@@ -14,15 +15,30 @@ from vllm_omni.diffusion.models.wan2_2.pipeline_wan2_2_i2v import (
     get_wan22_i2v_post_process_func,
     get_wan22_i2v_pre_process_func,
 )
+from vllm_omni.diffusion.registry import get_diffusion_post_process_func
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.diffusion]
 
 
+def test_wan22_i2v_diffusers_backend_skips_native_postprocess() -> None:
+    postprocess = get_diffusion_post_process_func(
+        SimpleNamespace(
+            model_class_name="WanImageToVideoPipeline",
+            diffusion_load_format="diffusers",
+        )
+    )
+
+    assert postprocess is None
+
+
 def test_wan22_i2v_postprocess_honors_request_output_type() -> None:
     video = torch.zeros(1, 4, 1, 2, 2)
 
-    output = get_wan22_i2v_post_process_func(SimpleNamespace())(
+    postprocess = get_wan22_i2v_post_process_func(SimpleNamespace(diffusion_load_format="default"))
+    assert postprocess is not None
+
+    output = postprocess(
         video,
         sampling_params=SimpleNamespace(output_type="latent"),
     )
@@ -45,7 +61,7 @@ def _make_i2v_pipeline(*, expand_timesteps: bool) -> Wan22I2VPipeline:
 
 
 def _make_i2v_sampling(**overrides):
-    values = {
+    values: dict[str, Any] = {
         "height": 16,
         "width": 16,
         "num_frames": 5,

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
@@ -56,6 +56,11 @@ DEBUG_PERF = False
 def get_wan22_i2v_post_process_func(
     od_config: OmniDiffusionConfig,
 ):
+    # The Diffusers adapter returns already-postprocessed frame lists, while
+    # this factory handles tensor output from the native Wan I2V pipeline.
+    if od_config.diffusion_load_format == "diffusers":
+        return None
+
     from diffusers.video_processor import VideoProcessor
 
     video_processor = VideoProcessor(vae_scale_factor=8)


### PR DESCRIPTION
## Purpose

### What broke

Scheduled build #14290 failed the Wan2.2 I2V Diffusers-backend accuracy test with `AttributeError: list object has no attribute shape`, and the video endpoint returned HTTP 500. The last healthy scheduled build was #14213 at commit `c6df39e`.

### Reproduction

On an H100 with the full model available:

```bash
.venv/bin/python -m pytest -s -v \
  "tests/e2e/accuracy/test_diffusers_backend_similarity.py::test_diffusers_backend_i2v_matches_diffusers[Wan-AI/Wan2.2-I2V-A14B-Diffusers]" \
  --run-level full_model
```

### Root cause

The regression window is `c6df39e..d5aced9`. Commit `b6a4baa` from #5885 made fallback stage construction resolve the checkpoint model class even when `diffusion_load_format=diffusers`. The official checkpoint declares `WanImageToVideoPipeline`, so the registry selected the native Wan I2V tensor postprocessor. The Diffusers adapter had already returned a postprocessed frame list, and the native `VideoProcessor.postprocess_video` path then accessed tensor shape during a second postprocess pass.

### Fix

Do not construct the native Wan I2V postprocessor when the Diffusers adapter owns the pipeline. The native/default Wan path continues to construct and execute the existing tensor postprocessor. A CPU regression test exercises the production registry selection boundary for Diffusers and preserves the native latent behavior.

Fixes #6733

## Duplicate check and scope

No open PR was found for the Wan I2V factory guard. #6749 appears in the `6733 in:body` search because it documents the shared regression trigger, but it changes only the Qwen postprocessor and explicitly leaves Wan/#6733 to a separate PR. #6477 concerns device-side video transport and does not change Diffusers postprocessor selection.

## Test Plan

```bash
.venv/bin/python -m pytest -q \
  tests/diffusion/models/wan2_2/test_wan22_i2v_pipeline.py \
  tests/diffusion/models/wan2_2/test_wan22_pipeline_helpers.py

pre-commit run --files \
  vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py \
  tests/diffusion/models/wan2_2/test_wan22_i2v_pipeline.py

git diff --check
```

**Environment:** vLLM 0.28.0, torch 2.13.0+cu130, diffusers 0.40.0

**vLLM-Omni Commit:** base `bbb3ae01a`, candidate `1bc7e7380`

## Test Result

- Focused Wan CPU tests: `21 passed, 15 warnings in 0.98s`
- Applicable pre-commit hooks: passed, including ruff, mypy, SPDX, forbidden imports, and pytest marker validation
- `git diff --check`: passed
- Full-model Wan accuracy evaluation was not run locally; the regression test covers the failing postprocessor-selection boundary without loading model weights

An additional adjacent-suite run was stopped after the independent Qwen #6731 regression reproduced on this unstacked main-based branch: `18 passed, 1 failed`, then interrupted. The failure was `test_t2i_random_weights` selecting the Qwen native postprocessor; #6749 contains that separate fix. It does not exercise the Wan files changed here.

## AI assistance

AI assistance was used for regression-window analysis, implementation, test authoring, and PR drafting. The human submitter must review every changed line and validate the reported results before merge.