### PR TITLE
[Model] Add quant-aware Boogu-Image construction

### DIFF
--- a/tests/diffusion/models/boogu_image/test_boogu_image_transformer.py
+++ b/tests/diffusion/models/boogu_image/test_boogu_image_transformer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 import logging
 import os
@@ -286,29 +286,58 @@ def test_transformer_rejects_prompt_tuning():
         BooguImageTransformer2DModel(od_config=_tiny_od_config(prompt_tuning_configs={"use_prompt_tuning": True}))
 
 
-def _native_to_checkpoint_name(name: str) -> str:
-    """Inverse of ``load_weights`` remapping: native param name -> diffusers name.
+_QKV_FANOUT = {
+    "to_qkv": ("to_q", "to_k", "to_v"),
+    "img_to_qkv": ("img_to_q", "img_to_k", "img_to_v"),
+    "instruct_to_qkv": ("instruct_to_q", "instruct_to_k", "instruct_to_v"),
+}
+
+
+def _native_to_checkpoint_weights(name: str, param: torch.Tensor) -> list[tuple[str, torch.Tensor]]:
+    """Inverse of ``load_weights`` remapping: native param -> diffusers weights.
+
+    The diffusers checkpoint stores fused projections as separate matrices, so a
+    single merged native param (QKV or FFN gate/up) fans out into several
+    checkpoint weights. Returns ``(diffusers_name, value)`` pairs whose values,
+    when fed through ``load_weights``, reassemble into the original ``param``.
 
     - ``.to_out.<suffix>`` -> ``.to_out.0.<suffix>`` (diffusers ModuleList wrap).
     - promoted joint-attention projections move back under ``.processor.``.
     """
+    q_size = NUM_HEADS * HEAD_DIM
+    kv_size = NUM_KV_HEADS * HEAD_DIM
+
+    # Fused QKV projections split back into per-matrix q/k/v weights.
+    for token, (q_name, k_name, v_name) in _QKV_FANOUT.items():
+        marker = f".{token}."
+        if marker in name:
+            q, k, v = param[:q_size], param[q_size : q_size + kv_size], param[q_size + kv_size :]
+            results = []
+            for sub_name, value in ((q_name, q), (k_name, k), (v_name, v)):
+                ckpt_name = name.replace(marker, f".{sub_name}.")
+                if token != "to_qkv":
+                    # Joint-attention projections live under `.processor.` upstream.
+                    ckpt_name = ckpt_name.replace(".img_instruct_attn.", ".img_instruct_attn.processor.")
+                results.append((ckpt_name, value))
+            return results
+
+    # Fused FFN gate/up splits into linear_1 (gate) / linear_3 (input).
+    if ".gate_up_proj." in name:
+        inner = param.shape[0] // 2
+        return [
+            (name.replace(".gate_up_proj.", ".linear_1."), param[:inner]),
+            (name.replace(".gate_up_proj.", ".linear_3."), param[inner:]),
+        ]
+
+    # Default: 1:1 with the existing diffusers name promotions.
     if ".to_out." in name:
         name = name.replace(".to_out.", ".to_out.0.")
-    for proj in (
-        "img_to_q",
-        "img_to_k",
-        "img_to_v",
-        "instruct_to_q",
-        "instruct_to_k",
-        "instruct_to_v",
-        "instruct_out",
-        "img_out",
-    ):
+    for proj in ("instruct_out", "img_out"):
         token = f".img_instruct_attn.{proj}."
         if token in name:
             name = name.replace(token, f".img_instruct_attn.processor.{proj}.")
             break
-    return name
+    return [(name, param)]
 
 
 def test_transformer_load_weights_round_trip():
@@ -319,24 +348,29 @@ def test_transformer_load_weights_round_trip():
     model = BooguImageTransformer2DModel(od_config=_tiny_od_config())
     native_params = dict(model.named_parameters())
 
-    # Build synthetic diffusers-named weights (one per native parameter).
-    checkpoint_weights = {}
+    # Build synthetic diffusers-named weights. Fused native projections fan out
+    # into the separate matrices the diffusers checkpoint stores.
+    expected: dict[str, torch.Tensor] = {}
+    checkpoint_weights: dict[str, torch.Tensor] = {}
     for native_name, param in native_params.items():
-        checkpoint_weights[_native_to_checkpoint_name(native_name)] = torch.randn_like(param)
+        full = torch.randn_like(param)
+        expected[native_name] = full
+        for ckpt_name, value in _native_to_checkpoint_weights(native_name, full):
+            checkpoint_weights[ckpt_name] = value
 
-    # The remapping must be a bijection over the parameter set.
-    assert len(checkpoint_weights) == len(native_params)
+    # Every checkpoint name is unique; merged params fan out to >=1 weight.
+    assert len(checkpoint_weights) >= len(native_params)
 
     loaded = model.load_weights(list(checkpoint_weights.items()))
 
     # No missing / unexpected parameters.
     assert loaded == set(native_params.keys())
 
-    # Values landed on the right parameters (TP=1: weight_loader copies verbatim).
+    # Values landed on the right parameters (TP=1: weight_loader copies verbatim;
+    # fused shards are placed at their q/k/v / gate/up offsets).
     reloaded = dict(model.named_parameters())
     for native_name in native_params:
-        expected = checkpoint_weights[_native_to_checkpoint_name(native_name)]
-        assert torch.allclose(reloaded[native_name], expected)
+        assert torch.allclose(reloaded[native_name], expected[native_name])
 
 
 def test_transformer_load_weights_warns_for_unexpected_and_unloaded():
@@ -360,11 +394,13 @@ def test_transformer_load_weights_warns_for_unexpected_and_unloaded():
         model = BooguImageTransformer2DModel(od_config=_tiny_od_config())
         native_params = dict(model.named_parameters())
         loaded_name = next(iter(native_params))
-        checkpoint_name = _native_to_checkpoint_name(loaded_name)
+        # For fused projections, load just one of the fan-out checkpoint matrices.
+        (checkpoint_name, checkpoint_value), *_ = _native_to_checkpoint_weights(loaded_name, native_params[loaded_name])
+        checkpoint_value = torch.randn_like(checkpoint_value)
 
         loaded = model.load_weights(
             [
-                (checkpoint_name, torch.randn_like(native_params[loaded_name])),
+                (checkpoint_name, checkpoint_value),
                 ("unexpected.weight", torch.ones(1)),
             ]
         )

--- a/tests/diffusion/models/boogu_image/test_boogu_image_transformer.py
+++ b/tests/diffusion/models/boogu_image/test_boogu_image_transformer.py
@@ -246,6 +246,191 @@ def test_transformer_instantiates():
     assert model.x_embedder.out_features == HIDDEN_SIZE
 
 
+def test_final_projection_forward_matches_reference():
+    from vllm_omni.diffusion.models.boogu_image.boogu_image_transformer import (
+        LuminaLayerNormContinuous,
+    )
+
+    layer = LuminaLayerNormContinuous(
+        embedding_dim=HIDDEN_SIZE,
+        conditioning_embedding_dim=32,
+        elementwise_affine=False,
+        out_dim=16,
+        prefix="norm_out",
+    )
+    _randomize_parameters(layer)
+    hidden_states = torch.randn(2, 4, HIDDEN_SIZE)
+    conditioning = torch.randn(2, 32)
+
+    output = layer(hidden_states, conditioning)
+    scale = torch.nn.functional.linear(
+        layer.silu(conditioning),
+        layer.linear_1.weight,
+        layer.linear_1.bias,
+    )
+    normalized = torch.nn.functional.layer_norm(hidden_states, (HIDDEN_SIZE,), eps=1e-5)
+    expected = torch.nn.functional.linear(
+        normalized * (1 + scale[:, None, :]),
+        layer.linear_2.weight,
+        layer.linear_2.bias,
+    )
+
+    torch.testing.assert_close(output, expected)
+
+
+def _expected_quant_aware_prefixes() -> set[str]:
+    prefixes = {"norm_out.linear_1", "norm_out.linear_2"}
+
+    def add_single_stream(prefix: str, *, modulation: bool) -> None:
+        prefixes.update(
+            {
+                f"{prefix}.attn.to_qkv",
+                f"{prefix}.attn.to_out",
+                f"{prefix}.feed_forward.gate_up_proj",
+                f"{prefix}.feed_forward.linear_2",
+            }
+        )
+        if modulation:
+            prefixes.add(f"{prefix}.norm1.linear")
+
+    for stack in ("noise_refiner", "ref_image_refiner"):
+        for index in range(2):
+            add_single_stream(f"{stack}.{index}", modulation=True)
+    for index in range(2):
+        add_single_stream(f"context_refiner.{index}", modulation=False)
+        add_single_stream(f"single_stream_layers.{index}", modulation=True)
+
+    double_stream_suffixes = {
+        "img_instruct_attn.img_to_qkv",
+        "img_instruct_attn.instruct_to_qkv",
+        "img_instruct_attn.instruct_out",
+        "img_instruct_attn.img_out",
+        "img_instruct_attn.to_out",
+        "img_self_attn.to_qkv",
+        "img_self_attn.to_out",
+        "img_feed_forward.gate_up_proj",
+        "img_feed_forward.linear_2",
+        "instruct_feed_forward.gate_up_proj",
+        "instruct_feed_forward.linear_2",
+        "img_norm1.linear",
+        "img_norm2.linear",
+        "img_norm3.linear",
+        "instruct_norm1.linear",
+        "instruct_norm2.linear",
+    }
+    for index in range(2):
+        prefixes.update(f"double_stream_layers.{index}.{suffix}" for suffix in double_stream_suffixes)
+
+    return prefixes
+
+
+def test_transformer_quant_config_targets_supported_boogu_linears():
+    from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+    from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+
+    from vllm_omni.diffusion.models.boogu_image.boogu_image_transformer import (
+        BooguImageTransformer2DModel,
+    )
+
+    class _RecordingQuantConfig(QuantizationConfig):
+        def __init__(self) -> None:
+            self.prefixes: list[str] = []
+
+        def get_name(self) -> str:
+            return "recording"
+
+        def get_quant_method(self, layer, prefix: str):
+            self.prefixes.append(prefix)
+            return UnquantizedLinearMethod()
+
+        @classmethod
+        def get_supported_act_dtypes(cls):
+            return [torch.float32]
+
+        def get_min_capability(self) -> int:
+            return 0
+
+        @classmethod
+        def from_config(cls, config):
+            return cls()
+
+        def get_config_filenames(self):
+            return []
+
+    quant_config = _RecordingQuantConfig()
+    model = BooguImageTransformer2DModel(
+        od_config=_tiny_od_config(),
+        quant_config=quant_config,
+    )
+    expected = _expected_quant_aware_prefixes()
+
+    assert len(quant_config.prefixes) == len(set(quant_config.prefixes))
+    assert set(quant_config.prefixes) == expected
+
+    configured = {
+        name
+        for name, module in model.named_modules()
+        if isinstance(module, LinearBase) and module.quant_config is quant_config
+    }
+    assert configured == expected
+
+    # Patch/caption/time projections remain ordinary torch linears and do not
+    # receive the vLLM quantization config.
+    assert isinstance(model.x_embedder, torch.nn.Linear)
+    assert isinstance(model.ref_image_patch_embedder, torch.nn.Linear)
+    assert isinstance(model.time_caption_embed.timestep_embedder.linear_1, torch.nn.Linear)
+    assert isinstance(model.time_caption_embed.caption_embedder[1], torch.nn.Linear)
+
+
+def test_transformer_without_quant_config_uses_unquantized_linears():
+    from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+
+    from vllm_omni.diffusion.models.boogu_image.boogu_image_transformer import (
+        BooguImageTransformer2DModel,
+    )
+
+    model = BooguImageTransformer2DModel(od_config=_tiny_od_config())
+    linears = [module for module in model.modules() if isinstance(module, LinearBase)]
+
+    assert linears
+    assert all(module.quant_config is None for module in linears)
+    assert all(isinstance(module.quant_method, UnquantizedLinearMethod) for module in linears)
+
+
+@pytest.mark.parametrize(
+    ("module_name", "expected"),
+    [
+        (
+            "double_stream_layers.0.img_instruct_attn.instruct_to_qkv",
+            ("instruct_to_qkv", ["instruct_to_q", "instruct_to_k", "instruct_to_v"]),
+        ),
+        (
+            "double_stream_layers.0.img_instruct_attn.img_to_qkv",
+            ("img_to_qkv", ["img_to_q", "img_to_k", "img_to_v"]),
+        ),
+        (
+            "single_stream_layers.0.attn.to_qkv",
+            ("to_qkv", ["to_q", "to_k", "to_v"]),
+        ),
+    ],
+)
+def test_transformer_packed_mapping_matches_weight_remapping(module_name, expected):
+    from vllm.model_executor.model_loader.utils import ParamMapping
+
+    from vllm_omni.diffusion.models.boogu_image.boogu_image_transformer import (
+        BooguImageTransformer2DModel,
+    )
+
+    assert BooguImageTransformer2DModel.packed_modules_mapping == {
+        "instruct_to_qkv": ["instruct_to_q", "instruct_to_k", "instruct_to_v"],
+        "img_to_qkv": ["img_to_q", "img_to_k", "img_to_v"],
+        "to_qkv": ["to_q", "to_k", "to_v"],
+        "gate_up_proj": ["linear_1", "linear_3"],
+    }
+    mapping = ParamMapping(BooguImageTransformer2DModel.packed_modules_mapping)
+    assert mapping.get_sub_modules(module_name) == expected
+
+
 def test_transformer_preprocesses_multiple_instruction_feature_layers():
     from vllm_omni.diffusion.models.boogu_image.boogu_image_transformer import (
         BooguImageTransformer2DModel,

--- a/tests/diffusion/models/boogu_image/test_pipeline_boogu_image.py
+++ b/tests/diffusion/models/boogu_image/test_pipeline_boogu_image.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 """L1 unit tests for the native Boogu-Image pipeline.
 
@@ -84,6 +84,7 @@ def mock_dependencies(mocker, monkeypatch):
         "vae": mock_vae,
         "scheduler": mock_scheduler,
         "transformer": mock_transformer_instance,
+        "transformer_cls": mock_transformer_cls,
     }
 
 
@@ -139,6 +140,38 @@ def test_constructor_weights_sources(boogu_pipeline):
     assert source.subfolder == "transformer"
     assert source.prefix == "transformer."
     assert source.fall_back_to_pt is True
+
+
+def test_constructor_passes_transformer_component_quant_config(mock_dependencies, mocker):
+    from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+
+    from vllm_omni.diffusion.models.boogu_image.pipeline_boogu_image import BooguImagePipeline
+
+    quant_config = mocker.MagicMock(spec_set=QuantizationConfig)
+    resolve_quant_config = mocker.patch(
+        f"{_MODULE}._resolve_component_quant_config",
+        return_value=quant_config,
+    )
+    configure_quant_config = mocker.patch(f"{_MODULE}.configure_quant_config")
+    od_config = OmniDiffusionConfig(
+        model="dummy-boogu",
+        tf_model_config=TransformerConfig(params={}),
+        dtype=torch.float32,
+        num_gpus=1,
+    )
+
+    BooguImagePipeline(od_config=od_config)
+
+    resolve_quant_config.assert_called_once_with(od_config.quantization_config, "transformer")
+    configure_quant_config.assert_called_once_with(
+        quant_config,
+        mock_dependencies["transformer_cls"],
+    )
+    assert not hasattr(quant_config, "packed_modules_mapping")
+    assert mock_dependencies["transformer_cls"].call_args.kwargs == {
+        "od_config": od_config,
+        "quant_config": quant_config,
+    }
 
 
 @pytest.mark.parametrize(

--- a/vllm_omni/diffusion/models/boogu_image/boogu_image_transformer.py
+++ b/vllm_omni/diffusion/models/boogu_image/boogu_image_transformer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 #
 # Native vLLM-Omni port of the Boogu-Image transformer.
 #
@@ -23,9 +23,9 @@ import torch.nn.functional as F
 from diffusers.models.embeddings import Timesteps, get_1d_rotary_pos_embed
 from einops import rearrange, repeat
 from vllm.logger import init_logger
-from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
-    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
 )
@@ -34,6 +34,7 @@ from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.layer import Attention
 from vllm_omni.diffusion.data import OmniDiffusionConfig
+from vllm_omni.diffusion.layers.norm import RMSNorm
 
 logger = init_logger(__name__)
 
@@ -111,7 +112,14 @@ class LuminaLayerNormContinuous(nn.Module):
 
 
 class LuminaFeedForward(nn.Module):
-    """SwiGLU feed-forward with tensor-parallel projections."""
+    """SwiGLU feed-forward with tensor-parallel projections.
+
+    The ``gate`` and ``input`` projections are fused into a single
+    ``MergedColumnParallelLinear`` (one GEMM instead of two), matching the
+    ``gate_up_proj`` convention used by the Hunyuan Image 3 port. The SwiGLU
+    activation keeps its float32 computation for numerical parity with
+    upstream.
+    """
 
     def __init__(
         self,
@@ -125,13 +133,16 @@ class LuminaFeedForward(nn.Module):
             inner_dim = int(ffn_dim_multiplier * inner_dim)
         inner_dim = multiple_of * ((inner_dim + multiple_of - 1) // multiple_of)
 
-        self.linear_1 = ColumnParallelLinear(dim, inner_dim, bias=False)  # gate
-        self.linear_3 = ColumnParallelLinear(dim, inner_dim, bias=False)  # input
+        self.gate_up_proj = MergedColumnParallelLinear(
+            input_size=dim,
+            output_sizes=[inner_dim, inner_dim],
+            bias=False,
+        )
         self.linear_2 = RowParallelLinear(inner_dim, dim, bias=False)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        h1, _ = self.linear_1(x)
-        h2, _ = self.linear_3(x)
+        gate_up, _ = self.gate_up_proj(x)
+        h1, h2 = gate_up.chunk(2, dim=-1)
         out, _ = self.linear_2(swiglu(h1, h2))
         return out
 
@@ -389,17 +400,22 @@ class BooguImageSelfAttention(nn.Module):
     def __init__(self, dim: int, num_attention_heads: int, num_kv_heads: int) -> None:
         super().__init__()
         self.head_dim = dim // num_attention_heads
-        kv_dim = self.head_dim * num_kv_heads
 
-        self.to_q = ColumnParallelLinear(dim, dim, bias=False)
-        self.to_k = ColumnParallelLinear(dim, kv_dim, bias=False)
-        self.to_v = ColumnParallelLinear(dim, kv_dim, bias=False)
+        self.to_qkv = QKVParallelLinear(
+            hidden_size=dim,
+            head_size=self.head_dim,
+            total_num_heads=num_attention_heads,
+            total_num_kv_heads=num_kv_heads,
+            bias=False,
+        )
         self.norm_q = RMSNorm(self.head_dim, eps=1e-5)
         self.norm_k = RMSNorm(self.head_dim, eps=1e-5)
         self.to_out = RowParallelLinear(dim, dim, bias=False)
 
-        self.num_local_heads = self.to_q.output_size_per_partition // self.head_dim
-        self.num_local_kv_heads = self.to_k.output_size_per_partition // self.head_dim
+        self.num_local_heads = self.to_qkv.num_heads
+        self.num_local_kv_heads = self.to_qkv.num_kv_heads
+        self.q_size = self.num_local_heads * self.head_dim
+        self.kv_size = self.num_local_kv_heads * self.head_dim
 
         self.attn = Attention(
             num_heads=self.num_local_heads,
@@ -417,9 +433,8 @@ class BooguImageSelfAttention(nn.Module):
     ) -> torch.Tensor:
         dtype = hidden_states.dtype
 
-        query, _ = self.to_q(hidden_states)
-        key, _ = self.to_k(hidden_states)
-        value, _ = self.to_v(hidden_states)
+        qkv, _ = self.to_qkv(hidden_states)
+        query, key, value = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
         query = query.unflatten(-1, (self.num_local_heads, self.head_dim))
         key = key.unflatten(-1, (self.num_local_kv_heads, self.head_dim))
@@ -454,15 +469,21 @@ class BooguImageJointAttention(nn.Module):
     def __init__(self, dim: int, num_attention_heads: int, num_kv_heads: int) -> None:
         super().__init__()
         self.head_dim = dim // num_attention_heads
-        kv_dim = self.head_dim * num_kv_heads
 
-        self.img_to_q = ColumnParallelLinear(dim, dim, bias=False)
-        self.img_to_k = ColumnParallelLinear(dim, kv_dim, bias=False)
-        self.img_to_v = ColumnParallelLinear(dim, kv_dim, bias=False)
-
-        self.instruct_to_q = ColumnParallelLinear(dim, dim, bias=False)
-        self.instruct_to_k = ColumnParallelLinear(dim, kv_dim, bias=False)
-        self.instruct_to_v = ColumnParallelLinear(dim, kv_dim, bias=False)
+        self.img_to_qkv = QKVParallelLinear(
+            hidden_size=dim,
+            head_size=self.head_dim,
+            total_num_heads=num_attention_heads,
+            total_num_kv_heads=num_kv_heads,
+            bias=False,
+        )
+        self.instruct_to_qkv = QKVParallelLinear(
+            hidden_size=dim,
+            head_size=self.head_dim,
+            total_num_heads=num_attention_heads,
+            total_num_kv_heads=num_kv_heads,
+            bias=False,
+        )
 
         self.norm_q = RMSNorm(self.head_dim, eps=1e-5)
         self.norm_k = RMSNorm(self.head_dim, eps=1e-5)
@@ -474,8 +495,10 @@ class BooguImageJointAttention(nn.Module):
         # Final joint projection applied to the merged full-dim sequence.
         self.to_out = ReplicatedLinear(dim, dim, bias=False)
 
-        self.num_local_heads = self.img_to_q.output_size_per_partition // self.head_dim
-        self.num_local_kv_heads = self.img_to_k.output_size_per_partition // self.head_dim
+        self.num_local_heads = self.img_to_qkv.num_heads
+        self.num_local_kv_heads = self.img_to_qkv.num_kv_heads
+        self.q_size = self.num_local_heads * self.head_dim
+        self.kv_size = self.num_local_kv_heads * self.head_dim
 
         self.attn = Attention(
             num_heads=self.num_local_heads,
@@ -497,13 +520,13 @@ class BooguImageJointAttention(nn.Module):
         dtype = img_hidden_states.dtype
         batch_size = img_hidden_states.shape[0]
 
-        img_query, _ = self.img_to_q(img_hidden_states)
-        img_key, _ = self.img_to_k(img_hidden_states)
-        img_value, _ = self.img_to_v(img_hidden_states)
+        img_qkv, _ = self.img_to_qkv(img_hidden_states)
+        img_query, img_key, img_value = img_qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
-        instruct_query, _ = self.instruct_to_q(instruct_hidden_states)
-        instruct_key, _ = self.instruct_to_k(instruct_hidden_states)
-        instruct_value, _ = self.instruct_to_v(instruct_hidden_states)
+        instruct_qkv, _ = self.instruct_to_qkv(instruct_hidden_states)
+        instruct_query, instruct_key, instruct_value = instruct_qkv.split(
+            [self.q_size, self.kv_size, self.kv_size], dim=-1
+        )
 
         query, key, value = _concat_instruction_image_features(
             [img_query, img_key, img_value],
@@ -798,6 +821,47 @@ def _cal_preprocessed_instruction_feat_dim(instruction_feature_configs: dict) ->
         return instruction_feat_dim
     else:
         raise ValueError(f"Invalid reduce_type: {reduce_type}")
+
+
+_QKV_PROJ_MERGES: dict[str, tuple[str, str]] = {
+    "img_to_q": ("img_to_qkv", "q"),
+    "img_to_k": ("img_to_qkv", "k"),
+    "img_to_v": ("img_to_qkv", "v"),
+    "instruct_to_q": ("instruct_to_qkv", "q"),
+    "instruct_to_k": ("instruct_to_qkv", "k"),
+    "instruct_to_v": ("instruct_to_qkv", "v"),
+    "to_q": ("to_qkv", "q"),
+    "to_k": ("to_qkv", "k"),
+    "to_v": ("to_qkv", "v"),
+}
+
+
+def _remap_fused_weight(name: str) -> tuple[str, str | int | None]:
+    """Map a diffusers checkpoint weight name onto the fused native parameter.
+
+    The diffusers checkpoint stores Q/K/V and FFN gate/input projections as
+    separate matrices; the native port fuses them into ``QKVParallelLinear``
+    and ``MergedColumnParallelLinear``. Returns ``(param_name, shard_id)`` where
+    ``shard_id`` is the shard the fused weight loader uses to place the matrix
+    (``"q"/"k"/"v"`` for QKV, ``0/1`` for gate/up), or ``(name, None)`` when the
+    weight is not fused.
+    """
+    parts = name.split(".")
+    leaf = parts[-2] if len(parts) >= 2 else ""
+    parent = parts[-3] if len(parts) >= 3 else ""
+
+    if leaf in _QKV_PROJ_MERGES:
+        new_leaf, shard_id = _QKV_PROJ_MERGES[leaf]
+        parts[-2] = new_leaf
+        return ".".join(parts), shard_id
+
+    # FFN gate/input: ``feed_forward`` / ``img_feed_forward`` /
+    # ``instruct_feed_forward`` all share the same fused ``gate_up_proj``.
+    if leaf in ("linear_1", "linear_3") and parent.endswith("feed_forward"):
+        parts[-2] = "gate_up_proj"
+        return ".".join(parts), 0 if leaf == "linear_1" else 1
+
+    return name, None
 
 
 class BooguImageTransformer2DModel(nn.Module):
@@ -1336,7 +1400,7 @@ class BooguImageTransformer2DModel(nn.Module):
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         """Load diffusers-named checkpoint weights into the native module.
 
-        Two name promotions relative to upstream (see step 8/10 findings):
+        Name promotions relative to upstream (see step 8/10 findings):
 
         - ``*.img_instruct_attn.processor.{img,instruct}_{to_q,to_k,to_v}`` /
           ``{instruct,img}_out`` -> drop ``.processor`` (upstream keeps the
@@ -1345,6 +1409,9 @@ class BooguImageTransformer2DModel(nn.Module):
         - ``*.to_out.0.weight`` -> ``*.to_out.weight`` (diffusers wraps the
           output projection in a ``ModuleList``; the native module uses a plain
           linear).
+        - Separate Q/K/V and FFN gate/input matrices are fused into
+          ``QKVParallelLinear`` / ``MergedColumnParallelLinear`` (handled by
+          :func:`_remap_fused_weight`).
         """
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
@@ -1356,13 +1423,18 @@ class BooguImageTransformer2DModel(nn.Module):
             if ".to_out.0." in name:
                 name = name.replace(".to_out.0.", ".to_out.")
 
+            name, shard_id = _remap_fused_weight(name)
+
             if name not in params_dict:
                 logger.warning("Skipping unexpected checkpoint weight %s", original_name)
                 continue
 
             param = params_dict[name]
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
-            weight_loader(param, loaded_weight)
+            if shard_id is not None:
+                weight_loader(param, loaded_weight, shard_id)
+            else:
+                weight_loader(param, loaded_weight)
             loaded_params.add(name)
 
         unloaded_params = sorted(params_dict.keys() - loaded_params)

--- a/vllm_omni/diffusion/models/boogu_image/boogu_image_transformer.py
+++ b/vllm_omni/diffusion/models/boogu_image/boogu_image_transformer.py
@@ -16,6 +16,7 @@
 
 import itertools
 from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 import torch
 import torch.nn as nn
@@ -36,7 +37,14 @@ from vllm_omni.diffusion.attention.layer import Attention
 from vllm_omni.diffusion.data import OmniDiffusionConfig
 from vllm_omni.diffusion.layers.norm import RMSNorm
 
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+
 logger = init_logger(__name__)
+
+
+def _join_prefix(prefix: str, name: str) -> str:
+    return f"{prefix}.{name}" if prefix else name
 
 
 def apply_rotary_emb(x: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tensor:
@@ -70,10 +78,23 @@ class TimestepEmbedding(nn.Module):
 class LuminaRMSNormZero(nn.Module):
     """AdaRMS modulation: projects `temb` into scale/gate terms."""
 
-    def __init__(self, embedding_dim: int, norm_eps: float) -> None:
+    def __init__(
+        self,
+        embedding_dim: int,
+        norm_eps: float,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
+    ) -> None:
         super().__init__()
         self.silu = nn.SiLU()
-        self.linear = nn.Linear(min(embedding_dim, 1024), 4 * embedding_dim, bias=True)
+        self.linear = ReplicatedLinear(
+            min(embedding_dim, 1024),
+            4 * embedding_dim,
+            bias=True,
+            return_bias=False,
+            quant_config=quant_config,
+            prefix=_join_prefix(prefix, "linear"),
+        )
         self.norm = RMSNorm(embedding_dim, eps=norm_eps)
 
     def forward(
@@ -96,12 +117,32 @@ class LuminaLayerNormContinuous(nn.Module):
         eps: float = 1e-5,
         bias: bool = True,
         out_dim: int | None = None,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
     ) -> None:
         super().__init__()
         self.silu = nn.SiLU()
-        self.linear_1 = nn.Linear(conditioning_embedding_dim, embedding_dim, bias=bias)
+        self.linear_1 = ReplicatedLinear(
+            conditioning_embedding_dim,
+            embedding_dim,
+            bias=bias,
+            return_bias=False,
+            quant_config=quant_config,
+            prefix=_join_prefix(prefix, "linear_1"),
+        )
         self.norm = nn.LayerNorm(embedding_dim, eps, elementwise_affine, bias)
-        self.linear_2 = nn.Linear(embedding_dim, out_dim, bias=bias) if out_dim is not None else None
+        self.linear_2 = (
+            ReplicatedLinear(
+                embedding_dim,
+                out_dim,
+                bias=bias,
+                return_bias=False,
+                quant_config=quant_config,
+                prefix=_join_prefix(prefix, "linear_2"),
+            )
+            if out_dim is not None
+            else None
+        )
 
     def forward(self, x: torch.Tensor, conditioning_embedding: torch.Tensor) -> torch.Tensor:
         scale = self.linear_1(self.silu(conditioning_embedding).to(x.dtype))
@@ -127,6 +168,8 @@ class LuminaFeedForward(nn.Module):
         inner_dim: int,
         multiple_of: int = 256,
         ffn_dim_multiplier: float | None = None,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
     ) -> None:
         super().__init__()
         if ffn_dim_multiplier is not None:
@@ -137,8 +180,16 @@ class LuminaFeedForward(nn.Module):
             input_size=dim,
             output_sizes=[inner_dim, inner_dim],
             bias=False,
+            quant_config=quant_config,
+            prefix=_join_prefix(prefix, "gate_up_proj"),
         )
-        self.linear_2 = RowParallelLinear(inner_dim, dim, bias=False)
+        self.linear_2 = RowParallelLinear(
+            inner_dim,
+            dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=_join_prefix(prefix, "linear_2"),
+        )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         gate_up, _ = self.gate_up_proj(x)
@@ -397,7 +448,14 @@ class BooguImageSelfAttention(nn.Module):
     SP/KV-cache concerns.
     """
 
-    def __init__(self, dim: int, num_attention_heads: int, num_kv_heads: int) -> None:
+    def __init__(
+        self,
+        dim: int,
+        num_attention_heads: int,
+        num_kv_heads: int,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
+    ) -> None:
         super().__init__()
         self.head_dim = dim // num_attention_heads
 
@@ -407,10 +465,18 @@ class BooguImageSelfAttention(nn.Module):
             total_num_heads=num_attention_heads,
             total_num_kv_heads=num_kv_heads,
             bias=False,
+            quant_config=quant_config,
+            prefix=_join_prefix(prefix, "to_qkv"),
         )
         self.norm_q = RMSNorm(self.head_dim, eps=1e-5)
         self.norm_k = RMSNorm(self.head_dim, eps=1e-5)
-        self.to_out = RowParallelLinear(dim, dim, bias=False)
+        self.to_out = RowParallelLinear(
+            dim,
+            dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=_join_prefix(prefix, "to_out"),
+        )
 
         self.num_local_heads = self.to_qkv.num_heads
         self.num_local_kv_heads = self.to_qkv.num_kv_heads
@@ -466,7 +532,14 @@ class BooguImageJointAttention(nn.Module):
     `img_instruct_attn.to_out[0]`.
     """
 
-    def __init__(self, dim: int, num_attention_heads: int, num_kv_heads: int) -> None:
+    def __init__(
+        self,
+        dim: int,
+        num_attention_heads: int,
+        num_kv_heads: int,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
+    ) -> None:
         super().__init__()
         self.head_dim = dim // num_attention_heads
 
@@ -476,6 +549,8 @@ class BooguImageJointAttention(nn.Module):
             total_num_heads=num_attention_heads,
             total_num_kv_heads=num_kv_heads,
             bias=False,
+            quant_config=quant_config,
+            prefix=_join_prefix(prefix, "img_to_qkv"),
         )
         self.instruct_to_qkv = QKVParallelLinear(
             hidden_size=dim,
@@ -483,6 +558,8 @@ class BooguImageJointAttention(nn.Module):
             total_num_heads=num_attention_heads,
             total_num_kv_heads=num_kv_heads,
             bias=False,
+            quant_config=quant_config,
+            prefix=_join_prefix(prefix, "instruct_to_qkv"),
         )
 
         self.norm_q = RMSNorm(self.head_dim, eps=1e-5)
@@ -490,10 +567,28 @@ class BooguImageJointAttention(nn.Module):
 
         # Per-stream output projections (attention output is head-sharded
         # under TP, hence row-parallel).
-        self.instruct_out = RowParallelLinear(dim, dim, bias=False)
-        self.img_out = RowParallelLinear(dim, dim, bias=False)
+        self.instruct_out = RowParallelLinear(
+            dim,
+            dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=_join_prefix(prefix, "instruct_out"),
+        )
+        self.img_out = RowParallelLinear(
+            dim,
+            dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=_join_prefix(prefix, "img_out"),
+        )
         # Final joint projection applied to the merged full-dim sequence.
-        self.to_out = ReplicatedLinear(dim, dim, bias=False)
+        self.to_out = ReplicatedLinear(
+            dim,
+            dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=_join_prefix(prefix, "to_out"),
+        )
 
         self.num_local_heads = self.img_to_qkv.num_heads
         self.num_local_kv_heads = self.img_to_qkv.num_kv_heads
@@ -576,21 +671,36 @@ class BooguImageTransformerBlock(nn.Module):
         ffn_dim_multiplier: float | None,
         norm_eps: float,
         modulation: bool = True,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
     ) -> None:
         super().__init__()
         self.head_dim = dim // num_attention_heads
         self.modulation = modulation
 
-        self.attn = BooguImageSelfAttention(dim, num_attention_heads, num_kv_heads)
+        self.attn = BooguImageSelfAttention(
+            dim,
+            num_attention_heads,
+            num_kv_heads,
+            quant_config=quant_config,
+            prefix=_join_prefix(prefix, "attn"),
+        )
         self.feed_forward = LuminaFeedForward(
             dim=dim,
             inner_dim=4 * dim,
             multiple_of=multiple_of,
             ffn_dim_multiplier=ffn_dim_multiplier,
+            quant_config=quant_config,
+            prefix=_join_prefix(prefix, "feed_forward"),
         )
 
         if modulation:
-            self.norm1 = LuminaRMSNormZero(embedding_dim=dim, norm_eps=norm_eps)
+            self.norm1 = LuminaRMSNormZero(
+                embedding_dim=dim,
+                norm_eps=norm_eps,
+                quant_config=quant_config,
+                prefix=_join_prefix(prefix, "norm1"),
+            )
         else:
             self.norm1 = RMSNorm(dim, eps=norm_eps)
 
@@ -653,6 +763,8 @@ class BooguImageDoubleStreamTransformerBlock(nn.Module):
         ffn_dim_multiplier: float | None,
         norm_eps: float,
         modulation: bool = True,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
     ) -> None:
         super().__init__()
         self.head_dim = dim // num_attention_heads
@@ -660,21 +772,50 @@ class BooguImageDoubleStreamTransformerBlock(nn.Module):
         self.modulation = modulation
         self.hidden_size = dim
 
-        self.img_instruct_attn = BooguImageJointAttention(dim, num_attention_heads, num_kv_heads)
-        self.img_self_attn = BooguImageSelfAttention(dim, num_attention_heads, num_kv_heads)
+        self.img_instruct_attn = BooguImageJointAttention(
+            dim,
+            num_attention_heads,
+            num_kv_heads,
+            quant_config=quant_config,
+            prefix=_join_prefix(prefix, "img_instruct_attn"),
+        )
+        self.img_self_attn = BooguImageSelfAttention(
+            dim,
+            num_attention_heads,
+            num_kv_heads,
+            quant_config=quant_config,
+            prefix=_join_prefix(prefix, "img_self_attn"),
+        )
 
         self.img_feed_forward = LuminaFeedForward(
             dim=dim,
             inner_dim=4 * dim,
             multiple_of=multiple_of,
             ffn_dim_multiplier=ffn_dim_multiplier,
+            quant_config=quant_config,
+            prefix=_join_prefix(prefix, "img_feed_forward"),
         )
 
         if modulation:
             # Image modulation terms: cross-attn, MLP, self-attn.
-            self.img_norm1 = LuminaRMSNormZero(embedding_dim=dim, norm_eps=norm_eps)
-            self.img_norm2 = LuminaRMSNormZero(embedding_dim=dim, norm_eps=norm_eps)
-            self.img_norm3 = LuminaRMSNormZero(embedding_dim=dim, norm_eps=norm_eps)
+            self.img_norm1 = LuminaRMSNormZero(
+                embedding_dim=dim,
+                norm_eps=norm_eps,
+                quant_config=quant_config,
+                prefix=_join_prefix(prefix, "img_norm1"),
+            )
+            self.img_norm2 = LuminaRMSNormZero(
+                embedding_dim=dim,
+                norm_eps=norm_eps,
+                quant_config=quant_config,
+                prefix=_join_prefix(prefix, "img_norm2"),
+            )
+            self.img_norm3 = LuminaRMSNormZero(
+                embedding_dim=dim,
+                norm_eps=norm_eps,
+                quant_config=quant_config,
+                prefix=_join_prefix(prefix, "img_norm3"),
+            )
         else:
             self.img_norm1 = RMSNorm(dim, eps=norm_eps)
             self.img_norm2 = RMSNorm(dim, eps=norm_eps)
@@ -690,12 +831,24 @@ class BooguImageDoubleStreamTransformerBlock(nn.Module):
             inner_dim=4 * dim,
             multiple_of=multiple_of,
             ffn_dim_multiplier=ffn_dim_multiplier,
+            quant_config=quant_config,
+            prefix=_join_prefix(prefix, "instruct_feed_forward"),
         )
 
         if modulation:
             # Instruction modulation terms: cross-attn, MLP.
-            self.instruct_norm1 = LuminaRMSNormZero(embedding_dim=dim, norm_eps=norm_eps)
-            self.instruct_norm2 = LuminaRMSNormZero(embedding_dim=dim, norm_eps=norm_eps)
+            self.instruct_norm1 = LuminaRMSNormZero(
+                embedding_dim=dim,
+                norm_eps=norm_eps,
+                quant_config=quant_config,
+                prefix=_join_prefix(prefix, "instruct_norm1"),
+            )
+            self.instruct_norm2 = LuminaRMSNormZero(
+                embedding_dim=dim,
+                norm_eps=norm_eps,
+                quant_config=quant_config,
+                prefix=_join_prefix(prefix, "instruct_norm2"),
+            )
         else:
             self.instruct_norm1 = RMSNorm(dim, eps=norm_eps)
             self.instruct_norm2 = RMSNorm(dim, eps=norm_eps)
@@ -881,8 +1034,18 @@ class BooguImageTransformer2DModel(nn.Module):
         "BooguImageSingleStreamTransformerBlock",
     ]
     _layerwise_offload_blocks_attrs = ["single_stream_layers", "double_stream_layers"]
+    packed_modules_mapping = {
+        "instruct_to_qkv": ["instruct_to_q", "instruct_to_k", "instruct_to_v"],
+        "img_to_qkv": ["img_to_q", "img_to_k", "img_to_v"],
+        "to_qkv": ["to_q", "to_k", "to_v"],
+        "gate_up_proj": ["linear_1", "linear_3"],
+    }
 
-    def __init__(self, od_config: OmniDiffusionConfig) -> None:
+    def __init__(
+        self,
+        od_config: OmniDiffusionConfig,
+        quant_config: "QuantizationConfig | None" = None,
+    ) -> None:
         super().__init__()
         self.od_config = od_config
         cfg = od_config.tf_model_config
@@ -969,8 +1132,10 @@ class BooguImageTransformer2DModel(nn.Module):
                     ffn_dim_multiplier,
                     norm_eps,
                     modulation=True,
+                    quant_config=quant_config,
+                    prefix=f"noise_refiner.{i}",
                 )
-                for _ in range(num_refiner_layers)
+                for i in range(num_refiner_layers)
             ]
         )
 
@@ -984,8 +1149,10 @@ class BooguImageTransformer2DModel(nn.Module):
                     ffn_dim_multiplier,
                     norm_eps,
                     modulation=True,
+                    quant_config=quant_config,
+                    prefix=f"ref_image_refiner.{i}",
                 )
-                for _ in range(num_refiner_layers)
+                for i in range(num_refiner_layers)
             ]
         )
 
@@ -999,8 +1166,10 @@ class BooguImageTransformer2DModel(nn.Module):
                     ffn_dim_multiplier,
                     norm_eps,
                     modulation=False,
+                    quant_config=quant_config,
+                    prefix=f"context_refiner.{i}",
                 )
-                for _ in range(num_refiner_layers)
+                for i in range(num_refiner_layers)
             ]
         )
 
@@ -1015,8 +1184,10 @@ class BooguImageTransformer2DModel(nn.Module):
                     ffn_dim_multiplier,
                     norm_eps,
                     modulation=True,
+                    quant_config=quant_config,
+                    prefix=f"double_stream_layers.{i}",
                 )
-                for _ in range(num_double_stream_layers)
+                for i in range(num_double_stream_layers)
             ]
         )
 
@@ -1030,8 +1201,10 @@ class BooguImageTransformer2DModel(nn.Module):
                     ffn_dim_multiplier,
                     norm_eps,
                     modulation=True,
+                    quant_config=quant_config,
+                    prefix=f"single_stream_layers.{i}",
                 )
-                for _ in range(self.num_single_stream_layers)
+                for i in range(self.num_single_stream_layers)
             ]
         )
 
@@ -1042,6 +1215,8 @@ class BooguImageTransformer2DModel(nn.Module):
             eps=1e-6,
             bias=True,
             out_dim=patch_size * patch_size * self.out_channels,
+            quant_config=quant_config,
+            prefix="norm_out",
         )
 
         # Distinguish multiple reference images (max 5).

--- a/vllm_omni/diffusion/models/boogu_image/pipeline_boogu_image.py
+++ b/vllm_omni/diffusion/models/boogu_image/pipeline_boogu_image.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 """Native vLLM-Omni pipeline for Boogu-Image-0.1.
 
@@ -33,6 +33,7 @@ from diffusers.utils.torch_utils import randn_tensor
 from torch import nn
 from transformers import Qwen3VLForConditionalGeneration, Qwen3VLProcessor
 from vllm.logger import init_logger
+from vllm.model_executor.model_loader.utils import configure_quant_config
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
@@ -52,6 +53,7 @@ from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
+from vllm_omni.quantization import resolve_component_quant_config as _resolve_component_quant_config
 
 logger = init_logger(__name__)
 
@@ -266,7 +268,13 @@ class BooguImagePipeline(nn.Module, ProgressBarMixin, SupportsComponentDiscovery
             local_files_only=local_files_only,
         ).to(self._execution_device)
 
-        self.transformer = BooguImageTransformer2DModel(od_config=od_config)
+        transformer_quant_config = _resolve_component_quant_config(od_config.quantization_config, "transformer")
+        if transformer_quant_config is not None:
+            configure_quant_config(transformer_quant_config, BooguImageTransformer2DModel)
+        self.transformer = BooguImageTransformer2DModel(
+            od_config=od_config,
+            quant_config=transformer_quant_config,
+        )
 
         self.vae_scale_factor = 2 ** (len(self.vae.config.block_out_channels) - 1) if getattr(self, "vae", None) else 8
         self.default_sample_size = 128


### PR DESCRIPTION
## Purpose

Make the native Boogu-Image transformer construction quantization-aware so a component-scoped quantization method can materialize DiT linears directly in their target representation.

This is the first implementation step from #6789 and is related to #6787 and #6665. It deliberately does not add a Hybrid W8A8 method, NPU kernels, a DiT sidecar loader, or the Qwen QuaRot loader.

This PR is stacked on #6649. After #6649 lands, the branch will be rebased onto `main` so the dependency commit disappears from the PR.

## Changes

- Resolve the `transformer` component quantization config in `BooguImagePipeline` and configure it against the concrete transformer class.
- Pass `quant_config` and stable layer prefixes through Boogu attention, FFN, adaptive-modulation, and final AdaLN/output-projection construction.
- Keep patch, caption, and timestep projections outside this vLLM-linear construction path.
- Declare model-owned packed mappings for fused QKV and gate/up projections.
- Order overlapping QKV suffixes from most specific to least specific so vLLM mapping helpers do not match `img_to_qkv` or `instruct_to_qkv` as `to_qkv`.
- Cover exact quant-aware prefixes, the unquantized construction path, component routing, final-projection numerical behavior, and packed suffix resolution.

The two final `norm_out` projections are included because the validated `dit-hybrid-w8a8-v2` sidecar contains both. Across all four published models, its 334 W8A16 entries map to 210 fused Omni layer prefixes; the DiT FFN sidecars add 104 targets for Base/Turbo and 108 for Edit/Edit-Turbo.

## Validation

All changed-file pre-commit hooks pass. Focused construction assertions pass in the local PyTorch 2.10 / torch-npu 2.10 environment. This PR makes no real-NPU, checkpoint-loading, accuracy, memory, performance, or Hybrid runtime claim.

It remains draft intentionally because #6649 must land first and #6789 still needs the manifest and Qwen construction-time loader contract. The four-model real-NPU evidence is tracked in #6787; it is not being used as a claim for this construction-only PR.
