### PR TITLE
[Bugfix][LTX] Restore distilled two-stage video serving

### DIFF
--- a/tests/entrypoints/openai_api/test_video_pipeline_capability.py
+++ b/tests/entrypoints/openai_api/test_video_pipeline_capability.py
@@ -57,6 +57,7 @@ def test_video_pipeline_rejects_non_video_final_outputs(stage_configs):
     [
         "LTX2TwoStagePipeline",
         "LTX2DistilledOneStagePipeline",
+        "LTX2DistilledTwoStagePipeline",
         "WanDMDPipeline",
         "LingBotWorldCausalDMDPipeline",
         "LongCatVideoAvatarPipeline",

--- a/vllm_omni/diffusion/model_metadata.py
+++ b/vllm_omni/diffusion/model_metadata.py
@@ -98,6 +98,7 @@ _DIFFUSION_MODEL_METADATA_ALIASES = {
     "WanDMDPipeline": "WanPipeline",
     "LTX2TwoStagePipeline": "LTX2Pipeline",
     "LTX2DistilledOneStagePipeline": "LTX2DistilledPipeline",
+    "LTX2DistilledTwoStagePipeline": "LTX2DistilledPipeline",
     "LingBotWorldCausalDMDPipeline": "LingBotVideoPipeline",
 }
 


### PR DESCRIPTION
## Problem

PR #5885 changed generic video-serving admission to require the final stage to explicitly declare `final_output_type="video"`. Its metadata aliases cover `LTX2TwoStagePipeline` and `LTX2DistilledOneStagePipeline`, but omit the explicit `LTX2DistilledTwoStagePipeline` class registered by #6070.

As a result, `LTX2DistilledTwoStagePipeline` falls back to `image` output metadata and `/v1/videos` rejects the pipeline because no final video output stage is found. The legacy `LTX2DistilledPipeline` alias remains classified correctly, which hides the regression when that older name is used.

## Summary

- Declare `LTX2DistilledTwoStagePipeline` as an alias of the existing distilled LTX video metadata.
- Add the explicit two-stage class to the video pipeline capability regression test.

## Tests

- `python -m pytest -q tests/entrypoints/openai_api/test_video_pipeline_capability.py` (`10 passed`)
- `pre-commit run --files vllm_omni/diffusion/model_metadata.py tests/entrypoints/openai_api/test_video_pipeline_capability.py`