### PR TITLE
[Core] Optimize Qwen2.5-Omni Token2Wav buffer loading

### DIFF
--- a/tests/model_executor/models/qwen2_5_omni/test_weight_loading.py
+++ b/tests/model_executor/models/qwen2_5_omni/test_weight_loading.py
@@ -1,6 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 import pytest
+import torch
+from torch import nn
+
+from vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni_token2wav import (
+    Qwen2_5OmniToken2WavForConditionalGenerationVLLM,
+)
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class _BufferModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.state_dict_calls = 0
+        self.register_buffer("persistent", torch.ones(1))
+        self.register_buffer("temporary", torch.ones(1), persistent=False)
+        self.child = nn.Module()
+        self.child.register_buffer("persistent", torch.ones(1))
+
+    def state_dict(self, *args, **kwargs):
+        self.state_dict_calls += 1
+        return super().state_dict(*args, **kwargs)
+
+
+def test_token2wav_buffer_discovery_avoids_state_dict():
+    model = _BufferModel()
+
+    buffers = Qwen2_5OmniToken2WavForConditionalGenerationVLLM.find_all_registers(model)
+
+    assert set(buffers) == {"persistent", "child.persistent"}
+    assert model.state_dict_calls == 0
 
 
 class TestQwen2_5OmniWeightLoading:

--- a/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_token2wav.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_token2wav.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 ############################
 #      Start Token2Wav     #
 ############################
@@ -1509,19 +1512,19 @@ class Qwen2_5OmniToken2WavForConditionalGenerationVLLM(nn.Module, SupportsPP):
         return loaded
 
     def find_all_registers(self):
-        """
-        Find all registered buffers in a PyTorch model.
-
-        Args:
-        Returns:
-            dict: Dictionary with buffer names as keys and their properties as values
-        """
+        """Find all persistent registered buffers in the model."""
         registers = {}
 
-        # Get all named buffers
-        for name, buf in self.named_buffers():
-            if name in self.state_dict():
-                registers[name] = {"name": name, "buffer": buf}
+        # Match state_dict() by excluding non-persistent buffers.
+        non_persistent_names = set()
+        for module_name, module in self.named_modules():
+            for buffer_name in getattr(module, "_non_persistent_buffers_set", set()):
+                name = f"{module_name}.{buffer_name}" if module_name else buffer_name
+                non_persistent_names.add(name)
+
+        for name, buffer in self.named_buffers():
+            if name not in non_persistent_names:
+                registers[name] = {"name": name, "buffer": buffer}
         return registers
 
     # remove buffers from the weights and reload them after loading weights


### PR DESCRIPTION

Resolves #7060.

#### Summary
`find_all_registers()` called `state_dict()` once for every named buffer. Qwen2.5-Omni made 219 calls during each startup, even though every call traversed the same module tree.

The loader now collects nonpersistent buffer names from `_non_persistent_buffers_set` and walks the named buffers once. The test checks that persistent child buffers remain included, nonpersistent buffers remain excluded, and `state_dict()` is not called.

The code follows the existing vLLM buffer loading pattern. vLLM-Omni also uses the same check in its diffusion weight loaders.

#### Benchmark

| Item | Value |
| --- | --- |
| Model | `Qwen/Qwen2.5-Omni-3B` |
| GPU | 1 AMD Instinct MI300X VF |
| GPU memory | 192 GB |
| PyTorch | `2.12.0+git6bbd260` |
| ROCm | `7.2.53211` |
| vLLM | `0.28.0+rocm723` |
| vLLM-Omni | `0.28.1.dev47` |

The server was started with:

```bash
MIOPEN_FIND_MODE=FAST vllm serve Qwen/Qwen2.5-Omni-3B --omni --host 127.0.0.1 --port 8091 --deploy-config /tmp/qwen2_5_omni_rocm_single_gpu.yaml
```

All three stages used device 0 with GPU memory utilization values of 0.35, 0.25, and 0.15. The benchmark used one warmup per version and five measured runs per version. The measured runs alternated between the baseline and optimized commits, and the model files were already cached.

| Measurement | Baseline median | Optimized median | Change |
| --- | ---: | ---: | ---: |
| Calls to `state_dict()` | 219 | 0 | Removed 219 calls |
| Buffer discovery | 456.946 ms | 1.564 ms | 455.382 ms faster, 99.66% |
| Token2Wav weight loading | 1099.526 ms | 620.436 ms | 479.090 ms faster, 43.57% |
| Startup to `/health` | 105.738 s | 104.322 s | 1.416 s faster, 1.34% |

The startup ranges overlapped, so the PR claims the direct reduction in Token2Wav loading work rather than a stable full startup improvement.

The logged GPU memory figures for stages 0 and 1 were unchanged. Stage 0 used 9.94 GiB for weights and non-PyTorch memory with 2.49 GiB of peak activation memory. Stage 1 used 1.95 GiB with 1.18 GiB of peak activation memory. No GPU memory improvement is claimed.

#### Test

```text
2 passed, 14 warnings in 0.13s
```

Command:

```bash
.venv/bin/pytest tests/model_executor/models/qwen2_5_omni/test_weight_loading.py --run-level advanced_model -q
```

`pre-commit run --files` passed for both changed files.


