### PR TITLE
[Bugfix][Diffusion] Validate SANA-WM zero values

### DIFF
--- a/tests/diffusion/models/sana_wm/test_request.py
+++ b/tests/diffusion/models/sana_wm/test_request.py
@@ -1,15 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Unit tests for SANA-WM request normalization."""
 
 import pytest
 
+from vllm_omni.diffusion.models.sana_wm.pipeline_sana_wm import (
+    SANA_WM_DEFAULT_GUIDANCE_SCALE,
+    SanaWmPipeline,
+)
 from vllm_omni.diffusion.models.sana_wm.request import (
     SANA_WM_DEFAULT_HEIGHT,
     SANA_WM_DEFAULT_NUM_FRAMES,
     SANA_WM_DEFAULT_WIDTH,
     normalize_sana_wm_payload,
 )
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -41,6 +46,51 @@ def test_defaults_are_latent_aligned():
     assert payload["num_frames"] == SANA_WM_DEFAULT_NUM_FRAMES
     assert payload["height"] == SANA_WM_DEFAULT_HEIGHT
     assert payload["width"] == SANA_WM_DEFAULT_WIDTH
+
+
+@pytest.mark.parametrize(
+    ("guidance_scale", "guidance_scale_provided", "expected"),
+    [
+        (None, None, SANA_WM_DEFAULT_GUIDANCE_SCALE),
+        (1.0, False, SANA_WM_DEFAULT_GUIDANCE_SCALE),
+        (0.0, True, 0.0),
+        (2.5, True, 2.5),
+    ],
+)
+def test_native_params_preserves_explicit_guidance_scale(guidance_scale, guidance_scale_provided, expected):
+    payload = {
+        "height": SANA_WM_DEFAULT_HEIGHT,
+        "width": SANA_WM_DEFAULT_WIDTH,
+        "num_frames": SANA_WM_DEFAULT_NUM_FRAMES,
+    }
+    sampling_params = None
+    if guidance_scale_provided is not None:
+        sampling_params = OmniDiffusionSamplingParams(
+            guidance_scale=guidance_scale,
+            guidance_scale_provided=guidance_scale_provided,
+        )
+
+    params = SanaWmPipeline.__new__(SanaWmPipeline)._native_params(payload, sampling_params)
+
+    assert params.cfg_scale == expected
+
+
+@pytest.mark.parametrize(
+    "sampling_params",
+    [
+        OmniDiffusionSamplingParams(num_inference_steps=0),
+        OmniDiffusionSamplingParams(extra_args={"num_inference_steps": 0}),
+    ],
+)
+def test_native_params_rejects_zero_num_inference_steps(sampling_params):
+    payload = {
+        "height": SANA_WM_DEFAULT_HEIGHT,
+        "width": SANA_WM_DEFAULT_WIDTH,
+        "num_frames": SANA_WM_DEFAULT_NUM_FRAMES,
+    }
+
+    with pytest.raises(ValueError, match="steps must be positive"):
+        SanaWmPipeline.__new__(SanaWmPipeline)._native_params(payload, sampling_params)
 
 
 @pytest.mark.parametrize("num_frames", [9, 33, 161])

--- a/vllm_omni/diffusion/models/sana_wm/pipeline_sana_wm.py
+++ b/vllm_omni/diffusion/models/sana_wm/pipeline_sana_wm.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Sana-WM pipeline integration.
 
 This module wires the registry-visible surface, release-layout validation, and
@@ -339,17 +339,18 @@ class SanaWmPipeline(
         height = int(getattr(sampling_params, "height", None) or payload["height"])
         width = int(getattr(sampling_params, "width", None) or payload["width"])
         num_frames = int(getattr(sampling_params, "num_frames", None) or payload["num_frames"])
-        steps = int(
-            getattr(sampling_params, "num_inference_steps", None)
-            or extra_args.get("num_inference_steps")
-            or SANA_WM_DEFAULT_NUM_INFERENCE_STEPS
-        )
+        steps = getattr(sampling_params, "num_inference_steps", None)
+        if steps is None:
+            steps = extra_args.get("num_inference_steps")
+        if steps is None:
+            steps = SANA_WM_DEFAULT_NUM_INFERENCE_STEPS
+        steps = int(steps)
         seed = int(getattr(sampling_params, "seed", None) or extra_args.get("seed", 0))
         if min(height, width, num_frames, steps) <= 0:
             raise ValueError("Sana-WM native height, width, num_frames, and steps must be positive.")
         cfg_scale = SANA_WM_DEFAULT_GUIDANCE_SCALE
         if sampling_params is not None and getattr(sampling_params, "guidance_scale_provided", False):
-            cfg_scale = float(getattr(sampling_params, "guidance_scale", 1.0) or 1.0)
+            cfg_scale = float(getattr(sampling_params, "guidance_scale", 1.0))
         return SanaWmNativeParams(
             height=height,
             width=width,


### PR DESCRIPTION
## Purpose

### What broke

SANA-WM treated explicit zero values as omitted while resolving native sampling parameters. An offline request with `num_inference_steps=0` silently ran the default 60 steps instead of reaching the existing positive-value validation, and `guidance_scale=0.0` was rewritten to `1.0`.

### Reproduction

On `main`, this script fails because zero steps are accepted and zero guidance is rewritten.

```bash
python - <<'PY'
from vllm_omni.diffusion.models.sana_wm.pipeline_sana_wm import SanaWmPipeline
from vllm_omni.inputs.data import OmniDiffusionSamplingParams

payload = {"height": 704, "width": 1280, "num_frames": 161}
pipeline = SanaWmPipeline.__new__(SanaWmPipeline)

guidance = OmniDiffusionSamplingParams(guidance_scale=0.0, guidance_scale_provided=True)
assert pipeline._native_params(payload, guidance).cfg_scale == 0.0

for sampling in (
    OmniDiffusionSamplingParams(num_inference_steps=0),
    OmniDiffusionSamplingParams(extra_args={"num_inference_steps": 0}),
):
    try:
        pipeline._native_params(payload, sampling)
    except ValueError:
        continue
    raise AssertionError("zero num_inference_steps was accepted")
PY
```

### Root cause

The native parameter resolver used truthiness-based `or` fallbacks. This cannot distinguish an omitted value from a numeric zero.

### Fix

Use `None` to select the inference-step fallback so explicit zero values reach the existing positive-value validation. Preserve an explicitly provided guidance scale without truthiness coercion. Seed resolution is unchanged.

Regression tests cover omitted and explicit guidance scales plus zero inference steps from both the top-level field and `extra_args`.

## Test Plan

`python -m pytest -q tests/diffusion/models/sana_wm/test_request.py tests/diffusion/test_diffusion_request.py`

`pre-commit run --files vllm_omni/diffusion/models/sana_wm/pipeline_sana_wm.py tests/diffusion/models/sana_wm/test_request.py`

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** 54494b1f3da0ff91fd120d2093b6ee5e49fb2647

## Test Result

- 49 passed
- All applicable pre-commit hooks passed

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
