### PR TITLE
[Model] Skip unused frame packing in Wan2.2 S2V

### DIFF
--- a/vllm_omni/diffusion/models/wan2_2/wan2_2_s2v_transformer.py
+++ b/vllm_omni/diffusion/models/wan2_2/wan2_2_s2v_transformer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """
 Wan2.2 Speech-to-Video (S2V) Transformer using vllm-omni ops.
 
@@ -1359,11 +1359,9 @@ class WanS2VTransformer3DModel(nn.Module):
         return flatten_mot, mot_remb
 
     def process_motion_frame_pack(self, motion_latents, drop_motion_frames=False, add_last_motion=2):
-        flatten_mot, mot_remb = self.frame_packer(motion_latents, add_last_motion)
         if drop_motion_frames:
-            return [m[:, :0] for m in flatten_mot], [m[:, :0] for m in mot_remb]
-        else:
-            return flatten_mot, mot_remb
+            return [], []
+        return self.frame_packer(motion_latents, add_last_motion)
 
     def process_motion_transformer_motioner(self, motion_latents, drop_motion_frames=False, add_last_motion=True):
         batch_size = motion_latents.shape[0]


### PR DESCRIPTION
## Purpose

Wan2.2 S2V enables FramePack, but the first clip uses `drop_motion_frames=True`. The current path still runs all three FramePack projections and builds motion RoPE, slices every result to zero length, and then enters no-op concatenations in `inject_motion`.

Return empty motion lists before calling FramePack when those frames will be dropped. This follows the existing non-FramePack drop path and leaves the Motioner path unchanged because that path retains zero-valued motion tokens.

## Test Plan

- Run Ruff, Python syntax, SPDX, forbidden-import, and direct `torch.cuda` checks on the changed file
- Run `pytest -q tests/diffusion/models/wan2_2/test_wan22_s2v_pipeline.py`
- Compare the old and new drop paths on an H200 with the official 720x1280 FramePack dimensions and exact tensor-output checks

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** parent `ff6e906a25de1ca3122c0d0d5250fde5a0ddbc7b`, candidate `aef6af17ef36ab409dfe7b7a6a398b91283dae5b`

## Test Result

- Changed-file checks: passed; the file was already Ruff-formatted
- S2V CPU tests: `17 passed, 18 warnings in 21.73s`
- H200 targeted forward: exact output match; FramePack calls `1 -> 0`
- H200 drop-path component benchmark, BF16 motion `[1, 16, 19, 90, 160]`, main sequence `[1, 75600, 5120]`, 10 warmups and 30 symmetrically interleaved measurements per arm:
  - median latency: `3.861 ms -> 0.0098 ms` (`-3.851 ms` per call)
  - P20-P80 latency: `3.845-3.884 ms -> 0.0079-0.0106 ms`
  - peak extra allocated memory: `831.17 MiB -> 0`

These are `inject_motion` drop-path component measurements, not full-model end-to-end latency.
