### PR TITLE
[Model] MiniMax-H3: expose temporal VAE chunks

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -37,7 +37,7 @@ nav:
       - Image-To-Video: user_guide/examples/online_serving/image_to_video.md
       - Speech-To-Video: user_guide/examples/online_serving/speech_to_video.md
       - Text-To-Image: user_guide/examples/online_serving/text_to_image.md
-      - Text-To-Speech: user_guide/examples/online_serving/text_to_speech.md
+      - Text-To-Speech (Online Serving): user_guide/examples/online_serving/text_to_speech.md
       - Text-To-Video: user_guide/examples/online_serving/text_to_video.md
   - General:
     - usage/*
@@ -127,6 +127,8 @@ nav:
         - Async Omni Output Materialization: design/feature/omni_async_output_materialization.md
         - Automatic Prefix Caching: design/feature/prefix_caching.md
         - Realtime AR-Diffusion: design/feature/realtime_ar_diffusion.md
+      - Model-Specific Capabilities:
+        - MiniMax H3 Temporal VAE Chunks: design/feature/minimax_h3_temporal_vae_chunks.md
       - Communication:
         - OmniConnector Implementations:
           - Mooncake Store Connector: design/feature/omni_connectors/mooncake_store_connector.md

--- a/docs/design/architecture_overview.md
+++ b/docs/design/architecture_overview.md
@@ -170,6 +170,10 @@ because the user-visible output is diffusion media rather than a token stream.
 The
 [MiniMax-H3 recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/MiniMaxAI/MiniMax-H3.md)
 contains the hardware-specific profiles and warmup requirements.
+The internal, opt-in
+[temporal VAE chunk callback](feature/minimax_h3_temporal_vae_chunks.md)
+documents the narrower released-source contract for publishing committed video
+frames during decode. It does not change the complete-output serving topology.
 
 ### Cosmos3: unified MoT reasoner and generator
 

--- a/docs/design/feature/minimax_h3_temporal_vae_chunks.md
+++ b/docs/design/feature/minimax_h3_temporal_vae_chunks.md
@@ -1,0 +1,260 @@
+# MiniMax H3 temporal VAE chunk callback
+
+!!! warning "Experimental internal capability"
+
+    This feature is an opt-in model integration seam. The current MiniMax H3
+    pipeline still uses complete-output VAE decode, and no CLI option, serving
+    path, transport, or MP4 sink enables temporal chunks by default.
+
+## Status and scope
+
+MiniMax H3 decodes video latents in temporal windows, but the released VAE
+normally exposes only the complete reconstructed video. The temporal callback
+publishes frames after the released decoder has completed overlap blending and
+padding removal. This gives a future runtime consumer a stable point at which
+it can schedule representation conversion, D2H transfer, and encoding while
+the VAE continues decoding later windows.
+
+The implementation remains model-local:
+
+- `vae.py` owns VAE topology and the thin
+  `decode_latent_with_chunks()` facade;
+- `chunked_decode.py` owns the normalized callback contract, metadata
+  validation, and fixed VAE-group rendezvous points; and
+- `temporal_chunks.py` owns the source-gated compatibility planner and the
+  released temporal assembly control flow.
+
+Crop policy, typed media, transport, backpressure, encoding, and public output
+remain runtime responsibilities. The model code does not schedule requests or
+select a presentation format.
+
+## Execution flow
+
+The default and opt-in paths are intentionally separate:
+
+```text
+Default:
+latent -> MiniMaxH3VideoVAE.decode_latent() -> complete RGB video
+
+Opt-in producer seam:
+latent
+  -> MiniMaxH3VideoVAE.decode_latent_with_chunks()
+  -> group-local preflight and callback-owner validation
+  -> released temporal decode / overlap blending / padding removal
+  -> borrowed decoder-domain chunk
+  -> normalize + clone into owned RGB float32 BCTHW [0, 1]
+  -> synchronous callback
+  -> complete RGB video is still returned
+```
+
+Calling `decode_latent_with_chunks()` is the opt-in. Supplying no callback on a
+VAE peer does not select the default decoder; every rank in a VAE patch group
+must enter the chunked method, and only the output rank receives the callback.
+
+## Producer contract
+
+The normalized callback has this structural signature:
+
+```python
+def callback(
+    frames: torch.Tensor,
+    /,
+    *,
+    chunk_index: int,
+    total_chunks: int,
+    frame_start: int,
+    is_final: bool,
+) -> None:
+    ...
+```
+
+For a successful decode:
+
+- `frames` is owned, contiguous RGB float32 in `BCTHW` layout and `[0, 1]`;
+- callback storage does not alias the returned complete video;
+- the consumer may retain or mutate a chunk;
+- `chunk_index` is zero-based, contiguous, and strictly increasing;
+- `total_chunks` is positive and stable for the decode;
+- `frame_start` equals the end of the previous published range;
+- chunks are nonempty and contain only temporally committed frames;
+- exactly one chunk has `is_final=True`; and
+- concatenating chunks along time exactly reconstructs the returned video.
+
+The callback runs synchronously on the producer's current device stream. A
+consumer that reads the tensor on another stream must establish ordering, for
+example with an event, and retain the allocation for that stream's lifetime.
+A slow callback also blocks VAE production. An overlap-oriented runtime
+consumer should therefore acquire bounded capacity, enqueue side-stream work,
+and return promptly instead of encoding frames inside the callback.
+
+Chunks retain the decoded VAE canvas dimensions. A future runtime integration
+must apply the same requested-height and requested-width crop as the complete
+MiniMax H3 pipeline before declaring the media transport-ready.
+
+The raw compatibility callback is deliberately narrower. It receives borrowed
+decoder-domain tensors and must not retain or mutate them. The coordinator is
+the ownership boundary that normalizes and clones raw chunks before invoking
+the public callback.
+
+## Temporal planning and terminal publication
+
+The released configuration advances five latent tokens per temporal window and
+includes a two-token overlap, so each `_adaptive_decode` input normally contains
+seven tokens. After temporal scaling, pre-padding removal, and five-frame
+overlap blending, the normal committed unit is 17 output frames. The final
+remainder depends on the requested frame plan.
+
+Representative released frame plans include:
+
+| Output frames | Published chunks |
+| ---: | --- |
+| 124 | `7 x 17 + 5` |
+| 209 | `12 x 17 + 5` |
+| 243 | `14 x 17 + 5` |
+| 362 | `21 x 17 + 5` |
+
+The terminal callback is held until the complete frame plan passes its logical
+frame, padding, written-frame, chunk-count, and finality checks. Earlier chunks
+are semantically stable, but they do not imply that the overall request has
+succeeded; a consumer must discard or abort partial output if a later decoder
+failure terminates the request.
+
+## Source and configuration gate
+
+The released VAE has no public temporal-callback API. vLLM-Omni therefore owns
+a compatibility implementation for one exact released code contract. The
+reference revision identifies its provenance, but runtime acceptance is based
+on source content, configuration, and structure rather than repository or
+weight metadata:
+
+- reference Hugging Face revision, not independently checked at runtime:
+  `42ed227ee7df40d41602854ae760620d6eb651fe`;
+- sorted 15-file top-level `video_vae/*.py` manifest (excluding
+  `__init__.py`) SHA-256:
+  `30e64afbaa940696bf8bfe2c86003a4b1666c84b22fa3aa12403a3e6a03f705d`;
+- clip length `17`;
+- token chunk, overlap, and drop `5`, `2`, and `3`;
+- temporal ratio `4`;
+- frame pre-padding and overlap `3` and `5`; and
+- no isolated first or last frame.
+
+The adapter does not verify Hugging Face revision metadata, repository identity,
+or model weights. The manifest pin detects Python compatibility drift; it is
+not a security boundary for remote-code execution. The source manifest, listed
+temporal attributes, structural contract, plan, and dtype are validated before
+the first `_adaptive_decode` call. A mismatch disables only the opt-in chunk path.
+`decode_latent()` remains available and performs no source fingerprint or chunk
+rendezvous.
+
+## Supported models
+
+Support in this table means the internal producer contract above, not public
+serving or end-to-end transport support.
+
+| Model or component | Source contract | Status | Validation |
+| --- | --- | --- | --- |
+| MiniMax H3 FL2VA video VAE | Released manifest/listed temporal attributes above (reference `42ed227e`) | Supported, opt-in | Same-environment full-output parity and L20X/B300 feasibility measured on the implementation through PR commit `60e9bbad` |
+| MiniMax H3 Ref2VA video VAE | Same released manifest/listed temporal attributes | Source-compatible; not separately benchmarked | Ref2VA and FL2VA use byte-identical video-VAE source and configuration in the reference snapshot |
+| MiniMax H3 with a different Python manifest or listed temporal attribute | Different enforced contract | Unsupported for chunk mode | Fails closed before decoder collectives; complete decode remains available |
+| Same manifest/temporal attributes with different weights or other component metadata | Not checked by this gate | Not independently qualified | The adapter does not inspect weights, repository identity, revision metadata, or arbitrary component configuration |
+| Other video models | Any | Unsupported | No generic temporal VAE producer ABI is declared by this feature |
+
+## Feature compatibility
+
+| Dimension or combination | Status | Constraint |
+| --- | --- | --- |
+| Existing complete-output decode | Supported and default | No source check, callback object, or callback rendezvous |
+| Explicit chunk decode | Supported internally | Caller invokes `decode_latent_with_chunks()` directly |
+| VAE patch parallel size 1 | Supported by the model seam | Caller supplies the callback only on the request output owner; no WORLD rendezvous is added |
+| VAE patch parallel size equal to the full DiT group | Supported when data parallel size is 1 | Every VAE-group rank calls; exactly group rank 0 owns the callback |
+| Partial VAE patch subgroup | Unsupported | MiniMax H3 currently accepts size 1 or the full DiT group only |
+| Data parallel size greater than 1 with VAE patch parallel size 1 | Model seam only | Per-replica callback ownership is possible, but no serving/runtime consumer is wired |
+| Data parallel size greater than 1 with VAE patch parallel size greater than 1 | Unsupported | Fails before decoder collectives because no replica-local VAE patch group is defined |
+| Too few spatial tiles for the VAE group | Correctness fallback | Decodes rank-locally and restores native tiling state; slower than patch parallel decode |
+| Device memory and full-output assembly | Not reduced or bounded | The compatibility path still assembles and returns the full decode while allocating owned callback chunks; no peak-HBM reduction is claimed |
+| DiT cache, attention, TP, SP, HSDP, LoRA, or quantization features | No direct callback dependency | This seam runs after denoising and does not independently qualify combinations beyond the MiniMax H3 model's own matrix |
+| Layerwise or distributed component offload | Not separately validated | Component residency must place the video VAE before decode |
+| Step execution or request batching | Not integrated | No pipeline caller binds a runtime chunk consumer |
+| Requested-size crop and device uint8 preparation | Not implemented here | Runtime-owned follow-up |
+| Pinned D2H, SHM/ZMQ, or cross-process transport | Not implemented here | Runtime-owned follow-up |
+| Complete MP4 or fragmented MP4 sink | Not implemented here | Existing serving behavior still waits for complete output |
+| Audio VAE chunks and incremental A/V composition | Not supported | Video chunks do not imply audio or request finality |
+| Cancellation and multi-output lease ownership | Not implemented here | Requires a bounded runtime lifecycle |
+| NVIDIA CUDA | Feasibility evidence | L20X and B300 measurements apply to the implementation through `60e9bbad`; the current coordination refactor was not reprofiled |
+| AMD ROCm | Not validated for this feature | Base MiniMax H3 support is documented separately and does not imply temporal-chunk validation |
+| Ascend, Intel, or other accelerators | No feature support claim | Consult the model support table independently; this design adds no platform qualification |
+
+## Distributed and failure semantics
+
+When VAE patch parallelism is active, all VAE-group ranks run the same
+preflight before entering checkpoint collectives. Source/planner errors and the
+resolved temporal concat dtype are reconciled at fixed group rendezvous points.
+
+Callback ownership is also a group decision. Rank `r` contributes `r + 1` when
+it owns a callback and zero otherwise. A group SUM equals one only when rank 0
+is the sole owner; every invalid owner configuration therefore fails
+identically on all ranks before decode.
+
+Callback exceptions are retained on the output rank. Further publication stops,
+but every rank completes the same remaining native decoder collective schedule.
+The original exception is then raised on the owner and
+`MiniMaxH3ChunkCallbackPeerError` on peers.
+
+Exceptions raised inside the checkpoint's native distributed decode cannot in
+general be reconciled by the adapter: a peer may already be blocked inside a
+checkpoint-owned collective. Resolving such failures requires native collective
+handling or supervisor-level timeout and worker-group teardown. The process
+group must not be assumed reusable after such a failure.
+
+## Validation evidence
+
+The contract suite covers ordinary and padded frame plans, blend boundaries,
+owned storage and mutation isolation, source-manifest/listed-temporal-attribute
+drift, callback failure, and healthy subsequent requests. Real Gloo processes cover
+rank-asymmetric preflight failures, dtype disagreement, two-rank callback
+failure propagation, three-rank wrong-owner rejection, insufficient-tile
+fallback, and group recovery for failures that occur at adapter-owned
+rendezvous points.
+
+Four-device L20X and independent four- and eight-device B300 experiments on the
+implementation through PR commit `60e9bbad` showed exact serial-versus-chunked
+frame/MP4 parity within each environment and lower VAE-to-complete-MP4 latency
+when an experimental consumer was attached. Hashes are not claimed to match
+across different hardware/software environments. The later coordination and
+module-boundary refactors were revalidated with CPU and real Gloo tests but were
+not reprofiled on GPUs. These are feasibility measurements, not a promise for
+default serving, because this change does not contain the transport or encoder
+consumer. See [RFC #6872](https://github.com/vllm-project/vllm-omni/issues/6872)
+and [PR #6885](https://github.com/vllm-project/vllm-omni/pull/6885) for the
+measurement provenance and limitations.
+
+## Generalization boundary and follow-ups
+
+This feature does not define a repository-wide `SupportsVideoChunkDecode`
+interface. H3 temporal blending, Wan causal caches, LTX temporal/spatial halos,
+and pipeline-level generation chunks have different commit and failure
+boundaries. A generic producer contract should be extracted only after a second
+model proves the same semantic event without `Any` arguments or model-name
+dispatch.
+
+The reusable future boundary is the emitted, committed video-media chunk, not a
+universal latent-to-VAE method. It should extend the typed media work in
+[RFC #6541](https://github.com/vllm-project/vllm-omni/issues/6541) and
+[PR #6615](https://github.com/vllm-project/vllm-omni/pull/6615), while keeping
+model-specific halo, cache, padding, blending, distributed, and source-gating
+logic inside each model adapter.
+
+Runtime follow-ups own:
+
+- typed video-plus-audio media and request/output identity;
+- requested-size crop and device preparation;
+- bounded leases, backpressure, cancellation, and cleanup;
+- D2H/IPC transport and observability; and
+- complete-MP4 and fragmented-MP4 consumers.
+
+## Related documentation
+
+- [Diffusion model integration](../module/diffusion/diffusion_model_integration.md)
+- [VAE patch parallelism](vae_parallel.md)
+- [Async diffusion output](async_diffusion_output.md)
+- [MiniMax H3 recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/MiniMaxAI/MiniMax-H3.md)

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -25,6 +25,10 @@ implementation contract; it is not, by itself, a general support claim.
 - [Automatic Prefix Caching in Omni Models](feature/prefix_caching.md)
 - [Realtime AR-Diffusion Sessions](feature/realtime_ar_diffusion.md)
 
+### Model-specific capabilities
+
+- [MiniMax H3 Temporal VAE Chunks](feature/minimax_h3_temporal_vae_chunks.md)
+
 ### Communication
 
 #### OmniConnector implementations

--- a/docs/design/module/diffusion/diffusion_model_integration.md
+++ b/docs/design/module/diffusion/diffusion_model_integration.md
@@ -57,3 +57,10 @@ cross-stage routing.
 
 Test registry selection, checkpoint loading, minimal inference, input and output
 contracts, and every declared optional capability.
+
+## Model-specific capability documents
+
+- [MiniMax H3 temporal VAE chunk callback](../../feature/minimax_h3_temporal_vae_chunks.md)
+  defines the source-gated producer seam and its boundary with future runtime
+  media transport. It is an internal opt-in capability, not a public serving
+  feature.

--- a/recipes/MiniMaxAI/MiniMax-H3.md
+++ b/recipes/MiniMaxAI/MiniMax-H3.md
@@ -1142,3 +1142,4 @@ vllm serve "${MODEL_ROOT}/FL2VA" \
 - [Supported models](../../docs/models/supported_models.md)
 - [Video API](../../docs/serving/videos_api.md)
 - [Diffusion parallelism](../../docs/user_guide/diffusion/parallelism/overview.md)
+- [Temporal VAE chunk callback design](../../docs/design/feature/minimax_h3_temporal_vae_chunks.md)

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_vae_chunks.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_vae_chunks.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import multiprocessing as mp
 import time
 from pathlib import Path
@@ -14,6 +15,11 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 
+import vllm_omni.diffusion.models.minimax_h3.temporal_chunks as temporal_chunks_module
+import vllm_omni.diffusion.models.minimax_h3.vae as vae_module
+from vllm_omni.diffusion.models.minimax_h3.temporal_chunks import (
+    MINIMAX_H3_RELEASED_BUNDLE_SHA256,
+)
 from vllm_omni.diffusion.models.minimax_h3.vae import (
     MiniMaxH3ChunkCallbackPeerError,
     MiniMaxH3ChunkedDecodeUnsupportedError,
@@ -29,81 +35,145 @@ class _IdentityProcessor:
         return tensor
 
 
-class _FakeVendorTemporalModel(nn.Module):
-    temporal_chunk_callback_api_version = 1
+class _FakeCompatTemporalModel(nn.Module):
+    use_3d_conv = True
+    clip_length = 17
+    tokens_chunk_size = 5
+    token_overlap = 2
+    token_drop = 3
+    vae_ratio_t = 4
+    frame_pre_padding = 3
+    frame_overlap = 5
+    isolated_first_frame = False
+    isolated_last_frame = False
     vae_ratio = 1
 
     def __init__(
         self,
+        latent_t: int,
         *,
         collective: bool = False,
-        metadata_mode: str = "valid",
+        tile_count: int = 2,
     ) -> None:
         super().__init__()
-        values = torch.linspace(0, 1, 124).view(1, 1, 124, 1, 1)
-        self.expected = values.expand(1, 3, -1, 1, 1).contiguous()
-        self.processor = _IdentityProcessor()
         self.parallel_tiling = collective
         self.collective = collective
-        self.metadata_mode = metadata_mode
+        self.tile_count = tile_count
+        pseudo_tokens = latent_t + self.token_drop
+        remainder = pseudo_tokens % self.tokens_chunk_size
+        self.pad_tokens = 0 if remainder == 0 else self.tokens_chunk_size - remainder
+        self.num_chunks = (pseudo_tokens + self.pad_tokens) // self.tokens_chunk_size - 1
+        ideal_frames = self.num_chunks * 17 + 5
+        output_frames = {
+            33: 111,
+            34: 115,
+            35: 119,
+            36: 120,
+        }.get(latent_t, ideal_frames)
+        values = torch.linspace(0, 1, ideal_frames).view(1, 1, ideal_frames, 1, 1)
+        self.ideal = values.expand(1, 3, -1, 1, 1).contiguous()
+        self.expected = self.ideal[:, :, :output_frames].clone()
+        self.processor = _IdentityProcessor()
         self.decode_base_calls = 0
-        self.vendor_callback_calls = 0
+        self.adaptive_decode_calls = 0
+        self.blend_calls = 0
+        self.eval()
 
-    @staticmethod
-    def split_tiles(size: int, tiled: bool):
+    def split_tiles(self, size: int, tiled: bool):
         del size, tiled
-        return [0, 1], None, None
+        return list(range(self.tile_count)), None, None
 
-    def decode_base(
-        self,
-        latent: torch.Tensor,
-        *,
-        temporal_chunk_callback=None,
-    ) -> torch.Tensor:
+    def decode_base(self, latent: torch.Tensor) -> torch.Tensor:
         del latent
         self.decode_base_calls += 1
-        output = self.expected.clone()
-        if temporal_chunk_callback is None:
-            return output
+        return self.expected.clone()
 
-        frame_start = 0
-        for chunk_index, chunk_size in enumerate([17] * 7 + [5]):
-            if self.collective:
-                collective_probe = torch.tensor([chunk_index], dtype=torch.int32)
-                dist.all_reduce(collective_probe)
-            self.vendor_callback_calls += 1
-            metadata_index = chunk_index
-            metadata_total = 8
-            metadata_start = frame_start
-            is_final = chunk_index == 7
-            if self.metadata_mode == "gap" and chunk_index == 1:
-                metadata_start += 1
-            elif self.metadata_mode == "bad_total" and chunk_index == 1:
-                metadata_total += 1
-            elif self.metadata_mode == "no_final":
-                is_final = False
-            temporal_chunk_callback(
-                self.expected[:, :, frame_start : frame_start + chunk_size].clone(),
-                chunk_index=metadata_index,
-                total_chunks=metadata_total,
-                frame_start=metadata_start,
-                is_final=is_final,
-            )
-            frame_start += chunk_size
-        return output
+    def _adaptive_decode(self, latent: torch.Tensor) -> torch.Tensor:
+        del latent
+        call_index = self.adaptive_decode_calls % self.num_chunks
+        self.adaptive_decode_calls += 1
+        if self.collective and self.parallel_tiling:
+            collective_probe = torch.tensor([call_index], dtype=torch.int32)
+            dist.all_reduce(collective_probe)
+        decoded = torch.full((1, 3, 28, 1, 1), -1.0)
+        body_start = call_index * 17
+        decoded[:, :, 3:20].copy_(self.ideal[:, :, body_start : body_start + 17])
+        if call_index == self.num_chunks - 1:
+            decoded[:, :, 23:28].copy_(self.ideal[:, :, -5:])
+        return decoded
+
+    def _decode_temporal_output_frame_plan(
+        self,
+        latent: torch.Tensor,
+        head: torch.Tensor | None,
+        tail: torch.Tensor | None,
+        num_chunks: int,
+        pad_tokens: int,
+    ) -> tuple[int, int, int]:
+        del latent
+        assert head is None
+        assert tail is None
+        assert num_chunks == self.num_chunks
+        assert pad_tokens == self.pad_tokens
+        total_frames = num_chunks * 17 + 5
+        pad_frames = total_frames - int(self.expected.shape[2])
+        return total_frames, pad_frames, int(self.expected.shape[2])
+
+    def _decode_temporal_pad_frames(
+        self,
+        latent: torch.Tensor,
+        pad_tokens: int,
+    ) -> int:
+        del latent
+        assert pad_tokens == self.pad_tokens
+        return int(self.ideal.shape[2] - self.expected.shape[2])
+
+    def blend(
+        self,
+        previous: torch.Tensor,
+        current: torch.Tensor,
+        extent: int,
+        *,
+        dim: int,
+    ) -> torch.Tensor:
+        del previous
+        assert extent == self.frame_overlap
+        assert dim == -3
+        self.blend_calls += 1
+        return current
 
 
-def _vae(
+def _install_released_source_fingerprint() -> None:
+    temporal_chunks_module._source_bundle_sha256 = lambda model: (
+        "fake/video_vae",
+        MINIMAX_H3_RELEASED_BUNDLE_SHA256,
+    )
+
+
+def _allow_released_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        temporal_chunks_module,
+        "_source_bundle_sha256",
+        lambda model: (
+            "fake/video_vae",
+            MINIMAX_H3_RELEASED_BUNDLE_SHA256,
+        ),
+    )
+
+
+def _compat_vae(
+    latent_t: int,
     *,
     parallel_size: int = 1,
     collective: bool = False,
-    metadata_mode: str = "valid",
-) -> tuple[MiniMaxH3VideoVAE, _FakeVendorTemporalModel]:
+    tile_count: int = 2,
+) -> tuple[MiniMaxH3VideoVAE, _FakeCompatTemporalModel]:
     vae = object.__new__(MiniMaxH3VideoVAE)
     nn.Module.__init__(vae)
-    model = _FakeVendorTemporalModel(
+    model = _FakeCompatTemporalModel(
+        latent_t,
         collective=collective,
-        metadata_mode=metadata_mode,
+        tile_count=tile_count,
     )
     vae.model = model
     vae.config_dict = {
@@ -115,22 +185,57 @@ def _vae(
     return vae, model
 
 
-def _latent() -> torch.Tensor:
-    return torch.zeros(1, 3, 37, 1, 1)
+def _latent(latent_t: int = 37) -> torch.Tensor:
+    return torch.zeros(1, 3, latent_t, 1, 1)
 
 
-def test_default_decode_path_does_not_request_vendor_chunks() -> None:
-    vae, model = _vae()
+def test_default_decode_path_does_not_request_chunks() -> None:
+    vae, model = _compat_vae(37)
 
     output = vae.decode_latent(_latent())
 
     torch.testing.assert_close(output, model.expected, rtol=0, atol=0)
     assert model.decode_base_calls == 1
-    assert model.vendor_callback_calls == 0
+    assert model.adaptive_decode_calls == 0
 
 
-def test_callback_chunks_are_owned_and_reconstruct_the_full_decode() -> None:
-    vae, model = _vae()
+def test_default_decode_bypasses_compatibility_source_checks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vae, model = _compat_vae(37)
+    monkeypatch.setattr(
+        temporal_chunks_module,
+        "_source_bundle_sha256",
+        lambda model: pytest.fail("default decode fingerprinted remote code"),
+    )
+
+    output = vae.decode_latent(_latent())
+
+    torch.testing.assert_close(output, model.expected, rtol=0, atol=0)
+    assert model.decode_base_calls == 1
+    assert model.adaptive_decode_calls == 0
+
+
+@pytest.mark.parametrize(
+    ("latent_t", "expected_chunk_sizes"),
+    [
+        (37, [17] * 7 + [5]),
+        (62, [17] * 12 + [5]),
+        (72, [17] * 14 + [5]),
+        (107, [17] * 21 + [5]),
+        (36, [17] * 7 + [1]),
+        (35, [17] * 7),
+        (34, [17] * 6 + [13]),
+        (33, [17] * 6 + [9]),
+    ],
+)
+def test_released_compatibility_chunks_reconstruct_full_decode(
+    monkeypatch: pytest.MonkeyPatch,
+    latent_t: int,
+    expected_chunk_sizes: list[int],
+) -> None:
+    _allow_released_source(monkeypatch)
+    vae, model = _compat_vae(latent_t)
     chunks: list[torch.Tensor] = []
     snapshots: list[torch.Tensor] = []
     metadata: list[tuple[int, int, int, bool]] = []
@@ -150,18 +255,35 @@ def test_callback_chunks_are_owned_and_reconstruct_the_full_decode() -> None:
         snapshots.append(frames.clone())
         metadata.append((chunk_index, total_chunks, frame_start, is_final))
 
-    output = vae.decode_latent_with_chunks(_latent(), consume)
+    output = vae.decode_latent_with_chunks(_latent(latent_t), consume)
 
     torch.testing.assert_close(output, model.expected, rtol=0, atol=0)
     torch.testing.assert_close(torch.cat(chunks, dim=2), output, rtol=0, atol=0)
+    assert [int(chunk.shape[2]) for chunk in chunks] == expected_chunk_sizes
+    expected_metadata = []
+    frame_start = 0
+    for chunk_index, chunk_size in enumerate(expected_chunk_sizes):
+        expected_metadata.append(
+            (
+                chunk_index,
+                len(expected_chunk_sizes),
+                frame_start,
+                chunk_index == len(expected_chunk_sizes) - 1,
+            )
+        )
+        frame_start += chunk_size
+    assert metadata == expected_metadata
     for chunk, snapshot in zip(chunks, snapshots, strict=True):
         torch.testing.assert_close(chunk, snapshot, rtol=0, atol=0)
     assert len({chunk.untyped_storage().data_ptr() for chunk in chunks}) == len(chunks)
-    assert metadata == [(index, 8, index * 17, index == 7) for index in range(8)]
+    assert model.adaptive_decode_calls == model.num_chunks
 
 
-def test_callback_mutation_does_not_change_returned_full_output() -> None:
-    vae, model = _vae()
+def test_compat_callback_mutation_does_not_change_returned_full_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _allow_released_source(monkeypatch)
+    vae, model = _compat_vae(37)
 
     def mutate(frames: torch.Tensor, **metadata: Any) -> None:
         del metadata
@@ -172,29 +294,77 @@ def test_callback_mutation_does_not_change_returned_full_output() -> None:
     torch.testing.assert_close(output, model.expected, rtol=0, atol=0)
 
 
-def test_callback_failure_is_deferred_until_vendor_decode_finishes() -> None:
-    vae, model = _vae()
-    callback_calls = 0
+def test_compat_source_fingerprint_is_cached_after_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
 
-    def fail(*args, **kwargs) -> None:
-        nonlocal callback_calls
-        del args, kwargs
-        callback_calls += 1
-        raise LookupError("sink failed")
+    def fingerprint(model):
+        nonlocal calls
+        del model
+        calls += 1
+        return "fake/video_vae", MINIMAX_H3_RELEASED_BUNDLE_SHA256
 
-    with pytest.raises(LookupError, match="sink failed"):
-        vae.decode_latent_with_chunks(_latent(), fail)
+    monkeypatch.setattr(
+        temporal_chunks_module,
+        "_source_bundle_sha256",
+        fingerprint,
+    )
+    vae, model = _compat_vae(37)
 
-    assert callback_calls == 1
-    assert model.vendor_callback_calls == 8
-    torch.testing.assert_close(vae.decode_latent(_latent()), model.expected, rtol=0, atol=0)
+    for _ in range(2):
+        output = vae.decode_latent_with_chunks(
+            _latent(),
+            lambda *args, **kwargs: None,
+        )
+        torch.testing.assert_close(output, model.expected, rtol=0, atol=0)
+
+    assert calls == 1
 
 
-def test_terminal_callback_failure_preserves_the_original_exception() -> None:
-    vae, model = _vae()
-    seen: list[tuple[int, int, int, bool]] = []
+def test_compat_callback_publishes_after_temporal_blending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _allow_released_source(monkeypatch)
+    vae, model = _compat_vae(37)
+    chunks: list[torch.Tensor] = []
 
-    def fail_final(
+    def mark_overlap(
+        previous: torch.Tensor,
+        current: torch.Tensor,
+        extent: int,
+        *,
+        dim: int,
+    ) -> torch.Tensor:
+        del previous
+        assert extent == 5
+        assert dim == -3
+        blended = current.clone()
+        blended[:, :, :extent].fill_(0.25)
+        return blended
+
+    monkeypatch.setattr(model, "blend", mark_overlap)
+    output = vae.decode_latent_with_chunks(
+        _latent(),
+        lambda frames, **metadata: chunks.append(frames.clone()),
+    )
+
+    expected_overlap = torch.full_like(chunks[1][:, :, :5], 0.25)
+    torch.testing.assert_close(chunks[1][:, :, :5], expected_overlap, rtol=0, atol=0)
+    torch.testing.assert_close(output[:, :, 17:22], expected_overlap, rtol=0, atol=0)
+    torch.testing.assert_close(torch.cat(chunks, dim=2), output, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("fail_final", [False, True])
+def test_compat_callback_failure_finishes_decode_and_recovers(
+    monkeypatch: pytest.MonkeyPatch,
+    fail_final: bool,
+) -> None:
+    _allow_released_source(monkeypatch)
+    vae, model = _compat_vae(37)
+    seen: list[tuple[int, bool]] = []
+
+    def fail(
         frames: torch.Tensor,
         *,
         chunk_index: int,
@@ -202,46 +372,163 @@ def test_terminal_callback_failure_preserves_the_original_exception() -> None:
         frame_start: int,
         is_final: bool,
     ) -> None:
-        del frames
-        seen.append((chunk_index, total_chunks, frame_start, is_final))
-        if is_final:
-            raise LookupError("final sink failed")
+        del frames, total_chunks, frame_start
+        seen.append((chunk_index, is_final))
+        if is_final == fail_final:
+            raise LookupError("compat sink failed")
 
-    with pytest.raises(LookupError, match="final sink failed"):
-        vae.decode_latent_with_chunks(_latent(), fail_final)
+    with pytest.raises(LookupError, match="compat sink failed"):
+        vae.decode_latent_with_chunks(_latent(), fail)
 
-    assert seen == [(index, 8, index * 17, index == 7) for index in range(8)]
-    assert model.vendor_callback_calls == 8
+    assert model.adaptive_decode_calls == model.num_chunks
+    if fail_final:
+        assert seen == [(index, index == 7) for index in range(8)]
+    else:
+        assert seen == [(0, False)]
+
+    recovered_chunks: list[torch.Tensor] = []
+    recovered = vae.decode_latent_with_chunks(
+        _latent(),
+        lambda frames, **metadata: recovered_chunks.append(frames),
+    )
+    torch.testing.assert_close(recovered, model.expected, rtol=0, atol=0)
+    torch.testing.assert_close(
+        torch.cat(recovered_chunks, dim=2),
+        model.expected,
+        rtol=0,
+        atol=0,
+    )
+    assert model.adaptive_decode_calls == model.num_chunks * 2
+
+
+@pytest.mark.parametrize("drift", ["changed", "missing"])
+def test_compat_source_drift_fails_closed_before_decode(
+    monkeypatch: pytest.MonkeyPatch,
+    drift: str,
+) -> None:
+    _allow_released_source(monkeypatch)
+    if drift == "changed":
+        monkeypatch.setattr(
+            temporal_chunks_module,
+            "_source_bundle_sha256",
+            lambda model: ("fake/video_vae", "0" * 64),
+        )
+    else:
+        monkeypatch.setattr(
+            temporal_chunks_module,
+            "_source_bundle_sha256",
+            lambda model: (None, None),
+        )
+    vae, model = _compat_vae(37)
+
+    with pytest.raises(
+        MiniMaxH3ChunkedDecodeUnsupportedError,
+        match="42ed227e",
+    ):
+        vae.decode_latent_with_chunks(_latent(), lambda *args, **kwargs: None)
+
+    assert model.adaptive_decode_calls == 0
+    torch.testing.assert_close(vae.decode_latent(_latent()), model.expected, rtol=0, atol=0)
+
+
+def test_uninspectable_compat_source_maps_to_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        temporal_chunks_module.inspect,
+        "getsourcefile",
+        lambda object_type: (_ for _ in ()).throw(TypeError("no source")),
+    )
+    vae, model = _compat_vae(37)
+
+    with pytest.raises(MiniMaxH3ChunkedDecodeUnsupportedError, match="bundle=None"):
+        vae.decode_latent_with_chunks(_latent(), lambda *args, **kwargs: None)
+
+    assert model.adaptive_decode_calls == 0
+
+
+def test_source_bundle_manifest_is_deterministic_and_excludes_init(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    package = tmp_path / "video_vae"
+    package.mkdir()
+    (package / "z.py").write_text("z = 1\n", encoding="utf-8")
+    (package / "klvae.py").write_text("k = 2\n", encoding="utf-8")
+    (package / "a.py").write_text("a = 3\n", encoding="utf-8")
+    (package / "__init__.py").write_text("ignored = 1\n", encoding="utf-8")
+    monkeypatch.setattr(
+        temporal_chunks_module.inspect,
+        "getsourcefile",
+        lambda object_type: str(package / "klvae.py"),
+    )
+
+    expected = hashlib.sha256()
+    for filename in ("a.py", "klvae.py", "z.py"):
+        expected.update(filename.encode())
+        expected.update(b"\0")
+        expected.update((package / filename).read_bytes())
+        expected.update(b"\0")
+    _, first = temporal_chunks_module._source_bundle_sha256(nn.Linear(1, 1))
+    assert first == expected.hexdigest()
+
+    (package / "__init__.py").write_text("ignored = 2\n", encoding="utf-8")
+    _, after_init = temporal_chunks_module._source_bundle_sha256(nn.Linear(1, 1))
+    assert after_init == first
+    (package / "a.py").write_text("a = 4\n", encoding="utf-8")
+    _, after_change = temporal_chunks_module._source_bundle_sha256(nn.Linear(1, 1))
+    assert after_change != first
 
 
 @pytest.mark.parametrize(
-    ("metadata_mode", "message"),
+    ("attribute", "value"),
     [
-        ("gap", "discontinuous chunk metadata"),
-        ("bad_total", "discontinuous chunk metadata"),
-        ("no_final", "discontinuous chunk metadata"),
+        ("tokens_chunk_size", 6),
+        ("token_overlap", 1),
+        ("isolated_first_frame", True),
+        ("isolated_last_frame", True),
     ],
 )
-def test_adapter_rejects_a_broken_vendor_callback_contract(
-    metadata_mode: str,
-    message: str,
+def test_compat_config_drift_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    attribute: str,
+    value: object,
 ) -> None:
-    vae, model = _vae(metadata_mode=metadata_mode)
+    _allow_released_source(monkeypatch)
+    vae, model = _compat_vae(37)
+    setattr(model, attribute, value)
 
-    with pytest.raises(RuntimeError, match=message):
+    with pytest.raises(
+        MiniMaxH3ChunkedDecodeUnsupportedError,
+        match="released temporal configuration",
+    ):
         vae.decode_latent_with_chunks(_latent(), lambda *args, **kwargs: None)
 
-    assert model.vendor_callback_calls == 8
-
-
-def test_callback_request_fails_closed_without_the_vendor_api() -> None:
-    vae, model = _vae()
-    model.temporal_chunk_callback_api_version = -1
-
-    with pytest.raises(MiniMaxH3ChunkedDecodeUnsupportedError, match="official MiniMax"):
-        vae.decode_latent_with_chunks(_latent(), lambda *args, **kwargs: None)
-
+    assert model.adaptive_decode_calls == 0
     torch.testing.assert_close(vae.decode_latent(_latent()), model.expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("invalid", ["rank", "empty_time", "training", "non_3d"])
+def test_compat_structural_invalids_fail_before_decode(
+    monkeypatch: pytest.MonkeyPatch,
+    invalid: str,
+) -> None:
+    _allow_released_source(monkeypatch)
+    vae, model = _compat_vae(37)
+    latent = _latent()
+    if invalid == "rank":
+        latent = latent[:, :, 0]
+    elif invalid == "empty_time":
+        latent = latent[:, :, :0]
+    elif invalid == "training":
+        model.train()
+    else:
+        model.use_3d_conv = False
+
+    with pytest.raises(MiniMaxH3ChunkedDecodeUnsupportedError):
+        vae.decode_latent_with_chunks(latent, lambda *args, **kwargs: None)
+
+    assert model.adaptive_decode_calls == 0
 
 
 def _distributed_worker(
@@ -256,11 +543,105 @@ def _distributed_worker(
         world_size=2,
     )
     try:
-        vae, model = _vae(parallel_size=2, collective=True)
-        vae._native_parallel_state = MethodType(
-            lambda self: {"sp_process_group": dist.group.WORLD},
-            vae,
+        vae_module.get_data_parallel_world_size = lambda: 1
+        vae_module.model_parallel_is_initialized = lambda: True
+
+        def attach_group(vae: MiniMaxH3VideoVAE) -> None:
+            vae._native_parallel_state = MethodType(
+                lambda self: {"sp_process_group": dist.group.WORLD},
+                vae,
+            )
+
+        _install_released_source_fingerprint()
+        source_vae, source_model = _compat_vae(
+            37,
+            parallel_size=2,
+            collective=True,
         )
+        attach_group(source_vae)
+        if rank == 1:
+            temporal_chunks_module._source_bundle_sha256 = lambda model: (
+                "fake/video_vae",
+                "0" * 64,
+            )
+        try:
+            source_vae.decode_latent_with_chunks(
+                _latent(),
+                (lambda *args, **kwargs: None) if rank == 0 else None,
+            )
+        except BaseException as exc:  # noqa: BLE001
+            source_mismatch_type = type(exc).__name__
+        else:
+            source_mismatch_type = "none"
+        source_decode_calls = source_model.adaptive_decode_calls
+
+        _install_released_source_fingerprint()
+        planner_vae, planner_model = _compat_vae(
+            37,
+            parallel_size=2,
+            collective=True,
+        )
+        attach_group(planner_vae)
+        if rank == 1:
+
+            def fail_plan(self, *args, **kwargs):
+                del self, args, kwargs
+                raise RuntimeError("rank-local planner failed")
+
+            setattr(
+                planner_model,
+                "_decode_temporal_output_frame_plan",
+                MethodType(fail_plan, planner_model),
+            )
+        try:
+            planner_vae.decode_latent_with_chunks(
+                _latent(),
+                (lambda *args, **kwargs: None) if rank == 0 else None,
+            )
+        except BaseException as exc:  # noqa: BLE001
+            planner_failure_type = type(exc).__name__
+        else:
+            planner_failure_type = "none"
+        planner_decode_calls = planner_model.adaptive_decode_calls
+
+        dtype_vae, dtype_model = _compat_vae(
+            37,
+            parallel_size=2,
+            collective=True,
+        )
+        attach_group(dtype_vae)
+        temporal_chunks_module.resolve_minimax_h3_temporal_cat_dtype = (
+            (lambda model: torch.float16) if rank == 0 else (lambda model: None)
+        )
+        try:
+            dtype_vae.decode_latent_with_chunks(
+                _latent(),
+                (lambda *args, **kwargs: None) if rank == 0 else None,
+            )
+        except BaseException as exc:  # noqa: BLE001
+            dtype_mismatch_type = type(exc).__name__
+        else:
+            dtype_mismatch_type = "none"
+        dtype_decode_calls = dtype_model.adaptive_decode_calls
+        temporal_chunks_module.resolve_minimax_h3_temporal_cat_dtype = lambda model: None
+
+        vae_module.get_data_parallel_world_size = lambda: 2
+        dp_vae, dp_model = _compat_vae(37, parallel_size=2, collective=True)
+        attach_group(dp_vae)
+        try:
+            dp_vae.decode_latent_with_chunks(
+                _latent(),
+                (lambda *args, **kwargs: None) if rank == 0 else None,
+            )
+        except BaseException as exc:  # noqa: BLE001
+            dp_vae_type = type(exc).__name__
+        else:
+            dp_vae_type = "none"
+        dp_decode_calls = dp_model.adaptive_decode_calls
+        vae_module.get_data_parallel_world_size = lambda: 1
+
+        vae, model = _compat_vae(37, parallel_size=2, collective=True)
+        attach_group(vae)
 
         try:
             vae.decode_latent_with_chunks(
@@ -298,7 +679,26 @@ def _distributed_worker(
             succeed if rank == 0 else None,
         )
 
-        local_vae, local_model = _vae(parallel_size=1)
+        fallback_vae, fallback_model = _compat_vae(
+            37,
+            parallel_size=2,
+            collective=True,
+            tile_count=1,
+        )
+        attach_group(fallback_vae)
+        fallback_calls = 0
+
+        def consume_fallback(*args, **kwargs) -> None:
+            nonlocal fallback_calls
+            del args, kwargs
+            fallback_calls += 1
+
+        fallback_output = fallback_vae.decode_latent_with_chunks(
+            _latent(),
+            consume_fallback if rank == 0 else None,
+        )
+
+        local_vae, local_model = _compat_vae(37, parallel_size=1)
         local_calls = 0
 
         def consume_local(*args, **kwargs) -> None:
@@ -316,11 +716,26 @@ def _distributed_worker(
         result_queue.put(
             {
                 "rank": rank,
+                "source_mismatch_type": source_mismatch_type,
+                "source_decode_calls": source_decode_calls,
+                "planner_failure_type": planner_failure_type,
+                "planner_decode_calls": planner_decode_calls,
+                "dtype_mismatch_type": dtype_mismatch_type,
+                "dtype_decode_calls": dtype_decode_calls,
+                "dp_vae_type": dp_vae_type,
+                "dp_decode_calls": dp_decode_calls,
                 "invalid_owner_type": invalid_owner_type,
                 "failure_type": failure_type,
-                "vendor_calls": model.vendor_callback_calls,
+                "adaptive_calls": model.adaptive_decode_calls,
                 "success_calls": success_calls,
                 "output_matches": torch.equal(output, model.expected),
+                "fallback_calls": fallback_calls,
+                "fallback_decode_calls": fallback_model.adaptive_decode_calls,
+                "fallback_output_matches": torch.equal(
+                    fallback_output,
+                    fallback_model.expected,
+                ),
+                "fallback_tiling_restored": fallback_model.parallel_tiling,
                 "local_calls": local_calls,
                 "local_output_matches": torch.equal(local_output, local_model.expected),
                 "recovery": int(recovery.item()),
@@ -367,13 +782,37 @@ def test_two_rank_callback_failure_is_symmetric_and_group_recovers(
         "LookupError",
         MiniMaxH3ChunkCallbackPeerError.__name__,
     ]
+    assert [result["source_mismatch_type"] for result in results] == [
+        MiniMaxH3ChunkedDecodeUnsupportedError.__name__,
+        MiniMaxH3ChunkedDecodeUnsupportedError.__name__,
+    ]
+    assert [result["source_decode_calls"] for result in results] == [0, 0]
+    assert [result["planner_failure_type"] for result in results] == [
+        MiniMaxH3ChunkedDecodeUnsupportedError.__name__,
+        "RuntimeError",
+    ]
+    assert [result["planner_decode_calls"] for result in results] == [0, 0]
+    assert [result["dtype_mismatch_type"] for result in results] == [
+        MiniMaxH3ChunkedDecodeUnsupportedError.__name__,
+        MiniMaxH3ChunkedDecodeUnsupportedError.__name__,
+    ]
+    assert [result["dtype_decode_calls"] for result in results] == [0, 0]
+    assert [result["dp_vae_type"] for result in results] == [
+        MiniMaxH3ChunkedDecodeUnsupportedError.__name__,
+        MiniMaxH3ChunkedDecodeUnsupportedError.__name__,
+    ]
+    assert [result["dp_decode_calls"] for result in results] == [0, 0]
     assert [result["invalid_owner_type"] for result in results] == [
         "ValueError",
         "ValueError",
     ]
-    assert [result["vendor_calls"] for result in results] == [16, 16]
+    assert [result["adaptive_calls"] for result in results] == [14, 14]
     assert [result["success_calls"] for result in results] == [8, 0]
     assert all(result["output_matches"] for result in results)
+    assert [result["fallback_calls"] for result in results] == [8, 0]
+    assert [result["fallback_decode_calls"] for result in results] == [7, 7]
+    assert all(result["fallback_output_matches"] for result in results)
+    assert all(result["fallback_tiling_restored"] for result in results)
     # With VAE parallelism disabled, the caller still designates one request owner.
     assert [result["local_calls"] for result in results] == [8, 0]
     assert all(result["local_output_matches"] for result in results)

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_vae_chunks.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_vae_chunks.py
@@ -1,0 +1,380 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import time
+from pathlib import Path
+from types import MethodType
+from typing import Any
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+from vllm_omni.diffusion.models.minimax_h3.vae import (
+    MiniMaxH3ChunkCallbackPeerError,
+    MiniMaxH3ChunkedDecodeUnsupportedError,
+    MiniMaxH3VideoVAE,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+class _IdentityProcessor:
+    @staticmethod
+    def revert_tensor(tensor: torch.Tensor) -> torch.Tensor:
+        return tensor
+
+
+class _FakeVendorTemporalModel(nn.Module):
+    temporal_chunk_callback_api_version = 1
+    vae_ratio = 1
+
+    def __init__(
+        self,
+        *,
+        collective: bool = False,
+        metadata_mode: str = "valid",
+    ) -> None:
+        super().__init__()
+        values = torch.linspace(0, 1, 124).view(1, 1, 124, 1, 1)
+        self.expected = values.expand(1, 3, -1, 1, 1).contiguous()
+        self.processor = _IdentityProcessor()
+        self.parallel_tiling = collective
+        self.collective = collective
+        self.metadata_mode = metadata_mode
+        self.decode_base_calls = 0
+        self.vendor_callback_calls = 0
+
+    @staticmethod
+    def split_tiles(size: int, tiled: bool):
+        del size, tiled
+        return [0, 1], None, None
+
+    def decode_base(
+        self,
+        latent: torch.Tensor,
+        *,
+        temporal_chunk_callback=None,
+    ) -> torch.Tensor:
+        del latent
+        self.decode_base_calls += 1
+        output = self.expected.clone()
+        if temporal_chunk_callback is None:
+            return output
+
+        frame_start = 0
+        for chunk_index, chunk_size in enumerate([17] * 7 + [5]):
+            if self.collective:
+                collective_probe = torch.tensor([chunk_index], dtype=torch.int32)
+                dist.all_reduce(collective_probe)
+            self.vendor_callback_calls += 1
+            metadata_index = chunk_index
+            metadata_total = 8
+            metadata_start = frame_start
+            is_final = chunk_index == 7
+            if self.metadata_mode == "gap" and chunk_index == 1:
+                metadata_start += 1
+            elif self.metadata_mode == "bad_total" and chunk_index == 1:
+                metadata_total += 1
+            elif self.metadata_mode == "no_final":
+                is_final = False
+            temporal_chunk_callback(
+                self.expected[:, :, frame_start : frame_start + chunk_size].clone(),
+                chunk_index=metadata_index,
+                total_chunks=metadata_total,
+                frame_start=metadata_start,
+                is_final=is_final,
+            )
+            frame_start += chunk_size
+        return output
+
+
+def _vae(
+    *,
+    parallel_size: int = 1,
+    collective: bool = False,
+    metadata_mode: str = "valid",
+) -> tuple[MiniMaxH3VideoVAE, _FakeVendorTemporalModel]:
+    vae = object.__new__(MiniMaxH3VideoVAE)
+    nn.Module.__init__(vae)
+    model = _FakeVendorTemporalModel(
+        collective=collective,
+        metadata_mode=metadata_mode,
+    )
+    vae.model = model
+    vae.config_dict = {
+        "latent_channels": 3,
+        "latents_mean": [0.0, 0.0, 0.0],
+        "latents_std": [1.0, 1.0, 1.0],
+    }
+    vae.parallel_size = parallel_size
+    return vae, model
+
+
+def _latent() -> torch.Tensor:
+    return torch.zeros(1, 3, 37, 1, 1)
+
+
+def test_default_decode_path_does_not_request_vendor_chunks() -> None:
+    vae, model = _vae()
+
+    output = vae.decode_latent(_latent())
+
+    torch.testing.assert_close(output, model.expected, rtol=0, atol=0)
+    assert model.decode_base_calls == 1
+    assert model.vendor_callback_calls == 0
+
+
+def test_callback_chunks_are_owned_and_reconstruct_the_full_decode() -> None:
+    vae, model = _vae()
+    chunks: list[torch.Tensor] = []
+    snapshots: list[torch.Tensor] = []
+    metadata: list[tuple[int, int, int, bool]] = []
+
+    def consume(
+        frames: torch.Tensor,
+        *,
+        chunk_index: int,
+        total_chunks: int,
+        frame_start: int,
+        is_final: bool,
+    ) -> None:
+        assert frames.dtype is torch.float32
+        assert frames.is_contiguous()
+        assert torch.all((0 <= frames) & (frames <= 1))
+        chunks.append(frames)
+        snapshots.append(frames.clone())
+        metadata.append((chunk_index, total_chunks, frame_start, is_final))
+
+    output = vae.decode_latent_with_chunks(_latent(), consume)
+
+    torch.testing.assert_close(output, model.expected, rtol=0, atol=0)
+    torch.testing.assert_close(torch.cat(chunks, dim=2), output, rtol=0, atol=0)
+    for chunk, snapshot in zip(chunks, snapshots, strict=True):
+        torch.testing.assert_close(chunk, snapshot, rtol=0, atol=0)
+    assert len({chunk.untyped_storage().data_ptr() for chunk in chunks}) == len(chunks)
+    assert metadata == [(index, 8, index * 17, index == 7) for index in range(8)]
+
+
+def test_callback_mutation_does_not_change_returned_full_output() -> None:
+    vae, model = _vae()
+
+    def mutate(frames: torch.Tensor, **metadata: Any) -> None:
+        del metadata
+        frames.fill_(1234)
+
+    output = vae.decode_latent_with_chunks(_latent(), mutate)
+
+    torch.testing.assert_close(output, model.expected, rtol=0, atol=0)
+
+
+def test_callback_failure_is_deferred_until_vendor_decode_finishes() -> None:
+    vae, model = _vae()
+    callback_calls = 0
+
+    def fail(*args, **kwargs) -> None:
+        nonlocal callback_calls
+        del args, kwargs
+        callback_calls += 1
+        raise LookupError("sink failed")
+
+    with pytest.raises(LookupError, match="sink failed"):
+        vae.decode_latent_with_chunks(_latent(), fail)
+
+    assert callback_calls == 1
+    assert model.vendor_callback_calls == 8
+    torch.testing.assert_close(vae.decode_latent(_latent()), model.expected, rtol=0, atol=0)
+
+
+def test_terminal_callback_failure_preserves_the_original_exception() -> None:
+    vae, model = _vae()
+    seen: list[tuple[int, int, int, bool]] = []
+
+    def fail_final(
+        frames: torch.Tensor,
+        *,
+        chunk_index: int,
+        total_chunks: int,
+        frame_start: int,
+        is_final: bool,
+    ) -> None:
+        del frames
+        seen.append((chunk_index, total_chunks, frame_start, is_final))
+        if is_final:
+            raise LookupError("final sink failed")
+
+    with pytest.raises(LookupError, match="final sink failed"):
+        vae.decode_latent_with_chunks(_latent(), fail_final)
+
+    assert seen == [(index, 8, index * 17, index == 7) for index in range(8)]
+    assert model.vendor_callback_calls == 8
+
+
+@pytest.mark.parametrize(
+    ("metadata_mode", "message"),
+    [
+        ("gap", "discontinuous chunk metadata"),
+        ("bad_total", "discontinuous chunk metadata"),
+        ("no_final", "discontinuous chunk metadata"),
+    ],
+)
+def test_adapter_rejects_a_broken_vendor_callback_contract(
+    metadata_mode: str,
+    message: str,
+) -> None:
+    vae, model = _vae(metadata_mode=metadata_mode)
+
+    with pytest.raises(RuntimeError, match=message):
+        vae.decode_latent_with_chunks(_latent(), lambda *args, **kwargs: None)
+
+    assert model.vendor_callback_calls == 8
+
+
+def test_callback_request_fails_closed_without_the_vendor_api() -> None:
+    vae, model = _vae()
+    model.temporal_chunk_callback_api_version = -1
+
+    with pytest.raises(MiniMaxH3ChunkedDecodeUnsupportedError, match="official MiniMax"):
+        vae.decode_latent_with_chunks(_latent(), lambda *args, **kwargs: None)
+
+    torch.testing.assert_close(vae.decode_latent(_latent()), model.expected, rtol=0, atol=0)
+
+
+def _distributed_worker(
+    rank: int,
+    init_file: str,
+    result_queue: Any,
+) -> None:
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=2,
+    )
+    try:
+        vae, model = _vae(parallel_size=2, collective=True)
+        vae._native_parallel_state = MethodType(
+            lambda self: {"sp_process_group": dist.group.WORLD},
+            vae,
+        )
+
+        try:
+            vae.decode_latent_with_chunks(
+                _latent(),
+                lambda *args, **kwargs: None,
+            )
+        except BaseException as exc:  # noqa: BLE001
+            invalid_owner_type = type(exc).__name__
+        else:
+            invalid_owner_type = "none"
+
+        def fail(*args, **kwargs) -> None:
+            del args, kwargs
+            raise LookupError("distributed sink failed")
+
+        try:
+            vae.decode_latent_with_chunks(
+                _latent(),
+                fail if rank == 0 else None,
+            )
+        except BaseException as exc:  # noqa: BLE001
+            failure_type = type(exc).__name__
+        else:
+            failure_type = "none"
+
+        success_calls = 0
+
+        def succeed(*args, **kwargs) -> None:
+            nonlocal success_calls
+            del args, kwargs
+            success_calls += 1
+
+        output = vae.decode_latent_with_chunks(
+            _latent(),
+            succeed if rank == 0 else None,
+        )
+
+        local_vae, local_model = _vae(parallel_size=1)
+        local_calls = 0
+
+        def consume_local(*args, **kwargs) -> None:
+            nonlocal local_calls
+            del args, kwargs
+            local_calls += 1
+
+        local_output = local_vae.decode_latent_with_chunks(
+            _latent(),
+            consume_local if rank == 0 else None,
+        )
+
+        recovery = torch.tensor([rank + 1], dtype=torch.int32)
+        dist.all_reduce(recovery)
+        result_queue.put(
+            {
+                "rank": rank,
+                "invalid_owner_type": invalid_owner_type,
+                "failure_type": failure_type,
+                "vendor_calls": model.vendor_callback_calls,
+                "success_calls": success_calls,
+                "output_matches": torch.equal(output, model.expected),
+                "local_calls": local_calls,
+                "local_output_matches": torch.equal(local_output, local_model.expected),
+                "recovery": int(recovery.item()),
+            }
+        )
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.parallel
+def test_two_rank_callback_failure_is_symmetric_and_group_recovers(
+    tmp_path: Path,
+) -> None:
+    context = mp.get_context("spawn")
+    result_queue = context.Queue()
+    init_file = str(tmp_path / "gloo-init")
+    processes = [
+        context.Process(
+            target=_distributed_worker,
+            args=(rank, init_file, result_queue),
+        )
+        for rank in range(2)
+    ]
+    for process in processes:
+        process.start()
+    deadline = time.monotonic() + 90
+    for process in processes:
+        process.join(timeout=max(0, deadline - time.monotonic()))
+    for process in processes:
+        if process.is_alive():
+            process.join(timeout=1)
+    hung = [process for process in processes if process.is_alive()]
+    for process in hung:
+        process.terminate()
+        process.join(timeout=5)
+    assert not hung, "two-rank chunk callback test deadlocked"
+    assert [process.exitcode for process in processes] == [0, 0]
+
+    results = sorted(
+        [result_queue.get(timeout=5) for _ in range(2)],
+        key=lambda result: result["rank"],
+    )
+    assert [result["failure_type"] for result in results] == [
+        "LookupError",
+        MiniMaxH3ChunkCallbackPeerError.__name__,
+    ]
+    assert [result["invalid_owner_type"] for result in results] == [
+        "ValueError",
+        "ValueError",
+    ]
+    assert [result["vendor_calls"] for result in results] == [16, 16]
+    assert [result["success_calls"] for result in results] == [8, 0]
+    assert all(result["output_matches"] for result in results)
+    # With VAE parallelism disabled, the caller still designates one request owner.
+    assert [result["local_calls"] for result in results] == [8, 0]
+    assert all(result["local_output_matches"] for result in results)
+    assert [result["recovery"] for result in results] == [3, 3]

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_vae_chunks.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_vae_chunks.py
@@ -402,6 +402,29 @@ def test_compat_callback_failure_finishes_decode_and_recovers(
     assert model.adaptive_decode_calls == model.num_chunks * 2
 
 
+def test_native_decoder_failure_propagates_on_single_rank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _allow_released_source(monkeypatch)
+    vae, model = _compat_vae(37)
+    callback_calls = 0
+
+    def fail_decode(latent: torch.Tensor) -> torch.Tensor:
+        del latent
+        raise LookupError("native decoder failed")
+
+    def consume(*args, **kwargs) -> None:
+        nonlocal callback_calls
+        del args, kwargs
+        callback_calls += 1
+
+    monkeypatch.setattr(model, "_adaptive_decode", fail_decode)
+    with pytest.raises(LookupError, match="native decoder failed"):
+        vae.decode_latent_with_chunks(_latent(), consume)
+
+    assert callback_calls == 0
+
+
 @pytest.mark.parametrize("drift", ["changed", "missing"])
 def test_compat_source_drift_fails_closed_before_decode(
     monkeypatch: pytest.MonkeyPatch,
@@ -744,6 +767,98 @@ def _distributed_worker(
         )
     finally:
         dist.destroy_process_group()
+
+
+def _wrong_owner_worker(
+    rank: int,
+    init_file: str,
+    result_queue: Any,
+) -> None:
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=3,
+    )
+    try:
+        vae_module.get_data_parallel_world_size = lambda: 1
+        vae_module.model_parallel_is_initialized = lambda: True
+        _install_released_source_fingerprint()
+        vae, model = _compat_vae(
+            37,
+            parallel_size=3,
+            collective=True,
+            tile_count=3,
+        )
+        vae._native_parallel_state = MethodType(
+            lambda self: {"sp_process_group": dist.group.WORLD},
+            vae,
+        )
+
+        try:
+            vae.decode_latent_with_chunks(
+                _latent(),
+                (lambda *args, **kwargs: None) if rank == 1 else None,
+            )
+        except BaseException as exc:  # noqa: BLE001
+            failure_type = type(exc).__name__
+        else:
+            failure_type = "none"
+
+        recovery = torch.tensor([rank + 1], dtype=torch.int32)
+        dist.all_reduce(recovery)
+        result_queue.put(
+            {
+                "rank": rank,
+                "failure_type": failure_type,
+                "adaptive_calls": model.adaptive_decode_calls,
+                "recovery": int(recovery.item()),
+            }
+        )
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.parallel
+def test_three_rank_wrong_callback_owner_is_symmetric_and_group_recovers(
+    tmp_path: Path,
+) -> None:
+    context = mp.get_context("spawn")
+    result_queue = context.Queue()
+    init_file = str(tmp_path / "gloo-wrong-owner-init")
+    processes = [
+        context.Process(
+            target=_wrong_owner_worker,
+            args=(rank, init_file, result_queue),
+        )
+        for rank in range(3)
+    ]
+    for process in processes:
+        process.start()
+    deadline = time.monotonic() + 90
+    for process in processes:
+        process.join(timeout=max(0, deadline - time.monotonic()))
+    for process in processes:
+        if process.is_alive():
+            process.join(timeout=1)
+    hung = [process for process in processes if process.is_alive()]
+    for process in hung:
+        process.terminate()
+        process.join(timeout=5)
+    assert not hung, "three-rank callback-owner validation deadlocked"
+    assert [process.exitcode for process in processes] == [0, 0, 0]
+
+    results = sorted(
+        [result_queue.get(timeout=5) for _ in range(3)],
+        key=lambda result: result["rank"],
+    )
+    assert [result["failure_type"] for result in results] == [
+        "ValueError",
+        "ValueError",
+        "ValueError",
+    ]
+    assert [result["adaptive_calls"] for result in results] == [0, 0, 0]
+    assert [result["recovery"] for result in results] == [6, 6, 6]
 
 
 @pytest.mark.parallel

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_vae_chunks.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_vae_chunks.py
@@ -182,6 +182,7 @@ def _compat_vae(
         "latents_std": [1.0, 1.0, 1.0],
     }
     vae.parallel_size = parallel_size
+    vae._chunk_decode_coordinator = None
     return vae, model
 
 

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_vae_chunks.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_vae_chunks.py
@@ -769,6 +769,55 @@ def _distributed_worker(
         dist.destroy_process_group()
 
 
+def _mismatched_plan_worker(
+    rank: int,
+    init_file: str,
+    result_queue: Any,
+) -> None:
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=2,
+    )
+    try:
+        vae_module.get_data_parallel_world_size = lambda: 1
+        vae_module.model_parallel_is_initialized = lambda: True
+        _install_released_source_fingerprint()
+
+        vae, model = _compat_vae(
+            37 if rank == 0 else 62,
+            parallel_size=2,
+            collective=True,
+        )
+        vae._native_parallel_state = MethodType(
+            lambda self: {"sp_process_group": dist.group.WORLD},
+            vae,
+        )
+        try:
+            vae.decode_latent_with_chunks(
+                _latent(37 if rank == 0 else 62),
+                (lambda *args, **kwargs: None) if rank == 0 else None,
+            )
+        except BaseException as exc:  # noqa: BLE001
+            failure_type = type(exc).__name__
+        else:
+            failure_type = "none"
+
+        recovery = torch.tensor([rank + 1], dtype=torch.int32)
+        dist.all_reduce(recovery)
+        result_queue.put(
+            {
+                "rank": rank,
+                "failure_type": failure_type,
+                "adaptive_calls": model.adaptive_decode_calls,
+                "recovery": int(recovery.item()),
+            }
+        )
+    finally:
+        dist.destroy_process_group()
+
+
 def _wrong_owner_worker(
     rank: int,
     init_file: str,
@@ -859,6 +908,47 @@ def test_three_rank_wrong_callback_owner_is_symmetric_and_group_recovers(
     ]
     assert [result["adaptive_calls"] for result in results] == [0, 0, 0]
     assert [result["recovery"] for result in results] == [6, 6, 6]
+
+
+@pytest.mark.parallel
+def test_two_rank_mismatched_decode_plans_fail_before_decoder_collectives(
+    tmp_path: Path,
+) -> None:
+    context = mp.get_context("spawn")
+    result_queue = context.Queue()
+    init_file = str(tmp_path / "gloo-mismatched-plan-init")
+    processes = [
+        context.Process(
+            target=_mismatched_plan_worker,
+            args=(rank, init_file, result_queue),
+        )
+        for rank in range(2)
+    ]
+    for process in processes:
+        process.start()
+    deadline = time.monotonic() + 90
+    for process in processes:
+        process.join(timeout=max(0, deadline - time.monotonic()))
+    for process in processes:
+        if process.is_alive():
+            process.join(timeout=1)
+    hung = [process for process in processes if process.is_alive()]
+    for process in hung:
+        process.terminate()
+        process.join(timeout=5)
+    assert not hung, "mismatched MiniMax-H3 decode plans deadlocked"
+    assert [process.exitcode for process in processes] == [0, 0]
+
+    results = sorted(
+        [result_queue.get(timeout=5) for _ in range(2)],
+        key=lambda result: result["rank"],
+    )
+    assert [result["failure_type"] for result in results] == [
+        MiniMaxH3ChunkedDecodeUnsupportedError.__name__,
+        MiniMaxH3ChunkedDecodeUnsupportedError.__name__,
+    ]
+    assert [result["adaptive_calls"] for result in results] == [0, 0]
+    assert [result["recovery"] for result in results] == [3, 3]
 
 
 @pytest.mark.parallel

--- a/vllm_omni/diffusion/models/minimax_h3/chunked_decode.py
+++ b/vllm_omni/diffusion/models/minimax_h3/chunked_decode.py
@@ -1,0 +1,316 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Model-local coordination for MiniMax H3 temporal chunk decoding.
+
+This boundary owns released-code compatibility and VAE-group failure semantics.
+Cropping, representation conversion, transport, and encoding remain runtime
+responsibilities.
+"""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from typing import Protocol
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+from .temporal_chunks import (
+    MiniMaxH3TemporalChunkCompatibilityError,
+    MiniMaxH3TemporalDecodePlan,
+    decode_minimax_h3_temporal_chunks_compat,
+    prepare_minimax_h3_temporal_chunks_compat,
+)
+
+
+class MiniMaxH3VideoChunkCallback(Protocol):
+    """Consume one ordered, temporally committed H3 video chunk.
+
+    ``frames`` is an owned, contiguous float32 RGB tensor in ``BCTHW`` layout
+    and the ``[0, 1]`` value range. The callback runs synchronously on the
+    producer's current device stream. Before reading it on another stream, the
+    consumer must establish ordering from the producer stream (for example via
+    an event) and retain the allocation for that stream's lifetime.
+    """
+
+    def __call__(
+        self,
+        frames: torch.Tensor,
+        *,
+        chunk_index: int,
+        total_chunks: int,
+        frame_start: int,
+        is_final: bool,
+    ) -> None: ...
+
+
+class MiniMaxH3ChunkedDecodeUnsupportedError(RuntimeError):
+    """Raised when loaded MiniMax H3 code cannot honor the chunk contract."""
+
+
+class MiniMaxH3ChunkCallbackPeerError(RuntimeError):
+    """Raised on peer VAE ranks when the output-rank callback fails."""
+
+
+class _MiniMaxH3ChunkDecodeHost(Protocol):
+    """Narrow VAE capabilities required by the chunk coordinator."""
+
+    model: nn.Module
+
+    def _denormalize_latent(self, latent: torch.Tensor) -> torch.Tensor: ...
+
+    def _decode_tiling_context(
+        self,
+        latent: torch.Tensor,
+    ) -> AbstractContextManager: ...
+
+    def _normalize_decoded_frames(
+        self,
+        decoded: torch.Tensor,
+    ) -> torch.Tensor: ...
+
+
+class _MiniMaxH3ChunkDecodeCoordinator:
+    """Run source-gated chunk decode with group-local failure semantics.
+
+    The coordinator is a plain Python object. It caches only successful source
+    validation; request callbacks, tensors, metadata, and process groups remain
+    local to :meth:`decode`.
+    """
+
+    def __init__(self) -> None:
+        self._sources_validated = False
+
+    @staticmethod
+    def _is_output_rank(
+        chunk_callback: MiniMaxH3VideoChunkCallback | None,
+        *,
+        group: dist.ProcessGroup | None,
+        device: torch.device,
+    ) -> bool:
+        if group is None:
+            return chunk_callback is not None
+
+        group_rank = dist.get_rank(group)
+        callback_owners = torch.tensor(
+            [int(chunk_callback is not None)],
+            dtype=torch.int32,
+            device=device,
+        )
+        dist.all_reduce(callback_owners, group=group)
+        valid_owner = int(callback_owners.item()) == 1 and ((group_rank == 0) == (chunk_callback is not None))
+        if not valid_owner:
+            raise ValueError("MiniMax-H3 chunk decode requires a callback on exactly VAE group rank 0")
+        return group_rank == 0
+
+    @staticmethod
+    def _synchronize_callback_error(
+        callback_error: BaseException | None,
+        *,
+        group: dist.ProcessGroup | None,
+        device: torch.device,
+    ) -> None:
+        if group is None:
+            if callback_error is not None:
+                raise callback_error
+            return
+
+        is_output_rank = dist.get_rank(group) == 0
+        failed = torch.tensor(
+            [int(is_output_rank and callback_error is not None)],
+            dtype=torch.int32,
+            device=device,
+        )
+        dist.broadcast(
+            failed,
+            src=dist.get_global_rank(group, 0),
+            group=group,
+        )
+        if int(failed.item()) == 0:
+            return
+        if is_output_rank:
+            assert callback_error is not None
+            raise callback_error
+        raise MiniMaxH3ChunkCallbackPeerError("MiniMax-H3 video chunk callback failed on this VAE group's output rank")
+
+    @staticmethod
+    def _synchronize_preflight_error(
+        preflight_error: Exception | None,
+        temporal_dtype: torch.dtype | None,
+        *,
+        group: dist.ProcessGroup | None,
+        device: torch.device,
+    ) -> None:
+        if group is None:
+            if preflight_error is not None:
+                raise preflight_error
+            return
+        failed = torch.tensor(
+            [int(preflight_error is not None)],
+            dtype=torch.int32,
+            device=device,
+        )
+        dist.all_reduce(failed, op=dist.ReduceOp.MAX, group=group)
+        if int(failed.item()) == 0:
+            dtype_codes = {
+                None: 0,
+                torch.float16: 1,
+                torch.bfloat16: 2,
+                torch.float32: 3,
+            }
+            code = torch.tensor(
+                [dtype_codes.get(temporal_dtype, -1)],
+                dtype=torch.int32,
+                device=device,
+            )
+            lowest = code.clone()
+            highest = code.clone()
+            dist.all_reduce(lowest, op=dist.ReduceOp.MIN, group=group)
+            dist.all_reduce(highest, op=dist.ReduceOp.MAX, group=group)
+            if int(lowest.item()) == int(highest.item()) and int(lowest.item()) >= 0:
+                return
+            raise MiniMaxH3ChunkedDecodeUnsupportedError(
+                "MiniMax-H3 VAE ranks selected incompatible temporal concat dtypes"
+            )
+        if preflight_error is not None:
+            raise preflight_error
+        raise MiniMaxH3ChunkedDecodeUnsupportedError("A peer VAE rank rejected the MiniMax-H3 temporal chunk preflight")
+
+    def decode(
+        self,
+        host: _MiniMaxH3ChunkDecodeHost,
+        latent: torch.Tensor,
+        chunk_callback: MiniMaxH3VideoChunkCallback | None,
+        *,
+        group: dist.ProcessGroup | None,
+    ) -> torch.Tensor:
+        """Decode one latent while publishing committed normalized chunks."""
+
+        plan: MiniMaxH3TemporalDecodePlan | None = None
+        preflight_error: Exception | None = None
+        if latent.ndim != 5:
+            preflight_error = MiniMaxH3ChunkedDecodeUnsupportedError(
+                f"MiniMax-H3 video latent must be rank 5, got {tuple(latent.shape)}"
+            )
+        else:
+            try:
+                denormalized = host._denormalize_latent(latent)
+                plan = prepare_minimax_h3_temporal_chunks_compat(
+                    host.model,
+                    denormalized,
+                    validate_sources=not self._sources_validated,
+                )
+                self._sources_validated = True
+                del denormalized
+            except MiniMaxH3TemporalChunkCompatibilityError as exc:
+                preflight_error = MiniMaxH3ChunkedDecodeUnsupportedError(str(exc))
+            except Exception as exc:  # noqa: BLE001
+                # Every VAE rank must reach the preflight reduction even when
+                # one node's private planner or environment fails locally.
+                exc.__traceback__ = None
+                preflight_error = exc
+        self._synchronize_preflight_error(
+            preflight_error,
+            plan.temporal_dtype if plan is not None else None,
+            group=group,
+            device=latent.device,
+        )
+        assert plan is not None
+        is_output_rank = self._is_output_rank(
+            chunk_callback,
+            group=group,
+            device=latent.device,
+        )
+        callback_error: BaseException | None = None
+        next_chunk_index = 0
+        expected_total_chunks: int | None = None
+        next_frame_start = 0
+        saw_final = False
+
+        def publish(
+            decoded_chunk: torch.Tensor,
+            *,
+            chunk_index: int,
+            total_chunks: int,
+            frame_start: int,
+            is_final: bool,
+        ) -> None:
+            nonlocal callback_error, expected_total_chunks
+            nonlocal next_chunk_index, next_frame_start, saw_final
+            if not is_output_rank or callback_error is not None:
+                return
+            try:
+                if expected_total_chunks is None:
+                    expected_total_chunks = total_chunks
+                if (
+                    saw_final
+                    or total_chunks <= 0
+                    or total_chunks != expected_total_chunks
+                    or chunk_index != next_chunk_index
+                    or chunk_index >= total_chunks
+                    or frame_start != next_frame_start
+                    or is_final != (chunk_index + 1 == total_chunks)
+                ):
+                    raise RuntimeError(
+                        "MiniMax-H3 temporal backend emitted discontinuous "
+                        "chunk metadata: "
+                        f"index={chunk_index}/{next_chunk_index}, "
+                        f"total={total_chunks}/{expected_total_chunks}, "
+                        f"frame_start={frame_start}/{next_frame_start}, "
+                        f"final={is_final}, after_final={saw_final}"
+                    )
+                frames = host._normalize_decoded_frames(decoded_chunk)
+                frames = frames.clone(memory_format=torch.contiguous_format)
+                frame_count = int(frames.shape[2])
+                if frame_count <= 0:
+                    raise RuntimeError("MiniMax-H3 temporal backend emitted an empty chunk")
+                next_chunk_index += 1
+                next_frame_start += frame_count
+                saw_final = is_final
+                assert chunk_callback is not None
+                chunk_callback(
+                    frames,
+                    chunk_index=chunk_index,
+                    total_chunks=total_chunks,
+                    frame_start=frame_start,
+                    is_final=is_final,
+                )
+            except BaseException as exc:  # noqa: BLE001
+                # Keep a failed GPU chunk and its callback locals out of the
+                # traceback while peer ranks finish the remaining collectives.
+                exc.__traceback__ = None
+                callback_error = exc
+
+        with host._decode_tiling_context(latent):
+            decoded = decode_minimax_h3_temporal_chunks_compat(
+                host.model,
+                plan,
+                publish,
+            )
+        frames = host._normalize_decoded_frames(decoded)
+        if (
+            is_output_rank
+            and callback_error is None
+            and (not saw_final or next_chunk_index != expected_total_chunks or next_frame_start != int(frames.shape[2]))
+        ):
+            callback_error = RuntimeError(
+                "MiniMax-H3 temporal backend did not reconstruct the full "
+                "decode: "
+                f"final={saw_final}, "
+                f"chunks={next_chunk_index}/{expected_total_chunks}, "
+                f"frames={next_frame_start}/{frames.shape[2]}"
+            )
+        self._synchronize_callback_error(
+            callback_error,
+            group=group,
+            device=frames.device,
+        )
+        return frames
+
+
+__all__ = [
+    "MiniMaxH3ChunkCallbackPeerError",
+    "MiniMaxH3ChunkedDecodeUnsupportedError",
+    "MiniMaxH3VideoChunkCallback",
+]

--- a/vllm_omni/diffusion/models/minimax_h3/chunked_decode.py
+++ b/vllm_omni/diffusion/models/minimax_h3/chunked_decode.py
@@ -2,8 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Model-local coordination for MiniMax H3 temporal chunk decoding.
 
-This boundary owns released-code compatibility and VAE-group failure semantics.
-Cropping, representation conversion, transport, and encoding remain runtime
+This boundary owns released-code compatibility and reconciles preflight and
+callback failures at fixed VAE-group rendezvous points. Cropping,
+representation conversion, transport, and encoding remain runtime
 responsibilities.
 """
 
@@ -19,30 +20,23 @@ import torch.nn as nn
 from .temporal_chunks import (
     MiniMaxH3TemporalChunkCompatibilityError,
     MiniMaxH3TemporalDecodePlan,
+    _TemporalChunkCallbackSignature,
     decode_minimax_h3_temporal_chunks_compat,
     prepare_minimax_h3_temporal_chunks_compat,
 )
 
 
-class MiniMaxH3VideoChunkCallback(Protocol):
+class MiniMaxH3VideoChunkCallback(_TemporalChunkCallbackSignature, Protocol):
     """Consume one ordered, temporally committed H3 video chunk.
 
     ``frames`` is an owned, contiguous float32 RGB tensor in ``BCTHW`` layout
     and the ``[0, 1]`` value range. The callback runs synchronously on the
     producer's current device stream. Before reading it on another stream, the
     consumer must establish ordering from the producer stream (for example via
-    an event) and retain the allocation for that stream's lifetime.
+    an event) and retain the allocation for that stream's lifetime. The
+    consumer may retain or mutate the tensor; it does not alias the returned
+    complete decode.
     """
-
-    def __call__(
-        self,
-        frames: torch.Tensor,
-        *,
-        chunk_index: int,
-        total_chunks: int,
-        frame_start: int,
-        is_final: bool,
-    ) -> None: ...
 
 
 class MiniMaxH3ChunkedDecodeUnsupportedError(RuntimeError):
@@ -77,6 +71,12 @@ class _MiniMaxH3ChunkDecodeCoordinator:
     The coordinator is a plain Python object. It caches only successful source
     validation; request callbacks, tensors, metadata, and process groups remain
     local to :meth:`decode`.
+
+    Errors raised inside the checkpoint decoder after native collectives begin
+    cannot be reconciled here: another rank may already be blocked inside that
+    collective. Resolving such a failure requires native collective handling or
+    supervisor-level timeout and worker-group teardown; the process group cannot
+    be assumed reusable.
     """
 
     def __init__(self) -> None:
@@ -93,14 +93,16 @@ class _MiniMaxH3ChunkDecodeCoordinator:
             return chunk_callback is not None
 
         group_rank = dist.get_rank(group)
-        callback_owners = torch.tensor(
-            [int(chunk_callback is not None)],
-            dtype=torch.int32,
+        # A valid configuration has one contribution: rank 0 contributes 1.
+        # A non-zero owner contributes at least 2, and multiple owners sum to
+        # at least 3, so every rank makes the same decision from one reduction.
+        callback_owner = torch.tensor(
+            [group_rank + 1 if chunk_callback is not None else 0],
+            dtype=torch.int64,
             device=device,
         )
-        dist.all_reduce(callback_owners, group=group)
-        valid_owner = int(callback_owners.item()) == 1 and ((group_rank == 0) == (chunk_callback is not None))
-        if not valid_owner:
+        dist.all_reduce(callback_owner, op=dist.ReduceOp.SUM, group=group)
+        if int(callback_owner.item()) != 1:
             raise ValueError("MiniMax-H3 chunk decode requires a callback on exactly VAE group rank 0")
         return group_rank == 0
 
@@ -282,6 +284,11 @@ class _MiniMaxH3ChunkDecodeCoordinator:
                 exc.__traceback__ = None
                 callback_error = exc
 
+        # Do not catch and reduce exceptions from this region. A peer may
+        # already be blocked in one of the checkpoint's native tile
+        # collectives, in which case a new adapter-level collective would also
+        # deadlock. A native backend or supervisor must handle timeout and
+        # worker-group teardown.
         with host._decode_tiling_context(latent):
             decoded = decode_minimax_h3_temporal_chunks_compat(
                 host.model,

--- a/vllm_omni/diffusion/models/minimax_h3/chunked_decode.py
+++ b/vllm_omni/diffusion/models/minimax_h3/chunked_decode.py
@@ -232,10 +232,7 @@ class _MiniMaxH3ChunkDecodeCoordinator:
                     dtype=torch.int64,
                     device=device,
                 )
-                gathered_signatures = [
-                    torch.empty_like(padded_signature)
-                    for _ in range(dist.get_world_size(group))
-                ]
+                gathered_signatures = [torch.empty_like(padded_signature) for _ in range(dist.get_world_size(group))]
                 dist.all_gather(gathered_signatures, padded_signature, group=group)
                 if any(not torch.equal(padded_signature, peer) for peer in gathered_signatures):
                     raise MiniMaxH3ChunkedDecodeUnsupportedError(

--- a/vllm_omni/diffusion/models/minimax_h3/chunked_decode.py
+++ b/vllm_omni/diffusion/models/minimax_h3/chunked_decode.py
@@ -83,6 +83,37 @@ class _MiniMaxH3ChunkDecodeCoordinator:
         self._sources_validated = False
 
     @staticmethod
+    def _build_execution_signature(
+        latent: torch.Tensor,
+        plan: MiniMaxH3TemporalDecodePlan,
+    ) -> tuple[int, ...]:
+        """Describe every shape and plan field used by the temporal schedule."""
+
+        dtype_codes: dict[torch.dtype | None, int] = {
+            None: 0,
+            torch.float16: 1,
+            torch.bfloat16: 2,
+            torch.float32: 3,
+            torch.float64: 4,
+        }
+        return (
+            # Keep the layout versioned so adding a field cannot silently make
+            # an older and newer worker appear compatible.
+            1,
+            *[int(size) for size in latent.shape],
+            dtype_codes.get(latent.dtype, -1),
+            *[int(size) for size in plan.latent.shape],
+            dtype_codes.get(plan.latent.dtype, -1),
+            int(plan.num_chunks),
+            int(plan.total_frames),
+            int(plan.pad_frames),
+            int(plan.output_frames),
+            len(plan.chunk_frames),
+            *[int(frame_count) for frame_count in plan.chunk_frames],
+            dtype_codes.get(plan.temporal_dtype, -1),
+        )
+
+    @staticmethod
     def _is_output_rank(
         chunk_callback: MiniMaxH3VideoChunkCallback | None,
         *,
@@ -140,6 +171,7 @@ class _MiniMaxH3ChunkDecodeCoordinator:
     def _synchronize_preflight_error(
         preflight_error: Exception | None,
         temporal_dtype: torch.dtype | None,
+        execution_signature: tuple[int, ...] | None,
         *,
         group: dist.ProcessGroup | None,
         device: torch.device,
@@ -171,6 +203,44 @@ class _MiniMaxH3ChunkDecodeCoordinator:
             dist.all_reduce(lowest, op=dist.ReduceOp.MIN, group=group)
             dist.all_reduce(highest, op=dist.ReduceOp.MAX, group=group)
             if int(lowest.item()) == int(highest.item()) and int(lowest.item()) >= 0:
+                if execution_signature is None:
+                    raise RuntimeError("MiniMax-H3 temporal decode preflight produced no execution signature")
+
+                # The plan length is shape-dependent, so first agree on a
+                # common tensor size and then compare the complete signatures.
+                # This keeps all ranks in tensor collectives and catches a
+                # schedule mismatch before entering the decoder's collectives.
+                signature_length = torch.tensor(
+                    [len(execution_signature)],
+                    dtype=torch.int64,
+                    device=device,
+                )
+                max_signature_length = signature_length.clone()
+                dist.all_reduce(
+                    max_signature_length,
+                    op=dist.ReduceOp.MAX,
+                    group=group,
+                )
+                padded_signature = torch.full(
+                    (int(max_signature_length.item()),),
+                    -2,
+                    dtype=torch.int64,
+                    device=device,
+                )
+                padded_signature[: len(execution_signature)] = torch.tensor(
+                    execution_signature,
+                    dtype=torch.int64,
+                    device=device,
+                )
+                gathered_signatures = [
+                    torch.empty_like(padded_signature)
+                    for _ in range(dist.get_world_size(group))
+                ]
+                dist.all_gather(gathered_signatures, padded_signature, group=group)
+                if any(not torch.equal(padded_signature, peer) for peer in gathered_signatures):
+                    raise MiniMaxH3ChunkedDecodeUnsupportedError(
+                        "MiniMax-H3 VAE ranks built incompatible temporal decode plans"
+                    )
                 return
             raise MiniMaxH3ChunkedDecodeUnsupportedError(
                 "MiniMax-H3 VAE ranks selected incompatible temporal concat dtypes"
@@ -215,6 +285,7 @@ class _MiniMaxH3ChunkDecodeCoordinator:
         self._synchronize_preflight_error(
             preflight_error,
             plan.temporal_dtype if plan is not None else None,
+            self._build_execution_signature(latent, plan) if plan is not None else None,
             group=group,
             device=latent.device,
         )

--- a/vllm_omni/diffusion/models/minimax_h3/temporal_chunks.py
+++ b/vllm_omni/diffusion/models/minimax_h3/temporal_chunks.py
@@ -1,0 +1,408 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Source-gated temporal chunk compatibility for the released MiniMax H3 VAE."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import inspect
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+import torch
+import torch.nn as nn
+
+MINIMAX_H3_RELEASED_REVISION = "42ed227ee7df40d41602854ae760620d6eb651fe"
+# Compatibility pins detect upstream code drift; they are not a trust or
+# security boundary for remote code execution.
+MINIMAX_H3_RELEASED_BUNDLE_SHA256 = "30e64afbaa940696bf8bfe2c86003a4b1666c84b22fa3aa12403a3e6a03f705d"
+
+_RELEASED_TEMPORAL_CONFIG = {
+    "clip_length": 17,
+    "tokens_chunk_size": 5,
+    "token_overlap": 2,
+    "token_drop": 3,
+    "vae_ratio_t": 4,
+    "frame_pre_padding": 3,
+    "frame_overlap": 5,
+    "isolated_first_frame": False,
+    "isolated_last_frame": False,
+}
+
+
+class MiniMaxH3TemporalChunkCompatibilityError(RuntimeError):
+    """Raised when remote H3 code cannot use the local compatibility path."""
+
+
+class _RawTemporalChunkCallback(Protocol):
+    def __call__(
+        self,
+        frames: torch.Tensor,
+        *,
+        chunk_index: int,
+        total_chunks: int,
+        frame_start: int,
+        is_final: bool,
+    ) -> None: ...
+
+
+@dataclass(slots=True)
+class MiniMaxH3TemporalDecodePlan:
+    latent: torch.Tensor
+    num_chunks: int
+    total_frames: int
+    pad_frames: int
+    output_frames: int
+    chunk_frames: tuple[int, ...]
+    temporal_dtype: torch.dtype | None
+
+
+class _RawChunkAssembly:
+    def __init__(
+        self,
+        *,
+        callback: _RawTemporalChunkCallback,
+        plan: MiniMaxH3TemporalDecodePlan,
+    ) -> None:
+        self.callback = callback
+        self.plan = plan
+        self.frames: torch.Tensor | None = None
+        self.write_pos = 0
+        self.logical_frames = 0
+        self.dropped_frames = 0
+        self.chunk_index = 0
+        self.pending_final: tuple[torch.Tensor, int, int] | None = None
+        self.contract_error: RuntimeError | None = None
+
+    def write(self, part: torch.Tensor) -> None:
+        part_frames = int(part.shape[2])
+        if part_frames <= 0:
+            return
+        self.logical_frames += part_frames
+        remaining = self.plan.output_frames - self.write_pos
+        copy_frames = min(part_frames, max(0, remaining))
+        if copy_frames <= 0:
+            self.dropped_frames += part_frames
+            return
+        if self.chunk_index >= len(self.plan.chunk_frames):
+            self.contract_error = RuntimeError("MiniMax-H3 compatibility decode emitted an extra chunk")
+        else:
+            expected_frames = self.plan.chunk_frames[self.chunk_index]
+            if copy_frames != expected_frames and self.contract_error is None:
+                self.contract_error = RuntimeError(
+                    "MiniMax-H3 compatibility chunk size mismatch: "
+                    f"chunk={self.chunk_index}, frames={copy_frames}/{expected_frames}"
+                )
+
+        emitted = part[:, :, :copy_frames]
+        if self.frames is None:
+            output_shape = list(emitted.shape)
+            output_shape[2] = self.plan.output_frames
+            self.frames = torch.empty(
+                output_shape,
+                dtype=emitted.dtype,
+                device=emitted.device,
+            )
+        frame_start = self.write_pos
+        frame_stop = frame_start + copy_frames
+        self.frames[:, :, frame_start:frame_stop].copy_(emitted)
+        if frame_stop == self.plan.output_frames:
+            self.pending_final = (emitted, self.chunk_index, frame_start)
+        elif self.contract_error is None:
+            self.callback(
+                emitted,
+                chunk_index=self.chunk_index,
+                total_chunks=len(self.plan.chunk_frames),
+                frame_start=frame_start,
+                is_final=False,
+            )
+        self.chunk_index += 1
+        self.write_pos = frame_stop
+        self.dropped_frames += part_frames - copy_frames
+
+    def finish(self) -> torch.Tensor:
+        if self.contract_error is not None:
+            raise self.contract_error
+        if self.frames is None or self.pending_final is None:
+            raise RuntimeError("MiniMax-H3 compatibility decode produced no terminal chunk")
+        if (
+            self.logical_frames != self.plan.total_frames
+            or self.dropped_frames != self.plan.pad_frames
+            or self.write_pos != self.plan.output_frames
+            or self.chunk_index != len(self.plan.chunk_frames)
+        ):
+            raise RuntimeError(
+                "MiniMax-H3 compatibility frame plan mismatch: "
+                f"logical={self.logical_frames}/{self.plan.total_frames}, "
+                f"dropped={self.dropped_frames}/{self.plan.pad_frames}, "
+                f"written={self.write_pos}/{self.plan.output_frames}, "
+                f"chunks={self.chunk_index}/{len(self.plan.chunk_frames)}"
+            )
+
+        final_frames, final_index, final_start = self.pending_final
+        self.callback(
+            final_frames,
+            chunk_index=final_index,
+            total_chunks=len(self.plan.chunk_frames),
+            frame_start=final_start,
+            is_final=True,
+        )
+        return self.frames
+
+
+def _source_bundle_sha256(model: nn.Module) -> tuple[str | None, str | None]:
+    try:
+        source = inspect.getsourcefile(type(model))
+    except TypeError:
+        return None, None
+    if source is None:
+        return None, None
+    package_dir = Path(source).parent
+    files = sorted(path for path in package_dir.glob("*.py") if path.name != "__init__.py")
+    digest = hashlib.sha256()
+    try:
+        for path in files:
+            digest.update(path.name.encode())
+            digest.update(b"\0")
+            digest.update(path.read_bytes())
+            digest.update(b"\0")
+    except OSError:
+        return str(package_dir), None
+    return str(package_dir), digest.hexdigest()
+
+
+def _validate_released_sources(model: nn.Module) -> None:
+    source_dir, actual = _source_bundle_sha256(model)
+    if actual != MINIMAX_H3_RELEASED_BUNDLE_SHA256:
+        raise MiniMaxH3TemporalChunkCompatibilityError(
+            "The vLLM-owned MiniMax-H3 chunk adapter supports only remote code "
+            f"from MiniMaxAI/MiniMax-H3@{MINIMAX_H3_RELEASED_REVISION}: "
+            f"bundle={actual!r} ({source_dir}). "
+            "The normal complete-output decode remains available."
+        )
+
+
+def _validate_released_config(model: nn.Module) -> None:
+    actual = {name: getattr(model, name, None) for name in _RELEASED_TEMPORAL_CONFIG}
+    if actual != _RELEASED_TEMPORAL_CONFIG:
+        raise MiniMaxH3TemporalChunkCompatibilityError(
+            "The vLLM-owned MiniMax-H3 chunk adapter requires the released temporal "
+            f"configuration {_RELEASED_TEMPORAL_CONFIG}, found {actual}. "
+            "The normal complete-output decode remains available."
+        )
+
+
+def _validate_compat_contract(model: nn.Module, latent: torch.Tensor) -> None:
+    if latent.ndim != 5 or int(latent.shape[2]) <= 0:
+        raise MiniMaxH3TemporalChunkCompatibilityError(
+            f"MiniMax-H3 video latent must have positive rank-5 time, got {tuple(latent.shape)}"
+        )
+    if not bool(getattr(model, "use_3d_conv", False)):
+        raise MiniMaxH3TemporalChunkCompatibilityError("MiniMax-H3 temporal chunk decode requires the 3D decoder")
+    if bool(getattr(model, "training", False)):
+        raise MiniMaxH3TemporalChunkCompatibilityError("MiniMax-H3 temporal chunk decode is inference-only")
+    required_methods = (
+        "_adaptive_decode",
+        "_decode_temporal_output_frame_plan",
+        "_decode_temporal_pad_frames",
+        "blend",
+    )
+    missing = [name for name in required_methods if not callable(getattr(model, name, None))]
+    if missing:
+        raise MiniMaxH3TemporalChunkCompatibilityError(
+            "Loaded MiniMax-H3 VAE lacks required released-code methods: " + ", ".join(missing)
+        )
+
+
+def _truncate_chunk_frames(
+    logical_chunk_frames: list[int],
+    output_frames: int,
+) -> tuple[int, ...]:
+    remaining = output_frames
+    result: list[int] = []
+    for logical_frames in logical_chunk_frames:
+        emitted_frames = min(logical_frames, max(0, remaining))
+        if emitted_frames > 0:
+            result.append(emitted_frames)
+            remaining -= emitted_frames
+    if remaining != 0:
+        raise RuntimeError(f"MiniMax-H3 compatibility chunk plan cannot cover output: remaining={remaining}")
+    return tuple(result)
+
+
+def _build_decode_plan(
+    model: nn.Module,
+    latent: torch.Tensor,
+    temporal_dtype: torch.dtype | None,
+) -> MiniMaxH3TemporalDecodePlan:
+    pseudo_total_tokens = int(latent.shape[2]) + int(model.token_drop)  # type: ignore[attr-defined]
+    tokens_chunk_size = int(model.tokens_chunk_size)  # type: ignore[attr-defined]
+    remainder = pseudo_total_tokens % tokens_chunk_size
+    pad_tokens = 0 if remainder == 0 else tokens_chunk_size - remainder
+    pseudo_total_tokens += pad_tokens
+    num_chunks = pseudo_total_tokens // tokens_chunk_size - int(model.token_drop > 0)  # type: ignore[attr-defined]
+    if num_chunks <= 0:
+        raise MiniMaxH3TemporalChunkCompatibilityError(
+            f"MiniMax-H3 temporal chunk plan is empty for latent T={latent.shape[2]}"
+        )
+
+    temporal_latent = latent
+    if pad_tokens:
+        pad = temporal_latent[:, :, -1:].repeat(1, 1, pad_tokens, 1, 1)
+        temporal_latent = torch.cat((temporal_latent, pad), dim=2)
+    total_frames, pad_frames, output_frames = model._decode_temporal_output_frame_plan(  # type: ignore[attr-defined]
+        temporal_latent,
+        None,
+        None,
+        num_chunks,
+        pad_tokens,
+    )
+    if output_frames <= 0:
+        raise MiniMaxH3TemporalChunkCompatibilityError(
+            f"MiniMax-H3 temporal chunk plan has {output_frames} output frames"
+        )
+
+    chunk_decoded_frames = tokens_chunk_size * int(model.vae_ratio_t)  # type: ignore[attr-defined]
+    split_count = int(model.token_drop > 0) + 1  # type: ignore[attr-defined]
+    logical_chunk_frames: list[int] = []
+    final_overlap_frames = 0
+    for temporal_index in range(num_chunks):
+        token_start = temporal_index * tokens_chunk_size
+        token_stop = token_start + tokens_chunk_size + int(model.token_overlap)  # type: ignore[attr-defined]
+        clip_tokens = max(
+            0,
+            min(token_stop, int(temporal_latent.shape[2])) - min(token_start, int(temporal_latent.shape[2])),
+        )
+        clip_frames = clip_tokens * int(model.vae_ratio_t)  # type: ignore[attr-defined]
+        for split_index in range(split_count):
+            frame_start = split_index * chunk_decoded_frames
+            frame_stop = min(frame_start + chunk_decoded_frames, clip_frames)
+            part_frames = max(
+                0,
+                frame_stop - frame_start - int(model.frame_pre_padding),  # type: ignore[attr-defined]
+            )
+            if split_index == 0:
+                if part_frames > 0:
+                    logical_chunk_frames.append(part_frames)
+            else:
+                final_overlap_frames = part_frames
+    if final_overlap_frames > 0:
+        logical_chunk_frames.append(final_overlap_frames)
+    if sum(logical_chunk_frames) != int(total_frames):
+        raise RuntimeError(
+            "MiniMax-H3 compatibility planner disagrees with released remote code: "
+            f"frames={sum(logical_chunk_frames)}/{total_frames}"
+        )
+    chunk_frames = _truncate_chunk_frames(logical_chunk_frames, int(output_frames))
+    return MiniMaxH3TemporalDecodePlan(
+        latent=temporal_latent,
+        num_chunks=num_chunks,
+        total_frames=int(total_frames),
+        pad_frames=int(pad_frames),
+        output_frames=int(output_frames),
+        chunk_frames=chunk_frames,
+        temporal_dtype=temporal_dtype,
+    )
+
+
+def resolve_minimax_h3_temporal_cat_dtype(model: nn.Module) -> torch.dtype | None:
+    module = importlib.import_module(type(model).__module__)
+    resolver = getattr(module, "_resolve_temporal_cat_dtype", None)
+    if resolver is None:
+        return None
+    if not callable(resolver):
+        raise MiniMaxH3TemporalChunkCompatibilityError(
+            "Loaded MiniMax-H3 VAE has a non-callable temporal dtype resolver"
+        )
+    try:
+        dtype = resolver()
+    except ValueError as exc:
+        raise MiniMaxH3TemporalChunkCompatibilityError(str(exc)) from None
+    if dtype is not None and not isinstance(dtype, torch.dtype):
+        raise MiniMaxH3TemporalChunkCompatibilityError(
+            f"Loaded MiniMax-H3 VAE returned invalid temporal dtype {dtype!r}"
+        )
+    return dtype
+
+
+def decode_minimax_h3_temporal_chunks_compat(
+    model: nn.Module,
+    plan: MiniMaxH3TemporalDecodePlan,
+    callback: _RawTemporalChunkCallback,
+) -> torch.Tensor:
+    """Mirror the released Apache-2.0 H3 temporal assembler with callbacks.
+
+    Keep this implementation and the source/config fingerprints above in sync
+    with ``MiniMaxAI/MiniMax-H3@42ed227e``. Unknown remote code fails closed
+    before this function is called.
+    """
+
+    chunk_decoded_frames = int(model.tokens_chunk_size) * int(model.vae_ratio_t)  # type: ignore[attr-defined]
+    split_count = int(model.token_drop > 0) + 1  # type: ignore[attr-defined]
+    assembly = _RawChunkAssembly(callback=callback, plan=plan)
+    overlap: torch.Tensor | None = None
+
+    for temporal_index in range(plan.num_chunks):
+        token_start = temporal_index * int(model.tokens_chunk_size)  # type: ignore[attr-defined]
+        token_stop = token_start + int(model.tokens_chunk_size) + int(model.token_overlap)  # type: ignore[attr-defined]
+        chunk_latent = plan.latent[:, :, token_start:token_stop]
+        decoded = model._adaptive_decode(chunk_latent)  # type: ignore[attr-defined]
+        if plan.temporal_dtype is not None and decoded.dtype != plan.temporal_dtype:
+            decoded = decoded.to(plan.temporal_dtype)
+        if decoded.device != plan.latent.device:
+            decoded = decoded.to(plan.latent.device)
+
+        for split_index in range(split_count):
+            frame_start = split_index * chunk_decoded_frames
+            frame_stop = min(frame_start + chunk_decoded_frames, int(decoded.shape[2]))
+            part = decoded[:, :, frame_start:frame_stop]
+            part = part[:, :, int(model.frame_pre_padding) :]  # type: ignore[attr-defined]
+            if split_index == 0:
+                if overlap is not None:
+                    part = model.blend(  # type: ignore[attr-defined]
+                        overlap,
+                        part,
+                        int(model.frame_overlap),  # type: ignore[attr-defined]
+                        dim=-3,
+                    )
+                    overlap = None
+                assembly.write(part)
+            else:
+                overlap = part.contiguous()
+            del part
+
+        if temporal_index == plan.num_chunks - 1 and overlap is not None:
+            assembly.write(overlap)
+            overlap = None
+        del decoded, chunk_latent
+
+    return assembly.finish()
+
+
+def prepare_minimax_h3_temporal_chunks_compat(
+    model: nn.Module,
+    latent: torch.Tensor,
+    *,
+    validate_sources: bool = True,
+) -> MiniMaxH3TemporalDecodePlan:
+    """Build a validated plan without entering decoder collectives."""
+
+    if validate_sources:
+        _validate_released_sources(model)
+    _validate_released_config(model)
+    _validate_compat_contract(model, latent)
+    temporal_dtype = resolve_minimax_h3_temporal_cat_dtype(model)
+    return _build_decode_plan(model, latent, temporal_dtype)
+
+
+__all__ = [
+    "MINIMAX_H3_RELEASED_REVISION",
+    "MINIMAX_H3_RELEASED_BUNDLE_SHA256",
+    "MiniMaxH3TemporalDecodePlan",
+    "MiniMaxH3TemporalChunkCompatibilityError",
+    "decode_minimax_h3_temporal_chunks_compat",
+    "prepare_minimax_h3_temporal_chunks_compat",
+    "resolve_minimax_h3_temporal_cat_dtype",
+]

--- a/vllm_omni/diffusion/models/minimax_h3/temporal_chunks.py
+++ b/vllm_omni/diffusion/models/minimax_h3/temporal_chunks.py
@@ -36,10 +36,13 @@ class MiniMaxH3TemporalChunkCompatibilityError(RuntimeError):
     """Raised when remote H3 code cannot use the local compatibility path."""
 
 
-class _RawTemporalChunkCallback(Protocol):
+class _TemporalChunkCallbackSignature(Protocol):
+    """Shared callable shape; each producer defines tensor semantics."""
+
     def __call__(
         self,
         frames: torch.Tensor,
+        /,
         *,
         chunk_index: int,
         total_chunks: int,
@@ -63,7 +66,7 @@ class _RawChunkAssembly:
     def __init__(
         self,
         *,
-        callback: _RawTemporalChunkCallback,
+        callback: _TemporalChunkCallbackSignature,
         plan: MiniMaxH3TemporalDecodePlan,
     ) -> None:
         self.callback = callback
@@ -330,13 +333,16 @@ def resolve_minimax_h3_temporal_cat_dtype(model: nn.Module) -> torch.dtype | Non
 def decode_minimax_h3_temporal_chunks_compat(
     model: nn.Module,
     plan: MiniMaxH3TemporalDecodePlan,
-    callback: _RawTemporalChunkCallback,
+    callback: _TemporalChunkCallbackSignature,
 ) -> torch.Tensor:
     """Mirror the released Apache-2.0 H3 temporal assembler with callbacks.
 
     Keep this implementation and the source/config fingerprints above in sync
     with ``MiniMaxAI/MiniMax-H3@42ed227e``. Unknown remote code fails closed
     before this function is called.
+
+    Callback tensors are borrowed decoder-domain views and must not be retained
+    or mutated. The high-level adapter owns normalization and storage isolation.
     """
 
     chunk_decoded_frames = int(model.tokens_chunk_size) * int(model.vae_ratio_t)  # type: ignore[attr-defined]

--- a/vllm_omni/diffusion/models/minimax_h3/vae.py
+++ b/vllm_omni/diffusion/models/minimax_h3/vae.py
@@ -21,7 +21,11 @@ from vllm.logger import init_logger
 from vllm_omni.diffusion.distributed.autoencoders.distributed_vae_executor import (
     DistributedVaeMixin,
 )
-from vllm_omni.diffusion.distributed.parallel_state import get_world_group
+from vllm_omni.diffusion.distributed.parallel_state import (
+    get_data_parallel_world_size,
+    get_world_group,
+    model_parallel_is_initialized,
+)
 from vllm_omni.diffusion.offloader.module_residency import (
     BoundedAllocatorCache,
     PinnedModuleStager,
@@ -29,6 +33,12 @@ from vllm_omni.diffusion.offloader.module_residency import (
 
 from .ops import install_h3_vae_optimizations
 from .packed_tokens import minimax_h3_patchify_video_latent
+from .temporal_chunks import (
+    MiniMaxH3TemporalChunkCompatibilityError,
+    MiniMaxH3TemporalDecodePlan,
+    decode_minimax_h3_temporal_chunks_compat,
+    prepare_minimax_h3_temporal_chunks_compat,
+)
 
 MINIMAX_H3_KEYFRAME_ENCODE_SEED = 42
 MINIMAX_H3_AUDIO_SAMPLE_RATE = 32000
@@ -60,7 +70,7 @@ class MiniMaxH3VideoChunkCallback(Protocol):
 
 
 class MiniMaxH3ChunkedDecodeUnsupportedError(RuntimeError):
-    """Raised when the loaded MiniMax H3 VAE lacks the vendor chunk API."""
+    """Raised when loaded MiniMax H3 code cannot honor the chunk contract."""
 
 
 class MiniMaxH3ChunkCallbackPeerError(RuntimeError):
@@ -338,6 +348,10 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
     def _chunk_process_group(self) -> dist.ProcessGroup | None:
         if not self.is_distributed_enabled():
             return None
+        if model_parallel_is_initialized() and get_data_parallel_world_size() > 1:
+            raise MiniMaxH3ChunkedDecodeUnsupportedError(
+                "MiniMax-H3 temporal chunks do not yet support combining data parallelism with VAE patch parallelism"
+            )
         group = self._native_parallel_state().get("sp_process_group")
         if group is None or dist.get_world_size(group) != self.parallel_size:
             raise RuntimeError("MiniMax-H3 VAE chunk decode has an invalid spatial-parallel group")
@@ -395,14 +409,48 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
             raise callback_error
         raise MiniMaxH3ChunkCallbackPeerError("MiniMax-H3 video chunk callback failed on this VAE group's output rank")
 
-    def _validate_vendor_chunk_api(self) -> None:
-        version = getattr(self.model, "temporal_chunk_callback_api_version", None)
-        if version != 1:
-            raise MiniMaxH3ChunkedDecodeUnsupportedError(
-                "Loaded MiniMax-H3 VAE does not provide temporal_chunk_callback API v1 "
-                f"(found {version!r}); install a model snapshot containing the official "
-                "MiniMax temporal chunk callback"
+    @staticmethod
+    def _synchronize_chunk_preflight_error(
+        preflight_error: Exception | None,
+        temporal_dtype: torch.dtype | None,
+        *,
+        group: dist.ProcessGroup | None,
+        device: torch.device,
+    ) -> None:
+        if group is None:
+            if preflight_error is not None:
+                raise preflight_error
+            return
+        failed = torch.tensor(
+            [int(preflight_error is not None)],
+            dtype=torch.int32,
+            device=device,
+        )
+        dist.all_reduce(failed, op=dist.ReduceOp.MAX, group=group)
+        if int(failed.item()) == 0:
+            dtype_codes = {
+                None: 0,
+                torch.float16: 1,
+                torch.bfloat16: 2,
+                torch.float32: 3,
+            }
+            code = torch.tensor(
+                [dtype_codes.get(temporal_dtype, -1)],
+                dtype=torch.int32,
+                device=device,
             )
+            lowest = code.clone()
+            highest = code.clone()
+            dist.all_reduce(lowest, op=dist.ReduceOp.MIN, group=group)
+            dist.all_reduce(highest, op=dist.ReduceOp.MAX, group=group)
+            if int(lowest.item()) == int(highest.item()) and int(lowest.item()) >= 0:
+                return
+            raise MiniMaxH3ChunkedDecodeUnsupportedError(
+                "MiniMax-H3 VAE ranks selected incompatible temporal concat dtypes"
+            )
+        if preflight_error is not None:
+            raise preflight_error
+        raise MiniMaxH3ChunkedDecodeUnsupportedError("A peer VAE rank rejected the MiniMax-H3 temporal chunk preflight")
 
     @torch.inference_mode()
     def encode_image(self, image: Image.Image) -> torch.Tensor:
@@ -506,11 +554,11 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
         latent: torch.Tensor,
         chunk_callback: MiniMaxH3VideoChunkCallback | None,
     ) -> torch.Tensor:
-        """Decode a video while publishing vendor-committed temporal chunks.
+        """Decode a video while publishing committed temporal chunks.
 
         Every rank collaborating in the configured H3 VAE tile group must call
         this method, with ``chunk_callback`` supplied only on group rank 0. A
-        callback failure is deferred until the vendor decoder finishes its
+        callback failure is deferred until the compatibility decoder finishes its
         remaining collectives, then propagated to every group rank. With
         ``parallel_size=1`` the runtime designates each request's output owner
         by supplying a callback there and ``None`` on replica peers.
@@ -522,8 +570,41 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
         requested-size crop as the complete H3 pipeline output.
         """
 
-        self._validate_vendor_chunk_api()
         group = self._chunk_process_group()
+        plan: MiniMaxH3TemporalDecodePlan | None = None
+        preflight_error: Exception | None = None
+        if latent.ndim != 5:
+            preflight_error = MiniMaxH3ChunkedDecodeUnsupportedError(
+                f"MiniMax-H3 video latent must be rank 5, got {tuple(latent.shape)}"
+            )
+        else:
+            try:
+                denormalized = self._denormalize_latent(latent)
+                plan = prepare_minimax_h3_temporal_chunks_compat(
+                    self.model,
+                    denormalized,
+                    validate_sources=not getattr(
+                        self,
+                        "_minimax_h3_chunk_sources_validated",
+                        False,
+                    ),
+                )
+                self._minimax_h3_chunk_sources_validated = True
+                del denormalized
+            except MiniMaxH3TemporalChunkCompatibilityError as exc:
+                preflight_error = MiniMaxH3ChunkedDecodeUnsupportedError(str(exc))
+            except Exception as exc:  # noqa: BLE001
+                # Every VAE rank must reach the preflight reduction even when
+                # one node's private planner or environment fails locally.
+                exc.__traceback__ = None
+                preflight_error = exc
+        self._synchronize_chunk_preflight_error(
+            preflight_error,
+            plan.temporal_dtype if plan is not None else None,
+            group=group,
+            device=latent.device,
+        )
+        assert plan is not None
         is_output_rank = self._is_chunk_output_rank(
             chunk_callback,
             group=group,
@@ -560,7 +641,7 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
                     or is_final != (chunk_index + 1 == total_chunks)
                 ):
                     raise RuntimeError(
-                        "MiniMax-H3 vendor callback emitted discontinuous chunk metadata: "
+                        "MiniMax-H3 temporal backend emitted discontinuous chunk metadata: "
                         f"index={chunk_index}/{next_chunk_index}, "
                         f"total={total_chunks}/{expected_total_chunks}, "
                         f"frame_start={frame_start}/{next_frame_start}, "
@@ -570,7 +651,7 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
                 frames = frames.clone(memory_format=torch.contiguous_format)
                 frame_count = int(frames.shape[2])
                 if frame_count <= 0:
-                    raise RuntimeError("MiniMax-H3 vendor callback emitted an empty chunk")
+                    raise RuntimeError("MiniMax-H3 temporal backend emitted an empty chunk")
                 next_chunk_index += 1
                 next_frame_start += frame_count
                 saw_final = is_final
@@ -589,9 +670,10 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
                 callback_error = exc
 
         with self._decode_tiling_context(latent):
-            decoded = self.model.decode_base(
-                self._denormalize_latent(latent),
-                temporal_chunk_callback=publish,
+            decoded = decode_minimax_h3_temporal_chunks_compat(
+                self.model,
+                plan,
+                publish,
             )
         frames = self._normalize_decoded_frames(decoded)
         if (
@@ -600,7 +682,7 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
             and (not saw_final or next_chunk_index != expected_total_chunks or next_frame_start != int(frames.shape[2]))
         ):
             callback_error = RuntimeError(
-                "MiniMax-H3 vendor callback did not reconstruct the full decode: "
+                "MiniMax-H3 temporal backend did not reconstruct the full decode: "
                 f"final={saw_final}, chunks={next_chunk_index}/{expected_total_chunks}, "
                 f"frames={next_frame_start}/{frames.shape[2]}"
             )

--- a/vllm_omni/diffusion/models/minimax_h3/vae.py
+++ b/vllm_omni/diffusion/models/minimax_h3/vae.py
@@ -9,7 +9,7 @@ import json
 from collections.abc import Iterator
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 import torch
 import torch.distributed as dist
@@ -36,6 +36,35 @@ MINIMAX_H3_AUDIO_CHANNELS = 2
 
 
 logger = init_logger(__name__)
+
+
+class MiniMaxH3VideoChunkCallback(Protocol):
+    """Consume one ordered, temporally committed H3 video chunk.
+
+    ``frames`` is an owned, contiguous float32 RGB tensor in ``BCTHW`` layout
+    and the ``[0, 1]`` value range. The callback runs synchronously on the
+    producer's current device stream. Before reading it on another stream, the
+    consumer must establish ordering from the producer stream (for example via
+    an event) and retain the allocation for that stream's lifetime.
+    """
+
+    def __call__(
+        self,
+        frames: torch.Tensor,
+        *,
+        chunk_index: int,
+        total_chunks: int,
+        frame_start: int,
+        is_final: bool,
+    ) -> None: ...
+
+
+class MiniMaxH3ChunkedDecodeUnsupportedError(RuntimeError):
+    """Raised when the loaded MiniMax H3 VAE lacks the vendor chunk API."""
+
+
+class MiniMaxH3ChunkCallbackPeerError(RuntimeError):
+    """Raised on peer VAE ranks when the output-rank callback fails."""
 
 
 def _load_component_config(component_path: str) -> dict[str, Any]:
@@ -265,6 +294,116 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
     def is_distributed_enabled(self) -> bool:
         return self.parallel_size > 1 and dist.is_initialized()
 
+    def _denormalize_latent(self, latent: torch.Tensor) -> torch.Tensor:
+        channels = int(self.config_dict["latent_channels"])
+        mean = torch.tensor(
+            self.config_dict["latents_mean"],
+            device=latent.device,
+            dtype=latent.dtype,
+        ).view(1, channels, 1, 1, 1)
+        std = torch.tensor(
+            self.config_dict["latents_std"],
+            device=latent.device,
+            dtype=latent.dtype,
+        ).view(1, channels, 1, 1, 1)
+        return latent * std + mean
+
+    def _decode_tiling_context(self, latent: torch.Tensor) -> AbstractContextManager:
+        # The checkpoint hands rank r the tiles ``range(r, num_tiles, sp_size)``
+        # and then rejects an empty share inside the gather. A rank with no
+        # tiles raises and leaves the collective while the others block in it
+        # forever, so too few tiles hangs the whole stage rather than failing
+        # it. Tile count depends only on the latent shape, so every rank takes
+        # this branch together.
+        num_tiles = self._decoder_tile_count(latent)
+        if self.parallel_size > 1 and num_tiles < self.parallel_size:
+            logger.warning_once(
+                "MiniMax-H3 VAE decode splits into %d tile(s) but the tile group has "
+                "%d ranks; decoding rank-locally for this shape instead, which is "
+                "slower but avoids ranks without tiles hanging the collective.",
+                num_tiles,
+                self.parallel_size,
+            )
+            return self._rank_local_tiling()
+        return nullcontext()
+
+    def _normalize_decoded_frames(self, decoded: torch.Tensor) -> torch.Tensor:
+        frames = self.model.processor.revert_tensor(decoded)
+        if frames.ndim == 4:
+            frames = frames.unsqueeze(0).transpose(1, 2)
+        if frames.ndim != 5:
+            raise ValueError(f"unexpected decoded video shape {tuple(frames.shape)}")
+        return frames.float()
+
+    def _chunk_process_group(self) -> dist.ProcessGroup | None:
+        if not self.is_distributed_enabled():
+            return None
+        group = self._native_parallel_state().get("sp_process_group")
+        if group is None or dist.get_world_size(group) != self.parallel_size:
+            raise RuntimeError("MiniMax-H3 VAE chunk decode has an invalid spatial-parallel group")
+        return group
+
+    @staticmethod
+    def _is_chunk_output_rank(
+        chunk_callback: MiniMaxH3VideoChunkCallback | None,
+        *,
+        group: dist.ProcessGroup | None,
+        device: torch.device,
+    ) -> bool:
+        if group is None:
+            return chunk_callback is not None
+
+        group_rank = dist.get_rank(group)
+        callback_owners = torch.tensor(
+            [int(chunk_callback is not None)],
+            dtype=torch.int32,
+            device=device,
+        )
+        dist.all_reduce(callback_owners, group=group)
+        valid_owner = int(callback_owners.item()) == 1 and ((group_rank == 0) == (chunk_callback is not None))
+        if not valid_owner:
+            raise ValueError("MiniMax-H3 chunk decode requires a callback on exactly VAE group rank 0")
+        return group_rank == 0
+
+    @staticmethod
+    def _synchronize_chunk_callback_error(
+        callback_error: BaseException | None,
+        *,
+        group: dist.ProcessGroup | None,
+        device: torch.device,
+    ) -> None:
+        if group is None:
+            if callback_error is not None:
+                raise callback_error
+            return
+
+        is_output_rank = dist.get_rank(group) == 0
+        failed = torch.tensor(
+            [int(is_output_rank and callback_error is not None)],
+            dtype=torch.int32,
+            device=device,
+        )
+        dist.broadcast(
+            failed,
+            src=dist.get_global_rank(group, 0),
+            group=group,
+        )
+        if int(failed.item()) == 0:
+            return
+        if is_output_rank:
+            assert callback_error is not None
+            raise callback_error
+        raise MiniMaxH3ChunkCallbackPeerError("MiniMax-H3 video chunk callback failed on this VAE group's output rank")
+
+    def _validate_vendor_chunk_api(self) -> None:
+        version = getattr(self.model, "temporal_chunk_callback_api_version", None)
+        if version != 1:
+            raise MiniMaxH3ChunkedDecodeUnsupportedError(
+                "Loaded MiniMax-H3 VAE does not provide temporal_chunk_callback API v1 "
+                f"(found {version!r}); install a model snapshot containing the official "
+                "MiniMax temporal chunk callback"
+            )
+
     @torch.inference_mode()
     def encode_image(self, image: Image.Image) -> torch.Tensor:
         previous_parallel = self.model.parallel_tiling
@@ -357,44 +496,120 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
 
     @torch.inference_mode()
     def decode_latent(self, latent: torch.Tensor) -> torch.Tensor:
-        channels = int(self.config_dict["latent_channels"])
-        mean = torch.tensor(
-            self.config_dict["latents_mean"],
-            device=latent.device,
-            dtype=latent.dtype,
-        ).view(1, channels, 1, 1, 1)
-        std = torch.tensor(
-            self.config_dict["latents_std"],
-            device=latent.device,
-            dtype=latent.dtype,
-        ).view(1, channels, 1, 1, 1)
-        # The checkpoint hands rank r the tiles ``range(r, num_tiles, sp_size)``
-        # and then rejects an empty share inside the gather. A rank with no
-        # tiles raises and leaves the collective while the others block in it
-        # forever, so too few tiles hangs the whole stage rather than failing
-        # it. Tile count depends only on the latent shape, so every rank takes
-        # this branch together.
-        num_tiles = self._decoder_tile_count(latent)
-        if self.parallel_size > 1 and num_tiles < self.parallel_size:
-            logger.warning_once(
-                "MiniMax-H3 VAE decode splits into %d tile(s) but the tile group has "
-                "%d ranks; decoding rank-locally for this shape instead, which is "
-                "slower but avoids ranks without tiles hanging the collective.",
-                num_tiles,
-                self.parallel_size,
-            )
-            tiling_context: AbstractContextManager = self._rank_local_tiling()
-        else:
-            tiling_context = nullcontext()
+        with self._decode_tiling_context(latent):
+            decoded = self.model.decode_base(self._denormalize_latent(latent))
+        return self._normalize_decoded_frames(decoded)
 
-        with tiling_context:
-            decoded = self.model.decode_base(latent * std + mean)
-        frames = self.model.processor.revert_tensor(decoded)
-        if frames.ndim == 4:
-            frames = frames.unsqueeze(0).transpose(1, 2)
-        if frames.ndim != 5:
-            raise ValueError(f"unexpected decoded video shape {tuple(frames.shape)}")
-        return frames.float()
+    @torch.inference_mode()
+    def decode_latent_with_chunks(
+        self,
+        latent: torch.Tensor,
+        chunk_callback: MiniMaxH3VideoChunkCallback | None,
+    ) -> torch.Tensor:
+        """Decode a video while publishing vendor-committed temporal chunks.
+
+        Every rank collaborating in the configured H3 VAE tile group must call
+        this method, with ``chunk_callback`` supplied only on group rank 0. A
+        callback failure is deferred until the vendor decoder finishes its
+        remaining collectives, then propagated to every group rank. With
+        ``parallel_size=1`` the runtime designates each request's output owner
+        by supplying a callback there and ``None`` on replica peers.
+
+        This is a model-local producer seam before the typed media boundary in
+        RFC #6541 / PR #6615. Representation conversion, transport,
+        presentation policy, and encoding remain runtime-owned. Chunks retain
+        the VAE canvas dimensions; a runtime consumer must apply the same
+        requested-size crop as the complete H3 pipeline output.
+        """
+
+        self._validate_vendor_chunk_api()
+        group = self._chunk_process_group()
+        is_output_rank = self._is_chunk_output_rank(
+            chunk_callback,
+            group=group,
+            device=latent.device,
+        )
+        callback_error: BaseException | None = None
+        next_chunk_index = 0
+        expected_total_chunks: int | None = None
+        next_frame_start = 0
+        saw_final = False
+
+        def publish(
+            decoded_chunk: torch.Tensor,
+            *,
+            chunk_index: int,
+            total_chunks: int,
+            frame_start: int,
+            is_final: bool,
+        ) -> None:
+            nonlocal callback_error, expected_total_chunks
+            nonlocal next_chunk_index, next_frame_start, saw_final
+            if not is_output_rank or callback_error is not None:
+                return
+            try:
+                if expected_total_chunks is None:
+                    expected_total_chunks = total_chunks
+                if (
+                    saw_final
+                    or total_chunks <= 0
+                    or total_chunks != expected_total_chunks
+                    or chunk_index != next_chunk_index
+                    or chunk_index >= total_chunks
+                    or frame_start != next_frame_start
+                    or is_final != (chunk_index + 1 == total_chunks)
+                ):
+                    raise RuntimeError(
+                        "MiniMax-H3 vendor callback emitted discontinuous chunk metadata: "
+                        f"index={chunk_index}/{next_chunk_index}, "
+                        f"total={total_chunks}/{expected_total_chunks}, "
+                        f"frame_start={frame_start}/{next_frame_start}, "
+                        f"final={is_final}, after_final={saw_final}"
+                    )
+                frames = self._normalize_decoded_frames(decoded_chunk)
+                frames = frames.clone(memory_format=torch.contiguous_format)
+                frame_count = int(frames.shape[2])
+                if frame_count <= 0:
+                    raise RuntimeError("MiniMax-H3 vendor callback emitted an empty chunk")
+                next_chunk_index += 1
+                next_frame_start += frame_count
+                saw_final = is_final
+                assert chunk_callback is not None
+                chunk_callback(
+                    frames,
+                    chunk_index=chunk_index,
+                    total_chunks=total_chunks,
+                    frame_start=frame_start,
+                    is_final=is_final,
+                )
+            except BaseException as exc:  # noqa: BLE001
+                # Keep a failed GPU chunk and its callback locals out of the
+                # traceback while peer ranks finish the remaining collectives.
+                exc.__traceback__ = None
+                callback_error = exc
+
+        with self._decode_tiling_context(latent):
+            decoded = self.model.decode_base(
+                self._denormalize_latent(latent),
+                temporal_chunk_callback=publish,
+            )
+        frames = self._normalize_decoded_frames(decoded)
+        if (
+            is_output_rank
+            and callback_error is None
+            and (not saw_final or next_chunk_index != expected_total_chunks or next_frame_start != int(frames.shape[2]))
+        ):
+            callback_error = RuntimeError(
+                "MiniMax-H3 vendor callback did not reconstruct the full decode: "
+                f"final={saw_final}, chunks={next_chunk_index}/{expected_total_chunks}, "
+                f"frames={next_frame_start}/{frames.shape[2]}"
+            )
+        self._synchronize_chunk_callback_error(
+            callback_error,
+            group=group,
+            device=frames.device,
+        )
+        return frames
 
 
 class MiniMaxH3AudioVAE(nn.Module):
@@ -516,4 +731,10 @@ class MiniMaxH3AudioVAE(nn.Module):
         return waveform.permute(1, 0, 2).contiguous().float()
 
 
-__all__ = ["MiniMaxH3AudioVAE", "MiniMaxH3VideoVAE"]
+__all__ = [
+    "MiniMaxH3AudioVAE",
+    "MiniMaxH3ChunkCallbackPeerError",
+    "MiniMaxH3ChunkedDecodeUnsupportedError",
+    "MiniMaxH3VideoChunkCallback",
+    "MiniMaxH3VideoVAE",
+]

--- a/vllm_omni/diffusion/models/minimax_h3/vae.py
+++ b/vllm_omni/diffusion/models/minimax_h3/vae.py
@@ -9,7 +9,7 @@ import json
 from collections.abc import Iterator
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any
 
 import torch
 import torch.distributed as dist
@@ -31,14 +31,14 @@ from vllm_omni.diffusion.offloader.module_residency import (
     PinnedModuleStager,
 )
 
+from .chunked_decode import (
+    MiniMaxH3ChunkCallbackPeerError,
+    MiniMaxH3ChunkedDecodeUnsupportedError,
+    MiniMaxH3VideoChunkCallback,
+    _MiniMaxH3ChunkDecodeCoordinator,
+)
 from .ops import install_h3_vae_optimizations
 from .packed_tokens import minimax_h3_patchify_video_latent
-from .temporal_chunks import (
-    MiniMaxH3TemporalChunkCompatibilityError,
-    MiniMaxH3TemporalDecodePlan,
-    decode_minimax_h3_temporal_chunks_compat,
-    prepare_minimax_h3_temporal_chunks_compat,
-)
 
 MINIMAX_H3_KEYFRAME_ENCODE_SEED = 42
 MINIMAX_H3_AUDIO_SAMPLE_RATE = 32000
@@ -46,35 +46,6 @@ MINIMAX_H3_AUDIO_CHANNELS = 2
 
 
 logger = init_logger(__name__)
-
-
-class MiniMaxH3VideoChunkCallback(Protocol):
-    """Consume one ordered, temporally committed H3 video chunk.
-
-    ``frames`` is an owned, contiguous float32 RGB tensor in ``BCTHW`` layout
-    and the ``[0, 1]`` value range. The callback runs synchronously on the
-    producer's current device stream. Before reading it on another stream, the
-    consumer must establish ordering from the producer stream (for example via
-    an event) and retain the allocation for that stream's lifetime.
-    """
-
-    def __call__(
-        self,
-        frames: torch.Tensor,
-        *,
-        chunk_index: int,
-        total_chunks: int,
-        frame_start: int,
-        is_final: bool,
-    ) -> None: ...
-
-
-class MiniMaxH3ChunkedDecodeUnsupportedError(RuntimeError):
-    """Raised when loaded MiniMax H3 code cannot honor the chunk contract."""
-
-
-class MiniMaxH3ChunkCallbackPeerError(RuntimeError):
-    """Raised on peer VAE ranks when the output-rank callback fails."""
 
 
 def _load_component_config(component_path: str) -> dict[str, Any]:
@@ -192,6 +163,7 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
         self.use_slicing = False
         self.parallel_size = 1
         self.device_module = torch.get_device_module()
+        self._chunk_decode_coordinator: _MiniMaxH3ChunkDecodeCoordinator | None = None
 
     def load_to_device(self) -> None:
         if self._stager is not None:
@@ -357,101 +329,6 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
             raise RuntimeError("MiniMax-H3 VAE chunk decode has an invalid spatial-parallel group")
         return group
 
-    @staticmethod
-    def _is_chunk_output_rank(
-        chunk_callback: MiniMaxH3VideoChunkCallback | None,
-        *,
-        group: dist.ProcessGroup | None,
-        device: torch.device,
-    ) -> bool:
-        if group is None:
-            return chunk_callback is not None
-
-        group_rank = dist.get_rank(group)
-        callback_owners = torch.tensor(
-            [int(chunk_callback is not None)],
-            dtype=torch.int32,
-            device=device,
-        )
-        dist.all_reduce(callback_owners, group=group)
-        valid_owner = int(callback_owners.item()) == 1 and ((group_rank == 0) == (chunk_callback is not None))
-        if not valid_owner:
-            raise ValueError("MiniMax-H3 chunk decode requires a callback on exactly VAE group rank 0")
-        return group_rank == 0
-
-    @staticmethod
-    def _synchronize_chunk_callback_error(
-        callback_error: BaseException | None,
-        *,
-        group: dist.ProcessGroup | None,
-        device: torch.device,
-    ) -> None:
-        if group is None:
-            if callback_error is not None:
-                raise callback_error
-            return
-
-        is_output_rank = dist.get_rank(group) == 0
-        failed = torch.tensor(
-            [int(is_output_rank and callback_error is not None)],
-            dtype=torch.int32,
-            device=device,
-        )
-        dist.broadcast(
-            failed,
-            src=dist.get_global_rank(group, 0),
-            group=group,
-        )
-        if int(failed.item()) == 0:
-            return
-        if is_output_rank:
-            assert callback_error is not None
-            raise callback_error
-        raise MiniMaxH3ChunkCallbackPeerError("MiniMax-H3 video chunk callback failed on this VAE group's output rank")
-
-    @staticmethod
-    def _synchronize_chunk_preflight_error(
-        preflight_error: Exception | None,
-        temporal_dtype: torch.dtype | None,
-        *,
-        group: dist.ProcessGroup | None,
-        device: torch.device,
-    ) -> None:
-        if group is None:
-            if preflight_error is not None:
-                raise preflight_error
-            return
-        failed = torch.tensor(
-            [int(preflight_error is not None)],
-            dtype=torch.int32,
-            device=device,
-        )
-        dist.all_reduce(failed, op=dist.ReduceOp.MAX, group=group)
-        if int(failed.item()) == 0:
-            dtype_codes = {
-                None: 0,
-                torch.float16: 1,
-                torch.bfloat16: 2,
-                torch.float32: 3,
-            }
-            code = torch.tensor(
-                [dtype_codes.get(temporal_dtype, -1)],
-                dtype=torch.int32,
-                device=device,
-            )
-            lowest = code.clone()
-            highest = code.clone()
-            dist.all_reduce(lowest, op=dist.ReduceOp.MIN, group=group)
-            dist.all_reduce(highest, op=dist.ReduceOp.MAX, group=group)
-            if int(lowest.item()) == int(highest.item()) and int(lowest.item()) >= 0:
-                return
-            raise MiniMaxH3ChunkedDecodeUnsupportedError(
-                "MiniMax-H3 VAE ranks selected incompatible temporal concat dtypes"
-            )
-        if preflight_error is not None:
-            raise preflight_error
-        raise MiniMaxH3ChunkedDecodeUnsupportedError("A peer VAE rank rejected the MiniMax-H3 temporal chunk preflight")
-
     @torch.inference_mode()
     def encode_image(self, image: Image.Image) -> torch.Tensor:
         previous_parallel = self.model.parallel_tiling
@@ -570,128 +447,14 @@ class MiniMaxH3VideoVAE(nn.Module, DistributedVaeMixin):
         requested-size crop as the complete H3 pipeline output.
         """
 
-        group = self._chunk_process_group()
-        plan: MiniMaxH3TemporalDecodePlan | None = None
-        preflight_error: Exception | None = None
-        if latent.ndim != 5:
-            preflight_error = MiniMaxH3ChunkedDecodeUnsupportedError(
-                f"MiniMax-H3 video latent must be rank 5, got {tuple(latent.shape)}"
-            )
-        else:
-            try:
-                denormalized = self._denormalize_latent(latent)
-                plan = prepare_minimax_h3_temporal_chunks_compat(
-                    self.model,
-                    denormalized,
-                    validate_sources=not getattr(
-                        self,
-                        "_minimax_h3_chunk_sources_validated",
-                        False,
-                    ),
-                )
-                self._minimax_h3_chunk_sources_validated = True
-                del denormalized
-            except MiniMaxH3TemporalChunkCompatibilityError as exc:
-                preflight_error = MiniMaxH3ChunkedDecodeUnsupportedError(str(exc))
-            except Exception as exc:  # noqa: BLE001
-                # Every VAE rank must reach the preflight reduction even when
-                # one node's private planner or environment fails locally.
-                exc.__traceback__ = None
-                preflight_error = exc
-        self._synchronize_chunk_preflight_error(
-            preflight_error,
-            plan.temporal_dtype if plan is not None else None,
-            group=group,
-            device=latent.device,
-        )
-        assert plan is not None
-        is_output_rank = self._is_chunk_output_rank(
+        if self._chunk_decode_coordinator is None:
+            self._chunk_decode_coordinator = _MiniMaxH3ChunkDecodeCoordinator()
+        return self._chunk_decode_coordinator.decode(
+            self,
+            latent,
             chunk_callback,
-            group=group,
-            device=latent.device,
+            group=self._chunk_process_group(),
         )
-        callback_error: BaseException | None = None
-        next_chunk_index = 0
-        expected_total_chunks: int | None = None
-        next_frame_start = 0
-        saw_final = False
-
-        def publish(
-            decoded_chunk: torch.Tensor,
-            *,
-            chunk_index: int,
-            total_chunks: int,
-            frame_start: int,
-            is_final: bool,
-        ) -> None:
-            nonlocal callback_error, expected_total_chunks
-            nonlocal next_chunk_index, next_frame_start, saw_final
-            if not is_output_rank or callback_error is not None:
-                return
-            try:
-                if expected_total_chunks is None:
-                    expected_total_chunks = total_chunks
-                if (
-                    saw_final
-                    or total_chunks <= 0
-                    or total_chunks != expected_total_chunks
-                    or chunk_index != next_chunk_index
-                    or chunk_index >= total_chunks
-                    or frame_start != next_frame_start
-                    or is_final != (chunk_index + 1 == total_chunks)
-                ):
-                    raise RuntimeError(
-                        "MiniMax-H3 temporal backend emitted discontinuous chunk metadata: "
-                        f"index={chunk_index}/{next_chunk_index}, "
-                        f"total={total_chunks}/{expected_total_chunks}, "
-                        f"frame_start={frame_start}/{next_frame_start}, "
-                        f"final={is_final}, after_final={saw_final}"
-                    )
-                frames = self._normalize_decoded_frames(decoded_chunk)
-                frames = frames.clone(memory_format=torch.contiguous_format)
-                frame_count = int(frames.shape[2])
-                if frame_count <= 0:
-                    raise RuntimeError("MiniMax-H3 temporal backend emitted an empty chunk")
-                next_chunk_index += 1
-                next_frame_start += frame_count
-                saw_final = is_final
-                assert chunk_callback is not None
-                chunk_callback(
-                    frames,
-                    chunk_index=chunk_index,
-                    total_chunks=total_chunks,
-                    frame_start=frame_start,
-                    is_final=is_final,
-                )
-            except BaseException as exc:  # noqa: BLE001
-                # Keep a failed GPU chunk and its callback locals out of the
-                # traceback while peer ranks finish the remaining collectives.
-                exc.__traceback__ = None
-                callback_error = exc
-
-        with self._decode_tiling_context(latent):
-            decoded = decode_minimax_h3_temporal_chunks_compat(
-                self.model,
-                plan,
-                publish,
-            )
-        frames = self._normalize_decoded_frames(decoded)
-        if (
-            is_output_rank
-            and callback_error is None
-            and (not saw_final or next_chunk_index != expected_total_chunks or next_frame_start != int(frames.shape[2]))
-        ):
-            callback_error = RuntimeError(
-                "MiniMax-H3 temporal backend did not reconstruct the full decode: "
-                f"final={saw_final}, chunks={next_chunk_index}/{expected_total_chunks}, "
-                f"frames={next_frame_start}/{frames.shape[2]}"
-            )
-        self._synchronize_chunk_callback_error(
-            callback_error,
-            group=group,
-            device=frames.device,
-        )
-        return frames
 
 
 class MiniMaxH3AudioVAE(nn.Module):


### PR DESCRIPTION
## Purpose

This PR adds a vLLM-Omni-owned MiniMax-H3 temporal VAE chunk callback for the currently released Hugging Face model code. It does not depend on a MiniMax repository or Hub update.

The released VAE does not expose its temporal assembler publicly, so the compatibility backend mirrors the Apache-2.0 temporal planning/assembly control flow using `MiniMaxAI/MiniMax-H3@42ed227ee7df40d41602854ae760620d6eb651fe` as its reference release. Runtime acceptance is content-based rather than a check of repository/revision metadata or weights. Chunk mode is fail-closed behind:

- the exact released, sorted 15-file top-level `video_vae/*.py` manifest (excluding `__init__.py`) SHA-256 `30e64afbaa940696bf8bfe2c86003a4b1666c84b22fa3aa12403a3e6a03f705d`;
- the released temporal configuration (`clip=17`, chunk/overlap/drop `5/2/3`, temporal ratio `4`, pre-padding/overlap `3/5`, no isolated head/tail frames); and
- structural, plan, dtype, ownership, and frame-count validation before decoder collectives.

A mismatching Python manifest or listed temporal configuration disables only `decode_latent_with_chunks()` with an actionable error. The gate does not inspect arbitrary component metadata or weights. The existing `decode_latent()` complete-output path does not fingerprint source code, add a rendezvous, or change behavior.

The callback publishes owned, contiguous RGB float32 `BCTHW` chunks in `[0, 1]`, with `chunk_index`, `total_chunks`, `frame_start`, and `is_final`. Publication happens after temporal overlap blending and final padding removal. The terminal callback is deferred until all frame-plan invariants pass.

The implementation is split by responsibility: `vae.py` owns VAE topology and a thin public facade, `chunked_decode.py` owns the callback contract and VAE-group coordination, and `temporal_chunks.py` owns only the released-source compatibility planner/assembler. The coordinator is a plain Python object that caches successful source validation only; it never retains a process group, callback, plan, or tensor between requests.

The internal [feature design](https://github.com/vllm-project/vllm-omni/blob/codex-minimax-h3-vendor-callback/docs/design/feature/minimax_h3_temporal_vae_chunks.md) documents the producer contract, source-gate provenance, limited model support, topology/platform compatibility, failure semantics, memory behavior, and the boundary with future typed-media/transport work. It is intentionally absent from the public user-selectable feature matrix because no runtime caller or configuration exists yet.

For distributed decode:

- every native VAE tile rank enters the method;
- exactly VAE-group rank 0 owns the callback;
- source/config/planner/dtype failures are reconciled before any rank enters `_adaptive_decode`;
- callback failures are retained while all remaining tile collectives finish, then the original error is raised on the owner and a peer error on the other VAE ranks;
- DP>1 combined with VAE patch parallelism fails closed until H3 uses a non-DP replica-local VAE group; and
- with `vae_patch_parallel_size=1`, the runtime supplies the callback only on the existing per-replica primary and no WORLD rendezvous is added.

This seam is intentionally upstream of #6541 / #6615. It does not add a media envelope, transport lease, SHM/ZMQ path, encoder, request-presentation policy, or public streaming protocol. A future runtime consumer remains responsible for the requested-size canvas crop, representation conversion, D2H/transport, encoding, cancellation, and audio/video composition.

[MiniMax-AI/MiniMax-H3#71](https://github.com/MiniMax-AI/MiniMax-H3/pull/71) remains a possible future way to replace the compatibility backend with a vendor hook, but it is not a dependency of this PR.

## Test Plan

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** `ff2e33a3290a9b7f0f24d76a733a130b01320bd6`

```bash
pytest -q -o addopts='' \
  tests/diffusion/models/minimax_h3/test_minimax_h3_vae_chunks.py \
  tests/diffusion/models/minimax_h3/test_minimax_h3_vae_tiling.py \
  tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py

pre-commit run --files \
  vllm_omni/diffusion/models/minimax_h3/chunked_decode.py \
  vllm_omni/diffusion/models/minimax_h3/temporal_chunks.py \
  vllm_omni/diffusion/models/minimax_h3/vae.py \
  tests/diffusion/models/minimax_h3/test_minimax_h3_vae_chunks.py

mkdocs build --strict
```

The tests cover:

- exact source-manifest acceptance and changed/missing/uninspectable source rejection;
- default-decode source-check bypass;
- temporal config and structural rejection;
- exact reconstruction, chunk sizes, continuity, `total_chunks`, and terminal metadata for T=33–37, 62, 72, and 107;
- retained ownership, unique storage, mutation isolation, and post-blend publication;
- early and final callback failures followed by a healthy second decode;
- real two-process Gloo cases for rank-asymmetric source/planner failures, dtype mismatch, wrong ownership, DP+VAE-PP rejection, symmetric callback failure, rank-local tiling fallback, and post-failure collective recovery;
- a real three-process Gloo case proving a sole callback on the wrong rank is rejected symmetrically before decoder collectives and the group remains healthy;
- single-rank native decoder exceptions propagate unchanged without an unsafe adapter rendezvous; and
- one-time source fingerprint caching per loaded VAE.

## Test Result

### CPU/static

- H3 callback + tiling + contract tests: **177 passed**.
- Applicable pre-commit hooks: **passed**, including Ruff, format, mypy 3.10, test marks, SPDX, forbidden imports, and no new `torch.cuda` call sites.
- Strict MkDocs build: **passed**; the design page is included under model-specific feature capabilities and all new links resolve.
- The exact cached 42ed bundle independently resolved to the expected manifest and produced the expected `17×7 + 5` plan without loading weights.
- CPU incremental mux fixture: byte-identical to the production complete-response mux path.

### Four-device real-checkpoint result

The benchmark loaded the untouched Hub snapshot directly:

`/data/models/hub/models--MiniMaxAI--MiniMax-H3/snapshots/42ed227ee7df40d41602854ae760620d6eb651fe/FL2VA`

Hardware evidence was collected at pre-rebase commit `34bf597842778717f41b31c1b40a8c1c4d16a9fe`; the tested implementation remained byte-identical through rebased head `60e9bbad5d21b87c8f93fc0ba6dfb4e919abd960`. Runtime head `0b5b0979` isolates callback/rank coordination behind a thin facade and makes callback-owner validation group-symmetric with the same one request-level reduction; it adds no per-chunk tensor work or collectives. Current head `ff2e33a3` adds documentation only. The 177-test suite (including real two- and three-rank Gloo failure/recovery), pre-commit gates, and strict documentation build passed on the corresponding current runtime/docs heads. The latency figures below remain attributed to the hardware-tested implementation rather than presented as a new post-refactor measurement.

Controlled setup: 4× NVIDIA L20X (`1,2,4,5`), CPU/memory bound to NUMA 0, torch 2.13.0+cu130, CUDA 13.0, PyAV 18.1.0, frozen seed-42 latent `1×24×62×48×84`, 209 frames at 1344×768/24 FPS, H.264 `ultrafast`/auto threads, stereo 32-kHz AAC, two pinned ring slots, one excluded warmup, and two alternating-order measured pairs. Model load and latent preparation were outside the timed arms; MP4 session creation and finalization were inside both arms.

| VAE-arm start → complete MP4 | Serial | Chunk-pipelined | Delta |
| --- | ---: | ---: | ---: |
| Mean ± sample stddev | 3.3298 ± 0.0174 s | 2.4451 ± 0.1387 s | −0.8847 s (−26.57%) |
| Round 1 | 3.3421 s | 2.3470 s | −0.9951 s |
| Round 2 | 3.3175 s | 2.5432 s | −0.7744 s |

One pipelined repetition included a 171-ms GPU preparation interval and correspondingly higher producer time; it is retained in the mean and uncertainty rather than discarded.

Every measured arm produced:

- chunk sizes `12×17 + 5` and maximum outstanding ownership matching the two-slot bound;
- frame SHA-256 `bb8c0a19b86c16ba112e6939dc51973b6f286eef2fabaca67a244885a47a2b4a`;
- 43,785,934-byte MP4 SHA-256 `d5ddc95d5565e27ce932cb1332c9cf023ecbac4aad5c3ffe09b33b00ce248636`;
- decoded-RGB SHA-256 `9c16d351d8df126079f4b8c38e6aa9e230c3e073ff7224c3fd029a23e70777e1`;
- 209 H.264 frames, 1344×768/24 FPS, 8.709 s duration, and stereo 32-kHz AAC.

Controlled-result JSON SHA-256: `fb044f11bfa74e722686ad75b20db82dfa554f3aa9ce9498947996cc75daca01`.

### Nsight overlap evidence

A separate one-L20X trace on the same callback implementation confirmed:

- 11/13 main D2H transfers overlapped VAE GPU kernels (1.767 ms union intersection);
- 12/13 MP4 chunk ranges overlapped VAE GPU kernels (729.083 ms union intersection);
- one D2H(N+1) transfer overlapped MP4(N) for 0.386 ms; and
- no sustained simultaneous VAE-kernel + D2H + MP4 three-stage intersection was observed.

The profiler-distorted timing is used only for overlap evidence. Trace SHA-256: `9df8afbdce5aaa90d94546a95453dd6804bc396bc5a3ff487f6e1515a40c82e5`.

### Independent B300 validation

@bobboli independently validated head `60e9bbad` on 4× B300 with the same seed-42 latent, 209-frame output, native VAE patch parallelism 4, two pinned slots, one excluded warmup, and two alternating-order measured pairs ([result](https://github.com/vllm-project/vllm-omni/pull/6885#issuecomment-5489576174)). Mean VAE invocation through MP4 finalization changed from `2.7917 s` to `1.7386 s` (`-37.72%`, `1.61×`), and all four measured outputs had identical frame and MP4 hashes within that environment. The two-pair spread was large (`-25.33%` and `-48.05%`), so this is independent feasibility evidence, not a stable production claim; the raw stage-wise harness and artifacts were not attached.

### Benchmark command

```bash
numactl --cpunodebind=0 --membind=0 \
  /home/hsliu/tmp/venvs/codex-hwr-vllm028-clean/bin/torchrun \
  --standalone --nproc-per-node=4 \
  benchmarks/diffusion/minimax_h3_output_overlap.py \
  --model /data/models/hub/models--MiniMaxAI--MiniMax-H3/snapshots/42ed227ee7df40d41602854ae760620d6eb651fe/FL2VA \
  --latent /tmp/codex-pr6607-eval-data/official_latent_seed42.pt \
  --frames 209 --height 768 --width 1344 \
  --fps 24 --audio-sample-rate 32000 \
  --ring-slots 2 --warmup 1 --rounds 2 \
  --codec-preset ultrafast --codec-threads 0
```

The feasibility harness is intentionally excluded from this model-only diff; it was run by absolute path from the final worktree, and its incremental mux path was separately checked byte-for-byte against the production complete-response encoder.

### Limitations

This is a source-gated model seam and feasibility result, not production-serving evidence. The timing bundle changes publication, per-chunk preparation, pinned-buffer reuse, D2H scheduling, and encoder concurrency together, so it does not isolate callback overhead. It bypasses production SHM/ZMQ, uses synthetic audio rather than audio-VAE overlap, and does not exercise cancellation, public streaming, multi-output leases, or cross-process cleanup. Runtime wiring remains follow-up work after the H3 video-plus-audio contract decision around #6615.

Related: #6872

The change was AI-assisted. The final diff was manually reviewed, passed the repository full pre-submit checklist, and was validated with CPU, real Gloo, real-checkpoint, four-device, and Nsight evidence.
