### PR TITLE
[Bugfix][NPU] Drain profiler schedule before stop to avoid mid-RECORD segfault

### DIFF
--- a/tests/profile/test_omni_torch_profiler.py
+++ b/tests/profile/test_omni_torch_profiler.py
@@ -36,6 +36,9 @@ class DummyProfilerConfig:
     torch_profiler_with_stack: bool = True
     torch_profiler_with_flops: bool = False
     torch_profiler_dump_cuda_time_total: bool = False
+    wait_iterations: int = 0
+    warmup_iterations: int = 0
+    active_iterations: int = 5
 
 
 class FakeEvent:
@@ -100,9 +103,13 @@ class FakeTorchProfiler:
         self.on_trace_ready = on_trace_ready
         self.exported_traces = []
         self.exported_stacks = []
+        self.step_calls = 0
 
     def start(self):
         self.started = True
+
+    def step(self):
+        self.step_calls += 1
 
     def stop(self):
         self.stopped = True
@@ -582,3 +589,96 @@ def test_event_list_to_rows_contains_expected_fields(wrapper):
     assert row["self_cuda_memory_usage_bytes"] == 1024
     assert "[[8, 16], [16, 32]]" == row["input_shapes"]
     assert row["stack"] == "f1\nf2"
+
+
+def test_schedule_disabled_by_default(wrapper):
+    assert wrapper._uses_schedule is False
+    assert wrapper._warmup_steps_remaining == 0
+    assert wrapper._build_schedule(lambda **kw: kw) is None
+
+
+def test_schedule_enabled_when_wait_or_warmup_configured(fake_config, fake_profiler_factory):
+    fake_config.warmup_iterations = 1
+    fake_config.wait_iterations = 1
+    fake_config.active_iterations = 2
+
+    wrapper = OmniTorchProfilerWrapper(
+        profiler_config=fake_config,
+        worker_name="worker0",
+        local_rank=0,
+        activities=["CPU", "CUDA"],
+    )
+
+    assert wrapper._uses_schedule is True
+    # start() consumes step 0, so wait + warmup - 1 warmup steps remain.
+    assert wrapper._warmup_steps_remaining == 1
+
+    built = wrapper._build_schedule(lambda **kw: kw)
+    assert built["wait"] == 1
+    assert built["warmup"] == 1
+    assert built["active"] == 2
+    assert built["repeat"] == 1
+
+
+def test_profiler_step_advances_schedule_and_tracks_warmup(fake_config, fake_profiler_factory):
+    fake_config.warmup_iterations = 1
+    fake_config.wait_iterations = 1
+    fake_config.active_iterations = 2
+
+    wrapper = OmniTorchProfilerWrapper(
+        profiler_config=fake_config,
+        worker_name="worker0",
+        local_rank=0,
+        activities=["CPU", "CUDA"],
+    )
+
+    # Warmup step is forwarded to the profiler but not counted as profiling.
+    assert wrapper._profiler_step() is False
+    assert wrapper.profiler.step_calls == 1
+    assert wrapper._warmup_steps_remaining == 0
+
+    # Remaining steps are active (RECORD) profiling steps.
+    assert wrapper._profiler_step() is True
+    assert wrapper.profiler.step_calls == 2
+
+
+def test_profiler_step_noop_without_schedule(wrapper):
+    assert wrapper._profiler_step() is True
+    assert wrapper.profiler.step_calls == 0
+
+
+def test_stop_drains_schedule_before_stopping(fake_config, fake_profiler_factory):
+    fake_config.warmup_iterations = 1
+    fake_config.wait_iterations = 1
+    fake_config.active_iterations = 2
+    fake_config.torch_profiler_with_memory = False
+
+    wrapper = OmniTorchProfilerWrapper(
+        profiler_config=fake_config,
+        worker_name="worker0",
+        local_rank=0,
+        activities=["CPU", "CUDA"],
+    )
+    wrapper.set_trace_filename("case_drain")
+
+    # Advance into the active capture window.
+    wrapper._start()
+    for _ in range(3):
+        wrapper._profiler_step()
+    step_before = wrapper.profiler.step_calls
+    assert step_before > 0
+
+    wrapper._stop()
+
+    # The schedule was drained (extra step() calls) before stop(), so trace
+    # export never runs while the profiler is mid-RECORD.
+    assert wrapper.profiler.step_calls > step_before
+    assert wrapper.profiler.stopped is True
+
+
+def test_stop_does_not_drain_without_schedule(wrapper):
+    wrapper.set_trace_filename("case_no_drain")
+    wrapper._stop()
+
+    assert wrapper.profiler.stopped is True
+    assert wrapper.profiler.step_calls == 0

--- a/vllm_omni/platforms/npu/profiler.py
+++ b/vllm_omni/platforms/npu/profiler.py
@@ -67,8 +67,22 @@ class NPUTorchProfilerWrapper(OmniTorchProfilerWrapper):
         os.makedirs(npu_trace_dir, exist_ok=True)
         self._trace_path = npu_trace_dir
 
+        # Schedule-based profiling (wait/warmup/active). torch_npu mirrors
+        # torch's schedule factory; if the installed version lacks it, fall
+        # back to always-recording profiling rather than breaking startup.
+        npu_schedule = None
+        try:
+            npu_schedule = self._build_schedule(torch_npu.profiler.schedule)
+        except Exception as e:
+            logger.warning(
+                "torch_npu schedule unavailable, schedule-based profiling disabled: %s",
+                e,
+            )
+            npu_schedule = None
+
         return torch_npu.profiler.profile(
             activities=npu_activities,
+            schedule=npu_schedule,
             with_stack=False,
             profile_memory=profiler_config.torch_profiler_with_memory,
             # NOTE: torch_npu.profiler.with_modules is equivalent to

--- a/vllm_omni/profiler/omni_torch_profiler.py
+++ b/vllm_omni/profiler/omni_torch_profiler.py
@@ -77,6 +77,24 @@ class OmniTorchProfilerWrapper(WorkerProfiler):
             )
 
         self.dump_cpu_time_total = "CPU" in activities and len(activities) == 1
+
+        # Schedule-based profiling (wait/warmup/active) mirrors vLLM's
+        # TorchProfilerWrapper. The schedule is advanced once per worker step
+        # via _profiler_step(), and _stop() drains any remaining RECORD steps
+        # before calling stop() so trace export never runs mid-capture.
+        self._uses_schedule = bool(
+            getattr(profiler_config, "warmup_iterations", 0)
+            or getattr(profiler_config, "wait_iterations", 0)
+        )
+        # Subtract 1 because start() already consumes step 0 (WAIT or WARMUP),
+        # so only wait + warmup - 1 non-active steps remain to advance through.
+        self._warmup_steps_remaining = max(
+            getattr(profiler_config, "wait_iterations", 0)
+            + getattr(profiler_config, "warmup_iterations", 0)
+            - 1,
+            0,
+        )
+
         self.profiler = self._create_profiler(profiler_config, activities)
 
     def _rank(self) -> int:
@@ -89,6 +107,27 @@ class OmniTorchProfilerWrapper(WorkerProfiler):
         """
         return ["CPU", "CUDA"]
 
+    def _build_schedule(self, schedule_fn: Any) -> Any | None:
+        """Build the profiler schedule for schedule-based profiling.
+
+        Returns ``None`` when schedule-based profiling is disabled (no wait or
+        warmup iterations configured), in which case the profiler records every
+        step and has no WAIT/WARMUP/RECORD state machine to advance.
+        """
+        cfg = self.profiler_config
+        if not (
+            getattr(cfg, "warmup_iterations", 0)
+            or getattr(cfg, "wait_iterations", 0)
+        ):
+            return None
+        return schedule_fn(
+            skip_first=0,
+            wait=getattr(cfg, "wait_iterations", 0),
+            warmup=getattr(cfg, "warmup_iterations", 0),
+            active=getattr(cfg, "active_iterations", 5),
+            repeat=1,
+        )
+
     def _create_profiler(
         self,
         profiler_config: ProfilerConfig,
@@ -100,6 +139,7 @@ class OmniTorchProfilerWrapper(WorkerProfiler):
         """
         return torch.profiler.profile(
             activities=[TorchProfilerActivityMap[a] for a in activities],
+            schedule=self._build_schedule(torch.profiler.schedule),
             record_shapes=profiler_config.torch_profiler_record_shapes,
             profile_memory=profiler_config.torch_profiler_with_memory,
             with_stack=profiler_config.torch_profiler_with_stack,
@@ -390,13 +430,65 @@ class OmniTorchProfilerWrapper(WorkerProfiler):
         self.profiler.start()
 
     @override
+    def _profiler_step(self) -> bool:
+        """Advance the profiler schedule once per worker step.
+
+        With schedule-based profiling the underlying profiler only moves
+        through WAIT/WARMUP/RECORD via ``step()`` calls, so forward the
+        schedule here. Warmup steps return False so only active (RECORD) steps
+        count toward the ``max_iterations`` auto-stop limit.
+        """
+        if self._uses_schedule:
+            self.profiler.step()
+            if self._warmup_steps_remaining > 0:
+                self._warmup_steps_remaining -= 1
+                return False
+        return True
+
+    @override
     def _stop(self) -> None:
-        """Stop profiler, export trace via on_trace_ready, and dump table."""
+        """Stop profiler, export trace via on_trace_ready, and dump table.
+
+        ``stop_profile`` is an out-of-band call that can arrive mid-RECORD.
+        Stopping a schedule-based profiler while it is still capturing
+        segfaults the NPU profiler (and yields incomplete traces elsewhere),
+        so first drain the schedule to IDLE so trace export always runs on a
+        consistent, non-capturing state.
+        """
+        self._drain_schedule()
         self.profiler.stop()
         try:
             self._on_stop_hook()
         finally:
             self._try_dump_memory_snapshot()
+
+    def _drain_schedule(self) -> None:
+        """Advance the profiler schedule out of the capture window before stop.
+
+        Each ``step()`` advances the state machine by one transition; a RECORD
+        window needs up to wait + warmup + active steps to fully drain to IDLE.
+        Draining more than the remaining steps is harmless because ``step()``
+        is a no-op once the schedule reaches IDLE. Profilers without a schedule
+        have no state machine to advance and are left untouched.
+        """
+        if not self._uses_schedule:
+            return
+        cfg = self.profiler_config
+        drain = (
+            int(getattr(cfg, "wait_iterations", 0) or 0)
+            + int(getattr(cfg, "warmup_iterations", 0) or 0)
+            + int(getattr(cfg, "active_iterations", 5) or 0)
+        )
+        for _ in range(max(drain, 1)):
+            try:
+                self.profiler.step()
+            except Exception as e:
+                logger.warning(
+                    "[Rank %s] Profiler schedule drain interrupted: %s",
+                    self._rank(),
+                    e,
+                )
+                break
 
     def _on_stop_hook(self) -> None:
         """Hook called after profiler.stop().

--- a/vllm_omni/profiler/omni_torch_profiler.py
+++ b/vllm_omni/profiler/omni_torch_profiler.py
@@ -83,15 +83,12 @@ class OmniTorchProfilerWrapper(WorkerProfiler):
         # via _profiler_step(), and _stop() drains any remaining RECORD steps
         # before calling stop() so trace export never runs mid-capture.
         self._uses_schedule = bool(
-            getattr(profiler_config, "warmup_iterations", 0)
-            or getattr(profiler_config, "wait_iterations", 0)
+            getattr(profiler_config, "warmup_iterations", 0) or getattr(profiler_config, "wait_iterations", 0)
         )
         # Subtract 1 because start() already consumes step 0 (WAIT or WARMUP),
         # so only wait + warmup - 1 non-active steps remain to advance through.
         self._warmup_steps_remaining = max(
-            getattr(profiler_config, "wait_iterations", 0)
-            + getattr(profiler_config, "warmup_iterations", 0)
-            - 1,
+            getattr(profiler_config, "wait_iterations", 0) + getattr(profiler_config, "warmup_iterations", 0) - 1,
             0,
         )
 
@@ -115,10 +112,7 @@ class OmniTorchProfilerWrapper(WorkerProfiler):
         step and has no WAIT/WARMUP/RECORD state machine to advance.
         """
         cfg = self.profiler_config
-        if not (
-            getattr(cfg, "warmup_iterations", 0)
-            or getattr(cfg, "wait_iterations", 0)
-        ):
+        if not (getattr(cfg, "warmup_iterations", 0) or getattr(cfg, "wait_iterations", 0)):
             return None
         return schedule_fn(
             skip_first=0,


### PR DESCRIPTION
## Why

`stop_profile` is an out-of-band API call and can arrive at **any** worker-step boundary. A schedule-based torch profiler only advances its state machine (WAIT -> WARMUP -> RECORD -> IDLE) via `profiler.step()`. When `OmniTorchProfilerWrapper._stop()` called `self.profiler.stop()` while the state machine was inside RECORD, the NPU profiler segfaulted during trace export, killing the Stage-0 EngineCore process and cascading into `EngineDeadError` + replica eviction (see #6620).

Two gaps made this possible:

1. **No schedule support.** Unlike vLLM's `TorchProfilerWrapper`, the omni wrapper never created a `wait/warmup/active` schedule, so it had no way to leave the capture window on a known boundary.
2. **No drain before stop.** `_stop()` called `profiler.stop()` directly, so a stop arriving mid-RECORD ran trace export on an inconsistent capturing state.

## What

- `OmniTorchProfilerWrapper` now builds a `wait/warmup/active` schedule from `ProfilerConfig` (mirroring `TorchProfilerWrapper`) and advances it once per worker step via a new `_profiler_step()` override, so the profiler leaves the capture window on a known boundary.
- `_stop()` first drains the schedule to IDLE (`wait + warmup + active` `step()` calls) before the underlying `profiler.stop()`, so trace export always runs on a consistent, non-capturing state. Draining past IDLE is a no-op and extra steps are harmless.
- `NPUTorchProfilerWrapper` passes the same schedule to `torch_npu.profiler`, with a fallback to always-recording profiling if the installed torch_npu lacks a schedule factory.
- Default behaviour (no `wait`/`warmup` configured) is unchanged: the profiler still records every step.

## Validation

- New unit tests cover schedule setup, per-step advancement (warmup steps not counted toward `max_iterations`), and the pre-stop drain; all 23 tests in `tests/profile/test_omni_torch_profiler.py` pass.
- Verified against the real `torch.profiler.schedule` state machine: stopping after a mid-RECORD drain (various wait/warmup/active combos) exports a valid trace without error.

Fixes #6620
