### PR TITLE
[Perf][NPU] Skip the per-step allocator walk unless the worker logger is at DEBUG

### DIFF
--- a/tests/platforms/npu/worker/test_npu_worker_profile_memory.py
+++ b/tests/platforms/npu/worker/test_npu_worker_profile_memory.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""The NPU worker's per-step allocator walk is DEBUG-only diagnostics.
+
+``NPUWorker.profile_memory`` runs inside every ``execute_model`` call and the
+numbers it collects are read by nothing but its own DEBUG log line. These tests
+pin the gate that keeps that walk off the serving hot path. vLLM-Ascend is faked
+and ``base.py`` is loaded from source, so they run on a plain CPU box like the
+rest of ``tests/platforms/npu``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+ASCEND_WORKER_MODULE = "vllm_ascend.worker.worker"
+
+
+def _repo_root() -> Path:
+    marker = Path("vllm_omni") / "platforms" / "npu" / "worker" / "base.py"
+    for parent in Path(__file__).resolve().parents:
+        if (parent / marker).is_file():
+            return parent
+    raise FileNotFoundError(f"could not locate repo root containing {marker}")
+
+
+def _install_fake_module(monkeypatch: pytest.MonkeyPatch, name: str, **attrs) -> types.ModuleType:
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+@pytest.fixture
+def worker_base(monkeypatch: pytest.MonkeyPatch):
+    """``platforms/npu/worker/base.py``, loaded with vLLM-Ascend faked out.
+
+    Yields the module and the list the fake parent appends to whenever its
+    ``profile_memory`` -- the allocator walk this PR is gating -- is reached.
+    """
+    parent_calls: list[object] = []
+
+    class FakeNPUWorker:
+        __module__ = ASCEND_WORKER_MODULE
+
+        def profile_memory(self) -> None:
+            parent_calls.append(self)
+
+    _install_fake_module(monkeypatch, "vllm_omni.platforms.npu._310p", is_310p=lambda *a, **k: False)
+    _install_fake_module(monkeypatch, ASCEND_WORKER_MODULE, NPUWorker=FakeNPUWorker)
+
+    path = _repo_root() / "vllm_omni" / "platforms" / "npu" / "worker" / "base.py"
+    spec = importlib.util.spec_from_file_location("omni_npu_worker_base_under_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    yield module, parent_calls
+
+
+def test_allocator_walk_is_skipped_at_the_default_log_level(worker_base, caplog):
+    module, parent_calls = worker_base
+    caplog.set_level(logging.INFO, logger=ASCEND_WORKER_MODULE)
+
+    worker = object.__new__(module.OmniNPUWorkerBase)
+    worker.profile_memory()
+
+    assert parent_calls == []
+
+
+def test_allocator_walk_still_runs_for_debug(worker_base, caplog):
+    module, parent_calls = worker_base
+    caplog.set_level(logging.DEBUG, logger=ASCEND_WORKER_MODULE)
+
+    worker = object.__new__(module.OmniNPUWorkerBase)
+    worker.profile_memory()
+
+    assert len(parent_calls) == 1
+
+
+def test_the_deciding_level_is_the_vllm_ascend_worker_logger(worker_base, caplog):
+    """Turning vLLM-Omni's own logging up must not switch the walk back on.
+
+    The values are logged by the parent, under the parent's logger, so that is
+    the only level that can decide whether collecting them is worth anything.
+    """
+    module, parent_calls = worker_base
+    caplog.set_level(logging.DEBUG, logger="vllm_omni")
+    caplog.set_level(logging.INFO, logger=ASCEND_WORKER_MODULE)
+
+    worker = object.__new__(module.OmniNPUWorkerBase)
+    worker.profile_memory()
+
+    assert parent_calls == []

--- a/vllm_omni/platforms/npu/worker/base.py
+++ b/vllm_omni/platforms/npu/worker/base.py
@@ -3,6 +3,7 @@
 
 """Base NPU worker class for vLLM-Omni with OmniProfiler support."""
 
+import logging
 import time
 
 from vllm_omni.platforms.npu._310p import is_310p
@@ -11,6 +12,8 @@ if is_310p():
     from vllm_ascend._310p.worker_310p import NPUWorker310 as NPUWorker
 else:
     from vllm_ascend.worker.worker import NPUWorker
+
+_NPU_WORKER_LOGGER = logging.getLogger(NPUWorker.__module__)
 
 
 class OmniNPUWorkerBase(NPUWorker):
@@ -35,6 +38,19 @@ class OmniNPUWorkerBase(NPUWorker):
                 worker_name=worker_name,
                 local_rank=self.local_rank,
             )
+
+    def profile_memory(self) -> None:
+        """Walk the NPU caching allocator only when someone will read the result.
+
+        ``NPUWorker.profile_memory`` samples ``torch.npu.memory_reserved`` and
+        ``memory_allocated`` on every ``execute_model`` call, and the values it
+        collects are consumed by nothing but its own DEBUG log line. Skip the
+        walk while the vLLM-Ascend worker logger is above DEBUG, and keep the
+        original diagnostics exactly as they were once it is turned on.
+        """
+        if not _NPU_WORKER_LOGGER.isEnabledFor(logging.DEBUG):
+            return
+        super().profile_memory()
 
     def profile(self, is_start: bool = True, profile_prefix: str | None = None):
         """Override to set trace filename before starting the profiler.


### PR DESCRIPTION
## Purpose

> Team: **5.6-sol**

`NPUWorker.profile_memory` samples `torch.npu.memory_reserved()` and
`torch.npu.memory_allocated()` inside **every** `execute_model` call, and the
values it collects are read by nothing but its own `logger.debug(...)` line. On a
decode-heavy Omni pipeline — MiniCPM-o 4.5's Talker runs one AR step per codec
frame — that is an allocator walk per step, on the serving hot path, for output
nobody sees.

`OmniNPUWorkerBase` already overrides the worker for Omni, so the gate goes there:
run the walk only while the vLLM-Ascend worker logger is at DEBUG, which is
exactly the condition under which the numbers are used. Raise that logger and the
original diagnostics come back byte for byte.

The gate deliberately reads **the parent's own logger**
(`logging.getLogger(NPUWorker.__module__)`) rather than introducing a vLLM-Omni
one, so a deployment that already runs the vLLM-Ascend worker at DEBUG keeps
today's behaviour without having to learn about a new switch, and there is no new
environment variable or config key to document.

Nothing else depends on the sample: `self.torch_reserved` and
`self.torch_allocated` are initialised to `0` in `NPUWorker.__init__` and are
read by that one `logger.debug` call and nowhere else in vLLM-Ascend, so skipping
the walk leaves no missing attribute and no stale value for another consumer.
Both call sites are covered — `execute_model` and `execute_dummy_batch`.

This is NPU-only and touches nothing on the CUDA path.

## Test Plan

**vLLM Version:** `0.1.dev1+ge5588e49b` (built from `vllm-project/vllm@e5588e49b`)

**vLLM-Omni Commit:** `ecd9d99da` — the base of this branch, and the base of both
measured arms

### 1. Unit tests

`tests/platforms/npu/worker/test_npu_worker_profile_memory.py` (new), 3 cases:
the walk is skipped at the default log level, it still runs at DEBUG, and the
logger the gate consults is the vLLM-Ascend worker's own. vLLM-Ascend is faked
and `base.py` is loaded from source, following
`tests/platforms/npu/test_310p_patches.py`, so the file runs on a plain CPU box
like the rest of `tests/platforms/npu`.

### 2. What the walk costs, measured directly

The walk was timed **in place**: an instrumented `OmniNPUWorkerBase.profile_memory`
that wraps `super().profile_memory()` in `time.perf_counter_ns()` and counts the
calls, over one full ranked run. This is the measurement that matters, because
it is a property of the code rather than of the machine it ran on.

### 3. End-to-end, paired A/B

Two arms differing only by this diff, both built on `ecd9d99da`, the organizer's
baseline deploy config, no environment variables:

| arm | tree |
| --- | --- |
| `ctl` | `ecd9d99da` |
| `pr4` | `ecd9d99da` + this diff |

Both arms run **at the same time, one per die**, and each round is repeated with
the dies swapped — these boxes are shared and permanently busy, and the two dies
are not equally fast, so only a same-round paired delta means anything and only
after both die assignments have been tried. Repeated on **two different
machines**; the second one runs stock `vllm-ascend` at `8092d3f6` with an
untouched `profile_memory`, and the full official concurrency matrix.

Exact invocation for one arm (the repo's own harness and case file):

```bash
ASCEND_RT_VISIBLE_DEVICES=<die> BENCHMARK_DIR=<out> PYTHONPATH=<tree> \
python3 -m pytest -s -vv tests/dfx/perf/scripts/run_benchmark.py \
  --test-config-file tests/dfx/perf/tests/test_minicpmo_4_5.json
```

`test_minicpmo_4_5_challenge`, Seed-TTS zh, `openai-chat-omni` on
`/v1/chat/completions`. The case file configures no warmup requests, so each
arm's server is freshly started and the first request is inside the average for
both arms equally.

## Test Result

### Unit tests

```
tests/platforms/ on ecd9d99da :  24 passed, 2 skipped
tests/platforms/ on this branch: 27 passed, 2 skipped
```

Without the change the three new cases fail on behaviour, not on a missing
symbol: `assert parent_calls == []` — the walk still ran.

### What the walk costs

One ranked C1 run: 32 prompts, measured duration **67.95 s**, mean e2el
**2123 ms**, 435 output tokens, 135.64 s of audio.

| stage | calls | host time | per call | per request |
| --- | ---: | ---: | ---: | ---: |
| 0 Thinker | 541 | 0.200 s | 369 µs | 6.2 ms |
| 1 Talker | 3,625 | 1.097 s | 303 µs | 34.3 ms |
| 2 Code2Wav | 15,619 | 4.750 s | 304 µs | 148.4 ms |
| **all three** | **19,785** | **6.047 s** | **306 µs** | **189.0 ms** |

Two readings worth separating:

- **The Talker's 3,625 calls are 113 per request — one per codec decode step.**
  That is 34.3 ms per request of host time sitting on the decode step's critical
  path, against a 2123 ms mean e2el: **1.6% of end-to-end latency**, spent
  entirely on a `logger.debug` that is not enabled.
- **Code2Wav's 15,619 calls are 488 per request, for a stage that emits a
  handful of audio chunks.** Nearly all of them are the engine loop stepping
  with nothing to do, so most of that 4.75 s is not on anyone's critical path —
  but it is still 7% of the run's wall clock burned by one process, on a host
  that is shared with the other stages.

### End-to-end, and why no single RTF number is quoted

Eight paired deltas — two machines, two die assignments each, three concurrency
levels on the machine running the full matrix:

| machine | `vllm-ascend` | candidate on | C1 (32) | C4 (64) | C8 (128) |
| --- | --- | --- | ---: | ---: | ---: |
| A | local patches | die 0 | −6.15% | — | — |
| A | local patches | die 1 | **+7.85%** | — | — |
| B | stock `8092d3f6` | die 0 | −8.45% | −10.71% | −0.38% |
| B | stock `8092d3f6` | die 1 | −2.39% | −3.81% | −2.15% |
| | | **B, die-balanced** | **−5.4%** | **−7.3%** | **−1.3%** |

Seven of the eight favour the change, and every one of machine B's six does.
The single positive is machine A's second round, and it is exactly that box's die
asymmetry: read machine A's four numbers by die instead of by arm and they are
0.481 / 0.485 on die 0 and 0.513 / 0.523 on die 1, whichever tree is sitting
there. Its two rounds average +0.85%, which is another way of saying that on that
host the effect is smaller than the noise.

So this PR does not put one RTF number in its title. The bound that is a property
of the code rather than of a machine is the direct measurement above: 189 ms of
host time per request against a 2123 ms mean e2el, **8.9%**, of which the
Talker's one-call-per-decode-step share is 1.6%. Machine B's −5.4% at C1 sits
inside that envelope; machine A's ~0 says how much of it a busy host can hide.

Every arm returned identical work: 32/32, 64/64 and 128/128 requests complete,
435 / 944 / 1878 output tokens, 135.64 s of audio at C1. Peak HBM was 44.10 GiB
against the control's 43.83 GiB on the other die — the same 0.26 GiB apart as the
two dies were before either server started. The change removes two allocator
*queries*, not allocations.

### Hardware / software

- Atlas A3 / 910C (`npu-smi` NPU Name 9382, Chip Name Ascend910), 1 die per arm,
  64 GiB HBM per die; two separate physical machines
- CANN toolkit 9.0.0; torch 2.10.0 / torch-npu 2.10.0; transformers 5.13.0
- vLLM `0.1.dev1+ge5588e49b`; `vllm-ascend` stock `8092d3f6` on machine B
- Both arms run from source trees at `ecd9d99da` via `VLLM_OMNI_SRC` +
  `PYTHONPATH`, so the editable install on the box is not what is being measured
- Deploy config unchanged from the organizer's baseline: `max_num_seqs: 4`,
  `gpu_memory_utilization` 0.55 / 0.15 / 0.18 across the three stages
