### PR TITLE
[Bugfix][Hardware][Intel] Wan2.2: skip the request-path empty_cache on XPU

### DIFF
--- a/tests/diffusion/models/wan2_2/test_wan22_request_cache_release.py
+++ b/tests/diffusion/models/wan2_2/test_wan22_request_cache_release.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""The Wan2.2 request-path cache release must not run on XPU.
+
+Returning cached blocks to the driver between denoising and VAE decoding is
+harmless elsewhere, but on XPU it moves the decoder's tensors to new device
+addresses and the collective backend then maps new peer segments on every
+request without releasing the old ones (10.3 GB of host memory per request on
+a 4-rank service). These tests pin the platform split and make sure the
+pipelines go through the shared helper instead of calling ``empty_cache``
+directly.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import vllm_omni.diffusion.models.wan2_2 as wan22_pkg
+from vllm_omni.diffusion.models.wan2_2 import device_cache
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.diffusion]
+
+
+def _platform(*, is_available: bool, is_xpu: bool):
+    """A stand-in platform that records ``empty_cache`` calls without a device."""
+    calls: list[str] = []
+    platform = SimpleNamespace(
+        is_available=lambda: is_available,
+        is_xpu=lambda: is_xpu,
+        empty_cache=lambda: calls.append("empty_cache"),
+    )
+    return platform, calls
+
+
+@pytest.mark.parametrize(
+    ("is_available", "is_xpu", "expected"),
+    [
+        (True, False, 1),  # every non-XPU accelerator keeps the previous behaviour
+        (True, True, 0),  # XPU skips the request-path release
+        (False, False, 0),  # no accelerator: nothing to release (previous behaviour)
+    ],
+)
+def test_release_request_cache_platform_split(is_available, is_xpu, expected) -> None:
+    platform, calls = _platform(is_available=is_available, is_xpu=is_xpu)
+
+    device_cache.release_request_cache(platform)
+
+    assert calls.count("empty_cache") == expected
+
+
+def test_release_request_cache_does_not_probe_xpu_without_an_accelerator() -> None:
+    """The pipelines' CPU tests stub the platform with ``is_available`` only."""
+    platform = SimpleNamespace(is_available=lambda: False)
+
+    device_cache.release_request_cache(platform)  # must not touch is_xpu / empty_cache
+
+
+def test_wan22_pipelines_release_cache_through_the_helper() -> None:
+    """A direct ``empty_cache()`` in a pipeline would bypass the XPU gate."""
+    pkg_dir = Path(wan22_pkg.__file__).parent
+    offenders = []
+    for path in sorted(pkg_dir.glob("pipeline_wan2_2*.py")):
+        text = path.read_text()
+        if "current_omni_platform.empty_cache()" in text:
+            offenders.append(path.name)
+        assert "release_request_cache(current_omni_platform)" in text, (
+            f"{path.name} does not release the cache through the shared helper"
+        )
+    assert offenders == [], f"request-path empty_cache called directly in: {offenders}"

--- a/vllm_omni/diffusion/models/wan2_2/device_cache.py
+++ b/vllm_omni/diffusion/models/wan2_2/device_cache.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Request-path device-cache release for the Wan2.2 pipelines."""
+
+from vllm_omni.platforms.interface import OmniPlatform
+
+
+def release_request_cache(platform: OmniPlatform) -> None:
+    """Return cached allocator blocks to the driver between pipeline stages.
+
+    The Wan2.2 pipelines call this on the request path (after denoising and
+    before VAE decoding, and between clips in S2V) to lower the peak before
+    the decoder allocates. Returning the blocks to the driver is not what
+    makes the freed memory reusable -- the caching allocator already hands
+    those blocks to the next allocation -- so on platforms where the call is
+    harmful it can be skipped without changing what the decoder can allocate.
+
+    It is harmful on XPU. Once the blocks are returned, the decoder's tensors
+    land at new device addresses, and the XPU collective backend maps the
+    peer segments those addresses belong to anew on every request without
+    ever unmapping the old ones. Measured on a 4-rank Wan2.2-TI2V-5B service
+    (SP4, no offload, 832x480x81 frames, 50 steps): host memory outside every
+    user-space and cgroup counter fell by 10.3 GB per request, linearly and
+    without a plateau, and came back only when the process exited. With this
+    single call skipped, seven consecutive requests held host memory flat
+    (227 -> 226 GB) at unchanged latency; a single-rank service never leaked,
+    and reusing the collectives' receive buffers alone did not help, because
+    the address churn comes from the cache release itself.
+
+    Every other platform keeps the previous behaviour byte for byte.
+
+    ``platform`` is passed in (normally ``current_omni_platform``) so each
+    pipeline module keeps owning its platform binding.
+
+    The ``is_available()`` check is kept from four of the five call sites and
+    now also applies to the fifth (the S2V offload branch, which called
+    ``empty_cache()`` unguarded); that is an extra gate on that one path, not a
+    removed one.
+    """
+    if not platform.is_available():
+        return
+    if platform.is_xpu():
+        return
+    platform.empty_cache()

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
@@ -32,6 +32,7 @@ from vllm_omni.diffusion.models.dmd2 import DMD2PipelineMixin
 from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin, _is_rank_zero
 from vllm_omni.diffusion.models.schedulers import FlowUniPCMultistepScheduler
+from vllm_omni.diffusion.models.wan2_2.device_cache import release_request_cache
 from vllm_omni.diffusion.models.wan2_2.scheduling_wan_euler import WanEulerScheduler
 from vllm_omni.diffusion.models.wan2_2.wan2_2_transformer import WanSelfAttention, WanTransformer3DModel
 from vllm_omni.diffusion.postprocess import interpolate_video_tensor
@@ -885,8 +886,7 @@ class Wan22Pipeline(
 
         # Wan2.2 is prone to out of memory errors when predicting large videos
         # so we empty the cache here to avoid OOM before vae decoding.
-        if current_omni_platform.is_available():
-            current_omni_platform.empty_cache()
+        release_request_cache(current_omni_platform)
         self._current_timestep = None
         if DEBUG_PERF:
             current_omni_platform.synchronize()

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
@@ -31,6 +31,7 @@ from vllm_omni.diffusion.models.dmd2 import DMD2PipelineMixin
 from vllm_omni.diffusion.models.interface import SupportImageInput, SupportsComponentDiscovery
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin, _is_rank_zero
 from vllm_omni.diffusion.models.utils import _load_json
+from vllm_omni.diffusion.models.wan2_2.device_cache import release_request_cache
 from vllm_omni.diffusion.models.wan2_2.pipeline_wan2_2 import (
     build_wan_scheduler,
     create_transformer_from_config,
@@ -715,8 +716,7 @@ class Wan22I2VPipeline(
 
         # Wan2.2 is prone to out of memory errors when predicting large videos
         # so we empty the cache here to avoid OOM before vae decoding.
-        if current_omni_platform.is_available():
-            current_omni_platform.empty_cache()
+        release_request_cache(current_omni_platform)
         self._current_timestep = None
 
         if DEBUG_PERF:

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_s2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_s2v.py
@@ -33,6 +33,7 @@ from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineL
 from vllm_omni.diffusion.models.interface import SupportAudioInput, SupportImageInput
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.models.schedulers import FlowUniPCMultistepScheduler
+from vllm_omni.diffusion.models.wan2_2.device_cache import release_request_cache
 from vllm_omni.diffusion.models.wan2_2.pipeline_wan2_2 import (
     load_transformer_config,
     load_wan_weights_with_optional_gate,
@@ -1403,7 +1404,7 @@ class Wan22S2VPipeline(
             # ---- Decode this clip ----
             if self.od_config.enable_cpu_offload and not getattr(self.od_config.parallel_config, "use_hsdp", False):
                 self.transformer.to("cpu")
-                current_omni_platform.empty_cache()
+                release_request_cache(current_omni_platform)
 
             if not (drop_first_motion and r == 0):
                 decode_latents = torch.cat([motion_latents, latents], dim=2)
@@ -1456,8 +1457,7 @@ class Wan22S2VPipeline(
             clips.append(clip_video.cpu())
 
             # Free VRAM between clips
-            if current_omni_platform.is_available():
-                current_omni_platform.empty_cache()
+            release_request_cache(current_omni_platform)
 
         # ---- Concatenate all clips ----
         output = torch.cat(clips, dim=2)  # [B, C, T_total, H, W]

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_vace.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_vace.py
@@ -25,6 +25,7 @@ from vllm.model_executor.layers.quantization.base_config import QuantizationConf
 
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.models.interface import SupportImageInput
+from vllm_omni.diffusion.models.wan2_2.device_cache import release_request_cache
 from vllm_omni.diffusion.models.wan2_2.pipeline_wan2_2 import (
     Wan22Pipeline,
     load_wan_weights_with_optional_gate,
@@ -717,8 +718,7 @@ class Wan22VACEPipeline(Wan22Pipeline, SupportImageInput):
 
         self._current_timestep = None
 
-        if current_omni_platform.is_available():
-            current_omni_platform.empty_cache()
+        release_request_cache(current_omni_platform)
 
         # Trim reference frames from output before decoding
         # (reference images were prepended as extra temporal frames)


### PR DESCRIPTION
## Purpose

**Problem:** the Wan2.2 pipelines call `empty_cache()` on the request path (after denoising in T2V/TI2V, I2V, VACE; between clips in S2V). The allocator already reuses those blocks, so the call does not change what the decoder can allocate; on XPU it makes the decoder's tensors land at new addresses each request and the collective backend maps new peer segments without unmapping the old ones, so device memory grows per request. A single-rank service never leaked, and reusing the receive buffers alone did not change the slope, which points at the cache release. (Mechanism inferred from these interventions.)

**Fix:** route the five call sites through `wan2_2/device_cache.release_request_cache()`, which skips the flush on XPU and keeps today's behaviour elsewhere. The S2V offload branch gains the same `is_available()` guard the other four already had.

## Test Plan

**Reproduce:** serve Wan2.2 T2V on multiple XPU cards, send serial requests, sample non-PyTorch device memory between requests.

```bash
pytest -q tests/diffusion/models/wan2_2/test_wan22_request_cache_release.py
```

**vLLM Version:** as pinned by `requirements/`. **vLLM-Omni Commit:** rebased onto current `main`.

## Test Result

CPU tests pass (helper flushes off XPU, skips on XPU and on an unavailable platform; a source-level guard fails if a pipeline calls `empty_cache()` directly again). On the XPU service the per-request growth stops; latency unchanged at about 50 s per request, output unchanged.

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

## Test Plan

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
