### PR TITLE
[Bugfix] Sanitize non-finite metric values in nightly HTML report

### DIFF
--- a/tests/tools/test_generate_nightly_perf_html.py
+++ b/tests/tools/test_generate_nightly_perf_html.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -55,3 +56,90 @@ def test_generate_html_report_with_perf_templates(tmp_path: Path):
     assert f"Diffusion records <strong>{len(diffusion_records)}</strong>" in html
     assert "const DIFF_DATA =" in html
     assert '"endpoint": "/v1/videos"' in html
+
+
+def _extract_embedded_json(html: str, variable: str) -> list:
+    match = re.search(rf"const {variable} = (\[.*?\]);\n", html, flags=re.DOTALL)
+    assert match is not None, f"embedded data block '{variable}' not found"
+    # json.loads is a strict parser: it must reject bare NaN/Infinity literals.
+    return json.loads(match.group(1))
+
+
+def test_generate_html_report_sanitizes_nonfinite_metric_values(tmp_path: Path):
+    module = _load_html_module()
+    input_dir = tmp_path / "input"
+    diffusion_input_dir = tmp_path / "diffusion_input"
+    input_dir.mkdir()
+    diffusion_input_dir.mkdir()
+
+    # Unmeasured metrics (e.g. TPOT with no multi-token samples, see #6693) are
+    # stored as NaN and vLLM's json.dump persists them as bare ``NaN`` literals.
+    omni_record = {
+        "date": "20260830-130405",
+        "backend": "openai-chat-omni",
+        "model_id": "Qwen/Qwen3-Omni-Flash",
+        "test_name": "qwen3_omni_chat",
+        "dataset_name": "daily",
+        "num_prompts": 8,
+        "max_concurrency": 4,
+        "duration": 60.0,
+        "completed": 8,
+        "failed": 0,
+        "request_throughput": 0.13,
+        "output_throughput": 6.6,
+        "total_token_throughput": 19.8,
+        "mean_ttft_ms": 251.9,
+        "p99_ttft_ms": 402.3,
+        "mean_tpot_ms": float("nan"),
+        "median_tpot_ms": float("nan"),
+        "p99_tpot_ms": float("nan"),
+        "mean_itl_ms": float("nan"),
+        "mean_e2el_ms": 3324.0,
+        "p99_e2el_ms": 5100.7,
+    }
+    omni_result_file = input_dir / "result_test_qwen3_omni_chat_daily_8_4_20260830-130405.json"
+    omni_result_file.write_text(json.dumps(omni_record), encoding="utf-8")
+    assert "NaN" in omni_result_file.read_text(encoding="utf-8")
+
+    diffusion_record = {
+        "date": "20260830-130405",
+        "test_name": "qwen_image_edit",
+        "model": "Qwen/Qwen-Image-Edit",
+        "endpoint": "/v1/images/edits",
+        "dataset": "seed-edit",
+        "task": "image-edit",
+        "duration": 120.0,
+        "throughput_qps": 0.08,
+        "latency_mean": float("inf"),
+        "latency_median": 12_500.0,
+        "latency_p50": 12_500.0,
+        "latency_p99": 19_800.0,
+        "completed_requests": 10,
+        "failed_requests": 0,
+        "slo_attainment_rate": 1.0,
+        "result": {"endpoint": "/v1/images/edits", "nested": {"latency_mean": float("inf")}},
+    }
+    diffusion_result_file = diffusion_input_dir / "diffusion_result_qwen_image_edit_20260830-130405.json"
+    diffusion_result_file.write_text(json.dumps([diffusion_record]), encoding="utf-8")
+    assert "Infinity" in diffusion_result_file.read_text(encoding="utf-8")
+
+    output_file = tmp_path / "nightly_perf_v2.html"
+    module.generate_html_report(
+        input_dir=str(input_dir),
+        diffusion_input_dir=str(diffusion_input_dir),
+        output_file=str(output_file),
+    )
+
+    assert output_file.exists()
+    html = output_file.read_text(encoding="utf-8")
+
+    omni_data = _extract_embedded_json(html, "OMNI_DATA")
+    assert omni_data[0]["mean_tpot_ms"] is None
+    assert omni_data[0]["mean_itl_ms"] is None
+    assert omni_data[0]["mean_ttft_ms"] == pytest.approx(251.9)
+
+    diffusion_data = _extract_embedded_json(html, "DIFF_DATA")
+    assert diffusion_data[0]["latency_mean"] is None
+    assert diffusion_data[0]["latency_median"] == pytest.approx(12_500.0)
+    # the ``result`` sub-dict is flattened into the record; nested values are sanitized too
+    assert diffusion_data[0]["nested"]["latency_mean"] is None

--- a/tools/nightly/generate_nightly_perf_html.py
+++ b/tools/nightly/generate_nightly_perf_html.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import math
 import os
 from collections.abc import Iterable, Sequence
 from datetime import datetime, timezone
@@ -297,6 +298,23 @@ def parse_args() -> argparse.Namespace:
         help="Directory containing diffusion_perf_*.json files; default falls back to --input-dir.",
     )
     return parser.parse_args()
+
+
+def _sanitize_nonfinite(value: Any) -> Any:
+    """Replace non-finite floats with ``None`` so the embedded report data stays strictly valid JSON.
+
+    Unmeasured metrics (e.g. TPOT with no multi-token samples) are stored as
+    ``NaN`` and vLLM's ``json.dump`` writes them as bare ``NaN`` literals,
+    which strict JSON parsers reject. The report JS already renders ``null``
+    as an empty cell and skips it in charts and sorting.
+    """
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, dict):
+        return {key: _sanitize_nonfinite(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_nonfinite(item) for item in value]
+    return value
 
 
 def _build_html_document(
@@ -633,8 +651,16 @@ code {
 }
 """
 
-    omni_data_json = json.dumps(list(omni_records), ensure_ascii=False)
-    diffusion_data_json = json.dumps(list(diffusion_records), ensure_ascii=False)
+    omni_data_json = json.dumps(
+        [_sanitize_nonfinite(record) for record in omni_records],
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+    diffusion_data_json = json.dumps(
+        [_sanitize_nonfinite(record) for record in diffusion_records],
+        ensure_ascii=False,
+        allow_nan=False,
+    )
     omni_cols_json = json.dumps(list(omni_columns), ensure_ascii=False)
     diffusion_cols_json = json.dumps(list(diffusion_columns), ensure_ascii=False)
 


### PR DESCRIPTION
## Why

Follow-up to #6693 (serve bench reports TPOT as 0.0 or negative).

After #6696, unmeasured TPOT/ITL are correctly stored as `NaN` instead of `0.0`/negative values. However, vLLM's upstream `json.dump` (`vllm/benchmarks/serve.py`) persists those values as **bare `NaN` literals** (non-standard JSON). The nightly HTML report generator embedded such records verbatim:

```python
omni_data_json = json.dumps(list(omni_records), ensure_ascii=False)
```

so the `OMNI_DATA` / `DIFF_DATA` blocks inside the report were **not strictly valid JSON** — any strict consumer (`JSON.parse`, `jq`, CI gate tooling) rejects them. This is exactly the "NaN lands in the nightly HTML" case called out in #6693.

## What

- Add `_sanitize_nonfinite()`: recursively replaces non-finite floats (`NaN`/`±Infinity`, including nested dicts like the flattened diffusion `result`) with `null`. The report JS already handles `null` gracefully (`toNumber` → `null` → empty cell, skipped in charts and numeric sorting), matching the "missing samples should be None" ask in #6693.
- Serialize the embedded data with `allow_nan=False`, so any future unsanitized path fails loudly at generation time instead of silently shipping invalid JSON.

The Excel generator already degrades gracefully (openpyxl renders non-finite cells as blank), so it is unchanged.

## Testing

- New regression test `test_generate_html_report_sanitizes_nonfinite_metric_values`: feeds a `result_test_*.json` with bare `NaN` TPOT fields and a `diffusion_result_*.json` with `Infinity` (both written exactly as the current pipeline persists them), then asserts the embedded data blocks parse with strict `json.loads` and non-finite values become `null` while finite values are untouched.
- Existing template-based report test still passes.

Follow-up to #6693 (closed by #6696): fixes the remaining nightly-HTML-report side of the NaN handling called out there.
