### PR TITLE
[Bugfix][Diffusion] Register Sana I2V pipeline as video output

### DIFF
--- a/tests/entrypoints/openai_api/test_video_pipeline_capability.py
+++ b/tests/entrypoints/openai_api/test_video_pipeline_capability.py
@@ -64,3 +64,14 @@ def test_video_pipeline_rejects_non_video_final_outputs(stage_configs):
 )
 def test_registered_video_aliases_declare_video_output(model_class_name):
     assert get_diffusion_output_type(model_class_name) == "video"
+
+
+@pytest.mark.parametrize(
+    "model_class_name",
+    [
+        "SanaVideoPipeline",
+        "SanaImageToVideoPipeline",
+    ],
+)
+def test_sana_video_pipelines_declare_video_output(model_class_name):
+    assert get_diffusion_output_type(model_class_name) == "video"

--- a/vllm_omni/diffusion/model_metadata.py
+++ b/vllm_omni/diffusion/model_metadata.py
@@ -88,6 +88,7 @@ _DIFFUSION_MODEL_METADATA: dict[str, DiffusionModelMetadata] = {
     "Cosmos3OmniDiffusersPipeline": DiffusionModelMetadata(final_output_type="video"),
     "Cosmos3OmniPipeline": DiffusionModelMetadata(final_output_type="video"),
     "SanaVideoPipeline": DiffusionModelMetadata(final_output_type="video"),
+    "SanaImageToVideoPipeline": DiffusionModelMetadata(final_output_type="video"),
     "SanaWmPipeline": DiffusionModelMetadata(
         supports_multimodal_inputs=True,
         max_multimodal_image_inputs=1,


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

- Online `/v1/videos` for `SanaImageToVideoPipeline` failed with HTTP 503 because the class was not registered in diffusion model metadata, so `get_diffusion_output_type()` fell back to `"image"` and the video serving path rejected the stage as a non-video pipeline.
- Register `SanaImageToVideoPipeline` with `final_output_type="video"` (same contract as `SanaVideoPipeline` / other I2V classes) and add an L1 CPU regression.

Fixes https://github.com/vllm-project/vllm-omni/issues/6951

## Test Plan

**vLLM Version:** N/A (metadata + unit test only)

**vLLM-Omni Commit:** `00c98966`

UT:

```bash
python -m pytest tests/entrypoints/openai_api/test_video_pipeline_capability.py -m "core_model and cpu" --run-level core_model --tb=short
```

Optional GPU smoke (the original CI failure):

```bash
python -m pytest tests/model_tests/diffusion/test_common_online.py -k "SanaImageToVideoPipeline" --run-level core_model --tb=short
```

## Test Result


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
