### PR TITLE
[Bugfix][Diffusion] Restore inline single-stage execution

### DIFF
--- a/tests/engine/test_async_omni_engine_stage_init.py
+++ b/tests/engine/test_async_omni_engine_stage_init.py
@@ -399,12 +399,20 @@ def test_initialize_local_diffusion_replica_restores_device_visibility_after_loc
             os.environ[env_var] = old_env
 
 
-def test_initialize_local_diffusion_replica_passes_stage_init_timeout_and_inline_flag(monkeypatch):
+@pytest.mark.parametrize(
+    ("num_stages", "expected_inline"),
+    [(1, True), (2, False)],
+)
+def test_initialize_local_diffusion_replica_passes_stage_init_timeout_and_inline_flag(
+    monkeypatch,
+    num_stages,
+    expected_inline,
+):
     import vllm_omni.engine.stage_runtime as runtime_mod
     from vllm_omni.engine.stage_engine_startup import StageReplicaResources
 
     runtime = StageRuntime(
-        stage_configs=[types.SimpleNamespace()],
+        stage_configs=[types.SimpleNamespace()] * num_stages,
         model="dummy-model",
         config_path="dummy-config",
         stage_init_timeout=1,
@@ -434,7 +442,7 @@ def test_initialize_local_diffusion_replica_passes_stage_init_timeout_and_inline
         "stage_id": 0,
         "stage_init_timeout": 302,
         "batch_size": 4,
-        "use_inline": False,
+        "use_inline": expected_inline,
         "omni_master_server": None,
     }
 

--- a/vllm_omni/engine/stage_runtime.py
+++ b/vllm_omni/engine/stage_runtime.py
@@ -673,7 +673,8 @@ class StageRuntime:
                     metadata=plan.metadata,
                     stage_init_timeout=stage_init_timeout,
                     batch_size=self._diffusion_batch_size,
-                    use_inline=plan.num_replicas == 1 and bool(inline_diffusion or custom_pipeline_args),
+                    use_inline=plan.num_replicas == 1
+                    and bool(self._num_stages == 1 or inline_diffusion or custom_pipeline_args),
                     replica_id=plan.replica_id,
                     omni_master_server=self._get_omni_master_server(),
                     omni_coordinator_address=self._get_coordinator_address(),


### PR DESCRIPTION
Fixes #6798.
Fixes #6797.

## Root cause

#5885 changed every diffusion stage to use a stage subprocess unless inline diffusion was explicitly enabled. That also changed legacy single-stage, single-replica deployments from inline execution to subprocess execution. Large diffusion outputs then crossed the stage boundary through shared memory: MiniMax-H3 serializes a 2.59 GB video tensor per request, and Cosmos3-Nano serializes 189-frame 720p float32 output, producing both reported latency regressions.

This restores the previous inline behavior when the entire pipeline has one stage and one replica. Multi-stage pipelines remain subprocess-isolated by default, while explicit inline diffusion and custom pipelines retain their existing opt-in behavior.

## Validation

- 111 passed: tests/engine/test_async_omni_engine_stage_init.py and tests/engine/test_single_stage_mode.py
- pre-commit passed for both changed files
- exact 4-case MiniMax-H3 benchmark passed with real weights on 4x L20X:

| Case | baseline | main before | fixed |
| --- | ---: | ---: | ---: |
| T2V | 37.29s | 41.43s | 34.31s |
| TI2V | 38.35s | 41.82s | 34.76s |
| V2V | 117.13s | 118.06s | 113.79s |
| T2V DLO | 37.00s | 38.95s | 33.60s |

- exact 4-case Cosmos3-Nano benchmark passed with real weights on 2x L20X:

| Case | baseline c6df39e9 | issue a5b8c827 | main c4192568 | fixed |
| --- | ---: | ---: | ---: | ---: |
| T2I | 0.7650s | 0.7342s | 0.7559s | 0.7290s |
| T2V | 28.6256s | 32.9358s | 31.9101s | 26.7357s |
| I2V | 28.5119s | 32.8296s | 31.6386s | 26.0620s |
| V2V | 28.8004s | 33.1189s | 33.0619s | 26.0799s |

Benchmark commands:

- pytest -s -v tests/dfx/perf/scripts/run_diffusion_benchmark.py --test-config-file tests/dfx/perf/tests/test_minimax_h3_vllm_omni.json
- pytest -s -v tests/dfx/perf/scripts/run_diffusion_benchmark.py --test-config-file tests/dfx/perf/tests/test_cosmos3_vllm_omni.json