### PR TITLE
[Misc][MiniCPM-o] Let a deploy config set Token2Wav's guidance weight

### DIFF
--- a/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
@@ -10,6 +10,7 @@ from vllm_omni.model_executor.models.minicpmo_4_5.batched_token2wav import (
 )
 from vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_code2wav import (
     MiniCPMO45Code2Wav,
+    apply_token2wav_cfg_rate,
 )
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
@@ -744,3 +745,24 @@ def test_reference_voice_and_duplex_metadata_follow_request_lifecycle():
     assert prompt_key not in model._runtime_prompts
     assert not Path(prompt_wav).exists()
     assert (prompt_cache_id, prompt_wav) not in model.backend._prompt_features
+
+
+def test_cfg_rate_override_reaches_the_flow_decoder() -> None:
+    token2wav = SimpleNamespace(flow=SimpleNamespace(decoder=SimpleNamespace(inference_cfg_rate=0.7)))
+
+    assert apply_token2wav_cfg_rate(token2wav, "0.3") == pytest.approx(0.3)
+    assert token2wav.flow.decoder.inference_cfg_rate == pytest.approx(0.3)
+
+
+@pytest.mark.parametrize(
+    "token2wav",
+    [
+        SimpleNamespace(),
+        SimpleNamespace(flow=SimpleNamespace()),
+        SimpleNamespace(flow=SimpleNamespace(decoder=SimpleNamespace())),
+    ],
+)
+def test_cfg_rate_override_refuses_to_pass_silently(token2wav) -> None:
+    # A configuration key that quietly does nothing is worse than a startup error.
+    with pytest.raises(ValueError, match="inference_cfg_rate"):
+        apply_token2wav_cfg_rate(token2wav, 0.3)

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
@@ -30,6 +30,29 @@ from .batched_token2wav import (
 logger = init_logger(__name__)
 
 
+def apply_token2wav_cfg_rate(token2wav: Any, cfg_rate: Any) -> float:
+    """Override the flow decoder's classifier-free guidance weight.
+
+    ``inference_cfg_rate`` ships in the checkpoint and is the one Token2Wav
+    constant that has to be re-derived whenever ``token2wav_n_timesteps``
+    changes: guidance is applied once per solver step, so a weight chosen for
+    one schedule is not the right weight for another. There is no way to reach
+    it from a deploy config today, which makes the pair impossible to sweep
+    together without patching the tree.
+
+    Raises rather than warning if the decoder has no such attribute: a
+    configuration key that silently does nothing is worse than a startup error.
+    """
+    decoder = getattr(getattr(token2wav, "flow", None), "decoder", None)
+    if decoder is None or not hasattr(decoder, "inference_cfg_rate"):
+        raise ValueError(
+            "token2wav_cfg_rate was set, but this Token2Wav's flow decoder exposes no inference_cfg_rate to override"
+        )
+    value = float(cfg_rate)
+    decoder.inference_cfg_rate = value
+    return value
+
+
 def _batch_error(reason: str, **details: Any) -> RuntimeError:
     payload = {"reason": reason, **details}
     return RuntimeError(f"MiniCPMO45Code2WavBatchError {json.dumps(payload, sort_keys=True)}")
@@ -775,4 +798,10 @@ class MiniCPMO45Code2Wav(nn.Module):
             )
         finally:
             torch.set_default_dtype(previous_dtype)
+        cfg_rate = extra.get("token2wav_cfg_rate")
+        if cfg_rate is not None:
+            logger.info(
+                "Token2wav inference_cfg_rate overridden to %s",
+                apply_token2wav_cfg_rate(token2wav, cfg_rate),
+            )
         self.backend = BatchedToken2Wav(token2wav)


### PR DESCRIPTION
## Purpose

> Team: **5.6-sol**

A MiniCPM-o 4.5 Code2Wav stage can set `token2wav_n_timesteps` from its `extra`
config. It cannot set `inference_cfg_rate` at all — and that is the one Token2Wav
constant that has to move *with* the step count.

Classifier-free guidance is applied **once per solver step**, so the weight that
suits one schedule is not the weight that suits another. There are four open PRs
on this branch changing `token2wav_n_timesteps` right now (#6465, #6386, #6589,
#6616) and none of them can sweep the pair without patching the tree, because the
value only exists inside the checkpoint.

This adds `token2wav_cfg_rate` next to it:

```yaml
extra:
  token2wav_n_timesteps: 3
  token2wav_cfg_rate: 0.3
```

**The default is unset**, so nothing changes for anyone who does not ask for it —
the checkpoint's own value is used exactly as before. There is no runtime cost
either way: CFG is `torch.cat((x, x), dim=0)`, which widens each kernel rather
than adding any, so only the weight moves.

`apply_token2wav_cfg_rate` **raises** if the flow decoder exposes no
`inference_cfg_rate`, rather than warning and carrying on. A configuration key
that silently does nothing is worse than a startup error, and this one would be
silent in exactly the situation where somebody is trying to measure its effect.

The measured reason this matters — a sweep on 300 Seed-TTS zh rows where 0.3
improves UTMOS, CER and SIM simultaneously at one flow step — is in #6907. This PR deliberately carries **no default change**; picking a
value is a per-schedule decision and belongs with whoever picks the schedule.

## Test Plan

**vLLM Version:** `0.1.dev1+ge5588e49b` (built from `vllm-project/vllm@e5588e49b`)

**vLLM-Omni Commit:** `ecd9d99da`

`tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py`, 4 new
pure-CPU cases: the override reaches `flow.decoder.inference_cfg_rate` and
accepts a string; and it raises rather than passing silently for each of the
three ways the decoder can be missing.

## Test Result

`tests/model_executor/models/minicpmo_4_5/`, same machine, same interpreter:

| tree | result |
| --- | --- |
| `ecd9d99da` | 91 passed, 3 skipped, 13 errors |
| this branch | **95 passed**, 3 skipped, 13 errors |

The 13 errors are on the base too — this box has no `pytest-mock`.
