### PR TITLE
[Test] Slim diffusion communication CPU coverage

### DIFF
--- a/tests/diffusion/distributed/test_comm.py
+++ b/tests/diffusion/distributed/test_comm.py
@@ -8,20 +8,15 @@ checks on real multi-GPU NCCL collectives.
 
 from __future__ import annotations
 
-import os
 from typing import Literal
 
 import pytest
 import torch
+import torch.distributed as dist
 
 from tests.helpers.mark import hardware_marks
+from tests.helpers.runtime import get_distributed_init_method
 from vllm_omni.diffusion.distributed.comm import RingComm, SeqAllToAll4D, SeqAllToAll5D
-from vllm_omni.diffusion.distributed.parallel_state import (
-    destroy_distributed_env,
-    get_sp_group,
-    init_distributed_environment,
-    initialize_model_parallel,
-)
 from vllm_omni.platforms import current_omni_platform
 
 _L4_TWO_GPU = hardware_marks(res={"cuda": "L4"}, num_cards=2)
@@ -30,65 +25,32 @@ _L4_FOUR_GPU = hardware_marks(res={"cuda": "L4"}, num_cards=4)
 DeviceKind = Literal["cpu", "cuda"]
 
 
-def _update_environment_variables(envs_dict: dict[str, str]) -> None:
-    for key, value in envs_dict.items():
-        os.environ[key] = value
-
-
 def _worker_device(local_rank: int, device_kind: DeviceKind) -> torch.device:
     if device_kind == "cpu":
         return torch.device("cpu")
     return torch.device(f"{current_omni_platform.device_type}:{local_rank}")
 
 
-def _init_worker(
-    local_rank: int,
-    world_size: int,
-    master_port: int,
-    device_kind: DeviceKind,
-) -> None:
-    _update_environment_variables(
-        {
-            "RANK": str(local_rank),
-            "LOCAL_RANK": str(local_rank),
-            "WORLD_SIZE": str(world_size),
-            "MASTER_ADDR": "localhost",
-            "MASTER_PORT": str(master_port),
-        }
-    )
-    backend = "gloo" if device_kind == "cpu" else None
-    init_distributed_environment(backend=backend)
-
-
 def _close_tolerance(dtype: torch.dtype) -> tuple[float, float]:
-    if dtype == torch.bfloat16:
-        return 1e-3, 1e-3
-    if dtype == torch.float16:
+    if dtype in (torch.bfloat16, torch.float16):
         return 1e-3, 1e-3
     return 1e-5, 1e-5
 
 
-def _run_4d_identity(
-    local_rank: int,
-    world_size: int,
+def _assert_4d_identity(
+    group: dist.ProcessGroup,
+    *,
     dtype: torch.dtype,
-    batch_size: int,
-    seq_len_per_rank: int,
-    num_heads: int,
-    head_size: int,
+    device: torch.device,
+    world_size: int,
     use_sync: bool,
-    device_kind: DeviceKind,
-    master_port: int,
 ) -> None:
-    device = _worker_device(local_rank, device_kind)
-    if device_kind == "cuda":
-        current_omni_platform.set_device(device)
+    batch_size = 2
+    seq_len_per_rank = 8
+    num_heads = 8
+    head_size = 32
 
-    _init_worker(local_rank, world_size, master_port, device_kind)
-    initialize_model_parallel(ulysses_degree=world_size)
-    sp_group = get_sp_group().ulysses_group
-
-    torch.manual_seed(42 + local_rank)
+    torch.manual_seed(42 + dist.get_rank(group))
     input_tensor = torch.randn(
         batch_size,
         seq_len_per_rank,
@@ -99,7 +61,7 @@ def _run_4d_identity(
     )
     original_input = input_tensor.clone()
 
-    intermediate = SeqAllToAll4D.apply(sp_group, input_tensor, 2, 1, use_sync)
+    intermediate = SeqAllToAll4D.apply(group, input_tensor, 2, 1, use_sync)
     expected_intermediate_shape = (
         batch_size,
         seq_len_per_rank * world_size,
@@ -110,7 +72,7 @@ def _run_4d_identity(
         f"Intermediate shape mismatch: expected {expected_intermediate_shape}, got {intermediate.shape}"
     )
 
-    output = SeqAllToAll4D.apply(sp_group, intermediate, 1, 2, use_sync)
+    output = SeqAllToAll4D.apply(group, intermediate, 1, 2, use_sync)
     assert output.shape == original_input.shape, (
         f"Output shape mismatch: expected {original_input.shape}, got {output.shape}"
     )
@@ -121,32 +83,24 @@ def _run_4d_identity(
         original_input,
         rtol=rtol,
         atol=atol,
-        msg="Output does not match original input after two all-to-all operations",
+        msg="Output does not match original input after two 4D all-to-all operations",
     )
-    destroy_distributed_env()
 
 
-def _run_5d_identity(
-    local_rank: int,
-    world_size: int,
+def _assert_5d_identity(
+    group: dist.ProcessGroup,
+    *,
     dtype: torch.dtype,
-    batch_size: int,
-    seq_len_per_rank: int,
-    num_heads: int,
-    head_size: int,
+    device: torch.device,
+    world_size: int,
     use_sync: bool,
-    device_kind: DeviceKind,
-    master_port: int,
 ) -> None:
-    device = _worker_device(local_rank, device_kind)
-    if device_kind == "cuda":
-        current_omni_platform.set_device(device)
+    batch_size = 2
+    seq_len_per_rank = 8
+    num_heads = 8
+    head_size = 32
 
-    _init_worker(local_rank, world_size, master_port, device_kind)
-    initialize_model_parallel(ulysses_degree=world_size)
-    sp_group = get_sp_group().ulysses_group
-
-    torch.manual_seed(42 + local_rank)
+    torch.manual_seed(42 + dist.get_rank(group))
     input_tensor = torch.randn(
         batch_size,
         seq_len_per_rank,
@@ -158,7 +112,7 @@ def _run_5d_identity(
     )
     original_input = input_tensor.clone()
 
-    intermediate = SeqAllToAll5D.apply(sp_group, input_tensor, 3, 1, use_sync)
+    intermediate = SeqAllToAll5D.apply(group, input_tensor, 3, 1, use_sync)
     expected_intermediate_shape = (
         batch_size,
         seq_len_per_rank * world_size,
@@ -170,7 +124,7 @@ def _run_5d_identity(
         f"Intermediate shape mismatch: expected {expected_intermediate_shape}, got {intermediate.shape}"
     )
 
-    output = SeqAllToAll5D.apply(sp_group, intermediate, 1, 3, use_sync)
+    output = SeqAllToAll5D.apply(group, intermediate, 1, 3, use_sync)
     assert output.shape == original_input.shape, (
         f"Output shape mismatch: expected {original_input.shape}, got {output.shape}"
     )
@@ -181,134 +135,110 @@ def _run_5d_identity(
         original_input,
         rtol=rtol,
         atol=atol,
-        msg="Output does not match original input after two all-to-all operations",
+        msg="Output does not match original input after two 5D all-to-all operations",
     )
-    destroy_distributed_env()
 
 
-def _run_ring_p2p(
+def _assert_ring_p2p(
+    group: dist.ProcessGroup,
+    *,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> None:
+    local_rank = dist.get_rank(group)
+    world_size = dist.get_world_size(group)
+    comm = RingComm(group)
+    input_tensor = torch.full(
+        (2, 8, 128),
+        fill_value=float(local_rank + 1),
+        dtype=dtype,
+        device=device,
+    )
+    recv_tensor = comm.send_recv(input_tensor)
+    comm.commit()
+    comm.wait()
+
+    prev_rank = (local_rank - 1 + world_size) % world_size
+    expected_tensor = torch.full_like(recv_tensor, fill_value=float(prev_rank + 1))
+    rtol, atol = _close_tolerance(dtype)
+    torch.testing.assert_close(
+        recv_tensor,
+        expected_tensor,
+        rtol=rtol,
+        atol=atol,
+        msg=f"[Rank {local_rank}] Ring P2P data mismatch",
+    )
+
+
+def _run_comm_checks(
     local_rank: int,
     world_size: int,
     dtype: torch.dtype,
-    batch_size: int,
-    num_heads: int,
-    head_size: int,
+    checks: tuple[str, ...],
+    use_sync_values: tuple[bool, ...],
     device_kind: DeviceKind,
-    master_port: int,
+    init_method: str,
+    run_ring: bool,
 ) -> None:
     device = _worker_device(local_rank, device_kind)
     if device_kind == "cuda":
         current_omni_platform.set_device(device)
 
+    backend = "gloo" if device_kind == "cpu" else "nccl"
     try:
-        _init_worker(local_rank, world_size, master_port, device_kind)
-        initialize_model_parallel(ring_degree=world_size)
-        sp_group = get_sp_group()
-        comm = RingComm(sp_group.ring_group)
-
-        input_tensor = torch.full(
-            (batch_size, num_heads, head_size),
-            fill_value=float(local_rank + 1),
-            dtype=dtype,
-            device=device,
+        dist.init_process_group(
+            backend,
+            init_method=init_method,
+            rank=local_rank,
+            world_size=world_size,
         )
-        recv_tensor = comm.send_recv(input_tensor)
-        comm.commit()
-        comm.wait()
-
-        prev_rank = (local_rank - 1 + world_size) % world_size
-        expected_value = float(prev_rank + 1)
-        expected_tensor = torch.full_like(recv_tensor, fill_value=expected_value)
-        rtol, atol = _close_tolerance(dtype)
-        torch.testing.assert_close(
-            recv_tensor,
-            expected_tensor,
-            rtol=rtol,
-            atol=atol,
-            msg=f"[Rank {local_rank}] Ring P2P data mismatch",
-        )
+        group = dist.group.WORLD
+        for use_sync in use_sync_values:
+            if "4d" in checks:
+                _assert_4d_identity(
+                    group,
+                    dtype=dtype,
+                    device=device,
+                    world_size=world_size,
+                    use_sync=use_sync,
+                )
+            if "5d" in checks:
+                _assert_5d_identity(
+                    group,
+                    dtype=dtype,
+                    device=device,
+                    world_size=world_size,
+                    use_sync=use_sync,
+                )
+        if run_ring:
+            _assert_ring_p2p(group, dtype=dtype, device=device)
     finally:
-        destroy_distributed_env()
+        if dist.is_initialized():
+            dist.destroy_process_group()
 
 
-def _spawn_4d_identity(
+def _spawn_comm_checks(
     *,
     world_size: int,
     dtype: torch.dtype,
-    batch_size: int,
-    seq_len_per_rank: int,
-    num_heads: int,
-    head_size: int,
-    use_sync: bool,
+    checks: tuple[str, ...],
+    use_sync_values: tuple[bool, ...],
     device_kind: DeviceKind,
-    master_port: int,
+    run_ring: bool = False,
 ) -> None:
     torch.multiprocessing.spawn(
-        _run_4d_identity,
+        _run_comm_checks,
         args=(
             world_size,
             dtype,
-            batch_size,
-            seq_len_per_rank,
-            num_heads,
-            head_size,
-            use_sync,
+            checks,
+            use_sync_values,
             device_kind,
-            master_port,
+            get_distributed_init_method(),
+            run_ring,
         ),
         nprocs=world_size,
     )
-
-
-def _spawn_5d_identity(
-    *,
-    world_size: int,
-    dtype: torch.dtype,
-    batch_size: int,
-    seq_len_per_rank: int,
-    num_heads: int,
-    head_size: int,
-    use_sync: bool,
-    device_kind: DeviceKind,
-    master_port: int,
-) -> None:
-    torch.multiprocessing.spawn(
-        _run_5d_identity,
-        args=(
-            world_size,
-            dtype,
-            batch_size,
-            seq_len_per_rank,
-            num_heads,
-            head_size,
-            use_sync,
-            device_kind,
-            master_port,
-        ),
-        nprocs=world_size,
-    )
-
-
-def _spawn_ring_p2p(
-    *,
-    world_size: int,
-    dtype: torch.dtype,
-    batch_size: int,
-    num_heads: int,
-    head_size: int,
-    device_kind: DeviceKind,
-    master_port: int,
-) -> None:
-    torch.multiprocessing.spawn(
-        _run_ring_p2p,
-        args=(world_size, dtype, batch_size, num_heads, head_size, device_kind, master_port),
-        nprocs=world_size,
-    )
-
-
-def _require_heads_divisible(num_heads: int, world_size: int) -> None:
-    if num_heads % world_size != 0:
-        pytest.skip(f"num_heads ({num_heads}) not divisible by world_size ({world_size})")
 
 
 def _require_gpus(world_size: int) -> None:
@@ -317,97 +247,17 @@ def _require_gpus(world_size: int) -> None:
         pytest.skip(f"Test requires {world_size} GPUs but only {available_gpus} available")
 
 
-# ---------------------------------------------------------------------------
-# CPU: gloo collectives on CPU tensors (no GPU)
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.core_model
 @pytest.mark.diffusion
 @pytest.mark.cpu
-@pytest.mark.parametrize("world_size", [2, 4])
-@pytest.mark.parametrize("use_sync", [False, True])
-def test_4d_identity(world_size: int, use_sync: bool):
-    _require_heads_divisible(8, world_size)
-    _spawn_4d_identity(
-        world_size=world_size,
+def test_cpu_comm_primitives():
+    _spawn_comm_checks(
+        world_size=2,
         dtype=torch.float32,
-        batch_size=2,
-        seq_len_per_rank=8,
-        num_heads=8,
-        head_size=32,
-        use_sync=use_sync,
+        checks=("4d", "5d"),
+        use_sync_values=(False,),
         device_kind="cpu",
-        master_port=29610,
-    )
-
-
-@pytest.mark.core_model
-@pytest.mark.diffusion
-@pytest.mark.cpu
-@pytest.mark.parametrize("world_size", [2, 4])
-@pytest.mark.parametrize("use_sync", [False, True])
-def test_5d_identity(world_size: int, use_sync: bool):
-    _require_heads_divisible(8, world_size)
-    _spawn_5d_identity(
-        world_size=world_size,
-        dtype=torch.float32,
-        batch_size=2,
-        seq_len_per_rank=8,
-        num_heads=8,
-        head_size=32,
-        use_sync=use_sync,
-        device_kind="cpu",
-        master_port=29611,
-    )
-
-
-@pytest.mark.core_model
-@pytest.mark.diffusion
-@pytest.mark.cpu
-@pytest.mark.parametrize("world_size", [2, 4])
-def test_ring_p2p(world_size: int):
-    _spawn_ring_p2p(
-        world_size=world_size,
-        dtype=torch.float32,
-        batch_size=2,
-        num_heads=8,
-        head_size=128,
-        device_kind="cpu",
-        master_port=29612,
-    )
-
-
-# ---------------------------------------------------------------------------
-# Nightly: same checks on real multi-GPU NCCL collectives
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.full_model
-@pytest.mark.diffusion
-@pytest.mark.parallel
-@pytest.mark.parametrize(
-    "world_size",
-    [
-        pytest.param(2, marks=_L4_TWO_GPU),
-        pytest.param(4, marks=_L4_FOUR_GPU),
-    ],
-)
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-@pytest.mark.parametrize("use_sync", [False, True])
-def test_4d_identity_parity(world_size: int, dtype: torch.dtype, use_sync: bool):
-    _require_gpus(world_size)
-    _require_heads_divisible(8, world_size)
-    _spawn_4d_identity(
-        world_size=world_size,
-        dtype=dtype,
-        batch_size=2,
-        seq_len_per_rank=8,
-        num_heads=8,
-        head_size=32,
-        use_sync=use_sync,
-        device_kind="cuda",
-        master_port=29500,
+        run_ring=True,
     )
 
 
@@ -422,20 +272,36 @@ def test_4d_identity_parity(world_size: int, dtype: torch.dtype, use_sync: bool)
     ],
 )
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-@pytest.mark.parametrize("use_sync", [False, True])
-def test_5d_identity_parity(world_size: int, dtype: torch.dtype, use_sync: bool):
+def test_4d_identity_parity(world_size: int, dtype: torch.dtype):
     _require_gpus(world_size)
-    _require_heads_divisible(8, world_size)
-    _spawn_5d_identity(
+    _spawn_comm_checks(
         world_size=world_size,
         dtype=dtype,
-        batch_size=2,
-        seq_len_per_rank=8,
-        num_heads=8,
-        head_size=32,
-        use_sync=use_sync,
+        checks=("4d",),
+        use_sync_values=(False, True),
         device_kind="cuda",
-        master_port=29502,
+    )
+
+
+@pytest.mark.full_model
+@pytest.mark.diffusion
+@pytest.mark.parallel
+@pytest.mark.parametrize(
+    "world_size",
+    [
+        pytest.param(2, marks=_L4_TWO_GPU),
+        pytest.param(4, marks=_L4_FOUR_GPU),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_5d_identity_parity(world_size: int, dtype: torch.dtype):
+    _require_gpus(world_size)
+    _spawn_comm_checks(
+        world_size=world_size,
+        dtype=dtype,
+        checks=("5d",),
+        use_sync_values=(False, True),
+        device_kind="cuda",
     )
 
 
@@ -452,12 +318,11 @@ def test_5d_identity_parity(world_size: int, dtype: torch.dtype, use_sync: bool)
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 def test_ring_p2p_parity(world_size: int, dtype: torch.dtype):
     _require_gpus(world_size)
-    _spawn_ring_p2p(
+    _spawn_comm_checks(
         world_size=world_size,
         dtype=dtype,
-        batch_size=2,
-        num_heads=8,
-        head_size=128,
+        checks=(),
+        use_sync_values=(),
         device_kind="cuda",
-        master_port=29501,
+        run_ring=True,
     )


### PR DESCRIPTION
## Summary

- slim the L1 CPU communication coverage to one 2-rank Gloo spawn covering 4D, 5D, and ring contracts
- reuse one process group inside each worker and remove full model-parallel initialization from the CPU path
- use `get_distributed_init_method()` for file-based rendezvous and reuse sync checks inside each nightly worker while preserving parity test names and matrices

## Validation

- `python -m py_compile tests/diffusion/distributed/test_comm.py`
- `python -m ruff check tests/diffusion/distributed/test_comm.py`
- `python -m ruff format --check tests/diffusion/distributed/test_comm.py`
- `python tools/pre_commit/check_test_marks.py tests/diffusion/distributed/test_comm.py`
- RTX 4090 (driver 595.84): two repeated 2-rank Gloo runs passed for 4D identity, 5D identity, and ring P2P; a 1-rank CUDA/NCCL smoke covering both sync modes also passed.
- Full repository pytest collection is unavailable in the remote environment because its installed vLLM/CUDA extension stack is not compatible with this checkout.
**Environment**
- 1x NVIDIA RTX 4090 (24 GB), 24 CPU cores, Ubuntu
- Python 3.12, torch 2.11.0, vllm 0.28.0, vllm-omni @ 764ddd9 (this PR head)

**Validation**
- New suite (`tests/diffusion/distributed/test_comm.py`): `1 passed, 12 skipped in 7.22s`
  - `test_cpu_comm_primitives` PASSED (world_size=2, gloo; covers 4D/5D all-to-all identity + ring P2P in a single spawn)
  - The 12 CUDA parity cases skip on this single-GPU box (`_require_gpus` needs 2/4 cards), as designed.
- Legacy suite (parent commit `fda3af8`, run from the same checkout): `10 passed, 20 skipped in 75.12s` - all CPU cases pass, CUDA parity cases skip identically.

**Runtime comparison (CPU coverage, same machine)**
| Suite | CPU tests | Wall time |
|---|---|---|
| Before (legacy) | 10 passed (ws 2+4, sync+async, separate spawn per case) | 75.12s |
| After (this PR) | 1 passed (single fused spawn, ws 2) | 7.18s |

Slowest per-test durations confirm the saving comes from fewer process-group spawns: legacy CPU cases cost 6.6-8.3s each (10 spawns), while the new fused `test_cpu_comm_primitives` costs 6.38s total (~10x less CPU-suite time with the same primitive coverage).
Closes #6850