### PR TITLE
[Bugfix] Catch non-ImportError exceptions in NVFP4 NaN-clamp install guard

### DIFF
--- a/tests/model_executor/quantization/test_nvfp4_nan_clamp_import_guard.py
+++ b/tests/model_executor/quantization/test_nvfp4_nan_clamp_import_guard.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Regression test for the NVFP4 NaN-clamp install guard in
+``vllm_omni.patch`` swallowing only ``ImportError``.
+
+https://github.com/vllm-project/vllm-omni/issues/7232 hit a weekly-CI
+crash where importing ``vllm_omni`` raised
+``vllm.third_party.pynvml.NVMLError_InvalidArgument``. That error comes
+from ``vllm.model_executor.layers.quantization.utils.w8a8_utils``'s
+module-level ``CUTLASS_FP8_SUPPORTED = cutlass_fp8_supported()``, which
+is reached transitively while ``vllm_omni.patch`` does:
+
+    from vllm.model_executor.layers.quantization.modelopt import (
+        ModelOptNvFp4LinearMethod as _OriginalModelOptNvFp4LinearMethod,
+    )
+
+to install the NVFP4 weight_scale NaN clamp. That import is guarded by
+``except ImportError`` so a missing/older modelopt degrades gracefully
+with a warning, but ``NVMLError_InvalidArgument`` is a ``RuntimeError``
+subclass, not an ``ImportError`` subclass — so the guard didn't catch it
+and the whole ``vllm_omni`` import crashed instead of degrading.
+
+This test does not require a real ``vllm`` install (unavailable in this
+environment, and CUDA/NVML-only): it extracts the actual try/except/else
+block via ``ast`` from the current ``vllm_omni/patch.py`` source, then
+execs it in a subprocess with a fake import chain that raises a
+non-ImportError exception where the real modelopt import chain would
+raise ``NVMLError_InvalidArgument``. This exercises the real, current
+source of the guard rather than a hand-copied duplicate that could drift
+out of sync.
+"""
+
+import ast
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+PATCH_PY = Path(__file__).resolve().parents[3] / "vllm_omni" / "patch.py"
+
+
+def _extract_nvfp4_install_block() -> str:
+    source = PATCH_PY.read_text()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Try) and any(
+            isinstance(handler, ast.ExceptHandler) and handler.name == "_nan_clamp_import_err"
+            for handler in node.handlers
+        ):
+            segment = ast.get_source_segment(source, node)
+            assert segment is not None
+            return segment
+    raise AssertionError("NVFP4 NaN-clamp try/except block not found in vllm_omni/patch.py")
+
+
+# Fakes the exact failure mode from the issue: importing
+# vllm.model_executor.layers.quantization.modelopt raises a non-ImportError
+# exception (standing in for NVMLError_InvalidArgument, a RuntimeError
+# subclass) instead of failing to import. Runs in a subprocess so the fake
+# `vllm.*` namespace packages and sys.meta_path finder never leak into other
+# tests in this process.
+_NVFP4_IMPORT_GUARD_PROBE = """
+import importlib.abc
+import importlib.machinery
+import logging
+import os
+import sys
+import types
+
+
+class _FakeNVMLError(RuntimeError):
+    pass  # stand-in for vllm.third_party.pynvml.NVMLError_InvalidArgument
+
+
+class _RaisingLoader(importlib.abc.Loader):
+    def create_module(self, spec):
+        return None
+
+    def exec_module(self, module):
+        raise _FakeNVMLError("Invalid Argument")
+
+
+class _RaisingFinder(importlib.abc.MetaPathFinder):
+    TARGET = "vllm.model_executor.layers.quantization.modelopt"
+
+    def find_spec(self, fullname, path, target=None):
+        if fullname == self.TARGET:
+            return importlib.machinery.ModuleSpec(fullname, _RaisingLoader())
+        return None
+
+
+for _pkg in (
+    "vllm",
+    "vllm.model_executor",
+    "vllm.model_executor.layers",
+    "vllm.model_executor.layers.quantization",
+):
+    _mod = types.ModuleType(_pkg)
+    _mod.__path__ = []
+    sys.modules[_pkg] = _mod
+
+sys.meta_path.insert(0, _RaisingFinder())
+
+_PATCH_LOGGER = logging.getLogger("vllm_omni.patch.test")
+_already_patched_upstream = False
+_clamp_installed = False
+
+__BLOCK__
+
+print("SURVIVED")
+"""
+
+
+def test_nvfp4_install_guard_survives_non_import_error_from_modelopt_chain():
+    """The install guard must not let a non-ImportError exception from the
+    optional modelopt import chain crash the whole vllm_omni import."""
+    block = _extract_nvfp4_install_block()
+    script = _NVFP4_IMPORT_GUARD_PROBE.replace("__BLOCK__", block)
+    env = os.environ.copy()
+    env.pop("VLLM_OMNI_SKIP_NVFP4_NAN_CLAMP", None)
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, timeout=30, env=env)
+    assert result.returncode == 0 and "SURVIVED" in result.stdout, (
+        "NVFP4 NaN-clamp install guard must catch non-ImportError exceptions raised by "
+        "the optional modelopt import chain (e.g. an NVML/driver error surfaced "
+        "transitively via cutlass_fp8_supported()) instead of crashing the whole "
+        f"vllm_omni import.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )

--- a/vllm_omni/patch.py
+++ b/vllm_omni/patch.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 import logging
 import os
 import sys
@@ -200,7 +203,14 @@ try:
     from vllm.model_executor.layers.quantization.modelopt import (
         ModelOptNvFp4LinearMethod as _OriginalModelOptNvFp4LinearMethod,
     )
-except ImportError as _nan_clamp_import_err:
+except Exception as _nan_clamp_import_err:  # noqa: BLE001 - this optional import
+    # transitively pulls in vllm.model_executor.layers.quantization.utils.w8a8_utils,
+    # whose module-level `cutlass_fp8_supported()` probes NVML and can raise
+    # environment/driver errors (e.g. NVMLError_InvalidArgument, which is NOT an
+    # ImportError subclass) instead of failing to import. A narrower `except
+    # ImportError` here lets that escape and crashes the whole vllm_omni import
+    # instead of degrading gracefully. See
+    # https://github.com/vllm-project/vllm-omni/issues/7232.
     _PATCH_LOGGER.warning(
         "NVFP4 weight_scale NaN-clamp patch could NOT install: %s. NVFP4 W4A4 "
         "checkpoints with NaN bytes in per-block weight_scale will serve `!!!!`.",


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

Fixes a weekly-CI crash reported in the issue: `import vllm_omni` can crash outright with
`vllm.third_party.pynvml.NVMLError_InvalidArgument: Invalid Argument` instead of degrading
gracefully.

`vllm_omni/patch.py` installs an optional NVFP4 `weight_scale` NaN-clamp by doing:

```python
from vllm.model_executor.layers.quantization.modelopt import (
    ModelOptNvFp4LinearMethod as _OriginalModelOptNvFp4LinearMethod,
)
```

guarded by `except ImportError`, intended to degrade gracefully (log a warning, skip the
patch) when modelopt isn't available. That import transitively pulls in
`vllm.model_executor.layers.quantization.utils.w8a8_utils`, whose module-level
`CUTLASS_FP8_SUPPORTED = cutlass_fp8_supported()` probes NVML via
`current_platform.get_device_capability()`. In the reported CI environment this raised
`NVMLError_InvalidArgument` — a `RuntimeError` subclass, **not** an `ImportError` subclass —
so the existing `except ImportError` did not catch it. The exception propagated through
`vllm_omni/patch.py` and then through `vllm_omni/__init__.py`'s own
`except ModuleNotFoundError` guard (which also doesn't match), crashing the entire
`import vllm_omni` instead of just skipping the optional NaN-clamp patch.

## Approach

Broaden the guard from `except ImportError` to `except Exception` (with `# noqa: BLE001`),
matching an existing precedent already used elsewhere in the same file for other
"this optional patch install must never crash the whole import" guards. This only changes
the import-*failure* path — the `else:` branch that installs the clamp on a *successful*
import is untouched, so this cannot mask a bug in the clamp-install logic itself.

## Test Plan

**vLLM Version:** N/A — `vllm` cannot be installed in this environment (manylinux/Linux-only
wheels, CUDA-only, ~300MB); this fix and its test do not require a real `vllm` install.

**vLLM-Omni Commit:** 7c2e30af (branch tip at time of this change)

Added `tests/model_executor/quantization/test_nvfp4_nan_clamp_import_guard.py`, which:
1. Extracts the exact try/except/else block from the live `vllm_omni/patch.py` source via
   `ast` (identified by the `except ... as _nan_clamp_import_err` handler name), so the test
   exercises the real current source rather than a hand-copied duplicate.
2. In a subprocess, injects fake `vllm.*` namespace packages plus a `sys.meta_path` finder
   that raises a non-`ImportError` exception (standing in for `NVMLError_InvalidArgument`)
   the moment `vllm.model_executor.layers.quantization.modelopt` is imported, then execs the
   extracted block and asserts it degrades gracefully instead of crashing.

Ran manually (not via `pytest`, because this repo's root `conftest.py` unconditionally
imports real `vllm` and therefore fails to collect anything at all in this `vllm`-less
sandbox — a pre-existing environment limitation, not introduced by this change) in a
throwaway venv (`torch`, `pytest`, `aenum`, `numpy`, `transformers`, `regex` via
`uv pip install`):
- `git stash` the fix and run the test directly: **fails** — subprocess crashes with an
  unhandled `_FakeNVMLError`, reproducing the issue's failure mode.
- Restore the fix and run the test directly: **passes** — subprocess exits 0, prints
  `SURVIVED`.
- `ruff check` / `ruff format --check` on both changed files: clean (a pre-existing,
  unrelated `ruff format` diff exists elsewhere in `patch.py` around a `qwen3_omni_moe`
  lambda — confirmed present on `HEAD` before this change too, a ruff-version formatting
  artifact, not touched here).
- `tools/pre_commit/check_test_marks.py`, `check_spdx_header.py`, `check_forbidden_imports.py`,
  `check_torch_cuda.py` all pass on both changed files.

Not run: `mypy` (pre-commit's mypy hooks are `stages: [manual]` and require the full `vllm`
dependency chain to type-check against, infeasible in this environment), and the original
GPU/NVML CI reproduction (also infeasible here — no GPU). The defect and fix are
demonstrated instead via the fails-before/passes-after targeted test above, which reproduces
the exact exception-type mismatch from the issue.

note: `main`'s CI (Build Wheel, pre-commit) was green at the time of this change.

## Test Result

Before the fix: the targeted regression test fails, reproducing
`vllm.third_party.pynvml.NVMLError_InvalidArgument`-style crash behavior (via a stand-in
exception) escaping the `except ImportError` guard.

After the fix: the same test passes — the guard catches the non-`ImportError` exception,
logs the existing "NVFP4 weight_scale NaN-clamp patch could NOT install" warning, and lets
the rest of `vllm_omni` import normally.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)

Fixes #7232