### PR TITLE
[CI/Build] Avoid duplicate stage CLI deploy config

### DIFF
--- a/tests/helpers/runtime.py
+++ b/tests/helpers/runtime.py
@@ -968,7 +968,6 @@ def iter_omni_server(
                 raise ValueError("omni_server with use_stage_cli=True requires use_omni=True")
             if stage_config_path is None:
                 raise ValueError("omni_server with use_stage_cli=True requires a stage_config_path")
-            server_args += ["--deploy-config", stage_config_path]
 
             with OmniServerStageCli(
                 model,

--- a/tests/helpers/tests/test_runtime_stage_cli.py
+++ b/tests/helpers/tests/test_runtime_stage_cli.py
@@ -5,12 +5,15 @@
 
 from __future__ import annotations
 
+import threading
+from contextlib import nullcontext
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
-from tests.helpers.runtime import OmniServerStageCli
+from tests.helpers import runtime
+from tests.helpers.runtime import OmniServerParams, OmniServerStageCli
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -47,6 +50,39 @@ def test_stage_cli_loads_stage_ids_and_replica_counts(tmp_path: Path) -> None:
 
     assert server.stage_ids == [0, 1]
     assert server.stage_replica_counts == {0: 1, 1: 3}
+
+
+def test_stage_cli_fixture_leaves_deploy_config_to_server(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    stage_config_path = _write_stage_config(tmp_path)
+    captured_args: list[str] = []
+
+    def fake_stage_cli(model, config_path, serve_args, **kwargs):
+        del kwargs
+        assert config_path == stage_config_path
+        captured_args.extend(serve_args)
+        return nullcontext(SimpleNamespace(model=model))
+
+    monkeypatch.setattr(runtime, "OmniServerStageCli", fake_stage_cli)
+    monkeypatch.setattr(runtime, "_whisper_device_free_around", nullcontext)
+    monkeypatch.setattr(
+        "tests.helpers.stage_config.stage_config_path_for_run_level",
+        lambda config_path, _run_level: config_path,
+    )
+    request = SimpleNamespace(
+        param=OmniServerParams(
+            model="fake-model",
+            stage_config_path=stage_config_path,
+            use_stage_cli=True,
+        ),
+        node=SimpleNamespace(get_closest_marker=lambda _name: None),
+    )
+
+    server_fixture = runtime.iter_omni_server(request, "core_model", threading.Lock())
+    next(server_fixture)
+    with pytest.raises(StopIteration):
+        next(server_fixture)
+
+    assert "--deploy-config" not in captured_args
 
 
 def test_stage_cli_enter_rolls_back_launched_stages_on_startup_failure(


### PR DESCRIPTION
## Summary

- let `OmniServerStageCli` remain the single owner of the per-stage `--deploy-config` argument
- stop the shared server fixture from adding the same option to `serve_args` first
- add a CPU regression test at the fixture boundary

## Why

`iter_omni_server()` appended `--deploy-config <path>` to `server_args`, then `OmniServerStageCli._build_stage_cmd()` added the same pair again for every stage subprocess. Besides noisy commands, duplicate argparse options make precedence implicit and can hide future config-routing mistakes.

This is a small, coverage-neutral harness cleanup identified while auditing the H100 L3 startup work in #6851; it does not implement the RFC's proposed coverage changes.

## Testing

- `pytest -o addopts="" -q tests/helpers/tests/test_runtime_stage_cli.py::test_stage_cli_fixture_leaves_deploy_config_to_server tests/helpers/tests/test_runtime_stage_cli.py::test_stage_cli_enter_rolls_back_launched_stages_on_startup_failure` (2 passed)
- Ruff check and format
- mypy via `tools/pre_commit/mypy.py`
- SPDX and test-mark checks

Related to #6851