### PR TITLE
[Feature][NPU] Add FP8 KV-slice dense FIA path for packed FP8 attention (MINDIESD_FP8_KV_SLICE)

### DIFF
--- a/tests/diffusion/attention/test_attention_layer_chunking.py
+++ b/tests/diffusion/attention/test_attention_layer_chunking.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Layer-level injection of KV quantization + attention chunking options.
 
 The Attention layer parses the diffusion config once (``_init_kv_cache_quantization``)
@@ -83,9 +83,7 @@ class TestWithKvCacheDtypeInjection:
 
     def test_layer_opt_out_pops_both_keys(self) -> None:
         layer = _bare_layer(disable=True)
-        metadata = AttentionMetadata(
-            extra={"kv_cache_dtype": "fp8", "attn_chunking": AttnChunkingOptions(q_chunk=8)}
-        )
+        metadata = AttentionMetadata(extra={"kv_cache_dtype": "fp8", "attn_chunking": AttnChunkingOptions(q_chunk=8)})
 
         cleaned = layer._with_kv_cache_dtype(metadata)
 
@@ -94,9 +92,7 @@ class TestWithKvCacheDtypeInjection:
 
     def test_skip_step_hit_pops_both_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(layer_mod, "is_forward_context_available", lambda: True)
-        monkeypatch.setattr(
-            layer_mod, "get_forward_context", lambda: SimpleNamespace(denoise_step_idx=3)
-        )
+        monkeypatch.setattr(layer_mod, "get_forward_context", lambda: SimpleNamespace(denoise_step_idx=3))
         layer = _bare_layer(skip_steps={3})
 
         cleaned = layer._with_kv_cache_dtype(AttentionMetadata(extra={"kv_cache_dtype": "fp8"}))

--- a/tests/diffusion/attention/test_attention_layer_chunking.py
+++ b/tests/diffusion/attention/test_attention_layer_chunking.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Layer-level injection of KV quantization + attention chunking options.
+
+The Attention layer parses the diffusion config once (``_init_kv_cache_quantization``)
+and injects/removes ``kv_cache_dtype`` and ``attn_chunking`` in
+``attn_metadata.extra`` together (``_with_kv_cache_dtype``): backends never
+see chunking without a dtype, and every skip gate disables both at once.
+
+These tests build the layer via ``__new__`` (no heavy ``__init__``) and set
+exactly the attributes the two methods read.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import vllm_omni.diffusion.attention.layer as layer_mod
+from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
+from vllm_omni.diffusion.attention.chunking import AttnChunkingOptions
+from vllm_omni.diffusion.attention.layer import Attention
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+def _bare_layer(
+    kv_dtype: str | None = "fp8",
+    chunking: AttnChunkingOptions | None = None,
+    disable: bool = False,
+    skip_steps: set[int] | None = None,
+    skip_layers: set[int] | None = None,
+) -> Attention:
+    layer = Attention.__new__(Attention)
+    layer._kv_cache_dtype = kv_dtype
+    layer._attn_chunking = chunking
+    layer._disable_kv_quant = disable
+    layer._kv_cache_skip_steps = skip_steps
+    layer._kv_cache_skip_layers = skip_layers
+    layer.layer_idx = None
+    return layer
+
+
+class TestWithKvCacheDtypeInjection:
+    def test_active_quant_injects_dtype_and_chunking(self) -> None:
+        options = AttnChunkingOptions(q_chunk=8, head_chunk=2)
+        layer = _bare_layer(chunking=options)
+
+        metadata = layer._with_kv_cache_dtype(AttentionMetadata(extra={"other": 1}))
+
+        assert metadata.extra["kv_cache_dtype"] == "fp8"
+        assert metadata.extra["attn_chunking"] is options
+        assert metadata.extra["other"] == 1  # untouched
+
+    def test_active_quant_without_chunking_only_dtype(self) -> None:
+        layer = _bare_layer(chunking=None)
+
+        metadata = layer._with_kv_cache_dtype(AttentionMetadata(extra={}))
+
+        assert metadata.extra["kv_cache_dtype"] == "fp8"
+        assert "attn_chunking" not in metadata.extra
+
+    def test_none_metadata_gets_both_keys(self) -> None:
+        options = AttnChunkingOptions(q_chunk=8)
+        layer = _bare_layer(chunking=options)
+
+        metadata = layer._with_kv_cache_dtype(None)
+
+        assert metadata is not None
+        assert metadata.extra == {"kv_cache_dtype": "fp8", "attn_chunking": options}
+
+    def test_quant_disabled_pops_both_keys(self) -> None:
+        options = AttnChunkingOptions(q_chunk=8)
+        layer = _bare_layer(kv_dtype=None)
+        # A stale chunking key (e.g. shared metadata object) must not survive.
+        metadata = AttentionMetadata(extra={"kv_cache_dtype": "fp8", "attn_chunking": options})
+
+        cleaned = layer._with_kv_cache_dtype(metadata)
+
+        assert "kv_cache_dtype" not in cleaned.extra
+        assert "attn_chunking" not in cleaned.extra
+
+    def test_layer_opt_out_pops_both_keys(self) -> None:
+        layer = _bare_layer(disable=True)
+        metadata = AttentionMetadata(
+            extra={"kv_cache_dtype": "fp8", "attn_chunking": AttnChunkingOptions(q_chunk=8)}
+        )
+
+        cleaned = layer._with_kv_cache_dtype(metadata)
+
+        assert "kv_cache_dtype" not in cleaned.extra
+        assert "attn_chunking" not in cleaned.extra
+
+    def test_skip_step_hit_pops_both_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(layer_mod, "is_forward_context_available", lambda: True)
+        monkeypatch.setattr(
+            layer_mod, "get_forward_context", lambda: SimpleNamespace(denoise_step_idx=3)
+        )
+        layer = _bare_layer(skip_steps={3})
+
+        cleaned = layer._with_kv_cache_dtype(AttentionMetadata(extra={"kv_cache_dtype": "fp8"}))
+
+        assert "kv_cache_dtype" not in cleaned.extra
+
+
+class TestInitKvCacheQuantizationParsing:
+    @staticmethod
+    def _config(**overrides) -> SimpleNamespace:
+        config = SimpleNamespace(
+            diffusion_kv_cache_dtype="fp8",
+            parallel_config=SimpleNamespace(ring_degree=1),
+            diffusion_kv_cache_skip_step_indices=None,
+            diffusion_kv_cache_skip_layer_indices=None,
+            diffusion_attn_q_chunk=1,
+            diffusion_attn_head_chunk=0,
+            diffusion_attn_head_chunk_min_kv=50000,
+        )
+        config.__dict__.update(overrides)
+        return config
+
+    @pytest.fixture
+    def npu_platform(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(layer_mod, "current_omni_platform", SimpleNamespace(device_name="npu"))
+
+    def _bare_init_layer(self) -> Attention:
+        layer = Attention.__new__(Attention)
+        layer.attention = SimpleNamespace(supports_kv_cache_dtype=lambda dtype, platform: True)
+        layer.attn_backend = SimpleNamespace(get_name=lambda: "FLASH_ATTN")
+        layer._kv_cache_dtype = None
+        layer._attn_chunking = None
+        layer._kv_cache_skip_steps = None
+        layer._kv_cache_skip_layers = None
+        return layer
+
+    def test_parses_chunk_fields_into_options(self, npu_platform) -> None:
+        layer = self._bare_init_layer()
+        config = self._config(diffusion_attn_q_chunk=8, diffusion_attn_head_chunk=2)
+
+        layer._init_kv_cache_quantization(config)
+
+        assert layer._attn_chunking == AttnChunkingOptions(q_chunk=8, head_chunk=2, head_chunk_min_kv=50000)
+
+    def test_inert_defaults_stay_none(self, npu_platform) -> None:
+        layer = self._bare_init_layer()
+
+        layer._init_kv_cache_quantization(self._config())
+
+        assert layer._kv_cache_dtype == "fp8"
+        assert layer._attn_chunking is None
+
+    def test_no_dtype_means_no_chunking(self, npu_platform) -> None:
+        # Config validation rejects chunk flags without fp8 upstream; the
+        # layer stays defensive and drops chunking with the dtype.
+        layer = self._bare_init_layer()
+        config = self._config(diffusion_kv_cache_dtype=None, diffusion_attn_q_chunk=8)
+
+        layer._init_kv_cache_quantization(config)
+
+        assert layer._kv_cache_dtype is None
+        assert layer._attn_chunking is None

--- a/tests/diffusion/attention/test_attn_chunking.py
+++ b/tests/diffusion/attention/test_attn_chunking.py
@@ -1,0 +1,324 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the backend-neutral attention chunking scheduler.
+
+These tests load ``chunking`` from its source file via ``importlib`` (same
+pattern as ``tests/platforms/npu/quant/test_kv_quant_npu.py``) so the test
+module does not ``import vllm_omni`` — the module must stay importable both
+inside and outside the package, which is the whole point of the design.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import torch
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+def _repo_root() -> Path:
+    """Resolve checkout root (parent of ``vllm_omni/``), not ``tests/``."""
+    here = Path(__file__).resolve()
+    marker = Path("vllm_omni") / "diffusion" / "attention" / "chunking.py"
+    for parent in here.parents:
+        if (parent / marker).is_file():
+            return parent
+    msg = f"could not locate repo root (no {marker}) starting from {here}"
+    raise FileNotFoundError(msg)
+
+
+def _load_chunking() -> ModuleType:
+    path = _repo_root() / "vllm_omni" / "diffusion" / "attention" / "chunking.py"
+    if not path.is_file():
+        msg = f"chunking source not found: {path}"
+        raise FileNotFoundError(msg)
+    name = "vllm_omni_test_chunking_standalone"
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        msg = f"cannot load import spec for {path}"
+        raise RuntimeError(msg)
+    mod = importlib.util.module_from_spec(spec)
+    # Register before exec: dataclass processing looks the module up in
+    # sys.modules (KW_ONLY detection) and crashes on a missing entry.
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+chunking = _load_chunking()
+
+
+def _plan_calls(plan) -> list[tuple[int, int, int, int]]:
+    return [(c.row0, c.row1, c.h0, c.h1) for c in plan]
+
+
+class TestAttnChunkingOptions:
+    def test_defaults_are_inactive(self) -> None:
+        assert not chunking.AttnChunkingOptions().active
+
+    def test_active_when_either_knob_set(self) -> None:
+        assert chunking.AttnChunkingOptions(q_chunk=8).active
+        assert chunking.AttnChunkingOptions(head_chunk=2).active
+        # q_chunk=1 alone (the default value) is not a chunking request.
+        assert not chunking.AttnChunkingOptions(q_chunk=1).active
+
+    def test_frozen(self) -> None:
+        options = chunking.AttnChunkingOptions()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            options.q_chunk = 4  # type: ignore[misc]
+
+
+class TestBuildChunkPlan:
+    def test_none_options_yields_single_call(self) -> None:
+        plan = chunking.build_chunk_plan(seq_len=128, num_heads=4, options=None)
+        assert _plan_calls(plan) == [(0, 128, 0, 4)]
+
+    def test_default_options_yield_single_call(self) -> None:
+        plan = chunking.build_chunk_plan(
+            seq_len=128, num_heads=4, options=chunking.AttnChunkingOptions()
+        )
+        assert _plan_calls(plan) == [(0, 128, 0, 4)]
+
+    def test_q_chunk_even_split_aligned(self) -> None:
+        plan = chunking.build_chunk_plan(
+            seq_len=1024,
+            num_heads=2,
+            options=chunking.AttnChunkingOptions(q_chunk=8),
+            row_align=128,
+        )
+        assert _plan_calls(plan) == [
+            (0, 128, 0, 2),
+            (128, 256, 0, 2),
+            (256, 384, 0, 2),
+            (384, 512, 0, 2),
+            (512, 640, 0, 2),
+            (640, 768, 0, 2),
+            (768, 896, 0, 2),
+            (896, 1024, 0, 2),
+        ]
+
+    def test_q_chunk_ragged_tail(self) -> None:
+        # chunk = ceil(1000 / (8*128)) * 128 = 128 → last chunk keeps 104 rows.
+        plan = chunking.build_chunk_plan(
+            seq_len=1000,
+            num_heads=1,
+            options=chunking.AttnChunkingOptions(q_chunk=8),
+            row_align=128,
+        )
+        calls = _plan_calls(plan)
+        assert len(calls) == 8
+        assert calls[-1] == (896, 1000, 0, 1)
+        # Every boundary except the last lands on the alignment grid.
+        assert all(row0 % 128 == 0 for row0, _, _, _ in calls)
+        assert all(row1 % 128 == 0 for _, row1, _, _ in calls[:-1])
+
+    def test_q_chunk_fewer_chunks_when_rows_run_out(self) -> None:
+        # ceil(200 / (8*128)) * 128 = 128 → only 2 chunks fit.
+        plan = chunking.build_chunk_plan(
+            seq_len=200,
+            num_heads=1,
+            options=chunking.AttnChunkingOptions(q_chunk=8),
+            row_align=128,
+        )
+        assert _plan_calls(plan) == [(0, 128, 0, 1), (128, 200, 0, 1)]
+
+    def test_seq_at_or_below_align_is_single_chunk(self) -> None:
+        plan = chunking.build_chunk_plan(
+            seq_len=128,
+            num_heads=1,
+            options=chunking.AttnChunkingOptions(q_chunk=8),
+            row_align=128,
+        )
+        assert _plan_calls(plan) == [(0, 128, 0, 1)]
+
+    def test_align_1_allows_any_boundary(self) -> None:
+        plan = chunking.build_chunk_plan(
+            seq_len=10,
+            num_heads=1,
+            options=chunking.AttnChunkingOptions(q_chunk=3),
+        )
+        assert _plan_calls(plan) == [(0, 4, 0, 1), (4, 8, 0, 1), (8, 10, 0, 1)]
+
+    def test_head_chunk_cartesian_q_major(self) -> None:
+        plan = chunking.build_chunk_plan(
+            seq_len=256,
+            num_heads=4,
+            options=chunking.AttnChunkingOptions(q_chunk=2, head_chunk=2),
+            num_kv_heads=4,
+            kv_len=60000,
+            row_align=128,
+        )
+        assert _plan_calls(plan) == [
+            (0, 128, 0, 2),
+            (0, 128, 2, 4),
+            (128, 256, 0, 2),
+            (128, 256, 2, 4),
+        ]
+
+    def test_head_chunk_collapses_for_gqa(self) -> None:
+        plan = chunking.build_chunk_plan(
+            seq_len=256,
+            num_heads=4,
+            options=chunking.AttnChunkingOptions(head_chunk=2),
+            num_kv_heads=2,  # GQA: KV heads cannot be split per query-head slice.
+            kv_len=60000,
+        )
+        assert all(h1 - h0 == 4 for _, _, h0, h1 in _plan_calls(plan))
+
+    def test_head_chunk_collapses_below_min_kv(self) -> None:
+        options = chunking.AttnChunkingOptions(head_chunk=2, head_chunk_min_kv=50000)
+        short = chunking.build_chunk_plan(
+            seq_len=256, num_heads=4, options=options, num_kv_heads=4, kv_len=49999
+        )
+        assert all(h1 - h0 == 4 for _, _, h0, h1 in _plan_calls(short))
+        long = chunking.build_chunk_plan(
+            seq_len=256, num_heads=4, options=options, num_kv_heads=4, kv_len=50000
+        )
+        assert all(h1 - h0 == 2 for _, _, h0, h1 in _plan_calls(long))
+
+    def test_min_kv_gate_leaves_q_chunking_alone(self) -> None:
+        plan = chunking.build_chunk_plan(
+            seq_len=256,
+            num_heads=4,
+            options=chunking.AttnChunkingOptions(q_chunk=2, head_chunk=2),
+            num_kv_heads=4,
+            kv_len=100,  # below the default gate: heads collapse, rows do not
+            row_align=128,
+        )
+        assert _plan_calls(plan) == [(0, 128, 0, 4), (128, 256, 0, 4)]
+
+    def test_head_chunk_larger_than_heads_is_single_head_slice(self) -> None:
+        plan = chunking.build_chunk_plan(
+            seq_len=64,
+            num_heads=4,
+            options=chunking.AttnChunkingOptions(head_chunk=8),
+            num_kv_heads=4,
+            kv_len=60000,
+        )
+        assert _plan_calls(plan) == [(0, 64, 0, 4)]
+
+    def test_coverage_exactly_once(self) -> None:
+        plan = chunking.build_chunk_plan(
+            seq_len=1000,
+            num_heads=6,
+            options=chunking.AttnChunkingOptions(q_chunk=8, head_chunk=4),
+            num_kv_heads=6,
+            kv_len=60000,
+            row_align=128,
+        )
+        by_row: dict[tuple[int, int], set[int]] = {}
+        for c in plan:
+            by_row.setdefault((c.row0, c.row1), set()).update(range(c.h0, c.h1))
+        assert sorted(by_row) == [
+            (0, 128),
+            (128, 256),
+            (256, 384),
+            (384, 512),
+            (512, 640),
+            (640, 768),
+            (768, 896),
+            (896, 1000),
+        ]
+        for heads in by_row.values():
+            assert heads == set(range(6))
+
+    @pytest.mark.parametrize(
+        "kwargs,match",
+        [
+            (dict(seq_len=0, num_heads=1), "seq_len"),
+            (dict(seq_len=8, num_heads=0), "num_heads"),
+        ],
+    )
+    def test_invalid_shapes_raise(self, kwargs: dict, match: str) -> None:
+        with pytest.raises(ValueError, match=match):
+            chunking.build_chunk_plan(**kwargs)
+
+    def test_invalid_row_align_raises(self) -> None:
+        with pytest.raises(ValueError, match="row_align"):
+            chunking.build_chunk_plan(seq_len=8, num_heads=1, row_align=0)
+
+    @pytest.mark.parametrize(
+        "options,match",
+        [
+            (chunking.AttnChunkingOptions(q_chunk=0), "q_chunk"),
+            (chunking.AttnChunkingOptions(head_chunk=-1), "head_chunk"),
+            (chunking.AttnChunkingOptions(head_chunk=2, head_chunk_min_kv=-1), "head_chunk_min_kv"),
+        ],
+    )
+    def test_invalid_options_raise(self, options, match: str) -> None:
+        with pytest.raises(ValueError, match=match):
+            chunking.build_chunk_plan(seq_len=8, num_heads=2, options=options)
+
+
+class TestRunChunked:
+    """Executor contract via a stub make_call echoing the call's shape."""
+
+    @staticmethod
+    def _make_call(out_width: int = 4) -> "type":
+        def make_call(call) -> torch.Tensor:
+            # Caller-layout output for one call: [1, rows, heads_slice, width].
+            return torch.full((1, call.row1 - call.row0, call.h1 - call.h0, out_width), call.row0)
+
+        return make_call
+
+    def test_reassembles_seq_and_head_axes(self) -> None:
+        plan = chunking.build_chunk_plan(
+            seq_len=256,
+            num_heads=4,
+            options=chunking.AttnChunkingOptions(q_chunk=2, head_chunk=2),
+            num_kv_heads=4,
+            kv_len=60000,
+            row_align=128,
+        )
+        out = chunking.run_chunked(plan, seq_dim=1, head_dim=2, make_call=self._make_call())
+        assert out.shape == (1, 256, 4, 4)
+        # Each row block is tagged with its row0: verifies both chunk order
+        # (seq axis) and head merge (head axis grew to full width).
+        assert torch.equal(out[0, :128, 0, 0], torch.full((128,), 0))
+        assert torch.equal(out[0, 128:, 0, 0], torch.full((128,), 128))
+
+    def test_single_call_plan_returns_make_call_result(self) -> None:
+        plan = chunking.build_chunk_plan(seq_len=64, num_heads=2, options=None)
+        out = chunking.run_chunked(plan, seq_dim=1, head_dim=2, make_call=self._make_call())
+        assert out.shape == (1, 64, 2, 4)
+
+    def test_q_chunk_only_reassembles_seq_axis(self) -> None:
+        plan = chunking.build_chunk_plan(
+            seq_len=10,
+            num_heads=2,
+            options=chunking.AttnChunkingOptions(q_chunk=3),
+        )
+        out = chunking.run_chunked(plan, seq_dim=1, head_dim=2, make_call=self._make_call())
+        assert out.shape == (1, 10, 2, 4)
+
+    def test_chunk_callback_consumes_per_q_chunk(self) -> None:
+        plan = chunking.build_chunk_plan(
+            seq_len=256,
+            num_heads=4,
+            options=chunking.AttnChunkingOptions(q_chunk=2, head_chunk=2),
+            num_kv_heads=4,
+            kv_len=60000,
+            row_align=128,
+        )
+        chunks: list[tuple[torch.Tensor, tuple[int, int]]] = []
+
+        def cb(out_chunk, call) -> None:
+            chunks.append((out_chunk, (call.row0, call.row1)))
+
+        result = chunking.run_chunked(
+            plan, seq_dim=1, head_dim=2, make_call=self._make_call(), chunk_callback=cb
+        )
+        assert result is None
+        # One head-merged chunk per q chunk, full head width each.
+        assert [tuple(t.shape) for t, _ in chunks] == [(1, 128, 4, 4)] * 2
+        assert [rows for _, rows in chunks] == [(0, 128), (128, 256)]
+
+    def test_empty_plan_raises(self) -> None:
+        with pytest.raises(ValueError, match="plan must not be empty"):
+            chunking.run_chunked([], seq_dim=1, head_dim=2, make_call=self._make_call())

--- a/tests/diffusion/attention/test_attn_chunking.py
+++ b/tests/diffusion/attention/test_attn_chunking.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Unit tests for the backend-neutral attention chunking scheduler.
 
 These tests load ``chunking`` from its source file via ``importlib`` (same
@@ -13,6 +13,7 @@ from __future__ import annotations
 import dataclasses
 import importlib.util
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from types import ModuleType
 
@@ -80,9 +81,7 @@ class TestBuildChunkPlan:
         assert _plan_calls(plan) == [(0, 128, 0, 4)]
 
     def test_default_options_yield_single_call(self) -> None:
-        plan = chunking.build_chunk_plan(
-            seq_len=128, num_heads=4, options=chunking.AttnChunkingOptions()
-        )
+        plan = chunking.build_chunk_plan(seq_len=128, num_heads=4, options=chunking.AttnChunkingOptions())
         assert _plan_calls(plan) == [(0, 128, 0, 4)]
 
     def test_q_chunk_even_split_aligned(self) -> None:
@@ -173,13 +172,9 @@ class TestBuildChunkPlan:
 
     def test_head_chunk_collapses_below_min_kv(self) -> None:
         options = chunking.AttnChunkingOptions(head_chunk=2, head_chunk_min_kv=50000)
-        short = chunking.build_chunk_plan(
-            seq_len=256, num_heads=4, options=options, num_kv_heads=4, kv_len=49999
-        )
+        short = chunking.build_chunk_plan(seq_len=256, num_heads=4, options=options, num_kv_heads=4, kv_len=49999)
         assert all(h1 - h0 == 4 for _, _, h0, h1 in _plan_calls(short))
-        long = chunking.build_chunk_plan(
-            seq_len=256, num_heads=4, options=options, num_kv_heads=4, kv_len=50000
-        )
+        long = chunking.build_chunk_plan(seq_len=256, num_heads=4, options=options, num_kv_heads=4, kv_len=50000)
         assert all(h1 - h0 == 2 for _, _, h0, h1 in _plan_calls(long))
 
     def test_min_kv_gate_leaves_q_chunking_alone(self) -> None:
@@ -260,7 +255,7 @@ class TestRunChunked:
     """Executor contract via a stub make_call echoing the call's shape."""
 
     @staticmethod
-    def _make_call(out_width: int = 4) -> "type":
+    def _make_call(out_width: int = 4) -> Callable[[object], torch.Tensor]:
         def make_call(call) -> torch.Tensor:
             # Caller-layout output for one call: [1, rows, heads_slice, width].
             return torch.full((1, call.row1 - call.row0, call.h1 - call.h0, out_width), call.row0)
@@ -311,9 +306,7 @@ class TestRunChunked:
         def cb(out_chunk, call) -> None:
             chunks.append((out_chunk, (call.row0, call.row1)))
 
-        result = chunking.run_chunked(
-            plan, seq_dim=1, head_dim=2, make_call=self._make_call(), chunk_callback=cb
-        )
+        result = chunking.run_chunked(plan, seq_dim=1, head_dim=2, make_call=self._make_call(), chunk_callback=cb)
         assert result is None
         # One head-merged chunk per q chunk, full head width each.
         assert [tuple(t.shape) for t, _ in chunks] == [(1, 128, 4, 4)] * 2

--- a/tests/diffusion/attention/test_flash_attn.py
+++ b/tests/diffusion/attention/test_flash_attn.py
@@ -730,7 +730,9 @@ def test_prefix_kv_slice_no_scaling_without_factor(monkeypatch):
     torch.testing.assert_close(out, torch.ones(1, 8, 2, 4))
 
 
-# --- Test group F: FP8 K/V-slice routing in forward_npu (MINDIESD_FP8_KV_SLICE) --
+# --- Test group F: FP8 K/V-slice routing in forward_npu ----------------------
+# The kv-slice path is the DEFAULT for packed FP8 inputs; MINDIESD_FP8_KV_SLICE
+# survives only as an escape hatch (explicitly falsy → unquantized).
 
 
 def _packed_extra(**overrides) -> dict:
@@ -746,7 +748,27 @@ def _packed_extra(**overrides) -> dict:
     return extra
 
 
-def test_npu_fp8_kv_slice_env_routes_to_slice_quant(monkeypatch):
+def test_npu_fp8_kv_slice_default_routes_to_slice_quant(monkeypatch):
+    monkeypatch.delenv("MINDIESD_FP8_KV_SLICE", raising=False)
+    _fake_mindiesd(monkeypatch)
+    impl = _npu_impl()
+    impl._forward_prefix_kv_slice_quant_npu = Mock(return_value=torch.tensor([5.0]))
+    impl.forward_fa_quant_npu = Mock(return_value=torch.tensor([4.0]))
+    impl.forward_fa_npu = Mock(return_value=torch.tensor([3.0]))
+    metadata = AttentionMetadata(extra=_packed_extra(kv_cache_dtype="fp8"))
+
+    out = impl.forward_npu(torch.randn(1, 8, 2, 4), *[torch.randn(1, 8, 2, 4)] * 2, metadata)
+
+    # No env needed anymore: dtype=fp8 + packed → kv-slice path.
+    impl._forward_prefix_kv_slice_quant_npu.assert_called_once()
+    impl.forward_fa_quant_npu.assert_not_called()
+    impl.forward_fa_npu.assert_not_called()
+    assert out.item() == 5.0
+
+
+def test_npu_fp8_kv_slice_env_truthy_keeps_slice_quant(monkeypatch):
+    # Legacy opt-in value is accepted but redundant: the default already runs
+    # the kv-slice path.
     monkeypatch.setenv("MINDIESD_FP8_KV_SLICE", "1")
     _fake_mindiesd(monkeypatch)
     impl = _npu_impl()
@@ -759,13 +781,13 @@ def test_npu_fp8_kv_slice_env_routes_to_slice_quant(monkeypatch):
 
     impl._forward_prefix_kv_slice_quant_npu.assert_called_once()
     impl.forward_fa_quant_npu.assert_not_called()
-    impl.forward_fa_npu.assert_not_called()
     assert out.item() == 5.0
 
 
-def test_npu_fp8_kv_slice_env_off_keeps_dense_quant(monkeypatch):
-    monkeypatch.delenv("MINDIESD_FP8_KV_SLICE", raising=False)
+@pytest.mark.parametrize("raw", ["0", "false", "off"])
+def test_npu_fp8_kv_slice_env_falsy_escapes_to_unquantized(monkeypatch, raw):
     _fake_mindiesd(monkeypatch)
+    monkeypatch.setenv("MINDIESD_FP8_KV_SLICE", raw)
     impl = _npu_impl()
     impl._forward_prefix_kv_slice_quant_npu = Mock(return_value=torch.tensor([5.0]))
     impl.forward_fa_quant_npu = Mock(return_value=torch.tensor([4.0]))
@@ -774,14 +796,16 @@ def test_npu_fp8_kv_slice_env_off_keeps_dense_quant(monkeypatch):
 
     out = impl.forward_npu(torch.randn(1, 8, 2, 4), *[torch.randn(1, 8, 2, 4)] * 2, metadata)
 
-    # The env is the opt-in: with it unset the dispatch is unchanged.
+    # Escape hatch: unquantized execution, never dense FP8 (it would cross
+    # packed document boundaries).
     impl._forward_prefix_kv_slice_quant_npu.assert_not_called()
-    impl.forward_fa_quant_npu.assert_called_once()
-    assert out.item() == 4.0
+    impl.forward_fa_quant_npu.assert_not_called()
+    impl.forward_fa_npu.assert_called_once()
+    assert out.item() == 3.0
 
 
 def test_npu_fp8_kv_slice_contract_failure_falls_back_unquantized(monkeypatch):
-    monkeypatch.setenv("MINDIESD_FP8_KV_SLICE", "1")
+    monkeypatch.delenv("MINDIESD_FP8_KV_SLICE", raising=False)
     _fake_mindiesd(monkeypatch)
     impl = _npu_impl()
     impl._forward_prefix_kv_slice_quant_npu = Mock(return_value=None)
@@ -805,13 +829,14 @@ def test_npu_fp8_kv_slice_single_call(monkeypatch):
 
     captured: dict = {}
 
-    def fake_kv_slice(q, k, v, kv_len, *, layout, softmax_scale=None):
+    def fake_kv_slice(q, k, v, kv_len, *, layout, softmax_scale=None, plan=None, chunk_callback=None):
         captured.update(
             q_shape=tuple(q.shape),
             k_shape=tuple(k.shape),
             kv_len=kv_len,
             layout=layout,
             softmax_scale=softmax_scale,
+            plan=plan,
         )
         return torch.zeros(q.shape)
 
@@ -826,7 +851,67 @@ def test_npu_fp8_kv_slice_single_call(monkeypatch):
     assert captured["kv_len"] == 5
     assert captured["layout"] == "BSND"
     assert captured["softmax_scale"] == pytest.approx(0.5)
+    # No chunking options in extra → no plan (single wide call).
+    assert captured["plan"] is None
     assert out.shape == (1, 8, 2, 4)
+
+
+def test_npu_fp8_kv_slice_builds_chunk_plan_from_extra(monkeypatch):
+    """Layer-injected options drive a chunk plan built at the call site."""
+    _fake_mindiesd(monkeypatch)
+    import vllm_omni.platforms.npu.quant.kv_quant_npu as kv_quant_npu
+    from vllm_omni.diffusion.attention.chunking import AttnChunkingOptions
+
+    captured: dict = {}
+
+    def fake_kv_slice(q, k, v, kv_len, *, layout, softmax_scale=None, plan=None, chunk_callback=None):
+        captured.update(kv_len=kv_len, plan=plan)
+        return torch.zeros(q.shape)
+
+    monkeypatch.setattr(kv_quant_npu, "fp8_rotate_quant_kv_slice", fake_kv_slice)
+    impl = _npu_impl()
+    q = torch.randn(1, 256, 2, 4)
+    cu = torch.tensor([0, 200, 256], dtype=torch.int32)
+    extra = {
+        "cu_seqlens_q": cu,
+        "cu_seqlens_k": cu,
+        "max_seqlen_q": 200,
+        "max_seqlen_k": 200,
+        "npu_attn_varlen": True,
+        "attn_chunking": AttnChunkingOptions(q_chunk=2, head_chunk=1, head_chunk_min_kv=0),
+    }
+
+    impl._forward_prefix_kv_slice_quant_npu(q, q, q, extra)
+
+    # q-chunk-major / head-minor plan over the 128-row quant grid, against
+    # the resolved kv prefix.
+    assert captured["kv_len"] == 200
+    assert [(c.row0, c.row1, c.h0, c.h1) for c in captured["plan"]] == [
+        (0, 128, 0, 1),
+        (0, 128, 1, 2),
+        (128, 256, 0, 1),
+        (128, 256, 1, 2),
+    ]
+
+
+def test_npu_fp8_nonpacked_with_chunking_warns_and_ignores(monkeypatch):
+    """Non-packed FP8 (dense layouts) has no chunking support: the knobs are
+    ignored with a warning and dense quant still runs."""
+    _fake_mindiesd(monkeypatch)
+    from vllm_omni.diffusion.attention.chunking import AttnChunkingOptions
+
+    impl = _npu_impl()
+    impl.forward_fa_quant_npu = Mock(return_value=torch.tensor([4.0]))
+    impl.forward_fa_npu = Mock(return_value=torch.tensor([3.0]))
+    metadata = AttentionMetadata(
+        extra={"kv_cache_dtype": "fp8", "attn_chunking": AttnChunkingOptions(q_chunk=8)}
+    )
+
+    out = impl.forward_npu(torch.randn(1, 8, 2, 4), *[torch.randn(1, 8, 2, 4)] * 2, metadata)
+
+    impl.forward_fa_quant_npu.assert_called_once()
+    impl.forward_fa_npu.assert_not_called()
+    assert out.item() == 4.0
 
 
 def test_npu_fp8_kv_slice_contract_failure_returns_none(monkeypatch):

--- a/tests/diffusion/attention/test_flash_attn.py
+++ b/tests/diffusion/attention/test_flash_attn.py
@@ -731,8 +731,9 @@ def test_prefix_kv_slice_no_scaling_without_factor(monkeypatch):
 
 
 # --- Test group F: FP8 K/V-slice routing in forward_npu ----------------------
-# The kv-slice path is the DEFAULT for packed FP8 inputs; MINDIESD_FP8_KV_SLICE
-# survives only as an escape hatch (explicitly falsy → unquantized).
+# The kv-slice path is the DEFAULT for packed FP8 inputs. The legacy
+# MINDIESD_FP8_KV_SLICE opt-in env is obsolete and ignored; run without
+# --diffusion-kv-cache-dtype fp8 to get unquantized execution.
 
 
 def _packed_extra(**overrides) -> dict:
@@ -749,7 +750,6 @@ def _packed_extra(**overrides) -> dict:
 
 
 def test_npu_fp8_kv_slice_default_routes_to_slice_quant(monkeypatch):
-    monkeypatch.delenv("MINDIESD_FP8_KV_SLICE", raising=False)
     _fake_mindiesd(monkeypatch)
     impl = _npu_impl()
     impl._forward_prefix_kv_slice_quant_npu = Mock(return_value=torch.tensor([5.0]))
@@ -759,53 +759,14 @@ def test_npu_fp8_kv_slice_default_routes_to_slice_quant(monkeypatch):
 
     out = impl.forward_npu(torch.randn(1, 8, 2, 4), *[torch.randn(1, 8, 2, 4)] * 2, metadata)
 
-    # No env needed anymore: dtype=fp8 + packed → kv-slice path.
+    # dtype=fp8 + packed → kv-slice path, no env needed.
     impl._forward_prefix_kv_slice_quant_npu.assert_called_once()
     impl.forward_fa_quant_npu.assert_not_called()
     impl.forward_fa_npu.assert_not_called()
     assert out.item() == 5.0
 
 
-def test_npu_fp8_kv_slice_env_truthy_keeps_slice_quant(monkeypatch):
-    # Legacy opt-in value is accepted but redundant: the default already runs
-    # the kv-slice path.
-    monkeypatch.setenv("MINDIESD_FP8_KV_SLICE", "1")
-    _fake_mindiesd(monkeypatch)
-    impl = _npu_impl()
-    impl._forward_prefix_kv_slice_quant_npu = Mock(return_value=torch.tensor([5.0]))
-    impl.forward_fa_quant_npu = Mock(return_value=torch.tensor([4.0]))
-    impl.forward_fa_npu = Mock(return_value=torch.tensor([3.0]))
-    metadata = AttentionMetadata(extra=_packed_extra(kv_cache_dtype="fp8"))
-
-    out = impl.forward_npu(torch.randn(1, 8, 2, 4), *[torch.randn(1, 8, 2, 4)] * 2, metadata)
-
-    impl._forward_prefix_kv_slice_quant_npu.assert_called_once()
-    impl.forward_fa_quant_npu.assert_not_called()
-    assert out.item() == 5.0
-
-
-@pytest.mark.parametrize("raw", ["0", "false", "off"])
-def test_npu_fp8_kv_slice_env_falsy_escapes_to_unquantized(monkeypatch, raw):
-    _fake_mindiesd(monkeypatch)
-    monkeypatch.setenv("MINDIESD_FP8_KV_SLICE", raw)
-    impl = _npu_impl()
-    impl._forward_prefix_kv_slice_quant_npu = Mock(return_value=torch.tensor([5.0]))
-    impl.forward_fa_quant_npu = Mock(return_value=torch.tensor([4.0]))
-    impl.forward_fa_npu = Mock(return_value=torch.tensor([3.0]))
-    metadata = AttentionMetadata(extra=_packed_extra(kv_cache_dtype="fp8"))
-
-    out = impl.forward_npu(torch.randn(1, 8, 2, 4), *[torch.randn(1, 8, 2, 4)] * 2, metadata)
-
-    # Escape hatch: unquantized execution, never dense FP8 (it would cross
-    # packed document boundaries).
-    impl._forward_prefix_kv_slice_quant_npu.assert_not_called()
-    impl.forward_fa_quant_npu.assert_not_called()
-    impl.forward_fa_npu.assert_called_once()
-    assert out.item() == 3.0
-
-
 def test_npu_fp8_kv_slice_contract_failure_falls_back_unquantized(monkeypatch):
-    monkeypatch.delenv("MINDIESD_FP8_KV_SLICE", raising=False)
     _fake_mindiesd(monkeypatch)
     impl = _npu_impl()
     impl._forward_prefix_kv_slice_quant_npu = Mock(return_value=None)

--- a/tests/diffusion/attention/test_flash_attn.py
+++ b/tests/diffusion/attention/test_flash_attn.py
@@ -730,6 +730,113 @@ def test_prefix_kv_slice_no_scaling_without_factor(monkeypatch):
     torch.testing.assert_close(out, torch.ones(1, 8, 2, 4))
 
 
+# --- Test group F: FP8 K/V-slice routing in forward_npu (MINDIESD_FP8_KV_SLICE) --
+
+
+def _packed_extra(**overrides) -> dict:
+    cu = torch.tensor([0, 5, 8], dtype=torch.int32)
+    extra = {
+        "cu_seqlens_q": cu,
+        "cu_seqlens_k": cu,
+        "max_seqlen_q": 5,
+        "max_seqlen_k": 5,
+        "npu_attn_varlen": True,
+    }
+    extra.update(overrides)
+    return extra
+
+
+def test_npu_fp8_kv_slice_env_routes_to_slice_quant(monkeypatch):
+    monkeypatch.setenv("MINDIESD_FP8_KV_SLICE", "1")
+    _fake_mindiesd(monkeypatch)
+    impl = _npu_impl()
+    impl._forward_prefix_kv_slice_quant_npu = Mock(return_value=torch.tensor([5.0]))
+    impl.forward_fa_quant_npu = Mock(return_value=torch.tensor([4.0]))
+    impl.forward_fa_npu = Mock(return_value=torch.tensor([3.0]))
+    metadata = AttentionMetadata(extra=_packed_extra(kv_cache_dtype="fp8"))
+
+    out = impl.forward_npu(torch.randn(1, 8, 2, 4), *[torch.randn(1, 8, 2, 4)] * 2, metadata)
+
+    impl._forward_prefix_kv_slice_quant_npu.assert_called_once()
+    impl.forward_fa_quant_npu.assert_not_called()
+    impl.forward_fa_npu.assert_not_called()
+    assert out.item() == 5.0
+
+
+def test_npu_fp8_kv_slice_env_off_keeps_dense_quant(monkeypatch):
+    monkeypatch.delenv("MINDIESD_FP8_KV_SLICE", raising=False)
+    _fake_mindiesd(monkeypatch)
+    impl = _npu_impl()
+    impl._forward_prefix_kv_slice_quant_npu = Mock(return_value=torch.tensor([5.0]))
+    impl.forward_fa_quant_npu = Mock(return_value=torch.tensor([4.0]))
+    impl.forward_fa_npu = Mock(return_value=torch.tensor([3.0]))
+    metadata = AttentionMetadata(extra=_packed_extra(kv_cache_dtype="fp8"))
+
+    out = impl.forward_npu(torch.randn(1, 8, 2, 4), *[torch.randn(1, 8, 2, 4)] * 2, metadata)
+
+    # The env is the opt-in: with it unset the dispatch is unchanged.
+    impl._forward_prefix_kv_slice_quant_npu.assert_not_called()
+    impl.forward_fa_quant_npu.assert_called_once()
+    assert out.item() == 4.0
+
+
+def test_npu_fp8_kv_slice_contract_failure_falls_back_unquantized(monkeypatch):
+    monkeypatch.setenv("MINDIESD_FP8_KV_SLICE", "1")
+    _fake_mindiesd(monkeypatch)
+    impl = _npu_impl()
+    impl._forward_prefix_kv_slice_quant_npu = Mock(return_value=None)
+    impl.forward_fa_npu = Mock(return_value=torch.tensor([3.0]))
+    impl.forward_fa_quant_npu = Mock(return_value=torch.tensor([4.0]))
+    metadata = AttentionMetadata(extra=_packed_extra(kv_cache_dtype="fp8"))
+
+    out = impl.forward_npu(torch.randn(1, 8, 2, 4), *[torch.randn(1, 8, 2, 4)] * 2, metadata)
+
+    # Dense FP8 must not run: it would ignore document boundaries.
+    impl.forward_fa_quant_npu.assert_not_called()
+    impl.forward_fa_npu.assert_called_once()
+    assert out.item() == 3.0
+
+
+def test_npu_fp8_kv_slice_single_call(monkeypatch):
+    """The backend resolves boundaries and forwards q/k/v unsliced (BSND);
+    the quant wrapper slices K/V to the valid prefix itself."""
+    _fake_mindiesd(monkeypatch)
+    import vllm_omni.platforms.npu.quant.kv_quant_npu as kv_quant_npu
+
+    captured: dict = {}
+
+    def fake_kv_slice(q, k, v, kv_len, *, layout, softmax_scale=None):
+        captured.update(
+            q_shape=tuple(q.shape),
+            k_shape=tuple(k.shape),
+            kv_len=kv_len,
+            layout=layout,
+            softmax_scale=softmax_scale,
+        )
+        return torch.zeros(q.shape)
+
+    monkeypatch.setattr(kv_quant_npu, "fp8_rotate_quant_kv_slice", fake_kv_slice)
+    impl = _npu_impl()
+    q = torch.randn(1, 8, 2, 4)
+
+    out = impl._forward_prefix_kv_slice_quant_npu(q, q, q, _packed_extra())
+
+    assert captured["q_shape"] == (1, 8, 2, 4)
+    assert captured["k_shape"] == (1, 8, 2, 4)  # unsliced; slicing is the wrapper's job
+    assert captured["kv_len"] == 5
+    assert captured["layout"] == "BSND"
+    assert captured["softmax_scale"] == pytest.approx(0.5)
+    assert out.shape == (1, 8, 2, 4)
+
+
+def test_npu_fp8_kv_slice_contract_failure_returns_none(monkeypatch):
+    _fake_mindiesd(monkeypatch)
+    impl = _npu_impl()
+    q = torch.randn(1, 8, 2, 4)
+    # No packed metadata at all -> contract cannot hold.
+    assert impl._forward_prefix_kv_slice_quant_npu(q, q, q, {"npu_attn_varlen": True}) is None
+
+
 if __name__ == "__main__":
     print("Running FlashAttention Padding Tests...")
     print("=" * 60)

--- a/tests/diffusion/attention/test_flash_attn.py
+++ b/tests/diffusion/attention/test_flash_attn.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 """
 Test script for FlashAttention backend with padding handling.
@@ -903,9 +903,7 @@ def test_npu_fp8_nonpacked_with_chunking_warns_and_ignores(monkeypatch):
     impl = _npu_impl()
     impl.forward_fa_quant_npu = Mock(return_value=torch.tensor([4.0]))
     impl.forward_fa_npu = Mock(return_value=torch.tensor([3.0]))
-    metadata = AttentionMetadata(
-        extra={"kv_cache_dtype": "fp8", "attn_chunking": AttnChunkingOptions(q_chunk=8)}
-    )
+    metadata = AttentionMetadata(extra={"kv_cache_dtype": "fp8", "attn_chunking": AttnChunkingOptions(q_chunk=8)})
 
     out = impl.forward_npu(torch.randn(1, 8, 2, 4), *[torch.randn(1, 8, 2, 4)] * 2, metadata)
 

--- a/tests/diffusion/test_diffusion_config_fields.py
+++ b/tests/diffusion/test_diffusion_config_fields.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Ensure diffusion stage YAML configs only use valid OmniDiffusionConfig fields.
 
 Regression test for https://github.com/vllm-project/vllm-omni/issues/2563
@@ -66,3 +66,57 @@ def test_diffusion_stage_configs_only_contain_valid_fields():
     assert not invalid_entries, "Diffusion stage configs contain fields not in OmniDiffusionConfig:\n" + "\n".join(
         f"  {name}: {sorted(bad)}" for name, bad in invalid_entries
     )
+
+
+@pytest.mark.skipif(
+    OmniDiffusionConfig is None,
+    reason="OmniDiffusionConfig could not be imported (missing torch?)",
+)
+class TestAttnChunkingValidation:
+    """Chunking knobs must fail fast when they cannot take effect.
+
+    Built via ``__new__`` with only the attributes _validate_attn_chunking
+    reads: the full __post_init__ (port probing, HF metadata) is unrelated
+    to this validation.
+    """
+
+    @staticmethod
+    def _bare(**overrides):
+        config = OmniDiffusionConfig.__new__(OmniDiffusionConfig)
+        config.diffusion_kv_cache_dtype = None
+        config.diffusion_attn_q_chunk = 1
+        config.diffusion_attn_head_chunk = 0
+        config.diffusion_attn_head_chunk_min_kv = 50000
+        for key, value in overrides.items():
+            setattr(config, key, value)
+        return config
+
+    def test_defaults_pass(self):
+        self._bare()._validate_attn_chunking()  # no raise
+
+    def test_chunking_with_fp8_passes(self):
+        self._bare(
+            diffusion_kv_cache_dtype="fp8", diffusion_attn_q_chunk=8, diffusion_attn_head_chunk=2
+        )._validate_attn_chunking()  # no raise
+
+    def test_chunking_without_fp8_is_rejected(self):
+        with pytest.raises(ValueError, match="require.*diffusion_kv_cache_dtype='fp8'"):
+            self._bare(diffusion_attn_q_chunk=8)._validate_attn_chunking()
+
+        with pytest.raises(ValueError, match="require.*diffusion_kv_cache_dtype='fp8'"):
+            self._bare(diffusion_attn_head_chunk=2)._validate_attn_chunking()
+
+        with pytest.raises(ValueError, match="require.*diffusion_kv_cache_dtype='fp8'"):
+            self._bare(diffusion_attn_head_chunk_min_kv=60000)._validate_attn_chunking()
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("diffusion_attn_q_chunk", 0),
+            ("diffusion_attn_head_chunk", -1),
+            ("diffusion_attn_head_chunk_min_kv", -1),
+        ],
+    )
+    def test_out_of_range_values_are_rejected(self, field: str, value: int):
+        with pytest.raises(ValueError, match=field.replace("diffusion_attn_", "")):
+            self._bare(diffusion_kv_cache_dtype="fp8", **{field: value})._validate_attn_chunking()

--- a/tests/platforms/npu/quant/test_kv_quant_npu.py
+++ b/tests/platforms/npu/quant/test_kv_quant_npu.py
@@ -95,20 +95,6 @@ def test_is_quantized_kv_cache() -> None:
     assert not kv_quant_npu.is_quantized_kv_cache("int8")
 
 
-def test_fp8_kv_slice_disabled_by_env_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    # The kv-slice path is the DEFAULT for packed FP8: unset keeps it on.
-    monkeypatch.delenv("MINDIESD_FP8_KV_SLICE", raising=False)
-    assert not kv_quant_npu.fp8_kv_slice_disabled_by_env()
-    # Explicitly falsy values are the operations escape hatch.
-    for raw in ("0", "false", "no", "off"):
-        monkeypatch.setenv("MINDIESD_FP8_KV_SLICE", raw)
-        assert kv_quant_npu.fp8_kv_slice_disabled_by_env(), raw
-    # Truthy (legacy opt-in) and unrecognized values keep the default.
-    for raw in ("1", "true", "yes", "on", "banana"):
-        monkeypatch.setenv("MINDIESD_FP8_KV_SLICE", raw)
-        assert not kv_quant_npu.fp8_kv_slice_disabled_by_env(), raw
-
-
 class TestKVQuantNPUUnit:
     @pytest.fixture(autouse=True)
     def clear_rot_cache(self):

--- a/tests/platforms/npu/quant/test_kv_quant_npu.py
+++ b/tests/platforms/npu/quant/test_kv_quant_npu.py
@@ -67,6 +67,17 @@ def test_is_quantized_kv_cache() -> None:
     assert not kv_quant_npu.is_quantized_kv_cache("int8")
 
 
+def test_fp8_kv_slice_enabled_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MINDIESD_FP8_KV_SLICE", raising=False)
+    assert not kv_quant_npu.fp8_kv_slice_enabled()
+    monkeypatch.setenv("MINDIESD_FP8_KV_SLICE", "1")
+    assert kv_quant_npu.fp8_kv_slice_enabled()
+    monkeypatch.setenv("MINDIESD_FP8_KV_SLICE", "true")
+    assert kv_quant_npu.fp8_kv_slice_enabled()
+    monkeypatch.setenv("MINDIESD_FP8_KV_SLICE", "0")
+    assert not kv_quant_npu.fp8_kv_slice_enabled()
+
+
 class TestKVQuantNPUUnit:
     @pytest.fixture(autouse=True)
     def clear_rot_cache(self):
@@ -99,6 +110,7 @@ class TestKVQuantNPUUnit:
     def fake_quant_ops(self, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
         captured: dict[str, Any] = {
             "fa_calls": [],
+            "fia_calls": [],
             "npu_kwargs": None,
             "out_shape": None,
         }
@@ -113,6 +125,24 @@ class TestKVQuantNPUUnit:
                 out_shape = captured["out_shape"]
                 return (torch.ones(out_shape, dtype=torch.float32),)
 
+        def fake_fia_v2(q, k, v, **kwargs):
+            captured["fia_calls"].append(
+                {
+                    "q_shape": tuple(q.shape),
+                    "k_shape": tuple(k.shape),
+                    "v_shape": tuple(v.shape),
+                    "kwargs": kwargs,
+                }
+            )
+            captured["npu_kwargs"] = kwargs
+            out_dtype = kwargs.get("out_dtype") or torch.float32
+            out_shape = captured["out_shape"]
+            if out_shape is not None:
+                return (torch.ones(out_shape, dtype=out_dtype),)
+            # Default: echo q (FIA output has q's shape), so dispatch contract
+            # tests can rely on the wrapper's own trim/transpose logic.
+            return (q.to(out_dtype),)
+
         def fake_fa_block_quant_preprocess(x, block_size, dst_type, layout):
             captured["fa_calls"].append(
                 {
@@ -122,7 +152,16 @@ class TestKVQuantNPUUnit:
                     "shape": tuple(x.shape),
                 }
             )
-            scale = torch.full((1,), float(block_size), dtype=torch.float32)
+            # Mirror the real kernel contract: BSND inputs are transposed
+            # before quantization, so the returned tensor is ALWAYS
+            # BNSD-logical [B, N, S, D] and the scale is per (head, row-block):
+            # [B, N, ceil(S / block_size), ceil(D / 128)].
+            if layout == "BSND":
+                x = x.transpose(1, 2)
+            x = x.contiguous()
+            b, n, s, _d = x.shape
+            blocks = -(-s // block_size)
+            scale = torch.ones(b, n, blocks, 1, dtype=torch.float32)
             return x, scale
 
         fake_qua_rot_mode = SimpleNamespace(HADAMARD="hadamard")
@@ -135,7 +174,7 @@ class TestKVQuantNPUUnit:
         monkeypatch.setattr(
             kv_quant_npu,
             "_load_quant_ops",
-            lambda: (FakeTorchNPU, fake_fa_block_quant_preprocess, fake_qua_rot_mode, fake_create_rot),
+            lambda: (FakeTorchNPU, fake_fia_v2, fake_fa_block_quant_preprocess, fake_qua_rot_mode, fake_create_rot),
         )
 
         return captured
@@ -186,6 +225,72 @@ class TestKVQuantNPUUnit:
         with pytest.raises(ValueError, match="unsupported layout"):
             kv_quant_npu.fp8_rotate_quant_fa(query, key, value, layout="INVALID")
 
+    @pytest.mark.parametrize(
+        "layout,input_shape,fia_out_shape,expected_quant_shapes",
+        [
+            # Quant always returns BNSD-logical tensors, so the FIA output is
+            # BNSD too; the wrapper transposes back to the caller's layout.
+            ("BSND", (1, 8, 2, 4), (1, 2, 8, 4), [(1, 8, 2, 4), (1, 5, 2, 4), (1, 5, 2, 4)]),
+            ("BNSD", (1, 2, 8, 4), (1, 2, 8, 4), [(1, 2, 8, 4), (1, 2, 5, 4), (1, 2, 5, 4)]),
+        ],
+    )
+    def test_fp8_rotate_quant_kv_slice_dense_contract(
+        self,
+        fake_quant_ops: dict[str, Any],
+        layout: str,
+        input_shape: tuple[int, int, int, int],
+        fia_out_shape: tuple[int, int, int, int],
+        expected_quant_shapes: list[tuple[int, int, int, int]],
+    ) -> None:
+        query, key, value = self._make_qkv(input_shape)
+        fake_quant_ops["out_shape"] = fia_out_shape
+
+        out = kv_quant_npu.fp8_rotate_quant_kv_slice(query, key, value, 5, layout=layout, softmax_scale=0.125)
+
+        assert out.shape == query.shape
+        # Q is quantized at full length; K/V are sliced to kv_len BEFORE quant.
+        assert [call["shape"] for call in fake_quant_ops["fa_calls"]] == expected_quant_shapes
+        assert [call["layout"] for call in fake_quant_ops["fa_calls"]] == [layout] * 3
+        assert [call["block_size"] for call in fake_quant_ops["fa_calls"]] == [128, 256, 256]
+        # Single dense FIA call.
+        assert len(fake_quant_ops["fia_calls"]) == 1
+        kwargs = fake_quant_ops["npu_kwargs"]
+        # Quant output is always BNSD-logical, so the FIA dispatch is BNSD
+        # regardless of the caller-facing layout.
+        assert kwargs["input_layout"] == "BNSD"
+        # Dense dispatch: the FIA varlen feature stays off.
+        assert "actual_seq_qlen" not in kwargs
+        assert "actual_seq_kvlen" not in kwargs
+        assert kwargs["query_quant_mode"] == 7
+        assert kwargs["key_quant_mode"] == 7
+        assert kwargs["value_quant_mode"] == 7
+        assert kwargs["softmax_scale"] == 0.125
+        expected_heads = input_shape[1] if layout == "BNSD" else input_shape[2]
+        assert kwargs["num_query_heads"] == expected_heads
+        assert kwargs["num_key_value_heads"] == expected_heads
+
+    def test_fp8_rotate_quant_kv_slice_full_length_kv_is_noop_slice(self, fake_quant_ops) -> None:
+        query, key, value = self._make_qkv((1, 8, 2, 4))
+        fake_quant_ops["out_shape"] = (1, 2, 8, 4)  # FIA output is BNSD-logical
+
+        out = kv_quant_npu.fp8_rotate_quant_kv_slice(query, key, value, 8, layout="BSND")
+
+        assert out.shape == query.shape
+        assert [call["shape"] for call in fake_quant_ops["fa_calls"]] == [(1, 8, 2, 4)] * 3
+
+    @pytest.mark.parametrize("kv_len", [0, -1, 9, 5.0])
+    def test_fp8_rotate_quant_kv_slice_invalid_kv_len_raises(self, fake_quant_ops, kv_len) -> None:
+        query, key, value = self._make_qkv((1, 8, 2, 4))
+
+        with pytest.raises(ValueError, match="kv_len"):
+            kv_quant_npu.fp8_rotate_quant_kv_slice(query, key, value, kv_len, layout="BSND")
+
+    def test_fp8_rotate_quant_kv_slice_invalid_layout_raises(self, fake_quant_ops) -> None:
+        query, key, value = self._make_qkv((1, 8, 2, 4))
+
+        with pytest.raises(ValueError, match="unsupported layout"):
+            kv_quant_npu.fp8_rotate_quant_kv_slice(query, key, value, 5, layout="INVALID")
+
 
 @npu_smoke
 class TestKVQuantNPUSmoke:
@@ -203,5 +308,20 @@ class TestKVQuantNPUSmoke:
         value = torch.randn(1, 2, 4, 64, dtype=torch.float16, device="npu")
 
         out = kv_quant_npu.fp8_rotate_quant_fa(query, key, value, layout="BNSD")
+        assert out.shape == query.shape
+        assert out.dtype == query.dtype
+
+    def test_fp8_rotate_quant_kv_slice_real_npu_shape_contract(self):
+        try:
+            kv_quant_npu._load_quant_ops.cache_clear()
+            kv_quant_npu._load_quant_ops()
+        except ImportError:
+            pytest.skip("NPU quant dependencies are not fully installed.")
+
+        query = torch.randn(1, 8, 2, 64, dtype=torch.float16, device="npu")
+        key = torch.randn(1, 8, 2, 64, dtype=torch.float16, device="npu")
+        value = torch.randn(1, 8, 2, 64, dtype=torch.float16, device="npu")
+
+        out = kv_quant_npu.fp8_rotate_quant_kv_slice(query, key, value, 5, layout="BSND")
         assert out.shape == query.shape
         assert out.dtype == query.dtype

--- a/tests/platforms/npu/quant/test_kv_quant_npu.py
+++ b/tests/platforms/npu/quant/test_kv_quant_npu.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Unit tests for NPU FP8 KV quantization helpers.
 
 These tests load ``kv_quant_npu`` from its source file via ``importlib`` so
@@ -335,7 +335,9 @@ class TestKVQuantNPUUnit:
         num_kv_heads: int | None = None,
     ) -> list:
         options = chunking.AttnChunkingOptions(
-            q_chunk=q_chunk, head_chunk=head_chunk, head_chunk_min_kv=0  # gate off in tests
+            q_chunk=q_chunk,
+            head_chunk=head_chunk,
+            head_chunk_min_kv=0,  # gate off in tests
         )
         return chunking.build_chunk_plan(
             seq_len=seq_len,

--- a/tests/platforms/npu/quant/test_kv_quant_npu.py
+++ b/tests/platforms/npu/quant/test_kv_quant_npu.py
@@ -50,6 +50,34 @@ def _load_kv_quant_npu() -> ModuleType:
 kv_quant_npu = _load_kv_quant_npu()
 
 
+def _load_chunking() -> ModuleType:
+    """Load the framework-level chunking scheduler standalone (same pattern).
+
+    The FIA adapter consumes its plan duck-typed (no runtime import), so the
+    plan objects used here double as an interop check that a real ChunkCall
+    sequence drives the chunked dispatch.
+    """
+    import sys
+
+    path = _repo_root() / "vllm_omni" / "diffusion" / "attention" / "chunking.py"
+    name = "vllm_omni_test_chunking_standalone"
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        msg = f"cannot load import spec for {path}"
+        raise RuntimeError(msg)
+    mod = importlib.util.module_from_spec(spec)
+    # Register before exec: dataclass KW_ONLY detection looks the module up
+    # in sys.modules and crashes on a missing entry.
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+chunking = _load_chunking()
+
+
 def _npu_smoke_available() -> bool:
     try:
         import torch_npu  # noqa: F401
@@ -67,15 +95,18 @@ def test_is_quantized_kv_cache() -> None:
     assert not kv_quant_npu.is_quantized_kv_cache("int8")
 
 
-def test_fp8_kv_slice_enabled_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_fp8_kv_slice_disabled_by_env_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The kv-slice path is the DEFAULT for packed FP8: unset keeps it on.
     monkeypatch.delenv("MINDIESD_FP8_KV_SLICE", raising=False)
-    assert not kv_quant_npu.fp8_kv_slice_enabled()
-    monkeypatch.setenv("MINDIESD_FP8_KV_SLICE", "1")
-    assert kv_quant_npu.fp8_kv_slice_enabled()
-    monkeypatch.setenv("MINDIESD_FP8_KV_SLICE", "true")
-    assert kv_quant_npu.fp8_kv_slice_enabled()
-    monkeypatch.setenv("MINDIESD_FP8_KV_SLICE", "0")
-    assert not kv_quant_npu.fp8_kv_slice_enabled()
+    assert not kv_quant_npu.fp8_kv_slice_disabled_by_env()
+    # Explicitly falsy values are the operations escape hatch.
+    for raw in ("0", "false", "no", "off"):
+        monkeypatch.setenv("MINDIESD_FP8_KV_SLICE", raw)
+        assert kv_quant_npu.fp8_kv_slice_disabled_by_env(), raw
+    # Truthy (legacy opt-in) and unrecognized values keep the default.
+    for raw in ("1", "true", "yes", "on", "banana"):
+        monkeypatch.setenv("MINDIESD_FP8_KV_SLICE", raw)
+        assert not kv_quant_npu.fp8_kv_slice_disabled_by_env(), raw
 
 
 class TestKVQuantNPUUnit:
@@ -290,6 +321,133 @@ class TestKVQuantNPUUnit:
 
         with pytest.raises(ValueError, match="unsupported layout"):
             kv_quant_npu.fp8_rotate_quant_kv_slice(query, key, value, 5, layout="INVALID")
+
+    # --- Chunked dispatch (plan from the generic chunking scheduler) -------
+
+    @staticmethod
+    def _chunk_plan(
+        seq_len: int,
+        num_heads: int,
+        kv_len: int,
+        *,
+        q_chunk: int = 1,
+        head_chunk: int = 0,
+        num_kv_heads: int | None = None,
+    ) -> list:
+        options = chunking.AttnChunkingOptions(
+            q_chunk=q_chunk, head_chunk=head_chunk, head_chunk_min_kv=0  # gate off in tests
+        )
+        return chunking.build_chunk_plan(
+            seq_len=seq_len,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads if num_kv_heads is not None else num_heads,
+            kv_len=kv_len,
+            options=options,
+            row_align=kv_quant_npu._Q_BLOCK_SIZE,
+        )
+
+    def test_kv_slice_plan_splits_fia_calls_and_reassembles(self, fake_quant_ops) -> None:
+        # BSND [1, T=256, N=2, D=4]; q_chunk=2 + head_chunk=1 → 2 q chunks x
+        # 2 head slices = 4 FIA calls over one shared quantization.
+        query, key, value = self._make_qkv((1, 256, 2, 4))
+        plan = self._chunk_plan(256, 2, 200, q_chunk=2, head_chunk=1)
+
+        out = kv_quant_npu.fp8_rotate_quant_kv_slice(
+            query, key, value, 200, layout="BSND", softmax_scale=0.125, plan=plan
+        )
+
+        assert out.shape == query.shape
+        # Quantization happens ONCE regardless of the plan.
+        assert len(fake_quant_ops["fa_calls"]) == 3
+        assert len(fake_quant_ops["fia_calls"]) == 4
+        for call in fake_quant_ops["fia_calls"]:
+            # Each dispatch: BNSD q slice (1, head_slice, 128, 4) against the
+            # materialized K/V head part (1, head_slice, kv_len=200, 4).
+            assert call["q_shape"] == (1, 1, 128, 4)
+            assert call["k_shape"] == (1, 1, 200, 4)
+            kwargs = call["kwargs"]
+            assert kwargs["num_query_heads"] == 1
+            assert kwargs["num_key_value_heads"] == 1
+            assert kwargs["input_layout"] == "BNSD"
+            # Exact block range of the full-length quantization: one 128-row
+            # block per chunk.
+            assert kwargs["dequant_scale_query"].shape == (1, 1, 1, 1)
+
+    def test_kv_slice_plan_qchunk_only_keeps_full_heads(self, fake_quant_ops) -> None:
+        query, key, value = self._make_qkv((1, 256, 2, 4))
+        plan = self._chunk_plan(256, 2, 200, q_chunk=2)
+
+        out = kv_quant_npu.fp8_rotate_quant_kv_slice(query, key, value, 200, layout="BSND", plan=plan)
+
+        assert out.shape == query.shape
+        assert len(fake_quant_ops["fia_calls"]) == 2
+        for call in fake_quant_ops["fia_calls"]:
+            assert call["q_shape"] == (1, 2, 128, 4)
+            # No head chunking: the real GQA kv head count is passed through.
+            assert call["kwargs"]["num_query_heads"] == 2
+            assert call["kwargs"]["num_key_value_heads"] == 2
+
+    def test_kv_slice_plan_ragged_tail_chunk(self, fake_quant_ops) -> None:
+        # 200 rows with 128-block alignment → chunks (0,128) and (128,200).
+        query, key, value = self._make_qkv((1, 200, 2, 4))
+        plan = self._chunk_plan(200, 2, 200, q_chunk=2)
+
+        out = kv_quant_npu.fp8_rotate_quant_kv_slice(query, key, value, 200, layout="BSND", plan=plan)
+
+        assert out.shape == query.shape
+        shapes = [call["q_shape"] for call in fake_quant_ops["fia_calls"]]
+        assert shapes == [(1, 2, 128, 4), (1, 2, 72, 4)]
+
+    def test_kv_slice_plan_single_call_matches_no_plan(self, fake_quant_ops) -> None:
+        query, key, value = self._make_qkv((1, 256, 2, 4))
+        single = [chunking.ChunkCall(0, 256, 0, 2)]
+
+        out_plan = kv_quant_npu.fp8_rotate_quant_kv_slice(query, key, value, 200, layout="BSND", plan=single)
+        assert len(fake_quant_ops["fia_calls"]) == 1
+        out_plain = kv_quant_npu.fp8_rotate_quant_kv_slice(query, key, value, 200, layout="BSND")
+        assert len(fake_quant_ops["fia_calls"]) == 2  # one more call recorded
+        assert out_plan.shape == out_plain.shape == query.shape
+
+    def test_kv_slice_plan_chunk_callback_consumes_chunks(self, fake_quant_ops) -> None:
+        query, key, value = self._make_qkv((1, 256, 2, 4))
+        plan = self._chunk_plan(256, 2, 200, q_chunk=2, head_chunk=1)
+        chunks: list[tuple[torch.Tensor, tuple[int, int]]] = []
+
+        def cb(out_chunk, call) -> None:
+            chunks.append((out_chunk, (call.row0, call.row1)))
+
+        result = kv_quant_npu.fp8_rotate_quant_kv_slice(
+            query, key, value, 200, layout="BSND", plan=plan, chunk_callback=cb
+        )
+
+        assert result is None
+        assert len(fake_quant_ops["fia_calls"]) == 4  # still fully executed
+        # One head-merged chunk per q chunk, in caller (BSND) layout.
+        assert [tuple(t.shape) for t, _ in chunks] == [(1, 128, 2, 4)] * 2
+        assert [rows for _, rows in chunks] == [(0, 128), (128, 256)]
+
+    def test_kv_slice_plan_misaligned_row_boundary_raises(self, fake_quant_ops) -> None:
+        # Duck-typed plan (no chunking import needed at runtime); row0=100 is
+        # off the 128-row block grid so scale slices would be inexact.
+        query, key, value = self._make_qkv((1, 256, 2, 4))
+        plan = [SimpleNamespace(row0=100, row1=200, h0=0, h1=2)]
+
+        with pytest.raises(ValueError, match="row boundaries"):
+            kv_quant_npu.fp8_rotate_quant_kv_slice(query, key, value, 200, layout="BSND", plan=plan)
+
+    def test_kv_slice_plan_skips_calls_beyond_seq_len(self, fake_quant_ops) -> None:
+        # Defensive: a plan covering rows past the real sequence contributes
+        # nothing (its outputs would be dropped anyway).
+        query, key, value = self._make_qkv((1, 256, 2, 4))
+        plan = [
+            SimpleNamespace(row0=0, row1=256, h0=0, h1=2),
+            SimpleNamespace(row0=256, row1=384, h0=0, h1=2),
+        ]
+
+        out = kv_quant_npu.fp8_rotate_quant_kv_slice(query, key, value, 200, layout="BSND", plan=plan)
+
+        assert out.shape == query.shape
+        assert len(fake_quant_ops["fia_calls"]) == 1
 
 
 @npu_smoke

--- a/tests/platforms/npu/quant/test_kv_quant_npu.py
+++ b/tests/platforms/npu/quant/test_kv_quant_npu.py
@@ -471,3 +471,41 @@ class TestKVQuantNPUSmoke:
         out = kv_quant_npu.fp8_rotate_quant_kv_slice(query, key, value, 5, layout="BSND")
         assert out.shape == query.shape
         assert out.dtype == query.dtype
+
+    def test_fp8_rotate_quant_kv_slice_chunked_matches_single_call(self):
+        """Config-7 core contract on real hardware: chunked dispatch (q rows
+        x heads) over one shared quantization matches the single wide call.
+
+        Boundaries are 128-row aligned so per-chunk dequant scales are exact
+        slices of the full-length scales — the outputs must agree bitwise.
+        """
+        try:
+            kv_quant_npu._load_quant_ops.cache_clear()
+            kv_quant_npu._load_quant_ops()
+        except ImportError:
+            pytest.skip("NPU quant dependencies are not fully installed.")
+
+        torch.manual_seed(425500)
+        seq_len, num_heads, head_dim, kv_len = 512, 4, 128, 400
+        query = torch.randn(1, seq_len, num_heads, head_dim, dtype=torch.float16, device="npu")
+        key = torch.randn(1, seq_len, num_heads, head_dim, dtype=torch.float16, device="npu")
+        value = torch.randn(1, seq_len, num_heads, head_dim, dtype=torch.float16, device="npu")
+
+        out_single = kv_quant_npu.fp8_rotate_quant_kv_slice(
+            query, key, value, kv_len, layout="BSND", softmax_scale=0.088
+        )
+        plan = chunking.build_chunk_plan(
+            seq_len=seq_len,
+            num_heads=num_heads,
+            num_kv_heads=num_heads,
+            kv_len=kv_len,
+            options=chunking.AttnChunkingOptions(q_chunk=4, head_chunk=2, head_chunk_min_kv=0),
+            row_align=kv_quant_npu._Q_BLOCK_SIZE,
+        )
+        assert len(plan) == 8  # 4 row chunks x 2 head slices
+        out_chunked = kv_quant_npu.fp8_rotate_quant_kv_slice(
+            query, key, value, kv_len, layout="BSND", softmax_scale=0.088, plan=plan
+        )
+
+        assert out_chunked.shape == out_single.shape
+        assert torch.equal(out_single, out_chunked)

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -721,6 +721,12 @@ class _DiffusionConfigProjection:
     diffusion_kv_cache_skip_layers: str | list[int] | tuple[int, ...] | set[int] | None = None
     diffusion_kv_cache_skip_step_indices: set[int] | None = None
     diffusion_kv_cache_skip_layer_indices: set[int] | None = None
+    # Attention call chunking (power-envelope mitigation for specific machine
+    # types; see vllm_omni/diffusion/attention/chunking.py). Requires the fp8
+    # kv dtype — validated in __post_init__.
+    diffusion_attn_q_chunk: int = 1
+    diffusion_attn_head_chunk: int = 0
+    diffusion_attn_head_chunk_min_kv: int = 50000
     moe_backend: str = "auto"
     force_cutlass_fp8: bool = False
     enable_diffusion_pipeline_profiler: bool = False
@@ -835,6 +841,7 @@ class _DiffusionConfigProjection:
             raise ValueError("paged_scheduler requires diffusion_kv_max_rows_per_request to be set")
         self.diffusion_kv_cache_skip_step_indices = parse_kv_cache_skip_selector(self.diffusion_kv_cache_skip_steps)
         self.diffusion_kv_cache_skip_layer_indices = parse_kv_cache_skip_selector(self.diffusion_kv_cache_skip_layers)
+        self._validate_attn_chunking()
 
         if self.max_cpu_loras is None:
             self.max_cpu_loras = 1
@@ -857,6 +864,39 @@ class _DiffusionConfigProjection:
                 "diffusers_load_kwargs and diffusers_call_kwargs are only "
                 "valid together with diffusion_load_format=diffusers"
             )
+
+    def _validate_attn_chunking(self) -> None:
+        """Fail fast on chunking knobs that cannot take effect.
+
+        Non-default chunk knobs without the fp8 kv dtype are a config
+        mistake (chunking currently has exactly one consumer: the NPU FP8
+        FIA path), and typos like q_chunk=0 would otherwise silently
+        disable chunking at plan time.
+        """
+        from vllm_omni.diffusion.attention.chunking import (
+            DEFAULT_HEAD_CHUNK_MIN_KV,
+            AttnChunkingOptions,
+            validate_options,
+        )
+
+        non_default = (
+            self.diffusion_attn_q_chunk != 1
+            or self.diffusion_attn_head_chunk != 0
+            or self.diffusion_attn_head_chunk_min_kv != DEFAULT_HEAD_CHUNK_MIN_KV
+        )
+        if non_default and self.diffusion_kv_cache_dtype != "fp8":
+            raise ValueError(
+                "--diffusion-attn-q-chunk/--diffusion-attn-head-chunk require "
+                "--diffusion-kv-cache-dtype fp8: attention chunking is a mitigation "
+                "for the NPU FP8 FIA path, not a standalone feature."
+            )
+        validate_options(
+            AttnChunkingOptions(
+                q_chunk=self.diffusion_attn_q_chunk,
+                head_chunk=self.diffusion_attn_head_chunk,
+                head_chunk_min_kv=self.diffusion_attn_head_chunk_min_kv,
+            )
+        )
 
     def _propagate_quantization_from_tf_config(self, tf_config: Any) -> None:
         quant_config = getattr(tf_config, "quant_config", None)

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -434,6 +434,11 @@ class StageDeployConfig:
     diffusion_kv_cache_dtype: str | None = None
     diffusion_kv_cache_skip_steps: str | None = None
     diffusion_kv_cache_skip_layers: str | None = None
+    # Attention call chunking (power-envelope mitigation; see
+    # vllm_omni/diffusion/attention/chunking.py). Requires the fp8 kv dtype.
+    diffusion_attn_q_chunk: int | None = None
+    diffusion_attn_head_chunk: int | None = None
+    diffusion_attn_head_chunk_min_kv: int | None = None
     auxiliary_text_encoder: str | None = None
 
     # Runtime optimizations used by diffusion loading/execution.

--- a/vllm_omni/diffusion/attention/backends/flash_attn.py
+++ b/vllm_omni/diffusion/attention/backends/flash_attn.py
@@ -486,6 +486,25 @@ class FlashAttentionImpl(AttentionImpl):
 
         kv_cache_dtype = attn_metadata.extra.get("kv_cache_dtype") if attn_metadata else None
         if kv_cache_dtype is not None:
+            extra = attn_metadata.extra if attn_metadata else {}
+            if extra.get("npu_attn_varlen", False):
+                # MINDIESD_FP8_KV_SLICE selects the dense-FIA variant: K/V are
+                # sliced to the valid prefix outside the operator instead of
+                # attending over the padding document.
+                from vllm_omni.platforms.npu.quant.kv_quant_npu import fp8_kv_slice_enabled
+
+                if fp8_kv_slice_enabled():
+                    out = self._forward_prefix_kv_slice_quant_npu(query, key, value, extra)
+                    if out is not None:
+                        return out
+                    # Packed contract failed. Dense FP8 would ignore document
+                    # boundaries, so run unquantized to keep varlen semantics.
+                    logger.warning_once(
+                        "kv_cache_dtype='fp8' is ignored for this attention layer: "
+                        "the packed varlen contract did not hold, so attention runs "
+                        "unquantized instead of crossing document boundaries."
+                    )
+                    return self.forward_fa_npu(query, key, value, attn_metadata)
             return self.forward_fa_quant_npu(query, key, value, attn_metadata)
         return self.forward_fa_npu(query, key, value, attn_metadata)
 
@@ -508,6 +527,44 @@ class FlashAttentionImpl(AttentionImpl):
             softmax_scale=self.softmax_scale,
         )
         return out.transpose(1, 2)
+
+    def _forward_prefix_kv_slice_quant_npu(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        extra: dict,
+    ) -> torch.Tensor | None:
+        """Packed FP8 attention on NPU: slice K/V to the valid prefix, then a
+        dense (non-varlen) FIA call via fp8_rotate_quant_kv_slice.
+
+        FP8 counterpart of _forward_prefix_kv_slice_npu, enabled via
+        MINDIESD_FP8_KV_SLICE. Same numerical contract as the unquantized
+        prefix-K/V-slice path: the padding document is a strict suffix, so
+        dropping it from K/V before quantization is identical to masking it
+        out. Query keeps full length; outputs on padding rows are never
+        consumed downstream. Returns None (caller falls back to the
+        unquantized path) when the packed contract does not hold; see
+        _resolve_packed_seq_npu.
+        """
+        resolved = self._resolve_packed_seq_npu(query, key, extra)
+        if resolved is None:
+            return None
+        _, seq_k = resolved
+        used_k = seq_k[0]  # real document length (first cumulative end)
+
+        from vllm_omni.platforms.npu.quant.kv_quant_npu import fp8_rotate_quant_kv_slice
+
+        # The packed contract guarantees [1, T, N, D] == BSND; the quant
+        # wrapper slices K/V on the seq axis itself.
+        return fp8_rotate_quant_kv_slice(
+            query,
+            key,
+            value,
+            used_k,
+            layout="BSND",
+            softmax_scale=self.softmax_scale,
+        )
 
     def forward_fa_npu(
         self,

--- a/vllm_omni/diffusion/attention/backends/flash_attn.py
+++ b/vllm_omni/diffusion/attention/backends/flash_attn.py
@@ -93,14 +93,12 @@ class FlashAttentionImpl(AttentionImpl):
         prefix: str = "",
         qkv_layout: str | None = None,
         backend_kwargs: dict | None = None,
-        role: str = "self",
         **extra_impl_args,
     ) -> None:
         self.num_heads = num_heads
         self.causal = causal
         self.softmax_scale = softmax_scale
         self.qkv_layout = qkv_layout
-        self.is_cross_attn = role == "cross"
         cfg = get_current_diffusion_config_or_none()
         self.fa_deterministic = bool(getattr(cfg, "fa_deterministic", False)) if cfg is not None else False
         if backend_kwargs:
@@ -154,7 +152,6 @@ class FlashAttentionImpl(AttentionImpl):
         attention_mask: torch.Tensor,
     ) -> torch.Tensor:
         from vllm_omni.diffusion.attention.backends.utils.fa import (
-            _index_first_axis,
             _pad_input,
             _unpad_input,
             _upad_input,
@@ -162,21 +159,10 @@ class FlashAttentionImpl(AttentionImpl):
         )
 
         assert attention_mask.ndim == 2, "attention_mask must be 2D, (batch_size, seq_len)"
-        batch_size, query_length = query.shape[:2]
-        if not self.is_cross_attn and query_length == key.size(1):
-            q, k, v, indices_q, (cu_seq_lens_q, cu_seq_lens_k), (max_length_q, max_length_k) = _upad_input(
-                query, key, value, attention_mask, query_length, _unpad_input
-            )
-        else:
-            # Cross-attention: the mask covers keys only, so keep every query row.
-            k, indices_k, cu_seq_lens_k, max_length_k, _ = _unpad_input(key, attention_mask)
-            v = _index_first_axis(value, indices_k)
-            q = query.flatten(0, 1)
-            cu_seq_lens_q = torch.arange(
-                0, (batch_size + 1) * query_length, query_length, dtype=torch.int32, device=query.device
-            )
-            max_length_q = query_length
-            indices_q = None
+        query_length = query.size(1)
+        q, k, v, indices_q, (cu_seq_lens_q, cu_seq_lens_k), (max_length_q, max_length_k) = _upad_input(
+            query, key, value, attention_mask, query_length, _unpad_input
+        )
 
         out_unpad = flash_attn_varlen_func(
             q,
@@ -192,9 +178,7 @@ class FlashAttentionImpl(AttentionImpl):
             },
         )
         out_unpad = self._unwrap_flash_output(out_unpad)
-        if indices_q is None:
-            return out_unpad.reshape(batch_size, query_length, *out_unpad.shape[1:])
-        return _pad_input(out_unpad, indices_q, batch_size, query_length)
+        return _pad_input(out_unpad, indices_q, query.size(0), query_length)
 
     def _forward_varlen_packed(
         self,
@@ -591,6 +575,21 @@ class FlashAttentionImpl(AttentionImpl):
                     "Attention head chunking is inactive for this layer/request "
                     "(requires MHA and kv_len >= --diffusion-attn-head-chunk-min-kv); "
                     "running with full heads."
+                )
+            # One activation line per attention layer per distinct schedule
+            # (q-chunk count x heads per call) so operators can confirm the
+            # chunking is live; short requests collapse to the single-call
+            # schedule, and the line re-fires when the shape changes.
+            head_width = plan[0].h1 - plan[0].h0 if plan else num_heads
+            schedule = (len({(c.row0, c.row1) for c in plan}), head_width)
+            if getattr(self, "_chunking_last_schedule", None) != schedule:
+                self._chunking_last_schedule = schedule
+                logger.info(
+                    "Attention chunking active: %d q chunks x %d/%d heads per FIA call, row_align=%d.",
+                    schedule[0],
+                    head_width,
+                    num_heads,
+                    kv_quant_npu._Q_BLOCK_SIZE,
                 )
 
         # The quant wrapper slices K/V on the seq axis itself.

--- a/vllm_omni/diffusion/attention/backends/flash_attn.py
+++ b/vllm_omni/diffusion/attention/backends/flash_attn.py
@@ -499,18 +499,9 @@ class FlashAttentionImpl(AttentionImpl):
             return self.forward_fa_quant_npu(query, key, value, attn_metadata)
         # Packed inputs: the kv-slice path is the DEFAULT for FP8 — K/V are
         # sliced to the valid prefix outside the operator instead of
-        # attending over the padding document. MINDIESD_FP8_KV_SLICE survives
-        # as an operations escape hatch: an explicitly falsy value drops the
-        # packed FP8 path and runs unquantized (never dense FP8, which would
-        # cross packed document boundaries).
-        from vllm_omni.platforms.npu.quant.kv_quant_npu import fp8_kv_slice_disabled_by_env
-
-        if fp8_kv_slice_disabled_by_env():
-            logger.warning_once(
-                "MINDIESD_FP8_KV_SLICE is explicitly disabled: packed FP8 kv-slice "
-                "attention falls back to unquantized execution."
-            )
-            return self.forward_fa_npu(query, key, value, attn_metadata)
+        # attending over the padding document. (The legacy MINDIESD_FP8_KV_SLICE
+        # opt-in env is obsolete and ignored; drop --diffusion-kv-cache-dtype
+        # fp8 to run unquantized.)
         out = self._forward_prefix_kv_slice_quant_npu(query, key, value, extra)
         if out is not None:
             return out

--- a/vllm_omni/diffusion/attention/backends/flash_attn.py
+++ b/vllm_omni/diffusion/attention/backends/flash_attn.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 import os
 from functools import partial

--- a/vllm_omni/diffusion/attention/backends/flash_attn.py
+++ b/vllm_omni/diffusion/attention/backends/flash_attn.py
@@ -485,27 +485,42 @@ class FlashAttentionImpl(AttentionImpl):
         """NPU attention implementation using mindiesd."""
 
         kv_cache_dtype = attn_metadata.extra.get("kv_cache_dtype") if attn_metadata else None
-        if kv_cache_dtype is not None:
-            extra = attn_metadata.extra if attn_metadata else {}
-            if extra.get("npu_attn_varlen", False):
-                # MINDIESD_FP8_KV_SLICE selects the dense-FIA variant: K/V are
-                # sliced to the valid prefix outside the operator instead of
-                # attending over the padding document.
-                from vllm_omni.platforms.npu.quant.kv_quant_npu import fp8_kv_slice_enabled
-
-                if fp8_kv_slice_enabled():
-                    out = self._forward_prefix_kv_slice_quant_npu(query, key, value, extra)
-                    if out is not None:
-                        return out
-                    # Packed contract failed. Dense FP8 would ignore document
-                    # boundaries, so run unquantized to keep varlen semantics.
-                    logger.warning_once(
-                        "kv_cache_dtype='fp8' is ignored for this attention layer: "
-                        "the packed varlen contract did not hold, so attention runs "
-                        "unquantized instead of crossing document boundaries."
-                    )
-                    return self.forward_fa_npu(query, key, value, attn_metadata)
+        if kv_cache_dtype is None:
+            return self.forward_fa_npu(query, key, value, attn_metadata)
+        extra = attn_metadata.extra if attn_metadata else {}
+        if not extra.get("npu_attn_varlen", False):
+            # Non-packed FP8 (dense layouts) has no chunking support: the
+            # chunk knobs ride along in extra but do nothing here.
+            if extra.get("attn_chunking") is not None:
+                logger.warning_once(
+                    "Attention chunking applies only to the packed FP8 kv-slice "
+                    "path; ignoring the chunking options for this non-packed layer."
+                )
             return self.forward_fa_quant_npu(query, key, value, attn_metadata)
+        # Packed inputs: the kv-slice path is the DEFAULT for FP8 — K/V are
+        # sliced to the valid prefix outside the operator instead of
+        # attending over the padding document. MINDIESD_FP8_KV_SLICE survives
+        # as an operations escape hatch: an explicitly falsy value drops the
+        # packed FP8 path and runs unquantized (never dense FP8, which would
+        # cross packed document boundaries).
+        from vllm_omni.platforms.npu.quant.kv_quant_npu import fp8_kv_slice_disabled_by_env
+
+        if fp8_kv_slice_disabled_by_env():
+            logger.warning_once(
+                "MINDIESD_FP8_KV_SLICE is explicitly disabled: packed FP8 kv-slice "
+                "attention falls back to unquantized execution."
+            )
+            return self.forward_fa_npu(query, key, value, attn_metadata)
+        out = self._forward_prefix_kv_slice_quant_npu(query, key, value, extra)
+        if out is not None:
+            return out
+        # Packed contract failed. Dense FP8 would ignore document boundaries,
+        # so run unquantized to keep varlen semantics.
+        logger.warning_once(
+            "kv_cache_dtype='fp8' is ignored for this attention layer: "
+            "the packed varlen contract did not hold, so attention runs "
+            "unquantized instead of crossing document boundaries."
+        )
         return self.forward_fa_npu(query, key, value, attn_metadata)
 
     def forward_fa_quant_npu(
@@ -538,14 +553,20 @@ class FlashAttentionImpl(AttentionImpl):
         """Packed FP8 attention on NPU: slice K/V to the valid prefix, then a
         dense (non-varlen) FIA call via fp8_rotate_quant_kv_slice.
 
-        FP8 counterpart of _forward_prefix_kv_slice_npu, enabled via
-        MINDIESD_FP8_KV_SLICE. Same numerical contract as the unquantized
-        prefix-K/V-slice path: the padding document is a strict suffix, so
-        dropping it from K/V before quantization is identical to masking it
-        out. Query keeps full length; outputs on padding rows are never
-        consumed downstream. Returns None (caller falls back to the
-        unquantized path) when the packed contract does not hold; see
-        _resolve_packed_seq_npu.
+        FP8 counterpart of _forward_prefix_kv_slice_npu and the default packed
+        FP8 path. Same numerical contract as the unquantized prefix-K/V-slice
+        path: the padding document is a strict suffix, so dropping it from K/V
+        before quantization is identical to masking it out. Query keeps full
+        length; outputs on padding rows are never consumed downstream. Returns
+        None (caller falls back to the unquantized path) when the packed
+        contract does not hold; see _resolve_packed_seq_npu.
+
+        When the layer injected chunking options (``extra["attn_chunking"]``,
+        from --diffusion-attn-q-chunk/--diffusion-attn-head-chunk), a chunk
+        plan is built here — the call site already knows every plan input
+        (seq/heads from the packed shapes, kv_len from the resolved contract)
+        — and handed to the quant wrapper, which executes it against one
+        shared quantization.
         """
         resolved = self._resolve_packed_seq_npu(query, key, extra)
         if resolved is None:
@@ -553,10 +574,35 @@ class FlashAttentionImpl(AttentionImpl):
         _, seq_k = resolved
         used_k = seq_k[0]  # real document length (first cumulative end)
 
+        from vllm_omni.platforms.npu.quant import kv_quant_npu
         from vllm_omni.platforms.npu.quant.kv_quant_npu import fp8_rotate_quant_kv_slice
 
-        # The packed contract guarantees [1, T, N, D] == BSND; the quant
-        # wrapper slices K/V on the seq axis itself.
+        plan = None
+        options = extra.get("attn_chunking")
+        if options is not None:
+            from vllm_omni.diffusion.attention.chunking import build_chunk_plan
+
+            # The packed contract guarantees [1, T, N, D] == BSND.
+            num_heads = query.shape[2]
+            plan = build_chunk_plan(
+                seq_len=query.shape[1],
+                num_heads=num_heads,
+                num_kv_heads=key.shape[2],
+                kv_len=used_k,
+                options=options,
+                # Row boundaries must land on the Q block-quant grid so
+                # per-chunk dequant scales are exact slices of the one-shot
+                # full-length quantization.
+                row_align=kv_quant_npu._Q_BLOCK_SIZE,
+            )
+            if options.head_chunk > 0 and plan and plan[0].h1 - plan[0].h0 == num_heads:
+                logger.warning_once(
+                    "Attention head chunking is inactive for this layer/request "
+                    "(requires MHA and kv_len >= --diffusion-attn-head-chunk-min-kv); "
+                    "running with full heads."
+                )
+
+        # The quant wrapper slices K/V on the seq axis itself.
         return fp8_rotate_quant_kv_slice(
             query,
             key,
@@ -564,6 +610,7 @@ class FlashAttentionImpl(AttentionImpl):
             used_k,
             layout="BSND",
             softmax_scale=self.softmax_scale,
+            plan=plan,
         )
 
     def forward_fa_npu(

--- a/vllm_omni/diffusion/attention/chunking.py
+++ b/vllm_omni/diffusion/attention/chunking.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Backend-neutral scheduling for chunked attention calls.
 
 Splitting one wide attention call into several narrower ones along the query
@@ -43,6 +43,7 @@ __all__ = [
     "ChunkCall",
     "build_chunk_plan",
     "run_chunked",
+    "validate_options",
 ]
 
 # Default L2-residency gate for head chunking: below this valid kv length the
@@ -74,6 +75,20 @@ class AttnChunkingOptions:
     def active(self) -> bool:
         """True when any chunking is requested (non-default knobs)."""
         return self.q_chunk > 1 or self.head_chunk > 0
+
+
+def validate_options(options: AttnChunkingOptions) -> None:
+    """Range-check the knobs; raise ValueError on impossible values.
+
+    Config surfaces call this at post-init so a typo (e.g. ``q_chunk=0``)
+    fails fast instead of silently disabling chunking at plan time.
+    """
+    if options.q_chunk < 1:
+        raise ValueError(f"q_chunk must be >= 1, got {options.q_chunk}")
+    if options.head_chunk < 0:
+        raise ValueError(f"head_chunk must be >= 0, got {options.head_chunk}")
+    if options.head_chunk_min_kv < 0:
+        raise ValueError(f"head_chunk_min_kv must be >= 0, got {options.head_chunk_min_kv}")
 
 
 @dataclass(frozen=True)
@@ -160,14 +175,7 @@ def build_chunk_plan(
     if row_align < 1:
         raise ValueError(f"build_chunk_plan: row_align must be >= 1, got {row_align}")
     if options is not None:
-        if options.q_chunk < 1:
-            raise ValueError(f"build_chunk_plan: q_chunk must be >= 1, got {options.q_chunk}")
-        if options.head_chunk < 0:
-            raise ValueError(f"build_chunk_plan: head_chunk must be >= 0, got {options.head_chunk}")
-        if options.head_chunk_min_kv < 0:
-            raise ValueError(
-                f"build_chunk_plan: head_chunk_min_kv must be >= 0, got {options.head_chunk_min_kv}"
-            )
+        validate_options(options)
 
     row_bounds = _row_chunk_bounds(seq_len, options.q_chunk if options is not None else 1, row_align)
 
@@ -229,6 +237,7 @@ def run_chunked(
         merged = head_parts[0] if len(head_parts) == 1 else torch.cat(head_parts, dim=head_dim)
         head_parts.clear()
         if chunk_callback is not None:
+            assert cur is not None  # head_parts non-empty implies a group started
             chunk_callback(merged, cur)
         else:
             out_parts.append(merged)

--- a/vllm_omni/diffusion/attention/chunking.py
+++ b/vllm_omni/diffusion/attention/chunking.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Backend-neutral scheduling for chunked attention calls.
+
+Splitting one wide attention call into several narrower ones along the query
+sequence and/or head axes is a *scheduling* decision — which ranges to call,
+in what order, and how to reassemble the outputs — that does not depend on
+the attention operator underneath. This module owns that decision so every
+backend can share it:
+
+* :class:`AttnChunkingOptions` — static user-facing knobs (parsed once per
+  attention layer from the diffusion config).
+* :class:`ChunkCall` — one scheduled dispatch: a query-row range x head range.
+* :func:`build_chunk_plan` — pure function turning shapes + options into the
+  call list. No tensors, no side effects: trivially unit-testable.
+* :func:`run_chunked` — generic executor for backends without per-call
+  bookkeeping (a ``make_call`` callable is invoked per scheduled call and the
+  outputs are reassembled).
+
+Backend adapters consume the plan however fits their operator. The NPU FIA
+fp8 path (``vllm_omni/platforms/npu/quant/kv_quant_npu.py``) quantizes once
+and drives ``fused_infer_attention_score_v2`` per call from the plan, keeping
+its own loop because per-call dequant-scale slices are FIA-specific; it takes
+the plan as a duck-typed sequence so this module stays importable both inside
+and outside the ``vllm_omni`` package.
+
+Chunking is a power/latency mitigation for specific machine types (each
+compute burst stays inside the NPU power envelope; per-call K/V slices
+become L2-resident), not a general win: it is opt-in via CLI flags and inert
+by default.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+import torch
+
+__all__ = [
+    "DEFAULT_HEAD_CHUNK_MIN_KV",
+    "AttnChunkingOptions",
+    "ChunkCall",
+    "build_chunk_plan",
+    "run_chunked",
+]
+
+# Default L2-residency gate for head chunking: below this valid kv length the
+# K/V slice is L2-resident already and splitting heads only adds per-call
+# overhead. Tuned on Ascend 950PR long-video workloads (kv >= 50k tokens).
+DEFAULT_HEAD_CHUNK_MIN_KV = 50000
+
+
+@dataclass(frozen=True)
+class AttnChunkingOptions:
+    """Static chunking knobs shared by every attention backend.
+
+    Args:
+        q_chunk: Split the query sequence into up to N row chunks per call
+            list (K/V kept whole). 1 = off.
+        head_chunk: Call the operator on H heads at a time. 0 = off.
+            Requires MHA (``num_kv_heads == num_heads``): grouped KV heads
+            would need re-grouping per slice. GQA layers run with full heads.
+        head_chunk_min_kv: Head chunking only engages when the valid kv
+            length reaches this threshold — the L2-residency gate. 0 =
+            always engage (when ``head_chunk`` is set).
+    """
+
+    q_chunk: int = 1
+    head_chunk: int = 0
+    head_chunk_min_kv: int = DEFAULT_HEAD_CHUNK_MIN_KV
+
+    @property
+    def active(self) -> bool:
+        """True when any chunking is requested (non-default knobs)."""
+        return self.q_chunk > 1 or self.head_chunk > 0
+
+
+@dataclass(frozen=True)
+class ChunkCall:
+    """One scheduled attention dispatch.
+
+    Query rows ``[row0, row1)`` x heads ``[h0, h1)``. Plans are emitted
+    q-chunk-major / head-minor: consecutive calls sharing a row range belong
+    to the same q chunk, and their outputs concatenate on the head axis.
+    """
+
+    row0: int
+    row1: int
+    h0: int
+    h1: int
+
+
+def _row_chunk_bounds(seq_len: int, n_chunks: int, align: int) -> list[tuple[int, int]]:
+    """``[start, end)`` query-row chunk boundaries covering ``[0, seq_len)``.
+
+    Boundaries start on ``align``-multiples so callers whose kernels attach
+    per-row-block metadata (e.g. block-quant dequant scales) get exact block
+    ranges per chunk; only the last chunk may be ragged. At most ``n_chunks``
+    chunks are emitted — fewer when there are not enough whole blocks.
+    """
+    if n_chunks <= 1 or seq_len <= align:
+        return [(0, seq_len)]
+    chunk = -(-seq_len // (n_chunks * align)) * align
+    bounds: list[tuple[int, int]] = []
+    start = 0
+    while start < seq_len:
+        end = min(seq_len, start + chunk)
+        bounds.append((start, end))
+        start = end
+    return bounds
+
+
+def _head_bounds(num_heads: int, head_chunk: int) -> list[tuple[int, int]]:
+    """``[start, end)`` head slice boundaries covering ``[0, num_heads)``."""
+    if head_chunk <= 0 or head_chunk >= num_heads:
+        return [(0, num_heads)]
+    return [(h0, min(h0 + head_chunk, num_heads)) for h0 in range(0, num_heads, head_chunk)]
+
+
+def build_chunk_plan(
+    *,
+    seq_len: int,
+    num_heads: int,
+    options: AttnChunkingOptions | None = None,
+    num_kv_heads: int | None = None,
+    kv_len: int | None = None,
+    row_align: int = 1,
+) -> list[ChunkCall]:
+    """Schedule the attention calls for one operator invocation.
+
+    Pure function over shapes and knobs: returns the q-chunk-major /
+    head-minor call list (cartesian product of row chunks and head slices).
+    ``options=None`` (or all-default) yields the single-call plan, so the
+    unchunked path is the degenerate case of the same schedule.
+
+    Args:
+        seq_len: Real query sequence length. Chunks cover exactly
+            ``[0, seq_len)``; operator-side padding rows beyond it are never
+            scheduled (their outputs are dropped anyway).
+        num_heads: Query head count.
+        options: Chunking knobs; ``None`` = single call.
+        num_kv_heads: KV head count. Head chunking collapses to full heads
+            for GQA (``num_kv_heads != num_heads``); the caller detects the
+            collapse (first call spans all heads) and warns.
+        kv_len: Valid kv length for this invocation, used by the
+            ``head_chunk_min_kv`` L2-residency gate.
+        row_align: Row-block alignment for q-chunk boundaries. 1 for plain
+            backends; backends with per-row-block metadata (FIA block-quant
+            scales) pass their block size so per-chunk metadata is an exact
+            slice of the full-length metadata.
+
+    Returns:
+        Non-empty call list covering all rows and heads exactly once.
+    """
+    if seq_len < 1:
+        raise ValueError(f"build_chunk_plan: seq_len must be >= 1, got {seq_len}")
+    if num_heads < 1:
+        raise ValueError(f"build_chunk_plan: num_heads must be >= 1, got {num_heads}")
+    if row_align < 1:
+        raise ValueError(f"build_chunk_plan: row_align must be >= 1, got {row_align}")
+    if options is not None:
+        if options.q_chunk < 1:
+            raise ValueError(f"build_chunk_plan: q_chunk must be >= 1, got {options.q_chunk}")
+        if options.head_chunk < 0:
+            raise ValueError(f"build_chunk_plan: head_chunk must be >= 0, got {options.head_chunk}")
+        if options.head_chunk_min_kv < 0:
+            raise ValueError(
+                f"build_chunk_plan: head_chunk_min_kv must be >= 0, got {options.head_chunk_min_kv}"
+            )
+
+    row_bounds = _row_chunk_bounds(seq_len, options.q_chunk if options is not None else 1, row_align)
+
+    head_chunk = 0
+    if options is not None and options.head_chunk > 0:
+        if num_kv_heads is not None and num_kv_heads != num_heads:
+            head_chunk = 0  # GQA: grouped KV heads cannot be split per slice; run full heads.
+        elif kv_len is not None and kv_len < options.head_chunk_min_kv:
+            head_chunk = 0  # Short KV is L2-resident; splitting only adds per-call overhead.
+        else:
+            head_chunk = options.head_chunk
+    head_bounds = _head_bounds(num_heads, head_chunk)
+
+    return [ChunkCall(r0, r1, h0, h1) for (r0, r1) in row_bounds for (h0, h1) in head_bounds]
+
+
+def run_chunked(
+    plan: Sequence[ChunkCall],
+    *,
+    seq_dim: int,
+    head_dim: int,
+    make_call: Callable[[ChunkCall], torch.Tensor],
+    chunk_callback: Callable[[torch.Tensor, ChunkCall], None] | None = None,
+) -> torch.Tensor | None:
+    """Execute a chunk plan for backends without per-call bookkeeping.
+
+    Groups consecutive calls sharing a row range (the plan's q-chunk-major
+    ordering), concatenates each group's outputs on the head axis, then
+    concatenates the groups on the sequence axis. ``make_call`` must return
+    one call's output already in caller layout, with the operator's own
+    padding trimmed.
+
+    With ``chunk_callback`` set, each q chunk's head-merged output is handed
+    to ``callback(out_chunk, first_call)`` instead of being reassembled and
+    None is returned — the caller consumes chunks itself (e.g. interleaving
+    low-power communication between compute bursts).
+
+    Args:
+        plan: Call list from :func:`build_chunk_plan` (q-chunk-major order).
+        seq_dim: Sequence axis of the output in caller layout.
+        head_dim: Head axis of the output in caller layout.
+        make_call: ``fn(call) -> out`` invoking the backend operator once.
+        chunk_callback: Optional per-q-chunk consumer; see above.
+
+    Returns:
+        Reassembled output covering all scheduled rows/heads; None when
+        ``chunk_callback`` consumed the chunks.
+    """
+    if not plan:
+        raise ValueError("run_chunked: plan must not be empty")
+
+    out_parts: list[torch.Tensor] = []
+    head_parts: list[torch.Tensor] = []
+    cur: ChunkCall | None = None
+
+    def _flush_rows() -> None:
+        if not head_parts:
+            return
+        merged = head_parts[0] if len(head_parts) == 1 else torch.cat(head_parts, dim=head_dim)
+        head_parts.clear()
+        if chunk_callback is not None:
+            chunk_callback(merged, cur)
+        else:
+            out_parts.append(merged)
+
+    for call in plan:
+        if cur is not None and (call.row0, call.row1) != (cur.row0, cur.row1):
+            _flush_rows()
+        cur = call
+        head_parts.append(make_call(call))
+    _flush_rows()
+
+    if chunk_callback is not None:
+        return None
+    if len(out_parts) == 1:
+        return out_parts[0]
+    return torch.cat(out_parts, dim=seq_dim)

--- a/vllm_omni/diffusion/attention/layer.py
+++ b/vllm_omni/diffusion/attention/layer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 # Copyright (c) Microsoft Corporation and Jiarui Fang
 # SPDX-License-Identifier: Apache-2.0
 # DeepSpeed Team & Jiarui Fang

--- a/vllm_omni/diffusion/attention/layer.py
+++ b/vllm_omni/diffusion/attention/layer.py
@@ -18,6 +18,7 @@ from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheSpec
 
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.backends.sdpa import SDPABackend
+from vllm_omni.diffusion.attention.chunking import AttnChunkingOptions
 from vllm_omni.diffusion.attention.parallel import build_parallel_attention_strategy
 from vllm_omni.diffusion.attention.parallel.base import NoParallelAttention
 from vllm_omni.diffusion.attention.parallel.ring import RingParallelAttention
@@ -189,6 +190,9 @@ class Attention(nn.Module):
         self._kv_cache_dtype: str | None = None
         self._kv_cache_skip_steps: set[int] | None = None
         self._kv_cache_skip_layers: set[int] | None = None
+        # Chunked-call scheduling options (None = single wide attention call);
+        # only meaningful together with an active kv_cache_dtype.
+        self._attn_chunking: AttnChunkingOptions | None = None
         # Per-layer opt-out from KV-cache quantization (set by model author).
         self._disable_kv_quant: bool = disable_kv_quant
         self._init_kv_cache_quantization(config)
@@ -255,6 +259,15 @@ class Attention(nn.Module):
         self._kv_cache_dtype = dtype
         self._kv_cache_skip_steps = getattr(config, "diffusion_kv_cache_skip_step_indices", None)
         self._kv_cache_skip_layers = getattr(config, "diffusion_kv_cache_skip_layer_indices", None)
+        if dtype is not None:
+            options = AttnChunkingOptions(
+                q_chunk=getattr(config, "diffusion_attn_q_chunk", 1),
+                head_chunk=getattr(config, "diffusion_attn_head_chunk", 0),
+                head_chunk_min_kv=getattr(config, "diffusion_attn_head_chunk_min_kv", 50000),
+            )
+            # Inert defaults stay None so backends never see a "chunking" key
+            # they cannot honor.
+            self._attn_chunking = options if options.active else None
 
     def _should_apply_kv_cache_quant(self) -> bool:
         skip_steps = self._kv_cache_skip_steps
@@ -271,16 +284,26 @@ class Attention(nn.Module):
     def _with_kv_cache_dtype(self, attn_metadata: AttentionMetadata | None) -> AttentionMetadata | None:
         kv_cache_dtype = self._kv_cache_dtype
         if kv_cache_dtype is None or self._disable_kv_quant or not self._should_apply_kv_cache_quant():
-            if attn_metadata is None or "kv_cache_dtype" not in attn_metadata.extra:
+            if attn_metadata is None or not (
+                "kv_cache_dtype" in attn_metadata.extra or "attn_chunking" in attn_metadata.extra
+            ):
                 return attn_metadata
             extra = dict(attn_metadata.extra)
             extra.pop("kv_cache_dtype", None)
+            extra.pop("attn_chunking", None)
             return replace(attn_metadata, extra=extra)
 
-        if attn_metadata is None:
-            return AttentionMetadata(extra={"kv_cache_dtype": kv_cache_dtype})
-        extra = dict(attn_metadata.extra)
+        extra = {"kv_cache_dtype": kv_cache_dtype} if attn_metadata is None else dict(attn_metadata.extra)
         extra["kv_cache_dtype"] = kv_cache_dtype
+        # Chunking rides along only when quantization is active for this step
+        # and layer; the skip-step/skip-layer/disable gates above pop both
+        # keys together, so backends never see chunking without a dtype.
+        if self._attn_chunking is not None:
+            extra["attn_chunking"] = self._attn_chunking
+        else:
+            extra.pop("attn_chunking", None)
+        if attn_metadata is None:
+            return AttentionMetadata(extra=extra)
         return replace(attn_metadata, extra=extra)
 
     def forward(

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -952,6 +952,12 @@ class OmniDiffusionConfig:
     diffusion_kv_cache_skip_layers: str | None = None
     diffusion_kv_cache_skip_step_indices: set[int] | None = None
     diffusion_kv_cache_skip_layer_indices: set[int] | None = None
+    # Attention call chunking (power-envelope mitigation for specific machine
+    # types; see vllm_omni/diffusion/attention/chunking.py). Requires the fp8
+    # kv dtype — validated in __post_init__.
+    diffusion_attn_q_chunk: int = 1
+    diffusion_attn_head_chunk: int = 0
+    diffusion_attn_head_chunk_min_kv: int = 50000
 
     # Diffusion pipeline Profiling config
     enable_diffusion_pipeline_profiler: bool = False
@@ -1194,6 +1200,7 @@ class OmniDiffusionConfig:
         self.diffusion_attention_config = build_attention_config(self.diffusion_attention_config)
         self.diffusion_kv_cache_skip_step_indices = parse_kv_cache_skip_selector(self.diffusion_kv_cache_skip_steps)
         self.diffusion_kv_cache_skip_layer_indices = parse_kv_cache_skip_selector(self.diffusion_kv_cache_skip_layers)
+        self._validate_attn_chunking()
 
         if self.max_cpu_loras is None:
             self.max_cpu_loras = 1
@@ -1228,6 +1235,40 @@ class OmniDiffusionConfig:
                     model_id,
                     self.model,
                 )
+
+    def _validate_attn_chunking(self) -> None:
+        """Fail fast on chunking knobs that cannot take effect.
+
+        Non-default chunk knobs without the fp8 kv dtype are a config
+        mistake (chunking currently has exactly one consumer: the NPU FP8
+        FIA path), and typos like q_chunk=0 would otherwise silently
+        disable chunking at plan time. Mirrors the same check in
+        ``_DiffusionConfigProjection`` (omni_config.py).
+        """
+        from vllm_omni.diffusion.attention.chunking import (
+            DEFAULT_HEAD_CHUNK_MIN_KV,
+            AttnChunkingOptions,
+            validate_options,
+        )
+
+        non_default = (
+            self.diffusion_attn_q_chunk != 1
+            or self.diffusion_attn_head_chunk != 0
+            or self.diffusion_attn_head_chunk_min_kv != DEFAULT_HEAD_CHUNK_MIN_KV
+        )
+        if non_default and self.diffusion_kv_cache_dtype != "fp8":
+            raise ValueError(
+                "diffusion_attn_q_chunk/diffusion_attn_head_chunk require "
+                "diffusion_kv_cache_dtype='fp8': attention chunking is a mitigation "
+                "for the NPU FP8 FIA path, not a standalone feature."
+            )
+        validate_options(
+            AttnChunkingOptions(
+                q_chunk=self.diffusion_attn_q_chunk,
+                head_chunk=self.diffusion_attn_head_chunk,
+                head_chunk_min_kv=self.diffusion_attn_head_chunk_min_kv,
+            )
+        )
 
     def _propagate_quantization_from_tf_config(self, tf_config: "TransformerConfig") -> None:
         if tf_config.quant_config is None:

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -581,6 +581,11 @@ class OrchestratorArgs:
     diffusion_kv_cache_dtype: str | None = None
     diffusion_kv_cache_skip_steps: str | None = None
     diffusion_kv_cache_skip_layers: str | None = None
+    # Attention call chunking (power-envelope mitigation; see
+    # vllm_omni/diffusion/attention/chunking.py). Requires the fp8 kv dtype.
+    diffusion_attn_q_chunk: int = 1
+    diffusion_attn_head_chunk: int = 0
+    diffusion_attn_head_chunk_min_kv: int = 50000
     cfg_parallel_size: int = 1
     vae_patch_parallel_size: int = 1
     vae_parallel_mode: str = "tile"

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1176,6 +1176,9 @@ class AsyncOmniEngine:
             "diffusion_kv_cache_dtype": kwargs.get("diffusion_kv_cache_dtype", None),
             "diffusion_kv_cache_skip_steps": kwargs.get("diffusion_kv_cache_skip_steps", None),
             "diffusion_kv_cache_skip_layers": kwargs.get("diffusion_kv_cache_skip_layers", None),
+            "diffusion_attn_q_chunk": kwargs.get("diffusion_attn_q_chunk", 1),
+            "diffusion_attn_head_chunk": kwargs.get("diffusion_attn_head_chunk", 0),
+            "diffusion_attn_head_chunk_min_kv": kwargs.get("diffusion_attn_head_chunk_min_kv", 50000),
             **({"diffusion_attention_config": attention_config} if attention_config is not None else {}),
             "force_cutlass_fp8": bool(kwargs.get("force_cutlass_fp8", False)),
             "enable_diffusion_pipeline_profiler": kwargs.get("enable_diffusion_pipeline_profiler", False),
@@ -1404,6 +1407,17 @@ class AsyncOmniEngine:
                         or cfg.engine_args.diffusion_kv_cache_skip_layers is None
                     ):
                         cfg.engine_args.diffusion_kv_cache_skip_layers = diffusion_kv_cache_skip_layers
+                # Chunk knobs have non-None engine-arg defaults, so "inject"
+                # means: the orchestrator-level value is non-default AND the
+                # stage kept the default (an explicit stage value wins).
+                for chunk_field, default in (
+                    ("diffusion_attn_q_chunk", 1),
+                    ("diffusion_attn_head_chunk", 0),
+                    ("diffusion_attn_head_chunk_min_kv", 50000),
+                ):
+                    value = kwargs.get(chunk_field, default)
+                    if value != default and getattr(cfg.engine_args, chunk_field, default) == default:
+                        setattr(cfg.engine_args, chunk_field, value)
             except Exception as e:
                 logger.warning("Failed to inject LoRA config for stage: %s", e)
 

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -812,6 +812,35 @@ class OmniServeCommand(CLISubcommand):
             default=None,
             help="Diffusion KV-cache quantization skip-layer selector, e.g. '0,1,4-8'.",
         )
+        # Attention call chunking: a power-envelope mitigation for specific
+        # machine types (e.g. NPU downclocking on wide attention bursts), not
+        # a general win. Currently takes effect only on the NPU FP8 FIA path,
+        # so the flags require --diffusion-kv-cache-dtype fp8.
+        omni_config_group.add_argument(
+            "--diffusion-attn-q-chunk",
+            type=int,
+            default=1,
+            help="Split each wide attention call into up to N smaller calls along the "
+            "query sequence axis (K/V kept whole, quantized once). 1 = off. Power-envelope "
+            "mitigation for specific machine types, not a general win. Requires "
+            "--diffusion-kv-cache-dtype fp8; currently only the NPU FP8 FIA path honors it.",
+        )
+        omni_config_group.add_argument(
+            "--diffusion-attn-head-chunk",
+            type=int,
+            default=0,
+            help="Call attention on H heads at a time (0 = off). Requires MHA. Engages only "
+            "when the valid kv length reaches --diffusion-attn-head-chunk-min-kv (short KV is "
+            "L2-resident already). Power-envelope mitigation for specific machine types. "
+            "Requires --diffusion-kv-cache-dtype fp8; currently only the NPU FP8 FIA path honors it.",
+        )
+        omni_config_group.add_argument(
+            "--diffusion-attn-head-chunk-min-kv",
+            type=int,
+            default=50000,
+            help="Minimum valid kv length for head chunking to engage (L2-residency gate). "
+            "Tuned on Ascend 950PR long-video workloads.",
+        )
         omni_config_group.add_argument(
             "--cfg-parallel-size",
             type=int,

--- a/vllm_omni/platforms/npu/quant/kv_quant_npu.py
+++ b/vllm_omni/platforms/npu/quant/kv_quant_npu.py
@@ -11,9 +11,8 @@ Two entry points dispatch to the MindIE-SD FIA operator:
 ``fp8_rotate_quant_kv_slice`` for the packed [real, pad] layout with K/V
 sliced to the valid prefix so a plain dense BNSD/BSND FIA call (no varlen
 feature) suffices. The kv-slice path is the default behavior of
-``--diffusion-kv-cache-dtype fp8`` on NPU; ``MINDIESD_FP8_KV_SLICE=0`` is
-an escape hatch that drops the packed FP8 path back to unquantized
-attention (see :func:`fp8_kv_slice_disabled_by_env`).
+``--diffusion-kv-cache-dtype fp8`` on NPU for packed inputs (the legacy
+``MINDIESD_FP8_KV_SLICE`` opt-in env is obsolete and ignored).
 
 ``fp8_rotate_quant_kv_slice`` also accepts a chunk plan from
 ``vllm_omni.diffusion.attention.chunking`` (duck-typed ``ChunkCall``
@@ -29,7 +28,6 @@ full-length scales and chunked results match the single call.
 from __future__ import annotations
 
 import math
-import os
 import threading
 from collections.abc import Sequence
 from functools import lru_cache
@@ -56,24 +54,6 @@ _KV_BLOCK_SIZE = 256
 def is_quantized_kv_cache(kv_cache_dtype: str | None) -> bool:
     """True if config requests FP8-style KV / QKV quantization for the NPU FA path."""
     return kv_cache_dtype in _FP8_KV_LABELS
-
-
-def fp8_kv_slice_disabled_by_env() -> bool:
-    """True only when ``MINDIESD_FP8_KV_SLICE`` is explicitly falsy
-    (``0``/``false``/``no``/``off``).
-
-    The kv-slice path is the *default* behavior of
-    ``--diffusion-kv-cache-dtype fp8`` for packed inputs — no opt-in env is
-    needed anymore. The env survives as an operations escape hatch: an
-    explicitly falsy value drops the packed FP8 path and runs unquantized
-    attention (never dense FP8, which would ignore packed document
-    boundaries). Unset or any other value keeps the default. Read per call
-    (no cache) so a changed environment takes effect without a process
-    restart, matching the ``MINDIE_SD_FA_TYPE`` dispatch."""
-    raw = os.environ.get("MINDIESD_FP8_KV_SLICE")
-    if raw is None:
-        return False
-    return raw.strip().lower() in ("0", "false", "no", "off")
 
 
 @lru_cache(maxsize=1)

--- a/vllm_omni/platforms/npu/quant/kv_quant_npu.py
+++ b/vllm_omni/platforms/npu/quant/kv_quant_npu.py
@@ -5,11 +5,19 @@
 Provides per-tensor dynamic quantization of Q/K/V tensors to
 float8_e4m3fn format. Designed for diffusion models where Q/K/V are
 computed fresh each forward pass (no persistent KV cache).
+
+Two entry points dispatch to the MindIE-SD FIA operator:
+``fp8_rotate_quant_fa`` for dense batched layouts (BNSD/BSND) and
+``fp8_rotate_quant_kv_slice`` for the packed [real, pad] layout with K/V
+sliced to the valid prefix so a plain dense BNSD/BSND FIA call (no varlen
+feature) suffices. Setting ``MINDIESD_FP8_KV_SLICE`` to a truthy value
+routes packed FP8 attention through the latter.
 """
 
 from __future__ import annotations
 
 import math
+import os
 import threading
 from functools import lru_cache
 
@@ -22,10 +30,26 @@ _ROT_MATRIX_LOCK = threading.Lock()
 
 _FP8_KV_LABELS = frozenset({"fp8"})
 
+# Block-quant row-block sizes for the FIA per-block FP8 path (Q: 128 rows,
+# K/V: 256 rows).
+_Q_BLOCK_SIZE = 128
+_KV_BLOCK_SIZE = 256
+
 
 def is_quantized_kv_cache(kv_cache_dtype: str | None) -> bool:
     """True if config requests FP8-style KV / QKV quantization for the NPU FA path."""
     return kv_cache_dtype in _FP8_KV_LABELS
+
+
+def fp8_kv_slice_enabled() -> bool:
+    """Truthy ``MINDIESD_FP8_KV_SLICE`` (``1``/``true``/``yes``/``on``) routes
+    packed FP8 attention through :func:`fp8_rotate_quant_kv_slice` — K/V sliced
+    to the valid prefix, then dense BNSD/BSND FIA — instead of the dense
+    full-length path. Read per call (no cache) so a changed environment takes
+    effect without a process restart, matching the ``MINDIE_SD_FA_TYPE``
+    dispatch."""
+    enabled = os.environ.get("MINDIESD_FP8_KV_SLICE", "false").strip().lower()
+    return enabled in ("1", "true", "yes", "on")
 
 
 @lru_cache(maxsize=1)
@@ -39,7 +63,17 @@ def _load_quant_ops():
             "fp8_rotate_quant_fa requires torch_npu, MindIE-SD (mindiesd), and MSModelSlim. "
             "See https://gitcode.com/Ascend/MindIE-SD and https://gitcode.com/Ascend/msmodelslim"
         ) from e
-    return torch_npu, fa_block_quant_preprocess, QuaRotMode, create_rot
+    # The MindIE-SD FIA wrapper is only needed by fp8_rotate_quant_kv_slice;
+    # keep it optional so the dense fp8_rotate_quant_fa path (which calls
+    # torch_npu directly) works against MindIE-SD builds that do not provide
+    # it yet.
+    try:
+        from mindiesd.layers.flash_attn.fused_infer_attention_score import (
+            fused_infer_attention_score_v2,
+        )
+    except ImportError:
+        fused_infer_attention_score_v2 = None
+    return torch_npu, fused_infer_attention_score_v2, fa_block_quant_preprocess, QuaRotMode, create_rot
 
 
 def _get_rot_matrix(
@@ -78,7 +112,7 @@ def fp8_rotate_quant_fa(
     Returns:
         Attention output in the same layout as inputs.
     """
-    torch_npu, fa_block_quant_preprocess, qua_rot_mode, create_rot = _load_quant_ops()
+    torch_npu, _fia_v2, fa_block_quant_preprocess, qua_rot_mode, create_rot = _load_quant_ops()
 
     out_dtype = query.dtype
     device = query.device
@@ -123,5 +157,129 @@ def fp8_rotate_quant_fa(
             out = out[:, :, :s, :]
         elif layout == "BSND":
             out = out[:, :s, :, :]
+
+    return out
+
+
+def fp8_rotate_quant_kv_slice(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    kv_len: int,
+    *,
+    layout: str = "BSND",
+    softmax_scale: float | None = None,
+) -> torch.Tensor:
+    """Run dense NPU fused attention with dynamic FP8 Q/K/V after slicing K/V
+    to the valid prefix.
+
+    Alternative to :func:`fp8_rotate_quant_fa` for the packed [real, pad]
+    two-document layout: the padding document is a strict suffix, so dropping
+    it from K/V is identical to masking it out, and the FIA operator's varlen
+    feature (``actual_seq_*`` / ``NTD_TND``) stays off — the call is a plain
+    dense ``BNSD``/``BSND`` FIA whose query is longer than its K/V. K/V are
+    sliced (zero-copy views) BEFORE rotation and quantization, so padding rows
+    are neither attended nor quantized. Query keeps its full length; outputs
+    on padding rows are never consumed downstream (same contract as the
+    unquantized prefix-K/V-slice path).
+
+    Query padding rows are quantized together with the real rows; per-block
+    scales (128-row blocks) can therefore mix both in the boundary block.
+    This is exact when the packing pads with zeros (zeros never raise the
+    block absmax) — the MiniMax-H3 packing this path is built for.
+
+    Args:
+        query: Query tensor in ``layout`` order; its seq length may exceed
+            ``kv_len``.
+        key: Key tensor in ``layout`` order; sliced to ``kv_len`` on the seq
+            axis before quantization.
+        value: Value tensor in ``layout`` order; sliced to ``kv_len`` on the seq
+            axis before quantization.
+        kv_len: Valid K/V prefix length (real document length of the packed
+            row).
+        layout: Caller-facing tensor layout, ``BNSD`` or ``BSND``. The FIA
+            operator itself is always fed BNSD (the quant kernel's output
+            layout) and its output is transposed back for ``BSND`` callers.
+        softmax_scale: If None, uses ``1 / sqrt(head_dim)``.
+
+    Returns:
+        Attention output in the same layout as the inputs, at the query's
+        full sequence length.
+    """
+    torch_npu, fia_v2, fa_block_quant_preprocess, qua_rot_mode, create_rot = _load_quant_ops()
+    if fia_v2 is None:
+        raise ImportError(
+            "fp8_rotate_quant_kv_slice requires MindIE-SD with "
+            "fused_infer_attention_score_v2 (mindiesd.layers.flash_attn.fused_infer_attention_score); "
+            "the installed MindIE-SD does not provide it."
+        )
+
+    if layout == "BNSD":
+        _, num_heads, seq_len, head_dim = query.shape
+        kv_seq_dim = 2
+        num_kv_heads = key.shape[1]
+    elif layout == "BSND":
+        _, seq_len, num_heads, head_dim = query.shape
+        kv_seq_dim = 1
+        num_kv_heads = key.shape[2]
+    else:
+        raise ValueError(f"fp8_rotate_quant_kv_slice: unsupported layout {layout!r}, expected BNSD or BSND")
+
+    kv_total = key.shape[kv_seq_dim]
+    if not isinstance(kv_len, int) or not 0 < kv_len <= kv_total:
+        raise ValueError(f"fp8_rotate_quant_kv_slice: kv_len must be an int in (0, {kv_total}], got {kv_len!r}")
+
+    out_dtype = query.dtype
+    device = query.device
+
+    rot = _get_rot_matrix(device, query.dtype, head_dim, qua_rot_mode, create_rot)
+    q_f = torch.matmul(query, rot)
+    # Slice K/V to the valid prefix (zero-copy views) before rotation and
+    # quantization: pad rows are neither attended nor quantized.
+    key = key.narrow(kv_seq_dim, 0, kv_len)
+    value = value.narrow(kv_seq_dim, 0, kv_len)
+    k_f = torch.matmul(key, rot)
+
+    # fa_block_quant_preprocess always returns BNSD-logical tensors (BSND
+    # inputs are transposed before the quant kernel), so the FIA call is
+    # always dispatched with input_layout="BNSD" and the output is transposed
+    # back to the caller's layout below.
+    q, q_scale = fa_block_quant_preprocess(
+        q_f, block_size=_Q_BLOCK_SIZE, dst_type=torch_npu.float8_e4m3fn, layout=layout
+    )
+    k, k_scale = fa_block_quant_preprocess(
+        k_f, block_size=_KV_BLOCK_SIZE, dst_type=torch_npu.float8_e4m3fn, layout=layout
+    )
+    v, v_scale = fa_block_quant_preprocess(
+        value, block_size=_KV_BLOCK_SIZE, dst_type=torch_npu.float8_e4m3fn, layout=layout
+    )
+
+    scale = softmax_scale if softmax_scale is not None else 1.0 / math.sqrt(head_dim)
+
+    out = fia_v2(
+        q,
+        k,
+        v,
+        input_layout="BNSD",
+        num_query_heads=num_heads,
+        num_key_value_heads=num_kv_heads,
+        softmax_scale=scale,
+        pre_tokens=2147483647,  # INT32_MAX: no left-context truncation.
+        next_tokens=2147483647,  # INT32_MAX: no right-context truncation.
+        query_quant_mode=7,  # NPU mode id for block FP8 dequant path.
+        key_quant_mode=7,  # Same quant mode as query branch.
+        value_quant_mode=7,  # Same quant mode as key/query branches.
+        dequant_scale_query=q_scale,
+        dequant_scale_key=k_scale,
+        dequant_scale_value=v_scale,
+        out_dtype=out_dtype,
+    )[0]
+
+    # The op hands back BNSD-logical output, possibly padded on the seq axis:
+    # trim to the query length, then transpose back for BSND callers.
+    if out.shape[2] != seq_len:
+        out = out[:, :, :seq_len, :]
+    if layout == "BSND":
+        out = out.transpose(1, 2)
 
     return out

--- a/vllm_omni/platforms/npu/quant/kv_quant_npu.py
+++ b/vllm_omni/platforms/npu/quant/kv_quant_npu.py
@@ -10,8 +10,20 @@ Two entry points dispatch to the MindIE-SD FIA operator:
 ``fp8_rotate_quant_fa`` for dense batched layouts (BNSD/BSND) and
 ``fp8_rotate_quant_kv_slice`` for the packed [real, pad] layout with K/V
 sliced to the valid prefix so a plain dense BNSD/BSND FIA call (no varlen
-feature) suffices. Setting ``MINDIESD_FP8_KV_SLICE`` to a truthy value
-routes packed FP8 attention through the latter.
+feature) suffices. The kv-slice path is the default behavior of
+``--diffusion-kv-cache-dtype fp8`` on NPU; ``MINDIESD_FP8_KV_SLICE=0`` is
+an escape hatch that drops the packed FP8 path back to unquantized
+attention (see :func:`fp8_kv_slice_disabled_by_env`).
+
+``fp8_rotate_quant_kv_slice`` also accepts a chunk plan from
+``vllm_omni.diffusion.attention.chunking`` (duck-typed ``ChunkCall``
+sequence; no runtime import so this file stays loadable outside the
+``vllm_omni`` package): the single wide FIA call becomes several narrower
+ones along the query sequence and/or head axes — a power-envelope
+mitigation for specific machine types. Quantization happens once up
+front; chunk boundaries align to the Q block-quant row block
+(``_Q_BLOCK_SIZE``) so per-chunk dequant scales are exact slices of the
+full-length scales and chunked results match the single call.
 """
 
 from __future__ import annotations
@@ -20,8 +32,12 @@ import math
 import os
 import threading
 from functools import lru_cache
+from typing import TYPE_CHECKING, Sequence
 
 import torch
+
+if TYPE_CHECKING:
+    from vllm_omni.diffusion.attention.chunking import ChunkCall
 
 # Hadamard rotation matrix for QuaRot-style preprocessing
 # keyed by (device, dtype, head_dim) to avoid matmul dtype mismatch.
@@ -41,15 +57,22 @@ def is_quantized_kv_cache(kv_cache_dtype: str | None) -> bool:
     return kv_cache_dtype in _FP8_KV_LABELS
 
 
-def fp8_kv_slice_enabled() -> bool:
-    """Truthy ``MINDIESD_FP8_KV_SLICE`` (``1``/``true``/``yes``/``on``) routes
-    packed FP8 attention through :func:`fp8_rotate_quant_kv_slice` — K/V sliced
-    to the valid prefix, then dense BNSD/BSND FIA — instead of the dense
-    full-length path. Read per call (no cache) so a changed environment takes
-    effect without a process restart, matching the ``MINDIE_SD_FA_TYPE``
-    dispatch."""
-    enabled = os.environ.get("MINDIESD_FP8_KV_SLICE", "false").strip().lower()
-    return enabled in ("1", "true", "yes", "on")
+def fp8_kv_slice_disabled_by_env() -> bool:
+    """True only when ``MINDIESD_FP8_KV_SLICE`` is explicitly falsy
+    (``0``/``false``/``no``/``off``).
+
+    The kv-slice path is the *default* behavior of
+    ``--diffusion-kv-cache-dtype fp8`` for packed inputs — no opt-in env is
+    needed anymore. The env survives as an operations escape hatch: an
+    explicitly falsy value drops the packed FP8 path and runs unquantized
+    attention (never dense FP8, which would ignore packed document
+    boundaries). Unset or any other value keeps the default. Read per call
+    (no cache) so a changed environment takes effect without a process
+    restart, matching the ``MINDIE_SD_FA_TYPE`` dispatch."""
+    raw = os.environ.get("MINDIESD_FP8_KV_SLICE")
+    if raw is None:
+        return False
+    return raw.strip().lower() in ("0", "false", "no", "off")
 
 
 @lru_cache(maxsize=1)
@@ -169,7 +192,9 @@ def fp8_rotate_quant_kv_slice(
     *,
     layout: str = "BSND",
     softmax_scale: float | None = None,
-) -> torch.Tensor:
+    plan: Sequence[ChunkCall] | None = None,
+    chunk_callback=None,
+) -> torch.Tensor | None:
     """Run dense NPU fused attention with dynamic FP8 Q/K/V after slicing K/V
     to the valid prefix.
 
@@ -188,6 +213,15 @@ def fp8_rotate_quant_kv_slice(
     This is exact when the packing pads with zeros (zeros never raise the
     block absmax) — the MiniMax-H3 packing this path is built for.
 
+    With ``plan`` (from
+    ``vllm_omni.diffusion.attention.chunking.build_chunk_plan`` with
+    ``row_align=_Q_BLOCK_SIZE``) the wide FIA call runs as several narrower
+    ones over the same one-shot quantization — a power-envelope mitigation
+    for specific machine types, not a general win. Calls are grouped per q
+    chunk (the plan's q-chunk-major order); K/V head slices are materialized
+    once and reused across q chunks. ``None`` (default) keeps the single
+    wide call.
+
     Args:
         query: Query tensor in ``layout`` order; its seq length may exceed
             ``kv_len``.
@@ -201,10 +235,20 @@ def fp8_rotate_quant_kv_slice(
             operator itself is always fed BNSD (the quant kernel's output
             layout) and its output is transposed back for ``BSND`` callers.
         softmax_scale: If None, uses ``1 / sqrt(head_dim)``.
+        plan: Optional duck-typed ``ChunkCall`` sequence scheduling the FIA
+            calls. Row boundaries must start on ``_Q_BLOCK_SIZE``-row blocks
+            so per-chunk dequant scales are exact slices of the full-length
+            scales.
+        chunk_callback: Optional ``fn(out_chunk, call)`` invoked with each q
+            chunk's head-merged output in the caller-facing layout. When set,
+            nothing is reassembled and the return value is None (the caller
+            consumes chunks, e.g. interleaving low-power communication
+            between compute bursts).
 
     Returns:
         Attention output in the same layout as the inputs, at the query's
-        full sequence length.
+        full sequence length; None when ``chunk_callback`` consumed the
+        per-chunk outputs.
     """
     torch_npu, fia_v2, fa_block_quant_preprocess, qua_rot_mode, create_rot = _load_quant_ops()
     if fia_v2 is None:
@@ -256,30 +300,127 @@ def fp8_rotate_quant_kv_slice(
 
     scale = softmax_scale if softmax_scale is not None else 1.0 / math.sqrt(head_dim)
 
-    out = fia_v2(
-        q,
-        k,
-        v,
-        input_layout="BNSD",
-        num_query_heads=num_heads,
-        num_key_value_heads=num_kv_heads,
-        softmax_scale=scale,
-        pre_tokens=2147483647,  # INT32_MAX: no left-context truncation.
-        next_tokens=2147483647,  # INT32_MAX: no right-context truncation.
-        query_quant_mode=7,  # NPU mode id for block FP8 dequant path.
-        key_quant_mode=7,  # Same quant mode as query branch.
-        value_quant_mode=7,  # Same quant mode as key/query branches.
-        dequant_scale_query=q_scale,
-        dequant_scale_key=k_scale,
-        dequant_scale_value=v_scale,
-        out_dtype=out_dtype,
-    )[0]
+    if plan is None:
+        out = fia_v2(
+            q,
+            k,
+            v,
+            input_layout="BNSD",
+            num_query_heads=num_heads,
+            num_key_value_heads=num_kv_heads,
+            softmax_scale=scale,
+            pre_tokens=2147483647,  # INT32_MAX: no left-context truncation.
+            next_tokens=2147483647,  # INT32_MAX: no right-context truncation.
+            query_quant_mode=7,  # NPU mode id for block FP8 dequant path.
+            key_quant_mode=7,  # Same quant mode as query branch.
+            value_quant_mode=7,  # Same quant mode as key/query branches.
+            dequant_scale_query=q_scale,
+            dequant_scale_key=k_scale,
+            dequant_scale_value=v_scale,
+            out_dtype=out_dtype,
+        )[0]
+        # The op hands back BNSD-logical output, possibly padded on the seq
+        # axis: trim to the query length, then transpose back for BSND.
+        if out.shape[2] != seq_len:
+            out = out[:, :, :seq_len, :]
+        if layout == "BSND":
+            out = out.transpose(1, 2)
+        return out
 
-    # The op hands back BNSD-logical output, possibly padded on the seq axis:
-    # trim to the query length, then transpose back for BSND callers.
-    if out.shape[2] != seq_len:
-        out = out[:, :, :seq_len, :]
-    if layout == "BSND":
-        out = out.transpose(1, 2)
+    # Chunked dispatch. The plan is q-chunk-major: group consecutive calls
+    # sharing a row range into one q chunk, run each of its head slices
+    # against the materialized K/V head part, merge on the head axis, then
+    # concatenate q chunks on the layout's sequence axis. q may be
+    # block-padded by the quant kernel beyond seq_len; the plan only
+    # schedules real rows, and each call's output still trims the op's own
+    # padding.
+    chunks: list[tuple[tuple[int, int], list[ChunkCall]]] = []
+    for call in plan:
+        rows = (call.row0, call.row1)
+        if chunks and chunks[-1][0] == rows:
+            chunks[-1][1].append(call)
+        else:
+            chunks.append((rows, [call]))
 
+    # Head chunking: materialize K/V head slices (and their scales) once and
+    # reuse them across q chunks — the per-call K/V footprint drops to
+    # L2-resident sizes, which is the point. Head chunking is MHA-only (the
+    # plan builder collapses GQA), so a slice's kv heads equal its q heads;
+    # without head chunking the real GQA counts are used below.
+    head_slices = sorted({(call.h0, call.h1) for call in plan})
+    if len(head_slices) > 1:
+        kv_head_parts = {
+            (h0, h1): (
+                k[:, h0:h1].contiguous(),
+                v[:, h0:h1].contiguous(),
+                k_scale[:, h0:h1].contiguous(),
+                v_scale[:, h0:h1].contiguous(),
+            )
+            for h0, h1 in head_slices
+        }
+        del k, v, k_scale, v_scale
+
+    out_parts = []
+    for (row0, row1), calls in chunks:
+        real_rows = min(row1, seq_len) - row0
+        if real_rows <= 0:
+            continue  # defensive: plans built over seq_len never emit these
+        if row0 % _Q_BLOCK_SIZE != 0:
+            raise ValueError(
+                "fp8_rotate_quant_kv_slice: plan row boundaries must start on "
+                f"{_Q_BLOCK_SIZE}-row blocks (got row0={row0}); build the plan with "
+                "row_align=_Q_BLOCK_SIZE so per-chunk dequant scales are exact "
+                "slices of the full-length scales."
+            )
+        head_parts = []
+        for call in calls:
+            h0, h1 = call.h0, call.h1
+            if len(head_slices) > 1:
+                k_c, v_c, ks_c, vs_c = kv_head_parts[(h0, h1)]
+                kv_heads_c = h1 - h0
+            else:
+                k_c, v_c, ks_c, vs_c = k, v, k_scale, v_scale
+                kv_heads_c = num_kv_heads
+            out_hc = fia_v2(
+                q[:, h0:h1, row0:row1, :].contiguous(),
+                k_c,
+                v_c,
+                input_layout="BNSD",
+                num_query_heads=h1 - h0,
+                num_key_value_heads=kv_heads_c,
+                softmax_scale=scale,
+                pre_tokens=2147483647,  # INT32_MAX: no left-context truncation.
+                next_tokens=2147483647,  # INT32_MAX: no right-context truncation.
+                query_quant_mode=7,  # NPU mode id for block FP8 dequant path.
+                key_quant_mode=7,  # Same quant mode as query branch.
+                value_quant_mode=7,  # Same quant mode as key/query branches.
+                # Per-chunk Q scale slice: block-aligned boundaries make this
+                # the exact block range of the full-length quantization.
+                dequant_scale_query=q_scale[
+                    :, h0:h1, row0 // _Q_BLOCK_SIZE : -(-row1 // _Q_BLOCK_SIZE), :
+                ].contiguous(),
+                dequant_scale_key=ks_c,
+                dequant_scale_value=vs_c,
+                out_dtype=out_dtype,
+            )[0]
+            # The op may hand back a padded seq axis; keep this call's real rows.
+            if out_hc.shape[2] != real_rows:
+                out_hc = out_hc[:, :, :real_rows, :]
+            head_parts.append(out_hc)
+        # Reassemble heads (BNSD head axis) before the caller layout transpose.
+        out_c = torch.cat(head_parts, dim=1) if len(head_parts) > 1 else head_parts[0]
+        if layout == "BSND":
+            out_c = out_c.transpose(1, 2)
+        if chunk_callback is not None:
+            # The caller consumes each q chunk (e.g. interleaved reverse
+            # communication); nothing is reassembled here.
+            chunk_callback(out_c, calls[0])
+        else:
+            out_parts.append(out_c)
+    if chunk_callback is not None:
+        return None
+    # Chunks were already transposed to the caller layout in the loop; just
+    # concatenate along the layout's sequence axis.
+    seq_dim = 1 if layout == "BSND" else 2
+    out = torch.cat(out_parts, dim=seq_dim) if len(out_parts) > 1 else out_parts[0]
     return out

--- a/vllm_omni/platforms/npu/quant/kv_quant_npu.py
+++ b/vllm_omni/platforms/npu/quant/kv_quant_npu.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """FP8 quantization utilities for diffusion attention tensors.
 
 Provides per-tensor dynamic quantization of Q/K/V tensors to
@@ -31,8 +31,9 @@ from __future__ import annotations
 import math
 import os
 import threading
+from collections.abc import Sequence
 from functools import lru_cache
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 import torch
 


### PR DESCRIPTION
## What

Adds an opt-in FP8 attention path for NPU where K/V are sliced to the
valid prefix *outside* the operator, so packed `[real, pad]` attention
runs as a single **dense** MindIE-SD FIA call instead of relying on the
operator's varlen feature:

- `vllm_omni/platforms/npu/quant/kv_quant_npu.py`
  - New entry point `fp8_rotate_quant_kv_slice(query, key, value, kv_len)`:
    K/V are sliced to the valid prefix (zero-copy `narrow`) **before**
    rotation and quantization — padding rows are neither attended nor
    quantized — then one dense block-FP8 FIA call runs with the varlen
    feature (`actual_seq_*` / `NTD_TND`) entirely off.
  - `fp8_kv_slice_enabled()` reads `MINDIESD_FP8_KV_SLICE` per call
    (no cache), matching the `MINDIE_SD_FA_TYPE` dispatch convention.
  - The MindIE-SD FIA wrapper is loaded **optionally** in
    `_load_quant_ops`, so the existing dense `fp8_rotate_quant_fa` path
    keeps working against MindIE-SD builds that do not provide it; the
    kv-slice entry point raises a clear `ImportError` in that case.
- `vllm_omni/diffusion/attention/backends/flash_attn.py`
  - `forward_npu`: when `kv_cache_dtype=fp8` rides the
    `npu_attn_varlen` packed route and `MINDIESD_FP8_KV_SLICE` is set,
    dispatch to `_forward_prefix_kv_slice_quant_npu`, which resolves the
    packed boundaries and hands the backend unsliced BSND q/k/v plus the
    real document length. If the packed contract does not hold, falls
    back to **unquantized** attention — dense FP8 would ignore document
    boundaries. With the env unset the dispatch is unchanged.

## Why

- The FIA dispatch always uses `input_layout="BNSD"` regardless of the
  caller-facing layout: `fa_block_quant_preprocess` transposes BSND
  inputs before the quant kernel, so its output (and the FIA output) is
  always BNSD-logical; the wrapper transposes back for BSND callers.
- Query keeps its full length; outputs on padding rows are never consumed
  downstream (same contract as the unquantized prefix-K/V-slice path).
  Per-block scales can mix pad rows in the boundary block — exact when
  the packing pads with zeros, which is the MiniMax-H3 packing this path
  is built for.
- With `kv_cache_dtype=fp8`, K/V slices shrink to the valid prefix, so
  quantization and attention both skip the padding document entirely.

### Usage

```bash
export MINDIESD_FP8_KV_SLICE=1
vllm serve ... \
  --diffusion-attention-backend FLASH_ATTN \
  --diffusion-kv-cache-dtype fp8

Test Plan
 CPU unit tests (tests/platforms/npu/quant/test_kv_quant_npu.py): fake quant ops mirror the real kernel contract (BNSD-logical quant output, per-(head, row-block) scales); cover env parsing, the dense single-call dispatch for BSND/BNSD callers (K/V sliced before quant, BNSD input_layout, varlen feature off), full-length K/V as a no-op slice, and kv_len/layout validation.
 Routing tests (tests/diffusion/attention/test_flash_attn.py): env opt-in selects the kv-slice path; env-off keeps the dense quant dispatch unchanged; a failed packed contract falls back to unquantized attention, never dense FP8; the quant wrapper receives unsliced BSND q/k/v with the real document length.
 NPU-only smoke test for the real shape contract (test_fp8_rotate_quant_kv_slice_real_npu_shape_contract).
 End-to-end on 4×950PR with MiniMax-H3 (--task-type fl2va) using the usage config above.