### PR TITLE
[CI][Bugfix] Normalize spoken units in text comparison

### DIFF
--- a/tests/helpers/media.py
+++ b/tests/helpers/media.py
@@ -600,7 +600,7 @@ def concat_audio(audio_val) -> np.ndarray:
 def preprocess_text(text):
     import opencc
 
-    word_to_num = {
+    word_normalizations = {
         "zero": "0",
         "one": "1",
         "two": "2",
@@ -612,10 +612,11 @@ def preprocess_text(text):
         "eight": "8",
         "nine": "9",
         "ten": "10",
+        "kilohertz": "khz",
     }
-    for word, num in word_to_num.items():
+    for word, replacement in word_normalizations.items():
         pattern = r"\b" + re.escape(word) + r"\b"
-        text = re.sub(pattern, num, text, flags=re.IGNORECASE)
+        text = re.sub(pattern, replacement, text, flags=re.IGNORECASE)
 
     text = re.sub(r"[^\w\s]", "", text)
     text = re.sub(r"\s+", " ", text)

--- a/tests/helpers/tests/test_media.py
+++ b/tests/helpers/tests/test_media.py
@@ -15,6 +15,14 @@ from tests.helpers import media
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 
+def test_preprocess_text_normalizes_spoken_kilohertz():
+    expected = "This response should be encoded as eight kilohertz audio."
+    transcript = "This response should be encoded as 8 kHz audio."
+
+    assert media.preprocess_text(expected) == media.preprocess_text(transcript)
+    assert media.cosine_similarity_text(expected, transcript) == pytest.approx(1.0)
+
+
 def _stub_transcribe(monkeypatch) -> dict:
     """Capture the kwargs the helper hands to whisper, with no model and no device."""
     captured: dict = {}


### PR DESCRIPTION
<!-- markdownlint-disable -->

Fixes #6932.

## Purpose

Qwen3-TTS E2E validation compares the expected input text with a Whisper transcript. Whisper may transcribe a spoken unit using an equivalent abbreviated form, for example `eight kilohertz` as `8 kHz`. The existing text preprocessing normalized number words, but not unit words, so semantically equivalent text could receive a lower similarity score and cause a false-negative test failure.

The issue can be reproduced with:

```python
from tests.helpers.media import cosine_similarity_text, preprocess_text

expected = "This response should be encoded as eight kilohertz audio."
transcript = "This response should be encoded as 8 kHz audio."

assert preprocess_text(expected) == preprocess_text(transcript)
assert cosine_similarity_text(expected, transcript) == 1.0
```

This change generalizes the existing number-word replacement table into a word normalization table and normalizes `kilohertz` to `khz`. It also adds a focused regression test covering both preprocessing and cosine similarity.

## Test Plan

Run the focused helper regression test:

```bash
pytest -q tests/helpers/tests/test_media.py
```

Run the original full-model L4 TTS E2E selection on NVIDIA A100-SXM4-80GB:

```bash
export VLLM_ALLOW_LONG_MAX_MODEL_LEN="1"
export VLLM_USE_DEEP_GEMM="0"
export VLLM_MOE_USE_DEEP_GEMM="0"
pytest -s -v tests/e2e/ \
  -m "full_model and L4 and tts" \
  --run-level "full_model" \
  --ignore=tests/e2e/accuracy
```

**vLLM Version:** v0.28.0

**vLLM-Omni Commit:** b356d36b57b863d7034abbe86a0620edac1491ee

## Test Result

```text
15 passed, 2 skipped, 862 deselected, 16 warnings in 2480.14s (0:41:20)
```

The regression scenario passed in both serving modes:

```text
test_sample_rate_001[async_chunk]       PASSED
test_sample_rate_001[no_async_chunk]    PASSED
```

Produced `This response should be encoded as 8kHz audio.` for the expected text `This response should be encoded as eight kilohertz audio.`; the normalized comparison passed with cosine similarity `0.932`.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
