### PR TITLE
[Perf][TTS] Voxtral TTS: defer per-frame D2H sync to chunk flush

### DIFF
--- a/vllm_omni/model_executor/stage_input_processors/voxtral_tts.py
+++ b/vllm_omni/model_executor/stage_input_processors/voxtral_tts.py
@@ -51,8 +51,10 @@ def generator2tokenizer_async_chunk(
     if isinstance(multimodal_output, Mapping):
         frame = _extract_last_frame(multimodal_output)
         if frame is not None:
-            codec_codes = frame.cpu().tolist()
-            transfer_manager.code_prompt_token_ids[request_id].append(codec_codes)
+            # Keep the frame on its producing device: appending must not force a
+            # per-frame D2H sync. The whole window is copied to host once per
+            # flushed chunk below instead.
+            transfer_manager.code_prompt_token_ids[request_id].append(frame.detach())
     elif not finished:
         # Some steps may not produce multimodal_output. Only flush on finish.
         return None
@@ -95,7 +97,13 @@ def generator2tokenizer_async_chunk(
     window_frames = transfer_manager.code_prompt_token_ids[request_id][-end_index:]
 
     # Pack context + chunk into codebook-major flat codes for adapter.
-    code_predictor_codes = torch.tensor(window_frames).reshape(-1).tolist()
+    # Frames may still be on the GPU, so flatten on-device and issue a single
+    # D2H copy for the whole window (one per chunk instead of one per frame).
+    # torch.as_tensor passes tensors through zero-copy and still accepts the
+    # plain-int frames older seeds/tests may have stored.
+    code_predictor_codes = torch.cat(
+        [torch.as_tensor(f).reshape(-1) for f in window_frames]
+    ).cpu().tolist()
 
     return OmniPayloadStruct(
         codes=CodesStruct(

--- a/vllm_omni/model_executor/stage_input_processors/voxtral_tts.py
+++ b/vllm_omni/model_executor/stage_input_processors/voxtral_tts.py
@@ -100,10 +100,12 @@ def generator2tokenizer_async_chunk(
     # Frames may still be on the GPU, so flatten on-device and issue a single
     # D2H copy for the whole window (one per chunk instead of one per frame).
     # torch.as_tensor passes tensors through zero-copy and still accepts the
-    # plain-int frames older seeds/tests may have stored.
-    code_predictor_codes = torch.cat(
-        [torch.as_tensor(f).reshape(-1) for f in window_frames]
-    ).cpu().tolist()
+    # plain-int frames older seeds/tests may have stored; stragglers on another
+    # device (e.g. pre-seeded CPU lists against CUDA frames) are moved to the
+    # producing device of the newest frame first. .to() is a no-op when the
+    # window is homogeneous.
+    frames = [torch.as_tensor(f).reshape(-1) for f in window_frames]
+    code_predictor_codes = torch.cat([f.to(frames[-1].device) for f in frames]).cpu().tolist()
 
     return OmniPayloadStruct(
         codes=CodesStruct(


### PR DESCRIPTION
## Purpose

`generator2tokenizer_async_chunk` (the Voxtral TTS generator → tokenizer stage processor) ran `frame.cpu().tolist()` on **every decoded frame**, forcing a blocking host sync per frame per request on the save_loop thread — while downstream chunks are only flushed every `codec_chunk_frames` (25) frames. At B concurrent requests that is B blocking syncs per engine step, locking the CPU thread in lockstep with GPU compute and hurting streaming chunk-interval jitter and high-concurrency throughput.

This PR keeps frames on their producing device while accumulating, and issues a single D2H copy for the whole window at chunk-flush time via `torch.cat(...).cpu()`. `torch.as_tensor` passes stored tensors through zero-copy and still accepts plain-list frames pre-seeded by tests / old state. A follow-up commit moves stragglers to the newest frame's device before the cat, so a window mixing pre-seeded CPU lists with CUDA-resident frames cannot raise on a device mismatch (the per-frame `.cpu()` path this replaces tolerated the mix; `.to()` is a no-op in the homogeneous steady state).

## Test Plan

**vLLM Version:** 0.26.0

**vLLM-Omni Commit:** eed6c204

- Old-vs-new equivalence on CPU and CUDA (RTX 3060) across 12 scenarios: 60-frame stream + finish tail, finish mid-chunk, empty EOF payload, list-seeded state + tensor frames (CPU and CUDA), CUDA-resident frames, custom chunk configs, interleaved requests, int32/float32 dtypes, multi-tensor `codes.audio`, and None/empty-frame steps — payload outputs identical to the pre-change implementation.
- Existing tests: `pytest tests/model_executor/stage_input_processors/test_voxtral_tts_async_chunk.py -q`
- ruff check / format clean
- e2e (`tests/e2e/{online_serving,offline_inference}/test_voxtral_tts_expansion.py`)
  needs a serving deployment — to run in CI.

## Test Result

- 12/12 equivalence scenarios pass (incl. the mixed-device case before and after the follow-up fix)
- `test_voxtral_tts_async_chunk.py`: 8 passed
- Simulated save_loop on GPU (B=8 requests × 100 frames, per-step GPU work): DtoH memcpy count 800 → 72 (~11x, exactly matching the chunk flush schedule), DtoH GPU time 0.94ms → 0.09ms, loop wall time 117.7ms → 96.3ms (18% faster); the GPU work in the microbenchmark is far lighter than real decode, so this is a conservative floor