### PR TITLE
[Bugfix] Make LTX vocoder decoding deterministic

### DIFF
--- a/tests/diffusion/models/ltx2/test_ltx2_vae.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_vae.py
@@ -12,6 +12,29 @@ import torch
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 
+@pytest.mark.parametrize("initial_deterministic", [False, True])
+@pytest.mark.parametrize("fail", [False, True])
+def test_ltx_vocoder_deterministic_context(monkeypatch, initial_deterministic, fail):
+    from vllm_omni.diffusion.models.ltx2.ltx2_runtime import _deterministic_ltx_vocoder
+
+    monkeypatch.setattr(torch.backends.cudnn, "deterministic", initial_deterministic)
+    if torch.backends.cudnn.is_available():
+        monkeypatch.setattr(torch.backends.cudnn, "benchmark_limit", 17)
+    settings = {
+        name: getattr(torch.backends.cudnn, name) for name in ("enabled", "benchmark", "benchmark_limit", "allow_tf32")
+    }
+    try:
+        with _deterministic_ltx_vocoder():
+            assert torch.backends.cudnn.deterministic
+            assert {name: getattr(torch.backends.cudnn, name) for name in settings} == settings
+            if fail:
+                raise RuntimeError("injected failure")
+    except RuntimeError as exc:
+        assert fail and str(exc) == "injected failure"
+    assert torch.backends.cudnn.deterministic == initial_deterministic
+    assert {name: getattr(torch.backends.cudnn, name) for name in settings} == settings
+
+
 def test_ltx_base_vocoder_keeps_native_dtype(monkeypatch):
     import vllm_omni.diffusion.models.ltx2.ltx2_runtime as ltx_runtime
 

--- a/tests/diffusion/models/ltx2/test_ltx2_vocoder_cuda.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_vocoder_cuda.py
@@ -1,10 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-"""Regression tests for scoped LTX vocoder determinism and precision."""
-
-import sys
-from types import ModuleType, SimpleNamespace
+"""CUDA regression tests for LTX-2 BWE vocoder precision."""
 
 import pytest
 import torch
@@ -14,109 +11,38 @@ from tests.helpers.mark import hardware_test
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion]
 
 
-def _cudnn_settings():
-    return (
-        torch.backends.cudnn.enabled,
-        torch.backends.cudnn.benchmark,
-        torch.backends.cudnn.benchmark_limit,
-        torch.backends.cudnn.allow_tf32,
-    )
-
-
 class _BWEConvVocoder(torch.nn.Module):
-    def __init__(self, bwe, fail):
+    def __init__(self):
         super().__init__()
         self.conv = torch.nn.Conv1d(
-            4,
-            4,
-            kernel_size=3,
+            1,
+            1,
+            kernel_size=1,
             bias=False,
             device="cuda",
             dtype=torch.bfloat16,
         )
-        if bwe:
-            self.bwe_generator = torch.nn.Identity()
-        self.fail = fail
+        self.bwe_generator = torch.nn.Identity()
         self.input_dtype = None
         self.conv_output_dtype = None
-        self.cudnn_deterministic = None
 
     def forward(self, value):
-        self.cudnn_deterministic = torch.backends.cudnn.deterministic
-        self.cudnn_settings = _cudnn_settings()
         self.input_dtype = value.dtype
-        if self.fail:
-            raise RuntimeError("injected vocoder failure")
         output = self.conv(value)
         self.conv_output_dtype = output.dtype
         return output
 
 
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
-@pytest.mark.parametrize("bwe", [False, True])
-@pytest.mark.parametrize("initial_deterministic", [False, True])
-@pytest.mark.parametrize("fail", [False, True])
-@torch.inference_mode()
-def test_ltx_vocoder_determinism_and_precision(monkeypatch, bwe, initial_deterministic, fail):
+def test_ltx_bwe_vocoder_runs_real_cuda_autocast_in_fp32():
     from vllm_omni.diffusion.models.ltx2.ltx2_runtime import _run_ltx_vocoder
 
-    vocoder = _BWEConvVocoder(bwe, fail)
-    generated_mel = torch.randn((1, 4, 128), device="cuda", dtype=torch.bfloat16)
-    monkeypatch.setattr(torch.backends.cudnn, "deterministic", initial_deterministic)
-    monkeypatch.setattr(torch.backends.cudnn, "benchmark", True)
-    monkeypatch.setattr(torch.backends.cudnn, "benchmark_limit", 17)
-    settings = _cudnn_settings()
-    if fail:
-        with pytest.raises(RuntimeError, match="injected vocoder failure"):
-            _run_ltx_vocoder(vocoder, generated_mel)
-    else:
-        outputs = [_run_ltx_vocoder(vocoder, generated_mel) for _ in range(3)]
-        assert all(torch.equal(outputs[0], output) for output in outputs[1:])
-        assert outputs[0].dtype == torch.bfloat16
-        assert vocoder.conv_output_dtype == (torch.float32 if bwe else torch.bfloat16)
+    vocoder = _BWEConvVocoder()
+    generated_mel = torch.ones((1, 1, 4), device="cuda", dtype=torch.bfloat16)
 
-    assert torch.backends.cudnn.deterministic == initial_deterministic
-    assert _cudnn_settings() == settings
-    assert vocoder.cudnn_settings == settings
+    output = _run_ltx_vocoder(vocoder, generated_mel)
+
     assert next(vocoder.parameters()).dtype == torch.bfloat16
-    assert vocoder.cudnn_deterministic
-    assert vocoder.input_dtype == (torch.float32 if bwe else torch.bfloat16)
-
-
-@pytest.mark.cpu
-@pytest.mark.parametrize("initial_deterministic", [False, True])
-@pytest.mark.parametrize("fail", [False, True])
-def test_official_vocoder_determinism_restores_settings(monkeypatch, initial_deterministic, fail):
-    from tests.e2e.accuracy.ltx.run_ltx25_reference import _configure_official_vocoder_determinism
-
-    monkeypatch.setattr(torch.backends.cudnn, "deterministic", initial_deterministic)
-    if torch.backends.cudnn.is_available():
-        monkeypatch.setattr(torch.backends.cudnn, "benchmark_limit", 17)
-    settings = _cudnn_settings()
-    calls = []
-
-    class FakeVocoder:
-        def forward(self, mel):
-            calls.append(mel)
-            assert torch.backends.cudnn.deterministic
-            assert _cudnn_settings() == settings
-            if fail:
-                raise RuntimeError("injected official failure")
-            return mel
-
-    module = ModuleType("ltx_core.model.audio_vae.vocoder")
-    module.VocoderWithBWE = FakeVocoder
-    monkeypatch.setitem(sys.modules, module.__name__, module)
-    _configure_official_vocoder_determinism()
-    wrapped = FakeVocoder.forward
-    _configure_official_vocoder_determinism()
-    assert FakeVocoder.forward is wrapped
-    mel = SimpleNamespace(device=SimpleNamespace(type="cuda"))
-    if fail:
-        with pytest.raises(RuntimeError, match="injected official failure"):
-            FakeVocoder().forward(mel)
-    else:
-        assert FakeVocoder().forward(mel) is mel
-    assert calls == [mel]
-    assert torch.backends.cudnn.deterministic == initial_deterministic
-    assert _cudnn_settings() == settings
+    assert vocoder.input_dtype == torch.float32
+    assert vocoder.conv_output_dtype == torch.float32
+    assert output.dtype == torch.bfloat16

--- a/tests/diffusion/models/ltx2/test_ltx2_vocoder_cuda.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_vocoder_cuda.py
@@ -25,8 +25,10 @@ class _BWEConvVocoder(torch.nn.Module):
         self.bwe_generator = torch.nn.Identity()
         self.input_dtype = None
         self.conv_output_dtype = None
+        self.cudnn_deterministic = None
 
     def forward(self, value):
+        self.cudnn_deterministic = torch.backends.cudnn.deterministic
         self.input_dtype = value.dtype
         output = self.conv(value)
         self.conv_output_dtype = output.dtype
@@ -40,9 +42,16 @@ def test_ltx_bwe_vocoder_runs_real_cuda_autocast_in_fp32():
     vocoder = _BWEConvVocoder()
     generated_mel = torch.ones((1, 1, 4), device="cuda", dtype=torch.bfloat16)
 
-    output = _run_ltx_vocoder(vocoder, generated_mel)
+    original_deterministic = torch.backends.cudnn.deterministic
+    torch.backends.cudnn.deterministic = False
+    try:
+        output = _run_ltx_vocoder(vocoder, generated_mel)
+        assert not torch.backends.cudnn.deterministic
+    finally:
+        torch.backends.cudnn.deterministic = original_deterministic
 
     assert next(vocoder.parameters()).dtype == torch.bfloat16
+    assert vocoder.cudnn_deterministic
     assert vocoder.input_dtype == torch.float32
     assert vocoder.conv_output_dtype == torch.float32
     assert output.dtype == torch.bfloat16

--- a/tests/diffusion/models/ltx2/test_ltx2_vocoder_cuda.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_vocoder_cuda.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-"""CUDA regression tests for LTX-2 BWE vocoder precision."""
+"""Regression tests for scoped LTX vocoder determinism and precision."""
+
+import sys
+from types import ModuleType, SimpleNamespace
 
 import pytest
 import torch
@@ -11,47 +14,109 @@ from tests.helpers.mark import hardware_test
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion]
 
 
+def _cudnn_settings():
+    return (
+        torch.backends.cudnn.enabled,
+        torch.backends.cudnn.benchmark,
+        torch.backends.cudnn.benchmark_limit,
+        torch.backends.cudnn.allow_tf32,
+    )
+
+
 class _BWEConvVocoder(torch.nn.Module):
-    def __init__(self):
+    def __init__(self, bwe, fail):
         super().__init__()
         self.conv = torch.nn.Conv1d(
-            1,
-            1,
-            kernel_size=1,
+            4,
+            4,
+            kernel_size=3,
             bias=False,
             device="cuda",
             dtype=torch.bfloat16,
         )
-        self.bwe_generator = torch.nn.Identity()
+        if bwe:
+            self.bwe_generator = torch.nn.Identity()
+        self.fail = fail
         self.input_dtype = None
         self.conv_output_dtype = None
         self.cudnn_deterministic = None
 
     def forward(self, value):
         self.cudnn_deterministic = torch.backends.cudnn.deterministic
+        self.cudnn_settings = _cudnn_settings()
         self.input_dtype = value.dtype
+        if self.fail:
+            raise RuntimeError("injected vocoder failure")
         output = self.conv(value)
         self.conv_output_dtype = output.dtype
         return output
 
 
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
-def test_ltx_bwe_vocoder_runs_real_cuda_autocast_in_fp32():
+@pytest.mark.parametrize("bwe", [False, True])
+@pytest.mark.parametrize("initial_deterministic", [False, True])
+@pytest.mark.parametrize("fail", [False, True])
+@torch.inference_mode()
+def test_ltx_vocoder_determinism_and_precision(monkeypatch, bwe, initial_deterministic, fail):
     from vllm_omni.diffusion.models.ltx2.ltx2_runtime import _run_ltx_vocoder
 
-    vocoder = _BWEConvVocoder()
-    generated_mel = torch.ones((1, 1, 4), device="cuda", dtype=torch.bfloat16)
+    vocoder = _BWEConvVocoder(bwe, fail)
+    generated_mel = torch.randn((1, 4, 128), device="cuda", dtype=torch.bfloat16)
+    monkeypatch.setattr(torch.backends.cudnn, "deterministic", initial_deterministic)
+    monkeypatch.setattr(torch.backends.cudnn, "benchmark", True)
+    monkeypatch.setattr(torch.backends.cudnn, "benchmark_limit", 17)
+    settings = _cudnn_settings()
+    if fail:
+        with pytest.raises(RuntimeError, match="injected vocoder failure"):
+            _run_ltx_vocoder(vocoder, generated_mel)
+    else:
+        outputs = [_run_ltx_vocoder(vocoder, generated_mel) for _ in range(3)]
+        assert all(torch.equal(outputs[0], output) for output in outputs[1:])
+        assert outputs[0].dtype == torch.bfloat16
+        assert vocoder.conv_output_dtype == (torch.float32 if bwe else torch.bfloat16)
 
-    original_deterministic = torch.backends.cudnn.deterministic
-    torch.backends.cudnn.deterministic = False
-    try:
-        output = _run_ltx_vocoder(vocoder, generated_mel)
-        assert not torch.backends.cudnn.deterministic
-    finally:
-        torch.backends.cudnn.deterministic = original_deterministic
-
+    assert torch.backends.cudnn.deterministic == initial_deterministic
+    assert _cudnn_settings() == settings
+    assert vocoder.cudnn_settings == settings
     assert next(vocoder.parameters()).dtype == torch.bfloat16
     assert vocoder.cudnn_deterministic
-    assert vocoder.input_dtype == torch.float32
-    assert vocoder.conv_output_dtype == torch.float32
-    assert output.dtype == torch.bfloat16
+    assert vocoder.input_dtype == (torch.float32 if bwe else torch.bfloat16)
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("initial_deterministic", [False, True])
+@pytest.mark.parametrize("fail", [False, True])
+def test_official_vocoder_determinism_restores_settings(monkeypatch, initial_deterministic, fail):
+    from tests.e2e.accuracy.ltx.run_ltx25_reference import _configure_official_vocoder_determinism
+
+    monkeypatch.setattr(torch.backends.cudnn, "deterministic", initial_deterministic)
+    if torch.backends.cudnn.is_available():
+        monkeypatch.setattr(torch.backends.cudnn, "benchmark_limit", 17)
+    settings = _cudnn_settings()
+    calls = []
+
+    class FakeVocoder:
+        def forward(self, mel):
+            calls.append(mel)
+            assert torch.backends.cudnn.deterministic
+            assert _cudnn_settings() == settings
+            if fail:
+                raise RuntimeError("injected official failure")
+            return mel
+
+    module = ModuleType("ltx_core.model.audio_vae.vocoder")
+    module.VocoderWithBWE = FakeVocoder
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    _configure_official_vocoder_determinism()
+    wrapped = FakeVocoder.forward
+    _configure_official_vocoder_determinism()
+    assert FakeVocoder.forward is wrapped
+    mel = SimpleNamespace(device=SimpleNamespace(type="cuda"))
+    if fail:
+        with pytest.raises(RuntimeError, match="injected official failure"):
+            FakeVocoder().forward(mel)
+    else:
+        assert FakeVocoder().forward(mel) is mel
+    assert calls == [mel]
+    assert torch.backends.cudnn.deterministic == initial_deterministic
+    assert _cudnn_settings() == settings

--- a/tests/e2e/accuracy/ltx/run_ltx25_reference.py
+++ b/tests/e2e/accuracy/ltx/run_ltx25_reference.py
@@ -114,6 +114,30 @@ def _insert_official_paths(official_root: Path) -> None:
             sys.path.insert(0, path)
 
 
+def _configure_official_vocoder_determinism() -> None:
+    """Make the pinned official LTX-2.5 vocoder a stable reference."""
+    from ltx_core.model.audio_vae.vocoder import VocoderWithBWE
+
+    original_forward = VocoderWithBWE.forward
+    if getattr(original_forward, "_vllm_omni_deterministic", False):
+        return
+
+    def deterministic_forward(self: Any, mel_spec: torch.Tensor) -> torch.Tensor:
+        device_type = mel_spec.device.type
+        if device_type != "cuda":
+            return original_forward(self, mel_spec)
+        with torch.backends.cudnn.flags(
+            enabled=torch.backends.cudnn.enabled,
+            benchmark=torch.backends.cudnn.benchmark,
+            deterministic=True,
+            allow_tf32=torch.backends.cudnn.allow_tf32,
+        ):
+            return original_forward(self, mel_spec)
+
+    setattr(deterministic_forward, "_vllm_omni_deterministic", True)
+    setattr(VocoderWithBWE, "forward", deterministic_forward)
+
+
 def _configure_official_sdpa(pipeline: Any) -> None:
     """Pin official connector and denoiser attention to cuDNN, with MATH fallback."""
     from ltx_core.loader.attention_ops import set_attention_module_op
@@ -187,6 +211,7 @@ def _run_official(args: argparse.Namespace, request: dict[str, Any]) -> None:
     if args.official_root is None:
         raise ValueError("Official backend requires --official-root")
     _insert_official_paths(args.official_root)
+    _configure_official_vocoder_determinism()
     # Keep Gemma on the same SDPA path in both subprocesses. DiT attention is
     # still pinned independently to the explicit cuDNN backend below.
     torch.backends.cuda.enable_cudnn_sdp(False)

--- a/tests/e2e/accuracy/ltx/run_ltx25_reference.py
+++ b/tests/e2e/accuracy/ltx/run_ltx25_reference.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 """Generate raw LTX video and audio outputs with the official or Omni runtime."""
 

--- a/tests/e2e/accuracy/ltx/run_ltx25_reference.py
+++ b/tests/e2e/accuracy/ltx/run_ltx25_reference.py
@@ -126,13 +126,12 @@ def _configure_official_vocoder_determinism() -> None:
         device_type = mel_spec.device.type
         if device_type != "cuda":
             return original_forward(self, mel_spec)
-        with torch.backends.cudnn.flags(
-            enabled=torch.backends.cudnn.enabled,
-            benchmark=torch.backends.cudnn.benchmark,
-            deterministic=True,
-            allow_tf32=torch.backends.cudnn.allow_tf32,
-        ):
+        previous = torch.backends.cudnn.deterministic
+        try:
+            torch.backends.cudnn.deterministic = True
             return original_forward(self, mel_spec)
+        finally:
+            torch.backends.cudnn.deterministic = previous
 
     setattr(deterministic_forward, "_vllm_omni_deterministic", True)
     setattr(VocoderWithBWE, "forward", deterministic_forward)

--- a/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
@@ -67,25 +67,36 @@ logger = init_logger(__name__)
 
 def _run_ltx_vocoder(vocoder: nn.Module, generated_mel: torch.Tensor) -> torch.Tensor:
     """Run the BWE vocoder in FP32, matching the official LTX pipeline."""
-    if not hasattr(vocoder, "bwe_generator"):
-        return vocoder(generated_mel)
-
-    input_dtype = generated_mel.dtype
     device_type = generated_mel.device.type
-    module_dtype = next(vocoder.parameters()).dtype
-    if device_type == "mps":
-        if module_dtype != torch.float32:
-            vocoder.float()
-        try:
-            return vocoder(generated_mel.float()).to(input_dtype)
-        finally:
-            if module_dtype != torch.float32:
-                vocoder.to(module_dtype)
+    cudnn_context = (
+        torch.backends.cudnn.flags(
+            enabled=torch.backends.cudnn.enabled,
+            benchmark=torch.backends.cudnn.benchmark,
+            deterministic=True,
+            allow_tf32=torch.backends.cudnn.allow_tf32,
+        )
+        if device_type == "cuda"
+        else nullcontext()
+    )
+    with cudnn_context:
+        if not hasattr(vocoder, "bwe_generator"):
+            return vocoder(generated_mel)
 
-    # BF16 errors compound through the BWE model's long convolution stack.
-    # FP32 autocast upcasts each op without materializing a second FP32 model.
-    with torch.autocast(device_type=device_type, dtype=torch.float32):
-        return vocoder(generated_mel.float()).to(input_dtype)
+        input_dtype = generated_mel.dtype
+        module_dtype = next(vocoder.parameters()).dtype
+        if device_type == "mps":
+            if module_dtype != torch.float32:
+                vocoder.float()
+            try:
+                return vocoder(generated_mel.float()).to(input_dtype)
+            finally:
+                if module_dtype != torch.float32:
+                    vocoder.to(module_dtype)
+
+        # BF16 errors compound through the BWE model's long convolution stack.
+        # FP32 autocast upcasts each op without materializing a second FP32 model.
+        with torch.autocast(device_type=device_type, dtype=torch.float32):
+            return vocoder(generated_mel.float()).to(input_dtype)
 
 
 def _prepare_ltx2_video_output(

--- a/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
@@ -65,19 +65,20 @@ from .ltx2_request import (
 logger = init_logger(__name__)
 
 
+@contextmanager
+def _deterministic_ltx_vocoder():
+    previous = torch.backends.cudnn.deterministic
+    try:
+        torch.backends.cudnn.deterministic = True
+        yield
+    finally:
+        torch.backends.cudnn.deterministic = previous
+
+
 def _run_ltx_vocoder(vocoder: nn.Module, generated_mel: torch.Tensor) -> torch.Tensor:
     """Run the BWE vocoder in FP32, matching the official LTX pipeline."""
     device_type = generated_mel.device.type
-    cudnn_context = (
-        torch.backends.cudnn.flags(
-            enabled=torch.backends.cudnn.enabled,
-            benchmark=torch.backends.cudnn.benchmark,
-            deterministic=True,
-            allow_tf32=torch.backends.cudnn.allow_tf32,
-        )
-        if device_type == "cuda"
-        else nullcontext()
-    )
+    cudnn_context = _deterministic_ltx_vocoder() if device_type == "cuda" else nullcontext()
     with cudnn_context:
         if not hasattr(vocoder, "bwe_generator"):
             return vocoder(generated_mel)


### PR DESCRIPTION
## Summary

Repeated LTX vocoder calls with identical mel inputs can produce different audio when cuDNN selects nondeterministic convolution algorithms. Temporarily enable `cudnn.deterministic` during CUDA vocoder execution and restore its previous value on both success and failure. Other cuDNN settings and the existing BWE FP32 handling are preserved.

Apply the same setting to the pinned official BWE vocoder used by the accuracy reference runner. This change is independent of DiffVAE tiling and operator optimizations.

## Validation

### Similarity failure motivating this fix

The eager NVIDIA H200 run of `test_ltx25_distilled_two_stage_matches_official` (`task=t2v`) failed only the audio relative-L2 threshold.

| Metric | Failing run | Unfixed rerun | Deterministic vocoders | Acceptance |
|---|---:|---:|---:|---:|
| Audio relative-L2 | **0.10105968 (FAIL)** | 0.01237781 | 0.00607631 | <= 0.10 |
| Audio cosine | 0.99490147 | 0.99992417 | 0.99998216 | >= 0.99 |
| Audio max absolute error | 0.00053406 | 0.00004160 | 0.00002670 | Diagnostic only |

The deterministic distilled-T2V case was run independently twice: the initial targeted validation and the subsequent full six-case rerun. Both produced exactly **audio relative-L2 = 0.006076306110274279** and **audio cosine = 0.9999821597405034**. SHA-256 checks also match across runs for the official audio artifacts and, separately, for the Omni audio artifacts. Thus the repeated runs reproduce identical audio outputs within each implementation, not merely the same rounded metric; the remaining official-versus-Omni difference is stable in these runs.

Passing an unfixed rerun did not resolve the instability. Subsequent fixed-mel probes isolated non-bitwise output in both the Diffusers and pinned-official vocoders without CUDA RNG consumption. Enabling cuDNN determinism yielded bitwise-equal repeated outputs within and across two fresh processes for each implementation.

These are historical investigation results, not a fresh similarity run of this PR head.

### Current branch checks

- 25 existing CPU VAE tests and 4 direct deterministic-context tests passed.
- The new tests check that the flag is enabled inside the context, restored to either initial value after normal or exceptional exit, and that other cuDNN settings are preserved. They do not simulate a vocoder or claim to reproduce numerical nondeterminism.
- The pre-existing CUDA vocoder precision test is unchanged.
- Ruff, formatting and diff checks passed. The new CPU cases are collected by the existing `Simple · Diffusion Test` CI job.
- Actual audio determinism is supported by the similarity and fixed-mel experiments above.

cuDNN policy remains process-wide; the temporary setting assumes serialized model execution within a worker.
