### PR TITLE
[CI][Bugfix] Update Qwen3-TTS CI Validation Message

### DIFF
--- a/examples/online_serving/text_to_speech/qwen3_tts/batch_speech_client.py
+++ b/examples/online_serving/text_to_speech/qwen3_tts/batch_speech_client.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 """Batch speech client for Qwen3-TTS via /v1/audio/speech/batch endpoint.
 
 This script demonstrates how to synthesize multiple texts in a single request.
@@ -7,7 +10,7 @@ the reference for each item.
 
 Start the server (with batch-optimized stage settings for best throughput):
 
-    vllm serve Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice \
+    vllm serve Qwen/Qwen3-TTS-12Hz-1.7B-Base \
         --omni \
         --trust-remote-code \
         --stage-overrides '{"0":{"max_num_seqs":4,"gpu_memory_utilization":0.2},

--- a/examples/online_serving/text_to_speech/qwen3_tts/gradio_demo.py
+++ b/examples/online_serving/text_to_speech/qwen3_tts/gradio_demo.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 """Gradio demo for Qwen3-TTS with gapless streaming audio playback.
 
 Uses a custom AudioWorklet-based player for gap-free streaming,
@@ -351,7 +354,7 @@ def generate_speech(
         raise gr.Error(f"Failed to decode audio: {e}")
 
 
-def create_app(api_base: str):
+def create_app(api_base: str, task_type: str = "CustomVoice"):
     """Create the FastAPI app with streaming proxy + Gradio UI."""
     fastapi_app = FastAPI()
 
@@ -463,10 +466,11 @@ def create_app(api_base: str):
                     lines=4,
                 )
                 with gr.Row():
-                    task_type = gr.Radio(
+                    task_type_input = gr.Radio(
                         choices=TASK_TYPES,
-                        value="CustomVoice",
+                        value=task_type,
                         label="Task Type",
+                        interactive=False,
                         scale=2,
                     )
                     language = gr.Dropdown(
@@ -479,17 +483,21 @@ def create_app(api_base: str):
                     choices=voices,
                     value=voices[0] if voices else None,
                     label="speaker",
-                    visible=True,
+                    visible=task_type == "CustomVoice",
                     allow_custom_value=True,
                 )
                 instructions = gr.Textbox(
                     label="Instructions",
                     placeholder="e.g., Speak with excitement / A warm, friendly female voice",
                     lines=2,
-                    visible=True,
-                    info="Optional style/emotion instructions",
+                    visible=task_type != "Base",
+                    info=(
+                        "Required: describe the voice style"
+                        if task_type == "VoiceDesign"
+                        else "Optional style/emotion instructions"
+                    ),
                 )
-                with gr.Column(visible=False) as ref_group:
+                with gr.Column(visible=task_type == "Base") as ref_group:
                     ref_audio = gr.Audio(
                         label="Reference Audio (upload for voice cloning)",
                         type="numpy",
@@ -563,7 +571,7 @@ def create_app(api_base: str):
                     autoplay=True,
                     visible=False,
                 )
-                with gr.Column(visible=True) as examples_cv:
+                with gr.Column(visible=task_type == "CustomVoice") as examples_cv:
                     gr.Examples(
                         examples=[
                             [
@@ -588,7 +596,7 @@ def create_app(api_base: str):
                         inputs=[text_input, voice, language, instructions],
                         label="examples",
                     )
-                with gr.Column(visible=False) as examples_vd:
+                with gr.Column(visible=task_type == "VoiceDesign") as examples_vd:
                     gr.Examples(
                         examples=[
                             [
@@ -605,7 +613,7 @@ def create_app(api_base: str):
                         inputs=[text_input, language, instructions],
                         label="examples",
                     )
-                with gr.Column(visible=False) as examples_base:
+                with gr.Column(visible=task_type == "Base") as examples_base:
                     gr.Examples(
                         examples=[
                             [
@@ -653,9 +661,9 @@ def create_app(api_base: str):
                 gr.update(visible=is_base),  # examples_base
             )
 
-        task_type.change(
+        task_type_input.change(
             fn=on_task_change,
-            inputs=[task_type],
+            inputs=[task_type_input],
             outputs=[
                 voice,
                 instructions,
@@ -703,7 +711,7 @@ def create_app(api_base: str):
 
         all_inputs = [
             text_input,
-            task_type,
+            task_type_input,
             voice,
             language,
             instructions,
@@ -788,6 +796,9 @@ def parse_args():
         description="Gradio demo for Qwen3-TTS with gapless AudioWorklet streaming.",
     )
     add_common_args(parser)
+    parser.add_argument(
+        "--task-type", choices=TASK_TYPES, default="CustomVoice", help="Task matching the served checkpoint"
+    )
     return parser.parse_args()
 
 
@@ -796,7 +807,7 @@ def main():
     logging.basicConfig(level=logging.INFO)
     print(f"Connecting to vLLM server at: {args.api_base}")
 
-    app = create_app(args.api_base)
+    app = create_app(args.api_base, task_type=args.task_type)
 
     import uvicorn
 

--- a/examples/online_serving/text_to_speech/qwen3_tts/openai_speech_client.py
+++ b/examples/online_serving/text_to_speech/qwen3_tts/openai_speech_client.py
@@ -8,25 +8,28 @@ to generate audio from text using Qwen3-TTS models.
 
 Examples:
     # CustomVoice task (predefined speaker)
-    python openai_speech_client.py --text "Hello, how are you?" --voice vivian
+    python openai_speech_client.py --text "Hello, how are you?" --speaker vivian
 
     # CustomVoice with emotion instruction
-    python openai_speech_client.py --text "I'm so happy!" --voice vivian \
+    python openai_speech_client.py --text "I'm so happy!" --speaker vivian \
         --instructions "Speak with excitement"
 
     # VoiceDesign task (voice from description)
     python openai_speech_client.py --text "Hello world" \
+        --model Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign \
         --task-type VoiceDesign \
         --instructions "A warm, friendly female voice"
 
     # Base task (voice cloning)
     python openai_speech_client.py --text "Hello world" \
+        --model Qwen/Qwen3-TTS-12Hz-1.7B-Base \
         --task-type Base \
         --ref-audio "https://example.com/reference.wav" \
         --ref-text "This is the reference transcript"
 
     # Base task with pre-computed speaker embedding
     python openai_speech_client.py --text "Hello world" \
+        --model Qwen/Qwen3-TTS-12Hz-1.7B-Base \
         --task-type Base \
         --speaker-embedding embedding.json
 """

--- a/examples/online_serving/text_to_speech/qwen3_tts/run_gradio_demo.sh
+++ b/examples/online_serving/text_to_speech/qwen3_tts/run_gradio_demo.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 # Launch both vLLM server and Gradio demo for Qwen3-TTS
 #
 # Usage:
@@ -179,7 +182,7 @@ fi
 echo ""
 echo "Starting Gradio demo..."
 cd "$SCRIPT_DIR"
-GRADIO_CMD=("python" "gradio_demo.py" "--api-base" "$API_BASE" "--host" "$GRADIO_IP" "--port" "$GRADIO_PORT")
+GRADIO_CMD=("python" "gradio_demo.py" "--api-base" "$API_BASE" "--host" "$GRADIO_IP" "--port" "$GRADIO_PORT" "--task-type" "$TASK_TYPE")
 if [ "$GRADIO_SHARE" = true ]; then
     GRADIO_CMD+=("--share")
 fi

--- a/tests/dfx/reliability/invalid_param_test/test_invalid_audio_speech.py
+++ b/tests/dfx/reliability/invalid_param_test/test_invalid_audio_speech.py
@@ -157,14 +157,8 @@ def test_speech_missing_required_fields(omni_server: OmniServer, online_client: 
                 "ref_audio": None,
                 "ref_text": None,
             },
-            # NOTE: This is delegating down the TTS adapter, so the message is both specific
-            # to the Qwen3TTS adapter and dependent on whether or not the model has any speakers
-            # (as opposed to having valida speakers, but getting an invalid speaker). it would
-            # be more ideal to validate that this is landing on `.validate()` on the adapter
-            # and ensuring that the returned message matches what we would get from calling the
-            # adapter validate directly.
-            ("no speakers configured",),
-            id="customvoice_invalid_voice",
+            ("Base checkpoint does not support task_type='CustomVoice'",),
+            id="base_checkpoint_customvoice_task_mismatch",
         ),
         pytest.param(
             {"task_type": "InvalidEnum"}, ("task_type", "literal_error", "CustomVoice"), id="task_type_invalid"


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fixes #7250.

#6113 added a task type check before the speaker check. My previous fix, #7054, fixed the performance tests but missed this weekly test.

#6827 updated the expected error to fix #6795. This test still sends a `CustomVoice` request to a Base checkpoint. It now fails at the task type check, so the expected error needs another update.

Also fix the Qwen3-TTS example commands. Set and lock the Gradio task type to match the model.

## Test Plan

Run the Qwen3-TTS parameter-validation cases selected by the weekly L4 marks on one NVIDIA A100-SXM4-80GB GPU.

```bash
pytest -s -v tests/dfx/reliability/invalid_param_test/test_invalid_audio_speech.py -m "slow and L4" -k qwen3_tts
```

Run Gradio locally and test speech generation with the three models on A100.

```bash
python gradio_demo.py --task-type CustomVoice --api-base http://127.0.0.1:18000 --port 17860
python gradio_demo.py --task-type VoiceDesign --api-base http://127.0.0.1:18001 --port 17861
python gradio_demo.py --task-type Base --api-base http://127.0.0.1:18002 --port 17862
```

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** `f3fabe4145df06947bc853a808928caa037f5e8f` + the test fix.

## Test Result

```text
--- Running Summary
66 passed, 26 skipped, 22 deselected, 14 warnings in 110.31s (0:01:50)
```

The updated case passed:

```text
test_speech_invalid_field_values[qwen3_tts-base_checkpoint_customvoice_task_mismatch] PASSED
```

Browser validation against the three checkpoints passed:

- CustomVoice: `Done`, 9.8 seconds of audio, 27 chunks.
- VoiceDesign: `Done`, 7.8 seconds of audio, 19 chunks.
- Base: `Done`, 5.2 seconds of audio, 13 chunks.

### CustomVoice

<img width="1381" height="1323" alt="CustomVoice-light" src="https://github.com/user-attachments/assets/6f24e076-1140-40ce-a9a8-a733d4e46c6a" />

### VoiceDesign

<img width="1381" height="1323" alt="VoiceDesign-light" src="https://github.com/user-attachments/assets/2c6089b4-201a-4c5c-9c33-a35797226130" />

### Base

<img width="1381" height="1323" alt="Base-light" src="https://github.com/user-attachments/assets/6340cf24-48b8-4cee-8af6-d8a265ce9ac9" />


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
