### PR TITLE
[Perf][NPU] Keep the Step-Audio2 HiFT constants on the accelerator

### DIFF
--- a/tests/platforms/npu/test_step_audio2_token2wav.py
+++ b/tests/platforms/npu/test_step_audio2_token2wav.py
@@ -194,3 +194,118 @@ def test_hift_patch_reports_incompatible_layout(monkeypatch: pytest.MonkeyPatch)
 
     with pytest.raises(TypeError, match=r"m_source\.l_sin_gen\._f02sine"):
         module.patch_step_audio2_hift_for_npu(SimpleNamespace())
+
+
+def _upstream_sinegen2_forward(sine_gen, f0: torch.Tensor):
+    """``flashcosyvoice.SineGen2.forward``, verbatim."""
+    fn = torch.multiply(f0, torch.FloatTensor([[range(1, sine_gen.harmonic_num + 2)]]).to(f0.device))
+    sine_waves = sine_gen._f02sine(fn) * sine_gen.sine_amp
+    uv = sine_gen._f02uv(f0)
+    noise_amp = uv * sine_gen.noise_std + (1 - uv) * sine_gen.sine_amp / 3
+    noise = noise_amp * torch.randn_like(sine_waves)
+    sine_waves = sine_waves * uv + noise
+    return sine_waves, uv, noise
+
+
+class _FakeSineGen2(torch.nn.Module):
+    """A SineGen2 stand-in with upstream's arithmetic and no NPU dependency."""
+
+    sampling_rate = 24000
+    upsample_scale = 4
+    flag_for_pulse = False
+    sine_amp = 0.1
+    noise_std = 0.003
+
+    def __init__(self, harmonic_num: int = 7) -> None:
+        super().__init__()
+        self.harmonic_num = harmonic_num
+
+    def _f02uv(self, f0: torch.Tensor) -> torch.Tensor:
+        return (f0 > 0).type(torch.float32)
+
+    def _f02sine(self, f0_values: torch.Tensor) -> torch.Tensor:
+        return _reference_f02sine(self, f0_values)
+
+    def forward(self, f0: torch.Tensor):
+        return _upstream_sinegen2_forward(self, f0)
+
+
+class _FakeHiFT(torch.nn.Module):
+    def __init__(self, harmonic_num: int = 7, window_length: int = 16) -> None:
+        super().__init__()
+        self.conv = torch.nn.Conv1d(1, 1, 1)
+        self.m_source = SimpleNamespace(l_sin_gen=_FakeSineGen2(harmonic_num))
+        # Upstream keeps the window as a plain attribute, not a buffer, which
+        # is exactly why it never follows the module onto the accelerator.
+        self.stft_window = torch.hann_window(window_length)
+
+
+def test_hift_constants_are_resident_and_the_forward_stays_exact(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_patch_module(monkeypatch)
+    hift = _FakeHiFT()
+    sine_gen = hift.m_source.l_sin_gen
+    upstream_forward = sine_gen.forward
+    window = hift.stft_window
+
+    module.patch_step_audio2_hift_for_npu(hift)
+
+    harmonics = sine_gen._npu_resident_harmonics
+    expected_harmonics = torch.FloatTensor([[range(1, sine_gen.harmonic_num + 2)]])
+    torch.testing.assert_close(harmonics, expected_harmonics, rtol=0, atol=0)
+    assert harmonics.dtype is torch.float32
+    assert harmonics.device == next(hift.parameters()).device
+    torch.testing.assert_close(hift.stft_window, window, rtol=0, atol=0)
+    assert hift.stft_window.device == next(hift.parameters()).device
+
+    f0 = torch.rand(1, 32, 1) * 300
+    torch.manual_seed(11)
+    expected = _upstream_sinegen2_forward(sine_gen, f0)
+    torch.manual_seed(11)
+    actual = sine_gen.forward(f0)
+
+    assert sine_gen.forward is not upstream_forward
+    for got, want in zip(actual, expected, strict=True):
+        torch.testing.assert_close(got, want, rtol=0, atol=0)
+
+
+def test_hift_constants_are_repaired_after_a_late_migration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_patch_module(monkeypatch)
+    hift = _FakeHiFT()
+    sine_gen = hift.m_source.l_sin_gen
+    module.patch_step_audio2_hift_for_npu(hift)
+
+    # Whatever a later ``.half()`` or ``.to()`` did to the module, upstream's
+    # multiplier is FP32 on the input's device — so the forward restores that.
+    sine_gen._npu_resident_harmonics = sine_gen._npu_resident_harmonics.to(torch.float64)
+
+    f0 = torch.rand(1, 32, 1) * 300
+    torch.manual_seed(3)
+    expected = _upstream_sinegen2_forward(sine_gen, f0)
+    torch.manual_seed(3)
+    actual = sine_gen.forward(f0)
+
+    assert sine_gen._npu_resident_harmonics.dtype is torch.float32
+    for got, want in zip(actual, expected, strict=True):
+        torch.testing.assert_close(got, want, rtol=0, atol=0)
+
+
+def test_hift_patch_skips_constants_when_the_module_has_no_parameters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_patch_module(monkeypatch)
+
+    class FakeSineGen:
+        flag_for_pulse = False
+        upsample_scale = 4
+
+        def _f02sine(self, f0_values):
+            return f0_values
+
+    hift = SimpleNamespace(m_source=SimpleNamespace(l_sin_gen=FakeSineGen()))
+    module.patch_step_audio2_hift_for_npu(hift)
+
+    assert not hasattr(hift.m_source.l_sin_gen, "_npu_resident_harmonics")

--- a/vllm_omni/platforms/npu/models/step_audio2_token2wav.py
+++ b/vllm_omni/platforms/npu/models/step_audio2_token2wav.py
@@ -6,7 +6,10 @@ Ascend-specific workarounds that must not live in the shared GPU model file:
 
 1. HiFT sine-source downsample — replace the failing 480x ``linear1d``
    downsample with its exact midpoint form while keeping HiFT on NPU.
-2. CosyVoice2 DiT SDPA — force MATH backend (+ DiT attn mask expand) to
+2. HiFT device constants — keep the harmonic multiplier and the STFT window
+   resident on the accelerator instead of copying them up from host memory on
+   every vocoder call.
+3. CosyVoice2 DiT SDPA — force MATH backend (+ DiT attn mask expand) to
    avoid fused FA rejecting CosyVoice ``(B,1,1,S)`` masks (error 161001).
 """
 
@@ -82,6 +85,84 @@ def _f02sine_with_npu_safe_downsample(self, f0_values: torch.Tensor) -> torch.Te
     return torch.sin(phase)
 
 
+def _sinegen2_forward_with_resident_harmonics(
+    self,
+    f0: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """``SineGen2.forward``, reading its harmonic multiplier from the device.
+
+    Identical to upstream in every operation and in the order it draws from
+    the RNG; the only difference is that the multiplier is a tensor that
+    already lives on ``f0``'s device instead of one built on the host and
+    copied up.
+    """
+    multipliers = self._npu_resident_harmonics
+    if multipliers.device != f0.device or multipliers.dtype != torch.float32:
+        # Upstream builds a fresh FP32 tensor on the input device every call,
+        # so honour that invariant if the module is migrated after loading —
+        # without paying for it in steady state.
+        multipliers = multipliers.to(device=f0.device, dtype=torch.float32)
+        self._npu_resident_harmonics = multipliers
+    fn = torch.multiply(f0, multipliers)
+    sine_waves = self._f02sine(fn) * self.sine_amp
+    uv = self._f02uv(f0)
+    noise_amp = uv * self.noise_std + (1 - uv) * self.sine_amp / 3
+    noise = noise_amp * torch.randn_like(sine_waves)
+    sine_waves = sine_waves * uv + noise
+    return sine_waves, uv, noise
+
+
+def _make_hift_constants_resident(hift: torch.nn.Module, sine_gen: torch.nn.Module) -> int:
+    """Materialize HiFT's two immutable tensors once, on the model's device.
+
+    ``SineGen2.forward`` rebuilds ``torch.FloatTensor([[range(1, n + 2)]])`` on
+    the host and copies it to the device on every call, and ``_stft`` /
+    ``_istft`` each run ``self.stft_window.to(x.device)`` — the window is a
+    plain attribute rather than a registered buffer, so it never moved with
+    the module. That is three unpinned host-to-device copies per vocoder call.
+
+    On Ascend an unpinned copy costs far more than its bytes: it drains the
+    device queue, so the price is a pipeline stall on a hot streaming path.
+    Both tensors are constants, so hoisting them is numerically exact.
+
+    Returns the number of constants made resident, for the log line.
+    """
+    parameters = getattr(hift, "parameters", None)
+    if not callable(parameters):
+        return 0
+    parameter = next(parameters(), None)
+    if parameter is None:
+        return 0
+    device = parameter.device
+    resident = 0
+
+    harmonic_num = getattr(sine_gen, "harmonic_num", None)
+    if harmonic_num is not None and all(
+        hasattr(sine_gen, name) for name in ("sine_amp", "noise_std", "_f02uv", "forward")
+    ):
+        # Deliberately a plain attribute, not a registered buffer: a buffer
+        # would follow ``Module.half()`` away from the FP32 tensor upstream
+        # builds explicitly. The replacement forward repairs device and dtype
+        # once if the module is migrated later.
+        sine_gen._npu_resident_harmonics = torch.arange(
+            1,
+            int(harmonic_num) + 2,
+            device=device,
+            dtype=torch.float32,
+        ).view(1, 1, -1)
+        sine_gen._step_audio2_original_forward = sine_gen.forward
+        sine_gen.forward = MethodType(_sinegen2_forward_with_resident_harmonics, sine_gen)
+        resident += 1
+
+    window = getattr(hift, "stft_window", None)
+    if isinstance(window, torch.Tensor):
+        # ``_patched_ensure_models_loaded`` runs this after final placement, so
+        # the window lands on the device the convolutions are already on.
+        hift.stft_window = window.to(device=device)
+        resident += 1
+    return resident
+
+
 def patch_step_audio2_hift_for_npu(hift: torch.nn.Module) -> None:
     """Patch the non-causal Step-Audio2 HiFT implementation for Ascend.
 
@@ -93,6 +174,9 @@ def patch_step_audio2_hift_for_npu(hift: torch.nn.Module) -> None:
     The exact midpoint form keeps the common path on NPU. Unsupported or pulse
     configurations delegate only ``_f02sine`` to CPU, preserving upstream
     behavior without restoring the old whole-HiFT CPU offload.
+
+    It also makes HiFT's two host-built constants resident on the device — see
+    ``_make_hift_constants_resident``. Both are numerically exact.
     """
     if getattr(hift, "_step_audio2_npu_downsample_patched", False):
         return
@@ -108,8 +192,12 @@ def patch_step_audio2_hift_for_npu(hift: torch.nn.Module) -> None:
 
     sine_gen._step_audio2_original_f02sine = original_f02sine
     sine_gen._f02sine = MethodType(_f02sine_with_npu_safe_downsample, sine_gen)
+    resident = _make_hift_constants_resident(hift, sine_gen)
     hift._step_audio2_npu_downsample_patched = True
-    logger.info("Patched Step-Audio2 HiFT linear downsample for Ascend NPU")
+    logger.info(
+        "Patched Step-Audio2 HiFT for Ascend NPU: linear downsample, %d resident constants",
+        resident,
+    )
 
 
 @contextmanager


### PR DESCRIPTION
## Purpose

> Team: **5.6-sol**

`flashcosyvoice`'s HiFT rebuilds two constants from host memory **inside every
vocoder call**:

| where | what | size |
| --- | --- | ---: |
| `SineGen2.forward` | `torch.FloatTensor([[range(1, harmonic_num + 2)]]).to(f0.device)` | 9 floats |
| `HiFTGenerator._stft` | `self.stft_window.to(x.device)` | 16 floats |
| `HiFTGenerator._istft` | `self.stft_window.to(magnitude.device)` | 16 floats |

The window is a plain attribute rather than a registered buffer, so it never
moved with the module and has to be copied up on each call — twice. Three
unpinned host-to-device copies per vocoder call, for tensors that are identical
on every call.

### Why that is not as cheap as it looks

On Ascend an unpinned host-to-device copy is a **synchronization point**, not a
transfer: it cannot begin until the device queue drains, so what it costs is
whatever is in the pipeline in front of it. Sixteen floats, and the calling
thread stops. Measured in place during a ranked run (§2 below) that is 4.4 ms
for the multiplier and 22.1 ms for each window copy.

Most of that is waiting on device work that is real, so it is *not* all saved —
what the change removes is the synchronization itself. The end-to-end effect is
correspondingly modest, and §4 reports it as measured rather than as inferred
from §2.

### It is also a prerequisite for capturing HiFT

A host-to-device copy inside an NPU graph capture is rejected outright (107030),
so as long as these three copies are in the forward, HiFT cannot be captured at
all. This removes that obstacle without asking anyone to capture anything.

### Where it goes

`patch_step_audio2_hift_for_npu` already patches this module for Ascend, at
exactly the right point — `_patched_ensure_models_loaded` calls it after the
model is on its final device. No new seam, no new switch, no environment
variable.

### Exactness

The resident multiplier compares `torch.equal` to the tensor upstream builds,
and so does the window. `_sinegen2_forward_with_resident_harmonics` keeps
upstream's operations **and its RNG order**, so a seeded forward is unchanged;
the CPU tests assert that against a verbatim copy of upstream's
`SineGen2.forward`. The multiplier stays a plain attribute rather than a
registered buffer, because a buffer would follow `Module.half()` away from the
FP32 tensor upstream builds explicitly — the replacement forward repairs device
and dtype once if the module is migrated after loading, and there is a test for
that too. A HiFT that exposes no parameters is left alone.

NPU only; nothing on the CUDA path changes.

## Test Plan

**vLLM Version:** `0.1.dev1+ge5588e49b` (built from `vllm-project/vllm@e5588e49b`)

**vLLM-Omni Commit:** `ecd9d99da` — the base of this branch and of every measured
arm

1. **Unit tests** — `tests/platforms/npu/test_step_audio2_token2wav.py`, 3 new
   pure-CPU cases on top of the file's 12.
2. **What the copies cost, in place** — an instrumented copy of the *untouched
   base*: upstream's `SineGen2.forward`, `_stft` and `_istft` transcribed
   verbatim with `time.perf_counter_ns()` around the three copies and a call
   counter, over one full ranked run.
3. **Per vocoder call** — both arms on one loaded HiFT, alternating, so host load
   and die identity cancel.
4. **End-to-end, paired and die-swapped** — two arms differing only by this diff,
   both on `ecd9d99da`, the baseline deploy config, no environment variables;
   both arms at the same time, one per die, and the round repeated with the dies
   swapped, because this box is shared and its two dies are not equally fast.

```bash
ASCEND_RT_VISIBLE_DEVICES=<die> BENCHMARK_DIR=<out> PYTHONPATH=<tree> \
python3 -m pytest -s -vv tests/dfx/perf/scripts/run_benchmark.py \
  --test-config-file <case>   # Seed-TTS zh, openai-chat-omni, c1, 32 prompts
```

## Test Result

### 1. Unit tests

`tests/platforms/npu/`, same machine, same interpreter:

| tree | result |
| --- | --- |
| `ecd9d99da` | 24 passed, 1 skipped |
| this branch | **27 passed**, 1 skipped |

### 2. What the copies cost, measured in place (Atlas A3 / 910C)

One ranked run on the instrumented base — 32 requests, RTF 0.4619, mean e2el
1930 ms:

| copy | calls | per call |
| --- | ---: | ---: |
| `SineGen2` harmonic multiplier | 160 | **4.42 ms** |
| `stft_window`, `_stft` + `_istft` | 320 | **22.11 ms** |

160 / 32 = **5 vocoder calls per request**, and exactly two window copies per
call, which is what the code says. These are host **blocking** times — the
thread is waiting on device work in front of the copy — so read them as "the
Code2Wav thread stops here three times per chunk", not as saved wall clock.

Put next to a timer around the whole vocoder call in the same configuration, they
decompose it:

| | per vocoder call |
| --- | ---: |
| whole call, timed in situ on the base | 66.44 ms |
| — blocked at the three copies (4.42 + 2 × 22.11) | **48.64 ms** |
| — everything else HiFT does | 17.80 ms |

and that 17.80 ms remainder lands within 2% of the 18.16 ms the same arm
measures on an idle device in §3, which is the check that says the decomposition
is real. **Three quarters of the wall time of a vocoder call is the thread
waiting at a copy of nine and sixteen floats.**

### 3. Per vocoder call, one process, arms alternating

| arm | per call | samples |
| --- | ---: | --- |
| upstream | 16.006 ms | 16.002 15.990 16.006 16.445 16.052 |
| resident (this PR) | **15.696 ms** | 15.740 15.696 15.768 15.639 15.637 |
| | **−0.310 ms, −1.9%** | no overlap |

This is a **lower bound**: the harness synchronizes before each timed call, so
the queue is shallow and the stall the copies cause is mostly not there to
remove. Priced on their own behind four queued vocoder calls, the three copies
are 77.6 µs + 2 × 44.7 µs; on an idle queue, 39.2 µs + 2 × 25.6 µs.

### 4. Numerically unchanged

`multiplier_bit_identical: true`, `window_bit_identical: true` (`torch.equal`).
On the waveform:

| | max abs diff |
| --- | ---: |
| same arm, same seed, twice (the device's own noise floor) | 5.51e-4 |
| upstream vs resident, same seed | **4.28e-4** |
| waveform peak amplitude | 0.284 |

The difference between the arms is smaller than the difference between two runs
of the same arm. The CPU tests assert exactness directly.

### 5. End-to-end, ranked configuration

| round | arm | die | RTF | e2el | completed | tokens | audio |
| --- | --- | --- | ---: | ---: | --- | ---: | ---: |
| 1 | ctl | 1 | 0.46532 | 1951.5 | 32/32 | 435 | 135.64 s |
| 1 | this PR | 0 | 0.46141 | 1934.7 | 32/32 | 435 | 135.64 s |
| | | | **−0.84%** | | | | |
| 2 | ctl | 0 | 0.46098 | 1930.1 | 32/32 | 435 | 135.64 s |
| 2 | this PR | 1 | 0.45924 | 1923.4 | 32/32 | 435 | 135.64 s |
| | | | **−0.38%** | | | | |

Negative under **both** die assignments, averaging −0.6%. I would not claim more
than that from two rounds on a shared box — two identical arms have measured
1.35% apart on these dies — but the sign holding across the swap is the strongest
statement this hardware supports for an effect of this size, and it is on the
same side as §2 and §3. All four arms: 32/32 completed, 435 output tokens,
135.64 s of audio.

**Why −0.6% and not more, given §2.** The three copies block the Code2Wav thread
for 243 ms per request, but that is time spent waiting on device work that still
has to happen; and on this base stage 2 runs *behind* the Talker, so the thread
usually has nothing to do with the time it gets back — it would be waiting for
the next codec chunk anyway. What the change buys grows with how much of the
critical path stage 2 owns, which is exactly what the other open performance PRs
on this branch are changing. The measurements that should carry this PR are §2
and §3.
