### PR TITLE
[Bugfix][HunyuanImage3] Fix get_expert_mapping shape for MoE LoRA packing

### DIFF
--- a/tests/model_executor/models/test_hunyuan_expert_mapping.py
+++ b/tests/model_executor/models/test_hunyuan_expert_mapping.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for HunyuanImage-3 ``get_expert_mapping`` contract.
+
+vLLM consumers such as ``get_moe_expert_mapping`` / ``process_packed_modules_mapping``
+unpack every mapping entry as a flat 4-tuple
+``(param_name, weight_name, expert_id, shard_id)``:
+
+.. code-block:: python
+
+    for _, weight_name, _, _ in get_moe_expert_mapping(model):
+        ...
+
+Historically HunyuanImage-3 returned a 2-tuple ``(mapping, remapping)`` which
+made the unpack fail with ``ValueError: not enough values to unpack
+(expected 4, got 2)`` as soon as a MoE LoRA adapter was loaded. These tests
+pin the flat 4-tuple contract for both the AR and the diffusion model.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+from vllm_omni.diffusion.models.hunyuan_image3.hunyuan_image3_transformer import (  # noqa: E402
+    HunyuanImage3Model,
+)
+from vllm_omni.model_executor.models.hunyuan_image3.hunyuan_image3 import (  # noqa: E402
+    HunyuanModel,
+)
+
+
+def _moe_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        num_experts=8,
+        num_attention_heads=4,
+        num_key_value_heads=1,
+        hidden_size=64,
+        head_dim=16,
+    )
+
+
+def _non_moe_config() -> SimpleNamespace:
+    return SimpleNamespace(num_experts=1)
+
+
+class _FakeHunyuanModel(nn.Module):
+    """Minimal stand-in exposing just the members ``get_expert_mapping`` reads."""
+
+    def __init__(self, config: SimpleNamespace) -> None:
+        super().__init__()
+        self.config = config
+        # e.g. a packed gate/up expert parameter so the mapping is non-empty.
+        self.routed_experts = nn.Parameter(torch.zeros(8, 64, 64))
+        self.num_redundant_experts = 0
+
+
+@pytest.mark.parametrize(
+    ("model_cls", "module_name"),
+    [
+        (HunyuanModel, "vllm_omni.model_executor.models.hunyuan_image3.hunyuan_image3"),
+        (
+            HunyuanImage3Model,
+            "vllm_omni.diffusion.models.hunyuan_image3.hunyuan_image3_transformer",
+        ),
+    ],
+)
+def test_get_expert_mapping_flat_4tuple_contract(
+    model_cls: type,
+    module_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MoE mapping entries must be flat 4-tuples, unpackable by vLLM."""
+    module = __import__(module_name, fromlist=["_is_moe"])
+    monkeypatch.setattr(module, "_is_moe", lambda config: config.num_experts > 1)
+
+    model = _FakeHunyuanModel(_moe_config())
+    mapping = model_cls.get_expert_mapping(model)
+
+    assert isinstance(mapping, list)
+    assert mapping, "MoE model should produce a non-empty expert mapping"
+    for entry in mapping:
+        assert len(entry) == 4, f"expected (param, weight, expert_id, shard_id), got {entry!r}"
+        param_name, weight_name, expert_id, shard_id = entry
+        assert isinstance(param_name, str)
+        assert isinstance(weight_name, str)
+        assert isinstance(expert_id, int)
+        assert isinstance(shard_id, str)
+    # The exact unpack vLLM consumers perform must not raise.
+    for _, weight_name, _, _ in mapping:
+        assert weight_name
+
+
+@pytest.mark.parametrize(
+    ("model_cls", "module_name"),
+    [
+        (HunyuanModel, "vllm_omni.model_executor.models.hunyuan_image3.hunyuan_image3"),
+        (
+            HunyuanImage3Model,
+            "vllm_omni.diffusion.models.hunyuan_image3.hunyuan_image3_transformer",
+        ),
+    ],
+)
+def test_get_expert_mapping_non_moe_returns_empty_list(
+    model_cls: type,
+    module_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-MoE models must return an empty list (not a 2-tuple)."""
+    module = __import__(module_name, fromlist=["_is_moe"])
+    monkeypatch.setattr(module, "_is_moe", lambda config: config.num_experts > 1)
+
+    model = _FakeHunyuanModel(_non_moe_config())
+    mapping = model_cls.get_expert_mapping(model)
+
+    assert mapping == []
+
+
+def test_mapping_entries_survive_vllm_get_moe_expert_mapping_unpack() -> None:
+    """The exact unpack vLLM performs must not raise for the diffusion model."""
+    from vllm.model_executor.utils import get_moe_expert_mapping
+
+    module = __import__(
+        "vllm_omni.diffusion.models.hunyuan_image3.hunyuan_image3_transformer",
+        fromlist=["_is_moe", "HunyuanImage3Model"],
+    )
+    orig_is_moe = module._is_moe
+    module._is_moe = lambda config: config.num_experts > 1
+    try:
+        model = _FakeHunyuanModel(_moe_config())
+        # Bind the real implementation so get_moe_expert_mapping can find it.
+        model.get_expert_mapping = lambda: module.HunyuanImage3Model.get_expert_mapping(
+            model
+        )
+        for _, weight_name, _, _ in get_moe_expert_mapping(model):
+            assert weight_name
+    finally:
+        module._is_moe = orig_is_moe

--- a/tests/model_executor/models/test_hunyuan_expert_mapping.py
+++ b/tests/model_executor/models/test_hunyuan_expert_mapping.py
@@ -132,9 +132,7 @@ def test_mapping_entries_survive_vllm_get_moe_expert_mapping_unpack() -> None:
     try:
         model = _FakeHunyuanModel(_moe_config())
         # Bind the real implementation so get_moe_expert_mapping can find it.
-        model.get_expert_mapping = lambda: module.HunyuanImage3Model.get_expert_mapping(
-            model
-        )
+        model.get_expert_mapping = lambda: module.HunyuanImage3Model.get_expert_mapping(model)
         for _, weight_name, _, _ in get_moe_expert_mapping(model):
             assert weight_name
     finally:

--- a/tests/model_executor/models/test_kv_cache_scale_mapper.py
+++ b/tests/model_executor/models/test_kv_cache_scale_mapper.py
@@ -67,8 +67,8 @@ class _FakeHunyuanModel(_FakeModel):
             use_cla=False,
         )
 
-    def get_expert_mapping(self) -> tuple[list[object], dict[str, object]]:
-        return [], {}
+    def get_expert_mapping(self) -> list[object]:
+        return []
 
     def _split_qkv_weight(self, weight: torch.Tensor) -> torch.Tensor:
         return weight

--- a/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
@@ -2075,7 +2075,7 @@ class HunyuanImage3Model(nn.Module):
         if _is_moe(self.config):
             # Params for weights, fp8 weight scales, fp8 activation scales
             # (param_name, weight_name, expert_id, shard_id)
-            fused_moe_expert_mapping = FusedMoE.make_expert_params_mapping(
+            return FusedMoE.make_expert_params_mapping(
                 self,
                 ckpt_gate_proj_name="gate_proj",
                 ckpt_down_proj_name="down_proj",
@@ -2083,13 +2083,8 @@ class HunyuanImage3Model(nn.Module):
                 num_experts=self.config.num_experts,
                 num_redundant_experts=self.num_redundant_experts,
             )
-            expert_weights_remapping = {
-                "gate_proj": ("gate_and_up_proj", 1, 2),
-                "up_proj": ("gate_and_up_proj", 0, 2),
-            }
-            return fused_moe_expert_mapping, expert_weights_remapping
         else:
-            return [], {}
+            return []
 
     # rename for delay load
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
@@ -2125,7 +2120,14 @@ class HunyuanImage3Model(nn.Module):
 
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
-        expert_params_mapping, expert_weights_remapping = self.get_expert_mapping()
+        # get_expert_mapping() must stay vLLM-compatible (flat list of
+        # (param, weight, expert_id, shard_id) tuples), so the fused
+        # gate/up weight remapping used only by this loader is kept local.
+        expert_params_mapping = self.get_expert_mapping()
+        expert_weights_remapping = {
+            "gate_proj": ("gate_and_up_proj", 1, 2),
+            "up_proj": ("gate_and_up_proj", 0, 2),
+        }
 
         # List of unexpected keywords in weight names
         unexpected_keywords = [

--- a/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
+++ b/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
@@ -128,11 +128,11 @@ class HunyuanModel(HunYuanModel):
         v = v.reshape(-1, hidden_size)
         return torch.concat((q, k, v))
 
-    def get_expert_mapping(self) -> tuple[list[tuple[str, str, int, str]], dict[str, tuple[str, int, int]]]:
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         if _is_moe(self.config):
             # Params for weights, fp8 weight scales, fp8 activation scales
             # (param_name, weight_name, expert_id, shard_id)
-            fused_moe_expert_mapping = fused_moe_make_expert_params_mapping(
+            return fused_moe_make_expert_params_mapping(
                 model=self,
                 ckpt_gate_proj_name="gate_proj",
                 ckpt_down_proj_name="down_proj",
@@ -140,13 +140,8 @@ class HunyuanModel(HunYuanModel):
                 num_experts=self.config.num_experts,
                 num_redundant_experts=self.num_redundant_experts,
             )
-            expert_weights_remapping = {
-                "gate_proj": ("gate_and_up_proj", 1, 2),
-                "up_proj": ("gate_and_up_proj", 0, 2),
-            }
-            return fused_moe_expert_mapping, expert_weights_remapping
         else:
-            return [], {}
+            return []
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         cla_factor = _get_cla_factor(self.config)
@@ -174,7 +169,14 @@ class HunyuanModel(HunYuanModel):
 
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
-        expert_params_mapping, expert_weights_remapping = self.get_expert_mapping()
+        # get_expert_mapping() must stay vLLM-compatible (flat list of
+        # (param, weight, expert_id, shard_id) tuples), so the fused
+        # gate/up weight remapping used only by this loader is kept local.
+        expert_params_mapping = self.get_expert_mapping()
+        expert_weights_remapping = {
+            "gate_proj": ("gate_and_up_proj", 1, 2),
+            "up_proj": ("gate_and_up_proj", 0, 2),
+        }
 
         # List of unexpected keywords in weight names
         unexpected_keywords = [


### PR DESCRIPTION
Closes #6770

### Problem
`HunyuanModel.get_expert_mapping()` (and the diffusion-side `HunyuanImage3Model`) returned a 2-tuple `(mapping, weights_remapping)` instead of the flat list of `(param, weight, expert_id, shard_id)` tuples that vLLM consumers expect.

vLLM’s LoRA path calls `get_moe_expert_mapping()` and unpacks each entry with:
```python
for _, weight_name, _, _ in get_moe_expert_mapping(model)
```
so loading any MoE LoRA adapter for HunyuanImage-3 fails with:
```text
ValueError: not enough values to unpack (expected 4, got 2)
```

### Fix
- `get_expert_mapping()` now returns only the flat vLLM-compatible mapping (same contract as `vllm.model_executor.utils.get_moe_expert_mapping`).
- The fused `gate_and_up_proj` weight remapping, which is only used by this loader, moved into `load_weights()` where it is consumed.
- Mirrored the same change on the diffusion path (`hunyuan_image3_transformer.py`) so both AR and diffusion loaders stay consistent.
- Updated the fake model in `test_kv_cache_scale_mapper.py` to the new return type.

### Verification
- `pytest tests/model_executor/models/test_kv_cache_scale_mapper.py` passes (8 passed).
- Locally confirmed the old 2-tuple raises the same `ValueError` the LoRA consumer hits, and the new flat list unpacks cleanly.