### PR TITLE
[Perf][MiniCPM-o] Use full attention for the duplex Talker to restore real-time throughput

### DIFF
--- a/tests/model_executor/models/minicpmo_4_5/test_pipeline.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_pipeline.py
@@ -172,7 +172,7 @@ class TestDeployTopology:
             assert "hf_overrides" not in stages[1].yaml_engine_args
         if filename == "minicpmo_4_5.yaml":
             assert [stage.yaml_engine_args["max_num_seqs"] for stage in stages] == [4, 4, 4]
-            assert stages[1].yaml_engine_args["hf_overrides"] == {"tts_config": {"attention_type": "sliding_recompute"}}
+            assert stages[1].yaml_engine_args["hf_overrides"] == {"tts_config": {"attention_type": "full_attention"}}
             memory_utilizations = [stage.yaml_engine_args["gpu_memory_utilization"] for stage in stages]
             assert memory_utilizations == [
                 0.55,
@@ -198,12 +198,12 @@ class TestDeployTopology:
         stages = merge_pipeline_deploy(OMNI_PIPELINES[deploy.pipeline], deploy)
         overrides = stages[1].yaml_engine_args["hf_overrides"]
         hf_config = PretrainedConfig()
-        hf_config.tts_config = PretrainedConfig(attention_type="full_attention")
+        hf_config.tts_config = PretrainedConfig(attention_type="sliding_recompute")
 
         model_config = object.__new__(ModelConfig)
         model_config._apply_dict_overrides(hf_config, overrides)
 
-        assert hf_config.tts_config.attention_type == "sliding_recompute"
+        assert hf_config.tts_config.attention_type == "full_attention"
 
     @pytest.mark.parametrize(
         "filename",

--- a/vllm_omni/deploy/minicpmo_4_5.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5.yaml
@@ -69,7 +69,8 @@ stages:
     # condition advance, forcing a per-second full re-prefill that pushed
     # duplex RTF from ~1.0 to ~1.85. Full attention keeps the whole context
     # resident (bounded by tts max_model_len 4096 below) and restores
-    # real-time pacing.
+    # real-time pacing. Until #6799 adds capacity-triggered rollover, a
+    # session that accumulates past that 4096 bound can still fail.
     hf_overrides:
       tts_config:
         attention_type: full_attention

--- a/vllm_omni/deploy/minicpmo_4_5.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5.yaml
@@ -64,13 +64,15 @@ stages:
 
   - stage_id: 1
     max_num_seqs: 4
-    # Native duplex uses MiniCPMTTS.generate_with_buffer's supported
-    # sliding_recompute policy: retain one completed condition/codec chunk
-    # when the next condition arrives. Other deploy profiles continue to use
-    # the checkpoint's full_attention policy.
+    # Native duplex reuses the checkpoint's default full_attention policy:
+    # sliding_recompute (window 2) drops most of the Talker context on every
+    # condition advance, forcing a per-second full re-prefill that pushed
+    # duplex RTF from ~1.0 to ~1.85. Full attention keeps the whole context
+    # resident (bounded by tts max_model_len 4096 below) and restores
+    # real-time pacing.
     hf_overrides:
       tts_config:
-        attention_type: sliding_recompute
+        attention_type: full_attention
     # Leave device-level headroom for the colocated HiFi-GAN cuDNN workspace.
     gpu_memory_utilization: 0.15
     enforce_eager: false


### PR DESCRIPTION
## What this PR does / why we need it

#6626 moved the duplex Talker to `sliding_recompute`, which dropped duplex RTF on A100 from ~1.0 to ~1.85 and made `test_duplex_soft_interrupt` fail intermittently: the follow-up answer no longer starts before the final input commit, so `second_response_before_final_commit` flips false.

Root cause: with `window_size` at its default (2), every condition advance drops almost the whole Talker context, so the pipeline re-prefills the previous condition plus its codec tokens once per second — the Talker spends most of each second re-computing context instead of emitting audio.

This PR switches the duplex Talker to the checkpoint's default **`full_attention`** policy (the same policy every non-duplex deploy profile already uses). The Talker context stays bounded by `tts max_model_len` (4096), so full attention does not grow memory without bound.

### Measured on `test_duplex_soft_interrupt` (`three-stage-single-gpu`, A100)

| config | r1 speak window | outcome |
|---|---|---|
| `sliding_recompute`, window 2 (main after #6626) | 10.7s → 22.0s (RTF ~1.85) | follow-up answer lands after the final commit → intermittent failure |
| `full_attention` (this PR) | 8.7s → 15.2s (RTF ~1.0) | 3/3 answers, contract passes |

### Trade-offs

- Full attention recomputes nothing per condition advance; the 4096-token `tts max_model_len` bound still caps the resident Talker KV.
- Stage-1 KV footprint now equals the full bound instead of a sliding window; the deploy profile already reserves 2 GiB of KV cache for the four Talker streams.

## Test plan

- [ ] `test_duplex_soft_interrupt` × 5 on A100 with this profile
- [ ] `test_duplex_admission_and_expiry_reaper` (shares this deploy profile)
- [ ] Compare per-chunk delta pacing from `events.jsonl` before/after

Ref #6716
