### PR TITLE
[Model][OmniGen2] Keep rotary frequencies on the target device

### DIFF
--- a/vllm_omni/diffusion/models/omnigen2/pipeline_omnigen2.py
+++ b/vllm_omni/diffusion/models/omnigen2/pipeline_omnigen2.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 import inspect
 import json
@@ -1150,6 +1150,8 @@ class OmniGen2Pipeline(CFGParallelMixin, nn.Module, SupportsComponentDiscovery):
             self.transformer.config.axes_lens,
             theta=10000,
         )
+        if device.type != "mps":
+            freqs_cis = [freqs.to(device) for freqs in freqs_cis]
 
         image = self.processing(
             latents=latents,


### PR DESCRIPTION
## Purpose

OmniGen2 builds three rotary frequency tables on CPU once per request, but `_get_freqs_cis` moves each table to the target device again on every denoise branch. A default 28-step request therefore performs 168 H2D copies for text-to-image and 252 for image editing.

Move the tables to the target device once before the denoise loop. Keep them on CPU for MPS, where `_get_freqs_cis` intentionally indexes on CPU.

## Test Plan

**vLLM Version:** `0.28.0`

**vLLM-Omni Commit:** `7afded7fae3cf21eac90eee02c4c79d2c36ffd84`

- Compare the existing and device-resident paths for complete 28-step T2I and edit rotary schedules on eight H200 GPUs.
- Check exact outputs for every positive, negative, and reference-negative branch.
- Count frequency-table transfers and bytes from calibrated Kineto `Memcpy HtoD` events.
- Run all applicable changed-file pre-commit hooks and Python compilation.

## Test Result

Environment: NVIDIA H200 (SM90), Python 3.12.13, PyTorch 2.13.0+cu130, CUDA 13.0, driver 595.58.03. Timing used all eight GPUs; the transfer trace used one isolated H200.

| Schedule | Before | After | Reduction | H2D before | H2D after | Transfer bytes saved |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| T2I, 56 calls | 32.853 ms | 22.663 ms | 31.02% | 168 | 3 | 73.05 MiB |
| Edit, 84 calls | 54.289 ms | 38.876 ms | 28.39% | 252 | 3 | 110.23 MiB |

All branch outputs matched exactly on every GPU. The p50 latency bands were separated on all eight GPUs for both schedules. The retained tables add 1.33 MiB of request-local device storage. These are rotary-component schedule results; no full-model end-to-end latency claim is made.
