### PR TITLE
[BugFix][Engine] Honor stage-0 engine-arg overrides in single-stage diffusion fallback

### DIFF
--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1163,6 +1163,11 @@ class AsyncOmniEngine:
             "lora_scale": kwargs.get("lora_scale", 1.0),
             "lora_backend": kwargs.get("lora_backend", "peft"),
             "custom_pipeline_args": kwargs.get("custom_pipeline_args", None),
+            # Opt the single diffusion stage into the InlineStageDiffusionClient
+            # (in-Orchestrator thread) instead of a StageDiffusionProc subprocess
+            # + ZMQ/msgpack IPC.  Honors --stage-overrides '{"0": {...}}' via the
+            # stage-0 override fold above; requires num_replicas == 1.
+            "inline_diffusion": bool(kwargs.get("inline_diffusion", False)),
             "worker_extension_cls": kwargs.get("worker_extension_cls", None),
             "trust_remote_code": (False if kwargs.get("trust_remote_code") is None else kwargs["trust_remote_code"]),
             "distributed_executor_backend": kwargs.get("distributed_executor_backend"),
@@ -1277,12 +1282,20 @@ class AsyncOmniEngine:
         # the complete override mapping through load_and_resolve_stage_configs.
         default_stage_kwargs = kwargs
         stage_zero_overrides = (stage_overrides or {}).get("0", {})
+        if stage_zero_overrides:
+            # Scalar engine-arg overrides (e.g. inline_diffusion) fold into the
+            # fallback kwargs verbatim; "extras" deep-merges instead so thin
+            # overrides do not drop keys already present in kwargs.
+            default_stage_kwargs = {
+                **kwargs,
+                **{k: v for k, v in stage_zero_overrides.items() if k != "extras"},
+            }
         if "extras" in stage_zero_overrides:
             override_extras = stage_zero_overrides["extras"]
             if not isinstance(override_extras, Mapping):
                 raise TypeError("stage 0 extras must be a mapping")
             default_stage_kwargs = {
-                **kwargs,
+                **default_stage_kwargs,
                 "extras": {
                     **(kwargs.get("extras") or {}),
                     **override_extras,


### PR DESCRIPTION
Since #5885, the inline-vs-subprocess decision for diffusion stages changed from

```python
use_inline = self._num_stages == 1 and plan.num_replicas == 1
```

to requiring `inline_diffusion` or `custom_pipeline_args` in the stage engine args
(`StageRuntime`). Deployments that serve a diffusion checkpoint **without a
registered pipeline** — the single-stage fallback built by
`AsyncOmniEngine._create_default_diffusion_stage_cfg` — had no way to opt into
inline mode:

- the fallback factory never emitted `inline_diffusion` (or `custom_pipeline_args`), and
- `--stage-overrides` entries for stage 0 were silently dropped on this path
  (only the `"extras"` key was folded into the fallback kwargs).

As a result, every unregistered single-stage deployment silently switched from
`InlineStageDiffusionClient` (engine runs inside the Orchestrator process, no
inter-process serialization) to a `StageDiffusionProc` subprocess + ZMQ/msgpack
after upgrading past #5885.

### Failure mode

The final diffusion result must now cross the msgpack IPC boundary, and msgpack's
bin format hard-caps a single bytes-like object at `2**32 - 1` bytes (msgspec
enforces this with no opt-out). Decoded video outputs are transported as one
float32 ndarray, so the payload is `frames × H × W × 3 × 4` bytes:

- 5s clip at 720p: ~1.3 GB → works
- 15s clip at 720p+: >4 GiB → request fails even though generation itself succeeded

```
ERROR ... in _dispatch_request
    await response_socket.send(encoder.encode({"type": "result", "output": result}))
msgspec.EncodeError: Can't encode bytes-like objects longer than 2**32 - 1
```

Observed on a text-to-video(+audio) serving deployment: 5s sync requests succeed,
15s requests abort with the error above.

### Fix

1. `_resolve_stage_configs`: fold scalar stage-0 `--stage-overrides` entries into
   the single-stage fallback kwargs (previously ignored). `"extras"` keeps its
   existing deep-merge behavior.
2. `_create_default_diffusion_stage_cfg`: emit `inline_diffusion` (default
   `False`) in the fallback stage engine args, so

   ```bash
   --stage-overrides '{"0": {"inline_diffusion": true}}'
   ```

   opts a `num_replicas == 1` single-stage deployment back into
   `InlineStageDiffusionClient`, removing the msgpack round-trip from the result
   path entirely.

### Compatibility

- Deployments that do not pass stage-0 overrides are unaffected: the emitted key
  defaults to `False`.
- Unknown engine-arg keys are already filtered by `OmniDiffusionConfig.from_kwargs`,
  so the extra key is inert downstream (registered pipelines have emitted
  `inline_diffusion` in engine args since #5885).
- Registered multi-stage pipelines are untouched.

### Verification

Single-stage text-to-video(+audio) deployment (MiniMax-H3 FL2VA, 8-way USP,
distributed layerwise offload enabled):

- before: 5s sync video requests succeed; 15s requests fail with the
  `msgspec.EncodeError` above
- after `--stage-overrides '{"0": {"inline_diffusion": true}}'`: startup log shows
  `[InlineStageDiffusionClient] stage-0 [rep-0] initialized inline`, and 15s
  requests complete end-to-end; 5s baseline unchanged

### Follow-ups

The msgpack 4 GiB per-blob limit still applies to subprocess deployments
(multi-replica, disaggregated topologies). A follow-up adding chunked blob
encoding in `OmniMsgpackEncoder` (+ optionally uint8 pixel transport) is planned
so large outputs no longer depend on execution topology.
