### PR TITLE
[Model] Add accelerated Breeze-TTS-2 voice design, cloning, and direction

### DIFF
--- a/.buildkite/cuda/test-merge.yml
+++ b/.buildkite/cuda/test-merge.yml
@@ -77,6 +77,23 @@ steps:
   - group: ":card_index_dividers: E2E Test"
     depends_on: upload-merge-pipeline
     steps:
+      - label: "TTS · Breeze-TTS-2 Voice Design"
+        timeout_in_minutes: 20
+        source_file_dependencies:
+          - tests/e2e/online_serving/test_breeze_tts_2.py
+          - tests/helpers/client.py
+          - tests/helpers/media.py
+          - vllm_omni/model_executor/models/breeze_tts/
+          - vllm_omni/model_executor/models/qwen3_tts/
+          - vllm_omni/model_executor/stage_input_processors/breeze_tts.py
+          - vllm_omni/entrypoints/openai/tts_adapters/breeze_tts.py
+          - vllm_omni/deploy/breeze_tts.yaml
+          - vllm_omni/config/pipeline_registry.py
+          - vllm_omni/engine/arg_utils.py
+        commands:
+          - pytest -s -v tests/e2e/online_serving/test_breeze_tts_2.py -m 'advanced_model and tts' --run-level=advanced_model
+        mirror_hardwares: l4_1
+
       - label: "TTS · Qwen3-TTS CustomVoice Test"
         source_file_dependencies:
           - tests/helpers/media.py

--- a/.buildkite/cuda/test-ready.yml
+++ b/.buildkite/cuda/test-ready.yml
@@ -284,6 +284,22 @@ steps:
             "
         mirror_hardwares: l4_1
 
+      - label: "TTS · Breeze-TTS-2 Voice Design"
+        timeout_in_minutes: 20
+        source_file_dependencies:
+          - tests/e2e/online_serving/test_breeze_tts_2.py
+          - tests/helpers/client.py
+          - vllm_omni/model_executor/models/breeze_tts/
+          - vllm_omni/model_executor/models/qwen3_tts/
+          - vllm_omni/model_executor/stage_input_processors/breeze_tts.py
+          - vllm_omni/entrypoints/openai/tts_adapters/breeze_tts.py
+          - vllm_omni/deploy/breeze_tts.yaml
+          - vllm_omni/config/pipeline_registry.py
+          - vllm_omni/engine/arg_utils.py
+        commands:
+          - pytest -s -v tests/e2e/online_serving/test_breeze_tts_2.py -m 'core_model and tts' --run-level=core_model
+        mirror_hardwares: l4_1
+
       - label: "Diffusion · Wan22 Test"
         source_file_dependencies:
           - tests/e2e/online_serving/test_wan22_t2v.py

--- a/benchmarks/tts/model_configs.yaml
+++ b/benchmarks/tts/model_configs.yaml
@@ -7,6 +7,17 @@
 # is tracked here.
 
 models:
+  BreezeBlue/Breeze-TTS-2:
+    supported_tasks: [default_voice, voice_design, voice_clone]
+    backend: openai-audio-speech
+    endpoint: /v1/audio/speech
+    task_extra_body:
+      default_voice: {}
+      voice_design:
+        task_type: VoiceDesign
+      voice_clone:
+        task_type: Base
+
   IndexTeam/IndexTTS-2.5:
     supported_tasks: [voice_clone]
     backend: openai-audio-speech

--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -70,6 +70,7 @@ th {
 | `OmniVoiceModel` | OmniVoice | `k2-fsa/OmniVoice` | ✅︎ | | | ✅︎ | — |
 | `VoxCPM2TalkerForConditionalGeneration` | VoxCPM2 | `openbmb/VoxCPM2` | ✅︎ | | | ✅︎ | — |
 | `DotsTTSForConditionalGeneration` | dots.tts | `dots-studio/dots.tts-soar` | ✅︎ | | | | — |
+| `BreezeForConditionalGeneration` | Breeze-TTS-2 (voice design, CFG=1) | `BreezeBlue/Breeze-TTS-2` | ✅︎ | | | | [Repository](https://github.com/vllm-project/vllm-omni/blob/main/recipes/BreezeBlue/Breeze-TTS-2.md) |
 | `MammothModa2ForConditionalGeneration` | MammothModa2-Preview | `bytedance-research/MammothModa2-Preview` | ✅︎ | ✅︎ | | | — |
 | `MammothModa2ForConditionalGeneration` | MammothModa2-Dev (AR-only image understanding) | `bytedance-research/MammothModa2-Dev` | ✅︎ | | | | — |
 | `Flux2KleinPipeline` | FLUX.2-klein | `black-forest-labs/FLUX.2-klein-4B`, `black-forest-labs/FLUX.2-klein-9B` | ✅︎ | ✅︎ | ✅︎ | ✅︎ | — |

--- a/recipes/BreezeBlue/Breeze-TTS-2.md
+++ b/recipes/BreezeBlue/Breeze-TTS-2.md
@@ -1,0 +1,221 @@
+# Breeze-TTS-2
+
+[Breeze-TTS-2](https://huggingface.co/BreezeBlue/Breeze-TTS-2) generates 24 kHz
+English and Chinese speech. The integration supports Voice Design from text
+instructions, Voice Clone from a reference recording and transcript, and
+Voice Direction combining reference conditioning with instructions.
+
+## Installation and serving
+
+Follow the project's source installation guide for vLLM and vLLM-Omni.
+The integration loads the released checkpoint directly. The original Breeze
+repository and the `qwen-tts` package are not required. The common requirements
+include `soxr` to reproduce reference-audio resampling.
+
+```bash
+vllm-omni serve BreezeBlue/Breeze-TTS-2 --omni --host 127.0.0.1 --port 8091
+```
+
+The default configuration uses one CUDA GPU, BF16 generation and FP32 reference
+encoding and waveform decoding. It targets GPUs with at least 16 GiB available
+for the deployment; other workloads consume additional memory.
+
+On WSL2, set vLLM's supported pinned-memory option before starting the server:
+
+```bash
+export VLLM_WSL2_ENABLE_PIN_MEMORY=1
+```
+
+Native Linux enables pinned memory by default. Startup warmup exercises plain
+generation, CFG, reference conditioning and two-request batches. New text
+lengths or batch sizes can require additional graph
+capture or compilation; warm the workload before measuring steady performance.
+
+## Voice Design
+
+```bash
+curl --fail http://127.0.0.1:8091/v1/audio/speech \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "BreezeBlue/Breeze-TTS-2",
+    "input": "你好，欢迎使用语音合成系统。",
+    "instructions": "年轻女性，声音温暖自然，使用标准普通话。",
+    "extra_params": {"guidance_scale": 4.0},
+    "response_format": "wav",
+    "seed": 42,
+    "max_new_tokens": 250
+  }' --output breeze.wav
+```
+
+Omitting `instructions` uses `Speak clearly and naturally.`. An explicitly
+empty instruction remains empty. Vocal-event tokens, including `(laughs)`
+and `[笑]`, are passed to the checkpoint unchanged.
+
+## Voice Clone and Voice Direction
+
+Add `ref_audio` and its exact `ref_text` transcript. Reference audio accepts the
+shared speech API's audio URLs and base64 data URLs. The shared resolver's
+format, duration and local-file access restrictions apply.
+
+```json
+{
+  "model": "BreezeBlue/Breeze-TTS-2",
+  "input": "Please read this new sentence clearly and naturally.",
+  "ref_audio": "data:audio/wav;base64,<base64-encoded-reference>",
+  "ref_text": "The words actually spoken in the reference recording.",
+  "instructions": "Keep the reference voice. Speak gently and calmly.",
+  "extra_params": {"guidance_scale": 4.0},
+  "response_format": "wav",
+  "seed": 42
+}
+```
+
+Use `guidance_scale: 1.0` with the default instruction for ordinary cloning.
+Reference audio plus a delivery instruction and CFG provides Voice Direction.
+When explicitly specified, `task_type` is `Base` for reference conditioning
+and `VoiceDesign` without reference audio.
+
+Stereo references are averaged to mono and resampled to 24 kHz with soxr HQ.
+Reference text is encoded independently from the target text. The reference
+codec preserves full causal attention during offline encoding, as used by the
+released Breeze runtime; newer Transformers sliding-window defaults would
+change long references. Reference convolution uses full FP32 precision.
+
+## Sampling and output
+
+Supported `extra_params`:
+
+| Parameter | Default | Meaning |
+| --- | --- | --- |
+| `guidance_scale` | 1.0 | Any finite positive value; values other than 1 use two CFG branches |
+| `temperature` | 0.9 | Zero selects greedy generation |
+| `top_k` | 50 | Zero or -1 disables top-k filtering |
+| `top_p` | 1.0 | Nucleus sampling probability in (0, 1] |
+| `repetition_penalty` | 1.1 | Positive penalty applied to the first codebook's generated history |
+
+CFG combines conditional and unconditional logits in the Qwen3 output head
+and all 15 remaining depth codebooks. Both branches retain reference audio
+and reference text; the unconditional branch removes only target instructions.
+
+`max_new_tokens` limits generated audio frames, including EOS. Each frame is
+80 ms; the default is 1500 tokens, subject to the remaining 2048-token context.
+Both CFG branches stop at the same generation limit despite unequal prompts.
+Each request owns its seed, generator, audio-code history and codec state.
+Different GPU kernels and batch shapes can still change sampled outputs.
+
+For streamed PCM, use `"stream": true`, `"stream_format": "audio"`, and
+`"response_format": "pcm"`. Output is mono signed 16-bit little-endian PCM at
+24 kHz. Complete WAV responses accumulate the same internal streaming output.
+The first chunks contain 1, 2, 4 and 5 codec frames, then remain at 5 frames.
+
+## Pipeline and optimization
+
+Stage 0 batches T5Gemma2 text encoding, optional reference-audio encoding,
+vLLM's native Qwen3 backbone with paged KV caching, and Breeze's Llama depth
+decoder. Text segments up to 128 tokens use padded CUDA Graphs with separate
+attention masks. Longer segments use dynamically compiled encoder layers
+without retaining a separate graph workspace for each input length.
+The depth decoder uses fused QKV/MLP projections, compiled layer kernels,
+fixed frame-local KV buffers and a CUDA Graph covering all 15 depth steps.
+Temperature, top-k and top-p are mutable GPU inputs to the captured sampler.
+Changing those settings, or changing a positive CFG scale within the paired
+path, reuses the graph. Each request owns its random-number generator.
+
+Reference encoding uses dynamic-shape compilation with CUDA Graphs disabled
+for that path, so large reference-convolution workspaces remain reusable by
+the allocator. Every convolution retains each recording's actual boundary;
+the final downsampler repeats its last valid state for partial frames, matching
+independent encoding. Static convolution metadata removes GPU-to-CPU padding
+calculations. Startup compiles reference batches of one and two.
+Waveform storage is aligned to 1920-sample frames, with that frame width
+marked static for compilation. Actual sample lengths still govern every
+convolution boundary. This avoids nested dynamic ceil/mod expressions that
+otherwise make compiler tiling spend minutes simplifying reference shapes.
+
+Stage 1 reuses Qwen3-TTS's stateful codec and its CUDA Graph decoder with the
+checkpoint's `audio_tokenizer/` weights. Shared-memory chunks connect stages.
+Only the generated-code decode path is captured: reference conditioning was
+already consumed in stage 0, so the Qwen ICL reference-prefix graphs and their
+large convolution workspaces are unnecessary for Breeze.
+
+The Qwen3 backbone uses compiled piecewise prefill and full decode graphs.
+Stage 0 uses synchronous scheduling to keep CFG branches at the same
+generation step; stage 1 uses asynchronous scheduling. CFG admission reserves
+enough KV pages for both branches' complete generation and preserves their
+actual position IDs. Cancellation finishes both branches.
+
+The default admission policy lets active requests produce eight audio frames
+before adding another prefill. This gives playback a buffer before text and
+reference encoding share the device with an existing stream. It increases a
+queued request's first-audio latency; benchmark it separately from an idle server.
+
+The default `max_num_seqs: 2` counts physical branches: it permits two plain
+requests or one CFG request at a time. Additional CFG requests queue.
+Prefix caching and chunked prefill are disabled because prompt token IDs
+reserve positions for externally encoded embeddings. The deployment requires
+`async_chunk: true`, including for complete HTTP responses.
+
+The supported execution scope is one CUDA GPU, TP=1, PP=1 and unquantized
+released weights. Named voices, speaker embeddings, dual CFG and multiple
+reference recordings are not supported. The original public fast runtime
+also does not expose dual CFG.
+
+## Offline inference and validation
+
+`vllm_omni.model_executor.models.breeze_tts.prompt.build_breeze_prompt`
+accepts a checkpoint tokenizer, text, instructions, sampling parameters,
+and optional `ref_audio=(waveform, sample_rate)` plus `ref_text`. Pass its
+result to `Omni.generate()` using the default Breeze deployment. Waveform
+arrays use soundfile's `(samples, channels)` convention.
+
+CPU tests compare cached depth attention and CFG against Hugging Face Llama
+and cover request-owned sampling, payload transport, chunk delivery and CFG
+admission. GPU tests compare padded batched text graphs with independent
+eager encoders and exercise depth graphs across CFG scales and batch shapes.
+
+```bash
+pytest -v tests/model_executor/models/test_breeze_tts.py \
+  tests/core/sched/test_omni_cfg_ar_scheduler.py -m 'core_model and cpu'
+pytest -v tests/model_executor/models/test_breeze_tts_graphs.py -m 'core_model and cuda'
+pytest -v tests/e2e/online_serving/test_breeze_tts_2.py \
+  -m 'core_model and tts' --run-level=core_model
+pytest -v tests/e2e/online_serving/test_breeze_tts_2.py \
+  -m 'advanced_model and tts' --run-level=advanced_model
+```
+
+Serving tests use the shared client for Chinese CFG design, English PCM,
+concurrent CFG requests, reference cloning and direction. Core tests use dummy
+weights and eight-frame requests; advanced tests use real weights and the
+shared content checks. These checks do not establish perceptual quality parity.
+The Chinese content check uses Whisper large-v3 as its primary transcriber:
+small misrecognizes homophones on the fixed test clip. The expected text and
+shared similarity threshold are unchanged; there is no failed-check retry.
+Ensure enough host memory and disk space for the large-v3 test model when
+Whisper runs on CPU alongside the serving process.
+
+The English PCM test uses a 0 dB harmonic-to-noise floor because the original
+eager runtime scores 0.56 dB on that same prompt and seed, below the shared
+1 dB floor. Raw PCM is not transcribed by the shared helper. Separate matched
+evaluations must retain audio and compare intelligibility, speaker similarity,
+instruction effects, first audio, RTF and playback underruns.
+
+The shared serving benchmark supports default speech, Voice Design and
+Voice Clone. For Voice Design:
+
+```bash
+python benchmarks/tts/bench_tts.py \
+  --model BreezeBlue/Breeze-TTS-2 --task voice_design --locale en \
+  --host 127.0.0.1 --port 8091 --concurrency 1 2 \
+  --num-prompts 4 --num-warmups 1 --request-seed 42 --output-len 250 \
+  --output-dir results/breeze
+```
+
+For a local model path, add `--served-model-name /path/to/Breeze-TTS-2`.
+For cloning, select `--task voice_clone --dataset-path /path/to/seed-tts-eval`
+with the desired locale. Reference conditioning with instructions and other
+CFG scales also require identical requests and sampling settings in the
+reference runtime and this deployment.
+
+The reference source and released weights have separate licenses. Consult
+the [reference repository](https://github.com/breezeblue-ai/breeze-tts) and
+checkpoint model card.

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -19,6 +19,8 @@ kernels==0.15.2
 safetensors>=0.8.0
 accelerate==1.12.0
 soundfile>=0.13.1
+# Breeze reference conditioning must use the released codec's soxr resampling.
+soxr>=0.5.0.post1
 cache-dit==1.5.0
 tqdm>=4.66.0
 torchsde>=0.2.6

--- a/tests/core/sched/test_omni_cfg_ar_scheduler.py
+++ b/tests/core/sched/test_omni_cfg_ar_scheduler.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from types import SimpleNamespace
+
+import pytest
+from vllm import SamplingParams
+from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
+from vllm.v1.request import Request, RequestStatus
+
+from vllm_omni.core.sched.omni_ar_scheduler import OmniARScheduler
+from vllm_omni.core.sched.omni_cfg_ar_scheduler import OmniCFGARScheduler
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _request(name: str, prompt_length: int) -> Request:
+    return Request(name, [0] * prompt_length, SamplingParams(max_tokens=100), None)
+
+
+def _scheduler(monkeypatch, waiting, running=()):
+    scheduler = OmniCFGARScheduler.__new__(OmniCFGARScheduler)
+    scheduler.policy = SchedulingPolicy.FCFS
+    scheduler.waiting = create_request_queue(scheduler.policy)
+    for request in waiting:
+        scheduler.waiting.add_request(request)
+    scheduler.skipped_waiting = create_request_queue(scheduler.policy)
+    scheduler.running = list(running)
+    scheduler.requests = {request.request_id: request for request in [*waiting, *running]}
+    scheduler.max_model_len = 128
+    scheduler.max_num_running_reqs = 2
+    scheduler.max_num_scheduled_tokens = 256
+    scheduler.block_size = 16
+    scheduler._capacity = 16
+    scheduler._pairs = {"pair": {"cond": "cond", "uncond": "uncond"}}
+    scheduler._request_pairs = {"cond": "pair", "uncond": "pair"}
+    scheduler._prefill_min_output_tokens = 0
+
+    def advance(self, throttle_prefills=False):
+        self.running.extend(self.waiting)
+        self.waiting = create_request_queue(self.policy)
+        scheduled = {}
+        for request in self.running:
+            count = request.num_tokens - request.num_computed_tokens
+            request.num_computed_tokens += count
+            request.append_output_token_ids(0)
+            scheduled[request.request_id] = count
+        return SimpleNamespace(num_scheduled_tokens=scheduled)
+
+    monkeypatch.setattr(OmniARScheduler, "schedule", advance)
+    return scheduler
+
+
+def test_unequal_prompts_keep_real_positions_and_share_context_limit(monkeypatch):
+    cond, uncond = _request("cond", 80), _request("uncond", 30)
+    scheduler = _scheduler(monkeypatch, [cond, uncond])
+    output = scheduler.schedule()
+    assert output.num_scheduled_tokens == {"cond": 80, "uncond": 30}
+    assert (cond.max_tokens, uncond.max_tokens) == (48, 48)
+    for _ in range(4):
+        assert scheduler.schedule().num_scheduled_tokens == {"cond": 1, "uncond": 1}
+    assert cond.num_computed_tokens - uncond.num_computed_tokens == 50
+
+
+def test_waiting_pair_cannot_be_split_or_starved_by_later_single(monkeypatch):
+    cond, uncond = _request("cond", 40), _request("uncond", 20)
+    running, later = _request("running", 10), _request("later", 10)
+    scheduler = _scheduler(monkeypatch, [cond, uncond, later], [running])
+    assert scheduler.schedule().num_scheduled_tokens == {"running": 10}
+    assert list(scheduler.waiting) == [cond, uncond, later]
+    scheduler.running.clear()
+    del scheduler.requests["running"]
+    assert scheduler.schedule().num_scheduled_tokens == {"cond": 40, "uncond": 20}
+    assert list(scheduler.waiting) == [later]
+
+
+def test_cancel_either_branch_finishes_both_and_releases_pair(monkeypatch):
+    cond, uncond = _request("cond", 40), _request("uncond", 20)
+    scheduler = _scheduler(monkeypatch, [cond, uncond])
+
+    def finish(self, ids, status):
+        assert set(ids) == {"cond", "uncond"}
+        assert status == RequestStatus.FINISHED_ABORTED
+        finished = [self.requests.pop(rid) for rid in ids]
+        self.waiting.remove_requests(finished)
+        return finished
+
+    monkeypatch.setattr(OmniARScheduler, "finish_requests", finish)
+    assert len(scheduler.finish_requests("uncond", RequestStatus.FINISHED_ABORTED)) == 2
+    assert not scheduler._pairs and not scheduler._request_pairs and not scheduler.waiting
+
+
+def test_new_prefill_waits_for_initial_streaming_audio(monkeypatch):
+    request = _request("plain", 20)
+    scheduler = _scheduler(monkeypatch, [], [request])
+    scheduler._prefill_min_output_tokens = 8
+    request.append_output_token_ids([0] * 7)
+    assert scheduler._should_defer_waiting_admission()
+    request.append_output_token_ids(0)
+    assert not scheduler._should_defer_waiting_admission()

--- a/tests/e2e/online_serving/test_breeze_tts_2.py
+++ b/tests/e2e/online_serving/test_breeze_tts_2.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Breeze design, reference conditioning and CFG through the shared speech client."""
+
+import pytest
+
+from tests.helpers.mark import hardware_test
+from tests.helpers.media import get_asset_path
+from tests.helpers.runtime import OmniServerParams
+from tests.helpers.stage_config import get_deploy_config_path
+
+MODEL = "BreezeBlue/Breeze-TTS-2"
+
+pytestmark = [
+    pytest.mark.core_model,
+    pytest.mark.advanced_model,
+    pytest.mark.tts,
+    pytest.mark.parametrize(
+        "omni_server",
+        [OmniServerParams(model=MODEL, stage_config_path=get_deploy_config_path("breeze_tts.yaml"))],
+        indirect=True,
+    ),
+]
+
+
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+def test_chinese_voice_design(omni_server, online_client, run_level) -> None:
+    online_client.send_audio_speech_request(
+        {
+            "model": omni_server.model,
+            "input": "你好，欢迎使用语音合成系统。今天的天气很好。",
+            "instructions": "年轻女性，使用标准普通话，语速适中。",
+            "extra_params": {"guidance_scale": 4.0},
+            "transcript_language": "zh",
+            # Whisper-small transcribes "合成" as "和程" on this fixed clip.
+            # Use the stronger primary ASR without changing the expected text
+            # or similarity threshold, or retrying after a failed assertion.
+            "transcript_model": "large-v3",
+            "response_format": "wav",
+            "sample_rate": 24000,
+            "min_audio_bytes": 24000,
+            "seed": 42,
+            "max_new_tokens": 8 if run_level == "core_model" else 250,
+        }
+    )
+
+
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+def test_english_streaming(omni_server, online_client, run_level) -> None:
+    online_client.send_audio_speech_request(
+        {
+            "model": omni_server.model,
+            "input": "Hello, this is a demonstration of natural speech synthesis.",
+            "instructions": "A warm, clear female voice speaking English at a moderate pace.",
+            "transcript_language": "en",
+            "response_format": "pcm",
+            "sample_rate": 24000,
+            "min_audio_bytes": 24000,
+            "stream": True,
+            "stream_format": "audio",
+            # The reference eager runtime scores 0.56 dB on this same prompt
+            # (seed 42, CFG=1); the shared 1 dB floor rejects it as well.
+            "min_hnr_db": 0.0,
+            "seed": 42,
+            "max_new_tokens": 8 if run_level == "core_model" else 250,
+        }
+    )
+
+
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+def test_two_concurrent_requests(omni_server, online_client, run_level) -> None:
+    online_client.send_audio_speech_request(
+        {
+            "model": omni_server.model,
+            "input": "Each request keeps its own audio generation state.",
+            "instructions": "A clear English voice.",
+            "extra_params": {"guidance_scale": 4.0},
+            "transcript_language": "en",
+            "response_format": "wav",
+            "sample_rate": 24000,
+            "min_audio_bytes": 24000,
+            "seed": 123,
+            "max_new_tokens": 8 if run_level == "core_model" else 250,
+        },
+        request_num=2,
+    )
+
+
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.parametrize("guidance_scale", [1.0, 4.0])
+def test_reference_cloning_and_direction(omni_server, online_client, run_level, guidance_scale) -> None:
+    online_client.send_audio_speech_request(
+        {
+            "model": omni_server.model,
+            "input": "Please read this sentence clearly and naturally.",
+            "instructions": "Keep the reference voice. Speak gently and calmly.",
+            "ref_audio": get_asset_path("qwen3_tts/clone_2.wav", as_data_url=True),
+            "ref_text": "Okay. Yeah. I resent you. I love you. I respect you. But you know what? You blew it! And thanks to you.",
+            "task_type": "Base",
+            "extra_params": {"guidance_scale": guidance_scale},
+            "transcript_language": "en",
+            "response_format": "wav",
+            "sample_rate": 24000,
+            "min_audio_bytes": 24000,
+            "seed": 42,
+            "max_new_tokens": 8 if run_level == "core_model" else 250,
+        }
+    )

--- a/tests/entrypoints/openai_api/test_serving_speech.py
+++ b/tests/entrypoints/openai_api/test_serving_speech.py
@@ -16,6 +16,7 @@ from inspect import Signature, signature
 from pathlib import Path
 from types import SimpleNamespace
 
+import anyio
 import numpy as np
 import pytest
 import torch
@@ -5457,21 +5458,32 @@ class TestTTSAsyncOffloading:
 
     @pytest.mark.asyncio
     async def test_generate_audio_chunks_discards_ref_audio_artifact_warmup_on_close(self, qwen3_tts_server):
+        closed = asyncio.Event()
+
         async def pcm_generator():
-            yield SimpleNamespace(
-                multimodal_output={
-                    "audio": torch.zeros(16, dtype=torch.float32),
-                    "sr": 24000,
-                }
-            )
-            await asyncio.sleep(0)
+            try:
+                yield SimpleNamespace(
+                    multimodal_output={
+                        "audio": torch.zeros(16, dtype=torch.float32),
+                        "sr": 24000,
+                    }
+                )
+            finally:
+                # Engine abort waits for stage acknowledgments. Retain an
+                # actual cancellation checkpoint to cover ASGI cancel scopes.
+                await anyio.sleep(0)
+                closed.set()
 
         qwen3_tts_server._request_ref_audio_artifact_keys["req-close"] = ("artifact-close", False)
 
-        stream = qwen3_tts_server._generate_audio_chunks(pcm_generator(), "req-close")
+        engine_stream = pcm_generator()
+        stream = qwen3_tts_server._generate_audio_chunks(engine_stream, "req-close")
         assert await anext(stream)
-        await stream.aclose()
+        with anyio.CancelScope() as scope:
+            scope.cancel()
+            await stream.aclose()
 
+        assert closed.is_set()
         assert "req-close" not in qwen3_tts_server._request_ref_audio_artifact_keys
         assert ("artifact-close", False) not in qwen3_tts_server._ref_audio_model_artifact_ready
 

--- a/tests/entrypoints/test_async_omni.py
+++ b/tests/entrypoints/test_async_omni.py
@@ -5,6 +5,7 @@ import asyncio
 import re
 from types import SimpleNamespace
 
+import anyio
 import pytest
 from vllm.lora.request import LoRARequest
 from vllm.sampling_params import RequestOutputKind, SamplingParams
@@ -411,6 +412,40 @@ def test_generate_cancellation_converges_after_engine_shutdown_starts(mocker):
         assert submitted_request_ids[0].startswith("cancel-shutdown-")
         assert omni.request_states == {}
         engine.request_queue.sync_q.put.assert_not_called()
+
+    asyncio.run(run_test())
+
+
+@pytest.mark.cpu
+def test_generate_waits_for_abort_inside_cancelled_asgi_scope():
+    async def run_test():
+        submitted = anyio.Event()
+        acknowledged = []
+
+        async def add_request(**kwargs):
+            submitted.set()
+
+        async def abort(request_ids):
+            await anyio.sleep(0)
+            acknowledged.extend(request_ids)
+
+        omni = get_async_omni_instance(fake_add_request=add_request, fake_abort_request=abort)
+
+        async def collect():
+            async for _ in omni.generate(
+                prompt={"prompt": "prompt"},
+                request_id="cancel-asgi",
+                sampling_params_list=[SimpleNamespace()],
+                output_modalities=["image"],
+            ):
+                pass
+
+        async with anyio.create_task_group() as group:
+            group.start_soon(collect)
+            await submitted.wait()
+            group.cancel_scope.cancel()
+        assert len(acknowledged) == 1 and acknowledged[0].startswith("cancel-asgi-")
+        assert omni.request_states == {}
 
     asyncio.run(run_test())
 

--- a/tests/helpers/assertions.py
+++ b/tests/helpers/assertions.py
@@ -740,7 +740,11 @@ def _resolve_audio_transcript(
     audio_bytes = getattr(response, "audio_bytes", None)
     if not audio_bytes:
         return None
-    return convert_audio_bytes_to_text(audio_bytes, language=request_config.get("transcript_language"))
+    return convert_audio_bytes_to_text(
+        audio_bytes,
+        model_size=request_config.get("transcript_model", "small"),
+        language=request_config.get("transcript_language"),
+    )
 
 
 def assert_omni_response(response: Any, request_config: dict[str, Any], run_level):

--- a/tests/helpers/client.py
+++ b/tests/helpers/client.py
@@ -1433,6 +1433,7 @@ class OnlineOmniClient:
           - task_type, ref_text, ref_audio: TTS-specific extras (optional, passed via extra_body)
           - min_audio_bytes: optional minimum ``len(audio_bytes)`` checked in ``assert_audio_speech_response``
           - transcript_expected_text: local expected spoken text; defaults to ``input``
+          - transcript_model: primary Whisper model for content checks; defaults to ``small``
           - timeout: request timeout in seconds (float, optional, default 120.0)
           - stream: whether to use streaming API (bool, optional, default False)
 
@@ -1456,6 +1457,7 @@ class OnlineOmniClient:
             "task_type",
             "ref_text",
             "ref_audio",
+            "extra_params",
             "language",
             "max_new_tokens",
             "seed",

--- a/tests/helpers/tests/test_assertions.py
+++ b/tests/helpers/tests/test_assertions.py
@@ -75,6 +75,26 @@ def test_resolve_transcript_leaves_language_unset_by_default(monkeypatch):
     assert captured["model_size"] == "small"
 
 
+def test_resolve_transcript_uses_configured_primary_model(monkeypatch):
+    captured = _capture_transcribe(monkeypatch)
+    response = SimpleNamespace(audio_content=None, audio_bytes=b"fake-wav")
+
+    _resolve_audio_transcript(
+        response,
+        {
+            "input": "你好",
+            "response_format": "wav",
+            "transcript_language": "zh",
+            "transcript_model": "large-v3",
+        },
+        "advanced_model",
+        speech_api=True,
+    )
+
+    assert captured["model_size"] == "large-v3"
+    assert captured["language"] == "zh"
+
+
 @pytest.mark.parametrize(
     ("request_config", "expected_text"),
     [

--- a/tests/model_executor/models/qwen3_tts/test_qwen3_tts_code2wav.py
+++ b/tests/model_executor/models/qwen3_tts/test_qwen3_tts_code2wav.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -23,7 +23,7 @@ class _FakeDecoder(nn.Module):
     def __init__(self, total_upsample: int = _TOTAL_UPSAMPLE):
         super().__init__()
         self.total_upsample = total_upsample
-        self.decode_calls: list[dict[str, int]] = []
+        self.decode_calls: list[dict[str, object]] = []
         self.batched_decode_calls: list[dict[str, object]] = []
         self.decode_codes: list[torch.Tensor] = []
         self.cudagraph_calls: list[dict[str, int | torch.device]] = []
@@ -91,8 +91,8 @@ class _FakeDecoder(nn.Module):
         wav_len = frames * self.total_upsample + 6
         wav = torch.arange(wav_len, dtype=torch.float32).view(1, 1, -1)
         offsets = torch.arange(batch, dtype=torch.float32).view(batch, 1, 1) * 1000
-        outputs = wav.expand(batch, 1, wav_len) + offsets
-        return [outputs[row, :, : lengths[row] * self.total_upsample] for row in range(batch)]
+        batched_outputs = wav.expand(batch, 1, wav_len) + offsets
+        return [batched_outputs[row, :, : lengths[row] * self.total_upsample] for row in range(batch)]
 
     def enable_cudagraph(self, **kwargs):
         self.cudagraph_calls.append(kwargs)
@@ -573,6 +573,7 @@ def test_decode_chunking_override_is_passed_to_cudagraph():
     _load_weights_noop(model)
 
     assert model.decoder.cudagraph_calls[-1] == {
+        "capture_modes": ("icl", "xvec"),
         "capture_batch_sizes": None,
         "stateless_capture_sizes": None,
         "device": torch.device("cuda"),
@@ -601,6 +602,13 @@ def test_cudagraph_batch_config_is_preserved():
 
     call = model.decoder.cudagraph_calls[-1]
     assert call["capture_batch_sizes"] == [1, 2, 4, 8]
+
+
+def test_cudagraph_captures_only_modes_used_by_the_model():
+    model = _make_model(async_chunk=True, device=torch.device("cuda"))
+    model.decoder_cudagraph_modes = ("xvec",)
+    _load_weights_noop(model)
+    assert model.decoder.cudagraph_calls[-1]["capture_modes"] == ("xvec",)
 
 
 def test_stateless_cudagraph_capture_sizes_are_passed_from_config():

--- a/tests/model_executor/models/test_breeze_tts.py
+++ b/tests/model_executor/models/test_breeze_tts.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Check depth attention against HF Llama and request-local sampling state."""
+
+from collections import defaultdict
+
+import numpy as np
+import pytest
+import torch
+import torch.nn.functional as F
+from transformers import LlamaConfig, MimiConfig
+from transformers.models.llama.modeling_llama import LlamaModel
+from transformers.models.mimi.modeling_mimi import MimiConv1d
+
+from vllm_omni.engine.serialization import deserialize_additional_information, serialize_additional_information
+from vllm_omni.model_executor.models.breeze_tts.depth_decoder import (
+    BreezeDepthDecoder,
+    sample_graph_logits,
+    sample_logits,
+)
+from vllm_omni.model_executor.models.breeze_tts.prompt import build_breeze_prompt
+from vllm_omni.model_executor.models.breeze_tts.reference_encoder import BreezeReferenceConv
+from vllm_omni.model_executor.stage_input_processors.breeze_tts import expand_cfg_prompts, talker2code2wav_async_chunk
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+@pytest.mark.parametrize("parameter", ["temperature", "top_p", "repetition_penalty"])
+@pytest.mark.parametrize("value", [float("nan"), float("inf")])
+def test_offline_prompt_rejects_nonfinite_sampling(mocker, parameter, value):
+    with pytest.raises(ValueError, match="sampling"):
+        build_breeze_prompt(mocker.Mock(), "Hello.", **{parameter: value})
+
+
+@pytest.mark.parametrize("stride", [2, 3])
+def test_reference_convolution_batch_preserves_partial_final_frames(stride):
+    torch.manual_seed(7)
+    config = MimiConfig(use_causal_conv=True, pad_mode="constant")
+    first = MimiConv1d(config, 1, 4, kernel_size=2 * stride, stride=stride)
+    last = MimiConv1d(config, 4, 4, kernel_size=4, stride=2, pad_mode="replicate", bias=False)
+    batched_first = BreezeReferenceConv(first, stride)
+    batched_last = BreezeReferenceConv(last, 2 * stride)
+    lengths = torch.tensor([37, 62])
+    batched_first.sample_lengths = batched_last.sample_lengths = lengths
+    waves = [torch.randn(1, 1, int(length)) for length in lengths]
+    padded = torch.cat([F.pad(wave, (0, 96 - wave.shape[-1])) for wave in waves])
+    actual = batched_last(batched_first(padded))
+    for row, waveform in enumerate(waves):
+        expected = last(first(waveform))
+        torch.testing.assert_close(actual[row : row + 1, :, : expected.shape[-1]], expected)
+        assert not actual[row, :, expected.shape[-1] :].count_nonzero()
+
+
+def test_reference_conditioning_survives_transport_and_cfg_keeps_true_prompt_lengths(mocker) -> None:
+    tokenizer = mocker.Mock()
+    tokenizer.encode.side_effect = lambda text, **kwargs: list(text.encode("utf-8"))
+    waveform = np.zeros(1921, dtype=np.float32)
+    prompt = build_breeze_prompt(
+        tokenizer, "Hello.", "Speak happily.", ref_audio=(waveform, 24000), ref_text="Reference.", guidance_scale=4
+    )
+    companion = expand_cfg_prompts(prompt, None)[0].prompt
+    assert len(prompt["prompt_token_ids"]) > len(companion["prompt_token_ids"])
+    positive = deserialize_additional_information(serialize_additional_information(prompt["additional_information"]))
+    negative = deserialize_additional_information(serialize_additional_information(companion["additional_information"]))
+    assert positive["breeze_prompt"]["target_ids"] == list(b"[S0]<ins_bos>Speak happily.<ins_eos>Hello.")
+    assert negative["breeze_prompt"]["target_ids"] == list(b"[S0]Hello.")
+    assert positive["breeze_prompt"]["reference_ids"] == negative["breeze_prompt"]["reference_ids"]
+    assert positive["breeze_prompt"]["reference_frames"] == 2
+    assert positive["cfg_group"]["role"] == "cond"
+    assert negative["cfg_group"]["role"] == "uncond"
+    torch.testing.assert_close(positive["reference_waveform"], torch.from_numpy(waveform), atol=0, rtol=0)
+    torch.testing.assert_close(negative["reference_waveform"], positive["reference_waveform"], atol=0, rtol=0)
+
+
+@pytest.fixture
+def depth() -> BreezeDepthDecoder:
+    torch.manual_seed(42)
+    config = LlamaConfig(
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        vocab_size=35,
+        max_position_embeddings=16,
+        rope_theta=500000.0,
+        rope_scaling={
+            "rope_type": "llama3",
+            "factor": 32.0,
+            "low_freq_factor": 0.001953125,
+            "high_freq_factor": 0.0078125,
+            "original_max_position_embeddings": 16,
+        },
+    )
+    config.num_codebooks = 4
+    config.audio_embed_size = 48
+    config._attn_implementation = "eager"
+    model = BreezeDepthDecoder(config).eval()
+    torch.nn.init.normal_(model.codebooks_head, std=0.1)
+    return model
+
+
+@pytest.fixture
+def hf_depth(depth: BreezeDepthDecoder) -> LlamaModel:
+    reference = LlamaModel(depth.config).eval()
+    weights = {}
+    for name, parameter in depth.named_parameters():
+        if name.startswith("layers."):
+            if name.endswith("qkv.weight"):
+                layer = depth.layers[int(name.split(".")[1])]
+                for part, tensor in zip(
+                    ("q", "k", "v"), parameter.split([layer.q_size, layer.kv_size, layer.kv_size]), strict=True
+                ):
+                    weights[name.replace("qkv.weight", f"self_attn.{part}_proj.weight")] = tensor
+            elif name.endswith("gate_up.weight"):
+                for part, tensor in zip(("gate", "up"), parameter.chunk(2), strict=True):
+                    weights[name.replace("gate_up.weight", f"mlp.{part}_proj.weight")] = tensor
+            else:
+                weights[name.replace(".o_proj.", ".self_attn.o_proj.").replace(".down_proj.", ".mlp.down_proj.")] = (
+                    parameter
+                )
+        elif name == "norm.weight":
+            weights[name] = parameter
+    result = reference.load_state_dict(weights, strict=False)
+    assert result.missing_keys == ["embed_tokens.weight"]
+    assert result.unexpected_keys == []
+    return reference
+
+
+@pytest.mark.parametrize("batch", [1, 2])
+@torch.inference_mode()
+def test_depth_cached_attention_matches_hf_full_sequence(
+    depth: BreezeDepthDecoder, hf_depth: LlamaModel, batch: int
+) -> None:
+    """Wrong cache positions or fused-QKV ordering change the reference hidden states."""
+    embeddings = torch.randn(batch, 4, depth.config.hidden_size)
+    expected = hf_depth(inputs_embeds=embeddings, use_cache=False).last_hidden_state
+    shape = (batch, 2, 4, 8)
+    caches = [(torch.zeros(shape), torch.zeros(shape)) for _ in depth.layers]
+    actual = []
+    for start, end in [(0, 2), (2, 3), (3, 4)]:
+        x = embeddings[:, start:end]
+        for layer, cache in zip(depth.layers, caches, strict=True):
+            x = layer(
+                x,
+                depth.positions[start:end],
+                cache,
+                depth.causal_mask[start:end, :4][None, None],
+                depth.rope_cos[start:end][None, None],
+                depth.rope_sin[start:end][None, None],
+            )
+        actual.append(depth.norm(x))
+    torch.testing.assert_close(torch.cat(actual, 1), expected, atol=2e-6, rtol=2e-5)
+
+
+@pytest.mark.parametrize("guidance_scale", [0.5, 4.0])
+@torch.inference_mode()
+def test_cfg_depth_matches_hf_full_prefix_at_every_codebook(
+    depth: BreezeDepthDecoder, hf_depth: LlamaModel, guidance_scale: float
+) -> None:
+    hidden = torch.randn(4, depth.config.audio_embed_size)
+    first = torch.tensor([7, 11])
+    prefix = torch.cat((hidden[:, None], depth.embed_tokens(first.repeat(2)[:, None])), dim=1)
+    expected = [first]
+    for codebook in range(depth.num_codebooks - 1):
+        states = hf_depth(inputs_embeds=depth.inputs_embeds_projector(prefix), use_cache=False).last_hidden_state
+        logits = F.linear(states[:, -1].float(), depth.codebooks_head[codebook].T)
+        cond, uncond = logits.chunk(2)
+        token = (uncond + guidance_scale * (cond - uncond))[:, : depth.vocab_size - 3].argmax(-1)
+        expected.append(token)
+        embed = depth.embed_tokens((token.repeat(2) + (codebook + 1) * depth.vocab_size)[:, None])
+        prefix = torch.cat((prefix, embed), dim=1)
+    actual = depth._generate_frame(
+        hidden, first, depth._allocate_cache(hidden), 0.0, 0, 1.0, torch.Generator(), guidance_scale=guidance_scale
+    )
+    torch.testing.assert_close(actual, torch.stack(expected, dim=-1), atol=0, rtol=0)
+
+
+@torch.inference_mode()
+def test_frame_generation_does_not_reuse_another_requests_cache(depth: BreezeDepthDecoder) -> None:
+    hidden = torch.randn(1, 48)
+    first = torch.tensor([7])
+
+    def generate(value: torch.Tensor) -> torch.Tensor:
+        return depth.generate_frame(
+            value, first, temperature=0.9, top_k=10, top_p=0.8, generator=torch.Generator().manual_seed(99)
+        )
+
+    expected = generate(hidden)
+    generate(hidden * -3)
+    torch.testing.assert_close(generate(hidden), expected, atol=0, rtol=0)
+
+
+def test_top_k_keeps_tied_candidates_and_nucleus_keeps_crossing_token() -> None:
+    generator = torch.Generator().manual_seed(42)
+    logits = torch.tensor([[0.0, 0.0, -100.0]]).expand(128, -1)
+    sampled = sample_logits(logits, 1.0, 1, 1.0, generator)
+    assert set(sampled.tolist()) == {0, 1}
+    sampled = sample_logits(torch.tensor([[10.0, 0.0]]), 1.0, 0, 0.1, generator)
+    assert sampled.item() == 0
+
+
+@pytest.mark.parametrize("parameters", [(0.0, 0, 1.0), (0.9, 50, 1.0), (0.7, 100, 0.8), (1.2, 0, 0.95)])
+def test_graph_sampler_matches_scalar_filtering_with_identical_noise(parameters) -> None:
+    generator = torch.Generator().manual_seed(42)
+    logits = torch.randn(32, 2051, generator=generator)
+    logits[:, -3:] = -torch.inf
+    logits[:, 10:14] = 4.0
+    noise = torch.empty_like(logits).exponential_(generator=generator)
+    expected = sample_logits(logits, *parameters, generator, noise)
+    actual = sample_graph_logits(logits, torch.tensor(parameters), noise)
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+def test_codec_chunks_preserve_zero_frames_and_flush_each_request_once(mocker) -> None:
+    manager = mocker.Mock()
+    manager.connector.config = {"extra": {"codec_chunk_frames": 5, "initial_codec_chunk_frames": 5}}
+    manager.code_prompt_token_ids = defaultdict(list)
+    manager.request_payload = {}
+    first = mocker.Mock(external_req_id="first")
+    first.is_finished.return_value = False
+    second = mocker.Mock(external_req_id="second")
+    second.is_finished.return_value = False
+    zeros = {"codes": {"audio": torch.zeros(3, 16, dtype=torch.long)}}
+    assert talker2code2wav_async_chunk(manager, zeros, first) is None
+    assert talker2code2wav_async_chunk(manager, zeros, second) is None
+    codes = torch.arange(64).reshape(4, 16)
+    output = talker2code2wav_async_chunk(manager, {"codes": {"audio": codes}}, first)
+    expected = torch.cat((torch.zeros(3, 16, dtype=torch.long), codes))
+    torch.testing.assert_close(output.codes.audio.reshape(16, -1).T, expected)
+    final = talker2code2wav_async_chunk(manager, None, first, is_finished=True)
+    assert final.codes.audio.numel() == 0
+    assert final.meta.finished.item()
+    other = talker2code2wav_async_chunk(manager, None, second, is_finished=True)
+    torch.testing.assert_close(other.codes.audio, torch.zeros(48, dtype=torch.long))
+
+
+def test_codec_chunk_ramp_keeps_frame_order_and_flushes_partial_tail(mocker) -> None:
+    manager = mocker.Mock()
+    manager.connector.config = {"extra": {"codec_chunk_frames": 5, "codec_chunk_ramp": [1, 2, 4, 5]}}
+    manager.code_prompt_token_ids = defaultdict(list)
+    manager.request_payload = {}
+    request = mocker.Mock(external_req_id="ramp")
+    request.is_finished.return_value = False
+    outputs = []
+    for index in range(15):
+        result = talker2code2wav_async_chunk(manager, {"codes": {"audio": torch.full((1, 16), index)}}, request)
+        if result is not None:
+            outputs.append(result.codes.audio.reshape(16, -1).T)
+    tail = talker2code2wav_async_chunk(manager, None, request, is_finished=True)
+    outputs.append(tail.codes.audio.reshape(16, -1).T)
+    assert [len(part) for part in outputs] == [1, 2, 4, 5, 3]
+    torch.testing.assert_close(torch.cat(outputs), torch.arange(15)[:, None].expand(-1, 16))
+    assert tail.meta.finished.item()

--- a/tests/model_executor/models/test_breeze_tts_graphs.py
+++ b/tests/model_executor/models/test_breeze_tts_graphs.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Check captured cache ownership and padded text masking against eager models."""
+
+import pytest
+import torch
+from transformers import LlamaConfig, T5Gemma2TextConfig
+from transformers.models.t5gemma2.modeling_t5gemma2 import T5Gemma2TextEncoder
+
+from tests.helpers.mark import hardware_test
+from vllm_omni.model_executor.models.breeze_tts.depth_decoder import BreezeDepthDecoder
+from vllm_omni.model_executor.models.breeze_tts.text_encoder_graph import (
+    BreezeTextEncoderCompiled,
+    BreezeTextEncoderGraph,
+)
+
+pytestmark = [pytest.mark.core_model]
+
+
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@torch.inference_mode()
+def test_text_graph_masks_padding_and_local_attention_across_replays() -> None:
+    torch.manual_seed(42)
+    config = T5Gemma2TextConfig(
+        vocab_size=64,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        sliding_window=16,
+        layer_types=["sliding_attention", "full_attention"],
+        dropout_rate=0.0,
+    )
+    config._attn_implementation = "sdpa"
+    encoder = T5Gemma2TextEncoder(config).to("cuda").eval()
+    encoder.embed_tokens.eoi_token_index = 17
+    encoder.embed_tokens.eoi_embedding.fill_(0.4)
+    projection = torch.nn.Linear(32, 48, bias=False).to("cuda").eval()
+    graph = BreezeTextEncoderGraph(encoder, projection, 64)
+    for length in (31, 51, 17, 31):
+        prompt = torch.randint(0, 64, (1, length), device="cuda")
+        prompt[:, 3] = 17
+        expected = projection(encoder(input_ids=prompt).last_hidden_state)[0]
+        actual = graph.run(prompt)
+        torch.testing.assert_close(actual, expected, atol=2e-6, rtol=2e-5)
+
+    batched = BreezeTextEncoderGraph(encoder, projection, 64, batch_size=3)
+    prompts = [torch.randint(0, 64, (length,), device="cuda") for length in (31, 51, 17)]
+    outputs = batched.run_batch(prompts)
+    for prompt, actual in zip(prompts, outputs, strict=True):
+        expected = projection(encoder(input_ids=prompt[None]).last_hidden_state)[0]
+        torch.testing.assert_close(actual, expected, atol=2e-6, rtol=2e-5)
+
+    compiled = BreezeTextEncoderCompiled(encoder, projection)
+    long_prompts = [torch.randint(0, 64, (length,)) for length in (211, 173, 129)]
+    for batch in ([long_prompts[0]], long_prompts, [long_prompts[1]]):
+        outputs = compiled.run_batch(batch)
+        for prompt, actual in zip(batch, outputs, strict=True):
+            expected = projection(encoder(input_ids=prompt[None].to("cuda")).last_hidden_state)[0]
+            torch.testing.assert_close(actual, expected, atol=2e-6, rtol=2e-5)
+
+
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@torch.inference_mode()
+def test_depth_graph_survives_interleaved_batches_and_workspace_allocations() -> None:
+    torch.manual_seed(42)
+    config = LlamaConfig(
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        vocab_size=35,
+        max_position_embeddings=16,
+        rope_theta=500000.0,
+        rope_scaling={
+            "rope_type": "llama3",
+            "factor": 32.0,
+            "low_freq_factor": 0.001953125,
+            "high_freq_factor": 0.0078125,
+            "original_max_position_embeddings": 16,
+        },
+    )
+    config.num_codebooks = 4
+    config.audio_embed_size = 48
+    depth = BreezeDepthDecoder(config).to("cuda").eval()
+    torch.nn.init.normal_(depth.codebooks_head, std=0.1)
+    hidden = torch.randn(2, 48, device="cuda")
+    first = torch.tensor([7, 11], device="cuda")
+    generators = [torch.Generator(device="cuda").manual_seed(seed) for seed in (42, 99)]
+    expected = torch.cat(
+        [
+            depth.generate_frame(hidden[i : i + 1], first[i : i + 1], temperature=0, top_k=0, top_p=1, generator=g)
+            for i, g in enumerate(generators)
+        ]
+    )
+    for batch in (1, 2, 1, 2):
+        # Unowned allocations made before graph capture would be recycled here.
+        pressure = [torch.full((batch, 2, 4, 8), float("nan"), device="cuda") for _ in range(32)]
+        actual = depth.generate_frames(
+            hidden[:batch], first[:batch], temperature=0, top_k=0, top_p=1, generators=generators[:batch]
+        )
+        torch.testing.assert_close(actual, expected[:batch], atol=0, rtol=0)
+        del pressure
+
+    def sample(batch: int) -> torch.Tensor:
+        return depth.generate_frames(
+            hidden[:batch],
+            first[:batch],
+            temperature=0.9,
+            top_k=10,
+            top_p=0.8,
+            generators=[torch.Generator(device="cuda").manual_seed(seed) for seed in (42, 99)[:batch]],
+        )
+
+    sampled = sample(1)
+    first_graph = depth._graphs[(1, 1)]
+    sample(2)
+    torch.testing.assert_close(sample(1), sampled, atol=0, rtol=0)
+    for temperature, top_k, top_p in ((0.0, 0, 1.0), (0.7, 20, 0.95), (1.2, 0, 0.8)):
+        depth.generate_frames(
+            hidden[:1], first[:1], temperature=temperature, top_k=top_k, top_p=top_p, generators=generators[:1]
+        )
+        assert depth._graphs[(1, 1)] is first_graph
+    torch.testing.assert_close(sample(1), sampled, atol=0, rtol=0)
+
+    graph = None
+    for scale in (4.0, 0.5, 4.0):
+        expected_cfg = depth._generate_frame(
+            hidden, first[:1], depth._allocate_cache(hidden), 0, 0, 1, generators[0], guidance_scale=scale
+        )
+        actual_cfg = depth.generate_frames(
+            hidden, first[:1], temperature=0, top_k=0, top_p=1, generators=generators[:1], guidance_scale=scale
+        )
+        torch.testing.assert_close(actual_cfg, expected_cfg, atol=0, rtol=0)
+        if graph is not None:
+            assert depth._graphs[(2, 2)] is graph
+        graph = depth._graphs[(2, 2)]
+        sample(2)

--- a/vllm_omni/config/pipeline_registry.py
+++ b/vllm_omni/config/pipeline_registry.py
@@ -46,6 +46,7 @@ from vllm_omni.model_executor.models.bagel.pipeline import (
     BAGEL_SINGLE_STAGE_PIPELINE,
     BAGEL_THINK_PIPELINE,
 )
+from vllm_omni.model_executor.models.breeze_tts.pipeline import BREEZE_TTS_PIPELINE
 from vllm_omni.model_executor.models.cosyvoice3.pipeline import COSYVOICE3_PIPELINE
 from vllm_omni.model_executor.models.covo_audio.pipeline import COVO_AUDIO_PIPELINE
 from vllm_omni.model_executor.models.dots_tts.pipeline import DOTS_TTS_PIPELINE
@@ -121,6 +122,7 @@ PipelineResolverFunc: TypeAlias = Callable[[PretrainedConfig | None], PipelineCo
 
 # --- Multi-stage omni pipelines (LLM-centric; audio / video I/O) ---
 OMNI_PIPELINES: dict[str, PipelineConfig | PipelineResolverFunc] = {
+    "breeze": BREEZE_TTS_PIPELINE,
     "aura_omni": AURA_OMNI_PIPELINE,
     "qwen2_5_omni": QWEN2_5_OMNI_PIPELINE,
     "qwen2_5_omni_thinker_only": QWEN2_5_OMNI_THINKER_ONLY_PIPELINE,

--- a/vllm_omni/core/sched/omni_cfg_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_cfg_ar_scheduler.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Atomic CFG admission for full-attention AR models with unequal prompts.
+
+Each branch retains its real prompt length and position IDs. Admission reserves
+capacity for the complete generation of both branches, so KV pressure cannot
+preempt one branch while its partner continues. Reservations account for pages;
+the ordinary paged attention manager still allocates pages as tokens arrive.
+"""
+
+from collections.abc import Iterable
+from typing import Any
+
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
+from vllm.v1.request import Request, RequestStatus
+
+from vllm_omni.core.sched.omni_ar_scheduler import OmniARScheduler
+from vllm_omni.engine.serialization import deserialize_additional_information
+
+
+class OmniCFGARScheduler(OmniARScheduler):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        if self.scheduler_config.async_scheduling or self.scheduler_config.enable_chunked_prefill:
+            raise ValueError("Atomic CFG scheduling requires synchronous scheduling and complete prefills")
+        if self.policy != SchedulingPolicy.FCFS or self.cache_config.enable_prefix_caching:
+            raise ValueError("Atomic CFG scheduling requires FCFS and disabled prefix caching")
+        if self.vllm_config.speculative_config is not None or self.connector is not None:
+            raise ValueError("Atomic CFG scheduling does not support speculative decoding or KV connectors")
+        if len(self.kv_cache_manager.kv_cache_config.kv_cache_groups) != 1:
+            raise ValueError("Atomic CFG reservations require one full-attention KV group")
+        self._capacity = self.kv_cache_manager.block_pool.num_gpu_blocks - 1 - self.kv_cache_manager.watermark_blocks
+        pair_pages = 2 * -(-self.max_model_len // self.block_size)
+        if self._capacity < pair_pages or self.max_num_running_reqs < 2:
+            raise ValueError("Atomic CFG requires KV capacity and max_num_seqs for two maximum-length branches")
+        if self.max_num_scheduled_tokens < 2 * self.max_model_len:
+            raise ValueError("Atomic CFG requires max_num_batched_tokens >= 2 * max_model_len")
+        self._pairs: dict[str, dict[str, str]] = {}
+        self._request_pairs: dict[str, str] = {}
+        self._prefill_min_output_tokens = int(self.vllm_config.additional_config.get("cfg_prefill_delay_tokens", 0))
+        if self._prefill_min_output_tokens < 0:
+            raise ValueError("cfg_prefill_delay_tokens cannot be negative")
+
+    def _should_defer_waiting_admission(self) -> bool:
+        # Let fresh streaming requests accumulate playback audio before
+        # another request's text/reference encoding occupies the same device.
+        return any(request.num_output_tokens < self._prefill_min_output_tokens for request in self.running)
+
+    def add_request(self, request: Request) -> None:
+        payload = getattr(request, "additional_information", None)
+        info = deserialize_additional_information(payload) if payload is not None else {}
+        group = info.get("cfg_group")
+        if group is not None:
+            role = group["role"]
+            suffix = group["uncond_suffix"]
+            if role not in ("cond", "uncond") or not suffix:
+                raise ValueError("CFG groups require cond/uncond roles and a companion suffix")
+            external_id = request.external_req_id
+            if role == "uncond":
+                if not external_id.endswith(suffix):
+                    raise ValueError("CFG companion request ID does not match its suffix")
+                pair_id = external_id[: -len(suffix)]
+            else:
+                pair_id = external_id
+            pair = self._pairs.setdefault(pair_id, {})
+            if role in pair:
+                raise ValueError("Duplicate CFG branch")
+            pair[role] = request.request_id
+            self._request_pairs[request.request_id] = pair_id
+        super().add_request(request)
+
+    def _reserved_pages(self, request: Request) -> int:
+        length = min(self.max_model_len, request.num_prompt_tokens + request.max_tokens)
+        return -(-length // self.block_size)
+
+    def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
+        self._drop_aborted_queued_requests()
+        self._prune_pairs()
+        original_waiting = self.waiting
+        admitted = create_request_queue(self.policy)
+        pending = {request.request_id: request for request in original_waiting}
+        pages = self._capacity - sum(self._reserved_pages(request) for request in self.running)
+        slots = self.max_num_running_reqs - len(self.running)
+        tokens = self.max_num_scheduled_tokens - len(self.running)
+        chosen: set[str] = set()
+        for request in original_waiting:
+            if request.request_id in chosen:
+                continue
+            pair_id = self._request_pairs.get(request.request_id)
+            if pair_id is None:
+                group = [request]
+            else:
+                pair = self._pairs[pair_id]
+                if len(pair) != 2 or any(rid not in pending for rid in pair.values()):
+                    continue
+                group = [pending[pair[role]] for role in ("cond", "uncond")]
+                # Offline callers also need both unequal-length prompts to
+                # stop together when the longer branch reaches the context.
+                limit = min(min(member.max_tokens, self.max_model_len - member.num_prompt_tokens) for member in group)
+                for member in group:
+                    member.max_tokens = limit
+            needed_pages = sum(self._reserved_pages(member) for member in group)
+            needed_tokens = sum(member.num_tokens - member.num_computed_tokens for member in group)
+            if len(group) > slots or needed_pages > pages or needed_tokens > tokens:
+                # Do not let later single-branch requests repeatedly occupy
+                # the spare slot and starve an earlier complete CFG pair.
+                break
+            for member in group:
+                admitted.add_request(member)
+                chosen.add(member.request_id)
+            pages -= needed_pages
+            tokens -= needed_tokens
+            slots -= len(group)
+        original_waiting.remove_requests([pending[rid] for rid in chosen])
+        self.waiting = admitted
+        try:
+            output = super().schedule(throttle_prefills)
+        finally:
+            original_waiting.prepend_requests(self.waiting)
+            self.waiting = original_waiting
+        for pair in self._pairs.values():
+            if len(pair) != 2:
+                continue
+            ids = list(pair.values())
+            scheduled = [rid in output.num_scheduled_tokens for rid in ids]
+            if any(scheduled) != all(scheduled):
+                raise RuntimeError("CFG atomic admission invariant violated: only one branch was scheduled")
+            if all(scheduled):
+                progress = [
+                    self.requests[rid].num_computed_tokens - self.requests[rid].num_prompt_tokens for rid in ids
+                ]
+                if progress[0] != progress[1]:
+                    raise RuntimeError("CFG branches reached different generation steps")
+        return output
+
+    def finish_requests(self, request_ids: str | Iterable[str] | None, finished_status: RequestStatus) -> list[Request]:
+        if request_ids is None:
+            ids = None
+        else:
+            ids = {request_ids} if isinstance(request_ids, str) else set(request_ids)
+            for rid in tuple(ids):
+                pair_id = self._request_pairs.get(rid)
+                if pair_id is not None:
+                    ids.update(self._pairs[pair_id].values())
+        finished = super().finish_requests(ids, finished_status)
+        self._prune_pairs()
+        return finished
+
+    def _prune_pairs(self) -> None:
+        for pair_id, pair in list(self._pairs.items()):
+            if all(rid not in self.requests for rid in pair.values()):
+                del self._pairs[pair_id]
+                for rid in pair.values():
+                    self._request_pairs.pop(rid, None)

--- a/vllm_omni/deploy/breeze_tts.yaml
+++ b/vllm_omni/deploy/breeze_tts.yaml
@@ -1,0 +1,61 @@
+# Breeze-TTS-2, one GPU, voice design, cloning, and instruction guidance.
+# Both streamed and complete HTTP responses use the stateful codec pipeline.
+async_chunk: true
+connectors:
+  shm:
+    name: SharedMemoryConnector
+    extra:
+      codec_streaming: true
+      codec_chunk_frames: 5
+      initial_codec_chunk_frames: 1
+      codec_chunk_ramp: [1, 2, 4, 5]
+      codec_left_context_frames: 0
+      decode_cudagraph_batch_sizes: [1, 2]
+      connector_get_sleep_s: 0.001
+      connector_get_max_wait_first_chunk: 1000
+      connector_get_max_wait: 300
+stages:
+  - stage_id: 0
+    devices: "0"
+    max_num_seqs: 2
+    max_model_len: 2048
+    max_num_batched_tokens: 4096
+    gpu_memory_utilization: 0.65
+    kv_cache_memory_bytes: 536870912
+    enforce_eager: false
+    compilation_config:
+      mode: 3
+      cudagraph_mode: FULL_AND_PIECEWISE
+      cudagraph_capture_sizes: [1, 2, 32, 64, 128, 256]
+    enable_prefix_caching: false
+    enable_chunked_prefill: false
+    async_scheduling: false
+    engine_extras:
+      additional_config:
+        cfg_prefill_delay_tokens: 8
+    output_connectors:
+      to_stage_1: shm
+    default_sampling_params:
+      temperature: 0.9
+      top_p: 1.0
+      top_k: 50
+      repetition_penalty: 1.1
+      max_tokens: 1500
+      seed: 42
+  - stage_id: 1
+    devices: "0"
+    max_num_seqs: 2
+    max_model_len: 32768
+    max_num_batched_tokens: 32768
+    gpu_memory_utilization: 0.15
+    enforce_eager: false
+    enable_prefix_caching: false
+    async_scheduling: true
+    input_connectors:
+      from_stage_0: shm
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      repetition_penalty: 1.0
+      max_tokens: 32768

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -54,6 +54,7 @@ def _register_omni_hf_configs() -> None:
     try:
         from transformers import AutoConfig
 
+        from vllm_omni.model_executor.models.breeze_tts.configuration_breeze import BreezeConfig
         from vllm_omni.model_executor.models.indextts2.configuration_indextts2 import (
             IndexTTS2Config,
             IndexTTS25Config,
@@ -92,6 +93,7 @@ def _register_omni_hf_configs() -> None:
         _CONFIG_REGISTRY = None
 
     for model_type, config_cls in [
+        ("breeze", BreezeConfig),
         ("dense", MingDenseConfig),
         ("bailingmm", MingMoeConfig),
         ("indextts2", IndexTTS2Config),

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -14,8 +14,9 @@ import asyncio
 import time
 import uuid
 from collections.abc import AsyncGenerator, Iterable, Mapping, Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
+import anyio
 from vllm import TokensPrompt
 from vllm.engine.protocol import EngineClient, StreamingInput
 from vllm.logger import init_logger
@@ -38,6 +39,7 @@ from vllm_omni.engine.duplex.messages import (
 from vllm_omni.engine.messages import ErrorMessage, OutputMessage
 from vllm_omni.entrypoints.client_request_state import ClientRequestState
 from vllm_omni.entrypoints.duplex_request_client import (
+    DuplexEnginePort,
     DuplexRequestClient,
     DuplexRequestOutputPort,
 )
@@ -94,6 +96,9 @@ class AsyncEventResolver:
 
         if tid is None and isinstance(ack, dict):
             tid = ack.get("task_id")
+        if tid is None:
+            logger.warning("Received ACK without a task_id")
+            return
 
         async with self._lock:
             task_info = self._pending_tasks.get(tid)
@@ -418,9 +423,9 @@ class AsyncOmni(EngineClient, OmniBase):
     def _get_duplex_request_client(self) -> DuplexRequestClient:
         client = getattr(self, "_duplex_request_client", None)
         if client is None:
-            engine = getattr(self, "engine", None)
+            engine = self.engine
             client = DuplexRequestClient(
-                engine,
+                cast(DuplexEnginePort, engine),
                 DuplexRequestOutputPort(
                     request_states=getattr(self, "request_states", {}),
                     num_stages=getattr(engine, "num_stages", 1),
@@ -612,7 +617,7 @@ class AsyncOmni(EngineClient, OmniBase):
             # chunks incrementally through streaming_update. The helper
             # returns as soon as the pump task is created; each ADD/update
             # takes its own admission slot inside the pump.
-            if streaming_input:
+            if isinstance(prompt, AsyncGenerator):
                 first_chunk_submitted = asyncio.get_running_loop().create_future()
                 input_stream_task = await self._add_streaming_input_request(
                     request_id=request_id,
@@ -636,7 +641,8 @@ class AsyncOmni(EngineClient, OmniBase):
                     lora_request=lora_request,
                 )
             submit_ts = time.time()
-            req_state.metrics.stage_first_ts[0] = submit_ts
+            stage_first_ts = cast(list[float | None], req_state.metrics.stage_first_ts)
+            stage_first_ts[0] = submit_ts
             req_start_ts[request_id] = submit_ts
             if admitting:
                 await self._release_generate_admission()
@@ -661,7 +667,10 @@ class AsyncOmni(EngineClient, OmniBase):
 
         except (asyncio.CancelledError, GeneratorExit):
             self._record_request_failure_once(request_id, reason="client_disconnect")
-            await self._abort_internal_requests(request_id)
+            # ASGI cancellation scopes cancel subsequent await points too.
+            # Finish the engine abort before removing the local request state.
+            with anyio.CancelScope(shield=True):
+                await self._abort_internal_requests(request_id)
             logger.info(f"[AsyncOmni] Request {request_id} aborted.")
             raise
         except Exception as e:
@@ -710,6 +719,7 @@ class AsyncOmni(EngineClient, OmniBase):
         # only check thinker's sampling params now
         stage0_params = sampling_params_list[0]
         self._validate_streaming_input_sampling_params(stage0_params)
+        stage0_params = cast(SamplingParams, stage0_params)
         req_state = self.request_states[request_id]
         has_submitted_first_chunk = False
 
@@ -1007,6 +1017,7 @@ class AsyncOmni(EngineClient, OmniBase):
                     if should_continue:
                         continue
 
+                    assert req_state is not None
                     req_state.stage_id = stage_id
 
                     # Route to the per-request queue
@@ -1385,7 +1396,8 @@ class AsyncOmni(EngineClient, OmniBase):
         async with self._pause_cond:
             return self._paused
 
-    async def start_profile(
+    # EngineClient exposes async operations; OmniBase implements the sync API.
+    async def start_profile(  # type: ignore[override]
         self,
         profile_prefix: str | None = None,
         stages: list[int] | None = None,
@@ -1400,7 +1412,7 @@ class AsyncOmni(EngineClient, OmniBase):
         """
         return await self.collective_rpc(method="profile", args=(True, profile_prefix), stage_ids=stages)
 
-    async def stop_profile(self, stages: list[int] | None = None) -> list[Any]:
+    async def stop_profile(self, stages: list[int] | None = None) -> list[Any]:  # type: ignore[override]
         """Stop profiling specified stages.
 
         Uses vLLM-compatible profile(is_start=False) interface.
@@ -1706,7 +1718,7 @@ class AsyncOmni(EngineClient, OmniBase):
         mechanism does not resolve abstract methods from sibling MRO
         entries).
         """
-        return OmniBase.errored.fget(self)  # type: ignore[union-attr]
+        return super().errored
 
     @property
     def _name(self) -> str:
@@ -1732,10 +1744,14 @@ class AsyncOmni(EngineClient, OmniBase):
         """Get tokenizer for the comprehension stage."""
         stage_index = self._get_comprehension_stage_index()
         if stage_index is not None:
-            tokenizer = self.engine.output_processors[stage_index].tokenizer
+            processor = self.engine.output_processors[stage_index]
+            assert processor is not None
+            tokenizer = processor.tokenizer
             if tokenizer is not None:
                 return tokenizer
-        return self.input_processor.tokenizer  # type: ignore[return-value]
+        processor = self.input_processor
+        assert processor is not None
+        return processor.tokenizer
 
     async def is_tracing_enabled(self) -> bool:
         """Check if tracing is enabled."""
@@ -1783,7 +1799,7 @@ class AsyncOmni(EngineClient, OmniBase):
         """Return the task set exposed by the orchestrator-backed engine."""
         return tuple(self.engine.supported_tasks)
 
-    async def check_health(self) -> None:
+    async def check_health(self) -> None:  # type: ignore[override]
         """Check engine health by verifying the Orchestrator process is alive."""
         OmniBase.check_health(self)
 

--- a/vllm_omni/entrypoints/client_request_state.py
+++ b/vllm_omni/entrypoints/client_request_state.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 import asyncio
 
 from vllm_omni.metrics import OrchestratorAggregator
@@ -17,6 +20,7 @@ class ClientRequestState:
         self.stage_id: int | None = None
         self.queue = queue if queue is not None else asyncio.Queue()
         self.metrics: OrchestratorAggregator | None = None
+        self.input_stream_task: asyncio.Task | None = None
         # Request-scoped idempotency guard for Prometheus failure counters.
         self.failure_recorded = False
         # Wall-clock time at which the user's request arrived in the engine

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -19,6 +19,7 @@ from typing import Any
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
+import anyio
 import numpy as np
 import soundfile as sf
 import torch
@@ -2437,6 +2438,12 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
         finally:
             if not artifact_ready:
                 self._discard_ref_audio_artifact_warmup(request_id)
+            # A disconnect can arrive while this generator is suspended at
+            # yield, outside the engine iterator's __anext__. Explicitly close
+            # it so its abort/finally path releases active stage requests.
+            # Starlette cancels an AnyIO scope; cleanup must survive that scope.
+            with anyio.CancelScope(shield=True):
+                await generator.aclose()
 
     async def _generate_audio_sse_events(
         self,

--- a/vllm_omni/entrypoints/openai/tts_adapters/__init__.py
+++ b/vllm_omni/entrypoints/openai/tts_adapters/__init__.py
@@ -104,6 +104,7 @@ def tts_entry_stage_archs() -> frozenset[str]:
 from vllm_omni.entrypoints.openai.tts_adapters import (  # noqa: E402,F401
     audex,
     audex_tta,
+    breeze_tts,
     cosyvoice3,
     covo_audio,
     dots_tts,

--- a/vllm_omni/entrypoints/openai/tts_adapters/breeze_tts.py
+++ b/vllm_omni/entrypoints/openai/tts_adapters/breeze_tts.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+import asyncio
+import math
+
+import numpy as np
+import pybase64 as base64
+from transformers import AutoTokenizer, PreTrainedTokenizerBase
+from vllm.inputs import TokensPrompt
+from vllm.logger import init_logger
+from vllm.sampling_params import SamplingParams
+from vllm.utils.async_utils import make_async
+
+from vllm_omni.entrypoints.openai.protocol.audio import OpenAICreateSpeechRequest
+from vllm_omni.entrypoints.openai.tts_adapters import register_tts_adapter
+from vllm_omni.entrypoints.openai.tts_adapters.base import (
+    ARTTSAdapter,
+    PreparedRequest,
+    SpeechServingContext,
+    apply_max_new_tokens,
+)
+from vllm_omni.model_executor.models.breeze_tts.prompt import DEFAULT_INSTRUCTION, build_breeze_prompt
+
+logger = init_logger(__name__)
+
+
+@register_tts_adapter
+class BreezeTTSAdapter(ARTTSAdapter):
+    name = "breeze_tts"
+    stage_keys = frozenset({"breeze_tts", "breeze_code2wav"})
+    supported_output_sample_rates = frozenset({24000})
+
+    def __init__(self, ctx: SpeechServingContext) -> None:
+        super().__init__(ctx)
+        self.tokenizer: PreTrainedTokenizerBase | None = None
+        self._build_async = make_async(self._build_prompt, executor=ctx.server._tts_executor)
+
+    def _load_codec_frame_rate(self) -> float:
+        # Breeze-TTS-2 uses 1,920 waveform samples per frame at 24 kHz.
+        return 24000 / 1920
+
+    async def warmup(self) -> None:
+        """Prime text, depth and reference paths through the ordinary runner."""
+        server = self.ctx.server
+        logger.info("Warming Breeze text graphs, CFG branches, reference encoder and streaming codec")
+
+        async def generate(text: str, request_id: str, **kwargs: object) -> bytes:
+            request = OpenAICreateSpeechRequest(
+                input=text, model=server.model_name, response_format="wav", seed=42, max_new_tokens=64, **kwargs
+            )
+            audio, _ = await server._generate_audio_bytes(request, request_id=request_id)
+            return audio
+
+        reference_text = "Welcome to this demonstration of clear and natural speech synthesis."
+        reference = await generate(reference_text, "breeze-warmup-single")
+        await generate(
+            "Hello.",
+            "breeze-warmup-cfg",
+            extra_params={"guidance_scale": 4.0, "temperature": 0.7, "top_k": 100, "top_p": 0.8},
+        )
+        await generate(
+            "Hello again.",
+            "breeze-warmup-reference",
+            ref_audio="data:audio/wav;base64," + base64.b64encode(reference).decode("ascii"),
+            ref_text=reference_text,
+            extra_params={"guidance_scale": 4.0},
+        )
+        await asyncio.gather(
+            generate(reference_text, "breeze-warmup-batch-a"),
+            generate("Thank you for listening to this clear and natural voice demonstration.", "breeze-warmup-batch-b"),
+        )
+        logger.info("Breeze speech warmup complete")
+
+    def validate(self, request: OpenAICreateSpeechRequest) -> str | None:
+        if not request.input.strip():
+            return "Input text cannot be empty"
+        if request.voice not in (None, "default"):
+            return "Breeze uses instructions or ref_audio/ref_text; named voices are not supported"
+        if request.ref_audio_2 is not None or request.speaker_embedding is not None:
+            return "Breeze accepts one reference recording and its transcript"
+        has_reference = request.ref_audio is not None
+        if has_reference:
+            if (
+                not isinstance(request.ref_audio, str)
+                or not isinstance(request.ref_text, str)
+                or not request.ref_text.strip()
+            ):
+                return "Breeze voice cloning requires one ref_audio URL and a non-empty ref_text transcript"
+            error = self.ctx.server._validate_ref_audio_format(request.ref_audio)
+            if error:
+                return error
+        elif request.ref_text is not None:
+            return "Breeze ref_text requires ref_audio"
+        expected_task = "Base" if has_reference else "VoiceDesign"
+        if request.task_type not in (None, expected_task):
+            return f"Breeze requires task_type='{expected_task}' for this conditioning"
+        if request.x_vector_only_mode is not None:
+            return "Breeze does not support x_vector_only_mode"
+        extra = request.extra_params or {}
+        supported = {"guidance_scale", "temperature", "top_k", "top_p", "repetition_penalty"}
+        if unknown := set(extra) - supported:
+            return f"Unsupported Breeze parameters: {sorted(unknown)}"
+        for key, value in extra.items():
+            if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+                return f"Breeze {key} must be a finite number"
+        if extra.get("guidance_scale", 1.0) <= 0 or extra.get("repetition_penalty", 1.1) <= 0:
+            return "Breeze guidance_scale and repetition_penalty must be positive"
+        if extra.get("temperature", 0.9) < 0 or not 0 < extra.get("top_p", 1.0) <= 1:
+            return "Breeze requires temperature >= 0 and 0 < top_p <= 1"
+        top_k = extra.get("top_k", 50)
+        if not isinstance(top_k, int) or top_k < -1:
+            return "Breeze top_k must be -1, 0, or a positive integer"
+        return None
+
+    def _build_prompt(
+        self,
+        request: OpenAICreateSpeechRequest,
+        sampling: SamplingParams,
+        reference: tuple[np.ndarray, int] | None,
+    ) -> TokensPrompt:
+        if self.tokenizer is None:
+            engine_client = self.ctx.engine_client
+            if engine_client is None:
+                raise RuntimeError("Breeze speech serving requires an engine client")
+            model = engine_client.model_config.model
+            self.tokenizer = AutoTokenizer.from_pretrained(model, config=engine_client.model_config.hf_config)
+        extra = request.extra_params or {}
+        return build_breeze_prompt(
+            self.tokenizer,
+            request.input,
+            DEFAULT_INSTRUCTION if request.instructions is None else request.instructions,
+            ref_audio=reference,
+            ref_text=request.ref_text,
+            guidance_scale=float(extra.get("guidance_scale", 1.0)),
+            temperature=float(extra.get("temperature", sampling.temperature)),
+            top_k=max(int(extra.get("top_k", sampling.top_k)), 0),
+            top_p=float(extra.get("top_p", sampling.top_p)),
+            repetition_penalty=float(extra.get("repetition_penalty", sampling.repetition_penalty)),
+        )
+
+    async def build(
+        self,
+        request: OpenAICreateSpeechRequest,
+        sampling_params_list: list[SamplingParams],
+        has_inline_ref_audio: bool,
+    ) -> PreparedRequest:
+        reference = None
+        if request.ref_audio is not None:
+            waveform, sample_rate, _ = await self.ctx.server._resolve_ref_audio(request.ref_audio)
+            reference = (np.asarray(waveform, dtype=np.float32), sample_rate)
+        prompt = await self._build_async(request, sampling_params_list[0], reference)
+        return PreparedRequest(prompt=prompt, model_type=self.name)
+
+    def apply_sampling_overrides(
+        self,
+        sampling_params_list: list[SamplingParams],
+        request: OpenAICreateSpeechRequest,
+        prompt: dict | None = None,
+        request_id: str | None = None,
+    ) -> list[SamplingParams]:
+        params = apply_max_new_tokens(sampling_params_list, request)
+        params = list(params)
+        params[0] = params[0].clone()
+        if params[0].top_k == 0:
+            params[0].top_k = -1
+        extra = request.extra_params or {}
+        if "repetition_penalty" in extra:
+            params[0].repetition_penalty = extra["repetition_penalty"]
+        if prompt is not None:
+            engine_client = self.ctx.engine_client
+            if engine_client is None:
+                raise RuntimeError("Breeze speech serving requires an engine client")
+            model_config = engine_client.model_config
+            available = model_config.max_model_len - len(prompt["prompt_token_ids"])
+            if available <= 0:
+                raise ValueError("Breeze conditioning fills the model context; shorten the text or reference audio")
+            # Both CFG branches must stop after the same number of frames,
+            # including when the conditioned prompt reaches the context limit.
+            params[0].max_tokens = min(params[0].max_tokens, available)
+        return params

--- a/vllm_omni/model_executor/models/breeze_tts/__init__.py
+++ b/vllm_omni/model_executor/models/breeze_tts/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from .code2wav import BreezeCode2Wav
+from .modeling_breeze import BreezeForConditionalGeneration
+
+__all__ = ["BreezeCode2Wav", "BreezeForConditionalGeneration"]

--- a/vllm_omni/model_executor/models/breeze_tts/code2wav.py
+++ b/vllm_omni/model_executor/models/breeze_tts/code2wav.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from vllm_omni.model_executor.models.qwen3_tts.qwen3_tts_code2wav import Qwen3TTSCode2Wav
+
+
+class BreezeCode2Wav(Qwen3TTSCode2Wav):
+    """Breeze bundles the same Qwen3 codec under audio_tokenizer/."""
+
+    tokenizer_subfolder = "audio_tokenizer"
+    # Reference conditioning is consumed by the AR stage. The codec receives
+    # generated codes only, so it never decodes an ICL reference prefix.
+    decoder_cudagraph_modes = ("xvec",)

--- a/vllm_omni/model_executor/models/breeze_tts/configuration_breeze.py
+++ b/vllm_omni/model_executor/models/breeze_tts/configuration_breeze.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Configuration for the released Breeze-TTS-2 checkpoint."""
+
+from transformers import LlamaConfig, PretrainedConfig, Qwen3Config
+from transformers.models.t5gemma2.configuration_t5gemma2 import T5Gemma2TextConfig
+
+
+class BreezeConfig(PretrainedConfig):
+    model_type = "breeze"
+
+    def __init__(
+        self,
+        backbone_config: dict | None = None,
+        depth_decoder_config: dict | None = None,
+        text_encoder_config: dict | None = None,
+        num_codebooks: int = 16,
+        audio_vocab_size: int = 2051,
+        audio_embed_size: int = 2048,
+        max_position_embeddings: int = 2048,
+        rope_scaling: dict | None = None,
+        rope_theta: float = 500000.0,
+        **kwargs: object,
+    ) -> None:
+        self.max_position_embeddings = max_position_embeddings
+        self.rope_parameters = {"rope_theta": rope_theta, **(rope_scaling or {"rope_type": "default"})}
+        self.num_codebooks = num_codebooks
+        self.audio_vocab_size = audio_vocab_size
+        self.audio_embed_size = audio_embed_size
+        self.backbone_config = Qwen3Config(**(backbone_config or {}))
+        self.depth_decoder_config = LlamaConfig(**(depth_decoder_config or {}))
+        self.text_encoder_config = T5Gemma2TextConfig(**(text_encoder_config or {}))
+        # The scheduler samples continuation/EOS tokens. Text encoder IDs are
+        # carried in the prompt payload and are outside this vocabulary.
+        self.vocab_size = audio_vocab_size + 1
+        self.eos_token_id = audio_vocab_size
+        self.backbone_config.vocab_size = self.vocab_size
+        self.backbone_config.bos_token_id = 0
+        self.backbone_config.pad_token_id = 0
+        self.backbone_config.eos_token_id = self.eos_token_id
+        self.backbone_config.tie_word_embeddings = False
+        super().__init__(**kwargs)
+        self.vocab_size = audio_vocab_size + 1
+        self.eos_token_id = audio_vocab_size
+
+    def get_text_config(self, decoder: bool = False) -> Qwen3Config:
+        return self.backbone_config

--- a/vllm_omni/model_executor/models/breeze_tts/depth_decoder.py
+++ b/vllm_omni/model_executor/models/breeze_tts/depth_decoder.py
@@ -1,0 +1,327 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Breeze's within-frame transformer, with frame-local KV state.
+
+Attention follows the reference BF16 matmul / FP32 softmax ordering. Each
+frame overwrites its causal cache before reading it. Captured workspaces
+belong to their graphs; generated frames and RNG state belong to requests.
+"""
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers import PretrainedConfig
+from vllm.platforms import current_platform
+
+from vllm_omni.platforms import current_omni_platform
+
+
+def sample_logits(
+    logits: torch.Tensor,
+    temperature: float,
+    top_k: int,
+    top_p: float,
+    generator: torch.Generator,
+    noise: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if temperature == 0:
+        return logits.argmax(-1)
+    scores = logits.float() / temperature
+    if top_k > 0:
+        threshold = scores.topk(min(top_k, scores.shape[-1]), dim=-1).values[..., -1:]
+        scores = scores.masked_fill(scores < threshold, -torch.inf)
+    if top_p < 1:
+        values, indices = scores.sort(dim=-1, descending=True)
+        probabilities = values.softmax(-1)
+        cumulative = probabilities.cumsum(-1)
+        # Keep the first candidate crossing the nucleus boundary as in HF.
+        remove = cumulative - probabilities >= top_p
+        scores = scores.scatter(-1, indices, values.masked_fill(remove, -torch.inf))
+    probabilities = scores.softmax(-1)
+    if noise is not None:
+        return (probabilities / noise).argmax(-1)
+    return torch.multinomial(probabilities, 1, generator=generator).squeeze(-1)
+
+
+def sample_graph_logits(logits: torch.Tensor, parameters: torch.Tensor, noise: torch.Tensor) -> torch.Tensor:
+    """Sample with mutable GPU parameters and a request-owned RNG draw.
+
+    Sorting once supplies both the top-k threshold and the nucleus order.
+    Filtering keeps ties at the top-k threshold, and keeps the first token
+    crossing the nucleus boundary. The three reserved codec IDs remain in
+    the RNG workspace, with zero probability, as in the reference sampler.
+    """
+    temperature, top_k, top_p = parameters.unbind()
+    scaled = logits.float() / torch.where(temperature > 0, temperature, 1.0)
+    values, indices = scaled.sort(dim=-1, descending=True)
+    cutoff = torch.where(top_k > 0, top_k, logits.shape[-1]).long().clamp(1, logits.shape[-1]) - 1
+    threshold = values.gather(-1, cutoff.expand(values.shape[0], 1))
+    values = values.masked_fill(values < threshold, -torch.inf)
+    cumulative = values.softmax(-1).cumsum(-1)
+    remove = F.pad(cumulative[..., :-1] > top_p, (1, 0), value=False) & (top_p < 1)
+    values = values.masked_fill(remove, -torch.inf)
+    # Argmax of p / Exp(1) is the single-sample multinomial algorithm.
+    selected = (values.softmax(-1) / noise.gather(-1, indices)).argmax(-1, keepdim=True)
+    sampled = indices.gather(-1, selected).squeeze(-1)
+    return torch.where(temperature > 0, sampled, logits.argmax(-1))
+
+
+class BreezeRMSNorm(nn.Module):
+    def __init__(self, size: int, eps: float) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(size))
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        y = x.float()
+        y = y * torch.rsqrt(y.square().mean(-1, keepdim=True) + self.eps)
+        return self.weight * y.to(x.dtype)
+
+
+class BreezeDepthLayer(nn.Module):
+    def __init__(self, config: PretrainedConfig) -> None:
+        super().__init__()
+        self.heads = config.num_attention_heads
+        self.kv_heads = config.num_key_value_heads
+        self.dim = config.head_dim
+        self.q_size = self.heads * self.dim
+        self.kv_size = self.kv_heads * self.dim
+        self.qkv = nn.Linear(config.hidden_size, self.q_size + 2 * self.kv_size, bias=False)
+        self.o_proj = nn.Linear(self.q_size, config.hidden_size, bias=False)
+        self.gate_up = nn.Linear(config.hidden_size, 2 * config.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(config.intermediate_size, config.hidden_size, bias=False)
+        self.input_layernorm = BreezeRMSNorm(config.hidden_size, config.rms_norm_eps)
+        self.post_attention_layernorm = BreezeRMSNorm(config.hidden_size, config.rms_norm_eps)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        positions: torch.Tensor,
+        cache: tuple[torch.Tensor, torch.Tensor],
+        mask: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+    ) -> torch.Tensor:
+        batch, length, _ = x.shape
+        residual = x
+        q, k, v = self.qkv(self.input_layernorm(x)).split([self.q_size, self.kv_size, self.kv_size], -1)
+        q = q.view(batch, length, self.heads, self.dim).transpose(1, 2)
+        k = k.view(batch, length, self.kv_heads, self.dim).transpose(1, 2)
+        v = v.view(batch, length, self.kv_heads, self.dim).transpose(1, 2)
+        q1, q2 = q.chunk(2, -1)
+        k1, k2 = k.chunk(2, -1)
+        q = q * cos + torch.cat((-q2, q1), -1) * sin
+        k = k * cos + torch.cat((-k2, k1), -1) * sin
+        cache[0].index_copy_(2, positions, k)
+        cache[1].index_copy_(2, positions, v)
+        # Fold query heads sharing one KV head into its query dimension.
+        # This avoids materializing repeated keys/values for grouped-query
+        # attention while preserving BF16 matmul and FP32 softmax ordering.
+        grouped_q = q.reshape(batch, self.kv_heads, self.heads // self.kv_heads * length, self.dim)
+        scores = (
+            torch.matmul(grouped_q, cache[0].transpose(-1, -2)).reshape(batch, self.heads, length, cache[0].shape[2])
+            * self.dim**-0.5
+        )
+        scores = scores.masked_fill(~mask, torch.finfo(q.dtype).min)
+        probabilities = scores.softmax(-1, dtype=torch.float32).to(q.dtype)
+        grouped_probabilities = probabilities.reshape(batch, self.kv_heads, -1, cache[0].shape[2])
+        y = torch.matmul(grouped_probabilities, cache[1]).reshape(batch, self.heads, length, self.dim)
+        y = y.transpose(1, 2).reshape(batch, length, self.q_size)
+        x = residual + self.o_proj(y)
+        gate, up = self.gate_up(self.post_attention_layernorm(x)).chunk(2, -1)
+        return x + self.down_proj(F.silu(gate) * up)
+
+
+class BreezeDepthDecoder(nn.Module):
+    def __init__(self, config: PretrainedConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.num_codebooks = config.num_codebooks
+        self.vocab_size = config.vocab_size
+        self.embed_tokens = nn.Embedding(self.num_codebooks * self.vocab_size, config.audio_embed_size)
+        self.inputs_embeds_projector = nn.Linear(config.audio_embed_size, config.hidden_size, bias=False)
+        self.layers = nn.ModuleList([BreezeDepthLayer(config) for _ in range(config.num_hidden_layers)])
+        self.norm = BreezeRMSNorm(config.hidden_size, config.rms_norm_eps)
+        self.codebooks_head = nn.Parameter(
+            torch.empty(self.num_codebooks - 1, config.hidden_size, self.vocab_size, dtype=torch.float32)
+        )
+        rope = config.rope_parameters
+        inv = 1.0 / (rope["rope_theta"] ** (torch.arange(0, config.head_dim, 2).float() / config.head_dim))
+        wavelength = 2 * torch.pi / inv
+        low = rope["original_max_position_embeddings"] / rope["low_freq_factor"]
+        high = rope["original_max_position_embeddings"] / rope["high_freq_factor"]
+        smooth = (rope["original_max_position_embeddings"] / wavelength - rope["low_freq_factor"]) / (
+            rope["high_freq_factor"] - rope["low_freq_factor"]
+        )
+        scaled = (1 - smooth) * inv / rope["factor"] + smooth * inv
+        inv = torch.where(wavelength > low, inv / rope["factor"], torch.where(wavelength < high, inv, scaled))
+        angles = torch.outer(torch.arange(self.num_codebooks).float(), inv)
+        angles = torch.cat((angles, angles), -1)
+        self.register_buffer("rope_cos", angles.cos(), persistent=False)
+        self.register_buffer("rope_sin", angles.sin(), persistent=False)
+        self.register_buffer("positions", torch.arange(self.num_codebooks), persistent=False)
+        self.register_buffer(
+            "causal_mask",
+            torch.arange(self.num_codebooks)[None, :] <= torch.arange(self.num_codebooks)[:, None],
+            persistent=False,
+        )
+        self._graphs: dict[tuple[int, int], BreezeDepthGraph] = {}
+        self._compiled_layer = None
+        self._compiled_sampler = None
+
+    def _allocate_cache(self, hidden: torch.Tensor) -> list[tuple[torch.Tensor, torch.Tensor]]:
+        shape = (hidden.shape[0], self.config.num_key_value_heads, self.num_codebooks, self.config.head_dim)
+        # Masked future positions still participate in the value matmul.
+        # Initialize them to finite values so zero probabilities cannot meet NaN.
+        return [(hidden.new_zeros(shape), hidden.new_zeros(shape)) for _ in self.layers]
+
+    def generate_frame(
+        self,
+        hidden: torch.Tensor,
+        first: torch.Tensor,
+        *,
+        temperature: float,
+        top_k: int,
+        top_p: float,
+        generator: torch.Generator,
+    ) -> torch.Tensor:
+        return self._generate_frame(hidden, first, self._allocate_cache(hidden), temperature, top_k, top_p, generator)
+
+    def _generate_frame(
+        self,
+        hidden: torch.Tensor,
+        first: torch.Tensor,
+        caches: list[tuple[torch.Tensor, torch.Tensor]],
+        temperature: float,
+        top_k: int,
+        top_p: float,
+        generator: torch.Generator,
+        noise: torch.Tensor | None = None,
+        guidance_scale: float | torch.Tensor | None = None,
+        sampling_parameters: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        batch = hidden.shape[0]
+        branches = 2 if guidance_scale is not None else 1
+        branch_first = first.repeat(branches)
+        x = torch.cat((hidden.unsqueeze(1), self.embed_tokens(branch_first.reshape(batch, 1))), 1)
+        frames = [first]
+        start = 0
+        for codebook in range(self.num_codebooks - 1):
+            x = self.inputs_embeds_projector(x)
+            end = start + x.shape[1]
+            cos = self.rope_cos[start:end].to(x.dtype)[None, None]
+            sin = self.rope_sin[start:end].to(x.dtype)[None, None]
+            for layer, cache in zip(self.layers, caches, strict=True):
+                args = (x, self.positions[start:end], cache, self.causal_mask[start:end][None, None], cos, sin)
+                if noise is None:
+                    x = layer(*args)
+                else:
+                    x = self._compiled_layer(layer, *args)
+            logits = F.linear(self.norm(x[:, -1]).float(), self.codebooks_head[codebook].T.float())
+            if guidance_scale is not None:
+                cond, uncond = logits.chunk(2, dim=0)
+                logits = uncond + guidance_scale * (cond - uncond)
+            logits[:, self.vocab_size - 3 :] = -torch.inf
+            if noise is None:
+                token = sample_logits(logits, temperature, top_k, top_p, generator)
+            else:
+                token = self._compiled_sampler(logits, sampling_parameters, noise[:, codebook])
+            frames.append(token)
+            x = self.embed_tokens((token.repeat(branches) + (codebook + 1) * self.vocab_size).reshape(batch, 1))
+            start = end
+        return torch.stack(frames, -1)
+
+    def generate_frames(
+        self,
+        hidden: torch.Tensor,
+        first: torch.Tensor,
+        *,
+        temperature: float,
+        top_k: int,
+        top_p: float,
+        generators: list[torch.Generator],
+        guidance_scale: float = 1.0,
+    ) -> torch.Tensor:
+        batch = hidden.shape[0]
+        branches = 2 if guidance_scale != 1.0 else 1
+        key = (batch, branches)
+        parameters = (temperature, top_k, top_p)
+        entry = self._graphs.get(key)
+        if entry is None:
+            if self._compiled_layer is None:
+                self._compiled_layer = torch.compile(
+                    BreezeDepthLayer.forward,
+                    fullgraph=True,
+                    dynamic=False,
+                    options={"epilogue_fusion": False, "max_autotune": True},
+                )
+                self._compiled_sampler = torch.compile(sample_graph_logits, fullgraph=True, dynamic=False)
+            entry = BreezeDepthGraph(self, hidden, first, parameters, guidance_scale)
+            self._graphs[key] = entry
+        if entry.parameter_values != parameters:
+            entry.parameters.copy_(entry.parameters.new_tensor(parameters))
+            entry.parameter_values = parameters
+        entry.hidden.copy_(hidden)
+        entry.first.copy_(first)
+        if entry.guidance_scale is not None and entry.guidance_value != guidance_scale:
+            entry.guidance_scale.fill_(guidance_scale)
+            entry.guidance_value = guidance_scale
+        if temperature > 0:
+            for row, generator in enumerate(generators):
+                # Match the 15 independent exponential draws used by
+                # torch.multinomial(..., num_samples=1), preserving each
+                # request's RNG stream even when requests are batched.
+                for codebook in range(self.num_codebooks - 1):
+                    entry.noise[row, codebook].exponential_(generator=generator)
+        entry.graph.replay()
+        # The tiny RVQ result outlives this replay in request state and the
+        # transfer queue. The graph owns and overwrites its output workspace.
+        return entry.output.clone()
+
+
+class BreezeDepthGraph:
+    def __init__(
+        self,
+        model: BreezeDepthDecoder,
+        hidden: torch.Tensor,
+        first: torch.Tensor,
+        parameters: tuple[float, int, float],
+        guidance_scale: float = 1.0,
+    ) -> None:
+        self.parameter_values = parameters
+        self.parameters = hidden.new_tensor(parameters, dtype=torch.float32)
+        self.guidance_value = guidance_scale
+        self.guidance_scale = hidden.new_tensor(guidance_scale, dtype=torch.float32) if guidance_scale != 1.0 else None
+        self.hidden = torch.zeros_like(hidden)
+        self.first = torch.zeros_like(first)
+        self.noise = hidden.new_ones((first.shape[0], model.num_codebooks - 1, model.vocab_size), dtype=torch.float32)
+        # Captured kernels retain addresses, not the Python tensors allocated
+        # before capture. Keep every KV allocation alive with its graph.
+        self.caches = model._allocate_cache(hidden)
+        generator = torch.Generator(device=hidden.device)
+        for _ in range(3):
+            model._generate_frame(
+                self.hidden,
+                self.first,
+                self.caches,
+                *parameters,
+                generator,
+                self.noise,
+                self.guidance_scale,
+                self.parameters,
+            )
+        current_omni_platform.synchronize()
+        self.graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(
+            self.graph, pool=current_platform.get_global_graph_pool(), capture_error_mode="thread_local"
+        ):
+            self.output = model._generate_frame(
+                self.hidden,
+                self.first,
+                self.caches,
+                *parameters,
+                generator,
+                self.noise,
+                self.guidance_scale,
+                self.parameters,
+            )

--- a/vllm_omni/model_executor/models/breeze_tts/modeling_breeze.py
+++ b/vllm_omni/model_executor/models/breeze_tts/modeling_breeze.py
@@ -1,0 +1,353 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Breeze-TTS-2: T5Gemma2 prompt encoding, paged Qwen3, and RVQ decoding."""
+
+from collections.abc import Iterable
+from typing import Any, TypedDict, cast
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers.models.t5gemma2.modeling_t5gemma2 import T5Gemma2TextEncoder
+from vllm.config import VllmConfig
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.models.qwen3 import Qwen3Model
+from vllm.sequence import IntermediateTensors
+from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.utils import record_function_or_nullcontext
+
+from vllm_omni.config.model import OmniModelConfig
+from vllm_omni.model_executor.models.breeze_tts.configuration_breeze import BreezeConfig
+from vllm_omni.model_executor.models.breeze_tts.depth_decoder import BreezeDepthDecoder, sample_logits
+from vllm_omni.model_executor.models.breeze_tts.prompt import CFG_UNCOND_SUFFIX
+from vllm_omni.model_executor.models.breeze_tts.reference_encoder import BreezeReferenceEncoder
+from vllm_omni.model_executor.models.breeze_tts.text_encoder_graph import (
+    BreezeTextEncoderCompiled,
+    BreezeTextEncoderGraph,
+)
+from vllm_omni.model_executor.models.output_templates import OmniOutput
+
+
+class BreezeSampling(TypedDict):
+    temperature: float
+    top_k: int
+    top_p: float
+    repetition_penalty: float
+
+
+class BreezeState(TypedDict):
+    generator: torch.Generator
+    history: torch.Tensor
+    current: torch.Tensor
+
+
+class BreezeForConditionalGeneration(nn.Module):
+    have_multimodal_outputs = True
+    has_preprocess = True
+    has_postprocess = False
+    requires_full_prefix_cached_hidden_states = False
+    omni_pooler_payload_include_hidden = False
+    use_async_omni_output = True
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        self.vllm_config = vllm_config
+        self.config = cast(BreezeConfig, vllm_config.model_config.hf_config)
+        parallel = vllm_config.parallel_config
+        if parallel.tensor_parallel_size != 1 or parallel.pipeline_parallel_size != 1:
+            raise ValueError("Breeze-TTS-2 currently supports TP=1 and PP=1")
+        if vllm_config.cache_config.enable_prefix_caching:
+            raise ValueError("Breeze prompt placeholders require enable_prefix_caching=False")
+        if vllm_config.scheduler_config.enable_chunked_prefill:
+            raise ValueError("Breeze text encoding requires enable_chunked_prefill=False")
+        if not cast(OmniModelConfig, vllm_config.model_config).async_chunk:
+            raise ValueError("Breeze requires async_chunk=True for its stateful codec stage")
+        if vllm_config.model_config.quantization is not None:
+            raise ValueError("The initial Breeze integration does not support quantization")
+        if self.config.backbone_model_type != "qwen3" or self.config.text_encoder_proj_type != "linear":
+            raise ValueError("This integration supports the Breeze-TTS-2 Qwen3/linear checkpoint")
+        if self.config.num_codebooks != 16 or self.config.audio_vocab_size != 2051:
+            raise ValueError("Breeze-TTS-2 requires 16 codebooks with 2048 audio codes and 3 reserved IDs")
+        self.num_codebooks = self.config.num_codebooks
+        self.codebook_size = self.config.audio_vocab_size - 3
+        self.hidden_size = self.config.backbone_config.hidden_size
+        backbone_config = vllm_config.with_hf_config(self.config.backbone_config, architectures=["Qwen3ForCausalLM"])
+        backbone_config.model_config.hf_text_config = backbone_config.model_config.hf_config
+        self.model = Qwen3Model(vllm_config=backbone_config, prefix=f"{prefix}.model".strip("."))
+        # Breeze replaces the backbone token embedding with summed RVQ embeddings.
+        self.model.embed_tokens = nn.Identity()
+        text_config = self.config.text_encoder_config
+        text_config._attn_implementation = "sdpa"
+        self.text_encoder = T5Gemma2TextEncoder(text_config)
+        self.text_encoder_proj = nn.Linear(text_config.hidden_size, self.hidden_size, bias=False)
+        self._long_text_encoder = BreezeTextEncoderCompiled(self.text_encoder, self.text_encoder_proj)
+        self.reference_encoder = BreezeReferenceEncoder(vllm_config)
+        self.depth_decoder = BreezeDepthDecoder(self.config.depth_decoder_config)
+        self.lm_head = nn.Linear(self.hidden_size, self.config.vocab_size, bias=False, dtype=torch.float32)
+        self.register_buffer(
+            "offsets", torch.arange(self.num_codebooks) * self.config.audio_vocab_size, persistent=False
+        )
+        self.gpu_resident_buffer_keys = {
+            ("breeze_state", "current"),
+            ("breeze_state", "history"),
+            ("breeze_prepared", "embeds"),
+        }
+        self._next_tokens: torch.Tensor | None = None
+        self._text_graphs: dict[tuple[int, int], BreezeTextEncoderGraph] = {}
+
+    @torch.inference_mode()
+    def preprocess_batch(
+        self, *, req_ids: list[str], model_intermediate_buffer: dict[str, dict[str, Any]], device: torch.device
+    ) -> None:
+        pending = [
+            model_intermediate_buffer[rid] for rid in req_ids if "breeze_state" not in model_intermediate_buffer[rid]
+        ]
+        if not pending:
+            return
+        segment_ids: dict[tuple[int, ...], None] = {}
+        references: dict[str, dict[str, Any]] = {}
+        reference_keys: dict[str, str] = {}
+        for info in pending:
+            conditioning = info["breeze_prompt"]
+            segment_ids[tuple(conditioning["target_ids"])] = None
+            if "reference_waveform" in info:
+                segment_ids[tuple(conditioning["reference_ids"])] = None
+                request_id = info["global_request_id"][0]
+                key = request_id.removesuffix(CFG_UNCOND_SUFFIX) if conditioning["role"] == "uncond" else request_id
+                reference_keys[request_id] = key
+                references.setdefault(key, info)
+        if not self._text_graphs:
+            # The serving warmup pays these captures before accepting speech
+            # requests. Cover the default two-row deployment's distinct text
+            # segments, including two independent reference recordings.
+            for batch in range(1, min(4, 2 * self.vllm_config.scheduler_config.max_num_seqs) + 1):
+                for size in (32, 64, 128):
+                    self._text_graphs[(batch, size)] = BreezeTextEncoderGraph(
+                        self.text_encoder, self.text_encoder_proj, size, batch_size=batch
+                    )
+            self.reference_encoder.warmup(min(2, self.vllm_config.scheduler_config.max_num_seqs))
+            self._long_text_encoder.warmup(min(4, 2 * self.vllm_config.scheduler_config.max_num_seqs))
+        length = max(len(ids) for ids in segment_ids)
+        bucket = max(32, 1 << (length - 1).bit_length())
+        with record_function_or_nullcontext("breeze:text_encoder"):
+            prompts = [torch.tensor(ids, device="cpu", dtype=torch.long) for ids in segment_ids]
+            if bucket > 128:
+                encoded = self._long_text_encoder.run_batch(prompts)
+                # Large prefill activations must not raise the decoder graph
+                # pool's permanent high-water mark. Return free prefill
+                # workspace to the device before starting streamed decode.
+                torch.accelerator.empty_cache()
+            else:
+                graph_key = (len(segment_ids), bucket)
+                if graph_key not in self._text_graphs:
+                    self._text_graphs[graph_key] = BreezeTextEncoderGraph(
+                        self.text_encoder, self.text_encoder_proj, bucket, batch_size=len(segment_ids)
+                    )
+                encoded = self._text_graphs[graph_key].run_batch(prompts)
+        segments = dict(zip(segment_ids, encoded, strict=True))
+        reference_embeds: dict[str, torch.Tensor] = {}
+        if references:
+            with record_function_or_nullcontext("breeze:reference_encoder"):
+                codes = self.reference_encoder.encode_batch(
+                    [info["reference_waveform"] for info in references.values()],
+                    [info["breeze_prompt"]["reference_frames"] for info in references.values()],
+                )
+            for key, code in zip(references, codes, strict=True):
+                # Audio EOS is a zero RVQ frame, distinct from generation EOS.
+                eos = code.new_full((1, self.num_codebooks), self.config.codebook_eos_token_id)
+                audio = self.depth_decoder.embed_tokens(torch.cat((code, eos)) + self.offsets).sum(1)
+                reference_ids = tuple(references[key]["breeze_prompt"]["reference_ids"])
+                reference_embeds[key] = torch.cat((segments[reference_ids], audio), dim=0)
+        for info in pending:
+            embeds = segments[tuple(info["breeze_prompt"]["target_ids"])]
+            request_id = info["global_request_id"][0]
+            if request_id in reference_keys:
+                embeds = torch.cat((reference_embeds[reference_keys[request_id]], embeds), dim=0)
+            info["breeze_prepared"] = {"embeds": embeds}
+
+    def embed_input_ids(self, input_ids: torch.Tensor, **_: object) -> torch.Tensor:
+        # vLLM's memory profiling does not have a request payload.
+        return self.lm_head.weight.new_zeros((input_ids.numel(), self.hidden_size), dtype=self.model.norm.weight.dtype)
+
+    def preprocess(
+        self,
+        input_ids: torch.Tensor,
+        input_embeds: torch.Tensor | None,
+        *,
+        breeze_prompt: dict[str, Any],
+        breeze_sampling: BreezeSampling,
+        global_request_id: list[str],
+        breeze_prepared: dict[str, torch.Tensor] | None = None,
+        breeze_state: BreezeState | None = None,
+        _omni_is_prefill: bool,
+        _omni_seed: int | None = None,
+        **_: object,
+    ) -> tuple[torch.Tensor, torch.Tensor, dict[str, object]]:
+        if _omni_is_prefill:
+            if breeze_prepared is None:
+                raise RuntimeError("Breeze prefill requires the runner's batch preprocessing hook")
+            embeds = breeze_prepared.pop("embeds")
+            if embeds.shape[0] != input_ids.numel():
+                raise ValueError("Breeze prompt payload and scheduled token count differ")
+            generator = torch.Generator(device=input_ids.device)
+            if _omni_seed is None:
+                generator.seed()
+            else:
+                generator.manual_seed(_omni_seed)
+            state: BreezeState = {
+                "generator": generator,
+                "history": input_ids.new_empty((1, 0)),
+                "current": input_ids.new_empty((1, self.num_codebooks)),
+            }
+            return input_ids, embeds, {"breeze_state": state}
+        if breeze_state is None or input_ids.numel() != 1:
+            raise ValueError("Breeze decode requires initialized per-request state and one token")
+        embeds = self.depth_decoder.embed_tokens(breeze_state["current"] + self.offsets).sum(1)
+        return input_ids, embeds, {}
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **_: object,
+    ) -> torch.Tensor | IntermediateTensors:
+        return self.model(None, positions, intermediate_tensors, inputs_embeds)
+
+    def compute_logits(
+        self, hidden_states: torch.Tensor, sampling_metadata: SamplingMetadata | None = None
+    ) -> torch.Tensor:
+        logits = hidden_states.new_full((hidden_states.shape[0], self.config.vocab_size), -torch.inf)
+        if self._next_tokens is None:
+            logits[:, 0] = 0
+        else:
+            if self._next_tokens.numel() != hidden_states.shape[0]:
+                raise RuntimeError("Breeze sampled rows do not match the current request batch")
+            logits.scatter_(1, self._next_tokens[:, None], 0)
+        return logits
+
+    def make_omni_output(
+        self,
+        model_outputs: torch.Tensor,
+        *,
+        model_intermediate_buffer: list[dict[str, object]] | None = None,
+        request_token_spans: list[tuple[int, int]] | None = None,
+        **_: object,
+    ) -> OmniOutput:
+        if not model_intermediate_buffer:
+            self._next_tokens = None
+            return OmniOutput(text_hidden_states=model_outputs, multimodal_outputs={})
+        if request_token_spans is None or len(request_token_spans) != len(model_intermediate_buffer):
+            raise RuntimeError("Breeze requires one hidden-state span per request")
+        self._next_tokens = torch.zeros(len(model_intermediate_buffer), device=model_outputs.device, dtype=torch.long)
+        output_codes = [
+            torch.empty((0, self.num_codebooks), device=model_outputs.device, dtype=torch.long)
+            for _ in model_intermediate_buffer
+        ]
+        infos = model_intermediate_buffer
+        request_rows = {cast(list[str], info["global_request_id"])[0]: index for index, info in enumerate(infos)}
+        groups: dict[tuple[float, int, float, float], list[tuple[list[int], torch.Tensor, torch.Tensor]]] = {}
+        for index, (info, (start, end)) in enumerate(zip(infos, request_token_spans, strict=True)):
+            if not 0 <= start < end <= model_outputs.shape[0]:
+                raise RuntimeError("Invalid Breeze request span")
+            conditioning = cast(dict[str, Any], info["breeze_prompt"])
+            if conditioning["role"] == "uncond":
+                parent = cast(list[str], info["global_request_id"])[0].removesuffix(CFG_UNCOND_SUFFIX)
+                if parent not in request_rows:
+                    raise RuntimeError("Breeze CFG companion was scheduled without its conditioned branch")
+                continue
+            hidden = model_outputs[end - 1 : end]
+            state = cast(BreezeState, info["breeze_state"])
+            sampling = cast(BreezeSampling, info["breeze_sampling"])
+            logits = F.linear(hidden.float(), self.lm_head.weight)
+            indices = [index]
+            guidance_scale = float(conditioning["guidance_scale"])
+            if guidance_scale != 1.0:
+                request_id = cast(list[str], info["global_request_id"])[0]
+                companion = request_rows.get(request_id + CFG_UNCOND_SUFFIX)
+                if companion is None:
+                    raise RuntimeError("Breeze CFG request was scheduled without its unconditional branch")
+                if infos[companion]["breeze_sampling"] != sampling:
+                    raise RuntimeError("Breeze CFG branches have different sampling parameters")
+                _, companion_end = request_token_spans[companion]
+                uncond = model_outputs[companion_end - 1 : companion_end]
+                uncond_logits = F.linear(uncond.float(), self.lm_head.weight)
+                logits = uncond_logits + guidance_scale * (logits - uncond_logits)
+                hidden = torch.cat((hidden, uncond))
+                indices.append(companion)
+            logits[:, self.codebook_size : self.config.eos_token_id] = -torch.inf
+            history = state["history"]
+            if history.numel():
+                selected = logits.gather(1, history)
+                penalty = sampling["repetition_penalty"]
+                logits.scatter_(1, history, torch.where(selected < 0, selected * penalty, selected / penalty))
+            first = sample_logits(
+                logits, sampling["temperature"], sampling["top_k"], sampling["top_p"], state["generator"]
+            )
+            if first.item() == self.config.eos_token_id:
+                self._next_tokens[indices] = self.config.eos_token_id
+                continue
+            state["history"] = torch.cat((history, first[:, None]), dim=1)
+            parameters = (sampling["temperature"], sampling["top_k"], sampling["top_p"], guidance_scale)
+            groups.setdefault(parameters, []).append((indices, hidden, first))
+        for (temperature, top_k, top_p, guidance_scale), rows in groups.items():
+            # Depth batches place every conditioned row before every
+            # unconditional row. Both branches consume the same sampled codes.
+            hidden = torch.stack([row[1] for row in rows]).transpose(0, 1).reshape(-1, self.hidden_size)
+            with record_function_or_nullcontext("breeze:depth_decoder"):
+                frames = self.depth_decoder.generate_frames(
+                    hidden,
+                    torch.cat([row[2] for row in rows]),
+                    temperature=temperature,
+                    top_k=top_k,
+                    top_p=top_p,
+                    generators=[cast(BreezeState, infos[row[0][0]]["breeze_state"])["generator"] for row in rows],
+                    guidance_scale=guidance_scale,
+                )
+            for offset, (indices, _, _) in enumerate(rows):
+                frame = frames[offset : offset + 1]
+                for index in indices:
+                    cast(BreezeState, infos[index]["breeze_state"])["current"] = frame
+                output_codes[indices[0]] = frame
+        return OmniOutput(text_hidden_states=model_outputs, multimodal_outputs={"codes": {"audio": output_codes}})
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        backbone: list[tuple[str, torch.Tensor]] = []
+        depth: dict[str, torch.Tensor] = {}
+        loaded: set[str] = set()
+        params = dict(self.named_parameters())
+        for name, value in weights:
+            if name.startswith(("backbone_model.layers.", "backbone_model.norm.")):
+                backbone.append((name.removeprefix("backbone_model."), value))
+            elif name.startswith("depth_decoder."):
+                depth[name] = value
+            elif name.startswith(("text_encoder.", "text_encoder_proj.", "lm_head.")):
+                default_weight_loader(params[name], value)
+                loaded.add(name)
+            elif not name.startswith(("codec_model.", "backbone_model.embed_tokens.", "embed_text_tokens.")):
+                raise ValueError(f"Unexpected Breeze checkpoint parameter: {name}")
+        loaded.update("model." + name for name in self.model.load_weights(backbone))
+        for target, parameter in self.depth_decoder.named_parameters():
+            if target == "codebooks_head":
+                value = depth["depth_decoder.codebooks_head.weight"]
+            elif target.endswith("qkv.weight"):
+                layer = target.split(".")[1]
+                value = torch.cat(
+                    [depth[f"depth_decoder.model.layers.{layer}.self_attn.{p}_proj.weight"] for p in ("q", "k", "v")]
+                )
+            elif target.endswith("gate_up.weight"):
+                layer = target.split(".")[1]
+                value = torch.cat(
+                    [depth[f"depth_decoder.model.layers.{layer}.mlp.{p}_proj.weight"] for p in ("gate", "up")]
+                )
+            else:
+                source = target.replace(".o_proj.", ".self_attn.o_proj.").replace(".down_proj.", ".mlp.down_proj.")
+                value = depth["depth_decoder.model." + source]
+            default_weight_loader(parameter, value)
+            loaded.add("depth_decoder." + target)
+        loaded.update("reference_encoder." + name for name in self.reference_encoder.load_weights(self.vllm_config))
+        missing = set(params) - loaded
+        if missing:
+            raise ValueError(f"Uninitialized Breeze parameters: {sorted(missing)}")
+        return loaded

--- a/vllm_omni/model_executor/models/breeze_tts/pipeline.py
+++ b/vllm_omni/model_executor/models/breeze_tts/pipeline.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from vllm_omni.config.stage_config import PipelineConfig, StageExecutionType, StagePipelineConfig
+
+BREEZE_TTS_PIPELINE = PipelineConfig(
+    model_type="breeze",
+    model_arch="BreezeForConditionalGeneration",
+    default_deploy_config_name="breeze_tts.yaml",
+    stages=(
+        StagePipelineConfig(
+            stage_id=0,
+            model_stage="breeze_tts",
+            execution_type=StageExecutionType.LLM_AR,
+            input_sources=(),
+            owns_tokenizer=True,
+            engine_output_type="latent",
+            scheduler_cls="vllm_omni.core.sched.omni_cfg_ar_scheduler.OmniCFGARScheduler",
+            prompt_expand_func="vllm_omni.model_executor.stage_input_processors.breeze_tts.expand_cfg_prompts",
+            async_chunk_process_next_stage_input_func=(
+                "vllm_omni.model_executor.stage_input_processors.breeze_tts.talker2code2wav_async_chunk"
+            ),
+            sampling_constraints={"detokenize": False, "stop_token_ids": [2051]},
+        ),
+        StagePipelineConfig(
+            stage_id=1,
+            model_stage="breeze_code2wav",
+            model_arch="BreezeCode2Wav",
+            execution_type=StageExecutionType.LLM_GENERATION,
+            input_sources=(0,),
+            final_output=True,
+            final_output_type="audio",
+            engine_output_type="audio",
+            retains_state_across_chunks=True,
+            sampling_constraints={"detokenize": True},
+        ),
+    ),
+)

--- a/vllm_omni/model_executor/models/breeze_tts/prompt.py
+++ b/vllm_omni/model_executor/models/breeze_tts/prompt.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Breeze's instruction and reference-audio templates for both public APIs."""
+
+import math
+from typing import Any
+
+import numpy as np
+import torch
+from transformers import PreTrainedTokenizerBase
+from vllm.inputs import TokensPrompt, tokens_input
+from vllm.multimodal.audio import AudioResampler
+
+DEFAULT_INSTRUCTION = "Speak clearly and naturally."
+SAMPLE_RATE = 24000
+ENCODE_DOWNSAMPLE_RATE = 1920
+CFG_UNCOND_SUFFIX = "__cfg_uncond"
+
+
+def build_breeze_prompt(
+    tokenizer: PreTrainedTokenizerBase,
+    text: str,
+    instructions: str = DEFAULT_INSTRUCTION,
+    *,
+    ref_audio: tuple[np.ndarray, int] | None = None,
+    ref_text: str | None = None,
+    guidance_scale: float = 1.0,
+    temperature: float = 0.9,
+    top_k: int = 50,
+    top_p: float = 1.0,
+    repetition_penalty: float = 1.1,
+) -> TokensPrompt:
+    if not text.strip():
+        raise ValueError("Breeze input text cannot be empty")
+    if not math.isfinite(guidance_scale) or guidance_scale <= 0:
+        raise ValueError("Breeze guidance_scale must be finite and positive")
+    if top_k == -1:
+        top_k = 0
+    if (
+        not all(math.isfinite(value) for value in (temperature, top_p, repetition_penalty))
+        or temperature < 0
+        or top_k < 0
+        or not 0 < top_p <= 1
+        or repetition_penalty <= 0
+    ):
+        raise ValueError("Invalid Breeze sampling parameters")
+    if (ref_audio is None) != (ref_text is None):
+        raise ValueError("Breeze voice cloning requires both ref_audio and ref_text")
+    target = tokenizer.encode(f"[S0]<ins_bos>{instructions}<ins_eos>{text}", add_special_tokens=True)
+    conditioning: dict[str, Any] = {"target_ids": target, "guidance_scale": guidance_scale, "role": "cond"}
+    prefix_length = 0
+    if ref_audio is not None:
+        if not ref_text or not ref_text.strip():
+            raise ValueError("Breeze reference transcript cannot be empty")
+        waveform, sample_rate = ref_audio
+        waveform = np.asarray(waveform, dtype=np.float32)
+        if waveform.ndim == 2:
+            # Public waveform input follows soundfile: (samples, channels).
+            waveform = waveform.mean(axis=1)
+        if waveform.ndim != 1 or not waveform.size or not np.isfinite(waveform).all() or sample_rate <= 0:
+            raise ValueError("Breeze reference audio must contain finite samples at a positive sample rate")
+        if sample_rate != SAMPLE_RATE:
+            # Match the released tokenizer's librosa/soxr_hq resampling,
+            # including ceil-length handling for non-integral rate ratios.
+            length = math.ceil(waveform.size * SAMPLE_RATE / sample_rate)
+            waveform = AudioResampler(target_sr=SAMPLE_RATE, method="soxr").resample(waveform, orig_sr=sample_rate)
+            waveform = np.pad(waveform, (0, max(0, length - waveform.size)))[:length]
+        reference_ids = tokenizer.encode(f"[S0]{ref_text}", add_special_tokens=True)
+        frames = math.ceil(waveform.size / ENCODE_DOWNSAMPLE_RATE)
+        conditioning.update(
+            reference_ids=reference_ids,
+            reference_frames=frames,
+        )
+        prefix_length = len(reference_ids) + frames + 1
+    if guidance_scale != 1.0:
+        conditioning["negative_ids"] = tokenizer.encode(f"[S0]{text}", add_special_tokens=True)
+    prompt = tokens_input(prompt_token_ids=[0] * (prefix_length + len(target)))
+    prompt["additional_information"] = {
+        "breeze_prompt": conditioning,
+        "breeze_sampling": {
+            "temperature": temperature,
+            "top_k": top_k,
+            "top_p": top_p,
+            "repetition_penalty": repetition_penalty,
+        },
+    }
+    if ref_audio is not None:
+        # Tensor payloads belong at the transport root (or in a declared
+        # tensor namespace), rather than inside JSON-valued model metadata.
+        prompt["additional_information"]["reference_waveform"] = torch.from_numpy(np.ascontiguousarray(waveform))
+    if guidance_scale != 1.0:
+        prompt["additional_information"]["cfg_group"] = {"role": "cond", "uncond_suffix": CFG_UNCOND_SUFFIX}
+    return prompt

--- a/vllm_omni/model_executor/models/breeze_tts/reference_encoder.py
+++ b/vllm_omni/model_executor/models/breeze_tts/reference_encoder.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""The bundled Qwen3 codec encoder used by Breeze voice cloning."""
+
+import torch
+from torch import nn
+from transformers.models.mimi.modeling_mimi import MimiConv1d
+from vllm.config import VllmConfig
+from vllm.model_executor.model_loader.default_loader import DefaultModelLoader
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+
+from vllm_omni.model_executor.models.qwen3_tts.tokenizer_12hz.configuration_qwen3_tts_tokenizer_v2 import (
+    Qwen3TTSTokenizerV2Config,
+)
+from vllm_omni.model_executor.models.qwen3_tts.tokenizer_12hz.modeling_qwen3_tts_tokenizer_v2 import (
+    Qwen3TTSTokenizerV2Encoder,
+)
+
+
+class BreezeReferenceEncoder(nn.Module):
+    def __init__(self, vllm_config: VllmConfig) -> None:
+        super().__init__()
+        config = Qwen3TTSTokenizerV2Config.from_pretrained(
+            vllm_config.model_config.model,
+            subfolder="audio_tokenizer",
+            revision=vllm_config.model_config.revision,
+        )
+        if config.input_sample_rate != 24000 or config.encode_downsample_rate != 1920:
+            raise ValueError("Breeze requires the bundled 24 kHz, 12.5 Hz Qwen3 codec")
+        config.encoder_config._attn_implementation = "sdpa"
+        # The released Breeze runtime encodes references in FP32. Quantizer
+        # boundaries affect speaker conditioning, so preserve that precision.
+        self.encoder = Qwen3TTSTokenizerV2Encoder._from_config(config.encoder_config, dtype=torch.float32).eval()
+        self._convolutions: list[BreezeReferenceConv] = []
+        hop = 1
+        for name, module in list(self.encoder.named_modules()):
+            if isinstance(module, MimiConv1d):
+                hop *= module.conv.stride[0]
+                convolution = BreezeReferenceConv(module, hop)
+                self._convolutions.append(convolution)
+                parent, _, attribute = name.rpartition(".")
+                self.encoder.get_submodule(parent).add_module(attribute, convolution)
+        if hop != config.encode_downsample_rate:
+            raise ValueError("Breeze reference convolution strides do not match the codec frame rate")
+        self.num_quantizers = config.encoder_valid_num_quantizers
+        # Reference convolutions have large temporary workspaces. Compile
+        # without a graph's permanently reserved workspace for every length.
+        self._compiled_encode = torch.compile(
+            self._encode_impl,
+            fullgraph=True,
+            dynamic=True,
+            options={"triton.cudagraphs": False, "epilogue_fusion": False},
+        )
+
+    def forward(self, waveform: torch.Tensor, frames: int) -> torch.Tensor:
+        return self.encode_batch([waveform], [frames])[0]
+
+    def encode_batch(self, waveforms: list[torch.Tensor], frame_counts: list[int]) -> list[torch.Tensor]:
+        device = next(self.encoder.parameters()).device
+        waveform = nn.utils.rnn.pad_sequence(waveforms, batch_first=True)
+        waveform = nn.functional.pad(waveform, (0, -waveform.shape[1] % 1920))
+        waveform_frames = waveform.reshape(len(waveforms), -1, 1920).to(device=device, dtype=torch.float32)
+        lengths = torch.tensor([waveform.numel() for waveform in waveforms], device=device, dtype=torch.long)
+        with torch.backends.cudnn.flags(allow_tf32=False):
+            encoded = self._compiled_encode(waveform_frames, lengths)
+        return [
+            encoded[row, :, :frames].transpose(0, 1).clone(memory_format=torch.contiguous_format)
+            for row, frames in enumerate(frame_counts)
+        ]
+
+    def warmup(self, max_batch_size: int) -> None:
+        device = next(self.encoder.parameters()).device
+        with torch.backends.cudnn.flags(allow_tf32=False):
+            for batch in range(1, max_batch_size + 1):
+                waveform_frames = torch.zeros((batch, 32, 1920), device=device, dtype=torch.float32)
+                lengths = torch.full((batch,), 32 * 1920, device=device, dtype=torch.long)
+                # Initialize the codec's normalized codebooks before tracing.
+                self._encode_impl(waveform_frames, lengths)
+                self._compiled_encode(waveform_frames, lengths)
+        torch.accelerator.empty_cache()
+
+    def _encode_impl(self, waveform_frames: torch.Tensor, sample_lengths: torch.Tensor) -> torch.Tensor:
+        # Expose the complete 1920-sample stride product to the compiler.
+        # Nested ceil/mod expressions for arbitrary waveform lengths otherwise
+        # cause expensive symbolic simplification during kernel tiling. Every
+        # convolution below masks the true per-recording boundary, so aligning
+        # the storage to full frames preserves partial final-frame semantics.
+        torch._dynamo.mark_static(waveform_frames, 2)
+        waveform = waveform_frames.flatten(1)
+        # The released Breeze reference encoder uses full causal attention
+        # during offline encoding. Recent Transformers Mimi defaults to a
+        # sliding mask, which changes references longer than ten seconds.
+        # Supply the actual reference mask rather than changing the checkpoint
+        # configuration or relying on a Transformers-version default.
+        for convolution in self._convolutions:
+            convolution.sample_lengths = sample_lengths
+        hidden = self.encoder.encoder(waveform.unsqueeze(1)).transpose(1, 2)
+        length = hidden.shape[1]
+        causal_mask = torch.ones((length, length), device=hidden.device, dtype=torch.bool).tril()[None, None]
+        hidden = self.encoder.encoder_transformer(
+            hidden, attention_mask=causal_mask, use_cache=False, return_dict=True
+        ).last_hidden_state
+        hidden = self.encoder.downsample(hidden.transpose(1, 2))
+        return self.encoder.quantizer.encode(hidden, self.num_quantizers).transpose(0, 1)
+
+    def load_weights(self, vllm_config: VllmConfig) -> set[str]:
+        loader = DefaultModelLoader(vllm_config.load_config)
+        source = DefaultModelLoader.Source(
+            model_or_path=vllm_config.model_config.model,
+            revision=vllm_config.model_config.revision,
+            subfolder="audio_tokenizer",
+        )
+        parameters = dict(self.named_parameters())
+        buffers = dict(self.named_buffers())
+        loaded: set[str] = set()
+        for name, value in loader._get_weights_iterator(source):
+            if name.startswith("decoder."):
+                continue
+            if name in parameters:
+                default_weight_loader(parameters[name], value)
+            elif name in buffers:
+                buffers[name].copy_(value)
+            else:
+                raise ValueError(f"Unexpected reference codec weight: {name}")
+            loaded.add(name)
+        required = set(parameters) | {name for name in buffers if ".quantizer." in name}
+        missing = required - loaded
+        if missing:
+            raise ValueError(f"Uninitialized reference codec weights or codebooks: {sorted(missing)}")
+        return loaded
+
+
+class BreezeReferenceConv(nn.Module):
+    """Offline Mimi convolution with padding derived from static shape metadata."""
+
+    def __init__(self, source: MimiConv1d, output_hop: int) -> None:
+        super().__init__()
+        if not source.causal or source.pad_mode not in ("constant", "replicate"):
+            raise ValueError("Breeze reference encoding requires causal zero/replicate-padded convolutions")
+        self.conv = source.conv
+        self.pad_mode = source.pad_mode
+        self.stride = self.conv.stride[0]
+        self.padding = (self.conv.kernel_size[0] - 1) * self.conv.dilation[0] + 1 - self.stride
+        self.output_hop = output_hop
+        self.sample_lengths: torch.Tensor | None = None
+
+    def forward(self, hidden: torch.Tensor) -> torch.Tensor:
+        # HF stores these integers in GPU tensors, introducing a device sync
+        # when F.pad converts them back to integers. Shapes determine padding.
+        if self.sample_lengths is None:
+            raise RuntimeError("Reference convolution requires the batch's input lengths")
+        if self.pad_mode == "replicate":
+            # Mimi's final downsampler repeats the actual last encoder state
+            # for a partial frame. Each row has its own boundary in a bucket.
+            input_hop = self.output_hop // self.stride
+            lengths = (self.sample_lengths + input_hop - 1) // input_hop
+            indices = torch.arange(hidden.shape[-1], device=hidden.device)[None, :]
+            indices = torch.minimum(indices, lengths[:, None] - 1)
+            hidden = hidden.gather(2, indices[:, None, :].expand(-1, hidden.shape[1], -1))
+        right = -hidden.shape[-1] % self.stride
+        hidden = nn.functional.pad(hidden, (self.padding, right), mode=self.pad_mode)
+        hidden = self.conv(hidden)
+        lengths = (self.sample_lengths + self.output_hop - 1) // self.output_hop
+        invalid = torch.arange(hidden.shape[-1], device=hidden.device)[None, :] >= lengths[:, None]
+        return hidden.masked_fill(invalid[:, None, :], 0)

--- a/vllm_omni/model_executor/models/breeze_tts/text_encoder_graph.py
+++ b/vllm_omni/model_executor/models/breeze_tts/text_encoder_graph.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Padded T5Gemma2 prefill graphs with explicit bidirectional masks."""
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers.models.t5gemma2.modeling_t5gemma2 import (
+    T5Gemma2EncoderLayer,
+    T5Gemma2TextEncoder,
+    sliding_window_mask_function,
+)
+from vllm.platforms import current_platform
+
+from vllm_omni.platforms import current_omni_platform
+
+
+class BreezeTextEncoderCompiled:
+    """Compiled prefill layers without retaining large activation graph pools."""
+
+    def __init__(self, encoder: T5Gemma2TextEncoder, projection: nn.Linear) -> None:
+        self.encoder = encoder
+        self.projection = projection
+        self._layer = torch.compile(
+            T5Gemma2EncoderLayer.forward,
+            fullgraph=True,
+            dynamic=True,
+            options={"triton.cudagraphs": False, "epilogue_fusion": False},
+        )
+
+    def run_batch(self, prompts: list[torch.Tensor]) -> list[torch.Tensor]:
+        encoder = self.encoder
+        device = self.projection.weight.device
+        dtype = self.projection.weight.dtype
+        lengths = [prompt.numel() for prompt in prompts]
+        ids = nn.utils.rnn.pad_sequence(prompts, batch_first=True).to(device)
+        positions = torch.arange(ids.shape[1], device=device)[None]
+        invalid = positions >= torch.tensor(lengths, device=device)[:, None]
+        mask = torch.zeros((len(prompts), 1, ids.shape[1], ids.shape[1]), device=device, dtype=dtype)
+        mask.masked_fill_(invalid[:, None, None, :], torch.finfo(dtype).min)
+        mask_function = sliding_window_mask_function(encoder.config.sliding_window, is_causal=False)
+        allowed = mask_function(0, 0, positions[:, :, None], positions[:, None, :])
+        local_mask = mask.masked_fill(~allowed[:, None], torch.finfo(dtype).min)
+        masks = {"full_attention": mask, "sliding_attention": local_mask}
+        embedding = encoder.embed_tokens
+        hidden = F.embedding(ids, embedding.weight) * embedding.embed_scale.to(dtype)
+        hidden = torch.where(
+            (ids == embedding.eoi_token_index).unsqueeze(-1), embedding.eoi_embedding.to(dtype), hidden
+        )
+        position_embeddings = {
+            kind: encoder.rotary_emb(hidden, positions, kind) for kind in set(encoder.config.layer_types)
+        }
+        for layer in encoder.layers:
+            kind = layer.attention_type
+            hidden = self._layer(layer, hidden, position_embeddings[kind], masks[kind], positions)
+        output = self.projection(encoder.norm(hidden))
+        return [output[row, :length].clone() for row, length in enumerate(lengths)]
+
+    def warmup(self, max_batch_size: int) -> None:
+        # Dynamo specializes size-one dimensions; a second batch exercises
+        # the general batch dimension used by paired and reference prompts.
+        for batch in sorted({1, max_batch_size}):
+            self.run_batch([torch.zeros(256, dtype=torch.long) for _ in range(batch)])
+        torch.accelerator.empty_cache()
+
+
+class BreezeTextEncoderGraph:
+    def __init__(self, encoder: T5Gemma2TextEncoder, projection: nn.Linear, size: int, batch_size: int = 1) -> None:
+        device = projection.weight.device
+        dtype = projection.weight.dtype
+        self.ids = torch.zeros((batch_size, size), device=device, dtype=torch.long)
+        self.positions = torch.arange(size, device=device).unsqueeze(0)
+        self.full_mask = torch.zeros((batch_size, 1, size, size), device=device, dtype=dtype)
+        mask_function = sliding_window_mask_function(encoder.config.sliding_window, is_causal=False)
+        allowed = mask_function(0, 0, self.positions[:, :, None], self.positions[:, None, :])
+        self.local_mask_base = torch.zeros_like(self.full_mask).masked_fill_(~allowed[:, None], torch.finfo(dtype).min)
+        self.local_mask = self.local_mask_base.clone()
+        self.masks = {"full_attention": self.full_mask, "sliding_attention": self.local_mask}
+        for _ in range(3):
+            self._encode(encoder, projection)
+        current_omni_platform.synchronize()
+        self.graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(
+            self.graph, pool=current_platform.get_global_graph_pool(), capture_error_mode="thread_local"
+        ):
+            self.output = self._encode(encoder, projection)
+
+    def _encode(self, encoder: T5Gemma2TextEncoder, projection: nn.Linear) -> torch.Tensor:
+        embedding = encoder.embed_tokens
+        hidden = F.embedding(self.ids, embedding.weight) * embedding.embed_scale.to(embedding.weight.dtype)
+        # HF's boolean-index assignment materializes a data-dependent index
+        # list. Express the same EOI substitution with a fixed-shape select.
+        hidden = torch.where(
+            (self.ids == embedding.eoi_token_index).unsqueeze(-1),
+            embedding.eoi_embedding.to(hidden.dtype),
+            hidden,
+        )
+        encoded = encoder(inputs_embeds=hidden, attention_mask=self.masks, position_ids=self.positions)
+        return projection(encoded.last_hidden_state)
+
+    def run(self, prompt: torch.Tensor) -> torch.Tensor:
+        return self.run_batch([prompt[0]])[0]
+
+    def run_batch(self, prompts: list[torch.Tensor]) -> list[torch.Tensor]:
+        if len(prompts) != self.ids.shape[0]:
+            raise ValueError("Breeze text batch differs from the captured graph size")
+        lengths = [prompt.numel() for prompt in prompts]
+        if not all(0 < length <= self.ids.shape[1] for length in lengths):
+            raise ValueError("Breeze text segment does not fit its graph bucket")
+        self.ids.zero_()
+        for row, (prompt, length) in enumerate(zip(prompts, lengths, strict=True)):
+            self.ids[row, :length].copy_(prompt)
+        invalid = self.positions >= torch.tensor(lengths, device=self.ids.device)[:, None]
+        invalid = invalid[:, None, None, :]
+        self.full_mask.zero_()
+        self.full_mask.masked_fill_(invalid, torch.finfo(self.full_mask.dtype).min)
+        self.local_mask.copy_(self.local_mask_base)
+        self.local_mask.masked_fill_(invalid, torch.finfo(self.local_mask.dtype).min)
+        self.graph.replay()
+        # Subsequent prefills and backbone/depth graphs reuse graph storage.
+        # The runner must receive independently owned prompt embeddings.
+        return [self.output[row, :length].clone() for row, length in enumerate(lengths)]

--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code2wav.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code2wav.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 from __future__ import annotations
 
 import os
@@ -55,6 +58,8 @@ class Qwen3TTSCode2Wav(nn.Module):
     via the SpeechTokenizer decoder directly (bypassing HF wrapper overhead)."""
 
     input_modalities = "audio"
+    tokenizer_subfolder = "speech_tokenizer"
+    decoder_cudagraph_modes: tuple[str, ...] = ("icl", "xvec")
 
     # Ask the model runner for the scheduler-side request IDs. Stateful
     # decoder caches must use the same IDs delivered by on_requests_finished;
@@ -98,7 +103,7 @@ class Qwen3TTSCode2Wav(nn.Module):
         # load_weights().
         tok_config = Qwen3TTSTokenizerV2Config.from_pretrained(
             self.model_path,
-            subfolder="speech_tokenizer",
+            subfolder=self.tokenizer_subfolder,
         )
         dec_config = tok_config.decoder_config
         self.decoder = Qwen3TTSTokenizerV2Decoder._from_config(dec_config)
@@ -187,6 +192,7 @@ class Qwen3TTSCode2Wav(nn.Module):
             )
 
         self.decoder.enable_cudagraph(
+            capture_modes=self.decoder_cudagraph_modes,
             capture_batch_sizes=decode_cudagraph_batch_sizes,
             stateless_capture_sizes=decode_cudagraph_capture_sizes,
             device=device,
@@ -549,7 +555,7 @@ class Qwen3TTSCode2Wav(nn.Module):
         source = DefaultModelLoader.Source(
             model_or_path=self.model_path,
             revision=self.vllm_config.model_config.revision,
-            subfolder="speech_tokenizer",
+            subfolder=self.tokenizer_subfolder,
         )
         subfolder_weights = model_loader._get_weights_iterator(source)
         loaded = AutoWeightsLoader(

--- a/vllm_omni/model_executor/models/qwen3_tts/segmented_graph_wrapper.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/segmented_graph_wrapper.py
@@ -1,5 +1,6 @@
 # Copyright 2026 The Alibaba Qwen team.
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """
 CUDA Graph wrapper for Qwen3TTSTokenizerV2Decoder.
 
@@ -38,6 +39,7 @@ class CUDAGraphDecoderWrapper:
     def __init__(
         self,
         decoder: torch.nn.Module,
+        capture_modes: tuple[str, ...] = ("icl", "xvec"),
         capture_batch_sizes: list[int] | None = None,
         stateless_capture_sizes: list[int] | None = None,
         num_quantizers: int = 8,
@@ -50,6 +52,9 @@ class CUDAGraphDecoderWrapper:
         decode_left_context: int = 25,
     ):
         self.decoder = decoder
+        if not capture_modes or set(capture_modes) - {"icl", "xvec"}:
+            raise ValueError("capture_modes must contain icl and/or xvec")
+        self.capture_modes = capture_modes
         self.capture_batch_sizes = sorted(set(capture_batch_sizes or [1]))
         self.num_quantizers = num_quantizers
         self.enabled = enabled
@@ -321,16 +326,18 @@ class CUDAGraphDecoderWrapper:
         icl_capture_shapes = self._get_icl_capture_shapes()
 
         for batch_size in self.capture_batch_sizes:
-            try:
-                self._capture_icl_prefix(batch_size, device, dtype)
-                logger.info("Captured ICL prefix CUDA Graph for batch=%d", batch_size)
-            except Exception:
-                logger.warning("Failed to capture ICL prefix CUDA Graph for batch=%d", batch_size, exc_info=True)
-            try:
-                self._capture_xvec_prefix(batch_size, device, dtype)
-                logger.info("Captured xvec prefix CUDA Graph for batch=%d", batch_size)
-            except Exception:
-                logger.warning("Failed to capture xvec prefix CUDA Graph for batch=%d", batch_size, exc_info=True)
+            if "icl" in self.capture_modes:
+                try:
+                    self._capture_icl_prefix(batch_size, device, dtype)
+                    logger.info("Captured ICL prefix CUDA Graph for batch=%d", batch_size)
+                except Exception:
+                    logger.warning("Failed to capture ICL prefix CUDA Graph for batch=%d", batch_size, exc_info=True)
+            if "xvec" in self.capture_modes:
+                try:
+                    self._capture_xvec_prefix(batch_size, device, dtype)
+                    logger.info("Captured xvec prefix CUDA Graph for batch=%d", batch_size)
+                except Exception:
+                    logger.warning("Failed to capture xvec prefix CUDA Graph for batch=%d", batch_size, exc_info=True)
 
         logger.info(
             "Starting CUDA Graph warmup for %d shapes: batch_sizes=%s seq_lens=%s",
@@ -339,7 +346,7 @@ class CUDAGraphDecoderWrapper:
             self.icl_capture_sizes,
         )
 
-        for batch_size, size in icl_capture_shapes:
+        for batch_size, size in icl_capture_shapes if "icl" in self.capture_modes else ():
             try:
                 caches = self._make_dummy_icl_cache(batch_size, device, next(self.decoder.parameters()).dtype)
                 self._capture_combined_suffix("icl", batch_size, size, caches, device, dtype)
@@ -353,7 +360,7 @@ class CUDAGraphDecoderWrapper:
                 )
 
         model_dtype = next(self.decoder.parameters()).dtype
-        for batch_size in self.capture_batch_sizes:
+        for batch_size in self.capture_batch_sizes if "xvec" in self.capture_modes else ():
             for size, previous_frames in self._xvec_previous_frames_by_target.items():
                 try:
                     caches = self._make_dummy_xvec_cache(batch_size, device, model_dtype)

--- a/vllm_omni/model_executor/models/qwen3_tts/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 # Copyright 2026 The Qwen team, Alibaba Group and the HuggingFace Inc. team. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -866,6 +869,7 @@ class Qwen3TTSTokenizerV2Decoder(Qwen3TTSTokenizerV2DecoderPreTrainedModel):
 
     def enable_cudagraph(
         self,
+        capture_modes: tuple[str, ...] = ("icl", "xvec"),
         capture_batch_sizes: list[int] | None = None,
         stateless_capture_sizes: list[int] | None = None,
         device: torch.device | None = None,
@@ -888,6 +892,7 @@ class Qwen3TTSTokenizerV2Decoder(Qwen3TTSTokenizerV2DecoderPreTrainedModel):
 
         self._cudagraph_wrapper = CUDAGraphDecoderWrapper(
             decoder=self,
+            capture_modes=capture_modes,
             capture_batch_sizes=capture_batch_sizes,
             stateless_capture_sizes=stateless_capture_sizes,
             num_quantizers=self.config.num_quantizers,

--- a/vllm_omni/model_executor/models/registry.py
+++ b/vllm_omni/model_executor/models/registry.py
@@ -9,6 +9,8 @@ from vllm.model_executor.models.registry import (
 )
 
 _OMNI_MODELS = {
+    "BreezeForConditionalGeneration": ("breeze_tts", "modeling_breeze", "BreezeForConditionalGeneration"),
+    "BreezeCode2Wav": ("breeze_tts", "code2wav", "BreezeCode2Wav"),
     "Qwen2_5OmniForConditionalGeneration": (
         "qwen2_5_omni",
         "qwen2_5_omni",

--- a/vllm_omni/model_executor/stage_input_processors/breeze_tts.py
+++ b/vllm_omni/model_executor/stage_input_processors/breeze_tts.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Transfer raw Breeze RVQ frames to the stateful Qwen3 codec."""
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+from vllm.v1.request import Request
+
+from vllm_omni.data_entry_keys import CodesStruct, MetaStruct, OmniPayload, OmniPayloadStruct
+from vllm_omni.model_executor.models.breeze_tts.prompt import CFG_UNCOND_SUFFIX
+from vllm_omni.model_executor.stage_input_processors.bagel import ExpandedPrompt
+
+if TYPE_CHECKING:
+    from vllm_omni.distributed.omni_connectors.transfer_adapter.chunk_transfer_adapter import OmniChunkTransferAdapter
+
+
+def expand_cfg_prompts(prompt: dict[str, Any] | str, sampling_params: Any) -> list[ExpandedPrompt]:
+    if not isinstance(prompt, dict):
+        raise ValueError("Breeze requires build_breeze_prompt to encode its conditioning")
+    info = prompt["additional_information"]
+    conditioning = info["breeze_prompt"]
+    if conditioning["guidance_scale"] == 1.0:
+        return []
+    negative = conditioning["negative_ids"]
+    companion_conditioning = {**conditioning, "role": "uncond", "target_ids": negative}
+    companion_conditioning.pop("negative_ids")
+    length = len(prompt["prompt_token_ids"]) - len(conditioning["target_ids"]) + len(negative)
+    companion = {
+        "prompt_token_ids": [0] * length,
+        "additional_information": {
+            **info,
+            "breeze_prompt": companion_conditioning,
+            "cfg_group": {"role": "uncond", "uncond_suffix": CFG_UNCOND_SUFFIX},
+        },
+    }
+    return [ExpandedPrompt(prompt=companion, role="uncond", request_id_suffix=CFG_UNCOND_SUFFIX)]
+
+
+def talker2code2wav_async_chunk(
+    transfer_manager: "OmniChunkTransferAdapter",
+    multimodal_output: OmniPayload | None,
+    request: Request,
+    is_finished: bool = False,
+) -> OmniPayloadStruct | None:
+    request_id = request.external_req_id
+    if request_id.endswith(CFG_UNCOND_SUFFIX):
+        return None
+    finished = is_finished or request.is_finished()
+    frames = transfer_manager.code_prompt_token_ids[request_id]
+    if multimodal_output is not None:
+        codes = multimodal_output.get("codes", {}).get("audio")
+        if codes is not None and codes.numel():
+            if codes.ndim != 2 or codes.shape[1] != 16:
+                raise ValueError("Breeze codec payload must have shape (frames, 16)")
+            rows = codes.to(device="cpu", dtype=torch.long)
+            if not bool(((rows >= 0) & (rows < 2048)).all()):
+                raise ValueError("Breeze codec payload contains a reserved or invalid code")
+            frames.extend(rows.unbind(0))
+    connector = transfer_manager.connector
+    if connector is None:
+        raise RuntimeError("Breeze streaming requires a stage connector")
+    config = connector.config
+    extra = config.get("extra", config)
+    state = transfer_manager.request_payload.setdefault(request_id, {"frames": 0, "chunks": 0})
+    emitted = state["frames"]
+    ramp = extra.get("codec_chunk_ramp", [])
+    if state["chunks"] < len(ramp):
+        chunk_size = int(ramp[state["chunks"]])
+    else:
+        chunk_size = int(
+            extra.get("initial_codec_chunk_frames", 1) if emitted == 0 else extra.get("codec_chunk_frames", 5)
+        )
+    if chunk_size <= 0:
+        raise ValueError("codec_chunk_frames must be positive")
+    pending = len(frames) - emitted
+    if not finished and pending < chunk_size:
+        return None
+    if pending < 0:
+        raise RuntimeError("Breeze codec transfer emitted more frames than generated")
+    # The shared codec retains its causal state; each frame is delivered once.
+    flat = torch.stack(frames[emitted:]).T.contiguous().reshape(-1) if pending else torch.empty(0, dtype=torch.long)
+    state["frames"] = len(frames)
+    state["chunks"] += 1
+    return OmniPayloadStruct(
+        codes=CodesStruct(audio=flat),
+        meta=MetaStruct(request_id=request_id, left_context_size=0, finished=torch.tensor(finished)),
+    )


### PR DESCRIPTION
## Purpose

Refs #6656.

Add Breeze-TTS-2 English/Chinese speech generation through the speech API and offline pipeline, covering Voice Design, reference-audio cloning, and instruction-guided reference generation (Voice Direction), with streaming PCM and complete WAV output.

- Use the native vLLM Qwen3 backbone with paged KV caching, the checkpoint's T5Gemma2 text encoder, and a frame-local Llama depth decoder.
- Batch text, reference, and depth processing. Compile the depth layers and capture all 15 depth steps in a CUDA Graph; use short-text graphs and dynamically compiled long-text/reference encoding.
- Apply CFG to both the backbone head and all depth codebooks. Preserve reference conditioning and actual prompt positions on both branches, with paired scheduling and cancellation.
- Reuse the Qwen3-TTS Code2Wav decoder for streaming audio generation.
- Keep sampling generators, history, and codec state per request. Propagate streaming cancellation so disconnected requests release their generation state.
- Add the deployment configuration, recipe, shared benchmark registration, and core/advanced serving tests.

The default deployment targets one CUDA GPU, with a 2048-token AR context, a 512 MiB KV cache, BF16 generation, and FP32 reference encoding/codec decoding. Two physical sequences support two plain requests or one CFG request; additional requests queue. TP/PP, quantization, prefix caching, and chunked prefill are outside this deployment's supported scope.

## Test Plan

**vLLM Version:** 0.28.0, editable source install using the matching official CUDA/Rust extensions.

**vLLM-Omni Commit:** based on `66bbebd9d3ef669b93fd7e39587672b20efc5933`.

**Environment:** Ubuntu 24.04 / WSL2, RTX 5070 Ti 16 GiB, PyTorch 2.13.0+cu130, Transformers 5.14.1.

Compare against the original accelerated Breeze PyTorch runtime.

Match weights, text, instructions, reference audio/transcripts, sampling settings, and seeds. Measure end-to-end RTF, first audio, and playback underruns through the HTTP API. Exclude warmup and retain complete audio. Cover long inputs, parameter changes, seed replay, reference formats, PCM/WAV equivalence, real client disconnects, and concurrent requests.

```bash
pytest -q tests/model_executor/models/test_breeze_tts.py \
  tests/model_executor/models/test_breeze_tts_graphs.py \
  tests/core/sched/test_omni_cfg_ar_scheduler.py

pytest -v -s tests/e2e/online_serving/test_breeze_tts_2.py \
  -m 'core_model and tts' --run-level=core_model

pytest -v -s tests/e2e/online_serving/test_breeze_tts_2.py \
  -m 'advanced_model and tts' --run-level=advanced_model
```

Serving and shared benchmark commands are documented in `recipes/BreezeBlue/Breeze-TTS-2.md`.

## Test Result

- Core serving: **5 passed**. Real-weight advanced serving: **5 passed**.
- Model CPU: **21 passed**; CUDA Graph: **2 passed**; CFG scheduling and speech cancellation: **9 passed**; AsyncOmni: **16 passed**; codec configuration: **28 passed**; shared benchmark CLI: **7 passed**; transcription helper: **8 passed**.
- **150 measured requests completed without playback underruns:** 44 requests across 22 functional cases, 18 mixed-concurrency requests, 80 reference-conditioned requests across 10 cases and eight distinct seeds, and 8 simultaneous-cloning requests.
- The 44 single-request measurements had case-mean RTF **0.318–0.337** and first audio **45–100 ms**. Representative matched English/Chinese results are below; each row shows the range of the two language-specific means.

| Mode | Optimized reference RTF | This integration RTF |
| --- | ---: | ---: |
| Voice Design, CFG 4 | 0.467–0.476 | 0.328–0.330 |
| Voice Clone, CFG 1 | 0.418–0.430 | 0.322–0.323 |
| Voice Direction, CFG 4 | 0.504–0.510 | 0.335–0.336 |

Across the separate eight-seed reference-conditioned evaluation, case-mean RTF was **0.321–0.335**, compared with **0.417–0.508** for the optimized reference. RTF is request wall time divided by generated audio duration; lower is faster. Concurrent measurements include queueing. The reference API rejects concurrent generation, so no matched-concurrency speedup is claimed.

AI assistance: implementation and test preparation used Codex; all reported tests and measurements were executed.
The generated audio has also been manually checked by a human through listening.
