### PR TITLE
[Bugfix] Skip HWR store-size scans when no limit is configured

### DIFF
--- a/vllm_omni/host_weight_runtime/filesystem/store.py
+++ b/vllm_omni/host_weight_runtime/filesystem/store.py
@@ -1247,8 +1247,10 @@ class FilesystemHostWeightStore:
                     retryable=True,
                 )
             )
-        store_bytes = self._tree_bytes(self.root)
-        if policy.max_store_bytes is not None and store_bytes + additional_bytes > policy.max_store_bytes:
+        if (
+            policy.max_store_bytes is not None
+            and self._tree_bytes(self.root) + additional_bytes > policy.max_store_bytes
+        ):
             raise HostWeightError(
                 _failure(
                     ResolutionStage.CAPACITY,


### PR DESCRIPTION
## Purpose

Fixes #7129. Part of #7107.

Every HWR capacity check currently scans all store files even when `max_store_bytes` is unset and the resulting count is unused. Move that traversal into the existing total-limit condition so Python short-circuiting skips it under the unlimited policy. Per-artifact limits, minimum free space, configured total-byte accounting, and typed errors remain unchanged.

The sub-issue records motivation, goals/non-goals, use cases, and design. This is a one-condition correction with no new state or configuration. It does not remove stable lock files or implement strict concurrent reservations.

## Test Plan

Run the existing filesystem-store suite, including configured total limits, per-artifact/free-space limits, ENOSPC, domain policy, publication, lifecycle, and concurrent builds:

```bash
CUDA_VISIBLE_DEVICES='' VLLM_TARGET_DEVICE=cpu \
  /tmp/codex-pr6607-vllm028/bin/python -m pytest -n 0 -q \
  tests/host_weight_runtime/test_filesystem_store.py
```

No new test mirrors this single short-circuit condition. Source inspection establishes that the scan is unreachable when the total limit is unset; existing tests validate the preserved behavior.

**vLLM Version:** 0.28.0; Python 3.12.13; torch 2.13.0+cu129; safetensors 0.8.0.

**vLLM-Omni Commit:** based on `e8526cc552bb8aa7d84dc01b0a0d85c64ed4c6c0`.

## Test Result

- Filesystem-store CPU suite: **80 passed**.
- All applicable local pre-commit hooks and full precheck passed; `git diff --check` passed. Exact hook pins are used with an external config selecting installed Node v22.23.1 for markdownlint; repository hook configuration is unchanged.
- No accelerator workload or timing benchmark was run. The reporter's measurements are not used as independently verified speedup claims.
