### PR TITLE
[Bugfix][Ascend NPU][Diffusion] Preserve native GQA in SDPA

### DIFF
--- a/tests/diffusion/attention/test_sdpa.py
+++ b/tests/diffusion/attention/test_sdpa.py
@@ -1,13 +1,38 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 import pytest
 import torch
 
 import vllm_omni.diffusion.attention.backends.sdpa as sdpa_backend
+from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.backends.sdpa import SDPAImpl
+from vllm_omni.diffusion.attention.backends.utils.attn_runtime_selector import can_sdpa_use_fused_gqa
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class _FakeNPUTensor:
+    device = torch.device("npu")
+    is_cuda = False
+
+
+def test_sdpa_native_gqa_is_available_on_npu():
+    query = key = value = _FakeNPUTensor()
+
+    assert can_sdpa_use_fused_gqa(query, key, value, None, False)
+
+
+def test_sdpa_rejects_invalid_gqa_head_ratio_before_native_dispatch(monkeypatch):
+    monkeypatch.setattr(sdpa_backend, "can_sdpa_use_fused_gqa", lambda *args: True)
+
+    impl = SDPAImpl(num_heads=3, num_kv_heads=2, head_size=8, softmax_scale=0.5)
+    with pytest.raises(ValueError, match="q_heads=3 and kv_heads=2"):
+        impl.forward_npu(
+            torch.randn(1, 3, 3, 8),
+            torch.randn(1, 3, 2, 8),
+            torch.randn(1, 3, 2, 8),
+        )
 
 
 def test_sdpa_expands_kv_when_native_gqa_kernel_is_unavailable(monkeypatch):
@@ -54,4 +79,55 @@ def test_sdpa_keeps_compressed_kv_when_native_gqa_kernel_is_available(monkeypatc
     assert query_shape == (1, 4, 3, 8)
     assert key_shape == value_shape == (1, 2, 3, 8)
     assert kwargs["enable_gqa"] is True
+    assert output.shape == (1, 3, 4, 8)
+
+
+def test_sdpa_native_gqa_matches_explicit_kv_expansion(monkeypatch):
+    torch.manual_seed(0)
+    query = torch.randn(2, 5, 4, 8)
+    key = torch.randn(2, 5, 2, 8)
+    value = torch.randn(2, 5, 2, 8)
+    metadata = AttentionMetadata(
+        attn_mask=torch.tensor([[True, True, True, False, False], [True, True, True, True, False]])
+    )
+    impl = SDPAImpl(num_heads=4, num_kv_heads=2, head_size=8, softmax_scale=0.5)
+
+    monkeypatch.setattr(sdpa_backend, "can_sdpa_use_fused_gqa", lambda *args: True)
+    native = impl.forward_cuda(query, key, value, metadata)
+
+    monkeypatch.setattr(sdpa_backend, "can_sdpa_use_fused_gqa", lambda *args: False)
+    expanded = impl.forward_cuda(query, key, value, metadata)
+
+    torch.testing.assert_close(native, expanded)
+
+
+def test_sdpa_npu_native_gqa_uses_full_qk_mask(monkeypatch):
+    calls = []
+
+    def fake_sdpa(query, key, value, **kwargs):
+        calls.append((query.shape, key.shape, value.shape, kwargs))
+        return query
+
+    monkeypatch.setattr(sdpa_backend, "can_sdpa_use_fused_gqa", lambda *args: True)
+    monkeypatch.setattr(torch.nn.functional, "scaled_dot_product_attention", fake_sdpa)
+
+    impl = SDPAImpl(num_heads=4, num_kv_heads=2, head_size=8, softmax_scale=0.5)
+    metadata = AttentionMetadata(attn_mask=torch.tensor([[True, True, True, False, False]]))
+    output = impl.forward_npu(
+        torch.randn(1, 3, 4, 8),
+        torch.randn(1, 5, 2, 8),
+        torch.randn(1, 5, 2, 8),
+        metadata,
+    )
+
+    query_shape, key_shape, value_shape, kwargs = calls[0]
+    assert query_shape == (1, 4, 3, 8)
+    assert key_shape == value_shape == (1, 2, 5, 8)
+    assert kwargs["enable_gqa"] is True
+    assert kwargs["attn_mask"].shape == (1, 1, 3, 5)
+    assert kwargs["attn_mask"].is_contiguous()
+    assert torch.equal(
+        kwargs["attn_mask"],
+        metadata.attn_mask[:, None, None, :].expand(1, 1, 3, 5),
+    )
     assert output.shape == (1, 3, 4, 8)

--- a/tests/platforms/npu/test_diffusion_sdpa_gqa.py
+++ b/tests/platforms/npu/test_diffusion_sdpa_gqa.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
+from vllm_omni.diffusion.attention.backends.sdpa import SDPAImpl
+from vllm_omni.platforms import current_omni_platform
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.npu]
+
+
+def _npu_available() -> bool:
+    try:
+        import torch_npu  # noqa: F401
+    except ImportError:
+        return False
+    return current_omni_platform.is_npu() and bool(hasattr(torch, "npu") and torch.npu.is_available())
+
+
+@pytest.mark.skipif(not _npu_available(), reason="requires an available Ascend NPU")
+def test_sdpa_npu_native_gqa_matches_explicit_kv_expansion() -> None:
+    torch.manual_seed(0)
+    device = torch.device("npu")
+    query = torch.randn(1, 5, 4, 8, device=device, dtype=torch.bfloat16)
+    key = torch.randn(1, 5, 2, 8, device=device, dtype=torch.bfloat16)
+    value = torch.randn_like(key)
+    mask = torch.tensor([[True, True, True, False, False]], device=device)
+    metadata = AttentionMetadata(attn_mask=mask)
+    impl = SDPAImpl(num_heads=4, num_kv_heads=2, head_size=8, softmax_scale=0.5)
+
+    actual = impl.forward_npu(query, key, value, metadata)
+
+    query_bnsd = query.permute(0, 2, 1, 3)
+    key_bnsd = key.permute(0, 2, 1, 3).repeat_interleave(2, dim=1)
+    value_bnsd = value.permute(0, 2, 1, 3).repeat_interleave(2, dim=1)
+    full_qk_mask = mask[:, None, None, :].expand(1, 1, 5, 5).contiguous()
+    expected = F.scaled_dot_product_attention(
+        query_bnsd,
+        key_bnsd,
+        value_bnsd,
+        attn_mask=full_qk_mask,
+        dropout_p=0.0,
+        is_causal=False,
+        scale=0.5,
+        enable_gqa=False,
+    ).permute(0, 2, 1, 3)
+
+    torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)

--- a/vllm_omni/diffusion/attention/backends/sdpa.py
+++ b/vllm_omni/diffusion/attention/backends/sdpa.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from typing import Literal
 
@@ -105,22 +105,20 @@ class SDPAImpl(AttentionImpl):
 
         enable_gqa = query.shape[2] != key.shape[2]
         query, key, value = (x.permute(0, 2, 1, 3) for x in (query, key, value))
+        if enable_gqa and query.shape[1] % key.shape[1] != 0:
+            raise ValueError(
+                "GQA requires query heads to be a multiple of KV heads, "
+                f"got q_heads={query.shape[1]} and kv_heads={key.shape[1]}."
+            )
         # Only the PyTorch SDPA backend needs this dispatch check. If SDPA
         # cannot select a fused GQA kernel for the runtime shape/mask, expand
         # K/V locally so it can use the better-supported equal-head path.
         if enable_gqa and not can_sdpa_use_fused_gqa(query, key, value, attention_mask, self.causal):
-            if query.shape[1] % key.shape[1] != 0:
-                raise ValueError(
-                    "GQA requires query heads to be a multiple of KV heads, "
-                    f"got q_heads={query.shape[1]} and kv_heads={key.shape[1]}."
-                )
             repeat_num = query.shape[1] // key.shape[1]
             key = key.repeat_interleave(repeat_num, dim=1)
             value = value.repeat_interleave(repeat_num, dim=1)
             enable_gqa = False
-            logger.debug(
-                "CUDA SDPA cannot use a fused native-GQA kernel for this shape; expanding K/V heads before SDPA."
-            )
+            logger.debug("SDPA cannot use a fused native-GQA kernel for this shape; expanding K/V heads before SDPA.")
         output = torch.nn.functional.scaled_dot_product_attention(
             query,
             key,

--- a/vllm_omni/diffusion/attention/backends/utils/attn_runtime_selector.py
+++ b/vllm_omni/diffusion/attention/backends/utils/attn_runtime_selector.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Runtime kernel-selection helpers for attention backends."""
 
 import torch
@@ -17,6 +17,12 @@ def can_sdpa_use_fused_gqa(
     This check is specific to the SDPA backend. Native GQA backends such as
     FlashAttention should keep compressed K/V heads and do not use this helper.
     """
+    if query.device.type == key.device.type == value.device.type == "npu":
+        # PyTorch 2.10 + torch-npu 2.10 dispatches enable_gqa=True to the
+        # native Ascend SDPA kernel. Keep K/V compressed instead of expanding
+        # them to the query-head count in Python.
+        return True
+
     if not query.is_cuda:
         return False
 


### PR DESCRIPTION
## Summary

Preserve compressed K/V heads for grouped-query attention in the diffusion SDPA backend on Ascend NPU.

PyTorch 2.10 with torch-npu 2.10 supports `scaled_dot_product_attention(..., enable_gqa=True)` natively. The current runtime selector only recognizes CUDA fused-GQA kernels, so NPU requests expand K/V to the query-head count before SDPA. That loses the native NPU path and materializes avoidable tensors for GQA models such as Boogu-Image.

Related to #6787 and #6665.

## Changes

- Treat NPU Q/K/V tensors as native-GQA capable in the shared SDPA runtime selector.
- Keep K/V compressed and pass `enable_gqa=True` to NPU SDPA.
- Validate the Q-head/KV-head ratio before either native or fallback dispatch.
- Keep explicit K/V expansion for runtimes where fused native GQA is unavailable.
- Cover native dispatch, fallback dispatch, invalid ratios, numerical equivalence with explicit expansion, and the NPU full-QK mask contract.

## Validation

Public checks are green: build (3.11), build (3.12), pre-commit, DCO, and Read the Docs.

CPU focused coverage passes. A real NPU probe on `Ascend910_9382` (PyTorch 2.10.0 + torch-npu 2.10.0.post2) used Boogu's shape `batch=1, seq=512, q_heads=28, kv_heads=7, head_dim=120` and a full-QK boolean mask:

```text
max_abs_error = 0.0
mean_abs_error = 0.0
native mean = 0.279 ms (20 iterations)
explicit expansion mean = 0.308 ms (20 iterations)
K/V materialization avoided = 4.92 MiB per call
```

The same native-GQA path is exercised by the four real-weight Boogu services in #6787; Base, Turbo, Edit, and Edit-Turbo all returned HTTP 200 images.

The regular pytest process prints `1 passed` before a known torch-npu allocator finalizer abort. The numeric result above comes from a synchronized standalone probe that exits cleanly after the assertion. This is an environment finalizer issue, not a failed GQA assertion.

The change remains runtime-gated to NPU SDPA and retains explicit K/V expansion for unsupported runtimes. Ready for review.
