### PR TITLE
[Bugfix][Frontend] Clear the P0 multimodal cache through the renderer

### DIFF
--- a/tests/entrypoints/test_async_omni_pause_sleep_routing.py
+++ b/tests/entrypoints/test_async_omni_pause_sleep_routing.py
@@ -1,12 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 """Unit tests for AR EngineCore vs diffusion worker pause/sleep routing."""
 
 from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, call
+from unittest.mock import AsyncMock, call, create_autospec
 
 import pytest
+from vllm.renderers import BaseRenderer
+from vllm.v1.engine.input_processor import InputProcessor
 
 from vllm_omni.diffusion.data import CuMemTag, OmniACK
 from vllm_omni.entrypoints.async_omni import AsyncOmni
@@ -35,6 +40,23 @@ def _make_omni(*, stage_types: list[str]) -> AsyncOmni:
     )
     omni.collective_rpc = AsyncMock(return_value=[True])
     return omni
+
+
+@pytest.mark.cpu
+def test_reset_mm_cache_clears_renderer_cache():
+    async def run() -> None:
+        omni = object.__new__(AsyncOmni)
+        renderer = create_autospec(BaseRenderer, instance=True)
+        renderer.clear_mm_cache_async = AsyncMock()
+        input_processor = create_autospec(InputProcessor, instance=True)
+        input_processor.renderer = renderer
+        omni.input_processor = input_processor
+
+        await omni.reset_mm_cache()
+
+        renderer.clear_mm_cache_async.assert_awaited_once_with()
+
+    asyncio.run(run())
 
 
 @pytest.mark.cpu

--- a/tests/entrypoints/test_async_omni_pause_sleep_routing.py
+++ b/tests/entrypoints/test_async_omni_pause_sleep_routing.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, call, create_autospec
+from unittest.mock import AsyncMock, call
 
 import pytest
 from vllm.renderers import BaseRenderer
@@ -43,12 +43,11 @@ def _make_omni(*, stage_types: list[str]) -> AsyncOmni:
 
 
 @pytest.mark.cpu
-def test_reset_mm_cache_clears_renderer_cache():
+def test_reset_mm_cache_routes_through_renderer(mocker):
     async def run() -> None:
         omni = object.__new__(AsyncOmni)
-        renderer = create_autospec(BaseRenderer, instance=True)
-        renderer.clear_mm_cache_async = AsyncMock()
-        input_processor = create_autospec(InputProcessor, instance=True)
+        renderer = mocker.create_autospec(BaseRenderer, instance=True)
+        input_processor = mocker.create_autospec(InputProcessor, instance=True)
         input_processor.renderer = renderer
         omni.input_processor = input_processor
 

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 """
 AsyncOmni - Refactored async orchestrator using AsyncOmniEngine.
 
@@ -1421,19 +1424,9 @@ class AsyncOmni(EngineClient, OmniBase):
         ``EngineCore.sleep(level>=1)`` already clears the P1 receiver cache.
         Clearing P0 avoids hash-only follow-up requests after that reset.
         """
-        processor = getattr(self, "input_processor", None)
-        if processor is None:
-            processor = getattr(self.engine, "input_processor", None)
-        cache = getattr(processor, "mm_processor_cache", None)
-        if cache is None:
-            logger.debug("[AsyncOmni] reset_mm_cache: no frontend mm_processor_cache")
-            return
-        for name in ("clear", "reset", "clear_cache"):
-            fn = getattr(cache, name, None)
-            if callable(fn):
-                fn()
-                return
-        logger.debug("[AsyncOmni] reset_mm_cache: cache has no clear/reset method")
+        renderer = self.renderer
+        if renderer is not None:
+            await renderer.clear_mm_cache_async()
 
     async def reset_encoder_cache(self) -> None:
         """Reset the encoder cache for all stages.


### PR DESCRIPTION
## Purpose

### Failure

`AsyncOmni.reset_mm_cache()` leaves the frontend P0 multimodal cache populated across sleep and cache-clearing pause flows. EngineCore clears the receiver cache, so a later hash-only multimodal request can omit data the receiver now needs and finish empty.

### Reproduction

The added CPU regression installs a renderer cache-clear spy and calls `AsyncOmni.reset_mm_cache()`. On `main`, it fails with:

```text
Expected clear_mm_cache_async to have been awaited once. Awaited 0 times.
```

### Root cause and fix

`InputProcessor` exposes the cache through its `renderer`; the previous code probes a nonexistent `input_processor.mm_processor_cache` attribute. This change calls `renderer.clear_mm_cache_async()`, preserving serialization with concurrent multimodal processing and matching vLLM's frontend cache-clear path.

EngineCore reset forwarding is tracked in #6766. This change owns the P0 frontend cache path used directly by `sleep()` and `pause_generation(clear_cache=True)`.

Fixes #6972.

## Test Plan

**vLLM Version:** `v0.28.0` (`2cf0a6915ce544dc493a0990f2ea38d81601128a`)

**vLLM-Omni Commit:** `ec22c7ac06ad1d344dbfcf6aaf8b641113bf87a5`

```bash
pytest -q \
  tests/entrypoints/test_async_omni_pause_sleep_routing.py \
  tests/entrypoints/test_async_omni.py \
  -m "core_model and cpu" -o addopts=""
```

## Test Result

```text
33 passed, 2 deselected, 16 warnings in 1.03s
```
