### PR TITLE
[CI][ROCm] Route LTX2 Ulysses parity to two-GPU lane

### DIFF
--- a/.buildkite/amd/test-amd-ready.yml
+++ b/.buildkite/amd/test-amd-ready.yml
@@ -127,9 +127,12 @@ steps:
       mirror_hardwares: [amdproduction]
       grade: Blocking
       commands:
+        # Preserve legacy one-GPU tests without cards_1 while excluding every
+        # registered multi-GPU marker from this one-GPU job.
         - >-
           timeout 15m pytest -sv tests/diffusion/models/
-          -m 'core_model and cuda and not cards_2'
+          -m 'core_model and cuda and not
+          (cards_2 or cards_3 or cards_4 or cards_5 or cards_6 or cards_7 or cards_8)'
           --run-level "core_model"
 
     - label: "Diffusion · Wan22 Test"

--- a/.buildkite/amd/test-amd-ready.yml
+++ b/.buildkite/amd/test-amd-ready.yml
@@ -107,6 +107,11 @@ steps:
         - export VLLM_LOGGING_LEVEL=DEBUG
         - export VLLM_WORKER_MULTIPROC_METHOD=spawn
         - timeout 20m pytest -s -v tests/diffusion/distributed/test_sequence_parallel.py -m core_model
+        - >-
+          timeout 20m pytest -s -v
+          tests/diffusion/models/ltx2/test_ltx2_transformer_ulysses.py
+          -m 'core_model and rocm and cards_2'
+          --run-level "core_model"
 
     - label: "Diffusion GPU Worker Test"
       agent_pool: mi300_2
@@ -122,7 +127,10 @@ steps:
       mirror_hardwares: [amdproduction]
       grade: Blocking
       commands:
-        - timeout 15m pytest -sv tests/diffusion/models/ -m 'core_model and cuda' --run-level "core_model"
+        - >-
+          timeout 15m pytest -sv tests/diffusion/models/
+          -m 'core_model and cuda and not cards_2'
+          --run-level "core_model"
 
     - label: "Diffusion · Wan22 Test"
       agent_pool: mi300_1

--- a/tests/buildkite/test_amd_pipeline.py
+++ b/tests/buildkite/test_amd_pipeline.py
@@ -10,11 +10,10 @@ import yaml
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 AMD_MERGE_PIPELINE = Path(".buildkite/amd/test-amd-merge.yml")
-AMD_READY_PIPELINE = Path(".buildkite/amd/test-amd-ready.yml")
 
 
-def _find_step(label: str, pipeline_path: Path = AMD_MERGE_PIPELINE) -> dict:
-    pipeline = yaml.safe_load(pipeline_path.read_text(encoding="utf-8"))
+def _find_step(label: str) -> dict:
+    pipeline = yaml.safe_load(AMD_MERGE_PIPELINE.read_text(encoding="utf-8"))
 
     def walk(steps: list[dict]) -> dict | None:
         for step in steps:
@@ -41,21 +40,3 @@ def test_qwen3_tts_base_preserves_advanced_model_arguments() -> None:
     run_level_index = argv.index("--run-level")
     assert argv[marker_index + 1] == "advanced_model and cuda"
     assert argv[run_level_index + 1] == "advanced_model"
-
-
-def test_ltx2_ulysses_uses_two_gpu_amd_lane() -> None:
-    model_step = _find_step("Diffusion · Model Test", AMD_READY_PIPELINE)
-    assert model_step["agent_pool"] == "mi300_1"
-    model_command = next(command for command in model_step["commands"] if "pytest" in command)
-    model_argv = split(model_command)
-    model_marker_index = model_argv.index("-m")
-    assert model_argv[model_marker_index + 1] == "core_model and cuda and not cards_2"
-
-    sp_step = _find_step("Diffusion Sequence Parallelism Test", AMD_READY_PIPELINE)
-    assert sp_step["agent_pool"] == "mi300_2"
-    ltx_command = next(command for command in sp_step["commands"] if "test_ltx2_transformer_ulysses.py" in command)
-    ltx_argv = split(ltx_command)
-    marker_index = ltx_argv.index("-m")
-    run_level_index = ltx_argv.index("--run-level")
-    assert ltx_argv[marker_index + 1] == "core_model and rocm and cards_2"
-    assert ltx_argv[run_level_index + 1] == "core_model"

--- a/tests/buildkite/test_amd_pipeline.py
+++ b/tests/buildkite/test_amd_pipeline.py
@@ -10,10 +10,11 @@ import yaml
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 AMD_MERGE_PIPELINE = Path(".buildkite/amd/test-amd-merge.yml")
+AMD_READY_PIPELINE = Path(".buildkite/amd/test-amd-ready.yml")
 
 
-def _find_step(label: str) -> dict:
-    pipeline = yaml.safe_load(AMD_MERGE_PIPELINE.read_text(encoding="utf-8"))
+def _find_step(label: str, pipeline_path: Path = AMD_MERGE_PIPELINE) -> dict:
+    pipeline = yaml.safe_load(pipeline_path.read_text(encoding="utf-8"))
 
     def walk(steps: list[dict]) -> dict | None:
         for step in steps:
@@ -40,3 +41,21 @@ def test_qwen3_tts_base_preserves_advanced_model_arguments() -> None:
     run_level_index = argv.index("--run-level")
     assert argv[marker_index + 1] == "advanced_model and cuda"
     assert argv[run_level_index + 1] == "advanced_model"
+
+
+def test_ltx2_ulysses_uses_two_gpu_amd_lane() -> None:
+    model_step = _find_step("Diffusion · Model Test", AMD_READY_PIPELINE)
+    assert model_step["agent_pool"] == "mi300_1"
+    model_command = next(command for command in model_step["commands"] if "pytest" in command)
+    model_argv = split(model_command)
+    model_marker_index = model_argv.index("-m")
+    assert model_argv[model_marker_index + 1] == "core_model and cuda and not cards_2"
+
+    sp_step = _find_step("Diffusion Sequence Parallelism Test", AMD_READY_PIPELINE)
+    assert sp_step["agent_pool"] == "mi300_2"
+    ltx_command = next(command for command in sp_step["commands"] if "test_ltx2_transformer_ulysses.py" in command)
+    ltx_argv = split(ltx_command)
+    marker_index = ltx_argv.index("-m")
+    run_level_index = ltx_argv.index("--run-level")
+    assert ltx_argv[marker_index + 1] == "core_model and rocm and cards_2"
+    assert ltx_argv[run_level_index + 1] == "core_model"

--- a/tests/diffusion/models/ltx2/test_ltx2_transformer_ulysses.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_transformer_ulysses.py
@@ -156,10 +156,14 @@ def _run_transformer_parity(rank: int, world_size: int, master_port: int) -> Non
 
 
 @pytest.mark.full_model
-@hardware_test(res={"cuda": "L4"}, num_cards=2)
+@hardware_test(res={"cuda": "L4", "rocm": "MI325"}, num_cards=2)
 def test_ltx_ulysses_transformer_matches_sp1(unused_tcp_port) -> None:
     """Exercise real plan hooks, RoPE/timestep sharding, and attention routing."""
     world_size = 2
+    device_count = current_omni_platform.device_count()
+    assert device_count >= world_size, (
+        f"LTX Ulysses parity requires {world_size} accelerator devices; only {device_count} are visible"
+    )
     torch.multiprocessing.spawn(
         _run_transformer_parity,
         args=(world_size, unused_tcp_port),


### PR DESCRIPTION
## Summary

- exclude all registered multi-GPU tests (`cards_2` through `cards_8`) from the generic one-GPU AMD diffusion model job while preserving legacy one-GPU tests without a `cards_1` marker
- run the LTX2 Ulysses parity test in the existing `mi300_2` sequence-parallel job
- mark the parity test for ROCm and fail early with a clear message if fewer than two accelerator devices are visible

## Context

[AMD Buildkite #11506](https://buildkite.com/vllm/vllm-omni-amd-ci/builds/11506#01a07ecb-d519-4723-bad3-2bef624ab928) failed in `mi300_1: Diffusion · Model Test` when rank 1 selected GPU 1 on a one-GPU worker, producing `invalid device ordinal`. The same unrelated failure occurred in [AMD Buildkite #11483](https://buildkite.com/vllm/vllm-omni-amd-ci/builds/11483) for #7079.

This is separate from #7225: its changed duplex-reaper test job completed both immediate and delayed variants with `2514 passed`. The failure is a deterministic routing problem already present on `main`.

## Validation

- `pytest -q -o addopts='' --confcutdir=tests/buildkite tests/buildkite/test_amd_pipeline.py` (`1 passed`)
- `pre-commit run --files .buildkite/amd/test-amd-ready.yml tests/diffusion/models/ltx2/test_ltx2_transformer_ulysses.py`
- `python3 -m compileall -q tests/diffusion/models/ltx2/test_ltx2_transformer_ulysses.py`
- hardware marker helper suite: `21 passed` with platform imports stubbed because the local macOS environment does not include `torch`/`vllm`

Exact-head AMD GPU execution remains pending CI.
