### PR TITLE
[Bugfix][MiniCPM-o] Fix duplex camera frame fixture

### DIFF
--- a/tests/e2e/online_serving/helpers/minicpmo_4_5_duplex.py
+++ b/tests/e2e/online_serving/helpers/minicpmo_4_5_duplex.py
@@ -101,7 +101,8 @@ def duplex_camera_frames(*, seconds: int, cache_dir: Path) -> list[str]:
     from tests.helpers.media import generate_synthetic_video
 
     video = generate_synthetic_video(448, 448, 30 * seconds, cache_dir=cache_dir)
-    return _video_frames_from_file(Path(video["file_path"]))
+    frames, _ = _video_frames_from_file(Path(video["file_path"]))
+    return frames
 
 
 def realtime_url(omni_server) -> str:

--- a/tests/e2e/online_serving/test_minicpmo_realtime_duplex_drivers.py
+++ b/tests/e2e/online_serving/test_minicpmo_realtime_duplex_drivers.py
@@ -1926,6 +1926,28 @@ def test_realtime_duplex_demo_sends_each_units_stacked_composite_next_to_its_bas
     assert _sent_video_frames(messages) == [["f0", "s0"], ["f1", "s1"], ["f2"]]
 
 
+def test_minicpmo_duplex_camera_fixture_returns_flat_base_frame_track(tmp_path, monkeypatch):
+    from tests.e2e.online_serving.helpers import minicpmo_4_5_duplex as fixtures
+    from tests.e2e.online_serving.helpers import minicpmo_realtime_duplex_scenarios as demo
+    from tests.helpers import media
+
+    video_path = tmp_path / "camera.mp4"
+    monkeypatch.setattr(
+        media,
+        "generate_synthetic_video",
+        lambda *args, **kwargs: {"file_path": str(video_path)},
+    )
+    monkeypatch.setattr(
+        demo,
+        "_video_frames_from_file",
+        lambda path: (["frame-0", "frame-1"], [None, None]),
+    )
+
+    frames = fixtures.duplex_camera_frames(seconds=2, cache_dir=tmp_path)
+
+    assert frames == ["frame-0", "frame-1"]
+
+
 def test_realtime_duplex_demo_decodes_a_video_file_into_one_frame_per_second(tmp_path):
     pytest.importorskip("cv2")
     pytest.importorskip("imageio")


### PR DESCRIPTION
Fixes #6754.

## Purpose

### What broke

`test_duplex_single_session_video_input` failed before server execution with `TypeError: unsupported frame type for stacking` because a list was passed where one encoded frame was expected.

### Reproduction

Run from the repository root on `main`:

```bash
uv run --project "$PWD" --python "$PWD/.venv/bin/python" --no-sync python -c "import tempfile; from pathlib import Path; from tests.e2e.online_serving.helpers.minicpmo_4_5_duplex import duplex_camera_frames; from vllm_omni.experimental.fullduplex.video_stacking import concat_frames_b64; d=tempfile.TemporaryDirectory(); frames=duplex_camera_frames(seconds=1, cache_dir=Path(d.name)); [concat_frames_b64([frames[index]] * 2) for index in range(len(frames))]"
```

### Root cause

`_video_frames_from_file` returns two parallel tracks, `(base_frames, stacked_frames)`. `duplex_camera_frames` declared `list[str]` but returned that tuple unchanged, so the E2E test treated each inner track list as an individual frame.

### Fix

Unpack the decoder result at the fixture boundary and return only `base_frames`. Add a deterministic CPU regression test that verifies the fixture preserves its flat `list[str]` contract.

## Test Plan

```bash
uv run --project "$PWD" --python "$PWD/.venv/bin/python" --no-sync pre-commit run --files tests/e2e/online_serving/helpers/minicpmo_4_5_duplex.py tests/e2e/online_serving/test_minicpmo_realtime_duplex_drivers.py

uv run --project "$PWD" --python "$PWD/.venv/bin/python" --no-sync pytest -q tests/e2e/online_serving/test_minicpmo_realtime_duplex_drivers.py tests/e2e/features/fullduplex/test_client.py::test_video_stacking_tiles_a_units_subframes_into_one_image tests/e2e/features/fullduplex/test_client.py::test_video_stacking_picks_the_squarest_grid tests/e2e/features/fullduplex/test_client.py::test_video_stacking_skips_the_subframe_that_duplicates_the_base_frame
```

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** 43c21c95729539896b0271bf27c3bfa277a23ce8

## Test Result

- All local pre-commit hooks passed.
- 82 tests passed with 14 existing PyTorch deprecation warnings.
- The H100 serving E2E was not run locally; the regression covers the failing pre-server frame-shape path on CPU.