### PR TITLE
[Doc] Restore JSON CLI argument guidance

### DIFF
--- a/docs/cli/json_tip.inc.md
+++ b/docs/cli/json_tip.inc.md
@@ -1,0 +1,10 @@
+<!-- markdownlint-disable MD041 -->
+When passing JSON CLI arguments, the following sets of arguments are equivalent:
+
+- `--json-arg '{"key1": "value1", "key2": {"key3": "value2"}}'`
+- `--json-arg.key1 value1 --json-arg.key2.key3 value2`
+
+Additionally, list elements can be passed individually using `+`:
+
+- `--json-arg '{"key4": ["value3", "value4", "value5"]}'`
+- `--json-arg.key4+ value3 --json-arg.key4+='value4,value5'`


### PR DESCRIPTION
## Purpose

### What broke

The `JSON CLI Arguments` section in `docs/cli/serve.md` rendered empty because its `--8<--` directive targeted a file that did not exist.

### Reproduction

```bash
mkdocs build --strict
rg "When passing JSON CLI arguments" site/cli/serve/index.html
```

On `main`, the second command finds no JSON guidance.

### Root cause

`docs/cli/serve.md` references `docs/cli/json_tip.inc.md`, but the include was missing.

### Fix

Restore the JSON CLI guidance used by the version-matched upstream vLLM parser. It documents equivalent object and nested argument forms, plus list append syntax.

Partially addresses #6142.

## Test Plan

**vLLM Version:** N/A (documentation-only)

**vLLM-Omni Commit:** `2233d47f`

- `uvx --from pre-commit==4.0.1 pre-commit run --files docs/cli/json_tip.inc.md`
- `.venv/bin/mkdocs build --strict --site-dir /tmp/vllm-omni-docs-cli-json`
- Confirm `site/cli/serve/index.html` contains the restored JSON examples.

## Test Result

- All applicable pre-commit hooks passed.
- The strict documentation build completed successfully in 295.44 seconds.
- The rendered serve page contains the JSON object, nested-key, and list-append examples.
