### PR TITLE
[Bugfix][Diffusion] Restore the TRTLLM attention default for the MiniMax-H3 modular alias

### DIFF
--- a/vllm_omni/diffusion/model_metadata.py
+++ b/vllm_omni/diffusion/model_metadata.py
@@ -48,12 +48,16 @@ _DIFFUSION_MODEL_METADATA: dict[str, DiffusionModelMetadata] = {
         attention_mask_free=True,
     ),
     # The modular alias is served by MiniMaxH3Pipeline and has the same
-    # Ref2VA request contract. Keep admission limits in sync with it.
+    # Ref2VA request contract and packed-sequence layout. Every field must stay
+    # in sync with it: the repository root ``model_index.json`` declares this
+    # alias, so serving the checkpoint by repo id resolves here rather than to
+    # ``MiniMaxH3Pipeline``.
     "MiniMaxH3ModularPipeline": DiffusionModelMetadata(
         supports_multimodal_inputs=True,
         max_multimodal_image_inputs=9,
         supports_mixed_reference_inputs=True,
         final_output_type="video",
+        attention_mask_free=True,
     ),
     "Magi2Pipeline": DiffusionModelMetadata(
         supports_multimodal_inputs=True,


### PR DESCRIPTION
## Purpose

`attention_mask_free` gates the TRTLLM diffusion attention default:

```python
allow_trtllm_default = get_diffusion_model_metadata(model_class_name).attention_mask_free
```

`MiniMaxH3Pipeline` declares it; `MiniMaxH3ModularPipeline` does not. The repository root `model_index.json` names the modular alias, while only `FL2VA/model_index.json` names `MiniMaxH3Pipeline`. Serving by repository id, as the recipe documents, therefore resolved to `attention_mask_free=False` and silently fell back to `CUDNN_ATTN` even where every TRTLLM condition held.

The entries drifted because they landed two hours apart on the same day: #5779 added the field to `MiniMaxH3Pipeline`, then #5720 added the modular alias from the pre-#5779 template. Both aliases resolve to the same `MiniMaxH3Pipeline` implementation, so the field applies to both.

## Test Plan

```bash
pytest -q tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
```

Backend resolution with **no** `--diffusion-attention-backend` flag, serving the repository root:

```bash
vllm serve /path/to/MiniMax-H3 --omni --host 127.0.0.1 --port 8091 \
  --trust-remote-code --task-type fl2va \
  --num-gpus 8 --usp 8 --ring 1 \
  --vae-patch-parallel-size 8 --vae-parallel-mode tile --vae-use-tiling

grep "diffusion attention backend" server.log
```

8x NVIDIA B300 (sm_103), head_dim 128, cuDNN 92000, flashinfer 0.6.16.post3 with `trtllm-gen` present.

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** af74a5a1

## Test Result

`129 passed`.

Same server command, before:

```text
[platform.py:319] Defaulting to diffusion attention backend CUDNN_ATTN (Blackwell sm_103, cuDNN 92000, head_dim 128)
[selector.py:93] Resolved diffusion attention backend 'CUDNN_ATTN' for role='self' via platform default
```

After:

```text
[platform.py:305] Defaulting to diffusion attention backend TRTLLM_ATTN (datacenter Blackwell sm_103, head_dim 128)
[selector.py:93] Resolved diffusion attention backend 'TRTLLM_ATTN' for role='self' via platform default
```

`role='minimax_h3.token_refiner'` resolves the same way. On a 15 s FL2VA request (1344x768, 362 frames) the base per-step cost goes from 4.18 s/it at USP4 + CUDNN_ATTN to 2.14 s/it at USP8 + TRTLLM_ATTN — the combined effect of the flag taking hold and the wider SP, not the backend alone. That figure matches the ~2.10 s/it dense baseline in #6909.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
