### PR TITLE
feat(diffusion): add MiniMax-H3 FastH3 FI VSA backends

### DIFF
--- a/benchmarks/kernels/bench_minimax_h3_vsa_backends.py
+++ b/benchmarks/kernels/bench_minimax_h3_vsa_backends.py
@@ -1,0 +1,279 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Compare FastVideo Triton and FlashInfer native blk64 VSA kernels.
+
+This is a kernel-only benchmark. Sparse-index construction, BSHD/BHSD layout
+conversion, and backend JIT compilation all happen before timing. The default
+shape models one rank of MiniMax-H3 under Ulysses-8 for the 15-second 768p
+workload; the synthetic sparse pattern keeps prefix queries dense and gives
+each video query every prefix block plus 64 video blocks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import inspect
+import math
+import statistics
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import torch
+
+BLOCK_SIZE = 64
+HEAD_DIM = 128
+
+
+@dataclass(frozen=True)
+class Timing:
+    p50_ms: float
+    p90_ms: float
+    minimum_ms: float
+    maximum_ms: float
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--seq-len", type=int, default=109632)
+    parser.add_argument("--num-heads", type=int, default=7)
+    parser.add_argument("--prefix-blocks", type=int, default=8)
+    parser.add_argument("--topk", type=int, default=64)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--repeat", type=int, default=30)
+    parser.add_argument("--seed", type=int, default=0)
+    return parser.parse_args()
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    if args.seq_len <= 0 or args.seq_len % BLOCK_SIZE:
+        raise ValueError("seq-len must be a positive multiple of 64")
+    num_blocks = args.seq_len // BLOCK_SIZE
+    if args.num_heads <= 0:
+        raise ValueError("num-heads must be positive")
+    if not 0 <= args.prefix_blocks < num_blocks:
+        raise ValueError("prefix-blocks must be in [0, seq-len / 64)")
+    if args.topk <= 0:
+        raise ValueError("topk must be positive")
+    if args.warmup <= 0 or args.repeat < 2:
+        raise ValueError("warmup must be positive and repeat must be at least 2")
+
+
+def build_h3_sparse_metadata(
+    num_blocks: int,
+    num_heads: int,
+    prefix_blocks: int,
+    topk: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
+    """Build deterministic prefix-dense plus video-top-k blk64 metadata."""
+    video_blocks = num_blocks - prefix_blocks
+    keep_video = min(topk, video_blocks)
+    rows: list[list[int]] = []
+    for query_block in range(num_blocks):
+        if query_block < prefix_blocks:
+            rows.append(list(range(num_blocks)))
+            continue
+        start = (query_block - prefix_blocks) % video_blocks
+        selected = [prefix_blocks + (start + offset) % video_blocks for offset in range(keep_video)]
+        rows.append([*range(prefix_blocks), *selected])
+
+    max_nnz = max(len(row) for row in rows)
+    q2k_idx = torch.full(
+        (1, num_heads, num_blocks, max_nnz),
+        -1,
+        dtype=torch.int32,
+        device=device,
+    )
+    q2k_num = torch.empty((1, num_heads, num_blocks), dtype=torch.int32, device=device)
+    for query_block, row in enumerate(rows):
+        q2k_idx[:, :, query_block, : len(row)] = torch.tensor(row, dtype=torch.int32, device=device)
+        q2k_num[:, :, query_block] = len(row)
+
+    block_sizes = torch.full((num_blocks,), BLOCK_SIZE, dtype=torch.int32, device=device)
+    active_blocks_per_head = sum(len(row) for row in rows)
+    return q2k_idx, q2k_num, block_sizes, active_blocks_per_head
+
+
+def flashinfer_kernel() -> tuple[Callable[..., tuple[torch.Tensor, object]], str]:
+    capability = torch.cuda.get_device_capability()
+    if capability in ((10, 0), (10, 3)):
+        from flashinfer.cute_dsl.sparse.bsa_attn_sm100_blk64 import (
+            bsa_attn_sm100_blk64_fwd,
+        )
+
+        return bsa_attn_sm100_blk64_fwd, "sm100_blk64_cuda"
+    if capability in ((12, 0), (12, 1)):
+        from flashinfer.cute_dsl.sparse.bsa_attn_sm120 import (
+            bsa_attn_sm120_blk64_fwd,
+        )
+
+        return bsa_attn_sm120_blk64_fwd, "sm120_blk64_cute_dsl"
+    raise RuntimeError(f"FlashInfer blk64 VSA requires SM100/SM103 or SM120/SM121; current capability is {capability}")
+
+
+def percentile(samples: list[float], fraction: float) -> float:
+    ordered = sorted(samples)
+    return ordered[math.ceil(fraction * len(ordered)) - 1]
+
+
+def summarize(samples: list[float]) -> Timing:
+    return Timing(
+        p50_ms=statistics.median(samples),
+        p90_ms=percentile(samples, 0.9),
+        minimum_ms=min(samples),
+        maximum_ms=max(samples),
+    )
+
+
+def time_one(call: Callable[[], object]) -> float:
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    call()
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end)
+
+
+def package_version(distribution: str) -> str:
+    try:
+        return importlib.metadata.version(distribution)
+    except importlib.metadata.PackageNotFoundError:
+        return "source-tree"
+
+
+def main() -> None:
+    args = parse_args()
+    validate_args(args)
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+
+    device = torch.device("cuda")
+    capability = torch.cuda.get_device_capability(device)
+    num_blocks = args.seq_len // BLOCK_SIZE
+    q2k_idx, q2k_num, block_sizes, active_blocks_per_head = build_h3_sparse_metadata(
+        num_blocks,
+        args.num_heads,
+        args.prefix_blocks,
+        args.topk,
+        device,
+    )
+
+    torch.manual_seed(args.seed)
+    shape = (1, args.seq_len, args.num_heads, HEAD_DIM)
+    query = torch.randn(shape, dtype=torch.bfloat16, device=device)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    flashinfer_out = torch.empty_like(query)
+    query_bhsd = query.transpose(1, 2).contiguous()
+    key_bhsd = key.transpose(1, 2).contiguous()
+    value_bhsd = value.transpose(1, 2).contiguous()
+
+    from fastvideo_kernel.triton_kernels.block_sparse_attn_triton import (
+        triton_block_sparse_attn_forward,
+    )
+
+    fi_kernel, fi_name = flashinfer_kernel()
+
+    def run_triton() -> torch.Tensor:
+        output, _ = triton_block_sparse_attn_forward(
+            query_bhsd,
+            key_bhsd,
+            value_bhsd,
+            q2k_idx,
+            q2k_num,
+            block_sizes,
+        )
+        return output
+
+    def run_flashinfer() -> torch.Tensor:
+        output, _ = fi_kernel(
+            query,
+            key,
+            value,
+            q2k_idx,
+            q2k_idx.shape[-1],
+            block_sizes=block_sizes,
+            q2k_block_nums=q2k_num,
+            softmax_scale=HEAD_DIM**-0.5,
+            return_lse=False,
+            out=flashinfer_out,
+        )
+        return output
+
+    # Compile/autotune both providers and populate their allocator caches before
+    # placing any CUDA events. Alternate the timed order to reduce clock drift.
+    for _ in range(args.warmup):
+        run_triton()
+        run_flashinfer()
+    torch.accelerator.synchronize()
+
+    triton_samples: list[float] = []
+    flashinfer_samples: list[float] = []
+    for repetition in range(args.repeat):
+        if repetition % 2:
+            flashinfer_samples.append(time_one(run_flashinfer))
+            triton_samples.append(time_one(run_triton))
+        else:
+            triton_samples.append(time_one(run_triton))
+            flashinfer_samples.append(time_one(run_flashinfer))
+
+    triton_output = run_triton().transpose(1, 2).contiguous()
+    fi_output = run_flashinfer()
+    torch.accelerator.synchronize()
+    difference = fi_output.float() - triton_output.float()
+    max_abs = float(difference.abs().max().item())
+    relative_l2 = float((difference.norm() / triton_output.float().norm().clamp_min(1e-20)).item())
+    if not torch.isfinite(fi_output).all():
+        raise RuntimeError("FlashInfer output contains non-finite values")
+    if max_abs > 0.04 or relative_l2 > 0.01:
+        raise RuntimeError(f"backend mismatch: max_abs={max_abs:.8f}, relative_l2={relative_l2:.8f}")
+
+    triton_timing = summarize(triton_samples)
+    flashinfer_timing = summarize(flashinfer_samples)
+    density = active_blocks_per_head / (num_blocks * num_blocks)
+    active_blocks = active_blocks_per_head * args.num_heads
+    attention_flops = 4 * active_blocks * BLOCK_SIZE**2 * HEAD_DIM
+
+    print("MINIMAX_H3_VSA_BACKEND_BENCHMARK: PASS")
+    print(
+        f"gpu={torch.cuda.get_device_name(device)} capability={capability} "
+        f"torch={torch.__version__} cuda={torch.version.cuda}"
+    )
+    print(
+        f"fastvideo_kernel={package_version('fastvideo-kernel')} "
+        f"source={inspect.getsourcefile(triton_block_sparse_attn_forward)}"
+    )
+    print(
+        f"flashinfer={package_version('flashinfer-python')} backend={fi_name} source={inspect.getsourcefile(fi_kernel)}"
+    )
+    print(
+        f"batch=1 seq_len={args.seq_len} heads={args.num_heads} "
+        f"head_dim={HEAD_DIM} logical_block={BLOCK_SIZE} blocks={num_blocks} "
+        f"prefix_blocks={args.prefix_blocks} topk={args.topk} "
+        f"max_nnz={q2k_idx.shape[-1]} density={density:.6f}"
+    )
+    print(
+        "fastvideo_triton "
+        f"p50_ms={triton_timing.p50_ms:.6f} "
+        f"p90_ms={triton_timing.p90_ms:.6f} "
+        f"min_ms={triton_timing.minimum_ms:.6f} "
+        f"max_ms={triton_timing.maximum_ms:.6f} "
+        f"effective_tflops={attention_flops / triton_timing.p50_ms / 1e9:.3f}"
+    )
+    print(
+        f"flashinfer_{fi_name} "
+        f"p50_ms={flashinfer_timing.p50_ms:.6f} "
+        f"p90_ms={flashinfer_timing.p90_ms:.6f} "
+        f"min_ms={flashinfer_timing.minimum_ms:.6f} "
+        f"max_ms={flashinfer_timing.maximum_ms:.6f} "
+        f"effective_tflops={attention_flops / flashinfer_timing.p50_ms / 1e9:.3f}"
+    )
+    print(
+        f"speedup={triton_timing.p50_ms / flashinfer_timing.p50_ms:.4f}x "
+        f"max_abs={max_abs:.8f} relative_l2={relative_l2:.8f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/bench_minimax_h3_vsa_e2e.py
+++ b/benchmarks/kernels/bench_minimax_h3_vsa_e2e.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Benchmark FastH3 VSA end to end on the 8-GPU TP2 x Ulysses4 layout."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import copy
+import hashlib
+import json
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from vllm_omni.entrypoints.async_omni import AsyncOmni
+
+
+PROMPT = (
+    "At night, three cats march into a bedroom playing tiny brass instruments, "
+    "then abruptly file out, with synchronized room ambience."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--adapter", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--duration", type=float, default=5.0)
+    parser.add_argument("--warmups", type=int, default=1)
+    parser.add_argument("--repeats", type=int, default=3)
+    return parser.parse_args()
+
+
+def _git_revision(path: Path) -> str | None:
+    try:
+        return subprocess.check_output(
+            ["git", "-C", str(path), "rev-parse", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def environment() -> dict[str, Any]:
+    import flashinfer
+    import torch
+    import vllm_omni
+
+    flashinfer_root = Path(flashinfer.__file__).resolve().parent.parent
+    vllm_omni_root = Path(vllm_omni.__file__).resolve().parent.parent
+    return {
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+        "gpu": torch.cuda.get_device_name(),
+        "capability": list(torch.cuda.get_device_capability()),
+        "flashinfer": flashinfer.__version__,
+        "flashinfer_source": str(flashinfer_root),
+        "flashinfer_commit": _git_revision(flashinfer_root),
+        "vllm_omni_source": str(vllm_omni_root),
+        "vllm_omni_commit": _git_revision(vllm_omni_root),
+    }
+
+
+def engine_kwargs(args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        "model": args.model,
+        "trust_remote_code": True,
+        "task_type": "fl2va",
+        "num_gpus": 8,
+        "tensor_parallel_size": 2,
+        "ulysses_degree": 4,
+        "ring_degree": 1,
+        "data_parallel_size": 1,
+        "text_encoder_tp_size": 8,
+        "vae_patch_parallel_size": 8,
+        "vae_parallel_mode": "tile",
+        "vae_use_tiling": True,
+        "diffusion_attention_config": {
+            "default": {
+                "backend": "FASTVIDEO_VSA",
+                "fastvideo_vsa_topk": 64,
+                "fastvideo_vsa_h3_kernel_backend": "flashinfer",
+            }
+        },
+        "lora_path": args.adapter,
+        "request_batch_max_wait_ms": 0.0,
+        "enable_diffusion_pipeline_profiler": True,
+        "stage_init_timeout": 1800.0,
+        "init_timeout": 1800.0,
+    }
+
+
+def sampling_params(engine: AsyncOmni, duration: float) -> list[Any]:
+    params = copy.deepcopy(engine.default_sampling_params_list)
+    diffusion = params[0]
+    diffusion.width = 1344
+    diffusion.height = 768
+    diffusion.fps = 24
+    diffusion.num_inference_steps = 4
+    diffusion.seed = 1101
+    diffusion.extra_args = {
+        "task": "t2va",
+        "duration": duration,
+        "aspect_ratio": "16:9",
+    }
+    return params
+
+
+async def generate(engine: AsyncOmni, duration: float, request_id: str) -> dict[str, Any]:
+    final_output = None
+    started = time.perf_counter()
+    async for output in engine.generate(
+        prompt=PROMPT,
+        request_id=request_id,
+        sampling_params_list=sampling_params(engine, duration),
+    ):
+        if output.finished:
+            final_output = output
+    elapsed = time.perf_counter() - started
+    if final_output is None or not final_output.images:
+        raise RuntimeError(f"{request_id} finished without video output")
+
+    frames = np.asarray(final_output.images[0])
+    payload = final_output.multimodal_output or {}
+    audio = np.asarray(payload.get("audio"))
+    return {
+        "request_id": request_id,
+        "wall_time_s": elapsed,
+        "stage_durations": final_output.stage_durations,
+        "peak_memory_mb": float(final_output.peak_memory_mb),
+        "frames_shape": list(frames.shape),
+        "frames_sha256": hashlib.sha256(frames.tobytes()).hexdigest(),
+        "audio_shape": list(audio.shape),
+        "audio_sha256": hashlib.sha256(audio.tobytes()).hexdigest(),
+    }
+
+
+async def run(args: argparse.Namespace) -> dict[str, Any]:
+    kwargs = engine_kwargs(args)
+    engine = AsyncOmni(**kwargs)
+    try:
+        for index in range(args.warmups):
+            await generate(engine, args.duration, f"warmup-{index + 1}")
+        measured = [
+            await generate(engine, args.duration, f"measured-{index + 1}")
+            for index in range(args.repeats)
+        ]
+    finally:
+        engine.close()
+
+    wall_times = [sample["wall_time_s"] for sample in measured]
+    return {
+        "environment": environment(),
+        "engine_kwargs": kwargs,
+        "workload": {
+            "duration_s": args.duration,
+            "width": 1344,
+            "height": 768,
+            "fps": 24,
+            "steps": 4,
+            "seed": 1101,
+            "warmups": args.warmups,
+            "repeats": args.repeats,
+        },
+        "measured": measured,
+        "summary": {
+            "mean_wall_time_s": sum(wall_times) / len(wall_times),
+            "min_wall_time_s": min(wall_times),
+            "max_wall_time_s": max(wall_times),
+        },
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    if args.warmups < 0 or args.repeats < 1:
+        raise ValueError("warmups must be non-negative and repeats must be positive")
+    result = asyncio.run(run(args))
+    rendered = json.dumps(result, indent=2, sort_keys=True)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(rendered + "\n", encoding="utf-8")
+    print("MINIMAX_H3_VSA_E2E: PASS")
+    print(rendered)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/design/feature/attention_backend_selection.md
+++ b/docs/design/feature/attention_backend_selection.md
@@ -62,7 +62,8 @@ unstructured keyword dictionaries:
   validation;
 - `skip_softmax` is consumed by TRTLLM; and
 - `block_sparse` is consumed by block-sparse backends such as RainFusion; and
-- `fastvideo_vsa_topk` is consumed by FastVideo VSA.
+- `fastvideo_vsa_topk` and `fastvideo_vsa_h3_kernel_backend` are consumed by
+  FastVideo VSA.
 
 A backend reads only the fields it owns and rejects incompatible values. New
 options should be added to a shared typed spec only when more than one backend

--- a/docs/user_guide/diffusion/attention_backends/fastvideo_vsa.md
+++ b/docs/user_guide/diffusion/attention_backends/fastvideo_vsa.md
@@ -20,6 +20,11 @@ dtypes, sequence-parallel execution, or kernel failures fall back to
 sequence-parallel context is one of those fallbacks; the H3 route supports pure
 Ulysses and rejects ring or all-gather sequence parallelism at startup.
 
+MiniMax-H3 can optionally execute the block-sparse attention compute through
+FlashInfer. This also requires a FlashInfer build that provides the blk64 VSA
+APIs. Explicit FlashInfer selection fails instead of silently falling back if
+the requested native kernel is unavailable or its launch fails.
+
 ## Enable the backend
 
 For online serving, select the backend with the existing attention backend
@@ -53,6 +58,28 @@ Do not combine `--diffusion-attention-backend` with an explicit
 `diffusion_attention_config.default.backend`. The top-k value must be positive
 and is valid only when the default backend is `FASTVIDEO_VSA`.
 
+### Choose the MiniMax-H3 compute kernel
+
+The default `fastvideo` provider preserves the existing FastVideo kernel. To
+select the architecture-specific FlashInfer provider for MiniMax-H3, use the
+structured configuration:
+
+```bash
+vllm-omni serve <model> \
+  --diffusion-attention-config \
+  '{"default":{"backend":"FASTVIDEO_VSA","fastvideo_vsa_topk":64,"fastvideo_vsa_h3_kernel_backend":"flashinfer"}}'
+```
+
+The `flashinfer` provider dispatches the same 64-token, variable-tail block
+contract to:
+
+- the native CUDA/C++ blk64 kernel on SM100 and SM103 (BF16); or
+- the CuTe DSL blk64 kernel on SM120 and SM121 (FP16 or BF16).
+
+Both kernels require head dimension 128. The provider changes only the
+block-sparse attention compute; H3 block scoring, top-k selection, and learned
+compression-gate behavior stay unchanged.
+
 For a deploy YAML stage, use either the shorthand fields:
 
 ```yaml
@@ -71,6 +98,7 @@ stages:
       default:
         backend: FASTVIDEO_VSA
         fastvideo_vsa_topk: 64
+        fastvideo_vsa_h3_kernel_backend: flashinfer
 ```
 
 ## Choose top-k
@@ -123,6 +151,9 @@ the backend guarantees sparse execution:
 - `route=VSA` means top-k block selection is active.
 - `route=VSA_ALL_BLOCKS` means the FastVideo DMD checkpoint retained all
   blocks through the VSA kernel.
+- `compute_backend=flashinfer` followed by `FlashInfer
+  vsa_sm120_blk64_cute_dsl` or `vsa_sm100_blk64_cuda` confirms the native H3
+  compute path.
 - `route=SDPA` or `FASTVIDEO_VSA falling back to SDPA: ...` means dense SDPA
   executed; the warning includes the reason.
 

--- a/tests/diffusion/attention/test_attention_config.py
+++ b/tests/diffusion/attention/test_attention_config.py
@@ -106,6 +106,19 @@ class TestAttentionSpec:
         with pytest.raises(ValueError, match="only supported by the FASTVIDEO_VSA"):
             AttentionSpec(backend="TORCH_SDPA", fastvideo_vsa_topk=96)
 
+    def test_fastvideo_vsa_h3_kernel_backend_serialized(self):
+        spec = AttentionSpec(backend="FASTVIDEO_VSA", fastvideo_vsa_h3_kernel_backend="FlashInfer")
+        assert spec.backend_kwargs() == {"h3_kernel_backend": "flashinfer"}
+
+    @pytest.mark.parametrize("value", ["triton", "cuda", "cute_dsl"])
+    def test_fastvideo_vsa_h3_kernel_backend_rejected(self, value):
+        with pytest.raises(ValueError, match="must be 'fastvideo' or 'flashinfer'"):
+            AttentionSpec(backend="FASTVIDEO_VSA", fastvideo_vsa_h3_kernel_backend=value)
+
+    def test_fastvideo_vsa_h3_kernel_backend_rejected_for_other_backend(self):
+        with pytest.raises(ValueError, match="only supported by the FASTVIDEO_VSA"):
+            AttentionSpec(backend="TORCH_SDPA", fastvideo_vsa_h3_kernel_backend="flashinfer")
+
     def test_block_sparse_defaults_applied_when_backend_selected(self):
         spec = AttentionSpec(backend="RAINFUSION_ATTN")
         assert spec.block_sparse.sparsity == 0.8

--- a/tests/diffusion/attention/test_fastvideo_vsa.py
+++ b/tests/diffusion/attention/test_fastvideo_vsa.py
@@ -19,6 +19,7 @@ from vllm_omni.diffusion.attention.backends.fastvideo_vsa import (
     FastVideoVSABackend,
     FastVideoVSAImpl,
     _build_h3_block_map,
+    _flashinfer_h3_vsa_bshd_impl,
     _get_h3_tile_metadata,
 )
 from vllm_omni.diffusion.attention.backends.registry import (
@@ -314,6 +315,94 @@ def test_h3_forward_keeps_prefix_dense_and_selects_top_k_video_tiles(monkeypatch
         *(x.float().transpose(1, 2) for x in (query, query, query))
     ).transpose(1, 2)
     torch.testing.assert_close(dense.float(), reference, atol=2e-2, rtol=2e-2)
+
+
+def test_h3_flashinfer_route_does_not_add_fastvideo_pair_padding(monkeypatch):
+    calls: dict[str, Any] = {}
+
+    def fake_flashinfer(q, k, v, block_map, variable_block_sizes, softmax_scale):
+        calls["q_shape"] = tuple(q.shape)
+        calls["block_map_shape"] = tuple(block_map.shape)
+        calls["variable_block_sizes"] = variable_block_sizes.tolist()
+        calls["softmax_scale"] = softmax_scale
+        return q
+
+    monkeypatch.setattr(
+        "vllm_omni.diffusion.attention.backends.fastvideo_vsa._flashinfer_h3_vsa_bshd_op",
+        fake_flashinfer,
+    )
+    impl = _h3_impl(topk=1, h3_kernel_backend="flashinfer")
+    prefix_segments, video_shape = (5,), (8, 4, 4)
+    seq_len = 5 + 8 * 4 * 4
+    query = torch.randn(1, seq_len, 2, 8, dtype=torch.bfloat16)
+
+    output = impl.forward_cuda(query, query, query, _h3_metadata(prefix_segments, video_shape))
+
+    assert calls["q_shape"] == (1, 3 * 64, 2, 8)
+    assert calls["block_map_shape"] == (1, 2, 3, 3)
+    assert calls["variable_block_sizes"] == [5, 64, 64]
+    assert calls["softmax_scale"] == 8**-0.5
+    torch.testing.assert_close(output, query)
+
+
+def test_h3_explicit_flashinfer_route_never_silently_falls_back(monkeypatch):
+    def failing_flashinfer(*args, **kwargs):
+        raise RuntimeError("flashinfer launch failed")
+
+    monkeypatch.setattr(
+        "vllm_omni.diffusion.attention.backends.fastvideo_vsa._flashinfer_h3_vsa_bshd_op",
+        failing_flashinfer,
+    )
+    impl = _h3_impl(h3_kernel_backend="flashinfer")
+    query = torch.randn(1, 5 + 2 * 4 * 4, 2, 8, dtype=torch.bfloat16)
+
+    with pytest.raises(RuntimeError, match="flashinfer launch failed"):
+        impl.forward_cuda(query, query, query, _h3_metadata((5,), (2, 4, 4)))
+
+
+@pytest.mark.parametrize(
+    ("capability", "module_name", "function_name"),
+    [
+        ((10, 3), "flashinfer.cute_dsl.sparse.bsa_attn_sm100_blk64", "bsa_attn_sm100_blk64_fwd"),
+        ((12, 0), "flashinfer.cute_dsl.sparse.bsa_attn_sm120", "bsa_attn_sm120_blk64_fwd"),
+    ],
+)
+def test_flashinfer_h3_provider_selects_arch_specific_blk64_kernel(monkeypatch, capability, module_name, function_name):
+    calls: dict[str, Any] = {}
+
+    def map_to_index(block_map):
+        blocks = block_map.shape[-1]
+        index = torch.arange(blocks, dtype=torch.int32).expand_as(block_map).clone()
+        counts = torch.full(block_map.shape[:-1], blocks, dtype=torch.int32)
+        return index, counts
+
+    index_module = types.ModuleType("fastvideo_kernel.triton_kernels.index")
+    setattr(index_module, "map_to_index", map_to_index)
+    monkeypatch.setitem(sys.modules, "fastvideo_kernel.triton_kernels.index", index_module)
+
+    def kernel(q, k, v, q2k_idx, block_sparse_num, **kwargs):
+        calls["q2k_dtype"] = q2k_idx.dtype
+        calls["block_sparse_num"] = block_sparse_num
+        calls.update(kwargs)
+        return q + k + v, None
+
+    kernel_module = types.ModuleType(module_name)
+    setattr(kernel_module, function_name, kernel)
+    monkeypatch.setitem(sys.modules, module_name, kernel_module)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device: capability)
+
+    query = torch.randn(1, 128, 2, 128, dtype=torch.bfloat16)
+    block_map = torch.ones(1, 2, 2, 2, dtype=torch.bool)
+    block_sizes = torch.tensor([64, 64], dtype=torch.int32)
+    output = _flashinfer_h3_vsa_bshd_impl(query, query, query, block_map, block_sizes, 128**-0.5)
+
+    torch.testing.assert_close(output, 3 * query)
+    assert calls["q2k_dtype"] == torch.int32
+    assert calls["block_sparse_num"] == 2
+    assert calls["block_sizes"].tolist() == [64, 64]
+    assert calls["q2k_block_nums"].shape == (1, 2, 2)
+    assert calls["softmax_scale"] == 128**-0.5
+    assert calls["return_lse"] is False
 
 
 def test_h3_forward_applies_the_learned_compression_gate(monkeypatch):

--- a/vllm_omni/diffusion/attention/backends/fastvideo_vsa.py
+++ b/vllm_omni/diffusion/attention/backends/fastvideo_vsa.py
@@ -159,6 +159,84 @@ if not hasattr(torch.ops.vllm_omni, "fastvideo_h3_vsa_bhsd"):
 _fastvideo_h3_vsa_bhsd_op = torch.ops.vllm_omni.fastvideo_h3_vsa_bhsd
 
 
+def _flashinfer_h3_vsa_bshd_impl(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    block_map: torch.Tensor,
+    variable_block_sizes: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    """Dispatch H3's blk64 VSA contract to the native FlashInfer kernel."""
+    from fastvideo_kernel.triton_kernels.index import map_to_index
+
+    q2k_idx, q2k_num = map_to_index(block_map)
+    q2k_idx = q2k_idx.to(torch.int32).contiguous()
+    q2k_num = q2k_num.to(torch.int32).contiguous()
+    block_sizes = variable_block_sizes.to(torch.int32).contiguous()
+
+    major, minor = torch.cuda.get_device_capability(query.device)
+    if (major, minor) in ((10, 0), (10, 3)):
+        if query.dtype != torch.bfloat16:
+            raise ValueError(f"FlashInfer SM100/SM103 blk64 VSA requires bfloat16, got {query.dtype}")
+        from flashinfer.cute_dsl.sparse.bsa_attn_sm100_blk64 import bsa_attn_sm100_blk64_fwd
+
+        kernel = bsa_attn_sm100_blk64_fwd
+        kernel_name = "vsa_sm100_blk64_cuda"
+    elif (major, minor) in ((12, 0), (12, 1)):
+        from flashinfer.cute_dsl.sparse.bsa_attn_sm120 import bsa_attn_sm120_blk64_fwd
+
+        kernel = bsa_attn_sm120_blk64_fwd
+        kernel_name = "vsa_sm120_blk64_cute_dsl"
+    else:
+        raise RuntimeError(
+            f"FlashInfer H3 blk64 VSA supports SM100/SM103 and SM120/SM121; current device is SM{major}{minor}"
+        )
+
+    logger.info_once("FASTVIDEO_VSA H3 compute kernel: FlashInfer %s", kernel_name)
+    output, _ = kernel(
+        query,
+        key,
+        value,
+        q2k_idx,
+        int(q2k_idx.shape[-1]),
+        block_sizes=block_sizes,
+        q2k_block_nums=q2k_num,
+        softmax_scale=softmax_scale,
+        return_lse=False,
+    )
+    return output
+
+
+if not hasattr(torch.ops.vllm_omni, "flashinfer_h3_vsa_bshd"):
+
+    @torch.library.custom_op("vllm_omni::flashinfer_h3_vsa_bshd", mutates_args=())
+    def _flashinfer_h3_vsa_bshd_op(
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        block_map: torch.Tensor,
+        variable_block_sizes: torch.Tensor,
+        softmax_scale: float,
+    ) -> torch.Tensor:
+        return _flashinfer_h3_vsa_bshd_impl(
+            query,
+            key,
+            value,
+            block_map,
+            variable_block_sizes,
+            softmax_scale,
+        )
+
+    @_flashinfer_h3_vsa_bshd_op.register_fake
+    def _(query, key, value, block_map, variable_block_sizes, softmax_scale):
+        del key, value, block_map, variable_block_sizes, softmax_scale
+        return torch.empty_like(query)
+
+
+_flashinfer_h3_vsa_bshd_op = torch.ops.vllm_omni.flashinfer_h3_vsa_bshd
+
+
 @functools.lru_cache(maxsize=32)
 def _get_tile_partition_indices(
     dit_seq_shape: tuple[int, int, int],
@@ -389,6 +467,11 @@ class FastVideoVSAImpl(AttentionImpl):
         self.min_seq_len = int(backend_kwargs.get("min_seq_len", self.block_elements * 2))
         self.fallback_on_error = bool(backend_kwargs.get("fallback_on_error", True))
         self.disable_when_sp_active = bool(backend_kwargs.get("disable_when_sp_active", True))
+        self.h3_kernel_backend = str(backend_kwargs.get("h3_kernel_backend", "fastvideo")).lower()
+        if self.h3_kernel_backend not in {"fastvideo", "flashinfer"}:
+            raise ValueError(
+                f"FASTVIDEO_VSA h3_kernel_backend must be 'fastvideo' or 'flashinfer', got {self.h3_kernel_backend!r}"
+            )
 
         self.sdpa_fallback = SDPAImpl(
             num_heads=num_heads,
@@ -536,10 +619,10 @@ class FastVideoVSAImpl(AttentionImpl):
             prefix_segments, video_shape, query.device
         )
         logical_blocks = int(sizes.numel())
-        # The native sm100a kernel assigns pairs of query blocks to CTAs. Its
-        # contract requires an even block count; the synthetic partner is
-        # transport-only and is removed before returning.
-        pair_pad = logical_blocks % 2
+        # FastVideo's optional native sm100a kernel assigns pairs of query
+        # blocks to CTAs. FlashInfer's blk64 kernels do not require the
+        # transport-only partner.
+        pair_pad = logical_blocks % 2 if self.h3_kernel_backend == "fastvideo" else 0
         kernel_blocks = logical_blocks + pair_pad
         target_shape = (query.shape[0], kernel_blocks * 64, query.shape[2], query.shape[3])
         q_tiled = torch.zeros(target_shape, device=query.device, dtype=query.dtype)
@@ -560,7 +643,7 @@ class FastVideoVSAImpl(AttentionImpl):
 
         logger.info_once(
             "FASTVIDEO_VSA H3 routing: seq_len=%d, prefix_segments=%s, video_shape=%s, "
-            "prefix_blocks=%d, video_blocks=%d, topk=%d, kernel_blocks=%d",
+            "prefix_blocks=%d, video_blocks=%d, topk=%d, kernel_blocks=%d, compute_backend=%s",
             query.shape[1],
             prefix_segments,
             video_shape,
@@ -568,15 +651,27 @@ class FastVideoVSAImpl(AttentionImpl):
             video_blocks,
             min(self.topk, video_blocks),
             kernel_blocks,
+            self.h3_kernel_backend,
         )
-        output = _fastvideo_h3_vsa_bhsd_op(
-            q_tiled.contiguous(),
-            k_tiled.contiguous(),
-            v_tiled.contiguous(),
-            block_map.contiguous(),
-            kernel_sizes.contiguous(),
-            logical_blocks,
-        )[:, : logical_blocks * 64]
+        if self.h3_kernel_backend == "flashinfer":
+            output = _flashinfer_h3_vsa_bshd_op(
+                q_tiled.contiguous(),
+                k_tiled.contiguous(),
+                v_tiled.contiguous(),
+                block_map.contiguous(),
+                kernel_sizes.contiguous(),
+                self.softmax_scale,
+            )
+        else:
+            output = _fastvideo_h3_vsa_bhsd_op(
+                q_tiled.contiguous(),
+                k_tiled.contiguous(),
+                v_tiled.contiguous(),
+                block_map.contiguous(),
+                kernel_sizes.contiguous(),
+                logical_blocks,
+            )
+        output = output[:, : logical_blocks * 64]
 
         if gate is not None:
             gate_tiled = torch.zeros_like(q_tiled[:, : logical_blocks * 64])
@@ -623,7 +718,7 @@ class FastVideoVSAImpl(AttentionImpl):
                 # A CUDA fault poisons the process context; attempting SDPA
                 # afterwards obscures the original kernel failure and cannot
                 # recover the request.
-                if isinstance(exc, torch.AcceleratorError):
+                if self.h3_kernel_backend == "flashinfer" or isinstance(exc, torch.AcceleratorError):
                     raise
                 if not self.fallback_on_error:
                     raise

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -1747,6 +1747,7 @@ class AttentionSpec:
     skip_softmax: SkipSoftmaxSpec | None = None
     quant: AttnQuantSpec | None = None
     fastvideo_vsa_topk: int | None = None
+    fastvideo_vsa_h3_kernel_backend: str | None = None
     block_sparse: BlockSparseSpec | None = None
     skip_calibration: dict | None = field(default=None, repr=False)
 
@@ -1771,6 +1772,12 @@ class AttentionSpec:
                 raise ValueError("fastvideo_vsa_topk is only supported by the FASTVIDEO_VSA backend.")
             if self.fastvideo_vsa_topk <= 0:
                 raise ValueError("fastvideo_vsa_topk must be positive.")
+        if self.fastvideo_vsa_h3_kernel_backend is not None:
+            if self.backend.upper() != "FASTVIDEO_VSA":
+                raise ValueError("fastvideo_vsa_h3_kernel_backend is only supported by the FASTVIDEO_VSA backend.")
+            self.fastvideo_vsa_h3_kernel_backend = self.fastvideo_vsa_h3_kernel_backend.lower()
+            if self.fastvideo_vsa_h3_kernel_backend not in {"fastvideo", "flashinfer"}:
+                raise ValueError("fastvideo_vsa_h3_kernel_backend must be 'fastvideo' or 'flashinfer'.")
         if self.backend.upper() in BLOCK_SPARSE_BACKENDS:
             # Selecting the backend is the opt-in; without an explicit block the
             # defaults apply rather than silently running dense.
@@ -1815,6 +1822,8 @@ class AttentionSpec:
                 kw["quant"] = quant_kw
         if self.fastvideo_vsa_topk is not None:
             kw["topk"] = self.fastvideo_vsa_topk
+        if self.fastvideo_vsa_h3_kernel_backend is not None:
+            kw["h3_kernel_backend"] = self.fastvideo_vsa_h3_kernel_backend
         if self.block_sparse is not None:
             bs = self.block_sparse
             kw["sparsity"] = bs.sparsity
@@ -1893,7 +1902,14 @@ class AttentionConfig:
             normalized[role] = node
             return
 
-        spec_keys = {"backend", "skip_softmax", "quant", "fastvideo_vsa_topk", "block_sparse"}
+        spec_keys = {
+            "backend",
+            "skip_softmax",
+            "quant",
+            "fastvideo_vsa_topk",
+            "fastvideo_vsa_h3_kernel_backend",
+            "block_sparse",
+        }
         node_dict = dict(node)
         node_keys = set(node_dict)
         if node_keys & spec_keys:


### PR DESCRIPTION
## Summary

- Add native MiniMax-H3 FastH3 VSA provider routing.
- Add a reproducible kernel-backend benchmark (FastVideo Triton vs FlashInfer).
- Add a TP2/SP4 MiniMax-H3 E2E benchmark harness.

The low-level SM120 kernel changes are maintained in FlashInfer; this PR wires the provider selection and provides the benchmark harness used to validate the integration.

## PRO5000 kernel microbenchmark

Hardware: NVIDIA RTX PRO 5000, CC 12.0, CUDA 13.0, PyTorch 2.13.0+cu130.

Workload: batch=1, seq_len=109632, heads=7, head_dim=128, logical_block=64, topk=64, logical_nnz=136464. Measurements used the same input, warmup, and repeat settings.

| Backend | p50 | Effective TFLOPS | Relative speed |
| --- | ---: | ---: | ---: |
| FastVideo Triton | 15.701 ms | 127.589 | 1.00x |
| FlashInfer SM120 VSA (`d14f1870`) | 8.995 ms | 222.716 | 1.746x |
| FlashInfer optimized Q/V-alias variant (`a2be065f`) | 8.984 ms | 222.977 | 1.748x |

Correctness for the reported runs: max_abs=0.00097656, relative_l2=0.00302094.

NCU for the optimized CuTe-DSL kernel: 8.97 ms kernel duration, 85.8% compute throughput, 54.6% memory throughput, zero local-memory spills, 246 registers/thread, 16.7% theoretical occupancy and 16.6% achieved occupancy.

## Correctness

- `CUDA_VISIBLE_DEVICES=4 pytest -q tests/attention/test_vsa_block_sparse_sm120.py -k 'not perf_sweep'`
- Result: 18 passed, 1 deselected.

## E2E status

The TP2/SP4 E2E harness was added, but the first remote attempt was blocked by an environment mismatch: the checkout reported vLLM-Omni `0.26.1.dev` while the environment had vLLM `0.28.0`, causing `ModuleNotFoundError: vllm.entrypoints.serve.utils.error_response`. E2E should be rerun after installing the matching vLLM-Omni 0.28.0 code line. No E2E speedup claim is made in this PR.

## Negative experiments

Several kernel variants were measured and excluded from the final claim: native CUDA load pipeline (93--118 ms), 3-CTA residency (~9.89 ms), register-paired softmax (~10.04 ms), and staggered CTAs (~9.8--9.9 ms).

## Checks

- Deterministic precheck: PASS against `upstream/main`.
- Python syntax checks for all changed Python files: PASS.
- Full local Python tests: unavailable on the review workstation (no Python executable).

Signed-off-by: lishunyang12 <lishunyang12@163.com>
