### PR TITLE
[Bugfix][Diffusion] Preserve OmniGen2 image guidance default

### DIFF
--- a/tests/diffusion/models/omnigen2/test_request.py
+++ b/tests/diffusion/models/omnigen2/test_request.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Unit tests for OmniGen2 request defaults."""
+
+import pytest
+import torch
+from torch import nn
+
+from vllm_omni.diffusion.models.omnigen2.pipeline_omnigen2 import OmniGen2Pipeline
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class _GuidanceResolvedError(Exception):
+    pass
+
+
+def _stop_after_guidance_resolution(*args, **kwargs):
+    raise _GuidanceResolvedError
+
+
+@pytest.mark.parametrize(
+    ("sampling_kwargs", "forward_kwargs", "expected_scales"),
+    [
+        ({}, {}, (4.0, 1.0)),
+        ({"guidance_scale": 5.0}, {}, (5.0, 1.0)),
+        ({"guidance_scale": 0.0}, {}, (0.0, 1.0)),
+        ({"guidance_scale_2": 0.0}, {}, (4.0, 0.0)),
+        ({"guidance_scale": 5.0, "guidance_scale_2": 2.0}, {}, (5.0, 2.0)),
+        ({}, {"image_guidance_scale": 3.0}, (4.0, 3.0)),
+    ],
+)
+def test_image_guidance_distinguishes_explicit_value_from_omission(sampling_kwargs, forward_kwargs, expected_scales):
+    pipeline = object.__new__(OmniGen2Pipeline)
+    nn.Module.__init__(pipeline)
+    pipeline.default_sample_size = 128
+    pipeline.vae_scale_factor = 8
+    pipeline.device = torch.device("cpu")
+    pipeline.encode_prompt = _stop_after_guidance_resolution
+
+    sampling_params = OmniDiffusionSamplingParams(height=64, width=64, **sampling_kwargs)
+    request = OmniDiffusionRequest(
+        prompt={
+            "prompt": "edit the image",
+            "negative_prompt": "blurred",
+            "additional_information": {"preprocessed_images": [object()]},
+        },
+        sampling_params=sampling_params,
+        request_id="request-0",
+    )
+
+    with pytest.raises(_GuidanceResolvedError):
+        pipeline.forward(DiffusionRequestBatch([request]), **forward_kwargs)
+
+    assert (pipeline.text_guidance_scale, pipeline.image_guidance_scale) == expected_scales

--- a/vllm_omni/diffusion/models/omnigen2/pipeline_omnigen2.py
+++ b/vllm_omni/diffusion/models/omnigen2/pipeline_omnigen2.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 import inspect
 import json
@@ -1058,7 +1058,7 @@ class OmniGen2Pipeline(CFGParallelMixin, nn.Module, SupportsComponentDiscovery):
         self._text_guidance_scale = text_guidance_scale
         self._image_guidance_scale = (
             req.sampling_params.guidance_scale_2
-            if req.sampling_params.guidance_scale_2 is not None
+            if req.sampling_params.guidance_scale_2_provided
             else image_guidance_scale
         )
         self._cfg_range = cfg_range


### PR DESCRIPTION
## Purpose

OmniGen2 uses independent defaults for text guidance (`4.0`) and image guidance (`1.0`). `OmniDiffusionRequest` records whether `guidance_scale_2` was explicitly provided before filling an omitted value from `guidance_scale`. The pipeline checked the filled value instead of that flag, which made the image guidance default unreachable for image-edit requests.

Use `guidance_scale_2_provided` when resolving OmniGen2 image guidance. This preserves the model default when the secondary scale is omitted while continuing to honor explicit values, including `0.0`.

## Test Plan

Add CPU request-level coverage for:

- omitted guidance scales;
- an explicit primary scale with an omitted secondary scale;
- explicit zero values for either scale;
- independently specified primary and secondary scales;
- the pipeline's `image_guidance_scale` argument.

Run the new OmniGen2 tests together with the shared diffusion request tests and run all pre-commit hooks for the touched files.

```bash
python -m pytest -q \
  tests/diffusion/models/omnigen2/test_request.py \
  tests/diffusion/test_diffusion_request.py
pre-commit run --files \
  vllm_omni/diffusion/models/omnigen2/pipeline_omnigen2.py \
  tests/diffusion/models/omnigen2/test_request.py
```

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** 8370596e044b6c60c67fb13c8452cc9cdd056e19

## Test Result

```text
17 passed
```

All pre-commit hooks for the touched files passed.
