### PR TITLE
[Bugfix][MiMo-Audio] Restore make_empty_intermediate_tensors on the talker for vLLM 0.28

### DIFF
--- a/vllm_omni/model_executor/models/mimo_audio/mimo_audio_llm.py
+++ b/vllm_omni/model_executor/models/mimo_audio/mimo_audio_llm.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 # Copyright 2025 Xiaomi Corporation.
 import logging
 import threading
@@ -540,6 +543,11 @@ class MiMoAudioLLMForConditionalGeneration(nn.Module, SupportsMultiModal, Suppor
             # hf_config=thinker_config.text_config,
             architectures=["Qwen2ForCausalLM"],
         )
+
+        # vLLM 0.28 turned SupportsPP.make_empty_intermediate_tensors from a
+        # method into a bare annotation, so declaring SupportsPP no longer
+        # supplies one. Delegate to the inner model, as the other omni talkers do.
+        self.make_empty_intermediate_tensors = self.model.make_empty_intermediate_tensors
 
         self.device = current_omni_platform.get_torch_device()
         # global_sampler MUST stay greedy (do_sample=False) so its token decision


### PR DESCRIPTION
Closes #6790

## What broke

After the vLLM 0.28.0 rebase (#6606), `XiaomiMiMo/MiMo-Audio-7B-Instruct` no longer loads — engine-core startup fails while loading the stage-0 model:

```text
File ".../vllm_omni/worker/gpu_model_runner.py", line 180, in load_model
File ".../vllm/v1/worker/gpu_model_runner.py", line 5435, in load_model
  self.model = model_loader.load_model(
AttributeError: 'MiMoAudioLLMForConditionalGeneration' object has no attribute 'make_empty_intermediate_tensors'
```

The same model loads and runs on vLLM 0.27.0, the pre-rebase pin.

## Repro

```bash
# MIMO_AUDIO_TOKENIZER_PATH is mandatory and is checked with os.path.exists()
# (mimo_audio.py:291), so it has to be a local directory — an HF repo id fails.
hf download XiaomiMiMo/MiMo-Audio-Tokenizer --local-dir /root/mimo-audio-tokenizer
export MIMO_AUDIO_TOKENIZER_PATH=/root/mimo-audio-tokenizer

python -c "from vllm_omni import Omni; Omni(model='XiaomiMiMo/MiMo-Audio-7B-Instruct', deploy_config='vllm_omni/deploy/mimo_audio.yaml')"
```

(The one-line repro in the issue stops earlier, at that tokenizer check, before reaching the crash.)

Environment: vllm-omni `main` @ `8be601ed`, vLLM 0.28.0, RTX A6000 48 GB, driver 580.173.02, `dtype=torch.bfloat16`, `enforce_eager=True`.

## Root cause

`SupportsPP` changed shape between the two pins:

```python
# vllm 0.27.0, model_executor/models/interfaces.py:655 — a real method on the Protocol class
class SupportsPP(Protocol):
    def make_empty_intermediate_tensors(self, batch_size, dtype, device) -> "IntermediateTensors":
        ...

# vllm 0.28.0 — a bare annotation, which creates no class attribute
class SupportsPP(Protocol):
    make_empty_intermediate_tensors: _MakeEmptyIntermediateTensors
```

`SupportsPP` is used as a base class here, so on 0.27 every subclass inherited that stub and the attribute always resolved even when the subclass never assigned it. On 0.28 there is nothing to inherit.

`MiMoAudioLLMForConditionalGeneration` (`mimo_audio_llm.py:489`) declares `SupportsPP` and — per `git log -S` — has never assigned `make_empty_intermediate_tensors`. The outer `MiMoAudioForConditionalGeneration.__init__` reads it off that inner model:

```python
# mimo_audio.py:585-589 — self.fused_thinker_talker is built at :560 via
# init_vllm_registered_model(architectures=["MiMoAudioLLMModel"]), which
# registry.py:239 maps to MiMoAudioLLMForConditionalGeneration
self.make_empty_intermediate_tensors = (
    (self.fused_thinker_talker.make_empty_intermediate_tensors)   # :586, raises here
    if self.model_stage == "fused_thinker_talker"
    else lambda: None
)
```

which is why the `AttributeError` names the inner class but is raised inside the outer model's `__init__`, under `initialize_model` → `load_model`.

## Fix

Delegate to the inner LM, which is a `Qwen2ForCausalLM` and sets the attribute in its own `__init__` (itself by delegation). This matches the pattern the other omni talkers already use — `glm_tts.py:828`, `fish_speech_slow_ar.py:225`, `voxcpm2_talker.py:852`.

The SPDX header in the diff was added by the repo's own `check_spdx_header` pre-commit hook when the file was touched; it is not a manual change.

## Scope

Two other `SupportsPP` classes never assign the attribute either — `MiMoAudioToken2WavForConditionalGenerationVLLM` (`mimo_audio_code2wav.py:428`) and `CovoAudioCode2WavForConditionalGeneration` (`covo_audio_code2wav.py:18`). Neither is reachable the same way: the only other consumer is the model runner's profiling path, guarded by `not get_pp_group().is_first_rank`, so they would surface only under PP > 1, and neither has an inner LM to delegate to. Left out of this PR deliberately — happy to file a separate issue.

## Verification

Both runs on one RTX A6000 48 GB box, same command, same cached weights.

Clean `main` @ `8be601ed` — the traceback confirms the read site and that the lookup falls through to `nn.Module.__getattr__`:

```text
File ".../vllm/model_executor/model_loader/utils.py", line 58, in initialize_model
  model = model_class(vllm_config=vllm_config, prefix=prefix)
File ".../vllm_omni/model_executor/models/mimo_audio/mimo_audio.py", line 586, in __init__
  (self.fused_thinker_talker.make_empty_intermediate_tensors)
File ".../torch/nn/modules/module.py", line 1967, in __getattr__
  raise AttributeError(
AttributeError: 'MiMoAudioLLMForConditionalGeneration' object has no attribute 'make_empty_intermediate_tensors'
```

With this patch: no `AttributeError`, both stages initialize, engine reaches ready and shuts down cleanly (`LOAD OK`).

No unit test: the class cannot be constructed without weights (its `__init__` builds tensor-parallel linears and two transformer stacks), so a load-level check is the meaningful regression signal. Happy to add a construction-mocking test if you'd prefer one.
