### PR TITLE
[WIP][BugFix][Ming-flash-omni] Engine/config prerequisites for native paged talker stage

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -16,13 +16,14 @@ from unittest.mock import Mock
 import pytest
 from omegaconf import OmegaConf
 from pydantic import ValidationError
-from transformers import PretrainedConfig, Qwen3OmniMoeConfig
+from transformers import PretrainedConfig, Qwen2Config, Qwen3OmniMoeConfig
 from vllm.engine.arg_utils import EngineArgs
 
 from vllm_omni.config.model import OmniModelConfig
 from vllm_omni.engine.arg_utils import OmniEngineArgs
 from vllm_omni.engine.stage_init_utils import build_engine_args_dict
 from vllm_omni.platforms import current_omni_platform
+from vllm_omni.transformers_utils.configs.ming_flash_omni import MingFlashOmniTalkerConfig
 from vllm_omni.worker.omni_connector_model_runner_mixin import OmniConnectorModelRunnerMixin
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
@@ -505,6 +506,120 @@ def test_stage_specific_text_config_override():
     assert omni_config.get_num_attention_heads(parallel_config) == talker_num_heads
     assert omni_config.get_num_kv_heads(parallel_config) == talker_num_kv_heads
     assert omni_config.get_head_size() == talker_head_dim
+
+
+def test_ming_talker_text_config_uses_nested_qwen2_llm_config(monkeypatch):
+    """Ming talker stage sizing must come from talker_config.llm_config."""
+    original_mac = SimpleNamespace(
+        vocab_size=151936,
+        total_num_attention_heads=32,
+        total_num_kv_heads=8,
+        head_size=128,
+    )
+    vllm_config = SimpleNamespace(
+        model="dummy-ming",
+        hf_config=SimpleNamespace(
+            architectures=["MingFlashOmniTalkerForConditionalGeneration"],
+            model_type="ming_flash_omni",
+        ),
+        hf_text_config=SimpleNamespace(),
+        model_arch_config=original_mac,
+        disable_sliding_window=False,
+        original_max_model_len=None,
+        max_model_len=None,
+    )
+    monkeypatch.setattr(
+        OmniModelConfig,
+        "get_and_verify_max_len",
+        lambda self, _original_max_model_len: self.hf_text_config.max_position_embeddings,
+    )
+
+    talker_llm_config = {
+        "vocab_size": original_mac.vocab_size,
+        "hidden_size": 512,
+        "intermediate_size": 1024,
+        "num_hidden_layers": 6,
+        "num_attention_heads": 8,
+        "num_key_value_heads": 2,
+        "head_dim": 64,
+        "max_position_embeddings": 4096,
+        "sliding_window": 2048,
+    }
+    vllm_config.hf_text_config = SimpleNamespace()
+    vllm_config.hf_config.talker_config = MingFlashOmniTalkerConfig(llm_config=talker_llm_config)
+
+    omni_config = OmniModelConfig.from_vllm_model_config(
+        vllm_config,
+        hf_config_name="talker_config",
+        model_arch="MingFlashOmniTalkerForConditionalGeneration",
+    )
+
+    assert isinstance(omni_config.hf_text_config, Qwen2Config)
+    assert omni_config.hf_text_config.hidden_size == 512
+    assert omni_config.hf_text_config.num_hidden_layers == 6
+    assert omni_config.max_model_len == 4096
+    assert omni_config.omni_kv_config is None
+
+    stage_mac = omni_config.model_arch_config
+    assert stage_mac is not original_mac
+    assert stage_mac.total_num_attention_heads == 8
+    assert stage_mac.total_num_kv_heads == 2
+    assert stage_mac.head_size == 64
+
+
+def test_ming_talker_text_config_loads_local_talker_llm_config(tmp_path, monkeypatch):
+    """Standalone Ming TTS checkpoints may only expose talker/llm/config.json."""
+    original_mac = SimpleNamespace(
+        vocab_size=151936,
+        total_num_attention_heads=32,
+        total_num_kv_heads=8,
+        head_size=128,
+    )
+    vllm_config = SimpleNamespace(
+        model=str(tmp_path),
+        hf_config=SimpleNamespace(
+            architectures=["MingFlashOmniTalkerForConditionalGeneration"],
+            model_type="ming_flash_omni",
+        ),
+        hf_text_config=SimpleNamespace(hidden_size=4096),
+        model_arch_config=original_mac,
+        disable_sliding_window=False,
+        original_max_model_len=None,
+        max_model_len=None,
+    )
+    monkeypatch.setattr(
+        OmniModelConfig,
+        "get_and_verify_max_len",
+        lambda self, _original_max_model_len: self.hf_text_config.max_position_embeddings,
+    )
+
+    llm_dir = tmp_path / "talker" / "llm"
+    llm_dir.mkdir(parents=True)
+    Qwen2Config(
+        vocab_size=original_mac.vocab_size,
+        hidden_size=896,
+        intermediate_size=4864,
+        num_hidden_layers=24,
+        num_attention_heads=14,
+        num_key_value_heads=2,
+        max_position_embeddings=32768,
+    ).to_json_file(llm_dir / "config.json")
+
+    omni_config = OmniModelConfig.from_vllm_model_config(
+        vllm_config,
+        hf_config_name="talker_config",
+        model_arch="MingFlashOmniTalkerForConditionalGeneration",
+    )
+
+    assert isinstance(omni_config.hf_text_config, Qwen2Config)
+    assert omni_config.hf_text_config.hidden_size == 896
+    assert omni_config.max_model_len == 32768
+
+    stage_mac = omni_config.model_arch_config
+    assert stage_mac is not original_mac
+    assert stage_mac.total_num_attention_heads == 14
+    assert stage_mac.total_num_kv_heads == 2
+    assert stage_mac.head_size == 64
 
 
 def test_non_override_ar_stage_inputs_embeds_size_matches_hidden_size():

--- a/vllm_omni/config/model.py
+++ b/vllm_omni/config/model.py
@@ -1,4 +1,3 @@
-import os
 from dataclasses import MISSING, field
 from typing import Any
 
@@ -239,62 +238,13 @@ class OmniModelConfig(ModelConfig):
     def _draw_ming_talker_text_config(self):
         """Resolve the Ming talker Qwen2 config before model construction."""
         try:
-            from transformers import Qwen2Config
-
             from vllm_omni.transformers_utils.configs.ming_flash_omni import (
-                MingFlashOmniTalkerConfig,
+                resolve_ming_talker_text_config,
             )
         except Exception:
             return None
 
-        stage_config = getattr(self.hf_config, "talker_config", None)
-        if isinstance(stage_config, dict):
-            stage_config = MingFlashOmniTalkerConfig(**stage_config)
-        if isinstance(stage_config, MingFlashOmniTalkerConfig):
-            text_config = stage_config.get_text_config()
-            if text_config is not None:
-                return text_config
-
-        model_path = getattr(self, "model", None)
-        if not isinstance(model_path, str) or not model_path:
-            return None
-
-        if os.path.isdir(model_path):
-            talker_dir = os.path.join(model_path, "talker")
-            if not os.path.isdir(talker_dir):
-                talker_dir = model_path
-
-            if os.path.isdir(talker_dir):
-                try:
-                    talker_config = MingFlashOmniTalkerConfig.from_pretrained(talker_dir)
-                except Exception:
-                    talker_config = None
-                if isinstance(talker_config, MingFlashOmniTalkerConfig):
-                    text_config = talker_config.get_text_config()
-                    if text_config is not None:
-                        return text_config
-
-                llm_dir = os.path.join(talker_dir, "llm")
-                if os.path.isdir(llm_dir):
-                    try:
-                        return Qwen2Config.from_pretrained(llm_dir)
-                    except Exception:
-                        return None
-            return None
-
-        for loader, subfolder in (
-            (MingFlashOmniTalkerConfig, "talker"),
-            (Qwen2Config, "talker/llm"),
-        ):
-            try:
-                cfg = loader.from_pretrained(model_path, subfolder=subfolder)
-            except Exception:
-                continue
-            text_config = cfg.get_text_config() if isinstance(cfg, MingFlashOmniTalkerConfig) else cfg
-            if text_config is not None:
-                return text_config
-
-        return None
+        return resolve_ming_talker_text_config(self.hf_config, getattr(self, "model", None))
 
     def _validate_startup_task_type(self) -> None:
         """Validate startup-only task selectors owned by an AR model."""

--- a/vllm_omni/config/model.py
+++ b/vllm_omni/config/model.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import MISSING, field
 from typing import Any
 
@@ -216,6 +217,11 @@ class OmniModelConfig(ModelConfig):
         # transformers' get_text_config method is used to get the text config from thinker_config.
         # to handle the case that each model stage has their own text config,
         # we need to draw the text config from the corresponding model stage.
+        if self.model_arch == "MingFlashOmniTalkerForConditionalGeneration" and self.hf_config_name == "talker_config":
+            ming_talker_text_config = self._draw_ming_talker_text_config()
+            if ming_talker_text_config is not None:
+                return ming_talker_text_config
+
         if self.hf_config_name is None:
             return get_hf_text_config(self.hf_config)
         try:
@@ -229,6 +235,66 @@ class OmniModelConfig(ModelConfig):
                 "falling back to default get_hf_text_config"
             )
             return get_hf_text_config(self.hf_config)
+
+    def _draw_ming_talker_text_config(self):
+        """Resolve the Ming talker Qwen2 config before model construction."""
+        try:
+            from transformers import Qwen2Config
+
+            from vllm_omni.transformers_utils.configs.ming_flash_omni import (
+                MingFlashOmniTalkerConfig,
+            )
+        except Exception:
+            return None
+
+        stage_config = getattr(self.hf_config, "talker_config", None)
+        if isinstance(stage_config, dict):
+            stage_config = MingFlashOmniTalkerConfig(**stage_config)
+        if isinstance(stage_config, MingFlashOmniTalkerConfig):
+            text_config = stage_config.get_text_config()
+            if text_config is not None:
+                return text_config
+
+        model_path = getattr(self, "model", None)
+        if not isinstance(model_path, str) or not model_path:
+            return None
+
+        if os.path.isdir(model_path):
+            talker_dir = os.path.join(model_path, "talker")
+            if not os.path.isdir(talker_dir):
+                talker_dir = model_path
+
+            if os.path.isdir(talker_dir):
+                try:
+                    talker_config = MingFlashOmniTalkerConfig.from_pretrained(talker_dir)
+                except Exception:
+                    talker_config = None
+                if isinstance(talker_config, MingFlashOmniTalkerConfig):
+                    text_config = talker_config.get_text_config()
+                    if text_config is not None:
+                        return text_config
+
+                llm_dir = os.path.join(talker_dir, "llm")
+                if os.path.isdir(llm_dir):
+                    try:
+                        return Qwen2Config.from_pretrained(llm_dir)
+                    except Exception:
+                        return None
+            return None
+
+        for loader, subfolder in (
+            (MingFlashOmniTalkerConfig, "talker"),
+            (Qwen2Config, "talker/llm"),
+        ):
+            try:
+                cfg = loader.from_pretrained(model_path, subfolder=subfolder)
+            except Exception:
+                continue
+            text_config = cfg.get_text_config() if isinstance(cfg, MingFlashOmniTalkerConfig) else cfg
+            if text_config is not None:
+                return text_config
+
+        return None
 
     def _validate_startup_task_type(self) -> None:
         """Validate startup-only task selectors owned by an AR model."""

--- a/vllm_omni/engine/stage_engine_core_client.py
+++ b/vllm_omni/engine/stage_engine_core_client.py
@@ -403,6 +403,10 @@ class StageEngineCoreClientBase(StageClientBase):
                 # stage's model config (e.g. a talker whose engine positions
                 # must cover a speaker-prompt prefill).
                 extra_kwargs["next_stage_hf_config"] = self._stage_hf_config
+            if "stage_client" in signature.parameters:
+                # Let a processor reach the stage client (tokenizer, model
+                # config) when it opts in by keyword.
+                extra_kwargs["stage_client"] = self
             # Match the context parameter by name, including the
             # underscore-prefixed spelling some processors use (e.g.
             # MiniCPM-o's ``llm2tts(..., _streaming_context)``), so bridge

--- a/vllm_omni/transformers_utils/configs/ming_flash_omni.py
+++ b/vllm_omni/transformers_utils/configs/ming_flash_omni.py
@@ -19,7 +19,7 @@
 import os
 from typing import Any, ClassVar
 
-from transformers import AutoConfig, AutoTokenizer, PretrainedConfig, PreTrainedTokenizerFast
+from transformers import AutoConfig, AutoTokenizer, PretrainedConfig, PreTrainedTokenizerFast, Qwen2Config
 from transformers.utils import logging
 
 logger = logging.get_logger(__name__)
@@ -358,7 +358,7 @@ class MingFlashOmniTalkerConfig(PretrainedConfig):
         # during PretrainedConfig.__init__, before llm_config is assigned
         llm_config = getattr(self, "llm_config", None)
         if isinstance(llm_config, dict):
-            return PretrainedConfig.from_dict(llm_config)
+            return Qwen2Config(**llm_config)
 
         return llm_config
 

--- a/vllm_omni/transformers_utils/configs/ming_flash_omni.py
+++ b/vllm_omni/transformers_utils/configs/ming_flash_omni.py
@@ -417,4 +417,72 @@ AutoConfig.register(MingFlashOmniConfig.model_type, MingFlashOmniConfig)
 # AutoTokenizer.from_pretrained can resolve the tokenizer class
 AutoTokenizer.register(BailingMM2Config, fast_tokenizer_class=PreTrainedTokenizerFast)
 AutoTokenizer.register(MingFlashOmniTalkerConfig, fast_tokenizer_class=PreTrainedTokenizerFast)
+
+
+def resolve_ming_talker_config(root_config: Any, talker_dir: str, model_path: str) -> MingFlashOmniTalkerConfig | None:
+    """Resolve ``MingFlashOmniTalkerConfig``, or ``None`` when nothing loads.
+
+    Shared by the talker's own init, the stage-sizing text-config lookup, and
+    the prompt-wav geometry derivation so all probe the same locations in the
+    same order. ``root_config`` is the in-memory config to prefer when it
+    already wraps a talker config; pass ``None`` from callers that only have a
+    model path.
+    """
+    wrapped = getattr(root_config, "talker_config", None)
+    if isinstance(wrapped, dict):
+        wrapped = MingFlashOmniTalkerConfig(**wrapped)
+    if isinstance(wrapped, MingFlashOmniTalkerConfig):
+        return wrapped
+
+    if os.path.isdir(talker_dir):
+        try:
+            return MingFlashOmniTalkerConfig.from_pretrained(talker_dir)
+        except Exception:
+            pass
+    try:
+        return MingFlashOmniTalkerConfig.from_pretrained(model_path, subfolder="talker", trust_remote_code=True)
+    except Exception as e:
+        logger.info("Could not resolve talker config from %s or %s/talker: %s", talker_dir, model_path, e)
+        return None
+
+
+def resolve_ming_talker_text_config(root_config: Any, model_path: Any) -> Qwen2Config | PretrainedConfig | None:
+    """Resolve the talker's Qwen2 text config for stage sizing.
+
+    Prefers an in-memory ``talker_config`` on ``root_config``, then
+    ``talker/config.json``, and finally ``talker/llm/config.json`` (local dir
+    or HF hub) for standalone TTS checkpoints that ship only the LLM config.
+    Returns ``None`` when nothing resolves.
+    """
+    if not isinstance(model_path, str) or not model_path:
+        model_path = ""
+
+    talker_dir = ""
+    if model_path and os.path.isdir(model_path):
+        talker_dir = os.path.join(model_path, "talker")
+        if not os.path.isdir(talker_dir):
+            talker_dir = model_path
+
+    talker_config = resolve_ming_talker_config(root_config, talker_dir, model_path)
+    if talker_config is not None:
+        text_config = talker_config.get_text_config()
+        if text_config is not None:
+            return text_config
+
+    if not model_path:
+        return None
+    if os.path.isdir(model_path):
+        llm_dir = os.path.join(talker_dir or model_path, "llm")
+        if os.path.isdir(llm_dir):
+            try:
+                return Qwen2Config.from_pretrained(llm_dir)
+            except Exception:
+                return None
+        return None
+    try:
+        return Qwen2Config.from_pretrained(model_path, subfolder="talker/llm")
+    except Exception:
+        return None
+
+
 AutoTokenizer.register(MingFlashOmniConfig, fast_tokenizer_class=PreTrainedTokenizerFast)


### PR DESCRIPTION
## Purpose

Split out of #4284 (port the Ming-flash-omni talker to a vLLM-native paged AR stage).
These are the two engine/config-level prerequisites that PR depends on; landing them
first keeps #4284 confined to `ming_flash_omni/` model code.

### 1. The Ming talker stage resolves the thinker's text config

The talker stage is registered with `hf_config_name="talker_config"`, but the real
checkpoint (`inclusionAI/Ming-flash-omni-2.0`) has no `talker_config` in its root
`config.json`, and `talker/config.json` carries no `llm_config` either: the Qwen2
geometry only lives in `talker/llm/config.json`. `OmniModelConfig.draw_hf_text_config()`
therefore hits the `AttributeError` fallback and returns the root (thinker) text config:

|                          | resolved on main | actual talker |
| ------------------------ | ---------------- | ------------- |
| `hidden_size`            | 4096             | 896           |
| attention heads / KV heads | 32 / 4         | 14 / 2        |
| `vocab_size`             | thinker's        | 151936        |

Nothing on main observes this today: the legacy talker builds its own HF `Qwen2Model`
+ `StaticCache` from `talker/config.json` and registers no vLLM attention layers, so
neither KV-cache sizing nor `profile_run` reads `hf_text_config`. The native-paged
talker in #4284 is the first consumer, and there it fails at engine init with
`inputs_embeds hidden size mismatch: got 4096, expected 896` and would size the paged
KV cache off the thinker's heads.

`OmniModelConfig` now resolves the talker text config as
`talker_config.llm_config` → `talker/config.json` → `talker/llm/config.json`
(local dir or HF hub) and returns a `Qwen2Config`, so `model_arch_config` (head counts,
head size) and `max_model_len` are derived from the talker. The resolution helpers live
in `vllm_omni/transformers_utils/configs/ming_flash_omni.py` next to
`MingFlashOmniTalkerConfig`, so the talker model and the voice-preset loader in #4284
probe the same locations in the same order.

### 2. Custom stage input processors can opt into `stage_client`

`process_engine_inputs` already passes `streaming_context` and `next_stage_hf_config`
by keyword; a processor that declares a `stage_client` parameter now receives the stage
client the same way, so it can reach the stage tokenizer and model config without
positional-arity tricks. No processor on main declares it yet; #4284's
`thinker2talker_token_only` does.

## Test Plan

CPU only, no weights needed.

```bash
pytest tests/engine/test_arg_utils.py -k "ming_talker_text_config" -v
```

- `test_ming_talker_text_config_uses_nested_qwen2_llm_config`: in-memory
  `talker_config.llm_config` → `Qwen2Config`, stage `model_arch_config` recomputed to
  the talker's heads/head size, `max_model_len` from the talker.
- `test_ming_talker_text_config_loads_local_talker_llm_config`: checkpoint layout with
  only `talker/llm/config.json` (the real Ming layout) → `hidden_size` 896,
  heads 14/2, head size 64.

Both fail on main (the first on the `Qwen2Config` type, the second on `hidden_size`
4096 vs 896) and pass on this branch.

The `stage_client` keyword path is exercised end-to-end by #4284; this PR does not
change behaviour for any existing processor.

- vLLM Version: 0.28.0
- vLLM-Omni Commit: based on `10701e183`

## Test Result

WIP
