### PR TITLE
[Bugfix][Hardware][Intel] Reuse the all-gather landing buffer on XPU so its address is stable

### DIFF
--- a/tests/diffusion/distributed/test_allgather_buffer_reuse.py
+++ b/tests/diffusion/distributed/test_allgather_buffer_reuse.py
@@ -1,0 +1,339 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Tests for `GroupCoordinator.all_gather`'s reused landing buffer.
+
+Communication libraries register the device memory handed to them and keep that
+registration alive. Allocating a fresh output for every all-gather therefore
+leaks registrations whenever the caching allocator hands back a different
+address -- which any `empty_cache()` on the request path guarantees. The
+coordinator now lands the collective in a reused buffer and copies out, so the
+registered address is stable while callers keep owning their result.
+
+That reuse is gated on XPU, because the copy-out is not free and the address
+churn is specific to the XPU collective backend. These tests therefore drive
+both halves of the gate: the reuse bodies force the platform to report XPU, and
+`_body_non_xpu_path_unchanged` pins that every other platform still gets main's
+allocate-and-gather path with no landing buffer and no copy.
+
+These run on gloo/CPU (no accelerator), matching `test_comm.py`.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from vllm_omni.diffusion.distributed import group_coordinator as gc_module
+from vllm_omni.diffusion.distributed.group_coordinator import GroupCoordinator
+
+
+class _AsXPU:
+    """`current_omni_platform` stand-in that only overrides `is_xpu`.
+
+    The reuse path is XPU-gated, but nothing in it is device-specific -- CPU
+    tensors over gloo exercise the same code -- so the gate is flipped rather
+    than requiring an accelerator.
+    """
+
+    def __init__(self, real):
+        self._real = real
+
+    def is_xpu(self) -> bool:
+        return True
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+def _run(
+    body: Callable[[GroupCoordinator, int, int], None],
+    local_rank: int,
+    world_size: int,
+    master_port: int,
+    as_xpu: bool = True,
+) -> None:
+    """Build a gloo group and a coordinator directly.
+
+    Deliberately *not* via `init_distributed_environment`: that helper does
+    `get_rank() % get_device_count()` and therefore needs at least one visible
+    accelerator, which an L1 CPU runner does not have. Everything under test
+    here is device-agnostic -- CPU tensors over gloo exercise the same code
+    path -- so the coordinator is constructed directly and stays runnable with
+    zero accelerators.
+    """
+    for key, value in {
+        "RANK": str(local_rank),
+        "LOCAL_RANK": str(local_rank),
+        "WORLD_SIZE": str(world_size),
+        "MASTER_ADDR": "localhost",
+        "MASTER_PORT": str(master_port),
+    }.items():
+        os.environ[key] = value
+
+    dist.init_process_group(backend="gloo", init_method="env://", world_size=world_size, rank=local_rank)
+    real_platform = gc_module.current_omni_platform
+    if as_xpu:
+        gc_module.current_omni_platform = _AsXPU(real_platform)
+    try:
+        group = GroupCoordinator(
+            group_ranks=[list(range(world_size))],
+            local_rank=local_rank,
+            torch_distributed_backend="gloo",
+        )
+        body(group, local_rank, world_size)
+    finally:
+        gc_module.current_omni_platform = real_platform
+        dist.destroy_process_group()
+
+
+def _rank_tensor(local_rank: int, rows: int = 3, cols: int = 4) -> torch.Tensor:
+    """Rank-distinguishable payload, so a wrong gather cannot look right."""
+    return torch.full((rows, cols), float(local_rank + 1)) + torch.arange(rows * cols, dtype=torch.float32).reshape(
+        rows, cols
+    )
+
+
+def _expected(world_size: int, rows: int = 3, cols: int = 4) -> torch.Tensor:
+    return torch.cat([_rank_tensor(r, rows, cols) for r in range(world_size)], dim=0)
+
+
+# ---------------------------------------------------------------------------
+# worker bodies
+# ---------------------------------------------------------------------------
+
+
+def _body_parity(group: GroupCoordinator, local_rank: int, world_size: int) -> None:
+    """Reused buffer must produce exactly what a fresh allocation produces."""
+    out = group.all_gather(_rank_tensor(local_rank))
+    torch.testing.assert_close(out, _expected(world_size), rtol=0, atol=0)
+
+
+def _body_landing_address_is_stable(group: GroupCoordinator, local_rank: int, world_size: int) -> None:
+    """The property that actually fixes the leak: one registered address.
+
+    Three same-shape gathers must all land in the same buffer. Without reuse the
+    coordinator allocates a new output each time and this dict stays empty.
+    """
+    seen = []
+    for _ in range(3):
+        group.all_gather(_rank_tensor(local_rank))
+        buffers = group._all_gather_buffers
+        assert buffers, "reuse is enabled but no landing buffer was cached"
+        assert len(buffers) == 1, f"expected one buffer per (dtype, device), got {len(buffers)}"
+        seen.append(next(iter(buffers.values())).data_ptr())
+    assert len(set(seen)) == 1, f"landing buffer moved between calls: {seen}"
+
+
+def _body_result_is_private(group: GroupCoordinator, local_rank: int, world_size: int) -> None:
+    """Callers still own their result -- the copy-out must not be skipped.
+
+    A caller may hold the previous result across the next gather; if we handed
+    back the landing buffer itself, the second gather would rewrite the first
+    result in place.
+    """
+    first = group.all_gather(_rank_tensor(local_rank))
+    first_snapshot = first.clone()
+    first.mul_(-1.0)  # a caller mutating what it owns must not corrupt the buffer
+
+    second = group.all_gather(_rank_tensor(local_rank))
+    torch.testing.assert_close(second, _expected(world_size), rtol=0, atol=0)
+    torch.testing.assert_close(first, -first_snapshot, rtol=0, atol=0)
+    assert first.data_ptr() != second.data_ptr(), "two results must not alias each other"
+
+
+def _body_non_zero_dim(group: GroupCoordinator, local_rank: int, world_size: int) -> None:
+    """`dim != 0` reshapes the gathered result; reuse must not disturb it."""
+    out = group.all_gather(_rank_tensor(local_rank), dim=1)
+    expected = torch.cat([_rank_tensor(r) for r in range(world_size)], dim=1)
+    torch.testing.assert_close(out, expected, rtol=0, atol=0)
+
+
+def _body_separate_tensors(group: GroupCoordinator, local_rank: int, world_size: int) -> None:
+    """`separate_tensors=True` returns per-rank views; they must stay correct."""
+    parts = group.all_gather(_rank_tensor(local_rank), separate_tensors=True)
+    assert len(parts) == world_size
+    for rank, part in enumerate(parts):
+        torch.testing.assert_close(part, _rank_tensor(rank), rtol=0, atol=0)
+
+
+def _body_grows_for_larger_shape(group: GroupCoordinator, local_rank: int, world_size: int) -> None:
+    """A bigger gather grows the single buffer instead of adding another."""
+    group.all_gather(_rank_tensor(local_rank, rows=2))
+    small = next(iter(group._all_gather_buffers.values())).numel()
+    group.all_gather(_rank_tensor(local_rank, rows=8))
+    buffers = group._all_gather_buffers
+    assert len(buffers) == 1, f"buffer count must stay 1 per (dtype, device), got {len(buffers)}"
+    grown = next(iter(buffers.values())).numel()
+    assert grown > small, "buffer did not grow for the larger gather"
+    # Going back below the record high must not shrink or re-key the buffer:
+    # that is what bounds the residency by the largest gather instead of by the
+    # number of shapes, and what keeps the address stable afterwards.
+    group.all_gather(_rank_tensor(local_rank, rows=2))
+    buffers = group._all_gather_buffers
+    assert len(buffers) == 1, f"a smaller gather added a second buffer: {len(buffers)}"
+    assert next(iter(buffers.values())).numel() == grown, "buffer shrank below its record high"
+
+
+def _body_non_xpu_path_unchanged(group: GroupCoordinator, local_rank: int, world_size: int) -> None:
+    """Off XPU, `all_gather` must be exactly what main does.
+
+    Two properties together pin that: no landing buffer is ever created, and the
+    tensor handed back to the caller *is* the tensor the collective wrote into
+    -- i.e. there is no extra clone on the hot path.
+    """
+    assert not gc_module.current_omni_platform.is_xpu(), "this body must run with the gate closed"
+
+    real_all_gather_into_tensor = dist.all_gather_into_tensor
+    written_to: list[int] = []
+
+    def recording(output, input_, **kwargs):
+        written_to.append(output.data_ptr())
+        return real_all_gather_into_tensor(output, input_, **kwargs)
+
+    dist.all_gather_into_tensor = recording
+    try:
+        for _ in range(3):
+            out = group.all_gather(_rank_tensor(local_rank))
+            torch.testing.assert_close(out, _expected(world_size), rtol=0, atol=0)
+            assert out.data_ptr() == written_to[-1], "off XPU the result must not be a copy"
+            assert group._all_gather_buffers is None, "off XPU no landing buffer may be allocated"
+    finally:
+        dist.all_gather_into_tensor = real_all_gather_into_tensor
+
+    # Note deliberately *not* asserted: that the three outputs sit at three
+    # distinct addresses. Off XPU each call does allocate afresh, but the
+    # caching allocator is free to hand back the block the previous result
+    # released, so identical addresses are legal and would make this flaky.
+
+
+# ---------------------------------------------------------------------------
+# spawn wrappers
+# ---------------------------------------------------------------------------
+
+
+def _body_pipeline_subclass_inherits_all_gather(group: GroupCoordinator, local_rank: int, world_size: int) -> None:
+    """The PP coordinator inherits `all_gather` without calling `super().__init__`.
+
+    `PipelineGroupCoordinator` re-implements `__init__`, so any per-instance
+    state the base constructor sets up is absent there while the inherited
+    `all_gather` still runs. Build one through the real factory and exercise the
+    inherited method.
+    """
+    from vllm_omni.diffusion.distributed.parallel_state import init_model_parallel_group
+
+    pp_group = init_model_parallel_group(
+        group_ranks=[list(range(world_size))],
+        local_rank=local_rank,
+        backend="gloo",
+        parallel_mode="pipeline",
+    )
+    out = pp_group.all_gather(_rank_tensor(local_rank))
+    torch.testing.assert_close(out, _expected(world_size), rtol=0, atol=0)
+
+
+_BODIES = {
+    "parity": _body_parity,
+    "pipeline": _body_pipeline_subclass_inherits_all_gather,
+    "stable": _body_landing_address_is_stable,
+    "private": _body_result_is_private,
+    "dim1": _body_non_zero_dim,
+    "separate": _body_separate_tensors,
+    "grow": _body_grows_for_larger_shape,
+    "non_xpu": _body_non_xpu_path_unchanged,
+}
+
+
+def _entry(local_rank: int, world_size: int, master_port: int, body_name: str, as_xpu: bool) -> None:
+    _run(_BODIES[body_name], local_rank, world_size, master_port, as_xpu=as_xpu)
+
+
+def _spawn(world_size: int, master_port: int, body_name: str, as_xpu: bool = True) -> None:
+    torch.multiprocessing.spawn(
+        _entry,
+        args=(world_size, master_port, body_name, as_xpu),
+        nprocs=world_size,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CPU: gloo collectives on CPU tensors (no accelerator)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.core_model
+@pytest.mark.diffusion
+@pytest.mark.cpu
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_all_gather_matches_fresh_allocation(world_size: int):
+    _spawn(world_size, 29660 + world_size, "parity")
+
+
+@pytest.mark.core_model
+@pytest.mark.diffusion
+@pytest.mark.cpu
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_pipeline_coordinator_inherits_all_gather(world_size: int):
+    """MRO regression: the subclass that skips `super().__init__` must still work."""
+    _spawn(world_size, 29740 + world_size, "pipeline")
+
+
+@pytest.mark.core_model
+@pytest.mark.diffusion
+@pytest.mark.cpu
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_landing_buffer_address_is_stable(world_size: int):
+    _spawn(world_size, 29680 + world_size, "stable")
+
+
+@pytest.mark.core_model
+@pytest.mark.diffusion
+@pytest.mark.cpu
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_result_does_not_alias_landing_buffer(world_size: int):
+    _spawn(world_size, 29690 + world_size, "private")
+
+
+@pytest.mark.core_model
+@pytest.mark.diffusion
+@pytest.mark.cpu
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_all_gather_non_zero_dim(world_size: int):
+    _spawn(world_size, 29700 + world_size, "dim1")
+
+
+@pytest.mark.core_model
+@pytest.mark.diffusion
+@pytest.mark.cpu
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_all_gather_separate_tensors(world_size: int):
+    _spawn(world_size, 29710 + world_size, "separate")
+
+
+@pytest.mark.core_model
+@pytest.mark.diffusion
+@pytest.mark.cpu
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_landing_buffer_grows_instead_of_multiplying(world_size: int):
+    _spawn(world_size, 29720 + world_size, "grow")
+
+
+@pytest.mark.core_model
+@pytest.mark.diffusion
+@pytest.mark.cpu
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_non_xpu_all_gather_is_unchanged(world_size: int):
+    """The other half of the gate: no landing buffer and no copy off XPU."""
+    _spawn(world_size, 29750 + world_size, "non_xpu", as_xpu=False)
+
+
+@pytest.mark.core_model
+@pytest.mark.diffusion
+@pytest.mark.cpu
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_non_xpu_all_gather_matches_fresh_allocation(world_size: int):
+    """Correctness parity on the ungated path, for completeness."""
+    _spawn(world_size, 29760 + world_size, "parity", as_xpu=False)

--- a/tests/diffusion/distributed/test_allgather_buffer_reuse.py
+++ b/tests/diffusion/distributed/test_allgather_buffer_reuse.py
@@ -1,26 +1,32 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
-"""Tests for `GroupCoordinator.all_gather`'s reused landing buffer.
+"""Tests for the XPU all-gather landing buffer in the platform layer.
 
 Communication libraries register the device memory handed to them and keep that
 registration alive. Allocating a fresh output for every all-gather therefore
 leaks registrations whenever the caching allocator hands back a different
-address -- which any `empty_cache()` on the request path guarantees. The
-coordinator now lands the collective in a reused buffer and copies out, so the
-registered address is stable while callers keep owning their result.
+address -- which any `empty_cache()` on the request path guarantees.
+`XPUOmniPlatform.all_gather_into_tensor` lands the collective in a reused
+buffer and copies out, so the registered address is stable while callers keep
+owning their result.
 
-That reuse is gated on XPU, because the copy-out is not free and the address
-churn is specific to the XPU collective backend. These tests therefore drive
-both halves of the gate: the reuse bodies force the platform to report XPU, and
-`_body_non_xpu_path_unchanged` pins that every other platform still gets main's
-allocate-and-gather path with no landing buffer and no copy.
+That reuse lives on the XPU platform only, because the copy-out is not free and
+the address churn is specific to the XPU collective backend. These tests
+therefore drive both platforms: the reuse bodies point
+`group_coordinator.current_omni_platform` at `XPUOmniPlatform`, and
+`_body_default_path_unchanged` pins that the default `OmniPlatform`
+implementation still allocates and gathers with no landing buffer and no copy.
 
 These run on gloo/CPU (no accelerator), matching `test_comm.py`.
 """
 
 from __future__ import annotations
 
+import contextlib
+import importlib.abc
+import importlib.machinery
 import os
+import sys
 from collections.abc import Callable
 
 import pytest
@@ -29,24 +35,72 @@ import torch.distributed as dist
 
 from vllm_omni.diffusion.distributed import group_coordinator as gc_module
 from vllm_omni.diffusion.distributed.group_coordinator import GroupCoordinator
+from vllm_omni.platforms.interface import OmniPlatform
+
+_REAL_PLATFORM = gc_module.current_omni_platform
 
 
-class _AsXPU:
-    """`current_omni_platform` stand-in that only overrides `is_xpu`.
+class _AbsentKernelsFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    """Satisfy `vllm_xpu_kernels` imports with empty modules.
 
-    The reuse path is XPU-gated, but nothing in it is device-specific -- CPU
-    tensors over gloo exercise the same code -- so the gate is flipped rather
-    than requiring an accelerator.
+    `vllm_omni.platforms.xpu.platform` imports vLLM's `XPUPlatform`, which
+    imports the compiled `vllm_xpu_kernels` extensions at module scope. Those
+    ship only in an XPU build, so on a CPU runner the real class is otherwise
+    unimportable. Nothing under test touches a kernel -- the landing buffer is
+    plain `torch.empty`/`view`/`clone` and runs on CPU tensors over gloo -- so
+    stubbing the missing extensions keeps the class under test the real
+    `XPUOmniPlatform` rather than a re-implementation of it.
     """
 
-    def __init__(self, real):
-        self._real = real
+    _NAME = "vllm_xpu_kernels"
 
-    def is_xpu(self) -> bool:
-        return True
+    def find_spec(self, name, path=None, target=None):
+        if name == self._NAME or name.startswith(f"{self._NAME}."):
+            return importlib.machinery.ModuleSpec(name, self, is_package=True)
+        return None
 
-    def __getattr__(self, name):
-        return getattr(self._real, name)
+    def create_module(self, spec):
+        return None
+
+    def exec_module(self, module):
+        pass
+
+
+def _xpu_platform() -> type[OmniPlatform]:
+    """Import the real `XPUOmniPlatform`, stubbing absent XPU kernel packages.
+
+    Called inside the spawned worker so the module-scope side effects of
+    `vllm_omni.platforms.xpu.platform` (an accelerator memory-info override and
+    a sampler env var) stay in the child process.
+    """
+    try:
+        from vllm_omni.platforms.xpu.platform import XPUOmniPlatform
+    except ModuleNotFoundError:
+        sys.meta_path.insert(0, _AbsentKernelsFinder())
+        from vllm_omni.platforms.xpu.platform import XPUOmniPlatform
+
+    return XPUOmniPlatform
+
+
+@contextlib.contextmanager
+def _platform(platform):
+    """Point the coordinator's module-level platform at `platform`.
+
+    The hooks are classmethods, so the class itself is everything the
+    coordinator needs -- no instance and no accelerator. Yields the platform it
+    replaced and puts it back on exit.
+    """
+    saved = gc_module.current_omni_platform
+    gc_module.current_omni_platform = platform
+    try:
+        yield saved
+    finally:
+        gc_module.current_omni_platform = saved
+
+
+def _buffers() -> dict:
+    """The XPU platform's landing buffers -- class state, not per coordinator."""
+    return _xpu_platform()._all_gather_buffers
 
 
 def _run(
@@ -64,6 +118,11 @@ def _run(
     here is device-agnostic -- CPU tensors over gloo exercise the same code
     path -- so the coordinator is constructed directly and stays runnable with
     zero accelerators.
+
+    The coordinator is built *before* the platform is swapped: `__init__` asks
+    the platform for a torch device and the XPU answer is an `xpu` device this
+    runner has none of. Only `all_gather` runs under the platform being tested,
+    which is the code path these tests are about.
     """
     for key, value in {
         "RANK": str(local_rank),
@@ -75,18 +134,19 @@ def _run(
         os.environ[key] = value
 
     dist.init_process_group(backend="gloo", init_method="env://", world_size=world_size, rank=local_rank)
-    real_platform = gc_module.current_omni_platform
-    if as_xpu:
-        gc_module.current_omni_platform = _AsXPU(real_platform)
+    xpu_platform = _xpu_platform()
+    # Class state must not carry into (or out of) a case.
+    xpu_platform.reset_all_gather_buffers()
     try:
         group = GroupCoordinator(
             group_ranks=[list(range(world_size))],
             local_rank=local_rank,
             torch_distributed_backend="gloo",
         )
-        body(group, local_rank, world_size)
+        with _platform(xpu_platform if as_xpu else OmniPlatform):
+            body(group, local_rank, world_size)
     finally:
-        gc_module.current_omni_platform = real_platform
+        xpu_platform.reset_all_gather_buffers()
         dist.destroy_process_group()
 
 
@@ -116,16 +176,39 @@ def _body_landing_address_is_stable(group: GroupCoordinator, local_rank: int, wo
     """The property that actually fixes the leak: one registered address.
 
     Three same-shape gathers must all land in the same buffer. Without reuse the
-    coordinator allocates a new output each time and this dict stays empty.
+    platform allocates a new output each time and this dict stays empty.
     """
     seen = []
     for _ in range(3):
         group.all_gather(_rank_tensor(local_rank))
-        buffers = group._all_gather_buffers
+        buffers = _buffers()
         assert buffers, "reuse is enabled but no landing buffer was cached"
         assert len(buffers) == 1, f"expected one buffer per (dtype, device), got {len(buffers)}"
         seen.append(next(iter(buffers.values())).data_ptr())
     assert len(set(seen)) == 1, f"landing buffer moved between calls: {seen}"
+
+
+def _body_reset_drops_the_buffers(group: GroupCoordinator, local_rank: int, world_size: int) -> None:
+    """`reset_all_gather_buffers` must really drop the class state.
+
+    After the reset the dict is empty and the next gather lands somewhere else;
+    a reset that only looked like it cleared would keep serving the old buffer.
+    The old buffer is held alive on purpose, so the allocator cannot hand its
+    address straight back and make the second half of this vacuous.
+    """
+    platform = _xpu_platform()
+    group.all_gather(_rank_tensor(local_rank))
+    kept_alive = next(iter(_buffers().values()))
+    first_ptr = kept_alive.data_ptr()
+
+    platform.reset_all_gather_buffers()
+    assert _buffers() == {}, "reset left landing buffers behind"
+
+    group.all_gather(_rank_tensor(local_rank))
+    buffers = _buffers()
+    assert len(buffers) == 1, f"the gather after reset must cache one buffer, got {len(buffers)}"
+    assert next(iter(buffers.values())).data_ptr() != first_ptr, "the gather after reset reused the dropped buffer"
+    assert kept_alive.numel() > 0, "kept_alive must stay referenced until here"
 
 
 def _body_result_is_private(group: GroupCoordinator, local_rank: int, world_size: int) -> None:
@@ -163,9 +246,9 @@ def _body_separate_tensors(group: GroupCoordinator, local_rank: int, world_size:
 def _body_grows_for_larger_shape(group: GroupCoordinator, local_rank: int, world_size: int) -> None:
     """A bigger gather grows the single buffer instead of adding another."""
     group.all_gather(_rank_tensor(local_rank, rows=2))
-    small = next(iter(group._all_gather_buffers.values())).numel()
+    small = next(iter(_buffers().values())).numel()
     group.all_gather(_rank_tensor(local_rank, rows=8))
-    buffers = group._all_gather_buffers
+    buffers = _buffers()
     assert len(buffers) == 1, f"buffer count must stay 1 per (dtype, device), got {len(buffers)}"
     grown = next(iter(buffers.values())).numel()
     assert grown > small, "buffer did not grow for the larger gather"
@@ -173,19 +256,20 @@ def _body_grows_for_larger_shape(group: GroupCoordinator, local_rank: int, world
     # that is what bounds the residency by the largest gather instead of by the
     # number of shapes, and what keeps the address stable afterwards.
     group.all_gather(_rank_tensor(local_rank, rows=2))
-    buffers = group._all_gather_buffers
+    buffers = _buffers()
     assert len(buffers) == 1, f"a smaller gather added a second buffer: {len(buffers)}"
     assert next(iter(buffers.values())).numel() == grown, "buffer shrank below its record high"
 
 
-def _body_non_xpu_path_unchanged(group: GroupCoordinator, local_rank: int, world_size: int) -> None:
+def _body_default_path_unchanged(group: GroupCoordinator, local_rank: int, world_size: int) -> None:
     """Off XPU, `all_gather` must be exactly what main does.
 
-    Two properties together pin that: no landing buffer is ever created, and the
-    tensor handed back to the caller *is* the tensor the collective wrote into
-    -- i.e. there is no extra clone on the hot path.
+    Two properties together pin that: the default `OmniPlatform` implementation
+    creates no landing buffer, and the tensor handed back to the caller *is* the
+    tensor the collective wrote into -- i.e. there is no extra clone on the hot
+    path.
     """
-    assert not gc_module.current_omni_platform.is_xpu(), "this body must run with the gate closed"
+    assert gc_module.current_omni_platform is OmniPlatform, "this body must run on the default implementation"
 
     real_all_gather_into_tensor = dist.all_gather_into_tensor
     written_to: list[int] = []
@@ -200,7 +284,7 @@ def _body_non_xpu_path_unchanged(group: GroupCoordinator, local_rank: int, world
             out = group.all_gather(_rank_tensor(local_rank))
             torch.testing.assert_close(out, _expected(world_size), rtol=0, atol=0)
             assert out.data_ptr() == written_to[-1], "off XPU the result must not be a copy"
-            assert group._all_gather_buffers is None, "off XPU no landing buffer may be allocated"
+            assert _buffers() == {}, "off XPU no landing buffer may be allocated"
     finally:
         dist.all_gather_into_tensor = real_all_gather_into_tensor
 
@@ -210,40 +294,45 @@ def _body_non_xpu_path_unchanged(group: GroupCoordinator, local_rank: int, world
     # released, so identical addresses are legal and would make this flaky.
 
 
-# ---------------------------------------------------------------------------
-# spawn wrappers
-# ---------------------------------------------------------------------------
-
-
 def _body_pipeline_subclass_inherits_all_gather(group: GroupCoordinator, local_rank: int, world_size: int) -> None:
     """The PP coordinator inherits `all_gather` without calling `super().__init__`.
 
     `PipelineGroupCoordinator` re-implements `__init__`, so any per-instance
     state the base constructor sets up is absent there while the inherited
-    `all_gather` still runs. Build one through the real factory and exercise the
-    inherited method.
+    `all_gather` still runs -- which is exactly why the landing buffer belongs
+    to the platform class rather than to a coordinator. Build one through the
+    real factory (with the real platform restored, since the factory asks it for
+    a torch device) and exercise the inherited method.
     """
     from vllm_omni.diffusion.distributed.parallel_state import init_model_parallel_group
 
-    pp_group = init_model_parallel_group(
-        group_ranks=[list(range(world_size))],
-        local_rank=local_rank,
-        backend="gloo",
-        parallel_mode="pipeline",
-    )
+    with _platform(_REAL_PLATFORM):
+        pp_group = init_model_parallel_group(
+            group_ranks=[list(range(world_size))],
+            local_rank=local_rank,
+            backend="gloo",
+            parallel_mode="pipeline",
+        )
     out = pp_group.all_gather(_rank_tensor(local_rank))
     torch.testing.assert_close(out, _expected(world_size), rtol=0, atol=0)
+    assert len(_buffers()) == 1, "the inherited all_gather must use the platform's landing buffer"
+
+
+# ---------------------------------------------------------------------------
+# spawn wrappers
+# ---------------------------------------------------------------------------
 
 
 _BODIES = {
     "parity": _body_parity,
     "pipeline": _body_pipeline_subclass_inherits_all_gather,
     "stable": _body_landing_address_is_stable,
+    "reset": _body_reset_drops_the_buffers,
     "private": _body_result_is_private,
     "dim1": _body_non_zero_dim,
     "separate": _body_separate_tensors,
     "grow": _body_grows_for_larger_shape,
-    "non_xpu": _body_non_xpu_path_unchanged,
+    "default": _body_default_path_unchanged,
 }
 
 
@@ -293,6 +382,15 @@ def test_landing_buffer_address_is_stable(world_size: int):
 @pytest.mark.diffusion
 @pytest.mark.cpu
 @pytest.mark.parametrize("world_size", [2, 4])
+def test_reset_all_gather_buffers_drops_them(world_size: int):
+    """The process-level teardown hook must free the class state, not fake it."""
+    _spawn(world_size, 29770 + world_size, "reset")
+
+
+@pytest.mark.core_model
+@pytest.mark.diffusion
+@pytest.mark.cpu
+@pytest.mark.parametrize("world_size", [2, 4])
 def test_result_does_not_alias_landing_buffer(world_size: int):
     _spawn(world_size, 29690 + world_size, "private")
 
@@ -325,15 +423,15 @@ def test_landing_buffer_grows_instead_of_multiplying(world_size: int):
 @pytest.mark.diffusion
 @pytest.mark.cpu
 @pytest.mark.parametrize("world_size", [2, 4])
-def test_non_xpu_all_gather_is_unchanged(world_size: int):
-    """The other half of the gate: no landing buffer and no copy off XPU."""
-    _spawn(world_size, 29750 + world_size, "non_xpu", as_xpu=False)
+def test_default_platform_all_gather_is_unchanged(world_size: int):
+    """The other half: no landing buffer and no copy on the default platform."""
+    _spawn(world_size, 29750 + world_size, "default", as_xpu=False)
 
 
 @pytest.mark.core_model
 @pytest.mark.diffusion
 @pytest.mark.cpu
 @pytest.mark.parametrize("world_size", [2, 4])
-def test_non_xpu_all_gather_matches_fresh_allocation(world_size: int):
-    """Correctness parity on the ungated path, for completeness."""
+def test_default_platform_all_gather_matches_fresh_allocation(world_size: int):
+    """Correctness parity on the default path, for completeness."""
     _spawn(world_size, 29760 + world_size, "parity", as_xpu=False)

--- a/vllm_omni/diffusion/distributed/group_coordinator.py
+++ b/vllm_omni/diffusion/distributed/group_coordinator.py
@@ -96,15 +96,6 @@ class GroupCoordinator:
     cpu_group: ProcessGroup  # group for CPU communication
     device_group: ProcessGroup  # group for device communication
 
-    # One flat all-gather landing buffer per (dtype, device); see
-    # `_all_gather_buffer`. Declared here rather than assigned in `__init__`
-    # because `PipelineGroupCoordinator` re-implements `__init__` without
-    # calling `super().__init__()` while still inheriting `all_gather`, so
-    # per-instance state created only in the base constructor would be missing
-    # there. The dict is built lazily per instance -- this class attribute is
-    # only the `None` sentinel and is never mutated.
-    _all_gather_buffers: dict[tuple[torch.dtype, torch.device], torch.Tensor] | None = None
-
     def __init__(
         self,
         group_ranks: list[list[int]],
@@ -133,55 +124,6 @@ class GroupCoordinator:
         assert self.device_group is not None
 
         self.device = current_omni_platform.get_torch_device(local_rank)
-
-    def _all_gather_buffer(self, numel: int, dtype: torch.dtype, device: torch.device) -> torch.Tensor:
-        """Return a stable, reused landing buffer of `numel` elements.
-
-        Allocating a fresh output per call means the collective sees a new
-        device address whenever the caching allocator has returned segments to
-        the driver, which any `empty_cache()` on the request path does. Measured
-        on XPU with an otherwise idle service, that came with ~1.16 GB per
-        request of linear growth outside PyTorch's own accounting
-        (`card_used - memory_reserved`), invisible to `memory_allocated` and
-        `memory_reserved`; suppressing those `empty_cache()` calls removed both
-        the new addresses and the growth. The registrations a communication
-        library keeps for the memory it is handed are the likely mechanism --
-        an inference from that intervention, not something read out of a driver
-        registry. All-gather is one share of that total, not all of it.
-
-        The same reasoning already drives the pre-allocated shard buffers in
-        `offloader/distributed_layerwise_backend.py`, whose docstring puts it as
-        "the same device address is reused for every layer's AllGather so HCCL
-        can reuse its internal communication buffers".
-
-        One flat buffer per (dtype, device) is kept and grown monotonically, so
-        the residency is bounded by the largest gather seen rather than by the
-        number of distinct shapes. Note what that guarantees: once a
-        dtype/device has seen its largest gather, every gather that does not
-        exceed it reuses one address. A new record high still reallocates once,
-        so the address count is bounded by the number of record highs rather
-        than fixed at one.
-
-        This is only reached on XPU (see `all_gather`), because the address
-        churn it defends against is specific to the XPU collective backend and
-        the copy-out it requires is not free. Every other platform keeps main's
-        allocate-a-fresh-output path.
-
-        The slot is shared, so this assumes the coordinator is driven from a
-        single execution stream -- which is what the diffusion worker does
-        today: forwards run on one busy-loop thread and the async output thread
-        issues no collectives. Concurrent callers on separate streams would need
-        per-stream landings or an event, not just this dict.
-        """
-        buffers = self._all_gather_buffers
-        if buffers is None:
-            buffers = self._all_gather_buffers = {}
-        key = (dtype, device)
-        buffer = buffers.get(key)
-        if buffer is None or buffer.numel() < numel:
-            buffer = torch.empty(numel, dtype=dtype, device=device)
-            buffers[key] = buffer
-        return buffer[:numel]
 
     @property
     def first_rank(self):
@@ -275,24 +217,10 @@ class GroupCoordinator:
         if dim < 0:
             # Convert negative dim to positive.
             dim += input_.dim()
-        # Allocate output tensor.
+        # Sizes for the `dim != 0` reshape below.
         input_size = list(input_.size())
         input_size[0] *= world_size
-        if current_omni_platform.is_xpu():
-            # XPU only. Land the collective in a reused buffer so its device
-            # address stays stable across requests (see `_all_gather_buffer`),
-            # then hand the caller its own tensor. The copy keeps the previous
-            # contract -- callers own the result and may hold or mutate it --
-            # and the copy's memory is never seen by the communication library,
-            # so it costs no registration. Every other platform keeps main's
-            # allocate-and-gather path exactly, so this hot path pays no extra
-            # copy where the address churn is not a problem.
-            landing = self._all_gather_buffer(input_.numel() * world_size, input_.dtype, input_.device).view(input_size)
-            torch.distributed.all_gather_into_tensor(landing, input_.contiguous(), group=group)
-            output_tensor = landing.clone()
-        else:
-            output_tensor = torch.empty(input_size, dtype=input_.dtype, device=input_.device)
-            torch.distributed.all_gather_into_tensor(output_tensor, input_.contiguous(), group=group)
+        output_tensor = current_omni_platform.all_gather_into_tensor(input_, world_size, group)
         if dim != 0:
             input_size[0] //= world_size
             output_tensor = output_tensor.reshape(
@@ -686,8 +614,6 @@ class GroupCoordinator:
         if self.cpu_group is not None:
             torch.distributed.destroy_process_group(self.cpu_group)
             self.cpu_group = None
-        # Drop the all-gather landing buffers with the group that used them.
-        self._all_gather_buffers = None
 
 
 class PipelineGroupCoordinator(GroupCoordinator):

--- a/vllm_omni/diffusion/distributed/group_coordinator.py
+++ b/vllm_omni/diffusion/distributed/group_coordinator.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 # Copyright 2024 xDiT team.
 # Adapted from
 # https://github.com/vllm-project/vllm/blob/main/vllm/distributed/parallel_state.py
@@ -94,6 +96,15 @@ class GroupCoordinator:
     cpu_group: ProcessGroup  # group for CPU communication
     device_group: ProcessGroup  # group for device communication
 
+    # One flat all-gather landing buffer per (dtype, device); see
+    # `_all_gather_buffer`. Declared here rather than assigned in `__init__`
+    # because `PipelineGroupCoordinator` re-implements `__init__` without
+    # calling `super().__init__()` while still inheriting `all_gather`, so
+    # per-instance state created only in the base constructor would be missing
+    # there. The dict is built lazily per instance -- this class attribute is
+    # only the `None` sentinel and is never mutated.
+    _all_gather_buffers: dict[tuple[torch.dtype, torch.device], torch.Tensor] | None = None
+
     def __init__(
         self,
         group_ranks: list[list[int]],
@@ -122,6 +133,55 @@ class GroupCoordinator:
         assert self.device_group is not None
 
         self.device = current_omni_platform.get_torch_device(local_rank)
+
+    def _all_gather_buffer(self, numel: int, dtype: torch.dtype, device: torch.device) -> torch.Tensor:
+        """Return a stable, reused landing buffer of `numel` elements.
+
+        Allocating a fresh output per call means the collective sees a new
+        device address whenever the caching allocator has returned segments to
+        the driver, which any `empty_cache()` on the request path does. Measured
+        on XPU with an otherwise idle service, that came with ~1.16 GB per
+        request of linear growth outside PyTorch's own accounting
+        (`card_used - memory_reserved`), invisible to `memory_allocated` and
+        `memory_reserved`; suppressing those `empty_cache()` calls removed both
+        the new addresses and the growth. The registrations a communication
+        library keeps for the memory it is handed are the likely mechanism --
+        an inference from that intervention, not something read out of a driver
+        registry. All-gather is one share of that total, not all of it.
+
+        The same reasoning already drives the pre-allocated shard buffers in
+        `offloader/distributed_layerwise_backend.py`, whose docstring puts it as
+        "the same device address is reused for every layer's AllGather so HCCL
+        can reuse its internal communication buffers".
+
+        One flat buffer per (dtype, device) is kept and grown monotonically, so
+        the residency is bounded by the largest gather seen rather than by the
+        number of distinct shapes. Note what that guarantees: once a
+        dtype/device has seen its largest gather, every gather that does not
+        exceed it reuses one address. A new record high still reallocates once,
+        so the address count is bounded by the number of record highs rather
+        than fixed at one.
+
+        This is only reached on XPU (see `all_gather`), because the address
+        churn it defends against is specific to the XPU collective backend and
+        the copy-out it requires is not free. Every other platform keeps main's
+        allocate-a-fresh-output path.
+
+        The slot is shared, so this assumes the coordinator is driven from a
+        single execution stream -- which is what the diffusion worker does
+        today: forwards run on one busy-loop thread and the async output thread
+        issues no collectives. Concurrent callers on separate streams would need
+        per-stream landings or an event, not just this dict.
+        """
+        buffers = self._all_gather_buffers
+        if buffers is None:
+            buffers = self._all_gather_buffers = {}
+        key = (dtype, device)
+        buffer = buffers.get(key)
+        if buffer is None or buffer.numel() < numel:
+            buffer = torch.empty(numel, dtype=dtype, device=device)
+            buffers[key] = buffer
+        return buffer[:numel]
 
     @property
     def first_rank(self):
@@ -218,9 +278,21 @@ class GroupCoordinator:
         # Allocate output tensor.
         input_size = list(input_.size())
         input_size[0] *= world_size
-        output_tensor = torch.empty(input_size, dtype=input_.dtype, device=input_.device)
-        # All-gather.
-        torch.distributed.all_gather_into_tensor(output_tensor, input_.contiguous(), group=group)
+        if current_omni_platform.is_xpu():
+            # XPU only. Land the collective in a reused buffer so its device
+            # address stays stable across requests (see `_all_gather_buffer`),
+            # then hand the caller its own tensor. The copy keeps the previous
+            # contract -- callers own the result and may hold or mutate it --
+            # and the copy's memory is never seen by the communication library,
+            # so it costs no registration. Every other platform keeps main's
+            # allocate-and-gather path exactly, so this hot path pays no extra
+            # copy where the address churn is not a problem.
+            landing = self._all_gather_buffer(input_.numel() * world_size, input_.dtype, input_.device).view(input_size)
+            torch.distributed.all_gather_into_tensor(landing, input_.contiguous(), group=group)
+            output_tensor = landing.clone()
+        else:
+            output_tensor = torch.empty(input_size, dtype=input_.dtype, device=input_.device)
+            torch.distributed.all_gather_into_tensor(output_tensor, input_.contiguous(), group=group)
         if dim != 0:
             input_size[0] //= world_size
             output_tensor = output_tensor.reshape(
@@ -614,6 +686,8 @@ class GroupCoordinator:
         if self.cpu_group is not None:
             torch.distributed.destroy_process_group(self.cpu_group)
             self.cpu_group = None
+        # Drop the all-gather landing buffers with the group that used them.
+        self._all_gather_buffers = None
 
 
 class PipelineGroupCoordinator(GroupCoordinator):

--- a/vllm_omni/diffusion/distributed/parallel_state.py
+++ b/vllm_omni/diffusion/distributed/parallel_state.py
@@ -1063,6 +1063,14 @@ def destroy_distributed_environment():
     _WORLD = None
     if torch.distributed.is_initialized():
         torch.distributed.destroy_process_group()
+    # The all-gather landing buffers a platform may keep are process-level
+    # state shared by every coordinator, so they are dropped here -- the one
+    # teardown point reached after the world group is gone -- rather than in
+    # `GroupCoordinator.destroy` (which runs per group, and would free memory
+    # still in use by the groups that outlive it) or in
+    # `destroy_model_parallel` (which is also called on the init error path
+    # while `_WORLD` stays alive).
+    current_omni_platform.reset_all_gather_buffers()
 
 
 def destroy_distributed_env():

--- a/vllm_omni/platforms/interface.py
+++ b/vllm_omni/platforms/interface.py
@@ -274,6 +274,22 @@ class OmniPlatform(Platform):
     def synchronize(cls) -> None:
         raise NotImplementedError
 
+    # ── Distributed collectives ──
+
+    @classmethod
+    def all_gather_into_tensor(cls, input_: torch.Tensor, world_size: int, group) -> torch.Tensor:
+        """Run all-gather and return an output tensor the caller owns."""
+        output_size = list(input_.size())
+        output_size[0] *= world_size
+        output = torch.empty(output_size, dtype=input_.dtype, device=input_.device)
+        torch.distributed.all_gather_into_tensor(output, input_.contiguous(), group=group)
+        return output
+
+    @classmethod
+    def reset_all_gather_buffers(cls) -> None:
+        """Drop any buffers ``all_gather_into_tensor`` keeps. No-op by default."""
+        pass
+
     # ── Async diffusion output: cross-stream sync ──
 
     @classmethod

--- a/vllm_omni/platforms/xpu/platform.py
+++ b/vllm_omni/platforms/xpu/platform.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 import os
+from typing import ClassVar
 
 import torch
 from vllm.config import VllmConfig
@@ -35,6 +36,49 @@ class XPUOmniPlatform(OmniPlatform, XPUPlatform):
     def __init__(self):
         super().__init__()
         apply_patches()
+
+    # One flat all-gather landing buffer per (dtype, device), held on the class
+    # so every coordinator in the process lands at the same address; see
+    # `all_gather_into_tensor`.
+    _all_gather_buffers: ClassVar[dict[tuple[torch.dtype, torch.device], torch.Tensor]] = {}
+
+    @classmethod
+    def all_gather_into_tensor(cls, input_: torch.Tensor, world_size: int, group) -> torch.Tensor:
+        """All-gather into a reused landing buffer, returning a private copy.
+
+        A fresh output per call means the collective sees a new receive address
+        after any request-path `empty_cache()`, and the driver-side registration
+        the communication library keeps for each such address is likely never
+        reclaimed -- an inference from intervention experiments (B70, 8 cards,
+        torch 2.13.0+xpu, xccl), not something read out of a driver registry. A
+        model-free 2x2 sandbox separated the factors: changing the collective
+        API does not help, reusing the receive buffer does. In an H3 server A/B
+        it moved per-request growth outside PyTorch's accounting
+        (`card_used - memory_reserved`) from 1726 MiB to 1626 MiB: all-gather is
+        one share of that total, not all of it.
+
+        One buffer per (dtype, device), grown monotonically, so residency is
+        bounded by the largest gather seen and the address count by the number
+        of record highs. `clone()` keeps the caller owning its result, and the
+        clone's memory is never handed to the library. The slot is shared, so
+        this assumes one execution stream per process, which is what the
+        diffusion worker does today.
+        """
+        output_size = list(input_.size())
+        output_size[0] *= world_size
+        numel = input_.numel() * world_size
+        key = (input_.dtype, input_.device)
+        buffer = cls._all_gather_buffers.get(key)
+        if buffer is None or buffer.numel() < numel:
+            buffer = torch.empty(numel, dtype=input_.dtype, device=input_.device)
+            cls._all_gather_buffers[key] = buffer
+        landing = buffer[:numel].view(output_size)
+        torch.distributed.all_gather_into_tensor(landing, input_.contiguous(), group=group)
+        return landing.clone()
+
+    @classmethod
+    def reset_all_gather_buffers(cls) -> None:
+        cls._all_gather_buffers.clear()
 
     @classmethod
     def get_omni_ar_worker_cls(cls) -> str:


### PR DESCRIPTION
## Purpose

**Problem:** `GroupCoordinator.all_gather` allocates a fresh output tensor every call, so after any request-path `empty_cache()` the collective sees a new device address each request. On XPU the collective backend keeps a non-reclaimable registration per distinct receive address, so device memory outside the PyTorch pool grows with every request. (Mechanism inferred from intervention experiments.) Eleven in-tree callers (SP key/value gather, `sp_gather`, CFG parallel, pipeline parallel, several model pipelines) go through this method.

**Fix:** on XPU only, land the collective in one flat per-(dtype, device) buffer grown monotonically and copy out, so callers keep owning their result and the buffer address is stable. Every other platform executes exactly main's `torch.empty` + `all_gather_into_tensor` with no buffer and no clone.

## Test Plan

**Reproduce:** any sequence-parallel model on XPU with a request-path `empty_cache()`, serial requests, sample non-PyTorch device memory between requests.

```bash
pytest -q tests/diffusion/distributed/test_allgather_buffer_reuse.py
```

**vLLM Version:** as pinned by `requirements/`. **vLLM-Omni Commit:** rebased onto current `main`.

## Test Result

18 CPU cases pass (output parity with a fresh gather, buffer reuse and growth, result does not alias the buffer, non-XPU path unchanged and creates no buffer). Removing the `is_xpu()` gate fails `test_non_xpu_all_gather_is_unchanged`; removing the copy-out fails `test_result_does_not_alias_landing_buffer`.

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

## Test Plan

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
