### PR TITLE
[Bugfix][Diffusion] Include guidance_scale_2_provided in the request-batch key

### DIFF
--- a/tests/diffusion/test_diffusion_scheduler.py
+++ b/tests/diffusion/test_diffusion_scheduler.py
@@ -276,12 +276,16 @@ class TestGetRequestBatchSamplingParamsKey:
         generator: torch.Generator | None = None,
         extra_args: dict | None = None,
         condition_key: tuple | None = None,
+        guidance_scale: float | None = None,
+        guidance_scale_2: float | None = None,
     ) -> OmniDiffusionRequest:
         sp = OmniDiffusionSamplingParams(
             num_inference_steps=num_inference_steps,
             seed=seed,
             generator=generator,
             extra_args=extra_args or {},
+            guidance_scale=guidance_scale,
+            guidance_scale_2=guidance_scale_2,
         )
         return OmniDiffusionRequest(
             prompt="prompt",
@@ -355,6 +359,21 @@ class TestGetRequestBatchSamplingParamsKey:
         assert scheduler._build_sampling_params_key(
             self._make(condition_key=("wan22_s2v_condition", True))
         ) != scheduler._build_sampling_params_key(self._make(condition_key=("wan22_s2v_condition", False)))
+
+    def test_distinguishes_explicit_guidance_scale_2(self) -> None:
+        # An omitted guidance_scale_2 is auto-filled from guidance_scale, so a
+        # request that omits it and one that passes the same value explicitly end
+        # up with an identical numeric guidance_scale_2 but different
+        # guidance_scale_2_provided. Pipelines read guidance_scale_2_provided from
+        # the batch's first request to gate image guidance, so the two must not
+        # share a request batch.
+        scheduler = RequestScheduler()
+        omitted = self._make(guidance_scale=2.0)
+        explicit = self._make(guidance_scale=2.0, guidance_scale_2=2.0)
+
+        assert omitted.sampling_params.guidance_scale_2 == explicit.sampling_params.guidance_scale_2
+        assert omitted.sampling_params.guidance_scale_2_provided != explicit.sampling_params.guidance_scale_2_provided
+        assert scheduler._build_sampling_params_key(omitted) != scheduler._build_sampling_params_key(explicit)
 
 
 class TestRequestScheduler:

--- a/vllm_omni/diffusion/sched/interface.py
+++ b/vllm_omni/diffusion/sched/interface.py
@@ -117,6 +117,7 @@ class RequestBatchSamplingParamsKey:
     guidance_scale: float = 0.0
     guidance_scale_provided: bool = False
     guidance_scale_2: float | None = None
+    guidance_scale_2_provided: bool = False
     guidance_rescale: float = 0.0
     true_cfg_scale: float | None = None
     cfg_normalize: bool = False


### PR DESCRIPTION
## Purpose

`RequestBatchSamplingParamsKey` doesn't include `guidance_scale_2_provided`, so
two requests with the same *numeric* `guidance_scale_2` — one explicit, one
auto-filled from `guidance_scale` — can share a request batch even though they
mean different things. `forward()` reads `guidance_scale_2_provided` from the
batch's first request only, so the wrong request silently gets (or silently
loses) image/second-stage guidance depending on batch order. Follow-up to
#6968, whose Scope section documents this exact gap as the reason TI2I
batching for Boogu-Image stays gated.

This PR:
- Adds `guidance_scale_2_provided: bool = False` to
  `RequestBatchSamplingParamsKey` (`vllm_omni/diffusion/sched/interface.py`) so
  a gs2-omitted and a gs2-explicit request no longer share a batch key.
- Adds `test_distinguishes_explicit_guidance_scale_2`, pinning the key split
  through the real key builder (`RequestScheduler._build_sampling_params_key`).

Backward compatibility: adds one boolean key field; requests that previously
co-batched purely by numeric `guidance_scale_2` coincidence may now be
scheduled into separate batches. Does not change output shape or per-request
semantics.

Not a duplicate: no open PR/issue addresses this beyond #6968's own Scope note
(searched issues/PRs for `guidance_scale_2`, `RequestBatchSamplingParamsKey`,
co-batch/contamination reports — nothing else references it).
Follow-up (out of scope): the full guidance-mode validation sweep #6968
mentions as required before un-gating TI2I batching.
AI-assistance: developed with Claude Code; I reviewed and tested every change.

## Test Plan

**vLLM Version:** 0.28.0
**vLLM-Omni Commit:** `upstream/main` @ `66bbebd9`

- [x] Unit (CPU): `tests/diffusion/test_diffusion_scheduler.py`
  - [x] Full file — 96 passed, including the new
    `test_distinguishes_explicit_guidance_scale_2`
  - [x] RED — reverting only the `interface.py` field addition makes the new
    test fail (non-vacuous); restoring it passes again
- [x] `ruff check` / `ruff format --check` — clean

## Test Result

- `96 passed` on `tests/diffusion/test_diffusion_scheduler.py` against a clean
  `upstream/main` checkout with only this PR's diff applied.
- RED/GREEN re-verified as above.
