### PR TITLE
[CI/Build] Continue Whisper GPU capacity fix on current main

### DIFF
--- a/.buildkite/cuda/test-merge.yml
+++ b/.buildkite/cuda/test-merge.yml
@@ -77,6 +77,7 @@ steps:
     steps:
       - label: "TTS · Qwen3-TTS CustomVoice Test"
         source_file_dependencies:
+          - tests/helpers/media.py
           - tests/e2e/online_serving/test_qwen3_tts_customvoice.py
           - tests/e2e/offline_inference/test_qwen3_tts_customvoice.py
           - vllm_omni/model_executor/models/qwen3_tts/
@@ -99,6 +100,7 @@ steps:
 
       - label: "TTS · Qwen3-TTS Base Test"
         source_file_dependencies:
+          - tests/helpers/media.py
           - tests/e2e/online_serving/test_qwen3_tts_base.py
           - tests/e2e/offline_inference/test_qwen3_tts_base.py
           - vllm_omni/model_executor/models/qwen3_tts/

--- a/.buildkite/cuda/test-ready.yml
+++ b/.buildkite/cuda/test-ready.yml
@@ -245,6 +245,7 @@ steps:
 
       - label: "TTS · Qwen3-TTS CustomVoice Test"
         source_file_dependencies:
+          - tests/helpers/media.py
           - tests/e2e/online_serving/test_qwen3_tts_customvoice.py
           - vllm_omni/model_executor/models/qwen3_tts/
           - vllm_omni/model_executor/models/common/qwen3_code_predictor.py

--- a/tests/helpers/media.py
+++ b/tests/helpers/media.py
@@ -710,12 +710,14 @@ def _select_whisper_device() -> str:
 
     if current_omni_platform.is_available():
         n = current_omni_platform.get_device_count()
-        # Single-GPU runners (e.g. the L4 nightly): the model server already
-        # occupies device 0, and a Whisper model resident there competes with
-        # it for VRAM and OOMs. Only borrow an accelerator when a spare device
-        # exists; otherwise validate on CPU.
-        if n > 1:
-            device_index = n - 1
+        if n > 0:
+            target = n - 1
+            # Load Whisper on GPU only when >=16 GiB free VRAM remains.
+            # Keeps 24 GiB L4 runners on CPU (avoiding OOMs) while
+            # picking up high-VRAM single-GPU (e.g. H100, MI325X) and multi-GPU hosts.
+            target_device = current_omni_platform.get_torch_device(target)
+            if current_omni_platform.get_free_memory(target_device) >= 16 * 1024**3:
+                device_index = target
 
     if device_index is None:
         return "cpu"

--- a/tests/helpers/media.py
+++ b/tests/helpers/media.py
@@ -31,6 +31,8 @@ from PIL import Image
 
 logger = logging.getLogger(__name__)
 
+_MIN_FREE_VRAM = 16 * 1024**3
+
 
 _synthetic_media_fallback_dir: Path | None = None
 
@@ -710,14 +712,15 @@ def _select_whisper_device() -> str:
 
     if current_omni_platform.is_available():
         n = current_omni_platform.get_device_count()
-        if n > 0:
-            target = n - 1
-            # Load Whisper on GPU only when >=16 GiB free VRAM remains.
-            # Keeps 24 GiB L4 runners on CPU (avoiding OOMs) while
-            # picking up high-VRAM single-GPU (e.g. H100, MI325X) and multi-GPU hosts.
-            target_device = current_omni_platform.get_torch_device(target)
-            if current_omni_platform.get_free_memory(target_device) >= 16 * 1024**3:
-                device_index = target
+        # Check every visible device and use the one with the most free memory,
+        # but keep the CPU fallback when none has enough room for Whisper.
+        best_free_memory = _MIN_FREE_VRAM
+        for candidate_index in range(n):
+            candidate_device = current_omni_platform.get_torch_device(candidate_index)
+            free_memory = current_omni_platform.get_free_memory(candidate_device)
+            if free_memory >= best_free_memory:
+                device_index = candidate_index
+                best_free_memory = free_memory
 
     if device_index is None:
         return "cpu"

--- a/tests/helpers/media.py
+++ b/tests/helpers/media.py
@@ -712,15 +712,16 @@ def _select_whisper_device() -> str:
 
     if current_omni_platform.is_available():
         n = current_omni_platform.get_device_count()
-        # Check every visible device and use the one with the most free memory,
-        # but keep the CPU fallback when none has enough room for Whisper.
-        best_free_memory = _MIN_FREE_VRAM
-        for candidate_index in range(n):
+        # Prefer the highest-index device with enough room for Whisper. The
+        # 16 GiB floor protects low-memory single-GPU runners such as the L4
+        # nightly, where the model server already occupies device 0, from the
+        # server-plus-Whisper OOM fixed in #3822. Keep the CPU fallback when no
+        # device has enough room.
+        for candidate_index in range(n - 1, -1, -1):
             candidate_device = current_omni_platform.get_torch_device(candidate_index)
-            free_memory = current_omni_platform.get_free_memory(candidate_device)
-            if free_memory >= best_free_memory:
+            if current_omni_platform.get_free_memory(candidate_device) >= _MIN_FREE_VRAM:
                 device_index = candidate_index
-                best_free_memory = free_memory
+                break
 
     if device_index is None:
         return "cpu"

--- a/tests/helpers/tests/test_media.py
+++ b/tests/helpers/tests/test_media.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 import sys
 from concurrent.futures.process import BrokenProcessPool

--- a/tests/helpers/tests/test_media.py
+++ b/tests/helpers/tests/test_media.py
@@ -105,6 +105,31 @@ def _reset_transcriber_singletons():
     media._WHISPER_MODELS.clear()
 
 
+@pytest.mark.parametrize(
+    ("device_count", "free_memory", "expected_device"),
+    [
+        (1, 16 * 1024**3, "cuda:0"),
+        (3, 16 * 1024**3, "cuda:2"),
+        (1, 16 * 1024**3 - 1, "cpu"),
+    ],
+)
+def test_select_whisper_device_by_available_memory(monkeypatch, device_count, free_memory, expected_device):
+    platform = SimpleNamespace(
+        is_available=lambda: True,
+        get_device_count=lambda: device_count,
+        get_torch_device=lambda index: f"cuda:{index}",
+        get_free_memory=lambda device: free_memory,
+        set_device=lambda device: None,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm_omni.platforms",
+        SimpleNamespace(current_omni_platform=platform),
+    )
+
+    assert media._select_whisper_device() == expected_device
+
+
 def test_bytes_entrypoint_forwards_language_to_subprocess(monkeypatch, tmp_path):
     """Cover the two hops the tests above skip: bytes -> file -> executor.submit.
 

--- a/tests/helpers/tests/test_media.py
+++ b/tests/helpers/tests/test_media.py
@@ -4,6 +4,7 @@
 import sys
 from concurrent.futures.process import BrokenProcessPool
 from contextlib import nullcontext
+from multiprocessing.context import BaseContext
 from types import SimpleNamespace
 
 import numpy as np
@@ -61,6 +62,7 @@ class _FakeExecutor:
 
     def __init__(self, outcomes=()):
         self._outcomes = list(outcomes)
+        self.init_kwargs: dict[str, object] = {}
         self.submitted: list[tuple] = []
         self.shutdown_calls = 0
 
@@ -177,7 +179,9 @@ def test_parent_reuses_one_spawned_worker_across_calls(monkeypatch):
     assert len(created) == 1
     assert len(created[0].submitted) == 2
     assert created[0].init_kwargs["max_workers"] == 1
-    assert created[0].init_kwargs["mp_context"].get_start_method() == "spawn"
+    mp_context = created[0].init_kwargs["mp_context"]
+    assert isinstance(mp_context, BaseContext)
+    assert mp_context.get_start_method() == "spawn"
 
 
 def test_release_forces_a_new_process_pool(monkeypatch):

--- a/tests/helpers/tests/test_media.py
+++ b/tests/helpers/tests/test_media.py
@@ -106,19 +106,22 @@ def _reset_transcriber_singletons():
 
 
 @pytest.mark.parametrize(
-    ("device_count", "free_memory", "expected_device"),
+    ("free_memory_by_device", "expected_device"),
     [
-        (1, 16 * 1024**3, "cuda:0"),
-        (3, 16 * 1024**3, "cuda:2"),
-        (1, 16 * 1024**3 - 1, "cpu"),
+        ([media._MIN_FREE_VRAM], "cuda:0"),
+        ([media._MIN_FREE_VRAM] * 3, "cuda:2"),
+        ([8 * 1024**3, 20 * 1024**3, 24 * 1024**3], "cuda:2"),
+        ([media._MIN_FREE_VRAM - 1], "cpu"),
+        ([20 * 1024**3, 8 * 1024**3], "cuda:0"),
+        ([8 * 1024**3, 12 * 1024**3], "cpu"),
     ],
 )
-def test_select_whisper_device_by_available_memory(monkeypatch, device_count, free_memory, expected_device):
+def test_select_whisper_device_by_available_memory(monkeypatch, free_memory_by_device, expected_device):
     platform = SimpleNamespace(
         is_available=lambda: True,
-        get_device_count=lambda: device_count,
+        get_device_count=lambda: len(free_memory_by_device),
         get_torch_device=lambda index: f"cuda:{index}",
-        get_free_memory=lambda device: free_memory,
+        get_free_memory=lambda device: free_memory_by_device[int(device.rsplit(":", 1)[1])],
         set_device=lambda device: None,
     )
     monkeypatch.setitem(

--- a/tests/helpers/tests/test_media.py
+++ b/tests/helpers/tests/test_media.py
@@ -106,22 +106,31 @@ def _reset_transcriber_singletons():
 
 
 @pytest.mark.parametrize(
-    ("free_memory_by_device", "expected_device"),
+    ("free_memory_by_device", "expected_device", "expected_probe_order"),
     [
-        ([media._MIN_FREE_VRAM], "cuda:0"),
-        ([media._MIN_FREE_VRAM] * 3, "cuda:2"),
-        ([8 * 1024**3, 20 * 1024**3, 24 * 1024**3], "cuda:2"),
-        ([media._MIN_FREE_VRAM - 1], "cpu"),
-        ([20 * 1024**3, 8 * 1024**3], "cuda:0"),
-        ([8 * 1024**3, 12 * 1024**3], "cpu"),
+        ([media._MIN_FREE_VRAM], "cuda:0", [0]),
+        ([media._MIN_FREE_VRAM] * 3, "cuda:2", [2]),
+        ([8 * 1024**3, 20 * 1024**3, 24 * 1024**3], "cuda:2", [2]),
+        ([media._MIN_FREE_VRAM - 1], "cpu", [0]),
+        ([20 * 1024**3, 8 * 1024**3], "cuda:0", [1, 0]),
+        ([8 * 1024**3, 12 * 1024**3], "cpu", [1, 0]),
     ],
 )
-def test_select_whisper_device_by_available_memory(monkeypatch, free_memory_by_device, expected_device):
+def test_select_whisper_device_by_available_memory(
+    monkeypatch, free_memory_by_device, expected_device, expected_probe_order
+):
+    probed_devices = []
+
+    def get_free_memory(device):
+        index = int(device.rsplit(":", 1)[1])
+        probed_devices.append(index)
+        return free_memory_by_device[index]
+
     platform = SimpleNamespace(
         is_available=lambda: True,
         get_device_count=lambda: len(free_memory_by_device),
         get_torch_device=lambda index: f"cuda:{index}",
-        get_free_memory=lambda device: free_memory_by_device[int(device.rsplit(":", 1)[1])],
+        get_free_memory=get_free_memory,
         set_device=lambda device: None,
     )
     monkeypatch.setitem(
@@ -131,6 +140,7 @@ def test_select_whisper_device_by_available_memory(monkeypatch, free_memory_by_d
     )
 
     assert media._select_whisper_device() == expected_device
+    assert probed_devices == expected_probe_order
 
 
 def test_bytes_entrypoint_forwards_language_to_subprocess(monkeypatch, tmp_path):


### PR DESCRIPTION
## Purpose

This is a current-main continuation of #5675, preserving Akshat Nayak's five original commits and authorship so its approved, backend-generic Whisper placement fix can receive valid AMD L3 coverage. If #5675 is rebased and validated directly, this continuation can be closed in favor of the original PR.

Recent AMD L3 builds in #6926 show the Qwen3-TTS serving requests completing, followed by the 40-minute Base or 75-minute CustomVoice timeout while quality validation uses CPU Whisper. The carried fix uses the existing platform API to select the highest-index accelerator with at least 16 GiB free, and keeps the CPU fallback when no device has enough capacity. It does not hardcode ROCm, AMD, or a model name.

Current-main follow-ups in this continuation are deliberately narrow:

- a typing update to the existing test fake required by the current mypy hook;
- CUDA ready/merge source dependencies so a change to `tests/helpers/media.py` actually selects the Qwen3-TTS integration lanes. Without this routing, a green CUDA pipeline would not exercise the changed helper.

Related failure evidence: AMD CI [#11286](https://buildkite.com/vllm/vllm-omni-amd-ci/builds/11286), [#11289](https://buildkite.com/vllm/vllm-omni-amd-ci/builds/11289), [#11292](https://buildkite.com/vllm/vllm-omni-amd-ci/builds/11292), and [#11296](https://buildkite.com/vllm/vllm-omni-amd-ci/builds/11296).

## Test Plan

**vLLM Version:** Current project dependency; no production dependency change.

**vLLM-Omni Commit:** Base `e51fe6ec1b9a9a0e14bb1fdb296d61b6593b93c6`; head `f436186792a644b8a80a138593101c9049e66203`.

## Test Result

- `pytest tests/helpers/tests/test_media.py`: 16 passed
- `pytest tests/buildkite/test_upload_pipeline.py tests/buildkite/test_skip_ci.py`: 46 passed
- Exact PR-diff rendering selects Qwen3-TTS CustomVoice in CUDA ready and both Qwen3-TTS CustomVoice and Base in CUDA merge.
- `pre-commit run --files .buildkite/cuda/test-ready.yml .buildkite/cuda/test-merge.yml tests/helpers/media.py tests/helpers/tests/test_media.py`
- `python3 -m compileall -q tests/helpers/media.py tests/helpers/tests/test_media.py`
- `git diff --check origin/main...HEAD`

All local/static checks pass. Exact-head AMD L3 validation is requested to verify that Base and CustomVoice complete quality validation without changing their existing full-sample checks. The routed CUDA TTS jobs should also run to guard the shared helper path.
