### PR TITLE
[CI][Bugfix]Drop dummy-weight Qwen3-TTS Base from Ready CI

### DIFF
--- a/.buildkite/cuda/test-merge.yml
+++ b/.buildkite/cuda/test-merge.yml
@@ -85,6 +85,9 @@ steps:
           - vllm_omni/model_executor/models/common/alias_free_activation.py
           - vllm_omni/model_executor/stage_input_processors/qwen3_tts.py
           - vllm_omni/deploy/qwen3_tts.yaml
+          - vllm_omni/entrypoints/openai/serving_speech.py
+          - vllm_omni/entrypoints/openai/tts_adapters/
+          - vllm_omni/engine/stage_pool.py
         commands:
           - |
             timeout 40m bash -c "
@@ -104,6 +107,9 @@ steps:
           - vllm_omni/model_executor/models/common/alias_free_activation.py
           - vllm_omni/model_executor/stage_input_processors/qwen3_tts.py
           - vllm_omni/deploy/qwen3_tts.yaml
+          - vllm_omni/entrypoints/openai/serving_speech.py
+          - vllm_omni/entrypoints/openai/tts_adapters/
+          - vllm_omni/engine/stage_pool.py
           - .buildkite/common/scripts/run_cov_split.sh
           - pyproject.toml
         # 40 -> 60: the coverage split runs the model twice.

--- a/.buildkite/cuda/test-ready.yml
+++ b/.buildkite/cuda/test-ready.yml
@@ -252,30 +252,14 @@ steps:
           - vllm_omni/model_executor/models/common/alias_free_activation.py
           - vllm_omni/model_executor/stage_input_processors/qwen3_tts.py
           - vllm_omni/deploy/qwen3_tts.yaml
+          - vllm_omni/entrypoints/openai/serving_speech.py
+          - vllm_omni/entrypoints/openai/tts_adapters/
+          - vllm_omni/engine/stage_pool.py
         commands:
           - |
             timeout 20m bash -c "
               export VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
               pytest -s -v tests/e2e/online_serving/test_qwen3_tts_customvoice.py -m 'core_model' --run-level 'core_model'
-            "
-        mirror_hardwares: l4_1
-
-      - label: "TTS · Qwen3-TTS Base Test"
-        source_file_dependencies:
-          - tests/e2e/online_serving/test_qwen3_tts_base.py
-          - vllm_omni/model_executor/models/qwen3_tts/
-          - vllm_omni/model_executor/models/common/qwen3_code_predictor.py
-          - vllm_omni/model_executor/models/common/snake_activation.py
-          - vllm_omni/model_executor/models/common/alias_free_activation.py
-          - vllm_omni/model_executor/stage_input_processors/qwen3_tts.py
-          - vllm_omni/deploy/qwen3_tts.yaml
-        commands:
-          - |
-            timeout 20m bash -c "
-              export VLLM_WORKER_MULTIPROC_METHOD=spawn
-              export VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
-              export VLLM_OMNI_USE_V2_RUNNER=1
-              pytest -s -v tests/e2e/online_serving/test_qwen3_tts_base.py -m 'core_model' --run-level 'core_model'
             "
         mirror_hardwares: l4_1
 

--- a/tests/e2e/online_serving/test_qwen3_tts_base.py
+++ b/tests/e2e/online_serving/test_qwen3_tts_base.py
@@ -55,7 +55,6 @@ tts_server_params = [
 
 
 @pytest.mark.advanced_model
-@pytest.mark.core_model
 @pytest.mark.tts
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 @pytest.mark.parametrize("omni_server", tts_server_params, indirect=True)


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Ready CI (`core_model`) runs Qwen3-TTS Base with dummy weights. After #6728, Base generations that hit `max_tokens` without codec EOS return HTTP 500. Dummy talker almost never samples EOS, so `test_text_to_audio_001[async_chunk]` fails as in #6855.

This PR:

- Drops `@pytest.mark.core_model` from the online Base smoke so Ready no longer collects it.
- Removes the **TTS · Qwen3-TTS Base Test** step from `.buildkite/cuda/test-ready.yml`.
- Keeps real-weight coverage on merge (`advanced_model`) for CUDA and AMD.
- Adds `serving_speech.py`, `tts_adapters/`, and `stage_pool.py` to CustomVoice (Ready + merge) and Base (merge) `source_file_dependencies` so serving-layer changes still schedule those jobs.

Fixes #6855

## Test Plan

**vLLM Version:** whatever the Buildkite image pins (no production runtime change)

**vLLM-Omni Commit:** this PR head

```bash
# Ready must collect nothing
pytest -q tests/e2e/online_serving/test_qwen3_tts_base.py -m 'core_model' --run-level core_model --collect-only

# Merge-equivalent (real weights, L4)
pytest -s -v tests/e2e/online_serving/test_qwen3_tts_base.py tests/e2e/offline_inference/test_qwen3_tts_base.py \
  -m 'advanced_model and cuda' --run-level advanced_model
```

No new test files. Production `qwen3_tts.yaml` is unchanged.

## Test Result

- Local: `core_model --collect-only` on `test_qwen3_tts_base.py` should be empty after this change.
- Real-weight e2e: Pending Buildkite merge jobs **TTS · Qwen3-TTS Base Test** / AMD **Qwen3-TTS Base E2E Test**.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
