### PR TITLE
[Bugfix] Encode video off the event loop

### DIFF
--- a/tests/entrypoints/openai_api/test_serving_video_encode_offload.py
+++ b/tests/entrypoints/openai_api/test_serving_video_encode_offload.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MP4 muxing must not run on the event loop.
+
+Encoding a finished video is CPU-bound and scales with resolution and duration.
+Called inline from an async handler it holds the loop for its whole duration,
+so the server answers nothing while it runs, liveness probes included, and a
+long render is indistinguishable from a dead server to anything watching it.
+
+These tests pin the encoders to a worker thread rather than the loop thread.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_omni.entrypoints.openai import serving_video
+from vllm_omni.entrypoints.openai.serving_video import OmniOpenAIServingVideo
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _artifacts(count: int = 1) -> SimpleNamespace:
+    return SimpleNamespace(
+        videos=[object() for _ in range(count)],
+        audios=[None] * count,
+        actions=[None] * count,
+        output_fps=24,
+        audio_sample_rate=None,
+        stage_durations={},
+        peak_memory_mb=0.0,
+    )
+
+
+def _handler(artifacts: SimpleNamespace) -> OmniOpenAIServingVideo:
+    handler = object.__new__(OmniOpenAIServingVideo)
+    handler._video_frame_converter = None
+
+    async def _run_and_extract(*args, **kwargs):
+        return artifacts
+
+    handler._run_and_extract = _run_and_extract
+    return handler
+
+
+def _request() -> SimpleNamespace:
+    return SimpleNamespace(extra_params=None)
+
+
+@pytest.mark.asyncio
+async def test_mp4_bytes_encoding_leaves_the_event_loop_free(monkeypatch):
+    loop_thread = threading.get_ident()
+    seen: dict[str, int] = {}
+
+    def fake_encode(video, **kwargs):
+        seen["thread"] = threading.get_ident()
+        return b"\x00\x00\x00\x18ftyp"
+
+    monkeypatch.setattr(serving_video, "_encode_video_bytes", fake_encode)
+
+    handler = _handler(_artifacts())
+    video_bytes, _, _, _ = await handler.generate_video_bytes(_request(), "req-1")
+
+    assert video_bytes.startswith(b"\x00\x00\x00")
+    assert seen["thread"] != loop_thread, "encoding ran on the event loop thread"
+
+
+@pytest.mark.asyncio
+async def test_base64_encoding_leaves_the_event_loop_free(monkeypatch):
+    loop_thread = threading.get_ident()
+    seen: list[int] = []
+
+    def fake_encode(video, **kwargs):
+        seen.append(threading.get_ident())
+        return "AAAA"
+
+    monkeypatch.setattr(serving_video, "encode_video_base64", fake_encode)
+
+    handler = _handler(_artifacts(count=2))
+    response = await handler.generate_videos(_request(), "req-2")
+
+    assert len(response.data) == 2
+    assert seen and all(t != loop_thread for t in seen), (
+        "encoding ran on the event loop thread"
+    )
+
+
+@pytest.mark.asyncio
+async def test_other_requests_are_served_while_a_video_is_muxed(monkeypatch):
+    """The point of the offload, stated as behaviour rather than as a thread id.
+
+    The encoder blocks until the loop tells it to stop. If the loop is free it
+    says so in milliseconds; if the encoder is holding the loop, nothing can
+    reach the release and the only way out is the timeout. So the elapsed time
+    is the assertion, and it separates the two cases by two orders of magnitude.
+    """
+    release = threading.Event()
+    stuck_for = 10.0
+
+    def fake_encode(video, **kwargs):
+        # Stands in for a mux long enough to matter. It blocks its own thread,
+        # which is what a real encode does.
+        release.wait(timeout=stuck_for)
+        return b"\x00\x00\x00\x18ftyp"
+
+    monkeypatch.setattr(serving_video, "_encode_video_bytes", fake_encode)
+
+    async def other_traffic():
+        for _ in range(5):
+            await asyncio.sleep(0.01)
+        release.set()
+
+    handler = _handler(_artifacts())
+    started = time.perf_counter()
+    await asyncio.gather(
+        handler.generate_video_bytes(_request(), "req-3"),
+        other_traffic(),
+    )
+    elapsed = time.perf_counter() - started
+
+    assert elapsed < stuck_for / 2, (
+        f"the loop was held for {elapsed:.1f}s; other requests could not be "
+        "served while the video was encoded"
+    )

--- a/vllm_omni/entrypoints/openai/serving_video.py
+++ b/vllm_omni/entrypoints/openai/serving_video.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import copy
 import math
 import time
@@ -425,30 +426,36 @@ class OmniOpenAIServingVideo:
             if "video_codec_options" in request.extra_params:
                 video_codec_options = request.extra_params["video_codec_options"]
 
+        # Same reason as the byte path below: encoding is CPU-bound and holds
+        # the event loop for its whole duration when called inline. This one
+        # encodes every video in the response, so it holds it for longer.
+        def _encode_all() -> list[VideoData]:
+            return [
+                VideoData(
+                    b64_json=(
+                        encode_video_base64(
+                            video,
+                            fps=artifacts.output_fps,
+                            video_codec_options=video_codec_options,
+                            frame_converter=self._video_frame_converter,
+                        )
+                        if artifacts.audios[idx] is None
+                        else encode_video_base64(
+                            video,
+                            fps=artifacts.output_fps,
+                            audio=artifacts.audios[idx],
+                            audio_sample_rate=artifacts.audio_sample_rate,
+                            video_codec_options=video_codec_options,
+                            frame_converter=self._video_frame_converter,
+                        )
+                    ),
+                    action=artifacts.actions[idx],
+                )
+                for idx, video in enumerate(artifacts.videos)
+            ]
+
         _t_encode_start = time.perf_counter()
-        video_data = [
-            VideoData(
-                b64_json=(
-                    encode_video_base64(
-                        video,
-                        fps=artifacts.output_fps,
-                        video_codec_options=video_codec_options,
-                        frame_converter=self._video_frame_converter,
-                    )
-                    if artifacts.audios[idx] is None
-                    else encode_video_base64(
-                        video,
-                        fps=artifacts.output_fps,
-                        audio=artifacts.audios[idx],
-                        audio_sample_rate=artifacts.audio_sample_rate,
-                        video_codec_options=video_codec_options,
-                        frame_converter=self._video_frame_converter,
-                    )
-                ),
-                action=artifacts.actions[idx],
-            )
-            for idx, video in enumerate(artifacts.videos)
-        ]
+        video_data = await asyncio.to_thread(_encode_all)
         _t_encode_ms = (time.perf_counter() - _t_encode_start) * 1000
         logger.info("Video response encoding (MP4+base64): %.2f ms", _t_encode_ms)
         return VideoGenerationResponse(
@@ -493,8 +500,14 @@ class OmniOpenAIServingVideo:
             logger.info("Action-only video request %s completed; skipping MP4 encoding.", reference_id)
             return b"", artifacts.stage_durations, artifacts.peak_memory_mb, action
 
+        # Muxing is CPU-bound and can run for seconds, so it goes to a worker
+        # thread. Calling it inline blocks the event loop for its whole
+        # duration: the server answers nothing at all while it runs, /health
+        # and /v1/models included, so a long render reads as a dead server to
+        # anything watching it.
         _t_encode_start = time.perf_counter()
-        video_bytes = _encode_video_bytes(
+        video_bytes = await asyncio.to_thread(
+            _encode_video_bytes,
             artifacts.videos[0],
             fps=artifacts.output_fps,
             **({"audio": audio, "audio_sample_rate": artifacts.audio_sample_rate} if audio is not None else {}),


### PR DESCRIPTION
## The problem

Both video response paths mux their MP4 inline from an async handler.
`generate_videos` encodes every video in the response to base64 and
`generate_video_bytes` encodes one to raw bytes, and neither hands the work to a
thread, so the event loop is held for the whole encode.

While it is held the server answers nothing. Not the request being encoded, not
other requests, and not `/health` or `/v1/models`, so an operator watching
liveness sees a server that has stopped responding and has no way to tell that
from one that has died. Anything with a probe timeout shorter than the encode
marks the server down and, depending on what is watching, restarts it.

## Why it is easy to miss

The cost scales with resolution and duration, so it is invisible in small tests
and severe in the workloads people actually run. Measured on one MiniMax-H3
server, with `/v1/models` polled from a separate process throughout:

| shape | encode | worst `/v1/models` latency during it |
| --- | ---: | ---: |
| 768x448, 2 s | 373 ms | 248 ms |
| 1344x768, 2 s | 2143 ms | 1931 ms |
| 1344x768, 4 s | 11653 ms | 11298 ms |

The liveness stall tracks the encode one to one, which is what being on the loop
means. A 960x576 / 4.5 s render on the same box stays under 250 ms and shows
nothing at all, so the shape of the workload decides whether anyone notices.

`serving_video.py` already logs the encode duration
(`Video response encoding (MP4 bytes): %.2f ms`), so anyone can check the
magnitude against their own workload without instrumenting anything.

## The change

Both call sites move to `asyncio.to_thread`. The encoders are self-contained CPU
work over frames already in memory and touch no loop state, so a worker thread is
where they belong. The base64 path wraps the whole comprehension rather than each
element, since encoding several videos one hop at a time would return to the loop
only between videos.

## Tests

`tests/entrypoints/openai_api/test_serving_video_encode_offload.py` asserts the
behaviour rather than the call shape:

- encoding must not run on the loop thread, for both paths
- an encode that blocks until the loop releases it must be released in
  milliseconds rather than by its own timeout

They fail on current `main` and pass with this change. Locally: 3 passed in 2.4 s
with the fix, 3 failed in 12.3 s without it, the difference being the loop unable
to reach the release.

Please add the `ready` label so CI can run.
