### PR TITLE
[CI/Build][ROCm] Normalize SenseNova paged-decode hardware markers

### DIFF
--- a/tests/diffusion/models/sensenova_u1/test_sensenova_u1_paged_decode.py
+++ b/tests/diffusion/models/sensenova_u1/test_sensenova_u1_paged_decode.py
@@ -17,6 +17,7 @@ import torch
 from vllm.lora.layers import BaseLayerWithLoRA
 
 import vllm_omni.diffusion.models.sensenova_u1.paged_decode as paged_decode
+from tests.helpers.mark import hardware_test
 from vllm_omni.diffusion.models.sensenova_u1.paged_decode import (
     BLOCK_SIZE,
     BUCKETS,
@@ -169,7 +170,8 @@ def test_length_lives_in_device_tensors():
 
 
 # ---------------------------------------------------------------------------
-# The capture contract. These need CUDA and the bundled flash-attention kernel.
+# The capture contract. Graph tests need a torch.cuda-compatible accelerator;
+# paged-attention equivalence also needs the bundled kernel's paged API.
 # ---------------------------------------------------------------------------
 
 cuda_only = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
@@ -181,8 +183,7 @@ vllm_flash_attn_only = pytest.mark.skipif(
 
 @cuda_only
 @vllm_flash_attn_only
-@pytest.mark.cuda
-@pytest.mark.L4
+@hardware_test(res={"cuda": "L4", "rocm": "MI325"})
 def test_paged_attention_matches_sdpa_over_the_same_buffer():
     import torch.nn.functional as F
 
@@ -223,8 +224,7 @@ def test_paged_attention_matches_sdpa_over_the_same_buffer():
 
 @cuda_only
 @vllm_flash_attn_only
-@pytest.mark.cuda
-@pytest.mark.L4
+@hardware_test(res={"cuda": "L4", "rocm": "MI325"})
 def test_a_captured_graph_follows_a_later_length():
     """One capture has to serve every length in the bucket.
 
@@ -285,8 +285,7 @@ def test_a_captured_graph_follows_a_later_length():
 
 @cuda_only
 @vllm_flash_attn_only
-@pytest.mark.cuda
-@pytest.mark.L4
+@hardware_test(res={"cuda": "L4", "rocm": "MI325"})
 def test_a_captured_graph_writes_each_step_to_its_own_slot():
     """The write slot has to be a device tensor, not a Python index.
 
@@ -347,8 +346,7 @@ def test_a_captured_graph_writes_each_step_to_its_own_slot():
 
 @cuda_only
 @vllm_flash_attn_only
-@pytest.mark.cuda
-@pytest.mark.L4
+@hardware_test(res={"cuda": "L4", "rocm": "MI325"})
 def test_a_whole_decode_loop_matches_the_unpaged_path():
     """Per-step kernel equivalence is not loop equivalence.
 
@@ -413,8 +411,7 @@ class _StubLM(torch.nn.Module):
 
 
 @cuda_only
-@pytest.mark.cuda
-@pytest.mark.L4
+@hardware_test(res={"cuda": "L4", "rocm": "MI325"})
 def test_the_decode_graph_captures_into_the_shared_platform_pool(monkeypatch):
     """``_decode_context`` builds a runner per request, so a private capture pool
     hands every request its own arena and never gives it back. Measured on a
@@ -556,10 +553,12 @@ def test_a_kernel_missing_any_kwarg_we_pass_is_not_supported(monkeypatch):
 def test_only_q_k_and_v_reach_the_kernel_positionally(monkeypatch):
     """A positional standard argument binds to whatever a future wheel puts in
     that slot, and the probe above only checks that the names exist."""
-    seen = {}
+    seen_args: tuple[object, ...] = ()
+    seen_kwargs: dict[str, object] = {}
 
-    def recorder(*args, **kwargs):
-        seen["args"], seen["kwargs"] = args, kwargs
+    def recorder(*args: object, **kwargs: object):
+        nonlocal seen_args, seen_kwargs
+        seen_args, seen_kwargs = args, kwargs
         return torch.zeros(1, N_HEADS, HEAD_DIM)
 
     monkeypatch.setattr(paged_decode, "_flash_varlen", lambda: recorder)
@@ -572,8 +571,8 @@ def test_only_q_k_and_v_reach_the_kernel_positionally(monkeypatch):
         torch.zeros(1, KV_HEADS, 1, HEAD_DIM),
         1.0,
     )
-    assert len(seen["args"]) == 3, "only q, k and v may be positional"
-    assert set(seen["kwargs"]) == {
+    assert len(seen_args) == 3, "only q, k and v may be positional"
+    assert set(seen_kwargs) == {
         "max_seqlen_q",
         "cu_seqlens_q",
         "max_seqlen_k",
@@ -694,8 +693,7 @@ def test_no_capture_crosses_a_request_once_lora_wrappers_are_installed(monkeypat
 
 
 @cuda_only
-@pytest.mark.cuda
-@pytest.mark.L4
+@hardware_test(res={"cuda": "L4", "rocm": "MI325"})
 def test_a_second_request_replays_the_first_capture(monkeypatch):
     """Reuse is only worth anything if the capture survives it."""
     dev = torch.device("cuda")


### PR DESCRIPTION
## Purpose

Current `main` now contains the focused `vllm_flash_attn_only` guard for the four SenseNova tests that exercise the bundled paged FlashAttention API (`ea3cf998`). This refresh rebases the PR onto current `main`, keeps that upstream guard as the single source of truth, and retains the remaining CI/test cleanup:

- replace the six touched direct `cuda`/`L4` marks with `hardware_test(res={"cuda": "L4", "rocm": "MI325"})` so CUDA and ROCm resource metadata are explicit;
- preserve the upstream guard split: the four paged-kernel tests use `cuda_only` plus `vllm_flash_attn_only`, while the two graph-only tests use only `cuda_only` and remain runnable on ROCm;
- type the recorder's positional and keyword captures so changed-file mypy stays clean.

There is no production-path change and no new backend, model-name, or device-SKU conditional. The prior duplicate guard and its follow-up review-fix commit were not replayed during the rebase because upstream now provides that behavior.

## Test Plan and Results

**vLLM-Omni Commit:** `896f3b433fe3d66120d78b20e06137329901a5f1`

Local validation on this exact head:

- `pre-commit run --files tests/diffusion/models/sensenova_u1/test_sensenova_u1_paged_decode.py` — passed all applicable hooks, including Ruff, formatting, mypy, CI-mark validation, forbidden imports, and the CUDA API guard;
- `python3 -m compileall -q tests/diffusion/models/sensenova_u1/test_sensenova_u1_paged_decode.py` — passed;
- `python3 tools/pre_commit/check_test_marks.py tests/diffusion/models/sensenova_u1/test_sensenova_u1_paged_decode.py` — passed;
- `git diff --check origin/main...HEAD` — passed;
- AST validation confirmed all six hardware decorators and the intended four paged-kernel versus two graph-only guard split.

Exact-head GitHub checks are green: pre-commit, Python 3.11 and 3.12 wheel builds, DCO, and docs all passed.

The local macOS Python environment does not contain PyTorch. The retained `ready` label also did not register new CUDA or AMD Buildkite contexts after the force-push, and this account cannot toggle repository labels or start Buildkite directly. Exact-head accelerator runtime validation is therefore still pending a maintainer re-trigger.

Prior hardware evidence established the intended backend behavior before this refresh, but is not being treated as exact-head validation:

- AMD #11318 `Diffusion · Model Test`: exactly four paged-kernel cases skipped and both graph-only cases passed (`12 passed, 5 skipped`); the full AMD build passed 19/19 jobs.
- CUDA #14554 `Diffusion · Model Test`: all six SenseNova accelerator cases passed (`16 passed, 1 unrelated skip`).
