### PR TITLE
[Bugfix][Core] Apply a stage's runtime.env while the replica is spawned

### DIFF
--- a/tests/engine/test_async_omni_engine_stage_init.py
+++ b/tests/engine/test_async_omni_engine_stage_init.py
@@ -571,6 +571,83 @@ def test_initialize_local_llm_replica_passes_stage_init_timeout_to_complete_stag
     assert captured_timeout == 302
 
 
+def test_initialize_local_llm_replica_applies_stage_runtime_env_while_spawning(monkeypatch):
+    """A stage's ``runtime.env`` has to be set while the replica is spawned.
+
+    The worker process inherits the environment of the spawn, so an env var that
+    is applied only while the deploy config is parsed never reaches it, and every
+    worker-side switch configured that way is silently inert.
+    """
+    import vllm_omni.engine.stage_runtime as runtime_mod
+    from vllm_omni.platforms import current_omni_platform
+
+    runtime = StageRuntime(
+        stage_configs=[],
+        model="dummy-model",
+        config_path="dummy-config",
+        stage_init_timeout=302,
+        diffusion_batch_size=1,
+        async_chunk=False,
+    )
+
+    env_key = "VLLM_OMNI_TEST_STAGE_RUNTIME_ENV"
+    assert env_key not in os.environ
+
+    fake_addresses = types.SimpleNamespace(inputs=["in"], outputs=["out"], frontend_stats_publish_address=None)
+    seen_at_spawn: str | None = None
+
+    plan = ReplicaInitPlan(
+        replica_id=0,
+        num_replicas=1,
+        launch_mode="local",
+        stage_cfg=types.SimpleNamespace(engine_args={}, runtime=types.SimpleNamespace(devices="0")),
+        metadata=types.SimpleNamespace(
+            stage_id=0,
+            runtime_cfg={"devices": "0", "env": {env_key: "enabled"}},
+        ),
+        stage_connector_spec={},
+        omni_kv_connector=(None, None, None),
+        stage_vllm_config=types.SimpleNamespace(),
+        executor_class=object,
+        engine_args_dict={},
+    )
+
+    device_env_var = current_omni_platform.device_control_env_var
+    prev_device_env = os.environ.get(device_env_var)
+    os.environ[device_env_var] = "0"
+
+    monkeypatch.setattr(runtime_mod, "acquire_device_locks", lambda *_args: [])
+
+    from vllm_omni.engine.stage_engine_startup import StageReplicaResources
+
+    @contextlib.contextmanager
+    def _fake_launch_stage_replica(**_kwargs):
+        nonlocal seen_at_spawn
+        seen_at_spawn = os.environ.get(env_key)
+        yield StageReplicaResources(
+            manager=types.SimpleNamespace(shutdown=lambda: None),
+            addresses=fake_addresses,
+        )
+
+    monkeypatch.setattr(runtime_mod, "launch_stage_replica", _fake_launch_stage_replica)
+    monkeypatch.setattr(
+        runtime_mod.StageEngineCoreClientBase,
+        "make_async_mp_client",
+        staticmethod(lambda **_: types.SimpleNamespace(shutdown=lambda: None)),
+    )
+
+    try:
+        runtime._initialize_local_llm_replica(plan, 302)
+    finally:
+        if prev_device_env is None:
+            os.environ.pop(device_env_var, None)
+        else:
+            os.environ[device_env_var] = prev_device_env
+
+    assert seen_at_spawn == "enabled"
+    assert env_key not in os.environ
+
+
 def test_build_engine_args_cli_tokenizer_overrides_inferred_base_tokenizer(tmp_path):
     from vllm_omni.engine.stage_init_utils import build_engine_args_dict
 

--- a/vllm_omni/engine/stage_runtime.py
+++ b/vllm_omni/engine/stage_runtime.py
@@ -58,6 +58,7 @@ from vllm_omni.engine.stage_init_utils import (
     load_omni_transfer_config_for_model,
     prepare_engine_environment,
     release_device_locks,
+    stage_runtime_env,
 )
 from vllm_omni.engine.stage_pool import StagePool
 from vllm_omni.entrypoints.stage_utils import resolve_stage_physical_devices
@@ -323,9 +324,9 @@ class StageRuntime:
 
     @contextmanager
     def _stage_device_scope(self, stage_id: int, runtime_cfg: Any) -> Iterator[None]:
-        """Temporarily apply the stage device env while launching a replica."""
+        """Temporarily apply the stage runtime and device env for a replica."""
         physical_devices = self._resolve_replica_physical_devices(stage_id, runtime_cfg)
-        with self._scoped_spawn_device_env(physical_devices):
+        with stage_runtime_env(stage_id, runtime_cfg), self._scoped_spawn_device_env(physical_devices):
             yield
 
     # ---- Internal methods ----
@@ -572,18 +573,25 @@ class StageRuntime:
             # Serialize engine-core spawning across all LLM replicas to avoid
             # ZMQ port-allocation races and simultaneous CUDA context init.
             with self._replica_launch_lock:
-                with launch_stage_replica(
-                    vllm_config=vllm_config,
-                    executor_class=executor_class,
-                    log_stats=False,
-                    stage_id=plan.metadata.stage_id,
-                    replica_id=plan.replica_id,
-                    stage_config=plan.stage_cfg,
-                    omni_master_server=self._get_omni_master_server(),
-                    omni_coordinator_address=self._get_coordinator_address(),
-                    stage_visible_devices=physical_devices,
-                    spawn_device_lock=self._spawn_device_lock,
-                ) as resources:
+                # ``runtime.env`` has to be set while multiprocessing spawns the
+                # EngineCore, not only while the deploy config is parsed: the
+                # worker process inherits the environment it is spawned with, so
+                # applying it any earlier leaves every worker-side switch unset.
+                with (
+                    stage_runtime_env(plan.metadata.stage_id, plan.metadata.runtime_cfg),
+                    launch_stage_replica(
+                        vllm_config=vllm_config,
+                        executor_class=executor_class,
+                        log_stats=False,
+                        stage_id=plan.metadata.stage_id,
+                        replica_id=plan.replica_id,
+                        stage_config=plan.stage_cfg,
+                        omni_master_server=self._get_omni_master_server(),
+                        omni_coordinator_address=self._get_coordinator_address(),
+                        stage_visible_devices=physical_devices,
+                        spawn_device_lock=self._spawn_device_lock,
+                    ) as resources,
+                ):
                     pass
 
             logger.info("[StageRuntime] Stage %s engine startup completed", plan.metadata.stage_id)


### PR DESCRIPTION
## Purpose

> Team: **5.6-sol**

### What breaks

A deploy config can give each stage an `env:` block:

```yaml
stages:
  - stage_id: 1
    env:
      SOME_WORKER_SIDE_SWITCH: "1"
```

It never reaches the worker. There is no error and no warning — the key is
accepted by `StageDeployConfig`, parsed, applied to the parent process for a
moment while the config is read, and dropped again before anything is spawned.
Every worker-side feature configured that way is silently inert, and the symptom
is not "my setting was rejected" but "my setting did nothing".

### Root cause

`stage_runtime_env(stage_id, runtime_cfg)` already exists in
`engine/stage_init_utils.py` and already does the right thing. It was simply not
wrapped around the launch. `StageRuntime._initialize_local_llm_replica` calls
`launch_stage_replica(...)`, which spawns the EngineCore process — and a spawned
process inherits the environment of the spawn, so the env has to be in place at
that moment, not earlier. The diffusion path's `_stage_device_scope` had the same
gap: it applied the stage's *device* env around the launch but not its
`runtime.env`.

### Repro

```bash
pytest tests/engine/test_async_omni_engine_stage_init.py \
  -k applies_stage_runtime_env_while_spawning
```

Fails on `assert seen_at_spawn == "enabled"` without this change.

Or, on real hardware: put `env: {VLLM_OMNI_TEST_STAGE_ENV: enabled}` on a stage
of any deploy config, start the server, and read the spawned worker's own
environment — `/proc/<StageEngineCoreProc pid>/environ` is what it was spawned
with. See the Test Result below.

### The fix

Wrap `stage_runtime_env(...)` around `launch_stage_replica` in the LLM path, and
around the device scope in the diffusion path. Twelve lines and one import.

The context manager mutates the parent's `os.environ`, so it is worth saying
where that is safe: it runs inside `self._replica_launch_lock`, which already
serialises engine-core spawning to avoid ZMQ port races, so two replicas cannot
interleave their env. It restores the previous value — including "was unset" — on
the way out, which the test asserts.

## Test Plan

**vLLM Version:** `0.1.dev1+ge5588e49b` (built from `vllm-project/vllm@e5588e49b`)

**vLLM-Omni Commit:** `ecd9d99da` — the base of this branch

1. `tests/engine/test_async_omni_engine_stage_init.py` — a new case,
   `test_initialize_local_llm_replica_applies_stage_runtime_env_while_spawning`,
   which reads the env from inside a faked `launch_stage_replica` (that is,
   at the moment of the spawn) and then asserts the key is gone again
   afterwards. CPU only.
2. On an Atlas A3 / 910C: MiniCPM-o 4.5, the organizer's baseline deploy config
   with `env: {VLLM_OMNI_TEST_STAGE_ENV: enabled}` added to stage 1 and nothing
   else changed. Two servers started at the same time, one per die, from two
   trees that differ only by this diff, and each stage worker's
   `/proc/<pid>/environ` read after startup completes.

## Test Result

### Unit tests

```
tests/engine/test_async_omni_engine_stage_init.py on ecd9d99da  : 27 passed
tests/engine/test_async_omni_engine_stage_init.py on this branch: 28 passed
```

Without the production change the new case fails on the assertion that matters,
not on an import or a missing symbol:

```
>       assert seen_at_spawn == "enabled"
FAILED ...::test_initialize_local_llm_replica_applies_stage_runtime_env_while_spawning
```

### On hardware — the worker's own environment

Atlas A3 / 910C, MiniCPM-o 4.5, the organizer's baseline deploy config with
`env: {VLLM_OMNI_TEST_STAGE_ENV: enabled}` added to **stage 1** and nothing else
changed. Two servers started at the same time, one per die, from two trees that
differ only by this diff. After `Application startup complete`, each stage
worker's `/proc/<pid>/environ` — the environment it was actually spawned with:

| stage | `ecd9d99da` | with this PR |
| --- | --- | --- |
| 0 Thinker | `<absent>` | `<absent>` |
| **1 Talker** | **`<absent>`** | **`VLLM_OMNI_TEST_STAGE_ENV=enabled`** |
| 2 Code2Wav | `<absent>` | `<absent>` |

The control row is the bug: the key was accepted and parsed, and the worker it
was written for never saw it. The right-hand column also shows the scope is
right — the value reaches stage 1 and only stage 1, so a per-stage `env:` does
not leak into the other stages' workers.

### Software

- vLLM `0.1.dev1+ge5588e49b`; CANN toolkit 9.0.0; torch 2.10.0 / torch-npu 2.10.0
- Both trees run from source at `ecd9d99da` via `VLLM_OMNI_SRC` + `PYTHONPATH`
