### PR TITLE
[Bugfix] Restore single-stage inline diffusion execution for MiniMax-H3

### DIFF
--- a/tests/engine/test_async_omni_engine_stage_init.py
+++ b/tests/engine/test_async_omni_engine_stage_init.py
@@ -398,12 +398,27 @@ def test_initialize_local_diffusion_replica_restores_device_visibility_after_loc
             os.environ[env_var] = old_env
 
 
-def test_initialize_local_diffusion_replica_passes_stage_init_timeout_and_inline_flag(monkeypatch):
+@pytest.mark.parametrize(
+    ("num_stages", "num_replicas", "engine_args", "expected_use_inline"),
+    [
+        pytest.param(1, 1, {}, True, id="single-stage-default-inline"),
+        pytest.param(2, 1, {"inline_diffusion": True}, True, id="multi-stage-explicit-inline"),
+        pytest.param(2, 1, {}, False, id="multi-stage-default-subprocess"),
+        pytest.param(1, 2, {"inline_diffusion": True}, False, id="multi-replica-subprocess"),
+    ],
+)
+def test_initialize_local_diffusion_replica_selects_inline_mode(
+    monkeypatch,
+    num_stages,
+    num_replicas,
+    engine_args,
+    expected_use_inline,
+):
     import vllm_omni.engine.stage_runtime as runtime_mod
     from vllm_omni.engine.stage_engine_startup import StageReplicaResources
 
     runtime = StageRuntime(
-        stage_configs=[types.SimpleNamespace()],
+        stage_configs=[types.SimpleNamespace() for _ in range(num_stages)],
         model="dummy-model",
         config_path="dummy-config",
         stage_init_timeout=1,
@@ -411,7 +426,8 @@ def test_initialize_local_diffusion_replica_passes_stage_init_timeout_and_inline
         async_chunk=False,
     )
 
-    plan = _make_diffusion_plan(0, stage_id=0).replicas[0]
+    plan = _make_diffusion_plan(0, stage_id=0, num_replicas=num_replicas).replicas[0]
+    plan.stage_cfg.engine_args.update(engine_args)
 
     captured: dict[str, object] = {}
 
@@ -433,33 +449,9 @@ def test_initialize_local_diffusion_replica_passes_stage_init_timeout_and_inline
         "stage_id": 0,
         "stage_init_timeout": 302,
         "batch_size": 4,
-        "use_inline": False,
+        "use_inline": expected_use_inline,
         "omni_master_server": None,
     }
-
-
-def test_initialize_local_diffusion_replica_uses_explicit_inline_opt_in(monkeypatch):
-    import vllm_omni.engine.stage_runtime as runtime_mod
-    from vllm_omni.engine.stage_engine_startup import StageReplicaResources
-
-    runtime = _make_stage_runtime()
-    plan = _make_diffusion_plan(0, stage_id=1).replicas[0]
-    plan.stage_cfg.engine_args["inline_diffusion"] = True
-    captured: dict[str, object] = {}
-
-    monkeypatch.setattr(runtime_mod, "inject_kv_stage_info", lambda *_: None)
-    monkeypatch.setattr(
-        runtime_mod,
-        "launch_diffusion_stage_replica",
-        lambda **kwargs: (
-            captured.update(use_inline=kwargs["use_inline"]),
-            (types.SimpleNamespace(), StageReplicaResources()),
-        )[1],
-    )
-
-    runtime._initialize_local_diffusion_replica(plan, stage_init_timeout=1)
-
-    assert captured["use_inline"] is True
 
 
 def test_initialize_local_llm_replica_scopes_runtime_env(monkeypatch):

--- a/vllm_omni/engine/stage_runtime.py
+++ b/vllm_omni/engine/stage_runtime.py
@@ -673,7 +673,8 @@ class StageRuntime:
                     metadata=plan.metadata,
                     stage_init_timeout=stage_init_timeout,
                     batch_size=self._diffusion_batch_size,
-                    use_inline=plan.num_replicas == 1 and bool(inline_diffusion or custom_pipeline_args),
+                    use_inline=plan.num_replicas == 1
+                    and (self._num_stages == 1 or bool(inline_diffusion or custom_pipeline_args)),
                     replica_id=plan.replica_id,
                     omni_master_server=self._get_omni_master_server(),
                     omni_coordinator_address=self._get_coordinator_address(),


### PR DESCRIPTION
## Purpose

Before #5885, a single-stage diffusion pipeline with one replica ran inline. #5885 narrowed inline selection to deployments with `inline_diffusion` or `custom_pipeline_args`, so a normal single-stage MiniMax-H3 service started `StageDiffusionProc`. Crossing that process boundary materialized generated frames as interleaved HWC data, preventing MP4 response encoding from selecting the direct planar conversion path.

Restore the original single-stage rule by selecting inline execution when the pipeline has one stage and one replica. Explicit multi-stage inline selection remains unchanged, and multi-replica stages continue to use subprocess clients.

## Test Plan

- Cover default and explicit inline selection across single-stage, multi-stage, single-replica, and multi-replica configurations.
- Run one MiniMax-H3 FL2VA/t2va serving smoke test on 8 Atlas A2 NPUs.

**vLLM Version:** source commit `2cf0a6915ce544dc493a0990f2ea38d81601128a`

**vLLM-Omni Commit:** `06444bd9c05573a90237dce53c7616ef2242467d`

## Test Result

- `python -m pytest -q tests/engine/test_async_omni_engine_stage_init.py::test_initialize_local_diffusion_replica_selects_inline_mode`: 4 passed.
- MiniMax-H3 started `InlineStageDiffusionClient`; the request selected `direct_planar` with 8 frame-conversion workers and returned a valid MP4.
