### PR TITLE
[Core] Cache FastVideo VSA tile metadata

### DIFF
--- a/vllm_omni/diffusion/attention/backends/fastvideo_vsa.py
+++ b/vllm_omni/diffusion/attention/backends/fastvideo_vsa.py
@@ -213,6 +213,7 @@ def _get_non_pad_index(variable_block_sizes: torch.Tensor, max_block_size: int) 
 
 
 @torch.compiler.disable
+@functools.lru_cache(maxsize=32)
 def _get_tile_metadata(
     dit_seq_shape: tuple[int, int, int],
     tile_size: tuple[int, int, int],


### PR DESCRIPTION
## Purpose

FastVideo VSA calls `_get_tile_metadata` in every attention block. Its three component helpers are cached, but the aggregate function still rebuilds the inverse row order with `argsort` and indexed gather on every call.

Cache the complete metadata tuple by sequence shape, tile size, block size, and device. The returned tensors are read-only at the call site, so layers and denoising steps can reuse the same objects. For the measured geometry, the additional cached allocation is one 27,280-element int64 inverse index (about 213 KiB, or 6.7 MiB if all 32 entries had this size).

## Test Plan

- Run `pytest -q tests/diffusion/attention/test_fastvideo_vsa.py` on an H200
- Run focused pre-commit checks on the changed file
- Verify repeated lookup through `torch.compile` uses the aggregate cache
- Compare exact main/candidate sources and benchmark repeated metadata lookup for the documented `(31, 22, 40)` FastWan geometry on an H200

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** parent `ff6e906a25de1ca3122c0d0d5250fde5a0ddbc7b`, candidate `6f4282917d62fa3ed6b3139a18ce6ebb2a165df2`

## Test Result

- Existing FastVideo VSA tests: `14 passed, 15 warnings in 2.24s`
- Focused changed-file checks, including Ruff and mypy 3.10: passed
- Two calls through `torch.compile` produced one cache miss and one hit
- All four returned metadata tensors matched main exactly, and repeated calls reused the cached tuple
- H200 / PyTorch 2.13.0+cu130 / CUDA 13.0 component benchmark, 20 warmups followed by 9 symmetrically interleaved rounds of 100 calls per arm:
  - median latency: `90.378 us -> 0.637 us` (`-99.30%`, `89.741 us` saved per call)
  - P20-P80 latency: `90.349-90.422 us -> 0.634-0.639 us`
  - profiler CUDA events: `23 -> 0`; the cached path issued no `argsort`, `sort`, or index kernels

These are `_get_tile_metadata` component measurements, not full-model end-to-end latency.
