### PR TITLE
[Bugfix][Diffusion] Keep nested layerwise blocks on the host

### DIFF
--- a/tests/diffusion/offloader/test_layerwise_backend.py
+++ b/tests/diffusion/offloader/test_layerwise_backend.py
@@ -206,6 +206,51 @@ class _NoAttrsModel(nn.Module):
         self.blocks = nn.ModuleList([_DummyBlock() for _ in range(num_blocks)])
 
 
+class _CountingBlocksParent(nn.Module):
+    def __init__(self, num_blocks: int):
+        super().__init__()
+        self.layers = nn.ModuleList([_DummyBlock() for _ in range(num_blocks)])
+        self.to_calls = 0
+
+    def to(self, *args, **kwargs):
+        self.to_calls += 1
+        return super().to(*args, **kwargs)
+
+
+class _CountingBlocks(nn.ModuleList):
+    def __init__(self, num_blocks: int):
+        super().__init__([_DummyBlock() for _ in range(num_blocks)])
+        self.to_calls = 0
+
+    def to(self, *args, **kwargs):
+        self.to_calls += 1
+        return super().to(*args, **kwargs)
+
+
+class _NestedBlocksModel(nn.Module):
+    """Streamed blocks live under a registered parent and are exposed through a property."""
+
+    _layerwise_offload_blocks_attrs = ["layers"]
+
+    def __init__(self, num_blocks: int = 2):
+        super().__init__()
+        self.embed = nn.Linear(4, 4)
+        self.block = _CountingBlocksParent(num_blocks)
+
+    @property
+    def layers(self) -> nn.ModuleList:
+        return self.block.layers
+
+
+class _DirectBlocksModel(nn.Module):
+    _layerwise_offload_blocks_attrs = ["blocks"]
+
+    def __init__(self, num_blocks: int = 2):
+        super().__init__()
+        self.embed = nn.Linear(4, 4)
+        self.blocks = _CountingBlocks(num_blocks)
+
+
 class TestGetBlocksFromDit:
     def test_get_blocks_from_dit_single_block_attr(self):
         model = _SingleBlockModel(num_blocks=3)
@@ -622,6 +667,29 @@ def _offload_od_config(**overrides):
 
 def _resolve_offload_config(public=None, **overrides) -> OffloadConfig:
     return OffloadConfig.from_od_config(_offload_od_config(diffusion_offload_config=public, **overrides))
+
+
+class TestLayerwiseResidentState:
+    @pytest.mark.parametrize(
+        ("model_cls", "owner_attr"),
+        [(_NestedBlocksModel, "block"), (_DirectBlocksModel, "blocks")],
+    )
+    def test_enable_streams_blocks_without_moving_their_owner(self, patched_offload_runtime, model_cls, owner_attr):
+        pipeline = nn.Module()
+        pipeline.transformer = model_cls()
+        _, blocks = LayerWiseOffloadBackend.get_blocks_from_dit(pipeline.transformer)
+        expected_weights = [block.weight.detach().clone() for block in blocks]
+        backend = _layer_backend()
+
+        backend.enable(pipeline)
+
+        assert getattr(pipeline.transformer, owner_attr).to_calls == 0
+        assert all(hasattr(block, "_hook_registry") for block in blocks)
+
+        backend.disable()
+
+        for block, expected in zip(blocks, expected_weights, strict=True):
+            torch.testing.assert_close(block.weight, expected)
 
 
 class TestLayerwiseComponentConfig:

--- a/vllm_omni/diffusion/offloader/layerwise_backend.py
+++ b/vllm_omni/diffusion/offloader/layerwise_backend.py
@@ -510,22 +510,8 @@ class LayerWiseOffloadBackend(OffloadBackend):
                 dit_module.to(self.device)
                 continue
 
-            # Move non-block modules to GPU (they stay resident)
-            for name, m in dit_module.named_children():
-                if name not in blocks_attr_names:
-                    m.to(self.device)
-                    logger.debug(f"Moved {name} to device {self.device}")
-                else:
-                    logger.debug(f"Skipped blocks module {name}")
-
-            # Move top-level params/buffers to GPU (dit_module's own, not sub-modules)
-            for param in dit_module._parameters.values():
-                if param is not None:
-                    param.data = param.data.to(self.device, non_blocking=True)
-
-            for buffer in dit_module._buffers.values():
-                if buffer is not None:
-                    buffer.data = buffer.data.to(self.device, non_blocking=True)
+            # Everything outside the streamed blocks stays resident on device
+            move_non_block_state_to_device(dit_module, [blocks], self.device)
 
             block_hooks = _install_layerwise_hook_group(
                 blocks,


### PR DESCRIPTION
Fixes #7186.

## What broke

The single-device `--enable-cpu-offload --enable-layerwise-offload` profile from `recipes/SandAI/MAGI-2-preview-L20X.md` OOMs on current `main` before the first denoising step. On one A800 80 GiB:

```
INFO [layerwise_backend.py:492] Applying layer-wise offloading on ['transformer']
INFO [component_utils.py:88] Applying hooks on transformer (Magi2PreviewTransformer)
  File "vllm_omni/diffusion/offloader/layerwise_backend.py", line 516, in _enable
    m.to(self.device)
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 1.88 GiB. GPU 0 has a
total capacity of 79.25 GiB of which 1.24 GiB is free. ... this process has 77.86 GiB
memory in use. Of the allocated memory 77.35 GiB is allocated by PyTorch
```

## Reproduction

```bash
export CUDA_VISIBLE_DEVICES=0
python examples/offline_inference/text_to_video/text_to_video.py \
  --model "$MAGI2_CKPT_ROOT" --model-class-name Magi2Pipeline \
  --prompt "A red fox walks through fresh snow while wind moves the pine branches." \
  --height 256 --width 448 --num-frames 125 --num-inference-steps 1 --fps 12.5 \
  --enable-cpu-offload --enable-layerwise-offload \
  --extra-body '{"seconds":10,"resolution":"272p"}' \
  --output magi2_272p_cpu_layerwise.mp4
```

## Root cause

`LayerWiseOffloadBackend._enable` kept every registered child resident whose name was not in the model's `_layerwise_offload_blocks_attrs`. `Magi2PreviewTransformer` declares `["layers"]`, but `layers` is a property over the registered child `block` (the released checkpoint hierarchy), so the whole 40-layer stack was moved to the device instead of being streamed. On a tiny config every streamed-block parameter sits inside the moved child:

```
get_blocks_from_dit -> ['layers'], 2 blocks
named_children      -> ['pre_adapter', 'post_adapter', 'block']
children moved      -> ['pre_adapter', 'post_adapter', 'block']
block params inside moved children: 70 of 70
```

MAGI-2 is the only model whose declared block attribute is not a direct child (checked all 39 declarations in `vllm_omni`). The distributed layerwise backend does not hit this because `_prepare_dit_non_block_modules` routes the oversized child through the submodule heuristic instead of `.to`.

## Fix

Replace the name-based `named_children` loop and the top-level `_parameters` / `_buffers` loops with the tensor-identity helper already used by the encoder path in the same file:

```python
move_non_block_state_to_device(dit_module, [blocks], self.device)
```

Everything outside the streamed blocks moves to the device; block tensors are excluded by identity regardless of where they live in the module tree. No model declaration or checkpoint hierarchy changes.

## Tests

`tests/diffusion/offloader/test_layerwise_backend.py::TestLayerwiseResidentState` adds a CPU regression test parametrized over a nested-parent model (blocks under `block.layers`, declared through a `layers` property) and a direct-child control model. It asserts the child that owns the blocks is never moved as a unit, every block carries the layerwise hook, and `disable` restores the weights.

- On `main`: nested case fails with `assert 1 == 0`, control passes.
- With this change: both pass; `tests/diffusion/offloader` and `tests/diffusion/models/magi2` CPU tests, 259 passed.

## Box verification (A800-SXM4-80GB, torch 2.13.0+cu130, vLLM 0.28.0, checkpoint 2dea51b)

Same command as the reproduction, one step, 272p, this change applied on top of f26f9c3a7:

| | `main` | this PR | recipe (L20X) |
|---|---|---|---|
| Offloader enable | CUDA OOM at `m.to` | 40 layers hooked | qualified |
| Worker peak GPU memory reserved | 77.86 GiB in use at OOM | 49.27 GiB | 49.29 GiB |
| One-step generation | none | 28.23 s | 8.86 s |
| Output | none | 448x256, 125 frames at 12.5 fps, 44.1 kHz stereo audio | valid video + audio |

Generation time is not comparable across L20X and a cold A800 request; the HBM envelope is the number this change restores.
