### PR TITLE
  [Perf] Add LongCat-Video-Avatar BSA support

### DIFF
--- a/examples/offline_inference/longcat_video/end2end.py
+++ b/examples/offline_inference/longcat_video/end2end.py
@@ -36,6 +36,8 @@ def parse_args():
     parser.add_argument("--input-json", default=None, help="Official LongCat Avatar JSON case for AI2V.")
     parser.add_argument("--output", default="longcat_avatar_output.mp4")
     parser.add_argument("--resolution", choices=["480p", "720p"], default="480p")
+    parser.add_argument("--height", type=int, default=None)
+    parser.add_argument("--width", type=int, default=None)
     parser.add_argument("--num-frames", type=int, default=93)
     parser.add_argument("--num-segments", default="1", help="Number of AVC segments, or 'auto' to cover full audio.")
     parser.add_argument("--num-cond-frames", type=int, default=13)
@@ -46,6 +48,12 @@ def parse_args():
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--use-distill", action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument("--use-int8", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument(
+        "--enable-bsa",
+        action="store_true",
+        default=False,
+        help="Enable LongCat Avatar block-sparse self-attention where tensor shapes are compatible.",
+    )
     parser.add_argument(
         "--build-components-on-gpu",
         action="store_true",
@@ -224,6 +232,7 @@ def main():
         "resolution": args.resolution,
         "use_distill": args.use_distill,
         "use_int8": args.use_int8,
+        "enable_bsa": args.enable_bsa,
         "build_components_on_gpu": args.build_components_on_gpu,
     }
     if args.base_model_dir:
@@ -270,6 +279,8 @@ def main():
             OmniDiffusionSamplingParams(
                 generator=torch.Generator(device=current_omni_platform.device_type).manual_seed(args.seed),
                 seed=args.seed,
+                height=args.height,
+                width=args.width,
                 guidance_scale=1.0 if args.use_distill else 4.0,
                 guidance_scale_2=1.0 if args.use_distill else 4.0,
                 num_inference_steps=args.num_inference_steps,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,10 +105,12 @@ local = [
     "FlagEmbedding",
 ]
 
-# LongCat-Video-Avatar A2V/AI2V runtime dependencies for vocal
-# separation and loudness normalization.
+# audio-separator 0.44.2 imports audioread and still uses the
+# librosa 0.10 get_duration(filename=...) API during vocal separation.
 longcat-video-avatar = [
     "audio-separator==0.44.2",
+    "audioread>=3.0.0",
+    "librosa>=0.10,<0.11",
     "pyloudnorm==0.1.1",
     "soundfile>=0.13.1",
 ]

--- a/tests/diffusion/models/longcat_video/test_longcat_video_avatar.py
+++ b/tests/diffusion/models/longcat_video/test_longcat_video_avatar.py
@@ -11,6 +11,7 @@ import torch
 from PIL import Image
 
 from vllm_omni.diffusion.models.longcat_video.longcat_video_avatar_transformer import (
+    Attention,
     LongCatVideoAvatarTransformer3DModel,
     _read_config,
     replace_linear_with_quantized,
@@ -172,6 +173,34 @@ def test_longcat_video_avatar_load_weights_supports_int8_buffers():
 
     assert buffer_name in loaded_params
     assert torch.equal(dict(model.named_buffers())[buffer_name], loaded_weight)
+
+
+def test_longcat_video_avatar_bsa_toggle_is_opt_in():
+    model = LongCatVideoAvatarTransformer3DModel(
+        hidden_size=8,
+        depth=1,
+        num_heads=1,
+        caption_channels=8,
+        intermediate_dim=8,
+        output_dim=8,
+        audio_channel=8,
+        context_tokens=1,
+        enable_bsa=False,
+    )
+
+    assert not model.blocks[0].attn.enable_bsa
+    model.enable_bsa()
+    assert model.blocks[0].attn.enable_bsa
+    model.disable_bsa()
+    assert not model.blocks[0].attn.enable_bsa
+
+
+def test_longcat_video_avatar_bsa_skips_cpu_and_incompatible_shapes():
+    attention = Attention(dim=8, num_heads=1, enable_bsa=True)
+    q = torch.randn(1, 1, 16, 8)
+    k = torch.randn(1, 1, 16, 8)
+
+    assert attention._bsa_latent_shapes(q, k, (4, 2, 2)) is None
 
 
 def test_longcat_video_avatar_multi_speaker_para_audio_arrays_are_aligned():

--- a/vllm_omni/diffusion/models/longcat_video/longcat_video_avatar_bsa.py
+++ b/vllm_omni/diffusion/models/longcat_video/longcat_video_avatar_bsa.py
@@ -1,0 +1,669 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# ruff: noqa: N803
+
+from __future__ import annotations
+
+import math
+import os
+
+import torch
+import torch.nn.functional as F
+import triton
+import triton.language as tl
+
+_TRITON_AUTOTUNE_ENABLE_ENV = "TRITON_AUTOTUNE_ENABLE"
+_LEGACY_TRITON_AUTOTUNE_ENABLE_ENV = "TRITON_AUTOTUNE_ENBALE"
+
+
+def _triton_autotune_enabled() -> bool:
+    return (
+        os.environ.get(_TRITON_AUTOTUNE_ENABLE_ENV, "0") == "1"
+        or os.environ.get(_LEGACY_TRITON_AUTOTUNE_ENABLE_ENV, "0") == "1"
+    )
+
+
+if _triton_autotune_enabled():
+    autotune = triton.autotune
+else:
+
+    def autotune(*args, **kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+
+_GATING_CONFIG_PRESET = {
+    "default": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "num_stages": 3,
+        "num_warps": 8,
+    }
+}
+
+_GATING_CONFIGS = [
+    triton.Config({"BLOCK_M": block_m, "BLOCK_N": block_n}, num_stages=stages, num_warps=warps)
+    for block_m in [64, 128]
+    for block_n in [32, 64]
+    for stages in [2, 3, 4, 5]
+    for warps in [4, 8]
+]
+
+_GATING_REEVALUATE_KEYS = ["M", "N"] if os.environ.get("TRITON_REEVALUATE_KEY", "0") == "1" else []
+
+
+@autotune(_GATING_CONFIGS, key=_GATING_REEVALUATE_KEYS)
+@triton.jit
+def _attn_fwd_gating(
+    Q,
+    K,
+    Out,
+    stride_qz,
+    stride_qh,
+    stride_qm,
+    stride_qk,
+    stride_kz,
+    stride_kh,
+    stride_kn,
+    stride_kk,
+    stride_oz,
+    stride_oh,
+    stride_om,
+    stride_on,
+    H,
+    M,
+    N,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    tl.static_assert(BLOCK_N <= HEAD_DIM)
+    start_m = tl.program_id(0)
+    off_hz = tl.program_id(1)
+    off_z = off_hz // H
+    off_h = off_hz % H
+    q_offset = off_z.to(tl.int64) * stride_qz + off_h.to(tl.int64) * stride_qh
+    k_offset = off_z.to(tl.int64) * stride_kz + off_h.to(tl.int64) * stride_kh
+    o_offset = off_z.to(tl.int64) * stride_oz + off_h.to(tl.int64) * stride_oh
+
+    q_block_ptr = tl.make_block_ptr(
+        base=Q + q_offset,
+        shape=(M, HEAD_DIM),
+        strides=(stride_qm, stride_qk),
+        offsets=(start_m * BLOCK_M, 0),
+        block_shape=(BLOCK_M, HEAD_DIM),
+        order=(1, 0),
+    )
+    k_block_ptr = tl.make_block_ptr(
+        base=K + k_offset,
+        shape=(HEAD_DIM, N),
+        strides=(stride_kk, stride_kn),
+        offsets=(0, 0),
+        block_shape=(HEAD_DIM, BLOCK_N),
+        order=(0, 1),
+    )
+    out_block_ptr = tl.make_block_ptr(
+        base=Out + o_offset,
+        shape=(M, N),
+        strides=(stride_om, stride_on),
+        offsets=(start_m * BLOCK_M, 0),
+        block_shape=(BLOCK_M, BLOCK_N),
+        order=(1, 0),
+    )
+
+    q = tl.load(q_block_ptr, boundary_check=(0,))
+    for start_n in range(0, N, BLOCK_N):
+        start_n = tl.multiple_of(start_n, BLOCK_N)
+        k = tl.load(k_block_ptr, boundary_check=(1,))
+        qk = tl.dot(q, k)
+        tl.store(out_block_ptr, qk.to(Out.type.element_ty), boundary_check=(0, 1))
+        k_block_ptr = tl.advance(k_block_ptr, (0, BLOCK_N))
+        out_block_ptr = tl.advance(out_block_ptr, (0, BLOCK_N))
+
+
+_FWD_BSA_VARLEN_CONFIG_PRESET = {
+    "default": {
+        "BLOCK_N": 64,
+        "num_stages": 3,
+        "num_warps": 8,
+    },
+    "BLOCK_N_LG=64": {
+        "BLOCK_N": 64,
+        "num_stages": 3,
+        "num_warps": 4,
+    },
+}
+_FWD_BSA_VARLEN_CONFIGS = [
+    triton.Config({"BLOCK_N": block_n}, num_stages=stages, num_warps=warps)
+    for block_n in [32, 64, 128]
+    for stages in [2, 3, 4, 5]
+    for warps in [4, 8]
+]
+_FWD_BSA_REEVALUATE_KEYS = (
+    ["N_CTX", "BLOCK_M", "BLOCK_N_LG", "SPARSITY"] if os.environ.get("TRITON_REEVALUATE_KEY", "0") == "1" else []
+)
+
+
+@autotune(_FWD_BSA_VARLEN_CONFIGS, key=_FWD_BSA_REEVALUATE_KEYS)
+@triton.jit
+def _attn_fwd_bsa_varlen(
+    Q,
+    K,
+    V,
+    sm_scale,
+    M,
+    Out,
+    block_indices,
+    block_indices_lens,
+    stride_qz,
+    stride_qh,
+    stride_qm,
+    stride_qk,
+    stride_kz,
+    stride_kh,
+    stride_kn,
+    stride_kk,
+    stride_vz,
+    stride_vh,
+    stride_vn,
+    stride_vk,
+    stride_oz,
+    stride_oh,
+    stride_om,
+    stride_ok,
+    stride_bz,
+    stride_bh,
+    stride_bm,
+    stride_bs,
+    stride_lz,
+    stride_lh,
+    stride_lm,
+    H,
+    N_CTX,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N_LG: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    SPARSITY: tl.constexpr,
+):
+    start_m = tl.program_id(0)
+    off_hz = tl.program_id(1)
+    off_z = off_hz // H
+    off_h = off_hz % H
+
+    q_offset = off_z.to(tl.int64) * stride_qz + off_h.to(tl.int64) * stride_qh
+    k_offset = off_z.to(tl.int64) * stride_kz + off_h.to(tl.int64) * stride_kh
+    v_offset = off_z.to(tl.int64) * stride_vz + off_h.to(tl.int64) * stride_vh
+    o_offset = off_z.to(tl.int64) * stride_oz + off_h.to(tl.int64) * stride_oh
+    b_offset = off_z.to(tl.int64) * stride_bz + off_h.to(tl.int64) * stride_bh
+    l_offset = off_z.to(tl.int64) * stride_lz + off_h.to(tl.int64) * stride_lh
+
+    q_block_ptr = tl.make_block_ptr(
+        base=Q + q_offset,
+        shape=(N_CTX, HEAD_DIM),
+        strides=(stride_qm, stride_qk),
+        offsets=(start_m * BLOCK_M, 0),
+        block_shape=(BLOCK_M, HEAD_DIM),
+        order=(1, 0),
+    )
+    v_block_ptr = tl.make_block_ptr(
+        base=V + v_offset,
+        shape=(N_CTX, HEAD_DIM),
+        strides=(stride_vn, stride_vk),
+        offsets=(0, 0),
+        block_shape=(BLOCK_N, HEAD_DIM),
+        order=(1, 0),
+    )
+    kt_block_ptr = tl.make_block_ptr(
+        base=K + k_offset,
+        shape=(HEAD_DIM, N_CTX),
+        strides=(stride_kk, stride_kn),
+        offsets=(0, 0),
+        block_shape=(HEAD_DIM, BLOCK_N),
+        order=(0, 1),
+    )
+    out_block_ptr = tl.make_block_ptr(
+        base=Out + o_offset,
+        shape=(N_CTX, HEAD_DIM),
+        strides=(stride_om, stride_ok),
+        offsets=(start_m * BLOCK_M, 0),
+        block_shape=(BLOCK_M, HEAD_DIM),
+        order=(1, 0),
+    )
+
+    block_indices += b_offset + start_m * stride_bm
+    block_indices_lens += l_offset + start_m * stride_lm
+    offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
+
+    m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([BLOCK_M], dtype=tl.float32) + 1.0
+    acc = tl.zeros([BLOCK_M, HEAD_DIM], dtype=tl.float32)
+    qk_scale = sm_scale * 1.44269504
+    q = tl.load(q_block_ptr)
+    selected_blocks = tl.load(block_indices_lens)
+    for i in range(selected_blocks):
+        block_id = tl.load(block_indices + i * stride_bs).to(tl.int32)
+        lo = block_id * BLOCK_N_LG
+        hi = (block_id + 1) * BLOCK_N_LG
+        lo = tl.multiple_of(lo, BLOCK_N)
+        kt_block_ptr_i = tl.advance(kt_block_ptr, (0, lo))
+        v_block_ptr_i = tl.advance(v_block_ptr, (lo, 0))
+
+        for start_n in range(lo, hi, BLOCK_N):
+            start_n = tl.multiple_of(start_n, BLOCK_N)
+            kt = tl.load(kt_block_ptr_i)
+            qkt = tl.dot(q, kt)
+
+            m_ij = tl.maximum(m_i, tl.max(qkt, 1) * qk_scale)
+            qkt = qkt * qk_scale - m_ij[:, None]
+            p = tl.math.exp2(qkt)
+
+            alpha = tl.math.exp2(m_i - m_ij)
+            l_ij = tl.sum(p, 1)
+            acc = acc * alpha[:, None]
+            v = tl.load(v_block_ptr_i)
+            acc = tl.dot(p.to(v.dtype), v, acc)
+            l_i = l_i * alpha + l_ij
+            m_i = m_ij
+            v_block_ptr_i = tl.advance(v_block_ptr_i, (BLOCK_N, 0))
+            kt_block_ptr_i = tl.advance(kt_block_ptr_i, (0, BLOCK_N))
+
+    m_i += tl.math.log2(l_i)
+    acc = acc / l_i[:, None]
+    m_ptrs = M + off_hz * N_CTX + offs_m
+    tl.store(m_ptrs, m_i)
+    tl.store(out_block_ptr, acc.to(Out.type.element_ty))
+
+
+_FWD_BSA_VARLEN_ALIGN_CONFIG_PRESET = {
+    "default": {
+        "num_stages": 3,
+        "num_warps": 8,
+    },
+    "BLOCK_N_LG=64": {
+        "num_stages": 3,
+        "num_warps": 4,
+    },
+}
+_FWD_BSA_VARLEN_ALIGN_CONFIGS = [
+    triton.Config({}, num_stages=stages, num_warps=warps) for stages in [2, 3, 4, 5] for warps in [4, 8]
+]
+
+
+@autotune(_FWD_BSA_VARLEN_ALIGN_CONFIGS, key=_FWD_BSA_REEVALUATE_KEYS)
+@triton.jit
+def _attn_fwd_bsa_varlen_align(
+    Q,
+    K,
+    V,
+    sm_scale,
+    M,
+    Out,
+    block_indices,
+    block_indices_lens,
+    stride_qz,
+    stride_qh,
+    stride_qm,
+    stride_qk,
+    stride_kz,
+    stride_kh,
+    stride_kn,
+    stride_kk,
+    stride_vz,
+    stride_vh,
+    stride_vn,
+    stride_vk,
+    stride_oz,
+    stride_oh,
+    stride_om,
+    stride_on,
+    stride_bz,
+    stride_bh,
+    stride_bm,
+    stride_bs,
+    stride_lz,
+    stride_lh,
+    stride_lm,
+    H,
+    N_CTX,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N_LG: tl.constexpr,
+    SPARSITY: tl.constexpr,
+):
+    start_m = tl.program_id(0)
+    off_hz = tl.program_id(1)
+    off_z = off_hz // H
+    off_h = off_hz % H
+
+    q_offset = off_z.to(tl.int64) * stride_qz + off_h.to(tl.int64) * stride_qh
+    k_offset = off_z.to(tl.int64) * stride_kz + off_h.to(tl.int64) * stride_kh
+    v_offset = off_z.to(tl.int64) * stride_vz + off_h.to(tl.int64) * stride_vh
+    o_offset = off_z.to(tl.int64) * stride_oz + off_h.to(tl.int64) * stride_oh
+    b_offset = off_z.to(tl.int64) * stride_bz + off_h.to(tl.int64) * stride_bh
+    l_offset = off_z.to(tl.int64) * stride_lz + off_h.to(tl.int64) * stride_lh
+
+    q_block_ptr = tl.make_block_ptr(
+        base=Q + q_offset,
+        shape=(N_CTX, HEAD_DIM),
+        strides=(stride_qm, stride_qk),
+        offsets=(start_m * BLOCK_M, 0),
+        block_shape=(BLOCK_M, HEAD_DIM),
+        order=(1, 0),
+    )
+    v_block_ptr = tl.make_block_ptr(
+        base=V + v_offset,
+        shape=(N_CTX, HEAD_DIM),
+        strides=(stride_vn, stride_vk),
+        offsets=(0, 0),
+        block_shape=(BLOCK_N_LG, HEAD_DIM),
+        order=(1, 0),
+    )
+    kt_block_ptr = tl.make_block_ptr(
+        base=K + k_offset,
+        shape=(HEAD_DIM, N_CTX),
+        strides=(stride_kk, stride_kn),
+        offsets=(0, 0),
+        block_shape=(HEAD_DIM, BLOCK_N_LG),
+        order=(0, 1),
+    )
+    out_block_ptr = tl.make_block_ptr(
+        base=Out + o_offset,
+        shape=(N_CTX, HEAD_DIM),
+        strides=(stride_om, stride_on),
+        offsets=(start_m * BLOCK_M, 0),
+        block_shape=(BLOCK_M, HEAD_DIM),
+        order=(1, 0),
+    )
+
+    block_indices += b_offset + start_m * stride_bm
+    block_indices_lens += l_offset + start_m * stride_lm
+    offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
+
+    m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([BLOCK_M], dtype=tl.float32) + 1.0
+    acc = tl.zeros([BLOCK_M, HEAD_DIM], dtype=tl.float32)
+    qk_scale = sm_scale * 1.44269504
+    q = tl.load(q_block_ptr)
+    selected_blocks = tl.load(block_indices_lens)
+    for i in range(selected_blocks):
+        block_id = tl.load(block_indices + i * stride_bs).to(tl.int32)
+        lo = block_id * BLOCK_N_LG
+        lo = tl.multiple_of(lo, BLOCK_N_LG)
+        kt_block_ptr_i = tl.advance(kt_block_ptr, (0, lo))
+        v_block_ptr_i = tl.advance(v_block_ptr, (lo, 0))
+
+        kt = tl.load(kt_block_ptr_i)
+        qkt = tl.dot(q, kt)
+
+        m_ij = tl.maximum(m_i, tl.max(qkt, 1) * qk_scale)
+        qkt = qkt * qk_scale - m_ij[:, None]
+        p = tl.math.exp2(qkt)
+
+        alpha = tl.math.exp2(m_i - m_ij)
+        l_ij = tl.sum(p, 1)
+        acc = acc * alpha[:, None]
+        v = tl.load(v_block_ptr_i)
+        acc = tl.dot(p.to(v.dtype), v, acc)
+        l_i = l_i * alpha + l_ij
+        m_i = m_ij
+
+    m_i += tl.math.log2(l_i)
+    acc = acc / l_i[:, None]
+    m_ptrs = M + off_hz * N_CTX + offs_m
+    tl.store(m_ptrs, m_i)
+    tl.store(out_block_ptr, acc.to(Out.type.element_ty))
+
+
+def _mean_pooling_compression(x: torch.Tensor, block_size: int) -> torch.Tensor:
+    batch, heads, seq_len = x.shape[:3]
+    num_blocks = math.ceil(seq_len / block_size)
+    if seq_len % block_size != 0:
+        x = F.pad(x, (0, 0, 0, num_blocks * block_size - seq_len))
+    return x.view(batch, heads, num_blocks, block_size, -1).mean(dim=3)
+
+
+def _cal_score_triton(q: torch.Tensor, k: torch.Tensor) -> torch.Tensor:
+    batch, heads, seq_q, head_dim = q.shape
+    seq_k = k.shape[2]
+    score = torch.empty(batch, heads, seq_q, seq_k, device=q.device, dtype=q.dtype)
+    kernel_config = {} if _triton_autotune_enabled() else _GATING_CONFIG_PRESET["default"]
+
+    def grid(args):
+        return (triton.cdiv(seq_q, args["BLOCK_M"]), batch * heads, 1)
+
+    _attn_fwd_gating[grid](
+        q,
+        k,
+        score,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        q.stride(3),
+        k.stride(0),
+        k.stride(1),
+        k.stride(2),
+        k.stride(3),
+        score.stride(0),
+        score.stride(1),
+        score.stride(2),
+        score.stride(3),
+        heads,
+        seq_q,
+        seq_k,
+        HEAD_DIM=head_dim,
+        **kernel_config,
+    )
+    return score
+
+
+def _get_select_indices_from_score(
+    score: torch.Tensor,
+    sparsity: float | None,
+    cdf_threshold: float | None,
+    sm_scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if sparsity is None and cdf_threshold is None:
+        raise ValueError("Either sparsity or cdf_threshold must be set for LongCat BSA.")
+
+    selected_topk = None
+    if sparsity is not None:
+        selected_topk = max(1, int((1 - sparsity) * score.shape[-1]))
+
+    if cdf_threshold is None:
+        block_indices = torch.topk(score, selected_topk)[1]
+        block_indices_lens = torch.full(
+            score.shape[:3],
+            selected_topk,
+            dtype=torch.int32,
+            device=score.device,
+        )
+        return block_indices, block_indices_lens
+
+    weights = torch.softmax(score * sm_scale, dim=-1)
+    batch, heads, seq_q, _ = weights.shape
+    threshold = torch.full(
+        (heads,),
+        cdf_threshold,
+        device=weights.device,
+    ).view(1, heads, 1, 1)
+    threshold = threshold.expand(batch, -1, seq_q, -1)
+    weights_sorted = torch.sort(weights, dim=-1, descending=True)
+    cdf = torch.cumsum(weights_sorted.values, dim=-1)
+    num_selected = torch.searchsorted(cdf, threshold, right=True).squeeze(-1)
+    if selected_topk is not None:
+        num_selected[num_selected < selected_topk] = selected_topk
+    block_indices_lens = num_selected.to(torch.int32)
+    return weights_sorted.indices, block_indices_lens
+
+
+def _attn_fwd_bsa_varlen_triton(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    sm_scale: float,
+    block_indices: torch.Tensor,
+    block_indices_lens: torch.Tensor,
+    chunk_size_q: int,
+    chunk_size_k: int,
+    sparsity: float | None,
+) -> torch.Tensor:
+    batch, heads, seq_q, head_dim = q.shape
+    output = torch.empty_like(q)
+    softmax_lse = torch.empty((batch, heads, seq_q), device=q.device, dtype=torch.float32)
+
+    def grid(args):
+        return (triton.cdiv(seq_q, args["BLOCK_M"]), batch * heads, 1)
+
+    config_key = "BLOCK_N_LG=64" if chunk_size_k == 64 else "default"
+    if chunk_size_k > 128:
+        fwd_func = _attn_fwd_bsa_varlen
+        kernel_config = {} if _triton_autotune_enabled() else _FWD_BSA_VARLEN_CONFIG_PRESET[config_key]
+    else:
+        fwd_func = _attn_fwd_bsa_varlen_align
+        kernel_config = {} if _triton_autotune_enabled() else _FWD_BSA_VARLEN_ALIGN_CONFIG_PRESET[config_key]
+
+    block_indices = block_indices.contiguous()
+    block_indices_lens = block_indices_lens.contiguous()
+    fwd_func[grid](
+        q,
+        k,
+        v,
+        sm_scale,
+        softmax_lse,
+        output,
+        block_indices,
+        block_indices_lens,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        q.stride(3),
+        k.stride(0),
+        k.stride(1),
+        k.stride(2),
+        k.stride(3),
+        v.stride(0),
+        v.stride(1),
+        v.stride(2),
+        v.stride(3),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        output.stride(3),
+        block_indices.stride(0),
+        block_indices.stride(1),
+        block_indices.stride(2),
+        block_indices.stride(3),
+        block_indices_lens.stride(0),
+        block_indices_lens.stride(1),
+        block_indices_lens.stride(2),
+        heads,
+        seq_q,
+        head_dim,
+        BLOCK_M=chunk_size_q,
+        BLOCK_N_LG=chunk_size_k,
+        SPARSITY=0.0 if sparsity is None else sparsity,
+        **kernel_config,
+    )
+    return output
+
+
+def _rearrange_thw_to_3d_block(
+    x: torch.Tensor,
+    num_t_blocks: int,
+    num_h_blocks: int,
+    num_w_blocks: int,
+    chunk_t: int,
+    chunk_h: int,
+    chunk_w: int,
+) -> torch.Tensor:
+    batch, heads, _, head_dim = x.shape
+    x = x.view(batch, heads, num_t_blocks, chunk_t, num_h_blocks, chunk_h, num_w_blocks, chunk_w, head_dim)
+    x = x.permute(0, 1, 2, 4, 6, 3, 5, 7, 8)
+    seq_len = num_t_blocks * num_h_blocks * num_w_blocks * chunk_t * chunk_h * chunk_w
+    return x.contiguous().view(batch, heads, seq_len, head_dim)
+
+
+def _rearrange_3d_block_to_thw(
+    x: torch.Tensor,
+    num_t_blocks: int,
+    num_h_blocks: int,
+    num_w_blocks: int,
+    chunk_t: int,
+    chunk_h: int,
+    chunk_w: int,
+) -> torch.Tensor:
+    batch, heads, _, head_dim = x.shape
+    x = x.view(batch, heads, num_t_blocks, num_h_blocks, num_w_blocks, chunk_t, chunk_h, chunk_w, head_dim)
+    x = x.permute(0, 1, 2, 5, 3, 6, 4, 7, 8)
+    seq_len = num_t_blocks * chunk_t * num_h_blocks * chunk_h * num_w_blocks * chunk_w
+    return x.contiguous().view(batch, heads, seq_len, head_dim)
+
+
+def flash_attn_bsa_3d(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    latent_shape_q: tuple[int, int, int],
+    latent_shape_k: tuple[int, int, int],
+    *,
+    sparsity: float | None = 0.875,
+    cdf_threshold: float | None = None,
+    chunk_3d_shape_q: tuple[int, int, int] | list[int] = (4, 4, 8),
+    chunk_3d_shape_k: tuple[int, int, int] | list[int] = (4, 4, 8),
+) -> torch.Tensor:
+    _, _, seq_q, head_dim_q = q.shape
+    _, _, seq_k, head_dim_k = k.shape
+    if head_dim_q != head_dim_k:
+        raise ValueError("LongCat BSA requires q and k to use the same head dimension.")
+
+    t_q, h_q, w_q = latent_shape_q
+    t_k, h_k, w_k = latent_shape_k
+    if t_q * h_q * w_q != seq_q:
+        raise ValueError("LongCat BSA q sequence length does not match latent_shape_q.")
+    if t_k * h_k * w_k != seq_k:
+        raise ValueError("LongCat BSA k sequence length does not match latent_shape_k.")
+
+    chunk_t_q, chunk_h_q, chunk_w_q = tuple(chunk_3d_shape_q)
+    chunk_t_k, chunk_h_k, chunk_w_k = tuple(chunk_3d_shape_k)
+    if t_q % chunk_t_q != 0 or h_q % chunk_h_q != 0 or w_q % chunk_w_q != 0:
+        raise ValueError("LongCat BSA q latent shape must be divisible by chunk_3d_shape_q.")
+    if t_k % chunk_t_k != 0 or h_k % chunk_h_k != 0 or w_k % chunk_w_k != 0:
+        raise ValueError("LongCat BSA k latent shape must be divisible by chunk_3d_shape_k.")
+
+    num_t_q = t_q // chunk_t_q
+    num_h_q = h_q // chunk_h_q
+    num_w_q = w_q // chunk_w_q
+    num_t_k = t_k // chunk_t_k
+    num_h_k = h_k // chunk_h_k
+    num_w_k = w_k // chunk_w_k
+
+    q = _rearrange_thw_to_3d_block(q, num_t_q, num_h_q, num_w_q, chunk_t_q, chunk_h_q, chunk_w_q)
+    k = _rearrange_thw_to_3d_block(k, num_t_k, num_h_k, num_w_k, chunk_t_k, chunk_h_k, chunk_w_k)
+    v = _rearrange_thw_to_3d_block(v, num_t_k, num_h_k, num_w_k, chunk_t_k, chunk_h_k, chunk_w_k)
+
+    chunk_size_q = chunk_t_q * chunk_h_q * chunk_w_q
+    chunk_size_k = chunk_t_k * chunk_h_k * chunk_w_k
+    q_cmp = _mean_pooling_compression(q, chunk_size_q)
+    k_cmp = _mean_pooling_compression(k, chunk_size_k)
+    score = _cal_score_triton(q_cmp, k_cmp)
+    block_indices, block_indices_lens = _get_select_indices_from_score(
+        score,
+        sparsity,
+        cdf_threshold,
+        1 / math.sqrt(head_dim_q),
+    )
+    output = _attn_fwd_bsa_varlen_triton(
+        q,
+        k,
+        v,
+        1 / math.sqrt(head_dim_q),
+        block_indices,
+        block_indices_lens,
+        chunk_size_q,
+        chunk_size_k,
+        sparsity,
+    )
+    return _rearrange_3d_block_to_thw(output, num_t_q, num_h_q, num_w_q, chunk_t_q, chunk_h_q, chunk_w_q)

--- a/vllm_omni/diffusion/models/longcat_video/longcat_video_avatar_transformer.py
+++ b/vllm_omni/diffusion/models/longcat_video/longcat_video_avatar_transformer.py
@@ -18,10 +18,20 @@ import torch.nn as nn
 import torch.nn.functional as F
 from einops import rearrange, repeat
 from safetensors.torch import load_file
+from vllm.logger import init_logger
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.layer import Attention as VllmAttention
+
+logger = init_logger(__name__)
+
+_DEFAULT_BSA_PARAMS = {
+    "sparsity": 0.875,
+    "cdf_threshold": None,
+    "chunk_3d_shape_q": (4, 4, 8),
+    "chunk_3d_shape_k": (4, 4, 8),
+}
 
 
 def linear_fp32(linear: nn.Module, x: torch.Tensor) -> torch.Tensor:
@@ -406,8 +416,6 @@ class Attention(nn.Module):
         super().__init__()
         if dim % num_heads != 0:
             raise ValueError("dim must be divisible by num_heads")
-        if enable_bsa:
-            raise NotImplementedError("LongCat-Video-Avatar block-sparse attention is not supported in native MVP.")
         if cp_split_hw not in (None, [1, 1], (1, 1)):
             raise NotImplementedError("LongCat-Video-Avatar context parallel attention is not supported in native MVP.")
 
@@ -415,6 +423,9 @@ class Attention(nn.Module):
         self.num_heads = num_heads
         self.head_dim = dim // num_heads
         self.scale = self.head_dim**-0.5
+        self.enable_bsa = enable_bsa
+        self.bsa_params = dict(_DEFAULT_BSA_PARAMS)
+        self.bsa_params.update(bsa_params or {})
 
         self.qkv = nn.Linear(dim, dim * 3, bias=True)
         self.q_norm = RMSNorm_FP32(self.head_dim, eps=1e-6)
@@ -432,9 +443,84 @@ class Attention(nn.Module):
             qkv_layout="BSND",
         )
 
-    def _process_attn(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+    def _bsa_latent_shapes(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        shape: tuple[int, int, int] | None,
+        log_fallback: bool = False,
+    ) -> tuple[tuple[int, int, int], tuple[int, int, int]] | None:
+        def fallback(reason: str) -> None:
+            if log_fallback:
+                logger.warning_once("LongCat-Video-Avatar BSA staying dense: %s", reason)
+
+        if not self.enable_bsa or q.shape[2] == 0:
+            return None
+        if shape is None:
+            fallback("latent shape metadata is missing")
+            return None
+        if q.device.type != "cuda":
+            fallback(f"device {q.device.type!r} is not CUDA")
+            return None
+        if q.shape[2] != k.shape[2]:
+            fallback(f"query/key sequence lengths differ ({q.shape[2]} vs {k.shape[2]})")
+            return None
+
+        _, num_h, num_w = shape
+        tokens_per_frame = num_h * num_w
+        if tokens_per_frame <= 0 or q.shape[2] % tokens_per_frame != 0 or k.shape[2] % tokens_per_frame != 0:
+            fallback(
+                "sequence length is not frame-aligned for latent grid "
+                f"shape={shape}, q_len={q.shape[2]}, k_len={k.shape[2]}"
+            )
+            return None
+
+        latent_shape_q = (q.shape[2] // tokens_per_frame, num_h, num_w)
+        latent_shape_k = (k.shape[2] // tokens_per_frame, num_h, num_w)
+        chunk_q = tuple(self.bsa_params["chunk_3d_shape_q"])
+        chunk_k = tuple(self.bsa_params["chunk_3d_shape_k"])
+        if any(size <= 0 for size in chunk_q + chunk_k):
+            raise ValueError("LongCat-Video-Avatar BSA chunk sizes must be positive.")
+        if any(dim % chunk != 0 for dim, chunk in zip(latent_shape_q, chunk_q, strict=True)):
+            fallback(f"query latent shape {latent_shape_q} is not divisible by chunk_3d_shape_q={chunk_q}")
+            return None
+        if any(dim % chunk != 0 for dim, chunk in zip(latent_shape_k, chunk_k, strict=True)):
+            fallback(f"key latent shape {latent_shape_k} is not divisible by chunk_3d_shape_k={chunk_k}")
+            return None
+        logger.info_once(
+            "LongCat-Video-Avatar BSA active: latent_shape_q=%s, latent_shape_k=%s, "
+            "chunk_3d_shape_q=%s, chunk_3d_shape_k=%s, sparsity=%s, cdf_threshold=%s",
+            latent_shape_q,
+            latent_shape_k,
+            chunk_q,
+            chunk_k,
+            self.bsa_params["sparsity"],
+            self.bsa_params["cdf_threshold"],
+        )
+        return latent_shape_q, latent_shape_k
+
+    def _process_attn(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        shape: tuple[int, int, int] | None = None,
+    ) -> torch.Tensor:
         if q.shape[2] == 0:
             return q
+        bsa_shapes = self._bsa_latent_shapes(q, k, shape, log_fallback=True)
+        if bsa_shapes is not None:
+            from vllm_omni.diffusion.models.longcat_video.longcat_video_avatar_bsa import flash_attn_bsa_3d
+
+            latent_shape_q, latent_shape_k = bsa_shapes
+            return flash_attn_bsa_3d(
+                q.contiguous(),
+                k.contiguous(),
+                v.contiguous(),
+                latent_shape_q,
+                latent_shape_k,
+                **self.bsa_params,
+            )
         q = q.transpose(1, 2).contiguous()
         k = k.transpose(1, 2).contiguous()
         v = v.transpose(1, 2).contiguous()
@@ -473,9 +559,9 @@ class Attention(nn.Module):
                 q_cond = q[:, :, :num_cond_latents_thw].contiguous()
                 k_cond = k[:, :, :num_cond_latents_thw].contiguous()
                 v_cond = v[:, :, :num_cond_latents_thw].contiguous()
-                x_cond = self._process_attn(q_cond, k_cond, v_cond)
+                x_cond = self._process_attn(q_cond, k_cond, v_cond, shape)
                 q_noise = q[:, :, num_cond_latents_thw:].contiguous()
-                x_noise = self._process_attn(q_noise, k, v)
+                x_noise = self._process_attn(q_noise, k, v, shape)
                 x = torch.cat([x_cond, x_noise], dim=2).contiguous()
             else:
                 if num_ref_latents is None or ref_img_index is None:
@@ -487,8 +573,8 @@ class Attention(nn.Module):
                 q_cond = q[:, :, num_ref_latents_thw:num_cond_latents_thw].contiguous()
                 k_cond = k[:, :, num_ref_latents_thw:num_cond_latents_thw].contiguous()
                 v_cond = v[:, :, num_ref_latents_thw:num_cond_latents_thw].contiguous()
-                x_ref = self._process_attn(q_ref, k_ref, v_ref)
-                x_cond = self._process_attn(q_cond, k_cond, v_cond)
+                x_ref = self._process_attn(q_ref, k_ref, v_ref, shape)
+                x_cond = self._process_attn(q_cond, k_cond, v_cond, shape)
                 if num_cond_latents == shape[0]:
                     x = torch.cat([x_ref, x_cond], dim=2).contiguous()
                 else:
@@ -506,15 +592,15 @@ class Attention(nn.Module):
                         q_noise_back = q_noise[:, :, end_pos:].contiguous()
                         k_non_ref = k[:, :, num_ref_latents_thw:].contiguous()
                         v_non_ref = v[:, :, num_ref_latents_thw:].contiguous()
-                        x_noise_front = self._process_attn(q_noise_front, k, v)
-                        x_noise_maskref = self._process_attn(q_noise_maskref, k_non_ref, v_non_ref)
-                        x_noise_back = self._process_attn(q_noise_back, k, v)
+                        x_noise_front = self._process_attn(q_noise_front, k, v, shape)
+                        x_noise_maskref = self._process_attn(q_noise_maskref, k_non_ref, v_non_ref, shape)
+                        x_noise_back = self._process_attn(q_noise_back, k, v, shape)
                         x_noise = torch.cat([x_noise_front, x_noise_maskref, x_noise_back], dim=2).contiguous()
                     else:
-                        x_noise = self._process_attn(q_noise, k, v)
+                        x_noise = self._process_attn(q_noise, k, v, shape)
                     x = torch.cat([x_ref, x_cond, x_noise], dim=2).contiguous()
         else:
-            x = self._process_attn(q, k, v)
+            x = self._process_attn(q, k, v, shape)
 
         x = x.transpose(1, 2).reshape(bsz, seq_len, channels)
         x = self.proj(x)
@@ -592,12 +678,12 @@ class Attention(nn.Module):
             q_noise_back = q[:, :, end_pos:].contiguous()
             k_non_ref = k_full[:, :, num_ref_latents_thw:].contiguous()
             v_non_ref = v_full[:, :, num_ref_latents_thw:].contiguous()
-            x_noise_front = self._process_attn(q_noise_front, k_full, v_full)
-            x_noise_maskref = self._process_attn(q_noise_maskref, k_non_ref, v_non_ref)
-            x_noise_back = self._process_attn(q_noise_back, k_full, v_full)
+            x_noise_front = self._process_attn(q_noise_front, k_full, v_full, shape)
+            x_noise_maskref = self._process_attn(q_noise_maskref, k_non_ref, v_non_ref, shape)
+            x_noise_back = self._process_attn(q_noise_back, k_full, v_full, shape)
             x_attn = torch.cat([x_noise_front, x_noise_maskref, x_noise_back], dim=2).contiguous()
         else:
-            x_attn = self._process_attn(q, k_full, v_full)
+            x_attn = self._process_attn(q, k_full, v_full, shape)
 
         x_out = x_attn.transpose(1, 2).reshape(bsz, seq_len, channels)
         x_out = self.proj(x_out)
@@ -1340,8 +1426,6 @@ class LongCatVideoAvatarTransformer3DModel(nn.Module):
         class_interval: int = 4,
     ) -> None:
         super().__init__()
-        if enable_bsa:
-            raise NotImplementedError("LongCat-Video-Avatar BSA is not supported in native MVP.")
         if cp_split_hw not in (None, [1, 1], (1, 1)):
             raise NotImplementedError("LongCat-Video-Avatar context parallel is not supported in native MVP.")
 
@@ -1491,10 +1575,12 @@ class LongCatVideoAvatarTransformer3DModel(nn.Module):
         self.active_loras.clear()
 
     def enable_bsa(self):
-        raise NotImplementedError("LongCat-Video-Avatar BSA is not supported in native MVP.")
+        for block in self.blocks:
+            block.attn.enable_bsa = True
 
     def disable_bsa(self):
-        return None
+        for block in self.blocks:
+            block.attn.enable_bsa = False
 
     def forward(
         self,

--- a/vllm_omni/diffusion/models/longcat_video/pipeline_longcat_video_avatar.py
+++ b/vllm_omni/diffusion/models/longcat_video/pipeline_longcat_video_avatar.py
@@ -529,6 +529,10 @@ class LongCatVideoAvatarPipeline(nn.Module, SupportImageInput, SupportAudioInput
         self.use_distill = _as_bool(additional_config.get("use_distill"), True)
         self.use_int8 = _as_bool(additional_config.get("use_int8"), True)
         self.build_components_on_gpu = _as_bool(additional_config.get("build_components_on_gpu"), False)
+        self.enable_bsa = _as_bool(additional_config.get("enable_bsa"), False)
+        self.bsa_params = additional_config.get("bsa_params") or {}
+        if isinstance(self.bsa_params, str):
+            self.bsa_params = json.loads(self.bsa_params)
         self.resolution = str(additional_config.get("resolution") or "480p")
         self.model_dir = _ensure_local_dir(
             od_config.model,
@@ -595,12 +599,16 @@ class LongCatVideoAvatarPipeline(nn.Module, SupportImageInput, SupportAudioInput
                 self.transformer = create_quantized_avatar_dit(
                     str(self.model_dir),
                     subfolder="base_model_int8",
+                    enable_bsa=self.enable_bsa,
+                    bsa_params=self.bsa_params,
                     cp_split_hw=[1, 1],
                 )
             else:
                 self.transformer = create_full_precision_avatar_dit(
                     str(self.model_dir),
                     subfolder="base_model",
+                    enable_bsa=self.enable_bsa,
+                    bsa_params=self.bsa_params,
                     cp_split_hw=[1, 1],
                 )
                 self.transformer = self.transformer.to(dtype=dtype)


### PR DESCRIPTION
<!-- markdownlint-disable -->

  ## Purpose

  Add opt-in LongCat-Video-Avatar block-sparse attention (BSA) support for the native vLLM-Omni LongCat-Video-Avatar-1.5
  pipeline.

  This builds on the LongCat-Video-Avatar-1.5 integration in https://github.com/vllm-project/vllm-omni/pull/4099.

  ## Supported

  - Opt-in LongCat Avatar block-sparse self-attention via `--enable-bsa`.
  - Model-local BSA path inside `LongCatVideoAvatarTransformer`.
  - Official LongCat default BSA parameters: `sparsity=0.875`, `chunk_3d_shape_q=(4, 4, 8)`, `chunk_3d_shape_k=(4, 4, 8)`.
  - Guarded dense fallback when runtime shapes are not compatible with BSA.
  - Offline example support for `--enable-bsa`.
  - Offline example support for explicit `--height` / `--width`, useful for selecting BSA-compatible LongCat buckets.
  - Targeted LongCat Avatar unit tests for BSA opt-in behavior and fallback guards.

  ## Implementation Notes

  LongCat Avatar BSA is implemented as a model-local opt-in path instead of a global diffusion attention backend. The
  official BSA kernel is tightly coupled to LongCat's Avatar self-attention layout and THW block structure, so this PR
  keeps it scoped to `LongCatVideoAvatarTransformer`.

  The BSA kernel is ported from the official LongCat-Video block-sparse attention implementation as a forward-only
  inference subset. This PR keeps the pieces needed by native Avatar generation. **It does not port the official backward kernels, autograd wrapper, context-parallel communication, or TMA helper paths.**

  ### Original LongCat BSA References

  - Avatar attention calls `flash_attn_bsa_3d` from the official block sparse attention implementation:
    https://github.com/meituan-longcat/LongCat-Video/blob/main/longcat_video/modules/avatar/attention.py
  - Official BSA kernel/interface:
    https://github.com/meituan-longcat/LongCat-Video/blob/main/longcat_video/block_sparse_attention/bsa_interface.py
  - Official Avatar DiT toggles BSA through `enable_bsa()`:
    https://github.com/meituan-longcat/LongCat-Video/blob/main/longcat_video/modules/avatar/longcat_video_dit_avatar.py

  When `--enable-bsa` is set, the transformer routes self-attention to the LongCat BSA kernel only when the runtime tensor
  shape is compatible with the configured 3D chunks. Otherwise it logs the reason and falls back to vLLM-Omni's standard
  dense diffusion attention path.

  The official default BSA chunk shape is `(4, 4, 8)`. Some official buckets are not divisible by this chunk shape. For
  example, the default 480p AT2V bucket `480x832` maps to latent shape `(24, 30, 52)`, so it intentionally stays dense.
  Active BSA was validated with the official audio/prompt using `--height 512 --width 768`, which maps to latent shape
  `(24, 32, 48)` and hits the BSA kernel.

  The official LongCat code uses the legacy environment variable spelling `TRITON_AUTOTUNE_ENBALE`. This PR supports the
  corrected spelling `TRITON_AUTOTUNE_ENABLE` and keeps compatibility with the official legacy spelling.

  The `longcat-video-avatar` optional extra was updated so vocal separation works in fresh containers.

  ## Out Of Scope

  - Global vLLM-Omni diffusion attention backend registration for LongCat BSA.
  - LongCat BSA backward kernels or training support.
  - Official LongCat context-parallel BSA communication paths.
  - Official LongCat TMA helper path.
  - BSA support for all LongCat resolution buckets. Incompatible shapes fall back to dense attention.

  ## Test Plan

  ### Dense vs BSA Benchmark

  Same Modal H100 container, same checkpoint/audio/prompt/seed/settings. Each mode was warmed once before measurement,
  using separate Omni instances initialized sequentially in the same container.

  Settings: official single-speaker AT2V example, height=512, width=768, num_frames=93, num_inference_steps=8, seed=42,
  enforce_eager=True.

   Mode     omni.generate() time    
   Dense    159.478s   
   BSA        152.734s    

  Observed speedup: 1.044x. The BSA run logged the active kernel path for latent shape (24, 32, 48) with chunk shape (4,
  4, 8).

This benchmark validates active BSA execution and basic performance. It does not claim visual parity with dense attention, because LongCat BSA follows the official block-sparse attention path rather than a lossless dense-attention approximation.

  ### Modal BSA Active Smoke Test
```
  python examples/offline_inference/longcat_video/end2end.py \
    --model /cache/longcat_models/LongCat-Video-Avatar-1.5 \
    --base-model-dir /cache/longcat_models/LongCat-Video \
    --stage at2v \
    --audio /root/LongCat-Video/assets/avatar/single/man.mp3 \
    --prompt "$PROMPT" \
    --height 512 \
    --width 768 \
    --num-frames 93 \
    --num-inference-steps 8 \
    --enable-bsa \
    --output /outputs/official_asset_longcat_avatar_at2v_bsa_active.mp4
```

  Observed log:

 ```LongCat-Video-Avatar BSA active: latent_shape_q=(24, 32, 48), latent_shape_k=(24, 32, 48), chunk_3d_shape_q=(4, 4, 8),
  chunk_3d_shape_k=(4, 4, 8), sparsity=0.875, cdf_threshold=None
```

  ### Modal Dense Fallback Smoke Tests

  Default 480p AT2V bucket falls back to dense attention because latent shape (24, 30, 52) is not divisible by (4, 4, 8).

  ## Test Results



  - Targeted LongCat Avatar unit tests: passed on Modal.



  - Modal active BSA AT2V smoke: passed.

https://github.com/user-attachments/assets/cdf45f68-cef2-40cf-80d4-86f7aaefae5c

  - AT2V fallback: passed
 
https://github.com/user-attachments/assets/5fba0d89-d9a1-4f39-9079-d48d3be09a6f

  - AI2V fallback: passed
  
https://github.com/user-attachments/assets/50a91871-1f7a-4e70-982f-4d22ba211b00


