### PR TITLE
[Bugfix] Seed-TTS UTMOS: retarget baked CUDA constants and restore int16-scale input

### DIFF
--- a/tests/benchmarks/test_seed_tts_utmos.py
+++ b/tests/benchmarks/test_seed_tts_utmos.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""Tests for the Seed-TTS UTMOS scorer.
+
+Two things make the published ``balacoon/utmos`` TorchScript archive unusable as
+shipped: it was traced on CUDA and hard-codes ``cuda:0`` inside its methods, and
+it normalizes its input by 32768 (it wants int16-valued samples) while the WER
+pipeline hands it a ``[-1, 1]`` array.  Both are checked here on CPU only —
+no CUDA, no NPU, and no network access to Hugging Face.
+
+vllm stubs are installed by tests/benchmarks/conftest.py before collection.
+"""
+
+from __future__ import annotations
+
+import io
+
+import numpy as np
+import pytest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+torch = pytest.importorskip("torch")
+
+
+def _round_trip(module: torch.nn.Module) -> torch.jit.ScriptModule:
+    """Script, serialize and reload — the shape a downloaded archive arrives in."""
+    buffer = io.BytesIO()
+    torch.jit.save(torch.jit.script(module), buffer)
+    buffer.seek(0)
+    return torch.jit.load(buffer, map_location="cpu")
+
+
+class _TracedOnCuda(torch.nn.Module):
+    """Mimics the archive's root ``forward``: cast to cuda, then normalize."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        moved = x.to(torch.device("cuda:0"))
+        return torch.mean(torch.div(moved, 32768.0)).reshape(1)
+
+
+class _Inner(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x.to(torch.device("cuda:0"))
+
+
+class _Outer(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.inner = _Inner()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.mean(self.inner(x)).reshape(1)
+
+
+class _NoNormalization(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.mean(x).reshape(1)
+
+
+class _NormalizesByTwo(torch.nn.Module):
+    """A hypothetical custom export: it normalizes, but not by the int16 factor."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.mean(torch.div(x, 2.0)).reshape(1)
+
+
+@pytest.mark.skipif(
+    torch.cuda.is_available(),
+    reason="the baked cuda:0 constant resolves on a CUDA build; the defect is a no-CUDA one",
+)
+def test_the_archive_as_shipped_is_unusable_without_cuda():
+    """A fresh instance, never retargeted: this is what the loader returns today.
+
+    ``balacoon/utmos`` itself raises ``NotImplementedError`` here (verified on an
+    Ascend build), and that is a ``RuntimeError`` subclass; a locally scripted
+    stand-in surfaces the same failed ``aten::to`` as the interpreter's plain
+    ``RuntimeError``. Matching on the device name is what pins the cause.
+    """
+    model = _round_trip(_TracedOnCuda())
+    with pytest.raises(RuntimeError, match="cuda"):
+        model(torch.zeros(1, 16))
+
+
+def test_retargeting_makes_it_run_on_the_loaded_device():
+    from vllm_omni.benchmarks.data_modules import seed_tts_eval
+
+    # A separate instance on purpose: TorchScript caches an execution plan on the
+    # first call, so the rewrite has to happen before the module is ever run --
+    # which is what ``_ensure_utmos_jit_model`` does.
+    model = _round_trip(_TracedOnCuda())
+    assert seed_tts_eval._utmos_retarget_device_constants(model, "cpu") == 1
+    assert float(model(torch.zeros(1, 16)).item()) == 0.0
+
+
+def test_retarget_reaches_nested_submodules():
+    from vllm_omni.benchmarks.data_modules import seed_tts_eval
+
+    model = _round_trip(_Outer())
+    assert seed_tts_eval._utmos_retarget_device_constants(model, "cpu") == 1
+    assert float(model(torch.ones(1, 4)).item()) == pytest.approx(1.0)
+
+
+def test_retarget_is_a_noop_when_the_graph_already_names_the_target():
+    from vllm_omni.benchmarks.data_modules import seed_tts_eval
+
+    model = _round_trip(_TracedOnCuda())
+    assert seed_tts_eval._utmos_retarget_device_constants(model, "cuda:0") == 0
+
+
+def test_resolve_device_uses_the_documented_env_var(monkeypatch):
+    from vllm_omni.benchmarks.data_modules import seed_tts_eval
+
+    monkeypatch.setenv("SEED_TTS_UTMOS_DEVICE", "cuda:1")
+    assert seed_tts_eval._utmos_resolve_device(torch) == "cuda:1"
+
+
+def test_resolve_device_falls_back_to_cpu_without_cuda(monkeypatch):
+    from vllm_omni.benchmarks.data_modules import seed_tts_eval
+
+    monkeypatch.delenv("SEED_TTS_UTMOS_DEVICE", raising=False)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    assert seed_tts_eval._utmos_resolve_device(torch) == "cpu"
+
+
+def test_input_scale_is_read_off_the_graph():
+    from vllm_omni.benchmarks.data_modules import seed_tts_eval
+
+    model = _round_trip(_TracedOnCuda())
+    assert seed_tts_eval._utmos_detect_input_scale(model) == pytest.approx(32768.0)
+
+
+def test_input_scale_ignores_an_export_that_normalizes_by_something_else():
+    """A custom ``SEED_TTS_UTMOS_HF_REPO`` graph must not be silently rescaled."""
+    from vllm_omni.benchmarks.data_modules import seed_tts_eval
+
+    model = _round_trip(_NormalizesByTwo())
+    assert seed_tts_eval._utmos_detect_input_scale(model) == pytest.approx(1.0)
+
+
+def test_input_scale_is_one_when_the_export_does_not_normalize():
+    from vllm_omni.benchmarks.data_modules import seed_tts_eval
+
+    model = _round_trip(_NoNormalization())
+    assert seed_tts_eval._utmos_detect_input_scale(model) == pytest.approx(1.0)
+
+
+def test_predict_hands_the_model_the_amplitude_it_normalizes_by(monkeypatch):
+    """With the scale applied, the export sees the waveform, not 1/32768 of it."""
+    from vllm_omni.benchmarks.data_modules import seed_tts_eval
+
+    model = _round_trip(_TracedOnCuda())
+    seed_tts_eval._utmos_retarget_device_constants(model, "cpu")
+    scale = seed_tts_eval._utmos_detect_input_scale(model)
+    monkeypatch.setattr(seed_tts_eval, "_ensure_utmos_jit_model", lambda: model)
+    monkeypatch.setattr(seed_tts_eval, "_utmos_jit_input_scale", scale)
+
+    rng = np.random.default_rng(0)
+    wav = rng.uniform(-1.0, 1.0, size=16000).astype(np.float32)
+
+    got = seed_tts_eval._utmos_predict_f32_16k(wav)
+    assert got == pytest.approx(float(np.mean(wav)), abs=1e-6)
+
+    # Without the scale the model is fed a waveform 32768x too quiet.
+    monkeypatch.setattr(seed_tts_eval, "_utmos_jit_input_scale", 1.0)
+    attenuated = seed_tts_eval._utmos_predict_f32_16k(wav)
+    assert attenuated == pytest.approx(float(np.mean(wav)) / scale, abs=1e-9)
+
+
+def test_predict_returns_none_when_the_archive_is_unavailable(monkeypatch):
+    from vllm_omni.benchmarks.data_modules import seed_tts_eval
+
+    monkeypatch.setattr(seed_tts_eval, "_ensure_utmos_jit_model", lambda: None)
+    assert seed_tts_eval._utmos_predict_f32_16k(np.zeros(16, dtype=np.float32)) is None

--- a/vllm_omni/benchmarks/data_modules/seed_tts_eval.py
+++ b/vllm_omni/benchmarks/data_modules/seed_tts_eval.py
@@ -22,13 +22,19 @@ https://github.com/zhaochenyang20/seed-tts-eval):
   (Sarulab-style demo export). Uses ``torch`` + ``huggingface_hub`` only. Aggregate metrics
   are over **all requests with captured PCM** (independent of ASR/WER). Non-finite scores are
   dropped and counted as failures. Override repo/file via ``SEED_TTS_UTMOS_HF_REPO`` /
-  ``SEED_TTS_UTMOS_JIT_FILE``. **Device**: defaults to **CPU** when ``SEED_TTS_UTMOS_DEVICE``
-  is unset; set ``SEED_TTS_UTMOS_DEVICE=cuda:0`` (or ``cuda:1`` etc.) to run on GPU. The JIT
-  model is loaded directly onto the target device via ``map_location`` to avoid cross-device
-  issues (some PyTorch builds/Windows have problems moving TorchScript modules after load).
-  Forward uses **float32** waveform in ``[-1, 1]`` (same as the WER resampled array) so
-  tensor dtypes match JIT weights; using int16 triggers
-  ``RuntimeError: input type and weight type should be same`` on common exports. Disable
+  ``SEED_TTS_UTMOS_JIT_FILE``. **Device**: ``SEED_TTS_UTMOS_DEVICE`` selects it; when unset,
+  ``cuda:0`` if CUDA is available and ``cpu`` otherwise. The JIT model is loaded directly onto
+  the target device via ``map_location`` (some PyTorch builds/Windows have problems moving
+  TorchScript modules after load), and device constants **baked into the traced graph** are
+  retargeted to match: the published ``balacoon/utmos`` archive was traced on CUDA and
+  hard-codes ``cuda:0`` in 14 places, which otherwise makes it unusable on any build without
+  CUDA. Forward uses a **float32** waveform rescaled to the amplitude the export expects —
+  these archives normalize internally (``balacoon`` divides by 32768, i.e. it wants
+  int16-valued samples), so the ``[-1, 1]`` array the WER path produces must be scaled back
+  up or the model sees near-silence and returns the same MOS for every input. Only that
+  divisor is recognised, so an export that normalizes differently is fed unchanged. The
+  tensor stays float32; passing an int16 *tensor* would still trigger
+  ``RuntimeError: input type and weight type should be same``. Disable
   with ``SEED_TTS_UTMOS_EVAL=0``.
 
 Enable with ``SEED_TTS_WER_EVAL=1`` or ``--seed-tts-wer-eval``. Install optional deps::
@@ -81,6 +87,10 @@ _wavlm_processor = None
 _wavlm_device: str | None = None
 _utmos_jit_model = None
 _utmos_jit_device: str | None = None
+_utmos_jit_input_scale: float = 1.0
+#: Divisor ``balacoon/utmos`` applies inside its own ``forward``; an export
+#: carrying it is telling us it wants int16-valued samples.
+_UTMOS_INT16_INPUT_SCALE: float = 32768.0
 _utmos_jit_load_failed = False
 _utmos_forward_warned = False
 
@@ -319,9 +329,101 @@ def _cosine_similarity_unit_vectors(a: np.ndarray, b: np.ndarray) -> float:
     return float(np.dot(a, b))
 
 
+def _utmos_resolve_device(torch: Any) -> str:
+    """Device for the UTMOS archive: ``SEED_TTS_UTMOS_DEVICE``, else CUDA if present."""
+    explicit = os.environ.get("SEED_TTS_UTMOS_DEVICE", "").strip()
+    if explicit:
+        return explicit
+    return "cuda:0" if torch.cuda.is_available() else "cpu"
+
+
+def _utmos_retarget_device_constants(model: Any, target: str) -> int:
+    """Rewrite Device constants baked into a traced graph, returning how many.
+
+    ``balacoon/utmos`` was traced on CUDA, so its methods carry literal ``cuda:0``
+    Device constants (root ``forward``, each ``self_attn.forward``, the decoder
+    RNN). ``map_location`` relocates the *weights* but cannot touch those, so on a
+    build without CUDA the first ``aten::to`` in ``forward`` raises
+    ``NotImplementedError`` and every utterance is counted as a UTMOS failure.
+
+    Must run before the module is first called: TorchScript caches an execution
+    plan on the first forward, and a later rewrite of the graph would not be
+    picked up.
+    """
+    rewritten = 0
+    seen: set[int] = set()
+    for _, module in model.named_modules():
+        cpp_module = getattr(module, "_c", None)
+        if cpp_module is None or id(cpp_module) in seen:
+            continue
+        seen.add(id(cpp_module))
+        for method_name in cpp_module._method_names():
+            graph = cpp_module._get_method(method_name).graph
+            for node in graph.nodes():
+                if node.kind() != "prim::Constant":
+                    continue
+                if "value" not in node.attributeNames() or node.kindOf("value") != "s":
+                    continue
+                value = node.s("value")
+                if value != "cuda" and not value.startswith("cuda:"):
+                    continue
+                if value == target:
+                    continue
+                node.s_("value", target)
+                rewritten += 1
+    return rewritten
+
+
+def _utmos_detect_input_scale(model: Any) -> float:
+    """Amplitude the export expects: 32768 if it normalizes by that, else 1.0.
+
+    ``balacoon/utmos`` divides the waveform by 32768 inside its root ``forward``,
+    i.e. it wants int16-valued samples. Handing it the ``[-1, 1]`` array the WER
+    path already has therefore attenuates every waveform by that factor, and the
+    model answers with the same MOS for clean speech as for noise.
+
+    Only that one divisor is recognised. ``SEED_TTS_UTMOS_HF_REPO`` /
+    ``SEED_TTS_UTMOS_JIT_FILE`` let anyone point this at a different export, and
+    rescaling one that normalizes by something else -- or not at all -- would be a
+    new bug of the same shape, so anything unrecognised keeps today's behaviour of
+    feeding the waveform through unchanged.
+    """
+    try:
+        graph = model.graph
+    except Exception:  # a module without a scripted ``forward``
+        return 1.0
+    for node in graph.nodes():
+        if node.kind() != "aten::div":
+            continue
+        inputs = list(node.inputs())
+        if len(inputs) < 2:
+            continue
+        producer = inputs[1].node()
+        if producer.kind() != "prim::Constant" or "value" not in producer.attributeNames():
+            continue
+        kind = producer.kindOf("value")
+        try:
+            if kind == "t":
+                tensor = producer.t("value")
+                if tensor.numel() != 1:
+                    continue
+                divisor = float(tensor.reshape(-1)[0].item())
+            elif kind == "f":
+                divisor = float(producer.f("value"))
+            elif kind == "i":
+                divisor = float(producer.i("value"))
+            else:
+                continue
+        except Exception:
+            continue
+        if divisor == _UTMOS_INT16_INPUT_SCALE:
+            return _UTMOS_INT16_INPUT_SCALE
+    return 1.0
+
+
 def _ensure_utmos_jit_model() -> Any | None:
     """Load UTMOS as TorchScript (``balacoon/utmos`` style): no ``import utmos`` / fairseq."""
-    global _utmos_jit_model, _utmos_jit_device, _utmos_jit_load_failed
+    global _utmos_jit_model, _utmos_jit_device, _utmos_jit_input_scale, _utmos_jit_load_failed
     with _lock:
         if _utmos_jit_load_failed:
             return None
@@ -340,30 +442,29 @@ def _ensure_utmos_jit_model() -> Any | None:
             )
             path = hf_hub_download(repo_id=repo, filename=fname, repo_type="model")
 
-            # TODO The model weights in UTMOS must be loaded in cuda:0; otherwise, the model execution will fail.
-            want = "cuda:0"
-            if want.startswith("cuda") and torch.cuda.is_available():
-                idx = want.split(":")[-1] if ":" in want else "0"
-                target_dev = f"cuda:{idx}"
-            else:
-                target_dev = "cpu"
-
+            target_dev = _utmos_resolve_device(torch)
             try:
                 m = torch.jit.load(path, map_location=target_dev)
-                m.eval()
-                _utmos_jit_device = target_dev
             except Exception as load_e:
-                if target_dev.startswith("cuda"):
-                    logger.warning(
-                        "UTMOS JIT load on %s failed (%s), retrying on CPU...",
-                        target_dev,
-                        load_e,
-                    )
-                    m = torch.jit.load(path, map_location="cpu")
-                    m.eval()
-                    _utmos_jit_device = "cpu"
-                else:
+                if target_dev == "cpu":
                     raise
+                logger.warning(
+                    "UTMOS JIT load on %s failed (%s), retrying on CPU...",
+                    target_dev,
+                    load_e,
+                )
+                m = torch.jit.load(path, map_location="cpu")
+                target_dev = "cpu"
+            retargeted = _utmos_retarget_device_constants(m, target_dev)
+            m.eval()
+            _utmos_jit_device = target_dev
+            _utmos_jit_input_scale = _utmos_detect_input_scale(m)
+            logger.info(
+                "UTMOS JIT ready on %s (%d baked device constants retargeted, input scale %g).",
+                target_dev,
+                retargeted,
+                _utmos_jit_input_scale,
+            )
             _utmos_jit_model = m
         except Exception as e:
             logger.warning(
@@ -378,9 +479,12 @@ def _ensure_utmos_jit_model() -> Any | None:
 def _utmos_predict_f32_16k(wav_f32: np.ndarray) -> float | None:
     """MOS from JIT model; input is float32 mono @ 16 kHz in ``[-1, 1]`` (WER pipeline).
 
-    ``balacoon/utmos`` demos sometimes use int16 numpy, but the exported ``.jit`` weights are
-    float32; passing int16 tensors causes: "RuntimeError: ... input type and weight type
-    should be same".
+    The tensor handed to the model stays float32 — ``balacoon/utmos`` demos use int16
+    numpy, but the exported ``.jit`` weights are float32 and an int16 tensor causes
+    "RuntimeError: ... input type and weight type should be same". Its *amplitude*,
+    however, must match what the export normalizes by (see
+    ``_utmos_detect_input_scale``): the archive divides by 32768, so a ``[-1, 1]``
+    array has to be scaled back up to int16 range first.
     """
     import torch
 
@@ -398,6 +502,8 @@ def _utmos_predict_f32_16k(wav_f32: np.ndarray) -> float | None:
         except StopIteration:
             model_dev = torch.device("cpu")
     w = np.ascontiguousarray(wav_f32, dtype=np.float32)
+    if _utmos_jit_input_scale != 1.0:
+        w = np.ascontiguousarray(w * _utmos_jit_input_scale, dtype=np.float32)
     x = torch.from_numpy(w).unsqueeze(0).to(device=model_dev, dtype=torch.float32)
     with torch.no_grad():
         out = model(x)


### PR DESCRIPTION
## Purpose

The Seed-TTS UTMOS metric does not work. On a build without CUDA it raises on
every utterance; on CUDA it runs but returns the same score for clean speech and
for 0 dB noise. Both come from the same place —
`_ensure_utmos_jit_model` / `_utmos_predict_f32_16k` in
`vllm_omni/benchmarks/data_modules/seed_tts_eval.py` — and both are fixed here.

This is the `main` landing of #6910, which targets `minicpm-challenge` and does
not reach `main`. `main` still has `want = "cuda:0"` and still feeds the model a
`[-1, 1]` array. Opened separately at @amy-why-3459's request on that PR.

### 1. The archive is traced on CUDA, and `map_location` cannot fix that

`balacoon/utmos` is a TorchScript archive carrying **14 literal `cuda:0` Device
constants** inside its methods: the root `forward`, each of the twelve
`self_attn.forward`, and `decoder_rnn.forward`. The first line of `forward` is

```
_0 = torch.to(x, torch.device("cuda:0"), 6)
```

`map_location` relocates the *weights*; it does not touch constants baked into
the graph. So on any build without CUDA the loader "succeeds" (the module loads,
`_utmos_jit_load_failed` stays `False`) and then **every** forward raises
`NotImplementedError`. The caller counts each one into `utmos_failed`, the
aggregate is dropped, and the warning it emits points the user at
`SEED_TTS_UTMOS_DEVICE` — a variable the module docstring documents in three
places and **the loader never reads**. The device was hard-coded:

```python
# TODO The model weights in UTMOS must be loaded in cuda:0; otherwise, the model execution will fail.
want = "cuda:0"
```

This PR retargets those constants to whatever device the model was loaded on, so
the TODO's "otherwise the model execution will fail" stops being true, and reads
`SEED_TTS_UTMOS_DEVICE` as documented (falling back to `cuda:0` when CUDA is
available and `cpu` otherwise — the same effective default as today on a CUDA
machine). Retargeting also fixes `SEED_TTS_UTMOS_DEVICE=cuda:1`, which currently
loads the weights on `cuda:1` while the graph still forces `cuda:0`.

The rewrite is bounded: only `prim::Constant` attributes of string kind whose
value is `cuda` or `cuda:N`, only rewritten to the device just loaded onto, and
the count is logged. It has to run before the first forward, because TorchScript
caches an execution plan on first call; `_ensure_utmos_jit_model` does it
immediately after load and a test pins that ordering.

### 2. The waveform is handed over 32768x too quiet — on every platform

The second line of the same `forward` is

```
x0 = torch.div(_0, CONSTANTS.c0)          # c0 = 32768.0
```

The export normalizes its input: it expects **int16-valued** samples and scales
them down itself. `_utmos_predict_f32_16k` passes the `[-1, 1]` float array the
WER path already has, so the model sees a waveform attenuated by 32768 — near
silence — and answers with essentially the same MOS whatever it is given.
**This half is not accelerator-specific: it is what CUDA has been measuring.**

Scored through the in-tree predictor, one clip and five degradations of it:

| input | today (`[-1, 1]`) | with this PR |
| --- | ---: | ---: |
| clean | 3.371 | **3.870** |
| + noise, SNR 10 dB | 3.371 | **1.360** |
| + noise, SNR 0 dB | 3.373 | **1.329** |
| 4-bit bitcrush | 3.371 | **1.245** |
| lowpass, k=16 | 3.370 | **2.862** |
| lowpass, k=48 | 3.368 | **2.287** |
| **spread (max − min)** | **0.005** | **2.625** |

0.005 MOS between clean speech and 0 dB noise: the number carries no
information. With the input at the amplitude the export normalizes by, the same
six are ranked correctly and span 2.6 MOS.

`_utmos_detect_input_scale` recognises **only** the default export's divisor
(32768) and returns `1.0` for anything else, so an archive reachable through
`SEED_TTS_UTMOS_HF_REPO` / `SEED_TTS_UTMOS_JIT_FILE` that normalizes by some
other factor — or not at all — is fed unchanged, exactly as today. The tensor
stays float32; only its amplitude changes, so the `RuntimeError: input type and
weight type should be same` the old docstring warns about is still avoided.

### Previously reported UTMOS numbers

**UTMOS figures produced through this path — including those in #2558 — should
be discarded, not compared against results from this change.** They were drawn
from a 0.005 MOS band on CUDA (#2558's mean 3.365 sits inside the same band as
the 3.371 clean / 3.373 at 0 dB above) and from nothing at all off CUDA. There
is no conversion between the old numbers and the new ones because the old ones
did not vary with the audio.

### Scope

`vllm_omni/benchmarks/data_modules/seed_tts_eval.py` only — the benchmark's
UTMOS scorer — plus a new CPU-only test file. No serving path, no model, no
scheduler, no config key, no new environment variable (it starts *reading* one
that was already documented). WER and SIM are untouched.

## Test Plan

**vLLM Version:** `0.1.dev1+ge5588e49b` (`0.28.0` line)

**vLLM-Omni Commit:** `d1c8beeb180b4617437c460ba5c8f61a4a561a7e`

1. **Unit tests, CPU only** — `tests/benchmarks/test_seed_tts_utmos.py`, eleven
   tests. No CUDA, no NPU, no network: they script a module reproducing both
   defects (a baked `cuda:0` cast followed by a divide by 32768), serialize and
   reload it so it arrives in the same shape as a downloaded archive, and check
   the retarget, its reach into submodules, its no-op case, the device
   resolution, the scale detection (including an export that normalizes by a
   different factor, which must be left alone) and the predictor.
2. **The real archive, end to end, through the in-tree predictor** — one process
   per arm on an Ascend A3 (910C) box, `torch 2.10.0`, `torch_npu 2.10.0`,
   `torch.cuda.is_available() == False`, `balacoon/utmos` from the local HF
   cache. Arm A is a pristine worktree; arm B is the same worktree with this
   diff and nothing else. `HT_ref_audio.wav` from the MiniCPM-o 4.5 assets,
   resampled to 16 kHz mono, first 4 s, plus the five degradations above.
3. **The scaling defect in isolation** — arm B again with
   `_utmos_jit_input_scale` forced back to `1.0`, i.e. the device fix only. That
   is the code path a CUDA machine runs today; I have no CUDA box, so this
   isolates the amplitude bug from the device bug on identical arithmetic.

## Test Result

**1. Unit tests** — 11 passed. `tests/benchmarks/` as a whole goes
**122 → 133 passed** on `d1c8beeb1`, with the same 1 pre-existing failure and
7 pre-existing collection errors before and after (environmental; run with
`--continue-on-collection-errors`).

**2. Arm A, pristine tree, non-CUDA build:** all six inputs raise.

```
"jit_device": "cpu", "jit_load_failed": false,
"errors": { "clean": "NotImplementedError: ... _0 = torch.to(x, torch.device(\"cuda:0\"), 6) <--- HERE", ... }
"scores": {}
```

The loader reports success and the metric produces nothing — which is why this
has gone unnoticed: there is no error at load time, only a per-utterance
`utmos_failed` counter.

**Arm B, same worktree + this diff:**

```
INFO seed_tts_eval.py] UTMOS JIT ready on cpu (14 baked device constants retargeted, input scale 32768).
"scores": {"clean": 3.8697, "noise_snr_10dB": 1.3599, "noise_snr_0dB": 1.3286,
           "bitcrush_4bit": 1.2446, "lowpass_k16": 2.8620, "lowpass_k48": 2.2869}
"spread": 2.6251
```

**3. Device fix only (today's CUDA behaviour):**

```
"jit_input_scale": 1.0
"scores": {"clean": 3.3706, "noise_snr_10dB": 3.3706, "noise_snr_0dB": 3.3734,
           "bitcrush_4bit": 3.3706, "lowpass_k16": 3.3697, "lowpass_k48": 3.3682}
"spread": 0.0052
```

Three columns, one code path, one archive: **raises → 0.005 MOS of dynamic range
→ 2.625**.

### Review points carried over from #6910

All four changes @amy-why-3459 asked for are in this branch (and were pushed to
#6910 as well, base untouched):

- `test_the_archive_as_shipped_is_unusable_without_cuda` is now skipped when
  `torch.cuda.is_available()`. On the exception type: the real archive raises
  `NotImplementedError`, but a locally scripted stand-in surfaces the same failed
  `aten::to` as the interpreter's plain `RuntimeError`, so a bare
  `pytest.raises(NotImplementedError)` fails on this test's own module. Verified
  against the downloaded archive on an Ascend build — `NotImplementedError` is a
  `RuntimeError` subclass, so the test asserts `RuntimeError` and matches on the
  device name, which pins the cause without being wrong for either module.
- `"UTMOS JIT ready on %s"` is now `logger.info`. `warning` is kept for the
  CUDA→CPU load retry and for load failure.
- `_utmos_detect_input_scale` pins 32768 and falls back to `1.0` when that
  constant is absent, instead of taking the first `aten::div` by a constant
  `> 1`. A new test covers a graph that divides by 2 and must be left alone.
- The test file's copyright line now says `vLLM-Omni project`.
