### PR TITLE
[Doc] Align documentation build guide with current repository setup

### DIFF
--- a/docs/contributing/DOCS_GUIDE.md
+++ b/docs/contributing/DOCS_GUIDE.md
@@ -1,12 +1,16 @@
 # Documentation Build Guide
 
-This directory contains the source files for the vLLM-Omni documentation.
+The `docs/` directory contains the source files for the vLLM-Omni documentation.
 
 ## Building Documentation Locally
 
 ### Prerequisites
 
-Install documentation dependencies:
+Use Python 3.12 to match the Read the Docs build environment. The package supports
+Python 3.10 through 3.13, as declared in
+[`pyproject.toml`](https://github.com/vllm-project/vllm-omni/blob/main/pyproject.toml).
+Follow [Getting Started](README.md#getting-started) to create and activate an
+environment, then install documentation dependencies from the repository root:
 
 ```bash
 uv pip install -e ".[docs]"
@@ -57,14 +61,17 @@ class Omni:
 
 ## Documentation Structure
 
-```
+```text
 docs/
-├── index.md              # Main documentation page
-├── getting_started/      # Getting started guides
-├── architecture/        # Architecture documentation
-├── api/                 # API reference (auto-generated from code)
-├── examples/            # Code examples
-└── stylesheets/         # Custom CSS
+├── README.md            # Main documentation page
+├── .nav.yml             # Documentation navigation
+├── getting_started/     # Getting started guides
+├── contributing/        # Contributor guides, including this page
+├── design/              # Architecture and design documents
+├── api/                 # API reference entry pages
+├── examples/            # Examples overview
+├── user_guide/examples/  # Task guides and generated model example pages
+└── mkdocs/              # Build hooks, theme overrides, CSS, and JavaScript
 ```
 
 ## Naming Model Examples
@@ -84,37 +91,15 @@ adjust its title because the directory defines its public documentation URL.
 
 ## Publishing Documentation
 
-### GitHub Pages (Recommended)
+The repository's Read the Docs build is configured in
+[`.readthedocs.yml`](https://github.com/vllm-project/vllm-omni/blob/main/.readthedocs.yml).
+It uses Python 3.12, installs the package with the `docs` extra, and builds with
+`mkdocs.yml`, treating warnings as failures.
 
-The documentation is automatically deployed to GitHub Pages using GitHub Actions.
-
-1. **Enable GitHub Pages**:
-   - Go to repository `Settings` → `Pages`
-   - Set `Source` to `GitHub Actions`
-   - Save settings
-
-2. **Push changes**:
-   ```bash
-   git push origin main
-   ```
-
-3. **Documentation will be available at**:
-   - `https://vllm-omni.readthedocs.io`
-
-The GitHub Actions workflow (`.github/workflows/docs.yml`) will automatically:
-- Build the documentation when you push to `main` branch
-- Deploy it to GitHub Pages
-- Update the documentation whenever you make changes
-
-
-### Read the Docs (Alternative)
-
-You can also use Read the Docs for hosting:
-
-1. Sign up at https://readthedocs.org/
-2. Import the `vllm-project/vllm-omni` repository
-3. Read the Docs will automatically build using `.readthedocs.yml`
-4. Documentation will be available at: `https://vllm-omni.readthedocs.io/`
+Submit documentation changes through a pull request following the
+[contribution guide](README.md#pull-requests-code-reviews). Contributors can
+preview changes locally with `mkdocs serve`; configuring a hosting service is
+not required to contribute.
 
 ## Configuration
 
@@ -123,15 +108,15 @@ The documentation configuration is in `mkdocs.yml` at the project root.
 ## Tips
 
 - **API Documentation**: API docs are automatically generated using `mkdocs-api-autonav` and `mkdocstrings`
-  - No need to manually create API pages - they're generated automatically
-  - Use `[module.name.ClassName][]` syntax for cross-references in Summary pages
+    - No need to manually create API pages - they're generated automatically
+    - Use `[module.name.ClassName][]` syntax for cross-references in Summary pages
 - **Code Snippets**: Use `--8<-- "path/to/file.py"` for including code snippets
 - **Markdown**: Use Markdown for all documentation (no need for RST)
 - **Material Theme**: Use Material theme features like:
-  - Admonitions: `!!! note`, `!!! warning`, etc.
-  - Code blocks with syntax highlighting
-  - Tabs for organizing content
-  - Math formulas using `pymdownx.arithmatex`
+    - Admonitions: `!!! note`, `!!! warning`, etc.
+    - Code blocks with syntax highlighting
+    - Tabs for organizing content
+    - Math formulas using `pymdownx.arithmatex`
 
 ## Troubleshooting
 
@@ -149,6 +134,6 @@ The documentation configuration is in `mkdocs.yml` at the project root.
 
 ### Build errors
 
-- Check Python version (requires 3.9+)
+- Check the Python version against `pyproject.toml`; Python 3.12 matches the Read the Docs build
 - Ensure all dependencies are installed: `pip install -e ".[docs]"`
 - Check `mkdocs.yml` syntax with `mkdocs build --strict`

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -19,7 +19,7 @@ source .venv/bin/activate
 vLLM-Omni is quickly evolving, please see the [installation guide](../getting_started/installation/README.md) for details. It's recommended to build from source to provide the latest development environment.
 
 !!! tip
-    vLLM-Omni is compatible with Python versions 3.10 to 3.12. However, we recommend developing with Python 3.12 to minimize the chance of your local environment clashing with our CI environment.
+    vLLM-Omni supports Python versions 3.10 to 3.13, as declared in [`pyproject.toml`](https://github.com/vllm-project/vllm-omni/blob/main/pyproject.toml). We recommend developing with Python 3.12 to match the Read the Docs build environment.
 
 ### Adding a new model to vLLM-Omni
 


### PR DESCRIPTION
## Purpose

The documentation build guide refers to a missing `.github/workflows/docs.yml`, describes a GitHub Pages deployment with a Read the Docs URL, and lists outdated Python requirements and documentation paths.

- Align both contributor guides with the Python 3.10–3.13 range declared in `pyproject.toml`, recommending Python 3.12 to match `.readthedocs.yml`.
- Update the documentation directory overview to the current layout.
- Replace the obsolete hosting setup instructions with the existing Read the Docs build configuration and the contribution workflow. Apply the required Markdown list indentation fixes in the touched guide.

## Test Plan

Documentation-only change; model inference and L1/L2 GPU tests are not applicable.

**vLLM Version:** Not installed; validation uses the documentation dependencies listed in `pyproject.toml`.

**vLLM-Omni Commit:** Based on `3204a0b2ade0f05424b7f11e3bcc03cb3542e0c6`.

Local environment: Windows x64, Python 3.11.5, MkDocs 1.6.1, pre-commit 4.0.1.

- `python -m pre_commit run --files docs/contributing/DOCS_GUIDE.md docs/contributing/README.md --show-diff-on-failure`
- `python -m mkdocs build --strict --site-dir ../docs-site`
- `git diff --check origin/main...HEAD`
- Check the documented Python range and build settings against `pyproject.toml` and `.readthedocs.yml`; verify the directory entries and local heading links.
- Render both changed pages with the Markdown extensions configured in `mkdocs.yml`.
- Run the repository `precheck-pr` full checklist, including the diff-scoped code-quality, examples-policy, and simplification checks.

## Test Result

- All applicable local pre-commit hooks passed, including Markdown linting and typos. The commit-message sign-off hook also passed.
- The complete strict documentation build passed (426.92 seconds), including API reference generation.
- Diff whitespace checks, documentation consistency checks, and both page renders passed.
- Full precheck: no blocking findings or additional simplification candidates.
