### PR TITLE
[Bugfix] Recover Omni benchmark TPOT from Stage 0 metrics

### DIFF
--- a/tests/benchmarks/patch/test_patch.py
+++ b/tests/benchmarks/patch/test_patch.py
@@ -9,6 +9,7 @@ import asyncio
 import base64
 import json
 import time
+from argparse import Namespace
 from types import SimpleNamespace
 
 import pytest
@@ -20,6 +21,7 @@ from vllm_omni.benchmarks.patch.patch import (
     _apply_stage0_token_timings,
     async_request_openai_chat_omni_completions,
     async_request_openai_realtime_duplex,
+    should_request_stage_metrics,
 )
 from vllm_omni.experimental.fullduplex.client import RealtimeEventCollector
 
@@ -272,6 +274,107 @@ def test_stage0_token_count_without_timing_is_not_measured():
 def create_sse_chunk(data_dict):
     """Helper to create SSE formatted chunk"""
     return f"data: {json.dumps(data_dict)}\n\n".encode()
+
+
+def test_chat_text_timing_metrics_request_stage_metrics():
+    args = Namespace(
+        backend="openai-chat-omni",
+        percentile_metrics="ttft,tpot,itl,e2el",
+        print_stage=False,
+        extra_body={},
+    )
+
+    assert should_request_stage_metrics(args) is True
+
+
+@pytest.mark.asyncio
+async def test_bundled_first_text_chunk_uses_stage0_token_timings(mocker: MockerFixture):
+    """Engine timings recover TPOT when every text token arrives together."""
+    request_input = RequestFuncInput(
+        model="test-model",
+        model_name="test-model",
+        prompt="test prompt",
+        api_url="http://test.com/v1/chat/completions",
+        prompt_len=10,
+        output_len=20,
+    )
+    chunks = [
+        create_sse_chunk(
+            {
+                "choices": [{"delta": {"content": "ABCD"}}],
+                "modality": "text",
+                "usage": {"prompt_tokens": 10, "completion_tokens": 4, "total_tokens": 14},
+                "metrics": {
+                    "stage_metrics": {
+                        "0": {
+                            "num_tokens_out": 4,
+                            "vllm_itls_ms": [10.0, 11.0, 12.0],
+                            "vllm_tpot_ms": 11.0,
+                        }
+                    }
+                },
+            }
+        ),
+        b"data: [DONE]\n\n",
+    ]
+    mock_response = MockResponse(200, chunks)
+    mock_session = mocker.AsyncMock()
+    mock_session.post = mocker.MagicMock(return_value=mock_response)
+
+    output = await async_request_openai_chat_omni_completions(request_input, mock_session)
+
+    assert output.success is True
+    assert output.output_tokens == 4
+    assert output.itl == pytest.approx([0.010, 0.011, 0.012])
+    assert output.text_latency - output.ttft == pytest.approx(0.033)
+    assert output.tpot_measured is True
+
+
+@pytest.mark.asyncio
+async def test_positive_client_text_timings_take_precedence_over_stage0(mocker: MockerFixture):
+    request_input = RequestFuncInput(
+        model="test-model",
+        model_name="test-model",
+        prompt="test prompt",
+        api_url="http://test.com/v1/chat/completions",
+        prompt_len=10,
+        output_len=20,
+    )
+    chunks = [
+        create_sse_chunk(
+            {
+                "choices": [{"delta": {"content": "A"}}],
+                "modality": "text",
+                "usage": {"prompt_tokens": 10, "completion_tokens": 1, "total_tokens": 11},
+            }
+        ),
+        create_sse_chunk(
+            {
+                "choices": [{"delta": {"content": "B"}}],
+                "modality": "text",
+                "usage": {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12},
+                "metrics": {
+                    "stage_metrics": {
+                        "0": {
+                            "num_tokens_out": 2,
+                            "vllm_itls_ms": [1000.0],
+                            "vllm_tpot_ms": 1000.0,
+                        }
+                    }
+                },
+            }
+        ),
+        b"data: [DONE]\n\n",
+    ]
+    mock_response = MockResponse(200, chunks, delay_between_chunks=0.01)
+    mock_session = mocker.AsyncMock()
+    mock_session.post = mocker.MagicMock(return_value=mock_response)
+
+    output = await async_request_openai_chat_omni_completions(request_input, mock_session)
+
+    assert output.success is True
+    assert len(output.itl) == 1
+    assert 0.0 < output.itl[0] < 0.1
 
 
 # ============================================================================

--- a/vllm_omni/benchmarks/patch/patch.py
+++ b/vllm_omni/benchmarks/patch/patch.py
@@ -119,6 +119,17 @@ def should_request_stage_metrics(args: Any) -> bool:
     if backend in _IMAGE_STAGE_METRICS_BACKENDS:
         return True
 
+    percentile_metrics = getattr(args, "percentile_metrics", ()) or ()
+    if isinstance(percentile_metrics, str):
+        percentile_metrics = percentile_metrics.split(",")
+    selected_metrics = {str(metric).strip().lower() for metric in percentile_metrics}
+    if backend == "openai-chat-omni" and selected_metrics.intersection({"tpot", "itl"}):
+        # Client receive timestamps normally provide these metrics. Under
+        # enough load, however, every text token can be coalesced into one
+        # event-loop read, leaving no positive interval. Request the engine's
+        # Stage 0 timings so that path still has an authoritative measurement.
+        return True
+
     extra_body = getattr(args, "extra_body", None) or {}
     modalities = extra_body.get("modalities") if isinstance(extra_body, dict) else None
     return backend == "openai-chat-omni" and "image" in (modalities or [])
@@ -854,6 +865,33 @@ def _update_output_stage_metrics_from_payload(
         output.stage_metrics.update(stage_snapshot)
 
 
+def _apply_chat_stage0_token_timings(output: MixRequestFuncOutput) -> bool:
+    """Apply native Stage 0 timings from a chat response snapshot."""
+    stage_metrics = output.stage_metrics
+    if not isinstance(stage_metrics, dict):
+        return False
+    stage0 = stage_metrics.get("0")
+    if not isinstance(stage0, dict):
+        return False
+
+    output_tokens = coerce_positive_int_scalar(stage0.get(defs.NUM_TOKENS_OUT))
+    expected_output_tokens = coerce_positive_int_scalar(output.output_tokens)
+    if output_tokens is None or expected_output_tokens is None or output_tokens != expected_output_tokens:
+        return False
+
+    return _apply_stage0_token_timings(
+        output,
+        [
+            {
+                "output_token_count": output_tokens,
+                "itls_ms": stage0.get(defs.VLLM_ITLS_MS),
+                "tpot_ms": stage0.get(defs.VLLM_TPOT_MS),
+            }
+        ],
+        expected_output_tokens=expected_output_tokens,
+    )
+
+
 def _image_metrics_from_stage_metrics(metrics: dict[str, Any] | None) -> tuple[int, float, int, float]:
     if not isinstance(metrics, dict):
         return 0, 0.0, 0, 0.0
@@ -1121,6 +1159,14 @@ async def async_request_openai_chat_omni_completions(
 
                     output.latency = timestamp - st
                     output.generated_text = generated_text
+                    if output.output_tokens > 1 and not any(
+                        isinstance(value, int | float)
+                        and not isinstance(value, bool)
+                        and np.isfinite(value)
+                        and value > 0
+                        for value in output.itl
+                    ):
+                        _apply_chat_stage0_token_timings(output)
                     if output.itl:
                         # Align text_latency with ITL so TPOT formula and
                         # mean(ITL) are consistent.  Do NOT infer output_tokens


### PR DESCRIPTION
Fixes #6796.

## Purpose

The weekly Qwen3-Omni multi-replica benchmark can fail with:

```text
AssertionError: TPOT baseline is configured, but no measurable TPOT samples were produced
```

The failure is intermittent: under load, multiple (or all) text tokens can be delivered in one event-loop read. The benchmark expands the continuous usage delta correctly, but if every token shares the first receive timestamp, every client-observed ITL is zero. The metrics layer correctly rejects that as an unmeasured TPOT, leaving `num_tpot_samples == 0`.

Stage 0 already records authoritative engine-side `vllm_itls_ms` and `vllm_tpot_ms`, but text TPOT benchmarks did not request those stage metrics. This change:

- requests stage metrics for `openai-chat-omni` runs that select TPOT or ITL;
- uses the Stage 0 native timing only when the client observed no positive ITL;
- requires the Stage 0 and OpenAI usage token counts to match before falling back; and
- preserves normal positive client-side timing unchanged.

The existing invalid-TPOT checks and DFX baseline assertion remain strict.

Reproduction command from the issue:

```bash
export BENCHMARK_DIR=tests/dfx/perf/results
pytest -s -v tests/dfx/perf/scripts/run_benchmark.py \
  --test-config-file tests/dfx/perf/tests/test_qwen3_omni_multi_replicas.json
```

The exact real-weight command did not naturally trigger the intermittent failure in two local runs. A deterministic regression test bundles four tokens into the first SSE arrival: it produces `[0.0, 0.0, 0.0]` on main and positive Stage 0 ITLs with this fix.

## Test Plan

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** 59fcc539309999fce3b312a8adee7b6136bdbb60

Hardware/software: 3x NVIDIA L20X (143771 MiB each), driver 570.133.20, PyTorch 2.13.0+cu129, CUDA 12.9. Model weights were loaded from the local Hugging Face cache.

Commands:

```bash
gpu run --gpus 1 -- bash -lc "source .venv/bin/activate && export HF_HOME=/workspace/models && pytest -q tests/benchmarks/patch/test_patch.py tests/benchmarks/metrics/test_metrics.py tests/dfx/perf/tests/test_runner_metadata.py"

gpu run --gpus 3 -- bash -lc "source .venv/bin/activate && export HF_HOME=/workspace/models && export BENCHMARK_DIR=tests/dfx/perf/results && pytest -s -v tests/dfx/perf/scripts/run_benchmark.py --test-config-file tests/dfx/perf/tests/test_qwen3_omni_multi_replicas.json"
```

## Test Result

- Deterministic regression before fix: 2 failed, 1 passed (missing stage-metric opt-in and bundled first-chunk ITLs remained zero).
- Deterministic regression after fix: 3 passed.
- Related benchmark/metrics/DFX tests: 66 passed, 14 warnings.
- Full 3-GPU real-weight suite: 4 passed, 14 warnings in 2672.34s (44:32).

| Concurrency | Requests | Mean TPOT | Duration |
| ---: | ---: | ---: | ---: |
| 8 | 128/128 | 5.93 ms | 410.77 s |
| 16 | 128/128 | 7.96 ms | 261.68 s |
| 24 | 128/128 | 9.89 ms | 249.37 s |
| 32 | 128/128 | 11.84 ms | 214.09 s |

All three random multimodal cases also passed (10 audio, 40 image/video, and 100 mixed image/video/audio requests).