### PR TITLE
[Doc] Document the s3tokenizer prerequisite for CosyVoice3

### DIFF
--- a/docs/user_guide/examples/offline_inference/text_to_speech.md
+++ b/docs/user_guide/examples/offline_inference/text_to_speech.md
@@ -81,6 +81,9 @@ python examples/offline_inference/text_to_speech/voxcpm2/end2end.py \
 ```bash
 uv pip install -e .
 # Includes soundfile, onnxruntime, x-transformers, einops via requirements.
+pip install s3tokenizer
+# Speech tokenizer used to extract tokens from reference audio. Not part of the
+# base install or of the published vllm/vllm-omni Docker image.
 ```
 
 Download the model snapshot:

--- a/docs/user_guide/examples/online_serving/text_to_speech.md
+++ b/docs/user_guide/examples/online_serving/text_to_speech.md
@@ -104,7 +104,10 @@ For full request-shape documentation (all parameters, response formats, error co
 
 ### Prerequisites
 
+The talker extracts speech tokens from `ref_audio` with `s3tokenizer`, which is not part of the base install or of the published `vllm/vllm-omni` Docker image:
+
 ```bash
+pip install s3tokenizer
 huggingface-cli download FunAudioLLM/Fun-CosyVoice3-0.5B-2512
 ```
 

--- a/examples/offline_inference/text_to_speech/README.md
+++ b/examples/offline_inference/text_to_speech/README.md
@@ -52,6 +52,9 @@ python examples/offline_inference/text_to_speech/<model>/end2end.py \
 ```bash
 uv pip install -e .
 # Includes soundfile, onnxruntime, x-transformers, einops via requirements.
+pip install s3tokenizer
+# Speech tokenizer used to extract tokens from reference audio. Not part of the
+# base install or of the published vllm/vllm-omni Docker image.
 ```
 
 Download the model snapshot:


### PR DESCRIPTION
## Purpose

Related to #7038. CosyVoice3 uses `s3tokenizer` to extract speech tokens from reference audio, but the package is only in the `dev` extras (`pyproject.toml`), so the base install and the published `vllm/vllm-omni` image do not ship it and `vllm serve FunAudioLLM/Fun-CosyVoice3-0.5B-2512 --omni` fails at engine startup. The code already raises a clear `ImportError` with the install hint (`cosyvoice3.py::_ensure_s3_model`); this PR documents the prerequisite where users actually look, matching how the Fish Speech and VoxCPM2 sections document their model-specific packages.

Files: `docs/user_guide/examples/online_serving/text_to_speech.md`, `docs/user_guide/examples/offline_inference/text_to_speech.md`, `examples/offline_inference/text_to_speech/README.md`.

Whether `s3tokenizer` should also be baked into the release image is a separate call for the maintainers; this PR does not change dependencies.

## Test Plan

Docs-only change. Checked against the repo `.markdownlint.yaml` rules (fenced blocks, no new headings, MD013 disabled).

**vLLM Version:** n/a (docs only)

**vLLM-Omni Commit:** f26f9c3 (main)

## Test Result

Rendered markdown reviewed; no code or dependency changes.
