### PR TITLE
[Bugfix][Benchmark] Measure streaming continuity on the chat path instead of defaulting it to OK

### DIFF
--- a/tests/benchmarks/metrics/test_metrics.py
+++ b/tests/benchmarks/metrics/test_metrics.py
@@ -117,12 +117,15 @@ def test_audio_continuity_aggregation():
     bad = _make_output(100)
     bad.audio_underrun_s = 0.5
     bad.audio_continuity_ok = False
+    bad.audio_continuity_measured = True
     good_a = _make_output(100)
     good_a.audio_underrun_s = 0.02
     good_a.audio_continuity_ok = True
+    good_a.audio_continuity_measured = True
     good_b = _make_output(100)
     good_b.audio_underrun_s = 0.0
     good_b.audio_continuity_ok = True
+    good_b.audio_continuity_measured = True
 
     metrics, _ = calculate_metrics(
         input_requests=[],
@@ -142,6 +145,60 @@ def test_audio_continuity_aggregation():
     # p99 of [0.5, 0.02, 0.0] is dominated by the 0.5 outlier.
     p99 = dict(metrics.percentiles_audio_underrun_s).get(99.0)
     assert p99 is not None and p99 > 0.4
+
+
+def test_a_request_nobody_measured_is_not_counted_as_continuous():
+    """An unmeasured request must not be folded in as a pass.
+
+    ``audio_continuity_ok`` defaults to ``True`` and ``audio_underrun_s`` to
+    ``0.0``, so a backend that records no chunk arrival times used to make every
+    one of its requests look perfect. Only ``audio_continuity_measured`` outputs
+    may reach the aggregate.
+    """
+    measured_bad = _make_output(100)
+    measured_bad.audio_underrun_s = 0.5
+    measured_bad.audio_continuity_ok = False
+    measured_bad.audio_continuity_measured = True
+    unmeasured = _make_output(100)  # defaults: ok=True, underrun=0.0, measured=False
+
+    metrics, _ = calculate_metrics(
+        input_requests=[],
+        outputs=[measured_bad, unmeasured],
+        dur_s=10.0,
+        tokenizer=None,
+        selected_percentiles=[50.0],
+        goodput_config_dict={},
+        task_type=TaskType.GENERATION,
+        selected_percentile_metrics=["audio_underrun"],
+        max_concurrency=None,
+        request_rate=float("inf"),
+        benchmark_duration=10.0,
+    )
+
+    # One measured request, and it failed.
+    assert metrics.audio_continuity_ok_rate == pytest.approx(0.0, abs=1e-6)
+    assert metrics.mean_audio_underrun_s == pytest.approx(0.5, abs=1e-6)
+
+
+def test_continuity_rate_is_not_a_number_when_nothing_was_measured():
+    """With no backend measuring, the rate has to abstain rather than print 100%."""
+    outputs = [_make_output(100), _make_output(100)]
+
+    metrics, _ = calculate_metrics(
+        input_requests=[],
+        outputs=outputs,
+        dur_s=10.0,
+        tokenizer=None,
+        selected_percentiles=[50.0],
+        goodput_config_dict={},
+        task_type=TaskType.GENERATION,
+        selected_percentile_metrics=["audio_underrun"],
+        max_concurrency=None,
+        request_rate=float("inf"),
+        benchmark_duration=10.0,
+    )
+
+    assert math.isnan(metrics.audio_continuity_ok_rate)
 
 
 def test_unmeasured_duplex_latency_does_not_add_zero_samples():

--- a/tests/benchmarks/patch/test_patch.py
+++ b/tests/benchmarks/patch/test_patch.py
@@ -7,8 +7,10 @@ Unit tests for patch.py
 
 import asyncio
 import base64
+import io
 import json
 import time
+import wave
 from argparse import Namespace
 from types import SimpleNamespace
 
@@ -1194,6 +1196,138 @@ async def test_prompt_len_assigned_from_usage(mocker: MockerFixture):
     assert output.prompt_len == 4992, (
         "prompt_len should be overridden by usage.prompt_tokens to reflect the true multimodal input token count"
     )
+
+
+def _wav_chunk_b64(seconds: float, sample_rate: int = 24000) -> str:
+    """One base64 WAV container carrying ``seconds`` of silence, as the server streams it."""
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as writer:
+        writer.setnchannels(1)
+        writer.setsampwidth(2)
+        writer.setframerate(sample_rate)
+        writer.writeframes(b"\x00\x00" * int(seconds * sample_rate))
+    return base64.b64encode(buffer.getvalue()).decode()
+
+
+def _audio_chunks(count: int, seconds_each: float) -> list[bytes]:
+    payload = _wav_chunk_b64(seconds_each)
+    chunks = [
+        create_sse_chunk({"choices": [{"delta": {"content": payload}}], "modality": "audio"}) for _ in range(count)
+    ]
+    return [*chunks, b"data: [DONE]\n\n"]
+
+
+class TestChatOmniStreamingContinuity:
+    """The chat path has to measure playback continuity, not inherit its default.
+
+    ``compute_continuity_stats`` already lives in the repo, but only
+    ``/v1/audio/speech`` ever called it. Every audio benchmark that runs through
+    ``/v1/chat/completions`` therefore reported ``audio_continuity_ok`` as ``True``
+    and ``audio_underrun_s`` as ``0.0`` no matter what the stream did.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_starved_stream_is_reported_as_a_starved_stream(self, mocker: MockerFixture):
+        """Chunks 80 ms apart carrying 5 ms of audio each: the player runs dry."""
+        request_input = RequestFuncInput(
+            model="test-model",
+            model_name="test-model",
+            prompt="test prompt",
+            api_url="http://test.com/v1/chat/completions",
+            prompt_len=10,
+            output_len=20,
+        )
+        mock_response = MockResponse(200, _audio_chunks(4, seconds_each=0.005), delay_between_chunks=0.08)
+        mock_session = mocker.AsyncMock()
+        mock_session.post = mocker.MagicMock(return_value=mock_response)
+
+        output = await async_request_openai_chat_omni_completions(request_input, mock_session)
+
+        assert output.success is True
+        assert output.audio_continuity_measured is True
+        assert output.audio_continuity_ok is False
+        assert output.audio_underrun_s > 0.1
+        assert output.audio_underrun_event_count > 0
+
+    @pytest.mark.asyncio
+    async def test_a_stream_that_keeps_ahead_is_continuous(self, mocker: MockerFixture):
+        """Chunks 20 ms apart carrying 200 ms of audio each: the buffer only grows."""
+        request_input = RequestFuncInput(
+            model="test-model",
+            model_name="test-model",
+            prompt="test prompt",
+            api_url="http://test.com/v1/chat/completions",
+            prompt_len=10,
+            output_len=20,
+        )
+        mock_response = MockResponse(200, _audio_chunks(4, seconds_each=0.2), delay_between_chunks=0.02)
+        mock_session = mocker.AsyncMock()
+        mock_session.post = mocker.MagicMock(return_value=mock_response)
+
+        output = await async_request_openai_chat_omni_completions(request_input, mock_session)
+
+        assert output.success is True
+        assert output.audio_continuity_measured is True
+        assert output.audio_continuity_ok is True
+        assert output.audio_underrun_s == 0.0
+
+    @pytest.mark.asyncio
+    async def test_continuity_uses_pcm_bytes_not_container_bytes(self, mocker: MockerFixture):
+        """Each chunk is a WAV container; its 44-byte header must not count as audio.
+
+        Counting the header would inflate every chunk by 44 bytes, which is 0.9 ms
+        of 24 kHz mono s16le -- small, but it would make the metric optimistic in
+        exactly the regime it exists to catch, one where chunks are short.
+        """
+        request_input = RequestFuncInput(
+            model="test-model",
+            model_name="test-model",
+            prompt="test prompt",
+            api_url="http://test.com/v1/chat/completions",
+            prompt_len=10,
+            output_len=20,
+        )
+        seconds_each = 0.005
+        mock_response = MockResponse(200, _audio_chunks(4, seconds_each=seconds_each), delay_between_chunks=0.08)
+        mock_session = mocker.AsyncMock()
+        mock_session.post = mocker.MagicMock(return_value=mock_response)
+
+        output = await async_request_openai_chat_omni_completions(request_input, mock_session)
+
+        # Four chunks of 5 ms is 20 ms of audio; the duration the run reports has
+        # to match that, i.e. be derived from frames rather than from bytes on the
+        # wire (a container-counting bug would show up here as ~24 ms).
+        assert output.audio_duration == pytest.approx(4 * seconds_each, abs=1e-6)
+
+    @pytest.mark.asyncio
+    async def test_an_encoded_format_is_left_unmeasured_rather_than_reported_ok(self, mocker: MockerFixture):
+        """mp3 chunk bytes say nothing about play time, so continuity must abstain."""
+        request_input = RequestFuncInput(
+            model="test-model",
+            model_name="test-model",
+            prompt="test prompt",
+            api_url="http://test.com/v1/chat/completions",
+            prompt_len=10,
+            output_len=20,
+            extra_body={"response_format": "mp3"},
+        )
+        chunks = [
+            create_sse_chunk(
+                {
+                    "choices": [{"delta": {"content": base64.b64encode(b"\xff\xfb" * 64).decode()}}],
+                    "modality": "audio",
+                }
+            ),
+            b"data: [DONE]\n\n",
+        ]
+        mock_response = MockResponse(200, chunks)
+        mock_session = mocker.AsyncMock()
+        mock_session.post = mocker.MagicMock(return_value=mock_response)
+
+        output = await async_request_openai_chat_omni_completions(request_input, mock_session)
+
+        assert output.success is True
+        assert output.audio_continuity_measured is False
 
 
 if __name__ == "__main__":

--- a/vllm_omni/benchmarks/metrics/metrics.py
+++ b/vllm_omni/benchmarks/metrics/metrics.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
+import math
 import warnings
 from collections import defaultdict
 from collections.abc import Sequence
@@ -282,10 +283,11 @@ def print_audio_metrics(selected_percentile_metrics, metrics: MultiModalsBenchma
     )
     print("{:<40} {:<10}".format("Total audio frames generated:", getattr(metrics, defs.TOTAL_AUDIO_FRAMES)))
     print("{:<40} {:<10.2f}".format("Audio throughput(audio duration/s):", getattr(metrics, defs.AUDIO_THROUGHPUT)))
+    continuity_ok_rate = getattr(metrics, defs.AUDIO_CONTINUITY_OK_RATE)
     print(
-        "{:<40} {:<10.2%}".format(
+        "{:<40} {:<10}".format(
             "Streaming continuity OK rate:",
-            getattr(metrics, defs.AUDIO_CONTINUITY_OK_RATE),
+            "n/a (not measured)" if not math.isfinite(continuity_ok_rate) else f"{continuity_ok_rate:.2%}",
         )
     )
     for metric in selected_percentile_metrics:
@@ -827,8 +829,13 @@ def calculate_metrics(
             denoise_step_latency_ms = float(getattr(outputs[i], defs.DENOISE_STEP_LATENCY_MS, 0.0) or 0.0)
             if denoise_step_latency_ms > 0:
                 denoise_step_latencies_ms.append(denoise_step_latency_ms)
-            audio_underruns.append(getattr(outputs[i], f"{defs.AUDIO_UNDERRUN}_s", 0.0))
-            audio_continuity_ok.append(bool(getattr(outputs[i], defs.AUDIO_CONTINUITY_OK, True)))
+            # Only requests whose backend actually ran continuity analysis. A
+            # backend that records no chunk arrival times leaves the fields at
+            # their defaults, and counting those would report every request as
+            # continuous with a zero underrun.
+            if getattr(outputs[i], defs.AUDIO_CONTINUITY_MEASURED, False):
+                audio_underruns.append(getattr(outputs[i], f"{defs.AUDIO_UNDERRUN}_s", 0.0))
+                audio_continuity_ok.append(bool(getattr(outputs[i], defs.AUDIO_CONTINUITY_OK, True)))
             e2els.append(outputs[i].latency)
             input_audio_duration += outputs[i].input_audio_duration
             completed += 1
@@ -1016,7 +1023,7 @@ def calculate_metrics(
                 (p, np.percentile(audio_underruns or 0, p)) for p in selected_percentiles
             ],
             defs.AUDIO_CONTINUITY_OK_RATE: (
-                (sum(audio_continuity_ok) / len(audio_continuity_ok)) if audio_continuity_ok else 1.0
+                (sum(audio_continuity_ok) / len(audio_continuity_ok)) if audio_continuity_ok else float("nan")
             ),
         },
     )

--- a/vllm_omni/benchmarks/patch/patch.py
+++ b/vllm_omni/benchmarks/patch/patch.py
@@ -660,15 +660,23 @@ class MixRequestFuncOutput(RequestFuncOutput):
     text_latency: float = 0.0
     tpot_measured: bool = True
     #: Worst-case streaming-audio underrun (wall-clock seconds the player
-    #: would have been starved). Populated by the audio-speech backend; ``0.0``
-    #: for backends that do not run continuity analysis.
+    #: would have been starved). Only meaningful when
+    #: ``audio_continuity_measured`` is set.
     audio_underrun_s: float = 0.0
     #: Whether the request stayed under the continuity threshold (default
-    #: 100 ms). Mirrors ``audio_underrun_s <= threshold``.
+    #: 100 ms). Mirrors ``audio_underrun_s <= threshold``. Only meaningful when
+    #: ``audio_continuity_measured`` is set.
     audio_continuity_ok: bool = True
     #: Number of inter-chunk intervals during which the player buffer went
     #: negative.
     audio_underrun_event_count: int = 0
+    #: Whether continuity analysis actually ran for this request. It needs the
+    #: arrival time and the *PCM* byte count of every audio chunk, so a backend
+    #: that does not record them -- or a response format whose chunks are
+    #: encoded rather than PCM -- leaves this ``False`` and the three fields
+    #: above at their defaults. Aggregation must not read them without it, or a
+    #: request nobody measured is counted as continuous.
+    audio_continuity_measured: bool = False
     #: Raw PCM s16le mono at 24 kHz for Seed-TTS WER: from ``/v1/audio/speech`` stream or
     #: resampled export after ``openai-chat-omni`` audio deltas.
     tts_output_pcm_bytes: bytes | None = None
@@ -1008,6 +1016,12 @@ async def async_request_openai_chat_omni_completions(
         first_inconsistent_wav_params: tuple[int, int, int] | None = None
         # For non-wav responses, accumulate encoded bytes then decode once.
         audio_bytes_buffer = bytearray()
+        # Arrival time and PCM byte count of every audio chunk, for continuity
+        # analysis. Only filled on the wav path: there the chunk's own header
+        # tells us the PCM it carries, while an encoded format's byte count says
+        # nothing about how long it plays for.
+        chunk_arrival_times_s: list[float] = []
+        chunk_pcm_bytes: list[int] = []
         st = time.perf_counter()
         output.start_time = st
         most_recent_timestamp = st
@@ -1119,9 +1133,11 @@ async def async_request_openai_chat_omni_completions(
                                                             if first_inconsistent_wav_params is None:
                                                                 first_inconsistent_wav_params = params
                                                             continue
-                                                        wav_pcm_buffer.extend(
-                                                            wav_reader.readframes(wav_reader.getnframes())
-                                                        )
+                                                        chunk_pcm = wav_reader.readframes(wav_reader.getnframes())
+                                                        wav_pcm_buffer.extend(chunk_pcm)
+                                                        if chunk_pcm:
+                                                            chunk_arrival_times_s.append(timestamp - st)
+                                                            chunk_pcm_bytes.append(len(chunk_pcm))
                                                 except Exception as ex:
                                                     logger.warning("Failed to parse wav audio chunk: %s", ex)
                                             else:
@@ -1193,6 +1209,19 @@ async def async_request_openai_chat_omni_completions(
                                 channels,
                                 frame_rate,
                             )
+                        if chunk_arrival_times_s and frame_rate > 0:
+                            continuity = compute_continuity_stats(
+                                chunk_arrival_times_s=chunk_arrival_times_s,
+                                chunk_bytes=chunk_pcm_bytes,
+                                sample_rate=frame_rate,
+                                sample_width=sample_width,
+                                channels=channels,
+                                threshold_s=_audio_continuity_threshold_s(),
+                            )
+                            output.audio_underrun_s = continuity.max_underrun_s
+                            output.audio_continuity_ok = continuity.is_continuous
+                            output.audio_underrun_event_count = continuity.underrun_event_count
+                            output.audio_continuity_measured = True
                     elif audio_bytes_buffer:
                         try:
                             from vllm.multimodal.audio import get_audio_duration
@@ -1498,6 +1527,7 @@ async def async_request_openai_audio_speech(
                 output.audio_underrun_s = continuity.max_underrun_s
                 output.audio_continuity_ok = continuity.is_continuous
                 output.audio_underrun_event_count = continuity.underrun_event_count
+                output.audio_continuity_measured = True
                 if pcm_capture is not None and pcm_capture:
                     try:
                         output.tts_output_pcm_bytes = _pcm_s16le_to_seed_tts_wer_bytes(

--- a/vllm_omni/metrics/definitions.py
+++ b/vllm_omni/metrics/definitions.py
@@ -35,6 +35,7 @@ AUDIO_RTF = "audio_rtf"
 AUDIO_FRAMES = "audio_frames"
 AUDIO_UNDERRUN = "audio_underrun"
 AUDIO_CONTINUITY_OK = "audio_continuity_ok"
+AUDIO_CONTINUITY_MEASURED = "audio_continuity_measured"
 AUDIO_SKIPPED_REQUESTS = "audio_skipped_requests"
 
 # Bench-side aggregate field names. Keep these centralized so new benchmark


### PR DESCRIPTION
## Purpose

`Streaming continuity OK rate` prints **100% for every tree**, and
`audio_underrun_s` prints 0, whenever audio is benchmarked through
`/v1/chat/completions`.

`vllm_omni/benchmarks/audio_continuity.py` is already in the repo and already
correct — it has its own unit tests. It has exactly one production caller:

```
$ rg -n 'compute_continuity_stats' vllm_omni/
vllm_omni/benchmarks/patch/patch.py:44:   from vllm_omni.benchmarks.audio_continuity import compute_continuity_stats
vllm_omni/benchmarks/patch/patch.py:1490:                continuity = compute_continuity_stats(   # async_request_openai_audio_speech
```

`async_request_openai_chat_omni_completions` records `audio_ttfp` and
accumulates the audio, but never records *when* each chunk arrived, so it never
calls it. Then `calculate_metrics` reads the result as

```python
audio_continuity_ok.append(bool(getattr(outputs[i], defs.AUDIO_CONTINUITY_OK, True)))
```

— **defaulting to `True`.** A request nobody measured is counted as a continuous
one. `ASYNC_REQUEST_FUNCS["openai-chat-omni"]` and `["daily-omni"]` both route
to that function, so this is the path the audio benchmarks actually run.

## What this changes

1. The chat backend records each audio chunk's arrival time and its **PCM** byte
   count, and runs the existing analysis when the request ends. The byte count
   comes from `wave.readframes`, so the per-chunk WAV header is excluded —
   counting it would add 44 bytes to every chunk, which is 0.9 ms of 24 kHz mono
   s16le, and would make the metric optimistic in exactly the short-chunk regime
   it exists to catch. There is a test for that.
2. An **encoded** response format cannot be measured this way: a compressed
   chunk's byte count says nothing about how long it plays. Rather than let
   those keep reporting a default, each request now carries
   `audio_continuity_measured`, aggregation skips requests without it, and if
   nothing was measured the rate is `NaN` and prints `n/a (not measured)`
   instead of `100.00%`. This is four lines, and it is the same defect: the
   number must not claim a result it does not have.

The speech backend sets the new flag and is otherwise untouched.

## Evidence

MiniCPM-o 4.5 Seed-TTS bench on an Atlas A3 / 910C, stock `minicpmo_4_5.yaml`,
recording the real SSE timelines off `/v1/chat/completions` and scoring them
with this same `compute_continuity_stats`:

| arm | n | continuity, if measured | worst underrun | starved requests | median first packet |
| --- | ---: | ---: | ---: | ---: | ---: |
| `codec_chunk_frames` 25, concurrency 1 | 8 | 1.000 | 0 ms | 0 | 1183 ms |
| `codec_chunk_frames` 25, concurrency 8 | 16 | **0.000** | **21464 ms** | **16 / 16** | 3790 ms |
| `codec_chunk_frames` 512, concurrency 1 | 8 | 1.000 | 0 ms | 0 | 2666 ms |
| `codec_chunk_frames` 512, concurrency 8 | 16 | 1.000 | 0 ms | 0 | **19126 ms** |

**All four arms print `Streaming continuity OK rate: 100.00%` today.** Row 2 is
a stock configuration in which every single request starves, for up to 21
seconds.

Row 4 is the counterweight, and it belongs next to the metric rather than being
left for a reader to discover: one large, late chunk never starves a player that
has not started, so continuity reads perfect while the first packet is 19 s
away. **This metric measures underrun, not latency**, and has to be read beside
TTFP. It is not a substitute for one.

## Test Plan

**vLLM Version:** `0.1.dev1+ge5588e49b` (`0.28.0` line)

**vLLM-Omni Commit:** `d1c8beeb180b4617437c460ba5c8f61a4a561a7e`

CPU only, no network, no accelerator. Six new tests plus one existing test
updated for the new semantics:

- `tests/benchmarks/patch/test_patch.py::TestChatOmniStreamingContinuity` — four
  tests driving `async_request_openai_chat_omni_completions` through the file's
  existing `MockResponse` harness with real base64 WAV chunks: a starved stream
  (chunks 80 ms apart carrying 5 ms of audio each) must report not-continuous
  with a >100 ms underrun; a stream that stays ahead (20 ms apart, 200 ms each)
  must report continuous with zero underrun; the reported duration must come
  from PCM frames rather than container bytes; and an `mp3` response format must
  leave `audio_continuity_measured` `False` rather than report OK.
- `tests/benchmarks/metrics/test_metrics.py` — an unmeasured request must not be
  folded into the rate or the underrun mean, and with nothing measured the rate
  must be NaN. `test_audio_continuity_aggregation` gains
  `audio_continuity_measured = True` on its three outputs, since it is asserting
  on measured requests.

## Test Result

`tests/benchmarks/` on `d1c8beeb1`, same box, before and after:

```
main             : 1 failed, 155 passed, 1 error
main + this PR   : 1 failed, 161 passed, 1 error
```

+6, and the same one pre-existing failure and one pre-existing collection error
on both sides (environmental). The four new backend tests and the two new
metrics tests pass individually:

```
tests/benchmarks/patch/test_patch.py -k Continuity   4 passed, 28 deselected
tests/benchmarks/metrics/test_metrics.py            18 passed
```

## Note

`vllm_omni/metrics/modality.py` emits `audio_continuity_ok_total` server-side at
SSE close, and that path is unaffected. This is the client-side benchmark
metric, which is what the printed report and any harness reading the result JSON
consume.
