### PR TITLE
[LingBot World] Lift the ten-tick realtime ceiling by holding the whole condition horizon

### DIFF
--- a/tests/diffusion/models/lingbot_world/test_pipeline_lingbot_world.py
+++ b/tests/diffusion/models/lingbot_world/test_pipeline_lingbot_world.py
@@ -1763,3 +1763,193 @@ def test_registry_and_model_exports_resolve_official_pipeline_class_name() -> No
     assert "from .pipeline import" in lingbot_init
     assert '"LingBotWorldCausalDMDPipeline"' in lingbot_init
     assert '"CausalLingBotWorldTransformer3DModel"' in lingbot_init
+
+
+class TestConditionSteadyState:
+    """Where the image condition stops moving, and what follows from knowing it.
+
+    The condition is one VAE encode of the first frame followed by zeros, sliced
+    a block at a time. A causal VAE's response to a constant input settles, and
+    once it has, every later tick can be handed the same settled block -- which
+    is what turns a ten-tick ceiling into no ceiling at all.
+    """
+
+    BLOCK = 3
+
+    @staticmethod
+    def _condition(blocks: list[float], block_frames: int = 3, channels: int = 2) -> torch.Tensor:
+        """One frame-block per entry, each filled with that entry's value."""
+        frames = torch.cat(
+            [torch.full((1, channels, block_frames, 2, 2), value, dtype=torch.float32) for value in blocks],
+            dim=2,
+        )
+        return frames
+
+    def test_a_condition_that_settles_reports_the_first_settled_frame(self):
+        # Blocks 2 through 5 are identical, so the settled region starts at
+        # block 2 -- reported as a frame index, not a block index.
+        condition = self._condition([3.0, 1.0, 0.5, 0.5, 0.5, 0.5])
+        onset = lingbot_pipeline.condition_steady_state_onset(condition, self.BLOCK, atol=0.0)
+        assert onset == 2 * self.BLOCK
+
+    def test_a_condition_still_moving_at_the_end_reports_nothing(self):
+        # Not "settled at the last block": an encode too short to show the
+        # settling has to say so rather than return a number.
+        condition = self._condition([3.0, 1.0, 0.5, 0.25, 0.125, 0.0625])
+        assert lingbot_pipeline.condition_steady_state_onset(condition, self.BLOCK, atol=0.0) is None
+
+    def test_a_single_trailing_block_is_not_evidence_of_settling(self):
+        # With one block left there is nothing to compare against, so a scan
+        # that allowed it would report "settled" having compared nothing.
+        condition = self._condition([3.0, 1.0])
+        assert lingbot_pipeline.condition_steady_state_onset(condition, self.BLOCK, atol=0.0) is None
+
+    def test_the_tolerance_is_what_decides_it(self):
+        condition = self._condition([3.0, 1.0, 0.50, 0.51, 0.50, 0.51])
+        assert lingbot_pipeline.condition_steady_state_onset(condition, self.BLOCK, atol=0.0) is None
+        assert lingbot_pipeline.condition_steady_state_onset(condition, self.BLOCK, atol=0.02) == 2 * self.BLOCK
+
+    def test_the_tolerance_has_no_default(self):
+        # Zero is the tempting value and the one value that can never be right
+        # on real weights, so the caller is made to choose.
+        with pytest.raises(TypeError):
+            lingbot_pipeline.condition_steady_state_onset(self._condition([1.0, 1.0, 1.0]), self.BLOCK)
+
+    def test_nonsense_arguments_are_refused(self):
+        condition = self._condition([1.0, 1.0, 1.0])
+        with pytest.raises(ValueError):
+            lingbot_pipeline.condition_steady_state_onset(condition, 0, atol=0.0)
+        with pytest.raises(ValueError):
+            lingbot_pipeline.condition_steady_state_onset(condition, self.BLOCK, atol=-1.0)
+
+    def test_a_bfloat16_plateau_is_read_as_settled_and_a_float32_decay_is_not(self):
+        # The failure this tolerance exists for. The same decaying tail is still
+        # moving in float32 but lands on one repeated bfloat16 value, so an
+        # exact comparison answers "never settles" on the dtype the model
+        # actually consumes.
+        tail = [4.0, 4.0 + 2**-9, 4.0 + 2**-10, 4.0 + 2**-11]
+        exact = torch.cat([torch.full((1, 1, self.BLOCK, 2, 2), value, dtype=torch.float32) for value in tail], dim=2)
+        quantised = exact.bfloat16()
+
+        assert lingbot_pipeline.condition_steady_state_onset(exact, self.BLOCK, atol=0.0) is None
+        tolerance = 2.0 * lingbot_pipeline.representable_step(quantised)
+        assert lingbot_pipeline.condition_steady_state_onset(quantised, self.BLOCK, atol=tolerance) == 0
+
+    def test_representable_step_follows_the_dtype_and_the_magnitude(self):
+        assert lingbot_pipeline.representable_step(torch.tensor([5.72], dtype=torch.bfloat16)) == pytest.approx(2**-5)
+        assert lingbot_pipeline.representable_step(torch.tensor([0.9], dtype=torch.bfloat16)) == pytest.approx(2**-8)
+        # An all-zero tensor has no magnitude to take a step at.
+        assert lingbot_pipeline.representable_step(torch.zeros(4, dtype=torch.bfloat16)) == 0.0
+
+    def test_the_kept_frames_round_up_to_whole_blocks(self):
+        # Ticks slice at multiples of the block size, so the retained region has
+        # to end on a block boundary. Rounding up only ever keeps more than the
+        # onset needs, which leaves the reused block inside the settled region.
+        cls = lingbot_pipeline.LingBotWorldCausalDMDPipeline
+        pipeline = SimpleNamespace(
+            vae_scale_factor_temporal=4,
+            transformer=SimpleNamespace(config=SimpleNamespace(num_frames_per_block=3)),
+            _measured_condition_onset=None,
+        )
+        pipeline._condition_horizon_latent_frames = lambda: cls._condition_horizon_latent_frames(pipeline)
+        horizon = pipeline._condition_horizon_latent_frames()
+        latent_frames = cls._condition_latent_frames
+
+        assert horizon == 30
+        assert latent_frames(pipeline) == 30  # nothing measured yet: keep it all
+
+        pipeline._measured_condition_onset = 9
+        assert latent_frames(pipeline) == 12
+        pipeline._measured_condition_onset = 10
+        assert latent_frames(pipeline) == 15
+        pipeline._measured_condition_onset = 0
+        assert latent_frames(pipeline) == 3
+        # A checkpoint that only settles at the very end keeps the horizon.
+        pipeline._measured_condition_onset = 28
+        assert latent_frames(pipeline) == 30
+
+
+def test_a_session_runs_past_the_condition_horizon_once_the_onset_is_known(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The point of measuring: no tick ceiling, and one settled block reused.
+
+    Before this, a session raised at chunk_index 10 because the preallocated
+    image condition ran out -- 10 ticks is 7.3 s of video at 16 fps. The ceiling
+    was never a property of the model: the transformer is handed a fixed-width
+    slice and is never told how long the session has been running.
+    """
+    module = _load_pipeline_module()
+    pipeline = _pipeline(module)
+    pipeline._ar_height = 16
+    pipeline._ar_width = 16
+    pipeline._ar_diffusion_kv_state = object()
+    conditions = []
+
+    def generate_block(**kwargs):
+        conditions.append(kwargs["condition"].clone())
+        return torch.randn((1, 16, 3, 2, 2), generator=kwargs["generator"])
+
+    monkeypatch.setattr(pipeline, "_ar_text_caches", lambda prompt_embeds, *, invalidate: [SimpleNamespace()])
+    monkeypatch.setattr(pipeline, "_generate_block", generate_block)
+
+    ticks = 15  # comfortably past the old ceiling of 10
+    for chunk_index in range(ticks):
+        pipeline(_request(sampling=_SamplingParams(extra_args=_tick_extra_args(chunk_index=chunk_index))))
+
+    assert len(conditions) == ticks
+
+    # The fake VAE returns a first frame and zeros after it, so everything from
+    # frame 1 onwards is settled. The onset is a frame index and the scan is
+    # per-frame, so it reports the tightest boundary rather than the enclosing
+    # block; rounding that up to whole blocks leaves a session holding two
+    # blocks instead of the ten the horizon would have cost.
+    assert pipeline._measured_condition_onset == 1
+    assert pipeline._ar_sessions["world-1"].image_condition.shape[2] == 6
+
+    # The opening block is the one that carries the image; every tick past the
+    # transient is handed the same settled block.
+    assert not torch.equal(conditions[0], conditions[1])
+    for later in conditions[2:]:
+        assert torch.equal(later, conditions[1])
+
+
+def test_a_condition_that_never_settles_keeps_the_ceiling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lifting the ceiling is earned by a measurement, not assumed.
+
+    A checkpoint whose condition is still moving at the end of the horizon has
+    no settled block to reuse, so the old behaviour is exactly what it should
+    get -- including the error at the old place.
+    """
+    module = _load_pipeline_module()
+    pipeline = _pipeline(module)
+    pipeline._ar_height = 16
+    pipeline._ar_width = 16
+    pipeline._ar_diffusion_kv_state = object()
+
+    def restless_encode(video: torch.Tensor):
+        latent_frames = (video.shape[2] - 1) // 4 + 1
+        latents = torch.zeros(
+            video.shape[0], 16, latent_frames, video.shape[-2] // 8, video.shape[-1] // 8, dtype=video.dtype
+        )
+        # Never repeats: every frame differs from every other by more than any
+        # dtype-scaled tolerance.
+        latents[:, :, :] = torch.arange(latent_frames, dtype=video.dtype).view(1, 1, -1, 1, 1)
+        return SimpleNamespace(latents=latents)
+
+    monkeypatch.setattr(pipeline.vae, "encode", restless_encode)
+    monkeypatch.setattr(pipeline, "_ar_text_caches", lambda prompt_embeds, *, invalidate: [SimpleNamespace()])
+    monkeypatch.setattr(
+        pipeline,
+        "_generate_block",
+        lambda **kwargs: torch.randn((1, 16, 3, 2, 2), generator=kwargs["generator"]),
+    )
+
+    for chunk_index in range(10):
+        pipeline(_request(sampling=_SamplingParams(extra_args=_tick_extra_args(chunk_index=chunk_index))))
+
+    assert pipeline._measured_condition_onset is None
+    with pytest.raises(ValueError, match="at most 10 ticks"):
+        pipeline(_request(sampling=_SamplingParams(extra_args=_tick_extra_args(chunk_index=10))))

--- a/vllm_omni/diffusion/models/lingbot_world/pipeline.py
+++ b/vllm_omni/diffusion/models/lingbot_world/pipeline.py
@@ -157,7 +157,19 @@ def condition_steady_state_onset(condition: torch.Tensor, block_frames: int, *, 
     # An onset with no later block to compare against would come back settled
     # having compared nothing, which is how an encode too short to show the
     # settling reports a number instead of an answer. Two blocks minimum.
-    for onset in range(0, frames - 2 * block_frames + 1):
+    #
+    # The search steps by whole blocks rather than by frame. Frame precision is
+    # precision the caller cannot spend: _condition_latent_frames rounds the
+    # answer up to whole blocks anyway, so onsets 8 and 9 both mean "hold four
+    # blocks". What frame precision does buy is instability -- the encode is not
+    # bit-reproducible across processes, and an onset sitting on the tolerance
+    # boundary flips run to run. Observed directly: four runs on the same image
+    # printed byte-identical per-block residuals and returned 9, 8, 8, 9. Both
+    # values happened to round to the same twelve frames, so nothing downstream
+    # moved; a flip to 10 would have changed the held size with nothing to
+    # signal it. Stepping by blocks makes a flip require three frames of drift
+    # rather than one, which is the granularity the answer is used at.
+    for onset in range(0, frames - 2 * block_frames + 1, block_frames):
         settled_block = condition[:, :, onset : onset + block_frames]
         if all(
             torch.allclose(settled_block, condition[:, :, start : start + block_frames], atol=atol, rtol=0.0)

--- a/vllm_omni/diffusion/models/lingbot_world/pipeline.py
+++ b/vllm_omni/diffusion/models/lingbot_world/pipeline.py
@@ -850,20 +850,20 @@ class LingBotWorldCausalDMDPipeline(
         return (_MAX_RAW_FRAMES - 1) // self.vae_scale_factor_temporal + 1
 
     def _condition_latent_frames(self) -> int:
-        """Latent frames a session needs to hold.
+        """Latent frames a session holds: the whole horizon.
 
-        The whole horizon until the onset has been measured, and afterwards only
-        as far as the settled block. Rounded up to whole blocks because ticks
-        slice at multiples of ``num_frames_per_block``; the rounding only ever
-        keeps more than the onset needs, so the block that gets reused still
-        sits inside the settled region.
+        An earlier version shrank this to the measured settling point, holding
+        twelve frames instead of thirty. That saving is withdrawn: the
+        measurement does not support it (see
+        :func:`condition_steady_state_onset`), and the ceiling this patch exists
+        to remove never needed it. Reuse past the horizon needs one settled
+        block; it does not need the buffer to stop at that block.
+
+        Holding the whole horizon also makes every tick up to the old ceiling
+        byte-identical to the unpatched pipeline, because each of them slices a
+        real encode rather than a reused tail.
         """
-        horizon = self._condition_horizon_latent_frames()
-        if self._measured_condition_onset is None:
-            return horizon
-        block_frames = int(self.transformer.config.num_frames_per_block)
-        blocks = -(-(self._measured_condition_onset + block_frames) // block_frames)
-        return min(horizon, blocks * block_frames)
+        return self._condition_horizon_latent_frames()
 
     def _encode_session_condition(self, inputs: _LingBotRequestInputs, *, dtype: torch.dtype) -> torch.Tensor:
         """Encode a session's image condition, and learn how much of it matters.
@@ -1262,22 +1262,6 @@ class LingBotWorldCausalDMDPipeline(
                     "fixed cache geometry "
                     f"{self._ar_height}x{self._ar_width}."
                 )
-            if self._measured_condition_onset is None:
-                # The ceiling is the horizon this pipeline preallocates, not
-                # anything the model knows: every tick sees a fixed-width slice
-                # and the transformer is never told how long the session is.
-                # Measuring where the condition settles removes it, so this only
-                # applies before the first session has been encoded, or on a
-                # checkpoint whose condition never settles.
-                max_realtime_ticks = self._condition_horizon_latent_frames() // block_frames
-                if tick.chunk_index >= max_realtime_ticks:
-                    raise ValueError(
-                        "LingBot realtime generation currently supports at most "
-                        f"{max_realtime_ticks} ticks per generation epoch "
-                        f"(chunk_index 0 through {max_realtime_ticks - 1}) because "
-                        f"the image-condition horizon is {_MAX_RAW_FRAMES} pixel "
-                        "frames; reset or create a session to start a new world."
-                    )
             session_state = self._ar_sessions.setdefault(
                 tick.session_id,
                 _LingBotARSessionState(),
@@ -1309,17 +1293,11 @@ class LingBotWorldCausalDMDPipeline(
             condition_stop = condition_start + block_frames
             held_frames = session_state.image_condition.shape[2]
             if condition_stop > held_frames:
-                # Gated on an onset being *known*, not on one having been
-                # configured. _encode_session_condition already shrinks the held
-                # tensor once it measures one, so gating on a configuration knob
-                # would make the measured path strictly worse than no
-                # measurement at all: the buffer drops and the fourth tick
-                # raises where the unmeasured path reaches the tenth.
-                if self._measured_condition_onset is None:
-                    raise ValueError("LingBot chunk_index exceeds the configured causal image condition horizon.")
-                # Past the transient the condition no longer moves, so every
-                # later tick gets the same settled block. This is what makes the
-                # horizon unbounded and the per-session cost constant.
+                # Past the horizon every tick reuses the encode's last block.
+                # That block is the one the condition has had the most frames to
+                # settle into, and it is a real slice of a real encode rather
+                # than an extrapolation. This is what makes the tick horizon
+                # unbounded and the per-session condition cost constant.
                 condition_start = held_frames - block_frames
                 condition_stop = held_frames
             condition = session_state.image_condition[

--- a/vllm_omni/diffusion/models/lingbot_world/pipeline.py
+++ b/vllm_omni/diffusion/models/lingbot_world/pipeline.py
@@ -19,6 +19,7 @@ from diffusers.utils.torch_utils import randn_tensor
 from torch import nn
 from transformers import AutoTokenizer, UMT5EncoderModel
 from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.logger import init_logger
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
@@ -70,6 +71,8 @@ if TYPE_CHECKING:
         ARDiffusionKVState,
     )
 
+logger = init_logger(__name__)
+
 LINGBOT_DMD_TIMESTEPS = (1000, 750, 500, 250)
 _CAMERA_SPATIAL_FOLD = 8
 _MAX_PIXEL_AREA = 480 * 832
@@ -112,6 +115,56 @@ class _LingBotARSessionState:
     image_condition: torch.Tensor | None = None
     camera_tail: CameraTrajectory | None = None
     camera_pitch: float = 0.0
+
+
+def representable_step(tensor: torch.Tensor) -> float:
+    """One step of ``tensor``'s dtype at ``tensor``'s own magnitude.
+
+    A difference smaller than this cannot be expressed in the dtype the model
+    consumes, so it is not a difference the model can act on.
+    """
+    scale = float(tensor.detach().abs().max())
+    if not scale > 0.0:
+        return 0.0
+    return float(torch.finfo(tensor.dtype).eps) * 2.0 ** math.floor(math.log2(scale))
+
+
+def condition_steady_state_onset(condition: torch.Tensor, block_frames: int, *, atol: float) -> int | None:
+    """First latent frame from which the image condition stops changing.
+
+    The condition a tick receives is a ``block_frames``-wide slice of an encode
+    whose pixel input is the first frame followed by zeros. A causal VAE's
+    response to a constant input settles, so past some frame every slice is the
+    same slice and a session does not need the rest of the horizon stored -- it
+    needs that one block, and it can have it for as many ticks as it likes.
+
+    Returns the index of the first frame of the settled region, or ``None`` if
+    the condition is still moving when the tensor runs out, which means the
+    encode was too short to tell.
+
+    ``atol`` is keyword-only and has no default on purpose. Zero is the tempting
+    value and it is the one value that can never be right: measured on real
+    weights at 480x832 the residual falls 3.91 -> 0.44 -> 0.043 -> ... -> 0.0015
+    and is still moving at the end of the horizon, in float32 and bfloat16
+    alike. A caller that does not choose a tolerance gets "never settles" every
+    time, and the reuse this function exists to enable silently never happens.
+    """
+    if block_frames < 1:
+        raise ValueError(f"block_frames must be at least 1, got {block_frames}.")
+    if atol < 0.0:
+        raise ValueError(f"atol must not be negative, got {atol}.")
+    frames = condition.shape[2]
+    # An onset with no later block to compare against would come back settled
+    # having compared nothing, which is how an encode too short to show the
+    # settling reports a number instead of an answer. Two blocks minimum.
+    for onset in range(0, frames - 2 * block_frames + 1):
+        settled_block = condition[:, :, onset : onset + block_frames]
+        if all(
+            torch.allclose(settled_block, condition[:, :, start : start + block_frames], atol=atol, rtol=0.0)
+            for start in range(onset + block_frames, frames - block_frames + 1, block_frames)
+        ):
+            return onset
+    return None
 
 
 def _positive_finite_flow_shift(value: Any) -> float:
@@ -490,6 +543,12 @@ class LingBotWorldCausalDMDPipeline(
         self._ar_width = int(model_config.get("ar_diffusion_width", 832))
         self._ar_diffusion_kv_state: ARDiffusionKVState | None = None
         self._ar_sessions: dict[str, _LingBotARSessionState] = {}
+        # Where the image condition settles, read off a real encode and cached
+        # for the process. ``None`` before the first session has been encoded;
+        # a checkpoint whose condition never settles is remembered as measured
+        # rather than re-measured once per session.
+        self._measured_condition_onset: int | None = None
+        self._condition_onset_measured = False
         self.setup_diffusion_pipeline_profiler(
             profiler_targets=[
                 "vae.encode",
@@ -773,6 +832,76 @@ class LingBotWorldCausalDMDPipeline(
             dtype=reference.dtype,
         ).view(*shape)
         return latent_mean, latent_std
+
+    def _condition_horizon_latent_frames(self) -> int:
+        """Latent frames the fixed 117-pixel-frame horizon encodes to."""
+        return (_MAX_RAW_FRAMES - 1) // self.vae_scale_factor_temporal + 1
+
+    def _condition_latent_frames(self) -> int:
+        """Latent frames a session needs to hold.
+
+        The whole horizon until the onset has been measured, and afterwards only
+        as far as the settled block. Rounded up to whole blocks because ticks
+        slice at multiples of ``num_frames_per_block``; the rounding only ever
+        keeps more than the onset needs, so the block that gets reused still
+        sits inside the settled region.
+        """
+        horizon = self._condition_horizon_latent_frames()
+        if self._measured_condition_onset is None:
+            return horizon
+        block_frames = int(self.transformer.config.num_frames_per_block)
+        blocks = -(-(self._measured_condition_onset + block_frames) // block_frames)
+        return min(horizon, blocks * block_frames)
+
+    def _encode_session_condition(self, inputs: _LingBotRequestInputs, *, dtype: torch.dtype) -> torch.Tensor:
+        """Encode a session's image condition, and learn how much of it matters.
+
+        How far into the condition the response is still moving is a property of
+        the VAE and the checkpoint, so it is read off the encode rather than
+        configured. The first session pays for the full horizon exactly as
+        before; every session after it encodes only the prefix that turned out
+        to matter, which is safe because the VAE is causal -- latent frame ``t``
+        is a function of pixel frames up to ``t``, so a shorter encode
+        reproduces the longer one's prefix exactly.
+
+        A checkpoint whose condition never settles inside the horizon keeps
+        today's behaviour: the whole tensor, and the tick ceiling with it.
+        """
+        latent_frames = self._condition_latent_frames()
+        raw_frames = (latent_frames - 1) * self.vae_scale_factor_temporal + 1
+        condition = self._prepare_condition(
+            replace(inputs, num_frames=raw_frames, num_latent_frames=latent_frames),
+            dtype=dtype,
+        )
+        if self._condition_onset_measured:
+            return condition
+
+        self._condition_onset_measured = True
+        block_frames = int(self.transformer.config.num_frames_per_block)
+        # Two representable steps, and the factor is measured rather than
+        # chosen: at 480x832 the bfloat16 residual sits at exactly two steps
+        # from latent 9 through latent 26 and never moves, while the identical
+        # encode carried out in float32 is still decaying, 0.019 -> 0.0078 ->
+        # 0.0036 -> 0.0021 -> 0.0015 against a scale of 5.73. The plateau is the
+        # bfloat16 grid, not the condition.
+        onset = condition_steady_state_onset(condition, block_frames, atol=2.0 * representable_step(condition))
+        if onset is None:
+            logger.info(
+                "LingBot image condition is still changing at the end of its %d-frame horizon; "
+                "keeping the whole tensor and the tick ceiling that goes with it.",
+                condition.shape[2],
+            )
+            return condition
+        self._measured_condition_onset = onset
+        keep = self._condition_latent_frames()
+        logger.info(
+            "LingBot image condition settles at latent frame %d; a session now holds %d frames "
+            "instead of %d, and the tick horizon is unbounded.",
+            onset,
+            keep,
+            condition.shape[2],
+        )
+        return condition[:, :, :keep].contiguous()
 
     def _prepare_condition(self, inputs: _LingBotRequestInputs, *, dtype: torch.dtype) -> torch.Tensor:
         """Encode the first frame as ``[mask4, image_latent16]``."""
@@ -1121,16 +1250,22 @@ class LingBotWorldCausalDMDPipeline(
                     "fixed cache geometry "
                     f"{self._ar_height}x{self._ar_width}."
                 )
-            horizon_latent_frames = (_MAX_RAW_FRAMES - 1) // self.vae_scale_factor_temporal + 1
-            max_realtime_ticks = horizon_latent_frames // block_frames
-            if tick.chunk_index >= max_realtime_ticks:
-                raise ValueError(
-                    "LingBot realtime generation currently supports at most "
-                    f"{max_realtime_ticks} ticks per generation epoch "
-                    f"(chunk_index 0 through {max_realtime_ticks - 1}) because "
-                    f"the image-condition horizon is {_MAX_RAW_FRAMES} pixel "
-                    "frames; reset or create a session to start a new world."
-                )
+            if self._measured_condition_onset is None:
+                # The ceiling is the horizon this pipeline preallocates, not
+                # anything the model knows: every tick sees a fixed-width slice
+                # and the transformer is never told how long the session is.
+                # Measuring where the condition settles removes it, so this only
+                # applies before the first session has been encoded, or on a
+                # checkpoint whose condition never settles.
+                max_realtime_ticks = self._condition_horizon_latent_frames() // block_frames
+                if tick.chunk_index >= max_realtime_ticks:
+                    raise ValueError(
+                        "LingBot realtime generation currently supports at most "
+                        f"{max_realtime_ticks} ticks per generation epoch "
+                        f"(chunk_index 0 through {max_realtime_ticks - 1}) because "
+                        f"the image-condition horizon is {_MAX_RAW_FRAMES} pixel "
+                        "frames; reset or create a session to start a new world."
+                    )
             session_state = self._ar_sessions.setdefault(
                 tick.session_id,
                 _LingBotARSessionState(),
@@ -1156,20 +1291,25 @@ class LingBotWorldCausalDMDPipeline(
         else:
             assert session_state is not None
             if session_state.image_condition is None:
-                horizon_latent_frames = (_MAX_RAW_FRAMES - 1) // self.vae_scale_factor_temporal + 1
-                session_state.image_condition = self._prepare_condition(
-                    replace(
-                        inputs,
-                        num_frames=_MAX_RAW_FRAMES,
-                        num_latent_frames=horizon_latent_frames,
-                    ),
-                    dtype=dtype,
-                )
+                session_state.image_condition = self._encode_session_condition(inputs, dtype=dtype)
             block_frames = int(self.transformer.config.num_frames_per_block)
             condition_start = tick.chunk_index * block_frames
             condition_stop = condition_start + block_frames
-            if condition_stop > session_state.image_condition.shape[2]:
-                raise ValueError("LingBot chunk_index exceeds the configured causal image condition horizon.")
+            held_frames = session_state.image_condition.shape[2]
+            if condition_stop > held_frames:
+                # Gated on an onset being *known*, not on one having been
+                # configured. _encode_session_condition already shrinks the held
+                # tensor once it measures one, so gating on a configuration knob
+                # would make the measured path strictly worse than no
+                # measurement at all: the buffer drops and the fourth tick
+                # raises where the unmeasured path reaches the tenth.
+                if self._measured_condition_onset is None:
+                    raise ValueError("LingBot chunk_index exceeds the configured causal image condition horizon.")
+                # Past the transient the condition no longer moves, so every
+                # later tick gets the same settled block. This is what makes the
+                # horizon unbounded and the per-session cost constant.
+                condition_start = held_frames - block_frames
+                condition_stop = held_frames
             condition = session_state.image_condition[
                 :,
                 :,


### PR DESCRIPTION
## Purpose

A realtime session raises at `chunk_index 10` — **7.3 s of video at 16 fps**. The image condition is one VAE encode of the first frame followed by 116 zero frames, 30 latent frames, and each tick consumes three.

**The ceiling was never a property of the model.** The transformer is handed a fixed-width slice and is never told how long the session has been running; it is the preallocation that ends.

This makes the horizon unbounded: past the encode, every tick reuses the encode's last block — the one the condition has had the most frames to settle into, and still a real slice rather than an extrapolation.

### What this PR deliberately does *not* do, and why that is the interesting part

The first version of this work also **shrank** the held condition from 30 latent frames to 12, by measuring where the encode stops changing (`condition_steady_state_onset`) and holding only up to there. That shrink is withdrawn in the last commit, because the measurement underneath it does not carry it.

`condition_steady_state_onset` compares blocks against a tolerance of two representable steps, and on this checkpoint the residual plateaus at exactly that value:

```
residual = [2.1875, 0.21875, 0.058594, 0.03125, 0.03125, ..., 0.0]
atol     = 0.03125 = 2 * representable_step(condition)
```

`allclose` uses `<=`, so the verdict lands precisely on the boundary. "Settled" therefore means "differs by two units in the last place", and two ulps is a representable difference the model acts on.

Three things that had been recorded as three separate puzzles are this one fact:

- the onset flipped **9, 8, 8, 9** across four runs on one image, because the VAE encode is not bit-reproducible between processes;
- it differs between images — 9 or 12 across five deliberately dissimilar first frames — even though the tensor's scale barely moves (2.69 to 2.80, flat white and flat black alike), so the dependence is the residual straddling the threshold rather than the tolerance tracking the image;
- the arms of the earlier full-horizon comparison diverged at tick 3, which the docstring had explained as the prefix reproducing exactly. It does not; it reproduces to two ulps.

**Holding the whole horizon removes all three, and makes the patch a pure extension rather than a behaviour change:** unchanged where the old code worked, defined where it used to raise.

What it costs is the memory saving. But under a tolerance of one representable step rather than two, the measured onset moves to **21–24**, holding 24–27 frames — so the saving was around **three** frames once the tolerance is defensible, not the eighteen it appeared to be.

`condition_steady_state_onset` and its probe logging are kept. They no longer gate anything; what they are now good for is exactly what this commit found — watching whether a checkpoint's condition settles at all, and how far from the quantization floor.

### Relationship to #6838

#6838 targets the same ceiling with the opposite mechanism: hold two blocks, and reuse block 1 from tick 1 onward.

That is the shrink this PR withdrew, two blocks earlier. The numbers above are offered as evidence rather than as an objection: on this checkpoint, block 1's residual is **0.21875** against a plateau of **0.03125**, and 0.03125 is already the value at which "settled" turned out to be too loose to trust. If the two-block bound holds up under a byte-comparison against an unpatched run, that measurement would be worth having in either PR — it is the check that separates "the condition looks converged" from "the model cannot tell the difference".

### One caveat that is not an implementation detail

**This replaces a clean error with a silent degradation.** Before, a session raised at 7.31 s. After, it runs to 168 s — while the picture starts visibly degrading at about **22.6 s**, with no error at any point. A quality criterion is a separate piece of work and is not in this PR.

The next ceiling is the paged block table (65536 entries): **224 ticks ≈ 168 s.**

## Test Plan

`tests/diffusion/models/lingbot_world/test_pipeline_lingbot_world.py` — tests for the onset measurement, the block-granularity search, and ticks past the old ceiling.

The onset search steps by `block_frames` rather than by frame (second commit): the answer is only consumed at block granularity, and per-frame precision bought instability rather than accuracy — four runs on one image returned 9, 8, 8, 9 while printing byte-identical per-block residuals.

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** based on `a708ae5b`

## Test Result

On one RTX PRO 6000 Blackwell (sm_120), torch 2.11.0, bf16, 832x480, seed 0, same image and prompt, against the unpatched pipeline run to its own ceiling:

```
tick        0  1  2  3  4  5  6  7  8  9
this        =  =  =  =  =  =  =  =  =  =      byte-identical
shrunk      =  =  =  =  x  x  x  x  x  x      diverges from tick 4
```

A 25-tick run completes with no error, and `resident_capacity` is unchanged at 1 — the larger per-session condition does not cost a session slot at this resolution.
