### PR TITLE
[Bugfix] Keep MiniMax-H3 reference audio budgets separate

### DIFF
--- a/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
+++ b/tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
@@ -2455,6 +2455,56 @@ def test_g4_standalone_audio_duration_and_total_duration_contract():
         )
 
 
+def test_ref2va_video_soundtrack_does_not_consume_standalone_audio_budget():
+    from PIL import Image
+
+    from vllm_omni.diffusion.cache.cachedit.runtime import RequestScopedCacheDiTRuntime
+    from vllm_omni.diffusion.models.minimax_h3 import MiniMaxH3Pipeline
+    from vllm_omni.diffusion.models.minimax_h3.quality_policy import MiniMaxH3QualityPolicy
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    pipeline = object.__new__(MiniMaxH3Pipeline)
+    torch.nn.Module.__init__(pipeline)
+    pipeline.partition = "ref2va"
+    pipeline.supported_tasks = frozenset({"ref2va"})
+    pipeline.device = torch.device("cpu")
+    pipeline.default_video_shift = 12.0
+    pipeline.default_audio_shift = 3.0
+    pipeline._resolve_sigma_positions = Mock(return_value=(None, 50))
+    pipeline._quality_policy = MiniMaxH3QualityPolicy(None)
+    pipeline._cache_dit_runtime = Mock(spec=RequestScopedCacheDiTRuntime)
+    pipeline.text_encoder = object()
+    pipeline.encode_prompt = Mock(return_value=(torch.ones(1, 2), torch.ones(1, dtype=torch.long)))
+    pipeline._prepare_reference_videos = Mock(return_value=[{"input_has_audio": True}])
+    pipeline._encode_visual_conditions = Mock(return_value=(torch.ones(1, 96), [(1, 16, 16), (17, 48, 84)]))
+    # A 2.35-second video soundtrack and a 15-second standalone reference
+    # each satisfy their modality's separate 15-second duration budget.
+    embedded = torch.full((188, 32), 1.0)
+    standalone = torch.full((1200, 32), 2.0)
+    pipeline._encode_reference_audio_conditions = Mock(return_value=(embedded, [94], standalone, [600]))
+    sampling = OmniDiffusionSamplingParams(
+        width=1344,
+        height=768,
+        fps=24,
+        num_inference_steps=50,
+        extra_args={"task": "ref2va", "duration": 15.0},
+    )
+
+    context = pipeline._prepare_request_inputs(
+        prompt="A person carrying books down a street",
+        multi_modal_data={
+            "image": Image.new("RGB", (256, 256)),
+            "video": ["reference.mp4"],
+            "audio": (torch.zeros(1, 15 * 16000), 16000),
+        },
+        sampling=sampling,
+    )
+
+    assert context["audio_condition_lengths"] == [94, 600]
+    assert [block["kind"] for block in context["ref_blocks"]] == ["image", "video_audio", "audio"]
+    torch.testing.assert_close(context["audio_condition"], torch.cat([embedded, standalone]))
+
+
 def test_ref2va_audio_duration_validation_precedes_rank_branch(monkeypatch):
     from vllm_omni.diffusion.models.minimax_h3 import pipeline_minimax_h3 as pipeline_module
 

--- a/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
+++ b/vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py
@@ -2456,8 +2456,9 @@ class MiniMaxH3Pipeline(
             if audio_lengths:
                 if any(length < 80 or length > 600 for length in audio_lengths):
                     raise OmniClientError("MiniMax H3 audio references must each be between 2 and 15 seconds")
-                if sum(audio_lengths) > 600:
-                    raise OmniClientError("MiniMax H3 audio references must be at most 15 seconds in total")
+                # Video soundtracks and standalone audio have separate
+                # 15-second budgets, validated before encoding. Do not merge
+                # those budgets when concatenating their conditioning rows.
                 if len(audio_lengths) == 1:
                     ref_audio_t = audio_lengths[0]
 


### PR DESCRIPTION
## Purpose

The complete image + video + standalone-audio example in #7254 fails on four B300 GPUs with `MiniMax H3 audio references must be at most 15 seconds in total`. The reference video contains about 2.33 seconds of audio and the standalone WAV contains 15 seconds. Both satisfy their respective input budgets.

Related to #7254. This fixes the request rejection discovered during that investigation. The generated-content difference from the hosted MiniMax API remains a separate investigation; this PR should not close that issue.

## Reproduction

With a Ref2VA server running on port 17254 using USP4, encoder TP4, tiled VAE parallel4 and distributed layerwise offload:

```bash
curl -fLO https://dev-efbf58ae.eos.nanjing-zs-1.cmecloud.cn/minimax-h3/1344.png
curl -fLO https://dev-efbf58ae.eos.nanjing-zs-1.cmecloud.cn/minimax-h3/2.mp4
curl -fLO https://dev-efbf58ae.eos.nanjing-zs-1.cmecloud.cn/minimax-h3/15s.wav
curl -sS http://127.0.0.1:17254/v1/videos \
  -F 'prompt=我抱着那包书走回人声渐起的街上' \
  -F width=1344 -F height=768 -F fps=24 \
  -F num_inference_steps=50 -F flow_shift=12 -F seed=3112 \
  -F 'extra_params={"task":"ref2va","duration":15.0,"audio_flow_shift":3.0}' \
  -F 'input_references=@1344.png' \
  -F 'input_references=@2.mp4' \
  -F 'input_references=@15s.wav'
```

Polling the returned job on main yields HTTP 500 and the duration error above.

The [model card](https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/42ed227ee7df40d41602854ae760620d6eb651fe/README.md) specifies separate video-reference and audio-reference duration budgets. The pipeline already validates these separately before encoding. It then concatenates the embedded and standalone audio latents and incorrectly applies one 600-latent-frame budget to both groups. Remove that combined check while retaining the existing source-duration and individual encoded-length validation. The regression test verifies acceptance and preservation of both audio blocks.

## Test Plan

```bash
pytest tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py \
  tests/diffusion/models/minimax_h3/test_minimax_h3_packing.py -q
pre-commit run --files \
  vllm_omni/diffusion/models/minimax_h3/pipeline_minimax_h3.py \
  tests/diffusion/models/minimax_h3/test_minimax_h3_contract.py
```

**vLLM Version:** 0.28.0; PyTorch 2.13.0+cu130; Transformers 5.14.1.

**vLLM-Omni Commit:** baseline d7740336; fix 2f2fe5e8. Model: MiniMaxAI/MiniMax-H3 Ref2VA, revision 42ed227ee7df40d41602854ae760620d6eb651fe.

## Test Result

- Regression failed on the original implementation; 141 contract/packing tests passed after the fix. The final test-fixture refinement was separately retested.
- Applicable pre-commit checks passed, including Ruff and mypy.
- Four B300 GPUs: the complete three-reference request failed before the fix and completed after it, producing a valid 1344x768 H.264 video with 362 frames at 24 fps and stereo AAC audio. The 15-second request aligns to 15.083 seconds under the existing frame-count contract.
- No inference-math, throughput or generated-content quality improvement is claimed. The successful GPU output still shows the content discrepancy reported in #7254.
- [Generated four-GPU video with the original prompt and all three references](https://github.com/david6666666/vllm-omni/releases/download/issue-7254-gpu-validation/issue7254-b300-4gpu-original-prompt-all-references.mp4).
