### PR TITLE
[Quantization][MiniMax-H3] Add Video VAE Online FP8

### DIFF
--- a/recipes/MiniMaxAI/MiniMax-H3.md
+++ b/recipes/MiniMaxAI/MiniMax-H3.md
@@ -454,6 +454,11 @@ To select a component, use `--diffusion-quantization-config` with
 `{"text_encoder":{"method":"fp8"}}` for text-decoder-only FP8. The two
 entries can be combined. The shorthand below enables both components.
 
+Video-VAE decoder FP8 is opt-in with `{"video_vae":{"method":"fp8"}}` in
+the same configuration. It quantizes eligible decoder Transformer linears and
+supports `ignored_layers` values `attn.to_qkv`, `ff.w1`, and `ff.w2`; plain
+`--quantization fp8` does not enable it.
+
 Add this option to an existing H3 server command:
 
 ```bash

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_vae_ops.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_vae_ops.py
@@ -124,12 +124,12 @@ def _make_decoder():
     class Attention(nn.Module):
         def __init__(self):
             super().__init__()
-            self.to_qkv = nn.Linear(8, 24)
-            self.to_out = nn.Linear(8, 8)
-            self.norm_q = nn.RMSNorm(8, elementwise_affine=False)
-            self.norm_k = nn.RMSNorm(8, elementwise_affine=False)
+            self.to_qkv = nn.Linear(16, 48)
+            self.to_out = nn.Linear(16, 16)
+            self.norm_q = nn.RMSNorm(16, elementwise_affine=False)
+            self.norm_k = nn.RMSNorm(16, elementwise_affine=False)
             self.spatial_parallel = False
-            self.dim_head = 8
+            self.dim_head = 16
 
         def perform_attention(self, query, _key, _value, _pack_info):
             return query
@@ -140,8 +140,8 @@ def _make_decoder():
     class FeedForward(nn.Module):
         def __init__(self):
             super().__init__()
-            self.w1 = nn.Linear(8, 32)
-            self.w2 = nn.Linear(16, 8)
+            self.w1 = nn.Linear(16, 64)
+            self.w2 = nn.Linear(32, 16)
             self.use_gated = True
             self.act_fn = nn.SiLU()
             self._compile_forward_enabled = False
@@ -158,10 +158,10 @@ def _make_decoder():
             super().__init__()
             self.attn = Attention()
             self.ff = FeedForward()
-            self.norm1 = nn.RMSNorm(8)
-            self.norm2 = nn.RMSNorm(8)
-            self.scale1 = nn.Parameter(torch.zeros(8))
-            self.scale2 = nn.Parameter(torch.zeros(8))
+            self.norm1 = nn.RMSNorm(16)
+            self.norm2 = nn.RMSNorm(16)
+            self.scale1 = nn.Parameter(torch.zeros(16))
+            self.scale2 = nn.Parameter(torch.zeros(16))
             self.use_scale = True
 
         def forward(self, hidden_states, rotary_pos_emb=None, pack_info=None):
@@ -169,7 +169,7 @@ def _make_decoder():
 
     decoder = nn.Module()
     decoder.transformer_blocks = nn.ModuleList([Block(), Block()])
-    decoder.proj_out = nn.Linear(8, 8)
+    decoder.proj_out = nn.Linear(16, 16)
     return decoder
 
 
@@ -216,6 +216,119 @@ def test_video_vae_installs_exact_optimizations(monkeypatch):
     )
 
 
+def test_video_vae_installs_requested_fp8_layers(monkeypatch):
+    from vllm_omni.diffusion.models.minimax_h3 import vae as vae_module
+
+    class FakeModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.decoder = torch.nn.Module()
+
+    class FakeRemote(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = FakeModel()
+
+    monkeypatch.setattr(
+        vae_module,
+        "_load_component_config",
+        lambda _path: {
+            "latent_channels": 1,
+            "latents_mean": [0.0],
+            "latents_std": [1.0],
+        },
+    )
+    monkeypatch.setattr(
+        vae_module,
+        "_load_remote_component",
+        lambda _path, _config: FakeRemote(),
+    )
+    install = Mock(return_value=True)
+    install_fp8 = Mock()
+    monkeypatch.setattr(vae_module, "install_h3_vae_optimizations", install)
+    monkeypatch.setattr(vae_module, "install_h3_vae_fp8_quantization", install_fp8)
+
+    vae_module.MiniMaxH3VideoVAE(
+        "unused",
+        device=torch.device("cpu"),
+        fp8_layers=frozenset({"attn.to_qkv", "ff.w1", "ff.w2"}),
+    )
+
+    install.assert_called_once()
+    assert isinstance(install.call_args.args[0], torch.nn.Module)
+    assert install.call_args.kwargs == {
+        "device": torch.device("cpu"),
+    }
+    install_fp8.assert_called_once()
+    assert install_fp8.call_args.args == install.call_args.args
+    assert install_fp8.call_args.kwargs == {
+        "execution_device": torch.device("cpu"),
+        "storage_device": torch.device("cpu"),
+        "layers": frozenset({"attn.to_qkv", "ff.w1", "ff.w2"}),
+    }
+
+
+def test_video_vae_fp8_config_requires_explicit_component_config():
+    from vllm_omni.diffusion.models.minimax_h3.vae import (
+        resolve_minimax_h3_video_vae_fp8_layers,
+    )
+    from vllm_omni.quantization import build_quant_config
+
+    assert resolve_minimax_h3_video_vae_fp8_layers(build_quant_config("fp8")) is None
+
+    disabled_config = build_quant_config(
+        {
+            "default": {"method": "fp8"},
+            "video_vae": None,
+        }
+    )
+    assert resolve_minimax_h3_video_vae_fp8_layers(disabled_config) is None
+
+    selective_config = build_quant_config(
+        {
+            "video_vae": {
+                "method": "fp8",
+                "ignored_layers": ["ff.w2"],
+            }
+        }
+    )
+    assert resolve_minimax_h3_video_vae_fp8_layers(selective_config) == frozenset({"attn.to_qkv", "ff.w1"})
+
+    aggressive_config = build_quant_config({"video_vae": {"method": "fp8"}})
+    assert resolve_minimax_h3_video_vae_fp8_layers(aggressive_config) == frozenset({"attn.to_qkv", "ff.w1", "ff.w2"})
+
+
+def test_video_vae_fp8_config_rejects_generic_component_fp8():
+    from vllm_omni.diffusion.models.minimax_h3.vae import (
+        resolve_minimax_h3_video_vae_fp8_layers,
+    )
+    from vllm_omni.quantization import ComponentQuantizationConfig
+
+    unsupported = Mock()
+    unsupported.get_name.return_value = "unsupported"
+    config = ComponentQuantizationConfig({"video_vae": unsupported})
+    with pytest.raises(ValueError, match="only supports online fp8"):
+        resolve_minimax_h3_video_vae_fp8_layers(config)
+
+
+@pytest.mark.parametrize(
+    "video_vae_config",
+    [
+        {"method": "fp8", "activation_scheme": "static"},
+        {"method": "fp8", "ignored_layers": ["attn.to_out"]},
+    ],
+)
+def test_video_vae_fp8_config_rejects_unsupported_policy(video_vae_config):
+    from vllm_omni.diffusion.models.minimax_h3.vae import (
+        resolve_minimax_h3_video_vae_fp8_layers,
+    )
+    from vllm_omni.quantization import build_quant_config
+
+    config = build_quant_config({"video_vae": video_vae_config})
+    with pytest.raises(ValueError, match="MiniMax H3 video_vae"):
+        resolve_minimax_h3_video_vae_fp8_layers(config)
+
+
 def test_h3_vae_install_precasts_only_block_linears(monkeypatch):
     from vllm_omni.diffusion.models.minimax_h3.ops import vae as vae_ops
 
@@ -247,6 +360,158 @@ def test_h3_vae_install_precasts_only_block_linears(monkeypatch):
     )
 
 
+def test_h3_vae_fp8_is_independent_from_eager_operator_dispatch(monkeypatch):
+    import vllm.model_executor.parameter as parameter_module
+    from vllm.model_executor.layers.linear import ReplicatedLinear
+    from vllm.model_executor.layers.quantization.online.fp8 import Fp8PtpcOnlineLinearMethod
+
+    from vllm_omni.diffusion.models.minimax_h3 import vae_fp8
+    from vllm_omni.diffusion.models.minimax_h3.ops import vae as vae_ops
+
+    resolver = Mock(side_effect=AssertionError("eager-op dispatch must not be used"))
+    monkeypatch.setattr(vae_ops, "resolve_h3_vae_operators", resolver)
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_world_size", lambda: 1)
+    device, _ = _selected_operators()
+    decoder = _make_decoder().to(device)
+
+    vae_fp8.install_h3_vae_fp8_quantization(
+        decoder,
+        execution_device=device,
+        storage_device=device,
+        layers=frozenset({"attn.to_qkv", "ff.w1", "ff.w2"}),
+    )
+    resolver.assert_not_called()
+
+    for block in decoder.transformer_blocks:
+        for linear in (
+            block.attn.to_qkv,
+            block.ff.w1,
+            block.ff.w2,
+        ):
+            assert isinstance(linear, ReplicatedLinear)
+            assert isinstance(linear.quant_method, Fp8PtpcOnlineLinearMethod)
+            assert linear.weight.dtype == current_omni_platform.fp8_dtype()
+            assert linear.weight_scale.dtype == torch.float32
+        assert not tuple(block.attn.to_out.buffers())
+
+
+def test_h3_vae_fp8_backend_preserves_linear_contract(monkeypatch):
+    import vllm.model_executor.parameter as parameter_module
+
+    from vllm_omni.diffusion.models.minimax_h3 import vae_fp8
+
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_world_size", lambda: 1)
+    device, _ = _selected_operators()
+    decoder = _make_decoder().to(device)
+    feed_forward = decoder.transformer_blocks[0].ff
+    hidden_states = torch.randn(37, 16, device=device, dtype=torch.float32)
+    with torch.inference_mode(), torch.autocast(device.type, dtype=torch.float16):
+        expected = feed_forward(hidden_states)
+
+    vae_fp8.install_h3_vae_fp8_quantization(
+        decoder,
+        execution_device=device,
+        storage_device=device,
+        layers=frozenset({"ff.w1", "ff.w2"}),
+    )
+    for linear in (feed_forward.w1, feed_forward.w2):
+        assert linear.quant_method.apply.__func__ is vae_fp8._H3VAEFp8LinearMethod.apply
+    with torch.inference_mode(), torch.autocast(device.type, dtype=torch.float16):
+        actual = feed_forward(hidden_states)
+
+    assert actual.shape == expected.shape
+    assert actual.dtype == torch.float16
+    relative_l2 = torch.linalg.vector_norm(actual.float() - expected.float()) / torch.linalg.vector_norm(
+        expected.float()
+    )
+    cosine = F.cosine_similarity(actual.float().flatten(), expected.float().flatten(), dim=0)
+    assert relative_l2 < 0.08
+    assert cosine > 0.995
+
+
+def test_h3_vae_fp8_is_not_processed_twice_by_model_finalizer(monkeypatch):
+    import vllm.model_executor.parameter as parameter_module
+    from vllm.model_executor.model_loader.reload import finalize_layerwise_processing
+
+    from vllm_omni.diffusion.models.minimax_h3 import vae_fp8
+
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_world_size", lambda: 1)
+    device, _ = _selected_operators()
+    decoder = _make_decoder().to(device)
+
+    vae_fp8.install_h3_vae_fp8_quantization(
+        decoder,
+        execution_device=device,
+        storage_device=device,
+        layers=frozenset({"ff.w1", "ff.w2"}),
+    )
+    weights_before = {
+        name: parameter.detach().clone()
+        for name, parameter in decoder.named_parameters()
+        if name.endswith(("ff.w1.weight", "ff.w2.weight"))
+    }
+
+    finalize_layerwise_processing(decoder, model_config=None)
+
+    for name, expected in weights_before.items():
+        assert torch.equal(dict(decoder.named_parameters())[name], expected)
+
+
+def test_h3_vae_fp8_backend_supports_cpu_storage(monkeypatch):
+    import vllm.model_executor.parameter as parameter_module
+
+    from vllm_omni.diffusion.models.minimax_h3 import vae_fp8
+
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_world_size", lambda: 1)
+    device, _ = _selected_operators()
+    decoder = _make_decoder().to(device)
+
+    vae_fp8.install_h3_vae_fp8_quantization(
+        decoder,
+        execution_device=device,
+        storage_device=torch.device("cpu"),
+        layers=frozenset({"ff.w1", "ff.w2"}),
+    )
+    for block in decoder.transformer_blocks:
+        assert block.ff.w1.weight.device.type == "cpu"
+        assert block.ff.w1.weight_scale.device.type == "cpu"
+        assert block.ff.w2.weight.device.type == "cpu"
+        assert block.ff.w2.weight_scale.device.type == "cpu"
+
+    decoder.to(device)
+    hidden_states = torch.randn(37, 16, device=device, dtype=torch.float32)
+    with torch.inference_mode(), torch.autocast(device.type, dtype=torch.float16):
+        output = decoder.transformer_blocks[0].ff(hidden_states)
+    assert output.shape == hidden_states.shape
+    assert torch.isfinite(output).all()
+
+
+def test_h3_vae_fp8_is_not_enabled_by_hardware_dispatch_alone(monkeypatch):
+    from vllm_omni.diffusion.models.minimax_h3.ops import vae as vae_ops
+
+    monkeypatch.setattr(
+        vae_ops,
+        "resolve_h3_vae_operators",
+        lambda _device: _operator_set(),
+    )
+    decoder = _make_decoder()
+
+    assert vae_ops.install_h3_vae_optimizations(
+        decoder,
+        device=torch.device("meta"),
+    )
+
+    for block in decoder.transformer_blocks:
+        assert not tuple(block.ff.w1.buffers())
+        assert not tuple(block.ff.w2.buffers())
+        assert block.ff.w1.forward.__func__.__name__ == "forward"
+        assert block.ff.w2.forward.__func__.__name__ == "forward"
+
+
 def test_h3_vae_install_accepts_remote_integer_parallel_flag(monkeypatch):
     from vllm_omni.diffusion.models.minimax_h3.ops import vae as vae_ops
 
@@ -270,7 +535,8 @@ def test_h3_vae_install_accepts_remote_integer_parallel_flag(monkeypatch):
 def test_h3_vae_swiglu_uses_post_linear_fp16_output(monkeypatch):
     from vllm_omni.diffusion.models.minimax_h3.ops import vae as vae_ops
 
-    device, operators = _selected_operators()
+    device, _ = _selected_operators()
+    operators = _operator_set()
     monkeypatch.setattr(vae_ops, "resolve_h3_vae_operators", lambda _device: operators)
     decoder = _make_decoder().to(device)
     feed_forward = decoder.transformer_blocks[0].ff
@@ -280,7 +546,7 @@ def test_h3_vae_swiglu_uses_post_linear_fp16_output(monkeypatch):
         device=device,
     )
 
-    hidden_states = torch.randn(4, 8, device=device, dtype=torch.float32)
+    hidden_states = torch.randn(4, 16, device=device, dtype=torch.float32)
     with torch.inference_mode(), torch.autocast(device.type, dtype=torch.float16):
         expected = reference_forward(feed_forward, hidden_states)
         actual = feed_forward(hidden_states)

--- a/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
+++ b/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
@@ -147,7 +147,11 @@ from .time_request import (
     minimax_h3_align_frame_count,
     minimax_h3_time_shift_sigmas,
 )
-from .vae import MiniMaxH3AudioVAE, MiniMaxH3VideoVAE
+from .vae import (
+    MiniMaxH3AudioVAE,
+    MiniMaxH3VideoVAE,
+    resolve_minimax_h3_video_vae_fp8_layers,
+)
 
 if TYPE_CHECKING:
     from vllm_omni.diffusion.worker.input_batch import InputBatch
@@ -1031,6 +1035,7 @@ class MiniMaxH3Pipeline(
             os.path.join(model_path, "video_vae"),
             device=self.device,
             load_device=component_load_device,
+            fp8_layers=resolve_minimax_h3_video_vae_fp8_layers(od_config.quantization_config),
         )
         self.audio_vae = MiniMaxH3AudioVAE(
             os.path.join(model_path, "audio_vae"),

--- a/vllm_omni/diffusion/models/minimax_h3/vae.py
+++ b/vllm_omni/diffusion/models/minimax_h3/vae.py
@@ -17,6 +17,8 @@ import torch.nn as nn
 from PIL import Image
 from transformers.dynamic_module_utils import get_class_from_dynamic_module
 from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+from vllm.model_executor.layers.quantization.fp8 import Fp8Config
 
 from vllm_omni.diffusion.distributed.autoencoders.distributed_vae_executor import (
     DistributedVaeMixin,
@@ -26,9 +28,14 @@ from vllm_omni.diffusion.offloader.module_residency import (
     BoundedAllocatorCache,
     PinnedModuleStager,
 )
+from vllm_omni.quantization.component_config import ComponentQuantizationConfig
 
 from .ops import install_h3_vae_optimizations
 from .packed_tokens import minimax_h3_patchify_video_latent
+from .vae_fp8 import (
+    H3_VAE_FP8_LINEAR_NAMES,
+    install_h3_vae_fp8_quantization,
+)
 
 MINIMAX_H3_KEYFRAME_ENCODE_SEED = 42
 MINIMAX_H3_AUDIO_SAMPLE_RATE = 32000
@@ -36,6 +43,39 @@ MINIMAX_H3_AUDIO_CHANNELS = 2
 
 
 logger = init_logger(__name__)
+
+
+def resolve_minimax_h3_video_vae_fp8_layers(
+    quant_config: QuantizationConfig | None,
+) -> frozenset[str] | None:
+    """Resolve an explicitly component-scoped generic FP8 config."""
+
+    if not isinstance(quant_config, ComponentQuantizationConfig):
+        return None
+
+    video_vae_config = quant_config.component_configs.get("video_vae")
+    if video_vae_config is None:
+        return None
+    if not isinstance(video_vae_config, Fp8Config):
+        raise ValueError(
+            f"MiniMax H3 video_vae only supports online fp8 component quantization, got {video_vae_config.get_name()!r}"
+        )
+    if (
+        video_vae_config.is_checkpoint_fp8_serialized
+        or video_vae_config.activation_scheme != "dynamic"
+        or video_vae_config.weight_block_size is not None
+        or video_vae_config.store_dtype is not None
+    ):
+        raise ValueError(
+            "MiniMax H3 video_vae requires online FP8 with dynamic activations, "
+            "no block size, and no store_dtype override"
+        )
+
+    ignored_layers = set(video_vae_config.ignored_layers)
+    unknown = ignored_layers - H3_VAE_FP8_LINEAR_NAMES
+    if unknown:
+        raise ValueError(f"MiniMax H3 video_vae FP8 does not recognize ignored_layers={sorted(unknown)}")
+    return H3_VAE_FP8_LINEAR_NAMES - ignored_layers
 
 
 def _load_component_config(component_path: str) -> dict[str, Any]:
@@ -121,6 +161,7 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
         *,
         device: torch.device,
         load_device: torch.device | None = None,
+        fp8_layers: frozenset[str] | None = None,
     ) -> None:
         super().__init__()
         self._device_target = device
@@ -136,11 +177,20 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
         initial_device = load_device or device
         self.remote.eval().to(device=initial_device, dtype=torch.float32)
         decoder = getattr(self.remote.model, "decoder", None)
+        if fp8_layers is not None and decoder is None:
+            raise ValueError("MiniMax H3 video-VAE FP8 requires a decoder module")
         if decoder is not None:
             install_h3_vae_optimizations(
                 decoder,
                 device=device,
             )
+            if fp8_layers is not None:
+                install_h3_vae_fp8_quantization(
+                    decoder,
+                    execution_device=device,
+                    storage_device=initial_device,
+                    layers=fp8_layers,
+                )
         self._stager = None
         if initial_device.type == "cpu" and device.type not in ("cpu", "meta"):
             self._stager = PinnedModuleStager(

--- a/vllm_omni/diffusion/models/minimax_h3/vae_fp8.py
+++ b/vllm_omni/diffusion/models/minimax_h3/vae_fp8.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Optional FP8 backend wiring for the MiniMax H3 video VAE."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+from vllm import _custom_ops as ops
+from vllm.logger import init_logger
+from vllm.model_executor.kernels.linear import init_fp8_linear_kernel
+from vllm.model_executor.kernels.linear.scaled_mm import (
+    MarlinFP8ScaledMMLinearKernel,
+)
+from vllm.model_executor.layers.linear import LinearBase, ReplicatedLinear
+from vllm.model_executor.layers.quantization.fp8 import Fp8Config
+from vllm.model_executor.layers.quantization.online.fp8 import (
+    Fp8PtpcOnlineLinearMethod,
+)
+from vllm.model_executor.parameter import ModelWeightParameter
+from vllm.model_executor.utils import replace_parameter
+
+H3_VAE_FP8_LINEAR_NAMES = frozenset({"attn.to_qkv", "ff.w1", "ff.w2"})
+
+logger = init_logger(__name__)
+
+
+class _H3VAEFp8LinearMethod(Fp8PtpcOnlineLinearMethod):
+    """Use vLLM's PTPC weights and scaled-MM backend without ``CustomOp``."""
+
+    def __init__(self) -> None:
+        # The pipeline decodes the video VAE under FP16 autocast even when the
+        # DiT uses BF16. Kernel selection must therefore not inherit the DiT's
+        # dtype from the process-wide vLLM config. The upstream base initializer
+        # only establishes these two fields, so declare the component contract
+        # directly before its common create/process/apply lifecycle runs.
+        self.input_dtype = torch.float16
+        self.out_dtype = torch.float16
+
+    def create_weights(
+        self,
+        layer: nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        """Create an already-loaded component weight without deferred loading.
+
+        The common online method registers a layerwise checkpoint loader because
+        LLM weights are normally populated after module construction. H3's remote
+        video VAE is already loaded before these linears are replaced. Registering
+        that loader would make Omni's finalizer quantize the weight a second time.
+        """
+
+        output_size_per_partition = sum(output_partition_sizes)
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+        layer.orig_dtype = params_dtype
+        layer.weight_block_size = None
+        weight = ModelWeightParameter(
+            data=torch.empty(
+                output_size_per_partition,
+                input_size_per_partition,
+                device="meta",
+                dtype=params_dtype,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=extra_weight_attrs.get("weight_loader"),
+        )
+        layer.register_parameter("weight", weight)
+
+        self.fp8_linear = init_fp8_linear_kernel(
+            activation_quant_key=self.activation_quant_key,
+            weight_quant_key=self.weight_quant_key,
+            weight_shape=layer.weight.shape,
+            input_dtype=self.input_dtype,
+            out_dtype=self.out_dtype,
+            module_name=self.__class__.__name__,
+        )
+        if isinstance(self.fp8_linear, MarlinFP8ScaledMMLinearKernel):
+            raise ValueError(
+                "MiniMax H3 video-VAE FP8 requires per-token activation "
+                "quantization, but the selected backend is weight-only Marlin FP8"
+            )
+
+    def apply(
+        self,
+        layer: nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # H3 keeps decoder-block residuals and normalized activations in FP32.
+        # Quantize that tensor directly, as the original optimized path did.
+        # Calling the registered accelerator op here deliberately bypasses vLLM's
+        # QuantFP8(CustomOp) wrapper: compile policy must not replace this eager
+        # kernel with the much slower native decomposition.
+        original_shape = x.shape
+        x_quantized, input_scale = ops.scaled_fp8_quant(
+            x.reshape(-1, x.shape[-1]),
+            use_per_token_if_dynamic=True,
+        )
+        return self.fp8_linear.apply_scaled_mm(
+            A=x_quantized,
+            B=layer.weight,
+            out_dtype=self.out_dtype,
+            As=input_scale,
+            Bs=layer.weight_scale,
+            bias=bias,
+            output_shape=[*original_shape[:-1], layer.output_size_per_partition],
+        )
+
+
+class _H3VAEFp8Config(Fp8Config):
+    """Select the common per-token/per-channel FP8 linear backend."""
+
+    def get_quant_method(self, layer: nn.Module, prefix: str):
+        if isinstance(layer, LinearBase):
+            return _H3VAEFp8LinearMethod()
+        return None
+
+
+def _decoder_targets(
+    decoder: nn.Module,
+    layers: frozenset[str],
+) -> list[tuple[nn.Module, str, str, nn.Linear]] | None:
+    blocks = getattr(decoder, "transformer_blocks", None)
+    if not isinstance(blocks, nn.ModuleList) or not blocks:
+        return None
+
+    targets: list[tuple[nn.Module, str, str, nn.Linear]] = []
+    for index, block in enumerate(blocks):
+        attention = getattr(block, "attn", None)
+        feed_forward = getattr(block, "ff", None)
+        candidates = {
+            "attn.to_qkv": (attention, "to_qkv", getattr(attention, "to_qkv", None)),
+            "ff.w1": (feed_forward, "w1", getattr(feed_forward, "w1", None)),
+            "ff.w2": (feed_forward, "w2", getattr(feed_forward, "w2", None)),
+        }
+        if not all(
+            isinstance(parent, nn.Module) and isinstance(linear, nn.Linear)
+            for parent, _attribute, linear in candidates.values()
+        ):
+            return None
+
+        to_qkv = candidates["attn.to_qkv"][2]
+        w1 = candidates["ff.w1"][2]
+        w2 = candidates["ff.w2"][2]
+        if (
+            to_qkv.out_features != 3 * to_qkv.in_features
+            or w1.in_features != to_qkv.in_features
+            or w1.out_features != 2 * w2.in_features
+            or w2.out_features != to_qkv.in_features
+        ):
+            return None
+
+        for name in sorted(layers):
+            parent, attribute, linear = candidates[name]
+            prefix = f"video_vae.decoder.transformer_blocks.{index}.{name}"
+            targets.append((parent, attribute, prefix, linear))
+    return targets
+
+
+@torch.no_grad()
+def _replace_with_fp8_linear(
+    source: nn.Linear,
+    *,
+    prefix: str,
+    execution_device: torch.device,
+    storage_device: torch.device,
+    quant_config: Fp8Config,
+) -> ReplicatedLinear:
+    with execution_device:
+        target = ReplicatedLinear(
+            input_size=source.in_features,
+            output_size=source.out_features,
+            bias=source.bias is not None,
+            params_dtype=torch.float16,
+            quant_config=quant_config,
+            prefix=prefix,
+            return_bias=False,
+            disable_tp=True,
+        )
+
+    # Online vLLM methods create a meta weight and normally materialize it via
+    # the checkpoint loader. The remote VAE is already loaded, so materialize
+    # that weight directly and then enter the same process/apply lifecycle.
+    dense_weight = source.weight.detach().to(device=execution_device, dtype=torch.float16)
+    replace_parameter(target, "weight", dense_weight)
+    if source.bias is not None:
+        target.bias.copy_(source.bias.detach().to(device=execution_device, dtype=torch.float16))
+
+    target.quant_method.process_weights_after_loading(target)
+    target.update_param_tp_status()
+    target.train(source.training)
+    if storage_device != execution_device:
+        target.to(storage_device)
+    return target
+
+
+def install_h3_vae_fp8_quantization(
+    decoder: nn.Module,
+    *,
+    execution_device: torch.device,
+    storage_device: torch.device,
+    layers: frozenset[str],
+) -> None:
+    """Replace selected decoder linears with vLLM's common FP8 backend."""
+
+    unknown = layers - H3_VAE_FP8_LINEAR_NAMES
+    if unknown:
+        raise ValueError(f"Unsupported MiniMax H3 video-VAE FP8 layers: {sorted(unknown)}")
+
+    installed_layers = getattr(decoder, "_omni_h3_vae_fp8_layers", None)
+    if installed_layers is not None:
+        if installed_layers != layers:
+            raise ValueError(
+                "MiniMax H3 VAE FP8 is already installed for "
+                f"layers={sorted(installed_layers)}, cannot reinstall for {sorted(layers)}"
+            )
+        return
+    if not layers:
+        decoder._omni_h3_vae_fp8_layers = layers
+        return
+
+    targets = _decoder_targets(decoder, layers)
+    if targets is None or any(
+        linear.weight.dtype not in {torch.float16, torch.float32} for _parent, _attribute, _prefix, linear in targets
+    ):
+        raise ValueError(
+            "MiniMax H3 video-VAE FP8 was explicitly requested, but the "
+            "loaded decoder does not match the supported remote-code contract"
+        )
+
+    quant_config = _H3VAEFp8Config()
+    replacements: list[tuple[nn.Module, str, nn.Linear]] = []
+    try:
+        for parent, attribute, prefix, source in targets:
+            target = _replace_with_fp8_linear(
+                source,
+                prefix=prefix,
+                execution_device=execution_device,
+                storage_device=storage_device,
+                quant_config=quant_config,
+            )
+            setattr(parent, attribute, target)
+            replacements.append((parent, attribute, source))
+    except BaseException:
+        for parent, attribute, source in reversed(replacements):
+            setattr(parent, attribute, source)
+        raise
+
+    decoder._omni_h3_vae_fp8_layers = layers
+    logger.info(
+        "Enabled user-requested MiniMax H3 video-VAE FP8 via the vLLM backend for layers=%s on %s",
+        sorted(layers),
+        execution_device,
+    )
+
+
+__all__ = [
+    "H3_VAE_FP8_LINEAR_NAMES",
+    "install_h3_vae_fp8_quantization",
+]


### PR DESCRIPTION
## Summary

This PR adds opt-in online FP8 quantization for MiniMax-H3's video-VAE decoder Transformer. It reuses vLLM's per-token/per-channel FP8 backend for `attn.to_qkv`, `ff.w1`, and `ff.w2`, while preserving the model-owned VAE operator path and its exact fallbacks.

The feature is component-scoped and does not change the default path:

```bash
--diffusion-quantization-config '{"video_vae":{"method":"fp8"}}'
```

`ignored_layers` can selectively keep `attn.to_qkv`, `ff.w1`, or `ff.w2` in the original precision. Plain `--quantization fp8` does not enable video-VAE FP8.

## FastH3 end-to-end performance

The online E2E test uses 4x NVIDIA H200, USP4, native VAE PP4 tile mode, regional compile, and the FastH3 Dense DataFree four-step recipe at `1344x768` and 209 output frames. Baseline and FP8 use separate server processes. Each mode runs 1 warmup followed by 2 measured requests. Latency is the API-reported `stage_0_gen_ms`; module times come from `DiffusionPipelineProfilerMixin`; peak memory is the request-scoped `max_memory_reserved()` reported by Omni.

| Mode | Stage 0 samples | p50 | 4-step denoise p50 | VAE decode p50 | Relative throughput | Request peak reserved |
|---|---:|---:|---:|---:|---:|---:|
| Baseline | 17.083 s, 17.233 s | 17.158 s | 14.281 s | 2.005 s | 1.000x | 130,542 MiB/GPU |
| Video VAE FP8 | 17.110 s, 16.676 s | **16.893 s** | 14.221 s | **1.790 s** | **1.016x** | **129,250 MiB/GPU** |

The independently timed joint video/audio VAE decode improves by **1.120x**. Only the video VAE changes, so this joint timing includes the unchanged audio decoder. FastH3 E2E improves by **1.016x**, while request peak memory decreases by **1,292 MiB/GPU**.

The standalone Video VAE benchmark uses 1x NVIDIA H200, native PP1 tile mode, the same real `1344x768` / 209-frame latent, and 1 warmup followed by 2 measured decodes.

| Mode | Decode samples | p50 | Relative throughput | Peak allocated |
|---|---:|---:|---:|---:|
| Baseline | 7.334 s, 7.839 s | 7.587 s | 1.000x | 15,261.8 MiB |
| Video VAE FP8 | 6.373 s, 6.322 s | **6.347 s** | **1.195x** | **13,137.2 MiB** |

Standalone FP8 reduces peak allocated memory by **2,124.6 MiB**. Peak reserved memory is unchanged (`20,596 MiB -> 20,600 MiB`).

## Quality

The real-latent A/B decodes share exactly the same latent and audio; FP8 only changes video-VAE decoding. Metrics below compare the separately encoded H.264 CRF 18 videos frame by frame.

| Metric | Result |
|---|---:|
| Mean SSIM | **0.991491** |
| Minimum per-frame SSIM | **0.987891** |
| Mean PSNR | **45.538 dB** |

A separate uncompressed 243-frame tensor comparison reports relative L2 `0.023018`, cosine similarity `0.999738`, PSNR `46.006 dB`, and sampled-frame SSIM mean/min `0.997722 / 0.997190`.

## FastH3 A/B video

Baseline is on the left and FP8 is on the right. The comparison is 1792x512, 8.709 seconds, H.264/AAC, and 7.09 MB.

https://github.com/user-attachments/assets/120ba48a-5438-4d02-9031-32ae97983967

## Validation

```text
tests/diffusion/models/minimax_h3/test_minimax_h3_vae_ops.py: 30 passed
targeted pre-commit: passed
```

Model revision: `42ed227ee7df40d41602854ae760620d6eb651fe`
