### PR TITLE
[Bugfix] Read engine-reported peak_memory_mb in Wan2.2 AutoRound e2e test

### DIFF
--- a/tests/e2e/offline_inference/test_wan22_autoround_w4a16_expansion.py
+++ b/tests/e2e/offline_inference/test_wan22_autoround_w4a16_expansion.py
@@ -20,7 +20,6 @@ import torch
 from PIL import Image
 
 from tests.helpers.mark import hardware_test
-from tests.helpers.monitor import DeviceMemoryMonitor
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 from vllm_omni.platforms import current_omni_platform
 
@@ -92,13 +91,16 @@ def _create_test_image(width: int = WIDTH, height: int = HEIGHT) -> Image.Image:
 
 
 def _generate_i2v_video(offline_client, prompt: str = "A cat sitting on a table, smooth motion") -> tuple:
-    """Generate one I2V video, return (frames, peak_memory_mb)."""
+    """Generate one I2V video, return (frames, peak_memory_mb).
+
+    ``peak_memory_mb`` is read from the engine output (``peak_memory_mb`` on the
+    diffusion output), which is measured inside the diffusion stage worker. A
+    local ``DeviceMemoryMonitor`` would be useless here: the diffusion model runs
+    in a separate stage subprocess, so the test process only ever sees its own
+    (orchestrator) memory.
+    """
     gc.collect()
     current_omni_platform.empty_cache()
-    device_index = current_omni_platform.current_device()
-    current_omni_platform.reset_peak_memory_stats()
-    monitor = DeviceMemoryMonitor(device_index=device_index, interval=0.02)
-    monitor.start()
 
     image = _create_test_image()
     response = offline_client.send_diffusion_request(
@@ -109,9 +111,6 @@ def _generate_i2v_video(offline_client, prompt: str = "A cat sitting on a table,
         },
     )
 
-    peak = monitor.peak_used_mb
-    monitor.stop()
-
     assert response.success, "Request failed"
     assert response.images is not None and len(response.images) > 0, "Expected image output"
     frames = response.images[0]
@@ -119,17 +118,13 @@ def _generate_i2v_video(offline_client, prompt: str = "A cat sitting on a table,
     gc.collect()
     current_omni_platform.empty_cache()
 
-    return frames, peak
+    return frames, response.peak_memory_mb
 
 
 def _generate_t2v_video(offline_client, prompt: str = "A cat sitting on a table") -> tuple:
     """Generate one T2V video, return (frames, peak_memory_mb)."""
     gc.collect()
     current_omni_platform.empty_cache()
-    device_index = current_omni_platform.current_device()
-    current_omni_platform.reset_peak_memory_stats()
-    monitor = DeviceMemoryMonitor(device_index=device_index, interval=0.02)
-    monitor.start()
 
     response = offline_client.send_diffusion_request(
         {
@@ -138,9 +133,6 @@ def _generate_t2v_video(offline_client, prompt: str = "A cat sitting on a table"
         },
     )
 
-    peak = monitor.peak_used_mb
-    monitor.stop()
-
     assert response.success, "Request failed"
     assert response.images is not None and len(response.images) > 0, "Expected image output"
     frames = response.images[0]
@@ -148,7 +140,7 @@ def _generate_t2v_video(offline_client, prompt: str = "A cat sitting on a table"
     gc.collect()
     current_omni_platform.empty_cache()
 
-    return frames, peak
+    return frames, response.peak_memory_mb
 
 
 # ------------------------------------------------------------------
@@ -240,6 +232,13 @@ def test_wan22_i2v_autoround_w4a16_memory_savings():
     quant_peak = _memory_results["quant_i2v"]
     baseline_peak = _memory_results["baseline_i2v"]
 
+    # The engine must have reported the stage-worker peak; a zero value means the
+    # output did not carry peak_memory_mb and the comparison below is meaningless.
+    assert quant_peak > 0 and baseline_peak > 0, (
+        f"peak_memory_mb not populated by the engine "
+        f"(quant={quant_peak:.0f}, baseline={baseline_peak:.0f})"
+    )
+
     savings = baseline_peak - quant_peak
     print(f"\nQuantized I2V (W4A16) peak memory: {quant_peak:.0f} MB")
     print(f"Baseline I2V (BF16) peak memory:   {baseline_peak:.0f} MB")
@@ -296,6 +295,13 @@ def test_wan22_t2v_autoround_w4a16_memory_savings():
     """Assert quantized T2V model uses meaningfully less memory than BF16 baseline."""
     quant_peak = _memory_results["quant_t2v"]
     baseline_peak = _memory_results["baseline_t2v"]
+
+    # The engine must have reported the stage-worker peak; a zero value means the
+    # output did not carry peak_memory_mb and the comparison below is meaningless.
+    assert quant_peak > 0 and baseline_peak > 0, (
+        f"peak_memory_mb not populated by the engine "
+        f"(quant={quant_peak:.0f}, baseline={baseline_peak:.0f})"
+    )
 
     savings = baseline_peak - quant_peak
     print(f"\nQuantized T2V (W4A16) peak memory: {quant_peak:.0f} MB")

--- a/tests/e2e/offline_inference/test_wan22_autoround_w4a16_expansion.py
+++ b/tests/e2e/offline_inference/test_wan22_autoround_w4a16_expansion.py
@@ -235,8 +235,7 @@ def test_wan22_i2v_autoround_w4a16_memory_savings():
     # The engine must have reported the stage-worker peak; a zero value means the
     # output did not carry peak_memory_mb and the comparison below is meaningless.
     assert quant_peak > 0 and baseline_peak > 0, (
-        f"peak_memory_mb not populated by the engine "
-        f"(quant={quant_peak:.0f}, baseline={baseline_peak:.0f})"
+        f"peak_memory_mb not populated by the engine (quant={quant_peak:.0f}, baseline={baseline_peak:.0f})"
     )
 
     savings = baseline_peak - quant_peak
@@ -299,8 +298,7 @@ def test_wan22_t2v_autoround_w4a16_memory_savings():
     # The engine must have reported the stage-worker peak; a zero value means the
     # output did not carry peak_memory_mb and the comparison below is meaningless.
     assert quant_peak > 0 and baseline_peak > 0, (
-        f"peak_memory_mb not populated by the engine "
-        f"(quant={quant_peak:.0f}, baseline={baseline_peak:.0f})"
+        f"peak_memory_mb not populated by the engine (quant={quant_peak:.0f}, baseline={baseline_peak:.0f})"
     )
 
     savings = baseline_peak - quant_peak

--- a/tests/helpers/client.py
+++ b/tests/helpers/client.py
@@ -122,6 +122,10 @@ class DiffusionResponse:
     #: End-to-end wall time in **seconds** (``perf_counter`` delta), from just before
     #: ``chat.completions.create`` through local image / audio decode.
     e2e_latency: float | None = None
+    #: Peak GPU memory (MB) measured inside the diffusion stage worker, from the
+    #: engine-reported ``peak_memory_mb`` on the output. 0.0 when unavailable
+    #: (e.g. online/HTTP paths where the engine does not report it).
+    peak_memory_mb: float = 0.0
     success: bool = False
 
 
@@ -1966,6 +1970,7 @@ class OfflineOmniClient:
             # Returning actual images
             result.images = output.images
         # [TODO] Add audio processing when tests are introduced
+        result.peak_memory_mb = float(getattr(output, "peak_memory_mb", 0.0) or 0.0)
         result.success = True
         return result
 


### PR DESCRIPTION
Fixes #6760

## Why
`test_wan22_i2v_autoround_w4a16_memory_savings` (and the T2V variant) always fail with:

```
AssertionError: Quantized model (425 MB) should use at least 5000 MB less than baseline (425 MB)
```

The peak was measured with a local `DeviceMemoryMonitor` in the test process, but the diffusion model runs in a separate stage subprocess (spawn). The test process therefore only ever observed its own orchestrator memory (~425 MB) for both quantized and baseline runs, so the savings comparison was meaningless.

## What
- `DiffusionResponse` now carries `peak_memory_mb`, populated from the engine output's `peak_memory_mb` (measured inside the diffusion stage worker via `reset_peak_memory_stats()` + `max_memory_reserved` in `DiffusionModelRunner._sample_peak_memory_mb`).
- The Wan2.2 AutoRound e2e helpers (`_generate_i2v_video` / `_generate_t2v_video`) use `response.peak_memory_mb` instead of the local `DeviceMemoryMonitor`.
- The savings tests assert the engine actually reported a peak (> 0) so a regression in the measurement path fails loudly instead of comparing 0/0.

## Notes
- No production code changed; the fix is confined to test helpers and the failing e2e test.
- Follows the existing pattern in `tests/diffusion/quantization/test_quantization_fp8.py`, which already reads `peak_memory_mb` from the engine output.