### PR TITLE
[Bugfix] Fix washed-out LingBot Video outputs

### DIFF
--- a/tests/diffusion/models/lingbot_video/test_pipeline_lingbot_video.py
+++ b/tests/diffusion/models/lingbot_video/test_pipeline_lingbot_video.py
@@ -147,7 +147,8 @@ def test_postprocess_keeps_torch_by_default_and_converts_np_when_requested():
     assert array.shape == (2, 4, 4, 3)
     video = post({"video": frames}, SimpleNamespace(output_type="pt"))
     assert set(video) == {"video"}
-    assert video["video"] is frames
+    assert isinstance(video["video"], np.ndarray)
+    np.testing.assert_array_equal(video["video"], frames.numpy())
     image = post(
         {"image": torch.ones(4, 4, 3)},
         SimpleNamespace(output_type="pt"),
@@ -159,6 +160,40 @@ def test_postprocess_keeps_torch_by_default_and_converts_np_when_requested():
     latent_output = post({"image": latent}, SimpleNamespace(output_type="latent"))
     assert set(latent_output) == {"image"}
     assert latent_output["image"] is latent
+
+
+@pytest.mark.parametrize("output_type", [None, "pt", "np"])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_postprocess_preserves_video_range_for_serving(output_type: str | None, dtype: torch.dtype) -> None:
+    from vllm_omni.diffusion.models.lingbot_video import get_lingbot_video_post_process_func
+    from vllm_omni.entrypoints.openai.video_api_utils import _coerce_video_to_frames
+
+    # Include black and midtones: all-white frames cannot expose double normalization.
+    frames = torch.tensor([0.0, 0.25, 0.5, 0.75, 1.0], dtype=dtype)
+    frames = frames.reshape(5, 1, 1, 1).expand(5, 2, 4, 3).clone()
+    expected = frames.float().numpy().copy()
+    sampling = None if output_type is None else OmniDiffusionSamplingParams(output_type=output_type)
+    post = get_lingbot_video_post_process_func(None)
+
+    processed = post({"video": frames}, sampling)
+    encoded_frames = np.stack(_coerce_video_to_frames(processed["video"]))
+
+    assert set(processed) == {"video"}
+    assert encoded_frames.dtype == np.float32
+    np.testing.assert_array_equal(encoded_frames, expected)
+    np.testing.assert_array_equal(frames.float().numpy(), expected)
+
+
+@pytest.mark.parametrize("output_key", ["image", "video"])
+def test_postprocess_preserves_latent_payload(output_key: str) -> None:
+    from vllm_omni.diffusion.models.lingbot_video import get_lingbot_video_post_process_func
+
+    latents = torch.tensor([-2.0, 0.0, 2.0]).reshape(1, 3, 1, 1, 1)
+    sampling = OmniDiffusionSamplingParams(output_type="latent")
+    processed = get_lingbot_video_post_process_func(None)({output_key: latents}, sampling)
+
+    assert set(processed) == {output_key}
+    assert processed[output_key] is latents
 
 
 def test_postprocess_preserves_image_contract_for_serving():
@@ -180,7 +215,9 @@ def test_postprocess_preserves_image_contract_for_serving():
         sampling_params=sampling,
         request_id="lingbot-image-contract-test",
     )
-    raw_output = {"image": torch.ones(8, 12, 3)}
+    image = torch.zeros(8, 12, 3)
+    image[4:] = 1.0
+    raw_output = {"image": image}
     processed = get_lingbot_video_post_process_func(SimpleNamespace())(raw_output, sampling)
     normalized = normalize_diffusion_postprocess_output(processed)
 
@@ -198,6 +235,8 @@ def test_postprocess_preserves_image_contract_for_serving():
     endpoint_images = _extract_images_from_result(result)
     assert len(endpoint_images) == 1
     assert endpoint_images[0].size == (12, 8)
+    assert endpoint_images[0].getpixel((0, 0)) == (0, 0, 0)
+    assert endpoint_images[0].getpixel((0, 7)) == (255, 255, 255)
 
 
 def test_forward_resolves_t2v_sampling_and_flow_shift_alias():

--- a/vllm_omni/diffusion/models/lingbot_video/pipeline_lingbot_video.py
+++ b/vllm_omni/diffusion/models/lingbot_video/pipeline_lingbot_video.py
@@ -287,13 +287,13 @@ def get_lingbot_video_post_process_func(od_config: OmniDiffusionConfig):
             output_key = output_keys[0]
             frames = frames[output_key]
         output_type = getattr(sampling_params, "output_type", None) or "pt"
-        # The image serving path currently accepts PIL images or NumPy arrays,
-        # while LingBot decodes T2I outputs to tensors. Keep that compatibility
-        # conversion without discarding the model's image/video payload key.
+        # Decoded LingBot pixels are already in [0, 1]. The video API treats
+        # floating tensors as [-1, 1], so use its NumPy path to avoid normalizing
+        # twice. Images also need NumPy for serving; keep latent tensors intact.
         if (
             isinstance(frames, torch.Tensor)
             and output_type != "latent"
-            and (output_type == "np" or output_key == "image")
+            and (output_type == "np" or output_key in {"image", "video"})
         ):
             frames = frames.float().cpu().numpy()
         return {output_key: frames} if output_key is not None else frames


### PR DESCRIPTION
## Purpose

LingBot Video decodes pixels into `[0, 1]` tensors, but the video API interprets
floating-point tensor payloads as `[-1, 1]` and normalizes them again. With the
default `pt` output, black becomes `0.5` and mid-gray becomes `0.75`, producing
washed-out videos. 

Convert decoded, keyed video payloads to NumPy in LingBot's postprocessor, matching
the existing image handling. The API's NumPy path preserves the decoded range.
This leaves VAE decoding and the shared API tensor convention unchanged, so other
models returning `[-1, 1]` tensors are unaffected. Structured decoded video outputs
now contain a NumPy array even when `output_type="pt"`; bare `pt` tensors and
`output_type="latent"` retain their existing behavior.

## What Changes

| File | Change |
|---|---|
| `vllm_omni/diffusion/models/lingbot_video/pipeline_lingbot_video.py` | Route decoded video payloads through the same NumPy conversion used for images, avoiding a second range normalization. Preserve latent tensors. |
| `tests/diffusion/models/lingbot_video/test_pipeline_lingbot_video.py` | Add black/midtone/white assertions through the real API frame conversion for default, `pt`, and `np` outputs in FP32/BF16; check image black/white values and image/video latent identity. Update the keyed video output-type expectation. |

## Test Plan

**vLLM Version:** `0.28.0`

**vLLM-Omni Commit:** base `4179b0cae`; candidate `53b6ea88c`.

**Environment:** Python 3.12.13, PyTorch 2.13.0+cu130; CPU regression tests and
one NVIDIA H200 for the video example. CPU tests require no model weights.
The test environment lacked optional `torchaudio`;
local validation used an import-only shim, with audio calls configured to fail.
The shim is not included in this PR.

```bash
pytest -q tests/diffusion/models/lingbot_video/test_pipeline_lingbot_video.py

pytest -q tests/diffusion/models/lingbot_video/test_pipeline_lingbot_video.py \
  tests/entrypoints/openai_api/test_video_api_utils.py \
  -m 'core_model and cpu' --run-level core_model
```

Existing CPU selectors in `.buildkite/cuda/test-ready.yml` and
`.buildkite/cuda/test-merge.yml` already collect these tests; no CI changes needed.

**Video example:** `robbyant/lingbot-video-moe-30b-a3b`, 832x480, 121 frames,
40 steps, CFG 3, flow shift 3, seed 42, and 24 FPS. Generate once per revision on
the same GPU using the online example's create/poll/download workflow and the same
structured prompt describing a woman modeling a cream cardigan in a bright apartment.
The structured prompt is sent with `curl --form-string` to preserve literal semicolons.

## Test Result

| Check | Result |
|---|---|
| Updated postprocess tests before the fix | 5 failed, 5 passed; default/`pt` video values were shifted upward |
| Full LingBot pipeline test module after the fix | 30 passed |
| Pipeline + shared video API tests with CI markers | 90 passed |
| Ruff lint / format check | Passed |
| Full-model video example | Both revisions completed; 121 frames at 832x480 and 24 FPS |

The regression preserves `[0, 0.25, 0.5, 0.75, 1]` exactly through postprocessing
and API frame conversion. Before the fix, the default/`pt` paths produced
`[0.5, 0.625, 0.75, 0.875, 1]`. The `np`, image, and latent checks pass after the fix.

### Visual comparison

Visual inspection used decoded frames 0, 60, and 120 from the generated MP4
files, without brightness, contrast, or color adjustment
<img width="1664" height="1554" alt="comparison" src="https://github.com/user-attachments/assets/38bc6726-f83b-417a-b12d-2f3d6ad2b88c" />
s.

The same subject, poses, and scene remain visible, while the washed-out appearance
is removed and dark details return in the corrected output.

| Decoded RGB statistic (0–255) | Before | After |
|---|---:|---:|
| 1st percentile | 142 | 29 |
| Mean | 218.18 | 182.67 |
| Minimum | 107 | 0 |
