### PR TITLE
[Feature][HunyuanImage3] Expose AR rollout metadata for RL teacher-forcing (closes #6768)

### DIFF
--- a/tests/dfx/reliability/invalid_param_test/test_invalid_audio_diffusion.py
+++ b/tests/dfx/reliability/invalid_param_test/test_invalid_audio_diffusion.py
@@ -70,10 +70,19 @@ _PARAMS = [
         pytest.param({"guidance_scale": -1.0}, "guidance_scale", id="guidance_scale_negative", marks=_SKIP_ISSUE_3649),
         pytest.param({"guidance_scale": 0}, "guidance_scale", id="guidance_scale_zero", marks=_SKIP_ISSUE_3649),
         pytest.param(
-            {"num_inference_steps": 0}, "num_inference_steps", id="num_inference_steps_zero", marks=_SKIP_ISSUE_3649
+            # #6598 added ge=1 to the request schema; 0 is now rejected at the
+            # route with the same pydantic contract as -1.
+            {"num_inference_steps": 0},
+            ("num_inference_steps", "greater_than_equal", "1"),
+            id="num_inference_steps_zero",
         ),
         pytest.param(
-            {"num_inference_steps": -1}, ("number of steps", "non-negative"), id="num_inference_steps_negative"
+            # #6598 moved num_inference_steps bounds into the request schema
+            # (ge=1), so the route now rejects -1 with a pydantic error instead
+            # of the engine-side "number of steps must be non-negative" message.
+            {"num_inference_steps": -1},
+            ("num_inference_steps", "greater_than_equal", "1"),
+            id="num_inference_steps_negative",
         ),
         pytest.param(
             {"num_inference_steps": 6000},

--- a/tests/dfx/reliability/invalid_param_test/test_invalid_image_editing_cpu.py
+++ b/tests/dfx/reliability/invalid_param_test/test_invalid_image_editing_cpu.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""CPU-only abnormal-input tests for ``POST /v1/images/edits`` (part of #3408).
+
+The GPU-backed suite in ``test_invalid_image_editing.py`` exercises the same
+route against a live model. These tests cover the validation matrix with a
+mocked engine, so malformed requests are rejected before any generation work:
+no model weights and no GPU are required.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from argparse import Namespace
+from http import HTTPStatus
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from vllm_omni.entrypoints.openai.api_server import router
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class _MockGenerationResult:
+    def __init__(self, images):
+        self.images = images
+        self.stage_durations = {}
+        self.peak_memory_mb = 0.0
+
+
+class _MockEngine:
+    """Minimal diffusion engine: captures the request and yields one image."""
+
+    is_running = True
+
+    def __init__(self) -> None:
+        self.generate_calls = 0
+
+    async def generate(self, **kwargs):
+        self.generate_calls += 1
+        yield _MockGenerationResult([Image.new("RGB", (64, 64), color="blue")])
+
+
+@pytest.fixture
+def edits_client() -> TestClient:
+    """FastAPI TestClient with a mocked single-stage diffusion engine."""
+    from vllm.entrypoints.openai.models.protocol import BaseModelPath
+
+    from vllm_omni.entrypoints.openai.api_server import _DiffusionServingModels
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.engine_client = _MockEngine()
+    app.state.diffusion_engine = app.state.engine_client
+    app.state.stage_configs = [SimpleNamespace(stage_type="diffusion")]
+    app.state.openai_serving_models = _DiffusionServingModels(
+        [BaseModelPath(name="test/edit-model", model_path="test/edit-model")]
+    )
+    app.state.args = Namespace(
+        default_sampling_params=None,
+        max_generated_image_size=1024 * 1792,
+    )
+    return TestClient(app)
+
+
+def _tiny_png() -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (32, 32), color="gray").save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _post_edits(
+    client: TestClient,
+    *,
+    data: dict | None = None,
+    with_image: bool = True,
+) -> Any:
+    files = {"image": ("edit.png", _tiny_png(), "image/png")} if with_image else None
+    return client.post("/v1/images/edits", data=data or {}, files=files)
+
+
+def _assert_error_response(response, status_code: int, fragment: str) -> None:
+    assert response.status_code == status_code
+    body = response.json()
+    assert isinstance(body, dict)
+    assert "detail" in body
+    assert fragment in json.dumps(body)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "fragment"),
+    [
+        # pydantic form validation: non-int values and out-of-range
+        # output_compression must 422. (num_inference_steps / guidance_scale
+        # are intentionally not range-constrained at this route; bounds are
+        # enforced engine-side.)
+        ("seed", "", "seed"),
+        ("seed", "abc", "seed"),
+        ("output_compression", "101", "output_compression"),
+        ("output_compression", "abc", "output_compression"),
+    ],
+)
+def test_edit_rejects_invalid_form_field(edits_client, field, value, fragment) -> None:
+    response = _post_edits(edits_client, data={"prompt": "make it brighter", field: value})
+    _assert_error_response(response, HTTPStatus.UNPROCESSABLE_ENTITY, fragment)
+
+
+def test_edit_rejects_missing_prompt(edits_client) -> None:
+    response = _post_edits(edits_client, data={})
+    _assert_error_response(response, HTTPStatus.UNPROCESSABLE_ENTITY, "prompt")
+
+
+def test_edit_rejects_missing_image(edits_client) -> None:
+    response = _post_edits(edits_client, data={"prompt": "make it brighter"}, with_image=False)
+    _assert_error_response(response, HTTPStatus.UNPROCESSABLE_ENTITY, "image")
+
+
+def test_edit_rejects_unsupported_response_format(edits_client) -> None:
+    response = _post_edits(edits_client, data={"prompt": "make it brighter", "response_format": "url"})
+    _assert_error_response(response, HTTPStatus.BAD_REQUEST, "response_format")
+
+
+def test_edit_rejects_model_mismatch(edits_client) -> None:
+    response = _post_edits(edits_client, data={"prompt": "make it brighter", "model": "wrong-model-id"})
+    _assert_error_response(response, HTTPStatus.BAD_REQUEST, "Model mismatch")
+
+
+def test_edit_rejects_invalid_layers(edits_client) -> None:
+    response = _post_edits(edits_client, data={"prompt": "make it brighter", "layers": "1"})
+    _assert_error_response(response, HTTPStatus.BAD_REQUEST, "Invalid layers")
+
+
+def test_edit_rejects_invalid_resolution(edits_client) -> None:
+    response = _post_edits(edits_client, data={"prompt": "make it brighter", "resolution": "512"})
+    _assert_error_response(response, HTTPStatus.BAD_REQUEST, "Invalid resolution")
+
+
+def test_edit_rejects_resolution_with_explicit_size(edits_client) -> None:
+    response = _post_edits(
+        edits_client,
+        data={"prompt": "make it brighter", "resolution": "1024", "size": "1024x1024"},
+    )
+    _assert_error_response(response, HTTPStatus.BAD_REQUEST, "Cannot specify both")
+
+
+@pytest.mark.parametrize(
+    ("size", "fragment"),
+    [
+        ("abc", "Invalid size format"),
+        ("0x1024", "positive integers"),
+    ],
+)
+def test_edit_rejects_invalid_size(edits_client, size, fragment) -> None:
+    response = _post_edits(edits_client, data={"prompt": "make it brighter", "size": size})
+    _assert_error_response(response, HTTPStatus.BAD_REQUEST, fragment)
+
+
+def test_edit_accepts_valid_request(edits_client) -> None:
+    """Positive control: the mocked route completes and returns an image."""
+    response = _post_edits(edits_client, data={"prompt": "make it brighter"})
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert body["data"][0]["b64_json"]
+    assert edits_client.app.state.engine_client.generate_calls == 1

--- a/tests/diffusion/models/hunyuan_image3/test_diffusion_kv_request.py
+++ b/tests/diffusion/models/hunyuan_image3/test_diffusion_kv_request.py
@@ -278,12 +278,15 @@ def test_prepared_model_inputs_match_local_tokenization(
     request = _request(guidance_scale=guidance_scale, prompt=prompt)
     prepared_layout = _prepare(request, tokenizer, image_processor)
 
-    prompts, cot_texts, system_prompt, batch_cond_image_info, bot_task = extract_hunyuan_prompt_inputs(
-        [request.prompt],
-        request.sampling_params.extra_args or {},
-        request_id=request.request_id,
-        allow_cond_image=True,
+    prompts, cot_texts, system_prompt, batch_cond_image_info, bot_task, rollout_metadata_list = (
+        extract_hunyuan_prompt_inputs(
+            [request.prompt],
+            request.sampling_params.extra_args or {},
+            request_id=request.request_id,
+            allow_cond_image=True,
+        )
     )
+    assert rollout_metadata_list == [None]
     cot_text = (
         [normalize_hunyuan_cot_text(text) for text in cot_texts]
         if any(text is not None for text in cot_texts)

--- a/tests/engine/test_omni_engine_core_request_contract.py
+++ b/tests/engine/test_omni_engine_core_request_contract.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""Contract tests guarding OmniEngineCoreRequest against upstream field drift.
+
+``OmniEngineCoreRequest.from_request`` mirrors upstream vLLM ``EngineCoreRequest``
+fields into the omni subclass by hand. When upstream vLLM adds, renames, or
+removes a field, the manual copy can silently drop it. These tests pin field
+parity so the drift is caught at test time instead of at runtime after a
+dependency bump.
+"""
+
+from __future__ import annotations
+
+import pytest
+from vllm.v1.engine import EngineCoreRequest
+
+from vllm_omni.engine import AdditionalInformationPayload, OmniEngineCoreRequest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+BASE_FIELDS = EngineCoreRequest.__struct_fields__
+OMNI_FIELDS = OmniEngineCoreRequest.__struct_fields__
+
+
+def test_omni_engine_core_request_inherits_every_base_field() -> None:
+    missing = [name for name in BASE_FIELDS if name not in OMNI_FIELDS]
+    assert missing == []
+
+
+def _build_request_with_all_fields() -> EngineCoreRequest:
+    return EngineCoreRequest(
+        request_id="req-1",
+        prompt_token_ids=[1, 2, 3],
+        mm_features=None,
+        sampling_params=None,
+        pooling_params=None,
+        arrival_time=1.0,
+        lora_request=None,
+        cache_salt="salt",
+        data_parallel_rank=0,
+        prompt_embeds=None,
+        prompt_is_token_ids=[True, False],
+        client_index=1,
+        current_wave=2,
+        priority=3,
+        trace_headers={"k": "v"},
+        resumable=True,
+        external_req_id="ext-1",
+        reasoning_ended=True,
+        reasoning_parser_kwargs={"a": 1},
+        abort_immediately=True,
+        session_id="sess-1",
+    )
+
+
+def test_from_request_copies_every_base_field() -> None:
+    """Every upstream field must survive the manual copy in from_request."""
+    request = _build_request_with_all_fields()
+    copied = OmniEngineCoreRequest.from_request(request)
+    for name in BASE_FIELDS:
+        assert getattr(copied, name) == getattr(request, name), name
+
+
+def test_from_request_keeps_omni_specific_fields() -> None:
+    request = _build_request_with_all_fields()
+    copied = OmniEngineCoreRequest.from_request(
+        request,
+        additional_information=AdditionalInformationPayload(entries={}),
+        model_intermediate_buffer={"m": 1},
+    )
+    assert copied.additional_information is not None
+    assert copied.additional_information.entries == {}
+    assert copied.model_intermediate_buffer == {"m": 1}

--- a/tests/model_executor/stage_input_processors/test_hunyuan_image3_bridge.py
+++ b/tests/model_executor/stage_input_processors/test_hunyuan_image3_bridge.py
@@ -19,16 +19,24 @@ from vllm_omni.model_executor.stage_input_processors.hunyuan_image3 import (
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 
-def _source_output(token_ids: list[int], text: str = ""):
+def _source_output(
+    token_ids: list[int],
+    text: str = "",
+    *,
+    logprobs: list | None = None,
+    prompt_token_ids: list[int] | None = None,
+):
     return SimpleNamespace(
         outputs=[
             SimpleNamespace(
                 token_ids=token_ids,
                 cumulative_token_ids=token_ids,
                 text=text,
+                logprobs=logprobs,
             )
         ],
         multimodal_output=None,
+        prompt_token_ids=prompt_token_ids,
     )
 
 
@@ -66,6 +74,38 @@ def test_ar2diffusion_uses_parent_output_when_companions_are_present():
 
     assert result is not None
     assert result["extra"]["ar_generated_text"] == "parent thought"
+
+
+def test_ar2diffusion_exposes_ar_rollout_metadata():
+    """#6768: sampled token ids / per-token log-probs / prompt ids must be
+    carried alongside ar_generated_text instead of being dropped."""
+    logprobs = [
+        {101: SimpleNamespace(logprob=-0.5), 999: SimpleNamespace(logprob=-8.0)},
+        {102: SimpleNamespace(logprob=-1.25)},
+    ]
+    result = ar2diffusion(
+        [_source_output([101, 102], text="thought", logprobs=logprobs, prompt_token_ids=[7, 8, 9])],
+        prompt={"prompt": "edit"},
+    )
+
+    assert result is not None
+    extra = result["extra"]
+    assert extra["ar_generated_text"] == "thought"
+    assert extra["ar_generated_token_ids"] == [101, 102]
+    assert extra["ar_generated_logprobs"] == [-0.5, -1.25]
+    assert extra["ar_prompt_token_ids"] == [7, 8, 9]
+
+
+def test_ar2diffusion_omits_logprobs_when_not_requested():
+    result = ar2diffusion(
+        [_source_output([100], text="thought", prompt_token_ids=[7])],
+        prompt={"prompt": "edit"},
+    )
+
+    assert result is not None
+    assert "ar_generated_logprobs" not in result["extra"]
+    assert result["extra"]["ar_generated_token_ids"] == [100]
+    assert result["extra"]["ar_prompt_token_ids"] == [7]
 
 
 def test_ar2diffusion_returns_none_without_parent_output():

--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -70,6 +70,7 @@ _STEP_GUIDANCE_SCALE = "hunyuan_guidance_scale"
 _STEP_CFG_FACTOR = "hunyuan_cfg_factor"
 _STEP_OUTPUT_SIZE = "hunyuan_output_size"
 _STEP_COT_TEXT_LIST = "hunyuan_cot_text_list"
+_STEP_ROLLOUT_METADATA = "hunyuan_rollout_metadata_list"
 _STEP_AR_KV = "hunyuan_ar_kv"
 _STEP_PROMPT_KV = "hunyuan_prompt_kv"
 
@@ -1716,6 +1717,7 @@ class HunyuanImage3Pipeline(
             system_prompt,
             batch_cond_image_info,
             tokenizer_bot_task,
+            rollout_metadata_list,
         ) = request_layout_utils.extract_hunyuan_prompt_inputs(
             [state.prompt] if state.prompt is not None else [],
             getattr(sampling, "extra_args", {}) or {},
@@ -1817,6 +1819,7 @@ class HunyuanImage3Pipeline(
             _STEP_CFG_FACTOR: 1 + int(guidance_scale > 1.0),
             _STEP_OUTPUT_SIZE: (target_height, target_width),
             _STEP_COT_TEXT_LIST: cot_text_list,
+            _STEP_ROLLOUT_METADATA: rollout_metadata_list,
             _STEP_AR_KV: self._snapshot_injected_ar_kv(),
         }
         return state
@@ -2093,9 +2096,14 @@ class HunyuanImage3Pipeline(
         # Postprocess deferred to engine post_process_func for overlap with next request.
 
         cot_text_list = state.extra.get(_STEP_COT_TEXT_LIST) or []
+        rollout_metadata_list = state.extra.get(_STEP_ROLLOUT_METADATA) or []
         metadata = {}
         if any(text is not None for text in cot_text_list):
-            metadata["text"] = {"ar_generated_text": cot_text_list[0]}
+            text_metadata: dict[str, Any] = {"ar_generated_text": cot_text_list[0]}
+            rollout_metadata = rollout_metadata_list[0] if rollout_metadata_list else None
+            if isinstance(rollout_metadata, dict):
+                text_metadata.update(rollout_metadata)
+            metadata["text"] = text_metadata
         return DiffusionOutput(
             output={
                 "payload": {"image": image[0]},
@@ -2123,6 +2131,7 @@ class HunyuanImage3Pipeline(
             system_prompt,
             batch_cond_image_info,
             tokenizer_bot_task,
+            rollout_metadata_list,
         ) = request_layout_utils.extract_hunyuan_prompt_inputs(
             req.prompts,
             extra_args,
@@ -2169,7 +2178,13 @@ class HunyuanImage3Pipeline(
         image = outputs[0]
         metadata = {}
         if any(t is not None for t in cot_text_list):
-            metadata["text"] = {"ar_generated_text": cot_text_list[0] if len(cot_text_list) == 1 else cot_text_list}
+            text_metadata: dict[str, Any] = {
+                "ar_generated_text": cot_text_list[0] if len(cot_text_list) == 1 else cot_text_list
+            }
+            rollout_metadata = rollout_metadata_list[0] if rollout_metadata_list else None
+            if isinstance(rollout_metadata, dict):
+                text_metadata.update(rollout_metadata)
+            metadata["text"] = text_metadata
         stage_durations = self.stage_durations if hasattr(self, "stage_durations") else None
         return DiffusionOutput(
             output={

--- a/vllm_omni/diffusion/models/hunyuan_image3/request_layout.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/request_layout.py
@@ -135,7 +135,14 @@ def extract_hunyuan_prompt_inputs(
     *,
     request_id: str,
     allow_cond_image: bool,
-) -> tuple[list[str], list[str | None], str | None, list[list[JointImageInfo]] | None, str]:
+) -> tuple[
+    list[str],
+    list[str | None],
+    str | None,
+    list[list[JointImageInfo]] | None,
+    str,
+    list[dict[str, Any] | None],
+]:
     """Normalize request prompt fields shared by planning and execution."""
 
     is_dummy_warmup = OmniDiffusionRequest.is_dummy_run_request_id(request_id)
@@ -162,6 +169,22 @@ def extract_hunyuan_prompt_inputs(
         (p.get("extra", {}).get("ar_generated_text") if isinstance(p, dict) else None) or None for p in prompts
     ]
 
+    # Per-prompt AR rollout metadata (#6768), surfaced through the same
+    # ``extra`` channel as ``ar_generated_text`` so RL consumers can
+    # teacher-force against the exact sampled tokens and log-probs.
+    rollout_metadata_list: list[dict[str, Any] | None] = []
+    for p in prompts:
+        if not isinstance(p, dict):
+            rollout_metadata_list.append(None)
+            continue
+        extra = p.get("extra", {}) or {}
+        fields = {
+            "ar_generated_token_ids": extra.get("ar_generated_token_ids"),
+            "ar_generated_logprobs": extra.get("ar_generated_logprobs"),
+            "ar_prompt_token_ids": extra.get("ar_prompt_token_ids"),
+        }
+        rollout_metadata_list.append(fields if any(v is not None for v in fields.values()) else None)
+
     batch_cond_image_info: list[list[JointImageInfo]] | None = None
     if any(not isinstance(p, str) for p in prompts):
         batch_cond_image_info = []
@@ -185,7 +208,7 @@ def extract_hunyuan_prompt_inputs(
         if not allow_cond_image or not any(has_cond_image):
             batch_cond_image_info = None
 
-    return prompt, cot_text_list, system_prompt, batch_cond_image_info, tokenizer_bot_task
+    return prompt, cot_text_list, system_prompt, batch_cond_image_info, tokenizer_bot_task, rollout_metadata_list
 
 
 def resolve_hunyuan_guidance_scale(sampling: Any, default_scale: float = 5.0) -> float:

--- a/vllm_omni/engine/__init__.py
+++ b/vllm_omni/engine/__init__.py
@@ -89,7 +89,12 @@ class OmniEngineCoreRequest(EngineCoreRequest):
         additional_information: AdditionalInformationPayload | None = None,
         model_intermediate_buffer: dict[str, Any] | None = None,
     ) -> "OmniEngineCoreRequest":
-        """Clone an EngineCoreRequest into an OmniEngineCoreRequest with optional payload overrides."""
+        """Clone an EngineCoreRequest into an OmniEngineCoreRequest with optional payload overrides.
+
+        Every upstream ``EngineCoreRequest`` field must be copied explicitly.
+        Field parity is pinned by tests/engine/test_omni_engine_core_request_contract.py
+        so upstream vLLM field drift is caught at test time.
+        """
 
         if prompt_embeds is None:
             prompt_embeds = request.prompt_embeds
@@ -119,6 +124,7 @@ class OmniEngineCoreRequest(EngineCoreRequest):
             reasoning_ended=request.reasoning_ended,
             reasoning_parser_kwargs=request.reasoning_parser_kwargs,
             abort_immediately=request.abort_immediately,
+            session_id=request.session_id,
             additional_information=additional_information,
             model_intermediate_buffer=model_intermediate_buffer,
         )

--- a/vllm_omni/model_executor/stage_input_processors/hunyuan_image3.py
+++ b/vllm_omni/model_executor/stage_input_processors/hunyuan_image3.py
@@ -91,6 +91,29 @@ def _extract_ratio_index(generated_token_ids) -> int | None:
     return None
 
 
+def _extract_generated_logprobs(output: Any) -> list[float | None] | None:
+    """Return the sampled token's logprob for each generated position.
+
+    ``output.logprobs`` is a list with one entry per generated token position,
+    each mapping token id -> Logprob (top-k). ``output.token_ids`` lists the
+    sampled token per position. Returns ``None`` when logprobs are unavailable
+    (e.g. not requested), so callers can omit the field instead of emitting a
+    misleading ``None``-filled list.
+    """
+    logprobs = getattr(output, "logprobs", None)
+    token_ids = getattr(output, "token_ids", None)
+    if not logprobs or not token_ids:
+        return None
+    per_position: list[float | None] = []
+    for position_logprobs, sampled_token_id in zip(logprobs, token_ids):
+        if not isinstance(position_logprobs, dict):
+            per_position.append(None)
+            continue
+        entry = position_logprobs.get(int(sampled_token_id))
+        per_position.append(float(entry.logprob) if entry is not None else None)
+    return per_position
+
+
 def ar2diffusion(
     source_outputs: list[Any],
     prompt: OmniTokensPrompt | TextPrompt | list | None = None,
@@ -189,6 +212,20 @@ def ar2diffusion(
             "ar_generated_text": cot_text_for_dit,
         },
     }
+
+    # Expose AR rollout metadata for RL teacher-forcing (#6768). These values
+    # are already computed by the AR stage but dropped; re-tokenizing
+    # ar_generated_text client-side is lossy (structure tokens) and cannot
+    # recover per-token log-probs.
+    extra = diffusion_input["extra"]
+    if generated_token_ids is not None:
+        extra["ar_generated_token_ids"] = list(generated_token_ids)
+    prompt_token_ids = getattr(ar_output, "prompt_token_ids", None)
+    if prompt_token_ids is not None:
+        extra["ar_prompt_token_ids"] = list(prompt_token_ids)
+    generated_logprobs = _extract_generated_logprobs(output)
+    if generated_logprobs is not None:
+        extra["ar_generated_logprobs"] = generated_logprobs
 
     # Forward use_system_prompt so the DiT can build the same system prefix.
     # Also forward the custom system prompt body when sys_type=custom so


### PR DESCRIPTION
## Why

[#6768](https://github.com/vllm-project/vllm-omni/issues/6768): RL frameworks (e.g. verl-omni) need the AR recaption segment as actually sampled during rollout — token ids and per-token log-probs — to teacher-force and compute `old_log_probs`. These values are already computed by the AR stage but dropped; only `ar_generated_text` survives, and re-tokenizing it client-side is lossy (structure tokens like `<img_size_*>` are stripped) and cannot recover log-probs.

## What

Thread the three requested fields through the same `extra` / output-metadata channel as `ar_generated_text`:

- `vllm_omni/model_executor/stage_input_processors/hunyuan_image3.py` (`ar2diffusion`): adds `ar_generated_token_ids` (from `output.cumulative_token_ids`), `ar_generated_logprobs` (sampled token per position, from `output.logprobs` + `output.token_ids`), and `ar_prompt_token_ids` (from `ar_output.prompt_token_ids`) to the diffusion input `extra`. Logprobs are omitted when not requested; extraction is defensive about missing/mismatched entries.
- `vllm_omni/diffusion/models/hunyuan_image3/request_layout.py` (`extract_hunyuan_prompt_inputs`): carries per-prompt rollout metadata alongside `cot_text_list`.
- `vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py`: stores the metadata on the step state and merges it into the output `metadata["text"]` envelope (both the step-execution `_post_process` and legacy `forward` paths), so consumers see it alongside `ar_generated_text`.

No existing keys or output shapes change; the new fields are additive.

## Tests

- `tests/model_executor/stage_input_processors/test_hunyuan_image3_bridge.py`: new cases pin that `ar2diffusion` carries token ids / per-token log-probs / prompt ids, and omits logprobs when unavailable.
- `tests/diffusion/models/hunyuan_image3/test_diffusion_kv_request.py`: updated for the extended `extract_hunyuan_prompt_inputs` tuple.

CPU-only (`core_model` + `cpu`), no model weights or GPU needed.

## Validation

- `ruff check` / `ruff format --check` pass with the pinned ruff 0.14.10.
- `python -m py_compile` passes on all changed files.
- Full pytest runs in the Buildkite CPU tier.

Closes #6768
