### PR TITLE
[Bugfix][Frontend] Surface streaming terminal submit failures

### DIFF
--- a/tests/entrypoints/test_async_omni.py
+++ b/tests/entrypoints/test_async_omni.py
@@ -13,6 +13,7 @@ from vllm.sampling_params import RequestOutputKind, SamplingParams
 from tests.helpers.mark import hardware_test
 from tests.helpers.stage_config import get_deploy_config_path
 from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
+from vllm_omni.entrypoints import async_omni
 from vllm_omni.entrypoints.async_omni import AsyncOmni
 from vllm_omni.outputs import OmniRequestOutput
 
@@ -381,7 +382,8 @@ def test_generate_accepts_request_after_repeated_cancellations():
 
 @pytest.mark.cpu
 @pytest.mark.parametrize("has_chunk", [False, True])
-def test_streaming_input_terminal_submit_failure_reaches_generate(mocker, has_chunk):
+@pytest.mark.parametrize("input_fails", [False, True])
+def test_streaming_input_terminal_submit_failure_reaches_generate(mocker, has_chunk, input_fails):
     async def run_test():
         submissions: list[tuple[str, bool]] = []
 
@@ -406,10 +408,13 @@ def test_streaming_input_terminal_submit_failure_reaches_generate(mocker, has_ch
             "vllm_omni.entrypoints.async_omni.extract_prompt_components",
             return_value=(None, None, None),
         )
+        error_metadata = mocker.spy(async_omni, "client_error_metadata")
 
         async def input_stream():
             if has_chunk:
                 yield StreamingInput(prompt={"prompt": "chunk"})
+            if input_fails:
+                raise RuntimeError("streaming input failed")
 
         async def consume():
             async for _ in omni.generate(
@@ -420,8 +425,10 @@ def test_streaming_input_terminal_submit_failure_reaches_generate(mocker, has_ch
             ):
                 pass
 
-        with pytest.raises(RuntimeError, match="terminal streaming submit failed"):
+        expected_error = "streaming input failed" if input_fails else "terminal streaming submit failed"
+        with pytest.raises(RuntimeError, match=expected_error):
             await asyncio.wait_for(consume(), timeout=1.0)
+        assert error_metadata.call_count == 1
         assert submissions == ([("add", True), ("update", False)] if has_chunk else [("add", False)])
         assert omni.request_states == {}
 

--- a/tests/entrypoints/test_async_omni.py
+++ b/tests/entrypoints/test_async_omni.py
@@ -6,6 +6,7 @@ import re
 from types import SimpleNamespace
 
 import pytest
+from vllm.engine.protocol import StreamingInput
 from vllm.lora.request import LoRARequest
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 
@@ -374,6 +375,55 @@ def test_generate_accepts_request_after_repeated_cancellations():
         for batch, prefix in zip(aborted_request_batches, ["cancel-0-", "cancel-1-", "cancel-2-"]):
             assert len(batch) == 1
             assert batch[0].startswith(prefix)
+
+    asyncio.run(run_test())
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("has_chunk", [False, True])
+def test_streaming_input_terminal_submit_failure_reaches_generate(mocker, has_chunk):
+    async def run_test():
+        submissions: list[tuple[str, bool]] = []
+
+        async def add_request_async(*, resumable, **kwargs):
+            del kwargs
+            submissions.append(("add", resumable))
+            if not resumable:
+                raise RuntimeError("terminal streaming submit failed")
+
+        async def add_streaming_update_async(*, resumable, **kwargs):
+            del kwargs
+            submissions.append(("update", resumable))
+            assert not resumable
+            raise RuntimeError("terminal streaming submit failed")
+
+        omni = get_async_omni_instance(fake_add_request=add_request_async)
+        omni.engine.add_streaming_update_async = add_streaming_update_async
+        omni.engine.stage_clients = []
+        omni.engine.model_config = object()
+        del omni._process_orchestrator_results
+        mocker.patch(
+            "vllm_omni.entrypoints.async_omni.extract_prompt_components",
+            return_value=(None, None, None),
+        )
+
+        async def input_stream():
+            if has_chunk:
+                yield StreamingInput(prompt={"prompt": "chunk"})
+
+        async def consume():
+            async for _ in omni.generate(
+                prompt=input_stream(),
+                request_id="stream-submit-error",
+                sampling_params_list=[SamplingParams(output_kind=RequestOutputKind.DELTA)],
+                output_modalities=["text"],
+            ):
+                pass
+
+        with pytest.raises(RuntimeError, match="terminal streaming submit failed"):
+            await asyncio.wait_for(consume(), timeout=1.0)
+        assert submissions == ([("add", True), ("update", False)] if has_chunk else [("add", False)])
+        assert omni.request_states == {}
 
     asyncio.run(run_test())
 

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 """
 AsyncOmni - Refactored async orchestrator using AsyncOmniEngine.
 
@@ -717,6 +720,7 @@ class AsyncOmni(EngineClient, OmniBase):
         self._validate_streaming_input_sampling_params(stage0_params)
         req_state = self.request_states[request_id]
         has_submitted_first_chunk = False
+        input_error_reported = False
 
         # NOTE: InputProcessor in vLLM should generally do this too, but for
         # now we do it defensively. TODO (Alex) ensure clones/copying are optimized
@@ -727,6 +731,21 @@ class AsyncOmni(EngineClient, OmniBase):
         def _mark_first_chunk_submitted() -> None:
             if first_chunk_submitted is not None and not first_chunk_submitted.done():
                 first_chunk_submitted.set_result(None)
+
+        async def _report_input_error(error: Exception) -> None:
+            nonlocal input_error_reported
+            if input_error_reported:
+                return
+            input_error_reported = True
+            status_code, error_type = client_error_metadata(error)
+            await req_state.queue.put(
+                ErrorMessage(
+                    request_id=request_id,
+                    error=str(error),
+                    status_code=status_code,
+                    error_type=error_type,
+                )
+            )
 
         async def handle_inputs() -> None:
             nonlocal has_submitted_first_chunk
@@ -773,15 +792,7 @@ class AsyncOmni(EngineClient, OmniBase):
             except (asyncio.CancelledError, GeneratorExit):
                 cancelled = True
             except Exception as error:
-                status_code, error_type = client_error_metadata(error)
-                await req_state.queue.put(
-                    ErrorMessage(
-                        request_id=request_id,
-                        error=str(error),
-                        status_code=status_code,
-                        error_type=error_type,
-                    )
-                )
+                await _report_input_error(error)
             finally:
                 try:
                     if not cancelled:
@@ -820,9 +831,11 @@ class AsyncOmni(EngineClient, OmniBase):
                                 )
                             )
                             has_submitted_first_chunk = True
+                except Exception as error:
+                    await _report_input_error(error)
                 finally:
                     # Unblock generate() even on cancel / empty stream / submit
-                    # failure so it can observe a terminal abort or empty result.
+                    # failure so it can observe the queued terminal result or error.
                     _mark_first_chunk_submitted()
 
         input_stream_task = asyncio.create_task(handle_inputs())


### PR DESCRIPTION
## Purpose

### What broke

Streaming-input requests send a final `resumable=False` ADD or UPDATE after
the input generator ends. If that terminal submission raised an exception,
the input-pump task ended with an unhandled error while `generate()` continued
waiting on an empty result queue.

### Root cause

The terminal submission ran from `finally`, outside the existing streaming
input error handler. The first-submission future was still resolved, so the
caller had no way to observe the failure.

### Fix

This change routes terminal submission failures through the same per-request
`ErrorMessage` path used by other streaming-input failures. It reports only
the first input failure when both input processing and terminal submission
fail. Cancellation behavior is unchanged.

### Reproduction

1. Start `AsyncOmni.generate()` with an asynchronous input stream.
2. End the stream either before its first chunk or after one chunk.
3. Raise from the final `add_request_async(..., resumable=False)` or
   `add_streaming_update_async(..., resumable=False)` call.

Before this change, both cases time out waiting for a result and leave an
unretrieved task exception. After this change, `generate()` raises the
submission error and completes its existing abort and cleanup path.

## Test Plan

```bash
python -m pytest tests/entrypoints/test_async_omni.py \
  tests/entrypoints/test_realtime_connection_helpers.py \
  -m "core_model and cpu" --run-level core_model -q

pre-commit run --files tests/entrypoints/test_async_omni.py \
  vllm_omni/entrypoints/async_omni.py
```

**vLLM Version:** 0.29.0; PyTorch 2.13.0+cu130; Python 3.12.

**vLLM-Omni Commit:** `53d7f93ebc15c04391cc1af186e3a90b734c4f4f`, including `main` at `224152566a705dd0347e4b4c3c3e74ce7e19ed8f`.

## Test Result

- Combined AsyncOmni and realtime connection helper CPU suites: **31 passed, 2 deselected** (GPU cases), in 1.69 seconds.
- The terminal-submission regression covers four combinations: empty/non-empty stream, with/without an earlier input failure.
- Main's cancellation/abort timeout tests are preserved alongside the PR's streaming failure tests. The merge conflict was limited to test placement and the module import alias.
- Applicable changed-file pre-commit checks passed except mypy. Mypy reports **13 errors identical to the unmodified main commit** after normalizing line numbers; there are no new diagnostics from this change.
- `git diff --check origin/main` passed. Only the two intended PR files differ from main.

The merge adds no further runtime behavior beyond this PR's original fix and the upstream changes. GPU tests were not run for this CPU control-flow merge resolution.
