### PR TITLE
[Bugfix][Hardware][Intel] Skip the offload-eviction empty_cache on XPU

### DIFF
--- a/tests/diffusion/offloader/test_eviction_empty_cache.py
+++ b/tests/diffusion/offloader/test_eviction_empty_cache.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""The per-eviction ``empty_cache`` must not run on XPU.
+
+Returning the freed segments to the driver is not what makes the HBM reusable
+-- the caching allocator already recycles those blocks. On XPU it does have a
+cost: it churns the addresses of the collective receive buffers allocated
+after it, and the XPU collective backend keeps a non-reclaimable driver
+registration per distinct receive-buffer address, so device memory outside the
+PyTorch pool was observed growing across the measured requests.
+
+These tests pin the platform split: XPU skips the call, every other platform
+keeps the previous behaviour byte for byte.
+"""
+
+import pytest
+import torch
+from torch import nn
+
+from vllm_omni.diffusion.offloader.module_residency import (
+    PinnedModuleStager,
+    _StorageGroup,
+    _TensorBinding,
+)
+from vllm_omni.diffusion.offloader.sequential_backend import SequentialOffloadHook
+from vllm_omni.platforms import current_omni_platform
+
+pytestmark = [pytest.mark.diffusion, pytest.mark.cpu, pytest.mark.core_model]
+
+
+@pytest.fixture
+def platform_probe(monkeypatch):
+    """Drive ``is_xpu`` and count ``empty_cache`` without touching a device."""
+    calls: list[str] = []
+
+    def _install(*, is_xpu: bool):
+        monkeypatch.setattr(current_omni_platform, "is_xpu", lambda: is_xpu, raising=False)
+        monkeypatch.setattr(current_omni_platform, "empty_cache", lambda: calls.append("empty_cache"), raising=False)
+        monkeypatch.setattr(current_omni_platform, "synchronize", lambda: calls.append("synchronize"), raising=False)
+        return calls
+
+    return _install
+
+
+def _hook_on_cpu_target() -> tuple[SequentialOffloadHook, nn.Module]:
+    module = nn.Linear(4, 4)
+    hook = SequentialOffloadHook([module], torch.device("cpu"), pin_memory=False)
+    return hook, module
+
+
+def _staged_module() -> PinnedModuleStager:
+    """A stager in the ``loaded`` state without requiring an accelerator."""
+    stager = object.__new__(PinnedModuleStager)
+    target = torch.zeros(4)
+    master = torch.zeros(4).view(torch.uint8)
+    binding = _TensorBinding(target=target, dtype=target.dtype, shape=(4,), stride=(1,), storage_offset=0)
+    stager.loaded = True
+    stager.cache_retention = None
+    stager._groups = [_StorageGroup(master=master, bindings=[binding])]
+    stager._device_storages = [torch.zeros(16, dtype=torch.uint8)]
+    return stager
+
+
+@pytest.mark.parametrize("is_xpu, expected", [(True, 0), (False, 1)])
+def test_stager_offload_skips_empty_cache_only_on_xpu(platform_probe, is_xpu, expected) -> None:
+    calls = platform_probe(is_xpu=is_xpu)
+    stager = _staged_module()
+
+    stager.offload()
+
+    assert stager.loaded is False
+    assert calls.count("synchronize") == 1, "the stage-boundary sync must run on every platform"
+    assert calls.count("empty_cache") == expected
+
+
+@pytest.mark.parametrize("is_xpu, expected", [(True, 0), (False, 1)])
+def test_sequential_to_cpu_skips_empty_cache_only_on_xpu(platform_probe, monkeypatch, is_xpu, expected) -> None:
+    calls = platform_probe(is_xpu=is_xpu)
+    hook, module = _hook_on_cpu_target()
+    # ``_to_cpu`` returns early when the module already lives on CPU, which
+    # would make the assertion pass for the wrong reason. ``meta`` gives a
+    # non-CPU device without needing an accelerator; the transfer itself is
+    # stubbed out because meta storage cannot be copied.
+    module.to(torch.device("meta"))
+    monkeypatch.setattr(
+        SequentialOffloadHook,
+        "_move_params",
+        # ``_move_params`` reports whether anything was evicted; the eviction
+        # ``empty_cache`` is only reached when it did, so the stub must say so.
+        staticmethod(lambda *args, **kwargs: calls.append("move_params") or True),
+    )
+
+    hook._to_cpu(module)
+
+    assert calls.count("move_params") == 1, "the eviction itself must still happen"
+    assert calls.count("empty_cache") == expected
+
+
+def test_stager_forced_release_still_flushes_on_xpu(platform_probe) -> None:
+    """Failure paths keep their explicit flush; only the eviction path is gated."""
+    calls = platform_probe(is_xpu=True)
+    stager = _staged_module()
+
+    stager._release_cache(force=True)
+
+    assert calls.count("empty_cache") == 1

--- a/vllm_omni/diffusion/offloader/module_residency.py
+++ b/vllm_omni/diffusion/offloader/module_residency.py
@@ -202,6 +202,18 @@ class PinnedModuleStager:
         self.cache_retention = cache_retention
 
     def _release_cache(self, *, force: bool = False) -> None:
+        # The eviction-path ``empty_cache`` is skipped on XPU. Returning the
+        # segments to the driver is not required for the freed HBM to be
+        # reusable -- the caching allocator already hands those blocks to the
+        # next allocation -- but on XPU it churns the addresses of the
+        # collective receive buffers allocated after it, and the XPU collective
+        # backend registers a non-reclaimable driver resource per distinct
+        # receive-buffer address, so device memory outside the PyTorch pool was
+        # observed growing across requests. The retention policy does not help
+        # here: it still releases whenever a bound trips or telemetry is
+        # missing. Forced releases (failure paths) keep their explicit flush.
+        if not force and current_omni_platform.is_xpu():
+            return
         if self.cache_retention is None:
             current_omni_platform.empty_cache()
         else:

--- a/vllm_omni/diffusion/offloader/sequential_backend.py
+++ b/vllm_omni/diffusion/offloader/sequential_backend.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from collections.abc import Collection, Iterator
 from contextlib import contextmanager
@@ -114,7 +114,14 @@ class SequentialOffloadHook(ModelHook):
             non_blocking=non_blocking,
             pin_memory=self.pin_memory,
         )
-        if moved:
+        # Skip the eviction ``empty_cache`` on XPU for the same reason it is
+        # skipped in ``PinnedModuleStager.offload``: handing the segments back
+        # to the driver is not needed for the freed HBM to be reusable, but it
+        # churns the addresses of the collective receive buffers allocated after
+        # it, and the XPU collective backend keeps a non-reclaimable driver
+        # registration per distinct receive-buffer address. See that method for
+        # the rationale.
+        if moved and not current_omni_platform.is_xpu():
             current_omni_platform.empty_cache()
 
     def _to_gpu(self, module: nn.Module) -> None:


### PR DESCRIPTION
## Purpose

**Problem:** `SequentialOffloadHook._to_cpu` and `PinnedModuleStager._release_cache` call `empty_cache()` after every module eviction. The caching allocator already recycles those blocks, so the flush frees nothing usable; on XPU it changes the addresses of the collective receive buffers allocated afterwards, and device memory outside the PyTorch pool grows across requests. (Mechanism inferred from intervention experiments.) The `cache_retention` bound does not cover this: `release_if_needed` still flushes when its telemetry is unavailable, which is the XPU case.

**Fix:** gate the two eviction call sites on `current_omni_platform.is_xpu()`, in front of the whole retention branch. `force=True` releases (failure paths) keep their flush on every platform. Non-XPU behaviour is byte-for-byte unchanged.

## Test Plan

**Reproduce:** MiniMax-H3 with model-level offload on XPU, serial requests, sample non-PyTorch device memory between requests: it grows each request.

```bash
pytest -q tests/diffusion/offloader/test_eviction_empty_cache.py
```

**vLLM Version:** as pinned by `requirements/`. **vLLM-Omni Commit:** rebased onto current `main`.

## Test Result

CPU tests pass: on XPU the two sites skip the flush, off XPU they call it exactly as before, forced releases flush on both. On the XPU service the per-request growth at these two sites is removed; timings are not a performance claim.

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

## Test Plan

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
