### PR TITLE
[Refactor] Chunk MAGI-2 Torch reference attention by query rows

### DIFF
--- a/tests/diffusion/models/magi2/test_chunked_attention.py
+++ b/tests/diffusion/models/magi2/test_chunked_attention.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.models.magi2.attention import torch_varlen_attention_with_sink
+
+pytestmark = [pytest.mark.diffusion, pytest.mark.core_model]
+
+
+def _inputs(dtype=torch.float32, kv_heads=2, sinks=2):
+    generator = torch.Generator().manual_seed(7)
+    q = torch.randn(11, 4, 32, generator=generator).to(dtype)[..., ::2]
+    k = torch.randn(13, kv_heads, 32, generator=generator).to(dtype)[..., ::2]
+    v = torch.randn(13, kv_heads, 32, generator=generator).to(dtype)[..., ::2]
+    sink = torch.randn(sinks, 4, generator=generator) if sinks else None
+    return q, k, v, sink, [0, 4, 4, 11], [0, 6, 6, 13]
+
+
+def _dense_reference(q, k, v, sink, cq, ck, softcap):
+    output = torch.empty_like(q)
+    for qs, qe, ks, ke in zip(cq[:-1], cq[1:], ck[:-1], ck[1:]):
+        qq = q[qs:qe].float().transpose(0, 1)
+        kk = k[ks:ke].float().repeat_interleave(q.shape[1] // k.shape[1], dim=1).transpose(0, 1)
+        vv = v[ks:ke].float().repeat_interleave(q.shape[1] // v.shape[1], dim=1).transpose(0, 1)
+        scores = (qq @ kk.transpose(-1, -2)) * q.shape[-1] ** -0.5
+        if softcap > 0:
+            scores = softcap * torch.tanh(scores / softcap)
+        if sink is not None and sink.numel():
+            scores = torch.cat((scores, sink.float().t().unsqueeze(1).expand(-1, qe - qs, -1)), dim=-1)
+        probabilities = scores.softmax(-1)[..., : ke - ks]
+        output[qs:qe] = (probabilities @ vv).transpose(0, 1).to(output.dtype)
+    return output
+
+
+def _run(q, k, v, sink, cq, ck, *, softcap=2.0, chunk=3):
+    return torch_varlen_attention_with_sink(
+        q,
+        k,
+        v,
+        sink=sink,
+        cu_seqlens_q=torch.tensor(cq, dtype=torch.int32),
+        cu_seqlens_k=torch.tensor(ck, dtype=torch.int32),
+        softcap=softcap,
+        query_chunk_size=chunk,
+    )
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("kv_heads,sinks,softcap", [(4, 0, -1.0), (2, 1, -1.0), (1, 2, 2.0)])
+@pytest.mark.parametrize("chunk", [1, 3, 512])
+def test_dense_oracle_parity(dtype, kv_heads, sinks, softcap, chunk):
+    q, k, v, sink, cq, ck = _inputs(dtype, kv_heads, sinks)
+    actual = _run(q, k, v, sink, cq, ck, softcap=softcap, chunk=chunk)
+    expected = _dense_reference(q, k, v, sink, cq, ck, softcap)
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=2e-6)
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("chunk", [0, -1, True, 2.5])
+def test_invalid_chunk_size(chunk):
+    with pytest.raises(ValueError, match="positive integer"):
+        _run(*_inputs(), chunk=chunk)
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("empty_query", [True, False])
+@pytest.mark.parametrize("sinks", [0, 2])
+def test_empty_sequences(empty_query, sinks):
+    q, k, v, sink, _, _ = _inputs(sinks=sinks)
+    if empty_query:
+        q, cq, ck = q[:0], [0, 0], [0, k.shape[0]]
+    else:
+        k, v, cq, ck = k[:0], v[:0], [0, q.shape[0]], [0, 0]
+    actual = _run(q, k, v, sink, cq, ck)
+    torch.testing.assert_close(actual, torch.zeros_like(q), rtol=0, atol=0)
+
+
+@pytest.mark.cpu
+def test_scores_are_bounded_but_all_keys_are_visible():
+    original = torch.einsum
+    shapes = []
+
+    def record(equation, *tensors):
+        if equation == "qhd,khd->hqk":
+            shapes.append((tensors[0].shape[0], tensors[1].shape[0]))
+        return original(equation, *tensors)
+
+    with patch.object(torch, "einsum", side_effect=record):
+        _run(*_inputs(), chunk=3)
+    assert shapes == [(3, 6), (1, 6), (0, 0), (3, 7), (3, 7), (1, 7)]
+
+
+@pytest.mark.cpu
+def test_default_chunk_size_applies_to_long_queries():
+    q, k, v = torch.ones(1025, 1, 4), torch.ones(3, 1, 4), torch.ones(3, 1, 4)
+    original = torch.einsum
+    rows = []
+
+    def record(equation, *tensors):
+        if equation == "qhd,khd->hqk":
+            rows.append(tensors[0].shape[0])
+        return original(equation, *tensors)
+
+    with torch.inference_mode(), patch.object(torch, "einsum", side_effect=record):
+        result = torch_varlen_attention_with_sink(
+            q,
+            k,
+            v,
+            cu_seqlens_q=torch.tensor([0, 1025]),
+            cu_seqlens_k=torch.tensor([0, 3]),
+        )
+    assert rows == [512, 512, 1]
+    torch.testing.assert_close(result, q, rtol=0, atol=0)
+
+
+@pytest.mark.cpu
+def test_gradients_match_dense_reference():
+    q, k, v, sink, cq, ck = _inputs()
+    inputs = (
+        q.clone().requires_grad_(),
+        k.clone().requires_grad_(),
+        v.clone().requires_grad_(),
+        sink.clone().requires_grad_(),
+    )
+    expected = _dense_reference(*inputs, cq, ck, 2.0)
+    reference_grads = torch.autograd.grad(expected.square().sum(), inputs)
+    actual = _run(*inputs, cq, ck)
+    actual_grads = torch.autograd.grad(actual.square().sum(), inputs)
+    for grad, reference in zip(actual_grads, reference_grads):
+        torch.testing.assert_close(grad, reference, rtol=2e-5, atol=2e-6)
+
+
+@pytest.mark.cpu
+def test_empty_query_keeps_autograd_dependencies():
+    q, k, v, sink, _, _ = _inputs()
+    inputs = (
+        q[:0].clone().requires_grad_(),
+        k.clone().requires_grad_(),
+        v.clone().requires_grad_(),
+        sink.clone().requires_grad_(),
+    )
+    cq, ck = [0, 0], [0, k.shape[0]]
+    expected = _dense_reference(*inputs, cq, ck, 2.0)
+    actual = _run(*inputs, cq, ck)
+    assert actual.requires_grad == expected.requires_grad
+    for left, right in zip(torch.autograd.grad(actual.sum(), inputs), torch.autograd.grad(expected.sum(), inputs)):
+        torch.testing.assert_close(left, right, rtol=0, atol=0)
+
+
+@pytest.mark.musa
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+def test_musa_chunked_matches_unchunked(dtype):
+    if not hasattr(torch, "musa") or not torch.musa.is_available():
+        pytest.skip("requires a MUSA device")
+    q, k, v, sink, cq, ck = _inputs(dtype)
+    q, k, v, sink = (tensor.to("musa") for tensor in (q, k, v, sink))
+    for cap in (-1.0, 2.0):
+        expected = _run(q, k, v, sink, cq, ck, softcap=cap, chunk=512)
+        for chunk in (1, 3):
+            actual = _run(q, k, v, sink, cq, ck, softcap=cap, chunk=chunk)
+            torch.testing.assert_close(actual, expected, rtol=1e-5, atol=2e-6)

--- a/vllm_omni/diffusion/models/magi2/attention.py
+++ b/vllm_omni/diffusion/models/magi2/attention.py
@@ -151,9 +151,17 @@ def torch_varlen_attention_with_sink(
     cu_seqlens_k: torch.Tensor,
     softcap: float = -1.0,
     sink: torch.Tensor | None = None,
+    query_chunk_size: int = 512,
 ) -> torch.Tensor:
-    """Reference packed attention, including GQA and sink logits."""
+    """Reference packed attention, including GQA and sink logits.
 
+    During inference, score/probability tensors have at most query_chunk_size
+    rows instead of the full query length. Each chunk still attends to all
+    keys; K/V storage and any tensors retained for autograd are not bounded.
+    """
+
+    if type(query_chunk_size) is not int or query_chunk_size <= 0:
+        raise ValueError("query_chunk_size must be a positive integer")
     if q.ndim != 3 or k.ndim != 3 or v.ndim != 3:
         raise ValueError("packed attention expects q/k/v shaped [tokens,heads,dim]")
     if cu_seqlens_q.numel() != cu_seqlens_k.numel():
@@ -166,15 +174,20 @@ def torch_varlen_attention_with_sink(
         q_part = q[q_start:q_end].float()
         k_part = _repeat_kv_heads(k[k_start:k_end], q.shape[1]).float()
         v_part = _repeat_kv_heads(v[k_start:k_end], q.shape[1]).float()
-        scores = torch.einsum("qhd,khd->hqk", q_part, k_part) * scale
-        if softcap > 0:
-            scores = softcap * torch.tanh(scores / softcap)
-        if sink is not None and sink.numel() > 0:
-            sink_scores = sink.float().transpose(0, 1).unsqueeze(1).expand(-1, q_part.shape[0], -1)
-            probabilities = torch.softmax(torch.cat((scores, sink_scores), dim=-1), dim=-1)[..., : k_part.shape[0]]
-        else:
-            probabilities = torch.softmax(scores, dim=-1)
-        output[q_start:q_end] = torch.einsum("hqk,khd->qhd", probabilities, v_part).to(output.dtype)
+        # Retain the empty calculation too, including its autograd dependencies.
+        for offset in range(0, max(1, q_part.shape[0]), query_chunk_size):
+            q_chunk = q_part[offset : offset + query_chunk_size]
+            scores = torch.einsum("qhd,khd->hqk", q_chunk, k_part) * scale
+            if softcap > 0:
+                scores = softcap * torch.tanh(scores / softcap)
+            if sink is not None and sink.numel() > 0:
+                sink_scores = sink.float().transpose(0, 1).unsqueeze(1).expand(-1, q_chunk.shape[0], -1)
+                probabilities = torch.softmax(torch.cat((scores, sink_scores), dim=-1), dim=-1)[..., : k_part.shape[0]]
+            else:
+                probabilities = torch.softmax(scores, dim=-1)
+            output[q_start + offset : q_start + offset + q_chunk.shape[0]] = torch.einsum(
+                "hqk,khd->qhd", probabilities, v_part
+            ).to(output.dtype)
     return output
 
 


### PR DESCRIPTION
## Summary

Chunk the Torch reference path of MAGI-2 attention along the query axis, keeping every chunk's full key range.

- Scores and probabilities cover at most `query_chunk_size` query rows (default 512) at a time during inference.
- Preserve FP32 Q/K/V computation, GQA, softcap, sink logits, output dtype and sequence order.
- Keep empty-query autograd dependencies as well as ordinary gradients. Invalid chunk sizes are rejected.

The bound concerns score/probability buffers only, not total memory: K/V storage and intermediates retained for autograd are not bounded by the query chunk size.

## Scope

Two files only: the reference implementation and its tests. No backend selection changes, MUSA-specific path, new environment variables, native kernels, caches, RoPE, EP or sampler changes. Existing callers need no changes.

This is an independent extraction of the chunked-reference idea in #7156. It does not depend on the standalone FA3 adapter or on the MUSA consumer. The latter's pending numerical checks are not bypassed or reclassified here.

## Validation

Commit: `f644b504d7f1f2018fe8be21900845c876bd0d2d`, one signed-off commit based on upstream `5378b77be`.

- Targeted pre-commit passed, including Ruff, mypy and test markers.
- **44 CPU tests passed**, 3 MUSA tests deselected: independent dense oracle, ragged/empty sequences, MHA/GQA, zero/one/multiple sinks, softcap, noncontiguous inputs, three floating dtypes, regular/empty-query gradients and existing native model tests.
- A structural test observes the score operands: a 1025-query call with the default setting uses query row counts `[512,512,1]`. Separate ragged tests verify every chunk keeps the full per-sequence key range.
- **3 MUSA tests passed** on one 48-SM MTT S5000 (driver `5.2.0-server`). FP32/BF16/FP16 chunk sizes 1 and 3 match the unchunked reference on the same GPU, with/without softcap and with GQA/two sinks. Tolerance remains `rtol=1e-5, atol=2e-6`.

Runtime: torch/torch_musa `2.11.0.post1+musa5.2.0`, torchada `0.1.83`, vLLM `0.28.0`, vllm-musa `0.1.28`. Exact source installed editable with `--no-deps --no-build-isolation`; MUSA entrypoint imports torchada first. No dependencies changed.

```bash
python -m pytest -q -o addopts= -m cpu \
  tests/diffusion/models/magi2/test_chunked_attention.py \
  tests/diffusion/models/magi2/test_native_preview.py
```

For MUSA, run the new test file with `-m musa` from a torchada-first entrypoint with one visible GPU.

**Not run:** CUDA hardware, GPU autograd, compile/graph, full MAGI-2 checkpoint/video, peak-memory or performance benchmarks. Structural buffer bounds and functional parity are not an E2E throughput/latency or full-resolution memory claim. This PR remains Draft.
