### PR TITLE
[Test] CPU-only abnormal-input tests for /v1/images/edits (part of #3408)

### DIFF
--- a/tests/dfx/reliability/invalid_param_test/test_invalid_image_editing_cpu.py
+++ b/tests/dfx/reliability/invalid_param_test/test_invalid_image_editing_cpu.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""CPU-only abnormal-input tests for ``POST /v1/images/edits`` (part of #3408).
+
+The GPU-backed suite in ``test_invalid_image_editing.py`` exercises the same
+route against a live model. These tests cover the validation matrix with a
+mocked engine, so malformed requests are rejected before any generation work:
+no model weights and no GPU are required.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from argparse import Namespace
+from http import HTTPStatus
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from vllm_omni.entrypoints.openai.api_server import router
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class _MockGenerationResult:
+    def __init__(self, images):
+        self.images = images
+        self.stage_durations = {}
+        self.peak_memory_mb = 0.0
+
+
+class _MockEngine:
+    """Minimal diffusion engine: captures the request and yields one image."""
+
+    is_running = True
+
+    def __init__(self) -> None:
+        self.generate_calls = 0
+
+    async def generate(self, **kwargs):
+        self.generate_calls += 1
+        yield _MockGenerationResult([Image.new("RGB", (64, 64), color="blue")])
+
+
+@pytest.fixture
+def edits_client() -> TestClient:
+    """FastAPI TestClient with a mocked single-stage diffusion engine."""
+    from vllm.entrypoints.openai.models.protocol import BaseModelPath
+
+    from vllm_omni.entrypoints.openai.api_server import _DiffusionServingModels
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.engine_client = _MockEngine()
+    app.state.diffusion_engine = app.state.engine_client
+    app.state.stage_configs = [SimpleNamespace(stage_type="diffusion")]
+    app.state.openai_serving_models = _DiffusionServingModels(
+        [BaseModelPath(name="test/edit-model", model_path="test/edit-model")]
+    )
+    app.state.args = Namespace(
+        default_sampling_params=None,
+        max_generated_image_size=1024 * 1792,
+    )
+    return TestClient(app)
+
+
+def _tiny_png() -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (32, 32), color="gray").save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _post_edits(
+    client: TestClient,
+    *,
+    data: dict | None = None,
+    with_image: bool = True,
+) -> Any:
+    files = {"image": ("edit.png", _tiny_png(), "image/png")} if with_image else None
+    return client.post("/v1/images/edits", data=data or {}, files=files)
+
+
+def _assert_error_response(response, status_code: int, fragment: str) -> None:
+    assert response.status_code == status_code
+    body = response.json()
+    assert isinstance(body, dict)
+    assert "detail" in body
+    assert fragment in json.dumps(body)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "fragment"),
+    [
+        # pydantic form validation: non-int values and out-of-range
+        # output_compression must 422. (num_inference_steps / guidance_scale
+        # are intentionally not range-constrained at this route; bounds are
+        # enforced engine-side.)
+        ("seed", "", "seed"),
+        ("seed", "abc", "seed"),
+        ("output_compression", "101", "output_compression"),
+        ("output_compression", "abc", "output_compression"),
+    ],
+)
+def test_edit_rejects_invalid_form_field(edits_client, field, value, fragment) -> None:
+    response = _post_edits(edits_client, data={"prompt": "make it brighter", field: value})
+    _assert_error_response(response, HTTPStatus.UNPROCESSABLE_ENTITY, fragment)
+
+
+def test_edit_rejects_missing_prompt(edits_client) -> None:
+    response = _post_edits(edits_client, data={})
+    _assert_error_response(response, HTTPStatus.UNPROCESSABLE_ENTITY, "prompt")
+
+
+def test_edit_rejects_missing_image(edits_client) -> None:
+    response = _post_edits(edits_client, data={"prompt": "make it brighter"}, with_image=False)
+    _assert_error_response(response, HTTPStatus.UNPROCESSABLE_ENTITY, "image")
+
+
+def test_edit_rejects_unsupported_response_format(edits_client) -> None:
+    response = _post_edits(edits_client, data={"prompt": "make it brighter", "response_format": "url"})
+    _assert_error_response(response, HTTPStatus.BAD_REQUEST, "response_format")
+
+
+def test_edit_rejects_model_mismatch(edits_client) -> None:
+    response = _post_edits(edits_client, data={"prompt": "make it brighter", "model": "wrong-model-id"})
+    _assert_error_response(response, HTTPStatus.BAD_REQUEST, "Model mismatch")
+
+
+def test_edit_rejects_invalid_layers(edits_client) -> None:
+    response = _post_edits(edits_client, data={"prompt": "make it brighter", "layers": "1"})
+    _assert_error_response(response, HTTPStatus.BAD_REQUEST, "Invalid layers")
+
+
+def test_edit_rejects_invalid_resolution(edits_client) -> None:
+    response = _post_edits(edits_client, data={"prompt": "make it brighter", "resolution": "512"})
+    _assert_error_response(response, HTTPStatus.BAD_REQUEST, "Invalid resolution")
+
+
+def test_edit_rejects_resolution_with_explicit_size(edits_client) -> None:
+    response = _post_edits(
+        edits_client,
+        data={"prompt": "make it brighter", "resolution": "1024", "size": "1024x1024"},
+    )
+    _assert_error_response(response, HTTPStatus.BAD_REQUEST, "Cannot specify both")
+
+
+@pytest.mark.parametrize(
+    ("size", "fragment"),
+    [
+        ("abc", "Invalid size format"),
+        ("0x1024", "positive integers"),
+    ],
+)
+def test_edit_rejects_invalid_size(edits_client, size, fragment) -> None:
+    response = _post_edits(edits_client, data={"prompt": "make it brighter", "size": size})
+    _assert_error_response(response, HTTPStatus.BAD_REQUEST, fragment)
+
+
+def test_edit_accepts_valid_request(edits_client) -> None:
+    """Positive control: the mocked route completes and returns an image."""
+    response = _post_edits(edits_client, data={"prompt": "make it brighter"})
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert body["data"][0]["b64_json"]
+    assert edits_client.app.state.engine_client.generate_calls == 1

--- a/tests/engine/test_omni_engine_core_request_contract.py
+++ b/tests/engine/test_omni_engine_core_request_contract.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""Contract tests guarding OmniEngineCoreRequest against upstream field drift.
+
+``OmniEngineCoreRequest.from_request`` mirrors upstream vLLM ``EngineCoreRequest``
+fields into the omni subclass by hand. When upstream vLLM adds, renames, or
+removes a field, the manual copy can silently drop it. These tests pin field
+parity so the drift is caught at test time instead of at runtime after a
+dependency bump.
+"""
+
+from __future__ import annotations
+
+import pytest
+from vllm.v1.engine import EngineCoreRequest
+
+from vllm_omni.engine import AdditionalInformationPayload, OmniEngineCoreRequest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+BASE_FIELDS = EngineCoreRequest.__struct_fields__
+OMNI_FIELDS = OmniEngineCoreRequest.__struct_fields__
+
+
+def test_omni_engine_core_request_inherits_every_base_field() -> None:
+    missing = [name for name in BASE_FIELDS if name not in OMNI_FIELDS]
+    assert missing == []
+
+
+def _build_request_with_all_fields() -> EngineCoreRequest:
+    return EngineCoreRequest(
+        request_id="req-1",
+        prompt_token_ids=[1, 2, 3],
+        mm_features=None,
+        sampling_params=None,
+        pooling_params=None,
+        arrival_time=1.0,
+        lora_request=None,
+        cache_salt="salt",
+        data_parallel_rank=0,
+        prompt_embeds=None,
+        prompt_is_token_ids=[True, False],
+        client_index=1,
+        current_wave=2,
+        priority=3,
+        trace_headers={"k": "v"},
+        resumable=True,
+        external_req_id="ext-1",
+        reasoning_ended=True,
+        reasoning_parser_kwargs={"a": 1},
+        abort_immediately=True,
+        session_id="sess-1",
+    )
+
+
+def test_from_request_copies_every_base_field() -> None:
+    """Every upstream field must survive the manual copy in from_request."""
+    request = _build_request_with_all_fields()
+    copied = OmniEngineCoreRequest.from_request(request)
+    for name in BASE_FIELDS:
+        assert getattr(copied, name) == getattr(request, name), name
+
+
+def test_from_request_keeps_omni_specific_fields() -> None:
+    request = _build_request_with_all_fields()
+    copied = OmniEngineCoreRequest.from_request(
+        request,
+        additional_information=AdditionalInformationPayload(entries={}),
+        model_intermediate_buffer={"m": 1},
+    )
+    assert copied.additional_information is not None
+    assert copied.additional_information.entries == {}
+    assert copied.model_intermediate_buffer == {"m": 1}

--- a/vllm_omni/engine/__init__.py
+++ b/vllm_omni/engine/__init__.py
@@ -89,7 +89,12 @@ class OmniEngineCoreRequest(EngineCoreRequest):
         additional_information: AdditionalInformationPayload | None = None,
         model_intermediate_buffer: dict[str, Any] | None = None,
     ) -> "OmniEngineCoreRequest":
-        """Clone an EngineCoreRequest into an OmniEngineCoreRequest with optional payload overrides."""
+        """Clone an EngineCoreRequest into an OmniEngineCoreRequest with optional payload overrides.
+
+        Every upstream ``EngineCoreRequest`` field must be copied explicitly.
+        Field parity is pinned by tests/engine/test_omni_engine_core_request_contract.py
+        so upstream vLLM field drift is caught at test time.
+        """
 
         if prompt_embeds is None:
             prompt_embeds = request.prompt_embeds
@@ -119,6 +124,7 @@ class OmniEngineCoreRequest(EngineCoreRequest):
             reasoning_ended=request.reasoning_ended,
             reasoning_parser_kwargs=request.reasoning_parser_kwargs,
             abort_immediately=request.abort_immediately,
+            session_id=request.session_id,
             additional_information=additional_information,
             model_intermediate_buffer=model_intermediate_buffer,
         )


### PR DESCRIPTION
## Why

[#3408](https://github.com/vllm-project/vllm-omni/issues/3408) asks for HTTP-layer abnormal-input tests that (a) live with the reliability suite, split by route family, and (b) mostly do **not** depend on `full_model`/GPU. The existing `tests/dfx/reliability/invalid_param_test/test_invalid_image_editing.py` covers `/v1/images/edits` against a live `Qwen/Qwen-Image-Edit` on H100; this PR adds the CPU counterpart so the validation matrix also runs in the cheap `core_model + cpu` tier.

## What

New `tests/dfx/reliability/invalid_param_test/test_invalid_image_editing_cpu.py`:

- Runs the real FastAPI router with a mocked single-stage diffusion engine (same pattern as `tests/entrypoints/openai_api/test_image_server.py`), so no model weights or GPU are needed.
- Pins the malformed-request matrix to 4xx + parsable JSON error bodies:
  - pydantic form validation: `seed=""` / `"abc"`, `output_compression=101` / `"abc"` → 422;
  - missing `prompt` → 422; missing `image` → 422;
  - unsupported `response_format` → 400; model mismatch → 400; invalid `layers` → 400; invalid `resolution` → 400; `resolution` + explicit `size` conflict → 400; malformed `size` (`"abc"`, `"0x1024"`) → 400.
- Positive control: a valid multipart request returns 200 and reaches the engine exactly once.

Note: `num_inference_steps` / `guidance_scale` are intentionally not range-constrained at this route (bounds are engine-side), so they are not asserted as 422 here.

## Validation

- Tests are marked `core_model` + `cpu` and are collected by the existing Buildkite "Simple · Other Test" step (`pytest tests/ -m "core_model and cpu"`).
- `ruff check` / `ruff format --check` pass with the pinned ruff 0.14.10.
- Local execution is not possible on this macOS machine (no vllm/fastapi), so the matrix is verified by CI.

Part of #3408
