### PR TITLE
[Feature][Model] Use common FusedMoE for LingBot Video

### DIFF
--- a/benchmarks/lingbot_video/README.md
+++ b/benchmarks/lingbot_video/README.md
@@ -5,11 +5,34 @@ vLLM-Omni. Run all commands from the repository root.
 
 | Benchmark | Script | Purpose |
 |-----------|--------|---------|
+| MoE block performance | `moe_block_benchmark.py` | Compare the legacy grouped-MM path and common FusedMoE at the measured production token shape |
 | Dense pipeline parity | `dense_pipeline_parity.py` | Compare generated videos and report MAE, MSE, PSNR, latency, and optional steady-state timings |
-| MoE numerical parity | `moe_transformer_parity.py` | Check bitwise parity for the sparse MoE block and the full MoE transformer |
+| MoE numerical parity | `moe_transformer_parity.py` | Check strict numerical parity and separately report bitwise equality for the sparse MoE block and full transformer |
 
-Both benchmarks require a local LingBot-Video checkout and local model files.
+The parity benchmarks require a local LingBot-Video checkout and local model files.
 They do not run in CI.
+
+## MoE block performance
+
+The default shape matches the nominal trace: 49,145 joint tokens, 128 experts,
+top-k 8, hidden size 2,048, and expert intermediate size 768. Run the same
+command from clean baseline and candidate worktrees; the JSON records the
+runner classes as fast-path evidence.
+
+```bash
+CUDA_VISIBLE_DEVICES=0 \
+python -m benchmarks.lingbot_video.moe_block_benchmark \
+  --warmups 5 \
+  --repeats 20 \
+  --output-json /tmp/lingbot_moe_block.json
+```
+
+Use `--padding-tokens N` as a separate padding stress arm. Do not mix its
+latency with the unpadded production comparison. For a production-shape block
+quality comparison, add `--output-tensor /tmp/<arm>.pt` to one baseline and
+one candidate run with identical arguments, then compare the tensors
+elementwise. Add `--routing-artifact /tmp/<arm>-routing.pt` when a mismatch
+must be split into top-k expert-ID, router-weight, and expert-execution causes.
 
 ## Dense pipeline parity
 
@@ -19,7 +42,7 @@ then compares the decoded MP4 frames.
 
 ```bash
 CUDA_VISIBLE_DEVICES=0 \
-python benchmarks/lingbot_video/dense_pipeline_parity.py \
+python -m benchmarks.lingbot_video.dense_pipeline_parity \
   --model /path/to/lingbot-video-dense-1.3b \
   --official-repo /path/to/lingbot-video \
   --output-dir /tmp/lingbot_dense_parity
@@ -32,12 +55,17 @@ pipeline diagnostic rather than a bitwise transformer check.
 ## MoE numerical parity
 
 The lightweight block comparison uses deterministic weights and inputs to
-cover correction-bias routing, group-limited top-k, routed experts, FP32
-scatter-weighted restore, padding masks, and the shared expert.
+cover correction-bias routing, group-limited top-k, routed experts, padding
+compaction and restore, and the shared expert. It reports bitwise equality
+separately because the common FusedMoE kernel numerically reorders expert
+execution. The block gate requires identical routed expert IDs, router weights
+aligned by expert ID within `rtol=3e-3, atol=2e-4`, and final output with
+relative L2 at most 0.5%, cosine at least 0.99999, and max absolute error at
+most 0.02. The full-transformer gate uses the same output thresholds.
 
 ```bash
 CUDA_VISIBLE_DEVICES=0 \
-python benchmarks/lingbot_video/moe_transformer_parity.py \
+python -m benchmarks.lingbot_video.moe_transformer_parity \
   --scope block \
   --official-repo /path/to/lingbot-video \
   --output-json /tmp/lingbot_moe_block_parity.json
@@ -49,7 +77,7 @@ sequentially and compares their output tensors. It requires a CUDA device with
 
 ```bash
 CUDA_VISIBLE_DEVICES=0 \
-python benchmarks/lingbot_video/moe_transformer_parity.py \
+python -m benchmarks.lingbot_video.moe_transformer_parity \
   --scope transformer \
   --official-repo /path/to/lingbot-video \
   --model /path/to/lingbot-video-moe-30b-a3b \
@@ -59,4 +87,5 @@ python benchmarks/lingbot_video/moe_transformer_parity.py \
 For the correctness oracle, the upstream transformer uses
 `diffusers:_native_math` and vLLM-Omni uses
 `TORCH_SDPA + SDPBackend.MATH`. The command exits with a nonzero status unless
-the selected comparisons are bitwise equal.
+the selected comparisons pass the strict numerical gate. The JSON retains an
+independent `exact` field.

--- a/benchmarks/lingbot_video/moe_block_benchmark.py
+++ b/benchmarks/lingbot_video/moe_block_benchmark.py
@@ -1,0 +1,304 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Benchmark one LingBot-Video MoE block at the measured production shape."""
+
+from __future__ import annotations
+
+import argparse
+import inspect
+import json
+import statistics
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+import torch
+from vllm.config import DeviceConfig, VllmConfig, set_current_vllm_config
+from vllm.distributed.parallel_state import (
+    destroy_distributed_environment,
+    destroy_model_parallel,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from vllm.utils.network_utils import (
+    get_distributed_init_method,
+    get_ip,
+    get_open_port,
+)
+from vllm.utils.torch_utils import set_default_torch_dtype
+from vllm.v1.worker.workspace import init_workspace_manager
+
+from vllm_omni.diffusion.models.lingbot_video.lingbot_video_transformer import (
+    LingBotVideoSparseMoeBlock,
+)
+
+
+@contextmanager
+def _single_rank_runtime(vllm_config: VllmConfig):
+    with (
+        set_current_vllm_config(vllm_config),
+        set_default_torch_dtype(torch.bfloat16),
+    ):
+        init_distributed_environment(
+            world_size=1,
+            rank=0,
+            local_rank=0,
+            distributed_init_method=get_distributed_init_method(
+                get_ip(),
+                get_open_port(),
+            ),
+            backend="nccl",
+        )
+        initialize_model_parallel()
+        init_workspace_manager(torch.device("cuda"))
+        try:
+            yield
+        finally:
+            destroy_model_parallel()
+            destroy_distributed_environment()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--num-tokens", type=int, default=49145)
+    parser.add_argument("--padding-tokens", type=int, default=0)
+    parser.add_argument("--hidden-size", type=int, default=2048)
+    parser.add_argument("--num-experts", type=int, default=128)
+    parser.add_argument("--top-k", type=int, default=8)
+    parser.add_argument("--intermediate-size", type=int, default=768)
+    parser.add_argument("--num-expert-groups", type=int, default=4)
+    parser.add_argument("--top-k-groups", type=int, default=2)
+    parser.add_argument("--route-scale", type=float, default=2.5)
+    parser.add_argument("--warmups", type=int, default=5)
+    parser.add_argument("--repeats", type=int, default=20)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output-json", type=Path, default=None)
+    parser.add_argument("--output-tensor", type=Path, default=None)
+    parser.add_argument("--routing-artifact", type=Path, default=None)
+    return parser.parse_args()
+
+
+def _initialize_block(block: LingBotVideoSparseMoeBlock, seed: int) -> str:
+    def generator(offset: int) -> torch.Generator:
+        return torch.Generator(device="cuda").manual_seed(seed + offset)
+
+    def initialize(parameter: torch.Tensor, offset: int) -> None:
+        values = torch.empty(
+            parameter.shape,
+            dtype=parameter.dtype,
+            device=parameter.device,
+        )
+        values.normal_(
+            mean=0.0,
+            std=0.02,
+            generator=generator(offset),
+        )
+        parameter.copy_(values)
+
+    runner = block.experts
+    with torch.no_grad():
+        if hasattr(runner, "routed_experts"):
+            runner.gate.to(dtype=torch.float32)
+            correction_bias = runner.routed_experts.e_score_correction_bias
+            correction_bias.data = correction_bias.data.float()
+            initialize(runner.gate.weight, 0)
+            correction_bias.zero_()
+            intermediate_size = runner.routed_experts.w13_weight.shape[1] // 2
+            initialize(
+                runner.routed_experts.w13_weight[:, :intermediate_size],
+                1,
+            )
+            initialize(runner.routed_experts.w2_weight, 2)
+            initialize(
+                runner.routed_experts.w13_weight[:, intermediate_size:],
+                3,
+            )
+            runner.routed_experts.quant_method.process_weights_after_loading(runner.routed_experts)
+            backend = "common_fused_moe"
+        else:
+            block.router.to(dtype=torch.float32)
+            initialize(block.router.weight, 0)
+            block.router.e_score_correction_bias.zero_()
+            initialize(runner.w1, 1)
+            initialize(runner.w2, 2)
+            initialize(runner.w3, 3)
+            backend = "torch_grouped_mm"
+        if block.shared_experts is not None:
+            for offset, parameter in enumerate(
+                block.shared_experts.parameters(),
+                start=4,
+            ):
+                initialize(parameter, offset)
+    return backend
+
+
+def _percentile(values: list[float], fraction: float) -> float:
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, int(round((len(ordered) - 1) * fraction)))
+    return ordered[index]
+
+
+def main() -> int:
+    args = parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("LingBot MoE block benchmark requires CUDA.")
+    if args.padding_tokens < 0 or args.padding_tokens >= args.num_tokens:
+        raise ValueError("--padding-tokens must be in [0, num_tokens).")
+
+    device = torch.device("cuda")
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+    vllm_config = VllmConfig(device_config=DeviceConfig(device="cuda"))
+
+    with _single_rank_runtime(vllm_config):
+        block_kwargs: dict[str, object] = {
+            "hidden_size": args.hidden_size,
+            "num_experts": args.num_experts,
+            "top_k": args.top_k,
+            "moe_intermediate_size": args.intermediate_size,
+            "score_func": "sigmoid",
+            "norm_topk_prob": True,
+            "n_group": args.num_expert_groups,
+            "topk_group": args.top_k_groups,
+            "routed_scaling_factor": args.route_scale,
+            "n_shared_experts": 1,
+        }
+        if "prefix" in inspect.signature(LingBotVideoSparseMoeBlock.__init__).parameters:
+            block_kwargs["prefix"] = "benchmark.lingbot_moe"
+        block = LingBotVideoSparseMoeBlock(
+            **block_kwargs,
+        ).to(device=device, dtype=torch.bfloat16)
+        backend = _initialize_block(block, args.seed)
+        hidden_states = torch.randn(
+            1,
+            args.num_tokens,
+            args.hidden_size,
+            generator=torch.Generator(device=device).manual_seed(
+                args.seed + 100,
+            ),
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        padding_mask = None
+        if args.padding_tokens:
+            padding_mask = torch.ones(
+                args.num_tokens,
+                device=device,
+                dtype=torch.float32,
+            )
+            padding_mask[-args.padding_tokens :] = 0
+
+        routing_artifact = None
+        if args.routing_artifact is not None:
+            tokens = hidden_states.reshape(-1, args.hidden_size)
+            if padding_mask is not None:
+                tokens = tokens.index_select(
+                    0,
+                    torch.where(padding_mask.bool())[0],
+                )
+            with torch.inference_mode():
+                if hasattr(block.experts, "routed_experts"):
+                    router_logits, _ = block.experts.gate(tokens)
+                    top_scores, top_indices = block.experts.router.select_experts(
+                        hidden_states=tokens,
+                        router_logits=router_logits,
+                        topk_indices_dtype=None,
+                    )
+                    gate_weight = block.experts.gate.weight
+                else:
+                    router_logits = torch.nn.functional.linear(
+                        tokens.float(),
+                        block.router.weight.float(),
+                    )
+                    top_indices, top_scores = block.router(tokens)
+                    gate_weight = block.router.weight
+            routing_artifact = {
+                "gate_weight": gate_weight.cpu(),
+                "router_logits": router_logits.cpu(),
+                "top_indices": top_indices.cpu(),
+                "top_scores": top_scores.cpu(),
+            }
+
+        def run_once() -> torch.Tensor:
+            with torch.inference_mode():
+                return block(hidden_states, padding_mask=padding_mask)
+
+        for _ in range(args.warmups):
+            output = run_once()
+        torch.accelerator.synchronize()
+        torch.accelerator.empty_cache()
+        torch.accelerator.reset_peak_memory_stats(device)
+
+        durations_ms: list[float] = []
+        start_wall = time.perf_counter()
+        for _ in range(args.repeats):
+            start = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+            start.record()
+            output = run_once()
+            end.record()
+            end.synchronize()
+            durations_ms.append(float(start.elapsed_time(end)))
+        wall_seconds = time.perf_counter() - start_wall
+
+    result = {
+        "backend": backend,
+        "fast_path": {
+            "runner": type(block.experts).__name__,
+            "routed_experts": type(getattr(block.experts, "routed_experts", block.experts)).__name__,
+            "quant_method": type(
+                getattr(
+                    getattr(block.experts, "routed_experts", None),
+                    "quant_method",
+                    None,
+                )
+            ).__name__,
+        },
+        "shape": {
+            "num_tokens": args.num_tokens,
+            "valid_tokens": args.num_tokens - args.padding_tokens,
+            "hidden_size": args.hidden_size,
+            "num_experts": args.num_experts,
+            "top_k": args.top_k,
+            "intermediate_size": args.intermediate_size,
+            "num_expert_groups": args.num_expert_groups,
+            "top_k_groups": args.top_k_groups,
+            "route_scale": args.route_scale,
+        },
+        "measurement": {
+            "warmups": args.warmups,
+            "repeats": args.repeats,
+            "median_ms": statistics.median(durations_ms),
+            "p95_ms": _percentile(durations_ms, 0.95),
+            "mean_ms": statistics.mean(durations_ms),
+            "stdev_ms": statistics.stdev(durations_ms) if len(durations_ms) > 1 else 0.0,
+            "min_ms": min(durations_ms),
+            "max_ms": max(durations_ms),
+            "wall_seconds": wall_seconds,
+            "peak_allocated_mb": torch.accelerator.max_memory_allocated(device) / 1_000_000,
+            "peak_reserved_mb": torch.accelerator.max_memory_reserved(device) / 1_000_000,
+        },
+        "output": {
+            "shape": list(output.shape),
+            "finite": bool(torch.isfinite(output).all()),
+            "checksum": float(output.float().sum()),
+        },
+    }
+    payload = json.dumps(result, indent=2, sort_keys=True)
+    print(payload)
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(payload + "\n", encoding="utf-8")
+    if args.output_tensor is not None:
+        args.output_tensor.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(output.detach().cpu(), args.output_tensor)
+    if args.routing_artifact is not None:
+        assert routing_artifact is not None
+        args.routing_artifact.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(routing_artifact, args.routing_artifact)
+    return 0 if result["output"]["finite"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/lingbot_video/moe_block_benchmark.py
+++ b/benchmarks/lingbot_video/moe_block_benchmark.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 """Benchmark one LingBot-Video MoE block at the measured production shape."""
 
@@ -148,7 +148,6 @@ def main() -> int:
 
     device = torch.device("cuda")
     torch.manual_seed(args.seed)
-    torch.cuda.manual_seed_all(args.seed)
     vllm_config = VllmConfig(device_config=DeviceConfig(device="cuda"))
 
     with _single_rank_runtime(vllm_config):

--- a/benchmarks/lingbot_video/moe_transformer_parity.py
+++ b/benchmarks/lingbot_video/moe_transformer_parity.py
@@ -35,7 +35,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--model",
         default=None,
-        help="Local MoE checkpoint path or a checkpoint already present in the Hugging Face cache.",
+        help="Local MoE checkpoint directory.",
     )
     parser.add_argument("--transformer-subfolder", default="transformer")
     parser.add_argument("--output-json", type=Path, default=None)
@@ -68,18 +68,20 @@ def _tensor_metrics(actual: torch.Tensor, expected: torch.Tensor) -> dict[str, A
     actual_float = actual.float()
     expected_float = expected.float()
     diff = (actual_float - expected_float).abs()
-    denominator = actual_float.norm() * expected_float.norm()
-    cosine = (
-        float(torch.dot(actual_float.flatten(), expected_float.flatten()) / denominator)
-        if float(denominator) > 0
-        else 1.0
-    )
+    actual_flat = actual_float.flatten().double()
+    expected_flat = expected_float.flatten().double()
+    denominator = actual_flat.norm() * expected_flat.norm()
+    cosine = float(torch.dot(actual_flat, expected_flat) / denominator) if float(denominator) > 0 else 1.0
+    expected_norm = expected_flat.norm()
     return {
         "shape": list(actual.shape),
         "equal": bool(torch.equal(actual, expected)),
         "max_abs": float(diff.max()) if diff.numel() else 0.0,
         "mean_abs": float(diff.mean()) if diff.numel() else 0.0,
         "rmse": float(torch.sqrt(torch.mean(diff.square()))) if diff.numel() else 0.0,
+        "relative_l2": (
+            float((actual_flat - expected_flat).norm() / expected_norm) if float(expected_norm) > 0 else 0.0
+        ),
         "cosine": cosine,
         "finite": bool(torch.isfinite(actual).all() and torch.isfinite(expected).all()),
     }
@@ -92,6 +94,22 @@ def _initialize_block(module: torch.nn.Module, seed: int) -> None:
             values = torch.randn(parameter.shape, generator=generator, dtype=torch.float32)
             parameter.copy_((values * 0.02).to(parameter.dtype))
         module.router.e_score_correction_bias.copy_(torch.tensor([0.9, 0.8, 1.0, 0.0, 0.7, 0.6, 0.5, 0.4]))
+
+
+def _copy_block_weights_to_common_runner(official, native) -> None:
+    runner = native.experts
+    routed_experts = runner.routed_experts
+    intermediate_size = official.experts.w1.shape[1]
+    with torch.no_grad():
+        runner.gate.weight.copy_(official.router.weight)
+        routed_experts.e_score_correction_bias.copy_(official.router.e_score_correction_bias)
+        routed_experts.w13_weight[:, :intermediate_size].copy_(official.experts.w1)
+        routed_experts.w13_weight[:, intermediate_size:].copy_(official.experts.w3)
+        routed_experts.w2_weight.copy_(official.experts.w2)
+        native.shared_experts.load_state_dict(
+            official.shared_experts.state_dict(),
+            strict=True,
+        )
 
 
 def _apply_padding(
@@ -111,8 +129,7 @@ def _run_block_parity(
     device: torch.device,
     seed: int,
 ) -> dict[str, Any]:
-    if not hasattr(torch, "_grouped_mm"):
-        raise RuntimeError("The block parity check requires torch._grouped_mm.")
+    from vllm.utils.torch_utils import set_default_torch_dtype
 
     common = {
         "hidden_size": 16,
@@ -130,11 +147,17 @@ def _run_block_parity(
         intermediate_size=32,
         **common,
     )
-    native = native_module.LingBotVideoSparseMoeBlock(**common)
-    _initialize_block(official, seed)
-    native.load_state_dict(official.state_dict(), strict=True)
+    with set_default_torch_dtype(torch.bfloat16):
+        native = native_module.LingBotVideoSparseMoeBlock(**common)
     official = official.to(device=device, dtype=torch.bfloat16).eval()
     native = native.to(device=device, dtype=torch.bfloat16).eval()
+    official.router.to(dtype=torch.float32)
+    native.experts.gate.to(dtype=torch.float32)
+    correction_bias = native.experts.routed_experts.e_score_correction_bias
+    correction_bias.data = correction_bias.data.float()
+    _initialize_block(official, seed)
+    _copy_block_weights_to_common_runner(official, native)
+    native.experts.routed_experts.quant_method.process_weights_after_loading(native.experts.routed_experts)
 
     generator = torch.Generator(device=device).manual_seed(seed)
     hidden_states = torch.randn(
@@ -151,40 +174,59 @@ def _run_block_parity(
         dtype=torch.float32,
     )
     tokens = hidden_states.reshape(-1, common["hidden_size"])
+    valid_indices = torch.where(padding_mask.bool())[0]
+    valid_tokens = tokens.index_select(0, valid_indices)
 
     with torch.inference_mode():
         official_router = official.router(tokens)
         official_indices, official_scores = official_router[:2]
-        native_indices, native_scores = native.router(tokens)
 
         official_scores = _apply_padding(
             official_scores,
             padding_mask,
             official.router.route_scale,
         )
-        native_scores = _apply_padding(
-            native_scores,
-            padding_mask,
-            native.router.route_scale,
+        native_logits, _ = native.experts.gate(valid_tokens)
+        native_scores, native_indices = native.experts.router.select_experts(
+            hidden_states=valid_tokens,
+            router_logits=native_logits,
+            topk_indices_dtype=None,
         )
         official_routed = official._run_selected_experts(
             tokens,
             official_scores,
             official_indices,
         )
-        native_routed = native._run_selected_experts(
-            tokens,
-            native_scores,
-            native_indices,
+        native_routed = tokens.new_zeros(tokens.shape)
+        native_routed.index_copy_(
+            0,
+            valid_indices,
+            native._run_routed_experts(valid_tokens),
         )
         official_shared = official.shared_experts(hidden_states)
         native_shared = native.shared_experts(hidden_states)
         official_output = official(hidden_states, padding_mask=padding_mask)
         native_output = native(hidden_states, padding_mask=padding_mask)
 
+    official_valid_indices = official_indices.index_select(0, valid_indices)
+    official_valid_scores = official_scores.index_select(0, valid_indices).float()
+    native_indices, native_order = torch.sort(native_indices.long(), dim=-1)
+    official_valid_indices, official_order = torch.sort(
+        official_valid_indices.long(),
+        dim=-1,
+    )
+    native_scores = torch.gather(native_scores.float(), 1, native_order)
+    official_valid_scores = torch.gather(
+        official_valid_scores,
+        1,
+        official_order,
+    )
     result = {
-        "router_indices_equal": bool(torch.equal(native_indices, official_indices)),
-        "router_scores": _tensor_metrics(native_scores, official_scores),
+        "router_indices_equal": bool(torch.equal(native_indices, official_valid_indices)),
+        "router_scores": _tensor_metrics(
+            native_scores,
+            official_valid_scores,
+        ),
         "routed_output": _tensor_metrics(native_routed, official_routed),
         "shared_output": _tensor_metrics(native_shared, official_shared),
         "final_output": _tensor_metrics(native_output, official_output),
@@ -195,6 +237,18 @@ def _run_block_parity(
         and result["routed_output"]["equal"]
         and result["shared_output"]["equal"]
         and result["final_output"]["equal"]
+    )
+    result["strict"] = bool(
+        result["router_indices_equal"]
+        and torch.allclose(
+            native_scores,
+            official_valid_scores,
+            rtol=3e-3,
+            atol=2e-4,
+        )
+        and result["final_output"]["relative_l2"] <= 5e-3
+        and result["final_output"]["cosine"] >= 0.99999
+        and result["final_output"]["max_abs"] <= 2e-2
     )
     return result
 
@@ -234,7 +288,7 @@ def _make_transformer_inputs(
     }
 
 
-def _load_transformer(
+def _load_official_transformer(
     transformer_cls,
     args: argparse.Namespace,
     device: torch.device,
@@ -248,6 +302,56 @@ def _load_transformer(
         low_cpu_mem_usage=True,
     )
     model = model.to(device=device, dtype=torch.bfloat16).eval()
+    torch.accelerator.synchronize()
+    return model, time.perf_counter() - start
+
+
+def _load_native_transformer(
+    transformer_cls,
+    args: argparse.Namespace,
+    device: torch.device,
+):
+    from safetensors import safe_open
+
+    from vllm_omni.diffusion.data import TransformerConfig
+    from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
+
+    transformer_dir = Path(args.model) / args.transformer_subfolder
+    config_path = transformer_dir / "config.json"
+    index_path = transformer_dir / "diffusion_pytorch_model.safetensors.index.json"
+    if not config_path.is_file() or not index_path.is_file():
+        raise FileNotFoundError(
+            f"Native transformer parity requires a local sharded checkpoint with {config_path} and {index_path}."
+        )
+
+    start = time.perf_counter()
+    config = TransformerConfig.from_dict(json.loads(config_path.read_text(encoding="utf-8")))
+    kwargs = get_transformer_config_kwargs(config, transformer_cls)
+    previous_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(torch.bfloat16)
+    try:
+        with torch.device(device):
+            model = transformer_cls(
+                **kwargs,
+                prefix="parity.transformer",
+            )
+    finally:
+        torch.set_default_dtype(previous_dtype)
+    model.to(dtype=torch.bfloat16)
+
+    weight_map = json.loads(index_path.read_text(encoding="utf-8"))["weight_map"]
+    shard_names = sorted(set(weight_map.values()))
+    for shard_name in shard_names:
+        shard_path = transformer_dir / shard_name
+        with safe_open(shard_path, framework="pt", device="cpu") as shard:
+            model.load_weights((name, shard.get_tensor(name)) for name in shard.keys())
+    for block in model.blocks:
+        if not hasattr(block.ffn, "experts"):
+            continue
+        routed_experts = getattr(block.ffn.experts, "routed_experts", None)
+        if routed_experts is not None:
+            routed_experts.quant_method.process_weights_after_loading(routed_experts)
+    model.eval()
     torch.accelerator.synchronize()
     return model, time.perf_counter() - start
 
@@ -285,7 +389,7 @@ def _run_transformer_parity(
     from vllm_omni.diffusion.config import set_current_diffusion_config
     from vllm_omni.diffusion.data import AttentionConfig, AttentionSpec, OmniDiffusionConfig
 
-    official, official_load = _load_transformer(
+    official, official_load = _load_official_transformer(
         official_module.LingBotVideoTransformer3DModel,
         args,
         device,
@@ -306,7 +410,7 @@ def _run_transformer_parity(
         ),
     )
     with set_current_diffusion_config(native_config):
-        native, native_load = _load_transformer(
+        native, native_load = _load_native_transformer(
             native_module.LingBotVideoTransformer3DModel,
             args,
             device,
@@ -343,6 +447,7 @@ def _run_transformer_parity(
         },
         "output": metrics,
         "exact": metrics["equal"],
+        "strict": bool(metrics["relative_l2"] <= 5e-3 and metrics["cosine"] >= 0.99999 and metrics["max_abs"] <= 2e-2),
     }
 
 
@@ -359,8 +464,25 @@ def main() -> int:
     os.environ["LINGBOT_MOE_REORDER_BACKEND"] = "sort"
     os.environ["LINGBOT_MOE_RESTORE_BACKEND"] = "scatter"
 
+    from vllm.config import DeviceConfig, VllmConfig, set_current_vllm_config
+    from vllm.distributed.parallel_state import (
+        destroy_distributed_environment,
+        destroy_model_parallel,
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+    from vllm.utils.network_utils import (
+        get_distributed_init_method,
+        get_ip,
+        get_open_port,
+    )
+    from vllm.v1.worker.workspace import init_workspace_manager
+
     official_module = _load_official_module(args.official_repo)
     native_module = _load_native_module()
+    vllm_config = VllmConfig(
+        device_config=DeviceConfig(device=str(device)),
+    )
 
     result: dict[str, Any] = {
         "settings": {
@@ -371,28 +493,47 @@ def main() -> int:
             "model": args.model,
         }
     }
-    if args.scope in {"block", "all"}:
-        result["block"] = _run_block_parity(
-            official_module,
-            native_module,
-            device=device,
-            seed=args.seed,
+    with set_current_vllm_config(vllm_config):
+        init_distributed_environment(
+            world_size=1,
+            rank=0,
+            local_rank=0,
+            distributed_init_method=get_distributed_init_method(
+                get_ip(),
+                get_open_port(),
+            ),
+            backend="nccl",
         )
-    if args.scope in {"transformer", "all"}:
-        result["transformer"] = _run_transformer_parity(
-            official_module,
-            native_module,
-            args=args,
-            device=device,
-        )
+        initialize_model_parallel()
+        init_workspace_manager(device)
+        try:
+            if args.scope in {"block", "all"}:
+                result["block"] = _run_block_parity(
+                    official_module,
+                    native_module,
+                    device=device,
+                    seed=args.seed,
+                )
+            if args.scope in {"transformer", "all"}:
+                result["transformer"] = _run_transformer_parity(
+                    official_module,
+                    native_module,
+                    args=args,
+                    device=device,
+                )
+        finally:
+            destroy_model_parallel()
+            destroy_distributed_environment()
 
-    result["exact"] = all(section["exact"] for name, section in result.items() if name in {"block", "transformer"})
+    selected = [section for name, section in result.items() if name in {"block", "transformer"}]
+    result["exact"] = all(section["exact"] for section in selected)
+    result["strict"] = all(section["strict"] for section in selected)
     payload = json.dumps(result, indent=2, sort_keys=True)
     print(payload)
     if args.output_json is not None:
         args.output_json.parent.mkdir(parents=True, exist_ok=True)
         args.output_json.write_text(payload + "\n", encoding="utf-8")
-    return 0 if result["exact"] else 1
+    return 0 if result["strict"] else 1
 
 
 if __name__ == "__main__":

--- a/tests/diffusion/models/lingbot_video/test_lingbot_video_moe_cuda.py
+++ b/tests/diffusion/models/lingbot_video/test_lingbot_video_moe_cuda.py
@@ -10,141 +10,160 @@ from tests.helpers.mark import hardware_test
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion]
 
 
-def _upstream_sparse_moe_reference(block, hidden_states, padding_mask=None):
-    """Independent eager reference for the upstream LingBot sparse MoE path."""
+@pytest.fixture
+def _single_rank_model_parallel(unused_tcp_port):
+    from vllm.distributed.parallel_state import (
+        destroy_distributed_environment,
+        destroy_model_parallel,
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+    from vllm.utils.network_utils import get_distributed_init_method
+
+    init_distributed_environment(
+        world_size=1,
+        rank=0,
+        local_rank=0,
+        distributed_init_method=get_distributed_init_method(
+            "127.0.0.1",
+            unused_tcp_port,
+        ),
+        backend="nccl",
+    )
+    initialize_model_parallel()
+    try:
+        yield
+    finally:
+        destroy_model_parallel()
+        destroy_distributed_environment()
+
+
+def _eager_sparse_moe_reference(block, hidden_states, padding_mask):
+    """Independent eager oracle for LingBot routing and packed expert weights."""
     batch_size, _, hidden_size = hidden_states.shape
     tokens = hidden_states.reshape(-1, hidden_size)
+    valid_indices = torch.where(padding_mask.bool())[0]
+    valid_tokens = tokens.index_select(0, valid_indices)
+    runner = block.experts
+    routed_experts = runner.routed_experts
+    router = runner.router
 
-    logits = F.linear(tokens.float(), block.router.weight.float())
-    if block.router.score_func == "softmax":
-        scores = F.softmax(logits, dim=-1)
-    else:
-        scores = logits.sigmoid()
-    scores_for_choice = scores + block.router.e_score_correction_bias.unsqueeze(0)
-
-    if block.router.n_group is not None and block.router.n_group > 1:
-        experts_per_group = block.router.num_experts // block.router.n_group
-        grouped = scores_for_choice.view(-1, block.router.n_group, experts_per_group)
-        group_scores = grouped.topk(2, dim=-1)[0].sum(dim=-1)
-        group_idx = torch.topk(
-            group_scores,
-            k=block.router.topk_group,
-            dim=-1,
-            sorted=False,
-        )[1]
-        group_mask = torch.zeros_like(group_scores)
-        group_mask.scatter_(1, group_idx, 1)
-        score_mask = group_mask.unsqueeze(-1).expand_as(grouped).reshape_as(scores_for_choice)
-        scores_for_choice = scores_for_choice.masked_fill(~score_mask.bool(), float("-inf"))
-
-    top_indices = torch.topk(
-        scores_for_choice,
-        k=block.router.top_k,
+    logits = F.linear(valid_tokens.float(), runner.gate.weight.float())
+    scores = logits.sigmoid()
+    corrected_scores = scores + routed_experts.e_score_correction_bias.unsqueeze(0)
+    grouped = corrected_scores.view(
+        -1,
+        router.num_expert_group,
+        corrected_scores.shape[-1] // router.num_expert_group,
+    )
+    group_scores = grouped.topk(2, dim=-1).values.sum(dim=-1)
+    group_indices = group_scores.topk(
+        router.topk_group,
         dim=-1,
         sorted=False,
-    )[1]
-    top_scores = scores.gather(1, top_indices)
-    if block.router.top_k > 1 and block.router.norm_topk_prob:
-        top_scores = top_scores / (top_scores.sum(dim=-1, keepdim=True) + 1e-20)
-    top_scores = top_scores.to(tokens.dtype) * block.router.route_scale
-
-    if padding_mask is not None:
-        mask = padding_mask.unsqueeze(-1).to(top_scores.dtype)
-        top_scores = top_scores * mask
-        top_scores = top_scores / (top_scores.sum(dim=-1, keepdim=True) + 1e-9)
-        top_scores = top_scores * block.router.route_scale
-
-    routed = torch.zeros(
-        tokens.shape,
-        dtype=torch.float32,
-        device=tokens.device,
+    ).indices
+    group_mask = torch.zeros_like(group_scores, dtype=torch.bool)
+    group_mask.scatter_(1, group_indices, True)
+    expert_mask = group_mask.unsqueeze(-1).expand_as(grouped).reshape_as(corrected_scores)
+    top_indices = (
+        corrected_scores.masked_fill(
+            ~expert_mask,
+            float("-inf"),
+        )
+        .topk(
+            router.top_k,
+            dim=-1,
+            sorted=False,
+        )
+        .indices
     )
-    for expert_idx in range(block.router.num_experts):
+
+    top_scores = scores.gather(1, top_indices)
+    if router.renormalize:
+        top_scores = top_scores / top_scores.sum(dim=-1, keepdim=True)
+    top_scores = top_scores * router.routed_scaling_factor
+
+    w13 = routed_experts.w13_weight
+    intermediate_size = w13.shape[1] // 2
+    w1 = w13[:, :intermediate_size]
+    w3 = w13[:, intermediate_size:]
+    w2 = routed_experts.w2_weight
+    valid_output = torch.zeros_like(valid_tokens, dtype=torch.float32)
+    for expert_idx in range(block.num_experts):
         token_idx, route_idx = torch.where(top_indices == expert_idx)
         if token_idx.numel() == 0:
             continue
-        expert_tokens = tokens[token_idx]
-        h = F.silu(expert_tokens @ block.experts.w1[expert_idx].transpose(-2, -1))
-        h = h * (expert_tokens @ block.experts.w3[expert_idx].transpose(-2, -1))
-        expert_output = h @ block.experts.w2[expert_idx].transpose(-2, -1)
-        weighted = expert_output.float() * top_scores[token_idx, route_idx, None].float()
-        routed.index_add_(0, token_idx, weighted)
+        expert_tokens = valid_tokens[token_idx]
+        hidden = F.silu(F.linear(expert_tokens, w1[expert_idx]))
+        hidden = hidden * F.linear(expert_tokens, w3[expert_idx])
+        expert_output = F.linear(hidden, w2[expert_idx])
+        valid_output.index_add_(
+            0,
+            token_idx,
+            expert_output.float() * top_scores[token_idx, route_idx, None],
+        )
 
-    output = routed.to(tokens.dtype).reshape(batch_size, -1, hidden_size)
-    if block.shared_experts is not None:
-        shared = F.linear(hidden_states, block.shared_experts.gate_proj.weight)
-        shared = F.silu(shared) * F.linear(hidden_states, block.shared_experts.up_proj.weight)
-        shared = F.linear(shared, block.shared_experts.down_proj.weight)
-        output = output + shared
-    return output, top_indices, top_scores
-
-
-@hardware_test(res={"cuda": "L4"}, num_cards=1)
-def test_grouped_mm_matches_per_expert_reference() -> None:
-    from vllm_omni.diffusion.models.lingbot_video import lingbot_video_transformer as module
-
-    if not hasattr(torch, "_grouped_mm"):
-        pytest.skip("torch._grouped_mm is unavailable")
-
-    torch.manual_seed(42)
-    block = module.LingBotVideoSparseMoeBlock(
-        hidden_size=16,
-        num_experts=4,
-        top_k=2,
-        moe_intermediate_size=8,
-        score_func="sigmoid",
-        norm_topk_prob=True,
-        n_group=None,
-        topk_group=None,
-        routed_scaling_factor=1.0,
-        n_shared_experts=None,
-    ).to(device="cuda", dtype=torch.bfloat16)
-    with torch.no_grad():
-        block.experts.w1.normal_(mean=0.0, std=0.02)
-        block.experts.w2.normal_(mean=0.0, std=0.02)
-        block.experts.w3.normal_(mean=0.0, std=0.02)
-    tokens = torch.randn(23, 16, device="cuda", dtype=torch.bfloat16)
-    counts = torch.tensor([5, 0, 9, 9], device="cuda", dtype=torch.int64)
-
-    expected = block._run_experts_for_loop(tokens, counts)
-    actual = block._run_grouped_experts(tokens, counts)
-
-    torch.testing.assert_close(actual, expected)
+    output = tokens.new_zeros(tokens.shape)
+    output.index_copy_(0, valid_indices, valid_output.to(tokens.dtype))
+    output = output.reshape(batch_size, -1, hidden_size)
+    shared = F.silu(F.linear(hidden_states, block.shared_experts.gate_proj.weight))
+    shared = shared * F.linear(hidden_states, block.shared_experts.up_proj.weight)
+    shared = F.linear(shared, block.shared_experts.down_proj.weight)
+    return output + shared, top_indices, top_scores
 
 
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
-def test_sparse_moe_block_matches_upstream_reference() -> None:
-    from vllm_omni.diffusion.models.lingbot_video import lingbot_video_transformer as module
+def test_common_fused_moe_matches_eager_lingbot_reference(_single_rank_model_parallel) -> None:
+    from vllm.utils.torch_utils import set_default_torch_dtype
+    from vllm.v1.worker.workspace import init_workspace_manager
 
-    if not hasattr(torch, "_grouped_mm"):
-        pytest.skip("torch._grouped_mm is unavailable")
-
-    torch.manual_seed(42)
-    block = module.LingBotVideoSparseMoeBlock(
-        hidden_size=16,
-        num_experts=8,
-        top_k=2,
-        moe_intermediate_size=8,
-        score_func="sigmoid",
-        norm_topk_prob=True,
-        n_group=4,
-        topk_group=1,
-        routed_scaling_factor=1.5,
-        n_shared_experts=1,
+    from vllm_omni.diffusion.models.lingbot_video import (
+        LingBotVideoTransformer3DModel,
     )
+
+    torch.manual_seed(42)
+    init_workspace_manager(torch.device("cuda"))
+    with set_default_torch_dtype(torch.bfloat16):
+        model = LingBotVideoTransformer3DModel(
+            patch_size=(1, 1, 1),
+            in_channels=2,
+            out_channels=2,
+            hidden_size=16,
+            num_attention_heads=1,
+            depth=1,
+            intermediate_size=32,
+            text_dim=8,
+            freq_dim=8,
+            axes_dims=(4, 4, 8),
+            axes_lens=(32, 32, 32),
+            num_experts=8,
+            num_experts_per_tok=2,
+            moe_intermediate_size=8,
+            n_shared_experts=1,
+            n_group=4,
+            topk_group=1,
+            routed_scaling_factor=1.5,
+            prefix="test_lingbot_common_fused_moe",
+        )
+    model.to(device="cuda", dtype=torch.bfloat16)
+    block = model.blocks[0].ffn
     with torch.no_grad():
-        block.router.weight.zero_()
-        block.router.e_score_correction_bias.copy_(torch.tensor([0.9, 0.8, 1.0, 0.0, 0.7, 0.6, 0.5, 0.4]))
+        block.experts.gate.weight.zero_()
+        block.experts.routed_experts.e_score_correction_bias.copy_(
+            torch.tensor(
+                [0.9, 0.8, 1.0, 0.0, 0.7, 0.6, 0.5, 0.4],
+                device="cuda",
+            )
+        )
         for parameter in (
-            block.experts.w1,
-            block.experts.w2,
-            block.experts.w3,
+            block.experts.routed_experts.w13_weight,
+            block.experts.routed_experts.w2_weight,
             block.shared_experts.gate_proj.weight,
             block.shared_experts.up_proj.weight,
             block.shared_experts.down_proj.weight,
         ):
             parameter.normal_(mean=0.0, std=0.02)
-    block = block.to(device="cuda", dtype=torch.bfloat16)
+    block.experts.routed_experts.quant_method.process_weights_after_loading(block.experts.routed_experts)
 
     hidden_states = torch.randn(2, 5, 16, device="cuda", dtype=torch.bfloat16)
     padding_mask = torch.tensor(
@@ -154,30 +173,29 @@ def test_sparse_moe_block_matches_upstream_reference() -> None:
     )
 
     with torch.no_grad():
-        expected, expected_indices, expected_scores = _upstream_sparse_moe_reference(
+        expected, expected_indices, expected_scores = _eager_sparse_moe_reference(
             block,
             hidden_states,
             padding_mask,
         )
-        actual_indices, actual_scores = block.router(hidden_states.reshape(-1, 16))
-        actual_scores = actual_scores * padding_mask.unsqueeze(-1).to(actual_scores.dtype)
-        actual_scores = actual_scores / (actual_scores.sum(dim=-1, keepdim=True) + 1e-9)
-        actual_scores = actual_scores * block.router.route_scale
+        valid_tokens = hidden_states.reshape(-1, 16)[:8]
+        router_logits, _ = block.experts.gate(valid_tokens)
+        actual_scores, actual_indices = block.experts.router.select_experts(
+            hidden_states=valid_tokens,
+            router_logits=router_logits,
+            topk_indices_dtype=None,
+        )
         actual = block(hidden_states, padding_mask=padding_mask)
 
-    corrected_scores = (
-        torch.full(
-            (8,),
-            0.5,
-            device="cuda",
-        )
-        + block.router.e_score_correction_bias
-    )
-    unrestricted_indices = torch.topk(corrected_scores, k=2, sorted=False)[1]
+    unrestricted_indices = torch.topk(
+        torch.full((8,), 0.5, device="cuda") + block.experts.routed_experts.e_score_correction_bias,
+        k=2,
+        sorted=False,
+    ).indices
 
     assert set(actual_indices[0].tolist()) == {0, 1}
     assert set(unrestricted_indices.tolist()) == {0, 2}
-    assert torch.equal(actual_indices, expected_indices)
+    assert torch.equal(actual_indices, expected_indices.to(actual_indices.dtype))
     torch.testing.assert_close(actual_scores, expected_scores, rtol=0, atol=0)
-    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-3)
     assert torch.isfinite(actual).all()

--- a/tests/diffusion/models/lingbot_video/test_lingbot_video_transformer.py
+++ b/tests/diffusion/models/lingbot_video/test_lingbot_video_transformer.py
@@ -117,44 +117,60 @@ def test_transformer_to_keeps_sensitive_modules_in_fp32():
     assert model.norm_out_modulation[1].weight.dtype == torch.float32
 
 
-def test_router_group_limited_topk_uses_bias_corrected_choice():
+def test_sparse_moe_configures_common_runner_with_lingbot_router_semantics(mocker):
     from vllm_omni.diffusion.models.lingbot_video import lingbot_video_transformer as module
 
-    router = module.LingBotVideoRouter(
-        hidden_size=2,
-        num_experts=4,
+    gate = torch.nn.Linear(16, 8, bias=False)
+    runner = torch.nn.Identity()
+    gate_factory = mocker.patch.object(module, "GateLinear", return_value=gate)
+    fused_moe_factory = mocker.patch.object(module, "FusedMoE", return_value=runner)
+
+    block = module.LingBotVideoSparseMoeBlock(
+        hidden_size=16,
+        num_experts=8,
         top_k=2,
+        moe_intermediate_size=8,
         score_func="sigmoid",
         norm_topk_prob=True,
-        n_group=2,
+        n_group=4,
         topk_group=1,
-        route_scale=2.5,
+        routed_scaling_factor=2.5,
+        n_shared_experts=None,
+        prefix="transformer.blocks.0.ffn.experts",
     )
-    with torch.no_grad():
-        router.weight.copy_(
-            torch.tensor(
-                [
-                    [8.0, 0.0],
-                    [7.0, 0.0],
-                    [-8.0, 0.0],
-                    [-7.0, 0.0],
-                ]
-            )
-        )
-        router.e_score_correction_bias.copy_(torch.tensor([0.0, 0.0, 2.0, 2.0]))
 
-    top_indices, top_scores = router(torch.tensor([[1.0, 0.0]]))
+    assert block.experts is runner
+    gate_factory.assert_called_once_with(
+        16,
+        8,
+        bias=False,
+        out_dtype=torch.float32,
+        params_dtype=torch.float32,
+        force_fp32_compute=True,
+        prefix="transformer.blocks.0.ffn.experts.gate",
+    )
+    kwargs = fused_moe_factory.call_args.kwargs
+    assert kwargs["renormalize"] is True
+    assert kwargs["use_grouped_topk"] is True
+    assert kwargs["num_expert_group"] == 4
+    assert kwargs["topk_group"] == 1
+    assert kwargs["scoring_func"] == "sigmoid"
+    assert kwargs["routed_scaling_factor"] == 2.5
+    assert kwargs["gate"] is gate
+    assert kwargs["ckpt_names"] == ("w1", "w2", "w3")
+    assert kwargs["e_score_correction_bias"].dtype == torch.float32
+    assert not kwargs["e_score_correction_bias"].requires_grad
 
-    assert set(top_indices[0].tolist()) == {2, 3}
-    assert torch.allclose(top_scores.sum(dim=-1), torch.tensor([2.5]))
-    low_score, high_score = sorted(top_scores[0].tolist())
-    assert low_score < 0.8
-    assert high_score > 1.7
 
-
-def test_sparse_moe_block_masks_padding_tokens():
+def test_sparse_moe_block_compacts_and_restores_padding_tokens(mocker):
     from vllm_omni.diffusion.models.lingbot_video import lingbot_video_transformer as module
 
+    mocker.patch.object(
+        module,
+        "GateLinear",
+        return_value=torch.nn.Linear(4, 2, bias=False),
+    )
+    mocker.patch.object(module, "FusedMoE", return_value=torch.nn.Identity())
     block = module.LingBotVideoSparseMoeBlock(
         hidden_size=4,
         num_experts=2,
@@ -167,19 +183,11 @@ def test_sparse_moe_block_masks_padding_tokens():
         routed_scaling_factor=1.0,
         n_shared_experts=None,
     )
-    with torch.no_grad():
-        block.router.weight.copy_(
-            torch.tensor(
-                [
-                    [8.0, 0.0, 0.0, 0.0],
-                    [-8.0, 0.0, 0.0, 0.0],
-                ]
-            )
-        )
-        block.router.e_score_correction_bias.zero_()
-        block.experts.w1.fill_(0.5)
-        block.experts.w2.fill_(0.5)
-        block.experts.w3.fill_(0.5)
+    routed = mocker.patch.object(
+        block,
+        "_run_routed_experts",
+        side_effect=lambda tokens: tokens * 2,
+    )
 
     hidden_states = torch.tensor([[[1.0, 0.0, 0.0, 0.0], [-1.0, 0.0, 0.0, 0.0]]])
     padding_mask = torch.tensor([1.0, 0.0])
@@ -188,79 +196,125 @@ def test_sparse_moe_block_masks_padding_tokens():
 
     assert out.shape == hidden_states.shape
     assert torch.isfinite(out).all()
-    assert not torch.allclose(out[0, 0], torch.zeros_like(out[0, 0]))
+    torch.testing.assert_close(out[0, 0], hidden_states[0, 0] * 2)
     assert torch.allclose(out[0, 1], torch.zeros_like(out[0, 1]))
+    routed.assert_called_once()
+    torch.testing.assert_close(routed.call_args.args[0], hidden_states[:, :1].reshape(1, 4))
 
 
-@pytest.mark.parametrize(
-    "counts_list",
-    [
-        [0, 0, 0, 0],
-        [1, 0, 7, 8, 9],
-        [16, 0, 1, 0],
-        [0, 0, 33, 0],
-    ],
-)
-def test_grouped_padding_matches_reference(counts_list):
+def test_sparse_moe_runner_is_a_narrow_compile_boundary():
     from vllm_omni.diffusion.models.lingbot_video import lingbot_video_transformer as module
 
-    align = 8
-    counts = torch.tensor(counts_list, dtype=torch.int64)
-    num_tokens = int(counts.sum())
-    tokens = torch.arange(num_tokens * 4, dtype=torch.float32).reshape(num_tokens, 4)
-
-    actual = module.LingBotVideoSparseMoeBlock._pad_grouped_tokens(
-        tokens,
-        counts,
-        align,
+    assert getattr(
+        module.LingBotVideoSparseMoeBlock._run_routed_experts,
+        "_torchdynamo_disable",
+        False,
     )
 
-    num_experts = len(counts_list)
-    max_len = ((num_tokens + num_experts * align + align - 1) // align) * align
-    aligned_counts = [((max(count, align) + align - 1) // align) * align for count in counts_list]
-    expected_indices = [num_tokens] * max_len
-    source_start = 0
-    write_start = 0
-    for count, aligned_count in zip(counts_list, aligned_counts):
-        expected_indices[write_start : write_start + count] = range(
-            source_start,
-            source_start + count,
-        )
-        source_start += count
-        write_start += aligned_count
 
-    expected_indices_tensor = torch.tensor(expected_indices, dtype=torch.int64)
-    tokens_with_pad = torch.vstack((tokens, tokens.new_zeros((tokens.shape[-1],))))
-    expected_aligned_counts = torch.tensor(aligned_counts, dtype=torch.int32)
-
-    assert actual[0] == tokens_with_pad.shape
-    torch.testing.assert_close(actual[1], tokens_with_pad[expected_indices_tensor])
-    torch.testing.assert_close(actual[2], expected_indices_tensor)
-    torch.testing.assert_close(actual[3], expected_aligned_counts)
-
-
-def test_tiny_transformer_constructs_moe_and_dense_layers():
+def test_sparse_moe_packs_checkpoint_weights_for_common_runner(mocker):
     from vllm_omni.diffusion.models.lingbot_video import lingbot_video_transformer as module
 
+    class FakeRoutedExperts(torch.nn.Module):
+        def __init__(self, num_experts, hidden_size, intermediate_size, correction_bias):
+            super().__init__()
+            self.w13_weight = torch.nn.Parameter(torch.empty(num_experts, 2 * intermediate_size, hidden_size))
+            self.w2_weight = torch.nn.Parameter(torch.empty(num_experts, hidden_size, intermediate_size))
+            self.e_score_correction_bias = correction_bias
+
+            def load_w13(param, loaded_weight, name, shard_id, expert_id):
+                del name
+                offset = 0 if shard_id == "w1" else intermediate_size
+                param.data[expert_id, offset : offset + intermediate_size].copy_(loaded_weight)
+
+            def load_w2(param, loaded_weight, name, shard_id, expert_id):
+                del name, shard_id
+                param.data[expert_id].copy_(loaded_weight)
+
+            self.w13_weight.weight_loader = load_w13
+            self.w2_weight.weight_loader = load_w2
+
+    class FakeRunner(torch.nn.Module):
+        def __init__(self, kwargs):
+            super().__init__()
+            self.gate = kwargs["gate"]
+            self.routed_experts = FakeRoutedExperts(
+                kwargs["num_experts"],
+                kwargs["hidden_size"],
+                kwargs["intermediate_size"],
+                kwargs["e_score_correction_bias"],
+            )
+
+    mocker.patch.object(
+        module,
+        "GateLinear",
+        side_effect=lambda input_size, output_size, **kwargs: torch.nn.Linear(
+            input_size,
+            output_size,
+            bias=kwargs["bias"],
+        ),
+    )
+    mocker.patch.object(
+        module,
+        "FusedMoE",
+        side_effect=lambda **kwargs: FakeRunner(kwargs),
+    )
+    mocker.patch.object(
+        module,
+        "LingBotVideoAttention",
+        side_effect=lambda *args, **kwargs: torch.nn.Identity(),
+    )
     model = _tiny_transformer(
-        depth=2,
+        depth=1,
         num_experts=4,
         num_experts_per_tok=2,
         moe_intermediate_size=8,
-        decoder_sparse_step=1,
-        mlp_only_layers=(1,),
         n_shared_experts=1,
         n_group=2,
         topk_group=1,
         routed_scaling_factor=2.5,
     )
+    w1 = torch.randn(4, 8, 16)
+    w2 = torch.randn(4, 16, 8)
+    w3 = torch.randn(4, 8, 16)
+    gate = torch.randn(4, 16)
+    correction_bias = torch.randn(4)
 
-    assert isinstance(model.blocks[0].ffn, module.LingBotVideoSparseMoeBlock)
-    assert isinstance(model.blocks[1].ffn, module.LingBotVideoMLP)
-    assert "blocks.0.ffn.experts.w1" in model.state_dict()
-    assert "blocks.0.ffn.shared_experts.gate_proj.weight" in model.state_dict()
+    loaded = model.load_weights(
+        [
+            ("blocks.0.ffn.experts.w1", w1),
+            ("blocks.0.ffn.experts.w2", w2),
+            ("blocks.0.ffn.experts.w3", w3),
+            ("blocks.0.ffn.router.weight", gate),
+            (
+                "blocks.0.ffn.router.e_score_correction_bias",
+                correction_bias,
+            ),
+        ]
+    )
+    params = dict(model.named_parameters())
+    w13 = params["blocks.0.ffn.experts.routed_experts.w13_weight"]
+
+    assert loaded == {
+        "blocks.0.ffn.experts.gate.weight",
+        "blocks.0.ffn.experts.routed_experts.e_score_correction_bias",
+        "blocks.0.ffn.experts.routed_experts.w13_weight",
+        "blocks.0.ffn.experts.routed_experts.w2_weight",
+    }
+    torch.testing.assert_close(w13[:, :8], w1)
+    torch.testing.assert_close(w13[:, 8:], w3)
+    torch.testing.assert_close(
+        params["blocks.0.ffn.experts.routed_experts.w2_weight"],
+        w2,
+    )
+    torch.testing.assert_close(params["blocks.0.ffn.experts.gate.weight"], gate)
+    torch.testing.assert_close(
+        params["blocks.0.ffn.experts.routed_experts.e_score_correction_bias"],
+        correction_bias,
+    )
 
     model.to(dtype=torch.bfloat16)
 
-    assert model.blocks[0].ffn.router.weight.dtype == torch.float32
-    assert model.blocks[0].ffn.experts.w1.dtype == torch.bfloat16
+    assert model.blocks[0].ffn.experts.gate.weight.dtype == torch.float32
+    assert model.blocks[0].ffn.experts.routed_experts.e_score_correction_bias.dtype == torch.float32
+    assert model.blocks[0].ffn.experts.routed_experts.w13_weight.dtype == torch.bfloat16

--- a/tests/diffusion/models/lingbot_video/test_pipeline_lingbot_video.py
+++ b/tests/diffusion/models/lingbot_video/test_pipeline_lingbot_video.py
@@ -71,6 +71,88 @@ def test_component_discovery_declarations():
     assert LingBotVideoPipeline.max_outputs_per_prompt == 1
 
 
+def test_constructor_declares_native_transformer_weight_source(mocker):
+    from vllm_omni.diffusion.models.lingbot_video import pipeline_lingbot_video as module
+
+    transformer = nn.Linear(2, 2)
+    transformer_factory = mocker.patch.object(
+        module,
+        "LingBotVideoTransformer3DModel",
+        return_value=transformer,
+    )
+    config_helper = mocker.patch.object(
+        module,
+        "get_transformer_config_kwargs",
+        return_value={"depth": 0},
+    )
+    mocker.patch.object(module, "get_local_device", return_value=torch.device("cpu"))
+    mocker.patch.object(
+        module.Qwen3VLForConditionalGeneration,
+        "from_pretrained",
+        return_value=nn.Linear(2, 2),
+    )
+    mocker.patch.object(
+        module.Qwen3VLProcessor,
+        "from_pretrained",
+        return_value=object(),
+    )
+    mocker.patch.object(
+        module.AutoencoderKLWan,
+        "from_pretrained",
+        return_value=nn.Linear(2, 2),
+    )
+    mocker.patch.object(
+        module.FlowUniPCMultistepScheduler,
+        "from_pretrained",
+        return_value=object(),
+    )
+    od_config = SimpleNamespace(
+        model="/tmp/lingbot-model",
+        revision="test-revision",
+        dtype=torch.bfloat16,
+        model_config={},
+        tf_model_config=object(),
+    )
+
+    pipeline = module.LingBotVideoPipeline(od_config=od_config)
+
+    config_helper.assert_called_once_with(
+        od_config.tf_model_config,
+        module.LingBotVideoTransformer3DModel,
+    )
+    transformer_factory.assert_called_once_with(
+        depth=0,
+        prefix="transformer",
+    )
+    assert pipeline.transformer is transformer
+    assert len(pipeline.weights_sources) == 1
+    source = pipeline.weights_sources[0]
+    assert source.model_or_path == od_config.model
+    assert source.subfolder == "transformer"
+    assert source.revision == "test-revision"
+    assert source.prefix == "transformer."
+
+
+def test_load_weights_delegates_to_auto_loader(mocker):
+    from vllm_omni.diffusion.models.lingbot_video import pipeline_lingbot_video as module
+
+    pipeline = _make_pipeline()
+    loader = mocker.MagicMock()
+    loader.load_weights.return_value = {"transformer.blocks.0.weight"}
+    loader_factory = mocker.patch.object(
+        module,
+        "AutoWeightsLoader",
+        return_value=loader,
+    )
+    weights = [("transformer.blocks.0.weight", torch.ones(1))]
+
+    loaded = pipeline.load_weights(iter(weights))
+
+    loader_factory.assert_called_once_with(pipeline)
+    loader.load_weights.assert_called_once()
+    assert loaded == {"transformer.blocks.0.weight"}
+
+
 def test_extra_body_params_include_video_flow_shift_alias():
     from vllm_omni.model_extras import get_extra_body_params
 
@@ -564,11 +646,3 @@ def test_forward_marks_unsupported_output_count_as_client_error():
         pipeline.forward(request)
 
     assert exc_info.value.status_code == 400
-
-
-def test_load_weights_rejects_external_weight_stream():
-    pipeline = _make_pipeline()
-
-    assert pipeline.load_weights([]) == set()
-    with pytest.raises(RuntimeError, match="components are loaded directly"):
-        pipeline.load_weights([("transformer.weight", torch.zeros(1))])

--- a/vllm_omni/diffusion/models/lingbot_video/lingbot_video_transformer.py
+++ b/vllm_omni/diffusion/models/lingbot_video/lingbot_video_transformer.py
@@ -3,6 +3,8 @@
 # Adapted from LingBot-Video (https://github.com/Robbyant/lingbot-video).
 
 import math
+from collections.abc import Iterable
+from contextlib import nullcontext
 
 import torch
 import torch.distributed as dist
@@ -12,12 +14,20 @@ from diffusers.configuration_utils import ConfigMixin, register_to_config
 from diffusers.models.embeddings import TimestepEmbedding, Timesteps
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
 from diffusers.models.modeling_utils import ModelMixin
+from vllm.config import get_current_vllm_config
+from vllm.forward_context import (
+    is_forward_context_available as is_vllm_forward_context_available,
+)
+from vllm.forward_context import set_forward_context as set_vllm_forward_context
+from vllm.model_executor.layers.fused_moe.router.gate_linear import GateLinear
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.backends.utils.fa import (
     flash_attn_varlen_func as flash_attn_varlen_func_v3,
 )
 from vllm_omni.diffusion.attention.layer import Attention
+from vllm_omni.diffusion.layers.fused_moe import FusedMoE
 
 LINGBOT_VIDEO_FP32_MODULES = (
     "time_embedder",
@@ -32,7 +42,8 @@ LINGBOT_VIDEO_FP32_MODULES = (
     "norm_post_ffn",
     "norm_out",
     "norm_out_modulation",
-    "router",
+    "gate",
+    "e_score_correction_bias",
 )
 
 
@@ -296,95 +307,9 @@ class LingBotVideoMLP(nn.Module):
         return self.down_proj(F.silu(self.gate_proj(x)) * self.up_proj(x))
 
 
-class LingBotVideoRouter(nn.Module):
-    """Token-choice top-k router used by the LingBot MoE checkpoints.
-
-    Selection uses the bias-corrected score, while the gating weights use the
-    original score. This asymmetry matches the reference LingBot inference path.
-    """
-
-    def __init__(
-        self,
-        hidden_size: int,
-        num_experts: int,
-        top_k: int,
-        score_func: str,
-        norm_topk_prob: bool,
-        n_group: int | None,
-        topk_group: int | None,
-        route_scale: float,
-    ):
-        super().__init__()
-        self.num_experts = num_experts
-        self.top_k = top_k
-        self.score_func = score_func
-        self.norm_topk_prob = norm_topk_prob
-        self.n_group = n_group
-        self.topk_group = topk_group
-        self.route_scale = route_scale
-        self.weight = nn.Parameter(torch.empty(num_experts, hidden_size))
-        self.register_buffer(
-            "e_score_correction_bias",
-            torch.zeros(num_experts),
-            persistent=True,
-        )
-
-    def _group_limited_topk(self, scores_for_choice: torch.Tensor) -> torch.Tensor:
-        if self.n_group is None or self.topk_group is None:
-            raise ValueError("group-limited top-k requires n_group and topk_group.")
-        seq_len = scores_for_choice.shape[0]
-        experts_per_group = self.num_experts // self.n_group
-        grouped = scores_for_choice.view(seq_len, self.n_group, experts_per_group)
-        group_scores = grouped.topk(2, dim=-1)[0].sum(dim=-1)
-        group_idx = torch.topk(group_scores, k=self.topk_group, dim=-1, sorted=False)[1]
-        group_mask = torch.zeros_like(group_scores)
-        group_mask.scatter_(1, group_idx, 1)
-        score_mask = group_mask.unsqueeze(-1).expand(seq_len, self.n_group, experts_per_group).reshape(seq_len, -1)
-        masked = scores_for_choice.masked_fill(~score_mask.bool(), float("-inf"))
-        return torch.topk(masked, k=self.top_k, dim=-1, sorted=False)[1]
-
-    def forward(self, tokens: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        with torch.amp.autocast(tokens.device.type, enabled=False):
-            logits = F.linear(tokens.float(), self.weight.float())
-        if self.score_func == "softmax":
-            scores = F.softmax(logits, dim=-1)
-        elif self.score_func == "sigmoid":
-            scores = logits.sigmoid()
-        else:
-            raise ValueError(f"Unsupported LingBot router score_func: {self.score_func!r}.")
-
-        scores_for_choice = scores + self.e_score_correction_bias.unsqueeze(0)
-        if self.n_group is not None and self.n_group > 1:
-            top_indices = self._group_limited_topk(scores_for_choice)
-        else:
-            top_indices = torch.topk(scores_for_choice, k=self.top_k, dim=-1, sorted=False)[1]
-        top_scores = scores.gather(1, top_indices)
-        if self.top_k > 1 and self.norm_topk_prob:
-            top_scores = top_scores / (top_scores.sum(dim=-1, keepdim=True) + 1e-20)
-        top_scores = top_scores * self.route_scale
-        return top_indices, top_scores.to(tokens.dtype)
-
-
-class LingBotVideoGroupedExperts(nn.Module):
-    """Grouped expert weights.
-
-    Weight layout matches the reference checkpoint:
-    w1 [E, I, H], w2 [E, H, I], w3 [E, I, H].
-    """
-
-    def __init__(self, num_experts: int, hidden_size: int, intermediate_size: int):
-        super().__init__()
-        self.num_experts = num_experts
-        self.w1 = nn.Parameter(torch.empty(num_experts, intermediate_size, hidden_size))
-        self.w2 = nn.Parameter(torch.empty(num_experts, hidden_size, intermediate_size))
-        self.w3 = nn.Parameter(torch.empty(num_experts, intermediate_size, hidden_size))
-
-
-def _round_up_to_multiple(value: int, multiple: int) -> int:
-    return ((value + multiple - 1) // multiple) * multiple
-
-
 class LingBotVideoSparseMoeBlock(nn.Module):
+    """LingBot routing semantics backed by vLLM's common FusedMoE path."""
+
     def __init__(
         self,
         hidden_size: int,
@@ -397,21 +322,45 @@ class LingBotVideoSparseMoeBlock(nn.Module):
         topk_group: int | None,
         routed_scaling_factor: float,
         n_shared_experts: int | None,
+        *,
+        prefix: str = "lingbot_video.experts",
     ):
         super().__init__()
         self.hidden_size = hidden_size
         self.num_experts = num_experts
-        self.router = LingBotVideoRouter(
+        gate = GateLinear(
             hidden_size,
             num_experts,
-            top_k,
-            score_func,
-            norm_topk_prob,
-            n_group,
-            topk_group,
-            routed_scaling_factor,
+            bias=False,
+            out_dtype=torch.float32,
+            params_dtype=torch.float32,
+            force_fp32_compute=True,
+            prefix=f"{prefix}.gate",
         )
-        self.experts = LingBotVideoGroupedExperts(num_experts, hidden_size, moe_intermediate_size)
+        correction_bias = nn.Parameter(
+            torch.zeros(num_experts, dtype=torch.float32),
+            requires_grad=False,
+        )
+        self.experts = FusedMoE(
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=moe_intermediate_size,
+            renormalize=norm_topk_prob,
+            use_grouped_topk=n_group is not None and n_group > 1,
+            num_expert_group=n_group,
+            topk_group=topk_group,
+            scoring_func=score_func,
+            routed_scaling_factor=routed_scaling_factor,
+            e_score_correction_bias=correction_bias,
+            activation="silu",
+            gate=gate,
+            ckpt_names=("w1", "w2", "w3"),
+            tp_size=1,
+            dp_size=1,
+            pcp_size=1,
+            prefix=prefix,
+        )
         self.shared_experts = None
         if n_shared_experts is not None and n_shared_experts > 0:
             self.shared_experts = LingBotVideoMLP(
@@ -419,166 +368,23 @@ class LingBotVideoSparseMoeBlock(nn.Module):
                 moe_intermediate_size * n_shared_experts,
             )
 
-    @staticmethod
-    def _reorder_tokens(
-        tokens: torch.Tensor,
-        top_scores: torch.Tensor,
-        top_indices: torch.Tensor,
-        num_experts: int,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int, int]:
-        num_tokens = tokens.shape[0]
-        top_k = top_indices.shape[1]
-        flat_scores = top_scores.reshape(-1)
-        flat_indices = top_indices.reshape(-1)
-        active_positions = torch.where(flat_scores != 0)[0]
-        active_experts = flat_indices[active_positions]
-
-        counts = torch.zeros(num_experts, device=tokens.device, dtype=torch.int64)
-        counts.scatter_add_(
-            0,
-            active_experts,
-            torch.ones_like(active_experts, dtype=torch.int64),
-        )
-
-        sort_order = torch.argsort(active_experts, stable=True)
-        sorted_positions = active_positions[sort_order]
-        sorted_scores = flat_scores[sorted_positions]
-        original_token_idx = sorted_positions // top_k
-        permuted_tokens = tokens[original_token_idx]
-        return permuted_tokens, counts, sorted_positions, sorted_scores, num_tokens, top_k
-
-    @staticmethod
-    def _pad_grouped_tokens(
-        tokens: torch.Tensor,
-        counts: torch.Tensor,
-        align: int = 8,
-    ) -> tuple[torch.Size, torch.Tensor, torch.Tensor, torch.Tensor]:
-        num_tokens = tokens.shape[0]
-        num_experts = int(counts.shape[0])
-        max_len = _round_up_to_multiple(num_tokens + num_experts * align, align)
-        counts_i64 = counts.to(torch.int64)
-        total_per_expert = torch.clamp_min(counts_i64, align)
-        aligned_counts_i64 = (total_per_expert + align - 1) // align * align
-        write_offsets = torch.cumsum(aligned_counts_i64, dim=0) - aligned_counts_i64
-        end_offsets = torch.cumsum(aligned_counts_i64, dim=0)
-        start_indices = torch.cumsum(counts_i64, dim=0) - counts_i64
-
-        slots = torch.arange(max_len, dtype=torch.int64, device=tokens.device)
-        expert_idx = torch.bucketize(slots, end_offsets, right=True)
-        valid_expert = expert_idx < num_experts
-        safe_expert_idx = expert_idx.clamp(max=num_experts - 1)
-        local_idx = slots - write_offsets[safe_expert_idx]
-        source_idx = start_indices[safe_expert_idx] + local_idx
-        valid = valid_expert & (local_idx < counts_i64[safe_expert_idx])
-        fill = torch.full_like(source_idx, num_tokens)
-        permuted_indices = torch.where(valid, source_idx, fill)
-
-        tokens_with_pad = torch.vstack((tokens, tokens.new_zeros((tokens.shape[-1],))))
-        input_shape = tokens_with_pad.shape
-        return (
-            input_shape,
-            tokens_with_pad[permuted_indices],
-            permuted_indices,
-            aligned_counts_i64.to(torch.int32),
-        )
-
-    @staticmethod
-    def _unpad_grouped_tokens(
-        output: torch.Tensor,
-        input_shape: torch.Size,
-        permuted_indices: torch.Tensor,
-    ) -> torch.Tensor:
-        unpermuted = output.new_empty(input_shape)
-        unpermuted[permuted_indices, :] = output
-        return unpermuted[:-1]
-
-    def _run_experts_for_loop(self, tokens: torch.Tensor, counts: torch.Tensor) -> torch.Tensor:
-        count_list = counts.tolist()
-        splits = torch.split(tokens, count_list, dim=0)
-        outputs = []
-        for expert_idx, expert_tokens in enumerate(splits):
-            if expert_tokens.numel() == 0:
-                continue
-            h = F.silu(expert_tokens @ self.experts.w1[expert_idx].transpose(-2, -1))
-            h = h * (expert_tokens @ self.experts.w3[expert_idx].transpose(-2, -1))
-            h = h @ self.experts.w2[expert_idx].transpose(-2, -1)
-            outputs.append(h)
-        if not outputs:
-            return tokens.new_zeros(tokens.shape)
-        return torch.cat(outputs, dim=0)
-
-    def _run_grouped_experts(self, tokens: torch.Tensor, counts: torch.Tensor) -> torch.Tensor:
-        if not hasattr(torch, "_grouped_mm") or tokens.device.type != "cuda":
-            return self._run_experts_for_loop(tokens, counts)
-        input_shape, padded_tokens, permuted_indices, aligned_counts = self._pad_grouped_tokens(tokens, counts)
-        offsets = torch.cumsum(aligned_counts, dim=0, dtype=torch.int32)
-        h = F.silu(
-            torch._grouped_mm(
-                padded_tokens.bfloat16(),
-                self.experts.w1.bfloat16().transpose(-2, -1),
-                offs=offsets,
+    @torch.compiler.disable
+    def _run_routed_experts(self, tokens: torch.Tensor) -> torch.Tensor:
+        """Run the opaque common MoE op with a valid vLLM forward context."""
+        context = (
+            nullcontext()
+            if is_vllm_forward_context_available()
+            else set_vllm_forward_context(
+                attn_metadata=None,
+                vllm_config=get_current_vllm_config(),
+                num_tokens=tokens.shape[0],
             )
         )
-        h = h * torch._grouped_mm(
-            padded_tokens.bfloat16(),
-            self.experts.w3.bfloat16().transpose(-2, -1),
-            offs=offsets,
-        )
-        out = torch._grouped_mm(
-            h,
-            self.experts.w2.bfloat16().transpose(-2, -1),
-            offs=offsets,
-        ).type_as(padded_tokens)
-        return self._unpad_grouped_tokens(out, input_shape, permuted_indices)
-
-    @staticmethod
-    def _restore_tokens(
-        expert_output: torch.Tensor,
-        sorted_positions: torch.Tensor,
-        sorted_scores: torch.Tensor,
-        num_tokens: int,
-        top_k: int,
-    ) -> torch.Tensor:
-        hidden_size = expert_output.shape[-1]
-        unsorted = torch.zeros(
-            (num_tokens * top_k, hidden_size),
-            dtype=expert_output.dtype,
-            device=expert_output.device,
-        )
-        unsorted[sorted_positions] = expert_output
-        unsorted = unsorted.reshape(num_tokens, top_k, hidden_size)
-
-        scores_unsorted = torch.zeros(
-            num_tokens * top_k,
-            dtype=sorted_scores.dtype,
-            device=sorted_scores.device,
-        )
-        scores_unsorted[sorted_positions] = sorted_scores
-        scores_unsorted = scores_unsorted.reshape(num_tokens, top_k, 1)
-        return (unsorted.float() * scores_unsorted).sum(dim=1).to(expert_output.dtype)
-
-    def _run_selected_experts(
-        self,
-        tokens: torch.Tensor,
-        top_scores: torch.Tensor,
-        top_indices: torch.Tensor,
-    ) -> torch.Tensor:
-        (
-            permuted_tokens,
-            counts,
-            sorted_positions,
-            sorted_scores,
-            num_tokens,
-            top_k,
-        ) = self._reorder_tokens(tokens, top_scores, top_indices, self.router.num_experts)
-        expert_output = self._run_grouped_experts(permuted_tokens, counts)
-        return self._restore_tokens(
-            expert_output,
-            sorted_positions,
-            sorted_scores,
-            num_tokens,
-            top_k,
-        )
+        with context:
+            return self.experts(
+                hidden_states=tokens,
+                router_logits=tokens,
+            )
 
     def forward(
         self,
@@ -587,14 +393,16 @@ class LingBotVideoSparseMoeBlock(nn.Module):
     ) -> torch.Tensor:
         batch_size = hidden_states.shape[0]
         tokens = hidden_states.reshape(-1, self.hidden_size)
-        top_indices, top_scores = self.router(tokens)
         if padding_mask is not None:
-            mask = padding_mask.unsqueeze(-1).to(top_scores.dtype)
-            top_scores = top_scores * mask
-            top_scores = top_scores / (top_scores.sum(dim=-1, keepdim=True) + 1e-9)
-            top_scores = top_scores * self.router.route_scale
-
-        out = self._run_selected_experts(tokens, top_scores, top_indices)
+            # The caller only supplies this mask when padding is present, so
+            # compaction avoids a device-to-host all-valid branch.
+            valid_indices = torch.where(padding_mask.bool())[0]
+            valid_tokens = tokens.index_select(0, valid_indices)
+            valid_output = self._run_routed_experts(valid_tokens)
+            out = tokens.new_zeros(tokens.shape)
+            out.index_copy_(0, valid_indices, valid_output)
+        else:
+            out = self._run_routed_experts(tokens)
         out = out.reshape(batch_size, -1, self.hidden_size)
         if self.shared_experts is not None:
             out = out + self.shared_experts(hidden_states)
@@ -622,6 +430,8 @@ class LingBotVideoBlock(nn.Module):
         topk_group,
         routed_scaling_factor,
         layer_idx: int,
+        *,
+        prefix: str = "lingbot_video.block",
     ):
         super().__init__()
         self.layer_idx = layer_idx
@@ -646,6 +456,7 @@ class LingBotVideoBlock(nn.Module):
                 topk_group=topk_group,
                 routed_scaling_factor=routed_scaling_factor,
                 n_shared_experts=n_shared_experts,
+                prefix=f"{prefix}.ffn.experts",
             )
         else:
             self.ffn = LingBotVideoMLP(h, intermediate_size)
@@ -762,6 +573,7 @@ class LingBotVideoTransformer3DModel(ModelMixin, ConfigMixin):
         n_group: int | None = None,
         topk_group: int | None = None,
         routed_scaling_factor: float = 1.0,
+        prefix: str = "transformer",
     ):
         super().__init__()
         head_dim = hidden_size // num_attention_heads
@@ -795,6 +607,7 @@ class LingBotVideoTransformer3DModel(ModelMixin, ConfigMixin):
                     topk_group=topk_group,
                     routed_scaling_factor=routed_scaling_factor,
                     layer_idx=i,
+                    prefix=f"{prefix}.blocks.{i}",
                 )
                 for i in range(depth)
             ]
@@ -802,6 +615,49 @@ class LingBotVideoTransformer3DModel(ModelMixin, ConfigMixin):
         self.norm_out = nn.LayerNorm(hidden_size, elementwise_affine=False, eps=norm_eps)
         self.norm_out_modulation = nn.Sequential(nn.SiLU(), nn.Linear(hidden_size, 2 * hidden_size))
         self.proj_out = nn.Linear(hidden_size, math.prod(patch_size) * out_channels)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        """Load LingBot checkpoints and pack aggregate w1/w3 into w13."""
+        params = dict(self.named_parameters())
+        tensors = {**dict(self.named_buffers()), **params}
+        loaded: set[str] = set()
+
+        for name, weight in weights:
+            if name.endswith((".ffn.experts.w1", ".ffn.experts.w2", ".ffn.experts.w3")):
+                source_prefix, shard_id = name.rsplit(".", 1)
+                target_suffix = "w2_weight" if shard_id == "w2" else "w13_weight"
+                target_name = f"{source_prefix}.routed_experts.{target_suffix}"
+                param = params[target_name]
+                weight_loader = getattr(param, "weight_loader")
+                for expert_id, expert_weight in enumerate(weight):
+                    weight_loader(
+                        param,
+                        expert_weight,
+                        target_name,
+                        shard_id,
+                        expert_id,
+                    )
+                loaded.add(target_name)
+                continue
+
+            if name.endswith(".ffn.router.weight"):
+                target_name = name.replace(".ffn.router.weight", ".ffn.experts.gate.weight")
+            elif name.endswith(".ffn.router.e_score_correction_bias"):
+                target_name = name.replace(
+                    ".ffn.router.e_score_correction_bias",
+                    ".ffn.experts.routed_experts.e_score_correction_bias",
+                )
+            else:
+                target_name = name
+
+            target = tensors.get(target_name)
+            if target is None:
+                raise KeyError(f"LingBot checkpoint tensor {name!r} does not map to a model parameter or buffer.")
+            weight_loader = getattr(target, "weight_loader", default_weight_loader)
+            weight_loader(target, weight)
+            loaded.add(target_name)
+
+        return loaded
 
     def forward(
         self,

--- a/vllm_omni/diffusion/models/lingbot_video/pipeline_lingbot_video.py
+++ b/vllm_omni/diffusion/models/lingbot_video/pipeline_lingbot_video.py
@@ -17,9 +17,11 @@ from diffusers.utils.torch_utils import randn_tensor
 from PIL import Image
 from torch import nn
 from transformers import Qwen3VLForConditionalGeneration, Qwen3VLProcessor
+from vllm.model_executor.models.utils import AutoWeightsLoader
 
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.utils import get_local_device
+from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.interface import (
     SupportImageInput,
     SupportsComponentDiscovery,
@@ -37,6 +39,7 @@ from vllm_omni.diffusion.models.lingbot_video.request_utils import (
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.models.schedulers import FlowUniPCMultistepScheduler
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 from vllm_omni.errors import OmniClientError
 
@@ -310,9 +313,9 @@ class LingBotVideoPipeline(
     """Native vLLM-Omni entry for LingBot-Video checkpoints.
 
     The in-tree transformer supports both dense MLP blocks and routed MoE blocks.
-    Fused expert kernels and the optional ``refiner/`` transformer are not loaded
-    or executed. ``t_thresh`` only selects a low-noise sigma schedule for the
-    primary transformer; it does not enable automatic refiner orchestration.
+    Routed blocks use vLLM's common FusedMoE runner. The optional
+    ``refiner/`` transformer is not loaded or executed; ``t_thresh`` only
+    selects a low-noise sigma schedule for the primary transformer.
     """
 
     supports_step_execution: ClassVar[bool] = False
@@ -348,12 +351,24 @@ class LingBotVideoPipeline(
         vae_subfolder = str(model_config.get("vae_subfolder", "vae"))
         scheduler_subfolder = str(model_config.get("scheduler_subfolder", "scheduler"))
 
-        self.transformer = LingBotVideoTransformer3DModel.from_pretrained(
-            model,
-            subfolder=transformer_subfolder,
-            torch_dtype=transformer_dtype,
-            local_files_only=local_files_only,
-        ).to(self.device)
+        self.weights_sources = [
+            DiffusersPipelineLoader.ComponentSource(
+                model_or_path=model,
+                subfolder=transformer_subfolder,
+                revision=getattr(od_config, "revision", None),
+                prefix="transformer.",
+                fall_back_to_pt=True,
+            )
+        ]
+        transformer_kwargs = get_transformer_config_kwargs(
+            od_config.tf_model_config,
+            LingBotVideoTransformer3DModel,
+        )
+        self.transformer = LingBotVideoTransformer3DModel(
+            **transformer_kwargs,
+            prefix="transformer",
+        )
+        self.transformer.to(dtype=transformer_dtype)
         text_encoder_kwargs: dict[str, Any] = {
             "dtype": text_encoder_dtype,
             "local_files_only": local_files_only,
@@ -396,13 +411,7 @@ class LingBotVideoPipeline(
         return self
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        consumed = list(weights)
-        if consumed:
-            raise RuntimeError(
-                f"{self.__class__.__name__}.load_weights received {len(consumed)} weight tensors; "
-                "LingBot components are loaded directly from subfolders during __init__."
-            )
-        return {name for name, _ in self.named_parameters()}
+        return AutoWeightsLoader(self).load_weights(weights)
 
     @staticmethod
     def check_inputs(height: int, width: int, num_frames: int) -> None:


### PR DESCRIPTION
## Purpose

LingBot Video currently executes routed experts through a model-specific
`torch._grouped_mm` implementation. This duplicates expert execution logic already
provided by vLLM and prevents the model from using the shared fused MoE backend.

This PR integrates LingBot Video with vLLM's common `FusedMoE` runner while preserving
its sigmoid routing, grouped top-k selection, correction bias, routed scaling, and
padding behavior. It also moves transformer weight loading to the shared diffusion
loader so checkpoint tensors can be mapped into the fused expert layout and undergo
the backend's post-load processing. Text encoder and VAE loading remain unchanged.

The goal is to reduce MoE execution latency and model-specific maintenance without
changing the public generation API or checkpoint format. Numerical and end-to-end
video comparisons are reported below because fused execution can change floating-point
rounding and does not guarantee bitwise-identical outputs.

## What Changes

| File | Change |
|---|---|
| `vllm_omni/diffusion/models/lingbot_video/lingbot_video_transformer.py` | Replace custom routed-expert execution with common `FusedMoE`; preserve routing and padding semantics; supply the vLLM forward context; map `w1`/`w3` into `w13_weight` and router parameters into the gate layout while retaining FP32-sensitive parameters. |
| `vllm_omni/diffusion/models/lingbot_video/pipeline_lingbot_video.py` | Declare the transformer weight source for `DiffusersPipelineLoader` and delegate loading to `AutoWeightsLoader`, replacing eager transformer `from_pretrained` loading. |
| `tests/diffusion/models/lingbot_video/test_lingbot_video_transformer.py` | Cover common-runner configuration, padding compaction/restoration, checkpoint mapping, FP32 parameter preservation, and the compile boundary. |
| `tests/diffusion/models/lingbot_video/test_pipeline_lingbot_video.py` | Test transformer weight-source registration and loader delegation; remove assertions for the obsolete loading contract. |
| `tests/diffusion/models/lingbot_video/test_lingbot_video_moe_cuda.py` | Compare the common fused path against an eager LingBot MoE reference on CUDA, including routing and output parity. |
| `benchmarks/lingbot_video/moe_block_benchmark.py` | Add a production-shape block benchmark with latency, memory, backend identification, and optional routing/output artifacts. |
| `benchmarks/lingbot_video/moe_transformer_parity.py` | Adapt official-reference block and transformer comparisons to the common runner; report numerical tolerance checks separately from bitwise equality. |
| `benchmarks/lingbot_video/README.md` | Document benchmark usage, production shapes, routing diagnostics, and numerical acceptance thresholds. |

## Test Plan

**vLLM Version:** `0.28.0`

**vLLM-Omni Commit:**

- Baseline:  `e51fe6ec1`
- Candidate: `0494b518a`

**Environment:** NVIDIA H200 (author-provided designation; runtime reports NVIDIA L20X;
143771 MiB), driver 570.133.20, Python 3.12.13,
PyTorch 2.13.0+cu130, CUDA 13.0, Triton 3.7.1.

**Model:** `robbyant/lingbot-video-moe-30b-a3b`

| Test | Configuration | Repeats |
|---|---|---|
| Production-shape MoE block | 49,145 tokens; hidden 2,048; intermediate 768; 128 experts; top-k 8; 4 groups; top-2 groups | 3 warmups + 20 measured iterations per revision |
| End-to-end serving | 832x480; 121 frames; 40 steps; CFG 3; flow shift 3; seed 42; 24 FPS; concurrency 1 | 1 exact-shape warmup + 3 measured requests per revision |
| Block numerical parity | Identical initialized weights and inputs; compare routing and output tensors | Reuse block artifacts |
| Video quality | Validate metadata, file/decoded hashes, per-frame PSNR/SSIM/MAE, and representative frames | Reuse all 6 measured videos |

Block acceptance thresholds: relative L2 <= 0.5%, cosine similarity >= 0.99999,
and maximum absolute error <= 0.02. No numeric video-quality acceptance threshold
was predefined; video metrics and visual observations are reported separately.


```bash
python -m benchmarks.lingbot_video.moe_block_benchmark --warmups 3 --repeats 20
```

For serving, start each revision separately with the same model and configuration:

```bash
vllm serve robbyant/lingbot-video-moe-30b-a3b --omni \
  --model-class-name LingBotVideoPipeline --port 8099 --log-stats
```

Set `PROMPT` to a fixed test prompt and submit the same request to each revision:

```bash
curl -sS http://localhost:8099/v1/videos \
  -F "prompt=${PROMPT:?Set the same prompt for both revisions}" \
  -F width=832 -F height=480 -F num_frames=121 -F fps=24 \
  -F num_inference_steps=40 -F guidance_scale=3 -F flow_shift=3 -F seed=42
```

Wait for each returned job ID to complete via `GET /v1/videos/{id}` and retrieve
the video via `GET /v1/videos/{id}/content`. Run one warmup and three measured
requests sequentially per revision. Compare decoded videos using PSNR, SSIM, and MAE.

## Test Result

### Performance

| Metric | Baseline | Candidate | Change |
|---|---:|---:|---:|
| MoE block median latency | 25.758 ms | 10.676 ms | **-58.55% (2.413x)** |
| MoE block peak allocated memory | 12,966 MB | 5,508 MB | -57.52% |
| End-to-end median latency | 205.786 s | 175.054 s | **-14.93% (1.176x)** |
| End-to-end p95 latency | 205.990 s | 175.241 s | -14.93% |
| End-to-end peak memory | 81,028 MB | 83,390 MB | **+2,362 MB (+2.92%)** |
| Successful measured requests | 3/3 | 3/3 | No failures |


### Block numerical parity

| Check | Result |
|---|---|
| Finite output | Both revisions pass |
| Gate weights / router logits | Exact match |
| Top-k expert IDs (sorted per token) | Exact match |
| Top-k score maximum absolute error | 0.0009765625 |
| Output relative L2 | 0.3004% — pass |
| Output cosine similarity | 0.99999550 — pass |
| Output maximum absolute error | 0.015625 — pass |
| Output MAE | 0.0005424 |

### Video correctness and quality

All six measured videos are valid H.264, 832x480, 121 frames, and 24 FPS. Each
revision produces identical file and decoded-frame hashes across its three requests.

| Baseline vs. candidate | Result |
|---|---:|
| Mean PSNR | 26.200 dB |
| Mean SSIM | 0.863116 |
| Worst-frame SSIM | 0.831879 (frame 117) |
| Mean MAE (0–255 scale) | 7.441 |
| Worst-frame MAE (0–255 scale) | 13.585 |

