### PR TITLE
[Bugfix][HunyuanImage3] Fix DiT LoRA binding: namespace alias + GQA QKV de-interleave

### DIFF
--- a/tests/diffusion/lora/test_lora_manager.py
+++ b/tests/diffusion/lora/test_lora_manager.py
@@ -482,6 +482,165 @@ def test_lora_manager_warns_when_all_adapters_pinned(monkeypatch):
     assert set(manager.list_adapters()) == {1, 2}
 
 
+def _make_hunyuan_image3_pipeline(num_heads=4, num_kv_heads=2, head_dim=2, hidden_size=8):
+    """Minimal stand-in for HunyuanImage3Pipeline exposing its LoRA hooks.
+
+    Mirrors the real pipeline's hooks: ``_get_diffusion_lora_name_aliases``
+    maps the ``transformer.*`` wrapper namespace to the PEFT ``model.*``
+    adapter namespace, and ``_deinterleave_fused_qkv_lora_b`` re-orders a
+    GQA-interleaved fused QKV LoRA-B into the block ``[Q; K; V]`` layout.
+    """
+
+    def _split_qkv_ref(qkv):
+        groups = num_heads // num_kv_heads
+        hidden = qkv.shape[1]
+        b = qkv.reshape(num_kv_heads, groups + 2, head_dim, hidden)
+        q, k, v = torch.split(b, (groups, 1, 1), dim=1)
+        return torch.concat((q.reshape(-1, hidden), k.reshape(-1, hidden), v.reshape(-1, hidden)))
+
+    class _Transformer:
+        config = SimpleNamespace(
+            num_attention_heads=num_heads,
+            num_key_value_heads=num_kv_heads,
+            attention_head_dim=head_dim,
+            hidden_size=hidden_size,
+        )
+        _split_qkv_weight = staticmethod(_split_qkv_ref)
+
+    class _HunyuanImage3Pipeline(torch.nn.Module):
+        transformer = _Transformer()
+
+        @staticmethod
+        def _get_diffusion_lora_name_aliases(full_module_name):
+            if full_module_name.startswith("transformer."):
+                return ["model." + full_module_name[len("transformer.") :]]
+            return []
+
+        @staticmethod
+        def _deinterleave_fused_qkv_lora_b(lora_b):
+            expected_rows = (num_heads + 2 * num_kv_heads) * head_dim
+            if lora_b.shape[0] != expected_rows:
+                return None
+            return _split_qkv_ref(lora_b)
+
+    return _HunyuanImage3Pipeline()
+
+
+def _make_hunyuan_image3_qkv_base():
+    """An un-initialized QKVParallelLinear instance for isinstance() checks.
+
+    Only the type identity matters to the manager's de-interleave branch, and
+    a real ``__init__`` requires a tensor-parallel group, so fabricate one.
+    """
+    from vllm.model_executor.layers.linear import QKVParallelLinear
+
+    return object.__new__(QKVParallelLinear)
+
+
+def test_lora_manager_activates_hunyuan_image3_fused_qkv_lora():
+    """A fused HI3 ``qkv_proj`` LoRA-B (GQA-interleaved in the adapter) is
+    de-interleaved to the block [Q; K; V] layout the QKV output slices expect,
+    with the namespace alias resolving the PEFT adapter tensors."""
+    manager = DiffusionLoRAManager(
+        pipeline=_make_hunyuan_image3_pipeline(),
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+        max_cached_adapters=1,
+    )
+
+    wrapper = "transformer.layers.0.self_attn.qkv_proj"
+    packed_layer = _DummyLoRALayer(
+        n_slices=3,
+        output_slices=(8, 4, 4),
+        tp_size=1,
+    )
+    # The real wrapped layer carries a QKVParallelLinear base_layer and the
+    # un-sharded output_sizes; the manager keys its de-interleave path on
+    # both being present.
+    packed_layer.base_layer = _make_hunyuan_image3_qkv_base()
+    packed_layer.output_sizes = (8, 4, 4)
+    manager._lora_modules = {wrapper: packed_layer}
+
+    rank = 3
+    # GQA-interleaved fused QKV rows: [Q-group0, K0, V0, Q-group1, K1, V1].
+    interleaved = torch.arange(16, dtype=torch.bfloat16).unsqueeze(1).repeat(1, rank)
+    lora = LoRALayerWeights(
+        module_name="model.layers.0.self_attn.qkv_proj",
+        rank=rank,
+        lora_alpha=rank,
+        lora_a=torch.ones((rank, 8)),
+        lora_b=interleaved,
+    )
+    manager._registered_adapters = {
+        11: type(
+            "LM",
+            (),
+            {
+                "id": 11,
+                "loras": {"model.layers.0.self_attn.qkv_proj": lora},
+                "get_lora": lambda self, k: self.loras.get(k),
+            },
+        )()
+    }
+
+    manager._activate_adapter(11, 0.5)
+
+    assert packed_layer.reset_calls == 0
+    assert len(packed_layer.set_calls) == 1
+    lora_a_list, lora_b_list = packed_layer.set_calls[0]
+    assert len(lora_a_list) == 3 and len(lora_b_list) == 3
+    # De-interleaved full [Q; K; V] slices, scaled by the lora scale.
+    expected_q = torch.cat([interleaved[0:4], interleaved[8:12]], dim=0) * 0.5
+    expected_k = torch.cat([interleaved[4:6], interleaved[12:14]], dim=0) * 0.5
+    expected_v = torch.cat([interleaved[6:8], interleaved[14:16]], dim=0) * 0.5
+    assert torch.equal(lora_b_list[0], expected_q)
+    assert torch.equal(lora_b_list[1], expected_k)
+    assert torch.equal(lora_b_list[2], expected_v)
+
+
+def test_lora_manager_rejects_hunyuan_image3_qkv_lora_with_unexpected_rows():
+    """If the fused HI3 QKV layout cannot be established (wrong row count), the
+    manager must fail closed instead of applying the LoRA to wrong slices."""
+    manager = DiffusionLoRAManager(
+        pipeline=_make_hunyuan_image3_pipeline(),
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+        max_cached_adapters=1,
+    )
+
+    wrapper = "transformer.layers.0.self_attn.qkv_proj"
+    packed_layer = _DummyLoRALayer(n_slices=3, output_slices=(8, 4, 4))
+    packed_layer.base_layer = _make_hunyuan_image3_qkv_base()
+    packed_layer.output_sizes = (8, 4, 4)
+    manager._lora_modules = {wrapper: packed_layer}
+
+    rank = 3
+    # Row count (12) does not match the HI3 QKV layout (16): fail closed.
+    lora = LoRALayerWeights(
+        module_name="model.layers.0.self_attn.qkv_proj",
+        rank=rank,
+        lora_alpha=rank,
+        lora_a=torch.ones((rank, 8)),
+        lora_b=torch.arange(12 * rank, dtype=torch.bfloat16).view(-1, rank),
+    )
+    manager._registered_adapters = {
+        12: type(
+            "LM",
+            (),
+            {
+                "id": 12,
+                "loras": {"model.layers.0.self_attn.qkv_proj": lora},
+                "get_lora": lambda self, k: self.loras.get(k),
+            },
+        )()
+    }
+
+    manager._activate_adapter(12, 0.5)
+
+    assert packed_layer.set_calls == []
+    assert packed_layer.reset_calls == 1
+
+
 def test_lora_manager_applies_multiple_scales_correctly(monkeypatch):
     """Ensure that the LoRA manager applies scales correctly when the
     active adapter receives a different scale, i.e., the rank is unchanged.

--- a/vllm_omni/diffusion/lora/manager.py
+++ b/vllm_omni/diffusion/lora/manager.py
@@ -538,7 +538,21 @@ class DiffusionLoRAManager:
             return lora_weights
 
         module_suffix = full_module_name.split(".")[-1]
-        return lora_model.get_lora(module_suffix)
+        lora_weights = lora_model.get_lora(module_suffix)
+        if lora_weights is not None:
+            return lora_weights
+
+        # Model-scoped namespace aliases. HunyuanImage-3 registers the DiT
+        # under ``transformer.layers.*`` (``self.transformer`` aliases
+        # ``self.model``) while PEFT adapters use ``model.layers.*``.
+        name_aliases = getattr(self.pipeline, "_get_diffusion_lora_name_aliases", None)
+        if callable(name_aliases):
+            for alias in name_aliases(full_module_name) or []:
+                lora_weights = lora_model.get_lora(alias)
+                if lora_weights is not None:
+                    return lora_weights
+
+        return None
 
     def _is_active_at_scale(self, adapter_id: int, scale: float) -> bool:
         """True if the adapter_id is active and the current scale matches."""
@@ -636,18 +650,37 @@ class DiffusionLoRAManager:
                     lora_layer.reset_lora(0)
                     continue
 
-                total = sum(output_slices)
-                if lora_weights.lora_b.shape[0] != total:
-                    logger.warning(
-                        "Skipping LoRA for %s due to shape mismatch: lora_b[0]=%d != sum(output_slices)=%d",
-                        full_module_name,
-                        lora_weights.lora_b.shape[0],
-                        total,
-                    )
-                    lora_layer.reset_lora(0)
-                    continue
+                # HunyuanImage-3 fused ``qkv_proj`` LoRA-B rows are
+                # GQA-interleaved in the checkpoint (per-KV-head
+                # [Q-group, K, V]); de-interleave them to the block layout
+                # [all Q, all K, all V] the QKV output slices expect. The
+                # un-sharded ``output_sizes`` yield full Q/K/V slices that
+                # vLLM's set_lora() then shards across TP ranks.
+                deinterleave = getattr(self.pipeline, "_deinterleave_fused_qkv_lora_b", None)
+                if isinstance(getattr(lora_layer, "base_layer", None), QKVParallelLinear) and callable(deinterleave):
+                    deinterleaved = deinterleave(lora_weights.lora_b)
+                    output_sizes = getattr(lora_layer, "output_sizes", None)
+                    if deinterleaved is None or output_sizes is None or len(output_sizes) != n_slices:
+                        logger.warning(
+                            "Skipping LoRA for %s: cannot establish HunyuanImage-3 fused-QKV layout",
+                            full_module_name,
+                        )
+                        lora_layer.reset_lora(0)
+                        continue
+                    b_splits = list(torch.split(deinterleaved, list(output_sizes), dim=0))
+                else:
+                    total = sum(output_slices)
+                    if lora_weights.lora_b.shape[0] != total:
+                        logger.warning(
+                            "Skipping LoRA for %s due to shape mismatch: lora_b[0]=%d != sum(output_slices)=%d",
+                            full_module_name,
+                            lora_weights.lora_b.shape[0],
+                            total,
+                        )
+                        lora_layer.reset_lora(0)
+                        continue
+                    b_splits = list(torch.split(lora_weights.lora_b, list(output_slices), dim=0))
 
-                b_splits = list(torch.split(lora_weights.lora_b, list(output_slices), dim=0))
                 lora_a_list = [lora_weights.lora_a] * n_slices
                 lora_b_list = [b * scale for b in b_splits]
                 lora_layer.set_lora(index=0, lora_a=lora_a_list, lora_b=lora_b_list)

--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -406,6 +406,38 @@ class HunyuanImage3Pipeline(
             enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler,
         )
 
+    def _get_diffusion_lora_name_aliases(self, full_module_name: str) -> list[str]:
+        """Map LoRA wrapper names to the PEFT adapter namespace.
+
+        ``self.transformer`` aliases ``self.model``, so the generic diffusion
+        LoRA manager registers the DiT layers under ``transformer.layers.*``.
+        PEFT adapters store the same weights under the ``model.layers.*``
+        namespace (matching the HF checkpoint), so expose the alias to let both
+        names resolve to the same adapter tensors.
+        """
+        if full_module_name.startswith("transformer."):
+            return [f"model.{full_module_name[len('transformer.') :]}"]
+        return []
+
+    def _deinterleave_fused_qkv_lora_b(self, lora_b: torch.Tensor) -> torch.Tensor | None:
+        """Re-order a fused ``qkv_proj`` LoRA-B from the checkpoint's
+        GQA-interleaved layout (per-KV-head ``[Q-group, K, V]``) into the block
+        layout ``[all Q, all K, all V]`` expected by the QKV output slices.
+
+        Reuses the exact same split as the base-weight loader
+        (``HunyuanImage3Model._split_qkv_weight``) so the LoRA deltas land on
+        the same output rows as the checkpoint weights. Returns ``None`` if the
+        HI3 fused-QKV layout cannot be established, in which case the caller
+        must fail closed rather than apply the rows to the wrong slices.
+        """
+        split_qkv = getattr(self.transformer, "_split_qkv_weight", None)
+        if not callable(split_qkv):
+            return None
+        try:
+            return split_qkv(lora_b)
+        except (RuntimeError, ValueError):
+            return None
+
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         skip_prefixes = ["lm_head."] if self.hf_config.tie_word_embeddings else []
         # List of unexpected keywords in weight names


### PR DESCRIPTION
Closes #6411

## Summary

Loading a PEFT LoRA adapter for HunyuanImage-3 failed because of two mismatches between how the diffusion pipeline registers DiT layers and how PEFT adapters store their weights:

1. **Namespace mismatch.** `HunyuanImage3Pipeline` aliases `self.transformer = self.model`, so vLLM-omni's generic diffusion LoRA manager registers the DiT layers under `transformer.layers.*`, while PEFT adapters store the same weights under `model.layers.*` (matching the HF checkpoint). The manager therefore failed to resolve any DiT LoRA key, leaving the adapter silently unbound.

2. **GQA-interleaved fused QKV LoRA-B.** For models with `num_key_value_heads < num_attention_heads`, the checkpoint (and PEFT adapter) stores a fused `qkv_proj` LoRA-B in a per-KV-head interleaved layout `[Q-group(i), K(i), V(i)]`. vLLM's `MergedQKVParallelLinearWithLoRA` expects a block layout `[all Q, all K, all V]` and splits by `output_sizes`; feeding it the interleaved rows lands the deltas on the wrong output slices.

## Fix

- `HunyuanImage3Pipeline._get_diffusion_lora_name_aliases()`: exposes the `transformer.*` -> `model.*` alias so the manager's `_get_lora_weights` can resolve PEFT keys from both namespaces.
- `HunyuanImage3Pipeline._deinterleave_fused_qkv_lora_b()`: converts a GQA-interleaved fused `qkv_proj` LoRA-B into the block layout, reusing the exact same split as the base-weight loader (`_split_qkv_weight`), so LoRA deltas land on the same output rows as the checkpoint weights.
- `DiffusionLoRAManager`: consults the pipeline hooks for namespace aliases and de-interleaves fused QKV LoRA-B before slicing by `output_sizes`. Fails closed (skips the layer, logs a warning) if the HI3 fused-QKV layout cannot be established.

## Verification

- `verify_6411.py` (no GPU): 5 static checks pass — ① namespace alias resolves PEFT keys; ② de-interleaving reproduces the exact base-loader block layout; ③ pipeline hook + fail-closed (wrong row count -> skip); ④ split by `output_sizes` yields correct full Q/K/V slices; ⑤ TP>1 per-rank extraction from the full slices.
- Pre-existing `tests/model_executor/models/test_kv_cache_scale_mapper.py` (8 tests) still passes.
