### PR TITLE
[BUGFIX] Stabilize duplex reaper cleanup recovery test

### DIFF
--- a/tests/engine/test_orchestrator.py
+++ b/tests/engine/test_orchestrator.py
@@ -2666,6 +2666,8 @@ async def test_duplex_reaper_loop_waits_between_ticks():
 
 @pytest.mark.asyncio
 async def test_duplex_reaper_loop_survives_one_cleanup_failure():
+    cleanup_succeeded = asyncio.Event()
+
     class _Plane:
         def __init__(self) -> None:
             self.calls = 0
@@ -2674,6 +2676,7 @@ async def test_duplex_reaper_loop_survives_one_cleanup_failure():
             self.calls += 1
             if self.calls == 1:
                 raise RuntimeError("transient cleanup failure")
+            cleanup_succeeded.set()
             return 0
 
     orchestrator = object.__new__(Orchestrator)
@@ -2682,9 +2685,12 @@ async def test_duplex_reaper_loop_survives_one_cleanup_failure():
     orchestrator._shutdown_event = asyncio.Event()
 
     task = asyncio.create_task(orchestrator._duplex_reaper_loop())
-    await asyncio.sleep(0.035)
-    orchestrator._shutdown_event.set()
-    await task
+    try:
+        # Wait for recovery rather than relying on CI scheduling within 35 ms.
+        await asyncio.wait_for(cleanup_succeeded.wait(), timeout=5.0)
+    finally:
+        orchestrator._shutdown_event.set()
+        await task
 
     assert orchestrator.duplex_control_plane.calls >= 2
 


### PR DESCRIPTION
## Purpose
Fix a flaky `test_duplex_reaper_loop_survives_one_cleanup_failure`.                                                                                 
The test previously waited a fixed 35 ms before stopping the reaper. Under CI scheduling delays, only the first cleanup attempt could run, causing  `assert calls >= 2` to fail.                                                                                                                        
Wait for an `asyncio.Event` signaling successful cleanup after the injected failure, with a 5-second timeout. Use `finally` to shut down and await the reaper task. Production behavior is unchanged.  

#7260 

## Test Plan
`pytest tests/engine/test_orchestrator.py::test_duplex_reaper_loop_survives_one_cleanup_failure -q`

## Test Result
<img width="1081" height="482" alt="image" src="https://github.com/user-attachments/assets/382c1f44-a4aa-43f5-8f20-a21d317aba6c" />
