### PR TITLE
[XPU] update the way integrate xpu mxfp8/mxfp4 by direct invoking vllm mxfp4/mxfp8 kernel

### DIFF
--- a/docs/user_guide/quantization/mxfp8.md
+++ b/docs/user_guide/quantization/mxfp8.md
@@ -167,7 +167,7 @@ omni = Omni(model="/path/to/Wan2.2-TI2V-5B-MXFP8")
 
 ### Offline Mode (AutoRound)
 
-AutoRound MXFP8 checkpoints declare `quant_method="auto-round"` with `data_type="mx_fp"` in their `config.json`. These are automatically detected and use the `IncMxfp8OfflineLinearMethod` backend.
+AutoRound MXFP8 checkpoints declare `quant_method="auto-round"` with `data_type="mx_fp"` in their `config.json`. These are automatically detected and use the `VllmMxfp8OfflineLinearMethod` backend.
 
 To use an AutoRound MXFP8 checkpoint:
 

--- a/tests/diffusion/quantization/test_wan_autoround_mxfp4.py
+++ b/tests/diffusion/quantization/test_wan_autoround_mxfp4.py
@@ -12,8 +12,10 @@ from vllm.model_executor.model_loader.utils import configure_quant_config
 from vllm_omni.diffusion.models.wan2_2.wan2_2_transformer import (
     WanTransformer3DModel,
 )
+from vllm_omni.platforms import current_omni_platform
 from vllm_omni.quantization import build_quant_config
 from vllm_omni.quantization.inc_config import OmniINCConfig
+from vllm_omni.quantization.mxfp4_config import VllmMxfp4OfflineLinearMethod
 
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
 
@@ -87,4 +89,8 @@ def test_wan_autoround_scope_dispatches_only_blocks_to_mxfp4():
         return_value=fake_method,
     ):
         method = config.get_quant_method(layer, "blocks.0.ffn.net_0.proj")
-    assert method is fake_method
+    if current_omni_platform.is_xpu():
+        # XPU serves MXFP4 from XPUMxFp4LinearKernel; the INC scheme is not used.
+        assert isinstance(method, VllmMxfp4OfflineLinearMethod)
+    else:
+        assert method is fake_method

--- a/vllm_omni/quantization/inc_config.py
+++ b/vllm_omni/quantization/inc_config.py
@@ -7,13 +7,13 @@ from __future__ import annotations
 from os.path import commonprefix
 from typing import TYPE_CHECKING, Any
 
-import torch
-from torch.nn import Module
-from vllm.model_executor.layers.linear import LinearMethodBase
+from vllm.model_executor.layers.linear import LinearBase
 from vllm.model_executor.layers.quantization.inc import INCConfig
 from vllm.model_executor.models.utils import WeightsMapper
-from vllm.model_executor.parameter import ModelWeightParameter
-from vllm.model_executor.utils import replace_parameter
+
+from vllm_omni.platforms import current_omni_platform
+from vllm_omni.quantization.mxfp4_config import VllmMxfp4OfflineLinearMethod
+from vllm_omni.quantization.mxfp8_config import VllmMxfp8OfflineLinearMethod
 
 if TYPE_CHECKING:
     from vllm.model_executor.layers.quantization.base_config import (
@@ -50,37 +50,41 @@ def _map_with_stage_prefix(
 
 
 class OmniINCConfig(INCConfig):
-    """INCConfig extended with multi-stage prefix remapping and MXFP8 support.
+    """INCConfig extended with multi-stage prefix remapping.
 
-    AutoRound MXFP8 checkpoints declare quant_method="auto-round" with data_type="mx_fp".
-    This config detects that case and dispatches to IncMxfp8OfflineLinearMethod instead
-    of the standard INT quantization path.
+    :class:`INCConfig` is used for AutoRound checkpoint detection and per-layer
+    config resolution only. MX linears are served by omni's own methods on top of
+    the XPU kernels; no INC linear method or scheme is involved.
 
     Architecture:
-      - AutoRound INT4/INT8 → standard INCConfig path (xpu_w4a16_quant_layer, etc.)
-      - AutoRound MXFP8 (data_type="mx_fp") → IncMxfp8OfflineLinearMethod
-      - Native MXFP8 (quant_method="mxfp8") → DiffusionMXFP8Config → NPUMxfp8LinearMethod (NPU only)
+      - AutoRound INT4/INT8 → vLLM INCWna16Scheme
+      - AutoRound MXFP4 (data_type="mx_fp", bits=4), XPU → VllmMxfp4OfflineLinearMethod
+        → XPUMxFp4LinearKernel
+      - AutoRound MXFP8 (data_type="mx_fp", bits=8), XPU → VllmMxfp8OfflineLinearMethod
+        → XPUMxFp8LinearKernel
+      - AutoRound MXFP4 / MXFP8 on other platforms → vLLM INCMxfp4Scheme / INCMxfp8Scheme
+      - Native MXFP8 (quant_method="mxfp8") → DiffusionMXFP8Config (see mxfp8_config.py)
     """
-
-    # Extend supported data types and formats to include MXFP8
-    SUPPORTED_DTYPES = {"int", "mx_fp"}
-    SUPPORTED_FORMATS = {"auto_round:auto_gptq", "auto_round:auto_awq", "auto_round:llm_compressor"}
 
     # ------------------------------------------------------------------
     # Core integration: called by vLLM's configure_quant_config()
     # ------------------------------------------------------------------
 
     def get_quant_method(self, layer, prefix: str):
-        """Get quantization method, handling AutoRound MXFP8 as a special case."""
-        # Check if this is an AutoRound MXFP8 checkpoint (data_type="mx_fp")
-        if hasattr(self, "data_type") and self.data_type == "mx_fp" and self.weight_bits == 8:
-            from vllm.model_executor.layers.linear import LinearBase
+        """MX linears go straight to the XPU kernels; everything else is vLLM's.
 
-            if isinstance(layer, LinearBase):
-                return IncMxfp8OfflineLinearMethod()
-            return None
-
-        # Otherwise, use parent INCConfig logic
+        Resolved from the layer config rather than from vLLM's INC method, so no
+        INC scheme (and no second kernel selection) is built just to be dropped.
+        XPU only: the XPU kernels assert is_supported() in their constructor, so
+        other platforms keep vLLM's INC schemes and their own kernel selection.
+        """
+        if self.is_mxfp and current_omni_platform.is_xpu() and isinstance(layer, LinearBase):
+            layer_config = self.config_parser.resolve(layer, prefix)
+            if layer_config.quantized:
+                if layer_config.is_mxfp8:
+                    return VllmMxfp8OfflineLinearMethod()
+                if layer_config.is_mxfp4:
+                    return VllmMxfp4OfflineLinearMethod(group_size=layer_config.group_size)
         return super().get_quant_method(layer, prefix)
 
     def apply_vllm_mapper(self, hf_to_vllm_mapper: WeightsMapper) -> None:
@@ -170,108 +174,3 @@ class OmniINCConfig(INCConfig):
         if isinstance(quant_config, INCConfig):
             return cls.from_inc_config(quant_config)
         return quant_config
-
-
-# ---------------------------------------------------------------------------
-# IncMxfp8OfflineLinearMethod - used by AutoRound MXFP8 checkpoints
-# ---------------------------------------------------------------------------
-
-
-class IncMxfp8OfflineLinearMethod(LinearMethodBase):
-    """Offline MXFP8 linear method for AutoRound MXFP8 checkpoints.
-
-    For pre-quantized AutoRound MXFP8 checkpoints (data_type="mx_fp") where weights
-    are stored as BF16 (losslessly representing FP8 E4M3 values) with uint8 MX block scales.
-    Delegates to the platform-appropriate kernel (XPUMxFp8LinearKernel, etc.).
-
-    Used by OmniINCConfig when data_type="mx_fp".
-    """
-
-    def __init__(self) -> None:
-        from vllm.model_executor.kernels.linear import init_mxfp8_linear_kernel
-        from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
-            MXFP8_BLOCK_SIZE,
-            MXFP8_SCALE_DTYPE,
-        )
-
-        self.kernel = init_mxfp8_linear_kernel()
-        self.block_size = MXFP8_BLOCK_SIZE
-        self.scale_dtype = MXFP8_SCALE_DTYPE
-
-    def create_weights(
-        self,
-        layer: torch.nn.Module,
-        input_size_per_partition: int,
-        output_partition_sizes: list[int],
-        input_size: int,
-        output_size: int,
-        params_dtype: torch.dtype,
-        **extra_weight_attrs,
-    ) -> None:
-        if input_size_per_partition % self.block_size != 0:
-            raise ValueError(
-                f"MXFP8 requires input_size_per_partition "
-                f"({input_size_per_partition}) to be divisible by "
-                f"{self.block_size}."
-            )
-
-        output_size_per_partition = sum(output_partition_sizes)
-        weight_loader = extra_weight_attrs.get("weight_loader")
-
-        layer.logical_widths = output_partition_sizes
-        layer.input_size_per_partition = input_size_per_partition
-        layer.output_size_per_partition = output_size_per_partition
-        layer.orig_dtype = params_dtype
-
-        # Allocate as params_dtype (BF16) to match checkpoint dtype.
-        # Will be cast to FP8 in process_weights_after_loading.
-        layer.register_parameter(
-            "weight",
-            ModelWeightParameter(
-                data=torch.empty(output_size_per_partition, input_size_per_partition, dtype=params_dtype),
-                input_dim=1,
-                output_dim=0,
-                weight_loader=weight_loader,
-            ),
-        )
-
-        num_groups = input_size_per_partition // self.block_size
-        layer.register_parameter(
-            "weight_scale",
-            ModelWeightParameter(
-                data=torch.empty(output_size_per_partition, num_groups, dtype=self.scale_dtype),
-                input_dim=1,
-                output_dim=0,
-                weight_loader=weight_loader,
-            ),
-        )
-
-    def process_weights_after_loading(self, layer: Module) -> None:
-        if getattr(layer, "_already_called_process_weights_after_loading", False):
-            return
-
-        # Cast BF16 weight to FP8.
-        # Checkpoint stores weights as BF16 (losslessly representing FP8 E4M3 values).
-        w = layer.weight.data
-        if w.dtype != torch.float8_e4m3fn:
-            # Cast to FP8 E4M3. AutoRound stores FP8 values as BF16, so this is lossless.
-            w = w.to(torch.float8_e4m3fn).contiguous()
-            replace_parameter(layer, "weight", w)
-
-        # Delegate layout transforms (transpose, scale reinterpret) to the platform kernel.
-        self.kernel.process_weights_after_loading(layer)
-        layer._already_called_process_weights_after_loading = True
-
-    def apply(
-        self,
-        layer: torch.nn.Module,
-        x: torch.Tensor,
-        bias: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        ori_shape = x.shape
-        if x.dim() > 2:
-            x = x.reshape(-1, ori_shape[-1])
-        output = self.kernel.apply_weights(layer, x, bias)
-        if len(ori_shape) > 2:
-            output = output.reshape(*ori_shape[:-1], -1)
-        return output

--- a/vllm_omni/quantization/mxfp4_config.py
+++ b/vllm_omni/quantization/mxfp4_config.py
@@ -59,6 +59,7 @@ from torch.nn import Module
 from vllm.logger import init_logger
 from vllm.model_executor.layers.linear import (
     LinearBase,
+    LinearMethodBase,
     UnquantizedLinearMethod,
 )
 from vllm.model_executor.layers.quantization import QuantizationMethods
@@ -863,3 +864,108 @@ class DiffusionMXFP4DualScaleMixedConfig(QuantizationConfig):
                 "DiffusionMXFP4DualScaleMixedConfig is currently only supported on NPU (Ascend) platforms."
             )
         return NPUMxfp4DualScaleOnlineLinearMethod(self)
+
+
+# ---------------------------------------------------------------------------
+# XPU method — built directly on XPUMxFp4LinearKernel
+#
+# Same split as MXFP8: the kernel owns the packed-weight / e8m0-scale relayout
+# and the fp4_gemm call, so vLLM's INC method layer is not depended on.
+# ---------------------------------------------------------------------------
+
+try:
+    from vllm.model_executor.kernels.linear.mxfp4.base import MxFp4LinearLayerConfig
+    from vllm.model_executor.kernels.linear.mxfp4.xpu import XPUMxFp4LinearKernel
+    from vllm.model_executor.layers.quantization.utils.quant_utils import kMxfp4Dynamic
+    from vllm.model_executor.parameter import GroupQuantScaleParameter
+except ImportError as e:
+    raise ImportError(
+        "vLLM MXFP4 support is not available. "
+        "MXFP4 quantization requires vLLM with XPUMxFp4LinearKernel support. "
+        "Please upgrade vLLM or use a compatible build."
+    ) from e
+
+MXFP4_PACK_FACTOR = 2  # two E2M1 values per uint8
+
+
+class VllmMxfp4OfflineLinearMethod(LinearMethodBase):
+    """Offline MXFP4 linear method for AutoRound checkpoints (data_type="mx_fp").
+
+    Weights arrive packed two E2M1 values per byte, with one uint8 e8m0 scale per
+    ``group_size`` input elements. Layout normalization and the GEMM are the
+    kernel's; activations are flattened to ``(M, K)`` for diffusion.
+    """
+
+    def __init__(self, group_size: int = 32) -> None:
+        self.group_size = group_size
+        self.kernel = XPUMxFp4LinearKernel(MxFp4LinearLayerConfig(activation_quant_key=kMxfp4Dynamic))
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        if input_size_per_partition % self.group_size != 0:
+            raise ValueError(
+                f"MXFP4 requires input_size_per_partition ({input_size_per_partition}) "
+                f"to be divisible by {self.group_size}."
+            )
+
+        output_size_per_partition = sum(output_partition_sizes)
+        weight_loader = extra_weight_attrs.get("weight_loader")
+
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+        layer.orig_dtype = params_dtype
+
+        # Checkpoint key is weight_packed; renamed to weight before the kernel
+        # relayout, which views it as float4_e2m1fn_x2.
+        layer.register_parameter(
+            "weight_packed",
+            ModelWeightParameter(
+                data=torch.empty(
+                    output_size_per_partition,
+                    input_size_per_partition // MXFP4_PACK_FACTOR,
+                    dtype=torch.uint8,
+                ),
+                input_dim=1,
+                output_dim=0,
+                weight_loader=weight_loader,
+            ),
+        )
+        layer.register_parameter(
+            "weight_scale",
+            GroupQuantScaleParameter(
+                data=torch.empty(
+                    output_size_per_partition,
+                    input_size_per_partition // self.group_size,
+                    dtype=torch.uint8,
+                ),
+                input_dim=1,
+                output_dim=0,
+                weight_loader=weight_loader,
+            ),
+        )
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        layer.weight = torch.nn.Parameter(layer.weight_packed.data, requires_grad=False)
+        del layer.weight_packed
+        self.kernel.process_weights_after_loading(layer)
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if x.dim() <= 2:
+            return self.kernel.apply_weights(layer, x, bias)
+        ori_shape = x.shape
+        output = self.kernel.apply_weights(layer, x.reshape(-1, ori_shape[-1]), bias)
+        return output.reshape(*ori_shape[:-1], -1)

--- a/vllm_omni/quantization/mxfp8_config.py
+++ b/vllm_omni/quantization/mxfp8_config.py
@@ -12,6 +12,14 @@ Architecture:
       NPUMxfp8OnlineLinearMethod  – NPU online: _LazyWeightMixin for create_weights,
                                      overrides process_weights to quantize BF16 → FP8.
 
+XPU builds on vLLM's kernels directly rather than on its quantization *methods*:
+``XPUMxFp8LinearKernel`` is the stable interface, while the INC / online linear
+method wrappers around it are not. MoE is left to vLLM for now.
+
+  VllmMxfp8OfflineLinearMethod  – offline AutoRound MXFP8 checkpoints
+  VllmMxfp8OnlineLinearMethod   – BF16 checkpoint, quantized at load time
+  VllmMxfp8OnlineMoEMethod      – vLLM Mxfp8OnlineMoEMethod, re-exported unchanged
+
 Extending to a new platform (e.g. CUDA MXFP8 once the ops are available):
 
     class CUDAMxfp8LinearMethod(MXFPLinearMethodBase):
@@ -39,6 +47,10 @@ from typing import TYPE_CHECKING, Any
 import torch
 from torch.nn import Module
 from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe import (
+    RoutedExperts,
+    UnquantizedFusedMoEMethod,
+)
 from vllm.model_executor.layers.linear import (
     LinearBase,
     LinearMethodBase,
@@ -122,6 +134,12 @@ class DiffusionMXFP8Config(QuantizationConfig):
             ignored_layers=ignored_layers,
         )
 
+    _XPU_OFFLINE_UNSUPPORTED = (
+        "Native MXFP8 offline mode is not supported on XPU. "
+        "Use AutoRound MXFP8 checkpoints (quant_method='auto-round', data_type='mx_fp') instead, "
+        "or use online MXFP8 mode without is_checkpoint_mxfp8_serialized."
+    )
+
     def get_quant_method(
         self,
         layer: torch.nn.Module,
@@ -140,16 +158,26 @@ class DiffusionMXFP8Config(QuantizationConfig):
                 return NPUMxfp8OnlineLinearMethod(self)
             if current_omni_platform.is_xpu():
                 if self.is_checkpoint_mxfp8_serialized:
-                    raise NotImplementedError(
-                        "Native MXFP8 offline mode is not supported on XPU. "
-                        "Use AutoRound MXFP8 checkpoints (quant_method='auto-round', data_type='mx_fp') instead, "
-                        "or use online MXFP8 mode without is_checkpoint_mxfp8_serialized."
-                    )
+                    raise NotImplementedError(self._XPU_OFFLINE_UNSUPPORTED)
                 return VllmMxfp8OnlineLinearMethod()
             raise NotImplementedError(
                 "DiffusionMXFP8Config (W8A8 MXFP8) is currently only supported "
                 "on NPU (Ascend) and XPU (Intel) platforms."
             )
+        if isinstance(layer, RoutedExperts):
+            if is_layer_skipped(
+                prefix=prefix,
+                ignored_layers=self.ignored_layers,
+                fused_mapping=self.packed_modules_mapping,
+            ):
+                return UnquantizedFusedMoEMethod(layer.moe_config)
+            if current_omni_platform.is_xpu():
+                if self.is_checkpoint_mxfp8_serialized:
+                    raise NotImplementedError(self._XPU_OFFLINE_UNSUPPORTED)
+                return VllmMxfp8OnlineMoEMethod(layer=layer)
+            # NPU has no MXFP8 MoE op yet; leave the experts in BF16 rather
+            # than failing the whole model load.
+            return None
         return None
 
 
@@ -465,45 +493,101 @@ class NPUMxfp8OnlineLinearMethod(_LazyWeightMixin, NPUMxfp8LinearMethod):
 
 
 # ---------------------------------------------------------------------------
-# vLLM kernel-based methods (XPU, CUDA, ROCm — any platform with Mxfp8LinearKernel)
+# XPU methods — built directly on XPUMxFp8LinearKernel
+#
+# The kernel is the stable contract: process_weights_after_loading() owns the
+# [N, K//32] -> [K//32, N] e8m0 scale relayout and apply_weights() owns the
+# oneDNN fp8_gemm call. vLLM's INC / online *method* layers are not depended on.
 # ---------------------------------------------------------------------------
-# Note: VllmMxfp8OfflineLinearMethod removed - XPU only supports AutoRound MXFP8 offline
-#       (see IncMxfp8OfflineLinearMethod in inc_config.py)
 
 try:
-    from vllm.model_executor.layers.quantization.online.mxfp8 import (
-        Mxfp8OnlineLinearMethod as _VllmMxfp8OnlineBase,
+    from vllm.model_executor.kernels.linear.mxfp8.Mxfp8LinearKernel import (
+        Mxfp8LinearLayerConfig,
     )
+    from vllm.model_executor.kernels.linear.mxfp8.xpu import XPUMxFp8LinearKernel
+    from vllm.model_executor.layers.quantization.online.mxfp8 import (
+        Mxfp8OnlineMoEMethod as VllmMxfp8OnlineMoEMethod,
+    )
+    from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
+        MXFP8_BLOCK_SIZE,
+        MXFP8_SCALE_DTYPE,
+        MXFP8_VALUE_DTYPE,
+        mxfp8_e4m3_quantize,
+    )
+    from vllm.model_executor.parameter import GroupQuantScaleParameter
 except ImportError as e:
     raise ImportError(
         "vLLM MXFP8 support is not available. "
-        "Online MXFP8 quantization requires vLLM with MXFP8 kernel support. "
+        "MXFP8 quantization requires vLLM with XPUMxFp8LinearKernel support. "
         "Please upgrade vLLM or use a compatible build."
     ) from e
 
 
-class VllmMxfp8OnlineLinearMethod(_VllmMxfp8OnlineBase):
-    """Online MXFP8 linear method extending vLLM's implementation with 3D tensor support.
+class VllmMxfp8OfflineLinearMethod(LinearMethodBase):
+    """Offline MXFP8 linear method for AutoRound checkpoints (data_type="mx_fp").
 
-    Loads BF16 weights, quantizes to MXFP8 at load time using vLLM's kernel.
-    Adds reshape logic to handle 3D tensors from diffusion models.
-
-    Inherits from vLLM's Mxfp8OnlineLinearMethod and only overrides __init__ and apply().
-    __init__ directly initializes the kernel without calling super().__init__() to avoid
-    vLLM config dependency in unit tests. All other methods (create_weights,
-    process_weights_after_loading) are inherited directly from vLLM.
+    Weights arrive already quantized: FP8-E4M3 values plus one uint8 e8m0 scale
+    per 32 input elements. Layout normalization and the GEMM are the kernel's.
     """
 
     def __init__(self) -> None:
-        """Initialize kernel directly without calling parent __init__ to avoid config dependency.
+        self.kernel = XPUMxFp8LinearKernel(Mxfp8LinearLayerConfig())
 
-        TODO: skipping super().__init__() couples this to vLLM internals. If the parent
-        adds required initialization, consider a version-aware assertion or calling
-        super().__init__() with a fallback config.
-        """
-        from vllm.model_executor.kernels.linear import init_mxfp8_linear_kernel
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        if input_size_per_partition % MXFP8_BLOCK_SIZE != 0:
+            raise ValueError(
+                f"MXFP8 requires input_size_per_partition ({input_size_per_partition}) "
+                f"to be divisible by {MXFP8_BLOCK_SIZE}."
+            )
 
-        self.kernel = init_mxfp8_linear_kernel()
+        output_size_per_partition = sum(output_partition_sizes)
+        weight_loader = extra_weight_attrs.get("weight_loader")
+
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+        layer.orig_dtype = params_dtype
+
+        layer.register_parameter(
+            "weight",
+            ModelWeightParameter(
+                data=torch.empty(
+                    output_size_per_partition,
+                    input_size_per_partition,
+                    dtype=MXFP8_VALUE_DTYPE,
+                ),
+                input_dim=1,
+                output_dim=0,
+                weight_loader=weight_loader,
+            ),
+        )
+        layer.register_parameter(
+            "weight_scale",
+            GroupQuantScaleParameter(
+                data=torch.empty(
+                    output_size_per_partition,
+                    input_size_per_partition // MXFP8_BLOCK_SIZE,
+                    dtype=MXFP8_SCALE_DTYPE,
+                ),
+                input_dim=1,
+                output_dim=0,
+                weight_loader=weight_loader,
+            ),
+        )
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        # Hands the [N, K//32] e8m0 scale to the kernel for its [K//32, N]
+        # relayout, which apply_weights() then recovers with a free .t().
+        self.kernel.process_weights_after_loading(layer)
 
     def apply(
         self,
@@ -511,15 +595,38 @@ class VllmMxfp8OnlineLinearMethod(_VllmMxfp8OnlineBase):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        """Apply with 3D tensor support for diffusion models.
-
-        vLLM's kernel expects 2D tensors (M, K), but diffusion models pass
-        3D tensors (batch, seq, hidden). Flatten before kernel, reshape after.
-        """
+        if x.dim() <= 2:
+            return self.kernel.apply_weights(layer, x, bias)
         ori_shape = x.shape
-        if x.dim() > 2:
-            x = x.reshape(-1, ori_shape[-1])
-        output = super().apply(layer, x, bias)
-        if len(ori_shape) > 2:
-            output = output.reshape(*ori_shape[:-1], -1)
-        return output
+        output = self.kernel.apply_weights(layer, x.reshape(-1, ori_shape[-1]), bias)
+        return output.reshape(*ori_shape[:-1], -1)
+
+
+class VllmMxfp8OnlineLinearMethod(_LazyWeightMixin, VllmMxfp8OfflineLinearMethod):
+    """Online MXFP8 linear method: BF16 checkpoint, quantized at load time.
+
+    create_weights comes from :class:`_LazyWeightMixin` (meta device, weights
+    materialized just-in-time); apply() is shared with the offline method.
+    """
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        if getattr(layer, "_already_called_process_weights_after_loading", False):
+            return
+
+        if layer.weight.device == torch.device("meta"):
+            weight = ModelWeightParameter(
+                data=torch.empty_like(layer.weight, device=layer._load_device),
+                input_dim=1,
+                output_dim=0,
+                weight_loader=layer.weight.weight_loader,
+            )
+            _copy_missing_attrs(layer.weight, weight)
+            layer.register_parameter("weight", weight)
+            initialize_single_dummy_weight(layer.weight)
+
+        weight_fp8, weight_scale = mxfp8_e4m3_quantize(layer.weight.data.contiguous())
+        replace_parameter(layer, "weight", weight_fp8)
+        replace_parameter(layer, "weight_scale", weight_scale)
+
+        self.kernel.process_weights_after_loading(layer)
+        layer._already_called_process_weights_after_loading = True


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

vLLM-Omni's MXFP8 path carried its own copies of weight allocation, the BF16→FP8
cast and the MX scale relayout — logic that already exists in vLLM's
`XPUMxFp8LinearKernel`. The duplicate drifted from upstream and needed hand
updates whenever the kernel layout changed.

The XPU MX kernels (`XPUMxFp8LinearKernel`, `XPUMxFp4LinearKernel`) are the
stable, long-lived interface in vLLM: `process_weights_after_loading()` owns the
scale relayout and `apply_weights()` owns the fp8/fp4 GEMM. The INC / online
*method* wrappers around them are not a contract we want to depend on. This PR
makes omni talk to the kernels directly for both precisions.

The XPU gate is deliberate: both XPU kernels `assert self.is_supported()[0]` in
their constructor, so CUDA/ROCm must keep vLLM's INC schemes and their own kernel
selection.

## Test Plan

XPU dev container, vllm 0.28.0+xpu / torch 2.13.0+xpu, 4x Intel Arc Pro B70.
Env for every run: `SYCL_UR_USE_LEVEL_ZERO_V2=0`,
`VLLM_WORKER_MULTIPROC_METHOD=spawn`.

**Unit**

```bash
pytest -q tests/diffusion/quantization/test_mxfp8_config.py \
          tests/diffusion/quantization/test_mxfp4_config.py \
          tests/diffusion/quantization/test_inc_config.py \
          tests/diffusion/quantization/test_wan_autoround_mxfp4.py \
          tests/diffusion/quantization/test_component_routing.py \
          tests/diffusion/offloader/test_distributed_layerwise_backend.py
# 211 passed, 1 skipped
```

**E2E (both precisions)**

```bash
# MXFP8, Wan2.2-T2V-A14B, TP=4  -> 34.4 s generation, pixel std 58.14
PYTHONPATH=$PWD ZE_AFFINITY_MASK=0,1,2,3 \
python examples/offline_inference/text_to_video/text_to_video.py \
  --model INCModel/Wan2.2-T2V-A14B-Diffusers-MXFP8-AutoRound \
  --prompt "A red toy car driving on a table" \
  --height 480 --width 832 --num-frames 5 --num-inference-steps 20 \
  --guidance-scale 4.0 --seed 42 --tensor-parallel-size 4 --fps 8 \
  --output mxfp8_480p.mp4
```

https://github.com/user-attachments/assets/06ed9a9b-3835-4ac5-ac33-93d1f6813a59





**vLLM Version:**

0.28.0

**vLLM-Omni Commit:**

## Test Result

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
