### PR TITLE
[Bugfix][Frontend] Route duplex cancellation by request ID scope

### DIFF
--- a/tests/entrypoints/openai/test_duplex_protocol.py
+++ b/tests/entrypoints/openai/test_duplex_protocol.py
@@ -8,6 +8,7 @@ import pytest
 
 from vllm_omni.entrypoints.duplex.protocol import (
     DuplexOverlapPolicy,
+    DuplexRequestIdScope,
     DuplexSession,
     DuplexSessionConfig,
     DuplexSessionRegistry,
@@ -418,6 +419,8 @@ def test_duplex_session_composes_single_owner_ledgers():
     assert not hasattr(session, "conversation")
     assert session.pending_text == ("hello",)
     assert session.active_request_id == "req-1"
+    assert session.active_request_binding is not None
+    assert session.active_request_binding.scope == DuplexRequestIdScope.INTERNAL
     assert session.active_response_id == response_id
     assert session.active_response_turn_id == 3
     assert session.playback.sent_ms == 240
@@ -428,6 +431,19 @@ def test_duplex_session_composes_single_owner_ledgers():
         pass
     else:
         raise AssertionError("playback view must be immutable")
+
+
+def test_duplex_session_records_external_request_id_scope():
+    session = DuplexSession(session_id="sid-external-request", config=DuplexSessionConfig())
+
+    session.bind_request(
+        "chatcmpl-external-request",
+        scope=DuplexRequestIdScope.EXTERNAL,
+    )
+
+    assert session.active_request_id == "chatcmpl-external-request"
+    assert session.active_request_binding is not None
+    assert session.active_request_binding.scope == DuplexRequestIdScope.EXTERNAL
 
 
 def test_duplex_barge_in_advances_epoch_and_drops_uncommitted_assistant_text():

--- a/tests/entrypoints/openai_api/test_duplex_handler.py
+++ b/tests/entrypoints/openai_api/test_duplex_handler.py
@@ -4225,6 +4225,41 @@ async def test_minicpmo_auto_response_continuation_stops_at_large_safety_boundar
 
 
 @pytest.mark.asyncio
+async def test_native_listen_aborts_internal_request_after_clearing_binding():
+    # Exercise the adapter contract, not a claim about a model's emitted flags.
+    request_id = "duplex-sid-listen-abort-e0-stage0"
+    engine = FakeEngineClient()
+    handler = OmniDuplexSessionHandler(chat_service=FakeChatService(engine))
+    session = DuplexSession(session_id="sid-listen-abort", config=DuplexSessionConfig())
+    response_id = session.begin_response(turn_id=0)
+    session.bind_request(request_id)
+    native = handler._runtime_session_state(session)
+    native.continuation_owner_id = f"response:{response_id}"
+    native.continuation_units = handler._NATIVE_RESPONSE_MAX_CONTINUATION_UNITS
+    ws = TimedWebSocket()
+
+    close_reason, emitted = await handler._send_one_native_duplex_event(
+        ws.send_json,
+        {
+            "is_listen": True,
+            "data_plane_request_id": request_id,
+            "abort_data_plane_request": True,
+        },
+        session=session,
+        expected_epoch=session.epoch,
+    )
+
+    assert close_reason is None
+    assert emitted is True
+    assert engine.internal_abort_batches == [[request_id]]
+    assert engine.abort_batches == []
+    assert session.active_request_id is None
+    assert session.active_response_id is None
+    assert ws.sent_types() == ["response.listen", "response.done"]
+    assert all(payload["response_id"] == response_id for payload in ws.sent)
+
+
+@pytest.mark.asyncio
 async def test_minicpmo_auto_response_boundary_listen_closes_response():
     request_id = "duplex-sid-boundary-listen-e0-stage0"
     engine = FakeEngineClient()

--- a/tests/entrypoints/openai_api/test_duplex_handler.py
+++ b/tests/entrypoints/openai_api/test_duplex_handler.py
@@ -36,6 +36,7 @@ from vllm_omni.entrypoints.duplex.protocol import (
     DuplexCapabilities,
     DuplexOverlapPolicy,
     DuplexPlaybackCommitPolicy,
+    DuplexRequestIdScope,
     DuplexSession,
     DuplexSessionConfig,
     ResponseCreateOptions,
@@ -5181,7 +5182,8 @@ async def test_duplex_handler_aborts_current_chat_request_id_on_barge_in():
     assert "audio.cancelled" in ws.sent_types()
     assert chat_service.seen_request_ids == ["duplex-sid-a-0-1"]
     assert engine.aborted == ["chatcmpl-duplex-sid-a-0-1"]
-    assert engine.internal_abort_batches == [["chatcmpl-duplex-sid-a-0-1"]]
+    assert engine.abort_batches == [["chatcmpl-duplex-sid-a-0-1"]]
+    assert engine.internal_abort_batches == []
 
 
 @pytest.mark.asyncio
@@ -5845,7 +5847,10 @@ async def test_cancel_chat_fallback_response_aborts_request_and_task():
     handler = OmniDuplexSessionHandler(chat_service=TurnBasedFakeChatService(engine))
     session = DuplexSession("sid-chat-cancel", DuplexSessionConfig())
     response_id = session.begin_response()
-    session.bind_request("chatcmpl-cancel")
+    session.bind_request(
+        "chatcmpl-cancel",
+        scope=DuplexRequestIdScope.EXTERNAL,
+    )
     ws = TimedWebSocket()
     task = asyncio.create_task(asyncio.sleep(60))
     try:
@@ -5853,7 +5858,8 @@ async def test_cancel_chat_fallback_response_aborts_request_and_task():
 
         assert cancelled is True
         assert task.cancelled()
-        assert engine.internal_abort_batches == [["chatcmpl-cancel"]]
+        assert engine.abort_batches == [["chatcmpl-cancel"]]
+        assert engine.internal_abort_batches == []
         assert "error" not in ws.sent_types()
         (event,) = [event for event in ws.sent if event["type"] == "audio.cancelled"]
         assert event["response_id"] == response_id

--- a/vllm_omni/entrypoints/duplex/chat_fallback.py
+++ b/vllm_omni/entrypoints/duplex/chat_fallback.py
@@ -12,7 +12,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionReque
 from vllm.entrypoints.openai.engine.protocol import ErrorResponse
 from vllm.logger import init_logger
 
-from vllm_omni.entrypoints.duplex.protocol import DuplexSession
+from vllm_omni.entrypoints.duplex.protocol import DuplexRequestIdScope, DuplexSession
 
 logger = init_logger(__name__)
 
@@ -24,7 +24,10 @@ class ChatFallbackProjectorMixin:
         response_id = session.begin_response()
         epoch = session.epoch
         request_id = f"duplex-{session.session_id}-{epoch}-{session.input_commit_seq}"
-        session.bind_request(f"chatcmpl-{request_id}")
+        session.bind_request(
+            f"chatcmpl-{request_id}",
+            scope=DuplexRequestIdScope.EXTERNAL,
+        )
         await send_json(
             self._response_created_payload(
                 session,

--- a/vllm_omni/entrypoints/duplex/protocol.py
+++ b/vllm_omni/entrypoints/duplex/protocol.py
@@ -31,6 +31,13 @@ class DuplexPlaybackCommitPolicy(str, Enum):
     ACK_ONLY = "ack_only"
 
 
+class DuplexRequestIdScope(str, Enum):
+    """Identify which AsyncOmni abort API accepts a bound request ID."""
+
+    EXTERNAL = "external"
+    INTERNAL = "internal"
+
+
 class DuplexSessionState(str, Enum):
     OPEN = "open"
     CLOSING = "closing"
@@ -389,6 +396,12 @@ class DuplexAssistantAudioTextMark:
     audio_end_ms: int
 
 
+@dataclass(frozen=True)
+class DuplexRequestBinding:
+    request_id: str
+    scope: DuplexRequestIdScope
+
+
 @dataclass
 class InputBufferState:
     commit_seq: int = 0
@@ -408,7 +421,7 @@ class InputBufferState:
 
 @dataclass
 class ResponseState:
-    active_request_id: str | None = None
+    active_request: DuplexRequestBinding | None = None
     active_response_id: str | None = None
     active_response_turn_id: int | None = None
     active_response_input_commit_seq: int | None = None
@@ -500,7 +513,12 @@ class DuplexSession:
 
     @property
     def active_request_id(self) -> str | None:
-        return self._response.active_request_id
+        binding = self._response.active_request
+        return binding.request_id if binding is not None else None
+
+    @property
+    def active_request_binding(self) -> DuplexRequestBinding | None:
+        return self._response.active_request
 
     @property
     def active_response_id(self) -> str | None:
@@ -642,13 +660,26 @@ class DuplexSession:
     def transition_session(self, state: DuplexSessionState) -> None:
         self.state = state
 
-    def bind_request(self, request_id: str | None) -> None:
-        self._response.active_request_id = request_id
+    def bind_request(
+        self,
+        request_id: str | None,
+        *,
+        scope: DuplexRequestIdScope = DuplexRequestIdScope.INTERNAL,
+    ) -> None:
+        """Bind the active response to the ID accepted by its abort API.
+
+        Native duplex paths expose engine-internal IDs. Chat fallback paths
+        expose the external ID passed to ``AsyncOmni.generate`` and must use
+        the public ``AsyncOmni.abort`` mapper.
+        """
+        self._response.active_request = (
+            DuplexRequestBinding(request_id=request_id, scope=scope) if request_id is not None else None
+        )
 
     def clear_request(self, expected_request_id: str | None = None) -> bool:
-        if expected_request_id is not None and self._response.active_request_id != expected_request_id:
+        if expected_request_id is not None and self.active_request_id != expected_request_id:
             return False
-        self._response.active_request_id = None
+        self._response.active_request = None
         return True
 
     def bind_response_turn(self, turn_id: int | None) -> None:
@@ -1237,7 +1268,7 @@ class DuplexSession:
             self._discard_history_item_placeholder(f"item_{response_id}")
         self._response.assistant_text_buffer.clear()
         if not preserve_request:
-            self._response.active_request_id = None
+            self._response.active_request = None
         self._response.active_response_id = None
         self._response.active_response_turn_id = None
         self._response.active_response_input_commit_seq = None
@@ -1554,7 +1585,7 @@ class DuplexSession:
         self._input.pending_audio.clear()
         self._response.assistant_text_buffer.clear()
         self._response.assistant_audio_text_marks.clear()
-        self._response.active_request_id = None
+        self._response.active_request = None
         self._response.active_response_id = None
         self._response.active_response_turn_id = None
         self._response.active_response_input_commit_seq = None

--- a/vllm_omni/entrypoints/duplex/runtime_bridge.py
+++ b/vllm_omni/entrypoints/duplex/runtime_bridge.py
@@ -17,6 +17,8 @@ from vllm_omni.engine.duplex.control_client import DuplexControlRequestError
 from vllm_omni.engine.duplex.messages import DuplexFence
 from vllm_omni.engine.duplex.runtime import duplex_data_plane_request_info
 from vllm_omni.entrypoints.duplex.protocol import (
+    DuplexRequestBinding,
+    DuplexRequestIdScope,
     DuplexSession,
     DuplexSessionState,
 )
@@ -1010,7 +1012,7 @@ class NativeRuntimeBridgeMixin:
             if native_result.get("abort_data_plane_request") is True and isinstance(data_plane_request_id, str):
                 await self._abort_request_background(
                     session,
-                    data_plane_request_id,
+                    DuplexRequestBinding(data_plane_request_id, DuplexRequestIdScope.INTERNAL),
                     send_json,
                     notify=False,
                 )

--- a/vllm_omni/entrypoints/duplex/serving.py
+++ b/vllm_omni/entrypoints/duplex/serving.py
@@ -32,6 +32,8 @@ from vllm_omni.entrypoints.duplex.protocol import (
     DuplexCommittedInput,
     DuplexOverlapPolicy,
     DuplexPlaybackCommitPolicy,
+    DuplexRequestBinding,
+    DuplexRequestIdScope,
     DuplexSession,
     DuplexSessionConfig,
     DuplexSessionRegistry,
@@ -2048,7 +2050,7 @@ class OmniDuplexSessionHandler(
             return False
 
         old_epoch = session.epoch
-        old_request_id = session.active_request_id
+        old_request = session.active_request_binding
         old_response_id = session.active_response_id
         committed_ms = session.playback.committed_ms
         committed_message = session.end_response(
@@ -2062,15 +2064,15 @@ class OmniDuplexSessionHandler(
             elif committed_ms > 0 and not session.playback_ack_is_too_late(old_response_id, item_id):
                 session.truncate_history_item(item_id, audio_end_ms=committed_ms)
         new_epoch, old_playback = self._advance_barge_in_epoch(session)
-        if old_request_id is not None:
+        if old_request is not None:
             # Epoch-scoped request ids prevent state reuse, but explicitly
             # release projector/parser cursors so cancelled epochs do not
             # accumulate until the whole session closes.
             if self._serving_runtime_adapter is not None:
-                self._serving_runtime_adapter.data_plane.close_stream(old_request_id)
+                self._serving_runtime_adapter.data_plane.close_stream(old_request.request_id)
             await self._abort_request_background(
                 session,
-                old_request_id,
+                old_request,
                 send_json,
                 notify=notify,
             )
@@ -2098,21 +2100,25 @@ class OmniDuplexSessionHandler(
     async def _abort_request_background(
         self,
         session: DuplexSession,
-        request_id: str,
+        request: DuplexRequestBinding,
         send_json,
         *,
         notify: bool,
     ) -> None:
         try:
-            abort_internal = getattr(self._chat_service.engine_client, "_abort_internal_requests", None)
-            if callable(abort_internal):
-                result = abort_internal([request_id])
+            engine_client = self._chat_service.engine_client
+            if request.scope == DuplexRequestIdScope.EXTERNAL:
+                result = engine_client.abort([request.request_id])
             else:
-                result = self._chat_service.engine_client.abort([request_id])
+                abort_internal = getattr(engine_client, "_abort_internal_requests", None)
+                if callable(abort_internal):
+                    result = abort_internal([request.request_id])
+                else:
+                    result = engine_client.abort([request.request_id])
             if inspect.isawaitable(result):
                 await result
         except Exception as exc:
-            logger.exception("Failed to abort duplex request %s: %s", request_id, exc)
+            logger.exception("Failed to abort duplex request %s: %s", request.request_id, exc)
             if notify and session.state != DuplexSessionState.CLOSED:
                 await self._send_runtime_error(send_json, "runtime_abort_failed", exc, session=session)
 


### PR DESCRIPTION
## Status — on hold

Following the [#7055 coordination update](https://github.com/vllm-project/vllm-omni/issues/7055#issuecomment-5677251141), this PR is on hold pending #7413. It remains open to preserve the diagnosis and recorded evidence; I am not seeking review or merge of this legacy call-site fix before the refactor lands. After that merge, cancellation request-ID routing will be re-evaluated against the engine-owned session implementation as part of the held C/D/E contribution. The validation below applies to its recorded revisions, not to the replacement framework.

## Purpose

Fix direct cancellation request-ID routing for turn-based Qwen3-Omni Chat fallback, as a focused part of #7055 D.

Chat fallback binds the external `chatcmpl-...` ID passed to `AsyncOmni.generate()`, but cancellation previously sent it to `_abort_internal_requests()`, which only matches engine-internal IDs. Native duplex requests already use internal IDs.

The session now holds one binding containing the request ID and its scope. Cancellation snapshots it before clearing response state, uses public `AsyncOmni.abort()` for external IDs, and retains internal abort for native requests. The native listen caller also passes an internal-scope binding from its saved ID, addressing [the bot finding](https://github.com/vllm-project/vllm-omni/pull/7278#discussion_r3975323021).

## Validation

Real Qwen3-Omni-30B-A3B-Instruct runs used two GB200 GPUs per service, model revision `26291f7`, vLLM 0.28.0, and the official arm64 vLLM-Omni nightly image. All three stages used `async_chunk: true` and `enforce_eager: true`.

- Comparing main `d774033` with PR `a916cbc`, direct cancellation on main matched no internal request. On the PR it mapped the external ID and reached stages 0, 1, and 2 before generator cleanup.
- Main still cancelled through subsequent generator cleanup: both runs cancelled the first response and completed the next. This is not evidence that main cannot cancel.
- The same scenario passed at current head `6f30faa`, with no old audio received after cancellation during observation. All 342 selected checks and the forbidden-import check passed in the serving container; Ruff, formatting, and compilation also passed.

The scenario used `/v1/realtime?duplex=1`, complete PCM `conversation.item.create` messages, and explicit `response.create` / `response.cancel`. `server_vad` had `create_response=false` and `interrupt_response=false`.

In the recorded PR run, subsequent generator cleanup repeated the internal abort after stage bindings had been released, without an error. This is an observed repeat-abort result, not a general race/idempotency guarantee. Full mypy and repository-wide pre-commit were not run locally.

<details>
<summary>Recorded routing trace and client timing observations</summary>

Recorded comparison: main `d774033` and PR `a916cbc`, using the model and configuration above. Request IDs are replaced with role labels.

```text
main, direct cancellation:
  AsyncOmni._abort_internal_requests([external_id])
    relevant binding: external_id -> internal_id
    matched_internal_ids: []
  AsyncOmniEngine.abort_async([])

main, subsequent generator cleanup:
  generate -> _abort_internal_requests([internal_id])
  StagePool.abort_requests: stages 0, 1, 2; replica 0 present

PR, direct cancellation:
  AsyncOmni.abort([external_id])
    matched_internal_ids: [internal_id]
  StagePool.abort_requests: stages 0, 1, 2; replica 0 present
```

| Client observation | Main `d774033` | PR `a916cbc` |
| --- | ---: | ---: |
| Cancel to `response.done(status=cancelled)` | 42.247 ms | 19.371 ms |
| Cancel to next `response.created` (not audio) | 105.454 ms | 106.713 ms |
| Cancel to next response's first audio delta | 1,965.404 ms | 2,001.675 ms |
| Old audio received after cancel send | 0 bytes | 0 bytes |
| Old audio received after cancelled terminal | 0 bytes | 0 bytes |
| Second voice response | completed | completed |

One run per revision on separate nodes, with eager execution; these are observations, not a performance comparison. The next-audio timings were recovered from the same original event logs, not a new run. Neither physical speaker stop/flush nor engine/GPU stop acknowledgement was measured: `response.done` is a client-observed protocol terminal, and stage abort calls returning do not prove GPU kernels have finished.

</details>

<details>
<summary>Minimal client reproduction: explicit cancellation</summary>

Use Python 3.11+ with `websockets` installed, from the repo root. Start a Qwen3-Omni server on port 18091 using `vllm serve MODEL --omni --port 18091 --deploy-config CONFIG.yaml`. Base that configuration on `vllm_omni/deploy/qwen3_omni_moe.yaml`, with a top-level `duplex_session` section containing `server_vad_model_path` for your VAD artifact. Set top-level `async_chunk: true` and stage-level `enforce_eager: true` on each stage. Keep the Qwen engines turn-based, not `session_mode: duplex`. Set `MODEL` below to the exact served name.

This minimal client cancels on first audio and checks the cancelled terminal; it is not the full two-turn experiment above. It can also pass on main through generator cleanup. To distinguish the routing paths, inspect the input and matched IDs at `AsyncOmni.abort()` / `_abort_internal_requests()`, as in the recorded trace. The playback cursor is synthetic.

```bash
MODEL=Qwen/Qwen3-Omni-30B-A3B-Instruct python - <<'PY'
import asyncio, base64, json, os, time, wave
from urllib.parse import urlencode
import websockets

async def main():
    model = os.environ["MODEL"]
    with wave.open("tests/assets/minicpmo_4_5/response_required_16k.wav", "rb") as f:
        assert (f.getnchannels(), f.getsampwidth(), f.getframerate()) == (1, 2, 16000)
        audio = base64.b64encode(f.readframes(f.getnframes())).decode()
    url = "ws://127.0.0.1:18091/v1/realtime?" + urlencode(
        {"duplex": "1", "autostart": "0", "model": model})
    async with websockets.connect(url, max_size=64 * 1024 * 1024) as ws:
        async def send(event):
            await ws.send(json.dumps(event))

        await send({"type": "session.update", "session": {
            "model": model, "modalities": ["audio", "text"],
            "input_audio_format": "pcm16", "output_audio_format": "pcm16",
            "sample_rate_hz": 16000,
            "audio": {"input": {"sample_rate_hz": 16000},
                      "output": {"sample_rate_hz": 24000}},
            "turn_detection": {"type": "server_vad", "create_response": False,
                               "interrupt_response": False},
            "extra_body": {"auto_response": False,
                           "audio": {"format": "pcm", "voice": "Chelsie"}}}})
        started, cancelled_id, cancel_at = False, None, None
        async with asyncio.timeout(600):
            while True:
                event = json.loads(await ws.recv())
                kind = event["type"]
                if kind == "error":
                    raise RuntimeError(event)
                if kind == "session.updated" and not started:
                    started = True
                    await send({"type": "conversation.item.create", "item": {
                        "type": "message", "role": "user",
                        "content": [{"type": "input_audio", "format": "pcm16",
                                     "sample_rate_hz": 16000, "audio": audio}]}})
                    await send({"type": "response.create"})
                if kind == "response.audio.delta" and cancelled_id is None:
                    cancelled_id = event["response_id"]
                    await send({"type": "playback.ack", "response_id": cancelled_id,
                                "played_ms": 148, "committed_ms": 148})
                    cancel_at = time.monotonic()
                    await send({"type": "response.cancel", "response_id": cancelled_id})
                if kind == "response.done":
                    response = event["response"]
                    assert cancelled_id is not None, "Response ended before cancellation"
                    assert response["id"] == cancelled_id, response
                    assert response["status"] == "cancelled", response
                    print("cancel -> response.done observed:",
                          round((time.monotonic() - cancel_at) * 1000, 3), "ms")
                    await send({"type": "session.close"})
                    break

asyncio.run(main())
PY
```

</details>

## Scope and limitations

Playback acknowledgement was injected, not measured at a speaker. These runs do not establish performance gains, exact GPU-kernel stop times, or streaming-input preservation. The native listen-plus-abort regression uses a constructed adapter result, not a model-observed GPU failure.

Server-VAD detection/configuration and the approximate history rule are unchanged. This is a routing fix, not complete reliable interruption. #7316 addresses audio accounting; #6372 covers the Qwen adapter; #5719 previously proposed public-abort routing; #7006 addresses multi-stage abort-result routing; #7181 covers the broader redesign.

AI assistance: Codex assisted with code, validation, and PR writing.
