### PR TITLE
[Bugfix] Preserve BF16 residual semantics in fused MiniMax-H3 modulation

### DIFF
--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_modulation.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_modulation.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+import pytest
+import torch
+from vllm.triton_utils import HAS_TRITON
+
+from vllm_omni.diffusion.attention.ops.minimax_h3_modulation import (
+    indexed_gate_rms_norm_scale_shift,
+    rms_norm_indexed_scale_shift,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cuda]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.skipif(not HAS_TRITON, reason="Triton required")
+def test_fused_modulation_preserves_bf16_residual_boundary() -> None:
+    torch.manual_seed(17)
+    rows, hidden_size, conditions = 11, 3072, 4
+    tensors = [
+        torch.randn(rows, hidden_size, device="cuda", dtype=torch.bfloat16),
+        torch.randn(conditions, hidden_size, device="cuda", dtype=torch.bfloat16),
+        torch.randn(rows, hidden_size, device="cuda", dtype=torch.bfloat16),
+        torch.randn(hidden_size, device="cuda", dtype=torch.bfloat16),
+        torch.randn(conditions, hidden_size, device="cuda", dtype=torch.bfloat16),
+        torch.randn(conditions, hidden_size, device="cuda", dtype=torch.bfloat16),
+    ]
+    residual, gate, branch, weight, shift, scale = tensors
+    indices = torch.arange(rows, device="cuda") % conditions
+    eps = 1e-6
+
+    residual_out, modulated_out = indexed_gate_rms_norm_scale_shift(
+        residual,
+        gate,
+        branch,
+        weight,
+        shift,
+        scale,
+        indices,
+        eps,
+    )
+    expected = rms_norm_indexed_scale_shift(
+        residual_out,
+        weight,
+        shift,
+        scale,
+        indices,
+        eps,
+    )
+
+    assert torch.equal(modulated_out, expected)

--- a/vllm_omni/diffusion/attention/ops/minimax_h3_modulation.py
+++ b/vllm_omni/diffusion/attention/ops/minimax_h3_modulation.py
@@ -133,7 +133,8 @@ def _indexed_gate_rms_norm_scale_shift_kernel(
     residual = tl.load(residual_ptr + row * stride_residual_row + columns, mask=mask, other=0.0).to(tl.float32)
     gate = tl.load(gate_ptr + index * stride_gate_row + columns, mask=mask, other=0.0).to(tl.float32)
     branch = tl.load(branch_ptr + row * stride_branch_row + columns, mask=mask, other=0.0).to(tl.float32)
-    updated = residual + gate * branch
+    # Match the BF16 residual value consumed by the unfused RMSNorm path.
+    updated = (residual + gate * branch).to(tl.bfloat16).to(tl.float32)
     tl.store(residual_out_ptr + row * hidden_size + columns, updated, mask=mask)
 
     weight = tl.load(weight_ptr + columns, mask=mask, other=0.0).to(tl.float32)


### PR DESCRIPTION
## Summary

Before the modulation fusion in #6281, MiniMax-H3 executed the gated residual update and the following RMSNorm as two operators:

```python
x = (residual + gate * branch).to(torch.bfloat16)
h = rms_norm(x)
```

The first operator materialized `x` as BF16. RMSNorm therefore loaded the rounded BF16 value and promoted it to FP32 for its reduction.

The fused Triton kernel instead loaded all three inputs as FP32, computed `updated` in FP32, stored it to the BF16 residual output, but also used the unrounded FP32 `updated` directly for RMSNorm:

```python
updated = residual_fp32 + gate_fp32 * branch_fp32
store_bf16(residual_out, updated)
normalized = rms_norm(updated)  # still the unrounded FP32 value
```

This changed the model numerics: the residual carried into the next block was BF16, while the current block's RMSNorm consumed a different FP32 value. The difference accumulates across the denoising trajectory and is clearly exposed by FP8 SAGE attention with Q block size 1 and K block size 16.

This PR rounds `updated` to BF16 and promotes it back to FP32 before both the store and RMSNorm. The conversion remains inside the Triton kernel as register operations; it does not add an intermediate global-memory materialization.

```python
updated = (residual_fp32 + gate_fp32 * branch_fp32).to(bfloat16).to(float32)
store_bf16(residual_out, updated)
normalized = rms_norm(updated)
```

## Reproduction

Tested from `vllm-project/vllm-omni@705e781b0efc52bea75930ecd584690eafcc204a` on 8x B300 using MiniMax-H3 FL2VA and the official 10-second starship prompt. See MiniMax-H3's [official generated video](https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/assets/t2va.mp4) for this workload.

Start the server with:

```bash
CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
VLLM_WORKER_MULTIPROC_METHOD=spawn \
VLLM_OMNI_VIDEO_SYNC_TIMEOUT=1800 \
vllm serve MiniMaxAI/MiniMax-H3 \
  --omni \
  --host 0.0.0.0 \
  --port 8091 \
  --trust-remote-code \
  --task-type fl2va \
  --num-gpus 8 \
  --usp 8 \
  --ring 1 \
  --ulysses-a2a-permute \
  --text-encoder-tp-size 8 \
  --vae-patch-parallel-size 8 \
  --vae-parallel-mode tile \
  --vae-use-tiling \
  --diffusion-attention-config '{
    "default": {
      "backend": "TRTLLM_ATTN",
      "quant": {
        "dtype_qk": "fp8_e4m3",
        "q_block_size": 1,
        "k_block_size": 16
      }
    },
    "per_role": {
      "minimax_h3.token_refiner": {
        "backend": "TRTLLM_ATTN"
      }
    }
  }'
```

Save the official MiniMax-H3 starship prompt as `minimax_h3_official_starship.txt`, then send the same request before and after the patch:

```bash
PROMPT_FILE=minimax_h3_official_starship.txt

curl --fail-with-body \
  --max-time 1800 \
  --request POST http://127.0.0.1:8091/v1/videos/sync \
  --form "prompt=<${PROMPT_FILE}" \
  --form "width=1344" \
  --form "height=768" \
  --form "fps=24" \
  --form "num_inference_steps=50" \
  --form "seed=0" \
  --form 'extra_params={"task":"t2va","duration":10.0,"aspect_ratio":"16:9","flow_shift":12.0,"audio_flow_shift":3.0}' \
  --output output.mp4
```

Only the one-line BF16 round trip in this PR differs between the following outputs.

### Current fused behavior

https://github.com/user-attachments/assets/60e12a28-234e-4a74-a5b7-cdfc48f0f62d



### BF16 residual boundary restored


https://github.com/user-attachments/assets/959f8fd7-19b3-4203-af70-11fda3ddb43e




Both files decode successfully and contain 243 video frames. Restoring the original BF16 boundary recovers the expected video quality.

## Testing

- End-to-end A/B reproduction above
- `git diff --check`
