### PR TITLE
[Bugfix][Engine] Share a deadline across correlated RPC submission and result waiting

### DIFF
--- a/docs/design/module/engine_orchestration.md
+++ b/docs/design/module/engine_orchestration.md
@@ -130,6 +130,21 @@ physical EngineCore abort succeeds.
 Changes that cross into stage runtime or public error behavior require review
 from that contract's owners.
 
+### Correlated control RPC timeouts
+
+`CorrelatedRpcClient.execute` uses a single monotonic timeout budget for
+blocking request submission and waiting for the correlated result. A full
+request queue that exhausts this budget raises the caller's `TimeoutError`;
+successful submission leaves only the remaining budget for the result.
+`timeout=None` keeps both waits unbounded. Negative timeouts are rejected
+before submission, while zero permits only immediately available operations.
+Non-blocking submission still raises `queue.Full` immediately when full.
+
+A local timeout unregisters the result waiter; it does not cancel work already
+submitted to the orchestrator. Late results are still discarded by correlation
+ID. This deadline does not change data-request admission, CFG companion
+grouping, or the orchestrator's queue ownership.
+
 ## Promotion gate
 
 - Reconcile current names and boundaries after #5441 merges, closes, or is

--- a/tests/engine/test_async_omni_engine_abort_ack.py
+++ b/tests/engine/test_async_omni_engine_abort_ack.py
@@ -190,7 +190,7 @@ def test_abort_async_tolerates_request_queue_close_during_shutdown(
     engine._shutdown_called = False
 
     class ClosingRequestQueue:
-        def put(self, item) -> None:
+        def put(self, item, block=True, timeout=None) -> None:
             del item
             engine._shutdown_called = True
             raise SyntheticSyncQueueShutDownError
@@ -216,7 +216,7 @@ def test_abort_async_surfaces_request_queue_close_while_engine_is_live(
         pass
 
     class ClosedRequestQueue:
-        def put(self, item) -> None:
+        def put(self, item, block=True, timeout=None) -> None:
             del item
             raise SyntheticSyncQueueShutDownError
 

--- a/tests/engine/test_correlated_rpc_client.py
+++ b/tests/engine/test_correlated_rpc_client.py
@@ -1,13 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from __future__ import annotations
 
 import queue
+from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 
+import janus
 import pytest
 
+from vllm_omni.engine import rpc_result_router
 from vllm_omni.engine.messages import (
     CollectiveRPCRequestMessage,
     CollectiveRPCResultMessage,
@@ -16,6 +19,18 @@ from vllm_omni.engine.messages import (
 from vllm_omni.engine.rpc_result_router import CorrelatedRpcClient
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+@pytest.fixture(params=["stdlib", "janus"])
+def bounded_request_queue(request: pytest.FixtureRequest) -> Iterator:
+    if request.param == "stdlib":
+        yield queue.Queue(maxsize=1)
+    else:
+        transport: janus.Queue = janus.Queue(maxsize=1)
+        try:
+            yield transport.sync_q
+        finally:
+            transport.close()
 
 
 def _request(rpc_id: str) -> CollectiveRPCRequestMessage:
@@ -69,6 +84,142 @@ def test_correlated_rpc_client_unregisters_timeout_before_late_result() -> None:
 
         assert isinstance(current, CollectiveRPCResultMessage)
         assert current.results == ["current"]
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize("timeout", [0.0, 0.01])
+def test_blocking_submission_times_out_when_queue_is_full(bounded_request_queue, monkeypatch, timeout: float) -> None:
+    queued = _request("already-queued")
+    bounded_request_queue.put_nowait(queued)
+    client = CorrelatedRpcClient(bounded_request_queue, queue.Queue())
+    original_put = bounded_request_queue.put
+
+    def bounded_put(item, block=True, timeout=None):
+        # Fail on an unbounded call instead of hanging the regression suite.
+        assert timeout is not None, "blocking submission must receive the RPC timeout"
+        return original_put(item, block=block, timeout=timeout)
+
+    monkeypatch.setattr(bounded_request_queue, "put", bounded_put)
+    key = ("collective", "timed-out")
+    try:
+        with pytest.raises(TimeoutError, match="submission timed out") as error:
+            client.execute(
+                key,
+                _request("timed-out"),
+                timeout=timeout,
+                timeout_message="submission timed out",
+                block_on_submit=True,
+            )
+        assert isinstance(error.value.__cause__, queue.Full)
+        assert bounded_request_queue.get_nowait() is queued
+        assert bounded_request_queue.empty()
+        assert key not in client._router._pending
+    finally:
+        client.close()
+
+
+def test_nonblocking_submission_preserves_queue_full(bounded_request_queue) -> None:
+    bounded_request_queue.put_nowait(_request("already-queued"))
+    client = CorrelatedRpcClient(bounded_request_queue, queue.Queue())
+    key = ("collective", "not-submitted")
+    try:
+        with pytest.raises(queue.Full):
+            client.execute(key, _request("not-submitted"), timeout=1, timeout_message="unexpected timeout")
+        assert key not in client._router._pending
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize("block_on_submit", [False, True])
+def test_negative_timeout_is_rejected_before_submission(bounded_request_queue, block_on_submit: bool) -> None:
+    client = CorrelatedRpcClient(bounded_request_queue, queue.Queue())
+    key = ("collective", "invalid-timeout")
+    try:
+        with pytest.raises(ValueError, match="non-negative"):
+            client.execute(
+                key,
+                _request("invalid-timeout"),
+                timeout=-1,
+                timeout_message="unexpected timeout",
+                block_on_submit=block_on_submit,
+            )
+        assert bounded_request_queue.empty()
+        assert key not in client._router._pending
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize("finished_at, remaining", [(107.0, 3.0), (110.0, 0.0), (112.0, 0.0)])
+def test_submission_and_result_wait_share_one_deadline(bounded_request_queue, mocker, finished_at, remaining) -> None:
+    client = CorrelatedRpcClient(bounded_request_queue, queue.Queue())
+    waiter: queue.Queue = queue.Queue()
+    expected = CollectiveRPCResultMessage(rpc_id="budget", method="health", stage_ids=[0], results=["ok"])
+    waiter.put_nowait(expected)
+    mocker.patch.object(client._router, "register", return_value=waiter)
+    mocker.patch.object(rpc_result_router, "monotonic", side_effect=[100.0, 102.0, finished_at], create=True)
+    submit = mocker.spy(bounded_request_queue, "put")
+    receive = mocker.spy(waiter, "get")
+    message = _request("budget")
+    try:
+        assert (
+            client.execute(
+                ("collective", "budget"),
+                message,
+                timeout=10,
+                timeout_message="budget exhausted",
+                block_on_submit=True,
+            )
+            is expected
+        )
+        submit.assert_called_once_with(message, timeout=8.0)
+        receive.assert_called_once_with(timeout=remaining)
+    finally:
+        client.close()
+
+
+def test_blocking_submission_without_deadline_still_receives_ack(bounded_request_queue) -> None:
+    result_queue: queue.Queue = queue.Queue()
+    client = CorrelatedRpcClient(bounded_request_queue, result_queue)
+    expected = CollectiveRPCResultMessage(rpc_id="unbounded", method="health", stage_ids=[0], results=["ok"])
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            pending = executor.submit(
+                client.execute,
+                ("collective", "unbounded"),
+                _request("unbounded"),
+                timeout=None,
+                timeout_message="unexpected timeout",
+                block_on_submit=True,
+            )
+            try:
+                assert bounded_request_queue.get(timeout=1).rpc_id == "unbounded"
+                result_queue.put_nowait(expected)
+                assert pending.result(timeout=1) is expected
+            finally:
+                client.close()
+    finally:
+        client.close()
+
+
+def test_submission_transport_error_is_preserved(bounded_request_queue, monkeypatch) -> None:
+    client = CorrelatedRpcClient(bounded_request_queue, queue.Queue())
+    key = ("collective", "transport-error")
+
+    def failed_put(*args, **kwargs):
+        raise RuntimeError("transport closed")
+
+    monkeypatch.setattr(bounded_request_queue, "put", failed_put)
+    try:
+        with pytest.raises(RuntimeError, match="transport closed"):
+            client.execute(
+                key,
+                _request("transport-error"),
+                timeout=1,
+                timeout_message="unexpected timeout",
+                block_on_submit=True,
+            )
+        assert key not in client._router._pending
     finally:
         client.close()
 

--- a/vllm_omni/engine/rpc_result_router.py
+++ b/vllm_omni/engine/rpc_result_router.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from __future__ import annotations
 
 import queue
 import threading
+from time import monotonic
 from typing import TypeAlias
 
 from vllm.logger import init_logger
@@ -133,14 +134,26 @@ class CorrelatedRpcClient:
         timeout_message: str,
         block_on_submit: bool = False,
     ) -> EngineQueueMessage:
+        """Share one timeout budget across submission and result waiting.
+
+        A timeout does not cancel a request that was already submitted.
+        """
+        if timeout is not None and timeout < 0:
+            raise ValueError("'timeout' must be a non-negative number")
+        deadline = None if timeout is None else monotonic() + timeout
         waiter = self._router.register(key)
         try:
             if block_on_submit:
-                self._request_queue.put(message)
+                submit_timeout = None if deadline is None else max(0.0, deadline - monotonic())
+                try:
+                    self._request_queue.put(message, timeout=submit_timeout)
+                except queue.Full as exc:
+                    raise TimeoutError(timeout_message) from exc
             else:
                 self._request_queue.put_nowait(message)
+            result_timeout = None if deadline is None else max(0.0, deadline - monotonic())
             try:
-                result = waiter.get(timeout=timeout)
+                result = waiter.get(timeout=result_timeout)
             except queue.Empty as exc:
                 raise TimeoutError(timeout_message) from exc
             if isinstance(result, ErrorMessage):


### PR DESCRIPTION
## Purpose

### What broke

A finite timeout passed to `CorrelatedRpcClient.execute(..., block_on_submit=True)` does not bound waiting for request-queue capacity. After submission, result waiting receives the original full budget. This affects the shared client used by acknowledged abort and collective control RPCs.

### Root cause

Blocking submission calls `put(message)` without a timeout, and acknowledgement waiting starts a fresh `get(timeout=timeout)`.

### Fix

- Compute one monotonic deadline and use remaining time for both waits.
- Convert only blocking-submit `queue.Full` into the existing caller-provided `TimeoutError`; preserve fail-fast nonblocking `queue.Full` and transport failures.
- Keep `timeout=None` unbounded and zero non-waiting. Reject negative values with `ValueError` before registration/submission instead of enqueuing before validation.
- Preserve waiter cleanup and correlation. Align two closing-queue test doubles with the standard queue interface.
- Document that local timeout does **not** revoke already-submitted work.

## Test Plan

### Reproduction

On base `af74a5a1551e3b809f7d5cddfbba070deb4bb298`, apply the test-only hunks of this candidate, then run:

```bash
cd tests
pytest -sv engine/test_correlated_rpc_client.py -m "core_model and cpu" --run-level core_model
```

The final test file gives **14 failed / 8 passed** on the original production code and **22 passed** with this patch. Full-queue tests explicitly reject an unbounded submit before delegating to the real queue, so the regression suite cannot hang on baseline. Shared-budget tests use a controlled monotonic clock; this is not a timing benchmark.

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** af74a5a1551e3b809f7d5cddfbba070deb4bb298 (base plus this candidate)

## Test Result

Related CPU regression: **68 passed / 1 deselected**, including router, acknowledged abort, engine outputs, duplex control, and stage-pool collective RPC tests. All applicable changed-file pre-commit hooks (including mypy 3.10) and manual mypy 3.12 passed. Existing Simple Engine&Entrypoints Buildkite collection covers the tests; no pipeline edit.

Environment: Python 3.12.3, torch 2.11.0+cpu, vLLM 0.28.0, Janus 2.0.0, transformers 5.14.1, pytest 9.1.1. A local WSL adapter selects CPU and disables NVML discovery only. No GPU/model inference, remote CI, or Janus 1.x execution claim.

This does not change data-queue admission, sync fire-and-forget abort, CFG grouping, or Janus loop ownership; it does not resolve the full #4855 queue-reliability design. It also does not bound executor scheduling before this client starts or cancel remote work after local timeout.

AI-assisted implementation and verification, with contributor review and a personal DCO sign-off in commit `7815bdca791af49bd11a923ae65d57ae8b2ca607`.

The signed tree was rechecked on 2026-09-06: **68 passed / 1 deselected / 15 warnings** in the related CPU run, and all applicable four-file pre-commit gates passed again. The earlier focused 22 tests are included in the 68, not additional. No new dependency or GPU test requirement is introduced by this patch.
