### PR TITLE
[Bugfix] Fix MiniMax Music 3 output validation

### DIFF
--- a/tests/e2e/online_serving/test_minimax_music3.py
+++ b/tests/e2e/online_serving/test_minimax_music3.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """E2E online tests for MiniMax Music 3 text-to-music.
 
 This is a music model on the speech endpoint, so the request shape differs
@@ -18,6 +18,7 @@ os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
 import pytest
 
+from tests.helpers.assertions import assert_wav_audio_valid
 from tests.helpers.mark import hardware_test
 from tests.helpers.runtime import OmniServerParams
 from tests.helpers.stage_config import get_deploy_config_path
@@ -32,6 +33,9 @@ _FRAMES_10S = 250
 _FRAMES_30S = 750
 _MIN_BYTES_10S = 500_000
 _MIN_BYTES_30S = 1_500_000
+_SAMPLE_RATE = 32_000
+_CHANNELS = 2
+_SAMPLE_WIDTH_BYTES = 2
 
 LYRICS = (
     "[Verse]\nWalking down the empty street at midnight\n"
@@ -80,8 +84,18 @@ def test_text_to_music_001(omni_server, openai_client) -> None:
         "response_format": "wav",
         "timeout": DEFAULT_AUDIO_SPEECH_TIMEOUT_S,
         "min_audio_bytes": _MIN_BYTES_10S,
+        # Music 3 provides generative lyric control, not a guarantee that every
+        # requested line is sung verbatim within a short clip.
+        "transcript_expected_text": None,
     }
-    openai_client.send_audio_speech_request(request_config)
+    responses = openai_client.send_audio_speech_request(request_config)
+    assert_wav_audio_valid(
+        responses[0].audio_bytes,
+        sample_rate=_SAMPLE_RATE,
+        channels=_CHANNELS,
+        sample_width_bytes=_SAMPLE_WIDTH_BYTES,
+        min_audio_bytes=_MIN_BYTES_10S,
+    )
 
 
 @pytest.mark.slow
@@ -108,5 +122,13 @@ def test_text_to_music_multi_window_002(omni_server, openai_client) -> None:
         "response_format": "wav",
         "timeout": DEFAULT_AUDIO_SPEECH_TIMEOUT_S,
         "min_audio_bytes": _MIN_BYTES_30S,
+        "transcript_expected_text": None,
     }
-    openai_client.send_audio_speech_request(request_config)
+    responses = openai_client.send_audio_speech_request(request_config)
+    assert_wav_audio_valid(
+        responses[0].audio_bytes,
+        sample_rate=_SAMPLE_RATE,
+        channels=_CHANNELS,
+        sample_width_bytes=_SAMPLE_WIDTH_BYTES,
+        min_audio_bytes=_MIN_BYTES_30S,
+    )

--- a/tests/helpers/assertions.py
+++ b/tests/helpers/assertions.py
@@ -462,6 +462,37 @@ def assert_audio_valid(
     )
 
 
+def assert_wav_audio_valid(
+    audio_bytes: bytes | None,
+    *,
+    sample_rate: int,
+    channels: int,
+    sample_width_bytes: int,
+    min_audio_bytes: int,
+    min_rms_dbfs: float = -60.0,
+) -> None:
+    """Assert that WAV bytes have the requested format, duration, and signal."""
+    assert audio_bytes is not None, "Expected WAV audio bytes"
+
+    with wave.open(io.BytesIO(audio_bytes), "rb") as wav_file:
+        assert wav_file.getnchannels() == channels
+        assert wav_file.getsampwidth() == sample_width_bytes
+        assert wav_file.getframerate() == sample_rate
+        assert wav_file.getcomptype() == "NONE"
+
+        frame_count = wav_file.getnframes()
+        min_frames = min_audio_bytes // (channels * sample_width_bytes)
+        assert frame_count > min_frames, (
+            f"Audio is too short: {frame_count / sample_rate:.2f}s, expected more than {min_frames / sample_rate:.2f}s"
+        )
+        pcm = np.frombuffer(wav_file.readframes(frame_count), dtype="<i2")
+
+    assert pcm.size == frame_count * channels
+    rms = float(np.sqrt(np.mean(np.square(pcm.astype(np.float32)))))
+    rms_dbfs = 20.0 * np.log10(max(rms, 1.0) / np.iinfo(np.int16).max)
+    assert rms_dbfs > min_rms_dbfs, f"Generated audio is effectively silent: RMS={rms_dbfs:.1f} dBFS"
+
+
 def _load_gender_pipeline():
     global _GENDER_PIPELINE
     if _GENDER_PIPELINE is not None:
@@ -1041,4 +1072,5 @@ __all__ = [
     "assert_video_diffusion_response",
     "assert_video_valid",
     "assert_audio_valid",
+    "assert_wav_audio_valid",
 ]

--- a/tests/helpers/tests/test_assertions.py
+++ b/tests/helpers/tests/test_assertions.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
+import io
+import wave
 from types import SimpleNamespace
 
 import pytest
@@ -10,9 +12,22 @@ from tests.helpers.assertions import (
     _assert_transcript_matches,
     _resolve_audio_transcript,
     assert_audio_speech_response,
+    assert_wav_audio_valid,
 )
+from tests.helpers.client import OmniResponse
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _make_wav_bytes(*, sample_value: int, frame_count: int = 32_000) -> bytes:
+    pcm_frame = sample_value.to_bytes(2, byteorder="little", signed=True) * 2
+    wav_buffer = io.BytesIO()
+    with wave.open(wav_buffer, "wb") as wav_file:
+        wav_file.setnchannels(2)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(32_000)
+        wav_file.writeframes(pcm_frame * frame_count)
+    return wav_buffer.getvalue()
 
 
 def test_short_transcript_repeat_passes_containment_fallback():
@@ -97,7 +112,7 @@ def test_speech_transcript_expected_text(monkeypatch, request_config, expected_t
         captured["expected_text"] = expected_text
 
     monkeypatch.setattr(assertions, "_assert_transcript_matches", capture_match)
-    response = SimpleNamespace(success=True, audio_bytes=b"fake-wav", audio_format="audio/wav")
+    response = OmniResponse(success=True, audio_bytes=b"fake-wav", audio_format="audio/wav")
     request_config["response_format"] = "wav"
 
     assert_audio_speech_response(
@@ -107,6 +122,43 @@ def test_speech_transcript_expected_text(monkeypatch, request_config, expected_t
     )
 
     assert captured["expected_text"] == expected_text
+
+
+def test_speech_transcript_expected_text_none_skips_transcription(monkeypatch):
+    def fail_if_transcribed(*_args, **_kwargs):
+        pytest.fail("Whisper should not run when transcript validation is disabled")
+
+    monkeypatch.setattr(assertions, "convert_audio_bytes_to_text", fail_if_transcribed)
+    response = OmniResponse(success=True, audio_bytes=b"fake-wav", audio_format="audio/wav")
+
+    assert_audio_speech_response(
+        response,
+        {
+            "input": "generative lyrics",
+            "response_format": "wav",
+            "transcript_expected_text": None,
+        },
+        "advanced_model",
+    )
+
+
+def test_wav_audio_valid_checks_format_duration_and_signal():
+    assert_wav_audio_valid(
+        _make_wav_bytes(sample_value=1_000),
+        sample_rate=32_000,
+        channels=2,
+        sample_width_bytes=2,
+        min_audio_bytes=100_000,
+    )
+
+    with pytest.raises(AssertionError, match="effectively silent"):
+        assert_wav_audio_valid(
+            _make_wav_bytes(sample_value=0),
+            sample_rate=32_000,
+            channels=2,
+            sample_width_bytes=2,
+            min_audio_bytes=100_000,
+        )
 
 
 def test_escalated_transcript_keeps_declared_language(monkeypatch):


### PR DESCRIPTION
## Purpose

Fixes #6842.

### What broke

The weekly H100 TTS job treated the complete MiniMax Music 3 lyrics prompt as strict expected speech. A valid short generated song could contain an intro, partial lyrics, or non-verbatim vocals, so Whisper output such as Lalalala failed the generic 0.9 transcript-similarity gate.

### Reproduction

At issue commit 1d75e63f7f7c0fcde83594a90876e20415c8bc52, the original CI command reproduced the same assertion path locally. The generated 10 second WAV was valid, but Whisper returned Oh Walking down the empty street in and the full-lyrics cosine similarity was 0.23.

    export VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
    export VLLM_USE_DEEP_GEMM=0
    export VLLM_MOE_USE_DEEP_GEMM=0
    pytest -sv tests/e2e/ -m "slow and H100 and tts" --run-level "full_model"

### Root cause

assert_audio_speech_response defaults transcript_expected_text to the request input. That default is appropriate for TTS, but MiniMax Music 3 uses the speech endpoint for generative music. Its model contract describes lyrics and structure as generative controls rather than strict symbolic guarantees, so whole-prompt ASR equality is not a stable correctness criterion across GPU architectures.

### Fix

- Explicitly disable transcript matching for the two MiniMax Music 3 music-generation cases.
- Replace it with a shared WAV contract assertion covering 32 kHz stereo 16-bit PCM, payload-backed duration, and a non-silence RMS floor.
- Add L1 coverage proving that transcript_expected_text=None skips Whisper and that the WAV assertion accepts valid signal while rejecting silence.

## Test Plan

The existing weekly H100 TTS command above is the CI-like validation path. No Buildkite change is needed because the weekly job already collects this module.

Local focused checks:

    pytest -q tests/helpers/tests/test_assertions.py \
      tests/model_executor/models/test_minimax_music3_frame_state.py \
      tests/model_executor/models/test_minimax_music3_repo_root.py \
      tests/model_executor/models/test_minimax_music3_batch_payload.py \
      tests/model_executor/models/test_minimax_music3_prompt.py \
      tests/model_executor/models/test_minimax_music3_row_binding.py

Prerequisites for the full-model command: one H100-class GPU and MiniMaxAI/MiniMax-Music3 in HF_HOME.

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** issue baseline 1d75e63f7f7c0fcde83594a90876e20415c8bc52; rebased branch base eb11446b7f2e30ca582f8aff3afe12e9a2e66f6c

## Test Result

- Original issue baseline: reproduced the transcript assertion failure at similarity 0.23; generated WAV was 1,279,560 bytes.
- Ruff check and format: passed on all three changed files.
- Focused unit/model tests: 99 passed, 14 warnings.
- Full changed-file pre-commit suite, including mypy, test marks, SPDX, forbidden imports, and DCO-related checks: passed.
- WAV assertion smoke check: passed with a generated 32 kHz stereo PCM fixture; silence rejection is covered by pytest.
- Latest-main full-model attempts on the local L20X reached model initialization but were blocked before request execution by the shared container memory cgroup at approximately 988.35/988.92 GB, which terminated stage 0 while stage 1 loaded. The H100 weekly job remains the authoritative post-fix full-model validation.