### PR TITLE
[Model] Enable TP text encoder for Dreamzero

### DIFF
--- a/examples/online_serving/dreamzero/README.md
+++ b/examples/online_serving/dreamzero/README.md
@@ -42,14 +42,18 @@ If you run the DROID client on Python < 3.12, also install `typing-extensions`.
 
 ### Configure TP and CFG parallelism
 
-The bundled DreamZero configs intentionally keep only:
+The bundled DreamZero configs are deliberately few:
 
 | Config | Purpose |
 |---|---|
 | `vllm_omni/deploy/dreamzero.yaml` | Default TP=1, CFG parallel disabled |
 | `vllm_omni/deploy/dreamzero_tp1_cfg2.yaml` | TP=1, CFG parallel size=2 |
+| `vllm_omni/deploy/dreamzero_tp4.yaml` | TP=4 denoise, TP=4 UMT5 text encoder |
+| `vllm_omni/deploy/dreamzero_tp8.yaml` | TP=8 denoise, TP=8 UMT5 text encoder |
 
 For other topologies, use CLI parallelism flags and update stage 0 `devices` with `--stage-overrides`. The number of listed devices must match `tensor_parallel_size * cfg_parallel_size`.
+
+The two TP configs also set `parallel_config.text_encoder_tp_size`, which shards the UMT5-XXL text encoder over the same ranks as the DiT instead of replicating it on every card. It must be either `1` (replicated Hugging Face UMT5, the default) or equal to `tensor_parallel_size`; anything in between is rejected at startup. At startup the log line `DreamZero text encoder: ...` reports which encoder was built.
 
 TP=2 with CFG parallel disabled:
 

--- a/tests/diffusion/models/t5_encoder/test_umt5_encoder.py
+++ b/tests/diffusion/models/t5_encoder/test_umt5_encoder.py
@@ -1,0 +1,242 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""UMT5 differs from T5 by giving every block its own relative attention bias.
+
+``T5Stack`` has to do two things together for that to be correct: build a
+``relative_attention_bias`` table on every block, AND stop threading block 0's
+``position_bias`` through the rest. Doing only the first leaves 23 of DreamZero's
+24 tables dead; doing only the second feeds zeros into every block after the
+first. Neither mistake raises — the output is just silently wrong — so both
+halves are pinned here, along with the T5 default staying untouched for the
+pipelines that already ship on it (flux, hunyuan_video_1_5, ming_flash_omni).
+"""
+
+import pytest
+import torch
+from torch import nn
+from transformers import T5Config
+from vllm.config import DeviceConfig, VllmConfig, set_current_vllm_config
+
+from vllm_omni.diffusion.models.t5_encoder.t5_encoder import (
+    T5EncoderModel,
+    T5Stack,
+    UMT5EncoderModel,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+_T5_MODULE = "vllm_omni.diffusion.models.t5_encoder.t5_encoder"
+
+# Same shape as test_t5_encoder_tp.py's config, with DreamZero's gated-gelu.
+SMALL_UMT5_CONFIG = dict(
+    d_model=64,
+    d_kv=8,
+    d_ff=128,
+    num_heads=8,
+    num_layers=4,
+    vocab_size=256,
+    relative_attention_num_buckets=32,
+    relative_attention_max_distance=128,
+    is_gated_act=True,
+    dense_act_fn="gelu_new",
+    layer_norm_epsilon=1e-6,
+    feed_forward_proj="gated-gelu",
+)
+
+
+@pytest.fixture(scope="module")
+def umt5_config() -> T5Config:
+    return T5Config(**SMALL_UMT5_CONFIG)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def setup_tp_group(monkeypatch, mocker):
+    """TP=2, rank 0, on CPU — mirrors test_t5_encoder_tp.py's fixture."""
+    device_config = DeviceConfig(device="cpu")
+
+    monkeypatch.setattr("vllm.model_executor.layers.linear.get_tensor_model_parallel_world_size", lambda: 2)
+    monkeypatch.setattr(f"{_T5_MODULE}.get_tensor_model_parallel_world_size", lambda: 2)
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.vocab_parallel_embedding.get_tensor_model_parallel_world_size",
+        lambda: 2,
+    )
+
+    monkeypatch.setattr(f"{_T5_MODULE}.get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.vocab_parallel_embedding.get_tensor_model_parallel_rank",
+        lambda: 0,
+    )
+
+    mock_tp_group = mocker.MagicMock()
+    mock_tp_group.world_size = 2
+    mocker.patch("vllm.distributed.parallel_state.get_tp_group", return_value=mock_tp_group)
+
+    monkeypatch.setattr(f"{_T5_MODULE}.get_act_fn", lambda _: torch.nn.GELU())
+
+    with set_current_vllm_config(VllmConfig(device_config=device_config)):
+        yield
+
+
+def _bias_blocks(stack: T5Stack) -> list[int]:
+    """Indices of blocks that own a relative_attention_bias table.
+
+    T5SelfAttention only *assigns* the attribute when it has a bias, so this
+    probes with getattr rather than comparing against None.
+    """
+    return [
+        i
+        for i, block in enumerate(stack.block)
+        if getattr(block.layer[0].SelfAttention, "relative_attention_bias", None) is not None
+    ]
+
+
+class TestPerLayerBiasConstruction:
+    def test_umt5_builds_a_bias_table_on_every_block(self, umt5_config):
+        model = UMT5EncoderModel(umt5_config)
+
+        assert _bias_blocks(model.encoder) == list(range(umt5_config.num_layers))
+
+    def test_t5_default_is_unchanged(self, umt5_config):
+        """Guards the pipelines already shipping on T5EncoderModel."""
+        model = T5EncoderModel(umt5_config)
+
+        assert _bias_blocks(model.encoder) == [0]
+        assert model.encoder.per_layer_relative_attention_bias is False
+
+    def test_bias_tables_are_distinct_objects(self, umt5_config):
+        model = UMT5EncoderModel(umt5_config)
+
+        tables = {id(b.layer[0].SelfAttention.relative_attention_bias.weight) for b in model.encoder.block}
+        assert len(tables) == umt5_config.num_layers
+
+    def test_bias_table_is_full_width_not_sharded(self, umt5_config):
+        """The table is [buckets, heads] and is sliced per rank in compute_bias.
+
+        Sharding it as a parameter would break the bucket lookup, so it must
+        stay full width even at TP=2.
+        """
+        model = UMT5EncoderModel(umt5_config)
+
+        table = model.encoder.block[0].layer[0].SelfAttention.relative_attention_bias.weight
+        assert table.shape == (
+            umt5_config.relative_attention_num_buckets,
+            umt5_config.num_heads,
+        )
+
+
+class TestPositionBiasThreading:
+    """The other half of the coupled change: who computes the bias, per block."""
+
+    class _RecordingBlock(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.seen: list[torch.Tensor | None] = []
+
+        def forward(self, hidden_states, mask=None, position_bias=None):
+            self.seen.append(position_bias)
+            # Stand in for a real block's returned bias.
+            return hidden_states, torch.zeros(1)
+
+    def _run_with_stub_blocks(self, config: T5Config, per_layer: bool) -> list[list]:
+        shared = nn.Embedding(config.vocab_size, config.d_model)
+        stack = T5Stack(config, shared, per_layer_relative_attention_bias=per_layer)
+        stubs = [self._RecordingBlock() for _ in range(config.num_layers)]
+        stack.block = nn.ModuleList(stubs)
+        stack.embed_tokens = shared
+
+        stack(torch.zeros(1, 3, dtype=torch.long))
+        return [stub.seen for stub in stubs]
+
+    def test_umt5_gives_every_block_a_fresh_none(self, umt5_config):
+        seen = self._run_with_stub_blocks(umt5_config, per_layer=True)
+
+        # Every block recomputes its own bias (and re-adds the mask), matching
+        # HF UMT5Attention, which is constructed with
+        # has_relative_attention_bias=True for every layer.
+        assert all(s == [None] for s in seen)
+
+    def test_t5_threads_block_zero_forward(self, umt5_config):
+        seen = self._run_with_stub_blocks(umt5_config, per_layer=False)
+
+        assert seen[0] == [None]
+        for later in seen[1:]:
+            assert later[0] is not None
+
+
+class TestDreamZeroKeyNamespace:
+    """The exact key namespace DreamZeroPipeline._remap_text_encoder_key emits.
+
+    DreamZero routes its `action_head.text_encoder.*` stream through this
+    module's load_weights(). Its only weight source declares prefix="", so the
+    loader's strict check requires EVERY parameter to be filled — a namespace
+    drift here surfaces as a startup ValueError, or worse, as a partially
+    random encoder.
+    """
+
+    @staticmethod
+    def _dreamzero_weights(config: T5Config) -> list[tuple[str, torch.Tensor]]:
+        inner_dim = config.num_heads * config.d_kv
+        weights: list[tuple[str, torch.Tensor]] = [
+            ("shared.weight", torch.randn(config.vocab_size, config.d_model)),
+            ("encoder.final_layer_norm.weight", torch.randn(config.d_model)),
+        ]
+        for i in range(config.num_layers):
+            attn = f"encoder.block.{i}.layer.0.SelfAttention."
+            ff = f"encoder.block.{i}.layer.1.DenseReluDense."
+            weights += [
+                (attn + "q.weight", torch.randn(inner_dim, config.d_model)),
+                (attn + "k.weight", torch.randn(inner_dim, config.d_model)),
+                (attn + "v.weight", torch.randn(inner_dim, config.d_model)),
+                (attn + "o.weight", torch.randn(config.d_model, inner_dim)),
+                (
+                    attn + "relative_attention_bias.weight",
+                    torch.randn(config.relative_attention_num_buckets, config.num_heads),
+                ),
+                (f"encoder.block.{i}.layer.0.layer_norm.weight", torch.randn(config.d_model)),
+                (ff + "wi_0.weight", torch.randn(config.d_ff, config.d_model)),
+                (ff + "wi_1.weight", torch.randn(config.d_ff, config.d_model)),
+                (ff + "wo.weight", torch.randn(config.d_model, config.d_ff)),
+                (f"encoder.block.{i}.layer.1.layer_norm.weight", torch.randn(config.d_model)),
+            ]
+        return weights
+
+    def test_every_parameter_is_filled(self, umt5_config):
+        model = UMT5EncoderModel(umt5_config)
+
+        reported = model.load_weights(self._dreamzero_weights(umt5_config))
+
+        expected = set(dict(model.named_parameters()))
+        filled = {name for name in reported if name in expected}
+        assert expected - filled == set(), f"unfilled parameters: {sorted(expected - filled)}"
+
+    def test_streaming_one_key_at_a_time_is_equivalent(self, umt5_config):
+        """DreamZero feeds keys individually to keep the checkpoint stream lazy."""
+        model = UMT5EncoderModel(umt5_config)
+
+        filled: set[str] = set()
+        for entry in self._dreamzero_weights(umt5_config):
+            filled |= set(model.load_weights([entry]))
+
+        expected = set(dict(model.named_parameters()))
+        assert expected - {name for name in filled if name in expected} == set()
+
+    def test_qkv_and_gated_ffn_are_fused_and_sharded(self, umt5_config):
+        model = UMT5EncoderModel(umt5_config)
+        model.load_weights(self._dreamzero_weights(umt5_config))
+
+        local_heads = umt5_config.num_heads // 2
+        attn = model.encoder.block[0].layer[0].SelfAttention
+        assert attn.qkv_proj.weight.shape == (3 * local_heads * umt5_config.d_kv, umt5_config.d_model)
+
+        # wi_0 and wi_1 fuse into one MergedColumnParallelLinear, each half
+        # column-sharded: 2 * (d_ff / tp).
+        ffn = model.encoder.block[0].layer[1].DenseReluDense
+        assert ffn.wi.weight.shape == (2 * (umt5_config.d_ff // 2), umt5_config.d_model)
+
+    def test_unknown_key_fills_nothing(self, umt5_config):
+        model = UMT5EncoderModel(umt5_config)
+
+        reported = model.load_weights([("encoder.block.0.layer.0.SelfAttention.nope.weight", torch.randn(4))])
+
+        assert {name for name in reported if name in dict(model.named_parameters())} == set()

--- a/vllm_omni/deploy/dreamzero_tp4.yaml
+++ b/vllm_omni/deploy/dreamzero_tp4.yaml
@@ -1,0 +1,43 @@
+# DreamZero-DROID deploy: TP=4 denoise, TP=4 UMT5 text encoder, CFG parallel disabled.
+#
+# Topology is declared in vllm_omni/model_executor/models/dreamzero/pipeline.py.
+# `devices` are logical indices within the stage; pin physical cards with
+# ZE_AFFINITY_MASK (XPU) or CUDA_VISIBLE_DEVICES.
+#
+# `text_encoder_tp_size` must be either 1 (replicated Hugging Face UMT5, the
+# default everywhere else) or equal to `tensor_parallel_size`. Matching it puts
+# the UMT5-XXL encoder on the DiT's own TP group, so its ~10.6 GiB of weights
+# shard with the DiT instead of being replicated on every rank. The image
+# encoder and the Wan VAE stay replicated (~1.4 GiB combined).
+
+pipeline: dreamzero
+async_chunk: false
+distributed_executor_backend: mp
+dtype: bfloat16
+
+stages:
+  - stage_id: 0
+    devices: "0,1,2,3"
+    max_num_seqs: 1
+    enforce_eager: false
+    model_class_name: DreamZeroPipeline
+    # DreamZero runs on the AR-Diffusion engine (engine-level paged KV cache).
+    engine_backend: vllm_omni.experimental.ar_diffusion.engine.ARDiffusionEngine
+    parallel_config:
+      tensor_parallel_size: 4
+      text_encoder_tp_size: 4
+      cfg_parallel_size: 1
+    model_config:
+      default_robot_embodiment: roboarena
+      policy_server_config:
+        image_resolution: [180, 320]
+        n_external_cameras: 2
+        needs_wrist_camera: true
+        needs_stereo_camera: false
+        needs_session_id: true
+        action_space: joint_position
+    cache_backend: step_cache
+    cache_config:
+      step_cache_dit_enabled: true
+      velocity_sim_thresholds: [0.95, 0.93]
+      velocity_skip_countdowns: [4, 2]

--- a/vllm_omni/deploy/dreamzero_tp4.yaml
+++ b/vllm_omni/deploy/dreamzero_tp4.yaml
@@ -1,14 +1,9 @@
-# DreamZero-DROID deploy: TP=4 denoise, TP=4 UMT5 text encoder, CFG parallel disabled.
-#
-# Topology is declared in vllm_omni/model_executor/models/dreamzero/pipeline.py.
-# `devices` are logical indices within the stage; pin physical cards with
-# ZE_AFFINITY_MASK (XPU) or CUDA_VISIBLE_DEVICES.
-#
-# `text_encoder_tp_size` must be either 1 (replicated Hugging Face UMT5, the
-# default everywhere else) or equal to `tensor_parallel_size`. Matching it puts
-# the UMT5-XXL encoder on the DiT's own TP group, so its ~10.6 GiB of weights
-# shard with the DiT instead of being replicated on every rank. The image
-# encoder and the Wan VAE stay replicated (~1.4 GiB combined).
+# DreamZero-DROID: TP=4 denoise and text encoder, CFG parallel disabled.
+# Topology: vllm_omni/model_executor/models/dreamzero/pipeline.py.
+# Devices are logical indices; select physical cards with ZE_AFFINITY_MASK
+# (XPU) or CUDA_VISIBLE_DEVICES.
+# text_encoder_tp_size must be 1 (replicated UMT5) or tensor_parallel_size
+# (shared DiT TP group). CLIP and Wan VAE remain replicated.
 
 pipeline: dreamzero
 async_chunk: false

--- a/vllm_omni/deploy/dreamzero_tp8.yaml
+++ b/vllm_omni/deploy/dreamzero_tp8.yaml
@@ -1,0 +1,42 @@
+# DreamZero-DROID deploy: TP=8 denoise, TP=8 UMT5 text encoder, CFG parallel disabled.
+#
+# Same stage shape as dreamzero_tp4.yaml, widened to 8 ranks (DiT num_heads=40
+# -> 5 heads/rank; UMT5 num_heads=64 -> 8/rank). This halves both the DiT and
+# the text-encoder footprint relative to TP=4, at the cost of more collectives
+# over narrower per-rank work; throughput at this width is unmeasured. The image
+# encoder and the Wan VAE stay replicated (~1.4 GiB combined).
+#
+# See dreamzero_tp4.yaml for the `text_encoder_tp_size` contract: 1, or equal to
+# `tensor_parallel_size`.
+
+pipeline: dreamzero
+async_chunk: false
+distributed_executor_backend: mp
+dtype: bfloat16
+
+stages:
+  - stage_id: 0
+    devices: "0,1,2,3,4,5,6,7"
+    max_num_seqs: 1
+    enforce_eager: false
+    model_class_name: DreamZeroPipeline
+    # DreamZero runs on the AR-Diffusion engine (engine-level paged KV cache).
+    engine_backend: vllm_omni.experimental.ar_diffusion.engine.ARDiffusionEngine
+    parallel_config:
+      tensor_parallel_size: 8
+      text_encoder_tp_size: 8
+      cfg_parallel_size: 1
+    model_config:
+      default_robot_embodiment: roboarena
+      policy_server_config:
+        image_resolution: [180, 320]
+        n_external_cameras: 2
+        needs_wrist_camera: true
+        needs_stereo_camera: false
+        needs_session_id: true
+        action_space: joint_position
+    cache_backend: step_cache
+    cache_config:
+      step_cache_dit_enabled: true
+      velocity_sim_thresholds: [0.95, 0.93]
+      velocity_skip_countdowns: [4, 2]

--- a/vllm_omni/deploy/dreamzero_tp8.yaml
+++ b/vllm_omni/deploy/dreamzero_tp8.yaml
@@ -1,13 +1,7 @@
-# DreamZero-DROID deploy: TP=8 denoise, TP=8 UMT5 text encoder, CFG parallel disabled.
-#
-# Same stage shape as dreamzero_tp4.yaml, widened to 8 ranks (DiT num_heads=40
-# -> 5 heads/rank; UMT5 num_heads=64 -> 8/rank). This halves both the DiT and
-# the text-encoder footprint relative to TP=4, at the cost of more collectives
-# over narrower per-rank work; throughput at this width is unmeasured. The image
-# encoder and the Wan VAE stay replicated (~1.4 GiB combined).
-#
-# See dreamzero_tp4.yaml for the `text_encoder_tp_size` contract: 1, or equal to
-# `tensor_parallel_size`.
+# DreamZero-DROID: TP=8 denoise and text encoder, CFG parallel disabled.
+# DiT and UMT5 heads divide evenly across the eight ranks. CLIP and Wan VAE
+# remain replicated. See dreamzero_tp4.yaml for device placement and the
+# text_encoder_tp_size contract. Throughput at TP=8 is unmeasured.
 
 pipeline: dreamzero
 async_chunk: false

--- a/vllm_omni/diffusion/models/dreamzero/pipeline_dreamzero.py
+++ b/vllm_omni/diffusion/models/dreamzero/pipeline_dreamzero.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 """DreamZero pipeline for vllm-omni.
 

--- a/vllm_omni/diffusion/models/dreamzero/pipeline_dreamzero.py
+++ b/vllm_omni/diffusion/models/dreamzero/pipeline_dreamzero.py
@@ -22,7 +22,8 @@ import numpy as np
 import torch
 import torch.nn as nn
 from huggingface_hub import hf_hub_download
-from transformers import AutoTokenizer, UMT5Config, UMT5EncoderModel
+from transformers import AutoTokenizer, UMT5Config
+from transformers import UMT5EncoderModel as HFUMT5EncoderModel
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
 from vllm_omni.diffusion.cache.stepcache import (
@@ -54,6 +55,7 @@ from vllm_omni.diffusion.models.dreamzero.utils import (
     DEFAULT_SIGMA_SHIFT,
 )
 from vllm_omni.diffusion.models.schedulers.scheduling_flow_unipc_multistep import FlowUniPCMultistepScheduler
+from vllm_omni.diffusion.models.t5_encoder import UMT5EncoderModel as TPUMT5EncoderModel
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 from vllm_omni.experimental.ar_diffusion.capability import (
@@ -401,9 +403,31 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         tokenizer_source = od_config.model_paths.get("tokenizer", "google/umt5-xxl")
         self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_source)
 
+        # ---- Text encoder ----
+        # `text_encoder_tp_size` is the repository-wide knob
+        # (`DiffusionParallelConfig.text_encoder_tp_size`). DreamZero is a single
+        # diffusion stage, so the encoder runs inside the DiT's own worker and
+        # sharding it means riding the ambient vLLM TP group -- which is exactly
+        # the DiT's ranks. Matching the DiT TP size is therefore the only size
+        # that needs no process group of its own. A smaller encoder subgroup
+        # would need group-bound TP layers and belongs to stage topology, not to
+        # the encoder implementation.
+        text_encoder_tp_size = int(getattr(od_config.parallel_config, "text_encoder_tp_size", 1))
+        tensor_parallel_size = int(getattr(od_config.parallel_config, "tensor_parallel_size", 1))
+        if text_encoder_tp_size not in (1, tensor_parallel_size):
+            raise ValueError(
+                "DreamZero supports text_encoder_tp_size=1 (replicated Hugging Face UMT5) or "
+                f"text_encoder_tp_size == tensor_parallel_size ({tensor_parallel_size}), "
+                f"got {text_encoder_tp_size}."
+            )
+        self._text_encoder_tp_enabled = text_encoder_tp_size > 1
+
         # Instantiate from config; weights load through `load_weights()`.
         umt5_config = UMT5Config(
             d_model=4096,
+            # Explicit even though 64 is the HF default: the TP encoder derives
+            # inner_dim = num_heads * d_kv for its qkv/o partitioning.
+            d_kv=64,
             d_ff=10240,
             num_heads=64,
             num_layers=24,
@@ -414,7 +438,22 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
             feed_forward_proj="gated-gelu",
             is_encoder_decoder=False,
         )
-        self.text_encoder = UMT5EncoderModel(umt5_config)
+        if self._text_encoder_tp_enabled:
+            # Tensor-parallel UMT5 over the ambient TP group, so the ~10.6 GiB
+            # encoder is sharded instead of replicated on every rank.
+            # num_heads=64 and d_ff=10240 divide by every supported TP size.
+            # Returns a tuple, not a HF ModelOutput -- see `_encode_text`.
+            self.text_encoder = TPUMT5EncoderModel(umt5_config)
+        else:
+            self.text_encoder = HFUMT5EncoderModel(umt5_config)
+        # Both classes are named UMT5EncoderModel, so say which one. Requesting
+        # TP and silently getting the replicated encoder is otherwise invisible:
+        # startup succeeds and only the per-card footprint gives it away.
+        logger.info(
+            "DreamZero text encoder: %s UMT5 (text_encoder_tp_size=%d).",
+            "tensor-parallel" if self._text_encoder_tp_enabled else "replicated Hugging Face",
+            text_encoder_tp_size,
+        )
 
         self.image_encoder = DreamZeroImageEncoder()
 
@@ -674,12 +713,21 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         # block stays fullgraph even on that path.
         dit_compile = {"mode": "default", "fullgraph": True, "dynamic": False}
 
+        # At TP>1 the text encoder is sharded, so its forward carries two
+        # all-reduces per layer. Compile those under `default` for the same
+        # reason the DiT blocks already do, rather than reduce-overhead's
+        # CUDAGraph buffer reuse around the new collectives. TP=1 keeps today's
+        # kwargs untouched.
+        text_encoder_compile = {**compile_ro, "mode": "default"} if self._text_encoder_tp_enabled else compile_ro
+
         logger.info(
-            "DreamZero: torch.compile text/image/VAE encode + per-block DiT (encoders reduce-overhead, DiT default)."
+            "DreamZero: torch.compile text/image/VAE encode + per-block DiT "
+            "(text_encoder %s, image/VAE reduce-overhead, DiT default).",
+            text_encoder_compile["mode"],
         )
 
         try:
-            self.text_encoder.forward = torch.compile(self.text_encoder.forward, **compile_ro)
+            self.text_encoder.forward = torch.compile(self.text_encoder.forward, **text_encoder_compile)
         except Exception as exc:
             logger.warning("DreamZero: text_encoder compile failed (%s); skipping.", exc)
 
@@ -838,17 +886,36 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
     # -----------------------------------------------------------------------
 
     def _encode_text(self, text_tokens: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
-        """Encode text prompt via UMT5."""
+        """Encode text prompt via UMT5.
+
+        At ``text_encoder_tp_size > 1`` the encoder is tensor-parallel, so this
+        runs collectives on the DiT's TP group; the row-parallel projections
+        all-reduce back to the full 4096-dim hidden state, giving every rank the
+        identical result the DiT expects. The two implementations differ only in
+        how they wrap that tensor, and this method is the only place that knows.
+        """
         self._cudagraph_mark_step_begin()
         seq_lens = attention_mask.gt(0).sum(dim=1).long()
-        prompt_emb = self.text_encoder(
-            text_tokens,
-            attention_mask,
-        ).last_hidden_state
-        prompt_emb = prompt_emb.clone().to(dtype=torch.bfloat16)
-        for i, v in enumerate(seq_lens):
-            prompt_emb[:, v:] = 0
-        return prompt_emb
+        encoder_output = self.text_encoder(text_tokens, attention_mask)
+        if self._text_encoder_tp_enabled:
+            # The TP encoder returns a plain tuple, not a HF ModelOutput.
+            prompt_emb = encoder_output[0]
+        else:
+            prompt_emb = encoder_output.last_hidden_state
+        prompt_emb = prompt_emb.to(dtype=torch.bfloat16)
+        # Zero the padding tail with a sync-free position mask. The previous loop
+        # sliced by elements of the device-resident `seq_lens`, forcing a
+        # device->host sync per row, which at TP>1 would sit inside a collective
+        # region. `where` (not a multiply) keeps the old `= 0` semantics exactly,
+        # and returns a fresh tensor, which is what the old `.clone()` was for:
+        # it decouples the result from a CUDAGraph-owned output buffer. Masking
+        # is per row here, where the old loop truncated every row to the
+        # shortest row's length. Both callers tokenize exactly one string, so
+        # B == 1 and the two agree today; the per-row form is the correct one if
+        # that ever stops being true.
+        positions = torch.arange(prompt_emb.shape[1], device=prompt_emb.device)
+        keep = (positions.unsqueeze(0) < seq_lens.unsqueeze(1)).unsqueeze(-1)
+        return torch.where(keep, prompt_emb, 0.0)
 
     # -----------------------------------------------------------------------
     # Image encoding
@@ -1802,10 +1869,26 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
                 if mapped is None:
                     continue
                 for new_name in mapped if isinstance(mapped, list) else [mapped]:
-                    full_name = "text_encoder." + new_name
-                    if full_name in params:
-                        params[full_name].data.copy_(tensor)
-                        loaded.add(full_name)
+                    if self._text_encoder_tp_enabled:
+                        # Delegate to the encoder's own loader rather than
+                        # copying into the param: it is tensor-parallel, so each
+                        # param holds only this rank's shard and a full-width
+                        # `.data.copy_()` would raise. Its loader owns the
+                        # q/k/v -> qkv_proj and wi_0/wi_1 -> wi fusions (which
+                        # need shard ids) and the shared/embed_tokens alias. Fed
+                        # one key at a time to keep the checkpoint stream lazy.
+                        for filled in self.text_encoder.load_weights([(new_name, tensor)]):
+                            full_name = "text_encoder." + filled
+                            # The loader also reports pre-fusion checkpoint
+                            # names; keep only real parameters so the
+                            # pipeline-level coverage check stays meaningful.
+                            if full_name in params:
+                                loaded.add(full_name)
+                    else:
+                        full_name = "text_encoder." + new_name
+                        if full_name in params:
+                            params[full_name].data.copy_(tensor)
+                            loaded.add(full_name)
 
             elif name.startswith("action_head.image_encoder."):
                 self._remap_image_encoder_key(name, tensor, params, loaded)

--- a/vllm_omni/diffusion/models/dreamzero/pipeline_dreamzero.py
+++ b/vllm_omni/diffusion/models/dreamzero/pipeline_dreamzero.py
@@ -403,15 +403,9 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         tokenizer_source = od_config.model_paths.get("tokenizer", "google/umt5-xxl")
         self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_source)
 
-        # ---- Text encoder ----
-        # `text_encoder_tp_size` is the repository-wide knob
-        # (`DiffusionParallelConfig.text_encoder_tp_size`). DreamZero is a single
-        # diffusion stage, so the encoder runs inside the DiT's own worker and
-        # sharding it means riding the ambient vLLM TP group -- which is exactly
-        # the DiT's ranks. Matching the DiT TP size is therefore the only size
-        # that needs no process group of its own. A smaller encoder subgroup
-        # would need group-bound TP layers and belongs to stage topology, not to
-        # the encoder implementation.
+        # The text encoder runs inside the DiT worker: it must stay replicated or
+        # use the entire ambient DiT TP group. A smaller subgroup would require
+        # separate group-bound TP layers and stage topology.
         text_encoder_tp_size = int(getattr(od_config.parallel_config, "text_encoder_tp_size", 1))
         tensor_parallel_size = int(getattr(od_config.parallel_config, "tensor_parallel_size", 1))
         if text_encoder_tp_size not in (1, tensor_parallel_size):
@@ -439,16 +433,13 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
             is_encoder_decoder=False,
         )
         if self._text_encoder_tp_enabled:
-            # Tensor-parallel UMT5 over the ambient TP group, so the ~10.6 GiB
-            # encoder is sharded instead of replicated on every rank.
-            # num_heads=64 and d_ff=10240 divide by every supported TP size.
-            # Returns a tuple, not a HF ModelOutput -- see `_encode_text`.
+            # Shard UMT5 on the ambient TP group; num_heads=64 and d_ff=10240 must
+            # divide by the TP size. _encode_text handles its tuple output.
             self.text_encoder = TPUMT5EncoderModel(umt5_config)
         else:
             self.text_encoder = HFUMT5EncoderModel(umt5_config)
-        # Both classes are named UMT5EncoderModel, so say which one. Requesting
-        # TP and silently getting the replicated encoder is otherwise invisible:
-        # startup succeeds and only the per-card footprint gives it away.
+        # Both implementations share a class name; log which was selected so an
+        # unexpected replicated encoder is visible at startup.
         logger.info(
             "DreamZero text encoder: %s UMT5 (text_encoder_tp_size=%d).",
             "tensor-parallel" if self._text_encoder_tp_enabled else "replicated Hugging Face",
@@ -713,11 +704,8 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         # block stays fullgraph even on that path.
         dit_compile = {"mode": "default", "fullgraph": True, "dynamic": False}
 
-        # At TP>1 the text encoder is sharded, so its forward carries two
-        # all-reduces per layer. Compile those under `default` for the same
-        # reason the DiT blocks already do, rather than reduce-overhead's
-        # CUDAGraph buffer reuse around the new collectives. TP=1 keeps today's
-        # kwargs untouched.
+        # Use default compile mode for TP collectives, avoiding reduce-overhead
+        # CUDAGraph buffer reuse around all-reduces. Keep TP=1 settings unchanged.
         text_encoder_compile = {**compile_ro, "mode": "default"} if self._text_encoder_tp_enabled else compile_ro
 
         logger.info(
@@ -886,13 +874,10 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
     # -----------------------------------------------------------------------
 
     def _encode_text(self, text_tokens: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
-        """Encode text prompt via UMT5.
+        """Encode text, returning full hidden states on every TP rank.
 
-        At ``text_encoder_tp_size > 1`` the encoder is tensor-parallel, so this
-        runs collectives on the DiT's TP group; the row-parallel projections
-        all-reduce back to the full 4096-dim hidden state, giving every rank the
-        identical result the DiT expects. The two implementations differ only in
-        how they wrap that tensor, and this method is the only place that knows.
+        The TP encoder runs collectives on the DiT group and returns a tuple;
+        the replicated HF encoder returns a ModelOutput.
         """
         self._cudagraph_mark_step_begin()
         seq_lens = attention_mask.gt(0).sum(dim=1).long()
@@ -903,16 +888,9 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         else:
             prompt_emb = encoder_output.last_hidden_state
         prompt_emb = prompt_emb.to(dtype=torch.bfloat16)
-        # Zero the padding tail with a sync-free position mask. The previous loop
-        # sliced by elements of the device-resident `seq_lens`, forcing a
-        # device->host sync per row, which at TP>1 would sit inside a collective
-        # region. `where` (not a multiply) keeps the old `= 0` semantics exactly,
-        # and returns a fresh tensor, which is what the old `.clone()` was for:
-        # it decouples the result from a CUDAGraph-owned output buffer. Masking
-        # is per row here, where the old loop truncated every row to the
-        # shortest row's length. Both callers tokenize exactly one string, so
-        # B == 1 and the two agree today; the per-row form is the correct one if
-        # that ever stops being true.
+        # Mask padding per row without reading device-resident lengths on the host.
+        # where writes exact zeros and returns a fresh tensor, decoupling the result
+        # from any CUDAGraph-owned output buffer.
         positions = torch.arange(prompt_emb.shape[1], device=prompt_emb.device)
         keep = (positions.unsqueeze(0) < seq_lens.unsqueeze(1)).unsqueeze(-1)
         return torch.where(keep, prompt_emb, 0.0)
@@ -1870,18 +1848,12 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
                     continue
                 for new_name in mapped if isinstance(mapped, list) else [mapped]:
                     if self._text_encoder_tp_enabled:
-                        # Delegate to the encoder's own loader rather than
-                        # copying into the param: it is tensor-parallel, so each
-                        # param holds only this rank's shard and a full-width
-                        # `.data.copy_()` would raise. Its loader owns the
-                        # q/k/v -> qkv_proj and wi_0/wi_1 -> wi fusions (which
-                        # need shard ids) and the shared/embed_tokens alias. Fed
-                        # one key at a time to keep the checkpoint stream lazy.
+                        # The encoder loader owns TP shard slicing, qkv/wi fusions and embedding
+                        # aliases; copying full-width weights directly would fail. Feed one key at
+                        # a time to preserve lazy checkpoint loading.
                         for filled in self.text_encoder.load_weights([(new_name, tensor)]):
                             full_name = "text_encoder." + filled
-                            # The loader also reports pre-fusion checkpoint
-                            # names; keep only real parameters so the
-                            # pipeline-level coverage check stays meaningful.
+                            # Keep only real parameter names; the loader also reports pre-fusion names.
                             if full_name in params:
                                 loaded.add(full_name)
                     else:

--- a/vllm_omni/diffusion/models/t5_encoder/__init__.py
+++ b/vllm_omni/diffusion/models/t5_encoder/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Tensor-parallel T5 encoder model."""
+"""Tensor-parallel T5 and UMT5 encoder models."""
 
-from vllm_omni.diffusion.models.t5_encoder.t5_encoder import T5EncoderModel
+from vllm_omni.diffusion.models.t5_encoder.t5_encoder import T5EncoderModel, UMT5EncoderModel
 
-__all__ = ["T5EncoderModel"]
+__all__ = ["T5EncoderModel", "UMT5EncoderModel"]

--- a/vllm_omni/diffusion/models/t5_encoder/__init__.py
+++ b/vllm_omni/diffusion/models/t5_encoder/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Tensor-parallel T5 and UMT5 encoder models."""
 
 from vllm_omni.diffusion.models.t5_encoder.t5_encoder import T5EncoderModel, UMT5EncoderModel

--- a/vllm_omni/diffusion/models/t5_encoder/t5_encoder.py
+++ b/vllm_omni/diffusion/models/t5_encoder/t5_encoder.py
@@ -285,12 +285,35 @@ class T5Block(nn.Module):
 
 
 class T5Stack(nn.Module):
-    def __init__(self, config: T5Config, shared: nn.Embedding, prefix: str = ""):
+    """Encoder stack for T5 (shared position bias) and UMT5 (per-layer bias).
+
+    ``per_layer_relative_attention_bias`` selects between the two families and
+    must stay consistent with ``forward``'s threading of ``position_bias``:
+    T5 computes the bias once on block 0 and reuses it, while UMT5 gives every
+    block its own ``relative_attention_bias`` table and recomputes per block
+    (HF ``UMT5LayerSelfAttention`` passes ``has_relative_attention_bias=True``
+    for every layer). Building the extra tables without also stopping the
+    threading would leave all but the first unused; stopping the threading
+    without building them would feed zeros into every block after the first.
+    """
+
+    def __init__(
+        self,
+        config: T5Config,
+        shared: nn.Embedding,
+        prefix: str = "",
+        per_layer_relative_attention_bias: bool = False,
+    ):
         super().__init__()
         self.embed_tokens = shared
+        self.per_layer_relative_attention_bias = per_layer_relative_attention_bias
         self.block = nn.ModuleList(
             [
-                T5Block(config, has_relative_attention_bias=(i == 0), prefix=f"{prefix}.block.{i}")
+                T5Block(
+                    config,
+                    has_relative_attention_bias=(per_layer_relative_attention_bias or i == 0),
+                    prefix=f"{prefix}.block.{i}",
+                )
                 for i in range(config.num_layers)
             ]
         )
@@ -312,11 +335,15 @@ class T5Stack(nn.Module):
 
         position_bias = None
         for block in self.block:
-            hidden_states, position_bias = block(
+            hidden_states, block_position_bias = block(
                 hidden_states,
                 mask=extended_mask,
                 position_bias=position_bias,
             )
+            # UMT5 re-derives bias (and re-adds the mask) in every block; T5
+            # carries block 0's result forward.
+            if not self.per_layer_relative_attention_bias:
+                position_bias = block_position_bias
 
         hidden_states = self.final_layer_norm(hidden_states)
         return hidden_states
@@ -325,12 +352,19 @@ class T5Stack(nn.Module):
 class T5EncoderModel(nn.Module):
     """T5 encoder model applying upstream vLLM layers"""
 
+    per_layer_relative_attention_bias: bool = False
+
     def __init__(self, config: T5Config, prefix: str = ""):
         super().__init__()
         self.config = config
         self.prefix = prefix
         self.shared = VocabParallelEmbedding(config.vocab_size, config.d_model)
-        self.encoder = T5Stack(config, self.shared, prefix=f"{prefix}.encoder")
+        self.encoder = T5Stack(
+            config,
+            self.shared,
+            prefix=f"{prefix}.encoder",
+            per_layer_relative_attention_bias=self.per_layer_relative_attention_bias,
+        )
 
     @property
     def dtype(self) -> torch.dtype:
@@ -421,3 +455,21 @@ class T5EncoderModel(nn.Module):
             loaded_params.add(lookup_name)
 
         return loaded_params
+
+
+class UMT5EncoderModel(T5EncoderModel):
+    """UMT5 encoder, tensor-parallel over the ambient vLLM TP group.
+
+    A drop-in replacement for ``transformers.UMT5EncoderModel`` for inference.
+    UMT5 differs from T5 in exactly one structural way that matters here: every
+    block carries its own ``relative_attention_bias`` table instead of sharing
+    block 0's. Everything else T5's implementation already handles — gated-GELU
+    (``feed_forward_proj="gated-gelu"`` sets ``is_gated_act``), bias-free
+    linears, the tied ``shared``/``encoder.embed_tokens`` embedding,
+    bidirectional position buckets, and no query scaling before the softmax.
+
+    Note ``forward`` returns ``(hidden_states,)``, not a HF ``ModelOutput``, so
+    callers read ``[0]`` rather than ``.last_hidden_state``.
+    """
+
+    per_layer_relative_attention_bias = True

--- a/vllm_omni/diffusion/models/t5_encoder/t5_encoder.py
+++ b/vllm_omni/diffusion/models/t5_encoder/t5_encoder.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 from __future__ import annotations
 
 import math

--- a/vllm_omni/diffusion/models/t5_encoder/t5_encoder.py
+++ b/vllm_omni/diffusion/models/t5_encoder/t5_encoder.py
@@ -287,14 +287,10 @@ class T5Block(nn.Module):
 class T5Stack(nn.Module):
     """Encoder stack for T5 (shared position bias) and UMT5 (per-layer bias).
 
-    ``per_layer_relative_attention_bias`` selects between the two families and
-    must stay consistent with ``forward``'s threading of ``position_bias``:
-    T5 computes the bias once on block 0 and reuses it, while UMT5 gives every
-    block its own ``relative_attention_bias`` table and recomputes per block
-    (HF ``UMT5LayerSelfAttention`` passes ``has_relative_attention_bias=True``
-    for every layer). Building the extra tables without also stopping the
-    threading would leave all but the first unused; stopping the threading
-    without building them would feed zeros into every block after the first.
+    UMT5 must both construct a bias table for each block and stop threading
+    ``position_bias`` between blocks. T5 computes it once on block 0 and
+    reuses it. Changing only construction or only forwarding would leave
+    bias tables unused or feed zero bias to later blocks.
     """
 
     def __init__(
@@ -458,18 +454,12 @@ class T5EncoderModel(nn.Module):
 
 
 class UMT5EncoderModel(T5EncoderModel):
-    """UMT5 encoder, tensor-parallel over the ambient vLLM TP group.
+    """UMT5 encoder using the ambient vLLM TP group.
 
-    A drop-in replacement for ``transformers.UMT5EncoderModel`` for inference.
-    UMT5 differs from T5 in exactly one structural way that matters here: every
-    block carries its own ``relative_attention_bias`` table instead of sharing
-    block 0's. Everything else T5's implementation already handles — gated-GELU
-    (``feed_forward_proj="gated-gelu"`` sets ``is_gated_act``), bias-free
-    linears, the tied ``shared``/``encoder.embed_tokens`` embedding,
-    bidirectional position buckets, and no query scaling before the softmax.
-
-    Note ``forward`` returns ``(hidden_states,)``, not a HF ``ModelOutput``, so
-    callers read ``[0]`` rather than ``.last_hidden_state``.
+    Each block owns its relative-attention bias. The T5 implementation supplies
+    gated-GELU, bias-free projections, tied embeddings, bidirectional buckets
+    and unscaled queries. ``forward`` returns ``(hidden_states,)`` rather than
+    a Hugging Face ModelOutput.
     """
 
     per_layer_relative_attention_bias = True


### PR DESCRIPTION
## Purpose

DreamZero replicates full UMT5-XXL text encoder on every TP rank. 

This wires DreamZero's text encoder onto the tensor-parallel T5 encoder the repository already ships
(`vllm_omni/diffusion/models/t5_encoder/t5_encoder.py`), behind the existing
`DiffusionParallelConfig.text_encoder_tp_size` knob:

```
text_encoder_tp_size == 1                        -> replicated HF UMT5 (unchanged default)
text_encoder_tp_size == tensor_parallel_size > 1  -> UMT5 sharded on the DiT's own TP group
```

No new process group and no new stage are introduced. 

**Default behaviour is unchanged.** `text_encoder_tp_size` defaults to 1, so existing config
keeps the replicated HF encoder and the same weights.


## Test Plan

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** branched from `3cddda97` (`v0.28.0-12-g3cddda97`)

  **End-to-end hardware run** — DreamZero-DROID offline inference, TP=4 denoise + TP=4 text encoder,
   10 requests (1 initial frame + 9 four-frame AR chunks), 16 denoise steps, bf16, on 4× Intel Arc
   B70 (32 GiB each). Cold container and cold process, no warmup requests.

Environment for item 4: `torch 2.13.0+xpu`, `triton 3.7.2`, `transformers 5.14.1`,
`vllm_omni 0.28.1.dev13`. 

## Test Result

**End-to-end at TP=4 with `text_encoder_tp_size: 4` — 10/10 requests, exit 0**, video and actions
written, no tracebacks and no OOM. All four workers confirm the selection.


**Per-card weights — the load-bearing result.** The runner's own `Model loading took N GiB` line
(`diffusion_model_runner.py:316`), read on all four ranks:

| `text_encoder_tp_size` | per-card weights | |
|---|---|---|
| 1 — replicated HF UMT5 | 20.18 GiB | |
| **4 — sharded UMT5** | **12.25 GiB** | **-7.93 GiB/card** |

12.2515 GiB is identical on all four ranks, reproduces unchanged across every encoder-TP run in
this series, and lands within 0.01 GiB of the 12.24 GiB the memory ledger predicted.

**What the saving buys is completion.** Both columns are TP=4 on B70 cards of 31.89 GB, 20
requests

| | replicated | `text_encoder_tp_size: 4` |
|---|---|---|
| requests completed | 3 of 20 — device OOM on request 4 | **20 of 20**, exit 0 |
| peak, worst card | 32,651 MiB (99.98% of cap) | 26,153 MiB (80.1%) |
| headroom at peak | 5 MiB | 6,503 MiB |
| per-card curve | climbs per AR chunk: 21,392 → 31,398 → 32,242 → 32,627 → OOM | 210 idle → 25,219 over load + request 1 → 25,221, then flat for the remaining 19 |

**Per-phase time split** (`DZ_PHASE_TIMING=1`, summed over the 10 requests, 366.97 s end to end):

| Phase | Time | Share |
|---|---:|---:|
| DiT denoise loop | 280.45 s | 76.4% |
| AR paged-KV prefill | 55.25 s | 15.1% |
| **UMT5 text encode** | **11.14 s** | **3.0%** |
| Observation VAE encode | 7.52 s | 2.1% |
| VAE decode + frame prep + MP4 write | 9.54 s | 2.6% |

