### PR TITLE
[Bugfix][Diffusion] Fix HunyuanImage-3 DiT LoRA namespace lookup and fused QKV layout

### DIFF
--- a/tests/diffusion/lora/test_lora_manager.py
+++ b/tests/diffusion/lora/test_lora_manager.py
@@ -482,6 +482,141 @@ def test_lora_manager_warns_when_all_adapters_pinned(monkeypatch):
     assert set(manager.list_adapters()) == {1, 2}
 
 
+def _make_hunyuan_image3_pipeline(num_heads=4, num_kv_heads=2, head_dim=2, hidden_size=8):
+    """Minimal stand-in for HunyuanImage3Pipeline exposing its LoRA hooks."""
+
+    def _split_qkv_ref(qkv):
+        groups = num_heads // num_kv_heads
+        hidden = qkv.shape[1]
+        b = qkv.reshape(num_kv_heads, groups + 2, head_dim, hidden)
+        q, k, v = torch.split(b, (groups, 1, 1), dim=1)
+        return torch.concat((q.reshape(-1, hidden), k.reshape(-1, hidden), v.reshape(-1, hidden)))
+
+    class _Transformer:
+        config = SimpleNamespace(
+            num_attention_heads=num_heads,
+            num_key_value_heads=num_kv_heads,
+            attention_head_dim=head_dim,
+            hidden_size=hidden_size,
+        )
+        _split_qkv_weight = staticmethod(_split_qkv_ref)
+
+    class _HunyuanImage3Pipeline(torch.nn.Module):
+        transformer = _Transformer()
+
+        @staticmethod
+        def _lora_module_name_aliases(full_module_name):
+            if full_module_name.startswith("transformer."):
+                return ["model." + full_module_name[len("transformer."):]]
+            return []
+
+        @staticmethod
+        def _split_fused_qkv_lora_b(lora_b):
+            expected_rows = (num_heads + 2 * num_kv_heads) * head_dim
+            if lora_b.shape[0] != expected_rows:
+                return None
+            qkv_block = _split_qkv_ref(lora_b)
+            q_size = num_heads * head_dim
+            kv_size = num_kv_heads * head_dim
+            return [
+                qkv_block[:q_size],
+                qkv_block[q_size:q_size + kv_size],
+                qkv_block[q_size + kv_size:],
+            ]
+
+    return _HunyuanImage3Pipeline()
+
+
+def test_lora_manager_activates_hunyuan_image3_fused_qkv_lora():
+    manager = DiffusionLoRAManager(
+        pipeline=_make_hunyuan_image3_pipeline(),
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+        max_cached_adapters=1,
+    )
+
+    # HI3 DiT wrappers register under transformer.layers.* but the PEFT adapter
+    # stores tensors under model.layers.* (the HF model namespace).
+    wrapper = "transformer.layers.0.self_attn.qkv_proj"
+    packed_layer = _DummyLoRALayer(n_slices=3, output_slices=(8, 4, 4))
+    manager._lora_modules = {wrapper: packed_layer}
+
+    rank = 3
+    # GQA-interleaved fused QKV rows: [Q-group0, K0, V0, Q-group1, K1, V1].
+    interleaved = torch.arange(16, dtype=torch.bfloat16).unsqueeze(1).repeat(1, rank)
+    lora = LoRALayerWeights(
+        module_name="model.layers.0.self_attn.qkv_proj",
+        rank=rank,
+        lora_alpha=rank,
+        lora_a=torch.ones((rank, 8)),
+        lora_b=interleaved,
+    )
+    manager._registered_adapters = {
+        11: type(
+            "LM",
+            (),
+            {
+                "id": 11,
+                "loras": {"model.layers.0.self_attn.qkv_proj": lora},
+                "get_lora": lambda self, k: self.loras.get(k),
+            },
+        )()
+    }
+
+    manager._activate_adapter(11, 0.5)
+
+    assert packed_layer.reset_calls == 0
+    assert len(packed_layer.set_calls) == 1
+    lora_a_list, lora_b_list = packed_layer.set_calls[0]
+    assert len(lora_a_list) == 3 and len(lora_b_list) == 3
+    # De-interleaved full [Q; K; V] slices, scaled by the lora scale.
+    expected_q = torch.cat([interleaved[0:4], interleaved[8:12]], dim=0) * 0.5
+    expected_k = torch.cat([interleaved[4:6], interleaved[12:14]], dim=0) * 0.5
+    expected_v = torch.cat([interleaved[6:8], interleaved[14:16]], dim=0) * 0.5
+    assert torch.equal(lora_b_list[0], expected_q)
+    assert torch.equal(lora_b_list[1], expected_k)
+    assert torch.equal(lora_b_list[2], expected_v)
+
+
+def test_lora_manager_rejects_hunyuan_image3_qkv_lora_with_unexpected_rows():
+    manager = DiffusionLoRAManager(
+        pipeline=_make_hunyuan_image3_pipeline(),
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+        max_cached_adapters=1,
+    )
+
+    wrapper = "transformer.layers.0.self_attn.qkv_proj"
+    packed_layer = _DummyLoRALayer(n_slices=3, output_slices=(8, 4, 4))
+    manager._lora_modules = {wrapper: packed_layer}
+
+    rank = 3
+    # Row count (12) does not match the HI3 QKV layout (16): fail closed.
+    lora = LoRALayerWeights(
+        module_name="model.layers.0.self_attn.qkv_proj",
+        rank=rank,
+        lora_alpha=rank,
+        lora_a=torch.ones((rank, 8)),
+        lora_b=torch.arange(12 * rank, dtype=torch.bfloat16).view(-1, rank),
+    )
+    manager._registered_adapters = {
+        12: type(
+            "LM",
+            (),
+            {
+                "id": 12,
+                "loras": {"model.layers.0.self_attn.qkv_proj": lora},
+                "get_lora": lambda self, k: self.loras.get(k),
+            },
+        )()
+    }
+
+    manager._activate_adapter(12, 0.5)
+
+    assert packed_layer.set_calls == []
+    assert packed_layer.reset_calls == 1
+
+
 def test_lora_manager_applies_multiple_scales_correctly(monkeypatch):
     """Ensure that the LoRA manager applies scales correctly when the
     active adapter receives a different scale, i.e., the rank is unchanged.

--- a/tests/diffusion/lora/test_lora_manager.py
+++ b/tests/diffusion/lora/test_lora_manager.py
@@ -507,7 +507,7 @@ def _make_hunyuan_image3_pipeline(num_heads=4, num_kv_heads=2, head_dim=2, hidde
         @staticmethod
         def _lora_module_name_aliases(full_module_name):
             if full_module_name.startswith("transformer."):
-                return ["model." + full_module_name[len("transformer."):]]
+                return ["model." + full_module_name[len("transformer.") :]]
             return []
 
         @staticmethod
@@ -520,8 +520,8 @@ def _make_hunyuan_image3_pipeline(num_heads=4, num_kv_heads=2, head_dim=2, hidde
             kv_size = num_kv_heads * head_dim
             return [
                 qkv_block[:q_size],
-                qkv_block[q_size:q_size + kv_size],
-                qkv_block[q_size + kv_size:],
+                qkv_block[q_size : q_size + kv_size],
+                qkv_block[q_size + kv_size :],
             ]
 
     return _HunyuanImage3Pipeline()

--- a/vllm_omni/diffusion/lora/manager.py
+++ b/vllm_omni/diffusion/lora/manager.py
@@ -538,7 +538,22 @@ class DiffusionLoRAManager:
             return lora_weights
 
         module_suffix = full_module_name.split(".")[-1]
-        return lora_model.get_lora(module_suffix)
+        lora_weights = lora_model.get_lora(module_suffix)
+        if lora_weights is not None:
+            return lora_weights
+
+        # Model-scoped namespace aliases. E.g. HI3 DiT wrappers are registered
+        # under transformer.layers.* while HI3 PEFT adapters store their LoRA
+        # tensors under model.layers.*. Pipelines opt in via
+        # ``_lora_module_name_aliases`` so other models are unaffected.
+        name_aliases = getattr(self.pipeline, "_lora_module_name_aliases", None)
+        if callable(name_aliases):
+            for alias in name_aliases(full_module_name):
+                lora_weights = lora_model.get_lora(alias)
+                if lora_weights is not None:
+                    return lora_weights
+
+        return None
 
     def _is_active_at_scale(self, adapter_id: int, scale: float) -> bool:
         """True if the adapter_id is active and the current scale matches."""
@@ -631,6 +646,31 @@ class DiffusionLoRAManager:
             # Fused (non-packed) weights: if the layer is multi-slice, split B.
             n_slices = getattr(lora_layer, "n_slices", 1)
             if n_slices > 1:
+                # HI3: a fused ``qkv_proj`` LoRA-B from PEFT is packed per KV
+                # head (GQA-interleaved). De-interleave into full [Q; K; V]
+                # slices first so deltas land on the correct output rows.
+                _, _, packed_suffix = full_module_name.rpartition(".")
+                split_fused_qkv = getattr(self.pipeline, "_split_fused_qkv_lora_b", None)
+                if packed_suffix == "qkv_proj" and callable(split_fused_qkv):
+                    full_slices = split_fused_qkv(lora_weights.lora_b)
+                    if full_slices is None:
+                        logger.warning(
+                            "Skipping LoRA for %s: cannot establish fused QKV layout",
+                            full_module_name,
+                        )
+                        lora_layer.reset_lora(0)
+                        continue
+                    lora_a_list = [lora_weights.lora_a] * len(full_slices)
+                    lora_b_list = [b * scale for b in full_slices]
+                    lora_layer.set_lora(index=0, lora_a=lora_a_list, lora_b=lora_b_list)
+                    _record_bound(lora_weights)
+                    logger.debug(
+                        "Activated fused QKV LoRA for %s (scale=%.2f)",
+                        full_module_name,
+                        scale,
+                    )
+                    continue
+
                 output_slices = getattr(lora_layer, "output_slices", None)
                 if output_slices is None:
                     lora_layer.reset_lora(0)

--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -417,7 +417,7 @@ class HunyuanImage3Pipeline(
         manager can resolve bindings to the adapter tensors.
         """
         if full_module_name.startswith("transformer."):
-            return ["model." + full_module_name[len("transformer."):]]
+            return ["model." + full_module_name[len("transformer.") :]]
         return []
 
     def _split_fused_qkv_lora_b(self, lora_b: torch.Tensor) -> list[torch.Tensor] | None:
@@ -454,8 +454,8 @@ class HunyuanImage3Pipeline(
         kv_size = num_kv_heads * attention_head_dim
         return [
             qkv_block[:q_size],
-            qkv_block[q_size:q_size + kv_size],
-            qkv_block[q_size + kv_size:],
+            qkv_block[q_size : q_size + kv_size],
+            qkv_block[q_size + kv_size :],
         ]
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:

--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -406,6 +406,58 @@ class HunyuanImage3Pipeline(
             enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler,
         )
 
+    def _lora_module_name_aliases(self, full_module_name: str) -> list[str]:
+        """Return model-scoped aliases for a registered DiT LoRA wrapper name.
+
+        HI3 DiT wrappers are discovered under the diffusers component name
+        ``transformer`` (``self.transformer is self.model``), so they register
+        as ``transformer.layers.<n>.self_attn.*``. HI3 PEFT adapters however
+        store their LoRA tensors under the HF model namespace
+        ``model.layers.<n>.self_attn.*``. Return the ``model.*`` alias so the
+        manager can resolve bindings to the adapter tensors.
+        """
+        if full_module_name.startswith("transformer."):
+            return ["model." + full_module_name[len("transformer."):]]
+        return []
+
+    def _split_fused_qkv_lora_b(self, lora_b: torch.Tensor) -> list[torch.Tensor] | None:
+        """De-interleave a fused ``qkv_proj`` LoRA-B into full [Q; K; V] slices.
+
+        HI3 checkpoints pack fused QKV rows per KV head
+        (``[Q-group, K, V] x num_key_value_heads``). The base-weight loader
+        (``HunyuanImage3Model._split_qkv_weight``) converts this GQA-interleaved
+        layout into the block layout ``[all Q; all K; all V]`` that
+        ``QKVParallelLinear`` expects. Apply the same conversion to a fused
+        ``qkv_proj`` LoRA-B tensor before it is installed into the packed QKV
+        LoRA layer.
+
+        Returns the three full (unsharded) Q/K/V slices, or ``None`` if the
+        tensor does not match the expected HI3 QKV row count (fail closed so a
+        mismatched adapter is never applied with wrong output rows).
+        """
+        config = self.transformer.config
+        num_attention_heads = config.num_attention_heads
+        num_kv_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
+        if hasattr(config, "head_dim"):
+            attention_head_dim = config.head_dim
+        elif hasattr(config, "attention_head_dim"):
+            attention_head_dim = config.attention_head_dim
+        else:
+            attention_head_dim = config.hidden_size // num_attention_heads
+
+        expected_rows = (num_attention_heads + 2 * num_kv_heads) * attention_head_dim
+        if lora_b.shape[0] != expected_rows:
+            return None
+
+        qkv_block = self.transformer._split_qkv_weight(lora_b)
+        q_size = num_attention_heads * attention_head_dim
+        kv_size = num_kv_heads * attention_head_dim
+        return [
+            qkv_block[:q_size],
+            qkv_block[q_size:q_size + kv_size],
+            qkv_block[q_size + kv_size:],
+        ]
+
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         skip_prefixes = ["lm_head."] if self.hf_config.tie_word_embeddings else []
         # List of unexpected keywords in weight names


### PR DESCRIPTION
## Why

HunyuanImage-3 DiT LoRA adapters could not be bound by the diffusion LoRA manager: the manager reported `resolved=0` for every layer, and when a fused `qkv_proj` LoRA-B was present it was applied to the wrong output rows. See #6411 for the full trace.

Two root causes:

1. **Namespace mismatch.** HI3 DiT wrappers are discovered under the diffusers component name `transformer` (`self.transformer is self.model`), so they register as `transformer.layers.<n>.self_attn.*`. HI3 PEFT adapters however store their LoRA tensors under the HF model namespace `model.layers.<n>.self_attn.*`. `_get_lora_weights` only tried the full name, the component-relative name, and the leaf suffix, so the lookup always missed (`model.layers.*` was never tried).

2. **Fused QKV layout mismatch.** HI3 checkpoints pack fused QKV rows per KV head (`[Q-group, K, V] x num_kv_heads`). The base-weight loader (`HunyuanImage3Model._split_qkv_weight`) converts this GQA-interleaved layout into the block layout `[all Q; all K; all V]` that `QKVParallelLinear` expects. A fused `qkv_proj` LoRA-B from PEFT was not converted, so the fused-split path divided the rows as if they were already block-packed, placing the deltas on the wrong output rows.

## What

- `DiffusionLoRAManager._get_lora_weights`: after the existing lookups, try model-scoped namespace aliases exposed by the pipeline (`_lora_module_name_aliases`).
- `DiffusionLoRAManager._bind_adapter_weights`: when binding a fused `qkv_proj` LoRA-B on a multi-slice layer, ask the pipeline to de-interleave it (`_split_fused_qkv_lora_b`) into full `[Q; K; V]` slices before installing them (per-rank slicing is then handled by `MergedQKVParallelLinearWithLoRA.set_lora`).
- `HunyuanImage3Pipeline`: add the two opt-in hooks. The de-interleave reuses `HunyuanImage3Model._split_qkv_weight` so the LoRA-B conversion is identical to the base-weight conversion.

## Scoping & safety

- Both hooks live on `HunyuanImage3Pipeline` only; other diffusion pipelines expose neither hook, so their behavior is unchanged.
- `_split_fused_qkv_lora_b` fails closed: if the fused LoRA-B row count does not match the expected HI3 QKV layout it returns `None` and the manager skips the layer (never applies a mismatched adapter).

## Validation

- Added `test_lora_manager_activates_hunyuan_image3_fused_qkv_lora` (alias resolution + de-interleaved full-slice install) and `test_lora_manager_rejects_hunyuan_image3_qkv_lora_with_unexpected_rows` (fail-closed) to `tests/diffusion/lora/test_lora_manager.py`.
- `tests/diffusion/lora/test_lora_manager.py`: 21 passed.
- `ruff check` on all touched files: clean.

Closes #6411
