### PR TITLE
[Bugfix] Resolve HunyuanImage-3 DiT LoRA names and fused QKV layout

### DIFF
--- a/tests/diffusion/lora/test_lora_manager.py
+++ b/tests/diffusion/lora/test_lora_manager.py
@@ -15,7 +15,12 @@ from tests.diffusion.lora.helpers import (
     FakeLinearBase,
     fake_replace_submodule,
 )
-from vllm_omni.diffusion.lora.manager import DiffusionLoRAManager
+from vllm_omni.diffusion.lora.manager import (
+    DiffusionLoRAManager,
+    deinterleave_hi3_gqa_qkv,
+    hi3_qkv_layout,
+    is_hunyuan_image3_pipeline,
+)
 from vllm_omni.lora.request import LoRARequest
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
@@ -723,3 +728,154 @@ def test_lora_manager_discovers_unet_component(monkeypatch):
     assert "unet.down_block.proj" in manager._lora_modules
     # Verify the module was actually replaced in the tree (not just recorded)
     assert isinstance(pipeline.unet.down_block.proj, _DummyBaseLayerWithLoRA)
+
+
+class HunyuanImage3Pipeline(torch.nn.Module):
+    """Name-matched stand-in so HI3 detection does not import the real pipeline."""
+
+    def __init__(self, *, num_attention_heads=4, num_kv_heads=2, head_dim=2):
+        super().__init__()
+        self.transformer = torch.nn.Module()
+        self.transformer.config = SimpleNamespace(
+            num_attention_heads=num_attention_heads,
+            num_key_value_heads=num_kv_heads,
+            head_dim=head_dim,
+        )
+
+
+class _NamedLookupLM:
+    def __init__(self, loras: dict[str, LoRALayerWeights]):
+        self.loras = loras
+
+    def get_lora(self, key: str) -> LoRALayerWeights | None:
+        return self.loras.get(key)
+
+
+def _make_lora_weights(name: str, lora_a: torch.Tensor, lora_b: torch.Tensor) -> LoRALayerWeights:
+    return LoRALayerWeights(
+        module_name=name,
+        rank=lora_a.shape[0],
+        lora_alpha=lora_a.shape[0],
+        lora_a=lora_a,
+        lora_b=lora_b,
+    )
+
+
+def test_is_hunyuan_image3_pipeline_is_name_scoped():
+    assert is_hunyuan_image3_pipeline(HunyuanImage3Pipeline())
+    assert not is_hunyuan_image3_pipeline(_DummyPipeline())
+
+
+def test_deinterleave_hi3_gqa_qkv_matches_base_weight_permutation():
+    num_attention_heads, num_kv_heads, head_dim = 4, 2, 2
+    rank = 1
+    # Per KV head: [Q-group (2 heads), K, V], each head_dim rows.
+    interleaved = torch.arange(16, dtype=torch.float32).reshape(16, rank)
+    packed = deinterleave_hi3_gqa_qkv(interleaved, num_attention_heads, num_kv_heads, head_dim)
+    # Q rows from both KV groups, then K, then V.
+    expected = torch.tensor(
+        [[0], [1], [2], [3], [8], [9], [10], [11], [4], [5], [12], [13], [6], [7], [14], [15]],
+        dtype=torch.float32,
+    )
+    assert torch.equal(packed, expected)
+
+
+def test_hi3_qkv_layout_reads_transformer_config():
+    pipeline = HunyuanImage3Pipeline(num_attention_heads=8, num_kv_heads=2, head_dim=4)
+    assert hi3_qkv_layout(pipeline) == (8, 2, 4)
+    assert hi3_qkv_layout(_DummyPipeline()) is None
+
+
+def test_lora_manager_resolves_hi3_model_layers_namespace():
+    pipeline = HunyuanImage3Pipeline()
+    manager = DiffusionLoRAManager(
+        pipeline=pipeline,
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+    )
+    lora_a = torch.ones((1, 4))
+    lora_b = torch.ones((4, 1))
+    weights = _make_lora_weights("qkv_proj", lora_a, lora_b)
+    lora_model = _NamedLookupLM({"model.layers.0.self_attn.qkv_proj": weights})
+
+    found = manager._get_lora_weights(lora_model, "transformer.layers.0.self_attn.qkv_proj")
+    assert found is weights
+
+
+def test_lora_manager_does_not_alias_model_layers_for_other_pipelines():
+    manager = DiffusionLoRAManager(
+        pipeline=_DummyPipeline(),
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+    )
+    weights = _make_lora_weights("qkv_proj", torch.ones((1, 4)), torch.ones((4, 1)))
+    lora_model = _NamedLookupLM({"model.layers.0.self_attn.qkv_proj": weights})
+
+    assert manager._get_lora_weights(lora_model, "transformer.layers.0.self_attn.qkv_proj") is None
+
+
+def test_lora_manager_deinterleaves_hi3_fused_qkv_lora_b():
+    pipeline = HunyuanImage3Pipeline()
+    manager = DiffusionLoRAManager(
+        pipeline=pipeline,
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+    )
+    layer = _DummyLoRALayer(n_slices=3, output_slices=(8, 4, 4))
+    manager._lora_modules = {"transformer.layers.0.self_attn.qkv_proj": layer}
+
+    interleaved = torch.arange(16, dtype=torch.float32).reshape(16, 1)
+    weights = _make_lora_weights("qkv_proj", torch.ones((1, 4)), interleaved)
+    lora_model = _NamedLookupLM({"model.layers.0.self_attn.qkv_proj": weights})
+
+    manager._bind_adapter_weights(lora_model, scale=1.0)
+
+    assert layer.reset_calls == 0
+    assert len(layer.set_calls) == 1
+    lora_a_list, lora_b_list = layer.set_calls[0]
+    assert len(lora_b_list) == 3
+    packed = deinterleave_hi3_gqa_qkv(interleaved, 4, 2, 2)
+    assert torch.equal(lora_b_list[0], packed[:8])
+    assert torch.equal(lora_b_list[1], packed[8:12])
+    assert torch.equal(lora_b_list[2], packed[12:])
+    assert all(torch.equal(a, weights.lora_a) for a in lora_a_list)
+
+
+def test_lora_manager_skips_hi3_fused_qkv_when_layout_unknown():
+    pipeline = HunyuanImage3Pipeline()
+    del pipeline.transformer.config
+    manager = DiffusionLoRAManager(
+        pipeline=pipeline,
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+    )
+    layer = _DummyLoRALayer(n_slices=3, output_slices=(8, 4, 4))
+    manager._lora_modules = {"transformer.layers.0.self_attn.qkv_proj": layer}
+    weights = _make_lora_weights("qkv_proj", torch.ones((1, 4)), torch.arange(16, dtype=torch.float32).reshape(16, 1))
+    lora_model = _NamedLookupLM({"model.layers.0.self_attn.qkv_proj": weights})
+
+    manager._bind_adapter_weights(lora_model, scale=1.0)
+
+    assert layer.set_calls == []
+    assert layer.reset_calls == 1
+
+
+def test_lora_manager_does_not_deinterleave_non_hi3_fused_qkv():
+    manager = DiffusionLoRAManager(
+        pipeline=_DummyPipeline(),
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+    )
+    layer = _DummyLoRALayer(n_slices=3, output_slices=(8, 4, 4))
+    manager._lora_modules = {"transformer.layers.0.self_attn.qkv_proj": layer}
+    packed = torch.arange(16, dtype=torch.float32).reshape(16, 1)
+    weights = _make_lora_weights("qkv_proj", torch.ones((1, 4)), packed)
+    lora_model = _NamedLookupLM({"transformer.layers.0.self_attn.qkv_proj": weights})
+
+    manager._bind_adapter_weights(lora_model, scale=1.0)
+
+    assert len(layer.set_calls) == 1
+    _, lora_b_list = layer.set_calls[0]
+    assert torch.equal(lora_b_list[0], packed[:8])
+    assert torch.equal(lora_b_list[1], packed[8:12])
+    assert torch.equal(lora_b_list[2], packed[12:])

--- a/vllm_omni/diffusion/lora/manager.py
+++ b/vllm_omni/diffusion/lora/manager.py
@@ -32,6 +32,83 @@ from vllm_omni.lora.utils import stable_lora_int_id
 
 logger = init_logger(__name__)
 
+_HI3_PIPELINE_TYPE = "HunyuanImage3Pipeline"
+_HI3_TRANSFORMER_TYPE = "HunyuanImage3Model"
+_HI3_FUSED_QKV_SUFFIX = "qkv_proj"
+
+
+def is_hunyuan_image3_pipeline(pipeline: nn.Module) -> bool:
+    """True when *pipeline* is the HunyuanImage-3 DiT stack.
+
+    The DiT LoRA manager registers wrappers under ``transformer.layers.*``,
+    while HI3 PEFT adapters store the matching tensors under ``model.layers.*``.
+    Both the GQA de-interleave and that namespace fallback are HI3-specific.
+    """
+    if type(pipeline).__name__ == _HI3_PIPELINE_TYPE:
+        return True
+    for attr in ("transformer", "model"):
+        component = getattr(pipeline, attr, None)
+        if component is not None and type(component).__name__ == _HI3_TRANSFORMER_TYPE:
+            return True
+    return False
+
+
+def hi3_qkv_layout(pipeline: nn.Module) -> tuple[int, int, int] | None:
+    """Return ``(num_attention_heads, num_kv_heads, head_dim)`` for HI3, or None."""
+    transformer = getattr(pipeline, "transformer", None) or getattr(pipeline, "model", None)
+    config = getattr(transformer, "config", None)
+    if config is None:
+        return None
+    num_attention_heads = getattr(config, "num_attention_heads", None)
+    num_kv_heads = getattr(config, "num_key_value_heads", num_attention_heads)
+    if not num_attention_heads or not num_kv_heads:
+        return None
+    if num_attention_heads % num_kv_heads != 0:
+        return None
+    if getattr(config, "head_dim", None):
+        head_dim = config.head_dim
+    elif getattr(config, "attention_head_dim", None):
+        head_dim = config.attention_head_dim
+    elif getattr(config, "hidden_size", None):
+        head_dim = config.hidden_size // num_attention_heads
+    else:
+        return None
+    if head_dim <= 0:
+        return None
+    return int(num_attention_heads), int(num_kv_heads), int(head_dim)
+
+
+def deinterleave_hi3_gqa_qkv(
+    qkv: torch.Tensor,
+    num_attention_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+) -> torch.Tensor:
+    """Convert HI3 GQA-interleaved QKV rows to ``[all Q; all K; all V]``.
+
+    Matches ``HunyuanImage3Model._split_qkv_weight``: checkpoint rows are packed
+    as ``[Q-group, K, V]`` per KV head. The last dimension is preserved so the
+    same permutation works for base weights (``hidden_size``) and LoRA-B (rank).
+    """
+    if qkv.ndim != 2:
+        raise ValueError(f"HI3 fused QKV tensor must be rank-2, got shape {tuple(qkv.shape)}")
+    if num_attention_heads % num_kv_heads != 0:
+        raise ValueError(
+            f"HI3 GQA layout is invalid: num_attention_heads={num_attention_heads} "
+            f"is not divisible by num_kv_heads={num_kv_heads}"
+        )
+    num_key_value_groups = num_attention_heads // num_kv_heads
+    expected_rows = (num_attention_heads + num_kv_heads * 2) * head_dim
+    if qkv.shape[0] != expected_rows:
+        raise ValueError(
+            f"HI3 fused QKV rows={qkv.shape[0]} do not match "
+            f"(num_attention_heads + 2 * num_kv_heads) * head_dim = {expected_rows}"
+        )
+    last_dim = qkv.shape[1]
+    packed = qkv.reshape(num_kv_heads, num_key_value_groups + 2, head_dim, last_dim)
+    q, k, v = torch.split(packed, (num_key_value_groups, 1, 1), dim=1)
+    return torch.concat((q.reshape(-1, last_dim), k.reshape(-1, last_dim), v.reshape(-1, last_dim)))
+
 
 class LoRABackend(str, Enum):
     PEFT = "peft"
@@ -537,8 +614,41 @@ class DiffusionLoRAManager:
         if lora_weights is not None:
             return lora_weights
 
+        # HI3 PEFT adapters live under model.layers.* while DiT wrappers are
+        # registered as transformer.layers.*. AR consumes the same adapter
+        # under the model. prefix, so this fallback is HI3-only.
+        if is_hunyuan_image3_pipeline(self.pipeline) and full_module_name.startswith("transformer."):
+            model_scoped_name = "model." + full_module_name.split(".", 1)[1]
+            lora_weights = lora_model.get_lora(model_scoped_name)
+            if lora_weights is not None:
+                return lora_weights
+
         module_suffix = full_module_name.split(".")[-1]
         return lora_model.get_lora(module_suffix)
+
+    def _convert_hi3_fused_qkv_lora_b(
+        self,
+        full_module_name: str,
+        lora_b: torch.Tensor,
+    ) -> torch.Tensor | None:
+        """De-interleave an HI3 fused qkv_proj LoRA-B, or None to skip bind."""
+        if full_module_name.rsplit(".", 1)[-1] != _HI3_FUSED_QKV_SUFFIX:
+            return lora_b
+        if not is_hunyuan_image3_pipeline(self.pipeline):
+            return lora_b
+        layout = hi3_qkv_layout(self.pipeline)
+        if layout is None:
+            logger.error(
+                "Skipping LoRA for %s: HunyuanImage-3 fused qkv_proj requires "
+                "an established GQA layout before the interleaved LoRA-B can be applied",
+                full_module_name,
+            )
+            return None
+        try:
+            return deinterleave_hi3_gqa_qkv(lora_b, *layout)
+        except ValueError as exc:
+            logger.error("Skipping LoRA for %s: %s", full_module_name, exc)
+            return None
 
     def _is_active_at_scale(self, adapter_id: int, scale: float) -> bool:
         """True if the adapter_id is active and the current scale matches."""
@@ -637,17 +747,21 @@ class DiffusionLoRAManager:
                     continue
 
                 total = sum(output_slices)
-                if lora_weights.lora_b.shape[0] != total:
+                lora_b = self._convert_hi3_fused_qkv_lora_b(full_module_name, lora_weights.lora_b)
+                if lora_b is None:
+                    lora_layer.reset_lora(0)
+                    continue
+                if lora_b.shape[0] != total:
                     logger.warning(
                         "Skipping LoRA for %s due to shape mismatch: lora_b[0]=%d != sum(output_slices)=%d",
                         full_module_name,
-                        lora_weights.lora_b.shape[0],
+                        lora_b.shape[0],
                         total,
                     )
                     lora_layer.reset_lora(0)
                     continue
 
-                b_splits = list(torch.split(lora_weights.lora_b, list(output_slices), dim=0))
+                b_splits = list(torch.split(lora_b, list(output_slices), dim=0))
                 lora_a_list = [lora_weights.lora_a] * n_slices
                 lora_b_list = [b * scale for b in b_splits]
                 lora_layer.set_lora(index=0, lora_a=lora_a_list, lora_b=lora_b_list)


### PR DESCRIPTION
## Purpose

Related to https://github.com/vllm-project/vllm-omni/issues/6411

HunyuanImage-3 DiT LoRA adapters can load and activate while none of the updates land on the correct layers.

The DiT manager registers wrappers as `transformer.layers.*`. HI3 PEFT checkpoints store the matching tensors as `model.layers.*` so that the AR engine can consume the same adapter. The existing lookup tried the full name, the name with the first component stripped, and the leaf suffix, so every HI3 DiT slot missed.

A second, independent defect is the fused `qkv_proj` LoRA-B layout. HI3 checkpoint QKV rows are GQA-interleaved per KV head (`[Q-group, K, V], ...`). The base-weight loader already converts that into `[all Q; all K; all V]`. The LoRA bind path split the fused LoRA-B as if it were already block-packed, so deltas were written onto the wrong output rows.

This change:

- Resolves `transformer.layers.*` wrappers against the HI3 `model.layers.*` PEFT namespace.
- Applies the same GQA de-interleave as the HI3 base-weight loader to fused `qkv_proj` LoRA-B before installing packed slices.
- Scopes both behaviors to HunyuanImage-3 so already block-packed QKV adapters for other models stay unchanged.
- Skips the bind (does not install a known-invalid interleaved tensor) when the HI3 GQA layout cannot be established.

## Test Plan

**vLLM Version:** current pin

**vLLM-Omni Commit:** this branch

```bash
pytest -q tests/diffusion/lora/test_lora_manager.py \
  -k "hi3 or hunyuan or deinterleave or model_layers or fused_qkv" \
  --run-level 1
```

Prerequisites: CPU, repo extras that provide `pytest`, `torch`, and `vllm`.

## Test Result

This environment does not have vLLM installed, so the repo pytest file could not be collected. The new helpers and bind path were executed against the live branch sources with a torch CPU stub of the LoRA manager:

- GQA de-interleave matches `[all Q; all K; all V]`
- `transformer.layers.*` resolves `model.layers.*` only for HunyuanImage-3
- fused `qkv_proj` LoRA-B is de-interleaved before slice install
- missing HI3 layout skips the bind instead of installing interleaved rows
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7554cc1-9aca-415e-b8a8-3c4bfd7f8a19?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7554cc1-9aca-415e-b8a8-3c4bfd7f8a19&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

