### PR TITLE
[Bugfix][Qwen2.5-Omni] Fix two stale call sites in the speech helpers

### DIFF
--- a/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni.py
@@ -862,61 +862,6 @@ class Qwen2_5OmniForConditionalGeneration(
         # Use thinker model for sampling
         return self.model.sample(logits, sampling_metadata)
 
-    def generate_speech(
-        self,
-        text_tokens: torch.Tensor,
-        sampling_metadata: SamplingMetadata,
-        voice_type: str = "default",
-    ) -> torch.Tensor:
-        """
-        Generate speech from text tokens using the talker and token2wav models.
-        This method is kept for backward compatibility and direct speech generation.
-
-        Args:
-            text_tokens: Text tokens from thinker model
-            sampling_metadata: Sampling metadata forwarded to the talker sampler
-            voice_type: Voice type for speech generation
-
-        Returns:
-            Audio tensor
-        """
-        # Generate codec tokens using talker model
-        talker_output = self.talker(input_ids=None, positions=None, inputs_embeds=text_tokens)
-
-        # Convert talker output to codec tokens
-        codec_tokens = self._convert_to_codec_tokens(talker_output, sampling_metadata)
-
-        # Generate audio using token2wav model
-        return self._codec_to_audio(codec_tokens, voice_type=voice_type)
-
-    def _convert_to_codec_tokens(
-        self, talker_output: torch.Tensor, sampling_metadata: SamplingMetadata
-    ) -> torch.Tensor:
-        """
-        Reference (HF): use the talker's codec head to obtain logits, suppress BOS,
-        then greedily select the next codec token for the current step.
-        """
-        with torch.inference_mode():
-            logits = self.talker.compute_logits(talker_output, None)
-            if logits is None:
-                return torch.zeros(
-                    (talker_output.size(0), 0),
-                    dtype=torch.long,
-                    device=talker_output.device,
-                )
-
-            # Suppress only codec_bos, consistent with HF generate's
-            # suppress_tokens behavior
-            bos_id = None
-            if hasattr(self, "talker_config") and hasattr(self.talker_config, "tts_codec_start_token_id"):
-                bos_id = int(getattr(self.talker_config, "tts_codec_start_token_id"))
-            if bos_id is not None:
-                logits[..., bos_id] = -1e9
-
-            # Take the distribution at the last step and select greedily
-            next_id = self.talker.sample(logits, sampling_metadata).sampled_token_ids
-            return next_id.to(dtype=torch.long)
-
     def _init_token2wav_model(self, hf_model_folder):
         """Initialize speaker resources if provided; model is constructed in
         __init__."""

--- a/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni.py
@@ -862,13 +862,19 @@ class Qwen2_5OmniForConditionalGeneration(
         # Use thinker model for sampling
         return self.model.sample(logits, sampling_metadata)
 
-    def generate_speech(self, text_tokens: torch.Tensor, voice_type: str = "default") -> torch.Tensor:
+    def generate_speech(
+        self,
+        text_tokens: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+        voice_type: str = "default",
+    ) -> torch.Tensor:
         """
         Generate speech from text tokens using the talker and token2wav models.
         This method is kept for backward compatibility and direct speech generation.
 
         Args:
             text_tokens: Text tokens from thinker model
+            sampling_metadata: Sampling metadata forwarded to the talker sampler
             voice_type: Voice type for speech generation
 
         Returns:
@@ -878,7 +884,7 @@ class Qwen2_5OmniForConditionalGeneration(
         talker_output = self.talker(input_ids=None, positions=None, inputs_embeds=text_tokens)
 
         # Convert talker output to codec tokens
-        codec_tokens = self._convert_to_codec_tokens(talker_output)
+        codec_tokens = self._convert_to_codec_tokens(talker_output, sampling_metadata)
 
         # Generate audio using token2wav model
         return self._codec_to_audio(codec_tokens, voice_type=voice_type)
@@ -942,8 +948,6 @@ class Qwen2_5OmniForConditionalGeneration(
                     self._token2wav_ref_mels[key] = torch.as_tensor(np.load(f), device=device)
 
     def _codec_to_audio(self, codec_tokens: torch.Tensor, voice_type: str = "default") -> torch.Tensor | None:
-        if self.token2wav is None:
-            self._init_token2wav_model()
         if self.token2wav is None:
             return None
         # Normalize voice type


### PR DESCRIPTION
## Problem

`Qwen2_5OmniForConditionalGeneration` has two call sites that no longer match the signature they invoke. Both raise `TypeError` the moment they run.

### 1. `_codec_to_audio` → `_init_token2wav_model()`

```python
def _init_token2wav_model(self, hf_model_folder):          # requires hf_model_folder
    """Initialize speaker resources if provided; model is constructed in
    __init__."""
    if self.token2wav is None or self.token2wav_config is None:
        return
    ...
```

| call site | argument passed | result |
|---|---|---|
| `load_weights` (line 1090) | `hf_model_folder` | ok |
| `_codec_to_audio` (line 946) | *none* | `TypeError` |

The broken call is also **dead code**, independent of the missing argument:

```python
if self.token2wav is None:
    self._init_token2wav_model()   # <- returns immediately when token2wav is None
if self.token2wav is None:
    return None
```

`_init_token2wav_model` bails out on its very first line when `self.token2wav is None`, which is exactly the condition guarding the call — so it can never do what the guard intends. It only loads *speaker resources*; the token2wav model itself is built in `__init__`, as the docstring says.

Removing the two lines leaves the already-present `if self.token2wav is None: return None`, which returns gracefully instead of raising.

### 2. `generate_speech` → `_convert_to_codec_tokens(talker_output)`

```python
def _convert_to_codec_tokens(
    self, talker_output: torch.Tensor, sampling_metadata: SamplingMetadata
) -> torch.Tensor:
    ...
    next_id = self.talker.sample(logits, sampling_metadata).sampled_token_ids
```

`generate_speech` is the only caller and passes just `talker_output`, so the method cannot run today. `sampling_metadata` is threaded through `generate_speech` and placed where `sample()` already puts it (right after the tensor, before the optional args). There are no in-tree callers of `generate_speech` to update.

## Verification

No GPU here, so I replayed both call sites against stubs extracted from the real file with `ast`, bound via `inspect.Signature.bind`, with the known-good sibling call site as a control:

```
### vllm-omni  Qwen2_5OmniForConditionalGeneration
  signature: (self, hf_model_folder)
  OK    line 1090 (control, load_weights)
  RAISE line  946 (flagged, _codec_to_audio): TypeError: missing a required argument: 'hf_model_folder'
  signature: (self, talker_output, sampling_metadata)
  RAISE line  881 (flagged, generate_speech): TypeError: missing a required argument: 'sampling_metadata'
```

The green control proves the harness is exercising the real signature rather than reporting a stub artifact.

`ruff check` and `ruff format --check` (v0.14.10, the `.pre-commit-config.yaml` pin) both pass on the modified file, run from the repo root.

## Note

If you would rather retire `generate_speech` than repair it — it is described as kept for backward compatibility, has no in-tree callers, and has been unusable for as long as `_convert_to_codec_tokens` has required `sampling_metadata` — say the word and I will replace that half with a removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
