### PR TITLE
[Model][dots.tts] Reuse the Euler CFG input workspace

### DIFF
--- a/vllm_omni/model_executor/models/dots_tts/dots_tts_talker.py
+++ b/vllm_omni/model_executor/models/dots_tts/dots_tts_talker.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """dots.tts talker — vLLM-native AR base LM + audio side path.
 
 Mirrors upstream rednote-hilab/dots.tts (pinned @ a393d2e):
@@ -948,7 +948,7 @@ class DotsTTSForConditionalGeneration(nn.Module):
         Manual Euler loop (upstream uses torchdyn.odeint; we manualize to
         avoid the dep and keep control flow explicit).  Each step:
           1. z_proj = _coordinate_proj(z), placed into the last
-             _LATENT_PATCH_SIZE positions of input_sequence / cfg_sequence.
+             _LATENT_PATCH_SIZE positions of the batched CFG workspace.
           2. Batch [conditional, unconditional] → DiT velocity field.
           3. CFG blend: v_c + guidance_scale * (v_c - v_u).
           4. Euler: z += v * dt.
@@ -963,11 +963,10 @@ class DotsTTSForConditionalGeneration(nn.Module):
         dtype = state.fm_sequence.dtype
         total_len = state.fm_seq_len + _LATENT_PATCH_SIZE
 
-        # Workspace: committed history + 4 noise slots (overwritten per step).
-        input_sequence = torch.zeros((1, total_len, _FM_HIDDEN), device=device, dtype=dtype)
-        input_sequence[:, : state.fm_seq_len] = state.fm_sequence[:, : state.fm_seq_len]
-        cfg_sequence = torch.zeros((1, total_len, _FM_HIDDEN), device=device, dtype=dtype)
-        cfg_sequence[:, : state.fm_seq_len] = state.fm_cfg_sequence[:, : state.fm_seq_len]
+        # Workspace: committed histories + 4 noise slots (overwritten per step).
+        z_batched = torch.zeros((2, total_len, _FM_HIDDEN), device=device, dtype=dtype)
+        z_batched[0:1, : state.fm_seq_len] = state.fm_sequence[:, : state.fm_seq_len]
+        z_batched[1:2, : state.fm_seq_len] = state.fm_cfg_sequence[:, : state.fm_seq_len]
 
         attn_mask = self._build_fm_attn_mask(state, total_len, device)
         pos_ids = self._build_fm_pos_ids(state, total_len, device)
@@ -1016,11 +1015,7 @@ class DotsTTSForConditionalGeneration(nn.Module):
             for step in range(num_steps):
                 t = times[step].reshape(1)
                 z_proj = self._coordinate_proj(z)
-                z_c = input_sequence.clone()
-                z_c[:, latent_start:] = z_proj
-                z_u = cfg_sequence.clone()
-                z_u[:, latent_start:] = z_proj
-                z_batched = torch.cat([z_c, z_u], dim=0)
+                z_batched[:, latent_start:] = z_proj
                 t_batched = t.repeat(2)
                 vt = self._head(
                     x=z_batched,


### PR DESCRIPTION
## Purpose

The dots.tts Euler solver clones both complete conditioning histories and concatenates them during every one of its ten steps. Build one contiguous `[2, total_len, 1024]` CFG workspace per solver invocation, copy both histories once, and update only the four latent positions at each step.

This removes 20 full-history clones and 10 concatenations per solver invocation without changing the solver API or tensor layout.

## Test Plan

**vLLM Version:** `0.28.0`

**vLLM-Omni Commit:** `5132dc7e1ce4ef5ac473d8b6e0092b65e1617f4e`

- Validate BF16 method parity on 8 NVIDIA H200 GPUs for sequence lengths 1, 156, 936, and 5116.
- Compare every DiT input, final output, history buffer, noise state, and RNG state across the ten Euler steps.
- Run an input-mutation check with the real DiT implementation and an exact full 18-layer solver comparison.
- Benchmark CFG input assembly with 20 warmups and nine alternating A/B rounds.
- Run all applicable changed-file pre-commit hooks.

## Test Result

Environment: 8x NVIDIA H200 (SM90), Python 3.12.13, PyTorch 2.13.0+cu130, Triton 3.7.1, CUDA 13.0, driver 595.58.03.

All four sequence lengths were bit-exact, including every DiT input and the final solver output. The real DiT left its input unchanged, and the full 18-layer solver produced exact, finite, nonzero output.

Cross-GPU p50 assembly results:

| Sequence length | Before | After | Reduction |
| ---: | ---: | ---: | ---: |
| 1 | 0.452 ms | 0.130 ms | 71.22% |
| 156 | 0.631 ms | 0.173 ms | 72.66% |
| 936 | 0.629 ms | 0.173 ms | 72.50% |
| 5116 | 0.624 ms | 0.175 ms | 71.89% |

The candidate removed all 20 `clone` and 10 `cat` operations and reduced measured temporary peak allocation by 75% at every tested length. These measurements cover Euler CFG input assembly only; no TTS end-to-end latency claim is made.

