### PR TITLE
[Bugfix][Cosmos3] Avoid logging prompts at INFO level

### DIFF
--- a/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
+++ b/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
@@ -2223,7 +2223,7 @@ class Cosmos3OmniDiffusersPipeline(
         if prompt_suffix:
             prompt = f"{prompt.rstrip()} {prompt_suffix.lstrip()}".strip()
         if _is_rank_zero():
-            logger.info("Final prompt: '%s'", prompt)
+            logger.debug("Final prompt: '%s'", prompt)
 
         if negative_metadata_mode == "none":
             negative_dur_tmpl = None


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Cosmos3 logs the fully formatted generation prompt at INFO level. Because this
prompt can contain user-provided or sensitive text, it should not appear in
normal production logs.

Move the message to DEBUG so it remains available for explicitly enabled
troubleshooting without changing prompt formatting or generation behavior.

## Test Plan

Run the Cosmos3 pipeline unit suite:

```bash
pytest -sv tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py -m "core_model and cpu"
```

Manually run a Cosmos3 generation request and verify that `Final prompt` is
absent at INFO level and present when DEBUG logging is enabled.

**vLLM Version:**

Not recorded.

**vLLM-Omni Version:**

`0.28.0`

**vLLM-Omni Commit:**

Base: `a65e89cbd47fe7c9f39dba558200c0bc16a758f3`

## Test Result

Passed.
