### PR TITLE
[Diffusion][Performance] Optimize MiniMax-H3 video output transfer

### DIFF
--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
@@ -57,7 +57,8 @@ def test_h3_prepares_resolved_cache_state_immediately_before_denoise():
         return torch.zeros(1), torch.zeros(1)
 
     pipeline.diffuse = diffuse
-    pipeline.decode = Mock(return_value=(torch.zeros(1), torch.zeros(1)))
+    decoded_audio = torch.zeros(1)
+    pipeline.decode = Mock(return_value=(torch.zeros(1, 3, 1, 1, 1), decoded_audio))
     sampling = OmniDiffusionSamplingParams(
         quality="high",
         width=1344,
@@ -86,7 +87,9 @@ def test_h3_prepares_resolved_cache_state_immediately_before_denoise():
         num_inference_steps=50,
         extra_args={"task": "t2va", "aspect_ratio": "16:9"},
     )
-    assert output.output == pipeline.decode.return_value
+    assert output.output[0].shape == (1, 1, 1, 1, 3)
+    assert output.output[0].dtype == torch.uint8
+    assert output.output[1] is decoded_audio
 
 
 def test_pipeline_import_registry_and_component_discovery():
@@ -505,6 +508,26 @@ def test_joint_postprocess_is_multiprocessing_picklable():
     assert result["fps"] == 24
 
 
+def test_joint_video_output_is_quantized_before_transfer():
+    from vllm_omni.diffusion.models.minimax_h3.pipeline_minimax_h3 import (
+        _minimax_h3_post_process,
+        _prepare_minimax_h3_video_output,
+    )
+
+    video = torch.linspace(-0.1, 1.1, 2 * 3 * 2 * 4 * 5, dtype=torch.float64).reshape(2, 3, 2, 4, 5)
+    expected = torch.round(video.float().clamp(0, 1) * 255).to(torch.uint8).permute(0, 2, 3, 4, 1)
+    prepared = _prepare_minimax_h3_video_output(video)
+
+    assert prepared.dtype == torch.uint8
+    assert prepared.is_contiguous()
+    assert prepared.shape == (2, 2, 4, 5, 3)
+    torch.testing.assert_close(prepared, expected, rtol=0, atol=0)
+
+    result = _minimax_h3_post_process((prepared, torch.zeros(1, 2, 6)))
+    assert result["video"][0].dtype == np.uint8
+    np.testing.assert_array_equal(result["video"][0], expected[0].numpy())
+
+
 def test_cfg_parallel_is_rejected_for_distilled_checkpoint():
     from vllm_omni.diffusion.models.minimax_h3 import MiniMaxH3Pipeline
 
@@ -627,7 +650,7 @@ def _distilled_pipeline(diffuse_calls, base_schedule_by_partition):
         return torch.zeros(1), torch.zeros(1)
 
     pipeline.diffuse = diffuse
-    pipeline.decode = Mock(return_value=(torch.zeros(1), torch.zeros(1)))
+    pipeline.decode = Mock(return_value=(torch.zeros(1, 3, 1, 1, 1), torch.zeros(1)))
     return pipeline
 
 

--- a/tests/entrypoints/openai_api/test_video_api_utils.py
+++ b/tests/entrypoints/openai_api/test_video_api_utils.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Unit tests for OpenAI-compatible video API encoding helpers."""
 
 import base64
@@ -220,6 +220,19 @@ def test_channel_first_video_tensor_is_converted_to_channel_last():
 
     assert frames.shape == (5, 2, 6, 3)
     np.testing.assert_array_equal(frames, video.permute(1, 2, 3, 0).numpy())
+
+
+def test_contiguous_uint8_video_reaches_mux_without_conversion(monkeypatch):
+    video = np.arange(2 * 4 * 5 * 3, dtype=np.uint8).reshape(2, 4, 5, 3)
+
+    def fail_prepare(*args, **kwargs):
+        raise AssertionError("ready-to-encode uint8 video must not be normalized")
+
+    monkeypatch.setattr(video_api_utils, "_prepare_video_frames", fail_prepare)
+
+    frames = video_api_utils._coerce_video_to_uint8_frames(video)
+
+    assert frames is video
 
 
 def test_channel_first_video_tensor_uses_direct_planar_mux(monkeypatch):

--- a/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
+++ b/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
@@ -361,7 +361,10 @@ def _minimax_h3_post_process(output, output_type: str = "np"):
     if output_type == "latent":
         return output
     if output_type == "np":
-        video = video.detach().float().cpu().permute(0, 2, 3, 4, 1).clamp(0, 1).numpy()
+        if video.dtype == torch.uint8 and video.ndim == 5 and video.shape[-1] == 3:
+            video = video.detach().cpu().numpy()
+        else:
+            video = video.detach().float().cpu().permute(0, 2, 3, 4, 1).clamp(0, 1).numpy()
         audio = audio.detach().float().cpu().numpy()
         video = [sample for sample in video]
     return {
@@ -370,6 +373,16 @@ def _minimax_h3_post_process(output, output_type: str = "np"):
         "audio_sample_rate": MINIMAX_H3_AUDIO_SAMPLE_RATE,
         "fps": MINIMAX_H3_FPS,
     }
+
+
+def _prepare_minimax_h3_video_output(video: torch.Tensor) -> torch.Tensor:
+    """Quantize decoded frames in place before worker-to-engine transfer."""
+    video = video.detach().float()
+    video.clamp_(0, 1).mul_(255).round_()
+    return video.permute(0, 2, 3, 4, 1).to(
+        dtype=torch.uint8,
+        memory_format=torch.contiguous_format,
+    )
 
 
 def _register_dlo_component_cache(cache: BoundedAllocatorCache, *components: Any) -> None:
@@ -2406,10 +2419,10 @@ class MiniMaxH3Pipeline(
                 height=context["height"],
                 width=context["width"],
             )
-            videos.append(video)
+            videos.append(_prepare_minimax_h3_video_output(video))
             audios.append(audio)
-        video = torch.cat(videos, dim=0)
-        audio = torch.cat(audios, dim=0)
+        video = videos[0] if len(videos) == 1 else torch.cat(videos, dim=0)
+        audio = audios[0] if len(audios) == 1 else torch.cat(audios, dim=0)
         return DiffusionOutput(
             output=(video, audio),
             post_process_func=get_minimax_h3_post_process_func(self.od_config),
@@ -2711,6 +2724,7 @@ class MiniMaxH3Pipeline(
             height=shape["height"],
             width=shape["width"],
         )
+        video = _prepare_minimax_h3_video_output(video)
         return DiffusionOutput(
             output=(video, audio),
             post_process_func=get_minimax_h3_post_process_func(self.od_config),

--- a/vllm_omni/entrypoints/openai/video_api_utils.py
+++ b/vllm_omni/entrypoints/openai/video_api_utils.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """
 Shared helper utilities for OpenAI-compatible video generation API.
 """
@@ -553,6 +553,14 @@ def _coerce_prepared_video_to_uint8_frames(
 
 def _coerce_video_to_uint8_frames(video: Any) -> np.ndarray:
     """Convert a video payload into contiguous uint8 frames shaped (F, H, W, 3)."""
+    if (
+        isinstance(video, np.ndarray)
+        and video.dtype == np.uint8
+        and video.ndim == 4
+        and video.shape[-1] == 3
+        and video.flags.c_contiguous
+    ):
+        return video
     frames, frame_shape, common_dtype = _prepare_video_frames(video)
     return _coerce_prepared_video_to_uint8_frames(frames, frame_shape, common_dtype)
 


### PR DESCRIPTION
## Purpose

MiniMax-H3 decoded video was returned from the diffusion worker as FP32 BCTHW. A 5-second 1344x768 output therefore moved 1,535,901,696 bytes through the worker-to-engine path before the parent process performed layout conversion and quantization for video encoding.

The worker-to-engine path already provides asynchronous pinned D2H transfer. This PR makes that path substantially cheaper by:

- clamping, scaling, and rounding decoded frames on the GPU after VAE decode;
- combining the dtype and BCTHW-to-BTHWC layout conversion into one contiguous uint8 allocation;
- avoiding an additional `torch.cat` allocation for the common single-output case; and
- letting the video encoder consume an already contiguous FHWC uint8 array without normalizing and copying it again.

There are no new Python or CLI options. The HTTP video response and encoded MP4 are unchanged. The raw MiniMax-H3 offline frame representation changes from float32 `[0, 1]` to contiguous uint8 `[0, 255]`; callers that consume `OmniRequestOutput.images[0]` directly should branch on dtype, as the generic offline video examples already do.

## Test Plan

The before/after runs and SGLang reference used the same MiniMax-H3 FL2VA BF16 checkpoint, prompt, seed, workload, and top-level parallel degree on 8x NVIDIA B300 SXM6 AC:

- 5.0 seconds, 124 frames, 1344x768, 24 FPS
- 50 scheduler points / 49 denoise updates
- DP1, TP1, SP8 (Ulysses 8, ring 1)
- vLLM-Omni: text-encoder TP8 and VAE tile/patch parallel 8
- SGLang: `encoder_parallel=fold` and its native SP8 decoder path
- CUDNN attention, eager mode, no offload
- vLLM-Omni: one warm-up followed by three measured generations in the same engine
- SGLang reference: one warm-up followed by two measured generations in the same engine

**vLLM Version:** 0.28.0 (Python 3.12.3, torch 2.13.0+cu130)

**vLLM-Omni Commit:** baseline `f7f48929db8dcd60c8ce538f4057bec5a789057c`; candidate `bdfd4847325ed70c88c7046c82acbbf7e7cf9459`

**SGLang Commit:** `fe694986a296787cb0ada3b8cd7b6dccd21de72a`

## Test Result

| Metric | vLLM-Omni baseline | This PR | SGLang reference | This PR vs baseline |
| --- | ---: | ---: | ---: | ---: |
| Steady end-to-end inference | 22.578 s (n=3) | 21.683 s (n=3) | 18.830 s (n=2) | -0.895 s / -3.96% |
| End-to-end standard deviation | 0.082 s | 0.018 s | 0.019 s | — |
| Worker video payload per output | 1,535,901,696 bytes | 383,975,424 bytes | N/A | -75% |
| Peak GPU memory | 84,358 MiB | 84,358 MiB | 82,866 MiB | unchanged |

Measured generations were `22.586 / 22.656 / 22.492 s` before and `21.703 / 21.676 / 21.669 s` after. Both runs produced a 2,503,544-byte MP4 with the same SHA256:

`9904a1ae9f0fb86d38cfc43d4398bdacd07c6ca4d289a37eaa87a9965378e6aa`

The matching SGLang no-offload/SP8 steady inference times were `18.816 / 18.844 s`; its corresponding wall times including MP4 materialization were `19.370 / 19.463 s` (mean `19.417 s`). The table compares vLLM-Omni `valid_wave_s` with SGLang scheduler `total_duration_ms`; both exclude engine shutdown and MP4 materialization. This PR closes 23.9% of the original vLLM-Omni-to-SGLang steady-inference gap, while the remaining vLLM-Omni latency is 2.853 s (15.15%) above SGLang.

Validation:

- `python -m pytest -q tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py tests/entrypoints/openai_api/test_video_api_utils.py` — 182 passed
- Ruff, formatting, typos, SPDX, forbidden-import, CUDA-call, and test-mark hooks passed for all changed files
- The changed-file mypy hook reports the same existing 3 library and 7 test errors on the clean baseline; this PR adds no mypy errors
- Signed-off commit and static pre-submit check passed against current `upstream/main`
