### PR TITLE
[Orchestrator] Implement cache reset RPC forwarding to AR stage engine cores

### DIFF
--- a/tests/engine/test_stage_pool_collective_rpc.py
+++ b/tests/engine/test_stage_pool_collective_rpc.py
@@ -40,14 +40,14 @@ def test_collective_rpc_normalizes_none_args_on_control_helper():
 def test_collective_rpc_unrelated_async_helper_uses_collective_path():
     async def run() -> None:
         other = AsyncMock(return_value="should-not-run")
-        pool, client = _make_pool(reset_prefix_cache_async=other)
+        pool, client = _make_pool(is_sleeping_async=other)
 
-        result = await pool.collective_rpc(0, "reset_prefix_cache", timeout=1.5, args=("x",), kwargs={"k": 1})
+        result = await pool.collective_rpc(0, "is_sleeping", timeout=1.5, args=("x",), kwargs={"k": 1})
 
         assert result == {"via": "collective"}
         other.assert_not_awaited()
         client.collective_rpc_async.assert_awaited_once_with(
-            method="reset_prefix_cache",
+            method="is_sleeping",
             timeout=1.5,
             args=("x",),
             kwargs={"k": 1},
@@ -81,10 +81,37 @@ def test_collective_rpc_control_method_reraises_worker_error():
 
 
 @pytest.mark.cpu
+def test_collective_rpc_reset_caches_use_control_helpers():
+    async def run() -> None:
+        reset_prefix = AsyncMock(return_value=True)
+        reset_encoder = AsyncMock(return_value=None)
+        reset_mm = AsyncMock(return_value=None)
+        pool, client = _make_pool(
+            reset_prefix_cache_async=reset_prefix,
+            reset_encoder_cache_async=reset_encoder,
+            reset_mm_cache_async=reset_mm,
+        )
+
+        result = await pool.collective_rpc(0, "reset_prefix_cache", args=(True, True), timeout=2.0)
+        assert result is True
+        reset_prefix.assert_awaited_once_with(True, True)
+
+        await pool.collective_rpc(0, "reset_encoder_cache", timeout=2.0)
+        reset_encoder.assert_awaited_once()
+
+        await pool.collective_rpc(0, "reset_mm_cache", timeout=2.0)
+        reset_mm.assert_awaited_once()
+
+        client.collective_rpc_async.assert_not_awaited()
+
+    asyncio.run(run())
+
+
+@pytest.mark.cpu
 def test_collective_rpc_non_control_method_still_returns_error_dict():
     async def run() -> None:
         pool, _client = _make_pool(collective_rpc_async=AsyncMock(side_effect=RuntimeError("probe failed")))
-        result = await pool.collective_rpc(0, "reset_prefix_cache")
+        result = await pool.collective_rpc(0, "is_sleeping")
         assert result["supported"] is False
         assert "probe failed" in result["error"]
 

--- a/tests/entrypoints/test_async_omni_pause_sleep_routing.py
+++ b/tests/entrypoints/test_async_omni_pause_sleep_routing.py
@@ -121,6 +121,80 @@ def test_resume_generation_resumes_ar_then_clears_frontend_pause():
 
 
 @pytest.mark.cpu
+def test_reset_prefix_cache_forwards_to_ar_stages():
+    async def run() -> None:
+        omni = _make_omni(stage_types=["llm", "diffusion"])
+
+        result = await omni.reset_prefix_cache(reset_running_requests=True, reset_connector=True)
+
+        assert result is True
+        omni.collective_rpc.assert_awaited_once_with(
+            method="reset_prefix_cache",
+            args=(True, True),
+            kwargs=None,
+            stage_ids=[0],
+        )
+
+    asyncio.run(run())
+
+
+@pytest.mark.cpu
+def test_reset_prefix_cache_diffusion_only_skips_rpc():
+    async def run() -> None:
+        omni = _make_omni(stage_types=["diffusion"])
+
+        result = await omni.reset_prefix_cache()
+
+        assert result is True
+        omni.collective_rpc.assert_not_awaited()
+
+    asyncio.run(run())
+
+
+@pytest.mark.cpu
+def test_reset_encoder_cache_forwards_to_ar_stages():
+    async def run() -> None:
+        omni = _make_omni(stage_types=["llm", "diffusion"])
+
+        await omni.reset_encoder_cache()
+
+        omni.collective_rpc.assert_awaited_once_with(
+            method="reset_encoder_cache",
+            args=(),
+            kwargs=None,
+            stage_ids=[0],
+        )
+
+    asyncio.run(run())
+
+
+@pytest.mark.cpu
+def test_reset_mm_cache_clears_frontend_then_forwards_to_ar_stages():
+    async def run() -> None:
+        omni = _make_omni(stage_types=["llm", "diffusion"])
+        cleared: list[str] = []
+        omni.engine.input_processor = SimpleNamespace(
+            mm_processor_cache=SimpleNamespace(
+                clear=lambda: cleared.append("clear"),
+                reset=lambda: cleared.append("reset"),
+            )
+        )
+        del omni.reset_mm_cache  # exercise the real implementation
+
+        await omni.reset_mm_cache()
+
+        assert cleared == ["clear"]
+        omni.collective_rpc.assert_awaited_once_with(
+            method="reset_mm_cache",
+            args=(),
+            kwargs=None,
+            stage_ids=[0],
+        )
+
+    asyncio.run(run())
+
+
+@pytest.mark.cpu
 def test_sleep_routes_ar_via_collective_rpc_and_diffusion_to_worker_rpc():
     async def run() -> None:
         omni = _make_omni(stage_types=["llm", "diffusion"])

--- a/vllm_omni/engine/stage_pool.py
+++ b/vllm_omni/engine/stage_pool.py
@@ -105,6 +105,9 @@ class StagePool:
             "resume_scheduler",
             "sleep",
             "wake_up",
+            "reset_prefix_cache",
+            "reset_encoder_cache",
+            "reset_mm_cache",
         }
     )
 

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -1416,10 +1416,14 @@ class AsyncOmni(EngineClient, OmniBase):
         return await self.collective_rpc(method="profile", args=(False, None), stage_ids=stages)
 
     async def reset_mm_cache(self) -> None:
-        """Reset the frontend (P0) multimodal processor cache.
+        """Reset the multimodal caches: frontend (P0) and stage engine cores.
 
-        ``EngineCore.sleep(level>=1)`` already clears the P1 receiver cache.
-        Clearing P0 avoids hash-only follow-up requests after that reset.
+        The frontend P0 processor cache maps input hashes to processed
+        multimodal data; without clearing it, hash-only follow-up requests
+        would be served from state computed under the previous weights. Stage
+        engine cores clear their worker-level mm caches the same way
+        ``EngineCore.sleep(level>=1)`` clears the P1 receiver cache. Diffusion
+        stages do not maintain a vLLM-style mm cache and are skipped.
         """
         processor = getattr(self, "input_processor", None)
         if processor is None:
@@ -1427,32 +1431,60 @@ class AsyncOmni(EngineClient, OmniBase):
         cache = getattr(processor, "mm_processor_cache", None)
         if cache is None:
             logger.debug("[AsyncOmni] reset_mm_cache: no frontend mm_processor_cache")
-            return
-        for name in ("clear", "reset", "clear_cache"):
-            fn = getattr(cache, name, None)
-            if callable(fn):
-                fn()
-                return
-        logger.debug("[AsyncOmni] reset_mm_cache: cache has no clear/reset method")
+        else:
+            for name in ("clear", "reset", "clear_cache"):
+                fn = getattr(cache, name, None)
+                if callable(fn):
+                    fn()
+                    break
+            else:
+                logger.debug("[AsyncOmni] reset_mm_cache: cache has no clear/reset method")
+
+        ar_stage_ids, diffusion_stage_ids = self._split_stage_ids_by_type()
+        if diffusion_stage_ids:
+            logger.debug("[AsyncOmni] reset_mm_cache: skipping diffusion stage(s) %s", diffusion_stage_ids)
+        if ar_stage_ids:
+            await self._engine_core_rpc("reset_mm_cache", stage_ids=ar_stage_ids)
 
     async def reset_encoder_cache(self) -> None:
-        """Reset the encoder cache for all stages.
+        """Reset the encoder cache on all AR/LLM stage engine cores.
 
-        TODO: Forward to Orchestrator process via message.
+        Forwarded to the stage engine cores via collective_rpc (the same route
+        used by ``sleep``/``wake_up``) so stale encoder outputs computed under
+        previous weights are invalidated after weight updates. Diffusion stages
+        do not maintain a vLLM-style encoder cache and are skipped.
         """
-        logger.warning("[AsyncOmni] reset_encoder_cache not yet supported with Orchestrator process")
+        ar_stage_ids, diffusion_stage_ids = self._split_stage_ids_by_type()
+        if diffusion_stage_ids:
+            logger.debug("[AsyncOmni] reset_encoder_cache: skipping diffusion stage(s) %s", diffusion_stage_ids)
+        if not ar_stage_ids:
+            return
+        await self._engine_core_rpc("reset_encoder_cache", stage_ids=ar_stage_ids)
 
     async def reset_prefix_cache(
         self,
         reset_running_requests: bool = False,
         reset_connector: bool = False,
     ) -> bool:
-        """Reset the prefix cache for all stages.
+        """Reset the prefix cache on all AR/LLM stage engine cores.
 
-        TODO: Forward to Orchestrator process via message.
+        Forwarded to the stage engine cores via collective_rpc (the same route
+        used by ``sleep``/``wake_up``). Without this, prefix-cache KV computed
+        under previous weights is silently reused after weight updates.
+        Diffusion stages do not maintain a vLLM-style prefix cache and are
+        skipped.
         """
-        logger.warning("[AsyncOmni] reset_prefix_cache not yet supported with Orchestrator process")
-        return True
+        ar_stage_ids, diffusion_stage_ids = self._split_stage_ids_by_type()
+        if diffusion_stage_ids:
+            logger.debug("[AsyncOmni] reset_prefix_cache: skipping diffusion stage(s) %s", diffusion_stage_ids)
+        if not ar_stage_ids:
+            return True
+        results = await self._engine_core_rpc(
+            "reset_prefix_cache",
+            stage_ids=ar_stage_ids,
+            args=(reset_running_requests, reset_connector),
+        )
+        return all(self._coerce_stage_bool(result) for result in results)
 
     async def sleep(
         self, stage_ids: list[int] | None = None, level: int = 2, mode: PauseMode = "abort"


### PR DESCRIPTION
Closes #6739

## Problem

, , and  were TODO stubs on the Orchestrator path: they logged `[AsyncOmni] ... not yet supported with Orchestrator process` and did nothing. Any weight-update workflow (see #6738) that resets caches before continuing to serve silently kept prefix/encoder/mm caches computed under the previous weights.

## Fix

Route the three resets through the same collective RPC path already used by `sleep`/`wake_up`:

- **`stage_pool.py`**: register `reset_prefix_cache`/`reset_encoder_cache`/`reset_mm_cache` as EngineCore control helpers so they dispatch to the per-stage engine core client.
- **`async_omni.py`**: forward each reset to AR/LLM stage engine cores; `reset_mm_cache` additionally clears the frontend `mm_processor_cache`. Diffusion stages maintain no vLLM-style prefix/encoder/mm caches and are skipped.

## Tests

- `tests/engine/test_stage_pool_collective_rpc.py`: cache resets use the control-helper dispatch path.
- `tests/entrypoints/test_async_omni_pause_sleep_routing.py`: resets forward to AR stages and skip diffusion-only pools.