### PR TITLE
[Misc] Add standalone safetensors retention diagnostic

### DIFF
--- a/benchmarks/host_weight_runtime/README.md
+++ b/benchmarks/host_weight_runtime/README.md
@@ -1,0 +1,49 @@
+# Host weight dependency memory diagnostic
+
+`safetensors_retention.py` isolates repeated CPU `get_tensor()` calls from
+access to one cached tensor view. It imports neither vLLM nor HWR and uses a
+synthetic 16-element float32 payload. HWR itself calls `get_tensor()` when
+acquiring a lease, then exposes cached views; this probe does not measure HWR
+requests or repeated lease acquisition.
+
+Run one mode per fresh process in the same Python environment and CPU affinity:
+
+```bash
+git rev-parse HEAD > revision.txt
+git status --short > working-tree.txt
+git diff > working-tree.patch
+# Select an allowed CPU from your process affinity; 0 is only an example.
+CUDA_VISIBLE_DEVICES='' taskset -c 0 timeout 120s python \
+  benchmarks/host_weight_runtime/safetensors_retention.py \
+  --mode get_tensor --iterations 10000 --sample-every 5000 > feasibility.json
+```
+
+For a comparison, run each mode twice in fresh processes with the same controls:
+
+```bash
+for repetition in 1 2; do
+  for mode in get_tensor reuse; do
+    CUDA_VISIBLE_DEVICES='' taskset -c 0 timeout 120s python \
+      benchmarks/host_weight_runtime/safetensors_retention.py \
+      --mode "$mode" > "$mode-$repetition.json"
+  done
+done
+```
+
+The diagnostic sets Torch to one CPU thread, warms up before the baseline,
+and reports preparation separately from timed loop work. Checkpoints run GC
+and report Linux private/anonymous memory, RSS, and open descriptors. It checks
+that transient tensor objects and the final cached view are released. Linux
+`/proc/self/smaps_rollup` must be readable; invalid arguments and missing proc
+support fail explicitly. Keep raw JSON and the repository snapshot with results.
+
+Compare the final loop sample with the warmed baseline, then inspect the closed
+sample. Private-memory growth after Python tensor objects disappear is evidence
+of retention in the dependency/allocator path, not proof of a leak's root cause.
+RSS can include file-backed pages; it is not a private-memory metric. Samples
+also include small diagnostic bookkeeping allocations. Do not assert a portable
+memory threshold or turn this synthetic loop into a per-request service estimate.
+
+Do not drop shared caches, trim allocators, or add serving-time GC to make the
+numbers look smaller. A dependency replacement or version change requires its
+own reproducible comparison and correctness/lifecycle validation.

--- a/benchmarks/host_weight_runtime/README.md
+++ b/benchmarks/host_weight_runtime/README.md
@@ -2,7 +2,11 @@
 
 `safetensors_retention.py` isolates repeated CPU `get_tensor()` calls from
 access to one cached tensor view. It imports neither vLLM nor HWR and uses a
-synthetic 16-element float32 payload. HWR itself calls `get_tensor()` when
+synthetic float32 payload controlled by `--tensor-elements` (default: 64).
+Tensor size can affect retention: a negative result for 16 elements does not
+rule out growth for 64 elements. The selected size is recorded in the JSON
+arguments and used for both file creation and the correctness check.
+HWR itself calls `get_tensor()` when
 acquiring a lease, then exposes cached views; this probe does not measure HWR
 requests or repeated lease acquisition.
 
@@ -18,14 +22,18 @@ CUDA_VISIBLE_DEVICES='' taskset -c 0 timeout 120s python \
   --mode get_tensor --iterations 10000 --sample-every 5000 > feasibility.json
 ```
 
-For a comparison, run each mode twice in fresh processes with the same controls:
+For a size comparison, run 16 and 64 elements twice each in fresh processes,
+with cached reuse as a control at both sizes:
 
 ```bash
 for repetition in 1 2; do
-  for mode in get_tensor reuse; do
-    CUDA_VISIBLE_DEVICES='' taskset -c 0 timeout 120s python \
-      benchmarks/host_weight_runtime/safetensors_retention.py \
-      --mode "$mode" > "$mode-$repetition.json"
+  for elements in 16 64; do
+    for mode in get_tensor reuse; do
+      CUDA_VISIBLE_DEVICES='' taskset -c 0 timeout 120s python \
+        benchmarks/host_weight_runtime/safetensors_retention.py \
+        --mode "$mode" --tensor-elements "$elements" \
+        > "$mode-$elements-$repetition.json"
+    done
   done
 done
 ```

--- a/benchmarks/host_weight_runtime/safetensors_retention.py
+++ b/benchmarks/host_weight_runtime/safetensors_retention.py
@@ -43,6 +43,9 @@ def sample(phase: str, iterations: int, loop_seconds: float) -> dict[str, object
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--mode", choices=("get_tensor", "reuse"), required=True)
+    parser.add_argument(
+        "--tensor-elements", type=positive_int, default=64, help="Number of float32 elements in the synthetic tensor"
+    )
     parser.add_argument("--iterations", type=positive_int, default=1_000_000)
     parser.add_argument("--sample-every", type=positive_int, default=100_000)
     parser.add_argument("--warmup", type=positive_int, default=1000)
@@ -61,10 +64,10 @@ def main() -> None:
     samples = [sample("before_file", 0, 0.0)]
     with tempfile.TemporaryDirectory(prefix="safetensors-retention-") as directory:
         path = Path(directory) / "synthetic.safetensors"
-        save_file({"weight": torch.arange(16, dtype=torch.float32)}, str(path))
+        save_file({"weight": torch.arange(args.tensor_elements, dtype=torch.float32)}, str(path))
         with safe_open(path, framework="pt", device="cpu") as reader:
             cached = reader.get_tensor("weight")
-            assert torch.equal(cached, torch.arange(16, dtype=torch.float32))
+            assert torch.equal(cached, torch.arange(args.tensor_elements, dtype=torch.float32))
             for _ in range(args.warmup):
                 tensor = reader.get_tensor("weight") if args.mode == "get_tensor" else cached
                 del tensor

--- a/benchmarks/host_weight_runtime/safetensors_retention.py
+++ b/benchmarks/host_weight_runtime/safetensors_retention.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Linux CPU diagnostic: repeated safetensors materialization versus view reuse."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+import platform
+import tempfile
+import time
+import weakref
+from pathlib import Path
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return parsed
+
+
+def sample(phase: str, iterations: int, loop_seconds: float) -> dict[str, object]:
+    gc.collect()
+    counters = {}
+    for line in Path("/proc/self/smaps_rollup").read_text().splitlines():
+        fields = line.split()
+        if len(fields) == 3 and fields[2] == "kB":
+            counters[fields[0].removesuffix(":")] = int(fields[1]) * 1024
+    return {
+        "phase": phase,
+        "iterations": iterations,
+        "loop_seconds": loop_seconds,
+        "rss_bytes": counters["Rss"],
+        "private_bytes": counters["Private_Clean"] + counters["Private_Dirty"],
+        "anonymous_bytes": counters["Anonymous"],
+        "fd_count": len(tuple(Path("/proc/self/fd").iterdir())),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=("get_tensor", "reuse"), required=True)
+    parser.add_argument("--iterations", type=positive_int, default=1_000_000)
+    parser.add_argument("--sample-every", type=positive_int, default=100_000)
+    parser.add_argument("--warmup", type=positive_int, default=1000)
+    args = parser.parse_args()
+    if not Path("/proc/self/smaps_rollup").is_file():
+        parser.error("requires Linux /proc/self/smaps_rollup")
+
+    preparation_start = time.monotonic()
+    import safetensors
+    import torch
+    from safetensors import safe_open
+    from safetensors.torch import save_file
+
+    torch.set_num_threads(1)
+    torch.set_num_interop_threads(1)
+    samples = [sample("before_file", 0, 0.0)]
+    with tempfile.TemporaryDirectory(prefix="safetensors-retention-") as directory:
+        path = Path(directory) / "synthetic.safetensors"
+        save_file({"weight": torch.arange(16, dtype=torch.float32)}, str(path))
+        with safe_open(path, framework="pt", device="cpu") as reader:
+            cached = reader.get_tensor("weight")
+            assert torch.equal(cached, torch.arange(16, dtype=torch.float32))
+            for _ in range(args.warmup):
+                tensor = reader.get_tensor("weight") if args.mode == "get_tensor" else cached
+                del tensor
+            samples.append(sample("baseline", 0, 0.0))
+            preparation_seconds = time.monotonic() - preparation_start
+            completed = 0
+            loop_seconds = 0.0
+            while completed < args.iterations:
+                count = min(args.sample_every, args.iterations - completed)
+                start = time.monotonic()
+                for _ in range(count):
+                    tensor = reader.get_tensor("weight") if args.mode == "get_tensor" else cached
+                last_tensor = weakref.ref(tensor)
+                del tensor
+                loop_seconds += time.monotonic() - start
+                completed += count
+                snapshot = sample("loop", completed, loop_seconds)
+                snapshot["last_tensor_alive"] = last_tensor() is not None
+                if args.mode == "get_tensor":
+                    assert last_tensor() is None, "diagnostic retained a transient tensor"
+                samples.append(snapshot)
+            del cached
+        del reader
+        samples.append(sample("closed", completed, loop_seconds))
+        assert last_tensor() is None, "last tensor survived reader/view teardown"
+
+    print(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "arguments": vars(args),
+                "python": platform.python_version(),
+                "torch": torch.__version__,
+                "safetensors": safetensors.__version__,
+                "kernel": platform.release(),
+                "hostname": platform.node(),
+                "pid": os.getpid(),
+                "cpu_affinity": sorted(os.sched_getaffinity(0)),
+                "torch_threads": torch.get_num_threads(),
+                "pythonmalloc": os.environ.get("PYTHONMALLOC", "default"),
+                "preparation_seconds": preparation_seconds,
+                "samples": samples,
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/design/feature/host_weight_runtime.md
+++ b/docs/design/feature/host_weight_runtime.md
@@ -42,6 +42,11 @@ V1 does not include:
 
 ## Motivation and use cases
 
+For investigating CPU memory retained by dependency tensor materialization,
+see the [standalone safetensors diagnostic](../../../benchmarks/host_weight_runtime/README.md).
+It distinguishes repeated dependency calls from reuse of cached views and does
+not establish per-request HWR leakage.
+
 Model loading can create the same final host representation repeatedly. This
 is especially expensive when loading performs checkpoint decoding, tensor
 renaming, TP slicing, quantization, packing, or scale construction before GPU

--- a/docs/design/feature/host_weight_runtime.md
+++ b/docs/design/feature/host_weight_runtime.md
@@ -43,7 +43,7 @@ V1 does not include:
 ## Motivation and use cases
 
 For investigating CPU memory retained by dependency tensor materialization,
-see the [standalone safetensors diagnostic](../../../benchmarks/host_weight_runtime/README.md).
+see the [standalone safetensors diagnostic](https://github.com/vllm-project/vllm-omni/blob/main/benchmarks/host_weight_runtime/README.md).
 It distinguishes repeated dependency calls from reuse of cached views and does
 not establish per-request HWR leakage.
 


### PR DESCRIPTION
## Purpose

Fixes #7143 (diagnostic scope). Part of #7107.

Add a standalone Linux CPU diagnostic for safetensors tensor-materialization retention. The synthetic float32 tensor size is configurable with `--tensor-elements`, defaults to 64, and is recorded in JSON. Both file creation and the correctness check use the same value. This exposes size-dependent behavior that a fixed 16-element probe misses.

Compare repeated `get_tensor()` calls with reuse of one cached view, without importing vLLM or HWR. Record warmed baselines, private/anonymous memory, RSS, descriptors, released-object checks, versions and CPU affinity as JSON; separate preparation from loop timing. Document a 16-versus-64 size comparison with cached reuse as a control at both sizes.

HWR acquires views at lease startup and exposes cached tensors afterward, so this synthetic loop cannot establish per-request HWR leakage. No runtime or dependency behavior changes.

## Test Plan

Primary variable: 16 versus 64 float32 elements, compared within each mode. Controls: CPU 0 affinity, one Torch thread, default allocator, identical environment, 1,000 warmup operations, one million measured operations, samples every 100,000. No shared-cache manipulation or accelerator work. Run one 10,000-operation feasibility probe, then two additional fresh-process measured repetitions for each size/mode pair (eight runs); exclude feasibility from comparisons.

```bash
CUDA_VISIBLE_DEVICES='' taskset -c 0 timeout 120s \
  /tmp/codex-pr6607-vllm028/bin/python \
  benchmarks/host_weight_runtime/safetensors_retention.py \
  --mode get_tensor --tensor-elements 64
# Repeat twice per size (16, 64) and mode (get_tensor, reuse).
```

**Versions:** Python 3.12.13, torch 2.13.0+cu129, safetensors 0.8.0; Linux 5.10.134-16.103.al8.x86_64. PR base is vLLM-Omni `039808e0d97d7969a2cb102d074c1e45b8ceef0b`; validated code is `743953b821e5352f3958c781811d53c28702584b` (the frozen tensor-size patch). Script bytes and working diff were frozen across all eight runs; this probe does not import vLLM.

## Test Result

Private-memory growth from warmed baseline to final loop sample (MiB):

| Tensor elements | Mode | Run 1 | Run 2 |
| --- | --- | --- | --- |
| 16 | `get_tensor` | 0.031250 | 0.039062 |
| 16 | `reuse` | 0.027344 | 0.023438 |
| 64 | `get_tensor` | 30.664062 | 30.656250 |
| 64 | `reuse` | 0.023438 | 0.023438 |

- **The reported ~30.66 MiB growth reproduces with 64 elements.** The two runs differ by 8 KiB; 30.660–30.668 MiB remains after closing the reader and deleting views. Anonymous-memory deltas match private-memory deltas. The earlier 16-element negative result does not generalize to other tensor sizes.
- All transient/final tensor weak-reference checks passed, and descriptor counts remained at four. This narrows the observation to size-dependent dependency/allocator retention; it does not identify its root cause or prove per-request HWR leakage.
- Default 64-element feasibility, both sizes/modes and invalid tensor sizes (zero, negative, nonnumeric) were checked. All applicable local gates and full precheck pass. The mypy wrapper has no benchmark targets; no claim of benchmark type coverage.
- Raw JSON, exact commands, script hash and working diff are preserved locally with the task artifacts. No GPU, inference, throughput improvement, memory fix or automatic leak verdict is claimed.
