### PR TITLE
[Diffusion][MAGI-2] Fuse multi-head MoE route construction

### DIFF
--- a/benchmarks/kernels/benchmark_magi2_moe_routing.py
+++ b/benchmarks/kernels/benchmark_magi2_moe_routing.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Benchmark MAGI-2 multi-head MoE route construction.
+
+Measures the two route-construction stages of
+``vllm_omni.diffusion.models.magi2.mh_moe`` in isolation:
+
+* ``compute_topk_probs_and_indices`` -- sigmoid, selection bias, top-k,
+  probability gather and L1 normalization;
+* ``global_sort_routes`` -- stable flattened-expert sort, counts and CSR
+  offsets.
+
+Both are reported against their unfused reference implementations, which are
+also used as automatic fallbacks for unsupported inputs.  This is a synthetic
+kernel microbenchmark: it builds random router logits and does not load a
+checkpoint.  ``--with-experts`` additionally times the fused expert kernel so
+the routing share of a whole MoE layer can be read off directly, at the cost of
+about 6 GiB of expert weights.
+
+Example:
+    python benchmarks/kernels/benchmark_magi2_moe_routing.py \
+        --tokens 1024,7674,29184,58368 --warmup 20 --iterations 50
+"""
+
+import argparse
+import math
+import statistics
+from collections.abc import Callable
+
+import torch
+from vllm.triton_utils import triton
+
+from vllm_omni.diffusion.models.magi2.mh_moe import (
+    _reference_global_sort_routes,
+    _reference_topk_probs_and_indices,
+    compute_topk_probs_and_indices,
+    global_sort_routes,
+    triton_mh_moe_forward,
+)
+
+MiB = 1024**2
+
+# sand-ai/MAGI-2-preview: 12 hidden-state heads, each routing to its own bank of
+# 256 experts, top-6.  540p is 56x32 latent patches over 16 latent frames, so a
+# full-trajectory denoise step sees roughly 29k video tokens per forward.
+DEFAULT_HEADS = 12
+DEFAULT_EXPERTS = 256
+DEFAULT_TOP_K = 6
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--tokens", default="1024,4096,7674,16384,29184,58368")
+    parser.add_argument("--heads", type=int, default=DEFAULT_HEADS)
+    parser.add_argument("--experts", type=int, default=DEFAULT_EXPERTS)
+    parser.add_argument("--top-k", type=int, default=DEFAULT_TOP_K)
+    parser.add_argument("--head-dim", type=int, default=256, help="Only used by --with-experts.")
+    parser.add_argument("--expert-dim", type=int, default=1280, help="Only used by --with-experts.")
+    parser.add_argument("--no-bias", action="store_true", help="Route without the auxiliary-free selection bias.")
+    parser.add_argument("--no-route-norm", action="store_true")
+    parser.add_argument("--with-experts", action="store_true", help="Also time the fused expert kernel.")
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--iterations", type=int, default=50)
+    parser.add_argument("--seed", type=int, default=0)
+    return parser.parse_args()
+
+
+def percentile(samples: list[float], probability: float) -> float:
+    ordered = sorted(samples)
+    position = probability * (len(ordered) - 1)
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    weight = position - lower
+    return ordered[lower] * (1 - weight) + ordered[upper] * weight
+
+
+def measure_latency_us(operation: Callable[[], object], warmup: int, iterations: int) -> list[float]:
+    for _ in range(warmup):
+        operation()
+    torch.accelerator.synchronize()
+    starts = [torch.cuda.Event(enable_timing=True) for _ in range(iterations)]
+    ends = [torch.cuda.Event(enable_timing=True) for _ in range(iterations)]
+    for start, end in zip(starts, ends, strict=True):
+        start.record()
+        operation()
+        end.record()
+    torch.accelerator.synchronize()
+    return [start.elapsed_time(end) * 1000.0 for start, end in zip(starts, ends, strict=True)]
+
+
+def measure_extra_peak_mib(operation: Callable[[], object]) -> float:
+    torch.accelerator.synchronize()
+    torch.accelerator.reset_peak_memory_stats()
+    allocated = torch.accelerator.memory_allocated()
+    operation()
+    torch.accelerator.synchronize()
+    return (torch.accelerator.max_memory_allocated() - allocated) / MiB
+
+
+def print_header(args: argparse.Namespace) -> None:
+    print(f"device={torch.cuda.get_device_name()} torch={torch.__version__}")
+    print(
+        f"heads={args.heads} experts={args.experts} top_k={args.top_k} "
+        f"bias={not args.no_bias} route_norm={not args.no_route_norm} "
+        f"warmup={args.warmup} iterations={args.iterations} seed={args.seed}"
+    )
+    print(
+        "tokens   ref_topk  new_topk  ref_sort  new_sort   ref_tot   new_tot  speedup"
+        "  ref_MiB  new_MiB   ties  max_dprob"
+    )
+
+
+def benchmark_shape(tokens: int, args: argparse.Namespace) -> None:
+    device = torch.device("cuda")
+    heads, experts, top_k = args.heads, args.experts, args.top_k
+    logits = torch.randn(heads, tokens, experts, device=device, dtype=torch.float32)
+    bias = None if args.no_bias else torch.randn(heads, experts, device=device, dtype=torch.float32) * 0.01
+    route_norm = not args.no_route_norm
+
+    def reference_route() -> tuple[torch.Tensor, torch.Tensor]:
+        return _reference_topk_probs_and_indices(logits, top_k, expert_bias=bias, route_norm=route_norm)
+
+    def fused_route() -> tuple[torch.Tensor, torch.Tensor]:
+        return compute_topk_probs_and_indices(logits, top_k, expert_bias=bias, route_norm=route_norm)
+
+    reference_probs, reference_indices = reference_route()
+    fused_probs, fused_indices = fused_route()
+    # Rows whose biased selection scores tie are the only rows allowed to
+    # disagree: torch.topk does not define the order of an exact tie.
+    agreeing = (reference_indices == fused_indices).all(dim=-1)
+    tied_rows = int((~agreeing).sum().item())
+    max_dprob = (reference_probs - fused_probs)[agreeing].abs().max().item() if bool(agreeing.any()) else 0.0
+
+    reference_layout = _reference_global_sort_routes(fused_probs, fused_indices, experts)
+    fused_layout = global_sort_routes(fused_probs, fused_indices, experts)
+    for expected, actual, name in zip(reference_layout, fused_layout, ("gather_ids", "probs", "offsets"), strict=True):
+        if not torch.equal(expected, actual):
+            raise AssertionError(f"global_sort_routes diverged from the reference layout in {name}")
+
+    reference_peak = measure_extra_peak_mib(lambda: _reference_global_sort_routes(*reference_route(), experts))
+    fused_peak = measure_extra_peak_mib(lambda: global_sort_routes(*fused_route(), experts))
+
+    samples = {
+        "ref_topk": measure_latency_us(reference_route, args.warmup, args.iterations),
+        "new_topk": measure_latency_us(fused_route, args.warmup, args.iterations),
+        "ref_sort": measure_latency_us(
+            lambda: _reference_global_sort_routes(fused_probs, fused_indices, experts), args.warmup, args.iterations
+        ),
+        "new_sort": measure_latency_us(
+            lambda: global_sort_routes(fused_probs, fused_indices, experts), args.warmup, args.iterations
+        ),
+    }
+    median = {name: statistics.median(values) for name, values in samples.items()}
+    reference_total = median["ref_topk"] + median["ref_sort"]
+    fused_total = median["new_topk"] + median["new_sort"]
+    print(
+        f"{tokens:<7} {median['ref_topk']:>9.1f} {median['new_topk']:>9.1f} "
+        f"{median['ref_sort']:>9.1f} {median['new_sort']:>9.1f} "
+        f"{reference_total:>9.1f} {fused_total:>9.1f} {reference_total / fused_total:>7.2f}x "
+        f"{reference_peak:>8.1f} {fused_peak:>8.1f} {tied_rows:>6} {max_dprob:>10.2e}"
+    )
+    for name in ("ref_topk", "new_topk", "ref_sort", "new_sort"):
+        values = samples[name]
+        p10, p90 = percentile(values, 0.1), percentile(values, 0.9)
+        print(f"        {name}: p10={p10:.1f} p50={median[name]:.1f} p90={p90:.1f} us")
+
+    if args.with_experts:
+        benchmark_expert_share(tokens, args, logits, bias, fused_total, reference_total)
+
+
+def benchmark_expert_share(
+    tokens: int,
+    args: argparse.Namespace,
+    logits: torch.Tensor,
+    bias: torch.Tensor | None,
+    fused_total: float,
+    reference_total: float,
+) -> None:
+    device = torch.device("cuda")
+    heads, experts = args.heads, args.experts
+    flat_experts = heads * experts
+    hidden = torch.randn(tokens, heads, args.head_dim, device=device, dtype=torch.bfloat16)
+    w_gate = torch.randn(flat_experts, args.head_dim, args.expert_dim, device=device, dtype=torch.bfloat16) * 0.02
+    w_up = torch.randn(flat_experts, args.head_dim, args.expert_dim, device=device, dtype=torch.bfloat16) * 0.02
+    w_down = torch.randn(flat_experts, args.expert_dim, args.head_dim, device=device, dtype=torch.bfloat16) * 0.02
+    probs, indices = compute_topk_probs_and_indices(logits, args.top_k, expert_bias=bias)
+    gather_ids, sorted_probs, offsets = global_sort_routes(probs, indices, experts)
+
+    def run_experts() -> torch.Tensor:
+        return triton_mh_moe_forward(hidden, gather_ids, sorted_probs, offsets, w_gate, w_up, w_down)
+
+    try:
+        expert_us = statistics.median(measure_latency_us(run_experts, args.warmup, max(args.iterations // 5, 5)))
+    except triton.runtime.errors.OutOfResources as error:
+        # The expert kernel picks its tiling from the device capability; a tile
+        # that does not fit is a property of that kernel, not of route
+        # construction, so keep the routing numbers and report the shortfall.
+        print(f"        experts: skipped, {error.__class__.__name__}: {str(error).splitlines()[0]}")
+        torch.accelerator.empty_cache()
+        return
+    print(
+        f"        experts: {expert_us:.1f} us -> routing share "
+        f"{reference_total / (reference_total + expert_us) * 100:.1f}% (reference) "
+        f"-> {fused_total / (fused_total + expert_us) * 100:.1f}% (fused); "
+        f"MoE-layer speedup {(reference_total + expert_us) / (fused_total + expert_us):.2f}x"
+    )
+    torch.accelerator.empty_cache()
+
+
+def main() -> None:
+    args = parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("This benchmark requires a CUDA GPU")
+    if args.warmup < 0 or args.iterations <= 0:
+        raise ValueError("warmup must be non-negative and iterations must be positive")
+    torch.manual_seed(args.seed)
+    print_header(args)
+    with torch.inference_mode():
+        for value in args.tokens.split(","):
+            tokens = int(value)
+            if tokens <= 0:
+                raise ValueError(f"token count must be positive, got {tokens}")
+            benchmark_shape(tokens, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/diffusion/models/magi2/test_mh_moe_routing.py
+++ b/tests/diffusion/models/magi2/test_mh_moe_routing.py
@@ -1,0 +1,307 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""Parity tests for the fused MAGI-2 multi-head MoE route construction.
+
+The fused CUDA path must reproduce the unfused fallback: the same expert bank
+per head, a bias that steers selection only, the same route weights, and a
+bit-identical CSR layout.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tests.helpers.mark import hardware_test
+from vllm_omni.diffusion.models.magi2.mh_moe import (
+    _reference_global_sort_routes,
+    _reference_topk_probs_and_indices,
+    compute_topk_probs_and_indices,
+    global_sort_routes,
+    torch_mh_moe_forward,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion]
+
+# ``heads, tokens, experts, top_k``.  The released MAGI-2 Preview bank is
+# ``(12, S, 256, 6)``; the rest cover padding, non-power-of-two banks and the
+# degenerate top_k values.
+ROUTING_SHAPES = [
+    (12, 1024, 256, 6),
+    (12, 1, 256, 6),
+    (1, 37, 256, 6),
+    (4, 512, 8, 2),
+    (3, 100, 12, 5),
+    (2, 77, 64, 1),
+    (2, 64, 32, 32),
+    (5, 129, 1024, 8),
+]
+
+
+def _router_inputs(
+    heads: int,
+    tokens: int,
+    experts: int,
+    *,
+    device: str,
+    with_bias: bool = True,
+    seed: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    generator = torch.Generator(device=device).manual_seed(seed)
+    logits = torch.randn(heads, tokens, experts, device=device, generator=generator)
+    if not with_bias:
+        return logits, None
+    return logits, torch.randn(heads, experts, device=device, generator=generator) * 0.01
+
+
+# The fused kernel evaluates sigmoid with libdevice's exp, which sits within one
+# ULP of torch.sigmoid rather than on top of it, and folds the L1 normalization
+# into the same pass.  Both leave a few-ULP margin on the route weights.
+ROUTE_WEIGHT_RTOL = 1e-6
+ROUTE_WEIGHT_ATOL = 1e-6
+
+
+def _resolvable_rows(
+    logits: torch.Tensor,
+    expert_bias: torch.Tensor | None,
+    top_k: int,
+    *,
+    margin: float = 1e-5,
+) -> torch.Tensor:
+    """Mask of ``[head, token]`` rows whose top-k selection is unambiguous.
+
+    Only the ``top_k + 1`` largest selection scores decide which experts are
+    picked and in what order.  Rows where two of them are closer than the
+    combined sigmoid and reduction error cannot be compared index-for-index:
+    ``torch.topk`` does not define the order of an exact tie either.
+    """
+
+    selection_scores = torch.sigmoid(logits)
+    if expert_bias is not None:
+        selection_scores = selection_scores + expert_bias.view(logits.shape[0], 1, -1)
+    boundary = min(top_k + 1, selection_scores.shape[-1])
+    ordered = selection_scores.topk(boundary, dim=-1).values
+    if boundary == 1:
+        return torch.ones(ordered.shape[:-1], dtype=torch.bool, device=ordered.device)
+    return ((ordered[..., :-1] - ordered[..., 1:]).abs() > margin).all(dim=-1)
+
+
+@hardware_test(res={"cuda": ["B200", "H100", "L4"]}, num_cards=1)
+@pytest.mark.parametrize(("heads", "tokens", "experts", "top_k"), ROUTING_SHAPES)
+@pytest.mark.parametrize("route_norm", [True, False])
+def test_fused_routing_matches_reference(heads: int, tokens: int, experts: int, top_k: int, route_norm: bool) -> None:
+    logits, expert_bias = _router_inputs(heads, tokens, experts, device="cuda")
+    reference_probs, reference_indices = _reference_topk_probs_and_indices(
+        logits, top_k, expert_bias=expert_bias, route_norm=route_norm
+    )
+    fused_probs, fused_indices = compute_topk_probs_and_indices(
+        logits, top_k, expert_bias=expert_bias, route_norm=route_norm
+    )
+
+    assert fused_probs.shape == reference_probs.shape
+    assert fused_probs.dtype == reference_probs.dtype
+    assert fused_indices.dtype == reference_indices.dtype
+
+    resolvable = _resolvable_rows(logits, expert_bias, top_k)
+    # Guards against the comparison below going vacuous, nothing more.  The
+    # unresolvable fraction grows with the bank width -- the top few order
+    # statistics of 1024 samples sit closer together than those of 256 -- and
+    # CUDA's RNG does not produce identical draws across GPU architectures, so
+    # this floor is deliberately loose.
+    assert resolvable.float().mean() > 0.95, "random router rows are unexpectedly ambiguous; the check below is vacuous"
+    assert torch.equal(fused_indices[resolvable], reference_indices[resolvable])
+    torch.testing.assert_close(
+        fused_probs[resolvable], reference_probs[resolvable], rtol=ROUTE_WEIGHT_RTOL, atol=ROUTE_WEIGHT_ATOL
+    )
+
+
+@hardware_test(res={"cuda": ["B200", "H100", "L4"]}, num_cards=1)
+def test_fused_routing_without_bias_matches_reference() -> None:
+    logits, _ = _router_inputs(12, 512, 256, device="cuda", with_bias=False)
+    reference = _reference_topk_probs_and_indices(logits, 6)
+    fused = compute_topk_probs_and_indices(logits, 6)
+    resolvable = _resolvable_rows(logits, None, 6)
+    assert torch.equal(fused[1][resolvable], reference[1][resolvable])
+    torch.testing.assert_close(fused[0], reference[0], rtol=ROUTE_WEIGHT_RTOL, atol=ROUTE_WEIGHT_ATOL)
+
+
+@hardware_test(res={"cuda": ["B200", "H100", "L4"]}, num_cards=1)
+def test_selection_bias_does_not_reach_the_route_weight() -> None:
+    """A bias large enough to reorder selection must not change the weights."""
+
+    logits, _ = _router_inputs(4, 256, 64, device="cuda", with_bias=False)
+    expert_bias = torch.zeros(4, 64, device="cuda")
+    expert_bias[:, ::2] = 5.0
+    probs, indices = compute_topk_probs_and_indices(logits, 4, expert_bias=expert_bias, route_norm=False)
+
+    # Every selected expert comes from the boosted half, and the returned weight
+    # is the unbiased sigmoid score.
+    assert (indices % 2 == 0).all()
+    expected = torch.sigmoid(logits).gather(-1, indices)
+    torch.testing.assert_close(probs, expected, rtol=ROUTE_WEIGHT_RTOL, atol=ROUTE_WEIGHT_ATOL)
+
+
+@hardware_test(res={"cuda": ["B200", "H100", "L4"]}, num_cards=1)
+def test_fused_routing_ties_break_towards_the_lowest_expert() -> None:
+    """Exact ties are undefined for torch.topk; the fused kernel is explicit."""
+
+    logits = torch.full((1, 1, 8), -10.0, device="cuda")
+    logits[0, 0, [1, 3, 5]] = 2.0
+    probs, indices = compute_topk_probs_and_indices(logits, 3, route_norm=False)
+    assert indices[0, 0].tolist() == [1, 3, 5]
+
+    logits[0, 0, 6] = 2.0
+    probs, indices = compute_topk_probs_and_indices(logits, 2, route_norm=False)
+    assert indices[0, 0].tolist() == [1, 3]
+    torch.testing.assert_close(
+        probs[0, 0], torch.sigmoid(logits[0, 0, [1, 3]]), rtol=ROUTE_WEIGHT_RTOL, atol=ROUTE_WEIGHT_ATOL
+    )
+
+
+@hardware_test(res={"cuda": ["B200", "H100", "L4"]}, num_cards=1)
+@pytest.mark.parametrize(("heads", "tokens", "experts", "top_k"), ROUTING_SHAPES)
+def test_global_sort_routes_is_bit_identical_to_reference(heads: int, tokens: int, experts: int, top_k: int) -> None:
+    logits, expert_bias = _router_inputs(heads, tokens, experts, device="cuda")
+    probs, indices = compute_topk_probs_and_indices(logits, top_k, expert_bias=expert_bias)
+    expected = _reference_global_sort_routes(probs, indices, experts)
+    actual = global_sort_routes(probs, indices, experts)
+    for reference_tensor, candidate, name in zip(expected, actual, ("gather_ids", "probs", "offsets"), strict=True):
+        assert candidate.dtype == reference_tensor.dtype, name
+        assert torch.equal(candidate, reference_tensor), name
+
+
+@hardware_test(res={"cuda": ["B200", "H100", "L4"]}, num_cards=1)
+def test_global_sort_routes_layout_invariants() -> None:
+    heads, tokens, experts, top_k = 6, 333, 64, 3
+    logits, expert_bias = _router_inputs(heads, tokens, experts, device="cuda")
+    probs, indices = compute_topk_probs_and_indices(logits, top_k, expert_bias=expert_bias)
+    gather_ids, sorted_probs, offsets = global_sort_routes(probs, indices, experts)
+
+    assert offsets.numel() == heads * experts + 1
+    assert int(offsets[0]) == 0
+    assert int(offsets[-1]) == heads * tokens * top_k
+    assert (offsets.diff() >= 0).all()
+    assert gather_ids.numel() == sorted_probs.numel() == heads * tokens * top_k
+    assert int(gather_ids.min()) >= 0 and int(gather_ids.max()) < tokens
+
+    # Each flat expert bucket holds exactly the tokens that routed to it, in
+    # ascending token order -- the stability the expert kernel's tiling relies on.
+    for flat_expert in range(0, heads * experts, 17):
+        head, expert = divmod(flat_expert, experts)
+        begin, end = int(offsets[flat_expert]), int(offsets[flat_expert + 1])
+        bucket = gather_ids[begin:end].long()
+        assert torch.equal(bucket, bucket.sort().values)
+        expected_tokens = (indices[head] == expert).any(dim=-1).nonzero().flatten()
+        assert torch.equal(bucket, expected_tokens.to(bucket.dtype))
+
+
+@hardware_test(res={"cuda": ["B200", "H100", "L4"]}, num_cards=1)
+def test_routes_drive_the_expert_kernel_identically() -> None:
+    """The two route builders must produce interchangeable expert inputs."""
+
+    heads, tokens, experts, top_k, head_dim, expert_dim = 3, 64, 16, 4, 32, 48
+    device = "cuda"
+    generator = torch.Generator(device=device).manual_seed(7)
+    logits, expert_bias = _router_inputs(heads, tokens, experts, device=device, seed=7)
+    hidden = torch.randn(tokens, heads, head_dim, device=device, generator=generator)
+    flat_experts = heads * experts
+    w_gate = torch.randn(flat_experts, head_dim, expert_dim, device=device, generator=generator) * 0.05
+    w_up = torch.randn(flat_experts, head_dim, expert_dim, device=device, generator=generator) * 0.05
+    w_down = torch.randn(flat_experts, expert_dim, head_dim, device=device, generator=generator) * 0.05
+
+    outputs = []
+    for builder, layout in (
+        (_reference_topk_probs_and_indices, _reference_global_sort_routes),
+        (compute_topk_probs_and_indices, global_sort_routes),
+    ):
+        probs, indices = builder(logits, top_k, expert_bias=expert_bias)
+        gather_ids, sorted_probs, offsets = layout(probs, indices, experts)
+        outputs.append(torch_mh_moe_forward(hidden, gather_ids, sorted_probs, offsets, w_gate, w_up, w_down))
+    torch.testing.assert_close(outputs[1], outputs[0], rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize(("heads", "tokens", "experts", "top_k"), [(3, 40, 32, 4), (2, 16, 12, 3)])
+def test_cpu_routing_falls_back_to_the_reference(heads: int, tokens: int, experts: int, top_k: int) -> None:
+    logits, expert_bias = _router_inputs(heads, tokens, experts, device="cpu")
+    reference = _reference_topk_probs_and_indices(logits, top_k, expert_bias=expert_bias)
+    fallback = compute_topk_probs_and_indices(logits, top_k, expert_bias=expert_bias)
+    assert torch.equal(fallback[0], reference[0])
+    assert torch.equal(fallback[1], reference[1])
+
+    expected = _reference_global_sort_routes(*reference, experts)
+    actual = global_sort_routes(*reference, experts)
+    for reference_tensor, candidate in zip(expected, actual, strict=True):
+        assert torch.equal(candidate, reference_tensor)
+
+
+@pytest.mark.cpu
+def test_routing_rejects_malformed_inputs() -> None:
+    logits = torch.randn(2, 8, 16)
+    with pytest.raises(ValueError, match="heads,tokens,experts"):
+        compute_topk_probs_and_indices(logits[0], 4)
+    with pytest.raises(ValueError, match="top_k"):
+        compute_topk_probs_and_indices(logits, 17)
+    with pytest.raises(ValueError, match="top_k"):
+        compute_topk_probs_and_indices(logits, 0)
+    with pytest.raises(ValueError, match="unsupported routing score function"):
+        compute_topk_probs_and_indices(logits, 4, score_func="argmax")  # type: ignore[arg-type]
+    probs, indices = compute_topk_probs_and_indices(logits, 4)
+    with pytest.raises(ValueError, match=r"\[H,S,K\] shape"):
+        global_sort_routes(probs, indices[..., :2], 16)
+
+
+# Route construction is deterministic in its output but not in its latency, and
+# CI spans L4, H100 and B200, so an absolute microsecond baseline would be
+# either meaningless or flaky.  Gate on the speedup over the reference measured
+# in the same process on the same device instead: that cancels the hardware
+# difference.  Observed on a B200 (torch 2.13, Triton 3.7.1): 6.1x at 4096
+# tokens and 11.1x at 29184.  The floor below leaves roughly half of that as
+# headroom, so it catches a real regression -- or the fused path silently
+# falling back -- without tracking normal run-to-run spread.
+ROUTING_SPEEDUP_FLOOR = 3.0
+
+
+def _median_microseconds(operation, *, warmup: int = 10, iterations: int = 30) -> float:
+    import statistics
+
+    for _ in range(warmup):
+        operation()
+    torch.accelerator.synchronize()
+    samples = []
+    for _ in range(iterations):
+        start, end = torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)
+        start.record()
+        operation()
+        end.record()
+        torch.accelerator.synchronize()
+        samples.append(start.elapsed_time(end) * 1000.0)
+    return statistics.median(samples)
+
+
+@pytest.mark.benchmark
+@hardware_test(res={"cuda": ["B200", "H100", "L4"]}, num_cards=1)
+def test_fused_routing_stays_faster_than_the_reference() -> None:
+    """Regression gate on the M1 route-construction speedup."""
+
+    heads, tokens, experts, top_k = 12, 4096, 256, 6
+    logits, expert_bias = _router_inputs(heads, tokens, experts, device="cuda")
+
+    reference_us = _median_microseconds(
+        lambda: _reference_topk_probs_and_indices(logits, top_k, expert_bias=expert_bias)
+    )
+    fused_us = _median_microseconds(lambda: compute_topk_probs_and_indices(logits, top_k, expert_bias=expert_bias))
+    topk_speedup = reference_us / fused_us
+
+    probs, indices = compute_topk_probs_and_indices(logits, top_k, expert_bias=expert_bias)
+    reference_layout_us = _median_microseconds(lambda: _reference_global_sort_routes(probs, indices, experts))
+    fused_layout_us = _median_microseconds(lambda: global_sort_routes(probs, indices, experts))
+    layout_speedup = reference_layout_us / fused_layout_us
+
+    total_speedup = (reference_us + reference_layout_us) / (fused_us + fused_layout_us)
+    assert total_speedup >= ROUTING_SPEEDUP_FLOOR, (
+        f"route construction speedup {total_speedup:.2f}x fell below {ROUTING_SPEEDUP_FLOOR}x "
+        f"(top-k {topk_speedup:.2f}x at {reference_us:.0f}->{fused_us:.0f} us, "
+        f"layout {layout_speedup:.2f}x at {reference_layout_us:.0f}->{fused_layout_us:.0f} us)"
+    )

--- a/tests/diffusion/models/magi2/test_mh_moe_routing.py
+++ b/tests/diffusion/models/magi2/test_mh_moe_routing.py
@@ -160,6 +160,67 @@ def test_fused_routing_ties_break_towards_the_lowest_expert() -> None:
 
 
 @hardware_test(res={"cuda": ["B200", "H100", "L4"]}, num_cards=1)
+@pytest.mark.parametrize("bias_shape", [(4, 1), (4,), (4, 1, 1)])
+def test_broadcast_expert_bias_matches_reference(bias_shape: tuple[int, ...]) -> None:
+    """A per-head scalar bias broadcasts in the reference and must in the kernel.
+
+    The kernel indexes a dense ``[heads, num_experts]`` bank, so a bias holding
+    one element per head is expanded before launch instead of being read past
+    the end of its own storage.
+    """
+
+    logits, _ = _router_inputs(4, 128, 64, device="cuda", with_bias=False)
+    generator = torch.Generator(device="cuda").manual_seed(7)
+    expert_bias = torch.randn(4, device="cuda", generator=generator).reshape(bias_shape)
+    reference = _reference_topk_probs_and_indices(logits, 5, expert_bias=expert_bias)
+    fused = compute_topk_probs_and_indices(logits, 5, expert_bias=expert_bias)
+    resolvable = _resolvable_rows(logits, expert_bias, 5)
+    assert torch.equal(fused[1][resolvable], reference[1][resolvable])
+    # A bias decouples the selection score from the route weight, so an
+    # unresolvable row disagrees on the weight too; mask both.
+    torch.testing.assert_close(
+        fused[0][resolvable], reference[0][resolvable], rtol=ROUTE_WEIGHT_RTOL, atol=ROUTE_WEIGHT_ATOL
+    )
+
+
+@hardware_test(res={"cuda": ["B200", "H100", "L4"]}, num_cards=1)
+@pytest.mark.parametrize("bias_dtype", [torch.bfloat16, torch.float16])
+def test_narrow_dtype_expert_bias_matches_reference(bias_dtype: torch.dtype) -> None:
+    """Upcasting a narrow bias is exactly the promotion the reference performs."""
+
+    logits, expert_bias = _router_inputs(4, 128, 64, device="cuda")
+    expert_bias = expert_bias.to(bias_dtype)
+    reference = _reference_topk_probs_and_indices(logits, 5, expert_bias=expert_bias)
+    fused = compute_topk_probs_and_indices(logits, 5, expert_bias=expert_bias)
+    resolvable = _resolvable_rows(logits, expert_bias, 5)
+    assert torch.equal(fused[1][resolvable], reference[1][resolvable])
+    # A bias decouples the selection score from the route weight, so an
+    # unresolvable row disagrees on the weight too; mask both.
+    torch.testing.assert_close(
+        fused[0][resolvable], reference[0][resolvable], rtol=ROUTE_WEIGHT_RTOL, atol=ROUTE_WEIGHT_ATOL
+    )
+
+
+@hardware_test(res={"cuda": ["B200", "H100", "L4"]}, num_cards=1)
+def test_exhausted_selection_scores_still_pick_distinct_experts() -> None:
+    """Selecting an expert must retire it even when every candidate left is -inf.
+
+    A bias that masks the bank down to fewer than ``top_k`` finite scores lets a
+    retired winner tie the running maximum, so a kernel that excludes by score
+    alone routes the same expert twice.
+    """
+
+    logits = torch.zeros(1, 4, 8, device="cuda")
+    expert_bias = torch.full((1, 8), float("-inf"), device="cuda")
+    expert_bias[0, 2] = 0.0
+    _, indices = compute_topk_probs_and_indices(logits, 3, expert_bias=expert_bias, route_norm=False)
+    for row in indices[0]:
+        assert row.unique().numel() == 3, f"duplicate route in {row.tolist()}"
+    # Expert 2 holds the only finite score; the -inf remainder resolves by id.
+    assert indices[0, 0].tolist() == [2, 0, 1]
+
+
+@hardware_test(res={"cuda": ["B200", "H100", "L4"]}, num_cards=1)
 @pytest.mark.parametrize(("heads", "tokens", "experts", "top_k"), ROUTING_SHAPES)
 def test_global_sort_routes_is_bit_identical_to_reference(heads: int, tokens: int, experts: int, top_k: int) -> None:
     logits, expert_bias = _router_inputs(heads, tokens, experts, device="cuda")

--- a/vllm_omni/diffusion/models/magi2/mh_moe.py
+++ b/vllm_omni/diffusion/models/magi2/mh_moe.py
@@ -27,6 +27,13 @@ from vllm_omni.platforms import current_omni_platform
 
 from .parallel import Magi2ParallelGroup, ep_dispatch, ep_undispatch, get_magi2_ep_group
 
+try:  # Triton's precise exp; ``tl.exp`` lowers to the 29-ULP ex2 approximation.
+    from triton.language.extra import libdevice as _tl_libdevice
+except ImportError:  # pragma: no cover - non-CUDA Triton builds
+    _tl_libdevice = None
+
+_HAS_PRECISE_EXP = _tl_libdevice is not None and hasattr(_tl_libdevice, "exp")
+
 RoutingScore = Literal["softmax", "sigmoid"]
 
 
@@ -39,7 +46,7 @@ def swiglu7_pair(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
     return (gate * torch.sigmoid(1.702 * gate) * (up + 1.0)).to(dtype)
 
 
-def compute_topk_probs_and_indices(
+def _reference_topk_probs_and_indices(
     router_logits: torch.Tensor,
     top_k: int,
     *,
@@ -48,16 +55,8 @@ def compute_topk_probs_and_indices(
     route_norm: bool = True,
     norm_eps: float = 1e-12,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Route independently for every ``[head, token]`` pair.
+    """Unfused reference routing.  Also the oracle the fused path is tested against."""
 
-    The auxiliary-free bias affects expert selection but deliberately does not
-    affect the returned routing probability, matching the training recipe.
-    """
-
-    if router_logits.ndim != 3:
-        raise ValueError("router_logits must be [heads,tokens,experts]")
-    if not 0 < top_k <= router_logits.shape[-1]:
-        raise ValueError("top_k must be in [1, num_experts]")
     if score_func == "sigmoid":
         router_scores = torch.sigmoid(router_logits)
     elif score_func == "softmax":
@@ -77,15 +76,226 @@ def compute_topk_probs_and_indices(
     return topk_probs, topk_indices
 
 
-def global_sort_routes(
+@triton.jit
+def _routing_topk_kernel(
+    logits_ptr,
+    bias_ptr,
+    probs_ptr,
+    indices_ptr,
+    num_tokens,
+    stride_logits_h,
+    stride_logits_s,
+    tiles_per_head,
+    top_k: tl.constexpr,
+    top_k_pad: tl.constexpr,
+    num_experts: tl.constexpr,
+    experts_pad: tl.constexpr,
+    block_t: tl.constexpr,
+    has_bias: tl.constexpr,
+    route_norm: tl.constexpr,
+    norm_eps: tl.constexpr,
+    precise_exp: tl.constexpr,
+):
+    """Sigmoid, selection bias, top-k, probability gather and L1 norm in one pass.
+
+    One program owns ``block_t`` ``[head, token]`` rows and keeps the whole
+    expert bank in registers, so the ``[heads,tokens,experts]`` logits are read
+    exactly once instead of once per routing stage.
+    """
+
+    tile = tl.program_id(0)
+    head = tile // tiles_per_head
+    token_tile = tile % tiles_per_head
+    token_offsets = token_tile * block_t + tl.arange(0, block_t)
+    expert_offsets = tl.arange(0, experts_pad)
+    token_mask = token_offsets < num_tokens
+    expert_mask = expert_offsets < num_experts
+    live = token_mask[:, None] & expert_mask[None, :]
+
+    # Head and token indices fit in int32, but scaling them by the per-head
+    # logit stride does not once the packed sequence gets long.  Promote before
+    # computing element offsets, as the expert kernel does.
+    logits_base = head.to(tl.int64) * stride_logits_h + token_offsets.to(tl.int64) * stride_logits_s
+    logits = tl.load(
+        logits_ptr + logits_base[:, None] + expert_offsets[None, :],
+        mask=live,
+        other=0.0,
+    )
+    # tl.sigmoid and tl.exp lower to the ex2 approximation, which drifts up to
+    # 29 ULP from torch.sigmoid and can reorder near-equal selection scores.
+    # libdevice's exp keeps the fused route within one ULP of the reference.
+    if precise_exp:
+        router_scores = 1.0 / (1.0 + _tl_libdevice.exp(-logits))
+    else:
+        router_scores = 1.0 / (1.0 + tl.exp(-logits))
+    if has_bias:
+        bias = tl.load(bias_ptr + head * num_experts + expert_offsets, mask=expert_mask, other=0.0)
+        selection_scores = router_scores + bias[None, :]
+    else:
+        selection_scores = router_scores
+    selection_scores = tl.where(live, selection_scores, float("-inf"))
+
+    route_offsets = tl.arange(0, top_k_pad)
+    topk_probs = tl.zeros([block_t, top_k_pad], dtype=tl.float32)
+    topk_indices = tl.zeros([block_t, top_k_pad], dtype=tl.int32)
+    l1_norm = tl.zeros([block_t], dtype=tl.float32)
+    for route in tl.static_range(top_k):
+        best_score = tl.max(selection_scores, axis=1)
+        # tl.argmax is several times more expensive than a plain max on this
+        # shape, so recover the winner with a second reduction.  Ties resolve to
+        # the lowest expert id, which torch.topk leaves unspecified.
+        best_expert = tl.min(tl.where(selection_scores == best_score[:, None], expert_offsets, experts_pad), axis=1)
+        selected = expert_offsets[None, :] == best_expert[:, None]
+        # The bias steers selection only; the route weight is the unbiased score.
+        probability = tl.sum(tl.where(selected, router_scores, 0.0), axis=1)
+        is_route = route_offsets == route
+        topk_probs += tl.where(is_route[None, :], probability[:, None], 0.0)
+        topk_indices += tl.where(is_route[None, :], best_expert[:, None].to(tl.int32), 0)
+        selection_scores = tl.where(selected, float("-inf"), selection_scores)
+        l1_norm += tl.abs(probability)
+    if route_norm:
+        topk_probs = topk_probs / tl.maximum(l1_norm, norm_eps)[:, None]
+
+    store_mask = token_mask[:, None] & (route_offsets[None, :] < top_k)
+    store_base = (head.to(tl.int64) * num_tokens + token_offsets.to(tl.int64)) * top_k
+    store_offsets = store_base[:, None] + route_offsets[None, :]
+    tl.store(probs_ptr + store_offsets, topk_probs, mask=store_mask)
+    tl.store(indices_ptr + store_offsets, topk_indices.to(tl.int64), mask=store_mask)
+
+
+# Above this the [block_t, experts_pad] score tiles no longer fit in registers
+# and the fused kernel loses to the unfused reference.
+_MAX_FUSED_EXPERTS_PAD = 1024
+
+
+def _fused_routing_config(experts_pad: int) -> tuple[int, int]:
+    """Return ``(block_t, num_warps)`` for a padded expert-bank width."""
+
+    # Two fp32 [block_t, experts_pad] tiles per program; one warp per 256-wide
+    # slice keeps the six top-k reductions inside warp shuffles.
+    num_warps = max(1, min(8, experts_pad // 256))
+    block_t = max(1, 256 // experts_pad)
+    return block_t, num_warps
+
+
+def _fused_routing_supported(
+    router_logits: torch.Tensor,
+    score_func: RoutingScore,
+    expert_bias: torch.Tensor | None,
+) -> bool:
+    if not router_logits.is_cuda or score_func != "sigmoid":
+        return False
+    # fp32 only: the reference evaluates sigmoid and the L1 norm in the logit
+    # dtype, and reproducing narrow-dtype rounding is not worth a second kernel.
+    if router_logits.dtype != torch.float32:
+        return False
+    if router_logits.stride(-1) != 1 or router_logits.shape[1] == 0:
+        return False
+    if triton.next_power_of_2(router_logits.shape[-1]) > _MAX_FUSED_EXPERTS_PAD:
+        return False
+    if expert_bias is not None and (expert_bias.dtype != torch.float32 or not expert_bias.is_contiguous()):
+        return False
+    return True
+
+
+def compute_topk_probs_and_indices(
+    router_logits: torch.Tensor,
+    top_k: int,
+    *,
+    score_func: RoutingScore = "sigmoid",
+    expert_bias: torch.Tensor | None = None,
+    route_norm: bool = True,
+    norm_eps: float = 1e-12,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Route independently for every ``[head, token]`` pair.
+
+    The auxiliary-free bias affects expert selection but deliberately does not
+    affect the returned routing probability, matching the training recipe.
+
+    Supported CUDA inputs run as a single fused kernel; other devices, dtypes,
+    score functions and shapes fall back to
+    :func:`_reference_topk_probs_and_indices`.  The two pick the same experts in
+    the same order whenever the top ``top_k + 1`` selection scores of a row are
+    separated by more than a few ULP, and the returned weights then agree to
+    about 1e-6 relative: the fused sigmoid is within one ULP of
+    ``torch.sigmoid`` and the folded L1 normalization sums in a different order.
+    Under an exact tie the fused kernel selects the lowest expert id, an order
+    ``torch.topk`` leaves unspecified.
+    """
+
+    if router_logits.ndim != 3:
+        raise ValueError("router_logits must be [heads,tokens,experts]")
+    if not 0 < top_k <= router_logits.shape[-1]:
+        raise ValueError("top_k must be in [1, num_experts]")
+    if not _fused_routing_supported(router_logits, score_func, expert_bias):
+        return _reference_topk_probs_and_indices(
+            router_logits,
+            top_k,
+            score_func=score_func,
+            expert_bias=expert_bias,
+            route_norm=route_norm,
+            norm_eps=norm_eps,
+        )
+
+    heads, num_tokens, num_experts = router_logits.shape
+    experts_pad = triton.next_power_of_2(num_experts)
+    block_t, num_warps = _fused_routing_config(experts_pad)
+    tiles_per_head = triton.cdiv(num_tokens, block_t)
+    topk_probs = torch.empty((heads, num_tokens, top_k), device=router_logits.device, dtype=torch.float32)
+    topk_indices = torch.empty((heads, num_tokens, top_k), device=router_logits.device, dtype=torch.int64)
+    _routing_topk_kernel[(heads * tiles_per_head,)](
+        router_logits,
+        expert_bias,
+        topk_probs,
+        topk_indices,
+        num_tokens,
+        router_logits.stride(0),
+        router_logits.stride(1),
+        tiles_per_head,
+        top_k,
+        triton.next_power_of_2(top_k),
+        num_experts,
+        experts_pad,
+        block_t,
+        expert_bias is not None,
+        route_norm,
+        norm_eps,
+        _HAS_PRECISE_EXP,
+        num_warps=num_warps,
+        num_stages=1,
+    )
+    return topk_probs, topk_indices
+
+
+@triton.jit
+def _route_gather_kernel(
+    order_ptr,
+    probs_ptr,
+    gather_ids_ptr,
+    sorted_probs_ptr,
+    num_routes,
+    routes_per_head,
+    top_k,
+    block: tl.constexpr,
+):
+    """Materialize the CSR payload from a permutation without a token index buffer."""
+
+    offsets = tl.program_id(0) * block + tl.arange(0, block)
+    mask = offsets < num_routes
+    source = tl.load(order_ptr + offsets, mask=mask, other=0)
+    # The pre-sort layout is [head, token, route], so the token id of a flat
+    # position is implied by the position itself.
+    tl.store(gather_ids_ptr + offsets, ((source % routes_per_head) // top_k).to(tl.int32), mask=mask)
+    tl.store(sorted_probs_ptr + offsets, tl.load(probs_ptr + source, mask=mask, other=0.0), mask=mask)
+
+
+def _reference_global_sort_routes(
     topk_probs: torch.Tensor,
     topk_indices: torch.Tensor,
     num_experts: int,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Convert per-head routes into a stable flattened-expert CSR layout."""
+    """Unfused reference layout builder.  Kept as the oracle for the fast path."""
 
-    if topk_probs.shape != topk_indices.shape or topk_indices.ndim != 3:
-        raise ValueError("top-k probabilities and indices must have the same [H,S,K] shape")
     heads, sequence, top_k = topk_indices.shape
     device = topk_indices.device
     head_offset = torch.arange(heads, device=device).view(heads, 1, 1) * num_experts
@@ -98,6 +308,54 @@ def global_sort_routes(
     counts = torch.bincount(flattened_experts, minlength=heads * num_experts)
     offsets = torch.zeros(heads * num_experts + 1, device=device, dtype=torch.long)
     offsets[1:] = counts.cumsum(0)
+    return gather_ids, sorted_probs, offsets
+
+
+def global_sort_routes(
+    topk_probs: torch.Tensor,
+    topk_indices: torch.Tensor,
+    num_experts: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Convert per-head routes into a stable flattened-expert CSR layout.
+
+    Bit-identical to :func:`_reference_global_sort_routes`, but the flattened
+    expert keys are sorted in the narrowest integer type that holds them, the
+    token ids are derived from the permutation instead of being gathered from a
+    materialized index tensor, and the CSR offsets come from a binary search
+    over the sorted keys rather than from ``torch.bincount``, which synchronizes.
+    """
+
+    if topk_probs.shape != topk_indices.shape or topk_indices.ndim != 3:
+        raise ValueError("top-k probabilities and indices must have the same [H,S,K] shape")
+    heads, sequence, top_k = topk_indices.shape
+    device = topk_indices.device
+    flat_experts = heads * num_experts
+    if not topk_indices.is_cuda or sequence == 0:
+        return _reference_global_sort_routes(topk_probs, topk_indices, num_experts)
+
+    # int16 halves the radix-sort key traffic and is exact while the largest
+    # flattened expert id stays inside a signed 16-bit value.
+    key_dtype = torch.int16 if flat_experts <= torch.iinfo(torch.int16).max else torch.int32
+    head_offset = torch.arange(heads, device=device, dtype=key_dtype).view(heads, 1, 1) * num_experts
+    keys = (topk_indices.to(key_dtype) + head_offset).reshape(-1)
+    sorted_keys, order = torch.sort(keys, stable=True)
+
+    num_routes = order.numel()
+    gather_ids = torch.empty(num_routes, device=device, dtype=torch.int32)
+    sorted_probs = torch.empty(num_routes, device=device, dtype=torch.float32)
+    block = 1024
+    _route_gather_kernel[(triton.cdiv(num_routes, block),)](
+        order,
+        topk_probs.reshape(-1).contiguous(),
+        gather_ids,
+        sorted_probs,
+        num_routes,
+        sequence * top_k,
+        top_k,
+        block,
+    )
+    bounds = torch.arange(flat_experts + 1, device=device, dtype=key_dtype)
+    offsets = torch.searchsorted(sorted_keys, bounds)
     return gather_ids, sorted_probs, offsets
 
 

--- a/vllm_omni/diffusion/models/magi2/mh_moe.py
+++ b/vllm_omni/diffusion/models/magi2/mh_moe.py
@@ -76,6 +76,11 @@ def _reference_topk_probs_and_indices(
     return topk_probs, topk_indices
 
 
+# Retirement sentinel floor: the largest finite negative fp32, so that -inf is
+# reserved for lanes the top-k loop has already consumed.
+_MIN_FINITE_FP32 = tl.constexpr(-3.4028234663852886e38)
+
+
 @triton.jit
 def _routing_topk_kernel(
     logits_ptr,
@@ -130,9 +135,17 @@ def _routing_topk_kernel(
         router_scores = 1.0 / (1.0 + tl.exp(-logits))
     if has_bias:
         bias = tl.load(bias_ptr + head * num_experts + expert_offsets, mask=expert_mask, other=0.0)
-        selection_scores = router_scores + bias[None, :]
+        # The loop below retires a winner by marking it -inf, so -inf must stay
+        # out of reach for anything still selectable.  An unbiased sigmoid is
+        # inside (0, 1), so the bias is the only way in: clamp it to the largest
+        # finite negative float, over the [experts] bank rather than the whole
+        # score tile.
+        selection_scores = router_scores + tl.maximum(bias, _MIN_FINITE_FP32)[None, :]
     else:
         selection_scores = router_scores
+    # Dead and padded lanes keep -inf and stay unreachable for good, which is
+    # sound because ``top_k <= num_experts`` leaves an unretired live lane in
+    # every round.
     selection_scores = tl.where(live, selection_scores, float("-inf"))
 
     route_offsets = tl.arange(0, top_k_pad)
@@ -143,7 +156,9 @@ def _routing_topk_kernel(
         best_score = tl.max(selection_scores, axis=1)
         # tl.argmax is several times more expensive than a plain max on this
         # shape, so recover the winner with a second reduction.  Ties resolve to
-        # the lowest expert id, which torch.topk leaves unspecified.
+        # the lowest expert id, which torch.topk leaves unspecified.  A retired
+        # expert sits at -inf, strictly below the clamp above, so it can never
+        # match ``best_score`` and be routed to twice.
         best_expert = tl.min(tl.where(selection_scores == best_score[:, None], expert_offsets, experts_pad), axis=1)
         selected = expert_offsets[None, :] == best_expert[:, None]
         # The bias steers selection only; the route weight is the unbiased score.
@@ -193,9 +208,31 @@ def _fused_routing_supported(
         return False
     if triton.next_power_of_2(router_logits.shape[-1]) > _MAX_FUSED_EXPERTS_PAD:
         return False
-    if expert_bias is not None and (expert_bias.dtype != torch.float32 or not expert_bias.is_contiguous()):
+    # Only contiguity is load bearing: the reference reshapes the bias with
+    # ``view``, and so does :func:`_dense_expert_bias`.  Narrow dtypes and the
+    # broadcast shapes the reference accepts are normalized there instead of
+    # costing the whole fused path.
+    if expert_bias is not None and not expert_bias.is_contiguous():
         return False
     return True
+
+
+def _dense_expert_bias(expert_bias: torch.Tensor, heads: int, num_experts: int) -> torch.Tensor:
+    """Return the dense fp32 ``[heads, num_experts]`` bank the kernel indexes.
+
+    The reference broadcasts the bias with ``expert_bias.view(heads, 1, -1)``, so
+    a per-head scalar is legal input, while the kernel reads ``heads *
+    num_experts`` elements.  Materialize that broadcast rather than drop to the
+    reference for a bank this small, and upcast narrow dtypes, which is exactly
+    the promotion the reference gets from adding the bias to fp32 scores.
+
+    ``view`` and ``expand`` reject the shapes the reference's own broadcast
+    rejects, ``contiguous`` is what actually retires the zero stride ``expand``
+    leaves behind, and every step is a no-op for a dense fp32 bias.
+    """
+
+    dense = expert_bias.view(heads, -1).expand(heads, num_experts)
+    return dense.to(torch.float32).contiguous()
 
 
 def compute_topk_probs_and_indices(
@@ -212,8 +249,8 @@ def compute_topk_probs_and_indices(
     The auxiliary-free bias affects expert selection but deliberately does not
     affect the returned routing probability, matching the training recipe.
 
-    Supported CUDA inputs run as a single fused kernel; other devices, dtypes,
-    score functions and shapes fall back to
+    Supported CUDA inputs run as a single fused kernel; other devices, logit
+    dtypes, score functions and shapes fall back to
     :func:`_reference_topk_probs_and_indices`.  The two pick the same experts in
     the same order whenever the top ``top_k + 1`` selection scores of a row are
     separated by more than a few ULP, and the returned weights then agree to
@@ -238,6 +275,8 @@ def compute_topk_probs_and_indices(
         )
 
     heads, num_tokens, num_experts = router_logits.shape
+    if expert_bias is not None:
+        expert_bias = _dense_expert_bias(expert_bias, heads, num_experts)
     experts_pad = triton.next_power_of_2(num_experts)
     block_t, num_warps = _fused_routing_config(experts_pad)
     tiles_per_head = triton.cdiv(num_tokens, block_t)


### PR DESCRIPTION
## Purpose
 #7085 M1

## Summary
MAGI-2 routes every one of twelve 256-wide hidden-state heads into its own 256-expert bank, so route construction runs on a [12, tokens, 256] fp32 score tensor 36 times per denoise step.  The unfused path walked that tensor once per routing stage and spent most of its time in torch.topk, which is heavily over-provisioned for selecting 6 of 256: on a B200 at 540p shapes (29184 tokens) topk alone cost 4.62 ms against a 0.07 ms read of the same logits.

Fuse sigmoid, the selection bias, top-k, the probability gather and the L1 normalization into one Triton kernel that keeps a whole expert bank in registers and reads the logits exactly once.  The winner of each of the six top-k rounds is recovered with a max plus a min-index reduction rather than tl.argmax, which is several times more expensive at this shape, and the score is evaluated with libdevice's exp so the fused sigmoid stays within one ULP of torch.sigmoid instead of the 29 ULP that tl.exp's ex2 approximation gives.

Rebuild the CSR layout the same way it was, only cheaper: sort the flattened expert keys as int16 while they fit, derive token ids from the permutation instead of gathering them out of a materialized index tensor, and take the offsets from a binary search over the sorted keys rather than torch.bincount, which synchronizes.  The layout is bit-identical to the reference.

## Performance

Measured on one NVIDIA B200 with 12 heads, 256 experts per head, and top-6 routing:

| Tokens | Reference | Fused | Speedup | Workspace |
|---:|---:|---:|---:|---:|
| 1,024 | 416.8 µs | 143.5 µs | 2.90× | 25.2 → 3.0 MiB |
| 7,674 | 1,502.3 µs | 191.4 µs | 7.85× | 188.8 → 23.0 MiB |
| 29,184 | 5,020.4 µs | 451.7 µs | 11.11× | 717.4 → 84.5 MiB |
| 58,368 | 9,817.7 µs | 840.4 µs | 11.68× | 1,434.8 → 169.1 MiB |

  ## Test Plan

  vLLM Version: 0.28.0

  Tested on one NVIDIA B200 using Python 3.11 and PyTorch 2.13.0+cu130.

  python -m pytest tests/config/test_environment_variables.py -q
  python -m pytest tests/diffusion/models/magi2/test_mh_moe_routing.py -q

  ## Test Result

  ```text
  tests/config/test_environment_variables.py:
  13 passed

  tests/diffusion/models/magi2/test_mh_moe_routing.py:
  33 passed

  All tests passed with no failures or skips. The routing suite covers:

  - Fused/reference output parity across representative shapes
  - Routing with and without expert bias
  - Route normalization enabled and disabled
  - CSR layout equivalence and ordering invariants
  - End-to-end expert output parity
  - CPU and unsupported-input fallback behavior
  - Invalid-input validation
  - A relative routing performance regression threshold of at least 3×

