### PR TITLE
[Bugfix][Examples] Make LTX2 I2V generation defaults testable (fixes #3519)

### DIFF
--- a/examples/offline_inference/image_to_video/image_to_video.py
+++ b/examples/offline_inference/image_to_video/image_to_video.py
@@ -58,7 +58,7 @@ import functools
 import json
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 import numpy as np
 import PIL.Image
@@ -386,11 +386,38 @@ def calculate_dimensions(
     return height, width
 
 
-def main():
-    args = parse_args()
-    generator = torch.Generator(device=current_omni_platform.device_type).manual_seed(args.seed)
-    model_name = str(args.model).lower() if args.model is not None else ""
-    model_class_name = args.model_class_name
+class ModelGenerationDefaults(NamedTuple):
+    """Model-aware generation defaults for the shared I2V example.
+
+    The CLI flags are shared across model families, but each family has
+    different defaults for frame rate, CFG scale, frame count, sampling steps,
+    flow shift, and output resolution. These values apply only when the
+    matching flag is omitted on the command line.
+    """
+
+    fps: float
+    guidance_scale: float | None
+    num_frames: int
+    num_inference_steps: int
+    flow_shift: float | None
+    max_area: int
+    mod_value: int
+    is_ltx2: bool
+
+
+def resolve_model_generation_defaults(
+    model_name: str,
+    model_class_name: str | None,
+) -> ModelGenerationDefaults:
+    """Resolve per-model generation defaults for ``image_to_video.py``.
+
+    ``model_name`` is the ``--model`` value and ``model_class_name`` is the
+    optional ``--model-class-name`` override. Matching is case-insensitive.
+    The returned defaults match the model families advertised in the module
+    docstring (LTX2 / LTX-2.3, SANA-Video, Cosmos3 / Cosmos3-Edge, and
+    Wan2.2 / HunyuanVideo).
+    """
+    model_name = model_name.lower()
     model_class_name_lower = (model_class_name or "").lower()
     is_ltx2_distilled = "distilled" in model_class_name_lower or "distilled" in model_name
     is_ltx23 = "ltx23" in model_class_name_lower or "ltx-2.3" in model_name
@@ -398,6 +425,32 @@ def main():
     is_sana = model_class_name == "SanaImageToVideoPipeline" or "sana-video" in model_name
     is_cosmos = "cosmos" in model_name or (model_class_name is not None and "cosmos" in model_class_name.lower())
     is_cosmos_edge = is_cosmos and ("edge" in model_name or "edge" in model_class_name_lower)
+
+    if is_cosmos_edge:
+        # Cosmos3-Edge native defaults: 480x832, gs 5.0, flow_shift 3.0 — NOT the
+        # Nano/Super 720p / gs 6.0 / flow_shift 10.0 values, which produce
+        # degenerate output on Edge.
+        return ModelGenerationDefaults(24, 5.0, 189, 35, 3.0, 480 * 832, 16, False)
+    if is_cosmos:
+        return ModelGenerationDefaults(24, 6.0, 189, 35, 10.0, 1280 * 720, 16, False)
+    if is_ltx2_distilled:
+        return ModelGenerationDefaults(24, None, 121, 8, None, 1024 * 1536, 64, True)
+    if is_ltx2:
+        return ModelGenerationDefaults(24, None, 121, 30 if is_ltx23 else 40, None, 512 * 768, 32, True)
+    if is_sana:
+        is_720p = "720p" in model_name
+        return ModelGenerationDefaults(
+            16, 6.0, 81, 50, 5.0, (704 * 1280) if is_720p else (480 * 832), 32 if is_720p else 16, False
+        )
+    # Wan2.2 / HunyuanVideo-1.5
+    return ModelGenerationDefaults(16, 5.0, 81, 50, 5.0, 480 * 832, 16, False)
+
+
+def main():
+    args = parse_args()
+    generator = torch.Generator(device=current_omni_platform.device_type).manual_seed(args.seed)
+    model_name = str(args.model).lower() if args.model is not None else ""
+    model_class_name = args.model_class_name
 
     image = PIL.Image.open(args.image).convert("RGB") if args.image else None
     last_image = PIL.Image.open(args.last_image).convert("RGB") if args.last_image else None
@@ -411,61 +464,9 @@ def main():
 
     # Per-model generation defaults, applied only when the matching flag is omitted.
     # Cosmos3 would otherwise silently inherit the Wan2.2 defaults (wrong size/steps/shift).
-    if is_cosmos_edge:
-        # Cosmos3-Edge native defaults: 480x832, gs 5.0, flow_shift 3.0 — NOT the Nano/Super
-        # 720p / gs 6.0 / flow_shift 10.0 below, which produce degenerate output on Edge.
-        d_fps, d_guidance, d_num_frames, d_steps, d_flow_shift, d_max_area, d_mod = (
-            24,
-            5.0,
-            189,
-            35,
-            3.0,
-            480 * 832,
-            16,
-        )
-    elif is_cosmos:
-        d_fps, d_guidance, d_num_frames, d_steps, d_flow_shift, d_max_area, d_mod = (
-            24,
-            6.0,
-            189,
-            35,
-            10.0,
-            1280 * 720,
-            16,
-        )
-    elif is_ltx2_distilled:
-        d_fps, d_guidance, d_num_frames, d_steps, d_flow_shift, d_max_area, d_mod = (
-            24,
-            None,
-            121,
-            8,
-            None,
-            1024 * 1536,
-            64,
-        )
-    elif is_ltx2:
-        d_fps, d_guidance, d_num_frames, d_steps, d_flow_shift, d_max_area, d_mod = (
-            24,
-            None,
-            121,
-            30 if is_ltx23 else 40,
-            None,
-            512 * 768,
-            32,
-        )
-    elif is_sana:
-        is_720p = "720p" in model_name
-        d_fps, d_guidance, d_num_frames, d_steps, d_flow_shift, d_max_area, d_mod = (
-            16,
-            6.0,
-            81,
-            50,
-            5.0,
-            (704 * 1280) if is_720p else (480 * 832),
-            32 if is_720p else 16,
-        )
-    else:  # Wan2.2 / HunyuanVideo-1.5
-        d_fps, d_guidance, d_num_frames, d_steps, d_flow_shift, d_max_area, d_mod = 16, 5.0, 81, 50, 5.0, 480 * 832, 16
+    d_fps, d_guidance, d_num_frames, d_steps, d_flow_shift, d_max_area, d_mod, is_ltx2 = (
+        resolve_model_generation_defaults(model_name, model_class_name)
+    )
 
     fps = args.fps if args.fps is not None else d_fps
     frame_rate = args.frame_rate if args.frame_rate is not None else float(fps)

--- a/tests/examples/offline_inference/test_image_to_video_defaults.py
+++ b/tests/examples/offline_inference/test_image_to_video_defaults.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+import functools
+import importlib.util
+import sys
+from typing import Any
+
+import pytest
+
+from tests.examples.helpers import EXAMPLES
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+@functools.cache
+def _load_example_module() -> Any:
+    """Load the shared I2V example without executing ``main()``."""
+    path = EXAMPLES / "offline_inference" / "image_to_video" / "image_to_video.py"
+    spec = importlib.util.spec_from_file_location("image_to_video_defaults_example", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _resolve(model_name: str, model_class_name: str | None = None) -> Any:
+    return _load_example_module().resolve_model_generation_defaults(model_name, model_class_name)
+
+
+@pytest.mark.parametrize(
+    (
+        "model_name",
+        "model_class_name",
+        "fps",
+        "guidance_scale",
+        "num_frames",
+        "num_inference_steps",
+        "flow_shift",
+        "max_area",
+        "mod_value",
+        "is_ltx2",
+    ),
+    [
+        # #3519: LTX2 advertised defaults (121 frames / 40 steps / 24 fps) must
+        # actually apply instead of silently falling back to the Wan2.2 numbers.
+        ("/path/to/LTX-2", None, 24, None, 121, 40, None, 512 * 768, 32, True),
+        # The issue's original repro selected the class name explicitly.
+        ("", "LTX2ImageToVideoPipeline", 24, None, 121, 40, None, 512 * 768, 32, True),
+        ("diffusers/LTX-2.3-Diffusers", None, 24, None, 121, 30, None, 512 * 768, 32, True),
+        ("ltx2-distilled", "LTX2DistilledPipeline", 24, None, 121, 8, None, 1024 * 1536, 64, True),
+        ("Efficient-Large-Model/SANA-Video_2B_480p_diffusers", None, 16, 6.0, 81, 50, 5.0, 480 * 832, 16, False),
+        ("sana-video-720p", None, 16, 6.0, 81, 50, 5.0, 704 * 1280, 32, False),
+        ("nvidia/Cosmos3-Nano", None, 24, 6.0, 189, 35, 10.0, 1280 * 720, 16, False),
+        ("nvidia/Cosmos3-Edge", None, 24, 5.0, 189, 35, 3.0, 480 * 832, 16, False),
+        ("Wan-AI/Wan2.2-I2V-A14B-Diffusers", None, 16, 5.0, 81, 50, 5.0, 480 * 832, 16, False),
+        (
+            "hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_i2v",
+            None,
+            16,
+            5.0,
+            81,
+            50,
+            5.0,
+            480 * 832,
+            16,
+            False,
+        ),
+    ],
+)
+def test_resolve_model_generation_defaults(
+    model_name: str,
+    model_class_name: str | None,
+    fps: float,
+    guidance_scale: float | None,
+    num_frames: int,
+    num_inference_steps: int,
+    flow_shift: float | None,
+    max_area: int,
+    mod_value: int,
+    is_ltx2: bool,
+) -> None:
+    defaults = _resolve(model_name, model_class_name)
+    assert (
+        defaults.fps,
+        defaults.guidance_scale,
+        defaults.num_frames,
+        defaults.num_inference_steps,
+        defaults.flow_shift,
+        defaults.max_area,
+        defaults.mod_value,
+        defaults.is_ltx2,
+    ) == (
+        fps,
+        guidance_scale,
+        num_frames,
+        num_inference_steps,
+        flow_shift,
+        max_area,
+        mod_value,
+        is_ltx2,
+    )
+
+
+def test_cli_defaults_are_none_so_model_defaults_apply(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Omitted CLI flags must fall back to the model-aware generation defaults."""
+    mod = _load_example_module()
+    monkeypatch.setattr(sys, "argv", ["image_to_video.py", "--model", "/path/to/LTX-2"])
+    args = mod.parse_args()
+    assert args.num_frames is None
+    assert args.num_inference_steps is None
+    assert args.guidance_scale is None
+    assert args.fps is None
+    assert args.frame_rate is None
+    defaults = mod.resolve_model_generation_defaults(str(args.model).lower(), args.model_class_name)
+    assert defaults == mod.ModelGenerationDefaults(24, None, 121, 40, None, 512 * 768, 32, True)


### PR DESCRIPTION
## Why

[#3519](https://github.com/vllm-project/vllm-omni/issues/3519) reported that the LTX2 branch of `examples/offline_inference/image_to_video/image_to_video.py` was dead code: LTX2 users silently received the Wan2.2 defaults (81 frames / 50 steps / guidance 5.0) instead of the documented LTX2 values (121 frames / 40 steps / 24 fps) unless they re-specified every flag.

The shared I2V runner has since gained reachable per-model branches (LTX-2.3 in #4739, SANA-Video in #5508, Cosmos3-Edge in #5596), so the original unreachable-branch defect no longer reproduces. The model-aware defaults were still inline in `main()` with zero regression coverage, leaving the exact failure mode from #3519 unguarded.

## What

- Extract the per-model default resolution from `main()` into a pure, module-level `resolve_model_generation_defaults(model_name, model_class_name)` returning a `ModelGenerationDefaults` NamedTuple. Runtime behavior is unchanged; `main()` consumes the helper.
- Matching is now case-insensitive inside the helper, so callers do not need to pre-lowercase the model string.
- Add CPU-only unit tests in `tests/examples/offline_inference/test_image_to_video_defaults.py` that pin the resolved defaults for LTX2 / LTX-2.3 / LTX2-distilled, SANA-Video (480p and 720p), Cosmos3 / Cosmos3-Edge, and Wan2.2 / HunyuanVideo-1.5, plus a CLI-contract test asserting omitted flags fall back to the model-aware defaults.

## Validation

- `ruff check` and `ruff format --check` pass with ruff 0.14.10 (the repo pre-commit pin).
- New tests are CPU-only: no GPU and no model weights required (`pytest tests/examples/offline_inference/test_image_to_video_defaults.py`).
- No runtime behavior change: the extracted logic matches the previous inline defaults for every model family.

Fixes #3519
