### PR TITLE
[Refactor] Share packed head-parallel exchanges for diffusion models

### DIFF
--- a/tests/diffusion/distributed/test_head_parallel.py
+++ b/tests/diffusion/distributed/test_head_parallel.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from datetime import timedelta
+from unittest.mock import Mock
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from vllm_omni.diffusion.distributed.head_parallel import (
+    HeadParallelLayout,
+    scatter_heads_gather_tokens,
+    scatter_tokens_gather_heads,
+)
+from vllm_omni.diffusion.models.magi2.parallel import Magi2ParallelGroup, ep_dispatch, ep_undispatch
+
+pytestmark = [pytest.mark.diffusion, pytest.mark.core_model]
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize(
+    "counts,rank",
+    [((), 0), ([1, 2], 0), ((1, -1), 0), ((1, 2.5), 0), ((True, 1), 0), ((1, 2), -1), ((1, 2), 2), ((1,), True)],
+)
+def test_invalid_layout(counts, rank):
+    with pytest.raises(ValueError):
+        HeadParallelLayout(counts, rank)
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("tokens", [0, 3])
+def test_single_rank_identity(tokens):
+    layout = HeadParallelLayout((tokens,), 0)
+    tensor = torch.empty(tokens, 4, 8)
+    assert scatter_heads_gather_tokens(tensor, None, layout) is tensor
+    assert scatter_tokens_gather_heads(tensor, None, layout) is tensor
+    assert layout.local_tokens == layout.total_tokens == tokens
+
+
+@pytest.mark.cpu
+def test_multi_rank_requires_owned_group():
+    with pytest.raises(ValueError, match="caller-owned process group"):
+        scatter_heads_gather_tokens(torch.empty(1, 2, 4), None, HeadParallelLayout((1, 2), 0))
+
+
+def _mock_group(monkeypatch, size=2, rank=0):
+    group = object()
+    monkeypatch.setattr(dist, "get_world_size", lambda passed: size if passed is group else -1)
+    monkeypatch.setattr(dist, "get_rank", lambda passed: rank if passed is group else -1)
+    return group
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("size,rank", [(3, 0), (2, 1)])
+def test_group_layout_mismatch_fails_before_collective(monkeypatch, size, rank):
+    group = _mock_group(monkeypatch, size, rank)
+    collective = Mock()
+    monkeypatch.setattr(dist, "all_to_all_single", collective)
+    with pytest.raises(ValueError, match="process group size/rank"):
+        scatter_heads_gather_tokens(torch.empty(1, 4, 8), group, HeadParallelLayout((1, 2), 0))
+    collective.assert_not_called()
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize(
+    "reverse,shape",
+    [
+        (False, (1, 4)),
+        (False, (2, 4, 8)),
+        (False, (1, 3, 8)),
+        (False, (1, 0, 8)),
+        (False, (1, 4, 0)),
+        (True, (3, 2)),
+        (True, (2, 2, 8)),
+        (True, (3, 0, 8)),
+        (True, (3, 2, 0)),
+    ],
+)
+def test_invalid_shape_fails_before_collective(monkeypatch, reverse, shape):
+    group = _mock_group(monkeypatch)
+    collective = Mock()
+    monkeypatch.setattr(dist, "all_to_all_single", collective)
+    exchange = scatter_tokens_gather_heads if reverse else scatter_heads_gather_tokens
+    with pytest.raises(ValueError):
+        exchange(torch.empty(shape), group, HeadParallelLayout((1, 2), 0))
+    collective.assert_not_called()
+
+
+@pytest.mark.cpu
+def test_explicit_layout_uses_token_counts_not_route_counts(monkeypatch):
+    group = _mock_group(monkeypatch)
+    collective = Mock()
+    monkeypatch.setattr(dist, "all_to_all_single", collective)
+    monkeypatch.setattr(dist, "all_gather", Mock(side_effect=AssertionError("no metadata collective expected")))
+    tensor = torch.empty(2, 6, 4)
+    layout = HeadParallelLayout((2, 5), 0)
+    dispatched = scatter_heads_gather_tokens(tensor, group, layout)
+    assert dispatched.shape == (7, 3, 4)
+    assert collective.call_args.kwargs == {
+        "output_split_sizes": [24, 60],
+        "input_split_sizes": [24, 24],
+        "group": group,
+    }
+    restored = scatter_tokens_gather_heads(dispatched, group, layout)
+    assert restored.shape == tensor.shape
+    assert collective.call_args.kwargs == {
+        "output_split_sizes": [24, 24],
+        "input_split_sizes": [24, 60],
+        "group": group,
+    }
+
+
+def _rank_tensor(rank: int, tokens: int, heads: int, dim: int) -> torch.Tensor:
+    # Noncontiguous packed view; values encode source rank and element position.
+    return (
+        torch.arange(tokens * heads * dim * 2, dtype=torch.float32).reshape(tokens, heads, dim * 2)[..., ::2]
+        + rank * 10000
+    )
+
+
+def _check_group(group: dist.ProcessGroup, ranks: tuple[int, ...], counts: tuple[int, ...], device: str) -> None:
+    rank = dist.get_rank(group)
+    layout = HeadParallelLayout(counts, rank)
+    heads, dim = 12, 4
+    inputs = [_rank_tensor(source, count, heads, dim) for source, count in zip(ranks, counts)]
+    # Preserve a noncontiguous layout after copying to the accelerator.
+    local = inputs[rank].to(device).repeat_interleave(2, dim=-1)[..., ::2]
+    local_heads = heads // len(ranks)
+    dispatched = scatter_heads_gather_tokens(local, group, layout)
+    expected = torch.cat(inputs)[:, rank * local_heads : (rank + 1) * local_heads]
+    torch.testing.assert_close(dispatched.cpu(), expected, rtol=0, atol=0)
+
+    # A head-owner-specific transformation catches wrong reverse permutations.
+    transformed = dispatched * 2 + rank
+    restored = scatter_tokens_gather_heads(transformed, group, layout)
+    offsets = torch.arange(len(ranks)).repeat_interleave(local_heads).view(1, heads, 1)
+    torch.testing.assert_close(restored.cpu(), inputs[rank] * 2 + offsets, rtol=0, atol=0)
+
+    magi_group = Magi2ParallelGroup(group, len(ranks), rank)
+    through_model = ep_dispatch(local, magi_group, list(counts))
+    torch.testing.assert_close(through_model.cpu(), expected, rtol=0, atol=0)
+    roundtrip = ep_undispatch(through_model, magi_group, list(counts))
+    torch.testing.assert_close(roundtrip.cpu(), inputs[rank], rtol=0, atol=0)
+    if len(set(counts)) == 1 and counts[0] > 0:
+        inferred = ep_dispatch(local, magi_group)
+        torch.testing.assert_close(ep_undispatch(inferred, magi_group).cpu(), inputs[rank], rtol=0, atol=0)
+
+
+def _worker(rank: int, rendezvous: str, world_size: int, backend: str, device_type: str) -> None:
+    torch.set_num_threads(1)
+    if device_type != "cpu":
+        torch.accelerator.set_device_index(rank)
+    device = "cpu" if device_type == "cpu" else f"{device_type}:{rank}"
+    dist.init_process_group(
+        backend, init_method=rendezvous, rank=rank, world_size=world_size, timeout=timedelta(seconds=60)
+    )
+    try:
+        ranks = tuple(range(world_size))
+        for counts in ((2,) * world_size, tuple(range(world_size)), (0,) * world_size):
+            _check_group(dist.group.WORLD, ranks, counts, device)
+        if world_size == 4:
+            for rank_sets in (((0, 1), (2, 3)), ((0, 2), (1, 3))):
+                for members in rank_sets:
+                    group = dist.new_group(ranks=list(members), backend=backend, timeout=timedelta(seconds=60))
+                    if rank in members:
+                        for counts in ((2, 3), (0, 3), (2, 0), (0, 0)):
+                            _check_group(group, members, counts, device)
+                        dist.destroy_process_group(group)
+                dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.cpu
+@pytest.mark.skipif(not dist.is_available() or not dist.is_gloo_available(), reason="requires Gloo")
+def test_four_rank_exchange_and_replica_subgroups(tmp_path):
+    mp.spawn(_worker, args=(f"file://{tmp_path / 'gloo-init'}", 4, "gloo", "cpu"), nprocs=4, join=True)
+
+
+@pytest.mark.musa
+def test_two_rank_musa_exchange(tmp_path):
+    if not hasattr(torch, "musa") or not torch.musa.is_available() or torch.musa.device_count() < 2:
+        pytest.skip("requires two MUSA devices")
+    mp.spawn(_worker, args=(f"file://{tmp_path / 'mccl-init'}", 2, "mccl", "musa"), nprocs=2, join=True)

--- a/vllm_omni/diffusion/distributed/head_parallel.py
+++ b/vllm_omni/diffusion/distributed/head_parallel.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+# Copyright (c) 2025-2026 SandAI. All Rights Reserved.
+
+"""Packed token/head exchanges over caller-owned parallel groups."""
+
+from dataclasses import dataclass
+
+import torch
+import torch.distributed as dist
+
+
+@dataclass(frozen=True)
+class HeadParallelLayout:
+    """Token counts in process-group rank order, shared by both exchanges.
+
+    Every rank must provide the same split tuple. Counts describe input tokens,
+    not routed expert rows. Head padding and replicated-token handling belong
+    to the caller; heads must be evenly partitioned within this group.
+    """
+
+    token_counts: tuple[int, ...]
+    rank: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.token_counts, tuple) or not self.token_counts:
+            raise ValueError("token_counts must be a nonempty tuple in process-group rank order")
+        if any(type(count) is not int or count < 0 for count in self.token_counts):
+            raise ValueError("token_counts must contain nonnegative integers")
+        if type(self.rank) is not int or not 0 <= self.rank < self.world_size:
+            raise ValueError("rank must index token_counts")
+
+    @property
+    def world_size(self) -> int:
+        return len(self.token_counts)
+
+    @property
+    def local_tokens(self) -> int:
+        return self.token_counts[self.rank]
+
+    @property
+    def total_tokens(self) -> int:
+        return sum(self.token_counts)
+
+    def validate_group(self, group: dist.ProcessGroup | None) -> None:
+        if group is None:
+            if self.world_size != 1:
+                raise ValueError("a caller-owned process group is required for a multi-rank exchange")
+        elif dist.get_world_size(group) != self.world_size or dist.get_rank(group) != self.rank:
+            raise ValueError("token layout does not match the process group size/rank")
+
+
+def scatter_heads_gather_tokens(
+    tensor: torch.Tensor,
+    group: dist.ProcessGroup | None,
+    layout: HeadParallelLayout,
+) -> torch.Tensor:
+    """Exchange ``[local_tokens, heads, dim]`` for ``[total_tokens, local_heads, dim]``."""
+    layout.validate_group(group)
+    if tensor.ndim != 3 or tensor.shape[0] != layout.local_tokens:
+        raise ValueError("input must be [local_tokens, heads, dim] matching the token layout")
+    if tensor.shape[1] == 0 or tensor.shape[2] == 0 or tensor.shape[1] % layout.world_size:
+        raise ValueError("positive head count must divide evenly across the group; head dimension must be positive")
+    if layout.world_size == 1:
+        return tensor
+
+    sequence, heads, dim = tensor.shape
+    local_heads = heads // layout.world_size
+    # Destination rank first; each destination receives a contiguous head shard.
+    send = tensor.reshape(sequence, layout.world_size, local_heads, dim).permute(1, 0, 2, 3).contiguous()
+    output = tensor.new_empty((layout.total_tokens, local_heads, dim))
+    if layout.total_tokens:
+        row_width = local_heads * dim
+        dist.all_to_all_single(
+            output.view(-1),
+            send.view(-1),
+            output_split_sizes=[count * row_width for count in layout.token_counts],
+            input_split_sizes=[sequence * row_width] * layout.world_size,
+            group=group,
+        )
+    return output
+
+
+def scatter_tokens_gather_heads(
+    tensor: torch.Tensor,
+    group: dist.ProcessGroup | None,
+    layout: HeadParallelLayout,
+) -> torch.Tensor:
+    """Undo the exchange using the same token layout and process group."""
+    layout.validate_group(group)
+    if tensor.ndim != 3 or tensor.shape[0] != layout.total_tokens:
+        raise ValueError("input must be [total_tokens, local_heads, dim] matching the token layout")
+    if tensor.shape[1] == 0 or tensor.shape[2] == 0:
+        raise ValueError("local head count and head dimension must be positive")
+    if layout.world_size == 1:
+        return tensor
+
+    local_heads, dim = tensor.shape[1:]
+    # Source rank first; restore its head shard after returning each token slice.
+    output = tensor.new_empty((layout.world_size, layout.local_tokens, local_heads, dim))
+    if layout.total_tokens:
+        row_width = local_heads * dim
+        dist.all_to_all_single(
+            output.view(-1),
+            tensor.contiguous().view(-1),
+            output_split_sizes=[layout.local_tokens * row_width] * layout.world_size,
+            input_split_sizes=[count * row_width for count in layout.token_counts],
+            group=group,
+        )
+    return output.permute(1, 0, 2, 3).contiguous().view(layout.local_tokens, layout.world_size * local_heads, dim)

--- a/vllm_omni/diffusion/models/magi2/parallel.py
+++ b/vllm_omni/diffusion/models/magi2/parallel.py
@@ -29,6 +29,12 @@ from dataclasses import dataclass
 import torch
 import torch.distributed as dist
 
+from vllm_omni.diffusion.distributed.head_parallel import (
+    HeadParallelLayout,
+    scatter_heads_gather_tokens,
+    scatter_tokens_gather_heads,
+)
+
 
 @dataclass(frozen=True)
 class Magi2ParallelGroup:
@@ -305,30 +311,16 @@ def ep_dispatch(
         raise ValueError(
             f"MoE head count {tensor.shape[1] if tensor.ndim >= 2 else '?'} must divide by EP size {group.world_size}"
         )
-    sequence, heads, dim = tensor.shape
-    local_heads = heads // group.world_size
+    sequence = tensor.shape[0]
     if sequence_split_sizes is None:
         local_size = torch.tensor([sequence], dtype=torch.int64, device=tensor.device)
         gathered_sizes = [torch.empty_like(local_size) for _ in range(group.world_size)]
         dist.all_gather(gathered_sizes, local_size, group=group.group)
         sequence_split_sizes = [int(size.item()) for size in gathered_sizes]
-    if len(sequence_split_sizes) != group.world_size or sequence_split_sizes[group.rank] != sequence:
+    if len(sequence_split_sizes) != group.world_size:
         raise ValueError("EP sequence split sizes do not describe the local tensor")
-    send = tensor.contiguous().view(sequence, group.world_size, local_heads, dim).permute(1, 0, 2, 3).contiguous()
-    output = torch.empty(
-        (sum(sequence_split_sizes), local_heads, dim),
-        dtype=tensor.dtype,
-        device=tensor.device,
-    )
-    row_width = local_heads * dim
-    dist.all_to_all_single(
-        output.view(-1),
-        send.view(-1),
-        output_split_sizes=[size * row_width for size in sequence_split_sizes],
-        input_split_sizes=[sequence * row_width] * group.world_size,
-        group=group.group,
-    )
-    return output
+    layout = HeadParallelLayout(tuple(sequence_split_sizes), group.rank)
+    return scatter_heads_gather_tokens(tensor, group.group, layout)
 
 
 def ep_undispatch(
@@ -347,25 +339,10 @@ def ep_undispatch(
         if tensor.shape[0] % group.world_size:
             raise ValueError("uneven EP sequence requires explicit split sizes")
         sequence_split_sizes = [tensor.shape[0] // group.world_size] * group.world_size
-    if len(sequence_split_sizes) != group.world_size or sum(sequence_split_sizes) != tensor.shape[0]:
+    if len(sequence_split_sizes) != group.world_size:
         raise ValueError("EP sequence split sizes do not partition the global tensor")
-    sequence = sequence_split_sizes[group.rank]
-    local_heads, dim = tensor.shape[1:]
-    send = tensor.contiguous()
-    output = torch.empty(
-        (group.world_size, sequence, local_heads, dim),
-        dtype=tensor.dtype,
-        device=tensor.device,
-    )
-    row_width = local_heads * dim
-    dist.all_to_all_single(
-        output.view(-1),
-        send.view(-1),
-        output_split_sizes=[sequence * row_width] * group.world_size,
-        input_split_sizes=[size * row_width for size in sequence_split_sizes],
-        group=group.group,
-    )
-    return output.permute(1, 0, 2, 3).contiguous().view(sequence, group.world_size * local_heads, dim)
+    layout = HeadParallelLayout(tuple(sequence_split_sizes), group.rank)
+    return scatter_tokens_gather_heads(tensor, group.group, layout)
 
 
 class Magi2SequenceDispatcher:


### PR DESCRIPTION
## Summary

Extract packed head-parallel exchanges into a shared diffusion distributed module, with MAGI-2 as the first caller.

- `HeadParallelLayout` holds immutable input-token counts in process-group rank order and validates the local rank/group contract.
- `scatter_heads_gather_tokens` maps `[local_tokens, heads, dim]` to `[total_tokens, local_heads, dim]`; `scatter_tokens_gather_heads` reverses the exchange using the same layout.
- Keep MAGI-2's existing group selection, single-rank behavior, and optional token-count discovery in its wrappers.

The functions consume an existing caller-owned process group. They do not create/destroy groups, select EP topology, pad model heads, route expert rows, or change conventional FusedMoE semantics. Explicit layouts need no token-count collective. All ranks must agree on the split tuple, dtype and head layout before entering a collective; local validation does not replace a distributed agreement protocol.

## Scope

Three files only: the shared primitive, minimal MAGI-2 wrappers, and focused tests. This is the exchange-contract portion of the MAGI-2 EP decomposition, not complete configurable EP support.

No changes to `DiffusionParallelConfig`, the existing TP/SP/CFG/DP/EP group lifecycle, public environment variables, MoE kernels, attention backends, sampler, compilation or dependency pins. Configurable group selection and the MAGI-2 EP adapter remain separate work. #7156 stays a reference draft.

The collective layout is retained from the native MAGI-2 implementation; its source attribution is preserved. Invalid rank/shape/count inputs are rejected, and globally empty exchanges skip communication.

## Validation

Commit: `7175f8575a3ab45726050c306862e6085b313616` (one signed-off commit), based on upstream `b58ff5cb8b17250b76f9cdf9b9b46385cdda4376`.

- Targeted pre-commit passed, including Ruff, mypy and test-marker checks.
- **64 CPU/Gloo tests passed**: layout/launch contracts; real four-rank exchanges over world, contiguous replica subgroups and noncontiguous rank subgroups; existing EP-layout tests; MAGI-2 pipeline/native tests and its four-rank TP4/TP2xSP2/SP4 tiny-model oracle.
- **One two-rank MCCL test passed** on two 60-SM MTT S5000 cards (driver `5.2.0-server`). It checks equal, uneven, one-empty and all-empty token partitions, direct exchange, head-owner-specific transformed return, and the MAGI-2 wrappers against exact CPU values (`rtol=atol=0`).
- Noncontiguous input and legacy inferred-count wrapper paths are covered. Shape/rank errors are checked before collective launch.

Stack: Python 3.10; torch/torch_musa `2.11.0.post1+musa5.2.0`; torchada `0.1.83`; vLLM `0.28.0`; vllm-musa `0.1.28`; Triton `3.2.0`. The exact checkout was installed editable with `--no-deps --no-build-isolation` into an isolated container; the MUSA entrypoint imports torchada before Torch/vLLM.

```bash
python -m pytest -q -o addopts= -m cpu \
  tests/diffusion/distributed/test_head_parallel.py \
  tests/diffusion/distributed/test_expert_parallel_layout.py \
  tests/diffusion/models/magi2/test_native_preview.py \
  tests/diffusion/models/magi2/test_pipeline_magi2.py \
  tests/diffusion/models/magi2/test_native_distributed_parity.py
```

For MUSA, run the new test file with `-m musa` from a torchada-first Python entrypoint with a `__main__` guard; it spawns two workers. Tests use bounded process-group timeouts.

**Not run:** CUDA/NCCL hardware, multi-node groups, graph/compile integration, full-checkpoint/video E2E, or performance benchmarks. This refactor does not claim a latency improvement or complete MAGI-2 EP enablement; it remains Draft.
