### PR TITLE
[Bugfix] Fix Step-Audio2 L4 CI KV cache allocation

### DIFF
--- a/tests/config/test_config_factory.py
+++ b/tests/config/test_config_factory.py
@@ -1556,7 +1556,7 @@ stages:
         assert stage.max_model_len == 1024
         assert stage.max_num_batched_tokens == 1024
         assert stage.max_num_seqs == 1
-        assert stage.gpu_memory_utilization == 0.7
+        assert stage.gpu_memory_utilization == 0.8
         assert stage.skip_mm_profiling is True
         assert stage.enforce_eager is True
         assert stage.async_scheduling is False

--- a/vllm_omni/deploy/step_audio2_ci.yaml
+++ b/vllm_omni/deploy/step_audio2_ci.yaml
@@ -15,7 +15,7 @@ stages:
     max_model_len: 1024
     max_num_batched_tokens: 1024
     max_num_seqs: 1
-    gpu_memory_utilization: 0.7
+    gpu_memory_utilization: 0.8
     skip_mm_profiling: true
     enforce_eager: true
     async_scheduling: false


### PR DESCRIPTION
## Purpose

Fixes #6836.

### What broke

The weekly single-L4 offline Step-Audio2 test fails while initializing Stage 0:

```text
Model loading took 15.59 GiB memory
Available KV cache memory: 0.0 GiB
ValueError: No available memory for the cache blocks
```

### Reproduction

```bash
pytest -sv \
  "tests/e2e/offline_inference/test_step_audio2_expansion.py::test_audio_to_text_and_audio[omni_runner0]" \
  --tb=short
```

### Root cause

The L4 reports about 23,034 MiB of total memory. At `gpu_memory_utilization: 0.7`, the Stage 0 memory budget is about 15.75 GiB. The model weights alone consume 15.59 GiB, leaving insufficient space for activations, non-PyTorch allocations, and KV cache blocks.

### Fix

Raise the Step-Audio2 CI deployment's `gpu_memory_utilization` from `0.7` to `0.8` and update the existing configuration assertion.

## Test Plan

```bash
pytest -q tests/config/test_config_factory.py \
  -k step_audio2_online_ci_deploy_is_single_thinker \
  --tb=short
```

Run the original offline expansion test on the single-L4 weekly CI runner.

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** f321cdbe16df69da4f1770decc500ad55ed764ac

## Test Result

- Targeted configuration test: `1 passed, 332 deselected`.
- All diff-scoped pre-commit hooks passed, including YAML, Ruff, mypy, test marks, SPDX, forbidden imports, and repository policy checks.
- On one RTX 4090, `0.7` left only `0.26 GiB` for KV cache.
- Using `0.67` on the same RTX 4090 to emulate the L4's absolute `0.7` memory budget reproduced `Available KV cache memory: 0.0 GiB` and the same `ValueError`.
- With the proposed `0.8`, KV cache increased to `2.61 GiB` (48,896 tokens), and `test_text_only_input` passed.
- Final validation of the original audio-input case remains the upstream single-L4 CI run.