### PR TITLE
[Model][ERNIE-Image] Delay AdaLN modulation broadcast

### DIFF
--- a/vllm_omni/diffusion/models/ernie_image/ernie_image_transformer.py
+++ b/vllm_omni/diffusion/models/ernie_image/ernie_image_transformer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 # Adapted from: https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/transformers/transformer_ernie_image.py
 
 from collections.abc import Iterable
@@ -599,17 +599,12 @@ class ErnieImageTransformer2DModel(nn.Module):
         hidden_states, freqs_cos, freqs_sin, attention_mask = self.unified_prepare(hidden_states, text_bth, text_lens)
         attention_mask = self._slice_attention_mask_for_ring(attention_mask)
         rotary_pos_emb = (freqs_cos, freqs_sin)
-        S = hidden_states.shape[0]
-
         sample = self.time_proj(timestep)
         sample = sample.to(dtype=dtype)
         c = self.time_embedding(sample)
-        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = [
-            t.unsqueeze(0).expand(S, -1, -1).contiguous() for t in self.adaLN_modulation(c).chunk(6, dim=-1)
-        ]
+        temb = self.adaLN_modulation(c).chunk(6, dim=-1)
 
         for layer in self.layers:
-            temb = [shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp]
             if torch.is_grad_enabled() and self.gradient_checkpointing:
                 hidden_states = self._gradient_checkpointing_func(
                     layer,


### PR DESCRIPTION
## Purpose

ERNIE-Image materializes six sequence-length AdaLN tensors before entering its transformer blocks. The blocks already use these values through broadcastable elementwise operations, so expanding and copying the modulation across every token is unnecessary.

Keep the six `[batch, hidden]` chunks and let the block operations broadcast them. At the default 1024px CFG shape (`sequence=4608`, `batch=2`, `hidden=3072`, BF16), this reduces request-local modulation storage from 324 MiB to 72 KiB.

## Test Plan

**vLLM Version:** `0.28.0`

**vLLM-Omni Commit:** `6b31c6e2946b6cfc9a05770dc1019c32bb5f3b89` (base `615f97b9c79e2143c91d3f7fe81603327df059aa`)

- Compare baseline and delayed-broadcast outputs across FP32/BF16, CFG/non-CFG, production sequence length, and noncontiguous inputs.
- Repeat the comparison with the production regional-compilation boundary: only `ErnieImageSharedAdaLNBlock.forward` is compiled with Inductor.
- Verify that both arms invoke Inductor and that each compiled arm is repeatable.
- Profile modulation materialization and run all applicable changed-file pre-commit hooks and Python compilation.
- Measure latency and peak allocation at the production 1024px shapes on one H200: the modulation builder alone, the builder plus one block, and the production boundary (eager builder, compiled block).

## Test Result

Environment: NVIDIA H200 (SM90), Python 3.12.13, PyTorch 2.13.0+cu130, CUDA 13.0, driver 595.58.03.

Baseline and candidate outputs matched bitwise in eager and compiled execution for four BF16 H200 cases, including the production sequence length and noncontiguous inputs, and again at both production shapes below. Each compiled arm was repeatable, and both invoked the Inductor backend. Ten additional CPU FP32/BF16 cases also matched exactly.

The modulation builder removes six `contiguous`/`clone`/`copy_` operations. The measurement is source-locked: the baseline and candidate modulation builders and the `ErnieImageSharedAdaLNBlock.forward` body are extracted from the base and head files, with identical identity attention and half-scale MLP stubs in both arms, so the only difference is the modulation materialization and how the block reads `temb`. Timing is CUDA-event device time per call, 20 warmups and nine ABBA/BAAB rounds of 20 calls, medians over rounds; peak allocation is the `max_memory_allocated` delta of one call.

Peak allocation, BF16, `sequence=4608`, `hidden=3072`:

| Shape | Segment | Before | After | Saved |
| --- | --- | ---: | ---: | ---: |
| 1024px, no CFG | modulation builder | 168.00 MiB | 0 | 168.00 MiB |
| 1024px, no CFG | eager builder + compiled block | 196.00 MiB | 28.00 MiB | 168.00 MiB |
| 1024px, CFG | modulation builder | 324.00 MiB | 0 | 324.00 MiB |
| 1024px, CFG | eager builder + compiled block | 378.00 MiB | 54.00 MiB | 324.00 MiB |

Latency p50 per call, same shapes:

| Shape | Segment | Before | After | Reduction |
| --- | --- | ---: | ---: | ---: |
| 1024px, no CFG | modulation builder, eager | 0.1438 ms | 0.0075 ms | 94.80% |
| 1024px, no CFG | eager builder + compiled block | 0.2027 ms | 0.0661 ms | 67.38% |
| 1024px, no CFG | builder + block, both eager | 1.0499 ms | 0.6146 ms | 41.46% |
| 1024px, CFG | modulation builder, eager | 0.3424 ms | 0.0079 ms | 97.69% |
| 1024px, CFG | eager builder + compiled block | 0.4538 ms | 0.0662 ms | 85.41% |
| 1024px, CFG | builder + block, both eager | 2.0575 ms | 1.1461 ms | 44.30% |

The P20-P80 bands were separated in every row above. The builder cost is paid once per forward; the block term repeats per layer, since the compiled block reads six `[batch, hidden]` values instead of six materialized `[sequence, batch, hidden]` tensors. When the builder and the block are compiled together in one graph, Inductor already eliminates the copies and both arms measure the same 0.051 ms, so the gain applies to eager execution and to the production regional boundary, where the builder runs outside the compiled block. These are component measurements on stubbed attention and MLP; no full-model end-to-end latency claim is made.
