### PR TITLE
[Feature] Support model-declared head-sharded expert parallel groups

### DIFF
--- a/tests/diffusion/distributed/test_head_expert_parallel.py
+++ b/tests/diffusion/distributed/test_head_expert_parallel.py
@@ -1,0 +1,240 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from dataclasses import asdict
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+import vllm_omni.diffusion.distributed.parallel_state as state
+import vllm_omni.diffusion.model_metadata as metadata
+from tests.diffusion.distributed.test_expert_parallel_layout import _FakeGroup
+from vllm_omni.diffusion.data import DiffusionParallelConfig, OmniDiffusionConfig
+from vllm_omni.diffusion.forward_context import set_forward_context
+from vllm_omni.diffusion.vllm_config import create_diffusion_vllm_config
+
+pytestmark = [pytest.mark.diffusion, pytest.mark.core_model]
+_MODEL = "TestHeadEPPipeline"
+
+
+def _config(ep_size=None, *, tp=1, sp=4, pp=1, cfg=1, dp=1, enabled=True):
+    return OmniDiffusionConfig(
+        model_class_name=_MODEL,
+        dtype=torch.float32,
+        parallel_config=DiffusionParallelConfig(
+            tensor_parallel_size=tp,
+            ulysses_degree=sp,
+            pipeline_parallel_size=pp,
+            cfg_parallel_size=cfg,
+            data_parallel_size=dp,
+            enable_expert_parallel=enabled,
+            expert_parallel_size=ep_size,
+        ),
+    )
+
+
+@pytest.fixture
+def head_model(monkeypatch):
+    monkeypatch.setitem(
+        metadata._DIFFUSION_MODEL_METADATA, _MODEL, metadata.DiffusionModelMetadata(expert_parallel_style="head")
+    )
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("value", [0, -1, True, "2", 2.5])
+def test_invalid_public_ep_size(value):
+    with pytest.raises(ValueError):
+        DiffusionParallelConfig(enable_expert_parallel=True, expert_parallel_size=value)
+
+
+@pytest.mark.cpu
+def test_ep_size_requires_enable_flag():
+    with pytest.raises(ValueError, match="requires enable_expert_parallel"):
+        DiffusionParallelConfig(expert_parallel_size=2)
+
+
+@pytest.mark.cpu
+def test_metadata_opt_in_and_config_roundtrip(head_model):
+    od = _config(2, cfg=2)
+    assert od.parallel_config.world_size == 8
+    assert od.use_head_expert_parallel
+    assert not od.is_moe  # Model capability does not require HF whole-token expert fields.
+    assert DiffusionParallelConfig(**asdict(od.parallel_config)).expert_parallel_size == 2
+    assert not _config(enabled=False).use_head_expert_parallel
+    od.model_class_name = "Magi2Pipeline"
+    assert not od.use_head_expert_parallel  # Model adapter is a separate opt-in.
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("head", [False, True])
+def test_vllm_view_does_not_fold_native_head_groups(monkeypatch, head):
+    monkeypatch.setitem(
+        metadata._DIFFUSION_MODEL_METADATA,
+        _MODEL,
+        metadata.DiffusionModelMetadata(expert_parallel_style="head" if head else "vllm"),
+    )
+    od = _config(2 if head else None, tp=2, sp=4, cfg=2, dp=2)
+    od.tf_model_config = {"num_experts": 8}
+    config = create_diffusion_vllm_config(torch.device("cpu"), od)
+    assert config.parallel_config.tensor_parallel_size == 2
+    assert config.parallel_config.data_parallel_size == (2 if head else 4)
+    assert config.parallel_config.prefill_context_parallel_size == (1 if head else 4)
+    assert config.parallel_config.enable_expert_parallel is not head
+
+
+def _fake_state(monkeypatch, od, rank=0, fail_ep=False):
+    created = []
+
+    def factory(group_ranks, local_rank, backend, parallel_mode, **kwargs):
+        if fail_ep and parallel_mode == "expert":
+            raise RuntimeError("EP creation failed")
+        group = _FakeGroup(group_ranks, local_rank, parallel_mode, **kwargs)
+        group.destroy = Mock()
+        created.append(group)
+        return group
+
+    monkeypatch.setattr(dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(dist, "get_world_size", lambda: od.parallel_config.world_size)
+    monkeypatch.setattr(dist, "new_group", lambda ranks: tuple(ranks))
+    monkeypatch.setattr(
+        state, "get_world_group", lambda: SimpleNamespace(rank_in_group=rank, local_rank=rank, device_group=object())
+    )
+    monkeypatch.setattr(state, "get_forward_context", lambda: SimpleNamespace(omni_diffusion_config=od))
+    monkeypatch.setattr(state, "init_model_parallel_group", factory)
+    monkeypatch.setattr(
+        state,
+        "init_vllm_model_parallel_group",
+        Mock(side_effect=AssertionError("native EP must not create FusedMoE communicators")),
+    )
+    for name in ("_DP", "_CFG", "_SP", "_PP", "_FS", "_HSDP_REPLICATE", "_EXPERT_PARALLEL_GROUP_RANKS"):
+        monkeypatch.setattr(state, name, None)
+    for name in ("_TP", "_PCP", "_DP", "_EP", "_PP"):
+        monkeypatch.setattr(state.vllm_parallel_state, name, None)
+    return created
+
+
+def _initialize(od, backend="gloo"):
+    pc = od.parallel_config
+    state.initialize_model_parallel(
+        tensor_parallel_size=pc.tensor_parallel_size,
+        sequence_parallel_size=pc.sequence_parallel_size,
+        ulysses_degree=pc.ulysses_degree,
+        pipeline_parallel_size=pc.pipeline_parallel_size,
+        cfg_parallel_size=pc.cfg_parallel_size,
+        data_parallel_size=pc.data_parallel_size,
+        enable_expert_parallel=pc.enable_expert_parallel,
+        backend=backend,
+    )
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize(
+    "tp,sp,pp,cfg,dp,ep", [(1, 4, 1, 2, 1, None), (1, 8, 1, 1, 1, 4), (2, 4, 2, 2, 2, 2), (1, 4, 1, 2, 2, 1)]
+)
+def test_head_ep_stays_inside_each_sp_replica(monkeypatch, head_model, tp, sp, pp, cfg, dp, ep):
+    od = _config(ep, tp=tp, sp=sp, pp=pp, cfg=cfg, dp=dp)
+    rank = od.parallel_config.world_size - 1
+    created = _fake_state(monkeypatch, od, rank)
+    _initialize(od)
+    groups = state.get_expert_parallel_group_ranks()
+    size = ep or sp
+    assert sorted(rank for members in groups for rank in members) == list(range(od.parallel_config.world_size))
+    for members in groups:
+        assert len(members) == size
+        # Fixed TP/PP/CFG/DP coordinates; only a contiguous part of the SP axis varies.
+        assert len({(r % tp, r // (tp * sp)) for r in members}) == 1
+        assert [r // tp % sp for r in members] == list(range(members[0] // tp % sp, members[0] // tp % sp + size))
+    ep_group = state.vllm_parallel_state._EP
+    assert ep_group.local_group == next(members for members in groups if rank in members)
+    assert state.vllm_parallel_state._DP is state._DP
+    assert state._DP.world_size == dp
+    assert state.vllm_parallel_state._PCP is None
+    state.destroy_model_parallel()
+    assert state.vllm_parallel_state._EP is None
+    assert state._EXPERT_PARALLEL_GROUP_RANKS is None
+    for group in created:
+        group.destroy.assert_called_once()
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("size,head", [(3, True), (8, True), (2, False)])
+def test_invalid_group_size_fails_before_creation(monkeypatch, size, head):
+    monkeypatch.setitem(
+        metadata._DIFFUSION_MODEL_METADATA,
+        _MODEL,
+        metadata.DiffusionModelMetadata(expert_parallel_style="head" if head else "vllm"),
+    )
+    od = _config(size)
+    od.tf_model_config = {"num_experts": 8}
+    created = _fake_state(monkeypatch, od)
+    with pytest.raises(ValueError, match="expert_parallel_size"):
+        _initialize(od)
+    assert created == []
+    assert state.vllm_parallel_state._EP is None
+
+
+@pytest.mark.cpu
+def test_failed_head_group_creation_uses_existing_rollback(monkeypatch, head_model):
+    od = _config(2)
+    created = _fake_state(monkeypatch, od, fail_ep=True)
+    with pytest.raises(RuntimeError, match="EP creation failed"):
+        _initialize(od)
+    assert created
+    assert state._EXPERT_PARALLEL_GROUP_RANKS is None
+    assert state.vllm_parallel_state._EP is None
+    for group in created:
+        group.destroy.assert_called_once()
+
+
+def _group_worker(rank, rendezvous, device_type):
+    torch.set_num_threads(1)
+    backend = "gloo" if device_type == "cpu" else "mccl"
+    if device_type != "cpu":
+        torch.accelerator.set_device_index(rank)
+    dist.init_process_group(backend, init_method=rendezvous, world_size=4, rank=rank, timeout=timedelta(seconds=60))
+    metadata._DIFFUSION_MODEL_METADATA[_MODEL] = metadata.DiffusionModelMetadata(expert_parallel_style="head")
+    try:
+        state.init_distributed_environment(world_size=4, rank=rank, local_rank=rank, backend=backend)
+        for tp, sp, cfg, dp, ep_size in (
+            (1, 2, 2, 1, 2),
+            (1, 4, 1, 1, 2),
+            (1, 2, 1, 2, 2),
+            (2, 2, 1, 1, 2),
+            (1, 4, 1, 1, 1),
+        ):
+            od = _config(ep_size, tp=tp, sp=sp, cfg=cfg, dp=dp)
+            with set_forward_context(omni_diffusion_config=od):
+                _initialize(od, backend)
+                ep = state.vllm_parallel_state.get_ep_group()
+                assert ep.world_size == ep_size
+                assert ep.ranks in state.get_expert_parallel_group_ranks()
+                for dtype in (torch.float32, torch.bfloat16, torch.int64):
+                    tensor = torch.full((ep_size,), rank, dtype=dtype, device=device_type)
+                    output = torch.empty_like(tensor)
+                    dist.all_to_all_single(output, tensor, group=ep.device_group)
+                    assert output.cpu().tolist() == ep.ranks
+                state.destroy_model_parallel()
+                assert state.vllm_parallel_state._EP is None
+                assert state._EXPERT_PARALLEL_GROUP_RANKS is None
+            dist.barrier()
+    finally:
+        state.destroy_model_parallel()
+        state.destroy_distributed_environment()
+
+
+@pytest.mark.cpu
+@pytest.mark.skipif(not dist.is_available() or not dist.is_gloo_available(), reason="requires Gloo")
+def test_real_four_rank_head_ep_reinitialization(tmp_path):
+    mp.spawn(_group_worker, args=(f"file://{tmp_path / 'head-gloo'}", "cpu"), nprocs=4, join=True)
+
+
+@pytest.mark.musa
+def test_real_four_rank_musa_head_ep_reinitialization(tmp_path):
+    if not hasattr(torch, "musa") or not torch.musa.is_available() or torch.musa.device_count() < 4:
+        pytest.skip("requires four MUSA devices")
+    mp.spawn(_group_worker, args=(f"file://{tmp_path / 'head-mccl'}", "musa"), nprocs=4, join=True)

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -225,6 +225,8 @@ class DiffusionParallelConfig:
     """Number of tensor parallel groups."""
 
     enable_expert_parallel: bool = False
+    # Head-sharded models may partition each SP group into smaller EP groups.
+    expert_parallel_size: int | None = Field(default=None, gt=0, strict=True)
     """Enable expert parallelism for MoE layers (TP is still used for non-MoE layers)."""
 
     sequence_parallel_size: int | None = None
@@ -309,6 +311,8 @@ class DiffusionParallelConfig:
     @model_validator(mode="after")
     def _validate_parallel_config(self) -> Self:
         """Validates the config relationships among the parallel strategies."""
+        if self.expert_parallel_size is not None and not self.enable_expert_parallel:
+            raise ValueError("expert_parallel_size requires enable_expert_parallel=True")
         assert self.pipeline_parallel_size > 0, "Pipeline parallel size must be > 0"
         assert self.data_parallel_size is None or self.data_parallel_size > 0, "Data parallel size must be > 0"
         assert self.tensor_parallel_size > 0, "Tensor parallel size must be > 0"
@@ -1046,6 +1050,13 @@ class OmniDiffusionConfig:
 
     # Supplementary model specific parameters
     extras: dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def use_head_expert_parallel(self) -> bool:
+        return (
+            self.parallel_config.enable_expert_parallel
+            and get_diffusion_model_metadata(self.model_class_name).expert_parallel_style == "head"
+        )
 
     @property
     def is_moe(self) -> bool:

--- a/vllm_omni/diffusion/distributed/parallel_state.py
+++ b/vllm_omni/diffusion/distributed/parallel_state.py
@@ -31,6 +31,7 @@ If you only need to use the distributed environment without model parallelism,
 
 import inspect
 from math import prod
+from typing import cast
 
 import torch
 import torch.distributed
@@ -221,9 +222,9 @@ class RankGenerator:
 
     def get_mask(self, order: str, token: str):
         ordered_token = order.split("-")
-        token = token.split("-")
+        tokens = token.split("-")
         mask = [False] * len(ordered_token)
-        for t in token:
+        for t in tokens:
             mask[ordered_token.index(t)] = True
         return mask
 
@@ -818,13 +819,30 @@ def _initialize_model_parallel(
         return rank_generator.get_ranks(token)
 
     use_moe_parallel_mapping = False
+    use_head_parallel_mapping = False
+    expert_parallel_size = None
     if enable_expert_parallel:
         od_config = get_forward_context().omni_diffusion_config
-        use_moe_parallel_mapping = bool(od_config and od_config.is_moe)
-        if not use_moe_parallel_mapping:
+        expert_parallel_size = getattr(getattr(od_config, "parallel_config", None), "expert_parallel_size", None)
+        use_head_parallel_mapping = bool(od_config and getattr(od_config, "use_head_expert_parallel", False))
+        use_moe_parallel_mapping = bool(od_config and od_config.is_moe and not use_head_parallel_mapping)
+        if not use_moe_parallel_mapping and not use_head_parallel_mapping:
             raise RuntimeError("Expert parallelism enabled for a non-MoE model")
 
     sp_group_ranks = get_rank_groups("sp")
+    if expert_parallel_size is not None and (
+        type(expert_parallel_size) is not int or expert_parallel_size < 1 or not use_head_parallel_mapping
+    ):
+        raise ValueError("expert_parallel_size requires a positive integer and a model with enabled head-sharded EP")
+    if use_head_parallel_mapping:
+        ep_size = expert_parallel_size or sequence_parallel_size
+        if sequence_parallel_size % ep_size:
+            raise ValueError("head-sharded expert_parallel_size must divide sequence_parallel_size")
+        ep_group_ranks = [
+            ranks[start : start + ep_size] for ranks in sp_group_ranks for start in range(0, len(ranks), ep_size)
+        ]
+    else:
+        ep_group_ranks = get_rank_groups("tp-sp-cfg-dp")
     global _DP
     assert _DP is None, "data parallel group is already initialized"
     _DP = init_model_parallel_group(
@@ -845,11 +863,14 @@ def _initialize_model_parallel(
     )
     global _PP
     assert _PP is None, "pipeline model parallel group is already initialized"
-    _PP = init_model_parallel_group(
-        group_ranks=get_rank_groups("pp"),
-        local_rank=get_world_group().local_rank,
-        backend=backend,
-        parallel_mode="pipeline",
+    _PP = cast(
+        PipelineGroupCoordinator,
+        init_model_parallel_group(
+            group_ranks=get_rank_groups("pp"),
+            local_rank=get_world_group().local_rank,
+            backend=backend,
+            parallel_mode="pipeline",
+        ),
     )
     vllm_parallel_state._PP = _PP
 
@@ -863,14 +884,17 @@ def _initialize_model_parallel(
         world_size=world_size,
         sp_group_ranks=sp_group_ranks,
     )
-    _SP = init_model_parallel_group(
-        group_ranks=sp_group_ranks,
-        local_rank=get_world_group().local_rank,
-        backend=backend,
-        parallel_mode="sequence",
-        ulysses_group=ulysses_pg,
-        ring_group=ring_pg,
-        allgather_group=allgather_pg,
+    _SP = cast(
+        SequenceParallelGroupCoordinator,
+        init_model_parallel_group(
+            group_ranks=sp_group_ranks,
+            local_rank=get_world_group().local_rank,
+            backend=backend,
+            parallel_mode="sequence",
+            ulysses_group=ulysses_pg,
+            ring_group=ring_pg,
+            allgather_group=allgather_pg,
+        ),
     )
     if use_moe_parallel_mapping:
         # Diffusion normally uses its own SP group. Map it to vLLM PCP only for
@@ -938,7 +962,7 @@ def _initialize_model_parallel(
             )
 
     global _EXPERT_PARALLEL_GROUP_RANKS
-    _EXPERT_PARALLEL_GROUP_RANKS = get_rank_groups("tp-sp-cfg-dp")
+    _EXPERT_PARALLEL_GROUP_RANKS = ep_group_ranks
     if use_moe_parallel_mapping:
         vllm_parallel_state._EP = init_vllm_model_parallel_group(
             group_ranks=_EXPERT_PARALLEL_GROUP_RANKS,
@@ -946,6 +970,13 @@ def _initialize_model_parallel(
             backend=backend,
             group_name="ep",
             use_all2all=True,
+        )
+    elif use_head_parallel_mapping:
+        vllm_parallel_state._EP = init_model_parallel_group(
+            group_ranks=_EXPERT_PARALLEL_GROUP_RANKS,
+            local_rank=get_world_group().local_rank,
+            backend=backend,
+            parallel_mode="expert",
         )
 
 

--- a/vllm_omni/diffusion/model_metadata.py
+++ b/vllm_omni/diffusion/model_metadata.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 from dataclasses import dataclass
+from typing import Literal
 
 
 @dataclass(frozen=True)
@@ -17,6 +18,8 @@ class DiffusionModelMetadata:
     supported_control_upload_types: tuple[str, ...] = ()
     attention_mask_free: bool = False
     final_output_type: str | None = None
+    # Head-sharded MoE uses SP-local groups, not vLLM FusedMoE rank folding.
+    expert_parallel_style: Literal["vllm", "head"] = "vllm"
 
 
 QWEN_IMAGE_EDIT_PLUS_MAX_INPUT_IMAGES = 4

--- a/vllm_omni/diffusion/vllm_config.py
+++ b/vllm_omni/diffusion/vllm_config.py
@@ -205,12 +205,16 @@ def configure_diffusion_vllm_config(vllm_config: VllmConfig, od_config: OmniDiff
     parallel_config = od_config.parallel_config
     vllm_config.parallel_config.tensor_parallel_size = parallel_config.tensor_parallel_size
     vllm_config.parallel_config.data_parallel_size = parallel_config.data_parallel_size
-    if parallel_config.enable_expert_parallel and od_config.is_moe:
+    head_ep = bool(getattr(od_config, "use_head_expert_parallel", False))
+    if parallel_config.enable_expert_parallel and od_config.is_moe and not head_ep:
+        assert parallel_config.data_parallel_size is not None
         vllm_config.parallel_config.data_parallel_size = (
             parallel_config.data_parallel_size * parallel_config.cfg_parallel_size
         )
         vllm_config.parallel_config.prefill_context_parallel_size = parallel_config.sequence_parallel_size
-    vllm_config.parallel_config.enable_expert_parallel = parallel_config.enable_expert_parallel
+    if head_ep:
+        vllm_config.parallel_config.prefill_context_parallel_size = 1
+    vllm_config.parallel_config.enable_expert_parallel = parallel_config.enable_expert_parallel and not head_ep
 
     vllm_config.model_config = _make_diffusion_vllm_model_config(od_config)  # type: ignore[assignment]
     vllm_config.quant_config = od_config.quantization_config


### PR DESCRIPTION
## Summary

Add model-declared head-sharded expert-parallel groups while preserving the existing vLLM FusedMoE layout.

- A model can declare `DiffusionModelMetadata(expert_parallel_style="head")`. The default stays `"vllm"`; this PR does not opt any production model in.
- `DiffusionParallelConfig.expert_parallel_size` optionally partitions each SP group. It requires enabled head-EP and must divide SP size; omitting it uses the whole SP group. EP size does not multiply world size.
- Head-EP groups never cross TP, PP, CFG or DP coordinates. They reuse the existing `_EP` owner and transactional initialization/teardown, with Omni's group coordinator.
- The vLLM config view does not fold CFG into DP or map SP into PCP for head-EP, and does not enable vLLM FusedMoE all-to-all managers. Conventional FusedMoE behavior is retained.

For an opted-in model, TP1/SP4/CFG2/EP4 uses `[0,1,2,3]` and `[4,5,6,7]`. TP1/SP8/EP4 partitions SP into those same two groups, without adding devices. A model adapter remains responsible for weight/head ownership, padding, replicated inputs and token-count mapping.

## Scope

Five files: model metadata, parallel config, group initialization, vLLM config projection, and tests. Initialization reads the existing forward context; the worker and its API are unchanged. Small typing cleanups in touched functions keep targeted mypy checks green.

No MAGI-2 model opt-in, kernels, attention policy, sampler, dependency pins, private process-group lifecycle or environment flags are added. This is the group-policy foundation of the decomposition. The MAGI-2 adapter will consume this and the exchange contract in #7266 separately. #7156 remains a reference draft.

## Validation

Tested commit: `3f56672f23800e7428fa7274c0cd0ae7f13a8a7b`, one signed-off commit based on upstream `b58ff5cb8b17250b76f9cdf9b9b46385cdda4376`.

- Targeted pre-commit passed, including Ruff, mypy, test markers and CUDA API checks.
- **90 CPU/Gloo tests passed**: public config validation/roundtrip, capability opt-in, native vs FusedMoE config views, rank-layout matrices, invalid-layout early failure, rollback/unique destruction, existing SP/EP/HSDP/config regressions, and real four-process group creation/reinitialization.
- **One four-rank MCCL test passed** on four 48-SM MTT S5000 cards, driver `5.2.0-server`. It creates/uses/destroys groups across CFG2xSP2/EP2, SP4/EP2, DP2xSP2/EP2, TP2xSP2/EP2, and SP4/EP1. Actual FP32/BF16/INT64 all-to-all outputs match each group's rank membership exactly.
- The real Gloo and MCCL tests exercise the actual group factories and forward context, with a synthetic model capability declaration and no model weights. The broader rank matrix, including CFG2xSP4/EP4, uses mocked factories.

Stack: Python 3.10.12; torch/torch_musa `2.11.0.post1+musa5.2.0`; torchada `0.1.83`; vLLM `0.28.0`; vllm-musa `0.1.28`; Triton `3.2.0`. Exact source installed editable with `--no-deps --no-build-isolation`; MUSA entrypoint imports torchada before Torch/vLLM.

```bash
python -m pytest -q -o addopts= -m cpu \
  tests/diffusion/distributed/test_head_expert_parallel.py \
  tests/diffusion/distributed/test_expert_parallel_layout.py \
  tests/diffusion/distributed/test_parallel_state_sp_groups.py \
  tests/diffusion/distributed/test_hsdp.py \
  tests/diffusion/diffusion_kv/test_initialization.py \
  tests/diffusion/test_diffusion_config_propagation.py \
  tests/diffusion/test_diffusion_config_fields.py
```

For MUSA, run the new test file with `-m musa` from a torchada-first, `__main__`-guarded Python entrypoint with four visible devices.

**Additional regression attempted, not passed:** worker process-title tests could not collect on the pinned Python 3.10 image. After installing test-only `pytest-mock==3.14.0`, collection reaches the pre-existing `from typing import ClassVar, Self` in `diffusion/interaction/modality_handlers/base.py`, which fails on Python 3.10. That file is unchanged here; the failure is not counted as a pass and no full-worker startup claim is made.

**Not run:** CUDA/NCCL, multi-node or eight-card runtime, compiled/graph execution, full-model/video E2E and performance benchmarks. Model adapter correctness and worker/E2E integration remain pending; this PR stays Draft.
