### PR TITLE
[CI][MiniCPM-o] Make audio consistency checks deterministic

### DIFF
--- a/tests/e2e/online_serving/test_minicpmo_4_5.py
+++ b/tests/e2e/online_serving/test_minicpmo_4_5.py
@@ -27,7 +27,16 @@ _MODEL = "openbmb/MiniCPM-o-4_5"
 _CI_DEPLOY = modify_stage_config(
     get_deploy_config_path("minicpmo_4_5.yaml"),
     updates={
-        "stages": {0: {"default_sampling_params.max_tokens": 64}, 1: {"default_sampling_params.max_tokens": 1024}}
+        "stages": {
+            0: {"default_sampling_params.max_tokens": 64},
+            1: {
+                "default_sampling_params.max_tokens": 1024,
+                # Content-consistency assertions must not depend on a random
+                # codec trajectory: different valid TTS samples can append an
+                # audible tail even when Thinker text is identical.
+                "default_sampling_params.temperature": 0.0,
+            },
+        },
     },
 )
 


### PR DESCRIPTION
## Summary

- make Stage 1 Talker generation greedy in the MiniCPM-o online-test CI deploy config
- keep the shipping `minicpmo_4_5.yaml` sampling parameters unchanged
- keep the existing content-similarity threshold and generated audio unchanged

## Why

`test_image_to_text_audio_001` compares a Whisper transcription of generated speech with the Thinker text. The CI-only deploy config previously inherited stochastic Talker codec sampling (`temperature: 0.8`). With the issue reproduction image, the Thinker text remained correct while different valid codec trajectories sometimes appended an audible semantic tail such as `Duh!` or `This is it.`, causing the content assertion to fluctuate.

The upstream checkpoint Talker can also produce a tail stochastically on the captured Thinker conditions, while greedy Talker decoding produced the expected transcription for every captured condition. Since this assertion is intended to check content consistency rather than sample diversity, the derived CI config now uses `temperature: 0.0` for Stage 1. Production behavior remains unchanged.

Fixes #6815.

## Validation

- fixed issue image, real weights, 5 concurrent requests: passed
- `pytest -q tests/config/test_config_factory.py -k minicpmo`: 21 passed
- `pre-commit run --files tests/e2e/online_serving/test_minicpmo_4_5.py`: passed
- exact H100/omni selection command below: 19 passed, 1 failed, 2 skipped, 843 deselected in 2:58:33
  - all 19 MiniCPM-o selected tests passed, including both default and async expansion variants
  - the sole failure was the unrelated Nemotron native-duplex test timing out after 300 seconds waiting for model output
  - an isolated real-weight rerun of that Nemotron test reproduced the same timeout (`1 failed in 641.76s`); this PR does not touch the Nemotron path

Exact selection command:

```bash
pytest -sv tests/e2e --run-level "full_model" -m "full_model and H100 and omni and cards_1" --ignore=tests/e2e/accuracy --ignore=tests/e2e/online_serving/test_minicpmo_4_5_duplex_expansion.py
```
