### PR TITLE
[Bugfix][Core] Ship only the accepted hidden-state rows to downstream Omni stages

### DIFF
--- a/tests/worker/test_accepted_hidden_rows.py
+++ b/tests/worker/test_accepted_hidden_rows.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Only the hidden-state rows a request emitted may go downstream.
+
+A speculative step forwards one real position plus the drafts, and rejection
+sampling keeps a prefix of them. Slicing the Omni payload by the scheduled
+token count also ships the rows past that prefix -- hidden states for tokens
+the model never emitted. Pure CPU: no model, no accelerator.
+"""
+
+import pytest
+
+from vllm_omni.worker.sampling_utils import accepted_hidden_rows
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _rows(
+    *,
+    num_scheduled_tokens: int,
+    drafts: dict[str, list[int]],
+    accepted: list[list[int]],
+    req_id: str = "r0",
+    req_index: int = 0,
+) -> int:
+    return accepted_hidden_rows(
+        req_id=req_id,
+        req_index=req_index,
+        num_scheduled_tokens=num_scheduled_tokens,
+        scheduled_spec_decode_tokens=drafts,
+        valid_sampled_token_ids=accepted,
+    )
+
+
+def test_partial_rejection_drops_the_remainder():
+    # 1 real position + 3 drafts scheduled, 2 tokens accepted.
+    assert _rows(num_scheduled_tokens=4, drafts={"r0": [11, 12, 13]}, accepted=[[101, 102]]) == 2
+
+
+def test_full_acceptance_keeps_every_row():
+    assert _rows(num_scheduled_tokens=4, drafts={"r0": [11, 12, 13]}, accepted=[[101, 102, 103, 104]]) == 4
+
+
+def test_total_rejection_keeps_only_the_real_position():
+    assert _rows(num_scheduled_tokens=4, drafts={"r0": [11, 12, 13]}, accepted=[[101]]) == 1
+
+
+def test_prefill_step_is_untouched():
+    # No drafts scheduled: the step carries the prompt and the downstream stage
+    # needs all of it, however many tokens were sampled.
+    assert _rows(num_scheduled_tokens=16, drafts={}, accepted=[[101]]) == 16
+    assert _rows(num_scheduled_tokens=16, drafts={"r0": []}, accepted=[[101]]) == 16
+
+
+def test_other_requests_drafts_do_not_shorten_this_one():
+    assert _rows(num_scheduled_tokens=16, drafts={"r1": [11]}, accepted=[[101]]) == 16
+
+
+def test_missing_accepted_bookkeeping_is_untouched():
+    # Async scheduling fills valid_sampled_token_ids in after the payload is
+    # built; an absent or empty entry must not shorten the slice.
+    assert _rows(num_scheduled_tokens=4, drafts={"r0": [11, 12, 13]}, accepted=[]) == 4
+    assert _rows(num_scheduled_tokens=4, drafts={"r0": [11, 12, 13]}, accepted=[[]]) == 4
+
+
+def test_accepted_count_never_lengthens_the_slice():
+    assert _rows(num_scheduled_tokens=2, drafts={"r0": [11]}, accepted=[[101, 102, 103]]) == 2
+
+
+def test_request_index_selects_its_own_row():
+    drafts = {"r0": [11], "r1": [21]}
+    accepted = [[101, 102], [201]]
+    assert _rows(num_scheduled_tokens=2, drafts=drafts, accepted=accepted, req_id="r0", req_index=0) == 2
+    assert _rows(num_scheduled_tokens=2, drafts=drafts, accepted=accepted, req_id="r1", req_index=1) == 1

--- a/tests/worker/test_gpu_ar_model_runner.py
+++ b/tests/worker/test_gpu_ar_model_runner.py
@@ -332,6 +332,7 @@ def test_build_omni_output_uses_snapshots_and_connector_after_accumulation(monke
         scheduler_output=SimpleNamespace(
             total_num_scheduled_tokens=3,
             num_scheduled_tokens={"r1": 1, "r2": 2},
+            scheduled_spec_decode_tokens={},
         ),
         hidden_states=torch.tensor([[1.0], [2.0], [3.0]]),
         staged_hidden_states_cpu=None,
@@ -377,6 +378,7 @@ def test_build_omni_output_copies_hidden_for_partial_downstream_batch(monkeypatc
         scheduler_output=SimpleNamespace(
             total_num_scheduled_tokens=6,
             num_scheduled_tokens={"r1": 1, "r2": 2, "r3": 3},
+            scheduled_spec_decode_tokens={},
         ),
         hidden_states=torch.tensor([[1.0], [2.0], [3.0], [4.0], [5.0], [6.0]]),
         staged_hidden_states_cpu=None,
@@ -400,6 +402,98 @@ def test_build_omni_output_copies_hidden_for_partial_downstream_batch(monkeypatc
     assert torch.equal(output.inter_stage_outputs[1]["hidden"], torch.tensor([[2.0], [3.0]]))
     assert output.inter_stage_outputs[2] is None
     assert output.multimodal_outputs is None
+
+
+def test_build_omni_output_drops_rejected_draft_rows(monkeypatch):
+    """A rejected draft's hidden state must not reach the downstream stage.
+
+    Both requests take a speculative step of 1 real position + 3 drafts, so the
+    step schedules 4 rows each. ``r1`` keeps 2 of them and ``r2`` keeps all 4;
+    only the accepted rows may be shipped.
+    """
+    runner = _make_async_output_runner()
+
+    monkeypatch.setattr(
+        GPUARModelRunner,
+        "_resolve_pooler_payload_req_ids",
+        lambda self, req_ids: ("audio", req_ids),
+    )
+    monkeypatch.setattr(GPUARModelRunner, "_should_accumulate_full_payload_output", lambda self: False)
+    monkeypatch.setattr(GPUARModelRunner, "get_omni_connector_output", lambda self: None)
+    monkeypatch.setattr(GPUARModelRunner, "_process_additional_information_updates", lambda *args, **kwargs: None)
+
+    output = GPUARModelRunner._build_omni_model_runner_output_from_snapshot(
+        runner,
+        scheduler_output=SimpleNamespace(
+            total_num_scheduled_tokens=8,
+            num_scheduled_tokens={"r1": 4, "r2": 4},
+            scheduled_spec_decode_tokens={"r1": [11, 12, 13], "r2": [21, 22, 23]},
+        ),
+        hidden_states=torch.tensor([[1.0], [2.0], [3.0], [4.0], [5.0], [6.0], [7.0], [8.0]]),
+        staged_hidden_states_cpu=None,
+        multimodal_outputs={},
+        req_ids_output_copy=["r1", "r2"],
+        req_id_to_index_output_copy={"r1": 0, "r2": 1},
+        valid_sampled_token_ids=[[101, 102], [201, 202, 203, 204]],
+        logprobs_lists=None,
+        prompt_logprobs_dict={},
+        num_nans_in_logits=None,
+        kv_connector_output=None,
+        ec_connector_output=None,
+        cudagraph_stats=None,
+        kv_extracted_req_ids=None,
+        num_scheduled_tokens_np=np.array([4, 4], dtype=np.int32),
+        query_start_loc_cpu=torch.tensor([0, 4], dtype=torch.long),
+    )
+
+    assert output.inter_stage_outputs is not None
+    assert torch.equal(output.inter_stage_outputs[0]["hidden"], torch.tensor([[1.0], [2.0]]))
+    assert torch.equal(
+        output.inter_stage_outputs[1]["hidden"],
+        torch.tensor([[5.0], [6.0], [7.0], [8.0]]),
+    )
+
+
+def test_build_omni_output_drops_rejected_draft_rows_on_per_request_copy(monkeypatch):
+    """Same slice on the per-request D2H path (only part of the batch is downstream)."""
+    runner = _make_async_output_runner(engine_output_type="latent")
+
+    monkeypatch.setattr(
+        GPUARModelRunner,
+        "_resolve_pooler_payload_req_ids",
+        lambda self, req_ids: ("latent", ["r2"]),
+    )
+    monkeypatch.setattr(GPUARModelRunner, "_should_accumulate_full_payload_output", lambda self: False)
+    monkeypatch.setattr(GPUARModelRunner, "get_omni_connector_output", lambda self: None)
+    monkeypatch.setattr(GPUARModelRunner, "_process_additional_information_updates", lambda *args, **kwargs: None)
+
+    output = GPUARModelRunner._build_omni_model_runner_output_from_snapshot(
+        runner,
+        scheduler_output=SimpleNamespace(
+            total_num_scheduled_tokens=5,
+            num_scheduled_tokens={"r1": 2, "r2": 3},
+            scheduled_spec_decode_tokens={"r1": [11], "r2": [21, 22]},
+        ),
+        hidden_states=torch.tensor([[1.0], [2.0], [3.0], [4.0], [5.0]]),
+        staged_hidden_states_cpu=None,
+        multimodal_outputs={},
+        req_ids_output_copy=["r1", "r2"],
+        req_id_to_index_output_copy={"r1": 0, "r2": 1},
+        valid_sampled_token_ids=[[101, 102], [201]],
+        logprobs_lists=None,
+        prompt_logprobs_dict={},
+        num_nans_in_logits=None,
+        kv_connector_output=None,
+        ec_connector_output=None,
+        cudagraph_stats=None,
+        kv_extracted_req_ids=None,
+        num_scheduled_tokens_np=np.array([2, 3], dtype=np.int32),
+        query_start_loc_cpu=torch.tensor([0, 2], dtype=torch.long),
+    )
+
+    assert output.inter_stage_outputs is not None
+    assert output.inter_stage_outputs[0] is None
+    assert torch.equal(output.inter_stage_outputs[1]["hidden"], torch.tensor([[3.0]]))
 
 
 def test_process_additional_information_uses_snapshot_request_order(monkeypatch):
@@ -430,6 +524,7 @@ def test_process_additional_information_uses_snapshot_request_order(monkeypatch)
         scheduler_output=SimpleNamespace(
             total_num_scheduled_tokens=3,
             num_scheduled_tokens={"r1": 1, "r2": 2},
+            scheduled_spec_decode_tokens={},
         ),
         hidden_states=torch.tensor([[1.0], [2.0], [3.0]]),
         staged_hidden_states_cpu=None,
@@ -490,6 +585,7 @@ def test_build_omni_output_skips_hidden_when_model_opts_out(monkeypatch):
         scheduler_output=SimpleNamespace(
             total_num_scheduled_tokens=2,
             num_scheduled_tokens={"r1": 2},
+            scheduled_spec_decode_tokens={},
         ),
         hidden_states=torch.tensor([[1.0], [2.0]]),
         staged_hidden_states_cpu=None,
@@ -536,6 +632,7 @@ def test_build_omni_output_splits_mm_by_scheduled_tokens_when_hidden_is_tail_onl
         scheduler_output=SimpleNamespace(
             total_num_scheduled_tokens=3,
             num_scheduled_tokens={"r1": 1, "r2": 1, "r3": 1},
+            scheduled_spec_decode_tokens={},
         ),
         hidden_states=torch.tensor([[1.0]]),
         staged_hidden_states_cpu=None,
@@ -582,6 +679,7 @@ def test_build_omni_output_splits_mm_by_hidden_len_when_scheduled_is_padded(monk
         scheduler_output=SimpleNamespace(
             total_num_scheduled_tokens=5,
             num_scheduled_tokens={"r1": 1, "r2": 1, "r3": 1},
+            scheduled_spec_decode_tokens={},
         ),
         hidden_states=torch.randn(3, 4),
         staged_hidden_states_cpu=None,
@@ -669,6 +767,7 @@ def test_sample_tokens_tail_only_prefix_cache_uses_staged_cpu_hidden_states(monk
         SimpleNamespace(
             total_num_scheduled_tokens=3,
             num_scheduled_tokens={"r1": 1, "r2": 2},
+            scheduled_spec_decode_tokens={},
         ),
         None,
         None,
@@ -781,6 +880,7 @@ def test_build_omni_output_falls_back_to_mm_cpu_without_prefix_merge(monkeypatch
         scheduler_output=SimpleNamespace(
             total_num_scheduled_tokens=2,
             num_scheduled_tokens={"r1": 1, "r2": 1},
+            scheduled_spec_decode_tokens={},
         ),
         hidden_states=torch.tensor([[1.0], [2.0]]),
         staged_hidden_states_cpu=None,
@@ -828,6 +928,7 @@ def test_build_omni_output_never_leaks_internal_pooler_output_on_wire(monkeypatc
         scheduler_output=SimpleNamespace(
             total_num_scheduled_tokens=3,
             num_scheduled_tokens={"r1": 1, "r2": 2},
+            scheduled_spec_decode_tokens={},
         ),
         hidden_states=torch.tensor([[1.0], [2.0], [3.0]]),
         staged_hidden_states_cpu=None,
@@ -868,6 +969,7 @@ def test_build_omni_output_splits_client_mm_from_inter_stage_keys(monkeypatch):
         scheduler_output=SimpleNamespace(
             total_num_scheduled_tokens=3,
             num_scheduled_tokens={"r1": 1, "r2": 2},
+            scheduled_spec_decode_tokens={},
         ),
         hidden_states=torch.tensor([[1.0], [2.0], [3.0]]),
         staged_hidden_states_cpu=None,

--- a/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
@@ -49,7 +49,7 @@ from vllm_omni.outputs import OmniModelRunnerOutput
 from vllm_omni.platforms.npu.worker.npu_model_runner import OmniNPUModelRunner
 from vllm_omni.utils.mm_outputs import build_mm_cpu, partition_payload_list, to_payload_element
 from vllm_omni.worker.omni_connector_model_runner_mixin import OmniConnectorModelRunnerMixin
-from vllm_omni.worker.sampling_utils import sanitize_min_tokens_stop_ids
+from vllm_omni.worker.sampling_utils import accepted_hidden_rows, sanitize_min_tokens_stop_ids
 
 
 def _ensure_tensor_values(payload: dict[str, object]) -> dict[str, torch.Tensor]:
@@ -1125,8 +1125,13 @@ class NPUARModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
                 for rid in downstream_req_ids:
                     idx = req_id_to_index_output_copy[rid]
                     start = int(query_start_loc_cpu[idx])
-                    sched = int(num_scheduled_tokens_np[idx])
-                    end = start + sched
+                    end = start + accepted_hidden_rows(
+                        req_id=rid,
+                        req_index=idx,
+                        num_scheduled_tokens=int(num_scheduled_tokens_np[idx]),
+                        scheduled_spec_decode_tokens=scheduler_output.scheduled_spec_decode_tokens,
+                        valid_sampled_token_ids=valid_sampled_token_ids,
+                    )
                     req_hidden_states_cpu[rid] = hidden_states[start:end].detach().to("cpu").contiguous()
 
             pooler_output = []
@@ -1136,8 +1141,13 @@ class NPUARModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
                     continue
                 idx = req_id_to_index_output_copy[rid]
                 start = int(query_start_loc_cpu[idx])
-                sched = int(num_scheduled_tokens_np[idx])
-                end = start + sched
+                end = start + accepted_hidden_rows(
+                    req_id=rid,
+                    req_index=idx,
+                    num_scheduled_tokens=int(num_scheduled_tokens_np[idx]),
+                    scheduled_spec_decode_tokens=scheduler_output.scheduled_spec_decode_tokens,
+                    valid_sampled_token_ids=valid_sampled_token_ids,
+                )
                 payload: dict[str, object] = {}
                 if not audio_sparse_output:
                     if req_hidden_states_cpu is not None and combined_hidden_states is None:

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -52,7 +52,7 @@ from vllm_omni.utils.mm_outputs import build_mm_cpu, partition_payload_list, to_
 from vllm_omni.worker.gpu_model_runner import OmniGPUModelRunner
 from vllm_omni.worker.omni_connector_model_runner_mixin import OmniConnectorModelRunnerMixin
 from vllm_omni.worker.runner_assisted_metadata import RunnerAssistedFullAttentionMetadataRequest
-from vllm_omni.worker.sampling_utils import sanitize_min_tokens_stop_ids
+from vllm_omni.worker.sampling_utils import accepted_hidden_rows, sanitize_min_tokens_stop_ids
 
 logger = init_logger(__name__)
 
@@ -1750,8 +1750,13 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
                     for rid in downstream_req_ids:
                         idx = req_id_to_index_output_copy[rid]
                         start = int(query_start_loc_cpu[idx])
-                        sched = int(num_scheduled_tokens_np[idx])
-                        end = start + sched
+                        end = start + accepted_hidden_rows(
+                            req_id=rid,
+                            req_index=idx,
+                            num_scheduled_tokens=int(num_scheduled_tokens_np[idx]),
+                            scheduled_spec_decode_tokens=scheduler_output.scheduled_spec_decode_tokens,
+                            valid_sampled_token_ids=valid_sampled_token_ids,
+                        )
                         req_hidden_states_cpu[rid] = _to_cpu_contiguous(hidden_states[start:end])
 
         # NOTE: pooler_output here is used only for the full-payload accumulation
@@ -1803,8 +1808,13 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
                         continue
                     idx = req_id_to_index_output_copy[rid]
                     start = int(query_start_loc_cpu[idx])
-                    sched = int(num_scheduled_tokens_np[idx])
-                    end = start + sched
+                    end = start + accepted_hidden_rows(
+                        req_id=rid,
+                        req_index=idx,
+                        num_scheduled_tokens=int(num_scheduled_tokens_np[idx]),
+                        scheduled_spec_decode_tokens=scheduler_output.scheduled_spec_decode_tokens,
+                        valid_sampled_token_ids=valid_sampled_token_ids,
+                    )
                     payload = self._build_omni_pooler_payload(
                         rid=rid,
                         idx=idx,

--- a/vllm_omni/worker/sampling_utils.py
+++ b/vllm_omni/worker/sampling_utils.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Sampling-state guards shared by the GPU and NPU AR model runners."""
+"""Sampling-state helpers shared by the GPU and NPU AR model runners."""
+
+from collections.abc import Mapping, Sequence
 
 import torch
 from vllm.logger import init_logger
@@ -8,7 +10,40 @@ from vllm.v1.sample.logits_processor import LogitsProcessors, MinTokensLogitsPro
 
 logger = init_logger(__name__)
 
-__all__ = ["sanitize_min_tokens_stop_ids"]
+__all__ = ["accepted_hidden_rows", "sanitize_min_tokens_stop_ids"]
+
+
+def accepted_hidden_rows(
+    *,
+    req_id: str,
+    req_index: int,
+    num_scheduled_tokens: int,
+    scheduled_spec_decode_tokens: Mapping[str, Sequence[int]],
+    valid_sampled_token_ids: Sequence[Sequence[int]],
+) -> int:
+    """Rows of this step's hidden states that ``req_id`` actually emitted.
+
+    A speculative step forwards one real position plus the drafts, and
+    rejection sampling keeps a *prefix* of them. Slicing an Omni payload by
+    ``num_scheduled_tokens`` therefore also ships the rows past that prefix:
+    hidden states for draft tokens the model never emitted. A downstream AR
+    stage that conditions on them -- a codec talker, say -- renders text that
+    does not exist.
+
+    ``num_scheduled_tokens`` is returned unchanged whenever the step cannot
+    carry a rejection remainder for this request: no drafts were scheduled for
+    it (a prefill step schedules the prompt, and the downstream stage needs all
+    of it), or its accepted-token bookkeeping is not available yet (async
+    scheduling fills ``valid_sampled_token_ids`` in after this point).
+    """
+    if not scheduled_spec_decode_tokens.get(req_id):
+        return num_scheduled_tokens
+    if req_index >= len(valid_sampled_token_ids):
+        return num_scheduled_tokens
+    num_accepted = len(valid_sampled_token_ids[req_index])
+    if num_accepted <= 0:
+        return num_scheduled_tokens
+    return min(num_scheduled_tokens, num_accepted)
 
 
 def sanitize_min_tokens_stop_ids(logitsprocs: LogitsProcessors, logits_vocab: int) -> None:


### PR DESCRIPTION
## Purpose

> Team: **5.6-sol**

### What breaks

With speculative decoding enabled on an AR stage, the hidden states handed to the
downstream Omni stage include the rows of **rejected draft tokens** — positions
the model never emitted. There is no error message: the payload is well formed,
the shapes are consistent, and the next stage happily conditions on text that was
never produced. On MiniCPM-o 4.5 it is audible — the Talker turns the phantom
rows into codec frames, i.e. into silence between words.

### Root cause

A speculative step schedules `1 + num_draft_tokens` positions for a running
request, and rejection sampling keeps a **prefix** of them. Both AR runners slice
the Omni payload by the *scheduled* count instead:

```python
start = int(query_start_loc_cpu[idx])
sched = int(num_scheduled_tokens_np[idx])
end = start + sched          # <- includes the rejected remainder
```

`worker/gpu_ar_model_runner.py` (per-request D2H copy, pooler payload) and
`platforms/npu/worker/npu_ar_model_runner.py` (same two sites) are affected
identically. Nothing here is model- or vendor-specific: any Omni pipeline whose
AR stage runs speculative decoding and whose next stage consumes `hidden` gets
the extra rows, on CUDA as much as on NPU.

### Repro

Unit level — these two cases fail on `ecd9d99da` (they get 4 rows where the
request emitted 2) and pass with this PR:

```bash
pytest tests/worker/test_gpu_ar_model_runner.py -k drops_rejected_draft_rows
```

Service level — take the official MiniCPM-o 4.5 deploy config, add nothing but a
`speculative_config` to stage 0:

```yaml
      speculative_config:
        method: ngram
        num_speculative_tokens: 1
        prompt_lookup_min: 1
        prompt_lookup_max: 32
```

then ask for audio and listen to the gaps:

```bash
curl -s localhost:8091/v1/chat/completions -H 'Content-Type: application/json' -d '{
  "model": "MiniCPM-o-4_5",
  "messages": [{"role": "user", "content": "请介绍一下你自己，说三到四句话。"}],
  "modalities": ["text", "audio"],
  "chat_template_kwargs": {"enable_thinking": false, "use_tts_template": true},
  "max_tokens": 1024, "temperature": 0.0, "seed": 42}' > out.json
```

### The fix

`accepted_hidden_rows()` joins `vllm_omni/worker/sampling_utils.py`, the
sampling-state helper module the two AR runners already share, and is used at the
four slice sites. It returns the scheduled count unchanged for every step that
cannot carry a rejection remainder:

- no drafts were scheduled for the request — so a prefill still hands the whole
  prompt downstream, and a non-speculative deployment is untouched;
- the accepted-token bookkeeping is not populated yet, as under async scheduling.

**Deliberately out of scope.** `_process_additional_information_updates()` slices
`hidden_states` by the same scheduled count before handing it to a model's
`postprocess()` hook. That is a per-runner buffer rather than the downstream wire
payload, and only models that set `has_postprocess` reach it (MiniCPM-o does
not), so it is left for a separate change rather than widened into this one —
glad to fold it in if you would rather have both at once.

## Test Plan

**vLLM Version:** `0.1.dev1+ge5588e49b` (built from `vllm-project/vllm@e5588e49b`)

**vLLM-Omni Commit:** `ecd9d99da` — the base of this branch, and the base every
arm below runs on

### 1. Unit tests — CPU only, no accelerator

- `tests/worker/test_accepted_hidden_rows.py` (new): the slice itself — partial
  rejection, full acceptance, total rejection, prefill, another request's drafts,
  absent/empty bookkeeping, clamping.
- `tests/worker/test_gpu_ar_model_runner.py`: two new cases drive the real payload
  builder (`_build_omni_model_runner_output_from_snapshot`) and assert the rows
  that come out, on both the whole-batch and the per-request-D2H copy paths. The
  existing fakes in that file gained `scheduled_spec_decode_tokens={}` so they
  keep matching `SchedulerOutput`.

### 2. End-to-end — Ascend 910C (A3, 2 dies), MiniCPM-o 4.5

Three arms, one variable, all built on `ecd9d99da`, official deploy config, the
same 12 free-form prompts, `temperature=0`, `seed=42`, non-streaming:

| arm | tree | deploy config |
| --- | --- | --- |
| `base` | `ecd9d99da` | official |
| `base + spec` | `ecd9d99da` | official + the `speculative_config` above |
| `base + spec + PR` | `ecd9d99da` + this diff | official + the same `speculative_config` |

`num_speculative_tokens: 1` is the narrowest setting that can exhibit the defect,
and it keeps the drafter close enough to output-exact that the generated text
stays comparable between arms — so an audio difference cannot be blamed on the
model having said something else.

Interior silence (runs below the clip's noise floor for ≥60 ms, leading and
trailing excluded) is measured on the rendered WAV and **normalised per generated
character**: the arms may produce different text lengths, and without
normalisation a longer reply simply reads as "more silence".

## Test Result

### Unit tests — `tests/worker/`, CPU only

```
base ecd9d99da :  1 failed, 223 passed
this branch    :  1 failed, 233 passed
```

The one failure is present on the untouched base as well
(`test_speech_extra_params_reach_model_sampler_as_sampling_metadata`:
`InputBatch.__init__() missing 1 required positional argument:
'max_num_blocks_per_req'` — a vLLM signature drift on this machine, unrelated to
this change). `tests/worker/test_process_gpu_memory.py` is excluded from both
runs: `pytest_mock` is not installed here.

Without the fix, the two new runner-level cases return 4 rows where the request
emitted 2.

### End-to-end — 12 clips per arm, one session, 2026-08-31

| arm | chars | speech / char | **silence / char** | longest pause, median | longest pause, p90 | clips with a pause > 400 ms |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `base` | 1546 | 156.5 ms | **31.7 ms** | 400 ms | 467 ms | 6/12 |
| `base + spec` | 1546 | 160.6 ms | **37.6 ms** | 535 ms | 760 ms | 12/12 |
| `base + spec + PR` | 1546 | 156.5 ms | **31.7 ms** | 400 ms | 467 ms | 6/12 |

Totals: 306.56 s of audio and 48.97 s of silence for `base`, 321.04 s / 58.15 s
for `base + spec`, and 306.56 s / 48.97 s again with the fix.

Three things make this a clean read rather than a sampling artefact:

1. **The model says exactly the same thing in all three arms** — the generated
   text is byte-identical on 12/12 clips, 1546 characters each. The speaking rate
   is unchanged too (156.5 ms/char in both correct arms). Every difference is
   silence.
2. **The fix restores the codec stream exactly.** The audio of `base + spec + PR`
   has the *same sample count as `base`* on 12/12 clips; `base + spec` differs on
   12/12. The Talker emits precisely the frames it would have emitted with no
   speculative decoding at all.
3. **It is not a burst-size effect.** Draft width 1 already shows it, and widening
   the drafts does not scale it — a separate sweep over the same base gave 31.7
   ms/char at width 0, 37.6 at 1, 38.5 at 7 and 34.4 at 15, which is what a
   per-step rejection remainder looks like rather than a burst-size effect. Width
   1 is the arm reported above because it is the only one where the generated
   text stays identical to the no-speculation base (1546 chars; 7 and 15 drift to
   1518 and 1551), so nothing else has to be controlled for.

Read-aloud style prompts cannot show this at all: there the n-gram drafter copies
the prompt verbatim, nothing is rejected, and every arm comes back identical.
That is why a TTS-style benchmark suite stays green while free-form conversation
degrades.

### Hardware / software

- Ascend 910C (A3), 2 dies, CANN, `vllm-ascend`, MiniCPM-o 4.5
- All three arms built on `ecd9d99da`; `base + spec + PR` differs from
  `base + spec` by this diff and nothing else
- Both trees carry the same unrelated local workaround for a model-inspection
  crash that this particular box hits on a cold cache; it is identical in both
  arms and touches only start-up
