### PR TITLE
[Config] Migrate DiT stage consumers to VllmOmniConfig

### DIFF
--- a/tests/config/test_config_factory.py
+++ b/tests/config/test_config_factory.py
@@ -15,6 +15,14 @@ from transformers import PretrainedConfig, Qwen3OmniMoeConfig
 
 from tests.helpers.stage_config import get_deploy_config_path, get_deploy_config_stage
 from vllm_omni.config import config_factory as config_factory_module
+from vllm_omni.config.composable_parallel import (
+    Broadcast,
+    FanInByStage,
+    MeshAxisSpec,
+    RouteByStage,
+    StrategySpec,
+    TakeRank,
+)
 from vllm_omni.config.config_factory import StageConfigFactory, _materialize_object_storage_configs
 from vllm_omni.config.endpoint_policy import EndpointRestriction, OmniServingCapability
 from vllm_omni.config.omni_config import VllmOmniConfig
@@ -612,6 +620,75 @@ class TestPipelineDiscovery:
         assert OMNI_PIPELINES.get("definitely_not_a_real_model") is None
         assert resolve_pipeline_config("definitely_not_a_real_model") is None
 
+    def test_pipeline_discovery_is_revision_aware(self, clean_pipeline_registry, monkeypatch):
+        """A pinned Hub revision must shape both discovery and its cache key."""
+        pipeline_key = "revision_aware_pipeline"
+        pipeline = PipelineConfig(model_type=pipeline_key)
+        register_pipeline(pipeline)
+        observed_revisions: list[str | None] = []
+
+        class FakeConfig(PretrainedConfig):
+            model_type = pipeline_key
+
+        def fake_get_config(_model, *, trust_remote_code, **kwargs):
+            assert trust_remote_code is False
+            observed_revisions.append(kwargs.get("revision"))
+            return FakeConfig()
+
+        monkeypatch.setattr(config_factory_module, "get_config", fake_get_config)
+        StageConfigFactory.get_hf_config.cache_clear()
+        StageConfigFactory.try_infer_model_type.cache_clear()
+
+        first = StageConfigFactory.get_pipeline_config(
+            "org/revision-aware",
+            trust_remote_code=False,
+            revision="refs/pr/41",
+        )
+        second = StageConfigFactory.get_pipeline_config(
+            "org/revision-aware",
+            trust_remote_code=False,
+            revision="refs/pr/42",
+        )
+
+        assert first is pipeline
+        assert second is pipeline
+        assert observed_revisions == ["refs/pr/41", "refs/pr/42"]
+
+    def test_diffusers_model_index_discovery_preserves_revision(self, clean_pipeline_registry, monkeypatch):
+        """The config-less Diffusers fallback must read the requested revision."""
+        pipeline = PipelineConfig(
+            model_type="revision_diffusers_pipeline",
+            diffusers_class_name="RevisionPipeline",
+        )
+        register_pipeline(pipeline)
+        observed: list[tuple[str, str | None]] = []
+
+        def fail_get_config(*_args, **_kwargs):
+            raise ValueError("custom config parser unavailable")
+
+        def fake_get_hf_file_to_dict(filename, _model, *, revision):
+            observed.append((filename, revision))
+            if filename == "model_index.json":
+                return {"_class_name": "RevisionPipeline"}
+            return None
+
+        monkeypatch.setattr(config_factory_module, "get_config", fail_get_config)
+        monkeypatch.setattr(config_factory_module, "get_hf_file_to_dict", fake_get_hf_file_to_dict)
+        StageConfigFactory.get_hf_config.cache_clear()
+        StageConfigFactory.try_infer_model_type.cache_clear()
+
+        resolved = StageConfigFactory.get_pipeline_config(
+            "org/revision-diffusers",
+            trust_remote_code=False,
+            revision="refs/pr/99",
+        )
+
+        assert resolved is pipeline
+        assert observed == [
+            ("config.json", "refs/pr/99"),
+            ("model_index.json", "refs/pr/99"),
+        ]
+
     def test_pipeline_config_supports_hf_architectures(self):
         """PipelineConfig accepts hf_architectures for HF-arch fallback
         (replaces the old _ARCHITECTURE_MODELS dict)."""
@@ -1049,6 +1126,138 @@ class TestPipelineRegistration:
         assert len(legacy_configs) == 1
         assert legacy_configs[0].yaml_engine_args["model_arch"] == "DeployOnlyArch"
 
+    def test_shared_resolver_aligns_effective_stage_views(self, clean_pipeline_registry, monkeypatch, tmp_path):
+        from vllm_omni.config import omni_config as omni_config_module
+        from vllm_omni.config import stage_config as stage_config_module
+
+        pipeline_key = "shared_stage_views"
+        pipeline = PipelineConfig(
+            model_type=pipeline_key,
+            model_arch="SharedViewsModel",
+            stages=(
+                StagePipelineConfig(
+                    stage_id=0,
+                    model_stage="ar",
+                    execution_type=StageExecutionType.LLM_AR,
+                ),
+                StagePipelineConfig(
+                    stage_id=1,
+                    model_stage="generation",
+                    execution_type=StageExecutionType.LLM_GENERATION,
+                    input_sources=(0,),
+                ),
+                StagePipelineConfig(
+                    stage_id=2,
+                    model_stage="dit",
+                    execution_type=StageExecutionType.DIFFUSION,
+                    input_sources=(1,),
+                    final_output=True,
+                    final_output_type="image",
+                    model_arch="SharedViewsDiT",
+                ),
+            ),
+        )
+        register_pipeline(pipeline)
+        deploy_path = tmp_path / "shared_views.yaml"
+        deploy_path.write_text(
+            f"pipeline: {pipeline_key}\n"
+            "async_chunk: false\n"
+            "stages:\n"
+            "  - stage_id: 0\n"
+            "    runtime:\n"
+            '      devices: "0"\n'
+            "  - stage_id: 1\n"
+            "    runtime:\n"
+            '      devices: "1"\n'
+            "  - stage_id: 2\n"
+            "    runtime:\n"
+            '      devices: "2,3"\n'
+            "      env:\n"
+            "        BASE_ENV: base\n"
+            "platforms:\n"
+            "  cpu:\n"
+            "    stages:\n"
+            "      - stage_id: 2\n"
+            "        engine_args: {}\n"
+            "        runtime:\n"
+            '          devices: "4,5"\n'
+            "          env:\n"
+            "            PLATFORM_ENV: cpu\n",
+            encoding="utf-8",
+        )
+
+        # Standalone builders retain their own platform resolution. In the
+        # shared path only the factory receives a deploy with an unmaterialized
+        # platform block; both downstream views receive effective copies.
+        apply_platform_overrides = stage_config_module._apply_platform_overrides
+        platform_block_seen: list[bool] = []
+
+        def tracked_platform_overrides(deploy, platform=None):
+            platform_block_seen.append(deploy.platforms is not None)
+            return apply_platform_overrides(deploy, platform)
+
+        monkeypatch.setattr(config_factory_module, "_apply_platform_overrides", tracked_platform_overrides)
+        monkeypatch.setattr(stage_config_module, "_apply_platform_overrides", tracked_platform_overrides)
+        monkeypatch.setattr(omni_config_module, "_apply_platform_overrides", tracked_platform_overrides)
+
+        tp = StrategySpec("tp", MeshAxisSpec("tp", 2), Broadcast(), TakeRank())
+        stage_replica = StrategySpec(
+            "stage_replica",
+            MeshAxisSpec("stage_replica", 2),
+            RouteByStage("round_robin"),
+            FanInByStage(),
+        )
+
+        class FakeConfig(PretrainedConfig):
+            model_type = "unregistered"
+
+        with patch("vllm_omni.config.config_factory.get_config", return_value=FakeConfig()):
+            resolved = StageConfigFactory.create_config_views_from_model(
+                "fake/model",
+                trust_remote_code=False,
+                cli_overrides={
+                    "stage_0_max_num_seqs": 7,
+                    "num_gpus": 8,
+                    "stage_2_num_gpus": 4,
+                    "stage_2_diffusion_quantization_config": "fp8",
+                },
+                deploy_config_path=str(deploy_path),
+                strategy_specs={"dit": [tp, stage_replica]},
+            )
+
+        assert resolved.omni_config is not None
+        assert resolved.legacy_stage_configs is not None
+        typed_stages = resolved.omni_config.stage_configs
+        legacy_stages = resolved.legacy_stage_configs
+        assert [(stage.stage_id, StageType(stage.stage_type), stage.model_stage) for stage in typed_stages] == [
+            (stage.stage_id, StageType(stage.stage_type), stage.model_stage) for stage in legacy_stages
+        ]
+        assert [stage.worker_type for stage in legacy_stages[:2]] == ["ar", "generation"]
+        assert legacy_stages[0].to_omegaconf().engine_args.max_num_seqs == 7
+        assert all("num_gpus" not in stage.to_omegaconf().engine_args for stage in legacy_stages[:2])
+        assert [stage.runtime_config.num_gpus for stage in typed_stages[:2]] == [
+            stage.parallel_config.world_size for stage in typed_stages[:2]
+        ]
+
+        typed_dit = resolved.omni_config.stage_by_id(2)
+        legacy_dit = legacy_stages[2].to_omegaconf()
+        assert typed_dit.runtime_config.devices == legacy_dit.runtime.devices == "4,5"
+        assert (
+            typed_dit.runtime_config.env
+            == legacy_dit.runtime.env
+            == {
+                "BASE_ENV": "base",
+                "PLATFORM_ENV": "cpu",
+            }
+        )
+        assert typed_dit.runtime_config.num_replicas == legacy_dit.runtime.num_replicas == 2
+        assert typed_dit.parallel_config.tensor_parallel_size == legacy_dit.engine_args.tensor_parallel_size == 2
+        assert typed_dit.runtime_config.num_gpus == legacy_dit.engine_args.num_gpus == 4
+        assert typed_dit.quantization_config == legacy_dit.engine_args.quantization_config == "fp8"
+        assert resolved.omni_lb_policy == "round-robin"
+        assert resolved.deploy_config is not None and resolved.deploy_config.platforms is not None
+        assert platform_block_seen == [True, False, False]
+
     def test_structured_path_loads_explicit_deploy_config_once(self, clean_pipeline_registry, tmp_path):
         pipeline_key = "single_load_pipeline"
         register_pipeline(PipelineConfig(model_type=pipeline_key))
@@ -1474,6 +1683,89 @@ stages:
 
         with pytest.raises(ValueError, match="stage_1_text_encoder_tp_size cannot be set"):
             normalize_pipeline_cli_overrides(pipeline, {"stage_1_text_encoder_tp_size": 4})
+
+    def test_resolve_user_deploy_path_adds_yaml_suffix_for_bare_name(self):
+        resolved = StageConfigFactory._resolve_user_deploy_path("dreamzero_tp1_cfg2")
+
+        assert resolved == _DEPLOY_DIR / "dreamzero_tp1_cfg2.yaml"
+
+    def test_diffusion_only_cli_values_route_to_diffusion_stages(self):
+        pipeline = PipelineConfig(
+            model_type="mixed_diffusion_cli",
+            stages=(
+                StagePipelineConfig(
+                    stage_id=0,
+                    model_stage="ar",
+                    execution_type=StageExecutionType.LLM_AR,
+                ),
+                StagePipelineConfig(
+                    stage_id=1,
+                    model_stage="dit",
+                    execution_type=StageExecutionType.DIFFUSION,
+                    input_sources=(0,),
+                    final_output=True,
+                    final_output_type="image",
+                ),
+            ),
+        )
+
+        normalized = normalize_pipeline_cli_overrides(
+            pipeline,
+            {
+                "diffusion_streaming_output": False,
+                "auxiliary_text_encoder": "/models/llama",
+                "cache_backend": "cache_dit",
+                "diffusion_quantization_config": "fp8",
+                "stage_1_cache_backend": "tea_cache",
+            },
+        )
+
+        assert normalized == {
+            "stage_1_streaming_output": False,
+            "stage_1_auxiliary_text_encoder": "/models/llama",
+            "stage_1_cache_backend": "tea_cache",
+            "stage_1_diffusion_quantization_config": "fp8",
+        }
+
+    def test_diffusion_only_cli_values_are_dropped_without_diffusion_stage(self):
+        pipeline = PipelineConfig(
+            model_type="llm_only_cli",
+            stages=(
+                StagePipelineConfig(
+                    stage_id=0,
+                    model_stage="ar",
+                    execution_type=StageExecutionType.LLM_AR,
+                    final_output=True,
+                ),
+            ),
+        )
+
+        assert (
+            normalize_pipeline_cli_overrides(
+                pipeline,
+                {
+                    "diffusion_streaming_output": True,
+                    "cache_backend": "cache_dit",
+                    "model_class_name": "DiffusionPipeline",
+                },
+            )
+            == {}
+        )
+
+    def test_shared_sleep_mode_override_reaches_all_stage_views(self):
+        pipeline = OMNI_PIPELINES["hunyuan_image_3_moe"]
+
+        legacy_stages, _ = StageConfigFactory._create_legacy_from_registry(
+            pipeline,
+            {"enable_sleep_mode": True},
+        )
+        assert all(stage.to_omegaconf().engine_args.get("enable_sleep_mode") is True for stage in legacy_stages)
+
+        typed = VllmOmniConfig.from_pipeline_config(
+            pipeline,
+            cli_overrides={"model": "hy3", "enable_sleep_mode": True},
+        )
+        assert all(stage.model_config.enable_sleep_mode is True for stage in typed.stage_configs)
 
     @pytest.mark.parametrize(
         ("config_json", "model_index", "expected_pipeline"),

--- a/tests/config/test_config_factory.py
+++ b/tests/config/test_config_factory.py
@@ -15,6 +15,14 @@ from transformers import PretrainedConfig, Qwen3OmniMoeConfig
 
 from tests.helpers.stage_config import get_deploy_config_path, get_deploy_config_stage
 from vllm_omni.config import config_factory as config_factory_module
+from vllm_omni.config.composable_parallel import (
+    Broadcast,
+    FanInByStage,
+    MeshAxisSpec,
+    RouteByStage,
+    StrategySpec,
+    TakeRank,
+)
 from vllm_omni.config.config_factory import StageConfigFactory, _materialize_object_storage_configs
 from vllm_omni.config.endpoint_policy import EndpointRestriction, OmniServingCapability
 from vllm_omni.config.omni_config import VllmOmniConfig
@@ -996,6 +1004,133 @@ class TestPipelineRegistration:
         assert legacy_configs is not None
         assert len(legacy_configs) == 1
         assert legacy_configs[0].yaml_engine_args["model_arch"] == "DeployOnlyArch"
+
+    def test_shared_resolver_aligns_effective_stage_views(self, clean_pipeline_registry, monkeypatch, tmp_path):
+        from vllm_omni.config import omni_config as omni_config_module
+        from vllm_omni.config import stage_config as stage_config_module
+
+        pipeline_key = "shared_stage_views"
+        pipeline = PipelineConfig(
+            model_type=pipeline_key,
+            model_arch="SharedViewsModel",
+            stages=(
+                StagePipelineConfig(
+                    stage_id=0,
+                    model_stage="ar",
+                    execution_type=StageExecutionType.LLM_AR,
+                ),
+                StagePipelineConfig(
+                    stage_id=1,
+                    model_stage="generation",
+                    execution_type=StageExecutionType.LLM_GENERATION,
+                    input_sources=(0,),
+                ),
+                StagePipelineConfig(
+                    stage_id=2,
+                    model_stage="dit",
+                    execution_type=StageExecutionType.DIFFUSION,
+                    input_sources=(1,),
+                    final_output=True,
+                    final_output_type="image",
+                    model_arch="SharedViewsDiT",
+                ),
+            ),
+        )
+        register_pipeline(pipeline)
+        deploy_path = tmp_path / "shared_views.yaml"
+        deploy_path.write_text(
+            f"pipeline: {pipeline_key}\n"
+            "async_chunk: false\n"
+            "stages:\n"
+            "  - stage_id: 0\n"
+            "    runtime:\n"
+            '      devices: "0"\n'
+            "  - stage_id: 1\n"
+            "    runtime:\n"
+            '      devices: "1"\n'
+            "  - stage_id: 2\n"
+            "    runtime:\n"
+            '      devices: "2,3"\n'
+            "      env:\n"
+            "        BASE_ENV: base\n"
+            "platforms:\n"
+            "  cpu:\n"
+            "    stages:\n"
+            "      - stage_id: 2\n"
+            "        engine_args: {}\n"
+            "        runtime:\n"
+            '          devices: "4,5"\n'
+            "          env:\n"
+            "            PLATFORM_ENV: cpu\n",
+            encoding="utf-8",
+        )
+
+        # Standalone builders retain their own platform resolution. In the
+        # shared path only the factory receives a deploy with an unmaterialized
+        # platform block; both downstream views receive effective copies.
+        apply_platform_overrides = stage_config_module._apply_platform_overrides
+        platform_block_seen: list[bool] = []
+
+        def tracked_platform_overrides(deploy, platform=None):
+            platform_block_seen.append(deploy.platforms is not None)
+            return apply_platform_overrides(deploy, platform)
+
+        monkeypatch.setattr(config_factory_module, "_apply_platform_overrides", tracked_platform_overrides)
+        monkeypatch.setattr(stage_config_module, "_apply_platform_overrides", tracked_platform_overrides)
+        monkeypatch.setattr(omni_config_module, "_apply_platform_overrides", tracked_platform_overrides)
+
+        tp = StrategySpec("tp", MeshAxisSpec("tp", 2), Broadcast(), TakeRank())
+        stage_replica = StrategySpec(
+            "stage_replica",
+            MeshAxisSpec("stage_replica", 2),
+            RouteByStage("round_robin"),
+            FanInByStage(),
+        )
+
+        class FakeConfig(PretrainedConfig):
+            model_type = "unregistered"
+
+        with patch("vllm_omni.config.config_factory.get_config", return_value=FakeConfig()):
+            resolved = StageConfigFactory.create_config_views_from_model(
+                "fake/model",
+                trust_remote_code=False,
+                cli_overrides={
+                    "stage_0_max_num_seqs": 7,
+                    "stage_2_num_gpus": 4,
+                    "stage_2_diffusion_quantization_config": "fp8",
+                },
+                deploy_config_path=str(deploy_path),
+                strategy_specs={"dit": [tp, stage_replica]},
+            )
+
+        assert resolved.omni_config is not None
+        assert resolved.legacy_stage_configs is not None
+        typed_stages = resolved.omni_config.stage_configs
+        legacy_stages = resolved.legacy_stage_configs
+        assert [(stage.stage_id, StageType(stage.stage_type), stage.model_stage) for stage in typed_stages] == [
+            (stage.stage_id, StageType(stage.stage_type), stage.model_stage) for stage in legacy_stages
+        ]
+        assert [stage.worker_type for stage in legacy_stages[:2]] == ["ar", "generation"]
+        assert legacy_stages[0].to_omegaconf().engine_args.max_num_seqs == 7
+
+        typed_dit = resolved.omni_config.stage_by_id(2)
+        legacy_dit = legacy_stages[2].to_omegaconf()
+        assert typed_dit.runtime_config.devices == legacy_dit.runtime.devices == "4,5"
+        assert (
+            typed_dit.runtime_config.env
+            == legacy_dit.runtime.env
+            == {
+                "BASE_ENV": "base",
+                "PLATFORM_ENV": "cpu",
+            }
+        )
+        assert typed_dit.runtime_config.num_replicas == legacy_dit.runtime.num_replicas == 2
+        assert typed_dit.parallel_config.tensor_parallel_size == legacy_dit.engine_args.tensor_parallel_size == 2
+        assert typed_dit.runtime_config.num_gpus == legacy_dit.engine_args.num_gpus == 4
+        assert typed_dit.quantization_config == legacy_dit.engine_args.quantization_config == "fp8"
+        assert resolved.omni_lb_policy == "round-robin"
+        assert resolved.deploy_config is not None and resolved.deploy_config.platforms is not None
+        assert platform_block_seen == [True, False, False]
 
     def test_structured_path_loads_explicit_deploy_config_once(self, clean_pipeline_registry, tmp_path):
         pipeline_key = "single_load_pipeline"

--- a/tests/config/test_omni_config.py
+++ b/tests/config/test_omni_config.py
@@ -50,7 +50,10 @@ from vllm_omni.config.stage_config import (
 )
 from vllm_omni.diffusion.diffusion_kv.config import DiffusionKVCacheMode
 from vllm_omni.engine.stage_engine_startup import _serialize_stage_config
-from vllm_omni.engine.stage_init_utils import build_legacy_engine_args_dict
+from vllm_omni.engine.stage_init_utils import (
+    build_engine_args_dict_from_omni_stage_config,
+    build_legacy_engine_args_dict,
+)
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -302,17 +305,31 @@ def test_runtime_num_gpus_is_derived_from_parallel_world_size():
     assert stage.runtime_config.num_gpus == 4
 
 
-def test_runtime_num_gpus_ignores_stale_runtime_override():
+def test_diffusion_runtime_preserves_explicit_num_gpus_for_terminal_dp_resolution():
     omni_config = _from_pipeline_key(
-        "hunyuan_image3_dit",
+        "hunyuan_video_15",
         cli_overrides={
-            "stage_0_num_gpus": 1,
+            "stage_0_num_gpus": 8,
         },
     )
     stage = omni_config.stage_by_id(0)
 
-    assert stage.parallel_config.world_size == 4
-    assert stage.runtime_config.num_gpus == 4
+    assert stage.parallel_config.world_size == 1
+    assert stage.parallel_config.data_parallel_size == 1
+    assert "data_parallel_size" not in stage.parallel_config._omni_explicit_fields
+    assert stage.runtime_config.num_gpus == 8
+    engine_args = build_engine_args_dict_from_omni_stage_config(stage, "/tmp")
+    assert engine_args["num_gpus"] == 8
+    assert "data_parallel_size" not in engine_args["parallel_config"]
+
+
+def test_diffusion_quantization_cli_alias_maps_to_structured_owner():
+    stage = _from_pipeline_key(
+        "hunyuan_image3_dit",
+        cli_overrides={"diffusion_quantization_config": "fp8"},
+    ).stage_by_id(0)
+
+    assert stage.quantization_config == "fp8"
 
 
 def test_from_pipeline_config_does_not_route_server_cli_keys_to_diffusion_stage():

--- a/tests/config/test_omni_config.py
+++ b/tests/config/test_omni_config.py
@@ -45,12 +45,16 @@ from vllm_omni.config.stage_config import (
     PipelineConfig,
     StageDeployConfig,
     StageExecutionType,
+    StagePipelineConfig,
     load_deploy_config,
     merge_pipeline_deploy,
 )
 from vllm_omni.diffusion.diffusion_kv.config import DiffusionKVCacheMode
 from vllm_omni.engine.stage_engine_startup import _serialize_stage_config
-from vllm_omni.engine.stage_init_utils import build_legacy_engine_args_dict
+from vllm_omni.engine.stage_init_utils import (
+    build_engine_args_dict_from_omni_stage_config,
+    build_legacy_engine_args_dict,
+)
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -90,6 +94,139 @@ def _from_pipeline_key(
         deploy_config_path=deploy_config_path,
         cli_overrides=cli_overrides,
     )
+
+
+def test_qwen3_omni_full_pipeline_keeps_all_consumers_on_llm_views() -> None:
+    pipeline = _resolve_pipeline_or_skip("qwen3_omni_moe", Qwen3OmniMoeConfig(enable_audio_output=True))
+    omni_config = VllmOmniConfig.from_pipeline_config(pipeline, cli_overrides={"model": "qwen3-omni"})
+
+    assert [type(stage).__name__ for stage in omni_config.stage_configs] == [
+        "VllmOmniARStageConfig",
+        "VllmOmniARStageConfig",
+        "VllmOmniGenerationStageConfig",
+    ]
+    assert all(stage.stage_type != StageExecutionType.DIFFUSION for stage in omni_config.stage_configs)
+    assert [stage.stage_id for stage in omni_config.stage_configs] == [0, 1, 2]
+
+
+def test_wan22_default_deploy_is_consumed_by_typed_diffusion_stage() -> None:
+    omni_config = _from_pipeline_key("wan2_2_ti2v", cli_overrides={"model": "wan22"})
+    stage = omni_config.stage_by_id(0)
+
+    assert isinstance(stage, VllmOmniDiffusionStageConfig)
+    assert stage.model_config.model_arch == "WanPipeline"
+    assert stage.diffusion_config.model_class_name == "WanPipeline"
+    assert stage.diffusion_config.vae_use_tiling is True
+    assert stage.scheduler_config.max_num_seqs == 4
+    assert stage.runtime_config.devices == "0"
+    assert stage.runtime_config.num_gpus == 1
+    assert stage.diffusion_config.revision is None
+    # HiDream's auxiliary encoder settings are model-private and must not be
+    # injected into unrelated diffusion stages.
+    assert stage.diffusion_config.extras == {}
+
+
+def test_hidream_diffusion_projection_keeps_model_specific_defaults() -> None:
+    topology = StagePipelineConfig(
+        stage_id=0,
+        model_stage="dit",
+        execution_type=StageExecutionType.DIFFUSION,
+        final_output=True,
+        final_output_type="image",
+        model_arch="HiDreamImagePipeline",
+    )
+    pipeline = PipelineConfig(
+        model_type="hidream_projection_test",
+        model_arch="HiDreamImagePipeline",
+        stages=(topology,),
+    )
+    deploy = DeployConfig(stages=[StageDeployConfig(stage_id=0, devices="0")])
+
+    stage = VllmOmniConfig.from_pipeline_config(
+        pipeline,
+        user_deploy_config=deploy,
+        cli_overrides={"model": "hidream-checkpoint"},
+    ).stage_by_id(0)
+
+    assert isinstance(stage, VllmOmniDiffusionStageConfig)
+    assert stage.diffusion_config.extras["auxiliary_text_encoder"] is None
+    assert stage.diffusion_config.extras["default_llama_model_id"] == ("meta-llama/Meta-Llama-3.1-8B-Instruct")
+
+
+def test_hunyuan_image3_dit_only_consumes_typed_parallel_and_sampling_config() -> None:
+    omni_config = _from_pipeline_key("hunyuan_image3_dit", cli_overrides={"model": "hy3-dit"})
+    stage = omni_config.stage_by_id(0)
+
+    assert isinstance(stage, VllmOmniDiffusionStageConfig)
+    assert stage.model_stage == "dit"
+    assert stage.input_sources == []
+    assert stage.runtime_config.devices == "0,1,2,3"
+    assert stage.runtime_config.num_gpus == 4
+    assert stage.parallel_config.tensor_parallel_size == 4
+    assert stage.parallel_config.enable_expert_parallel is True
+    assert stage.model_config.default_sampling_params == {"seed": 42}
+
+
+def test_hunyuan_image3_ar_dit_keeps_ar_legacy_and_dit_typed() -> None:
+    omni_config = _from_pipeline_key(
+        "hunyuan_image_3_moe",
+        cli_overrides={
+            "model": "hy3-mixed",
+            "diffusion_streaming_output": True,
+            "auxiliary_text_encoder": "/models/llama",
+        },
+    )
+    ar_stage = omni_config.stage_by_id(0)
+    dit_stage = omni_config.stage_by_id(1)
+
+    assert isinstance(ar_stage, VllmOmniARStageConfig)
+    assert isinstance(dit_stage, VllmOmniDiffusionStageConfig)
+    assert ar_stage.model_stage == "AR"
+    assert dit_stage.model_stage == "dit"
+    assert dit_stage.input_sources == [0]
+    assert dit_stage.runtime_config.devices == "2,3"
+    assert dit_stage.runtime_config.num_gpus == 2
+    assert dit_stage.parallel_config.tensor_parallel_size == 2
+    assert dit_stage.parallel_config.enable_expert_parallel is True
+    assert dit_stage.connector_config.input_connectors == {"from_stage_0": "rdma_connector"}
+    assert dit_stage.connector_config.omni_kv_config["need_recv_cache"] is True
+    assert dit_stage.diffusion_config.streaming_output is True
+    assert dit_stage.diffusion_config.extras["auxiliary_text_encoder"] == "/models/llama"
+    assert "auxiliary_text_encoder" not in ar_stage.model_config.__dict__
+
+
+def test_global_num_gpus_routes_only_to_typed_dit_in_mixed_pipeline() -> None:
+    omni_config = _from_pipeline_key(
+        "hunyuan_image_3_moe",
+        cli_overrides={"model": "hy3-mixed", "num_gpus": 8},
+    )
+    ar_stage = omni_config.stage_by_id(0)
+    dit_stage = omni_config.stage_by_id(1)
+
+    assert ar_stage.runtime_config.num_gpus == ar_stage.parallel_config.world_size == 2
+    assert dit_stage.runtime_config.num_gpus == 8
+
+
+def test_typed_diffusion_projection_preserves_revision_family() -> None:
+    omni_config = _from_pipeline_key(
+        "wan2_2_ti2v",
+        cli_overrides={
+            "model": "wan22",
+            "revision": "model-rev",
+            "tokenizer_revision": "tokenizer-rev",
+            "code_revision": "code-rev",
+        },
+    )
+    stage = omni_config.stage_by_id(0)
+
+    assert isinstance(stage, VllmOmniDiffusionStageConfig)
+    assert stage.diffusion_config.revision == "model-rev"
+    assert stage.model_config.tokenizer_revision == "tokenizer-rev"
+    assert stage.model_config.code_revision == "code-rev"
+    engine_args = build_engine_args_dict_from_omni_stage_config(stage, "wan22")
+    assert engine_args["revision"] == "model-rev"
+    assert engine_args["tokenizer_revision"] == "tokenizer-rev"
+    assert engine_args["code_revision"] == "code-rev"
 
 
 def test_minimax_h3_text_encoder_tp_targets_only_structured_stage_zero() -> None:
@@ -347,17 +484,31 @@ def test_runtime_num_gpus_is_derived_from_parallel_world_size():
     assert stage.runtime_config.num_gpus == 4
 
 
-def test_runtime_num_gpus_ignores_stale_runtime_override():
+def test_diffusion_runtime_preserves_explicit_num_gpus_for_terminal_dp_resolution():
     omni_config = _from_pipeline_key(
-        "hunyuan_image3_dit",
+        "hunyuan_video_15",
         cli_overrides={
-            "stage_0_num_gpus": 1,
+            "stage_0_num_gpus": 8,
         },
     )
     stage = omni_config.stage_by_id(0)
 
-    assert stage.parallel_config.world_size == 4
-    assert stage.runtime_config.num_gpus == 4
+    assert stage.parallel_config.world_size == 1
+    assert stage.parallel_config.data_parallel_size == 1
+    assert "data_parallel_size" not in stage.parallel_config._omni_explicit_fields
+    assert stage.runtime_config.num_gpus == 8
+    engine_args = build_engine_args_dict_from_omni_stage_config(stage, "/tmp")
+    assert engine_args["num_gpus"] == 8
+    assert "data_parallel_size" not in engine_args["parallel_config"]
+
+
+def test_diffusion_quantization_cli_alias_maps_to_structured_owner():
+    stage = _from_pipeline_key(
+        "hunyuan_image3_dit",
+        cli_overrides={"diffusion_quantization_config": "fp8"},
+    ).stage_by_id(0)
+
+    assert stage.quantization_config == "fp8"
 
 
 def test_from_pipeline_config_does_not_route_server_cli_keys_to_diffusion_stage():

--- a/tests/diffusion/models/hunyuan_image3/test_diffusion_kv_request.py
+++ b/tests/diffusion/models/hunyuan_image3/test_diffusion_kv_request.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from types import SimpleNamespace
 
@@ -47,6 +47,72 @@ def test_dense_legacy_preprocess_does_not_initialize_layout_tokenizer(monkeypatc
     get_hunyuan_image_3_pre_process_func(
         SimpleNamespace(model="model", diffusion_kv_mode=DiffusionKVCacheMode.DENSE_LEGACY)
     )
+
+
+def test_paged_preprocess_propagates_revision_to_hf_components(monkeypatch) -> None:
+    revision = "refs/pr/42"
+    calls: dict[str, object] = {}
+    hf_config = SimpleNamespace(vae_downsample_factor=(8, 8), patch_size=2, image_base_size=1024)
+    image_processor = SimpleNamespace(vision_encoder_processor=SimpleNamespace(patch_size=1))
+    tokenizer = object()
+
+    def fake_get_config(model, **kwargs):
+        calls["config"] = (model, kwargs)
+        return hf_config
+
+    def fake_tokenizer(model, **kwargs):
+        calls["tokenizer"] = (model, kwargs)
+        return tokenizer
+
+    def fake_generation_config(model, **kwargs):
+        calls["generation_config"] = (model, kwargs)
+        return SimpleNamespace(sequence_template="instruct", drop_think=False)
+
+    monkeypatch.setattr(pipeline_module, "get_config", fake_get_config)
+    monkeypatch.setattr(pipeline_module, "HunyuanImage3ImageProcessor", lambda _config: image_processor)
+    monkeypatch.setattr(pipeline_module, "TokenizerWrapper", fake_tokenizer)
+    monkeypatch.setattr(pipeline_module.GenerationConfig, "from_pretrained", fake_generation_config)
+
+    get_hunyuan_image_3_pre_process_func(
+        SimpleNamespace(
+            model="org/hunyuan-image3",
+            revision=revision,
+            diffusion_kv_mode=DiffusionKVCacheMode.PAGED_SCHEDULER,
+        )
+    )
+
+    expected = {"revision": revision}
+    assert calls == {
+        "config": ("org/hunyuan-image3", {"trust_remote_code": True, **expected}),
+        "tokenizer": ("org/hunyuan-image3", expected),
+        "generation_config": ("org/hunyuan-image3", expected),
+    }
+
+
+def test_hunyuan_tokenizer_wrapper_passes_revision(monkeypatch) -> None:
+    from vllm_omni.diffusion.models.hunyuan_image3 import hunyuan_image3_tokenizer as tokenizer_module
+
+    calls = []
+
+    class FakeTokenizer:
+        bos_token_id = 1
+        eos_token_id = 2
+        pad_token_id = 0
+        added_tokens_encoder = {}
+
+        @staticmethod
+        def convert_tokens_to_ids(_token):
+            return 3
+
+    def fake_from_pretrained(model, **kwargs):
+        calls.append((model, kwargs))
+        return FakeTokenizer()
+
+    monkeypatch.setattr(tokenizer_module.AutoTokenizer, "from_pretrained", fake_from_pretrained)
+
+    tokenizer_module.TokenizerWrapper("org/hunyuan-image3", revision="refs/pr/42")
+
+    assert calls == [("org/hunyuan-image3", {"revision": "refs/pr/42"})]
 
 
 class _FakeTokenizerWrapper:

--- a/tests/diffusion/models/wan2_2/test_wan22_pipeline_helpers.py
+++ b/tests/diffusion/models/wan2_2/test_wan22_pipeline_helpers.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 import json
 from types import SimpleNamespace
@@ -58,6 +58,33 @@ def test_load_transformer_config_reads_local_subfolder_config(tmp_path) -> None:
 
     assert load_transformer_config(str(tmp_path), "transformer_2") == {"patch_size": [1, 2, 2], "num_layers": 2}
     assert load_transformer_config(str(tmp_path), "missing") == {}
+
+
+def test_load_transformer_config_passes_revision_for_hub_model(monkeypatch, tmp_path) -> None:
+    calls = []
+    config_path = tmp_path / "transformer" / "config.json"
+    config_path.parent.mkdir()
+    config_path.write_text(json.dumps({"model_type": "wan"}))
+
+    def fake_hf_hub_download(**kwargs):
+        calls.append(kwargs)
+        return str(config_path)
+
+    monkeypatch.setattr("huggingface_hub.hf_hub_download", fake_hf_hub_download)
+
+    assert load_transformer_config(
+        "org/wan22",
+        "transformer",
+        local_files_only=False,
+        revision="refs/pr/42",
+    ) == {"model_type": "wan"}
+    assert calls == [
+        {
+            "repo_id": "org/wan22",
+            "filename": "transformer/config.json",
+            "revision": "refs/pr/42",
+        }
+    ]
 
 
 def test_create_transformer_from_config_maps_supported_keys(monkeypatch) -> None:

--- a/tests/diffusion/test_diffusion_config_propagation.py
+++ b/tests/diffusion/test_diffusion_config_propagation.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Tests that parallel_config survives the create_default_diffusion roundtrip.
 
 Regression tests for https://github.com/vllm-project/vllm-omni/issues/1862
@@ -220,3 +220,39 @@ def test_additional_config_roundtrip():
     additional_config = {"torchair_graph_config": {"enabled": True}}
     od = _roundtrip_diffusion_config(model="x", additional_config=additional_config)
     assert od.additional_config == additional_config
+
+
+def test_hidream_signature_probe_uses_requested_revision(monkeypatch):
+    """The secondary HiDream weight-index lookup must share ``revision``."""
+    from vllm_omni.diffusion import data as diffusion_data
+    from vllm_omni.diffusion.utils import hf_utils
+
+    revision = "refs/pr/42"
+    observed: dict[str, object] = {}
+
+    monkeypatch.setattr(hf_utils, "get_diffusion_model_index", lambda *_args, **_kwargs: None)
+
+    def fake_get_hf_file_to_dict(filename, model, **kwargs):
+        assert model == "org/hidream"
+        observed.setdefault("file_revisions", []).append((filename, kwargs.get("revision")))
+        if filename == "config.json":
+            return {"model_type": "qwen3_vl"}
+        return None
+
+    monkeypatch.setattr("vllm.transformers_utils.config.get_hf_file_to_dict", fake_get_hf_file_to_dict)
+
+    def fake_looks_like_hidream(model, config=None, *, revision=None):
+        observed["signature_revision"] = revision
+        assert model == "org/hidream"
+        assert config == {"model_type": "qwen3_vl"}
+        return True
+
+    monkeypatch.setattr(hf_utils, "_looks_like_hidream_o1", fake_looks_like_hidream)
+    monkeypatch.setattr(OmniDiffusionConfig, "_resolve_master_port", lambda _self: 29500)
+
+    config = diffusion_data.OmniDiffusionConfig(model="org/hidream", revision=revision)
+    config.enrich_config()
+
+    assert observed["signature_revision"] == revision
+    assert observed["file_revisions"] == [("config.json", revision)]
+    assert config.model_class_name == "HiDreamO1ImagePipeline"

--- a/tests/e2e/offline_inference/test_hunyuanimage3.py
+++ b/tests/e2e/offline_inference/test_hunyuanimage3.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 # ruff: noqa: E501
 from collections.abc import Generator
 
@@ -7,6 +10,7 @@ import torch.nn.functional as F
 from PIL import Image
 from transformers import CLIPModel, CLIPProcessor
 
+from tests.helpers.mark import hardware_test
 from tests.helpers.runtime import OmniRunner
 from tests.helpers.stage_config import get_deploy_config_path
 from vllm_omni import Omni
@@ -16,7 +20,7 @@ from vllm_omni.platforms import current_omni_platform
 PROMPT = "A brown and white dog is running on the grass"
 MODEL_NAME = "tencent/HunyuanImage-3.0"
 LOCAL_CLIP_PATH = "openai/clip-vit-base-patch32"
-DEPLOY_CONFIG_PATH = get_deploy_config_path("hunyuan_image3.yaml")
+DEPLOY_CONFIG_PATH = get_deploy_config_path("hunyuan_image_3_moe.yaml")
 
 pytestmark = [pytest.mark.advanced_model, pytest.mark.diffusion]
 
@@ -330,6 +334,7 @@ def _generate_image(omni: Omni, use_system_prompt: str | None) -> Image.Image:
 
 @pytest.mark.skipif(torch.accelerator.device_count() < 8, reason="Need at least 8 CUDA GPUs for this test.")
 @pytest.mark.parametrize("system_prompt_name,use_system_prompt,expected_embedding", SYSTEM_PROMPT_CASES)
+@hardware_test(res={"cuda": "H100"}, num_cards=8)
 def test_system_prompt_scores(
     omni: Omni,
     clip_bundle: tuple[CLIPModel, CLIPProcessor],

--- a/tests/engine/test_async_omni_engine_stage_init.py
+++ b/tests/engine/test_async_omni_engine_stage_init.py
@@ -11,6 +11,14 @@ import types
 
 import pytest
 
+from vllm_omni.config.omni_config import VllmOmniConfig, VllmOmniDiffusionStageConfig
+from vllm_omni.config.stage_config import (
+    DeployConfig,
+    PipelineConfig,
+    StageDeployConfig,
+    StageExecutionType,
+    StagePipelineConfig,
+)
 from vllm_omni.diffusion.data import AttentionConfig, AttentionSpec
 from vllm_omni.engine import async_omni_engine as async_omni_engine_module
 from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
@@ -22,6 +30,7 @@ from vllm_omni.engine.stage_init_utils import (
     split_devices_for_replicas,
 )
 from vllm_omni.engine.stage_runtime import StageRuntime
+from vllm_omni.entrypoints.utils import ResolvedStageConfigs
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -90,6 +99,35 @@ def _make_diffusion_metadata(stage_id: int, *, replica_id: int = 0, final_output
     )
 
 
+def _make_typed_diffusion_stage(
+    stage_id: int,
+    *,
+    devices: str = "0",
+    num_replicas: int = 1,
+) -> tuple[VllmOmniConfig, object]:
+    """Build the smallest real typed diffusion view used by startup tests."""
+    topology = StagePipelineConfig(
+        stage_id=stage_id,
+        model_stage="diffusion",
+        execution_type=StageExecutionType.DIFFUSION,
+        final_output=True,
+        final_output_type="image",
+        model_arch="TestDiffusion",
+    )
+    pipeline = PipelineConfig(
+        model_type=f"test_diffusion_{stage_id}",
+        model_arch="TestDiffusion",
+        stages=(topology,),
+    )
+    deploy = DeployConfig(stages=[StageDeployConfig(stage_id=stage_id, devices=devices, num_replicas=num_replicas)])
+    omni_config = VllmOmniConfig.from_pipeline_config(
+        pipeline,
+        user_deploy_config=deploy,
+        cli_overrides={"model": "dummy-model"},
+    )
+    return omni_config, omni_config.stage_by_id(stage_id)
+
+
 def _make_llm_plan(
     stage_idx: int,
     *,
@@ -142,6 +180,11 @@ def _make_diffusion_plan(
 ):
     replicas: list[ReplicaInitPlan] = []
     for replica_id in range(num_replicas):
+        _, typed_stage = _make_typed_diffusion_stage(
+            stage_id,
+            devices=str(replica_id),
+            num_replicas=num_replicas,
+        )
         stage_cfg = types.SimpleNamespace(
             stage_id=stage_id,
             stage_type="diffusion",
@@ -157,6 +200,7 @@ def _make_diffusion_plan(
                 metadata=_make_diffusion_metadata(stage_id, replica_id=replica_id),
                 stage_connector_spec={},
                 omni_kv_connector=(None, None, None),
+                omni_stage_config=typed_stage,
             )
         )
     return LogicalStageInitPlan(
@@ -207,6 +251,15 @@ def test_async_omni_engine_initialize_stages_passes_log_stats_to_runtime(monkeyp
     engine._omni_lb_policy = "random"
     engine.request_queue = types.SimpleNamespace()
     engine._log_stats = True
+    topology_stage = types.SimpleNamespace(stage_id=99)
+    engine._resolved_stage_configs = ResolvedStageConfigs(
+        config_path="dummy-config",
+        omni_config=None,
+        stage_configs=engine.stage_configs,
+        deploy_config=None,
+        omni_lb_policy=None,
+        typed_topology_stage_configs=(topology_stage,),
+    )
 
     captured: dict[str, object] = {}
     runtime = types.SimpleNamespace(stage_pools=[], initialize=lambda: None)
@@ -221,6 +274,7 @@ def test_async_omni_engine_initialize_stages_passes_log_stats_to_runtime(monkeyp
 
     assert captured["stage_init_timeout"] == 7
     assert captured["log_stats"] is True
+    assert captured["typed_topology_stage_configs"] == (topology_stage,)
 
 
 def test_compute_replica_layout_splits_diffusion_devices_by_world_size():
@@ -305,6 +359,23 @@ def test_build_logical_stage_init_plans_handles_stage_without_devices(monkeypatc
 
     assert [replica.replica_id for replica in stage_plans[0].replicas] == [0, 1, 2]
     assert [replica.stage_cfg.runtime.devices for replica in stage_plans[0].replicas] == [None, None, None]
+
+
+def test_compute_replica_layout_uses_explicit_diffusion_num_gpus():
+    stage_cfg = types.SimpleNamespace(
+        stage_id=0,
+        stage_type="diffusion",
+        engine_args={
+            "num_gpus": 4,
+            "parallel_config": {"tensor_parallel_size": 2},
+        },
+        runtime={"devices": "0,1,2,3,4,5,6,7", "num_replicas": 2},
+    )
+
+    replicas_per_stage, replica_devices_map = compute_replica_layout([stage_cfg])
+
+    assert replicas_per_stage == [2]
+    assert replica_devices_map == {0: ["0,1,2,3", "4,5,6,7"]}
 
 
 def test_collect_initialized_clients_for_cleanup_deduplicates_clients():
@@ -558,9 +629,21 @@ def test_launch_diffusion_stage_replica_does_not_write_max_num_seqs_from_batch_s
     import vllm_omni.diffusion.stage_diffusion_client as client_mod
     import vllm_omni.diffusion.stage_diffusion_proc as proc_mod
     import vllm_omni.engine.stage_engine_startup as startup_mod
+    import vllm_omni.engine.stage_init_utils as init_mod
 
     od_config = types.SimpleNamespace(max_num_seqs=1, parallel_config=types.SimpleNamespace(world_size=1))
-    monkeypatch.setattr(startup_mod, "build_diffusion_config", lambda *args: od_config)
+    typed_calls: list[tuple[object, object]] = []
+
+    def _build_typed(*args, **kwargs):
+        typed_calls.append((args[1], kwargs))
+        return od_config
+
+    def _legacy_builder_must_not_run(*_args, **_kwargs):
+        raise AssertionError("distributed diffusion startup used the legacy builder")
+
+    monkeypatch.setattr(startup_mod, "build_diffusion_config_from_omni_stage_config", _build_typed)
+    monkeypatch.setattr(startup_mod, "build_diffusion_config", _legacy_builder_must_not_run)
+    monkeypatch.setattr(init_mod, "build_diffusion_config", _legacy_builder_must_not_run)
     monkeypatch.setattr(startup_mod, "acquire_device_locks", lambda *args: [])
     monkeypatch.setattr(
         startup_mod,
@@ -591,10 +674,15 @@ def test_launch_diffusion_stage_replica_does_not_write_max_num_seqs_from_batch_s
         lambda metadata, **kwargs: sentinel_client,
     )
 
+    _, typed_stage = _make_typed_diffusion_stage(0)
     result, resources = startup_mod.launch_diffusion_stage_replica(
         model="dummy-model",
-        stage_config=types.SimpleNamespace(),
+        stage_config=typed_stage,
+        legacy_registration_config=types.SimpleNamespace(),
         metadata=types.SimpleNamespace(stage_id=0),
+        stage_connector_spec={},
+        omni_kv_connector=(None, None, None),
+        stage_configs=[typed_stage],
         stage_init_timeout=12,
         batch_size=4,
         use_inline=False,
@@ -604,6 +692,51 @@ def test_launch_diffusion_stage_replica_does_not_write_max_num_seqs_from_batch_s
     assert result is sentinel_client
     assert od_config.max_num_seqs == 1
     assert resources.manager is proc_manager
+    assert len(typed_calls) == 1
+    assert isinstance(typed_calls[0][0], VllmOmniDiffusionStageConfig)
+
+
+def test_launch_diffusion_stage_replica_colocated_uses_typed_initializer(monkeypatch):
+    """Colocated DiT startup must not fall back to the legacy config builder."""
+    import vllm_omni.engine.stage_engine_startup as startup_mod
+    import vllm_omni.engine.stage_init_utils as init_mod
+
+    _, typed_stage = _make_typed_diffusion_stage(0)
+    typed_client = object()
+    typed_calls: list[tuple[object, object, object]] = []
+
+    def _initialize_typed(model, stage_config, metadata, stage_init_timeout, **kwargs):
+        typed_calls.append((model, stage_config, metadata))
+        assert stage_init_timeout == 17
+        assert kwargs["batch_size"] == 3
+        return typed_client
+
+    def _legacy_builder_must_not_run(*_args, **_kwargs):
+        raise AssertionError("colocated diffusion startup used the legacy path")
+
+    monkeypatch.setattr(startup_mod, "initialize_diffusion_stage_from_omni_stage_config", _initialize_typed)
+    monkeypatch.setattr(startup_mod, "build_diffusion_config", _legacy_builder_must_not_run)
+    monkeypatch.setattr(init_mod, "build_diffusion_config", _legacy_builder_must_not_run)
+    monkeypatch.setattr(init_mod, "initialize_diffusion_stage", _legacy_builder_must_not_run)
+
+    result, resources = startup_mod.launch_diffusion_stage_replica(
+        model="dummy-model",
+        stage_config=typed_stage,
+        legacy_registration_config=types.SimpleNamespace(),
+        metadata=_make_diffusion_metadata(0),
+        stage_connector_spec={},
+        omni_kv_connector=(None, None, None),
+        stage_configs=[typed_stage],
+        stage_init_timeout=17,
+        batch_size=3,
+        use_inline=True,
+        omni_master_server=None,
+    )
+
+    assert result is typed_client
+    assert resources == startup_mod.StageReplicaResources()
+    assert len(typed_calls) == 1
+    assert typed_calls[0][1] is typed_stage
 
 
 def test_initialize_diffusion_stage_does_not_write_max_num_seqs(monkeypatch):
@@ -638,7 +771,11 @@ def test_launch_diffusion_stage_replica_preserves_step_execution_max_num_seqs(mo
         step_execution=True,
         parallel_config=types.SimpleNamespace(world_size=1),
     )
-    monkeypatch.setattr(startup_mod, "build_diffusion_config", lambda *args: od_config)
+    monkeypatch.setattr(
+        startup_mod,
+        "build_diffusion_config_from_omni_stage_config",
+        lambda *args, **kwargs: od_config,
+    )
     monkeypatch.setattr(startup_mod, "acquire_device_locks", lambda *args: [])
     monkeypatch.setattr(
         startup_mod,
@@ -667,10 +804,15 @@ def test_launch_diffusion_stage_replica_preserves_step_execution_max_num_seqs(mo
         lambda metadata, **kwargs: object(),
     )
 
+    _, typed_stage = _make_typed_diffusion_stage(0)
     startup_mod.launch_diffusion_stage_replica(
         model="dummy-model",
-        stage_config=types.SimpleNamespace(),
+        stage_config=typed_stage,
+        legacy_registration_config=types.SimpleNamespace(),
         metadata=types.SimpleNamespace(stage_id=0),
+        stage_connector_spec={},
+        omni_kv_connector=(None, None, None),
+        stage_configs=[typed_stage],
         stage_init_timeout=12,
         batch_size=4,
         use_inline=False,
@@ -884,6 +1026,104 @@ def test_build_logical_stage_init_plans_applies_replica_device_splits(monkeypatc
     assert [replica.stage_cfg.runtime.devices for replica in stage_plans[1].replicas] == ["1", "2", "3"]
     assert [replica.replica_id for replica in stage_plans[1].replicas] == [0, 1, 2]
     assert all(replica.num_replicas == 3 for replica in stage_plans[1].replicas)
+
+
+def test_build_logical_plans_keep_ar_generation_legacy_and_dit_typed(monkeypatch):
+    import vllm_omni.engine.stage_runtime as runtime_mod
+
+    llm0 = types.SimpleNamespace(
+        stage_id=0,
+        stage_type="llm",
+        runtime=types.SimpleNamespace(devices="0"),
+        engine_args={},
+    )
+    llm1 = types.SimpleNamespace(
+        stage_id=1,
+        stage_type="llm",
+        runtime=types.SimpleNamespace(devices="1"),
+        engine_args={},
+    )
+    legacy_calls: list[int] = []
+
+    def legacy_metadata(stage_cfg):
+        legacy_calls.append(stage_cfg.stage_id)
+        metadata = _make_llm_metadata(stage_cfg.stage_id)
+        metadata.runtime_cfg = stage_cfg.runtime
+        return metadata
+
+    typed_config, _ = _make_typed_diffusion_stage(2, devices="2")
+    dit_legacy = types.SimpleNamespace(
+        stage_id=2,
+        stage_type="diffusion",
+        runtime=types.SimpleNamespace(devices="2"),
+        engine_args={},
+    )
+    topology0 = StagePipelineConfig(stage_id=0, model_stage="ar", execution_type=StageExecutionType.LLM_AR)
+    topology1 = StagePipelineConfig(
+        stage_id=1,
+        model_stage="generation",
+        execution_type=StageExecutionType.LLM_GENERATION,
+        input_sources=(0,),
+    )
+    pipeline = PipelineConfig(
+        model_type="mixed_runtime",
+        model_arch="TestDiffusion",
+        stages=(topology0, topology1, typed_config.pipeline_config.stages[0]),
+    )
+    mixed = VllmOmniConfig.from_pipeline_config(
+        pipeline,
+        user_deploy_config=DeployConfig(
+            async_chunk=False,
+            stages=[
+                StageDeployConfig(stage_id=0, devices="0"),
+                StageDeployConfig(stage_id=1, devices="1"),
+                StageDeployConfig(stage_id=2, devices="2"),
+            ],
+        ),
+        cli_overrides={"model": "dummy-model"},
+    )
+    runtime = StageRuntime(
+        stage_configs=[llm0, llm1, dit_legacy],
+        omni_config=mixed,
+        model="dummy-model",
+        config_path="dummy-config",
+        stage_init_timeout=1,
+        diffusion_batch_size=1,
+        async_chunk=False,
+    )
+
+    typed_metadata_calls: list[int] = []
+    extract_typed_metadata = runtime_mod.extract_stage_metadata_from_omni_stage_config
+
+    def typed_metadata(stage_cfg):
+        typed_metadata_calls.append(stage_cfg.stage_id)
+        return extract_typed_metadata(stage_cfg)
+
+    engine_builder_calls: list[int] = []
+
+    def build_legacy_engine_args(stage_cfg, *_, **__):
+        engine_builder_calls.append(stage_cfg.stage_id)
+        return {}
+
+    monkeypatch.setattr(runtime_mod, "extract_legacy_stage_metadata", legacy_metadata)
+    monkeypatch.setattr(runtime_mod, "extract_stage_metadata_from_omni_stage_config", typed_metadata)
+    monkeypatch.setattr(runtime_mod, "get_stage_connector_spec", lambda **_: {})
+    monkeypatch.setattr(runtime_mod, "resolve_omni_kv_config_for_stage", lambda *_: (None, None, None))
+    monkeypatch.setattr(runtime_mod, "build_engine_args_dict", build_legacy_engine_args)
+    monkeypatch.setattr(
+        runtime_mod,
+        "build_vllm_config",
+        lambda *_, **__: (types.SimpleNamespace(), object),
+    )
+
+    plans = runtime._build_logical_stage_init_plans(None, [1, 1, 1], {})
+
+    assert legacy_calls == [0, 0, 1, 1]
+    assert typed_metadata_calls == [2, 2]
+    assert engine_builder_calls == [0, 1]
+    assert plans[2].replicas[0].omni_stage_config.stage_id == 2
+    assert isinstance(plans[2].replicas[0].omni_stage_config, VllmOmniDiffusionStageConfig)
+    assert plans[2].replicas[0].metadata.stage_type == "diffusion"
 
 
 def test_initialize_stage_replicas_collects_results_by_stage_and_replica_id(monkeypatch):
@@ -1753,68 +1993,20 @@ def test_inject_kv_stage_info_infers_receiver_tp_topology():
     assert stage1.engine_args["omni_kv_config"]["rank_mapping"] == {"from_tp": 4, "to_tp": 2}
 
 
-def test_resolve_stage_configs_injects_global_diffusion_attention_when_missing(monkeypatch):
-    import vllm_omni.engine.async_omni_engine as engine_mod
-
-    engine = object.__new__(AsyncOmniEngine)
-    stage_cfg = types.SimpleNamespace(
-        stage_type="diffusion",
-        engine_args=types.SimpleNamespace(
-            diffusion_attention_config=None,
-            lora_path=None,
-            lora_scale=None,
-            enable_sleep_mode=None,
-            quantization_config=None,
-        ),
-    )
-
-    monkeypatch.setattr(
-        engine_mod,
-        "load_and_resolve_stage_configs",
-        lambda *args, **kwargs: ("dummy-config", [stage_cfg], None),
-    )
-
-    _config_path, stage_configs = engine._resolve_stage_configs(
-        model="dummy-model",
-        kwargs={"diffusion_attention_backend": "FLASH_ATTN"},
-        trust_remote_code=False,
-    )
-
-    diffusion_attention_config = stage_configs[0].engine_args.diffusion_attention_config
+def test_resolve_stage_configs_injects_global_diffusion_attention_when_missing():
+    stage_cfg = AsyncOmniEngine._create_default_diffusion_stage_cfg({"diffusion_attention_backend": "FLASH_ATTN"})[0]
+    diffusion_attention_config = stage_cfg["engine_args"]["diffusion_attention_config"]
     assert isinstance(diffusion_attention_config, AttentionConfig)
     assert diffusion_attention_config.default is not None
     assert diffusion_attention_config.default.backend == "FLASH_ATTN"
 
 
-def test_resolve_stage_configs_preserves_stage_diffusion_attention(monkeypatch):
-    import vllm_omni.engine.async_omni_engine as engine_mod
-
-    engine = object.__new__(AsyncOmniEngine)
+def test_resolve_stage_configs_preserves_stage_diffusion_attention():
     existing_attention = AttentionConfig(default=AttentionSpec(backend="TORCH_SDPA"))
-    stage_cfg = types.SimpleNamespace(
-        stage_type="diffusion",
-        engine_args=types.SimpleNamespace(
-            diffusion_attention_config=existing_attention,
-            lora_path=None,
-            lora_scale=None,
-            enable_sleep_mode=None,
-            quantization_config=None,
-        ),
-    )
-
-    monkeypatch.setattr(
-        engine_mod,
-        "load_and_resolve_stage_configs",
-        lambda *args, **kwargs: ("dummy-config", [stage_cfg], None),
-    )
-
-    _config_path, stage_configs = engine._resolve_stage_configs(
-        model="dummy-model",
-        kwargs={"diffusion_attention_backend": "FLASH_ATTN"},
-        trust_remote_code=False,
-    )
-
-    assert stage_configs[0].engine_args.diffusion_attention_config is existing_attention
+    stage_cfg = AsyncOmniEngine._create_default_diffusion_stage_cfg({"diffusion_attention_config": existing_attention})[
+        0
+    ]
+    assert stage_cfg["engine_args"]["diffusion_attention_config"] == existing_attention
 
 
 def test_resolve_stage_configs_does_not_inject_diffusion_attention_into_llm_stage(monkeypatch):
@@ -1831,8 +2023,14 @@ def test_resolve_stage_configs_does_not_inject_diffusion_attention_into_llm_stag
 
     monkeypatch.setattr(
         engine_mod,
-        "load_and_resolve_stage_configs",
-        lambda *args, **kwargs: ("dummy-config", [stage_cfg], None),
+        "load_and_resolve_stage_config_views",
+        lambda *args, **kwargs: ResolvedStageConfigs(
+            config_path="dummy-config",
+            omni_config=None,
+            stage_configs=[stage_cfg],
+            deploy_config=None,
+            omni_lb_policy=None,
+        ),
     )
 
     _config_path, stage_configs = engine._resolve_stage_configs(

--- a/tests/engine/test_async_omni_engine_stage_init.py
+++ b/tests/engine/test_async_omni_engine_stage_init.py
@@ -7,6 +7,14 @@ import types
 
 import pytest
 
+from vllm_omni.config.omni_config import VllmOmniConfig
+from vllm_omni.config.stage_config import (
+    DeployConfig,
+    PipelineConfig,
+    StageDeployConfig,
+    StageExecutionType,
+    StagePipelineConfig,
+)
 from vllm_omni.diffusion.data import AttentionConfig, AttentionSpec
 from vllm_omni.engine import async_omni_engine as async_omni_engine_module
 from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
@@ -18,6 +26,7 @@ from vllm_omni.engine.stage_init_utils import (
     split_devices_for_replicas,
 )
 from vllm_omni.engine.stage_runtime import StageRuntime
+from vllm_omni.entrypoints.utils import ResolvedStageConfigs
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -86,6 +95,35 @@ def _make_diffusion_metadata(stage_id: int, *, replica_id: int = 0, final_output
     )
 
 
+def _make_typed_diffusion_stage(
+    stage_id: int,
+    *,
+    devices: str = "0",
+    num_replicas: int = 1,
+) -> tuple[VllmOmniConfig, object]:
+    """Build the smallest real typed diffusion view used by startup tests."""
+    topology = StagePipelineConfig(
+        stage_id=stage_id,
+        model_stage="diffusion",
+        execution_type=StageExecutionType.DIFFUSION,
+        final_output=True,
+        final_output_type="image",
+        model_arch="TestDiffusion",
+    )
+    pipeline = PipelineConfig(
+        model_type=f"test_diffusion_{stage_id}",
+        model_arch="TestDiffusion",
+        stages=(topology,),
+    )
+    deploy = DeployConfig(stages=[StageDeployConfig(stage_id=stage_id, devices=devices, num_replicas=num_replicas)])
+    omni_config = VllmOmniConfig.from_pipeline_config(
+        pipeline,
+        user_deploy_config=deploy,
+        cli_overrides={"model": "dummy-model"},
+    )
+    return omni_config, omni_config.stage_by_id(stage_id)
+
+
 def _make_llm_plan(
     stage_idx: int,
     *,
@@ -138,6 +176,11 @@ def _make_diffusion_plan(
 ):
     replicas: list[ReplicaInitPlan] = []
     for replica_id in range(num_replicas):
+        _, typed_stage = _make_typed_diffusion_stage(
+            stage_id,
+            devices=str(replica_id),
+            num_replicas=num_replicas,
+        )
         stage_cfg = types.SimpleNamespace(
             stage_id=stage_id,
             stage_type="diffusion",
@@ -153,6 +196,7 @@ def _make_diffusion_plan(
                 metadata=_make_diffusion_metadata(stage_id, replica_id=replica_id),
                 stage_connector_spec={},
                 omni_kv_connector=(None, None, None),
+                omni_stage_config=typed_stage,
             )
         )
     return LogicalStageInitPlan(
@@ -301,6 +345,23 @@ def test_build_logical_stage_init_plans_handles_stage_without_devices(monkeypatc
 
     assert [replica.replica_id for replica in stage_plans[0].replicas] == [0, 1, 2]
     assert [replica.stage_cfg.runtime.devices for replica in stage_plans[0].replicas] == [None, None, None]
+
+
+def test_compute_replica_layout_uses_explicit_diffusion_num_gpus():
+    stage_cfg = types.SimpleNamespace(
+        stage_id=0,
+        stage_type="diffusion",
+        engine_args={
+            "num_gpus": 4,
+            "parallel_config": {"tensor_parallel_size": 2},
+        },
+        runtime={"devices": "0,1,2,3,4,5,6,7", "num_replicas": 2},
+    )
+
+    replicas_per_stage, replica_devices_map = compute_replica_layout([stage_cfg])
+
+    assert replicas_per_stage == [2]
+    assert replica_devices_map == {0: ["0,1,2,3", "4,5,6,7"]}
 
 
 def test_collect_initialized_clients_for_cleanup_deduplicates_clients():
@@ -519,7 +580,7 @@ def test_launch_diffusion_stage_replica_applies_batch_size_to_config(monkeypatch
     import vllm_omni.engine.stage_engine_startup as startup_mod
 
     od_config = types.SimpleNamespace(max_num_seqs=1, parallel_config=types.SimpleNamespace(world_size=1))
-    monkeypatch.setattr(startup_mod, "build_diffusion_config", lambda *args: od_config)
+    monkeypatch.setattr(startup_mod, "build_diffusion_config_from_omni_stage_config", lambda *args, **kwargs: od_config)
     monkeypatch.setattr(startup_mod, "acquire_device_locks", lambda *args: [])
     monkeypatch.setattr(
         startup_mod,
@@ -550,10 +611,15 @@ def test_launch_diffusion_stage_replica_applies_batch_size_to_config(monkeypatch
         lambda metadata, **kwargs: sentinel_client,
     )
 
+    _, typed_stage = _make_typed_diffusion_stage(0)
     result, resources = startup_mod.launch_diffusion_stage_replica(
         model="dummy-model",
-        stage_config=types.SimpleNamespace(),
+        stage_config=typed_stage,
+        legacy_registration_config=types.SimpleNamespace(),
         metadata=types.SimpleNamespace(stage_id=0),
+        stage_connector_spec={},
+        omni_kv_connector=(None, None, None),
+        stage_configs=[typed_stage],
         stage_init_timeout=12,
         batch_size=4,
         use_inline=False,
@@ -768,6 +834,103 @@ def test_build_logical_stage_init_plans_applies_replica_device_splits(monkeypatc
     assert [replica.stage_cfg.runtime.devices for replica in stage_plans[1].replicas] == ["1", "2", "3"]
     assert [replica.replica_id for replica in stage_plans[1].replicas] == [0, 1, 2]
     assert all(replica.num_replicas == 3 for replica in stage_plans[1].replicas)
+
+
+def test_build_logical_plans_keep_ar_generation_legacy_and_dit_typed(monkeypatch):
+    import vllm_omni.engine.stage_runtime as runtime_mod
+
+    llm0 = types.SimpleNamespace(
+        stage_id=0,
+        stage_type="llm",
+        runtime=types.SimpleNamespace(devices="0"),
+        engine_args={},
+    )
+    llm1 = types.SimpleNamespace(
+        stage_id=1,
+        stage_type="llm",
+        runtime=types.SimpleNamespace(devices="1"),
+        engine_args={},
+    )
+    legacy_calls: list[int] = []
+
+    def legacy_metadata(stage_cfg):
+        legacy_calls.append(stage_cfg.stage_id)
+        metadata = _make_llm_metadata(stage_cfg.stage_id)
+        metadata.runtime_cfg = stage_cfg.runtime
+        return metadata
+
+    typed_config, _ = _make_typed_diffusion_stage(2, devices="2")
+    dit_legacy = types.SimpleNamespace(
+        stage_id=2,
+        stage_type="diffusion",
+        runtime=types.SimpleNamespace(devices="2"),
+        engine_args={},
+    )
+    topology0 = StagePipelineConfig(stage_id=0, model_stage="ar", execution_type=StageExecutionType.LLM_AR)
+    topology1 = StagePipelineConfig(
+        stage_id=1,
+        model_stage="generation",
+        execution_type=StageExecutionType.LLM_GENERATION,
+        input_sources=(0,),
+    )
+    pipeline = PipelineConfig(
+        model_type="mixed_runtime",
+        model_arch="TestDiffusion",
+        stages=(topology0, topology1, typed_config.pipeline_config.stages[0]),
+    )
+    mixed = VllmOmniConfig.from_pipeline_config(
+        pipeline,
+        user_deploy_config=DeployConfig(
+            async_chunk=False,
+            stages=[
+                StageDeployConfig(stage_id=0, devices="0"),
+                StageDeployConfig(stage_id=1, devices="1"),
+                StageDeployConfig(stage_id=2, devices="2"),
+            ],
+        ),
+        cli_overrides={"model": "dummy-model"},
+    )
+    runtime = StageRuntime(
+        stage_configs=[llm0, llm1, dit_legacy],
+        omni_config=mixed,
+        model="dummy-model",
+        config_path="dummy-config",
+        stage_init_timeout=1,
+        diffusion_batch_size=1,
+        async_chunk=False,
+    )
+
+    typed_metadata_calls: list[int] = []
+    extract_typed_metadata = runtime_mod.extract_stage_metadata_from_omni_stage_config
+
+    def typed_metadata(stage_cfg):
+        typed_metadata_calls.append(stage_cfg.stage_id)
+        return extract_typed_metadata(stage_cfg)
+
+    engine_builder_calls: list[int] = []
+
+    def build_legacy_engine_args(stage_cfg, *_, **__):
+        engine_builder_calls.append(stage_cfg.stage_id)
+        return {}
+
+    monkeypatch.setattr(runtime_mod, "extract_legacy_stage_metadata", legacy_metadata)
+    monkeypatch.setattr(runtime_mod, "extract_stage_metadata_from_omni_stage_config", typed_metadata)
+    monkeypatch.setattr(runtime_mod, "get_stage_connector_spec", lambda **_: {})
+    monkeypatch.setattr(runtime_mod, "resolve_omni_kv_config_for_stage", lambda *_: (None, None, None))
+    monkeypatch.setattr(runtime_mod, "build_engine_args_dict", build_legacy_engine_args)
+    monkeypatch.setattr(
+        runtime_mod,
+        "build_vllm_config",
+        lambda *_, **__: (types.SimpleNamespace(), object),
+    )
+
+    plans = runtime._build_logical_stage_init_plans(None, [1, 1, 1], {})
+
+    assert legacy_calls == [0, 0, 1, 1]
+    assert typed_metadata_calls == [2, 2]
+    assert engine_builder_calls == [0, 1]
+    assert plans[2].replicas[0].omni_stage_config.stage_id == 2
+    assert plans[2].replicas[0].metadata.stage_type == "diffusion"
 
 
 def test_initialize_stage_replicas_collects_results_by_stage_and_replica_id(monkeypatch):
@@ -1193,68 +1356,20 @@ def test_inject_kv_stage_info_infers_receiver_tp_topology():
     assert stage1.engine_args["omni_kv_config"]["rank_mapping"] == {"from_tp": 4, "to_tp": 2}
 
 
-def test_resolve_stage_configs_injects_global_diffusion_attention_when_missing(monkeypatch):
-    import vllm_omni.engine.async_omni_engine as engine_mod
-
-    engine = object.__new__(AsyncOmniEngine)
-    stage_cfg = types.SimpleNamespace(
-        stage_type="diffusion",
-        engine_args=types.SimpleNamespace(
-            diffusion_attention_config=None,
-            lora_path=None,
-            lora_scale=None,
-            enable_sleep_mode=None,
-            quantization_config=None,
-        ),
-    )
-
-    monkeypatch.setattr(
-        engine_mod,
-        "load_and_resolve_stage_configs",
-        lambda *args, **kwargs: ("dummy-config", [stage_cfg], None),
-    )
-
-    _config_path, stage_configs = engine._resolve_stage_configs(
-        model="dummy-model",
-        kwargs={"diffusion_attention_backend": "FLASH_ATTN"},
-        trust_remote_code=False,
-    )
-
-    diffusion_attention_config = stage_configs[0].engine_args.diffusion_attention_config
+def test_resolve_stage_configs_injects_global_diffusion_attention_when_missing():
+    stage_cfg = AsyncOmniEngine._create_default_diffusion_stage_cfg({"diffusion_attention_backend": "FLASH_ATTN"})[0]
+    diffusion_attention_config = stage_cfg["engine_args"]["diffusion_attention_config"]
     assert isinstance(diffusion_attention_config, AttentionConfig)
     assert diffusion_attention_config.default is not None
     assert diffusion_attention_config.default.backend == "FLASH_ATTN"
 
 
-def test_resolve_stage_configs_preserves_stage_diffusion_attention(monkeypatch):
-    import vllm_omni.engine.async_omni_engine as engine_mod
-
-    engine = object.__new__(AsyncOmniEngine)
+def test_resolve_stage_configs_preserves_stage_diffusion_attention():
     existing_attention = AttentionConfig(default=AttentionSpec(backend="TORCH_SDPA"))
-    stage_cfg = types.SimpleNamespace(
-        stage_type="diffusion",
-        engine_args=types.SimpleNamespace(
-            diffusion_attention_config=existing_attention,
-            lora_path=None,
-            lora_scale=None,
-            enable_sleep_mode=None,
-            quantization_config=None,
-        ),
-    )
-
-    monkeypatch.setattr(
-        engine_mod,
-        "load_and_resolve_stage_configs",
-        lambda *args, **kwargs: ("dummy-config", [stage_cfg], None),
-    )
-
-    _config_path, stage_configs = engine._resolve_stage_configs(
-        model="dummy-model",
-        kwargs={"diffusion_attention_backend": "FLASH_ATTN"},
-        trust_remote_code=False,
-    )
-
-    assert stage_configs[0].engine_args.diffusion_attention_config is existing_attention
+    stage_cfg = AsyncOmniEngine._create_default_diffusion_stage_cfg({"diffusion_attention_config": existing_attention})[
+        0
+    ]
+    assert stage_cfg["engine_args"]["diffusion_attention_config"] == existing_attention
 
 
 def test_resolve_stage_configs_does_not_inject_diffusion_attention_into_llm_stage(monkeypatch):
@@ -1271,8 +1386,14 @@ def test_resolve_stage_configs_does_not_inject_diffusion_attention_into_llm_stag
 
     monkeypatch.setattr(
         engine_mod,
-        "load_and_resolve_stage_configs",
-        lambda *args, **kwargs: ("dummy-config", [stage_cfg], None),
+        "load_and_resolve_stage_config_views",
+        lambda *args, **kwargs: ResolvedStageConfigs(
+            config_path="dummy-config",
+            omni_config=None,
+            stage_configs=[stage_cfg],
+            deploy_config=None,
+            omni_lb_policy=None,
+        ),
     )
 
     _config_path, stage_configs = engine._resolve_stage_configs(

--- a/tests/engine/test_single_stage_mode.py
+++ b/tests/engine/test_single_stage_mode.py
@@ -16,7 +16,15 @@ from pytest_mock import MockerFixture
 from vllm.v1.engine.utils import EngineZmqAddresses
 
 from vllm_omni.config.config_factory import StageConfigFactory
-from vllm_omni.config.stage_config import DuplexSessionRuntimeConfig
+from vllm_omni.config.omni_config import VllmOmniConfig
+from vllm_omni.config.stage_config import (
+    DeployConfig,
+    DuplexSessionRuntimeConfig,
+    PipelineConfig,
+    StageDeployConfig,
+    StageExecutionType,
+    StagePipelineConfig,
+)
 from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
 from vllm_omni.engine.stage_engine_core_client import StageEngineCoreClientBase
 from vllm_omni.engine.stage_engine_startup import (
@@ -47,6 +55,34 @@ def _make_stage_cfg(stage_id: int, stage_type: str = "llm"):
             engine_output_type=None,
         ),
     )
+
+
+def _make_typed_diffusion_stage(
+    stage_id: int,
+    *,
+    devices: str = "0",
+    num_replicas: int = 1,
+) -> tuple[VllmOmniConfig, object]:
+    topology = StagePipelineConfig(
+        stage_id=stage_id,
+        model_stage="diffusion",
+        execution_type=StageExecutionType.DIFFUSION,
+        final_output=True,
+        final_output_type="image",
+        model_arch="TestDiffusion",
+    )
+    pipeline = PipelineConfig(
+        model_type=f"test_diffusion_{stage_id}",
+        model_arch="TestDiffusion",
+        stages=(topology,),
+    )
+    deploy = DeployConfig(stages=[StageDeployConfig(stage_id=stage_id, devices=devices, num_replicas=num_replicas)])
+    omni_config = VllmOmniConfig.from_pipeline_config(
+        pipeline,
+        user_deploy_config=deploy,
+        cli_overrides={"model": "dummy-model"},
+    )
+    return omni_config, omni_config.stage_by_id(stage_id)
 
 
 def _make_llm_plan(
@@ -98,6 +134,7 @@ def _make_diffusion_plan(
     launch_mode: str,
 ) -> LogicalStageInitPlan:
     stage_cfg = _make_stage_cfg(stage_id, stage_type="diffusion")
+    _, typed_stage = _make_typed_diffusion_stage(stage_id)
     metadata = SimpleNamespace(
         stage_id=stage_id,
         stage_type="diffusion",
@@ -123,6 +160,7 @@ def _make_diffusion_plan(
                 metadata=metadata,
                 stage_connector_spec={},
                 omni_kv_connector=(None, None, None),
+                omni_stage_config=typed_stage,
             )
         ],
     )
@@ -569,11 +607,18 @@ class TestEndpointRestrictionsTrustRemoteCode:
 
 
 class TestSingleStageInitialization:
-    def _build_runtime(self, stage_cfgs: list[Any], *, stage_id_filter: int | None) -> DistStageRuntime:
+    def _build_runtime(
+        self,
+        stage_cfgs: list[Any],
+        *,
+        stage_id_filter: int | None,
+        omni_config: VllmOmniConfig | None = None,
+    ) -> DistStageRuntime:
         return DistStageRuntime(
             stage_configs=stage_cfgs,
             model="fake-model",
             config_path="/fake/stages.yaml",
+            omni_config=omni_config,
             stage_init_timeout=60,
             diffusion_batch_size=2,
             async_chunk=False,
@@ -745,7 +790,8 @@ class TestSingleStageInitialization:
 
         stage_cfg = _make_stage_cfg(0, stage_type="diffusion")
         stage_cfg.runtime.devices = "0,1"
-        runtime = self._build_runtime([stage_cfg], stage_id_filter=0)
+        omni_config, _ = _make_typed_diffusion_stage(0, devices="0,1", num_replicas=2)
+        runtime = self._build_runtime([stage_cfg], stage_id_filter=0, omni_config=omni_config)
 
         monkeypatch = pytest.MonkeyPatch()
         monkeypatch.setattr(
@@ -775,7 +821,8 @@ class TestSingleStageInitialization:
         replicas = stage_plans[0].replicas
         assert [replica.replica_id for replica in replicas] == [0, 1]
         assert [replica.stage_cfg.runtime.devices for replica in replicas] == ["0", "1"]
-        assert [replica.metadata.runtime_cfg for replica in replicas] == [{"devices": "0"}, {"devices": "1"}]
+        assert [replica.metadata.runtime_cfg.devices for replica in replicas] == ["0", "1"]
+        assert all(replica.omni_stage_config is not None for replica in replicas)
 
     def test_initialize_stages_calls_master_server_only_in_single_stage_mode(self, mocker: MockerFixture):
         import vllm_omni.engine.stage_runtime as runtime_mod
@@ -1142,7 +1189,10 @@ class TestSingleStageReplicaInitialization:
 
         mocker.patch.object(runtime_mod, "inject_kv_stage_info")
         od_config = SimpleNamespace(max_num_seqs=None, parallel_config=SimpleNamespace(world_size=1))
-        mocker.patch("vllm_omni.engine.stage_engine_startup.build_diffusion_config", return_value=od_config)
+        mocker.patch(
+            "vllm_omni.engine.stage_engine_startup.build_diffusion_config_from_omni_stage_config",
+            return_value=od_config,
+        )
         mock_register = mocker.patch(
             "vllm_omni.engine.stage_engine_startup.register_stage_with_omni_master",
             return_value=StageRegistrationResponse(
@@ -1278,7 +1328,10 @@ class TestSingleStageReplicaInitialization:
 
         mocker.patch.object(runtime_mod, "inject_kv_stage_info")
         od_config = SimpleNamespace(max_num_seqs=None, parallel_config=SimpleNamespace(world_size=1))
-        mocker.patch("vllm_omni.engine.stage_engine_startup.build_diffusion_config", return_value=od_config)
+        mocker.patch(
+            "vllm_omni.engine.stage_engine_startup.build_diffusion_config_from_omni_stage_config",
+            return_value=od_config,
+        )
         mocker.patch(
             "vllm_omni.engine.stage_engine_startup.register_stage_with_omni_master",
             return_value=StageRegistrationResponse(

--- a/tests/engine/test_single_stage_mode.py
+++ b/tests/engine/test_single_stage_mode.py
@@ -13,7 +13,15 @@ from pytest_mock import MockerFixture
 from vllm.v1.engine.utils import EngineZmqAddresses
 
 from vllm_omni.config.config_factory import StageConfigFactory
-from vllm_omni.config.stage_config import DuplexSessionRuntimeConfig
+from vllm_omni.config.omni_config import VllmOmniConfig
+from vllm_omni.config.stage_config import (
+    DeployConfig,
+    DuplexSessionRuntimeConfig,
+    PipelineConfig,
+    StageDeployConfig,
+    StageExecutionType,
+    StagePipelineConfig,
+)
 from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
 from vllm_omni.engine.stage_engine_core_client import StageEngineCoreClientBase
 from vllm_omni.engine.stage_engine_startup import (
@@ -44,6 +52,34 @@ def _make_stage_cfg(stage_id: int, stage_type: str = "llm"):
             engine_output_type=None,
         ),
     )
+
+
+def _make_typed_diffusion_stage(
+    stage_id: int,
+    *,
+    devices: str = "0",
+    num_replicas: int = 1,
+) -> tuple[VllmOmniConfig, object]:
+    topology = StagePipelineConfig(
+        stage_id=stage_id,
+        model_stage="diffusion",
+        execution_type=StageExecutionType.DIFFUSION,
+        final_output=True,
+        final_output_type="image",
+        model_arch="TestDiffusion",
+    )
+    pipeline = PipelineConfig(
+        model_type=f"test_diffusion_{stage_id}",
+        model_arch="TestDiffusion",
+        stages=(topology,),
+    )
+    deploy = DeployConfig(stages=[StageDeployConfig(stage_id=stage_id, devices=devices, num_replicas=num_replicas)])
+    omni_config = VllmOmniConfig.from_pipeline_config(
+        pipeline,
+        user_deploy_config=deploy,
+        cli_overrides={"model": "dummy-model"},
+    )
+    return omni_config, omni_config.stage_by_id(stage_id)
 
 
 def _make_llm_plan(
@@ -95,6 +131,7 @@ def _make_diffusion_plan(
     launch_mode: str,
 ) -> LogicalStageInitPlan:
     stage_cfg = _make_stage_cfg(stage_id, stage_type="diffusion")
+    _, typed_stage = _make_typed_diffusion_stage(stage_id)
     metadata = SimpleNamespace(
         stage_id=stage_id,
         stage_type="diffusion",
@@ -120,6 +157,7 @@ def _make_diffusion_plan(
                 metadata=metadata,
                 stage_connector_spec={},
                 omni_kv_connector=(None, None, None),
+                omni_stage_config=typed_stage,
             )
         ],
     )
@@ -566,11 +604,18 @@ class TestEndpointRestrictionsTrustRemoteCode:
 
 
 class TestSingleStageInitialization:
-    def _build_runtime(self, stage_cfgs: list[Any], *, stage_id_filter: int | None) -> DistStageRuntime:
+    def _build_runtime(
+        self,
+        stage_cfgs: list[Any],
+        *,
+        stage_id_filter: int | None,
+        omni_config: VllmOmniConfig | None = None,
+    ) -> DistStageRuntime:
         return DistStageRuntime(
             stage_configs=stage_cfgs,
             model="fake-model",
             config_path="/fake/stages.yaml",
+            omni_config=omni_config,
             stage_init_timeout=60,
             diffusion_batch_size=2,
             async_chunk=False,
@@ -742,7 +787,8 @@ class TestSingleStageInitialization:
 
         stage_cfg = _make_stage_cfg(0, stage_type="diffusion")
         stage_cfg.runtime.devices = "0,1"
-        runtime = self._build_runtime([stage_cfg], stage_id_filter=0)
+        omni_config, _ = _make_typed_diffusion_stage(0, devices="0,1", num_replicas=2)
+        runtime = self._build_runtime([stage_cfg], stage_id_filter=0, omni_config=omni_config)
 
         monkeypatch = pytest.MonkeyPatch()
         monkeypatch.setattr(
@@ -772,7 +818,8 @@ class TestSingleStageInitialization:
         replicas = stage_plans[0].replicas
         assert [replica.replica_id for replica in replicas] == [0, 1]
         assert [replica.stage_cfg.runtime.devices for replica in replicas] == ["0", "1"]
-        assert [replica.metadata.runtime_cfg for replica in replicas] == [{"devices": "0"}, {"devices": "1"}]
+        assert [replica.metadata.runtime_cfg.devices for replica in replicas] == ["0", "1"]
+        assert all(replica.omni_stage_config is not None for replica in replicas)
 
     def test_initialize_stages_calls_master_server_only_in_single_stage_mode(self, mocker: MockerFixture):
         import vllm_omni.engine.stage_runtime as runtime_mod
@@ -1139,7 +1186,10 @@ class TestSingleStageReplicaInitialization:
 
         mocker.patch.object(runtime_mod, "inject_kv_stage_info")
         od_config = SimpleNamespace(max_num_seqs=None, parallel_config=SimpleNamespace(world_size=1))
-        mocker.patch("vllm_omni.engine.stage_engine_startup.build_diffusion_config", return_value=od_config)
+        mocker.patch(
+            "vllm_omni.engine.stage_engine_startup.build_diffusion_config_from_omni_stage_config",
+            return_value=od_config,
+        )
         mock_register = mocker.patch(
             "vllm_omni.engine.stage_engine_startup.register_stage_with_omni_master",
             return_value=StageRegistrationResponse(
@@ -1233,7 +1283,10 @@ class TestSingleStageReplicaInitialization:
 
         mocker.patch.object(runtime_mod, "inject_kv_stage_info")
         od_config = SimpleNamespace(max_num_seqs=None, parallel_config=SimpleNamespace(world_size=1))
-        mocker.patch("vllm_omni.engine.stage_engine_startup.build_diffusion_config", return_value=od_config)
+        mocker.patch(
+            "vllm_omni.engine.stage_engine_startup.build_diffusion_config_from_omni_stage_config",
+            return_value=od_config,
+        )
         mocker.patch(
             "vllm_omni.engine.stage_engine_startup.register_stage_with_omni_master",
             return_value=StageRegistrationResponse(

--- a/tests/engine/test_stage_metadata.py
+++ b/tests/engine/test_stage_metadata.py
@@ -1,10 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 import copy
 import operator
 
 import pytest
 from vllm.sampling_params import SamplingParams
 
-from vllm_omni.config.omni_config import VllmOmniConfig
+from vllm_omni.config.omni_config import OmniStageRuntimeConfig, VllmOmniConfig
 from vllm_omni.config.stage_config import (
     DeployConfig,
     PipelineConfig,
@@ -17,13 +20,14 @@ from vllm_omni.engine.stage_init_utils import (
     extract_legacy_stage_metadata,
     extract_stage_metadata,
     extract_stage_metadata_from_omni_stage_config,
+    setup_stage_devices,
 )
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 
-def _metadata_inputs() -> tuple[PipelineConfig, DeployConfig]:
+def _metadata_inputs(*, diffusion_requires_multimodal_data: bool = False) -> tuple[PipelineConfig, DeployConfig]:
     pipeline = PipelineConfig(
         model_type="metadata-test",
         stages=(
@@ -53,6 +57,7 @@ def _metadata_inputs() -> tuple[PipelineConfig, DeployConfig]:
                 input_sources=(1,),
                 final_output=True,
                 final_output_type="image",
+                requires_multimodal_data=diffusion_requires_multimodal_data,
                 custom_process_input_func="operator.neg",
                 cfg_kv_collect_func="operator.concat",
             ),
@@ -158,6 +163,35 @@ def test_extract_stage_metadata_preserves_legacy_one_argument_api():
     assert metadata.stage_id == 0
     assert metadata.model_stage == "thinker"
     assert metadata.custom_process_input_func is operator.add
+
+
+def test_extract_typed_diffusion_metadata_preserves_multimodal_requirement():
+    """Typed DiT metadata must retain topology-owned multimodal forwarding."""
+    pipeline, deploy = _metadata_inputs(diffusion_requires_multimodal_data=True)
+    omni_config = VllmOmniConfig.from_pipeline_config(
+        pipeline,
+        user_deploy_config=copy.deepcopy(deploy),
+    )
+
+    metadata = extract_stage_metadata_from_omni_stage_config(omni_config.stage_by_id(2))
+
+    assert metadata.stage_type == "diffusion"
+    assert metadata.requires_multimodal_data is True
+
+
+def test_setup_stage_devices_accepts_typed_runtime_config(monkeypatch):
+    """Typed diffusion startup must use the same device setup helper."""
+    captured: dict[str, object] = {}
+
+    def capture(stage_id, devices):
+        captured.update(stage_id=stage_id, devices=devices)
+        return devices
+
+    monkeypatch.setattr("vllm_omni.engine.stage_init_utils.set_stage_devices", capture)
+
+    setup_stage_devices(2, OmniStageRuntimeConfig(devices="3,4"))
+
+    assert captured == {"stage_id": 2, "devices": "3,4"}
 
 
 def test_extract_stage_metadata_defaults_missing_engine_input_source():

--- a/tests/entrypoints/test_async_omni_diffusion_config.py
+++ b/tests/entrypoints/test_async_omni_diffusion_config.py
@@ -8,6 +8,7 @@ import pytest
 from vllm_omni.diffusion.data import AttentionConfig
 from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
 from vllm_omni.entrypoints.cli.serve import OmniServeCommand
+from vllm_omni.entrypoints.utils import _build_default_diffusion_config_views
 from vllm_omni.utils.tracking_parser import TrackingArgumentParser
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
@@ -83,25 +84,74 @@ def test_default_stage_config_preserves_and_overrides_promoted_extras():
     assert extras["default_llama_model_id"] == "top-level/default-llama"
 
 
-def test_stage_override_preserves_model_extras_for_default_diffusion_stage(mocker):
-    """Local/unregistered Diffusers checkpoints still honor stage-0 extras."""
+def test_default_diffusion_views_keep_missing_model_arch_unset():
+    """An unregistered checkpoint may need diffusion-side class discovery."""
+    raw_stage_configs = AsyncOmniEngine._create_default_diffusion_stage_cfg({})
+
+    _, omni_config, _ = _build_default_diffusion_config_views(
+        "unregistered/diffusion-checkpoint",
+        raw_stage_configs,
+    )
+
+    stage = omni_config.stage_by_id(0)
+    assert stage.diffusion_config.model_arch is None
+    assert stage.diffusion_config.model_class_name is None
+
+
+@pytest.mark.parametrize("stage_key", ["0", 0])
+def test_stage_override_preserves_complete_fallback_diffusion_config(mocker, stage_key):
+    """Unregistered diffusion checkpoints receive all stage-0 overrides."""
+    from vllm_omni.entrypoints.utils import ResolvedStageConfigs
+
+    captured: dict[str, object] = {}
 
     def resolve_with_default(*_args, default_stage_cfg_factory, **_kwargs):
-        return None, default_stage_cfg_factory(), None
+        fallback = default_stage_cfg_factory()
+        captured["fallback"] = fallback
+        return ResolvedStageConfigs(
+            config_path=None,
+            omni_config=None,
+            stage_configs=fallback,
+            deploy_config=None,
+            omni_lb_policy=None,
+        )
 
     mocker.patch(
-        "vllm_omni.engine.async_omni_engine.load_and_resolve_stage_configs",
+        "vllm_omni.engine.async_omni_engine.load_and_resolve_stage_config_views",
         side_effect=resolve_with_default,
     )
     engine = AsyncOmniEngine.__new__(AsyncOmniEngine)
 
+    stage_overrides = {
+        stage_key: {
+            "extras": {
+                "ltx2_use_conv_vae": True,
+                "nested": {"override": 2},
+            },
+            "diffusion_load_format": "diffusers",
+            "num_gpus": 2,
+            "devices": "2,3",
+        }
+    }
     _, stage_configs = engine._resolve_stage_configs(
         "/models/LTX-2.5-Diffusers",
-        {"stage_overrides": '{"0":{"extras":{"ltx2_use_conv_vae":true}}}'},
+        {
+            "model_class_name": "LTXVideoPipeline",
+            "diffusion_load_format": "default",
+            "num_gpus": 1,
+            "extras": {"nested": {"base": 1}},
+            "stage_overrides": stage_overrides,
+        },
         trust_remote_code=False,
     )
 
-    assert stage_configs[0]["engine_args"]["extras"]["ltx2_use_conv_vae"] is True
+    assert stage_configs[0]["engine_args"]["diffusion_load_format"] == "diffusers"
+    assert stage_configs[0]["engine_args"]["num_gpus"] == 2
+    assert stage_configs[0]["runtime"]["devices"] == "2,3"
+    extras = stage_configs[0]["engine_args"]["extras"]
+    assert extras["ltx2_use_conv_vae"] is True
+    assert extras["nested"] == {"base": 1, "override": 2}
+    assert captured["fallback"] is stage_configs
 
 
 def test_default_cache_config_used_when_missing():
@@ -616,19 +666,20 @@ def test_default_stage_resolves_video_output_from_checkpoint(mocker):
     def resolve_with_default(*args, default_stage_cfg_factory, **kwargs):
         del args, kwargs
         captured.update(default_stage_cfg_factory()[0])
-        stage = SimpleNamespace(stage_type="diffusion", engine_args=SimpleNamespace())
-        return ("", [stage], None)
+        from vllm_omni.entrypoints.utils import ResolvedStageConfigs
+
+        stage = SimpleNamespace(stage_id=0, stage_type="diffusion", engine_args=SimpleNamespace())
+        return ResolvedStageConfigs("", None, [stage], None, None)
 
     resolver = mocker.patch(
         "vllm_omni.engine.async_omni_engine.resolve_model_class_name",
         return_value="MiniMaxH3Pipeline",
     )
     mocker.patch(
-        "vllm_omni.engine.async_omni_engine.load_and_resolve_stage_configs",
+        "vllm_omni.engine.async_omni_engine.load_and_resolve_stage_config_views",
         side_effect=resolve_with_default,
     )
     engine = AsyncOmniEngine.__new__(AsyncOmniEngine)
-    engine._strip_single_engine_args = lambda kwargs: kwargs
 
     engine._resolve_stage_configs(
         "/models/MiniMax-H3/FL2VA",
@@ -640,34 +691,79 @@ def test_default_stage_resolves_video_output_from_checkpoint(mocker):
     assert captured["final_output_type"] == "video"
 
 
-def test_default_diffusers_stage_preserves_video_model_identity(mocker):
+def test_default_stage_class_discovery_receives_requested_revision(mocker):
+    """Fallback class discovery must inspect the same Hub revision as loading."""
+    from vllm_omni.entrypoints.utils import ResolvedStageConfigs
+
     captured = {}
 
     def resolve_with_default(*args, default_stage_cfg_factory, **kwargs):
         del args, kwargs
         captured.update(default_stage_cfg_factory()[0])
-        stage = SimpleNamespace(stage_type="diffusion", engine_args=SimpleNamespace())
-        return ("", [stage], None)
+        stage = SimpleNamespace(stage_id=0, stage_type="diffusion", engine_args=SimpleNamespace())
+        return ResolvedStageConfigs(None, None, [stage], None, None)
 
-    mocker.patch(
-        "vllm_omni.diffusion.utils.hf_utils.get_diffusion_model_index",
-        return_value={"_class_name": "WanImageToVideoPipeline"},
+    resolver = mocker.patch(
+        "vllm_omni.engine.async_omni_engine.resolve_model_class_name",
+        return_value="RevisionAwarePipeline",
     )
     mocker.patch(
-        "vllm_omni.engine.async_omni_engine.load_and_resolve_stage_configs",
+        "vllm_omni.engine.async_omni_engine.load_and_resolve_stage_config_views",
         side_effect=resolve_with_default,
     )
     engine = AsyncOmniEngine.__new__(AsyncOmniEngine)
-    engine._strip_single_engine_args = lambda kwargs: kwargs
 
     engine._resolve_stage_configs(
-        "/models/Wan2.2-I2V",
-        {"diffusion_load_format": "diffusers"},
+        "/models/revision-aware",
+        {"revision": "refs/pr/42"},
         trust_remote_code=False,
     )
 
-    assert captured["engine_args"]["model_class_name"] == "WanImageToVideoPipeline"
-    assert captured["final_output_type"] == "video"
+    resolver.assert_called_once_with(
+        "/models/revision-aware",
+        "default",
+        revision="refs/pr/42",
+    )
+    assert captured["engine_args"]["revision"] == "refs/pr/42"
+    assert captured["engine_args"]["model_class_name"] == "RevisionAwarePipeline"
+
+
+def test_diffusion_od_metadata_reuses_typed_stage_revision(mocker):
+    """Serving metadata must agree with the typed DiT consumer's class name."""
+    engine = AsyncOmniEngine.__new__(AsyncOmniEngine)
+    engine.model = "/models/revision-aware"
+    engine._model_revision = "refs/pr/42"
+    engine._diffusion_od_config_view = None
+    engine.vllm_omni_config = SimpleNamespace(
+        stage_configs=[
+            SimpleNamespace(
+                diffusion_config=SimpleNamespace(
+                    model_class_name="HunyuanImage3ForCausalMM",
+                    revision="refs/pr/42",
+                )
+            )
+        ]
+    )
+    resolver = mocker.patch("vllm_omni.engine.async_omni_engine.resolve_model_class_name")
+
+    metadata = engine.get_diffusion_od_config()
+
+    resolver.assert_not_called()
+    assert metadata.model == "/models/revision-aware"
+    assert metadata.model_class_name == "HunyuanImage3ForCausalMM"
+    assert metadata.revision == "refs/pr/42"
+
+
+def test_default_diffusers_stage_preserves_video_model_identity(mocker):
+    stage_cfg = AsyncOmniEngine._create_default_diffusion_stage_cfg(
+        {
+            "diffusion_load_format": "diffusers",
+            "model_class_name": "WanImageToVideoPipeline",
+        }
+    )[0]
+
+    assert stage_cfg["engine_args"]["model_class_name"] == "WanImageToVideoPipeline"
+    assert stage_cfg["final_output_type"] == "video"
 
 
 def test_resolve_stage_configs_injects_additional_config_into_diffusion_stage(mocker):
@@ -680,13 +776,20 @@ def test_resolve_stage_configs_injects_additional_config_into_diffusion_stage(mo
         stage_type="llm",
         engine_args=SimpleNamespace(),
     )
+    from vllm_omni.entrypoints.utils import ResolvedStageConfigs
+
     mocker.patch(
-        "vllm_omni.engine.async_omni_engine.load_and_resolve_stage_configs",
-        return_value=("dummy.yaml", [fake_llm_stage, fake_diffusion_stage], None),
+        "vllm_omni.engine.async_omni_engine.load_and_resolve_stage_config_views",
+        return_value=ResolvedStageConfigs(
+            "dummy.yaml",
+            None,
+            [fake_llm_stage, fake_diffusion_stage],
+            None,
+            None,
+        ),
     )
 
     engine = AsyncOmniEngine.__new__(AsyncOmniEngine)
-
     _, stage_configs = engine._resolve_stage_configs(
         "dummy-model",
         {
@@ -696,8 +799,19 @@ def test_resolve_stage_configs_injects_additional_config_into_diffusion_stage(mo
         trust_remote_code=False,
     )
 
+    # The typed resolver is now the owner of this field.  The legacy view is
+    # retained only as a compatibility payload and is not post-mutated here.
     assert not hasattr(stage_configs[0].engine_args, "additional_config")
-    assert stage_configs[1].engine_args.additional_config == {"torchair_graph_config": {"enabled": True}}
+    assert not hasattr(stage_configs[1].engine_args, "additional_config")
+
+
+def test_default_diffusion_stage_forwards_additional_config():
+    """Ensure the typed fallback owner receives top-level additional_config."""
+    stage_cfg = AsyncOmniEngine._create_default_diffusion_stage_cfg(
+        {"additional_config": {"torchair_graph_config": {"enabled": True}}}
+    )[0]
+
+    assert stage_cfg["engine_args"]["additional_config"] == {"torchair_graph_config": {"enabled": True}}
 
 
 @pytest.mark.parametrize(
@@ -730,25 +844,9 @@ def test_default_stage_config_includes_quantization_config():
     assert stage_cfg["engine_args"]["quantization_config"] == quantization_config
 
 
-def test_resolve_stage_configs_injects_quantization_config_into_diffusion_stage(mocker):
-    fake_diffusion_stage = SimpleNamespace(
-        stage_type="diffusion",
-        engine_args=SimpleNamespace(quantization_config=None),
-    )
-    mocker.patch(
-        "vllm_omni.engine.async_omni_engine.load_and_resolve_stage_configs",
-        return_value=("dummy.yaml", [fake_diffusion_stage], None),
-    )
+def test_default_diffusion_stage_forwards_quantization_config():
+    stage_cfg = AsyncOmniEngine._create_default_diffusion_stage_cfg(
+        {"quantization_config": {"method": "bitsandbytes"}}
+    )[0]
 
-    engine = AsyncOmniEngine.__new__(AsyncOmniEngine)
-
-    _, stage_configs = engine._resolve_stage_configs(
-        "dummy-model",
-        {
-            "deploy_config": "dummy.yaml",
-            "quantization_config": {"method": "bitsandbytes"},
-        },
-        trust_remote_code=False,
-    )
-
-    assert stage_configs[0].engine_args.quantization_config == {"method": "bitsandbytes"}
+    assert stage_cfg["engine_args"]["quantization_config"] == {"method": "bitsandbytes"}

--- a/tests/entrypoints/test_async_omni_diffusion_config.py
+++ b/tests/entrypoints/test_async_omni_diffusion_config.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from types import SimpleNamespace
 
 import pytest
 
@@ -479,34 +478,13 @@ def test_serve_cli_accepts_additional_config():
     assert engine_args["additional_config"] == {"torchair_graph_config": {"enabled": True}}
 
 
-def test_resolve_stage_configs_injects_additional_config_into_diffusion_stage(mocker):
-    """Ensure YAML/deploy stage resolution forwards top-level additional_config."""
-    fake_diffusion_stage = SimpleNamespace(
-        stage_type="diffusion",
-        engine_args=SimpleNamespace(),
-    )
-    fake_llm_stage = SimpleNamespace(
-        stage_type="llm",
-        engine_args=SimpleNamespace(),
-    )
-    mocker.patch(
-        "vllm_omni.engine.async_omni_engine.load_and_resolve_stage_configs",
-        return_value=("dummy.yaml", [fake_llm_stage, fake_diffusion_stage], None),
-    )
+def test_default_diffusion_stage_forwards_additional_config():
+    """Ensure the typed fallback owner receives top-level additional_config."""
+    stage_cfg = AsyncOmniEngine._create_default_diffusion_stage_cfg(
+        {"additional_config": {"torchair_graph_config": {"enabled": True}}}
+    )[0]
 
-    engine = AsyncOmniEngine.__new__(AsyncOmniEngine)
-
-    _, stage_configs = engine._resolve_stage_configs(
-        "dummy-model",
-        {
-            "deploy_config": "dummy.yaml",
-            "additional_config": {"torchair_graph_config": {"enabled": True}},
-        },
-        trust_remote_code=False,
-    )
-
-    assert not hasattr(stage_configs[0].engine_args, "additional_config")
-    assert stage_configs[1].engine_args.additional_config == {"torchair_graph_config": {"enabled": True}}
+    assert stage_cfg["engine_args"]["additional_config"] == {"torchair_graph_config": {"enabled": True}}
 
 
 @pytest.mark.parametrize(
@@ -539,25 +517,9 @@ def test_default_stage_config_includes_quantization_config():
     assert stage_cfg["engine_args"]["quantization_config"] == quantization_config
 
 
-def test_resolve_stage_configs_injects_quantization_config_into_diffusion_stage(mocker):
-    fake_diffusion_stage = SimpleNamespace(
-        stage_type="diffusion",
-        engine_args=SimpleNamespace(quantization_config=None),
-    )
-    mocker.patch(
-        "vllm_omni.engine.async_omni_engine.load_and_resolve_stage_configs",
-        return_value=("dummy.yaml", [fake_diffusion_stage], None),
-    )
+def test_default_diffusion_stage_forwards_quantization_config():
+    stage_cfg = AsyncOmniEngine._create_default_diffusion_stage_cfg(
+        {"quantization_config": {"method": "bitsandbytes"}}
+    )[0]
 
-    engine = AsyncOmniEngine.__new__(AsyncOmniEngine)
-
-    _, stage_configs = engine._resolve_stage_configs(
-        "dummy-model",
-        {
-            "deploy_config": "dummy.yaml",
-            "quantization_config": {"method": "bitsandbytes"},
-        },
-        trust_remote_code=False,
-    )
-
-    assert stage_configs[0].engine_args.quantization_config == {"method": "bitsandbytes"}
+    assert stage_cfg["engine_args"]["quantization_config"] == {"method": "bitsandbytes"}

--- a/tests/entrypoints/test_serve.py
+++ b/tests/entrypoints/test_serve.py
@@ -7,12 +7,21 @@ from __future__ import annotations
 
 import argparse
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from pytest_mock import MockerFixture
 
+from vllm_omni.config.omni_config import VllmOmniConfig
+from vllm_omni.config.stage_config import (
+    DeployConfig,
+    PipelineConfig,
+    StageDeployConfig,
+    StageExecutionType,
+    StagePipelineConfig,
+)
 from vllm_omni.entrypoints.cli.serve import OmniServeCommand, run_headless
-from vllm_omni.entrypoints.utils import parse_stage_overrides
+from vllm_omni.entrypoints.utils import ResolvedStageConfigs, parse_stage_overrides
 from vllm_omni.utils.tracking_parser import TrackingArgumentParser, TrackingNamespace
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
@@ -33,6 +42,17 @@ def test_serve_parser_accepts_no_async_chunk_and_marks_it_explicit() -> None:
     explicit = args.get_explicit_kwargs_dict()
     assert args.get_explicit_kwargs_dict()
     assert not explicit["async_chunk"]
+
+
+def test_serve_parser_does_not_treat_diffusion_streaming_default_as_explicit() -> None:
+    parser = TrackingArgumentParser()
+    subparsers = parser.add_subparsers(dest="subcommand")
+    OmniServeCommand().subparser_init(subparsers)
+
+    args = parser.parse_args(["serve", "fake-model", "--omni"])
+
+    assert args.diffusion_streaming_output is False
+    assert "diffusion_streaming_output" not in args.get_explicit_kwargs_dict()
 
 
 def test_serve_parser_accepts_strategy_config() -> None:
@@ -180,10 +200,7 @@ def test_parse_stage_overrides_invalid_json_raises() -> None:
 
 
 def test_run_headless_parses_and_forwards_stage_overrides(mocker: MockerFixture) -> None:
-    """Regression: the headless path must parse ``--stage-overrides`` (a JSON
-    string) and forward the parsed dict to ``load_and_resolve_stage_configs``,
-    mirroring the standard engine path. Previously it was dropped entirely,
-    silently producing a different per-stage device layout."""
+    """Headless forwards parsed overrides through the shared typed resolver."""
     captured: dict = {}
 
     def _fake_resolve(*args, **kwargs):
@@ -191,10 +208,10 @@ def test_run_headless_parses_and_forwards_stage_overrides(mocker: MockerFixture)
         captured.update(kwargs)
         # Return a stage that does NOT match stage_id=0 so run_headless stops
         # right after the resolver call (we only care about how it was called).
-        return ("/fake/stages.yaml", [SimpleNamespace(stage_id=99)], None)
+        return _resolved_stage_configs([SimpleNamespace(stage_id=99)])
 
     mocker.patch(
-        "vllm_omni.entrypoints.utils.load_and_resolve_stage_configs",
+        "vllm_omni.entrypoints.utils.load_and_resolve_stage_config_views",
         side_effect=_fake_resolve,
     )
 
@@ -217,8 +234,8 @@ def test_run_headless_invalid_stage_overrides_raises(mocker: MockerFixture) -> N
     """Invalid ``--stage-overrides`` JSON in headless mode fails fast with the
     shared ValueError instead of being silently ignored."""
     mocker.patch(
-        "vllm_omni.entrypoints.utils.load_and_resolve_stage_configs",
-        return_value=("/fake/stages.yaml", [SimpleNamespace(stage_id=0)], None),
+        "vllm_omni.entrypoints.utils.load_and_resolve_stage_config_views",
+        return_value=_resolved_stage_configs([SimpleNamespace(stage_id=0)]),
     )
 
     args = _make_headless_args(stage_id=0, stage_overrides="{not valid json}")
@@ -231,8 +248,8 @@ def test_run_headless_raises_when_stage_id_not_in_configs(mocker: MockerFixture)
     fails fast when the launcher's --stage-id doesn't match any entry."""
     other_stage = SimpleNamespace(stage_id=99)
     mocker.patch(
-        "vllm_omni.entrypoints.utils.load_and_resolve_stage_configs",
-        return_value=("/fake/stages.yaml", [other_stage], None),
+        "vllm_omni.entrypoints.utils.load_and_resolve_stage_config_views",
+        return_value=_resolved_stage_configs([other_stage]),
     )
 
     args = _make_headless_args(stage_id=0)
@@ -262,6 +279,61 @@ def _make_stage_cfg(stage_id: int, stage_type: str) -> SimpleNamespace:
     )
 
 
+def _make_typed_diffusion_config(stage_id: int, *, upstream_tp: int | None = None) -> VllmOmniConfig:
+    upstream_id = stage_id - 1
+    topologies = []
+    deploy_stages = []
+    if upstream_tp is not None:
+        topologies.append(
+            StagePipelineConfig(
+                stage_id=upstream_id,
+                model_stage="ar",
+                execution_type=StageExecutionType.LLM_AR,
+            )
+        )
+        deploy_stages.append(StageDeployConfig(stage_id=upstream_id, tensor_parallel_size=upstream_tp))
+    topologies.append(
+        StagePipelineConfig(
+            stage_id=stage_id,
+            model_stage="diffusion",
+            execution_type=StageExecutionType.DIFFUSION,
+            input_sources=(upstream_id,) if upstream_tp is not None else (),
+            final_output=True,
+            final_output_type="image",
+            model_arch="TestDiffusion",
+        )
+    )
+    deploy_stages.append(StageDeployConfig(stage_id=stage_id, tensor_parallel_size=2))
+    pipeline = PipelineConfig(
+        model_type=f"test_headless_diffusion_{stage_id}",
+        model_arch="TestDiffusion",
+        stages=tuple(topologies),
+    )
+    deploy = DeployConfig(async_chunk=False, stages=deploy_stages)
+    return VllmOmniConfig.from_pipeline_config(
+        pipeline,
+        user_deploy_config=deploy,
+        cli_overrides={"model": "fake-model"},
+    )
+
+
+def _resolved_stage_configs(
+    stage_configs: list[Any],
+    *,
+    omni_config: VllmOmniConfig | None = None,
+    config_path: str = "/fake/stages.yaml",
+    typed_topology_stage_configs: tuple[Any, ...] = (),
+) -> ResolvedStageConfigs:
+    return ResolvedStageConfigs(
+        config_path=config_path,
+        omni_config=omni_config,
+        stage_configs=stage_configs,
+        deploy_config=None,
+        omni_lb_policy=None,
+        typed_topology_stage_configs=typed_topology_stage_configs,
+    )
+
+
 def test_run_headless_llm_registers_with_auto_assigned_replica_id(mocker: MockerFixture) -> None:
     """LLM headless: each loop iteration registers with auto-assigned
     replica_id (master picks a free slot) and spawns one
@@ -280,8 +352,8 @@ def test_run_headless_llm_registers_with_auto_assigned_replica_id(mocker: Mocker
     engine_manager = mocker.Mock()
 
     mocker.patch(
-        "vllm_omni.entrypoints.utils.load_and_resolve_stage_configs",
-        return_value=("/fake/stages.yaml", [stage_cfg], None),
+        "vllm_omni.entrypoints.utils.load_and_resolve_stage_config_views",
+        return_value=_resolved_stage_configs([stage_cfg]),
     )
     mocker.patch("vllm_omni.engine.stage_init_utils.prepare_engine_environment")
     mocker.patch("vllm_omni.engine.stage_init_utils.load_omni_transfer_config_for_model", return_value=None)
@@ -360,8 +432,8 @@ def test_run_headless_llm_launches_one_manager_per_omni_dp_size_local(mocker: Mo
     manager_b = mocker.Mock()
 
     mocker.patch(
-        "vllm_omni.entrypoints.utils.load_and_resolve_stage_configs",
-        return_value=("/fake/stages.yaml", [stage_cfg], None),
+        "vllm_omni.entrypoints.utils.load_and_resolve_stage_config_views",
+        return_value=_resolved_stage_configs([stage_cfg]),
     )
     mocker.patch("vllm_omni.engine.stage_init_utils.prepare_engine_environment")
     mocker.patch("vllm_omni.engine.stage_init_utils.load_omni_transfer_config_for_model", return_value=None)
@@ -414,13 +486,23 @@ def test_run_headless_diffusion_registers_and_spawns_proc(mocker: MockerFixture)
     from vllm_omni.engine.stage_engine_startup import StageRegistrationResponse
 
     stage_cfg = _make_stage_cfg(1, stage_type="diffusion")
+    topology_config = _make_typed_diffusion_config(stage_cfg.stage_id, upstream_tp=4)
+    active_config = VllmOmniConfig(
+        pipeline_config=topology_config.pipeline_config,
+        stage_configs=(topology_config.stage_by_id(stage_cfg.stage_id),),
+        orchestrator_config=topology_config.orchestrator_config,
+    )
     od_config = mocker.Mock()
     proc = mocker.Mock(sentinel=object(), exitcode=0)
     proc.is_alive.return_value = False
 
     mocker.patch(
-        "vllm_omni.entrypoints.utils.load_and_resolve_stage_configs",
-        return_value=("/fake/stages.yaml", [stage_cfg], None),
+        "vllm_omni.entrypoints.utils.load_and_resolve_stage_config_views",
+        return_value=_resolved_stage_configs(
+            [stage_cfg],
+            omni_config=active_config,
+            typed_topology_stage_configs=topology_config.stage_configs,
+        ),
     )
     mocker.patch("vllm_omni.engine.stage_init_utils.prepare_engine_environment")
     mocker.patch("vllm_omni.engine.stage_init_utils.load_omni_transfer_config_for_model", return_value=None)
@@ -428,12 +510,15 @@ def test_run_headless_diffusion_registers_and_spawns_proc(mocker: MockerFixture)
         "vllm_omni.distributed.omni_connectors.utils.initialization.resolve_omni_kv_config_for_stage",
         return_value=(None, None, None),
     )
-    mocker.patch(
-        "vllm_omni.engine.stage_init_utils.extract_legacy_stage_metadata",
-        return_value=SimpleNamespace(stage_id=1, stage_type="diffusion"),
-    )
     mock_inject = mocker.patch("vllm_omni.engine.stage_init_utils.inject_kv_stage_info")
-    mocker.patch("vllm_omni.engine.stage_init_utils.build_diffusion_config", return_value=od_config)
+    mock_build = mocker.patch(
+        "vllm_omni.engine.stage_init_utils.build_diffusion_config_from_omni_stage_config",
+        return_value=od_config,
+    )
+    mock_legacy_build = mocker.patch(
+        "vllm_omni.engine.stage_init_utils.build_diffusion_config",
+        side_effect=AssertionError("headless diffusion startup used the legacy builder"),
+    )
     mock_register = mocker.patch(
         "vllm_omni.engine.stage_engine_startup.register_stage_with_omni_master",
         return_value=StageRegistrationResponse(
@@ -466,10 +551,12 @@ def test_run_headless_diffusion_registers_and_spawns_proc(mocker: MockerFixture)
 
     run_headless(_make_headless_args(stage_id=1))
 
-    mock_inject.assert_called_once()
-    assert mock_inject.call_args.args[0] is stage_cfg
-    assert mock_inject.call_args.args[1] == 1
-    assert mock_inject.call_args.args[2] == [stage_cfg]
+    mock_inject.assert_not_called()
+    mock_build.assert_called_once()
+    assert mock_build.call_args.args[1].stage_id == 1
+    assert mock_build.call_args.args[1].__class__.__name__ == "VllmOmniDiffusionStageConfig"
+    assert [stage.stage_id for stage in mock_build.call_args.kwargs["stage_configs"]] == [0, 1]
+    mock_legacy_build.assert_not_called()
 
     reg_kwargs = mock_register.call_args.kwargs
     assert reg_kwargs["omni_master_address"] == "127.0.0.1"
@@ -499,8 +586,11 @@ def test_run_headless_diffusion_raises_on_nonzero_proc_exit(mocker: MockerFixtur
     proc.is_alive.return_value = False
 
     mocker.patch(
-        "vllm_omni.entrypoints.utils.load_and_resolve_stage_configs",
-        return_value=("/fake/stages.yaml", [stage_cfg], None),
+        "vllm_omni.entrypoints.utils.load_and_resolve_stage_config_views",
+        return_value=_resolved_stage_configs(
+            [stage_cfg],
+            omni_config=_make_typed_diffusion_config(stage_cfg.stage_id),
+        ),
     )
     mocker.patch("vllm_omni.engine.stage_init_utils.prepare_engine_environment")
     mocker.patch("vllm_omni.engine.stage_init_utils.load_omni_transfer_config_for_model", return_value=None)
@@ -508,12 +598,11 @@ def test_run_headless_diffusion_raises_on_nonzero_proc_exit(mocker: MockerFixtur
         "vllm_omni.distributed.omni_connectors.utils.initialization.resolve_omni_kv_config_for_stage",
         return_value=(None, None, None),
     )
-    mocker.patch(
-        "vllm_omni.engine.stage_init_utils.extract_legacy_stage_metadata",
-        return_value=SimpleNamespace(stage_id=1, stage_type="diffusion"),
-    )
     mocker.patch("vllm_omni.engine.stage_init_utils.inject_kv_stage_info")
-    mocker.patch("vllm_omni.engine.stage_init_utils.build_diffusion_config", return_value=mocker.Mock())
+    mocker.patch(
+        "vllm_omni.engine.stage_init_utils.build_diffusion_config_from_omni_stage_config",
+        return_value=mocker.Mock(),
+    )
     mocker.patch(
         "vllm_omni.engine.stage_engine_startup.register_stage_with_omni_master",
         return_value=StageRegistrationResponse(

--- a/tests/entrypoints/test_serve.py
+++ b/tests/entrypoints/test_serve.py
@@ -4,12 +4,21 @@ from __future__ import annotations
 
 import argparse
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from pytest_mock import MockerFixture
 
+from vllm_omni.config.omni_config import VllmOmniConfig
+from vllm_omni.config.stage_config import (
+    DeployConfig,
+    PipelineConfig,
+    StageDeployConfig,
+    StageExecutionType,
+    StagePipelineConfig,
+)
 from vllm_omni.entrypoints.cli.serve import OmniServeCommand, run_headless
-from vllm_omni.entrypoints.utils import parse_stage_overrides
+from vllm_omni.entrypoints.utils import ResolvedStageConfigs, parse_stage_overrides
 from vllm_omni.utils.tracking_parser import TrackingArgumentParser, TrackingNamespace
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
@@ -166,10 +175,7 @@ def test_parse_stage_overrides_invalid_json_raises() -> None:
 
 
 def test_run_headless_parses_and_forwards_stage_overrides(mocker: MockerFixture) -> None:
-    """Regression: the headless path must parse ``--stage-overrides`` (a JSON
-    string) and forward the parsed dict to ``load_and_resolve_stage_configs``,
-    mirroring the standard engine path. Previously it was dropped entirely,
-    silently producing a different per-stage device layout."""
+    """Headless forwards parsed overrides through the shared typed resolver."""
     captured: dict = {}
 
     def _fake_resolve(*args, **kwargs):
@@ -177,10 +183,10 @@ def test_run_headless_parses_and_forwards_stage_overrides(mocker: MockerFixture)
         captured.update(kwargs)
         # Return a stage that does NOT match stage_id=0 so run_headless stops
         # right after the resolver call (we only care about how it was called).
-        return ("/fake/stages.yaml", [SimpleNamespace(stage_id=99)], None)
+        return _resolved_stage_configs([SimpleNamespace(stage_id=99)])
 
     mocker.patch(
-        "vllm_omni.entrypoints.utils.load_and_resolve_stage_configs",
+        "vllm_omni.entrypoints.utils.load_and_resolve_stage_config_views",
         side_effect=_fake_resolve,
     )
 
@@ -203,8 +209,8 @@ def test_run_headless_invalid_stage_overrides_raises(mocker: MockerFixture) -> N
     """Invalid ``--stage-overrides`` JSON in headless mode fails fast with the
     shared ValueError instead of being silently ignored."""
     mocker.patch(
-        "vllm_omni.entrypoints.utils.load_and_resolve_stage_configs",
-        return_value=("/fake/stages.yaml", [SimpleNamespace(stage_id=0)], None),
+        "vllm_omni.entrypoints.utils.load_and_resolve_stage_config_views",
+        return_value=_resolved_stage_configs([SimpleNamespace(stage_id=0)]),
     )
 
     args = _make_headless_args(stage_id=0, stage_overrides="{not valid json}")
@@ -217,8 +223,8 @@ def test_run_headless_raises_when_stage_id_not_in_configs(mocker: MockerFixture)
     fails fast when the launcher's --stage-id doesn't match any entry."""
     other_stage = SimpleNamespace(stage_id=99)
     mocker.patch(
-        "vllm_omni.entrypoints.utils.load_and_resolve_stage_configs",
-        return_value=("/fake/stages.yaml", [other_stage], None),
+        "vllm_omni.entrypoints.utils.load_and_resolve_stage_config_views",
+        return_value=_resolved_stage_configs([other_stage]),
     )
 
     args = _make_headless_args(stage_id=0)
@@ -248,6 +254,43 @@ def _make_stage_cfg(stage_id: int, stage_type: str) -> SimpleNamespace:
     )
 
 
+def _make_typed_diffusion_config(stage_id: int) -> VllmOmniConfig:
+    topology = StagePipelineConfig(
+        stage_id=stage_id,
+        model_stage="diffusion",
+        execution_type=StageExecutionType.DIFFUSION,
+        final_output=True,
+        final_output_type="image",
+        model_arch="TestDiffusion",
+    )
+    pipeline = PipelineConfig(
+        model_type=f"test_headless_diffusion_{stage_id}",
+        model_arch="TestDiffusion",
+        stages=(topology,),
+    )
+    deploy = DeployConfig(stages=[StageDeployConfig(stage_id=stage_id)])
+    return VllmOmniConfig.from_pipeline_config(
+        pipeline,
+        user_deploy_config=deploy,
+        cli_overrides={"model": "fake-model"},
+    )
+
+
+def _resolved_stage_configs(
+    stage_configs: list[Any],
+    *,
+    omni_config: VllmOmniConfig | None = None,
+    config_path: str = "/fake/stages.yaml",
+) -> ResolvedStageConfigs:
+    return ResolvedStageConfigs(
+        config_path=config_path,
+        omni_config=omni_config,
+        stage_configs=stage_configs,
+        deploy_config=None,
+        omni_lb_policy=None,
+    )
+
+
 def test_run_headless_llm_registers_with_auto_assigned_replica_id(mocker: MockerFixture) -> None:
     """LLM headless: each loop iteration registers with auto-assigned
     replica_id (master picks a free slot) and spawns one
@@ -266,8 +309,8 @@ def test_run_headless_llm_registers_with_auto_assigned_replica_id(mocker: Mocker
     engine_manager = mocker.Mock()
 
     mocker.patch(
-        "vllm_omni.entrypoints.utils.load_and_resolve_stage_configs",
-        return_value=("/fake/stages.yaml", [stage_cfg], None),
+        "vllm_omni.entrypoints.utils.load_and_resolve_stage_config_views",
+        return_value=_resolved_stage_configs([stage_cfg]),
     )
     mocker.patch("vllm_omni.engine.stage_init_utils.prepare_engine_environment")
     mocker.patch("vllm_omni.engine.stage_init_utils.load_omni_transfer_config_for_model", return_value=None)
@@ -346,8 +389,8 @@ def test_run_headless_llm_launches_one_manager_per_omni_dp_size_local(mocker: Mo
     manager_b = mocker.Mock()
 
     mocker.patch(
-        "vllm_omni.entrypoints.utils.load_and_resolve_stage_configs",
-        return_value=("/fake/stages.yaml", [stage_cfg], None),
+        "vllm_omni.entrypoints.utils.load_and_resolve_stage_config_views",
+        return_value=_resolved_stage_configs([stage_cfg]),
     )
     mocker.patch("vllm_omni.engine.stage_init_utils.prepare_engine_environment")
     mocker.patch("vllm_omni.engine.stage_init_utils.load_omni_transfer_config_for_model", return_value=None)
@@ -405,8 +448,11 @@ def test_run_headless_diffusion_registers_and_spawns_proc(mocker: MockerFixture)
     proc.is_alive.return_value = False
 
     mocker.patch(
-        "vllm_omni.entrypoints.utils.load_and_resolve_stage_configs",
-        return_value=("/fake/stages.yaml", [stage_cfg], None),
+        "vllm_omni.entrypoints.utils.load_and_resolve_stage_config_views",
+        return_value=_resolved_stage_configs(
+            [stage_cfg],
+            omni_config=_make_typed_diffusion_config(stage_cfg.stage_id),
+        ),
     )
     mocker.patch("vllm_omni.engine.stage_init_utils.prepare_engine_environment")
     mocker.patch("vllm_omni.engine.stage_init_utils.load_omni_transfer_config_for_model", return_value=None)
@@ -414,12 +460,11 @@ def test_run_headless_diffusion_registers_and_spawns_proc(mocker: MockerFixture)
         "vllm_omni.distributed.omni_connectors.utils.initialization.resolve_omni_kv_config_for_stage",
         return_value=(None, None, None),
     )
-    mocker.patch(
-        "vllm_omni.engine.stage_init_utils.extract_legacy_stage_metadata",
-        return_value=SimpleNamespace(stage_id=1, stage_type="diffusion"),
-    )
     mock_inject = mocker.patch("vllm_omni.engine.stage_init_utils.inject_kv_stage_info")
-    mocker.patch("vllm_omni.engine.stage_init_utils.build_diffusion_config", return_value=od_config)
+    mock_build = mocker.patch(
+        "vllm_omni.engine.stage_init_utils.build_diffusion_config_from_omni_stage_config",
+        return_value=od_config,
+    )
     mock_register = mocker.patch(
         "vllm_omni.engine.stage_engine_startup.register_stage_with_omni_master",
         return_value=StageRegistrationResponse(
@@ -452,10 +497,9 @@ def test_run_headless_diffusion_registers_and_spawns_proc(mocker: MockerFixture)
 
     run_headless(_make_headless_args(stage_id=1))
 
-    mock_inject.assert_called_once()
-    assert mock_inject.call_args.args[0] is stage_cfg
-    assert mock_inject.call_args.args[1] == 1
-    assert mock_inject.call_args.args[2] == [stage_cfg]
+    mock_inject.assert_not_called()
+    mock_build.assert_called_once()
+    assert mock_build.call_args.args[1].stage_id == 1
 
     reg_kwargs = mock_register.call_args.kwargs
     assert reg_kwargs["omni_master_address"] == "127.0.0.1"
@@ -485,8 +529,11 @@ def test_run_headless_diffusion_raises_on_nonzero_proc_exit(mocker: MockerFixtur
     proc.is_alive.return_value = False
 
     mocker.patch(
-        "vllm_omni.entrypoints.utils.load_and_resolve_stage_configs",
-        return_value=("/fake/stages.yaml", [stage_cfg], None),
+        "vllm_omni.entrypoints.utils.load_and_resolve_stage_config_views",
+        return_value=_resolved_stage_configs(
+            [stage_cfg],
+            omni_config=_make_typed_diffusion_config(stage_cfg.stage_id),
+        ),
     )
     mocker.patch("vllm_omni.engine.stage_init_utils.prepare_engine_environment")
     mocker.patch("vllm_omni.engine.stage_init_utils.load_omni_transfer_config_for_model", return_value=None)
@@ -494,12 +541,11 @@ def test_run_headless_diffusion_raises_on_nonzero_proc_exit(mocker: MockerFixtur
         "vllm_omni.distributed.omni_connectors.utils.initialization.resolve_omni_kv_config_for_stage",
         return_value=(None, None, None),
     )
-    mocker.patch(
-        "vllm_omni.engine.stage_init_utils.extract_legacy_stage_metadata",
-        return_value=SimpleNamespace(stage_id=1, stage_type="diffusion"),
-    )
     mocker.patch("vllm_omni.engine.stage_init_utils.inject_kv_stage_info")
-    mocker.patch("vllm_omni.engine.stage_init_utils.build_diffusion_config", return_value=mocker.Mock())
+    mocker.patch(
+        "vllm_omni.engine.stage_init_utils.build_diffusion_config_from_omni_stage_config",
+        return_value=mocker.Mock(),
+    )
     mocker.patch(
         "vllm_omni.engine.stage_engine_startup.register_stage_with_omni_master",
         return_value=StageRegistrationResponse(

--- a/tests/entrypoints/test_utils.py
+++ b/tests/entrypoints/test_utils.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 """Unit tests for vllm_omni.entrypoints.utils module."""
 
 import os
@@ -11,22 +14,36 @@ import torch
 from pytest_mock import MockerFixture
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 
+from tests.helpers.stage_config import get_deploy_config_path
+from vllm_omni.config.omni_config import VllmOmniConfig, VllmOmniDiffusionStageConfig
+from vllm_omni.config.stage_config import (
+    DeployConfig,
+    PipelineConfig,
+    StageDeployConfig,
+    StageExecutionType,
+    StagePipelineConfig,
+    merge_pipeline_deploy,
+)
 from vllm_omni.config.yaml_util import create_config
 from vllm_omni.diffusion.data import OmniDiffusionConfig
 from vllm_omni.engine.arg_utils import OmniEngineArgs
 from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
 from vllm_omni.engine.stage_init_utils import (
+    build_diffusion_engine_args_from_omni_stage_config,
     get_stage_connector_spec,
     load_omni_transfer_config_for_model,
 )
 from vllm_omni.entrypoints.utils import (
+    ResolvedStageConfigs,
     _convert_dataclasses_to_dict,
     _filter_dict_like_object,
+    _filter_resolved_stage_views,
     _try_resolve_omni_model_type,
     coerce_param_message_types,
     filter_dataclass_kwargs,
     filter_stages,
     load_and_resolve_stage_configs,
+    load_stage_config_views_from_model,
     load_stage_configs_from_model,
     resolve_model_config_path,
 )
@@ -519,21 +536,115 @@ class TestLoadAndResolveStageConfigs:
         assert filtered[0].final_output is False
         assert filtered[0].final_output_type is None
 
+    def test_mode_filter_keeps_full_typed_topology_for_dit_kv_inference(self, tmp_path):
+        pipeline = PipelineConfig(
+            model_type="mode_filtered_typed_topology",
+            stages=(
+                StagePipelineConfig(
+                    stage_id=0,
+                    model_stage="ar",
+                    execution_type=StageExecutionType.LLM_AR,
+                ),
+                StagePipelineConfig(
+                    stage_id=1,
+                    model_stage="dit",
+                    execution_type=StageExecutionType.DIFFUSION,
+                    input_sources=(0,),
+                    final_output=True,
+                    final_output_type="image",
+                    model_arch="TestDiffusion",
+                    omni_kv_config={"need_recv_cache": True},
+                ),
+            ),
+        )
+        deploy = DeployConfig(
+            async_chunk=False,
+            stages=[
+                StageDeployConfig(stage_id=0, tensor_parallel_size=4),
+                StageDeployConfig(stage_id=1, tensor_parallel_size=2),
+            ],
+        )
+        omni_config = VllmOmniConfig.from_pipeline_config(
+            pipeline,
+            user_deploy_config=deploy,
+            cli_overrides={"model": "test-model"},
+        )
+        legacy_stages = [stage.to_omegaconf() for stage in merge_pipeline_deploy(pipeline, deploy)]
+        config_path = tmp_path / "mode.yaml"
+        config_path.write_text("modes:\n  - mode: dit-only\n    stages: [1]\n", encoding="utf-8")
+
+        filtered = _filter_resolved_stage_views(
+            ResolvedStageConfigs(
+                config_path=str(config_path),
+                omni_config=omni_config,
+                stage_configs=legacy_stages,
+                deploy_config=deploy,
+                omni_lb_policy=None,
+            ),
+            {"mode": "dit-only"},
+        )
+
+        assert [stage.stage_id for stage in filtered.stage_configs] == [1]
+        assert [stage.stage_id for stage in filtered.omni_config.stage_configs] == [1]
+        assert [stage.stage_id for stage in filtered.typed_topology()] == [0, 1]
+
+        dit_stage = filtered.typed_stage_by_id(1)
+        assert isinstance(dit_stage, VllmOmniDiffusionStageConfig)
+        engine_args = build_diffusion_engine_args_from_omni_stage_config(
+            dit_stage,
+            "test-model",
+            omni_kv_connector=({"name": "TestConnector"}, "0", "1"),
+            stage_configs=filtered.typed_topology(),
+        )
+        assert engine_args["omni_kv_config"]["rank_mapping"] == {
+            "from_tp": 4,
+            "to_tp": 2,
+        }
+
 
 class TestLoadStageConfigsFromModel:
-    def test_unresolved_model_does_not_fall_back_to_yaml(self, mocker: MockerFixture, caplog):
+    def test_unresolved_model_does_not_fall_back_to_yaml(self, mocker: MockerFixture):
         mocker.patch(
             "vllm_omni.entrypoints.utils.StageConfigFactory.create_legacy_stage_configs_from_model",
             return_value=(None, None),
         )
         resolve_path = mocker.patch("vllm_omni.entrypoints.utils.resolve_model_config_path")
+        warning = mocker.patch("vllm_omni.entrypoints.utils.logger.warning")
 
         result = load_stage_configs_from_model("unregistered-model", trust_remote_code=False)
 
         assert result == ([], None)
         resolve_path.assert_not_called()
-        assert "No registered PipelineConfig resolved" in caplog.text
-        assert "deploy_config" in caplog.text
+        warning.assert_called_once()
+        assert "No registered PipelineConfig resolved" in warning.call_args.args[0]
+        assert "deploy_config" in warning.call_args.args[0]
+
+    def test_revision_reaches_legacy_and_typed_diffusion_views(self, mocker: MockerFixture):
+        """The shared resolver must keep Hub revision aligned across consumers."""
+
+        class FakeConfig:
+            model_type = "wan2_2_ti2v"
+
+        get_config = mocker.patch(
+            "vllm_omni.config.config_factory.get_config",
+            return_value=FakeConfig(),
+        )
+        # Use a unique model id so this test cannot observe another test's
+        # cached discovery result.
+        model = "org/wan2-2-revision-views"
+        revision = "refs/pr/6701"
+        resolved = load_stage_config_views_from_model(
+            model,
+            trust_remote_code=False,
+            base_engine_args={"revision": revision},
+            deploy_config_path=get_deploy_config_path("wan2_2_ti2v.yaml"),
+        )
+
+        assert get_config.call_args.kwargs["revision"] == revision
+        legacy_stage = resolved.legacy_stage_by_id(0)
+        typed_stage = resolved.typed_stage_by_id(0)
+        assert legacy_stage.engine_args.revision == revision
+        assert typed_stage.diffusion_config.revision == revision
 
 
 class TestCumulativeStreamingCoercion:

--- a/vllm_omni/config/config_factory.py
+++ b/vllm_omni/config/config_factory.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import copy
 import dataclasses
 import functools
 from collections.abc import Mapping
@@ -26,6 +27,7 @@ from vllm_omni.config.stage_config import (
     PipelineConfig,
     StageConfig,
     StageType,
+    _apply_platform_overrides,
     build_stage_runtime_overrides,
     load_deploy_config,
     merge_pipeline_deploy,
@@ -46,6 +48,28 @@ logger = init_logger(__name__)
 # defaults can't drift apart. This is the light slice; the full device-layout
 # centralization is tracked as a follow-up.
 _DEFAULT_PARALLEL_DEGREE = 1
+
+
+def _optional_revision_kwargs(revision: str | None) -> dict[str, str]:
+    """Return a revision keyword only when the caller explicitly pinned one.
+
+    A few downstream integrations still monkeypatch the discovery helpers with
+    their historical two-argument signatures.  Keeping the no-revision call
+    shape unchanged preserves that compatibility while a pinned revision is
+    propagated end to end.
+    """
+    return {"revision": revision} if revision is not None else {}
+
+
+@dataclasses.dataclass(frozen=True)
+class StageConfigResolution:
+    """Aligned structured and compatibility views of one pipeline resolution."""
+
+    omni_config: VllmOmniConfig | None
+    legacy_stage_configs: list[StageConfig] | None
+    deploy_config: DeployConfig | None
+    deploy_config_path: str | None
+    omni_lb_policy: str | None
 
 
 @functools.cache
@@ -121,6 +145,7 @@ class StageConfigFactory:
         model: str,
         trust_remote_code: bool,
         deploy_config_path: str | None,
+        revision: str | None = None,
     ) -> tuple[EndpointRestriction, ...]:
         """Given a model string, determine the corresponding endpoint restrictions.
 
@@ -136,12 +161,18 @@ class StageConfigFactory:
             model=model,
             trust_remote_code=trust_remote_code,
             deploy_config_path=deploy_config_path,
+            **_optional_revision_kwargs(revision),
         )
         return pipeline_cfg.endpoint_restrictions if pipeline_cfg else ()
 
     @classmethod
     @functools.cache
-    def get_hf_config(cls, model: str, trust_remote_code: bool) -> PretrainedConfig | None:
+    def get_hf_config(
+        cls,
+        model: str,
+        trust_remote_code: bool,
+        revision: str | None = None,
+    ) -> PretrainedConfig | None:
         """Fetch the HF config (if it exists) from the model directory.
 
         Args:
@@ -153,14 +184,21 @@ class StageConfigFactory:
         """
         hf_config = None
         try:
-            return get_config(_materialize_object_storage_configs(model), trust_remote_code=trust_remote_code)
+            config_kwargs = {"trust_remote_code": trust_remote_code}
+            config_kwargs.update(_optional_revision_kwargs(revision))
+            return get_config(_materialize_object_storage_configs(model), **config_kwargs)
         except Exception as e:
             logger.debug(f"`get_config` failed with exception {e}; inferred HF config is None")
         return hf_config
 
     @classmethod
     @functools.cache
-    def try_infer_model_type(cls, model: str, trust_remote_code: bool) -> str | None:
+    def try_infer_model_type(
+        cls,
+        model: str,
+        trust_remote_code: bool,
+        revision: str | None = None,
+    ) -> str | None:
         """Auto-detect model_type from model directory and apply any model
         specific patches to get the correct model_type str. If we are unable
         to infer it from the model directory, we fall back to the PipelineConfig.
@@ -175,14 +213,24 @@ class StageConfigFactory:
         model_type = cls._try_infer_model_type(
             model=model,
             trust_remote_code=trust_remote_code,
+            **_optional_revision_kwargs(revision),
         )
         if model_type == "vla":
-            if _looks_like_dreamzero(model):
+            if revision is None:
+                looks_like_dreamzero = _looks_like_dreamzero(model)
+            else:
+                looks_like_dreamzero = _looks_like_dreamzero(model, revision=revision)
+            if looks_like_dreamzero:
                 model_type = "dreamzero"
         return model_type
 
     @classmethod
-    def _try_infer_model_type(cls, model: str, trust_remote_code: bool) -> str | None:
+    def _try_infer_model_type(
+        cls,
+        model: str,
+        trust_remote_code: bool,
+        revision: str | None = None,
+    ) -> str | None:
         """Auto-detect model_type from model directory.
 
         Args:
@@ -195,6 +243,7 @@ class StageConfigFactory:
         hf_config = cls.get_hf_config(
             model=model,
             trust_remote_code=trust_remote_code,
+            **_optional_revision_kwargs(revision),
         )
         if hf_config is not None:
             return hf_config.model_type
@@ -204,7 +253,7 @@ class StageConfigFactory:
         # Fallback: read config.json directly for custom model types that
         # are not registered with transformers (e.g. qwen3_tts).
         try:
-            config_dict = get_hf_file_to_dict("config.json", config_source, revision=None)
+            config_dict = get_hf_file_to_dict("config.json", config_source, revision=revision)
             if config_dict:
                 if "model_type" in config_dict:
                     return config_dict["model_type"]
@@ -221,7 +270,7 @@ class StageConfigFactory:
         # model_index.json with _class_name that maps to a pipeline key via
         # PipelineConfig.diffusers_class_name.
         try:
-            model_index = get_hf_file_to_dict("model_index.json", config_source, revision=None)
+            model_index = get_hf_file_to_dict("model_index.json", config_source, revision=revision)
             if model_index and "_class_name" in model_index:
                 class_name = model_index["_class_name"]
                 for obj in OMNI_PIPELINES.values():
@@ -267,10 +316,19 @@ class StageConfigFactory:
         trust_remote_code: bool,
         deploy_config_path: str | None = None,
         user_deploy_config: DeployConfig | None = None,
+        revision: str | None = None,
     ) -> PipelineConfig | None:
         """Resolve the PipelineConfig for a model path/name."""
-        model_type = cls.try_infer_model_type(model=model, trust_remote_code=trust_remote_code)
-        hf_config = cls.get_hf_config(model=model, trust_remote_code=trust_remote_code)
+        model_type = cls.try_infer_model_type(
+            model=model,
+            trust_remote_code=trust_remote_code,
+            **_optional_revision_kwargs(revision),
+        )
+        hf_config = cls.get_hf_config(
+            model=model,
+            trust_remote_code=trust_remote_code,
+            **_optional_revision_kwargs(revision),
+        )
 
         # Resolve the deploy config & check if the user set the pipeline;
         # If the pipeline is explicitly set, it takes highest priority
@@ -338,18 +396,242 @@ class StageConfigFactory:
         return pipeline_cfg
 
     @staticmethod
-    def _load_user_deploy_config(deploy_config_path: str | None) -> DeployConfig | None:
+    def _resolve_user_deploy_path(deploy_config_path: str) -> Path:
+        """Resolve an explicit deploy path using the legacy lookup rules."""
+        deploy_path = Path(deploy_config_path)
+        if not deploy_path.exists() and deploy_path.parent == Path("."):
+            bare_name = deploy_path.name
+            if not bare_name.endswith(".yaml"):
+                bare_name = f"{bare_name}.yaml"
+            candidate = _DEPLOY_DIR / bare_name
+            if candidate.exists():
+                deploy_path = candidate
+        return deploy_path
+
+    @classmethod
+    def _load_user_deploy_config(cls, deploy_config_path: str | None) -> DeployConfig | None:
         """Load an explicit deploy YAML once for resolution and construction."""
         if deploy_config_path is None:
             return None
-        deploy_path = Path(deploy_config_path)
-        if not deploy_path.exists() and deploy_path.parent == Path("."):
-            candidate = _DEPLOY_DIR / deploy_path
-            if candidate.exists():
-                deploy_path = candidate
+        deploy_path = cls._resolve_user_deploy_path(deploy_config_path)
         if not deploy_path.exists():
             raise FileNotFoundError(f"Deploy config not found: {deploy_path}")
         return load_deploy_config(deploy_path)
+
+    @classmethod
+    def _select_deploy_config(
+        cls,
+        pipeline_cfg: PipelineConfig,
+        deploy_config_path: str | None,
+        user_deploy_config: DeployConfig | None,
+    ) -> tuple[DeployConfig, str | None]:
+        """Select and load the deploy input once for both config views."""
+        if user_deploy_config is not None:
+            resolved_path = (
+                str(cls._resolve_user_deploy_path(deploy_config_path)) if deploy_config_path is not None else None
+            )
+            return copy.deepcopy(user_deploy_config), resolved_path
+        if deploy_config_path is not None:
+            deploy_path = cls._resolve_user_deploy_path(deploy_config_path)
+            if not deploy_path.exists():
+                raise FileNotFoundError(f"Deploy config not found: {deploy_path}")
+            return load_deploy_config(deploy_path), str(deploy_path)
+        if pipeline_cfg.default_deploy_config_name is not None:
+            deploy_path = _DEPLOY_DIR / pipeline_cfg.default_deploy_config_name
+            return load_deploy_config(deploy_path), str(deploy_path)
+        return DeployConfig(), None
+
+    @staticmethod
+    def _prepare_registry_inputs(
+        pipeline_cfg: PipelineConfig,
+        deploy_cfg: DeployConfig,
+        cli_overrides: dict[str, Any],
+    ) -> tuple[PipelineConfig, DeployConfig]:
+        """Apply topology/deploy transforms shared by both resolved views."""
+        # Normalize aliases (for example ``--num-gpus`` and diffusion-specific
+        # spellings) once before constructing either compatibility view.  This
+        # keeps the typed consumer and the legacy wire payload on the same
+        # effective override set.
+        normalized_cli_overrides = normalize_pipeline_cli_overrides(pipeline_cfg, cli_overrides)
+        # Replace the input mapping rather than updating it in place.  Alias
+        # normalization intentionally removes source spellings (for example
+        # ``diffusion_streaming_output``); retaining them would route a
+        # diffusion-only value to every AR/generation stage in a mixed
+        # pipeline before the typed owner check runs.
+        cli_overrides.clear()
+        cli_overrides.update(normalized_cli_overrides)
+        deploy_cfg = copy.deepcopy(deploy_cfg)
+        # Apply platform overlays once before either representation is built;
+        # otherwise the legacy merge and typed projection can observe
+        # different devices/env/engine extras on platform-specific deploys.
+        deploy_cfg = _apply_platform_overrides(deploy_cfg)
+        cli_async_chunk = cli_overrides.get("async_chunk")
+        if cli_async_chunk is not None:
+            deploy_cfg.async_chunk = bool(cli_async_chunk)
+
+        from vllm_omni.utils.forced_aligner import inject_forced_aligner_stage
+
+        return inject_forced_aligner_stage(pipeline_cfg, deploy_cfg, cli_overrides)
+
+    @staticmethod
+    def _deploy_for_materialized_builder(deploy_cfg: DeployConfig) -> DeployConfig:
+        """Copy an effective deploy without re-applying its platform block."""
+        builder_deploy = copy.deepcopy(deploy_cfg)
+        # ``merge_pipeline_deploy`` and ``VllmOmniConfig.from_pipeline_config``
+        # retain their historical overlay call for standalone callers. The
+        # shared resolver already applied it, so hide only the declarative
+        # block while preserving it on StageConfigResolution.deploy_config.
+        builder_deploy.platforms = None
+        return builder_deploy
+
+    @staticmethod
+    def _typed_strategy_overrides(
+        cli_overrides: dict[str, Any],
+        applied: Any,
+    ) -> dict[str, Any]:
+        """Translate strategy-owned values into typed per-stage inputs.
+
+        Strategy values fill only axes that the CLI did not set. This preserves
+        the legacy order: deploy, then strategy, then global/per-stage CLI.
+        """
+        overrides = dict(cli_overrides)
+        if applied is None:
+            return overrides
+
+        axis_fields = {
+            "tp": ("tensor_parallel_size", "tensor_parallel_size"),
+            "dp": ("data_parallel_size", "data_parallel_size"),
+            "pp": ("pipeline_parallel_size", "pipeline_parallel_size"),
+        }
+        for stage_id, strategy_cfg in applied.per_stage_config.items():
+            declared = set(strategy_cfg.l1_owners)
+            for kind, (field_name, attr_name) in axis_fields.items():
+                if kind not in declared:
+                    continue
+                stage_key = f"stage_{stage_id}_{field_name}"
+                if overrides.get(stage_key) is None and overrides.get(field_name) is None:
+                    overrides[stage_key] = getattr(strategy_cfg, attr_name)
+
+            if "ep" in declared:
+                stage_key = f"stage_{stage_id}_enable_expert_parallel"
+                if overrides.get(stage_key) is None and overrides.get("enable_expert_parallel") is None:
+                    overrides[stage_key] = strategy_cfg.enable_expert_parallel
+
+            if "stage_replica" in declared:
+                stage_key = f"stage_{stage_id}_num_replicas"
+                if overrides.get(stage_key) is None and overrides.get("num_replicas") is None:
+                    overrides[stage_key] = strategy_cfg.stage_replica_size
+        return overrides
+
+    @staticmethod
+    def _validate_config_view_alignment(
+        omni_config: VllmOmniConfig,
+        legacy_stage_configs: list[StageConfig],
+    ) -> None:
+        typed_stages = omni_config.stage_configs
+        if len(typed_stages) != len(legacy_stage_configs):
+            raise ValueError(
+                "Structured and legacy stage views have different lengths: "
+                f"{len(typed_stages)} != {len(legacy_stage_configs)}"
+            )
+        for typed_stage, legacy_stage in zip(typed_stages, legacy_stage_configs):
+            typed_identity = (
+                typed_stage.stage_id,
+                StageType(typed_stage.stage_type),
+                typed_stage.model_stage,
+            )
+            legacy_identity = (
+                legacy_stage.stage_id,
+                StageType(legacy_stage.stage_type),
+                legacy_stage.model_stage,
+            )
+            if typed_identity != legacy_identity:
+                raise ValueError(
+                    "Structured and legacy stage views are not aligned: "
+                    f"typed={typed_identity!r}, legacy={legacy_identity!r}"
+                )
+
+            typed_runtime = typed_stage.runtime_config
+            # ``legacy_stage_configs`` are the dataclass compatibility view at
+            # this point (conversion to OmegaConf happens in entrypoints).
+            # Materialize once here so the alignment check observes the same
+            # runtime projection that downstream consumers receive.
+            legacy_runtime = legacy_stage.to_omegaconf().runtime
+            typed_layout = (
+                typed_runtime.num_replicas,
+                typed_runtime.devices,
+                typed_runtime.env,
+            )
+            legacy_layout = (
+                int(legacy_runtime.get("num_replicas", 1)),
+                legacy_runtime.get("devices"),
+                legacy_runtime.get("env"),
+            )
+            if typed_layout != legacy_layout:
+                raise ValueError(
+                    "Structured and legacy stage runtime layouts are not aligned: "
+                    f"stage={typed_stage.stage_id}, typed={typed_layout!r}, "
+                    f"legacy={legacy_layout!r}"
+                )
+
+    @classmethod
+    def create_config_views_from_model(
+        cls,
+        model: str,
+        *,
+        trust_remote_code: bool | None,
+        cli_overrides: dict[str, Any],
+        deploy_config_path: str | None,
+        strategy_specs: Mapping[Any, Any] | None = None,
+    ) -> StageConfigResolution:
+        """Resolve one model into aligned typed and legacy stage views."""
+        cli_overrides = with_trust_remote_code_override(
+            cli_overrides,
+            trust_remote_code,
+        )
+        user_deploy_config = cls._load_user_deploy_config(deploy_config_path)
+        pipeline_cfg = cls.get_pipeline_config(
+            model=model,
+            trust_remote_code=bool(trust_remote_code),
+            deploy_config_path=deploy_config_path,
+            user_deploy_config=user_deploy_config,
+            **_optional_revision_kwargs(cli_overrides.get("revision")),
+        )
+        if pipeline_cfg is None:
+            return StageConfigResolution(None, None, None, deploy_config_path, None)
+
+        deploy_cfg, resolved_deploy_path = cls._select_deploy_config(
+            pipeline_cfg,
+            deploy_config_path,
+            user_deploy_config,
+        )
+        prepared_pipeline, prepared_deploy = cls._prepare_registry_inputs(
+            pipeline_cfg,
+            deploy_cfg,
+            cli_overrides,
+        )
+        legacy_stages, applied = cls._create_legacy_from_prepared_registry(
+            prepared_pipeline,
+            prepared_deploy,
+            cli_overrides,
+            strategy_specs,
+        )
+        typed_overrides = cls._typed_strategy_overrides(cli_overrides, applied)
+        typed_overrides["model"] = model
+        omni_config = VllmOmniConfig.from_pipeline_config(
+            prepared_pipeline,
+            user_deploy_config=cls._deploy_for_materialized_builder(prepared_deploy),
+            deploy_config_path=resolved_deploy_path,
+            cli_overrides=typed_overrides,
+        )
+        cls._validate_config_view_alignment(omni_config, legacy_stages)
+        return StageConfigResolution(
+            omni_config=omni_config,
+            legacy_stage_configs=legacy_stages,
+            deploy_config=prepared_deploy,
+            deploy_config_path=resolved_deploy_path,
+            omni_lb_policy=applied.omni_lb_policy if applied is not None else None,
+        )
 
     @classmethod
     def create_from_model(
@@ -369,6 +651,7 @@ class StageConfigFactory:
             trust_remote_code=bool(trust_remote_code),
             deploy_config_path=deploy_config_path,
             user_deploy_config=user_deploy_config,
+            **_optional_revision_kwargs(cli_overrides.get("revision")),
         )
         if pipeline_cfg is None:
             return None
@@ -407,6 +690,7 @@ class StageConfigFactory:
             trust_remote_code=bool(trust_remote_code),
             deploy_config_path=deploy_config_path,
             user_deploy_config=user_deploy_config,
+            **_optional_revision_kwargs(cli_overrides.get("revision")),
         )
         if pipeline_cfg is None:
             return None, None
@@ -438,30 +722,39 @@ class StageConfigFactory:
         load-balancer policy (``None`` when no strategy set one) travels with the
         stages instead of through a mutable out-param.
         """
-        cli_overrides = normalize_pipeline_cli_overrides(pipeline_cfg, cli_overrides)
-        deploy_cfg: DeployConfig | None
-        if user_deploy_config is not None:
-            deploy_cfg = user_deploy_config
-        elif deploy_config_path is not None:
-            deploy_cfg = cls._load_user_deploy_config(deploy_config_path)
-            assert deploy_cfg is not None
-        elif pipeline_cfg.default_deploy_config_name is not None:
-            deploy_cfg = load_deploy_config(_DEPLOY_DIR / pipeline_cfg.default_deploy_config_name)
-            assert deploy_cfg is not None
-        else:
-            deploy_cfg = DeployConfig()
+        deploy_cfg, _ = cls._select_deploy_config(
+            pipeline_cfg,
+            deploy_config_path,
+            user_deploy_config,
+        )
+        pipeline_cfg, deploy_cfg = cls._prepare_registry_inputs(
+            pipeline_cfg,
+            deploy_cfg,
+            cli_overrides,
+        )
+        stages, applied = cls._create_legacy_from_prepared_registry(
+            pipeline_cfg,
+            deploy_cfg,
+            cli_overrides,
+            strategy_specs,
+        )
+        omni_lb_policy = applied.omni_lb_policy if applied is not None else None
+        return stages, omni_lb_policy
 
-        assert deploy_cfg is not None
-
-        cli_async_chunk = cli_overrides.get("async_chunk")
-        if cli_async_chunk is not None:
-            deploy_cfg.async_chunk = bool(cli_async_chunk)
-
-        from vllm_omni.utils.forced_aligner import inject_forced_aligner_stage
-
-        pipeline_cfg, deploy_cfg = inject_forced_aligner_stage(pipeline_cfg, deploy_cfg, cli_overrides)
-
-        stages = merge_pipeline_deploy(pipeline_cfg, deploy_cfg, cli_overrides)
+    @classmethod
+    def _create_legacy_from_prepared_registry(
+        cls,
+        pipeline_cfg: PipelineConfig,
+        deploy_cfg: DeployConfig,
+        cli_overrides: dict[str, Any],
+        strategy_specs: Mapping[Any, Any] | None,
+    ) -> tuple[list[StageConfig], Any]:
+        """Build the legacy view from already selected/transformed inputs."""
+        stages = merge_pipeline_deploy(
+            pipeline_cfg,
+            cls._deploy_for_materialized_builder(deploy_cfg),
+            cli_overrides,
+        )
 
         # Overlay declarative parallel strategies (opt-in) before CLI overrides.
         applied = cls._apply_strategy_specs(stages, strategy_specs)
@@ -470,12 +763,36 @@ class StageConfigFactory:
 
         for stage in stages:
             stage.runtime_overrides = cls._merge_cli_overrides(stage, explicit_overrides)
+            if StageType(stage.stage_type) != StageType.DIFFUSION:
+                continue
+
+            # These diffusion-only CLI values were historically finalized by
+            # AsyncOmniEngine after the legacy factory returned. Resolve them
+            # here so the compatibility and typed views see the same input.
+            stage_num_gpus = explicit_overrides.get(f"stage_{stage.stage_id}_num_gpus")
+            global_num_gpus = explicit_overrides.get("num_gpus")
+            if stage_num_gpus is not None or global_num_gpus is not None:
+                stage.runtime_overrides["num_gpus"] = stage_num_gpus if stage_num_gpus is not None else global_num_gpus
+
+            yaml_diffusion_quantization = stage.yaml_engine_args.pop(
+                "diffusion_quantization_config",
+                None,
+            )
+            if yaml_diffusion_quantization is not None and stage.yaml_engine_args.get("quantization_config") is None:
+                stage.yaml_engine_args["quantization_config"] = yaml_diffusion_quantization
+
+            cli_diffusion_quantization = explicit_overrides.get(
+                f"stage_{stage.stage_id}_diffusion_quantization_config",
+                explicit_overrides.get("diffusion_quantization_config"),
+            )
+            if cli_diffusion_quantization is not None and stage.runtime_overrides.get("quantization_config") is None:
+                stage.runtime_overrides["quantization_config"] = cli_diffusion_quantization
+            stage.runtime_overrides.pop("diffusion_quantization_config", None)
 
         # Re-validate the resolved layout now that CLI overrides are on top.
         cls._reconcile_strategy_with_cli(stages, applied)
 
-        omni_lb_policy = applied.omni_lb_policy if applied is not None else None
-        return stages, omni_lb_policy
+        return stages, applied
 
     @staticmethod
     def _apply_strategy_specs(

--- a/vllm_omni/config/config_factory.py
+++ b/vllm_omni/config/config_factory.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import copy
 import dataclasses
 import functools
 from collections.abc import Mapping
@@ -26,6 +27,7 @@ from vllm_omni.config.stage_config import (
     PipelineConfig,
     StageConfig,
     StageType,
+    _apply_platform_overrides,
     build_stage_runtime_overrides,
     load_deploy_config,
     merge_pipeline_deploy,
@@ -44,6 +46,17 @@ logger = init_logger(__name__)
 # defaults can't drift apart. This is the light slice; the full device-layout
 # centralization is tracked as a follow-up.
 _DEFAULT_PARALLEL_DEGREE = 1
+
+
+@dataclasses.dataclass(frozen=True)
+class StageConfigResolution:
+    """Aligned structured and compatibility views of one pipeline resolution."""
+
+    omni_config: VllmOmniConfig | None
+    legacy_stage_configs: list[StageConfig] | None
+    deploy_config: DeployConfig | None
+    deploy_config_path: str | None
+    omni_lb_policy: str | None
 
 
 @functools.cache
@@ -333,18 +346,226 @@ class StageConfigFactory:
         return pipeline_cfg
 
     @staticmethod
-    def _load_user_deploy_config(deploy_config_path: str | None) -> DeployConfig | None:
-        """Load an explicit deploy YAML once for resolution and construction."""
-        if deploy_config_path is None:
-            return None
+    def _resolve_user_deploy_path(deploy_config_path: str) -> Path:
+        """Resolve an explicit deploy path using the legacy lookup rules."""
         deploy_path = Path(deploy_config_path)
         if not deploy_path.exists() and deploy_path.parent == Path("."):
             candidate = _DEPLOY_DIR / deploy_path
             if candidate.exists():
                 deploy_path = candidate
+        return deploy_path
+
+    @classmethod
+    def _load_user_deploy_config(cls, deploy_config_path: str | None) -> DeployConfig | None:
+        """Load an explicit deploy YAML once for resolution and construction."""
+        if deploy_config_path is None:
+            return None
+        deploy_path = cls._resolve_user_deploy_path(deploy_config_path)
         if not deploy_path.exists():
             raise FileNotFoundError(f"Deploy config not found: {deploy_path}")
         return load_deploy_config(deploy_path)
+
+    @classmethod
+    def _select_deploy_config(
+        cls,
+        pipeline_cfg: PipelineConfig,
+        deploy_config_path: str | None,
+        user_deploy_config: DeployConfig | None,
+    ) -> tuple[DeployConfig, str | None]:
+        """Select and load the deploy input once for both config views."""
+        if user_deploy_config is not None:
+            resolved_path = (
+                str(cls._resolve_user_deploy_path(deploy_config_path)) if deploy_config_path is not None else None
+            )
+            return copy.deepcopy(user_deploy_config), resolved_path
+        if deploy_config_path is not None:
+            deploy_path = cls._resolve_user_deploy_path(deploy_config_path)
+            if not deploy_path.exists():
+                raise FileNotFoundError(f"Deploy config not found: {deploy_path}")
+            return load_deploy_config(deploy_path), str(deploy_path)
+        if pipeline_cfg.default_deploy_config_name is not None:
+            deploy_path = _DEPLOY_DIR / pipeline_cfg.default_deploy_config_name
+            return load_deploy_config(deploy_path), str(deploy_path)
+        return DeployConfig(), None
+
+    @staticmethod
+    def _prepare_registry_inputs(
+        pipeline_cfg: PipelineConfig,
+        deploy_cfg: DeployConfig,
+        cli_overrides: dict[str, Any],
+    ) -> tuple[PipelineConfig, DeployConfig]:
+        """Apply topology/deploy transforms shared by both resolved views."""
+        deploy_cfg = copy.deepcopy(deploy_cfg)
+        # Apply platform overlays once before either representation is built;
+        # otherwise the legacy merge and typed projection can observe
+        # different devices/env/engine extras on platform-specific deploys.
+        deploy_cfg = _apply_platform_overrides(deploy_cfg)
+        cli_async_chunk = cli_overrides.get("async_chunk")
+        if cli_async_chunk is not None:
+            deploy_cfg.async_chunk = bool(cli_async_chunk)
+
+        from vllm_omni.utils.forced_aligner import inject_forced_aligner_stage
+
+        return inject_forced_aligner_stage(pipeline_cfg, deploy_cfg, cli_overrides)
+
+    @staticmethod
+    def _deploy_for_materialized_builder(deploy_cfg: DeployConfig) -> DeployConfig:
+        """Copy an effective deploy without re-applying its platform block."""
+        builder_deploy = copy.deepcopy(deploy_cfg)
+        # ``merge_pipeline_deploy`` and ``VllmOmniConfig.from_pipeline_config``
+        # retain their historical overlay call for standalone callers. The
+        # shared resolver already applied it, so hide only the declarative
+        # block while preserving it on StageConfigResolution.deploy_config.
+        builder_deploy.platforms = None
+        return builder_deploy
+
+    @staticmethod
+    def _typed_strategy_overrides(
+        cli_overrides: dict[str, Any],
+        applied: Any,
+    ) -> dict[str, Any]:
+        """Translate strategy-owned values into typed per-stage inputs.
+
+        Strategy values fill only axes that the CLI did not set. This preserves
+        the legacy order: deploy, then strategy, then global/per-stage CLI.
+        """
+        overrides = dict(cli_overrides)
+        if applied is None:
+            return overrides
+
+        axis_fields = {
+            "tp": ("tensor_parallel_size", "tensor_parallel_size"),
+            "dp": ("data_parallel_size", "data_parallel_size"),
+            "pp": ("pipeline_parallel_size", "pipeline_parallel_size"),
+        }
+        for stage_id, strategy_cfg in applied.per_stage_config.items():
+            declared = set(strategy_cfg.l1_owners)
+            for kind, (field_name, attr_name) in axis_fields.items():
+                if kind not in declared:
+                    continue
+                stage_key = f"stage_{stage_id}_{field_name}"
+                if overrides.get(stage_key) is None and overrides.get(field_name) is None:
+                    overrides[stage_key] = getattr(strategy_cfg, attr_name)
+
+            if "ep" in declared:
+                stage_key = f"stage_{stage_id}_enable_expert_parallel"
+                if overrides.get(stage_key) is None and overrides.get("enable_expert_parallel") is None:
+                    overrides[stage_key] = strategy_cfg.enable_expert_parallel
+
+            if "stage_replica" in declared:
+                stage_key = f"stage_{stage_id}_num_replicas"
+                if overrides.get(stage_key) is None and overrides.get("num_replicas") is None:
+                    overrides[stage_key] = strategy_cfg.stage_replica_size
+        return overrides
+
+    @staticmethod
+    def _validate_config_view_alignment(
+        omni_config: VllmOmniConfig,
+        legacy_stage_configs: list[StageConfig],
+    ) -> None:
+        typed_stages = omni_config.stage_configs
+        if len(typed_stages) != len(legacy_stage_configs):
+            raise ValueError(
+                "Structured and legacy stage views have different lengths: "
+                f"{len(typed_stages)} != {len(legacy_stage_configs)}"
+            )
+        for typed_stage, legacy_stage in zip(typed_stages, legacy_stage_configs):
+            typed_identity = (
+                typed_stage.stage_id,
+                StageType(typed_stage.stage_type),
+                typed_stage.model_stage,
+            )
+            legacy_identity = (
+                legacy_stage.stage_id,
+                StageType(legacy_stage.stage_type),
+                legacy_stage.model_stage,
+            )
+            if typed_identity != legacy_identity:
+                raise ValueError(
+                    "Structured and legacy stage views are not aligned: "
+                    f"typed={typed_identity!r}, legacy={legacy_identity!r}"
+                )
+
+            typed_runtime = typed_stage.runtime_config
+            # ``legacy_stage_configs`` are the dataclass compatibility view at
+            # this point (conversion to OmegaConf happens in entrypoints).
+            # Materialize once here so the alignment check observes the same
+            # runtime projection that downstream consumers receive.
+            legacy_runtime = legacy_stage.to_omegaconf().runtime
+            typed_layout = (
+                typed_runtime.num_replicas,
+                typed_runtime.devices,
+                typed_runtime.env,
+            )
+            legacy_layout = (
+                int(legacy_runtime.get("num_replicas", 1)),
+                legacy_runtime.get("devices"),
+                legacy_runtime.get("env"),
+            )
+            if typed_layout != legacy_layout:
+                raise ValueError(
+                    "Structured and legacy stage runtime layouts are not aligned: "
+                    f"stage={typed_stage.stage_id}, typed={typed_layout!r}, "
+                    f"legacy={legacy_layout!r}"
+                )
+
+    @classmethod
+    def create_config_views_from_model(
+        cls,
+        model: str,
+        *,
+        trust_remote_code: bool | None,
+        cli_overrides: dict[str, Any],
+        deploy_config_path: str | None,
+        strategy_specs: Mapping[Any, Any] | None = None,
+    ) -> StageConfigResolution:
+        """Resolve one model into aligned typed and legacy stage views."""
+        cli_overrides = with_trust_remote_code_override(
+            cli_overrides,
+            trust_remote_code,
+        )
+        user_deploy_config = cls._load_user_deploy_config(deploy_config_path)
+        pipeline_cfg = cls.get_pipeline_config(
+            model=model,
+            trust_remote_code=bool(trust_remote_code),
+            deploy_config_path=deploy_config_path,
+            user_deploy_config=user_deploy_config,
+        )
+        if pipeline_cfg is None:
+            return StageConfigResolution(None, None, None, deploy_config_path, None)
+
+        deploy_cfg, resolved_deploy_path = cls._select_deploy_config(
+            pipeline_cfg,
+            deploy_config_path,
+            user_deploy_config,
+        )
+        prepared_pipeline, prepared_deploy = cls._prepare_registry_inputs(
+            pipeline_cfg,
+            deploy_cfg,
+            cli_overrides,
+        )
+        legacy_stages, applied = cls._create_legacy_from_prepared_registry(
+            prepared_pipeline,
+            prepared_deploy,
+            cli_overrides,
+            strategy_specs,
+        )
+        typed_overrides = cls._typed_strategy_overrides(cli_overrides, applied)
+        typed_overrides["model"] = model
+        omni_config = VllmOmniConfig.from_pipeline_config(
+            prepared_pipeline,
+            user_deploy_config=cls._deploy_for_materialized_builder(prepared_deploy),
+            deploy_config_path=resolved_deploy_path,
+            cli_overrides=typed_overrides,
+        )
+        cls._validate_config_view_alignment(omni_config, legacy_stages)
+        return StageConfigResolution(
+            omni_config=omni_config,
+            legacy_stage_configs=legacy_stages,
+            deploy_config=prepared_deploy,
+            deploy_config_path=resolved_deploy_path,
+            omni_lb_policy=applied.omni_lb_policy if applied is not None else None,
+        )
 
     @classmethod
     def create_from_model(
@@ -433,25 +654,39 @@ class StageConfigFactory:
         load-balancer policy (``None`` when no strategy set one) travels with the
         stages instead of through a mutable out-param.
         """
-        if user_deploy_config is not None:
-            deploy_cfg = user_deploy_config
-        elif deploy_config_path is not None:
-            deploy_cfg = cls._load_user_deploy_config(deploy_config_path)
-            assert deploy_cfg is not None
-        elif pipeline_cfg.default_deploy_config_name is not None:
-            deploy_cfg = load_deploy_config(_DEPLOY_DIR / pipeline_cfg.default_deploy_config_name)
-        else:
-            deploy_cfg = DeployConfig()
+        deploy_cfg, _ = cls._select_deploy_config(
+            pipeline_cfg,
+            deploy_config_path,
+            user_deploy_config,
+        )
+        pipeline_cfg, deploy_cfg = cls._prepare_registry_inputs(
+            pipeline_cfg,
+            deploy_cfg,
+            cli_overrides,
+        )
+        stages, applied = cls._create_legacy_from_prepared_registry(
+            pipeline_cfg,
+            deploy_cfg,
+            cli_overrides,
+            strategy_specs,
+        )
+        omni_lb_policy = applied.omni_lb_policy if applied is not None else None
+        return stages, omni_lb_policy
 
-        cli_async_chunk = cli_overrides.get("async_chunk")
-        if cli_async_chunk is not None:
-            deploy_cfg.async_chunk = bool(cli_async_chunk)
-
-        from vllm_omni.utils.forced_aligner import inject_forced_aligner_stage
-
-        pipeline_cfg, deploy_cfg = inject_forced_aligner_stage(pipeline_cfg, deploy_cfg, cli_overrides)
-
-        stages = merge_pipeline_deploy(pipeline_cfg, deploy_cfg, cli_overrides)
+    @classmethod
+    def _create_legacy_from_prepared_registry(
+        cls,
+        pipeline_cfg: PipelineConfig,
+        deploy_cfg: DeployConfig,
+        cli_overrides: dict[str, Any],
+        strategy_specs: Mapping[Any, Any] | None,
+    ) -> tuple[list[StageConfig], Any]:
+        """Build the legacy view from already selected/transformed inputs."""
+        stages = merge_pipeline_deploy(
+            pipeline_cfg,
+            cls._deploy_for_materialized_builder(deploy_cfg),
+            cli_overrides,
+        )
 
         # Overlay declarative parallel strategies (opt-in) before CLI overrides.
         applied = cls._apply_strategy_specs(stages, strategy_specs)
@@ -460,12 +695,36 @@ class StageConfigFactory:
 
         for stage in stages:
             stage.runtime_overrides = cls._merge_cli_overrides(stage, explicit_overrides)
+            if StageType(stage.stage_type) != StageType.DIFFUSION:
+                continue
+
+            # These diffusion-only CLI values were historically finalized by
+            # AsyncOmniEngine after the legacy factory returned. Resolve them
+            # here so the compatibility and typed views see the same input.
+            stage_num_gpus = explicit_overrides.get(f"stage_{stage.stage_id}_num_gpus")
+            global_num_gpus = explicit_overrides.get("num_gpus")
+            if stage_num_gpus is not None or global_num_gpus is not None:
+                stage.runtime_overrides["num_gpus"] = stage_num_gpus if stage_num_gpus is not None else global_num_gpus
+
+            yaml_diffusion_quantization = stage.yaml_engine_args.pop(
+                "diffusion_quantization_config",
+                None,
+            )
+            if yaml_diffusion_quantization is not None and stage.yaml_engine_args.get("quantization_config") is None:
+                stage.yaml_engine_args["quantization_config"] = yaml_diffusion_quantization
+
+            cli_diffusion_quantization = explicit_overrides.get(
+                f"stage_{stage.stage_id}_diffusion_quantization_config",
+                explicit_overrides.get("diffusion_quantization_config"),
+            )
+            if cli_diffusion_quantization is not None and stage.runtime_overrides.get("quantization_config") is None:
+                stage.runtime_overrides["quantization_config"] = cli_diffusion_quantization
+            stage.runtime_overrides.pop("diffusion_quantization_config", None)
 
         # Re-validate the resolved layout now that CLI overrides are on top.
         cls._reconcile_strategy_with_cli(stages, applied)
 
-        omni_lb_policy = applied.omni_lb_policy if applied is not None else None
-        return stages, omni_lb_policy
+        return stages, applied
 
     @staticmethod
     def _apply_strategy_specs(

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -327,6 +327,28 @@ def _stage_cli_overrides(stage_id: int, cli_overrides: Mapping[str, Any]) -> dic
     return result
 
 
+def _diffusion_stage_cli_overrides(
+    stage_id: int,
+    cli_overrides: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Add diffusion-only aliases excluded from generic stage CLI routing."""
+    result = _stage_cli_overrides(stage_id, cli_overrides)
+
+    stage_num_gpus = cli_overrides.get(f"stage_{stage_id}_num_gpus")
+    global_num_gpus = cli_overrides.get("num_gpus")
+    if stage_num_gpus is not None or global_num_gpus is not None:
+        result["num_gpus"] = stage_num_gpus if stage_num_gpus is not None else global_num_gpus
+
+    diffusion_quantization = cli_overrides.get(
+        f"stage_{stage_id}_diffusion_quantization_config",
+        cli_overrides.get("diffusion_quantization_config"),
+    )
+    if diffusion_quantization is not None and result.get("quantization_config") is None:
+        result["quantization_config"] = _copy_value(diffusion_quantization)
+    result.pop("diffusion_quantization_config", None)
+    return result
+
+
 def _resolve_deploy_path(deploy_config_path: str) -> Path:
     deploy_path = Path(deploy_config_path)
     if not deploy_path.exists() and deploy_path.parent == Path("."):
@@ -1185,6 +1207,10 @@ def _stage_engine_values(
         engine["omni_kv_config"] = _copy_value(topology.omni_kv_config)
     if stage_cli_overrides:
         engine.update(_copy_value(stage_cli_overrides))
+    if topology.execution_type == StageExecutionType.DIFFUSION:
+        diffusion_quantization = engine.pop("diffusion_quantization_config", None)
+        if diffusion_quantization is not None and engine.get("quantization_config") is None:
+            engine["quantization_config"] = diffusion_quantization
     _validate_stage_engine_override_ownership(
         topology.stage_id,
         topology.execution_type,
@@ -1722,7 +1748,8 @@ def _build_runtime_config(
         kwargs["num_replicas"] = stage_deploy.num_replicas
     if "env" not in kwargs and stage_deploy is not None and stage_deploy.env is not None:
         kwargs["env"] = _copy_value(stage_deploy.env)
-    kwargs["num_gpus"] = parallel_config.world_size
+    if "num_gpus" not in kwargs:
+        kwargs["num_gpus"] = parallel_config.world_size
     return OmniStageRuntimeConfig(**kwargs)
 
 
@@ -1841,7 +1868,11 @@ class VllmOmniConfig:
                 _stage_engine_values(
                     deploy_by_id.get(topology.stage_id),
                     topology,
-                    _stage_cli_overrides(topology.stage_id, cli_overrides),
+                    (
+                        _diffusion_stage_cli_overrides(topology.stage_id, cli_overrides)
+                        if topology.execution_type == StageExecutionType.DIFFUSION
+                        else _stage_cli_overrides(topology.stage_id, cli_overrides)
+                    ),
                 ),
                 model=model,
             )

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -329,6 +329,28 @@ def _stage_cli_overrides(stage_id: int, cli_overrides: Mapping[str, Any]) -> dic
     return result
 
 
+def _diffusion_stage_cli_overrides(
+    stage_id: int,
+    cli_overrides: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Add diffusion-only aliases excluded from generic stage CLI routing."""
+    result = _stage_cli_overrides(stage_id, cli_overrides)
+
+    stage_num_gpus = cli_overrides.get(f"stage_{stage_id}_num_gpus")
+    global_num_gpus = cli_overrides.get("num_gpus")
+    if stage_num_gpus is not None or global_num_gpus is not None:
+        result["num_gpus"] = stage_num_gpus if stage_num_gpus is not None else global_num_gpus
+
+    diffusion_quantization = cli_overrides.get(
+        f"stage_{stage_id}_diffusion_quantization_config",
+        cli_overrides.get("diffusion_quantization_config"),
+    )
+    if diffusion_quantization is not None and result.get("quantization_config") is None:
+        result["quantization_config"] = _copy_value(diffusion_quantization)
+    result.pop("diffusion_quantization_config", None)
+    return result
+
+
 def _resolve_deploy_path(deploy_config_path: str) -> Path:
     deploy_path = Path(deploy_config_path)
     if not deploy_path.exists() and deploy_path.parent == Path("."):
@@ -985,7 +1007,19 @@ _DIFFUSION_BACKCOMPAT_ENGINE_FIELDS = frozenset(
         "static_lora_scale",
     }
 )
-_DIFFUSION_STAGE_ENGINE_FIELDS = (_DIFFUSION_CONFIG_FIELDS | _DIFFUSION_BACKCOMPAT_ENGINE_FIELDS) - {
+# These are legacy top-level EngineArgs spellings for model-specific values
+# that OmniDiffusionConfig intentionally stores under ``extras``.  Keep them
+# explicit here so the typed owner can preserve the old API without pretending
+# they are generic diffusion fields.
+_DIFFUSION_EXTRA_ENGINE_FIELDS = frozenset(
+    {
+        "auxiliary_text_encoder",
+        "default_llama_model_id",
+    }
+)
+_DIFFUSION_STAGE_ENGINE_FIELDS = (
+    _DIFFUSION_CONFIG_FIELDS | _DIFFUSION_BACKCOMPAT_ENGINE_FIELDS | _DIFFUSION_EXTRA_ENGINE_FIELDS
+) - {
     "model",
     "stage_id",
 }
@@ -1208,6 +1242,10 @@ def _stage_engine_values(
         engine["omni_kv_config"] = _copy_value(topology.omni_kv_config)
     if stage_cli_overrides:
         engine.update(_copy_value(stage_cli_overrides))
+    if topology.execution_type == StageExecutionType.DIFFUSION:
+        diffusion_quantization = engine.pop("diffusion_quantization_config", None)
+        if diffusion_quantization is not None and engine.get("quantization_config") is None:
+            engine["quantization_config"] = diffusion_quantization
     _validate_stage_engine_override_ownership(
         topology.stage_id,
         topology.execution_type,
@@ -1754,7 +1792,8 @@ def _build_runtime_config(
         kwargs["num_replicas"] = stage_deploy.num_replicas
     if "env" not in kwargs and stage_deploy is not None and stage_deploy.env is not None:
         kwargs["env"] = _copy_value(stage_deploy.env)
-    kwargs["num_gpus"] = parallel_config.world_size
+    if "num_gpus" not in kwargs:
+        kwargs["num_gpus"] = parallel_config.world_size
     return OmniStageRuntimeConfig(**kwargs)
 
 
@@ -1815,6 +1854,26 @@ def _build_diffusion_config_projection(
     if quantization_config is not None:
         diffusion_kwargs["quantization_config"] = _copy_value(quantization_config)
 
+    # HiDream historically received these values as top-level EngineArgs, while
+    # OmniDiffusionConfig exposes them through its model-specific ``extras``
+    # mapping. Preserve explicit values for every diffusion adapter, but only
+    # synthesize HiDream's fallback defaults for a HiDream pipeline. Injecting
+    # those model-private keys into every registered DiT changes the effective
+    # config (and can make backend parity checks fail).
+    extras = dict(diffusion_kwargs.pop("extras", {}) or {})
+    for name in ("auxiliary_text_encoder", "default_llama_model_id"):
+        value = diffusion_kwargs.pop(name, None)
+        if value is not None:
+            extras[name] = _copy_value(value)
+
+    model_class_name = diffusion_kwargs.get("model_class_name")
+    short_model_class_name = model_class_name.rsplit(".", 1)[-1].lower() if isinstance(model_class_name, str) else ""
+    if short_model_class_name.startswith("hidream"):
+        extras.setdefault("auxiliary_text_encoder", None)
+        extras.setdefault("default_llama_model_id", "meta-llama/Meta-Llama-3.1-8B-Instruct")
+    if extras:
+        diffusion_kwargs["extras"] = extras
+
     return _DiffusionConfigProjection.from_kwargs(**{k: v for k, v in diffusion_kwargs.items() if v is not None})
 
 
@@ -1874,7 +1933,11 @@ class VllmOmniConfig:
                 _stage_engine_values(
                     deploy_by_id.get(topology.stage_id),
                     topology,
-                    _stage_cli_overrides(topology.stage_id, cli_overrides),
+                    (
+                        _diffusion_stage_cli_overrides(topology.stage_id, cli_overrides)
+                        if topology.execution_type == StageExecutionType.DIFFUSION
+                        else _stage_cli_overrides(topology.stage_id, cli_overrides)
+                    ),
                 ),
                 model=model,
             )

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -28,6 +28,88 @@ _DEPLOY_DIR = Path(__file__).resolve().parent.parent / "deploy"
 
 _STAGE_OVERRIDE_PATTERN = re.compile(r"^stage_(\d+)_(.+)$")
 
+# Top-level API/CLI spellings that are meaningful only to a diffusion stage.
+# They are deliberately kept at this schema boundary rather than in the
+# entrypoint so the typed and compatibility views receive identical routing.
+# Shared engine controls (TP/DP/PP, dtype, revision, memory limits, etc.) are
+# intentionally absent and continue to apply to every applicable stage.
+_DIFFUSION_STAGE_ONLY_CLI_FIELDS = frozenset(
+    {
+        "VSA_sparsity",
+        "additional_config",
+        "auxiliary_text_encoder",
+        "boundary_ratio",
+        "cache_backend",
+        "cache_config",
+        "cache_strategy",
+        "cfg_parallel_size",
+        "custom_pipeline_args",
+        "default_llama_model_id",
+        "diffusers_call_kwargs",
+        "diffusers_load_kwargs",
+        "diffusers_pipeline_cls",
+        "diffusion_attention_backend",
+        "diffusion_attention_config",
+        "diffusion_compile_dynamic",
+        "diffusion_compile_granularity",
+        "diffusion_kv_cache_dtype",
+        "diffusion_kv_cache_skip_layers",
+        "diffusion_kv_cache_skip_steps",
+        "diffusion_load_format",
+        "diffusion_model_runner_cls",
+        "diffusion_quantization_config",
+        "enable_cache_dit_summary",
+        "enable_cpu_offload",
+        "enable_diffusion_pipeline_profiler",
+        "enable_distributed_layerwise_offload",
+        "enable_layerwise_offload",
+        "fa_deterministic",
+        "fastvideo_vsa_topk",
+        "flow_shift",
+        "force_cutlass_fp8",
+        "hsdp_replicate_size",
+        "hsdp_shard_size",
+        "host_weight_runtime_mode",
+        "host_weight_runtime_root",
+        "lora_backend",
+        "lora_path",
+        "lora_scale",
+        "max_cpu_loras",
+        "moba_config_path",
+        "model_class_name",
+        "output_type",
+        "pin_cpu_memory",
+        "prompt_embed_cache_size",
+        "enable_prompt_embed_cache",
+        "enable_session_state_manager",
+        "enable_stage_verification",
+        "request_batch_max_wait_ms",
+        "skip_time_steps",
+        "static_lora_scale",
+        "step_execution",
+        "streaming_output",
+        "supports_mixed_reference_inputs",
+        "supports_multimodal_inputs",
+        "vae_use_slicing",
+        "vae_use_tiling",
+        "vae_parallel_mode",
+        "vae_patch_parallel_size",
+        "text_encoder_tp_size",
+        "ulysses_a2a_permute",
+        "ulysses_degree",
+        "ulysses_mode",
+        "ring_degree",
+        "allgather_degree",
+        "use_hsdp",
+        "diffusion_kv_mode",
+        "diffusion_kv_max_rows_per_request",
+        "dlo_use_allgather",
+        "dlo_resident_layers",
+        "dlo_host_registration_limit_gib",
+        "override_transformer_cls_name",
+    }
+)
+
 
 def pipeline_cfg_resolver(config_type: type[PretrainedConfig]):
     """Wraps a resolver such that we return None if a hf_config of the wrong type is provided."""
@@ -68,7 +150,13 @@ def build_stage_runtime_overrides(
         # the default blacklist for true orchestrator/shared fields while
         # allowing any field explicitly represented by the deploy schema to
         # continue flowing into per-stage overrides.
-        internal_keys = (internal_blacklist_keys() | SHARED_FIELDS) - deploy_runtime_override_keys()
+        # ``enable_sleep_mode`` is parsed by the orchestrator as well as the
+        # stage engine.  It is intentionally absent from DeployConfig because
+        # the CLI/API value is a process-wide switch, but it still must reach
+        # every stage's model config (including typed diffusion stages).
+        internal_keys = (
+            (internal_blacklist_keys() | SHARED_FIELDS) - deploy_runtime_override_keys() - {"enable_sleep_mode"}
+        )
 
     result: dict[str, Any] = {}
 
@@ -93,7 +181,15 @@ def normalize_pipeline_cli_overrides(
     pipeline: PipelineConfig,
     cli_overrides: dict[str, Any],
 ) -> dict[str, Any]:
-    """Translate pipeline-owned global CLI aliases into stage-scoped overrides."""
+    """Translate pipeline-owned global CLI aliases into stage-scoped overrides.
+
+    Diffusion-only global CLI spellings (for example
+    ``--diffusion-streaming-output`` and ``--auxiliary-text-encoder``) are
+    translated to the owning diffusion stage here.  Keeping that translation
+    at the shared config boundary means both the typed and legacy views see the
+    same value; pipelines without a diffusion stage simply discard these
+    diffusion-only flags instead of forwarding them to an LLM stage.
+    """
     normalized = dict(cli_overrides)
     for source, (stage_id, target) in pipeline.stage_cli_aliases.items():
         invalid_stage_keys = [
@@ -123,6 +219,57 @@ def normalize_pipeline_cli_overrides(
             )
             continue
         normalized[stage_key] = value
+
+    diffusion_stage_ids = {
+        stage.stage_id for stage in pipeline.stages if stage.execution_type == StageExecutionType.DIFFUSION
+    }
+
+    # These spellings are accepted by the top-level API/CLI for historical
+    # compatibility, but their structured owners exist only on diffusion
+    # stages. Route each global value to every diffusion stage (there is
+    # normally one), preserving an explicit stage-local value as the winner.
+    diffusion_aliases = {name: name for name in _DIFFUSION_STAGE_ONLY_CLI_FIELDS}
+    diffusion_aliases["diffusion_streaming_output"] = "streaming_output"
+    for key in list(normalized):
+        match = _STAGE_OVERRIDE_PATTERN.match(key)
+        if match is None or match.group(2) not in diffusion_aliases:
+            continue
+        stage_id = int(match.group(1))
+        source = match.group(2)
+        value = normalized.pop(key)
+        if value is None:
+            continue
+        if stage_id not in diffusion_stage_ids:
+            raise ValueError(
+                f"{key} cannot be set for pipeline {pipeline.model_type!r}; {source} belongs to a diffusion stage."
+            )
+        target_key = f"stage_{stage_id}_{diffusion_aliases[source]}"
+        existing = normalized.get(target_key)
+        if existing is not None and existing != value:
+            warnings.warn(
+                f"Ignoring {key}={value!r} because {target_key}={existing!r} takes precedence.",
+                UserWarning,
+                stacklevel=2,
+            )
+            continue
+        normalized[target_key] = value
+
+    for source, target in diffusion_aliases.items():
+        global_value = normalized.pop(source, None)
+        if global_value is None:
+            continue
+        for stage_id in diffusion_stage_ids:
+            target_key = f"stage_{stage_id}_{target}"
+            existing = normalized.get(target_key)
+            if existing is not None and existing != global_value:
+                warnings.warn(
+                    f"Ignoring {source}={global_value!r} because {target_key}={existing!r} takes precedence.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                continue
+            normalized[target_key] = global_value
+
     return normalized
 
 

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -656,7 +656,8 @@ def resolve_model_class_name(
 
     from vllm_omni.diffusion.utils.hf_utils import _looks_like_hidream_o1
 
-    if _looks_like_hidream_o1(model, cfg):
+    hidream_kwargs = {"revision": revision} if revision is not None else {}
+    if _looks_like_hidream_o1(model, cfg, **hidream_kwargs):
         return "HiDreamO1ImagePipeline"
     if model_type == "bagel" or "BagelForConditionalGeneration" in architectures:
         return "BagelPipeline"
@@ -682,7 +683,11 @@ def resolve_model_class_name(
     if model_type == "vla":
         from vllm_omni.diffusion.utils.hf_utils import _looks_like_dreamzero
 
-        return "DreamZeroPipeline" if _looks_like_dreamzero(model) else None
+        if revision is None:
+            looks_like_dreamzero = _looks_like_dreamzero(model)
+        else:
+            looks_like_dreamzero = _looks_like_dreamzero(model, revision=revision)
+        return "DreamZeroPipeline" if looks_like_dreamzero else None
     if len(architectures) == 1:
         return architectures[0]
     return None
@@ -1415,7 +1420,14 @@ class OmniDiffusionConfig:
                 from vllm_omni.diffusion.utils.hf_utils import _looks_like_hidream_o1
 
                 assert self.model is not None
-                is_hidream_o1 = _looks_like_hidream_o1(self.model, cfg)
+                # ``cfg`` was loaded from ``self.revision`` above, but the
+                # HiDream signature check reads the weight index separately.
+                # Keep that lookup on the same revision so a non-default
+                # checkpoint cannot be classified using another commit's
+                # index. Preserve the historical call shape when no revision
+                # is pinned for integrations that provide a narrow detector.
+                hidream_kwargs = {"revision": self.revision} if self.revision is not None else {}
+                is_hidream_o1 = _looks_like_hidream_o1(self.model, cfg, **hidream_kwargs)
                 if self.model_class_name == "HiDreamO1ImagePipeline" and not is_hidream_o1:
                     raise ValueError(f"Checkpoint {self.model} does not have the HiDream-O1 signature")
 
@@ -1473,7 +1485,11 @@ class OmniDiffusionConfig:
                     from vllm_omni.diffusion.utils.hf_utils import _looks_like_dreamzero
 
                     assert self.model is not None
-                    if _looks_like_dreamzero(self.model):
+                    if self.revision is None:
+                        looks_like_dreamzero = _looks_like_dreamzero(self.model)
+                    else:
+                        looks_like_dreamzero = _looks_like_dreamzero(self.model, revision=self.revision)
+                    if looks_like_dreamzero:
                         self.model_class_name = "DreamZeroPipeline"
                         self.set_tf_model_config(TransformerConfig())
                         self.update_multimodal_support()

--- a/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_tokenizer.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_tokenizer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 import random
 import warnings
@@ -45,9 +45,10 @@ class Conversation:
 
 
 class TokenizerWrapper:
-    def __init__(self, tokenizer):
+    def __init__(self, tokenizer, *, revision: str | None = None):
         if isinstance(tokenizer, str):
-            self.tokenizer = AutoTokenizer.from_pretrained(tokenizer)
+            tokenizer_kwargs = {"revision": revision} if revision is not None else {}
+            self.tokenizer = AutoTokenizer.from_pretrained(tokenizer, **tokenizer_kwargs)
         else:
             self.tokenizer = tokenizer
 

--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 import copy
 import logging
@@ -162,11 +162,15 @@ def _shift_full_attn_spans(
 
 
 def get_hunyuan_image_3_pre_process_func(od_config: OmniDiffusionConfig):
-    hf_config = get_config(od_config.model, trust_remote_code=True)
+    revision = getattr(od_config, "revision", None)
+    revision_kwargs = {"revision": revision} if revision is not None else {}
+    hf_config = get_config(od_config.model, trust_remote_code=True, **revision_kwargs)
     image_processor = HunyuanImage3ImageProcessor(hf_config)
     prepare_diffusion_kv_layout = od_config.diffusion_kv_mode is DiffusionKVCacheMode.PAGED_SCHEDULER
-    tokenizer_wrapper = TokenizerWrapper(od_config.model) if prepare_diffusion_kv_layout else None
-    generation_config = GenerationConfig.from_pretrained(od_config.model) if prepare_diffusion_kv_layout else None
+    tokenizer_wrapper = TokenizerWrapper(od_config.model, **revision_kwargs) if prepare_diffusion_kv_layout else None
+    generation_config = (
+        GenerationConfig.from_pretrained(od_config.model, **revision_kwargs) if prepare_diffusion_kv_layout else None
+    )
     vae_h_factor = hf_config.vae_downsample_factor[0] * hf_config.patch_size
     vae_w_factor = hf_config.vae_downsample_factor[1] * hf_config.patch_size
     vit_patch_size = getattr(image_processor.vision_encoder_processor, "patch_size", 1)
@@ -347,16 +351,18 @@ class HunyuanImage3Pipeline(
     ]
 
     def __init__(self, od_config: OmniDiffusionConfig) -> None:
-        self.hf_config = get_config(od_config.model, trust_remote_code=True)
+        revision = getattr(od_config, "revision", None)
+        revision_kwargs = {"revision": revision} if revision is not None else {}
+        self.hf_config = get_config(od_config.model, trust_remote_code=True, **revision_kwargs)
         super().__init__(self.hf_config)
         # update diffusion config
-        self.generation_config = GenerationConfig.from_pretrained(od_config.model)
+        self.generation_config = GenerationConfig.from_pretrained(od_config.model, **revision_kwargs)
         self.od_config = od_config
         self.weights_sources = [
             DiffusersPipelineLoader.ComponentSource(
                 model_or_path=od_config.model,
                 subfolder=None,
-                revision=od_config.revision,
+                revision=revision,
                 prefix="",
                 fall_back_to_pt=True,
             )
@@ -373,7 +379,7 @@ class HunyuanImage3Pipeline(
         self.vae = DistributedAutoencoderKLHunyuan.from_config(self.hf_config.vae)
         self.vae.use_spatial_tiling = self.od_config.vae_use_tiling
         self._pipeline = None
-        self._tkwrapper = TokenizerWrapper(od_config.model)
+        self._tkwrapper = TokenizerWrapper(od_config.model, **revision_kwargs)
         self.image_processor = HunyuanImage3ImageProcessor(self.hf_config)
         self.vision_model = Siglip2VisionTransformer(self.hf_config.vit)
         # self.vision_model = vision_model.vision_model

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
@@ -145,7 +145,12 @@ def retrieve_latents(
         raise AttributeError("Could not access latents of provided encoder_output")
 
 
-def load_transformer_config(model_path: str, subfolder: str = "transformer", local_files_only: bool = True) -> dict:
+def load_transformer_config(
+    model_path: str,
+    subfolder: str = "transformer",
+    local_files_only: bool = True,
+    revision: str | None = None,
+) -> dict:
     """Load transformer config from model directory or HF Hub."""
     if local_files_only:
         config_path = os.path.join(model_path, subfolder, "config.json")
@@ -157,10 +162,13 @@ def load_transformer_config(model_path: str, subfolder: str = "transformer", loc
         try:
             from huggingface_hub import hf_hub_download
 
-            config_path = hf_hub_download(
-                repo_id=model_path,
-                filename=f"{subfolder}/config.json",
-            )
+            download_kwargs = {
+                "repo_id": model_path,
+                "filename": f"{subfolder}/config.json",
+            }
+            if revision is not None:
+                download_kwargs["revision"] = revision
+            config_path = hf_hub_download(**download_kwargs)
             with open(config_path) as f:
                 return json.load(f)
         except Exception:
@@ -334,6 +342,7 @@ class Wan22Pipeline(
 
         self.device = get_local_device()
         dtype = getattr(od_config, "dtype", torch.bfloat16)
+        revision = getattr(od_config, "revision", None)
 
         model = od_config.model
         local_files_only = os.path.exists(model)
@@ -357,7 +366,10 @@ class Wan22Pipeline(
             try:
                 from huggingface_hub import hf_hub_download
 
-                model_index_path = hf_hub_download(repo_id=model, filename="model_index.json")
+                download_kwargs = {"repo_id": model, "filename": "model_index.json"}
+                if revision is not None:
+                    download_kwargs["revision"] = revision
+                model_index_path = hf_hub_download(**download_kwargs)
                 with open(model_index_path) as f:
                     model_index = json.load(f)
                     self.expand_timesteps = model_index.get("expand_timesteps", False)
@@ -386,7 +398,7 @@ class Wan22Pipeline(
                 DiffusersPipelineLoader.ComponentSource(
                     model_or_path=od_config.model,
                     subfolder="transformer",
-                    revision=None,
+                    revision=revision,
                     prefix="transformer.",
                     fall_back_to_pt=True,
                 )
@@ -396,7 +408,7 @@ class Wan22Pipeline(
                 DiffusersPipelineLoader.ComponentSource(
                     model_or_path=od_config.model,
                     subfolder="transformer_2",
-                    revision=None,
+                    revision=revision,
                     prefix="transformer_2.",
                     fall_back_to_pt=True,
                 )
@@ -408,7 +420,10 @@ class Wan22Pipeline(
             model,
             component_subfolders,
             local_files_only=local_files_only,
+            revision=revision,
         )
+
+        revision_kwargs = {"revision": revision} if revision is not None else {}
 
         # ``from_pretrained_with_prefetch`` re-prefetches and retries if the
         # cache is still half-written (the missing-shard ``OSError`` and the
@@ -420,6 +435,7 @@ class Wan22Pipeline(
             subfolder="tokenizer",
             prefetch_list=component_subfolders,
             local_files_only=local_files_only,
+            **revision_kwargs,
         )
         self.text_encoder = from_pretrained_with_prefetch(
             UMT5EncoderModel.from_pretrained,
@@ -428,6 +444,7 @@ class Wan22Pipeline(
             prefetch_list=component_subfolders,
             local_files_only=local_files_only,
             torch_dtype=dtype,
+            **revision_kwargs,
         ).to(self.device)
         self.vae = from_pretrained_with_prefetch(
             DistributedAutoencoderKLWan.from_pretrained,
@@ -436,17 +453,28 @@ class Wan22Pipeline(
             prefetch_list=component_subfolders,
             local_files_only=local_files_only,
             torch_dtype=dtype,
+            **revision_kwargs,
         ).to(self.device)
 
         # Initialize transformers with correct config (weights loaded via load_weights)
         if load_transformer:
-            transformer_config = load_transformer_config(model, "transformer", local_files_only)
+            transformer_config = load_transformer_config(
+                model,
+                "transformer",
+                local_files_only,
+                revision=revision,
+            )
             self.transformer = self._create_transformer(transformer_config)
         else:
             self.transformer = None
 
         if load_transformer_2:
-            transformer_2_config = load_transformer_config(model, "transformer_2", local_files_only)
+            transformer_2_config = load_transformer_config(
+                model,
+                "transformer_2",
+                local_files_only,
+                revision=revision,
+            )
             self.transformer_2 = self._create_transformer(transformer_2_config)
         else:
             self.transformer_2 = None

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
@@ -204,6 +204,7 @@ class Wan22I2VPipeline(
 
         self.device = get_local_device()
         dtype = getattr(od_config, "dtype", torch.bfloat16)
+        revision = getattr(od_config, "revision", None)
 
         model = od_config.model
         local_files_only = os.path.exists(model)
@@ -213,7 +214,7 @@ class Wan22I2VPipeline(
             DiffusersPipelineLoader.ComponentSource(
                 model_or_path=od_config.model,
                 subfolder="transformer",
-                revision=None,
+                revision=revision,
                 prefix="transformer.",
                 fall_back_to_pt=True,
             ),
@@ -233,7 +234,7 @@ class Wan22I2VPipeline(
                 DiffusersPipelineLoader.ComponentSource(
                     model_or_path=od_config.model,
                     subfolder="transformer_2",
-                    revision=None,
+                    revision=revision,
                     prefix="transformer_2.",
                     fall_back_to_pt=True,
                 )
@@ -250,7 +251,14 @@ class Wan22I2VPipeline(
         subfolders = ["tokenizer", "text_encoder", "vae"]
         if self.has_image_encoder:
             subfolders.extend(["image_processor", "image_encoder"])
-        prefetch_subfolders(model, subfolders, local_files_only=local_files_only)
+        prefetch_subfolders(
+            model,
+            subfolders,
+            local_files_only=local_files_only,
+            revision=revision,
+        )
+
+        revision_kwargs = {"revision": revision} if revision is not None else {}
 
         # Text encoder
         self.tokenizer = from_pretrained_with_prefetch(
@@ -259,6 +267,7 @@ class Wan22I2VPipeline(
             subfolder="tokenizer",
             prefetch_list=subfolders,
             local_files_only=local_files_only,
+            **revision_kwargs,
         )
         self.text_encoder = from_pretrained_with_prefetch(
             UMT5EncoderModel.from_pretrained,
@@ -267,6 +276,7 @@ class Wan22I2VPipeline(
             prefetch_list=subfolders,
             local_files_only=local_files_only,
             torch_dtype=dtype,
+            **revision_kwargs,
         ).to(self.device)
 
         if self.has_image_encoder:
@@ -276,6 +286,7 @@ class Wan22I2VPipeline(
                 subfolder="image_processor",
                 prefetch_list=subfolders,
                 local_files_only=local_files_only,
+                **revision_kwargs,
             )
             self.image_encoder = from_pretrained_with_prefetch(
                 CLIPVisionModel.from_pretrained,
@@ -284,6 +295,7 @@ class Wan22I2VPipeline(
                 prefetch_list=subfolders,
                 local_files_only=local_files_only,
                 torch_dtype=dtype,
+                **revision_kwargs,
             ).to(self.device)
         else:
             self.image_processor = None
@@ -297,17 +309,28 @@ class Wan22I2VPipeline(
             prefetch_list=subfolders,
             local_files_only=local_files_only,
             torch_dtype=dtype,
+            **revision_kwargs,
         ).to(self.device)
 
         # Transformers (weights loaded via load_weights)
         # Load config from model directory or HF Hub to get correct in_channels for I2V models
-        transformer_config = load_transformer_config(model, "transformer", local_files_only)
+        transformer_config = load_transformer_config(
+            model,
+            "transformer",
+            local_files_only,
+            revision=revision,
+        )
         self.transformer = create_transformer_from_config(
             transformer_config,
             quant_config=od_config.quantization_config,
         )
         if self.has_transformer_2:
-            transformer_2_config = load_transformer_config(model, "transformer_2", local_files_only)
+            transformer_2_config = load_transformer_config(
+                model,
+                "transformer_2",
+                local_files_only,
+                revision=revision,
+            )
             t2_quant = transformer_2_config.get("quantization_config")
             if isinstance(t2_quant, dict) and "quant_method" in t2_quant:
                 from vllm_omni.quantization.factory import build_quant_config

--- a/vllm_omni/diffusion/utils/hf_utils.py
+++ b/vllm_omni/diffusion/utils/hf_utils.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 import os
 from collections.abc import Mapping
 from functools import lru_cache
@@ -26,17 +29,19 @@ def get_diffusion_model_index(
     return None
 
 
-def load_diffusers_config(model_name) -> dict:
+def load_diffusers_config(model_name, *, revision: str | None = None) -> dict:
     from diffusers.pipelines.pipeline_utils import DiffusionPipeline
 
-    config = DiffusionPipeline.load_config(model_name)
+    load_kwargs = {"revision": revision} if revision is not None else {}
+    config = DiffusionPipeline.load_config(model_name, **load_kwargs)
     return config
 
 
-def _looks_like_bagel(model_name: str) -> bool:
+def _looks_like_bagel(model_name: str, *, revision: str | None = None) -> bool:
     """Best-effort detection for Bagel (non-diffusers) diffusion models."""
     try:
-        cfg = get_hf_file_to_dict("config.json", model_name)
+        file_kwargs = {"revision": revision} if revision is not None else {}
+        cfg = get_hf_file_to_dict("config.json", model_name, **file_kwargs)
         model_type = cfg.get("model_type")
         if model_type == "bagel":
             return True
@@ -46,10 +51,11 @@ def _looks_like_bagel(model_name: str) -> bool:
         return False
 
 
-def _looks_like_dreamzero(model_name: str) -> bool:
+def _looks_like_dreamzero(model_name: str, *, revision: str | None = None) -> bool:
     """Best-effort detection for DreamZero-style VLA diffusion checkpoints."""
     try:
-        cfg = get_hf_file_to_dict("config.json", model_name)
+        file_kwargs = {"revision": revision} if revision is not None else {}
+        cfg = get_hf_file_to_dict("config.json", model_name, **file_kwargs)
         if cfg.get("model_type") != "vla":
             return False
         action_head_cfg = cfg.get("action_head_cfg") or {}
@@ -77,14 +83,20 @@ HIDREAM_O1_SIGNATURE_WEIGHTS = (
 )
 
 
-def _looks_like_hidream_o1(model_name: str, config: Mapping | None = None) -> bool:
+def _looks_like_hidream_o1(
+    model_name: str,
+    config: Mapping | None = None,
+    *,
+    revision: str | None = None,
+) -> bool:
     """Detect HiDream-O1 without matching regular Qwen3-VL checkpoints."""
     try:
-        cfg = config if config is not None else get_hf_file_to_dict("config.json", model_name)
+        file_kwargs = {"revision": revision} if revision is not None else {}
+        cfg = config if config is not None else get_hf_file_to_dict("config.json", model_name, **file_kwargs)
         if not isinstance(cfg, Mapping) or cfg.get("model_type") != "qwen3_vl":
             return False
 
-        index = get_hf_file_to_dict("model.safetensors.index.json", model_name)
+        index = get_hf_file_to_dict("model.safetensors.index.json", model_name, **file_kwargs)
         if not isinstance(index, Mapping):
             return False
         weight_map = index.get("weight_map")
@@ -96,7 +108,7 @@ def _looks_like_hidream_o1(model_name: str, config: Mapping | None = None) -> bo
 
 
 @lru_cache
-def is_diffusion_model(model_name: str) -> bool:
+def is_diffusion_model(model_name: str, revision: str | None = None) -> bool:
     """Check if a model is a diffusion model.
 
     Uses multiple fallback strategies to detect diffusion models:
@@ -122,7 +134,10 @@ def is_diffusion_model(model_name: str) -> bool:
                 logger.debug("Failed to read local %s: %s", filename, e)
 
     # Strategy 2: Check using vllm's utility (works for both local and remote models)
-    config_dict = get_diffusion_model_index(model_name)
+    if revision is None:
+        config_dict = get_diffusion_model_index(model_name)
+    else:
+        config_dict = get_diffusion_model_index(model_name, revision=revision)
     if config_dict is not None and config_dict.get("_class_name") and config_dict.get("_diffusers_version"):
         logger.debug("Detected diffusion model via a standard Diffusers index")
         return True
@@ -131,7 +146,10 @@ def is_diffusion_model(model_name: str) -> bool:
     # This is last because it requires importing diffusers/xformers/flash_attn
     # which may have compatibility issues
     try:
-        load_diffusers_config(model_name)
+        if revision is None:
+            load_diffusers_config(model_name)
+        else:
+            load_diffusers_config(model_name, revision=revision)
         return True
     except (ImportError, ModuleNotFoundError) as e:
         logger.debug("Failed to import diffusers dependencies: %s", e)
@@ -139,4 +157,12 @@ def is_diffusion_model(model_name: str) -> bool:
     except Exception as e:
         logger.debug("Failed to load diffusers config via DiffusionPipeline: %s", e)
 
-    return _looks_like_bagel(model_name) or _looks_like_dreamzero(model_name) or _looks_like_hidream_o1(model_name)
+    if revision is None:
+        looks_like_bagel = _looks_like_bagel(model_name)
+        looks_like_dreamzero = _looks_like_dreamzero(model_name)
+        looks_like_hidream = _looks_like_hidream_o1(model_name)
+    else:
+        looks_like_bagel = _looks_like_bagel(model_name, revision=revision)
+        looks_like_dreamzero = _looks_like_dreamzero(model_name, revision=revision)
+        looks_like_hidream = _looks_like_hidream_o1(model_name, revision=revision)
+    return looks_like_bagel or looks_like_dreamzero or looks_like_hidream

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 
 import janus
 import torch
-from omegaconf import OmegaConf
 from vllm import envs as vllm_envs
 from vllm.inputs import PromptType
 from vllm.logger import init_logger
@@ -29,10 +28,7 @@ from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.engine.input_processor import InputProcessor
 
 from vllm_omni.config.config_factory import StageConfigFactory, with_trust_remote_code_override
-from vllm_omni.config.stage_config import (
-    DuplexSessionRuntimeConfig,
-    load_deploy_config,
-)
+from vllm_omni.config.stage_config import DuplexSessionRuntimeConfig, load_deploy_config
 from vllm_omni.diffusion.data import DiffusionParallelConfig, parse_attention_config
 from vllm_omni.diffusion.diffusion_engine import supports_audio_output
 from vllm_omni.engine.async_engine_utils import (
@@ -66,13 +62,22 @@ from vllm_omni.engine.stage_runtime import (
 )
 from vllm_omni.entrypoints.pd_utils import PDDisaggregationMixin
 from vllm_omni.entrypoints.utils import (
-    load_and_resolve_stage_configs,
+    ResolvedStageConfigs,
+    load_and_resolve_stage_config_views,
     parse_stage_overrides,
+)
+from vllm_omni.entrypoints.utils import (
+    load_and_resolve_stage_configs as _legacy_stage_config_resolver,
 )
 from vllm_omni.inputs.data import OmniInteractionPrompt, OmniSamplingParams
 from vllm_omni.metrics.prometheus import OmniRequestCounter
 
 logger = init_logger(__name__)
+
+# Kept as a module-level compatibility symbol for downstream tests and
+# integrations that patched the pre-Phase-3 resolver. Runtime startup uses the
+# typed view resolver below.
+load_and_resolve_stage_configs = _legacy_stage_config_resolver
 
 if TYPE_CHECKING:
     from vllm_omni.experimental.fullduplex.engine.duplex_control_client import DuplexControlClient
@@ -104,6 +109,7 @@ class AsyncOmniEngine:
     _coordinator_runtime: Any = None
     _transfer_emitter: Any = None
     _enable_orch_monitor: bool = False
+    vllm_omni_config: Any = None
 
     def __init__(
         self,
@@ -173,14 +179,12 @@ class AsyncOmniEngine:
                 self._omni_master_port,
             )
 
-        # Stage resolution pops deploy_config, so get pipeline-wide settings beforehand.
+        # Resolve pipeline-wide metadata before stage resolution.  The typed
+        # resolver normally supplies the same values, but this early lookup is
+        # intentionally retained as a compatibility/fallback boundary for
+        # callers that override or mock stage resolution (and for deploy files
+        # that contain no registered stage pipeline).
         deploy_config_path = kwargs.get("deploy_config")
-        # ``trust_remote_code`` is tri-state (bool | None): ``None`` means "not
-        # specified" so stage-config resolution can defer to the deploy yaml's
-        # per-stage value (see ``with_trust_remote_code_override``). The
-        # restriction path below loads the top-level HF config via vLLM's
-        # ``get_config``, which needs a real bool, so collapse ``None`` to the
-        # default ``False`` here (#5495).
         pipeline_config = StageConfigFactory.get_pipeline_config(
             model=model,
             trust_remote_code=bool(trust_remote_code),
@@ -196,7 +200,22 @@ class AsyncOmniEngine:
         self._duplex_control_enabled = bool(pipeline_config and pipeline_config.duplex_control_enabled)
         self.duplex_session_config = DuplexSessionRuntimeConfig()
         if deploy_config_path is not None:
-            self.duplex_session_config = load_deploy_config(deploy_config_path).duplex_session
+            # This is an early compatibility read used for endpoint/session
+            # metadata. Reuse the factory's bare-name lookup (``deploy/foo``)
+            # and let the canonical resolver remain the source of truth. A
+            # missing path is intentionally deferred so patched resolvers and
+            # the eventual typed resolution can decide how to handle it.
+            try:
+                # Keep the legacy module-level hook for integrations that
+                # patch it, then fall back to the factory's bare-name lookup.
+                early_deploy_config = load_deploy_config(deploy_config_path)
+            except FileNotFoundError:
+                try:
+                    early_deploy_config = StageConfigFactory._load_user_deploy_config(deploy_config_path)
+                except FileNotFoundError:
+                    early_deploy_config = None
+            if early_deploy_config is not None:
+                self.duplex_session_config = early_deploy_config.duplex_session
 
         # Tri-state: None means "not specified" — the deploy yaml's per-stage
         # trust_remote_code stays in effect. An explicit True/False here is a
@@ -208,6 +227,26 @@ class AsyncOmniEngine:
             kwargs,
             trust_remote_code=trust_remote_code,
         )
+
+        resolved = getattr(self, "_resolved_stage_configs", None)
+        resolved_pipeline_config = (
+            resolved.omni_config.pipeline_config if resolved is not None and resolved.omni_config is not None else None
+        )
+        if resolved_pipeline_config is not None:
+            pipeline_config = resolved_pipeline_config
+            self.endpoint_restrictions = pipeline_config.endpoint_restrictions
+        self._duplex_runtime_extension_path = (
+            pipeline_config.duplex_runtime_extension
+            if pipeline_config is not None
+            else self._duplex_runtime_extension_path
+        )
+        self.duplex_serving_adapter_path = (
+            pipeline_config.duplex_serving_adapter if pipeline_config is not None else self.duplex_serving_adapter_path
+        )
+        if pipeline_config is not None:
+            self._duplex_control_enabled = bool(pipeline_config.duplex_control_enabled)
+        if resolved is not None and resolved.deploy_config is not None:
+            self.duplex_session_config = resolved.deploy_config.duplex_session
 
         self.num_stages = len(self.stage_configs)
         stage0_args = getattr(self.stage_configs[0], "engine_args", None) if self.num_stages > 0 else None
@@ -293,6 +332,7 @@ class AsyncOmniEngine:
         """Initialize stage clients/processors via StageRuntime and assign to self."""
         self._runtime = create_stage_runtime(
             stage_configs=self.stage_configs,
+            omni_config=self.vllm_omni_config,
             model=self.model,
             config_path=self.config_path,
             single_stage_mode=self.single_stage_mode,
@@ -1007,6 +1047,13 @@ class AsyncOmniEngine:
         num_gpus = normalized_kwargs.get("num_gpus")
         if num_gpus is not None:
             num_gpus = int(num_gpus)
+            if num_gpus < 1:
+                raise ValueError(f"num_gpus must be >= 1, got {num_gpus}")
+            # The unregistered single-stage fallback has historically
+            # materialized its device layout before creating the legacy stage.
+            # Keep that behavior (including WORLD-derived DP) while the
+            # registered-pipeline typed path defers the same validation to the
+            # terminal OmniDiffusionConfig consumer.
             parallel_config.resolve_data_parallel_size(num_gpus)
 
         num_devices = max(1, int(parallel_config.world_size))
@@ -1072,7 +1119,7 @@ class AsyncOmniEngine:
             "enable_multithread_weight_load": kwargs.get("enable_multithread_weight_load", True),
             "num_weight_load_threads": kwargs.get("num_weight_load_threads", 4),
             "quantization": kwargs.get("quantization", None),
-            "quantization_config": kwargs.get("quantization_config", None),
+            "quantization_config": kwargs.get("diffusion_quantization_config") or kwargs.get("quantization_config"),
             "diffusion_kv_cache_dtype": kwargs.get("diffusion_kv_cache_dtype", None),
             "diffusion_kv_cache_skip_steps": kwargs.get("diffusion_kv_cache_skip_steps", None),
             "diffusion_kv_cache_skip_layers": kwargs.get("diffusion_kv_cache_skip_layers", None),
@@ -1160,7 +1207,7 @@ class AsyncOmniEngine:
         kwargs: dict[str, Any],
         *,
         trust_remote_code: bool | None,
-    ) -> tuple[str, list[Any]]:
+    ) -> tuple[str | None, list[Any]]:
         """Resolve stage configs and inject defaults shared by orchestrator/headless."""
 
         for legacy_arg in ("stage_configs_path", "stage_configs"):
@@ -1174,7 +1221,7 @@ class AsyncOmniEngine:
         # Parse --stage-overrides JSON string if provided
         stage_overrides = parse_stage_overrides(stage_overrides_json)
 
-        config_path, stage_configs, strategy_lb_policy = load_and_resolve_stage_configs(
+        resolved: ResolvedStageConfigs = load_and_resolve_stage_config_views(
             model,
             kwargs,
             trust_remote_code=trust_remote_code,
@@ -1183,103 +1230,14 @@ class AsyncOmniEngine:
             stage_overrides=stage_overrides,
             strategy_config_path=strategy_config_path,
         )
+        self.vllm_omni_config = resolved.omni_config
+        self._resolved_stage_configs = resolved
 
         # A strategy.yaml may derive a pipeline-wide load-balancer policy. It is
         # an orchestrator-level knob (read once at construction), so apply it here
         # rather than as a per-stage config field.
-        self._apply_strategy_lb_policy(strategy_lb_policy, kwargs)
-
-        # Inject diffusion LoRA-related knobs from kwargs if not present in the stage config.
-        for cfg in stage_configs:
-            try:
-                if not hasattr(cfg, "engine_args") or cfg.engine_args is None:
-                    cfg.engine_args = OmegaConf.create({})
-                global_sleep_mode = kwargs.get("enable_sleep_mode")
-                if global_sleep_mode is not None:
-                    if not hasattr(cfg.engine_args, "enable_sleep_mode") or cfg.engine_args.enable_sleep_mode is None:
-                        cfg.engine_args.enable_sleep_mode = global_sleep_mode
-                if getattr(cfg, "stage_type", None) != "diffusion":
-                    continue
-                if not hasattr(cfg, "engine_args") or cfg.engine_args is None:
-                    cfg.engine_args = OmegaConf.create({})
-                additional_config = kwargs.get("additional_config")
-                if additional_config is not None:
-                    current_additional_config = getattr(cfg.engine_args, "additional_config", None)
-                    if current_additional_config in (None, {}):
-                        cfg.engine_args.additional_config = additional_config
-                if kwargs.get("lora_path") is not None:
-                    if not hasattr(cfg.engine_args, "lora_path") or cfg.engine_args.lora_path is None:
-                        cfg.engine_args.lora_path = kwargs["lora_path"]
-                lora_scale = kwargs.get("lora_scale")
-                if lora_scale is None:
-                    # Backwards compatibility for older callers.
-                    lora_scale = kwargs.get("static_lora_scale")
-                if lora_scale is not None:
-                    if not hasattr(cfg.engine_args, "lora_scale") or cfg.engine_args.lora_scale is None:
-                        cfg.engine_args.lora_scale = lora_scale
-                if kwargs.get("lora_backend") is not None:
-                    if not hasattr(cfg.engine_args, "lora_backend") or cfg.engine_args.lora_backend is None:
-                        cfg.engine_args.lora_backend = kwargs["lora_backend"]
-                if (
-                    kwargs.get("diffusion_attention_config") is not None
-                    or kwargs.get("diffusion_attention_backend") is not None
-                ):
-                    has_stage_attention = (
-                        hasattr(cfg.engine_args, "diffusion_attention_config")
-                        and cfg.engine_args.diffusion_attention_config is not None
-                    )
-                    if not has_stage_attention:
-                        cfg.engine_args.diffusion_attention_config = parse_attention_config(
-                            kwargs.get("diffusion_attention_config"),
-                            attention_backend=kwargs.get("diffusion_attention_backend"),
-                        )
-                quantization_config = kwargs.get("diffusion_quantization_config") or kwargs.get("quantization_config")
-                if quantization_config is not None:
-                    if (
-                        not hasattr(cfg.engine_args, "quantization_config")
-                        or cfg.engine_args.quantization_config is None
-                    ):
-                        cfg.engine_args.quantization_config = quantization_config
-                # Inject profiler flags for diffusion stages
-                for profiler_key in (
-                    "enable_diffusion_pipeline_profiler",
-                    "enable_ar_profiler",
-                ):
-                    val = kwargs.get(profiler_key)
-                    if val:
-                        if not hasattr(cfg.engine_args, profiler_key) or not getattr(
-                            cfg.engine_args, profiler_key, False
-                        ):
-                            setattr(cfg.engine_args, profiler_key, val)
-                quantization = kwargs.get("quantization")
-                if quantization is not None:
-                    if not hasattr(cfg.engine_args, "quantization") or cfg.engine_args.quantization is None:
-                        cfg.engine_args.quantization = quantization
-                diffusion_kv_cache_dtype = kwargs.get("diffusion_kv_cache_dtype")
-                if diffusion_kv_cache_dtype is not None:
-                    if (
-                        not hasattr(cfg.engine_args, "diffusion_kv_cache_dtype")
-                        or cfg.engine_args.diffusion_kv_cache_dtype is None
-                    ):
-                        cfg.engine_args.diffusion_kv_cache_dtype = diffusion_kv_cache_dtype
-                diffusion_kv_cache_skip_steps = kwargs.get("diffusion_kv_cache_skip_steps")
-                if diffusion_kv_cache_skip_steps is not None:
-                    if (
-                        not hasattr(cfg.engine_args, "diffusion_kv_cache_skip_steps")
-                        or cfg.engine_args.diffusion_kv_cache_skip_steps is None
-                    ):
-                        cfg.engine_args.diffusion_kv_cache_skip_steps = diffusion_kv_cache_skip_steps
-                diffusion_kv_cache_skip_layers = kwargs.get("diffusion_kv_cache_skip_layers")
-                if diffusion_kv_cache_skip_layers is not None:
-                    if (
-                        not hasattr(cfg.engine_args, "diffusion_kv_cache_skip_layers")
-                        or cfg.engine_args.diffusion_kv_cache_skip_layers is None
-                    ):
-                        cfg.engine_args.diffusion_kv_cache_skip_layers = diffusion_kv_cache_skip_layers
-            except Exception as e:
-                logger.warning("Failed to inject LoRA config for stage: %s", e)
-
-        return config_path, stage_configs
+        self._apply_strategy_lb_policy(resolved.omni_lb_policy, kwargs)
+        return resolved.config_path, resolved.stage_configs
 
     # ==================== Public API ====================
 

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -26,7 +26,6 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 
 import janus
 import torch
-from omegaconf import OmegaConf
 from vllm import envs as vllm_envs
 from vllm.inputs import PromptType
 from vllm.logger import init_logger
@@ -82,13 +81,22 @@ from vllm_omni.engine.stage_runtime import (
 )
 from vllm_omni.entrypoints.pd_utils import PDDisaggregationMixin
 from vllm_omni.entrypoints.utils import (
-    load_and_resolve_stage_configs,
+    ResolvedStageConfigs,
+    load_and_resolve_stage_config_views,
     parse_stage_overrides,
+)
+from vllm_omni.entrypoints.utils import (
+    load_and_resolve_stage_configs as _legacy_stage_config_resolver,
 )
 from vllm_omni.inputs.data import OmniInteractionPrompt, OmniSamplingParams
 from vllm_omni.metrics.prometheus import OmniRequestCounter
 
 logger = init_logger(__name__)
+
+# Kept as a module-level compatibility symbol for downstream tests and
+# integrations that patched the pre-Phase-3 resolver. Runtime startup uses the
+# typed view resolver below.
+load_and_resolve_stage_configs = _legacy_stage_config_resolver
 
 if TYPE_CHECKING:
     from vllm_omni.experimental.fullduplex.engine.duplex_control_client import DuplexControlClient
@@ -123,6 +131,7 @@ class AsyncOmniEngine:
     _enable_orch_monitor: bool = False
     # Lazily created by get_output_blocking_async().
     _output_drain_executor: concurrent.futures.ThreadPoolExecutor | None = None
+    vllm_omni_config: Any = None
 
     def __init__(
         self,
@@ -140,6 +149,12 @@ class AsyncOmniEngine:
     ) -> None:
         self.model = model
         self.tokenizer = tokenizer
+        # Keep the caller-selected model revision available at the public
+        # metadata boundary.  The typed resolver normally carries this value
+        # on the diffusion stage, but unregistered-model fallback and clients
+        # that query metadata before stage startup still need the original
+        # revision for class discovery.
+        self._model_revision = kwargs.get("revision")
         self.diffusion_batch_size = diffusion_batch_size
         # Cached by get_diffusion_od_config().
         self._diffusion_od_config_view: Any = None
@@ -194,19 +209,20 @@ class AsyncOmniEngine:
                 self._omni_master_port,
             )
 
-        # Stage resolution pops deploy_config, so get pipeline-wide settings beforehand.
+        # Resolve pipeline-wide metadata before stage resolution.  The typed
+        # resolver normally supplies the same values, but this early lookup is
+        # intentionally retained as a compatibility/fallback boundary for
+        # callers that override or mock stage resolution (and for deploy files
+        # that contain no registered stage pipeline).
         deploy_config_path = kwargs.get("deploy_config")
-        # ``trust_remote_code`` is tri-state (bool | None): ``None`` means "not
-        # specified" so stage-config resolution can defer to the deploy yaml's
-        # per-stage value (see ``with_trust_remote_code_override``). The
-        # restriction path below loads the top-level HF config via vLLM's
-        # ``get_config``, which needs a real bool, so collapse ``None`` to the
-        # default ``False`` here (#5495).
-        pipeline_config = StageConfigFactory.get_pipeline_config(
-            model=model,
-            trust_remote_code=bool(trust_remote_code),
-            deploy_config_path=deploy_config_path,
-        )
+        pipeline_lookup_kwargs = {
+            "model": model,
+            "trust_remote_code": bool(trust_remote_code),
+            "deploy_config_path": deploy_config_path,
+        }
+        if kwargs.get("revision") is not None:
+            pipeline_lookup_kwargs["revision"] = kwargs["revision"]
+        pipeline_config = StageConfigFactory.get_pipeline_config(**pipeline_lookup_kwargs)
         self.endpoint_restrictions = pipeline_config.endpoint_restrictions if pipeline_config is not None else ()
         self._duplex_runtime_extension_path = (
             pipeline_config.duplex_runtime_extension if pipeline_config is not None else None
@@ -217,7 +233,22 @@ class AsyncOmniEngine:
         self._duplex_control_enabled = bool(pipeline_config and pipeline_config.duplex_control_enabled)
         self.duplex_session_config = DuplexSessionRuntimeConfig()
         if deploy_config_path is not None:
-            self.duplex_session_config = load_deploy_config(deploy_config_path).duplex_session
+            # This is an early compatibility read used for endpoint/session
+            # metadata. Reuse the factory's bare-name lookup (``deploy/foo``)
+            # and let the canonical resolver remain the source of truth. A
+            # missing path is intentionally deferred so patched resolvers and
+            # the eventual typed resolution can decide how to handle it.
+            try:
+                # Keep the legacy module-level hook for integrations that
+                # patch it, then fall back to the factory's bare-name lookup.
+                early_deploy_config = load_deploy_config(deploy_config_path)
+            except FileNotFoundError:
+                try:
+                    early_deploy_config = StageConfigFactory._load_user_deploy_config(deploy_config_path)
+                except FileNotFoundError:
+                    early_deploy_config = None
+            if early_deploy_config is not None:
+                self.duplex_session_config = early_deploy_config.duplex_session
 
         # Tri-state: None means "not specified" — the deploy yaml's per-stage
         # trust_remote_code stays in effect. An explicit True/False here is a
@@ -229,6 +260,26 @@ class AsyncOmniEngine:
             kwargs,
             trust_remote_code=trust_remote_code,
         )
+
+        resolved = getattr(self, "_resolved_stage_configs", None)
+        resolved_pipeline_config = (
+            resolved.omni_config.pipeline_config if resolved is not None and resolved.omni_config is not None else None
+        )
+        if resolved_pipeline_config is not None:
+            pipeline_config = resolved_pipeline_config
+            self.endpoint_restrictions = pipeline_config.endpoint_restrictions
+        self._duplex_runtime_extension_path = (
+            pipeline_config.duplex_runtime_extension
+            if pipeline_config is not None
+            else self._duplex_runtime_extension_path
+        )
+        self.duplex_serving_adapter_path = (
+            pipeline_config.duplex_serving_adapter if pipeline_config is not None else self.duplex_serving_adapter_path
+        )
+        if pipeline_config is not None:
+            self._duplex_control_enabled = bool(pipeline_config.duplex_control_enabled)
+        if resolved is not None and resolved.deploy_config is not None:
+            self.duplex_session_config = resolved.deploy_config.duplex_session
 
         self.num_stages = len(self.stage_configs)
         stage0_args = getattr(self.stage_configs[0], "engine_args", None) if self.num_stages > 0 else None
@@ -293,19 +344,42 @@ class AsyncOmniEngine:
     def get_diffusion_od_config(self) -> Any:
         """Expose the diffusion ``model_class_name`` to client-side model-extras.
 
-        The worker holds the full config; here we just resolve the pipeline class
-        name from the model config (cached). ``model_class_name`` may be ``None``.
+        The worker holds the full config.  Reuse the already-resolved typed
+        diffusion stage when available so registry selection and the worker
+        cannot disagree (especially for revision-specific Hub files).  The
+        read-only fallback is retained for mocked/unregistered engines.
         """
-        if self._diffusion_od_config_view is None:
+        if getattr(self, "_diffusion_od_config_view", None) is None:
             from types import SimpleNamespace
 
             from vllm_omni.diffusion.data import resolve_model_class_name
             from vllm_omni.diffusion.model_metadata import get_diffusion_model_metadata
 
-            model_class_name = resolve_model_class_name(self.model)
+            model_class_name = None
+            revision = getattr(self, "_model_revision", None)
+            # ``VllmOmniDiffusionStageConfig`` owns the canonical class name;
+            # avoid importing the concrete class here to keep this lightweight
+            # metadata API usable by tests and out-of-process clients.
+            omni_config = getattr(self, "vllm_omni_config", None)
+            for stage in getattr(omni_config, "stage_configs", ()):
+                diffusion_config = getattr(stage, "diffusion_config", None)
+                if diffusion_config is None:
+                    continue
+                model_class_name = getattr(diffusion_config, "model_class_name", None)
+                revision = getattr(diffusion_config, "revision", None) or revision
+                if model_class_name is not None:
+                    break
+
+            if model_class_name is None:
+                if revision is None:
+                    model_class_name = resolve_model_class_name(self.model)
+                else:
+                    model_class_name = resolve_model_class_name(self.model, revision=revision)
             metadata = get_diffusion_model_metadata(model_class_name)
             self._diffusion_od_config_view = SimpleNamespace(
+                model=self.model,
                 model_class_name=model_class_name,
+                revision=revision,
                 supports_multimodal_inputs=metadata.supports_multimodal_inputs,
                 max_multimodal_image_inputs=metadata.max_multimodal_image_inputs,
                 supports_mixed_reference_inputs=metadata.supports_mixed_reference_inputs,
@@ -314,8 +388,16 @@ class AsyncOmniEngine:
 
     def _initialize_stages(self, stage_init_timeout: int) -> None:
         """Initialize stage clients/processors via StageRuntime and assign to self."""
+        resolved = getattr(self, "_resolved_stage_configs", None)
+        typed_topology_stage_configs = (
+            resolved.typed_topology()
+            if isinstance(resolved, ResolvedStageConfigs)
+            else tuple(getattr(getattr(self, "vllm_omni_config", None), "stage_configs", ()))
+        )
         self._runtime = create_stage_runtime(
             stage_configs=self.stage_configs,
+            omni_config=self.vllm_omni_config,
+            typed_topology_stage_configs=typed_topology_stage_configs,
             model=self.model,
             config_path=self.config_path,
             single_stage_mode=self.single_stage_mode,
@@ -1025,7 +1107,13 @@ class AsyncOmniEngine:
                 default_sampling_params = None
         if not isinstance(default_sampling_params, dict):
             default_sampling_params = None
-        stage_default_sampling_params = default_sampling_params.get("0", {}) if default_sampling_params else {}
+        if default_sampling_params:
+            # The top-level CLI historically accepts a stage-indexed mapping,
+            # while ``--stage-overrides`` supplies the stage's sampling mapping
+            # directly.  Accept both forms at the fallback boundary.
+            stage_default_sampling_params = default_sampling_params.get("0", default_sampling_params)
+        else:
+            stage_default_sampling_params = {}
         if normalized_kwargs.get("dtype") is None:
             normalized_kwargs["dtype"] = "auto"
 
@@ -1091,10 +1179,21 @@ class AsyncOmniEngine:
         num_gpus = normalized_kwargs.get("num_gpus")
         if num_gpus is not None:
             num_gpus = int(num_gpus)
+            if num_gpus < 1:
+                raise ValueError(f"num_gpus must be >= 1, got {num_gpus}")
+            # The unregistered single-stage fallback has historically
+            # materialized its device layout before creating the legacy stage.
+            # Keep that behavior (including WORLD-derived DP) while the
+            # registered-pipeline typed path defers the same validation to the
+            # terminal OmniDiffusionConfig consumer.
             parallel_config.resolve_data_parallel_size(num_gpus)
 
         num_devices = max(1, int(parallel_config.world_size))
-        devices = ",".join(str(i) for i in range(num_devices))
+        devices = normalized_kwargs.get("devices")
+        if devices is None:
+            devices = ",".join(str(i) for i in range(num_devices))
+        elif isinstance(devices, (list, tuple)):
+            devices = ",".join(str(device) for device in devices)
         model_class_name = kwargs.get("model_class_name", None)
         final_output_type = get_diffusion_output_type(model_class_name)
 
@@ -1165,6 +1264,14 @@ class AsyncOmniEngine:
             "custom_pipeline_args": kwargs.get("custom_pipeline_args", None),
             "worker_extension_cls": kwargs.get("worker_extension_cls", None),
             "trust_remote_code": (False if kwargs.get("trust_remote_code") is None else kwargs["trust_remote_code"]),
+            # Keep the revision on the fallback stage as well as on the
+            # registered typed path.  Once a Hub id is resolved to a local
+            # snapshot, the diffusion consumer can no longer recover a
+            # caller-supplied revision, so dropping it here changes which
+            # checkpoint is loaded.
+            "revision": kwargs.get("revision"),
+            "tokenizer_revision": kwargs.get("tokenizer_revision"),
+            "code_revision": kwargs.get("code_revision"),
             "distributed_executor_backend": kwargs.get("distributed_executor_backend"),
             "enable_sleep_mode": kwargs.get("enable_sleep_mode", False),
             "enable_prompt_embed_cache": kwargs.get("enable_prompt_embed_cache", False),
@@ -1172,14 +1279,17 @@ class AsyncOmniEngine:
             "enable_multithread_weight_load": kwargs.get("enable_multithread_weight_load", True),
             "num_weight_load_threads": kwargs.get("num_weight_load_threads", 4),
             "quantization": kwargs.get("quantization", None),
-            "quantization_config": kwargs.get("quantization_config", None),
+            "quantization_config": kwargs.get("diffusion_quantization_config") or kwargs.get("quantization_config"),
             "diffusion_kv_cache_dtype": kwargs.get("diffusion_kv_cache_dtype", None),
             "diffusion_kv_cache_skip_steps": kwargs.get("diffusion_kv_cache_skip_steps", None),
             "diffusion_kv_cache_skip_layers": kwargs.get("diffusion_kv_cache_skip_layers", None),
             **({"diffusion_attention_config": attention_config} if attention_config is not None else {}),
             "force_cutlass_fp8": bool(kwargs.get("force_cutlass_fp8", False)),
             "enable_diffusion_pipeline_profiler": kwargs.get("enable_diffusion_pipeline_profiler", False),
-            "streaming_output": kwargs.get("diffusion_streaming_output", False),
+            "streaming_output": kwargs.get(
+                "streaming_output",
+                kwargs.get("diffusion_streaming_output", False),
+            ),
             "enable_ar_profiler": kwargs.get("enable_ar_profiler", False),
             "extras": extras,
             **(
@@ -1204,14 +1314,19 @@ class AsyncOmniEngine:
         if kwargs.get("diffusers_call_kwargs") is not None:
             stage_engine_args["diffusers_call_kwargs"] = kwargs["diffusers_call_kwargs"]
 
+        runtime = {
+            "process": True,
+            "devices": devices,
+        }
+        for runtime_field in ("num_replicas", "env"):
+            if normalized_kwargs.get(runtime_field) is not None:
+                runtime[runtime_field] = normalized_kwargs[runtime_field]
+
         default_stage_cfg = [
             {
                 "stage_id": 0,
                 "stage_type": "diffusion",
-                "runtime": {
-                    "process": True,
-                    "devices": devices,
-                },
+                "runtime": runtime,
                 "engine_args": stage_engine_args,
                 "engine_input_source": [],
                 "default_sampling_params": stage_default_sampling_params,
@@ -1257,7 +1372,7 @@ class AsyncOmniEngine:
         kwargs: dict[str, Any],
         *,
         trust_remote_code: bool | None,
-    ) -> tuple[str, list[Any]]:
+    ) -> tuple[str | None, list[Any]]:
         """Resolve stage configs and inject defaults shared by orchestrator/headless."""
 
         for legacy_arg in ("stage_configs_path", "stage_configs"):
@@ -1272,35 +1387,75 @@ class AsyncOmniEngine:
         stage_overrides = parse_stage_overrides(stage_overrides_json)
 
         # Unregistered diffusion checkpoints use the single-stage fallback
-        # below instead of StageConfigFactory, so fold stage-0 model extras
-        # into the fallback's input as well.  Registered pipelines still get
-        # the complete override mapping through load_and_resolve_stage_configs.
-        default_stage_kwargs = kwargs
-        stage_zero_overrides = (stage_overrides or {}).get("0", {})
-        if "extras" in stage_zero_overrides:
-            override_extras = stage_zero_overrides["extras"]
-            if not isinstance(override_extras, Mapping):
+        # below instead of StageConfigFactory, so fold the complete stage-0
+        # override mapping into the fallback's input as well. Registered
+        # pipelines receive the same mapping through the factory below.
+        default_stage_kwargs = dict(kwargs)
+        stage_zero_overrides: dict[str, Any] = {}
+        if stage_overrides:
+            if not isinstance(stage_overrides, Mapping):
+                raise TypeError("--stage-overrides must be a mapping keyed by stage id")
+            # JSON produces string keys, while Python callers often use integer
+            # stage ids.  Merge both spellings deterministically, with the
+            # JSON-compatible string key taking precedence when both exist.
+            for stage_key in (0, "0"):
+                raw_overrides = stage_overrides.get(stage_key)
+                if raw_overrides is None:
+                    continue
+                if not isinstance(raw_overrides, Mapping):
+                    raise TypeError("stage 0 overrides must be a mapping")
+                stage_zero_overrides.update(raw_overrides)
+
+        if stage_zero_overrides:
+            default_stage_kwargs.update(stage_zero_overrides)
+            base_extras = kwargs.get("extras")
+            override_extras = stage_zero_overrides.get("extras")
+            if base_extras is not None and not isinstance(base_extras, Mapping):
+                raise TypeError("global extras must be a mapping")
+            if override_extras is not None and not isinstance(override_extras, Mapping):
                 raise TypeError("stage 0 extras must be a mapping")
-            default_stage_kwargs = {
-                **kwargs,
-                "extras": {
-                    **(kwargs.get("extras") or {}),
-                    **override_extras,
-                },
-            }
+            if base_extras is not None or override_extras is not None:
+                # Keep nested model-specific extras from the global API while
+                # allowing a stage override to replace only one leaf.
+                def merge_extras(base: Mapping[str, Any], overlay: Mapping[str, Any]) -> dict[str, Any]:
+                    merged = copy.deepcopy(dict(base))
+                    for key, value in overlay.items():
+                        old_value = merged.get(key)
+                        if isinstance(old_value, Mapping) and isinstance(value, Mapping):
+                            merged[key] = merge_extras(old_value, value)
+                        else:
+                            merged[key] = copy.deepcopy(value)
+                    return merged
+
+                default_stage_kwargs["extras"] = merge_extras(base_extras or {}, override_extras or {})
+
+            # The typed projection owns the canonical names.  Normalize the
+            # two legacy spellings here because the fallback bypasses the
+            # registered pipeline alias normalizer.
+            if "streaming_output" in stage_zero_overrides:
+                default_stage_kwargs["diffusion_streaming_output"] = stage_zero_overrides["streaming_output"]
+            if (
+                "diffusion_quantization_config" in stage_zero_overrides
+                and "quantization_config" not in stage_zero_overrides
+            ):
+                default_stage_kwargs["quantization_config"] = stage_zero_overrides["diffusion_quantization_config"]
 
         def create_default_stage_config() -> list:
             fallback_kwargs = dict(default_stage_kwargs)
             if not fallback_kwargs.get("model_class_name"):
-                model_class_name = resolve_model_class_name(
-                    model,
-                    fallback_kwargs.get("diffusion_load_format", "default"),
-                )
+                diffusion_load_format = fallback_kwargs.get("diffusion_load_format", "default")
+                resolve_kwargs: dict[str, Any] = {}
+                # Keep the historical two-argument call shape when no
+                # revision was supplied; integrations commonly monkeypatch
+                # this read-only helper with that signature.
+                if fallback_kwargs.get("revision") is not None:
+                    resolve_kwargs["revision"] = fallback_kwargs["revision"]
+                model_class_name = resolve_model_class_name(model, diffusion_load_format, **resolve_kwargs)
                 if model_class_name is not None:
                     fallback_kwargs["model_class_name"] = model_class_name
             return self._create_default_diffusion_stage_cfg(fallback_kwargs)
 
-        config_path, stage_configs, strategy_lb_policy = load_and_resolve_stage_configs(
+        resolved: ResolvedStageConfigs = load_and_resolve_stage_config_views(
             model,
             kwargs,
             trust_remote_code=trust_remote_code,
@@ -1309,105 +1464,14 @@ class AsyncOmniEngine:
             stage_overrides=stage_overrides,
             strategy_config_path=strategy_config_path,
         )
+        self.vllm_omni_config = resolved.omni_config
+        self._resolved_stage_configs = resolved
 
         # A strategy.yaml may derive a pipeline-wide load-balancer policy. It is
         # an orchestrator-level knob (read once at construction), so apply it here
         # rather than as a per-stage config field.
-        self._apply_strategy_lb_policy(strategy_lb_policy, kwargs)
-
-        # Inject diffusion LoRA-related knobs from kwargs if not present in the stage config.
-        for cfg in stage_configs:
-            try:
-                if not hasattr(cfg, "engine_args") or cfg.engine_args is None:
-                    cfg.engine_args = OmegaConf.create({})
-                global_sleep_mode = kwargs.get("enable_sleep_mode")
-                if global_sleep_mode is not None:
-                    if not hasattr(cfg.engine_args, "enable_sleep_mode") or cfg.engine_args.enable_sleep_mode is None:
-                        cfg.engine_args.enable_sleep_mode = global_sleep_mode
-                if getattr(cfg, "stage_type", None) != "diffusion":
-                    continue
-                if not hasattr(cfg, "engine_args") or cfg.engine_args is None:
-                    cfg.engine_args = OmegaConf.create({})
-                additional_config = kwargs.get("additional_config")
-                if additional_config is not None:
-                    current_additional_config = getattr(cfg.engine_args, "additional_config", None)
-                    if current_additional_config in (None, {}):
-                        cfg.engine_args.additional_config = additional_config
-                if kwargs.get("lora_path") is not None:
-                    if not hasattr(cfg.engine_args, "lora_path") or cfg.engine_args.lora_path is None:
-                        cfg.engine_args.lora_path = kwargs["lora_path"]
-                lora_scale = kwargs.get("lora_scale")
-                if lora_scale is None:
-                    # Backwards compatibility for older callers.
-                    lora_scale = kwargs.get("static_lora_scale")
-                if lora_scale is not None:
-                    if not hasattr(cfg.engine_args, "lora_scale") or cfg.engine_args.lora_scale is None:
-                        cfg.engine_args.lora_scale = lora_scale
-                if kwargs.get("lora_backend") is not None:
-                    if not hasattr(cfg.engine_args, "lora_backend") or cfg.engine_args.lora_backend is None:
-                        cfg.engine_args.lora_backend = kwargs["lora_backend"]
-                if (
-                    kwargs.get("diffusion_attention_config") is not None
-                    or kwargs.get("diffusion_attention_backend") is not None
-                    or kwargs.get("fastvideo_vsa_topk") is not None
-                ):
-                    has_stage_attention = (
-                        hasattr(cfg.engine_args, "diffusion_attention_config")
-                        and cfg.engine_args.diffusion_attention_config is not None
-                    )
-                    if not has_stage_attention:
-                        cfg.engine_args.diffusion_attention_config = parse_attention_config(
-                            kwargs.get("diffusion_attention_config"),
-                            attention_backend=kwargs.get("diffusion_attention_backend"),
-                            fastvideo_vsa_topk=kwargs.get("fastvideo_vsa_topk"),
-                        )
-                quantization_config = kwargs.get("diffusion_quantization_config") or kwargs.get("quantization_config")
-                if quantization_config is not None:
-                    if (
-                        not hasattr(cfg.engine_args, "quantization_config")
-                        or cfg.engine_args.quantization_config is None
-                    ):
-                        cfg.engine_args.quantization_config = quantization_config
-                # Inject profiler flags for diffusion stages
-                for profiler_key in (
-                    "enable_diffusion_pipeline_profiler",
-                    "enable_ar_profiler",
-                ):
-                    val = kwargs.get(profiler_key)
-                    if val:
-                        if not hasattr(cfg.engine_args, profiler_key) or not getattr(
-                            cfg.engine_args, profiler_key, False
-                        ):
-                            setattr(cfg.engine_args, profiler_key, val)
-                quantization = kwargs.get("quantization")
-                if quantization is not None:
-                    if not hasattr(cfg.engine_args, "quantization") or cfg.engine_args.quantization is None:
-                        cfg.engine_args.quantization = quantization
-                diffusion_kv_cache_dtype = kwargs.get("diffusion_kv_cache_dtype")
-                if diffusion_kv_cache_dtype is not None:
-                    if (
-                        not hasattr(cfg.engine_args, "diffusion_kv_cache_dtype")
-                        or cfg.engine_args.diffusion_kv_cache_dtype is None
-                    ):
-                        cfg.engine_args.diffusion_kv_cache_dtype = diffusion_kv_cache_dtype
-                diffusion_kv_cache_skip_steps = kwargs.get("diffusion_kv_cache_skip_steps")
-                if diffusion_kv_cache_skip_steps is not None:
-                    if (
-                        not hasattr(cfg.engine_args, "diffusion_kv_cache_skip_steps")
-                        or cfg.engine_args.diffusion_kv_cache_skip_steps is None
-                    ):
-                        cfg.engine_args.diffusion_kv_cache_skip_steps = diffusion_kv_cache_skip_steps
-                diffusion_kv_cache_skip_layers = kwargs.get("diffusion_kv_cache_skip_layers")
-                if diffusion_kv_cache_skip_layers is not None:
-                    if (
-                        not hasattr(cfg.engine_args, "diffusion_kv_cache_skip_layers")
-                        or cfg.engine_args.diffusion_kv_cache_skip_layers is None
-                    ):
-                        cfg.engine_args.diffusion_kv_cache_skip_layers = diffusion_kv_cache_skip_layers
-            except Exception as e:
-                logger.warning("Failed to inject LoRA config for stage: %s", e)
-
-        return config_path, stage_configs
+        self._apply_strategy_lb_policy(resolved.omni_lb_policy, kwargs)
+        return resolved.config_path, resolved.stage_configs
 
     # ==================== Public API ====================
 

--- a/vllm_omni/engine/stage_engine_startup.py
+++ b/vllm_omni/engine/stage_engine_startup.py
@@ -7,7 +7,7 @@ import dataclasses
 import os
 import socket
 import threading
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass, field
 from multiprocessing import connection
 from types import SimpleNamespace
@@ -29,18 +29,28 @@ from vllm.v1.engine.utils import (
 )
 from vllm.v1.executor import Executor
 
+from vllm_omni.config.omni_config import (
+    BaseVllmOmniStageConfig,
+    VllmOmniDiffusionStageConfig,
+)
 from vllm_omni.distributed.omni_connectors.utils import initialization
 from vllm_omni.engine import stage_init_utils
 from vllm_omni.engine.stage_init_utils import (
     acquire_device_locks,
-    build_diffusion_config,
-    initialize_diffusion_stage,
+    build_diffusion_config_from_omni_stage_config,
+    initialize_diffusion_stage_from_omni_stage_config,
     release_device_locks,
 )
-from vllm_omni.entrypoints.utils import inject_omni_kv_config
+from vllm_omni.engine.stage_init_utils import (
+    build_diffusion_config as _legacy_build_diffusion_config,
+)
 from vllm_omni.platforms import current_omni_platform
 
 logger = init_logger(__name__)
+
+# Compatibility symbol for callers that imported the pre-Phase-3 builder.
+# Diffusion startup below intentionally uses the typed builder.
+build_diffusion_config = _legacy_build_diffusion_config
 
 StageRoute = tuple[int, int]
 
@@ -1307,7 +1317,7 @@ def launch_headless_diffusion_replica(
     *,
     model: str,
     od_config: Any,
-    stage_config: Any,
+    legacy_registration_config: Any,
     stage_id: int,
     omni_master_address: str,
     omni_master_port: int,
@@ -1322,7 +1332,7 @@ def launch_headless_diffusion_replica(
         omni_master_address=omni_master_address,
         omni_master_port=omni_master_port,
         omni_stage_id=stage_id,
-        omni_stage_config=stage_config,
+        omni_stage_config=legacy_registration_config,
         replica_id=None,
         replica_bind_address=replica_bind_address,
     )
@@ -1460,8 +1470,9 @@ def launch_headless_replica_group(
 def launch_headless_diffusion_replicas(
     *,
     model: str,
-    stage_cfg: Any,
-    stage_configs: list[Any],
+    stage_config: VllmOmniDiffusionStageConfig,
+    legacy_registration_config: Any,
+    stage_configs: list[BaseVllmOmniStageConfig] | tuple[BaseVllmOmniStageConfig, ...],
     stage_id: int,
     omni_master_address: str,
     omni_master_port: int,
@@ -1477,17 +1488,20 @@ def launch_headless_diffusion_replicas(
         stage_id,
     )
 
-    # Headless diffusion startup and its downstream helpers still consume the
-    # legacy StageConfig shape; switch this with the coordinated RFC #4021
-    # stage-init cutover.
-    metadata = stage_init_utils.extract_legacy_stage_metadata(stage_cfg)
-    if omni_conn_cfg:
-        inject_omni_kv_config(stage_cfg, omni_conn_cfg, omni_from, omni_to)
-    # Headless single-stage launch must still infer cross-stage TP topology
-    # from the loaded deploy config so heterogeneous KV routing keys match the
-    # head process (e.g. from_tp=2, to_tp=1).
-    stage_init_utils.inject_kv_stage_info(stage_cfg, stage_id, stage_configs)
-    od_config = stage_init_utils.build_diffusion_config(model, stage_cfg, metadata)
+    metadata = stage_init_utils.extract_stage_metadata_from_omni_stage_config(stage_config)
+    stage_connector_spec = stage_init_utils.get_stage_connector_spec(
+        omni_transfer_config=omni_transfer_config,
+        stage_id=stage_id,
+        async_chunk=stage_config.connector_config.async_chunk,
+    )
+    od_config = stage_init_utils.build_diffusion_config_from_omni_stage_config(
+        model,
+        stage_config,
+        metadata,
+        stage_connector_spec=stage_connector_spec,
+        omni_kv_connector=(omni_conn_cfg, omni_from, omni_to),
+        stage_configs=stage_configs,
+    )
 
     logger.info(
         "[Headless] Launching %d diffusion replica(s) for stage %d via OmniMasterServer at %s:%d",
@@ -1508,7 +1522,7 @@ def launch_headless_diffusion_replicas(
         return launch_headless_diffusion_replica(
             model=model,
             od_config=od_config,
-            stage_config=stage_cfg,
+            legacy_registration_config=legacy_registration_config,
             stage_id=stage_id,
             omni_master_address=omni_master_address,
             omni_master_port=omni_master_port,
@@ -1527,8 +1541,12 @@ def launch_headless_diffusion_replicas(
 def launch_diffusion_stage_replica(
     *,
     model: str,
-    stage_config: Any,
+    stage_config: VllmOmniDiffusionStageConfig,
+    legacy_registration_config: Any,
     metadata: Any,
+    stage_connector_spec: dict[str, Any] | None,
+    omni_kv_connector: tuple[dict[str, Any] | None, str | None, str | None],
+    stage_configs: Sequence[BaseVllmOmniStageConfig],
     stage_init_timeout: int,
     batch_size: int,
     use_inline: bool,
@@ -1538,26 +1556,35 @@ def launch_diffusion_stage_replica(
 ) -> tuple[Any, StageReplicaResources]:
     """Launch a local diffusion stage replica.
 
-    Colocated mode delegates to ``initialize_diffusion_stage``. Distributed
+    Colocated mode delegates to typed diffusion initialization. Distributed
     local mode registers with ``OmniMasterServer`` and spawns a
     ``StageDiffusionProc`` that heartbeats to ``OmniCoordinator``.
     """
     if omni_master_server is None:
-        client = initialize_diffusion_stage(
-            metadata.stage_id,
+        client = initialize_diffusion_stage_from_omni_stage_config(
             model,
             stage_config,
             metadata,
             stage_init_timeout=stage_init_timeout,
             batch_size=batch_size,
             use_inline=use_inline,
+            stage_connector_spec=stage_connector_spec,
+            omni_kv_connector=omni_kv_connector,
+            stage_configs=stage_configs,
         )
         return client, StageReplicaResources()
 
     from vllm_omni.diffusion import stage_diffusion_proc
     from vllm_omni.diffusion.stage_diffusion_client import StageDiffusionClient
 
-    od_config = build_diffusion_config(model, stage_config, metadata)
+    od_config = build_diffusion_config_from_omni_stage_config(
+        model,
+        stage_config,
+        metadata,
+        stage_connector_spec=stage_connector_spec,
+        omni_kv_connector=omni_kv_connector,
+        stage_configs=stage_configs,
+    )
     od_config.max_num_seqs = batch_size
     parallel_config = getattr(od_config, "parallel_config", None)
     world_size = getattr(parallel_config, "world_size", 1)
@@ -1576,7 +1603,7 @@ def launch_diffusion_stage_replica(
             omni_master_address=omni_master_server.address,
             omni_master_port=omni_master_server.port,
             omni_stage_id=metadata.stage_id,
-            omni_stage_config=stage_config,
+            omni_stage_config=legacy_registration_config,
             replica_id=replica_id,
         )
         omni_master_server.release_route_port_reservations(

--- a/vllm_omni/engine/stage_engine_startup.py
+++ b/vllm_omni/engine/stage_engine_startup.py
@@ -10,7 +10,7 @@ import dataclasses
 import os
 import socket
 import threading
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass, field
 from multiprocessing import connection
 from types import SimpleNamespace
@@ -33,18 +33,28 @@ from vllm.v1.engine.utils import (
 )
 from vllm.v1.executor import Executor
 
+from vllm_omni.config.omni_config import (
+    BaseVllmOmniStageConfig,
+    VllmOmniDiffusionStageConfig,
+)
 from vllm_omni.distributed.omni_connectors.utils import initialization
 from vllm_omni.engine import stage_init_utils
 from vllm_omni.engine.stage_init_utils import (
     acquire_device_locks,
-    build_diffusion_config,
-    initialize_diffusion_stage,
+    build_diffusion_config_from_omni_stage_config,
+    initialize_diffusion_stage_from_omni_stage_config,
     release_device_locks,
 )
-from vllm_omni.entrypoints.utils import inject_omni_kv_config
+from vllm_omni.engine.stage_init_utils import (
+    build_diffusion_config as _legacy_build_diffusion_config,
+)
 from vllm_omni.platforms import current_omni_platform
 
 logger = init_logger(__name__)
+
+# Compatibility symbol for callers that imported the pre-Phase-3 builder.
+# Diffusion startup below intentionally uses the typed builder.
+build_diffusion_config = _legacy_build_diffusion_config
 
 StageRoute = tuple[int, int]
 
@@ -1323,7 +1333,10 @@ def launch_headless_diffusion_replica(
     *,
     model: str,
     od_config: Any,
-    stage_config: Any,
+    legacy_registration_config: Any | None = None,
+    # Keep accepting the pre-PR9 keyword while the registration protocol still
+    # carries the compatibility StageConfig payload.
+    stage_config: Any | None = None,
     stage_id: int,
     omni_master_address: str,
     omni_master_port: int,
@@ -1334,11 +1347,16 @@ def launch_headless_diffusion_replica(
     Headless diffusion follows the LLM remote-attach model: the head binds
     handshake/input/output sockets, while this backend process only connects.
     """
+    if legacy_registration_config is None:
+        legacy_registration_config = stage_config
+    if legacy_registration_config is None:
+        raise TypeError("headless diffusion registration requires a legacy stage config payload")
+
     response = register_stage_with_omni_master(
         omni_master_address=omni_master_address,
         omni_master_port=omni_master_port,
         omni_stage_id=stage_id,
-        omni_stage_config=stage_config,
+        omni_stage_config=legacy_registration_config,
         replica_id=None,
         replica_bind_address=replica_bind_address,
     )
@@ -1476,8 +1494,12 @@ def launch_headless_replica_group(
 def launch_headless_diffusion_replicas(
     *,
     model: str,
-    stage_cfg: Any,
-    stage_configs: list[Any],
+    stage_config: VllmOmniDiffusionStageConfig | None = None,
+    legacy_registration_config: Any | None = None,
+    # ``stage_cfg`` was the old name for the registration payload. It remains
+    # an input alias, but the actual diffusion consumer must be typed.
+    stage_cfg: Any | None = None,
+    stage_configs: list[BaseVllmOmniStageConfig] | tuple[BaseVllmOmniStageConfig, ...] = (),
     stage_id: int,
     omni_master_address: str,
     omni_master_port: int,
@@ -1487,23 +1509,45 @@ def launch_headless_diffusion_replicas(
     replica_bind_address: str | None = None,
 ) -> None:
     """Prepare diffusion config, launch replicas, monitor, and clean up."""
-    omni_transfer_config = stage_init_utils.load_omni_transfer_config_for_model(model, config_path)
+    if stage_config is None and isinstance(stage_cfg, VllmOmniDiffusionStageConfig):
+        stage_config = stage_cfg
+    if legacy_registration_config is None:
+        legacy_registration_config = stage_cfg
+    if legacy_registration_config is None:
+        legacy_registration_config = stage_config
+    if not isinstance(stage_config, VllmOmniDiffusionStageConfig):
+        raise TypeError("headless diffusion startup requires VllmOmniDiffusionStageConfig")
+    if legacy_registration_config is None:
+        raise TypeError("headless diffusion registration requires a legacy stage config payload")
+
+    revision = getattr(getattr(stage_config, "diffusion_config", None), "revision", None)
+    if revision is None:
+        omni_transfer_config = stage_init_utils.load_omni_transfer_config_for_model(model, config_path)
+    else:
+        omni_transfer_config = stage_init_utils.load_omni_transfer_config_for_model(
+            model,
+            config_path,
+            revision=revision,
+        )
     omni_conn_cfg, omni_from, omni_to = initialization.resolve_omni_kv_config_for_stage(
         omni_transfer_config,
         stage_id,
     )
 
-    # Headless diffusion startup and its downstream helpers still consume the
-    # legacy StageConfig shape; switch this with the coordinated RFC #4021
-    # stage-init cutover.
-    metadata = stage_init_utils.extract_legacy_stage_metadata(stage_cfg)
-    if omni_conn_cfg:
-        inject_omni_kv_config(stage_cfg, omni_conn_cfg, omni_from, omni_to)
-    # Headless single-stage launch must still infer cross-stage TP topology
-    # from the loaded deploy config so heterogeneous KV routing keys match the
-    # head process (e.g. from_tp=2, to_tp=1).
-    stage_init_utils.inject_kv_stage_info(stage_cfg, stage_id, stage_configs)
-    od_config = stage_init_utils.build_diffusion_config(model, stage_cfg, metadata)
+    metadata = stage_init_utils.extract_stage_metadata_from_omni_stage_config(stage_config)
+    stage_connector_spec = stage_init_utils.get_stage_connector_spec(
+        omni_transfer_config=omni_transfer_config,
+        stage_id=stage_id,
+        async_chunk=stage_config.connector_config.async_chunk,
+    )
+    od_config = stage_init_utils.build_diffusion_config_from_omni_stage_config(
+        model,
+        stage_config,
+        metadata,
+        stage_connector_spec=stage_connector_spec,
+        omni_kv_connector=(omni_conn_cfg, omni_from, omni_to),
+        stage_configs=stage_configs,
+    )
 
     logger.info(
         "[Headless] Launching %d diffusion replica(s) for stage %d via OmniMasterServer at %s:%d",
@@ -1524,7 +1568,7 @@ def launch_headless_diffusion_replicas(
         return launch_headless_diffusion_replica(
             model=model,
             od_config=od_config,
-            stage_config=stage_cfg,
+            legacy_registration_config=legacy_registration_config,
             stage_id=stage_id,
             omni_master_address=omni_master_address,
             omni_master_port=omni_master_port,
@@ -1543,8 +1587,12 @@ def launch_headless_diffusion_replicas(
 def launch_diffusion_stage_replica(
     *,
     model: str,
-    stage_config: Any,
+    stage_config: VllmOmniDiffusionStageConfig,
+    legacy_registration_config: Any,
     metadata: Any,
+    stage_connector_spec: dict[str, Any] | None,
+    omni_kv_connector: tuple[dict[str, Any] | None, str | None, str | None],
+    stage_configs: Sequence[BaseVllmOmniStageConfig],
     stage_init_timeout: int,
     batch_size: int,
     use_inline: bool,
@@ -1554,26 +1602,35 @@ def launch_diffusion_stage_replica(
 ) -> tuple[Any, StageReplicaResources]:
     """Launch a local diffusion stage replica.
 
-    Colocated mode delegates to ``initialize_diffusion_stage``. Distributed
+    Colocated mode delegates to typed diffusion initialization. Distributed
     local mode registers with ``OmniMasterServer`` and spawns a
     ``StageDiffusionProc`` that heartbeats to ``OmniCoordinator``.
     """
     if omni_master_server is None:
-        client = initialize_diffusion_stage(
-            metadata.stage_id,
+        client = initialize_diffusion_stage_from_omni_stage_config(
             model,
             stage_config,
             metadata,
             stage_init_timeout=stage_init_timeout,
             batch_size=batch_size,
             use_inline=use_inline,
+            stage_connector_spec=stage_connector_spec,
+            omni_kv_connector=omni_kv_connector,
+            stage_configs=stage_configs,
         )
         return client, StageReplicaResources()
 
     from vllm_omni.diffusion import stage_diffusion_proc
     from vllm_omni.diffusion.stage_diffusion_client import StageDiffusionClient
 
-    od_config = build_diffusion_config(model, stage_config, metadata)
+    od_config = build_diffusion_config_from_omni_stage_config(
+        model,
+        stage_config,
+        metadata,
+        stage_connector_spec=stage_connector_spec,
+        omni_kv_connector=omni_kv_connector,
+        stage_configs=stage_configs,
+    )
     parallel_config = getattr(od_config, "parallel_config", None)
     world_size = getattr(parallel_config, "world_size", 1)
     try:
@@ -1591,7 +1648,7 @@ def launch_diffusion_stage_replica(
             omni_master_address=omni_master_server.address,
             omni_master_port=omni_master_server.port,
             omni_stage_id=metadata.stage_id,
-            omni_stage_config=stage_config,
+            omni_stage_config=legacy_registration_config,
             replica_id=replica_id,
         )
         omni_master_server.release_route_port_reservations(

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -68,6 +68,7 @@ class ReplicaInitPlan:
     stage_vllm_config: Any | None = None
     executor_class: type | None = None
     engine_args_dict: dict[str, Any] | None = None
+    omni_stage_config: BaseVllmOmniStageConfig | None = None
 
 
 @dataclass
@@ -199,6 +200,11 @@ def _tp_size_for_stage(stage_configs: Sequence[Any], stage_id: Any) -> int | Non
     for stage_cfg in stage_configs:
         if str(getattr(stage_cfg, "stage_id", None)) not in id_strs:
             continue
+        if isinstance(stage_cfg, BaseVllmOmniStageConfig):
+            try:
+                return max(1, int(stage_cfg.parallel_config.tensor_parallel_size))
+            except (TypeError, ValueError):
+                return 1
         engine_args = getattr(stage_cfg, "engine_args", None)
         if engine_args is None:
             return 1
@@ -323,19 +329,30 @@ def inject_omni_kv_connector_config(
     engine_args_dict: dict[str, Any],
     omni_kv_connector: tuple[dict[str, Any] | None, str | None, str | None],
     stage_id: int,
+    engine_input_source: Sequence[int] | None = None,
 ) -> None:
-    """Inject resolved connector config into a stage engine-args dict."""
+    """Inject resolved connector and stage identity into engine arguments.
+
+    The legacy stage-init path populated ``stage_id`` and
+    ``engine_input_source`` in a second mutation pass. Typed consumers build a
+    detached argument dictionary, so keep those identity fields in the same
+    helper and preserve existing user values with ``setdefault``.
+    """
     omni_conn_cfg, omni_from, omni_to = omni_kv_connector
-    if not omni_conn_cfg:
+    omni_kv = engine_args_dict.get("omni_kv_config")
+    if omni_kv is None and not omni_conn_cfg:
         return
 
-    omni_kv = engine_args_dict.get("omni_kv_config") or {}
+    omni_kv = omni_kv or {}
     if not isinstance(omni_kv, dict):
         omni_kv = dict(omni_kv)
-    omni_kv["connector_config"] = omni_conn_cfg
-    omni_kv["omni_from_stage"] = omni_from
-    omni_kv["omni_to_stage"] = omni_to
+    if omni_conn_cfg:
+        omni_kv["connector_config"] = omni_conn_cfg
+        omni_kv["omni_from_stage"] = omni_from
+        omni_kv["omni_to_stage"] = omni_to
     omni_kv.setdefault("stage_id", stage_id)
+    if engine_input_source is not None:
+        omni_kv.setdefault("engine_input_source", list(engine_input_source))
     engine_args_dict["omni_kv_config"] = omni_kv
 
 
@@ -491,12 +508,7 @@ def _resolve_omni_metadata_hook(path: str | None) -> Callable | None:
 def extract_stage_metadata_from_omni_stage_config(
     stage_config: BaseVllmOmniStageConfig,
 ) -> StageMetadata:
-    """Project one typed stage config into metadata for a future cutover.
-
-    This projection is not used by production startup yet. Current replica
-    layout, engine-argument, remote-diffusion, and platform setup paths still
-    require the legacy StageConfig/OmegaConf shape.
-    """
+    """Project one typed stage config into runtime metadata."""
     stage_type: Literal["llm", "diffusion"] = "diffusion" if stage_config.stage_type == StageType.DIFFUSION else "llm"
     sampling_params_cls = SamplingParams if stage_type == "llm" else OmniDiffusionSamplingParams
     sampling_params: OmniSamplingParams = sampling_params_cls(
@@ -607,7 +619,6 @@ def split_devices_for_replicas(
         # ``get_headless_replica_devices``. Returning a single-element list here
         # made callers index past the end for every replica after the first.
         return [None] * max(1, num_replicas)
-
     if num_replicas <= 1:
         return [devices_str]
 
@@ -649,6 +660,10 @@ def get_stage_devices_per_replica(stage_cfg: Any) -> int:
     """Return the number of devices consumed by one replica of *stage_cfg*."""
     engine_args = getattr(stage_cfg, "engine_args", {})
     if getattr(stage_cfg, "stage_type", "llm") == "diffusion":
+        num_gpus = _get_attr_or_item(engine_args, "num_gpus")
+        if num_gpus is not None:
+            return max(1, int(num_gpus))
+
         parallel_config = _get_attr_or_item(engine_args, "parallel_config")
         if parallel_config is None:
             return 1
@@ -671,7 +686,7 @@ def compute_replica_layout(
     stage_configs: Sequence[Any],
     *,
     allow_zero: bool = False,
-) -> tuple[list[int], dict[int, list[str]]]:
+) -> tuple[list[int], dict[int, list[str | None]]]:
     """Compute per-stage replica counts and device assignments.
 
     Args:
@@ -849,7 +864,7 @@ def _project_omni_stage_engine_args(
         ),
         (
             stage_config.runtime_config,
-            frozenset({"devices", "num_replicas", "env", "num_gpus"}),
+            frozenset({"devices", "num_replicas", "env"}) | (frozenset() if is_diffusion else frozenset({"num_gpus"})),
         ),
     ):
         engine_args.update(
@@ -903,10 +918,14 @@ def _project_omni_stage_engine_args(
         engine_args["omni_kv_config"] = copy.deepcopy(connector_config.omni_kv_config)
 
     if is_diffusion:
+        parallel_excludes = {"world_size"}
+        explicit_parallel_fields = getattr(stage_config.parallel_config, "_omni_explicit_fields", frozenset())
+        if "data_parallel_size" not in explicit_parallel_fields:
+            parallel_excludes.add("data_parallel_size")
         engine_args["parallel_config"] = _project_omni_config_fields(
             stage_config.parallel_config,
             field_map={name: name for name in _DIFFUSION_PARALLEL_CONFIG_ENGINE_FIELDS},
-            exclude=frozenset({"world_size"}),
+            exclude=frozenset(parallel_excludes),
         )
     else:
         engine_args.update(
@@ -1091,13 +1110,7 @@ def build_engine_args_dict_from_omni_stage_config(
     stage_connector_spec: dict[str, Any] | None = None,
     cli_tokenizer: str | None = None,
 ) -> dict[str, Any]:
-    """Project one typed stage config into backend engine arguments.
-
-    This projection is prepared for the RFC #4021 stage-init cutover. Current
-    production startup reaches the legacy implementation through
-    ``build_engine_args_dict`` while strategy and startup-plan inputs still
-    use the legacy representation.
-    """
+    """Project one typed stage config into backend engine arguments."""
     engine_args_dict = _project_omni_stage_engine_args(stage_config)
     _apply_rocm_attention_backend(engine_args_dict, stage_config.stage_type)
     return _finalize_engine_args_dict(
@@ -1465,12 +1478,85 @@ def build_diffusion_config(
     stage_cfg: Any,
     metadata: StageMetadata,
 ) -> Any:
-    """Build diffusion config for a stage."""
+    """Build diffusion config from the legacy compatibility representation."""
 
     engine_args_dict = build_engine_args_dict(stage_cfg, model)
     od_config = OmniDiffusionConfig.from_kwargs(**engine_args_dict)
 
-    num_devices_per_stage = od_config.parallel_config.world_size
+    _validate_diffusion_device_capacity(od_config, metadata.stage_id)
+    # Preserve the legacy adapter's terminal device projection. The typed
+    # Phase-3 builder intentionally leaves an explicit ``num_gpus`` untouched,
+    # but callers that still use this compatibility entry point expect the
+    # resolved parallel world size to become the terminal GPU count.
+    od_config.num_gpus = int(od_config.parallel_config.world_size)
+    if metadata.cfg_kv_collect_func is not None:
+        od_config.cfg_kv_collect_func = metadata.cfg_kv_collect_func
+    return od_config
+
+
+def build_diffusion_engine_args_from_omni_stage_config(
+    stage_config: VllmOmniDiffusionStageConfig,
+    model: str,
+    *,
+    stage_connector_spec: dict[str, Any] | None = None,
+    omni_kv_connector: tuple[dict[str, Any] | None, str | None, str | None] = (None, None, None),
+    stage_configs: Sequence[BaseVllmOmniStageConfig] = (),
+) -> dict[str, Any]:
+    """Build and enrich detached diffusion engine args from the typed stage."""
+    if not isinstance(stage_config, VllmOmniDiffusionStageConfig):
+        raise TypeError(f"Diffusion startup requires VllmOmniDiffusionStageConfig, got {type(stage_config).__name__}")
+
+    engine_args_dict = build_engine_args_dict_from_omni_stage_config(
+        stage_config,
+        model,
+        stage_connector_spec=stage_connector_spec,
+    )
+    inject_omni_kv_connector_config(
+        engine_args_dict,
+        omni_kv_connector,
+        stage_config.stage_id,
+        engine_input_source=stage_config.input_sources,
+    )
+    _inject_inferred_kv_tp_topology(
+        engine_args_dict.get("omni_kv_config"),
+        stage_id=stage_config.stage_id,
+        stage_configs=stage_configs,
+        engine_input_source=stage_config.input_sources,
+    )
+    return engine_args_dict
+
+
+def build_diffusion_config_from_omni_stage_config(
+    model: str,
+    stage_config: VllmOmniDiffusionStageConfig,
+    metadata: StageMetadata,
+    *,
+    stage_connector_spec: dict[str, Any] | None = None,
+    omni_kv_connector: tuple[dict[str, Any] | None, str | None, str | None] = (None, None, None),
+    stage_configs: Sequence[BaseVllmOmniStageConfig] = (),
+) -> OmniDiffusionConfig:
+    """Materialize the terminal diffusion config from one typed stage."""
+    engine_args_dict = build_diffusion_engine_args_from_omni_stage_config(
+        stage_config,
+        model,
+        stage_connector_spec=stage_connector_spec,
+        omni_kv_connector=omni_kv_connector,
+        stage_configs=stage_configs,
+    )
+    od_config = OmniDiffusionConfig.from_kwargs(**engine_args_dict)
+    _validate_diffusion_device_capacity(od_config, metadata.stage_id)
+    if metadata.cfg_kv_collect_func is not None:
+        od_config.cfg_kv_collect_func = metadata.cfg_kv_collect_func
+    return od_config
+
+
+def _validate_diffusion_device_capacity(
+    od_config: OmniDiffusionConfig,
+    stage_id: int,
+) -> None:
+    """Validate device availability without rewriting terminal topology."""
+    num_devices_per_stage = int(od_config.num_gpus or od_config.parallel_config.world_size)
+
     device_control_env = current_omni_platform.device_control_env_var
     visible_devices_str = os.environ.get(device_control_env) if device_control_env else None
     if visible_devices_str:
@@ -1480,14 +1566,9 @@ def build_diffusion_config(
 
     if len(physical_devices) < num_devices_per_stage:
         raise ValueError(
-            f"Stage {metadata.stage_id} requires {num_devices_per_stage} device(s) based on parallel_config, "
+            f"Stage {stage_id} requires {num_devices_per_stage} device(s) based on parallel_config, "
             f"but {len(physical_devices)} device(s) are available: {physical_devices}"
         )
-
-    od_config.num_gpus = num_devices_per_stage
-    if metadata.cfg_kv_collect_func is not None:
-        od_config.cfg_kv_collect_func = metadata.cfg_kv_collect_func
-    return od_config
 
 
 def initialize_diffusion_stage(
@@ -1514,6 +1595,33 @@ def initialize_diffusion_stage(
     from vllm_omni.diffusion.stage_diffusion_client import create_diffusion_client
 
     od_config = build_diffusion_config(model, stage_cfg, metadata)
+    od_config.max_num_seqs = batch_size
+    return create_diffusion_client(model, od_config, metadata, stage_init_timeout, batch_size, use_inline)
+
+
+def initialize_diffusion_stage_from_omni_stage_config(
+    model: str,
+    stage_config: VllmOmniDiffusionStageConfig,
+    metadata: StageMetadata,
+    stage_init_timeout: int,
+    *,
+    batch_size: int = 1,
+    use_inline: bool = False,
+    stage_connector_spec: dict[str, Any] | None = None,
+    omni_kv_connector: tuple[dict[str, Any] | None, str | None, str | None] = (None, None, None),
+    stage_configs: Sequence[BaseVllmOmniStageConfig] = (),
+) -> Any:
+    """Build a diffusion client from the typed stage representation."""
+    from vllm_omni.diffusion.stage_diffusion_client import create_diffusion_client
+
+    od_config = build_diffusion_config_from_omni_stage_config(
+        model,
+        stage_config,
+        metadata,
+        stage_connector_spec=stage_connector_spec,
+        omni_kv_connector=omni_kv_connector,
+        stage_configs=stage_configs,
+    )
     od_config.max_num_seqs = batch_size
     return create_diffusion_client(model, od_config, metadata, stage_init_timeout, batch_size, use_inline)
 

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -76,6 +76,7 @@ class ReplicaInitPlan:
     stage_vllm_config: Any | None = None
     executor_class: type | None = None
     engine_args_dict: dict[str, Any] | None = None
+    omni_stage_config: BaseVllmOmniStageConfig | None = None
 
 
 @dataclass
@@ -398,6 +399,11 @@ def _tp_size_for_stage(stage_configs: Sequence[Any], stage_id: Any) -> int | Non
     for stage_cfg in stage_configs:
         if str(getattr(stage_cfg, "stage_id", None)) not in id_strs:
             continue
+        if isinstance(stage_cfg, BaseVllmOmniStageConfig):
+            try:
+                return max(1, int(stage_cfg.parallel_config.tensor_parallel_size))
+            except (TypeError, ValueError):
+                return 1
         engine_args = getattr(stage_cfg, "engine_args", None)
         if engine_args is None:
             return 1
@@ -522,19 +528,30 @@ def inject_omni_kv_connector_config(
     engine_args_dict: dict[str, Any],
     omni_kv_connector: tuple[dict[str, Any] | None, str | None, str | None],
     stage_id: int,
+    engine_input_source: Sequence[int] | None = None,
 ) -> None:
-    """Inject resolved connector config into a stage engine-args dict."""
+    """Inject resolved connector and stage identity into engine arguments.
+
+    The legacy stage-init path populated ``stage_id`` and
+    ``engine_input_source`` in a second mutation pass. Typed consumers build a
+    detached argument dictionary, so keep those identity fields in the same
+    helper and preserve existing user values with ``setdefault``.
+    """
     omni_conn_cfg, omni_from, omni_to = omni_kv_connector
-    if not omni_conn_cfg:
+    omni_kv = engine_args_dict.get("omni_kv_config")
+    if omni_kv is None and not omni_conn_cfg:
         return
 
-    omni_kv = engine_args_dict.get("omni_kv_config") or {}
+    omni_kv = omni_kv or {}
     if not isinstance(omni_kv, dict):
         omni_kv = dict(omni_kv)
-    omni_kv["connector_config"] = omni_conn_cfg
-    omni_kv["omni_from_stage"] = omni_from
-    omni_kv["omni_to_stage"] = omni_to
+    if omni_conn_cfg:
+        omni_kv["connector_config"] = omni_conn_cfg
+        omni_kv["omni_from_stage"] = omni_from
+        omni_kv["omni_to_stage"] = omni_to
     omni_kv.setdefault("stage_id", stage_id)
+    if engine_input_source is not None:
+        omni_kv.setdefault("engine_input_source", list(engine_input_source))
     engine_args_dict["omni_kv_config"] = omni_kv
 
 
@@ -699,12 +716,7 @@ def _resolve_omni_metadata_hook(path: str | None) -> Callable | None:
 def extract_stage_metadata_from_omni_stage_config(
     stage_config: BaseVllmOmniStageConfig,
 ) -> StageMetadata:
-    """Project one typed stage config into metadata for a future cutover.
-
-    This projection is not used by production startup yet. Current replica
-    layout, engine-argument, remote-diffusion, and platform setup paths still
-    require the legacy StageConfig/OmegaConf shape.
-    """
+    """Project one typed stage config into runtime metadata."""
     stage_type: Literal["llm", "diffusion"] = "diffusion" if stage_config.stage_type == StageType.DIFFUSION else "llm"
     sampling_params_cls = SamplingParams if stage_type == "llm" else OmniDiffusionSamplingParams
     sampling_params: OmniSamplingParams = sampling_params_cls(
@@ -718,7 +730,11 @@ def extract_stage_metadata_from_omni_stage_config(
             stage_type="diffusion",
             engine_output_type=None,
             is_comprehension=False,
-            requires_multimodal_data=False,
+            # Diffusion stages such as HY3's DiT consume the original image
+            # payload alongside AR-produced tokens.  Preserve the topology
+            # declaration instead of assuming every diffusion stage is text
+            # only; the legacy extractor remains unchanged for compatibility.
+            requires_multimodal_data=stage_config.requires_multimodal_data,
             engine_input_source=stage_config.input_sources,
             final_output=stage_config.final_output,
             final_output_type=stage_config.final_output_type,
@@ -817,7 +833,6 @@ def split_devices_for_replicas(
         # ``get_headless_replica_devices``. Returning a single-element list here
         # made callers index past the end for every replica after the first.
         return [None] * max(1, num_replicas)
-
     if num_replicas <= 1:
         return [devices_str]
 
@@ -884,6 +899,10 @@ def get_stage_devices_per_replica(stage_cfg: Any, engine_args: Any | None = None
     if engine_args is None:
         engine_args = getattr(stage_cfg, "engine_args", {})
     if getattr(stage_cfg, "stage_type", "llm") == "diffusion":
+        num_gpus = _get_attr_or_item(engine_args, "num_gpus")
+        if num_gpus is not None:
+            return max(1, int(num_gpus))
+
         parallel_config = _get_attr_or_item(engine_args, "parallel_config")
         if parallel_config is None:
             return 1
@@ -966,7 +985,7 @@ def setup_stage_devices(stage_id: int, runtime_cfg: Any) -> None:
     """Device mapping via set_stage_devices for a single stage."""
     physical_devices = set_stage_devices(
         stage_id,
-        runtime_cfg.get("devices") if hasattr(runtime_cfg, "get") else None,
+        _get_attr_or_item(runtime_cfg, "devices"),
     )
     # Only log if we actually set the env vars in the stage
     if physical_devices:
@@ -1085,7 +1104,7 @@ def _project_omni_stage_engine_args(
         ),
         (
             stage_config.runtime_config,
-            frozenset({"devices", "num_replicas", "env", "num_gpus"}),
+            frozenset({"devices", "num_replicas", "env"}) | (frozenset() if is_diffusion else frozenset({"num_gpus"})),
         ),
     ):
         engine_args.update(
@@ -1140,10 +1159,14 @@ def _project_omni_stage_engine_args(
         engine_args["omni_kv_config"] = copy.deepcopy(connector_config.omni_kv_config)
 
     if is_diffusion:
+        parallel_excludes = {"world_size"}
+        explicit_parallel_fields = getattr(stage_config.parallel_config, "_omni_explicit_fields", frozenset())
+        if "data_parallel_size" not in explicit_parallel_fields:
+            parallel_excludes.add("data_parallel_size")
         engine_args["parallel_config"] = _project_omni_config_fields(
             stage_config.parallel_config,
             field_map={name: name for name in _DIFFUSION_PARALLEL_CONFIG_ENGINE_FIELDS},
-            exclude=frozenset({"world_size"}),
+            exclude=frozenset(parallel_excludes),
         )
     else:
         engine_args.update(
@@ -1329,13 +1352,7 @@ def build_engine_args_dict_from_omni_stage_config(
     stage_connector_spec: dict[str, Any] | None = None,
     cli_tokenizer: str | None = None,
 ) -> dict[str, Any]:
-    """Project one typed stage config into backend engine arguments.
-
-    This projection is prepared for the RFC #4021 stage-init cutover. Current
-    production startup reaches the legacy implementation through
-    ``build_engine_args_dict`` while strategy and startup-plan inputs still
-    use the legacy representation.
-    """
+    """Project one typed stage config into backend engine arguments."""
     engine_args_dict = _project_omni_stage_engine_args(stage_config)
     _apply_rocm_attention_backend(engine_args_dict, stage_config.stage_type)
     return _finalize_engine_args_dict(
@@ -1729,7 +1746,12 @@ def release_device_locks(lock_fds: list[int]) -> None:
             pass
 
 
-def load_omni_transfer_config_for_model(model: str, config_path: str | None) -> Any:
+def load_omni_transfer_config_for_model(
+    model: str,
+    config_path: str | None,
+    *,
+    revision: str | None = None,
+) -> Any:
     """Load omni transfer config from an explicit path or resolved model config.
 
     Resolves ``base_config`` inheritance (CI overlay → base deploy YAML) so
@@ -1739,7 +1761,14 @@ def load_omni_transfer_config_for_model(model: str, config_path: str | None) -> 
     from vllm_omni.distributed.omni_connectors import load_omni_transfer_config
 
     try:
-        resolved_config_path = config_path or resolve_model_config_path(model)
+        if config_path is not None:
+            resolved_config_path = config_path
+        elif revision is None:
+            # Preserve the historical call shape for integrations that patch
+            # the ancillary path resolver with a model-only signature.
+            resolved_config_path = resolve_model_config_path(model)
+        else:
+            resolved_config_path = resolve_model_config_path(model, revision=revision)
         if resolved_config_path is None:
             return None
         from vllm_omni.config.stage_config import resolve_deploy_yaml
@@ -1781,12 +1810,85 @@ def build_diffusion_config(
     stage_cfg: Any,
     metadata: StageMetadata,
 ) -> Any:
-    """Build diffusion config for a stage."""
+    """Build diffusion config from the legacy compatibility representation."""
 
     engine_args_dict = build_engine_args_dict(stage_cfg, model)
     od_config = OmniDiffusionConfig.from_kwargs(**engine_args_dict)
 
-    num_devices_per_stage = od_config.parallel_config.world_size
+    _validate_diffusion_device_capacity(od_config, metadata.stage_id)
+    # Preserve the legacy adapter's terminal device projection. The typed
+    # Phase-3 builder intentionally leaves an explicit ``num_gpus`` untouched,
+    # but callers that still use this compatibility entry point expect the
+    # resolved parallel world size to become the terminal GPU count.
+    od_config.num_gpus = int(od_config.parallel_config.world_size)
+    if metadata.cfg_kv_collect_func is not None:
+        od_config.cfg_kv_collect_func = metadata.cfg_kv_collect_func
+    return od_config
+
+
+def build_diffusion_engine_args_from_omni_stage_config(
+    stage_config: VllmOmniDiffusionStageConfig,
+    model: str,
+    *,
+    stage_connector_spec: dict[str, Any] | None = None,
+    omni_kv_connector: tuple[dict[str, Any] | None, str | None, str | None] = (None, None, None),
+    stage_configs: Sequence[BaseVllmOmniStageConfig] = (),
+) -> dict[str, Any]:
+    """Build and enrich detached diffusion engine args from the typed stage."""
+    if not isinstance(stage_config, VllmOmniDiffusionStageConfig):
+        raise TypeError(f"Diffusion startup requires VllmOmniDiffusionStageConfig, got {type(stage_config).__name__}")
+
+    engine_args_dict = build_engine_args_dict_from_omni_stage_config(
+        stage_config,
+        model,
+        stage_connector_spec=stage_connector_spec,
+    )
+    inject_omni_kv_connector_config(
+        engine_args_dict,
+        omni_kv_connector,
+        stage_config.stage_id,
+        engine_input_source=stage_config.input_sources,
+    )
+    _inject_inferred_kv_tp_topology(
+        engine_args_dict.get("omni_kv_config"),
+        stage_id=stage_config.stage_id,
+        stage_configs=stage_configs,
+        engine_input_source=stage_config.input_sources,
+    )
+    return engine_args_dict
+
+
+def build_diffusion_config_from_omni_stage_config(
+    model: str,
+    stage_config: VllmOmniDiffusionStageConfig,
+    metadata: StageMetadata,
+    *,
+    stage_connector_spec: dict[str, Any] | None = None,
+    omni_kv_connector: tuple[dict[str, Any] | None, str | None, str | None] = (None, None, None),
+    stage_configs: Sequence[BaseVllmOmniStageConfig] = (),
+) -> OmniDiffusionConfig:
+    """Materialize the terminal diffusion config from one typed stage."""
+    engine_args_dict = build_diffusion_engine_args_from_omni_stage_config(
+        stage_config,
+        model,
+        stage_connector_spec=stage_connector_spec,
+        omni_kv_connector=omni_kv_connector,
+        stage_configs=stage_configs,
+    )
+    od_config = OmniDiffusionConfig.from_kwargs(**engine_args_dict)
+    _validate_diffusion_device_capacity(od_config, metadata.stage_id)
+    if metadata.cfg_kv_collect_func is not None:
+        od_config.cfg_kv_collect_func = metadata.cfg_kv_collect_func
+    return od_config
+
+
+def _validate_diffusion_device_capacity(
+    od_config: OmniDiffusionConfig,
+    stage_id: int,
+) -> None:
+    """Validate device availability without rewriting terminal topology."""
+    num_devices_per_stage = int(od_config.num_gpus or od_config.parallel_config.world_size)
+
     device_control_env = current_omni_platform.device_control_env_var
     visible_devices_str = os.environ.get(device_control_env) if device_control_env else None
     physical_devices: list[str | int]
@@ -1797,14 +1899,9 @@ def build_diffusion_config(
 
     if len(physical_devices) < num_devices_per_stage:
         raise ValueError(
-            f"Stage {metadata.stage_id} requires {num_devices_per_stage} device(s) based on parallel_config, "
+            f"Stage {stage_id} requires {num_devices_per_stage} device(s) based on parallel_config, "
             f"but {len(physical_devices)} device(s) are available: {physical_devices}"
         )
-
-    od_config.num_gpus = num_devices_per_stage
-    if metadata.cfg_kv_collect_func is not None:
-        od_config.cfg_kv_collect_func = metadata.cfg_kv_collect_func
-    return od_config
 
 
 def initialize_diffusion_stage(
@@ -1831,6 +1928,32 @@ def initialize_diffusion_stage(
     from vllm_omni.diffusion.stage_diffusion_client import create_diffusion_client
 
     od_config = build_diffusion_config(model, stage_cfg, metadata)
+    return create_diffusion_client(model, od_config, metadata, stage_init_timeout, batch_size, use_inline)
+
+
+def initialize_diffusion_stage_from_omni_stage_config(
+    model: str,
+    stage_config: VllmOmniDiffusionStageConfig,
+    metadata: StageMetadata,
+    stage_init_timeout: int,
+    *,
+    batch_size: int = 1,
+    use_inline: bool = False,
+    stage_connector_spec: dict[str, Any] | None = None,
+    omni_kv_connector: tuple[dict[str, Any] | None, str | None, str | None] = (None, None, None),
+    stage_configs: Sequence[BaseVllmOmniStageConfig] = (),
+) -> Any:
+    """Build a diffusion client from the typed stage representation."""
+    from vllm_omni.diffusion.stage_diffusion_client import create_diffusion_client
+
+    od_config = build_diffusion_config_from_omni_stage_config(
+        model,
+        stage_config,
+        metadata,
+        stage_connector_spec=stage_connector_spec,
+        omni_kv_connector=omni_kv_connector,
+        stage_configs=stage_configs,
+    )
     return create_diffusion_client(model, od_config, metadata, stage_init_timeout, batch_size, use_inline)
 
 

--- a/vllm_omni/engine/stage_runtime.py
+++ b/vllm_omni/engine/stage_runtime.py
@@ -15,9 +15,14 @@ from dataclasses import dataclass
 from typing import Any
 
 import janus
-from omegaconf import OmegaConf
 from vllm.logger import init_logger
 
+from vllm_omni.config.omni_config import (
+    BaseVllmOmniStageConfig,
+    VllmOmniConfig,
+    VllmOmniDiffusionStageConfig,
+)
+from vllm_omni.config.stage_config import StageType
 from vllm_omni.distributed.omni_connectors.utils.initialization import (
     resolve_omni_kv_config_for_stage,
 )
@@ -52,21 +57,27 @@ from vllm_omni.engine.stage_init_utils import (
     build_vllm_config,
     compute_replica_layout,
     extract_legacy_stage_metadata,
+    extract_stage_metadata_from_omni_stage_config,
     get_stage_connector_spec,
-    inject_kv_stage_info,
     inject_omni_kv_connector_config,
     load_omni_transfer_config_for_model,
     prepare_engine_environment,
     release_device_locks,
     stage_runtime_env,
 )
+from vllm_omni.engine.stage_init_utils import (
+    inject_kv_stage_info as _legacy_inject_kv_stage_info,
+)
 from vllm_omni.engine.stage_pool import StagePool
 from vllm_omni.entrypoints.stage_utils import resolve_stage_physical_devices
-from vllm_omni.entrypoints.utils import inject_omni_kv_config
 from vllm_omni.outputs.output_metadata import FinalOutputModalityType
 from vllm_omni.platforms import current_omni_platform
 
 logger = init_logger(__name__)
+
+# Compatibility symbol for integrations that still patch the legacy diffusion
+# metadata mutator. Typed diffusion startup does not call this helper.
+inject_kv_stage_info = _legacy_inject_kv_stage_info
 
 
 @dataclass(frozen=True, slots=True)
@@ -123,6 +134,7 @@ class StageRuntime:
         model: str,
         config_path: str,
         *,
+        omni_config: VllmOmniConfig | None = None,
         stage_init_timeout: int,
         diffusion_batch_size: int,
         async_chunk: bool,
@@ -130,6 +142,8 @@ class StageRuntime:
         log_stats: bool = False,
     ) -> None:
         self._stage_configs = stage_configs
+        self._omni_config = omni_config
+        self._omni_stage_configs = tuple(omni_config.stage_configs) if omni_config is not None else ()
         self._model = model
         self._config_path = config_path
         self._stage_init_timeout = stage_init_timeout
@@ -342,12 +356,18 @@ class StageRuntime:
         """Build startup plans for every logical stage and replica."""
         stage_plans: list[LogicalStageInitPlan] = []
 
-        # RFC #4021 transition boundary: stage planning still relies on legacy
-        # StageConfig.runtime and StageConfig.engine_args for replica and engine
-        # setup. Keep metadata extraction on the legacy path until the
-        # coordinated stage-init cutover.
         for stage_idx, stage_cfg in enumerate(self._stage_configs):
-            base_metadata = extract_legacy_stage_metadata(stage_cfg)
+            legacy_stage_id = int(stage_cfg.stage_id)
+            omni_stage_config = None
+            if self._omni_config is not None:
+                omni_stage_config = self._omni_config.stage_by_id(legacy_stage_id)
+
+            if isinstance(omni_stage_config, VllmOmniDiffusionStageConfig):
+                base_metadata = extract_stage_metadata_from_omni_stage_config(omni_stage_config)
+            else:
+                if StageType(getattr(stage_cfg, "stage_type", StageType.LLM)) is StageType.DIFFUSION:
+                    raise TypeError(f"Diffusion stage {legacy_stage_id} has no typed VllmOmniDiffusionStageConfig")
+                base_metadata = extract_legacy_stage_metadata(stage_cfg)
             stage_id = int(base_metadata.stage_id)
             if stage_id != stage_idx:
                 raise ValueError(
@@ -356,6 +376,16 @@ class StageRuntime:
                     "Stage ids must be contiguous and zero-based because the "
                     "orchestrator indexes stage pools by stage_id."
                 )
+
+            if isinstance(omni_stage_config, BaseVllmOmniStageConfig) and not isinstance(
+                omni_stage_config,
+                VllmOmniDiffusionStageConfig,
+            ):
+                # PR9 keeps AR/generation consumers on the compatibility path,
+                # but the typed stage travels with every plan for PR8 parity.
+                typed_plan_config = copy.deepcopy(omni_stage_config)
+            else:
+                typed_plan_config = omni_stage_config
 
             stage_connector_spec = get_stage_connector_spec(
                 omni_transfer_config=omni_transfer_config,
@@ -399,10 +429,19 @@ class StageRuntime:
 
             for replica_id in range(num_replicas):
                 replica_cfg = copy.deepcopy(stage_cfg) if replica_id > 0 else stage_cfg
+                replica_omni_config = (
+                    copy.deepcopy(omni_stage_config) if isinstance(omni_stage_config, BaseVllmOmniStageConfig) else None
+                )
                 if stage_idx in replica_devices_map:
-                    replica_cfg.runtime.devices = replica_devices_map[stage_idx][replica_id]
+                    replica_devices = replica_devices_map[stage_idx][replica_id]
+                    replica_cfg.runtime.devices = replica_devices
+                    if replica_omni_config is not None:
+                        replica_omni_config.runtime_config.devices = replica_devices
 
-                replica_metadata = extract_legacy_stage_metadata(replica_cfg)
+                if isinstance(replica_omni_config, VllmOmniDiffusionStageConfig):
+                    replica_metadata = extract_stage_metadata_from_omni_stage_config(replica_omni_config)
+                else:
+                    replica_metadata = extract_legacy_stage_metadata(replica_cfg)
                 replica_metadata.replica_id = replica_id
                 if launch_mode == "remote" and replica_metadata.stage_type != "diffusion":
                     replica_metadata.runtime_cfg = None
@@ -415,6 +454,9 @@ class StageRuntime:
                         metadata=replica_metadata,
                         stage_connector_spec=stage_connector_spec,
                         omni_kv_connector=omni_kv_connector,
+                        omni_stage_config=(
+                            replica_omni_config if replica_omni_config is not None else typed_plan_config
+                        ),
                         stage_vllm_config=stage_vllm_config,
                         executor_class=executor_class,
                         engine_args_dict=copy.deepcopy(engine_args_dict) if engine_args_dict is not None else None,
@@ -650,14 +692,18 @@ class StageRuntime:
                 stage_runtime_env(plan.metadata.stage_id, plan.metadata.runtime_cfg),
                 self._stage_device_scope(plan.metadata.stage_id, plan.metadata.runtime_cfg),
             ):
-                omni_conn_cfg, omni_from, omni_to = plan.omni_kv_connector
-                if omni_conn_cfg:
-                    inject_omni_kv_config(plan.stage_cfg, omni_conn_cfg, omni_from, omni_to)
-                inject_kv_stage_info(plan.stage_cfg, plan.metadata.stage_id, self._stage_configs)
+                if not isinstance(plan.omni_stage_config, VllmOmniDiffusionStageConfig):
+                    raise TypeError(
+                        f"Stage {plan.metadata.stage_id} diffusion startup is missing its typed stage config"
+                    )
                 client, resources = launch_diffusion_stage_replica(
                     model=self._model,
-                    stage_config=plan.stage_cfg,
+                    stage_config=plan.omni_stage_config,
+                    legacy_registration_config=plan.stage_cfg,
                     metadata=plan.metadata,
+                    stage_connector_spec=plan.stage_connector_spec,
+                    omni_kv_connector=plan.omni_kv_connector,
+                    stage_configs=self._omni_stage_configs,
                     stage_init_timeout=stage_init_timeout,
                     batch_size=self._diffusion_batch_size,
                     use_inline=self._num_stages == 1 and plan.num_replicas == 1,
@@ -753,6 +799,7 @@ class DistStageRuntime(StageRuntime):
         model: str,
         config_path: str,
         *,
+        omni_config: VllmOmniConfig | None = None,
         stage_init_timeout: int,
         diffusion_batch_size: int,
         async_chunk: bool,
@@ -770,6 +817,7 @@ class DistStageRuntime(StageRuntime):
             stage_configs=stage_configs,
             model=model,
             config_path=config_path,
+            omni_config=omni_config,
             stage_init_timeout=stage_init_timeout,
             diffusion_batch_size=diffusion_batch_size,
             async_chunk=async_chunk,
@@ -822,12 +870,14 @@ class DistStageRuntime(StageRuntime):
                 except (AttributeError, TypeError):
                     if hasattr(runtime_cfg, "__setitem__"):
                         runtime_cfg["num_replicas"] = self._omni_dp_size_local
-                        continue
-                    logger.warning(
-                        "[DistStageRuntime] Failed to apply omni_dp_size_local=%s to stage %s runtime config",
-                        self._omni_dp_size_local,
-                        stage_id,
-                    )
+                    else:
+                        logger.warning(
+                            "[DistStageRuntime] Failed to apply omni_dp_size_local=%s to stage %s runtime config",
+                            self._omni_dp_size_local,
+                            stage_id,
+                        )
+                if self._omni_config is not None:
+                    self._omni_config.stage_by_id(stage_id).runtime_config.num_replicas = self._omni_dp_size_local
 
     def _before_initialize_stage_replicas(self, stage_plans: Sequence[LogicalStageInitPlan]) -> None:
         self._start_omni_master_server(stage_plans)
@@ -885,13 +935,9 @@ class DistStageRuntime(StageRuntime):
         if registered_stage_cfg is None:
             raise ValueError(f"Remote stage {plan.metadata.stage_id} registered without stage config")
 
-        # Remote diffusion registration still transports the legacy mapping
-        # shape. Reconstruct and project that shape until its RFC #4021 cutover.
-        metadata = (
-            extract_legacy_stage_metadata(OmegaConf.create(registered_stage_cfg))
-            if plan.metadata.stage_type == "diffusion"
-            else copy.deepcopy(plan.metadata)
-        )
+        # Registration transports a compatibility payload for the wire
+        # protocol. Runtime metadata always comes from the local startup plan.
+        metadata = copy.deepcopy(plan.metadata)
         metadata.replica_id = plan.replica_id
         ctx = StageRemoteFactoryContext(
             stage_id=plan.metadata.stage_id,
@@ -1093,6 +1139,7 @@ def create_stage_runtime(
     model: str,
     config_path: str,
     *,
+    omni_config: VllmOmniConfig | None = None,
     single_stage_mode: bool,
     stage_init_timeout: int,
     diffusion_batch_size: int,
@@ -1116,6 +1163,7 @@ def create_stage_runtime(
             stage_configs=stage_configs,
             model=model,
             config_path=config_path,
+            omni_config=omni_config,
             stage_init_timeout=stage_init_timeout,
             diffusion_batch_size=diffusion_batch_size,
             async_chunk=async_chunk,
@@ -1133,6 +1181,7 @@ def create_stage_runtime(
         stage_configs=stage_configs,
         model=model,
         config_path=config_path,
+        omni_config=omni_config,
         stage_init_timeout=stage_init_timeout,
         diffusion_batch_size=diffusion_batch_size,
         async_chunk=async_chunk,

--- a/vllm_omni/engine/stage_runtime.py
+++ b/vllm_omni/engine/stage_runtime.py
@@ -15,9 +15,14 @@ from dataclasses import dataclass
 from typing import Any, cast
 
 import janus
-from omegaconf import OmegaConf
 from vllm.logger import init_logger
 
+from vllm_omni.config.omni_config import (
+    BaseVllmOmniStageConfig,
+    VllmOmniConfig,
+    VllmOmniDiffusionStageConfig,
+)
+from vllm_omni.config.stage_config import StageType
 from vllm_omni.distributed.omni_connectors.utils.initialization import (
     resolve_omni_kv_config_for_stage,
 )
@@ -52,21 +57,27 @@ from vllm_omni.engine.stage_init_utils import (
     build_vllm_config,
     compute_replica_layout,
     extract_legacy_stage_metadata,
+    extract_stage_metadata_from_omni_stage_config,
     get_stage_connector_spec,
-    inject_kv_stage_info,
     inject_omni_kv_connector_config,
     load_omni_transfer_config_for_model,
     prepare_engine_environment,
     release_device_locks,
     stage_runtime_env,
 )
+from vllm_omni.engine.stage_init_utils import (
+    inject_kv_stage_info as _legacy_inject_kv_stage_info,
+)
 from vllm_omni.engine.stage_pool import StagePool
 from vllm_omni.entrypoints.stage_utils import resolve_stage_physical_devices
-from vllm_omni.entrypoints.utils import inject_omni_kv_config
 from vllm_omni.outputs.output_metadata import FinalOutputModalityType
 from vllm_omni.platforms import current_omni_platform
 
 logger = init_logger(__name__)
+
+# Compatibility symbol for integrations that still patch the legacy diffusion
+# metadata mutator. Typed diffusion startup does not call this helper.
+inject_kv_stage_info = _legacy_inject_kv_stage_info
 
 
 @dataclass(frozen=True, slots=True)
@@ -123,6 +134,8 @@ class StageRuntime:
         model: str,
         config_path: str,
         *,
+        omni_config: VllmOmniConfig | None = None,
+        typed_topology_stage_configs: Sequence[BaseVllmOmniStageConfig] = (),
         stage_init_timeout: int,
         diffusion_batch_size: int,
         async_chunk: bool,
@@ -130,6 +143,10 @@ class StageRuntime:
         log_stats: bool = False,
     ) -> None:
         self._stage_configs = stage_configs
+        self._omni_config = omni_config
+        self._omni_stage_configs = tuple(typed_topology_stage_configs) or (
+            tuple(omni_config.stage_configs) if omni_config is not None else ()
+        )
         self._model = model
         self._config_path = config_path
         self._stage_init_timeout = stage_init_timeout
@@ -279,7 +296,20 @@ class StageRuntime:
         """Build logical stage plans and cache prompt expansion metadata."""
         replicas_per_stage, replica_devices_map = compute_replica_layout(self._stage_configs)
         prepare_engine_environment()
-        omni_transfer_config = load_omni_transfer_config_for_model(self._model, self._config_path)
+        revision = None
+        for stage_config in self._omni_stage_configs:
+            diffusion_config = getattr(stage_config, "diffusion_config", None)
+            revision = getattr(diffusion_config, "revision", None)
+            if revision is not None:
+                break
+        if revision is None:
+            omni_transfer_config = load_omni_transfer_config_for_model(self._model, self._config_path)
+        else:
+            omni_transfer_config = load_omni_transfer_config_for_model(
+                self._model,
+                self._config_path,
+                revision=revision,
+            )
         stage_plans = self._build_logical_stage_init_plans(
             omni_transfer_config,
             replicas_per_stage,
@@ -342,12 +372,18 @@ class StageRuntime:
         """Build startup plans for every logical stage and replica."""
         stage_plans: list[LogicalStageInitPlan] = []
 
-        # RFC #4021 transition boundary: stage planning still relies on legacy
-        # StageConfig.runtime and StageConfig.engine_args for replica and engine
-        # setup. Keep metadata extraction on the legacy path until the
-        # coordinated stage-init cutover.
         for stage_idx, stage_cfg in enumerate(self._stage_configs):
-            base_metadata = extract_legacy_stage_metadata(stage_cfg)
+            legacy_stage_id = int(stage_cfg.stage_id)
+            omni_stage_config = None
+            if self._omni_config is not None:
+                omni_stage_config = self._omni_config.stage_by_id(legacy_stage_id)
+
+            if isinstance(omni_stage_config, VllmOmniDiffusionStageConfig):
+                base_metadata = extract_stage_metadata_from_omni_stage_config(omni_stage_config)
+            else:
+                if StageType(getattr(stage_cfg, "stage_type", StageType.LLM)) is StageType.DIFFUSION:
+                    raise TypeError(f"Diffusion stage {legacy_stage_id} has no typed VllmOmniDiffusionStageConfig")
+                base_metadata = extract_legacy_stage_metadata(stage_cfg)
             stage_id = int(base_metadata.stage_id)
             if stage_id != stage_idx:
                 raise ValueError(
@@ -356,6 +392,16 @@ class StageRuntime:
                     "Stage ids must be contiguous and zero-based because the "
                     "orchestrator indexes stage pools by stage_id."
                 )
+
+            if isinstance(omni_stage_config, BaseVllmOmniStageConfig) and not isinstance(
+                omni_stage_config,
+                VllmOmniDiffusionStageConfig,
+            ):
+                # PR9 keeps AR/generation consumers on the compatibility path,
+                # but the typed stage travels with every plan for PR8 parity.
+                typed_plan_config = copy.deepcopy(omni_stage_config)
+            else:
+                typed_plan_config = omni_stage_config
 
             stage_connector_spec = get_stage_connector_spec(
                 omni_transfer_config=omni_transfer_config,
@@ -399,10 +445,19 @@ class StageRuntime:
 
             for replica_id in range(num_replicas):
                 replica_cfg = copy.deepcopy(stage_cfg) if replica_id > 0 else stage_cfg
+                replica_omni_config = (
+                    copy.deepcopy(omni_stage_config) if isinstance(omni_stage_config, BaseVllmOmniStageConfig) else None
+                )
                 if stage_idx in replica_devices_map:
-                    replica_cfg.runtime.devices = replica_devices_map[stage_idx][replica_id]
+                    replica_devices = replica_devices_map[stage_idx][replica_id]
+                    replica_cfg.runtime.devices = replica_devices
+                    if replica_omni_config is not None:
+                        replica_omni_config.runtime_config.devices = replica_devices
 
-                replica_metadata = extract_legacy_stage_metadata(replica_cfg)
+                if isinstance(replica_omni_config, VllmOmniDiffusionStageConfig):
+                    replica_metadata = extract_stage_metadata_from_omni_stage_config(replica_omni_config)
+                else:
+                    replica_metadata = extract_legacy_stage_metadata(replica_cfg)
                 replica_metadata.replica_id = replica_id
                 if launch_mode == "remote" and replica_metadata.stage_type != "diffusion":
                     replica_metadata.runtime_cfg = None
@@ -415,6 +470,9 @@ class StageRuntime:
                         metadata=replica_metadata,
                         stage_connector_spec=stage_connector_spec,
                         omni_kv_connector=omni_kv_connector,
+                        omni_stage_config=(
+                            replica_omni_config if replica_omni_config is not None else typed_plan_config
+                        ),
                         stage_vllm_config=stage_vllm_config,
                         executor_class=executor_class,
                         engine_args_dict=copy.deepcopy(engine_args_dict) if engine_args_dict is not None else None,
@@ -650,27 +708,39 @@ class StageRuntime:
                 stage_runtime_env(plan.metadata.stage_id, plan.metadata.runtime_cfg),
                 self._stage_device_scope(plan.metadata.stage_id, plan.metadata.runtime_cfg),
             ):
-                omni_conn_cfg, omni_from, omni_to = plan.omni_kv_connector
-                if omni_conn_cfg:
-                    if omni_from is None or omni_to is None:
-                        raise RuntimeError("Omni KV connector requires source and destination stages")
-                    inject_omni_kv_config(plan.stage_cfg, omni_conn_cfg, omni_from, omni_to)
-                inject_kv_stage_info(plan.stage_cfg, plan.metadata.stage_id, self._stage_configs)
-                engine_args = getattr(plan.stage_cfg, "engine_args", {})
-                inline_diffusion = (
-                    engine_args.get("inline_diffusion", False)
-                    if hasattr(engine_args, "get")
-                    else getattr(engine_args, "inline_diffusion", False)
+                if not isinstance(plan.omni_stage_config, VllmOmniDiffusionStageConfig):
+                    raise TypeError(
+                        f"Stage {plan.metadata.stage_id} diffusion startup is missing its typed stage config"
+                    )
+                # Inline placement is a topology decision.  Read it from the
+                # immutable typed stage first, while retaining the legacy
+                # field as a compatibility fallback for synthetic plans.
+                inline_diffusion = bool(
+                    getattr(plan.omni_stage_config.stage_pipeline_config, "inline_diffusion", False)
                 )
-                custom_pipeline_args = (
-                    engine_args.get("custom_pipeline_args")
-                    if hasattr(engine_args, "get")
-                    else getattr(engine_args, "custom_pipeline_args", None)
-                )
+                if not inline_diffusion:
+                    legacy_engine_args = getattr(plan.stage_cfg, "engine_args", {})
+                    inline_diffusion = bool(
+                        legacy_engine_args.get("inline_diffusion", False)
+                        if hasattr(legacy_engine_args, "get")
+                        else getattr(legacy_engine_args, "inline_diffusion", False)
+                    )
+                custom_pipeline_args = getattr(plan.omni_stage_config.diffusion_config, "custom_pipeline_args", None)
+                if custom_pipeline_args is None:
+                    legacy_engine_args = getattr(plan.stage_cfg, "engine_args", {})
+                    custom_pipeline_args = (
+                        legacy_engine_args.get("custom_pipeline_args")
+                        if hasattr(legacy_engine_args, "get")
+                        else getattr(legacy_engine_args, "custom_pipeline_args", None)
+                    )
                 client, resources = launch_diffusion_stage_replica(
                     model=self._model,
-                    stage_config=plan.stage_cfg,
+                    stage_config=plan.omni_stage_config,
+                    legacy_registration_config=plan.stage_cfg,
                     metadata=plan.metadata,
+                    stage_connector_spec=plan.stage_connector_spec,
+                    omni_kv_connector=plan.omni_kv_connector,
+                    stage_configs=self._omni_stage_configs,
                     stage_init_timeout=stage_init_timeout,
                     batch_size=self._diffusion_batch_size,
                     use_inline=plan.num_replicas == 1
@@ -767,6 +837,8 @@ class DistStageRuntime(StageRuntime):
         model: str,
         config_path: str,
         *,
+        omni_config: VllmOmniConfig | None = None,
+        typed_topology_stage_configs: Sequence[BaseVllmOmniStageConfig] = (),
         stage_init_timeout: int,
         diffusion_batch_size: int,
         async_chunk: bool,
@@ -784,6 +856,8 @@ class DistStageRuntime(StageRuntime):
             stage_configs=stage_configs,
             model=model,
             config_path=config_path,
+            omni_config=omni_config,
+            typed_topology_stage_configs=typed_topology_stage_configs,
             stage_init_timeout=stage_init_timeout,
             diffusion_batch_size=diffusion_batch_size,
             async_chunk=async_chunk,
@@ -836,12 +910,14 @@ class DistStageRuntime(StageRuntime):
                 except (AttributeError, TypeError):
                     if hasattr(runtime_cfg, "__setitem__"):
                         runtime_cfg["num_replicas"] = self._omni_dp_size_local
-                        continue
-                    logger.warning(
-                        "[DistStageRuntime] Failed to apply omni_dp_size_local=%s to stage %s runtime config",
-                        self._omni_dp_size_local,
-                        stage_id,
-                    )
+                    else:
+                        logger.warning(
+                            "[DistStageRuntime] Failed to apply omni_dp_size_local=%s to stage %s runtime config",
+                            self._omni_dp_size_local,
+                            stage_id,
+                        )
+                if self._omni_config is not None:
+                    self._omni_config.stage_by_id(stage_id).runtime_config.num_replicas = self._omni_dp_size_local
 
     def _before_initialize_stage_replicas(self, stage_plans: Sequence[LogicalStageInitPlan]) -> None:
         self._start_omni_master_server(stage_plans)
@@ -899,13 +975,9 @@ class DistStageRuntime(StageRuntime):
         if registered_stage_cfg is None:
             raise ValueError(f"Remote stage {plan.metadata.stage_id} registered without stage config")
 
-        # Remote diffusion registration still transports the legacy mapping
-        # shape. Reconstruct and project that shape until its RFC #4021 cutover.
-        metadata = (
-            extract_legacy_stage_metadata(OmegaConf.create(registered_stage_cfg))
-            if plan.metadata.stage_type == "diffusion"
-            else copy.deepcopy(plan.metadata)
-        )
+        # Registration transports a compatibility payload for the wire
+        # protocol. Runtime metadata always comes from the local startup plan.
+        metadata = copy.deepcopy(plan.metadata)
         metadata.replica_id = plan.replica_id
         ctx = StageRemoteFactoryContext(
             stage_id=plan.metadata.stage_id,
@@ -1107,6 +1179,8 @@ def create_stage_runtime(
     model: str,
     config_path: str,
     *,
+    omni_config: VllmOmniConfig | None = None,
+    typed_topology_stage_configs: Sequence[BaseVllmOmniStageConfig] = (),
     single_stage_mode: bool,
     stage_init_timeout: int,
     diffusion_batch_size: int,
@@ -1130,6 +1204,8 @@ def create_stage_runtime(
             stage_configs=stage_configs,
             model=model,
             config_path=config_path,
+            omni_config=omni_config,
+            typed_topology_stage_configs=typed_topology_stage_configs,
             stage_init_timeout=stage_init_timeout,
             diffusion_batch_size=diffusion_batch_size,
             async_chunk=async_chunk,
@@ -1147,6 +1223,8 @@ def create_stage_runtime(
         stage_configs=stage_configs,
         model=model,
         config_path=config_path,
+        omni_config=omni_config,
+        typed_topology_stage_configs=typed_topology_stage_configs,
         stage_init_timeout=stage_init_timeout,
         diffusion_batch_size=diffusion_batch_size,
         async_chunk=async_chunk,

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -193,7 +193,15 @@ class OmniServeCommand(CLISubcommand):
         from vllm_omni.diffusion.utils.hf_utils import is_diffusion_model
 
         model = getattr(args, "model_tag", None) or getattr(args, "model", None)
-        if model and is_diffusion_model(model):
+        revision = getattr(args, "revision", None)
+        if model:
+            if revision is None:
+                diffusion_model = is_diffusion_model(model)
+            else:
+                diffusion_model = is_diffusion_model(model, revision=revision)
+        else:
+            diffusion_model = False
+        if diffusion_model:
             logger.info("Detected diffusion model: %s", model)
             return
         validate_parsed_serve_args(args)
@@ -934,6 +942,7 @@ def run_headless(args: TrackingNamespace) -> None:
     from vllm.v1.executor.multiproc_executor import MultiprocExecutor
     from vllm.version import __version__ as VLLM_VERSION
 
+    from vllm_omni.config.omni_config import VllmOmniDiffusionStageConfig
     from vllm_omni.distributed.omni_connectors.utils.initialization import resolve_omni_kv_config_for_stage
     from vllm_omni.engine.stage_engine_startup import (
         get_headless_replica_devices,
@@ -949,7 +958,7 @@ def run_headless(args: TrackingNamespace) -> None:
         prepare_engine_environment,
     )
     from vllm_omni.entrypoints.utils import (
-        load_and_resolve_stage_configs,
+        load_and_resolve_stage_config_views,
         parse_stage_overrides,
     )
 
@@ -991,7 +1000,7 @@ def run_headless(args: TrackingNamespace) -> None:
     # standard launches resolve to the same per-stage device layout.
     stage_overrides = parse_stage_overrides(args_dict.get("stage_overrides"))
 
-    config_path, stage_configs, _ = load_and_resolve_stage_configs(
+    resolved_stage_configs = load_and_resolve_stage_config_views(
         model,
         args_dict,
         # store_true cannot express an explicit False: absent maps to None
@@ -1001,6 +1010,8 @@ def run_headless(args: TrackingNamespace) -> None:
         stage_overrides=stage_overrides,
         strategy_config_path=args_dict.get("strategy_config"),
     )
+    config_path = resolved_stage_configs.config_path
+    stage_configs = resolved_stage_configs.stage_configs
 
     # Locate the stage config that matches stage_id.
     stage_cfg = None
@@ -1013,14 +1024,19 @@ def run_headless(args: TrackingNamespace) -> None:
             f"No stage config found for stage_id={stage_id}. Available stage ids: {[c.stage_id for c in stage_configs]}"
         )
 
+    typed_stage_cfg = (
+        resolved_stage_configs.typed_stage_by_id(stage_id) if resolved_stage_configs.omni_config is not None else None
+    )
+
     prepare_engine_environment()
     per_replica_devices = get_headless_replica_devices(stage_cfg, stage_id, omni_dp_size_local)
 
-    if stage_cfg.stage_type == "diffusion":
+    if isinstance(typed_stage_cfg, VllmOmniDiffusionStageConfig):
         launch_headless_diffusion_replicas(
             model=model,
-            stage_cfg=stage_cfg,
-            stage_configs=stage_configs,
+            stage_config=typed_stage_cfg,
+            legacy_registration_config=stage_cfg,
+            stage_configs=list(resolved_stage_configs.typed_topology()),
             stage_id=stage_id,
             omni_master_address=omni_master_address,
             omni_master_port=omni_master_port,
@@ -1030,8 +1046,14 @@ def run_headless(args: TrackingNamespace) -> None:
             replica_bind_address=omni_replica_address,
         )
         return
+    if stage_cfg.stage_type == "diffusion":
+        raise TypeError(f"Diffusion stage {stage_id} did not resolve to a typed diffusion config")
 
-    omni_transfer_config = load_omni_transfer_config_for_model(model, config_path)
+    revision = stage_cfg.engine_args.get("revision")
+    if revision is None:
+        omni_transfer_config = load_omni_transfer_config_for_model(model, config_path)
+    else:
+        omni_transfer_config = load_omni_transfer_config_for_model(model, config_path, revision=revision)
     omni_kv_connector = resolve_omni_kv_config_for_stage(omni_transfer_config, stage_id)
     stage_connector_spec = get_stage_connector_spec(
         omni_transfer_config=omni_transfer_config,

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -885,6 +885,7 @@ def run_headless(args: TrackingNamespace) -> None:
     from vllm.v1.executor.multiproc_executor import MultiprocExecutor
     from vllm.version import __version__ as VLLM_VERSION
 
+    from vllm_omni.config.omni_config import VllmOmniDiffusionStageConfig
     from vllm_omni.distributed.omni_connectors.utils.initialization import resolve_omni_kv_config_for_stage
     from vllm_omni.engine.stage_engine_startup import (
         get_headless_replica_devices,
@@ -900,7 +901,7 @@ def run_headless(args: TrackingNamespace) -> None:
         prepare_engine_environment,
     )
     from vllm_omni.entrypoints.utils import (
-        load_and_resolve_stage_configs,
+        load_and_resolve_stage_config_views,
         parse_stage_overrides,
     )
 
@@ -942,7 +943,7 @@ def run_headless(args: TrackingNamespace) -> None:
     # standard launches resolve to the same per-stage device layout.
     stage_overrides = parse_stage_overrides(args_dict.get("stage_overrides"))
 
-    config_path, stage_configs, _ = load_and_resolve_stage_configs(
+    resolved_stage_configs = load_and_resolve_stage_config_views(
         model,
         args_dict,
         # store_true cannot express an explicit False: absent maps to None
@@ -952,6 +953,8 @@ def run_headless(args: TrackingNamespace) -> None:
         stage_overrides=stage_overrides,
         strategy_config_path=args_dict.get("strategy_config"),
     )
+    config_path = resolved_stage_configs.config_path
+    stage_configs = resolved_stage_configs.stage_configs
 
     # Locate the stage config that matches stage_id.
     stage_cfg = None
@@ -964,14 +967,19 @@ def run_headless(args: TrackingNamespace) -> None:
             f"No stage config found for stage_id={stage_id}. Available stage ids: {[c.stage_id for c in stage_configs]}"
         )
 
+    typed_stage_cfg = (
+        resolved_stage_configs.typed_stage_by_id(stage_id) if resolved_stage_configs.omni_config is not None else None
+    )
+
     prepare_engine_environment()
     per_replica_devices = get_headless_replica_devices(stage_cfg, stage_id, omni_dp_size_local)
 
-    if stage_cfg.stage_type == "diffusion":
+    if isinstance(typed_stage_cfg, VllmOmniDiffusionStageConfig):
         launch_headless_diffusion_replicas(
             model=model,
-            stage_cfg=stage_cfg,
-            stage_configs=stage_configs,
+            stage_config=typed_stage_cfg,
+            legacy_registration_config=stage_cfg,
+            stage_configs=list(resolved_stage_configs.omni_config.stage_configs),
             stage_id=stage_id,
             omni_master_address=omni_master_address,
             omni_master_port=omni_master_port,
@@ -981,6 +989,8 @@ def run_headless(args: TrackingNamespace) -> None:
             replica_bind_address=omni_replica_address,
         )
         return
+    if stage_cfg.stage_type == "diffusion":
+        raise TypeError(f"Diffusion stage {stage_id} did not resolve to a typed diffusion config")
 
     omni_transfer_config = load_omni_transfer_config_for_model(model, config_path)
     omni_kv_connector = resolve_omni_kv_config_for_stage(omni_transfer_config, stage_id)

--- a/vllm_omni/entrypoints/utils.py
+++ b/vllm_omni/entrypoints/utils.py
@@ -1,8 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 import json
 import os
 import types
 from collections import Counter
-from dataclasses import fields, is_dataclass
+from dataclasses import dataclass, fields, is_dataclass
 from pathlib import Path
 from typing import Any, get_args, get_origin
 
@@ -13,12 +16,22 @@ from vllm.transformers_utils.repo_utils import file_or_path_exists
 
 from vllm_omni.config.config_factory import (
     StageConfigFactory,
+    StageConfigResolution,
     _materialize_object_storage_configs,
     _name_match_candidate,
     with_trust_remote_code_override,
 )
+from vllm_omni.config.omni_config import VllmOmniConfig
 from vllm_omni.config.pipeline_registry import OMNI_PIPELINES
-from vllm_omni.config.stage_config import _DEPLOY_DIR
+from vllm_omni.config.stage_config import (
+    _DEPLOY_DIR,
+    DeployConfig,
+    PipelineConfig,
+    StageDeployConfig,
+    StageExecutionType,
+    StagePipelineConfig,
+    StageType,
+)
 from vllm_omni.config.yaml_util import create_config, load_yaml_config
 from vllm_omni.diffusion.utils.hf_utils import (
     _looks_like_dreamzero,
@@ -32,6 +45,39 @@ from vllm_omni.platforms import current_omni_platform
 PROJECT_ROOT = Path(__file__).parent.parent.parent
 
 logger = init_logger(__name__)
+
+
+@dataclass(frozen=True)
+class ResolvedStageConfigs:
+    """Canonical typed config plus the aligned Phase-3 compatibility view."""
+
+    config_path: str | None
+    omni_config: VllmOmniConfig | None
+    stage_configs: list[Any]
+    deploy_config: DeployConfig | None
+    omni_lb_policy: str | None
+    # Mode filtering controls which stages are launched, but a typed DiT may
+    # still need a filtered peer's TP size to derive its KV rank mapping. Keep
+    # the pre-filter structured topology separate from the active stage view.
+    typed_topology_stage_configs: tuple[Any, ...] = ()
+
+    def typed_stage_by_id(self, stage_id: int) -> Any:
+        if self.omni_config is None:
+            raise KeyError(f"no structured config for stage {stage_id}")
+        return self.omni_config.stage_by_id(stage_id)
+
+    def legacy_stage_by_id(self, stage_id: int) -> Any:
+        for stage in self.stage_configs:
+            if int(stage.stage_id) == stage_id:
+                return stage
+        raise KeyError(f"no legacy compatibility stage {stage_id}")
+
+    def typed_topology(self) -> tuple[Any, ...]:
+        if self.typed_topology_stage_configs:
+            return self.typed_topology_stage_configs
+        if self.omni_config is None:
+            return ()
+        return tuple(self.omni_config.stage_configs)
 
 
 _DIFFUSERS_CLASS_TO_CONFIG: dict[str, str] = {
@@ -72,7 +118,11 @@ def inject_omni_kv_config(stage: Any, omni_conn_cfg: dict[str, Any], omni_from: 
         logger.error(f"Failed to inject omni connector config into stage: {e}")
 
 
-def _try_get_class_name_from_diffusers_config(model: str) -> str | None:
+def _try_get_class_name_from_diffusers_config(
+    model: str,
+    *,
+    revision: str | None = None,
+) -> str | None:
     """Try to get class name from diffusers model configuration files.
 
     Args:
@@ -81,7 +131,10 @@ def _try_get_class_name_from_diffusers_config(model: str) -> str | None:
     Returns:
         Model type string if found, None otherwise
     """
-    model_index = get_diffusion_model_index(model)
+    if revision is None:
+        model_index = get_diffusion_model_index(model)
+    else:
+        model_index = get_diffusion_model_index(model, revision=revision)
     if model_index and isinstance(model_index, dict) and "_class_name" in model_index:
         logger.debug(f"Found Diffusers model type '{model_index['_class_name']}'")
         return model_index["_class_name"]
@@ -236,7 +289,7 @@ def _try_resolve_omni_model_type(model: str) -> str | None:
     return best_match
 
 
-def _registry_default_deploy_path(model: str) -> str | None:
+def _registry_default_deploy_path(model: str, *, revision: str | None = None) -> str | None:
     """Return the registered pipeline's default deploy YAML path, if any.
 
     A checkpoint's HF ``model_type`` is not always the registered Omni pipeline
@@ -245,9 +298,14 @@ def _registry_default_deploy_path(model: str) -> str | None:
     loads that pipeline's default deploy config, so connector discovery must
     resolve the same path.
     """
+    pipeline_kwargs = {
+        "model": model,
+        "trust_remote_code": True,
+    }
+    if revision is not None:
+        pipeline_kwargs["revision"] = revision
     pipeline_config = StageConfigFactory.get_pipeline_config(
-        model=model,
-        trust_remote_code=True,
+        **pipeline_kwargs,
     )
     if pipeline_config is None or pipeline_config.default_deploy_config_name is None:
         return None
@@ -257,7 +315,7 @@ def _registry_default_deploy_path(model: str) -> str | None:
     return None
 
 
-def resolve_model_config_path(model: str) -> str | None:
+def resolve_model_config_path(model: str, revision: str | None = None) -> str | None:
     """Resolve the stage/deploy config file path from the model name.
 
     Resolves configuration path based on the model type and device type.
@@ -287,22 +345,32 @@ def resolve_model_config_path(model: str) -> str | None:
     config_source = _materialize_object_storage_configs(model)
     # Try to get config from standard transformers format first
     try:
-        hf_config = get_config(config_source, trust_remote_code=True)
+        config_kwargs = {"trust_remote_code": True}
+        if revision is not None:
+            config_kwargs["revision"] = revision
+        hf_config = get_config(config_source, **config_kwargs)
         model_type = hf_config.model_type
     except (ValueError, Exception):
         # If standard transformers format fails, try diffusers format
-        if get_diffusion_model_index(config_source) is not None:
-            model_type = _try_get_class_name_from_diffusers_config(config_source)
+        if revision is None:
+            model_index = get_diffusion_model_index(config_source)
+        else:
+            model_index = get_diffusion_model_index(config_source, revision=revision)
+        if model_index is not None:
+            if revision is None:
+                model_type = _try_get_class_name_from_diffusers_config(config_source)
+            else:
+                model_type = _try_get_class_name_from_diffusers_config(config_source, revision=revision)
             if model_type is None:
                 raise ValueError(
                     f"Could not determine model_type for diffusers model: {model}. "
                     "Please ensure its Diffusers pipeline index contains '_class_name'"
                 )
-        elif file_or_path_exists(config_source, "config.json", revision=None):
+        elif file_or_path_exists(config_source, "config.json", revision=revision):
             # Try to read config.json manually for custom models like Bagel that fail get_config
             # but have a valid config.json with model_type
             try:
-                config_dict = get_hf_file_to_dict("config.json", config_source, revision=None)
+                config_dict = get_hf_file_to_dict("config.json", config_source, revision=revision)
                 if config_dict and "model_type" in config_dict:
                     model_type = config_dict["model_type"]
                 else:
@@ -326,7 +394,14 @@ def resolve_model_config_path(model: str) -> str | None:
                 )
 
     default_config_path = current_omni_platform.get_default_stage_config_path()
-    if model_type == "vla" and _looks_like_dreamzero(config_source):
+    if model_type == "vla":
+        if revision is None:
+            looks_like_dreamzero = _looks_like_dreamzero(config_source)
+        else:
+            looks_like_dreamzero = _looks_like_dreamzero(config_source, revision=revision)
+    else:
+        looks_like_dreamzero = False
+    if model_type == "vla" and looks_like_dreamzero:
         model_type = "dreamzero"
 
     if model_type in _DIFFUSERS_CLASS_TO_CONFIG:
@@ -342,7 +417,10 @@ def resolve_model_config_path(model: str) -> str | None:
     # HF type is not itself a pipeline key. Otherwise a future
     # deploy/minicpmo.yaml would desync connectors from stages for MiniCPM-o 4.5.
     if normalized_model_type not in OMNI_PIPELINES:
-        registry_path = _registry_default_deploy_path(model)
+        if revision is None:
+            registry_path = _registry_default_deploy_path(model)
+        else:
+            registry_path = _registry_default_deploy_path(model, revision=revision)
         if registry_path is not None:
             return registry_path
 
@@ -355,7 +433,34 @@ def resolve_model_config_path(model: str) -> str | None:
     if os.path.exists(stage_config_path):
         return str(stage_config_path)
 
-    return _registry_default_deploy_path(model)
+    if revision is None:
+        return _registry_default_deploy_path(model)
+    return _registry_default_deploy_path(model, revision=revision)
+
+
+def _build_stage_cli_overrides(
+    base_engine_args: dict | None,
+    trust_remote_code: bool | None,
+    stage_overrides: dict[str, dict[str, Any]] | None,
+) -> dict[str, Any]:
+    """Normalize global and per-stage caller inputs for both config views."""
+    cli_overrides = _convert_dataclasses_to_dict(dict(base_engine_args or {}))
+    if not cli_overrides.get("trust_remote_code"):
+        cli_overrides.pop("trust_remote_code", None)
+    cli_overrides = with_trust_remote_code_override(cli_overrides, trust_remote_code)
+    if stage_overrides:
+        for stage_id_str, overrides in stage_overrides.items():
+            for key, val in overrides.items():
+                cli_overrides[f"stage_{stage_id_str}_{key}"] = val
+    return cli_overrides
+
+
+def _load_strategy_specs(strategy_config_path: str | None) -> Any:
+    if strategy_config_path is None:
+        return None
+    from vllm_omni.config.composable_parallel.strategy_loader import load_strategy_specs
+
+    return load_strategy_specs(strategy_config_path)
 
 
 def load_stage_configs_from_model(
@@ -392,30 +497,17 @@ def load_stage_configs_from_model(
         (``None`` when no strategy set one). The policy is returned rather than
         written into a caller-provided mutable dict.
     """
-    if base_engine_args is None:
-        base_engine_args = {}
-
-    cli_overrides = _convert_dataclasses_to_dict(dict(base_engine_args))
-    # A False inherited from the engine-args dump is the store_true flag's
-    # default, not an explicit choice — drop it so only the tri-state
-    # parameter below decides (see with_trust_remote_code_override).
-    if not cli_overrides.get("trust_remote_code"):
-        cli_overrides.pop("trust_remote_code", None)
-    cli_overrides = with_trust_remote_code_override(cli_overrides, trust_remote_code)
-    if stage_overrides:
-        for stage_id_str, overrides in stage_overrides.items():
-            for key, val in overrides.items():
-                cli_overrides[f"stage_{stage_id_str}_{key}"] = val
+    cli_overrides = _build_stage_cli_overrides(
+        base_engine_args,
+        trust_remote_code,
+        stage_overrides,
+    )
 
     # Current runtime initialization still consumes legacy OmegaConf stage
     # configs. ``StageConfigFactory.create_from_model`` now produces the
     # structured ``VllmOmniConfig`` object; future RFC #4021 changes will
     # migrate the engine/runtime consumers and replace this legacy resolver.
-    strategy_specs = None
-    if strategy_config_path is not None:
-        from vllm_omni.config.composable_parallel.strategy_loader import load_strategy_specs
-
-        strategy_specs = load_strategy_specs(strategy_config_path)
+    strategy_specs = _load_strategy_specs(strategy_config_path)
 
     stages, omni_lb_policy = StageConfigFactory.create_legacy_stage_configs_from_model(
         model,
@@ -439,6 +531,162 @@ def load_stage_configs_from_model(
         strategy_note,
     )
     return [], None
+
+
+def load_stage_config_views_from_model(
+    model: str,
+    *,
+    trust_remote_code: bool | None,
+    base_engine_args: dict | None = None,
+    deploy_config_path: str | None = None,
+    stage_overrides: dict[str, dict[str, Any]] | None = None,
+    strategy_config_path: str | None = None,
+) -> ResolvedStageConfigs:
+    """Resolve aligned typed and legacy views in one factory pass."""
+    cli_overrides = _build_stage_cli_overrides(
+        base_engine_args,
+        trust_remote_code,
+        stage_overrides,
+    )
+    resolution: StageConfigResolution = StageConfigFactory.create_config_views_from_model(
+        model,
+        trust_remote_code=trust_remote_code,
+        cli_overrides=cli_overrides,
+        deploy_config_path=deploy_config_path,
+        strategy_specs=_load_strategy_specs(strategy_config_path),
+    )
+    if resolution.legacy_stage_configs is None:
+        strategy_note = ""
+        if strategy_config_path is not None:
+            strategy_note = f" Strategy config {strategy_config_path!r} was not applied."
+        logger.warning(
+            "No registered PipelineConfig resolved for model %r. Legacy `stage_args` "
+            "YAMLs are no longer supported; register the pipeline and provide deployment "
+            "overrides through `deploy_config`.%s",
+            model,
+            strategy_note,
+        )
+        legacy_stages: list[Any] = []
+    else:
+        legacy_stages = [stage.to_omegaconf() for stage in resolution.legacy_stage_configs]
+    return ResolvedStageConfigs(
+        config_path=resolution.deploy_config_path,
+        omni_config=resolution.omni_config,
+        stage_configs=legacy_stages,
+        deploy_config=resolution.deploy_config,
+        omni_lb_policy=resolution.omni_lb_policy,
+        typed_topology_stage_configs=(
+            tuple(resolution.omni_config.stage_configs) if resolution.omni_config is not None else ()
+        ),
+    )
+
+
+def _build_default_diffusion_config_views(
+    model: str,
+    default_stage_configs: Any,
+) -> tuple[list[Any], VllmOmniConfig, DeployConfig]:
+    """Build both views from the normalized single-stage diffusion fallback."""
+    raw_stages = _convert_dataclasses_to_dict(default_stage_configs)
+    if not isinstance(raw_stages, list) or len(raw_stages) != 1:
+        raise ValueError("The unregistered-model fallback must define exactly one diffusion stage")
+
+    raw_stage = dict(raw_stages[0])
+    stage_type = raw_stage.get("stage_type")
+    if stage_type not in {StageType.DIFFUSION, StageType.DIFFUSION.value}:
+        raise ValueError("The unregistered-model fallback only supports a diffusion stage")
+
+    engine_args = dict(raw_stage.get("engine_args") or {})
+    runtime = dict(raw_stage.get("runtime") or {})
+    stage_id = int(raw_stage.get("stage_id", 0))
+    if stage_id != 0:
+        raise ValueError(f"The single-stage diffusion fallback must use stage_id=0, got {stage_id}")
+
+    topology = StagePipelineConfig(
+        stage_id=stage_id,
+        model_stage=str(engine_args.get("model_stage") or "diffusion"),
+        execution_type=StageExecutionType.DIFFUSION,
+        input_sources=tuple(int(source) for source in raw_stage.get("engine_input_source", ())),
+        final_output=bool(raw_stage.get("final_output", True)),
+        final_output_type=raw_stage.get("final_output_type"),
+        model_arch=engine_args.get("model_arch"),
+        custom_process_input_func=raw_stage.get("custom_process_input_func"),
+        cfg_kv_collect_func=raw_stage.get("cfg_kv_collect_func") or engine_args.get("cfg_kv_collect_func"),
+    )
+    for topology_owned_field in (
+        "cfg_kv_collect_func",
+        "model_stage",
+    ):
+        engine_args.pop(topology_owned_field, None)
+    # Historical no-op accepted only because OmniDiffusionConfig.from_kwargs
+    # silently discarded unknown fields. It has no typed config owner.
+    engine_args.pop("enable_ar_profiler", None)
+    pipeline = PipelineConfig(
+        model_type="__single_stage_diffusion__",
+        # Keep an omitted architecture as ``None``.  The diffusion consumer
+        # uses ``None`` to request model-class discovery from the checkpoint;
+        # converting it to ``""`` makes the value look explicit and prevents
+        # that fallback from running.
+        model_arch=engine_args.get("model_arch"),
+        stages=(topology,),
+    )
+    stage_deploy = StageDeployConfig(
+        stage_id=stage_id,
+        devices=runtime.get("devices"),
+        num_replicas=int(runtime.get("num_replicas", 1)),
+        env=runtime.get("env"),
+        default_sampling_params=dict(raw_stage.get("default_sampling_params") or {}),
+        engine_extras=engine_args,
+    )
+    deploy = DeployConfig(
+        async_chunk=bool(engine_args.get("async_chunk", False)),
+        stages=[stage_deploy],
+    )
+    omni_config = VllmOmniConfig.from_pipeline_config(
+        pipeline,
+        user_deploy_config=deploy,
+        cli_overrides={"model": model},
+    )
+    legacy_stages = list(create_config(raw_stages))
+    return legacy_stages, omni_config, deploy
+
+
+def _filter_resolved_stage_views(
+    resolved: ResolvedStageConfigs,
+    kwargs: dict | None,
+) -> ResolvedStageConfigs:
+    """Apply mode filtering once and mirror the selected IDs to the typed view."""
+    filtered_legacy = filter_stages(resolved.config_path, resolved.stage_configs, kwargs)
+    if resolved.omni_config is None:
+        return ResolvedStageConfigs(
+            config_path=resolved.config_path,
+            omni_config=None,
+            stage_configs=filtered_legacy,
+            deploy_config=resolved.deploy_config,
+            omni_lb_policy=resolved.omni_lb_policy,
+            typed_topology_stage_configs=resolved.typed_topology(),
+        )
+
+    typed_topology = resolved.typed_topology()
+    selected_ids = [int(stage.stage_id) for stage in filtered_legacy]
+    typed_stages = tuple(resolved.omni_config.stage_by_id(stage_id) for stage_id in selected_ids)
+    omni_config = VllmOmniConfig(
+        pipeline_config=resolved.omni_config.pipeline_config,
+        stage_configs=typed_stages,
+        orchestrator_config=resolved.omni_config.orchestrator_config,
+    )
+    typed_ids = [stage.stage_id for stage in omni_config.stage_configs]
+    if typed_ids != selected_ids:
+        raise ValueError(
+            f"Structured and legacy stage views diverged after mode filtering: typed={typed_ids}, legacy={selected_ids}"
+        )
+    return ResolvedStageConfigs(
+        config_path=resolved.config_path,
+        omni_config=omni_config,
+        stage_configs=filtered_legacy,
+        deploy_config=resolved.deploy_config,
+        omni_lb_policy=resolved.omni_lb_policy,
+        typed_topology_stage_configs=typed_topology,
+    )
 
 
 def filter_stages(
@@ -554,6 +802,77 @@ def parse_stage_overrides(value: Any) -> dict[str, dict[str, Any]] | None:
     return value
 
 
+def load_and_resolve_stage_config_views(
+    model: str,
+    kwargs: dict | None,
+    *,
+    trust_remote_code: bool | None,
+    default_stage_cfg_factory: Any = None,
+    deploy_config_path: str | None = None,
+    stage_overrides: dict[str, dict[str, Any]] | None = None,
+    strategy_config_path: str | None = None,
+) -> ResolvedStageConfigs:
+    """Resolve aligned typed and compatibility stage views for runtime startup."""
+    resolved = load_stage_config_views_from_model(
+        model,
+        trust_remote_code=trust_remote_code,
+        base_engine_args=kwargs,
+        deploy_config_path=deploy_config_path,
+        stage_overrides=stage_overrides,
+        strategy_config_path=strategy_config_path,
+    )
+    config_path = resolved.config_path
+    # A registered pipeline may omit a default deploy file; retain the legacy
+    # path lookup for that case.  An unresolved model is intentionally handled
+    # by the single-stage diffusion fallback (when supplied), so do not perform
+    # a second HF/model-index lookup merely to populate a compatibility path.
+    if config_path is None and resolved.omni_config is not None:
+        if deploy_config_path is not None:
+            config_path = deploy_config_path
+        else:
+            # A registry entry may intentionally omit a default deploy file
+            # (and callers/tests often use a synthetic model key). Path lookup
+            # is only ancillary for transfer/mode discovery; never make a
+            # successful structured resolution fail because that lookup cannot
+            # infer a local/HF config path.
+            try:
+                revision = (kwargs or {}).get("revision")
+                if revision is None:
+                    config_path = resolve_model_config_path(model)
+                else:
+                    config_path = resolve_model_config_path(model, revision=revision)
+            except Exception as exc:
+                logger.debug("Could not resolve ancillary config path for %r: %s", model, exc)
+                config_path = None
+
+    if not resolved.stage_configs and default_stage_cfg_factory is not None:
+        legacy_stages, omni_config, deploy_config = _build_default_diffusion_config_views(
+            model,
+            default_stage_cfg_factory(),
+        )
+        resolved = ResolvedStageConfigs(
+            config_path=config_path,
+            omni_config=omni_config,
+            stage_configs=legacy_stages,
+            deploy_config=deploy_config,
+            omni_lb_policy=resolved.omni_lb_policy,
+            typed_topology_stage_configs=tuple(omni_config.stage_configs),
+        )
+    else:
+        resolved = ResolvedStageConfigs(
+            config_path=config_path,
+            omni_config=resolved.omni_config,
+            stage_configs=resolved.stage_configs,
+            deploy_config=resolved.deploy_config,
+            omni_lb_policy=resolved.omni_lb_policy,
+            typed_topology_stage_configs=resolved.typed_topology(),
+        )
+
+    resolved = _filter_resolved_stage_views(resolved, kwargs)
+    logger.debug("stage_configs: %s", resolved.stage_configs)
+    return resolved
+
+
 def load_and_resolve_stage_configs(
     model: str,
     kwargs: dict | None,
@@ -563,7 +882,7 @@ def load_and_resolve_stage_configs(
     deploy_config_path: str | None = None,
     stage_overrides: dict[str, dict[str, Any]] | None = None,
     strategy_config_path: str | None = None,
-) -> tuple[str, list, str | None]:
+) -> tuple[str | None, list, str | None]:
     """Load stage configurations from a deploy YAML or model defaults.
 
     Args:
@@ -583,7 +902,14 @@ def load_and_resolve_stage_configs(
         the strategy-derived pipeline-wide load-balancer policy (``None`` when no
         strategy set one), returned for the engine to apply.
     """
-    config_path = deploy_config_path if deploy_config_path is not None else resolve_model_config_path(model)
+    if deploy_config_path is not None:
+        config_path = deploy_config_path
+    else:
+        revision = (kwargs or {}).get("revision")
+        if revision is None:
+            config_path = resolve_model_config_path(model)
+        else:
+            config_path = resolve_model_config_path(model, revision=revision)
     stage_configs, omni_lb_policy = load_stage_configs_from_model(
         model,
         trust_remote_code=trust_remote_code,
@@ -594,14 +920,12 @@ def load_and_resolve_stage_configs(
     )
     if not stage_configs:
         if default_stage_cfg_factory is not None:
-            default_stage_cfg = default_stage_cfg_factory()
-            stage_configs = create_config(_convert_dataclasses_to_dict(default_stage_cfg))
+            stage_configs = create_config(_convert_dataclasses_to_dict(default_stage_cfg_factory()))
         else:
             stage_configs = []
 
     stage_configs = filter_stages(config_path, stage_configs, kwargs)
-    logger.debug(f"stage_configs: {stage_configs}")
-
+    logger.debug("stage_configs: %s", stage_configs)
     return config_path, stage_configs, omni_lb_policy
 
 

--- a/vllm_omni/entrypoints/utils.py
+++ b/vllm_omni/entrypoints/utils.py
@@ -2,7 +2,7 @@ import json
 import os
 import types
 from collections import Counter
-from dataclasses import fields, is_dataclass
+from dataclasses import dataclass, fields, is_dataclass
 from pathlib import Path
 from typing import Any, get_args, get_origin
 
@@ -13,12 +13,22 @@ from vllm.transformers_utils.repo_utils import file_or_path_exists
 
 from vllm_omni.config.config_factory import (
     StageConfigFactory,
+    StageConfigResolution,
     _materialize_object_storage_configs,
     _name_match_candidate,
     with_trust_remote_code_override,
 )
+from vllm_omni.config.omni_config import VllmOmniConfig
 from vllm_omni.config.pipeline_registry import OMNI_PIPELINES
-from vllm_omni.config.stage_config import _DEPLOY_DIR
+from vllm_omni.config.stage_config import (
+    _DEPLOY_DIR,
+    DeployConfig,
+    PipelineConfig,
+    StageDeployConfig,
+    StageExecutionType,
+    StagePipelineConfig,
+    StageType,
+)
 from vllm_omni.config.yaml_util import create_config, load_yaml_config
 from vllm_omni.diffusion.utils.hf_utils import (
     _looks_like_dreamzero,
@@ -32,6 +42,28 @@ from vllm_omni.platforms import current_omni_platform
 PROJECT_ROOT = Path(__file__).parent.parent.parent
 
 logger = init_logger(__name__)
+
+
+@dataclass(frozen=True)
+class ResolvedStageConfigs:
+    """Canonical typed config plus the aligned Phase-3 compatibility view."""
+
+    config_path: str | None
+    omni_config: VllmOmniConfig | None
+    stage_configs: list[Any]
+    deploy_config: DeployConfig | None
+    omni_lb_policy: str | None
+
+    def typed_stage_by_id(self, stage_id: int) -> Any:
+        if self.omni_config is None:
+            raise KeyError(f"no structured config for stage {stage_id}")
+        return self.omni_config.stage_by_id(stage_id)
+
+    def legacy_stage_by_id(self, stage_id: int) -> Any:
+        for stage in self.stage_configs:
+            if int(stage.stage_id) == stage_id:
+                return stage
+        raise KeyError(f"no legacy compatibility stage {stage_id}")
 
 
 _DIFFUSERS_CLASS_TO_CONFIG: dict[str, str] = {
@@ -358,6 +390,31 @@ def resolve_model_config_path(model: str) -> str | None:
     return _registry_default_deploy_path(model)
 
 
+def _build_stage_cli_overrides(
+    base_engine_args: dict | None,
+    trust_remote_code: bool | None,
+    stage_overrides: dict[str, dict[str, Any]] | None,
+) -> dict[str, Any]:
+    """Normalize global and per-stage caller inputs for both config views."""
+    cli_overrides = _convert_dataclasses_to_dict(dict(base_engine_args or {}))
+    if not cli_overrides.get("trust_remote_code"):
+        cli_overrides.pop("trust_remote_code", None)
+    cli_overrides = with_trust_remote_code_override(cli_overrides, trust_remote_code)
+    if stage_overrides:
+        for stage_id_str, overrides in stage_overrides.items():
+            for key, val in overrides.items():
+                cli_overrides[f"stage_{stage_id_str}_{key}"] = val
+    return cli_overrides
+
+
+def _load_strategy_specs(strategy_config_path: str | None) -> Any:
+    if strategy_config_path is None:
+        return None
+    from vllm_omni.config.composable_parallel.strategy_loader import load_strategy_specs
+
+    return load_strategy_specs(strategy_config_path)
+
+
 def load_stage_configs_from_model(
     model: str,
     *,
@@ -392,30 +449,17 @@ def load_stage_configs_from_model(
         (``None`` when no strategy set one). The policy is returned rather than
         written into a caller-provided mutable dict.
     """
-    if base_engine_args is None:
-        base_engine_args = {}
-
-    cli_overrides = _convert_dataclasses_to_dict(dict(base_engine_args))
-    # A False inherited from the engine-args dump is the store_true flag's
-    # default, not an explicit choice — drop it so only the tri-state
-    # parameter below decides (see with_trust_remote_code_override).
-    if not cli_overrides.get("trust_remote_code"):
-        cli_overrides.pop("trust_remote_code", None)
-    cli_overrides = with_trust_remote_code_override(cli_overrides, trust_remote_code)
-    if stage_overrides:
-        for stage_id_str, overrides in stage_overrides.items():
-            for key, val in overrides.items():
-                cli_overrides[f"stage_{stage_id_str}_{key}"] = val
+    cli_overrides = _build_stage_cli_overrides(
+        base_engine_args,
+        trust_remote_code,
+        stage_overrides,
+    )
 
     # Current runtime initialization still consumes legacy OmegaConf stage
     # configs. ``StageConfigFactory.create_from_model`` now produces the
     # structured ``VllmOmniConfig`` object; future RFC #4021 changes will
     # migrate the engine/runtime consumers and replace this legacy resolver.
-    strategy_specs = None
-    if strategy_config_path is not None:
-        from vllm_omni.config.composable_parallel.strategy_loader import load_strategy_specs
-
-        strategy_specs = load_strategy_specs(strategy_config_path)
+    strategy_specs = _load_strategy_specs(strategy_config_path)
 
     stages, omni_lb_policy = StageConfigFactory.create_legacy_stage_configs_from_model(
         model,
@@ -439,6 +483,152 @@ def load_stage_configs_from_model(
         strategy_note,
     )
     return [], None
+
+
+def load_stage_config_views_from_model(
+    model: str,
+    *,
+    trust_remote_code: bool | None,
+    base_engine_args: dict | None = None,
+    deploy_config_path: str | None = None,
+    stage_overrides: dict[str, dict[str, Any]] | None = None,
+    strategy_config_path: str | None = None,
+) -> ResolvedStageConfigs:
+    """Resolve aligned typed and legacy views in one factory pass."""
+    cli_overrides = _build_stage_cli_overrides(
+        base_engine_args,
+        trust_remote_code,
+        stage_overrides,
+    )
+    resolution: StageConfigResolution = StageConfigFactory.create_config_views_from_model(
+        model,
+        trust_remote_code=trust_remote_code,
+        cli_overrides=cli_overrides,
+        deploy_config_path=deploy_config_path,
+        strategy_specs=_load_strategy_specs(strategy_config_path),
+    )
+    if resolution.legacy_stage_configs is None:
+        strategy_note = ""
+        if strategy_config_path is not None:
+            strategy_note = f" Strategy config {strategy_config_path!r} was not applied."
+        logger.warning(
+            "No registered PipelineConfig resolved for model %r. Legacy `stage_args` "
+            "YAMLs are no longer supported; register the pipeline and provide deployment "
+            "overrides through `deploy_config`.%s",
+            model,
+            strategy_note,
+        )
+        legacy_stages: list[Any] = []
+    else:
+        legacy_stages = [stage.to_omegaconf() for stage in resolution.legacy_stage_configs]
+    return ResolvedStageConfigs(
+        config_path=resolution.deploy_config_path,
+        omni_config=resolution.omni_config,
+        stage_configs=legacy_stages,
+        deploy_config=resolution.deploy_config,
+        omni_lb_policy=resolution.omni_lb_policy,
+    )
+
+
+def _build_default_diffusion_config_views(
+    model: str,
+    default_stage_configs: Any,
+) -> tuple[list[Any], VllmOmniConfig, DeployConfig]:
+    """Build both views from the normalized single-stage diffusion fallback."""
+    raw_stages = _convert_dataclasses_to_dict(default_stage_configs)
+    if not isinstance(raw_stages, list) or len(raw_stages) != 1:
+        raise ValueError("The unregistered-model fallback must define exactly one diffusion stage")
+
+    raw_stage = dict(raw_stages[0])
+    stage_type = raw_stage.get("stage_type")
+    if stage_type not in {StageType.DIFFUSION, StageType.DIFFUSION.value}:
+        raise ValueError("The unregistered-model fallback only supports a diffusion stage")
+
+    engine_args = dict(raw_stage.get("engine_args") or {})
+    runtime = dict(raw_stage.get("runtime") or {})
+    stage_id = int(raw_stage.get("stage_id", 0))
+    if stage_id != 0:
+        raise ValueError(f"The single-stage diffusion fallback must use stage_id=0, got {stage_id}")
+
+    topology = StagePipelineConfig(
+        stage_id=stage_id,
+        model_stage=str(engine_args.get("model_stage") or "diffusion"),
+        execution_type=StageExecutionType.DIFFUSION,
+        input_sources=tuple(int(source) for source in raw_stage.get("engine_input_source", ())),
+        final_output=bool(raw_stage.get("final_output", True)),
+        final_output_type=raw_stage.get("final_output_type"),
+        model_arch=engine_args.get("model_arch"),
+        custom_process_input_func=raw_stage.get("custom_process_input_func"),
+        cfg_kv_collect_func=raw_stage.get("cfg_kv_collect_func") or engine_args.get("cfg_kv_collect_func"),
+    )
+    for topology_owned_field in (
+        "cfg_kv_collect_func",
+        "model_stage",
+    ):
+        engine_args.pop(topology_owned_field, None)
+    # Historical no-op accepted only because OmniDiffusionConfig.from_kwargs
+    # silently discarded unknown fields. It has no typed config owner.
+    engine_args.pop("enable_ar_profiler", None)
+    pipeline = PipelineConfig(
+        model_type="__single_stage_diffusion__",
+        model_arch=str(engine_args.get("model_arch") or ""),
+        stages=(topology,),
+    )
+    stage_deploy = StageDeployConfig(
+        stage_id=stage_id,
+        devices=runtime.get("devices"),
+        num_replicas=int(runtime.get("num_replicas", 1)),
+        env=runtime.get("env"),
+        default_sampling_params=dict(raw_stage.get("default_sampling_params") or {}),
+        engine_extras=engine_args,
+    )
+    deploy = DeployConfig(
+        async_chunk=bool(engine_args.get("async_chunk", False)),
+        stages=[stage_deploy],
+    )
+    omni_config = VllmOmniConfig.from_pipeline_config(
+        pipeline,
+        user_deploy_config=deploy,
+        cli_overrides={"model": model},
+    )
+    legacy_stages = list(create_config(raw_stages))
+    return legacy_stages, omni_config, deploy
+
+
+def _filter_resolved_stage_views(
+    resolved: ResolvedStageConfigs,
+    kwargs: dict | None,
+) -> ResolvedStageConfigs:
+    """Apply mode filtering once and mirror the selected IDs to the typed view."""
+    filtered_legacy = filter_stages(resolved.config_path, resolved.stage_configs, kwargs)
+    if resolved.omni_config is None:
+        return ResolvedStageConfigs(
+            config_path=resolved.config_path,
+            omni_config=None,
+            stage_configs=filtered_legacy,
+            deploy_config=resolved.deploy_config,
+            omni_lb_policy=resolved.omni_lb_policy,
+        )
+
+    selected_ids = [int(stage.stage_id) for stage in filtered_legacy]
+    typed_stages = tuple(resolved.omni_config.stage_by_id(stage_id) for stage_id in selected_ids)
+    omni_config = VllmOmniConfig(
+        pipeline_config=resolved.omni_config.pipeline_config,
+        stage_configs=typed_stages,
+        orchestrator_config=resolved.omni_config.orchestrator_config,
+    )
+    typed_ids = [stage.stage_id for stage in omni_config.stage_configs]
+    if typed_ids != selected_ids:
+        raise ValueError(
+            f"Structured and legacy stage views diverged after mode filtering: typed={typed_ids}, legacy={selected_ids}"
+        )
+    return ResolvedStageConfigs(
+        config_path=resolved.config_path,
+        omni_config=omni_config,
+        stage_configs=filtered_legacy,
+        deploy_config=resolved.deploy_config,
+        omni_lb_policy=resolved.omni_lb_policy,
+    )
 
 
 def filter_stages(
@@ -554,6 +744,71 @@ def parse_stage_overrides(value: Any) -> dict[str, dict[str, Any]] | None:
     return value
 
 
+def load_and_resolve_stage_config_views(
+    model: str,
+    kwargs: dict | None,
+    *,
+    trust_remote_code: bool | None,
+    default_stage_cfg_factory: Any = None,
+    deploy_config_path: str | None = None,
+    stage_overrides: dict[str, dict[str, Any]] | None = None,
+    strategy_config_path: str | None = None,
+) -> ResolvedStageConfigs:
+    """Resolve aligned typed and compatibility stage views for runtime startup."""
+    resolved = load_stage_config_views_from_model(
+        model,
+        trust_remote_code=trust_remote_code,
+        base_engine_args=kwargs,
+        deploy_config_path=deploy_config_path,
+        stage_overrides=stage_overrides,
+        strategy_config_path=strategy_config_path,
+    )
+    config_path = resolved.config_path
+    # A registered pipeline may omit a default deploy file; retain the legacy
+    # path lookup for that case.  An unresolved model is intentionally handled
+    # by the single-stage diffusion fallback (when supplied), so do not perform
+    # a second HF/model-index lookup merely to populate a compatibility path.
+    if config_path is None and resolved.omni_config is not None:
+        if deploy_config_path is not None:
+            config_path = deploy_config_path
+        else:
+            # A registry entry may intentionally omit a default deploy file
+            # (and callers/tests often use a synthetic model key). Path lookup
+            # is only ancillary for transfer/mode discovery; never make a
+            # successful structured resolution fail because that lookup cannot
+            # infer a local/HF config path.
+            try:
+                config_path = resolve_model_config_path(model)
+            except Exception as exc:
+                logger.debug("Could not resolve ancillary config path for %r: %s", model, exc)
+                config_path = None
+
+    if not resolved.stage_configs and default_stage_cfg_factory is not None:
+        legacy_stages, omni_config, deploy_config = _build_default_diffusion_config_views(
+            model,
+            default_stage_cfg_factory(),
+        )
+        resolved = ResolvedStageConfigs(
+            config_path=config_path,
+            omni_config=omni_config,
+            stage_configs=legacy_stages,
+            deploy_config=deploy_config,
+            omni_lb_policy=resolved.omni_lb_policy,
+        )
+    else:
+        resolved = ResolvedStageConfigs(
+            config_path=config_path,
+            omni_config=resolved.omni_config,
+            stage_configs=resolved.stage_configs,
+            deploy_config=resolved.deploy_config,
+            omni_lb_policy=resolved.omni_lb_policy,
+        )
+
+    resolved = _filter_resolved_stage_views(resolved, kwargs)
+    logger.debug("stage_configs: %s", resolved.stage_configs)
+    return resolved
+
+
 def load_and_resolve_stage_configs(
     model: str,
     kwargs: dict | None,
@@ -563,7 +818,7 @@ def load_and_resolve_stage_configs(
     deploy_config_path: str | None = None,
     stage_overrides: dict[str, dict[str, Any]] | None = None,
     strategy_config_path: str | None = None,
-) -> tuple[str, list, str | None]:
+) -> tuple[str | None, list, str | None]:
     """Load stage configurations from a deploy YAML or model defaults.
 
     Args:
@@ -594,14 +849,12 @@ def load_and_resolve_stage_configs(
     )
     if not stage_configs:
         if default_stage_cfg_factory is not None:
-            default_stage_cfg = default_stage_cfg_factory()
-            stage_configs = create_config(_convert_dataclasses_to_dict(default_stage_cfg))
+            stage_configs = create_config(_convert_dataclasses_to_dict(default_stage_cfg_factory()))
         else:
             stage_configs = []
 
     stage_configs = filter_stages(config_path, stage_configs, kwargs)
-    logger.debug(f"stage_configs: {stage_configs}")
-
+    logger.debug("stage_configs: %s", stage_configs)
     return config_path, stage_configs, omni_lb_policy
 
 

--- a/vllm_omni/model_executor/models/wan2_2/pipeline.py
+++ b/vllm_omni/model_executor/models/wan2_2/pipeline.py
@@ -10,6 +10,7 @@ from vllm_omni.config.stage_config import (
 
 WAN2_2_TI2V_PIPELINE = PipelineConfig(
     model_type="wan2_2_ti2v",
+    default_deploy_config_name="wan2_2_ti2v.yaml",
     model_arch="WanPipeline",
     diffusers_class_name="WanPipeline",
     diffusers_class_aliases=("WanDMDPipeline",),


### PR DESCRIPTION
 ## Purpose

  Implement RFC #4021 Phase 3 PR9 by migrating the DiT stage consumer path from the legacy StageConfig/OmegaConf representation to the typed VllmOmniConfig representation.

  - Add a shared resolver that produces aligned typed and legacy stage views from one pipeline/deploy/CLI resolution.

  - Add the typed omni_stage_config field to ReplicaInitPlan and propagate typed stage configuration through local, distributed, and headless startup.

  - Route all DiT initialization through the typed diffusion builder and OmniDiffusionConfig.

  - Keep AR and generation stages on the existing legacy consumer path.
  - Preserve the legacy stage configuration in the registration payload for wire compatibility.

  - Preserve model revision information through model discovery, diffusion configuration, tokenizer loading, model-index loading, and model component loading.

  - Route diffusion-only CLI arguments only to diffusion stages.
  - Preserve full typed pipeline topology after mode filtering so heterogeneous AR/DiT tensor-parallel layouts can still derive KV rank mappings.

  - Validate the following model boundaries:
      - Wan2.2: typed DiT consumer path.
      - HunyuanImage3 DiT-only: typed DiT consumer path.
      - HunyuanImage3 AR + DiT: AR remains legacy, DiT uses the typed path.

  ## Test Plan

  - Run configuration, resolver, stage initialization, headless, distributed, and engine-argument regression tests.

  - Run diffusion configuration and model-specific tests for Wan2.2 and HunyuanImage3.

  - Verify revision propagation for pipeline discovery, Diffusers model indexes, tokenizers, and model components.

  - Verify heterogeneous TP topology propagation through mode-filtered pipelines.

  - Collect Qwen3-Omni, Wan2.2, and HunyuanImage3 offline E2E tests without downloading model weights.

  - Run ruff check, ruff format, and git diff --check.
  - Real model E2E execution is deferred because it requires GPU hardware and model checkpoints.

  vLLM Version: 0.27.0+cpu (existing local validation environment; no
  vLLM build or model download performed)

  vLLM-Omni Commit: 1221054667c5af876f0050451accaab12799a8ad

  ## Test Result

  - Focused regression tests: 833 passed, 2 skipped
  - Wan2.2, and HunyuanImage3 E2E collection: 9 tests collected

  - ruff check: passed
  - ruff format: passed
  - git diff --check: passed
  - Commit hooks passed except the Python 3.10 mypy hook. That hook reports cross-version typing issues in the current local environment, including enum.StrEnum and vLLM compatibility annotations, and was skipped for this commit.

  - No real model inference E2E was executed.
