### PR TITLE
[Doc] Add design doc for scheduler-managed diffusion paged KV cache

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -69,6 +69,8 @@ nav:
       - Cache Acceleration:
         - TeaCache: user_guide/diffusion/cache_acceleration/teacache.md
         - Cache-DiT: user_guide/diffusion/cache_acceleration/cache_dit.md
+      - KV Cache:
+        - Scheduler-Managed Paged KV Cache: user_guide/diffusion/paged_kv_cache.md
       - Parallelism:
         - Overview: user_guide/diffusion/parallelism/overview.md
         - CFG Parallel: user_guide/diffusion/parallelism/cfg_parallel.md

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -140,6 +140,7 @@ nav:
         - Attention Optimization:
           - Backend Selection: design/feature/attention_backend_selection.md
           - Skip-Softmax: design/feature/skip_softmax.md
+          - Scheduler-Managed Paged KV Cache: design/feature/diffusion_paged_kv_cache.md
         - CPU Offloading:
           - Overview: design/feature/offloader/README.md
           - Model-Level: design/feature/offloader/cpu_offload.md

--- a/docs/design/feature/diffusion_paged_kv_cache.md
+++ b/docs/design/feature/diffusion_paged_kv_cache.md
@@ -1,379 +1,337 @@
----
-title: Scheduler-Managed Paged KV Cache for Diffusion DiT Stages
-kind: feature
-status: draft
-owners:
-  - "@Acerak01-fy"
-  - "@zwhzzz0821"
-primary_code_paths:
-  - vllm_omni/diffusion/diffusion_kv/**
-  - vllm_omni/diffusion/sched/**
-  - vllm_omni/diffusion/worker/**
-  - vllm_omni/diffusion/attention/**
-related_code_paths:
-  - vllm_omni/diffusion/models/hunyuan_image3/**
-  - vllm_omni/diffusion/forward_context.py
-  - vllm_omni/platforms/**
-depends_on:
-  - ../module/diffusion/diffusion_runtime.md
-  - ../module/cache_management.md
-validation_paths:
-  - tests/diffusion/diffusion_kv/**
-  - tests/diffusion/models/hunyuan_image3/**
-  - tests/e2e/accuracy/test_hunyuan_image3.py
-upstream_refs:
-  - https://github.com/vllm-project/vllm-omni/issues/5244
-  - https://github.com/vllm-project/vllm-omni/pull/5541
-  - https://github.com/vllm-project/vllm-omni/pull/5550
-  - https://github.com/vllm-project/vllm-omni/pull/6094
-  - https://github.com/vllm-project/vllm-omni/pull/6102
-  - https://github.com/vllm-project/vllm-omni/pull/6563
-  - https://github.com/vllm-project/vllm-omni/pull/6658
-last_reviewed: 2026-09-01
----
+# Scheduler-Managed Paged KV Cache
 
-# Scheduler-Managed Paged KV Cache for Diffusion DiT Stages
+This document describes the design and lifecycle of Scheduler-managed paged KV cache for diffusion DiT stages.
 
-This document defines the implementation contract for Scheduler-managed
-key/value (KV) cache in a diffusion DiT stage. HunyuanImage-3.0 is the first
-complete integration, using request-level execution on NVIDIA GPU and Ascend
-NPU. The contract applies only to the models and platforms listed in the
-compatibility matrix.
+For operator-facing configuration and examples, see the
+[Paged KV Cache user guide](../../user_guide/diffusion/paged_kv_cache.md).
 
-## Scope and goals
+## Table of Contents
 
-Paging changes KV storage and ownership, not Hunyuan's attention semantics.
-Prompt and reference-image tokens are stable across denoising steps, while
-the timestep and generated-image span is rewritten. The paged path stores the
-stable prefix in Worker-owned pages and updates only the changing span after
-the first step.
+1. [Overview](#overview)
+2. [Motivation](#motivation)
+3. [Architecture](#architecture)
+4. [Execution Modes](#execution-modes)
+5. [Design](#design)
+6. [Model and Platform Integration](#model-and-platform-integration)
+7. [Configuration and Compatibility](#configuration-and-compatibility)
+8. [Limitations](#limitations)
+9. [Related Files](#related-files)
 
-The design guarantees:
+## Overview
 
-- the Scheduler owns logical allocation and release;
-- the Worker owns physical tensors, native BlockTables, slots, and metadata;
-- when CFG is enabled, all CFG rows are admitted atomically (a request without
-  CFG has one row);
-- the model supplies layout and attention spans but never allocates pages or
-  activates the Worker runtime; and
-- invalid or stale metadata fails explicitly instead of silently falling back
-  to dense execution.
+Scheduler-managed paged KV provides a page-based memory and data-movement
+foundation for diffusion DiT stages. It makes KV capacity explicit, preserves
+stable prefixes across denoising steps, and defines page-granular destinations
+for future AR-to-DiT transfer. HunyuanImage-3.0 is the current request-mode
+reference on CUDA and Ascend NPU; the supported boundaries and follow-up work
+are described below.
 
-The current implementation does not cover Hunyuan paged step execution,
-continuous batching, independent public request batching
-(`supports_request_batch=False`), more than two CFG branches, imported
-AR-to-DiT KV, independent Hunyuan KV contexts, cross-request prefix
-publication, Ring attention, or AllGather-KV SP. The reserved
-`paged_worker_local` mode is also not implemented.
+## Motivation
 
-## Architecture and ownership
+Paged KV is introduced for three related goals:
 
-~~~mermaid
+1. **Memory management:** make diffusion KV capacity visible to the Scheduler
+   so logical requests can reserve and release fixed-size blocks while the
+   Worker owns one reusable physical pool. This improves capacity planning and
+   memory utilization, and can increase request concurrency and throughput when
+   the dense path would otherwise reserve separate full tensors.
+2. **Transfer optimization:** give a DiT stage stable destination page slots so
+   a future AR-to-DiT connector can transfer missing KV blocks directly,
+   instead of gathering a complete tensor into a temporary receiver buffer.
+3. **Prefix reuse:** keep the stable prompt/reference prefix resident while
+   only the timestep/image target is rewritten at each denoising step. The same
+   page-level contract also provides the foundation for canonical prefix-cache
+   reuse when a model supplies cacheable block identities.
+
+Request-local memory management and prefix reuse are implemented by the local
+request path. Cross-stage transfer and cross-request canonical prefix caching
+use the same page interfaces but require model/connector integration that is
+outside the current Hunyuan implementation.
+
+The legacy dense path keeps complete model-owned tensors for each request. The
+paged path instead maps requests to Scheduler blocks and reuses a Worker page
+pool, making capacity and fragmentation explicit. This can improve HBM
+utilization and concurrency, although it does not guarantee lower latency for
+every shape.
+
+## Architecture
+
+The control plane describes and reserves logical sequences. The data plane
+installs the resulting snapshot on each Worker and runs the native attention
+backend.
+
+```mermaid
 flowchart LR
-    A[Request] --> B[Model preprocessing]
-    B -->|Prepared layout + KV requests| C[Scheduler]
-    C -->|Allocation metadata| D[Executor / Worker RPC]
-    D --> E[Worker KV backend]
-    E -->|Pages + BlockTables + slots| F[Model runner]
-    F -->|ForwardContext runtime| G[Common Attention]
-    G --> H[CUDA paged attention]
-    G --> I[Ascend FIA paged attention]
-    C -. release logical blocks .-> C
-    E -. clear physical rows .-> E
-~~~
+    subgraph CP[Control plane]
+        R[Diffusion request] --> P[Model preprocessing<br/>layout, CFG rows, spans]
+        P --> S[Diffusion Scheduler<br/>logical sequences and blocks]
+        S --> M[DiffusionKVMetadata]
+    end
+    M -->|immutable snapshot| X[Executor / RPC]
+    subgraph DP[Data plane: each Worker rank]
+        W[Model runner<br/>physical pages and block tables]
+        W --> A[Paged attention adapter]
+        A --> C[CUDA FlashAttention / FA3]
+        A --> N[Ascend FIA]
+        W --> O[Denoising output]
+    end
+    X --> W
+```
+
+### Ownership boundary
 
 | Component | Owns | Does not own |
 | --- | --- | --- |
-| Model preprocessing | Token/image layout, positions, CFG count, `full_attn_spans` | Physical blocks or Worker state |
-| Scheduler | Request lifecycle, logical sequences, admission, block release | Device tensors or native metadata |
-| Executor/RPC | Transport of an immutable allocation snapshot | Allocation decisions |
-| Worker/model runner | Physical KV tensors, rows, BlockTables, slots, active runtime | Scheduler block lifetime |
-| Common attention layer | Parallel hooks and backend boundary | Request admission or page allocation |
-| Platform backend | Native geometry, BlockTables, metadata, kernel selection | Model-specific token semantics |
+| Model preprocessing | Lengths, positions, CFG count, and attention spans | Physical blocks or Worker state |
+| Diffusion Scheduler | Request lifecycle, logical sequences, admission, and release | Device tensors or native kernel metadata |
+| Executor/RPC | Transport of the immutable allocation snapshot | Allocation decisions or page contents |
+| Worker/model runner | Rank-local KV tensors, rows, block tables, slots, and active metadata | Scheduler block lifetime |
+| Paged attention adapter | Layout translation, slot metadata, and backend dispatch | Capacity management or request admission |
+| Platform backend | Native page geometry, metadata construction, and kernel selection | Model-specific token semantics |
 
-The public request owns one logical sequence per Hunyuan CFG branch (one
-sequence when CFG is disabled). These sequences are allocated and released as
-one unit. `DiffusionKVMetadata` is an allocation snapshot containing IDs,
-lengths, and block IDs; it contains no device pointers, K/V tensors, or mutable
-Scheduler objects.
+`DiffusionKVCacheManager` is the request-facing Scheduler facade: it groups and
+atomically allocates the internal sequences for one request, then publishes
+`DiffusionKVMetadata` over the Worker-owned physical pool.
 
-## Lifecycle
+### Request lifecycle
+
+1. **Admission:** preprocessing creates one logical sequence per CFG branch;
+   the Scheduler reserves all required blocks atomically.
+2. **Activation:** the Worker validates the metadata generation, binds rows,
+   stages block tables, and installs native attention metadata.
+3. **Execution:** the first denoising step writes the complete sequence once;
+   later steps write only the changing target span and read retained pages.
+4. **Release:** completion, cancellation, errors, and reinitialization release
+   Scheduler blocks and clear Worker rows.
+
+Dense requests do not install paged metadata. Paged requests reject legacy
+dense KV payloads or stale/incomplete native metadata instead of silently
+falling back to dense execution.
+
+### AR-to-DiT transfer contract
+
+When an AR stage and a DiT stage are deployed separately, the previous
+model-owned transfer commonly gathers and flattens a complete KV tensor into a
+temporary receiver buffer before the DiT model can use it.
+
+The Scheduler-managed contract gives the DiT Worker a destination page layout
+before transfer. The current feature implements this DiT-side destination
+contract (reservation, layout, and generation/readiness metadata); it does not
+execute connector transfers or import AR KV. A future connector can target the
+reserved slots directly:
+
+```mermaid
+flowchart LR
+    A[AR Worker<br/>source pages] --> X[Connector<br/>missing blocks]
+    S[DiT Scheduler<br/>reserve destination blocks] --> D[DiT Worker<br/>destination pages]
+    X --> D
+    D --> F[Native DiT attention]
+```
+
+The diagram is a target connector boundary, not an enabled runtime path in this
+feature. The expected benefits of a future connector using this contract are:
+
+| Concern | Previous model-owned transfer | Page-native destination contract |
+| --- | --- | --- |
+| Transfer unit | Packed or complete KV tensor | Individual missing page blocks |
+| Receiver storage | Temporary contiguous tensor, then model cache | Scheduler-reserved Worker pages |
+| Data movement | Gather/flatten plus another copy or concatenation | Direct write to destination slots when a connector is enabled |
+| Readiness | Implicit runner-side synchronization | Explicit generation and ready metadata |
+| Denoising reuse | Reassemble the stable prefix in the model | Native attention reads resident pages |
+| Cleanup | Transfer and model-cache lifetimes are coupled | Source lease, destination reservation, and request release are explicit |
+
+Reserving destination pages up front supplies stable physical targets and an
+explicit generation/ready state, so a future connector can move only missing
+blocks and pass the same metadata to native attention. Imported AR KV is not
+enabled for `paged_scheduler` in this PR; DreamZero and LingBot-World use the
+separate `ar_diffusion_kv` contract.
+
+## Execution Modes
+
+Paged KV is a cache feature; request batching and step execution are separate
+engine modes. The terminology follows the
+[diffusion continuous batching design](diffusion_continuous_batching.md):
+
+| Execution path | Configuration | Scheduler batch unit | Hunyuan `paged_scheduler` status |
+| --- | --- | --- | --- |
+| Request execution | `step_execution=false`, `max_num_seqs=1` | One complete denoising request | Current supported path |
+| Request-level batching | `step_execution=false`, `max_num_seqs>1` | Multiple compatible public requests in one forward | Not supported by the current `paged_scheduler` integration |
+| Step execution | `step_execution=true`, `max_num_seqs=1` | One request advances one denoising step per scheduler tick | Paged path rejects it |
+| Step continuous batching | `step_execution=true`, `max_num_seqs>1` | Compatible active step states advance together | Separate feature; paged Hunyuan is not implemented |
+
+`max_num_seqs` limits public requests. CFG branches are internal rows of one
+request and are controlled by `diffusion_kv_max_rows_per_request`: a request
+without CFG uses one row, while the standard positive/negative CFG request uses
+two. Atomic CFG admission does not mean that CFG is required.
+
+## Design
 
 ### Startup and cache sizing
 
-Before admitting requests, the engine and Workers:
+Before real requests are admitted, the engine and Workers:
 
 1. Resolve `diffusion_kv_mode` and prepare a maximum-shape profile request.
-2. Register paged attention layers and report a native `KVCacheSpec` per group.
-3. Profile the request to determine non-KV memory. This probe is marked
-   `in_diffusion_kv_memory_profile` and is not a latency sample.
-4. Build the native vLLM cache configuration and resolve block geometry.
-5. Allocate rank-local physical pages and native BlockTables, then create the
-   Scheduler's `DiffusionKVCacheManager` over the same geometry.
+2. Register paged attention layers and collect a native `KVCacheSpec` per KV
+   group.
+3. Run the marked memory profile to determine non-KV memory. This probe is not
+   a latency sample. On NPU, it may use SDPA only when MindIE-SD is
+   unavailable; this is the sole intentional fallback and applies only to this
+   startup profile.
+4. Build the native cache configuration and resolve block geometry.
+5. Allocate rank-local physical pages and create the Scheduler facade over the
+   same geometry.
 
-`kv_cache_memory_bytes` is an explicit physical KV-pool budget per Worker and
-rank. It is not a request token count. Without it, sizing uses the normal
-`gpu_memory_utilization` path:
+`kv_cache_memory_bytes` is a physical KV-pool budget per Worker rank, not a
+request token count. When omitted, the normal utilization path sizes the pool
+after subtracting profiled non-KV memory. Reserved pool memory can exceed the
+live payload because it also reflects capacity and fragmentation.
 
-~~~text
-requested_memory = device_total_memory * gpu_memory_utilization
-available_kv_memory = requested_memory - profiled_non_kv_memory
-~~~
+### Logical layout
 
-Once the pool exists, a sequence of length `seq_len` needs approximately
-`ceil(seq_len / block_size)` blocks. Allocator `reserved` memory can exceed
-live payload because it describes pool capacity and fragmentation.
+Each sequence has a stable prefix and a changing target:
 
-Relevant configuration fields are:
+```text
+|-------------------------- allocated seq_len --------------------------|
+|---------------- prefix_len ----------------|---- target_len ----|unused|
+             retained across steps                 rewritten each step
+```
 
-| Field | Meaning |
-| --- | --- |
-| `diffusion_kv_mode` | `dense_legacy` (default) or `paged_scheduler` |
-| `diffusion_kv_max_rows_per_request` | Maximum Worker rows, including CFG branches |
-| `kv_cache_memory_bytes` | Optional explicit per-rank physical pool budget |
-| `gpu_memory_utilization` | Automatic pool-sizing fraction when no byte budget is set |
-| `max_model_len` | Per-sequence admission ceiling |
-| `max_num_seqs` | Maximum public requests in one Scheduler wave |
-| `max_num_batched_tokens` | Native attention token capacity for a prepared batch |
-
-### Admission and release
-
-The Scheduler facade validates IDs and lengths, computes the full reservation
-for every CFG branch, and waits when the pool is temporarily full. When all
-branches fit, it allocates them with `full_sequence_must_fit=True`; any
-partial failure rolls back the whole request. One metadata snapshot is then
-published with an allocation generation.
-
-On the Worker, installing a snapshot validates the generation, group count,
-block IDs, row capacity, and lengths; binds each logical identity to a free
-row; stages BlockTables; and invalidates metadata if the tables changed.
-Reinstalling the same generation is idempotent. A stale generation, duplicate
-identity, invalid block, or mismatched group count is a hard error.
-
-Scheduler logical blocks and Worker physical rows are released independently
-on completion, cancellation, admission failure, errors, `close`, and
-reinitialization. Dense requests never install paged metadata, and paged
-requests reject legacy dense `past_key_values` payloads.
-
-## Request execution and Hunyuan layout
-
-The current contract is request-level execution (`step_execution=false`). The
-runner installs the allocation snapshot, prepares row metadata, and executes
-the normal pipeline forward. For each sequence it uses the following rows:
+The runner exposes these boundaries to the adapter:
 
 | Phase | `query_len` | `seq_len` | `kv_start_pos` |
 | --- | ---: | ---: | ---: |
 | First denoising/prefill | `seq_len` | `seq_len` | `0` |
 | Later denoising steps | `target_len` | `prefix_len + target_len` | `prefix_len` |
 
-The ordered sequence identity is unchanged between phases. The runner places
-the active rows and `DiffusionPagedAttentionRuntime` in `ForwardContext`; the
-denoising loop switches from prefill to denoise metadata once and reuses it
-across all attention layers.
+For `block_size`, token position `p` maps to the native slot
+`block_id(p // block_size) * block_size + p % block_size`. The Scheduler owns
+the block IDs; the Worker turns them into rank-local tables and slots.
 
-Hunyuan-specific preprocessing in `request_layout.py` derives:
+### Dense and paged representation
 
-~~~text
-prefix_len = final generated-timestep scatter position
-target_len = image tokens + timestep token + guidance token
-seq_len    = final real position in the prepared row
-~~~
+Both modes implement Hunyuan's mixed causal/full attention. They differ in KV
+representation and backend input, not in the attention result they describe:
 
-`HunyuanImage3Pipeline` creates one KV sequence for each conditional or
-unconditional CFG branch. CFG rows are internal branches of one request, not
-unrelated public requests. `_forward_paged()` validates lengths and spans,
-describes Q/K/V layout, clears the legacy dense prompt cache, and handles the
-Hunyuan prompt/image split needed by strict Ulysses SP. It does not allocate
-blocks or activate the Worker runtime.
-
-Strict Ulysses SP is supported in request mode. The parallel strategy performs
-its Q/K/V exchange, the paged adapter removes synthetic padding before native
-metadata preparation, and zero placeholders are restored before the reverse
-exchange. Ring and AllGather-KV SP are rejected because their metadata and
-communication contracts are different.
-
-## Attention execution
-
-Dense and paged paths implement the same mixed causal/full attention. They
-differ in storage and in how a backend realizes the mask.
-
-### Dense path
-
-The Hunyuan dense path materializes a 4-D mask and carries equivalent
-`full_attn_spans` metadata. On NPU, the normal dense backend usually makes one
-masked attention call per layer. On CUDA, the shared piecewise FA helper may
-use one dense call per aligned segment. Thus "dense" describes the tensor
-representation, not a universal number of kernel calls.
-
-### Paged path
-
-Paged execution passes `full_attn_spans` instead of a quadratic mask. Each row
-is converted into aligned native segments:
-
-| Segment | Native inputs | Causal flag |
+| Aspect | `dense_legacy` | `paged_scheduler` |
 | --- | --- | --- |
-| Causal `[s, e)` | `Q[s:e]`, `K[:e]`, `V[:e]` | `true` |
-| Full `[a, b)` | Query overlap, `K[:b]`, `V[:b]` | `false` |
+| KV owner | Model-owned contiguous cache | Worker-owned physical pages |
+| Attention input | Contiguous K/V with a dense mask and/or span metadata | Block tables, slots, lengths, and `full_attn_spans` |
+| Prefix reuse | Model-owned prefix tensor; cache scope depends on the dense path | Stable prefix pages are retained across denoising steps; canonical cross-request reuse requires cache identities |
+| Scheduler state | No diffusion page reservation | Logical sequences, admission, generation, and release |
 
-The segment boundaries preserve bottom-right causal alignment. Native paged
-calls read persistent Worker pages, and results are restored to the original
-token order before `o_proj`, residual, and MLP layers consume them.
+The current implementation guarantees prefix reuse between the first and later
+denoising steps. Native vLLM cross-request prefix caching is not enabled by
+this Hunyuan integration: the diffusion KV manager uses
+`enable_caching=False`, and Hunyuan does not publish canonical block hashes.
 
-The K/V update is outside the segment loop:
+### Attention execution
 
-~~~text
+The two paths preserve the same mixed causal/full spans. In the paged path,
+the adapter converts each row into aligned native segments:
+
+| Segment | Query input | KV visibility | Causal flag |
+| --- | --- | --- | --- |
+| Causal `[s, e)` | `Q[s:e]` | `K[:e]`, `V[:e]` | `true` |
+| Full `[a, b)` | Query overlap | `K[:b]`, `V[:b]` | `false` |
+
+The K/V update is deliberately outside the segment loop:
+
+```text
 Q/K/V projection
-  -> write the current K/V span once
-  -> run all piecewise native attention segments
-  -> restore output order
-~~~
+    -> write the current K/V span once per layer
+    -> run all causal/full native segments
+    -> restore output order
+```
 
-CUDA keeps the update in its native paged-attention contract. Ascend performs
-an explicit normal-layout cache prewrite, then FIA segment calls read the
-written pages without a K/V source. The obsolete logical-cache to PA_NZ and
-back conversion is not part of this contract.
+CUDA keeps cache-update ownership in its native paged-attention contract.
+Ascend prewrites the normal-layout K/V span once, then FIA segment calls read
+the persistent pages without receiving K/V again. Output is restored to the
+original token order before projection, residual, and MLP layers consume it.
 
-## Piecewise planning
+Dense does not imply one universal kernel call. Hunyuan's CUDA dense path can
+also use the shared piecewise FlashAttention helper for aligned regions. In
+the paged path, the same regions are described as native segments that read
+persistent pages. The two modes can therefore have different kernel names and
+call counts while preserving the same mask semantics.
 
-`DiffusionPagedAttentionAdapter` resolves Worker rows, gathers BlockTables,
-computes slots, builds platform metadata, and caches the segment plan for the
-active forward.
+### Piecewise planning
 
-| Row layout | Execution | Purpose |
-| --- | --- | --- |
-| Homogeneous query lengths and ranges | Keep `[B, T, ...]`, flatten each segment for the native call, then reshape/concatenate or write directly to the output buffer | Avoid the large indexed output scatter for homogeneous CFG rows |
-| Heterogeneous lengths or offsets | `index_select` valid tokens, run native calls, then `index_copy_` into the original layout | General fallback preserving each row's token order |
+The common planner supports both row layouts:
 
-The fast path applies only to rows inside one attention invocation. It does not
-enable arbitrary public-request batching or change Scheduler allocation.
-
-## Platform boundary
-
-| Concern | NVIDIA GPU | Ascend NPU |
-| --- | --- | --- |
-| Block tables | Native vLLM `BlockTables` | `AscendBlockTables` from vLLM-Ascend |
-| Paged kernel | Native FlashAttention/FA3 | Ascend `FusedInferAttentionScore` (FIA) |
-| Cache update | Native paged writer/kernel | Explicit normal-layout prewrite |
-| Attention metadata | vLLM GPU builder | Ascend builder with `ChunkedPrefill` state |
-| SP specialization | Native strict Ulysses integration | Ascend paged strict-Ulysses path |
-| Dense dependency | Platform-selected dense backend | MindIE-SD when available; SDPA only for the marked startup profile |
-
-Hardware-specific imports and policy stay behind `OmniPlatform` hooks such as
-`get_diffusion_kv_block_tables_cls()`,
-`build_diffusion_kv_attn_metadata()`, and
-`requires_diffusion_paged_kv_prewrite()`.
-
-## Configuration and compatibility
-
-`paged_scheduler` requires a native cache configuration,
-`diffusion_kv_max_rows_per_request`, and a prepared memory-profile request.
-The dense path remains the default `dense_legacy` path and keeps its existing
-backend and compatibility cache.
-
-For operator-facing setup and a request example, see the
-[Scheduler-Managed Paged KV Cache user guide](../../user_guide/diffusion/paged_kv_cache.md).
-
-### Supported model, platform, and mode matrix
-
-The matrix below describes the current implementation and validation scope.
-`paged_scheduler` is a model integration, not a switch that enables paging for
-every diffusion pipeline.
-
-| Model or integration | Platform | Mode or KV contract | Execution | Backend and status |
-| --- | --- | --- | --- | --- |
-| HunyuanImage3 | NVIDIA CUDA | `dense_legacy` | Request; dense step execution follows existing backend constraints | Existing dense path |
-| HunyuanImage3 | NVIDIA CUDA | `paged_scheduler` | Request-level only | `FLASH_ATTN` -> native FlashAttention/FA3; implemented and validated |
-| HunyuanImage3 | Ascend NPU | `dense_legacy` | Request; dense step execution follows existing backend constraints | Existing dense path |
-| HunyuanImage3 | Ascend NPU | `paged_scheduler` | Request-level only | `FLASH_ATTN` -> Ascend FIA; implemented and validated |
-| DreamZero / LingBot-World | Platform-specific | Separate `ar_diffusion_kv` contract | Model-specific AR-to-DiT flow | Imported-AR-KV path; not a `diffusion_kv_mode` value or `paged_scheduler` |
-| Other diffusion models | Any | `paged_scheduler` | N/A | No model integration or validation yet |
-
-The two Hunyuan paged rows are the only current Scheduler-managed paged-KV
-model integrations. The `ar_diffusion_kv` state used by DreamZero and
-LingBot-World is a different contract; imported AR KV is explicitly rejected
-when `diffusion_kv_mode=paged_scheduler`.
-
-### Attention backend capability
-
-The abstract `AttentionBackend` defaults to `supports_paged_kv=False`. At
-present, only `FlashAttentionBackend` opts in. Select the logical
-`FLASH_ATTN` backend: CUDA resolves it to native FlashAttention/FA3 and Ascend
-resolves it to native FIA. `TORCH_SDPA`, `CUDNN_ATTN`, `FLASHINFER_ATTN`,
-`SAGE_ATTN`, the Hub backends, and other diffusion backends do not currently
-advertise Scheduler-managed paged-KV support and must not be treated as a
-transparent fallback.
-
-### Quantization
-
-The current Hunyuan Scheduler-managed paged KV path is unquantized BF16. The
-paged adapter initializes Q/K/V scales to identity, and Hunyuan's paged cache
-specification uses `torch.bfloat16`. The generic `diffusion_kv_cache_dtype` quantization
-metadata is not part of the current `forward_paged()` contract. Model weight
-quantization (`quantization_config`) is a separate concern; its interaction
-with paged KV has not been validated. Do not infer FP8 paged-KV support from a
-quantized model or from the dense attention path.
-
-### CPU offload and distributed layerwise offload
-
-`enable_cpu_offload`, `enable_layerwise_offload`, and distributed layerwise
-offload (DLO) have no combined compatibility validation or complete test
-coverage with `paged_scheduler`. Their status with Scheduler-managed paged KV
-is therefore **unknown / untested**. For a validated paged-KV setup, leave
-these offload options disabled. If offload is required, use the
-`dense_legacy` mode instead.
-
-| Combination | Status |
+| Row layout | Preparation and output handling |
 | --- | --- |
-| Request execution, TP, no SP with `FLASH_ATTN` | Supported for the Hunyuan CUDA and NPU integrations above |
-| Request execution, strict Ulysses SP with `FLASH_ATTN` | Supported by the current GPU and NPU integrations |
-| Request execution, two-branch CFG parallel with `FLASH_ATTN` | Supported with one allocated row per CFG rank |
-| Other diffusion attention backends | Rejected for Scheduler-managed paged KV; no `supports_paged_kv` opt-in |
-| Hunyuan paged step execution | Rejected; use `dense_legacy` |
-| Independent public request batching | Disabled (`supports_request_batch=False`) |
-| Ring or AllGather-KV SP | Rejected in the paged path |
-| Imported AR KV or independent Hunyuan contexts | Not implemented |
-| Cross-request prefix publication | Disabled; pages are request-local |
+| Homogeneous ranges, such as CFG rows from one request | Keep the batched layout, use contiguous views/direct output-buffer writes, and avoid the large indexed output scatter |
+| Heterogeneous lengths or offsets | Gather valid tokens with `index_select`, run native segments, and scatter them back with `index_copy_` |
 
-## Invariants, errors, and validation
+The homogeneous fast path applies to rows in one attention invocation; it does
+not enable arbitrary public-request batching or change Scheduler allocation.
 
-Implementations must preserve these invariants:
+## Model and Platform Integration
 
-1. Each `(request_id, sequence_id/context_id)` maps to one active Worker row.
-2. Every CFG branch fits before execution begins.
-3. `kv_start_pos + query_len <= seq_len`, and installed pages cover `seq_len`.
-4. Prefill and denoise retain identity; only lengths and write offset change.
-5. Span and native metadata stay stable across layers in one forward.
-6. Dense and paged ownership are exclusive, with no accidental fallback.
-7. Scheduler blocks and Worker rows are both released on every terminal path.
+### HunyuanImage-3.0
 
-Errors should be raised by the owner that can explain them: preprocessing for
-malformed layout, Scheduler for capacity, Worker for row/table state, adapter
-for shape or metadata mismatch, and platform for unavailable kernels or
-parallel strategies. The only intentional pre-admission exception is the
-explicitly marked memory profile.
+Hunyuan is the reference integration because its self-attention mixes causal
+and full regions and its generated-image region changes across denoising
+steps. It creates one logical row per conditional or unconditional CFG branch
+and supports strict Ulysses SP in request mode. Its runner owns row creation,
+phase activation, and page metadata; the model boundary supplies token layout
+and attention spans without allocating Scheduler blocks.
 
-Validation should cover mode and sizing, atomic Scheduler allocation, Worker
-row/BlockTable contracts, adapter metadata and piecewise paths, Hunyuan layout,
-and matched dense/paged E2E output. A run should record model and Omni commit,
-platform/backend, TP/SP/CFGP topology, block geometry, KV budget, warmup
-policy, request count, and output validity. A paged run is valid only with
-native-path evidence (CUDA paged FlashAttention or Ascend FIA/cache-writer
-events) and no active dense fallback.
+### Platform matrix
 
-## Implementation map
+| Model/integration | Platform | Execution | Backend | Status |
+| --- | --- | --- | --- | --- |
+| HunyuanImage-3.0 | NVIDIA CUDA | Request-level | `FLASH_ATTN` -> native FlashAttention/FA3 | Implemented and validated |
+| HunyuanImage-3.0 | Ascend NPU | Request-level | `FLASH_ATTN` -> Ascend FIA | Implemented and validated |
+| DreamZero / LingBot-World | Platform-specific | Separate `ar_diffusion_kv` contract | Imported AR-KV path | Not `paged_scheduler` |
+| Other diffusion models | Any | N/A | N/A | No paged integration yet |
 
-- Scheduler and requests: [`diffusion_kv/manager.py`](gh-file:vllm_omni/diffusion/diffusion_kv/manager.py), [`diffusion_kv/request.py`](gh-file:vllm_omni/diffusion/diffusion_kv/request.py), [`diffusion_kv/metadata.py`](gh-file:vllm_omni/diffusion/diffusion_kv/metadata.py)
-- Initialization and Worker data plane: [`diffusion_kv/initialization.py`](gh-file:vllm_omni/diffusion/diffusion_kv/initialization.py), [`diffusion_kv/model_runner_backend.py`](gh-file:vllm_omni/diffusion/diffusion_kv/model_runner_backend.py)
-- Adapter and runtime: [`diffusion_kv/paged_attention_adapter.py`](gh-file:vllm_omni/diffusion/diffusion_kv/paged_attention_adapter.py), [`worker/diffusion_model_runner.py`](gh-file:vllm_omni/diffusion/worker/diffusion_model_runner.py), [`forward_context.py`](gh-file:vllm_omni/diffusion/forward_context.py)
-- Attention and piecewise planner: [`attention/layer.py`](gh-file:vllm_omni/diffusion/attention/layer.py), [`attention/backends/flash_attn.py`](gh-file:vllm_omni/diffusion/attention/backends/flash_attn.py), [`attention/backends/utils/piecewise_attn.py`](gh-file:vllm_omni/diffusion/attention/backends/utils/piecewise_attn.py)
-- Hunyuan boundary: [`models/hunyuan_image3/request_layout.py`](gh-file:vllm_omni/diffusion/models/hunyuan_image3/request_layout.py), [`models/hunyuan_image3/pipeline_hunyuan_image3.py`](gh-file:vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py), [`models/hunyuan_image3/hunyuan_image3_transformer.py`](gh-file:vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py)
+The logical `FLASH_ATTN` selector is the only current paged-KV capability
+advertised by `FlashAttentionBackend`. Other diffusion backends do not
+transparently fall back to dense attention for a paged request.
+
+## Configuration and Compatibility
+
+`paged_scheduler` requires a native cache configuration, a positive row limit,
+and a prepared memory-profile request. The main fields are:
+
+| Field | Meaning |
+| --- | --- |
+| `diffusion_kv_mode` | `dense_legacy` (default) or `paged_scheduler` |
+| `diffusion_kv_max_rows_per_request` | Worker row capacity for one public request, including CFG branches |
+| `kv_cache_memory_bytes` | Optional explicit physical KV-pool budget per Worker rank |
+| `gpu_memory_utilization` | Automatic pool sizing when no byte budget is supplied |
+| `diffusion_attention_backend` | Must resolve to `FLASH_ATTN` for the current paged implementation |
+
+The user guide contains the stage YAML and `vllm serve --omni` example.
+Use request execution for the current Hunyuan integration; the unsupported
+batching and step modes are summarized in [Execution Modes](#execution-modes).
+
+The current paged KV format is unquantized BF16 with identity Q/K/V scales.
+Model weight quantization, CPU offload, layerwise offload, and distributed
+layerwise offload (DLO) have not been validated with this path. Leave those
+options disabled for a validated paged setup; use `dense_legacy` when they are
+required.
+
+## Limitations
+
+- Hunyuan `paged_scheduler` is request-level only; request batching and step
+  execution are not implemented (see [Execution Modes](#execution-modes)).
+- Only strict Ulysses SP and the current two-branch CFG layout are supported;
+  Ring, AllGather-KV, and independent Hunyuan KV contexts are not implemented.
+- Imported AR-to-DiT page transfer and cross-request canonical prefix caching
+  are follow-up integrations; `ar_diffusion_kv` is a separate contract.
+- Quantized KV and CPU/DLO offload combinations are untested.
+- For a formal `paged_scheduler` request, missing native metadata or backend
+  support is an explicit error, not a dense or SDPA fallback. The marked
+  startup memory profile is the only intentional exception.
+
+## Related Files
+
+- Scheduler and allocation: [`diffusion_kv/manager.py`](gh-file:vllm_omni/diffusion/diffusion_kv/manager.py), [`diffusion_kv/request.py`](gh-file:vllm_omni/diffusion/diffusion_kv/request.py), [`diffusion_kv/metadata.py`](gh-file:vllm_omni/diffusion/diffusion_kv/metadata.py)
+- Scheduler and runtime: [`sched/base_scheduler.py`](gh-file:vllm_omni/diffusion/sched/base_scheduler.py), [`diffusion_kv/config.py`](gh-file:vllm_omni/diffusion/diffusion_kv/config.py), [`forward_context.py`](gh-file:vllm_omni/diffusion/forward_context.py), [`vllm_config.py`](gh-file:vllm_omni/diffusion/vllm_config.py)
+- Executor boundary: [`executor/abstract.py`](gh-file:vllm_omni/diffusion/executor/abstract.py), [`executor/uniproc_executor.py`](gh-file:vllm_omni/diffusion/executor/uniproc_executor.py)
+- Worker data plane: [`diffusion_kv/initialization.py`](gh-file:vllm_omni/diffusion/diffusion_kv/initialization.py), [`diffusion_kv/model_runner_backend.py`](gh-file:vllm_omni/diffusion/diffusion_kv/model_runner_backend.py), [`worker/diffusion_model_runner.py`](gh-file:vllm_omni/diffusion/worker/diffusion_model_runner.py)
+- Attention adapter and planner: [`diffusion_kv/paged_attention_adapter.py`](gh-file:vllm_omni/diffusion/diffusion_kv/paged_attention_adapter.py), [`attention/layer.py`](gh-file:vllm_omni/diffusion/attention/layer.py), [`attention/backends/flash_attn.py`](gh-file:vllm_omni/diffusion/attention/backends/flash_attn.py), [`attention/backends/utils/piecewise_attn.py`](gh-file:vllm_omni/diffusion/attention/backends/utils/piecewise_attn.py)
+- Model boundary: [`models/hunyuan_image3/request_layout.py`](gh-file:vllm_omni/diffusion/models/hunyuan_image3/request_layout.py), [`models/hunyuan_image3/pipeline_hunyuan_image3.py`](gh-file:vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py), [`models/hunyuan_image3/hunyuan_image3_transformer.py`](gh-file:vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py)
 - Platform hooks: [`platforms/interface.py`](gh-file:vllm_omni/platforms/interface.py), [`platforms/cuda/platform.py`](gh-file:vllm_omni/platforms/cuda/platform.py), [`platforms/npu/platform.py`](gh-file:vllm_omni/platforms/npu/platform.py)
-
-## Related design work
-
-The control-plane contracts were introduced in #5541 and #5550, native
-Scheduler allocation was added in #6094, and the Worker data plane in #6102.
-Hunyuan GPU integration and shared piecewise execution began in #6658 and
-were consolidated with the Ascend implementation in #6563. Future DiT models
-should reuse these contracts and add only model-specific layout, profiling,
-and backend capability requirements.

--- a/docs/design/feature/diffusion_paged_kv_cache.md
+++ b/docs/design/feature/diffusion_paged_kv_cache.md
@@ -37,7 +37,8 @@ last_reviewed: 2026-09-01
 This document defines the implementation contract for Scheduler-managed
 key/value (KV) cache in a diffusion DiT stage. HunyuanImage-3.0 is the first
 complete integration, using request-level execution on NVIDIA GPU and Ascend
-NPU. The contract is not a general support claim for every model or platform.
+NPU. The contract applies only to the models and platforms listed in the
+compatibility matrix.
 
 ## Scope and goals
 
@@ -51,15 +52,16 @@ The design guarantees:
 
 - the Scheduler owns logical allocation and release;
 - the Worker owns physical tensors, native BlockTables, slots, and metadata;
-- all CFG rows are admitted atomically;
+- when CFG is enabled, all CFG rows are admitted atomically (a request without
+  CFG has one row);
 - the model supplies layout and attention spans but never allocates pages or
   activates the Worker runtime; and
 - invalid or stale metadata fails explicitly instead of silently falling back
   to dense execution.
 
 The current implementation does not cover Hunyuan paged step execution,
-continuous batching, arbitrary public request batching
-`supports_request_batch=False`, more than two CFG branches, imported
+continuous batching, independent public request batching
+(`supports_request_batch=False`), more than two CFG branches, imported
 AR-to-DiT KV, independent Hunyuan KV contexts, cross-request prefix
 publication, Ring attention, or AllGather-KV SP. The reserved
 `paged_worker_local` mode is also not implemented.
@@ -89,10 +91,11 @@ flowchart LR
 | Common attention layer | Parallel hooks and backend boundary | Request admission or page allocation |
 | Platform backend | Native geometry, BlockTables, metadata, kernel selection | Model-specific token semantics |
 
-The public request owns one logical sequence per Hunyuan CFG branch. These
-sequences are allocated and released as one unit. `DiffusionKVMetadata`
-is an allocation snapshot containing IDs, lengths, and block IDs; it contains no
-device pointers, K/V tensors, or mutable Scheduler objects.
+The public request owns one logical sequence per Hunyuan CFG branch (one
+sequence when CFG is disabled). These sequences are allocated and released as
+one unit. `DiffusionKVMetadata` is an allocation snapshot containing IDs,
+lengths, and block IDs; it contains no device pointers, K/V tensors, or mutable
+Scheduler objects.
 
 ## Lifecycle
 
@@ -267,11 +270,64 @@ Hardware-specific imports and policy stay behind `OmniPlatform` hooks such as
 The dense path remains the default `dense_legacy` path and keeps its existing
 backend and compatibility cache.
 
+For operator-facing setup and a request example, see the
+[Scheduler-Managed Paged KV Cache user guide](../../user_guide/diffusion/paged_kv_cache.md).
+
+### Supported model, platform, and mode matrix
+
+The matrix below describes the current implementation and validation scope.
+`paged_scheduler` is a model integration, not a switch that enables paging for
+every diffusion pipeline.
+
+| Model or integration | Platform | Mode or KV contract | Execution | Backend and status |
+| --- | --- | --- | --- | --- |
+| HunyuanImage3 | NVIDIA CUDA | `dense_legacy` | Request; dense step execution follows existing backend constraints | Existing dense path |
+| HunyuanImage3 | NVIDIA CUDA | `paged_scheduler` | Request-level only | `FLASH_ATTN` -> native FlashAttention/FA3; implemented and validated |
+| HunyuanImage3 | Ascend NPU | `dense_legacy` | Request; dense step execution follows existing backend constraints | Existing dense path |
+| HunyuanImage3 | Ascend NPU | `paged_scheduler` | Request-level only | `FLASH_ATTN` -> Ascend FIA; implemented and validated |
+| DreamZero / LingBot-World | Platform-specific | Separate `ar_diffusion_kv` contract | Model-specific AR-to-DiT flow | Imported-AR-KV path; not a `diffusion_kv_mode` value or `paged_scheduler` |
+| Other diffusion models | Any | `paged_scheduler` | N/A | No model integration or validation yet |
+
+The two Hunyuan paged rows are the only current Scheduler-managed paged-KV
+model integrations. The `ar_diffusion_kv` state used by DreamZero and
+LingBot-World is a different contract; imported AR KV is explicitly rejected
+when `diffusion_kv_mode=paged_scheduler`.
+
+### Attention backend capability
+
+The abstract `AttentionBackend` defaults to `supports_paged_kv=False`. At
+present, only `FlashAttentionBackend` opts in. Select the logical
+`FLASH_ATTN` backend: CUDA resolves it to native FlashAttention/FA3 and Ascend
+resolves it to native FIA. `TORCH_SDPA`, `CUDNN_ATTN`, `FLASHINFER_ATTN`,
+`SAGE_ATTN`, the Hub backends, and other diffusion backends do not currently
+advertise Scheduler-managed paged-KV support and must not be treated as a
+transparent fallback.
+
+### Quantization
+
+The current Hunyuan Scheduler-managed paged KV path is unquantized BF16. The
+paged adapter initializes Q/K/V scales to identity, and Hunyuan's paged cache
+specification uses `torch.bfloat16`. The generic `diffusion_kv_cache_dtype` quantization
+metadata is not part of the current `forward_paged()` contract. Model weight
+quantization (`quantization_config`) is a separate concern; its interaction
+with paged KV has not been validated. Do not infer FP8 paged-KV support from a
+quantized model or from the dense attention path.
+
+### CPU offload and distributed layerwise offload
+
+`enable_cpu_offload`, `enable_layerwise_offload`, and distributed layerwise
+offload (DLO) have no combined compatibility validation or complete test
+coverage with `paged_scheduler`. Their status with Scheduler-managed paged KV
+is therefore **unknown / untested**. For a validated paged-KV setup, leave
+these offload options disabled. If offload is required, use the
+`dense_legacy` mode instead.
+
 | Combination | Status |
 | --- | --- |
-| Request execution, TP, no SP | Supported when the backend has paged support |
-| Request execution, strict Ulysses SP | Supported by current GPU and NPU integrations |
-| Request execution, two-branch CFG parallel | Supported with one allocated row per CFG rank |
+| Request execution, TP, no SP with `FLASH_ATTN` | Supported for the Hunyuan CUDA and NPU integrations above |
+| Request execution, strict Ulysses SP with `FLASH_ATTN` | Supported by the current GPU and NPU integrations |
+| Request execution, two-branch CFG parallel with `FLASH_ATTN` | Supported with one allocated row per CFG rank |
+| Other diffusion attention backends | Rejected for Scheduler-managed paged KV; no `supports_paged_kv` opt-in |
 | Hunyuan paged step execution | Rejected; use `dense_legacy` |
 | Independent public request batching | Disabled (`supports_request_batch=False`) |
 | Ring or AllGather-KV SP | Rejected in the paged path |
@@ -300,9 +356,9 @@ Validation should cover mode and sizing, atomic Scheduler allocation, Worker
 row/BlockTable contracts, adapter metadata and piecewise paths, Hunyuan layout,
 and matched dense/paged E2E output. A run should record model and Omni commit,
 platform/backend, TP/SP/CFGP topology, block geometry, KV budget, warmup
-policy, request count, and output validity. Paged claims require native-path
-evidence (CUDA paged FlashAttention or Ascend FIA/cache-writer events) and
-must verify that no dense fallback was active.
+policy, request count, and output validity. A paged run is valid only with
+native-path evidence (CUDA paged FlashAttention or Ascend FIA/cache-writer
+events) and no active dense fallback.
 
 ## Implementation map
 

--- a/docs/design/feature/diffusion_paged_kv_cache.md
+++ b/docs/design/feature/diffusion_paged_kv_cache.md
@@ -1,0 +1,619 @@
+---
+title: Scheduler-Managed Paged KV Cache for Diffusion DiT Stages
+kind: feature
+status: draft
+owners:
+  - "@Acerak01-fy"
+  - "@zwhzzz0821"
+primary_code_paths:
+  - vllm_omni/diffusion/diffusion_kv/**
+  - vllm_omni/diffusion/sched/**
+  - vllm_omni/diffusion/worker/**
+  - vllm_omni/diffusion/attention/**
+related_code_paths:
+  - vllm_omni/diffusion/models/hunyuan_image3/**
+  - vllm_omni/diffusion/forward_context.py
+  - vllm_omni/platforms/**
+depends_on:
+  - ../module/diffusion/diffusion_runtime.md
+  - ../module/cache_management.md
+validation_paths:
+  - tests/diffusion/diffusion_kv/**
+  - tests/diffusion/models/hunyuan_image3/**
+  - tests/e2e/accuracy/test_hunyuan_image3.py
+upstream_refs:
+  - https://github.com/vllm-project/vllm-omni/issues/5244
+  - https://github.com/vllm-project/vllm-omni/pull/5541
+  - https://github.com/vllm-project/vllm-omni/pull/5550
+  - https://github.com/vllm-project/vllm-omni/pull/6094
+  - https://github.com/vllm-project/vllm-omni/pull/6102
+  - https://github.com/vllm-project/vllm-omni/pull/6563
+  - https://github.com/vllm-project/vllm-omni/pull/6658
+last_reviewed: 2026-09-01
+---
+
+# Scheduler-Managed Paged KV Cache for Diffusion DiT Stages
+
+This document defines the design contract for Scheduler-managed paged
+key/value (KV) cache in a diffusion DiT stage. The first complete integration
+is HunyuanImage-3.0 DiT, running in request-level execution on NVIDIA GPU and
+Ascend NPU. The document describes ownership, lifecycle, metadata, and
+attention execution; it is not a claim that every diffusion model or platform
+supports the feature.
+
+## Motivation
+
+A diffusion transformer executes the same self-attention layers at every
+denoising step. HunyuanImage-3.0 keeps the prompt and reference-image tokens
+constant while rewriting the timestep and generated-image tokens. The legacy
+dense path carries the complete K/V tensor through every step. Paged KV keeps
+the stable prefix in Worker-owned pages and writes only the current span after
+the first step.
+
+Paging is a memory-management and execution feature, not a change to the
+model's attention semantics. Hunyuan still has mixed causal/full attention:
+text and image regions use the same rules as the dense implementation. The
+difference is how the sequence is stored and how the mixed attention is
+expressed to the native kernel.
+
+## Goals and non-goals
+
+| Goal | Contract |
+| --- | --- |
+| Scheduler ownership | Allocate and release logical KV blocks with the native vLLM KV cache manager. |
+| Worker ownership | Allocate physical KV tensors, native BlockTables, slot mappings, and attention metadata on each rank. |
+| Stable denoising reuse | Write the complete sequence once, then update only the timestep/image span. |
+| Model isolation | Keep block allocation and runtime activation out of model code. The model supplies layout and attention spans. |
+| Platform portability | Share the row and adapter contract while allowing CUDA and Ascend to provide different native metadata and kernels. |
+| Failure safety | Reject invalid metadata and roll back partial CFG allocation instead of running a dense fallback. |
+
+The current implementation does not provide:
+
+- Hunyuan paged step execution or continuous batching;
+- arbitrary Hunyuan request-level batching (`supports_request_batch` is false);
+- Hunyuan CFG parallelism with more than its current two branches;
+- imported AR-to-DiT KV, independently allocated Hunyuan KV contexts, or
+  cross-request prefix publication;
+- Ring attention or AllGather-KV sequence parallelism in the paged path; or
+- the reserved `paged_worker_local` ownership mode.
+
+Dense execution remains the default `dense_legacy` path and is not changed by
+enabling this feature for another stage.
+
+## Ownership model
+
+The ownership boundary is deliberately split between the control plane and the
+data plane:
+
+| Component | Owns | Must not own |
+| --- | --- | --- |
+| Model preprocessing | Token/image layout, positions, CFG branch count, and `full_attn_spans` | Physical blocks or Worker runtime state |
+| Scheduler | Public request lifecycle, logical `DiffusionKVRequest` objects, block admission, and release | Device tensors or native kernel metadata |
+| Executor/RPC | Transport of the immutable allocation snapshot | Independent allocation decisions |
+| Worker/model runner | Physical cache tensors, Worker rows, BlockTables, slot mappings, and active runtime | Scheduler block lifetime |
+| Common `Attention` layer | Parallel hooks and the GPU/NPU backend boundary | Request admission or block-table construction |
+| Platform backend | Native BlockTables, cache-writer contract, metadata builder, and kernel selection | Model-specific token semantics |
+
+The same public request can own more than one logical sequence. Hunyuan uses
+one sequence per CFG branch; those rows are allocated and released as one
+atomic unit.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    A[Request] --> B[Model preprocessing]
+    B -->|HunyuanPreparedLayout + DiffusionKVRequest[]| C[Scheduler]
+    C -->|DiffusionKVMetadata| D[Executor / Worker RPC]
+    D --> E[Worker KV backend]
+    E -->|physical pages + BlockTables / slots| F[Model runner]
+    F -->|opaque ForwardContext runtime| G[Common Attention]
+    G --> H[CUDA FA3 paged backend]
+    G --> I[Ascend FIA paged backend]
+    C -. release logical blocks .-> C
+    E -. clear Worker rows .-> E
+```
+
+There are two important distinctions in this graph:
+
+1. `DiffusionKVMetadata` is an allocation snapshot, not a cache tensor. It
+   crosses the Scheduler-to-Worker boundary and contains physical block IDs
+   selected by the Scheduler.
+2. `DiffusionPagedAttentionRuntime` is created by the runner and exposed
+   through `ForwardContext`. The model can trigger the current denoising phase
+   through the normal forward-context API, but it does not create or activate
+   the runtime itself.
+
+## Startup and cache sizing
+
+Paged KV is initialized before the Scheduler starts admitting real requests.
+The startup sequence is:
+
+1. `DiffusionEngine` resolves `diffusion_kv_mode` and prepares a maximum-shape
+   profile request through the model's normal preprocessing hook.
+2. Each Worker loads the model, registers marked paged attention layers, and
+   reports a native `KVCacheSpec` for every cache group.
+3. Each Worker profiles the prepared request to determine available KV memory.
+   This forward runs before Scheduler pages exist and is explicitly marked as
+   `in_diffusion_kv_memory_profile`.
+4. The engine builds the native vLLM `VllmConfig`, calls
+   `get_kv_cache_configs()`, creates the Scheduler cache configuration, and
+   resolves the Scheduler and hash block sizes.
+5. Rank-local `KVCacheConfig` objects are sent back to Workers. Workers create
+   physical KV tensors and native BlockTables, then the Scheduler constructs a
+   `DiffusionKVCacheManager` over the same native geometry.
+
+The profile is a capacity probe, not a measured request. On NPU, SDPA may be
+used only by this explicitly marked probe when the optional dense MindIE-SD
+dependency is unavailable. A real paged request with a missing Worker adapter
+fails instead of silently taking a dense path.
+
+### Memory budget semantics
+
+`kv_cache_memory_bytes` is an explicit per-Worker (and therefore per-rank) KV
+pool budget. It sizes the already allocated physical page pool; it is not the
+number of tokens in a request. When it is absent, the native sizing path uses
+`gpu_memory_utilization` and subtracts profiled non-KV memory:
+
+```text
+requested_memory = device_total_memory * gpu_memory_utilization
+available_kv_memory = requested_memory - profiled_non_kv_memory
+```
+
+Once a pool exists, a request consumes blocks according to its sequence
+length, approximately:
+
+```text
+blocks_for_sequence = ceil(seq_len / block_size)
+```
+
+The Scheduler admits a request only when all of its CFG sequences fit. An
+allocator or memory pool can reserve more memory than the live tensors use;
+therefore allocator `reserved` values describe pool capacity and fragmentation,
+not only active payload bytes.
+
+The relevant configuration fields are:
+
+| Field | Meaning |
+| --- | --- |
+| `diffusion_kv_mode` | `dense_legacy` (default) or `paged_scheduler`. |
+| `diffusion_kv_max_rows_per_request` | Maximum Worker rows for one public request, including CFG sequences and future independent contexts. |
+| `kv_cache_memory_bytes` | Optional explicit per-rank physical KV pool budget. |
+| `gpu_memory_utilization` | Automatic pool-sizing fraction when no explicit byte budget is supplied. |
+| `max_model_len` | Native per-sequence admission ceiling. Hunyuan can derive it from its model position limit when omitted. |
+| `max_num_seqs` | Maximum number of public requests in a Scheduler wave. It is distinct from Hunyuan's internal CFG row count. |
+| `max_num_batched_tokens` | Worker/native attention token capacity for one prepared batch. |
+
+An illustrative stage-level configuration is:
+
+```yaml
+stages:
+  - stage_id: 0
+    diffusion_kv_mode: paged_scheduler
+    diffusion_kv_max_rows_per_request: 2  # conditional + unconditional
+    kv_cache_memory_bytes: 536870912      # 512 MiB per Worker
+    max_num_seqs: 1
+    max_model_len: 8192
+    max_num_batched_tokens: 8192
+    enforce_eager: true
+```
+
+This snippet shows the contract and is not a statement that every bundled
+Hunyuan deploy file enables paging by default. The model and platform must also
+resolve a paged-capable attention backend.
+
+## Request admission and logical block lifecycle
+
+### Preprocessing contract
+
+The model preprocessor runs once, before Scheduler admission:
+
+```text
+OmniDiffusionRequest
+  -> HunyuanPreparedLayout
+  -> one DiffusionKVRequest per CFG branch
+```
+
+`HunyuanPreparedLayout` contains tokenized rows, image/RoPE information, and
+the generated-image layout. It is reused by the Worker so token positions do
+not get recomputed independently on different ranks.
+
+For each Hunyuan branch, `DiffusionKVRequest` records:
+
+| Field | Meaning |
+| --- | --- |
+| `sequence_id` | Stable branch identity within the public request. |
+| `prefix_len` | End of the prompt/reference-image prefix that remains valid across denoising steps. |
+| `target_len` | Timestep plus generated-image span rewritten at each step. |
+| `seq_len` | Complete first-step allocation boundary. |
+| `kv_contexts` | Independent contexts; Hunyuan currently supplies an empty tuple because prompt/image tokens share the primary sequence. |
+
+The normal request payload does not carry mutable `DiffusionKVRequest` objects
+to a Worker. `BaseScheduler` takes ownership of them and clears the request
+field before constructing `NewRequestData`.
+
+### Atomic admission
+
+`DiffusionKVCacheManager` is a thin semantic facade over native vLLM
+`KVCacheManager`:
+
+1. Validate sequence IDs, lengths, model limits, and internal request IDs.
+2. Compute the full-sequence reservation for every CFG branch.
+3. Return `None` when the current pool is temporarily full, leaving the
+   request waiting.
+4. Allocate every branch with `full_sequence_must_fit=True` when capacity is
+   available.
+5. Roll back all allocations if any branch fails.
+6. Publish one `DiffusionKVMetadata` snapshot with an allocation generation.
+
+This prevents a conditional row from running while its unconditional partner
+has no physical page. Prefix hashing and `cache_blocks` publication are
+disabled in the current implementation, so pages are request-local rather
+than a cross-request prefix cache.
+
+### Release paths
+
+The Scheduler releases logical blocks on normal completion, cancellation,
+admission failure, error, `pop_request_state`, `close`, and reinitialization.
+The engine separately asks Workers to clear the corresponding physical rows.
+Neither side frees the other side's resources:
+
+```text
+terminal request
+  -> Scheduler: DiffusionKVCacheManager.free_request()
+  -> Worker: clear row contents and return Worker row slots
+```
+
+The same rule applies during partial startup failure: a created native manager
+or Worker cache is closed before initialization propagates its exception.
+
+## Scheduler-to-Worker metadata
+
+`DiffusionKVMetadata` is the Scheduler allocation snapshot sent in
+`NewRequestData` and through Executor RPC. It contains:
+
+```text
+DiffusionKVMetadata
+  request_id
+  allocation_generation
+  sequences[]
+    sequence_id
+    prefix_len
+    target_len
+    seq_len
+    block_ids per KV group
+    context_ids
+  contexts[] (currently unused by Hunyuan)
+```
+
+The payload carries logical lengths together with native block IDs so the
+Worker can validate both views. It does not contain device pointers, K/V
+tensors, or mutable Scheduler request objects.
+
+## Worker data plane
+
+### Physical initialization
+
+`DiffusionKVModelRunnerBackend` registers every attention layer marked with a
+`paged_kv_cache_role` and verifies that all layers in a cache group share one
+native attention geometry. It then:
+
+- obtains the platform BlockTables class;
+- creates rank-local physical KV tensors through native vLLM cache builders;
+- creates the platform-native BlockTables with the resolved block geometry;
+- builds one `DiffusionPagedAttentionLayerAdapter` per layer; and
+- creates a common `DiffusionPagedAttentionAdapter` for row resolution and
+  metadata preparation.
+
+On CUDA, the default BlockTables and metadata builders use vLLM's native
+interfaces. On NPU, the platform supplies `AscendBlockTables`, Ascend block
+geometry, and the Ascend metadata builder.
+
+### Installing a snapshot
+
+When a new request is scheduled, the Worker:
+
+1. validates the request ID, allocation generation, group count, block IDs,
+   row capacity, and token length;
+2. resolves the public sequence/context identity to a free Worker row;
+3. stages the block IDs in native BlockTables and applies the staged writes;
+4. invalidates prepared metadata if BlockTables changed; and
+5. stores the row binding for the lifetime of the request.
+
+Repeated installation of the same generation is idempotent. A stale
+generation, duplicate identity, invalid block, or mismatched group count is a
+hard error. Dense execution must not install paged metadata, and paged mode
+rejects legacy dense `past_key_values` payloads.
+
+## Runner-owned request execution
+
+The current feature uses request-level execution (`step_execution=false`). The
+runner receives a complete request, installs its allocation snapshot, and
+executes the normal `pipeline.forward()` call. It does not make the model aware
+of Scheduler internals.
+
+For each allocated sequence, the runner constructs two row descriptions:
+
+| Phase | `query_len` | `seq_len` | `kv_start_pos` |
+| --- | ---: | ---: | ---: |
+| First denoising/prefill forward | `seq_len` | `seq_len` | `0` |
+| Later denoising forward | `target_len` | `prefix_len + target_len` | `prefix_len` |
+
+The rows keep the same ordered identity in both phases. The runner places the
+metadata and a `DiffusionPagedAttentionRuntime` in `ForwardContext`. When the
+Hunyuan denoising loop publishes its step index, the runtime swaps from the
+prefill rows to the denoise rows once and reuses that phase for all attention
+layers in the step.
+
+The common attention layer observes the opaque Worker adapter only while the
+forward is active. This keeps allocation, row binding, and activation in the
+runner/Worker boundary and lets future DiT models reuse the same protocol.
+
+## HunyuanImage-3.0 integration
+
+### Model boundary
+
+`request_layout.py` owns Hunyuan-specific preprocessing and derives the
+Scheduler lengths from tokenizer positions:
+
+```text
+prefix_len = final generated-timestep scatter position
+target_len = image tokens + timestep token + guidance token
+seq_len    = final real position in the prepared row
+```
+
+`HunyuanImage3Pipeline` creates one KV sequence for each CFG branch. The
+current pipeline deliberately declares `supports_request_batch = False`; a
+public request is therefore normally run with `max_num_seqs=1`, while its
+conditional and unconditional rows may still be processed together inside the
+model's CFG batch.
+
+`ImageKVCacheManager._forward_paged()` is intentionally a model boundary,
+not a cache manager. It:
+
+- validates the prepared query/sequence lengths and span rows;
+- clears the legacy model-owned dense prompt cache;
+- describes Hunyuan's Q/K/V layout and `full_attn_spans`; and
+- for strict Ulysses, separates the joint prompt portion from the local image
+  shard before invoking the common attention layer.
+
+It does not allocate blocks, construct BlockTables, or activate the Worker
+runtime.
+
+### CFG parallelism
+
+The current Hunyuan integration supports the two-branch conditional and
+unconditional CFG layout. The Scheduler metadata contains one sequence per
+branch, and the runner selects the branch belonging to the current CFG rank
+before building rank-local rows. Positive and negative sequence identities
+remain stable, so each rank writes and reads the correct physical page. This
+is different from public request batching: CFG rows are internal branches of
+one request, not unrelated requests merged by the Scheduler.
+
+### Sequence parallelism
+
+The paged path supports strict Ulysses SP in request mode. The parallel
+strategy performs its normal Q/K/V exchange first. The common attention layer
+removes synthetic SP padding before preparing paged metadata and restores zero
+placeholders before the reverse exchange. Hunyuan supplies the prompt/image
+split needed for its joint attention layout.
+
+Ring attention and AllGather-KV SP are rejected explicitly because their
+metadata and communication contracts do not match the current paged native
+adapter.
+
+## Attention execution
+
+### Dense legacy path
+
+The dense Hunyuan path materializes a 4-D mixed causal/full attention mask and
+also carries the equivalent `full_attn_spans` metadata. Dense therefore
+represents the same mixed attention pattern; it is not a different model mask.
+The number and shape of native calls depend on the selected platform backend:
+
+| Dense backend | Execution shape |
+| --- | --- |
+| CUDA `FLASH_ATTN` | The CUDA implementation prioritizes `full_attn_spans` and uses the shared piecewise FA helper, so one dense K/V call is made per aligned segment. No persistent page or Scheduler slot mapping is involved. |
+| NPU `FLASH_ATTN` / MindIE-SD | Hunyuan passes the materialized mask to `attention_forward`; the normal Hunyuan dense path uses one masked call per layer. |
+| Other dense backends | Follow their own mask/piecewise capability contract; they do not acquire Scheduler-managed pages. |
+
+This distinction is important when comparing traces: "dense" describes the
+tensor/cache representation, while piecewise execution describes how a
+backend realizes Hunyuan's mixed mask.
+
+### Paged path
+
+The paged path passes `full_attn_spans` instead of requiring a quadratic mask.
+The common piecewise planner converts each row into aligned segments:
+
+| Segment | Native inputs | Causal flag |
+| --- | --- | --- |
+| Causal `[s, e)` | `Q[s:e]`, `K[:e]`, `V[:e]` | `true` |
+| Full span `[a, b)` intersecting the query | `Q[overlap]`, `K[:b]`, `V[:b]` | `false` |
+
+The segment boundaries preserve FlashAttention's bottom-right causal
+alignment. The resulting outputs are restored to the original token order
+before `o_proj`, residual, and MLP layers consume them.
+
+Paged attention is consequently a sequence of native paged calls per layer. On
+CUDA, Dense `FLASH_ATTN` can also be piecewise, whereas Dense NPU MindIE-SD
+normally remains one masked call. In every case, the distinction is storage
+and backend execution shape only; both paths implement the same Hunyuan
+causal/full semantics.
+
+### One K/V write per layer
+
+The K/V update is deliberately outside the segment loop:
+
+```text
+current Q/K/V projection
+  -> write the current K/V span to the Worker cache once
+  -> run each piecewise attention segment against persistent pages
+  -> restore output order
+```
+
+The CUDA/default backend keeps cache-update ownership in its native paged
+attention contract. Ascend requires an explicit normal-layout cache prewrite;
+its FIA segment calls read the just-written pages and pass no K/V source for
+those reads. Thus a request with three segments performs one layer write and
+three FIA calls, rather than three repeated writes. The obsolete logical-cache
+to-PA_NZ-to-logical conversion is not part of the current design.
+
+## Piecewise planning and fast paths
+
+`DiffusionPagedAttentionAdapter` prepares common row metadata once per active
+forward:
+
+1. resolve logical identities to Worker row indices;
+2. gather native BlockTables;
+3. compute positions and slot mappings for the current write span;
+4. build platform-native attention metadata; and
+5. cache the piecewise plan and per-segment native metadata for all layers.
+
+The planner has two output-layout paths:
+
+### Homogeneous rows
+
+When rows have the same local query length and segment ranges, the runner keeps
+the row-major `[B, T, ...]` layout. Each segment is flattened only for the
+native call, then reshaped and concatenated along the sequence dimension. On
+NPU this avoids a large per-segment indexed `ScatterUpdate` for homogeneous CFG
+rows.
+
+### Heterogeneous rows
+
+When local ranges differ, the planner packs valid tokens with `index_select`,
+runs the native segment calls, and restores the original layout with
+`index_copy_`. This fallback supports different row lengths and offsets while
+preserving the contract seen by subsequent transformer layers. It is the
+general path; the homogeneous optimization must not change its semantics.
+
+The fast path concerns rows inside one attention invocation. It does not enable
+arbitrary public-request batching, and it does not change Scheduler allocation.
+
+## Platform boundary
+
+| Concern | CUDA/GPU | Ascend/NPU |
+| --- | --- | --- |
+| Block tables | Native vLLM `BlockTables` | `AscendBlockTables` from vLLM-Ascend |
+| Paged kernel | Native FlashAttention/FA3 contract | Ascend `FusedInferAttentionScore` (FIA) |
+| Cache update | Owned by the native paged attention writer/kernel | Explicit normal-layout `do_kv_cache_update()` before segment calls |
+| Attention metadata | vLLM GPU metadata builder | Ascend metadata builder with `ChunkedPrefill` state |
+| SP specialization | Native strict Ulysses integration | Ascend paged backend specialization for strict Ulysses |
+| Dense optional dependency | Platform-selected dense backend | MindIE-SD may serve dense attention; absence is tolerated only for the startup profile fallback |
+
+The shared `OmniPlatform` interface owns capability hooks such as
+`get_diffusion_kv_block_tables_cls()`,
+`build_diffusion_kv_attn_metadata()`, and
+`requires_diffusion_paged_kv_prewrite()`. Hardware-specific imports stay behind
+these hooks, so the common adapter does not import vLLM-Ascend directly.
+
+## Correctness invariants
+
+The following invariants are required for a new model or backend integration:
+
+1. **One identity, one row.** A `(request_id, sequence_id/context_id)` maps to
+   exactly one Worker row during an active request.
+2. **Allocation is complete before execution.** Every CFG branch fits before
+   any branch is sent to a Worker.
+3. **Write span is bounded.** `kv_start_pos + query_len <= seq_len` and the
+   installed page count covers `seq_len`.
+4. **Prefill and denoise identities agree.** Only lengths and the write offset
+   change between phases.
+5. **Attention metadata is stable within a forward.** Span layout and native
+   segment metadata cannot change between layers.
+6. **Dense and paged ownership are exclusive.** Dense requests do not install
+   paged metadata; paged requests do not accept legacy dense KV payloads.
+7. **No accidental fallback.** A missing adapter, unsupported backend, stale
+   generation, or unsupported SP strategy raises an actionable error. The only
+   pre-admission exception is the explicitly marked memory profile.
+8. **Both owners clean up.** Scheduler logical blocks and Worker physical rows
+   are released on every terminal path.
+
+## Configuration and compatibility
+
+The mode parser accepts `dense_legacy` and `paged_scheduler`. The
+`paged_worker_local` enum value documents a migration topology but is rejected
+until a separate implementation exists. `paged_scheduler` additionally
+requires `diffusion_kv_max_rows_per_request`, a native cache configuration, and
+a prepared memory-profile request.
+
+For the current Hunyuan integration:
+
+| Combination | Status |
+| --- | --- |
+| Request execution, no SP, TP | Supported when the selected backend has paged support. |
+| Request execution, strict Ulysses SP | Supported by the current GPU and NPU integrations. |
+| Request execution, two-branch CFG parallel | Supported when one allocated row exists per CFG rank. |
+| Hunyuan step execution with paged KV | Rejected; use `dense_legacy` until a step-mode contract is added. |
+| Hunyuan independent request batching | Not enabled (`supports_request_batch=False`). |
+| Ring or AllGather-KV SP | Rejected in the paged path. |
+| Imported AR KV or independent Hunyuan contexts | Not implemented. |
+| Cross-request prefix cache publication | Disabled; pages are request-local. |
+
+The dense path can continue to use its existing backend and model-owned
+compatibility cache when `diffusion_kv_mode=dense_legacy`. Marking an attention
+layer as paged-capable does not route unmarked dense layers through the native
+KV pool.
+
+## Validation strategy
+
+Validation is split by ownership boundary:
+
+| Area | Representative coverage |
+| --- | --- |
+| Mode and native sizing | `tests/diffusion/diffusion_kv/test_config.py`, `test_initialization.py` |
+| Scheduler allocation | `test_manager.py`, `test_request.py`, `test_metadata.py`, and `test_diffusion_scheduler.py` |
+| Worker rows and BlockTables | `test_block_tables.py`, `test_worker_contract.py`, and native GPU adapter tests |
+| Adapter and piecewise metadata | `test_paged_attention_adapter.py`, `test_paged_attention_adapter_gpu.py`, and piecewise attention tests |
+| Hunyuan layout/ownership | `tests/diffusion/models/hunyuan_image3/test_diffusion_kv_request.py` and `test_image_kv_cache_manager.py` |
+| End-to-end correctness | Hunyuan E2E and pixel-accuracy tests with matched dense/paged inputs |
+
+An end-to-end validation run should record the mode, model and Omni commit,
+platform/backend, TP/SP/CFGP topology, block geometry, KV budget, warmup
+policy, request count, and output validity. Paged claims require native-path
+evidence (for example, CUDA paged FlashAttention or Ascend FIA/cache-writer
+events) and must verify that no dense fallback was active. Profiling runs are
+separate from latency samples because profiler instrumentation changes host and
+device timing.
+
+## Failure handling and observability
+
+Errors are intentionally raised at the earliest owner that can explain them:
+
+- preprocessing rejects a malformed Hunyuan layout or CFG count;
+- the Scheduler reports an admission or capacity error;
+- the Worker reports an invalid block table, row binding, or generation;
+- the adapter reports a shape, dtype, span, or native metadata mismatch; and
+- the platform reports an unavailable kernel or unsupported parallel strategy.
+
+Request errors still pass through the normal diffusion output stream. Cleanup
+is performed independently of output delivery, so a cancelled consumer cannot
+leave Scheduler blocks or Worker rows active.
+
+Useful debug records include the allocation generation, logical lengths,
+resolved Worker row indices, native block IDs, active denoising phase, selected
+backend, and whether the NPU prewrite contract was used. These records should
+remain request-scoped and must not expose device pointers or prompt contents.
+
+## Related implementation
+
+- Scheduler facade: [`diffusion_kv/manager.py`](gh-file:vllm_omni/diffusion/diffusion_kv/manager.py)
+- Request and allocation DTOs: [`diffusion_kv/request.py`](gh-file:vllm_omni/diffusion/diffusion_kv/request.py), [`diffusion_kv/metadata.py`](gh-file:vllm_omni/diffusion/diffusion_kv/metadata.py)
+- Native cache initialization: [`diffusion_kv/initialization.py`](gh-file:vllm_omni/diffusion/diffusion_kv/initialization.py), [`vllm_config.py`](gh-file:vllm_omni/diffusion/vllm_config.py)
+- Worker data plane: [`diffusion_kv/model_runner_backend.py`](gh-file:vllm_omni/diffusion/diffusion_kv/model_runner_backend.py)
+- Generic adapter and runtime: [`diffusion_kv/paged_attention_adapter.py`](gh-file:vllm_omni/diffusion/diffusion_kv/paged_attention_adapter.py)
+- Runner activation: [`diffusion_model_runner.py`](gh-file:vllm_omni/diffusion/worker/diffusion_model_runner.py), [`forward_context.py`](gh-file:vllm_omni/diffusion/forward_context.py)
+- Common attention boundary: [`attention/layer.py`](gh-file:vllm_omni/diffusion/attention/layer.py), [`attention/backends/flash_attn.py`](gh-file:vllm_omni/diffusion/attention/backends/flash_attn.py)
+- Piecewise planner: [`attention/backends/utils/piecewise_attn.py`](gh-file:vllm_omni/diffusion/attention/backends/utils/piecewise_attn.py)
+- Hunyuan layout and model boundary: [`models/hunyuan_image3/request_layout.py`](gh-file:vllm_omni/diffusion/models/hunyuan_image3/request_layout.py), [`pipeline_hunyuan_image3.py`](gh-file:vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py), [`hunyuan_image3_transformer.py`](gh-file:vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py)
+- Platform hooks: [`platforms/interface.py`](gh-file:vllm_omni/platforms/interface.py), [`platforms/cuda/platform.py`](gh-file:vllm_omni/platforms/cuda/platform.py), [`platforms/npu/platform.py`](gh-file:vllm_omni/platforms/npu/platform.py)
+
+## Related design work
+
+The control-plane contracts were introduced in PR #5541 and PR #5550, native
+Scheduler allocation was added in PR #6094, and the Worker data plane was added
+in PR #6102. Hunyuan GPU integration and the shared piecewise execution work
+began in PR #6658 and were consolidated with the Ascend implementation in PR #6563.
+Future models should reuse these contracts and add only their model-specific
+layout, capacity profile, and backend capability requirements.

--- a/docs/design/feature/diffusion_paged_kv_cache.md
+++ b/docs/design/feature/diffusion_paged_kv_cache.md
@@ -34,586 +34,290 @@ last_reviewed: 2026-09-01
 
 # Scheduler-Managed Paged KV Cache for Diffusion DiT Stages
 
-This document defines the design contract for Scheduler-managed paged
-key/value (KV) cache in a diffusion DiT stage. The first complete integration
-is HunyuanImage-3.0 DiT, running in request-level execution on NVIDIA GPU and
-Ascend NPU. The document describes ownership, lifecycle, metadata, and
-attention execution; it is not a claim that every diffusion model or platform
-supports the feature.
+This document defines the implementation contract for Scheduler-managed
+key/value (KV) cache in a diffusion DiT stage. HunyuanImage-3.0 is the first
+complete integration, using request-level execution on NVIDIA GPU and Ascend
+NPU. The contract is not a general support claim for every model or platform.
 
-## Motivation
+## Scope and goals
 
-A diffusion transformer executes the same self-attention layers at every
-denoising step. HunyuanImage-3.0 keeps the prompt and reference-image tokens
-constant while rewriting the timestep and generated-image tokens. The legacy
-dense path carries the complete K/V tensor through every step. Paged KV keeps
-the stable prefix in Worker-owned pages and writes only the current span after
+Paging changes KV storage and ownership, not Hunyuan's attention semantics.
+Prompt and reference-image tokens are stable across denoising steps, while
+the timestep and generated-image span is rewritten. The paged path stores the
+stable prefix in Worker-owned pages and updates only the changing span after
 the first step.
 
-Paging is a memory-management and execution feature, not a change to the
-model's attention semantics. Hunyuan still has mixed causal/full attention:
-text and image regions use the same rules as the dense implementation. The
-difference is how the sequence is stored and how the mixed attention is
-expressed to the native kernel.
+The design guarantees:
 
-## Goals and non-goals
+- the Scheduler owns logical allocation and release;
+- the Worker owns physical tensors, native BlockTables, slots, and metadata;
+- all CFG rows are admitted atomically;
+- the model supplies layout and attention spans but never allocates pages or
+  activates the Worker runtime; and
+- invalid or stale metadata fails explicitly instead of silently falling back
+  to dense execution.
 
-| Goal | Contract |
-| --- | --- |
-| Scheduler ownership | Allocate and release logical KV blocks with the native vLLM KV cache manager. |
-| Worker ownership | Allocate physical KV tensors, native BlockTables, slot mappings, and attention metadata on each rank. |
-| Stable denoising reuse | Write the complete sequence once, then update only the timestep/image span. |
-| Model isolation | Keep block allocation and runtime activation out of model code. The model supplies layout and attention spans. |
-| Platform portability | Share the row and adapter contract while allowing CUDA and Ascend to provide different native metadata and kernels. |
-| Failure safety | Reject invalid metadata and roll back partial CFG allocation instead of running a dense fallback. |
+The current implementation does not cover Hunyuan paged step execution,
+continuous batching, arbitrary public request batching
+`supports_request_batch=False`, more than two CFG branches, imported
+AR-to-DiT KV, independent Hunyuan KV contexts, cross-request prefix
+publication, Ring attention, or AllGather-KV SP. The reserved
+`paged_worker_local` mode is also not implemented.
 
-The current implementation does not provide:
+## Architecture and ownership
 
-- Hunyuan paged step execution or continuous batching;
-- arbitrary Hunyuan request-level batching (`supports_request_batch` is false);
-- Hunyuan CFG parallelism with more than its current two branches;
-- imported AR-to-DiT KV, independently allocated Hunyuan KV contexts, or
-  cross-request prefix publication;
-- Ring attention or AllGather-KV sequence parallelism in the paged path; or
-- the reserved `paged_worker_local` ownership mode.
-
-Dense execution remains the default `dense_legacy` path and is not changed by
-enabling this feature for another stage.
-
-## Ownership model
-
-The ownership boundary is deliberately split between the control plane and the
-data plane:
-
-| Component | Owns | Must not own |
-| --- | --- | --- |
-| Model preprocessing | Token/image layout, positions, CFG branch count, and `full_attn_spans` | Physical blocks or Worker runtime state |
-| Scheduler | Public request lifecycle, logical `DiffusionKVRequest` objects, block admission, and release | Device tensors or native kernel metadata |
-| Executor/RPC | Transport of the immutable allocation snapshot | Independent allocation decisions |
-| Worker/model runner | Physical cache tensors, Worker rows, BlockTables, slot mappings, and active runtime | Scheduler block lifetime |
-| Common `Attention` layer | Parallel hooks and the GPU/NPU backend boundary | Request admission or block-table construction |
-| Platform backend | Native BlockTables, cache-writer contract, metadata builder, and kernel selection | Model-specific token semantics |
-
-The same public request can own more than one logical sequence. Hunyuan uses
-one sequence per CFG branch; those rows are allocated and released as one
-atomic unit.
-
-## Architecture
-
-```mermaid
+~~~mermaid
 flowchart LR
     A[Request] --> B[Model preprocessing]
-    B -->|HunyuanPreparedLayout + DiffusionKVRequest[]| C[Scheduler]
-    C -->|DiffusionKVMetadata| D[Executor / Worker RPC]
+    B -->|Prepared layout + KV requests| C[Scheduler]
+    C -->|Allocation metadata| D[Executor / Worker RPC]
     D --> E[Worker KV backend]
-    E -->|physical pages + BlockTables / slots| F[Model runner]
-    F -->|opaque ForwardContext runtime| G[Common Attention]
-    G --> H[CUDA FA3 paged backend]
-    G --> I[Ascend FIA paged backend]
+    E -->|Pages + BlockTables + slots| F[Model runner]
+    F -->|ForwardContext runtime| G[Common Attention]
+    G --> H[CUDA paged attention]
+    G --> I[Ascend FIA paged attention]
     C -. release logical blocks .-> C
-    E -. clear Worker rows .-> E
-```
+    E -. clear physical rows .-> E
+~~~
 
-There are two important distinctions in this graph:
+| Component | Owns | Does not own |
+| --- | --- | --- |
+| Model preprocessing | Token/image layout, positions, CFG count, `full_attn_spans` | Physical blocks or Worker state |
+| Scheduler | Request lifecycle, logical sequences, admission, block release | Device tensors or native metadata |
+| Executor/RPC | Transport of an immutable allocation snapshot | Allocation decisions |
+| Worker/model runner | Physical KV tensors, rows, BlockTables, slots, active runtime | Scheduler block lifetime |
+| Common attention layer | Parallel hooks and backend boundary | Request admission or page allocation |
+| Platform backend | Native geometry, BlockTables, metadata, kernel selection | Model-specific token semantics |
 
-1. `DiffusionKVMetadata` is an allocation snapshot, not a cache tensor. It
-   crosses the Scheduler-to-Worker boundary and contains physical block IDs
-   selected by the Scheduler.
-2. `DiffusionPagedAttentionRuntime` is created by the runner and exposed
-   through `ForwardContext`. The model can trigger the current denoising phase
-   through the normal forward-context API, but it does not create or activate
-   the runtime itself.
+The public request owns one logical sequence per Hunyuan CFG branch. These
+sequences are allocated and released as one unit. `DiffusionKVMetadata`
+is an allocation snapshot containing IDs, lengths, and block IDs; it contains no
+device pointers, K/V tensors, or mutable Scheduler objects.
 
-## Startup and cache sizing
+## Lifecycle
 
-Paged KV is initialized before the Scheduler starts admitting real requests.
-The startup sequence is:
+### Startup and cache sizing
 
-1. `DiffusionEngine` resolves `diffusion_kv_mode` and prepares a maximum-shape
-   profile request through the model's normal preprocessing hook.
-2. Each Worker loads the model, registers marked paged attention layers, and
-   reports a native `KVCacheSpec` for every cache group.
-3. Each Worker profiles the prepared request to determine available KV memory.
-   This forward runs before Scheduler pages exist and is explicitly marked as
-   `in_diffusion_kv_memory_profile`.
-4. The engine builds the native vLLM `VllmConfig`, calls
-   `get_kv_cache_configs()`, creates the Scheduler cache configuration, and
-   resolves the Scheduler and hash block sizes.
-5. Rank-local `KVCacheConfig` objects are sent back to Workers. Workers create
-   physical KV tensors and native BlockTables, then the Scheduler constructs a
-   `DiffusionKVCacheManager` over the same native geometry.
+Before admitting requests, the engine and Workers:
 
-The profile is a capacity probe, not a measured request. On NPU, SDPA may be
-used only by this explicitly marked probe when the optional dense MindIE-SD
-dependency is unavailable. A real paged request with a missing Worker adapter
-fails instead of silently taking a dense path.
+1. Resolve `diffusion_kv_mode` and prepare a maximum-shape profile request.
+2. Register paged attention layers and report a native `KVCacheSpec` per group.
+3. Profile the request to determine non-KV memory. This probe is marked
+   `in_diffusion_kv_memory_profile` and is not a latency sample.
+4. Build the native vLLM cache configuration and resolve block geometry.
+5. Allocate rank-local physical pages and native BlockTables, then create the
+   Scheduler's `DiffusionKVCacheManager` over the same geometry.
 
-### Memory budget semantics
+`kv_cache_memory_bytes` is an explicit physical KV-pool budget per Worker and
+rank. It is not a request token count. Without it, sizing uses the normal
+`gpu_memory_utilization` path:
 
-`kv_cache_memory_bytes` is an explicit per-Worker (and therefore per-rank) KV
-pool budget. It sizes the already allocated physical page pool; it is not the
-number of tokens in a request. When it is absent, the native sizing path uses
-`gpu_memory_utilization` and subtracts profiled non-KV memory:
-
-```text
+~~~text
 requested_memory = device_total_memory * gpu_memory_utilization
 available_kv_memory = requested_memory - profiled_non_kv_memory
-```
+~~~
 
-Once a pool exists, a request consumes blocks according to its sequence
-length, approximately:
+Once the pool exists, a sequence of length `seq_len` needs approximately
+`ceil(seq_len / block_size)` blocks. Allocator `reserved` memory can exceed
+live payload because it describes pool capacity and fragmentation.
 
-```text
-blocks_for_sequence = ceil(seq_len / block_size)
-```
-
-The Scheduler admits a request only when all of its CFG sequences fit. An
-allocator or memory pool can reserve more memory than the live tensors use;
-therefore allocator `reserved` values describe pool capacity and fragmentation,
-not only active payload bytes.
-
-The relevant configuration fields are:
+Relevant configuration fields are:
 
 | Field | Meaning |
 | --- | --- |
-| `diffusion_kv_mode` | `dense_legacy` (default) or `paged_scheduler`. |
-| `diffusion_kv_max_rows_per_request` | Maximum Worker rows for one public request, including CFG sequences and future independent contexts. |
-| `kv_cache_memory_bytes` | Optional explicit per-rank physical KV pool budget. |
-| `gpu_memory_utilization` | Automatic pool-sizing fraction when no explicit byte budget is supplied. |
-| `max_model_len` | Native per-sequence admission ceiling. Hunyuan can derive it from its model position limit when omitted. |
-| `max_num_seqs` | Maximum number of public requests in a Scheduler wave. It is distinct from Hunyuan's internal CFG row count. |
-| `max_num_batched_tokens` | Worker/native attention token capacity for one prepared batch. |
+| `diffusion_kv_mode` | `dense_legacy` (default) or `paged_scheduler` |
+| `diffusion_kv_max_rows_per_request` | Maximum Worker rows, including CFG branches |
+| `kv_cache_memory_bytes` | Optional explicit per-rank physical pool budget |
+| `gpu_memory_utilization` | Automatic pool-sizing fraction when no byte budget is set |
+| `max_model_len` | Per-sequence admission ceiling |
+| `max_num_seqs` | Maximum public requests in one Scheduler wave |
+| `max_num_batched_tokens` | Native attention token capacity for a prepared batch |
 
-An illustrative stage-level configuration is:
+### Admission and release
 
-```yaml
-stages:
-  - stage_id: 0
-    diffusion_kv_mode: paged_scheduler
-    diffusion_kv_max_rows_per_request: 2  # conditional + unconditional
-    kv_cache_memory_bytes: 536870912      # 512 MiB per Worker
-    max_num_seqs: 1
-    max_model_len: 8192
-    max_num_batched_tokens: 8192
-    enforce_eager: true
-```
+The Scheduler facade validates IDs and lengths, computes the full reservation
+for every CFG branch, and waits when the pool is temporarily full. When all
+branches fit, it allocates them with `full_sequence_must_fit=True`; any
+partial failure rolls back the whole request. One metadata snapshot is then
+published with an allocation generation.
 
-This snippet shows the contract and is not a statement that every bundled
-Hunyuan deploy file enables paging by default. The model and platform must also
-resolve a paged-capable attention backend.
+On the Worker, installing a snapshot validates the generation, group count,
+block IDs, row capacity, and lengths; binds each logical identity to a free
+row; stages BlockTables; and invalidates metadata if the tables changed.
+Reinstalling the same generation is idempotent. A stale generation, duplicate
+identity, invalid block, or mismatched group count is a hard error.
 
-## Request admission and logical block lifecycle
+Scheduler logical blocks and Worker physical rows are released independently
+on completion, cancellation, admission failure, errors, `close`, and
+reinitialization. Dense requests never install paged metadata, and paged
+requests reject legacy dense `past_key_values` payloads.
 
-### Preprocessing contract
+## Request execution and Hunyuan layout
 
-The model preprocessor runs once, before Scheduler admission:
-
-```text
-OmniDiffusionRequest
-  -> HunyuanPreparedLayout
-  -> one DiffusionKVRequest per CFG branch
-```
-
-`HunyuanPreparedLayout` contains tokenized rows, image/RoPE information, and
-the generated-image layout. It is reused by the Worker so token positions do
-not get recomputed independently on different ranks.
-
-For each Hunyuan branch, `DiffusionKVRequest` records:
-
-| Field | Meaning |
-| --- | --- |
-| `sequence_id` | Stable branch identity within the public request. |
-| `prefix_len` | End of the prompt/reference-image prefix that remains valid across denoising steps. |
-| `target_len` | Timestep plus generated-image span rewritten at each step. |
-| `seq_len` | Complete first-step allocation boundary. |
-| `kv_contexts` | Independent contexts; Hunyuan currently supplies an empty tuple because prompt/image tokens share the primary sequence. |
-
-The normal request payload does not carry mutable `DiffusionKVRequest` objects
-to a Worker. `BaseScheduler` takes ownership of them and clears the request
-field before constructing `NewRequestData`.
-
-### Atomic admission
-
-`DiffusionKVCacheManager` is a thin semantic facade over native vLLM
-`KVCacheManager`:
-
-1. Validate sequence IDs, lengths, model limits, and internal request IDs.
-2. Compute the full-sequence reservation for every CFG branch.
-3. Return `None` when the current pool is temporarily full, leaving the
-   request waiting.
-4. Allocate every branch with `full_sequence_must_fit=True` when capacity is
-   available.
-5. Roll back all allocations if any branch fails.
-6. Publish one `DiffusionKVMetadata` snapshot with an allocation generation.
-
-This prevents a conditional row from running while its unconditional partner
-has no physical page. Prefix hashing and `cache_blocks` publication are
-disabled in the current implementation, so pages are request-local rather
-than a cross-request prefix cache.
-
-### Release paths
-
-The Scheduler releases logical blocks on normal completion, cancellation,
-admission failure, error, `pop_request_state`, `close`, and reinitialization.
-The engine separately asks Workers to clear the corresponding physical rows.
-Neither side frees the other side's resources:
-
-```text
-terminal request
-  -> Scheduler: DiffusionKVCacheManager.free_request()
-  -> Worker: clear row contents and return Worker row slots
-```
-
-The same rule applies during partial startup failure: a created native manager
-or Worker cache is closed before initialization propagates its exception.
-
-## Scheduler-to-Worker metadata
-
-`DiffusionKVMetadata` is the Scheduler allocation snapshot sent in
-`NewRequestData` and through Executor RPC. It contains:
-
-```text
-DiffusionKVMetadata
-  request_id
-  allocation_generation
-  sequences[]
-    sequence_id
-    prefix_len
-    target_len
-    seq_len
-    block_ids per KV group
-    context_ids
-  contexts[] (currently unused by Hunyuan)
-```
-
-The payload carries logical lengths together with native block IDs so the
-Worker can validate both views. It does not contain device pointers, K/V
-tensors, or mutable Scheduler request objects.
-
-## Worker data plane
-
-### Physical initialization
-
-`DiffusionKVModelRunnerBackend` registers every attention layer marked with a
-`paged_kv_cache_role` and verifies that all layers in a cache group share one
-native attention geometry. It then:
-
-- obtains the platform BlockTables class;
-- creates rank-local physical KV tensors through native vLLM cache builders;
-- creates the platform-native BlockTables with the resolved block geometry;
-- builds one `DiffusionPagedAttentionLayerAdapter` per layer; and
-- creates a common `DiffusionPagedAttentionAdapter` for row resolution and
-  metadata preparation.
-
-On CUDA, the default BlockTables and metadata builders use vLLM's native
-interfaces. On NPU, the platform supplies `AscendBlockTables`, Ascend block
-geometry, and the Ascend metadata builder.
-
-### Installing a snapshot
-
-When a new request is scheduled, the Worker:
-
-1. validates the request ID, allocation generation, group count, block IDs,
-   row capacity, and token length;
-2. resolves the public sequence/context identity to a free Worker row;
-3. stages the block IDs in native BlockTables and applies the staged writes;
-4. invalidates prepared metadata if BlockTables changed; and
-5. stores the row binding for the lifetime of the request.
-
-Repeated installation of the same generation is idempotent. A stale
-generation, duplicate identity, invalid block, or mismatched group count is a
-hard error. Dense execution must not install paged metadata, and paged mode
-rejects legacy dense `past_key_values` payloads.
-
-## Runner-owned request execution
-
-The current feature uses request-level execution (`step_execution=false`). The
-runner receives a complete request, installs its allocation snapshot, and
-executes the normal `pipeline.forward()` call. It does not make the model aware
-of Scheduler internals.
-
-For each allocated sequence, the runner constructs two row descriptions:
+The current contract is request-level execution (`step_execution=false`). The
+runner installs the allocation snapshot, prepares row metadata, and executes
+the normal pipeline forward. For each sequence it uses the following rows:
 
 | Phase | `query_len` | `seq_len` | `kv_start_pos` |
 | --- | ---: | ---: | ---: |
-| First denoising/prefill forward | `seq_len` | `seq_len` | `0` |
-| Later denoising forward | `target_len` | `prefix_len + target_len` | `prefix_len` |
+| First denoising/prefill | `seq_len` | `seq_len` | `0` |
+| Later denoising steps | `target_len` | `prefix_len + target_len` | `prefix_len` |
 
-The rows keep the same ordered identity in both phases. The runner places the
-metadata and a `DiffusionPagedAttentionRuntime` in `ForwardContext`. When the
-Hunyuan denoising loop publishes its step index, the runtime swaps from the
-prefill rows to the denoise rows once and reuses that phase for all attention
-layers in the step.
+The ordered sequence identity is unchanged between phases. The runner places
+the active rows and `DiffusionPagedAttentionRuntime` in `ForwardContext`; the
+denoising loop switches from prefill to denoise metadata once and reuses it
+across all attention layers.
 
-The common attention layer observes the opaque Worker adapter only while the
-forward is active. This keeps allocation, row binding, and activation in the
-runner/Worker boundary and lets future DiT models reuse the same protocol.
+Hunyuan-specific preprocessing in `request_layout.py` derives:
 
-## HunyuanImage-3.0 integration
-
-### Model boundary
-
-`request_layout.py` owns Hunyuan-specific preprocessing and derives the
-Scheduler lengths from tokenizer positions:
-
-```text
+~~~text
 prefix_len = final generated-timestep scatter position
 target_len = image tokens + timestep token + guidance token
 seq_len    = final real position in the prepared row
-```
+~~~
 
-`HunyuanImage3Pipeline` creates one KV sequence for each CFG branch. The
-current pipeline deliberately declares `supports_request_batch = False`; a
-public request is therefore normally run with `max_num_seqs=1`, while its
-conditional and unconditional rows may still be processed together inside the
-model's CFG batch.
+`HunyuanImage3Pipeline` creates one KV sequence for each conditional or
+unconditional CFG branch. CFG rows are internal branches of one request, not
+unrelated public requests. `_forward_paged()` validates lengths and spans,
+describes Q/K/V layout, clears the legacy dense prompt cache, and handles the
+Hunyuan prompt/image split needed by strict Ulysses SP. It does not allocate
+blocks or activate the Worker runtime.
 
-`ImageKVCacheManager._forward_paged()` is intentionally a model boundary,
-not a cache manager. It:
-
-- validates the prepared query/sequence lengths and span rows;
-- clears the legacy model-owned dense prompt cache;
-- describes Hunyuan's Q/K/V layout and `full_attn_spans`; and
-- for strict Ulysses, separates the joint prompt portion from the local image
-  shard before invoking the common attention layer.
-
-It does not allocate blocks, construct BlockTables, or activate the Worker
-runtime.
-
-### CFG parallelism
-
-The current Hunyuan integration supports the two-branch conditional and
-unconditional CFG layout. The Scheduler metadata contains one sequence per
-branch, and the runner selects the branch belonging to the current CFG rank
-before building rank-local rows. Positive and negative sequence identities
-remain stable, so each rank writes and reads the correct physical page. This
-is different from public request batching: CFG rows are internal branches of
-one request, not unrelated requests merged by the Scheduler.
-
-### Sequence parallelism
-
-The paged path supports strict Ulysses SP in request mode. The parallel
-strategy performs its normal Q/K/V exchange first. The common attention layer
-removes synthetic SP padding before preparing paged metadata and restores zero
-placeholders before the reverse exchange. Hunyuan supplies the prompt/image
-split needed for its joint attention layout.
-
-Ring attention and AllGather-KV SP are rejected explicitly because their
-metadata and communication contracts do not match the current paged native
-adapter.
+Strict Ulysses SP is supported in request mode. The parallel strategy performs
+its Q/K/V exchange, the paged adapter removes synthetic padding before native
+metadata preparation, and zero placeholders are restored before the reverse
+exchange. Ring and AllGather-KV SP are rejected because their metadata and
+communication contracts are different.
 
 ## Attention execution
 
-### Dense legacy path
+Dense and paged paths implement the same mixed causal/full attention. They
+differ in storage and in how a backend realizes the mask.
 
-The dense Hunyuan path materializes a 4-D mixed causal/full attention mask and
-also carries the equivalent `full_attn_spans` metadata. Dense therefore
-represents the same mixed attention pattern; it is not a different model mask.
-The number and shape of native calls depend on the selected platform backend:
+### Dense path
 
-| Dense backend | Execution shape |
-| --- | --- |
-| CUDA `FLASH_ATTN` | The CUDA implementation prioritizes `full_attn_spans` and uses the shared piecewise FA helper, so one dense K/V call is made per aligned segment. No persistent page or Scheduler slot mapping is involved. |
-| NPU `FLASH_ATTN` / MindIE-SD | Hunyuan passes the materialized mask to `attention_forward`; the normal Hunyuan dense path uses one masked call per layer. |
-| Other dense backends | Follow their own mask/piecewise capability contract; they do not acquire Scheduler-managed pages. |
-
-This distinction is important when comparing traces: "dense" describes the
-tensor/cache representation, while piecewise execution describes how a
-backend realizes Hunyuan's mixed mask.
+The Hunyuan dense path materializes a 4-D mask and carries equivalent
+`full_attn_spans` metadata. On NPU, the normal dense backend usually makes one
+masked attention call per layer. On CUDA, the shared piecewise FA helper may
+use one dense call per aligned segment. Thus "dense" describes the tensor
+representation, not a universal number of kernel calls.
 
 ### Paged path
 
-The paged path passes `full_attn_spans` instead of requiring a quadratic mask.
-The common piecewise planner converts each row into aligned segments:
+Paged execution passes `full_attn_spans` instead of a quadratic mask. Each row
+is converted into aligned native segments:
 
 | Segment | Native inputs | Causal flag |
 | --- | --- | --- |
 | Causal `[s, e)` | `Q[s:e]`, `K[:e]`, `V[:e]` | `true` |
-| Full span `[a, b)` intersecting the query | `Q[overlap]`, `K[:b]`, `V[:b]` | `false` |
+| Full `[a, b)` | Query overlap, `K[:b]`, `V[:b]` | `false` |
 
-The segment boundaries preserve FlashAttention's bottom-right causal
-alignment. The resulting outputs are restored to the original token order
-before `o_proj`, residual, and MLP layers consume them.
+The segment boundaries preserve bottom-right causal alignment. Native paged
+calls read persistent Worker pages, and results are restored to the original
+token order before `o_proj`, residual, and MLP layers consume them.
 
-Paged attention is consequently a sequence of native paged calls per layer. On
-CUDA, Dense `FLASH_ATTN` can also be piecewise, whereas Dense NPU MindIE-SD
-normally remains one masked call. In every case, the distinction is storage
-and backend execution shape only; both paths implement the same Hunyuan
-causal/full semantics.
+The K/V update is outside the segment loop:
 
-### One K/V write per layer
-
-The K/V update is deliberately outside the segment loop:
-
-```text
-current Q/K/V projection
-  -> write the current K/V span to the Worker cache once
-  -> run each piecewise attention segment against persistent pages
+~~~text
+Q/K/V projection
+  -> write the current K/V span once
+  -> run all piecewise native attention segments
   -> restore output order
-```
+~~~
 
-The CUDA/default backend keeps cache-update ownership in its native paged
-attention contract. Ascend requires an explicit normal-layout cache prewrite;
-its FIA segment calls read the just-written pages and pass no K/V source for
-those reads. Thus a request with three segments performs one layer write and
-three FIA calls, rather than three repeated writes. The obsolete logical-cache
-to-PA_NZ-to-logical conversion is not part of the current design.
+CUDA keeps the update in its native paged-attention contract. Ascend performs
+an explicit normal-layout cache prewrite, then FIA segment calls read the
+written pages without a K/V source. The obsolete logical-cache to PA_NZ and
+back conversion is not part of this contract.
 
-## Piecewise planning and fast paths
+## Piecewise planning
 
-`DiffusionPagedAttentionAdapter` prepares common row metadata once per active
-forward:
+`DiffusionPagedAttentionAdapter` resolves Worker rows, gathers BlockTables,
+computes slots, builds platform metadata, and caches the segment plan for the
+active forward.
 
-1. resolve logical identities to Worker row indices;
-2. gather native BlockTables;
-3. compute positions and slot mappings for the current write span;
-4. build platform-native attention metadata; and
-5. cache the piecewise plan and per-segment native metadata for all layers.
+| Row layout | Execution | Purpose |
+| --- | --- | --- |
+| Homogeneous query lengths and ranges | Keep `[B, T, ...]`, flatten each segment for the native call, then reshape/concatenate or write directly to the output buffer | Avoid the large indexed output scatter for homogeneous CFG rows |
+| Heterogeneous lengths or offsets | `index_select` valid tokens, run native calls, then `index_copy_` into the original layout | General fallback preserving each row's token order |
 
-The planner has two output-layout paths:
-
-### Homogeneous rows
-
-When rows have the same local query length and segment ranges, the runner keeps
-the row-major `[B, T, ...]` layout. Each segment is flattened only for the
-native call, then reshaped and concatenated along the sequence dimension. On
-NPU this avoids a large per-segment indexed `ScatterUpdate` for homogeneous CFG
-rows.
-
-### Heterogeneous rows
-
-When local ranges differ, the planner packs valid tokens with `index_select`,
-runs the native segment calls, and restores the original layout with
-`index_copy_`. This fallback supports different row lengths and offsets while
-preserving the contract seen by subsequent transformer layers. It is the
-general path; the homogeneous optimization must not change its semantics.
-
-The fast path concerns rows inside one attention invocation. It does not enable
-arbitrary public-request batching, and it does not change Scheduler allocation.
+The fast path applies only to rows inside one attention invocation. It does not
+enable arbitrary public-request batching or change Scheduler allocation.
 
 ## Platform boundary
 
-| Concern | CUDA/GPU | Ascend/NPU |
+| Concern | NVIDIA GPU | Ascend NPU |
 | --- | --- | --- |
 | Block tables | Native vLLM `BlockTables` | `AscendBlockTables` from vLLM-Ascend |
-| Paged kernel | Native FlashAttention/FA3 contract | Ascend `FusedInferAttentionScore` (FIA) |
-| Cache update | Owned by the native paged attention writer/kernel | Explicit normal-layout `do_kv_cache_update()` before segment calls |
-| Attention metadata | vLLM GPU metadata builder | Ascend metadata builder with `ChunkedPrefill` state |
-| SP specialization | Native strict Ulysses integration | Ascend paged backend specialization for strict Ulysses |
-| Dense optional dependency | Platform-selected dense backend | MindIE-SD may serve dense attention; absence is tolerated only for the startup profile fallback |
+| Paged kernel | Native FlashAttention/FA3 | Ascend `FusedInferAttentionScore` (FIA) |
+| Cache update | Native paged writer/kernel | Explicit normal-layout prewrite |
+| Attention metadata | vLLM GPU builder | Ascend builder with `ChunkedPrefill` state |
+| SP specialization | Native strict Ulysses integration | Ascend paged strict-Ulysses path |
+| Dense dependency | Platform-selected dense backend | MindIE-SD when available; SDPA only for the marked startup profile |
 
-The shared `OmniPlatform` interface owns capability hooks such as
+Hardware-specific imports and policy stay behind `OmniPlatform` hooks such as
 `get_diffusion_kv_block_tables_cls()`,
 `build_diffusion_kv_attn_metadata()`, and
-`requires_diffusion_paged_kv_prewrite()`. Hardware-specific imports stay behind
-these hooks, so the common adapter does not import vLLM-Ascend directly.
-
-## Correctness invariants
-
-The following invariants are required for a new model or backend integration:
-
-1. **One identity, one row.** A `(request_id, sequence_id/context_id)` maps to
-   exactly one Worker row during an active request.
-2. **Allocation is complete before execution.** Every CFG branch fits before
-   any branch is sent to a Worker.
-3. **Write span is bounded.** `kv_start_pos + query_len <= seq_len` and the
-   installed page count covers `seq_len`.
-4. **Prefill and denoise identities agree.** Only lengths and the write offset
-   change between phases.
-5. **Attention metadata is stable within a forward.** Span layout and native
-   segment metadata cannot change between layers.
-6. **Dense and paged ownership are exclusive.** Dense requests do not install
-   paged metadata; paged requests do not accept legacy dense KV payloads.
-7. **No accidental fallback.** A missing adapter, unsupported backend, stale
-   generation, or unsupported SP strategy raises an actionable error. The only
-   pre-admission exception is the explicitly marked memory profile.
-8. **Both owners clean up.** Scheduler logical blocks and Worker physical rows
-   are released on every terminal path.
+`requires_diffusion_paged_kv_prewrite()`.
 
 ## Configuration and compatibility
 
-The mode parser accepts `dense_legacy` and `paged_scheduler`. The
-`paged_worker_local` enum value documents a migration topology but is rejected
-until a separate implementation exists. `paged_scheduler` additionally
-requires `diffusion_kv_max_rows_per_request`, a native cache configuration, and
-a prepared memory-profile request.
-
-For the current Hunyuan integration:
+`paged_scheduler` requires a native cache configuration,
+`diffusion_kv_max_rows_per_request`, and a prepared memory-profile request.
+The dense path remains the default `dense_legacy` path and keeps its existing
+backend and compatibility cache.
 
 | Combination | Status |
 | --- | --- |
-| Request execution, no SP, TP | Supported when the selected backend has paged support. |
-| Request execution, strict Ulysses SP | Supported by the current GPU and NPU integrations. |
-| Request execution, two-branch CFG parallel | Supported when one allocated row exists per CFG rank. |
-| Hunyuan step execution with paged KV | Rejected; use `dense_legacy` until a step-mode contract is added. |
-| Hunyuan independent request batching | Not enabled (`supports_request_batch=False`). |
-| Ring or AllGather-KV SP | Rejected in the paged path. |
-| Imported AR KV or independent Hunyuan contexts | Not implemented. |
-| Cross-request prefix cache publication | Disabled; pages are request-local. |
+| Request execution, TP, no SP | Supported when the backend has paged support |
+| Request execution, strict Ulysses SP | Supported by current GPU and NPU integrations |
+| Request execution, two-branch CFG parallel | Supported with one allocated row per CFG rank |
+| Hunyuan paged step execution | Rejected; use `dense_legacy` |
+| Independent public request batching | Disabled (`supports_request_batch=False`) |
+| Ring or AllGather-KV SP | Rejected in the paged path |
+| Imported AR KV or independent Hunyuan contexts | Not implemented |
+| Cross-request prefix publication | Disabled; pages are request-local |
 
-The dense path can continue to use its existing backend and model-owned
-compatibility cache when `diffusion_kv_mode=dense_legacy`. Marking an attention
-layer as paged-capable does not route unmarked dense layers through the native
-KV pool.
+## Invariants, errors, and validation
 
-## Validation strategy
+Implementations must preserve these invariants:
 
-Validation is split by ownership boundary:
+1. Each `(request_id, sequence_id/context_id)` maps to one active Worker row.
+2. Every CFG branch fits before execution begins.
+3. `kv_start_pos + query_len <= seq_len`, and installed pages cover `seq_len`.
+4. Prefill and denoise retain identity; only lengths and write offset change.
+5. Span and native metadata stay stable across layers in one forward.
+6. Dense and paged ownership are exclusive, with no accidental fallback.
+7. Scheduler blocks and Worker rows are both released on every terminal path.
 
-| Area | Representative coverage |
-| --- | --- |
-| Mode and native sizing | `tests/diffusion/diffusion_kv/test_config.py`, `test_initialization.py` |
-| Scheduler allocation | `test_manager.py`, `test_request.py`, `test_metadata.py`, and `test_diffusion_scheduler.py` |
-| Worker rows and BlockTables | `test_block_tables.py`, `test_worker_contract.py`, and native GPU adapter tests |
-| Adapter and piecewise metadata | `test_paged_attention_adapter.py`, `test_paged_attention_adapter_gpu.py`, and piecewise attention tests |
-| Hunyuan layout/ownership | `tests/diffusion/models/hunyuan_image3/test_diffusion_kv_request.py` and `test_image_kv_cache_manager.py` |
-| End-to-end correctness | Hunyuan E2E and pixel-accuracy tests with matched dense/paged inputs |
+Errors should be raised by the owner that can explain them: preprocessing for
+malformed layout, Scheduler for capacity, Worker for row/table state, adapter
+for shape or metadata mismatch, and platform for unavailable kernels or
+parallel strategies. The only intentional pre-admission exception is the
+explicitly marked memory profile.
 
-An end-to-end validation run should record the mode, model and Omni commit,
+Validation should cover mode and sizing, atomic Scheduler allocation, Worker
+row/BlockTable contracts, adapter metadata and piecewise paths, Hunyuan layout,
+and matched dense/paged E2E output. A run should record model and Omni commit,
 platform/backend, TP/SP/CFGP topology, block geometry, KV budget, warmup
 policy, request count, and output validity. Paged claims require native-path
-evidence (for example, CUDA paged FlashAttention or Ascend FIA/cache-writer
-events) and must verify that no dense fallback was active. Profiling runs are
-separate from latency samples because profiler instrumentation changes host and
-device timing.
+evidence (CUDA paged FlashAttention or Ascend FIA/cache-writer events) and
+must verify that no dense fallback was active.
 
-## Failure handling and observability
+## Implementation map
 
-Errors are intentionally raised at the earliest owner that can explain them:
-
-- preprocessing rejects a malformed Hunyuan layout or CFG count;
-- the Scheduler reports an admission or capacity error;
-- the Worker reports an invalid block table, row binding, or generation;
-- the adapter reports a shape, dtype, span, or native metadata mismatch; and
-- the platform reports an unavailable kernel or unsupported parallel strategy.
-
-Request errors still pass through the normal diffusion output stream. Cleanup
-is performed independently of output delivery, so a cancelled consumer cannot
-leave Scheduler blocks or Worker rows active.
-
-Useful debug records include the allocation generation, logical lengths,
-resolved Worker row indices, native block IDs, active denoising phase, selected
-backend, and whether the NPU prewrite contract was used. These records should
-remain request-scoped and must not expose device pointers or prompt contents.
-
-## Related implementation
-
-- Scheduler facade: [`diffusion_kv/manager.py`](gh-file:vllm_omni/diffusion/diffusion_kv/manager.py)
-- Request and allocation DTOs: [`diffusion_kv/request.py`](gh-file:vllm_omni/diffusion/diffusion_kv/request.py), [`diffusion_kv/metadata.py`](gh-file:vllm_omni/diffusion/diffusion_kv/metadata.py)
-- Native cache initialization: [`diffusion_kv/initialization.py`](gh-file:vllm_omni/diffusion/diffusion_kv/initialization.py), [`vllm_config.py`](gh-file:vllm_omni/diffusion/vllm_config.py)
-- Worker data plane: [`diffusion_kv/model_runner_backend.py`](gh-file:vllm_omni/diffusion/diffusion_kv/model_runner_backend.py)
-- Generic adapter and runtime: [`diffusion_kv/paged_attention_adapter.py`](gh-file:vllm_omni/diffusion/diffusion_kv/paged_attention_adapter.py)
-- Runner activation: [`diffusion_model_runner.py`](gh-file:vllm_omni/diffusion/worker/diffusion_model_runner.py), [`forward_context.py`](gh-file:vllm_omni/diffusion/forward_context.py)
-- Common attention boundary: [`attention/layer.py`](gh-file:vllm_omni/diffusion/attention/layer.py), [`attention/backends/flash_attn.py`](gh-file:vllm_omni/diffusion/attention/backends/flash_attn.py)
-- Piecewise planner: [`attention/backends/utils/piecewise_attn.py`](gh-file:vllm_omni/diffusion/attention/backends/utils/piecewise_attn.py)
-- Hunyuan layout and model boundary: [`models/hunyuan_image3/request_layout.py`](gh-file:vllm_omni/diffusion/models/hunyuan_image3/request_layout.py), [`pipeline_hunyuan_image3.py`](gh-file:vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py), [`hunyuan_image3_transformer.py`](gh-file:vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py)
+- Scheduler and requests: [`diffusion_kv/manager.py`](gh-file:vllm_omni/diffusion/diffusion_kv/manager.py), [`diffusion_kv/request.py`](gh-file:vllm_omni/diffusion/diffusion_kv/request.py), [`diffusion_kv/metadata.py`](gh-file:vllm_omni/diffusion/diffusion_kv/metadata.py)
+- Initialization and Worker data plane: [`diffusion_kv/initialization.py`](gh-file:vllm_omni/diffusion/diffusion_kv/initialization.py), [`diffusion_kv/model_runner_backend.py`](gh-file:vllm_omni/diffusion/diffusion_kv/model_runner_backend.py)
+- Adapter and runtime: [`diffusion_kv/paged_attention_adapter.py`](gh-file:vllm_omni/diffusion/diffusion_kv/paged_attention_adapter.py), [`worker/diffusion_model_runner.py`](gh-file:vllm_omni/diffusion/worker/diffusion_model_runner.py), [`forward_context.py`](gh-file:vllm_omni/diffusion/forward_context.py)
+- Attention and piecewise planner: [`attention/layer.py`](gh-file:vllm_omni/diffusion/attention/layer.py), [`attention/backends/flash_attn.py`](gh-file:vllm_omni/diffusion/attention/backends/flash_attn.py), [`attention/backends/utils/piecewise_attn.py`](gh-file:vllm_omni/diffusion/attention/backends/utils/piecewise_attn.py)
+- Hunyuan boundary: [`models/hunyuan_image3/request_layout.py`](gh-file:vllm_omni/diffusion/models/hunyuan_image3/request_layout.py), [`models/hunyuan_image3/pipeline_hunyuan_image3.py`](gh-file:vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py), [`models/hunyuan_image3/hunyuan_image3_transformer.py`](gh-file:vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py)
 - Platform hooks: [`platforms/interface.py`](gh-file:vllm_omni/platforms/interface.py), [`platforms/cuda/platform.py`](gh-file:vllm_omni/platforms/cuda/platform.py), [`platforms/npu/platform.py`](gh-file:vllm_omni/platforms/npu/platform.py)
 
 ## Related design work
 
-The control-plane contracts were introduced in PR #5541 and PR #5550, native
-Scheduler allocation was added in PR #6094, and the Worker data plane was added
-in PR #6102. Hunyuan GPU integration and the shared piecewise execution work
-began in PR #6658 and were consolidated with the Ascend implementation in PR #6563.
-Future models should reuse these contracts and add only their model-specific
-layout, capacity profile, and backend capability requirements.
+The control-plane contracts were introduced in #5541 and #5550, native
+Scheduler allocation was added in #6094, and the Worker data plane in #6102.
+Hunyuan GPU integration and shared piecewise execution began in #6658 and
+were consolidated with the Ascend implementation in #6563. Future DiT models
+should reuse these contracts and add only model-specific layout, profiling,
+and backend capability requirements.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -60,6 +60,7 @@ The design contracts separate selection mechanics from backend algorithms:
 
 - [Attention Backend Selection](feature/attention_backend_selection.md)
 - [Skip-Softmax](feature/skip_softmax.md)
+- [Scheduler-Managed Paged KV Cache for Diffusion DiT Stages](feature/diffusion_paged_kv_cache.md)
 
 #### CPU offloading
 

--- a/docs/user_guide/diffusion/execution_modes.md
+++ b/docs/user_guide/diffusion/execution_modes.md
@@ -100,7 +100,10 @@ set `DIFFUSION_ATTENTION_BACKEND=TORCH_SDPA` or configure
 `diffusion_attention_config.default.backend=TORCH_SDPA` before using
 `--max-num-seqs >1`. See the
 [HunyuanImage-3.0 recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/Tencent/HunyuanImage-3.0-Instruct.md)
-for its validated configuration. Helios supports single-request step execution only: use
+for its validated configuration. For HunyuanImage3, this step-execution
+support applies to the `dense_legacy` path; `paged_scheduler` currently
+supports request-level execution only. Helios supports single-request step
+execution only: use
 `--step-execution --max-num-seqs 1` for Helios. MiniMax H3 supports step-wise
 continuous batching by packing co-batched requests into one sequence that keeps
 a separate attention document per request; that layout needs a backend which

--- a/docs/user_guide/diffusion/execution_modes.md
+++ b/docs/user_guide/diffusion/execution_modes.md
@@ -102,7 +102,9 @@ set `DIFFUSION_ATTENTION_BACKEND=TORCH_SDPA` or configure
 [HunyuanImage-3.0 recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/Tencent/HunyuanImage-3.0-Instruct.md)
 for its validated configuration. For HunyuanImage3, this step-execution
 support applies to the `dense_legacy` path; `paged_scheduler` currently
-supports request-level execution only. Helios supports single-request step
+supports request-level execution only. See the
+[Scheduler-Managed Paged KV Cache guide](paged_kv_cache.md) for its required
+backend and configuration. Helios supports single-request step
 execution only: use
 `--step-execution --max-num-seqs 1` for Helios. MiniMax H3 supports step-wise
 continuous batching by packing co-batched requests into one sequence that keeps

--- a/docs/user_guide/diffusion/paged_kv_cache.md
+++ b/docs/user_guide/diffusion/paged_kv_cache.md
@@ -1,0 +1,167 @@
+# Scheduler-Managed Paged KV Cache
+
+Scheduler-managed paged KV cache stores diffusion DiT key/value tensors in
+Worker-owned pages. It is useful when a denoising request should keep its
+stable prompt/reference prefix in device memory while rewriting only the
+changing image span on later steps. The current HunyuanImage-3.0 integration
+is request-level only; it does not silently change an unsupported request to
+dense attention.
+
+Paging changes KV storage and scheduling ownership; it does not change the
+model's causal/full attention semantics.
+
+## Choose a mode
+
+| Need | Mode |
+| --- | --- |
+| Broadest compatibility or step execution | `dense_legacy` (default) |
+| HunyuanImage-3.0 request-mode serving with Scheduler-managed KV pages | `paged_scheduler` |
+
+Use `dense_legacy` when the model, attention backend, or offload combination
+has not been validated for paged KV. HunyuanImage-3.0 paged KV currently accepts
+request-level execution only; set `step_execution: false`.
+
+## Supported scope
+
+| Model | Platform | Execution | Backend | Status |
+| --- | --- | --- | --- | --- |
+| HunyuanImage-3.0 | NVIDIA CUDA | Request-level | `FLASH_ATTN` (native FlashAttention/FA3) | Implemented and validated |
+| HunyuanImage-3.0 | Ascend NPU | Request-level | `FLASH_ATTN` (Ascend FIA) | Implemented and validated |
+| Other diffusion models | Any | N/A | Any | Not integrated or tested |
+
+Only the logical `FLASH_ATTN` backend currently advertises paged-KV support.
+`TORCH_SDPA`, `CUDNN_ATTN`, `FLASHINFER_ATTN`, SAGE, Hub, and other diffusion
+backends do not transparently fall back to dense execution for a paged request.
+
+Strict Ulysses SP and two-branch CFG parallel are supported in HunyuanImage-3.0
+request mode when the selected device topology has been validated. Ring SP,
+AllGather-KV SP, Hunyuan paged step execution, and independent public-request
+batching are not supported by this path. DreamZero and LingBot-World use the
+separate `ar_diffusion_kv` imported-AR-KV contract.
+
+## Configure
+
+The diffusion KV fields are stage settings. The two
+`diffusion_kv_*` fields are diffusion-specific engine fields and are forwarded
+through `engine_extras`; `kv_cache_memory_bytes` is a standard stage field and
+is placed directly under the stage:
+
+```yaml
+stages:
+  - stage_id: 0
+    max_num_seqs: 1
+    enforce_eager: true
+    diffusion_attention_backend: FLASH_ATTN
+    step_execution: false
+    kv_cache_memory_bytes: 536870912  # 512 MiB per Worker/rank
+    engine_extras:
+      diffusion_kv_mode: paged_scheduler
+      diffusion_kv_max_rows_per_request: 2
+```
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `diffusion_kv_mode` | Yes | `paged_scheduler` enables Scheduler-managed pages; `dense_legacy` is the default |
+| `diffusion_kv_max_rows_per_request` | Yes for paged | Positive Worker row limit, including all internal CFG branches; use `1` without CFG and `2` for standard CFG |
+| `kv_cache_memory_bytes` | Optional | Explicit physical KV-pool budget per Worker/rank; omit it to use automatic sizing |
+| `gpu_memory_utilization` | Optional | Automatic pool-sizing fraction when no explicit byte budget is set |
+| `max_num_seqs` | Recommended `1` | Public request capacity; it is separate from the internal CFG row limit |
+| `step_execution` | Must be `false` | Hunyuan paged KV is request-level only |
+| `diffusion_attention_backend` | `FLASH_ATTN` | Required logical backend for the current paged implementation |
+
+`kv_cache_memory_bytes` describes pool capacity, not live payload. Reserved
+memory can therefore exceed the memory currently used by active requests.
+The Scheduler allocates all rows belonging to one request together: a request
+with CFG disabled has one row, while standard two-branch CFG has two rows. CFG
+rows are internal branches, not independent public requests.
+
+Paged KV is currently unquantized BF16. `diffusion_kv_cache_dtype` does not
+enable quantized paged KV, and model weight quantization has not been validated
+in combination with this mode. CPU offload, layerwise offload, and distributed
+layerwise offload (DLO) are currently untested with paged KV. Leave these
+options disabled for paged KV; use `dense_legacy` when offload is required.
+
+## Hunyuan request-mode example
+
+Create a small deploy overlay (for example,
+`hunyuan_image3_paged.yaml`) with the stage settings above, then start the
+validated Hunyuan request-mode path:
+
+```bash
+vllm serve tencent/HunyuanImage-3.0-Instruct \
+  --omni \
+  --trust-remote-code \
+  --port 8091 \
+  --deploy-config /path/to/hunyuan_image3_paged.yaml
+```
+
+The base Hunyuan DiT deploy file can be reused and overridden from the command
+line when a separate overlay is inconvenient:
+
+```bash
+vllm serve tencent/HunyuanImage-3.0-Instruct \
+  --omni \
+  --trust-remote-code \
+  --deploy-config vllm_omni/deploy/hunyuan_image3_dit.yaml \
+  --stage-overrides \
+  '{"0":{"diffusion_kv_mode":"paged_scheduler","diffusion_kv_max_rows_per_request":2,"kv_cache_memory_bytes":536870912,"step_execution":false,"diffusion_attention_backend":"FLASH_ATTN"}}'
+```
+
+After the server is ready, send the normal Hunyuan image-generation request:
+
+```bash
+curl -s http://localhost:8091/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "modalities": ["image"],
+    "messages": [{"role": "user", "content": "A red ceramic vase on a wooden table"}],
+    "extra_body": {
+      "height": 1024,
+      "width": 1024,
+      "num_inference_steps": 20,
+      "guidance_scale": 5.0,
+      "seed": 1234
+    }
+  }' | jq -r '.choices[0].message.content[0].image_url.url' \
+    | cut -d',' -f2- | base64 -d > hunyuan_image3_paged.png
+```
+
+The same configuration is shown in the
+[HunyuanImage-3.0 recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/Tencent/HunyuanImage-3.0-Instruct.md).
+
+Confirm from startup and worker logs that the resolved backend is
+`FLASH_ATTN` and that the paged native path is active. A paged request must
+fail explicitly if its Worker metadata or native backend is unavailable; it
+must not silently switch to dense attention.
+
+## Parallelism
+
+Hunyuan request-mode paged KV can be combined with tensor parallelism, strict
+Ulysses SP, or two-way CFG parallel when the selected topology has been
+validated. Configure the topology in the stage's existing `parallel_config`:
+
+| Setting | User-visible effect | Paged-KV requirement |
+| --- | --- | --- |
+| `tensor_parallel_size` | Shards model weights across ranks | Device count must match the stage topology |
+| `sequence_parallel_size` + strict Ulysses | Shards the sequence across ranks | Ring and AllGather-KV modes are not supported |
+| `cfg_parallel_size: 2` | Places the positive and negative branches on separate ranks | Set `diffusion_kv_max_rows_per_request` to at least `2` |
+
+`max_num_seqs` controls public request concurrency and is independent of the
+internal CFG row limit. Keep `max_num_seqs: 1` for the current Hunyuan paged
+path; increasing it does not enable independent request batching.
+
+## Troubleshooting
+
+- `paged_scheduler requires diffusion_kv_max_rows_per_request`: add a positive
+  stage value and include all CFG rows.
+- Unsupported backend error: select `FLASH_ATTN`; the other attention backends
+  currently do not implement the paged-KV capability.
+- Step-mode rejection: remove `step_execution: true` and use request-level
+  execution, or select `dense_legacy` for step execution.
+- Imported AR-KV rejection: `paged_scheduler` does not consume the
+  `ar_diffusion_kv` contract used by DreamZero or LingBot-World.
+- Missing image output: include `"modalities": ["image"]` when using the chat
+  completions endpoint, and decode the returned data URI as shown above.
+
+For the ownership and lifecycle contract, see the
+[Scheduler-managed paged KV design](../../design/feature/diffusion_paged_kv_cache.md).

--- a/docs/user_guide/diffusion_features.md
+++ b/docs/user_guide/diffusion_features.md
@@ -246,6 +246,7 @@ The Diffusion Acceleration navigation groups the remaining guides as follows:
 | Compatibility | [Feature Compatibility](feature_compatibility.md) |
 | CPU offloading | [CPU Offloading](diffusion/cpu_offload.md) |
 | Cache acceleration | [TeaCache](diffusion/cache_acceleration/teacache.md), [Cache-DiT](diffusion/cache_acceleration/cache_dit.md) |
+| KV cache paging | [Scheduler-Managed Paged KV Cache](diffusion/paged_kv_cache.md) |
 | Parallelism | [Parallelism Overview](diffusion/parallelism/overview.md) |
 | Attention | [Attention Backends](diffusion/attention_backends.md) |
 | Compilation | [Regional Compilation](diffusion/regional_compilation.md) |

--- a/recipes/Tencent/HunyuanImage-3.0-Instruct.md
+++ b/recipes/Tencent/HunyuanImage-3.0-Instruct.md
@@ -255,6 +255,56 @@ of:
   the TP=4 configuration before increasing batch size. GPU memory utilization
   is not a useful primary tuning knob for this DiT-only recipe.
 
+### Scheduler-managed paged KV (request mode)
+
+HunyuanImage-3 can use Scheduler-managed paged KV in request-level execution.
+The current paged implementation uses unquantized BF16 KV and requires the
+logical `FLASH_ATTN` backend. The following command reuses the standard DiT
+deploy file and supplies the paged-only stage settings with
+`--stage-overrides`:
+
+For the mode-selection guide, configuration field reference, and parallelism
+limits, see the [Scheduler-Managed Paged KV Cache user guide](../../docs/user_guide/diffusion/paged_kv_cache.md).
+
+```bash
+vllm serve tencent/HunyuanImage-3.0-Instruct \
+  --omni \
+  --trust-remote-code \
+  --port 8091 \
+  --deploy-config vllm_omni/deploy/hunyuan_image3_dit.yaml \
+  --stage-overrides \
+  '{"0":{"diffusion_kv_mode":"paged_scheduler","diffusion_kv_max_rows_per_request":2,"kv_cache_memory_bytes":536870912,"step_execution":false,"diffusion_attention_backend":"FLASH_ATTN"}}'
+```
+
+Here `kv_cache_memory_bytes` reserves a 512 MiB physical KV pool per Worker
+and rank, and `diffusion_kv_max_rows_per_request=2` reserves the two internal
+rows used by standard positive/negative CFG. Use `1` when CFG is disabled.
+Keep `max_num_seqs=1`: this paged Hunyuan path does not currently batch
+independent public requests.
+
+Generate an image after `/health` reports ready:
+
+```bash
+curl -s http://localhost:8091/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "modalities": ["image"],
+    "messages": [{"role": "user", "content": "A red ceramic vase on a wooden table"}],
+    "extra_body": {
+      "height": 1024,
+      "width": 1024,
+      "num_inference_steps": 20,
+      "guidance_scale": 5.0,
+      "seed": 1234
+    }
+  }' | jq -r '.choices[0].message.content[0].image_url.url' \
+    | cut -d',' -f2- | base64 -d > hunyuan_image3_paged.png
+```
+
+This mode is also implemented on Ascend NPU, where `FLASH_ATTN` resolves to
+Ascend FIA. Hunyuan paged step execution, quantized paged KV, and CPU/DLO
+offload combinations are not validated; use `dense_legacy` for those cases.
+
 ### 2x B200 ModelOpt mixed FP8/NVFP4
 
 #### Environment


### PR DESCRIPTION
## Purpose

  - Add a design document for Scheduler-managed paged KV cache in diffusion DiT stages.
  - Document the ownership boundary between the Scheduler, Executor, Worker, model runner, attention layer, and platform backend.
  - Describe the request-level KV-cache lifecycle, including allocation, metadata transport, physical page initialization, activation, update, and release.
  - Document the HunyuanImage-3.0 integration, including CFG branches, strict Ulysses SP, mixed causal/full attention, and the one-KV-write- per-layer contract.
  - Describe the differences between dense and paged execution on NVIDIA GPU and Ascend NPU.
  - Document the homogeneous-row fast path, heterogeneous-row fallback, configuration options, correctness invariants, compatibility limits, and failure handling.
  - Clarify in the diffusion execution guide that Hunyuan step execution applies to `dense_legacy`, while `paged_scheduler` currently supports request-level execution only.
  - Link the related RFC and implementation work in #5244, #5541, #5550, #6094, #6102, #6563.
  - This is a documentation-only change. It does not modify runtime behavior.

  ## Test Plan

  - Run Markdown lint on the new and modified documentation files.
  - Parse the documentation navigation YAML.
  - Validate all `gh-file` references in the feature document.
  - Parse the Markdown document to check syntax.
  - Run `git diff --check`.
  - Runtime unit tests and E2E tests are not required because this PR changes documentation only.

  **vLLM Version:** N/A (documentation-only change)

  **vLLM-Omni Commit:** `2ecf5b6c844723dce3032a0e27526316c7503f99`
  Base commit: `7992c2213ef1b1502b1ebeb8890e5a835e9c5d60`

  ## Test Result

  - Markdown lint: PASS, 0 errors.
  - Markdown syntax validation: PASS.
  - Navigation YAML validation: PASS.
  - `gh-file` references: PASS, 17 links resolved successfully.
  - `git diff --check`: PASS.
  - Production code and test code were not modified.
  - Runtime behavior was not changed or revalidated in this documentation-only PR.

  ## CC List

  @hsliuustc0106 @asukaqaq-s @Bounty-hunter @Gaohan123 @zwhzzz0821