### PR TITLE
[Bugfix] Fix offline example profiler configuration

### DIFF
--- a/examples/offline_inference/qwen2_5_omni/end2end.py
+++ b/examples/offline_inference/qwen2_5_omni/end2end.py
@@ -5,10 +5,11 @@ This example shows how to use vLLM-Omni for running offline inference
 with the correct prompt format on Qwen2.5-Omni
 """
 
+import argparse
 import json
 import os
 import time
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 import numpy as np
 import soundfile as sf
@@ -29,6 +30,16 @@ SEED = 42
 class QueryResult(NamedTuple):
     inputs: dict
     limit_mm_per_prompt: dict[str, int]
+
+
+def parse_profiler_config(value: str) -> dict[str, Any]:
+    try:
+        config = json.loads(value)
+    except json.JSONDecodeError as e:
+        raise argparse.ArgumentTypeError(f"--profiler-config must be valid JSON: {e}") from e
+    if not isinstance(config, dict):
+        raise argparse.ArgumentTypeError("--profiler-config must be a JSON object")
+    return config
 
 
 # NOTE: The default `max_num_seqs` and `max_model_len` may result in OOM on
@@ -378,11 +389,11 @@ def main(args):
         for i, prompt in enumerate(prompts):
             prompt["modalities"] = output_modalities
 
-    profiler_enabled = bool(os.getenv("VLLM_TORCH_PROFILER_DIR"))
+    profiler_enabled = args.profiler_config is not None
     if profiler_enabled and hasattr(omni, "start_profile"):
         omni.start_profile(stages=[0])
     elif profiler_enabled:
-        print("[Warn] VLLM_TORCH_PROFILER_DIR is set, but current engine does not support profiler controls.")
+        print("[Warn] --profiler-config was provided, but current engine does not support profiler controls.")
     omni_generator = omni.generate(prompts, sampling_params_list, py_generator=args.py_generator)
 
     # Determine output directory: prefer --output-dir; fallback to --output-wav
@@ -457,6 +468,12 @@ def parse_args():
         action="store_true",
         default=False,
         help="Enable writing detailed statistics (default: disabled)",
+    )
+    parser.add_argument(
+        "--profiler-config",
+        type=parse_profiler_config,
+        default=None,
+        help='JSON profiler config for torch/cuda profiling, e.g. \'{"profiler":"torch","torch_profiler_dir":"./perf"}\'.',
     )
     parser.add_argument(
         "--stage-init-timeout",

--- a/examples/offline_inference/qwen2_5_omni/end2end.py
+++ b/examples/offline_inference/qwen2_5_omni/end2end.py
@@ -5,11 +5,10 @@ This example shows how to use vLLM-Omni for running offline inference
 with the correct prompt format on Qwen2.5-Omni
 """
 
-import argparse
 import json
 import os
 import time
-from typing import Any, NamedTuple
+from typing import NamedTuple
 
 import numpy as np
 import soundfile as sf
@@ -22,6 +21,7 @@ from vllm.multimodal.media.audio import load_audio
 from vllm.sampling_params import SamplingParams
 
 from vllm_omni.entrypoints.omni import Omni
+from vllm_omni.utils.profiler import add_profiler_config_arg
 from vllm_omni.utils.tracking_parser import TrackingArgumentParser
 
 SEED = 42
@@ -30,16 +30,6 @@ SEED = 42
 class QueryResult(NamedTuple):
     inputs: dict
     limit_mm_per_prompt: dict[str, int]
-
-
-def parse_profiler_config(value: str) -> dict[str, Any]:
-    try:
-        config = json.loads(value)
-    except json.JSONDecodeError as e:
-        raise argparse.ArgumentTypeError(f"--profiler-config must be valid JSON: {e}") from e
-    if not isinstance(config, dict):
-        raise argparse.ArgumentTypeError("--profiler-config must be a JSON object")
-    return config
 
 
 # NOTE: The default `max_num_seqs` and `max_model_len` may result in OOM on
@@ -336,6 +326,7 @@ def main(args):
     else:
         query_result = query_func()
     args.quantization_config = quantization_config
+    # ``vars(args)`` below forwards profiler_config to Omni.
     omni_kwargs = vars(args).copy()
     # Override CLI --model with the derived model_name.
     omni_kwargs["model"] = model_name
@@ -469,12 +460,7 @@ def parse_args():
         default=False,
         help="Enable writing detailed statistics (default: disabled)",
     )
-    parser.add_argument(
-        "--profiler-config",
-        type=parse_profiler_config,
-        default=None,
-        help='JSON profiler config for torch/cuda profiling, e.g. \'{"profiler":"torch","torch_profiler_dir":"./perf"}\'.',
-    )
+    add_profiler_config_arg(parser)
     parser.add_argument(
         "--stage-init-timeout",
         type=int,

--- a/examples/offline_inference/text_to_speech/cosyvoice3/end2end.py
+++ b/examples/offline_inference/text_to_speech/cosyvoice3/end2end.py
@@ -1,11 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import argparse
-import json
 import os
 import urllib.request
 from pathlib import Path
-from typing import Any
 
 import numpy as np
 import soundfile as sf
@@ -16,19 +14,10 @@ from vllm_omni.entrypoints.omni import Omni
 from vllm_omni.model_executor.models.cosyvoice3.tokenizer import get_qwen_tokenizer
 from vllm_omni.model_executor.models.cosyvoice3.utils import extract_text_token
 from vllm_omni.transformers_utils.configs.cosyvoice3 import CosyVoice3Config
+from vllm_omni.utils.profiler import add_profiler_config_arg
 
 # Upstream zero-shot reference clip
 ZERO_SHOT_PROMPT_URL = "https://raw.githubusercontent.com/FunAudioLLM/CosyVoice/main/asset/zero_shot_prompt.wav"
-
-
-def parse_profiler_config(value: str) -> dict[str, Any]:
-    try:
-        config = json.loads(value)
-    except json.JSONDecodeError as e:
-        raise argparse.ArgumentTypeError(f"--profiler-config must be valid JSON: {e}") from e
-    if not isinstance(config, dict):
-        raise argparse.ArgumentTypeError("--profiler-config must be a JSON object")
-    return config
 
 
 def _default_ref_audio() -> str:
@@ -57,12 +46,7 @@ def run_e2e():
         help="Override the deploy config path. If unset, auto-loads "
         "vllm_omni/deploy/cosyvoice3.yaml based on the HF model_type.",
     )
-    parser.add_argument(
-        "--profiler-config",
-        type=parse_profiler_config,
-        default=None,
-        help='JSON profiler config for torch/cuda profiling, e.g. \'{"profiler":"torch","torch_profiler_dir":"./perf"}\'.',
-    )
+    add_profiler_config_arg(parser)
     parser.add_argument("--text", type=str, default="Hello, this is a test of the CosyVoice system capability.")
     parser.add_argument(
         "--prompt-text",

--- a/examples/offline_inference/text_to_speech/cosyvoice3/end2end.py
+++ b/examples/offline_inference/text_to_speech/cosyvoice3/end2end.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import argparse
+import json
 import os
 import urllib.request
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import soundfile as sf
@@ -17,6 +19,16 @@ from vllm_omni.transformers_utils.configs.cosyvoice3 import CosyVoice3Config
 
 # Upstream zero-shot reference clip
 ZERO_SHOT_PROMPT_URL = "https://raw.githubusercontent.com/FunAudioLLM/CosyVoice/main/asset/zero_shot_prompt.wav"
+
+
+def parse_profiler_config(value: str) -> dict[str, Any]:
+    try:
+        config = json.loads(value)
+    except json.JSONDecodeError as e:
+        raise argparse.ArgumentTypeError(f"--profiler-config must be valid JSON: {e}") from e
+    if not isinstance(config, dict):
+        raise argparse.ArgumentTypeError("--profiler-config must be a JSON object")
+    return config
 
 
 def _default_ref_audio() -> str:
@@ -44,6 +56,12 @@ def run_e2e():
         default=None,
         help="Override the deploy config path. If unset, auto-loads "
         "vllm_omni/deploy/cosyvoice3.yaml based on the HF model_type.",
+    )
+    parser.add_argument(
+        "--profiler-config",
+        type=parse_profiler_config,
+        default=None,
+        help='JSON profiler config for torch/cuda profiling, e.g. \'{"profiler":"torch","torch_profiler_dir":"./perf"}\'.',
     )
     parser.add_argument("--text", type=str, default="Hello, this is a test of the CosyVoice system capability.")
     parser.add_argument(
@@ -79,6 +97,7 @@ def run_e2e():
         deploy_config=args.deploy_config,
         tokenizer=args.tokenizer,
         log_stats=True,
+        profiler_config=args.profiler_config,
     )
 
     sampling_cfg = {"top_p": 0.8, "top_k": 25, "eos_token_id": 6561 + 1}
@@ -149,8 +168,8 @@ def run_e2e():
 
     sampling_params_list = [gpt_sampling, s2mel_sampling]
 
-    # Start profiling (requires VLLM_TORCH_PROFILER_DIR env var)
-    if os.environ.get("VLLM_TORCH_PROFILER_DIR"):
+    profiler_enabled = args.profiler_config is not None
+    if profiler_enabled:
         print("Starting profiler...")
         omni.start_profile()
 
@@ -158,7 +177,7 @@ def run_e2e():
     outputs = list(omni.generate(prompts, sampling_params_list=sampling_params_list[:2]))
 
     # Stop profiling and get results
-    if os.environ.get("VLLM_TORCH_PROFILER_DIR"):
+    if profiler_enabled:
         print("Stopping profiler...")
         profile_results = omni.stop_profile()
         print(f"Profile traces saved to: {profile_results}")

--- a/tests/docs/test_offline_profiler_config.py
+++ b/tests/docs/test_offline_profiler_config.py
@@ -18,6 +18,6 @@ _EXAMPLES = (
 def test_offline_examples_use_typed_profiler_config(relative_path: str):
     source = (_REPO_ROOT / relative_path).read_text(encoding="utf-8")
 
-    assert "--profiler-config" in source
+    assert "add_profiler_config_arg(parser)" in source
     assert "profiler_enabled = args.profiler_config is not None" in source
     assert "VLLM_TORCH_PROFILER_DIR" not in source

--- a/tests/docs/test_offline_profiler_config.py
+++ b/tests/docs/test_offline_profiler_config.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_EXAMPLES = (
+    "examples/offline_inference/text_to_speech/cosyvoice3/end2end.py",
+    "examples/offline_inference/qwen2_5_omni/end2end.py",
+)
+
+
+@pytest.mark.parametrize("relative_path", _EXAMPLES)
+def test_offline_examples_use_typed_profiler_config(relative_path: str):
+    source = (_REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+    assert "--profiler-config" in source
+    assert "profiler_enabled = args.profiler_config is not None" in source
+    assert "VLLM_TORCH_PROFILER_DIR" not in source

--- a/vllm_omni/utils/profiler.py
+++ b/vllm_omni/utils/profiler.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+
+def parse_json_object(value: str, flag_name: str = "argument") -> dict[str, Any]:
+    """Parse a CLI value as a JSON object, attributing errors to ``flag_name``."""
+    try:
+        config = json.loads(value)
+    except json.JSONDecodeError as e:
+        raise argparse.ArgumentTypeError(f"{flag_name} must be valid JSON: {e}") from e
+    if not isinstance(config, dict):
+        raise argparse.ArgumentTypeError(f"{flag_name} must be a JSON object")
+    return config
+
+
+def parse_profiler_config(value: str) -> dict[str, Any]:
+    """Parse the JSON object passed to ``--profiler-config``."""
+    return parse_json_object(value, flag_name="--profiler-config")
+
+
+def add_profiler_config_arg(parser: argparse.ArgumentParser) -> None:
+    """Add the shared JSON profiler configuration option to ``parser``."""
+    parser.add_argument(
+        "--profiler-config",
+        type=parse_profiler_config,
+        default=None,
+        help=(
+            "JSON profiler config for torch/cuda profiling, e.g. "
+            '\'{"profiler":"torch","torch_profiler_dir":"./perf"}\'.'
+        ),
+    )


### PR DESCRIPTION
## Purpose

Make offline profiling explicit and consistent by adding a validated `--profiler-config` JSON option to the Qwen2.5-Omni and CosyVoice3 examples. Start and stop profiling based on that option instead of the unrelated `VLLM_TORCH_PROFILER_DIR` environment variable. Share the argument parser through `vllm_omni.utils.profiler`, and document that Qwen2.5 forwards the parsed configuration through `vars(args)` to `Omni`.

## Test Plan

**vLLM Version:** Not available; runtime dependencies are not installed in this workspace.

**VLLM-Omni Commit:** d97bc28c681b1d5ac7cadf3b8cf9495fc225154b

## Test Result

- `python3 -m compileall -q examples/offline_inference/qwen2_5_omni/end2end.py examples/offline_inference/text_to_speech/cosyvoice3/end2end.py vllm_omni/utils/profiler.py tests/docs/test_offline_profiler_config.py` — passed
- `git diff --check` — passed
- `uv run --no-project --with ruff ruff check vllm_omni/utils/profiler.py examples/offline_inference/qwen2_5_omni/end2end.py examples/offline_inference/text_to_speech/cosyvoice3/end2end.py tests/docs/test_offline_profiler_config.py` — passed
- `uv run --no-project --with pytest pytest -o addopts='' --confcutdir=tests/docs -q tests/docs/test_offline_profiler_config.py` — passed (`2 passed`, one non-blocking unknown-config warning)
- Full runtime tests — not run: `torch`, `vllm`, and related runtime dependencies are unavailable