### PR TITLE
[Bugfix][Magi2] Allow import without an active Triton driver

### DIFF
--- a/vllm_omni/diffusion/models/magi2/mh_moe.py
+++ b/vllm_omni/diffusion/models/magi2/mh_moe.py
@@ -21,7 +21,7 @@ from typing import Literal
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from vllm.triton_utils import tl, triton
+from vllm.triton_utils import HAS_TRITON, tl, triton
 
 from vllm_omni.platforms import current_omni_platform
 
@@ -133,9 +133,10 @@ def torch_mh_moe_forward(
     return output
 
 
-_SWIGLU7_ALPHA = tl.constexpr(1.702)
-_SWIGLU7_LIMIT = tl.constexpr(7.0)
-_SWIGLU7_BIAS = tl.constexpr(1.0)
+# vLLM's no-Triton placeholder exposes ``tl.constexpr`` as ``None``.
+_SWIGLU7_ALPHA = tl.constexpr(1.702) if HAS_TRITON else 1.702
+_SWIGLU7_LIMIT = tl.constexpr(7.0) if HAS_TRITON else 7.0
+_SWIGLU7_BIAS = tl.constexpr(1.0) if HAS_TRITON else 1.0
 
 
 @triton.jit
@@ -198,7 +199,7 @@ def _mh_moe_kernel(
     block_t: tl.constexpr,
     block_dh: tl.constexpr,
     block_de: tl.constexpr,
-    acc_dtype: tl.constexpr = tl.float32,
+    acc_dtype: tl.constexpr,
     deterministic: tl.constexpr = False,
 ):
     tile_id = tl.program_id(0)


### PR DESCRIPTION
## Purpose

Fix the Magi2 module import when vLLM disables Triton because no active accelerator driver is visible.

### What broke

The CPU/Gloo Magi2 DLO regression failed while spawned workers imported `mh_moe.py`:

```text
vllm_omni/diffusion/models/magi2/mh_moe.py:136
_SWIGLU7_ALPHA = tl.constexpr(1.702)
TypeError: 'NoneType' object is not callable
```

This was observed in [AMD CI build #11506](https://buildkite.com/vllm/vllm-omni-amd-ci/builds/11506) while testing #7225. The identical failure also occurred on its `main` base commit `b1ec136b` in [AMD CI build #11504](https://buildkite.com/vllm/vllm-omni-amd-ci/builds/11504), so it is independent of #7225.

### Reproduction

```bash
CUDA_VISIBLE_DEVICES="" pytest -sv \
  tests/diffusion/models/magi2/test_native_dlo_allgather.py::test_dlo_mmap_transform_dp_shard_and_allgather_for_dp4_and_dp2sp2
```

### Root cause and fix

When Triton is unavailable, `vllm.triton_utils` supplies a placeholder whose `tl.constexpr` attribute is `None`. Magi2 called it at module import time even though this CPU/Gloo path does not execute the Triton kernel.

Use ordinary numeric constants only for the no-Triton fallback. When Triton is available, the existing `tl.constexpr` values and GPU kernel behavior are unchanged.

## Test Plan

The existing four-process Gloo test above exercises the failing import path in AMD CI.

**vLLM Version:** v0.28.0

**vLLM-Omni Commit:** 10be9839e699b188fa5c818715b9d2b2983c38d8

## Test Result

- `git diff --check origin/main...HEAD` — passed
- `python3 -m compileall -q vllm_omni/diffusion/models/magi2/mh_moe.py` — passed
- `pre-commit run --files vllm_omni/diffusion/models/magi2/mh_moe.py` — passed
- Focused pytest not run locally because this Mac does not have `torch` or `vllm`; exact-head AMD runtime validation is pending CI.
