### PR TITLE
[Bugfix] Trust the model-inspection child's result file over its exit status

### DIFF
--- a/tests/test_registry_inspection_patch.py
+++ b/tests/test_registry_inspection_patch.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""The model-info child's output file outranks its exit status.
+
+vLLM's registry inspects each architecture in a subprocess that writes its
+result to a file and only then exits, so a child that finished the inspection
+and crashed on the way out still left a usable answer behind. Upstream calls
+``check_returncode()`` first and throws it away, which takes the server down.
+Pure CPU: no model, no accelerator, no real subprocess.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+OUTPUT_NAME = "registry_output.tmp"
+RESULT = {"architecture": "SomeOmniModel"}
+
+
+def _fake_child(tmp_path: Path, *, returncode: int, writes: bytes | None, stderr: bytes = b""):
+    """Stand in for the inspection child: optionally write a result, then exit."""
+
+    def run(_command: object, input: object = None, capture_output: bool = False, **_kwargs: object):
+        del input, capture_output
+        if writes is not None:
+            (tmp_path / OUTPUT_NAME).write_bytes(writes)
+        return subprocess.CompletedProcess(["child"], returncode, b"", stderr)
+
+    return run
+
+
+@pytest.fixture
+def install(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Point the registry's tempdir and subprocess at the test, then patch it.
+
+    Returns ``install(child) -> registry``. ``tmp_path`` stands in for the
+    ``TemporaryDirectory`` that ``_run_in_subprocess`` creates and destroys, so
+    the result file outlives the call and the child can be told where to write.
+    """
+    from vllm.model_executor.models import registry
+
+    from vllm_omni.patch import _patch_registry_inspection_trusts_its_output
+
+    class _TemporaryDirectory:
+        def __enter__(self) -> str:
+            return str(tmp_path)
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+    class _Tempfile:
+        TemporaryDirectory = _TemporaryDirectory
+
+    def _install(child):
+        class _Subprocess:
+            CompletedProcess = subprocess.CompletedProcess
+            run = staticmethod(child)
+
+        monkeypatch.setattr(registry, "_omni_registry_output_trusted", False, raising=False)
+        monkeypatch.setattr(registry, "tempfile", _Tempfile, raising=False)
+        monkeypatch.setattr(registry, "subprocess", _Subprocess, raising=False)
+        _patch_registry_inspection_trusts_its_output()
+        return registry
+
+    return _install
+
+
+def _pickled(registry: Any, value: object) -> bytes:
+    """Serialize with the registry's own pickle, the one it will read back."""
+    return registry.pickle.dumps(value)
+
+
+def test_complete_result_survives_a_child_that_aborts_on_exit(install, monkeypatch, tmp_path):
+    """The answer comes back, and the crash is reported rather than hidden."""
+    from vllm.model_executor.models import registry as unpatched
+
+    import vllm_omni.patch as patch_mod
+
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        patch_mod._PATCH_LOGGER,
+        "warning",
+        lambda msg, *args: warnings.append(msg % args if args else msg),
+    )
+
+    registry = install(
+        _fake_child(
+            tmp_path,
+            returncode=-6,
+            writes=_pickled(unpatched, RESULT),
+            stderr=b"corrupted size vs. prev_size\n",
+        )
+    )
+
+    assert registry._run_in_subprocess(lambda: None) == RESULT
+
+    assert len(warnings) == 1
+    assert "exited -6" in warnings[0]
+    assert "corrupted size vs. prev_size" in warnings[0]
+
+
+def test_clean_child_is_unchanged(install, tmp_path):
+    from vllm.model_executor.models import registry as unpatched
+
+    registry = install(_fake_child(tmp_path, returncode=0, writes=_pickled(unpatched, RESULT)))
+
+    assert registry._run_in_subprocess(lambda: None) == RESULT
+
+
+def test_child_that_produced_nothing_still_raises(install, tmp_path):
+    registry = install(_fake_child(tmp_path, returncode=1, writes=None, stderr=b"boom: a real failure"))
+
+    with pytest.raises(RuntimeError, match="boom: a real failure"):
+        registry._run_in_subprocess(lambda: None)
+
+
+def test_child_killed_mid_write_still_raises(install, tmp_path):
+    """A truncated result is not a result, so the exit status stands."""
+    registry = install(
+        _fake_child(tmp_path, returncode=-9, writes=b"\x80\x05\x95truncated", stderr=b"boom: killed mid-write")
+    )
+
+    with pytest.raises(RuntimeError, match="boom: killed mid-write"):
+        registry._run_in_subprocess(lambda: None)
+
+
+def test_patch_is_idempotent(install, tmp_path):
+    from vllm.model_executor.models import registry as unpatched
+
+    from vllm_omni.patch import _patch_registry_inspection_trusts_its_output
+
+    registry = install(_fake_child(tmp_path, returncode=0, writes=_pickled(unpatched, RESULT)))
+    once = registry.subprocess
+
+    _patch_registry_inspection_trusts_its_output()
+
+    assert registry.subprocess is once

--- a/vllm_omni/patch.py
+++ b/vllm_omni/patch.py
@@ -484,3 +484,108 @@ def _patch_cumem_free_callback_cuda() -> None:
 
 
 _patch_cumem_free_callback_cuda()
+
+
+def _patch_registry_inspection_trusts_its_output() -> None:
+    """Accept a model-info child that produced its result and then died.
+
+    vLLM inspects each model architecture in a subprocess: the child pickles its
+    ``_ModelInfo`` to a file and only *then* exits, and the parent calls
+    ``check_returncode()`` before reading it. So a process that finished the
+    inspection and crashed on the way out -- in a static destructor, an atexit
+    handler, a teardown in some unrelated library -- throws away a complete
+    answer and takes the server down with
+    ``Model architectures [...] failed to be inspected``.
+
+    That is not hypothetical. On an Atlas A3 image every ``import vllm_omni``
+    ends in a glibc ``corrupted size vs. prev_size`` abort inside
+    libtorch_python's static destructors, after the interpreter has done its
+    work. It stays invisible while vLLM's on-disk cache is warm and stops the
+    server the moment anything under the model's directory changes the hash
+    that keys it.
+
+    The output file is the honest signal: an interrupted child does not leave a
+    loadable pickle behind. So when the child exits non-zero, look at what it
+    left; if that is a complete result, keep the exit status as what it can
+    actually tell us -- something to warn about, with the child's stderr
+    attached -- and let the caller read the answer it already has. A child that
+    produced nothing raises exactly as before.
+
+    Implemented by recording the temporary directory and filtering the exit
+    status, rather than by re-implementing ``_run_in_subprocess``: a vendored
+    copy of that function would silently stop matching upstream the next time it
+    changes, and would have to import ``pickle`` and ``cloudpickle`` here, which
+    ``tools/pre_commit/check_pickle_imports.py`` rightly does not want. Nothing
+    new is serialized or deserialized -- the result is validated with the very
+    ``pickle.load`` the registry is about to run on the same file.
+    """
+    try:
+        from vllm.model_executor.models import registry as _registry
+    except ImportError:
+        _PATCH_LOGGER.debug("[registry] vLLM model registry not available; skipping patch")
+        return
+
+    if getattr(_registry, "_omni_registry_output_trusted", False):
+        return
+
+    real_tempfile = _registry.tempfile
+    real_subprocess = _registry.subprocess
+    # `_run_in_subprocess` names its output file inside a TemporaryDirectory it
+    # creates and destroys itself, so the path is only knowable from the inside.
+    latest_tempdir: dict[str, str | None] = {"path": None}
+
+    class _RecordingTemporaryDirectory(real_tempfile.TemporaryDirectory):  # type: ignore[misc]
+        def __enter__(self) -> str:
+            path = super().__enter__()
+            latest_tempdir["path"] = path
+            return path
+
+    def _run(*args: object, **kwargs: object) -> object:
+        returned = real_subprocess.run(*args, **kwargs)
+        if returned.returncode == 0:
+            return returned
+
+        tempdir = latest_tempdir["path"]
+        if tempdir is None:
+            return returned
+        output_filepath = os.path.join(tempdir, "registry_output.tmp")
+        try:
+            with open(output_filepath, "rb") as handle:
+                _registry.pickle.load(handle)
+        except Exception:  # noqa: BLE001
+            # Reading a missing, empty or half-written pickle can raise almost
+            # anything -- OSError, EOFError, UnpicklingError, MemoryError on a
+            # truncated frame header. Whatever it raises, the child left no
+            # usable result, so this is a real inspection failure and the caller
+            # must see the child's own error.
+            return returned
+
+        stderr = returned.stderr.decode(errors="replace") if returned.stderr else ""
+        _PATCH_LOGGER.warning(
+            "[registry] model inspection child exited %s after writing a complete result; "
+            "using the result. Tail of its stderr:\n%s",
+            returned.returncode,
+            stderr[-2000:],
+        )
+        return real_subprocess.CompletedProcess(returned.args, 0, returned.stdout, returned.stderr)
+
+    class _AttributeOverlay:
+        """`module`, with `overrides` in front of it."""
+
+        def __init__(self, module: object, **overrides: object) -> None:
+            self._module = module
+            self._overrides = overrides
+
+        def __getattr__(self, name: str) -> object:
+            try:
+                return self._overrides[name]
+            except KeyError:
+                return getattr(self._module, name)
+
+    _registry.tempfile = _AttributeOverlay(real_tempfile, TemporaryDirectory=_RecordingTemporaryDirectory)
+    _registry.subprocess = _AttributeOverlay(real_subprocess, run=_run)
+    _registry._omni_registry_output_trusted = True
+    _PATCH_LOGGER.info("[registry] model-info inspection now trusts the child's output file over its exit status.")
+
+
+_patch_registry_inspection_trusts_its_output()


### PR DESCRIPTION
## Purpose

> Team: **5.6-sol**

### What breaks

```
ValueError: Model architectures ['MiniCPMO45OmniForConditionalGeneration'] failed to be inspected.
Please check the logs for more details.
```

The server does not start. Nothing is wrong with the model, the config or the
tree — the architecture *was* inspected successfully, and the answer was thrown
away.

### Root cause

`vllm/model_executor/models/registry.py::_run_in_subprocess` inspects each
architecture in a child process. The child writes its `_ModelInfo` to a file and
**then** exits; the parent calls `returned.check_returncode()` **before** reading
that file:

```python
returned = subprocess.run(_SUBPROCESS_COMMAND, input=input_bytes, capture_output=True)
returned.check_returncode()          # <- decided before the answer is even looked at
with open(output_filepath, "rb") as f:
    return pickle.load(f)
```

So a child that completed the inspection and crashed on the way out — in a
static destructor, an atexit handler, a teardown in some unrelated library —
takes the server down while a complete, correct result sits on disk unread.

On the Ascend A3 image this happens every single time: `import vllm_omni` ends in
a glibc `corrupted size vs. prev_size` abort inside libtorch_python's static
destructors, after the interpreter has finished its work. It is invisible while
vLLM's on-disk cache is warm, and it stops the server the moment anything under
the model directory changes the hash that keys that cache — a new checkpoint, an
edited config, a first run on a fresh machine.

### Repro

On an affected machine, any tree, cold cache:

```bash
VLLM_CACHE_ROOT=$(mktemp -d) vllm serve <model> --omni \
  --deploy-config vllm_omni/deploy/minicpmo_4_5.yaml --trust-remote-code
```

Unit level, on any machine:

```bash
pytest tests/test_registry_inspection_patch.py
```

### The fix

When the child exits non-zero, look at what it left behind. If it is a complete
result, keep the exit status as what it can actually tell us — something to
**warn** about, loudly, with the child's stderr attached — and let the registry
read the answer it already has. A child that produced nothing raises exactly as
before, with its own error text.

An interrupted child does not leave a loadable pickle behind, so the file is the
honest signal; a truncated one is rejected and the original error stands.

**On the shape of the patch.** It records the temporary directory and filters the
exit status rather than re-implementing `_run_in_subprocess`. Two reasons: a
vendored copy of that function would silently stop matching upstream the next
time it changes, and it would have to `import pickle` and `import cloudpickle`
here — which `tools/pre_commit/check_pickle_imports.py` rightly does not want,
and which I did not think should be answered by adding a file to that
allowlist. Nothing new is serialized or deserialized: the result is validated
with the very `pickle.load` the registry is about to run on the same file, one
line later.

**What this deliberately does not do.** It does not diagnose the ABI mismatch
underneath, and it turns "the child died" into a warning, which could in
principle mask a real teardown bug. That is why it logs at WARNING with the
child's stderr attached rather than swallowing it, and why a child that wrote
nothing still fails loudly. If maintainers would rather this were behind a flag,
say so and I will add one — but a server that refuses to start while holding the
correct answer seemed like the worse default.

The right long-term home for this is `vllm/model_executor/models/registry.py`
itself, where the file could simply be read before `check_returncode()` is
consulted. Happy to take it there instead, or as well.

## Test Plan

**vLLM Version:** `0.1.dev1+ge5588e49b` (built from `vllm-project/vllm@e5588e49b`)

**vLLM-Omni Commit:** `ecd9d99da` — the base of this branch, and of both arms below

### 1. Unit tests — CPU only, no subprocess, no model

`tests/test_registry_inspection_patch.py` (new), 5 cases: a child that aborts
after writing a complete result (the answer comes back **and** a warning
carrying its stderr is emitted); a clean child (unchanged); a child that wrote
nothing (still raises, with its own error); a child killed mid-write (a
truncated pickle is not a result, so the exit status stands); and the patch
being idempotent.

### 2. On hardware — cold cache, two trees, one variable

Atlas A3 / 910C, MiniCPM-o 4.5, the organizer's baseline deploy config. Two
servers started at the same time, one per die, from two trees that differ only
by this diff, each with a **fresh `VLLM_CACHE_ROOT`** so the inspection actually
runs instead of being served from cache.

## Test Result

### Unit tests — CPU only

```
tests/test_registry_inspection_patch.py :  5 passed
```

The `child killed mid-write` case is the one worth looking at: `file exists`
would have been the wrong predicate, and a truncated pickle has to keep raising.

### On hardware — cold cache, `ecd9d99da` vs `ecd9d99da` + this diff

Atlas A3 / 910C, MiniCPM-o 4.5, the organizer's baseline deploy config. Two
servers started at the same time, one per die, each with a fresh
`VLLM_CACHE_ROOT` so the inspection actually runs.

```
=== ctl (pristine ecd9d99da, die 0, cold cache) ===
  RESULT: server FAILED to start
  error: Model architectures ['MiniCPMO45OmniForConditionalGeneration'] failed to be inspected
  child aborts seen: 2

=== fix (ecd9d99da + this diff, die 1, cold cache) ===
  RESULT: server started
  note: model inspection child exited -6 after writing a complete result
  child aborts seen: 2
```

**Both arms hit the same two child aborts.** `-6` is `SIGABRT` — the glibc
`corrupted size vs. prev_size` in libtorch_python's static destructors, after
the child had already written its answer. The control turned that into
`failed to be inspected` and never came up. The patched arm logged it, with the
exit code and the child's stderr, and went on to load the model and serve.

The recovery path fired exactly twice, once per abort — it is not that the
inspection happened to succeed on that die.

To be explicit about what this does **not** show: the underlying abort is
unchanged and unexplained. This PR is about not discarding a correct answer
because of it.

### Software

- vLLM `0.1.dev1+ge5588e49b`; CANN toolkit 9.0.0; torch 2.10.0 / torch-npu 2.10.0
- Both trees run from source at `ecd9d99da` via `VLLM_OMNI_SRC` + `PYTHONPATH`;
  the two differ by this diff and nothing else
