### PR TITLE
[Bugfix] Drop the removed diffusion_batch_size kwarg from the stage-init test

### DIFF
--- a/tests/engine/test_parallel_stage_init.py
+++ b/tests/engine/test_parallel_stage_init.py
@@ -85,7 +85,6 @@ def _runtime(parallel_stage_init: bool = False) -> StageRuntime:
         model="dummy",
         config_path="dummy",
         stage_init_timeout=5,
-        diffusion_batch_size=1,
         async_chunk=False,
         parallel_stage_init=parallel_stage_init,
     )


### PR DESCRIPTION
## Purpose

`main` is red. Every test in `tests/engine/test_parallel_stage_init.py` fails with the same error, and it takes the whole `Simple · Engine&Entrypoints Test` Buildkite step down with it:

```
TypeError: StageRuntime.__init__() got an unexpected keyword argument 'diffusion_batch_size'
```

From [build #14688](https://buildkite.com/vllm/vllm-omni/builds/14688), step `pytest -sv tests/entrypoints tests/engine -m 'core_model and cpu'`:

```
FAILED tests/engine/test_parallel_stage_init.py::test_init_group_key_resolves_physical_devices_serial - TypeError: StageRuntime.__init__() got an unexpected keyword argument 'diffusion_batch_size'
FAILED tests/engine/test_parallel_stage_init.py::test_init_group_key_parallel_is_unique_per_replica - TypeError: StageRuntime.__init__() got an unexpected keyword argument 'diffusion_batch_size'
...
FAILED tests/engine/test_parallel_stage_init.py::test_parallel_init_ignores_remote_ray_replicas - TypeError: StageRuntime.__init__() got an unexpected keyword argument 'diffusion_batch_size'
====== 16 failed, 2461 passed, 4 skipped, 73 deselected, 18 warnings in 279.29s (0:04:39) ======
```

Two merged PRs disagree, and git could not see it because they touch disjoint files:

- #6484 (Sep 1) removed `diffusion_batch_size` from `StageRuntime.__init__`, in favour of `max_num_seqs`.
- #5224 (Sep 5, `142151fe`) added `tests/engine/test_parallel_stage_init.py`, whose `_runtime()` helper was written before that removal and still passes `diffusion_batch_size=1`.

Both merged cleanly, so the mismatch only appeared at runtime, on main's own tip.

Nothing replaces the argument, so the helper just has to stop sending it:

- the production call site, `create_stage_runtime`, never passed it;
- `OmniBase.__init__` already rejects it with an actionable `TypeError` pointing at `max_num_seqs`, and `tests/entrypoints/test_omni_base_profiler.py::test_removed_diffusion_batch_size_fails_loudly` guards that behaviour;
- `git grep diffusion_batch_size` shows this test helper is the only remaining caller.

## Test Plan

```bash
# the file that fails
pytest -q tests/engine/test_parallel_stage_init.py

# the full Buildkite step it takes down
pytest -sv tests/entrypoints tests/engine -m 'core_model and cpu'
```

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** `142151fe` (current `main` tip, and the commit that introduced the failure)

## Test Result

`tests/engine/test_parallel_stage_init.py`, same checkout, with and without the change:

| Tree | Result |
| --- | --- |
| `142151fe` (`main`) | `16 failed, 29 passed, 1 skipped` |
| this PR | `45 passed, 1 skipped` |

The 16 failures reproduce locally exactly as on the agent, all on the same `TypeError`.

The full Buildkite step is green with the fix:

```
$ pytest -sv tests/entrypoints tests/engine -m 'core_model and cpu'
====== 2477 passed, 4 skipped, 73 deselected, 20 warnings in 240.26s (0:04:00) ======
```

That accounts for everything the failing build ran: its 2461 passed plus the 16 failed is exactly the 2477 now passing, with the same 4 skipped and 73 deselected.

Environment: Python 3.12, vLLM 0.28.0, PyTorch 2.13.0+cu129, CPU-only markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
