### PR TITLE
[Bugfix] Fix MiniMax-H3 packed padding with Ring attention

### DIFF
--- a/docs/design/feature/sequence_parallel.md
+++ b/docs/design/feature/sequence_parallel.md
@@ -77,7 +77,9 @@ Use it when plain Ulysses-SP would otherwise fail because:
 
 - `auto_pad=True` pads sequence tokens in `_sp_plan` and requires attention backends that support `attention_mask`.
 - `advanced_uaa` does not depend on mask-based token padding inside Ulysses attention. It is therefore a better fit for non-divisible head counts and uneven Ulysses shard sizes.
-- `auto_pad=True` remains incompatible with Ring attention because the ring backend does not consume `attention_mask`.
+- `auto_pad=True` remains incompatible with Ring attention because the ring backend does not consume arbitrary
+  `attention_mask` values. A model with contiguous suffix padding may instead publish `valid_kv_length`; Ring trims
+  each circulated K/V block against that global valid prefix.
 - `advanced_uaa` is still experimental and hybrid mode remains limited by Ring's equal-shape requirement.
 
 ---
@@ -416,7 +418,7 @@ _sp_plan = {
 | Constraint | Description |
 |------------|-------------|
 | **Attention Backend Compatibility** | The attention backends must support `attention_mask`. Currently only `TORCH_SDPA` and `FLASH_ATTN` (default for diffusion models) are supported. |
-| **Ring Attention Limitation** | Ring attention does not support `attention_mask`. Therefore, when using `auto_pad=True`, the combination of Ulysses + Ring attention is not feasible. |
+| **Ring Attention Limitation** | Ring attention does not support arbitrary `attention_mask` values, so `auto_pad=True` remains incompatible. Contiguous suffix padding is supported when the model publishes the global `valid_kv_length` prefix. |
 
 1. Enable `auto_pad=True` for all sequence-dimension inputs in `_sp_plan`:
 ```python

--- a/recipes/MiniMaxAI/MiniMax-H3.md
+++ b/recipes/MiniMaxAI/MiniMax-H3.md
@@ -1157,8 +1157,9 @@ vllm serve "${MODEL_ROOT}/FL2VA" \
 - `--cfg-parallel-size > 1` is rejected by design (CFG-distilled, no negative branch).
 - VAE patch parallelism requires size 1 or the full DiT group size and supports the
   H3 native `tile` mode only.
-- A U2 x Ring2 hybrid currently fails with an attention-mask length mismatch; use
-  pure Ulysses.
+- Ulysses x Ring hybrid attention supports H3's single-request contiguous suffix
+  padding. Arbitrary attention masks and multi-request packed batches remain
+  unsupported on the Ring path.
 - Online FP8 with DLO AllGather temporarily materializes the complete FP8 model
   in host memory on every rank during startup before retaining only each rank's
   shard. Size startup host memory for that transient peak.

--- a/tests/diffusion/attention/test_ring_padding.py
+++ b/tests/diffusion/attention/test_ring_padding.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.attention.backends import ring_flash_attn, ring_pytorch_attn
+from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
+from vllm_omni.diffusion.attention.backends.ring.ring_selector import AttnType
+from vllm_omni.diffusion.attention.backends.ring.ring_utils import ring_kv_block_valid_length
+from vllm_omni.diffusion.attention.parallel import ring as ring_parallel
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.diffusion]
+
+
+class _SingleRankComm:
+    rank = 0
+    world_size = 1
+
+
+@dataclass(frozen=True)
+class _FakeSequenceParallelGroup:
+    ring_group: object
+
+
+def _fake_attention_result(q, _k, _v, **_kwargs):
+    return torch.zeros_like(q), torch.zeros(q.shape[0], q.shape[2], q.shape[1])
+
+
+@pytest.mark.parametrize(("block_rank", "expected"), [(0, 4), (1, 1), (2, 0)])
+def test_global_prefix_is_partitioned_across_ring_blocks(block_rank, expected):
+    assert ring_kv_block_valid_length(5, 4, block_rank, 3) == expected
+
+
+def test_absent_prefix_length_keeps_the_full_ring_block():
+    assert ring_kv_block_valid_length(None, 4, 2, 3) == 4
+
+
+def test_pytorch_ring_trims_padding_from_each_kv_block(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    def fake_attention(q, k, v, **kwargs):
+        captured.update(k=k, v=v, **kwargs)
+        return _fake_attention_result(q, k, v, **kwargs)
+
+    monkeypatch.setattr(ring_pytorch_attn, "RingComm", lambda _group: _SingleRankComm())
+    monkeypatch.setattr(ring_pytorch_attn, "pytorch_attn_forward", fake_attention)
+    qkv = torch.randn(1, 4, 2, 8)
+
+    output = ring_pytorch_attn.ring_pytorch_attn_func(
+        qkv,
+        qkv,
+        qkv,
+        group=object(),
+        valid_kv_length=3,
+    )
+
+    assert output.shape == qkv.shape
+    assert captured["k"].shape[1] == 3
+    assert captured["v"].shape[1] == 3
+
+
+def test_pytorch_ring_trims_circulated_blocks_by_source_rank(monkeypatch):
+    observed_lengths = []
+    # Each ring step sends K and V separately.
+    blocks = [torch.randn(1, 4, 2, 8) for _ in range(4)]
+
+    class FakeRingComm:
+        rank = 2
+        world_size = 3
+
+        def __init__(self, _group):
+            self._next_block = 0
+
+        def send_recv(self, _tensor):
+            block = blocks[self._next_block]
+            self._next_block += 1
+            return block
+
+        def commit(self):
+            pass
+
+        def wait(self):
+            pass
+
+    def fake_attention(q, k, v, **kwargs):
+        observed_lengths.append(k.shape[1])
+        return _fake_attention_result(q, k, v, **kwargs)
+
+    monkeypatch.setattr(ring_pytorch_attn, "RingComm", FakeRingComm)
+    monkeypatch.setattr(ring_pytorch_attn, "pytorch_attn_forward", fake_attention)
+    qkv = torch.randn(1, 4, 2, 8)
+
+    ring_pytorch_attn.ring_pytorch_attn_func(
+        qkv,
+        qkv,
+        qkv,
+        group=object(),
+        valid_kv_length=5,
+    )
+
+    # Rank 2 starts with global block 2, then receives blocks 1 and 0.
+    # The first block is empty and therefore does not launch attention.
+    assert observed_lengths == [1, 4]
+
+
+def test_flash_ring_trims_padding_from_each_kv_block(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    def fake_attention(q, k, v, **kwargs):
+        captured.update(k=k, v=v, **kwargs)
+        return _fake_attention_result(q, k, v, **kwargs)
+
+    monkeypatch.setattr(ring_flash_attn, "RingComm", lambda _group: _SingleRankComm())
+    monkeypatch.setattr(ring_flash_attn, "select_flash_attn_impl", lambda *_args, **_kwargs: fake_attention)
+    qkv = torch.randn(1, 4, 2, 8)
+
+    output, _ = ring_flash_attn.ring_flash_attn_forward(
+        object(),
+        qkv,
+        qkv,
+        qkv,
+        softmax_scale=0.25,
+        causal=False,
+        attn_type=AttnType.FA,
+        valid_kv_length=3,
+    )
+
+    assert output.shape == qkv.shape
+    assert captured["k"].shape[1] == 3
+    assert captured["v"].shape[1] == 3
+
+
+def test_ring_dispatch_forwards_global_valid_kv_length(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    def fake_ring_attention(*_args, **kwargs):
+        captured.update(kwargs)
+        return "output"
+
+    monkeypatch.setattr(ring_pytorch_attn, "ring_pytorch_attn_func", fake_ring_attention)
+    strategy = ring_parallel.RingParallelAttention(
+        _FakeSequenceParallelGroup(ring_group=object()),
+        attn_backend_pref="sdpa",
+    )
+    metadata = AttentionMetadata(extra={"valid_kv_length": 3})
+    query = torch.randn(1, 4, 2, 8)
+
+    assert strategy.run_attention(query, query, query, metadata) == "output"
+    assert captured["valid_kv_length"] == 3
+
+
+def test_pytorch_ring_rejects_causal_with_a_valid_prefix(monkeypatch):
+    """Trimming a K/V block under causal=True would silently shift the diagonal.
+
+    The query block keeps the full padded length while the circulated K/V block
+    is trimmed, and a causal mask over a rectangular tile is bottom-right
+    aligned, so the combination must be refused rather than computed.
+    """
+    monkeypatch.setattr(ring_pytorch_attn, "RingComm", lambda _group: _SingleRankComm())
+    monkeypatch.setattr(ring_pytorch_attn, "pytorch_attn_forward", _fake_attention_result)
+    qkv = torch.randn(1, 4, 2, 8)
+
+    with pytest.raises(ValueError, match="valid_kv_length is not supported with causal=True"):
+        ring_pytorch_attn.ring_pytorch_attn_func(
+            qkv,
+            qkv,
+            qkv,
+            causal=True,
+            group=object(),
+            valid_kv_length=3,
+        )
+
+
+def test_flash_ring_rejects_causal_with_a_valid_prefix(monkeypatch):
+    """Same refusal on the Flash-Attention ring path."""
+    monkeypatch.setattr(ring_flash_attn, "RingComm", lambda _group: _SingleRankComm())
+    monkeypatch.setattr(
+        ring_flash_attn,
+        "select_flash_attn_impl",
+        lambda *_args, **_kwargs: _fake_attention_result,
+    )
+    qkv = torch.randn(1, 4, 2, 8)
+
+    with pytest.raises(ValueError, match="valid_kv_length is not supported with causal=True"):
+        ring_flash_attn.ring_flash_attn_forward(
+            object(),
+            qkv,
+            qkv,
+            qkv,
+            softmax_scale=0.25,
+            causal=True,
+            attn_type=AttnType.FA,
+            valid_kv_length=3,
+        )
+
+
+def test_ring_paths_still_accept_causal_without_a_valid_prefix(monkeypatch):
+    """The guard is scoped to the padded case: plain causal Ring is unchanged."""
+    monkeypatch.setattr(ring_flash_attn, "RingComm", lambda _group: _SingleRankComm())
+    monkeypatch.setattr(
+        ring_flash_attn,
+        "select_flash_attn_impl",
+        lambda *_args, **_kwargs: _fake_attention_result,
+    )
+    qkv = torch.randn(1, 4, 2, 8)
+
+    output, _ = ring_flash_attn.ring_flash_attn_forward(
+        object(),
+        qkv,
+        qkv,
+        qkv,
+        softmax_scale=0.25,
+        causal=True,
+        attn_type=AttnType.FA,
+    )
+
+    assert output.shape == qkv.shape

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
@@ -924,6 +924,45 @@ def test_ring_packed_attention_publishes_prefix_length_without_global_mask():
     assert metadata.extra["valid_kv_length"] == 5
 
 
+def test_ring_packed_attention_keeps_mask_when_runtime_sp_is_inactive(monkeypatch):
+    from vllm_omni.diffusion.models.minimax_h3 import minimax_h3_transformer
+
+    class InactiveContext:
+        sp_active = False
+
+    attention = _fake_packed_attention("CUDNN_ATTN")
+    attention.attention.use_ring = True
+    monkeypatch.setattr(
+        minimax_h3_transformer,
+        "is_forward_context_available",
+        lambda: True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        minimax_h3_transformer,
+        "get_forward_context",
+        InactiveContext,
+        raising=False,
+    )
+    q = torch.randn(8, 2, 4)
+
+    attention._run_packed_attention(
+        q,
+        q,
+        q,
+        cu_seqlens=torch.tensor([0, 5, 8], dtype=torch.int32),
+        max_seqlen=5,
+        packed_total=8,
+    )
+
+    metadata = attention.attention.metadata
+    assert torch.equal(
+        metadata.attn_mask,
+        torch.tensor([[True, True, True, True, True, False, False, False]]),
+    )
+    assert metadata.extra["npu_attn_varlen"] is True
+
+
 def _fake_packed_attention(
     backend_name: str,
     *,
@@ -944,6 +983,10 @@ def _fake_packed_attention(
         @classmethod
         def supports_multi_doc_packed_varlen(cls) -> bool:
             return supports_multi_doc
+
+        @classmethod
+        def supports_packed_mask_free(cls) -> bool:
+            return False
 
     class FakeAttention(torch.nn.Module):
         attn_backend = FakeBackend

--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
@@ -905,6 +905,25 @@ def test_packed_attention_keeps_padding_mask_for_other_backends():
     )
 
 
+def test_ring_packed_attention_publishes_prefix_length_without_global_mask():
+    attention = _fake_packed_attention("CUDNN_ATTN")
+    attention.attention.use_ring = True
+    q = torch.randn(4, 2, 4)
+
+    attention._run_packed_attention(
+        q,
+        q,
+        q,
+        cu_seqlens=torch.tensor([0, 5, 8], dtype=torch.int32),
+        max_seqlen=5,
+        packed_total=8,
+    )
+
+    metadata = attention.attention.metadata
+    assert metadata.attn_mask is None
+    assert metadata.extra["valid_kv_length"] == 5
+
+
 def _fake_packed_attention(
     backend_name: str,
     *,

--- a/vllm_omni/diffusion/attention/backends/abstract.py
+++ b/vllm_omni/diffusion/attention/backends/abstract.py
@@ -208,8 +208,9 @@ class AttentionMetadata:
     #     variable-length query/key sequences for FlashAttention.
     #   "max_seqlen_q" / "max_seqlen_k": maximum sequence lengths paired with
     #     the packed cu_seqlens tensors.
-    #   "valid_kv_length": int — contiguous valid K/V prefix length for a
-    #     backend that advertises supports_prefix_kv_slicing.
+    #   "valid_kv_length": int — contiguous valid K/V prefix length. Local
+    #     backends may slice it directly; ring backends trim each circulated
+    #     K/V block from the same global prefix.
     #   "npu_attn_varlen": bool — model opt-in for the NPU packed varlen path
     #     (TND npu_fusion_attention driven by cu_seqlens, mask never read).
     #     Requires the [real, pad] two-document packing contract; see

--- a/vllm_omni/diffusion/attention/backends/ring/ring_utils.py
+++ b/vllm_omni/diffusion/attention/backends/ring/ring_utils.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 # Copyright (c) 2024, Jiarui Fang.
 # Adapted from https://github.com/feifeibear/long-context-attention
 
@@ -9,7 +10,33 @@ import torch.nn.functional as F
 
 LseLayout = Literal["bhs", "bsh"]
 
-__all__ = ["update_out_and_lse", "flatten_varlen_lse", "unflatten_varlen_lse"]
+__all__ = [
+    "ring_kv_block_valid_length",
+    "update_out_and_lse",
+    "flatten_varlen_lse",
+    "unflatten_varlen_lse",
+]
+
+
+def ring_kv_block_valid_length(
+    valid_kv_length: int | None,
+    block_size: int,
+    block_rank: int,
+    world_size: int,
+) -> int:
+    """Return the valid prefix length in one globally ordered ring K/V block."""
+    if valid_kv_length is None:
+        return block_size
+    if isinstance(valid_kv_length, bool) or not isinstance(valid_kv_length, int):
+        raise ValueError("valid_kv_length must be a Python integer")
+    total_length = block_size * world_size
+    if not 0 < valid_kv_length <= total_length:
+        raise ValueError(
+            "valid_kv_length must be within the global ring K/V sequence, "
+            f"got {valid_kv_length} for length {total_length}"
+        )
+    block_start = block_rank * block_size
+    return max(0, min(block_size, valid_kv_length - block_start))
 
 
 def _normalize_lse(block_lse: torch.Tensor, block_out: torch.Tensor, lse_layout: LseLayout) -> torch.Tensor:

--- a/vllm_omni/diffusion/attention/backends/ring_flash_attn.py
+++ b/vllm_omni/diffusion/attention/backends/ring_flash_attn.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 # Copyright (c) 2024, Jiarui Fang.
 # Adapted from https://github.com/feifeibear/long-context-attention
 
@@ -6,7 +7,10 @@
 import torch
 
 from vllm_omni.diffusion.attention.backends.ring.ring_selector import AttnType, select_flash_attn_impl
-from vllm_omni.diffusion.attention.backends.ring.ring_utils import update_out_and_lse
+from vllm_omni.diffusion.attention.backends.ring.ring_utils import (
+    ring_kv_block_valid_length,
+    update_out_and_lse,
+)
 from vllm_omni.diffusion.distributed.comm import RingComm
 
 
@@ -27,6 +31,7 @@ def ring_flash_attn_forward(
     joint_tensor_key=None,
     joint_tensor_value=None,
     joint_strategy="front",
+    valid_kv_length: int | None = None,
 ):
     # Validate causal + joint_strategy combination
     # When causal=True and joint_strategy="rear", the causal mask would incorrectly
@@ -40,6 +45,21 @@ def ring_flash_attn_forward(
             "to ensure joint tokens act as a visible prefix for all local tokens. "
             "With 'rear' strategy, the causal mask would incorrectly block local tokens "
             "from seeing the joint tokens."
+        )
+
+    # Trimming the circulated K/V blocks changes their length while the query
+    # block keeps the full padded length. Flash-Attention aligns a causal mask
+    # to the bottom-right of a rectangular (seqlen_q, seqlen_k) tile, so a
+    # trimmed block would shift the diagonal and let queries attend to the
+    # wrong key positions -- silently, with no shape error. The two are
+    # therefore an unsupported combination rather than a slow path: the caller
+    # must either drop the padding before the ring or run non-causal.
+    if causal and valid_kv_length is not None:
+        raise ValueError(
+            "valid_kv_length is not supported with causal=True in Ring Attention. "
+            "Trimming a circulated K/V block shortens seqlen_k while seqlen_q keeps "
+            "the padded length, and the causal diagonal is bottom-right aligned, so "
+            "the mask would silently shift. Unpad before the ring, or use causal=False."
         )
 
     comm = RingComm(process_group)
@@ -66,8 +86,15 @@ def ring_flash_attn_forward(
             comm.commit()
 
         if not causal or step <= comm.rank:
-            step_k = k
-            step_v = v
+            block_rank = (comm.rank - step) % comm.world_size
+            block_valid_length = ring_kv_block_valid_length(
+                valid_kv_length,
+                k.shape[1],
+                block_rank,
+                comm.world_size,
+            )
+            step_k = k[:, :block_valid_length]
+            step_v = v[:, :block_valid_length]
             if step == 0 and joint_tensor_key is not None:
                 if joint_strategy == "front":
                     step_k = torch.cat([joint_tensor_key, step_k], dim=1)
@@ -76,27 +103,28 @@ def ring_flash_attn_forward(
                     step_k = torch.cat([step_k, joint_tensor_key], dim=1)
                     step_v = torch.cat([step_v, joint_tensor_value], dim=1)
 
-            fn = select_flash_attn_impl(attn_type, stage="fwd-only", attn_processor=attn_processor)
-            block_out, block_lse = fn(
-                q,
-                step_k,
-                step_v,
-                dropout_p=dropout_p,
-                softmax_scale=softmax_scale,
-                causal=causal and step == 0,
-                window_size=window_size,
-                softcap=softcap,
-                alibi_slopes=alibi_slopes,
-                return_softmax=True and dropout_p > 0,
-            )
+            if step_k.shape[1] > 0:
+                fn = select_flash_attn_impl(attn_type, stage="fwd-only", attn_processor=attn_processor)
+                block_out, block_lse = fn(
+                    q,
+                    step_k,
+                    step_v,
+                    dropout_p=dropout_p,
+                    softmax_scale=softmax_scale,
+                    causal=causal and step == 0,
+                    window_size=window_size,
+                    softcap=softcap,
+                    alibi_slopes=alibi_slopes,
+                    return_softmax=True and dropout_p > 0,
+                )
 
-            # Ensure block_out is contiguous if needed, though usually it is from FA
+                # Ensure block_out is contiguous if needed, though usually it is from FA
 
-            if attn_type == AttnType.SPARSE_SAGE:
-                out, lse = block_out, block_lse
-            else:
-                # Ring kernel wrappers canonicalize LSE to (B, H, S).
-                out, lse = update_out_and_lse(out, lse, block_out, block_lse, lse_layout="bhs")
+                if attn_type == AttnType.SPARSE_SAGE:
+                    out, lse = block_out, block_lse
+                else:
+                    # Ring kernel wrappers canonicalize LSE to (B, H, S).
+                    out, lse = update_out_and_lse(out, lse, block_out, block_lse, lse_layout="bhs")
 
         if step + 1 != comm.world_size:
             comm.wait()
@@ -132,6 +160,7 @@ class RingFlashAttnFunc(torch.autograd.Function):
         joint_tensor_key=None,
         joint_tensor_value=None,
         joint_strategy="front",
+        valid_kv_length: int | None = None,
     ):
         if softmax_scale is None:
             softmax_scale = q.shape[-1] ** (-0.5)
@@ -158,6 +187,7 @@ class RingFlashAttnFunc(torch.autograd.Function):
             joint_tensor_key=joint_tensor_key,
             joint_tensor_value=joint_tensor_value,
             joint_strategy=joint_strategy,
+            valid_kv_length=valid_kv_length,
         )
         return out if not return_softmax else (out, softmax_lse, None)
 
@@ -193,6 +223,7 @@ def ring_flash_attn_qkvpacked_func(
         None,  # joint_tensor_key
         None,  # joint_tensor_value
         "front",  # joint_strategy
+        None,  # valid_kv_length
     )
 
 
@@ -228,6 +259,7 @@ def ring_flash_attn_kvpacked_func(
         None,  # joint_tensor_key
         None,  # joint_tensor_value
         "front",  # joint_strategy
+        None,  # valid_kv_length
     )
 
 
@@ -249,6 +281,7 @@ def ring_flash_attn_func(
     joint_tensor_key=None,
     joint_tensor_value=None,
     joint_strategy="front",
+    valid_kv_length: int | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor, None]:
     """Ring Attention forward pass using Flash Attention backend.
 
@@ -290,6 +323,8 @@ def ring_flash_attn_func(
             Defaults to None.
         joint_strategy (str): Concatenation strategy ("front" or "back").
             Defaults to "front".
+        valid_kv_length (int | None): Length of the contiguous valid prefix in
+            the global ring K/V sequence. Defaults to the full sequence.
 
     Returns:
         Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor, None]]:
@@ -314,4 +349,5 @@ def ring_flash_attn_func(
         joint_tensor_key,
         joint_tensor_value,
         joint_strategy,
+        valid_kv_length,
     )

--- a/vllm_omni/diffusion/attention/backends/ring_pytorch_attn.py
+++ b/vllm_omni/diffusion/attention/backends/ring_pytorch_attn.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 # Copyright (c) 2024, Jiarui Fang.
 # Adapted from https://github.com/feifeibear/long-context-attention
 
@@ -10,7 +11,10 @@ import torch
 from vllm.logger import init_logger
 
 from vllm_omni.diffusion.attention.backends.ring.ring_kernels import pytorch_attn_forward
-from vllm_omni.diffusion.attention.backends.ring.ring_utils import update_out_and_lse
+from vllm_omni.diffusion.attention.backends.ring.ring_utils import (
+    ring_kv_block_valid_length,
+    update_out_and_lse,
+)
 from vllm_omni.diffusion.distributed.comm import RingComm
 
 logger = init_logger(__name__)
@@ -33,6 +37,7 @@ def ring_pytorch_attn_func(
     joint_tensor_key=None,
     joint_tensor_value=None,
     joint_strategy="front",
+    valid_kv_length: int | None = None,
 ):
     return RingAttentionFunc.apply(
         group,
@@ -45,6 +50,7 @@ def ring_pytorch_attn_func(
         joint_tensor_key,
         joint_tensor_value,
         joint_strategy,
+        valid_kv_length,
     )
 
 
@@ -64,6 +70,7 @@ class RingAttentionFunc(torch.autograd.Function):
         joint_tensor_key=None,
         joint_tensor_value=None,
         joint_strategy="front",
+        valid_kv_length: int | None = None,
     ):
         # Validate causal + joint_strategy combination
         # When causal=True and joint_strategy="rear", the causal mask would incorrectly
@@ -77,6 +84,22 @@ class RingAttentionFunc(torch.autograd.Function):
                 "to ensure joint tokens act as a visible prefix for all local tokens. "
                 "With 'rear' strategy, the causal mask would incorrectly block local tokens "
                 "from seeing the joint tokens."
+            )
+
+        # Trimming the circulated K/V blocks changes their length while the
+        # query block keeps the full padded length. A causal SDPA mask over a
+        # rectangular (seqlen_q, seqlen_k) tile is aligned to the bottom right,
+        # so a trimmed block would shift the diagonal and let queries attend to
+        # the wrong key positions -- silently, with no shape error. The two are
+        # therefore an unsupported combination rather than a slow path: the
+        # caller must either drop the padding before the ring or run
+        # non-causal.
+        if is_causal and valid_kv_length is not None:
+            raise ValueError(
+                "valid_kv_length is not supported with causal=True in Ring Attention. "
+                "Trimming a circulated K/V block shortens seqlen_k while seqlen_q keeps "
+                "the padded length, and the causal diagonal is bottom-right aligned, so "
+                "the mask would silently shift. Unpad before the ring, or use causal=False."
             )
 
         comm = RingComm(group)
@@ -98,8 +121,15 @@ class RingAttentionFunc(torch.autograd.Function):
                 comm.commit()
 
             if not is_causal or step <= comm.rank:
-                step_k = k
-                step_v = v
+                block_rank = (comm.rank - step) % comm.world_size
+                block_valid_length = ring_kv_block_valid_length(
+                    valid_kv_length,
+                    k.shape[1],
+                    block_rank,
+                    comm.world_size,
+                )
+                step_k = k[:, :block_valid_length]
+                step_v = v[:, :block_valid_length]
                 if step == 0 and joint_tensor_key is not None:
                     if joint_strategy == "front":
                         step_k = torch.cat([joint_tensor_key, step_k], dim=1)
@@ -108,15 +138,16 @@ class RingAttentionFunc(torch.autograd.Function):
                         step_k = torch.cat([step_k, joint_tensor_key], dim=1)
                         step_v = torch.cat([step_v, joint_tensor_value], dim=1)
 
-                block_out, block_lse = pytorch_attn_forward(
-                    q,
-                    step_k,
-                    step_v,
-                    softmax_scale=sm_scale,
-                    causal=is_causal and step == 0,
-                    op_type=op_type,
-                )
-                out, lse = update_out_and_lse(out, lse, block_out, block_lse, lse_layout="bhs")
+                if step_k.shape[1] > 0:
+                    block_out, block_lse = pytorch_attn_forward(
+                        q,
+                        step_k,
+                        step_v,
+                        softmax_scale=sm_scale,
+                        causal=is_causal and step == 0,
+                        op_type=op_type,
+                    )
+                    out, lse = update_out_and_lse(out, lse, block_out, block_lse, lse_layout="bhs")
 
             if step + 1 != comm.world_size:
                 comm.wait()

--- a/vllm_omni/diffusion/attention/parallel/ring.py
+++ b/vllm_omni/diffusion/attention/parallel/ring.py
@@ -156,9 +156,11 @@ class RingParallelAttention:
         # Extract joint tensors
         joint_key, joint_value = None, None
         joint_strategy = "front"
+        valid_kv_length = None
         if attn_metadata is not None:
             joint_key = attn_metadata.joint_key
             joint_value = attn_metadata.joint_value
+            valid_kv_length = attn_metadata.extra.get("valid_kv_length")
             if attn_metadata.joint_strategy is not None:
                 joint_strategy = attn_metadata.joint_strategy
 
@@ -176,6 +178,7 @@ class RingParallelAttention:
                 joint_tensor_key=joint_key,
                 joint_tensor_value=joint_value,
                 joint_strategy=joint_strategy,
+                valid_kv_length=valid_kv_length,
             )
 
         # Ring only implements local Flash/AITER and SDPA kernels. HuggingFace
@@ -261,4 +264,5 @@ class RingParallelAttention:
             joint_tensor_key=joint_key,
             joint_tensor_value=joint_value,
             joint_strategy=joint_strategy,
+            valid_kv_length=valid_kv_length,
         )

--- a/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
+++ b/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
@@ -534,12 +534,18 @@ class MiniMaxH3Attention(nn.Module):
             # supports_packed_mask_free: backend consumes the packed metadata
             # without ever reading attn_mask (CUDA packed varlen, NPU
             # npu_attn_varlen opt-in with its own fallback rebuild).
-            use_ring = getattr(self.attention, "use_ring", False)
+            use_ring = getattr(self.attention, "use_ring", False) and not getattr(
+                self.attention, "skip_sequence_parallel", False
+            )
             mask_free_packed_padding = not use_ring and self.attention.attn_backend.supports_packed_mask_free()
             no_mask = not use_ring and (
                 self.attention.attn_backend.supports_prefix_kv_slicing or mask_free_packed_padding
             )
-            if used < packed_total and not no_mask:
+            # Hybrid Ulysses reshards Q to one ring partition before the ring
+            # kernel runs, so a global [packed_total] mask cannot pass its
+            # query-length check. Ring consumes valid_kv_length directly and
+            # trims the circulated K/V blocks instead.
+            if used < packed_total and not no_mask and not use_ring:
                 attn_mask = torch.arange(packed_total, device=q.device)[None] < used
         metadata = AttentionMetadata(
             attn_mask=attn_mask,

--- a/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
+++ b/vllm_omni/diffusion/models/minimax_h3/minimax_h3_transformer.py
@@ -44,6 +44,10 @@ from vllm_omni.diffusion.distributed.sp_plan import (
     SequenceParallelInput,
     SequenceParallelOutput,
 )
+from vllm_omni.diffusion.forward_context import (
+    get_forward_context,
+    is_forward_context_available,
+)
 from vllm_omni.diffusion.layers.activation import SiluAndMul
 from vllm_omni.diffusion.layers.fused_qk_norm_rope import fused_qk_norm_rope
 from vllm_omni.diffusion.layers.norm import RMSNorm
@@ -67,6 +71,15 @@ logger = init_logger(__name__)
 # packing, and ``_run_packed_attention`` re-checks it per forward; a name-only
 # gate would let FLASH_ATTN's NPU/XPU code paths through even though those
 # variants would silently attend across request boundaries.
+def _ring_sequence_parallel_is_active(attention_layer: Attention) -> bool:
+    """Match :meth:`Attention._get_active_parallel_strategy` for Ring."""
+    if not getattr(attention_layer, "use_ring", False) or getattr(attention_layer, "skip_sequence_parallel", False):
+        return False
+    if is_forward_context_available() and not get_forward_context().sp_active:
+        return False
+    return True
+
+
 def _attention_isolates_packed_requests(attention_layer: Any) -> bool:
     """True if this attention layer keeps N-document packed boundaries.
 
@@ -78,7 +91,7 @@ def _attention_isolates_packed_requests(attention_layer: Any) -> bool:
     backend = getattr(attention_layer, "attn_backend", None)
     if backend is None or not backend.supports_multi_doc_packed_varlen():
         return False
-    return not getattr(attention_layer, "use_ring", False)
+    return not _ring_sequence_parallel_is_active(attention_layer)
 
 
 @dataclass
@@ -508,6 +521,7 @@ class MiniMaxH3Attention(nn.Module):
             )
         attn_mask = None
         mask_free_packed_padding = False
+        use_ring = _ring_sequence_parallel_is_active(self.attention)
         if num_requests > 1:
             # A step-mode batch packs one document per request, so its valid
             # rows are block-diagonal rather than a prefix: neither a KV prefix
@@ -534,9 +548,6 @@ class MiniMaxH3Attention(nn.Module):
             # supports_packed_mask_free: backend consumes the packed metadata
             # without ever reading attn_mask (CUDA packed varlen, NPU
             # npu_attn_varlen opt-in with its own fallback rebuild).
-            use_ring = getattr(self.attention, "use_ring", False) and not getattr(
-                self.attention, "skip_sequence_parallel", False
-            )
             mask_free_packed_padding = not use_ring and self.attention.attn_backend.supports_packed_mask_free()
             no_mask = not use_ring and (
                 self.attention.attn_backend.supports_prefix_kv_slicing or mask_free_packed_padding
@@ -569,7 +580,7 @@ class MiniMaxH3Attention(nn.Module):
                 # quadratic full_qk mask is never materialized. Ring attention
                 # is excluded: it keeps the aligned padding rows for its
                 # fixed-size P2P buffers and still needs the mask.
-                "npu_attn_varlen": not getattr(self.attention, "use_ring", False),
+                "npu_attn_varlen": not use_ring,
                 # fp16-range protection for the ascend_laser_attention kernel
                 # (see MINIMAX_H3_LASER_INPUT_SCALE). Ignored by every other
                 # backend/path.


### PR DESCRIPTION
Two commits; the second depends on the first.

# Commit 1: [Bugfix] Fix MiniMax-H3 packed padding with Ring attention

## Purpose

**Problem:** MiniMax-H3 pads its packed sequence to an aligned length and passes `valid_kv_length` to the local attention backends. On the Ring path it instead builds an `attn_mask` at the global padded length (`minimax_h3_transformer.py:514`), which the Ring backends reject, so any padded request fails under Ring (the failure recorded in `recipes/MiniMaxAI/MiniMax-H3.md`).

**Fix:** both Ring backends accept an optional `valid_kv_length` and trim each K/V block to the valid prefix of its source rank (`ring_utils.ring_kv_block_valid_length`); a fully padded block launches no attention. H3 publishes `valid_kv_length` on the Ring path instead of the mask. `causal=True` together with `valid_kv_length` raises `ValueError`: on a rectangular tile the causal diagonal would silently shift. With `valid_kv_length=None` every path is byte-for-byte the previous behaviour.

## Test Plan

**Reproduce:** serve MiniMax-H3 with Ring sequence parallel and send a request whose packed length is not a multiple of the alignment.

```bash
pytest -q tests/diffusion/attention/test_ring_padding.py
pytest -q tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py -k ring
```

**vLLM Version:** as pinned by `requirements/`. **vLLM-Omni Commit:** rebased onto current `main`.

## Test Result

CPU tests pass (ring communicator and kernel stubbed, rank-2-of-3 block ordering covered). Reverting the K/V trim makes the ordering test observe `[4, 4]` instead of `[1, 4]`; removing the causal guard makes the two refusal tests fail with `DID NOT RAISE`. Not run on multi-rank hardware.

---

# Commit 2: [Bugfix] Honor runtime SP state in H3 Ring padding

## Purpose

**Problem:** `MiniMaxH3Attention._run_packed_attention` reads the static `use_ring` flag in three places to decide between the Ring and local packed paths. Whether Ring actually runs is a runtime decision (`Attention._get_active_parallel_strategy` also honours `skip_sequence_parallel` and `forward_context.sp_active`), so a layer that declares Ring but is not running it this step takes the Ring branch with the wrong inputs.

**Fix:** decide from the active strategy through one local helper; a layer not running Ring this step takes the local packed path (including NPU `npu_attn_varlen`). A layer genuinely running Ring behaves as before. Depends on the previous commit for the Ring branch.

## Test Plan

**Reproduce:** configure Ring, then run a step with `sp_active=False` (or a layer with `skip_sequence_parallel`): the packed attention still takes the Ring branch.

```bash
pytest -q tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py -k ring
```

**vLLM Version:** as pinned by `requirements/`. **vLLM-Omni Commit:** rebased onto current `main`.

## Test Result

CPU tests pass for the three combinations (Ring active, Ring declared but inactive, no Ring).