### PR TITLE
[Bugfix] Register CFG companions before parent dispatch

### DIFF
--- a/tests/engine/test_async_omni_engine_input.py
+++ b/tests/engine/test_async_omni_engine_input.py
@@ -10,6 +10,7 @@ from vllm.v1.engine import EngineCoreRequest
 from vllm_omni.distributed.omni_coordinator import ReplicaInfo, ReplicaStatus
 from vllm_omni.engine import OmniEngineCoreRequest
 from vllm_omni.engine.async_omni_engine import AsyncOmniEngine, StageRuntimeInfo
+from vllm_omni.engine.messages import AddCompanionRequestMessage, StageSubmissionMessage
 from vllm_omni.engine.serialization import deserialize_additional_information
 from vllm_omni.engine.stage_pool import StagePool
 from vllm_omni.model_executor.stage_input_processors.bagel import ExpandedPrompt
@@ -587,6 +588,40 @@ def test_cfg_companion_build_returns_messages_without_enqueueing(mocker: MockerF
     assert companions[0].companion_id == "req__cfg_text"
     assert companions[0].parent_id == "req"
     engine.request_queue.sync_q.put.assert_not_called()
+
+
+def test_add_request_announces_cfg_companions_with_parent(mocker: MockerFixture):
+    engine = object.__new__(AsyncOmniEngine)
+    parent = StageSubmissionMessage(
+        type="add_request",
+        request_id="req",
+        prompt=_make_engine_core_request("req"),
+        original_prompt={"prompt": "positive"},
+        output_prompt_text=None,
+        sampling_params_list=[SamplingParams(max_tokens=8)],
+        final_stage_id=1,
+        preprocess_ms=0,
+        request_timestamp=0,
+        enqueue_ts=0,
+    )
+    companion = AddCompanionRequestMessage(
+        companion_id="req__cfg_text",
+        parent_id="req",
+        role="cfg_text",
+        prompt=_make_engine_core_request("req__cfg_text"),
+        companion_prompt_text=None,
+        sampling_params_list=parent.sampling_params_list,
+    )
+    engine.prompt_expand_func = object()
+    engine.request_queue = mocker.Mock()
+    mocker.patch.object(engine, "_build_add_request_message", return_value=parent)
+    mocker.patch.object(engine, "_build_cfg_companions", return_value=[companion])
+
+    engine.add_request("req", {"prompt": "positive"}, final_stage_id=1)
+
+    queued = [call.args[0] for call in engine.request_queue.sync_q.put.call_args_list]
+    assert queued == [parent, companion]
+    assert parent.cfg_companion_ids == {"cfg_text": "req__cfg_text"}
 
 
 def test_cfg_expansion_returning_nothing_is_not_an_error(mocker: MockerFixture):

--- a/tests/engine/test_cfg_companion_lifecycle.py
+++ b/tests/engine/test_cfg_companion_lifecycle.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Deterministic tests for the CFG-companion output lifecycle.
 
 Regression suite for the companion-output race behind the nightly Bagel
@@ -20,7 +20,7 @@ from types import SimpleNamespace
 import pytest
 
 from vllm_omni.engine.cfg_companion_tracker import CfgCompanionTracker
-from vllm_omni.engine.messages import AbortRequestMessage, ErrorMessage
+from vllm_omni.engine.messages import AbortRequestMessage, ErrorMessage, StageSubmissionMessage
 from vllm_omni.engine.orchestrator import Orchestrator
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
@@ -80,8 +80,10 @@ class _FakePool:
 
     def __init__(self, stage_type: str = "diffusion") -> None:
         self.stage_type = stage_type
+        self.final_output = False
         self.stage_client = SimpleNamespace(requires_multimodal_data=False, custom_process_input_func=None)
         self.aborted: list[list[str]] = []
+        self.submitted: list[str] = []
 
     def live_replica_ids(self) -> list[int]:
         # Single always-live replica: these tests cover CFG bundling, not
@@ -90,6 +92,10 @@ class _FakePool:
 
     async def abort_requests(self, request_ids):
         self.aborted.append(list(request_ids))
+
+    async def submit_initial(self, request_id, *_args, **_kwargs):
+        self.submitted.append(request_id)
+        return 0
 
     def release_bindings(self, request_ids):
         pass
@@ -119,7 +125,38 @@ def _req_state(final_stage_id: int = 1) -> SimpleNamespace:
         running_counter_registered=False,
         prompt={"prompt": "x"},
         pipeline_timings={},
+        duplex_identity=None,
     )
+
+
+@pytest.mark.asyncio
+async def test_parent_output_before_companion_message_is_not_forwarded(mocker):
+    """A queued CFG companion must block its parent even when the parent
+    finishes before the companion message is handled."""
+    orch = _make_orchestrator()
+    await orch._handle_add_request(
+        StageSubmissionMessage(
+            type="add_request",
+            request_id="p",
+            prompt=mocker.Mock(resumable=False, mm_features=None),
+            original_prompt={"prompt": "x"},
+            output_prompt_text=None,
+            sampling_params_list=[object(), object()],
+            final_stage_id=1,
+            preprocess_ms=0,
+            request_timestamp=0,
+            enqueue_ts=0,
+            cfg_companion_ids={"neg": "p__neg"},
+        )
+    )
+    state = orch.request_states["p"]
+    assert orch.stage_pools[0].submitted == ["p"]
+
+    forward = mocker.patch.object(orch, "_forward_to_next_stage", new=mocker.AsyncMock())
+    output = mocker.Mock(request_id="p", finished=True, kv_transfer_params=None)
+    await orch._route_output(0, 0, output, state, None)
+
+    forward.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1474,6 +1474,7 @@ class AsyncOmniEngine:
                         request_id, msg.original_prompt, stage0_params, effective_spl
                     )
 
+            msg.cfg_companion_ids = {companion.role: companion.companion_id for companion in companions} or None
             self.request_queue.sync_q.put(msg)
         except BaseException:
             for artifact_dir in msg.request_artifact_dirs or ():

--- a/vllm_omni/engine/messages.py
+++ b/vllm_omni/engine/messages.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 from __future__ import annotations
 
 from typing import Literal
@@ -28,6 +31,7 @@ class StageSubmissionMessage(EngineQueueMessage, kw_only=True):
     enqueue_ts: float
     final_output_stage_ids: list[int] | None = None
     request_artifact_dirs: list[str] | None = None
+    cfg_companion_ids: dict[str, str] | None = None
 
 
 class AddCompanionRequestMessage(EngineQueueMessage, kw_only=True):

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -774,6 +774,8 @@ class Orchestrator:
         )
         self.request_states[request_id] = req_state
         self._register_running_request(req_state)
+        for role, companion_id in (msg.cfg_companion_ids or {}).items():
+            self._cfg_tracker.register_companion(request_id, role, companion_id)
         req_state.streaming.enabled = bool(getattr(prompt, "resumable", False))
         req_state.stage_submit_ts[stage_id] = _time.time()
         enqueue_ts = msg.enqueue_ts


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

Fixes #7103.

### What broke

`AsyncOmniEngine.add_request()` enqueues the parent before its CFG companion messages. Because `_handle_add_request()` awaits stage-0 submission while output routing runs in a separate task, a fast parent can finish before `_handle_add_companion()` registers the queued companions. The tracker then reports no companions and the parent is forwarded without the required CFG bundle.

### Reproduction

The new deterministic L1 test admits a parent whose companion message has not yet been handled, completes the parent, and checks whether `_forward_to_next_stage()` runs. Before the production fix it fails because the parent is forwarded; after the fix it is deferred.

```bash
pytest -o addopts='' --confcutdir=tests/engine -q \
  tests/engine/test_cfg_companion_lifecycle.py::test_parent_output_before_companion_message_is_not_forwarded
```

### Root cause

Companion membership was registered only while consuming each `AddCompanionRequestMessage`. Queue FIFO did not protect this state because parent submission yields to the independent output task.

### Fix

- add the expected `{role: companion_id}` mapping to the parent submission message;
- populate it after all companions are built and before the parent is enqueued;
- register those companions before submitting the parent to stage 0.

The later registration in `_handle_add_companion()` remains idempotent and preserves compatibility with producers that do not announce companions.

## Test Plan

L1 CPU regression coverage; no GPU or model weights are required.

```bash
pytest -o addopts='' --confcutdir=tests/engine -q \
  tests/engine/test_orchestrator.py \
  tests/engine/test_cfg_companion_lifecycle.py \
  tests/engine/test_async_omni_engine_input.py
```

**vLLM Version:** 0.28.0+cpu (`VLLM_TARGET_DEVICE=empty`)

**vLLM-Omni Commit:** c9c8b6a6d6c59a487c256c04051ea54c66d2af48

## Test Result

- `96 passed in 5.54s`
- Ruff check and format: passed
- `git diff --check`: passed
- pre-commit: all applicable hooks passed except `mypy-3.10`; that hook reports 33 existing module-level baseline errors in the touched engine files, with no error on an added line.
