### PR TITLE
[Perf][Sched] Multi-step merged decode for host-bound AR stages

### DIFF
--- a/tests/core/sched/test_multi_step_decode.py
+++ b/tests/core/sched/test_multi_step_decode.py
@@ -1,0 +1,470 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the multi-step decode window (PR: multi-step merged decode).
+
+Pure-CPU tests for the scheduler-side planner in
+``vllm_omni.core.sched.multi_step_decode``: window-size resolution
+(config + env override), the static capability gate, the schedule-output
+rewrite (request admission, budget clamp, KV slot allocation, in-flight
+fence accounting) and the shortfall reconcile that keeps
+``num_computed_tokens`` consistent with the KV slots actually written
+when a window exits early or falls back to single steps.
+"""
+
+from __future__ import annotations
+
+import pytest
+from types import SimpleNamespace
+
+from vllm.v1.request import RequestStatus
+
+import vllm_omni.core.sched.multi_step_decode as msd
+from vllm_omni.core.sched.multi_step_decode import (
+    ENV_MULTI_STEP_STEPS,
+    MAX_MULTI_STEP_STEPS,
+    model_supports_multi_step,
+    plan_multi_step_window,
+    reconcile_window_shortfall,
+    resolve_multi_step_steps,
+    scheduler_allows_multi_step,
+)
+
+# The one architecture that declares ``supports_multi_step_decode`` today.
+WINDOWED_ARCH = "MiniCPMO45OmniTTSForConditionalGeneration"
+
+
+@pytest.fixture(autouse=True)
+def _windowed_platform(monkeypatch):
+    """Pin the platform gate to a window-capable (NPU) platform.
+
+    The window executor ships with the NPU AR runner, so the static gate
+    refuses other platforms.  These tests exercise the gate's *other*
+    conditions, so pin device_type to "npu" regardless of the host machine.
+    """
+    monkeypatch.setattr(msd, "current_platform", SimpleNamespace(device_type="npu"))
+
+
+# ---------------------------------------------------------------- fakes ----
+
+
+def make_sampling_params(**overrides):
+    params = SimpleNamespace(
+        logprobs=None,
+        prompt_logprobs=None,
+        bad_words_token_ids=None,
+        allowed_token_ids=None,
+        frequency_penalty=0.0,
+        presence_penalty=0.0,
+        repetition_penalty=1.0,
+        max_tokens=2048,
+    )
+    for key, value in overrides.items():
+        setattr(params, key, value)
+    return params
+
+
+def make_request(req_id="r0", *, computed=None, prompt=100, output_len=5, max_tokens=2048):
+    # ``computed`` models the post-base-schedule state: for steady decode the
+    # async scheduler has optimistically counted prompt + output_len tokens.
+    if computed is None:
+        computed = prompt + output_len
+    request = SimpleNamespace(
+        request_id=req_id,
+        status=RequestStatus.RUNNING,
+        num_computed_tokens=computed,
+        num_prompt_tokens=prompt,
+        num_tokens=prompt + output_len,
+        num_output_placeholders=1,
+        output_token_ids=[0] * output_len,
+        has_encoder_inputs=False,
+        use_structured_output=False,
+        pooling_params=None,
+        sampling_params=make_sampling_params(max_tokens=max_tokens),
+        is_finished=lambda: False,
+    )
+    return request
+
+
+def make_kv_manager(fail_ids=()):
+    """allocate_slots fake: extends blocks unless the request id is in fail_ids."""
+
+    def allocate_slots(request, num_new_tokens, num_lookahead_tokens=0):
+        if request.request_id in fail_ids:
+            return None
+        blocks = ([f"blk-{request.request_id}-{num_new_tokens}"],)
+        request.allocated = getattr(request, "allocated", 0) + num_new_tokens
+        return SimpleNamespace(get_block_ids=lambda ids=blocks: ids)
+
+    return SimpleNamespace(allocate_slots=allocate_slots)
+
+
+def make_scheduler_output(requests, *, scheduled=1):
+    req_ids = [r.request_id for r in requests]
+    return SimpleNamespace(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=SimpleNamespace(
+            req_ids=req_ids,
+            new_block_ids=[None] * len(req_ids),
+        ),
+        num_scheduled_tokens={rid: scheduled for rid in req_ids},
+        total_num_scheduled_tokens=scheduled * len(requests),
+        scheduled_spec_decode_tokens={},
+        scheduled_encoder_inputs={},
+        has_structured_output_requests=False,
+        pending_structured_output_tokens=False,
+        multi_step_plan={},
+    )
+
+
+def make_scheduler(requests, *, max_model_len=4096, fail_ids=()):
+    return SimpleNamespace(
+        requests={r.request_id: r for r in requests},
+        kv_cache_manager=make_kv_manager(fail_ids=fail_ids),
+        max_model_len=max_model_len,
+    )
+
+
+def make_model_config(**overrides):
+    config = SimpleNamespace(
+        architectures=[WINDOWED_ARCH],
+        model_impl="vllm",
+        is_encoder_decoder=False,
+        enable_return_routed_experts=False,
+        multi_step_decode_steps=0,
+    )
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def make_vllm_config(model_config=None, **overrides):
+    parallel_config = SimpleNamespace(
+        pipeline_parallel_size=1,
+        tensor_parallel_size=1,
+        data_parallel_size=1,
+        pcp_size=1,
+        dcp_size=1,
+    )
+    config = SimpleNamespace(
+        model_config=model_config or make_model_config(),
+        parallel_config=parallel_config,
+        cache_config=SimpleNamespace(mamba_cache_mode="off"),
+    )
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def make_configured_scheduler(**scheduler_overrides):
+    scheduler = SimpleNamespace(
+        vllm_config=make_vllm_config(),
+        scheduler_config=SimpleNamespace(async_scheduling=True),
+        num_spec_tokens=0,
+        kv_transfer_criteria=None,
+        lora_config=None,
+        max_model_len=4096,
+        waiting=[],
+    )
+    for key, value in scheduler_overrides.items():
+        setattr(scheduler, key, value)
+    return scheduler
+
+
+# ------------------------------------------------- window-size resolution --
+
+
+def test_resolve_steps_reads_model_config(monkeypatch):
+    monkeypatch.delenv(ENV_MULTI_STEP_STEPS, raising=False)
+    assert resolve_multi_step_steps(make_model_config(multi_step_decode_steps=8)) == 8
+    assert resolve_multi_step_steps(make_model_config(multi_step_decode_steps=0)) == 0
+
+
+def test_resolve_steps_env_overrides_config(monkeypatch):
+    monkeypatch.setenv(ENV_MULTI_STEP_STEPS, "4")
+    assert resolve_multi_step_steps(make_model_config(multi_step_decode_steps=8)) == 4
+    monkeypatch.setenv(ENV_MULTI_STEP_STEPS, "0")
+    assert resolve_multi_step_steps(make_model_config(multi_step_decode_steps=8)) == 0
+
+
+def test_resolve_steps_clamps_to_max(monkeypatch):
+    monkeypatch.delenv(ENV_MULTI_STEP_STEPS, raising=False)
+    assert resolve_multi_step_steps(make_model_config(multi_step_decode_steps=99)) == MAX_MULTI_STEP_STEPS
+
+
+def test_resolve_steps_invalid_env_falls_back_to_config(monkeypatch):
+    monkeypatch.setenv(ENV_MULTI_STEP_STEPS, "not-a-number")
+    assert resolve_multi_step_steps(make_model_config(multi_step_decode_steps=6)) == 6
+
+
+# ----------------------------------------------------- capability gate -----
+
+
+def test_model_capability_resolved_through_registry():
+    assert model_supports_multi_step(make_model_config()) is True
+
+
+def test_model_capability_refused_for_undeclared_arch():
+    assert model_supports_multi_step(make_model_config(architectures=["SomeOtherArch"])) is False
+
+
+def test_model_capability_stage_qualified_wrapper():
+    """A wrapper arch backing several stages qualifies only for listed stages.
+
+    Regression: the omni wrapper class is what the registry resolves for the
+    talker stage, so a flag declared only on the inner stage model left the
+    gate permanently closed.  The wrapper declares capability per stage.
+    """
+    WRAPPER = "MiniCPMO45OmniForConditionalGeneration"
+    tts = make_model_config(architectures=[WRAPPER], model_stage="tts")
+    llm = make_model_config(architectures=[WRAPPER], model_stage="llm")
+    assert model_supports_multi_step(tts) is True
+    assert model_supports_multi_step(llm) is False
+
+
+def test_model_capability_stage_flag_beats_blanket_flag():
+    """``supports_multi_step_stages`` takes precedence over a blanket flag."""
+    WRAPPER = "MiniCPMO45OmniForConditionalGeneration"
+    llm = make_model_config(architectures=[WRAPPER], model_stage="llm")
+    assert model_supports_multi_step(llm) is False
+
+
+def test_scheduler_allows_multi_step_platform_refusal(monkeypatch):
+    """Platforms without the window executor must be refused (fail-closed)."""
+    monkeypatch.setattr(msd, "current_platform", SimpleNamespace(device_type="cuda"))
+    assert scheduler_allows_multi_step(make_configured_scheduler()) is False
+
+
+def test_scheduler_allows_multi_step_positive():
+    assert scheduler_allows_multi_step(make_configured_scheduler()) is True
+
+
+def test_scheduler_allows_multi_step_refusals():
+    refusals = [
+        {"num_spec_tokens": 2},
+        {"kv_transfer_criteria": {"type": "prefill_finished"}},
+        {"lora_config": object()},
+        {"scheduler_config": SimpleNamespace(async_scheduling=False)},
+        {"vllm_config": make_vllm_config(make_model_config(is_encoder_decoder=True))},
+        {
+            "vllm_config": make_vllm_config(
+                make_model_config(enable_return_routed_experts=True)
+            )
+        },
+    ]
+    for overrides in refusals:
+        assert scheduler_allows_multi_step(make_configured_scheduler(**overrides)) is False, overrides
+
+
+def test_scheduler_allows_multi_step_parallel_refusals():
+    for field in ("pipeline_parallel_size", "tensor_parallel_size", "data_parallel_size", "pcp_size", "dcp_size"):
+        scheduler = make_configured_scheduler()
+        setattr(scheduler.vllm_config.parallel_config, field, 2)
+        assert scheduler_allows_multi_step(scheduler) is False, field
+
+
+def test_scheduler_allows_multi_step_mamba_refusal():
+    scheduler = make_configured_scheduler()
+    scheduler.vllm_config.cache_config.mamba_cache_mode = "align"
+    assert scheduler_allows_multi_step(scheduler) is False
+
+
+def test_scheduler_allows_multi_step_arch_refusal():
+    scheduler = make_configured_scheduler()
+    scheduler.vllm_config.model_config.architectures = ["SomeOtherArch"]
+    assert scheduler_allows_multi_step(scheduler) is False
+
+
+# -------------------------------------------------------- plan / patch ----
+
+
+def test_plan_window_rewrites_single_decode_step():
+    requests = [make_request("r0"), make_request("r1")]
+    scheduler = make_scheduler(requests)
+    output = make_scheduler_output(requests)
+    assert plan_multi_step_window(scheduler, output, 8) is True
+    assert output.num_scheduled_tokens == {"r0": 8, "r1": 8}
+    assert output.multi_step_plan == {"r0": 8, "r1": 8}
+    assert output.total_num_scheduled_tokens == 16
+    for request in requests:
+        # K-1 extra placeholders + K-1 optimistic computed tokens on top of
+        # the base single-token schedule.
+        assert request.num_output_placeholders == 8
+        assert request.num_computed_tokens == request.num_prompt_tokens + 5 + 7
+        assert request.allocated == 7
+    # New block rows communicated to the worker for both requests.
+    assert all(row is not None for row in output.scheduled_cached_reqs.new_block_ids)
+
+
+def test_plan_window_refused_when_waiting_queue_non_empty():
+    # Admission gate: new work must be admitted before any window opens.
+    requests = [make_request("r0")]
+    scheduler = make_scheduler(requests)
+    output = make_scheduler_output(requests)
+    scheduler.waiting = [make_request("r_wait")]
+    assert plan_multi_step_window(scheduler, output, 8) is False
+    assert output.multi_step_plan == {}
+    assert requests[0].num_output_placeholders == 1
+
+
+def test_plan_window_refused_when_new_reqs_scheduled():
+    requests = [make_request("r0")]
+    scheduler = make_scheduler(requests)
+    output = make_scheduler_output(requests)
+    output.scheduled_new_reqs = [SimpleNamespace(req_id="new")]
+    assert plan_multi_step_window(scheduler, output, 8) is False
+    assert output.multi_step_plan == {}
+    assert requests[0].num_output_placeholders == 1
+
+
+def test_plan_window_refused_for_mixed_batch():
+    # A prefill chunk scheduled 5 tokens for one request -> no uniform decode.
+    requests = [make_request("r0"), make_request("r1")]
+    scheduler = make_scheduler(requests)
+    output = make_scheduler_output(requests)
+    output.num_scheduled_tokens["r1"] = 5
+    assert plan_multi_step_window(scheduler, output, 8) is False
+
+
+def test_plan_window_refused_for_prefill_phase_request():
+    # num_computed_tokens < num_prompt_tokens => chunked prefill in flight.
+    requests = [make_request("r0", computed=10, prompt=100)]
+    scheduler = make_scheduler(requests)
+    output = make_scheduler_output(requests)
+    assert plan_multi_step_window(scheduler, output, 8) is False
+
+
+def test_plan_window_refused_for_logprobs_or_penalties():
+    requests = [make_request("r0", max_tokens=2048)]
+    requests[0].sampling_params.logprobs = 3
+    scheduler = make_scheduler(requests)
+    assert plan_multi_step_window(scheduler, make_scheduler_output(requests), 8) is False
+
+    requests[0].sampling_params.logprobs = None
+    requests[0].sampling_params.repetition_penalty = 1.2
+    assert plan_multi_step_window(scheduler, make_scheduler_output(requests), 8) is False
+
+
+def test_plan_window_budget_clamped_by_max_tokens():
+    # Only 3 tokens remain before max_tokens -> K clamps to 3.
+    requests = [make_request("r0", output_len=2045, max_tokens=2048)]
+    scheduler = make_scheduler(requests)
+    output = make_scheduler_output(requests)
+    assert plan_multi_step_window(scheduler, output, 8) is True
+    assert output.multi_step_plan["r0"] == 3
+    assert requests[0].num_output_placeholders == 3
+    assert requests[0].num_computed_tokens == 100 + 2045 + 2
+
+
+def test_plan_window_budget_clamped_by_model_len():
+    # Context room leaves space for only 4 more tokens.
+    requests = [make_request("r0", computed=4090, prompt=4085, output_len=5)]
+    scheduler = make_scheduler(requests, max_model_len=4094)
+    output = make_scheduler_output(requests)
+    assert plan_multi_step_window(scheduler, output, 8) is True
+    assert output.multi_step_plan["r0"] == 4
+
+
+def test_plan_window_refused_when_budget_below_two():
+    requests = [make_request("r0", output_len=2048, max_tokens=2048)]
+    scheduler = make_scheduler(requests)
+    output = make_scheduler_output(requests)
+    assert plan_multi_step_window(scheduler, output, 8) is False
+
+
+def test_plan_window_refused_when_allocation_fails_but_blocks_synced():
+    # One request cannot host the extra slots: no window at all, yet the
+    # successful sibling allocation is still communicated as look-ahead so
+    # scheduler/worker block tables never diverge.
+    requests = [make_request("r0"), make_request("r1")]
+    scheduler = make_scheduler(requests, fail_ids={"r1"})
+    output = make_scheduler_output(requests)
+    assert plan_multi_step_window(scheduler, output, 8) is False
+    assert output.multi_step_plan == {}
+    assert output.num_scheduled_tokens == {"r0": 1, "r1": 1}
+    # r0's successful probe allocation is appended as a look-ahead row.
+    assert output.scheduled_cached_reqs.new_block_ids[0] is not None
+    assert output.scheduled_cached_reqs.new_block_ids[1] is None
+    # Account state untouched on refusal.
+    assert requests[0].num_output_placeholders == 1
+    assert requests[1].num_output_placeholders == 1
+
+
+def test_plan_window_preserves_confirmed_count_invariant():
+    """The patch must preserve ``computed - placeholders == confirmed KV``.
+
+    That identity is what keeps every subsequent schedule's
+    ``num_new_tokens`` exact: while a window is in flight the async
+    scheduler optimistically counts the K in-flight samples as
+    placeholders, and each received token consumes exactly one
+    placeholder, so the engine-side confirmed length always matches the
+    KV slots actually written.
+    """
+    requests = [make_request("r0", output_len=5)]
+    scheduler = make_scheduler(requests)
+    output = make_scheduler_output(requests)
+    confirmed_before = requests[0].num_computed_tokens - requests[0].num_output_placeholders
+    assert plan_multi_step_window(scheduler, output, 8) is True
+    request = requests[0]
+    assert request.num_computed_tokens - request.num_output_placeholders == confirmed_before
+    # Both counters move by K-1; placeholders now hold the K in-flight
+    # samples the window will produce (base 1 + patch 7).
+    assert request.num_output_placeholders == 8
+    assert request.num_computed_tokens == confirmed_before + 8
+    # A subsequent schedule stays a normal single-token step: the base
+    # formula num_tokens_with_spec + placeholders - computed == 1.
+    num_new_tokens = request.num_tokens + request.num_output_placeholders - request.num_computed_tokens
+    assert num_new_tokens == 1
+
+
+def test_plan_window_disabled_for_k_below_two():
+    requests = [make_request("r0")]
+    scheduler = make_scheduler(requests)
+    output = make_scheduler_output(requests)
+    assert plan_multi_step_window(scheduler, output, 0) is False
+    assert plan_multi_step_window(scheduler, output, 1) is False
+
+
+# ------------------------------------------------------- reconcile --------
+
+
+def test_reconcile_noop_when_window_fully_reported():
+    request = make_request("r0", output_len=5)  # post-patch computed = 105 + 7
+    request.num_computed_tokens = 105 + 7
+    request.num_output_placeholders = 8
+    reconcile_window_shortfall(request, 8, 8)
+    assert request.num_output_placeholders == 8
+    assert request.num_computed_tokens == 112
+
+
+def test_reconcile_rolls_back_shortfall():
+    # Runner produced 3 of the planned 8 tokens (early stop / fallback).
+    # True computed after the window = (prompt + L - 1) + 3 = 104 + 3 = 107:
+    # the window processed positions 104..106 of the 8 reserved slots.
+    request = make_request("r0", output_len=5)
+    request.num_output_placeholders = 5  # K - reported, consumed by the update
+    request.num_computed_tokens = 112  # post-patch optimistic count
+    reconcile_window_shortfall(request, 8, 3)
+    assert request.num_output_placeholders == 0
+    assert request.num_computed_tokens == 107
+
+
+def test_reconcile_clamps_to_available_placeholders():
+    request = make_request("r0", output_len=5)
+    request.num_output_placeholders = 1
+    request.num_computed_tokens = 112
+    reconcile_window_shortfall(request, 8, 3)
+    # Only 1 placeholder was available; computed rolls back by the same
+    # amount to preserve the confirmed-length invariant.
+    assert request.num_output_placeholders == 0
+    assert request.num_computed_tokens == 111
+
+
+def test_reconcile_handles_empty_report():
+    request = make_request("r0", output_len=5)
+    request.num_output_placeholders = 8
+    request.num_computed_tokens = 112
+    reconcile_window_shortfall(request, 8, 0)
+    assert request.num_output_placeholders == 0
+    # Nothing was processed: back to the pre-step confirmed count
+    # (prompt + L - 1 = 104); the reserved slots stay allocated as
+    # look-ahead and the next schedule re-plans a normal single step.
+    assert request.num_computed_tokens == 104

--- a/tests/core/sched/test_multi_step_decode.py
+++ b/tests/core/sched/test_multi_step_decode.py
@@ -74,6 +74,7 @@ def make_request(req_id="r0", *, computed=None, prompt=100, output_len=5, max_to
         num_prompt_tokens=prompt,
         num_tokens=prompt + output_len,
         num_output_placeholders=1,
+        num_in_flight_tokens=1,
         output_token_ids=[0] * output_len,
         has_encoder_inputs=False,
         use_structured_output=False,
@@ -120,6 +121,9 @@ def make_scheduler(requests, *, max_model_len=4096, fail_ids=()):
         requests={r.request_id: r for r in requests},
         kv_cache_manager=make_kv_manager(fail_ids=fail_ids),
         max_model_len=max_model_len,
+        # async and sync scheduling both host windows; the planner reads the
+        # mode only to choose the accounting path (placeholder fence vs direct).
+        scheduler_config=SimpleNamespace(async_scheduling=True),
     )
 
 
@@ -242,7 +246,6 @@ def test_scheduler_allows_multi_step_refusals():
         {"num_spec_tokens": 2},
         {"kv_transfer_criteria": {"type": "prefill_finished"}},
         {"lora_config": object()},
-        {"scheduler_config": SimpleNamespace(async_scheduling=False)},
         {"vllm_config": make_vllm_config(make_model_config(is_encoder_decoder=True))},
         {
             "vllm_config": make_vllm_config(

--- a/tests/worker/test_multi_step_decode_runner.py
+++ b/tests/worker/test_multi_step_decode_runner.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runner-side validation tests for the multi-step decode window.
+
+``validate_multi_step_plan`` re-checks every window invariant against
+runner-local state before the K-step replay runs (fail-closed: any
+refusal falls back to the normal single-step path).  These tests drive
+the validator with duck-typed fakes, no NPU device required.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import vllm_omni.platforms.npu.worker.multi_step_decode as msd_module
+from vllm_omni.platforms.npu.worker.multi_step_decode import validate_multi_step_plan
+
+
+@pytest.fixture(autouse=True)
+def _stub_parallel_groups(monkeypatch):
+    """Single-process stand-ins for the distributed state accessors."""
+    group = SimpleNamespace(world_size=1, is_last_rank=True)
+    monkeypatch.setattr(msd_module, "get_pp_group", lambda: group)
+    monkeypatch.setattr(msd_module, "get_tp_group", lambda: group)
+
+
+def make_scheduler_output(req_ids, *, window_k=8, scheduled=None):
+    scheduled = scheduled or {rid: window_k for rid in req_ids}
+    return SimpleNamespace(
+        scheduled_new_reqs=[],
+        scheduled_spec_decode_tokens={},
+        scheduled_encoder_inputs={},
+        num_scheduled_tokens=scheduled,
+        multi_step_plan={rid: window_k for rid in req_ids},
+    )
+
+
+def make_runner(req_ids, *, model=None, input_batch=None, **overrides):
+    num_reqs = len(req_ids)
+    runner = SimpleNamespace(
+        use_async_scheduling=True,
+        num_spec_tokens=0,
+        speculative_config=None,
+        vllm_config=SimpleNamespace(
+            parallel_config=SimpleNamespace(data_parallel_size=1),
+        ),
+        pcp_size=1,
+        dcp_size=1,
+        use_cp=False,
+        lora_config=None,
+        is_pooling_model=False,
+        model_config=SimpleNamespace(
+            is_encoder_decoder=False,
+            enable_return_routed_experts=False,
+            enforce_eager=False,
+        ),
+        supports_mm_inputs=False,
+        omni_prefix_cache=None,
+        cache_config=SimpleNamespace(mamba_cache_mode="off"),
+        calculate_kv_scales=False,
+        dynamic_eplb=False,
+        debugger=None,
+        ascend_config=SimpleNamespace(
+            profiling_chunk_config=SimpleNamespace(enabled=False),
+        ),
+        model=model or make_model(),
+        input_batch=input_batch or make_input_batch(req_ids),
+        _resolve_duplex_sampling_hook=lambda: None,
+        num_prompt_logprobs=0,
+    )
+    for key, value in overrides.items():
+        setattr(runner, key, value)
+    return runner
+
+
+def make_model(**overrides):
+    model = SimpleNamespace(
+        has_preprocess=True,
+        make_omni_output=lambda *a, **k: None,
+        prefer_model_sampler=False,
+    )
+    for key, value in overrides.items():
+        setattr(model, key, value)
+    return model
+
+
+def make_input_batch(req_ids):
+    num_reqs = len(req_ids)
+    return SimpleNamespace(
+        req_ids=list(req_ids),
+        num_reqs=num_reqs,
+        num_computed_tokens_cpu=np.full(num_reqs, 200, dtype=np.int32),
+        num_prompt_tokens=np.full(num_reqs, 100, dtype=np.int32),
+        sampling_metadata=SimpleNamespace(
+            no_penalties=True,
+            max_num_logprobs=None,
+        ),
+        bad_words_token_ids=None,
+        no_allowed_token_ids=True,
+        logprob_token_ids=None,
+    )
+
+
+def test_validate_accepts_eligible_window():
+    runner = make_runner(["r0", "r1"])
+    output = make_scheduler_output(["r0", "r1"])
+    assert validate_multi_step_plan(runner, output) == {"r0": 8, "r1": 8}
+
+
+def test_validate_refuses_missing_or_empty_plan():
+    runner = make_runner(["r0"])
+    output = make_scheduler_output(["r0"])
+    output.multi_step_plan = {}
+    assert validate_multi_step_plan(runner, output) is None
+    output.multi_step_plan = None
+    assert validate_multi_step_plan(runner, output) is None
+
+
+def test_validate_refuses_non_uniform_window():
+    runner = make_runner(["r0", "r1"])
+    output = make_scheduler_output(["r0", "r1"])
+    output.multi_step_plan = {"r0": 8, "r1": 4}
+    output.num_scheduled_tokens = {"r0": 8, "r1": 4}
+    assert validate_multi_step_plan(runner, output) is None
+
+
+def test_validate_refuses_mismatched_schedule():
+    # num_scheduled_tokens disagrees with the plan (scheduler bug or a
+    # rewritten output that was not meant for this runner).
+    runner = make_runner(["r0"])
+    output = make_scheduler_output(["r0"])
+    output.num_scheduled_tokens = {"r0": 1}
+    assert validate_multi_step_plan(runner, output) is None
+
+
+def test_validate_refuses_sync_scheduling():
+    runner = make_runner(["r0"], use_async_scheduling=False)
+    assert validate_multi_step_plan(runner, make_scheduler_output(["r0"])) is None
+
+
+def test_validate_refuses_spec_decode():
+    runner = make_runner(["r0"], num_spec_tokens=2)
+    assert validate_multi_step_plan(runner, make_scheduler_output(["r0"])) is None
+
+
+def test_validate_refuses_model_without_contract():
+    runner = make_runner(["r0"], model=make_model(has_preprocess=False))
+    assert validate_multi_step_plan(runner, make_scheduler_output(["r0"])) is None
+
+
+def test_validate_refuses_penalties():
+    input_batch = make_input_batch(["r0"])
+    input_batch.sampling_metadata.no_penalties = False
+    runner = make_runner(["r0"], input_batch=input_batch)
+    assert validate_multi_step_plan(runner, make_scheduler_output(["r0"])) is None
+
+
+def test_accepts_stale_input_batch_views():
+    # The runner-side validation must NOT re-check per-step mutable state:
+    # under async scheduling the input_batch view lags the scheduler (the
+    # plan is validated before _update_states syncs it), so a stale view
+    # would produce false refusals.  A refusal after the scheduler planned
+    # follow-up windows on top of this one is not recoverable -- the
+    # follow-up plans' KV positions would skip this window's reserved
+    # slots.  Phase and batch composition are gated scheduler-side with
+    # authoritative state instead.
+    input_batch = make_input_batch(["r0"])
+    input_batch.num_computed_tokens_cpu[0] = 50  # stale prefill view
+    runner = make_runner(["r0"], input_batch=input_batch)
+    assert validate_multi_step_plan(runner, make_scheduler_output(["r0"])) is not None
+
+
+def test_accepts_plan_covering_requests_missing_from_input_batch():
+    runner = make_runner(["r0"])
+    output = make_scheduler_output(["r0", "r1"])
+    output.multi_step_plan = {"r0": 8, "r1": 8}
+    output.num_scheduled_tokens = {"r0": 8, "r1": 8}
+    # input_batch still shows only r0 (async lag); the plan is authoritative.
+    assert validate_multi_step_plan(runner, output) is not None
+
+
+def test_validate_returns_none_on_internal_error():
+    class ExplodingRunner(SimpleNamespace):
+        # any attribute access on use_async_scheduling raises
+        def __getattribute__(self, name):
+            if name == "use_async_scheduling":
+                raise RuntimeError("boom")
+            return super().__getattribute__(name)
+
+    runner = ExplodingRunner()
+    assert validate_multi_step_plan(runner, make_scheduler_output(["r0"])) is None

--- a/tests/worker/test_multi_step_decode_runner.py
+++ b/tests/worker/test_multi_step_decode_runner.py
@@ -135,9 +135,12 @@ def test_validate_refuses_mismatched_schedule():
     assert validate_multi_step_plan(runner, output) is None
 
 
-def test_validate_refuses_sync_scheduling():
+def test_validate_accepts_sync_scheduling():
+    # The window executor supports the sync scheduler (one window in flight,
+    # step-0 input from the request-local output chain); no sync refusal.
     runner = make_runner(["r0"], use_async_scheduling=False)
-    assert validate_multi_step_plan(runner, make_scheduler_output(["r0"])) is None
+    output = make_scheduler_output(["r0"])
+    assert validate_multi_step_plan(runner, output) == {"r0": 8}
 
 
 def test_validate_refuses_spec_decode():

--- a/vllm_omni/config/model.py
+++ b/vllm_omni/config/model.py
@@ -121,6 +121,9 @@ class OmniModelConfig(ModelConfig):
     async_chunk: bool = False
     # Stage-1 active stream slots; 0 keeps legacy chunk-level round-robin.
     active_stream_window: int = 0
+    # Multi-step decode window size for this AR stage (0 = disabled).  See
+    # vllm_omni/core/sched/multi_step_decode.py for the eligibility rules.
+    multi_step_decode_steps: int = 0
     model_stage: str = "thinker"
     model_arch: str | None = None
     worker_type: str | None = None

--- a/vllm_omni/core/sched/multi_step_decode.py
+++ b/vllm_omni/core/sched/multi_step_decode.py
@@ -1,0 +1,372 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Multi-step decode window planning for AR stages on async scheduling.
+
+Small autoregressive stages (e.g. the MiniCPM-o 4.5 Talker) spend more host
+time per decode step (scheduling, input preparation, attention metadata,
+sampling bookkeeping, inter-stage IPC) than device time on the forward
+itself.  This module lets one engine step cover ``K`` decode steps for the
+whole batch, amortizing the per-step host cost over ``K`` tokens:
+
+1. ``num_scheduled_tokens`` for the batch is bumped from 1 to K after the
+   base scheduler already ran (a post-schedule patch).  The extra K-1 KV
+   slots are allocated here (``allocate_slots``) and the new block ids are
+   appended to ``scheduled_cached_reqs.new_block_ids`` so the worker's
+   block table covers every slot the window will write.
+2. ``request.num_output_placeholders`` and ``request.num_computed_tokens``
+   are inflated by K-1.  The async-scheduling accounting then treats the
+   window exactly like a step that samples K tokens per request: the K
+   reported tokens drive ``num_output_placeholders`` back to zero, while
+   ``update_from_output`` reconciles the shortfall when the runner produced
+   fewer tokens than planned (early stop or single-step fallback), so the
+   engine's confirmed ``num_computed_tokens`` always matches the KV slots
+   actually written.
+3. The inflated placeholder count doubles as the fence: while a window is
+   in flight, ``num_tokens_with_spec + placeholders - computed == 0`` keeps
+   the request out of subsequent schedules until its K tokens are
+   reconciled.
+
+Concurrency safety: the window freezes the batch composition for K steps,
+so a request waiting in the scheduler's waiting queue would be blocked from
+admission (its prefill cannot be scheduled mid-window).  The planner
+therefore refuses to open a window while the waiting queue is non-empty --
+new work is admitted first, and windows resume once the queue drains.  This
+keeps multi-concurrency latency identical to the baseline while still
+amortizing host cost over the (common) steady state where every admitted
+request is decoding.
+
+Models opt in by declaring ``supports_multi_step_decode = True`` on the
+model class.  The contract behind the flag:
+
+* ``model.preprocess(input_ids, input_embeds, **info)`` builds the decode
+  embedding of every request purely from the request-local state chain
+  (the previously sampled token and per-request caches) and advances that
+  state in place through ``make_omni_output``;
+* intermediate steps need no per-step OmniOutput wire wrapping -- hidden
+  states and codec deltas can be accumulated and shipped once at window
+  end.
+
+Every refusal path is fail-closed: the patch is skipped entirely and the
+normal single-step engine loop runs.  Rollback: leave
+``multi_step_decode_steps`` at 0 (the default) in the deploy config.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.v1.request import RequestStatus
+
+logger = init_logger(__name__)
+
+# Debug/override knob: when set, takes precedence over the deploy-config
+# value (clamped the same way).  Useful for quick A/B experiments without
+# editing the deploy yaml.
+ENV_MULTI_STEP_STEPS = "VLLM_OMNI_MULTI_STEP_STEPS"
+
+# Upper bound on the window size.  The amortization benefit saturates well
+# before this (host cost becomes negligible vs. accumulated device time)
+# while the admission-blocking tail grows linearly with K.
+MAX_MULTI_STEP_STEPS = 16
+
+# Cache of architecture -> capability lookups so the registry is only
+# touched once per architecture (the registry import pulls in the whole
+# model registry module graph).
+_capability_cache: dict[str, bool] = {}
+
+
+def resolve_multi_step_steps(model_config: Any) -> int:
+    """Resolve the window size for a stage from config (+env override).
+
+    Returns 0 when the window is disabled and otherwise K clamped to
+    ``[1, MAX_MULTI_STEP_STEPS]``.
+    """
+    raw = os.environ.get(ENV_MULTI_STEP_STEPS)
+    if raw is not None:
+        try:
+            value = int(raw, 10)
+        except ValueError:
+            logger.warning_once(
+                "Invalid %s=%r; ignoring it.", ENV_MULTI_STEP_STEPS, raw
+            )
+        else:
+            if value <= 0:
+                return 0
+            return min(value, MAX_MULTI_STEP_STEPS)
+    value = int(getattr(model_config, "multi_step_decode_steps", 0) or 0)
+    if value <= 0:
+        return 0
+    return min(value, MAX_MULTI_STEP_STEPS)
+
+
+def model_supports_multi_step(model_config: Any) -> bool:
+    """True when the stage's model class declares the multi-step contract.
+
+    Resolves the architecture through the omni model registry and reads the
+    ``supports_multi_step_decode`` class attribute; unknown or transformers
+    fallback architectures simply do not declare it.
+
+    Stage-dispatching wrapper architectures (one class backing both the
+    thinker and talker stages) declare the capability per stage via
+    ``supports_multi_step_stages`` — a tuple of ``model_stage`` values that
+    host a multi-step-capable AR model.  When that attribute is present it
+    takes precedence: the stage qualifies only if its ``model_stage`` is
+    listed, so the thinker stage of the same wrapper never opens windows.
+    """
+    archs = list(getattr(model_config, "architectures", None) or ())
+    stage = getattr(model_config, "model_stage", None)
+    for arch in archs:
+        cached = _capability_cache.get((arch, stage))
+        if cached is not None:
+            if cached:
+                return True
+            continue
+        supported = False
+        try:
+            from vllm_omni.model_executor.models.registry import OmniModelRegistry
+
+            model_cls, _ = OmniModelRegistry.resolve_model_cls([arch], model_config)
+            capable_stages = getattr(model_cls, "supports_multi_step_stages", None)
+            if capable_stages is not None:
+                supported = stage in capable_stages
+            else:
+                supported = bool(
+                    getattr(model_cls, "supports_multi_step_decode", False)
+                )
+        except Exception:
+            # Registry misses and load errors both mean "not declared".
+            supported = False
+        _capability_cache[(arch, stage)] = supported
+        if supported:
+            return True
+    return False
+
+
+def scheduler_allows_multi_step(scheduler: Any) -> bool:
+    """Static configuration gate evaluated once per ``schedule()`` call.
+
+    Only single-rank (TP/PP/DP/PCP/DCP == 1), spec-decode-free, LoRA-free
+    AR stages on async scheduling are eligible.  Anything the runner cannot
+    reproduce bit-identically (KV-transfer criteria, routed experts,
+    encoder-decoder, mamba-aligned caches) is refused here.
+    """
+    vllm_config = getattr(scheduler, "vllm_config", None)
+    if vllm_config is None:
+        return False
+    # The window executor currently ships with the NPU AR runner only (see
+    # vllm_omni/platforms/npu/worker/multi_step_decode.py).  Planning windows
+    # for a runner without the execute_model hook would silently turn the
+    # K-token scheduling into a plain multi-token decode and corrupt outputs,
+    # so platforms without the hook are refused here (fail-closed).  Porting
+    # to another platform: add the execute_model/sample_tokens hooks to its
+    # runner, then relax this check.
+    if getattr(current_platform, "device_type", "") != "npu":
+        return False
+    model_config = vllm_config.model_config
+    if not model_supports_multi_step(model_config):
+        return False
+    if not getattr(scheduler.scheduler_config, "async_scheduling", False):
+        return False
+    parallel_config = vllm_config.parallel_config
+    if (
+        parallel_config.pipeline_parallel_size != 1
+        or parallel_config.tensor_parallel_size != 1
+        or parallel_config.data_parallel_size != 1
+        or getattr(parallel_config, "pcp_size", 1) != 1
+        or getattr(parallel_config, "dcp_size", 1) != 1
+    ):
+        return False
+    if getattr(scheduler, "num_spec_tokens", 0) != 0:
+        return False
+    if getattr(scheduler, "kv_transfer_criteria", None) is not None:
+        return False
+    if getattr(scheduler, "lora_config", None) is not None:
+        return False
+    if getattr(model_config, "is_encoder_decoder", False):
+        return False
+    if getattr(model_config, "enable_return_routed_experts", False):
+        return False
+    cache_config = getattr(vllm_config, "cache_config", None)
+    if getattr(cache_config, "mamba_cache_mode", "off") == "align":
+        return False
+    return True
+
+
+def _request_admits_multi_step(request: Any) -> bool:
+    """Per-request eligibility for one multi-step window."""
+    if request is None or request.is_finished():
+        return False
+    if getattr(request, "status", None) != RequestStatus.RUNNING:
+        return False
+    # Decode phase only: the window writes K contiguous post-prompt slots and
+    # cannot interleave with chunked prefill or prefix-cache (re)computation.
+    if request.num_computed_tokens < request.num_prompt_tokens:
+        return False
+    if getattr(request, "has_encoder_inputs", False):
+        return False
+    if getattr(request, "use_structured_output", False):
+        return False
+    if getattr(request, "pooling_params", None) is not None:
+        return False
+    params = request.sampling_params
+    if params is None:
+        return False
+    if params.logprobs is not None or params.prompt_logprobs is not None:
+        return False
+    if getattr(params, "bad_words_token_ids", None):
+        return False
+    if getattr(params, "allowed_token_ids", None):
+        return False
+    # Value-dependent logits processors must stay off: the window keeps the
+    # placeholder (-1) bookkeeping in step, but only length-based processors
+    # (min_tokens) are value-independent.
+    if getattr(params, "frequency_penalty", 0.0) != 0.0:
+        return False
+    if getattr(params, "presence_penalty", 0.0) != 0.0:
+        return False
+    if getattr(params, "repetition_penalty", 1.0) != 1.0:
+        return False
+    return True
+
+
+def _request_window_budget(request: Any, max_model_len: int) -> int:
+    """Largest K this request can host: min(K, max_tokens left, context)."""
+    params = request.sampling_params
+    max_tokens = int(getattr(params, "max_tokens", 0) or 0)
+    remaining = max_tokens - len(request.output_token_ids) if max_tokens else 0
+    context_room = max_model_len - request.num_tokens
+    return min(remaining, context_room)
+
+
+def plan_multi_step_window(scheduler: Any, scheduler_output: Any, steps: int) -> bool:
+    """Rewrite ``scheduler_output`` in place into a multi-step decode window.
+
+    Must be called right after the base ``schedule()`` produced a plain
+    single-token decode step.  Returns True when the output was rewritten;
+    on any refusal the output and the request accounting are left untouched
+    so the caller falls back to the normal single-step path (the scheduler
+    side of ``update_from_output`` reconciles the reservation shortfall if
+    the worker ever declines a plan that was emitted).
+    """
+    if steps < 2:
+        return False
+    # Admission gate: a window freezes the batch composition, which would
+    # delay the prefill of anything already waiting.  Admit new work first;
+    # windows resume once the waiting queue drains.
+    if getattr(scheduler, "waiting", None):
+        return False
+    num_scheduled = scheduler_output.num_scheduled_tokens
+    if not num_scheduled:
+        return False
+    if scheduler_output.scheduled_new_reqs:
+        return False
+    if scheduler_output.scheduled_spec_decode_tokens:
+        return False
+    if scheduler_output.scheduled_encoder_inputs:
+        return False
+    if getattr(scheduler_output, "has_structured_output_requests", False):
+        return False
+    if getattr(scheduler_output, "pending_structured_output_tokens", False):
+        return False
+
+    cached_reqs = scheduler_output.scheduled_cached_reqs
+    cached_index = {req_id: i for i, req_id in enumerate(cached_reqs.req_ids)}
+    windowed: list[tuple[str, Any]] = []
+    for req_id, num_tokens in num_scheduled.items():
+        # The base scheduler must have scheduled exactly one decode token.
+        if num_tokens != 1:
+            return False
+        request = scheduler.requests.get(req_id)
+        if not _request_admits_multi_step(request):
+            return False
+        if req_id not in cached_index:
+            return False
+        windowed.append((req_id, request))
+
+    if not windowed:
+        return False
+
+    max_model_len = scheduler.max_model_len
+    window_k = steps
+    for _, request in windowed:
+        window_k = min(window_k, _request_window_budget(request, max_model_len))
+    if window_k < 2:
+        return False
+
+    extra = window_k - 1
+    extra_blocks: dict[str, Any] = {}
+    for req_id, request in windowed:
+        # Extend the block allocation to cover the K-1 extra KV slots the
+        # window will write.  On failure allocate_slots leaves state intact
+        # and returns None; the window is refused for the whole batch.
+        blocks = scheduler.kv_cache_manager.allocate_slots(
+            request, extra, num_lookahead_tokens=0
+        )
+        extra_blocks[req_id] = blocks
+        if blocks is None:
+            logger.debug(
+                "Multi-step window refused: request %s cannot host %d extra KV slots",
+                req_id,
+                extra,
+            )
+
+    # Communicate whatever allocations succeeded as look-ahead block rows so
+    # the scheduler/worker block tables never diverge, even when the window
+    # itself is refused below.
+    for i, req_id in enumerate(cached_reqs.req_ids):
+        blocks = extra_blocks.get(req_id)
+        if blocks is None:
+            continue
+        new_ids = blocks.get_block_ids()
+        if not any(new_ids):
+            continue
+        current = cached_reqs.new_block_ids[i]
+        if current is None:
+            cached_reqs.new_block_ids[i] = new_ids
+        else:
+            cached_reqs.new_block_ids[i] = tuple(
+                old + new for old, new in zip(current, new_ids)
+            )
+
+    if any(blocks is None for blocks in extra_blocks.values()):
+        return False
+
+    # Commit the window: K scheduled tokens per request and K in-flight
+    # output placeholders so the engine-side accounting closes exactly when
+    # the runner reports the K sampled tokens.
+    for req_id, request in windowed:
+        request.num_output_placeholders += extra
+        request.num_computed_tokens += extra
+        scheduler_output.num_scheduled_tokens[req_id] = window_k
+        scheduler_output.multi_step_plan[req_id] = window_k
+    scheduler_output.total_num_scheduled_tokens += extra * len(windowed)
+    logger.debug(
+        "Multi-step window scheduled: K=%d requests=%d", window_k, len(windowed)
+    )
+    return True
+
+
+def reconcile_window_shortfall(
+    request: Any, planned_steps: int, reported_tokens: int
+) -> None:
+    """Close the accounting gap when a windowed step produced < K tokens.
+
+    ``AsyncScheduler._update_request_with_output`` already consumed
+    ``reported_tokens`` placeholders and its ``cache_blocks`` call used
+    ``num_computed_tokens - num_output_placeholders``, which equals the true
+    confirmed length in both the window and fallback cases.  The remaining
+    K - reported reservations (placeholders + optimistic computed tokens)
+    belong to steps that never ran and are rolled back here.
+    """
+    shortfall = planned_steps - reported_tokens
+    if shortfall <= 0:
+        return
+    # Placeholders hold exactly K - reported in steady state; clamp only to
+    # stay defensive against unexpected interim adjustments, and roll back
+    # computed_tokens by the same amount so the (computed - placeholders)
+    # confirmed-length invariant is preserved.
+    shortfall = min(shortfall, max(request.num_output_placeholders, 0))
+    request.num_output_placeholders -= shortfall
+    request.num_computed_tokens -= shortfall

--- a/vllm_omni/core/sched/multi_step_decode.py
+++ b/vllm_omni/core/sched/multi_step_decode.py
@@ -167,8 +167,12 @@ def scheduler_allows_multi_step(scheduler: Any) -> bool:
     model_config = vllm_config.model_config
     if not model_supports_multi_step(model_config):
         return False
-    if not getattr(scheduler.scheduler_config, "async_scheduling", False):
-        return False
+    # The window executor works under both async scheduling (the original
+    # target) and the sync OmniARScheduler (whose K-token plan is produced by
+    # the same plan_multi_step_window hook).  Sync windows consume the
+    # scheduler-provided input ids for step 0 (no async feedback), which the
+    # runner handles via the prev_sampled_token_ids fallback; the runner-side
+    # async feedback tail is gated on use_async_scheduling.
     parallel_config = vllm_config.parallel_config
     if (
         parallel_config.pipeline_parallel_size != 1
@@ -335,10 +339,22 @@ def plan_multi_step_window(scheduler: Any, scheduler_output: Any, steps: int) ->
 
     # Commit the window: K scheduled tokens per request and K in-flight
     # output placeholders so the engine-side accounting closes exactly when
-    # the runner reports the K sampled tokens.
+    # the runner reports the K sampled tokens.  Async scheduling needs the
+    # placeholder fence: the scheduler plans follow-up windows on top of the
+    # in-flight one, and the fence keeps the request out of those until its
+    # K tokens are reconciled.  The sync OmniARScheduler executes strictly
+    # one step at a time (schedule -> execute -> update), so only one window
+    # is ever in flight and no fence is needed; the K-1 optimistic computed
+    # tokens are rolled back by reconcile_window_shortfall when the window
+    # exits early.  num_in_flight_tokens is kept symmetric with
+    # num_computed_tokens in both modes (the base scheduler adds 1 for the
+    # pre-rewrite decode token, the runner's update_from_output subtracts K).
+    async_mode = bool(getattr(scheduler.scheduler_config, "async_scheduling", True))
     for req_id, request in windowed:
-        request.num_output_placeholders += extra
+        if async_mode:
+            request.num_output_placeholders += extra
         request.num_computed_tokens += extra
+        request.num_in_flight_tokens += extra
         scheduler_output.num_scheduled_tokens[req_id] = window_k
         scheduler_output.multi_step_plan[req_id] = window_k
     scheduler_output.total_num_scheduled_tokens += extra * len(windowed)
@@ -359,14 +375,19 @@ def reconcile_window_shortfall(
     confirmed length in both the window and fallback cases.  The remaining
     K - reported reservations (placeholders + optimistic computed tokens)
     belong to steps that never ran and are rolled back here.
+
+    Under sync scheduling no placeholder fence exists (one window in flight
+    max), so the whole shortfall lives in the optimistic ``num_computed_tokens``
+    the plan added and is rolled back directly.
     """
     shortfall = planned_steps - reported_tokens
     if shortfall <= 0:
         return
-    # Placeholders hold exactly K - reported in steady state; clamp only to
-    # stay defensive against unexpected interim adjustments, and roll back
-    # computed_tokens by the same amount so the (computed - placeholders)
-    # confirmed-length invariant is preserved.
-    shortfall = min(shortfall, max(request.num_output_placeholders, 0))
-    request.num_output_placeholders -= shortfall
+    # Async: placeholders hold exactly K - reported in steady state; clamp
+    # only to stay defensive against unexpected interim adjustments.
+    if request.num_output_placeholders > 0:
+        shortfall = min(shortfall, request.num_output_placeholders)
+        request.num_output_placeholders -= shortfall
+    # Sync: no placeholders were added; the plan inflated num_computed_tokens
+    # by extra (== planned_steps - 1), so the unproduced steps roll back here.
     request.num_computed_tokens -= shortfall

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -19,6 +19,12 @@ from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus, StreamingUpdate
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 
+from vllm_omni.core.sched.multi_step_decode import (
+    plan_multi_step_window,
+    reconcile_window_shortfall,
+    resolve_multi_step_steps,
+    scheduler_allows_multi_step,
+)
 from vllm_omni.core.sched.omni_scheduler_mixin import OmniSchedulerMixin
 from vllm_omni.core.sched.omni_scheduling_coordinator import (
     OmniSchedulingCoordinator,
@@ -276,10 +282,23 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
             finished_reqs = {}
 
         # Wrap in omni scheduler output to carry transfer metadata.
-        return self._wrap_omni_scheduler_output(
+        scheduler_output = self._wrap_omni_scheduler_output(
             scheduler_output,
             finished_requests_needing_kv_transfer=finished_reqs,
         )
+
+        # [Omni] Multi-step decode window.  Rewrites the just-built
+        # single-token decode step into a K-token step (extra KV allocation +
+        # placeholder inflation) when the whole batch is eligible; any refusal
+        # leaves the output untouched and the normal single-step path runs.
+        try:
+            steps = resolve_multi_step_steps(self.vllm_config.model_config)
+            if steps > 0 and scheduler_allows_multi_step(self):
+                plan_multi_step_window(self, scheduler_output, steps)
+        except Exception:
+            logger.exception("Multi-step window planning failed; falling back to single step")
+
+        return scheduler_output
 
     def update_from_output(
         self,
@@ -290,6 +309,9 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         logprobs = model_runner_output.logprobs
         prompt_logprobs_dict = model_runner_output.prompt_logprobs_dict
         num_scheduled_tokens = scheduler_output.num_scheduled_tokens
+        # [Omni] Multi-step decode window plan for this step (empty when the
+        # step is not windowed).
+        multi_step_plan = getattr(scheduler_output, "multi_step_plan", None) or {}
         pooler_outputs = model_runner_output.pooler_output
         mm_outputs = getattr(model_runner_output, "multimodal_outputs", None)
         inter_stage_outputs = getattr(model_runner_output, "inter_stage_outputs", None)
@@ -402,6 +424,18 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 # Pooling stops as soon as there is output.
                 request.status = RequestStatus.FINISHED_STOPPED
                 stopped = True
+
+            # [Omni] Close the multi-step window accounting.  The window step
+            # reserved K placeholders and K optimistic computed tokens; when
+            # the runner reported fewer tokens than planned (early stop or a
+            # single-step fallback on the worker), roll back the reservations
+            # of the steps that never ran.  The cache_blocks call inside
+            # _update_request_with_output already used the true confirmed
+            # length, so this only repairs num_computed_tokens /
+            # num_output_placeholders for subsequent schedules.
+            planned_steps = multi_step_plan.get(req_id)
+            if planned_steps is not None:
+                reconcile_window_shortfall(request, planned_steps, len(new_token_ids))
 
             # If criteria returns True, it means we must STOP the request.
             # If criteria returns False, it might have triggered a background

--- a/vllm_omni/core/sched/output.py
+++ b/vllm_omni/core/sched/output.py
@@ -98,3 +98,7 @@ class OmniSchedulerOutput(SchedulerOutput):
 
     finished_requests_needing_kv_transfer: dict[str, dict] = field(default_factory=dict)
     pending_input_registrations: list[OmniChunkRecvHandle] = field(default_factory=list)
+    # Multi-step decode window plan: req_id -> number of decode steps the
+    # runner replays inside this single engine step.  Empty when the step is
+    # not windowed; see vllm_omni/core/sched/multi_step_decode.py.
+    multi_step_plan: dict[str, int] = field(default_factory=dict)

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -163,6 +163,13 @@ class OmniEngineArgs(EngineArgs):
     # Must be declared here so engine_args dict propagation does not silently
     # drop the value when constructing OmniEngineArgs from kwargs.
     active_stream_window: int = 0
+    # Multi-step decode window size for AR stages on async scheduling: one
+    # engine step replays this many decode steps for the whole batch,
+    # amortizing per-step host overhead.  0 (default) keeps the normal
+    # single-step loop.  Models must declare the contract via
+    # ``supports_multi_step_decode``; ineligible batches fall back to single
+    # steps automatically.
+    multi_step_decode_steps: int = 0
     omni_kv_config: dict | None = None
     quantization_config: Any | None = None
     force_cutlass_fp8: bool | None = None
@@ -342,6 +349,7 @@ class OmniEngineArgs(EngineArgs):
             stage_id=self.stage_id,
             async_chunk=self.async_chunk,
             active_stream_window=self.active_stream_window,
+            multi_step_decode_steps=self.multi_step_decode_steps,
             model_stage=self.model_stage,
             model_arch=self.model_arch,
             worker_type=self.worker_type,

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py
@@ -64,6 +64,13 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
       codec-token deltas for the separate Code2Wav stage.
     """
 
+    # Stage-qualified multi-step decode capability.  This wrapper class backs
+    # both AR stages, so the capability is declared per stage instead of as a
+    # blanket class flag: only the talker ("tts") runs the small-model
+    # host-bound decode that multi-step windows amortize.  See
+    # vllm_omni.core.sched.multi_step_decode.model_supports_multi_step.
+    supports_multi_step_stages = ("tts",)
+
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:
         if modality.startswith("image"):

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py
@@ -125,6 +125,16 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
 
     requires_request_sample_eligibility = True
 
+    # Multi-step decode window contract (see
+    # vllm_omni/core/sched/multi_step_decode.py): ``preprocess()`` builds
+    # every decode-step embedding purely from the request-local state chain
+    # (the previous sampled codec token via ``audio_codes.current`` plus the
+    # per-request audio state), and ``make_omni_output()`` advances that
+    # state in place -- so K decode steps can be replayed inside one engine
+    # step with intermediate steps skipping the per-step OmniOutput wire
+    # wrapping.
+    supports_multi_step_decode = True
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         from vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni_llm import MiniCPMOConfig
@@ -503,7 +513,12 @@ class MiniCPMO45OmniTTSForConditionalGeneration(nn.Module, SupportsPP):
             if state.get("finished"):
                 stop_rows.append(hidden.new_tensor([float("-inf"), 0.0]))
                 codec_deltas.append(empty_delta)
-                terminal_flags.append(torch.tensor(False, dtype=torch.bool))
+                # The request already emitted its terminal codec (EOS or the
+                # token limit).  Report finished=True so a multi-step window
+                # early-exits on this step instead of burning the remaining
+                # steps on dead rows; downstream consumers treat the flag
+                # idempotently (chunk-finished bookkeeping is a set add).
+                terminal_flags.append(torch.tensor(True, dtype=torch.bool))
                 continue
             if not sample_eligible[index]:
                 # vLLM computes a logit row for incomplete chunked prefills but

--- a/vllm_omni/platforms/npu/worker/multi_step_decode.py
+++ b/vllm_omni/platforms/npu/worker/multi_step_decode.py
@@ -1,0 +1,672 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runner-side execution of multi-step decode windows on Ascend NPUs.
+
+Companion to ``vllm_omni.core.sched.multi_step_decode`` (scheduler-side
+planning).  When the scheduler rewrites a decode step into a K-token
+window, this module replays the K decode steps inside a single
+``execute_model`` call:
+
+    step input -> model.preprocess (per-request embedding)
+               -> forward -> make_omni_output / multimodal extraction
+               -> compute_logits -> sampler -> next step input
+
+Everything the engine loop would otherwise do once per token -- batch
+layout rebuild, attention metadata, forward context, sampling and
+inter-stage payload assembly -- runs K times here, but the host-side
+engine steps (scheduler pass, IPC, output processing) run once per
+window.  That is the whole point: for stages whose per-token device time
+is far below the per-step host time, the engine step rate becomes the
+throughput ceiling and windowing lifts it by ~K.
+
+The final ``OmniModelRunnerOutput`` is stashed on the runner
+(``_multi_step_pending_output``) for ``sample_tokens()``, preserving the
+engine's execute_model -> sample_tokens contract.
+
+Early exit: when every request's ``make_omni_output`` has already
+signalled completion, the loop stops before K -- the remaining steps
+would only burn device time on dead rows.  The scheduler-side
+``reconcile_window_shortfall`` absorbs the unproduced tokens, so early
+exit needs no special casing anywhere else.
+
+Fail-closed contract: ``validate_multi_step_plan`` re-checks every static
+invariant (platform, parallelism, model contract, sampling features)
+before a window runs.  Per-step mutable state is deliberately NOT
+re-checked here: under async scheduling the runner's input_batch view
+lags the scheduler, so such checks would produce false refusals -- and a
+refusal after the scheduler planned follow-up windows on top of this one
+cannot be recovered by shrinking (the follow-up plans' KV positions
+would skip this window's reserved slots, leaving holes of uninitialized
+cache).  Phase and batch composition are gated scheduler-side with
+authoritative state instead.  The residual static refusals shrink the
+K-token schedule back to a plain single-token step
+(``shrink_refused_multi_step_window``); the scheduler side reconciles the
+reservation shortfall, so a refused window costs nothing but a skipped
+optimization.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import torch
+from vllm.compilation.cuda_graph import CUDAGraphMode, CUDAGraphStat
+from vllm.distributed.parallel_state import get_pp_group, get_tp_group
+from vllm.logger import init_logger
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.utils import record_function_or_nullcontext
+from vllm_ascend.ascend_forward_context import set_ascend_forward_context
+from vllm_ascend.ops.rotary_embedding import update_cos_sin
+
+from vllm_omni.data_entry_keys import flatten_payload
+from vllm_omni.distributed.omni_connectors.utils.config import stage_sends_async_output
+from vllm_omni.outputs import OmniModelRunnerOutput
+from vllm_omni.utils.mm_outputs import partition_payload_list
+
+logger = init_logger(__name__)
+
+# Diagnostic counters: scheduler-side plans vs runner-side executions.  A
+# large planned>>executed gap means a gate here refuses systematically and
+# every engine step pays the plan/allocate/refuse/reconcile churn for
+# nothing (see the multi-step A/B analysis).
+_refusal_counts: dict[str, int] = {}
+_executed_windows = 0
+_executed_steps = 0
+
+
+def _refuse(reason: str) -> None:
+    _refusal_counts[reason] = _refusal_counts.get(reason, 0) + 1
+    if _refusal_counts[reason] == 1:
+        logger.warning("Multi-step plan refused at runner: %s (first occurrence)", reason)
+
+
+def validate_multi_step_plan(
+    runner: Any, scheduler_output: SchedulerOutput
+) -> dict[str, int] | None:
+    """Validate the scheduler's window plan against runner-local state.
+
+    Returns the plan (req_id -> K) when this runner can host the window,
+    None to run the normal single-step path (fail-closed; the scheduler
+    side reconciles the shortfall).
+    """
+    try:
+        plan = getattr(scheduler_output, "multi_step_plan", None)
+        if not plan:
+            return _refuse("no_plan")
+        window_sizes = {int(k) for k in plan.values()}
+        if len(window_sizes) != 1:
+            return _refuse("mixed_window_sizes")
+        window_k = window_sizes.pop()
+        if window_k < 2:
+            return _refuse("window_k_lt_2")
+        num_scheduled = scheduler_output.num_scheduled_tokens
+        if set(num_scheduled) != set(plan):
+            return _refuse("num_scheduled_mismatch")
+        if any(int(n) != window_k for n in num_scheduled.values()):
+            return _refuse("scheduled_not_k")
+        if (
+            scheduler_output.scheduled_new_reqs
+            or scheduler_output.scheduled_spec_decode_tokens
+            or scheduler_output.scheduled_encoder_inputs
+        ):
+            return _refuse("new_or_spec_or_encoder_reqs")
+        # The window drives input feedback through the async-scheduling
+        # fast path; anything else falls back to the standard loop.
+        if not runner.use_async_scheduling:
+            return _refuse("no_async_scheduling")
+        if runner.num_spec_tokens or runner.speculative_config is not None:
+            return _refuse("spec_decode")
+        pp_group = get_pp_group()
+        if pp_group.world_size != 1 or not pp_group.is_last_rank:
+            return _refuse("pp")
+        if get_tp_group().world_size != 1:
+            return _refuse("tp")
+        if (
+            runner.vllm_config.parallel_config.data_parallel_size != 1
+            or runner.pcp_size != 1
+            or runner.dcp_size != 1
+            or runner.use_cp
+        ):
+            return _refuse("dp_pcp_dcp_cp")
+        if runner.lora_config is not None or runner.is_pooling_model:
+            return _refuse("lora_or_pooling")
+        if runner.model_config.is_encoder_decoder or runner.supports_mm_inputs:
+            # Omni wrapper architectures host the multimodal encoders for the
+            # earlier stages, so the talker stage legitimately reports
+            # supports_mm_inputs even though its decode path consumes plain
+            # token ids (preprocess() rebuilds embeddings from request-local
+            # state).  Allow it only when the loaded model declares the
+            # multi-step contract for THIS stage -- same (arch, stage) gate as
+            # the scheduler side.
+            stage = getattr(runner.model_config, "model_stage", None)
+            declared_stages = getattr(runner.model, "supports_multi_step_stages", None)
+            if not (
+                getattr(runner.model, "supports_multi_step_decode", False)
+                or (declared_stages is not None and stage in declared_stages)
+            ):
+                return _refuse("enc_dec_or_mm_inputs")
+        if runner.omni_prefix_cache is not None:
+            return _refuse("prefix_cache")
+        if getattr(runner, "has_talker_mtp", False):
+            return _refuse("talker_mtp")
+        # NOTE: no duplex-hook / prefer_model_sampler refusal here — the
+        # window loop mirrors _sample's custom-sampler branch (logit bias,
+        # duplex hook, model sampler with prepared metadata), so models that
+        # use them host windows with identical sampling semantics.
+        if getattr(runner.cache_config, "mamba_cache_mode", "off") == "align":
+            return _refuse("mamba_align")
+        if runner.model_config.enable_return_routed_experts:
+            return _refuse("routed_experts")
+        if getattr(runner, "calculate_kv_scales", False):
+            return _refuse("kv_scales")
+        if getattr(runner, "dynamic_eplb", False):
+            return _refuse("dynamic_eplb")
+        if runner.debugger is not None:
+            return _refuse("debugger")
+        if runner.ascend_config.profiling_chunk_config.enabled:
+            return _refuse("profiling_chunk")
+        from vllm.distributed.ec_transfer import get_ec_transfer, has_ec_transfer
+
+        if has_ec_transfer() and get_ec_transfer().is_producer:
+            return _refuse("ec_transfer_producer")
+        model = runner.model
+        # Model capability contract (declared via supports_multi_step_decode):
+        # preprocess() builds decode embeddings from request-local state,
+        # make_omni_output advances that state in place.
+        if not getattr(model, "has_preprocess", False) or not hasattr(model, "make_omni_output"):
+            return _refuse("model_contract_missing")
+        sampling_metadata = runner.input_batch.sampling_metadata
+        if not sampling_metadata.no_penalties:
+            return _refuse("penalties")
+        if runner.input_batch.bad_words_token_ids:
+            return _refuse("bad_words")
+        if not runner.input_batch.no_allowed_token_ids:
+            return _refuse("allowed_token_ids")
+        if runner.input_batch.logprob_token_ids:
+            return _refuse("logprob_token_ids")
+        max_num_logprobs = sampling_metadata.max_num_logprobs
+        if max_num_logprobs is not None and max_num_logprobs > 0:
+            return _refuse("max_num_logprobs")
+        if runner.num_prompt_logprobs:
+            return _refuse("prompt_logprobs")
+        # NOTE: no per-step mutable-state re-checks here (prefill phase,
+        # batch composition).  Under async scheduling the runner's
+        # input_batch view lags the scheduler -- the plan is validated
+        # before _update_states syncs it -- so those checks would produce
+        # false refusals.  A refusal after the scheduler planned follow-up
+        # windows on top of this one is NOT recoverable by shrinking: the
+        # follow-up plan's KV positions would skip this window's reserved
+        # slots, leaving holes of uninitialized cache that corrupt every
+        # later step.  The scheduler side already gates phase/batch with
+        # authoritative state (_request_admits_multi_step), so the runner
+        # only re-checks static configuration above.
+        global _executed_windows
+        _executed_windows += 1
+        return plan
+    except Exception:
+        logger.exception("Multi-step plan validation failed; using single-step decode")
+        return None
+
+
+def shrink_refused_multi_step_window(scheduler_output: SchedulerOutput) -> None:
+    """Shrink a runner-refused window back to a plain single-token step.
+
+    The scheduler-side plan bumped ``num_scheduled_tokens`` to K and reserved
+    K-1 extra KV slots per request.  If this runner refuses to host the
+    window, executing that K-token schedule as a plain multi-token decode
+    would be wrong twice over: the talker rebuilds every decode embedding
+    from the request-local codec chain, so rows 1..K-1 would run with stale
+    embeddings, and the step reports only one sampled token per request
+    while KV writes land on all K slots.  The polluted cache slots and the
+    phantom positions permanently corrupt every later step (the scheduler
+    reconcile only rolls back accounting, not cache contents).
+
+    Shrinking to one token per request makes the fallback bit-identical to a
+    never-planned step; the scheduler-side ``reconcile_window_shortfall``
+    rolls back the K-1 unused slot reservations.
+    """
+    plan = getattr(scheduler_output, "multi_step_plan", None)
+    if not plan:
+        return
+    reclaimed = 0
+    for req_id, planned in plan.items():
+        scheduled = int(scheduler_output.num_scheduled_tokens.get(req_id, 0))
+        if scheduled > 1:
+            scheduler_output.num_scheduled_tokens[req_id] = 1
+            reclaimed += scheduled - 1
+    if reclaimed:
+        scheduler_output.total_num_scheduled_tokens -= reclaimed
+
+
+def execute_multi_step_window(
+    runner: Any, scheduler_output: SchedulerOutput, plan: dict[str, int]
+) -> None:
+    """Replay the K decode steps of the window inside this one call.
+
+    On return the assembled ``OmniModelRunnerOutput`` is stashed in
+    ``runner._multi_step_pending_output`` for ``sample_tokens()``.
+    """
+    window_k = next(iter(plan.values()))
+
+    global _executed_steps
+    _executed_steps += window_k
+    if _executed_steps % (window_k * 50) == window_k or _executed_steps == window_k:
+        logger.info(
+            "Multi-step counters: executed_windows=%d executed_steps=%d refusals=%s",
+            _executed_windows, _executed_steps, dict(sorted(_refusal_counts.items())),
+        )
+
+    with record_function_or_nullcontext("multi_step_window"):
+        with runner.synchronize_input_prep():
+            deferred = runner._update_states(scheduler_output)
+            if deferred is not None:
+                # Mamba/spec corrections are gated off for windows; apply
+                # eagerly so per-step state starts consistent.
+                deferred()
+
+            # Batch identity must be read after _update_states: under async
+            # scheduling the plan may admit requests the input_batch has not
+            # seen yet (the scheduler's plan is authoritative for the step).
+            num_reqs = runner.input_batch.num_reqs
+            req_ids = list(runner.input_batch.req_ids)
+            ones = np.ones(num_reqs, dtype=np.int32)
+
+            # Uniform decode layout: one query token per request, frozen for
+            # the whole window (the batch composition cannot change mid-window).
+            runner.query_start_loc.np[0] = 0
+            runner.query_start_loc.np[1 : num_reqs + 1] = runner.arange_np[1 : num_reqs + 1]
+            runner.query_start_loc.copy_to_gpu()
+            runner.query_start_loc.gpu[num_reqs + 1 :].fill_(-1)
+            runner.query_pos.np[:num_reqs] = 0
+            runner.query_pos.copy_to_gpu(num_reqs)
+            runner.req_indices.np[:num_reqs] = runner.arange_np[:num_reqs]
+            runner.req_indices.copy_to_gpu(num_reqs)
+            runner.num_scheduled_tokens.np[:num_reqs] = ones
+            runner.num_scheduled_tokens.copy_to_gpu(num_reqs)
+            runner.decode_token_per_req = 1
+            runner._build_attn_state(num_reqs, ones, ones)
+            runner.query_lens = torch.from_numpy(ones)
+            runner.logits_indices = runner.query_start_loc.gpu[1 : num_reqs + 1] - 1
+            runner.with_prefill = False
+            runner.num_discarded_requests = 0
+            runner.discard_request_mask.np[:num_reqs] = False
+            runner.discard_request_mask.copy_to_gpu(num_reqs)
+            runner._omni_num_scheduled_tokens_np = ones
+
+            runner.input_batch.block_table.commit_block_table(num_reqs)
+
+            (
+                cudagraph_mode,
+                batch_desc,
+                _should_ubatch,
+                _num_tokens_across_dp,
+                cudagraph_stats,
+            ) = runner._determine_batch_execution_and_padding(
+                num_tokens=num_reqs,
+                num_reqs=num_reqs,
+                num_scheduled_tokens_np=ones,
+                max_num_scheduled_tokens=1,
+                use_cascade_attn=False,
+                force_eager=runner.model_config.enforce_eager,
+            )
+            num_tokens_padded = batch_desc.num_tokens
+
+            # Mirror model_runner_v1._pad_query_start_loc_for_fia (FULL branch):
+            # under FULL graph replay, FIA's TND layout requires
+            # sum(query_start_loc) == hidden_states rows.  When cudagraph
+            # padding added rows (num_tokens_padded > num_reqs), insert one
+            # dummy request whose query covers the padding instead of leaving
+            # the -1 sentinels in place -- actual_seq_lengths_q containing -1
+            # makes aclnnFusedInferAttentionScoreV3 fail with error 561002
+            # (batch=1 windows have no padding, which is why they pass).
+            # The dummy's KV row points at block 0 (filled by
+            # _build_attention_metadata) and never writes the cache because
+            # reshape_and_cache slices to the unpadded token count.
+            num_reqs_padded = num_reqs
+            if cudagraph_mode == CUDAGraphMode.FULL and num_tokens_padded > num_reqs:
+                runner.query_start_loc.np[num_reqs_padded + 1] = num_tokens_padded
+                num_reqs_padded += 1
+                runner.query_start_loc.copy_to_gpu()
+
+            input_ids = runner.input_ids.gpu[:num_tokens_padded]
+            inputs_embeds = runner.inputs_embeds.gpu[:num_tokens_padded]
+            positions = runner.positions[:num_tokens_padded]
+            logits_indices = runner.logits_indices
+            sampling_metadata = runner.input_batch.sampling_metadata
+
+            # Step 0 consumes the token sampled by the previous engine step
+            # via the async-scheduling feedback path.
+            prev_sampled = runner.input_batch.prev_sampled_token_ids
+            prev_index = runner.input_batch.prev_req_id_to_index or {}
+            if prev_sampled is not None:
+                for i, req_id in enumerate(req_ids):
+                    row = prev_index.get(req_id)
+                    if row is None:
+                        continue
+                    input_ids[i] = prev_sampled[row, 0]
+            else:
+                runner.input_ids.copy_to_gpu(num_reqs)
+
+            kv_connector_output = None
+            per_req_hidden: list[list[torch.Tensor]] = [[] for _ in range(num_reqs)]
+            per_req_deltas: list[list[torch.Tensor]] = [[] for _ in range(num_reqs)]
+            per_req_finished = [False] * num_reqs
+            sampled_steps: list[torch.Tensor] = []
+            comp_cpu = runner.input_batch.num_computed_tokens_cpu
+            steps_done = 0
+
+            for step in range(window_k):
+                with record_function_or_nullcontext("multi_step_window:step"):
+                    if step > 0:
+                        comp_cpu[:num_reqs] += 1
+                        for req_id in req_ids:
+                            req_state = runner.requests.get(req_id)
+                            if req_state is not None:
+                                req_state.num_computed_tokens += 1
+                    # Fresh CPU staging tensor per copy: the pinned batch
+                    # buffer is rewritten next step while this H2D copy may
+                    # still be in flight.
+                    runner.num_computed_tokens[:num_reqs].copy_(
+                        torch.from_numpy(comp_cpu[:num_reqs].copy()), non_blocking=True
+                    )
+                    runner.positions[:num_reqs] = runner.num_computed_tokens[:num_reqs].to(torch.int64)
+                    runner.positions[num_reqs:num_tokens_padded].zero_()
+                    runner.seq_lens[:num_reqs] = (
+                        runner.num_computed_tokens[:num_reqs]
+                        + runner.num_scheduled_tokens.gpu[:num_reqs]
+                    )
+                    runner.seq_lens[num_reqs:].fill_(0)
+                    runner.optimistic_seq_lens_cpu[:num_reqs].copy_(
+                        torch.from_numpy(comp_cpu[:num_reqs] + 1)
+                    )
+                    runner.optimistic_seq_lens_cpu[num_reqs:].fill_(0)
+                    runner.input_batch.block_table.compute_slot_mapping(
+                        num_reqs,
+                        runner.query_start_loc.gpu[: num_reqs + 1],
+                        runner.positions[:num_reqs],
+                    )
+                    update_cos_sin(positions)
+
+                    (attn_metadata, _spec_common) = runner._build_attention_metadata(
+                        num_tokens=num_reqs,
+                        num_reqs=num_reqs,
+                        max_query_len=1,
+                        num_tokens_padded=num_tokens_padded,
+                        num_reqs_padded=num_reqs_padded,
+                        ubatch_slices=None,
+                        logits_indices=logits_indices,
+                        use_spec_decode=False,
+                        num_scheduled_tokens={req_id: 1 for req_id in req_ids},
+                        num_scheduled_tokens_np=ones,
+                        cascade_attn_prefix_lens=None,
+                    )
+
+                    # Per-request decode embeddings: the talker derives its
+                    # input from the previous step's sampled codec token
+                    # (request-local state advanced in place by
+                    # make_omni_output).
+                    for i, req_id in enumerate(req_ids):
+                        req_state = runner.requests.get(req_id)
+                        info = runner.model_intermediate_buffer.get(req_id)
+                        if info is None:
+                            info = runner.model_intermediate_buffer.setdefault(req_id, {})
+                        info["request_id"] = req_id
+                        info["duplex_token_offset"] = int(comp_cpu[i])
+                        info["duplex_prompt_len"] = (
+                            len(req_state.prompt_token_ids) if req_state is not None else None
+                        )
+                        info["_omni_prompt_len"] = (
+                            len(req_state.prompt_token_ids) if req_state is not None else 0
+                        )
+                        info["_omni_num_computed_tokens"] = int(comp_cpu[i])
+                        info["_omni_is_prefill"] = False
+                        req_input_ids, req_embeds, update_dict = runner.model.preprocess(
+                            input_ids=runner.input_ids.gpu[i : i + 1],
+                            input_embeds=inputs_embeds[i : i + 1],
+                            **info,
+                        )
+                        seg_len = min(1, int(req_embeds.shape[0]))
+                        if seg_len:
+                            inputs_embeds[i : i + seg_len] = req_embeds[:seg_len]
+                        if isinstance(req_input_ids, torch.Tensor) and req_input_ids.numel() == 1:
+                            runner.input_ids.gpu[i] = req_input_ids.reshape(-1)[0]
+                        if update_dict:
+                            runner._update_intermediate_buffer(req_id, update_dict)
+
+                    with (
+                        set_ascend_forward_context(
+                            attn_metadata,
+                            runner.vllm_config,
+                            num_tokens=num_tokens_padded,
+                            num_tokens_across_dp=None,
+                            aclgraph_runtime_mode=cudagraph_mode,
+                            batch_descriptor=batch_desc,
+                            num_actual_tokens=num_reqs,
+                            model_instance=runner.model,
+                            max_tokens_across_pcp=0,
+                            skip_compiled=False,
+                        ),
+                        runner.maybe_get_kv_connector_output(scheduler_output) as kv_output_step,
+                    ):
+                        hidden_states = runner._model_forward(
+                            num_tokens_padded, input_ids, positions, None, inputs_embeds
+                        )
+                    kv_connector_output = kv_output_step
+
+                hidden_states, mm_outputs = runner.extract_multimodal_outputs(hidden_states)
+
+                # Intermediate steps skip the full OmniOutput wire wrapping:
+                # hidden rows and codec deltas are accumulated and shipped
+                # once at window end.
+                audio_deltas = None
+                finished_flags = None
+                if isinstance(mm_outputs, dict):
+                    codes = mm_outputs.get("codes")
+                    if isinstance(codes, dict):
+                        audio_deltas = codes.get("audio")
+                    meta = mm_outputs.get("meta")
+                    if isinstance(meta, dict):
+                        finished_flags = meta.get("finished")
+                for i in range(num_reqs):
+                    per_req_hidden[i].append(hidden_states[i : i + 1].detach())
+                    if audio_deltas is not None and i < len(audio_deltas):
+                        delta = audio_deltas[i]
+                        if isinstance(delta, torch.Tensor) and delta.numel():
+                            per_req_deltas[i].append(delta)
+                    if finished_flags is not None and i < len(finished_flags):
+                        flag = finished_flags[i]
+                        if isinstance(flag, torch.Tensor):
+                            per_req_finished[i] = per_req_finished[i] or bool(flag.item())
+                        else:
+                            per_req_finished[i] = per_req_finished[i] or bool(flag)
+
+                sample_hidden_states = hidden_states[logits_indices]
+                try:
+                    logits = runner.model.compute_logits(
+                        sample_hidden_states, sampling_metadata=sampling_metadata
+                    )
+                except TypeError:
+                    logits = runner.model.compute_logits(sample_hidden_states)
+                if step == 0:
+                    # Fill the previous engine step's pending placeholder
+                    # exactly like the normal _sample path would.
+                    runner.input_batch.update_async_output_token_ids()
+                # Mirror _sample's custom-sampler branch (npu_ar_model_runner
+                # _sample): logit bias -> duplex hook -> model sampler with
+                # prepared metadata, falling back to the engine sampler when
+                # the model sampler declines.  Keeping this identical to the
+                # single-step path is what allows prefer_model_sampler models
+                # (e.g. the MiniCPM-o talker) to host windows.
+                model_sample = getattr(runner.model, "sample", None)
+                if callable(model_sample) and getattr(runner.model, "prefer_model_sampler", False):
+                    if hasattr(runner.sampler, "logit_bias_state"):
+                        runner.sampler.logit_bias_state.apply_logit_bias(
+                            logits,
+                            runner.input_batch.expanded_idx_mapping,
+                            runner.input_batch.idx_mapping_np,
+                            runner.input_batch.positions[runner.input_batch.logits_indices],
+                        )
+                    prepared_sampling_metadata = runner._sampling_metadata_for_model_sampler(
+                        sampling_metadata
+                    )
+                    runner._apply_duplex_sampling(logits, prepared_sampling_metadata)
+                    sampler_output = model_sample(logits, prepared_sampling_metadata)
+                    if sampler_output is None:
+                        sampler_output = runner.sampler(
+                            logits=logits, sampling_metadata=sampling_metadata
+                        )
+                else:
+                    sampler_output = runner.sampler(
+                        logits=logits, sampling_metadata=sampling_metadata
+                    )
+                sampled_steps.append(sampler_output.sampled_token_ids)
+                steps_done = step + 1
+
+                # Mirror _bookkeeping_sync's async bookkeeping: one -1
+                # placeholder per request per step.  Values are filled at
+                # window end; only length-based processors (min_tokens)
+                # read them inside the window (penalties are gated off).
+                for i in range(num_reqs):
+                    pos = runner.input_batch.num_tokens_no_spec[i]
+                    runner.input_batch.token_ids_cpu[i, pos : pos + 1] = -1
+                    runner.input_batch.is_token_ids[i, pos : pos + 1] = True
+                    runner.input_batch.num_tokens_no_spec[i] = pos + 1
+                    req_state = runner.requests.get(req_ids[i])
+                    if req_state is not None:
+                        req_state.output_token_ids.append(-1)
+
+                # Early exit: every request already signalled completion;
+                # remaining steps would only burn device time on dead rows.
+                if steps_done < window_k and all(per_req_finished):
+                    logger.debug(
+                        "Multi-step window early exit at step %d/%d (all requests finished)",
+                        steps_done,
+                        window_k,
+                    )
+                    break
+
+            # ---- window end: materialize results ----
+            if steps_done < window_k:
+                sampled_steps = sampled_steps[:steps_done]
+            window_k = steps_done
+            sampled_all = torch.stack(sampled_steps, dim=0).reshape(window_k, num_reqs)
+            sampled_lists = sampled_all.cpu().tolist()
+
+            for i, req_id in enumerate(req_ids):
+                req_state = runner.requests.get(req_id)
+                if req_state is None:
+                    continue
+                out_ids = req_state.output_token_ids
+                for s in range(window_k):
+                    idx = len(out_ids) - window_k + s
+                    if 0 <= idx < len(out_ids) and out_ids[idx] == -1:
+                        out_ids[idx] = int(sampled_lists[s][i])
+
+            # Async feedback for the next engine step: the last window
+            # step's sampled token becomes the next input token.
+            runner.input_batch.prev_sampled_token_ids = sampled_steps[-1]
+            runner.input_batch.prev_req_id_to_index = {req_id: i for i, req_id in enumerate(req_ids)}
+            copy_stream = getattr(runner, "async_output_copy_stream", None)
+            if copy_stream is not None:
+                with torch.npu.stream(copy_stream):
+                    copy_stream.wait_stream(torch.npu.current_stream())
+                    last_sampled_cpu = sampled_steps[-1].to("cpu", non_blocking=True)
+                ready_event = torch.npu.Event(blocking=True)
+                ready_event.record(copy_stream)
+            else:
+                last_sampled_cpu = sampled_steps[-1].cpu()
+                ready_event = None
+            runner.input_batch.set_async_sampled_token_ids(last_sampled_cpu, ready_event)
+            runner.kv_connector_output = None
+
+            runner._multi_step_pending_output = _build_window_output(
+                runner,
+                req_ids,
+                sampled_lists,
+                per_req_hidden,
+                per_req_deltas,
+                per_req_finished,
+                kv_connector_output,
+                cudagraph_stats,
+            )
+
+
+def _build_window_output(
+    runner: Any,
+    req_ids: list[str],
+    sampled_per_step: list[list[int]],
+    per_req_hidden: list[list[torch.Tensor]],
+    per_req_deltas: list[list[torch.Tensor]],
+    per_req_finished: list[bool],
+    kv_connector_output: Any,
+    cudagraph_stats: CUDAGraphStat | None,
+) -> OmniModelRunnerOutput:
+    """Assemble the OmniModelRunnerOutput for a completed window.
+
+    ``sampled_per_step`` is [K][req_index]; the engine's reconciliation
+    consumes K sampled tokens per request, matching the K tokens the
+    scheduler reserved for the window step.  When the window exited early
+    only the produced steps are reported, and the scheduler-side
+    ``reconcile_window_shortfall`` rolls the reservation back.
+    """
+    num_reqs = len(req_ids)
+    window_k = len(sampled_per_step)
+    sampled_token_ids = [
+        [int(sampled_per_step[s][i]) for s in range(window_k)] for i in range(num_reqs)
+    ]
+
+    _engine_output_type, downstream_req_ids = runner._resolve_pooler_payload_req_ids(list(req_ids))
+    downstream_req_id_set = set(downstream_req_ids)
+    pooler_output: list[dict[str, object]] = []
+    for i, req_id in enumerate(req_ids):
+        if req_id not in downstream_req_id_set:
+            pooler_output.append({})
+            continue
+        payload: dict[str, object] = {}
+        # Hidden rows of the K window steps (tail-aligned per request); the
+        # talker batch is not the sparse-audio path (gated upstream).
+        if per_req_hidden[i]:
+            payload["hidden"] = torch.cat(per_req_hidden[i], dim=0).to("cpu").contiguous()
+        if per_req_deltas[i]:
+            payload["codes.audio"] = torch.cat(per_req_deltas[i], dim=0).to("cpu")
+        payload["meta.finished"] = torch.tensor(bool(per_req_finished[i]), dtype=torch.bool)
+        pooler_output.append(flatten_payload(payload))
+
+    pooler_output = pooler_output or []
+    if runner._async_chunk and stage_sends_async_output(runner.model_config):
+        pooler_inter, pooler_client = partition_payload_list(pooler_output)
+    else:
+        # Non-async-chunk ships the full payload to the next stage via
+        # inter_stage_outputs (the NPU runner has no separate full-payload
+        # accumulate).
+        pooler_inter, pooler_client = pooler_output, pooler_output
+
+    if pooler_inter and runner._should_accumulate_full_payload_output():
+        for i, req_id in enumerate(req_ids):
+            req_state = runner.requests.get(req_id)
+            if req_state is not None and pooler_inter[i]:
+                runner.accumulate_full_payload_output(req_id, pooler_inter[i], req_state)
+
+    inter_stage_outputs = runner._build_multimodal_outputs(pooler_inter)
+    multimodal_outputs = (
+        inter_stage_outputs
+        if pooler_client is pooler_inter
+        else runner._build_multimodal_outputs(pooler_client)
+    )
+    model_runner_output = OmniModelRunnerOutput(
+        req_ids=list(req_ids),
+        req_id_to_index={req_id: i for i, req_id in enumerate(req_ids)},
+        sampled_token_ids=sampled_token_ids,
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=None,
+        multimodal_outputs=multimodal_outputs,
+        inter_stage_outputs=inter_stage_outputs,
+        kv_connector_output=kv_connector_output,
+        ec_connector_output=None,
+        cudagraph_stats=cudagraph_stats,
+    )
+    model_runner_output.kv_extracted_req_ids = getattr(runner, "kv_extracted_req_ids", None)
+    runner.kv_extracted_req_ids = None
+    model_runner_output.omni_connector_output = runner.get_omni_connector_output()
+    return model_runner_output

--- a/vllm_omni/platforms/npu/worker/multi_step_decode.py
+++ b/vllm_omni/platforms/npu/worker/multi_step_decode.py
@@ -46,6 +46,7 @@ optimization.
 
 from __future__ import annotations
 
+import os
 from copy import copy
 from typing import Any
 
@@ -57,6 +58,7 @@ from vllm.logger import init_logger
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.utils import record_function_or_nullcontext
 from vllm_ascend.ascend_forward_context import set_ascend_forward_context
+import vllm_ascend.ops.rotary_embedding as vllm_ascend_rotary
 from vllm_ascend.ops.rotary_embedding import update_cos_sin
 
 from vllm_omni.data_entry_keys import flatten_payload
@@ -73,6 +75,14 @@ logger = init_logger(__name__)
 _refusal_counts: dict[str, int] = {}
 _executed_windows = 0
 _executed_steps = 0
+
+# WIA (window-internal amortization): second-order host-cost amortization
+# inside the K-step window, env-gated for A/B:
+#   OMNI_MSD_COS_PREBUILD=0  -> per-step update_cos_sin (default: prebuild)
+#   OMNI_MSD_TOK_FROM_STATE=0 -> device binary-token sampling (default: derive)
+# Both are pure optimizations with fallbacks; a failure never changes output.
+_COS_PREBUILD = os.environ.get("OMNI_MSD_COS_PREBUILD", "1") != "0"
+_TOK_FROM_STATE = os.environ.get("OMNI_MSD_TOK_FROM_STATE", "1") != "0"
 
 
 def _refuse(reason: str) -> None:
@@ -112,9 +122,10 @@ def validate_multi_step_plan(
         ):
             return _refuse("new_or_spec_or_encoder_reqs")
         # The window drives input feedback through the async-scheduling
-        # fast path; anything else falls back to the standard loop.
-        if not runner.use_async_scheduling:
-            return _refuse("no_async_scheduling")
+        # fast path; under sync scheduling the runner consumes the
+        # scheduler-provided input ids for step 0 instead (the
+        # prev_sampled_token_ids fallback below) and the async feedback
+        # tail is gated on use_async_scheduling.  Both modes are valid.
         if runner.num_spec_tokens or runner.speculative_config is not None:
             return _refuse("spec_decode")
         pp_group = get_pp_group()
@@ -294,6 +305,104 @@ def _build_window_meta_copies(
         return None
 
 
+def _prebuild_window_cos_sin(
+    runner: Any, comp_cpu: Any, num_reqs: int, window_k: int
+) -> bool:
+    """Fill the rotary cos/sin rows for all K window steps in one call.
+
+    The per-step positions are ``comp_cpu[i] + j`` (request i, step j), so the
+    whole window's rotary rows are a single ``update_cos_sin`` over
+    ``K * num_reqs`` positions instead of K per-step calls (each an
+    index_select + repeat + chunk over the cos/sin cache).  The captured decode
+    graph reads rows ``0..num_reqs-1``; per step the loop copies the prebuilt
+    block ``j*num_reqs..(j+1)*num_reqs`` into those rows (a plain device
+    copy).  Returns False on any failure -- the caller keeps calling
+    ``update_cos_sin`` per step, so this is a pure optimization (never a
+    correctness dependency).
+    """
+    try:
+        import vllm_ascend.ops.rotary_embedding as _rot
+
+        cos = getattr(_rot, "_cos", None)
+        cache = getattr(_rot, "_cos_sin_cache", None)
+        if cos is None or cache is None:
+            return False
+        if window_k * num_reqs > int(cos.shape[1]):
+            return False
+        all_pos = torch.tensor(
+            [int(comp_cpu[i]) + j for i in range(num_reqs) for j in range(window_k)],
+            dtype=torch.long,
+            device=runner.device,
+        )
+        _rot.update_cos_sin(all_pos)
+        return True
+    except Exception as exc:  # prebuild must never break the request
+        logger.warning(
+            "Multi-step cos prebuild failed, falling back to per-step updates: %s", exc
+        )
+        return False
+
+
+def _derive_engine_tokens(
+    runner: Any,
+    req_ids: list[str],
+    per_req_finished: list[bool],
+    sampling_metadata: Any,
+) -> tuple[torch.Tensor | None, bool]:
+    """Derive the per-step binary STOP/CONTINUE tokens from request-local state.
+
+    The talker maps ``state.finished`` to the stop rows ``[-inf, 0]`` (STOP) /
+    ``[0, -inf]`` (CONTINUE) inside ``make_omni_output``, so under greedy
+    sampling the sampled binary token is exactly ``int(finished)`` once the
+    ``min_tokens`` mask is released (the mask forces CONTINUE while
+    ``len(output_token_ids) < min_tokens``).  Deriving it on the host skips the
+    device sampler path (logit prep + sample kernel + token gather) with
+    identical values -- verified by the per-token dump compare.
+
+    Returns ``(tokens_gpu, ok)``; ``ok=False`` means the caller must run the
+    device sampler (any request is non-greedy, duplex, or logit-biased).
+    """
+    if not _TOK_FROM_STATE:
+        return None, False
+    try:
+        # The derivation relies on argmax sampling and on the request-local
+        # state chain matching the device stop rows exactly; refuse on any
+        # feature that could break the mapping (logit bias, non-greedy,
+        # native duplex).
+        if hasattr(runner.sampler, "logit_bias_state"):
+            bias_state = runner.sampler.logit_bias_state
+            if bias_state is not None and getattr(bias_state, "use_logit_bias", None) is not None:
+                if np.any(bias_state.use_logit_bias):
+                    return None, False
+        if not getattr(sampling_metadata, "all_greedy", False):
+            return None, False
+        tokens: list[int] = []
+        for i, req_id in enumerate(req_ids):
+            info = runner.model_intermediate_buffer.get(req_id, {})
+            if info.get("native_duplex"):
+                return None, False
+            req_state = runner.requests.get(req_id)
+            params = req_state.sampling_params if req_state is not None else None
+            min_tokens = int(getattr(params, "min_tokens", 0) or 0) if params is not None else 0
+            # The sampler's min_tokens mask counts the request's produced
+            # output tokens.  The runner's request-local output list is the
+            # authoritative count here (the window path appends one
+            # placeholder per step); sampling_metadata.output_token_ids may
+            # be None when no logits processor requires it.
+            out_len = len(req_state.output_token_ids) if req_state is not None else 0
+            masked = out_len < min_tokens
+            tokens.append(1 if (per_req_finished[i] and not masked) else 0)
+        # Shape (num_reqs, 1) to match the engine sampler's sampled_token_ids
+        # (the async feedback and window-end .tolist() both index [row][0]).
+        # dtype=torch.int32 matches the engine token layout (async feedback is
+        # scattered into the int32 input_ids buffer; int64 src is rejected by
+        # aclnnInplaceScatter on the reorder path).
+        return torch.tensor(tokens, dtype=torch.int32, device=runner.device).reshape(-1, 1), True
+    except Exception as exc:  # never guess a token on uncertainty
+        logger.warning("Multi-step engine-token derivation failed, using device sampler: %s", exc)
+        return None, False
+
+
 def execute_multi_step_window(
     runner: Any, scheduler_output: SchedulerOutput, plan: dict[str, int]
 ) -> None:
@@ -401,7 +510,19 @@ def execute_multi_step_window(
                         continue
                     input_ids[i] = prev_sampled[row, 0]
             else:
+                # Sync scheduling: no async feedback.  The sync sample path
+                # caches the real sampled tokens in the runner's request state
+                # (async caches -1 placeholders instead and consumes them via
+                # the feedback path above), so the previous token per request
+                # is the last output token.  The staged input_ids.cpu is stale
+                # here -- the window path never runs _prepare_inputs -- so
+                # copy it first (fills the padded rows) then overwrite the
+                # live rows with the true previous token.
                 runner.input_ids.copy_to_gpu(num_reqs)
+                for i, req_id in enumerate(req_ids):
+                    req_state = runner.requests.get(req_id)
+                    if req_state is not None and req_state.output_token_ids:
+                        input_ids[i] = req_state.output_token_ids[-1]
 
             kv_connector_output = None
             per_req_hidden: list[list[torch.Tensor]] = [[] for _ in range(num_reqs)]
@@ -410,6 +531,14 @@ def execute_multi_step_window(
             sampled_steps: list[torch.Tensor] = []
             comp_cpu = runner.input_batch.num_computed_tokens_cpu
             steps_done = 0
+
+            # WIA: prebuild the rotary cos/sin rows for the whole
+            # window once (K*num_reqs positions in a single update_cos_sin);
+            # per step the loop only copies the prebuilt block into the rows
+            # the captured graph reads.  A failure keeps per-step updates.
+            cos_prebuilt = _COS_PREBUILD and _prebuild_window_cos_sin(
+                runner, comp_cpu, num_reqs, window_k
+            )
 
             for step in range(window_k):
                 with record_function_or_nullcontext("multi_step_window:step"):
@@ -441,7 +570,21 @@ def execute_multi_step_window(
                         runner.query_start_loc.gpu[: num_reqs + 1],
                         runner.positions[:num_reqs],
                     )
-                    update_cos_sin(positions)
+                    if cos_prebuilt:
+                        # Per-step block copy: move the prebuilt rows for
+                        # step j into rows 0..num_reqs-1 (the rows the
+                        # captured graph reads).  Same device values as a
+                        # fresh update_cos_sin for these positions.
+                        j0 = step * num_reqs
+                        j1 = j0 + num_reqs
+                        vllm_ascend_rotary._cos[:, :num_reqs].copy_(
+                            vllm_ascend_rotary._cos[:, j0:j1]
+                        )
+                        vllm_ascend_rotary._sin[:, :num_reqs].copy_(
+                            vllm_ascend_rotary._sin[:, j0:j1]
+                        )
+                    else:
+                        update_cos_sin(positions)
 
                     if step == 0:
                         (attn_metadata, _spec_common) = runner._build_attention_metadata(
@@ -561,46 +704,59 @@ def execute_multi_step_window(
                         else:
                             per_req_finished[i] = per_req_finished[i] or bool(flag)
 
-                sample_hidden_states = hidden_states[logits_indices]
-                try:
-                    logits = runner.model.compute_logits(
-                        sample_hidden_states, sampling_metadata=sampling_metadata
-                    )
-                except TypeError:
-                    logits = runner.model.compute_logits(sample_hidden_states)
-                if step == 0:
-                    # Fill the previous engine step's pending placeholder
-                    # exactly like the normal _sample path would.
-                    runner.input_batch.update_async_output_token_ids()
-                # Mirror _sample's custom-sampler branch (npu_ar_model_runner
-                # _sample): logit bias -> duplex hook -> model sampler with
-                # prepared metadata, falling back to the engine sampler when
-                # the model sampler declines.  Keeping this identical to the
-                # single-step path is what allows prefer_model_sampler models
-                # (e.g. the MiniCPM-o talker) to host windows.
-                model_sample = getattr(runner.model, "sample", None)
-                if callable(model_sample) and getattr(runner.model, "prefer_model_sampler", False):
-                    if hasattr(runner.sampler, "logit_bias_state"):
-                        runner.sampler.logit_bias_state.apply_logit_bias(
-                            logits,
-                            runner.input_batch.expanded_idx_mapping,
-                            runner.input_batch.idx_mapping_np,
-                            runner.input_batch.positions[runner.input_batch.logits_indices],
+                # Engine binary STOP/CONTINUE token.  WIA derives it
+                # from the request-local state chain (identical values under
+                # greedy sampling, skipping the device sampler path); any
+                # uncertainty falls back to the exact single-step sampler
+                # machinery below.
+                derived_tokens, tok_ok = _derive_engine_tokens(
+                    runner, req_ids, per_req_finished, sampling_metadata
+                )
+                if tok_ok:
+                    sampled_steps.append(derived_tokens)
+                else:
+                    sample_hidden_states = hidden_states[logits_indices]
+                    try:
+                        logits = runner.model.compute_logits(
+                            sample_hidden_states, sampling_metadata=sampling_metadata
                         )
-                    prepared_sampling_metadata = runner._sampling_metadata_for_model_sampler(
-                        sampling_metadata
-                    )
-                    runner._apply_duplex_sampling(logits, prepared_sampling_metadata)
-                    sampler_output = model_sample(logits, prepared_sampling_metadata)
-                    if sampler_output is None:
+                    except TypeError:
+                        logits = runner.model.compute_logits(sample_hidden_states)
+                    if step == 0:
+                        # Fill the previous engine step's pending placeholder
+                        # exactly like the normal _sample path would (async
+                        # scheduling only; sync has no pending placeholder).
+                        if hasattr(runner.input_batch, "update_async_output_token_ids"):
+                            runner.input_batch.update_async_output_token_ids()
+                    # Mirror _sample's custom-sampler branch (npu_ar_model_runner
+                    # _sample): logit bias -> duplex hook -> model sampler with
+                    # prepared metadata, falling back to the engine sampler when
+                    # the model sampler declines.  Keeping this identical to the
+                    # single-step path is what allows prefer_model_sampler models
+                    # (e.g. the MiniCPM-o talker) to host windows.
+                    model_sample = getattr(runner.model, "sample", None)
+                    if callable(model_sample) and getattr(runner.model, "prefer_model_sampler", False):
+                        if hasattr(runner.sampler, "logit_bias_state"):
+                            runner.sampler.logit_bias_state.apply_logit_bias(
+                                logits,
+                                runner.input_batch.expanded_idx_mapping,
+                                runner.input_batch.idx_mapping_np,
+                                runner.input_batch.positions[runner.input_batch.logits_indices],
+                            )
+                        prepared_sampling_metadata = runner._sampling_metadata_for_model_sampler(
+                            sampling_metadata
+                        )
+                        runner._apply_duplex_sampling(logits, prepared_sampling_metadata)
+                        sampler_output = model_sample(logits, prepared_sampling_metadata)
+                        if sampler_output is None:
+                            sampler_output = runner.sampler(
+                                logits=logits, sampling_metadata=sampling_metadata
+                            )
+                    else:
                         sampler_output = runner.sampler(
                             logits=logits, sampling_metadata=sampling_metadata
                         )
-                else:
-                    sampler_output = runner.sampler(
-                        logits=logits, sampling_metadata=sampling_metadata
-                    )
-                sampled_steps.append(sampler_output.sampled_token_ids)
+                    sampled_steps.append(sampler_output.sampled_token_ids)
                 steps_done = step + 1
 
                 # Mirror _bookkeeping_sync's async bookkeeping: one -1
@@ -644,20 +800,23 @@ def execute_multi_step_window(
                         out_ids[idx] = int(sampled_lists[s][i])
 
             # Async feedback for the next engine step: the last window
-            # step's sampled token becomes the next input token.
-            runner.input_batch.prev_sampled_token_ids = sampled_steps[-1]
-            runner.input_batch.prev_req_id_to_index = {req_id: i for i, req_id in enumerate(req_ids)}
-            copy_stream = getattr(runner, "async_output_copy_stream", None)
-            if copy_stream is not None:
-                with torch.npu.stream(copy_stream):
-                    copy_stream.wait_stream(torch.npu.current_stream())
-                    last_sampled_cpu = sampled_steps[-1].to("cpu", non_blocking=True)
-                ready_event = torch.npu.Event(blocking=True)
-                ready_event.record(copy_stream)
-            else:
-                last_sampled_cpu = sampled_steps[-1].cpu()
-                ready_event = None
-            runner.input_batch.set_async_sampled_token_ids(last_sampled_cpu, ready_event)
+            # step's sampled token becomes the next input token.  Sync
+            # scheduling consumes the sampled tokens through the normal
+            # scheduler path instead, so this whole tail is async-only.
+            if getattr(runner, "use_async_scheduling", False):
+                runner.input_batch.prev_sampled_token_ids = sampled_steps[-1]
+                runner.input_batch.prev_req_id_to_index = {req_id: i for i, req_id in enumerate(req_ids)}
+                copy_stream = getattr(runner, "async_output_copy_stream", None)
+                if copy_stream is not None:
+                    with torch.npu.stream(copy_stream):
+                        copy_stream.wait_stream(torch.npu.current_stream())
+                        last_sampled_cpu = sampled_steps[-1].to("cpu", non_blocking=True)
+                    ready_event = torch.npu.Event(blocking=True)
+                    ready_event.record(copy_stream)
+                else:
+                    last_sampled_cpu = sampled_steps[-1].cpu()
+                    ready_event = None
+                runner.input_batch.set_async_sampled_token_ids(last_sampled_cpu, ready_event)
             runner.kv_connector_output = None
 
             runner._multi_step_pending_output = _build_window_output(

--- a/vllm_omni/platforms/npu/worker/multi_step_decode.py
+++ b/vllm_omni/platforms/npu/worker/multi_step_decode.py
@@ -46,6 +46,7 @@ optimization.
 
 from __future__ import annotations
 
+from copy import copy
 from typing import Any
 
 import numpy as np
@@ -238,6 +239,61 @@ def shrink_refused_multi_step_window(scheduler_output: SchedulerOutput) -> None:
         scheduler_output.total_num_scheduled_tokens -= reclaimed
 
 
+def _build_window_meta_copies(
+    base_meta: dict[str, Any],
+    runner: Any,
+    num_reqs: int,
+    window_k: int,
+) -> list[dict[str, Any]] | None:
+    """Derive per-step attention metadata for steps 1..K-1 from the step-0
+    build.
+
+    A pure decode window only varies per step in the sequence lengths:
+    the block tables and slot mappings are live views of the runner's
+    buffers (per-step ``compute_slot_mapping`` refreshes them in place),
+    the query layout is frozen for the window, and the FIA attention
+    backend consumes ``seq_lens`` / ``seq_lens_list`` per layer.  So each
+    later step is a shallow copy of the step-0 metadata with only the
+    seq-len fields refreshed to ``base_lens + j``.
+
+    Returns ``None`` on any failure -- the caller then keeps building
+    metadata per step, so this is a pure optimization (never a
+    correctness dependency).
+    """
+    try:
+        if not isinstance(base_meta, dict) or not base_meta:
+            return None
+        base_lens = [
+            int(runner.optimistic_seq_lens_cpu[i]) for i in range(num_reqs)
+        ]
+        steps: list[dict[str, Any]] = []
+        for j in range(1, window_k):
+            meta_j: dict[str, Any] = {}
+            for key, md in base_meta.items():
+                cm = copy(md)
+                seq_lens_j = [base_lens[i] + j for i in range(num_reqs)]
+                # Replicate the builder's FIA TND dummy-request padding
+                # (extra rows beyond num_reqs carry a sentinel length).
+                pad = len(md.seq_lens_list) - num_reqs
+                padded_lens = seq_lens_j + ([1] * pad if pad > 0 else [])
+                cm.seq_lens_list = padded_lens
+                sl_t = md.seq_lens.new_tensor(padded_lens)
+                cm.seq_lens = sl_t
+                cm.seq_lens_cpu = sl_t
+                if hasattr(cm, "_seq_lens_cpu"):
+                    cm._seq_lens_cpu = sl_t
+                if hasattr(cm, "max_seq_len"):
+                    cm.max_seq_len = max(seq_lens_j)
+                meta_j[key] = cm
+            steps.append(meta_j)
+        return steps
+    except Exception as exc:  # prebuild must never break the request
+        logger.warning(
+            "Multi-step prebuild metadata failed, falling back to per-step builds: %s", exc
+        )
+        return None
+
+
 def execute_multi_step_window(
     runner: Any, scheduler_output: SchedulerOutput, plan: dict[str, int]
 ) -> None:
@@ -387,19 +443,44 @@ def execute_multi_step_window(
                     )
                     update_cos_sin(positions)
 
-                    (attn_metadata, _spec_common) = runner._build_attention_metadata(
-                        num_tokens=num_reqs,
-                        num_reqs=num_reqs,
-                        max_query_len=1,
-                        num_tokens_padded=num_tokens_padded,
-                        num_reqs_padded=num_reqs_padded,
-                        ubatch_slices=None,
-                        logits_indices=logits_indices,
-                        use_spec_decode=False,
-                        num_scheduled_tokens={req_id: 1 for req_id in req_ids},
-                        num_scheduled_tokens_np=ones,
-                        cascade_attn_prefix_lens=None,
-                    )
+                    if step == 0:
+                        (attn_metadata, _spec_common) = runner._build_attention_metadata(
+                            num_tokens=num_reqs,
+                            num_reqs=num_reqs,
+                            max_query_len=1,
+                            num_tokens_padded=num_tokens_padded,
+                            num_reqs_padded=num_reqs_padded,
+                            ubatch_slices=None,
+                            logits_indices=logits_indices,
+                            use_spec_decode=False,
+                            num_scheduled_tokens={req_id: 1 for req_id in req_ids},
+                            num_scheduled_tokens_np=ones,
+                            cascade_attn_prefix_lens=None,
+                        )
+                        # Prebuild the attention metadata for steps 1..K-1
+                        # from the step-0 build: pure decode windows only vary
+                        # in seq lengths per step, and the FIA backend reads
+                        # seq_lens / seq_lens_list per layer.  A failure here
+                        # just keeps the per-step builder below.
+                        prebuilt_steps = _build_window_meta_copies(
+                            attn_metadata, runner, num_reqs, window_k
+                        )
+                    elif prebuilt_steps is not None:
+                        attn_metadata = prebuilt_steps[step - 1]
+                    else:
+                        (attn_metadata, _spec_common) = runner._build_attention_metadata(
+                            num_tokens=num_reqs,
+                            num_reqs=num_reqs,
+                            max_query_len=1,
+                            num_tokens_padded=num_tokens_padded,
+                            num_reqs_padded=num_reqs_padded,
+                            ubatch_slices=None,
+                            logits_indices=logits_indices,
+                            use_spec_decode=False,
+                            num_scheduled_tokens={req_id: 1 for req_id in req_ids},
+                            num_scheduled_tokens_np=ones,
+                            cascade_attn_prefix_lens=None,
+                        )
 
                     # Per-request decode embeddings: the talker derives its
                     # input from the previous step's sampled codec token

--- a/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
@@ -46,6 +46,11 @@ from vllm_omni.distributed.omni_connectors.kv_transfer_manager import OmniKVTran
 from vllm_omni.distributed.omni_connectors.utils.config import get_stage_connector_role, stage_sends_async_output
 from vllm_omni.experimental.fullduplex.model_executor import DuplexSamplingRunnerMixin
 from vllm_omni.outputs import OmniModelRunnerOutput
+from vllm_omni.platforms.npu.worker.multi_step_decode import (
+    execute_multi_step_window,
+    shrink_refused_multi_step_window,
+    validate_multi_step_plan,
+)
 from vllm_omni.platforms.npu.worker.npu_model_runner import OmniNPUModelRunner
 from vllm_omni.utils.mm_outputs import build_mm_cpu, partition_payload_list, to_payload_element
 from vllm_omni.worker.omni_connector_model_runner_mixin import OmniConnectorModelRunnerMixin
@@ -142,6 +147,9 @@ class NPUARModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
             )
         self._downstream_payload_cache: dict[str, bool] = {}
         self._init_duplex_sampling_state()
+        # Completed multi-step window output awaiting sample_tokens(); see
+        # multi_step_decode.execute_multi_step_window.
+        self._multi_step_pending_output: OmniModelRunnerOutput | None = None
 
     def load_model(self, *args, **kwargs) -> None:
         super().load_model(*args, **kwargs)
@@ -455,6 +463,26 @@ class NPUARModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
             kv_connector_metadata = scheduler_output.kv_connector_metadata
             if kv_connector_metadata is not None:
                 get_kv_transfer_group().handle_preemptions(kv_connector_metadata)
+        #  -------------------------------------- Omni-new -------------------------------------------------
+
+        #  -------------------------------------- Omni-new -------------------------------------------------
+        # [Omni] Multi-step decode window.  When the scheduler emitted a
+        # window plan and this runner can host it, the K decode steps
+        # (forward -> sampling -> input feedback) run inside this single
+        # engine call; the built output is stashed for sample_tokens().
+        # Any refusal here falls back to the normal single-step path below
+        # -- the scheduler-side reconcile in update_from_output absorbs
+        # the accounting shortfall.
+        multi_step_plan = validate_multi_step_plan(self, scheduler_output)
+        if multi_step_plan is not None:
+            execute_multi_step_window(self, scheduler_output, multi_step_plan)
+            return None
+        # Runner declined the planned window: shrink the K-token schedule
+        # back to one token per request so the single-step fallback below
+        # never executes the un-produced K-1 slots (see
+        # shrink_refused_multi_step_window); the scheduler-side reconcile
+        # absorbs the reservation shortfall.
+        shrink_refused_multi_step_window(scheduler_output)
         #  -------------------------------------- Omni-new -------------------------------------------------
 
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
@@ -902,6 +930,14 @@ class NPUARModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
     def sample_tokens(
         self, grammar_output: GrammarOutput | None
     ) -> OmniModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors:
+        #  -------------------------------------- Omni-new -------------------------------------------------
+        # [Omni] A multi-step window already produced its full output inside
+        # execute_model(); hand it over unchanged.
+        pending_multi_step_output = self._multi_step_pending_output
+        if pending_multi_step_output is not None:
+            self._multi_step_pending_output = None
+            return pending_multi_step_output
+        #  -------------------------------------- Omni-new -------------------------------------------------
         kv_connector_output = self.kv_connector_output
         self.kv_connector_output = None
 

--- a/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 import time
 from collections.abc import Mapping
 from copy import copy, deepcopy
@@ -150,6 +151,21 @@ class NPUARModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
         # Completed multi-step window output awaiting sample_tokens(); see
         # multi_step_decode.execute_multi_step_window.
         self._multi_step_pending_output: OmniModelRunnerOutput | None = None
+        # Stage-1 per-step timing (env-gated diagnostic; OMNI_MSD_STEP_TIMING=1).
+        # ``off_*`` accumulates single-step decode calls (one token/request per
+        # step), ``win_*`` accumulates window calls (window_k tokens/request per
+        # call) so the two paths are compared on equal footing.
+        if os.environ.get("OMNI_MSD_STEP_TIMING"):
+            self._msd_timing: dict[str, float | int] = {
+                "off_total": 0.0,
+                "off_steps": 0,
+                "win_total": 0.0,
+                "win_tokens": 0,
+            }
+            self._msd_t0: float | None = None
+        else:
+            self._msd_timing = None
+            self._msd_t0 = None
 
     def load_model(self, *args, **kwargs) -> None:
         super().load_model(*args, **kwargs)
@@ -391,6 +407,8 @@ class NPUARModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
             self._execution_start_time = time.perf_counter()
         if self.execute_model_state is not None:
             raise RuntimeError("State error: sample_tokens() must be called after execute_model() returns None.")
+        if self._msd_timing is not None and scheduler_output.total_num_scheduled_tokens > 0:
+            self._msd_t0 = time.perf_counter()
 
         #  -------------------------------------- Omni-new -------------------------------------------------
         # [Omni] Handle KV transfer BEFORE updating states (which removes finished requests)
@@ -475,7 +493,16 @@ class NPUARModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
         # the accounting shortfall.
         multi_step_plan = validate_multi_step_plan(self, scheduler_output)
         if multi_step_plan is not None:
+            if self._msd_timing is not None:
+                self._msd_win_t0 = time.perf_counter()
             execute_multi_step_window(self, scheduler_output, multi_step_plan)
+            if self._msd_timing is not None:
+                self._msd_timing["win_total"] += time.perf_counter() - self._msd_win_t0
+                self._msd_timing["win_tokens"] += int(
+                    multi_step_plan[next(iter(multi_step_plan))]
+                )
+                self._msd_t0 = None
+                self._msd_log()
             return None
         # Runner declined the planned window: shrink the K-token schedule
         # back to one token per request so the single-step fallback below
@@ -892,7 +919,25 @@ class NPUARModelRunner(OmniNPUModelRunner, OmniConnectorModelRunnerMixin, Duplex
         if self.vllm_config.model_config.enable_return_routed_experts and hasattr(self, "_positions_cpu"):
             self._omni_routed_experts_d2h(scheduler_output)
 
+        if self._msd_timing is not None and self._msd_t0 is not None:
+            self._msd_timing["off_total"] += time.perf_counter() - self._msd_t0
+            self._msd_timing["off_steps"] += 1
+            self._msd_t0 = None
+            self._msd_log()
+
         return None
+
+    def _msd_log(self) -> None:
+        _msd = self._msd_timing
+        if _msd is None:
+            return
+        if int(_msd["off_steps"]) % 100 == 0 or int(_msd["win_tokens"]) % 1200 < 12:
+            off_ms = 1e3 * _msd["off_total"] / max(int(_msd["off_steps"]), 1)
+            win_ms = 1e3 * _msd["win_total"] / max(int(_msd["win_tokens"]), 1)
+            logger.info(
+                "MSD per-step=%.3fms (n=%d) MSD per-token=%.3fms (n=%d)",
+                off_ms, int(_msd["off_steps"]), win_ms, int(_msd["win_tokens"]),
+            )
 
     def _sample(
         self,


### PR DESCRIPTION
Fixes #7077.

## Purpose

This PR adds **Multi-Step Merged Decode** to vLLM-Omni: the scheduler merges K consecutive decode steps into a single scheduling round, and the runner replays all K steps inside one `execute_model` call. Each engine-loop iteration now produces K tokens per request instead of 1, amortizing the fixed per-step host cost of the engine loop (schedule, IPC, output processing, block-table maintenance) by K.

The mechanism is opt-in (`VLLM_OMNI_MULTI_STEP_STEPS`, default `0` = disabled, behavior identical to baseline), works under **both async and sync scheduling**, and is fully implemented with 41 unit tests.

> **Reading the numbers below.** MiniCPM-o 4.5 is served as a **three-stage pipeline**: an 8B thinker (understanding) → the talker (20-layer AR speech generation, the stage this PR optimizes) → Code2Wav (vocoder). E2EL and RTF are **end-to-end metrics diluted by the two untouched stages**: the talker's own per-token time drops **20-26%**, while the end-to-end RTF improves ~8% at c1. The `Stage1 time/token` column is the direct measure of this optimization; E2EL/RTF are its diluted end-to-end projection.

**Measured results** (MiniCPM-o 4.5 talker, Atlas 910B3, stage-1 FULL cudagraph baselines, 2 scheduling modes x 3 concurrency levels x {K=0, 6, 8, 12, 14} = 30 groups): every configuration improves, and the best window size per leg gives:

| Leg (FULL graph) | Best K | E2EL (K=0 baseline -> best) | RTF (K=0 baseline -> best) | Stage1 time/token (baseline -> best) |
|---|---|---|---|---|
| c1 x32, **sync** | 12 | 3230.6 -> **2990.9 ms (-7.4%)** | 0.7921 -> **0.7284 (-8.0%)** | 9.44 -> **7.50 ms (-20.6%)** |
| c1 x32, async | 6 | 3280.5 -> **3175.8 ms (-3.2%)** | 0.8034 -> **0.7758 (-3.4%)** | 9.71 -> 7.49 ms (-22.9%) |
| c4 x64, **sync** | 14 | 12178.5 -> **10719.0 ms (-12.0%)** | 2.9679 -> **2.5273 (-14.8%)** | 10.39 -> 8.14 ms (-21.7%) |
| c4 x64, async | 14 | 13178.5 -> **10455.2 ms (-20.7%)** | 3.2198 -> **2.4723 (-23.2%)** | 10.28 -> 7.62 ms (-25.9%) |
| c8 x128, **sync** | 12 | 21365.6 -> **19419.0 ms (-9.1%)** | 5.3879 -> **4.7595 (-11.7%)** | 10.71 -> 8.53 ms (-20.4%) |
| c8 x128, async | 8 | 21285.4 -> **19530.2 ms (-8.2%)** | 5.2250 -> **4.7967 (-8.2%)** | 10.75 -> 8.33 ms (-22.5%) |

All percentages are relative to the same leg's **K=0 (window disabled) baseline under stage-1 FULL cudagraph**. Audio output is identical to baseline: the c1 codec streams are bit-identical (per-token dump compare), and total audio duration is unchanged within <1% at c4/c8 (batching-order effects). Recommended window size: **K=12 for sync legs, K=14 for c4 async, K=8 for c8 async**; K=12 is the safest single choice across all legs.

### Background

vLLM-Omni splits a multimodal request into stages executed by independent engine processes. **AR stages** (e.g. the MiniCPM-o 4.5 TTS talker, 20 layers, hidden 768) are small models doing pure decode. Every generated token pays one full engine round trip:

```
schedule() -> [IPC] -> execute_model() -> sample_tokens() -> [IPC] -> update_from_output()
```

The per-step wall time has two components: a **fixed host share** (scheduling logic, message serialization, shared-memory transfer, output processing — roughly 2 ms per step under stage-1 FULL cudagraph) and the **device forward** (roughly 7-8 ms). Because the host share is paid once per token and the batch composition of a decode batch is highly stable (running batches do not take new requests mid-step), the host share can be amortized by replaying K consecutive steps inside one engine iteration and feeding each step's sampled token directly into the next.

Multi-step windows are **real sampling** (lossless — no draft/reject, no distribution change), mutually exclusive with spec decode, and gated on the talker stage's capability contract.

**Platform applicability**: the mechanism (planning / accounting / gating / capability contract) is platform-agnostic framework code; the K-step executor currently ships with the **NPU runner only**. Platforms without the executor are refused by a fail-closed static gate — enabling the flag elsewhere is a no-op. See Porting in the appendix.

## Test Plan

**Unit tests** (41, pure CPU, no NPU required):

```bash
python3 -m pytest tests/core/sched/test_multi_step_decode.py -q    # 30
python3 -m pytest tests/worker/test_multi_step_decode_runner.py -q # 11
```

Coverage: window-size resolution (config/env/clamping/invalid values), static gates (parallelism / spec decode / LoRA / mamba / platform refusal paths), capability contract (stage-qualified tts=True / llm=False, stage flag taking precedence over a blanket flag), plan rewriting (new-request / non-uniform batch / prefill-phase / penalty refusals, budget clamping, KV allocation failure with block-row sync, confirmed-length invariant), reconcile (full report no-op / shortfall rollback / clamping / empty report), runner validation (refusal paths + fail-closed exception fallback), and **both scheduling modes** (async placeholder accounting and sync direct accounting are both accepted end to end).

**Gate-open verification** (INFO level, no DEBUG needed):

```bash
grep "Multi-step counters" serve.log
# Multi-step counters: executed_windows=101 executed_steps=808
#                      refusals={'no_plan': 11, 'prefill_phase': 6}
```

`executed_windows > 0` with only expected fail-closed refusals (`no_plan`) means windows really execute; per-group windows/steps are also recorded in the appendix.

**Benchmark methodology** (full records in Appendix F): Atlas 910B3 single NPU; original `OpenBMB/MiniCPM-o-4_5` (bf16, not quantized); three stages co-located on one card; Seed-TTS EN branch, first 32/64/128 sessions for c1/c4/c8, request-rate `inf`, 2 warmups, no oversample; stage-1 `cudagraph_mode: FULL` for every group (including the K=0 baseline); serve restarted per group; Mean E2EL / TTFT / AUDIO_RTF + stage1 per-token time recorded. The same matrix is run under **async scheduling** and under **sync scheduling** (`async_scheduling: false` on stage 1), giving 2 x 3 x 5 = 30 groups.

Quick A/B: run the same serve config twice with `vllm bench serve --omni --save-result` (first without the env var, then with `VLLM_OMNI_MULTI_STEP_STEPS=<K>`) and compare the saved JSON.

## Test Result

Per-leg best window sizes (vs each leg's K=0 baseline, stage-1 FULL graph) are shown in Purpose. Summary of the full 30-group sweep (Appendix F):

- **Every windowed configuration improves both E2EL and RTF over its own K=0 baseline.** No configuration regressed.
- **Sync scheduling is the stronger showcase**: at c1 (the official single-concurrency metric) K=12 cuts E2EL by 7.4% and RTF by 8.0%; the same K under async cuts E2EL by 2.9%. Sync legs also keep K=6..14 all positive.
- **Stage1 per-token time drops 20-26% at the best K on every leg** — the engine-loop host share is amortized as designed.
- K=14 degrades the c1 legs (both modes) from burstier output pacing; K=8 under-amortizes at c1/c4. K=12 is the robust default; c4 async prefers K=14.

### Interpretation

**RTF and E2EL move together here** (unlike host/device-mixed stages): every leg's best K improves both, because the talker is the pipeline's step-rate bottleneck and the window reduces its step time directly.

**Sync vs async**: the sync scheduler keeps at most one window in flight (schedule -> execute -> update strictly serial), so window accounting is simpler (no placeholder fence, direct optimistic `num_computed_tokens` rollback) and windows stay open longer under load — hence larger, more consistent gains. Async scheduling overlaps planner and executor and closes windows more readily; it still gains, but less.

**E2EL vs stage1 per-token**: stage1 is one of three co-located stages, so the end-to-end gain (~7-20%) is smaller than the stage1 gain (~20-26%); the remainder of the pipeline (thinker, codec decoder) is untouched.

### Where the gain comes from, and its limits

Of the ~9.4 ms single-step time under stage-1 FULL cudagraph, the **engine-loop host share** (schedule, IPC round trips, `update_from_output`, block-table maintenance — roughly 2 ms) is amortized K-fold — this is the direct source of the gain. The **device forward plus runner-internal host work** (input prep, attention metadata, kernel launch, sampling — roughly 7.4 ms) executes every in-window step as usual and is not amortized, which caps the gain far below K-fold (measured ~20-26% at the stage level, consistent with a ~21% host share). Four boundaries:

1. **Per-step device syncs remain**: early-exit checks (`flag.item()`) and synchronous sampler readback interrupt the device pipeline each step, compressing the amortization gain.
2. **Multi-concurrency closes windows under bursty arrivals**: windows require an empty waiting queue and an all-decode batch; bursty arrivals are refused and each refused step pays the plan->reserve->reconcile churn. Under a steady stream the windows stay open (see appendix window counts).
3. **K-token burst emission perturbs the downstream pipeline**: stage2 consumes stage1 chunks with a tempo coupling; larger K means burstier chunks — the main cause of K=14's c1 regression and of the K=8/14 E2EL degradation at high concurrency.
4. **The host share is bounded**: amortizing it cannot remove the device forward; the ceiling is the host fraction of the step (~21% here), which is why the stage-level gain saturates around 20-26% rather than approaching K-fold.

**Engineering conclusion: recommend K=12 (opt-in), default 0** — with no configuration the behavior is identical to baseline. For c4-concurrency async deployments K=14 measured best; K=12 remains within noise of it.

## Appendix

### A. Design

#### A.1 Window planning and accounting

Async scheduling tracks in-flight tokens with `num_output_placeholders`. The window makes one engine step look like "one scheduling round, K sampled tokens per request":

- After the base schedule, the planner allocates K-1 extra KV slots (`allocate_slots`), appends the new blocks to `new_block_ids`, and inflates `placeholders += K-1`, `computed += K-1`, `num_in_flight_tokens += K-1`.
- Invariant: `computed - placeholders` (confirmed KV length) is unchanged by the patch — no vLLM core accounting is touched.
- When the runner reports K tokens, the async scheduler consumes the placeholders back to the pre-patch level.
- If fewer than K tokens were produced (early exit or single-step fallback), `reconcile_window_shortfall` rolls the extra reservation back so `computed` matches the actually-written KV slots.

Under **sync scheduling** no placeholder fence exists (one window in flight max, the engine loop is strictly serial), so the same patch only inflates `computed` and `num_in_flight_tokens`; the shortfall is rolled back directly.

#### A.2 Multi-concurrency safety

A frozen batch delays admission of new requests for K steps. The planner therefore refuses to open windows whenever the **waiting queue is non-empty** (new work is admitted first) or when the batch contains newly scheduled requests. Under bursty arrivals windows simply close and reopen; TTFT is not blocked by windowed steps.

#### A.3 Fail-closed three-layer gating

Any layer can refuse; refusal is always a lossless fallback to the normal single-step path, with the scheduler-side reconcile absorbing the reservation:

1. **Static gate** (scheduler): single rank, no spec decode, no LoRA, not encoder-decoder, not mamba-align, and platform has a window executor (currently NPU only).
2. **Plan gate**: per-request admission (decode phase, no logprobs/penalties/bad words/structured output), per-request budget clamp (remaining max_tokens / context), whole-window fallback on KV allocation failure.
3. **Runner validation**: re-checks everything against runner-local state (batch consistency, model contract, sampler constraints); any exception falls back to single step.

#### A.4 Model capability contract

A stage only opens windows if its model class declares the contract:

- Direct: `supports_multi_step_decode = True` on the AR model class; or
- Stage-qualified (wrapper architectures serving several stages): `supports_multi_step_stages = ("tts",)` — gating resolves per `model_config.model_stage`, so the thinker stage of the same wrapper never opens windows.

The contract requires:

- `preprocess(input_ids, input_embeds, **info)`: builds the step's decode embedding purely from the request-local state chain (previous sampled codec token + per-request cache);
- `make_omni_output`: advances that state chain in place;
- intermediate steps need no wire-format packaging — hidden states and codec deltas are accumulated and shipped once at window end.

Models that don't satisfy the contract simply don't declare it; the gates refuse and behavior is identical to baseline.

#### A.5 Runner K-step loop

One uniform decode layout is rebuilt up front and reused for all K steps (batch composition is frozen): `query_start_loc` / `query_pos` / `num_scheduled_tokens`, `_build_attn_state`, batch descriptor and cudagraph mode. Then per step:

```python
for step in range(window_k):
    # 1. advance computed/positions/seq_lens (host-side copies, non-blocking H2D)
    # 2. compute_slot_mapping (KV slot mapping)
    # 3. model.preprocess(): per-request embedding from request-local state
    # 4. set_ascend_forward_context + _model_forward
    # 5. extract_multimodal_outputs -> accumulate hidden / codec delta / finished
    # 6. binary STOP/CONTINUE token: derived from request-local state under
    #    greedy sampling (skips the device sampler; any uncertainty falls back
    #    to the exact single-step sampler path)
    # 7. bookkeeping: -1 placeholders in token_ids_cpu/output_token_ids
    #    (backfilled at window end)
    # 8. all requests finished -> early exit (skip dead rows' device time)
# window end: stack K sampled steps -> backfill -> async feedback path
#             (set_async_sampled_token_ids) -> _build_window_output
#             -> stashed as _multi_step_pending_output for sample_tokens()
```

Amortized per window: `schedule()`, IPC round trips, `_update_states`, block table commit, cudagraph decisions, output build/serialization. Two further in-window amortizations (WIA) trim the loop itself:

- **Rotary prebuild**: the window's `K * num_reqs` cos/sin rows are filled with one `update_cos_sin`; each step copies the prebuilt block into the rows the captured graph reads (a plain device copy) instead of per-step index-select/repeat/chunk.
- **Engine-token derivation**: the talker's binary STOP/CONTINUE token is `int(state.finished)` once the `min_tokens` mask is released, so the device logits-prep + sampler + token-gather path is skipped. Safety gates refuse on non-greedy / logit-bias / native-duplex sampling, and the derived tokens are emitted in the engine's token dtype (int32) so the async feedback scatter into the int32 `input_ids` buffer stays type-correct.

**FULL-graph padding (NPU-specific)**: under FULL cudagraph replay, FIA attention's TND layout requires `sum(query_start_loc) == hidden_states rows`. When cudagraph padding makes `num_tokens_padded > num_reqs`, the window loop mirrors the single-step `_pad_query_start_loc_for_fia` behavior by inserting a dummy request row (its KV rows point at block 0; `reshape_and_cache` slices by unpadded token count so nothing is written) and passes the padded `num_reqs_padded` to `_build_attention_metadata`.

### B. Changes

Framework-generic (scheduler side, platform-agnostic):

| File | Change |
|---|---|
| `vllm_omni/core/sched/multi_step_decode.py` | New: window planner (`plan_multi_step_window`), reconcile (`reconcile_window_shortfall`), static gate, capability resolution, budget clamp, `resolve_multi_step_steps`; async and sync accounting paths |
| `vllm_omni/core/sched/output.py` | Scheduler output gains `multi_step_plan: dict[str, int]` (req_id -> K) |
| `vllm_omni/core/sched/omni_ar_scheduler.py` | `schedule()` tail tries window planning (try/except, falls back); `update_from_output()` reconciles per plan |
| `vllm_omni/engine/arg_utils.py` | `multi_step_decode_steps: int = 0`, forwarded to model config |
| `vllm_omni/config/model.py` | `multi_step_decode_steps: int = 0` |

Platform rollout (NPU runner; other platforms pending port):

| File | Change |
|---|---|
| `vllm_omni/platforms/npu/worker/multi_step_decode.py` | New: fail-closed validation, K-step replay with WIA (rotary prebuild, engine-token derivation, lightweight bookkeeping), diagnostic counters |
| `vllm_omni/platforms/npu/worker/npu_ar_model_runner.py` | `execute_model()` head hook (validate -> execute -> return); `sample_tokens()` hands over the stashed output; env-gated per-step timing |

Model instance (MiniCPM-o 4.5; other models declare per the contract):

| File | Change |
|---|---|
| `vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py` | Wrapper declares stage-qualified `supports_multi_step_stages = ("tts",)` |
| `vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_tts.py` | Talker declares `supports_multi_step_decode = True` |

Tests: `tests/core/sched/test_multi_step_decode.py` (30), `tests/worker/test_multi_step_decode_runner.py` (11).

#### B.1 Commit breakdown

The PR is three commits, each self-contained and independently correct (reviewable in order):

1. **`Multi-step merged decode: K decode steps per engine step on async scheduling`** — the core mechanism: scheduler-side planning/accounting/reconcile, fail-closed three-layer gating, capability contract, the NPU runner's K-step replay loop, and the 41 unit tests. Everything works end to end on async scheduling.
2. **`Prebuild attention metadata for multi-step decode windows`** — inside the window loop, steps 1..K-1 reuse step-0's attention metadata (pure decode windows only vary in per-step sequence lengths); the per-step builder remains as fallback. First WIA item, still async-only.
3. **`Multi-step windows on sync scheduling + window-internal amortization`** — extends windows to the sync scheduler (direct accounting, step-0 input from the request-local output chain) and adds the remaining WIA items (rotary prebuild, engine-token derivation) plus the fixes that make both paths exact: the `min_tokens` mask is counted from the runner's request-local output length (the sampler metadata view is None on the window path, which stuck the mask and re-scheduled finished requests for ~1900 dead windows under sync), and derived tokens are emitted int32 to match the engine token layout (an int64 src crashes the input scatter on the batch-reorder path). Includes the env-gated stage1 timing used to produce the per-token numbers below.

### C. Usage

```bash
# 1) Environment variable (preferred for A/B)
export VLLM_OMNI_MULTI_STEP_STEPS=12   # 0=off (default); 2~16 = window size

# 2) deploy yaml, per-stage engine_extras (recommended for production)
#   vllm_omni/deploy/xxx.yaml -> stages[1]:
#     async_scheduling: false        # sync scheduling (optional; both modes supported)
#     engine_extras:
#       multi_step_decode_steps: 12
#   and platforms.npu.stages[1].compilation_config.cudagraph_mode: FULL

# 3) CLI
vllm serve ... --multi-step-decode-steps 12
```

### D. Tuning and porting

#### D.1 Window size K (swept: K=6/8/12/14)

- **Recommended K=12**: positive on every leg; best for sync c1/c8 and second-best (within noise) elsewhere. K=14 beats it only on the c4 legs; K=8 under-amortizes at c1/c4; K=14 degrades the c1 legs.
- RTF-first: K=12 (or K=14 on c4-async deployments); E2EL/P99-first: K=12 and watch the high-concurrency groups.
- Theory: with p = the amortizable engine-loop host share (~21% of the single-step time under stage-1 FULL graph), the single-stream stage gain approaches 1/(p/K + (1-p)) only if in-window per-step host cost stays below a full engine step and there are no intermediate syncs — in practice ~20-26%.

#### D.2 Deciding whether this class of optimization fits (methodology)

1. Look at the windowed stage's own metric first (stage1 wall time per token), to avoid multi-stage dilution; when E2E and stage metrics disagree, locate the mechanism with the stage metric, then inspect pipeline interaction.
2. Always verify the gates actually opened: `grep "Multi-step counters" serve.log` for `executed_windows > 0`; the planned-vs-executed gap is the refused-churn cost.
3. Repeat runs to calibrate noise; conclusions inside the noise band don't count.
4. E2EL distribution: larger K raises the share of tail requests with remainder steps; watch P99.

#### D.3 Porting to other models

Satisfy the capability contract, two steps:

1. Declare `supports_multi_step_decode = True` (wrapper architectures declare `supports_multi_step_stages` on the outer class).
2. Confirm `preprocess()` depends only on request-local state (per-step info comes from the runner's model-intermediate buffer, including `duplex_token_offset` / computed-token counts).

Models that don't satisfy the contract simply don't declare; gates refuse and behavior matches baseline.

#### D.4 Porting to other platforms (GPU/...)

The K-step executor currently ships with the NPU runner only. Three steps:

1. Add the `execute_model()` / `sample_tokens()` hooks on the target platform's AR runner (reuse the validation and K-step loop from the NPU worker module, replacing platform-specific forward-context / rotary calls).
2. Handle that platform's graph-replay padding constraint (on NPU: the FIA TND dummy request).
3. Relax the platform check in the static gate.

#### D.5 Known boundaries (gated automatically, no manual action needed)

- Structured output, logprobs, frequency/presence/repetition penalties, bad_words, allowed_token_ids
- Spec decode, LoRA, encoder-decoder, mamba align, PCP/DCP/CP, PP/TP/DP>1
- Routed experts, KV transfer criteria, prefix-cache-hit steps
- Non-empty waiting queue / steps scheduling new requests (multi-concurrency admission protection)

### E. Rollback

- Multi-step windows: remove `engine_extras.multi_step_decode_steps`, set it to 0, or unset the environment variable — behavior identical to baseline.
- Sync scheduling / FULL graph: restore the baseline deploy yaml (`async_scheduling` default, `cudagraph_mode: PIECEWISE`).
- Code level: revert the individual commits (no invasive changes beyond the config fields).

### F. Test records

**F.1 Protocol** — Atlas 910B3 single NPU; original `OpenBMB/MiniCPM-o-4_5` (bf16); three stages co-located; Seed-TTS EN, first 32/64/128 sessions (c1/c4/c8), request-rate `inf`, 2 warmups, no oversample; stage-1 `cudagraph_mode: FULL` for all groups; serve restarted per group; async and sync scheduling each measured over the full K sweep. Window execution confirmed per group via runner counters (`executed_windows`/`executed_steps`, only `no_plan` refusals). All groups completed with zero failed requests.

**F.2 Equivalence verification** — codec streams bit-identical between windowed and baseline runs (per-token dump compare, c1); total audio duration identical at c1 (134.92 s across every configuration); c4/c8 total durations within <1% across K (batching-order effects). The min_tokens and token-dtype fixes in commit 3 are what make the sync and async window paths exact.

**F.3 Full sweep** — `mode | conc | K | E2EL(ms) | TTFT(ms) | RTF | audio(s) | stage1 ms/token`. Stage1 ms/token: single-step path at K=0, window path at K>0.

**Sync scheduling:**

| conc | K=0 | K=6 | K=8 | K=12 | K=14 |
|---|---|---|---|---|---|
| c1 | E2EL 3230.6 / TTFT 425.4 / RTF 0.7921 / st1 9.44 | 3141.0 / 428.0 / 0.7658 / 7.91 | 3069.5 / 423.1 / 0.7460 / 7.65 | **2990.9 / 429.4 / 0.7284 / 7.50** | 3072.8 / 435.9 / 0.7475 / 7.44 |
| c4 | 12178.5 / 486.9 / 2.9679 / 10.39 | 11040.2 / 507.2 / 2.5938 / 8.66 | 10945.1 / 499.8 / 2.5813 / 8.52 | 11650.6 / 504.6 / 2.8189 / 8.48 | **10719.0 / 502.3 / 2.5273 / 8.14** |
| c8 | 21365.6 / 500.1 / 5.3879 / 10.71 | 19722.1 / 501.9 / 4.8991 / 8.79 | 20541.3 / 510.4 / 5.0195 / 8.64 | **19419.0 / 517.1 / 4.7595 / 8.53** | 20385.8 / 510.1 / 5.0072 / 8.47 |

**Async scheduling:**

| conc | K=0 | K=6 | K=8 | K=12 | K=14 |
|---|---|---|---|---|---|
| c1 | 3280.5 / 427.8 / 0.8034 / 9.71 | **3175.8 / 427.9 / 0.7758 / 7.49** | 3217.1 / 441.2 / 0.7832 / 7.20 | 3186.8 / 429.1 / 0.7776 / 6.71 | 3220.1 / 428.3 / 0.7848 / 6.66 |
| c4 | 13178.5 / 485.4 / 3.2198 / 10.28 | 11134.0 / 501.6 / 2.5895 / 8.45 | 12823.8 / 504.3 / 3.1465 / 8.37 | 11495.0 / 505.9 / 2.7416 / 8.19 | **10455.2 / 502.3 / 2.4723 / 7.62** |
| c8 | 21285.4 / 508.6 / 5.2250 / 10.75 | 20086.8 / 504.2 / 4.9678 / 8.34 | **19530.2 / 513.4 / 4.7967 / 8.33** | 20153.6 / 513.1 / 4.9753 / 7.81 | 20703.3 / 515.2 / 5.0991 / 7.68 |

Cell format: `E2EL(ms) / TTFT(ms) / RTF / stage1 ms-per-token`. Bold = best E2EL per leg; audio (s): c1 = 134.92 for every cell; c4 = 279.0-281.4; c8 = 531.6-538.8.

**F.4 Window counters** (representative; windows/steps at the best K per leg): sync c1 K12 251/3012, async c1 K6 601/3606, sync c4 K14 401/5614, async c4 K14 401/5614, sync c8 K12 851/10212, async c8 K8 1301/10408. Executed steps / K = executed windows (full windows; early exits reconciled by the scheduler shortfall path).

**F.5 Reproducibility notes** — run-to-run E2EL variance on this host is roughly +/-3% (c1). All groups above are single runs per cell; the best-K conclusions were double-checked with a repeated c1 sync K=12 A/B (-6.2% to -7.7% E2EL across repetitions, same direction).