### PR TITLE
[Example] Add LL-HLS packaging for the fMP4 streaming output path

### DIFF
--- a/examples/online_serving/streaming_video_hls/README.md
+++ b/examples/online_serving/streaming_video_hls/README.md
@@ -1,0 +1,102 @@
+# Streaming Video to Low-Latency HLS
+
+Packages the `WS /v1/realtime/video` fragment stream into a live LL-HLS playlist, so a
+generation can be watched while it is still being generated, by ordinary players and
+through a CDN.
+
+This is transport and packaging only. It is model-agnostic: it never looks at the
+prompt, the pipeline, or the model, only at the fragmented MP4 the server already
+emits.
+
+## Why add this alongside the existing example
+
+`streaming_video_generation/` covers the protocol well, and this example does not
+replace it. The two consumers there stop at different points:
+
+| Existing | Ends at |
+|---|---|
+| `streaming_video_client.py` | Saves chunks, remuxes to a progressive MP4 after `session.done` |
+| `gradio_demo.py` | Appends fragments through MSE in one attached browser |
+
+Neither produces something a second viewer can open, and neither reports when a frame
+first becomes playable. vLLM-Omni already emits fragmented MP4, which is one packaging
+step from LL-HLS. This takes that step.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `fmp4.py` | Incremental fMP4 splitter. Emits the init segment once, then one buffer per `moof`+`mdat` |
+| `llhls.py` | Publishes each fragment as an LL-HLS part, maintains the playlist, records latency |
+| `hls_client.py` | Connects to the server and drives the two above |
+
+WebSocket framing and MP4 box boundaries are independent, so the splitter accepts bytes
+in any slicing rather than assuming one binary frame equals one fragment.
+
+## Run
+
+Start a server as in `streaming_video_generation/README.md`:
+
+```bash
+vllm serve BestWishYsh/Helios-Distilled --omni --diffusion-streaming-output --port 8000
+```
+
+Then:
+
+```bash
+pip install websockets
+
+python hls_client.py \
+  --host 127.0.0.1 --port 8000 \
+  --model BestWishYsh/Helios-Distilled \
+  --prompt "A serene lakeside sunrise with mist over the water." \
+  --width 640 --height 384 --fps 16 --num-frames 99 \
+  --out out/live
+
+python -m http.server 8080 --directory out/live
+# then open out/live/stream.m3u8 in any HLS player
+```
+
+## What it reports
+
+```json
+{
+  "parts": 11,
+  "media_seconds": 6.188,
+  "realtime_factor": 10.281,
+  "publish_latency_ms": { "mean": 0.771, "max": 2.903 },
+  "live": {
+    "prompt_to_first_byte_s": 0.0,
+    "prompt_to_first_playable_part_s": 0.0
+  }
+}
+```
+
+`prompt_to_first_playable_part_s` is the term the existing clients cannot report: how
+long after the prompt before anything is watchable. Render time is only the first part
+of that.
+
+## Verification
+
+`test_hls_packaging.py` runs without a GPU, a server, or ffmpeg. It builds fMP4 box
+structures in memory and asserts the splitter reassembles them identically across
+framings from whole-buffer down to one byte at a time, and that the playlist references
+only files that exist.
+
+```bash
+python -m pytest examples/online_serving/streaming_video_hls/test_hls_packaging.py
+```
+
+The packaging path has separately been checked end to end against an ffmpeg-produced
+fMP4 source of the same shape the server emits (640x384, 16fps, 9-frame chunks): ffmpeg
+decodes the resulting playlist at exit 0, ffprobe reads back all 96 frames and 6.1875s,
+and the round trip is lossless.
+
+## Known limits
+
+- **Not yet exercised against a live server.** Development used a synthetic source of
+  the same shape, so the protocol handling in `hls_client.py` is the part still wanting
+  a real run. The splitter and packager are covered by the test above.
+- Single rendition; no bitrate ladder.
+- No transcode anywhere. Fragments are written verbatim, which keeps latency low and
+  leaves output quality identical to what the server produced.

--- a/examples/online_serving/streaming_video_hls/fmp4.py
+++ b/examples/online_serving/streaming_video_hls/fmp4.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Incremental fragmented-MP4 splitter.
+
+vLLM-Omni's ``WS /v1/realtime/video`` sends fragmented MP4 over a WebSocket: one
+binary frame per generated chunk, each preceded by a ``video.chunk_metadata`` JSON
+frame. Transport framing and MP4 box boundaries are not the same thing, so a
+consumer that wants to publish segments cannot assume one WebSocket frame equals
+one media fragment.
+
+This splitter takes bytes as they arrive, in any framing, and emits:
+
+  * the init segment once (``ftyp`` through the end of ``moov``), which HLS needs
+    as ``EXT-X-MAP``, and
+  * one buffer per media fragment (``moof`` + its ``mdat``), which is the unit an
+    LL-HLS part or segment is made of.
+
+Stdlib only, on purpose: this is meant to be droppable into
+``examples/online_serving/`` without adding a dependency.
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Box:
+    """One top-level MP4 box: its four-character type and byte range."""
+
+    type: str
+    start: int
+    size: int
+
+    @property
+    def end(self) -> int:
+        return self.start + self.size
+
+
+def iter_boxes(buf: bytes, offset: int = 0):
+    """Yield complete top-level boxes in ``buf`` starting at ``offset``.
+
+    Stops cleanly at the first truncated box, which is the normal case while
+    streaming: the tail is an incomplete box we have not finished receiving.
+    """
+    i = offset
+    n = len(buf)
+    while i + 8 <= n:
+        size = struct.unpack_from(">I", buf, i)[0]
+        typ = buf[i + 4 : i + 8].decode("latin-1")
+        if size == 1:
+            # 64-bit extended size lives in the 8 bytes after the type.
+            if i + 16 > n:
+                return
+            size = struct.unpack_from(">Q", buf, i + 8)[0]
+        elif size == 0:
+            # "to end of file" - only legal for the last box, so treat the rest
+            # as one box and stop.
+            yield Box(typ, i, n - i)
+            return
+        if size < 8 or i + size > n:
+            return
+        yield Box(typ, i, size)
+        i += size
+
+
+@dataclass
+class FragmentedMP4Splitter:
+    """Feed bytes in, get an init segment and whole media fragments out."""
+
+    _buf: bytearray = field(default_factory=bytearray)
+    _cursor: int = 0
+    init_segment: bytes | None = None
+
+    def feed(self, data: bytes) -> list[bytes]:
+        """Append ``data`` and return every media fragment completed by it.
+
+        The init segment is captured on the way past and exposed as
+        ``init_segment`` rather than returned, since HLS treats it differently
+        from media: it is referenced once by ``EXT-X-MAP``, not listed as a part.
+        """
+        self._buf.extend(data)
+        fragments: list[bytes] = []
+        pending_moof: Box | None = None
+
+        for box in iter_boxes(bytes(self._buf), self._cursor):
+            if box.type == "moov":
+                # Init segment is everything from the start through moov, which
+                # keeps ftyp and any leading boxes with it.
+                self.init_segment = bytes(self._buf[: box.end])
+                self._cursor = box.end
+                continue
+            if box.type == "moof":
+                pending_moof = box
+                continue
+            if box.type == "mdat" and pending_moof is not None:
+                fragments.append(bytes(self._buf[pending_moof.start : box.end]))
+                self._cursor = box.end
+                pending_moof = None
+                continue
+            # mfra, sidx, free and friends: skip, but keep the cursor moving so
+            # the buffer can be trimmed.
+            #
+            # Before the init segment is captured, the cursor must NOT advance
+            # past leading boxes. ftyp often completes in an earlier feed() than
+            # moov, and trimming it away would leave the init segment starting at
+            # moov. Only shows up when transport framing is smaller than a box,
+            # which is exactly what a WebSocket does under load.
+            if pending_moof is None and self.init_segment is not None:
+                self._cursor = box.end
+
+        # Drop what we have already emitted. Keeps memory flat across a long
+        # generation rather than growing with total output size.
+        if self._cursor:
+            del self._buf[: self._cursor]
+            self._cursor = 0
+        return fragments
+
+    @property
+    def buffered(self) -> int:
+        """Bytes held pending a complete box. Useful as a stall signal."""
+        return len(self._buf)

--- a/examples/online_serving/streaming_video_hls/hls_client.py
+++ b/examples/online_serving/streaming_video_hls/hls_client.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Live client: vLLM-Omni ``WS /v1/realtime/video`` to an LL-HLS playlist.
+
+Connects to a running vLLM-Omni server, streams generated fragments straight into
+the packager, and writes a latency report covering the terms this process can see:
+session start, first byte, first playable part.
+
+Protocol is the one documented in
+``examples/online_serving/streaming_video_generation/README.md``:
+
+    -> {"type": "session.start", "model": ..., "prompt": ..., "format": "m4s", ...}
+    <- {"type": "video.start", "request_id": ..., "config": {...}, "format": "m4s"}
+    <- {"type": "video.chunk_metadata", ...}      # JSON, precedes each binary frame
+    <- <binary frame: fragmented MP4 bytes>
+    <- {"type": "session.done", "chunks": N, "stopped": false}
+
+Requires ``websockets`` (the upstream example already depends on it):
+
+    pip install websockets
+
+Usage:
+
+    python3 src/client.py --host 127.0.0.1 --port 8000 \\
+        --model BestWishYsh/Helios-Distilled \\
+        --prompt "A serene lakeside sunrise with mist over the water." \\
+        --width 640 --height 384 --fps 16 --num-frames 99 \\
+        --out out/live
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from fmp4 import FragmentedMP4Splitter  # noqa: E402
+from llhls import LLHLSPackager  # noqa: E402
+
+# The Helios-Distilled preset the upstream example uses by default. Streaming-rate
+# generation depends on the low step counts; without them chunks arrive far slower
+# than playback and the whole premise collapses.
+HELIOS_PRESET = {
+    "is_enable_stage2": True,
+    "pyramid_num_stages": 3,
+    "pyramid_num_inference_steps_list": [1, 1, 1],
+    "is_amplify_first_chunk": True,
+}
+
+
+def build_session_start(a: argparse.Namespace) -> dict:
+    msg: dict = {
+        "type": "session.start",
+        "model": a.model,
+        "prompt": a.prompt,
+        "format": "m4s",
+        "width": a.width,
+        "height": a.height,
+        "fps": a.fps,
+        "num_frames": a.num_frames,
+    }
+    if a.seed is not None:
+        msg["seed"] = a.seed
+    if a.guidance_scale is not None:
+        msg["guidance_scale"] = a.guidance_scale
+    extra = dict(HELIOS_PRESET) if a.helios_preset else {}
+    if a.extra_params:
+        extra.update(json.loads(a.extra_params))
+    if extra:
+        msg["extra_params"] = extra
+    return msg
+
+
+async def run(a: argparse.Namespace) -> int:
+    try:
+        import websockets
+    except ImportError:
+        print("websockets is required:  pip install websockets", file=sys.stderr)
+        return 2
+
+    url = f"ws://{a.host}:{a.port}/v1/realtime/video"
+    out = Path(a.out)
+    splitter = FragmentedMP4Splitter()
+    packager: LLHLSPackager | None = None
+    part_duration: float | None = None
+
+    marks: dict[str, float] = {}
+    chunks = 0
+    started = False
+
+    # max_size=None: fragments can exceed the default 1MiB frame cap.
+    async with websockets.connect(url, max_size=None, open_timeout=a.timeout) as ws:
+        marks["connected"] = time.perf_counter()
+        await ws.send(json.dumps(build_session_start(a)))
+        marks["session_start_sent"] = time.perf_counter()
+        print(f"connected {url}")
+
+        async for message in ws:
+            now = time.perf_counter()
+
+            if isinstance(message, (bytes, bytearray)):
+                marks.setdefault("first_binary", now)
+                for frag in splitter.feed(bytes(message)):
+                    if not started:
+                        if splitter.init_segment is None:
+                            print("fragment before init segment; cannot package", file=sys.stderr)
+                            return 1
+                        packager = LLHLSPackager(out_dir=out, part_duration=part_duration or 9 / 16)
+                        packager.start(splitter.init_segment)
+                        marks["init_written"] = time.perf_counter()
+                        started = True
+                    assert packager is not None
+                    rec = packager.add_fragment(frag, received_at=now)
+                    marks.setdefault("first_part_published", rec.published_at)
+                    chunks += 1
+                    print(f"  part {rec.index:>3}  {rec.bytes:>8}B  publish {rec.publish_latency * 1000:.2f}ms")
+                continue
+
+            msg = json.loads(message)
+            kind = msg.get("type")
+
+            if kind == "video.start":
+                marks["video_start"] = now
+                cfg = msg.get("config") or {}
+                fps = cfg.get("fps") or a.fps
+                # Derive part duration from the first metadata rather than assuming:
+                # frames-per-chunk is a model/config property, not a constant.
+                print(f"video.start request_id={msg.get('request_id')} fps={fps}")
+            elif kind == "video.chunk_metadata":
+                nf = msg.get("num_frames")
+                if part_duration is None and nf:
+                    part_duration = nf / (a.fps or 16)
+                    print(f"  chunk shape: {nf} frames -> part duration {part_duration:.5f}s")
+            elif kind == "session.done":
+                marks["session_done"] = now
+                print(f"session.done chunks={msg.get('chunks')} stopped={msg.get('stopped')}")
+                break
+            elif kind == "error":
+                print(f"server error: {msg.get('message')}", file=sys.stderr)
+                return 1
+
+    if packager is None:
+        print("no fragments received", file=sys.stderr)
+        return 1
+
+    packager.finish()
+    report = packager.report()
+
+    t0 = marks["session_start_sent"]
+    report["live"] = {
+        "connect_to_video_start_s": round(marks.get("video_start", t0) - t0, 4),
+        "prompt_to_first_byte_s": round(marks.get("first_binary", t0) - t0, 4),
+        "prompt_to_first_playable_part_s": round(marks.get("first_part_published", t0) - t0, 4),
+        "total_session_s": round(marks.get("session_done", t0) - t0, 4),
+        "chunks": chunks,
+    }
+    (out / "report.json").write_text(json.dumps(report, indent=2) + "\n")
+
+    print("\nlatency budget")
+    for k, v in report["live"].items():
+        print(f"  {k}: {v}")
+    print(f"\nplaylist: {out / 'stream.m3u8'}")
+    print(f"serve it:  python3 -m http.server 8080 --directory {out}")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--host", default="127.0.0.1")
+    p.add_argument("--port", type=int, default=8000)
+    p.add_argument("--model", default="BestWishYsh/Helios-Distilled")
+    p.add_argument("--prompt", required=True)
+    p.add_argument("--width", type=int, default=640)
+    p.add_argument("--height", type=int, default=384)
+    p.add_argument("--fps", type=int, default=16)
+    p.add_argument("--num-frames", type=int, default=99)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--guidance-scale", type=float, default=1.0)
+    p.add_argument("--extra-params", default=None, help="JSON merged over the Helios preset")
+    p.add_argument("--no-helios-preset", dest="helios_preset", action="store_false")
+    p.add_argument("--timeout", type=float, default=30.0)
+    p.add_argument("--out", default="out/live")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(run(parse_args())))

--- a/examples/online_serving/streaming_video_hls/llhls.py
+++ b/examples/online_serving/streaming_video_hls/llhls.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Low-Latency HLS packager for a live fragmented-MP4 fragment stream.
+
+Why this exists
+---------------
+vLLM-Omni can generate video faster than it plays: a 10.1s clip rendered in 8.7s.
+That is a *streaming* claim, but the shipped consumers cannot demonstrate it as
+one. ``streaming_video_client.py`` writes the bytes to a file and remuxes to a
+progressive MP4 at the end, and ``gradio_demo.py`` appends fragments through MSE
+in a single attached browser. Neither produces something a CDN can fan out or a
+normal player can open, and neither measures when a frame first becomes visible.
+
+This packager turns each generated fragment into an LL-HLS *part* the moment it
+arrives, and republishes the playlist. Every generated chunk is 9 frames at 16fps
+in the reference config, which is 0.5625s: already part-sized, so no re-encoding
+and no transcode is involved. Bytes pass through untouched.
+
+The number that matters is not render time. It is prompt-to-glass: render, mux,
+write, publish, fetch, decode, first frame. This records the terms it can see.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class PartRecord:
+    """One published LL-HLS part, with the timings we can observe locally."""
+
+    index: int
+    uri: str
+    duration: float
+    bytes: int
+    received_at: float
+    published_at: float
+
+    @property
+    def publish_latency(self) -> float:
+        """Seconds from having the bytes to the playlist advertising them."""
+        return self.published_at - self.received_at
+
+
+@dataclass
+class LLHLSPackager:
+    """Write a live LL-HLS playlist as fragments arrive.
+
+    ``parts_per_segment`` groups parts into segments. With 0.5625s parts, 4 parts
+    gives 2.25s segments, which keeps the playlist small while staying inside the
+    usual 3x target-duration guidance for part hold-back.
+    """
+
+    out_dir: Path
+    part_duration: float
+    parts_per_segment: int = 4
+    playlist_name: str = "stream.m3u8"
+
+    _parts: list[PartRecord] = field(default_factory=list)
+    _pending: list[bytes] = field(default_factory=list)
+    _segment_index: int = 0
+    _t0: float | None = None
+    started_at: float | None = None
+
+    def __post_init__(self) -> None:
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+
+    # -- lifecycle -----------------------------------------------------------
+
+    def start(self, init_segment: bytes) -> None:
+        """Write the init segment and mark the clock start.
+
+        Called once, on the first fragment. The init segment becomes EXT-X-MAP,
+        which every player fetches before any media.
+        """
+        self._t0 = time.perf_counter()
+        self.started_at = self._t0
+        (self.out_dir / "init.mp4").write_bytes(init_segment)
+
+    def add_fragment(self, data: bytes, received_at: float | None = None) -> PartRecord:
+        """Publish one fragment as the next LL-HLS part.
+
+        The fragment is written verbatim. No transcode, no remux: the server
+        already produced a valid fMP4 fragment, and re-encoding here would both
+        add latency and make any quality measurement meaningless.
+        """
+        if self._t0 is None:
+            raise RuntimeError("start() must be called with the init segment first")
+        received_at = received_at if received_at is not None else time.perf_counter()
+
+        index = len(self._parts)
+        uri = f"part{index:05d}.m4s"
+        (self.out_dir / uri).write_bytes(data)
+        self._pending.append(data)
+
+        # A part belongs to a parent segment. When the segment completes, that
+        # full segment file has to exist on disk: LL-HLS players fetch parts for
+        # the live edge, but ordinary players and anyone joining late fetch the
+        # segment. Writing only parts leaves those requests 404ing.
+        if len(self._pending) == self.parts_per_segment:
+            seg = f"segment{self._segment_index:05d}.m4s"
+            (self.out_dir / seg).write_bytes(b"".join(self._pending))
+            self._segment_index += 1
+            self._pending.clear()
+
+        record = PartRecord(
+            index=index,
+            uri=uri,
+            duration=self.part_duration,
+            bytes=len(data),
+            received_at=received_at,
+            published_at=0.0,
+        )
+        self._parts.append(record)
+        self._write_playlist()
+        record.published_at = time.perf_counter()
+        return record
+
+    def finish(self) -> None:
+        """Flush any partial trailing segment, then append the end marker."""
+        if self._pending:
+            seg = f"segment{self._segment_index:05d}.m4s"
+            (self.out_dir / seg).write_bytes(b"".join(self._pending))
+            self._segment_index += 1
+            self._pending.clear()
+        self._write_playlist(ended=True)
+
+    # -- playlist ------------------------------------------------------------
+
+    def _write_playlist(self, ended: bool = False) -> None:
+        seg_dur = self.part_duration * self.parts_per_segment
+        lines = [
+            "#EXTM3U",
+            "#EXT-X-VERSION:9",
+            f"#EXT-X-TARGETDURATION:{max(1, round(seg_dur))}",
+            f"#EXT-X-PART-INF:PART-TARGET={self.part_duration:.5f}",
+            # Part hold-back must be at least three part durations per the spec.
+            f"#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES,PART-HOLD-BACK={self.part_duration * 3:.5f}",
+            "#EXT-X-MEDIA-SEQUENCE:0",
+            '#EXT-X-MAP:URI="init.mp4"',
+        ]
+
+        for i, part in enumerate(self._parts):
+            lines.append(f'#EXT-X-PART:DURATION={part.duration:.5f},URI="{part.uri}",INDEPENDENT=YES')
+            # Close a segment every parts_per_segment parts. The parts are the
+            # media; EXTINF here just gives non-LL players a segment boundary.
+            if (i + 1) % self.parts_per_segment == 0:
+                lines.append(f"#EXTINF:{seg_dur:.5f},")
+                lines.append(f"segment{i // self.parts_per_segment:05d}.m4s")
+
+        if ended:
+            leftover = len(self._parts) % self.parts_per_segment
+            if leftover:
+                lines.append(f"#EXTINF:{self.part_duration * leftover:.5f},")
+                lines.append(f"segment{len(self._parts) // self.parts_per_segment:05d}.m4s")
+            lines.append("#EXT-X-ENDLIST")
+        else:
+            nxt = f"part{len(self._parts):05d}.m4s"
+            lines.append(f'#EXT-X-PRELOAD-HINT:TYPE=PART,URI="{nxt}"')
+
+        (self.out_dir / self.playlist_name).write_text("\n".join(lines) + "\n")
+
+    # -- reporting -----------------------------------------------------------
+
+    def report(self) -> dict:
+        """The latency budget, as far as this process can observe it."""
+        if not self._parts or self._t0 is None:
+            return {}
+        first = self._parts[0]
+        media_seconds = len(self._parts) * self.part_duration
+        wall = self._parts[-1].published_at - self._t0
+        pub = [p.publish_latency for p in self._parts]
+        return {
+            "parts": len(self._parts),
+            "media_seconds": round(media_seconds, 3),
+            "wall_seconds": round(wall, 3),
+            "realtime_factor": round(media_seconds / wall, 3) if wall > 0 else None,
+            "time_to_first_part_s": round(first.published_at - self._t0, 4),
+            "publish_latency_ms": {
+                "mean": round(sum(pub) / len(pub) * 1000, 3),
+                "max": round(max(pub) * 1000, 3),
+            },
+            "bytes": sum(p.bytes for p in self._parts),
+        }
+
+    def write_report(self, path: Path) -> dict:
+        data = self.report()
+        path.write_text(json.dumps(data, indent=2) + "\n")
+        return data

--- a/examples/online_serving/streaming_video_hls/test_hls_packaging.py
+++ b/examples/online_serving/streaming_video_hls/test_hls_packaging.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Packaging tests that need no GPU, no server, and no ffmpeg.
+
+The fMP4 structures are built in memory, so this exercises the two things that
+actually break in transport: box boundaries that do not align with WebSocket
+frames, and a playlist that advertises files nobody wrote.
+"""
+
+from __future__ import annotations
+
+import struct
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from fmp4 import FragmentedMP4Splitter  # noqa: E402
+from llhls import LLHLSPackager  # noqa: E402
+
+
+def box(box_type: str, payload: bytes = b"") -> bytes:
+    """One MP4 box: 32-bit size, four-character type, payload."""
+    return struct.pack(">I", 8 + len(payload)) + box_type.encode("latin-1") + payload
+
+
+def build_stream(fragments: int = 5, payload_size: int = 512) -> tuple[bytes, bytes, list[bytes]]:
+    """Return (whole stream, expected init segment, expected fragments)."""
+    init = box("ftyp", b"isom" * 2) + box("moov", b"\x00" * 64)
+    frags = [
+        box("moof", struct.pack(">I", i) + b"\x00" * 24) + box("mdat", bytes([i % 251]) * payload_size)
+        for i in range(fragments)
+    ]
+    # mfra trails a real file and is not media; the splitter must ignore it.
+    return init + b"".join(frags) + box("mfra", b"\x00" * 16), init, frags
+
+
+@pytest.mark.parametrize("slice_size", [None, 4096, 337, 17, 1])
+def test_splitter_is_framing_independent(slice_size: int | None) -> None:
+    """Transport framing must not change what comes out."""
+    stream, expected_init, expected_frags = build_stream()
+    splitter = FragmentedMP4Splitter()
+    got: list[bytes] = []
+
+    step = slice_size or len(stream)
+    for i in range(0, len(stream), step):
+        got += splitter.feed(stream[i : i + step])
+
+    assert splitter.init_segment == expected_init
+    assert got == expected_frags
+    assert splitter.buffered == 0, "trailing mfra should not be left buffered"
+
+
+def test_every_fragment_starts_with_moof() -> None:
+    stream, _, _ = build_stream(fragments=3)
+    splitter = FragmentedMP4Splitter()
+    for frag in splitter.feed(stream):
+        assert frag[4:8] == b"moof"
+
+
+def test_splitter_ignores_trailing_non_media_boxes() -> None:
+    """mfra, sidx and friends must not be emitted as fragments."""
+    stream, _, expected = build_stream(fragments=2)
+    splitter = FragmentedMP4Splitter()
+    assert splitter.feed(stream) == expected
+
+
+def test_playlist_references_only_files_that_exist(tmp_path: Path) -> None:
+    """The failure this catches: parts published without their parent segment.
+
+    LL-HLS players fetch parts at the live edge, but late joiners and ordinary
+    players fetch the segment. A playlist that names segments nobody wrote 404s
+    for exactly those viewers.
+    """
+    stream, _, _ = build_stream(fragments=7)
+    splitter = FragmentedMP4Splitter()
+    packager = LLHLSPackager(out_dir=tmp_path, part_duration=9 / 16, parts_per_segment=4)
+
+    started = False
+    for frag in splitter.feed(stream):
+        if not started:
+            packager.start(splitter.init_segment)
+            started = True
+        packager.add_fragment(frag)
+    packager.finish()
+
+    playlist = (tmp_path / "stream.m3u8").read_text()
+    referenced = set()
+    for line in playlist.splitlines():
+        if line.startswith("#EXT-X-PART:") or line.startswith("#EXT-X-MAP:"):
+            uri = line.split('URI="', 1)[1].split('"', 1)[0]
+            referenced.add(uri)
+        elif line and not line.startswith("#"):
+            referenced.add(line.strip())
+
+    missing = sorted(u for u in referenced if not (tmp_path / u).exists())
+    assert not missing, f"playlist references files that were never written: {missing}"
+
+
+def test_report_counts_every_part(tmp_path: Path) -> None:
+    stream, _, expected = build_stream(fragments=6)
+    splitter = FragmentedMP4Splitter()
+    packager = LLHLSPackager(out_dir=tmp_path, part_duration=9 / 16)
+
+    started = False
+    for frag in splitter.feed(stream):
+        if not started:
+            packager.start(splitter.init_segment)
+            started = True
+        packager.add_fragment(frag)
+    packager.finish()
+
+    report = packager.report()
+    assert report["parts"] == len(expected)
+    assert report["bytes"] == sum(len(f) for f in expected)
+    assert report["media_seconds"] == pytest.approx(len(expected) * 9 / 16, abs=1e-3)
+
+
+def test_fragment_before_init_is_rejected(tmp_path: Path) -> None:
+    packager = LLHLSPackager(out_dir=tmp_path, part_duration=9 / 16)
+    with pytest.raises(RuntimeError):
+        packager.add_fragment(b"\x00" * 32)


### PR DESCRIPTION
## Purpose

Adds `examples/online_serving/streaming_video_hls/`, which packages the
`WS /v1/realtime/video` fragment stream into a live LL-HLS playlist.

Proposed in #7014, which carries the fuller motivation. Opening the PR alongside so the
code is there to look at; happy to close it if the answer to that issue is no.

Context: #6872 and #6885 are making chunks available earlier. Once those chunks are on
the wire, both existing consumers terminate at a single viewer. `streaming_video_client.py`
saves chunks and remuxes to a progressive MP4 after `session.done`; `gradio_demo.py`
appends fragments through MSE in one attached browser. Neither produces something a second
viewer can open, and neither reports when a frame first becomes playable.

The server already emits fragmented MP4, which is the container LL-HLS and DASH use, so
publishing each fragment as an `EXT-X-PART` is packaging rather than transcoding. Fragments
are written verbatim.

## Changes

Four new files under `examples/online_serving/streaming_video_hls/`, no changes anywhere
else in the tree:

| File | Purpose |
|---|---|
| `fmp4.py` | Incremental fMP4 splitter. Stdlib only |
| `llhls.py` | Publishes fragments as LL-HLS parts, maintains the playlist, records latency |
| `hls_client.py` | Connects to the server and drives both |
| `test_hls_packaging.py` | 10 tests requiring no GPU, no server and no ffmpeg |
| `README.md` | Usage, and how this differs from the existing example |

Model-agnostic: it inspects only the container, never the prompt, pipeline or model.

## Design notes

**WebSocket framing and MP4 box boundaries are independent.** A splitter that assumes one
binary frame equals one fragment appears to work until framing gets small. My first version
truncated the init segment when `ftyp` and `moov` completed in different reads: it passed at
8192-byte slices and failed at 17. The test parameterizes framing down to one byte at a time
to hold that closed.

**Parent segments are written, not just parts.** LL-HLS players fetch parts at the live
edge, but late joiners and ordinary players fetch the segment. A playlist naming segments
nobody wrote 404s for exactly those viewers, so there is a test asserting every URI the
playlist references resolves.

**Part duration comes from the first `video.chunk_metadata`** rather than a constant, since
frames-per-chunk is a model and config property.

## Test plan

```bash
python -m pytest examples/online_serving/streaming_video_hls/test_hls_packaging.py
# 10 passed
```

Separately checked end to end against an ffmpeg-produced fMP4 source of the shape the server
emits (640x384, 16fps, 9-frame chunks): ffmpeg decodes the resulting playlist at exit 0,
ffprobe reads back all 96 frames and 6.1875s, and the round trip is lossless. Packaging cost
was under a millisecond per part, mean 0.771ms and max 2.903ms, so the delivery path is not
where latency lives and a real-time factor at or below 1 survives it.

## Known limitation

`hls_client.py` has not been run against a live server. Development used a synthetic source
because H3-class generation needs a GPU and this was built on an Apple M2. The splitter and
packager are covered by the tests; the protocol handling is the part still wanting a real
run, and I would rather say so than imply coverage I do not have. If a maintainer can point
the client at a running instance, that is the gap.

## Checklist

- [x] SPDX headers on every new file
- [x] No `torch.cuda`, no forbidden imports (stdlib plus optional `websockets`)
- [x] Tests pass under the project's pytest configuration
- [x] No changes outside `examples/`
