### PR TITLE
feat(attention): share standalone FA3 varlen and LSE adapter

### DIFF
--- a/tests/diffusion/attention/test_fa3_varlen_adapter.py
+++ b/tests/diffusion/attention/test_fa3_varlen_adapter.py
@@ -5,6 +5,7 @@ import inspect
 import sys
 from types import ModuleType, SimpleNamespace
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -116,6 +117,30 @@ def test_optional_features_forwarded_only_when_supported(monkeypatch):
     set_provider(monkeypatch, provider)
     fa.flash_attn_3_varlen(q, k, v, **kwargs, sinks=sink, softcap=2.0, deterministic=True)
     assert seen == dict(sinks=sink, softcap=2.0, deterministic=True)
+
+
+@pytest.mark.cpu
+def test_optional_backend_is_forwarded_only_when_supported(monkeypatch):
+    q, k, v, kwargs = inputs()
+    seen: dict[str, Any] = {}
+
+    def provider(*, backend="auto", **kw):
+        seen["backend"] = backend
+        return q
+
+    monkeypatch.setattr(fa, "_external_fa3_varlen", lambda: (provider, frozenset(("backend",))))
+    fa.flash_attn_3_varlen(q, k, v, **kwargs, backend="mutlass")
+    assert seen == {"backend": "mutlass"}
+
+
+@pytest.mark.cpu
+def test_backend_is_rejected_when_provider_does_not_advertise_it(monkeypatch):
+    q, k, v, kwargs = inputs()
+    provider = Mock(return_value=q)
+    monkeypatch.setattr(fa, "_external_fa3_varlen", lambda: (provider, frozenset()))
+    with pytest.raises(NotImplementedError, match="backend"):
+        fa.flash_attn_3_varlen(q, k, v, **kwargs, backend="mutlass")
+    provider.assert_not_called()
 
 
 @pytest.mark.cpu

--- a/tests/diffusion/attention/test_fa3_varlen_adapter.py
+++ b/tests/diffusion/attention/test_fa3_varlen_adapter.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+import inspect
+import sys
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.attention.backends.utils import fa
+
+pytestmark = [pytest.mark.diffusion, pytest.mark.local_model]
+
+
+@pytest.fixture(autouse=True)
+def clear_provider_cache():
+    fa._external_fa3_varlen.cache_clear()
+    yield
+    fa._external_fa3_varlen.cache_clear()
+
+
+def inputs():
+    q = torch.randn(5, 2, 64)
+    k = torch.randn(7, 1, 64)
+    v = torch.randn_like(k)
+    kwargs = dict(
+        cu_seqlens_q=torch.tensor([0, 2, 5], dtype=torch.int32),
+        cu_seqlens_k=torch.tensor([0, 3, 7], dtype=torch.int32),
+        max_seqlen_q=3,
+        max_seqlen_k=4,
+    )
+    return q, k, v, kwargs
+
+
+def set_provider(monkeypatch, func):
+    monkeypatch.setattr(fa, "_external_fa3_varlen", lambda: (func, frozenset(inspect.signature(func).parameters)))
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("layout", ["fa3_fwd_interface", "flash_attn_interface", "flash_attn_3.interface"])
+def test_provider_layout_and_cached_resolution(monkeypatch, layout):
+    calls = []
+
+    def provider(q, **kwargs):
+        return q
+
+    def load(name):
+        calls.append(name)
+        if name == layout:
+            return SimpleNamespace(flash_attn_varlen_func=provider)
+        raise ImportError(name)
+
+    monkeypatch.setattr(fa.importlib, "import_module", load)
+    assert fa._external_fa3_varlen()[0] is provider
+    first_calls = calls[:]
+    assert fa._external_fa3_varlen()[0] is provider
+    assert calls == first_calls
+
+
+@pytest.mark.cpu
+def test_missing_provider_has_actionable_error(monkeypatch):
+    def missing(name):
+        raise ImportError(name)
+
+    monkeypatch.setattr(fa.importlib, "import_module", missing)
+    with pytest.raises(ImportError, match="standalone FlashAttention-3"):
+        fa._external_fa3_varlen()
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("returns_tuple", [False, True])
+def test_output_only_contract(monkeypatch, returns_tuple):
+    q, k, v, kwargs = inputs()
+    seen: dict[str, Any] = {}
+
+    def provider(**kw):
+        seen.update(kw)
+        return (q, torch.zeros(2, 5)) if returns_tuple else q
+
+    set_provider(monkeypatch, provider)
+    assert fa.flash_attn_3_varlen(q, k, v, **kwargs, softmax_scale=0.2, causal=True) is q
+    assert seen["q"] is q and seen["cu_seqlens_q"] is kwargs["cu_seqlens_q"]
+    assert seen["softmax_scale"] == 0.2 and seen["causal"] is True
+    assert "return_attn_probs" not in seen and "return_softmax_lse" not in seen
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("flag", ["return_attn_probs", "return_softmax_lse"])
+def test_lse_request_aliases(monkeypatch, flag):
+    q, k, v, kwargs = inputs()
+    lse = torch.randn(2, 5)
+    seen: dict[str, Any] = {}
+
+    def provider(**kw):
+        seen.update(kw)
+        return q, lse, None
+
+    monkeypatch.setattr(fa, "_external_fa3_varlen", lambda: (provider, frozenset((flag,))))
+    out, actual_lse = fa.flash_attn_3_varlen(q, k, v, **kwargs, return_softmax_lse=True)
+    assert out is q and actual_lse is lse
+    assert seen[flag] is True
+
+
+@pytest.mark.cpu
+def test_optional_features_forwarded_only_when_supported(monkeypatch):
+    q, k, v, kwargs = inputs()
+    sink = torch.randn(2)
+    seen: dict[str, Any] = {}
+
+    def provider(*, sinks=None, softcap=0.0, deterministic=False, **kw):
+        seen.update(sinks=sinks, softcap=softcap, deterministic=deterministic)
+        return q
+
+    set_provider(monkeypatch, provider)
+    fa.flash_attn_3_varlen(q, k, v, **kwargs, sinks=sink, softcap=2.0, deterministic=True)
+    assert seen == dict(sinks=sink, softcap=2.0, deterministic=True)
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize(
+    "option", [dict(sinks=torch.ones(2)), dict(softcap=1.0), dict(deterministic=True), dict(return_softmax_lse=True)]
+)
+def test_unsupported_features_fail_closed(monkeypatch, option):
+    q, k, v, kwargs = inputs()
+
+    def provider(**kw):
+        pytest.fail("unsupported features must fail before calling the provider")
+
+    set_provider(monkeypatch, provider)
+    with pytest.raises(NotImplementedError):
+        fa.flash_attn_3_varlen(q, k, v, **kwargs, **option)
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize(
+    "result", [None, torch.zeros(5, 2, 64), (torch.zeros(5, 2, 64), None), (torch.zeros(5, 2, 64), torch.zeros(5, 2))]
+)
+def test_malformed_lse_results_are_rejected(monkeypatch, result):
+    q, k, v, kwargs = inputs()
+
+    def provider(*, return_attn_probs=False, **kw):
+        return result
+
+    set_provider(monkeypatch, provider)
+    with pytest.raises(RuntimeError):
+        fa.flash_attn_3_varlen(q, k, v, **kwargs, return_softmax_lse=True)
+
+
+@pytest.mark.cpu
+def test_bundled_backend_keeps_priority(monkeypatch):
+    q, k, v, kwargs = inputs()
+    lse = torch.zeros(2, 5)
+    module = ModuleType("vllm.vllm_flash_attn")
+
+    def bundled(*args, **kw):
+        assert kw["fa_version"] == 3 and kw["return_softmax_lse"] is True
+        return q, lse
+
+    setattr(module, "flash_attn_varlen_func", bundled)
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    monkeypatch.setattr(fa, "resolve_vllm_flash_attn_version", lambda requested: 3)
+
+    def unused():
+        pytest.fail("standalone provider must not replace the bundled backend")
+
+    monkeypatch.setattr(fa, "_external_fa3_varlen", unused)
+    out, actual_lse = fa.vllm_flash_attn_varlen_with_lse(q, k, v, **kwargs)
+    assert out is q and actual_lse is lse
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("requested", [None, 3])
+def test_shared_lse_entry_uses_standalone_fallback(monkeypatch, requested):
+    q, k, v, kwargs = inputs()
+    lse = torch.zeros(2, 5)
+    monkeypatch.setitem(sys.modules, "vllm.vllm_flash_attn", None)
+
+    def provider(*, return_attn_probs=False, **kw):
+        assert return_attn_probs
+        return q, lse
+
+    set_provider(monkeypatch, provider)
+    out, actual_lse = fa.vllm_flash_attn_varlen_with_lse(q, k, v, **kwargs, fa_version=requested)
+    assert out is q and actual_lse is lse
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("requested", [2, 4])
+def test_explicit_versions_are_not_redirected(monkeypatch, requested):
+    q, k, v, kwargs = inputs()
+    monkeypatch.setitem(sys.modules, "vllm.vllm_flash_attn", None)
+    with pytest.raises(ImportError):
+        fa.vllm_flash_attn_varlen_with_lse(q, k, v, **kwargs, fa_version=requested)
+
+
+@pytest.mark.parametrize(
+    "device_kind", [pytest.param("cuda", marks=pytest.mark.cuda), pytest.param("musa", marks=pytest.mark.musa)]
+)
+@pytest.mark.parametrize("causal", [False, True])
+def test_standalone_gpu_lse_parity(device_kind, causal):
+    device_module = getattr(torch, device_kind, None)
+    if device_module is None or not device_module.is_available():
+        pytest.skip(f"requires {device_kind}")
+    try:
+        fa._external_fa3_varlen()
+    except ImportError:
+        pytest.skip("standalone FA3 provider is not installed")
+    torch.manual_seed(42)
+    q, k, v, kwargs = inputs()
+    q, k, v = [x.to(device=device_kind, dtype=torch.bfloat16) for x in (q, k, v)]
+    kwargs = {key: value.to(device_kind) if isinstance(value, torch.Tensor) else value for key, value in kwargs.items()}
+    out, lse = fa.flash_attn_3_varlen(q, k, v, **kwargs, causal=causal, return_softmax_lse=True)
+    expected, expected_lse = [], []
+    for qs, qe, ks, ke in ((0, 2, 0, 3), (2, 5, 3, 7)):
+        qq = q[qs:qe].float()
+        kk = k[ks:ke].float().expand(-1, 2, -1)
+        vv = v[ks:ke].float().expand(-1, 2, -1)
+        score = torch.einsum("qhd,khd->hqk", qq, kk) / 8
+        if causal:
+            qi = torch.arange(qe - qs, device=device_kind)[:, None]
+            ki = torch.arange(ke - ks, device=device_kind)[None, :]
+            score.masked_fill_(ki > qi + (ke - ks) - (qe - qs), float("-inf"))
+        expected_lse.append(torch.logsumexp(score, -1))
+        expected.append(torch.einsum("hqk,khd->qhd", torch.softmax(score, -1), vv))
+    torch.testing.assert_close(out.float(), torch.cat(expected), rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(lse.float(), torch.cat(expected_lse, -1), rtol=3e-3, atol=3e-3)

--- a/tests/diffusion/attention/test_fa3_varlen_adapter.py
+++ b/tests/diffusion/attention/test_fa3_varlen_adapter.py
@@ -5,7 +5,6 @@ import inspect
 import sys
 from types import ModuleType, SimpleNamespace
 from typing import Any
-from unittest.mock import Mock
 
 import pytest
 import torch
@@ -117,30 +116,6 @@ def test_optional_features_forwarded_only_when_supported(monkeypatch):
     set_provider(monkeypatch, provider)
     fa.flash_attn_3_varlen(q, k, v, **kwargs, sinks=sink, softcap=2.0, deterministic=True)
     assert seen == dict(sinks=sink, softcap=2.0, deterministic=True)
-
-
-@pytest.mark.cpu
-def test_optional_backend_is_forwarded_only_when_supported(monkeypatch):
-    q, k, v, kwargs = inputs()
-    seen: dict[str, Any] = {}
-
-    def provider(*, backend="auto", **kw):
-        seen["backend"] = backend
-        return q
-
-    monkeypatch.setattr(fa, "_external_fa3_varlen", lambda: (provider, frozenset(("backend",))))
-    fa.flash_attn_3_varlen(q, k, v, **kwargs, backend="mutlass")
-    assert seen == {"backend": "mutlass"}
-
-
-@pytest.mark.cpu
-def test_backend_is_rejected_when_provider_does_not_advertise_it(monkeypatch):
-    q, k, v, kwargs = inputs()
-    provider = Mock(return_value=q)
-    monkeypatch.setattr(fa, "_external_fa3_varlen", lambda: (provider, frozenset()))
-    with pytest.raises(NotImplementedError, match="backend"):
-        fa.flash_attn_3_varlen(q, k, v, **kwargs, backend="mutlass")
-    provider.assert_not_called()
 
 
 @pytest.mark.cpu

--- a/vllm_omni/diffusion/attention/backends/utils/fa.py
+++ b/vllm_omni/diffusion/attention/backends/utils/fa.py
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # Adapted from https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_flash_attention_utils.py
+import importlib
+import inspect
 from collections.abc import Callable
 from functools import cache, lru_cache
 from typing import Any
@@ -209,6 +211,87 @@ def resolve_vllm_flash_attn_version(requested: str | int | None = None) -> int:
     return _choose_vllm_flash_attn_version(capability.major, requested, supported_versions)
 
 
+@cache
+def _external_fa3_varlen() -> tuple[FlashAttnFn, frozenset[str]]:
+    """Resolve standalone FA3 package layouts without device-specific policy."""
+    error = None
+    for module_name in ("fa3_fwd_interface", "flash_attn_interface", "flash_attn_3.interface"):
+        try:
+            func = importlib.import_module(module_name).flash_attn_varlen_func
+        except (ImportError, AttributeError) as exc:
+            error = exc
+            continue
+        return func, frozenset(inspect.signature(func).parameters)
+    raise ImportError("A standalone FlashAttention-3 varlen interface is required") from error
+
+
+def flash_attn_3_varlen(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    softmax_scale: float | None = None,
+    softcap: float = 0.0,
+    causal: bool = False,
+    deterministic: bool = False,
+    sinks: torch.Tensor | None = None,
+    return_softmax_lse: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    """Call standalone FA3 with an output-only or packed ``(output, LSE)`` contract.
+
+    Providers name the LSE request either ``return_attn_probs`` or
+    ``return_softmax_lse``. Native sinks require explicit provider support; this
+    helper does not emulate sinks or select an accelerator platform.
+    """
+    func, parameters = _external_fa3_varlen()
+    kwargs = {
+        "q": q,
+        "k": k,
+        "v": v,
+        "cu_seqlens_q": cu_seqlens_q,
+        "cu_seqlens_k": cu_seqlens_k,
+        "max_seqlen_q": int(max_seqlen_q),
+        "max_seqlen_k": int(max_seqlen_k),
+        "softmax_scale": softmax_scale,
+        "causal": causal,
+    }
+    for name, value in (("softcap", max(float(softcap), 0.0)), ("deterministic", deterministic)):
+        if name in parameters:
+            kwargs[name] = value
+        elif value:
+            raise NotImplementedError(f"This FlashAttention-3 provider does not support {name}")
+    if sinks is not None:
+        if "sinks" not in parameters:
+            raise NotImplementedError("This FlashAttention-3 provider does not support native sinks")
+        kwargs["sinks"] = sinks
+    if return_softmax_lse:
+        if "return_attn_probs" in parameters:
+            kwargs["return_attn_probs"] = True
+        elif "return_softmax_lse" in parameters:
+            kwargs["return_softmax_lse"] = True
+        else:
+            raise NotImplementedError("This FlashAttention-3 provider does not expose an LSE return option")
+    result = func(**kwargs)
+    if not return_softmax_lse:
+        out = result[0] if isinstance(result, tuple) and result else result
+        if not isinstance(out, torch.Tensor):
+            raise RuntimeError("FlashAttention-3 must return an output tensor")
+        return out
+    if not isinstance(result, tuple) or len(result) < 2:
+        raise RuntimeError("FlashAttention-3 must return (output, softmax_lse) when LSE is requested")
+    out, lse = result[:2]
+    if not isinstance(out, torch.Tensor) or not isinstance(lse, torch.Tensor):
+        raise RuntimeError("FlashAttention-3 output and softmax_lse must be tensors")
+    expected_shape = (q.shape[1], q.shape[0])
+    if lse.shape != expected_shape:
+        raise RuntimeError(f"Expected packed softmax_lse shape {expected_shape}, got {tuple(lse.shape)}")
+    return out, lse
+
+
 def vllm_flash_attn_varlen_with_lse(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -224,9 +307,31 @@ def vllm_flash_attn_varlen_with_lse(
     deterministic: bool = False,
     fa_version: int | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Run packed vLLM FlashAttention and retain LSE for post-processing."""
+    """Run packed attention with LSE, preferring vLLM's versioned backend.
 
-    from vllm.vllm_flash_attn import flash_attn_varlen_func as vllm_flash_attn_varlen_func
+    When the bundled API is not installed, standalone FA3 supplies the same
+    contract. Explicit FA2/FA4 requests are never redirected to FA3.
+    """
+
+    try:
+        from vllm.vllm_flash_attn import flash_attn_varlen_func as vllm_flash_attn_varlen_func
+    except ImportError:
+        if fa_version not in (None, 3):
+            raise
+        return flash_attn_3_varlen(
+            q,
+            k,
+            v,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            softmax_scale=softmax_scale,
+            softcap=softcap,
+            causal=causal,
+            deterministic=deterministic,
+            return_softmax_lse=True,
+        )
 
     version = resolve_vllm_flash_attn_version(fa_version)
     out, lse = vllm_flash_attn_varlen_func(

--- a/vllm_omni/diffusion/attention/backends/utils/fa.py
+++ b/vllm_omni/diffusion/attention/backends/utils/fa.py
@@ -238,7 +238,6 @@ def flash_attn_3_varlen(
     softcap: float = 0.0,
     causal: bool = False,
     deterministic: bool = False,
-    backend: str | None = None,
     sinks: torch.Tensor | None = None,
     return_softmax_lse: bool = False,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
@@ -246,9 +245,7 @@ def flash_attn_3_varlen(
 
     Providers name the LSE request either ``return_attn_probs`` or
     ``return_softmax_lse``. Native sinks require explicit provider support; this
-    helper does not emulate sinks or select an accelerator platform. ``backend``
-    is an optional provider selector; it is forwarded only when the provider
-    advertises that parameter.
+    helper does not emulate sinks or select an accelerator platform.
     """
     func, parameters = _external_fa3_varlen()
     kwargs = {
@@ -262,12 +259,10 @@ def flash_attn_3_varlen(
         "softmax_scale": softmax_scale,
         "causal": causal,
     }
-    for name, value in (("softcap", max(float(softcap), 0.0)), ("deterministic", deterministic), ("backend", backend)):
-        if name == "backend" and value is None:
-            continue
+    for name, value in (("softcap", max(float(softcap), 0.0)), ("deterministic", deterministic)):
         if name in parameters:
             kwargs[name] = value
-        elif value is not None and value is not False and value != 0.0:
+        elif value:
             raise NotImplementedError(f"This FlashAttention-3 provider does not support {name}")
     if sinks is not None:
         if "sinks" not in parameters:

--- a/vllm_omni/diffusion/attention/backends/utils/fa.py
+++ b/vllm_omni/diffusion/attention/backends/utils/fa.py
@@ -238,6 +238,7 @@ def flash_attn_3_varlen(
     softcap: float = 0.0,
     causal: bool = False,
     deterministic: bool = False,
+    backend: str | None = None,
     sinks: torch.Tensor | None = None,
     return_softmax_lse: bool = False,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
@@ -245,7 +246,9 @@ def flash_attn_3_varlen(
 
     Providers name the LSE request either ``return_attn_probs`` or
     ``return_softmax_lse``. Native sinks require explicit provider support; this
-    helper does not emulate sinks or select an accelerator platform.
+    helper does not emulate sinks or select an accelerator platform. ``backend``
+    is an optional provider selector; it is forwarded only when the provider
+    advertises that parameter.
     """
     func, parameters = _external_fa3_varlen()
     kwargs = {
@@ -259,10 +262,12 @@ def flash_attn_3_varlen(
         "softmax_scale": softmax_scale,
         "causal": causal,
     }
-    for name, value in (("softcap", max(float(softcap), 0.0)), ("deterministic", deterministic)):
+    for name, value in (("softcap", max(float(softcap), 0.0)), ("deterministic", deterministic), ("backend", backend)):
+        if name == "backend" and value is None:
+            continue
         if name in parameters:
             kwargs[name] = value
-        elif value:
+        elif value is not None and value is not False and value != 0.0:
             raise NotImplementedError(f"This FlashAttention-3 provider does not support {name}")
     if sinks is not None:
         if "sinks" not in parameters:


### PR DESCRIPTION
## Summary

Extract the standalone FlashAttention-3 adapter from the MAGI-2/MUSA reference draft into the shared diffusion attention utilities.

- Support the standalone FA3 package layouts through one cached resolver.
- Normalize output-only and `(output, LSE)` calls, including `return_attn_probs` / `return_softmax_lse` aliases.
- Forward optional native sinks only when the provider explicitly supports them; do not silently emulate unsupported features.
- Reuse this adapter from `vllm_flash_attn_varlen_with_lse` when the bundled API cannot be imported. Preserve the existing bundled-backend priority and do not redirect explicit FA2/FA4 requests.

No MAGI-2 algorithm, MUSA platform gating, kernel implementation, EP, sampler change or performance configuration is included. No environment-variable inventory changes.

## Tests

Changed-file pre-commit: all pass (including Ruff and mypy).

55 CPU contract/attention tests pass in a CPU-only container, including existing version-selection coverage. The two MUSA numerical tests now pass; the two CUDA numerical tests remain not run. Five existing device-dependent attention tests were excluded from this CPU-only run; the initial unrestricted selection failed on accelerator allocation because the container had no GPU.

```bash
python -m pytest -q -o addopts='' -p no:cacheprovider \
  tests/diffusion/attention/test_fa3_varlen_adapter.py \
  tests/diffusion/attention/test_flash_attn.py -m cpu \
  -k 'not test_padding_equivalence and not test_fa_vs_sdpa and not test_flash_attn_func_preferred_over_varlen and not test_cross_attn_key_padding_vs_sdpa'
```

On the MUSA development image, `torchada` was imported before invoking `pytest.main` with the above arguments. The MUSA provider validation below covers this adapter only. CUDA runtime validation and model end-to-end/performance remain not run; this PR stays Draft.

## MUSA provider validation

Exact tested head: `612bdad0914c3c13214fd2d31d1f391a31eeeacf`.

- **2 passed, 24 deselected, 0 skipped**, including causal and non-causal packed BF16 GQA with unequal Q/K lengths.
- Both output and packed LSE are checked against independent FP32 Torch references. Existing tolerances are unchanged: output `rtol=2e-2, atol=2e-2`; LSE `rtol=3e-3, atol=3e-3`.
- MTT S5000, one 48-SM device, driver `5.2.0-server`. Python 3.10.12, torch/torch_musa `2.11.0.post1+musa5.2.0`, torchada `0.1.83`, MATE `0.2.6`, flash_attn_3 `0.2.6+musa`, vLLM `0.28.0`, vllm-musa `0.1.28`.
- Resolved provider: `flash_attn_3.interface` through the installed torchada wrapper; `return_attn_probs` requests LSE.
- Image: `registry.mthreads.com/mcconline/inference/vllm-omni@sha256:7f4f2cd83a88979025ef92968334f6e075eb24d45d02e0c30dbb222f7780d58a`.
- Exact checkout installed with `SETUPTOOLS_SCM_PRETEND_VERSION=0.28.0 python -m pip install -e . --no-deps --no-build-isolation`; import path verified. Install, tests and container exit codes were 0.

After importing `torchada`, the runner invokes:

```python
pytest.main([
    "-vv", "-s", "-o", "addopts=", "-p", "no:cacheprovider",
    "tests/diffusion/attention/test_fa3_varlen_adapter.py", "-m", "musa",
])
```

No native-sink, MAGI-2 consumer, full-model, compilation/capture or performance qualification is implied by these two adapter tests. The separate MAGI-2 FA3 consumer still has its own numerical gate; this result does not qualify that branch.

## Split boundary

This is the generic adapter part of #7156, which remains unchanged as reference. The later MUSA wiring PR will consume the shared API; it is intentionally not bundled here. BF16 MoE remains in #7206.
