### PR TITLE
[Bugfix][JoyVL] Close all delegation bridges on failure

### DIFF
--- a/tests/e2e/features/fullduplex/test_joyvl_policy.py
+++ b/tests/e2e/features/fullduplex/test_joyvl_policy.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 import asyncio
 
@@ -10,6 +10,7 @@ from vllm_omni.experimental.fullduplex.joyvl.bridges.delegation import (
     ImageEditDelegationBridge,
     ImageGenDelegationBridge,
     OpenAIDelegationBridge,
+    RoutingDelegationBridge,
 )
 from vllm_omni.experimental.fullduplex.joyvl.decision.policy import JoyVLPolicy, sample_frames
 
@@ -185,6 +186,37 @@ async def test_routing_delegation_dispatches_by_request():
     assert await route("把你看到的画面变成卡通风格") == "edit"  # restyle current view
     assert await route("画一只红色的龙") == "image"  # generate a new image
     assert await route("这道数学题的答案是什么") == "chat"  # hard question -> chat brain
+
+
+@pytest.mark.asyncio
+async def test_routing_delegation_aclose_attempts_all_bridges_and_raises_first_error():
+    events: list[str] = []
+    first_error = RuntimeError("chat close failed")
+    second_error = RuntimeError("edit close failed")
+
+    class _CloseBridge:
+        def __init__(self, name, error=None):
+            self.name = name
+            self.error = error
+
+        async def aclose(self):
+            assert not router._route
+            events.append(self.name)
+            if self.error is not None:
+                raise self.error
+
+    chat = _CloseBridge("chat", first_error)
+    image = _CloseBridge("image")
+    edit = _CloseBridge("edit", second_error)
+    router = RoutingDelegationBridge(chat=chat, image=image, edit=edit)
+    router._route["pending"] = (chat, "inner")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await router.aclose()
+
+    assert router._route == {}
+    assert events == ["chat", "image", "edit"]
+    assert exc_info.value is first_error
 
 
 class _Delegation:

--- a/vllm_omni/experimental/fullduplex/joyvl/bridges/delegation.py
+++ b/vllm_omni/experimental/fullduplex/joyvl/bridges/delegation.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from __future__ import annotations
 
@@ -146,7 +146,7 @@ class OpenAIDelegationBridge:
             content.append({"type": "text", "text": f"<{time_range}>"})
             content.append({"type": "image_url", "image_url": {"url": data_url}})
         content.append({"type": "text", "text": question or note or "Answer the user's question."})
-        messages = [
+        messages: list[dict[str, Any]] = [
             {"role": "system", "content": self._system_prompt},
             {"role": "user", "content": content},
         ]
@@ -384,6 +384,13 @@ class RoutingDelegationBridge:
 
     async def aclose(self) -> None:
         self._route.clear()
+        first_error: Exception | None = None
         for bridge in (self._chat, self._image, self._edit):
             if bridge is not None:
-                await bridge.aclose()
+                try:
+                    await bridge.aclose()
+                except Exception as exc:  # noqa: BLE001 - close every owned bridge before propagating
+                    if first_error is None:
+                        first_error = exc
+        if first_error is not None:
+            raise first_error


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

### What broke

`RoutingDelegationBridge.aclose()` stopped at the first sub-bridge cleanup failure. If one bridge raised while closing, the remaining owned bridges never received `aclose()`, so their pending background tasks could survive server shutdown.

### Reproduction

Run the deterministic CPU regression test:

```bash
CUDA_VISIBLE_DEVICES="" pytest -q \
  tests/e2e/features/fullduplex/test_joyvl_policy.py::test_routing_delegation_aclose_attempts_all_bridges_and_raises_first_error
```

Before this fix, only the first bridge is closed and the test fails with `events == ["chat"]`. With this fix, all three configured bridges are closed in order and the original cleanup exception is preserved.

### Root cause

The cleanup loop awaited each bridge directly. An exception from any `aclose()` immediately unwound the routing bridge cleanup and skipped every later bridge.

### Fix

- Attempt cleanup for every configured chat, image, and edit bridge after an ordinary cleanup error.
- Preserve and re-raise the first exception after all cleanup attempts, so secondary failures do not hide the original cause.
- Add CPU regression coverage for routing-state cleanup, close order, and first-error identity.

## Test Plan

```bash
CUDA_VISIBLE_DEVICES="" pytest -q \
  tests/e2e/features/fullduplex/test_joyvl_policy.py \
  -m "core_model and cpu"

pre-commit run --files \
  tests/e2e/features/fullduplex/test_joyvl_policy.py \
  vllm_omni/experimental/fullduplex/joyvl/bridges/delegation.py
```

**vLLM Version:** N/A; this is CPU-only lifecycle logic and does not load a model.

**vLLM-Omni Commit:** `e2b83db6`

## Test Result

- Full JoyVL policy test module: 18 passed.
- Fault-injection comparison: main stopped after the first close; this branch attempted chat, image, and edit cleanup and re-raised the same first exception object.
- All applicable changed-file pre-commit hooks passed, including Ruff, format, mypy 3.10, test marks, SPDX, forbidden imports, and direct `torch.cuda` checks.
- No GPU or model weights required.
