### PR TITLE
[Bugfix][MiniCPM-o] Let the thinker stream when the client asked for a stream

### DIFF
--- a/tests/entrypoints/openai_api/test_serving_chat_stage0_output_kind.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_stage0_output_kind.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Which output kind each MiniCPM-o 4.5 stage gets on an audio chat stream.
+
+A client that asked for ``stream=true`` should get a stream. Stage 0's kind also
+decides what TTFT measures: under ``FINAL_ONLY`` the stage emits exactly one
+output, at the end, so ``serving_time_to_first_output_ms`` -- the age of a
+stage's first non-empty output -- reports the time to the thinker's *last*
+token.
+
+See ``OmniOpenAIServingChat._fix_minicpmo45_audio_stream_output_kinds``.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from vllm.sampling_params import RequestOutputKind, SamplingParams
+
+from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+_ARCH = "MiniCPMO45OmniForConditionalGeneration"
+
+
+def _stage(model_stage: str, arch: str = _ARCH):
+    return SimpleNamespace(engine_args=SimpleNamespace(model_arch=arch, model_stage=model_stage))
+
+
+def _service(stages):
+    service = OmniOpenAIServingChat.__new__(OmniOpenAIServingChat)
+    service.engine_client = SimpleNamespace(stage_configs=stages)
+    return service
+
+
+def _params(n: int = 3):
+    return [SamplingParams(max_tokens=8) for _ in range(n)]
+
+
+def _fix(service, params, modalities=("text", "audio"), request=None):
+    return service._fix_minicpmo45_audio_stream_output_kinds(params, modalities, request)
+
+
+@pytest.fixture
+def service():
+    return _service([_stage("llm"), _stage("tts"), _stage("token2wav")])
+
+
+def test_thinker_streams_on_a_simplex_audio_request(service) -> None:
+    params = _params()
+
+    _fix(service, params)
+
+    assert params[0].output_kind == RequestOutputKind.DELTA
+    # The talker streams either way -- that half was never in question.
+    assert params[1].output_kind == RequestOutputKind.DELTA
+
+
+def test_duplex_session_keeps_the_thinker_final_only(service) -> None:
+    # A duplex response is a streaming session: the orchestrator forwards stage 0
+    # on segment boundaries and derives `is_final_update` from this output kind.
+    params = _params()
+
+    _fix(service, params, request=SimpleNamespace(omni_duplex_session=True))
+
+    assert params[0].output_kind == RequestOutputKind.FINAL_ONLY
+    assert params[1].output_kind == RequestOutputKind.DELTA
+
+
+def test_a_request_without_the_duplex_marker_still_streams(service) -> None:
+    params = _params()
+
+    _fix(service, params, request=SimpleNamespace())
+
+    assert params[0].output_kind == RequestOutputKind.DELTA
+
+
+def test_text_only_request_is_untouched(service) -> None:
+    params = _params()
+    before = [p.output_kind for p in params]
+
+    _fix(service, params, modalities=("text",))
+
+    assert [p.output_kind for p in params] == before
+
+
+def test_other_architectures_are_untouched() -> None:
+    service = _service([_stage("llm", arch="Qwen3OmniMoeForConditionalGeneration")])
+    params = _params(1)
+    before = [p.output_kind for p in params]
+
+    _fix(service, params)
+
+    assert [p.output_kind for p in params] == before

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -207,23 +207,41 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         self,
         sampling_params_list: list[Any],
         output_modalities: list[str] | tuple[str, ...] | None,
+        request: Any = None,
     ) -> list[Any]:
-        """Keep MiniCPM-o 4.5's thinker final-only during audio streaming.
+        """Set each MiniCPM-o 4.5 stage's output kind for an audio chat stream.
 
-        Chat ``stream=true`` normally coerces every AR stage to DELTA output.
-        That is correct for token-level text streaming, but MiniCPM-o 4.5's
-        Talker consumes the completed TTS span plus aligned thinker hidden
-        states. If Stage0 is DELTA, llm2tts receives one generated token at a
-        time and repeatedly starts tiny, independent TTS streams. The API then
-        never represents one coherent audio response.
+        The Talker streams; that half was never in question. The thinker used to
+        be forced to ``FINAL_ONLY`` here too, on the grounds that a DELTA thinker
+        would make ``llm2tts`` receive one generated token at a time and start a
+        tiny independent TTS stream per token. On a simplex request that does not
+        happen:
 
-        For this model, stream the audio stage, not the thinker-to-talker
-        boundary.
+        * The orchestrator forwards stage 0 to stage 1 only once the stage-0
+          request is **finished** -- ``_route_output``'s gate is
+          ``finished or (streaming.enabled and segment_finished)``, and
+          ``streaming.enabled`` describes a streaming *input* session, not
+          ``stream=true``. A per-token delta never reaches the bridge.
+        * ``llm2tts`` already reads ``cumulative_token_ids``, precisely because
+          "DELTA outputs carry only the newest tokens, while the forwarded hidden
+          states span prompt + whole reply".
+
+        Meanwhile the client asked for a stream and got one response at the end,
+        which is the contract this restores. It also fixes what TTFT reports:
+        ``serving_time_to_first_output_ms`` is the age of a stage's first
+        *non-empty* output, so under ``FINAL_ONLY`` it timed the thinker's last
+        token rather than its first.
+
+        Duplex sessions keep ``FINAL_ONLY``. There ``streaming.enabled`` is true,
+        the orchestrator forwards on segment boundaries, and it derives
+        ``is_final_update`` from this very output kind.
         """
         if not output_modalities or "audio" not in output_modalities:
             return sampling_params_list
         if not self._has_minicpmo45_stage():
             return sampling_params_list
+
+        duplex_session = bool(getattr(request, "omni_duplex_session", False))
 
         stage_configs = getattr(self.engine_client, "stage_configs", []) or []
         for idx, stage in enumerate(stage_configs):
@@ -239,7 +257,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
 
             model_stage = self._stage_get(engine_args, "model_stage")
             if model_stage == "llm":
-                sp.output_kind = RequestOutputKind.FINAL_ONLY
+                sp.output_kind = RequestOutputKind.FINAL_ONLY if duplex_session else RequestOutputKind.DELTA
             elif model_stage == "tts":
                 sp.output_kind = RequestOutputKind.DELTA
         return sampling_params_list
@@ -666,6 +684,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     sampling_params_list = self._fix_minicpmo45_audio_stream_output_kinds(
                         sampling_params_list,
                         output_modalities,
+                        request,
                     )
 
                 # Apply user-specified overrides to diffusion stage(s) for image generation

--- a/vllm_omni/experimental/fullduplex/openai/chat_fallback.py
+++ b/vllm_omni/experimental/fullduplex/openai/chat_fallback.py
@@ -108,6 +108,11 @@ class ChatFallbackProjectorMixin:
             kwargs["tool_choice"] = tool_choice
 
         request = ChatCompletionRequest(**kwargs)
+        # A duplex response runs as a streaming session: the orchestrator
+        # forwards stage 0 on segment boundaries and derives `is_final_update`
+        # from stage 0's output kind, so this path keeps the thinker
+        # final-only. See `_fix_minicpmo45_audio_stream_output_kinds`.
+        object.__setattr__(request, "omni_duplex_session", True)
         object.__setattr__(request, "modalities", response_config.modalities)
         object.__setattr__(request, "request_id", request_id)
         object.__setattr__(


### PR DESCRIPTION
## Purpose

> Team: **5.6-sol**

`OmniOpenAIServingChat._fix_minicpmo45_audio_stream_output_kinds` forces
MiniCPM-o 4.5's thinker (stage 0) to `FINAL_ONLY` whenever `audio` is among the
output modalities — including on an ordinary `stream=true` chat request. The
stage then emits exactly one output, at the very end, so a client that asked for
a stream gets the whole reply in one piece once the model has finished.

### The reason given for the coercion does not hold on this path

The docstring says a DELTA thinker would make `llm2tts` receive one generated
token at a time and start a tiny independent TTS stream per token. On a simplex
request neither half happens:

- The orchestrator forwards stage 0 to stage 1 only once the stage-0 request is
  **finished**. `_route_output`'s gate is
  `finished or (streaming.enabled and segment_finished)`, and `streaming.enabled`
  describes a streaming **input** session, not `stream=true`. A per-token delta
  never reaches the bridge.
- `llm2tts` already reads `cumulative_token_ids`, for the reason its own comment
  gives: *"DELTA outputs carry only the newest tokens, while the forwarded hidden
  states span prompt + whole reply."*

So the audio path is indifferent to stage 0's output kind on a simplex request,
and the only thing `FINAL_ONLY` changes is what the client — and the metrics —
see.

### It also fixes what TTFT reports

`serving_time_to_first_output_ms` is the age of a stage's **first non-empty**
output (`stage_pool.build_stage_metrics`). Under `FINAL_ONLY` stage 0 has exactly
one non-empty output, its last, so the reported TTFT was the time to the
thinker's *final* token rather than its first.

### Duplex keeps `FINAL_ONLY`

There `streaming.enabled` is true, the orchestrator forwards on segment
boundaries, and it derives `is_final_update` from this very output kind — a
different contract. The duplex chat fallback now marks the request it builds
(`omni_duplex_session`) instead of leaving that to be inferred, and a request
without the marker streams.

## Test Plan

**vLLM Version:** `0.1.dev1+ge5588e49b` (built from `vllm-project/vllm@e5588e49b`)

**vLLM-Omni Commit:** `ecd9d99da`

### 1. Unit tests

`tests/entrypoints/openai_api/test_serving_chat_stage0_output_kind.py` (new),
5 pure-CPU cases: a simplex audio request streams the thinker and the talker; a
duplex session keeps the thinker final-only; a request without the duplex marker
streams; a text-only request is untouched; another architecture is untouched.

### 2. The duplex path is unchanged

`tests/entrypoints/openai_api/test_duplex_handler.py` — the only test file that
exercises `ChatFallbackProjectorMixin` — run on the base and on this branch.

### 3. What the client actually receives

One server per arm, one per die, same prompt, `stream=true` with
`modalities: ["text", "audio"]`; every SSE event recorded with its arrival time.

## Test Result

### 1. Unit tests

5 passed.

### 2. Duplex path

| tree | `test_duplex_handler.py` |
| --- | --- |
| `ecd9d99da` | 198 passed |
| this branch | 198 passed |

### 3. What the client receives

One server per arm, one per die, the same 31-character Chinese prompt, `stream=true`
with `modalities: ["text", "audio"]`. Every SSE event, with the time since the
request was sent:

| | `ecd9d99da` | this branch |
| --- | --- | --- |
| text events | **1** | **20** |
| first text | **604.2 ms** | **209.9 ms** |
| last text | 604.2 ms | 559.6 ms |
| audio chunks | 6 | 6 |
| base64 lengths | 53820, 64060 x4, 56380 | 53820, 64060 x4, 56380 |

On the base the entire reply arrives in one 31-character event. On this branch it
arrives as twenty deltas — `今天` / `天气` / `不错` / `，` / … — which is what the
client asked for:

```
ecd9d99da                       this branch
   604.2 ms  31 chars              209.9 ms   2 chars  今天
                                   234.6 ms   2 chars  天气
                                   250.8 ms   2 chars  不错
                                   270.4 ms   1 char   ，
                                       ...
                                   559.6 ms   1 char   。
```

**The audio is untouched**: the same six chunks, with byte-identical base64
lengths in both arms. The two arms ran on different dies, so the absolute times
are not comparable to each other beyond the shape — but "one event" versus
"twenty" is not a timing artefact.
