### PR TITLE
[Bugfix][Ascend NPU][Diffusion] Fall back for CPU tensors in NPU dispatch

### DIFF
--- a/tests/diffusion/layers/test_activation.py
+++ b/tests/diffusion/layers/test_activation.py
@@ -19,6 +19,16 @@ def test_silu_and_mul_native_matches_packed_reference() -> None:
     torch.testing.assert_close(SiluAndMul().forward_native(packed), F.silu(gate) * up)
 
 
+@pytest.mark.cpu
+def test_silu_and_mul_npu_dispatch_falls_back_for_cpu_tensor() -> None:
+    packed = torch.randn(257, 256, dtype=torch.float32)
+
+    torch.testing.assert_close(
+        SiluAndMul().forward_npu(packed),
+        SiluAndMul().forward_native(packed),
+    )
+
+
 @hardware_test(res={"npu": "A3"}, num_cards=1)
 def test_silu_and_mul_npu_matches_packed_reference() -> None:
     packed = torch.randn(257, 256, device="npu", dtype=torch.bfloat16)

--- a/tests/diffusion/layers/test_norm.py
+++ b/tests/diffusion/layers/test_norm.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Unit tests for LayerNorm and RMSNorm custom ops in diffusion layers."""
 
 import sys
@@ -331,6 +331,7 @@ def test_rmsnorm_npu_receives_gamma_with_configured_dtype(monkeypatch: pytest.Mo
         return (x,)
 
     monkeypatch.setitem(sys.modules, "torch_npu", types.SimpleNamespace(npu_rms_norm=npu_rms_norm))
+    monkeypatch.setattr("vllm_omni.diffusion.layers.norm._is_npu_tensor", lambda _: True)
     norm = RMSNorm(64, eps=1e-5, dtype=torch.bfloat16)
     x = torch.randn(2, 4, 64, dtype=torch.bfloat16)
 
@@ -338,6 +339,26 @@ def test_rmsnorm_npu_receives_gamma_with_configured_dtype(monkeypatch: pytest.Mo
     assert captured["gamma"] is norm.weight
     assert captured["gamma"].dtype == torch.bfloat16
     assert captured["epsilon"].item() == pytest.approx(1e-5)
+
+
+@pytest.mark.parametrize("with_residual", [False, True])
+def test_rmsnorm_npu_dispatch_falls_back_for_cpu_tensor(with_residual: bool):
+    from vllm_omni.diffusion.layers.norm import RMSNorm
+
+    norm = RMSNorm(64, eps=1e-5, dtype=torch.bfloat16)
+    x = torch.randn(2, 4, 64, dtype=torch.bfloat16)
+    residual = torch.randn_like(x) if with_residual else None
+
+    actual = norm.forward_npu(x, residual)
+    expected = norm.forward_native(x, residual)
+
+    if with_residual:
+        actual_output, actual_residual = actual
+        expected_output, expected_residual = expected
+        torch.testing.assert_close(actual_output, expected_output)
+        torch.testing.assert_close(actual_residual, expected_residual)
+    else:
+        torch.testing.assert_close(actual, expected)
 
 
 # ── RMSNorm residual tests ──
@@ -417,6 +438,7 @@ def test_rmsnorm_npu_residual_uses_torch_npu_fused_op(monkeypatch: pytest.Monkey
         "torch_npu",
         types.SimpleNamespace(npu_add_rms_norm=npu_add_rms_norm),
     )
+    monkeypatch.setattr("vllm_omni.diffusion.layers.norm._is_npu_tensor", lambda _: True)
     norm = RMSNorm(4, eps=1e-5, dtype=torch.bfloat16)
     x = torch.randn(2, 4, dtype=torch.bfloat16)
     residual = torch.randn(2, 4, dtype=torch.bfloat16)

--- a/vllm_omni/diffusion/layers/activation.py
+++ b/vllm_omni/diffusion/layers/activation.py
@@ -32,6 +32,8 @@ class SiluAndMul(CustomOp):
         return out
 
     def forward_npu(self, x: torch.Tensor) -> torch.Tensor:
+        if x.device.type != "npu":
+            return self.forward_native(x)
         import torch_npu
 
         return torch_npu.npu_swiglu(x, dim=-1)

--- a/vllm_omni/diffusion/layers/norm.py
+++ b/vllm_omni/diffusion/layers/norm.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 from importlib.util import find_spec
 
 import torch
@@ -12,6 +15,10 @@ logger = init_logger(__name__)
 _HAS_MINDIESD = find_spec("mindiesd") is not None
 
 
+def _is_npu_tensor(x: torch.Tensor) -> bool:
+    return x.device.type == "npu"
+
+
 class LayerNorm(nn.LayerNorm, CustomOp):
     """
     LayerNorm implementation that inherits from both ``nn.LayerNorm`` and ``CustomOp``.
@@ -22,7 +29,11 @@ class LayerNorm(nn.LayerNorm, CustomOp):
     """
 
     def __init__(self, dim: int, eps: float = 1e-6, elementwise_affine: bool = True):
-        super().__init__(normalized_shape=dim, eps=eps, elementwise_affine=elementwise_affine)
+        super().__init__(  # type: ignore[call-arg]
+            normalized_shape=dim,
+            eps=eps,
+            elementwise_affine=elementwise_affine,
+        )
         # CustomOp.__init__ cannot be called here because it would re-run
         # nn.Module initialization and clear LayerNorm parameters.
         self._forward_method = CustomOp.dispatch_forward(self)
@@ -136,6 +147,8 @@ class RMSNorm(CustomOp):
         x: torch.Tensor,
         residual: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if not _is_npu_tensor(x):
+            return self.forward_native(x, residual)
         import torch_npu
 
         if residual is not None:


### PR DESCRIPTION
## Purpose

Keep the shared diffusion NPU operator dispatch correct when a CPU tensor is used in an NPU-enabled process. This is required by Boogu-Image's CPU tests and is a generally valid device boundary for the shared layers.

## Changes

- `SiluAndMul.forward_npu` uses the native implementation for CPU tensors and keeps `torch_npu.npu_swiglu` for NPU tensors.
- `RMSNorm.forward_npu` uses the native implementation for CPU tensors, including the residual form, and keeps the fused Ascend operations for NPU tensors.
- Add regression coverage for both branches and preserve the existing mocked fused-op parameter tests.

Related to #6787 and #6649. This is a prerequisite for the Boogu-Image NPU integration; it does not add model-specific code or change the NPU kernel path.

## Validation

```text
focused fallback tests: 4 passed
public build (3.11): passed
public build (3.12): passed
public pre-commit: passed
public DCO: passed
public Read the Docs: passed
```

The remaining four failures in the complete local activation/norm collection are pre-existing CUDA-only tests on this non-CUDA host (`Torch not compiled with CUDA enabled`). This PR is independently mergeable and ready for review.
