### PR TITLE
[Bugfix][Diffusion][LoRA] Fail loudly when an activated adapter binds zero layers

### DIFF
--- a/tests/diffusion/lora/test_lora_manager.py
+++ b/tests/diffusion/lora/test_lora_manager.py
@@ -848,3 +848,91 @@ def test_removing_suspended_adapter_drops_the_upload(monkeypatch):
     assert manager._suspended_adapter_id is None
     assert layer.reset_calls == 1, "the upload must be torn down"
     assert layer.suspended_slices is None
+
+
+def test_lora_manager_raises_when_adapter_binds_zero_layers():
+    # An adapter whose tensors match no wrappable layer must fail loudly
+    # (vLLM-core checkpoint-path parity) instead of activating silently
+    # with base-identical output.
+    manager = DiffusionLoRAManager(
+        pipeline=torch.nn.Module(),
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+        max_cached_adapters=1,
+    )
+
+    layer = _DummyLoRALayer(n_slices=1, output_slices=(2,))
+    manager._lora_modules = {"transformer.foo": layer}
+
+    def _weights(name: str) -> LoRALayerWeights:
+        return LoRALayerWeights(
+            module_name=name,
+            rank=2,
+            lora_alpha=2,
+            lora_a=torch.ones((2, 2)),
+            lora_b=torch.ones((2, 2)),
+        )
+
+    loras = {
+        "language_model.model.layers.0.nonexistent_target": _weights(
+            "language_model.model.layers.0.nonexistent_target"
+        ),
+        "language_model.model.layers.1.nonexistent_target": _weights(
+            "language_model.model.layers.1.nonexistent_target"
+        ),
+    }
+    manager._registered_adapters = {
+        7: type(
+            "LM",
+            (),
+            {"id": 7, "loras": loras, "get_lora": lambda self, key: self.loras.get(key)},
+        )()
+    }
+
+    with pytest.raises(ValueError, match="bound to 0 of 2"):
+        manager._activate_adapter(7, scale=1.0)
+
+    # The failed activation must roll back: no layer was ever set, none active.
+    assert len(layer.set_calls) == 0
+    assert layer.reset_calls >= 1
+    assert manager._active_adapter_id is None
+
+
+def test_lora_manager_partial_bind_still_activates():
+    # Adapters that bind some (but not all) engine layers were legal before
+    # this guard and must remain so; only a zero-bind is an error.
+    manager = DiffusionLoRAManager(
+        pipeline=torch.nn.Module(),
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+        max_cached_adapters=1,
+    )
+
+    bound_layer = _DummyLoRALayer(n_slices=1, output_slices=(2,))
+    unmatched_layer = _DummyLoRALayer(n_slices=1, output_slices=(2,))
+    manager._lora_modules = {
+        "transformer.foo": bound_layer,
+        "transformer.bar": unmatched_layer,
+    }
+
+    lora = LoRALayerWeights(
+        module_name="transformer.foo",
+        rank=2,
+        lora_alpha=2,
+        lora_a=torch.ones((2, 2)),
+        lora_b=torch.ones((2, 2)),
+    )
+    manager._registered_adapters = {
+        7: type(
+            "LM",
+            (),
+            {"id": 7, "loras": {"transformer.foo": lora}, "get_lora": lambda self, key: self.loras.get(key)},
+        )()
+    }
+
+    manager._activate_adapter(7, scale=1.0)
+
+    assert manager._active_adapter_id == 7
+    assert len(bound_layer.set_calls) == 1
+    # The layer with no matching adapter weights is reset, not an error.
+    assert unmatched_layer.reset_calls == 1

--- a/vllm_omni/diffusion/lora/manager.py
+++ b/vllm_omni/diffusion/lora/manager.py
@@ -556,9 +556,7 @@ class DiffusionLoRAManager:
 
     def _bind_adapter_weights(self, lora_model: LoRAModel, scale: float) -> None:
         binding_validator = getattr(self.pipeline, "_validate_diffusion_lora_binding", None)
-        lora_names_by_id = (
-            {id(weights): name for name, weights in lora_model.loras.items()} if callable(binding_validator) else {}
-        )
+        lora_names_by_id = {id(weights): name for name, weights in lora_model.loras.items()}
         bound_lora_names: set[str] = set()
 
         def _record_bound(weights: LoRALayerWeights | PackedLoRALayerWeights) -> None:
@@ -675,6 +673,21 @@ class DiffusionLoRAManager:
                 lora_weights.lora_a.shape,
                 lora_weights.lora_b.shape,
                 scale,
+            )
+
+        if lora_model.loras and not bound_lora_names:
+            # vLLM core's checkpoint path fails fast on target-module
+            # mismatches (LoRAModel.from_local_checkpoint); the in-memory
+            # tensor path has no such guard, so an adapter whose modules
+            # match no wrappable layer would otherwise activate silently
+            # with zero effect (base-identical output).
+            unbound = sorted(lora_model.loras)
+            raise ValueError(
+                f"LoRA adapter {lora_model.id} bound to 0 of {len(unbound)} "
+                f"LoRA modules; none of its target modules matched a wrappable "
+                f"layer in the pipeline (expected target modules in "
+                f"{self._expected_lora_modules}, received {unbound[:5]}). "
+                f"Please verify that the loaded LoRA module is correct."
             )
 
         if callable(binding_validator):


### PR DESCRIPTION
## Purpose

Fixes #7190.

A diffusion LoRA adapter whose `target_modules` match no wrappable engine-side layer currently activates "successfully" with zero effect: `add_adapter()` returns `True`, activation completes, and output is identical to the base model. The only trace is DEBUG-level logging.

vLLM core already fails fast on this for the checkpoint path, `LoRAModel.from_local_checkpoint` raises `ValueError: expected target modules in {...} but received {...}. Please verify that the loaded LoRA module is correct`. The in-memory tensor path (`from_lora_tensors`, used by `DiffusionWorker.add_lora` and external tensor-pushers) had no equivalent guard.

## Change

- `DiffusionLoRAManager._bind_adapter_weights` already tracked which LoRA modules actually bound (`bound_lora_names`, used for the opt-in `_validate_diffusion_lora_binding` pipeline hook). This promotes that existing signal into a manager-level default: if an adapter declares LoRA modules but **zero** of them bound to an engine layer, activation raises `ValueError` naming the adapter id, `bound 0 of N`, and the unmatched module names (message shaped after core's).
- Partial binds remain legal and unchanged, an adapter binding some layers still activates, same as before. Per-pipeline binding validators (MiniMax-H3's stricter completeness check) still run after the new guard.
- The raise happens inside `_activate_adapter`'s existing rollback path, so a failed activation leaves every wrapper reset and no adapter active; `DiffusionWorker` surfaces the error to the request that carried the LoRA.

Verified against vllm 0.28.0: `from_local_checkpoint`'s `check_unexpected_modules` raises on unexpected modules; `from_lora_tensors` (lora_model.py:117) validates nothing, this guard closes that gap at the manager level where binding is observable.

## Test Plan

Two CPU unit tests in `tests/diffusion/lora/test_lora_manager.py` using the existing `_DummyLoRALayer` / `LoRALayerWeights` seams:

- `test_lora_manager_raises_when_adapter_binds_zero_layers`: adapter tensors keyed by names that match no layer → `ValueError` ("bound to 0 of 2"), no `set_lora` call, `_active_adapter_id` stays `None` (rollback holds). Fails on pre-fix code with DID NOT RAISE.
- `test_lora_manager_partial_bind_still_activates`: adapter binding one of two layers still activates (preservation case, partial bind was legal before and stays legal).

## Test Result

Local (CPU, macOS, vllm 0.28.0+cpu wheel):

- `pytest tests/diffusion/lora/test_lora_manager.py`: 21 passed
- `pytest tests/diffusion/lora/`: 44 passed (2 GPU e2e tests error locally with no device; unchanged vs main)
- `ruff check` / `ruff format --check` on both files, clean

The zero-bind regression case was verified to fail on unpatched main before the fix.
