### PR TITLE
[Lingbot World][bugfix] Skip reloading LingBot source image on follow-up AR ticks

### DIFF
--- a/examples/offline_inference/diffusion/lingbot_world_v2_realtime.py
+++ b/examples/offline_inference/diffusion/lingbot_world_v2_realtime.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Run LingBot-World 2.0 as an in-process realtime AR-Diffusion session.
 
 This example exercises the internal session API. It is not a public HTTP or
@@ -127,7 +127,10 @@ async def run(argv: Sequence[str] | None = None) -> Path:
 
     from vllm_omni.diffusion.models.lingbot_world.actions import LingBotCameraControlReducer
     from vllm_omni.entrypoints.async_omni import AsyncOmni
-    from vllm_omni.experimental.ar_diffusion.consumer import ARDiffusionOmniTickConsumer
+    from vllm_omni.experimental.ar_diffusion.consumer import (
+        ARDiffusionOmniTickConsumer,
+        omni_prompt_for_ar_tick,
+    )
     from vllm_omni.experimental.ar_diffusion.session import (
         ARDiffusionSessionEvent,
         ARDiffusionSessionManager,
@@ -163,10 +166,10 @@ async def run(argv: Sequence[str] | None = None) -> Path:
     )
     consumer = ARDiffusionOmniTickConsumer(
         engine,
-        prompt_provider=lambda tick: {
-            "prompt": tick.prompt,
-            "multi_modal_data": {"image": str(image)},
-        },
+        prompt_provider=lambda tick: omni_prompt_for_ar_tick(
+            tick,
+            init_multi_modal_data={"image": str(image)},
+        ),
         sampling_params_list=[sampling],
         diffusion_stage_id=0,
     )

--- a/tests/diffusion/ar_diffusion/test_consumer.py
+++ b/tests/diffusion/ar_diffusion/test_consumer.py
@@ -1,13 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Sequence
+from dataclasses import replace
 from typing import Any
 
 import pytest
 
-from vllm_omni.experimental.ar_diffusion.consumer import ARDiffusionOmniTickConsumer
+from vllm_omni.experimental.ar_diffusion.consumer import (
+    ARDiffusionOmniTickConsumer,
+    omni_prompt_for_ar_tick,
+)
 from vllm_omni.experimental.ar_diffusion.session import (
     ARDiffusionSession,
     ARDiffusionSessionEvent,
@@ -110,6 +115,21 @@ def make_tick() -> ARDiffusionTickRequest:
             ),
         ),
     )
+
+
+def test_omni_prompt_for_ar_tick_attaches_init_image_only_on_chunk_zero() -> None:
+    later = make_tick()
+    first = replace(later, chunk_index=0, request_id="world-1-chunk-0")
+
+    init = {"image": "initial-image"}
+    assert omni_prompt_for_ar_tick(first, init_multi_modal_data=init) == {
+        "prompt": "turn left",
+        "multi_modal_data": {"image": "initial-image"},
+    }
+    assert omni_prompt_for_ar_tick(later, init_multi_modal_data=init) == {
+        "prompt": "turn left",
+        "multi_modal_data": {},
+    }
 
 
 def test_consumer_rejects_replicated_ar_diffusion_stage() -> None:

--- a/tests/diffusion/models/lingbot_world/test_pipeline_lingbot_world.py
+++ b/tests/diffusion/models/lingbot_world/test_pipeline_lingbot_world.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from __future__ import annotations
 
@@ -549,6 +549,101 @@ def test_preprocess_materializes_chunk_sized_actions_from_typed_tick() -> None:
         ("w", "j"),
         (),
     )
+
+
+def _camera_action_tick(*, chunk_index: int) -> ARDiffusionTickRequest:
+    return ARDiffusionTickRequest(
+        session_id="world-actions",
+        request_id=f"tick-request-{chunk_index}",
+        chunk_index=chunk_index,
+        controls=(
+            ARDiffusionControlInput(
+                track="camera",
+                schema="lingbot.camera_actions.v1",
+                data={
+                    "mode": "frames",
+                    "frames": [["w"], ["w"], []],
+                },
+            ),
+        ),
+    )
+
+
+def test_preprocess_does_not_open_image_on_followup_ar_ticks(tmp_path: Path) -> None:
+    module = _load_pipeline_module()
+    missing_path = tmp_path / "must-not-be-opened.png"
+    tick = _camera_action_tick(chunk_index=1)
+    sampling = _SamplingParams(include_action=False)
+    sampling.extra_args.update(tick.to_extra_args())
+    request = SimpleNamespace(
+        prompt={"prompt": "move", "multi_modal_data": {"image": str(missing_path)}},
+        sampling_params=sampling,
+    )
+
+    result = module.get_lingbot_world_pre_process_func(_od_config())(request)
+
+    assert "image" not in result.prompt["multi_modal_data"]
+    assert result.sampling_params.extra_args["_lingbot_camera_actions"] == (
+        ("w",),
+        ("w",),
+        (),
+    )
+
+
+def test_preprocess_allows_followup_tick_without_image() -> None:
+    module = _load_pipeline_module()
+    tick = _camera_action_tick(chunk_index=2)
+    sampling = _SamplingParams(include_action=False)
+    sampling.extra_args.update(tick.to_extra_args())
+    request = SimpleNamespace(
+        prompt={"prompt": "move", "multi_modal_data": {}},
+        sampling_params=sampling,
+    )
+
+    result = module.get_lingbot_world_pre_process_func(_od_config())(request)
+
+    assert "image" not in result.prompt["multi_modal_data"]
+
+
+def test_preprocess_chunk0_tick_still_requires_image() -> None:
+    module = _load_pipeline_module()
+    tick = _camera_action_tick(chunk_index=0)
+    sampling = _SamplingParams(include_action=False)
+    sampling.extra_args.update(tick.to_extra_args())
+    request = SimpleNamespace(
+        prompt={"prompt": "move", "multi_modal_data": {}},
+        sampling_params=sampling,
+    )
+
+    with pytest.raises(ValueError, match="exactly one image"):
+        module.get_lingbot_world_pre_process_func(_od_config())(request)
+
+
+def test_parse_request_accepts_followup_tick_without_image() -> None:
+    module = _load_pipeline_module()
+    tick = _camera_action_tick(chunk_index=1)
+    sampling = _SamplingParams()
+    sampling.extra_args.update(tick.to_extra_args())
+
+    parsed = _pipeline(module)._parse_request(
+        _RequestBatch({"prompt": "move through the room", "multi_modal_data": {}}, sampling)
+    )
+
+    assert parsed.image is None
+    assert parsed.height == 16
+    assert parsed.width == 16
+
+
+def test_parse_request_followup_tick_requires_explicit_resolution() -> None:
+    module = _load_pipeline_module()
+    tick = _camera_action_tick(chunk_index=1)
+    sampling = _SamplingParams(height=None, width=None)
+    sampling.extra_args.update(tick.to_extra_args())
+
+    with pytest.raises(ValueError, match="omit the source image"):
+        _pipeline(module)._parse_request(
+            _RequestBatch({"prompt": "move through the room", "multi_modal_data": {}}, sampling)
+        )
 
 
 def _request(*, sampling=None, prompt=None, num_reqs: int = 1):

--- a/vllm_omni/diffusion/models/lingbot_world/pipeline.py
+++ b/vllm_omni/diffusion/models/lingbot_world/pipeline.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Request-scoped LingBot-World v2 causal DMD pipeline."""
 
 from __future__ import annotations
@@ -84,12 +84,18 @@ _SOURCE_IMAGE_ERROR = (
 )
 
 
+def _tick_reuses_cached_image_condition(tick: ARDiffusionTickRequest | None) -> bool:
+    """Later realtime chunks keep the chunk-0 VAE image condition."""
+
+    return tick is not None and tick.chunk_index > 0
+
+
 @dataclass(frozen=True)
 class _LingBotRequestInputs:
     """Validated model-specific request boundary."""
 
     prompt: str
-    image: PIL.Image.Image | torch.Tensor
+    image: PIL.Image.Image | torch.Tensor | None
     camera_trajectory: CameraTrajectory | None
     camera_actions: tuple[tuple[str, ...], ...] | None
     height: int
@@ -244,22 +250,27 @@ def get_lingbot_world_pre_process_func(
                 "sampling_params.extra_args.action_path."
             )
 
-        image = multi_modal_data.get("image")
-        if isinstance(image, list):
-            raise ValueError("LingBot World requires one image and does not accept an image list.")
-        if image is None:
-            raise ValueError("LingBot World requires exactly one image in multi_modal_data.image.")
-        if isinstance(image, (str, os.PathLike)):
-            image = _load_source_image(image)
-        elif isinstance(image, PIL.Image.Image):
-            image = _decode_source_image(image)
-        elif not isinstance(image, torch.Tensor):
-            raise ValueError("multi_modal_data.image must be a PIL image, tensor, or file path.")
-
         extra_args = getattr(request.sampling_params, "extra_args", None) or {}
         if not isinstance(extra_args, dict):
             raise ValueError("sampling_params.extra_args must be a mapping.")
         tick = ARDiffusionTickRequest.from_extra_args(extra_args)
+        image = multi_modal_data.get("image")
+        if _tick_reuses_cached_image_condition(tick):
+            # Chunk 0 already encoded the first frame into session state.
+            # Drop any caller-supplied image so later ticks do not reopen,
+            # convert, or pickle pixels to the GPU worker.
+            image = None
+        else:
+            if isinstance(image, list):
+                raise ValueError("LingBot World requires one image and does not accept an image list.")
+            if image is None:
+                raise ValueError("LingBot World requires exactly one image in multi_modal_data.image.")
+            if isinstance(image, (str, os.PathLike)):
+                image = _load_source_image(image)
+            elif isinstance(image, PIL.Image.Image):
+                image = _decode_source_image(image)
+            elif not isinstance(image, torch.Tensor):
+                raise ValueError("multi_modal_data.image must be a PIL image, tensor, or file path.")
         if tick is not None:
             camera_controls = [control for control in tick.controls if control.track == "camera"]
             if len(camera_controls) != 1:
@@ -326,7 +337,10 @@ def get_lingbot_world_pre_process_func(
 
         updated_prompt = dict(prompt)
         updated_multi_modal_data = dict(multi_modal_data)
-        updated_multi_modal_data["image"] = image
+        if image is None:
+            updated_multi_modal_data.pop("image", None)
+        else:
+            updated_multi_modal_data["image"] = image
         updated_prompt["multi_modal_data"] = updated_multi_modal_data
         request.prompt = updated_prompt
         request.sampling_params.extra_args = {
@@ -602,19 +616,25 @@ class LingBotWorldCausalDMDPipeline(
         if not isinstance(multi_modal_data, dict):
             raise ValueError("prompt.multi_modal_data must be a mapping containing image.")
 
-        image = multi_modal_data.get("image")
-        if isinstance(image, list):
-            raise ValueError("LingBot World requires one image and does not accept an image list.")
-        if image is None:
-            raise ValueError("LingBot World requires exactly one image in multi_modal_data.image.")
-        if isinstance(image, (str, os.PathLike)):
-            raise ValueError("file-path images must be materialized by the LingBot pre-process function.")
-        if not isinstance(image, (PIL.Image.Image, torch.Tensor)):
-            raise ValueError("multi_modal_data.image must be a PIL image, tensor, or file path.")
-
         extra_args = getattr(sampling, "extra_args", None) or {}
         if not isinstance(extra_args, dict):
             raise ValueError("sampling_params.extra_args must be a mapping.")
+        tick = ARDiffusionTickRequest.from_extra_args(extra_args)
+        reuse_session_image = _tick_reuses_cached_image_condition(tick)
+
+        image = multi_modal_data.get("image")
+        if isinstance(image, list):
+            raise ValueError("LingBot World requires one image and does not accept an image list.")
+        if reuse_session_image:
+            image = None
+        else:
+            if image is None:
+                raise ValueError("LingBot World requires exactly one image in multi_modal_data.image.")
+            if isinstance(image, (str, os.PathLike)):
+                raise ValueError("file-path images must be materialized by the LingBot pre-process function.")
+            if not isinstance(image, (PIL.Image.Image, torch.Tensor)):
+                raise ValueError("multi_modal_data.image must be a PIL image, tensor, or file path.")
+
         camera_trajectory = extra_args.get(_PREPROCESSED_CAMERA_KEY)
         camera_actions = extra_args.get(_PREPROCESSED_CAMERA_ACTIONS_KEY)
         if camera_trajectory is not None and not isinstance(camera_trajectory, CameraTrajectory):
@@ -631,7 +651,15 @@ class LingBotWorldCausalDMDPipeline(
 
         height = getattr(sampling, "height", None)
         width = getattr(sampling, "width", None)
-        if isinstance(image, PIL.Image.Image):
+        if image is None:
+            if (height is None) != (width is None):
+                raise ValueError("height and width must either both be provided or both be omitted.")
+            if height is None or width is None:
+                raise ValueError(
+                    "Follow-up LingBot AR-Diffusion ticks omit the source image; "
+                    "sampling height and width must both be provided."
+                )
+        elif isinstance(image, PIL.Image.Image):
             image_width, image_height = image.size
         elif image.ndim == 3 and image.shape[0] == 3:
             image_height, image_width = image.shape[-2:]
@@ -639,12 +667,13 @@ class LingBotWorldCausalDMDPipeline(
             image_height, image_width = image.shape[-2:]
         else:
             raise ValueError("tensor image must have shape [3, height, width] or [1, 3, height, width].")
-        if image_height <= 0 or image_width <= 0:
-            raise ValueError("source image width and height must be positive integers.")
-        if image_height * image_width > _MAX_SOURCE_IMAGE_PIXELS:
-            raise ValueError("source image pixel count must not exceed 4096 * 4096.")
-        if (height is None) != (width is None):
-            raise ValueError("height and width must either both be provided or both be omitted.")
+        if image is not None:
+            if image_height <= 0 or image_width <= 0:
+                raise ValueError("source image width and height must be positive integers.")
+            if image_height * image_width > _MAX_SOURCE_IMAGE_PIXELS:
+                raise ValueError("source image pixel count must not exceed 4096 * 4096.")
+            if (height is None) != (width is None):
+                raise ValueError("height and width must either both be provided or both be omitted.")
         patch_size = tuple(self.transformer.config.patch_size)
         if len(patch_size) != 3 or patch_size[0] != 1:
             raise RuntimeError(
@@ -777,6 +806,8 @@ class LingBotWorldCausalDMDPipeline(
     def _prepare_condition(self, inputs: _LingBotRequestInputs, *, dtype: torch.dtype) -> torch.Tensor:
         """Encode the first frame as ``[mask4, image_latent16]``."""
 
+        if inputs.image is None:
+            raise RuntimeError("LingBot image condition requires multi_modal_data.image on the first chunk.")
         image = self._prepare_image_tensor(inputs.image, height=inputs.height, width=inputs.width)
         video_condition = image.new_zeros(1, 3, inputs.num_frames, inputs.height, inputs.width)
         video_condition[:, :, 0] = image
@@ -1156,6 +1187,10 @@ class LingBotWorldCausalDMDPipeline(
         else:
             assert session_state is not None
             if session_state.image_condition is None:
+                if inputs.image is None:
+                    raise RuntimeError(
+                        "LingBot realtime image condition is missing; chunk 0 must provide multi_modal_data.image."
+                    )
                 horizon_latent_frames = (_MAX_RAW_FRAMES - 1) // self.vae_scale_factor_temporal + 1
                 session_state.image_condition = self._prepare_condition(
                     replace(

--- a/vllm_omni/experimental/ar_diffusion/consumer.py
+++ b/vllm_omni/experimental/ar_diffusion/consumer.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """AsyncOmni consumer for typed realtime AR-Diffusion ticks."""
 
 from __future__ import annotations
@@ -19,6 +20,24 @@ from vllm_omni.inputs.data import (
 from vllm_omni.outputs import OmniRequestOutput
 
 AR_DIFFUSION_OUTPUT_METADATA_KEY = "ar_diffusion"
+
+
+def omni_prompt_for_ar_tick(
+    tick: ARDiffusionTickRequest,
+    *,
+    init_multi_modal_data: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the Omni prompt for one AR-Diffusion tick.
+
+    Session-initialization multimodal payloads (for example the first-frame
+    image) are attached only on ``chunk_index == 0``. Later ticks reuse
+    worker-side session state and must not re-send those bytes.
+    """
+
+    multi_modal_data: dict[str, Any] = {}
+    if tick.chunk_index == 0 and init_multi_modal_data:
+        multi_modal_data = dict(init_multi_modal_data)
+    return {"prompt": tick.prompt, "multi_modal_data": multi_modal_data}
 
 
 class ARDiffusionGenerateClient(Protocol):
@@ -78,8 +97,10 @@ class ARDiffusionOmniTickConsumer:
     """Converts a typed tick into one AsyncOmni diffusion request.
 
     ``prompt_provider`` packages session initialization data such as an initial
-    image into the normal Omni prompt. Control ``track/schema/data`` remains in
-    the typed tick and is not interpreted by this class.
+    image into the normal Omni prompt. Attach that payload on ``chunk_index==0``
+    only; later ticks reuse worker-side session state. Control
+    ``track/schema/data`` remains in the typed tick and is not interpreted by
+    this class.
     """
 
     def __init__(


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Summary

This PR stops resending and reloading LingBot World's source image after the
first AR-Diffusion tick. Tick zero still validates and encodes the image;
follow-up ticks reuse the image condition already owned by the worker session.

## What broke

The realtime client attached the same source image to every Omni request.
Although the LingBot pipeline cached the encoded condition during tick zero,
the preprocessor still reopened, decoded, converted, and serialized identical
pixels on every follow-up tick.

This repeated host-side work does not change DiT computation, but adds avoidable
latency to every realtime step.

## Fix

- Add an AR-Diffusion prompt helper that attaches initialization multimodal data
  only when `chunk_index == 0`.
- Defensively discard a caller-supplied image on follow-up LingBot ticks before
  file loading or pixel conversion.
- Allow follow-up ticks to omit the image when explicit height and width are
  available.
- Preserve the source-image requirement and validation on tick zero.

The public realtime WebSocket path is outside this PR because that entrypoint
is not present on the upstream base.

## Test Plan

```bash
python -m pytest \
  tests/diffusion/ar_diffusion/test_consumer.py \
  tests/diffusion/models/lingbot_world/test_pipeline_lingbot_world.py -q
```

The GPU comparison uses the same model, prompt, source image, seed, action
sequence, 832x480 resolution, ten ticks, four DMD steps, latent output, and
`--enforce-eager` before and after the change. The first tick is excluded from
steady-state measurements.

**vLLM Version:** 0.27.0 for CPU tests; 0.28.0 for GPU validation

**vLLM-Omni Commit:** bfb739ec59780814d7e02ca59aa70955b5f67e04

## Test Result

- Consumer and LingBot pipeline suites: **113 passed**.
- Both GPU runs produced ten finite latent chunks.

| Metric | Before | This PR | Delta |
|---|---:|---:|---:|
| Steady tick mean, ticks 1-9 | 2.6532 s | 2.5072 s | **-5.50%** |
| Filled-window tick mean, ticks 5-9 | 2.8256 s | 2.6886 s | **-4.85%** |
| Filled-window DiT mean | 2.6485 s | 2.6538 s | +0.20% |
| Filled-window non-DiT overhead | 0.1771 s | 0.0348 s | **-80.38%** |
| Peak worker memory | 86560 MiB | 86560 MiB | unchanged |

DiT time and peak memory are unchanged; the improvement comes from removing
repeated host-side image preprocessing on follow-up ticks.

- Targeted pre-commit checks passed.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
