### PR TITLE
[Bugfix] Make diffusion video benchmark timeout configurable and report failures

### DIFF
--- a/benchmarks/diffusion/README.md
+++ b/benchmarks/diffusion/README.md
@@ -123,7 +123,7 @@ Precedence rules for `trace` (i.e., what actually gets sent):
 ### Video job timeouts
 
 `--video-poll-timeout` sets the polling budget for each `/v1/videos` job
-(default: `600` seconds). It starts after job creation and includes server
+(default: `1200` seconds). It starts after job creation and includes server
 queueing and generation, but excludes waiting for the client concurrency
 semaphore. Long videos or high concurrency may need a larger budget, for
 example `--video-poll-timeout 1800`.

--- a/benchmarks/diffusion/README.md
+++ b/benchmarks/diffusion/README.md
@@ -17,18 +17,18 @@ The main entrypoint is:
 vllm serve Qwen/Qwen-Image --omni --port 8099
 ```
 
-2. Run a minimal benchmark:
+1. Run a minimal benchmark:
 
 ```bash
 python3 benchmarks/diffusion/diffusion_benchmark_serving.py \
-	--base-url http://localhost:8099 \
-	--model Qwen/Qwen-Image \
-	--task t2i \
-	--dataset vbench \
-	--num-prompts 5
+ --base-url http://localhost:8099 \
+ --model Qwen/Qwen-Image \
+ --task t2i \
+ --dataset vbench \
+ --num-prompts 5
 ```
 
-**Notes**
+Notes:
 
 - By default, image tasks talk to `http://<host>:<port>/v1/chat/completions`; video tasks talk to `/v1/videos`.
 - If you run the server on another host or port, pass `--base-url` accordingly.
@@ -52,14 +52,14 @@ Example (`t2v`):
 
 ```bash
 python3 benchmarks/diffusion/diffusion_benchmark_serving.py \
-	--base-url http://localhost:8099 \
-	--model Wan-AI/Wan2.2-T2V-A14B-Diffusers \
-	--task t2v \
-	--dataset vbench \
-	--num-prompts 50 \
-	--width 640 --height 480 \
-	--num-frames 81 --fps 16 \
-	--num-inference-steps 40
+ --base-url http://localhost:8099 \
+ --model Wan-AI/Wan2.2-T2V-A14B-Diffusers \
+ --task t2v \
+ --dataset vbench \
+ --num-prompts 50 \
+ --width 640 --height 480 \
+ --num-frames 81 --fps 16 \
+ --num-inference-steps 40
 ```
 
 Note: `vbench` can also be used for other tasks such as `t2i` / `i2v` (and `i2i`). For `t2i`, the loader reuses VBench t2v text prompts; for `i2v` / `i2i`, it loads the VBench i2v dataset (with image paths).
@@ -119,6 +119,24 @@ Precedence rules for `trace` (i.e., what actually gets sent):
 - `width/height`: if either `--width` or `--height` is explicitly set, it overrides per-request values from the trace; otherwise per-request values are used when present.
 - `num_frames`: per-request `num_frames` takes precedence; otherwise fall back to `--num-frames`.
 - `num_inference_steps`: per-request `num_inference_steps` takes precedence; otherwise fall back to `--num-inference-steps`.
+
+### Video job timeouts
+
+`--video-poll-timeout` sets the polling budget for each `/v1/videos` job
+(default: `600` seconds). It starts after job creation and includes server
+queueing and generation, but excludes waiting for the client concurrency
+semaphore. Long videos or high concurrency may need a larger budget, for
+example `--video-poll-timeout 1800`.
+
+When the budget expires, the benchmark records a failure and deletes the job,
+which cancels queued or running generation on the server. This can produce
+server-side aborted-request logs. The progress bar counts both successful and
+failed requests; `Successful requests` counts only successes. The console and
+JSON report include failure reasons. Raising the timeout allows more waiting;
+it does not retry requests or fix server-side generation errors.
+
+`VLLM_OMNI_VIDEO_SYNC_TIMEOUT` controls the separate `/v1/videos/sync` endpoint
+and does not change this benchmark's async video polling budget.
 
 ### SLO, warmup, and max concurrency
 

--- a/benchmarks/diffusion/backends.py
+++ b/benchmarks/diffusion/backends.py
@@ -46,7 +46,7 @@ class RequestFuncInput:
     video_paths: list[str] | None = None
     request_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     default_bot_task: str | None = DEFAULT_EDITS_BOT_TASK
-    video_poll_timeout: float = 600.0
+    video_poll_timeout: float = 1200.0
 
 
 @dataclass

--- a/benchmarks/diffusion/backends.py
+++ b/benchmarks/diffusion/backends.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 import asyncio
 import base64
 import json
@@ -43,6 +46,7 @@ class RequestFuncInput:
     video_paths: list[str] | None = None
     request_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     default_bot_task: str | None = DEFAULT_EDITS_BOT_TASK
+    video_poll_timeout: float = 600.0
 
 
 @dataclass
@@ -351,44 +355,44 @@ async def async_request_v1_videos(
         form.add_field(k, str(v))
 
     image_file = None
-    if input.image_paths and input.video_paths:
-        output.error = "Only one of image_paths or video_paths can be provided"
-        output.success = False
-        return output
-
-    if input.image_paths and len(input.image_paths) > 0:
-        image_path = input.image_paths[0]
-        image_file = open(image_path, "rb")
-        form.add_field(
-            "input_reference",
-            image_file,
-            filename=os.path.basename(image_path),
-            content_type=_guess_mime_type(image_path),
-        )
-    elif input.video_paths and len(input.video_paths) > 0:
-        video_path = input.video_paths[0]
-        if _is_minimax_h3_mixed_reference(input.model):
-            with open(video_path, "rb") as reference_file:
-                video_b64 = base64.b64encode(reference_file.read()).decode("ascii")
-            form.add_field(
-                "video_reference",
-                json.dumps([{"video_url": f"data:video/mp4;base64,{video_b64}"}]),
-            )
-        else:
-            image_file = open(video_path, "rb")
-            form.add_field(
-                "input_reference",
-                image_file,
-                filename=os.path.basename(video_path),
-                content_type=_guess_mime_type(video_path),
-            )
-
     job_id = None
     job_status = None
     poll_json = {}
     resp_json = {}
 
     try:
+        if input.image_paths and input.video_paths:
+            output.error = "Only one of image_paths or video_paths can be provided"
+            output.success = False
+            return output
+
+        if input.image_paths and len(input.image_paths) > 0:
+            image_path = input.image_paths[0]
+            image_file = open(image_path, "rb")
+            form.add_field(
+                "input_reference",
+                image_file,
+                filename=os.path.basename(image_path),
+                content_type=_guess_mime_type(image_path),
+            )
+        elif input.video_paths and len(input.video_paths) > 0:
+            video_path = input.video_paths[0]
+            if _is_minimax_h3_mixed_reference(input.model):
+                with open(video_path, "rb") as reference_file:
+                    video_b64 = base64.b64encode(reference_file.read()).decode("ascii")
+                form.add_field(
+                    "video_reference",
+                    json.dumps([{"video_url": f"data:video/mp4;base64,{video_b64}"}]),
+                )
+            else:
+                image_file = open(video_path, "rb")
+                form.add_field(
+                    "input_reference",
+                    image_file,
+                    filename=os.path.basename(video_path),
+                    content_type=_guess_mime_type(video_path),
+                )
+
         # invoke a post request (POST /v1/videos)
         async with session.post(input.api_url, data=form) as response:
             if response.status == 200:
@@ -406,7 +410,7 @@ async def async_request_v1_videos(
 
         # invoke a poll request (GET /v1/videos/{video_id})
         poll_interval = 2.0  # Unit(s)
-        timeout_seconds = 600.0
+        timeout_seconds = input.video_poll_timeout
         deadline = time.perf_counter() + timeout_seconds
         job_url = f"{input.api_url}/{job_id}"
 
@@ -422,8 +426,11 @@ async def async_request_v1_videos(
                 poll_json = await poll_response.json()
                 job_status = poll_json.get("status")
 
-                if time.perf_counter() >= deadline:
-                    output.error = f"Timed out waiting for video job {job_id} to complete."
+                if job_status not in {"completed", "failed"} and time.perf_counter() >= deadline:
+                    output.error = (
+                        f"Timed out waiting for video job {job_id} after {timeout_seconds:g}s "
+                        f"(status={job_status}). Increase --video-poll-timeout to allow for queueing and generation."
+                    )
                     output.success = False
                     return output
 
@@ -452,7 +459,7 @@ async def async_request_v1_videos(
             elif "peak_memory_mb" in resp_json:
                 output.peak_memory_mb = resp_json["peak_memory_mb"]
     except Exception as e:
-        output.error = str(e)
+        output.error = f"{type(e).__name__}: {e}"
         output.success = False
     finally:
         if image_file is not None:
@@ -465,13 +472,13 @@ async def async_request_v1_videos(
             except Exception as e:
                 print(f"Failed to clean up video job {job_id}: {e}")
 
-    output.latency = time.perf_counter() - output.start_time
+        output.latency = time.perf_counter() - output.start_time
 
-    if output.success and input.slo_ms is not None:
-        output.slo_achieved = (output.latency * 1000.0) <= float(input.slo_ms)
+        if output.success and input.slo_ms is not None:
+            output.slo_achieved = (output.latency * 1000.0) <= float(input.slo_ms)
 
-    if pbar:
-        pbar.update(1)
+        if pbar:
+            pbar.update(1)
     return output
 
 

--- a/benchmarks/diffusion/diffusion_benchmark_serving.py
+++ b/benchmarks/diffusion/diffusion_benchmark_serving.py
@@ -1,6 +1,6 @@
 # adapted from fastvideo
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 """
 Benchmark online serving for diffusion models (Image/Video Generation).
@@ -93,6 +93,7 @@ import tempfile
 import time
 import uuid
 from abc import ABC, abstractmethod
+from collections import Counter
 from collections.abc import AsyncGenerator
 from dataclasses import replace
 from typing import Any
@@ -1116,6 +1117,7 @@ def calculate_metrics(
         "duration": total_duration,
         "completed_requests": num_success,
         "failed_requests": len(error_outputs),
+        "errors": dict(Counter(o.error or "Unknown error" for o in error_outputs)),
         "throughput_qps": num_success / total_duration if total_duration > 0 else 0,
         "latency_mean": np.mean(latencies) if latencies else 0,
         "latency_median": np.median(latencies) if latencies else 0,
@@ -1261,6 +1263,9 @@ def _default_endpoint_for_task(task: str) -> str:
 
 
 async def benchmark(args):
+    if not 0 < args.video_poll_timeout < float("inf"):
+        raise ValueError("--video-poll-timeout must be a finite positive number of seconds.")
+
     # Construct base_url if not provided
     if args.base_url is None:
         args.base_url = f"http://{args.host}:{args.port}"
@@ -1312,6 +1317,8 @@ async def benchmark(args):
     print("Loading requests...")
     requests_list = dataset.get_requests()
     print(f"Prepared {len(requests_list)} requests from {args.dataset} dataset.")
+    for req in requests_list:
+        req.video_poll_timeout = args.video_poll_timeout
 
     if args.return_stage_metrics and args.endpoint in _STAGE_METRICS_ENDPOINTS:
         for req in requests_list:
@@ -1376,6 +1383,8 @@ async def benchmark(args):
     metrics["model"] = args.model
     metrics["dataset"] = args.dataset
     metrics["task"] = args.task
+    if args.endpoint == "/v1/videos":
+        metrics["video_poll_timeout"] = args.video_poll_timeout
     if args.endpoint == "/v1/images/edits":
         metrics["bot_task"] = args.bot_task
 
@@ -1398,6 +1407,12 @@ async def benchmark(args):
         )
     )
     print("{:<40} {}/{:<15}".format("Successful requests:", metrics["completed_requests"], len(requests_list)))
+
+    print("{:<40} {:<15}".format("Failed requests:", metrics["failed_requests"]))
+    if metrics["errors"]:
+        print("Request errors:")
+        for error, count in metrics["errors"].items():
+            print(f"  {count} request(s): {error}")
 
     # Section 3: Performance Metrics
     print(f"{'-' * 50}")
@@ -1479,6 +1494,13 @@ if __name__ == "__main__":
         type=str,
         default=None,
         help="Path to local dataset file (optional).",
+    )
+    parser.add_argument(
+        "--video-poll-timeout",
+        type=float,
+        default=600.0,
+        help="Maximum seconds to poll an async video job, including server queueing and generation. "
+        "Increase this for long videos or high concurrency. Timed-out jobs are deleted and cancelled.",
     )
     parser.add_argument("--num-prompts", type=int, default=10, help="Number of prompts to benchmark.")
     parser.add_argument(

--- a/benchmarks/diffusion/diffusion_benchmark_serving.py
+++ b/benchmarks/diffusion/diffusion_benchmark_serving.py
@@ -1498,7 +1498,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--video-poll-timeout",
         type=float,
-        default=600.0,
+        default=1200.0,
         help="Maximum seconds to poll an async video job, including server queueing and generation. "
         "Increase this for long videos or high concurrency. Timed-out jobs are deleted and cancelled.",
     )

--- a/tests/benchmarks/test_diffusion_video_timeout.py
+++ b/tests/benchmarks/test_diffusion_video_timeout.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from benchmarks.diffusion import backends
+
+pytestmark = [pytest.mark.core_model, pytest.mark.benchmark, pytest.mark.cpu]
+
+
+class Response:
+    def __init__(self, payload=None, status=200):
+        self.payload = payload
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def json(self):
+        return self.payload
+
+    async def text(self):
+        return str(self.payload)
+
+    async def read(self):
+        return b"video"
+
+
+class VideoSession:
+    def __init__(self, clock, *, post_status=200, poll_status="completed", http_error=None):
+        self.clock = clock
+        self.post_status = post_status
+        self.poll_status = poll_status
+        self.http_error = http_error
+        self.deleted = []
+        self.content_read = False
+        self.polls = 0
+
+    def post(self, *args, **kwargs):
+        if self.http_error:
+            raise self.http_error
+        return Response({"id": "video-test", "status": "queued"}, self.post_status)
+
+    def get(self, url):
+        if url.endswith("/content"):
+            self.content_read = True
+            return Response()
+        # A queued job takes over ten minutes, independent of wall-clock time.
+        self.clock.now = 600.0 + self.polls + 1
+        self.polls += 1
+        status = self.poll_status
+        if isinstance(status, list):
+            status = status[self.polls - 1]
+        return Response({"status": status, "error": "generation failed"})
+
+    def delete(self, url):
+        self.deleted.append(url)
+        return Response()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("timeout", "status", "success", "error"),
+    [
+        (600, "in_progress", False, "after 600s"),
+        (1800, ["in_progress", "completed"], True, ""),
+        (600, "completed", True, ""),
+        (600, "failed", False, "Video job failed"),
+    ],
+)
+async def test_video_poll_timeout_and_terminal_status(monkeypatch, timeout, status, success, error):
+    clock = SimpleNamespace(now=0.0)
+    monkeypatch.setattr(backends, "time", SimpleNamespace(perf_counter=lambda: clock.now))
+
+    async def sleep(_):
+        clock.now += 2
+
+    monkeypatch.setattr(backends.asyncio, "sleep", sleep)
+    session = VideoSession(clock, poll_status=status)
+    progress = Mock()
+    request = backends.RequestFuncInput(prompt="test", api_url="http://test/v1/videos", model="MiniMax-H3")
+    request.video_poll_timeout = timeout
+    output = await backends.async_request_v1_videos(request, session, progress)
+    assert output.success is success
+    assert error in output.error
+    assert output.latency == (602.0 if isinstance(status, list) else 601.0)
+    assert session.content_read is success
+    assert session.deleted == ["http://test/v1/videos/video-test"]
+    progress.update.assert_called_once_with(1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["http_error", "timeout_exception", "invalid_references"])
+async def test_video_failures_always_update_progress(monkeypatch, mode):
+    ticks = iter([0.0, 1.0])
+    monkeypatch.setattr(backends, "time", SimpleNamespace(perf_counter=lambda: next(ticks)))
+    session = VideoSession(
+        SimpleNamespace(now=0.0),
+        post_status=503 if mode == "http_error" else 200,
+        http_error=TimeoutError() if mode == "timeout_exception" else None,
+    )
+    request = backends.RequestFuncInput(prompt="test", api_url="http://test/v1/videos", model="MiniMax-H3")
+    if mode == "invalid_references":
+        request.image_paths = ["image.png"]
+        request.video_paths = ["video.mp4"]
+    progress = Mock()
+    output = await backends.async_request_v1_videos(request, session, progress)
+    assert not output.success
+    assert output.error
+    if mode == "timeout_exception":
+        assert "TimeoutError" in output.error
+    assert output.latency == 1.0
+    progress.update.assert_called_once_with(1)


### PR DESCRIPTION
## Purpose

Related to #7246.

The async `/v1/videos` benchmark hard-codes a 600-second polling budget. Under long generation times or server queueing, it returns a failure and deletes the job; the server cancels outstanding generation, producing aborted-request logs. Those early returns skip latency and progress updates, so a run that submitted every prompt can appear to stop early. The console also omits the collected failure reasons. A terminal `completed` or `failed` response can additionally be misclassified as a timeout when observed after the deadline.

This change adds `--video-poll-timeout` (finite positive seconds, default increased from 600 to 1200 seconds), carries it into warmups, honors terminal status before checking the polling deadline, and finalizes video latency/progress on early returns. Console and JSON results report failure reasons, including the exception type for otherwise empty timeout exceptions. Timed-out jobs are still cleaned up; there are no retries or model/server inference changes.

For long queued video workloads, pass e.g. `--video-poll-timeout 1800`. `VLLM_OMNI_VIDEO_SYNC_TIMEOUT` belongs to `/v1/videos/sync` and does not affect this async benchmark.

## Test Plan

**vLLM Version:** 0.28.0; PyTorch 2.13.0; Python 3.13.12; aiohttp 3.14.3.

**vLLM-Omni Commit:** baseline `c704aecc`; GPU validation `3d7cec37`; default-1200s update `78035202` (CPU tests and pre-commit rechecked).

CPU regression coverage (pytest + pytest-asyncio; no model weights/GPU required):

```bash
pytest -q tests/benchmarks/test_diffusion_video_timeout.py tests/benchmarks/test_diffusion_backends_metrics.py -m 'core_model and cpu' --run-level core_model
```

Real-model baseline: 4 x NVIDIA B300 (devices 0,2,3,4), MiniMax-H3 FL2VA snapshot `42ed227ee7df40d41602854ae760620d6eb651fe`, dense BF16, USP4/HSDP4, text-encoder TP4, VAE tile parallelism 4. The model cache and venv were already local. No shared caches were dropped. One server was reused after readiness and warmup; initialization is excluded from benchmark duration. The initial environment probe found `/tmp/storage` was root-owned; the actual benchmark used an explicitly writable storage directory.

```bash
export MODEL=/path/to/MiniMax-H3/FL2VA
export VLLM_OMNI_SERVER_STORAGE__PATH=/path/to/writable/video-storage
CUDA_VISIBLE_DEVICES=0,2,3,4 VLLM_WORKER_MULTIPROC_METHOD=spawn \
vllm serve "$MODEL" --omni --host 127.0.0.1 --port 18746 \
  --trust-remote-code --task-type fl2va --num-gpus 4 --usp 4 --ring 1 \
  --use-hsdp --hsdp-shard-size 4 --text-encoder-tp-size 4 \
  --vae-patch-parallel-size 4 --vae-parallel-mode tile --vae-use-tiling \
  --stage-init-timeout 1800 --init-timeout 1800 \
  --enable-diffusion-pipeline-profiler

python benchmarks/diffusion/diffusion_benchmark_serving.py \
  --model "$MODEL" --host 127.0.0.1 --port 18746 \
  --endpoint /v1/videos --dataset random --task t2v \
  --num-prompts 90 --max-concurrency 15 \
  --warmup-requests 1 --warmup-concurrency 1 --seed 758 \
  --random-request-config '[{"width":1344,"height":768,"num_inference_steps":8,"num_frames":209,"fps":24,"weight":1}]' \
  --extra-body '{"flow_shift":12.0,"extra_params":"{\"task\":\"t2va\",\"duration\":8.7,\"aspect_ratio\":\"16:9\",\"audio_flow_shift\":3.0}"}' \
  --output-file result.json
```

## Test Result

- Seven new regression cases fail against the frozen original backend. The fixed suite passes: **12 passed** (7 new + 5 existing).
- A deterministic clock probe submits all 90 requests with 62 successes and 28 timeouts: original progress stops at 62 with failed latency 0; the fix reaches progress 90 and preserves failure latencies/reasons.
- A real local HTTP fixture with a shortened polling budget confirms 90 POSTs, 90 cleanup DELETEs, 62 successes and 28 explicitly reported failures, with full progress.
- Relevant pre-commit checks and `git diff --check` pass. SPDX and existing README formatting were normalized by the required hooks.


Real-model results:

| Check | Requests / concurrency | Poll budget | Successful / failed |
| --- | --- | --- | --- |
| Unmodified baseline, issue workload | 90 / 15 | 600 s (hard-coded) | 90 / 0 |
| Fixed client, deliberately short budget | 3 / 1 | 0.1 s | 0 / 3 |
| Fixed client, longer budget immediately after cancellation test | 3 / 1 | 1800 s | 3 / 0 |

The original benchmark completed in **1268.35 s**, with mean request latency **195.13 s** and P99 **213.29 s**. There were no server errors or aborted requests during this baseline. Thus the reported default-budget failure **did not reproduce naturally on these faster B300 GPUs**; the NPU incident is not independently verified.

For the targeted checks, reuse the command above with `--num-prompts 3 --max-concurrency 1 --warmup-requests 0`, first adding `--video-poll-timeout 0.1`, then `--video-poll-timeout 1800 --save-dir validation-media`. Every short-budget failure reports its job ID and timeout and corresponds to a DELETE and server-side `Aborted request(s)` log. The progress bar reaches 3/3 in both checks. These are functional timeout/cancellation tests, not a performance A/B comparison. The polling interval remains 2 s, so a 0.1 s budget is observed at the first poll, not enforced as a subsecond HTTP deadline.

All three successful validation MP4s pass full ffmpeg decode and contain H.264 video (1344x768, 209 frames, 8.708333 s) plus 32 kHz stereo AAC audio. The existing inference path is unchanged. The CPU tests separately verify jobs remaining in progress beyond the old 600-second budget with an extended timeout, and completed/failed terminal responses observed at the deadline.

