### PR TITLE
[Model] MAGI-2: weight-only INT8/FP8 quantization for dense/shared-expert/text-encoder linears

### DIFF
--- a/tests/diffusion/models/magi2/test_native_dlo_allgather.py
+++ b/tests/diffusion/models/magi2/test_native_dlo_allgather.py
@@ -7,7 +7,7 @@ import json
 import os
 import tempfile
 from contextlib import ExitStack, contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from unittest.mock import patch
 
 import pytest
@@ -81,6 +81,28 @@ def _tiny_config() -> Magi2PreviewConfig:
             layers=(0, 1),
         ),
     )
+
+
+def test_mmap_plan_rejects_magi2_post_load_quantization() -> None:
+    config = replace(
+        _tiny_config(),
+        quant_config=type("QuantConfig", (), {"get_name": lambda self: "fp8"})(),
+    )
+    pipeline = nn.Module()
+    pipeline.transformer = Magi2PreviewTransformer(config)
+
+    result = build_checkpoint_mmap_plan(
+        pipeline,
+        dit_modules=(("transformer", pipeline.transformer),),
+        sources=(),
+        model_path=None,
+        tensor_parallel_size=1,
+        use_hsdp=False,
+        online_quantization=False,
+    )
+
+    assert result.plan is None
+    assert result.fallback_reason == "post-load weight conversion requires the ordinary loader"
 
 
 @contextmanager

--- a/tests/diffusion/models/magi2/test_pipeline_magi2.py
+++ b/tests/diffusion/models/magi2/test_pipeline_magi2.py
@@ -434,6 +434,24 @@ def test_native_topology_rejects_cfg_data_parallel_combination():
         _validate_native_topology(_topology_config(cfg_parallel_size=2, data_parallel_size=2))
 
 
+@dataclass
+class _FakeQuantConfig:
+    name: str
+
+    def get_name(self) -> str:
+        return self.name
+
+
+def test_native_topology_accepts_self_contained_int8_and_fp8_quant_methods():
+    _validate_native_topology(_topology_config(quantization_config=_FakeQuantConfig("int8")))
+    _validate_native_topology(_topology_config(quantization_config=_FakeQuantConfig("fp8")))
+
+
+def test_native_topology_rejects_unsupported_quant_methods():
+    with pytest.raises(ValueError, match="quantization='mxfp4'"):
+        _validate_native_topology(_topology_config(quantization_config=_FakeQuantConfig("mxfp4")))
+
+
 def test_cfg_parallel_branch_adapter_preserves_packed_cfg_math():
     sampler = Magi2PreviewSampler(nn.Identity(), Magi2DataProxy(), device="cpu", dtype=torch.float32)
     latent = torch.arange(8, dtype=torch.float32).reshape(1, 2, 2, 1, 2)

--- a/tests/diffusion/models/magi2/test_quant_config.py
+++ b/tests/diffusion/models/magi2/test_quant_config.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.models.magi2.configuration_magi2 import (
+    Magi2MHCConfig,
+    Magi2MoEConfig,
+    Magi2PreviewConfig,
+)
+from vllm_omni.diffusion.models.magi2.layers import Magi2GroupedLinear, make_grouped_linear
+
+pytestmark = [pytest.mark.diffusion, pytest.mark.cpu, pytest.mark.core_model]
+
+
+@dataclass
+class _FakeInt8Config:
+    """Duck-typed stand-in for vllm's DiffusionInt8Config (`get_name()` only)."""
+
+    def get_name(self) -> str:
+        return "int8"
+
+
+def _tiny_config(quant_config: object | None) -> Magi2PreviewConfig:
+    return Magi2PreviewConfig(
+        num_layers=1,
+        hidden_size=16,
+        head_dim=8,
+        num_query_groups=2,
+        video_in_channels=4,
+        audio_in_channels=4,
+        text_in_channels=4,
+        intermediate_factor=2,
+        multimodal_layers=(0,),
+        params_dtype=torch.float32,
+        mhc=Magi2MHCConfig(num_streams=2),
+        moe=Magi2MoEConfig(
+            num_heads=2,
+            num_experts=4,
+            top_k=2,
+            expert_intermediate_size=8,
+            shared_expert_intermediate_size=8,
+            modality_shared_expert_intermediate_size=8,
+            layers=(),  # keep layer 0 on the dense Magi2MLP path
+        ),
+        quant_config=quant_config,
+    )
+
+
+def _make_linear(quant_config: object | None, *, num_experts: int = 3) -> Magi2GroupedLinear:
+    torch.manual_seed(0)
+    linear = make_grouped_linear(
+        in_features=16,
+        out_features=12,
+        num_experts=num_experts,
+        bias=False,
+        dtype=torch.float32,
+        quant_config=quant_config,
+    )
+    with torch.no_grad():
+        linear.weight.copy_(torch.randn_like(linear.weight))
+    return linear
+
+
+def test_unquantized_linear_is_unaffected_by_quant_config_field() -> None:
+    linear = _make_linear(None)
+    assert not linear._int8_quantized
+    assert linear.weight is not None
+
+
+def test_maybe_quantize_int8_is_noop_without_supported_quant_config() -> None:
+    linear = _make_linear(None)
+    linear.maybe_quantize_int8_()
+    assert not linear._int8_quantized
+    assert linear.weight is not None
+
+
+def test_maybe_quantize_int8_replaces_weight_with_int8_buffers() -> None:
+    linear = _make_linear(_FakeInt8Config())
+    linear.maybe_quantize_int8_()
+    assert linear._int8_quantized
+    assert linear.weight is None
+    assert linear.weight_int8.dtype == torch.int8
+    assert linear.weight_int8.shape == (3, 12, 16)
+    assert linear.weight_scale.shape == (3, 12, 1)
+
+    # Idempotent: calling again must not raise or requantize.
+    linear.maybe_quantize_int8_()
+
+
+def test_quantized_forward_matches_unquantized_within_tolerance() -> None:
+    baseline = _make_linear(None, num_experts=1)
+    quantized = _make_linear(_FakeInt8Config(), num_experts=1)
+    with torch.no_grad():
+        quantized.weight.copy_(baseline.weight)
+    quantized.maybe_quantize_int8_()
+
+    x = torch.randn(5, 16)
+    expected = baseline(x)
+    actual = quantized(x)
+    assert actual.shape == expected.shape
+    # Per-channel symmetric int8 (127 levels) on N(0, 1) weights: relative
+    # error is dominated by quantization step size, not a hard numerical bug.
+    torch.testing.assert_close(actual, expected, atol=5e-2, rtol=5e-2)
+
+
+def test_quant_config_field_threads_from_model_config_into_dense_layers() -> None:
+    from vllm_omni.diffusion.models.magi2.modeling_magi2 import Magi2MLP
+
+    quant_config = _FakeInt8Config()
+    config = _tiny_config(quant_config)
+    mlp = Magi2MLP(config, num_modality=1)
+    assert mlp.up_gate_proj.quant_config is quant_config
+    assert mlp.down_proj.quant_config is quant_config

--- a/tests/diffusion/models/magi2/test_quant_config.py
+++ b/tests/diffusion/models/magi2/test_quant_config.py
@@ -7,23 +7,43 @@ from dataclasses import dataclass
 
 import pytest
 import torch
+import torch.nn as nn
 
 from vllm_omni.diffusion.models.magi2.configuration_magi2 import (
     Magi2MHCConfig,
     Magi2MoEConfig,
     Magi2PreviewConfig,
 )
-from vllm_omni.diffusion.models.magi2.layers import Magi2GroupedLinear, make_grouped_linear
+from vllm_omni.diffusion.models.magi2.layers import (
+    Magi2GroupedLinear,
+    QuantizedLinear,
+    make_grouped_linear,
+    quantize_linear_modules_,
+)
 
 pytestmark = [pytest.mark.diffusion, pytest.mark.cpu, pytest.mark.core_model]
 
 
 @dataclass
-class _FakeInt8Config:
-    """Duck-typed stand-in for vllm's DiffusionInt8Config (`get_name()` only)."""
+class _FakeQuantConfig:
+    """Duck-typed stand-in for a vllm QuantizationConfig (`get_name()` only)."""
+
+    name: str
 
     def get_name(self) -> str:
-        return "int8"
+        return self.name
+
+
+def _int8() -> _FakeQuantConfig:
+    return _FakeQuantConfig("int8")
+
+
+def _fp8() -> _FakeQuantConfig:
+    return _FakeQuantConfig("fp8")
+
+
+def _unsupported() -> _FakeQuantConfig:
+    return _FakeQuantConfig("mxfp4")
 
 
 def _tiny_config(quant_config: object | None) -> Magi2PreviewConfig:
@@ -69,51 +89,122 @@ def _make_linear(quant_config: object | None, *, num_experts: int = 3) -> Magi2G
 
 def test_unquantized_linear_is_unaffected_by_quant_config_field() -> None:
     linear = _make_linear(None)
-    assert not linear._int8_quantized
+    assert linear._quantized_dtype is None
     assert linear.weight is not None
 
 
-def test_maybe_quantize_int8_is_noop_without_supported_quant_config() -> None:
-    linear = _make_linear(None)
-    linear.maybe_quantize_int8_()
-    assert not linear._int8_quantized
-    assert linear.weight is not None
+def test_maybe_quantize_is_noop_without_supported_quant_config() -> None:
+    for quant_config in (None, _unsupported()):
+        linear = _make_linear(quant_config)
+        linear.maybe_quantize_()
+        assert linear._quantized_dtype is None
+        assert linear.weight is not None
 
 
-def test_maybe_quantize_int8_replaces_weight_with_int8_buffers() -> None:
-    linear = _make_linear(_FakeInt8Config())
-    linear.maybe_quantize_int8_()
-    assert linear._int8_quantized
+@pytest.mark.parametrize("quant_config,expected_dtype", [(_int8(), torch.int8), (_fp8(), torch.float8_e4m3fn)])
+def test_maybe_quantize_replaces_weight_with_quantized_buffers(quant_config, expected_dtype) -> None:
+    linear = _make_linear(quant_config)
+    linear.maybe_quantize_()
+    assert linear._quantized_dtype == expected_dtype
     assert linear.weight is None
-    assert linear.weight_int8.dtype == torch.int8
-    assert linear.weight_int8.shape == (3, 12, 16)
+    assert linear.weight_quantized.dtype == expected_dtype
+    assert linear.weight_quantized.shape == (3, 12, 16)
     assert linear.weight_scale.shape == (3, 12, 1)
 
     # Idempotent: calling again must not raise or requantize.
-    linear.maybe_quantize_int8_()
+    linear.maybe_quantize_()
 
 
-def test_quantized_forward_matches_unquantized_within_tolerance() -> None:
+@pytest.mark.parametrize(
+    "quant_config,atol,rtol",
+    [
+        (_int8(), 5e-2, 5e-2),
+        # e4m3 has only 3 mantissa bits (~1/8 relative step) vs int8's 7-bit
+        # magnitude (~1/127 relative step), so fp8 needs a looser tolerance
+        # for the same per-channel symmetric scheme -- this is the expected
+        # quantization error, not a correctness bug.
+        (_fp8(), 2e-1, 2e-1),
+    ],
+)
+def test_quantized_forward_matches_unquantized_within_tolerance(quant_config, atol, rtol) -> None:
     baseline = _make_linear(None, num_experts=1)
-    quantized = _make_linear(_FakeInt8Config(), num_experts=1)
+    quantized = _make_linear(quant_config, num_experts=1)
     with torch.no_grad():
         quantized.weight.copy_(baseline.weight)
-    quantized.maybe_quantize_int8_()
+    quantized.maybe_quantize_()
 
     x = torch.randn(5, 16)
     expected = baseline(x)
     actual = quantized(x)
     assert actual.shape == expected.shape
-    # Per-channel symmetric int8 (127 levels) on N(0, 1) weights: relative
-    # error is dominated by quantization step size, not a hard numerical bug.
-    torch.testing.assert_close(actual, expected, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
 
 
 def test_quant_config_field_threads_from_model_config_into_dense_layers() -> None:
     from vllm_omni.diffusion.models.magi2.modeling_magi2 import Magi2MLP
 
-    quant_config = _FakeInt8Config()
+    quant_config = _int8()
     config = _tiny_config(quant_config)
     mlp = Magi2MLP(config, num_modality=1)
     assert mlp.up_gate_proj.quant_config is quant_config
     assert mlp.down_proj.quant_config is quant_config
+
+
+def test_quant_config_field_threads_into_shared_expert_linears() -> None:
+    from vllm_omni.diffusion.models.magi2.modeling_magi2 import Magi2MultiHeadMoELayer
+
+    quant_config = _int8()
+    config = _tiny_config(quant_config)
+    moe_layer = Magi2MultiHeadMoELayer(config)
+    assert moe_layer.shared_expert_fc1.quant_config is quant_config
+    assert moe_layer.shared_expert_fc2.quant_config is quant_config
+    assert moe_layer.modality_specific_shared_expert_fc1.quant_config is quant_config
+    assert moe_layer.modality_specific_shared_expert_fc2.quant_config is quant_config
+    # The routed-expert gather/scatter path stays unquantized: it overlaps
+    # the fused expert kernel work tracked separately under M2 in #7085.
+    assert moe_layer.split_linear.quant_config is None
+    assert moe_layer.merge_linear.quant_config is None
+
+
+class _TinyMLP(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(8, 16, bias=True)
+        self.fc2 = nn.Linear(16, 8, bias=False)
+        self.nested = nn.Sequential(nn.Linear(8, 8))
+
+
+def test_quantize_linear_modules_is_noop_without_supported_quant_config() -> None:
+    model = _TinyMLP()
+    count = quantize_linear_modules_(model, None)
+    assert count == 0
+    assert isinstance(model.fc1, nn.Linear)
+
+
+@pytest.mark.parametrize("quant_config,expected_dtype", [(_int8(), torch.int8), (_fp8(), torch.float8_e4m3fn)])
+def test_quantize_linear_modules_replaces_all_linears(quant_config, expected_dtype) -> None:
+    torch.manual_seed(0)
+    model = _TinyMLP()
+    count = quantize_linear_modules_(model, quant_config)
+    assert count == 3
+    assert isinstance(model.fc1, QuantizedLinear)
+    assert isinstance(model.fc2, QuantizedLinear)
+    assert isinstance(model.nested[0], QuantizedLinear)
+    assert model.fc1.weight_quantized.dtype == expected_dtype
+    assert model.fc2.bias is None
+    assert model.fc1.bias is not None
+
+
+@pytest.mark.parametrize(
+    "quant_config,atol,rtol",
+    [(_int8(), 5e-2, 5e-2), (_fp8(), 2e-1, 2e-1)],
+)
+def test_quantized_linear_forward_matches_unquantized_within_tolerance(quant_config, atol, rtol) -> None:
+    torch.manual_seed(0)
+    reference = nn.Linear(8, 16, bias=True)
+    quantized_linear = QuantizedLinear(reference, {"int8": torch.int8, "fp8": torch.float8_e4m3fn}[quant_config.name])
+
+    x = torch.randn(4, 8)
+    expected = reference(x)
+    actual = quantized_linear(x)
+    torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)

--- a/tests/diffusion/models/magi2/test_quant_config.py
+++ b/tests/diffusion/models/magi2/test_quant_config.py
@@ -208,3 +208,20 @@ def test_quantized_linear_forward_matches_unquantized_within_tolerance(quant_con
     expected = reference(x)
     actual = quantized_linear(x)
     torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize("weight_dtype", [torch.int8, torch.float8_e4m3fn])
+def test_fp16_zero_and_small_rows_quantize_with_fp32_scales(weight_dtype) -> None:
+    linear = nn.Linear(4, 3, bias=False, dtype=torch.float16)
+    with torch.no_grad():
+        linear.weight.zero_()
+        linear.weight[1].fill_(1e-5)
+
+    quantized = QuantizedLinear(linear, weight_dtype)
+    assert torch.isfinite(quantized.weight_scale).all()
+    assert quantized.weight_scale[1].item() > 0
+
+    actual = quantized(torch.ones(1, 4, dtype=torch.float16))
+    assert torch.isfinite(actual).all()
+    assert actual[0, 0].item() == 0
+    assert actual[0, 1].item() > 0

--- a/vllm_omni/diffusion/model_loader/host_weight_plan.py
+++ b/vllm_omni/diffusion/model_loader/host_weight_plan.py
@@ -330,6 +330,8 @@ def build_checkpoint_mmap_plan(
         return HostWeightPlanResult(None, "HSDP requires the ordinary loader")
     if online_quantization:
         return HostWeightPlanResult(None, "online quantization requires the ordinary loader")
+    if any(getattr(module, "requires_ordinary_weight_loading", False) for module in pipeline.modules()):
+        return HostWeightPlanResult(None, "post-load weight conversion requires the ordinary loader")
 
     remap_fn = getattr(type(pipeline), "_remap_ckpt_key", None)
     if not callable(remap_fn):

--- a/vllm_omni/diffusion/models/magi2/conditioning.py
+++ b/vllm_omni/diffusion/models/magi2/conditioning.py
@@ -20,6 +20,8 @@ import torch.nn as nn
 from tokenizers import Regex, pre_tokenizers
 from transformers import AutoTokenizer
 
+from .layers import quantize_linear_modules_
+
 
 def _strip_empty(obj: Any) -> Any:
     if isinstance(obj, dict):
@@ -224,6 +226,7 @@ class Magi2Qwen35TextEncoder(nn.Module):
         max_length: int = 7000,
         skip_layer: int = 2,
         local_files_only: bool = True,
+        quant_config: Any | None = None,
     ) -> None:
         super().__init__()
         self.max_length = max_length
@@ -251,6 +254,11 @@ class Magi2Qwen35TextEncoder(nn.Module):
             local_files_only=local_files_only,
         )
         self.text_model.eval().requires_grad_(False)
+        # Weight-only, dequant-on-forward quantization of the encoder's plain
+        # nn.Linear layers -- see QuantizedLinear/quantize_linear_modules_ in
+        # layers.py. A no-op when quant_config is None or names an
+        # unsupported method.
+        quantize_linear_modules_(self.text_model, quant_config)
 
     def _tokenize(self, prompt: str, *, offsets: bool = False):
         return self.tokenizer(

--- a/vllm_omni/diffusion/models/magi2/conditioning.py
+++ b/vllm_omni/diffusion/models/magi2/conditioning.py
@@ -254,10 +254,7 @@ class Magi2Qwen35TextEncoder(nn.Module):
             local_files_only=local_files_only,
         )
         self.text_model.eval().requires_grad_(False)
-        # Weight-only, dequant-on-forward quantization of the encoder's plain
-        # nn.Linear layers -- see QuantizedLinear/quantize_linear_modules_ in
-        # layers.py. A no-op when quant_config is None or names an
-        # unsupported method.
+        # No-op when quant_config is None or unsupported; see layers.py.
         quantize_linear_modules_(self.text_model, quant_config)
 
     def _tokenize(self, prompt: str, *, offsets: bool = False):

--- a/vllm_omni/diffusion/models/magi2/configuration_magi2.py
+++ b/vllm_omni/diffusion/models/magi2/configuration_magi2.py
@@ -65,10 +65,11 @@ class Magi2PreviewConfig:
     attention_gating: bool = True
     mhc: Magi2MHCConfig = field(default_factory=Magi2MHCConfig)
     moe: Magi2MoEConfig = field(default_factory=Magi2MoEConfig)
-    # Applied only to the dense attention/MLP grouped linears (Magi2Attention,
-    # Magi2MLP). The MoE routed/shared-expert linears (Magi2MultiHeadMoELayer)
-    # are left unquantized here to avoid overlapping the in-progress fused
-    # expert kernel work tracked separately under M2 in #7085.
+    # Applied to the dense attention/MLP grouped linears (Magi2Attention,
+    # Magi2MLP) and the shared-expert linears in Magi2MultiHeadMoELayer. The
+    # routed-expert gather/SwiGLU7/scatter path (split_linear, moe_mlp,
+    # merge_linear) is left unquantized to avoid overlapping the in-progress
+    # fused expert kernel work tracked separately under M2 in #7085.
     quant_config: Any | None = None
 
     @property

--- a/vllm_omni/diffusion/models/magi2/configuration_magi2.py
+++ b/vllm_omni/diffusion/models/magi2/configuration_magi2.py
@@ -65,11 +65,8 @@ class Magi2PreviewConfig:
     attention_gating: bool = True
     mhc: Magi2MHCConfig = field(default_factory=Magi2MHCConfig)
     moe: Magi2MoEConfig = field(default_factory=Magi2MoEConfig)
-    # Applied to the dense attention/MLP grouped linears (Magi2Attention,
-    # Magi2MLP) and the shared-expert linears in Magi2MultiHeadMoELayer. The
-    # routed-expert gather/SwiGLU7/scatter path (split_linear, moe_mlp,
-    # merge_linear) is left unquantized to avoid overlapping the in-progress
-    # fused expert kernel work tracked separately under M2 in #7085.
+    # Applied to dense attention/MLP and shared-expert linears; the
+    # routed-expert path stays unquantized (overlaps M2's kernel, #7085).
     quant_config: Any | None = None
 
     @property

--- a/vllm_omni/diffusion/models/magi2/configuration_magi2.py
+++ b/vllm_omni/diffusion/models/magi2/configuration_magi2.py
@@ -12,6 +12,7 @@ also gives tests a small-config entry point.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
 import torch
 
@@ -64,6 +65,11 @@ class Magi2PreviewConfig:
     attention_gating: bool = True
     mhc: Magi2MHCConfig = field(default_factory=Magi2MHCConfig)
     moe: Magi2MoEConfig = field(default_factory=Magi2MoEConfig)
+    # Applied only to the dense attention/MLP grouped linears (Magi2Attention,
+    # Magi2MLP). The MoE routed/shared-expert linears (Magi2MultiHeadMoELayer)
+    # are left unquantized here to avoid overlapping the in-progress fused
+    # expert kernel work tracked separately under M2 in #7085.
+    quant_config: Any | None = None
 
     @property
     def num_attention_heads(self) -> int:

--- a/vllm_omni/diffusion/models/magi2/layers.py
+++ b/vllm_omni/diffusion/models/magi2/layers.py
@@ -28,14 +28,28 @@ from .parallel import Magi2ParallelGroup, get_magi2_tp_group
 # ColumnParallelLinear/RowParallelLinear contract. `quant_config` is duck
 # typed (`get_name()`) rather than the vLLM `QuantizationConfig` type so this
 # module has no hard vLLM import for its quantization path.
-_SUPPORTED_QUANT_METHODS = frozenset({"int8"})
+#
+# Both formats here are weight-only, dynamic, symmetric quantization: the
+# int8/fp8 tensor is dequantized to the compute dtype before every matmul,
+# so neither needs a real int8/fp8 GEMM kernel or specific GPU generation to
+# run correctly (only to be fast) -- see WEIGHT_DTYPE_BY_QUANT_METHOD.
+# NVFP4 (block-scaled 4-bit) is intentionally not implemented here: it needs
+# a real block-scaled kernel to be worth the precision loss, tracked as a
+# separate path per the #7085 roadmap wording rather than folded into this
+# dequant-on-forward scheme.
+WEIGHT_DTYPE_BY_QUANT_METHOD: dict[str, torch.dtype] = {
+    "int8": torch.int8,
+    "fp8": torch.float8_e4m3fn,
+}
 
 
-def _is_int8_quant_config(quant_config: Any | None) -> bool:
+def _quant_weight_dtype(quant_config: Any | None) -> torch.dtype | None:
     if quant_config is None:
-        return False
+        return None
     get_name = getattr(quant_config, "get_name", None)
-    return callable(get_name) and get_name() in _SUPPORTED_QUANT_METHODS
+    if not callable(get_name):
+        return None
+    return WEIGHT_DTYPE_BY_QUANT_METHOD.get(get_name())
 
 
 def swiglu7(
@@ -148,7 +162,7 @@ class Magi2GroupedLinear(nn.Module):
                 self.bias.checkpoint_weight_transform = self.shard_checkpoint_bias
 
         self.quant_config = quant_config
-        self._int8_quantized = False
+        self._quantized_dtype: torch.dtype | None = None
 
     def _column_slices(self) -> tuple[tuple[int, int], ...]:
         splits = self.qkv_splits or (self.out_features,)
@@ -195,31 +209,43 @@ class Magi2GroupedLinear(nn.Module):
         shards = [grouped[:, start:end] for start, end in self._column_slices()]
         return torch.cat(shards, dim=1).reshape(-1)
 
-    def maybe_quantize_int8_(self) -> None:
-        """Quantize the (already-loaded) weight to per-expert, per-output-channel int8.
+    def maybe_quantize_(self) -> None:
+        """Quantize the (already-loaded) weight to per-expert, per-output-channel
+        int8 or fp8 (e4m3), per ``quant_config.get_name()``.
 
         Weight-only, symmetric, dynamic quantization: no calibration data or
         serialized scales are needed, so this can run right after checkpoint
-        loading. Activations stay in ``params_dtype``; the int8 weight is
+        loading. Activations stay in ``params_dtype``; the quantized weight is
         dequantized on the fly in `forward`, so this trades compute (one
-        extra elementwise multiply per forward) for ~2x smaller resident
-        weight memory vs bf16/fp16.
+        extra elementwise multiply per forward) for smaller resident weight
+        memory vs bf16/fp16 (~2x for int8/fp8). Because dequantization happens
+        before the matmul, this needs no int8/fp8 GEMM kernel or specific GPU
+        generation to run correctly.
         """
-        if self._int8_quantized or not _is_int8_quant_config(self.quant_config):
+        weight_dtype = _quant_weight_dtype(self.quant_config)
+        if self._quantized_dtype is not None or weight_dtype is None:
             return
         with torch.no_grad():
             grouped = self.weight.data.view(self.num_experts, self.local_out_features, self.local_in_features)
-            scale = grouped.abs().amax(dim=-1, keepdim=True).clamp_min(1e-8) / 127.0
-            quantized = (grouped / scale).round().clamp(-127, 127).to(torch.int8)
+            if weight_dtype == torch.int8:
+                scale = grouped.abs().amax(dim=-1, keepdim=True).clamp_min(1e-8) / 127.0
+                quantized = (grouped / scale).round().clamp(-127, 127).to(torch.int8)
+            else:
+                finfo = torch.finfo(weight_dtype)
+                scale = grouped.abs().amax(dim=-1, keepdim=True).clamp_min(1e-12) / finfo.max
+                quantized = (grouped / scale).clamp(finfo.min, finfo.max).to(weight_dtype)
         del self._parameters["weight"]
-        self.register_buffer("weight_int8", quantized)
+        self.register_buffer("weight_quantized", quantized)
         self.register_buffer("weight_scale", scale.to(torch.float32))
         self.weight = None
-        self._int8_quantized = True
+        self._quantized_dtype = weight_dtype
+
+    # Backwards-compatible alias for the int8-only entry point.
+    maybe_quantize_int8_ = maybe_quantize_
 
     def _grouped_weight(self, compute_dtype: torch.dtype) -> torch.Tensor:
-        if self._int8_quantized:
-            return self.weight_int8.to(compute_dtype) * self.weight_scale.to(compute_dtype)
+        if self._quantized_dtype is not None:
+            return self.weight_quantized.to(compute_dtype) * self.weight_scale.to(compute_dtype)
         return self.weight.view(self.num_experts, self.local_out_features, self.local_in_features)
 
     def forward(
@@ -255,6 +281,57 @@ class Magi2GroupedLinear(nn.Module):
                 outputs = [part + bias[index] for index, part in enumerate(modality_dispatcher.dispatch(output))]
                 output = torch.cat(outputs, dim=0)
         return output
+
+
+class QuantizedLinear(nn.Module):
+    """Drop-in replacement for a plain ``nn.Linear`` with a quantized weight.
+
+    Same weight-only, dynamic, symmetric, dequant-on-forward scheme as
+    ``Magi2GroupedLinear.maybe_quantize_``, for models that aren't built out
+    of grouped linears -- e.g. the stock HF ``transformers`` text encoder
+    (``Qwen3_5TextModel``), which has ordinary ``nn.Linear`` submodules with
+    no per-expert grouping.
+    """
+
+    def __init__(self, linear: nn.Linear, weight_dtype: torch.dtype) -> None:
+        super().__init__()
+        self.in_features = linear.in_features
+        self.out_features = linear.out_features
+        with torch.no_grad():
+            weight = linear.weight.data
+            if weight_dtype == torch.int8:
+                scale = weight.abs().amax(dim=-1, keepdim=True).clamp_min(1e-8) / 127.0
+                quantized = (weight / scale).round().clamp(-127, 127).to(torch.int8)
+            else:
+                finfo = torch.finfo(weight_dtype)
+                scale = weight.abs().amax(dim=-1, keepdim=True).clamp_min(1e-12) / finfo.max
+                quantized = (weight / scale).clamp(finfo.min, finfo.max).to(weight_dtype)
+        self.register_buffer("weight_quantized", quantized)
+        self.register_buffer("weight_scale", scale.to(torch.float32))
+        self.bias = linear.bias
+
+    def forward(self, tensor: torch.Tensor) -> torch.Tensor:
+        weight = self.weight_quantized.to(tensor.dtype) * self.weight_scale.to(tensor.dtype)
+        return F.linear(tensor, weight, self.bias)
+
+
+def quantize_linear_modules_(module: nn.Module, quant_config: Any | None) -> int:
+    """Replace every plain ``nn.Linear`` child of ``module`` in place with a
+    ``QuantizedLinear``, per ``quant_config.get_name()``. Returns the number of
+    linears quantized; a no-op (returns 0) when ``quant_config`` names a
+    method this scheme doesn't support (see ``WEIGHT_DTYPE_BY_QUANT_METHOD``).
+    """
+    weight_dtype = _quant_weight_dtype(quant_config)
+    if weight_dtype is None:
+        return 0
+    count = 0
+    for name, child in list(module.named_children()):
+        if isinstance(child, nn.Linear):
+            setattr(module, name, QuantizedLinear(child, weight_dtype))
+            count += 1
+        else:
+            count += quantize_linear_modules_(child, quant_config)
+    return count
 
 
 def make_grouped_linear(
@@ -480,7 +557,9 @@ __all__ = [
     "Magi2GroupedLinear",
     "ModalityDispatcher",
     "MultiModalityRMSNorm",
+    "QuantizedLinear",
     "make_grouped_linear",
+    "quantize_linear_modules_",
     "sinkhorn_knopp",
     "swiglu7",
 ]

--- a/vllm_omni/diffusion/models/magi2/layers.py
+++ b/vllm_omni/diffusion/models/magi2/layers.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Callable
+from typing import Any
 
 import torch
 import torch.distributed as dist
@@ -20,6 +21,21 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from .parallel import Magi2ParallelGroup, get_magi2_tp_group
+
+# Quantization here is intentionally self-contained (no vLLM LinearBase
+# dependency): Magi2GroupedLinear stores a flattened [num_experts * out, in]
+# weight with its own TP sharding hooks, which doesn't fit vLLM's
+# ColumnParallelLinear/RowParallelLinear contract. `quant_config` is duck
+# typed (`get_name()`) rather than the vLLM `QuantizationConfig` type so this
+# module has no hard vLLM import for its quantization path.
+_SUPPORTED_QUANT_METHODS = frozenset({"int8"})
+
+
+def _is_int8_quant_config(quant_config: Any | None) -> bool:
+    if quant_config is None:
+        return False
+    get_name = getattr(quant_config, "get_name", None)
+    return callable(get_name) and get_name() in _SUPPORTED_QUANT_METHODS
 
 
 def swiglu7(
@@ -84,6 +100,7 @@ class Magi2GroupedLinear(nn.Module):
         parallel_mode: str | None = None,
         qkv_splits: tuple[int, int, int] | None = None,
         tp_group: Magi2ParallelGroup | None = None,
+        quant_config: Any | None = None,
     ) -> None:
         super().__init__()
         if parallel_mode not in (None, "column", "row"):
@@ -130,6 +147,9 @@ class Magi2GroupedLinear(nn.Module):
             if self.bias is not None and parallel_mode == "column":
                 self.bias.checkpoint_weight_transform = self.shard_checkpoint_bias
 
+        self.quant_config = quant_config
+        self._int8_quantized = False
+
     def _column_slices(self) -> tuple[tuple[int, int], ...]:
         splits = self.qkv_splits or (self.out_features,)
         offsets: list[tuple[int, int]] = []
@@ -175,12 +195,39 @@ class Magi2GroupedLinear(nn.Module):
         shards = [grouped[:, start:end] for start, end in self._column_slices()]
         return torch.cat(shards, dim=1).reshape(-1)
 
+    def maybe_quantize_int8_(self) -> None:
+        """Quantize the (already-loaded) weight to per-expert, per-output-channel int8.
+
+        Weight-only, symmetric, dynamic quantization: no calibration data or
+        serialized scales are needed, so this can run right after checkpoint
+        loading. Activations stay in ``params_dtype``; the int8 weight is
+        dequantized on the fly in `forward`, so this trades compute (one
+        extra elementwise multiply per forward) for ~2x smaller resident
+        weight memory vs bf16/fp16.
+        """
+        if self._int8_quantized or not _is_int8_quant_config(self.quant_config):
+            return
+        with torch.no_grad():
+            grouped = self.weight.data.view(self.num_experts, self.local_out_features, self.local_in_features)
+            scale = grouped.abs().amax(dim=-1, keepdim=True).clamp_min(1e-8) / 127.0
+            quantized = (grouped / scale).round().clamp(-127, 127).to(torch.int8)
+        del self._parameters["weight"]
+        self.register_buffer("weight_int8", quantized)
+        self.register_buffer("weight_scale", scale.to(torch.float32))
+        self.weight = None
+        self._int8_quantized = True
+
+    def _grouped_weight(self, compute_dtype: torch.dtype) -> torch.Tensor:
+        if self._int8_quantized:
+            return self.weight_int8.to(compute_dtype) * self.weight_scale.to(compute_dtype)
+        return self.weight.view(self.num_experts, self.local_out_features, self.local_in_features)
+
     def forward(
         self,
         tensor: torch.Tensor,
         modality_dispatcher: ModalityDispatcher | None = None,
     ) -> torch.Tensor:
-        weight = self.weight.view(self.num_experts, self.local_out_features, self.local_in_features)
+        weight = self._grouped_weight(tensor.dtype)
         bias_features = self.local_out_features if self.parallel_mode == "column" else self.out_features
         bias = self.bias.view(self.num_experts, bias_features) if self.bias is not None else None
         linear_bias = None if self.parallel_mode == "row" else bias
@@ -219,6 +266,7 @@ def make_grouped_linear(
     dtype: torch.dtype | None = None,
     parallel_mode: str | None = None,
     qkv_splits: tuple[int, int, int] | None = None,
+    quant_config: Any | None = None,
 ) -> Magi2GroupedLinear:
     return Magi2GroupedLinear(
         in_features,
@@ -228,6 +276,7 @@ def make_grouped_linear(
         dtype=dtype,
         parallel_mode=parallel_mode,
         qkv_splits=qkv_splits,
+        quant_config=quant_config,
     )
 
 

--- a/vllm_omni/diffusion/models/magi2/layers.py
+++ b/vllm_omni/diffusion/models/magi2/layers.py
@@ -22,21 +22,12 @@ import torch.nn.functional as F
 
 from .parallel import Magi2ParallelGroup, get_magi2_tp_group
 
-# Quantization here is intentionally self-contained (no vLLM LinearBase
-# dependency): Magi2GroupedLinear stores a flattened [num_experts * out, in]
-# weight with its own TP sharding hooks, which doesn't fit vLLM's
-# ColumnParallelLinear/RowParallelLinear contract. `quant_config` is duck
-# typed (`get_name()`) rather than the vLLM `QuantizationConfig` type so this
-# module has no hard vLLM import for its quantization path.
-#
-# Both formats here are weight-only, dynamic, symmetric quantization: the
-# int8/fp8 tensor is dequantized to the compute dtype before every matmul,
-# so neither needs a real int8/fp8 GEMM kernel or specific GPU generation to
-# run correctly (only to be fast) -- see WEIGHT_DTYPE_BY_QUANT_METHOD.
-# NVFP4 (block-scaled 4-bit) is intentionally not implemented here: it needs
-# a real block-scaled kernel to be worth the precision loss, tracked as a
-# separate path per the #7085 roadmap wording rather than folded into this
-# dequant-on-forward scheme.
+# Self-contained (no vLLM LinearBase) since Magi2GroupedLinear's flattened
+# weight layout and TP hooks don't fit ColumnParallelLinear/RowParallelLinear.
+# `quant_config` is duck typed (`get_name()`) to avoid a hard vLLM import.
+# Weight-only, dequantized before every matmul, so no real int8/fp8 GEMM
+# kernel is needed for correctness. NVFP4 isn't implemented: it needs a real
+# block-scaled kernel this scheme doesn't provide (separate path, see #7085).
 WEIGHT_DTYPE_BY_QUANT_METHOD: dict[str, torch.dtype] = {
     "int8": torch.int8,
     "fp8": torch.float8_e4m3fn,
@@ -210,17 +201,9 @@ class Magi2GroupedLinear(nn.Module):
         return torch.cat(shards, dim=1).reshape(-1)
 
     def maybe_quantize_(self) -> None:
-        """Quantize the (already-loaded) weight to per-expert, per-output-channel
-        int8 or fp8 (e4m3), per ``quant_config.get_name()``.
-
-        Weight-only, symmetric, dynamic quantization: no calibration data or
-        serialized scales are needed, so this can run right after checkpoint
-        loading. Activations stay in ``params_dtype``; the quantized weight is
-        dequantized on the fly in `forward`, so this trades compute (one
-        extra elementwise multiply per forward) for smaller resident weight
-        memory vs bf16/fp16 (~2x for int8/fp8). Because dequantization happens
-        before the matmul, this needs no int8/fp8 GEMM kernel or specific GPU
-        generation to run correctly.
+        """Quantize the loaded weight to per-expert, per-output-channel int8
+        or fp8, per ``quant_config.get_name()``. Call once, after checkpoint
+        loading; a no-op if already quantized or the method is unsupported.
         """
         weight_dtype = _quant_weight_dtype(self.quant_config)
         if self._quantized_dtype is not None or weight_dtype is None:
@@ -239,9 +222,6 @@ class Magi2GroupedLinear(nn.Module):
         self.register_buffer("weight_scale", scale.to(torch.float32))
         self.weight = None
         self._quantized_dtype = weight_dtype
-
-    # Backwards-compatible alias for the int8-only entry point.
-    maybe_quantize_int8_ = maybe_quantize_
 
     def _grouped_weight(self, compute_dtype: torch.dtype) -> torch.Tensor:
         if self._quantized_dtype is not None:
@@ -286,11 +266,9 @@ class Magi2GroupedLinear(nn.Module):
 class QuantizedLinear(nn.Module):
     """Drop-in replacement for a plain ``nn.Linear`` with a quantized weight.
 
-    Same weight-only, dynamic, symmetric, dequant-on-forward scheme as
-    ``Magi2GroupedLinear.maybe_quantize_``, for models that aren't built out
-    of grouped linears -- e.g. the stock HF ``transformers`` text encoder
-    (``Qwen3_5TextModel``), which has ordinary ``nn.Linear`` submodules with
-    no per-expert grouping.
+    Same scheme as ``Magi2GroupedLinear.maybe_quantize_``, for models built
+    out of ordinary ``nn.Linear``s rather than grouped linears -- e.g. the
+    stock HF ``Qwen3_5TextModel`` text encoder.
     """
 
     def __init__(self, linear: nn.Linear, weight_dtype: torch.dtype) -> None:

--- a/vllm_omni/diffusion/models/magi2/layers.py
+++ b/vllm_omni/diffusion/models/magi2/layers.py
@@ -43,6 +43,27 @@ def _quant_weight_dtype(quant_config: Any | None) -> torch.dtype | None:
     return WEIGHT_DTYPE_BY_QUANT_METHOD.get(get_name())
 
 
+def _quantize_weight_per_output_channel(
+    weight: torch.Tensor,
+    weight_dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize a linear weight with FP32 scales and arithmetic.
+
+    Checkpoints may be FP16. Computing a per-channel FP8 scale in that dtype
+    makes both the zero-row floor and small nonzero scales underflow before the
+    scale is saved as FP32.
+    """
+    weight_fp32 = weight.float()
+    if weight_dtype == torch.int8:
+        scale = weight_fp32.abs().amax(dim=-1, keepdim=True).clamp_min(1e-8) / 127.0
+        quantized = (weight_fp32 / scale).round().clamp(-127, 127).to(torch.int8)
+    else:
+        finfo = torch.finfo(weight_dtype)
+        scale = weight_fp32.abs().amax(dim=-1, keepdim=True).clamp_min(1e-12) / finfo.max
+        quantized = (weight_fp32 / scale).clamp(finfo.min, finfo.max).to(weight_dtype)
+    return quantized, scale
+
+
 def swiglu7(
     x: torch.Tensor,
     alpha: float = 1.702,
@@ -210,13 +231,7 @@ class Magi2GroupedLinear(nn.Module):
             return
         with torch.no_grad():
             grouped = self.weight.data.view(self.num_experts, self.local_out_features, self.local_in_features)
-            if weight_dtype == torch.int8:
-                scale = grouped.abs().amax(dim=-1, keepdim=True).clamp_min(1e-8) / 127.0
-                quantized = (grouped / scale).round().clamp(-127, 127).to(torch.int8)
-            else:
-                finfo = torch.finfo(weight_dtype)
-                scale = grouped.abs().amax(dim=-1, keepdim=True).clamp_min(1e-12) / finfo.max
-                quantized = (grouped / scale).clamp(finfo.min, finfo.max).to(weight_dtype)
+            quantized, scale = _quantize_weight_per_output_channel(grouped, weight_dtype)
         del self._parameters["weight"]
         self.register_buffer("weight_quantized", quantized)
         self.register_buffer("weight_scale", scale.to(torch.float32))
@@ -225,7 +240,7 @@ class Magi2GroupedLinear(nn.Module):
 
     def _grouped_weight(self, compute_dtype: torch.dtype) -> torch.Tensor:
         if self._quantized_dtype is not None:
-            return self.weight_quantized.to(compute_dtype) * self.weight_scale.to(compute_dtype)
+            return (self.weight_quantized.float() * self.weight_scale).to(compute_dtype)
         return self.weight.view(self.num_experts, self.local_out_features, self.local_in_features)
 
     def forward(
@@ -276,20 +291,13 @@ class QuantizedLinear(nn.Module):
         self.in_features = linear.in_features
         self.out_features = linear.out_features
         with torch.no_grad():
-            weight = linear.weight.data
-            if weight_dtype == torch.int8:
-                scale = weight.abs().amax(dim=-1, keepdim=True).clamp_min(1e-8) / 127.0
-                quantized = (weight / scale).round().clamp(-127, 127).to(torch.int8)
-            else:
-                finfo = torch.finfo(weight_dtype)
-                scale = weight.abs().amax(dim=-1, keepdim=True).clamp_min(1e-12) / finfo.max
-                quantized = (weight / scale).clamp(finfo.min, finfo.max).to(weight_dtype)
+            quantized, scale = _quantize_weight_per_output_channel(linear.weight.data, weight_dtype)
         self.register_buffer("weight_quantized", quantized)
         self.register_buffer("weight_scale", scale.to(torch.float32))
         self.bias = linear.bias
 
     def forward(self, tensor: torch.Tensor) -> torch.Tensor:
-        weight = self.weight_quantized.to(tensor.dtype) * self.weight_scale.to(tensor.dtype)
+        weight = (self.weight_quantized.float() * self.weight_scale).to(tensor.dtype)
         return F.linear(tensor, weight, self.bias)
 
 

--- a/vllm_omni/diffusion/models/magi2/modeling_magi2.py
+++ b/vllm_omni/diffusion/models/magi2/modeling_magi2.py
@@ -27,8 +27,8 @@ from .attention import Magi2PackedAttentionKernel, VarlenHandler, apply_rotary_e
 from .configuration_magi2 import Magi2PreviewConfig
 from .layers import (
     ElementWiseFourierEmbed,
-    MHCHandler,
     Magi2GroupedLinear,
+    MHCHandler,
     ModalityDispatcher,
     MultiModalityRMSNorm,
     make_grouped_linear,

--- a/vllm_omni/diffusion/models/magi2/modeling_magi2.py
+++ b/vllm_omni/diffusion/models/magi2/modeling_magi2.py
@@ -262,6 +262,7 @@ class Magi2MultiHeadMoELayer(nn.Module):
             bias=False,
             dtype=config.params_dtype,
             parallel_mode="column",
+            quant_config=config.quant_config,
         )
         self.shared_expert_fc2 = make_grouped_linear(
             moe.shared_expert_intermediate_size,
@@ -269,6 +270,7 @@ class Magi2MultiHeadMoELayer(nn.Module):
             bias=False,
             dtype=config.params_dtype,
             parallel_mode="row",
+            quant_config=config.quant_config,
         )
         self.modality_specific_shared_expert_fc1 = make_grouped_linear(
             config.hidden_size,
@@ -277,6 +279,7 @@ class Magi2MultiHeadMoELayer(nn.Module):
             bias=False,
             dtype=config.params_dtype,
             parallel_mode="column",
+            quant_config=config.quant_config,
         )
         self.modality_specific_shared_expert_fc2 = make_grouped_linear(
             moe.modality_shared_expert_intermediate_size,
@@ -285,6 +288,7 @@ class Magi2MultiHeadMoELayer(nn.Module):
             bias=False,
             dtype=config.params_dtype,
             parallel_mode="row",
+            quant_config=config.quant_config,
         )
         tp_size = self.split_linear.tp_group.world_size
         self.local_shared_expert_intermediate_size = moe.shared_expert_intermediate_size // tp_size
@@ -739,7 +743,7 @@ class Magi2PreviewTransformer(nn.Module):
         if self.config.quant_config is not None:
             for module in self.modules():
                 if isinstance(module, Magi2GroupedLinear):
-                    module.maybe_quantize_int8_()
+                    module.maybe_quantize_()
 
         return loaded
 

--- a/vllm_omni/diffusion/models/magi2/modeling_magi2.py
+++ b/vllm_omni/diffusion/models/magi2/modeling_magi2.py
@@ -28,6 +28,7 @@ from .configuration_magi2 import Magi2PreviewConfig
 from .layers import (
     ElementWiseFourierEmbed,
     MHCHandler,
+    Magi2GroupedLinear,
     ModalityDispatcher,
     MultiModalityRMSNorm,
     make_grouped_linear,
@@ -69,6 +70,7 @@ class Magi2Attention(nn.Module):
             bias=False,
             dtype=config.params_dtype,
             parallel_mode="column",
+            quant_config=config.quant_config,
         )
         self.linear_qkv = make_grouped_linear(
             config.hidden_size,
@@ -78,6 +80,7 @@ class Magi2Attention(nn.Module):
             dtype=config.params_dtype,
             parallel_mode="column",
             qkv_splits=(global_q_size, global_kv_size, global_kv_size),
+            quant_config=config.quant_config,
         )
         self.linear_proj = make_grouped_linear(
             global_q_size,
@@ -86,6 +89,7 @@ class Magi2Attention(nn.Module):
             bias=False,
             dtype=config.params_dtype,
             parallel_mode="row",
+            quant_config=config.quant_config,
         )
         self.tp_group = self.linear_qkv.tp_group
         self.num_heads_q = config.num_heads_q // self.tp_group.world_size
@@ -200,6 +204,7 @@ class Magi2MLP(nn.Module):
             bias=False,
             dtype=config.params_dtype,
             parallel_mode="column",
+            quant_config=config.quant_config,
         )
         self.down_proj = make_grouped_linear(
             intermediate_size,
@@ -208,6 +213,7 @@ class Magi2MLP(nn.Module):
             bias=False,
             dtype=config.params_dtype,
             parallel_mode="row",
+            quant_config=config.quant_config,
         )
 
     def forward(self, hidden_states: torch.Tensor, dispatcher: ModalityDispatcher) -> torch.Tensor:
@@ -729,6 +735,12 @@ class Magi2PreviewTransformer(nn.Module):
         missing = set(targets) - loaded
         if missing:
             raise ValueError(f"MAGI-2 preview checkpoint is missing {len(missing)} weights: {sorted(missing)[:8]}")
+
+        if self.config.quant_config is not None:
+            for module in self.modules():
+                if isinstance(module, Magi2GroupedLinear):
+                    module.maybe_quantize_int8_()
+
         return loaded
 
 

--- a/vllm_omni/diffusion/models/magi2/modeling_magi2.py
+++ b/vllm_omni/diffusion/models/magi2/modeling_magi2.py
@@ -31,6 +31,7 @@ from .layers import (
     MHCHandler,
     ModalityDispatcher,
     MultiModalityRMSNorm,
+    _quant_weight_dtype,
     make_grouped_linear,
     swiglu7,
 )
@@ -622,6 +623,9 @@ class Magi2PreviewTransformer(nn.Module):
         super().__init__()
         self.config = config or Magi2PreviewConfig()
         self.config.validate()
+        # This conversion happens after checkpoint loading. Direct mmap binds
+        # checkpoint tensors straight into DLO and would skip that conversion.
+        self.requires_ordinary_weight_loading = _quant_weight_dtype(self.config.quant_config) is not None
         self.pre_adapter = Magi2PreAdapter(self.config)
         self.post_adapter = Magi2PostAdapter(self.config)
         self.block = Magi2TransformerBlock(self.config)

--- a/vllm_omni/diffusion/models/magi2/pipeline_magi2.py
+++ b/vllm_omni/diffusion/models/magi2/pipeline_magi2.py
@@ -253,8 +253,18 @@ def _validate_native_topology(od_config: OmniDiffusionConfig) -> None:
             unsupported.append(f"{name}={value}")
     if getattr(parallel, "enable_expert_parallel", False):
         unsupported.append("enable_expert_parallel")
-    if od_config.quantization_config is not None:
-        unsupported.append("quantization")
+    quant_config = od_config.quantization_config
+    if quant_config is not None:
+        from .layers import WEIGHT_DTYPE_BY_QUANT_METHOD
+
+        get_name = getattr(quant_config, "get_name", None)
+        method = get_name() if callable(get_name) else None
+        if method not in WEIGHT_DTYPE_BY_QUANT_METHOD:
+            # Anything other than our self-contained weight-only int8/fp8
+            # scheme (see layers.py) assumes vLLM's LinearBase contract,
+            # which Magi2GroupedLinear's custom weight layout/TP sharding
+            # doesn't fit.
+            unsupported.append(f"quantization={method!r}")
     if unsupported:
         raise ValueError(
             "MAGI-2 Preview uses Ulysses sequence parallelism and MoE-head "
@@ -582,9 +592,21 @@ class Magi2Pipeline(
 
         # Importing here keeps config-only model detection light.  The class is
         # an in-tree implementation; there is no dynamic remote-code import.
+        import dataclasses
+
         from .modeling_magi2 import Magi2PreviewTransformer
 
         MAGI2_PREVIEW_CONFIG.validate()
+        preview_config = MAGI2_PREVIEW_CONFIG
+        if od_config.quantization_config is not None:
+            # _validate_native_topology has already rejected any method not
+            # in WEIGHT_DTYPE_BY_QUANT_METHOD, so this is always one of our
+            # self-contained schemes. dataclasses.replace avoids mutating the
+            # module-level singleton shared by every MAGI-2 pipeline instance.
+            preview_config = dataclasses.replace(
+                MAGI2_PREVIEW_CONFIG, quant_config=od_config.quantization_config
+            )
+        self._preview_config = preview_config
         mmap_dlo = bool(
             od_config.enable_distributed_layerwise_offload and getattr(od_config, "dlo_use_allgather", True)
         )
@@ -593,13 +615,13 @@ class Magi2Pipeline(
             # only this rank's orthogonal DP shard.  Constructing the 212-GiB
             # Preview transformer on CPU first would defeat that memory model.
             with torch.device("meta"):
-                self.transformer = Magi2PreviewTransformer(MAGI2_PREVIEW_CONFIG)
+                self.transformer = Magi2PreviewTransformer(preview_config)
             # The mmap path is inference-only. Removing autograd ownership here
             # lets the shared DLO backend shard views without a MAGI-specific
             # detach branch.
             self.transformer.requires_grad_(False)
         else:
-            self.transformer = Magi2PreviewTransformer(MAGI2_PREVIEW_CONFIG)
+            self.transformer = Magi2PreviewTransformer(preview_config)
         self.data_proxy = Magi2DataProxy()
         self.sampler = Magi2PreviewSampler(
             self.transformer,
@@ -617,6 +639,7 @@ class Magi2Pipeline(
                 text_encoder: nn.Module = Magi2Qwen35TextEncoder(
                     str(root / "text_encoder"),
                     dtype=self.dtype,
+                    quant_config=od_config.quantization_config,
                 )
                 from vllm_omni.diffusion.models.lance.wan_vae import LanceWanVAE
 

--- a/vllm_omni/diffusion/models/magi2/pipeline_magi2.py
+++ b/vllm_omni/diffusion/models/magi2/pipeline_magi2.py
@@ -599,9 +599,7 @@ class Magi2Pipeline(
         if od_config.quantization_config is not None:
             # dataclasses.replace avoids mutating the singleton shared by
             # every MAGI-2 pipeline instance.
-            preview_config = dataclasses.replace(
-                MAGI2_PREVIEW_CONFIG, quant_config=od_config.quantization_config
-            )
+            preview_config = dataclasses.replace(MAGI2_PREVIEW_CONFIG, quant_config=od_config.quantization_config)
         self._preview_config = preview_config
         mmap_dlo = bool(
             od_config.enable_distributed_layerwise_offload and getattr(od_config, "dlo_use_allgather", True)

--- a/vllm_omni/diffusion/models/magi2/pipeline_magi2.py
+++ b/vllm_omni/diffusion/models/magi2/pipeline_magi2.py
@@ -260,10 +260,8 @@ def _validate_native_topology(od_config: OmniDiffusionConfig) -> None:
         get_name = getattr(quant_config, "get_name", None)
         method = get_name() if callable(get_name) else None
         if method not in WEIGHT_DTYPE_BY_QUANT_METHOD:
-            # Anything other than our self-contained weight-only int8/fp8
-            # scheme (see layers.py) assumes vLLM's LinearBase contract,
-            # which Magi2GroupedLinear's custom weight layout/TP sharding
-            # doesn't fit.
+            # Anything else assumes vLLM's LinearBase contract, which
+            # Magi2GroupedLinear's custom weight layout doesn't fit.
             unsupported.append(f"quantization={method!r}")
     if unsupported:
         raise ValueError(
@@ -599,10 +597,8 @@ class Magi2Pipeline(
         MAGI2_PREVIEW_CONFIG.validate()
         preview_config = MAGI2_PREVIEW_CONFIG
         if od_config.quantization_config is not None:
-            # _validate_native_topology has already rejected any method not
-            # in WEIGHT_DTYPE_BY_QUANT_METHOD, so this is always one of our
-            # self-contained schemes. dataclasses.replace avoids mutating the
-            # module-level singleton shared by every MAGI-2 pipeline instance.
+            # dataclasses.replace avoids mutating the singleton shared by
+            # every MAGI-2 pipeline instance.
             preview_config = dataclasses.replace(
                 MAGI2_PREVIEW_CONFIG, quant_config=od_config.quantization_config
             )

--- a/vllm_omni/diffusion/models/magi2/pipeline_magi2.py
+++ b/vllm_omni/diffusion/models/magi2/pipeline_magi2.py
@@ -57,6 +57,7 @@ from .configuration_magi2 import (
     MAGI2_GENERATION_CONFIG,
     MAGI2_PREVIEW_CONFIG,
 )
+from .layers import _quant_weight_dtype
 from .parallel import get_magi2_replica_group
 from .preview_data_proxy import Magi2DataProxy
 from .sampler_magi2 import (
@@ -602,7 +603,9 @@ class Magi2Pipeline(
             preview_config = dataclasses.replace(MAGI2_PREVIEW_CONFIG, quant_config=od_config.quantization_config)
         self._preview_config = preview_config
         mmap_dlo = bool(
-            od_config.enable_distributed_layerwise_offload and getattr(od_config, "dlo_use_allgather", True)
+            od_config.enable_distributed_layerwise_offload
+            and getattr(od_config, "dlo_use_allgather", True)
+            and _quant_weight_dtype(od_config.quantization_config) is None
         )
         if mmap_dlo:
             # AllGather DLO binds checkpoint tensors as mmap views and copies


### PR DESCRIPTION
## Summary

Part of the "component-scoped quantization" sub-item of the quantization/memory-efficient-execution workstream in #7085.

Adds weight-only, dynamic, symmetric quantization (INT8 and FP8/e4m3) for MAGI-2's dense attention/MLP linears, shared-expert linears, and the Qwen3.5 text encoder.

`Magi2GroupedLinear` uses a custom flattened `[num_experts*out, in]` weight layout with its own TP sharding hooks, which doesn't fit vLLM's `ColumnParallelLinear`/`RowParallelLinear` contract. So quantization here is self-contained instead of routed through vLLM's `quant_config`/`ComponentQuantizationConfig`: weights are quantized once after checkpoint loading and dequantized on the fly before each matmul, so no calibration data, serialized scales, or actual int8/fp8 GEMM kernel is required for correctness (only for speed).

**In scope:**
- Dense attention/MLP linears (`Magi2Attention`, `Magi2MLP`) — int8/fp8.
- Shared-expert linears (`Magi2MultiHeadMoELayer.shared_expert_fc1/fc2`, `modality_specific_shared_expert_fc1/fc2`) — same scheme.
- Text encoder — a new generic `QuantizedLinear`/`quantize_linear_modules_` path applied to the Qwen3.5 encoder's plain `nn.Linear`s.
- `Magi2Pipeline`'s topology validation, which previously rejected any `quantization_config` outright — it now accepts our supported int8/fp8 methods and threads them into both the transformer and text encoder.

**Explicitly out of scope:**
- The routed-expert gather/SwiGLU7/scatter path (`split_linear`, `moe_mlp`, `merge_linear`) — that's the kernel guozhihao-224 is tuning under M2 in #7085; touching it here would risk colliding with that work.
- NVFP4 — needs a real block-scaled kernel, which this weight-only dequant-before-matmul scheme doesn't provide.
- TP/SP/DLO shard validation, profiling, and throughput/latency benchmarking — those need the real (~212GiB) MAGI-2 checkpoint on multi-GPU hardware and are tracked separately.

## Test plan

- `tests/diffusion/models/magi2/test_quant_config.py`: no-op without a supported quant config, int8/fp8 buffer creation, numerical parity vs bf16 baseline within tolerance (looser for fp8, reflecting e4m3's 3-bit mantissa), config threading into dense and shared-expert layers, and the generic `QuantizedLinear` path.
- `tests/diffusion/models/magi2/test_pipeline_magi2.py`: new tests for the topology-validation gate (accepts int8/fp8, rejects unsupported methods).
- Ran the full `test_quant_config.py` + `test_pipeline_magi2.py` suites on a real GPU (Modal, T4, vLLM v0.28.0 install) — 42 passed, no regressions in existing pipeline tests.
- Not yet validated: full-checkpoint generation quality with quantization enabled, or anything requiring TP/SP > 1.
