### PR TITLE
[Core] Avoid device synchronization in FlowUniPC scalar updates

### DIFF
--- a/tests/diffusion/sched/test_flow_unipc_host_scalars.py
+++ b/tests/diffusion/sched/test_flow_unipc_host_scalars.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Tests for FlowUniPC's host-side scalar math and small-system solve.
+
+``FlowUniPCMultistepScheduler`` used to move 0-d sigma tensors to the accelerator
+before doing any algebra with them, then rebuild device tensors from the resulting
+device scalars via ``torch.tensor([...])`` -- which has to read their values on the
+host, forcing a blocking device-to-host synchronize on every scheduler step. The
+chain now stays on the host and the finished coefficient vector is transferred once.
+
+Separately, ``_small_solve`` replaces the general LAPACK solve with Cramer's rule for
+the 1x1 and 2x2 systems UniPC actually builds at ``solver_order <= 2``, falling
+through to :func:`safe_linalg_solve` for anything larger.
+
+Neither part is meant to change results. The trajectory test gets a genuine
+before/after inside one process by pointing ``_small_solve`` at the general solve --
+which is exactly the pre-change solve behaviour -- and comparing full denoise
+trajectories.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.models.schedulers import scheduling_flow_unipc_multistep as mod
+from vllm_omni.diffusion.models.schedulers.scheduling_flow_unipc_multistep import (
+    FlowUniPCMultistepScheduler,
+    _small_solve,
+)
+from vllm_omni.diffusion.utils.flow_matching import safe_linalg_solve
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+# Measured envelope for the trajectory comparison: max abs error 1.67e-06 at 16 steps
+# on values spanning +-3.15, i.e. about 4.4 float32 ULP. Deliberately not
+# assert_close at its default rtol -- reordered float32 arithmetic does not reproduce
+# bitwise, and pretending otherwise would make this test lie.
+TRAJECTORY_ATOL = 5e-06
+LATENT_SHAPE = (1, 16, 2, 12, 16)  # DreamZero-ish geometry, shrunk for test runtime
+
+
+# ── _small_solve ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("n", [1, 2, 3, 4])
+def test_small_solve_matches_the_general_solve(n: int) -> None:
+    """Cramer's rule for n <= 2, delegation above it, same answer either way."""
+    torch.manual_seed(n)
+    # Diagonally dominant, so well conditioned at every size.
+    matrix = torch.randn(n, n, dtype=torch.float64) + n * torch.eye(n, dtype=torch.float64)
+    rhs = torch.randn(n, dtype=torch.float64)
+
+    got = _small_solve(matrix, rhs)
+    expected = safe_linalg_solve(matrix, rhs)
+
+    assert got.shape == expected.shape == (n,)
+    torch.testing.assert_close(got, expected, rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.parametrize("n", [1, 2])
+def test_small_solve_raises_on_a_singular_system(n: int) -> None:
+    """Cramer's rule would return inf/nan; the general solve raises, so this must too."""
+    matrix = torch.zeros(n, n, dtype=torch.float32)
+    if n == 2:
+        # Genuinely singular rather than trivially zero: row 1 duplicates row 0,
+        # which is the shape UniPC's Vandermonde R takes when two rk values coincide.
+        matrix[0] = torch.tensor([1.0, 2.0])
+        matrix[1] = torch.tensor([2.0, 4.0])
+    rhs = torch.ones(n, dtype=torch.float32)
+
+    with pytest.raises(torch.linalg.LinAlgError):
+        _small_solve(matrix, rhs)
+
+
+def test_small_solve_delegates_above_two() -> None:
+    """The n > 2 path must reach safe_linalg_solve, not a hand-rolled expansion.
+
+    safe_linalg_solve carries a numpy fallback for ROCm wheels whose CPU LAPACK probe
+    reports support they do not have. It only triggers for CPU matrices, and this
+    change makes the coefficient matrices host tensors -- so losing that delegation
+    would break exactly the platform it was added for.
+    """
+    calls: list[tuple[int, ...]] = []
+    real = mod.safe_linalg_solve
+
+    def spy(matrix, rhs):
+        calls.append(tuple(matrix.shape))
+        return real(matrix, rhs)
+
+    matrix = torch.eye(3, dtype=torch.float64) * 2.0
+    rhs = torch.tensor([2.0, 4.0, 6.0], dtype=torch.float64)
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(mod, "safe_linalg_solve", spy)
+        got = _small_solve(matrix, rhs)
+        # And confirm the small path does NOT delegate.
+        _small_solve(torch.eye(2, dtype=torch.float64), torch.ones(2, dtype=torch.float64))
+
+    assert calls == [(3, 3)]
+    torch.testing.assert_close(got, torch.tensor([1.0, 2.0, 3.0], dtype=torch.float64))
+
+
+# ── full denoise trajectory ─────────────────────────────────────────────────────
+
+
+def _fake_model(sample: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+    """Deterministic stand-in for the DiT: smooth, bounded, and t-dependent."""
+    return torch.tanh(sample * 1.3 + t / 1000.0) * 0.9 + sample * 0.05
+
+
+def _run_denoise(num_steps: int, *, solver_order: int = 2) -> torch.Tensor:
+    scheduler = FlowUniPCMultistepScheduler(solver_order=solver_order)
+    scheduler.set_timesteps(num_inference_steps=num_steps, device="cpu")
+
+    generator = torch.Generator().manual_seed(1234)
+    sample = torch.randn(*LATENT_SHAPE, dtype=torch.float32, generator=generator)
+    for timestep in scheduler.timesteps:
+        sample = scheduler.step(_fake_model(sample, timestep), timestep, sample, return_dict=False)[0]
+    return sample
+
+
+@pytest.mark.parametrize("num_steps", [4, 8, 16])
+def test_denoise_trajectory_matches_the_general_solve(num_steps: int) -> None:
+    """The closed-form solve must not move the trajectory beyond float32 noise.
+
+    ``_small_solve`` is pointed at the general solve for the reference run, which is
+    precisely the pre-change behaviour of both call sites, so this is a real A/B of
+    the solve change rather than a comparison against stored data.
+    """
+    fast = _run_denoise(num_steps)
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(mod, "_small_solve", safe_linalg_solve)
+        reference = _run_denoise(num_steps)
+
+    assert fast.shape == reference.shape == LATENT_SHAPE
+    assert torch.isfinite(fast).all(), "closed-form solve produced non-finite latents"
+    torch.testing.assert_close(fast, reference, rtol=0.0, atol=TRAJECTORY_ATOL)
+
+
+@pytest.mark.parametrize("num_steps", [4, 16])
+def test_denoise_trajectory_is_finite_at_solver_order_three(num_steps: int) -> None:
+    """order=3 builds 3x3 systems, so it exercises the delegation path end to end."""
+    out = _run_denoise(num_steps, solver_order=3)
+    assert out.shape == LATENT_SHAPE
+    assert torch.isfinite(out).all()
+
+
+def test_sigmas_stay_on_the_host() -> None:
+    """The premise of the change: the sigma table is CPU-resident and stays that way.
+
+    ``set_timesteps`` puts ``sigmas`` on the host deliberately. The scalar chain now
+    derives from it without an early ``.to(device)``, so a future change that moves
+    the table would silently reintroduce the per-step synchronize this removed.
+    """
+    scheduler = FlowUniPCMultistepScheduler(solver_order=2)
+    scheduler.set_timesteps(num_inference_steps=8, device="cpu")
+    assert scheduler.sigmas.device.type == "cpu"

--- a/vllm_omni/diffusion/models/schedulers/scheduling_flow_unipc_multistep.py
+++ b/vllm_omni/diffusion/models/schedulers/scheduling_flow_unipc_multistep.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 # Adapted from https://github.com/hao-ai-lab/FastVideo
 # Originally from https://github.com/huggingface/diffusers/blob/v0.31.0/src/diffusers/schedulers/scheduling_unipc_multistep.py
 # Convert unipc for flow matching
@@ -24,6 +24,50 @@ from diffusers.utils import deprecate
 
 from vllm_omni.diffusion.models.schedulers.base import BaseScheduler
 from vllm_omni.diffusion.utils.flow_matching import safe_linalg_solve
+
+
+def _small_solve(matrix: torch.Tensor, rhs: torch.Tensor) -> torch.Tensor:
+    """Solve ``matrix @ x = rhs`` for the tiny systems UniPC actually builds.
+
+    At the deployed ``solver_order=2`` the UniC corrector solves a **2x2** system on
+    every denoise step, and the predictor a 1x1 or 2x2. Dispatching the general
+    LAPACK/oneMKL path for that is pure overhead: it allocates workspaces and runs LU
+    with partial pivoting for a system that has a two-line closed form.
+
+    Closed form via Cramer's rule for n <= 2; anything larger falls through to
+    :func:`safe_linalg_solve` unchanged, so higher solver orders keep their exact
+    current behaviour -- including its numpy fallback for ROCm wheels whose CPU LAPACK
+    probe reports support they do not have. That fallback matters *more* after this
+    change, not less: it only triggers for CPU matrices, and ``matrix``/``rhs`` are
+    host tensors now.
+
+    ``torch.linalg.solve`` semantics are matched deliberately:
+
+    * **Singular input raises.** The general solve raises ``LinAlgError`` rather than
+      returning inf/nan, and Cramer's rule would silently divide by zero, so an
+      exactly-zero determinant is turned back into a real error. UniPC's ``R`` is a
+      Vandermonde matrix in ``rks``, singular only when two ``rk`` values coincide --
+      itself a degenerate step, so raising is right.
+    * **Dtype and device follow the inputs**, as they would from the general solve.
+    """
+    n = matrix.shape[-1]
+    if n == 1:
+        det = matrix[0, 0]
+        if det == 0:
+            raise torch.linalg.LinAlgError("singular 1x1 system in UniPC coefficient solve")
+        return (rhs[0] / det).reshape(1)
+    if n == 2:
+        m00, m01 = matrix[0, 0], matrix[0, 1]
+        m10, m11 = matrix[1, 0], matrix[1, 1]
+        det = m00 * m11 - m01 * m10
+        if det == 0:
+            raise torch.linalg.LinAlgError("singular 2x2 system in UniPC coefficient solve")
+        r0, r1 = rhs[0], rhs[1]
+        # Cramer's rule: x0 = |r0 m01; r1 m11| / det, x1 = |m00 r0; m10 r1| / det.
+        x0 = (r0 * m11 - m01 * r1) / det
+        x1 = (m00 * r1 - r0 * m10) / det
+        return torch.stack([x0, x1])
+    return safe_linalg_solve(matrix, rhs)
 
 
 class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
@@ -291,12 +335,17 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
                 "is now handled via an internal counter `self.step_index`",
             )
 
-        sigma = self.sigmas[self.step_index].to(sample.device)
+        # D3: keep sigma on the host. It is a 0-d CPU scalar that only ever
+        # multiplies/subtracts against `model_output`/`sample` (device tensors),
+        # and PyTorch broadcasts a CPU 0-d tensor against a device tensor without
+        # requiring an explicit transfer. The two `.to(sample.device)` calls here
+        # were 2 tiny H2D copies per denoise step for no benefit.
+        sigma = self.sigmas[self.step_index]
         alpha_t, sigma_t = self._sigma_to_alpha_sigma_t(sigma)
 
         if self.predict_x0:
             if self.config.prediction_type == "flow_prediction":
-                sigma_t = sigma.to(sample.device)
+                sigma_t = sigma
                 x0_pred = sample - sigma_t * model_output
             else:
                 raise ValueError(
@@ -374,12 +423,37 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
             return x_t
 
         device = sample.device
-        sigma_t, sigma_s0 = (
-            self.sigmas[self.step_index + 1].to(device),
-            self.sigmas[self.step_index].to(device),
+        # ---- D3: keep the sigma/lambda/h scalar chain on the HOST ----------
+        # self.sigmas is deliberately CPU-resident (set_timesteps does
+        # `self.sigmas = self.sigmas.to("cpu")`). The old code moved each element
+        # to the device FIRST, so every scalar derived from it -- alpha, sigma,
+        # lambda, h, rk, the b coefficients -- became a device 0-d tensor. The
+        # subsequent `torch.tensor(rks, device=device)` and `torch.tensor(b, ...)`
+        # then had to read those device scalars back, forcing a blocking D2H
+        # synchronize per scheduler step (~12.4 ms/step, ~206 ms/request).
+        #
+        # These are 1-3 element scalars: computing them on CPU costs microseconds
+        # and needs no transfer at all. Device tensors are only produced where the
+        # value actually multiplies a device tensor -- and PyTorch broadcasts a
+        # CPU 0-d tensor against a device tensor natively, so even those need no
+        # explicit .to(device). (Verified on torch 2.12.0+xpu: mul/sub/rsub/div and
+        # the expm1 chain all accept a CPU 0-d scalar against an XPU tensor, and are
+        # ~20% FASTER than the device-scalar form. torch.einsum is the exception --
+        # it requires same-device operands -- which is why rhos is still moved
+        # explicitly below.)
+        #
+        # dtype is unchanged: self.sigmas is float32, so every derived scalar stays
+        # float32 exactly as before. Results are bitwise identical for mul/sub, and
+        # differ by <=1 ULP of float32 (~1e-6 relative) for division, because a
+        # CPU-scalar divide and a device-scalar divide round the reciprocal
+        # differently. That is round-off, not a semantic change -- see the D3 note
+        # on numerical validation.
+        sigma_t_c, sigma_s0_c = (
+            self.sigmas[self.step_index + 1],
+            self.sigmas[self.step_index],
         )
-        alpha_t, sigma_t = self._sigma_to_alpha_sigma_t(sigma_t)
-        alpha_s0, sigma_s0 = self._sigma_to_alpha_sigma_t(sigma_s0)
+        alpha_t, sigma_t = self._sigma_to_alpha_sigma_t(sigma_t_c)
+        alpha_s0, sigma_s0 = self._sigma_to_alpha_sigma_t(sigma_s0_c)
 
         lambda_t = torch.log(alpha_t) - torch.log(sigma_t)
         lambda_s0 = torch.log(alpha_s0) - torch.log(sigma_s0)
@@ -391,15 +465,20 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
         for i in range(1, order):
             si = self.step_index - i
             mi = model_output_list[-(i + 1)]
-            alpha_si, sigma_si = self._sigma_to_alpha_sigma_t(self.sigmas[si].to(device))
+            # sigmas[si] stays on CPU: lambda_si/rk are host scalars.
+            alpha_si, sigma_si = self._sigma_to_alpha_sigma_t(self.sigmas[si])
             lambda_si = torch.log(alpha_si) - torch.log(sigma_si)
             rk = (lambda_si - lambda_s0) / h
             rks.append(rk)
             assert mi is not None
+            # mi/m0 ARE device tensors; dividing by a CPU 0-d scalar broadcasts
+            # without a transfer and keeps the result on the device.
             D1s.append((mi - m0) / rk)
 
-        rks.append(1.0)
-        rks = torch.tensor(rks, device=device)
+        rks.append(torch.ones((), dtype=h.dtype))
+        # Built from CPU scalars -> a CPU stack, no D2H sync. Previously this
+        # line was `torch.tensor(rks, device=device)` over device 0-d tensors.
+        rks = torch.stack(rks)
 
         R = []
         b = []
@@ -424,7 +503,7 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
             h_phi_k = h_phi_k / hh - 1 / factorial_i
 
         R = torch.stack(R)
-        b = torch.tensor(b, device=device)
+        b = torch.stack(b)  # CPU stack of CPU scalars; was torch.tensor(device=...)
 
         if D1s is not None and len(D1s) > 0:
             D1s = torch.stack(D1s, dim=1)
@@ -432,7 +511,9 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
                 rhos_p = torch.tensor([0.5], dtype=x.dtype, device=device)
             else:
                 assert isinstance(R, torch.Tensor)
-                rhos_p = safe_linalg_solve(R[:-1, :-1], b[:-1]).to(device).to(x.dtype)
+                # Solve on CPU (R/b are now host tensors), then move the 1-3
+                # element result to the device in ONE transfer.
+                rhos_p = _small_solve(R[:-1, :-1], b[:-1]).to(device=device, dtype=x.dtype)
         else:
             D1s = None
 
@@ -506,12 +587,13 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
         model_t = this_model_output
 
         device = this_sample.device
-        sigma_t, sigma_s0 = (
-            self.sigmas[self.step_index].to(device),
-            self.sigmas[self.step_index - 1].to(device),
+        # ---- D3: host-side scalar chain, same rationale as the predictor -----
+        sigma_t_c, sigma_s0_c = (
+            self.sigmas[self.step_index],
+            self.sigmas[self.step_index - 1],
         )
-        alpha_t, sigma_t = self._sigma_to_alpha_sigma_t(sigma_t)
-        alpha_s0, sigma_s0 = self._sigma_to_alpha_sigma_t(sigma_s0)
+        alpha_t, sigma_t = self._sigma_to_alpha_sigma_t(sigma_t_c)
+        alpha_s0, sigma_s0 = self._sigma_to_alpha_sigma_t(sigma_s0_c)
 
         lambda_t = torch.log(alpha_t) - torch.log(sigma_t)
         lambda_s0 = torch.log(alpha_s0) - torch.log(sigma_s0)
@@ -523,15 +605,15 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
         for i in range(1, order):
             si = self.step_index - (i + 1)
             mi = model_output_list[-(i + 1)]
-            alpha_si, sigma_si = self._sigma_to_alpha_sigma_t(self.sigmas[si].to(device))
+            alpha_si, sigma_si = self._sigma_to_alpha_sigma_t(self.sigmas[si])
             lambda_si = torch.log(alpha_si) - torch.log(sigma_si)
             rk = (lambda_si - lambda_s0) / h
             rks.append(rk)
             assert mi is not None
             D1s.append((mi - m0) / rk)
 
-        rks.append(1.0)
-        rks = torch.tensor(rks, device=device)
+        rks.append(torch.ones((), dtype=h.dtype))
+        rks = torch.stack(rks)
 
         R = []
         b = []
@@ -556,7 +638,7 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
             h_phi_k = h_phi_k / hh - 1 / factorial_i
 
         R = torch.stack(R)
-        b = torch.tensor(b, device=device)
+        b = torch.stack(b)
 
         if D1s is not None and len(D1s) > 0:
             D1s = torch.stack(D1s, dim=1)
@@ -566,7 +648,11 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
         if order == 1:
             rhos_c = torch.tensor([0.5], dtype=x.dtype, device=device)
         else:
-            rhos_c = safe_linalg_solve(R, b).to(device).to(x.dtype)
+            # This is THE hot solve: at the deployed solver_order=2 the corrector
+            # runs order=2 on every step, so a general LAPACK solve was being
+            # dispatched 16x/request for a 2x2 system. _small_solve uses the
+            # closed form for 2x2 and falls back to safe_linalg_solve otherwise.
+            rhos_c = _small_solve(R, b).to(device=device, dtype=x.dtype)
 
         if self.predict_x0:
             x_t_ = sigma_t / sigma_s0 * x - alpha_t * h_phi_1 * m0

--- a/vllm_omni/diffusion/models/schedulers/scheduling_flow_unipc_multistep.py
+++ b/vllm_omni/diffusion/models/schedulers/scheduling_flow_unipc_multistep.py
@@ -27,28 +27,12 @@ from vllm_omni.diffusion.utils.flow_matching import safe_linalg_solve
 
 
 def _small_solve(matrix: torch.Tensor, rhs: torch.Tensor) -> torch.Tensor:
-    """Solve ``matrix @ x = rhs`` for the tiny systems UniPC actually builds.
+    """Solve 1x1/2x2 systems in closed form; delegate larger systems.
 
-    At the deployed ``solver_order=2`` the UniC corrector solves a **2x2** system on
-    every denoise step, and the predictor a 1x1 or 2x2. Dispatching the general
-    LAPACK/oneMKL path for that is pure overhead: it allocates workspaces and runs LU
-    with partial pivoting for a system that has a two-line closed form.
-
-    Closed form via Cramer's rule for n <= 2; anything larger falls through to
-    :func:`safe_linalg_solve` unchanged, so higher solver orders keep their exact
-    current behaviour -- including its numpy fallback for ROCm wheels whose CPU LAPACK
-    probe reports support they do not have. That fallback matters *more* after this
-    change, not less: it only triggers for CPU matrices, and ``matrix``/``rhs`` are
-    host tensors now.
-
-    ``torch.linalg.solve`` semantics are matched deliberately:
-
-    * **Singular input raises.** The general solve raises ``LinAlgError`` rather than
-      returning inf/nan, and Cramer's rule would silently divide by zero, so an
-      exactly-zero determinant is turned back into a real error. UniPC's ``R`` is a
-      Vandermonde matrix in ``rks``, singular only when two ``rk`` values coincide --
-      itself a degenerate step, so raising is right.
-    * **Dtype and device follow the inputs**, as they would from the general solve.
+    Uses Cramer's rule for small systems and ``safe_linalg_solve`` otherwise.
+    Exactly singular systems raise ``LinAlgError`` instead of returning inf/nan.
+    Dtype and device follow the inputs; the delegated path retains its
+    platform-specific fallback.
     """
     n = matrix.shape[-1]
     if n == 1:
@@ -335,11 +319,8 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
                 "is now handled via an internal counter `self.step_index`",
             )
 
-        # D3: keep sigma on the host. It is a 0-d CPU scalar that only ever
-        # multiplies/subtracts against `model_output`/`sample` (device tensors),
-        # and PyTorch broadcasts a CPU 0-d tensor against a device tensor without
-        # requiring an explicit transfer. The two `.to(sample.device)` calls here
-        # were 2 tiny H2D copies per denoise step for no benefit.
+        # Keep sigma on CPU: PyTorch broadcasts a CPU 0-d scalar against device
+        # tensors without an explicit transfer.
         sigma = self.sigmas[self.step_index]
         alpha_t, sigma_t = self._sigma_to_alpha_sigma_t(sigma)
 
@@ -423,31 +404,11 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
             return x_t
 
         device = sample.device
-        # ---- D3: keep the sigma/lambda/h scalar chain on the HOST ----------
-        # self.sigmas is deliberately CPU-resident (set_timesteps does
-        # `self.sigmas = self.sigmas.to("cpu")`). The old code moved each element
-        # to the device FIRST, so every scalar derived from it -- alpha, sigma,
-        # lambda, h, rk, the b coefficients -- became a device 0-d tensor. The
-        # subsequent `torch.tensor(rks, device=device)` and `torch.tensor(b, ...)`
-        # then had to read those device scalars back, forcing a blocking D2H
-        # synchronize per scheduler step (~12.4 ms/step, ~206 ms/request).
-        #
-        # These are 1-3 element scalars: computing them on CPU costs microseconds
-        # and needs no transfer at all. Device tensors are only produced where the
-        # value actually multiplies a device tensor -- and PyTorch broadcasts a
-        # CPU 0-d tensor against a device tensor natively, so even those need no
-        # explicit .to(device). (Verified on torch 2.12.0+xpu: mul/sub/rsub/div and
-        # the expm1 chain all accept a CPU 0-d scalar against an XPU tensor, and are
-        # ~20% FASTER than the device-scalar form. torch.einsum is the exception --
-        # it requires same-device operands -- which is why rhos is still moved
-        # explicitly below.)
-        #
-        # dtype is unchanged: self.sigmas is float32, so every derived scalar stays
-        # float32 exactly as before. Results are bitwise identical for mul/sub, and
-        # differ by <=1 ULP of float32 (~1e-6 relative) for division, because a
-        # CPU-scalar divide and a device-scalar divide round the reciprocal
-        # differently. That is round-off, not a semantic change -- see the D3 note
-        # on numerical validation.
+        # Keep the sigma -> alpha/lambda -> h/rk/b scalar chain on CPU to avoid
+        # device-to-host synchronization when building the coefficient tensors.
+        # The derived scalars retain self.sigmas' float32 dtype. CPU 0-d scalars
+        # broadcast against device tensors; einsum coefficients need an explicit
+        # transfer because its operands must share a device.
         sigma_t_c, sigma_s0_c = (
             self.sigmas[self.step_index + 1],
             self.sigmas[self.step_index],
@@ -465,19 +426,16 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
         for i in range(1, order):
             si = self.step_index - i
             mi = model_output_list[-(i + 1)]
-            # sigmas[si] stays on CPU: lambda_si/rk are host scalars.
             alpha_si, sigma_si = self._sigma_to_alpha_sigma_t(self.sigmas[si])
             lambda_si = torch.log(alpha_si) - torch.log(sigma_si)
             rk = (lambda_si - lambda_s0) / h
             rks.append(rk)
             assert mi is not None
-            # mi/m0 ARE device tensors; dividing by a CPU 0-d scalar broadcasts
-            # without a transfer and keeps the result on the device.
+            # Dividing device tensors by a CPU 0-d scalar preserves their device.
             D1s.append((mi - m0) / rk)
 
         rks.append(torch.ones((), dtype=h.dtype))
-        # Built from CPU scalars -> a CPU stack, no D2H sync. Previously this
-        # line was `torch.tensor(rks, device=device)` over device 0-d tensors.
+        # Stack host scalars without a device-to-host readback.
         rks = torch.stack(rks)
 
         R = []
@@ -511,8 +469,7 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
                 rhos_p = torch.tensor([0.5], dtype=x.dtype, device=device)
             else:
                 assert isinstance(R, torch.Tensor)
-                # Solve on CPU (R/b are now host tensors), then move the 1-3
-                # element result to the device in ONE transfer.
+                # Move the host solve result to the device for einsum.
                 rhos_p = _small_solve(R[:-1, :-1], b[:-1]).to(device=device, dtype=x.dtype)
         else:
             D1s = None
@@ -587,7 +544,7 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
         model_t = this_model_output
 
         device = this_sample.device
-        # ---- D3: host-side scalar chain, same rationale as the predictor -----
+        # Keep this scalar chain on CPU, as in the predictor.
         sigma_t_c, sigma_s0_c = (
             self.sigmas[self.step_index],
             self.sigmas[self.step_index - 1],
@@ -648,10 +605,7 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
         if order == 1:
             rhos_c = torch.tensor([0.5], dtype=x.dtype, device=device)
         else:
-            # This is THE hot solve: at the deployed solver_order=2 the corrector
-            # runs order=2 on every step, so a general LAPACK solve was being
-            # dispatched 16x/request for a 2x2 system. _small_solve uses the
-            # closed form for 2x2 and falls back to safe_linalg_solve otherwise.
+            # Solve coefficients on CPU; einsum below consumes them on the device.
             rhos_c = _small_solve(R, b).to(device=device, dtype=x.dtype)
 
         if self.predict_x0:


### PR DESCRIPTION
## Purpose
*This distributes some scalar calculations back to CPU, so there may be issue for circumstance with heavy cpu usage. 
FlowUniPCMultistepScheduler was moving 0-d sigma-derived scalars to the accelerator, causing a blocking D2H sync every scheduler step when they were later rebuilt on the host. This change keeps the sigma → alpha → lambda → h → rk → b chain on CPU, uses torch.stack for host scalars, and adds _small_solve() with Cramer's rule for 1×1/2×2 systems while delegating larger cases to safe_linalg_solve; only the small rhos tensor is transferred once for einsum. Semantics are unchanged: singular inputs still raise LinAlgError, solver_order > 2 follows the existing path, and dtype remains float32.

## Test Plan

New `tests/diffusion/sched/test_flow_unipc_host_scalars.py` — 12 cases, CPU only. Covers `_small_solve` vs `safe_linalg_solve` at n=1–4, singular input raising at 1×1 and 2×2, the n > 2 delegation boundary, full denoise trajectories at 4/8/16 steps and at `solver_order=3`, and that `sigmas` stays CPU-resident.

```bash
pytest -q tests/diffusion/sched/test_flow_unipc_host_scalars.py
```

**vLLM Version:** v0.28.0 (`docker/Dockerfile.xpu`); nothing here depends on a vLLM change.
**vLLM-Omni Commit:** branched from `10701e18389fe282ca8c2510cd2022a76a9dad2a` (`main`, 2026-09-04).

## Test Result

| series | n | mean/req |
|---|---:|---:|
| baseline (before) | 20 | 6,518.6 ms |
| **this PR** | 20 | **6,329.2 ms** |

**−156.6 ms/req (−2.41 %), 95 % CI −238.0 to −75.3 ms**, position-matched on `(scene, request)`.
Faster than each bracket separately (both CIs exclude zero), and ~2.4× the 65.5 ms bracket-to-bracket
drift, so a time trend cannot explain it. Negative at 16 of 20 positions.

**This requires the `vllm-xpu-kernels`'s next release**