### PR TITLE
[Core] Avoid diffusion InputBatch mapping device syncs

### DIFF
--- a/tests/diffusion/test_input_batch_mapping.py
+++ b/tests/diffusion/test_input_batch_mapping.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+import numpy as np
+import pytest
+import torch
+
+from vllm_omni.diffusion.worker.input_batch import InputBatch, _select_states, scatter_latents
+from vllm_omni.diffusion.worker.utils import StepRequestState
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+def _make_state(request_id: str, latent_value: float) -> StepRequestState:
+    return StepRequestState(
+        request_id=request_id,
+        sampling=OmniDiffusionSamplingParams(),
+        latents=torch.tensor([[latent_value]]),
+        timesteps=torch.tensor([1.0]),
+    )
+
+
+def test_select_states_explicit_mapping_preserves_device_and_order():
+    states = [_make_state(f"req-{index}", float(index)) for index in range(3)]
+    selected, idx_mapping, idx_mapping_np = _select_states(
+        states,
+        torch.tensor([2, 0], dtype=torch.int64),
+    )
+
+    assert selected[0] is states[2]
+    assert selected[1] is states[0]
+    assert idx_mapping.dtype == torch.int32
+    assert idx_mapping.device.type == "cpu"
+    np.testing.assert_array_equal(idx_mapping_np, np.array([2, 0], dtype=np.int32))
+
+
+def test_identity_mapping_reuses_cached_device_and_host_mappings(mocker):
+    states = [_make_state(f"req-{index}", float(index)) for index in range(2)]
+    arange = mocker.spy(torch, "arange")
+    batch = InputBatch.make_batch(states)
+    cached_idx_mapping = batch.idx_mapping
+    cached_idx_mapping_np = batch.idx_mapping_np
+
+    refreshed = InputBatch.make_batch(states, cached_batch=batch)
+
+    assert refreshed is batch
+    assert arange.call_count == 1
+    assert refreshed.idx_mapping is cached_idx_mapping
+    assert refreshed.idx_mapping_np is cached_idx_mapping_np
+    assert refreshed.states[0] is states[0]
+    assert refreshed.states[1] is states[1]
+
+
+def test_identity_mapping_does_not_reuse_cached_explicit_reordering():
+    states = [_make_state(f"req-{index}", float(index)) for index in range(2)]
+    batch = InputBatch.make_batch(
+        states,
+        idx_mapping=torch.tensor([1, 0], dtype=torch.int32),
+    )
+    reordered_idx_mapping = batch.idx_mapping
+
+    rebuilt = InputBatch.make_batch(states, cached_batch=batch)
+
+    assert rebuilt is batch
+    assert rebuilt.idx_mapping is not reordered_idx_mapping
+    assert rebuilt.request_ids == ["req-0", "req-1"]
+    torch.testing.assert_close(rebuilt.idx_mapping, torch.tensor([0, 1], dtype=torch.int32))
+    np.testing.assert_array_equal(rebuilt.idx_mapping_np, np.array([0, 1], dtype=np.int32))
+
+
+def test_identity_mapping_rebuilds_when_batch_size_changes():
+    states = [_make_state(f"req-{index}", float(index)) for index in range(2)]
+    batch = InputBatch.make_batch(states)
+    cached_idx_mapping = batch.idx_mapping
+    states.append(_make_state("req-2", 2.0))
+
+    rebuilt = InputBatch.make_batch(states, cached_batch=batch)
+
+    assert rebuilt is batch
+    assert rebuilt.idx_mapping is not cached_idx_mapping
+    torch.testing.assert_close(rebuilt.idx_mapping, torch.tensor([0, 1, 2], dtype=torch.int32))
+    np.testing.assert_array_equal(rebuilt.idx_mapping_np, np.array([0, 1, 2], dtype=np.int32))
+
+
+def test_identity_mapping_takes_ownership_from_explicit_identity_mapping():
+    states = [_make_state(f"req-{index}", float(index)) for index in range(2)]
+    explicit_mapping = torch.tensor([0, 1], dtype=torch.int32)
+    batch = InputBatch.make_batch(states, idx_mapping=explicit_mapping)
+
+    refreshed = InputBatch.make_batch(states, cached_batch=batch)
+
+    assert refreshed is batch
+    assert refreshed.idx_mapping is not explicit_mapping
+    explicit_mapping.fill_(1)
+    torch.testing.assert_close(refreshed.idx_mapping, torch.tensor([0, 1], dtype=torch.int32))
+
+
+def test_cached_identity_mapping_handles_request_reordering_and_scatter():
+    first, second = _make_state("first", 1.0), _make_state("second", 2.0)
+    batch = InputBatch.make_batch([first, second])
+    mapping = batch.idx_mapping
+    reordered_states = [second, first]
+
+    refreshed = InputBatch.make_batch(reordered_states, cached_batch=batch)
+
+    assert refreshed is batch
+    assert refreshed.idx_mapping is mapping
+    assert refreshed.request_ids == ["second", "first"]
+    torch.testing.assert_close(refreshed.latents, torch.tensor([[2.0], [1.0]]))
+    refreshed.latents = torch.tensor([[20.0], [10.0]])
+    scatter_latents(reordered_states, refreshed)
+    torch.testing.assert_close(first.latents, torch.tensor([[10.0]]))
+    torch.testing.assert_close(second.latents, torch.tensor([[20.0]]))

--- a/vllm_omni/diffusion/worker/input_batch.py
+++ b/vllm_omni/diffusion/worker/input_batch.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Diffusion input-batch structures following the MRV2-style vLLM layout.
 
 Request states remain the only persistent source of truth. Static tensors are
@@ -62,24 +62,46 @@ def _pad_mask(x: torch.Tensor, target_seq_len: int) -> torch.Tensor:
 def _select_states(
     states: Sequence[StepRequestState],
     idx_mapping: torch.Tensor | None,
+    cached_batch: InputBatch | None = None,
 ) -> tuple[list[StepRequestState], torch.Tensor, np.ndarray]:
     if not states:
         raise ValueError("Cannot build InputBatch from empty states.")
 
     if idx_mapping is None:
+        identity_states = list(states)
         device = states[0].latents.device if states[0].latents is not None else None
+        expected_device = torch.device("cpu") if device is None else device
+
+        # The common stepwise path uses an identity mapping. Avoid reading a
+        # device arange back to the host, and reuse the cached device tensor
+        # across denoising steps when its device contract still matches.
+        if cached_batch is not None and cached_batch._owns_identity_mapping:
+            cached_mapping = cached_batch.idx_mapping
+            if (
+                cached_mapping.dtype == torch.int32
+                and cached_mapping.device == expected_device
+                and cached_mapping.numel() == len(states)
+            ):
+                return identity_states, cached_mapping, cached_batch.idx_mapping_np
+
         idx_mapping = torch.arange(len(states), dtype=torch.int32, device=device)
-    else:
-        if idx_mapping.ndim != 1:
-            raise ValueError("idx_mapping must be a 1D tensor.")
-        idx_mapping = idx_mapping.to(dtype=torch.int32)
+        idx_mapping_np = np.arange(len(states), dtype=np.int32)
+        return identity_states, idx_mapping, idx_mapping_np
+
+    if idx_mapping.ndim != 1:
+        raise ValueError("idx_mapping must be a 1D tensor.")
+    idx_mapping = idx_mapping.to(dtype=torch.int32)
+    idx_mapping_np = idx_mapping.detach().cpu().numpy()
 
     selected_states: list[StepRequestState] = []
-    for batch_idx, state_idx in enumerate(idx_mapping.tolist()):
+    # Materialize Python ints from the host array. Unlike calling tolist() on
+    # the device tensor, this does not introduce another device sync and is
+    # faster than iterating NumPy scalar objects for larger batches.
+    for batch_idx, state_idx in enumerate(idx_mapping_np.tolist()):
         if state_idx < 0 or state_idx >= len(states):
             raise ValueError(f"idx_mapping[{batch_idx}]={state_idx} is out of range for states.")
         selected_states.append(states[state_idx])
-    return selected_states, idx_mapping, idx_mapping.detach().cpu().numpy()
+    return selected_states, idx_mapping, idx_mapping_np
 
 
 def _prepare_request_ids(states: Sequence[StepRequestState]) -> list[str]:
@@ -542,7 +564,10 @@ def _same_composition(
         return False
     if cached_batch.request_ids != request_ids:
         return False
-    if not np.array_equal(cached_batch.idx_mapping_np, idx_mapping_np):
+    if cached_batch.idx_mapping_np is not idx_mapping_np and not np.array_equal(
+        cached_batch.idx_mapping_np,
+        idx_mapping_np,
+    ):
         return False
     # Midway prompt updates (typically for video generation) can change prompt_embeds without changing ids/mapping.
     # In this case, each request state manages the embedding's "version". Use it to determine if cache is still valid.
@@ -621,6 +646,10 @@ class InputBatch:
     negative_txt_seq_lens: list[int] | None = None
     states: Sequence[StepRequestState] = field(default_factory=tuple)
 
+    # True only when InputBatch created the identity mapping itself, making
+    # the device tensor safe to reuse across steps without external mutation.
+    _owns_identity_mapping: bool = field(default=False, init=False, repr=False)
+
     # For midway prompt updates (typically for video generation) that changes embeddings without changing ids,
     # Keep a snapshot of the current per-request versions of prompt embeddings for later runtime comparison
     _prompt_update_versions: tuple[int, ...] = ()
@@ -680,12 +709,14 @@ class InputBatch:
         idx_mapping: torch.Tensor,
         idx_mapping_np: np.ndarray,
         request_ids: list[str],
+        owns_identity_mapping: bool,
     ) -> InputBatch:
         self.request_ids = request_ids
         self.num_reqs = len(request_ids)
         self.num_reqs_after_padding = len(request_ids)
         self.idx_mapping = idx_mapping
         self.idx_mapping_np = idx_mapping_np
+        self._owns_identity_mapping = owns_identity_mapping
         self.states = tuple(selected_states)
         self.latents = _prepare_latents(selected_states, out=self.latents)
         self.timesteps = _prepare_timesteps(selected_states, out=self.timesteps)
@@ -701,11 +732,16 @@ class InputBatch:
         cached_batch: InputBatch | None = None,
     ) -> InputBatch:
         """Build a temporary step-local batch view from request states."""
-        selected_states, idx_mapping, idx_mapping_np = _select_states(states, idx_mapping)
+        owns_identity_mapping = idx_mapping is None
+        selected_states, idx_mapping, idx_mapping_np = _select_states(states, idx_mapping, cached_batch)
         request_ids = _prepare_request_ids(selected_states)
 
         if _same_composition(cached_batch, request_ids, idx_mapping_np, selected_states):
             assert cached_batch is not None
+            if owns_identity_mapping and cached_batch.idx_mapping is not idx_mapping:
+                cached_batch.idx_mapping = idx_mapping
+                cached_batch.idx_mapping_np = idx_mapping_np
+                cached_batch._owns_identity_mapping = True
             cached_batch._repack_dynamic_fields(selected_states)
             return cached_batch
 
@@ -715,12 +751,13 @@ class InputBatch:
                 idx_mapping,
                 idx_mapping_np,
                 request_ids,
+                owns_identity_mapping,
             )
 
         prompt_embeds, prompt_embeds_mask = _prepare_prompt_embeds(selected_states)
         negative_prompt_embeds, negative_prompt_embeds_mask = _prepare_negative_prompt_embeds(selected_states)
         do_true_cfg, true_cfg_scale, cfg_normalize = _prepare_cfg_scalars(selected_states)
-        return cls(
+        batch = cls(
             request_ids=request_ids,
             num_reqs=len(selected_states),
             num_reqs_after_padding=len(selected_states),
@@ -746,6 +783,8 @@ class InputBatch:
             states=tuple(selected_states),
             _prompt_update_versions=prompt_update_versions(selected_states),
         )
+        batch._owns_identity_mapping = owns_identity_mapping
+        return batch
 
 
 def scatter_latents(


### PR DESCRIPTION
## Purpose

`InputBatch.make_batch` runs once per diffusion denoising step. In the common identity-mapping path it created a device `arange`, converted it to a Python list, and then copied it to CPU again for NumPy consumers. On CUDA, those reads add two stream synchronizations to every call.

This PR:

- builds the host identity mapping directly with NumPy;
- reuses internally owned device and host identity mappings while batch size, dtype, and device stay compatible;
- keeps caller-provided mappings out of the cache until `InputBatch` owns a fresh identity mapping, avoiding reuse after external mutation;
- transfers an explicit device mapping to the host once and derives the Python indices from that host copy;
- covers ordering, cache reuse and invalidation, external mutation, request reordering, and scatter correctness.

This is a narrow step-wise runtime optimization. It does not change diffusion math, scheduling policy, or model kernels.

## Test Plan

- [x] Rebase onto current `main` and run the six committed mapping tests plus three existing `InputBatch` integration tests.
- [x] Run the repository's changed-file pre-commit hooks.
- [x] Compare the parent and candidate `InputBatch.make_batch` implementations with an A-B-B-A microbenchmark on one H200.
- [x] Verify synchronization events with `torch.profiler`.
- [x] Replay fixed inputs across 20 denoising steps at batch sizes 1 and 2.
- [x] Run an unprofiled H200 end-to-end regression check at concurrency 8.

**vLLM Version:** 0.28.0 for the focused regression environment

**Post-rebase validation commits:** candidate `62ea48dae7082213915994bb077847cbddd8bbf1`, parent `c94cf4ddde3cddf28fb02fbe27029824ae5ad6c8`

## Test Result

The focused suite passed on the post-rebase candidate:

```bash
pytest -q \
  tests/diffusion/test_input_batch_mapping.py \
  tests/diffusion/test_diffusion_step_pipeline.py::test_input_batch_cached_repack_refreshes_state_references_without_prompt_embeds \
  tests/diffusion/test_diffusion_step_pipeline.py::test_input_batch_cached_repack_keeps_static_prompt_fields_for_same_composition \
  tests/diffusion/streaming_interactive_generation/test_prompt_interaction.py::TestPromptUpdateExecution::test_input_batch_refreshes_prompt_embeds_on_version_change
```

```text
9 passed, 16 warnings in 4.03s
```

The warnings are existing deprecation and development-version warnings. The repository's changed-file pre-commit hooks also passed:

```bash
pre-commit run --show-diff-on-failure --files \
  vllm_omni/diffusion/worker/input_batch.py \
  tests/diffusion/test_input_batch_mapping.py
```

On one NVIDIA H200 with PyTorch 2.13.0+cu130, the complete cached `InputBatch.make_batch` call, including dynamic-field repacking, measured:

| Batch size | Parent | Candidate | Speedup | Time reduction |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 81.131 us | 32.649 us | 2.485x | 59.76% |
| 8 | 268.469 us | 215.116 us | 1.248x | 19.87% |
| 64 | 1732.892 us | 1649.666 us | 1.050x | 4.80% |

The benchmark used an A-B-B-A process sequence and reports the mean of the two per-process medians. Each process ran 12 measured repeats with 2,000/500/100 calls per repeat for batch sizes 1/8/64, synchronizing CUDA only at repeat boundaries. Each request used one CUDA float32 latent row and one CUDA timestep, matching the minimal `StepRequestState` test fixture. At 20 denoising steps, the measured absolute savings are approximately 0.97 ms, 1.07 ms, and 1.66 ms for batch sizes 1, 8, and 64, respectively.

Across eight profiled cache-hit calls, the parent emitted 16 `cudaStreamSynchronize` events and the candidate emitted zero. Both traces contained the same two benchmark-boundary `cudaDeviceSynchronize` events.

As a separate end-to-end regression check, I ran an unprofiled H200 A-B-B-A comparison at concurrency 8 on the equivalent pre-rebase diff (two parent/candidate pairs, 160 requests per pass). Parent and candidate mean throughput were 0.801021 and 0.800812 requests/s, respectively, a -0.0261% difference. The pairwise changes had opposite signs (-0.312% and +0.261%), so I treat this as neutral within run-to-run variation and do not claim an end-to-end throughput improvement.

An earlier profiler-enabled concurrency-8 run showed a -1.47% throughput difference. The diffusion stage profiler synchronizes the GPU before and after each wrapped stage, so that run changed the timing behavior this PR is intended to improve. Reconstructing the actual denoise waves from the profiler events showed 2,096 candidate waves versus 1,997 parent waves across four formal passes, including 428 versus 226 batch-size-1 waves. At the same batch size of 8, the candidate and parent denoise medians were 434.784 ms and 434.537 ms, respectively, only a +0.057% difference; the matched batch-size-6 and batch-size-7 timings were also neutral. These results indicate that the -1.47% result tracked a profiler-amplified change in closed-loop request refill and scheduler batch composition, rather than slower same-batch compute. The difference disappeared in the unprofiled ABBA check above.

In a separate fixed-input diagnostic with a fresh compile cache shared by the parent and candidate runs, the denoising trajectories matched exactly at every snapshot across all 20 steps for batch sizes 1 and 2. Host mapping order and final RNG state also matched. This diagnostic covers the denoising/InputBatch path rather than the full HTTP/VAE pipeline.

AI assistance: Codex was used to analyze the hot path, draft the regression tests and PR text, and run and interpret benchmarks. The final diff and reported evidence were checked before this update.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
