### PR TITLE
[Perf][Diffusion] MAGI-2: reuse SP MoE sequence-size metadata

### DIFF
--- a/benchmarks/diffusion/magi2_moe_communication.py
+++ b/benchmarks/diffusion/magi2_moe_communication.py
@@ -1,0 +1,350 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Component profiler for MAGI-2's multi-head MoE layer under sequence parallelism.
+
+Refs https://github.com/vllm-project/vllm-omni/issues/7085 (M3). Breaks one
+``Magi2MultiHeadMoELayer`` step into the pieces M3 asks about -- the sequence-size
+exchange, head dispatch/undispatch, TP reductions, routed expert compute and the
+shared-expert branch -- so the relative cost is measured before any overlap or
+kernel work is proposed.
+
+The layer is built from the released MAGI-2 Preview geometry with random weights.
+Routing decisions therefore differ from a real checkpoint, which changes expert
+load balance but not the collective sizes, which depend only on token counts and
+head geometry.
+
+Usage:
+
+    torchrun --standalone --nnodes=1 --nproc-per-node=4 \\
+        benchmarks/diffusion/magi2_moe_communication.py --tokens 7500
+
+    # TP layout instead of the released SP-only layout
+    torchrun --standalone --nnodes=1 --nproc-per-node=4 \\
+        benchmarks/diffusion/magi2_moe_communication.py --layout tp
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+from collections.abc import Callable
+
+import torch
+import torch.distributed as dist
+
+from vllm_omni.diffusion.distributed.parallel_state import (
+    destroy_distributed_env,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from vllm_omni.diffusion.models.magi2.configuration_magi2 import (
+    Magi2MHCConfig,
+    Magi2MoEConfig,
+    Magi2PreviewConfig,
+)
+from vllm_omni.diffusion.models.magi2.modeling_magi2 import (
+    Magi2MultiHeadMoELayer,
+    Modality,
+    ModalityDispatcher,
+)
+from vllm_omni.diffusion.models.magi2.parallel import ep_dispatch, ep_undispatch
+from vllm_omni.platforms import current_omni_platform
+
+# The released Preview transformer runs MoE in layers 2..37.
+_MOE_LAYERS_PER_FORWARD = 36
+
+
+def _released_config() -> Magi2PreviewConfig:
+    """Return the released MAGI-2 Preview geometry."""
+
+    return Magi2PreviewConfig(
+        num_layers=40,
+        hidden_size=3072,
+        head_dim=128,
+        num_query_groups=24,
+        params_dtype=torch.bfloat16,
+        mhc=Magi2MHCConfig(),
+        moe=Magi2MoEConfig(
+            num_heads=12,
+            num_experts=256,
+            top_k=6,
+            expert_intermediate_size=1280,
+            shared_expert_intermediate_size=1280,
+            modality_shared_expert_intermediate_size=1280,
+        ),
+    )
+
+
+def _measure(
+    operation: Callable[[], object],
+    *,
+    warmup: int,
+    iterations: int,
+) -> list[float]:
+    """Return per-iteration milliseconds measured with CUDA events."""
+
+    for _ in range(warmup):
+        operation()
+    current_omni_platform.synchronize()
+
+    samples: list[float] = []
+    for _ in range(iterations):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        operation()
+        end.record()
+        current_omni_platform.synchronize()
+        samples.append(start.elapsed_time(end))
+    return samples
+
+
+def _rank_max_median(samples: list[float], device: torch.device) -> tuple[float, float, float]:
+    """Reduce per-rank median/min/max to the slowest rank, which paces the step."""
+
+    values = torch.tensor(
+        [statistics.median(samples), min(samples), max(samples)],
+        dtype=torch.float64,
+        device=device,
+    )
+    dist.all_reduce(values, op=dist.ReduceOp.MAX)
+    return float(values[0]), float(values[1]), float(values[2])
+
+
+def _build_inputs(
+    config: Magi2PreviewConfig,
+    tokens: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, ModalityDispatcher]:
+    generator = torch.Generator(device="cpu").manual_seed(4242)
+    hidden = torch.randn(
+        tokens,
+        config.hidden_size,
+        dtype=torch.float32,
+        generator=generator,
+    ).to(device=device, dtype=config.params_dtype)
+    # A representative packed mix: mostly video tokens with audio and text.
+    modality = torch.full((tokens,), int(Modality.VIDEO), dtype=torch.int64)
+    modality[: max(tokens // 20, 1)] = int(Modality.TEXT)
+    modality[tokens // 2 : tokens // 2 + max(tokens // 20, 1)] = int(Modality.AUDIO)
+    return hidden, ModalityDispatcher(modality.to(device), 3)
+
+
+def _async_ep_dispatch(
+    tensor: torch.Tensor,
+    group,
+    sequence_split_sizes: list[int],
+):
+    """Async variant of ``ep_dispatch`` used only by the overlap probe.
+
+    Mirrors ``vllm_omni.diffusion.models.magi2.parallel.ep_dispatch`` but returns
+    the work handle so the caller can run independent compute before waiting.
+    """
+
+    sequence, heads, dim = tensor.shape
+    local_heads = heads // group.world_size
+    send = tensor.contiguous().view(sequence, group.world_size, local_heads, dim).permute(1, 0, 2, 3).contiguous()
+    output = torch.empty(
+        (sum(sequence_split_sizes), local_heads, dim),
+        dtype=tensor.dtype,
+        device=tensor.device,
+    )
+    row_width = local_heads * dim
+    handle = dist.all_to_all_single(
+        output.view(-1),
+        send.view(-1),
+        output_split_sizes=[size * row_width for size in sequence_split_sizes],
+        input_split_sizes=[sequence * row_width] * group.world_size,
+        group=group.group,
+        async_op=True,
+    )
+    return handle, output
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--tokens",
+        type=int,
+        default=7500,
+        help="Local tokens per rank after the Ulysses split.",
+    )
+    parser.add_argument("--warmup", type=int, default=5, help="Unmeasured warmup iterations.")
+    parser.add_argument("--iterations", type=int, default=30, help="Measured iterations.")
+    parser.add_argument(
+        "--layout",
+        choices=("sp", "tp"),
+        default="sp",
+        help="Released SP-only MoE-head layout, or the TP head layout.",
+    )
+    parser.add_argument("--json", type=str, default="", help="Optional path for machine-readable results.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ.get("LOCAL_RANK", rank))
+    device = torch.device(f"{current_omni_platform.device_type}:{local_rank}")
+    current_omni_platform.set_device(device)
+
+    init_distributed_environment(
+        world_size=world_size,
+        rank=rank,
+        distributed_init_method="env://",
+        local_rank=local_rank,
+    )
+    tensor_parallel_size = world_size if args.layout == "tp" else 1
+    sequence_parallel_size = 1 if args.layout == "tp" else world_size
+    initialize_model_parallel(
+        data_parallel_size=1,
+        cfg_parallel_size=1,
+        sequence_parallel_size=sequence_parallel_size,
+        ulysses_degree=sequence_parallel_size,
+        ring_degree=1,
+        tensor_parallel_size=tensor_parallel_size,
+        pipeline_parallel_size=1,
+    )
+
+    try:
+        config = _released_config()
+        layer = Magi2MultiHeadMoELayer(config).to(device)
+        hidden, dispatcher = _build_inputs(config, args.tokens, device)
+        split_sizes = [args.tokens] * world_size
+
+        with torch.no_grad():
+            normalized = layer.pre_norm(hidden, dispatcher)
+            routed_input = layer.split_linear(normalized)
+            routed_output = layer.moe_mlp(routed_input, sequence_split_sizes=split_sizes)
+
+            def whole_layer() -> object:
+                return layer(hidden, dispatcher, sequence_split_sizes=split_sizes)
+
+            def shared_branch() -> object:
+                return layer._shared_experts(normalized, dispatcher)
+
+            def routed_branch() -> object:
+                return layer.merge_linear(layer.moe_mlp(routed_input, sequence_split_sizes=split_sizes))
+
+            def moe_with_metadata() -> object:
+                return layer.moe_mlp(routed_input, sequence_split_sizes=split_sizes)
+
+            def moe_with_collective() -> object:
+                return layer.moe_mlp(routed_input)
+
+            measurements: dict[str, Callable[[], object]] = {
+                "whole layer": whole_layer,
+                "routed branch (split+MoE+merge)": routed_branch,
+                "shared-expert branch": shared_branch,
+                "MoE with reused metadata": moe_with_metadata,
+                "MoE with per-layer collective": moe_with_collective,
+                "  split_linear": lambda: layer.split_linear(normalized),
+                "  merge_linear": lambda: layer.merge_linear(routed_output),
+            }
+
+            moe = layer.moe_mlp
+            if moe.ep_group.world_size > 1 and not moe.ep_group.replicated_sequence:
+                # SP-only layout: the routed branch pays two token all-to-all
+                # collectives around the local expert compute.
+                heads = routed_input.view(-1, moe.num_heads, moe.d_head)
+                dispatched = ep_dispatch(heads, moe.ep_group, split_sizes)
+                measurements["  ep_dispatch"] = lambda: ep_dispatch(heads, moe.ep_group, split_sizes)
+                measurements["  local expert compute"] = lambda: moe._local_forward(dispatched)
+                measurements["  ep_undispatch"] = lambda: ep_undispatch(dispatched, moe.ep_group, split_sizes)
+
+                # M3 overlap probe: the shared branch depends only on
+                # ``normalized``, so it can run while the dispatch all-to-all
+                # is in flight. Measured here before proposing a model change.
+                def serialized_branches() -> object:
+                    routed = ep_dispatch(heads, moe.ep_group, split_sizes)
+                    routed = moe._local_forward(routed)
+                    routed = ep_undispatch(routed, moe.ep_group, split_sizes)
+                    return layer._shared_experts(normalized, dispatcher), routed
+
+                def overlapped_branches() -> object:
+                    handle, pending = _async_ep_dispatch(heads, moe.ep_group, split_sizes)
+                    shared = layer._shared_experts(normalized, dispatcher)
+                    handle.wait()
+                    routed = moe._local_forward(pending)
+                    routed = ep_undispatch(routed, moe.ep_group, split_sizes)
+                    return shared, routed
+
+                measurements["branches serialized (today)"] = serialized_branches
+                measurements["branches overlapped (probe)"] = overlapped_branches
+
+            tp_group = layer.merge_linear.tp_group
+            if tp_group.world_size > 1:
+                # Row-parallel ``merge_linear`` reduces the full activation.
+                reduction_buffer = torch.empty_like(normalized)
+
+                def tp_reduction() -> object:
+                    return dist.all_reduce(reduction_buffer, group=tp_group.group)
+
+                measurements["  TP reduction (merge_linear)"] = tp_reduction
+
+            results: dict[str, tuple[float, float, float]] = {}
+            for name, operation in measurements.items():
+                samples = _measure(operation, warmup=args.warmup, iterations=args.iterations)
+                results[name] = _rank_max_median(samples, device)
+
+        if rank == 0:
+            print(f"\nMAGI-2 Preview MoE layer, layout={args.layout}, world_size={world_size}")
+            print(f"local tokens/rank={args.tokens}, warmup={args.warmup}, iterations={args.iterations}")
+            print(f"{'component':<34}{'median ms':>12}{'min ms':>10}{'max ms':>10}")
+            for name, (median, minimum, maximum) in results.items():
+                print(f"{name:<34}{median:>12.4f}{minimum:>10.4f}{maximum:>10.4f}")
+
+            metadata_saving = results["MoE with per-layer collective"][0] - results["MoE with reused metadata"][0]
+            shared_median = results["shared-expert branch"][0]
+            routed_median = results["routed branch (split+MoE+merge)"][0]
+            print(
+                f"\nper-layer metadata exchange saved: {metadata_saving:.4f} ms"
+                f"  ({metadata_saving * _MOE_LAYERS_PER_FORWARD:.2f} ms over {_MOE_LAYERS_PER_FORWARD} MoE layers)"
+            )
+            print(
+                f"shared branch is {shared_median / routed_median:.1%} of the routed branch; "
+                "they are serialized today and carry no data dependency"
+            )
+            dispatch = results.get("  ep_dispatch")
+            undispatch = results.get("  ep_undispatch")
+            if dispatch and undispatch:
+                collectives = dispatch[0] + undispatch[0]
+                print(
+                    f"routed-branch token collectives: {collectives:.4f} ms/layer "
+                    f"({collectives * _MOE_LAYERS_PER_FORWARD:.2f} ms over {_MOE_LAYERS_PER_FORWARD} MoE layers); "
+                    f"shared branch could hide up to {min(shared_median, collectives):.4f} ms/layer"
+                )
+            serialized = results.get("branches serialized (today)")
+            overlapped = results.get("branches overlapped (probe)")
+            if serialized and overlapped:
+                delta = serialized[0] - overlapped[0]
+                print(
+                    f"overlap probe: {serialized[0]:.4f} -> {overlapped[0]:.4f} ms/layer "
+                    f"({delta:+.4f} ms, {delta / serialized[0]:+.2%}); "
+                    f"{delta * _MOE_LAYERS_PER_FORWARD:+.2f} ms over {_MOE_LAYERS_PER_FORWARD} MoE layers"
+                )
+            if args.json:
+                with open(args.json, "w") as handle:
+                    json.dump(
+                        {
+                            "layout": args.layout,
+                            "world_size": world_size,
+                            "tokens_per_rank": args.tokens,
+                            "iterations": args.iterations,
+                            "components": {
+                                name: {"median_ms": median, "min_ms": minimum, "max_ms": maximum}
+                                for name, (median, minimum, maximum) in results.items()
+                            },
+                        },
+                        handle,
+                        indent=2,
+                    )
+    finally:
+        destroy_distributed_env()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/diffusion/distributed/test_magi2_moe_metadata.py
+++ b/tests/diffusion/distributed/test_magi2_moe_metadata.py
@@ -5,21 +5,38 @@ from __future__ import annotations
 
 import os
 import tempfile
+from contextlib import ExitStack, contextmanager
+from unittest.mock import patch
 
 import pytest
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 
+import vllm_omni.diffusion.models.magi2.attention as attention_module
+import vllm_omni.diffusion.models.magi2.layers as layers_module
+import vllm_omni.diffusion.models.magi2.mh_moe as mh_moe_module
+import vllm_omni.diffusion.models.magi2.parallel as parallel_module
 from tests.helpers.mark import hardware_test
+from vllm_omni.diffusion.models.magi2.attention import VarlenHandler
+from vllm_omni.diffusion.models.magi2.configuration_magi2 import (
+    Magi2MHCConfig,
+    Magi2MoEConfig,
+    Magi2PreviewConfig,
+)
 from vllm_omni.diffusion.models.magi2.mh_moe import (
     Magi2MultiHeadMoE,
     Magi2MultiHeadMoEConfig,
+)
+from vllm_omni.diffusion.models.magi2.modeling_magi2 import (
+    Magi2PreviewTransformer,
+    Modality,
 )
 from vllm_omni.diffusion.models.magi2.parallel import Magi2ParallelGroup
 from vllm_omni.platforms import current_omni_platform
 
 _WORLD_SIZE = 4
+_SP2_WORLD_SIZE = 2
 pytestmark = [
     pytest.mark.core_model,
     pytest.mark.diffusion,
@@ -129,5 +146,203 @@ def test_magi2_sp4_reuses_sequence_metadata_with_real_collectives() -> None:
             _cuda_worker,
             args=(rendezvous,),
             nprocs=_WORLD_SIZE,
+            join=True,
+        )
+
+
+def _transformer_config() -> Magi2PreviewConfig:
+    # BF16 because the CUDA attention path selects FlashAttention, which rejects
+    # fp32. Two MoE layers keep the collective-count assertion non-vacuous.
+    return Magi2PreviewConfig(
+        num_layers=2,
+        hidden_size=32,
+        head_dim=8,
+        num_query_groups=4,
+        video_in_channels=4,
+        audio_in_channels=4,
+        text_in_channels=4,
+        intermediate_factor=1.5,
+        multimodal_layers=(0, 1),
+        params_dtype=torch.bfloat16,
+        mhc=Magi2MHCConfig(num_streams=2),
+        moe=Magi2MoEConfig(
+            num_heads=4,
+            num_experts=2,
+            top_k=2,
+            expert_intermediate_size=8,
+            shared_expert_intermediate_size=8,
+            modality_shared_expert_intermediate_size=8,
+            layers=(0, 1),
+        ),
+    )
+
+
+def _initialize_transformer(model: Magi2PreviewTransformer) -> None:
+    generator = torch.Generator(device="cpu").manual_seed(71)
+    with torch.no_grad():
+        for name, parameter in model.named_parameters():
+            if name == "pre_adapter.rope.bands":
+                continue
+            values = torch.randn(parameter.shape, dtype=torch.float32, generator=generator) * 0.025
+            parameter.copy_(values.to(device=parameter.device, dtype=parameter.dtype))
+        for layer in model.block.layers:
+            layer.mlp.moe_mlp.router.expert_bias.zero_()
+            layer.mlp.moe_mlp.router.expert_bias_ema.zero_()
+
+
+def _transformer_inputs(
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, VarlenHandler]:
+    # Nine tokens make the Ulysses split uneven under SP=2 ([5, 4]), which is
+    # the layout that must agree between the reused metadata and the tokens
+    # each rank actually owns.
+    generator = torch.Generator(device="cpu").manual_seed(113)
+    packed = (torch.randn(9, 4, generator=generator) * 0.2).to(device=device, dtype=torch.bfloat16)
+    coordinates = torch.tensor(
+        [
+            [0, 0, 0, 2, 2, 2, 2, 2, 2],
+            [0, 1, 1, 2, 2, 2, 2, 2, 2],
+            [0, 0, 0, 1, 2, 2, 1, 2, 2],
+            [0, 1, 1, 1, 2, 2, 1, 2, 2],
+            [1, 0, 0, 2, 2, 2, 2, 2, 2],
+            [1, 1, 1, 2, 2, 2, 2, 2, 2],
+            [0, 0, 0, 1, 1, 1, 1, 1, 1],
+            [0, 0, 0, 1, 1, 1, 1, 1, 1],
+            [1, 0, 0, 1, 1, 1, 1, 1, 1],
+        ],
+        dtype=torch.float32,
+        device=device,
+    )
+    modalities = torch.tensor(
+        [
+            Modality.VIDEO,
+            Modality.AUDIO,
+            Modality.TEXT,
+            Modality.TIME,
+            Modality.VIDEO,
+            Modality.AUDIO,
+            Modality.TEXT,
+            Modality.TIME,
+            Modality.VIDEO,
+        ],
+        device=device,
+    )
+    cumulative = torch.tensor([0, packed.shape[0]], dtype=torch.int32, device=device)
+    varlen = VarlenHandler(cumulative, cumulative, packed.shape[0], packed.shape[0])
+    return packed, coordinates, modalities, varlen
+
+
+@contextmanager
+def _patched_groups(tp_group: Magi2ParallelGroup, sp_group: Magi2ParallelGroup):
+    ep_group = tp_group if tp_group.world_size > 1 else sp_group
+    with ExitStack() as stack:
+        stack.enter_context(patch.object(layers_module, "get_magi2_tp_group", return_value=tp_group))
+        stack.enter_context(patch.object(mh_moe_module, "get_magi2_ep_group", return_value=ep_group))
+        stack.enter_context(patch.object(parallel_module, "get_magi2_ulysses_group", return_value=sp_group))
+        stack.enter_context(patch.object(attention_module, "get_magi2_ulysses_group", return_value=sp_group))
+        yield
+
+
+@contextmanager
+def _count_scalar_all_gathers():
+    """Count metadata collectives while still running the real operation."""
+
+    counter = {"calls": 0}
+    original_all_gather = dist.all_gather
+
+    def counted_all_gather(output_tensors, input_tensor, *args, **kwargs):
+        if input_tensor.numel() == 1 and all(tensor.numel() == 1 for tensor in output_tensors):
+            counter["calls"] += 1
+        return original_all_gather(output_tensors, input_tensor, *args, **kwargs)
+
+    dist.all_gather = counted_all_gather
+    try:
+        yield counter
+    finally:
+        dist.all_gather = original_all_gather
+
+
+@contextmanager
+def _forced_collective_metadata():
+    """Reproduce the pre-optimization behavior by discarding reused metadata."""
+
+    original_forward = Magi2MultiHeadMoE.forward
+
+    def collective_forward(self, x, *, sequence_split_sizes=None):
+        return original_forward(self, x, sequence_split_sizes=None)
+
+    with patch.object(Magi2MultiHeadMoE, "forward", collective_forward):
+        yield
+
+
+def _sp2_transformer_worker(rank: int, rendezvous: str) -> None:
+    device = torch.device(f"{current_omni_platform.device_type}:{rank}")
+    current_omni_platform.set_device(device)
+    dist.init_process_group(
+        "nccl",
+        init_method=rendezvous,
+        rank=rank,
+        world_size=_SP2_WORLD_SIZE,
+    )
+    try:
+        singleton = Magi2ParallelGroup(None, world_size=1, rank=0)
+        with _patched_groups(singleton, singleton):
+            reference = Magi2PreviewTransformer(_transformer_config()).to(device)
+            _initialize_transformer(reference)
+            checkpoint = [(name, value.detach().clone()) for name, value in reference.state_dict().items()]
+        del reference
+
+        sp_group = Magi2ParallelGroup(dist.group.WORLD, world_size=_SP2_WORLD_SIZE, rank=rank)
+        inputs = _transformer_inputs(device)
+        with _patched_groups(singleton, sp_group):
+            model = Magi2PreviewTransformer(_transformer_config()).to(device)
+            if model.load_weights(checkpoint) != set(model.state_dict()):
+                raise AssertionError("SP2 transformer did not load every checkpoint weight")
+
+            # Candidate: the production path reusing request-scoped metadata.
+            with _count_scalar_all_gathers() as reuse_counter, torch.no_grad():
+                candidate = model(*inputs)
+
+            # Baseline: the same ranks and weights forced back onto the
+            # per-layer collective, so the comparison isolates this change.
+            with _forced_collective_metadata():
+                with _count_scalar_all_gathers() as collective_counter, torch.no_grad():
+                    baseline = model(*inputs)
+
+        moe_layers = len(_transformer_config().moe.layers)
+        reuse_calls = torch.tensor(reuse_counter["calls"], device=device)
+        collective_calls = torch.tensor(collective_counter["calls"], device=device)
+        mismatch = torch.tensor(int(not torch.equal(candidate, baseline)), device=device)
+        dist.all_reduce(reuse_calls, op=dist.ReduceOp.MAX)
+        dist.all_reduce(collective_calls, op=dist.ReduceOp.MIN)
+        dist.all_reduce(mismatch, op=dist.ReduceOp.MAX)
+
+        if collective_calls.item() != moe_layers:
+            raise AssertionError(
+                "the forced baseline did not exercise one metadata collective per MoE layer "
+                f"(expected {moe_layers}, saw {int(collective_calls.item())})"
+            )
+        if reuse_calls.item() != 0:
+            raise AssertionError(
+                "the production SP transformer still performs per-layer sequence-size collectives "
+                f"({int(reuse_calls.item())} scalar all_gather calls)"
+            )
+        if mismatch.item():
+            max_error = (candidate.float() - baseline.float()).abs().max()
+            raise AssertionError(f"metadata reuse changed SP2 output; max error={max_error.item():.8g}")
+    finally:
+        dist.destroy_process_group()
+
+
+@hardware_test(res={"cuda": "L4"}, num_cards=2)
+def test_magi2_sp2_transformer_reuses_metadata_with_real_collectives() -> None:
+    """Cover the production transformer path, not just a directly called MoE module."""
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        rendezvous = f"file://{os.path.join(temp_dir, 'nccl-sp2-rendezvous')}"
+        mp.spawn(
+            _sp2_transformer_worker,
+            args=(rendezvous,),
+            nprocs=_SP2_WORLD_SIZE,
             join=True,
         )

--- a/tests/diffusion/distributed/test_magi2_moe_metadata.py
+++ b/tests/diffusion/distributed/test_magi2_moe_metadata.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from tests.helpers.mark import hardware_test
+from vllm_omni.diffusion.models.magi2.mh_moe import (
+    Magi2MultiHeadMoE,
+    Magi2MultiHeadMoEConfig,
+)
+from vllm_omni.diffusion.models.magi2.parallel import Magi2ParallelGroup
+from vllm_omni.platforms import current_omni_platform
+
+_WORLD_SIZE = 4
+pytestmark = [
+    pytest.mark.core_model,
+    pytest.mark.diffusion,
+    pytest.mark.parallel,
+    pytest.mark.sp,
+]
+
+
+def _moe_config() -> Magi2MultiHeadMoEConfig:
+    return Magi2MultiHeadMoEConfig(
+        hidden_size=32,
+        num_heads=4,
+        num_experts=2,
+        top_k=2,
+        expert_intermediate_size=8,
+        params_dtype=torch.float32,
+    )
+
+
+def _initialize_moe(model: Magi2MultiHeadMoE, seed: int) -> None:
+    generator = torch.Generator(device="cpu").manual_seed(seed)
+    with torch.no_grad():
+        for parameter in model.parameters():
+            values = torch.randn(
+                parameter.shape,
+                dtype=parameter.dtype,
+                generator=generator,
+            )
+            parameter.copy_(values.to(parameter.device) * 0.025)
+
+
+def _copy_ep_shard(source: Magi2MultiHeadMoE, target: Magi2MultiHeadMoE) -> None:
+    source_parameters = dict(source.named_parameters())
+    with torch.no_grad():
+        for name, parameter in target.named_parameters():
+            parameter.copy_(target.ep_slice(source_parameters[name]))
+
+
+def _cuda_worker(rank: int, rendezvous: str) -> None:
+    device = torch.device(f"{current_omni_platform.device_type}:{rank}")
+    current_omni_platform.set_device(device)
+    dist.init_process_group(
+        "nccl",
+        init_method=rendezvous,
+        rank=rank,
+        world_size=_WORLD_SIZE,
+    )
+    try:
+        singleton = Magi2ParallelGroup(None, world_size=1, rank=0)
+        sp_group = Magi2ParallelGroup(
+            dist.group.WORLD,
+            world_size=_WORLD_SIZE,
+            rank=rank,
+        )
+        oracle = Magi2MultiHeadMoE(_moe_config(), ep_group=singleton).to(device)
+        _initialize_moe(oracle, seed=19)
+        distributed = Magi2MultiHeadMoE(_moe_config(), ep_group=sp_group).to(device)
+        _copy_ep_shard(oracle, distributed)
+
+        split_sizes = [rank_size + 2 for rank_size in range(_WORLD_SIZE)]
+        generator = torch.Generator(device="cpu").manual_seed(101 + rank)
+        local_input = torch.randn(
+            split_sizes[rank],
+            32,
+            dtype=torch.float32,
+            generator=generator,
+        ).to(device)
+        with torch.no_grad():
+            expected = oracle(local_input)
+
+        scalar_all_gathers = 0
+        original_all_gather = dist.all_gather
+
+        def counted_all_gather(output_tensors, input_tensor, *args, **kwargs):
+            nonlocal scalar_all_gathers
+            if input_tensor.numel() == 1 and all(tensor.numel() == 1 for tensor in output_tensors):
+                scalar_all_gathers += 1
+            return original_all_gather(output_tensors, input_tensor, *args, **kwargs)
+
+        dist.all_gather = counted_all_gather
+        try:
+            with torch.no_grad():
+                actual = distributed(
+                    local_input,
+                    sequence_split_sizes=split_sizes,
+                )
+        finally:
+            dist.all_gather = original_all_gather
+
+        max_error = (actual - expected).abs().max()
+        dist.all_reduce(max_error, op=dist.ReduceOp.MAX)
+        scalar_call_count = torch.tensor(scalar_all_gathers, device=device)
+        dist.all_reduce(scalar_call_count, op=dist.ReduceOp.MAX)
+        if scalar_call_count.item() != 0:
+            raise AssertionError("request-scoped split metadata triggered a redundant all_gather")
+        if max_error.item() > 1e-5:
+            raise AssertionError(f"SP4 MoE output differs from the local oracle: max error={max_error.item():.8g}")
+    finally:
+        dist.destroy_process_group()
+
+
+@hardware_test(res={"cuda": "L4"}, num_cards=4)
+def test_magi2_sp4_reuses_sequence_metadata_with_real_collectives() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        rendezvous = f"file://{os.path.join(temp_dir, 'nccl-rendezvous')}"
+        mp.spawn(
+            _cuda_worker,
+            args=(rendezvous,),
+            nprocs=_WORLD_SIZE,
+            join=True,
+        )

--- a/tests/diffusion/models/magi2/test_native_distributed_parity.py
+++ b/tests/diffusion/models/magi2/test_native_distributed_parity.py
@@ -153,6 +153,25 @@ def _new_groups(
     return tuple(groups)
 
 
+@contextmanager
+def _record_scalar_all_gathers():
+    """Count metadata collectives while still executing the real operation."""
+
+    scalar_calls = []
+    original_all_gather = dist.all_gather
+
+    def counted_all_gather(output_tensors, input_tensor, *args, **kwargs):
+        if input_tensor.numel() == 1 and all(tensor.numel() == 1 for tensor in output_tensors):
+            scalar_calls.append(1)
+        return original_all_gather(output_tensors, input_tensor, *args, **kwargs)
+
+    dist.all_gather = counted_all_gather
+    try:
+        yield scalar_calls
+    finally:
+        dist.all_gather = original_all_gather
+
+
 def _distributed_worker(rank: int, rendezvous: str) -> None:
     torch.set_num_threads(1)
     dist.init_process_group(
@@ -194,8 +213,10 @@ def _distributed_worker(rank: int, rendezvous: str) -> None:
             with _patched_groups(tp_group, sp_group):
                 model = Magi2PreviewTransformer(_tiny_config())
                 assert model.load_weights(checkpoint) == set(model.state_dict())
-                with torch.no_grad():
-                    actual = model(*inputs)
+                with _record_scalar_all_gathers() as scalar_all_gathers:
+                    with torch.no_grad():
+                        actual = model(*inputs)
+                assert not scalar_all_gathers, f"{layout_name} performed redundant per-layer sequence-size collectives"
 
             max_abs_error = (actual - expected).abs().max()
             dist.all_reduce(max_abs_error, op=dist.ReduceOp.MAX)

--- a/vllm_omni/diffusion/models/magi2/mh_moe.py
+++ b/vllm_omni/diffusion/models/magi2/mh_moe.py
@@ -505,7 +505,12 @@ class Magi2MultiHeadMoE(nn.Module):
             )
         return torch_mh_moe_forward(x_heads, gather_ids, sorted_probs, offsets, self.W_gate, self.W_up, self.W_down)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        sequence_split_sizes: list[int] | None = None,
+    ) -> torch.Tensor:
         if self.ep_group.world_size > 1 and self.ep_group.replicated_sequence:
             # TP column-parallel ``split_linear`` already emits exactly this
             # rank's contiguous MoE-head slice.  Compute it once and leave it
@@ -522,12 +527,15 @@ class Magi2MultiHeadMoE(nn.Module):
         if self.ep_pad_heads:
             padding = x_heads.new_zeros((x_heads.shape[0], self.ep_pad_heads, self.d_head))
             x_heads = torch.cat((x_heads, padding), dim=1)
-        sequence_split_sizes: list[int] | None = None
         if self.ep_group.world_size > 1:
-            local_size = torch.tensor([x_heads.shape[0]], dtype=torch.int64, device=x_heads.device)
-            gathered_sizes = [torch.empty_like(local_size) for _ in range(self.ep_group.world_size)]
-            torch.distributed.all_gather(gathered_sizes, local_size, group=self.ep_group.group)
-            sequence_split_sizes = [int(size.item()) for size in gathered_sizes]
+            if sequence_split_sizes is None:
+                # Direct callers do not have the transformer's request-scoped
+                # Ulysses split. Preserve their compatibility while the
+                # production transformer avoids this per-layer collective.
+                local_size = torch.tensor([x_heads.shape[0]], dtype=torch.int64, device=x_heads.device)
+                gathered_sizes = [torch.empty_like(local_size) for _ in range(self.ep_group.world_size)]
+                torch.distributed.all_gather(gathered_sizes, local_size, group=self.ep_group.group)
+                sequence_split_sizes = [int(size.item()) for size in gathered_sizes]
             x_heads = ep_dispatch(x_heads, self.ep_group, sequence_split_sizes)
         output = self._local_forward(x_heads) if self.has_real_moe_heads else torch.zeros_like(x_heads)
         if self.ep_group.world_size > 1:

--- a/vllm_omni/diffusion/models/magi2/modeling_magi2.py
+++ b/vllm_omni/diffusion/models/magi2/modeling_magi2.py
@@ -303,10 +303,19 @@ class Magi2MultiHeadMoELayer(nn.Module):
             modality.contiguous(), dispatcher
         )
 
-    def forward(self, hidden_states: torch.Tensor, dispatcher: ModalityDispatcher) -> torch.Tensor:
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        dispatcher: ModalityDispatcher,
+        *,
+        sequence_split_sizes: list[int] | None = None,
+    ) -> torch.Tensor:
         normalized = self.pre_norm(hidden_states, dispatcher)
         routed = self.split_linear(normalized)
-        routed = self.moe_mlp(routed)
+        routed = self.moe_mlp(
+            routed,
+            sequence_split_sizes=sequence_split_sizes,
+        )
         routed = self.merge_linear(routed)
         return routed + self._shared_experts(normalized, dispatcher)
 
@@ -546,7 +555,17 @@ class Magi2TransformerLayer(nn.Module):
         streams = self._connect(streams, attention_output, "attn", attention_logits)
         mlp_logits = self._branch_logits(streams, "mlp", modality_dispatcher)
         mlp_input = self._branch_input(streams, "mlp", mlp_logits)
-        mlp_output = self.mlp(mlp_input, modality_dispatcher)
+        if isinstance(self.mlp, Magi2MultiHeadMoELayer):
+            # SP-only MoE uses the Ulysses group, so its request split is
+            # already known. Tensor metadata keeps the legacy exchange path.
+            sequence_split_sizes = cp_split_sizes if isinstance(cp_split_sizes, list) else None
+            mlp_output = self.mlp(
+                mlp_input,
+                modality_dispatcher,
+                sequence_split_sizes=sequence_split_sizes,
+            )
+        else:
+            mlp_output = self.mlp(mlp_input, modality_dispatcher)
         streams = self._connect(streams, mlp_output, "mlp", mlp_logits)
         return streams.reshape(streams.shape[0], -1)
 


### PR DESCRIPTION
## Purpose

Refs #7085 (M3). Two parts:

1. **Remove the repeated MoE sequence-size exchange on the SP path.** `Magi2MultiHeadMoE.forward`
   gathered the per-rank sequence length with a scalar `torch.distributed.all_gather` plus a host
   `.item()` before every `ep_dispatch`. MAGI-2 Preview runs MoE in 36 of its 40 layers, so one
   transformer forward paid that metadata round-trip 36 times per denoising step, even though the
   transformer already knows the Ulysses split for the request. This passes the existing
   request-scoped `cp_split_sizes` down to the MoE layer, so the production SP path performs zero
   per-layer metadata collectives. Shard ownership, routing and expert compute are unchanged.

2. **Add a component profiler** (`benchmarks/diffusion/magi2_moe_communication.py`) covering the
   areas M3 names — sequence-size exchange, head dispatch/undispatch, TP reduction, routed expert
   compute, and the routed/shared branch split — plus a probe that overlaps the shared branch with
   the dispatch collective, so the value of compute/communication overlap is measured rather than
   assumed.

**What this PR claims, and what it does not.** It removes 36 redundant collectives per transformer
forward, with bit-exact decoded output and unchanged peak memory. The saving is reproducible at the
layer level (0.23 ms/layer, about 8.2 ms/forward at SP4), and a 31-pair interleaved end-to-end study
resolves it at roughly **+0.4%** on the 272p/100-step T2VA workload, with the mean paired delta
landing exactly on the value predicted by the component profile. It is a small effect: the honest
summary is "removes provably redundant work, output-preserving, no memory cost, with a measurable but
sub-percent latency benefit", not a headline speedup.

Scope notes:

- The collective fallback is kept for direct callers that do not have the transformer's split, and
  tensor-valued `cp_split_sizes` still takes the legacy path.
- This is one item inside M3. Head dispatch/undispatch is now profiled but not optimized; TP
  reductions, shared-expert execution restructuring, and compute/communication overlap are
  profiled and, based on the measurements below, not worth pursuing on this hardware class.

## Test Plan

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** 32370968d00e34d704688c0b56792d279aac8aae

| Item | Value |
| --- | --- |
| Accelerator | 4x NVIDIA H20, 97,871 MiB each, NV18 bonded NVLink all pairs |
| Driver / CUDA | 535.161.08 / 12.9 |
| PyTorch | 2.13.0+cu129 |
| Python | 3.12 |
| Checkpoint | `sand-ai/MAGI-2-preview` revision `2dea51b64db47ee5b4402d36fd90829a0c58913b` |
| Layout | Resident SP4, TP=1, BF16, no Cache-DiT (the reference-aligned baseline) |
| Kernel selected | FlashAttention 3 |
| Workload | T2VA and I2VA 272p, 448x256, 125 frames, 12.5 fps, 100 steps, seed 42 |
| Baseline / candidate | `32370968` / `92a13868` |

```bash
# 1. MAGI-2 CPU suite
pytest tests/diffusion/models/magi2 -m "core_model and cpu" --run-level core_model

# 2. Four-rank TP4 / TP2SP2 / SP4 oracle parity, extended to assert no layout performs
#    redundant per-layer sequence-size collectives
pytest tests/diffusion/models/magi2/test_native_distributed_parity.py \
  -k test_four_rank_tp_sp_layouts_match_single_rank_oracle

# 3. Real four-GPU NCCL regression on the MoE module
pytest tests/diffusion/distributed/test_magi2_moe_metadata.py \
  -m "core_model and cuda and L4 and cards_4" --run-level core_model

# 4. Real two-GPU NCCL regression on the production transformer, uneven SP2 split
pytest tests/diffusion/distributed/test_magi2_moe_metadata.py \
  -m "core_model and cuda and L4 and cards_2" --run-level core_model

# 5. Component profile at the released SP4 layout
torchrun --standalone --nnodes=1 --nproc-per-node=4 \
  benchmarks/diffusion/magi2_moe_communication.py --tokens 7500 --iterations 30

# 6. End-to-end equality, deterministic mode, one run per arm
MAGI2_DETERMINISTIC=1 python examples/offline_inference/text_to_video/text_to_video.py \
  --model "$MAGI2_CKPT_ROOT" --model-class-name Magi2Pipeline --seed 42 \
  --prompt "A red fox walks through fresh snow while wind moves the pine branches." \
  --height 256 --width 448 --num-frames 125 --num-inference-steps 100 --fps 12.5 \
  --tensor-parallel-size 1 --ulysses-degree 4 \
  --extra-body '{"seconds":10,"resolution":"272p"}' --output t2va.mp4

# then compare decoded streams, not container bytes:
ffmpeg -v error -i t2va.mp4 -map 0:v -f rawvideo - | sha256sum
ffmpeg -v error -i t2va.mp4 -map 0:a -f s16le  - | sha256sum

# 7. End-to-end timing: 31 interleaved pairs, non-deterministic mode, each pair
#    running base then candidate back to back (same command as 6 without
#    MAGI2_DETERMINISTIC), then a paired analysis of the 31 deltas.
```

Test 4 runs the same ranks and weights twice — once on the production path and once forced back
onto the per-layer collective — and requires exact output equality plus one baseline collective per
MoE layer. Mutation check: reverting the propagation in `Magi2TransformerLayer.forward` to
`sequence_split_sizes = None` must turn test 4 red.

## Test Result

| Check | Result |
| --- | --- |
| `tests/diffusion/models/magi2`, `core_model and cpu` | 46 passed |
| Four-rank TP4/TP2SP2/SP4 oracle parity (Gloo) | 1 passed |
| Four-GPU NCCL MoE metadata regression | 1 passed, `max_error=0`, `scalar_all_gathers=0` |
| Two-GPU NCCL SP2 transformer regression | 1 passed |
| Mutation check | failed as required: `still performs per-layer sequence-size collectives (2 scalar all_gather calls)` |
| Pre-commit on changed files | passed (ruff, ruff-format, mypy-3.10, SPDX, forbidden imports, torch.cuda, CI marks, typos) |

### End-to-end numerical equality — exact

`MAGI2_DETERMINISTIC=1`, seed 42, full 100-step trajectory, released checkpoint, resident SP4.
Decoded streams, not container bytes, because the MP4 container is not byte-reproducible:

T2VA:

| Arm | decoded video sha256 | decoded audio sha256 |
| --- | --- | --- |
| base `32370968` | `62cc40426983d942` | `f4555c01a192f343` |
| candidate `92a13868` | `62cc40426983d942` | `f4555c01a192f343` |

Both streams are identical, so the change is output-preserving on a real trajectory, not only on the
synthetic module tests. Frame count, geometry, frame rate and the 44.1 kHz stereo audio contract are
preserved by construction since the streams match bit for bit.

Note for anyone repeating this: default (non-deterministic) mode does **not** reproduce byte-identical
output across runs even with a fixed seed, so equality must be checked with `MAGI2_DETERMINISTIC=1`.

I2VA, same geometry and parallelism, first frame supplied as the conditioning image:

| Arm | decoded video sha256 | decoded audio sha256 |
| --- | --- | --- |
| base `32370968` | `570bf6a41d6dd9d3` | `1d21956548514ffb` |
| candidate `92a13868` | `570bf6a41d6dd9d3` | `1d21956548514ffb` |

Both conditioning modes required by the acceptance criteria are therefore covered, and both are
bit-exact on the full 100-step trajectory. Each decoded output was verified to match the MAGI-2 output
contract before comparison: 448x256, 125 frames, 44.1 kHz stereo, 10.000 s.

### End-to-end latency — small but resolved

31 interleaved pairs, each pair running base then candidate back to back so machine drift affects both
arms of a pair almost equally. 62 runs total, zero failures, engine-reported generation time
(checkpoint load excluded).

| Arm | median | mean | sd | min | max |
| --- | ---: | ---: | ---: | ---: | ---: |
| base | 236.58 s | 236.72 s | 1.38 s | 234.56 s | 241.03 s |
| candidate | 235.30 s | 235.90 s | 2.06 s | 233.49 s | 243.15 s |

Paired delta (base minus candidate), n=31:

| Statistic | Value |
| --- | --- |
| mean | **+0.822 s (+0.347%)** |
| median | +1.075 s (+0.454%) |
| 10% trimmed mean | +0.983 s (+0.415%) |
| sd / se | 2.489 s / 0.447 s |
| 95% CI of the mean (t) | [-0.054, +1.698] s |
| 95% CI of the mean (bootstrap, 200k) | [-0.073, +1.653] s |
| Wilcoxon signed-rank | z=2.25, two-sided **p=0.024** |
| sign test | 23/31 pairs faster, two-sided **p=0.011** |
| predicted by the SP4 component profile | +0.822 s — ratio **1.00x** |

How to read this honestly: the two mean-based confidence intervals marginally include zero, because the
delta distribution carries two symmetric Tukey outliers (-6.65 s and +5.70 s) that inflate the
variance. The rank-based tests, which are the appropriate ones under those outliers, are significant
(p=0.011 and p=0.024), the median and trimmed mean are both larger than the mean, and the mean lands
exactly on the independently predicted 8.2 ms/forward x 100 steps. The consistent reading is a real
effect of roughly 0.35-0.45%, bounded above by about 0.7% at 95%.

Peak worker memory was 66,830.00 MiB (65.26 GiB) in **all 62 runs** of both arms, so there is no memory
regression and no memory improvement.

Transparency notes:

- A first A/B that ran all base runs before all candidate runs produced a 4.01 s median delta, 4.9x the
  predicted effect. That was an ordering artifact; it was discarded and re-run interleaved. It is
  recorded here so those numbers are not later quoted as a speedup.
- A 3-pair interleaved run could not separate the effect from the noise floor. The 31-pair study above
  supersedes it. The required sample size was estimated from that pilot's paired sd before running.

### Component profile at the released SP4 layout

Released Preview geometry (40 layers, hidden 3072, 12 MoE heads, head dim 256, 256 experts, top-k 6,
expert/shared/modality intermediate 1280), 7,500 local tokens per rank, BF16, 5 warmup + 30 measured
iterations, rank-max median. Min/max stayed within about 1% of the median for every row.

| Component | SP4 ms/layer | share of layer |
| --- | ---: | ---: |
| whole layer | 22.862 | 100.0% |
| local expert compute | 16.209 | 70.9% |
| shared-expert branch | 3.521 | 15.4% |
| `split_linear` | 1.049 | 4.6% |
| `merge_linear` | 1.047 | 4.6% |
| `ep_undispatch` | 0.292 | 1.3% |
| `ep_dispatch` | 0.271 | 1.2% |
| sequence-size exchange (removed here) | 0.228 | 1.0% |

Secondary layouts, same workload: SP2 removes 0.180 ms/layer; TP2 removes about 0 because the TP
path returns before the exchange, and its `merge_linear` reduction costs 0.202 ms/layer.

Two conclusions:

- The exchange removed here is **29% of all MoE-layer communication** at SP4 (0.228 of 0.792 ms), and
  it grows with world size (0.180 ms at SP2 to 0.228 ms at SP4), for a change that adds no new state
  and no new collective.
- Communication is **not** the MAGI-2 MoE bottleneck: all SP token collectives together are 2.5% of
  the layer, while local expert compute is 70.9%. That points at M2, not further M3 communication work.

### Negative result: shared/routed overlap is not worth it

The shared-expert branch depends only on `normalized`, not on the routed result, so it can legally run
while the dispatch collective is in flight. Measured with an async `all_to_all_single` and the shared
branch in the gap:

| Variant | SP4 ms/layer | SP2 ms/layer |
| --- | ---: | ---: |
| branches serialized (today) | 20.199 | 20.356 |
| branches overlapped (probe) | 20.192 | 20.353 |

The difference is +0.03% at SP4 and +0.01% at SP2, inside run-to-run spread, and it repeated across
runs. The dispatch is only 0.27 ms and the two branches contend for the same SMs, so there is nothing
meaningful to hide. Recommendation: **do not** restructure the layer for overlap on this hardware
class. Reported so the next contributor does not repeat the experiment.

### Compatibility

| Combination | Status |
| --- | --- |
| Resident SP4, BF16, no Cache-DiT | Validated end to end on the released checkpoint |
| SP2 | Covered by the two-GPU GPU regression |
| TP4, TP2SP2 | Covered by four-rank parity; unchanged code path |
| Direct `Magi2MultiHeadMoE` callers without split metadata | Collective fallback retained |
| Tensor-valued `cp_split_sizes` | Falls back to the legacy collective |
| I2VA | Bit-exact on the released checkpoint, deterministic mode |
| CFG parallelism, DLO, HSDP, Cache-DiT, regional compile, quantization | Not exercised |

Note for #7112: its regional-compile refactor calls `self.mlp.moe_mlp(routed)` directly, so whichever
lands second needs to forward the split metadata through that call.
