### PR TITLE
[Bugfix][Model] Restore Dynin MAGVIT import compatibility

### DIFF
--- a/tests/model_executor/models/dynin_omni/test_dynin_omni_remote_compat.py
+++ b/tests/model_executor/models/dynin_omni/test_dynin_omni_remote_compat.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Event
+from types import ModuleType
+
+import pytest
+from diffusers import utils as diffusers_utils
+
+from vllm_omni.model_executor.models.dynin_omni import dynin_omni_common
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+_FLAX_WEIGHTS_NAME = "FLAX_WEIGHTS_NAME"
+
+
+@pytest.fixture
+def remote_module(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    snapshots: list[str] = []
+
+    def create(name: str, source: str) -> Path:
+        snapshot = tmp_path / name
+        snapshot.mkdir()
+        (snapshot / "modeling_magvitv2.py").write_text(source)
+        snapshots.append(str(snapshot.resolve()))
+        return snapshot
+
+    def resolve_snapshot_dir(*, source: str, **kwargs) -> str:
+        del kwargs
+        return str(Path(source).resolve())
+
+    monkeypatch.setattr(dynin_omni_common, "_resolve_remote_snapshot_dir", resolve_snapshot_dir)
+    yield create
+
+    for snapshot in snapshots:
+        package = dynin_omni_common._DYNIN_REMOTE_PACKAGE_BY_SNAPSHOT.pop(snapshot, None)
+        if package is not None:
+            for module_name in list(sys.modules):
+                if module_name == package or module_name.startswith(f"{package}."):
+                    sys.modules.pop(module_name, None)
+        for cache_key in list(dynin_omni_common._DYNIN_REMOTE_ATTR_CACHE):
+            if cache_key[2] == snapshot:
+                dynin_omni_common._DYNIN_REMOTE_ATTR_CACHE.pop(cache_key, None)
+
+
+def test_magvit_remote_import_supplies_removed_diffusers_export(
+    remote_module,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delattr(diffusers_utils, _FLAX_WEIGHTS_NAME, raising=False)
+    source = remote_module(
+        "success",
+        "from diffusers.utils import FLAX_WEIGHTS_NAME\nclass MAGVITv2:\n    flax_weights_name = FLAX_WEIGHTS_NAME\n",
+    )
+
+    model_class = dynin_omni_common.get_dynin_magvit_attr(
+        "MAGVITv2",
+        source=str(source),
+        local_files_only=True,
+    )
+
+    assert model_class.flax_weights_name == "diffusion_flax_model.msgpack"
+    assert _FLAX_WEIGHTS_NAME not in vars(diffusers_utils)
+    assert (
+        dynin_omni_common.get_dynin_magvit_attr(
+            "MAGVITv2",
+            source=str(source),
+            local_files_only=True,
+        )
+        is model_class
+    )
+    assert _FLAX_WEIGHTS_NAME not in vars(diffusers_utils)
+
+
+def test_magvit_remote_import_preserves_existing_diffusers_export(
+    remote_module,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing = object()
+    monkeypatch.setattr(diffusers_utils, _FLAX_WEIGHTS_NAME, existing, raising=False)
+    source = remote_module(
+        "existing",
+        "from diffusers.utils import FLAX_WEIGHTS_NAME\nclass MAGVITv2:\n    flax_weights_name = FLAX_WEIGHTS_NAME\n",
+    )
+
+    model_class = dynin_omni_common.get_dynin_magvit_attr(
+        "MAGVITv2",
+        source=str(source),
+        local_files_only=True,
+    )
+
+    assert model_class.flax_weights_name is existing
+    assert getattr(diffusers_utils, _FLAX_WEIGHTS_NAME) is existing
+
+
+@pytest.mark.parametrize("export_exists", [False, True])
+def test_magvit_remote_import_restores_diffusers_after_failure(
+    remote_module,
+    monkeypatch: pytest.MonkeyPatch,
+    export_exists: bool,
+) -> None:
+    existing = object()
+    if export_exists:
+        monkeypatch.setattr(diffusers_utils, _FLAX_WEIGHTS_NAME, existing, raising=False)
+    else:
+        monkeypatch.delattr(diffusers_utils, _FLAX_WEIGHTS_NAME, raising=False)
+    source = remote_module(
+        f"failure-{export_exists}",
+        "from diffusers.utils import FLAX_WEIGHTS_NAME\nraise RuntimeError('remote import failed')\n",
+    )
+
+    with pytest.raises(ImportError, match="Failed to resolve 'MAGVITv2'"):
+        dynin_omni_common.get_dynin_magvit_attr(
+            "MAGVITv2",
+            source=str(source),
+            local_files_only=True,
+        )
+
+    if export_exists:
+        assert getattr(diffusers_utils, _FLAX_WEIGHTS_NAME) is existing
+    else:
+        assert _FLAX_WEIGHTS_NAME not in vars(diffusers_utils)
+    package = dynin_omni_common._DYNIN_REMOTE_PACKAGE_BY_SNAPSHOT[str(source.resolve())]
+    assert f"{package}.modeling_magvitv2" not in sys.modules
+
+
+def test_concurrent_magvit_imports_keep_compatibility_window_serialized(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delattr(diffusers_utils, _FLAX_WEIGHTS_NAME, raising=False)
+    first_path = tmp_path / "first"
+    second_path = tmp_path / "second"
+    first_path.mkdir()
+    second_path.mkdir()
+    first_source = str(first_path.resolve())
+    second_source = str(second_path.resolve())
+    first_entered = Event()
+    release_first = Event()
+    second_started = Event()
+    second_entered = Event()
+    model_classes = {first_source: type("FirstMAGVITv2", (), {}), second_source: type("SecondMAGVITv2", (), {})}
+
+    def load_remote_module(*, source: str, **kwargs) -> ModuleType:
+        del kwargs
+        assert _FLAX_WEIGHTS_NAME in vars(diffusers_utils)
+        if source == first_source:
+            first_entered.set()
+            assert release_first.wait(timeout=5)
+        else:
+            second_entered.set()
+        module = ModuleType(f"remote_{Path(source).name}")
+        setattr(module, "MAGVITv2", model_classes[source])
+        return module
+
+    def load_second():
+        second_started.set()
+        return dynin_omni_common.get_dynin_magvit_attr(
+            "MAGVITv2",
+            source=second_source,
+            local_files_only=True,
+        )
+
+    monkeypatch.setattr(dynin_omni_common, "_load_remote_module", load_remote_module)
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first = executor.submit(
+                dynin_omni_common.get_dynin_magvit_attr,
+                "MAGVITv2",
+                source=first_source,
+                local_files_only=True,
+            )
+            assert first_entered.wait(timeout=5)
+            second = executor.submit(load_second)
+            assert second_started.wait(timeout=5)
+            assert not second_entered.wait(timeout=0.5)
+            release_first.set()
+            assert first.result(timeout=5) is model_classes[first_source]
+            assert second.result(timeout=5) is model_classes[second_source]
+    finally:
+        release_first.set()
+        for cache_key in list(dynin_omni_common._DYNIN_REMOTE_ATTR_CACHE):
+            if cache_key[2] in {first_source, second_source}:
+                dynin_omni_common._DYNIN_REMOTE_ATTR_CACHE.pop(cache_key, None)
+
+    assert second_entered.is_set()
+    assert _FLAX_WEIGHTS_NAME not in vars(diffusers_utils)

--- a/tests/model_executor/models/dynin_omni/test_dynin_omni_remote_compat.py
+++ b/tests/model_executor/models/dynin_omni/test_dynin_omni_remote_compat.py
@@ -4,10 +4,11 @@
 from __future__ import annotations
 
 import sys
-from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Callable
 from pathlib import Path
-from threading import Event
+from threading import Event, Thread
 from types import ModuleType
+from typing import Any
 
 import pytest
 from diffusers import utils as diffusers_utils
@@ -17,35 +18,110 @@ from vllm_omni.model_executor.models.dynin_omni import dynin_omni_common
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 _FLAX_WEIGHTS_NAME = "FLAX_WEIGHTS_NAME"
+_FLAX_WEIGHTS_FILENAME = "diffusion_flax_model.msgpack"
+_GATE_MODULE = "_dynin_magvit_test_gate"
+_MAGVIT_SOURCE = (
+    "from diffusers.utils import FLAX_WEIGHTS_NAME\nclass MAGVITv2:\n    flax_weights_name = FLAX_WEIGHTS_NAME\n"
+)
+# Blocks inside module execution until the test releases it, so tests can observe
+# what other callers do while a MAGVIT import is in flight.
+_GATED_MAGVIT_SOURCE = (
+    f"import {_GATE_MODULE} as gate\n"
+    "from diffusers.utils import FLAX_WEIGHTS_NAME\n"
+    "gate.entered.set()\n"
+    "if not gate.release.wait(timeout=10):\n"
+    "    raise RuntimeError('test gate was never released')\n"
+    "class MAGVITv2:\n"
+    "    flax_weights_name = FLAX_WEIGHTS_NAME\n"
+)
+
+
+class _FakeSnapshots:
+    """Fake MAGVIT remote-code snapshots served for directory sources and registered repo ids."""
+
+    def __init__(self, root: Path) -> None:
+        self._root = root
+        self.by_repo_id: dict[str, str] = {}
+
+    def create(self, name: str, source: str, *, repo_id: str | None = None) -> Path:
+        snapshot = self._root / name
+        snapshot.mkdir()
+        (snapshot / "modeling_magvitv2.py").write_text(source)
+        if repo_id is not None:
+            self.by_repo_id[repo_id] = str(snapshot.resolve())
+        return snapshot
+
+    def resolve(self, *, source: str, **kwargs) -> str:
+        del kwargs
+        if Path(source).is_dir():
+            return str(Path(source).resolve())
+        if source in self.by_repo_id:
+            return self.by_repo_id[source]
+        raise FileNotFoundError(f"{source} is not cached (local_files_only)")
+
+
+class _Task:
+    """Run ``fn`` on a daemon thread; a deadlocked call fails on ``result`` instead of hanging pytest."""
+
+    def __init__(self, fn: Callable[..., Any], *args: Any) -> None:
+        self._done = Event()
+        self._value: Any = None
+        self._error: BaseException | None = None
+
+        def run() -> None:
+            try:
+                self._value = fn(*args)
+            except BaseException as e:  # noqa: BLE001 - re-raised from result()
+                self._error = e
+            finally:
+                self._done.set()
+
+        Thread(target=run, daemon=True).start()
+
+    def finished(self, timeout: float) -> bool:
+        return self._done.wait(timeout)
+
+    def result(self, timeout: float) -> Any:
+        assert self._done.wait(timeout), "call did not finish in time"
+        if self._error is not None:
+            raise self._error
+        return self._value
 
 
 @pytest.fixture
-def remote_module(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    snapshots: list[str] = []
+def remote_snapshots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Isolate remote-code registries per test and drop the modules a test registered."""
+    settings = dynin_omni_common.MAGVIT_REMOTE_SETTINGS
+    for env_name in (settings.repo_env, settings.revision_env, settings.local_only_env):
+        monkeypatch.delenv(env_name, raising=False)
+    packages: dict[str, str] = {}
+    monkeypatch.setattr(dynin_omni_common, "_DYNIN_REMOTE_PACKAGE_BY_SNAPSHOT", packages)
+    monkeypatch.setattr(dynin_omni_common, "_DYNIN_REMOTE_ATTR_CACHE", {})
+    yield _FakeSnapshots(tmp_path)
+    for package in packages.values():
+        for module_name in list(sys.modules):
+            if module_name == package or module_name.startswith(f"{package}."):
+                sys.modules.pop(module_name, None)
 
-    def create(name: str, source: str) -> Path:
-        snapshot = tmp_path / name
-        snapshot.mkdir()
-        (snapshot / "modeling_magvitv2.py").write_text(source)
-        snapshots.append(str(snapshot.resolve()))
-        return snapshot
 
-    def resolve_snapshot_dir(*, source: str, **kwargs) -> str:
-        del kwargs
-        return str(Path(source).resolve())
+@pytest.fixture
+def remote_module(remote_snapshots: _FakeSnapshots, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(dynin_omni_common, "_resolve_remote_snapshot_dir", remote_snapshots.resolve)
+    return remote_snapshots.create
 
-    monkeypatch.setattr(dynin_omni_common, "_resolve_remote_snapshot_dir", resolve_snapshot_dir)
-    yield create
 
-    for snapshot in snapshots:
-        package = dynin_omni_common._DYNIN_REMOTE_PACKAGE_BY_SNAPSHOT.pop(snapshot, None)
-        if package is not None:
-            for module_name in list(sys.modules):
-                if module_name == package or module_name.startswith(f"{package}."):
-                    sys.modules.pop(module_name, None)
-        for cache_key in list(dynin_omni_common._DYNIN_REMOTE_ATTR_CACHE):
-            if cache_key[2] == snapshot:
-                dynin_omni_common._DYNIN_REMOTE_ATTR_CACHE.pop(cache_key, None)
+@pytest.fixture
+def import_gate(monkeypatch: pytest.MonkeyPatch):
+    gate = ModuleType(_GATE_MODULE)
+    gate.entered = Event()  # type: ignore[attr-defined]
+    gate.release = Event()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, _GATE_MODULE, gate)
+    yield gate
+    gate.release.set()
+
+
+def _get_magvit(source: str, **kwargs):
+    return dynin_omni_common.get_dynin_magvit_attr("MAGVITv2", source=source, local_files_only=True, **kwargs)
 
 
 def test_magvit_remote_import_supplies_removed_diffusers_export(
@@ -53,27 +129,13 @@ def test_magvit_remote_import_supplies_removed_diffusers_export(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delattr(diffusers_utils, _FLAX_WEIGHTS_NAME, raising=False)
-    source = remote_module(
-        "success",
-        "from diffusers.utils import FLAX_WEIGHTS_NAME\nclass MAGVITv2:\n    flax_weights_name = FLAX_WEIGHTS_NAME\n",
-    )
+    source = remote_module("success", _MAGVIT_SOURCE)
 
-    model_class = dynin_omni_common.get_dynin_magvit_attr(
-        "MAGVITv2",
-        source=str(source),
-        local_files_only=True,
-    )
+    model_class = _get_magvit(str(source))
 
-    assert model_class.flax_weights_name == "diffusion_flax_model.msgpack"
+    assert model_class.flax_weights_name == _FLAX_WEIGHTS_FILENAME
     assert _FLAX_WEIGHTS_NAME not in vars(diffusers_utils)
-    assert (
-        dynin_omni_common.get_dynin_magvit_attr(
-            "MAGVITv2",
-            source=str(source),
-            local_files_only=True,
-        )
-        is model_class
-    )
+    assert _get_magvit(str(source)) is model_class
     assert _FLAX_WEIGHTS_NAME not in vars(diffusers_utils)
 
 
@@ -83,16 +145,9 @@ def test_magvit_remote_import_preserves_existing_diffusers_export(
 ) -> None:
     existing = object()
     monkeypatch.setattr(diffusers_utils, _FLAX_WEIGHTS_NAME, existing, raising=False)
-    source = remote_module(
-        "existing",
-        "from diffusers.utils import FLAX_WEIGHTS_NAME\nclass MAGVITv2:\n    flax_weights_name = FLAX_WEIGHTS_NAME\n",
-    )
+    source = remote_module("existing", _MAGVIT_SOURCE)
 
-    model_class = dynin_omni_common.get_dynin_magvit_attr(
-        "MAGVITv2",
-        source=str(source),
-        local_files_only=True,
-    )
+    model_class = _get_magvit(str(source))
 
     assert model_class.flax_weights_name is existing
     assert getattr(diffusers_utils, _FLAX_WEIGHTS_NAME) is existing
@@ -115,11 +170,7 @@ def test_magvit_remote_import_restores_diffusers_after_failure(
     )
 
     with pytest.raises(ImportError, match="Failed to resolve 'MAGVITv2'"):
-        dynin_omni_common.get_dynin_magvit_attr(
-            "MAGVITv2",
-            source=str(source),
-            local_files_only=True,
-        )
+        _get_magvit(str(source))
 
     if export_exists:
         assert getattr(diffusers_utils, _FLAX_WEIGHTS_NAME) is existing
@@ -129,64 +180,126 @@ def test_magvit_remote_import_restores_diffusers_after_failure(
     assert f"{package}.modeling_magvitv2" not in sys.modules
 
 
-def test_concurrent_magvit_imports_keep_compatibility_window_serialized(
+def test_magvit_remote_import_falls_back_to_default_repo_for_weights_only_source(
+    remote_module,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Production resolves the VQ weights repo (e.g. showlab/magvitv2), which ships
+    # no remote code, so the accessor must fetch the code from the default repo.
     monkeypatch.delattr(diffusers_utils, _FLAX_WEIGHTS_NAME, raising=False)
-    first_path = tmp_path / "first"
-    second_path = tmp_path / "second"
-    first_path.mkdir()
-    second_path.mkdir()
-    first_source = str(first_path.resolve())
-    second_source = str(second_path.resolve())
-    first_entered = Event()
-    release_first = Event()
-    second_started = Event()
-    second_entered = Event()
-    model_classes = {first_source: type("FirstMAGVITv2", (), {}), second_source: type("SecondMAGVITv2", (), {})}
+    weights_only = tmp_path / "weights-only"
+    weights_only.mkdir()
+    (weights_only / "config.json").write_text("{}")
+    remote_module("default-repo", _MAGVIT_SOURCE, repo_id=dynin_omni_common.DEFAULT_MAGVIT_REMOTE_CODE_REPO)
 
-    def load_remote_module(*, source: str, **kwargs) -> ModuleType:
-        del kwargs
-        assert _FLAX_WEIGHTS_NAME in vars(diffusers_utils)
-        if source == first_source:
-            first_entered.set()
-            assert release_first.wait(timeout=5)
-        else:
-            second_entered.set()
-        module = ModuleType(f"remote_{Path(source).name}")
-        setattr(module, "MAGVITv2", model_classes[source])
-        return module
+    model_class = _get_magvit(str(weights_only))
 
-    def load_second():
-        second_started.set()
-        return dynin_omni_common.get_dynin_magvit_attr(
-            "MAGVITv2",
-            source=second_source,
-            local_files_only=True,
-        )
+    assert model_class.flax_weights_name == _FLAX_WEIGHTS_FILENAME
+    assert _FLAX_WEIGHTS_NAME not in vars(diffusers_utils)
 
-    monkeypatch.setattr(dynin_omni_common, "_load_remote_module", load_remote_module)
-    try:
-        with ThreadPoolExecutor(max_workers=2) as executor:
-            first = executor.submit(
-                dynin_omni_common.get_dynin_magvit_attr,
-                "MAGVITv2",
-                source=first_source,
-                local_files_only=True,
-            )
-            assert first_entered.wait(timeout=5)
-            second = executor.submit(load_second)
-            assert second_started.wait(timeout=5)
-            assert not second_entered.wait(timeout=0.5)
-            release_first.set()
-            assert first.result(timeout=5) is model_classes[first_source]
-            assert second.result(timeout=5) is model_classes[second_source]
-    finally:
-        release_first.set()
-        for cache_key in list(dynin_omni_common._DYNIN_REMOTE_ATTR_CACHE):
-            if cache_key[2] in {first_source, second_source}:
-                dynin_omni_common._DYNIN_REMOTE_ATTR_CACHE.pop(cache_key, None)
 
-    assert second_entered.is_set()
+def test_magvit_remote_import_downloads_repo_id_snapshot_at_revision(
+    remote_snapshots: _FakeSnapshots,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delattr(diffusers_utils, _FLAX_WEIGHTS_NAME, raising=False)
+    repo_id = dynin_omni_common.DEFAULT_MAGVIT_REMOTE_CODE_REPO
+    revision = "5a869517cbbda6ac4de8b438fc59b7f053cb4238"
+    snapshot = remote_snapshots.create("hub", _MAGVIT_SOURCE)
+    download_calls: list[dict] = []
+
+    def snapshot_download(**kwargs):
+        download_calls.append(kwargs)
+        return str(snapshot.resolve())
+
+    monkeypatch.setattr(dynin_omni_common, "snapshot_download", snapshot_download)
+
+    model_class = _get_magvit(repo_id, revision=revision)
+
+    assert model_class.flax_weights_name == _FLAX_WEIGHTS_FILENAME
+    assert len(download_calls) == 1
+    assert download_calls[0]["repo_id"] == repo_id
+    assert download_calls[0]["revision"] == revision
+    assert download_calls[0]["local_files_only"] is True
+    assert "*.py" in download_calls[0]["allow_patterns"]
+    assert _FLAX_WEIGHTS_NAME not in vars(diffusers_utils)
+
+
+def test_concurrent_magvit_imports_serialize_module_execution_only(
+    remote_module,
+    import_gate,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delattr(diffusers_utils, _FLAX_WEIGHTS_NAME, raising=False)
+    gated = str(remote_module("gated", _GATED_MAGVIT_SOURCE))
+    plain = str(remote_module("plain", _MAGVIT_SOURCE))
+    plain_resolved = Event()
+    resolve_snapshot_dir = dynin_omni_common._resolve_remote_snapshot_dir
+
+    def resolve_and_flag(*, source: str, **kwargs) -> str:
+        if source == plain:
+            plain_resolved.set()
+        return resolve_snapshot_dir(source=source, **kwargs)
+
+    monkeypatch.setattr(dynin_omni_common, "_resolve_remote_snapshot_dir", resolve_and_flag)
+
+    first = _Task(_get_magvit, gated)
+    assert import_gate.entered.wait(timeout=5)
+    # The shim is active exactly while the remote module executes.
+    assert _FLAX_WEIGHTS_NAME in vars(diffusers_utils)
+
+    second = _Task(_get_magvit, plain)
+    # Snapshot resolution is not serialized behind the in-flight import...
+    assert plain_resolved.wait(timeout=5)
+    # ...but module execution is.
+    assert not second.finished(timeout=0.5)
+
+    import_gate.release.set()
+    assert first.result(timeout=5).flax_weights_name == _FLAX_WEIGHTS_FILENAME
+    assert second.result(timeout=5).flax_weights_name == _FLAX_WEIGHTS_FILENAME
+    assert _FLAX_WEIGHTS_NAME not in vars(diffusers_utils)
+
+
+def test_concurrent_lookups_of_same_module_share_one_execution(
+    remote_module,
+    import_gate,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delattr(diffusers_utils, _FLAX_WEIGHTS_NAME, raising=False)
+    gated = str(remote_module("gated", _GATED_MAGVIT_SOURCE))
+
+    first = _Task(_get_magvit, gated)
+    assert import_gate.entered.wait(timeout=5)
+    # A second caller for the same module must wait for the execution in flight
+    # rather than pick up the half-executed entry from ``sys.modules``.
+    second = _Task(_get_magvit, gated)
+    assert not second.finished(timeout=0.5)
+
+    import_gate.release.set()
+    first_class = first.result(timeout=5)
+    assert second.result(timeout=5) is first_class
+    assert first_class.flax_weights_name == _FLAX_WEIGHTS_FILENAME
+    assert _FLAX_WEIGHTS_NAME not in vars(diffusers_utils)
+
+
+def test_cached_magvit_lookup_is_not_blocked_by_in_flight_import(
+    remote_module,
+    import_gate,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delattr(diffusers_utils, _FLAX_WEIGHTS_NAME, raising=False)
+    cached = str(remote_module("cached", _MAGVIT_SOURCE))
+    gated = str(remote_module("gated", _GATED_MAGVIT_SOURCE))
+    model_class = _get_magvit(cached)
+
+    pending = _Task(_get_magvit, gated)
+    assert import_gate.entered.wait(timeout=5)
+
+    cache_hit = _Task(_get_magvit, cached)
+    assert cache_hit.result(timeout=2) is model_class
+    assert not pending.finished(timeout=0)
+
+    import_gate.release.set()
+    assert pending.result(timeout=5).flax_weights_name == _FLAX_WEIGHTS_FILENAME
     assert _FLAX_WEIGHTS_NAME not in vars(diffusers_utils)

--- a/vllm_omni/model_executor/models/dynin_omni/dynin_omni_common.py
+++ b/vllm_omni/model_executor/models/dynin_omni/dynin_omni_common.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 from __future__ import annotations
 
 import hashlib
@@ -7,6 +10,7 @@ import sys
 import threading
 import types
 from collections.abc import Iterable
+from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import IntEnum
 from functools import lru_cache
@@ -152,6 +156,25 @@ _DYNIN_REMOTE_ALLOW_PATTERNS = ("*.py", "*.json", "*.yaml", "*.yml")
 _DYNIN_REMOTE_CACHE_LOCK = threading.Lock()
 _DYNIN_REMOTE_PACKAGE_BY_SNAPSHOT: dict[str, str] = {}
 _DYNIN_REMOTE_ATTR_CACHE: dict[tuple[str, str, str, str | None, bool], Any] = {}
+_DYNIN_MAGVIT_IMPORT_LOCK = threading.RLock()
+_DIFFUSERS_FLAX_WEIGHTS_NAME = "diffusion_flax_model.msgpack"
+
+
+@contextmanager
+def _dynin_magvit_diffusers_compat():
+    """Temporarily restore the diffusers export required by MAGVIT remote code."""
+    from diffusers import utils as diffusers_utils
+
+    with _DYNIN_MAGVIT_IMPORT_LOCK:
+        attributes = vars(diffusers_utils)
+        injected = "FLAX_WEIGHTS_NAME" not in attributes
+        if injected:
+            attributes["FLAX_WEIGHTS_NAME"] = _DIFFUSERS_FLAX_WEIGHTS_NAME
+        try:
+            yield
+        finally:
+            if injected:
+                attributes.pop("FLAX_WEIGHTS_NAME", None)
 
 
 @dataclass(frozen=True)
@@ -965,7 +988,7 @@ def get_dynin_config_resolver_attr(
     )
 
 
-def get_dynin_magvit_attr(
+def _get_dynin_magvit_attr(
     name: str,
     *,
     source: str | None = None,
@@ -1006,6 +1029,22 @@ def get_dynin_magvit_attr(
     raise ImportError(
         f"Failed to resolve MAGVIT attr '{attr_name}' from source={resolved_source!r} (revision={resolved_revision!r})."
     )
+
+
+def get_dynin_magvit_attr(
+    name: str,
+    *,
+    source: str | None = None,
+    revision: str | None = None,
+    local_files_only: bool | None = None,
+) -> Any:
+    with _dynin_magvit_diffusers_compat():
+        return _get_dynin_magvit_attr(
+            name,
+            source=source,
+            revision=revision,
+            local_files_only=local_files_only,
+        )
 
 
 def build_dynin_chat_prompt(content: str) -> str:

--- a/vllm_omni/model_executor/models/dynin_omni/dynin_omni_common.py
+++ b/vllm_omni/model_executor/models/dynin_omni/dynin_omni_common.py
@@ -988,7 +988,8 @@ def get_dynin_config_resolver_attr(
     )
 
 
-def _get_dynin_magvit_attr(
+@_dynin_magvit_diffusers_compat()
+def get_dynin_magvit_attr(
     name: str,
     *,
     source: str | None = None,
@@ -1029,22 +1030,6 @@ def _get_dynin_magvit_attr(
     raise ImportError(
         f"Failed to resolve MAGVIT attr '{attr_name}' from source={resolved_source!r} (revision={resolved_revision!r})."
     )
-
-
-def get_dynin_magvit_attr(
-    name: str,
-    *,
-    source: str | None = None,
-    revision: str | None = None,
-    local_files_only: bool | None = None,
-) -> Any:
-    with _dynin_magvit_diffusers_compat():
-        return _get_dynin_magvit_attr(
-            name,
-            source=source,
-            revision=revision,
-            local_files_only=local_files_only,
-        )
 
 
 def build_dynin_chat_prompt(content: str) -> str:

--- a/vllm_omni/model_executor/models/dynin_omni/dynin_omni_common.py
+++ b/vllm_omni/model_executor/models/dynin_omni/dynin_omni_common.py
@@ -9,8 +9,8 @@ import os
 import sys
 import threading
 import types
-from collections.abc import Iterable
-from contextlib import contextmanager
+from collections.abc import Callable, Iterable
+from contextlib import AbstractContextManager, contextmanager, nullcontext
 from dataclasses import dataclass
 from enum import IntEnum
 from functools import lru_cache
@@ -154,27 +154,40 @@ _DYNIN_CONFIG_CANDIDATE_RELPATHS = (
 _DYNIN_REMOTE_ALLOW_PATTERNS = ("*.py", "*.json", "*.yaml", "*.yml")
 
 _DYNIN_REMOTE_CACHE_LOCK = threading.Lock()
+# Serializes remote module *execution* only. Attr-cache lookups and snapshot
+# resolution stay lock-free; the lock keeps concurrent ``_load_remote_module``
+# calls from returning a half-executed module out of ``sys.modules``. Shims
+# passed as ``import_context`` run inside this critical section.
+_DYNIN_REMOTE_IMPORT_LOCK = threading.RLock()
 _DYNIN_REMOTE_PACKAGE_BY_SNAPSHOT: dict[str, str] = {}
 _DYNIN_REMOTE_ATTR_CACHE: dict[tuple[str, str, str, str | None, bool], Any] = {}
-_DYNIN_MAGVIT_IMPORT_LOCK = threading.RLock()
 _DIFFUSERS_FLAX_WEIGHTS_NAME = "diffusion_flax_model.msgpack"
+
+RemoteImportContext = Callable[[], AbstractContextManager[Any]]
 
 
 @contextmanager
 def _dynin_magvit_diffusers_compat():
-    """Temporarily restore the diffusers export required by MAGVIT remote code."""
+    """Temporarily restore the diffusers export required by MAGVIT remote code.
+
+    diffusers 0.40 removed ``FLAX_WEIGHTS_NAME`` from ``diffusers.utils`` while the
+    MAGVIT remote code still imports it at module import time. The export is
+    injected only while that module executes and removed again afterwards; the
+    process-wide mutation lasts for that window only. Entered by
+    ``_load_remote_module`` while ``_DYNIN_REMOTE_IMPORT_LOCK`` is held, which is
+    what keeps concurrent inject/restore pairs from interleaving.
+    """
     from diffusers import utils as diffusers_utils
 
-    with _DYNIN_MAGVIT_IMPORT_LOCK:
-        attributes = vars(diffusers_utils)
-        injected = "FLAX_WEIGHTS_NAME" not in attributes
+    attributes = vars(diffusers_utils)
+    injected = "FLAX_WEIGHTS_NAME" not in attributes
+    if injected:
+        attributes["FLAX_WEIGHTS_NAME"] = _DIFFUSERS_FLAX_WEIGHTS_NAME
+    try:
+        yield
+    finally:
         if injected:
-            attributes["FLAX_WEIGHTS_NAME"] = _DIFFUSERS_FLAX_WEIGHTS_NAME
-        try:
-            yield
-        finally:
-            if injected:
-                attributes.pop("FLAX_WEIGHTS_NAME", None)
+            attributes.pop("FLAX_WEIGHTS_NAME", None)
 
 
 @dataclass(frozen=True)
@@ -785,6 +798,7 @@ def _load_remote_module(
     source: str,
     revision: str | None,
     local_files_only: bool,
+    import_context: RemoteImportContext = nullcontext,
 ):
     snapshot_dir = _resolve_remote_snapshot_dir(
         source=source,
@@ -799,23 +813,25 @@ def _load_remote_module(
     package_name = _ensure_remote_package(snapshot_dir)
     full_name = f"{package_name}.{module_name}"
 
-    existing = sys.modules.get(full_name)
-    if existing is not None:
-        return existing
+    with _DYNIN_REMOTE_IMPORT_LOCK:
+        existing = sys.modules.get(full_name)
+        if existing is not None:
+            return existing
 
-    spec = importlib.util.spec_from_file_location(full_name, module_path)
-    if spec is None or spec.loader is None:
-        raise ImportError(f"Failed to create import spec for '{module_path}'.")
+        spec = importlib.util.spec_from_file_location(full_name, module_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Failed to create import spec for '{module_path}'.")
 
-    module = importlib.util.module_from_spec(spec)
-    module.__package__ = package_name
-    sys.modules[full_name] = module
-    try:
-        spec.loader.exec_module(module)
-    except Exception:
-        sys.modules.pop(full_name, None)
-        raise
-    return module
+        module = importlib.util.module_from_spec(spec)
+        module.__package__ = package_name
+        sys.modules[full_name] = module
+        try:
+            with import_context():
+                spec.loader.exec_module(module)
+        except Exception:
+            sys.modules.pop(full_name, None)
+            raise
+        return module
 
 
 def resolve_remote_attr(
@@ -828,6 +844,7 @@ def resolve_remote_attr(
     local_files_only: bool | None = None,
     fallback_module_names: Iterable[str] = (),
     optional: bool = False,
+    import_context: RemoteImportContext = nullcontext,
 ) -> Any | None:
     resolved_source = _resolve_remote_source(source, settings)
     resolved_revision = _resolve_remote_revision(revision, settings)
@@ -848,6 +865,7 @@ def resolve_remote_attr(
                 source=resolved_source,
                 revision=resolved_revision,
                 local_files_only=resolved_local_only,
+                import_context=import_context,
             )
             if hasattr(module, attr_name):
                 value = getattr(module, attr_name)
@@ -988,7 +1006,6 @@ def get_dynin_config_resolver_attr(
     )
 
 
-@_dynin_magvit_diffusers_compat()
 def get_dynin_magvit_attr(
     name: str,
     *,
@@ -1008,6 +1025,7 @@ def get_dynin_magvit_attr(
         revision=revision,
         local_files_only=local_files_only,
         optional=True,
+        import_context=_dynin_magvit_diffusers_compat,
     )
     if value is not None:
         return value
@@ -1025,6 +1043,7 @@ def get_dynin_magvit_attr(
             revision=resolved_revision,
             local_files_only=resolved_local_only,
             optional=False,
+            import_context=_dynin_magvit_diffusers_compat,
         )
 
     raise ImportError(


### PR DESCRIPTION
<!-- markdownlint-disable -->
Fixes #6833.

## Purpose

### What broke

Dynin's MAGVIT remote code imports `FLAX_WEIGHTS_NAME`, which was removed from `diffusers.utils` in diffusers 0.40.0. This prevents `MAGVITv2` from loading before model weights are read.

### Reproduction

Run against `origin/main` with the project dependencies installed:

```bash
python - <<'PY'
from vllm_omni.model_executor.models.dynin_omni.dynin_omni_common import get_dynin_magvit_attr

model_class = get_dynin_magvit_attr(
    "MAGVITv2",
    source="snu-aidas/magvitv2",
    revision="5a869517cbbda6ac4de8b438fc59b7f053cb4238",
)
print(model_class.__name__)
PY
```

The command raises `ImportError: Failed to resolve MAGVIT attr 'MAGVITv2'` on `origin/main`.

### Root cause

Diffusers removed its Flax weight-name export, while the MAGVIT snapshot reported in #6833 still imports the historical constant at module import time. The import fails even though the PyTorch load path does not use Flax weights.

### Fix

Temporarily restore the historical filename constant only during MAGVIT remote module execution, restoring the original `diffusers.utils` state on success and failure. The shared remote import lock covers module lookup/publication/execution, preventing callers from observing a half-executed module. Attribute-cache hits and snapshot resolution remain outside the lock. Only the MAGVIT accessor supplies the compatibility context, including its fallback to the default code repository.

Following review, add coverage for weights-only source fallback, repo ID/revision forwarding, concurrent imports of the same module, and cached lookups during another import. The latest follow-up fixes the snapshot test's monkeypatch target after merging the shared `hf_api()` migration; no runtime changes in that follow-up.

## Test Plan

From the checkout root, with the project development/test dependencies installed:

```bash
PYTHONPATH=. python -m pytest tests/model_executor/models/dynin_omni \
  -m 'core_model and cpu' --run-level core_model -q

pre-commit run --files \
  tests/model_executor/models/dynin_omni/test_dynin_omni_remote_compat.py \
  vllm_omni/model_executor/models/dynin_omni/dynin_omni_common.py
```

Also run the pinned real remote-code import shown above, checking that `FLAX_WEIGHTS_NAME` is absent from `diffusers.utils` before and after it. This requires access to the snapshot or a populated local Hub cache; it does not load model weights.

**vLLM Version:** CPU/import checks: 0.28.0. GPU E2E: 0.29.0, PyTorch 2.13.0+cu130, transformers 5.14.1, diffusers 0.40.0, Triton 3.7.1, Python 3.12.

**vLLM-Omni Commit:** `4cd2c7a02edaae150f7dd35ca7b0fb6dcaf48fe9`.

## Test Result

- Full Dynin CPU unit-test directory: **10 passed**, comprising 9 remote-import compatibility cases and 1 existing token-to-audio compatibility case.
- Regression proof for the latest follow-up: the same command at `ec3f4444` gave **1 failed, 9 passed** (`AttributeError` on the removed module-level `snapshot_download`); the one-line mock target fix gives **10 passed**.
- Real remote-code snapshot `snu-aidas/magvitv2@5a869517cbbda6ac4de8b438fc59b7f053cb4238`: **import and cleanup assertions passed** on diffusers 0.40.0. No model weights or generation are exercised by this check.
- All applicable pre-commit hooks for both PR files passed; `git diff --check` passed.
- CPU coverage includes import success/failure cleanup, preservation of an existing export, cache hits, weights-only fallback, repo ID/revision forwarding, concurrent import serialization, same-module reuse, and nonblocking cached lookup.

### GPU E2E validation

Ran the complete reviewer-requested test file on **one NVIDIA A100 80GB PCIe**, using `vllm/vllm-openai:v0.29.0`, the unmodified `dynin_omni_ci.yaml` configuration, and **real weights** (`full_model`, not dummy loading). The remote checkout was clean at `4cd2c7a02edaae150f7dd35ca7b0fb6dcaf48fe9`.

```bash
python -m pytest tests/e2e/offline_inference/test_dynin_omni_expansion.py \
  --run-level full_model -m cuda -q -s --junitxml=e2e.xml
```

**5 passed, 0 failed, 0 errors, 0 skipped; process exit 0.** Pytest wall time: 394.33 seconds, including cold-cache downloads and initialization; this is not a serving latency benchmark.

| Test | Result |
| --- | --- |
| `test_dynin_t2i_decode_to_image` | PASS |
| `test_dynin_mmu_to_text` | PASS |
| `test_dynin_image_to_text` | PASS |
| `test_dynin_speech_to_text` | PASS |
| `test_dynin_t2s_decode_to_audio` | PASS |

The first case exercises the failing MAGVIT token-to-image path from #6833 through the actual multi-stage runtime. The decode cases use the test's predefined token IDs. This establishes the existing smoke assertions, not perceptual generation quality.

Model repository revisions observed during the run:

- `snu-aidas/Dynin-Omni@ebdefada8dfbcfe8d8b21fac6f8fb671d7505d87`
- `snu-aidas/magvitv2@5a869517cbbda6ac4de8b438fc59b7f053cb4238`
- `showlab/magvitv2@5c3fa78f8b3523347c5cd1a4c97f3c4e96f33d5d`
- `snu-aidas/emova_speech_tokenizer_vllm@1062a384c4950fcda60be38fc0fc3f169acc7e77`

Pytest reported 15 warnings (including deprecation/development-version warnings). At process shutdown, Python's resource tracker warned about 1 semaphore and 3 shared-memory objects to clean up. The command still exited 0; these warnings are recorded rather than treated as a clean teardown guarantee. No runtime workaround or source patch was applied for this run.

AI assistance: Codex inspected the review comments, fixed the outdated test mock, ran the reported CPU and GPU E2E checks, and updated this description. Human/maintainer review remains outstanding.

