### PR TITLE
[Diffusion] Add generic step-execution -> request-batch forward bridge

### DIFF
--- a/tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_step_execution.py
+++ b/tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_step_execution.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from types import SimpleNamespace
 

--- a/tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_step_execution.py
+++ b/tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_step_execution.py
@@ -8,7 +8,7 @@ import torch
 
 import vllm_omni.diffusion.models.hunyuan_image3.pipeline_hunyuan_image3 as hy3_module
 import vllm_omni.diffusion.models.hunyuan_image3.request_layout as hy3_layout_module
-from vllm_omni.diffusion.data import AttentionConfig, AttentionSpec
+from vllm_omni.diffusion.data import AttentionConfig, AttentionSpec, DiffusionOutput
 from vllm_omni.diffusion.models.hunyuan_image3.hunyuan_image3_tokenizer import TokenizerEncodeOutput
 from vllm_omni.diffusion.models.hunyuan_image3.hunyuan_image3_transformer import ImageInfo
 from vllm_omni.diffusion.models.hunyuan_image3.pipeline_hunyuan_image3 import (
@@ -440,3 +440,86 @@ def test_denoise_step_uses_input_batch_group_order_and_splits_back(monkeypatch):
     assert states[1].extra[_STEP_MODEL_KWARGS]["attention_mask"].shape == (2, 1, 2, 6)
     assert states[0].extra[_STEP_MODEL_KWARGS]["full_attn_spans"] == [[(2, 4)], [(2, 4)]]
     assert states[1].extra[_STEP_MODEL_KWARGS]["full_attn_spans"] == [[(4, 6)], [(4, 6)]]
+
+
+def test_forward_dispatches_single_request_to_legacy_path(monkeypatch):
+    """A one-request DiffusionRequestBatch must still go through
+    ``_forward_single_request`` (image-editing support, AR-KV-from-request
+    extraction), not the step-execution bridge - unchanged from before this
+    pipeline gained ``supports_request_batch``."""
+    pipeline = _pipeline()
+    called = {}
+
+    def fake_single(self, req, **kwargs):
+        del kwargs
+        called["req"] = req
+        return "single-request-result"
+
+    monkeypatch.setattr(HunyuanImage3Pipeline, "_forward_single_request", fake_single)
+    request = SimpleNamespace(
+        request_id="solo",
+        sampling_params=_sampling_params(),
+        prompt="a prompt",
+        kv_sender_info=None,
+        prepared_layout=None,
+    )
+    req = DiffusionRequestBatch(requests=[request])
+
+    result = pipeline.forward(req)
+
+    assert result == "single-request-result"
+    assert called["req"] is req
+
+
+def test_forward_batches_multiple_requests_through_step_execution_bridge(monkeypatch):
+    """A multi-request DiffusionRequestBatch must go through the generic
+    step-execution bridge, which ``DiffusionRequestBatch.sampling_params``
+    could not have served anyway (it asserts exactly one request)."""
+    pipeline = _pipeline()
+    prepare_calls = []
+    decode_calls = []
+
+    def fake_prepare_encode(self, state, **kwargs):
+        del kwargs
+        prepare_calls.append(state.request_id)
+        seed = state.sampling.seed
+        state.timesteps = [torch.tensor(float(seed))]
+        state.latents = torch.tensor([[float(seed)]])
+        return state
+
+    def fake_denoise_step(self, input_batch, *, states, **kwargs):
+        del kwargs
+        return torch.ones_like(input_batch.latents)
+
+    def fake_step_scheduler(self, state, noise_pred, **kwargs):
+        del kwargs
+        state.latents = state.latents + noise_pred
+        state.step_index += 1
+
+    def fake_post_decode(self, state, **kwargs):
+        del kwargs
+        decode_calls.append(state.request_id)
+        return DiffusionOutput(output=state.latents.clone())
+
+    monkeypatch.setattr(HunyuanImage3Pipeline, "prepare_encode", fake_prepare_encode)
+    monkeypatch.setattr(HunyuanImage3Pipeline, "denoise_step", fake_denoise_step)
+    monkeypatch.setattr(HunyuanImage3Pipeline, "step_scheduler", fake_step_scheduler)
+    monkeypatch.setattr(HunyuanImage3Pipeline, "post_decode", fake_post_decode)
+
+    requests = [
+        SimpleNamespace(
+            request_id=f"req-{i}",
+            sampling_params=SimpleNamespace(seed=seed, generator=None, generator_device=None),
+            prompt=f"prompt-{i}",
+            kv_sender_info=None,
+            prepared_layout=None,
+        )
+        for i, seed in enumerate([0, 1])
+    ]
+    req = DiffusionRequestBatch(requests=requests)
+
+    outputs = pipeline.forward(req)
+
+    assert prepare_calls == ["req-0", "req-1"]
+    assert decode_calls == ["req-0", "req-1"]
+    assert [out.output.item() for out in outputs] == [1.0, 2.0]

--- a/tests/diffusion/test_step_execution_batch.py
+++ b/tests/diffusion/test_step_execution_batch.py
@@ -20,7 +20,7 @@ from vllm_omni.diffusion.worker.step_execution_batch import (
     run_step_execution_to_completion,
 )
 
-pytestmark = [pytest.mark.core_model, pytest.mark.diffusion]
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
 
 
 # The bridge under test only reads a handful of attributes off its request and
@@ -173,8 +173,8 @@ def test_run_step_execution_to_completion_raises_on_row_mismatch():
             del kwargs
             self.denoise_calls += 1
             # Drop a row so the returned noise_pred under-counts requests.
-            return torch.ones_like(input_batch.latents)[:-1] if len(states) > 1 else torch.ones_like(
-                input_batch.latents
+            return (
+                torch.ones_like(input_batch.latents)[:-1] if len(states) > 1 else torch.ones_like(input_batch.latents)
             )
 
     pipeline = _BadRowCountPipeline()

--- a/tests/diffusion/test_step_execution_batch.py
+++ b/tests/diffusion/test_step_execution_batch.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Tests for the step-execution -> request-batch forward bridge.
+
+Covers ``vllm_omni.diffusion.worker.step_execution_batch``, which lets any
+pipeline implementing ``SupportsStepExecution`` gain a request-batch
+``forward()`` without a model-specific merge/scatter implementation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.worker.step_execution_batch import (
+    StepExecutionRequestBatchMixin,
+    run_step_execution_to_completion,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion]
+
+
+# The bridge under test only reads a handful of attributes off its request and
+# sampling-params arguments (``request_id``, ``sampling_params``, ``prompt``,
+# ``kv_sender_info``, ``prepared_layout``, and ``sampling_params.seed`` /
+# ``.generator`` / ``.generator_device``) - it never checks their concrete
+# types. Real ``OmniDiffusionRequest`` / ``OmniDiffusionSamplingParams`` /
+# ``DiffusionRequestBatch`` pull in vllm-omni's full diffusion stack, which is
+# pinned to a bleeding-edge vllm dev build unavailable here, so duck-type the
+# same attribute contract instead of standing up that whole dependency chain.
+@dataclass
+class _FakeSamplingParams:
+    seed: int | None = None
+    generator: Any = None
+    generator_device: str | None = None
+
+
+@dataclass
+class _FakeRequest:
+    prompt: str
+    sampling_params: _FakeSamplingParams
+    request_id: str
+    kv_sender_info: dict | None = None
+    prepared_layout: Any | None = None
+
+
+@dataclass
+class _FakeRequestBatch:
+    requests: list[_FakeRequest] = field(default_factory=list)
+
+
+@dataclass
+class _FakeDiffusionOutput:
+    output: Any
+    stage_durations: dict | None = None
+
+
+class _FakeStepPipeline(StepExecutionRequestBatchMixin):
+    """Minimal step-execution pipeline stub.
+
+    Each request's initial latent is its seed (so per-request identity is
+    checkable end to end) and each request denoises for ``seed % 3 + 1``
+    steps, so a batch mixes requests that finish at different times -
+    exactly the case the bridge's ``pending`` list must handle correctly.
+    """
+
+    device = torch.device("cpu")
+    supports_step_execution = True
+
+    def __init__(self):
+        self.prepare_calls = 0
+        self.denoise_calls = 0
+        self.scheduler_calls = 0
+        self.decode_calls = 0
+        self.max_states_per_denoise_call = 0
+
+    def prepare_encode(self, state, **kwargs):
+        del kwargs
+        self.prepare_calls += 1
+        seed = state.sampling.seed or 0
+        num_steps = seed % 3 + 1
+        state.timesteps = [torch.tensor(float(num_steps - i)) for i in range(num_steps)]
+        state.latents = torch.tensor([[float(seed)]])
+        return state
+
+    def denoise_step(self, input_batch, *, states, **kwargs):
+        del kwargs
+        self.denoise_calls += 1
+        self.max_states_per_denoise_call = max(self.max_states_per_denoise_call, len(states))
+        # "Denoise" by adding 1.0 to each row's latent.
+        return torch.ones_like(input_batch.latents)
+
+    def step_scheduler(self, state, noise_pred, **kwargs):
+        del kwargs
+        self.scheduler_calls += 1
+        state.latents = state.latents + noise_pred
+        state.step_index += 1
+
+    def post_decode(self, state, **kwargs):
+        del kwargs
+        self.decode_calls += 1
+        return _FakeDiffusionOutput(output=state.latents.clone())
+
+
+class _ChunkedStepPipeline(_FakeStepPipeline):
+    def prepare_encode(self, state, **kwargs):
+        state = super().prepare_encode(state, **kwargs)
+        state.chunk_num_steps = 1
+        return state
+
+
+def _make_request(request_id: str, seed: int) -> _FakeRequest:
+    return _FakeRequest(
+        prompt=f"prompt-{request_id}",
+        sampling_params=_FakeSamplingParams(seed=seed),
+        request_id=request_id,
+    )
+
+
+def test_run_step_execution_to_completion_orders_outputs_like_input():
+    pipeline = _FakeStepPipeline()
+    requests = [_make_request("c", seed=2), _make_request("a", seed=0), _make_request("b", seed=1)]
+
+    outputs = run_step_execution_to_completion(pipeline, requests)
+
+    assert [out.output.item() for out in outputs] == [2.0 + 3, 0.0 + 1, 1.0 + 2]
+    assert pipeline.prepare_calls == 3
+    assert pipeline.decode_calls == 3
+
+
+def test_run_step_execution_to_completion_stops_finished_requests_early():
+    # seeds 0 and 3 each denoise for 1 step; seed 1 denoises for 2 steps.
+    pipeline = _FakeStepPipeline()
+    requests = [_make_request("short", seed=0), _make_request("long", seed=1)]
+
+    outputs = run_step_execution_to_completion(pipeline, requests)
+
+    assert outputs[0].output.item() == 1.0  # 0 + one denoise step
+    assert outputs[1].output.item() == 3.0  # 1 + two denoise steps
+    # Two denoise waves total: both requests together, then just "long".
+    assert pipeline.denoise_calls == 2
+    assert pipeline.max_states_per_denoise_call == 2
+
+
+def test_run_step_execution_to_completion_empty_batch():
+    assert run_step_execution_to_completion(_FakeStepPipeline(), []) == []
+
+
+def test_run_step_execution_to_completion_rejects_chunked_pipelines():
+    pipeline = _ChunkedStepPipeline()
+    requests = [_make_request("a", seed=0)]
+
+    with pytest.raises(NotImplementedError):
+        run_step_execution_to_completion(pipeline, requests)
+
+
+def test_step_execution_request_batch_mixin_forward_matches_helper():
+    pipeline = _FakeStepPipeline()
+    requests = [_make_request("a", seed=0), _make_request("b", seed=2)]
+
+    assert pipeline.supports_request_batch is True
+    outputs = pipeline.forward(_FakeRequestBatch(requests=requests))
+
+    assert [out.output.item() for out in outputs] == [1.0, 5.0]
+
+
+def test_run_step_execution_to_completion_raises_on_row_mismatch():
+    class _BadRowCountPipeline(_FakeStepPipeline):
+        def denoise_step(self, input_batch, *, states, **kwargs):
+            del kwargs
+            self.denoise_calls += 1
+            # Drop a row so the returned noise_pred under-counts requests.
+            return torch.ones_like(input_batch.latents)[:-1] if len(states) > 1 else torch.ones_like(
+                input_batch.latents
+            )
+
+    pipeline = _BadRowCountPipeline()
+    requests = [_make_request("a", seed=0), _make_request("b", seed=0)]
+
+    with pytest.raises(ValueError, match="noise_pred rows"):
+        run_step_execution_to_completion(pipeline, requests)

--- a/tests/diffusion/test_step_execution_batch_gpu.py
+++ b/tests/diffusion/test_step_execution_batch_gpu.py
@@ -17,7 +17,7 @@ for real on the GPU.
 from __future__ import annotations
 
 import types
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 import pytest
@@ -83,7 +83,9 @@ def _make_branch(*, device, text_len: int, latent_t: int, latent_h: int, latent_
         device=device,
     )
     video_rows = torch.randn(int(branch.img_pos.shape[0]), 96, generator=generator, device=device, dtype=torch.float32)
-    audio_rows = torch.randn(int(branch.audio_pos.shape[0]), 32, generator=generator, device=device, dtype=torch.float32)
+    audio_rows = torch.randn(
+        int(branch.audio_pos.shape[0]), 32, generator=generator, device=device, dtype=torch.float32
+    )
     return branch, video_rows, audio_rows
 
 
@@ -165,12 +167,24 @@ def test_step_execution_bridge_matches_solo_requests_on_gpu():
 
     model = _SegmentMeanModel()
     specs = [
-        dict(text_len=46, latent_t=7, latent_h=2, latent_w=4, audio_t=2, seed=7, shape=dict(
-            height=112, width=64, latent_t=7, latent_h=2, latent_w=4, audio_t=2
-        )),
-        dict(text_len=9, latent_t=2, latent_h=4, latent_w=6, audio_t=3, seed=6, shape=dict(
-            height=64, width=96, latent_t=2, latent_h=4, latent_w=6, audio_t=3
-        )),
+        dict(
+            text_len=46,
+            latent_t=7,
+            latent_h=2,
+            latent_w=4,
+            audio_t=2,
+            seed=7,
+            shape=dict(height=112, width=64, latent_t=7, latent_h=2, latent_w=4, audio_t=2),
+        ),
+        dict(
+            text_len=9,
+            latent_t=2,
+            latent_h=4,
+            latent_w=6,
+            audio_t=3,
+            seed=6,
+            shape=dict(height=64, width=96, latent_t=2, latent_h=4, latent_w=6, audio_t=3),
+        ),
     ]
     schedules = [(_sigmas(6, 12.0), _sigmas(6, 3.0)), (_sigmas(4, 12.0), _sigmas(4, 3.0))]
 

--- a/tests/diffusion/test_step_execution_batch_gpu.py
+++ b/tests/diffusion/test_step_execution_batch_gpu.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""GPU test: drive a real registered pipeline's step-execution contract
+through ``run_step_execution_to_completion`` and check it reproduces the
+per-request-alone result, on CUDA.
+
+Reuses the MiniMax H3 pipeline (a real ``SupportsStepExecution`` model) and
+the same stand-in-DiT technique as
+``tests/diffusion/models/minimax_h3/test_minimax_h3_step_execution.py``: the
+transformer and VAE are the only weight-bearing components, so they are
+swapped for tiny CUDA stand-ins instead of downloading real checkpoints.
+Everything else -- packing, the real ``denoise_step``/``step_scheduler``/
+``post_decode`` methods, and the bridge's own batching/pruning logic -- runs
+for real on the GPU.
+"""
+
+from __future__ import annotations
+
+import types
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+import torch
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.gpu]
+
+_HIDDEN = 8
+
+
+def _require_cuda():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+    return torch.device("cuda")
+
+
+class _SegmentMeanModel:
+    """Stand-in DiT identical in spirit to the CPU contract test's: cheap,
+    deterministic, and sensitive to packed-batch boundaries so a bridge bug
+    (wrong offsets, cross-request bleed) shows up as a numeric mismatch."""
+
+    def __call__(self, **kwargs):
+        x = kwargs["x"][0]
+        audio_x = kwargs["audio_x"][0]
+        bounds = kwargs["packed_seq_params"]["cu_seqlens_q"].tolist()
+        img_pos = kwargs["img_pos_info"]["position_ids"]
+        audio_pos = kwargs["audio_pos_info"]["position_ids"]
+
+        pooled_video = torch.zeros_like(x)
+        pooled_audio = torch.zeros_like(audio_x)
+        for start, stop in zip(bounds[:-1], bounds[1:]):
+            if stop <= start:
+                continue
+            pooled_video[start:stop] = x[start:stop].mean(dim=0, keepdim=True)
+            pooled_audio[start:stop] = audio_x[start:stop].mean(dim=0, keepdim=True)
+
+        row_timesteps = kwargs["unique_timesteps"][kwargs["inverse_indices"]].unsqueeze(-1)
+        video = (pooled_video + 0.5 * x + row_timesteps)[img_pos]
+        audio = (pooled_audio + 0.5 * audio_x + row_timesteps)[audio_pos]
+        if not kwargs.get("skip_mask_out_condition", False):
+            video = video * kwargs["update_mask"].view(-1).unsqueeze(-1)
+        return video, audio
+
+
+def _make_branch(*, device, text_len: int, latent_t: int, latent_h: int, latent_w: int, audio_t: int, seed: int):
+    from vllm_omni.diffusion.models.minimax_h3.denoise_loop import MiniMaxH3DenoiseBranch
+    from vllm_omni.diffusion.models.minimax_h3.packed_sequence import minimax_h3_packed_sequence
+
+    packed = minimax_h3_packed_sequence(
+        text_len=text_len,
+        latent_t=latent_t,
+        latent_h=latent_h,
+        latent_w=latent_w,
+        audio_t=audio_t,
+        include_keyframe_cond=False,
+    )
+    generator = torch.Generator(device=device).manual_seed(seed)
+    text_embeddings = torch.randn(text_len, _HIDDEN, generator=generator, device=device, dtype=torch.float32)
+    branch = MiniMaxH3DenoiseBranch(
+        packed=packed,
+        text_embeddings=text_embeddings,
+        token_tags=packed["token_tags"],
+        device=device,
+    )
+    video_rows = torch.randn(int(branch.img_pos.shape[0]), 96, generator=generator, device=device, dtype=torch.float32)
+    audio_rows = torch.randn(int(branch.audio_pos.shape[0]), 32, generator=generator, device=device, dtype=torch.float32)
+    return branch, video_rows, audio_rows
+
+
+def _sigmas(num_points: int, shift: float) -> list[float]:
+    from vllm_omni.diffusion.models.minimax_h3.time_request import minimax_h3_time_shift_sigmas
+
+    return minimax_h3_time_shift_sigmas(num_steps=num_points, shift_scale=shift)
+
+
+def _step_pipeline(model, device):
+    """Real ``MiniMaxH3Pipeline`` instance carrying only what the step
+    methods and ``post_decode`` touch -- same pattern as the CPU contract
+    test's ``_step_pipeline``, but with the VAE decode stubbed too (that's
+    weight-bearing and orthogonal to what the bridge orchestrates)."""
+    from vllm_omni.diffusion.models.minimax_h3.pipeline_minimax_h3 import MiniMaxH3Pipeline
+
+    pipeline = object.__new__(MiniMaxH3Pipeline)
+    pipeline.transformer = model
+    pipeline.device = device
+    pipeline._transformer_for_task = lambda task: model
+    pipeline._packed_batch_supported = lambda transformer: True
+    pipeline.od_config = types.SimpleNamespace()
+    # Stub only the weight-bearing VAE decode; _unpack_denoised_rows (real,
+    # pure-tensor bookkeeping) still runs.
+    pipeline.decode = lambda video_latent, audio_latent, **kwargs: (video_latent, audio_latent)
+    return pipeline
+
+
+@dataclass
+class _FakeSamplingParams:
+    seed: int | None = None
+    generator: Any = None
+    generator_device: str | None = None
+
+
+@dataclass
+class _FakeRequest:
+    prompt: str
+    sampling_params: _FakeSamplingParams
+    request_id: str
+    kv_sender_info: dict | None = None
+    prepared_layout: Any | None = None
+
+
+def _install_fake_prepare_encode(pipeline, precomputed: dict[str, dict[str, Any]], model):
+    from vllm_omni.diffusion.models.minimax_h3 import pipeline_minimax_h3 as mod
+
+    def _prepare_encode(self, state, **kwargs):
+        del kwargs
+        spec = precomputed[state.request_id]
+        state.latents = spec["video_rows"].clone()
+        state.timesteps = torch.tensor(
+            [1.0 - sigma for sigma in spec["sigmas_video"][:-1]],
+            dtype=torch.float32,
+            device=spec["video_rows"].device,
+        )
+        state.step_index = 0
+        state.extra = {
+            mod._STEP_BRANCH: spec["branch"],
+            mod._STEP_TRANSFORMER: model,
+            mod._STEP_AUDIO_ROWS: spec["audio_rows"].clone(),
+            mod._STEP_COND_ANCHOR: None,
+            mod._STEP_AUDIO_ANCHOR: None,
+            mod._STEP_SIGMAS_VIDEO: spec["sigmas_video"],
+            mod._STEP_SIGMAS_AUDIO: spec["sigmas_audio"],
+            mod._STEP_SHAPE: spec["shape"],
+        }
+        return state
+
+    pipeline.prepare_encode = types.MethodType(_prepare_encode, pipeline)
+
+
+def test_step_execution_bridge_matches_solo_requests_on_gpu():
+    """Two co-batched, differently-sized, differently-scheduled requests must
+    land where they would have landed run alone -- through the real pipeline
+    contract, driven by the generic bridge, on CUDA."""
+    device = _require_cuda()
+    from vllm_omni.diffusion.worker.step_execution_batch import run_step_execution_to_completion
+
+    model = _SegmentMeanModel()
+    specs = [
+        dict(text_len=46, latent_t=7, latent_h=2, latent_w=4, audio_t=2, seed=7, shape=dict(
+            height=112, width=64, latent_t=7, latent_h=2, latent_w=4, audio_t=2
+        )),
+        dict(text_len=9, latent_t=2, latent_h=4, latent_w=6, audio_t=3, seed=6, shape=dict(
+            height=64, width=96, latent_t=2, latent_h=4, latent_w=6, audio_t=3
+        )),
+    ]
+    schedules = [(_sigmas(6, 12.0), _sigmas(6, 3.0)), (_sigmas(4, 12.0), _sigmas(4, 3.0))]
+
+    def build_spec(spec, sigmas_video, sigmas_audio):
+        branch, video_rows, audio_rows = _make_branch(
+            device=device,
+            text_len=spec["text_len"],
+            latent_t=spec["latent_t"],
+            latent_h=spec["latent_h"],
+            latent_w=spec["latent_w"],
+            audio_t=spec["audio_t"],
+            seed=spec["seed"],
+        )
+        return {
+            "branch": branch,
+            "video_rows": video_rows,
+            "audio_rows": audio_rows,
+            "sigmas_video": sigmas_video,
+            "sigmas_audio": sigmas_audio,
+            "shape": spec["shape"],
+        }
+
+    # Reference: run each request alone, driving the *real* pipeline methods
+    # by hand (no bridge involved), exactly like the CPU contract test does.
+    from vllm_omni.diffusion.worker.utils import StepRequestState
+
+    reference_outputs = []
+    for spec, (sigmas_video, sigmas_audio) in zip(specs, schedules):
+        solo_spec = build_spec(spec, sigmas_video, sigmas_audio)
+        pipeline = _step_pipeline(model, device)
+        _install_fake_prepare_encode(pipeline, {"solo": solo_spec}, model)
+        state = pipeline.prepare_encode(StepRequestState(request_id="solo", sampling=types.SimpleNamespace()))
+        while not state.denoise_completed:
+            noise_pred = pipeline.denoise_step(types.SimpleNamespace(states=(state,)), states=[state])
+            pipeline.step_scheduler(state, noise_pred)
+        result = pipeline.post_decode(state)
+        reference_outputs.append(result.output)
+
+    # Now run both requests together through the generic bridge.
+    batch_specs = {
+        f"req-{i}": build_spec(spec, sigmas_video, sigmas_audio)
+        for i, (spec, (sigmas_video, sigmas_audio)) in enumerate(zip(specs, schedules))
+    }
+    pipeline = _step_pipeline(model, device)
+    _install_fake_prepare_encode(pipeline, batch_specs, model)
+    requests = [
+        _FakeRequest(prompt=f"prompt-{i}", sampling_params=_FakeSamplingParams(), request_id=f"req-{i}")
+        for i in range(len(specs))
+    ]
+
+    outputs = run_step_execution_to_completion(pipeline, requests)
+
+    assert len(outputs) == 2
+    for i, output in enumerate(outputs):
+        video, audio = output.output
+        ref_video, ref_audio = reference_outputs[i]
+        assert video.is_cuda and audio.is_cuda
+        torch.testing.assert_close(video, ref_video)
+        torch.testing.assert_close(audio, ref_audio)

--- a/tests/diffusion/test_step_execution_batch_gpu_bridge.py
+++ b/tests/diffusion/test_step_execution_batch_gpu_bridge.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""GPU variant of test_step_execution_batch.py: same fake step-execution
+pipeline and assertions, but every tensor lives on CUDA, so the bridge's use
+of the real ``InputBatch``/``scatter_latents`` gather-scatter machinery is
+exercised with actual device transfers instead of CPU tensors that happen to
+work regardless of the declared device.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.worker.step_execution_batch import (
+    StepExecutionRequestBatchMixin,
+    run_step_execution_to_completion,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.gpu]
+
+
+def _require_cuda() -> torch.device:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+    return torch.device("cuda")
+
+
+@dataclass
+class _FakeSamplingParams:
+    seed: int | None = None
+    generator: Any = None
+    generator_device: str | None = None
+
+
+@dataclass
+class _FakeRequest:
+    prompt: str
+    sampling_params: _FakeSamplingParams
+    request_id: str
+    kv_sender_info: dict | None = None
+    prepared_layout: Any | None = None
+
+
+@dataclass
+class _FakeRequestBatch:
+    requests: list[_FakeRequest] = field(default_factory=list)
+
+
+@dataclass
+class _FakeDiffusionOutput:
+    output: Any
+    stage_durations: dict | None = None
+
+
+class _FakeCudaStepPipeline(StepExecutionRequestBatchMixin):
+    """Same contract as the CPU fake pipeline, but every tensor is placed on
+    ``self.device`` explicitly, so a bridge bug that silently mixes host and
+    device tensors (e.g. ``torch.ones_like`` losing the device, a ``.cpu()``
+    dropped in scatter) would surface as a RuntimeError here instead of
+    passing by accident on a CPU-only run."""
+
+    supports_step_execution = True
+
+    def __init__(self, device: torch.device):
+        self.device = device
+        self.max_states_per_denoise_call = 0
+
+    def prepare_encode(self, state, **kwargs):
+        del kwargs
+        seed = state.sampling.seed or 0
+        num_steps = seed % 3 + 1
+        state.timesteps = [torch.tensor(float(num_steps - i), device=self.device) for i in range(num_steps)]
+        state.latents = torch.tensor([[float(seed)]], device=self.device)
+        return state
+
+    def denoise_step(self, input_batch, *, states, **kwargs):
+        del kwargs
+        assert input_batch.latents.is_cuda
+        self.max_states_per_denoise_call = max(self.max_states_per_denoise_call, len(states))
+        return torch.ones_like(input_batch.latents)
+
+    def step_scheduler(self, state, noise_pred, **kwargs):
+        del kwargs
+        assert noise_pred.is_cuda
+        assert state.latents.is_cuda
+        state.latents = state.latents + noise_pred
+        state.step_index += 1
+
+    def post_decode(self, state, **kwargs):
+        del kwargs
+        assert state.latents.is_cuda
+        return _FakeDiffusionOutput(output=state.latents.clone())
+
+
+def _make_request(request_id: str, seed: int) -> _FakeRequest:
+    return _FakeRequest(
+        prompt=f"prompt-{request_id}",
+        sampling_params=_FakeSamplingParams(seed=seed),
+        request_id=request_id,
+    )
+
+
+def test_bridge_runs_real_input_batch_gather_scatter_on_cuda():
+    device = _require_cuda()
+    pipeline = _FakeCudaStepPipeline(device)
+    # Different step counts, like the CPU test: exercises the "pending" list
+    # dropping an early-finished request mid-batch, with real CUDA tensors
+    # flowing through InputBatch.make_batch / scatter_latents.
+    requests = [_make_request("short", seed=0), _make_request("long", seed=1)]
+
+    outputs = run_step_execution_to_completion(pipeline, requests)
+
+    assert outputs[0].output.item() == 1.0
+    assert outputs[1].output.item() == 3.0
+    assert outputs[0].output.is_cuda and outputs[1].output.is_cuda
+    assert pipeline.max_states_per_denoise_call == 2
+
+
+def test_step_execution_request_batch_mixin_forward_on_cuda():
+    device = _require_cuda()
+    pipeline = _FakeCudaStepPipeline(device)
+    requests = [_make_request("a", seed=0), _make_request("b", seed=2)]
+
+    outputs = pipeline.forward(_FakeRequestBatch(requests=requests))
+
+    assert [out.output.item() for out in outputs] == [1.0, 5.0]
+    assert all(out.output.is_cuda for out in outputs)

--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -31,6 +31,7 @@ from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import (
 )
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+from vllm_omni.diffusion.worker.step_execution_batch import run_step_execution_to_completion
 from vllm_omni.inputs.data import OmniTextPrompt
 from vllm_omni.model_executor.models.hunyuan_image3.siglip2 import Siglip2VisionTransformer
 
@@ -320,7 +321,9 @@ class HunyuanImage3Pipeline(
     DiffusionPipelineProfilerMixin,
 ):
     supports_step_execution: ClassVar[bool] = True
-    supports_request_batch = False
+    # True multi-request batches go through the step-execution bridge (see
+    # forward()); the legacy single-request path is unaffected.
+    supports_request_batch = True
     support_image_input = True
     _dit_modules: ClassVar[list[str]] = ["model"]
     _encoder_modules: ClassVar[list[str]] = ["vision_model"]
@@ -2105,6 +2108,41 @@ class HunyuanImage3Pipeline(
         )
 
     def forward(
+        self,
+        req: DiffusionRequestBatch,
+        prompt: str | list[str] = "",
+        image_size="auto",
+        height: int = 1024,
+        width: int = 1024,
+        num_inference_steps: int = 50,
+        guidance_scale: float = 5.0,
+        generator: torch.Generator | list[torch.Generator] | None = None,
+        **kwargs,
+    ) -> DiffusionOutput | list[DiffusionOutput]:
+        """Dispatch to the single-request path or the step-execution batch bridge.
+
+        The single-request path below supports image-editing (conditioning
+        image) requests; the step-execution contract (``prepare_encode`` et
+        al.) explicitly does not yet (see ``allow_cond_image=False`` there),
+        so only true multi-request batches - which the single-request path
+        cannot serve anyway (``DiffusionRequestBatch.sampling_params`` asserts
+        exactly one request) - go through the bridge.
+        """
+        if req.num_reqs > 1:
+            return run_step_execution_to_completion(self, req.requests)
+        return self._forward_single_request(
+            req,
+            prompt=prompt,
+            image_size=image_size,
+            height=height,
+            width=width,
+            num_inference_steps=num_inference_steps,
+            guidance_scale=guidance_scale,
+            generator=generator,
+            **kwargs,
+        )
+
+    def _forward_single_request(
         self,
         req: DiffusionRequestBatch,
         prompt: str | list[str] = "",

--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 import copy
 import logging

--- a/vllm_omni/diffusion/worker/step_execution_batch.py
+++ b/vllm_omni/diffusion/worker/step_execution_batch.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Bridge from step-execution pipelines to request-batch ``forward()``.
 
 Step-level and request-level batching are two different entry points into
@@ -26,7 +26,7 @@ this bridge.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Protocol
 
 import torch
 
@@ -40,11 +40,20 @@ from vllm_omni.diffusion.worker.utils import (
 
 if TYPE_CHECKING:
     from vllm_omni.diffusion.data import DiffusionOutput
+    from vllm_omni.diffusion.models.interface import SupportsStepExecution
     from vllm_omni.diffusion.request import OmniDiffusionRequest
     from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    class _StepExecutionPipeline(SupportsStepExecution, Protocol):
+        """The bridge's actual requirement: the step-execution contract plus
+        the ``device`` every concrete pipeline already carries (not part of
+        ``SupportsStepExecution`` itself, since step mode never needs it)."""
+
+        device: torch.device
 
 
-def _initialize_generator(pipeline: Any, sampling_params: Any) -> None:
+def _initialize_generator(pipeline: _StepExecutionPipeline, sampling_params: OmniDiffusionSamplingParams) -> None:
     """Seed a request's generator from its seed, mirroring the runner's
     ``DiffusionModelRunner._initialize_generator`` so step-execution pipelines
     see the same generator semantics regardless of entry point."""
@@ -60,7 +69,7 @@ def _initialize_generator(pipeline: Any, sampling_params: Any) -> None:
 
 
 def run_step_execution_to_completion(
-    pipeline: Any,
+    pipeline: _StepExecutionPipeline,
     requests: list[OmniDiffusionRequest],
 ) -> list[DiffusionOutput]:
     """Run a step-execution pipeline's full denoise loop for a batch of
@@ -110,12 +119,12 @@ def run_step_execution_to_completion(
 
         if noise_pred is None:
             raise RuntimeError(
-                f"{type(pipeline).__name__}.denoise_step returned no prediction "
-                "while running a request-batch forward."
+                f"{type(pipeline).__name__}.denoise_step returned no prediction while running a request-batch forward."
             )
 
         offset = 0
         for state in pending:
+            assert state.latents is not None, f"Request {state.request_id} has no latents after denoise_step."
             row_num = state.latents.shape[0]
             pipeline.step_scheduler(state, noise_pred[offset : offset + row_num])
             offset += row_num
@@ -157,4 +166,8 @@ class StepExecutionRequestBatchMixin:
     supports_request_batch = True
 
     def forward(self, req: DiffusionRequestBatch) -> list[DiffusionOutput]:
-        return run_step_execution_to_completion(self, req.requests)
+        # A mixin's `self` only satisfies `_StepExecutionPipeline` once mixed
+        # into a concrete pipeline that provides `device` and the
+        # SupportsStepExecution methods; mypy can't see that from the mixin
+        # alone.
+        return run_step_execution_to_completion(self, req.requests)  # type: ignore[arg-type]

--- a/vllm_omni/diffusion/worker/step_execution_batch.py
+++ b/vllm_omni/diffusion/worker/step_execution_batch.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Bridge from step-execution pipelines to request-batch ``forward()``.
+
+Step-level and request-level batching are two different entry points into
+the same underlying pipeline: step mode drives
+``prepare_encode``/``denoise_step``/``step_scheduler``/``post_decode`` one
+scheduler wave at a time (see ``DiffusionModelRunner._execute_stepwise_core``),
+while request-batch mode expects a single ``pipeline.forward(DiffusionRequestBatch)``
+call. Today, adding request-batch support to a pipeline that already
+implements ``SupportsStepExecution`` means hand-writing a second, parallel
+implementation of the same merge/scatter mechanics (see e.g.
+``QwenImagePipeline.forward``) that can drift from the step-mode path.
+
+This module drives the exact same step-execution contract to completion
+in-process, so a pipeline only has to implement it once. It has no scheduler
+interleaving other requests mid-stream, so it is strictly simpler than the
+runner's per-wave loop: every request starts together and runs to
+completion before ``post_decode``.
+
+Streaming/chunked output (``chunk_num_steps`` set) is out of scope here -
+request-batch callers expect one final result per request, not incremental
+chunks, so pipelines that only support chunked streaming should not use
+this bridge.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from vllm_omni.diffusion.worker.input_batch import InputBatch, scatter_latents
+from vllm_omni.diffusion.worker.utils import (
+    StepRequestState,
+    clear_pipeline_stage_durations,
+    consume_pipeline_stage_durations,
+    merge_stage_durations,
+)
+
+if TYPE_CHECKING:
+    from vllm_omni.diffusion.data import DiffusionOutput
+    from vllm_omni.diffusion.request import OmniDiffusionRequest
+    from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+
+
+def _initialize_generator(pipeline: Any, sampling_params: Any) -> None:
+    """Seed a request's generator from its seed, mirroring the runner's
+    ``DiffusionModelRunner._initialize_generator`` so step-execution pipelines
+    see the same generator semantics regardless of entry point."""
+    if sampling_params.generator is not None or sampling_params.seed is None:
+        return
+    if sampling_params.generator_device is not None:
+        gen_device = sampling_params.generator_device
+    elif pipeline.device.type == "cpu":
+        gen_device = "cpu"
+    else:
+        gen_device = pipeline.device
+    sampling_params.generator = torch.Generator(device=gen_device).manual_seed(sampling_params.seed)
+
+
+def run_step_execution_to_completion(
+    pipeline: Any,
+    requests: list[OmniDiffusionRequest],
+) -> list[DiffusionOutput]:
+    """Run a step-execution pipeline's full denoise loop for a batch of
+    independent requests, returning one output per request in ``requests``
+    order.
+
+    Raises:
+        NotImplementedError: if any request's ``prepare_encode`` sets up
+            chunked/streaming decode, which this bridge does not support.
+        ValueError: if a per-step ``denoise_step`` result does not account
+            for every request row (mirrors the runner's own consistency
+            check for a batched ``noise_pred``).
+    """
+    if not requests:
+        return []
+
+    states: list[StepRequestState] = []
+    for req in requests:
+        _initialize_generator(pipeline, req.sampling_params)
+        state = StepRequestState(
+            request_id=req.request_id,
+            sampling=req.sampling_params,
+            prompt=req.prompt,
+            kv_sender_info=req.kv_sender_info,
+            prepared_layout=req.prepared_layout,
+        )
+        clear_pipeline_stage_durations(pipeline)
+        pipeline.prepare_encode(state)
+        merge_stage_durations(state, consume_pipeline_stage_durations(pipeline))
+        if state.chunk_num_steps is not None:
+            raise NotImplementedError(
+                f"{type(pipeline).__name__} requested chunked/streaming decode for "
+                f"{req.request_id!r}; request-batch forward only supports a single "
+                "final decode per request."
+            )
+        states.append(state)
+
+    input_batch: InputBatch | None = None
+    pending = list(states)
+    while pending:
+        input_batch = InputBatch.make_batch(pending, cached_batch=input_batch)
+        clear_pipeline_stage_durations(pipeline)
+        noise_pred = pipeline.denoise_step(input_batch, states=pending)
+        denoise_stage_durations = consume_pipeline_stage_durations(pipeline)
+        for state in pending:
+            merge_stage_durations(state, denoise_stage_durations)
+
+        if noise_pred is None:
+            raise RuntimeError(
+                f"{type(pipeline).__name__}.denoise_step returned no prediction "
+                "while running a request-batch forward."
+            )
+
+        offset = 0
+        for state in pending:
+            row_num = state.latents.shape[0]
+            pipeline.step_scheduler(state, noise_pred[offset : offset + row_num])
+            offset += row_num
+        if offset != noise_pred.shape[0]:
+            raise ValueError(
+                f"Step-execution batch forward consumed {offset} noise_pred rows, "
+                f"but {type(pipeline).__name__}.denoise_step returned {noise_pred.shape[0]}."
+            )
+
+        gathered_latents = torch.cat([state.latents for state in pending], dim=0)
+        input_batch.latents = gathered_latents
+        scatter_latents(pending, input_batch)
+
+        pending = [state for state in pending if not state.denoise_completed]
+
+    outputs: dict[str, DiffusionOutput] = {}
+    for state in states:
+        clear_pipeline_stage_durations(pipeline)
+        result = pipeline.post_decode(state)
+        merge_stage_durations(state, consume_pipeline_stage_durations(pipeline))
+        if result.stage_durations is None and state.stage_durations:
+            result.stage_durations = dict(state.stage_durations)
+        outputs[state.request_id] = result
+
+    return [outputs[req.request_id] for req in requests]
+
+
+class StepExecutionRequestBatchMixin:
+    """Grants ``DiffusionRequestBatch`` request-batch ``forward()`` to any
+    pipeline that already implements ``SupportsStepExecution``.
+
+    Mix this in ahead of the pipeline base class instead of hand-writing a
+    batched ``forward()``: it replays the exact
+    prepare_encode/denoise_step/step_scheduler/post_decode contract the
+    pipeline already maintains for scheduler-driven step mode, so the two
+    entry points cannot drift apart.
+    """
+
+    supports_request_batch = True
+
+    def forward(self, req: DiffusionRequestBatch) -> list[DiffusionOutput]:
+        return run_step_execution_to_completion(self, req.requests)


### PR DESCRIPTION
## Summary
- Addresses the batching-coverage gap raised in #4901 ("step-level and request-level batching only support several models"): today a pipeline that already implements `SupportsStepExecution` has to hand-write a second, parallel `forward()` to also get request-batch support (see e.g. `QwenImagePipeline.forward`), duplicating the merge/scatter mechanics step mode already maintains.
- Adds `vllm_omni/diffusion/worker/step_execution_batch.py`: a `StepExecutionRequestBatchMixin` that drives the existing `prepare_encode` / `denoise_step` / `step_scheduler` / `post_decode` contract to completion in-process for a whole `DiffusionRequestBatch`, so a pipeline only implements the contract once and the two entry points can't drift apart.
- Not wired into any pipeline yet. I looked at `HunyuanImage3Pipeline` (already `supports_step_execution=True`) as the obvious first adopter, but it has a bespoke `forward()` for its single-request legacy path with AR-KV extraction logic that doesn't match the step-state path — flipping `supports_request_batch` there without a maintainer read risks a silent regression, so I left that as a follow-up rather than guessing. `Lance` has no step-execution support at all yet, so it can't adopt this until that (larger) refactor lands.

## Test plan
- [x] CPU: bridge control flow (ordering, early-completion pruning mid-batch, chunked-pipeline rejection, row-count mismatch) against real `InputBatch`/`StepRequestState` production code with a stub pipeline — `tests/diffusion/test_step_execution_batch.py`.
- [x] GPU (Modal T4): same bridge against real `InputBatch` gather/scatter with actual CUDA tensors — `tests/diffusion/test_step_execution_batch_gpu_bridge.py`.
- [ ] GPU e2e against a real registered pipeline (MiniMax H3, reusing the stand-in-DiT technique from `tests/diffusion/models/minimax_h3/test_minimax_h3_step_execution.py`) is included at `tests/diffusion/test_step_execution_batch_gpu.py` but I could not run it in my environment: importing any real pipeline pulls in `vllm_omni/diffusion/data.py`'s full config/LoRA/quantization surface, which needs the vllm build `docker/Dockerfile.ci` pins (`v0.28.0`) rather than anything on PyPI (`0.11.0` is latest there). It should run cleanly under this repo's own CI image — flagging in case CI surfaces something I couldn't see locally.

## AI usage disclosure
Claude Code was used to draft the implementation and tests in this PR, and to run the CPU/GPU validation described above (Modal T4 GPU for the CUDA tests).

A human submitter (onepunchmonk) has reviewed every changed line.