### PR TITLE
[Feature] Support request-level batching for SDXL text2image

### DIFF
--- a/tests/diffusion/models/sdxl/test_sdxl_request_batch.py
+++ b/tests/diffusion/models/sdxl/test_sdxl_request_batch.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""Request-level batching contract for the SDXL text2image pipeline."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from vllm_omni.diffusion.data import DiffusionOutput
+from vllm_omni.diffusion.models.sdxl.pipeline_sdxl import StableDiffusionXLPipeline
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.diffusion]
+
+HEIGHT = 64
+WIDTH = 64
+LATENT_CHANNELS = 4
+VAE_SCALE = 8
+
+
+class _StubScheduler:
+    def __init__(self) -> None:
+        self.timesteps = torch.tensor([9, 5], dtype=torch.int64)
+        self.sigmas = torch.tensor([1.0, 0.5, 0.0])
+        self.init_noise_sigma = 1.0
+        self.set_timesteps_calls: list[int] = []
+
+    def set_timesteps(self, num_steps: int) -> None:
+        self.set_timesteps_calls.append(num_steps)
+
+
+class _StubVAE:
+    dtype = torch.float32
+    config = SimpleNamespace(scaling_factor=0.13025)
+
+    def decode(self, latents: torch.Tensor, return_dict: bool = True):
+        # Emit one distinguishable image row per latent row so that the
+        # per-request split can be asserted.
+        batch = latents.shape[0]
+        image = torch.stack([torch.full((3, HEIGHT, WIDTH), float(i)) for i in range(batch)])
+        return (image,)
+
+
+def _make_pipeline(recorder: dict) -> StableDiffusionXLPipeline:
+    pipeline = object.__new__(StableDiffusionXLPipeline)
+    nn.Module.__init__(pipeline)
+    pipeline.device = torch.device("cpu")
+    pipeline.od_config = SimpleNamespace(dtype=torch.float32)
+    pipeline.vae_scale_factor = VAE_SCALE
+    pipeline.default_sample_size = HEIGHT // VAE_SCALE
+    pipeline.tokenizer_max_length = 77
+    pipeline.output_type = "pt"
+    pipeline.unet = SimpleNamespace(in_channels=LATENT_CHANNELS)
+    pipeline.scheduler = _StubScheduler()
+    pipeline.vae = _StubVAE()
+
+    def _encode_prompt(prompt, num_images_per_prompt=1):
+        recorder.setdefault("encoded_prompts", []).append(prompt)
+        n = (1 if isinstance(prompt, str) else len(prompt)) * num_images_per_prompt
+        return torch.zeros(n, 77, 2048), torch.zeros(n, 1280)
+
+    def _diffuse(latents, **kwargs):
+        recorder["diffuse_batch"] = latents.shape[0]
+        recorder["diffuse_latents"] = latents.clone()
+        return latents
+
+    pipeline.encode_prompt = _encode_prompt
+    pipeline.diffuse = _diffuse
+    return pipeline
+
+
+def _make_batch(prompts: list[str], latents: list[torch.Tensor] | None = None) -> DiffusionRequestBatch:
+    requests = []
+    for idx, prompt in enumerate(prompts):
+        sampling = OmniDiffusionSamplingParams(
+            height=HEIGHT,
+            width=WIDTH,
+            num_inference_steps=2,
+            guidance_scale=1.0,
+        )
+        if latents is not None:
+            sampling.latents = latents[idx]
+        requests.append(
+            OmniDiffusionRequest(
+                request_id=f"req-{idx}",
+                prompt={"prompt": prompt},
+                sampling_params=sampling,
+            )
+        )
+    return DiffusionRequestBatch(requests=requests)
+
+
+def test_sdxl_declares_request_batch_support() -> None:
+    """SDXL must opt in, otherwise DiffusionEngine rejects max_num_seqs > 1."""
+    assert StableDiffusionXLPipeline.supports_request_batch is True
+
+
+def test_forward_returns_one_output_per_request() -> None:
+    recorder: dict = {}
+    pipeline = _make_pipeline(recorder)
+    batch = _make_batch(["a cat", "a dog", "a bird"])
+
+    outputs = pipeline.forward(batch)
+
+    assert isinstance(outputs, list)
+    assert len(outputs) == batch.num_reqs
+    assert all(isinstance(out, DiffusionOutput) for out in outputs)
+    # All three prompts must ride in a single UNet forward.
+    assert recorder["diffuse_batch"] == 3
+    assert recorder["encoded_prompts"][0] == ["a cat", "a dog", "a bird"]
+
+
+def test_forward_splits_output_rows_per_request() -> None:
+    recorder: dict = {}
+    pipeline = _make_pipeline(recorder)
+    batch = _make_batch(["p0", "p1"])
+
+    outputs = pipeline.forward(batch)
+
+    # Request i must receive exactly its own image row (value i), not the
+    # whole batched tensor.
+    for idx, out in enumerate(outputs):
+        assert out.output.shape[0] == 1
+        assert torch.allclose(out.output[0], torch.full((3, HEIGHT, WIDTH), float(idx)))
+
+
+def test_forward_collates_per_request_latents() -> None:
+    recorder: dict = {}
+    pipeline = _make_pipeline(recorder)
+    shape = (1, LATENT_CHANNELS, HEIGHT // VAE_SCALE, WIDTH // VAE_SCALE)
+    latents = [torch.full(shape, 1.0), torch.full(shape, 2.0)]
+    batch = _make_batch(["p0", "p1"], latents=latents)
+
+    pipeline.forward(batch)
+
+    used = recorder["diffuse_latents"]
+    assert used.shape[0] == 2
+    assert torch.allclose(used[0], torch.full(shape[1:], 1.0))
+    assert torch.allclose(used[1], torch.full(shape[1:], 2.0))
+
+
+def test_forward_single_request_still_returns_list() -> None:
+    recorder: dict = {}
+    pipeline = _make_pipeline(recorder)
+
+    outputs = pipeline.forward(_make_batch(["only"]))
+
+    assert len(outputs) == 1
+    assert recorder["diffuse_batch"] == 1

--- a/vllm_omni/diffusion/models/sdxl/pipeline_sdxl.py
+++ b/vllm_omni/diffusion/models/sdxl/pipeline_sdxl.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 import logging
 import os
@@ -22,7 +22,7 @@ from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_p
 from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
 from vllm_omni.diffusion.models.sdxl.sdxl_unet import SDXLUNet2DConditionModel
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
-from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch, split_diffusion_output_by_request
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +47,7 @@ class StableDiffusionXLPipeline(
     _encoder_modules: list[str] = ["text_encoder", "text_encoder_2"]
     _vae_modules: list[str] = ["vae"]
     _resident_modules: list[str] = []
+    supports_request_batch = True
 
     def __init__(
         self,
@@ -306,23 +307,29 @@ class StableDiffusionXLPipeline(
         num_images_per_prompt: int = 1,
         generator: torch.Generator | list[torch.Generator] | None = None,
         latents: torch.Tensor | None = None,
-    ) -> DiffusionOutput:
+    ) -> list[DiffusionOutput]:
         prompt = [p if isinstance(p, str) else (p.get("prompt") or "") for p in req.prompts] or prompt
         negative_prompt = [
             "" if isinstance(p, str) else (p.get("negative_prompt") or "") for p in req.prompts
         ] or negative_prompt
 
-        height = req.sampling_params.height or self.default_sample_size * self.vae_scale_factor
-        width = req.sampling_params.width or self.default_sample_size * self.vae_scale_factor
-        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
-        generator = req.sampling_params.generator or generator
+        # Request-batch-wide fields are guaranteed identical across the batch by
+        # RequestBatchSamplingParamsKey, so the first request carries them.
+        common_sampling_params = req.sampling_params_list[0]
+
+        height = common_sampling_params.height or self.default_sample_size * self.vae_scale_factor
+        width = common_sampling_params.width or self.default_sample_size * self.vae_scale_factor
+        num_inference_steps = common_sampling_params.num_inference_steps or num_inference_steps
         num_images_per_prompt = (
-            req.sampling_params.num_outputs_per_prompt
-            if req.sampling_params.num_outputs_per_prompt > 0
+            common_sampling_params.num_outputs_per_prompt
+            if common_sampling_params.num_outputs_per_prompt > 0
             else num_images_per_prompt
         )
+        # Seeds/generators and latents are request-local: collate them per request.
+        generator = req.collate_request_generators(num_images_per_prompt, generator)
+        latents = req.collate_request_tensors("latents", latents)
 
-        self._guidance_scale = req.sampling_params.guidance_scale
+        self._guidance_scale = common_sampling_params.guidance_scale
         self._current_timestep = None
         self._interrupt = False
 
@@ -412,9 +419,13 @@ class StableDiffusionXLPipeline(
             latents = latents / self.vae.config.scaling_factor
             image = self.vae.decode(latents, return_dict=False)[0]
 
-        return DiffusionOutput(
-            output=image,
-            stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
+        return split_diffusion_output_by_request(
+            DiffusionOutput(
+                output=image,
+                stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
+            ),
+            req,
+            num_outputs_per_prompt=num_images_per_prompt,
         )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:


### PR DESCRIPTION
## Purpose

**Problem:** `StableDiffusionXLPipeline` never declares `supports_request_batch`, so the engine gate defaults to False and serving SDXL with `--max-num-seqs > 1` fails at startup with "does not support request-level batching". SDXL is limited to serial batch=1 execution and cannot answer concurrency-under-SLA questions. Three things block N>1 even though the pipeline internals already carry a batch dimension: the opt-in attribute is missing; `forward()` reads batch-wide values from `req.sampling_params`, whose property asserts a single request; and `forward()` returns one fused `DiffusionOutput` instead of `list[DiffusionOutput]`, so the first request would receive every image. Per-request generators and latents were also read from a single sampling-params object, ignoring per-request seeds.

**Fix:** opt in with `supports_request_batch = True`; read batch-wide parameters from `req.sampling_params_list[0]` (the scheduler guarantees they are identical across a batch via `RequestBatchSamplingParamsKey`); collate request-local generators and latents with `collate_request_generators` / `collate_request_tensors`; split the fused result with `split_diffusion_output_by_request` so each request receives only its own images. This follows the QwenImage request-batch pattern. The SPDX copyright line on the touched file is rewritten by the repo's `check-spdx-header` hook.

## Test Plan

**Reproduce:**

```bash
vllm serve stabilityai/stable-diffusion-xl-base-1.0 --omni --max-num-seqs 4
```

Startup fails with `'StableDiffusionXLPipeline' does not support request-level batching.`

```bash
pytest -q tests/diffusion/models/sdxl/test_sdxl_request_batch.py
```

Five CPU cases (no accelerator, no checkpoint) run the real `forward()` with stubbed encoder, denoiser and VAE: the opt-in attribute; three prompts ride one UNet call (`latents.shape[0] == 3`); request i receives exactly its own image row; per-request latents are collated in order; a single request still returns a list.

**vLLM Version:** as pinned by `requirements/`. **vLLM-Omni Commit:** rebased onto current `main`.

## Test Result

CPU tests: 5 failed on main, 5 passed with the change. On an 8-card Intel XPU host, serving with `--max-num-seqs 16` and 16 concurrent requests produced a single fused forward with `latents.shape == (16, 4, 128, 128)` (one UNet call for 16 requests), each request receiving its own image; `--max-num-seqs 4` and `8` behaved the same.

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

## Test Plan

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
