### PR TITLE
[Model] MiniMax-H3: Support Comfy INT8 ConvRot checkpoints

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -59,6 +59,7 @@ nav:
       - Quantized KV Cache: user_guide/quantization/quantized_kvcache.md
       - FP8 W8A8: user_guide/quantization/fp8.md
       - Int8 W8A8: user_guide/quantization/int8.md
+      - INT8 ConvRot: user_guide/quantization/int8_convrot.md
       - BitsAndBytes W4: user_guide/quantization/bitsandbytes.md
       - MXFP8 W8A8: user_guide/quantization/mxfp8.md
       - MXFP4 W4A4: user_guide/quantization/mxfp4.md

--- a/docs/user_guide/quantization/int8_convrot.md
+++ b/docs/user_guide/quantization/int8_convrot.md
@@ -1,0 +1,117 @@
+# INT8 ConvRot Quantization
+
+## Overview
+
+INT8 ConvRot loads ComfyUI tensor-wise W8A8 checkpoints whose linear weights
+were rotated and quantized offline. At runtime, `comfy-kitchen` applies the
+matching Hadamard rotation to each activation, dynamically quantizes it to
+INT8, and executes the INT8 GEMM.
+
+This path currently supports the pruned FL2VA MiniMax-H3 checkpoint:
+
+`Comfy-Org/MiniMax-H3/diffusion_models/minimax_h3_fl2va_pruned_int8_convrot.safetensors`
+
+The base `MiniMaxAI/MiniMax-H3` repository still supplies the model config,
+tokenizer, text encoder, and VAEs. The Comfy checkpoint replaces only the
+FL2VA diffusion transformer.
+
+## Installation
+
+Install the optional native kernel dependency:
+
+```bash
+pip install "vllm-omni[int8-convrot]"
+```
+
+The published `comfy-kitchen` CUDA wheel requires a CUDA 13 PyTorch runtime
+and an R580-or-newer NVIDIA driver. INT8 ConvRot fails at startup or execution
+when the native CUDA backend is unavailable; it does not silently fall back to
+an eager or dequantized implementation.
+
+## Configuration
+
+Download the checkpoint locally, or use its Hugging Face `resolve` URL as the
+transformer override. For the standard single-stage diffusion path, construct
+`Omni` with both the replacement path and its quantization method:
+
+```python
+from vllm_omni import Omni
+
+checkpoint = (
+    "https://huggingface.co/Comfy-Org/MiniMax-H3/resolve/main/"
+    "diffusion_models/minimax_h3_fl2va_pruned_int8_convrot.safetensors"
+)
+
+omni = Omni(
+    model="MiniMaxAI/MiniMax-H3",
+    task_type="fl2va",
+    model_paths={"transformer": checkpoint},
+    diffusion_quantization_config={
+        "transformer": {"method": "int8_convrot"},
+    },
+    trust_remote_code=True,
+)
+```
+
+For the opt-in disaggregated topology, stage 0 is the text encoder and stage 1
+is diffusion. Scope both settings to stage 1:
+
+```bash
+export CHECKPOINT="https://huggingface.co/Comfy-Org/MiniMax-H3/resolve/main/diffusion_models/minimax_h3_fl2va_pruned_int8_convrot.safetensors"
+
+vllm-omni serve MiniMaxAI/MiniMax-H3 \
+  --omni \
+  --task-type fl2va \
+  --deploy-config vllm_omni/deploy/minimax_h3_disaggregated.yaml \
+  --stage-overrides \
+  "{\"1\":{\"model_paths\":{\"transformer\":\"${CHECKPOINT}\"}}}" \
+  --diffusion-quantization-config \
+  '{"transformer":{"method":"int8_convrot"}}'
+```
+
+Adjust the disaggregated deploy's stage devices and parallel sizes for your
+hardware. Do not apply a global tensor-parallel override: its text-encoder and
+diffusion stages intentionally have different topologies.
+
+For a local checkpoint, `model_paths["transformer"]` may point to the
+`.safetensors` file itself or to a directory containing exactly one
+`.safetensors` file. Because the published files do not carry partition
+metadata and FL2VA/Ref2VA have the same tensor schema, the filename must contain
+exactly one standalone `fl2va` or `ref2va` token. The loader rejects a missing,
+ambiguous, or serving-partition-mismatched token.
+
+The loader reads each layer's `.comfy_quant` marker and configures only the
+marked linears. Unmarked token-refiner and input/output layers keep their
+checkpoint dtype. The pruned checkpoint's `adaln_t_table` is also detected
+automatically, so the model uses the matching low-rank AdaLN curve path instead
+of constructing the dense time embedder.
+
+## Tensor Parallelism
+
+ConvRot operates independently on fixed-size groups along the input dimension.
+For row-parallel linears, every tensor-parallel shard boundary must therefore
+remain aligned to the checkpoint's `convrot_groupsize` (256 for this
+checkpoint). vLLM-Omni validates the TP-local width and rejects incompatible
+parallel sizes instead of producing incorrect output.
+
+The loader rejects any tensor-parallel degree that splits a ConvRot group.
+Validate end-to-end output quality and memory for the exact deploy topology,
+resolution, and clip length used in production.
+
+HSDP/FSDP is rejected for this checkpoint. Its mixed INT8 weights, FP32
+per-row scales, and FP32 AdaLN curve projections require a dedicated sharding
+policy that is not yet implemented.
+
+## Checkpoint Contract
+
+Each quantized linear uses three tensors:
+
+```text
+<layer>.weight        I8  [out_features, in_features]
+<layer>.weight_scale  F32 [out_features] or [out_features, 1]
+<layer>.comfy_quant   U8  JSON bytes
+```
+
+The marker must identify the `int8_tensorwise` format and its ConvRot group
+size. The loader validates marker JSON, tensor dtypes and shapes, per-output-row
+scales, and group alignment before model construction.

--- a/docs/user_guide/quantization/int8_convrot.md
+++ b/docs/user_guide/quantization/int8_convrot.md
@@ -46,7 +46,7 @@ omni = Omni(
     model="MiniMaxAI/MiniMax-H3",
     task_type="fl2va",
     model_paths={"transformer": checkpoint},
-    diffusion_quantization_config={
+    quantization_config={
         "transformer": {"method": "int8_convrot"},
     },
     trust_remote_code=True,
@@ -64,9 +64,7 @@ vllm-omni serve MiniMaxAI/MiniMax-H3 \
   --task-type fl2va \
   --deploy-config vllm_omni/deploy/minimax_h3_disaggregated.yaml \
   --stage-overrides \
-  "{\"1\":{\"model_paths\":{\"transformer\":\"${CHECKPOINT}\"}}}" \
-  --diffusion-quantization-config \
-  '{"transformer":{"method":"int8_convrot"}}'
+  "{\"1\":{\"model_paths\":{\"transformer\":\"${CHECKPOINT}\"},\"quantization_config\":{\"transformer\":{\"method\":\"int8_convrot\"}}}}"
 ```
 
 Adjust the disaggregated deploy's stage devices and parallel sizes for your
@@ -85,6 +83,12 @@ marked linears. Unmarked token-refiner and input/output layers keep their
 checkpoint dtype. The pruned checkpoint's `adaln_t_table` is also detected
 automatically, so the model uses the matching low-rank AdaLN curve path instead
 of constructing the dense time embedder.
+
+The curve table and its AdaLN projections stay FP32 to preserve interpolation
+and modulation precision.
+
+FastH3 fusion is unsupported: its dense-weight deltas cannot be added directly
+to rotated INT8 weights.
 
 ## Tensor Parallelism
 

--- a/docs/user_guide/quantization/overview.md
+++ b/docs/user_guide/quantization/overview.md
@@ -14,7 +14,7 @@ For the internal architecture and backend extension points, see the
 | ------ | ------- | ------------- | --------- |
 | Online quantization | [Online Quantization](online.md) | vLLM-Omni computes quantized weights and scales while loading the model. | FP8 W8A8, Int8 W8A8, BitsAndBytes W4, MXFP8 W8A8, MXFP4 W4A4 |
 | Runtime attention quantization | [Quantized KV Cache](quantized_kvcache.md) | vLLM-Omni dynamically quantizes eligible diffusion Flash Attention tensors during inference. | FP8 FA |
-| Pre-quantized checkpoints | Method-specific guides | The checkpoint or an offline quantizer provides quantized weights and scales before serving. | ModelOpt, AutoRound, TorchAO, msModelSlim, serialized Int8, offline MXFP8, offline MXFP4 DualScale |
+| Pre-quantized checkpoints | Method-specific guides | The checkpoint or an offline quantizer provides quantized weights and scales before serving. | ModelOpt, AutoRound, TorchAO, msModelSlim, serialized Int8, [INT8 ConvRot](int8_convrot.md), offline MXFP8, offline MXFP4 DualScale |
 
 ## Hardware Support
 
@@ -43,6 +43,7 @@ otherwise.
 | -------- | ------- | ------ | ---------------- | -------- |
 | FP8 W8A8 | [FP8](fp8.md) | Online W8A8 or checkpoint FP8 | Qwen-Image; Wan2.2 is not validated | Validated for Qwen-Image family and other DiT models |
 | Int8 W8A8 | [Int8](int8.md) | Online or serialized W8A8 | Qwen-Image; Wan2.2 is not validated | Validated for Qwen-Image and Z-Image |
+| INT8 ConvRot | [INT8 ConvRot](int8_convrot.md) | Offline ComfyUI W8A8 | MiniMax-H3 FL2VA | End-to-end validated on 2x A800 80GB with TP=2; compatible TP layouts are loader-validated but require topology-specific end-to-end validation |
 | BitsAndBytes W4 | [BitsAndBytes](bitsandbytes.md) | Online W4 weight-only | Z-Image-Turbo; Qwen-Image/Wan2.2 not validated | Validated for Z-Image-Turbo |
 | ModelOpt | [ModelOpt](modelopt.md) | Pre-quantized FP8 checkpoints | Qwen-Image, Z-Image, FLUX.2, HunyuanImage-3.0 | Validated for ModelOpt FP8 diffusion checkpoints |
 | MXFP8 W8A8 | [MXFP8](mxfp8.md) | Online W8A8 or offline pre-quantized | Wan2.2-T2V-A14B, I2V-A14B, TI2V-5B | Ascend NPU only; validated for Wan2.2 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,13 @@ quack = [
     "quack-kernels>=0.3.11",
 ]
 
+# Native W8A8 ConvRot kernels for serialized ComfyUI diffusion checkpoints.
+# Keep this opt-in: the published CUDA wheel requires a CUDA 13 runtime and an
+# R580+ NVIDIA driver, while non-CUDA installations do not need the package.
+int8-convrot = [
+    "comfy-kitchen[cublas]==0.2.31",
+]
+
 # Optional Blackwell-native FlashAttention-4 backend. Keep this opt-in because
 # the CuTe/CUTLASS dependency is CUDA 13 and Blackwell specific.
 fa4 = [

--- a/tests/config/test_config_factory.py
+++ b/tests/config/test_config_factory.py
@@ -1503,18 +1503,21 @@ stages:
         assert "text_encoder_tp_size" not in stages[1].runtime_overrides
         assert stages[1].yaml_engine_args["parallel_config"]["tensor_parallel_size"] == 1
 
-    def test_minimax_h3_model_path_override_reaches_only_diffusion_stage(self):
+    def test_minimax_h3_convrot_overrides_reach_only_diffusion_stage(self):
         pipeline = OMNI_PIPELINES["minimax_h3_disaggregated"]
         model_paths = {"transformer": "/models/minimax_h3_fl2va_int8_convrot.safetensors"}
+        quantization_config = {"transformer": {"method": "int8_convrot"}}
         stages, _ = StageConfigFactory._create_legacy_from_registry(
             pipeline,
-            {"stage_1_model_paths": model_paths},
+            {"stage_1_model_paths": model_paths, "stage_1_quantization_config": quantization_config},
         )
 
         stage_zero_args = stages[0].to_omegaconf()["engine_args"]
         stage_one_args = stages[1].to_omegaconf()["engine_args"]
         assert "model_paths" not in stage_zero_args
+        assert stage_zero_args.get("quantization_config") is None
         assert stage_one_args["model_paths"] == model_paths
+        assert stage_one_args["quantization_config"] == quantization_config
 
     def test_minimax_h3_disaggregated_defaults_match_validated_topology(self):
         pipeline = OMNI_PIPELINES["minimax_h3_disaggregated"]

--- a/tests/config/test_config_factory.py
+++ b/tests/config/test_config_factory.py
@@ -1503,6 +1503,19 @@ stages:
         assert "text_encoder_tp_size" not in stages[1].runtime_overrides
         assert stages[1].yaml_engine_args["parallel_config"]["tensor_parallel_size"] == 1
 
+    def test_minimax_h3_model_path_override_reaches_only_diffusion_stage(self):
+        pipeline = OMNI_PIPELINES["minimax_h3_disaggregated"]
+        model_paths = {"transformer": "/models/minimax_h3_fl2va_int8_convrot.safetensors"}
+        stages, _ = StageConfigFactory._create_legacy_from_registry(
+            pipeline,
+            {"stage_1_model_paths": model_paths},
+        )
+
+        stage_zero_args = stages[0].to_omegaconf()["engine_args"]
+        stage_one_args = stages[1].to_omegaconf()["engine_args"]
+        assert "model_paths" not in stage_zero_args
+        assert stage_one_args["model_paths"] == model_paths
+
     def test_minimax_h3_disaggregated_defaults_match_validated_topology(self):
         pipeline = OMNI_PIPELINES["minimax_h3_disaggregated"]
         deploy = load_deploy_config(Path(get_deploy_config_path("minimax_h3_disaggregated.yaml")))

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_quantization.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_quantization.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
+import json
 from types import SimpleNamespace
-from unittest.mock import Mock
 
 import pytest
 import torch
 import torch.nn as nn
+from safetensors.torch import save_file
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.diffusion]
 
@@ -66,7 +68,7 @@ def _small_od_config():
     )
 
 
-def test_fp8_scope_and_prefix_propagation(monkeypatch):
+def test_fp8_scope_and_prefix_propagation(monkeypatch, mocker):
     from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
     from vllm.model_executor.layers.quantization.fp8 import Fp8Config
     from vllm.model_executor.layers.quantization.utils.quant_utils import (
@@ -123,7 +125,7 @@ def test_fp8_scope_and_prefix_propagation(monkeypatch):
     assert all(linears[prefix] is fp8_config for prefix in quantized)
     assert all(linears[prefix] is None for prefix in full_precision)
     assert {prefix for prefix in quantized if is_layer_skipped(prefix, fp8_config.ignored_layers)} == ignored_layers
-    linear = Mock(spec=LinearBase)
+    linear = mocker.Mock(spec=LinearBase)
     assert all(
         isinstance(
             fp8_config.get_quant_method(linear, prefix),
@@ -138,6 +140,25 @@ class _WeightTarget(nn.Module):
         super().__init__()
         self.weight = nn.Parameter(torch.empty(1))
         self.weight.weight_loader = loader
+
+
+class _QuantWeightTarget(_WeightTarget):
+    def __init__(self, weight_loader, scale_loader):
+        from vllm.model_executor.parameter import ChannelQuantScaleParameter
+
+        super().__init__(weight_loader)
+        self.weight_scale = ChannelQuantScaleParameter(
+            data=torch.empty((1, 1), dtype=torch.float32),
+            output_dim=0,
+            weight_loader=scale_loader,
+        )
+
+
+class _OtherQuantWeightTarget(_WeightTarget):
+    def __init__(self, weight_loader, scale_loader):
+        super().__init__(weight_loader)
+        self.weight_scale = nn.Parameter(torch.empty(1))
+        self.weight_scale.weight_loader = scale_loader
 
 
 def test_model_load_weights_transforms_before_calling_vllm_loader():
@@ -191,6 +212,516 @@ def test_model_load_weights_transforms_before_calling_vllm_loader():
     ]
 
 
+def test_model_load_weights_applies_fused_transforms_to_int8_scales(monkeypatch):
+    import vllm.model_executor.parameter as parameter_module
+
+    from vllm_omni.diffusion.models.minimax_h3.minimax_h3_transformer import (
+        MiniMaxH3DiTArchConfig,
+        MiniMaxH3DiTModel,
+    )
+
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_world_size", lambda: 1)
+
+    qkv_scale_calls = []
+    fc1_scale_calls = []
+    other_scale_calls = []
+
+    model = object.__new__(MiniMaxH3DiTModel)
+    nn.Module.__init__(model)
+    model.arch = MiniMaxH3DiTArchConfig(
+        hidden_size=1,
+        num_attention_heads=2,
+        attention_head_dim=1,
+        ffn_hidden_size=2,
+    )
+    model.blocks = nn.ModuleList([nn.Module()])
+    model.blocks[0].attn = nn.Module()
+    model.blocks[0].attn.qkv_proj = _QuantWeightTarget(
+        lambda *_: None,
+        lambda _param, value: qkv_scale_calls.append(value.clone()),
+    )
+    model.blocks[0].attn.out_proj = _OtherQuantWeightTarget(
+        lambda *_: None,
+        lambda _param, value: other_scale_calls.append(value.clone()),
+    )
+    model.blocks[0].mlp = nn.Module()
+    model.blocks[0].mlp.fc1 = _QuantWeightTarget(
+        lambda *_: None,
+        lambda _param, value, shard_id: fc1_scale_calls.append((shard_id, value.clone())),
+    )
+
+    qkv_scale = torch.arange(6, dtype=torch.float32)
+    fc1_scale = torch.arange(4, dtype=torch.float32)
+    loaded = model.load_weights(
+        [
+            ("blocks.0.attn.qkv_proj.weight_scale", qkv_scale),
+            ("blocks.0.mlp.fc1.weight_scale", fc1_scale),
+            ("blocks.0.attn.out_proj.weight_scale", torch.arange(3, dtype=torch.float32)),
+            (
+                "blocks.0.attn.qkv_proj.comfy_quant",
+                torch.tensor(list(b"{}"), dtype=torch.uint8),
+            ),
+        ]
+    )
+
+    assert loaded == {
+        "blocks.0.attn.qkv_proj.weight_scale",
+        "blocks.0.mlp.fc1.weight_scale",
+        "blocks.0.attn.out_proj.weight_scale",
+        "blocks.0.attn.qkv_proj.comfy_quant",
+    }
+    assert qkv_scale_calls[0][:, 0].tolist() == [0, 3, 1, 4, 2, 5]
+    assert [(shard_id, tensor[:, 0].tolist()) for shard_id, tensor in fc1_scale_calls] == [
+        (0, [0, 1]),
+        (1, [2, 3]),
+    ]
+    assert other_scale_calls[0].shape == (3,)
+
+
+def test_model_load_weights_leaves_non_channel_fused_scales_to_their_loader():
+    from vllm_omni.diffusion.models.minimax_h3.minimax_h3_transformer import (
+        MiniMaxH3DiTArchConfig,
+        MiniMaxH3DiTModel,
+    )
+
+    qkv_calls = []
+    fc1_calls = []
+    model = object.__new__(MiniMaxH3DiTModel)
+    nn.Module.__init__(model)
+    model.arch = MiniMaxH3DiTArchConfig(
+        hidden_size=1,
+        num_attention_heads=2,
+        attention_head_dim=1,
+        ffn_hidden_size=2,
+    )
+    model.blocks = nn.ModuleList([nn.Module()])
+    model.blocks[0].attn = nn.Module()
+    model.blocks[0].attn.qkv_proj = _OtherQuantWeightTarget(
+        lambda *_: None,
+        lambda _param, value: qkv_calls.append(value.clone()),
+    )
+    model.blocks[0].mlp = nn.Module()
+    model.blocks[0].mlp.fc1 = _OtherQuantWeightTarget(
+        lambda *_: None,
+        lambda _param, value: fc1_calls.append(value.clone()),
+    )
+    qkv_scale = torch.tensor([1.0, 2.0, 3.0])
+    fc1_scale = torch.tensor([4.0, 5.0])
+
+    loaded = model.load_weights(
+        [
+            ("blocks.0.attn.qkv_proj.weight_scale", qkv_scale),
+            ("blocks.0.mlp.fc1.weight_scale", fc1_scale),
+        ]
+    )
+
+    assert loaded == {
+        "blocks.0.attn.qkv_proj.weight_scale",
+        "blocks.0.mlp.fc1.weight_scale",
+    }
+    torch.testing.assert_close(qkv_calls[0], qkv_scale)
+    torch.testing.assert_close(fc1_calls[0], fc1_scale)
+
+
+def test_int8_convrot_factory_routes_only_checkpoint_marked_layers(mocker):
+    from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+
+    from vllm_omni.quantization import build_quant_config
+    from vllm_omni.quantization.int8_convrot_config import Int8ConvRotLinearMethod
+
+    config = build_quant_config(
+        {
+            "method": "int8_convrot",
+            "quantized_layers": ["blocks.0.attn.qkv_proj"],
+        }
+    )
+    linear = mocker.Mock(spec=LinearBase)
+
+    assert config.get_name() == "int8_convrot"
+    assert isinstance(config.get_quant_method(linear, "blocks.0.attn.qkv_proj"), Int8ConvRotLinearMethod)
+    assert isinstance(config.get_quant_method(linear, "blocks.0.attn.out_proj"), UnquantizedLinearMethod)
+
+
+def test_int8_convrot_rejects_ignored_checkpoint_layers():
+    from vllm_omni.quantization.int8_convrot_config import (
+        DiffusionInt8ConvRotConfig,
+        Int8ConvRotLayerConfig,
+    )
+
+    prefix = "blocks.0.attn.qkv_proj"
+    with pytest.raises(ValueError, match="cannot also be ignored"):
+        DiffusionInt8ConvRotConfig(
+            quantized_layers=[prefix],
+            ignored_layers=[prefix],
+        )
+    config = DiffusionInt8ConvRotConfig(ignored_layers=[prefix])
+    with pytest.raises(ValueError, match="cannot also be ignored"):
+        config.configure_layers({prefix: Int8ConvRotLayerConfig(True, 256)})
+
+
+@pytest.mark.parametrize("prefix", ["final_layer.video_out", "blocks.99.missing"])
+def test_int8_convrot_rejects_checkpoint_markers_without_executable_binding(prefix):
+    from vllm_omni.quantization.int8_convrot_config import (
+        DiffusionInt8ConvRotConfig,
+    )
+
+    config = DiffusionInt8ConvRotConfig(quantized_layers=[prefix])
+
+    with pytest.raises(ValueError, match="unbound markers"):
+        config.validate_model_bindings(nn.Module())
+
+
+def test_int8_convrot_accepts_exact_executable_bindings():
+    from vllm_omni.quantization.int8_convrot_config import (
+        DiffusionInt8ConvRotConfig,
+        Int8ConvRotLayerConfig,
+        Int8ConvRotLinearMethod,
+    )
+
+    prefix = "blocks.0.attn.qkv_proj"
+    config = DiffusionInt8ConvRotConfig(quantized_layers=[prefix])
+    model = nn.Module()
+    model.linear = nn.Linear(1, 1)
+    model.linear.quant_method = Int8ConvRotLinearMethod(
+        config,
+        Int8ConvRotLayerConfig(convrot=True),
+        prefix=prefix,
+    )
+
+    config.validate_model_bindings(model)
+
+
+def test_component_config_reports_offline_only_when_every_quantizer_is_offline():
+    from vllm_omni.quantization import build_quant_config
+
+    offline = build_quant_config(
+        {
+            "transformer": {
+                "method": "int8_convrot",
+                "quantized_layers": ["blocks.0.attn.qkv_proj"],
+            }
+        }
+    )
+    mixed = build_quant_config(
+        {
+            "transformer": {
+                "method": "int8_convrot",
+                "quantized_layers": ["blocks.0.attn.qkv_proj"],
+            },
+            "text_encoder": {"method": "fp8"},
+        }
+    )
+
+    assert offline.is_checkpoint_quantized
+    assert not mixed.is_checkpoint_quantized
+
+
+def test_int8_convrot_checkpoint_and_quantization_must_be_configured_together():
+    from vllm_omni.diffusion.models.minimax_h3.pipeline_minimax_h3 import (
+        _validate_int8_convrot_override_pair,
+    )
+    from vllm_omni.quantization import build_quant_config
+
+    config = build_quant_config({"method": "int8_convrot"})
+
+    _validate_int8_convrot_override_pair(False, None)
+    _validate_int8_convrot_override_pair(True, config)
+    with pytest.raises(ValueError, match="requires a validated Comfy checkpoint"):
+        _validate_int8_convrot_override_pair(False, config)
+    with pytest.raises(ValueError, match="requires component quantization"):
+        _validate_int8_convrot_override_pair(True, None)
+
+
+def test_int8_convrot_apply_resolves_native_cuda_backend_once(monkeypatch, mocker):
+    from vllm_omni.quantization.int8_convrot_config import (
+        DiffusionInt8ConvRotConfig,
+        Int8ConvRotLayerConfig,
+        Int8ConvRotLinearMethod,
+    )
+
+    output = object()
+    implementation = mocker.Mock(return_value=output)
+    custom_op = mocker.Mock(return_value=output)
+    registry = SimpleNamespace(get_implementation=mocker.Mock(return_value=implementation))
+    kitchen = SimpleNamespace(registry=registry)
+    method = Int8ConvRotLinearMethod(
+        DiffusionInt8ConvRotConfig(),
+        Int8ConvRotLayerConfig(convrot=True, convrot_groupsize=256),
+        prefix="blocks.0.attn.qkv_proj",
+    )
+    monkeypatch.setattr(method, "_load_comfy_kitchen", lambda: kitchen)
+    monkeypatch.setattr(method, "_run_custom_op", custom_op)
+    activation = mocker.Mock(spec=torch.Tensor)
+    activation.is_cuda = True
+    activation.dtype = torch.bfloat16
+    layer = SimpleNamespace(weight=object(), weight_scale=object())
+
+    assert method.apply(layer, activation) is output
+    assert method.apply(layer, activation) is output
+    registry.get_implementation.assert_called_once()
+    assert registry.get_implementation.call_args.kwargs["backend"] == "cuda"
+    implementation.assert_not_called()
+    assert custom_op.call_count == 2
+
+    activation.dtype = torch.float32
+    with pytest.raises(TypeError, match="supports only FP16/BF16"):
+        method.apply(layer, activation)
+    assert custom_op.call_count == 2
+
+
+def test_comfy_checkpoint_inspection_derives_quantized_layers_and_curve_arch(tmp_path):
+    from vllm_omni.diffusion.models.minimax_h3.comfy_checkpoint import (
+        inspect_comfy_checkpoint,
+        resolve_comfy_checkpoint_path,
+    )
+
+    marker = {
+        "format": "int8_tensorwise",
+        "convrot": True,
+        "convrot_groupsize": 4,
+    }
+    checkpoint_path = tmp_path / "minimax_h3_fl2va_pruned_int8_convrot.safetensors"
+    prefix = "blocks.0.attn.qkv_proj"
+    save_file(
+        {
+            f"{prefix}.weight": torch.ones((6, 4), dtype=torch.int8),
+            f"{prefix}.weight_scale": torch.ones((6, 1), dtype=torch.float32),
+            f"{prefix}.comfy_quant": torch.tensor(list(json.dumps(marker).encode()), dtype=torch.uint8),
+            "adaln_t_table": torch.arange(10, dtype=torch.float32).reshape(5, 2),
+        },
+        checkpoint_path,
+    )
+
+    info = inspect_comfy_checkpoint(checkpoint_path)
+
+    assert resolve_comfy_checkpoint_path(str(tmp_path)) == checkpoint_path
+    assert info.partition == "fl2va"
+    assert set(info.layer_configs) == {prefix}
+    assert info.layer_configs[prefix].convrot
+    assert info.layer_configs[prefix].convrot_groupsize == 4
+    assert info.arch_overrides == {"adaln_curve_grid": 5, "adaln_curve_dim": 2}
+
+
+def test_comfy_checkpoint_resolution_preserves_snapshot_symlink_suffix(tmp_path):
+    from vllm_omni.diffusion.models.minimax_h3.comfy_checkpoint import (
+        inspect_comfy_checkpoint,
+        resolve_comfy_checkpoint_path,
+    )
+
+    blob = tmp_path / "blobs" / "0123456789abcdef"
+    blob.parent.mkdir()
+    marker = json.dumps(
+        {
+            "format": "int8_tensorwise",
+            "convrot": True,
+            "convrot_groupsize": 4,
+        }
+    ).encode()
+    save_file(
+        {
+            "blocks.0.attn.qkv_proj.weight": torch.ones((4, 4), dtype=torch.int8),
+            "blocks.0.attn.qkv_proj.weight_scale": torch.ones((4, 1), dtype=torch.float32),
+            "blocks.0.attn.qkv_proj.comfy_quant": torch.tensor(list(marker), dtype=torch.uint8),
+        },
+        blob,
+    )
+    snapshot = tmp_path / "snapshots" / "main" / "minimax_h3_ref2va_int8_convrot.safetensors"
+    snapshot.parent.mkdir(parents=True)
+    snapshot.symlink_to(blob)
+
+    resolved = resolve_comfy_checkpoint_path(str(snapshot))
+
+    assert resolved == snapshot.absolute()
+    assert resolved.suffix == ".safetensors"
+    assert resolved.is_symlink()
+    info = inspect_comfy_checkpoint(resolved)
+    assert info.partition == "ref2va"
+    assert set(info.layer_configs) == {"blocks.0.attn.qkv_proj"}
+
+
+def test_comfy_checkpoint_resolution_uses_shared_hf_downloader(monkeypatch, tmp_path):
+    from vllm_omni.diffusion.models.minimax_h3 import comfy_checkpoint
+
+    calls = []
+    snapshot = tmp_path / "snapshot"
+    target = snapshot / "diffusion_models" / "minimax_h3_fl2va_pruned_int8_convrot.safetensors"
+
+    def fake_download(**kwargs):
+        calls.append(kwargs)
+        return str(snapshot)
+
+    monkeypatch.setattr(
+        comfy_checkpoint,
+        "download_weights_from_hf_specific",
+        fake_download,
+    )
+
+    result = comfy_checkpoint.resolve_comfy_checkpoint_path(
+        "https://huggingface.co/Comfy-Org/MiniMax-H3/resolve/main/"
+        "diffusion_models/minimax_h3_fl2va_pruned_int8_convrot.safetensors"
+    )
+
+    assert result == target
+    assert calls == [
+        {
+            "model_name_or_path": "Comfy-Org/MiniMax-H3",
+            "cache_dir": None,
+            "allow_patterns": ["diffusion_models/minimax_h3_fl2va_pruned_int8_convrot.safetensors"],
+            "revision": "main",
+            "require_all": True,
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "transformer.safetensors",
+        "minimax_h3_notfl2va_int8_convrot.safetensors",
+        "minimax_h3_fl2va_ref2va_int8_convrot.safetensors",
+    ],
+)
+def test_comfy_checkpoint_rejects_missing_or_ambiguous_partition_token(tmp_path, name):
+    from vllm_omni.diffusion.models.minimax_h3.comfy_checkpoint import inspect_comfy_checkpoint
+
+    checkpoint = tmp_path / name
+    save_file({}, checkpoint)
+
+    with pytest.raises(ValueError, match="must identify exactly one partition"):
+        inspect_comfy_checkpoint(checkpoint)
+
+
+def test_comfy_checkpoint_rejects_wrong_serving_partition(tmp_path):
+    from vllm_omni.diffusion.models.minimax_h3.comfy_checkpoint import inspect_comfy_checkpoint
+
+    checkpoint = tmp_path / "minimax_h3_ref2va_int8_convrot.safetensors"
+    save_file({}, checkpoint)
+
+    with pytest.raises(ValueError, match="REF2VA checkpoint .* cannot serve the FL2VA partition"):
+        inspect_comfy_checkpoint(checkpoint, expected_partition="fl2va")
+
+
+def test_comfy_checkpoint_rejects_unmarked_int8_weights(tmp_path):
+    from vllm_omni.diffusion.models.minimax_h3.comfy_checkpoint import inspect_comfy_checkpoint
+
+    marker = json.dumps(
+        {
+            "format": "int8_tensorwise",
+            "convrot": True,
+            "convrot_groupsize": 4,
+        }
+    ).encode()
+    checkpoint = tmp_path / "minimax_h3_fl2va_unmarked.safetensors"
+    save_file(
+        {
+            "blocks.0.attn.qkv_proj.weight": torch.ones((4, 4), dtype=torch.int8),
+            "blocks.0.attn.qkv_proj.weight_scale": torch.ones((4, 1), dtype=torch.float32),
+            "blocks.0.attn.qkv_proj.comfy_quant": torch.tensor(list(marker), dtype=torch.uint8),
+            "blocks.1.attn.out_proj.weight": torch.ones((4, 4), dtype=torch.int8),
+            "blocks.1.attn.out_proj.weight_scale": torch.ones((4, 1), dtype=torch.float32),
+        },
+        checkpoint,
+    )
+
+    with pytest.raises(ValueError, match="missing markers"):
+        inspect_comfy_checkpoint(checkpoint)
+
+
+def test_adaln_curve_model_interpolates_without_dense_time_embedder(monkeypatch):
+    from vllm_omni.diffusion.models.minimax_h3 import minimax_h3_transformer as h3
+
+    monkeypatch.setattr(h3, "ColumnParallelLinear", _FakeLinear)
+    monkeypatch.setattr(h3, "MergedColumnParallelLinear", _FakeLinear)
+    monkeypatch.setattr(h3, "QKVParallelLinear", _FakeLinear)
+    monkeypatch.setattr(h3, "RowParallelLinear", _FakeLinear)
+    monkeypatch.setattr(h3, "Attention", _FakeAttention)
+    monkeypatch.setattr(h3, "get_tensor_model_parallel_world_size", lambda: 1)
+
+    model = h3.MiniMaxH3DiTModel(
+        _small_od_config(),
+        arch_overrides={"adaln_curve_grid": 3, "adaln_curve_dim": 2},
+    )
+    model.adaln_t_table.copy_(
+        torch.tensor(
+            [
+                [0.0, 10.0],
+                [2.0, 12.0],
+                [4.0, 14.0],
+            ]
+        )
+    )
+
+    assert model.time_embedder is None
+    assert model.blocks[0].adaln_proj.linear.weight.dtype == torch.float32
+    torch.testing.assert_close(
+        model._embed_timesteps(torch.tensor([0.0, 0.25, 1.0])),
+        torch.tensor([[0.0, 10.0], [1.0, 11.0], [4.0, 14.0]]),
+    )
+
+
+@pytest.mark.parametrize("adaln_dtype", [torch.float32, torch.bfloat16])
+def test_final_layer_matches_comfy_adaln_precision(adaln_dtype):
+    from vllm_omni.diffusion.attention.ops.minimax_h3_modulation import (
+        indexed_scale_shift_,
+    )
+    from vllm_omni.diffusion.models.minimax_h3.minimax_h3_transformer import (
+        MiniMaxH3FinalLayer,
+    )
+
+    class _FixedAdaln(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.input_dtype = adaln_dtype
+            self.register_buffer(
+                "shift",
+                torch.tensor([[0.0031, -0.0073]], dtype=adaln_dtype),
+            )
+            self.register_buffer(
+                "scale",
+                torch.tensor([[0.0127, -0.0189]], dtype=adaln_dtype),
+            )
+
+        def forward(self, _t_emb):
+            return self.shift, self.scale
+
+    class _IdentityHead(nn.Module):
+        def forward(self, hidden):
+            return hidden, None
+
+    layer = object.__new__(MiniMaxH3FinalLayer)
+    nn.Module.__init__(layer)
+    layer.norm = nn.Identity()
+    layer.adaln_proj = _FixedAdaln()
+    layer.video_out = _IdentityHead()
+    layer.audio_out = _IdentityHead()
+
+    hidden = torch.tensor([[1.25, -0.75]], dtype=torch.bfloat16)
+    indices = torch.tensor([0], dtype=torch.long)
+    shift, scale = layer.adaln_proj(torch.empty(0))
+    # This is Comfy's out-of-place expression. FP32 curve modulation promotes
+    # the result; dense BF16 modulation intentionally retains BF16 rounding.
+    comfy_result = (hidden * (1.0 + scale[indices]) + shift[indices]).to(torch.float32)
+    legacy_in_place_result = indexed_scale_shift_(
+        hidden.clone(),
+        shift,
+        scale,
+        indices,
+    ).to(torch.float32)
+    expected = comfy_result if adaln_dtype == torch.float32 else legacy_in_place_result
+
+    video, audio = layer(
+        hidden,
+        t_emb=torch.empty(0),
+        inverse_indices=indices,
+    )
+
+    torch.testing.assert_close(video, expected, rtol=0, atol=0)
+    torch.testing.assert_close(audio, expected, rtol=0, atol=0)
+    if adaln_dtype == torch.float32:
+        assert not torch.equal(comfy_result, legacy_in_place_result)
+
+
 def test_loader_adapter_declares_equivalent_direct_mmap_transform(monkeypatch):
     from vllm_omni.diffusion.model_loader.checkpoint_adapters import (
         get_direct_mmap_adapter,
@@ -231,6 +762,7 @@ def test_loader_adapter_declares_equivalent_direct_mmap_transform(monkeypatch):
     checkpoint_weight = torch.arange(6, dtype=torch.float32).reshape(6, 1)
 
     assert policy.transform(checkpoint_weight)[:, 0].tolist() == [0, 3, 1, 4, 2, 5]
+
     assert not hasattr(attention.qkv_proj.weight, "mmap_weight_transform")
 
 

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_quantization.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_quantization.py
@@ -279,6 +279,53 @@ def test_model_load_weights_applies_fused_transforms_to_int8_scales(monkeypatch)
     assert other_scale_calls[0].shape == (3,)
 
 
+def test_model_load_weights_preserves_comfy_int8_runtime_qkv_layout(monkeypatch):
+    import vllm.model_executor.parameter as parameter_module
+
+    from vllm_omni.diffusion.models.minimax_h3.minimax_h3_transformer import (
+        MiniMaxH3DiTArchConfig,
+        MiniMaxH3DiTModel,
+    )
+
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_world_size", lambda: 1)
+
+    weight_calls = []
+    scale_calls = []
+    model = object.__new__(MiniMaxH3DiTModel)
+    nn.Module.__init__(model)
+    model.arch = MiniMaxH3DiTArchConfig(
+        hidden_size=1,
+        num_attention_heads=2,
+        attention_head_dim=1,
+        ffn_hidden_size=2,
+    )
+    model._qkv_checkpoint_is_runtime_layout = True
+    model.blocks = nn.ModuleList([nn.Module()])
+    model.blocks[0].attn = nn.Module()
+    model.blocks[0].attn.qkv_proj = _QuantWeightTarget(
+        lambda _param, value: weight_calls.append(value.clone()),
+        lambda _param, value: scale_calls.append(value.clone()),
+    )
+
+    # Comfy serializes all query rows first, then key rows, then value rows.
+    qkv = torch.arange(6, dtype=torch.float32).reshape(6, 1)
+    qkv_scale = torch.arange(6, dtype=torch.float32)
+    loaded = model.load_weights(
+        [
+            ("blocks.0.attn.qkv_proj.weight", qkv),
+            ("blocks.0.attn.qkv_proj.weight_scale", qkv_scale),
+        ]
+    )
+
+    assert loaded == {
+        "blocks.0.attn.qkv_proj.weight",
+        "blocks.0.attn.qkv_proj.weight_scale",
+    }
+    torch.testing.assert_close(weight_calls[0], qkv)
+    torch.testing.assert_close(scale_calls[0], qkv_scale.unsqueeze(1))
+
+
 def test_model_load_weights_leaves_non_channel_fused_scales_to_their_loader():
     from vllm_omni.diffusion.models.minimax_h3.minimax_h3_transformer import (
         MiniMaxH3DiTArchConfig,
@@ -455,7 +502,9 @@ def test_int8_convrot_apply_resolves_native_cuda_backend_once(monkeypatch, mocke
     activation = mocker.Mock(spec=torch.Tensor)
     activation.is_cuda = True
     activation.dtype = torch.bfloat16
-    layer = SimpleNamespace(weight=object(), weight_scale=object())
+    layer = nn.Module()
+    layer.weight = object()
+    layer.weight_scale = object()
 
     assert method.apply(layer, activation) is output
     assert method.apply(layer, activation) is output

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_quantization.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_quantization.py
@@ -677,6 +677,41 @@ def test_comfy_checkpoint_rejects_unmarked_int8_weights(tmp_path):
         inspect_comfy_checkpoint(checkpoint)
 
 
+def test_convrot_rejects_resolved_fasth3_fusion(monkeypatch, mocker, tmp_path):
+    from vllm_omni.diffusion.data import OmniDiffusionConfig
+    from vllm_omni.diffusion.models.minimax_h3 import pipeline_minimax_h3 as pipeline
+    from vllm_omni.diffusion.models.minimax_h3.comfy_checkpoint import MiniMaxH3ComfyCheckpoint
+    from vllm_omni.quantization.int8_convrot_config import DiffusionInt8ConvRotConfig
+
+    partition = tmp_path / "FL2VA"
+    partition.mkdir()
+    (partition / "model_index.json").write_text(json.dumps({"_minimax_h3": {"partition": "fl2va"}}))
+    checkpoint = tmp_path / "convrot.safetensors"
+    od_config = OmniDiffusionConfig(
+        model=str(tmp_path),
+        revision=None,
+        task_type="fl2va",
+        model_loaded={"text_encoder": False},
+        model_paths={"transformer": str(checkpoint)},
+        quantization_config=DiffusionInt8ConvRotConfig(),
+    )
+    transformer = nn.Module()
+    monkeypatch.setattr(pipeline, "get_local_device", lambda: torch.device("cpu"))
+    mocker.patch.object(pipeline, "resolve_comfy_checkpoint_path", return_value=checkpoint)
+    mocker.patch.object(
+        pipeline,
+        "inspect_comfy_checkpoint",
+        return_value=MiniMaxH3ComfyCheckpoint(checkpoint, "fl2va", {}, None, None),
+    )
+    mocker.patch.object(pipeline, "MiniMaxH3DiTModel", return_value=transformer)
+    resolve_fusion = mocker.patch.object(pipeline, "resolve_fasth3_fusion", return_value=object())
+
+    with pytest.raises(ValueError, match="FastH3 weight deltas cannot be fused"):
+        pipeline.MiniMaxH3Pipeline(od_config=od_config)
+
+    resolve_fusion.assert_called_once_with(od_config, transformer)
+
+
 def test_adaln_curve_model_interpolates_without_dense_time_embedder(monkeypatch):
     from vllm_omni.diffusion.models.minimax_h3 import minimax_h3_transformer as h3
 
@@ -691,17 +726,17 @@ def test_adaln_curve_model_interpolates_without_dense_time_embedder(monkeypatch)
         _small_od_config(),
         arch_overrides={"adaln_curve_grid": 3, "adaln_curve_dim": 2},
     )
-    model.adaln_t_table.copy_(
-        torch.tensor(
-            [
-                [0.0, 10.0],
-                [2.0, 12.0],
-                [4.0, 14.0],
-            ]
-        )
+    table = torch.tensor(
+        [[0.0, 10.0], [2.0, 12.0], [4.0, 14.0]],
+        dtype=torch.float32,
     )
+    assert model.load_weights([("adaln_t_table", table)]) == {"adaln_t_table"}
+    model.post_load_weights()
+    model.validate_restored_host_weights()
 
     assert model.time_embedder is None
+    assert model.adaln_t_table.dtype == torch.float32
+    torch.testing.assert_close(model.adaln_t_table, table, rtol=0, atol=0)
     assert model.blocks[0].adaln_proj.linear.weight.dtype == torch.float32
     torch.testing.assert_close(
         model._embed_timesteps(torch.tensor([0.0, 0.25, 1.0])),

--- a/tests/diffusion/offloader/test_distributed_layerwise_backend.py
+++ b/tests/diffusion/offloader/test_distributed_layerwise_backend.py
@@ -1895,6 +1895,36 @@ class TestMmapValidation:
         assert result.plan is None
         assert result.fallback_reason == expected_reason
 
+    def test_int8_convrot_falls_back_to_run_quant_postprocessing(self, tmp_path):
+        from vllm_omni.quantization.int8_convrot_config import (
+            DiffusionInt8ConvRotConfig,
+            Int8ConvRotLayerConfig,
+            Int8ConvRotLinearMethod,
+        )
+
+        pipeline = nn.Module()
+        pipeline.transformer = nn.Linear(2, 2, bias=False)
+        pipeline.transformer.quant_method = Int8ConvRotLinearMethod(
+            DiffusionInt8ConvRotConfig(),
+            Int8ConvRotLayerConfig(convrot=True),
+            prefix="transformer",
+        )
+
+        result = build_checkpoint_mmap_plan(
+            pipeline,
+            dit_modules=(("transformer", pipeline.transformer),),
+            sources=(),
+            model_path=str(tmp_path),
+            tensor_parallel_size=1,
+            use_hsdp=False,
+            online_quantization=False,
+        )
+
+        assert result.plan is None
+        assert result.fallback_reason == (
+            "INT8 ConvRot requires the ordinary loader to run quantization post-processing"
+        )
+
     @pytest.mark.parametrize(
         ("checkpoint_tensor", "expected_reason"),
         [

--- a/tests/engine/test_async_omni_engine_stage_init.py
+++ b/tests/engine/test_async_omni_engine_stage_init.py
@@ -1593,6 +1593,42 @@ def test_model_path_resolver_is_generic_and_model_owned(tmp_path):
     assert "model_path_resolver" not in engine_args
 
 
+def test_model_path_resolver_forwards_component_overrides(monkeypatch):
+    from vllm_omni.diffusion.models.minimax_h3 import pipeline_minimax_h3
+    from vllm_omni.engine.stage_init_utils import _resolve_model_path
+
+    calls = []
+
+    def resolver(model, revision, task_type, *, model_paths=None, use_hsdp=None, lora_path=None):
+        calls.append((model, revision, task_type, model_paths, use_hsdp, lora_path))
+        return "/resolved/FL2VA"
+
+    monkeypatch.setattr(pipeline_minimax_h3, "resolve_minimax_h3_diffusion_model_path", resolver)
+    model_paths = {"transformer": "/models/convrot.safetensors"}
+    engine_args = {
+        "model_path_resolver": (
+            "vllm_omni.diffusion.models.minimax_h3.pipeline_minimax_h3.resolve_minimax_h3_diffusion_model_path"
+        ),
+        "revision": "main",
+        "task_type": "fl2va",
+        "model_paths": model_paths,
+        "parallel_config": {"use_hsdp": True},
+        "lora_path": "/models/adapter.safetensors",
+    }
+
+    assert _resolve_model_path("MiniMaxAI/MiniMax-H3", engine_args) == "/resolved/FL2VA"
+    assert calls == [
+        (
+            "MiniMaxAI/MiniMax-H3",
+            "main",
+            "fl2va",
+            model_paths,
+            True,
+            "/models/adapter.safetensors",
+        )
+    ]
+
+
 def test_build_stage0_input_processor_uses_omni_input_preprocessor(monkeypatch):
     import vllm_omni.engine.stage_init_utils as init_mod
 

--- a/tests/engine/test_async_omni_engine_stage_init.py
+++ b/tests/engine/test_async_omni_engine_stage_init.py
@@ -1599,8 +1599,8 @@ def test_model_path_resolver_forwards_component_overrides(monkeypatch):
 
     calls = []
 
-    def resolver(model, revision, task_type, *, model_paths=None, use_hsdp=None, lora_path=None):
-        calls.append((model, revision, task_type, model_paths, use_hsdp, lora_path))
+    def resolver(model, revision, task_type, *, model_paths=None, use_hsdp=None):
+        calls.append((model, revision, task_type, model_paths, use_hsdp))
         return "/resolved/FL2VA"
 
     monkeypatch.setattr(pipeline_minimax_h3, "resolve_minimax_h3_diffusion_model_path", resolver)
@@ -1613,7 +1613,6 @@ def test_model_path_resolver_forwards_component_overrides(monkeypatch):
         "task_type": "fl2va",
         "model_paths": model_paths,
         "parallel_config": {"use_hsdp": True},
-        "lora_path": "/models/adapter.safetensors",
     }
 
     assert _resolve_model_path("MiniMaxAI/MiniMax-H3", engine_args) == "/resolved/FL2VA"
@@ -1624,7 +1623,6 @@ def test_model_path_resolver_forwards_component_overrides(monkeypatch):
             "fl2va",
             model_paths,
             True,
-            "/models/adapter.safetensors",
         )
     ]
 

--- a/tests/entrypoints/test_async_omni_diffusion_config.py
+++ b/tests/entrypoints/test_async_omni_diffusion_config.py
@@ -120,6 +120,39 @@ def test_stage_override_preserves_model_extras_for_default_diffusion_stage(mocke
     assert stage_configs[0]["engine_args"]["extras"]["ltx2_use_conv_vae"] is True
 
 
+@pytest.mark.parametrize("per_stage", [False, True])
+def test_default_diffusion_fallback_preserves_model_loading_overrides(mocker, per_stage):
+    """Single-stage fallback must retain component path/load overrides."""
+    mocker.patch(
+        "vllm_omni.config.resolver.StageConfigFactory.create_from_model",
+        return_value=None,
+    )
+    mocker.patch(
+        "vllm_omni.config.resolver._resolve_generic_diffusion_model_class",
+        return_value=(True, "MiniMaxH3Pipeline"),
+    )
+    engine = AsyncOmniEngine.__new__(AsyncOmniEngine)
+    model_paths = {"transformer": "/models/convrot.safetensors"}
+    model_loaded = {"transformer": True, "vae": True, "text_encoder": False}
+    quantization_config = {"transformer": {"method": "int8_convrot"}}
+    overrides = {
+        "model_paths": model_paths,
+        "model_loaded": model_loaded,
+        "quantization_config": quantization_config,
+    }
+
+    _, stage_configs = engine._resolve_stage_configs(
+        "/models/MiniMax-H3",
+        {"stage_overrides": {"0": overrides}} if per_stage else overrides,
+        trust_remote_code=False,
+    )
+
+    engine_args = stage_configs[0]["engine_args"]
+    assert engine_args["model_paths"] == model_paths
+    assert engine_args["model_loaded"] == model_loaded
+    assert engine_args["quantization_config"] == quantization_config
+
+
 def test_default_stage_rejects_unknown_nested_parallel_config_key():
     unknown_key = "unknown_parallel_field"
     with pytest.raises(ValidationError, match=unknown_key):

--- a/tests/model_executor/stage_input_processors/test_minimax_h3.py
+++ b/tests/model_executor/stage_input_processors/test_minimax_h3.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 import torch
 from PIL import Image
+from safetensors.torch import save_file
 
 from vllm_omni.data_entry_keys import OmniPayload, deserialize_payload, serialize_payload
 from vllm_omni.diffusion.models.minimax_h3.pipeline_minimax_h3 import (
@@ -464,3 +465,70 @@ def test_diffusion_resolver_normalizes_partial_partition_directory(tmp_path):
     (ref2va / "text_encoder").mkdir(parents=True)
 
     assert resolve_minimax_h3_diffusion_model_path(str(ref2va), None, "ref2va") == str(ref2va)
+
+
+def test_diffusion_resolver_skips_native_transformer_for_override(monkeypatch, tmp_path):
+    from vllm_omni.diffusion.models.minimax_h3 import pipeline_minimax_h3 as pipeline_module
+
+    calls = []
+
+    def fake_download(**kwargs):
+        calls.append(kwargs)
+        return str(tmp_path)
+
+    monkeypatch.setattr(pipeline_module, "download_weights_from_hf_specific", fake_download)
+
+    resolved = resolve_minimax_h3_diffusion_model_path(
+        "MiniMaxAI/MiniMax-H3",
+        None,
+        "fl2va",
+        model_paths={"transformer": "/models/convrot.safetensors"},
+    )
+
+    assert resolved == str(tmp_path / "FL2VA")
+    assert len(calls) == 1
+    assert calls[0]["allow_patterns"] == pipeline_module.MINIMAX_H3_OVERRIDE_DOWNLOAD_PATTERNS["fl2va"]["diffusion"]
+    transformer_patterns = [pattern for pattern in calls[0]["allow_patterns"] if "transformer" in pattern]
+    assert transformer_patterns == ["FL2VA/transformer/config.json"]
+
+
+def test_diffusion_resolver_rejects_incompatible_convrot_modes_before_download(monkeypatch, tmp_path):
+    from vllm_omni.diffusion.models.minimax_h3 import pipeline_minimax_h3 as pipeline_module
+
+    calls = []
+    monkeypatch.setattr(
+        pipeline_module,
+        "download_weights_from_hf_specific",
+        lambda **kwargs: calls.append(kwargs),
+    )
+    model_paths = {"transformer": "/models/convrot.safetensors"}
+
+    with pytest.raises(ValueError, match="not HSDP/FSDP"):
+        resolve_minimax_h3_diffusion_model_path(
+            "MiniMaxAI/MiniMax-H3",
+            None,
+            "fl2va",
+            model_paths=model_paths,
+            use_hsdp=True,
+        )
+
+    adapter = tmp_path / "fasth3.safetensors"
+    save_file(
+        {"dummy": torch.zeros(1)},
+        adapter,
+        metadata={
+            "format": "fastvideo-lora-v2",
+            "finetuned_model": "FastVideo/FastVideo-FastH3-Dense-4-step-v1",
+            "base_model": "MiniMaxAI/MiniMax-H3",
+        },
+    )
+    with pytest.raises(ValueError, match="cannot be combined with FastH3"):
+        resolve_minimax_h3_diffusion_model_path(
+            "MiniMaxAI/MiniMax-H3",
+            None,
+            "fl2va",
+            model_paths=model_paths,
+            lora_path=[str(tmp_path / "ordinary.safetensors"), str(adapter)],
+        )
+
+    assert calls == []

--- a/tests/model_executor/stage_input_processors/test_minimax_h3.py
+++ b/tests/model_executor/stage_input_processors/test_minimax_h3.py
@@ -11,7 +11,6 @@ import numpy as np
 import pytest
 import torch
 from PIL import Image
-from safetensors.torch import save_file
 
 from vllm_omni.data_entry_keys import OmniPayload, deserialize_payload, serialize_payload
 from vllm_omni.diffusion.models.minimax_h3.pipeline_minimax_h3 import (
@@ -492,7 +491,7 @@ def test_diffusion_resolver_skips_native_transformer_for_override(monkeypatch, t
     assert transformer_patterns == ["FL2VA/transformer/config.json"]
 
 
-def test_diffusion_resolver_rejects_incompatible_convrot_modes_before_download(monkeypatch, tmp_path):
+def test_diffusion_resolver_rejects_convrot_hsdp_before_download(monkeypatch):
     from vllm_omni.diffusion.models.minimax_h3 import pipeline_minimax_h3 as pipeline_module
 
     calls = []
@@ -510,25 +509,6 @@ def test_diffusion_resolver_rejects_incompatible_convrot_modes_before_download(m
             "fl2va",
             model_paths=model_paths,
             use_hsdp=True,
-        )
-
-    adapter = tmp_path / "fasth3.safetensors"
-    save_file(
-        {"dummy": torch.zeros(1)},
-        adapter,
-        metadata={
-            "format": "fastvideo-lora-v2",
-            "finetuned_model": "FastVideo/FastVideo-FastH3-Dense-4-step-v1",
-            "base_model": "MiniMaxAI/MiniMax-H3",
-        },
-    )
-    with pytest.raises(ValueError, match="cannot be combined with FastH3"):
-        resolve_minimax_h3_diffusion_model_path(
-            "MiniMaxAI/MiniMax-H3",
-            None,
-            "fl2va",
-            model_paths=model_paths,
-            lora_path=[str(tmp_path / "ordinary.safetensors"), str(adapter)],
         )
 
     assert calls == []

--- a/vllm_omni/diffusion/model_loader/host_weight_plan.py
+++ b/vllm_omni/diffusion/model_loader/host_weight_plan.py
@@ -84,6 +84,15 @@ def has_online_quantization(model: nn.Module) -> bool:
     return any(getattr(getattr(module, "quant_method", None), "uses_meta_device", False) for module in model.modules())
 
 
+def _has_int8_convrot_quantization(model: nn.Module) -> bool:
+    """Whether direct mmap would skip required ConvRot finalization."""
+    from vllm_omni.quantization.int8_convrot_config import (
+        Int8ConvRotLinearMethod,
+    )
+
+    return any(isinstance(getattr(module, "quant_method", None), Int8ConvRotLinearMethod) for module in model.modules())
+
+
 def _resolve_source_root(source: object) -> str:
     source_root = os.fspath(getattr(source, "model_or_path"))
     subfolder = getattr(source, "subfolder", None)
@@ -330,6 +339,11 @@ def build_checkpoint_mmap_plan(
         return HostWeightPlanResult(None, "HSDP requires the ordinary loader")
     if online_quantization:
         return HostWeightPlanResult(None, "online quantization requires the ordinary loader")
+    if _has_int8_convrot_quantization(pipeline):
+        return HostWeightPlanResult(
+            None,
+            "INT8 ConvRot requires the ordinary loader to run quantization post-processing",
+        )
 
     remap_fn = getattr(type(pipeline), "_remap_ckpt_key", None)
     if not callable(remap_fn):

--- a/vllm_omni/diffusion/models/minimax_h3/comfy_checkpoint.py
+++ b/vllm_omni/diffusion/models/minimax_h3/comfy_checkpoint.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Inspection and resolution helpers for ComfyUI MiniMax-H3 checkpoints."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+from urllib.parse import unquote, urlparse
+
+import regex as re
+import torch
+from safetensors import safe_open
+
+from vllm_omni.model_executor.model_loader.weight_utils import (
+    download_weights_from_hf_specific,
+)
+from vllm_omni.quantization.int8_convrot_config import Int8ConvRotLayerConfig
+
+
+@dataclass(frozen=True)
+class MiniMaxH3ComfyCheckpoint:
+    path: Path
+    partition: Literal["fl2va", "ref2va"]
+    layer_configs: dict[str, Int8ConvRotLayerConfig]
+    adaln_curve_grid: int | None
+    adaln_curve_dim: int | None
+
+    @property
+    def arch_overrides(self) -> dict[str, int]:
+        if self.adaln_curve_grid is None or self.adaln_curve_dim is None:
+            return {}
+        return {
+            "adaln_curve_grid": self.adaln_curve_grid,
+            "adaln_curve_dim": self.adaln_curve_dim,
+        }
+
+
+def resolve_comfy_checkpoint_path(value: str, *, cache_dir: str | None = None) -> Path:
+    """Resolve a local file/directory or a Hugging Face resolve URL."""
+    local = Path(value).expanduser()
+    if local.is_file():
+        # Preserve a Hub snapshot symlink's user-facing filename.  Resolving it
+        # to ``blobs/<sha>`` drops the ``.safetensors`` suffix, which makes the
+        # generic diffusion loader misclassify the file as a PyTorch checkpoint.
+        return local.absolute()
+    if local.is_dir():
+        candidates = sorted(local.glob("*.safetensors"))
+        if len(candidates) != 1:
+            raise ValueError(
+                f"MiniMax-H3 transformer directory {local} must contain exactly one "
+                f".safetensors file, found {len(candidates)}."
+            )
+        return candidates[0].absolute()
+
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or parsed.netloc not in {
+        "huggingface.co",
+        "www.huggingface.co",
+    }:
+        raise FileNotFoundError(
+            f"MiniMax-H3 ConvRot checkpoint {value!r} is not a local path or supported Hugging Face URL."
+        )
+    parts = [unquote(part) for part in parsed.path.strip("/").split("/")]
+    try:
+        marker_index = next(i for i, part in enumerate(parts) if part in {"resolve", "blob"})
+    except StopIteration as exc:
+        raise ValueError(
+            f"Hugging Face checkpoint URL lacks /resolve/<revision>/ or /blob/<revision>/: {value}"
+        ) from exc
+    if marker_index != 2 or len(parts) <= marker_index + 2:
+        raise ValueError(f"Unsupported Hugging Face checkpoint URL: {value}")
+    repo_id = "/".join(parts[:marker_index])
+    revision = parts[marker_index + 1]
+    filename = "/".join(parts[marker_index + 2 :])
+    snapshot = download_weights_from_hf_specific(
+        model_name_or_path=repo_id,
+        cache_dir=cache_dir,
+        allow_patterns=[filename],
+        revision=revision,
+        require_all=True,
+    )
+    return Path(snapshot) / filename
+
+
+def _decode_marker(marker: torch.Tensor, *, name: str) -> dict[str, object]:
+    if marker.dtype != torch.uint8 or marker.dim() != 1:
+        raise ValueError(
+            f"{name} must be a one-dimensional uint8 JSON tensor, got {marker.dtype} {tuple(marker.shape)}."
+        )
+    try:
+        decoded = json.loads(bytes(marker.tolist()).decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{name} does not contain valid UTF-8 JSON.") from exc
+    if not isinstance(decoded, dict):
+        raise ValueError(f"{name} must decode to a JSON object.")
+    return decoded
+
+
+def _checkpoint_partition(path: Path) -> Literal["fl2va", "ref2va"]:
+    """Read the partition contract carried by official Comfy filenames.
+
+    The published MiniMax-H3 safetensors files do not contain safetensors
+    ``__metadata__`` identifying their partition, and FL2VA/Ref2VA use the
+    same tensor names and shapes.  The official filenames therefore provide
+    the only inspectable contract.  Refuse ambiguous renamed files instead of
+    silently loading one partition's weights into the other model.
+    """
+    matches = set(re.findall(r"(?:^|[._-])(fl2va|ref2va)(?=$|[._-])", path.name.lower()))
+    if len(matches) != 1:
+        raise ValueError(
+            f"MiniMax-H3 ConvRot checkpoint filename {path.name!r} must identify exactly one "
+            "partition with an 'fl2va' or 'ref2va' token."
+        )
+    return "fl2va" if "fl2va" in matches else "ref2va"
+
+
+def inspect_comfy_checkpoint(
+    path: str | Path,
+    *,
+    expected_partition: Literal["fl2va", "ref2va"] | None = None,
+) -> MiniMaxH3ComfyCheckpoint:
+    """Validate markers and derive mixed-precision/curve architecture metadata.
+
+    Only tiny marker tensors and the optional AdaLN curve table are read.  INT8
+    weights remain memory-mapped for the ordinary streaming loader.
+    """
+    checkpoint_path = Path(path)
+    partition = _checkpoint_partition(checkpoint_path)
+    if expected_partition is not None and partition != expected_partition:
+        raise ValueError(
+            f"{partition.upper()} checkpoint {checkpoint_path.name!r} cannot serve "
+            f"the {expected_partition.upper()} partition."
+        )
+    layer_configs: dict[str, Int8ConvRotLayerConfig] = {}
+    with safe_open(checkpoint_path, framework="pt", device="cpu") as checkpoint:
+        keys = set(checkpoint.keys())
+        marker_names = sorted(name for name in keys if name.endswith(".comfy_quant"))
+        if not marker_names:
+            raise ValueError(f"{checkpoint_path} contains no Comfy .comfy_quant layer metadata.")
+
+        for marker_name in marker_names:
+            prefix = marker_name.removesuffix(".comfy_quant")
+            weight_name = f"{prefix}.weight"
+            scale_name = f"{prefix}.weight_scale"
+            if weight_name not in keys or scale_name not in keys:
+                raise ValueError(f"{marker_name} requires companion tensors {weight_name!r} and {scale_name!r}.")
+            marker = _decode_marker(checkpoint.get_tensor(marker_name), name=marker_name)
+            layer_config = Int8ConvRotLayerConfig.from_mapping(marker)
+            weight_slice = checkpoint.get_slice(weight_name)
+            scale_slice = checkpoint.get_slice(scale_name)
+            weight_shape = tuple(weight_slice.get_shape())
+            scale_shape = tuple(scale_slice.get_shape())
+            if weight_slice.get_dtype() != "I8" or len(weight_shape) != 2:
+                raise ValueError(
+                    f"{weight_name} must be a two-dimensional I8 tensor, got {weight_slice.get_dtype()} {weight_shape}."
+                )
+            if scale_slice.get_dtype() != "F32" or scale_shape not in {(weight_shape[0],), (weight_shape[0], 1)}:
+                raise ValueError(
+                    f"{scale_name} must be F32 with one value per output row, got "
+                    f"{scale_slice.get_dtype()} {scale_shape} for weight {weight_shape}."
+                )
+            if layer_config.convrot and weight_shape[1] % layer_config.convrot_groupsize:
+                raise ValueError(
+                    f"{weight_name} input width {weight_shape[1]} is not divisible by "
+                    f"ConvRot group size {layer_config.convrot_groupsize}."
+                )
+            layer_configs[prefix] = layer_config
+
+        marked_weights = {f"{prefix}.weight" for prefix in layer_configs}
+        unmarked_int8_weights = []
+        for name in sorted(keys):
+            if not name.endswith(".weight") or name in marked_weights:
+                continue
+            tensor_slice = checkpoint.get_slice(name)
+            if tensor_slice.get_dtype() == "I8" and len(tensor_slice.get_shape()) == 2:
+                unmarked_int8_weights.append(name)
+        if unmarked_int8_weights:
+            raise ValueError(
+                "Every two-dimensional INT8 weight in a ConvRot checkpoint must have matching "
+                f".comfy_quant metadata; missing markers for {unmarked_int8_weights[:5]}."
+            )
+
+        if "adaln_t_table" in keys:
+            table = checkpoint.get_tensor("adaln_t_table")
+            if table.dtype != torch.float32 or table.dim() != 2 or table.shape[0] < 2:
+                raise ValueError(
+                    "adaln_t_table must be a two-dimensional FP32 table with at least two rows, "
+                    f"got {table.dtype} {tuple(table.shape)}."
+                )
+            curve_grid, curve_dim = (int(table.shape[0]), int(table.shape[1]))
+        else:
+            curve_grid = curve_dim = None
+
+    return MiniMaxH3ComfyCheckpoint(
+        path=checkpoint_path,
+        partition=partition,
+        layer_configs=layer_configs,
+        adaln_curve_grid=curve_grid,
+        adaln_curve_dim=curve_dim,
+    )
+
+
+__all__ = [
+    "MiniMaxH3ComfyCheckpoint",
+    "inspect_comfy_checkpoint",
+    "resolve_comfy_checkpoint_path",
+]

--- a/vllm_omni/diffusion/models/minimax_h3/fasth3.py
+++ b/vllm_omni/diffusion/models/minimax_h3/fasth3.py
@@ -743,6 +743,12 @@ def _resolve_adapter_file(path: str | Path) -> Path | None:
     return None
 
 
+def is_fasth3_adapter(path: str | Path) -> bool:
+    """Return whether a local adapter carries the FastH3 release identity."""
+    weights_path = _resolve_adapter_file(path)
+    return weights_path is not None and _is_fasth3_release(_safetensors_metadata(weights_path))
+
+
 __all__ = [
     "FASTH3_BASE_MODEL",
     "FASTH3_BASE_SCHEDULE",
@@ -751,5 +757,6 @@ __all__ = [
     "FASTH3_SUPPORTED_TASKS",
     "FastH3AdapterError",
     "FastH3WeightFusion",
+    "is_fasth3_adapter",
     "resolve_fasth3_fusion",
 ]

--- a/vllm_omni/diffusion/models/minimax_h3/fasth3.py
+++ b/vllm_omni/diffusion/models/minimax_h3/fasth3.py
@@ -743,12 +743,6 @@ def _resolve_adapter_file(path: str | Path) -> Path | None:
     return None
 
 
-def is_fasth3_adapter(path: str | Path) -> bool:
-    """Return whether a local adapter carries the FastH3 release identity."""
-    weights_path = _resolve_adapter_file(path)
-    return weights_path is not None and _is_fasth3_release(_safetensors_metadata(weights_path))
-
-
 __all__ = [
     "FASTH3_BASE_MODEL",
     "FASTH3_BASE_SCHEDULE",
@@ -757,6 +751,5 @@ __all__ = [
     "FASTH3_SUPPORTED_TASKS",
     "FastH3AdapterError",
     "FastH3WeightFusion",
-    "is_fasth3_adapter",
     "resolve_fasth3_fusion",
 ]

--- a/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
+++ b/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
@@ -144,7 +144,7 @@ MINIMAX_H3_FP32_PARAM_NAMES = frozenset(
         "final_layer.audio_out.bias",
     }
 )
-MINIMAX_H3_FP32_BUFFER_NAMES = frozenset({"rope.inv_freq", "adaln_t_table"})
+MINIMAX_H3_FP32_BUFFER_NAMES = frozenset({"rope.inv_freq"})
 
 # AdaLN modality count: token tags carry -1 for padding and 0/1/2 for
 # video/text/audio tokens (padding is clamped to 0 before the embedding

--- a/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
+++ b/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
@@ -26,6 +26,7 @@ from vllm.model_executor.layers.linear import (
     RowParallelLinear,
 )
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.parameter import ChannelQuantScaleParameter
 
 from vllm_omni.diffusion.attention.backends.abstract import (
     AttentionMetadata,
@@ -96,6 +97,10 @@ class MiniMaxH3DiTArchConfig:
     timestep_input_dim: int = 256
     time_embed_hidden_size: int = 5376
     time_embed_dim: int = 2688
+    # ComfyUI's AdaLN-pruned checkpoints replace the dense time embedder with
+    # a small shared interpolation table and project its low-rank coordinates.
+    adaln_curve_grid: int | None = None
+    adaln_curve_dim: int = 8
     adaln_out_features: int = 18 * 5376
     final_adaln_out_features: int = 2 * 5376
     rope_inv_freq_len: int = 16
@@ -113,6 +118,10 @@ class MiniMaxH3DiTArchConfig:
         if len(arch.patch_size) != 3:
             raise ValueError(f"patch_size must contain three values, got {arch.patch_size!r}")
         return arch
+
+    @property
+    def adaln_input_dim(self) -> int:
+        return self.adaln_curve_dim if self.adaln_curve_grid is not None else self.time_embed_dim
 
 
 _ARCH_DEFAULTS = MiniMaxH3DiTArchConfig()
@@ -135,7 +144,7 @@ MINIMAX_H3_FP32_PARAM_NAMES = frozenset(
         "final_layer.audio_out.bias",
     }
 )
-MINIMAX_H3_FP32_BUFFER_NAMES = frozenset({"rope.inv_freq"})
+MINIMAX_H3_FP32_BUFFER_NAMES = frozenset({"rope.inv_freq", "adaln_t_table"})
 
 # AdaLN modality count: token tags carry -1 for padding and 0/1/2 for
 # video/text/audio tokens (padding is clamped to 0 before the embedding
@@ -730,20 +739,22 @@ class MiniMaxH3AdalnProj(nn.Module):
         self.expand_ratio = expand_ratio
         self.modality_num = modality_num
         self.hidden_size = arch.hidden_size
+        self.apply_silu = arch.adaln_curve_grid is None
+        self.input_dtype = _BF16_DTYPE if self.apply_silu else _FP32_DTYPE
         self.linear = ColumnParallelLinear(
-            arch.time_embed_dim,
+            arch.adaln_input_dim,
             out_features,
             bias=True,
             gather_output=True,
-            params_dtype=_BF16_DTYPE,
+            params_dtype=self.input_dtype,
             quant_config=quant_config,
             prefix=f"{prefix}.linear",
         )
 
     def forward(self, t_emb: torch.Tensor) -> tuple[torch.Tensor, ...]:
         """t_emb: [M, t_dim] -> expand_ratio tensors of [M*modality_num, H]."""
-        x = nn.functional.silu(t_emb)
-        x, _ = self.linear(x.to(_BF16_DTYPE))
+        x = nn.functional.silu(t_emb) if self.apply_silu else t_emb
+        x, _ = self.linear(x.to(self.input_dtype))
         m = x.shape[0]
         x = x.view(m * self.modality_num, self.expand_ratio * self.hidden_size)
         return tuple(x.chunk(self.expand_ratio, dim=-1))
@@ -982,6 +993,13 @@ class MiniMaxH3FinalLayer(nn.Module):
         """
         shift, scale = self.adaln_proj(t_emb)
         h = self.norm(x)
+        # Comfy's out-of-place affine naturally promotes the normalized BF16
+        # activations when an AdaLN-curve checkpoint supplies FP32 modulation.
+        # Our fused affine writes in-place, so promote its destination first or
+        # the FP32 shift/scale contribution is silently rounded back to BF16.
+        # Dense checkpoints keep BF16 AdaLN inputs and retain the existing path.
+        if self.adaln_proj.input_dtype == _FP32_DTYPE:
+            h = h.to(_FP32_DTYPE)
         h = indexed_scale_shift_(h, shift, scale, inverse_indices)
         # Preserve full precision through both final output projections.
         h = h.to(_FP32_DTYPE)
@@ -1107,11 +1125,19 @@ class MiniMaxH3DiTModel(nn.Module):
         self,
         od_config: OmniDiffusionConfig,
         quant_config: QuantizationConfig | None = None,
+        arch_overrides: Mapping[str, Any] | None = None,
     ) -> None:
         super().__init__()
         tf_config = od_config.tf_model_config
         config_mapping = tf_config.to_dict() if hasattr(tf_config, "to_dict") else dict(tf_config)
+        if arch_overrides:
+            config_mapping.update(arch_overrides)
         arch = MiniMaxH3DiTArchConfig.from_mapping(config_mapping)
+        if arch.adaln_curve_grid is not None:
+            if arch.adaln_curve_grid < 2:
+                raise ValueError(f"adaln_curve_grid must be >= 2, got {arch.adaln_curve_grid}")
+            if arch.adaln_curve_dim <= 0:
+                raise ValueError(f"adaln_curve_dim must be positive, got {arch.adaln_curve_dim}")
         self.arch = arch
         self.od_config = od_config
         self.parallel_config = od_config.parallel_config
@@ -1160,10 +1186,21 @@ class MiniMaxH3DiTModel(nn.Module):
             quant_config=quant_config,
             prefix="condition_proj",
         )
-        self.time_embedder = MiniMaxH3TimeEmbedder(
-            arch,
-            prefix="time_embedder",
-        )
+        if arch.adaln_curve_grid is None:
+            self.time_embedder: MiniMaxH3TimeEmbedder | None = MiniMaxH3TimeEmbedder(
+                arch,
+                prefix="time_embedder",
+            )
+        else:
+            self.time_embedder = None
+            self.register_buffer(
+                "adaln_t_table",
+                torch.empty(
+                    arch.adaln_curve_grid,
+                    arch.adaln_curve_dim,
+                    dtype=_FP32_DTYPE,
+                ),
+            )
         self.rope = MiniMaxH3Rope(arch.rope_inv_freq_len)
         self.token_refiner = MiniMaxH3TokenRefiner(
             arch,
@@ -1190,6 +1227,9 @@ class MiniMaxH3DiTModel(nn.Module):
             prefix="final_layer",
         )
         self._mark_missing_params_required()
+        validate_bindings = getattr(quant_config, "validate_model_bindings", None)
+        if callable(validate_bindings):
+            validate_bindings(self)
 
     def enable_vsa_gates(self) -> None:
         """Give every DiT block's attention a VSA compression gate.
@@ -1261,6 +1301,8 @@ class MiniMaxH3DiTModel(nn.Module):
         for name, param in self.named_parameters():
             if name in MINIMAX_H3_FP32_PARAM_NAMES and param.dtype != _FP32_DTYPE:
                 raise ValueError(f"{name} must stay fp32 after load, got {param.dtype}.")
+            if self.arch.adaln_curve_grid is not None and ".adaln_proj.linear." in name and param.dtype != _FP32_DTYPE:
+                raise ValueError(f"{name} must stay fp32 for an AdaLN-curve checkpoint, got {param.dtype}.")
         for name, buffer in self.named_buffers():
             if name in MINIMAX_H3_FP32_BUFFER_NAMES and buffer.dtype != _FP32_DTYPE:
                 raise ValueError(f"{name} must stay fp32 after load, got {buffer.dtype}.")
@@ -1278,12 +1320,30 @@ class MiniMaxH3DiTModel(nn.Module):
         params.update(dict(self.named_buffers()))
         loaded: set[str] = set()
         for name, loaded_weight in weights:
+            if name.endswith(".comfy_quant"):
+                # Marker JSON was validated before construction.  It is a
+                # checkpoint protocol tensor, not executable model state.
+                loaded.add(name)
+                continue
             param = params.get(name)
             if param is None:
                 logger.warning("Skipping MiniMax H3 weight not present in model: %s", name)
                 continue
+            # Comfy serializes row scales as either [N] or [N, 1]. Normalize
+            # only our channel-scale parameter; other quantizers may attach a
+            # different meaning and loader contract to a 1-D weight_scale.
+            if (
+                isinstance(param, ChannelQuantScaleParameter)
+                and loaded_weight.dim() == 1
+                and param.dim() == 2
+                and param.shape[1] == 1
+            ):
+                loaded_weight = loaded_weight.unsqueeze(1)
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
-            if name.endswith(".attn.qkv_proj.weight"):
+            is_channel_scale = isinstance(param, ChannelQuantScaleParameter)
+            if name.endswith(".attn.qkv_proj.weight") or (
+                name.endswith(".attn.qkv_proj.weight_scale") and is_channel_scale
+            ):
                 # Transform checkpoint layout before entering vLLM's loader so
                 # online FP8 can keep ``online_process_loader`` outermost.
                 loaded_weight = _reorder_grouped_qkv_to_qkv(
@@ -1293,7 +1353,7 @@ class MiniMaxH3DiTModel(nn.Module):
                     head_dim=self.arch.attention_head_dim,
                 )
                 weight_loader(param, loaded_weight)
-            elif name.endswith(".mlp.fc1.weight"):
+            elif name.endswith(".mlp.fc1.weight") or (name.endswith(".mlp.fc1.weight_scale") and is_channel_scale):
                 if loaded_weight.shape[0] % 2:
                     raise ValueError(
                         "MiniMax H3 fc1 checkpoint rows must split evenly into "
@@ -1306,6 +1366,18 @@ class MiniMaxH3DiTModel(nn.Module):
                 weight_loader(param, loaded_weight)
             loaded.add(name)
         return loaded
+
+    def _embed_timesteps(self, unique_timesteps: torch.Tensor) -> torch.Tensor:
+        if self.arch.adaln_curve_grid is None:
+            if self.time_embedder is None:
+                raise RuntimeError("MiniMax-H3 dense AdaLN model is missing its time embedder.")
+            return self.time_embedder(unique_timesteps)
+
+        table = self.adaln_t_table
+        positions = unique_timesteps.to(_FP32_DTYPE).clamp(0.0, 1.0) * (table.shape[0] - 1)
+        lower = positions.floor().to(torch.long).clamp(max=table.shape[0] - 2)
+        fraction = (positions - lower).unsqueeze(1)
+        return torch.lerp(table[lower], table[lower + 1], fraction)
 
     @staticmethod
     def _pos_ids(pos_info: Any, key: str) -> torch.Tensor:
@@ -1419,7 +1491,7 @@ class MiniMaxH3DiTModel(nn.Module):
             audio_embed.to(_BF16_DTYPE)[: audio_local_pos.shape[0]],
         )
 
-        t_emb = self.time_embedder(unique_timesteps)
+        t_emb = self._embed_timesteps(unique_timesteps)
         return embeddings, t_emb
 
     def forward(self, **kwargs: Any) -> tuple[torch.Tensor, torch.Tensor]:

--- a/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
+++ b/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
@@ -1141,6 +1141,13 @@ class MiniMaxH3DiTModel(nn.Module):
         self.arch = arch
         self.od_config = od_config
         self.parallel_config = od_config.parallel_config
+        # Comfy's serialized INT8 ConvRot checkpoint already stores fused QKV
+        # rows in runtime [Q-all, K-all, V-all] order.  Dense and online
+        # quantized MiniMax checkpoints retain the original grouped layout and
+        # still need the transform in load_weights().
+        self._qkv_checkpoint_is_runtime_layout = bool(
+            getattr(quant_config, "is_checkpoint_int8_convrot_serialized", False)
+        )
         self.hidden_size = arch.hidden_size
         self.num_attention_heads = arch.num_attention_heads
         self.num_channels_latents = arch.latents_dim
@@ -1344,14 +1351,15 @@ class MiniMaxH3DiTModel(nn.Module):
             if name.endswith(".attn.qkv_proj.weight") or (
                 name.endswith(".attn.qkv_proj.weight_scale") and is_channel_scale
             ):
-                # Transform checkpoint layout before entering vLLM's loader so
-                # online FP8 can keep ``online_process_loader`` outermost.
-                loaded_weight = _reorder_grouped_qkv_to_qkv(
-                    loaded_weight,
-                    num_query_groups=self.arch.num_attention_heads,
-                    heads_per_group=1,
-                    head_dim=self.arch.attention_head_dim,
-                )
+                if not getattr(self, "_qkv_checkpoint_is_runtime_layout", False):
+                    # Transform checkpoint layout before entering vLLM's loader
+                    # so online FP8 can keep ``online_process_loader`` outermost.
+                    loaded_weight = _reorder_grouped_qkv_to_qkv(
+                        loaded_weight,
+                        num_query_groups=self.arch.num_attention_heads,
+                        heads_per_group=1,
+                        head_dim=self.arch.attention_head_dim,
+                    )
                 weight_loader(param, loaded_weight)
             elif name.endswith(".mlp.fc1.weight") or (name.endswith(".mlp.fc1.weight_scale") and is_channel_scale):
                 if loaded_weight.shape[0] % 2:

--- a/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
+++ b/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
@@ -113,6 +113,11 @@ from vllm_omni.quantization.component_config import (
 )
 
 from .batched_packing import minimax_h3_batched_forward_kwargs
+from .comfy_checkpoint import (
+    MiniMaxH3ComfyCheckpoint,
+    inspect_comfy_checkpoint,
+    resolve_comfy_checkpoint_path,
+)
 from .condition_noise import (
     minimax_h3_audio_cond_noise_aug_rows,
     minimax_h3_imgvid_cond_noise_aug_rows,
@@ -219,6 +224,58 @@ MINIMAX_H3_DIFFUSION_DOWNLOAD_PATTERNS = {
         "Ref2VA/transformer/**",
     ],
 }
+MINIMAX_H3_OVERRIDE_DOWNLOAD_PATTERNS = {
+    "fl2va": {
+        "diffusion": [
+            "FL2VA/model_index.json",
+            "FL2VA/transformer/config.json",
+            "FL2VA/video_vae/**",
+            "FL2VA/audio_vae/**",
+        ],
+        "all": [
+            "FL2VA/model_index.json",
+            "FL2VA/tokenizer/**",
+            "FL2VA/processor/**",
+            "FL2VA/text_encoder/**",
+            "FL2VA/transformer/config.json",
+            "FL2VA/video_vae/**",
+            "FL2VA/audio_vae/**",
+        ],
+    },
+    "ref2va": {
+        "diffusion": [
+            "Ref2VA/model_index.json",
+            "Ref2VA/transformer/config.json",
+            "Ref2VA/video_vae/**",
+            "Ref2VA/audio_vae/**",
+        ],
+        "all": [
+            "Ref2VA/model_index.json",
+            "Ref2VA/tokenizer/**",
+            "Ref2VA/processor/**",
+            "Ref2VA/text_encoder/**",
+            "Ref2VA/transformer/config.json",
+            "Ref2VA/video_vae/**",
+            "Ref2VA/audio_vae/**",
+        ],
+    },
+}
+
+
+def _validate_int8_convrot_override_pair(
+    transformer_override: bool,
+    transformer_quant_config: QuantizationConfig | None,
+) -> None:
+    uses_int8_convrot = transformer_quant_config is not None and transformer_quant_config.get_name() == "int8_convrot"
+    if transformer_override and not uses_int8_convrot:
+        raise ValueError(
+            "A Comfy INT8 ConvRot transformer checkpoint requires component quantization "
+            '`{"transformer":{"method":"int8_convrot"}}`.'
+        )
+    if uses_int8_convrot and not transformer_override:
+        raise ValueError(
+            'MiniMax-H3 int8_convrot quantization requires a validated Comfy checkpoint in model_paths["transformer"].'
+        )
 
 
 def _resolve_minimax_h3_text_encoder_quant_config(
@@ -241,13 +298,19 @@ def _resolve_minimax_h3_model_root(
     partition: str,
     *,
     load_text_encoder: bool,
+    skip_transformer: bool = False,
 ) -> Path:
     path = Path(model)
     if path.is_dir():
         if path.name in {"FL2VA", "Ref2VA"}:
             return path.parent
         return path
-    if load_text_encoder:
+    if skip_transformer:
+        if partition == "combined":
+            raise ValueError("A MiniMax-H3 transformer override does not support combined mode.")
+        scope = "all" if load_text_encoder else "diffusion"
+        allow_patterns = MINIMAX_H3_OVERRIDE_DOWNLOAD_PATTERNS[partition][scope]
+    elif load_text_encoder:
         allow_patterns = (
             MINIMAX_H3_DOWNLOAD_PATTERNS if partition == "combined" else MINIMAX_H3_TASK_DOWNLOAD_PATTERNS[partition]
         )
@@ -335,6 +398,9 @@ def resolve_minimax_h3_diffusion_model_path(
     model: str,
     revision: str | None,
     task_type: str | None,
+    *,
+    model_paths: Mapping[str, str] | None = None,
+    use_hsdp: bool | None = None,
 ) -> str:
     """Resolve a repository root or Hub ID to its startup partition."""
     partition = (
@@ -342,11 +408,15 @@ def resolve_minimax_h3_diffusion_model_path(
         if str(task_type or "").lower() == "combined"
         else resolve_minimax_h3_partition(model, task_type, auto_partition="fl2va")
     )
+    transformer_override = bool(model_paths and model_paths.get("transformer"))
+    if transformer_override and use_hsdp:
+        raise ValueError("MiniMax-H3 INT8 ConvRot currently supports tensor parallelism, not HSDP/FSDP.")
     model_root = _resolve_minimax_h3_model_root(
         model,
         revision,
         partition,
         load_text_encoder=False,
+        skip_transformer=transformer_override,
     )
     if partition == "combined":
         return str(model_root)
@@ -904,11 +974,15 @@ class MiniMaxH3Pipeline(
         self._turbo_lora_specs: dict[int, TurboSpec] = {}
         self._native_lora_adapter_ids: set[int] = set()
         self._lora_sigma_schedules: dict[int, DMD2SigmaSchedule] = {}
+        transformer_override = od_config.model_paths.get("transformer")
+        if transformer_override and bool(getattr(self.parallel_config, "use_hsdp", False)):
+            raise ValueError("MiniMax-H3 INT8 ConvRot currently supports tensor parallelism, not HSDP/FSDP.")
         model_root = _resolve_minimax_h3_model_root(
             str(od_config.model),
             od_config.revision,
             self.partition,
             load_text_encoder=self.load_text_encoder,
+            skip_transformer=bool(transformer_override),
         )
         model_path = model_root / ("Ref2VA" if self.partition == "ref2va" else "FL2VA")
         model_index = json.loads((model_path / "model_index.json").read_text(encoding="utf-8"))
@@ -945,15 +1019,50 @@ class MiniMaxH3Pipeline(
         if ref2va_model_path is not None:
             self._base_schedule_by_partition["ref2va"] = _read_base_schedule(ref2va_release)
 
-        self.weights_sources = [
-            DiffusersPipelineLoader.ComponentSource(
-                model_or_path=str(model_path),
-                subfolder="transformer",
-                revision=od_config.revision,
-                prefix="transformer.",
-                fall_back_to_pt=False,
+        transformer_quant_config = _resolve_component_quant_config(
+            od_config.quantization_config,
+            "transformer",
+        )
+        _validate_int8_convrot_override_pair(
+            bool(transformer_override),
+            transformer_quant_config,
+        )
+        transformer_checkpoint: MiniMaxH3ComfyCheckpoint | None = None
+        if transformer_override:
+            if self.partition == "combined":
+                raise ValueError(
+                    "A Comfy MiniMax-H3 transformer override currently supports one partition at a time; "
+                    "start FL2VA or Ref2VA instead of combined mode."
+                )
+            checkpoint_path = resolve_comfy_checkpoint_path(transformer_override)
+            transformer_checkpoint = inspect_comfy_checkpoint(
+                checkpoint_path,
+                expected_partition=expected_partition,
             )
-        ]
+            configure_layers = getattr(transformer_quant_config, "configure_layers", None)
+            if configure_layers is None:
+                raise TypeError("The active int8_convrot config cannot consume checkpoint layer metadata.")
+            configure_layers(transformer_checkpoint.layer_configs)
+            self.weights_sources = [
+                DiffusersPipelineLoader.ComponentSource(
+                    model_or_path=str(checkpoint_path.parent),
+                    subfolder=None,
+                    revision=None,
+                    prefix="transformer.",
+                    fall_back_to_pt=False,
+                    allow_patterns_overrides=[checkpoint_path.name],
+                )
+            ]
+        else:
+            self.weights_sources = [
+                DiffusersPipelineLoader.ComponentSource(
+                    model_or_path=str(model_path),
+                    subfolder="transformer",
+                    revision=od_config.revision,
+                    prefix="transformer.",
+                    fall_back_to_pt=False,
+                )
+            ]
         self._dit_modules = ["transformer"]
         if ref2va_model_path is not None:
             self.weights_sources.append(
@@ -966,13 +1075,10 @@ class MiniMaxH3Pipeline(
                 )
             )
             self._dit_modules.append("transformers_ref")
-        transformer_quant_config = _resolve_component_quant_config(
-            od_config.quantization_config,
-            "transformer",
-        )
         self.transformer = MiniMaxH3DiTModel(
             od_config,
             quant_config=transformer_quant_config,
+            arch_overrides=transformer_checkpoint.arch_overrides if transformer_checkpoint is not None else None,
         )
         if ref2va_model_path is not None:
             self.transformers_ref = MiniMaxH3DiTModel(
@@ -981,6 +1087,8 @@ class MiniMaxH3Pipeline(
             )
 
         self._fasth3 = resolve_fasth3_fusion(od_config, self.transformer)
+        if transformer_checkpoint is not None and self._fasth3 is not None:
+            raise ValueError("FastH3 weight deltas cannot be fused into rotated INT8 ConvRot weights.")
         if self._fasth3 is not None and self._fasth3.requires_vsa:
             # The artifact assigns a compression gate per DiT block, so those
             # modules have to exist before load_weights streams them in. Only

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -321,7 +321,7 @@ def _resolve_model_path(model: str, engine_args: dict[str, Any]) -> str:
     except (TypeError, ValueError):
         parameters = {}
     accepts_var_kwargs = any(parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters.values())
-    for field in ("model_paths", "use_hsdp", "lora_path"):
+    for field in ("model_paths", "use_hsdp"):
         if field in parameters or accepts_var_kwargs:
             value = engine_args.get(field)
             if field == "use_hsdp" and value is None:

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import copy
 import fcntl
 import importlib
+import inspect
 import json
 import multiprocessing as mp
 import os
@@ -313,11 +314,27 @@ def _resolve_model_path(model: str, engine_args: dict[str, Any]) -> str:
     resolver = _resolve_omni_metadata_hook(str(resolver_path))
     if resolver is None:
         return model
+    resolver_kwargs: dict[str, Any] = {}
+    parameters: Mapping[str, inspect.Parameter]
+    try:
+        parameters = inspect.signature(resolver).parameters
+    except (TypeError, ValueError):
+        parameters = {}
+    accepts_var_kwargs = any(parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters.values())
+    for field in ("model_paths", "use_hsdp", "lora_path"):
+        if field in parameters or accepts_var_kwargs:
+            value = engine_args.get(field)
+            if field == "use_hsdp" and value is None:
+                parallel_config = engine_args.get("parallel_config")
+                if isinstance(parallel_config, Mapping):
+                    value = parallel_config.get(field)
+            resolver_kwargs[field] = value
     return str(
         resolver(
             model,
             engine_args.get("revision"),
             engine_args.get("task_type"),
+            **resolver_kwargs,
         )
     )
 

--- a/vllm_omni/quantization/component_config.py
+++ b/vllm_omni/quantization/component_config.py
@@ -158,3 +158,11 @@ class ComponentQuantizationConfig(QuantizationConfig):
     @property
     def default_config(self) -> QuantizationConfig | None:
         return self._default
+
+    @property
+    def is_checkpoint_quantized(self) -> bool:
+        """Whether every configured quantized component is checkpoint-native."""
+        configs = [config for config in self._components.values() if config is not None]
+        if self._default is not None:
+            configs.append(self._default)
+        return bool(configs) and all(getattr(config, "is_checkpoint_quantized", False) for config in configs)

--- a/vllm_omni/quantization/factory.py
+++ b/vllm_omni/quantization/factory.py
@@ -88,6 +88,13 @@ def _build_int8(**kw: Any) -> QuantizationConfig:
     return DiffusionInt8Config(**kw)
 
 
+def _build_int8_convrot(**kw: Any) -> QuantizationConfig:
+    """Build the serialized ComfyUI tensor-wise INT8 ConvRot config."""
+    from .int8_convrot_config import DiffusionInt8ConvRotConfig
+
+    return DiffusionInt8ConvRotConfig(**kw)
+
+
 def _build_bitsandbytes(**kw: Any) -> QuantizationConfig:
     """Lazy import for BitsAndBytes 4-bit diffusion config (CUDA only)."""
     from .bitsandbytes_config import DiffusionBitsAndBytesConfig
@@ -169,6 +176,7 @@ def _build_torchao_float8_weight_only(**kw: Any) -> QuantizationConfig:
 
 _OVERRIDES: dict[str, Callable[..., QuantizationConfig]] = {
     "int8": _build_int8,
+    "int8_convrot": _build_int8_convrot,
     "bitsandbytes": _build_bitsandbytes,
     "mxfp8": _build_mxfp8,
     "mxfp4": _build_mxfp4,

--- a/vllm_omni/quantization/int8_convrot_config.py
+++ b/vllm_omni/quantization/int8_convrot_config.py
@@ -1,0 +1,368 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""ComfyUI tensor-wise INT8 ConvRot checkpoint support.
+
+The on-disk format stores an already rotated, row-wise quantized weight and a
+per-output-row scale.  At runtime the activation must receive the matching
+Hadamard rotation before dynamic INT8 quantization; treating these weights as
+ordinary INT8 silently produces incorrect output.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from torch.nn import Module
+from vllm.logger import init_logger
+from vllm.model_executor.layers.linear import (
+    LinearBase,
+    LinearMethodBase,
+    UnquantizedLinearMethod,
+)
+from vllm.model_executor.layers.quantization import QuantizationMethods
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizationConfig,
+    QuantizeMethodBase,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    is_layer_skipped,
+)
+from vllm.model_executor.parameter import ChannelQuantScaleParameter
+
+from vllm_omni.quantization.int8_config import create_weight_parameter
+
+logger = init_logger(__name__)
+
+_FORMAT = "int8_tensorwise"
+
+
+@dataclass(frozen=True)
+class Int8ConvRotLayerConfig:
+    """Validated per-linear metadata decoded from ``.comfy_quant``."""
+
+    convrot: bool
+    convrot_groupsize: int = 256
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> Int8ConvRotLayerConfig:
+        fmt = value.get("format")
+        if fmt != _FORMAT:
+            raise ValueError(f"Unsupported Comfy quant format {fmt!r}; expected {_FORMAT!r}.")
+        convrot = value.get("convrot", False)
+        if not isinstance(convrot, bool):
+            raise ValueError(f"Comfy ConvRot flag must be boolean, got {convrot!r}.")
+        group_size = value.get("convrot_groupsize", 256)
+        if not isinstance(group_size, int) or group_size < 4:
+            raise ValueError(f"Comfy ConvRot group size must be an integer >= 4, got {group_size!r}.")
+        # comfy-kitchen's regular Hadamard is defined for powers of four.
+        value_left = group_size
+        while value_left > 1 and value_left % 4 == 0:
+            value_left //= 4
+        if value_left != 1:
+            raise ValueError(f"Comfy ConvRot group size must be a power of four, got {group_size}.")
+        return cls(convrot=convrot, convrot_groupsize=group_size)
+
+
+class DiffusionInt8ConvRotConfig(QuantizationConfig):
+    """Offline ComfyUI W8A8 ConvRot configuration.
+
+    Quantized layers are explicit because a Comfy checkpoint can mix INT8
+    linears with BF16/FP16 linears.  The MiniMax-H3 pipeline fills this mapping
+    from each layer's ``.comfy_quant`` tensor before constructing the model.
+    """
+
+    def __init__(
+        self,
+        layer_configs: Mapping[str, Mapping[str, Any] | Int8ConvRotLayerConfig] | None = None,
+        quantized_layers: list[str] | None = None,
+        convrot_groupsize: int = 256,
+        ignored_layers: list[str] | None = None,
+    ) -> None:
+        super().__init__()
+        self.ignored_layers = ignored_layers or []
+        self.layer_configs: dict[str, Int8ConvRotLayerConfig] = {}
+        self.is_checkpoint_quantized = True
+        self.is_checkpoint_int8_convrot_serialized = True
+
+        if layer_configs:
+            self.configure_layers(layer_configs)
+        if quantized_layers:
+            default = Int8ConvRotLayerConfig.from_mapping(
+                {
+                    "format": _FORMAT,
+                    "convrot": True,
+                    "convrot_groupsize": convrot_groupsize,
+                }
+            )
+            for prefix in quantized_layers:
+                self.layer_configs.setdefault(prefix, default)
+        self._validate_checkpoint_layers_are_quantized(self.layer_configs)
+
+    @classmethod
+    def get_name(cls) -> QuantizationMethods:
+        return "int8_convrot"
+
+    @classmethod
+    def get_supported_act_dtypes(cls) -> list[torch.dtype]:
+        return [torch.bfloat16, torch.float16]
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        # comfy-kitchen supports INT8 tensor cores from Turing onward.
+        return 75
+
+    @classmethod
+    def get_config_filenames(cls) -> list[str]:
+        return []
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> DiffusionInt8ConvRotConfig:
+        return cls(
+            layer_configs=config.get("layer_configs"),
+            quantized_layers=config.get("quantized_layers"),
+            convrot_groupsize=config.get("convrot_groupsize", 256),
+            ignored_layers=config.get("ignored_layers"),
+        )
+
+    def configure_layers(
+        self,
+        layer_configs: Mapping[str, Mapping[str, Any] | Int8ConvRotLayerConfig],
+    ) -> None:
+        """Install checkpoint-derived metadata before model construction."""
+        parsed: dict[str, Int8ConvRotLayerConfig] = {}
+        for prefix, value in layer_configs.items():
+            if not prefix or prefix.endswith((".weight", ".weight_scale", ".comfy_quant")):
+                raise ValueError(f"ConvRot layer metadata must use a module prefix, got {prefix!r}.")
+            parsed[prefix] = (
+                value if isinstance(value, Int8ConvRotLayerConfig) else Int8ConvRotLayerConfig.from_mapping(value)
+            )
+        self._validate_checkpoint_layers_are_quantized(parsed)
+        if self.layer_configs and self.layer_configs != parsed:
+            raise ValueError("ConvRot layer metadata was already configured with different checkpoint values.")
+        self.layer_configs = parsed
+
+    def _validate_checkpoint_layers_are_quantized(
+        self,
+        layer_configs: Mapping[str, Int8ConvRotLayerConfig],
+    ) -> None:
+        conflicts = sorted(prefix for prefix in layer_configs if is_layer_skipped(prefix, self.ignored_layers))
+        if conflicts:
+            raise ValueError(
+                "Checkpoint-marked INT8 ConvRot layers cannot also be ignored: "
+                f"{conflicts[:5]}. Remove them from ignored_layers."
+            )
+
+    def validate_model_bindings(self, model: Module) -> None:
+        """Require every checkpoint marker to bind an executable ConvRot layer."""
+        expected = set(self.layer_configs)
+        bound = {
+            method.prefix
+            for module in model.modules()
+            if isinstance(
+                method := getattr(module, "quant_method", None),
+                Int8ConvRotLinearMethod,
+            )
+            and method.quant_config is self
+        }
+        if bound != expected:
+            missing = sorted(expected - bound)
+            unexpected = sorted(bound - expected)
+            raise ValueError(
+                "MiniMax-H3 ConvRot checkpoint metadata does not match executable quantized layers: "
+                f"unbound markers={missing[:5]}, unexpected bindings={unexpected[:5]}."
+            )
+
+    def get_quant_method(
+        self,
+        layer: torch.nn.Module,
+        prefix: str,
+    ) -> QuantizeMethodBase | None:
+        if not isinstance(layer, LinearBase):
+            return None
+        if is_layer_skipped(prefix, self.ignored_layers):
+            return UnquantizedLinearMethod()
+        layer_config = self.layer_configs.get(prefix)
+        if layer_config is None:
+            return UnquantizedLinearMethod()
+        return Int8ConvRotLinearMethod(self, layer_config, prefix=prefix)
+
+
+class Int8ConvRotLinearMethod(LinearMethodBase):
+    """Execute a serialized Comfy INT8 weight without dequantizing it."""
+
+    def __init__(
+        self,
+        quant_config: DiffusionInt8ConvRotConfig,
+        layer_config: Int8ConvRotLayerConfig,
+        *,
+        prefix: str,
+    ) -> None:
+        self.quant_config = quant_config
+        self.layer_config = layer_config
+        self.prefix = prefix
+        self._cuda_impl: Callable[..., torch.Tensor] | None = None
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        del input_size, output_size
+        output_size_per_partition = sum(output_partition_sizes)
+        group_size = self.layer_config.convrot_groupsize
+        if self.layer_config.convrot and input_size_per_partition % group_size:
+            raise ValueError(
+                f"{self.prefix} has TP-local input width {input_size_per_partition}, "
+                f"which is not aligned to its ConvRot group size {group_size}. "
+                "Choose a tensor-parallel degree whose row-parallel shards preserve group boundaries."
+            )
+
+        weight_loader = extra_weight_attrs.get("weight_loader")
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+        layer.orig_dtype = params_dtype
+
+        weight = create_weight_parameter(
+            output_size_per_partition=output_size_per_partition,
+            input_size_per_partition=input_size_per_partition,
+            weight_loader=weight_loader,
+            params_dtype=torch.int8,
+        )
+        layer.register_parameter("weight", weight)
+        scale = ChannelQuantScaleParameter(
+            data=torch.empty((output_size_per_partition, 1), dtype=torch.float32),
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight_scale", scale)
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        if layer.weight.dtype != torch.int8 or layer.weight.dim() != 2:
+            raise ValueError(
+                f"{self.prefix} expected a 2-D INT8 weight, got {tuple(layer.weight.shape)} {layer.weight.dtype}."
+            )
+        scale = layer.weight_scale
+        if scale.dtype != torch.float32 or scale.numel() != layer.weight.shape[0]:
+            raise ValueError(
+                f"{self.prefix} expected one FP32 scale per output row; got "
+                f"{tuple(scale.shape)} {scale.dtype} for weight {tuple(layer.weight.shape)}."
+            )
+        if not torch.isfinite(scale).all() or not torch.all(scale > 0):
+            raise ValueError(f"{self.prefix} contains non-finite or non-positive INT8 weight scales.")
+        layer.weight.data = layer.weight.data.contiguous()
+        layer.weight_scale.data = scale.data.reshape(-1).contiguous()
+        if layer.weight.is_cuda:
+            probe = torch.empty(
+                (1, layer.weight.shape[1]),
+                dtype=layer.orig_dtype,
+                device=layer.weight.device,
+            )
+            self._resolve_cuda_impl(layer, probe, bias=None)
+
+    @staticmethod
+    def _load_comfy_kitchen():
+        try:
+            import comfy_kitchen as ck
+        except ImportError as exc:
+            raise ImportError(
+                "INT8 ConvRot requires comfy-kitchen with its CUDA backend. "
+                'Install it with `pip install "vllm-omni[int8-convrot]"`.'
+            ) from exc
+        return ck
+
+    @torch.compiler.disable
+    def _resolve_cuda_impl(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        *,
+        bias: torch.Tensor | None,
+    ) -> Callable[..., torch.Tensor]:
+        impl = self._cuda_impl
+        if impl is not None:
+            return impl
+        ck = self._load_comfy_kitchen()
+        kwargs = {
+            "x": x,
+            "weight": layer.weight,
+            "weight_scale": layer.weight_scale,
+            "bias": bias,
+            "out_dtype": x.dtype,
+            "convrot": self.layer_config.convrot,
+            "convrot_groupsize": self.layer_config.convrot_groupsize,
+            "input_act": None,
+        }
+        impl = ck.registry.get_implementation(
+            "int8_linear",
+            backend="cuda",
+            kwargs=kwargs,
+        )
+        self._cuda_impl = impl
+        return impl
+
+    @staticmethod
+    def _run_custom_op(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        weight_scale: torch.Tensor,
+        bias: torch.Tensor | None,
+        output_dtype_code: int,
+        convrot: bool,
+        convrot_groupsize: int,
+    ) -> torch.Tensor:
+        # comfy-kitchen registers a fake implementation for this op, so Dynamo
+        # keeps it opaque instead of tracing into the CUDA backend's DLPack calls.
+        return torch.ops.comfy_kitchen.int8_linear(
+            x,
+            weight,
+            weight_scale,
+            bias,
+            output_dtype_code,
+            convrot,
+            convrot_groupsize,
+            None,
+        )
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if not x.is_cuda:
+            raise RuntimeError(f"{self.prefix} INT8 ConvRot currently requires a CUDA activation tensor.")
+        if x.dtype == torch.bfloat16:
+            dtype_code = 2
+        elif x.dtype == torch.float16:
+            dtype_code = 1
+        else:
+            raise TypeError(f"{self.prefix} INT8 ConvRot supports only FP16/BF16 activations, got {x.dtype}.")
+        # Normal model loading resolves this before regional torch.compile is
+        # installed. Keep the lazy path for direct callers and unusual loaders.
+        if self._cuda_impl is None:
+            self._resolve_cuda_impl(layer, x, bias=bias)
+        return self._run_custom_op(
+            x.contiguous(),
+            layer.weight,
+            layer.weight_scale,
+            bias,
+            dtype_code,
+            self.layer_config.convrot,
+            self.layer_config.convrot_groupsize,
+        )
+
+
+__all__ = [
+    "DiffusionInt8ConvRotConfig",
+    "Int8ConvRotLayerConfig",
+    "Int8ConvRotLinearMethod",
+]


### PR DESCRIPTION
## Purpose

- Fixes https://github.com/vllm-project/vllm-omni/issues/6139.
- Contributes to https://github.com/vllm-project/vllm-omni/issues/5700.
- Add native loading and inference support for the published Comfy-Org MiniMax-H3 pruned W8A8 INT8 ConvRot checkpoint.
- Add checkpoint inspection and fail-closed validation, per-layer quantization metadata, tensor-parallel weight/scale loading, AdaLN low-rank curve support, and the matching ConvRot runtime dispatch.
- Integrate the path with distributed layerwise offload, single-stage AsyncOmni startup, and stage-specific configuration routing.
- Add the optional `int8-convrot` dependency, user documentation, and focused regression coverage.

## Test Plan

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** `be89929001563a882f1f783fb9ee37b4d5a970f4`

### Static and unit validation

- Full pre-commit suite on every changed file: Ruff check/format, mypy, markdownlint, SPDX, forbidden imports, test marks, YAML/TOML, and typos.
- Strict MkDocs build.
- Focused final MiniMax-H3 quantization suite:

  ```bash
  pytest -q tests/diffusion/models/minimax_h3/test_minimax_h3_quantization.py
  ```

- Broader targeted regression coverage for configuration routing, checkpoint inspection, distributed layerwise offload, AsyncOmni stage initialization, and MiniMax-H3 input processing.
- Native A800 CUDA dispatch smoke using `torch.ops.comfy_kitchen.int8_linear` with BF16 CUDA activations.

### End-to-end A/B

Hardware: `2 x NVIDIA A800-SXM4-80GB`.

Software: Python 3.12.11, PyTorch `2.13.0+cu132`, vLLM 0.28.0, Transformers 5.14.1, Diffusers 0.40.0, and comfy-kitchen 0.2.31.

Topology: diffusion TP=2, text-encoder TP=2, DP=1, VAE patch parallel=2, `CUDNN_ATTN`, eager execution, and DLO disabled.

Workload: MiniMax-H3 FL2VA T2VA request, `672x384`, requested duration 4 seconds (107 output frames at 24 fps), 10 inference steps, seed 42.

Prompt:

> A red paper boat floats on calm water at sunset, with gentle synchronized water sounds.

The BF16 arm used the base FL2VA transformer. The INT8 arm changed only the transformer path to the published `minimax_h3_fl2va_pruned_int8_convrot.safetensors` checkpoint and enabled `{"transformer":{"method":"int8_convrot"}}`.

Each arm ran in a separate process with one warm-up request followed by three measured requests in one initialized engine. Initialization and MP4 muxing are excluded from `generation_s`.

## Test Result

- GitHub build, pre-commit, and DCO checks: passed.
- Strict MkDocs build: passed.
- Focused final MiniMax-H3 quantization suite: `33 passed`.
- Broader targeted pytest run: `234 passed`.
- Native A800 CUDA dispatch: finite BF16 output with the expected shape.
- All measured runs produced finite video/audio outputs and shut down without remaining workers.

### Performance

| Transformer | Measured `generation_s` | Median | Sample CV | Primary-worker peak CUDA reserved memory |
|---|---:|---:|---:|---:|
| Base BF16 | 17.854 / 17.909 / 17.972 s | **17.909 s** | 0.33% | 69,766 MiB |
| Published pruned W8A8 INT8 ConvRot | 15.990 / 15.937 / 15.955 s | **15.955 s** | 0.17% | 48,030 MiB |

For this serial-concurrency workload, the published pruned INT8 ConvRot transformer reduced median warm-engine request latency by **10.91%**, equivalent to **1.122x throughput (+12.25%)** at concurrency 1. Reported primary-worker peak CUDA reserved memory fell by **21,736 MiB (31.16%)**. The memory value is from `torch.cuda.max_memory_reserved()` on the primary worker, not the sum across both GPUs.

The three measured requests within each arm produced identical raw frame hashes.

### Output similarity

Both final artifacts contain 107 `672x384` H.264 frames at 24 fps and finite stereo audio (`[1, 2, 142400]`, 32 kHz). Comparing all decoded RGB frames between the BF16 output and the post-QKV-fix INT8 output gives:

- PSNR: **36.95 dB**
- MAE: **2.41 / 255** (`0.00944` normalized)

These are deployment-level results for the base BF16 transformer versus the published **pruned + W8A8 ConvRot** transformer, not a pure quantization ablation. The similarity metrics cover one prompt/seed and conservatively include each MP4's H.264 encode/decode effects.

### Visual A/B

Same prompt, seed, sampling parameters, and execution topology. **Left: base BF16; right: published pruned W8A8 INT8 ConvRot.**


https://github.com/user-attachments/assets/25ec3352-4e7e-4845-aa0f-22f88866e1a5

BEFORE SUBMITTING: read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
