### PR TITLE
[Bugfix][Cosmos3] Preserve positional torch.load map location

### DIFF
--- a/tests/diffusion/models/cosmos3/test_guardrails_load.py
+++ b/tests/diffusion/models/cosmos3/test_guardrails_load.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Test the torch.load wrapper without importing model or accelerator runtimes."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.diffusion]
+
+
+@pytest.fixture
+def load_guardrails(monkeypatch):
+    def load(platform, cuda_available=False):
+        # Use an explicit signature so duplicate map_location arguments raise
+        # exactly as they do in torch.load, instead of being accepted by a Mock.
+        def torch_load(f, map_location=None, pickle_module=None, *, weights_only=True, mmap=None):
+            return f, map_location, pickle_module, weights_only, mmap
+
+        dependencies = {
+            "numpy": {"ndarray": object},
+            "torch": {
+                "load": torch_load,
+                "cuda": SimpleNamespace(is_available=lambda: cuda_available),
+            },
+            "vllm.logger": {"init_logger": lambda name: None},
+            "vllm_omni.diffusion.models.progress_bar": {"_is_rank_zero": lambda: True},
+            "vllm_omni.errors": {"GuardrailViolationError": RuntimeError},
+            "vllm_omni.platforms": {
+                "current_omni_platform": SimpleNamespace(
+                    is_npu=lambda: platform == "npu", is_xpu=lambda: platform == "xpu"
+                )
+            },
+            "cosmos_guardrail": {"CosmosSafetyChecker": object},
+        }
+        for name, attrs in dependencies.items():
+            module = ModuleType(name)
+            module.__dict__.update(attrs)
+            monkeypatch.setitem(sys.modules, name, module)
+
+        path = Path(__file__).resolve().parents[4] / "vllm_omni/diffusion/models/cosmos3/guardrails.py"
+        spec = importlib.util.spec_from_file_location("_test_cosmos3_guardrails", path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return sys.modules["torch"].load
+
+    return load
+
+
+@pytest.mark.parametrize("platform", ["npu", "xpu"])
+@pytest.mark.parametrize("location", ["cpu", None, {"cuda:0": "cpu"}, lambda storage, location: storage])
+def test_preserves_explicit_map_location(load_guardrails, platform, location):
+    load = load_guardrails(platform)
+    # Positional and keyword forms must agree, including explicit None.
+    assert load("checkpoint.pt", location)[1] is location
+    assert load("checkpoint.pt", map_location=location)[1] is location
+
+
+@pytest.mark.parametrize(
+    ("platform", "cuda_available", "expected"),
+    [("npu", False, "cpu"), ("xpu", False, "cpu"), ("cpu", False, None), ("npu", True, None)],
+)
+def test_default_map_location(load_guardrails, platform, cuda_available, expected):
+    load = load_guardrails(platform, cuda_available)
+    assert load("checkpoint.pt")[1] == expected
+
+
+def test_forwards_remaining_load_arguments(load_guardrails):
+    load = load_guardrails("npu")
+    pickle_module = object()
+    assert load("checkpoint.pt", "cpu", pickle_module, weights_only=False, mmap=True) == (
+        "checkpoint.pt",
+        "cpu",
+        pickle_module,
+        False,
+        True,
+    )
+
+
+def test_duplicate_map_location_still_raises(load_guardrails):
+    load = load_guardrails("npu")
+    with pytest.raises(TypeError, match="multiple values.*map_location"):
+        load("checkpoint.pt", "cpu", map_location="cpu")

--- a/vllm_omni/diffusion/models/cosmos3/guardrails.py
+++ b/vllm_omni/diffusion/models/cosmos3/guardrails.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Cosmos3 guardrail hooks for vllm-omni.
 
 Thin adapter around the ``cosmos_guardrail`` package's ``CosmosSafetyChecker``
@@ -41,8 +41,11 @@ _original_torch_load = torch.load
 
 
 def _patched_torch_load(*args, **kwargs):
+    # torch.load accepts map_location as its second positional argument too.
+    # Preserve explicit locations (including None) in either calling form.
     if (
-        "map_location" not in kwargs
+        len(args) < 2
+        and "map_location" not in kwargs
         and not torch.cuda.is_available()
         and (current_omni_platform.is_npu() or current_omni_platform.is_xpu())
     ):


### PR DESCRIPTION
## Purpose

On NPU/XPU without CUDA, the Cosmos3 `torch.load` wrapper adds `map_location="cpu"` even when the caller supplies the location positionally. A valid call such as `torch.load(path, "cpu")` then raises `TypeError: load() got multiple values for argument 'map_location'` after the guardrails module is imported.

Check for a second positional argument before supplying the default. Explicit locations, including `None`, retain their original semantics. Add regression coverage for both calling forms, default mapping, argument forwarding, and invalid duplicate arguments. The touched source header is also normalized by the repository SPDX hook.

## Test Plan

The regression can be reproduced on the parent revision by copying the new test file there and running:

```sh
python -m pytest --noconftest -o addopts='' tests/diffusion/models/cosmos3/test_guardrails_load.py -q
```

The tests load the source module with isolated dependency stubs and simulate NPU/XPU platform conditions. Before the fix: 9 failed, 5 passed. After the fix: 14 passed.

In a fully provisioned repository test environment, the existing CPU CI selection includes this file:

```sh
pytest tests/diffusion/models/cosmos3/test_guardrails_load.py -m 'core_model and cpu' --run-level core_model
```

**vLLM Version:** Not exercised by the isolated tests.

**vLLM-Omni Commit:** Base c086554d; fix ef249d84.

## Test Result

- Python 3.11, PyTorch 2.13.0, macOS CPU: 14 regression cases passed. One pytest configuration warning (`asyncio_mode`, plugin unavailable).
- Additional local check using the production wrapper function and real `torch.save`/`torch.load`: the parent reproduced the duplicate-argument error; 22 checkpoint round trips passed with the fix. Platform predicates were simulated.
- Ruff check/format, SPDX, forbidden imports, torch.cuda policy, test markers, and whitespace checks passed.
- Full pre-commit/mypy and accelerator inference were not run. No model-quality or performance claim.
