### PR TITLE
[Hardware][Ascend] Add optional unified SP attention executor

### DIFF
--- a/docs/user_guide/diffusion/parallelism/sequence_parallel.md
+++ b/docs/user_guide/diffusion/parallelism/sequence_parallel.md
@@ -85,6 +85,41 @@ omni = Omni(
 )
 ```
 
+### Optional MindIE-SD USP path (Ascend NPU)
+
+On Ascend NPU, vLLM-Omni can delegate the complete Ulysses and ring-group
+attention hot path to MindIE-SD in one call. The public attention backend
+remains `FLASH_ATTN`; this option only replaces its sequence-parallel
+communication and local FA execution. The configured ring process group is
+passed to MindIE-SD as `kv_gather_group`.
+
+```python
+omni = Omni(
+    model="Qwen/Qwen-Image",
+    parallel_config=DiffusionParallelConfig(
+        ulysses_degree=2,
+        ring_degree=2,
+        enable_mindiesd_usp=True,
+    ),
+)
+```
+
+The initial integration intentionally exposes only this switch. vLLM-Omni
+passes its Ulysses group and its ring group (as `kv_gather_group`) while
+MindIE-SD uses its own defaults for chunking, communication dtype, overlap,
+and FA backend selection.
+
+This is an opt-in path and requires a MindIE-SD build that provides
+`mindiesd.layers.usp`. If the package is absent or MindIE-SD raises one of its
+structured `USPError` capability exceptions, vLLM-Omni logs the reason once
+and uses its existing native Ulysses/Ring implementation. Unexpected errors
+are not hidden.
+
+The first integration supports strict, non-causal, dense `FLASH_ATTN`
+execution. Advanced UAA, Scheduler-paged KV, piecewise/packed attention,
+attention masks, custom softmax scales, and joint-query attention remain on
+the native path.
+
 ---
 
 ## Example Script
@@ -165,6 +200,7 @@ In `DiffusionParallelConfig`:
 | `ring_degree` | int | 1 | Number of GPUs for Ring-Attention. Uses P2P ring communication. |
 | `ulysses_mode` | str | `"default"` | Ulysses attention mode. Set to `"advanced_uaa"` to handle arbitrary sequence lengths and head counts without padding. |
 | `mask_sp_padding` | bool | `False` | When the sequence length is not divisible by the SP size, tokens are auto-padded with zeros. Set to `True` to mask those padding tokens (strict, but uses the slower varlen attention path); the default `False` leaves them unmasked, keeping the fast path with negligible numerical impact. |
+| `enable_mindiesd_usp` | bool | `False` | Delegate supported Ascend sequence-parallel attention to `mindiesd.layers.usp`. |
 
 **Notes:**
 - Total sequence parallel size equals to `ulysses_degree × ring_degree`

--- a/docs/user_guide/diffusion/parallelism/sequence_parallel.md
+++ b/docs/user_guide/diffusion/parallelism/sequence_parallel.md
@@ -85,13 +85,14 @@ omni = Omni(
 )
 ```
 
-### Optional MindIE-SD USP path (Ascend NPU)
+### Optional unified SP executor (Ascend NPU)
 
 On Ascend NPU, vLLM-Omni can delegate the complete Ulysses and ring-group
-attention hot path to MindIE-SD in one call. The public attention backend
-remains `FLASH_ATTN`; this option only replaces its sequence-parallel
-communication and local FA execution. The configured ring process group is
-passed to MindIE-SD as `kv_gather_group`.
+attention hot path to the platform's unified sequence-parallel (USP) executor.
+The public attention backend remains `FLASH_ATTN`; this option only replaces
+its sequence-parallel communication and local FA execution. The Ascend
+implementation is provided by MindIE-SD, and receives the configured ring
+process group as `kv_gather_group`.
 
 ```python
 omni = Omni(
@@ -99,17 +100,17 @@ omni = Omni(
     parallel_config=DiffusionParallelConfig(
         ulysses_degree=2,
         ring_degree=2,
-        enable_mindiesd_usp=True,
+        enable_usp=True,
     ),
 )
 ```
 
-The initial integration intentionally exposes only this switch. vLLM-Omni
-passes its Ulysses group and its ring group (as `kv_gather_group`) while
-MindIE-SD uses its own defaults for chunking, communication dtype, overlap,
-and FA backend selection.
+The initial integration intentionally exposes only the technical `enable_usp`
+switch. vLLM-Omni passes its Ulysses group and its ring group (as
+`kv_gather_group`) while the platform executor uses its own defaults for
+chunking, communication dtype, overlap, and FA backend selection.
 
-This is an opt-in path and requires a MindIE-SD build that provides
+The Ascend implementation requires a MindIE-SD build that provides
 `mindiesd.layers.usp`. If the package is absent or MindIE-SD raises one of its
 structured `USPError` capability exceptions, vLLM-Omni logs the reason once
 and uses its existing native Ulysses/Ring implementation. Unexpected errors
@@ -200,7 +201,7 @@ In `DiffusionParallelConfig`:
 | `ring_degree` | int | 1 | Number of GPUs for Ring-Attention. Uses P2P ring communication. |
 | `ulysses_mode` | str | `"default"` | Ulysses attention mode. Set to `"advanced_uaa"` to handle arbitrary sequence lengths and head counts without padding. |
 | `mask_sp_padding` | bool | `False` | When the sequence length is not divisible by the SP size, tokens are auto-padded with zeros. Set to `True` to mask those padding tokens (strict, but uses the slower varlen attention path); the default `False` leaves them unmasked, keeping the fast path with negligible numerical impact. |
-| `enable_mindiesd_usp` | bool | `False` | Delegate supported Ascend sequence-parallel attention to `mindiesd.layers.usp`. |
+| `enable_usp` | bool | `False` | Use the platform's unified sequence-parallel executor for supported attention calls. |
 
 **Notes:**
 - Total sequence parallel size equals to `ulysses_degree × ring_degree`

--- a/tests/config/test_omni_config.py
+++ b/tests/config/test_omni_config.py
@@ -687,6 +687,7 @@ def test_sub_config_fields_match_structured_scopes():
         "allgather_degree",
         "ulysses_mode",
         "ulysses_a2a_permute",
+        "enable_mindiesd_usp",
         "cfg_parallel_size",
         "vae_patch_parallel_size",
         "vae_parallel_mode",

--- a/tests/config/test_omni_config.py
+++ b/tests/config/test_omni_config.py
@@ -687,7 +687,7 @@ def test_sub_config_fields_match_structured_scopes():
         "allgather_degree",
         "ulysses_mode",
         "ulysses_a2a_permute",
-        "enable_mindiesd_usp",
+        "enable_usp",
         "cfg_parallel_size",
         "vae_patch_parallel_size",
         "vae_parallel_mode",

--- a/tests/diffusion/attention/test_mindiesd_usp.py
+++ b/tests/diffusion/attention/test_mindiesd_usp.py
@@ -11,18 +11,14 @@ import torch
 
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.layer import Attention
-from vllm_omni.diffusion.attention.mindiesd_usp import (
-    MindIESDUSPAdapter,
-    MindIESDUSPOptions,
-)
 from vllm_omni.diffusion.data import DiffusionParallelConfig
+from vllm_omni.platforms.npu.usp import AscendUSPExecutor
 
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
 
 
 @dataclass
 class _ParallelConfigStub:
-    enable_mindiesd_usp: bool = True
     ulysses_degree: int = 2
     ring_degree: int = 2
     allgather_degree: int = 1
@@ -49,37 +45,43 @@ def _usp_module(usp_attention, usp_error: USPErrorType = RuntimeError) -> Module
     return module
 
 
-def _adapter(**overrides):
+def _executor(**overrides):
     config = _parallel_config(**overrides)
     groups = _SPGroupsStub(
         ulysses_group=object(),
         ring_group=object(),
     )
-    return MindIESDUSPAdapter(MindIESDUSPOptions.from_parallel_config(config), groups)
+    return AscendUSPExecutor(
+        sp_group=groups,
+        ulysses_degree=config.ulysses_degree,
+        ring_degree=config.ring_degree,
+        allgather_degree=config.allgather_degree,
+        ulysses_mode=config.ulysses_mode,
+    )
 
 
-def test_parallel_config_exposes_one_mindiesd_usp_switch():
+def test_parallel_config_exposes_technical_usp_switch():
     config = DiffusionParallelConfig(
         ulysses_degree=2,
-        enable_mindiesd_usp=True,
+        enable_usp=True,
     )
 
     assert config.sequence_parallel_size == 2
-    assert config.enable_mindiesd_usp is True
+    assert config.enable_usp is True
 
 
-def test_adapter_maps_vllm_owned_state_to_explicit_mindie_contract(monkeypatch):
-    adapter = _adapter()
+def test_executor_maps_vllm_owned_state_to_explicit_mindie_contract(monkeypatch):
+    executor = _executor()
     usp_attention = Mock(return_value=torch.full((1, 3, 4, 8), 7.0))
     module = _usp_module(usp_attention)
-    monkeypatch.setattr(adapter, "_load_usp_module", lambda: module)
+    monkeypatch.setattr(executor, "_load_usp_module", lambda: module)
 
     query = torch.randn(1, 3, 4, 8)
     key = torch.randn(1, 3, 4, 8)
     value = torch.randn(1, 3, 4, 8)
     metadata = AttentionMetadata()
 
-    output = adapter.try_forward(
+    output = executor.try_forward(
         query,
         key,
         value,
@@ -96,22 +98,22 @@ def test_adapter_maps_vllm_owned_state_to_explicit_mindie_contract(monkeypatch):
         query,
         key,
         value,
-        ulysses_group=adapter.sp_group.ulysses_group,
-        kv_gather_group=adapter.sp_group.ring_group,
+        ulysses_group=executor.sp_group.ulysses_group,
+        kv_gather_group=executor.sp_group.ring_group,
     )
 
 
-def test_adapter_maps_pure_ring_to_kv_gather(monkeypatch):
-    adapter = _adapter(ulysses_degree=1, ring_degree=2)
+def test_executor_maps_pure_ring_to_kv_gather(monkeypatch):
+    executor = _executor(ulysses_degree=1, ring_degree=2)
     usp_attention = Mock(return_value=torch.zeros(1, 3, 4, 8))
     monkeypatch.setattr(
-        adapter,
+        executor,
         "_load_usp_module",
         lambda: _usp_module(usp_attention),
     )
     query = torch.randn(1, 3, 4, 8)
 
-    adapter.try_forward(
+    executor.try_forward(
         query,
         query,
         query,
@@ -125,7 +127,7 @@ def test_adapter_maps_pure_ring_to_kv_gather(monkeypatch):
 
     kwargs = usp_attention.call_args.kwargs
     assert kwargs["ulysses_group"] is None
-    assert kwargs["kv_gather_group"] is adapter.sp_group.ring_group
+    assert kwargs["kv_gather_group"] is executor.sp_group.ring_group
 
 
 def test_attention_delegates_before_native_sequence_parallel_collectives():
@@ -147,7 +149,7 @@ def test_attention_delegates_before_native_sequence_parallel_collectives():
     layer.scatter_idx = 2
     layer.gather_idx = 1
     expected = torch.zeros(1, 3, 4, 8)
-    layer._mindiesd_usp_adapter = Mock(try_forward=Mock(return_value=expected))
+    layer._usp_executor = Mock(try_forward=Mock(return_value=expected))
     query = torch.randn(1, 3, 4, 8)
 
     output = layer._forward_impl(query, query, query)
@@ -165,7 +167,7 @@ def test_attention_does_not_delegate_outside_sp_sharded_region():
     layer._active_paged_kv_adapter = Mock(return_value=None)
     layer._scheduler_paged_kv = False
     layer.paged_kv_cache_role = None
-    layer._mindiesd_usp_adapter = Mock()
+    layer._usp_executor = Mock()
     layer.use_ring = False
     layer._with_kv_cache_dtype = Mock(side_effect=lambda metadata: metadata)
     layer._run_local_attention = Mock(return_value=torch.zeros(1, 3, 4, 8))
@@ -181,13 +183,12 @@ def test_attention_does_not_delegate_outside_sp_sharded_region():
 
     layer._forward_impl(query, query, query)
 
-    layer._mindiesd_usp_adapter.try_forward.assert_not_called()
+    layer._usp_executor.try_forward.assert_not_called()
 
 
 @pytest.mark.parametrize(
-    ("adapter_overrides", "call_overrides", "metadata"),
+    ("executor_overrides", "call_overrides", "metadata"),
     [
-        ({"enable_mindiesd_usp": False}, {}, None),
         ({}, {"backend_name": "TORCH_SDPA"}, None),
         ({}, {"causal": True}, None),
         ({}, {"softmax_scale": 0.25}, None),
@@ -199,16 +200,16 @@ def test_attention_does_not_delegate_outside_sp_sharded_region():
         ({}, {}, AttentionMetadata(extra={"kv_cache_dtype": "fp8"})),
     ],
 )
-def test_adapter_skips_semantics_not_covered_by_mindie(
+def test_executor_skips_semantics_not_covered_by_mindie(
     monkeypatch,
-    adapter_overrides,
+    executor_overrides,
     call_overrides,
     metadata,
 ):
-    adapter = _adapter(**adapter_overrides)
+    executor = _executor(**executor_overrides)
     usp_attention = Mock(return_value=torch.zeros(1, 3, 4, 8))
     monkeypatch.setattr(
-        adapter,
+        executor,
         "_load_usp_module",
         lambda: _usp_module(usp_attention),
     )
@@ -223,25 +224,25 @@ def test_adapter_skips_semantics_not_covered_by_mindie(
     }
     call.update(call_overrides)
 
-    assert adapter.try_forward(query, query, query, **call) is None
+    assert executor.try_forward(query, query, query, **call) is None
     usp_attention.assert_not_called()
 
 
-def test_adapter_falls_back_only_for_structured_mindie_errors(monkeypatch):
+def test_executor_falls_back_only_for_structured_mindie_errors(monkeypatch):
     class USPError(RuntimeError):
         pass
 
-    adapter = _adapter()
+    executor = _executor()
     usp_attention = Mock(side_effect=USPError("unsupported shape"))
     monkeypatch.setattr(
-        adapter,
+        executor,
         "_load_usp_module",
         lambda: _usp_module(usp_attention, USPError),
     )
     query = torch.randn(1, 3, 4, 8)
 
     assert (
-        adapter.try_forward(
+        executor.try_forward(
             query,
             query,
             query,
@@ -257,7 +258,7 @@ def test_adapter_falls_back_only_for_structured_mindie_errors(monkeypatch):
 
     usp_attention.side_effect = ValueError("programming error")
     with pytest.raises(ValueError, match="programming error"):
-        adapter.try_forward(
+        executor.try_forward(
             query,
             query,
             query,

--- a/tests/diffusion/attention/test_mindiesd_usp.py
+++ b/tests/diffusion/attention/test_mindiesd_usp.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from dataclasses import dataclass, replace
+from types import ModuleType
+from typing import TypeAlias
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
+from vllm_omni.diffusion.attention.layer import Attention
+from vllm_omni.diffusion.attention.mindiesd_usp import (
+    MindIESDUSPAdapter,
+    MindIESDUSPOptions,
+)
+from vllm_omni.diffusion.data import DiffusionParallelConfig
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+@dataclass
+class _ParallelConfigStub:
+    enable_mindiesd_usp: bool = True
+    ulysses_degree: int = 2
+    ring_degree: int = 2
+    allgather_degree: int = 1
+    ulysses_mode: str = "strict"
+
+
+@dataclass
+class _SPGroupsStub:
+    ulysses_group: object
+    ring_group: object
+
+
+USPErrorType: TypeAlias = type[BaseException]
+
+
+def _parallel_config(**overrides):
+    return replace(_ParallelConfigStub(), **overrides)
+
+
+def _usp_module(usp_attention, usp_error: USPErrorType = RuntimeError) -> ModuleType:
+    module = ModuleType("mindiesd.layers.usp")
+    setattr(module, "usp_attention", usp_attention)
+    setattr(module, "USPError", usp_error)
+    return module
+
+
+def _adapter(**overrides):
+    config = _parallel_config(**overrides)
+    groups = _SPGroupsStub(
+        ulysses_group=object(),
+        ring_group=object(),
+    )
+    return MindIESDUSPAdapter(MindIESDUSPOptions.from_parallel_config(config), groups)
+
+
+def test_parallel_config_exposes_one_mindiesd_usp_switch():
+    config = DiffusionParallelConfig(
+        ulysses_degree=2,
+        enable_mindiesd_usp=True,
+    )
+
+    assert config.sequence_parallel_size == 2
+    assert config.enable_mindiesd_usp is True
+
+
+def test_adapter_maps_vllm_owned_state_to_explicit_mindie_contract(monkeypatch):
+    adapter = _adapter()
+    usp_attention = Mock(return_value=torch.full((1, 3, 4, 8), 7.0))
+    module = _usp_module(usp_attention)
+    monkeypatch.setattr(adapter, "_load_usp_module", lambda: module)
+
+    query = torch.randn(1, 3, 4, 8)
+    key = torch.randn(1, 3, 4, 8)
+    value = torch.randn(1, 3, 4, 8)
+    metadata = AttentionMetadata()
+
+    output = adapter.try_forward(
+        query,
+        key,
+        value,
+        attn_metadata=metadata,
+        backend_name="FLASH_ATTN",
+        causal=False,
+        softmax_scale=8**-0.5,
+        scatter_dim=2,
+        gather_dim=1,
+    )
+
+    assert output is usp_attention.return_value
+    usp_attention.assert_called_once_with(
+        query,
+        key,
+        value,
+        ulysses_group=adapter.sp_group.ulysses_group,
+        kv_gather_group=adapter.sp_group.ring_group,
+    )
+
+
+def test_adapter_maps_pure_ring_to_kv_gather(monkeypatch):
+    adapter = _adapter(ulysses_degree=1, ring_degree=2)
+    usp_attention = Mock(return_value=torch.zeros(1, 3, 4, 8))
+    monkeypatch.setattr(
+        adapter,
+        "_load_usp_module",
+        lambda: _usp_module(usp_attention),
+    )
+    query = torch.randn(1, 3, 4, 8)
+
+    adapter.try_forward(
+        query,
+        query,
+        query,
+        attn_metadata=None,
+        backend_name="FLASH_ATTN",
+        causal=False,
+        softmax_scale=8**-0.5,
+        scatter_dim=2,
+        gather_dim=1,
+    )
+
+    kwargs = usp_attention.call_args.kwargs
+    assert kwargs["ulysses_group"] is None
+    assert kwargs["kv_gather_group"] is adapter.sp_group.ring_group
+
+
+def test_attention_delegates_before_native_sequence_parallel_collectives():
+    layer = Attention.__new__(Attention)
+    torch.nn.Module.__init__(layer)
+    strategy = Mock()
+    layer._get_active_parallel_strategy = Mock(return_value=strategy)
+    layer._no_parallel_strategy = Mock()
+    layer._active_paged_kv_adapter = Mock(return_value=None)
+    layer._scheduler_paged_kv = False
+    layer.paged_kv_cache_role = None
+    layer._kv_cache_dtype = None
+    layer._disable_kv_quant = False
+    layer._kv_cache_skip_steps = None
+    layer._kv_cache_skip_layers = None
+    layer.attn_backend = Mock(get_name=Mock(return_value="FLASH_ATTN"))
+    layer.causal = False
+    layer.softmax_scale = 8**-0.5
+    layer.scatter_idx = 2
+    layer.gather_idx = 1
+    expected = torch.zeros(1, 3, 4, 8)
+    layer._mindiesd_usp_adapter = Mock(try_forward=Mock(return_value=expected))
+    query = torch.randn(1, 3, 4, 8)
+
+    output = layer._forward_impl(query, query, query)
+
+    assert output is expected
+    strategy.pre_attention.assert_not_called()
+    strategy.post_attention.assert_not_called()
+
+
+def test_attention_does_not_delegate_outside_sp_sharded_region():
+    layer = Attention.__new__(Attention)
+    torch.nn.Module.__init__(layer)
+    layer._no_parallel_strategy = Mock()
+    layer._get_active_parallel_strategy = Mock(return_value=layer._no_parallel_strategy)
+    layer._active_paged_kv_adapter = Mock(return_value=None)
+    layer._scheduler_paged_kv = False
+    layer.paged_kv_cache_role = None
+    layer._mindiesd_usp_adapter = Mock()
+    layer.use_ring = False
+    layer._with_kv_cache_dtype = Mock(side_effect=lambda metadata: metadata)
+    layer._run_local_attention = Mock(return_value=torch.zeros(1, 3, 4, 8))
+    layer._no_parallel_strategy.pre_attention.return_value = (
+        torch.zeros(1, 3, 4, 8),
+        torch.zeros(1, 3, 4, 8),
+        torch.zeros(1, 3, 4, 8),
+        None,
+        object(),
+    )
+    layer._no_parallel_strategy.post_attention.side_effect = lambda output, _ctx: output
+    query = torch.randn(1, 3, 4, 8)
+
+    layer._forward_impl(query, query, query)
+
+    layer._mindiesd_usp_adapter.try_forward.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("adapter_overrides", "call_overrides", "metadata"),
+    [
+        ({"enable_mindiesd_usp": False}, {}, None),
+        ({}, {"backend_name": "TORCH_SDPA"}, None),
+        ({}, {"causal": True}, None),
+        ({}, {"softmax_scale": 0.25}, None),
+        ({"ulysses_mode": "advanced_uaa"}, {}, None),
+        ({"ulysses_degree": 1, "ring_degree": 1, "allgather_degree": 2}, {}, None),
+        ({}, {}, AttentionMetadata(joint_query=torch.zeros(1, 1, 4, 8))),
+        ({}, {}, AttentionMetadata(attn_mask=torch.ones(1, 3, dtype=torch.bool))),
+        ({}, {}, AttentionMetadata(full_attn_spans=[[(0, 1)]])),
+        ({}, {}, AttentionMetadata(extra={"kv_cache_dtype": "fp8"})),
+    ],
+)
+def test_adapter_skips_semantics_not_covered_by_mindie(
+    monkeypatch,
+    adapter_overrides,
+    call_overrides,
+    metadata,
+):
+    adapter = _adapter(**adapter_overrides)
+    usp_attention = Mock(return_value=torch.zeros(1, 3, 4, 8))
+    monkeypatch.setattr(
+        adapter,
+        "_load_usp_module",
+        lambda: _usp_module(usp_attention),
+    )
+    query = torch.randn(1, 3, 4, 8)
+    call = {
+        "attn_metadata": metadata,
+        "backend_name": "FLASH_ATTN",
+        "causal": False,
+        "softmax_scale": 8**-0.5,
+        "scatter_dim": 2,
+        "gather_dim": 1,
+    }
+    call.update(call_overrides)
+
+    assert adapter.try_forward(query, query, query, **call) is None
+    usp_attention.assert_not_called()
+
+
+def test_adapter_falls_back_only_for_structured_mindie_errors(monkeypatch):
+    class USPError(RuntimeError):
+        pass
+
+    adapter = _adapter()
+    usp_attention = Mock(side_effect=USPError("unsupported shape"))
+    monkeypatch.setattr(
+        adapter,
+        "_load_usp_module",
+        lambda: _usp_module(usp_attention, USPError),
+    )
+    query = torch.randn(1, 3, 4, 8)
+
+    assert (
+        adapter.try_forward(
+            query,
+            query,
+            query,
+            attn_metadata=None,
+            backend_name="FLASH_ATTN",
+            causal=False,
+            softmax_scale=8**-0.5,
+            scatter_dim=2,
+            gather_dim=1,
+        )
+        is None
+    )
+
+    usp_attention.side_effect = ValueError("programming error")
+    with pytest.raises(ValueError, match="programming error"):
+        adapter.try_forward(
+            query,
+            query,
+            query,
+            attn_metadata=None,
+            backend_name="FLASH_ATTN",
+            causal=False,
+            softmax_scale=8**-0.5,
+            scatter_dim=2,
+            gather_dim=1,
+        )

--- a/tests/platforms/npu/test_diffusion_platform.py
+++ b/tests/platforms/npu/test_diffusion_platform.py
@@ -23,6 +23,30 @@ def test_dense_flash_capability_tracks_mindiesd(monkeypatch, available):
     assert NPUOmniPlatform.supports_diffusion_dense_flash_attention() is available
 
 
+def test_usp_executor_uses_technical_platform_switch() -> None:
+    pytest.importorskip("vllm_ascend")
+    from vllm_omni.platforms.npu.platform import NPUOmniPlatform
+    from vllm_omni.platforms.npu.usp import AscendUSPExecutor
+
+    groups = SimpleNamespace(ulysses_group=object(), ring_group=object())
+    disabled = SimpleNamespace(enable_usp=False)
+    assert NPUOmniPlatform.build_diffusion_usp_executor(disabled, groups) is None
+
+    enabled = SimpleNamespace(
+        enable_usp=True,
+        ulysses_degree=2,
+        ring_degree=4,
+        allgather_degree=1,
+        ulysses_mode="strict",
+    )
+    executor = NPUOmniPlatform.build_diffusion_usp_executor(enabled, groups)
+
+    assert isinstance(executor, AscendUSPExecutor)
+    assert executor.sp_group is groups
+    assert executor.ulysses_degree == 2
+    assert executor.ring_degree == 4
+
+
 def test_paged_config_uses_ascend_kernel_block_size() -> None:
     pytest.importorskip("vllm_ascend")
     from vllm_ascend.attention.attention_v1 import AscendAttentionBackend

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -216,6 +216,7 @@ class _ParallelConfigEngineOverrides(TypedDict, total=False):
     allgather_degree: int
     ulysses_mode: str
     ulysses_a2a_permute: bool
+    enable_mindiesd_usp: bool
     cfg_parallel_size: int
     vae_patch_parallel_size: int
     vae_parallel_mode: str
@@ -608,6 +609,7 @@ class OmniStageDiffusionParallelConfig(OmniStageParallelConfig):
     allgather_degree: int = Field(default=1, ge=1)
     ulysses_mode: str = "strict"
     ulysses_a2a_permute: bool = False
+    enable_mindiesd_usp: bool = False
     cfg_parallel_size: int = Field(default=1, ge=1)
     vae_patch_parallel_size: int = Field(default=1, ge=1)
     text_encoder_tp_size: int = Field(default=1, ge=1)

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -216,7 +216,7 @@ class _ParallelConfigEngineOverrides(TypedDict, total=False):
     allgather_degree: int
     ulysses_mode: str
     ulysses_a2a_permute: bool
-    enable_mindiesd_usp: bool
+    enable_usp: bool
     cfg_parallel_size: int
     vae_patch_parallel_size: int
     vae_parallel_mode: str
@@ -609,7 +609,7 @@ class OmniStageDiffusionParallelConfig(OmniStageParallelConfig):
     allgather_degree: int = Field(default=1, ge=1)
     ulysses_mode: str = "strict"
     ulysses_a2a_permute: bool = False
-    enable_mindiesd_usp: bool = False
+    enable_usp: bool = False
     cfg_parallel_size: int = Field(default=1, ge=1)
     vae_patch_parallel_size: int = Field(default=1, ge=1)
     text_encoder_tp_size: int = Field(default=1, ge=1)

--- a/vllm_omni/diffusion/attention/layer.py
+++ b/vllm_omni/diffusion/attention/layer.py
@@ -18,10 +18,6 @@ from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheSpec
 
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.backends.sdpa import SDPABackend
-from vllm_omni.diffusion.attention.mindiesd_usp import (
-    MindIESDUSPAdapter,
-    MindIESDUSPOptions,
-)
 from vllm_omni.diffusion.attention.parallel import build_parallel_attention_strategy
 from vllm_omni.diffusion.attention.parallel.base import NoParallelAttention
 from vllm_omni.diffusion.attention.parallel.ring import RingParallelAttention
@@ -249,17 +245,16 @@ class Attention(nn.Module):
         # Local strategy when SP is intentionally inactive outside sharded regions.
         self._no_parallel_strategy = NoParallelAttention()
 
-        self._mindiesd_usp_adapter: MindIESDUSPAdapter | None = None
+        self._usp_executor = None
         if (
             config is not None
             and not self._has_custom_attention
             and not skip_sequence_parallel
-            and current_omni_platform.is_npu()
-            and getattr(config.parallel_config, "enable_mindiesd_usp", False)
+            and getattr(config.parallel_config, "enable_usp", False)
             and getattr(config.parallel_config, "sequence_parallel_size", 1) > 1
         ):
-            self._mindiesd_usp_adapter = MindIESDUSPAdapter(
-                MindIESDUSPOptions.from_parallel_config(config.parallel_config),
+            self._usp_executor = current_omni_platform.build_diffusion_usp_executor(
+                config.parallel_config,
                 get_sp_group(),
             )
 
@@ -425,16 +420,12 @@ class Attention(nn.Module):
             if strategy_name == "ulysses" and get_ulysses_mode(default="strict") != "strict":
                 raise NotImplementedError("paged Scheduler KV currently supports only strict Ulysses")
 
-        # MindIE-SD owns the complete Ulysses + ring-group KV gather + FA hot
-        # path. Invoke it before Omni performs any communication so one and
-        # only one implementation owns the collectives for this forward.
-        if (
-            self._mindiesd_usp_adapter is not None
-            and strategy is not self._no_parallel_strategy
-            and not use_paged_attention
-        ):
+        # A platform USP executor owns the complete Ulysses + ring-group KV
+        # gather + FA hot path. Invoke it before Omni performs communication so
+        # one and only one implementation owns the collectives for this forward.
+        if self._usp_executor is not None and strategy is not self._no_parallel_strategy and not use_paged_attention:
             usp_metadata = self._with_kv_cache_dtype(attn_metadata)
-            usp_output = self._mindiesd_usp_adapter.try_forward(
+            usp_output = self._usp_executor.try_forward(
                 query,
                 key,
                 value,

--- a/vllm_omni/diffusion/attention/layer.py
+++ b/vllm_omni/diffusion/attention/layer.py
@@ -18,6 +18,10 @@ from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheSpec
 
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.backends.sdpa import SDPABackend
+from vllm_omni.diffusion.attention.mindiesd_usp import (
+    MindIESDUSPAdapter,
+    MindIESDUSPOptions,
+)
 from vllm_omni.diffusion.attention.parallel import build_parallel_attention_strategy
 from vllm_omni.diffusion.attention.parallel.base import NoParallelAttention
 from vllm_omni.diffusion.attention.parallel.ring import RingParallelAttention
@@ -245,6 +249,20 @@ class Attention(nn.Module):
         # Local strategy when SP is intentionally inactive outside sharded regions.
         self._no_parallel_strategy = NoParallelAttention()
 
+        self._mindiesd_usp_adapter: MindIESDUSPAdapter | None = None
+        if (
+            config is not None
+            and not self._has_custom_attention
+            and not skip_sequence_parallel
+            and current_omni_platform.is_npu()
+            and getattr(config.parallel_config, "enable_mindiesd_usp", False)
+            and getattr(config.parallel_config, "sequence_parallel_size", 1) > 1
+        ):
+            self._mindiesd_usp_adapter = MindIESDUSPAdapter(
+                MindIESDUSPOptions.from_parallel_config(config.parallel_config),
+                get_sp_group(),
+            )
+
         self.layer_idx: int | None = _try_extract_layer_index(prefix)
 
         self._kv_cache_dtype: str | None = None
@@ -406,6 +424,29 @@ class Attention(nn.Module):
                 raise NotImplementedError("paged Scheduler KV is not supported with AllGather-KV sequence parallelism")
             if strategy_name == "ulysses" and get_ulysses_mode(default="strict") != "strict":
                 raise NotImplementedError("paged Scheduler KV currently supports only strict Ulysses")
+
+        # MindIE-SD owns the complete Ulysses + ring-group KV gather + FA hot
+        # path. Invoke it before Omni performs any communication so one and
+        # only one implementation owns the collectives for this forward.
+        if (
+            self._mindiesd_usp_adapter is not None
+            and strategy is not self._no_parallel_strategy
+            and not use_paged_attention
+        ):
+            usp_metadata = self._with_kv_cache_dtype(attn_metadata)
+            usp_output = self._mindiesd_usp_adapter.try_forward(
+                query,
+                key,
+                value,
+                attn_metadata=usp_metadata,
+                backend_name=self.attn_backend.get_name(),
+                causal=self.causal,
+                softmax_scale=self.softmax_scale,
+                scatter_dim=self.scatter_idx,
+                gather_dim=self.gather_idx,
+            )
+            if usp_output is not None:
+                return usp_output
 
         # 1. Prepare inputs (Communication / Resharding)
         # For Ulysses: AllToAll Q/K/V; Slicing joint_q/k/v

--- a/vllm_omni/diffusion/attention/mindiesd_usp.py
+++ b/vllm_omni/diffusion/attention/mindiesd_usp.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""Optional MindIE-SD unified sequence-parallel attention adapter."""
+
+from __future__ import annotations
+
+import importlib
+import math
+from dataclasses import dataclass
+from types import ModuleType
+from typing import TYPE_CHECKING, Protocol
+
+import torch
+from vllm.logger import init_logger
+
+if TYPE_CHECKING:
+    from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
+
+logger = init_logger(__name__)
+
+
+class SequenceParallelGroups(Protocol):
+    """Process groups owned by vLLM-Omni's SP coordinator."""
+
+    ulysses_group: object
+    ring_group: object
+
+
+@dataclass(frozen=True, slots=True)
+class MindIESDUSPOptions:
+    """vLLM-Omni-owned, normalized options for the MindIE-SD USP call."""
+
+    enabled: bool = False
+    ulysses_degree: int = 1
+    ring_degree: int = 1
+    allgather_degree: int = 1
+    ulysses_mode: str = "strict"
+
+    @classmethod
+    def from_parallel_config(cls, config: object) -> MindIESDUSPOptions:
+        return cls(
+            enabled=bool(getattr(config, "enable_mindiesd_usp", False)),
+            ulysses_degree=int(getattr(config, "ulysses_degree", 1)),
+            ring_degree=int(getattr(config, "ring_degree", 1)),
+            allgather_degree=int(getattr(config, "allgather_degree", 1)),
+            ulysses_mode=str(getattr(config, "ulysses_mode", "strict")),
+        )
+
+
+class MindIESDUSPAdapter:
+    """Translate vLLM-Omni attention state to MindIE-SD's explicit USP ABI.
+
+    The adapter deliberately returns ``None`` when the optional fast path does
+    not cover the current semantics. The caller then executes its existing
+    native Ulysses/Ring path unchanged.
+    """
+
+    def __init__(
+        self,
+        options: MindIESDUSPOptions,
+        sp_group: SequenceParallelGroups,
+    ) -> None:
+        self.options = options
+        self.sp_group = sp_group
+        self._usp_module: ModuleType | None = None
+        self._load_attempted = False
+
+    def _load_usp_module(self) -> ModuleType | None:
+        if self._load_attempted:
+            return self._usp_module
+        self._load_attempted = True
+        try:
+            module = importlib.import_module("mindiesd.layers.usp")
+        except ImportError as exc:
+            logger.warning_once(
+                "MindIE-SD USP is enabled but mindiesd.layers.usp is unavailable; "
+                "using vLLM-Omni native sequence-parallel attention: %s",
+                exc,
+            )
+            return None
+
+        if not callable(getattr(module, "usp_attention", None)) or not isinstance(
+            getattr(module, "USPError", None), type
+        ):
+            logger.warning_once(
+                "MindIE-SD USP is enabled but its installed API is incompatible; "
+                "using vLLM-Omni native sequence-parallel attention."
+            )
+            return None
+        self._usp_module = module
+        logger.info_once("Using MindIE-SD unified sequence-parallel attention.")
+        return module
+
+    def _groups(self):
+        ulysses_group = self.sp_group.ulysses_group if self.options.ulysses_degree > 1 else None
+        if self.options.ring_degree > 1:
+            # MindIE-SD currently materializes K/V with AllGather over this
+            # group. It is numerically equivalent to Omni's Ring path but is
+            # intentionally not described as a true P2P Ring implementation.
+            kv_gather_group = self.sp_group.ring_group
+        else:
+            kv_gather_group = None
+        return ulysses_group, kv_gather_group
+
+    def _supports_call(
+        self,
+        query: torch.Tensor,
+        attn_metadata: AttentionMetadata | None,
+        *,
+        backend_name: str,
+        causal: bool,
+        softmax_scale: float,
+        scatter_dim: int,
+        gather_dim: int,
+    ) -> bool:
+        options = self.options
+        if not options.enabled or backend_name != "FLASH_ATTN":
+            return False
+        if options.allgather_degree > 1 or options.ulysses_degree * options.ring_degree == 1:
+            return False
+        if options.ulysses_mode != "strict" or causal:
+            return False
+        if scatter_dim != 2 or gather_dim != 1 or query.ndim != 4:
+            return False
+        if not math.isclose(float(softmax_scale), query.shape[-1] ** -0.5, rel_tol=1e-6, abs_tol=1e-8):
+            return False
+        if attn_metadata is None:
+            return True
+        if any(
+            tensor is not None
+            for tensor in (
+                attn_metadata.joint_query,
+                attn_metadata.joint_key,
+                attn_metadata.joint_value,
+                attn_metadata.joint_attn_mask,
+            )
+        ):
+            return False
+        # Omni may still hold a rank-local mask here; its native SP strategy
+        # normalizes that mask only after the interception point.
+        if attn_metadata.attn_mask is not None:
+            return False
+        if attn_metadata.full_attn_spans is not None or attn_metadata.query_ranges is not None:
+            return False
+        if attn_metadata.packed_padding is not None:
+            return False
+        unsupported_extra = {
+            "cu_seqlens_q",
+            "cu_seqlens_k",
+            "gate_compress",
+            "kv_cache_dtype",
+            "laser_input_scale",
+            "npu_attn_varlen",
+            "seq_lens",
+            "valid_kv_length",
+        }
+        return not unsupported_extra.intersection(attn_metadata.extra)
+
+    def try_forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        *,
+        attn_metadata: AttentionMetadata | None,
+        backend_name: str,
+        causal: bool,
+        softmax_scale: float,
+        scatter_dim: int,
+        gather_dim: int,
+    ) -> torch.Tensor | None:
+        """Run MindIE-SD once when compatible, otherwise request native fallback."""
+        if not self._supports_call(
+            query,
+            attn_metadata,
+            backend_name=backend_name,
+            causal=causal,
+            softmax_scale=softmax_scale,
+            scatter_dim=scatter_dim,
+            gather_dim=gather_dim,
+        ):
+            return None
+
+        module = self._load_usp_module()
+        if module is None:
+            return None
+
+        ulysses_group, kv_gather_group = self._groups()
+        try:
+            return module.usp_attention(
+                query,
+                key,
+                value,
+                ulysses_group=ulysses_group,
+                kv_gather_group=kv_gather_group,
+            )
+        except module.USPError as exc:
+            logger.warning_once(
+                "MindIE-SD USP rejected the current attention contract; "
+                "using vLLM-Omni native sequence-parallel attention: %s",
+                exc,
+            )
+            return None
+
+
+__all__ = ["MindIESDUSPAdapter", "MindIESDUSPOptions"]

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -233,8 +233,8 @@ class DiffusionParallelConfig:
     ulysses_a2a_permute: bool = False
     """Use fused permute-free all-to-all for eligible strict Ulysses exchanges."""
 
-    enable_mindiesd_usp: bool = False
-    """Use MindIE-SD's optional single-call sequence-parallel attention path."""
+    enable_usp: bool = False
+    """Use the platform's unified sequence-parallel attention executor."""
 
     cfg_parallel_size: int = 1
     """Number of ranks used to execute guidance passes in parallel."""

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -233,6 +233,9 @@ class DiffusionParallelConfig:
     ulysses_a2a_permute: bool = False
     """Use fused permute-free all-to-all for eligible strict Ulysses exchanges."""
 
+    enable_mindiesd_usp: bool = False
+    """Use MindIE-SD's optional single-call sequence-parallel attention path."""
+
     cfg_parallel_size: int = 1
     """Number of ranks used to execute guidance passes in parallel."""
 

--- a/vllm_omni/platforms/interface.py
+++ b/vllm_omni/platforms/interface.py
@@ -157,6 +157,16 @@ class OmniPlatform(Platform):
         return True
 
     @classmethod
+    def build_diffusion_usp_executor(
+        cls,
+        parallel_config: Any,
+        sp_group: Any,
+    ) -> Any | None:
+        """Build a platform-specific unified sequence-parallel executor."""
+
+        return None
+
+    @classmethod
     def supports_torch_inductor(cls) -> bool:
         """Check if the platform supports torch.compile with inductor backend."""
         raise NotImplementedError

--- a/vllm_omni/platforms/npu/platform.py
+++ b/vllm_omni/platforms/npu/platform.py
@@ -289,6 +289,27 @@ class NPUOmniPlatform(OmniPlatform, NPUPlatform):
         return find_spec("mindiesd") is not None
 
     @classmethod
+    def build_diffusion_usp_executor(
+        cls,
+        parallel_config: Any,
+        sp_group: Any,
+    ) -> Any | None:
+        """Build the Ascend unified sequence-parallel executor when enabled."""
+
+        if not getattr(parallel_config, "enable_usp", False):
+            return None
+
+        from vllm_omni.platforms.npu.usp import AscendUSPExecutor
+
+        return AscendUSPExecutor(
+            sp_group=sp_group,
+            ulysses_degree=int(getattr(parallel_config, "ulysses_degree", 1)),
+            ring_degree=int(getattr(parallel_config, "ring_degree", 1)),
+            allgather_degree=int(getattr(parallel_config, "allgather_degree", 1)),
+            ulysses_mode=str(getattr(parallel_config, "ulysses_mode", "strict")),
+        )
+
+    @classmethod
     def supports_torch_inductor(cls) -> bool:
         return False
 

--- a/vllm_omni/platforms/npu/usp.py
+++ b/vllm_omni/platforms/npu/usp.py
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
-"""Optional MindIE-SD unified sequence-parallel attention adapter."""
+"""Ascend implementation of unified sequence-parallel attention."""
 
 from __future__ import annotations
 
 import importlib
 import math
-from dataclasses import dataclass
 from types import ModuleType
 from typing import TYPE_CHECKING, Protocol
 
@@ -27,42 +26,27 @@ class SequenceParallelGroups(Protocol):
     ring_group: object
 
 
-@dataclass(frozen=True, slots=True)
-class MindIESDUSPOptions:
-    """vLLM-Omni-owned, normalized options for the MindIE-SD USP call."""
+class AscendUSPExecutor:
+    """Execute supported Ascend SP attention through MindIE-SD.
 
-    enabled: bool = False
-    ulysses_degree: int = 1
-    ring_degree: int = 1
-    allgather_degree: int = 1
-    ulysses_mode: str = "strict"
-
-    @classmethod
-    def from_parallel_config(cls, config: object) -> MindIESDUSPOptions:
-        return cls(
-            enabled=bool(getattr(config, "enable_mindiesd_usp", False)),
-            ulysses_degree=int(getattr(config, "ulysses_degree", 1)),
-            ring_degree=int(getattr(config, "ring_degree", 1)),
-            allgather_degree=int(getattr(config, "allgather_degree", 1)),
-            ulysses_mode=str(getattr(config, "ulysses_mode", "strict")),
-        )
-
-
-class MindIESDUSPAdapter:
-    """Translate vLLM-Omni attention state to MindIE-SD's explicit USP ABI.
-
-    The adapter deliberately returns ``None`` when the optional fast path does
-    not cover the current semantics. The caller then executes its existing
-    native Ulysses/Ring path unchanged.
+    Unsupported calls return ``None`` so the portable attention layer can use
+    its existing Ulysses/Ring implementation without duplicating collectives.
     """
 
     def __init__(
         self,
-        options: MindIESDUSPOptions,
+        *,
         sp_group: SequenceParallelGroups,
+        ulysses_degree: int,
+        ring_degree: int,
+        allgather_degree: int,
+        ulysses_mode: str,
     ) -> None:
-        self.options = options
         self.sp_group = sp_group
+        self.ulysses_degree = ulysses_degree
+        self.ring_degree = ring_degree
+        self.allgather_degree = allgather_degree
+        self.ulysses_mode = ulysses_mode
         self._usp_module: ModuleType | None = None
         self._load_attempted = False
 
@@ -74,7 +58,7 @@ class MindIESDUSPAdapter:
             module = importlib.import_module("mindiesd.layers.usp")
         except ImportError as exc:
             logger.warning_once(
-                "MindIE-SD USP is enabled but mindiesd.layers.usp is unavailable; "
+                "Ascend USP is enabled but mindiesd.layers.usp is unavailable; "
                 "using vLLM-Omni native sequence-parallel attention: %s",
                 exc,
             )
@@ -84,23 +68,17 @@ class MindIESDUSPAdapter:
             getattr(module, "USPError", None), type
         ):
             logger.warning_once(
-                "MindIE-SD USP is enabled but its installed API is incompatible; "
+                "Ascend USP is enabled but the installed MindIE-SD API is incompatible; "
                 "using vLLM-Omni native sequence-parallel attention."
             )
             return None
         self._usp_module = module
-        logger.info_once("Using MindIE-SD unified sequence-parallel attention.")
+        logger.info_once("Using the Ascend unified sequence-parallel attention executor.")
         return module
 
-    def _groups(self):
-        ulysses_group = self.sp_group.ulysses_group if self.options.ulysses_degree > 1 else None
-        if self.options.ring_degree > 1:
-            # MindIE-SD currently materializes K/V with AllGather over this
-            # group. It is numerically equivalent to Omni's Ring path but is
-            # intentionally not described as a true P2P Ring implementation.
-            kv_gather_group = self.sp_group.ring_group
-        else:
-            kv_gather_group = None
+    def _groups(self) -> tuple[object | None, object | None]:
+        ulysses_group = self.sp_group.ulysses_group if self.ulysses_degree > 1 else None
+        kv_gather_group = self.sp_group.ring_group if self.ring_degree > 1 else None
         return ulysses_group, kv_gather_group
 
     def _supports_call(
@@ -114,12 +92,11 @@ class MindIESDUSPAdapter:
         scatter_dim: int,
         gather_dim: int,
     ) -> bool:
-        options = self.options
-        if not options.enabled or backend_name != "FLASH_ATTN":
+        if backend_name != "FLASH_ATTN":
             return False
-        if options.allgather_degree > 1 or options.ulysses_degree * options.ring_degree == 1:
+        if self.allgather_degree > 1 or self.ulysses_degree * self.ring_degree == 1:
             return False
-        if options.ulysses_mode != "strict" or causal:
+        if self.ulysses_mode != "strict" or causal:
             return False
         if scatter_dim != 2 or gather_dim != 1 or query.ndim != 4:
             return False
@@ -137,8 +114,6 @@ class MindIESDUSPAdapter:
             )
         ):
             return False
-        # Omni may still hold a rank-local mask here; its native SP strategy
-        # normalizes that mask only after the interception point.
         if attn_metadata.attn_mask is not None:
             return False
         if attn_metadata.full_attn_spans is not None or attn_metadata.query_ranges is not None:
@@ -170,7 +145,7 @@ class MindIESDUSPAdapter:
         scatter_dim: int,
         gather_dim: int,
     ) -> torch.Tensor | None:
-        """Run MindIE-SD once when compatible, otherwise request native fallback."""
+        """Run the Ascend USP executor when compatible, else request fallback."""
         if not self._supports_call(
             query,
             attn_metadata,
@@ -197,11 +172,11 @@ class MindIESDUSPAdapter:
             )
         except module.USPError as exc:
             logger.warning_once(
-                "MindIE-SD USP rejected the current attention contract; "
+                "Ascend USP rejected the current attention contract; "
                 "using vLLM-Omni native sequence-parallel attention: %s",
                 exc,
             )
             return None
 
 
-__all__ = ["MindIESDUSPAdapter", "MindIESDUSPOptions"]
+__all__ = ["AscendUSPExecutor"]


### PR DESCRIPTION
## Purpose

MindIE-SD provides a single-call `usp_attention` API that can own Ulysses communication, K/V gathering, and local FlashAttention execution. vLLM-Omni currently performs sequence-parallel communication before entering the NPU FlashAttention implementation, so the integration must run before those native collectives.

This PR adds a small, opt-in, platform-owned unified sequence-parallel (USP) executor:

- adds only the technical `DiffusionParallelConfig.enable_usp` switch (no new CLI or tuning parameters);
- keeps Ulysses/Ring topology in the existing `ulysses_degree` and `ring_degree` fields;
- keeps the public attention backend as `FLASH_ATTN`;
- exposes a generic platform hook from the portable attention layer;
- keeps the MindIE-SD import, ABI mapping, and structured errors inside the Ascend platform implementation;
- calls `mindiesd.layers.usp.usp_attention(q, k, v, ...)` once before native SP communication;
- passes Omni's Ulysses process group as `ulysses_group` and its **ring process group** as `kv_gather_group`;
- leaves chunking, communication dtype, overlap, and FA dispatch at platform defaults;
- falls back to the unchanged native Ulysses/Ring path when the optional API is unavailable or raises `USPError`.

The initial eligibility boundary is intentionally conservative: Ascend NPU, strict non-causal dense `FLASH_ATTN`, default softmax scale, standard BSND/SP dimensions, and no joint/masked/paged/UAA-specific semantics.

Companion RFC: #7229.

## Test Plan

- Unit contract tests cover platform selection, group mapping (including `kv_gather_group == ring_group`), delegation before native collectives, inactive-SP behavior, unsupported-semantics fallback, and exception handling.
- Passed locally:
  - Ruff check and format on all changed Python files.
  - `python -m compileall` on changed production modules.
  - pre-commit debug/end-of-file/line-ending/whitespace/typos/test-mark/SPDX/forbidden-import/torch.cuda hooks.
  - isolated Ascend USP contract smoke with a fake MindIE module.
  - `git diff --check`.
- Environment gaps:
  - Full pytest collection requires PyTorch and the complete Linux vLLM runtime; this Windows Python 3.14 environment has no PyTorch.
  - Ascend multi-rank numerical and performance validation requires an NPU environment with the matching MindIE-SD build.
  - mypy reports four pre-existing errors in `platforms/interface.py` and `attention/layer.py`; the new NPU USP module and tests introduce no additional mypy errors.

**vLLM Version:** `d4004455d2`

**vLLM-Omni Commit:** base `30d6a0b4e`, current PR head `3c8d9f81b`

## Test Result

Static checks and the isolated ABI contract pass. This PR remains a draft pending RFC feedback and Ascend multi-rank validation; it makes no measured performance claim yet.