### PR TITLE
[CI][NPU] Right-size Qwen3-Omni nightly perf jobs to 2 NPUs

### DIFF
--- a/.buildkite/npu/test-npu-nightly.yml
+++ b/.buildkite/npu/test-npu-nightly.yml
@@ -10,7 +10,7 @@ steps:
       - label: ":full_moon: Omni · Perf Test · No Async Chunk"
         key: nightly-omni-performance-no-async-chunk
         timeout_in_minutes: 180
-        mirror_hardwares: a3_npu_4
+        mirror_hardwares: a3_npu_2
         env:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
           VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
@@ -26,7 +26,7 @@ steps:
       - label: ":full_moon: Omni · Perf Test · Async Chunk"
         key: nightly-omni-performance-async-chunk
         timeout_in_minutes: 180
-        mirror_hardwares: a3_npu_4
+        mirror_hardwares: a3_npu_2
         env:
           VLLM_WORKER_MULTIPROC_METHOD: spawn
           VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"


### PR DESCRIPTION
The two Qwen3-Omni nightly performance jobs each reserved four A3 NPUs, but their configs specify `num_cards: 2`, which is also what the test skip logic enforces. This moves both jobs from `a3_npu_4` to `a3_npu_2`. It does not change the benchmark matrix or baselines.

Fixes #6508.

Validation: pre-commit and the docs build pass. I have not run the NPU workload locally.

