### PR TITLE
[Perf][DreamZero] Stop the DiT block recompiling per query length and AR chunk position

### DIFF
--- a/tests/diffusion/models/dreamzero/test_rope_compile_guards.py
+++ b/tests/diffusion/models/dreamzero/test_rope_compile_guards.py
@@ -33,6 +33,7 @@ import os
 
 import pytest
 import torch
+import torch._dynamo
 
 from vllm_omni.diffusion.models.dreamzero.causal_wan_model import (
     _mark_seq_dynamic,
@@ -158,13 +159,17 @@ def test_paged_write_attn_derives_max_query_len_from_query(monkeypatch) -> None:
 
     sentinel = -12345
     query_len, heads, head_dim = 1785, 4, 8
+    block_size = 16
     captured: dict[str, object] = {}
 
+    # Positional layout of vllm_omni::ar_diffusion_paged_write_attn: query, k_curr,
+    # v_curr, k_act, v_act, key_pool, value_pool, block_size, video_slots,
+    # action_slots, block_table, query_start_loc, seq_lens, max_query_len, max_seq_len,
+    # softmax_scale.
+    _MAX_QUERY_LEN_ARG = 13
+
     def spy(*args):
-        # Positional layout of vllm_omni::ar_diffusion_paged_write_attn; index 11 is
-        # max_query_len (query, k_curr, v_curr, k_act, v_act, layer_idx, video_slots,
-        # action_slots, block_table, query_start_loc, seq_lens, max_query_len, ...).
-        captured["max_query_len"] = args[11]
+        captured["max_query_len"] = args[_MAX_QUERY_LEN_ARG]
         captured["all_args"] = args
         return torch.empty_like(args[0])
 
@@ -175,6 +180,9 @@ def test_paged_write_attn_derives_max_query_len_from_query(monkeypatch) -> None:
     value = torch.zeros(query_len, heads, head_dim)
     inputs = pa.ARDiffusionPagedLayerInputs(
         layer_idx=torch.tensor(0),
+        key_pool=torch.zeros(block_size, heads, head_dim),
+        value_pool=torch.zeros(block_size, heads, head_dim),
+        block_size=block_size,
         seq_len=1760,
         video_slots=torch.zeros(1, dtype=torch.int64),
         action_slots=torch.zeros(1, dtype=torch.int64),
@@ -188,7 +196,10 @@ def test_paged_write_attn_derives_max_query_len_from_query(monkeypatch) -> None:
     pa.paged_write_attn(inputs, query, key, value, None, None, 1.0)
 
     assert captured["max_query_len"] == query_len
-    assert sentinel not in captured["all_args"], "inputs.max_query_len still reaches the op"
+    # Compare only the int arguments: `sentinel in args` would run == against the
+    # tensor arguments and raise on the multi-element result.
+    int_args = [a for a in captured["all_args"] if isinstance(a, int)]
+    assert sentinel not in int_args, "inputs.max_query_len still reaches the op"
 
 
 # ── The acceptance test: compilation count must not grow with AR geometry ────────

--- a/tests/diffusion/models/dreamzero/test_rope_compile_guards.py
+++ b/tests/diffusion/models/dreamzero/test_rope_compile_guards.py
@@ -1,0 +1,355 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Guard-stability tests for DreamZero's hoisted RoPE path.
+
+Hoisting the RoPE table out of the compiled DiT block removes 79 redundant rebuilds per
+forward. It does not, on its own, stop the block being *retraced* per query length. The
+deployed geometry runs three: 880 (first prefill chunk), 1760 (later prefill) and 1785
+(diffuse, 2x880 video + 24 action + 1 state), and Dynamo specializes on each. Three
+things together collapse them to one graph, and this module covers all three:
+
+* ``_materialize_block_freqs`` returns a fresh allocation rather than a view, so the
+  table can carry a ``mark_dynamic`` hint at all, and so both branches of
+  ``causal_rope_action_freqs`` hand the block the same flavour of tensor;
+* ``paged_write_attn`` derives ``max_query_len`` from ``query.shape[0]``, keeping the
+  varlen bound a symbolic int instead of a Dynamo value guard;
+* the block's compilation count does not grow with sequence length or AR chunk position.
+
+The first two are cheap, CPU-only and run by default. The third builds a real
+``CausalWanAttentionBlock`` and compiles it with a counting backend, which is slow and
+hardware-sensitive, so it is opt-in. Run it on the target accelerator when touching this
+path::
+
+    VLLM_OMNI_RUN_DREAMZERO_COMPILE_GUARD_TEST=1 \
+        pytest -sv tests/diffusion/models/dreamzero/test_rope_compile_guards.py
+
+It needs no engine, no KV pool and no distributed launcher: TP=1 is initialized in
+process and the attention kernel is stubbed, so what remains under test is exactly the
+RoPE/freqs plumbing and the block signature.
+"""
+
+import os
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.models.dreamzero.causal_wan_model import (
+    _mark_seq_dynamic,
+    causal_rope_action_freqs,
+    rope_params,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+_HEAVY_ENV = "VLLM_OMNI_RUN_DREAMZERO_COMPILE_GUARD_TEST"
+
+# num_frame_per_block=1 in the deployed config, so action_state_index == chunk_pos - 1.
+NUM_FRAME_PER_BLOCK = 1
+NUM_ACTION = 24
+NUM_STATE = 1
+ARL = NUM_ACTION + NUM_STATE  # 25 action/state registers
+DIM = 256  # small, but structurally identical to the deployed block
+HEADS = 4
+HEAD_DIM = DIM // HEADS
+VIDEO_LENS = (880, 1760)  # prefill geometries, no action registers
+CHUNK_POSITIONS = (1, 3, 5, 7, 9, 11, 13, 15)  # AR positions, including unseen ones
+
+
+def _action_state_index(chunk_pos: int) -> int:
+    """The same expression ``_forward_blocks`` evaluates before the block loop."""
+    return max(0, (chunk_pos - 1) // NUM_FRAME_PER_BLOCK)
+
+
+def _video_freqs(video_len: int, head_dim: int = HEAD_DIM, device: str = "cpu") -> torch.Tensor:
+    """Video RoPE table shaped the way ``_create_freqs`` hands it down.
+
+    Built by slicing ``rope_params`` rather than from ``randn``: the real table has unit
+    modulus, and a random complex stand-in would carry magnitudes that blow bf16 up to
+    NaN and hide numerical regressions.
+    """
+    return rope_params(1024 * 10, head_dim)[:video_len].reshape(video_len, 1, -1).to(device)
+
+
+def _build_table(video_len: int, with_action: bool, chunk_pos: int = 1, device: str = "cpu"):
+    freqs_action = rope_params(1024 * 10, HEAD_DIM).to(device)
+    freqs_state = rope_params(1024, HEAD_DIM).to(device)
+    return causal_rope_action_freqs(
+        _video_freqs(video_len, device=device),
+        freqs_action,
+        freqs_state,
+        ARL if with_action else None,
+        NUM_ACTION,
+        NUM_STATE,
+        _action_state_index(chunk_pos),
+    )
+
+
+# ── The table must be markable, and the same flavour on both branches ────────────
+
+
+@pytest.mark.parametrize("with_action", [False, True])
+def test_block_freqs_is_a_fresh_allocation(with_action: bool) -> None:
+    """Both branches return an allocation, not a view.
+
+    This is what makes the ``mark_dynamic`` hint in ``_forward_blocks`` land. On a view,
+    ``mark_dynamic`` can raise, ``_mark_seq_dynamic`` swallows it by design, and the
+    result is one graph per query length with no error to show for it. It is also what
+    makes the two branches' dispatch key sets agree: the no-action branch would
+    otherwise view the table handed down from ``_create_freqs`` while the action branch
+    views a local ``torch.cat``, and Dynamo guards on that difference.
+    """
+    video_len = 1760
+    table = _build_table(video_len, with_action)
+
+    assert table._base is None, "block freqs is a view; the mark_dynamic hint will not land"
+    assert table.shape == (video_len + (ARL if with_action else 0), 1, HEAD_DIM // 2, 2)
+    assert table.dtype == torch.float32  # rope_params narrows to complex64
+    assert table.is_contiguous()
+
+    # Called directly, not through _mark_seq_dynamic, so a failure is not swallowed.
+    torch._dynamo.mark_dynamic(table, 0)
+
+
+@pytest.mark.parametrize("with_action", [False, True])
+def test_materializing_the_table_does_not_change_its_values(with_action: bool) -> None:
+    """The allocation is a copy, so it must be bit-for-bit the table it replaced."""
+    video_len = 880
+    chunk_pos = 5
+    table = _build_table(video_len, with_action, chunk_pos)
+
+    freqs = _video_freqs(video_len)
+    if with_action:
+        idx = _action_state_index(chunk_pos)
+        action = rope_params(1024 * 10, HEAD_DIM)[idx * NUM_ACTION : (idx + 1) * NUM_ACTION]
+        state = rope_params(1024, HEAD_DIM)[idx * NUM_STATE : (idx + 1) * NUM_STATE]
+        tail = torch.cat([action, state], dim=0).view(ARL, 1, -1)
+        freqs = torch.cat([freqs, tail], dim=0)
+    expected = torch.view_as_real(freqs)
+
+    assert torch.equal(table, expected)
+
+
+def test_mark_seq_dynamic_swallows_failures() -> None:
+    """The hint helper must never be able to fail a request.
+
+    ``None`` and a double mark are the two cases that reach it in practice: the second
+    happens whenever a tensor is marked twice across retries.
+    """
+    _mark_seq_dynamic(None, 1)  # must not raise
+
+    t = torch.zeros(4, 8)
+    _mark_seq_dynamic(t, 1)
+    _mark_seq_dynamic(t, 1)  # already marked; swallowed
+
+
+# ── The varlen bound must come from the query tensor, not from a Python int ──────
+
+
+def test_paged_write_attn_derives_max_query_len_from_query(monkeypatch) -> None:
+    """``inputs.max_query_len`` must not reach the op; ``query.shape[0]`` must.
+
+    A Python int here is a Dynamo value guard, so forwarding it re-specializes the graph
+    per query length even when the query's own sequence dim is marked dynamic. The
+    sentinel below is deliberately a value no real bound could take, so a regression
+    shows up as the sentinel arriving rather than as a silent numeric coincidence.
+    """
+    from vllm_omni.experimental.ar_diffusion.kv_cache import paged_attention as pa
+
+    sentinel = -12345
+    query_len, heads, head_dim = 1785, 4, 8
+    captured: dict[str, object] = {}
+
+    def spy(*args):
+        # Positional layout of vllm_omni::ar_diffusion_paged_write_attn; index 11 is
+        # max_query_len (query, k_curr, v_curr, k_act, v_act, layer_idx, video_slots,
+        # action_slots, block_table, query_start_loc, seq_lens, max_query_len, ...).
+        captured["max_query_len"] = args[11]
+        captured["all_args"] = args
+        return torch.empty_like(args[0])
+
+    monkeypatch.setattr(torch.ops.vllm_omni, "ar_diffusion_paged_write_attn", spy)
+
+    query = torch.zeros(query_len, heads, head_dim)
+    key = torch.zeros(query_len, heads, head_dim)
+    value = torch.zeros(query_len, heads, head_dim)
+    inputs = pa.ARDiffusionPagedLayerInputs(
+        layer_idx=torch.tensor(0),
+        seq_len=1760,
+        video_slots=torch.zeros(1, dtype=torch.int64),
+        action_slots=torch.zeros(1, dtype=torch.int64),
+        block_table=torch.zeros(1, 1, dtype=torch.int32),
+        query_start_loc=torch.tensor([0, query_len], dtype=torch.int32),
+        seq_lens=torch.tensor([query_len], dtype=torch.int32),
+        max_query_len=sentinel,
+        max_seq_len=18480,
+    )
+
+    pa.paged_write_attn(inputs, query, key, value, None, None, 1.0)
+
+    assert captured["max_query_len"] == query_len
+    assert sentinel not in captured["all_args"], "inputs.max_query_len still reaches the op"
+
+
+# ── The acceptance test: compilation count must not grow with AR geometry ────────
+
+
+def _init_single_rank_tp():
+    """TP=1 group for the block's Column/RowParallelLinear layers.
+
+    ``initialize_model_parallel()`` reads ``get_current_vllm_config()``, so the whole
+    thing has to happen inside a ``set_current_vllm_config()`` context. The context is
+    returned so the caller keeps it open for the lifetime of the block: the TP layers
+    read the config lazily.
+    """
+    import torch.distributed as dist
+    from vllm.config import VllmConfig, set_current_vllm_config
+    from vllm.distributed import (
+        ensure_model_parallel_initialized,
+        init_distributed_environment,
+    )
+
+    cfg_ctx = set_current_vllm_config(VllmConfig())
+    cfg_ctx.__enter__()
+    if not dist.is_initialized():
+        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+        os.environ.setdefault("MASTER_PORT", "29777")
+        os.environ.setdefault("RANK", "0")
+        os.environ.setdefault("WORLD_SIZE", "1")
+        os.environ.setdefault("LOCAL_RANK", "0")
+        init_distributed_environment(
+            world_size=1, rank=0, distributed_init_method="env://", local_rank=0, backend="gloo"
+        )
+    ensure_model_parallel_initialized(1, 1)
+    return cfg_ctx
+
+
+def _stub_attention(blk) -> None:
+    """Replace the attention *call* with a traceable stand-in.
+
+    Both self-attention paths bottom out in an op Dynamo cannot trace under fake
+    tensors: the paged path needs a live KV pool and slot registry (an engine), and the
+    non-paged fallback calls ``torch.ops._vllm_fa2_C.varlen_fwd``, which has no meta
+    kernel. Neither is what this test is about. Everything the RoPE hoist touches stays
+    real; only the kernel is substituted, by a shape-correct elementwise stand-in.
+    """
+    import types
+
+    def fake_attn(self, q, k, v, *a, **kw):
+        return q * 1.0  # (B, L, H, D) -> same shape, cheap and traceable
+
+    for holder in (blk.self_attn, blk.cross_attn):
+        inner = getattr(holder, "attn", None)
+        if inner is not None:
+            inner.forward = types.MethodType(fake_attn, inner)
+
+
+def _make_inputs(video_len: int, with_action: bool, device: str, dtype: torch.dtype):
+    g = torch.Generator(device="cpu").manual_seed(video_len)
+    q_len = video_len + (ARL if with_action else 0)
+    x = torch.randn(1, q_len, DIM, generator=g, dtype=torch.float32).to(device=device, dtype=dtype)
+    e = torch.randn(1, q_len, 6, DIM, generator=g, dtype=torch.float32).to(device=device, dtype=dtype)
+    ctx = torch.randn(1, 32, DIM, generator=g, dtype=torch.float32).to(device=device, dtype=dtype)
+    # Non-paged fallback KV: stacked (2, B, L, H, D) with an existing window.
+    kv = torch.randn(2, 1, video_len, HEADS, HEAD_DIM, generator=g, dtype=torch.float32).to(device=device, dtype=dtype)
+    return x, e, ctx, kv
+
+
+@pytest.mark.skipif(
+    os.environ.get(_HEAVY_ENV, "0").strip().lower() not in ("1", "true", "yes", "on"),
+    reason=f"compiles a real DiT block; opt in with {_HEAVY_ENV}=1",
+)
+def test_compilation_count_does_not_grow_with_ar_geometry() -> None:
+    """Two graphs across 10 geometry/position cases, and two is the minimum.
+
+    Prefill forwards carry no action registers (``action_register_length is None``,
+    q=880/1760) while diffuse forwards carry 25 (q=1785). The
+    ``if action_register_length is not None`` branch in the block splits it into two
+    genuinely different dataflows -- the action branch slices off an action tail, RoPEs
+    it separately and re-concatenates -- so specializing on that is correct and
+    desirable: one graph per real code path, reused across every sequence length and
+    every AR chunk position.
+
+    What must hold, and what this asserts, is that the count does not grow with chunk
+    position or sequence length. Before the hoist and these hints, the same sweep
+    produced a new graph per ``(length, chunk position)`` pair.
+    """
+    from torch._inductor.compile_fx import compile_fx
+
+    from vllm_omni.diffusion.models.dreamzero.causal_wan_model import CausalWanAttentionBlock
+
+    device = "xpu" if hasattr(torch, "xpu") and torch.xpu.is_available() else "cpu"
+    if device == "cpu" and torch.cuda.is_available():
+        device = "cuda"
+    dtype = torch.bfloat16
+
+    cfg_ctx = _init_single_rank_tp()  # keep open: TP layers read the config lazily
+    try:
+        torch.manual_seed(1234)
+        blk = (
+            CausalWanAttentionBlock(
+                cross_attn_type="t2v_cross_attn",
+                dim=DIM,
+                ffn_dim=DIM * 2,
+                num_heads=HEADS,
+                frame_seqlen=220,
+                local_attn_size=-1,
+                sink_size=0,
+                num_frame_per_block=NUM_FRAME_PER_BLOCK,
+                qk_norm=True,
+                cross_attn_norm=True,
+                eps=1e-6,
+                num_action_per_block=NUM_ACTION,
+                num_state_per_block=NUM_STATE,
+            )
+            .to(device=device, dtype=dtype)
+            .eval()
+        )
+        _stub_attention(blk)
+
+        n_compiles = 0
+
+        def counting_backend(gm, example_inputs, **kwargs):
+            nonlocal n_compiles
+            n_compiles += 1
+            return compile_fx(gm, example_inputs, **kwargs)
+
+        # Exactly setup_compile()'s DiT kwargs, plus a counting backend.
+        blk.forward = torch.compile(blk.forward, backend=counting_backend, fullgraph=True, dynamic=False)
+
+        cases = [(video_len, False, 0) for video_len in VIDEO_LENS]
+        cases += [(1760, True, chunk_pos) for chunk_pos in CHUNK_POSITIONS]
+
+        with torch.inference_mode():
+            for video_len, with_action, chunk_pos in cases:
+                x, e, ctx, kv = _make_inputs(video_len, with_action, device, dtype)
+                arl = ARL if with_action else None
+                table = _build_table(video_len, with_action, max(chunk_pos, 1), device=device)
+
+                _mark_seq_dynamic(x, 1)
+                _mark_seq_dynamic(e, 1)
+                _mark_seq_dynamic(table, 0)
+                # Harness only. This exercises the non-paged fallback, where kv_cache is
+                # a (2, B, L, H, D) tensor whose L grows with the window. The deployed
+                # path passes ARDiffusionPagedLayerInputs, whose block_table is padded to
+                # a fixed width by design, so there is nothing to mark there.
+                _mark_seq_dynamic(kv, 2)
+
+                out, _ = blk(
+                    x=x,
+                    e=e,
+                    freqs=table,
+                    context=ctx,
+                    action_register_length=arl,
+                    kv_cache=kv,
+                    crossattn_cache=None,
+                )
+                assert out.shape == x.shape
+                assert not torch.isnan(out.float()).any()
+
+        assert n_compiles == 2, (
+            f"expected 2 graphs (prefill-no-action + diffuse-with-action), got {n_compiles} "
+            f"across {len(VIDEO_LENS)} sequence lengths x {len(CHUNK_POSITIONS)} AR chunk positions"
+        )
+    finally:
+        cfg_ctx.__exit__(None, None, None)

--- a/tests/diffusion/models/dreamzero/test_rope_compile_guards.py
+++ b/tests/diffusion/models/dreamzero/test_rope_compile_guards.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 """Guard-stability tests for DreamZero's hoisted RoPE path.
 

--- a/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
+++ b/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
@@ -70,6 +70,12 @@ def sinusoidal_embedding_1d(dim: int, position: torch.Tensor) -> torch.Tensor:
 
 def rope_params(max_seq_len: int, dim: int) -> torch.Tensor:
     """Precompute complex-valued RoPE frequencies (polar form).
+
+    The angles are accumulated in float64 -- at the far end of the table they
+    reach 1e4 radians, where float32 would resolve them to only ~1e-3 -- and the
+    table is handed out as complex64, since cos and sin land in [-1, 1] and the
+    rotation they feed ends in bfloat16.
+
     Returns: complex tensor [max_seq_len, dim // 2]
     """
     if dim % 2 != 0:
@@ -79,7 +85,7 @@ def rope_params(max_seq_len: int, dim: int) -> torch.Tensor:
         1.0 / torch.pow(10000, torch.arange(0, dim, 2).to(torch.float64).div(dim)),
     )
     freqs = torch.polar(torch.ones_like(freqs), freqs)
-    return freqs
+    return freqs.to(torch.complex64)
 
 
 def rope_apply(x: torch.Tensor, freqs: torch.Tensor) -> torch.Tensor:
@@ -94,14 +100,19 @@ def rope_apply(x: torch.Tensor, freqs: torch.Tensor) -> torch.Tensor:
     gfx950 as three kernels collapsing to one.
 
     Eager: the real form is the slower one by about 4x, because each of its
-    multiply-adds becomes its own pass over a float64 temporary while the complex
+    multiply-adds becomes its own pass over a temporary while the complex
     multiply is a single elementwise kernel.
 
     Both branches evaluate the same products in the same order and agree bitwise
     once the caller casts back to bfloat16.
+
+    The rotation runs in float32. Only the angles need anything wider, and they
+    are already spent by the time ``rope_params`` hands over cos and sin: those
+    live in [-1, 1], where float32 carries four more decimal digits than the
+    bfloat16 this result is cast back to.
     """
     B, seq_len, n, _ = x.shape
-    pairs = x.to(torch.float64).reshape(B, seq_len, n, -1, 2)
+    pairs = x.to(torch.float32).reshape(B, seq_len, n, -1, 2)
     if not torch.compiler.is_compiling():
         rotated = torch.view_as_complex(pairs) * torch.view_as_complex(freqs).unsqueeze(0)
         return torch.view_as_real(rotated).flatten(3)
@@ -121,7 +132,7 @@ def rope_action_apply(
 ) -> torch.Tensor:
     """RoPE with action/state frequency tables for multi-step sequences."""
     B, seq_len, n, _ = x.shape
-    x = torch.view_as_complex(x.to(torch.float64).reshape(B, seq_len, n, -1, 2))
+    x = torch.view_as_complex(x.to(torch.float32).reshape(B, seq_len, n, -1, 2))
     if action_register_length is not None:
         if num_action_per_block is None:
             raise ValueError("num_action_per_block is required when action_register_length is set.")

--- a/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
+++ b/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
@@ -149,6 +149,27 @@ def rope_action_apply(
     return x
 
 
+def _mark_seq_dynamic(t: torch.Tensor | None, dim: int) -> None:
+    """Tell Dynamo that ``dim`` varies, so one graph serves every query length.
+
+    ``setup_compile()`` passes ``dynamic=False``, which disables *automatic* dynamic-shape
+    inference but does not override an explicit hint: verified on torch 2.12.0+xpu, four
+    distinct sequence lengths collapse from four compilations to one, with fusion quality
+    and kernel timings within ~2% of the static build.
+
+    Best-effort and silent on purpose. Under ``enforce_eager: true`` there is no
+    compilation to influence and marking is a harmless no-op, and ``mark_dynamic`` raises
+    if the tensor was already marked or is a view whose base cannot carry the hint. A
+    RoPE shape hint is never worth failing a request over.
+    """
+    if t is None:
+        return
+    try:
+        torch._dynamo.mark_dynamic(t, dim)
+    except Exception:  # hint only; correctness never depends on it
+        pass
+
+
 def _materialize_block_freqs(freqs: torch.Tensor) -> torch.Tensor:
     """Real ``(..., 2)`` cos/sin table as a freshly allocated tensor, not a view.
 
@@ -1076,6 +1097,18 @@ class CausalWanModel(nn.Module):
             self.num_state_per_block,
             max(0, (current_start_frame - 1) // self.num_frame_per_block),
         )
+
+        # One graph for every AR geometry. x, e0 and freqs all carry the query-length
+        # dim, which is 880 (first prefill chunk), 1760 (later prefill) or 1785 (diffuse,
+        # +25 action/state registers). Unmarked, the block is retraced per length --
+        # "tensor 'e' size mismatch at index 1" -- so the table hoist above removes the
+        # redundant work but not the recompiles. These three hints are what collapse the
+        # lengths, and they need both of the preceding commits to bite: the table must be
+        # a real allocation to carry a hint at all, and paged_write_attn must stop passing
+        # max_query_len as a Python int or the graph re-specializes on that instead.
+        _mark_seq_dynamic(x, 1)
+        _mark_seq_dynamic(e0, 1)
+        _mark_seq_dynamic(freqs, 0)
 
         updated_kv_caches: list[torch.Tensor | None] = []
         for block_index, block in enumerate(self.blocks):

--- a/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
+++ b/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
@@ -149,6 +149,39 @@ def rope_action_apply(
     return x
 
 
+def _materialize_block_freqs(freqs: torch.Tensor) -> torch.Tensor:
+    """Real ``(..., 2)`` cos/sin table as a freshly allocated tensor, not a view.
+
+    ``view_as_real`` on its own returns a *view*, and both of the reasons this matters
+    are about what the compiled block sees, not about the values:
+
+    1. ``torch._dynamo.mark_dynamic`` cannot always place a hint on a view -- it raises
+       when the base cannot carry it. The next commit marks this table's sequence dim,
+       and on a view that marking silently does nothing, which quietly costs one graph
+       per query length. A real allocation always carries the hint.
+    2. Dynamo guards on the tensor's dispatch key set, and the two branches of
+       :func:`causal_rope_action_freqs` reach ``view_as_real`` with different bases: the
+       no-action branch views the table handed down from ``_create_freqs``, while the
+       action branch views a ``torch.cat`` performed here. Under ``inference_mode`` those
+       do not reliably agree -- a tensor viewed out of a longer-lived buffer keeps
+       ``(XPU, ADInplaceOrView, AutogradXPU, AutocastXPU)`` where a freshly allocated one
+       carries ``(XPU, AutocastXPU)`` -- and a mismatch makes prefill and diffuse
+       guard-incompatible, costing a second graph:
+
+           tensor 'freqs' dispatch key set mismatch. expected
+           DispatchKeySet(XPU, BackendSelect, ADInplaceOrView), actual
+           DispatchKeySet(XPU, BackendSelect)
+
+       Allocating on both paths makes the branches hand the block the same flavour of
+       tensor by construction.
+
+    ``.contiguous()`` is not a substitute: on an already-contiguous view it returns the
+    same view and drops nothing. The copy is of a table four orders of magnitude smaller
+    than the activations it rotates, once per forward against the 80 rotations it feeds.
+    """
+    return torch.view_as_real(freqs).clone()
+
+
 def causal_rope_action_freqs(
     freqs: torch.Tensor,
     freqs_action: torch.Tensor,
@@ -168,9 +201,12 @@ def causal_rope_action_freqs(
     to build it, so no complex tensor reaches the compiled blocks, where inductor
     would fall back to eager. Converting here costs one view of a table that is
     four orders of magnitude smaller than the tensors it rotates.
+
+    Both exits route through :func:`_materialize_block_freqs`, which is what makes the
+    table markable and its dispatch key set branch-independent.
     """
     if action_register_length is None:
-        return torch.view_as_real(freqs)
+        return _materialize_block_freqs(freqs)
     expected_length = num_action_per_block + num_state_per_block
     if action_register_length != expected_length:
         raise ValueError(
@@ -182,7 +218,7 @@ def causal_rope_action_freqs(
     ]
     freqs_state = freqs_state[action_state_index * num_state_per_block : (action_state_index + 1) * num_state_per_block]
     freqs_1d = torch.cat([freqs_action, freqs_state], dim=0).view(action_register_length, 1, -1)
-    return torch.view_as_real(torch.cat([freqs, freqs_1d], dim=0))
+    return _materialize_block_freqs(torch.cat([freqs, freqs_1d], dim=0))
 
 
 # ── Normalization ───────────────────────────────────────────────────

--- a/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
+++ b/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
@@ -17,6 +17,7 @@ import math
 from typing import Any
 
 import torch
+import torch._dynamo  # noqa: F401  -- _mark_seq_dynamic needs the submodule bound
 import torch.nn as nn
 from vllm.distributed import (
     get_tensor_model_parallel_rank,

--- a/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
+++ b/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
@@ -119,8 +119,7 @@ def rope_action_apply(
     return x
 
 
-def causal_rope_action_apply(
-    x: torch.Tensor,
+def causal_rope_action_freqs(
     freqs: torch.Tensor,
     freqs_action: torch.Tensor,
     freqs_state: torch.Tensor,
@@ -129,27 +128,26 @@ def causal_rope_action_apply(
     num_state_per_block: int,
     action_state_index: int,
 ) -> torch.Tensor:
-    """RoPE for single inference step (causal / KV-cache mode)."""
-    B, seq_len, n, _ = x.shape
-    x = torch.view_as_complex(x.to(torch.float64).reshape(B, seq_len, n, -1, 2))
-    if action_register_length is not None:
-        expected_length = num_action_per_block + num_state_per_block
-        if action_register_length != expected_length:
-            raise ValueError(
-                f"action_register_length must equal num_action_per_block + num_state_per_block "
-                f"({expected_length}), got {action_register_length}."
-            )
-        freqs_action = freqs_action[
-            action_state_index * num_action_per_block : (action_state_index + 1) * num_action_per_block
-        ]
-        freqs_state = freqs_state[
-            action_state_index * num_state_per_block : (action_state_index + 1) * num_state_per_block
-        ]
-        freqs_1d = torch.cat([freqs_action, freqs_state], dim=0).view(action_register_length, 1, -1)
-        freqs = torch.cat([freqs, freqs_1d], dim=0)
-    freqs = freqs.unsqueeze(0)
-    x = torch.view_as_real(x * freqs).flatten(3)
-    return x
+    """Video RoPE table with the current step's action/state rows appended.
+
+    Single inference step (causal / KV-cache mode). A function of the step index
+    only, so all layers and both q and k share one build -- see ``_forward_blocks``,
+    which calls this once per forward and passes the result down.
+    """
+    if action_register_length is None:
+        return freqs
+    expected_length = num_action_per_block + num_state_per_block
+    if action_register_length != expected_length:
+        raise ValueError(
+            f"action_register_length must equal num_action_per_block + num_state_per_block "
+            f"({expected_length}), got {action_register_length}."
+        )
+    freqs_action = freqs_action[
+        action_state_index * num_action_per_block : (action_state_index + 1) * num_action_per_block
+    ]
+    freqs_state = freqs_state[action_state_index * num_state_per_block : (action_state_index + 1) * num_state_per_block]
+    freqs_1d = torch.cat([freqs_action, freqs_state], dim=0).view(action_register_length, 1, -1)
+    return torch.cat([freqs, freqs_1d], dim=0)
 
 
 # ── Normalization ───────────────────────────────────────────────────
@@ -521,14 +519,15 @@ class CausalWanSelfAttention(nn.Module):
         self,
         x: torch.Tensor,
         freqs: torch.Tensor,
-        freqs_action: torch.Tensor,
-        freqs_state: torch.Tensor,
         action_register_length: int | None,
         kv_cache: torch.Tensor | Any | None = None,
-        current_start_frame: int = 0,
         is_tf: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        """Inference-only forward (KV cache path)."""
+        """Inference-only forward (KV cache path).
+
+        ``freqs`` already carries this step's action/state rows (built once per
+        forward by ``causal_rope_action_freqs``).
+        """
         n, d = self.tp_num_heads, self.head_dim
 
         # Single fused QKV GEMM, then split into the per-rank q/k/v shards.
@@ -546,28 +545,8 @@ class CausalWanSelfAttention(nn.Module):
         if kv_cache is None:
             raise RuntimeError("Inference only: kv_cache is required.")
 
-        action_state_index = max(0, (current_start_frame - 1) // self.num_frame_per_block)
-
-        roped_query = causal_rope_action_apply(
-            q,
-            freqs,
-            freqs_action,
-            freqs_state,
-            action_register_length,
-            self.num_action_per_block,
-            self.num_state_per_block,
-            action_state_index,
-        ).type_as(v)
-        roped_key = causal_rope_action_apply(
-            k,
-            freqs,
-            freqs_action,
-            freqs_state,
-            action_register_length,
-            self.num_action_per_block,
-            self.num_state_per_block,
-            action_state_index,
-        ).type_as(v)
+        roped_query = rope_apply(q, freqs).type_as(v)
+        roped_key = rope_apply(k, freqs).type_as(v)
 
         roped_action_query = None
         roped_action_key = None
@@ -676,13 +655,10 @@ class CausalWanAttentionBlock(nn.Module):
         x: torch.Tensor,
         e: torch.Tensor,
         freqs: torch.Tensor,
-        freqs_action: torch.Tensor,
-        freqs_state: torch.Tensor,
         context: torch.Tensor,
         action_register_length: int | None = None,
         kv_cache: torch.Tensor | Any | None = None,
         crossattn_cache: dict | None = None,
-        current_start_frame: int = 0,
         is_tf: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         e = (self.modulation.unsqueeze(1) + e).chunk(6, dim=2)
@@ -690,12 +666,9 @@ class CausalWanAttentionBlock(nn.Module):
         y, updated_kv_cache = self.self_attn(
             x=(self.norm1(x) * (1 + e[1].squeeze(2)) + e[0].squeeze(2)),
             freqs=freqs,
-            freqs_action=freqs_action,
-            freqs_state=freqs_state,
             action_register_length=action_register_length,
             kv_cache=kv_cache,
             is_tf=is_tf,
-            current_start_frame=current_start_frame,
         )
         x = x + (y * e[2].squeeze(2))
 
@@ -1021,19 +994,28 @@ class CausalWanModel(nn.Module):
             )
             kv_cache = [c.to_layer_inputs() for c in kv_cache]
 
+        # Append this step's action/state RoPE rows once, outside the compiled blocks:
+        # the table is the same for all 40 layers and for both q and k.
+        freqs = causal_rope_action_freqs(
+            freqs,
+            self.freqs_action,
+            self.freqs_state,
+            action_register_length,
+            self.num_action_per_block,
+            self.num_state_per_block,
+            max(0, (current_start_frame - 1) // self.num_frame_per_block),
+        )
+
         updated_kv_caches: list[torch.Tensor | None] = []
         for block_index, block in enumerate(self.blocks):
             x, updated_kv_cache = block(
                 x=x,
                 e=e0,
                 freqs=freqs,
-                freqs_action=self.freqs_action,
-                freqs_state=self.freqs_state,
                 context=context,
                 action_register_length=action_register_length,
                 kv_cache=kv_cache[block_index] if kv_cache else None,
                 crossattn_cache=crossattn_cache[block_index] if crossattn_cache else None,
-                current_start_frame=current_start_frame,
             )
             updated_kv_caches.append(updated_kv_cache)
 

--- a/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
+++ b/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 """CausalWanModel — 40-layer DiT with causal attention and KV cache.
 

--- a/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
+++ b/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
@@ -83,12 +83,31 @@ def rope_params(max_seq_len: int, dim: int) -> torch.Tensor:
 
 
 def rope_apply(x: torch.Tensor, freqs: torch.Tensor) -> torch.Tensor:
-    """Apply RoPE to x using precomputed complex freqs."""
+    """Apply RoPE to x, with ``freqs`` as a real ``(..., 2)`` cos/sin table.
+
+    Two forms of the same rotation, picked by whether inductor is generating code.
+
+    Compiled: inductor cannot generate code for complex operators, so a complex
+    multiply here falls back to eager, and being opaque to the scheduler it also
+    splits the surrounding qk-norm and layout work into separate fusion groups.
+    Written out in real arithmetic the whole segment fuses instead, measured on
+    gfx950 as three kernels collapsing to one.
+
+    Eager: the real form is the slower one by about 4x, because each of its
+    multiply-adds becomes its own pass over a float64 temporary while the complex
+    multiply is a single elementwise kernel.
+
+    Both branches evaluate the same products in the same order and agree bitwise
+    once the caller casts back to bfloat16.
+    """
     B, seq_len, n, _ = x.shape
-    x = torch.view_as_complex(x.to(torch.float64).reshape(B, seq_len, n, -1, 2))
-    freqs = freqs.unsqueeze(0)
-    x = torch.view_as_real(x * freqs).flatten(3)
-    return x
+    pairs = x.to(torch.float64).reshape(B, seq_len, n, -1, 2)
+    if not torch.compiler.is_compiling():
+        rotated = torch.view_as_complex(pairs) * torch.view_as_complex(freqs).unsqueeze(0)
+        return torch.view_as_real(rotated).flatten(3)
+    x_re, x_im = pairs[..., 0], pairs[..., 1]
+    cos, sin = freqs[..., 0].unsqueeze(0), freqs[..., 1].unsqueeze(0)
+    return torch.stack((x_re * cos - x_im * sin, x_re * sin + x_im * cos), dim=-1).flatten(3)
 
 
 def rope_action_apply(
@@ -133,9 +152,14 @@ def causal_rope_action_freqs(
     Single inference step (causal / KV-cache mode). A function of the step index
     only, so all layers and both q and k share one build -- see ``_forward_blocks``,
     which calls this once per forward and passes the result down.
+
+    Returned as a real ``(..., 2)`` cos/sin table: the complex form is only used
+    to build it, so no complex tensor reaches the compiled blocks, where inductor
+    would fall back to eager. Converting here costs one view of a table that is
+    four orders of magnitude smaller than the tensors it rotates.
     """
     if action_register_length is None:
-        return freqs
+        return torch.view_as_real(freqs)
     expected_length = num_action_per_block + num_state_per_block
     if action_register_length != expected_length:
         raise ValueError(
@@ -147,7 +171,7 @@ def causal_rope_action_freqs(
     ]
     freqs_state = freqs_state[action_state_index * num_state_per_block : (action_state_index + 1) * num_state_per_block]
     freqs_1d = torch.cat([freqs_action, freqs_state], dim=0).view(action_register_length, 1, -1)
-    return torch.cat([freqs, freqs_1d], dim=0)
+    return torch.view_as_real(torch.cat([freqs, freqs_1d], dim=0))
 
 
 # ── Normalization ───────────────────────────────────────────────────
@@ -525,8 +549,8 @@ class CausalWanSelfAttention(nn.Module):
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """Inference-only forward (KV cache path).
 
-        ``freqs`` already carries this step's action/state rows (built once per
-        forward by ``causal_rope_action_freqs``).
+        ``freqs`` is the real cos/sin table already carrying this step's
+        action/state rows (built once per forward by ``causal_rope_action_freqs``).
         """
         n, d = self.tp_num_heads, self.head_dim
 

--- a/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
+++ b/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
@@ -70,14 +70,10 @@ def sinusoidal_embedding_1d(dim: int, position: torch.Tensor) -> torch.Tensor:
 
 
 def rope_params(max_seq_len: int, dim: int) -> torch.Tensor:
-    """Precompute complex-valued RoPE frequencies (polar form).
+    """Precompute complex64 RoPE frequencies of shape [max_seq_len, dim // 2].
 
-    The angles are accumulated in float64 -- at the far end of the table they
-    reach 1e4 radians, where float32 would resolve them to only ~1e-3 -- and the
-    table is handed out as complex64, since cos and sin land in [-1, 1] and the
-    rotation they feed ends in bfloat16.
-
-    Returns: complex tensor [max_seq_len, dim // 2]
+    Accumulate angles in float64 to preserve precision at large positions;
+    cos/sin values and the downstream bfloat16 rotation need less precision.
     """
     if dim % 2 != 0:
         raise ValueError(f"dim must be even, got {dim}.")
@@ -90,27 +86,11 @@ def rope_params(max_seq_len: int, dim: int) -> torch.Tensor:
 
 
 def rope_apply(x: torch.Tensor, freqs: torch.Tensor) -> torch.Tensor:
-    """Apply RoPE to x, with ``freqs`` as a real ``(..., 2)`` cos/sin table.
+    """Apply float32 RoPE using a real ``(..., 2)`` cos/sin table.
 
-    Two forms of the same rotation, picked by whether inductor is generating code.
-
-    Compiled: inductor cannot generate code for complex operators, so a complex
-    multiply here falls back to eager, and being opaque to the scheduler it also
-    splits the surrounding qk-norm and layout work into separate fusion groups.
-    Written out in real arithmetic the whole segment fuses instead, measured on
-    gfx950 as three kernels collapsing to one.
-
-    Eager: the real form is the slower one by about 4x, because each of its
-    multiply-adds becomes its own pass over a temporary while the complex
-    multiply is a single elementwise kernel.
-
-    Both branches evaluate the same products in the same order and agree bitwise
-    once the caller casts back to bfloat16.
-
-    The rotation runs in float32. Only the angles need anything wider, and they
-    are already spent by the time ``rope_params`` hands over cos and sin: those
-    live in [-1, 1], where float32 carries four more decimal digits than the
-    bfloat16 this result is cast back to.
+    Compiled execution uses real arithmetic so Inductor can generate and
+    fuse the rotation; eager execution uses a complex multiply to avoid
+    multiple elementwise passes. The caller casts the result back to its dtype.
     """
     B, seq_len, n, _ = x.shape
     pairs = x.to(torch.float32).reshape(B, seq_len, n, -1, 2)
@@ -151,17 +131,10 @@ def rope_action_apply(
 
 
 def _mark_seq_dynamic(t: torch.Tensor | None, dim: int) -> None:
-    """Tell Dynamo that ``dim`` varies, so one graph serves every query length.
+    """Best-effort hint that ``dim`` varies across requests.
 
-    ``setup_compile()`` passes ``dynamic=False``, which disables *automatic* dynamic-shape
-    inference but does not override an explicit hint: verified on torch 2.12.0+xpu, four
-    distinct sequence lengths collapse from four compilations to one, with fusion quality
-    and kernel timings within ~2% of the static build.
-
-    Best-effort and silent on purpose. Under ``enforce_eager: true`` there is no
-    compilation to influence and marking is a harmless no-op, and ``mark_dynamic`` raises
-    if the tensor was already marked or is a view whose base cannot carry the hint. A
-    RoPE shape hint is never worth failing a request over.
+    Explicit hints work even when automatic dynamic-shape inference is
+    disabled. Unsupported hints must not fail an inference request.
     """
     if t is None:
         return
@@ -172,34 +145,11 @@ def _mark_seq_dynamic(t: torch.Tensor | None, dim: int) -> None:
 
 
 def _materialize_block_freqs(freqs: torch.Tensor) -> torch.Tensor:
-    """Real ``(..., 2)`` cos/sin table as a freshly allocated tensor, not a view.
+    """Materialize a real cos/sin table that can carry dynamic-shape hints.
 
-    ``view_as_real`` on its own returns a *view*, and both of the reasons this matters
-    are about what the compiled block sees, not about the values:
-
-    1. ``torch._dynamo.mark_dynamic`` cannot always place a hint on a view -- it raises
-       when the base cannot carry it. The next commit marks this table's sequence dim,
-       and on a view that marking silently does nothing, which quietly costs one graph
-       per query length. A real allocation always carries the hint.
-    2. Dynamo guards on the tensor's dispatch key set, and the two branches of
-       :func:`causal_rope_action_freqs` reach ``view_as_real`` with different bases: the
-       no-action branch views the table handed down from ``_create_freqs``, while the
-       action branch views a ``torch.cat`` performed here. Under ``inference_mode`` those
-       do not reliably agree -- a tensor viewed out of a longer-lived buffer keeps
-       ``(XPU, ADInplaceOrView, AutogradXPU, AutocastXPU)`` where a freshly allocated one
-       carries ``(XPU, AutocastXPU)`` -- and a mismatch makes prefill and diffuse
-       guard-incompatible, costing a second graph:
-
-           tensor 'freqs' dispatch key set mismatch. expected
-           DispatchKeySet(XPU, BackendSelect, ADInplaceOrView), actual
-           DispatchKeySet(XPU, BackendSelect)
-
-       Allocating on both paths makes the branches hand the block the same flavour of
-       tensor by construction.
-
-    ``.contiguous()`` is not a substitute: on an already-contiguous view it returns the
-    same view and drops nothing. The copy is of a table four orders of magnitude smaller
-    than the activations it rotates, once per forward against the 80 rotations it feeds.
+    A fresh allocation avoids view-base restrictions and normalizes tensor
+    metadata across branches. ``contiguous()`` cannot guarantee this because
+    it may return an already-contiguous view unchanged.
     """
     return torch.view_as_real(freqs).clone()
 
@@ -213,19 +163,10 @@ def causal_rope_action_freqs(
     num_state_per_block: int,
     action_state_index: int,
 ) -> torch.Tensor:
-    """Video RoPE table with the current step's action/state rows appended.
+    """Build the video RoPE table with this step's action/state rows appended.
 
-    Single inference step (causal / KV-cache mode). A function of the step index
-    only, so all layers and both q and k share one build -- see ``_forward_blocks``,
-    which calls this once per forward and passes the result down.
-
-    Returned as a real ``(..., 2)`` cos/sin table: the complex form is only used
-    to build it, so no complex tensor reaches the compiled blocks, where inductor
-    would fall back to eager. Converting here costs one view of a table that is
-    four orders of magnitude smaller than the tensors it rotates.
-
-    Both exits route through :func:`_materialize_block_freqs`, which is what makes the
-    table markable and its dispatch key set branch-independent.
+    All layers share the real table, keeping complex operators outside
+    compiled blocks. See ``_materialize_block_freqs`` for its allocation contract.
     """
     if action_register_length is None:
         return _materialize_block_freqs(freqs)
@@ -1087,8 +1028,7 @@ class CausalWanModel(nn.Module):
             )
             kv_cache = [c.to_layer_inputs() for c in kv_cache]
 
-        # Append this step's action/state RoPE rows once, outside the compiled blocks:
-        # the table is the same for all 40 layers and for both q and k.
+        # Build action/state RoPE rows once; all layers and both q/k share them.
         freqs = causal_rope_action_freqs(
             freqs,
             self.freqs_action,
@@ -1099,14 +1039,9 @@ class CausalWanModel(nn.Module):
             max(0, (current_start_frame - 1) // self.num_frame_per_block),
         )
 
-        # One graph for every AR geometry. x, e0 and freqs all carry the query-length
-        # dim, which is 880 (first prefill chunk), 1760 (later prefill) or 1785 (diffuse,
-        # +25 action/state registers). Unmarked, the block is retraced per length --
-        # "tensor 'e' size mismatch at index 1" -- so the table hoist above removes the
-        # redundant work but not the recompiles. These three hints are what collapse the
-        # lengths, and they need both of the preceding commits to bite: the table must be
-        # a real allocation to carry a hint at all, and paged_write_attn must stop passing
-        # max_query_len as a Python int or the graph re-specializes on that instead.
+        # Mark every query-length dimension to avoid per-length specialization.
+        # The RoPE table must be materialized and paged attention must use a
+        # symbolic query length for these hints to remain effective.
         _mark_seq_dynamic(x, 1)
         _mark_seq_dynamic(e0, 1)
         _mark_seq_dynamic(freqs, 0)

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
@@ -580,7 +580,22 @@ if not hasattr(torch.ops.vllm_omni, "ar_diffusion_paged_write_attn"):
 def paged_write_attn(
     inputs: ARDiffusionPagedLayerInputs, query, k_curr, v_curr, k_act, v_act, softmax_scale: float
 ) -> torch.Tensor:
-    """Model-facing entry: routes through the custom op (traceable in fullgraph)."""
+    """Model-facing entry: routes through the custom op (traceable in fullgraph).
+
+    ``max_query_len`` is deliberately not read off ``inputs``. It equals the live query
+    length -- 880 for the first prefill chunk, 1760 for later prefill, 1785 for diffuse
+    (2x880 video + 24 action + 1 state) -- and a plain Python int is a Dynamo *value*
+    guard, so passing it re-specializes the graph per length even when the query
+    tensor's own sequence dim is marked dynamic. Measured on torch 2.12.0+xpu: three
+    lengths gave three compilations either way.
+
+    ``query.shape[0]`` is the same number as a *symbolic* int tied to the already-dynamic
+    dim, which lets one graph serve all three. The equality is structural rather than
+    incidental: ``query`` is the flattened ``(T, H, D)`` query for one batch-1 sequence,
+    so ``T == query_len == max_query_len``.
+    """
+    # (T, H, D) for batch 1 -> T is exactly the varlen max_seqlen_q bound.
+    max_query_len = query.shape[0]
     return torch.ops.vllm_omni.ar_diffusion_paged_write_attn(
         query,
         k_curr,
@@ -595,7 +610,7 @@ def paged_write_attn(
         inputs.block_table,
         inputs.query_start_loc,
         inputs.seq_lens,
-        inputs.max_query_len,
+        max_query_len,
         inputs.max_seq_len,
         softmax_scale,
     )

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Paged self-attention helpers for AR-Diffusion KV reuse."""
 
 from __future__ import annotations

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/paged_attention.py
@@ -581,21 +581,12 @@ if not hasattr(torch.ops.vllm_omni, "ar_diffusion_paged_write_attn"):
 def paged_write_attn(
     inputs: ARDiffusionPagedLayerInputs, query, k_curr, v_curr, k_act, v_act, softmax_scale: float
 ) -> torch.Tensor:
-    """Model-facing entry: routes through the custom op (traceable in fullgraph).
+    """Route through the traceable custom op using a symbolic query length.
 
-    ``max_query_len`` is deliberately not read off ``inputs``. It equals the live query
-    length -- 880 for the first prefill chunk, 1760 for later prefill, 1785 for diffuse
-    (2x880 video + 24 action + 1 state) -- and a plain Python int is a Dynamo *value*
-    guard, so passing it re-specializes the graph per length even when the query
-    tensor's own sequence dim is marked dynamic. Measured on torch 2.12.0+xpu: three
-    lengths gave three compilations either way.
-
-    ``query.shape[0]`` is the same number as a *symbolic* int tied to the already-dynamic
-    dim, which lets one graph serve all three. The equality is structural rather than
-    incidental: ``query`` is the flattened ``(T, H, D)`` query for one batch-1 sequence,
-    so ``T == query_len == max_query_len``.
+    For the flattened batch-1 query (T, H, D), query.shape[0] equals
+    max_query_len. Reading a Python integer from inputs would instead add
+    a value guard and specialize the graph for each length.
     """
-    # (T, H, D) for batch 1 -> T is exactly the varlen max_seqlen_q bound.
     max_query_len = query.shape[0]
     return torch.ops.vllm_omni.ar_diffusion_paged_write_attn(
         query,


### PR DESCRIPTION
## Purpose

**Depends on #5808, whose RoPE changes are already included in this branch.**

DreamZero's DiT block recompiles as query length changes. This PR derives `max_query_len` from the symbolic query shape, materializes RoPE tables as fresh allocations, and marks sequence dimensions dynamic. #5808 removes chunk-position specialization; this PR targets the remaining query-length guards.

## Test Plan

**vLLM Version:** target v0.28.0.
**vLLM-Omni Commit:** PR head `29470edea9d9`; original base `b5e898f29538`, with #5808 included.

Tests cover allocation/value preservation, dynamic hints, symbolic query length, and an opt-in real-block compile test expecting two graphs across AR geometries:

```bash
pytest -q tests/diffusion/models/dreamzero/test_rope_compile_guards.py
VLLM_OMNI_RUN_DREAMZERO_COMPILE_GUARD_TEST=1 pytest -sv tests/diffusion/models/dreamzero/test_rope_compile_guards.py
pytest -q tests/diffusion/ar_diffusion/test_paged_attention.py
```

Hardware comparison: Intel Arc Pro B70, denoise TP=4, encode/decode on one separate card; bf16, 16 steps, inductor, rebuilt 880-token-page XPU kernels, 2 warmups and 20 measured requests across 4 DROID scenes per arm.

## Test Result

Previously reported static/lint checks passed. The pytest suite and opt-in graph-count acceptance test remain unexecuted; hardware timing did not re-verify numerics or output quality.

| Arm | Mean / request | Query-length recompile triggers |
|---|---:|---:|
| Baseline | 6,432.2 ms | 76 |
| #5808 alone | 5,890.2 ms | 12 |
| This branch, including #5808 | 5,959.4 ms | 0 |

The branch is 7.35% faster than baseline, but **the speedup belongs to #5808**. The guard changes add 69.2 ms (+1.17%, 95% CI +2.7 to +135.7 ms) versus #5808 alone in this warmed workload. They remove query-length recompiles without demonstrating a steady-state latency benefit. There are still 28 generic recompile log lines; these are distinct from the unit test's two-graph assertion.
