### PR TITLE
[Feature] Omni disagg: connector plumbing and downstream handlers

### DIFF
--- a/examples/online_serving/text_to_speech/qwen3_tts/run_standalone_servers.sh
+++ b/examples/online_serving/text_to_speech/qwen3_tts/run_standalone_servers.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+# Launch two standalone Qwen3-TTS stages for disaggregated serving.
+#
+# Usage:
+#   ./run_standalone_servers.sh                  # Default model, needs 2 GPUs
+#   ./run_standalone_servers.sh CustomVoice      # CustomVoice model
+#
+# This starts talker (stage 0) on GPU 0 / port 8000
+# and code2wav (stage 1) on GPU 1 / port 8001.
+# Then use standalone_disagg_client.py to chain them.
+
+set -e
+
+TASK_TYPE="${1:-CustomVoice}"
+
+case "$TASK_TYPE" in
+    CustomVoice)
+        MODEL="Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
+        ;;
+    Base)
+        MODEL="Qwen/Qwen3-TTS-12Hz-1.7B-Base"
+        ;;
+    *)
+        echo "Unknown task type: $TASK_TYPE"
+        echo "Supported: CustomVoice, Base"
+        exit 1
+        ;;
+esac
+
+echo "Starting standalone talker (stage 0) on GPU 0, port 8000..."
+CUDA_VISIBLE_DEVICES=0 vllm-omni serve "$MODEL" \
+    --omni \
+    --standalone \
+    --stage-id 0 \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --trust-remote-code &
+TALKER_PID=$!
+
+echo "Starting standalone code2wav (stage 1) on GPU 1, port 8001..."
+CUDA_VISIBLE_DEVICES=1 vllm-omni serve "$MODEL" \
+    --omni \
+    --standalone \
+    --stage-id 1 \
+    --host 0.0.0.0 \
+    --port 8001 \
+    --trust-remote-code &
+CODE2WAV_PID=$!
+
+echo "Talker PID=$TALKER_PID (GPU 0), Code2wav PID=$CODE2WAV_PID (GPU 1)"
+echo "Waiting for servers... use standalone_disagg_client.py to test."
+
+trap "kill $TALKER_PID $CODE2WAV_PID 2>/dev/null" EXIT
+wait

--- a/examples/online_serving/text_to_speech/qwen3_tts/standalone_disagg_client.py
+++ b/examples/online_serving/text_to_speech/qwen3_tts/standalone_disagg_client.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Disaggregated Qwen3-TTS client: chains standalone stages over HTTP.
+
+Reference coordinator that calls talker (stage 0) then forwards codec tokens
+to code2wav (stage 1) to produce audio.
+
+Start the servers first:
+    ./run_standalone_servers.sh
+
+Examples:
+    python standalone_disagg_client.py --text "Hello, how are you?"
+    python standalone_disagg_client.py --text "Hello" --voice vivian -o hello.wav
+"""
+
+import argparse
+import sys
+import time
+
+import httpx
+
+DEFAULT_TALKER_URL = "http://localhost:8000"
+DEFAULT_CODE2WAV_URL = "http://localhost:8001"
+
+
+def _post(client, url, body, label):
+    resp = client.post(url, json=body)
+    if resp.status_code != 200:
+        try:
+            detail = resp.json().get("error", resp.text)
+        except Exception:
+            detail = resp.text
+        print(f"{label} failed ({resp.status_code}): {detail}", file=sys.stderr)
+        sys.exit(1)
+    return resp
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Disaggregated TTS via standalone stages")
+    parser.add_argument("--text", required=True, help="Text to synthesize")
+    parser.add_argument("--voice", default="", help="Speaker voice name")
+    parser.add_argument("--model", default="Qwen/Qwen3-TTS", help="Model name")
+    parser.add_argument("--talker-url", default=DEFAULT_TALKER_URL, help="Talker stage URL")
+    parser.add_argument("--code2wav-url", default=DEFAULT_CODE2WAV_URL, help="Code2wav stage URL")
+    parser.add_argument("-o", "--output", default="output.wav", help="Output WAV path")
+    parser.add_argument("--timeout", type=int, default=120, help="Per-stage timeout (seconds)")
+    args = parser.parse_args()
+
+    with httpx.Client(timeout=args.timeout) as client:
+        # Step 1: talker (entry mode)
+        print(f"[1/2] Talker @ {args.talker_url} ...")
+        t0 = time.time()
+        resp = _post(
+            client,
+            f"{args.talker_url}/v1/stage/run",
+            {"model": args.model, "input": args.text, "voice": args.voice},
+            "Talker",
+        )
+        talker_result = resp.json()
+        t1 = time.time()
+
+        stage_output = talker_result.get("stage_output")
+        if stage_output is None:
+            print(f"Talker returned no stage_output: {talker_result}", file=sys.stderr)
+            sys.exit(1)
+
+        codec_frames = len(stage_output.get("codes", {}).get("audio", []))
+        print(f"      {t1 - t0:.1f}s, {codec_frames} codec frames")
+
+        # Step 2: code2wav (downstream mode)
+        print(f"[2/2] Code2wav @ {args.code2wav_url} ...")
+        t2 = time.time()
+        resp = _post(
+            client,
+            f"{args.code2wav_url}/v1/stage/run",
+            {
+                "stage_output": stage_output,
+                "request_id": talker_result.get("request_id", "disagg"),
+            },
+            "Code2wav",
+        )
+        t3 = time.time()
+
+        with open(args.output, "wb") as f:
+            f.write(resp.content)
+
+        print(f"      {t3 - t2:.1f}s, {len(resp.content)} bytes")
+        print(f"Total {t3 - t0:.1f}s, saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/entrypoints/test_standalone_stage.py
+++ b/tests/entrypoints/test_standalone_stage.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Unit tests for standalone stage mode."""
+
+from __future__ import annotations
+
+import pytest
+from omegaconf import OmegaConf
+
+from vllm_omni.entrypoints.cli.serve import OmniServeCommand
+from vllm_omni.entrypoints.utils import extract_standalone_stage_config
+from vllm_omni.utils.tracking_parser import TrackingArgumentParser
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _make_stage_configs():
+    """Build a 2-stage TTS-like OmegaConf config list."""
+    return OmegaConf.create(
+        [
+            {
+                "stage_id": 0,
+                "max_num_seqs": 64,
+                "final_output": False,
+                "output_connectors": {"to_stage_1": "connector_of_shared_memory"},
+                "engine_args": {
+                    "model_stage": "talker",
+                    "engine_output_type": "latent",
+                    "async_chunk": True,
+                    "custom_process_next_stage_input_func": "some.module.talker2code2wav",
+                    "async_chunk_process_next_stage_input_func": "some.module.talker2code2wav_async",
+                    "custom_process_input_func": "some.module.entry_input",
+                },
+            },
+            {
+                "stage_id": 1,
+                "max_num_seqs": 64,
+                "final_output": True,
+                "final_output_type": "audio",
+                "input_sources": [0],
+                "input_connectors": {"from_stage_0": "connector_of_shared_memory"},
+                "engine_args": {
+                    "model_stage": "code2wav",
+                    "engine_output_type": "audio",
+                    "custom_process_input_func": "some.module.downstream_input",
+                },
+            },
+        ]
+    )
+
+
+class TestExtractStandaloneStageConfig:
+    def test_downstream_stage_renumbered_to_zero(self):
+        """Extracting stage 1 renumbers it to stage_id=0 and marks final_output."""
+        configs = _make_stage_configs()
+        result = extract_standalone_stage_config(configs, 1)
+        cfg = result[0]
+
+        assert cfg.stage_id == 0
+        assert cfg.final_output is True
+
+    def test_clears_all_connectors_and_input_sources(self):
+        """Connectors and input_sources reference other stages that don't exist standalone."""
+        configs = _make_stage_configs()
+
+        r0 = extract_standalone_stage_config(configs, 0)
+        assert "output_connectors" not in r0[0]
+
+        r1 = extract_standalone_stage_config(configs, 1)
+        assert "input_connectors" not in r1[0]
+        assert "input_sources" not in r1[0]
+
+    def test_disables_async_chunk_and_strips_next_stage_transforms(self):
+        """Async chunk and next-stage transforms require an orchestrator."""
+        configs = _make_stage_configs()
+        result = extract_standalone_stage_config(configs, 0)
+        ea = result[0].engine_args
+
+        assert ea.async_chunk is False
+        assert "custom_process_next_stage_input_func" not in ea
+        assert "async_chunk_process_next_stage_input_func" not in ea
+
+    def test_preserves_own_input_processor(self):
+        """The stage's own custom_process_input_func must survive extraction."""
+        configs = _make_stage_configs()
+
+        r0 = extract_standalone_stage_config(configs, 0)
+        assert r0[0].engine_args.custom_process_input_func == "some.module.entry_input"
+
+        r1 = extract_standalone_stage_config(configs, 1)
+        assert r1[0].engine_args.custom_process_input_func == "some.module.downstream_input"
+
+    def test_infers_final_output_type_from_engine_output_type(self):
+        """Stage 0 has no final_output_type — should infer from engine_output_type."""
+        configs = _make_stage_configs()
+        result = extract_standalone_stage_config(configs, 0)
+
+        assert result[0].final_output_type == "latent"
+
+    def test_preserves_existing_final_output_type(self):
+        """Stage 1 already has final_output_type=audio — don't overwrite."""
+        configs = _make_stage_configs()
+        result = extract_standalone_stage_config(configs, 1)
+
+        assert result[0].final_output_type == "audio"
+
+    def test_invalid_stage_id_raises_with_available_list(self):
+        configs = _make_stage_configs()
+        with pytest.raises(ValueError, match=r"stage_id 99 not found.*available: \[0, 1\]"):
+            extract_standalone_stage_config(configs, 99)
+
+    def test_returns_omegaconf_config(self):
+        """Result should be usable by the engine (OmegaConf attribute access)."""
+        configs = _make_stage_configs()
+        result = extract_standalone_stage_config(configs, 0)
+
+        assert len(result) == 1
+        cfg = result[0]
+        assert cfg.engine_args.model_stage == "talker"
+        assert cfg.max_num_seqs == 64
+
+
+class TestStandaloneCLIValidation:
+    @pytest.fixture()
+    def parser(self):
+        parser = TrackingArgumentParser()
+        subparsers = parser.add_subparsers(dest="subcommand")
+        cmd = OmniServeCommand()
+        cmd.subparser_init(subparsers)
+        return parser
+
+    def test_standalone_requires_stage_id(self, parser):
+        args = parser.parse_args(["serve", "fake-model", "--omni", "--standalone"])
+        cmd = OmniServeCommand()
+        with pytest.raises(ValueError, match="--standalone requires --stage-id"):
+            cmd.validate(args)
+
+    def test_standalone_headless_mutually_exclusive(self, parser):
+        args = parser.parse_args(
+            [
+                "serve",
+                "fake-model",
+                "--omni",
+                "--standalone",
+                "--headless",
+                "--stage-id",
+                "0",
+                "--omni-master-address",
+                "127.0.0.1",
+                "--omni-master-port",
+                "9999",
+            ]
+        )
+        cmd = OmniServeCommand()
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            cmd.validate(args)
+
+    def test_standalone_with_stage_id_validates(self, parser):
+        args = parser.parse_args(["serve", "fake-model", "--omni", "--standalone", "--stage-id", "0"])
+        cmd = OmniServeCommand()
+        cmd.validate(args)
+
+    def test_stage_id_without_standalone_requires_master(self, parser):
+        args = parser.parse_args(["serve", "fake-model", "--omni", "--stage-id", "0"])
+        cmd = OmniServeCommand()
+        with pytest.raises(ValueError, match="--omni-master-address"):
+            cmd.validate(args)

--- a/tests/entrypoints/test_standalone_stage.py
+++ b/tests/entrypoints/test_standalone_stage.py
@@ -120,6 +120,208 @@ class TestExtractStandaloneStageConfig:
         assert cfg.max_num_seqs == 64
 
 
+class TestClearConnectorsParam:
+    def test_clear_connectors_false_preserves_stage_id_and_connectors(self):
+        """With clear_connectors=False, original stage_id and connectors survive.
+
+        This is required for connector key matching: keys include stage IDs,
+        so renumbering breaks producer-consumer key agreement.
+        """
+        configs = _make_stage_configs()
+
+        r0 = extract_standalone_stage_config(configs, 0, clear_connectors=False)
+        assert r0[0].stage_id == 0
+        assert "output_connectors" in r0[0]
+
+        r1 = extract_standalone_stage_config(configs, 1, clear_connectors=False)
+        assert r1[0].stage_id == 1
+        assert "input_connectors" in r1[0]
+
+    def test_clear_connectors_false_preserves_producer_hook(self):
+        """Producer hook controls embedding accumulation for send_full_payload_outputs.
+
+        Without it, the model runner skips embedding accumulation and the
+        downstream stage never receives data.
+        """
+        configs = _make_stage_configs()
+        result = extract_standalone_stage_config(configs, 0, clear_connectors=False)
+        ea = result[0].engine_args
+
+        assert ea.custom_process_next_stage_input_func == "some.module.talker2code2wav"
+        assert ea.async_chunk_process_next_stage_input_func == "some.module.talker2code2wav_async"
+
+    def test_clear_connectors_false_still_disables_async_chunk(self):
+        """async_chunk requires orchestrator coordination regardless of connector mode."""
+        configs = _make_stage_configs()
+        result = extract_standalone_stage_config(configs, 0, clear_connectors=False)
+
+        assert result[0].engine_args.async_chunk is False
+        assert result[0].final_output is True
+
+
+class TestCodecTokenParsing:
+    """Test _parse_codec_tokens which is the critical data path for downstream stages."""
+
+    def test_2d_codec_transposed_to_codebook_major(self):
+        """2D [num_frames, Q] must be transposed to codebook-major [Q*num_frames].
+
+        This ordering matches how the code2wav model expects flattened codec input.
+        Wrong ordering produces garbage audio.
+        """
+        from vllm_omni.entrypoints.openai.serving_stage import _parse_codec_tokens
+
+        result = _parse_codec_tokens({"codes": {"audio": [[1, 2], [3, 4], [5, 6]]}}, "test")
+        assert result == [1, 3, 5, 2, 4, 6]
+
+    def test_rejects_oversized_codec_data(self):
+        """Prevent unbounded allocation from malicious/corrupt input."""
+        from fastapi.responses import JSONResponse
+
+        from vllm_omni.entrypoints.openai.serving_stage import _parse_codec_tokens
+
+        huge = list(range(3 * 1024 * 1024))
+        result = _parse_codec_tokens({"codes": {"audio": huge}}, "test")
+        assert isinstance(result, JSONResponse)
+
+    def test_rejects_missing_codec_data(self):
+        from fastapi.responses import JSONResponse
+
+        from vllm_omni.entrypoints.openai.serving_stage import _parse_codec_tokens
+
+        result = _parse_codec_tokens({"no_codes": {}}, "test")
+        assert isinstance(result, JSONResponse)
+
+
+class TestConnectorPlumbing:
+    """Test kv_transfer_params flow through the connector plumbing.
+
+    Follows llm-d's pattern: mock internal components, verify data flows
+    correctly without real GPUs or RDMA. Each test covers a real failure
+    mode that would break omni disagg if the plumbing is wrong.
+    """
+
+    @pytest.fixture()
+    def _mixin(self):
+        """Create a minimal OmniConnectorModelRunnerMixin with recv state."""
+        from unittest.mock import MagicMock
+
+        from vllm_omni.worker.omni_connector_model_runner_mixin import OmniConnectorModelRunnerMixin
+
+        m = object.__new__(OmniConnectorModelRunnerMixin)
+        m._stage_id = 1
+        m._request_ids_mapping = {}
+        m._per_request_sender = {}
+        m._stage_recv_req_ids = set()
+        m._chunk_stream_completed = set()
+        m._pending_load_reqs = {}
+        m._work_available = MagicMock()
+        m._lock = __import__("threading").Lock()
+        m._get_req_chunk = {}
+        m._finished_load_reqs = set()
+        m._chunk_ready_req_ids = set()
+        m._chunk_finished_req_ids = set()
+        m._full_payload_pending_broadcast_req_ids = set()
+        m._async_chunk_updated_req_ids = set()
+        m._local_stage_payload_cache = {}
+        m._local_request_metadata = {}
+        return m
+
+    def test_per_request_sender_survives_to_poll(self, _mixin):
+        """kv_transfer_params from register_chunk_recv must be readable by _poll_single_request.
+
+        If the stash is lost between registration and polling, the recv thread
+        falls back to the default sender (update_sender_info) which may point
+        to a different thinker pod — wrong data for this request.
+        """
+        from types import SimpleNamespace
+
+        request = SimpleNamespace(
+            request_id="req-42",
+            external_req_id="ext-42",
+            kv_transfer_params={"source_host": "10.0.0.1", "source_port": 50051},
+        )
+        _mixin.register_chunk_recv(request)
+
+        sender_meta = _mixin._per_request_sender.get("req-42")
+        assert sender_meta is not None
+        assert sender_meta["source_host"] == "10.0.0.1"
+        assert sender_meta["source_port"] == 50051
+
+    def test_orchestrator_managed_requests_use_default_sender(self, _mixin):
+        """Requests without kv_transfer_params must not populate per-request sender.
+
+        This preserves backward compatibility: orchestrator-managed deployments
+        use update_sender_info (Path 3), not per-request metadata (Path 2).
+        """
+        from types import SimpleNamespace
+
+        request = SimpleNamespace(request_id="req-99", external_req_id=None)
+        _mixin.register_chunk_recv(request)
+
+        assert _mixin._per_request_sender.get("req-99") is None
+
+    def test_cleanup_prevents_sender_leak(self, _mixin):
+        """Per-request sender must be cleaned up when the request finishes.
+
+        Without cleanup, long-running talker processes accumulate stale entries
+        for every completed request — unbounded memory growth.
+        """
+        _mixin._per_request_sender["req-1"] = {"source_host": "10.0.0.1"}
+        _mixin._get_req_chunk["req-1"] = 0
+
+        _mixin._clear_recv_delivery_state("req-1")
+
+        assert "req-1" not in _mixin._per_request_sender
+
+    def test_recv_methods_accept_metadata_kwarg(self):
+        """All recv methods must accept metadata=None without breaking.
+
+        This is the backward compatibility contract: existing orchestrator
+        paths pass no metadata, and the connector falls back to Path 3
+        (default sender). If the signature is wrong, every deployment breaks.
+        """
+        from unittest.mock import MagicMock
+
+        from vllm_omni.worker.omni_connector_model_runner_mixin import OmniConnectorModelRunnerMixin
+
+        m = object.__new__(OmniConnectorModelRunnerMixin)
+        mock_connector = MagicMock()
+        mock_connector.get.return_value = ({"data": "test"}, 100)
+
+        m._get_local_tp_group = lambda: None
+
+        m._recv_ordinary_stage_result(mock_connector, "0", "1", "key-1", metadata=None)
+        mock_connector.get.assert_called_with("0", "1", "key-1", metadata=None)
+
+        m._recv_ordinary_stage_result(
+            mock_connector,
+            "0",
+            "1",
+            "key-2",
+            metadata={"source_host": "10.0.0.1", "source_port": 50051},
+        )
+        mock_connector.get.assert_called_with(
+            "0",
+            "1",
+            "key-2",
+            metadata={"source_host": "10.0.0.1", "source_port": 50051},
+        )
+
+    def test_extra_args_kv_transfer_params_on_sampling_params(self):
+        """kv_transfer_params set via SamplingParams.extra_args must survive.
+
+        This is how the downstream handler passes connector info to the engine.
+        If extra_args is dropped or ignored, the talker never learns where to
+        pull embeddings from.
+        """
+        from vllm import SamplingParams
+
+        sp = SamplingParams(max_tokens=100, detokenize=False)
+        sp.extra_args = {"kv_transfer_params": {"source_host": "10.0.0.1"}}
+
+        assert sp.extra_args["kv_transfer_params"]["source_host"] == "10.0.0.1"
+
+
 class TestStandaloneCLIValidation:
     @pytest.fixture()
     def parser(self):

--- a/vllm_omni/core/sched/omni_generation_scheduler.py
+++ b/vllm_omni/core/sched/omni_generation_scheduler.py
@@ -362,6 +362,8 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
         num_nans_in_logits = model_runner_output.num_nans_in_logits
         kv_connector_output = model_runner_output.kv_connector_output
         ec_connector_output = getattr(model_runner_output, "ec_connector_output", None)
+        omni_conn_out = getattr(model_runner_output, "omni_connector_output", None)
+        _omni_connector_info = getattr(omni_conn_out, "connector_info", None) if omni_conn_out else None
 
         cudagraph_stats: CUDAGraphStat | None = model_runner_output.cudagraph_stats
 
@@ -532,6 +534,8 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                         self.chunk_transfer_adapter.segment_finished_requests.discard(req_id)
                 if finished:
                     kv_transfer_params, ec_transfer_params = self._free_request(request)
+                    if kv_transfer_params is None and _omni_connector_info is not None:
+                        kv_transfer_params = _omni_connector_info
                     if self.chunk_transfer_adapter is not None:
                         self.chunk_transfer_adapter.cleanup(
                             request.request_id,
@@ -597,6 +601,8 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
             ec_transfer_params = None
             if finished:
                 kv_transfer_params, ec_transfer_params = self._free_request(request)
+                if kv_transfer_params is None and _omni_connector_info is not None:
+                    kv_transfer_params = _omni_connector_info
                 if self.chunk_transfer_adapter is not None:
                     self.chunk_transfer_adapter.cleanup(
                         request.request_id,

--- a/vllm_omni/core/sched/omni_scheduling_coordinator.py
+++ b/vllm_omni/core/sched/omni_scheduling_coordinator.py
@@ -121,6 +121,7 @@ class OmniSchedulingCoordinator:
                     OmniChunkRecvHandle(
                         request_id=request.request_id,
                         external_req_id=getattr(request, "external_req_id", None),
+                        kv_transfer_params=getattr(request, "kv_transfer_params", None),
                     )
                 )
             elif request.status == RequestStatus.WAITING_FOR_INPUT:

--- a/vllm_omni/core/sched/output.py
+++ b/vllm_omni/core/sched/output.py
@@ -105,6 +105,7 @@ class OmniChunkRecvHandle:
 
     request_id: str
     external_req_id: str | None = None
+    kv_transfer_params: dict | None = None
 
 
 @dataclass

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1266,8 +1266,7 @@ class AsyncOmniEngine:
         standalone_configs = kwargs.pop("_standalone_stage_configs", None)
         if standalone_configs is not None:
             config_path = kwargs.pop("deploy_config", None) or model
-            for key in ("strategy_config", "stage_overrides",
-                        "stage_configs_path", "stage_configs"):
+            for key in ("strategy_config", "stage_overrides", "stage_configs_path", "stage_configs"):
                 kwargs.pop(key, None)
             return config_path, standalone_configs
 

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -156,6 +156,7 @@ class AsyncOmniEngine:
         # --log-stats CLI flag set by the user via OmniBase.
         self._log_stats = log_stats
         self._enable_orch_monitor = bool(kwargs.pop("enable_orch_monitor", False))
+        self._standalone = bool(kwargs.pop("_standalone", False))
 
         logger.info(f"[AsyncOmniEngine] Initializing with model {model}")
 
@@ -372,6 +373,8 @@ class AsyncOmniEngine:
             supported_tasks.add("generate")
         if any(meta.final_output_type == "audio" for meta in self.stage_metadata):
             supported_tasks.add("speech")
+        if self._standalone:
+            supported_tasks.add("generate")
         self.supported_tasks = tuple(supported_tasks) if supported_tasks else ("generate",)
 
     def _bootstrap_orchestrator(
@@ -1259,6 +1262,14 @@ class AsyncOmniEngine:
         trust_remote_code: bool | None,
     ) -> tuple[str, list[Any]]:
         """Resolve stage configs and inject defaults shared by orchestrator/headless."""
+
+        standalone_configs = kwargs.pop("_standalone_stage_configs", None)
+        if standalone_configs is not None:
+            config_path = kwargs.pop("deploy_config", None) or model
+            for key in ("strategy_config", "stage_overrides",
+                        "stage_configs_path", "stage_configs"):
+                kwargs.pop(key, None)
+            return config_path, standalone_configs
 
         for legacy_arg in ("stage_configs_path", "stage_configs"):
             if legacy_arg in kwargs:

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -129,7 +129,11 @@ class OmniServeCommand(CLISubcommand):
             raise ValueError("--standalone requires --stage-id")
         if standalone and args.headless:
             raise ValueError("--standalone and --headless are mutually exclusive")
-        if args.stage_id is not None and not standalone and (args.omni_master_address is None or args.omni_master_port is None):
+        if (
+            args.stage_id is not None
+            and not standalone
+            and (args.omni_master_address is None or args.omni_master_port is None)
+        ):
             raise ValueError("--stage-id requires --omni-master-address and --omni-master-port (or use --standalone)")
 
         # --omni-replica-address is only consulted in run_headless(); reject it
@@ -969,10 +973,10 @@ async def run_standalone(args: TrackingNamespace) -> None:
     args._standalone_stage_configs = standalone_configs
     args._standalone = True
     if hasattr(args, "explicit_keys"):
-        args.explicit_keys = (
-            (args.explicit_keys | {"_standalone_stage_configs", "_standalone", "async_chunk"})
-            - {"stage_id", "standalone"}
-        )
+        args.explicit_keys = (args.explicit_keys | {"_standalone_stage_configs", "_standalone", "async_chunk"}) - {
+            "stage_id",
+            "standalone",
+        }
 
     await omni_run_server(args)
 

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -116,14 +116,21 @@ class OmniServeCommand(CLISubcommand):
             if explicit_keys is not None:
                 args.explicit_keys = explicit_keys | {"model_config"}
 
-        if args.headless:
+        if getattr(args, "standalone", False):
+            uvloop.run(run_standalone(args))
+        elif args.headless:
             run_headless(args)
         else:
             uvloop.run(omni_run_server(args))
 
     def validate(self, args: argparse.Namespace) -> None:
-        if args.stage_id is not None and (args.omni_master_address is None or args.omni_master_port is None):
-            raise ValueError("--stage-id requires both --omni-master-address and --omni-master-port to be set")
+        standalone = getattr(args, "standalone", False)
+        if standalone and args.stage_id is None:
+            raise ValueError("--standalone requires --stage-id")
+        if standalone and args.headless:
+            raise ValueError("--standalone and --headless are mutually exclusive")
+        if args.stage_id is not None and not standalone and (args.omni_master_address is None or args.omni_master_port is None):
+            raise ValueError("--stage-id requires --omni-master-address and --omni-master-port (or use --standalone)")
 
         # --omni-replica-address is only consulted in run_headless(); reject it
         # on the head so a misconfigured launch fails loudly instead of being
@@ -302,6 +309,13 @@ class OmniServeCommand(CLISubcommand):
             type=int,
             default=None,
             help="Select and launch a single stage by stage_id.",
+        )
+        omni_config_group.add_argument(
+            "--standalone",
+            action="store_true",
+            default=False,
+            help="Run a single stage as a standalone HTTP server. "
+            "Requires --stage-id. Mutually exclusive with --headless.",
         )
         omni_config_group.add_argument(
             "--replica-id",
@@ -920,6 +934,47 @@ class OmniServeCommand(CLISubcommand):
         type(self)._parser = serve_parser
 
         return serve_parser
+
+
+async def run_standalone(args: TrackingNamespace) -> None:
+    """Run a single stage as a standalone HTTP server."""
+    from vllm_omni.entrypoints.utils import (
+        extract_standalone_stage_config,
+        load_and_resolve_stage_configs,
+    )
+
+    model = args.model
+    stage_id: int = args.stage_id
+
+    if not model:
+        raise ValueError("--model is required")
+
+    args_dict = args.get_explicit_kwargs_dict()
+
+    config_path, stage_configs, _ = load_and_resolve_stage_configs(
+        model,
+        dict(args_dict),
+        trust_remote_code=getattr(args, "trust_remote_code", None),
+        deploy_config_path=args_dict.get("deploy_config"),
+        stage_overrides=None,
+    )
+
+    standalone_configs = extract_standalone_stage_config(stage_configs, stage_id)
+
+    stage_cfg = standalone_configs[0]
+    model_stage = stage_cfg.get("engine_args", {}).get("model_stage", f"stage-{stage_id}")
+    logger.info("[Standalone] Booting stage %d (%s) as independent server", stage_id, model_stage)
+
+    args.async_chunk = False
+    args._standalone_stage_configs = standalone_configs
+    args._standalone = True
+    if hasattr(args, "explicit_keys"):
+        args.explicit_keys = (
+            (args.explicit_keys | {"_standalone_stage_configs", "_standalone", "async_chunk"})
+            - {"stage_id", "standalone"}
+        )
+
+    await omni_run_server(args)
 
 
 def run_headless(args: TrackingNamespace) -> None:

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -3843,6 +3843,254 @@ async def omni_wakeup(request: OmniWakeupRequest, raw_request: Request):
     return {"status": "SUCCESS", "acks": [dataclasses.asdict(a) if dataclasses.is_dataclass(a) else a for a in acks]}
 
 
+@router.post("/v1/stage/run")
+@with_cancellation
+async def stage_run(raw_request: Request):
+    """Run a standalone stage. Two modes based on request body:
+    - Entry mode (no stage_output): accepts client request, returns stage_output
+    - Downstream mode (has stage_output): accepts upstream output, returns result
+    """
+    import uuid as _uuid
+
+    engine_client = raw_request.app.state.engine_client
+    engine = getattr(engine_client, "engine", engine_client)
+    if not getattr(engine, "_standalone", False):
+        return JSONResponse(
+            {"error": "This endpoint is only available in standalone mode"},
+            status_code=HTTPStatus.NOT_FOUND.value,
+        )
+
+    body = await raw_request.json()
+    request_id = body.get("request_id", f"stage-{_uuid.uuid4().hex[:8]}")
+
+    if "stage_output" in body and body["stage_output"] is not None:
+        return await _stage_run_downstream(raw_request, body, request_id)
+    return await _stage_run_entry(raw_request, body, request_id)
+
+
+async def _stage_run_entry(raw_request: Request, body: dict, request_id: str):
+    """Entry stage: accept client request, run generation, return raw stage_output.
+
+    Dispatches to the appropriate handler based on what the standalone stage
+    supports, then returns the raw multimodal_output as serialized JSON
+    instead of converting to a final format (WAV, image, etc.).
+    """
+    import torch
+
+    engine_client = raw_request.app.state.engine_client
+
+    handler = Omnispeech(raw_request)
+    if handler is None:
+        return JSONResponse(
+            {"error": "No handler available for this stage type"},
+            status_code=HTTPStatus.NOT_FOUND.value,
+        )
+
+    try:
+        from vllm_omni.entrypoints.openai.protocol.audio import (
+            OpenAICreateSpeechRequest,
+        )
+
+        speech_fields = {"model", "input", "voice", "speed", "response_format",
+                         "ref_audio", "ref_text", "audio_reference", "language"}
+        extra = {k: v for k, v in body.items()
+                 if k in speech_fields and k not in ("model", "input", "voice")}
+        speech_request = OpenAICreateSpeechRequest(
+            model=body.get("model", ""),
+            input=body.get("input", ""),
+            voice=body.get("voice", ""),
+            **extra,
+        )
+
+        # Uses the internal _prepare_speech_generation (stable, 4+ internal
+        # callers) to get the raw engine generator without WAV conversion.
+        _, generator, _ = await handler._prepare_speech_generation(
+            speech_request, request_id=request_id,
+        )
+
+        final_output = None
+        try:
+            async for output in generator:
+                final_output = output
+        except asyncio.CancelledError:
+            await engine_client.abort(request_id)
+            raise
+
+        if final_output is None:
+            return JSONResponse(
+                {"error": "No output generated", "request_id": request_id},
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+            )
+
+        mm_output = None
+        for co in getattr(final_output, "outputs", []):
+            mm = getattr(co, "multimodal_output", None)
+            if mm:
+                mm_output = mm
+                break
+
+        def _serialize(obj):
+            if isinstance(obj, torch.Tensor):
+                return obj.cpu().tolist()
+            if isinstance(obj, dict):
+                return {k: _serialize(v) for k, v in obj.items()}
+            if hasattr(obj, "items") and callable(obj.items):
+                return {k: _serialize(v) for k, v in obj.items()}
+            if isinstance(obj, list):
+                return [_serialize(x) for x in obj]
+            if isinstance(obj, (int, float, str, bool, type(None))):
+                return obj
+            return str(obj)
+
+        return JSONResponse({
+            "request_id": request_id,
+            "stage_output": _serialize(mm_output) if mm_output else None,
+            "finished": getattr(final_output, "finished", True),
+        })
+
+    except ValueError as e:
+        return JSONResponse(
+            {"error": str(e), "request_id": request_id},
+            status_code=HTTPStatus.BAD_REQUEST.value,
+        )
+    except Exception as e:
+        return JSONResponse(
+            {"error": str(e), "request_id": request_id},
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+        )
+
+
+async def _stage_run_downstream(raw_request: Request, body: dict, request_id: str):
+    """Downstream stage: accept upstream stage_output, run engine, return result."""
+    import io
+    import wave
+
+    import numpy as np
+    import torch
+
+    engine_client = raw_request.app.state.engine_client
+    stage_output = body["stage_output"]
+
+    try:
+        codes = stage_output.get("codes", {})
+        codec_data = codes.get("audio") if isinstance(codes, dict) else None
+        if codec_data is None:
+            codec_data = stage_output.get("codes.audio")
+        if codec_data is None:
+            return JSONResponse(
+                {"error": "No codec data in stage_output", "request_id": request_id},
+                status_code=HTTPStatus.BAD_REQUEST.value,
+            )
+
+        if not codec_data:
+            return JSONResponse(
+                {"error": "Empty codec data in stage_output", "request_id": request_id},
+                status_code=HTTPStatus.BAD_REQUEST.value,
+            )
+
+        MAX_CODEC_ELEMENTS = 2 * 1024 * 1024
+        flat_len = sum(len(row) for row in codec_data) if isinstance(codec_data[0], list) else len(codec_data)
+        if flat_len > MAX_CODEC_ELEMENTS:
+            return JSONResponse(
+                {"error": f"Codec data too large ({flat_len} elements, max {MAX_CODEC_ELEMENTS})",
+                 "request_id": request_id},
+                status_code=HTTPStatus.BAD_REQUEST.value,
+            )
+
+        codec_tensor = torch.tensor(codec_data, dtype=torch.long)
+        if codec_tensor.ndim == 2:
+            prompt_token_ids = codec_tensor.transpose(0, 1).reshape(-1).tolist()
+        else:
+            prompt_token_ids = codec_tensor.tolist()
+
+        from vllm import SamplingParams
+
+        generator = engine_client.generate(
+            prompt={"prompt_token_ids": prompt_token_ids},
+            request_id=request_id,
+            output_modalities=["audio"],
+            sampling_params=SamplingParams(
+                max_tokens=65536,
+                detokenize=False,
+            ),
+        )
+
+        final_output = None
+        try:
+            async for output in generator:
+                final_output = output
+        except asyncio.CancelledError:
+            await engine_client.abort(request_id)
+            raise
+
+        if final_output is None:
+            return JSONResponse(
+                {"error": "No output generated", "request_id": request_id},
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+            )
+
+        audio_data = None
+        sample_rate = 24000
+        for co in getattr(final_output, "outputs", []):
+            mm = getattr(co, "multimodal_output", None)
+            if mm is not None:
+                if isinstance(mm, dict):
+                    audio_data = mm.get("audio")
+                elif hasattr(mm, "get"):
+                    audio_data = mm.get("audio")
+                if audio_data is not None:
+                    sr_raw = mm.get("sr") if hasattr(mm, "get") else None
+                    if sr_raw is not None:
+                        sr_val = sr_raw[-1] if isinstance(sr_raw, list) and sr_raw else sr_raw
+                        sample_rate = sr_val.item() if hasattr(sr_val, "item") else int(sr_val)
+                    break
+
+        if audio_data is None:
+            return JSONResponse({
+                "request_id": request_id,
+                "stage_output": None,
+                "error": "No audio output",
+            }, status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value)
+
+        if isinstance(audio_data, torch.Tensor):
+            audio_np = audio_data.cpu().float().numpy()
+        elif isinstance(audio_data, np.ndarray):
+            audio_np = audio_data.astype(np.float32)
+        else:
+            audio_np = np.array(audio_data, dtype=np.float32)
+
+        if audio_np.size > 0 and np.all(np.isfinite(audio_np)):
+            abs_max = np.abs(audio_np).max()
+            if abs_max <= 1.0:
+                audio_np = audio_np * 32767
+            elif abs_max <= 32768:
+                pass
+            else:
+                audio_np = audio_np * (32767 / abs_max)
+        audio_np = np.clip(audio_np, -32768, 32767)
+        audio_int16 = audio_np.astype(np.int16)
+
+        buf = io.BytesIO()
+        with wave.open(buf, "wb") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(sample_rate)
+            wf.writeframes(audio_int16.tobytes())
+        buf.seek(0)
+
+        return Response(
+            content=buf.read(),
+            media_type="audio/wav",
+            headers={"X-Request-Id": request_id},
+        )
+
+    except Exception as e:
+        return JSONResponse(
+            {"error": str(e), "request_id": request_id},
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+        )
+
+
 if __name__ == "__main__":
     parser = TrackingArgumentParser(description="vLLM-Omni OpenAI-Compatible REST API server")
     parser = make_arg_parser(parser)

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -3863,9 +3863,30 @@ async def stage_run(raw_request: Request):
     body = await raw_request.json()
     request_id = body.get("request_id", f"stage-{_uuid.uuid4().hex[:8]}")
 
-    if "stage_output" in body and body["stage_output"] is not None:
-        return await _stage_run_downstream(raw_request, body, request_id)
-    return await _stage_run_entry(raw_request, body, request_id)
+    try:
+        if "stage_output" in body and body["stage_output"] is not None:
+            from vllm_omni.entrypoints.openai.serving_stage import (
+                run_downstream_audio,
+                run_downstream_intermediate,
+            )
+
+            output_mode = body.get("output_mode", "final")
+            if output_mode == "intermediate":
+                return await run_downstream_intermediate(raw_request, body, request_id)
+            return await run_downstream_audio(raw_request, body, request_id)
+
+        return await _stage_run_entry(raw_request, body, request_id)
+
+    except ValueError as e:
+        return JSONResponse(
+            {"error": str(e), "request_id": request_id},
+            status_code=HTTPStatus.BAD_REQUEST.value,
+        )
+    except Exception as e:
+        return JSONResponse(
+            {"error": str(e), "request_id": request_id},
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+        )
 
 
 async def _stage_run_entry(raw_request: Request, body: dict, request_id: str):

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -3891,10 +3891,18 @@ async def _stage_run_entry(raw_request: Request, body: dict, request_id: str):
             OpenAICreateSpeechRequest,
         )
 
-        speech_fields = {"model", "input", "voice", "speed", "response_format",
-                         "ref_audio", "ref_text", "audio_reference", "language"}
-        extra = {k: v for k, v in body.items()
-                 if k in speech_fields and k not in ("model", "input", "voice")}
+        speech_fields = {
+            "model",
+            "input",
+            "voice",
+            "speed",
+            "response_format",
+            "ref_audio",
+            "ref_text",
+            "audio_reference",
+            "language",
+        }
+        extra = {k: v for k, v in body.items() if k in speech_fields and k not in ("model", "input", "voice")}
         speech_request = OpenAICreateSpeechRequest(
             model=body.get("model", ""),
             input=body.get("input", ""),
@@ -3905,7 +3913,8 @@ async def _stage_run_entry(raw_request: Request, body: dict, request_id: str):
         # Uses the internal _prepare_speech_generation (stable, 4+ internal
         # callers) to get the raw engine generator without WAV conversion.
         _, generator, _ = await handler._prepare_speech_generation(
-            speech_request, request_id=request_id,
+            speech_request,
+            request_id=request_id,
         )
 
         final_output = None
@@ -3942,11 +3951,13 @@ async def _stage_run_entry(raw_request: Request, body: dict, request_id: str):
                 return obj
             return str(obj)
 
-        return JSONResponse({
-            "request_id": request_id,
-            "stage_output": _serialize(mm_output) if mm_output else None,
-            "finished": getattr(final_output, "finished", True),
-        })
+        return JSONResponse(
+            {
+                "request_id": request_id,
+                "stage_output": _serialize(mm_output) if mm_output else None,
+                "finished": getattr(final_output, "finished", True),
+            }
+        )
 
     except ValueError as e:
         return JSONResponse(
@@ -3992,8 +4003,10 @@ async def _stage_run_downstream(raw_request: Request, body: dict, request_id: st
         flat_len = sum(len(row) for row in codec_data) if isinstance(codec_data[0], list) else len(codec_data)
         if flat_len > MAX_CODEC_ELEMENTS:
             return JSONResponse(
-                {"error": f"Codec data too large ({flat_len} elements, max {MAX_CODEC_ELEMENTS})",
-                 "request_id": request_id},
+                {
+                    "error": f"Codec data too large ({flat_len} elements, max {MAX_CODEC_ELEMENTS})",
+                    "request_id": request_id,
+                },
                 status_code=HTTPStatus.BAD_REQUEST.value,
             )
 
@@ -4046,11 +4059,14 @@ async def _stage_run_downstream(raw_request: Request, body: dict, request_id: st
                     break
 
         if audio_data is None:
-            return JSONResponse({
-                "request_id": request_id,
-                "stage_output": None,
-                "error": "No audio output",
-            }, status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value)
+            return JSONResponse(
+                {
+                    "request_id": request_id,
+                    "stage_output": None,
+                    "error": "No audio output",
+                },
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+            )
 
         if isinstance(audio_data, torch.Tensor):
             audio_np = audio_data.cpu().float().numpy()

--- a/vllm_omni/entrypoints/openai/serving_stage.py
+++ b/vllm_omni/entrypoints/openai/serving_stage.py
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Standalone stage serving: downstream handler utilities.
+
+Shared utilities and downstream-only handlers for /v1/stage/run.
+Entry mode logic remains in api_server.py (per-handler dispatch).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import wave
+from http import HTTPStatus
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import torch
+from fastapi.responses import JSONResponse, Response
+from vllm.logger import init_logger
+
+if TYPE_CHECKING:
+    from fastapi import Request
+
+logger = init_logger(__name__)
+
+MAX_CODEC_ELEMENTS = 2 * 1024 * 1024
+
+
+def extract_multimodal_output(final_output: Any) -> Any | None:
+    for co in getattr(final_output, "outputs", []):
+        mm = getattr(co, "multimodal_output", None)
+        if mm:
+            return mm
+    return None
+
+
+def serialize(obj: Any) -> Any:
+    if isinstance(obj, torch.Tensor):
+        return obj.cpu().tolist()
+    if isinstance(obj, dict):
+        return {k: serialize(v) for k, v in obj.items()}
+    if hasattr(obj, "items") and callable(obj.items):
+        return {k: serialize(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [serialize(x) for x in obj]
+    if isinstance(obj, (int, float, str, bool, type(None))):
+        return obj
+    return str(obj)
+
+
+def stage_output_response(mm_output: Any, final_output: Any, request_id: str) -> JSONResponse:
+    return JSONResponse(
+        {
+            "request_id": request_id,
+            "stage_output": serialize(mm_output) if mm_output else None,
+            "finished": getattr(final_output, "finished", True) if final_output else True,
+        }
+    )
+
+
+def extract_sample_rate(mm: Any) -> int:
+    sr_raw = mm.get("sr") if hasattr(mm, "get") else None
+    if sr_raw is None:
+        return 24000
+    sr_val = sr_raw[-1] if isinstance(sr_raw, list) and sr_raw else sr_raw
+    return sr_val.item() if hasattr(sr_val, "item") else int(sr_val)
+
+
+def build_wav_response(audio_data: Any, sample_rate: int, request_id: str) -> Response:
+    if isinstance(audio_data, torch.Tensor):
+        audio_np = audio_data.cpu().float().numpy()
+    elif isinstance(audio_data, np.ndarray):
+        audio_np = audio_data.astype(np.float32)
+    else:
+        audio_np = np.array(audio_data, dtype=np.float32)
+
+    if audio_np.size > 0 and np.all(np.isfinite(audio_np)):
+        abs_max = np.abs(audio_np).max()
+        if abs_max <= 1.0:
+            audio_np = audio_np * 32767
+        elif abs_max > 32768:
+            audio_np = audio_np * (32767 / abs_max)
+    audio_np = np.clip(audio_np, -32768, 32767)
+    audio_int16 = audio_np.astype(np.int16)
+
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(audio_int16.tobytes())
+    buf.seek(0)
+
+    return Response(
+        content=buf.read(),
+        media_type="audio/wav",
+        headers={"X-Request-Id": request_id},
+    )
+
+
+def _parse_codec_tokens(stage_output: dict, request_id: str) -> list[int] | JSONResponse:
+    """Extract and validate codec tokens from stage_output. Returns token list or error response."""
+    codes = stage_output.get("codes", {})
+    codec_data = codes.get("audio") if isinstance(codes, dict) else None
+    if codec_data is None:
+        codec_data = stage_output.get("codes.audio")
+    if not codec_data:
+        return JSONResponse(
+            {"error": "No codec data in stage_output", "request_id": request_id},
+            status_code=HTTPStatus.BAD_REQUEST.value,
+        )
+
+    flat_len = sum(len(row) for row in codec_data) if isinstance(codec_data[0], list) else len(codec_data)
+    if flat_len > MAX_CODEC_ELEMENTS:
+        return JSONResponse(
+            {
+                "error": f"Codec data too large ({flat_len} elements, max {MAX_CODEC_ELEMENTS})",
+                "request_id": request_id,
+            },
+            status_code=HTTPStatus.BAD_REQUEST.value,
+        )
+
+    codec_tensor = torch.tensor(codec_data, dtype=torch.long)
+    if codec_tensor.ndim == 2:
+        return codec_tensor.transpose(0, 1).reshape(-1).tolist()
+    return codec_tensor.tolist()
+
+
+async def _generate_and_collect(
+    engine_client: Any,
+    prompt_token_ids: list[int],
+    request_id: str,
+    output_modalities: list[str] | None = None,
+    kv_transfer_params: dict | None = None,
+) -> Any:
+    """Run engine.generate() and collect final output with cancellation support."""
+    from vllm import SamplingParams
+
+    sp = SamplingParams(max_tokens=65536, detokenize=False)
+    if kv_transfer_params:
+        sp.extra_args = {"kv_transfer_params": kv_transfer_params}
+
+    kwargs: dict[str, Any] = {
+        "prompt": {"prompt_token_ids": prompt_token_ids},
+        "request_id": request_id,
+        "sampling_params": sp,
+    }
+    if output_modalities:
+        kwargs["output_modalities"] = output_modalities
+
+    generator = engine_client.generate(**kwargs)
+    final_output = None
+    try:
+        async for output in generator:
+            final_output = output
+    except asyncio.CancelledError:
+        await engine_client.abort(request_id)
+        raise
+    return final_output
+
+
+async def run_downstream_audio(
+    raw_request: Request,
+    body: dict,
+    request_id: str,
+) -> Response | JSONResponse:
+    """Final audio stage: accept codec tokens, return WAV."""
+    engine_client = raw_request.app.state.engine_client
+    stage_output = body["stage_output"]
+
+    tokens_or_error = _parse_codec_tokens(stage_output, request_id)
+    if isinstance(tokens_or_error, JSONResponse):
+        return tokens_or_error
+
+    kvtp = body.get("kv_transfer_params")
+    final_output = await _generate_and_collect(
+        engine_client,
+        tokens_or_error,
+        request_id,
+        output_modalities=["audio"],
+        kv_transfer_params=kvtp,
+    )
+    if final_output is None:
+        return JSONResponse(
+            {"error": "No output generated", "request_id": request_id},
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+        )
+
+    mm_output = extract_multimodal_output(final_output)
+    if mm_output is None:
+        return JSONResponse(
+            {"error": "No audio output", "request_id": request_id},
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+        )
+
+    audio_data = mm_output.get("audio") if hasattr(mm_output, "get") else None
+    if audio_data is None:
+        return JSONResponse(
+            {"error": "No audio in multimodal output", "request_id": request_id},
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+        )
+
+    return build_wav_response(audio_data, extract_sample_rate(mm_output), request_id)
+
+
+async def run_downstream_intermediate(
+    raw_request: Request,
+    body: dict,
+    request_id: str,
+) -> JSONResponse:
+    """Intermediate stage: accept stage_output, return stage_output for next stage."""
+    engine_client = raw_request.app.state.engine_client
+    stage_output = body["stage_output"]
+
+    tokens_or_error = _parse_codec_tokens(stage_output, request_id)
+    if isinstance(tokens_or_error, JSONResponse):
+        return tokens_or_error
+
+    kvtp = body.get("kv_transfer_params")
+    final_output = await _generate_and_collect(
+        engine_client,
+        tokens_or_error,
+        request_id,
+        kv_transfer_params=kvtp,
+    )
+    if final_output is None:
+        return JSONResponse(
+            {"error": "No output generated", "request_id": request_id},
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+        )
+
+    return stage_output_response(extract_multimodal_output(final_output), final_output, request_id)

--- a/vllm_omni/entrypoints/utils.py
+++ b/vllm_omni/entrypoints/utils.py
@@ -608,12 +608,18 @@ def load_and_resolve_stage_configs(
 def extract_standalone_stage_config(
     stage_configs: list,
     stage_id: int,
+    *,
+    clear_connectors: bool = True,
 ) -> list:
     """Extract a single stage from a multi-stage config list for standalone operation.
 
-    Adjusts the stage for independent execution: renumbers to stage_id 0,
-    marks as final output, clears input_sources, and strips next-stage
-    transform references. Connector and sampling config are preserved.
+    Args:
+        stage_configs: Full pipeline OmegaConf config list.
+        stage_id: Which stage to extract.
+        clear_connectors: If True (default), clear connectors, renumber
+            stage_id to 0, and strip next-stage transforms. If False,
+            preserve connectors and original stage_id for connector-based
+            transfer (omni disagg).
     """
     from omegaconf import OmegaConf
 
@@ -626,7 +632,6 @@ def extract_standalone_stage_config(
         available = [int(c.stage_id) for c in stage_configs]
         raise ValueError(f"stage_id {stage_id} not found (available: {available})")
 
-    target["stage_id"] = 0
     target["final_output"] = True
     if not target.get("final_output_type"):
         engine_args = target.get("engine_args", {})
@@ -635,17 +640,21 @@ def extract_standalone_stage_config(
             target["final_output_type"] = "audio"
         elif eot == "latent":
             target["final_output_type"] = "latent"
-    target.pop("input_sources", None)
-    target.pop("input_connectors", None)
-    target.pop("output_connectors", None)
 
     engine_args = target.get("engine_args", {})
     engine_args["async_chunk"] = False
-    for key in (
-        "custom_process_next_stage_input_func",
-        "async_chunk_process_next_stage_input_func",
-    ):
-        engine_args.pop(key, None)
+
+    if clear_connectors:
+        target["stage_id"] = 0
+        target.pop("input_sources", None)
+        target.pop("input_connectors", None)
+        target.pop("output_connectors", None)
+        for key in (
+            "custom_process_next_stage_input_func",
+            "async_chunk_process_next_stage_input_func",
+        ):
+            engine_args.pop(key, None)
+
     target["engine_args"] = engine_args
 
     return [create_config(target)]

--- a/vllm_omni/entrypoints/utils.py
+++ b/vllm_omni/entrypoints/utils.py
@@ -605,6 +605,52 @@ def load_and_resolve_stage_configs(
     return config_path, stage_configs, omni_lb_policy
 
 
+def extract_standalone_stage_config(
+    stage_configs: list,
+    stage_id: int,
+) -> list:
+    """Extract a single stage from a multi-stage config list for standalone operation.
+
+    Adjusts the stage for independent execution: renumbers to stage_id 0,
+    marks as final output, clears input_sources, and strips next-stage
+    transform references. Connector and sampling config are preserved.
+    """
+    from omegaconf import OmegaConf
+
+    target = None
+    for cfg in stage_configs:
+        if int(cfg.stage_id) == stage_id:
+            target = OmegaConf.to_container(cfg, resolve=True)
+            break
+    if target is None:
+        available = [int(c.stage_id) for c in stage_configs]
+        raise ValueError(f"stage_id {stage_id} not found (available: {available})")
+
+    target["stage_id"] = 0
+    target["final_output"] = True
+    if not target.get("final_output_type"):
+        engine_args = target.get("engine_args", {})
+        eot = engine_args.get("engine_output_type", "")
+        if eot == "audio":
+            target["final_output_type"] = "audio"
+        elif eot == "latent":
+            target["final_output_type"] = "latent"
+    target.pop("input_sources", None)
+    target.pop("input_connectors", None)
+    target.pop("output_connectors", None)
+
+    engine_args = target.get("engine_args", {})
+    engine_args["async_chunk"] = False
+    for key in (
+        "custom_process_next_stage_input_func",
+        "async_chunk_process_next_stage_input_func",
+    ):
+        engine_args.pop(key, None)
+    target["engine_args"] = engine_args
+
+    return [create_config(target)]
+
+
 def get_final_stage_id_for_e2e(
     output_modalities: list[str] | None, default_modalities: list[str], stage_list: list
 ) -> int:

--- a/vllm_omni/outputs/__init__.py
+++ b/vllm_omni/outputs/__init__.py
@@ -34,6 +34,7 @@ class OmniConnectorOutput:
     kv_sent_req_ids: list[str] = field(default_factory=list)
     stage_recv_req_ids: set[str] = field(default_factory=set)
     has_pending_kv_work: bool = False
+    connector_info: dict | None = None
 
 
 @dataclass

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -462,9 +462,9 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
         engine_output_type = (self.vllm_config.model_config.engine_output_type or "").lower()
         if self._client_multimodal_output_keys():
             downstream_req_ids = req_ids_output_copy
-        # Single-stage AR TTS models (e.g. VoxCPM2) finish on this stage but still
-        # need multimodal payloads for final audio postprocess/output.
-        elif engine_output_type == "audio" and not downstream_req_ids:
+        # Single-stage or standalone AR stages need multimodal payloads for
+        # postprocess even when no downstream stage exists in this process.
+        elif engine_output_type in ("audio", "latent") and not downstream_req_ids:
             downstream_req_ids = req_ids_output_copy
         return engine_output_type, downstream_req_ids
 

--- a/vllm_omni/worker/omni_connector_model_runner_mixin.py
+++ b/vllm_omni/worker/omni_connector_model_runner_mixin.py
@@ -147,6 +147,10 @@ class OmniConnectorModelRunnerMixin:
         # -- next stage ID (from connector config or default stage_id + 1) --
         self._next_stage_id: int = self._resolve_next_stage_id(model_config)
 
+        self._connector_info: dict | None = None
+        if self._omni_connector is not None and hasattr(self._omni_connector, "get_connection_info"):
+            self._connector_info = self._omni_connector.get_connection_info()
+
         # -- heterogeneous TP rank support --
         rank_cfg = self._parse_rank_mapping(model_config)
         if self._kv_transfer_manager is not None:
@@ -186,6 +190,7 @@ class OmniConnectorModelRunnerMixin:
         self._code_prompt_token_ids: dict[str, list[list[int]]] = defaultdict(list)
         self._cached_ic: dict[str, int] = {}
         self._request_ids_mapping: dict[str, str] = {}
+        self._per_request_sender: dict[str, dict] = {}
 
         # -- async I/O state (shared by chunk + full_payload_mode) --
         self._pending_load_reqs: dict[str, Any] = {}
@@ -374,6 +379,7 @@ class OmniConnectorModelRunnerMixin:
         self._async_chunk_updated_req_ids.discard(req_id)
         self._local_stage_payload_cache.pop(req_id, None)
         self._local_request_metadata.pop(req_id, None)
+        self._per_request_sender.pop(req_id, None)
 
     def prune_inactive_requests(self, active_req_ids: Any) -> set[str]:
         """Drop connector state for requests that no longer exist locally.
@@ -440,6 +446,7 @@ class OmniConnectorModelRunnerMixin:
             "_kv_active_transfers",
             "_kv_completed_transfers",
             "_kv_triggered_requests",
+            "_per_request_sender",
         ):
             state = getattr(self, attr_name, None)
             if isinstance(state, dict):
@@ -605,14 +612,15 @@ class OmniConnectorModelRunnerMixin:
         from_stage: str,
         to_stage: str,
         connector_get_key: str,
+        metadata: dict | None = None,
     ) -> Any:
         """Receive one ordinary non-KV stage payload on the local leader rank only."""
         tp_group = self._get_local_tp_group()
         if tp_group is None or getattr(tp_group, "world_size", 1) <= 1:
-            return connector.get(from_stage, to_stage, connector_get_key)
+            return connector.get(from_stage, to_stage, connector_get_key, metadata=metadata)
         if not self.is_data_transfer_rank():
             return None
-        return connector.get(from_stage, to_stage, connector_get_key)
+        return connector.get(from_stage, to_stage, connector_get_key, metadata=metadata)
 
     def _recv_full_payload_result(
         self,
@@ -620,6 +628,7 @@ class OmniConnectorModelRunnerMixin:
         from_stage: str,
         to_stage: str,
         connector_get_key: str,
+        metadata: dict | None = None,
     ) -> Any:
         """Receive one full-payload transfer on the local leader rank only."""
         return self._recv_ordinary_stage_result(
@@ -627,6 +636,7 @@ class OmniConnectorModelRunnerMixin:
             from_stage,
             to_stage,
             connector_get_key,
+            metadata=metadata,
         )
 
     def _recv_async_chunk_result(
@@ -635,6 +645,7 @@ class OmniConnectorModelRunnerMixin:
         from_stage: str,
         to_stage: str,
         connector_get_key: str,
+        metadata: dict | None = None,
     ) -> Any:
         """Receive one ordinary async chunk on the local leader rank only."""
         return self._recv_ordinary_stage_result(
@@ -642,6 +653,7 @@ class OmniConnectorModelRunnerMixin:
             from_stage,
             to_stage,
             connector_get_key,
+            metadata=metadata,
         )
 
     @staticmethod
@@ -1092,6 +1104,9 @@ class OmniConnectorModelRunnerMixin:
         # across requests.
         ext = getattr(request, "external_req_id", None)
         self._request_ids_mapping[request_id] = ext if ext is not None else request_id
+        kvtp = getattr(request, "kv_transfer_params", None)
+        if kvtp:
+            self._per_request_sender[request_id] = kvtp
         with self._lock:
             if request_id in self._stage_recv_req_ids:
                 return
@@ -1595,6 +1610,7 @@ class OmniConnectorModelRunnerMixin:
             kv_sent_req_ids=list(self._kv_sent_req_ids),
             stage_recv_req_ids=set(self._stage_recv_req_ids),
             has_pending_kv_work=self.has_pending_kv_work(),
+            connector_info=self._connector_info,
         )
         if output.stage_recv_req_ids or chunk_finished or newly_finished:
             logger.debug(
@@ -1787,12 +1803,15 @@ class OmniConnectorModelRunnerMixin:
         external_req_id = self._request_ids_mapping.get(req_id, req_id)
         connector_get_key = f"{external_req_id}_{target_stage_id}_{chunk_id}"
 
+        sender_meta = self._per_request_sender.get(req_id)
+
         if self._async_chunk:
             result = self._recv_async_chunk_result(
                 connector,
                 str(target_stage_id),
                 str(self._stage_id),
                 connector_get_key,
+                metadata=sender_meta,
             )
         else:
             result = self._recv_full_payload_result(
@@ -1800,6 +1819,7 @@ class OmniConnectorModelRunnerMixin:
                 str(target_stage_id),
                 str(self._stage_id),
                 connector_get_key,
+                metadata=sender_meta,
             )
 
         if result is None:


### PR DESCRIPTION
## Purpose

Extends standalone stage mode (#6883) to support omni multi-stage disaggregation across separate pods.

Ref #6389

### Problem

PR 1 (#6883) enables TTS disagg with inline JSON transfer. Omni disagg (thinker → talker) transfers hidden state embeddings (float tensors, 1-15MB) which is impractical inline. The data needs to go through connectors (Mooncake/Mori RDMA) with the coordinator passing only a small transfer handle — the same pattern vLLM P/D uses for KV cache via `kv_transfer_params`.

### Solution

Reuse `kv_transfer_params` end-to-end. No new fields or protocols.

**The flow:**

1. Thinker's model runner caches its connector endpoint info (`host`, `zmq_port`) at init.
2. Scheduler populates `kv_transfer_params` on finished requests using this connector info (fallback when the KV connector returns None).
3. Chat/speech handler includes `kv_transfer_params` in the response — already wired, no handler changes.
4. Coordinator reads the handle, forwards it in the downstream request body as opaque bytes.
5. Downstream engine extracts it from `SamplingParams.extra_args` (same as P/D).
6. `register_chunk_recv` stashes per-request sender info. The recv thread passes it as `metadata` to `connector.get()` Path 2, enabling multi-thinker routing.

### Other changes

**Downstream handlers (`serving_stage.py`):** Two modes — `run_downstream_audio` (final stage → WAV) and `run_downstream_intermediate` (middle stage → stage_output JSON). Coordinator signals via `output_mode`.

**`clear_connectors` param:** `extract_standalone_stage_config(clear_connectors=False)` preserves original stage_id (connector keys depend on it), connectors, and `custom_process_next_stage_input_func` (controls embedding accumulation). Default `True` preserves PR 1 TTS behavior.

### Backward compatibility

All `None` defaults — orchestrator-managed deployments see no behavior change. `SharedMemoryConnector` (no `get_connection_info`) returns `None`, correctly preventing cross-pod handles for same-node-only connectors.

### Limitations

- Connector E2E not tested (needs Mooncake/Mori infra + Qwen3-Omni)
- Standalone omni requires a cross-network connector deploy YAML (not SharedMemory)

## Test Plan

- [x] `clear_connectors=False` preserves stage_id, connectors, producer hook
- [x] `clear_connectors=True` clears (backward compat)
- [x] Codec token transposition (codebook-major order)
- [x] Per-request sender stashed and cleaned up correctly
- [x] Recv methods forward `metadata` kwarg to `connector.get()`
- [x] Orchestrator-managed requests use default sender (no override)
- [x] TTS E2E not regressed
- [ ] Omni E2E with connectors (needs infra)

## Test Result

23/23 unit tests passed. TTS E2E verified on 2x NVIDIA H200.
## Follow-on work

Async-chunk streaming for standalone stages, so the upstream stage streams frames directly to the downstream stage and recovers the ~92% TTFP reduction that standalone mode loses today.

Image gen disagg for BAGEL and HunyuanImage3, which needs CFG companion fan-out/fan-in.

This PR reuses `kv_transfer_params` for omni embedding transfer handles since the field is already wired end-to-end. If the community prefers a dedicated `stage_transfer_params` field, the change is mechanical.