### PR TITLE
[Bugfix] Fix create_error_response import across vLLM versions

### DIFF
--- a/vllm_omni/config/endpoint_policy.py
+++ b/vllm_omni/config/endpoint_policy.py
@@ -8,7 +8,14 @@ from typing import NamedTuple
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
-from vllm.entrypoints.serve import create_error_response
+
+# vLLM < 0.28 keeps create_error_response under serve.utils (it is not
+# re-exported from vllm.entrypoints.serve); 0.28+ moved it under
+# serve.exception_handling and re-exports it from the package root.
+try:
+    from vllm.entrypoints.serve import create_error_response
+except ImportError:
+    from vllm.entrypoints.serve.utils.error_response import create_error_response
 
 
 class RouteTarget(NamedTuple):

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -64,7 +64,14 @@ from vllm.entrypoints.pooling.embed.serving import ServingEmbedding as OpenAISer
 from vllm.entrypoints.pooling.pooling.serving import ServingPooling
 from vllm.entrypoints.pooling.scoring.serving import ServingScores
 from vllm.entrypoints.scale_out.token_in_token_out.serving import ServingTokens
-from vllm.entrypoints.serve import create_error_response
+
+# vLLM < 0.28 keeps create_error_response under serve.utils (it is not
+# re-exported from vllm.entrypoints.serve); 0.28+ moved it under
+# serve.exception_handling and re-exports it from the package root.
+try:
+    from vllm.entrypoints.serve import create_error_response
+except ImportError:
+    from vllm.entrypoints.serve.utils.error_response import create_error_response
 
 # vLLM moved `base` from openai.basic.api_router to serve.instrumentator.basic.
 # Keep a fallback for older/newer upstream layouts during rebase windows.


### PR DESCRIPTION
Closes #6705, Closes #6746

### Problem
Both `vllm_omni/config/endpoint_policy.py` and `vllm_omni/entrypoints/openai/api_server.py` import `create_error_response` from `vllm.entrypoints.serve`. That re-export only exists on vLLM 0.28+; on 0.26/0.27 the symbol lives under `vllm.entrypoints.serve.utils.error_response` and is not re-exported from the package root.

Consequences:
- NPU nightly fails systemically before any test runs (pytest cannot import the shared `tests.helpers.fixtures.clean` plugin because `endpoint_policy` fails at import).
- Users serving models with vllm-ascend 0.26.0 (e.g. MiniMax-H3) hit the same `cannot import name create_error_response from vllm.entrypoints.serve` error on startup.

### Fix
Keep the 0.28+ import as the primary path and fall back to the pre-0.28 location when the package root does not re-export the symbol:

```python
try:
    from vllm.entrypoints.serve import create_error_response
except ImportError:
    from vllm.entrypoints.serve.utils.error_response import create_error_response
```

### Verification
- `import vllm_omni.config.endpoint_policy` succeeds on vLLM 0.28 (primary path).
- Simulated the vLLM < 0.28 layout (removed the package-root export, provided `serve.utils.error_response`); the fallback import resolves correctly.
- `tests/config/test_config_factory.py` passes (330 tests in the config suite pass; the 4 `test_endpoint_policy` failures are a local torchaudio CPU-ABI issue unrelated to this change).