### PR TITLE
[Bugfix][Diffusion] Keep diffusers backend on the adapter class name

### DIFF
--- a/tests/diffusion/diffusion_backend/test_diffusers_backend_class_name.py
+++ b/tests/diffusion/diffusion_backend/test_diffusers_backend_class_name.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Regression tests for #6731 / #6733.
+
+Client-side stage-config resolution stamps ``model_class_name`` via
+``resolve_model_class_name``. When the diffusers backend is selected, it must
+resolve to ``DiffusersAdapterPipeline`` (mirroring ``enrich_config``) — never
+to the checkpoint's native ``_class_name``. A native name routes the native
+tensor-based post-process funcs onto the adapter's PIL/list outputs, which
+crashes postprocessing (e.g. Qwen-Image "We only support pytorch tensor",
+Wan2.2 I2V "'list' object has no attribute 'shape'").
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_omni.diffusion.data import resolve_model_class_name
+from vllm_omni.diffusion.registry import get_diffusion_post_process_func
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_diffusers_backend_resolves_adapter_even_with_model_index(mocker):
+    """The adapter must win over the pipeline index for the diffusers backend."""
+    mocker.patch(
+        "vllm_omni.diffusion.utils.hf_utils.get_diffusion_model_index",
+        return_value={"_class_name": "QwenImagePipeline"},
+    )
+
+    assert resolve_model_class_name("Qwen/Qwen-Image", diffusion_load_format="diffusers") == "DiffusersAdapterPipeline"
+
+
+def test_default_backend_still_resolves_native_class_from_model_index(mocker):
+    """Native pipelines keep resolving from the pipeline index."""
+    mocker.patch(
+        "vllm_omni.diffusion.utils.hf_utils.get_diffusion_model_index",
+        return_value={"_class_name": "WanImageToVideoPipeline"},
+    )
+
+    assert (
+        resolve_model_class_name("Wan-AI/Wan2.2-I2V-A14B-Diffusers", diffusion_load_format="default")
+        == "WanImageToVideoPipeline"
+    )
+
+
+def test_diffusers_backend_resolves_adapter_without_model_index(mocker):
+    """Missing/unreadable index still falls back to the adapter."""
+    mocker.patch(
+        "vllm_omni.diffusion.utils.hf_utils.get_diffusion_model_index",
+        side_effect=OSError("no such repo"),
+    )
+
+    assert resolve_model_class_name("/models/missing", diffusion_load_format="diffusers") == "DiffusersAdapterPipeline"
+
+
+def test_adapter_class_has_no_native_post_process_func():
+    """The adapter's outputs must pass through: no registered post-process."""
+    od_config = SimpleNamespace(model_class_name="DiffusersAdapterPipeline")
+
+    assert get_diffusion_post_process_func(od_config) is None

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -630,6 +630,13 @@ def resolve_model_class_name(
 
     if not model:
         return None
+    # The diffusers backend always executes through the adapter, so resolve to
+    # its class before consulting the pipeline index — matching
+    # ``enrich_config``'s precedence. Returning the checkpoint's native
+    # ``_class_name`` here would route native (tensor-based) pre/post-process
+    # funcs onto the adapter's PIL/list outputs.
+    if diffusion_load_format == "diffusers":
+        return "DiffusersAdapterPipeline"
     is_lance_subfolder = os.path.basename(str(model).rstrip("/")) in {"Lance_3B", "Lance_3B_Video"}
 
     # Diffusers models: read _class_name from the pipeline index. Missing
@@ -640,8 +647,6 @@ def resolve_model_class_name(
         model_index = None
     if model_index is not None:
         return model_index.get("_class_name")
-    if diffusion_load_format == "diffusers":
-        return "DiffusersAdapterPipeline"
 
     # Other models: map model_type / architecture from config.json.
     try:


### PR DESCRIPTION
Fixes #6731. Fixes #6733.

## Purpose

Since #5885, the fallback stage configuration stamps `model_class_name` via `resolve_model_class_name()`, which returns the checkpoint's native `_class_name` from the pipeline index even when `diffusion_load_format=diffusers` — the `DiffusersAdapterPipeline` branch was only reachable when the index is missing, the opposite precedence of its documented counterpart `enrich_config()`. The stage `od_config` then carries the native class name, so `get_diffusion_post_process_func()` applies the native tensor-based post-process func to the diffusers adapter's output, which is already a postprocessed Python list:

- Qwen/Qwen-Image → `ValueError: Input for postprocessing is in incorrect format: <class 'list'>. We only support pytorch tensor` (#6731)
- Wan2.2-I2V → `AttributeError: 'list' object has no attribute 'shape'` (#6733)

This PR makes `resolve_model_class_name()` return `DiffusersAdapterPipeline` first for the diffusers backend, mirroring `enrich_config()`'s precedence. The adapter has no registered pre/post-process funcs, so its outputs pass through unchanged — the behavior every diffusers-backend test was green under through the 08-27 nightly. Structural: any pipeline with a native post-process func is covered.

## Related PRs

- #6749 and #6751 guard the native postprocessor construction inside the Qwen-Image and Wan2.2-I2V pipelines respectively; #6747 fixes the sibling failure #6732. No file overlap with any of the three.
- This PR fixes the class-name resolution at the source instead of per-pipeline: `_DIFFUSION_POST_PROCESS_FUNCS` in `registry.py` maps 60 pipeline class names to native post-process funcs (plus 25 pre-process entries), and any checkpoint whose `model_index.json` `_class_name` matches one of them hits the same list-vs-tensor failure family when served through the diffusers backend — the two guards cover 2 of the 60. Example still exposed after the guards: `QwenImageEditPipeline` (a real diffusers `_class_name`, registered post-process, no guard). Compatible if all land; the guards then become defense-in-depth.

## Test Plan

New CPU tests in `tests/diffusion/diffusion_backend/test_diffusers_backend_class_name.py`:

1. diffusers backend + pipeline index present → resolves the adapter (red before this fix: returned `QwenImagePipeline`)
2. default backend + index → still resolves the native class
3. diffusers backend + missing index → adapter fallback intact
4. `get_diffusion_post_process_func()` returns `None` for the adapter (pass-through contract)

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** 46cfa84 (main) + this change

## Test Result

Red before / green after: `1 failed, 3 passed` → `4 passed`. Neighbors green: `tests/entrypoints/test_async_omni_diffusion_config.py` (37, incl. #5885's stage-resolution test), `tests/diffusion/diffusion_backend/` (36). GPU e2e similarity tests need the full serving stack + weights; left to nightly CI.

## AI Disclosure

This change was developed and tested with AI assistance. All changes were human-reviewed before submission.
