### PR TITLE
[Perf][NPU] Reuse the previous step's decode inputs when the batch has not changed

### DIFF
--- a/tests/platforms/npu/worker/test_decode_prep_fast.py
+++ b/tests/platforms/npu/worker/test_decode_prep_fast.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""Tests for the steady-state decode input reuse gates.
+
+Every one of these runs on CPU with duck-typed stand-ins: the gates read plain
+attributes off the runner, the scheduler output and the input batch, so none of
+them needs an accelerator, a model or vLLM's engine.
+
+The property under test throughout is the same one: **a gate that cannot prove
+the step is a plain unchanged decode must return a reason, and the caller then
+takes the generic path.** A false "yes" is a wrong step; a false "no" is only a
+slow one.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+from vllm_omni.platforms.npu.worker import decode_prep_fast  # noqa: E402
+
+
+def _input_batch(*, num_reqs=1, req_ids=("r0",), computed=None, **overrides):
+    batch = SimpleNamespace(
+        num_reqs=num_reqs,
+        req_ids=list(req_ids),
+        prev_sampled_token_ids=object(),
+        prev_req_id_to_index={"r0": 0},
+        req_prompt_embeds=None,
+        num_computed_tokens_cpu=np.array(computed if computed is not None else [7], dtype=np.int32),
+        block_table=SimpleNamespace(block_tables=[]),
+    )
+    for key, value in overrides.items():
+        setattr(batch, key, value)
+    return batch
+
+
+def _runner(**overrides):
+    runner = SimpleNamespace(
+        input_batch=_input_batch(),
+        calculate_kv_scales=False,
+        num_accepted_tokens_event=None,
+        routed_experts_initialized=False,
+    )
+    for key, value in overrides.items():
+        setattr(runner, key, value)
+    return runner
+
+
+def _scheduler_output(**overrides):
+    out = SimpleNamespace(scheduled_spec_decode_tokens={}, total_num_scheduled_tokens=1)
+    for key, value in overrides.items():
+        setattr(out, key, value)
+    return out
+
+
+class TestStepGate:
+    """`_step_gate_block` decides whether *this* step is a plain decode."""
+
+    def test_a_plain_one_token_decode_is_allowed(self):
+        assert decode_prep_fast._step_gate_block(_runner(), _scheduler_output(), np.array([1], dtype=np.int32)) is None
+
+    @pytest.mark.parametrize(
+        ("overrides", "reason"),
+        [
+            ({"calculate_kv_scales": True}, "kv_scales"),
+            ({"num_accepted_tokens_event": object()}, "accepted_tokens_event"),
+            ({"routed_experts_initialized": True}, "routed_experts"),
+        ],
+    )
+    def test_runner_state_that_the_fast_path_does_not_reproduce_blocks(self, overrides, reason):
+        assert (
+            decode_prep_fast._step_gate_block(_runner(**overrides), _scheduler_output(), np.array([1], dtype=np.int32))
+            == reason
+        )
+
+    def test_a_speculative_step_blocks(self):
+        blocked = decode_prep_fast._step_gate_block(
+            _runner(), _scheduler_output(scheduled_spec_decode_tokens={"r0": [5]}), np.array([1], dtype=np.int32)
+        )
+        assert blocked == "spec_decode_tokens"
+
+    def test_more_than_one_token_for_a_request_blocks(self):
+        blocked = decode_prep_fast._step_gate_block(
+            _runner(), _scheduler_output(total_num_scheduled_tokens=3), np.array([3], dtype=np.int32)
+        )
+        assert blocked == "not_one_token_per_request"
+
+    def test_a_request_still_on_its_prompt_blocks(self):
+        """`num_computed_tokens == 0` means this request is prefilling, not decoding."""
+        runner = _runner(input_batch=_input_batch(computed=[0]))
+        blocked = decode_prep_fast._step_gate_block(runner, _scheduler_output(), np.array([1], dtype=np.int32))
+        assert blocked == "prefill_in_batch"
+
+    def test_a_batch_with_no_previous_sample_blocks(self):
+        """There is nothing to scatter the new token from on the first step."""
+        runner = _runner(input_batch=_input_batch(prev_sampled_token_ids=None))
+        blocked = decode_prep_fast._step_gate_block(runner, _scheduler_output(), np.array([1], dtype=np.int32))
+        assert blocked == "no_prev_sampled_token_ids"
+
+    def test_an_empty_batch_blocks(self):
+        runner = _runner(input_batch=_input_batch(num_reqs=0))
+        blocked = decode_prep_fast._step_gate_block(
+            runner, _scheduler_output(total_num_scheduled_tokens=0), np.array([], dtype=np.int32)
+        )
+        assert blocked == "no_requests"
+
+
+class TestBlockTableSnapshot:
+    """A decode allocates a block once per `block_size` tokens; the other steps
+    re-upload a table the device already has."""
+
+    @staticmethod
+    def _runner_with_rows(rows):
+        table = SimpleNamespace(block_table=SimpleNamespace(np=rows))
+        return SimpleNamespace(input_batch=SimpleNamespace(block_table=SimpleNamespace(block_tables=[table])))
+
+    def test_the_first_call_records_rather_than_claims_unchanged(self):
+        cache = decode_prep_fast.DecodeInputCache()
+        runner = self._runner_with_rows(np.arange(8, dtype=np.int32).reshape(1, 8))
+        assert decode_prep_fast._block_tables_unchanged(runner, cache, 1) is False
+        assert cache.block_table_snapshot is not None
+
+    def test_an_identical_table_is_recognised(self):
+        cache = decode_prep_fast.DecodeInputCache()
+        runner = self._runner_with_rows(np.arange(8, dtype=np.int32).reshape(1, 8))
+        decode_prep_fast._block_tables_unchanged(runner, cache, 1)
+        assert decode_prep_fast._block_tables_unchanged(runner, cache, 1) is True
+
+    def test_a_newly_allocated_block_is_noticed(self):
+        cache = decode_prep_fast.DecodeInputCache()
+        rows = np.arange(8, dtype=np.int32).reshape(1, 8)
+        runner = self._runner_with_rows(rows)
+        decode_prep_fast._block_tables_unchanged(runner, cache, 1)
+        rows[0, 4] = 99  # the step that crosses a block boundary
+        assert decode_prep_fast._block_tables_unchanged(runner, cache, 1) is False
+
+    def test_the_snapshot_is_a_copy_not_a_view(self):
+        """Holding a view would compare the live buffer against itself and
+        report 'unchanged' for a table that had in fact moved."""
+        cache = decode_prep_fast.DecodeInputCache()
+        rows = np.arange(8, dtype=np.int32).reshape(1, 8)
+        runner = self._runner_with_rows(rows)
+        decode_prep_fast.snapshot_block_tables(runner, cache, 1)
+        rows[0, 0] = 12345
+        assert decode_prep_fast._block_tables_unchanged(runner, cache, 1) is False
+
+    def test_an_unreadable_layout_keeps_committing_every_step(self):
+        cache = decode_prep_fast.DecodeInputCache()
+        table = SimpleNamespace(block_table=SimpleNamespace(np=None))
+        runner = SimpleNamespace(input_batch=SimpleNamespace(block_table=SimpleNamespace(block_tables=[table])))
+        assert decode_prep_fast._block_tables_unchanged(runner, cache, 1) is False
+        assert cache.block_table_snapshot is None
+
+
+class TestSignatureAndCache:
+    def test_the_signature_tracks_the_request_set(self):
+        one = decode_prep_fast.signature_of(_runner(input_batch=_input_batch(num_reqs=1, req_ids=("r0",))))
+        same = decode_prep_fast.signature_of(_runner(input_batch=_input_batch(num_reqs=1, req_ids=("r0",))))
+        other = decode_prep_fast.signature_of(_runner(input_batch=_input_batch(num_reqs=1, req_ids=("r1",))))
+        two = decode_prep_fast.signature_of(_runner(input_batch=_input_batch(num_reqs=2, req_ids=("r0", "r1"))))
+        assert one == same
+        assert one != other
+        assert one != two
+
+    def test_invalidate_drops_the_signature(self):
+        """Anything that rewrites the shared buffers behind `_prepare_inputs`
+        has to make the next step ineligible."""
+        cache = decode_prep_fast.DecodeInputCache()
+        cache.signature = (1, ("r0",))
+        cache.block_table_snapshot = [np.zeros(4, dtype=np.int32)]
+        cache.invalidate()
+        assert cache.signature is None
+
+    def test_the_cache_holds_no_torch_tensors(self):
+        """A tensor created under `inference_mode` cannot be carried into a
+        later step, so nothing cached here may be one."""
+        import torch
+
+        cache = decode_prep_fast.DecodeInputCache()
+        cache.signature = (1, ("r0",))
+        cache.cu_num_tokens = np.zeros(2, dtype=np.int32)
+        cache.num_tokens_np = np.ones(1, dtype=np.int32)
+        cache.block_table_snapshot = [np.zeros((1, 4), dtype=np.int32)]
+        for slot in decode_prep_fast.DecodeInputCache.__slots__:
+            value = getattr(cache, slot)
+            values = value if isinstance(value, list) else [value]
+            assert not any(isinstance(v, torch.Tensor) for v in values), slot

--- a/vllm_omni/platforms/npu/worker/decode_prep_fast.py
+++ b/vllm_omni/platforms/npu/worker/decode_prep_fast.py
@@ -1,0 +1,375 @@
+"""Steady-state decode input preparation for the MiniCPM-o Talker.
+
+`_prepare_inputs` is written for the general case: chunked prefill, spec decode,
+PCP/DCP, M-RoPE, LoRA, prompt embeds. It rebuilds every per-step tensor from
+numpy each step and pushes ~15 separate H2D copies, because in general every
+one of them can change.
+
+On the scored simplex path none of them do. Stage 1 runs one request at a time
+generating one codec frame per step for ~118 steps, and across those steps the
+request set, the batch shape and the scheduled-token counts are all constant.
+Only four things move: the token that was just sampled, the position, the
+sequence length and the KV slot. Everything else -- `query_start_loc`,
+`req_indices`, `query_pos`, `num_scheduled_tokens`, `num_accepted_tokens`,
+`logits_indices`, `query_lens` -- is recomputed to the same value it already
+held.
+
+Measured in place on A3 / 910C with the stock deploy config, Seed-TTS zh,
+32 requests at concurrency 1: `_prepare_inputs` runs 3591 times in stage 1 and
+507 times in stage 0 per run, costing 0.95-1.24 ms a call and 127 ms of host
+time per request. 98% of those calls are steps where nothing it rebuilds has
+changed. This module reuses the previous step's tensors when the batch is
+provably unchanged and applies only the deltas, which takes that 127 ms to
+81 ms.
+
+**The reuse rule is deliberately narrow.** The fast path runs only when the
+*immediately preceding* step also prepared a pure single-token decode with the
+identical request set. Any other step -- a prefill, a new request, a reordering
+-- goes through the generic path, which rewrites the shared buffers, and only
+the step after *that* becomes eligible again. So a cached tensor can never
+outlive the buffer contents it was cached against.
+
+There is no switch to turn this off, because there is no state in which it is
+the only thing standing between a correct step and a wrong one: every gate below
+returns a *reason* and the caller falls back to the generic path, so an
+unrecognised configuration, an unfamiliar block-table layout or an unexpected
+step shape all degrade to today's behaviour rather than to a guess.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import torch
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class DecodeInputCache:
+    """Per-runner state for the steady-state decode reuse.
+
+    **Holds no torch tensors.** A tensor created inside `torch.inference_mode()`
+    is an inference tensor; carrying one into a later step and indexing with it
+    raises "Inference tensors cannot be saved for backward". Everything cached
+    here is a numpy array, an int, or an enum, and every tensor the fast path
+    hands back is built in the step that uses it.
+    """
+
+    __slots__ = (
+        "signature",
+        "cu_num_tokens",
+        "num_tokens_np",
+        "block_table_snapshot",
+        "static_ok",
+        "attn_state",
+        "with_prefill",
+        "fast_steps",
+        "generic_steps",
+        "blocked_reason",
+    )
+
+    def __init__(self) -> None:
+        self.signature: tuple | None = None
+        self.cu_num_tokens: np.ndarray | None = None
+        self.num_tokens_np: np.ndarray | None = None
+        self.block_table_snapshot: list[np.ndarray] | None = None
+        self.static_ok: bool | None = None
+        # Taken from the generic run rather than imported: the enum lives in
+        # vllm-ascend, which a ranked run installs but does not let us patch.
+        self.attn_state: Any = None
+        self.with_prefill: bool = False
+        self.fast_steps: int = 0
+        self.generic_steps: int = 0
+        self.blocked_reason: str | None = None
+
+    def invalidate(self) -> None:
+        self.signature = None
+
+
+def _static_gate_block(runner: Any) -> str | None:
+    """Configuration-level gates, evaluated once per runner.
+
+    Every branch of `_prepare_inputs` that the fast path does not reproduce is
+    excluded here rather than tested per step. Returns the name of the first
+    gate that blocks, or None when the fast path is allowed -- a bare bool made
+    a non-engaging fast path indistinguishable from a broken one.
+    """
+    try:
+        from vllm.distributed.parallel_state import get_pp_group
+
+        if get_pp_group().world_size > 1:
+            return "pipeline_parallel"
+    except Exception:
+        return "no_pp_group"
+    if getattr(runner, "uses_mrope", False):
+        return "mrope"
+    if getattr(runner, "uses_xdrope_dim", 0):
+        return "xdrope"
+    if getattr(runner, "pcp_size", 1) != 1 or getattr(runner, "dcp_size", 1) != 1:
+        return "pcp_dcp"
+    if getattr(runner, "use_cp", False):
+        return "context_parallel"
+    if getattr(runner, "speculative_config", None) is not None:
+        return "speculative_config"
+    if getattr(runner, "num_spec_tokens", 0):
+        return "num_spec_tokens"
+    if getattr(runner, "use_async_spec_decode", False):
+        return "async_spec_decode"
+    if not getattr(runner, "use_async_scheduling", False):
+        return "not_async_scheduling"
+    if getattr(runner, "enable_prompt_embeds", False):
+        return "prompt_embeds"
+    if getattr(runner, "_has_gdn", False):
+        return "gdn"
+    if getattr(runner, "lora_config", None) is not None:
+        return "lora"
+    # Deliberately *not* gated on `cascade_attn_enabled`. Cascade prefix
+    # lengths are computed in `execute_model` after `_prepare_inputs` returns
+    # and are consumed by `_build_attention_metadata`, which stays generic --
+    # `_prepare_inputs` has no cascade branch at all. Gating on it here kept
+    # the fast path off the Talker entirely (round 20260828T103028Z).
+    if getattr(runner, "dynamic_eplb", False):
+        return "dynamic_eplb"
+    model_config = getattr(runner, "model_config", None)
+    if getattr(model_config, "enable_encoder_decoder", False):
+        return "encoder_decoder"
+    if getattr(model_config, "is_encoder_decoder", False):
+        return "is_encoder_decoder"
+    if getattr(model_config, "enable_return_routed_experts", False):
+        return "routed_experts"
+    cache_config = getattr(runner, "cache_config", None)
+    if getattr(cache_config, "mamba_cache_mode", None) == "align":
+        return "mamba_align"
+    try:
+        from vllm_ascend.utils import lmhead_tp_enable
+
+        if lmhead_tp_enable():
+            return "lmhead_tp"
+    except Exception:
+        return "no_lmhead_tp_probe"
+    return None
+
+
+def _step_gate_block(runner: Any, scheduler_output: Any, num_scheduled_tokens: np.ndarray) -> str | None:
+    """Per-step gates: this really is a plain one-token-per-request decode."""
+    if scheduler_output.scheduled_spec_decode_tokens:
+        return "spec_decode_tokens"
+    if getattr(runner, "calculate_kv_scales", False):
+        return "kv_scales"
+    if getattr(runner, "num_accepted_tokens_event", None) is not None:
+        return "accepted_tokens_event"
+    if getattr(runner, "routed_experts_initialized", False):
+        return "routed_experts"
+    input_batch = runner.input_batch
+    if getattr(input_batch, "req_prompt_embeds", None):
+        return "req_prompt_embeds"
+    if input_batch.prev_sampled_token_ids is None:
+        # Nothing to scatter from; the generic path's CPU copy is required.
+        return "no_prev_sampled_token_ids"
+    if not input_batch.prev_req_id_to_index:
+        return "no_prev_req_index"
+    num_reqs = input_batch.num_reqs
+    if num_reqs <= 0:
+        return "no_requests"
+    if int(scheduler_output.total_num_scheduled_tokens) != num_reqs:
+        return "not_one_token_per_request"
+    if not bool(np.all(num_scheduled_tokens[:num_reqs] == 1)):
+        return "not_one_token_per_request"
+    # A step where any request is still consuming its prompt is not a decode.
+    if bool(np.any(input_batch.num_computed_tokens_cpu[:num_reqs] == 0)):
+        return "prefill_in_batch"
+    return None
+
+
+def _log_block_once(cache: DecodeInputCache, reason: str) -> None:
+    """Say once why the fast path never engaged; silence is the worse failure."""
+    if cache.blocked_reason == reason:
+        return
+    cache.blocked_reason = reason
+    logger.info("[minicpmo] fast decode prep not engaged: %s", reason)
+
+
+def _block_tables_unchanged(runner: Any, cache: DecodeInputCache, num_reqs: int) -> bool:
+    """True when every block-table row is byte-identical to the last committed one.
+
+    A decode allocates a new block once per `block_size` tokens, so for 127 of
+    every 128 Talker steps the table the generic path re-uploads is the table
+    already on the device. Returns False -- and refreshes the snapshot -- if it
+    cannot see the rows, so an unrecognised block-table layout just keeps
+    committing every step.
+    """
+    tables = getattr(runner.input_batch.block_table, "block_tables", None)
+    if not tables:
+        return False
+    views = []
+    for table in tables:
+        rows = getattr(getattr(table, "block_table", None), "np", None)
+        if rows is None:
+            return False
+        views.append(rows[:num_reqs])
+    previous = cache.block_table_snapshot
+    if previous is not None and len(previous) == len(views):
+        if all(np.array_equal(p, v) for p, v in zip(previous, views)):
+            return True
+    cache.block_table_snapshot = [v.copy() for v in views]
+    return False
+
+
+def snapshot_block_tables(runner: Any, cache: DecodeInputCache, num_reqs: int) -> None:
+    """Record the rows the generic path just committed, so the next fast step
+    can tell whether anything moved."""
+    tables = getattr(runner.input_batch.block_table, "block_tables", None)
+    if not tables:
+        cache.block_table_snapshot = None
+        return
+    views = []
+    for table in tables:
+        rows = getattr(getattr(table, "block_table", None), "np", None)
+        if rows is None:
+            cache.block_table_snapshot = None
+            return
+        views.append(rows[:num_reqs].copy())
+    cache.block_table_snapshot = views
+
+
+def signature_of(runner: Any) -> tuple:
+    input_batch = runner.input_batch
+    return (input_batch.num_reqs, tuple(input_batch.req_ids))
+
+
+def try_fast_prepare(
+    runner: Any,
+    scheduler_output: Any,
+    num_scheduled_tokens: np.ndarray,
+) -> tuple | None:
+    """Prepare a steady-state decode step, or return None to use the generic path."""
+    cache: DecodeInputCache = runner._decode_input_cache
+    if cache.static_ok is None:
+        block = _static_gate_block(runner)
+        cache.static_ok = block is None
+        if block is not None:
+            logger.info("[minicpmo] fast decode prep disabled for this stage: %s", block)
+    if not cache.static_ok:
+        return None
+    block = _step_gate_block(runner, scheduler_output, num_scheduled_tokens)
+    if block is not None:
+        _log_block_once(cache, block)
+        cache.invalidate()
+        return None
+    if cache.signature is None or cache.signature != signature_of(runner):
+        # The previous step did not leave the shared buffers in a shape this
+        # step can inherit. Fall through; `note_generic` re-arms the cache.
+        return None
+
+    input_batch = runner.input_batch
+    num_reqs = input_batch.num_reqs
+    total = num_reqs
+
+    # The block table grows once per `block_size` tokens under a decode, so
+    # this is a delta -- but almost always a no-op delta, and the upload is
+    # ~0.15 ms of the step.
+    if not _block_tables_unchanged(runner, cache, num_reqs):
+        input_batch.block_table.commit_block_table(num_reqs)
+
+    runner.with_prefill = cache.with_prefill
+    runner.attn_state = cache.attn_state
+
+    computed_cpu_tensor = input_batch.num_computed_tokens_cpu_tensor
+    # numpy, not torch. Nothing here may outlive the step that made it: a torch
+    # tensor born inside `torch.inference_mode()` is an *inference tensor*, and
+    # a later step indexing with it raises "Inference tensors cannot be saved
+    # for backward". Only plain arrays and scalars are safe to carry across
+    # steps -- round 20260828T100420Z died on exactly this.
+    np.add(
+        input_batch.num_computed_tokens_cpu[:num_reqs],
+        np.int32(1),
+        out=runner.optimistic_seq_lens_cpu.numpy()[:num_reqs],
+    )
+
+    # `prev_positions` feeds the scatter in `_prepare_input_ids`; both are
+    # cheap and both depend on this step's request order.
+    runner._compute_prev_positions(num_reqs)
+    runner._prepare_input_ids(scheduler_output, num_reqs, total, cache.cu_num_tokens)
+
+    runner.num_computed_tokens[:num_reqs].copy_(computed_cpu_tensor[:num_reqs], non_blocking=True)
+    # One scheduled token per request means `query_pos` is all zeros and
+    # `req_indices` is arange(num_reqs), so both gathers collapse to a slice.
+    runner.positions[:total] = runner.num_computed_tokens[:num_reqs].to(torch.int64)
+    runner.seq_lens[:num_reqs] = runner.num_computed_tokens[:num_reqs] + 1
+
+    input_batch.block_table.compute_slot_mapping(
+        num_reqs,
+        runner.query_start_loc.gpu[: num_reqs + 1],
+        runner.positions[:total],
+    )
+
+    # A request whose sampled token would land past its own length must be
+    # discarded. In steady state nothing is discarded, but the compare is a
+    # handful of CPU elements and the cost of being wrong is a wrong token.
+    num_tokens_np = cache.num_tokens_np
+    for i, req_id in enumerate(input_batch.req_ids[:num_reqs]):
+        num_tokens_np[i] = runner.requests[req_id].num_tokens
+    discard_mask = runner.optimistic_seq_lens_cpu[:num_reqs].numpy() < num_tokens_np[:num_reqs]
+    if bool(discard_mask.any()):
+        cache.invalidate()
+        return None
+    if runner.num_discarded_requests:
+        runner.num_discarded_requests = 0
+        runner.discard_request_mask.np[:num_reqs] = False
+        runner.discard_request_mask.copy_to_gpu(num_reqs)
+
+    # Both are rebuilt, not cached, for the reason in the note above. One
+    # scheduled token per request makes `logits_indices` the last (only)
+    # position of each request, which is what the generic path computes too.
+    logits_indices = runner.query_start_loc.gpu[1 : num_reqs + 1] - 1
+    runner.query_lens = torch.from_numpy(num_scheduled_tokens[:num_reqs])
+    runner.logits_indices = logits_indices
+    cache.fast_steps += 1
+    if cache.fast_steps == 1:
+        logger.info("[minicpmo] fast decode prep engaged (num_reqs=%d)", num_reqs)
+    return logits_indices, None, total
+
+
+def note_generic(
+    runner: Any,
+    scheduler_output: Any,
+    num_scheduled_tokens: np.ndarray,
+    result: tuple,
+) -> None:
+    """Arm the cache from a generic run, when that run was itself a plain decode."""
+    cache: DecodeInputCache = runner._decode_input_cache
+    cache.generic_steps += 1
+    if not cache.static_ok:
+        return
+    _logits_indices, spec_decode_metadata, total = result
+    if spec_decode_metadata is not None:
+        _log_block_once(cache, "spec_decode_metadata")
+        cache.invalidate()
+        return
+    block = _step_gate_block(runner, scheduler_output, num_scheduled_tokens)
+    if block is not None:
+        _log_block_once(cache, block)
+        cache.invalidate()
+        return
+    num_reqs = runner.input_batch.num_reqs
+    if int(total) != num_reqs:
+        _log_block_once(cache, "total_tokens_ne_num_reqs")
+        cache.invalidate()
+        return
+    if runner.num_discarded_requests:
+        # Something in this batch is not sampled; the fast path assumes nothing is.
+        _log_block_once(cache, "discarded_requests")
+        cache.invalidate()
+        return
+    if runner.with_prefill:
+        _log_block_once(cache, "with_prefill")
+        cache.invalidate()
+        return
+    cache.attn_state = runner.attn_state
+    cache.with_prefill = runner.with_prefill
+    cache.cu_num_tokens = np.arange(1, num_reqs + 1, dtype=np.int32)
+    cache.num_tokens_np = np.zeros(num_reqs, dtype=np.int32)
+    snapshot_block_tables(runner, cache, num_reqs)
+    cache.signature = signature_of(runner)

--- a/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
@@ -48,6 +48,7 @@ from vllm_omni.distributed.omni_connectors.kv_transfer_manager import OmniKVTran
 from vllm_omni.distributed.omni_connectors.utils.config import stage_sends_async_output
 from vllm_omni.experimental.fullduplex.model_executor import DuplexSamplingRunnerMixin
 from vllm_omni.outputs import OmniModelRunnerOutput
+from vllm_omni.platforms.npu.worker import decode_prep_fast
 from vllm_omni.platforms.npu.worker.npu_model_runner import OmniNPUModelRunner
 from vllm_omni.utils.mm_outputs import build_mm_cpu, partition_payload_list, to_payload_element
 from vllm_omni.worker.omni_connector_model_runner_mixin import (
@@ -113,6 +114,7 @@ class NPUARModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self._decode_input_cache = decode_prep_fast.DecodeInputCache()
         self.input_ids = self._make_buffer(self.max_num_tokens, dtype=torch.int32)
         # each model stage has their own hidden size
         self.hidden_size = self.model_config.hf_text_config.hidden_size
@@ -384,6 +386,31 @@ class NPUARModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
             return value.lower() in ("1", "true", "yes", "on")
         return bool(value)
     #  -------------------------------------- Omni-new -------------------------------------------------
+
+    def _dummy_run(self, *args, **kwargs):
+        """Invalidate the decode-input cache around a dummy run.
+
+        A dummy run rewrites the shared input buffers without going through
+        `_prepare_inputs`, so anything cached against them is stale afterwards.
+        """
+        self._decode_input_cache.invalidate()
+        return super()._dummy_run(*args, **kwargs)
+
+    def _prepare_inputs(self, scheduler_output, num_scheduled_tokens):
+        """Reuse the previous step's inputs when this is the same decode again.
+
+        The Talker spends ~112 consecutive steps on one request emitting one
+        codec frame each, and `_prepare_inputs` rebuilds every tensor from numpy
+        every time. See `decode_prep_fast` for the reuse rule, for what the fast
+        path still recomputes, and for why every gate degrades to this generic
+        path rather than to a guess.
+        """
+        fast = decode_prep_fast.try_fast_prepare(self, scheduler_output, num_scheduled_tokens)
+        if fast is not None:
+            return fast
+        result = super()._prepare_inputs(scheduler_output, num_scheduled_tokens)
+        decode_prep_fast.note_generic(self, scheduler_output, num_scheduled_tokens, result)
+        return result
 
     @torch.inference_mode()
     def execute_model(


### PR DESCRIPTION
## Purpose

`_prepare_inputs` on the NPU AR runner is written for the general case — chunked
prefill, speculative decode, PCP/DCP, M-RoPE, LoRA, prompt embeds — and rebuilds
every per-step tensor from numpy on every call, pushing ~15 separate H2D copies,
because in general every one of them can change.

On a long single-request decode, none of them do. The MiniCPM-o Talker spends
~112 consecutive steps on one request emitting one codec frame each. Across
those steps the request set, the batch shape and the scheduled-token counts are
all constant; only four things move — the token just sampled, the position, the
sequence length, and the KV slot. Everything else (`query_start_loc`,
`req_indices`, `query_pos`, `num_scheduled_tokens`, `num_accepted_tokens`,
`logits_indices`, `query_lens`) is recomputed to the value it already held.

This PR caches the previous step's derived arrays and applies only the deltas.

## What the removed work costs, measured in place

The evidence here is a timer around the function itself, not an end-to-end
delta: on a shared box a sub-5% end-to-end difference is not resolvable, but
"this call took N µs and ran M times per request" is something a reviewer can
re-derive.

Atlas A3 / 910C, stock `minicpmo_4_5.yaml`, Seed-TTS zh, **32 requests at
concurrency 1**, `_prepare_inputs` wrapped with `perf_counter_ns` and a call
counter dumped per pid. Two rounds; round 2 swaps which die each arm runs on and
runs the arms concurrently.

| | calls / run | round 1 control | round 1 with PR | round 2 control | round 2 with PR |
| --- | ---: | ---: | ---: | ---: | ---: |
| stage 0 (Thinker) | 507 | 562.9 ms | 402.2 ms | 629.0 ms | 369.4 ms |
| stage 1 (Talker) | 3591 | 3410.6 ms | 2183.3 ms | 3547.6 ms | 2213.4 ms |
| **total** | **4098** | **3973.5 ms** | **2585.5 ms** | **4176.6 ms** | **2582.8 ms** |
| per request | | 124.2 ms | **80.8 ms** | 130.5 ms | **80.7 ms** |
| reduction | | | **−34.9%** | | **−38.2%** |

Per call, stage 1: **949.6 / 987.9 µs → 607.9 / 616.4 µs.**

**Call counts are identical in every arm** (507 and 3591), so the two arms did
the same work; only the cost of preparing it moved. The fast path served
**3523 of 3591** stage-1 calls (98.1%) and 439 of 507 stage-0 calls (86.6%).

One thing worth noticing in that table: the treated arm reads **2585.5 and
2582.8 ms** across two rounds on two different dies — 0.1% apart — while the
control reads 3973.5 and 4176.6, which are 5.1% apart. Removing the host work
also removes its sensitivity to what else the box is doing.

### End to end, as corroboration only

| | round 1 | round 2 |
| --- | ---: | ---: |
| mean e2el | 1980.3 → 1928.0 ms (−2.64%) | 1914.1 → 1888.9 ms (−1.32%) |
| mean audio RTF | 0.4715 → 0.4596 (−2.51%) | 0.4575 → 0.4514 (−1.33%) |
| total output tokens | 435 → 435 | 435 → 435 |

Negative in both rounds with the dies swapped, and in the same band as the
in-place saving (43-50 ms against a ~1950 ms request is 2.2-2.6%). I would not
ask anyone to accept the end-to-end numbers on their own — this box drifts more
than that — but they agree with the in-place measurement, and the identical
token counts show the output did not change.

## How the reuse stays safe

The rule is deliberately narrow. The fast path runs **only when the immediately
preceding step also prepared a pure single-token decode with the identical
request set.** Any other step — a prefill, a new request, a reordering, a dummy
run — goes through the generic path, which rewrites the shared buffers, and only
the step *after that* becomes eligible again. A cached array therefore cannot
outlive the buffer contents it was cached against.

Three further properties, each with a test:

- **Every gate returns a reason, not a bool.** A bare bool makes a fast path
  that never engages indistinguishable from one that is broken; with reasons,
  the first block is logged once and says which one it was. There is no
  environment switch to disable this, because there is no state in which it is
  the only thing standing between a correct step and a wrong one — an
  unrecognised config, an unfamiliar block-table layout or an unexpected step
  shape all degrade to today's behaviour.
- **The block table is compared, not assumed.** A decode allocates a block once
  per `block_size` tokens, so most steps re-upload a table the device already
  has; the snapshot is a copy rather than a view, or it would compare the live
  buffer against itself.
- **The cache holds no torch tensors.** A tensor created inside
  `torch.inference_mode()` is an inference tensor, and indexing with one in a
  later step raises "Inference tensors cannot be saved for backward". Everything
  cached is a numpy array, an int or an enum.

`cascade_attn_enabled` is deliberately *not* a gate: cascade prefix lengths are
computed in `execute_model` after `_prepare_inputs` returns and are consumed by
`_build_attention_metadata`, which stays generic — `_prepare_inputs` has no
cascade branch. Gating on it kept the fast path off entirely.

## Test Plan

**vLLM Version:** `0.1.dev1+ge5588e49b` (`0.28.0` line)

**vLLM-Omni Commit:** `d1c8beeb180b4617437c460ba5c8f61a4a561a7e`

1. **Unit tests, CPU only** — `tests/platforms/npu/worker/test_decode_prep_fast.py`,
   17 tests. The gates read plain attributes off the runner, the scheduler
   output and the input batch, so they take duck-typed stand-ins: no
   accelerator, no model, no engine. They cover the step gate (plain decode
   allowed; speculative tokens, multi-token steps, a request still on its
   prompt, an empty batch and three pieces of runner state each blocked with
   their own reason), the block-table snapshot (first call records rather than
   claims unchanged, an identical table is recognised, a newly allocated block
   is noticed, the snapshot is a copy not a view, an unreadable layout keeps
   committing), the signature, and the two invariants above.
2. **In-place probe on real hardware** — the two rounds in the table, on an
   Atlas A3 / 910C.

**On which branch the hardware numbers were taken.** This box's image ships a
vLLM that `main` no longer imports against (`CoreEngineLaunch` is missing from
`vllm.v1.engine.utils`), so `main` cannot serve here. The rounds were run on
`ecd9d99da`. The hook point is unchanged between the two: the `_prepare_inputs`
call site in `npu_ar_model_runner.py` is byte-identical in the surrounding
block, and on both branches `_prepare_inputs` resolves to vllm-ascend's
`NPUModelRunner` with nothing caching it. The diff in this PR applies cleanly to
`d1c8beeb1` and its unit tests run there; I could not run a served benchmark on
`main` myself, and would want a reviewer with a current stack to confirm the
end-to-end column.

## Test Result

`tests/platforms/npu/` on `d1c8beeb1`, same box, before and after:

```
main             : 63 passed, 1 skipped
main + this PR   : 80 passed, 1 skipped
```

+17, no new failures, nothing skipped that was not skipped before. The new file
alone:

```
tests/platforms/npu/worker/test_decode_prep_fast.py    17 passed in 0.06s
```
