### PR TITLE
Add MAGI-2 Preview support and MUSA optimizations

### DIFF
--- a/tests/diffusion/models/magi2/test_owned_w13.py
+++ b/tests/diffusion/models/magi2/test_owned_w13.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.models.magi2.mh_moe import (
+    Magi2MultiHeadMoE,
+    Magi2MultiHeadMoEConfig,
+)
+from vllm_omni.diffusion.models.magi2.parallel import Magi2ParallelGroup
+
+pytestmark = [pytest.mark.diffusion, pytest.mark.core_model, pytest.mark.cpu]
+
+
+def make_module():
+    module = Magi2MultiHeadMoE(
+        Magi2MultiHeadMoEConfig(32, 2, 7, 2, 24, torch.bfloat16),
+        ep_group=Magi2ParallelGroup(None, 1, 0),
+    )
+    with torch.no_grad():
+        for parameter in module.parameters():
+            parameter.uniform_(-1, 1)
+    return module
+
+
+def test_values_storage_identity_and_checkpoint():
+    module = make_module()
+    gate, up = module.W_gate.clone(), module.W_up.clone()
+    identities = id(module.W_gate), id(module.W_up)
+    keys = set(module.state_dict())
+    module.prepare_owned_w13()
+    assert identities == (id(module.W_gate), id(module.W_up))
+    assert keys == set(module.state_dict())
+    assert torch.equal(module.W_gate, gate)
+    assert torch.equal(module.W_up, up)
+    packed = module._get_owned_w13()
+    expected = torch.stack((gate.transpose(1, 2), up.transpose(1, 2)), dim=2).flatten(1, 2)
+    assert torch.equal(packed, expected)
+    assert module.W_gate.untyped_storage().data_ptr() == module.W_up.untyped_storage().data_ptr()
+    assert packed.untyped_storage().nbytes() == (gate.numel() + up.numel()) * gate.element_size()
+    module.prepare_owned_w13()
+    assert module._get_owned_w13() is packed
+
+
+def test_inplace_update_and_replacement():
+    module = make_module()
+    module.prepare_owned_w13()
+    with torch.no_grad():
+        module.W_gate.fill_(3)
+    assert torch.all(module._get_owned_w13()[:, 0::2] == 3)
+    module.W_gate.data = module.W_gate.clone().contiguous()
+    assert module._get_owned_w13() is None
+    module.prepare_owned_w13()
+    assert torch.all(module._get_owned_w13()[:, 0::2] == 3)
+
+
+def test_device_dtype_conversion_invalidates_alias():
+    module = make_module()
+    module.prepare_owned_w13()
+    module.float()
+    assert module._get_owned_w13() is None
+    with pytest.raises(ValueError, match="BF16"):
+        module.prepare_owned_w13()
+
+
+def test_checkpoint_reload_updates_views():
+    module = make_module()
+    other = make_module()
+    module.prepare_owned_w13()
+    module.load_state_dict(other.state_dict())
+    assert module._get_owned_w13() is not None
+    assert torch.equal(module.W_gate, other.W_gate)
+    assert torch.equal(module.W_up, other.W_up)
+
+
+def test_owned_w2_layout_and_values():
+    module = make_module()
+    down = module.W_down.clone()
+    module.prepare_owned_w2()
+    assert torch.equal(module._get_owned_w2(), down.transpose(1, 2))
+    assert torch.equal(module.W_down, down)
+    assert module._get_owned_w2().is_contiguous()
+    module.prepare_owned_w2()

--- a/tests/diffusion/models/magi2/test_swiglu7.py
+++ b/tests/diffusion/models/magi2/test_swiglu7.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+import os
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.models.magi2.layers import MHCHandler, swiglu7
+
+pytestmark = [pytest.mark.diffusion, pytest.mark.core_model]
+
+
+@pytest.mark.cpu
+def test_mhc_coefficient_fusion_preserves_cpu_reference_and_strides(monkeypatch):
+    torch.manual_seed(29)
+    handler = MHCHandler(4, 2560)
+    packed = torch.randn(5, 24, dtype=torch.float32)
+    post_logits = packed[:, 4:8]
+    residual_logits = packed[:, 8:].reshape(5, 4, 4)
+    post = (
+        torch.tensor([1.3]),
+        torch.randn(4),
+        post_logits,
+    )
+    residual = (
+        torch.tensor([0.8]),
+        torch.randn(4, 4),
+        residual_logits,
+    )
+    assert post_logits.stride(0) == 24
+    assert residual_logits.stride(0) == 24
+    monkeypatch.setenv("MAGI2_FUSED_MHC_COEFFICIENTS", "0")
+    expected = handler.compute_post_residual(post, residual, out_dtype=torch.bfloat16)
+    monkeypatch.setenv("MAGI2_FUSED_MHC_COEFFICIENTS", "1")
+    actual = handler.compute_post_residual(post, residual, out_dtype=torch.bfloat16)
+    torch.testing.assert_close(actual[0], expected[0], rtol=0, atol=0)
+    torch.testing.assert_close(actual[1], expected[1], rtol=0, atol=0)
+
+
+@pytest.mark.cpu
+def test_fused_swiglu7_keeps_cpu_fallback(monkeypatch):
+    torch.manual_seed(17)
+    x = torch.randn(9, 32, dtype=torch.bfloat16)
+    monkeypatch.setenv("MAGI2_USE_FUSED_SWIGLU7", "0")
+    expected = swiglu7(x)
+    monkeypatch.setenv("MAGI2_USE_FUSED_SWIGLU7", "1")
+    torch.testing.assert_close(swiglu7(x), expected, rtol=0, atol=0)
+
+
+@pytest.mark.cpu
+def test_fused_swiglu7_empty_and_odd_inputs_fall_back_safely(monkeypatch):
+    monkeypatch.setenv("MAGI2_USE_FUSED_SWIGLU7", "1")
+    empty = torch.empty(0, 2560, dtype=torch.bfloat16)
+    torch.testing.assert_close(swiglu7(empty), torch.empty(0, 1280, dtype=torch.bfloat16))
+    with pytest.raises(RuntimeError):
+        swiglu7(torch.empty(3, 7, dtype=torch.bfloat16))
+
+
+@pytest.mark.cpu
+def test_fused_swiglu7_boundary_values_use_reference_contract(monkeypatch):
+    values = torch.tensor(
+        [
+            -float("inf"),
+            -8.0,
+            -7.0,
+            -0.0,
+            0.0,
+            7.0,
+            8.0,
+            float("inf"),
+            float("nan"),
+        ],
+        dtype=torch.float32,
+    )
+    x = torch.stack((values, values.flip(0)), dim=-1).reshape(1, -1)
+    monkeypatch.setenv("MAGI2_USE_FUSED_SWIGLU7", "0")
+    output = swiglu7(x)
+    assert torch.isnan(output).any()
+    assert torch.isinf(output).logical_not().all()
+
+
+@pytest.mark.parametrize("shape", [(33, 2560), (3, 16384), (3, 21840), (2, 514)])
+@pytest.mark.musa
+@pytest.mark.skipif(
+    not (hasattr(torch.version, "musa") and torch.version.musa is not None),
+    reason="requires MUSA",
+)
+def test_fused_swiglu7_matches_reference_on_musa(monkeypatch, shape):
+    visible = os.environ.get("MUSA_VISIBLE_DEVICES")
+    if visible:
+        assert os.environ.get("CUDA_VISIBLE_DEVICES") == visible
+    torch.musa.set_device(0)
+    torch.manual_seed(23)
+    x = torch.randn(*shape, device="musa", dtype=torch.bfloat16)
+    monkeypatch.setenv("MAGI2_USE_FUSED_SWIGLU7", "0")
+    expected = swiglu7(x)
+    monkeypatch.setenv("MAGI2_USE_FUSED_SWIGLU7", "1")
+    actual = swiglu7(x)
+    torch.musa.synchronize()
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch.version, "musa") and torch.version.musa is not None),
+    reason="requires MUSA",
+)
+@pytest.mark.musa
+def test_fused_swiglu7_matches_boundary_nan_mask_on_musa(monkeypatch):
+    torch.musa.set_device(0)
+    values = torch.tensor(
+        [
+            -float("inf"),
+            -8.0,
+            -7.0,
+            -0.0,
+            0.0,
+            7.0,
+            8.0,
+            float("inf"),
+            float("nan"),
+        ],
+        device="musa",
+        dtype=torch.bfloat16,
+    )
+    x = torch.stack((values, values.flip(0)), dim=-1).reshape(1, -1)
+    monkeypatch.setenv("MAGI2_USE_FUSED_SWIGLU7", "0")
+    expected = swiglu7(x)
+    monkeypatch.setenv("MAGI2_USE_FUSED_SWIGLU7", "1")
+    actual = swiglu7(x)
+    torch.musa.synchronize()
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0, equal_nan=True)

--- a/vllm_omni/diffusion/attention/backends/utils/fa.py
+++ b/vllm_omni/diffusion/attention/backends/utils/fa.py
@@ -249,6 +249,55 @@ def vllm_flash_attn_varlen_with_lse(
     return out, lse
 
 
+def flash_attn_3_varlen(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    softcap: float = 0.0,
+    sinks: torch.Tensor | None = None,
+    deterministic: bool = False,
+) -> torch.Tensor | None:
+    """Run an optional FlashAttention-3 varlen backend without LSE.
+
+    This adapter is backend-neutral: MATE/FlashAttention-3 builds on MUSA or
+    CUDA may provide either ``flash_attn_3.interface`` or the compatibility
+    ``flash_attn_interface`` module.  Callers needing log-sum-exp should keep
+    using :func:`vllm_flash_attn_varlen_with_lse`, whose return contract is
+    intentionally different.
+    """
+    try:
+        from flash_attn_3.interface import flash_attn_varlen_func
+    except (ImportError, ModuleNotFoundError):
+        try:
+            from flash_attn_interface import flash_attn_varlen_func
+        except (ImportError, ModuleNotFoundError):
+            return None
+    result = flash_attn_varlen_func(
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        softmax_scale=q.shape[-1] ** -0.5,
+        causal=False,
+        softcap=max(0.0, softcap),
+        deterministic=deterministic,
+        return_softmax_lse=False,
+        sinks=sinks,
+    )
+    out = result[0] if isinstance(result, tuple) else result
+    if not isinstance(out, torch.Tensor):
+        raise TypeError(f"FlashAttention-3 returned unsupported type {type(out)!r}")
+    return out
+
+
 @lru_cache(maxsize=1)
 def is_flash_attn_installed() -> bool:
     """Return whether a Flash Attention backend package is importable.

--- a/vllm_omni/diffusion/models/magi2/attention.py
+++ b/vllm_omni/diffusion/models/magi2/attention.py
@@ -22,9 +22,11 @@ import torch.nn as nn
 
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.backends.utils.fa import (
+    flash_attn_3_varlen,
     resolve_vllm_flash_attn_version,
     vllm_flash_attn_varlen_with_lse,
 )
+from vllm_omni.platforms import current_omni_platform
 
 from .parallel import (
     Magi2ParallelGroup,
@@ -44,6 +46,40 @@ def _resolve_flash_attn_version() -> int:
     version = resolve_vllm_flash_attn_version(requested)
     logger.info("MAGI-2 selected FlashAttention %d", version)
     return version
+
+
+def _magi2_mate_flash_attn_varlen(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    softcap: float,
+    sink: torch.Tensor | None,
+) -> torch.Tensor | None:
+    if os.environ.get("MAGI2_USE_MATE_FA", "1") != "1":
+        return None
+    if sink is not None and sink.shape[0] != 1:
+        logger.warning("FlashAttention-3 sink adapter supports one sink token; using Torch fallback")
+        return None
+    sinks = None if sink is None else sink[0].to(device=q.device, dtype=q.dtype).contiguous()
+    return flash_attn_3_varlen(
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        softmax_scale=q.shape[-1] ** -0.5,
+        causal=False,
+        softcap=max(0.0, softcap),
+        sinks=sinks,
+        deterministic=os.environ.get("MAGI2_DETERMINISTIC", "0") == "1",
+    )
 
 
 @dataclass(frozen=True)
@@ -93,6 +129,22 @@ def apply_rotary_emb(
     rotary_dim = cos.shape[-1] * 2
     if rotary_dim > x.shape[-1]:
         raise ValueError(f"RoPE dimension {rotary_dim} exceeds head dimension {x.shape[-1]}")
+    # MAGI-2 uses the released non-interleaved layout.  Avoid materializing
+    # duplicated cosine/sine tables and the temporary rotate_half tensor on
+    # MUSA; the arithmetic order remains the same pairwise rotation.
+    if (
+        not interleaved
+        # This pairwise MUSA path is numerically equivalent and is the
+        # validated performance default; set MAGI2_FAST_ROPE=0 to roll back.
+        and os.environ.get("MAGI2_FAST_ROPE", "1") == "1"
+        and x.device.type in {"musa", "privateuseone"}
+    ):
+        cos = cos.to(dtype=x.dtype).unsqueeze(-2)
+        sin = sin.to(dtype=x.dtype).unsqueeze(-2)
+        x_rot = x[..., :rotary_dim]
+        x1, x2 = x_rot.chunk(2, dim=-1)
+        rotated = torch.cat((x1 * cos - x2 * sin, x2 * cos + x1 * sin), dim=-1)
+        return torch.cat((rotated, x[..., rotary_dim:]), dim=-1)
     if interleaved:
         cos = cos.unsqueeze(-2).repeat_interleave(2, dim=-1)
         sin = sin.unsqueeze(-2).repeat_interleave(2, dim=-1)
@@ -160,21 +212,34 @@ def torch_varlen_attention_with_sink(
         raise ValueError("query and key cumulative-length arrays must contain the same batch count")
     output = torch.empty_like(q)
     scale = q.shape[-1] ** -0.5
+    # Materializing a full [heads, q_tokens, k_tokens] score tensor is
+    # prohibitive for MAGI-2 at 272p/540p on the MUSA Torch fallback. Process
+    # query rows in chunks instead; each row's softmax is independent, so this
+    # is numerically equivalent up to the reduction order. Tune for available
+    # workspace with MAGI2_TORCH_ATTN_Q_CHUNK (512 is a conservative default).
+    try:
+        q_chunk_size = max(1, int(os.environ.get("MAGI2_TORCH_ATTN_Q_CHUNK", "512")))
+    except ValueError:
+        q_chunk_size = 512
     for batch_idx in range(cu_seqlens_q.numel() - 1):
         q_start, q_end = (int(v) for v in cu_seqlens_q[batch_idx : batch_idx + 2].tolist())
         k_start, k_end = (int(v) for v in cu_seqlens_k[batch_idx : batch_idx + 2].tolist())
         q_part = q[q_start:q_end].float()
         k_part = _repeat_kv_heads(k[k_start:k_end], q.shape[1]).float()
         v_part = _repeat_kv_heads(v[k_start:k_end], q.shape[1]).float()
-        scores = torch.einsum("qhd,khd->hqk", q_part, k_part) * scale
-        if softcap > 0:
-            scores = softcap * torch.tanh(scores / softcap)
-        if sink is not None and sink.numel() > 0:
-            sink_scores = sink.float().transpose(0, 1).unsqueeze(1).expand(-1, q_part.shape[0], -1)
-            probabilities = torch.softmax(torch.cat((scores, sink_scores), dim=-1), dim=-1)[..., : k_part.shape[0]]
-        else:
-            probabilities = torch.softmax(scores, dim=-1)
-        output[q_start:q_end] = torch.einsum("hqk,khd->qhd", probabilities, v_part).to(output.dtype)
+        for q_offset in range(0, q_part.shape[0], q_chunk_size):
+            q_chunk = q_part[q_offset : q_offset + q_chunk_size]
+            scores = torch.einsum("qhd,khd->hqk", q_chunk, k_part) * scale
+            if softcap > 0:
+                scores = softcap * torch.tanh(scores / softcap)
+            if sink is not None and sink.numel() > 0:
+                sink_scores = sink.float().transpose(0, 1).unsqueeze(1).expand(-1, q_chunk.shape[0], -1)
+                probabilities = torch.softmax(torch.cat((scores, sink_scores), dim=-1), dim=-1)[..., : k_part.shape[0]]
+            else:
+                probabilities = torch.softmax(scores, dim=-1)
+            output[q_start + q_offset : q_start + q_offset + q_chunk.shape[0]] = torch.einsum(
+                "hqk,khd->qhd", probabilities, v_part
+            ).to(output.dtype)
     return output
 
 
@@ -192,7 +257,10 @@ def packed_attention_with_sink(
     cu_q, cu_k, max_q, max_k = varlen.resolved(q.shape[0], k.shape[0])
     cu_q = cu_q.to(device=q.device, dtype=torch.int32).contiguous()
     cu_k = cu_k.to(device=q.device, dtype=torch.int32).contiguous()
-    if q.is_cuda:
+    # The bundled vLLM FlashAttention extension is CUDA-only. MUSA keeps the
+    # exact Torch reference path until a MATE/FA3 adapter is explicitly
+    # selected and validated on the target runtime.
+    if current_omni_platform.is_cuda() and q.device.type == "cuda":
         out, lse = vllm_flash_attn_varlen_with_lse(
             q,
             k,
@@ -206,6 +274,25 @@ def packed_attention_with_sink(
             fa_version=_resolve_flash_attn_version(),
         )
         return correct_out_lse_with_sink(out, lse, sink)[0]
+    is_musa_tensor = bool(getattr(q, "is_musa", False)) or q.device.type == "musa"
+    if current_omni_platform.is_musa() and is_musa_tensor:
+        try:
+            mate_out = _magi2_mate_flash_attn_varlen(
+                q,
+                k,
+                v,
+                cu_seqlens_q=cu_q,
+                cu_seqlens_k=cu_k,
+                max_seqlen_q=max_q,
+                max_seqlen_k=max_k,
+                softcap=softcap,
+                sink=sink,
+            )
+        except (RuntimeError, TypeError, ValueError) as exc:
+            logger.warning("MATE MAGI-2 attention failed; falling back to chunked Torch attention: %s", exc)
+            mate_out = None
+        if mate_out is not None:
+            return mate_out
     return torch_varlen_attention_with_sink(
         q,
         k,

--- a/vllm_omni/diffusion/models/magi2/layers.py
+++ b/vllm_omni/diffusion/models/magi2/layers.py
@@ -11,7 +11,9 @@ MagiCompiler and external Triton runtime dependencies.
 
 from __future__ import annotations
 
+import logging
 import math
+import os
 from collections.abc import Callable
 
 import torch
@@ -20,6 +22,9 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from .parallel import Magi2ParallelGroup, get_magi2_tp_group
+
+logger = logging.getLogger(__name__)
+_SWIGLU7_FUSED_DISABLED = False
 
 
 def swiglu7(
@@ -30,7 +35,31 @@ def swiglu7(
 ) -> torch.Tensor:
     """Released GPT-OSS-style clamped SwiGLU activation."""
 
+    global _SWIGLU7_FUSED_DISABLED
     out_dtype = x.dtype if out_dtype is None else out_dtype
+    use_fused = (
+        not _SWIGLU7_FUSED_DISABLED
+        and os.environ.get("MAGI2_USE_FUSED_SWIGLU7", "1") == "1"
+        and os.environ.get("MAGI2_DETERMINISTIC", "0") != "1"
+        and x.device.type in {"musa", "privateuseone"}
+        and x.dtype == torch.bfloat16
+        and out_dtype == x.dtype
+        and x.is_contiguous()
+        and x.shape[-1] % 2 == 0
+        and alpha == 1.702
+        and limit == 7.0
+    )
+    if use_fused:
+        try:
+            from .swiglu_kernel import magi2_swiglu7
+
+            return magi2_swiglu7(x)
+        except Exception as exc:
+            _SWIGLU7_FUSED_DISABLED = True
+            logger.warning(
+                "MUSA fused MAGI-2 SwiGLU7 failed; using eager fallback: %s",
+                exc,
+            )
     x = x.to(torch.float32)
     gate, linear = x[..., ::2], x[..., 1::2]
     gate = gate.clamp(max=limit)
@@ -256,8 +285,47 @@ class MultiModalityRMSNorm(nn.Module):
         self,
         tensor: torch.Tensor,
         modality_dispatcher: ModalityDispatcher | None = None,
+        *,
+        out_dtype: torch.dtype | None = None,
     ) -> torch.Tensor:
         original_dtype = tensor.dtype
+        target_dtype = out_dtype or self.out_dtype or original_dtype
+
+        # ``tensor.float(); square(); mean(); rsqrt()`` is a surprisingly large
+        # part of a MAGI-2 step on MUSA.  The MUSA implementation of
+        # ``aten.rms_norm`` performs the reduction and scale in one kernel.  Keep
+        # this guarded by an environment rollback switch; callers can set the
+        # variable to ``0`` to retain the checkpoint/reference path below.
+        fast_rms = (
+            os.environ.get("MAGI2_FAST_RMS_NORM", "1") == "1"
+            and os.environ.get("MAGI2_DETERMINISTIC", "0") != "1"
+            and tensor.device.type in {"musa", "privateuseone"}
+        )
+        if fast_rms:
+            compute_dtype = torch.float32 if target_dtype == torch.float32 else tensor.dtype
+            normalized_input = tensor.to(compute_dtype)
+            if self.num_modality == 1:
+                normalized = F.rms_norm(
+                    normalized_input,
+                    (self.dim,),
+                    None,
+                    self.eps,
+                )
+                weight = (self.weight.view(self.num_patterns, self.dim) + 1.0).to(compute_dtype)
+                return (normalized * weight).to(target_dtype)
+            if modality_dispatcher is None:
+                raise ValueError("modality_dispatcher is required for multimodal RMSNorm")
+            normalized = F.rms_norm(
+                normalized_input,
+                (self.dim,),
+                None,
+                self.eps,
+            )
+            weights = (self.weight.view(self.num_modality, self.num_patterns, self.dim) + 1.0).to(compute_dtype)
+            inputs = modality_dispatcher.dispatch(normalized)
+            result = modality_dispatcher.undispatch(*(part * weights[index] for index, part in enumerate(inputs)))
+            return result.to(target_dtype)
+
         normalized = tensor.float()
         normalized = normalized * torch.rsqrt(normalized.square().mean(dim=-1, keepdim=True) + self.eps)
         if self.num_modality == 1:
@@ -271,7 +339,7 @@ class MultiModalityRMSNorm(nn.Module):
             result = modality_dispatcher.undispatch(
                 *(part * (weights[index] + 1.0) for index, part in enumerate(inputs))
             )
-        return result.to(self.out_dtype or original_dtype)
+        return result.to(target_dtype)
 
 
 def _frequency_bands(
@@ -329,7 +397,27 @@ class ElementWiseFourierEmbed(nn.Module):
 MHCTensorTuple = tuple[torch.Tensor, torch.Tensor, torch.Tensor]
 
 
+_MHC_FUSED_DISABLED = False
+
+
 def sinkhorn_knopp(matrix_logits: torch.Tensor, iterations: int, epsilon: float) -> torch.Tensor:
+    global _MHC_FUSED_DISABLED
+    fused_setting = os.environ.get("MAGI2_USE_MHC_FUSED")
+    use_fused = (
+        not _MHC_FUSED_DISABLED
+        and fused_setting != "0"
+        and matrix_logits.device.type in ("musa", "privateuseone")
+        and matrix_logits.ndim == 3
+        and matrix_logits.shape[-2:] == (4, 4)
+    )
+    if use_fused:
+        try:
+            from .mhc_kernel import mhc_sinkhorn
+
+            return mhc_sinkhorn(matrix_logits, num_iters=iterations, eps=epsilon)
+        except Exception as exc:
+            logger.warning("MAGI-2 fused mHC Sinkhorn failed; using reference path: %s", exc)
+            _MHC_FUSED_DISABLED = True
     matrix = torch.exp(matrix_logits - matrix_logits.amax(dim=(-2, -1), keepdim=True))
     for _ in range(iterations):
         matrix = matrix / (matrix.sum(dim=-2, keepdim=True) + epsilon)
@@ -355,6 +443,31 @@ class MHCHandler:
         self.sinkhorn_epsilon = sinkhorn_epsilon
         self.dtype = dtype
         self.matmul_scale = 1.0 / math.sqrt(float(num_streams * hidden_size))
+        self._phi_fused_bf16: dict[int, tuple[tuple[int, int], torch.Tensor]] = {}
+
+    @staticmethod
+    def _parameter_source(parameter: torch.Tensor) -> tuple[int, int]:
+        try:
+            version = parameter._version
+        except RuntimeError:
+            version = -1
+        return parameter.data_ptr(), version
+
+    def _bf16_phi(self, phi_fused: torch.Tensor) -> torch.Tensor:
+        """Cache the tiny BF16 projection matrix without changing state dicts."""
+        key = id(phi_fused)
+        source = self._parameter_source(phi_fused)
+        cached = self._phi_fused_bf16.get(key)
+        if (
+            cached is None
+            or cached[0] != source
+            or cached[1].device != phi_fused.device
+            or cached[1].shape != phi_fused.shape
+        ):
+            value = phi_fused.detach().to(dtype=torch.bfloat16).contiguous()
+            self._phi_fused_bf16[key] = (source, value)
+            return value
+        return cached[1]
 
     def flatten(self, tensor: torch.Tensor) -> torch.Tensor:
         self._check_multi(tensor)
@@ -368,7 +481,20 @@ class MHCHandler:
     ) -> MHCTensorTuple:
         if flattened.ndim != 2 or flattened.shape[-1] != self.num_streams * self.hidden_size:
             raise ValueError("invalid flattened mHC shape")
-        fused = norm(flattened).to(self.dtype) @ phi_fused
+        normalized = norm(flattened)
+        use_bf16 = (
+            os.environ.get("MAGI2_MHC_BF16_PROJECT", "1") == "1"
+            and os.environ.get("MAGI2_DETERMINISTIC", "0") != "1"
+            and flattened.device.type in {"musa", "privateuseone"}
+            and self.num_streams == 4
+            and flattened.ndim == 2
+            and flattened.shape[-1] == self.num_streams * self.hidden_size
+            and phi_fused.dtype == torch.float32
+        )
+        if use_bf16:
+            fused = (normalized.to(dtype=torch.bfloat16) @ self._bf16_phi(phi_fused)).float()
+        else:
+            fused = normalized.to(self.dtype) @ phi_fused
         pre, post, residual = torch.split(
             fused,
             (self.num_streams, self.num_streams, self.num_streams**2),
@@ -386,6 +512,14 @@ class MHCHandler:
         self._check_multi(streams)
         alpha, bias, logits = alpha_bias_logits
         coefficients = torch.sigmoid(alpha * self.matmul_scale * logits + bias.unsqueeze(0))
+        if (
+            os.environ.get("MAGI2_MHC_FAST_MIX", "1") == "1"
+            and os.environ.get("MAGI2_DETERMINISTIC", "0") != "1"
+            and streams.device.type in {"musa", "privateuseone"}
+            and streams.dtype == torch.bfloat16
+            and streams.shape[1] == 4
+        ):
+            return (coefficients.to(streams.dtype).unsqueeze(-1) * streams).sum(dim=1)
         return torch.einsum("tn,tnc->tc", coefficients.to(out_dtype or streams.dtype), streams)
 
     def compute_post_residual(
@@ -397,6 +531,47 @@ class MHCHandler:
     ) -> tuple[torch.Tensor, torch.Tensor]:
         alpha_post, bias_post, post_logits = post
         alpha_residual, bias_residual, residual_logits = residual
+        use_fused_coefficients = (
+            # Validated on S5000; set MAGI2_FUSED_MHC_COEFFICIENTS=0 to roll
+            # back if an older MUSA runtime lacks this custom op.
+            os.environ.get("MAGI2_FUSED_MHC_COEFFICIENTS", "1") == "1"
+            and os.environ.get("MAGI2_DETERMINISTIC", "0") != "1"
+            and residual_logits.device.type in {"musa", "privateuseone"}
+            and residual_logits.dtype == torch.float32
+            and post_logits.dtype == torch.float32
+            and out_dtype == torch.bfloat16
+            and alpha_post.dtype == torch.float32
+            and bias_post.dtype == torch.float32
+            and alpha_residual.dtype == torch.float32
+            and bias_residual.dtype == torch.float32
+            and self.num_streams == 4
+            and post_logits.ndim == 2
+            and post_logits.shape[-1] == 4
+            and residual_logits.ndim == 3
+            and residual_logits.shape[-2:] == (4, 4)
+            and post_logits.stride(-1) == 1
+            and residual_logits.stride()[-2:] == (4, 1)
+        )
+        if use_fused_coefficients:
+            try:
+                from .mhc_kernel import mhc_coefficients
+
+                return mhc_coefficients(
+                    post_logits,
+                    residual_logits,
+                    alpha_post,
+                    bias_post,
+                    alpha_residual,
+                    bias_residual,
+                    scale=self.matmul_scale,
+                    num_iters=self.sinkhorn_iterations,
+                    eps=self.sinkhorn_epsilon,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "MAGI-2 fused mHC coefficient kernel failed; using reference path: %s",
+                    exc,
+                )
         post_coefficients = 2.0 * torch.sigmoid(alpha_post * self.matmul_scale * post_logits + bias_post.unsqueeze(0))
         residual_matrix = sinkhorn_knopp(
             alpha_residual * self.matmul_scale * residual_logits.float() + bias_residual.unsqueeze(0).float(),
@@ -415,6 +590,26 @@ class MHCHandler:
         self._check_multi(residual_streams)
         if branch_output.ndim != 2 or branch_output.shape[-1] != self.hidden_size:
             raise ValueError("invalid mHC branch-output shape")
+        fused_setting = os.environ.get("MAGI2_USE_MHC_FUSED")
+        if fused_setting != "0" and residual_streams.device.type in ("musa", "privateuseone") and self.num_streams == 4:
+            try:
+                from .mhc_kernel import mhc_mix_output
+
+                if not (
+                    residual_streams.is_contiguous()
+                    and branch_output.is_contiguous()
+                    and post_coefficients.is_contiguous()
+                    and residual_matrix.is_contiguous()
+                ):
+                    raise ValueError("mHC fused inputs must be contiguous")
+                return mhc_mix_output(
+                    residual_streams,
+                    branch_output,
+                    post_coefficients,
+                    residual_matrix,
+                )
+            except Exception as exc:
+                logger.warning("MAGI-2 fused mHC mix failed; using reference path: %s", exc)
         branch = torch.einsum("tn,tc->tnc", post_coefficients, branch_output)
         mixed = torch.einsum("tij,tjc->tic", residual_matrix, residual_streams)
         return mixed + branch

--- a/vllm_omni/diffusion/models/magi2/mh_moe.py
+++ b/vllm_omni/diffusion/models/magi2/mh_moe.py
@@ -13,6 +13,8 @@ whole-token :class:`FusedMoE` primitive.
 
 from __future__ import annotations
 
+import importlib
+import logging
 import math
 import os
 from dataclasses import dataclass
@@ -28,6 +30,316 @@ from vllm_omni.platforms import current_omni_platform
 from .parallel import Magi2ParallelGroup, ep_dispatch, ep_undispatch, get_magi2_ep_group
 
 RoutingScore = Literal["softmax", "sigmoid"]
+
+logger = logging.getLogger(__name__)
+_MATE_MOE_WARNED = False
+_SGL_FUSED_MOE_MODULE = None
+_SGL_FUSED_MOE_WORKSPACES: dict[tuple, torch.Tensor] = {}
+_MAGI2_ALIGN_OP_AVAILABLE: bool | None = None
+
+
+def _magi2_align_block_size_fixed_capacity(
+    ids: torch.Tensor,
+    num_experts: int,
+    block_size: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build aligned route metadata without device-to-host scalar reads.
+
+    The generic ``_moe_C`` align op is not present in the vLLM-MUSA image.
+    Its eager fallback used a dynamic ``repeat_interleave`` result and called
+    ``.item()`` twice per MoE layer to discover the published length.  Keep
+    the buffers at their deterministic worst-case capacity instead: the
+    fused Triton kernel already consumes ``num_tokens_post_pad`` on device
+    and returns early for the unused tail.  ``searchsorted`` maps block
+    indices to experts without a dynamic output allocation.
+    """
+
+    route_count = ids.numel()
+    capacity = max(route_count + num_experts * (block_size - 1), block_size)
+    max_blocks = (capacity + block_size - 1) // block_size
+    sorted_ids = torch.full((capacity,), route_count, device=ids.device, dtype=torch.int32)
+
+    # ``torch.sort`` returns values and indices in one operation and preserves
+    # the route order used by the previous argsort + gather implementation.
+    sorted_experts, order = torch.sort(ids)
+    counts = torch.zeros(num_experts, device=ids.device, dtype=torch.int32)
+    if route_count:
+        counts.scatter_add_(0, ids, torch.ones_like(ids, dtype=torch.int32))
+    padded_counts = ((counts + block_size - 1) // block_size) * block_size
+    starts = torch.cumsum(padded_counts, 0) - padded_counts
+    ends = torch.cumsum(counts, 0)
+    begins = ends - counts
+    positions = torch.arange(route_count, device=ids.device, dtype=torch.int64)
+    experts = sorted_experts.to(torch.int64)
+    destinations = starts[experts] + positions - begins[experts]
+    sorted_ids[destinations] = order.to(torch.int32)
+
+    block_counts = padded_counts // block_size
+    cumulative_blocks = torch.cumsum(block_counts, 0)
+    block_indices = torch.arange(max_blocks, device=ids.device, dtype=torch.int32)
+    mapped_experts = torch.searchsorted(cumulative_blocks, block_indices, right=True).to(torch.int32)
+    expert_ids = torch.where(block_indices < cumulative_blocks[-1], mapped_experts, -1).to(torch.int32)
+    num_padded = padded_counts.sum(dtype=torch.int32).reshape(1)
+    return sorted_ids, expert_ids, num_padded
+
+
+def _magi2_align_block_size(
+    topk_ids: torch.Tensor,
+    num_experts: int,
+    block_size: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Return SGLang-compatible sorted route metadata on MUSA.
+
+    The vLLM CUDA extension exposes an in-place align op, but the MUSA image
+    used for MAGI-2 does not load ``_moe_C``.  Keep a device-side fallback so
+    the fused path remains usable while an AOT MUSA align op is upstreamed.
+    """
+    ids = topk_ids.reshape(-1).to(torch.int32)
+    align_mode = os.environ.get("MAGI2_MOE_ALIGN_FIXED_CAPACITY")
+    force_fixed_capacity = align_mode == "1"
+    force_dynamic_fallback = align_mode == "0"
+    # Keep the existing CUDA/CPU behavior untouched.  The fixed-capacity
+    # implementation is a MUSA fallback for the image where the Python
+    # wrapper is present but the CUDA ``_moe_C`` extension is absent; callers
+    # can still force it on another backend for diagnostics.
+    musa_device = ids.device.type in {"musa", "privateuseone"}
+    if force_fixed_capacity:
+        return _magi2_align_block_size_fixed_capacity(ids, num_experts, block_size)
+
+    global _MAGI2_ALIGN_OP_AVAILABLE
+    if not force_dynamic_fallback and _MAGI2_ALIGN_OP_AVAILABLE is not False:
+        try:
+            from vllm._custom_ops import moe_align_block_size
+
+            capacity = ids.numel() + num_experts * block_size
+            sorted_ids = torch.empty((capacity,), device=ids.device, dtype=torch.int32)
+            expert_ids = torch.empty((capacity // block_size,), device=ids.device, dtype=torch.int32)
+            num_padded = torch.empty((1,), device=ids.device, dtype=torch.int32)
+            moe_align_block_size(
+                ids,
+                num_experts,
+                block_size,
+                sorted_ids,
+                expert_ids,
+                num_padded,
+            )
+            _MAGI2_ALIGN_OP_AVAILABLE = True
+            n = int(num_padded.item())
+            return sorted_ids[:n], expert_ids[: n // block_size], num_padded
+        except Exception:
+            # Some MUSA images expose the Python wrapper but not its CUDA
+            # ``_moe_C`` symbol.  Cache that fact to avoid an exception and
+            # failed custom-op dispatch on every layer.
+            _MAGI2_ALIGN_OP_AVAILABLE = False
+
+    if musa_device and not force_dynamic_fallback:
+        # The MUSA image normally has the Python wrapper but not its CUDA
+        # ``_moe_C`` implementation. Prefer the device-count/capacity path by
+        # default; setting ``MAGI2_MOE_ALIGN_FIXED_CAPACITY=0`` retains the
+        # original dynamic fallback as an emergency rollback.
+        return _magi2_align_block_size_fixed_capacity(ids, num_experts, block_size)
+
+    # MUSA builds may expose the Python wrapper without the CUDA `_moe_C`
+    # extension.  This implementation intentionally stays on-device.
+    order = torch.argsort(ids)
+    sorted_experts = ids[order]
+    counts = torch.bincount(ids, minlength=num_experts)
+    padded_counts = ((counts + block_size - 1) // block_size) * block_size
+    total = int(padded_counts.sum().item())
+    sorted_ids = torch.full((total,), ids.numel(), device=ids.device, dtype=torch.int32)
+    starts = torch.cumsum(padded_counts, 0) - padded_counts
+    ends = torch.cumsum(counts, 0)
+    begins = ends - counts
+    positions = torch.arange(ids.numel(), device=ids.device, dtype=torch.int64)
+    experts = sorted_experts.to(torch.int64)
+    destinations = starts[experts] + positions - begins[experts]
+    sorted_ids[destinations] = order.to(torch.int32)
+    expert_ids = torch.repeat_interleave(
+        torch.arange(num_experts, device=ids.device, dtype=torch.int32),
+        padded_counts // block_size,
+    )
+    return (
+        sorted_ids,
+        expert_ids,
+        torch.tensor(total, device=ids.device, dtype=torch.int32),
+    )
+
+
+def _magi2_sgl_fused_moe_module():
+    global _SGL_FUSED_MOE_MODULE
+    if _SGL_FUSED_MOE_MODULE is None:
+        _SGL_FUSED_MOE_MODULE = importlib.import_module("vllm_omni.diffusion.models.magi2.sgl_fused_moe_kernels")
+    return _SGL_FUSED_MOE_MODULE
+
+
+def _magi2_sgl_fused_moe_forward(
+    x_heads: torch.Tensor,
+    probabilities: torch.Tensor,
+    indices: torch.Tensor,
+    w_gate: torch.Tensor,
+    w_up: torch.Tensor,
+    w_down: torch.Tensor,
+    packed_w13: torch.Tensor | None = None,
+    packed_w2: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """SGLang-compatible fused SwiGLU MoE for MAGI-2's head-routed layout."""
+    if x_heads.ndim != 3 or probabilities.ndim != 3 or indices.ndim != 3:
+        raise ValueError("unexpected MAGI-2 MoE tensor rank")
+    num_tokens, num_heads, hidden_size = x_heads.shape
+    top_k = probabilities.shape[-1]
+    if top_k != 6:
+        raise ValueError(f"SGLang MAGI-2 path expects top_k=6, got {top_k}")
+    num_experts_per_head = w_gate.shape[0] // num_heads
+    intermediate_size = w_gate.shape[-1]
+    num_experts = w_gate.shape[0]
+    # The generic fused kernel consumes one row per (head, token), with expert
+    # IDs offset into the flattened head-local expert table.
+    hidden = x_heads.permute(1, 0, 2).contiguous().reshape(num_heads * num_tokens, hidden_size)
+    route_weights = probabilities.permute(0, 1, 2).contiguous().reshape(num_heads * num_tokens, top_k)
+    route_ids = indices.to(torch.int32).contiguous()
+    route_ids = (
+        route_ids
+        + torch.arange(num_heads, device=route_ids.device, dtype=torch.int32)
+        .view(num_heads, 1, 1)
+        .mul(num_experts_per_head)
+    ).reshape(num_heads * num_tokens, top_k)
+    sorted_ids, expert_ids, num_padded = _magi2_align_block_size(route_ids, num_experts, 128)
+
+    # W13 is packed only into one per-process scratch buffer.  Keeping this
+    # buffer out of each layer avoids a resident ~1 GB duplicate for all 36
+    # MAGI-2 MoE layers; the model invokes layers serially on each rank.
+    key = (
+        str(w_gate.device),
+        w_gate.dtype,
+        num_experts,
+        intermediate_size,
+        hidden_size,
+    )
+    shape = (num_experts, 2 * intermediate_size, hidden_size)
+    if packed_w13 is not None:
+        if tuple(packed_w13.shape) != shape or not packed_w13.is_contiguous():
+            raise ValueError("Invalid prepacked MAGI2 W13 layout")
+        packed = packed_w13
+    else:
+        packed = _SGL_FUSED_MOE_WORKSPACES.get(key)
+        if packed is None or tuple(packed.shape) != shape:
+            packed = torch.empty(shape, device=w_gate.device, dtype=w_gate.dtype)
+            _SGL_FUSED_MOE_WORKSPACES[key] = packed
+        packed_view = packed.view(num_experts, intermediate_size, 2, hidden_size)
+        packed_view[:, :, 0, :].copy_(w_gate.transpose(1, 2))
+        packed_view[:, :, 1, :].copy_(w_up.transpose(1, 2))
+
+    kernels = _magi2_sgl_fused_moe_module()
+    import triton.language as tl
+
+    block_n = int(os.environ.get("MAGI2_SGL_BLOCK_N", "128"))
+    default_block_k = "32" if packed_w13 is not None else "64"
+    block_k = int(os.environ.get("MAGI2_SGL_BLOCK_K", default_block_k))
+    if block_n not in (64, 128, 256, 512) or block_k not in (16, 32, 64, 128):
+        raise ValueError("invalid MAGI2 SGL tile config")
+    num_warps = int(os.environ.get("MAGI2_SGL_NUM_WARPS", "16"))
+    num_stages = int(os.environ.get("MAGI2_SGL_NUM_STAGES", "1"))
+    if num_warps not in (4, 8, 16, 32) or num_stages not in (1, 2, 3, 4):
+        raise ValueError("invalid MAGI2 SGL launch config")
+    config = {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": block_n,
+        "BLOCK_SIZE_K": block_k,
+        "GROUP_SIZE_M": 16,
+        "num_warps": num_warps,
+        "num_stages": num_stages,
+    }
+    config_down = dict(config)
+    if packed_w13 is not None and os.environ.get("MAGI2_SGL_BLOCK_K") is None:
+        config_down["BLOCK_SIZE_K"] = 64
+    # c_sorted=False uses original route IDs and masks padded rows with
+    # num_valid_tokens; only real routed rows need intermediate storage.
+    # Keep zero initialization for any filtered experts.
+    intermediate_rows = route_ids.numel()
+    intermediate = torch.zeros(
+        (intermediate_rows, intermediate_size),
+        device=x_heads.device,
+        dtype=x_heads.dtype,
+    )
+    kernels.invoke_fused_moe_kernel(
+        hidden,
+        packed,
+        None,
+        intermediate,
+        None,
+        None,
+        None,
+        route_weights,
+        route_ids,
+        sorted_ids,
+        expert_ids,
+        num_padded,
+        False,
+        top_k,
+        config,
+        tl.bfloat16,
+        False,
+        False,
+        False,
+        False,
+        False,
+        no_combine=True,
+        c_sorted=False,
+        filter_expert=True,
+        fuse_swiglu=True,
+        swiglu_alpha=1.702,
+        swiglu_limit=7.0,
+    )
+    route_output = torch.zeros(
+        (hidden.shape[0], top_k, hidden_size),
+        device=hidden.device,
+        dtype=hidden.dtype,
+    )
+    kernels.invoke_fused_moe_kernel(
+        intermediate,
+        # The fused kernel follows SGLang's convention for W2: [E, K, N]
+        # (output/hidden dimension first).  MAGI-2 stores W_down as
+        # [E, N, K], so expose the transposed view here.
+        packed_w2 if packed_w2 is not None else w_down.transpose(1, 2),
+        None,
+        route_output,
+        None,
+        None,
+        None,
+        route_weights,
+        route_ids,
+        sorted_ids,
+        expert_ids,
+        num_padded,
+        True,
+        1,
+        config_down,
+        tl.bfloat16,
+        False,
+        False,
+        False,
+        False,
+        False,
+        no_combine=False,
+        c_sorted=False,
+        filter_expert=True,
+    )
+    # SGLang's MUSA AOT ``moe_sum_reduce`` combines the six routed rows in
+    # one custom kernel.  Use the equivalent reduction while we keep the
+    # adapter self-contained; this is a single device reduction and leaves a
+    # clean seam for replacing it with the AOT op when available in the image.
+    output = torch.empty((hidden.shape[0], hidden_size), device=hidden.device, dtype=hidden.dtype)
+    used_fast_sum = False
+    if os.environ.get("MAGI2_USE_MUSA_MOE_SUM", "1") == "1":
+        try:
+            from vllm_musa.jit_kernel.csrc.moe import maybe_fast_moe_sum
+
+            used_fast_sum = maybe_fast_moe_sum(route_output, output)
+        except Exception as exc:
+            logger.debug("MUSA MoE sum-reduce unavailable: %s", exc)
+    if not used_fast_sum:
+        output.copy_(route_output.sum(dim=1))
+    return output.view(num_heads, num_tokens, hidden_size).permute(1, 0, 2).contiguous()
 
 
 def swiglu7_pair(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
@@ -77,12 +389,12 @@ def compute_topk_probs_and_indices(
     return topk_probs, topk_indices
 
 
-def global_sort_routes(
+def _global_sort_routes_impl(
     topk_probs: torch.Tensor,
     topk_indices: torch.Tensor,
     num_experts: int,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Convert per-head routes into a stable flattened-expert CSR layout."""
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build the stable flattened-expert route layout and retain sort order."""
 
     if topk_probs.shape != topk_indices.shape or topk_indices.ndim != 3:
         raise ValueError("top-k probabilities and indices must have the same [H,S,K] shape")
@@ -95,10 +407,81 @@ def global_sort_routes(
     order = flattened_experts.argsort(stable=True)
     gather_ids = flat_tokens[order].to(torch.int32)
     sorted_probs = flat_probs[order].float()
-    counts = torch.bincount(flattened_experts, minlength=heads * num_experts)
+    # ``torch.bincount`` on MUSA performs an internal min/max and scalar
+    # synchronization before building its histogram.  Route IDs are already
+    # bounded non-negative integers, so an int32 scatter accumulation is both
+    # exact and substantially cheaper while preserving the same CSR counts.
+    counts = torch.zeros(heads * num_experts, device=device, dtype=torch.int32)
+    if flattened_experts.numel():
+        counts.scatter_add_(
+            0,
+            flattened_experts,
+            torch.ones_like(flattened_experts, dtype=torch.int32),
+        )
     offsets = torch.zeros(heads * num_experts + 1, device=device, dtype=torch.long)
     offsets[1:] = counts.cumsum(0)
+    return gather_ids, sorted_probs, offsets, order, counts
+
+
+def global_sort_routes(
+    topk_probs: torch.Tensor,
+    topk_indices: torch.Tensor,
+    num_experts: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Convert per-head routes into a stable flattened-expert CSR layout.
+
+    Keep this three-tensor return contract for existing callers.  The MATE
+    path can use :func:`global_sort_routes_with_head_ids` when it also needs
+    the source head for every sorted route.
+    """
+
+    gather_ids, sorted_probs, offsets, _, _ = _global_sort_routes_impl(topk_probs, topk_indices, num_experts)
     return gather_ids, sorted_probs, offsets
+
+
+def global_sort_routes_with_head_ids(
+    topk_probs: torch.Tensor,
+    topk_indices: torch.Tensor,
+    num_experts: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Return sorted routes plus source-head IDs without expanding counts.
+
+    ``flattened_experts`` is laid out as ``[head, sequence, top_k]`` before
+    sorting.  Therefore the source head of a sorted route is recoverable from
+    its stable-sort position with one integer division.  The optional metadata
+    lets the MATE adapter avoid constructing an ``E``-element head table and
+    ``repeat_interleave``-ing it to route length on every layer.
+    """
+
+    gather_ids, sorted_probs, offsets, order, _ = _global_sort_routes_impl(topk_probs, topk_indices, num_experts)
+    _, sequence, top_k = topk_indices.shape
+    if order.numel() == 0:
+        sorted_head_ids = order
+    else:
+        sorted_head_ids = torch.div(order, sequence * top_k, rounding_mode="floor")
+    return gather_ids, sorted_probs, offsets, sorted_head_ids
+
+
+def global_sort_routes_with_head_ids_and_counts(
+    topk_probs: torch.Tensor,
+    topk_indices: torch.Tensor,
+    num_experts: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Return sorted routes, source heads, and the exact route counts.
+
+    The count vector is the same int32 histogram used to build ``offsets``.
+    MATE's per-expert grouped GEMM consumes it directly, so exposing it here
+    avoids a second ``diff(offsets)`` plus dtype/layout conversion in the
+    adapter while keeping the legacy three-/four-tensor APIs unchanged.
+    """
+
+    gather_ids, sorted_probs, offsets, order, counts = _global_sort_routes_impl(topk_probs, topk_indices, num_experts)
+    _, sequence, top_k = topk_indices.shape
+    if order.numel() == 0:
+        sorted_head_ids = order
+    else:
+        sorted_head_ids = torch.div(order, sequence * top_k, rounding_mode="floor")
+    return gather_ids, sorted_probs, offsets, sorted_head_ids, counts
 
 
 def torch_mh_moe_forward(
@@ -116,9 +499,12 @@ def torch_mh_moe_forward(
         raise ValueError("multi-head MoE input must be [tokens,heads,head_dim]")
     output = torch.zeros_like(x)
     experts_per_head = (expert_offsets.numel() - 1) // x.shape[1]
-    for flat_expert in range(expert_offsets.numel() - 1):
-        begin = int(expert_offsets[flat_expert].item())
-        end = int(expert_offsets[flat_expert + 1].item())
+    # Materialize the compact CSR offsets once per layer. Calling ``item``
+    # for every expert forces a device-to-host synchronization for each
+    # route; one bounded copy preserves the exact route order while avoiding
+    # thousands of scalar syncs across the DiT stack.
+    offsets = expert_offsets.detach().to(device="cpu").tolist()
+    for flat_expert, (begin, end) in enumerate(zip(offsets, offsets[1:])):
         if begin == end:
             continue
         head = flat_expert // experts_per_head
@@ -131,6 +517,136 @@ def torch_mh_moe_forward(
         expert_output = expert_output * probs[begin:end, None].to(expert_output.dtype)
         output[:, head].index_add_(0, token_ids, expert_output)
     return output
+
+
+def _mate_bf16_grouped_linear(
+    input_a: torch.Tensor,
+    weight: torch.Tensor,
+    token_counts: torch.Tensor,
+    *,
+    major_b_mode: Literal["N"],
+    backend: str,
+) -> torch.Tensor:
+    """Run one MAGI expert projection through MATE's ragged BF16 GEMM.
+
+    MAGI stores gate/up/down weights as ``[expert, K, N]``.  The lower-level
+    MATE entry point is used instead of materializing transposed gate/up
+    copies: its ``major_b_mode="N"`` contract
+    accepts the checkpoint's K-major layout directly.
+    """
+
+    if major_b_mode != "N":
+        raise ValueError("MAGI grouped BF16 weights must use MATE major_b_mode='N'")
+    if not input_a.is_contiguous() or not weight.is_contiguous() or not token_counts.is_contiguous():
+        raise ValueError("MATE grouped BF16 operands must be contiguous")
+    # MAGI checkpoint tensors are all stored as ``[K, N]`` per expert.  The
+    # MATE ``N`` major mode describes this physical layout and exposes the
+    # trailing dimension as the output width.
+    out_features = weight.shape[-1]
+    output = torch.empty((input_a.shape[0], out_features), device=input_a.device, dtype=input_a.dtype)
+    from mate.gemm import ragged_m_moe_gemm_16bit
+
+    ragged_m_moe_gemm_16bit(
+        input_a,
+        weight,
+        token_counts,
+        output,
+        gemm_mode="per_expert",
+        major_a_mode="K",
+        major_b_mode=major_b_mode,
+        backend=backend,
+    )
+    return output
+
+
+def mate_bf16_mh_moe_forward(
+    x: torch.Tensor,
+    gather_ids: torch.Tensor,
+    probs: torch.Tensor,
+    expert_offsets: torch.Tensor,
+    w_gate: torch.Tensor,
+    w_up: torch.Tensor,
+    w_down: torch.Tensor,
+    *,
+    backend: str = "mubin",
+    sorted_head_ids: torch.Tensor | None = None,
+    token_counts: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Evaluate the routed MAGI-2 MoE with MATE's grouped BF16 GEMMs.
+
+    ``global_sort_routes`` already lays routes out as contiguous expert
+    segments.  We only gather the corresponding head slices once, run the
+    three projections as ragged grouped GEMMs, and scatter the weighted result
+    once.  ``sorted_head_ids`` and ``token_counts`` are optional companions
+    produced by :func:`global_sort_routes_with_head_ids_and_counts`; supplying
+    them avoids rebuilding route metadata in the adapter. This is intentionally
+    an opt-in experiment until the complete distributed/capture matrix has
+    been validated.
+    """
+
+    if x.ndim != 3:
+        raise ValueError("multi-head MoE input must be [tokens,heads,head_dim]")
+    if x.dtype != torch.bfloat16 or any(weight.dtype != torch.bfloat16 for weight in (w_gate, w_up, w_down)):
+        raise ValueError("MATE BF16 grouped MoE requires BF16 activations and weights")
+    num_flat_experts = expert_offsets.numel() - 1
+    if num_flat_experts <= 0 or num_flat_experts % x.shape[1]:
+        raise ValueError("expert count must be a positive multiple of the head count")
+    if gather_ids.numel() == 0:
+        return torch.zeros_like(x)
+
+    if token_counts is None:
+        token_counts = torch.diff(expert_offsets).to(dtype=torch.int32).contiguous()
+    else:
+        if token_counts.ndim != 1 or token_counts.numel() != num_flat_experts:
+            raise ValueError("token_counts must have one entry per flattened expert")
+        if token_counts.device != x.device:
+            raise ValueError("token_counts must be on the MoE input device")
+        if token_counts.dtype != torch.int32 or not token_counts.is_contiguous():
+            token_counts = token_counts.to(dtype=torch.int32).contiguous()
+    token_ids = gather_ids.to(dtype=torch.long)
+    if sorted_head_ids is None:
+        experts_per_head = num_flat_experts // x.shape[1]
+        head_for_expert = torch.arange(num_flat_experts, device=x.device, dtype=torch.long) // experts_per_head
+        head_ids = torch.repeat_interleave(head_for_expert, token_counts.to(torch.long))
+    else:
+        if sorted_head_ids.ndim != 1 or sorted_head_ids.numel() != token_ids.numel():
+            raise ValueError("sorted_head_ids must be one entry per sorted route")
+        if sorted_head_ids.device != x.device:
+            raise ValueError("sorted_head_ids must be on the MoE input device")
+        head_ids = sorted_head_ids.to(dtype=torch.long)
+    route_linear_ids = (token_ids * x.shape[1] + head_ids).contiguous()
+    routed_input = x.contiguous().view(-1, x.shape[-1]).index_select(0, route_linear_ids)
+
+    gate = _mate_bf16_grouped_linear(
+        routed_input,
+        w_gate,
+        token_counts,
+        major_b_mode="N",
+        backend=backend,
+    )
+    up = _mate_bf16_grouped_linear(
+        routed_input,
+        w_up,
+        token_counts,
+        major_b_mode="N",
+        backend=backend,
+    )
+    hidden = swiglu7_pair(gate, up)
+    expert_output = _mate_bf16_grouped_linear(
+        hidden,
+        w_down,
+        token_counts,
+        major_b_mode="N",
+        backend=backend,
+    )
+    expert_output = expert_output * probs[:, None].to(expert_output.dtype)
+    output = torch.zeros(
+        (x.shape[0] * x.shape[1], x.shape[-1]),
+        device=x.device,
+        dtype=x.dtype,
+    )
+    output.index_add_(0, route_linear_ids, expert_output)
+    return output.view_as(x)
 
 
 _SWIGLU7_ALPHA = tl.constexpr(1.702)
@@ -427,6 +943,8 @@ class Magi2MultiHeadMoE(nn.Module):
         self.W_down = nn.Parameter(
             torch.empty(self.local_flatten_num_experts, self.d_expert, self.d_head, dtype=config.params_dtype)
         )
+        self.register_buffer("_owned_w13", None, persistent=False)
+        self.register_buffer("_owned_w2", None, persistent=False)
         self.router = nn.Module()
         # Both tensors are released checkpoint entries.  Non-trainable
         # Parameters let the DLO mmap path bind them on a meta-constructed
@@ -448,6 +966,74 @@ class Magi2MultiHeadMoE(nn.Module):
                 target = getattr(target, part)
             parameter = getattr(target, parts[-1])
             parameter.mmap_weight_transform = self.ep_slice
+
+    @torch.no_grad()
+    def prepare_owned_w13(self) -> None:
+        """Replace W_gate/W_up storage with SGL's interleaved W13 layout."""
+        if self.W_gate.dtype != torch.bfloat16 or self.W_up.dtype != torch.bfloat16:
+            raise ValueError("Owned W13 requires BF16 gate and up weights")
+        if self._get_owned_w13() is not None:
+            return
+        packed = torch.empty(
+            (self.local_flatten_num_experts, 2 * self.d_expert, self.d_head),
+            dtype=self.W_gate.dtype,
+            device=self.W_gate.device,
+        )
+        views = packed.view(self.local_flatten_num_experts, self.d_expert, 2, self.d_head)
+        gate = views[:, :, 0, :].transpose(1, 2)
+        up = views[:, :, 1, :].transpose(1, 2)
+        gate.copy_(self.W_gate)
+        up.copy_(self.W_up)
+        self.W_gate.data = gate
+        self.W_up.data = up
+        self._owned_w13 = packed
+
+    def _get_owned_w13(self) -> torch.Tensor | None:
+        packed = self._owned_w13
+        if packed is None:
+            return None
+        expected_stride = (2 * self.d_expert * self.d_head, 1, 2 * self.d_head)
+        if (
+            packed.device != self.W_gate.device
+            or packed.dtype != self.W_gate.dtype
+            or self.W_up.device != packed.device
+            or self.W_up.dtype != packed.dtype
+            or self.W_gate.data_ptr() != packed.data_ptr()
+            or self.W_up.data_ptr() != packed.data_ptr() + self.d_head * packed.element_size()
+            or self.W_gate.stride() != expected_stride
+            or self.W_up.stride() != expected_stride
+        ):
+            return None
+        return packed
+
+    @torch.no_grad()
+    def prepare_owned_w2(self) -> None:
+        """Replace W2 storage with SGL's contiguous [E,H,I] layout."""
+        if self.W_down.dtype != torch.bfloat16:
+            raise ValueError("Owned W2 requires BF16 weights")
+        if self._get_owned_w2() is not None:
+            return
+        packed = torch.empty(
+            (self.local_flatten_num_experts, self.d_head, self.d_expert),
+            dtype=self.W_down.dtype,
+            device=self.W_down.device,
+        )
+        packed.copy_(self.W_down.transpose(1, 2))
+        self.W_down.data = packed.transpose(1, 2)
+        self._owned_w2 = packed
+
+    def _get_owned_w2(self) -> torch.Tensor | None:
+        packed = self._owned_w2
+        if packed is None:
+            return None
+        if (
+            packed.device != self.W_down.device
+            or packed.dtype != self.W_down.dtype
+            or self.W_down.data_ptr() != packed.data_ptr()
+            or self.W_down.stride() != (packed.stride(0), packed.stride(2), packed.stride(1))
+        ):
+            return None
+        return packed
 
     def ep_slice(self, checkpoint_tensor: torch.Tensor) -> torch.Tensor:
         """Slice flattened ``(head,expert)`` checkpoint rows for this rank."""
@@ -490,9 +1076,95 @@ class Magi2MultiHeadMoE(nn.Module):
         return probs * self.config.route_scale, indices
 
     def _local_forward(self, x_heads: torch.Tensor) -> torch.Tensor:
+        global _MATE_MOE_WARNED
         probabilities, indices = self._route(x_heads)
-        gather_ids, sorted_probs, offsets = global_sort_routes(probabilities, indices, self.num_experts)
-        if x_heads.is_cuda:
+        use_sgl_fused = (
+            os.environ.get("MAGI2_USE_SGL_FUSED_MOE", "1") == "1"
+            and x_heads.device.type in {"musa", "privateuseone"}
+            and x_heads.dtype == torch.bfloat16
+            and os.environ.get("MAGI2_DETERMINISTIC", "0") != "1"
+        )
+        if use_sgl_fused:
+            try:
+                packed_w13 = None
+                # The memory-neutral owned layouts are the qualified MUSA
+                # default; set either variable to 0 for an emergency rollback.
+                if os.environ.get("MAGI2_SGL_OWNED_W13", "1") == "1":
+                    if self._get_owned_w13() is None:
+                        self.prepare_owned_w13()
+                    packed_w13 = self._get_owned_w13()
+                packed_w2 = None
+                if os.environ.get("MAGI2_SGL_OWNED_W2", "1") == "1":
+                    if self._get_owned_w2() is None:
+                        self.prepare_owned_w2()
+                    packed_w2 = self._get_owned_w2()
+                return _magi2_sgl_fused_moe_forward(
+                    x_heads,
+                    probabilities,
+                    indices,
+                    self.W_gate,
+                    self.W_up,
+                    self.W_down,
+                    packed_w13=packed_w13,
+                    packed_w2=packed_w2,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "SGLang-compatible fused MAGI-2 MoE path failed; falling back to the configured route: %s",
+                    exc,
+                )
+        use_mate = (
+            os.environ.get("MAGI2_USE_MATE_MOE", "0") == "1"
+            and x_heads.device.type == "musa"
+            and x_heads.dtype == torch.bfloat16
+        )
+        sorted_head_ids: torch.Tensor | None = None
+        route_counts: torch.Tensor | None = None
+        if use_mate:
+            (
+                gather_ids,
+                sorted_probs,
+                offsets,
+                sorted_head_ids,
+                route_counts,
+            ) = global_sort_routes_with_head_ids_and_counts(probabilities, indices, self.num_experts)
+        else:
+            gather_ids, sorted_probs, offsets = global_sort_routes(probabilities, indices, self.num_experts)
+        if use_mate:
+            backend = (os.environ.get("MAGI2_MATE_MOE_BACKEND") or "mubin").strip().lower()
+            if backend not in {"auto", "mubin"}:
+                raise ValueError(
+                    "MAGI2_MATE_MOE_BACKEND must be auto or mubin; mutlass does not accept per-expert count metadata"
+                )
+            if backend == "auto":
+                # ``auto`` currently resolves to Mubin for this API. Keep the
+                # effective choice explicit because the Mutlass branch treats
+                # the same tensor as an MGroupedContiguous row-ID layout.
+                backend = "mubin"
+            try:
+                return mate_bf16_mh_moe_forward(
+                    x_heads,
+                    gather_ids,
+                    sorted_probs,
+                    offsets,
+                    self.W_gate,
+                    self.W_up,
+                    self.W_down,
+                    backend=backend,
+                    sorted_head_ids=sorted_head_ids,
+                    token_counts=route_counts,
+                )
+            except Exception as exc:
+                if not _MATE_MOE_WARNED:
+                    logger.warning(
+                        "MATE BF16 grouped MAGI-2 MoE path failed; falling back to the Torch route: %s",
+                        exc,
+                    )
+                    _MATE_MOE_WARNED = True
+        # The Triton kernel is currently qualified only on CUDA. Keep MUSA on
+        # the numerically equivalent Torch path until a MUSA Triton launch is
+        # explicitly enabled and benchmarked.
+        if current_omni_platform.is_cuda() and x_heads.device.type == "cuda":
             return triton_mh_moe_forward(
                 x_heads,
                 gather_ids,
@@ -505,7 +1177,12 @@ class Magi2MultiHeadMoE(nn.Module):
             )
         return torch_mh_moe_forward(x_heads, gather_ids, sorted_probs, offsets, self.W_gate, self.W_up, self.W_down)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        sequence_split_sizes: list[int] | torch.Tensor | None = None,
+    ) -> torch.Tensor:
         if self.ep_group.world_size > 1 and self.ep_group.replicated_sequence:
             # TP column-parallel ``split_linear`` already emits exactly this
             # rank's contiguous MoE-head slice.  Compute it once and leave it
@@ -522,16 +1199,42 @@ class Magi2MultiHeadMoE(nn.Module):
         if self.ep_pad_heads:
             padding = x_heads.new_zeros((x_heads.shape[0], self.ep_pad_heads, self.d_head))
             x_heads = torch.cat((x_heads, padding), dim=1)
-        sequence_split_sizes: list[int] | None = None
+        resolved_split_sizes: list[int] | None = None
         if self.ep_group.world_size > 1:
-            local_size = torch.tensor([x_heads.shape[0]], dtype=torch.int64, device=x_heads.device)
-            gathered_sizes = [torch.empty_like(local_size) for _ in range(self.ep_group.world_size)]
-            torch.distributed.all_gather(gathered_sizes, local_size, group=self.ep_group.group)
-            sequence_split_sizes = [int(size.item()) for size in gathered_sizes]
-            x_heads = ep_dispatch(x_heads, self.ep_group, sequence_split_sizes)
+            # ``sequence_split_sizes`` is normally produced by the SP group
+            # (world=8), while the experimental EP group may contain only a
+            # contiguous subset (world=4).  Select the entries belonging to
+            # this EP group's global ranks before issuing all-to-all.
+            global_ranks = getattr(self.ep_group, "global_ranks", None)
+            if sequence_split_sizes is None:
+                local_size = torch.tensor([x_heads.shape[0]], dtype=torch.int64, device=x_heads.device)
+                gathered_sizes = [torch.empty_like(local_size) for _ in range(self.ep_group.world_size)]
+                torch.distributed.all_gather(gathered_sizes, local_size, group=self.ep_group.group)
+                resolved_split_sizes = [int(size.item()) for size in gathered_sizes]
+            elif isinstance(sequence_split_sizes, torch.Tensor):
+                if sequence_split_sizes.device.type != "cpu":
+                    raise ValueError("sequence_split_sizes tensor must be CPU-resident")
+                raw_split_sizes = [int(size) for size in sequence_split_sizes.tolist()]
+                if global_ranks is not None and len(raw_split_sizes) != self.ep_group.world_size:
+                    resolved_split_sizes = [raw_split_sizes[index] for index in global_ranks]
+                else:
+                    resolved_split_sizes = raw_split_sizes
+            else:
+                raw_split_sizes = [int(size) for size in sequence_split_sizes]
+                if global_ranks is not None and len(raw_split_sizes) != self.ep_group.world_size:
+                    resolved_split_sizes = [raw_split_sizes[index] for index in global_ranks]
+                else:
+                    resolved_split_sizes = raw_split_sizes
+            if (
+                len(resolved_split_sizes) != self.ep_group.world_size
+                or any(size < 0 for size in resolved_split_sizes)
+                or resolved_split_sizes[self.ep_group.rank] != x_heads.shape[0]
+            ):
+                raise ValueError("sequence_split_sizes must match the MoE group's local sequence shard")
+            x_heads = ep_dispatch(x_heads, self.ep_group, resolved_split_sizes)
         output = self._local_forward(x_heads) if self.has_real_moe_heads else torch.zeros_like(x_heads)
         if self.ep_group.world_size > 1:
-            output = ep_undispatch(output, self.ep_group, sequence_split_sizes)
+            output = ep_undispatch(output, self.ep_group, resolved_split_sizes)
         if self.ep_pad_heads:
             output = output[:, : self.num_heads]
         return output.reshape(-1, self.num_heads * self.d_head)
@@ -542,6 +1245,9 @@ __all__ = [
     "Magi2MultiHeadMoEConfig",
     "compute_topk_probs_and_indices",
     "global_sort_routes",
+    "global_sort_routes_with_head_ids",
+    "global_sort_routes_with_head_ids_and_counts",
     "torch_mh_moe_forward",
+    "mate_bf16_mh_moe_forward",
     "triton_mh_moe_forward",
 ]

--- a/vllm_omni/diffusion/models/magi2/mhc_kernel.py
+++ b/vllm_omni/diffusion/models/magi2/mhc_kernel.py
@@ -1,0 +1,322 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+# ruff: noqa: N803
+
+"""Fixed-size Triton kernels for MAGI-2 mHC post processing."""
+
+from __future__ import annotations
+
+import torch
+from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import direct_register_custom_op
+
+
+@triton.jit
+def _mhc_coefficients_kernel(
+    post_logits_ptr,
+    residual_logits_ptr,
+    alpha_post_ptr,
+    bias_post_ptr,
+    alpha_residual_ptr,
+    bias_residual_ptr,
+    post_out_ptr,
+    residual_out_ptr,
+    post_stride,
+    residual_stride,
+    scale,
+    eps,
+    NUM_ITERS: tl.constexpr,
+):
+    """Fuse MAGI-2 coefficient affine transforms and Sinkhorn normalization.
+
+    The input views are the post-split portions of the [tokens, 24] projection,
+    hence their token stride is intentionally a runtime value (normally 24).
+    Both outputs are contiguous BF16 tensors consumed by the connection
+    kernel, without intermediate packed tensors or layout copies.
+    """
+
+    token = tl.program_id(0)
+    post_offs = tl.arange(0, 4)
+    residual_offs = tl.arange(0, 16)
+    post_logits = tl.load(post_logits_ptr + token * post_stride + post_offs).to(tl.float32)
+    residual_logits = tl.load(residual_logits_ptr + token * residual_stride + residual_offs).to(tl.float32)
+    alpha_post = tl.load(alpha_post_ptr).to(tl.float32)
+    alpha_residual = tl.load(alpha_residual_ptr).to(tl.float32)
+    post_bias = tl.load(bias_post_ptr + post_offs).to(tl.float32)
+    residual_bias = tl.load(bias_residual_ptr + residual_offs).to(tl.float32)
+
+    post = 2.0 * tl.sigmoid(alpha_post * scale * post_logits + post_bias)
+    rows = residual_offs // 4
+    cols = residual_offs - rows * 4
+    matrix = alpha_residual * scale * residual_logits + residual_bias
+    matrix = tl.exp(matrix - tl.max(matrix, axis=0))
+    for _ in tl.static_range(NUM_ITERS):
+        col0 = tl.sum(tl.where(cols == 0, matrix, 0.0), axis=0)
+        col1 = tl.sum(tl.where(cols == 1, matrix, 0.0), axis=0)
+        col2 = tl.sum(tl.where(cols == 2, matrix, 0.0), axis=0)
+        col3 = tl.sum(tl.where(cols == 3, matrix, 0.0), axis=0)
+        col_sum = tl.where(
+            cols == 0,
+            col0,
+            tl.where(cols == 1, col1, tl.where(cols == 2, col2, col3)),
+        )
+        matrix = matrix / (col_sum + eps)
+        row0 = tl.sum(tl.where(rows == 0, matrix, 0.0), axis=0)
+        row1 = tl.sum(tl.where(rows == 1, matrix, 0.0), axis=0)
+        row2 = tl.sum(tl.where(rows == 2, matrix, 0.0), axis=0)
+        row3 = tl.sum(tl.where(rows == 3, matrix, 0.0), axis=0)
+        row_sum = tl.where(
+            rows == 0,
+            row0,
+            tl.where(rows == 1, row1, tl.where(rows == 2, row2, row3)),
+        )
+        matrix = matrix / (row_sum + eps)
+
+    tl.store(post_out_ptr + token * 4 + post_offs, post.to(tl.bfloat16))
+    tl.store(residual_out_ptr + token * 16 + residual_offs, matrix.to(tl.bfloat16))
+
+
+def _mhc_coefficients(
+    post_logits: torch.Tensor,
+    residual_logits: torch.Tensor,
+    alpha_post: torch.Tensor,
+    bias_post: torch.Tensor,
+    alpha_residual: torch.Tensor,
+    bias_residual: torch.Tensor,
+    *,
+    scale: float,
+    num_iters: int,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if post_logits.ndim != 2 or post_logits.shape[-1] != 4:
+        raise ValueError("expected post logits shape [tokens, 4]")
+    if residual_logits.ndim != 3 or residual_logits.shape[-2:] != (4, 4):
+        raise ValueError("expected residual logits shape [tokens, 4, 4]")
+    if post_logits.shape[0] != residual_logits.shape[0]:
+        raise ValueError("post and residual token counts must match")
+    if post_logits.stride(-1) != 1 or residual_logits.stride()[-2:] != (4, 1):
+        raise ValueError("mHC coefficient views must be contiguous in their stream dimensions")
+    if num_iters > 64:
+        raise ValueError("MAGI-2 fused Sinkhorn requires iters<=64")
+    tokens = post_logits.shape[0]
+    post_out = torch.empty((tokens, 4), dtype=torch.bfloat16, device=post_logits.device)
+    residual_out = torch.empty((tokens, 4, 4), dtype=torch.bfloat16, device=post_logits.device)
+    if tokens == 0:
+        return post_out, residual_out
+    _mhc_coefficients_kernel[(tokens,)](
+        post_logits,
+        residual_logits,
+        alpha_post,
+        bias_post,
+        alpha_residual,
+        bias_residual,
+        post_out,
+        residual_out,
+        post_logits.stride(0),
+        residual_logits.stride(0),
+        scale,
+        eps,
+        NUM_ITERS=num_iters,
+        num_warps=1,
+        enable_fp_fusion=False,
+    )
+    return post_out, residual_out
+
+
+@triton.jit
+def _mhc_mix_output_kernel(
+    streams_ptr,
+    block_out_ptr,
+    post_ptr,
+    res_ptr,
+    out_ptr,
+    hidden,
+    NUM_STREAM: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+):
+    token = tl.program_id(0)
+    offs_c = tl.program_id(1) * BLOCK_C + tl.arange(0, BLOCK_C)
+    mask_c = offs_c < hidden
+    offs_n = tl.arange(0, NUM_STREAM)
+
+    acc = tl.zeros([NUM_STREAM, BLOCK_C], dtype=tl.float32)
+    for j in tl.static_range(NUM_STREAM):
+        stream = tl.load(
+            streams_ptr + (token * NUM_STREAM + j) * hidden + offs_c,
+            mask=mask_c,
+            other=0.0,
+        ).to(tl.float32)
+        res = tl.load(res_ptr + token * NUM_STREAM * NUM_STREAM + offs_n * NUM_STREAM + j)
+        acc += res[:, None] * stream[None, :]
+
+    written = tl.load(block_out_ptr + token * hidden + offs_c, mask=mask_c, other=0.0)
+    post = tl.load(post_ptr + token * NUM_STREAM + offs_n)
+    acc += post[:, None] * written.to(tl.float32)[None, :]
+
+    tl.store(
+        out_ptr + (token * NUM_STREAM + offs_n[:, None]) * hidden + offs_c[None, :],
+        acc.to(out_ptr.dtype.element_ty),
+        mask=mask_c[None, :],
+    )
+
+
+@triton.jit
+def _mhc_sinkhorn_kernel(
+    h_ptr,
+    out_ptr,
+    eps,
+    NUM_STREAM: tl.constexpr,
+    NUM_ITERS: tl.constexpr,
+):
+    """Run the fixed four-stream Sinkhorn normalization per token."""
+
+    token = tl.program_id(0)
+    offs = tl.arange(0, 16)
+    rows = offs // 4
+    cols = offs - rows * 4
+    matrix = tl.load(h_ptr + token * NUM_STREAM * NUM_STREAM + offs)
+    matrix = tl.exp(matrix - tl.max(matrix, axis=0))
+    for _ in tl.static_range(NUM_ITERS):
+        col0 = tl.sum(tl.where(cols == 0, matrix, 0.0), axis=0)
+        col1 = tl.sum(tl.where(cols == 1, matrix, 0.0), axis=0)
+        col2 = tl.sum(tl.where(cols == 2, matrix, 0.0), axis=0)
+        col3 = tl.sum(tl.where(cols == 3, matrix, 0.0), axis=0)
+        col_sum = tl.where(
+            cols == 0,
+            col0,
+            tl.where(cols == 1, col1, tl.where(cols == 2, col2, col3)),
+        )
+        matrix = matrix / (col_sum + eps)
+        row0 = tl.sum(tl.where(rows == 0, matrix, 0.0), axis=0)
+        row1 = tl.sum(tl.where(rows == 1, matrix, 0.0), axis=0)
+        row2 = tl.sum(tl.where(rows == 2, matrix, 0.0), axis=0)
+        row3 = tl.sum(tl.where(rows == 3, matrix, 0.0), axis=0)
+        row_sum = tl.where(
+            rows == 0,
+            row0,
+            tl.where(rows == 1, row1, tl.where(rows == 2, row2, row3)),
+        )
+        matrix = matrix / (row_sum + eps)
+    tl.store(out_ptr + token * NUM_STREAM * NUM_STREAM + offs, matrix)
+
+
+def _mhc_mix_output(
+    streams: torch.Tensor,
+    block_out: torch.Tensor,
+    post: torch.Tensor,
+    residual: torch.Tensor,
+) -> torch.Tensor:
+    if streams.ndim != 3:
+        raise ValueError("streams must have shape [tokens, streams, hidden]")
+    tokens, num_stream, hidden = streams.shape
+    if num_stream != 4:
+        raise ValueError("MAGI-2 fused mHC kernel requires exactly 4 streams")
+    if block_out.shape != (tokens, hidden):
+        raise ValueError("invalid mHC branch output shape")
+    if post.shape != (tokens, num_stream):
+        raise ValueError("invalid mHC post coefficient shape")
+    if residual.shape != (tokens, num_stream, num_stream):
+        raise ValueError("invalid mHC residual matrix shape")
+    out = torch.empty_like(streams)
+    block_c = min(1024, triton.next_power_of_2(hidden))
+    _mhc_mix_output_kernel[(tokens, triton.cdiv(hidden, block_c))](
+        streams,
+        block_out,
+        post.contiguous(),
+        residual.contiguous(),
+        out,
+        hidden,
+        NUM_STREAM=num_stream,
+        BLOCK_C=block_c,
+        num_warps=4,
+    )
+    return out
+
+
+def _mhc_sinkhorn(
+    logits: torch.Tensor,
+    *,
+    num_iters: int,
+    eps: float,
+) -> torch.Tensor:
+    if logits.ndim != 3 or logits.shape[-1] != logits.shape[-2]:
+        raise ValueError("expected [tokens, streams, streams] logits")
+    tokens, num_stream, _ = logits.shape
+    if num_stream != 4 or num_iters > 64:
+        raise ValueError("MAGI-2 fused Sinkhorn requires 4 streams and iters<=64")
+    out = torch.empty_like(logits, dtype=torch.float32)
+    _mhc_sinkhorn_kernel[(tokens,)](
+        logits.contiguous(),
+        out,
+        eps,
+        NUM_STREAM=num_stream,
+        NUM_ITERS=num_iters,
+        num_warps=1,
+    )
+    return out
+
+
+def _mhc_mix_output_fake(
+    streams: torch.Tensor,
+    block_out: torch.Tensor,
+    post: torch.Tensor,
+    residual: torch.Tensor,
+) -> torch.Tensor:
+    return torch.empty_like(streams)
+
+
+def _mhc_sinkhorn_fake(logits: torch.Tensor, *, num_iters: int, eps: float) -> torch.Tensor:
+    return torch.empty_like(logits, dtype=torch.float32)
+
+
+def _mhc_coefficients_fake(
+    post_logits: torch.Tensor,
+    residual_logits: torch.Tensor,
+    alpha_post: torch.Tensor,
+    bias_post: torch.Tensor,
+    alpha_residual: torch.Tensor,
+    bias_residual: torch.Tensor,
+    *,
+    scale: float,
+    num_iters: int,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del alpha_post, bias_post, alpha_residual, bias_residual, scale, num_iters, eps
+    return (
+        torch.empty((post_logits.shape[0], 4), dtype=torch.bfloat16, device=post_logits.device),
+        torch.empty(
+            (post_logits.shape[0], 4, 4),
+            dtype=torch.bfloat16,
+            device=post_logits.device,
+        ),
+    )
+
+
+# Register at import time so compiled diffusion regions see an opaque custom op
+# instead of a first-call Triton graph break/JIT.
+direct_register_custom_op(
+    "magi2_mhc_mix_output",
+    _mhc_mix_output,
+    mutates_args=[],
+    fake_impl=_mhc_mix_output_fake,
+)
+mhc_mix_output = torch.ops.vllm.magi2_mhc_mix_output
+
+direct_register_custom_op(
+    "magi2_mhc_sinkhorn",
+    _mhc_sinkhorn,
+    mutates_args=[],
+    fake_impl=_mhc_sinkhorn_fake,
+)
+mhc_sinkhorn = torch.ops.vllm.magi2_mhc_sinkhorn
+
+direct_register_custom_op(
+    "magi2_mhc_coefficients",
+    _mhc_coefficients,
+    mutates_args=[],
+    fake_impl=_mhc_coefficients_fake,
+)
+mhc_coefficients = torch.ops.vllm.magi2_mhc_coefficients
+
+
+__all__ = ["mhc_coefficients", "mhc_mix_output", "mhc_sinkhorn"]

--- a/vllm_omni/diffusion/models/magi2/modeling_magi2.py
+++ b/vllm_omni/diffusion/models/magi2/modeling_magi2.py
@@ -210,7 +210,12 @@ class Magi2MLP(nn.Module):
             parallel_mode="row",
         )
 
-    def forward(self, hidden_states: torch.Tensor, dispatcher: ModalityDispatcher) -> torch.Tensor:
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        dispatcher: ModalityDispatcher,
+        _sequence_split_sizes: list[int] | torch.Tensor | None = None,
+    ) -> torch.Tensor:
         hidden_states = self.pre_norm(hidden_states, dispatcher)
         hidden_states = self.up_gate_proj(hidden_states, dispatcher)
         hidden_states = swiglu7(hidden_states)
@@ -303,10 +308,15 @@ class Magi2MultiHeadMoELayer(nn.Module):
             modality.contiguous(), dispatcher
         )
 
-    def forward(self, hidden_states: torch.Tensor, dispatcher: ModalityDispatcher) -> torch.Tensor:
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        dispatcher: ModalityDispatcher,
+        sequence_split_sizes: list[int] | torch.Tensor | None = None,
+    ) -> torch.Tensor:
         normalized = self.pre_norm(hidden_states, dispatcher)
         routed = self.split_linear(normalized)
-        routed = self.moe_mlp(routed)
+        routed = self.moe_mlp(routed, sequence_split_sizes=sequence_split_sizes)
         routed = self.merge_linear(routed)
         return routed + self._shared_experts(normalized, dispatcher)
 
@@ -343,6 +353,7 @@ class Magi2PreAdapter(nn.Module):
         video_indices: torch.Tensor,
         audio_indices: torch.Tensor,
         text_indices: torch.Tensor,
+        _time_indices: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         rope = self.rope(coords_mapping)
         output = torch.zeros(
@@ -479,9 +490,22 @@ class Magi2TransformerLayer(nn.Module):
         branch: str,
         dispatcher: ModalityDispatcher,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        norm_dtype = None
+        if (
+            os.environ.get("MAGI2_MHC_BF16_NORM", "1") == "1"
+            and os.environ.get("MAGI2_DETERMINISTIC", "0") != "1"
+            and streams.device.type in {"musa", "privateuseone"}
+            and streams.dtype == torch.bfloat16
+            and streams.shape[1] == self.config.mhc.num_streams == 4
+        ):
+            norm_dtype = torch.bfloat16
         return self.mhc_handler.compute_logits(
             self.mhc_handler.flatten(streams),
-            partial(self.mhc_norm, modality_dispatcher=dispatcher),
+            partial(
+                self.mhc_norm,
+                modality_dispatcher=dispatcher,
+                out_dtype=norm_dtype,
+            ),
             getattr(self, f"mhc_phi_fused_{branch}"),
         )
 
@@ -546,7 +570,7 @@ class Magi2TransformerLayer(nn.Module):
         streams = self._connect(streams, attention_output, "attn", attention_logits)
         mlp_logits = self._branch_logits(streams, "mlp", modality_dispatcher)
         mlp_input = self._branch_input(streams, "mlp", mlp_logits)
-        mlp_output = self.mlp(mlp_input, modality_dispatcher)
+        mlp_output = self.mlp(mlp_input, modality_dispatcher, cp_split_sizes)
         streams = self._connect(streams, mlp_output, "mlp", mlp_logits)
         return streams.reshape(streams.shape[0], -1)
 
@@ -653,6 +677,7 @@ class Magi2PreviewTransformer(nn.Module):
         video_indices = torch.nonzero(modality_mapping == int(Modality.VIDEO)).flatten()
         audio_indices = torch.nonzero(modality_mapping == int(Modality.AUDIO)).flatten()
         text_indices = torch.nonzero(modality_mapping == int(Modality.TEXT)).flatten()
+        time_indices = torch.nonzero(time_mask).flatten()
 
         hidden_states, rope = self.pre_adapter(
             x,
@@ -660,6 +685,7 @@ class Magi2PreviewTransformer(nn.Module):
             video_indices,
             audio_indices,
             text_indices,
+            time_indices,
         )
         if time_token_sequence is not None and time_token_sequence.shape[-1] > 0:
             hidden_states[:, : time_token_sequence.shape[-1]] = time_token_sequence.to(hidden_states.dtype)

--- a/vllm_omni/diffusion/models/magi2/parallel.py
+++ b/vllm_omni/diffusion/models/magi2/parallel.py
@@ -18,16 +18,22 @@ Ulysses keeps using SP while native column/row tensor parallelism and the MoE
 heads use TP.  This gives TP4 and TP2SP2 independent weight/head and token
 axes while preserving the released equations and checkpoint hierarchy.
 
-These helpers intentionally do not create or own process groups.
+The normal path reuses vLLM-owned groups.  The opt-in ``MAGI2_EP_SIZE`` path
+creates deterministic contiguous EP subgroups for MAGI-2 experiments when the
+pipeline does not expose an expert-parallel group yet.
 """
 
 from __future__ import annotations
 
+import logging
+import os
 from collections.abc import Iterable
 from dataclasses import dataclass
 
 import torch
 import torch.distributed as dist
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -38,6 +44,13 @@ class Magi2ParallelGroup:
     world_size: int
     rank: int
     replicated_sequence: bool = False
+    # Global ranks in an experimental MAGI MoE group. ``None`` denotes a
+    # vLLM-owned group whose rank order is already local to its coordinator.
+    global_ranks: tuple[int, ...] | None = None
+    global_rank: int | None = None
+
+
+_CUSTOM_EP_GROUPS: dict[tuple[int, int, str], Magi2ParallelGroup] = {}
 
 
 def _dist_group_info(group: dist.ProcessGroup | None) -> Magi2ParallelGroup:
@@ -76,13 +89,52 @@ def get_magi2_ep_group() -> Magi2ParallelGroup:
     """Return the process group used for MAGI's MoE-head parallelism.
 
     TP is the explicit MoE-head axis when it is larger than one.  Otherwise
-    the released SP-only layout overlaps head parallelism with Ulysses.  Both
-    groups are initialized and owned by vLLM-Omni; MAGI creates no ad-hoc
-    process groups.
+    the released SP-only layout overlaps head parallelism with Ulysses.  The
+    normal path reuses vLLM-owned groups; ``MAGI2_EP_SIZE`` is an explicit
+    experimental escape hatch that creates deterministic contiguous subgroups.
     """
 
     if not dist.is_available() or not dist.is_initialized():
         return Magi2ParallelGroup(None, 1, 0)
+    ep_size_text = os.environ.get("MAGI2_EP_SIZE")
+    if ep_size_text:
+        try:
+            ep_size = int(ep_size_text)
+        except ValueError as exc:
+            raise ValueError("MAGI2_EP_SIZE must be an integer") from exc
+        world = dist.get_world_size()
+        global_rank = dist.get_rank()
+        if ep_size < 1 or world % ep_size != 0:
+            raise ValueError(f"MAGI2_EP_SIZE={ep_size} must divide diffusion world size {world}")
+        if ep_size > 1:
+            backend = str(dist.get_backend())
+            cache_key = (world, ep_size, backend)
+            cached = _CUSTOM_EP_GROUPS.get(cache_key)
+            if cached is not None:
+                return cached
+            selected = None
+            # Every rank creates every subgroup in identical order, as
+            # required by torch.distributed.new_group.
+            for start in range(0, world, ep_size):
+                ranks = tuple(range(start, start + ep_size))
+                group = dist.new_group(ranks=list(ranks), backend=backend)
+                if global_rank in ranks:
+                    selected = Magi2ParallelGroup(
+                        group=group,
+                        world_size=ep_size,
+                        rank=ranks.index(global_rank),
+                        replicated_sequence=False,
+                        global_ranks=ranks,
+                        global_rank=global_rank,
+                    )
+            assert selected is not None
+            _CUSTOM_EP_GROUPS[cache_key] = selected
+            logger.info(
+                "MAGI2 experimental EP group: global_rank=%d ranks=%s",
+                global_rank,
+                selected.global_ranks,
+            )
+            return selected
     try:
         from vllm.distributed.parallel_state import get_tp_group
 
@@ -124,10 +176,7 @@ def get_magi2_replica_group(data_parallel_size: int) -> Magi2ParallelGroup:
     The pipeline uses this group for conditioning broadcasts and output-rank
     ownership.  With DP=1 the diffusion world is exactly one TP x SP replica.
     With DP>1, MAGI currently requires TP=1, so the existing SP group is the
-    complete per-replica group. CFG x DP is deliberately rejected by
-    ``_validate_native_topology``; if that combination is enabled in the
-    future, this helper must select a group fixed to one DP replica and include
-    its CFG ranks rather than returning the SP group alone.
+    complete per-replica group.  Topology validation enforces those premises.
     """
 
     if not dist.is_available() or not dist.is_initialized():

--- a/vllm_omni/diffusion/models/magi2/pipeline_magi2.py
+++ b/vllm_omni/diffusion/models/magi2/pipeline_magi2.py
@@ -118,15 +118,24 @@ DEFAULT_NEGATIVE_PROMPT += (
 class _PeakReservedMonitor:
     def __init__(self, device: int) -> None:
         self.device = device
-        self.peak_bytes = torch.accelerator.memory_reserved(device)
+        self.peak_bytes = self._memory_reserved()
         self._stop = threading.Event()
         self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def _memory_reserved(self) -> int:
+        try:
+            return int(torch.accelerator.memory_reserved(self.device))
+        except (AttributeError, RuntimeError, NotImplementedError):
+            # Some accelerator builds expose synchronization but not a
+            # reserved-memory counter. Monitoring is diagnostic only and must
+            # not block a correctness run on those platforms.
+            return 0
 
     def _run(self) -> None:
         while not self._stop.is_set():
             self.peak_bytes = max(
                 self.peak_bytes,
-                torch.accelerator.memory_reserved(self.device),
+                self._memory_reserved(),
             )
             self._stop.wait(0.05)
 
@@ -138,7 +147,7 @@ class _PeakReservedMonitor:
         self._thread.join()
         self.peak_bytes = max(
             self.peak_bytes,
-            torch.accelerator.memory_reserved(self.device),
+            self._memory_reserved(),
         )
 
 
@@ -370,6 +379,12 @@ def _seed_request(seed: int) -> None:
     random.seed(seed)
     np.random.seed(seed % (2**32))
     torch.manual_seed(seed)
+    if current_omni_platform.is_musa():
+        # torch.cuda intentionally reports false on MUSA; use the platform
+        # hook when available so each worker's accelerator RNG is seeded.
+        manual_seed_all = getattr(current_omni_platform, "manual_seed_all", None)
+        if manual_seed_all is not None:
+            manual_seed_all(seed)
 
 
 def _resolve_request_seed(sampling: object) -> int:
@@ -496,6 +511,16 @@ class Magi2Pipeline(
     SupportImageInput,
     SupportAudioOutput,
 ):
+    _PROFILER_TARGETS = (
+        "_encode_prompts",
+        "_encode_reference_image",
+        "_pool_figure_token",
+        "sampler.sample",
+        "sampler.denoise_step",
+        "_decode_video",
+        "_decode_audio",
+    )
+
     """Native MAGI-2 Preview text/image-to-video-and-audio pipeline.
 
     One pipeline instance is supported per worker process. Initialization sets
@@ -527,11 +552,7 @@ class Magi2Pipeline(
 
     @staticmethod
     def _remap_ckpt_key(checkpoint_key: str) -> str | None:
-        """Map released Preview keys to the native pipeline namespace.
-
-        The DLO host-weight planner looks this hook up by name when it builds
-        a direct mmap plan; the ordinary loader uses ``load_weights`` below.
-        """
+        """Map released Preview keys to the native pipeline namespace."""
 
         checkpoint_key = checkpoint_key.removeprefix("transformer.")
         if checkpoint_key.startswith(("block.", "pre_adapter.", "post_adapter.")):
@@ -546,12 +567,15 @@ class Magi2Pipeline(
         if not od_config.model:
             raise ValueError("MAGI-2 requires od_config.model")
         _validate_native_topology(od_config)
-        if not current_omni_platform.is_cuda() or not current_omni_platform.is_available():
-            raise RuntimeError("MAGI-2 Preview requires CUDA GPUs")
+        if not (
+            (current_omni_platform.is_cuda() or current_omni_platform.is_musa())
+            and current_omni_platform.is_available()
+        ):
+            raise RuntimeError("MAGI-2 Preview requires a CUDA or MUSA accelerator")
 
         self.od_config = od_config
         self.dtype = od_config.dtype or torch.bfloat16
-        self.device_str = f"cuda:{torch.accelerator.current_device_index()}"
+        self.device_str = f"{current_omni_platform.device_type}:{torch.accelerator.current_device_index()}"
         self.checkpoint_root = _resolve_checkpoint_root(
             str(od_config.model),
             od_config.revision,
@@ -678,14 +702,7 @@ class Magi2Pipeline(
             )
         ]
         self.setup_diffusion_pipeline_profiler(
-            profiler_targets=[
-                "_encode_prompts",
-                "_encode_reference_image",
-                "_pool_figure_token",
-                "sampler.sample",
-                "_decode_video",
-                "_decode_audio",
-            ],
+            profiler_targets=list(self._PROFILER_TARGETS),
             enable_diffusion_pipeline_profiler=bool(getattr(od_config, "enable_diffusion_pipeline_profiler", False)),
         )
 
@@ -841,10 +858,6 @@ class Magi2Pipeline(
     ) -> torch.Tensor:
         special: torch.Tensor | None = None
         if self._is_output_rank:
-            # This helper only tokenizes the prompt and pools rows that are
-            # already present in ``context``; it does not read encoder weights.
-            # Keep it outside the staged encoder window so CPU-only pooling
-            # cannot trigger an unnecessary device transfer.
             special = self.text_encoder.module.pool_figure_tokens(
                 prompt,
                 ["<Figure 1>"],
@@ -911,15 +924,7 @@ class Magi2Pipeline(
 
         latent_height = height // MAGI2_GENERATION_CONFIG.video_vae_stride[1]
         latent_width = width // MAGI2_GENERATION_CONFIG.video_vae_stride[2]
-        public_frame_length = int(round(MAGI2_GENERATION_CONFIG.duration_seconds * MAGI2_GENERATION_CONFIG.fps))
-        if public_frame_length != MAGI2_GENERATION_CONFIG.output_frames:
-            raise RuntimeError(
-                "MAGI-2 generation config is inconsistent: duration_seconds * fps must equal output_frames"
-            )
-        # The Preview DiT/decoder operates on the internal 25-FPS timeline,
-        # while the public output contract is 12.5 FPS. The internal timeline
-        # is therefore twice as long; the decoded result is muxed at 12.5 FPS.
-        video_frame_length = public_frame_length * 2
+        video_frame_length = int(round(MAGI2_GENERATION_CONFIG.duration_seconds * MAGI2_GENERATION_CONFIG.fps * 2))
         latent_length = (video_frame_length - 1) // MAGI2_GENERATION_CONFIG.video_vae_stride[0] + 1
         audio_length = int(round(MAGI2_GENERATION_CONFIG.duration_seconds * MAGI2_GENERATION_CONFIG.audio_latent_fps))
         # Draw order is parity-critical: video noise precedes audio noise.
@@ -1062,18 +1067,12 @@ class Magi2Pipeline(
         seed = _resolve_request_seed(sampling)
         _seed_request(seed)
 
-        has_cuda = current_omni_platform.is_cuda() and current_omni_platform.is_available()
-        device_index = torch.accelerator.current_device_index() if has_cuda else None
-        # Sampling reserved memory is qualification instrumentation, not part
-        # of ordinary serving. It starts only when the pipeline profiler is
-        # explicitly enabled, so every CUDA request avoids a 20 Hz thread.
-        monitor = (
-            _PeakReservedMonitor(device_index)
-            if device_index is not None and getattr(self, "enable_diffusion_pipeline_profiler", False)
-            else None
-        )
+        has_accelerator = (
+            current_omni_platform.is_cuda() or current_omni_platform.is_musa()
+        ) and current_omni_platform.is_available()
+        device_index = torch.accelerator.current_device_index() if has_accelerator else None
+        monitor = _PeakReservedMonitor(device_index) if device_index is not None else None
         monitor_started = False
-        started = time.perf_counter()
         try:
             if monitor is not None:
                 monitor.start()
@@ -1087,7 +1086,7 @@ class Magi2Pipeline(
                 height=height,
                 num_inference_steps=steps,
             )
-            if has_cuda:
+            if has_accelerator:
                 torch.accelerator.synchronize()
         finally:
             if monitor_started:
@@ -1098,7 +1097,7 @@ class Magi2Pipeline(
             video = _resize_video(video, output_width, output_height)
 
         peak_memory_mb = monitor.peak_bytes / 1024**2 if monitor is not None else 0.0
-        if has_cuda and dist.is_available() and dist.is_initialized() and self._parallel_group.world_size > 1:
+        if has_accelerator and dist.is_available() and dist.is_initialized() and self._parallel_group.world_size > 1:
             peak = torch.tensor(peak_memory_mb, device=self.device_str)
             dist.all_reduce(
                 peak,

--- a/vllm_omni/diffusion/models/magi2/preview_data_proxy.py
+++ b/vllm_omni/diffusion/models/magi2/preview_data_proxy.py
@@ -539,13 +539,7 @@ class PackedModelInput:
 
 
 class Magi2DataProxy:
-    """Convert dense modality tensors to/from the transformer's packed ABI.
-
-    The proxy is request-stateless: all packing state needed by
-    ``process_output`` is returned as ``PackedModelInput.output_layout`` rather
-    than stored on this shared instance, so concurrent requests cannot
-    overwrite one another.
-    """
+    """Convert dense modality tensors to/from the transformer's packed ABI."""
 
     def __init__(self, config: Magi2PreviewDataProxyConfig | None = None) -> None:
         self.config = config or Magi2PreviewDataProxyConfig()

--- a/vllm_omni/diffusion/models/magi2/sampler_magi2.py
+++ b/vllm_omni/diffusion/models/magi2/sampler_magi2.py
@@ -151,6 +151,77 @@ class Magi2PreviewSampler(CFGParallelMixin):
         return self.forward(model_input)
 
     @torch.inference_mode()
+    def denoise_step(
+        self,
+        *,
+        sampler_input: SamplerInput,
+        latent: torch.Tensor,
+        audio_latent: torch.Tensor,
+        timestep: torch.Tensor,
+        video_cfg: float,
+        audio_cfg: float,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Execute exactly one joint video/audio denoising step.
+
+        Keeping the loop body in a named method gives the diffusion pipeline
+        profiler a real per-step boundary.  The returned tensors are the next
+        scheduler states, and no model placement is changed here.
+        """
+        model_input = self.prepare_model_input(
+            latent=latent,
+            audio_latent=audio_latent,
+            txt_feat=sampler_input.txt_feat,
+            null_txt_feat=sampler_input.null_txt_feat,
+            ref_audio_feat=sampler_input.ref_audio_feat,
+            ref_video_feat=sampler_input.ref_video_feat,
+            ref_image_feat=sampler_input.ref_image_feat,
+            ref_image_feat_len=sampler_input.ref_image_feat_len,
+            ref_image_special_token_embedding=sampler_input.ref_image_special_token_embedding,
+            t=timestep,
+            cfg_config=sampler_input.cfg_config,
+        )
+        if get_classifier_free_guidance_world_size() > 1:
+            positive_input, negative_input = self._split_cfg_model_input(model_input)
+            guided = self.predict_noise_maybe_with_cfg(
+                do_true_cfg=True,
+                true_cfg_scale=1.0,
+                positive_kwargs={"model_input": positive_input},
+                negative_kwargs={"model_input": negative_input},
+                cfg_normalize=False,
+                kwargs={
+                    "video_txt_guidance_scale": video_cfg,
+                    "audio_txt_guidance_scale": audio_cfg,
+                    "cfg_config": sampler_input.cfg_config,
+                    "latent": latent,
+                    "audio_latent": audio_latent,
+                },
+            )
+            if not isinstance(guided, tuple) or len(guided) != 2:
+                raise RuntimeError("MAGI-2 CFG parallel combine must return video and audio predictions")
+            return self._step_guided(
+                guided,
+                latent,
+                audio_latent,
+                sampler_input.video_scheduler,
+                sampler_input.audio_scheduler,
+                timestep,
+            )
+
+        model_pred = self.forward(model_input)
+        latent, audio_latent, _, _ = self.step(
+            model_pred,
+            latent,
+            audio_latent,
+            video_cfg,
+            audio_cfg,
+            sampler_input.video_scheduler,
+            sampler_input.audio_scheduler,
+            timestep,
+            cfg_config=sampler_input.cfg_config,
+        )
+        return latent, audio_latent
+
+    @torch.inference_mode()
     def sample(self, sampler_input: SamplerInput) -> tuple[torch.Tensor, torch.Tensor]:
         video_timesteps = list(sampler_input.video_t_list)
         audio_timesteps = list(sampler_input.audio_t_list)
@@ -174,58 +245,14 @@ class Magi2PreviewSampler(CFGParallelMixin):
             audio_cfgs,
             strict=True,
         ):
-            model_input = self.prepare_model_input(
+            latent, audio_latent = self.denoise_step(
+                sampler_input=sampler_input,
                 latent=latent,
                 audio_latent=audio_latent,
-                txt_feat=sampler_input.txt_feat,
-                null_txt_feat=sampler_input.null_txt_feat,
-                ref_audio_feat=sampler_input.ref_audio_feat,
-                ref_video_feat=sampler_input.ref_video_feat,
-                ref_image_feat=sampler_input.ref_image_feat,
-                ref_image_feat_len=sampler_input.ref_image_feat_len,
-                ref_image_special_token_embedding=(sampler_input.ref_image_special_token_embedding),
-                t=timestep,
-                cfg_config=sampler_input.cfg_config,
+                timestep=timestep,
+                video_cfg=video_cfg,
+                audio_cfg=audio_cfg,
             )
-            if get_classifier_free_guidance_world_size() > 1:
-                positive_input, negative_input = self._split_cfg_model_input(model_input)
-                guided = self.predict_noise_maybe_with_cfg(
-                    do_true_cfg=True,
-                    true_cfg_scale=1.0,
-                    positive_kwargs={"model_input": positive_input},
-                    negative_kwargs={"model_input": negative_input},
-                    cfg_normalize=False,
-                    kwargs={
-                        "video_txt_guidance_scale": video_cfg,
-                        "audio_txt_guidance_scale": audio_cfg,
-                        "cfg_config": sampler_input.cfg_config,
-                        "latent": latent,
-                        "audio_latent": audio_latent,
-                    },
-                )
-                if not isinstance(guided, tuple) or len(guided) != 2:
-                    raise RuntimeError("MAGI-2 CFG parallel combine must return video and audio predictions")
-                latent, audio_latent = self._step_guided(
-                    guided,
-                    latent,
-                    audio_latent,
-                    sampler_input.video_scheduler,
-                    sampler_input.audio_scheduler,
-                    timestep,
-                )
-            else:
-                model_pred = self.forward(model_input)
-                latent, audio_latent, _, _ = self.step(
-                    model_pred,
-                    latent,
-                    audio_latent,
-                    video_cfg,
-                    audio_cfg,
-                    sampler_input.video_scheduler,
-                    sampler_input.audio_scheduler,
-                    timestep,
-                    cfg_config=sampler_input.cfg_config,
-                )
 
         return latent, audio_latent
 

--- a/vllm_omni/diffusion/models/magi2/sgl_fused_moe_kernels.py
+++ b/vllm_omni/diffusion/models/magi2/sgl_fused_moe_kernels.py
@@ -1,0 +1,1538 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+# ruff: noqa: N803, E731
+
+"""MUSA-compatible fused MoE kernel used by the MAGI-2 fast path.
+
+The kernel body is adapted from SGLang's fused MoE implementation at
+``d533d3bf464d280f180e18d4d396e613a5998502`` (Apache-2.0).  Only the
+unquantized BF16 path is enabled here; quantized helpers are intentionally
+stubbed so this module does not acquire a runtime dependency on SGLang.
+"""
+
+from __future__ import annotations
+
+import functools
+import importlib
+import os
+from collections import OrderedDict
+from typing import Any
+
+import torch
+from vllm.triton_utils import tl, triton
+
+
+def _unsupported_quant(*args, **kwargs):
+    raise RuntimeError("quantized SGLang MoE path is not vendored")
+
+
+per_token_group_quant_fp8 = _unsupported_quant
+scaled_fp8_quant = _unsupported_quant
+sglang_per_token_group_quant_fp8 = _unsupported_quant
+per_token_group_quant_int8 = _unsupported_quant
+per_token_quant_int8 = _unsupported_quant
+sglang_per_token_group_quant_int8 = _unsupported_quant
+
+
+def is_batch_invariant_mode_enabled():
+    return False
+
+
+def get_moe_padding_size(_use_aiter):
+    return 0
+
+
+def cpu_has_amx_support():
+    return False
+
+
+def get_bool_env_var(name):
+    return os.environ.get(name, "0") == "1"
+
+
+def is_cpu():
+    return False
+
+
+def is_cuda():
+    return False
+
+
+def is_hip():
+    return False
+
+
+def is_sm90_supported():
+    return False
+
+
+try:
+    TensorDescriptor = importlib.import_module("triton.tools.tensor_descriptor").TensorDescriptor
+    _support_tensor_descriptor = True
+except Exception:
+    _support_tensor_descriptor = False
+
+_is_hip = is_hip()
+_is_cuda = is_cuda()
+_is_cpu_amx_available = cpu_has_amx_support()
+_is_cpu = is_cpu()
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
+
+if _is_cuda:
+    pass
+elif _is_cpu and _is_cpu_amx_available:
+    pass
+elif _is_hip:
+    pass
+
+padding_size = get_moe_padding_size(_use_aiter)
+
+
+def support_tensor_descriptor():
+    return _support_tensor_descriptor
+
+
+# swap_ab benefits SM90 GPUs (H20, H100, H200, etc.) for certain block shapes.
+@functools.lru_cache(maxsize=8)
+def should_enable_swap_ab(
+    BLOCK_SIZE_M: int,
+    BLOCK_SIZE_N: int,
+) -> bool:
+    if not _is_cuda or is_batch_invariant_mode_enabled():
+        return False
+
+    return is_sm90_supported() and BLOCK_SIZE_M < 64 and BLOCK_SIZE_N >= 64
+
+
+@triton.jit
+def write_zeros_to_output(
+    c_ptr,
+    stride_cm,
+    stride_cn,
+    pid_n,
+    N,
+    offs_token,
+    token_mask,
+    BLOCK_SIZE_M,
+    BLOCK_SIZE_N,
+    compute_type,
+):
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=compute_type)
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
+    c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, accumulator, mask=c_mask)
+
+
+@triton.jit
+def fused_moe_kernel_gptq_awq(
+    # Pointers to matrices
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    b_scale_ptr,
+    b_zp_ptr,
+    topk_weights_ptr,
+    sorted_token_ids_ptr,
+    expert_ids_ptr,
+    num_tokens_post_padded_ptr,
+    # Matrix dimensions
+    N: tl.constexpr,
+    K: tl.constexpr,
+    EM,
+    num_valid_tokens,
+    # The stride variables represent how much to increase the ptr by when
+    # moving by 1 element in a particular dimension. E.g. `stride_am` is
+    # how much to increase `a_ptr` by to get the element one row down
+    # (A has M rows).
+    stride_am,
+    stride_ak,
+    stride_be,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    stride_base,
+    stride_bsk,
+    stride_bsn,
+    stride_bze,
+    stride_bzk,
+    stride_bzn,
+    group_size: tl.constexpr,
+    # Meta-parameters
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    MUL_ROUTED_WEIGHT: tl.constexpr,
+    top_k: tl.constexpr,
+    compute_type: tl.constexpr,
+    has_zp: tl.constexpr,
+    use_int4_w4a16: tl.constexpr,
+    use_int8_w8a16: tl.constexpr,
+    even_Ks: tl.constexpr,
+    filter_expert: tl.constexpr,
+):
+    """
+    Implements the fused computation for a Mixture of Experts (MOE) using
+    token and expert matrices.
+    Key Parameters:
+    - A: The input tensor representing tokens with shape (*, K), where '*' can
+        be any shape representing batches and K is the feature dimension of
+        each token.
+    - B: The stacked MOE weight tensor with shape (E, N, K), where E is
+        the number of experts, K is the input feature dimension, and N is
+        the output feature dimension.
+    - C: The output cache tensor with shape (M, topk, N), where M is the
+        total number of tokens post padding, topk is the number of times
+        each token is repeated, and N is the output feature dimension.
+    - sorted_token_ids: A tensor containing the sorted indices of tokens,
+        repeated topk times and arranged by the expert index they are
+        assigned to.
+    - expert_ids: A tensor containing the indices of the expert for each
+        block. It determines which expert matrix from B should be used for
+        each block in A.
+    This kernel performs the multiplication of a token by its corresponding
+    expert matrix as determined by `expert_ids`. The sorting of
+    `sorted_token_ids` by expert index and padding ensures divisibility by
+    BLOCK_SIZE_M, which is necessary to maintain consistency in block matrix
+    multiplication across different blocks processed by the same expert.
+    """
+    # -----------------------------------------------------------
+    # Map program ids `pid` to the block of C it should compute.
+    # This is done in a grouped ordering to promote L2 data reuse.
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(EM, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    # ----------------------------------------------------------
+    # Create pointers for the first blocks of A and B.
+    # We will advance this pointer as we move in the K direction
+    # and accumulate
+    # `a_ptrs` is a block of [BLOCK_SIZE_M, BLOCK_SIZE_K] pointers
+    # `b_ptrs` is a block of [BLOCK_SIZE_K, BLOCK_SIZE_N] pointers
+    num_tokens_post_padded = tl.load(num_tokens_post_padded_ptr)
+    if pid_m * BLOCK_SIZE_M >= num_tokens_post_padded:
+        return
+    offs_token_id = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
+    offs_token = tl.load(sorted_token_ids_ptr + offs_token_id)
+    token_mask = offs_token < num_valid_tokens
+
+    off_experts = tl.load(expert_ids_ptr + pid_m).to(tl.int64)
+    if filter_expert and off_experts == -1:
+        # -----------------------------------------------------------
+        # Write back zeros to the output when the expert is not
+        # in the current expert parallel rank.
+        write_zeros_to_output(
+            c_ptr,
+            stride_cm,
+            stride_cn,
+            pid_n,
+            N,
+            offs_token,
+            token_mask,
+            BLOCK_SIZE_M,
+            BLOCK_SIZE_N,
+            compute_type,
+        )
+        return
+
+    offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)) % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = a_ptr + (offs_token[:, None] // top_k * stride_am + offs_k[None, :] * stride_ak)
+
+    if use_int4_w4a16:
+        b_ptrs = b_ptr + off_experts * stride_be + (offs_k[:, None] // 2) * stride_bk + offs_bn[None, :] * stride_bn
+        b_shifter = (offs_k[:, None] % 2) * 4
+    elif use_int8_w8a16:
+        b_ptrs = b_ptr + off_experts * stride_be + offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn
+
+    if not has_zp and use_int4_w4a16:
+        b_zp_num = 8
+    if not has_zp and use_int8_w8a16:
+        b_zp_num = 128
+    elif has_zp and use_int4_w4a16:
+        b_zp_shifter = (offs_bn[None, :] % 2) * 4
+
+    # -----------------------------------------------------------
+    # Iterate to compute a block of the C matrix.
+    # We accumulate into a `[BLOCK_SIZE_M, BLOCK_SIZE_N]` block
+    # of fp32 values for higher accuracy.
+    # `accumulator` will be converted back to fp16 after the loop.
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        # Load the next block of A and B, generate a mask by checking the
+        # K dimension.
+
+        if not even_Ks:
+            k_mask = offs_k[:, None] < K - k * BLOCK_SIZE_K
+            k_other = 0.0
+        else:
+            k_mask = None
+            k_other = None
+
+        a = tl.load(
+            a_ptrs,
+            mask=token_mask[:, None] & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+            other=0.0,
+        )
+        b = tl.load(b_ptrs)
+        if use_int4_w4a16:
+            b = (b >> b_shifter) & 0xF
+
+        b_scale_ptrs = (
+            b_scale_ptr
+            + off_experts * stride_base
+            + offs_bn[None, :] * stride_bsn
+            + ((offs_k[:, None] + BLOCK_SIZE_K * k) // group_size) * stride_bsk
+        )
+        b_scale = tl.load(b_scale_ptrs, mask=k_mask, other=k_other)
+        b_scale = b_scale.to(tl.float32)
+
+        if has_zp and use_int4_w4a16:
+            offs_k_true = (offs_k[:, None] + BLOCK_SIZE_K * k) // group_size
+            b_zp_ptrs = (
+                b_zp_ptr + off_experts * stride_bze + (offs_bn[None, :] // 2) * stride_bzn + offs_k_true * stride_bzk
+            )
+            b_zp = tl.load(b_zp_ptrs, mask=k_mask, other=k_other)
+            b_zp = (b_zp >> b_zp_shifter) & 0xF
+            b_zp = b_zp.to(tl.float32)
+        elif has_zp and use_int8_w8a16:
+            offs_k_true = (offs_k[:, None] + BLOCK_SIZE_K * k) // group_size
+            b_zp_ptrs = b_zp_ptr + off_experts * stride_bze + offs_bn[None, :] * stride_bzn + offs_k_true * stride_bzk
+            b_zp = tl.load(b_zp_ptrs, mask=k_mask, other=k_other)
+            b_zp = b_zp.to(tl.float32)
+
+        # We accumulate along the K dimension.
+        if has_zp:
+            b = ((b.to(tl.float32) - b_zp) * b_scale).to(compute_type)
+        else:
+            b = ((b.to(tl.float32) - b_zp_num) * b_scale).to(compute_type)
+        accumulator = tl.dot(a, b, acc=accumulator)
+
+        # Advance the ptrs to the next K block.
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        if use_int4_w4a16:
+            b_ptrs += (BLOCK_SIZE_K // 2) * stride_bk
+        else:
+            b_ptrs += BLOCK_SIZE_K * stride_bk
+
+    if MUL_ROUTED_WEIGHT:
+        moe_weight = tl.load(topk_weights_ptr + offs_token, mask=token_mask, other=0)
+        accumulator = accumulator * moe_weight[:, None]
+
+    accumulator = accumulator.to(compute_type)
+    # -----------------------------------------------------------
+    # Write back the block of the output
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
+    c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, accumulator, mask=c_mask)
+
+
+@triton.jit
+def fused_moe_kernel(
+    # Pointers to matrices
+    a_ptr,
+    a_desc,
+    b_ptr,
+    b_desc,
+    bias_ptr,
+    c_ptr,
+    a_scale_ptr,
+    b_scale_ptr,
+    topk_weights_ptr,
+    sorted_token_ids_ptr,
+    expert_ids_ptr,
+    num_tokens_post_padded_ptr,
+    add_mask_ptr,
+    # Matrix dimensions
+    N,
+    K,
+    EM,
+    num_valid_tokens,
+    # The stride variables represent how much to increase the ptr by when
+    # moving by 1 element in a particular dimension. E.g. `stride_am` is
+    # how much to increase `a_ptr` by to get the element one row down
+    # (A has M rows).
+    stride_am,
+    stride_ak,
+    stride_be,
+    stride_bk,
+    stride_bn,
+    stride_bias_e,
+    stride_bias_n,
+    stride_cm,
+    stride_cn,
+    stride_asm,
+    stride_ask,
+    stride_base,
+    stride_bsk,
+    stride_bsn,
+    # Block size for block-wise quantization
+    group_n: tl.constexpr,
+    group_k: tl.constexpr,
+    # Meta-parameters
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    MUL_ROUTED_WEIGHT: tl.constexpr,
+    top_k: tl.constexpr,
+    compute_type: tl.constexpr,
+    use_fp8_w8a8: tl.constexpr,
+    use_int8_w8a8: tl.constexpr,
+    use_int8_w8a16: tl.constexpr,
+    per_channel_quant: tl.constexpr,
+    even_Ks: tl.constexpr,
+    c_sorted: tl.constexpr,
+    filter_expert: tl.constexpr,
+    swap_ab: tl.constexpr,
+    FUSE_ADD_TO_OUTPUT: tl.constexpr,
+    MASK_OUTPUT: tl.constexpr,
+    FUSE_SUM_ALL_REDUCE: tl.constexpr,
+    LORA_PRESERVE_BASE: tl.constexpr,
+    ROUTER_TOPK: tl.constexpr,
+    FUSE_SWIGLU: tl.constexpr = False,
+    SWIGLU_ALPHA: tl.constexpr = 0.0,
+    SWIGLU_LIMIT: tl.constexpr = 0.0,
+    HAS_SWIGLU_ALPHA: tl.constexpr = False,
+):
+    """
+    Implements the fused computation for a Mixture of Experts (MOE) using
+    token and expert matrices.
+
+    Key Parameters:
+    - A: The input tensor representing tokens with shape (*, K), where '*' can
+        be any shape representing batches and K is the feature dimension of
+        each token.
+    - B: The stacked MOE weight tensor with shape (E, N, K), where E is
+        the number of experts, K is the input feature dimension, and N is
+        the output feature dimension.
+    - C: The output cache tensor with shape (M, topk, N), where M is the
+        total number of tokens post padding, topk is the number of times
+        each token is repeated, and N is the output feature dimension.
+    - sorted_token_ids: A tensor containing the sorted indices of tokens,
+        repeated topk times and arranged by the expert index they are
+        assigned to.
+    - expert_ids: A tensor containing the indices of the expert for each
+        block. It determines which expert matrix from B should be used for
+        each block in A.
+
+    This kernel performs the multiplication of a token by its corresponding
+    expert matrix as determined by `expert_ids`. The sorting of
+    `sorted_token_ids` by expert index and padding ensures divisibility by
+    BLOCK_SIZE_M, which is necessary to maintain consistency in block matrix
+    multiplication across different blocks processed by the same expert.
+    """
+    # -----------------------------------------------------------
+    # Map program ids `pid` to the block of C it should compute.
+    # This is done in a grouped ordering to promote L2 data reuse.
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(EM, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    # ----------------------------------------------------------
+    # Create pointers for the first blocks of A and B.
+    # We will advance this pointer as we move in the K direction
+    # and accumulate
+    # `a_ptrs` is a block of [BLOCK_SIZE_M, BLOCK_SIZE_K] pointers
+    # `b_ptrs` is a block of [BLOCK_SIZE_K, BLOCK_SIZE_N] pointers
+    num_tokens_post_padded = tl.load(num_tokens_post_padded_ptr)
+    if pid_m * BLOCK_SIZE_M >= num_tokens_post_padded:
+        return
+    offs_token_id = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
+    offs_token = tl.load(sorted_token_ids_ptr + offs_token_id)
+    offs_token = offs_token.to(tl.int64)
+    token_mask = offs_token < num_valid_tokens
+
+    off_experts_i32 = tl.load(expert_ids_ptr + pid_m)
+    off_experts = off_experts_i32.to(tl.int64)
+
+    if filter_expert and off_experts == -1:
+        if FUSE_SWIGLU:
+            # C is the half-width post-activation buffer here. Rows owned by a
+            # filtered expert are never read (the down-GEMM CTA for this block
+            # early-exits before loading A), and an N-wide zero store would run
+            # past the row end into a neighboring token's data.
+            return
+        if not FUSE_ADD_TO_OUTPUT and not (FUSE_SUM_ALL_REDUCE and LORA_PRESERVE_BASE):
+            # Write zeros only when this kernel owns the full output; the experimental LoRA
+            # add path (LORA_PRESERVE_BASE) keeps the base output from the prior MoE kernel.
+            write_zeros_to_output(
+                c_ptr,
+                stride_cm,
+                stride_cn,
+                pid_n,
+                N,
+                offs_token,
+                token_mask,
+                BLOCK_SIZE_M,
+                BLOCK_SIZE_N,
+                compute_type,
+            )
+        return
+
+    offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)) % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    if a_desc is not None:
+        assert use_fp8_w8a8 and group_n > 0 and group_k > 0
+        start_offs_m = pid_m * BLOCK_SIZE_M
+    else:
+        a_ptrs = a_ptr + (offs_token[:, None] // top_k * stride_am + offs_k[None, :] * stride_ak)
+
+    if b_desc is not None:
+        start_offs_n = pid_n * BLOCK_SIZE_N
+    else:
+        b_ptrs = b_ptr + off_experts * stride_be + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+
+    if bias_ptr is not None:
+        bias = tl.load(bias_ptr + off_experts * stride_bias_e + offs_bn[None, :] * stride_bias_n)
+    if use_int8_w8a16:
+        b_scale_ptrs = b_scale_ptr + off_experts * stride_base + offs_bn[None, :] * stride_bsn
+        b_scale = tl.load(b_scale_ptrs)
+
+    if use_fp8_w8a8 or use_int8_w8a8:
+        # block-wise
+        if group_k > 0 and group_n > 0:
+            if a_desc is not None:
+                a_scale_ptrs = a_scale_ptr + offs_token_id * stride_asm
+            else:
+                a_scale_ptrs = a_scale_ptr + (offs_token // top_k) * stride_asm
+            if BLOCK_SIZE_N > group_n:
+                offs_bsn = offs_bn // group_n
+            else:
+                offs_bsn = pid_n * BLOCK_SIZE_N // group_n
+            b_scale_ptrs = b_scale_ptr + off_experts * stride_base + offs_bsn * stride_bsn
+        # channel-wise
+        elif per_channel_quant:
+            b_scale_ptrs = b_scale_ptr + off_experts * stride_base + offs_bn[None, :] * stride_bsn
+            b_scale = tl.load(b_scale_ptrs)
+            # Load per-token scale for activations
+            a_scale_ptrs = a_scale_ptr + (offs_token // top_k) * stride_asm
+            a_scale = tl.load(a_scale_ptrs, mask=token_mask, other=0.0)[:, None]
+        # tensor-wise
+        else:
+            a_scale = tl.load(a_scale_ptr)
+            b_scale = tl.load(b_scale_ptr + off_experts)
+
+    # -----------------------------------------------------------
+    # Iterate to compute a block of the C matrix.
+    # We accumulate into a `[BLOCK_SIZE_M, BLOCK_SIZE_N]` block
+    # of fp32 values for higher accuracy.
+    # `accumulator` will be converted back to fp16 after the loop.
+    if swap_ab:
+        accumulator = tl.zeros((BLOCK_SIZE_N, BLOCK_SIZE_M), dtype=tl.float32)
+    else:
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    for k_start in range(0, K, BLOCK_SIZE_K):
+        # Load the next block of A and B, generate a mask by checking the
+        # K dimension.
+        if a_desc is not None:
+            a = a_desc.load([start_offs_m, k_start])
+        elif even_Ks:
+            a = tl.load(
+                a_ptrs,
+                mask=token_mask[:, None],
+                other=0.0,
+            )
+        else:
+            a = tl.load(
+                a_ptrs,
+                mask=token_mask[:, None] & (offs_k[None, :] < K - k_start),
+                other=0.0,
+            )
+
+        if b_desc is not None:
+            b = b_desc.load([off_experts_i32, start_offs_n, k_start]).reshape(BLOCK_SIZE_N, BLOCK_SIZE_K).T
+        elif even_Ks:
+            b = tl.load(b_ptrs)
+        else:
+            b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k_start, other=0.0)
+
+        # We accumulate along the K dimension.
+        if use_int8_w8a16:
+            accumulator = tl.dot(a, b.to(compute_type), acc=accumulator)
+        elif use_fp8_w8a8 or use_int8_w8a8:
+            if group_k > 0 and group_n > 0:
+                offs_ks = k_start // group_k
+                a_scale = tl.load(a_scale_ptrs + offs_ks * stride_ask, mask=token_mask, other=0.0)
+                b_scale = tl.load(b_scale_ptrs + offs_ks * stride_bsk)
+                if swap_ab:
+                    a, b = tl.trans(b, (1, 0)), tl.trans(a, (1, 0))
+                    a_scale, b_scale = b_scale, a_scale
+                if BLOCK_SIZE_N > group_n:
+                    accumulator += tl.dot(a, b) * a_scale[:, None] * b_scale[None, :]
+                else:
+                    accumulator += tl.dot(a, b) * (a_scale[:, None] * b_scale)
+            else:
+                if use_fp8_w8a8:
+                    if swap_ab:
+                        a, b = tl.trans(b, (1, 0)), tl.trans(a, (1, 0))
+                    accumulator = tl.dot(a, b, acc=accumulator)
+                else:
+                    accumulator += tl.dot(a, b)
+        else:
+            accumulator += tl.dot(a, b)
+        # Advance the ptrs to the next K block.
+        if a_desc is None:
+            a_ptrs += BLOCK_SIZE_K * stride_ak
+        if b_desc is None:
+            b_ptrs += BLOCK_SIZE_K * stride_bk
+
+    if swap_ab:
+        accumulator = tl.trans(accumulator, (1, 0))
+
+    if use_int8_w8a16:
+        accumulator *= b_scale
+    elif use_fp8_w8a8 or use_int8_w8a8:
+        if group_k == 0 or group_n == 0:
+            accumulator *= a_scale * b_scale
+
+    if bias_ptr is not None:
+        accumulator += bias
+
+    if MUL_ROUTED_WEIGHT:
+        moe_weight = tl.load(topk_weights_ptr + offs_token, mask=token_mask, other=0)
+        accumulator *= moe_weight[:, None]
+
+    accumulator = accumulator.to(compute_type)
+    # -----------------------------------------------------------
+    # Write back the block of the output
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+
+    if FUSE_SWIGLU:
+        # W13 rows were interleaved at load time, so gate/up of the same
+        # intermediate channel sit in adjacent (even, odd) columns of this
+        # tile; silu(gate) * up is applied in-register and only the
+        # half-width activation is stored, eliminating intermediate_cache1
+        # and the standalone activation launch.
+        #
+        # The asm below is the bit-parity contract with the `silu_and_mul` this
+        # replaces, not an optimization: that kernel uses the fast-math
+        # intrinsics `__fdividef(x, 1 + __expf(-x))`, while Triton's operators
+        # lower to accurate expf and IEEE `div.rn`. The 1-2 ULP gap is enough to
+        # flip the stored bf16 (8 mantissa bits) on many inputs. The final
+        # multiply needs no asm -- plain fp32 multiply matches `mul.ftz.f32`
+        # except on denormals. Silu stays fp32 until the store, as in the
+        # reference; rounding it to bf16 first double-rounds and diverges.
+        acc_pairs = tl.reshape(accumulator, (BLOCK_SIZE_M, BLOCK_SIZE_N // 2, 2))
+        gate_b, up_b = tl.split(acc_pairs)
+        gate_f = gate_b.to(tl.float32)
+        if HAS_SWIGLU_ALPHA:
+            # Accurate ops, not the approximate asm below: the unfused swiglu path
+            # this replaces uses tl.sigmoid on an fp32 tile.
+            gate_c = tl.minimum(gate_f, SWIGLU_LIMIT)
+            up_c = tl.maximum(tl.minimum(up_b.to(tl.float32), SWIGLU_LIMIT), -SWIGLU_LIMIT)
+            out_act = (gate_c * tl.sigmoid(SWIGLU_ALPHA * gate_c) * (up_c + 1.0)).to(compute_type)
+        else:
+            # __expf(-x) == ex2.approx(x * -log2(e)); folding the negation into
+            # the constant (0fBFB8AA3B == -log2(e)) flips the sign exactly.
+            exp_neg = tl.inline_asm_elementwise(
+                "{ mul.ftz.f32 $0, $1, 0fBFB8AA3B; ex2.approx.ftz.f32 $0, $0; }",
+                "=f,f",
+                [gate_f],
+                dtype=tl.float32,
+                is_pure=True,
+                pack=1,
+            )
+            silu_f = tl.inline_asm_elementwise(
+                "div.approx.ftz.f32 $0, $1, $2;",
+                "=f,f,f",
+                [gate_f, 1.0 + exp_neg],
+                dtype=tl.float32,
+                is_pure=True,
+                pack=1,
+            )
+            out_act = (silu_f * up_b.to(tl.float32)).to(compute_type)
+        offs_half = pid_n * (BLOCK_SIZE_N // 2) + tl.arange(0, BLOCK_SIZE_N // 2)
+        if c_sorted:
+            c_ptrs = c_ptr + stride_cm * offs_token_id[:, None] + stride_cn * offs_half[None, :]
+        else:
+            c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_half[None, :]
+        c_mask = token_mask[:, None] & (offs_half[None, :] < N // 2)
+        tl.store(c_ptrs, out_act, mask=c_mask)
+    elif FUSE_ADD_TO_OUTPUT:
+        # Accumulate into existing output with per-token mask.
+        offs_token_out = offs_token // ROUTER_TOPK
+        add_mask = tl.load(add_mask_ptr + offs_token_out, mask=token_mask, other=False)
+        c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
+        c_mask = token_mask[:, None] & add_mask[:, None] & (offs_cn[None, :] < N)
+        existing = tl.load(c_ptrs, mask=c_mask, other=0.0)
+        tl.store(c_ptrs, existing + accumulator, mask=c_mask)
+    # ===== TO BE REFACTORED ====
+    elif MASK_OUTPUT:
+        # Store a fresh output while zeroing rows whose request has no active LoRA.
+        offs_token_out = offs_token // ROUTER_TOPK
+        output_mask = tl.load(add_mask_ptr + offs_token_out, mask=token_mask, other=False)
+        c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
+        c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
+        accumulator = tl.where(output_mask[:, None], accumulator, 0.0)
+        tl.store(c_ptrs, accumulator, mask=c_mask)
+    # ===== END TO BE REFACTORED ====
+    elif FUSE_SUM_ALL_REDUCE:
+        offs_token_out = offs_token // ROUTER_TOPK
+        c_ptrs = c_ptr + stride_cm * offs_token_out[:, None] + stride_cn * offs_cn[None, :]
+        c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
+        tl.atomic_add(c_ptrs, accumulator, mask=c_mask)
+    else:
+        if c_sorted:
+            c_ptrs = c_ptr + stride_cm * offs_token_id[:, None] + stride_cn * offs_cn[None, :]
+        else:
+            c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
+        c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
+        tl.store(c_ptrs, accumulator, mask=c_mask)
+
+
+# -----------------------------------------------------------------------------
+# TMA allocator: set once per process (avoid per-call triton.set_allocator)
+# -----------------------------------------------------------------------------
+_TMA_ALLOCATOR_SET = False
+
+
+def _set_triton_tma_allocator():
+    """TMA descriptors require a global allocator; set it once to avoid per-call overhead."""
+    global _TMA_ALLOCATOR_SET
+    if _TMA_ALLOCATOR_SET:
+        return
+
+    # TMA descriptors require a global memory allocation
+    def alloc_fn(size: int, alignment: int, stream: int | None):
+        # NOTE: keep this allocation on CUDA device
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+    _TMA_ALLOCATOR_SET = True
+
+
+# --- B TensorDescriptor cache (LRU) ---
+_B_DESC_CACHE_MAX = 64
+_B_DESC_CACHE: OrderedDict[tuple, TensorDescriptor] = OrderedDict()
+
+
+def _get_b_tma_desc_cached(B: torch.Tensor, block_n: int, block_k: int):
+    """
+    Cache TensorDescriptor for constant weight B.
+    Keyed by storage ptr + shape/stride/dtype + tile shape.
+    """
+    key = (
+        int(B.data_ptr()),
+        tuple(B.shape),
+        tuple(B.stride()),
+        str(B.dtype),
+        int(block_n),
+        int(block_k),
+    )
+
+    desc = _B_DESC_CACHE.get(key, None)
+    if desc is not None:
+        _B_DESC_CACHE.move_to_end(key)
+        return desc
+
+    # Create outside lock to reduce lock hold time (ok if duplicated rarely)
+    desc = TensorDescriptor(
+        B,
+        B.shape,
+        B.stride(),
+        [1, block_n, block_k],
+    )
+
+    _B_DESC_CACHE[key] = desc
+    _B_DESC_CACHE.move_to_end(key)
+    if len(_B_DESC_CACHE) > _B_DESC_CACHE_MAX:
+        _B_DESC_CACHE.popitem(last=False)
+
+    return desc
+
+
+def invoke_fused_moe_kernel(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    bias: torch.Tensor | None,
+    C: torch.Tensor,
+    A_scale: torch.Tensor | None,
+    B_scale: torch.Tensor | None,
+    B_zp: torch.Tensor | None,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    sorted_token_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    mul_routed_weight: bool,
+    top_k: int,
+    config: dict[str, Any],
+    compute_type: tl.dtype,
+    use_fp8_w8a8: bool,
+    use_int8_w8a8: bool,
+    use_int8_w8a16: bool,
+    use_int4_w4a16: bool,
+    per_channel_quant: bool,
+    block_shape: list[int] | None = None,
+    no_combine: bool = False,
+    a_use_tma: bool = False,
+    b_use_tma: bool = False,
+    c_sorted: bool = False,
+    filter_expert: bool = True,
+    fuse_sum_all_reduce: bool = False,
+    router_topk: int = 1,
+    fuse_add_to_output: bool = False,
+    add_output_mask: torch.Tensor | None = None,
+    mask_output: bool = False,
+    lora_preserve_base: bool = False,
+    fuse_swiglu: bool = False,
+    swiglu_alpha: float | None = None,
+    swiglu_limit: float | None = None,
+) -> None:
+    assert topk_weights.stride(1) == 1
+    assert sorted_token_ids.stride(0) == 1
+
+    if fuse_swiglu:
+        # The epilogue assumes an interleaved-gate/up bf16 up-GEMM writing a
+        # plain half-width output; every other output flavor is out of scope.
+        # In particular the LoRA output paths (fuse_add_to_output / mask_output)
+        # address C at full width N and would corrupt the half-width buffer.
+        assert not (use_fp8_w8a8 or use_int8_w8a8 or use_int8_w8a16 or use_int4_w4a16)
+        assert bias is None
+        assert not mul_routed_weight
+        assert not (fuse_add_to_output or mask_output or fuse_sum_all_reduce)
+        assert not lora_preserve_base
+        assert compute_type == tl.bfloat16
+
+    if use_fp8_w8a8:
+        swap_ab = should_enable_swap_ab(config["BLOCK_SIZE_M"], config["BLOCK_SIZE_N"])
+    else:
+        swap_ab = False
+
+    padded_size = 0
+    if use_fp8_w8a8:
+        assert B_scale is not None
+        if block_shape is None:
+            # activation tensor-wise fp8 quantization, dynamic or static
+            padded_size = padding_size
+            # activations apply per-token quantization when weights apply per-channel quantization by default
+            A, A_scale = scaled_fp8_quant(A, A_scale, use_per_token_if_dynamic=per_channel_quant)
+        else:
+            # activation block-wise fp8 quantization
+            assert len(block_shape) == 2
+            block_n, block_k = block_shape[0], block_shape[1]
+            if A.dtype == torch.float8_e4m3fn:
+                # Pre-quantized activation (SGLANG_OPT_MOE_QUANT_ONCE): the
+                # caller already ran the per-token-group quant; A_scale holds
+                # the matching scales (row- or column-major, strides are
+                # passed to the kernel below).
+                assert A_scale is not None
+            elif _is_cuda:
+                A, A_scale = sglang_per_token_group_quant_fp8(A, block_k)
+            else:
+                A, A_scale = per_token_group_quant_fp8(A, block_k)
+            assert triton.cdiv(A.shape[-1], block_k) == A_scale.shape[-1]
+            assert triton.cdiv(B.shape[-2], block_n) == B_scale.shape[-2]
+            assert triton.cdiv(B.shape[-1], block_k) == B_scale.shape[-1]
+    elif use_int8_w8a8:
+        assert B_scale is not None
+        if block_shape is None:
+            # activation channel-wise int8 quantization
+            assert per_channel_quant, (
+                "int8 quantization only supports channel-wise quantization except for block-wise quantization"
+            )
+            A, A_scale = per_token_quant_int8(A)
+        else:
+            # activation block-wise int8 quantization
+            assert len(block_shape) == 2
+            block_n, block_k = block_shape[0], block_shape[1]
+            if _is_cuda:
+                A, A_scale = sglang_per_token_group_quant_int8(A, block_k)
+            else:
+                A, A_scale = per_token_group_quant_int8(A, block_k)
+            assert triton.cdiv(A.shape[-1], block_k) == A_scale.shape[-1]
+            assert triton.cdiv(B.shape[-2], block_n) == B_scale.shape[-2]
+            assert triton.cdiv(B.shape[-1], block_k) == B_scale.shape[-1]
+    elif use_int8_w8a16 or use_int4_w4a16:
+        assert B_scale is not None
+        assert block_shape is None or block_shape[0] == 0
+    else:
+        assert A_scale is None
+        assert B_scale is None
+
+    grid = lambda META: (
+        triton.cdiv(sorted_token_ids.shape[0], META["BLOCK_SIZE_M"]) * triton.cdiv(B.shape[1], META["BLOCK_SIZE_N"]),
+    )
+
+    K = B.shape[2] - padded_size
+    if K % config["BLOCK_SIZE_K"] == 0:
+        even_Ks = True
+    else:
+        even_Ks = False
+
+    if fuse_sum_all_reduce:
+        assert not c_sorted, "fuse_sum_all_reduce only supports c_sorted=False"
+    if fuse_add_to_output:
+        assert not fuse_sum_all_reduce, "fuse_add_to_output and fuse_sum_all_reduce are mutually exclusive"
+        assert add_output_mask is not None, "add_output_mask required when fuse_add_to_output=True"
+    # ===== TO BE REFACTORED ====
+    if mask_output:
+        assert not fuse_add_to_output, "mask_output and fuse_add_to_output are mutually exclusive"
+        assert not fuse_sum_all_reduce, "mask_output and fuse_sum_all_reduce are mutually exclusive"
+        assert add_output_mask is not None, "add_output_mask required when mask_output=True"
+    # ===== END TO BE REFACTORED ====
+
+    if (use_int8_w8a16 or use_int4_w4a16) and block_shape is not None and block_shape[1] > 0:
+        assert not fuse_sum_all_reduce, "fuse_sum_all_reduce is not supported for GPTQ/AWQ kernels"
+        assert B_scale is not None and B_scale.ndim == 3
+        assert B_zp is None or B_zp.ndim == 3
+        assert bias is None
+        fused_moe_kernel_gptq_awq[grid](
+            A,
+            B,
+            C,
+            B_scale,
+            B_zp,
+            topk_weights,
+            sorted_token_ids,
+            expert_ids,
+            num_tokens_post_padded,
+            B.shape[1],
+            A.shape[1],
+            sorted_token_ids.shape[0],
+            topk_ids.numel(),
+            A.stride(0),
+            A.stride(1),
+            B.stride(0),
+            B.stride(2),
+            B.stride(1),
+            C.stride(-2),
+            C.stride(-1),
+            B_scale.stride(0),
+            B_scale.stride(2),
+            B_scale.stride(1),
+            B_zp.stride(0) if B_zp is not None else 0,
+            B_zp.stride(2) if B_zp is not None else 0,
+            B_zp.stride(1) if B_zp is not None else 0,
+            group_size=block_shape[1],
+            MUL_ROUTED_WEIGHT=mul_routed_weight,
+            top_k=top_k,
+            compute_type=compute_type,
+            has_zp=B_zp is not None,
+            use_int4_w4a16=use_int4_w4a16,
+            use_int8_w8a16=use_int8_w8a16,
+            even_Ks=even_Ks,
+            filter_expert=filter_expert,
+            **config,
+        )
+
+    else:
+        if a_use_tma or b_use_tma:
+            _set_triton_tma_allocator()
+
+        if a_use_tma:
+            a_desc = TensorDescriptor(A, A.shape, A.stride(), [config["BLOCK_SIZE_M"], config["BLOCK_SIZE_K"]])
+        else:
+            a_desc = None
+        if b_use_tma:
+            # B is constant weights -> cache descriptor
+            b_desc = _get_b_tma_desc_cached(
+                B,
+                config["BLOCK_SIZE_N"],
+                config["BLOCK_SIZE_K"],
+            )
+        else:
+            b_desc = None
+
+        fused_moe_kernel[grid](
+            A,
+            a_desc,
+            B,
+            b_desc,
+            bias,
+            C,
+            A_scale,
+            B_scale,
+            topk_weights,
+            sorted_token_ids,
+            expert_ids,
+            num_tokens_post_padded,
+            add_output_mask,
+            B.shape[1],
+            B.shape[2] - padded_size,
+            sorted_token_ids.shape[0],
+            topk_ids.numel(),
+            A.stride(0),
+            A.stride(1),
+            B.stride(0),
+            B.stride(2),
+            B.stride(1),
+            bias.stride(0) if bias is not None else 0,
+            bias.stride(1) if bias is not None else 0,
+            C.stride(-2),
+            C.stride(-1),
+            A_scale.stride(0) if A_scale is not None and A_scale.ndim == 2 else 0,
+            A_scale.stride(1) if A_scale is not None and A_scale.ndim == 2 else 0,
+            B_scale.stride(0) if B_scale is not None and B_scale.ndim >= 2 else 0,
+            B_scale.stride(2) if B_scale is not None and B_scale.ndim == 3 else 0,
+            B_scale.stride(1) if B_scale is not None and B_scale.ndim >= 2 else 0,
+            0 if block_shape is None else block_shape[0],
+            0 if block_shape is None else block_shape[1],
+            MUL_ROUTED_WEIGHT=mul_routed_weight,
+            top_k=top_k,
+            compute_type=compute_type,
+            use_fp8_w8a8=use_fp8_w8a8,
+            use_int8_w8a8=use_int8_w8a8,
+            use_int8_w8a16=use_int8_w8a16,
+            per_channel_quant=per_channel_quant,
+            even_Ks=even_Ks,
+            c_sorted=c_sorted,
+            filter_expert=filter_expert,
+            swap_ab=swap_ab,
+            FUSE_ADD_TO_OUTPUT=fuse_add_to_output,
+            MASK_OUTPUT=mask_output,
+            LORA_PRESERVE_BASE=lora_preserve_base,
+            FUSE_SWIGLU=fuse_swiglu,
+            SWIGLU_ALPHA=float(swiglu_alpha or 0.0),
+            SWIGLU_LIMIT=float(swiglu_limit or 0.0),
+            HAS_SWIGLU_ALPHA=swiglu_alpha is not None,
+            FUSE_SUM_ALL_REDUCE=fuse_sum_all_reduce,
+            ROUTER_TOPK=router_topk,
+            **config,
+        )
+
+
+@triton.jit
+def tanh(x):
+    return 2 * tl.sigmoid(2 * x) - 1
+
+
+@triton.jit
+def _apply_activation(x, ACTIVATION_TYPE: tl.constexpr):
+    """
+    Apply activation function based on compile-time constant.
+
+    Args:
+        x: Input tensor (converted to float32 inside)
+        ACTIVATION_TYPE: Compile-time constant string ("silu" or "gelu")
+
+    Returns:
+        Activated output in the same dtype as input
+    """
+    x = x.to(tl.float32)
+    if ACTIVATION_TYPE == "silu":
+        return x * tl.sigmoid(x)
+    elif ACTIVATION_TYPE == "gelu":
+        kAlpha = 0.7978845608028654
+        return 0.5 * x * (1 + tanh(kAlpha * (x + 0.044715 * x * x * x)))
+    else:
+        raise ValueError(f"Unsupported activation: {ACTIVATION_TYPE}")
+
+
+@triton.jit
+def act_and_mul_kernel(
+    gateup_output,
+    down_input,
+    hidden_size,
+    expert_ids_ptr,
+    expert_step: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    ACTIVATION_TYPE: tl.constexpr,
+    SWIGLU_LIMIT: tl.constexpr = 0.0,
+    HAS_SWIGLU_LIMIT: tl.constexpr = False,
+    HAS_EXPERT_FILTER: tl.constexpr = True,
+):
+    """
+    Unified activation and multiply kernel that handles both sorted and unsorted routing,
+    and both SiLU and GELU activations using compile-time constants.
+    """
+    InDtype = gateup_output.dtype.element_ty
+    OutDtype = down_input.dtype.element_ty
+
+    half_hidden_size = hidden_size // 2
+    pid = tl.program_id(0)
+
+    if HAS_EXPERT_FILTER:
+        expert_id = tl.load(expert_ids_ptr + pid // expert_step)
+        if expert_id == -1:
+            return
+
+    gateup_output_ptr = gateup_output + pid * hidden_size
+    down_input_ptr = down_input + pid * half_hidden_size
+    gate_output_ptr = gateup_output_ptr
+    up_output_ptr = gateup_output_ptr + half_hidden_size
+
+    for start_offset in tl.range(0, half_hidden_size, BLOCK_SIZE):
+        offset = start_offset + tl.arange(0, BLOCK_SIZE)
+        mask = offset < half_hidden_size
+
+        gate_output = tl.load(gate_output_ptr + offset, mask=mask)
+        up_output = tl.load(up_output_ptr + offset, mask=mask)
+
+        if HAS_SWIGLU_LIMIT:
+            gate_output = tl.minimum(gate_output, SWIGLU_LIMIT)
+            up_output = tl.maximum(tl.minimum(up_output, SWIGLU_LIMIT), -SWIGLU_LIMIT)
+
+        gate_output_activated = _apply_activation(gate_output, ACTIVATION_TYPE)
+        gate_output_activated = gate_output_activated.to(InDtype)
+
+        act_mul_output = gate_output_activated * up_output
+        act_mul_output = act_mul_output.to(OutDtype)
+        tl.store(down_input_ptr + offset, act_mul_output, mask=mask)
+
+
+def act_and_mul_triton(
+    gateup_output: torch.Tensor,
+    down_input: torch.Tensor,
+    config: dict[str, Any],
+    topk_ids: torch.Tensor | None = None,
+    expert_ids: torch.Tensor | None = None,
+    down_moe_use_tma: bool = False,
+    activation: str = "silu",
+    swiglu_limit: float | None = None,
+) -> None:
+    """
+    Args:
+        gateup_output: Input tensor containing gate and up outputs concatenated
+        down_input: Output tensor for the result
+        config: Configuration dictionary with BLOCK_SIZE_M and BLOCK_SIZE_N
+        topk_ids: Expert IDs for unsorted routing (used when down_moe_use_tma=False)
+        expert_ids: Expert IDs for sorted routing (used when down_moe_use_tma=True)
+        down_moe_use_tma: Whether to use sorted routing layout
+        activation: Activation type ("silu" or "gelu")
+        swiglu_limit: if not None, clamp gate to [-inf, L] and up to [-L, L] before activation
+                      (compiles a separate kernel variant via tl.constexpr).
+    """
+    grid = (down_input.shape[0],)
+    hidden_size = gateup_output.shape[1]
+    has_expert_filter = topk_ids is not None or expert_ids is not None
+    if has_expert_filter:
+        expert_ids_row = topk_ids.view(-1) if not down_moe_use_tma else expert_ids
+        expert_step = 1 if not down_moe_use_tma else config["BLOCK_SIZE_M"]
+    else:
+        expert_ids_row = None
+        expert_step = 1
+    has_swiglu_limit = swiglu_limit is not None
+    act_and_mul_kernel[grid](
+        gateup_output,
+        down_input,
+        hidden_size,
+        expert_ids_row,
+        expert_step,
+        BLOCK_SIZE=512,
+        ACTIVATION_TYPE=activation,
+        SWIGLU_LIMIT=float(swiglu_limit) if has_swiglu_limit else 0.0,
+        HAS_SWIGLU_LIMIT=has_swiglu_limit,
+        HAS_EXPERT_FILTER=has_expert_filter,
+    )
+
+
+# _moe_sum_reduce_kernel kernel modified from https://github.com/ModelTC/lightllm/blob/main/lightllm/common/fused_moe/moe_sum_reduce.py
+@triton.jit
+def _moe_sum_reduce_kernel(
+    input_ptr,
+    input_stride_0,
+    input_stride_1,
+    input_stride_2,
+    output_ptr,
+    output_stride_0,
+    output_stride_1,
+    token_num: int,
+    topk_num: int,
+    hidden_dim: int,
+    routed_scaling_factor: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_DIM: tl.constexpr,
+    NUM_STAGE: tl.constexpr,
+):
+    input_stride_0 = tl.cast(input_stride_0, dtype=tl.int64)
+    input_stride_1 = tl.cast(input_stride_1, dtype=tl.int64)
+    output_stride_0 = tl.cast(output_stride_0, dtype=tl.int64)
+
+    token_block_id = tl.program_id(0)
+    dim_block_id = tl.program_id(1)
+
+    offs_token = token_block_id * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_dim = dim_block_id * BLOCK_DIM + tl.arange(0, BLOCK_DIM)
+
+    mask_token = offs_token < token_num
+    mask_dim = offs_dim < hidden_dim
+
+    base_ptrs = input_ptr + offs_token[:, None] * input_stride_0 + offs_dim[None, :]
+
+    accumulator = tl.zeros((BLOCK_M, BLOCK_DIM), dtype=tl.float32)
+
+    for i in tl.range(0, topk_num, num_stages=NUM_STAGE):
+        tile = tl.load(
+            base_ptrs + i * input_stride_1,
+            mask=mask_token[:, None] & mask_dim[None, :],
+            other=0.0,
+        )
+        accumulator += tile.to(tl.float32)
+    accumulator *= routed_scaling_factor
+
+    # -------- Write back --------
+    store_ptrs = output_ptr + offs_token[:, None] * output_stride_0 + offs_dim[None, :]
+    tl.store(
+        store_ptrs,
+        accumulator.to(input_ptr.dtype.element_ty),
+        mask=mask_token[:, None] & mask_dim[None, :],
+    )
+
+
+def moe_sum_reduce_triton(input: torch.Tensor, output: torch.Tensor, routed_scaling_factor: float):
+    assert input.is_contiguous()
+    assert output.is_contiguous()
+
+    token_num, topk_num, hidden_dim = input.shape
+    assert output.shape[0] == token_num and output.shape[1] == hidden_dim
+
+    BLOCK_M = 1
+    BLOCK_DIM = 2048
+    NUM_STAGE = 1
+    num_warps = 16
+
+    grid = (
+        triton.cdiv(token_num, BLOCK_M),
+        triton.cdiv(hidden_dim, BLOCK_DIM),
+    )
+
+    _moe_sum_reduce_kernel[grid](
+        input,
+        *input.stride(),
+        output,
+        *output.stride(),
+        token_num=token_num,
+        topk_num=topk_num,
+        hidden_dim=hidden_dim,
+        routed_scaling_factor=routed_scaling_factor,
+        BLOCK_M=BLOCK_M,
+        BLOCK_DIM=BLOCK_DIM,
+        NUM_STAGE=NUM_STAGE,
+        num_warps=num_warps,
+    )
+    return
+
+
+@triton.jit
+def _fused_append_shared_experts_kernel(
+    topk_ids_ptr,
+    topk_weights_ptr,
+    out_ids_ptr,
+    out_weights_ptr,
+    N_BASE,  # runtime scalar
+    scale_factor,  # runtime scalar
+    K: tl.constexpr,
+    S: tl.constexpr,
+):
+    """
+    for m in range(M):
+        for n in range(K):
+            fused_ids[m, n] = topk_ids[m, n]
+            fused_weights[m, n] = topk_weights[m, n]
+        for s in range(S):
+            fused_ids[m, K + s] = N + s
+            fused_weights[m, K + s] = scale_factor
+    """
+    pid = tl.program_id(0)
+
+    ids_row_ptr = pid * K
+    w_row_ptr = pid * K
+    out_ids_row_ptr = pid * (K + S)
+    out_w_row_ptr = pid * (K + S)
+
+    offs_k = tl.arange(0, K)
+    ids = tl.load(topk_ids_ptr + ids_row_ptr + offs_k)
+    ws = tl.load(topk_weights_ptr + w_row_ptr + offs_k)
+
+    tl.store(out_ids_ptr + out_ids_row_ptr + offs_k, ids)
+    tl.store(out_weights_ptr + out_w_row_ptr + offs_k, ws)
+
+    offs_s = tl.arange(0, S)
+
+    shared_ids = tl.cast(N_BASE + offs_s, ids.dtype)
+    shared_ws = tl.full([S], scale_factor, dtype=ws.dtype)
+
+    tl.store(out_ids_ptr + out_ids_row_ptr + K + offs_s, shared_ids)
+    tl.store(out_weights_ptr + out_w_row_ptr + K + offs_s, shared_ws)
+
+
+def fused_append_shared_experts(topk_ids, topk_weights, num_fused_shared_experts, scale_factor, N=None):
+    assert N is not None, "N (shared expert base id) must be provided"
+    m, k = topk_ids.shape
+    s = int(num_fused_shared_experts)
+    if s <= 0:
+        return topk_ids, topk_weights
+
+    out_ids = torch.empty((m, k + s), dtype=topk_ids.dtype, device=topk_ids.device)
+    out_weights = torch.empty((m, k + s), dtype=topk_weights.dtype, device=topk_weights.device)
+
+    _fused_append_shared_experts_kernel[(m,)](
+        topk_ids,
+        topk_weights,
+        out_ids,
+        out_weights,
+        N_BASE=N,
+        scale_factor=scale_factor,
+        K=k,
+        S=s,
+        num_warps=1,
+    )
+    return out_ids, out_weights
+
+
+@triton.jit
+def _fused_append_remap_shared_experts_deepep_kernel(
+    topk_ids_ptr,
+    topk_weights_ptr,
+    out_ids_ptr,
+    out_weights_ptr,
+    shared_id_base,  # runtime scalar: ep_rank * num_local_experts + num_local_routed
+    num_local_routed,  # runtime scalar: routed experts per rank (for gap-insertion)
+    scale_factor,  # runtime scalar: shared-expert weight
+    num_token_non_padded_ptr,  # 1-elem int tensor; only read when HAS_PADDING
+    pad_fill_id,  # runtime scalar: routed-id fill for padded rows
+    K: tl.constexpr,
+    S: tl.constexpr,
+    HAS_PADDING: tl.constexpr,
+):
+    """Append shared experts AND apply the DeepEP interleaved remap in one pass.
+
+    Equivalent to fused_append_shared_experts() immediately followed by
+    topk._remap_topk_for_deepep(), but the remap math runs on the rows already
+    loaded into registers, so it costs a few ALU ops instead of ~6 extra eager
+    kernel launches (div_floor / add / arange / fill / copy) per MoE layer.
+
+    Routed IDs:   e -> e + e // num_local_routed   (insert gaps for shared slots)
+    Shared IDs:   shared_id_base + arange(S)        (one id per shared slot)
+    Shared wgt:   scale_factor                     (1.0 on aiter; 1/rsf otherwise)
+    """
+    pid = tl.program_id(0)
+
+    ids_row_ptr = pid * K
+    out_ids_row_ptr = pid * (K + S)
+
+    offs_k = tl.arange(0, K)
+    ids = tl.load(topk_ids_ptr + ids_row_ptr + offs_k)
+    ws = tl.load(topk_weights_ptr + ids_row_ptr + offs_k)
+
+    # DeepEP interleaved layout: shift each routed id past the shared slots that
+    # precede it. Matches `routed + routed // num_local_routed` exactly.
+    ids = ids + ids // num_local_routed
+
+    if HAS_PADDING:
+        # Fold the padded-topk_ids fill (previously a separate _fill_padded_rows
+        # launch): rows >= num_token_non_padded get pad_fill_id in every routed
+        # slot. Matches the old fill(topk_ids=0) -> remap(0)=0 when pad_fill_id==0.
+        n_valid = tl.load(num_token_non_padded_ptr)
+        if pid >= n_valid:
+            ids = tl.full((K,), pad_fill_id, dtype=ids.dtype)
+
+    tl.store(out_ids_ptr + out_ids_row_ptr + offs_k, ids)
+    tl.store(out_weights_ptr + out_ids_row_ptr + offs_k, ws)
+
+    offs_s = tl.arange(0, S)
+    shared_ids = tl.cast(shared_id_base + offs_s, ids.dtype)
+    shared_ws = tl.full([S], scale_factor, dtype=ws.dtype)
+
+    tl.store(out_ids_ptr + out_ids_row_ptr + K + offs_s, shared_ids)
+    tl.store(out_weights_ptr + out_ids_row_ptr + K + offs_s, shared_ws)
+
+
+def fused_append_remap_shared_experts_deepep(
+    topk_ids,
+    topk_weights,
+    num_fused_shared_experts,
+    scale_factor,
+    shared_id_base,
+    num_local_routed,
+    num_token_non_padded=None,
+    pad_fill_id=0,
+):
+    """Fused append + DeepEP remap (see kernel docstring).
+
+    Replaces the fused_append_shared_experts() + _remap_topk_for_deepep() pair on
+    the aiter/DeepEP-class path. Host computes the scalar remap params so the
+    kernel stays branch-free.
+    """
+    m, k = topk_ids.shape
+    s = int(num_fused_shared_experts)
+    if s <= 0:
+        return topk_ids, topk_weights
+
+    out_ids = torch.empty((m, k + s), dtype=topk_ids.dtype, device=topk_ids.device)
+    out_weights = torch.empty((m, k + s), dtype=topk_weights.dtype, device=topk_weights.device)
+
+    has_padding = num_token_non_padded is not None
+    # Placeholder pointer when no padding (never dereferenced: HAS_PADDING False).
+    ntnp_ptr = num_token_non_padded if has_padding else topk_ids
+    _fused_append_remap_shared_experts_deepep_kernel[(m,)](
+        topk_ids,
+        topk_weights,
+        out_ids,
+        out_weights,
+        shared_id_base,
+        num_local_routed,
+        scale_factor,
+        ntnp_ptr,
+        pad_fill_id,
+        K=k,
+        S=s,
+        HAS_PADDING=has_padding,
+        num_warps=1,
+    )
+    return out_ids, out_weights
+
+
+@triton.jit
+def _fused_append_shared_experts_with_weights_kernel(
+    topk_ids_ptr,
+    topk_weights_ptr,
+    shared_weights_ptr,
+    out_ids_ptr,
+    out_weights_ptr,
+    hidden_ptr,
+    wgate_ptr,
+    N_BASE,
+    scale,
+    K: tl.constexpr,
+    S: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    BLOCK_S: tl.constexpr,
+    APPLY_SIGMOID: tl.constexpr,
+    FUSE_GATE: tl.constexpr,
+    HIDDEN: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+):
+    pid = tl.program_id(0)
+
+    ids_row_ptr = pid * K
+    out_row_ptr = pid * (K + S)
+
+    offs_k = tl.arange(0, BLOCK_K)
+    mask_k = offs_k < K
+    ids = tl.load(topk_ids_ptr + ids_row_ptr + offs_k, mask=mask_k)
+    ws = tl.load(topk_weights_ptr + ids_row_ptr + offs_k, mask=mask_k)
+
+    tl.store(out_ids_ptr + out_row_ptr + offs_k, ids, mask=mask_k)
+    tl.store(out_weights_ptr + out_row_ptr + offs_k, ws, mask=mask_k)
+
+    offs_s = tl.arange(0, BLOCK_S)
+    mask_s = offs_s < S
+    shared_ids = tl.cast(N_BASE + offs_s, ids.dtype)
+    if FUSE_GATE:
+        offs_h = tl.arange(0, BLOCK_H)
+        mask_h = offs_h < HIDDEN
+        h = tl.load(hidden_ptr + pid * HIDDEN + offs_h, mask=mask_h, other=0.0).to(tl.float32)
+        w = tl.load(wgate_ptr + offs_h, mask=mask_h, other=0.0).to(tl.float32)
+        logit = tl.sum(h * w)
+        shared_val = tl.sigmoid(logit) * scale
+        shared_ws = tl.zeros((BLOCK_S,), dtype=tl.float32) + shared_val
+    else:
+        shared_ws = tl.load(shared_weights_ptr + pid * S + offs_s, mask=mask_s)
+        if APPLY_SIGMOID:
+            shared_ws = tl.sigmoid(shared_ws.to(tl.float32)) * scale
+
+    tl.store(out_ids_ptr + out_row_ptr + K + offs_s, shared_ids, mask=mask_s)
+    tl.store(out_weights_ptr + out_row_ptr + K + offs_s, shared_ws, mask=mask_s)
+
+
+def fused_append_shared_experts_with_weights(
+    topk_ids,
+    topk_weights,
+    shared_weights,
+    num_fused_shared_experts,
+    N=None,
+    apply_sigmoid=False,
+    fuse_gate=False,
+    hidden_states=None,
+    gate_weight=None,
+    scale=1.0,
+):
+    """Like fused_append_shared_experts but accepts per-token shared weights tensor.
+
+    Two optional in-kernel fusions are supported (both default off → legacy
+    behavior is preserved byte-for-byte):
+
+    - ``apply_sigmoid=True``: ``shared_weights`` are treated as raw gate logits;
+      the kernel applies ``sigmoid`` (in fp32) and the optional ``scale``
+      in-register, so the caller can skip the separate ``sigmoid`` activation
+      and the bf16->fp32 cast.
+    - ``fuse_gate=True``: the shared_expert_gate GEMV
+      (``hidden_states @ gate_weight.T``) + sigmoid + ``scale`` are computed
+      *inside* the kernel, eliminating the standalone gate GEMM launch.
+      ``shared_weights`` is ignored; ``hidden_states`` ([M, HIDDEN]) and
+      ``gate_weight`` ([1, HIDDEN] or [HIDDEN]) must be provided. This subsumes
+      ``apply_sigmoid`` (the sigmoid is intrinsic), so the two are mutually
+      exclusive.
+    """
+    assert not (fuse_gate and apply_sigmoid), (
+        "fuse_gate already applies sigmoid in-kernel; do not also set apply_sigmoid"
+    )
+    assert N is not None, "N (shared expert base id) must be provided"
+    m, k = topk_ids.shape
+    s = int(num_fused_shared_experts)
+    if s <= 0:
+        return topk_ids, topk_weights
+
+    if fuse_gate:
+        assert hidden_states is not None and gate_weight is not None, (
+            "fuse_gate=True requires hidden_states and gate_weight"
+        )
+        hidden_arg = hidden_states.contiguous()
+        wgate_arg = gate_weight.reshape(-1).contiguous()
+        hidden_dim = hidden_arg.shape[1]
+        block_h = triton.next_power_of_2(hidden_dim)
+        shared_arg = topk_weights
+        num_warps = 8
+    else:
+        # When fusing sigmoid in-kernel (apply_sigmoid), keep the raw logits
+        # dtype (the kernel emits fp32 directly); otherwise match the output
+        # weight dtype as before.
+        shared_weights_2d = shared_weights if apply_sigmoid else shared_weights.to(topk_weights.dtype)
+        if shared_weights_2d.ndim == 1:
+            shared_weights_2d = shared_weights_2d.unsqueeze(-1)
+        if shared_weights_2d.shape[1] < s:
+            shared_weights_2d = shared_weights_2d.expand(m, s)
+        shared_arg = shared_weights_2d.contiguous()
+        # hidden_ptr / wgate_ptr are unused; pass placeholders.
+        hidden_arg = topk_weights
+        wgate_arg = topk_weights
+        hidden_dim = 1
+        block_h = 1
+        num_warps = 1
+
+    out_ids = torch.empty((m, k + s), dtype=topk_ids.dtype, device=topk_ids.device)
+    out_weights = torch.empty((m, k + s), dtype=topk_weights.dtype, device=topk_weights.device)
+
+    block_k = triton.next_power_of_2(k)
+    block_s = triton.next_power_of_2(s)
+
+    _fused_append_shared_experts_with_weights_kernel[(m,)](
+        topk_ids,
+        topk_weights,
+        shared_arg,
+        out_ids,
+        out_weights,
+        hidden_arg,
+        wgate_arg,
+        N_BASE=N,
+        scale=scale,
+        K=k,
+        S=s,
+        BLOCK_K=block_k,
+        BLOCK_S=block_s,
+        APPLY_SIGMOID=apply_sigmoid,
+        FUSE_GATE=fuse_gate,
+        HIDDEN=hidden_dim,
+        BLOCK_H=block_h,
+        num_warps=num_warps,
+    )
+    return out_ids, out_weights

--- a/vllm_omni/diffusion/models/magi2/swiglu_kernel.py
+++ b/vllm_omni/diffusion/models/magi2/swiglu_kernel.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+# ruff: noqa: N803
+
+"""Fused BF16 SwiGLU7 kernel for MAGI-2 MUSA execution.
+
+The elementwise kernel is adapted from SGLang revision
+``25536524af6701518d0b8ec0efca8109c23b3706``.
+"""
+
+from __future__ import annotations
+
+import torch
+from vllm.triton_utils import tl, triton
+
+from vllm_omni.diffusion.layers.custom_op import CustomOp
+
+
+@triton.jit
+def _swiglu7_kernel(
+    x_ptr,
+    out_ptr,
+    numel,
+    BLOCK: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offsets < numel
+    gate = tl.load(x_ptr + offsets * 2, mask=mask, other=0.0).to(tl.float32)
+    linear = tl.load(x_ptr + offsets * 2 + 1, mask=mask, other=0.0).to(tl.float32)
+    # Preserve NaNs exactly like the reference ``torch.minimum``/clamp path;
+    # plain Triton minimum/max lowering is allowed to select the finite bound
+    # for a NaN on some MUSA compiler revisions.
+    gate = tl.where(gate != gate, gate, tl.minimum(gate, 7.0))
+    linear = tl.where(
+        linear != linear,
+        linear,
+        tl.maximum(tl.minimum(linear, 7.0), -7.0),
+    )
+    activated = gate * tl.sigmoid(1.702 * gate) * (linear + 1.0)
+    tl.store(out_ptr + offsets, activated, mask=mask)
+
+
+def _swiglu7_musa(x: torch.Tensor) -> torch.Tensor:
+    if x.ndim < 1 or x.shape[-1] % 2:
+        raise ValueError("SwiGLU7 expects an even final dimension")
+    if not x.is_contiguous():
+        raise ValueError("fused SwiGLU7 requires contiguous input")
+    out = torch.empty((*x.shape[:-1], x.shape[-1] // 2), device=x.device, dtype=x.dtype)
+    numel = out.numel()
+    if numel == 0:
+        return out
+    _swiglu7_kernel[(triton.cdiv(numel, 256),)](
+        x,
+        out,
+        numel,
+        BLOCK=256,
+        num_warps=4,
+    )
+    return out
+
+
+def _swiglu7_native(x: torch.Tensor) -> torch.Tensor:
+    if x.shape[-1] % 2:
+        raise ValueError(f"expected an even last dimension, got {x.shape[-1]}")
+    gate = x[..., ::2].to(torch.float32).clamp(max=7.0)
+    linear = x[..., 1::2].to(torch.float32).clamp(min=-7.0, max=7.0)
+    return gate * torch.sigmoid(1.702 * gate) * (linear + 1.0)
+
+
+class Magi2SwiGLU7(CustomOp):
+    """MAGI-2 SwiGLU7 activation using the vLLM-Omni dispatch contract."""
+
+    def forward_native(self, x: torch.Tensor) -> torch.Tensor:
+        return _swiglu7_native(x)
+
+    def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
+        return _swiglu7_native(x)
+
+    def forward_musa(self, x: torch.Tensor) -> torch.Tensor:
+        return _swiglu7_musa(x)
+
+
+magi2_swiglu7 = Magi2SwiGLU7()
+
+
+__all__ = ["Magi2SwiGLU7", "magi2_swiglu7"]


### PR DESCRIPTION
## Summary

- Add MAGI-2 Preview diffusion pipeline support on top of upstream `main`.
- Add MUSA/S5000 execution path with MATE FlashAttention, SGL fused MoE, fused SwiGLU7, mHC fused path, owned W13/W2 layouts, and fast RoPE.
- Keep the implementation focused on code; benchmark details are tracked separately in the workspace ticket.

## Validation

Workload: 272p/10s, 256x448, 125 frames, seed 42, 100 inference steps, EP4 + Ulysses8.

- MTT S5000 host `10.20.35.88`: steady mean 781.162 ms/DiT step, p50 780.776 ms, p90 781.880 ms, max 815.733 ms.
- Generated 10-second MP4 was validated with `ffprobe`; checksum and full environment are tracked in workspace evidence.
- MAGI-2 Python modules compile successfully from the upstream-main worktree.

The historical 754.388 ms result is retained only as unverified evidence because its complete environment header was not captured; the number above is the conservative reproducible result.

## Notes

This is a draft PR for review. Optimization commits were rebased onto the latest upstream `main`; follow-up splitting can be done after API review.
