### PR TITLE
Fix MiniCPM-o concurrent audio first-packet latency

### DIFF
--- a/tests/config/test_config_factory.py
+++ b/tests/config/test_config_factory.py
@@ -1159,7 +1159,7 @@ class TestDeployConfigLoading:
         stages = merge_pipeline_deploy(pipeline, deploy)
 
         assert deploy.session_mode == "duplex"
-        assert deploy.active_stream_window == 1
+        assert deploy.active_stream_window == max_sessions
         assert deploy.duplex_session.max_sessions == max_sessions
         assert [stage.session_mode for stage in stages] == ["duplex", "duplex", "duplex"]
         assert [stage.to_omegaconf().session_mode for stage in stages] == ["duplex", "duplex", "duplex"]

--- a/vllm_omni/deploy/minicpmo_4_5.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5.yaml
@@ -4,7 +4,9 @@ async_chunk: true
 # Native full-duplex shares this profile with /v1/chat/completions. Every other
 # duplex_session knob keeps its runtime default.
 session_mode: duplex
-active_stream_window: 1
+# Keep the active window aligned with the session and stage capacities below.
+# A smaller window serializes first-packet generation for concurrent chat turns.
+active_stream_window: 4
 duplex_session:
   # Matches Stage 0/1 max_num_seqs below.
   max_sessions: 4

--- a/vllm_omni/deploy/minicpmo_4_5_2gpu.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5_2gpu.yaml
@@ -7,7 +7,9 @@ async_chunk: true
 # Native full-duplex shares this profile with /v1/chat/completions. Every other
 # duplex_session knob keeps its runtime default.
 session_mode: duplex
-active_stream_window: 1
+# Keep the active window aligned with the session and stage capacities below.
+# A smaller window serializes first-packet generation for concurrent chat turns.
+active_stream_window: 4
 duplex_session:
   # Matches Stage 0/1 max_num_seqs below.
   max_sessions: 4

--- a/vllm_omni/deploy/minicpmo_4_5_3gpu.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5_3gpu.yaml
@@ -7,7 +7,9 @@ async_chunk: true
 # Native full-duplex shares this profile with /v1/chat/completions. Every other
 # duplex_session knob keeps its runtime default.
 session_mode: duplex
-active_stream_window: 1
+# Keep the active window aligned with the session and stage capacities below.
+# A smaller window serializes first-packet generation for concurrent chat turns.
+active_stream_window: 4
 duplex_session:
   # Matches Stage 0/1 max_num_seqs below.
   max_sessions: 4


### PR DESCRIPTION
Fixes #6741.

## Summary

MiniCPM-o deployment profiles that allow four duplex sessions and set max_num_seqs=4 were configured with active_stream_window=1. Because the same profiles serve both /v1/realtime and /v1/chat/completions, that window serialized audio first-packet generation for concurrent chat requests.

This change aligns active_stream_window with the configured session/stage capacity for the default, 2-GPU, and 3-GPU profiles. The memory-constrained 8x4090 profile remains at 1 because its max_sessions and max_num_seqs are both 1. The config test now enforces active_stream_window == max_sessions for all MiniCPM-o profiles, including inherited replica profiles.

## L20X Seed-TTS results

Compared with baseline 0e4b28f491721af618525f4ba9f679f0eb5a7157 and latest main 72a1ce488bf72edae6315a9d63d54b36018d8ccb before this fix:

| Concurrency / prompts | Baseline audio TTFP | Main before fix | After fix | vs main |
|---|---:|---:|---:|---:|
| 1 / 32 | 478.03 ms | 425.13 ms | 427.95 ms | +0.7% |
| 4 / 64 | 1145.43 ms | 2119.80 ms | 996.33 ms | -53.0% |
| 8 / 128 | 3460.35 ms | 4299.62 ms | 2951.26 ms | -31.4% |

All 224 standard chat requests succeeded. After the fix, request throughput was 1.04 / 1.61 / 1.76 req/s for concurrency 1 / 4 / 8.

The native duplex Seed-TTS benchmark also passed all four turns: audio TTFP 415.91 ms, RTF 0.217, versus 407.43 ms and 0.213 before the fix.

## Tests

- 97 config and chunk-transfer adapter tests passed
- 698 related MiniCPM-o, stage processor, full-duplex, and stream-output tests passed; 6 skipped
- exact real-weight Seed-TTS standard benchmark: 32 + 64 + 128 requests, zero failures
- exact real-weight Seed-TTS duplex benchmark: 4 turns, zero failures
- Ruff check and format check passed