### PR TITLE
[Bugfix][Engine] Copy session_id in OmniEngineCoreRequest.from_request (fixes #4015)

### DIFF
--- a/tests/engine/test_omni_engine_core_request_contract.py
+++ b/tests/engine/test_omni_engine_core_request_contract.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""Contract tests guarding OmniEngineCoreRequest against upstream field drift.
+
+``OmniEngineCoreRequest.from_request`` mirrors upstream vLLM ``EngineCoreRequest``
+fields into the omni subclass by hand. When upstream vLLM adds, renames, or
+removes a field, the manual copy can silently drop it. These tests pin field
+parity so the drift is caught at test time instead of at runtime after a
+dependency bump.
+"""
+
+from __future__ import annotations
+
+import pytest
+from vllm.v1.engine import EngineCoreRequest
+
+from vllm_omni.engine import AdditionalInformationPayload, OmniEngineCoreRequest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+BASE_FIELDS = EngineCoreRequest.__struct_fields__
+OMNI_FIELDS = OmniEngineCoreRequest.__struct_fields__
+
+
+def test_omni_engine_core_request_inherits_every_base_field() -> None:
+    missing = [name for name in BASE_FIELDS if name not in OMNI_FIELDS]
+    assert missing == []
+
+
+def _build_request_with_all_fields() -> EngineCoreRequest:
+    return EngineCoreRequest(
+        request_id="req-1",
+        prompt_token_ids=[1, 2, 3],
+        mm_features=None,
+        sampling_params=None,
+        pooling_params=None,
+        arrival_time=1.0,
+        lora_request=None,
+        cache_salt="salt",
+        data_parallel_rank=0,
+        prompt_embeds=None,
+        prompt_is_token_ids=[True, False],
+        client_index=1,
+        current_wave=2,
+        priority=3,
+        trace_headers={"k": "v"},
+        resumable=True,
+        external_req_id="ext-1",
+        reasoning_ended=True,
+        reasoning_parser_kwargs={"a": 1},
+        abort_immediately=True,
+        session_id="sess-1",
+    )
+
+
+def test_from_request_copies_every_base_field() -> None:
+    """Every upstream field must survive the manual copy in from_request."""
+    request = _build_request_with_all_fields()
+    copied = OmniEngineCoreRequest.from_request(request)
+    for name in BASE_FIELDS:
+        assert getattr(copied, name) == getattr(request, name), name
+
+
+def test_from_request_keeps_omni_specific_fields() -> None:
+    request = _build_request_with_all_fields()
+    copied = OmniEngineCoreRequest.from_request(
+        request,
+        additional_information=AdditionalInformationPayload(entries={}),
+        model_intermediate_buffer={"m": 1},
+    )
+    assert copied.additional_information is not None
+    assert copied.additional_information.entries == {}
+    assert copied.model_intermediate_buffer == {"m": 1}

--- a/vllm_omni/engine/__init__.py
+++ b/vllm_omni/engine/__init__.py
@@ -89,7 +89,12 @@ class OmniEngineCoreRequest(EngineCoreRequest):
         additional_information: AdditionalInformationPayload | None = None,
         model_intermediate_buffer: dict[str, Any] | None = None,
     ) -> "OmniEngineCoreRequest":
-        """Clone an EngineCoreRequest into an OmniEngineCoreRequest with optional payload overrides."""
+        """Clone an EngineCoreRequest into an OmniEngineCoreRequest with optional payload overrides.
+
+        Every upstream ``EngineCoreRequest`` field must be copied explicitly.
+        Field parity is pinned by tests/engine/test_omni_engine_core_request_contract.py
+        so upstream vLLM field drift is caught at test time.
+        """
 
         if prompt_embeds is None:
             prompt_embeds = request.prompt_embeds
@@ -119,6 +124,7 @@ class OmniEngineCoreRequest(EngineCoreRequest):
             reasoning_ended=request.reasoning_ended,
             reasoning_parser_kwargs=request.reasoning_parser_kwargs,
             abort_immediately=request.abort_immediately,
+            session_id=request.session_id,
             additional_information=additional_information,
             model_intermediate_buffer=model_intermediate_buffer,
         )


### PR DESCRIPTION
## Why

[#4015](https://github.com/vllm-project/vllm-omni/issues/4015) flagged that `OmniEngineCoreRequest.from_request()` mirrors upstream vLLM `EngineCoreRequest` fields by hand, so upstream field drift is only caught at runtime after a dependency bump — or silently drops request metadata.

Inspecting vLLM 0.28.0 (`vllm/v1/engine/__init__.py`) shows the drift has already happened: upstream added `session_id`, and the omni copy never forwards it. Every request cloned through `from_request()` therefore loses its session id before it reaches stage routing / duplex orchestration, even though downstream paths (`vllm_omni/request.py`, `engine/orchestrator.py`) already consume `session_id`.

## What

- `OmniEngineCoreRequest.from_request()` now copies `session_id` from the upstream request.
- Added `tests/engine/test_omni_engine_core_request_contract.py` (CPU-only, `core_model` + `cpu` marks) which pins field parity against the installed vLLM `EngineCoreRequest`:
  - the omni subclass covers every upstream `__struct_fields__` entry;
  - `from_request()` preserves every upstream field value;
  - omni-specific payload fields (`additional_information`, `model_intermediate_buffer`) still pass through.

Any future upstream field add/rename/remove now fails CI at test time instead of silently dropping data.

## Validation

- New tests are CPU-only; no GPU or model weights required.
- `ruff check` and `ruff format --check` pass with ruff 0.14.10 (repo pre-commit pin).
- Verified the contract-test design against a local msgspec replica of the vLLM 0.28 `EngineCoreRequest`: without the `session_id` copy the test fails on exactly that field; with the fix all fields are preserved.

Fixes #4015
