### PR TITLE
[Bugfix] Clear prompt embedding cache before diffusion worker sleep

### DIFF
--- a/tests/diffusion/test_diffusion_worker.py
+++ b/tests/diffusion/test_diffusion_worker.py
@@ -13,6 +13,7 @@ import pytest
 import torch
 from pytest_mock import MockerFixture
 
+from vllm_omni.diffusion.cache.prompt_embed_cache import PromptEmbedCache
 from vllm_omni.diffusion.worker.diffusion_worker import DiffusionWorker
 
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.gpu]
@@ -67,6 +68,48 @@ class TestDiffusionWorkerSleep:
         self.mock_allocator_class.get_instance.return_value = self.mock_allocator
         self.mock_allocator.get_current_usage.return_value = 4 * 1024**3
         self.mock_allocator.sleep = mocker.Mock()
+
+    @pytest.mark.parametrize("level", [1, 2])
+    def test_sleep_clears_prompt_embed_cache_before_allocator(self, mocker, mock_gpu_worker, level):
+        events = []
+        prompt_cache = PromptEmbedCache(max_size=1)
+        prompt_cache.put("prompt-key", torch.ones(1))
+        mock_platform = mocker.patch("vllm_omni.diffusion.worker.diffusion_worker.current_omni_platform")
+        mock_platform.get_free_memory.side_effect = [10 * 1024**3, 12 * 1024**3]
+        mock_platform.get_device_total_memory.return_value = 80 * 1024**3
+        mock_gpu_worker.model_runner.pipeline.named_buffers.return_value = []
+
+        def clear_prompt_embed_cache():
+            prompt_cache.clear()
+            events.append("clear")
+
+        mock_gpu_worker.model_runner.clear_prompt_embed_cache.side_effect = clear_prompt_embed_cache
+        self.mock_allocator.sleep.side_effect = lambda **_: events.append("sleep")
+
+        mock_gpu_worker.sleep(level=level)
+
+        assert events == ["clear", "sleep"]
+        assert prompt_cache.stats()["size"] == 0
+
+    def test_sleep_accepts_model_runner_without_prompt_cache_hook(self, mocker, mock_gpu_worker):
+        mock_platform = mocker.patch("vllm_omni.diffusion.worker.diffusion_worker.current_omni_platform")
+        mock_platform.get_free_memory.side_effect = [10 * 1024**3, 12 * 1024**3]
+        mock_platform.get_device_total_memory.return_value = 80 * 1024**3
+        mock_gpu_worker.model_runner = object()
+
+        mock_gpu_worker.sleep(level=1)
+
+        self.mock_allocator.sleep.assert_called_once_with(offload_tags=("weights",))
+
+    @pytest.mark.parametrize("level", [1, 2])
+    def test_sleep_does_not_enter_allocator_if_prompt_cache_clear_fails(self, mock_gpu_worker, level):
+        mock_gpu_worker.model_runner.clear_prompt_embed_cache.side_effect = RuntimeError("clear failed")
+
+        with pytest.raises(RuntimeError, match="clear failed"):
+            mock_gpu_worker.sleep(level=level)
+
+        self.mock_allocator.sleep.assert_not_called()
+        mock_gpu_worker.model_runner.release_captured_graphs.assert_not_called()
 
     def test_sleep_level_1(self, mocker: MockerFixture, mock_gpu_worker):
         """Test sleep mode level 1 (offload weights only)."""

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -785,6 +785,11 @@ class DiffusionWorker:
 
         usage_before = allocator.get_current_usage()
 
+        if self.model_runner is not None:
+            clear_prompt_embed_cache = getattr(self.model_runner, "clear_prompt_embed_cache", None)
+            if callable(clear_prompt_embed_cache):
+                clear_prompt_embed_cache()
+
         if level == 2 and self.model_runner is not None:
             self.model_runner.release_captured_graphs()
             logger.info(f"[Worker {self.rank}] CUDA Graphs cleared.")


### PR DESCRIPTION
## Purpose

- Clear cached `encode_prompt()` outputs at the diffusion worker sleep boundary.
- Perform the clear before `allocator.sleep()` for both sleep levels.
- Preserve compatibility with custom or test runners that do not expose the optional clear hook.
- Abort before graph or allocator mutation if cache clearing fails.
- Add focused lifecycle coverage for ordering, real cache eviction, compatibility, and failure behavior.

## Why this change is needed

`PromptEmbedCache` keeps detached prompt-encoder outputs in an LRU, including tensor outputs. `DiffusionModelRunner` already owns `clear_prompt_embed_cache()`, but `DiffusionWorker.sleep()` did not invoke it. Prompt embeddings could therefore remain strongly referenced while the worker entered sleep, outside the intended memory-release lifecycle.

The bug applies to both supported worker sleep levels. Level 1 offloads weights, while level 2 additionally releases captured graphs and saves buffers; neither base path cleared prompt embeddings.

## Implementation

`DiffusionWorker.sleep()` now invokes the model runner's existing cache-ownership API before level-specific handling and allocator sleep:

```python
if self.model_runner is not None:
    clear_prompt_embed_cache = getattr(self.model_runner, "clear_prompt_embed_cache", None)
    if callable(clear_prompt_embed_cache):
        clear_prompt_embed_cache()
```

The callable `getattr` preserves the duck-typed boundary for custom and test runners that do not expose this optional hook.

The focused tests verify that:

- a real `PromptEmbedCache` starts with size 1 and reaches size 0;
- the event order is exactly `['clear', 'sleep']` for levels 1 and 2;
- a runner without `clear_prompt_embed_cache` still enters allocator sleep;
- a clear exception propagates before graph release or allocator sleep for levels 1 and 2.

## Test Result

| Check | Result | Evidence boundary |
| --- | --- | --- |
| Latest base + clear-before-sleep oracle | `2 failed` as expected | Levels 1 and 2 observe only `sleep`, reproducing the missing lifecycle call. |
| Exact head + expanded focused lifecycle set | `5 passed` | Covers level 1/2 ordering and cache size `1 -> 0`, no-hook compatibility, and clear failures before mutation. |
| `TestDiffusionWorkerSleep` + complete `PromptEmbedCache` suite | `81 passed` | Directly related regression coverage. |
| `ruff-check`, `ruff-format`, test marks, SPDX, forbidden imports, and `torch.cuda` guard | passed | Repository pre-commit hooks on both changed files. |
| `compileall`, `py_compile`, and `git diff --check` | passed | Syntax and whitespace checks. |
| mypy base/head comparison | same 39 pre-existing errors on each | The patch adds no new mypy diagnostic; the added production lines are not reported. |