### PR TITLE
[Perf][MiniCPM-o] Fold HiFT's weight norm once at load instead of on every chunk

### DIFF
--- a/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 import torch.nn as nn
+from torch.nn.utils import parametrize
 
 import vllm_omni.model_executor.models.minicpmo_4_5.batched_token2wav as batched_token2wav_module
 from vllm_omni.model_executor.models.minicpmo_4_5.batched_token2wav import (
@@ -20,6 +21,7 @@ from vllm_omni.model_executor.models.minicpmo_4_5.batched_token2wav import (
 )
 from vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_code2wav import (
     MiniCPMO45Code2Wav,
+    fold_weight_norm,
 )
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
@@ -1313,3 +1315,64 @@ def test_reference_voice_and_duplex_metadata_follow_request_lifecycle():
     assert prompt_key not in model._runtime_prompts
     assert not Path(prompt_wav).exists()
     assert (prompt_cache_id, prompt_wav) not in model.backend._prompt_features
+
+
+class _WeightNormedStack(nn.Module):
+    """A stand-in for HiFT's convolution stack, with weight norm live."""
+
+    def __init__(self, legacy: bool = False):
+        super().__init__()
+        if legacy:
+            import warnings
+
+            from torch.nn.utils import weight_norm
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                self.conv_pre = weight_norm(nn.Conv1d(4, 4, 3, padding=1))
+                self.body = nn.Sequential(weight_norm(nn.Conv1d(4, 4, 3, padding=1)))
+        else:
+            from torch.nn.utils.parametrizations import weight_norm
+
+            self.conv_pre = weight_norm(nn.Conv1d(4, 4, 3, padding=1))
+            self.body = nn.Sequential(weight_norm(nn.Conv1d(4, 4, 3, padding=1)))
+        self.plain = nn.Conv1d(4, 4, 1)
+
+    def forward(self, x):
+        return self.plain(self.body(self.conv_pre(x)))
+
+
+@pytest.mark.parametrize("legacy", [False, True])
+def test_fold_weight_norm_materializes_the_effective_inference_weight(legacy: bool) -> None:
+    torch.manual_seed(0)
+    model = _WeightNormedStack(legacy=legacy).eval()
+    x = torch.randn(1, 4, 16)
+
+    with torch.no_grad():
+        expected = model(x).clone()
+    effective = {
+        name: child.weight.detach().clone() for name, child in model.named_modules() if name in ("conv_pre", "body.0")
+    }
+
+    folded = fold_weight_norm(model)
+
+    assert set(folded) == {"conv_pre.weight", "body.0.weight"}
+    for name, child in model.named_modules():
+        if name in effective:
+            torch.testing.assert_close(child.weight, effective[name], rtol=0, atol=0)
+            assert not parametrize.is_parametrized(child, "weight")
+            assert not child._forward_pre_hooks
+    with torch.no_grad():
+        torch.testing.assert_close(model(x), expected, rtol=0, atol=0)
+
+
+def test_fold_weight_norm_leaves_plain_modules_untouched() -> None:
+    model = nn.Sequential(nn.Conv1d(2, 2, 1), nn.Linear(2, 2))
+    assert fold_weight_norm(model) == ()
+
+
+def test_fold_weight_norm_is_idempotent() -> None:
+    torch.manual_seed(1)
+    model = _WeightNormedStack().eval()
+    assert len(fold_weight_norm(model)) == 2
+    assert fold_weight_norm(model) == ()

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_code2wav.py
@@ -16,6 +16,7 @@ from typing import Any
 import soundfile as sf
 import torch
 import torch.nn as nn
+from torch.nn.utils import parametrize
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 
@@ -42,6 +43,39 @@ def _resolve_model_dir(model_ref: str, revision: str | None = None) -> str:
     from huggingface_hub import snapshot_download
 
     return snapshot_download(model_ref, revision=revision, allow_patterns=["assets/*"])
+
+
+def fold_weight_norm(module: nn.Module) -> tuple[str, ...]:
+    """Materialize frozen weight-norm parametrizations once, for inference.
+
+    HiFT wraps every convolution in weight norm and keeps it live, so each
+    forward recomputes ``g * v / ||v||`` -- a norm reduction plus a broadcast
+    multiply per convolution -- even though an inference weight never changes.
+    Removing the parametrization with ``leave_parametrized=True`` stores the
+    weight the model is already using, so the arithmetic is unchanged and the
+    per-call kernels go away.
+
+    Both spellings are handled: ``torch.nn.utils.parametrizations.weight_norm``
+    (what ``flashcosyvoice`` uses when torch provides it) and the legacy
+    forward-pre-hook ``torch.nn.utils.weight_norm``.
+
+    Returns the qualified names of the weights that were folded.
+    """
+    from torch.nn.utils import remove_weight_norm
+    from torch.nn.utils.weight_norm import WeightNorm
+
+    folded: list[str] = []
+    for module_name, child in list(module.named_modules()):
+        qualified = f"{module_name}.weight" if module_name else "weight"
+        if parametrize.is_parametrized(child, "weight"):
+            if not any(type(item).__name__ == "_WeightNorm" for item in child.parametrizations.weight):
+                continue
+            parametrize.remove_parametrizations(child, "weight", leave_parametrized=True)
+            folded.append(qualified)
+        elif any(isinstance(hook, WeightNorm) for hook in child._forward_pre_hooks.values()):
+            remove_weight_norm(child)
+            folded.append(qualified)
+    return tuple(folded)
 
 
 def _batch_error(reason: str, **details: Any) -> RuntimeError:
@@ -867,6 +901,10 @@ class MiniCPMO45Code2Wav(nn.Module):
             )
         finally:
             torch.set_default_dtype(previous_dtype)
+
+        if bool(extra.get("token2wav_hift_fold_weight_norm", True)):
+            folded = fold_weight_norm(token2wav.hift)
+            logger.info("Folded weight norm into %d HiFT inference weights", len(folded))
 
         trt_stepper = None
         use_trt = bool(extra.get("token2wav_trt", False)) or os.environ.get("MINICPMO_TOKEN2WAV_TRT", "") == "1"


### PR DESCRIPTION
## Purpose

MiniCPM-o 4.5's Code2Wav stage builds its HiFT vocoder with weight norm live on
**all 82 convolution weights**, and leaves it that way for the life of the
server. An inference weight never changes, so every streamed audio chunk
recomputes `g * v / ||v||` for each of them — a norm reduction plus a broadcast
multiply, per convolution, per call — and gets the same tensor back every time.

`parametrize.remove_parametrizations(..., leave_parametrized=True)` stores the
weight the module is *already* using and drops the parametrization. The
arithmetic that produces the weight is unchanged; it simply happens once, at
load, instead of on the streaming path.

### Why this has been sitting there

HiFT does ship a `remove_weight_norm()` of its own — but it calls the legacy
`torch.nn.utils.remove_weight_norm`, which only knows the forward-pre-hook
spelling, while `flashcosyvoice` selects
`torch.nn.utils.parametrizations.weight_norm` whenever torch provides it. On any
current torch that method raises

```
ValueError: weight_norm of 'weight' not found in ParametrizedConv1d(...)
```

rather than folding anything, and nothing in the serving path calls it anyway.
`fold_weight_norm` therefore handles **both** spellings and returns the names it
folded, so a no-op shows up in the log line instead of passing silently.

### Scope and blast radius

- **Not Ascend-specific.** The work it removes is the same on any accelerator,
  which is why the tests are plain CPU tests over both spellings. The numbers
  below are from an Atlas A3; no claim is made about the size of the win
  elsewhere.
- It runs in `_build_backend`, after `Token2wav(...)` has loaded `flow.pt` and
  `hift.pt` inside its own constructor. The stage's `load_weights` puts nothing
  further into HiFT, so no later weight load can be surprised by it.
- It does change HiFT's `state_dict` keys — `parametrizations.weight.original0/1`
  become `weight`. Nothing in the serving path reads that state dict after
  construction.
- `token2wav_hift_fold_weight_norm: false` in the stage's `extra` config turns it
  off.

## Test Plan

**vLLM Version:** `0.1.dev1+ge5588e49b` (built from `vllm-project/vllm@e5588e49b`)

**vLLM-Omni Commit:** this branch is against `main`. The **served** numbers below
were taken on `ecd9d99da` instead, and here is why: the vLLM in the Ascend image
these machines run (`0.1.dev1+ge5588e49b`) has no `vllm.v1.engine.utils.CoreEngineLaunch`,
which `vllm_omni/engine/stage_engine_startup.py` imports on `main`, so `main`
cannot start a server there at all. The changed code is identical on both bases
— `_build_backend` in `minicpmo_4_5_code2wav.py` — and the unit tests below run
on `main` itself.

### 1. Unit tests

`tests/model_executor/models/minicpmo_4_5/test_code2wav_batching.py`, 4 new
cases, all pure CPU: the folded weight is bit-identical to the effective weight
the module was already using and the forward output is unchanged — parametrized
**and** legacy-hook spellings; a plain module folds nothing; the fold is
idempotent.

### 2. What the fold removes, on the real vocoder

Both arms in **one process, on one loaded HiFT, alternating**. Folding is
reversible for measurement purposes: re-applying `weight_norm` to a folded
convolution recovers exactly the same effective weight (`g = ||v||`, `v = w`), so
the two arms can be swapped as often as we like. That takes host load, die
identity and weight layout out of the comparison, which matters on a shared box.

### 3. In situ, during a ranked run

The same paired round, but with a `time.perf_counter_ns()` wrapper around the
HiFT call itself in **both** arms, so the change is attributed where it happens
rather than inferred. (A host-side timer is fair here because HiFT's own
`_istft` copies its window up from host memory, which drains the device queue —
so the call is effectively synchronous on both arms.)

### 4. End-to-end, paired and die-swapped

Two arms differing only by this diff, both on `ecd9d99da`, the baseline deploy
config, no environment variables. Both arms run at the same time, one per die,
and the round is repeated with the dies swapped — this box is shared and its two
dies are not equally fast, so only a same-round paired delta means anything.

```bash
ASCEND_RT_VISIBLE_DEVICES=<die> BENCHMARK_DIR=<out> PYTHONPATH=<tree> \
python3 -m pytest -s -vv tests/dfx/perf/scripts/run_benchmark.py \
  --test-config-file <case>   # Seed-TTS zh, openai-chat-omni, c1, 32 prompts
```

## Test Result

### 1. Unit tests

`tests/model_executor/models/minicpmo_4_5/`, same machine, same interpreter:

| tree | result |
| --- | --- |
| `main` (`e51fe6ec1`) | 389 passed, 14 skipped, 3 failed |
| this branch | **393 passed**, 14 skipped, 3 failed |
| `ecd9d99da` | 91 passed, 3 skipped, 13 errors |
| the same change on `ecd9d99da` | **95 passed**, 3 skipped, 13 errors |

The four new cases are the whole difference. The three failures are on `main`
itself, identical in both arms and unrelated to this change:
`test_code2wav_batching.py::test_npu_patch_preserves_ragged_estimator_contract`
and two `test_cuda_graph_wrapper.py` cases, which want a newer vLLM than the
Ascend image on this machine ships. The 13 errors in the `ecd9d99da` rows were a
missing `pytest-mock`, installed since.

### 2. Per vocoder call — Atlas A3 / 910C, one process, arms alternating

| arm | per call | samples |
| --- | ---: | --- |
| weight norm live (upstream) | 18.156 ms | 17.906 17.928 18.156 18.164 18.277 |
| folded (this PR) | **13.122 ms** | 12.956 13.170 13.177 13.122 13.042 |
| | **−5.033 ms, −27.7%** | no overlap |

82 weights folded. The ranked configuration makes **5 vocoder calls per
request**, counted in the run in §4.

This is on an otherwise idle device. Two things say the `live` arm here is a
faithful stand-in for the as-loaded module: re-applying `weight_norm` to a folded
convolution recovers the same effective weight by construction, and its 18.16 ms
lands within 2% of the 17.80 ms that the *untouched base* spends per vocoder call
outside its own host-to-device copies (§4).

### 3. Numerically unchanged

| | max abs diff on the waveform |
| --- | ---: |
| same arm, same seed, twice (the device's own noise floor) | 7.26e-4 |
| live vs folded, same seed | **6.26e-4** |
| waveform peak amplitude | 0.233 |

The difference between the arms is **smaller than the difference between two
runs of the same arm**, which is what "bit-exact arithmetic on a
non-deterministic device" looks like. The CPU unit tests assert exactness
directly.

### 4. In situ, ranked configuration

A `time.perf_counter_ns()` wrapper around the HiFT call itself, in **both** arms,
during a paired ranked round:

| round | arm | die | HiFT per call | HiFT per request |
| --- | --- | --- | ---: | ---: |
| 1 | ctl | 1 | 66.44 ms | 332.2 ms |
| 1 | this PR | 0 | 65.39 ms | 327.0 ms |
| | | | **−1.05 ms** | −5.2 ms |
| 2 | ctl | 0 | 70.40 ms | 352.0 ms |
| 2 | this PR | 1 | 60.81 ms | 304.1 ms |
| | | | **−9.59 ms** | −47.9 ms |

160 calls in every arm — five per request, exactly. The per-round spread is
large because an in-situ HiFT call is mostly *waiting*, and how long it waits
depends on what the AR stages are doing on the same die; that is why the round is
run under both die assignments. Averaged over the two, **−5.3 ms per call**,
which is where the isolated −5.03 ms of §2 says it should be.

For context on what that 66 ms is: a separate probe on the untouched base times
HiFT's own three unpinned host-to-device copies (the harmonic multiplier, and the
STFT window twice) at 4.42 + 2 x 22.11 = **48.6 ms per call** of blocking. So of
a 66.4 ms vocoder call, 48.6 ms is the thread waiting at those copies and
17.8 ms is everything else HiFT does — which is the 18.16 ms of §2, and the
5.03 ms this PR removes comes out of it. (Those copies are a separate problem and
not this PR's; removing them does not need this change and this change does not
need them removed.)

### 5. End-to-end

| round | arm | die | RTF | e2el | completed | tokens | audio |
| --- | --- | --- | ---: | ---: | --- | ---: | ---: |
| 1 | ctl | 1 | 0.45594 | 1912.3 | 32/32 | 435 | 135.64 s |
| 1 | this PR | 0 | 0.45767 | 1916.5 | 32/32 | 435 | 135.64 s |
| | | | **+0.38%** | | | | |
| 2 | ctl | 0 | 0.46569 | 1949.6 | 32/32 | 435 | 135.64 s |
| 2 | this PR | 1 | 0.47101 | 1975.1 | 32/32 | 435 | 135.64 s |
| | | | **+1.14%** | | | | |

The two §4 rounds — same protocol, with the timer in both arms — read **−1.18%**
and **−2.30%** on the same column. So across four paired die-swapped rounds the
deltas are +0.38%, +1.14%, −1.18%, −2.30%: **the sign does not settle, and this
change is not resolvable end-to-end on this base.** I would rather say that than
pick the two rounds I like.

That is expected rather than disappointing. On this base stage 2 runs *behind*
the Talker: a saving inside the vocoder is hidden by the AR stage in front of it,
and only the final chunk is on the critical path, so ~25 ms of vocoder time per
request turns into a few ms of e2el — well under the 1.35% two identical arms
have measured apart on these dies (`ctl` itself drifted 2.1% between rounds 1
and 2). It stops being hidden as soon as the AR stages get faster, which is what
most of the open performance PRs on this branch do, and on any deployment where
stage 2 is not sharing a die with them.

The arms are otherwise identical: 32/32 completed, 435 output tokens and 135.64 s
of audio in all four arms. The measurements that should carry this PR are §2
and §4.
