### PR TITLE
[Model][Boogu-Image] In-repo AutoencoderKL with fused GroupNorm+SiLU

### DIFF
--- a/tests/diffusion/models/boogu_image/test_boogu_vae.py
+++ b/tests/diffusion/models/boogu_image/test_boogu_vae.py
@@ -1,0 +1,328 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""Equivalence matrix: BooguAutoencoderKL vs diffusers AutoencoderKL.
+
+The whole point of the Boogu-private VAE (#6686, D-15) is that it is a
+faithful copy of diffusers' with the GroupNorm+SiLU fusion baked into an
+owned forward — so the core test obligation is submodule-by-submodule
+equivalence against diffusers, with shared weights.
+
+CPU-only: ``HAS_TRITON`` is forced off (autouse fixture), so the fused op's
+native fallback is ``F.silu(F.group_norm(...))`` — mathematically the same
+functional calls the eager modules make, hence every comparison below can
+demand ``torch.equal`` (bit-exact), which is stronger than the task's
+fp32-equal/bf16-envelope requirement.
+"""
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+import torch
+from diffusers.models.autoencoders.autoencoder_kl import AutoencoderKL
+from diffusers.models.autoencoders.vae import Decoder as DiffusersDecoder
+from diffusers.models.autoencoders.vae import Encoder as DiffusersEncoder
+from diffusers.models.downsampling import Downsample2D
+from diffusers.models.resnet import ResnetBlock2D
+from diffusers.models.upsampling import Upsample2D
+from torch import nn
+
+from vllm_omni.diffusion.models.boogu_image.vae import (
+    BooguAutoencoderKL,
+    BooguDecoder,
+    BooguDownsample2D,
+    BooguEncoder,
+    BooguResnetBlock2D,
+    BooguUpsample2D,
+    vae_group_norm_silu_fusion_enabled,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.diffusion]
+
+
+@pytest.fixture(autouse=True)
+def _force_native_fallback(monkeypatch: pytest.MonkeyPatch):
+    # HAS_TRITON is a platform property, not per-tensor: on a CUDA host a CPU
+    # tensor would be handed to the Triton path. Force the native fallback.
+    op_module = importlib.import_module("vllm_omni.model_executor.models.common.ops.fused_group_norm_silu")
+    monkeypatch.setattr(op_module, "HAS_TRITON", False)
+
+
+# Tiny config used everywhere below (kept divisible-by-groups); the real
+# Boogu architecture is asserted separately in the site-count test.
+_TINY = dict(
+    in_channels=3,
+    out_channels=3,
+    down_block_types=("DownEncoderBlock2D", "DownEncoderBlock2D"),
+    up_block_types=("UpDecoderBlock2D", "UpDecoderBlock2D"),
+    block_out_channels=(32, 64),
+    layers_per_block=1,
+    latent_channels=4,
+    norm_num_groups=8,
+    sample_size=32,
+    mid_block_add_attention=True,
+    use_quant_conv=False,
+    use_post_quant_conv=False,
+)
+
+# The real Boogu decoder architecture (vae/config.json @ 334ad7e5).
+_BOOGU = dict(
+    in_channels=3,
+    out_channels=3,
+    down_block_types=("DownEncoderBlock2D",) * 4,
+    up_block_types=("UpDecoderBlock2D",) * 4,
+    block_out_channels=(128, 256, 512, 512),
+    layers_per_block=2,
+    latent_channels=16,
+    norm_num_groups=32,
+    sample_size=1024,
+    mid_block_add_attention=True,
+    use_quant_conv=False,
+    use_post_quant_conv=False,
+)
+
+
+# --- 1. ResnetBlock vs diffusers ResnetBlock2D ------------------------------
+
+
+@pytest.mark.parametrize("in_ch,out_ch", [(32, 32), (32, 64)])
+@pytest.mark.parametrize("fused", [False, True])
+def test_resnet_block_matches_diffusers(in_ch: int, out_ch: int, fused: bool) -> None:
+    torch.manual_seed(0)
+    theirs = ResnetBlock2D(
+        in_channels=in_ch, out_channels=out_ch, temb_channels=None, groups=8, eps=1e-6
+    ).eval()
+    ours = BooguResnetBlock2D(in_channels=in_ch, out_channels=out_ch, groups=8, eps=1e-6, act_fn="silu").eval()
+    ours.load_state_dict(theirs.state_dict(), strict=True)
+    ours.fuse_group_norm_silu = fused
+
+    x = torch.randn(2, in_ch, 16, 16)
+    with torch.no_grad():
+        assert torch.equal(ours(x), theirs(x, None))
+
+
+# --- 2. Upsample / Downsample vs diffusers ----------------------------------
+
+
+def test_upsample_matches_diffusers() -> None:
+    torch.manual_seed(0)
+    theirs = Upsample2D(32, use_conv=True, out_channels=32).eval()
+    ours = BooguUpsample2D(32).eval()
+    ours.load_state_dict(theirs.state_dict(), strict=True)
+    x = torch.randn(1, 32, 8, 8)
+    with torch.no_grad():
+        assert torch.equal(ours(x), theirs(x))
+
+
+def test_downsample_matches_diffusers() -> None:
+    torch.manual_seed(0)
+    # The encoder builds Downsample2D with padding=0 / name="op" (asymmetric pad).
+    theirs = Downsample2D(32, use_conv=True, out_channels=32, padding=0, name="op").eval()
+    ours = BooguDownsample2D(32).eval()
+    ours.load_state_dict(theirs.state_dict(), strict=True)
+    x = torch.randn(1, 32, 9, 9)  # odd spatial exercises the (0,1,0,1) pad
+    with torch.no_grad():
+        assert torch.equal(ours(x), theirs(x))
+
+
+# --- 3./4. Decoder / Encoder vs diffusers -----------------------------------
+
+
+def _decoder_kwargs(cfg):
+    return dict(
+        in_channels=cfg["latent_channels"],
+        out_channels=cfg["out_channels"],
+        block_out_channels=cfg["block_out_channels"],
+        layers_per_block=cfg["layers_per_block"],
+        norm_num_groups=cfg["norm_num_groups"],
+        act_fn="silu",
+        mid_block_add_attention=cfg["mid_block_add_attention"],
+    )
+
+
+@pytest.mark.parametrize("latent_hw", [8, 16])
+@pytest.mark.parametrize("fused", [False, True])
+def test_decoder_matches_diffusers(latent_hw: int, fused: bool) -> None:
+    torch.manual_seed(0)
+    theirs = DiffusersDecoder(up_block_types=_TINY["up_block_types"], **_decoder_kwargs(_TINY)).eval()
+    ours = BooguDecoder(**_decoder_kwargs(_TINY)).eval()
+    ours.load_state_dict(theirs.state_dict(), strict=True)
+    for resnet in list(ours.mid_block.resnets) + [r for b in ours.up_blocks for r in b.resnets]:
+        resnet.fuse_group_norm_silu = fused
+    ours.fuse_conv_norm_out = fused
+
+    z = torch.randn(1, _TINY["latent_channels"], latent_hw, latent_hw)
+    with torch.no_grad():
+        assert torch.equal(ours(z), theirs(z))
+
+
+def test_encoder_matches_diffusers() -> None:
+    torch.manual_seed(0)
+    kwargs = dict(
+        in_channels=_TINY["in_channels"],
+        out_channels=_TINY["latent_channels"],
+        block_out_channels=_TINY["block_out_channels"],
+        layers_per_block=_TINY["layers_per_block"],
+        norm_num_groups=_TINY["norm_num_groups"],
+        act_fn="silu",
+        mid_block_add_attention=_TINY["mid_block_add_attention"],
+    )
+    theirs = DiffusersEncoder(down_block_types=_TINY["down_block_types"], double_z=True, **kwargs).eval()
+    ours = BooguEncoder(double_z=True, **kwargs).eval()
+    ours.load_state_dict(theirs.state_dict(), strict=True)
+    x = torch.randn(1, 3, 32, 32)
+    with torch.no_grad():
+        assert torch.equal(ours(x), theirs(x))
+
+
+# --- 5./6. Full model: decode/encode parity + weight-load completeness ------
+
+
+def _full_pair():
+    torch.manual_seed(0)
+    theirs = AutoencoderKL(**_TINY).eval()
+    ours = BooguAutoencoderKL(**_TINY).eval()
+    ours.load_state_dict(theirs.state_dict(), strict=True)
+    return ours, theirs
+
+
+def test_full_decode_and_encode_match_diffusers() -> None:
+    ours, theirs = _full_pair()
+    z = torch.randn(1, _TINY["latent_channels"], 8, 8)
+    x = torch.randn(1, 3, 32, 32)
+    with torch.no_grad():
+        assert torch.equal(ours.decode(z, return_dict=False)[0], theirs.decode(z, return_dict=False)[0])
+        ours_post = ours.encode(x).latent_dist
+        theirs_post = theirs.encode(x).latent_dist
+        assert torch.equal(ours_post.mean, theirs_post.mean)
+        assert torch.equal(ours_post.logvar, theirs_post.logvar)
+
+
+def test_weight_load_completeness_both_directions() -> None:
+    # The #1 silent-bug guard: zero missing and zero unexpected keys, both ways.
+    torch.manual_seed(0)
+    theirs = AutoencoderKL(**_TINY)
+    ours = BooguAutoencoderKL(**_TINY)
+    assert set(ours.state_dict().keys()) == set(theirs.state_dict().keys())
+    ours.load_state_dict(theirs.state_dict(), strict=True)
+    theirs.load_state_dict(ours.state_dict(), strict=True)
+
+
+# --- 7. Fusion on == off (native fallback) ----------------------------------
+
+
+def test_fusion_on_equals_off_on_fallback() -> None:
+    ours, _ = _full_pair()
+    z = torch.randn(1, _TINY["latent_channels"], 8, 8)
+    assert ours.set_group_norm_silu_fusion(True) == 13
+    with torch.no_grad():
+        fused = ours.decode(z, return_dict=False)[0]
+    assert ours.set_group_norm_silu_fusion(False) == 0
+    with torch.no_grad():
+        plain = ours.decode(z, return_dict=False)[0]
+    assert torch.equal(fused, plain)
+
+
+# --- 8. Site counts (real architecture + tiny) -------------------------------
+
+
+def test_site_counts() -> None:
+    with torch.device("meta"):
+        vae = BooguAutoencoderKL(**_BOOGU)
+    # Decoder: 4 up blocks x 3 resnets x 2 + mid 2 x 2 + conv_norm_out = 29.
+    assert vae.group_norm_silu_fusion_site_count() == 29  # armed at construction (act_fn silu)
+    assert vae.set_group_norm_silu_fusion(True) == 29
+    assert vae.set_group_norm_silu_fusion(False) == 0
+    # Encoder is plain by construction: its blocks are never armed.
+    assert all(not r.fuse_group_norm_silu for b in vae.encoder.down_blocks for r in b.resnets)
+    assert all(not r.fuse_group_norm_silu for r in vae.encoder.mid_block.resnets)
+
+
+# --- 9. Non-SiLU activation: fusion refuses, output == diffusers ------------
+
+
+def test_non_silu_act_fn_disables_fusion_and_matches_diffusers() -> None:
+    cfg = dict(_TINY, act_fn="mish")
+    torch.manual_seed(0)
+    theirs = AutoencoderKL(**cfg).eval()
+    ours = BooguAutoencoderKL(**cfg).eval()
+    ours.load_state_dict(theirs.state_dict(), strict=True)
+
+    # Fusion can never arm for a non-SiLU activation.
+    assert ours.group_norm_silu_fusion_site_count() == 0
+    assert ours.set_group_norm_silu_fusion(True) == 0
+
+    z = torch.randn(1, _TINY["latent_channels"], 8, 8)
+    with torch.no_grad():
+        assert torch.equal(ours.decode(z, return_dict=False)[0], theirs.decode(z, return_dict=False)[0])
+
+
+# --- 10. Kill-switch resolution ----------------------------------------------
+
+
+def test_kill_switch_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("VLLM_OMNI_VAE_GN_SILU_FUSION", raising=False)
+
+    on_by_default = SimpleNamespace(additional_config=None)
+    assert vae_group_norm_silu_fusion_enabled(on_by_default) is True
+
+    config_off = SimpleNamespace(additional_config={"vae_group_norm_silu_fusion": False})
+    assert vae_group_norm_silu_fusion_enabled(config_off) is False
+
+    config_off_str = SimpleNamespace(additional_config={"vae_group_norm_silu_fusion": "false"})
+    assert vae_group_norm_silu_fusion_enabled(config_off_str) is False
+
+    monkeypatch.setenv("VLLM_OMNI_VAE_GN_SILU_FUSION", "0")
+    assert vae_group_norm_silu_fusion_enabled(on_by_default) is False
+
+
+# --- guardrails ---------------------------------------------------------------
+
+
+def test_tiling_and_slicing_refuse() -> None:
+    with torch.device("meta"):
+        vae = BooguAutoencoderKL(**_TINY)
+    with pytest.raises(NotImplementedError):
+        vae.enable_tiling()
+    with pytest.raises(NotImplementedError):
+        vae.enable_slicing()
+
+
+def test_unsupported_block_types_refuse() -> None:
+    with pytest.raises(NotImplementedError):
+        BooguAutoencoderKL(**dict(_TINY, up_block_types=("AttnUpDecoderBlock2D", "UpDecoderBlock2D")))
+
+
+# --- strict loading -----------------------------------------------------------
+
+
+def test_strict_from_pretrained_raises_on_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    from diffusers.models.modeling_utils import ModelMixin
+
+    from vllm_omni.diffusion.models.boogu_image.vae import BooguVaeStrictLoadError
+
+    monkeypatch.setattr(
+        ModelMixin,
+        "from_pretrained",
+        classmethod(
+            lambda cls, *a, **k: (
+                object(),
+                {"missing_keys": ["decoder.foo"], "unexpected_keys": [], "mismatched_keys": []},
+            )
+        ),
+    )
+    with pytest.raises(BooguVaeStrictLoadError, match="decoder.foo"):
+        BooguAutoencoderKL.from_pretrained("x")
+
+
+def test_from_pretrained_roundtrip_ok(tmp_path) -> None:
+    # Happy path: the strict override must not false-positive on a clean
+    # save/load round trip.
+    torch.manual_seed(0)
+    vae = BooguAutoencoderKL(**_TINY)
+    vae.save_pretrained(tmp_path)
+    loaded = BooguAutoencoderKL.from_pretrained(tmp_path)
+    src, dst = vae.state_dict(), loaded.state_dict()
+    assert set(src) == set(dst)
+    assert all(torch.equal(src[k], dst[k]) for k in src)

--- a/tests/diffusion/models/boogu_image/test_pipeline_boogu_image.py
+++ b/tests/diffusion/models/boogu_image/test_pipeline_boogu_image.py
@@ -49,6 +49,8 @@ def mock_dependencies(mocker, monkeypatch):
     mock_vae = mocker.MagicMock(name="vae")
     mock_vae.config.block_out_channels = [128, 256, 512, 512]  # scale factor 8
     mock_vae.to.return_value = mock_vae
+    # __init__ arms the GroupNorm+SiLU fusion and logs the site count with %d.
+    mock_vae.set_group_norm_silu_fusion.return_value = 29
 
     mock_scheduler = mocker.MagicMock(name="scheduler")
 
@@ -65,7 +67,7 @@ def mock_dependencies(mocker, monkeypatch):
         lambda *a, **k: mock_processor,
     )
     monkeypatch.setattr(
-        f"{_MODULE}.AutoencoderKL.from_pretrained",
+        f"{_MODULE}.BooguAutoencoderKL.from_pretrained",
         lambda *a, **k: mock_vae,
     )
 
@@ -153,7 +155,7 @@ def test_constructor_forwards_revision_to_all_component_loaders(mock_dependencie
         return_value=mock_dependencies["processor"],
     )
     vae_loader = mocker.patch(
-        f"{_MODULE}.AutoencoderKL.from_pretrained",
+        f"{_MODULE}.BooguAutoencoderKL.from_pretrained",
         return_value=mock_dependencies["vae"],
     )
     od_config = OmniDiffusionConfig(
@@ -944,3 +946,42 @@ def test_forward_image_guidance_ignored_without_reference():
     # t2i text CFG: cond + uncond -> 2 predictions/step, no ref anywhere.
     assert _count_per_step(pipeline.transformer.calls, num_steps) == 2
     assert all(ref is None for ref in pipeline.transformer.calls)
+
+
+def test_vae_loader_falls_back_to_diffusers(monkeypatch):
+    """On any in-repo VAE load failure the pipeline must serve diffusers'
+    AutoencoderKL (correct but unfused) — and must not crash by calling the
+    fusion-arm method on the fallback object (which does not have one)."""
+    from diffusers.models.autoencoders.autoencoder_kl import AutoencoderKL
+
+    from vllm_omni.diffusion.models.boogu_image import pipeline_boogu_image as M
+    from vllm_omni.diffusion.models.boogu_image.vae import BooguVaeStrictLoadError
+
+    # Build the fallback instance BEFORE patching from_pretrained.
+    tiny_diffusers = AutoencoderKL(
+        block_out_channels=(8,),
+        down_block_types=("DownEncoderBlock2D",),
+        up_block_types=("UpDecoderBlock2D",),
+        layers_per_block=1,
+        latent_channels=4,
+        norm_num_groups=4,
+    )
+
+    def _raise(cls, *a, **k):
+        raise BooguVaeStrictLoadError("boom")
+
+    monkeypatch.setattr(M, "from_pretrained_with_prefetch", lambda fn, model, **kw: fn(model))
+    monkeypatch.setattr(M.BooguAutoencoderKL, "from_pretrained", classmethod(_raise))
+    monkeypatch.setattr(M.AutoencoderKL, "from_pretrained", classmethod(lambda cls, *a, **k: tiny_diffusers))
+
+    vae = M._load_boogu_vae(
+        "dummy-model",
+        SimpleNamespace(additional_config=None),
+        subfolder="vae",
+        prefetch_list=[],
+        local_files_only=True,
+        revision=None,
+        device=torch.device("cpu"),
+    )
+    assert isinstance(vae, AutoencoderKL)
+    assert not hasattr(vae, "set_group_norm_silu_fusion")

--- a/vllm_omni/diffusion/models/boogu_image/pipeline_boogu_image.py
+++ b/vllm_omni/diffusion/models/boogu_image/pipeline_boogu_image.py
@@ -47,6 +47,10 @@ from vllm_omni.diffusion.models.boogu_image.image_processor import BooguImagePro
 from vllm_omni.diffusion.models.boogu_image.scheduling_flow_match_euler_discrete_time_shifting import (
     FlowMatchEulerDiscreteScheduler,
 )
+from vllm_omni.diffusion.models.boogu_image.vae import (
+    BooguAutoencoderKL,
+    vae_group_norm_silu_fusion_enabled,
+)
 from vllm_omni.diffusion.models.interface import SupportImageInput, SupportsComponentDiscovery
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
@@ -54,6 +58,45 @@ from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
 
 logger = init_logger(__name__)
+
+
+def _load_boogu_vae(model, od_config, *, subfolder, prefetch_list, local_files_only, revision, device):
+    """Load the in-repo BooguAutoencoderKL (strict) with a diffusers fallback.
+
+    The in-repo class refuses any checkpoint it cannot match key-for-key
+    (BooguVaeStrictLoadError); on any failure of the primary path the stock
+    diffusers AutoencoderKL is served instead — correct but UNFUSED. The
+    fusion arming happens inside the try, so a fallback object (which has no
+    such method) can never be handed a fusion call.
+    """
+    try:
+        vae = from_pretrained_with_prefetch(
+            BooguAutoencoderKL.from_pretrained,
+            model,
+            subfolder=subfolder,
+            prefetch_list=prefetch_list,
+            local_files_only=local_files_only,
+            revision=revision,
+        ).to(device)
+        fused_sites = vae.set_group_norm_silu_fusion(vae_group_norm_silu_fusion_enabled(od_config))
+        logger.info(
+            "Boogu VAE: in-repo impl (strict load OK); GroupNorm+SiLU fusion @ %d site(s)", fused_sites
+        )
+        return vae
+    except Exception:
+        logger.exception(
+            "Boogu VAE: in-repo BooguAutoencoderKL failed to load; falling back to "
+            "diffusers AutoencoderKL (correct but UNFUSED)"
+        )
+        return from_pretrained_with_prefetch(
+            AutoencoderKL.from_pretrained,
+            model,
+            subfolder=subfolder,
+            prefetch_list=prefetch_list,
+            local_files_only=local_files_only,
+            revision=revision,
+        ).to(device)
+
 
 # Reference-image preprocessing limits (upstream ``BooguImagePipeline.__call__``
 # defaults). The VLM copy is aggressively downscaled for the Qwen3VL encoder;
@@ -270,14 +313,18 @@ class BooguImagePipeline(nn.Module, ProgressBarMixin, SupportsComponentDiscovery
             revision=od_config.revision,
         )
 
-        self.vae = from_pretrained_with_prefetch(
-            AutoencoderKL.from_pretrained,
+        # Boogu-private VAE: diffusers-faithful copy with GroupNorm+SiLU fused
+        # in its own decoder forward (#6686, D-15). Same checkpoint, zero key
+        # remap; strict load with a diffusers fallback.
+        self.vae = _load_boogu_vae(
             model,
+            od_config,
             subfolder="vae",
             prefetch_list=boogu_subfolders,
             local_files_only=local_files_only,
             revision=od_config.revision,
-        ).to(self._execution_device)
+            device=self._execution_device,
+        )
 
         self.transformer = BooguImageTransformer2DModel(od_config=od_config)
 

--- a/vllm_omni/diffusion/models/boogu_image/vae.py
+++ b/vllm_omni/diffusion/models/boogu_image/vae.py
@@ -1,0 +1,553 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+#
+# Adapted from diffusers `AutoencoderKL` (v0.40.0):
+# diffusers/models/autoencoders/{autoencoder_kl.py, vae.py},
+# diffusers/models/unets/unet_2d_blocks.py, upsampling.py, downsampling.py.
+
+"""Boogu-private AutoencoderKL with GroupNorm+SiLU fusion in the owned forward.
+
+Why this exists (#6686, decision D-15): GroupNorm followed by SiLU is ~55% of
+``vae.decode`` on Boogu-Image — 29 sites, all in the decoder. Fusing them by
+patching diffusers' modules requires trusting that diffusers' block forwards
+call the activation immediately after the norm, which an attribute-level guard
+cannot verify. Owning the forward removes that trust: this module is a faithful
+copy of diffusers' ``AutoencoderKL`` for Boogu's FLUX-style configuration, with
+:func:`fused_group_norm_silu` called exactly where this file's own forwards put
+it. Precedent: HunyuanImage3's in-repo ``AutoencoderKLConv3D`` (#6306).
+
+Fidelity contract:
+
+- **Owned dataflow, reused leaves.** Only the block forwards are ours; the
+  parameterised leaves are stock ``nn.GroupNorm`` / ``nn.Conv2d`` and the mid
+  block runs diffusers' own ``Attention``, so numerics reduce to the fused
+  op's ~1-ulp envelope (unfused paths are bit-identical to diffusers).
+- **Submodule names mirror diffusers exactly** (``decoder.up_blocks[i]
+  .resnets[j]``, ``mid_block.attentions[0]``, ``conv_norm_out``, ...), so the
+  stock Boogu ``vae/`` checkpoint loads with zero key remapping.
+- The fusion sits behind a runtime switch (:meth:`BooguAutoencoderKL
+  .set_group_norm_silu_fusion`) and is only ever armed when
+  ``config.act_fn == "silu"``; with the switch off every site computes the
+  plain ``act(norm(x))``, and the fused op itself falls back natively where
+  Triton is unavailable.
+- Tiling and slicing are not implemented (the Boogu pipeline never enables
+  them); the enable methods raise rather than silently diverge.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from diffusers.configuration_utils import ConfigMixin, register_to_config
+from diffusers.models.activations import get_activation
+from diffusers.models.attention_processor import Attention
+from diffusers.models.autoencoders.autoencoder_kl import AutoencoderKLOutput
+from diffusers.models.autoencoders.vae import DecoderOutput, DiagonalGaussianDistribution
+from diffusers.models.modeling_utils import ModelMixin
+from torch import nn
+from vllm.logger import init_logger
+
+from vllm_omni.model_executor.models.common.ops.fused_group_norm_silu import (
+    fused_group_norm_silu,
+)
+
+logger = init_logger(__name__)
+
+# Kill-switch, identical keys to the T5/T8 install path: additional_config
+# (bool, default on) with a disable-only env override.
+CONFIG_KEY = "vae_group_norm_silu_fusion"
+ENV_KEY = "VLLM_OMNI_VAE_GN_SILU_FUSION"
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return value.strip().lower() not in ("0", "false", "no", "off")
+    return bool(value)
+
+
+def vae_group_norm_silu_fusion_enabled(od_config: Any) -> bool:
+    """Resolve the kill-switch: on by default; ``additional_config
+    {"vae_group_norm_silu_fusion": false}`` or ``VLLM_OMNI_VAE_GN_SILU_FUSION=0``
+    disables it."""
+    if not _as_bool(os.environ.get(ENV_KEY), True):
+        return False
+    additional_config = getattr(od_config, "additional_config", None) or {}
+    return _as_bool(additional_config.get(CONFIG_KEY), True)
+
+
+class BooguVaeStrictLoadError(Exception):
+    """The in-repo VAE could not load a checkpoint with a complete, exact key
+    match — a bug in THIS module, to be caught by the pipeline's diffusers
+    fallback, not papered over. Deliberately not an OSError/RuntimeError/
+    ValueError so from_pretrained_with_prefetch's cache-heal retry does not
+    swallow it."""
+
+
+def _norm_silu(norm: nn.GroupNorm, x: torch.Tensor) -> torch.Tensor:
+    return fused_group_norm_silu(x, norm.weight, norm.bias, norm.num_groups, norm.eps)
+
+
+class BooguResnetBlock2D(nn.Module):
+    """diffusers ``ResnetBlock2D`` for the temb-free VAE case, forward owned.
+
+    Parameter names (norm1/conv1/norm2/conv2/conv_shortcut) mirror diffusers.
+    ``fuse_group_norm_silu`` selects, per call, the fused GroupNorm+SiLU kernel
+    or the plain ``act(norm(x))`` pair; it is armed only by the parent module
+    and only when the activation is SiLU.
+    """
+
+    def __init__(
+        self,
+        *,
+        in_channels: int,
+        out_channels: int,
+        groups: int,
+        eps: float,
+        act_fn: str,
+        dropout: float = 0.0,
+        output_scale_factor: float = 1.0,
+    ) -> None:
+        super().__init__()
+        self.output_scale_factor = output_scale_factor
+        self.fuse_group_norm_silu = False
+
+        self.norm1 = nn.GroupNorm(num_groups=groups, num_channels=in_channels, eps=eps, affine=True)
+        self.conv1 = nn.Conv2d(in_channels, out_channels, kernel_size=3, stride=1, padding=1)
+        self.norm2 = nn.GroupNorm(num_groups=groups, num_channels=out_channels, eps=eps, affine=True)
+        self.dropout = nn.Dropout(dropout)
+        self.conv2 = nn.Conv2d(out_channels, out_channels, kernel_size=3, stride=1, padding=1)
+        self.nonlinearity = get_activation(act_fn)
+
+        self.conv_shortcut = None
+        if in_channels != out_channels:
+            self.conv_shortcut = nn.Conv2d(in_channels, out_channels, kernel_size=1, stride=1, padding=0, bias=True)
+
+    def forward(self, input_tensor: torch.Tensor, temb: torch.Tensor | None = None) -> torch.Tensor:
+        # The whole point of T9: the norm -> activation adjacency is a fact of
+        # THIS forward, not an assumption about a third-party one.
+        hidden_states = input_tensor
+        if self.fuse_group_norm_silu:
+            hidden_states = _norm_silu(self.norm1, hidden_states)
+        else:
+            hidden_states = self.nonlinearity(self.norm1(hidden_states))
+        hidden_states = self.conv1(hidden_states)
+        if self.fuse_group_norm_silu:
+            hidden_states = _norm_silu(self.norm2, hidden_states)
+        else:
+            hidden_states = self.nonlinearity(self.norm2(hidden_states))
+        hidden_states = self.dropout(hidden_states)
+        hidden_states = self.conv2(hidden_states)
+        if self.conv_shortcut is not None:
+            input_tensor = self.conv_shortcut(input_tensor)
+        return (input_tensor + hidden_states) / self.output_scale_factor
+
+
+class BooguUpsample2D(nn.Module):
+    """diffusers ``Upsample2D(use_conv=True)``: nearest 2x then a 3x3 conv."""
+
+    def __init__(self, channels: int) -> None:
+        super().__init__()
+        self.conv = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        # diffusers works around two upsample_nearest issues; replicate both
+        # (they only force contiguity, never values).
+        if hidden_states.shape[0] >= 64 or hidden_states.numel() * 2 > 2**31:
+            hidden_states = hidden_states.contiguous()
+        hidden_states = F.interpolate(hidden_states, scale_factor=2.0, mode="nearest")
+        return self.conv(hidden_states)
+
+
+class BooguDownsample2D(nn.Module):
+    """diffusers ``Downsample2D(use_conv=True, padding=0, name="op")``:
+    asymmetric (0,1,0,1) pad then a stride-2 3x3 conv."""
+
+    def __init__(self, channels: int) -> None:
+        super().__init__()
+        self.conv = nn.Conv2d(channels, channels, kernel_size=3, stride=2, padding=0)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = F.pad(hidden_states, (0, 1, 0, 1), mode="constant", value=0)
+        return self.conv(hidden_states)
+
+
+class BooguUpDecoderBlock2D(nn.Module):
+    def __init__(
+        self,
+        *,
+        in_channels: int,
+        out_channels: int,
+        num_layers: int,
+        groups: int,
+        eps: float,
+        act_fn: str,
+        add_upsample: bool,
+    ) -> None:
+        super().__init__()
+        self.resnets = nn.ModuleList(
+            [
+                BooguResnetBlock2D(
+                    in_channels=in_channels if i == 0 else out_channels,
+                    out_channels=out_channels,
+                    groups=groups,
+                    eps=eps,
+                    act_fn=act_fn,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        self.upsamplers = nn.ModuleList([BooguUpsample2D(out_channels)]) if add_upsample else None
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        for resnet in self.resnets:
+            hidden_states = resnet(hidden_states)
+        if self.upsamplers is not None:
+            for upsampler in self.upsamplers:
+                hidden_states = upsampler(hidden_states)
+        return hidden_states
+
+
+class BooguDownEncoderBlock2D(nn.Module):
+    def __init__(
+        self,
+        *,
+        in_channels: int,
+        out_channels: int,
+        num_layers: int,
+        groups: int,
+        eps: float,
+        act_fn: str,
+        add_downsample: bool,
+    ) -> None:
+        super().__init__()
+        self.resnets = nn.ModuleList(
+            [
+                BooguResnetBlock2D(
+                    in_channels=in_channels if i == 0 else out_channels,
+                    out_channels=out_channels,
+                    groups=groups,
+                    eps=eps,
+                    act_fn=act_fn,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        self.downsamplers = nn.ModuleList([BooguDownsample2D(out_channels)]) if add_downsample else None
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        for resnet in self.resnets:
+            hidden_states = resnet(hidden_states)
+        if self.downsamplers is not None:
+            for downsampler in self.downsamplers:
+                hidden_states = downsampler(hidden_states)
+        return hidden_states
+
+
+class BooguMidBlock2D(nn.Module):
+    """diffusers ``UNetMidBlock2D`` for the VAE case: resnet, attention, resnet.
+
+    The attention IS diffusers' ``Attention`` (deprecated-attn-block flavour,
+    exactly as ``UNetMidBlock2D`` constructs it), so its numerics and its
+    checkpoint keys (``attentions.0.group_norm/to_q/to_k/to_v/to_out.0``) are
+    inherited rather than re-implemented.
+    """
+
+    def __init__(self, *, in_channels: int, groups: int, eps: float, act_fn: str, add_attention: bool) -> None:
+        super().__init__()
+
+        def _resnet() -> BooguResnetBlock2D:
+            return BooguResnetBlock2D(
+                in_channels=in_channels, out_channels=in_channels, groups=groups, eps=eps, act_fn=act_fn
+            )
+
+        self.resnets = nn.ModuleList([_resnet(), _resnet()])
+        attention = None
+        if add_attention:
+            attention = Attention(
+                in_channels,
+                heads=1,
+                dim_head=in_channels,
+                rescale_output_factor=1.0,
+                eps=eps,
+                norm_num_groups=groups,
+                spatial_norm_dim=None,
+                residual_connection=True,
+                bias=True,
+                upcast_softmax=True,
+                _from_deprecated_attn_block=True,
+            )
+        self.attentions = nn.ModuleList([attention])
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.resnets[0](hidden_states)
+        if self.attentions[0] is not None:
+            hidden_states = self.attentions[0](hidden_states, temb=None)
+        return self.resnets[1](hidden_states)
+
+
+class BooguDecoder(nn.Module):
+    def __init__(
+        self,
+        *,
+        in_channels: int,
+        out_channels: int,
+        block_out_channels: tuple[int, ...],
+        layers_per_block: int,
+        norm_num_groups: int,
+        act_fn: str,
+        mid_block_add_attention: bool,
+    ) -> None:
+        super().__init__()
+        self.fuse_conv_norm_out = False
+
+        self.conv_in = nn.Conv2d(in_channels, block_out_channels[-1], kernel_size=3, stride=1, padding=1)
+        self.mid_block = BooguMidBlock2D(
+            in_channels=block_out_channels[-1],
+            groups=norm_num_groups,
+            eps=1e-6,
+            act_fn=act_fn,
+            add_attention=mid_block_add_attention,
+        )
+
+        self.up_blocks = nn.ModuleList([])
+        reversed_channels = list(reversed(block_out_channels))
+        output_channel = reversed_channels[0]
+        for i, ch in enumerate(reversed_channels):
+            prev_output_channel = output_channel
+            output_channel = ch
+            self.up_blocks.append(
+                BooguUpDecoderBlock2D(
+                    in_channels=prev_output_channel,
+                    out_channels=output_channel,
+                    num_layers=layers_per_block + 1,
+                    groups=norm_num_groups,
+                    eps=1e-6,
+                    act_fn=act_fn,
+                    add_upsample=i != len(block_out_channels) - 1,
+                )
+            )
+
+        self.conv_norm_out = nn.GroupNorm(num_channels=block_out_channels[0], num_groups=norm_num_groups, eps=1e-6)
+        # diffusers hardcodes SiLU here regardless of act_fn — mirror that.
+        self.conv_act = nn.SiLU()
+        self.conv_out = nn.Conv2d(block_out_channels[0], out_channels, 3, padding=1)
+
+    def forward(self, sample: torch.Tensor) -> torch.Tensor:
+        sample = self.conv_in(sample)
+        sample = self.mid_block(sample)
+        for up_block in self.up_blocks:
+            sample = up_block(sample)
+        if self.fuse_conv_norm_out:
+            sample = _norm_silu(self.conv_norm_out, sample)
+        else:
+            sample = self.conv_act(self.conv_norm_out(sample))
+        return self.conv_out(sample)
+
+
+class BooguEncoder(nn.Module):
+    """Owned but plain: same composed leaves, no fused op (encoder fusion is
+    out of scope for v1 so the perf claim stays aligned with T4's
+    decoder-only measurement)."""
+
+    def __init__(
+        self,
+        *,
+        in_channels: int,
+        out_channels: int,
+        block_out_channels: tuple[int, ...],
+        layers_per_block: int,
+        norm_num_groups: int,
+        act_fn: str,
+        mid_block_add_attention: bool,
+        double_z: bool = True,
+    ) -> None:
+        super().__init__()
+        self.conv_in = nn.Conv2d(in_channels, block_out_channels[0], kernel_size=3, stride=1, padding=1)
+
+        self.down_blocks = nn.ModuleList([])
+        output_channel = block_out_channels[0]
+        for i, ch in enumerate(block_out_channels):
+            input_channel = output_channel
+            output_channel = ch
+            self.down_blocks.append(
+                BooguDownEncoderBlock2D(
+                    in_channels=input_channel,
+                    out_channels=output_channel,
+                    num_layers=layers_per_block,
+                    groups=norm_num_groups,
+                    eps=1e-6,
+                    act_fn=act_fn,
+                    add_downsample=i != len(block_out_channels) - 1,
+                )
+            )
+
+        self.mid_block = BooguMidBlock2D(
+            in_channels=block_out_channels[-1],
+            groups=norm_num_groups,
+            eps=1e-6,
+            act_fn=act_fn,
+            add_attention=mid_block_add_attention,
+        )
+
+        self.conv_norm_out = nn.GroupNorm(num_channels=block_out_channels[-1], num_groups=norm_num_groups, eps=1e-6)
+        # diffusers hardcodes SiLU here regardless of act_fn — mirror that.
+        self.conv_act = nn.SiLU()
+        conv_out_channels = 2 * out_channels if double_z else out_channels
+        self.conv_out = nn.Conv2d(block_out_channels[-1], conv_out_channels, 3, padding=1)
+
+    def forward(self, sample: torch.Tensor) -> torch.Tensor:
+        sample = self.conv_in(sample)
+        for down_block in self.down_blocks:
+            sample = down_block(sample)
+        sample = self.mid_block(sample)
+        sample = self.conv_act(self.conv_norm_out(sample))
+        return self.conv_out(sample)
+
+
+class BooguAutoencoderKL(ModelMixin, ConfigMixin):
+    """Boogu-private AutoencoderKL; drop-in for diffusers' at the pipeline
+    boundary (``from_pretrained`` / ``.config`` / ``encode`` / ``decode``)."""
+
+    _supports_gradient_checkpointing = False
+
+    @register_to_config
+    def __init__(
+        self,
+        in_channels: int = 3,
+        out_channels: int = 3,
+        down_block_types: tuple[str, ...] = ("DownEncoderBlock2D",),
+        up_block_types: tuple[str, ...] = ("UpDecoderBlock2D",),
+        block_out_channels: tuple[int, ...] = (64,),
+        layers_per_block: int = 1,
+        act_fn: str = "silu",
+        latent_channels: int = 4,
+        norm_num_groups: int = 32,
+        sample_size: int = 32,
+        scaling_factor: float = 0.18215,
+        shift_factor: float | None = None,
+        latents_mean: tuple[float] | None = None,
+        latents_std: tuple[float] | None = None,
+        force_upcast: bool = True,
+        use_quant_conv: bool = True,
+        use_post_quant_conv: bool = True,
+        mid_block_add_attention: bool = True,
+    ) -> None:
+        super().__init__()
+        if any(t != "DownEncoderBlock2D" for t in down_block_types) or any(
+            t != "UpDecoderBlock2D" for t in up_block_types
+        ):
+            raise NotImplementedError(
+                "BooguAutoencoderKL implements the plain DownEncoderBlock2D/UpDecoderBlock2D "
+                f"architecture only; got {down_block_types} / {up_block_types}"
+            )
+
+        self.encoder = BooguEncoder(
+            in_channels=in_channels,
+            out_channels=latent_channels,
+            block_out_channels=tuple(block_out_channels),
+            layers_per_block=layers_per_block,
+            norm_num_groups=norm_num_groups,
+            act_fn=act_fn,
+            mid_block_add_attention=mid_block_add_attention,
+        )
+        self.decoder = BooguDecoder(
+            in_channels=latent_channels,
+            out_channels=out_channels,
+            block_out_channels=tuple(block_out_channels),
+            layers_per_block=layers_per_block,
+            norm_num_groups=norm_num_groups,
+            act_fn=act_fn,
+            mid_block_add_attention=mid_block_add_attention,
+        )
+        self.quant_conv = nn.Conv2d(2 * latent_channels, 2 * latent_channels, 1) if use_quant_conv else None
+        self.post_quant_conv = nn.Conv2d(latent_channels, latent_channels, 1) if use_post_quant_conv else None
+
+        # Fusion is only ever armed for the activation the fused op implements.
+        self._fusion_supported = act_fn == "silu"
+        self.set_group_norm_silu_fusion(self._fusion_supported)
+
+    # -- strict loading ------------------------------------------------------
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        """diffusers' loader only *warns* on missing/unexpected/mismatched
+        keys; this module must match the checkpoint exactly or refuse it, so
+        the pipeline can fall back to diffusers rather than serve a
+        partially-initialised VAE."""
+        kwargs["output_loading_info"] = True
+        model, info = super().from_pretrained(pretrained_model_name_or_path, **kwargs)
+        problems = {k: info[k] for k in ("missing_keys", "unexpected_keys", "mismatched_keys") if info.get(k)}
+        if problems:
+            raise BooguVaeStrictLoadError(
+                f"strict load failed for {pretrained_model_name_or_path}: {problems}"
+            )
+        return model
+
+    # -- fusion control ----------------------------------------------------
+
+    def _decoder_fusion_sites(self):
+        for up_block in self.decoder.up_blocks:
+            yield from up_block.resnets
+        yield from self.decoder.mid_block.resnets
+
+    def set_group_norm_silu_fusion(self, enabled: bool) -> int:
+        """Arm or disarm the fused GroupNorm+SiLU sites in the decoder.
+
+        Returns the number of fused sites now active (0 when disabled or when
+        the configured activation is not SiLU — the fusion never applies to a
+        non-SiLU activation).
+        """
+        enabled = bool(enabled) and self._fusion_supported
+        for resnet in self._decoder_fusion_sites():
+            resnet.fuse_group_norm_silu = enabled
+        self.decoder.fuse_conv_norm_out = enabled
+        return self.group_norm_silu_fusion_site_count()
+
+    def group_norm_silu_fusion_site_count(self) -> int:
+        count = sum(2 for r in self._decoder_fusion_sites() if r.fuse_group_norm_silu)
+        return count + (1 if self.decoder.fuse_conv_norm_out else 0)
+
+    # -- tiling / slicing: not implemented, refuse loudly -------------------
+
+    def enable_tiling(self, *args, **kwargs) -> None:
+        raise NotImplementedError("BooguAutoencoderKL does not implement tiling")
+
+    def enable_slicing(self) -> None:
+        raise NotImplementedError("BooguAutoencoderKL does not implement slicing")
+
+    # -- encode / decode (diffusers' contract, minus tiling/slicing) --------
+
+    def encode(
+        self, x: torch.Tensor, return_dict: bool = True
+    ) -> AutoencoderKLOutput | tuple[DiagonalGaussianDistribution]:
+        h = self.encoder(x)
+        if self.quant_conv is not None:
+            h = self.quant_conv(h)
+        posterior = DiagonalGaussianDistribution(h)
+        if not return_dict:
+            return (posterior,)
+        return AutoencoderKLOutput(latent_dist=posterior)
+
+    def decode(self, z: torch.Tensor, return_dict: bool = True, generator=None) -> DecoderOutput | torch.Tensor:
+        if self.post_quant_conv is not None:
+            z = self.post_quant_conv(z)
+        decoded = self.decoder(z)
+        if not return_dict:
+            return (decoded,)
+        return DecoderOutput(sample=decoded)
+
+    def forward(
+        self,
+        sample: torch.Tensor,
+        sample_posterior: bool = False,
+        return_dict: bool = True,
+        generator: torch.Generator | None = None,
+    ) -> DecoderOutput | torch.Tensor:
+        posterior = self.encode(sample).latent_dist
+        z = posterior.sample(generator=generator) if sample_posterior else posterior.mode()
+        return self.decode(z, return_dict=return_dict)


### PR DESCRIPTION
## Summary

This PR adds a model-specific VAE module (`BooguAutoencoderKL`) for Boogu-Image and
replaces every GroupNorm + SiLU chain in its decoder with `fused_group_norm_silu`, to accelerate
the `vae.decode` stage of the pipeline.

Originally, Boogu-Image's VAE came from the third-party `diffusers` library, which makes
it hard to swap its operators for the fused kernel from within the vllm-omni repo. We
therefore rewrite the VAE module in-repo for Boogu-Image (following the same approach as
#6306). The in-repo code is almost a verbatim copy of the third-party implementation and
passes the numerical checks below. A fallback path to the original diffusers VAE module
is also kept. 

## Design & Implementation

The module mirrors the `diffusers` implementation; the design comes down to three pieces: 

- **Module composition.** `BooguResnetBlock2D` / `BooguDecoder` / `BooguEncoder`
  reproduce the VAE's module structure and override `forward()`; the parameterised
  leaves stay stock `nn.GroupNorm` / `nn.Conv2d`, and the mid block reuses diffusers'
  own `Attention`. The unfused paths are **bit-identical** to diffusers.
  `fused_group_norm_silu()` is called only at the decoder's GroupNorm→SiLU sites —
  `norm1`/`norm2` inside `BooguResnetBlock2D` and the decoder's `conv_norm_out`
  (29 sites in total); the encoder is left unfused.
- **Checkpoint loading.** Submodule names match diffusers' exactly
  (`decoder.up_blocks[i].resnets[j]`, `mid_block.attentions[0]`, `conv_norm_out`, …),
  so the stock Boogu `vae/` checkpoint loads with **zero key remap**. `from_pretrained`
  is strict — it raises on any missing/unexpected/mismatched key — and the pipeline
  then falls back to diffusers' `AutoencoderKL` (correct, unfused) with a logged error.
- **Kill-switch.** On by default; disable with
  `additional_config {"vae_group_norm_silu_fusion": false}` or
  `VLLM_OMNI_VAE_GN_SILU_FUSION=0`. Fusion arms only when `config.act_fn == "silu"`,
  and the op falls back to native `F.silu(F.group_norm(...))` where Triton is
  unavailable.

## Correctness

Env: single H200, bf16; Boogu-Image-0.1-Base `vae/` rev `334ad7e5`;
diffusers 0.40.0, torch 2.13.0+cu132, vllm 0.28.0, triton 3.7.1.

- **Weight completeness:** 244/244 keys both directions, zero missing/unexpected;
  every loaded tensor bit-identical to diffusers'.
- **Unfused decode == diffusers, bit-for-bit** at 512² and 1024² (`torch.equal`);
  **encode** mean/logvar bit-equal. The copy is exact.
- **End-to-end image** (seed 42, 1024²×28×cfg4): SSIM 0.9989, PSNR 57.7 dB,
  max |Δ| 3/255 vs the eager baseline.
- Unit suite: **463 passed / 1 skipped** (22 new tests: 19 covering diffusers
  equivalence — every comparison `torch.equal` on the op's native fallback — plus
  weight-load completeness, fusion on/off, site counts and the kill-switch; and 3 for
  strict load / fallback).

## Performance

Same env as above; 10 requests, 2 discarded. `vae.decode` GroupNorm+SiLU: ~29 ms per
1024² request saved (2.0–2.6× per site). End-to-end A/B, fusion ON vs the diffusers
baseline:

- 28-step CFG serving: **−34.9 ms (−0.43%)** engine time.
- 4-step CFG-off (Turbo-style) proxy: **−29.0 ms (−4.22%)**.

`vae.decode` is per-request and step-invariant, so the saving's share scales inversely
with steps — ~0.4% at 28 steps and ~4.2% at the 4-step Turbo proxy, as measured above.
Fusion OFF vs baseline is ≈0 within session noise.

## Test plan

`pytest tests/diffusion/models/boogu_image/ -k "boogu or vae"` (CPU, native fallback,
bit-exact vs diffusers). H200 real-weight parity + A/B as reproduced above.

Part of #6686 / #6665 Track 3 item 1.