### PR TITLE
[Diffusion] MAGI-2: reuse packing metadata across denoising steps

### DIFF
--- a/tests/diffusion/models/magi2/test_native_compile.py
+++ b/tests/diffusion/models/magi2/test_native_compile.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.models.magi2.sampler_magi2 import CFGConfig, Magi2PreviewSampler
+
+pytestmark = [pytest.mark.diffusion, pytest.mark.cpu, pytest.mark.core_model]
+
+
+def _sampler_tensors() -> dict[str, torch.Tensor]:
+    return {
+        "latent": torch.randn(1, 4, 2, 1, 3),
+        "audio_latent": torch.randn(1, 5, 4),
+        "txt_feat": torch.randn(1, 3, 4),
+        "null_txt_feat": torch.randn(1, 2, 4),
+    }
+
+
+def test_prepare_model_input_keeps_lengths_on_host() -> None:
+    sampler = Magi2PreviewSampler(torch.nn.Identity())
+    model_input = sampler.prepare_model_input(**_sampler_tensors(), t=torch.tensor([500.0]), cfg_config=CFGConfig())
+
+    assert model_input.audio_feat_len == [5, 5]
+    assert model_input.txt_feat_len == [3, 2]
+    assert model_input.ref_audio_feat_len == [0, 0]
+    assert model_input.ref_video_feat_len == [0, 0]
+
+    positive, negative = Magi2PreviewSampler._split_cfg_model_input(model_input)
+    assert positive.txt_feat_len == [3]
+    assert negative.txt_feat_len == [2]

--- a/tests/diffusion/models/magi2/test_native_compile.py
+++ b/tests/diffusion/models/magi2/test_native_compile.py
@@ -6,23 +6,83 @@ from __future__ import annotations
 import pytest
 import torch
 
+import vllm_omni.diffusion.models.magi2.layers as layers_module
+from vllm_omni.diffusion.models.magi2.configuration_magi2 import (
+    Magi2MHCConfig,
+    Magi2MoEConfig,
+    Magi2PreviewConfig,
+)
+from vllm_omni.diffusion.models.magi2.layers import MultiModalityRMSNorm
+from vllm_omni.diffusion.models.magi2.mh_moe import Magi2MultiHeadMoE
+from vllm_omni.diffusion.models.magi2.modeling_magi2 import Magi2PreviewTransformer
+from vllm_omni.diffusion.models.magi2.preview_data_proxy import (
+    Magi2DataProxy,
+    Magi2PackedLayout,
+    Magi2PreviewDataProxyConfig,
+)
 from vllm_omni.diffusion.models.magi2.sampler_magi2 import CFGConfig, Magi2PreviewSampler
 
 pytestmark = [pytest.mark.diffusion, pytest.mark.cpu, pytest.mark.core_model]
 
 
-def _sampler_tensors() -> dict[str, torch.Tensor]:
+def _tiny_config(params_dtype: torch.dtype = torch.float32) -> Magi2PreviewConfig:
+    # Layer 0 is multimodal with MoE, layer 1 is single-modality dense.
+    return Magi2PreviewConfig(
+        num_layers=2,
+        hidden_size=16,
+        head_dim=8,
+        num_query_groups=2,
+        video_in_channels=4,
+        audio_in_channels=4,
+        text_in_channels=4,
+        intermediate_factor=2,
+        multimodal_layers=(0,),
+        params_dtype=params_dtype,
+        mhc=Magi2MHCConfig(num_streams=2),
+        moe=Magi2MoEConfig(
+            num_heads=2,
+            num_experts=4,
+            top_k=2,
+            expert_intermediate_size=8,
+            shared_expert_intermediate_size=8,
+            modality_shared_expert_intermediate_size=8,
+            layers=(0,),
+        ),
+    )
+
+
+def _tiny_model(seed: int = 11, params_dtype: torch.dtype = torch.float32) -> Magi2PreviewTransformer:
+    model = Magi2PreviewTransformer(_tiny_config(params_dtype))
+    generator = torch.Generator(device="cpu").manual_seed(seed)
+    with torch.no_grad():
+        for parameter in model.parameters():
+            parameter.copy_(torch.randn(parameter.shape, generator=generator, dtype=parameter.dtype) * 0.02)
+        for module in model.modules():
+            if isinstance(module, MultiModalityRMSNorm):
+                module.weight.zero_()
+            elif isinstance(module, Magi2MultiHeadMoE):
+                module.router.expert_bias.zero_()
+                module.router.expert_bias_ema.zero_()
+    return model
+
+
+def _tiny_sampler(model: torch.nn.Module) -> Magi2PreviewSampler:
+    return Magi2PreviewSampler(model, Magi2DataProxy(Magi2PreviewDataProxyConfig(time_channel_dim=8)))
+
+
+def _sampler_tensors(seed: int) -> dict[str, torch.Tensor]:
+    generator = torch.Generator(device="cpu").manual_seed(seed)
     return {
-        "latent": torch.randn(1, 4, 2, 1, 3),
-        "audio_latent": torch.randn(1, 5, 4),
-        "txt_feat": torch.randn(1, 3, 4),
-        "null_txt_feat": torch.randn(1, 2, 4),
+        "latent": torch.randn(1, 4, 2, 1, 3, generator=generator),
+        "audio_latent": torch.randn(1, 5, 4, generator=generator),
+        "txt_feat": torch.randn(1, 3, 4, generator=generator),
+        "null_txt_feat": torch.randn(1, 2, 4, generator=generator),
     }
 
 
 def test_prepare_model_input_keeps_lengths_on_host() -> None:
     sampler = Magi2PreviewSampler(torch.nn.Identity())
-    model_input = sampler.prepare_model_input(**_sampler_tensors(), t=torch.tensor([500.0]), cfg_config=CFGConfig())
+    model_input = sampler.prepare_model_input(**_sampler_tensors(0), t=torch.tensor([500.0]), cfg_config=CFGConfig())
 
     assert model_input.audio_feat_len == [5, 5]
     assert model_input.txt_feat_len == [3, 2]
@@ -32,3 +92,81 @@ def test_prepare_model_input_keeps_lengths_on_host() -> None:
     positive, negative = Magi2PreviewSampler._split_cfg_model_input(model_input)
     assert positive.txt_feat_len == [3]
     assert negative.txt_feat_len == [2]
+
+
+def test_shared_layout_matches_fresh_packing_bitwise() -> None:
+    sampler = _tiny_sampler(_tiny_model())
+    layout = Magi2PackedLayout()
+    timesteps = (torch.tensor([900.0]), torch.tensor([450.0]))
+
+    with torch.no_grad():
+        reused = [
+            sampler.forward(
+                sampler.prepare_model_input(**_sampler_tensors(seed), t=t, cfg_config=CFGConfig(), layout=layout)
+            )
+            for seed, t in enumerate(timesteps)
+        ]
+        fresh = [
+            sampler.forward(sampler.prepare_model_input(**_sampler_tensors(seed), t=t, cfg_config=CFGConfig()))
+            for seed, t in enumerate(timesteps)
+        ]
+
+    for (video_a, audio_a), (video_b, audio_b) in zip(reused, fresh, strict=True):
+        assert torch.equal(video_a, video_b)
+        assert torch.equal(audio_a, audio_b)
+    assert not torch.equal(reused[0][0], reused[1][0])
+
+
+def test_shared_layout_builds_token_metadata_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    sampler = _tiny_sampler(_tiny_model())
+    layout = Magi2PackedLayout()
+    counts = {"nonzero": 0, "dispatcher": 0, "rope": 0}
+
+    real_nonzero = torch.nonzero
+    real_dispatcher_init = layers_module.ModalityDispatcher.__init__
+    real_rope_forward = layers_module.ElementWiseFourierEmbed.forward
+
+    def counting_nonzero(*args, **kwargs):
+        counts["nonzero"] += 1
+        return real_nonzero(*args, **kwargs)
+
+    def counting_dispatcher_init(self, *args, **kwargs):
+        counts["dispatcher"] += 1
+        real_dispatcher_init(self, *args, **kwargs)
+
+    def counting_rope_forward(self, *args, **kwargs):
+        counts["rope"] += 1
+        return real_rope_forward(self, *args, **kwargs)
+
+    monkeypatch.setattr(torch, "nonzero", counting_nonzero)
+    monkeypatch.setattr(layers_module.ModalityDispatcher, "__init__", counting_dispatcher_init)
+    monkeypatch.setattr(layers_module.ElementWiseFourierEmbed, "forward", counting_rope_forward)
+
+    with torch.no_grad():
+        sampler.forward(
+            sampler.prepare_model_input(
+                **_sampler_tensors(0), t=torch.tensor([900.0]), cfg_config=CFGConfig(), layout=layout
+            )
+        )
+        first_step = dict(counts)
+        sampler.forward(
+            sampler.prepare_model_input(
+                **_sampler_tensors(1), t=torch.tensor([450.0]), cfg_config=CFGConfig(), layout=layout
+            )
+        )
+
+    assert first_step == {"nonzero": 3, "dispatcher": 1, "rope": 1}
+    assert counts == first_step
+    assert layout.sequence is not None
+    assert layout.tokens is not None
+
+
+def test_cfg_branches_carry_their_own_layout() -> None:
+    sampler = Magi2PreviewSampler(torch.nn.Identity())
+    layouts = (Magi2PackedLayout(), Magi2PackedLayout())
+    model_input = sampler.prepare_model_input(**_sampler_tensors(0), t=torch.tensor([500.0]), cfg_config=CFGConfig())
+
+    positive, negative = Magi2PreviewSampler._split_cfg_model_input(model_input, layouts)
+
+    assert positive.layout is layouts[0]
+    assert negative.layout is layouts[1]

--- a/tests/diffusion/models/magi2/test_native_compile.py
+++ b/tests/diffusion/models/magi2/test_native_compile.py
@@ -170,3 +170,15 @@ def test_cfg_branches_carry_their_own_layout() -> None:
 
     assert positive.layout is layouts[0]
     assert negative.layout is layouts[1]
+
+
+def test_pre_adapter_embeds_directly_in_checkpoint_dtype() -> None:
+    model = _tiny_model(params_dtype=torch.bfloat16)
+    packed = torch.randn(6, 4)
+    indices = torch.tensor([0, 1]), torch.tensor([2, 3]), torch.tensor([4, 5])
+
+    with torch.no_grad():
+        hidden = model.pre_adapter(packed, *indices)
+
+    assert hidden.dtype == torch.bfloat16
+    assert hidden.shape == (6, model.config.virtual_width)

--- a/tests/diffusion/models/magi2/test_native_packing.py
+++ b/tests/diffusion/models/magi2/test_native_packing.py
@@ -25,10 +25,12 @@ from vllm_omni.diffusion.models.magi2.sampler_magi2 import CFGConfig, Magi2Previ
 pytestmark = [pytest.mark.diffusion, pytest.mark.cpu, pytest.mark.core_model]
 
 
-def _tiny_config(params_dtype: torch.dtype = torch.float32) -> Magi2PreviewConfig:
-    # Layer 0 is multimodal with MoE, layer 1 is single-modality dense.
+def _tiny_config(params_dtype: torch.dtype = torch.float32, *, moe_layers: int = 1) -> Magi2PreviewConfig:
+    # The leading layers are multimodal with MoE, the rest single-modality
+    # dense, so every layer belongs to one of two kinds.
+    moe_indices = tuple(range(moe_layers))
     return Magi2PreviewConfig(
-        num_layers=2,
+        num_layers=2 * moe_layers,
         hidden_size=16,
         head_dim=8,
         num_query_groups=2,
@@ -36,7 +38,7 @@ def _tiny_config(params_dtype: torch.dtype = torch.float32) -> Magi2PreviewConfi
         audio_in_channels=4,
         text_in_channels=4,
         intermediate_factor=2,
-        multimodal_layers=(0,),
+        multimodal_layers=moe_indices,
         params_dtype=params_dtype,
         mhc=Magi2MHCConfig(num_streams=2),
         moe=Magi2MoEConfig(
@@ -46,13 +48,18 @@ def _tiny_config(params_dtype: torch.dtype = torch.float32) -> Magi2PreviewConfi
             expert_intermediate_size=8,
             shared_expert_intermediate_size=8,
             modality_shared_expert_intermediate_size=8,
-            layers=(0,),
+            layers=moe_indices,
         ),
     )
 
 
-def _tiny_model(seed: int = 11, params_dtype: torch.dtype = torch.float32) -> Magi2PreviewTransformer:
-    model = Magi2PreviewTransformer(_tiny_config(params_dtype))
+def _tiny_model(
+    seed: int = 11,
+    params_dtype: torch.dtype = torch.float32,
+    *,
+    moe_layers: int = 1,
+) -> Magi2PreviewTransformer:
+    model = Magi2PreviewTransformer(_tiny_config(params_dtype, moe_layers=moe_layers))
     generator = torch.Generator(device="cpu").manual_seed(seed)
     with torch.no_grad():
         for parameter in model.parameters():
@@ -78,6 +85,13 @@ def _sampler_tensors(seed: int) -> dict[str, torch.Tensor]:
         "txt_feat": torch.randn(1, 3, 4, generator=generator),
         "null_txt_feat": torch.randn(1, 2, 4, generator=generator),
     }
+
+
+def _longer_text_tensors(seed: int) -> dict[str, torch.Tensor]:
+    tensors = _sampler_tensors(seed)
+    generator = torch.Generator(device="cpu").manual_seed(seed + 100)
+    tensors["txt_feat"] = torch.randn(1, 4, 4, generator=generator)
+    return tensors
 
 
 def test_prepare_model_input_keeps_lengths_on_host() -> None:
@@ -115,6 +129,29 @@ def test_shared_layout_matches_fresh_packing_bitwise() -> None:
         assert torch.equal(video_a, video_b)
         assert torch.equal(audio_a, audio_b)
     assert not torch.equal(reused[0][0], reused[1][0])
+
+
+def test_new_request_layouts_match_fresh_packing_bitwise() -> None:
+    sampler = _tiny_sampler(_tiny_model())
+    t = torch.tensor([900.0])
+    requests = [
+        (_sampler_tensors(0), Magi2PackedLayout()),
+        (_sampler_tensors(1), Magi2PackedLayout()),
+        (_longer_text_tensors(2), Magi2PackedLayout()),
+    ]
+
+    with torch.no_grad():
+        for tensors, layout in requests:
+            fresh = sampler.forward(sampler.prepare_model_input(**tensors, t=t, cfg_config=CFGConfig()))
+            first = sampler.forward(sampler.prepare_model_input(**tensors, t=t, cfg_config=CFGConfig(), layout=layout))
+            second = sampler.forward(
+                sampler.prepare_model_input(**tensors, t=t / 2, cfg_config=CFGConfig(), layout=layout)
+            )
+            assert torch.equal(first[0], fresh[0])
+            assert torch.equal(first[1], fresh[1])
+            assert layout.tokens is not None
+            assert not torch.equal(second[0], first[0])
+    assert requests[2][1].tokens.rope.shape[0] != requests[0][1].tokens.rope.shape[0]
 
 
 def test_shared_layout_builds_token_metadata_once(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/vllm_omni/diffusion/models/magi2/modeling_magi2.py
+++ b/vllm_omni/diffusion/models/magi2/modeling_magi2.py
@@ -344,30 +344,23 @@ class Magi2PreAdapter(nn.Module):
         audio_indices: torch.Tensor,
         text_indices: torch.Tensor,
     ) -> torch.Tensor:
-        output = torch.zeros(
+        # Every token belongs to exactly one modality, so the three copies
+        # below cover the whole buffer.  Embedding in fp32 and rounding each
+        # modality once matches the released cast at the block boundary.
+        output = torch.empty(
             packed.shape[0],
             self.adapter_dim,
-            dtype=torch.float32,
+            dtype=self.config.params_dtype,
             device=packed.device,
         )
-        if text_indices.numel():
-            output.index_copy_(
-                0,
-                text_indices,
-                self.text_embedder(packed.index_select(0, text_indices)[:, : self.config.text_in_channels].float()),
-            )
-        if audio_indices.numel():
-            output.index_copy_(
-                0,
-                audio_indices,
-                self.audio_embedder(packed.index_select(0, audio_indices)[:, : self.config.audio_in_channels].float()),
-            )
-        if video_indices.numel():
-            output.index_copy_(
-                0,
-                video_indices,
-                self.video_embedder(packed.index_select(0, video_indices)[:, : self.config.video_in_channels].float()),
-            )
+        for indices, embedder, in_channels in (
+            (text_indices, self.text_embedder, self.config.text_in_channels),
+            (audio_indices, self.audio_embedder, self.config.audio_in_channels),
+            (video_indices, self.video_embedder, self.config.video_in_channels),
+        ):
+            if indices.numel():
+                tokens = packed[:, :in_channels].index_select(0, indices).float()
+                output.index_copy_(0, indices, embedder(tokens).to(output.dtype))
         return output
 
 

--- a/vllm_omni/diffusion/models/magi2/modeling_magi2.py
+++ b/vllm_omni/diffusion/models/magi2/modeling_magi2.py
@@ -35,6 +35,7 @@ from .layers import (
 )
 from .mh_moe import Magi2MultiHeadMoE, Magi2MultiHeadMoEConfig
 from .parallel import Magi2SequenceDispatcher
+from .preview_data_proxy import Magi2PackedLayout
 
 
 class Modality(IntEnum):
@@ -339,12 +340,10 @@ class Magi2PreAdapter(nn.Module):
     def forward(
         self,
         packed: torch.Tensor,
-        coords_mapping: torch.Tensor,
         video_indices: torch.Tensor,
         audio_indices: torch.Tensor,
         text_indices: torch.Tensor,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        rope = self.rope(coords_mapping)
+    ) -> torch.Tensor:
         output = torch.zeros(
             packed.shape[0],
             self.adapter_dim,
@@ -369,7 +368,7 @@ class Magi2PreAdapter(nn.Module):
                 video_indices,
                 self.video_embedder(packed.index_select(0, video_indices)[:, : self.config.video_in_channels].float()),
             )
-        return output, rope
+        return output
 
 
 class Magi2PostAdapter(nn.Module):
@@ -637,40 +636,39 @@ class Magi2PreviewTransformer(nn.Module):
         modality_mapping: torch.Tensor,
         varlen_handler: VarlenHandler,
         time_token_sequence: torch.Tensor | None = None,
+        layout: Magi2PackedLayout | None = None,
     ) -> torch.Tensor:
         dispatcher = Magi2SequenceDispatcher()
         x = dispatcher.dispatch(x)
-        coords_mapping = dispatcher.dispatch(coords_mapping)
-        modality_mapping = dispatcher.dispatch(modality_mapping)
         if time_token_sequence is not None:
             time_token_sequence = dispatcher.dispatch(time_token_sequence)
+        if layout is None:
+            layout = Magi2PackedLayout()
+        tokens = layout.tokens
+        if tokens is None:
+            tokens = layout.resolve_tokens(
+                dispatcher.dispatch(modality_mapping),
+                self.pre_adapter.rope(dispatcher.dispatch(coords_mapping)),
+            )
         assert dispatcher.split_sizes is not None
         cp_split_sizes = dispatcher.split_sizes
 
-        time_mask = modality_mapping == int(Modality.TIME)
-        modality_mapping = torch.where(time_mask, int(Modality.TEXT), modality_mapping)
-        modality_dispatcher = ModalityDispatcher(modality_mapping, 3)
-        video_indices = torch.nonzero(modality_mapping == int(Modality.VIDEO)).flatten()
-        audio_indices = torch.nonzero(modality_mapping == int(Modality.AUDIO)).flatten()
-        text_indices = torch.nonzero(modality_mapping == int(Modality.TEXT)).flatten()
-
-        hidden_states, rope = self.pre_adapter(
+        hidden_states = self.pre_adapter(
             x,
-            coords_mapping,
-            video_indices,
-            audio_indices,
-            text_indices,
+            tokens.video_indices,
+            tokens.audio_indices,
+            tokens.text_indices,
         )
         if time_token_sequence is not None and time_token_sequence.shape[-1] > 0:
             hidden_states[:, : time_token_sequence.shape[-1]] = time_token_sequence.to(hidden_states.dtype)
         hidden_states = self.block(
             hidden_states,
-            rope,
+            tokens.rope,
             varlen_handler,
-            modality_dispatcher,
+            tokens.dispatcher,
             cp_split_sizes,
         )
-        output = self.post_adapter(hidden_states, video_indices, audio_indices)
+        output = self.post_adapter(hidden_states, tokens.video_indices, tokens.audio_indices)
         return dispatcher.undispatch(output)
 
     def _moe_for_weight(self, name: str) -> Magi2MultiHeadMoE | None:

--- a/vllm_omni/diffusion/models/magi2/preview_data_proxy.py
+++ b/vllm_omni/diffusion/models/magi2/preview_data_proxy.py
@@ -28,6 +28,7 @@ from einops import rearrange
 from torch.nn import functional as F
 
 from .attention import VarlenHandler
+from .layers import ModalityDispatcher
 
 
 class Modality(IntEnum):
@@ -62,6 +63,51 @@ class Magi2PreviewDataProxyConfig:
             raise ValueError("time_channel_dim must be non-negative")
 
 
+@dataclass(frozen=True)
+class Magi2SequenceLayout:
+    """Packed-sequence metadata built by the proxy once per request."""
+
+    coords_mapping: torch.Tensor
+    modality_mapping: torch.Tensor
+    varlen_handler: VarlenHandler
+
+
+@dataclass(frozen=True)
+class Magi2TokenLayout:
+    """Rank-local modality metadata built by the transformer once per request."""
+
+    dispatcher: ModalityDispatcher
+    video_indices: torch.Tensor
+    audio_indices: torch.Tensor
+    text_indices: torch.Tensor
+    rope: torch.Tensor
+
+
+@dataclass
+class Magi2PackedLayout:
+    """Request-scoped packing metadata shared by every denoising step.
+
+    Token layout is fixed for the lifetime of a request, so the sequence part
+    is filled on the first proxy call and the token part on the first
+    transformer forward, after sequence-parallel dispatch.
+    """
+
+    sequence: Magi2SequenceLayout | None = None
+    tokens: Magi2TokenLayout | None = None
+
+    def resolve_tokens(self, modality_mapping: torch.Tensor, rope: torch.Tensor) -> Magi2TokenLayout:
+        time_mask = modality_mapping == int(Modality.TIME)
+        modality_mapping = torch.where(time_mask, int(Modality.TEXT), modality_mapping)
+        self.tokens = Magi2TokenLayout(
+            dispatcher=ModalityDispatcher(modality_mapping, 3),
+            video_indices=torch.nonzero(modality_mapping == int(Modality.VIDEO)).flatten(),
+            audio_indices=torch.nonzero(modality_mapping == int(Modality.AUDIO)).flatten(),
+            text_indices=torch.nonzero(modality_mapping == int(Modality.TEXT)).flatten(),
+            rope=rope,
+        )
+        return self.tokens
+
+
 @dataclass
 class ModelInput:
     """Unpacked tensors for one native preview-transformer invocation."""
@@ -83,6 +129,7 @@ class ModelInput:
     ref_image_feat: torch.Tensor | None = None
     ref_image_feat_len: torch.Tensor | None = None
     ref_image_special_token_embedding: torch.Tensor | None = None
+    layout: Magi2PackedLayout | None = None
 
 
 def _to_int(value: int | torch.Tensor) -> int:
@@ -521,20 +568,22 @@ class PackedModelInput:
     """Request-owned packed transformer arguments and output layout."""
 
     token_sequence: torch.Tensor
-    coords_mapping: torch.Tensor
-    modality_mapping: torch.Tensor
-    varlen_handler: VarlenHandler
     time_token_sequence: torch.Tensor
     output_layout: SimplePackedData
+    sequence: Magi2SequenceLayout
+    layout: Magi2PackedLayout
 
     @property
-    def model_args(self) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, VarlenHandler, torch.Tensor]:
+    def model_args(
+        self,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, VarlenHandler, torch.Tensor, Magi2PackedLayout]:
         return (
             self.token_sequence,
-            self.coords_mapping,
-            self.modality_mapping,
-            self.varlen_handler,
+            self.sequence.coords_mapping,
+            self.sequence.modality_mapping,
+            self.sequence.varlen_handler,
             self.time_token_sequence,
+            self.layout,
         )
 
 
@@ -653,20 +702,27 @@ class Magi2DataProxy:
             )
 
         packed = SimplePackedData(items)
-        cu_seqlens = packed.cu_seqlen.to(device=data.x_t.device, dtype=torch.int32)
-        varlen_handler = VarlenHandler(
-            cu_seqlens_q=cu_seqlens,
-            cu_seqlens_k=cu_seqlens,
-            max_seqlen_q=packed.max_seqlen,
-            max_seqlen_k=packed.max_seqlen,
-        )
+        layout = data.layout if data.layout is not None else Magi2PackedLayout()
+        sequence = layout.sequence
+        if sequence is None:
+            cu_seqlens = packed.cu_seqlen.to(device=data.x_t.device, dtype=torch.int32)
+            sequence = Magi2SequenceLayout(
+                coords_mapping=packed.coords_mapping,
+                modality_mapping=packed.modality_mapping,
+                varlen_handler=VarlenHandler(
+                    cu_seqlens_q=cu_seqlens,
+                    cu_seqlens_k=cu_seqlens,
+                    max_seqlen_q=packed.max_seqlen,
+                    max_seqlen_k=packed.max_seqlen,
+                ),
+            )
+            layout.sequence = sequence
         return PackedModelInput(
             token_sequence=packed.token_sequence,
-            coords_mapping=packed.coords_mapping,
-            modality_mapping=packed.modality_mapping,
-            varlen_handler=varlen_handler,
             time_token_sequence=packed.time_token_sequence,
             output_layout=packed,
+            sequence=sequence,
+            layout=layout,
         )
 
     @staticmethod
@@ -679,7 +735,10 @@ class Magi2DataProxy:
 
 __all__ = [
     "Magi2DataProxy",
+    "Magi2PackedLayout",
     "Magi2PreviewDataProxyConfig",
+    "Magi2SequenceLayout",
+    "Magi2TokenLayout",
     "Modality",
     "ModelInput",
     "PackedModelInput",

--- a/vllm_omni/diffusion/models/magi2/preview_data_proxy.py
+++ b/vllm_omni/diffusion/models/magi2/preview_data_proxy.py
@@ -570,18 +570,19 @@ class PackedModelInput:
     token_sequence: torch.Tensor
     time_token_sequence: torch.Tensor
     output_layout: SimplePackedData
-    sequence: Magi2SequenceLayout
     layout: Magi2PackedLayout
 
     @property
     def model_args(
         self,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, VarlenHandler, torch.Tensor, Magi2PackedLayout]:
+        sequence = self.layout.sequence
+        assert sequence is not None
         return (
             self.token_sequence,
-            self.sequence.coords_mapping,
-            self.sequence.modality_mapping,
-            self.sequence.varlen_handler,
+            sequence.coords_mapping,
+            sequence.modality_mapping,
+            sequence.varlen_handler,
             self.time_token_sequence,
             self.layout,
         )
@@ -703,10 +704,9 @@ class Magi2DataProxy:
 
         packed = SimplePackedData(items)
         layout = data.layout if data.layout is not None else Magi2PackedLayout()
-        sequence = layout.sequence
-        if sequence is None:
+        if layout.sequence is None:
             cu_seqlens = packed.cu_seqlen.to(device=data.x_t.device, dtype=torch.int32)
-            sequence = Magi2SequenceLayout(
+            layout.sequence = Magi2SequenceLayout(
                 coords_mapping=packed.coords_mapping,
                 modality_mapping=packed.modality_mapping,
                 varlen_handler=VarlenHandler(
@@ -716,12 +716,10 @@ class Magi2DataProxy:
                     max_seqlen_k=packed.max_seqlen,
                 ),
             )
-            layout.sequence = sequence
         return PackedModelInput(
             token_sequence=packed.token_sequence,
             time_token_sequence=packed.time_token_sequence,
             output_layout=packed,
-            sequence=sequence,
             layout=layout,
         )
 

--- a/vllm_omni/diffusion/models/magi2/sampler_magi2.py
+++ b/vllm_omni/diffusion/models/magi2/sampler_magi2.py
@@ -25,7 +25,7 @@ from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.parallel_state import get_classifier_free_guidance_world_size
 from vllm_omni.diffusion.models.schedulers import FlowUniPCMultistepScheduler
 
-from .preview_data_proxy import Magi2DataProxy, ModelInput
+from .preview_data_proxy import Magi2DataProxy, Magi2PackedLayout, ModelInput
 
 
 def _pad_or_trim(
@@ -167,6 +167,9 @@ class Magi2PreviewSampler(CFGParallelMixin):
         )
         latent = sampler_input.latent.clone()
         audio_latent = sampler_input.audio_latent.clone()
+        cfg_parallel = get_classifier_free_guidance_world_size() > 1
+        layout = Magi2PackedLayout()
+        branch_layouts = (Magi2PackedLayout(), Magi2PackedLayout())
 
         for timestep, video_cfg, audio_cfg in zip(
             video_timesteps,
@@ -186,9 +189,10 @@ class Magi2PreviewSampler(CFGParallelMixin):
                 ref_image_special_token_embedding=(sampler_input.ref_image_special_token_embedding),
                 t=timestep,
                 cfg_config=sampler_input.cfg_config,
+                layout=None if cfg_parallel else layout,
             )
-            if get_classifier_free_guidance_world_size() > 1:
-                positive_input, negative_input = self._split_cfg_model_input(model_input)
+            if cfg_parallel:
+                positive_input, negative_input = self._split_cfg_model_input(model_input, branch_layouts)
                 guided = self.predict_noise_maybe_with_cfg(
                     do_true_cfg=True,
                     true_cfg_scale=1.0,
@@ -257,6 +261,7 @@ class Magi2PreviewSampler(CFGParallelMixin):
         ref_image_special_token_embedding: torch.Tensor | None = None,
         t: torch.Tensor | float | None = None,
         cfg_config: CFGConfig | None = None,
+        layout: Magi2PackedLayout | None = None,
     ) -> ModelInput:
         self._validate_prepare_inputs(latent, audio_latent, txt_feat, null_txt_feat)
         batch_size = latent.shape[0]
@@ -330,10 +335,14 @@ class Magi2PreviewSampler(CFGParallelMixin):
             ref_image_feat=ref_image_feat_cfg,
             ref_image_feat_len=ref_image_feat_len_cfg,
             ref_image_special_token_embedding=ref_image_special_tokens_cfg,
+            layout=layout,
         )
 
     @staticmethod
-    def _split_cfg_model_input(model_input: ModelInput) -> tuple[ModelInput, ModelInput]:
+    def _split_cfg_model_input(
+        model_input: ModelInput,
+        layouts: tuple[Magi2PackedLayout, Magi2PackedLayout] | None = None,
+    ) -> tuple[ModelInput, ModelInput]:
         """Split the packed positive/negative batch for CFG rank dispatch."""
 
         batch = model_input.x_t.shape[0]
@@ -374,7 +383,10 @@ class Magi2PreviewSampler(CFGParallelMixin):
         }
         branches = []
         for branch in range(2):
-            branches.append(ModelInput(**{name: pair[branch] for name, pair in field_pairs.items()}))
+            branch_layout = None if layouts is None else layouts[branch]
+            branches.append(
+                ModelInput(**{name: pair[branch] for name, pair in field_pairs.items()}, layout=branch_layout)
+            )
         return branches[0], branches[1]
 
     @staticmethod

--- a/vllm_omni/diffusion/models/magi2/sampler_magi2.py
+++ b/vllm_omni/diffusion/models/magi2/sampler_magi2.py
@@ -308,29 +308,11 @@ class Magi2PreviewSampler(CFGParallelMixin):
         per_token_video_t = t_batch.view(-1, 1, 1, 1, 1).expand(cfg_batch, 1, video_t, video_h, video_w)
         per_token_audio_t = t_batch.view(-1, 1, 1).expand(cfg_batch, audio_t, 1)
 
-        audio_lengths = torch.full(
-            (cfg_batch,),
-            audio_latent_len,
-            device=latent.device,
-            dtype=torch.long,
-        )
-        text_lengths = torch.tensor(
-            [txt_feat_len] * batch_size + [null_txt_feat_len] * batch_size,
-            device=latent.device,
-            dtype=torch.long,
-        )
-        ref_audio_lengths = torch.full(
-            (cfg_batch,),
-            ref_audio_feat_len,
-            device=latent.device,
-            dtype=torch.long,
-        )
-        ref_video_lengths = torch.full(
-            (cfg_batch,),
-            ref_video_feat_len,
-            device=latent.device,
-            dtype=torch.long,
-        )
+        # Lengths stay host integers; the data proxy reads them as Python ints.
+        audio_lengths = [audio_latent_len] * cfg_batch
+        text_lengths = [txt_feat_len] * batch_size + [null_txt_feat_len] * batch_size
+        ref_audio_lengths = [ref_audio_feat_len] * cfg_batch
+        ref_video_lengths = [ref_video_feat_len] * cfg_batch
 
         return ModelInput(
             x_t=torch.cat((latent, latent), dim=0),


### PR DESCRIPTION
## Purpose

Part of the MAGI-2 Preview roadmap in #7085 (M4: allocation and synchronization overhead). This PR removes the per-step host-device synchronization and repeated packing-metadata work from the native denoising loop. It is the eager-only part of M4; the regional torch.compile path is a separate stacked PR so that its numerics can be judged on their own.

What changes:

- Sampler lengths stay host integers instead of being sent to the device and read back with `.item()` by the data proxy.
- `Magi2PackedLayout` is a request-scoped object created once per request (one per CFG branch under CFG parallel). The data proxy fills coords, modality mapping and cu_seqlens on the first step; the transformer fills the modality dispatcher, the three modality index tensors and the RoPE table on its first forward, after sequence-parallel dispatch. Later steps reuse them, so `nonzero`, `argsort`/`bincount`/`tolist` and the RoPE `isfinite` check run once per request instead of once per step.
- The pre adapter gathers only the modality's channel prefix and embeds straight into the checkpoint dtype, so the fp32 `[tokens, 4 x hidden]` buffer and the block-entry cast disappear.

Nothing in the model math changes. MoE-head parallel semantics, DLO, CFG and Cache-DiT are untouched.

## Evidence

- Tiny config (CPU): outputs with a shared layout are bitwise equal to fresh per-step packing on every step; a second and a third request (new layout object, different text length) are bitwise equal to fresh packing; on the second step of a request `torch.nonzero`, `ModalityDispatcher` construction and the RoPE embedding run zero times (first step: 3 / 1 / 1); the pinned bf16 golden still passes at atol 1e-6; 4-rank gloo TP/SP parity and DLO mmap tests unchanged.
- A800 real weights, resident SP4, 272p, one step, `MAGI2_DETERMINISTIC=1`, seed 42: the PR with `--enforce-eager` produces an mp4 with the same sha256 as the merge base (video 125 frames rgb24 max abs diff 0, audio int16 max abs diff 0). Base run-to-run is also bitwise stable, so this is a real comparison and not a noise-floor artifact.
- Peak reserved device memory per rank in that run: base 65.23 GiB, PR eager 65.46 GiB (+0.23 GiB).

## Checklist

- [x] Code: host-integer lengths, request-scoped packing layout, bf16 pre adapter
- [x] Tiny-config L1 tests (CPU) including a second and a third request with new layouts
- [x] A800 one-step parity, base vs PR eager, deterministic mode: bitwise equal
- [x] End-to-end comparison numbers per the protocol below

## End-to-end comparison protocol and numbers

Not a test; run on the box and reported here as raw data.

- Setting: A800 (4x SXM4 80 GB), resident SP4 (`--tensor-parallel-size 1 --ulysses-degree 4`), 272p, 20 denoising steps, `MAGI2_DETERMINISTIC=1`, same seed. Per session the first request is warmup and not counted; the next 3 requests run back to back in the same process.
- Metrics per request: per-step denoising time (sampling stage time divided by steps), conditioning encode, video decode, audio decode, full response time; per-rank peak device memory. Each reported as median and range over the 3 counted requests.
- Groups: base (merge base), PR eager (`--enforce-eager`), PR compiled (default). All groups run on the same machine in one interleaved session to avoid thermal drift.
- Noise floor: base runs twice first. Any group difference smaller than the base-vs-base spread is reported as "no measurable difference".

Result (A800 SXM4 80 GB x4, torch 2.13.0+cu130, vllm 0.28.0; median over the 3 counted requests, range in parentheses; PR tree at the head of #7174 with `--enforce-eager`, which runs exactly this PR's code path):

| metric | base run 1 | base run 2 | PR eager | base1 vs base2 |
|---|---:|---:|---:|---:|
| denoise step (s) | 1.929 (0.002) | 1.935 (0.011) | 1.931 (0.008) | 0.006 |
| conditioning encode (s) | 4.750 (0.250) | 4.969 (0.519) | 4.959 (1.416) | 0.220 |
| video decode (s) | 0.883 (0.145) | 0.731 (0.194) | 0.739 (0.278) | 0.153 |
| audio decode (s) | 0.246 (0.222) | 0.117 (0.150) | 0.116 (0.331) | 0.130 |
| full response (s) | 82.37 (5.82) | 81.95 (3.45) | 86.77 (10.70) | 0.42 |
| peak reserved per rank, max (GiB) | 65.53 | 65.53 | 65.76 | 0.00 |
| nvidia-smi peak used per rank (MiB) | 68964 / 68358 / 68370 / 68338 | 69198 / 68358 / 68370 / 68338 | 69188 / 68358 / 68370 / 68222 | |
| host PSS, largest worker (GiB) | 134.8 | 137.2 | 136.2 | 2.4 |

Reading: denoise step, encode and decode show no measurable difference (inside the base-vs-base gap or the base ranges). The full-response median is 4.6 s higher, but the sampling stage is identical to 0.1 s (38.6 s in all three groups) and the whole gap sits in the transformer-to-host staging around the text encoder, which this PR does not touch and whose per-request spread is 34 to 45 s across all sessions. Peak reserved memory is +0.23 GiB. Raw JSON per session is in the experiment log.

## Test Plan

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** 792fef8f7 (on main f26f9c3a7)

```
PYTHONPATH=$PWD python -m pytest tests/diffusion/models/magi2/test_native_packing.py \
  tests/diffusion/models/magi2/test_native_preview.py tests/diffusion/models/magi2/test_pipeline_magi2.py -q
PYTHONPATH=$PWD python -m pytest tests/diffusion/models/magi2/test_native_distributed_parity.py \
  tests/diffusion/models/magi2/test_native_dlo_allgather.py -q
```

## Test Result

- CPU unit tests: 38 passed
- CPU 4-rank gloo parity and DLO: 2 passed
- ruff check, ruff format, SPDX, forbidden-import, torch.cuda-call, test-mark and mypy-3.10 hooks pass on the changed files
