### PR TITLE
[Bugfix] Build the forced-aligner prompt without a chat template (word timestamps one bin late)

### DIFF
--- a/tests/utils/test_qwen3_force_align_processor.py
+++ b/tests/utils/test_qwen3_force_align_processor.py
@@ -10,7 +10,21 @@ def test_build_prompt_has_boundary_timestamp_markers():
 
     assert prompt.count("<timestamp>") == 4
     assert "hello<timestamp><timestamp>world" in prompt
-    assert prompt.endswith("<|im_start|>assistant\n")
+    # Official aligner format: audio placeholder + words, no chat template
+    # (a leading "<|im_start|>user\n" shifts the predicted markers one bin late).
+    assert prompt == f"{processor.AUDIO_PLACEHOLDER}hello<timestamp><timestamp>world<timestamp><timestamp>"
+    assert "<|im_start|>" not in prompt
+    assert processor.build_prompt([]) == f"{processor.AUDIO_PLACEHOLDER}<timestamp><timestamp>"
+
+
+def test_build_prompt_matches_official_encode_timestamp():
+    pytest.importorskip("qwen_asr")
+    from qwen_asr.inference.qwen3_forced_aligner import Qwen3ForceAlignProcessor
+
+    text = "It's 3 o'clock, 你好 world."
+    word_list, official_prompt = Qwen3ForceAlignProcessor().encode_timestamp(text, "english")
+
+    assert processor.build_prompt(list(word_list)) == official_prompt
 
 
 @pytest.mark.parametrize(

--- a/vllm_omni/deploy/qwen3_tts_forced_aligner.yaml
+++ b/vllm_omni/deploy/qwen3_tts_forced_aligner.yaml
@@ -5,8 +5,9 @@
 # --forced-aligner sets just the model path.
 #
 # The stage runs the model with runner="pooling" + pooling_task="token_classify".
-# Prompt tokens, chat template and word segmentation are Qwen-specific and live
-# in qwen3_force_align_processor (not configurable here).
+# Prompt tokens and word segmentation are Qwen-specific and live in
+# qwen3_force_align_processor (not configurable here); the prompt is the same
+# string qwen_asr's encode_timestamp builds, with no chat template.
 
 forced_aligner:
   model: Qwen/Qwen3-ForcedAligner-0.6B

--- a/vllm_omni/utils/qwen3_force_align_processor.py
+++ b/vllm_omni/utils/qwen3_force_align_processor.py
@@ -65,18 +65,18 @@ _LANG_ALIASES = {
 
 
 def build_prompt(words: list[str]) -> str:
-    """Wrap segmented words in the Qwen3 aligner prompt template.
+    """Build the Qwen3 aligner prompt exactly as qwen_asr's
+    ``Qwen3ForceAlignProcessor.encode_timestamp`` does: the audio placeholder
+    followed by the words, each with two trailing ``<timestamp>`` markers
+    (start + end) that the model classifies into audio time bins.
 
-    Each word gets two trailing ``<timestamp>`` markers (start + end); the
-    model classifies each marker into an audio time bin.
+    No chat template. The official aligner feeds this string straight to the
+    tokenizer; wrapping it in ``<|im_start|>user ... <|im_start|>assistant``
+    puts three tokens in front of the audio and shifts almost every predicted
+    marker one 80 ms bin later than the official output.
     """
-    if not words:
-        # Pad with one timestamp so the decoder always has something to
-        # read; an empty result still surfaces as "[]" upstream.
-        body = TIMESTAMP_TOKEN
-    else:
-        body = f"{TIMESTAMP_TOKEN}{TIMESTAMP_TOKEN}".join(words) + f"{TIMESTAMP_TOKEN}{TIMESTAMP_TOKEN}"
-    return f"<|im_start|>user\n{AUDIO_PLACEHOLDER}{body}<|im_end|>\n<|im_start|>assistant\n"
+    body = f"{TIMESTAMP_TOKEN}{TIMESTAMP_TOKEN}".join(words) + f"{TIMESTAMP_TOKEN}{TIMESTAMP_TOKEN}"
+    return f"{AUDIO_PLACEHOLDER}{body}"
 
 
 # --- word segmentation (port of Qwen3ForceAlignProcessor) ----------------


### PR DESCRIPTION
## Purpose

`vllm_omni/utils/qwen3_force_align_processor.py::build_prompt` wraps the Qwen3-ForcedAligner input in `<|im_start|>user\n … <|im_end|>\n<|im_start|>assistant\n`. The official `qwen_asr` aligner (`Qwen3ForceAlignProcessor.encode_timestamp`) feeds `<|audio_start|><|audio_pad|><|audio_end|>` + `word<timestamp><timestamp>…` straight to the tokenizer, with no chat template (the checkpoint's own `chat_template.json` would even drop the user text).

The three tokens placed before the audio move the predicted markers late. Official transformers implementation (`qwen-asr` 0.0.6, `Qwen/Qwen3-ForcedAligner-0.6B`, fp32), same audio, text and weights, 20 FLEURS test clips (10 Mandarin + 10 English, 1014 markers), reference = official prompt:

| prompt | markers later / earlier / unchanged | mean shift |
|---|---|---|
| current `build_prompt` (prefix + suffix) | 925 / 12 / 77 | +92 ms |
| prefix `<\|im_start\|>user\n` only | 925 / 12 / 77 | +92 ms |
| suffix `<\|im_end\|>\n<\|im_start\|>assistant\n` only | 0 / 0 / 1014 | 0 |

662 markers move by exactly one 80 ms bin and 250 by two; every clip shows it (per-clip mean +52 … +137 ms, 95 % CI of the clip mean ±10 ms, sign test p ≈ 1e-255). The median word in these clips lasts 160 ms, so the bias is visible to any consumer of `word_timestamps`.

Fix: `build_prompt` returns exactly what `encode_timestamp` returns (empty word list → two markers, as upstream). vLLM's Qwen3-ASR multimodal processor only replaces `<|audio_pad|>`, so the bare prompt is valid input for the pooling stage; `code2wav2aligner` and the decoder are unchanged.

## Test Plan

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** cf36f5e4 (unit tests), 3204a0b2 (end to end); branch rebased on 087ac46

- `pytest tests/utils/test_qwen3_force_align_processor.py tests/utils/test_forced_aligner.py tests/model_executor/stage_input_processors/test_forced_aligner_stage.py` (CPU). The existing `build_prompt` test now pins the official format; a new test compares against `qwen_asr` when it is installed.
- End to end on an RTX 6000 Ada: `vllm serve Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice --omni --deploy-config <qwen3_tts.yaml with async_chunk: false> --forced-aligner Qwen/Qwen3-ForcedAligner-0.6B`, 10 `/v1/audio/speech` requests with `word_timestamps: true` and a fixed seed (5 English / Vivian, 5 Mandarin / Serena), with and without this diff; the official aligner run on each returned wav + text is the reference. (`async_chunk: false` because with the shipped yaml the aligner stage stalls "waiting for a chunk" on both branches — separate issue, unrelated to this change.)

## Test Result

- `main`: 24 passed. This branch: 24 passed, 1 skipped (no `qwen_asr` in that env; with it installed the new test passes). `ruff check` / `ruff format --check` clean. `build_prompt` equals the `encode_timestamp` output for English, Chinese, Japanese, Korean and empty text.
- End to end: the wav files are byte-identical between the two servers, so only the timestamps differ. Server `X-Word-Timestamps` vs the official aligner on the same audio, 392 markers:

  | server | later / earlier / equal | mean signed difference |
  |---|---|---|
  | `main` | 336 / 8 / 48 | +87.8 ms |
  | `main` + this PR | 20 / 35 / 337 | −2.9 ms |

  "quick brown fox", `(start_ms, end_ms)`: official `(160,560) (560,960) (960,1440)`; `main` `(160,720) (720,1120) (1120,1600)`; with this PR identical to official. The remaining single-bin differences after the fix come from the decoder's monotonic/duration clamp and bf16 (server) vs fp32 (reference).

<details>
<summary>A/B script (official transformers aligner; variants bare / wrapped / prefix_only / suffix_only)</summary>

```python
import json, statistics as st, sys, torch
from qwen_asr.inference.qwen3_forced_aligner import Qwen3ForcedAligner
from qwen_asr.inference.utils import normalize_audios

al = Qwen3ForcedAligner.from_pretrained("Qwen/Qwen3-ForcedAligner-0.6B", dtype=torch.float32, device_map="cpu")
PRE, POST = "<|im_start|>user\n", "<|im_end|>\n<|im_start|>assistant\n"
VARIANTS = {"bare": (False, False), "wrapped": (True, True), "prefix_only": (True, False), "suffix_only": (False, True)}

@torch.inference_mode()
def run(audio, text, lang, pre, post):
    word_list, input_text = al.aligner_processor.encode_timestamp(text, lang)
    input_text = (PRE if pre else "") + input_text + (POST if post else "")
    inputs = al.processor(text=[input_text], audio=[audio], return_tensors="pt", padding=True).to(al.model.device).to(al.model.dtype)
    out_ids = al.model.thinker(**inputs).logits.argmax(dim=-1)
    masked = out_ids[0][inputs["input_ids"][0] == al.timestamp_token_id]
    parsed = al.aligner_processor.parse_timestamp(word_list, (masked * al.timestamp_segment_time).cpu().numpy())
    return [(w["start_time"], w["end_time"]) for w in parsed]

for m in json.load(open("clips/meta.json")):  # [{"path", "lang", "text"}, ...] FLEURS test clips, 3-20 s
    audio = normalize_audios([m["path"]])[0]
    ts = {k: run(audio, m["text"], m["lang"], *v) for k, v in VARIANTS.items()}
    for k in ("wrapped", "prefix_only", "suffix_only"):
        d = [b - a for (a1, a2), (b1, b2) in zip(ts["bare"], ts[k]) for a, b in ((a1, b1), (a2, b2))]
        print(m["path"], k, "changed", sum(1 for x in d if x), "/", len(d), "mean %+.0f ms" % st.mean(d))
```

</details>
