### PR TITLE
[Bugfix][Core] Do not advance the segment watermark past an unmaintained request counter

### DIFF
--- a/tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
+++ b/tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
@@ -2959,3 +2959,34 @@ def test_abort_clears_native_codec_state_before_external_id_reuse(build_adapter)
     )
 
     assert torch.equal(replacement_payload.codes.audio, torch.full((1, 31), 202, dtype=torch.long))
+
+
+def test_save_async_boundary_holds_generation_without_request_counter(build_adapter):
+    """A boundary must not advance past a generation nothing can catch up to.
+
+    When the producing stage maintains ``_omni_segment_generation`` on the
+    request, a boundary may start the next segment's watermark at
+    ``generation + 1`` because the following frame will carry it. On paths
+    where the request has no such counter, that speculative advance makes every
+    subsequent frame look stale and starves the stream permanently
+    (vllm-project/vllm-omni#6816).
+    """
+    adapter, _ = build_adapter(stage_id=1)
+
+    request = _req("req-nogen", RequestStatus.WAITING, external_req_id="ext-nogen")
+    request.resumable = True
+    request._omni_segment_generation = None
+
+    adapter.save_async(multimodal_output=None, request=request, is_segment_finished=True)
+    assert adapter._segment_generation["ext-nogen"] == 0
+
+    follow_up = _req("req-nogen-next", RequestStatus.WAITING, external_req_id="ext-nogen")
+    follow_up.resumable = True
+    follow_up.num_computed_tokens = 3
+    follow_up._omni_segment_generation = None
+    queued_before = len(adapter._pending_save_reqs)
+
+    adapter.save_async(multimodal_output=None, request=follow_up, is_segment_finished=False)
+
+    assert len(adapter._pending_save_reqs) == queued_before + 1
+    assert adapter._pending_save_reqs[-1]["request"] is follow_up

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -401,7 +401,15 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
                 if is_segment_finished:
                     # The queued FIFO item now owns the old segment. Start the next
                     # segment's deduplication watermark before the worker sends it.
-                    self._segment_generation[external_req_id] = generation + 1
+                    # Only advance past the current generation when the producer
+                    # maintains a request-side counter that can catch up. On paths
+                    # where the request carries no `_omni_segment_generation`, a
+                    # speculative +1 makes every subsequent frame look stale and
+                    # starves the stream permanently (see #6816).
+                    if getattr(request, "_omni_segment_generation", None) is not None:
+                        self._segment_generation[external_req_id] = generation + 1
+                    else:
+                        self._segment_generation[external_req_id] = generation
                     self.requests_num_chunks_sent.pop(external_req_id, None)
         if reject_reason is not None:
             logger.error("Cannot enqueue %s: %s", external_req_id, reject_reason)


### PR DESCRIPTION
## Purpose

Fixes #6816.

On a segment boundary, `save_async` moves the dedup watermark to `generation + 1`:

```python
if is_segment_finished:
    self._segment_generation[external_req_id] = generation + 1
```

That assumes the next frame will arrive carrying the higher value. It does, as
long as the producing stage keeps `request._omni_segment_generation` up to date.
Where nothing maintains that counter, the watermark can never be reached: every
later frame fails `generation < expected_generation` and gets dropped, and the
only reset (`_clear_sender_state_locked`) needs a terminal that never comes.

## Symptom

On the native Nemotron VoiceChat duplex path, Stage 0 kept producing while
Stage 1 discarded everything:

```
(StageEngineCoreProc_stage1_replica0) WARNING [chunk_transfer_adapter.py:354]
Skip late save_async for request duplex-s.<session>.i.0.e.0.r.stage0,
segment_generation=0, expected=1
```

381 drops in one run, starting ~3s after the websocket opened. No audio ever
reached the client, so the failure surfaced only as
`TimeoutError: Timed out waiting for model output` at 300s.

## Root cause

Two counters have to stay in step, but only one advances unconditionally:

- `chunk_transfer_adapter.py:404` — advances on every boundary
- `omni_ar_scheduler.py:803`/`:831`, `omni_scheduler_mixin.py:152` — advance the
  request-side counter, reachable only through `_update_request_as_session` /
  `_replace_streaming_session`

An instrumented run showed the Nemotron stage-1 path never reaches those
scheduler sites: 0 hits over a run with 381 drops. The same run showed two
populations at the write site — 87 requests with no counter, 118 with one that
advances monotonically.

## Changes

- Hold the watermark at `generation` when the request has no
  `_omni_segment_generation`; keep the `+1` where it does.
- Add `test_save_async_boundary_holds_generation_without_request_counter`
  (fails without the fix, passes with it).

## Testing

H100 PCIe, single GPU, vLLM 0.28.0:

- `test_native_duplex_turn_taking_streams_model_audio`: **4/4 pass**, 0 drops,
  ~119s. Previously failed after 409s.
- Adapter unit suite: **116/116**, including
  `test_save_async_drops_late_previous_segment_after_boundary_reset`. An earlier
  attempt that simply removed the `+1` failed that test; this one does not.
- MiniCPM-o duplex e2e fails the same way with and without this change on my box
  (server exits during startup), so it is effectively untested here and needs CI
  coverage.

@Sy0307 @yenuo26 — flagging since this touches #6529. Happy to move the fix to
the scheduler side instead if that matches the intended invariant.