### PR TITLE
[Refactor] Reuse FP32 RMSNorm normalization in MAGI-2

### DIFF
--- a/tests/diffusion/models/magi2/test_rmsnorm.py
+++ b/tests/diffusion/models/magi2/test_rmsnorm.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from tests.diffusion.models.magi2.test_native_preview import _initialize_tiny_model, _tiny_config
+from vllm_omni.diffusion.models.magi2.attention import VarlenHandler
+from vllm_omni.diffusion.models.magi2.layers import ModalityDispatcher, MultiModalityRMSNorm
+from vllm_omni.diffusion.models.magi2.modeling_magi2 import Magi2PreviewTransformer, Modality
+
+pytestmark = [pytest.mark.diffusion, pytest.mark.core_model]
+
+
+def _reference(module, tensor, modality_dispatcher=None):
+    normalized = tensor.float()
+    normalized = normalized * torch.rsqrt(normalized.square().mean(dim=-1, keepdim=True) + module.eps)
+    if module.num_modality == 1:
+        result = normalized * (module.weight.view(module.num_patterns, module.dim) + 1.0)
+    else:
+        if modality_dispatcher is None:
+            raise ValueError("modality_dispatcher is required for multimodal RMSNorm")
+        parts = modality_dispatcher.dispatch(normalized)
+        weights = module.weight.view(module.num_modality, module.num_patterns, module.dim)
+        result = modality_dispatcher.undispatch(*(part * (weights[i] + 1.0) for i, part in enumerate(parts)))
+    return result.to(module.out_dtype or tensor.dtype)
+
+
+def _fixture(dtype, output_dtype, modalities=1, patterns=1, width=128, count=7, device="cpu", seed=91):
+    generator = torch.Generator().manual_seed(seed)
+    module = MultiModalityRMSNorm(width, num_modality=modalities, num_patterns=patterns, out_dtype=output_dtype)
+    with torch.no_grad():
+        module.weight.copy_(torch.randn(module.weight.shape, generator=generator) * 0.1)
+    module = module.to(device)
+    tensor = torch.randn(count, patterns, width * 2, generator=generator).to(device=device, dtype=dtype)[..., ::2]
+    # One modality can be empty; order matches the packed dispatch contract.
+    counts = [count] if modalities == 1 else [count // 2, 0, count - count // 2]
+    mapping = torch.tensor(
+        [index for index, size in enumerate(counts) for _ in range(size)], dtype=torch.int64, device=device
+    )
+    return module, tensor, ModalityDispatcher(mapping, modalities)
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize(
+    "dtype,output_dtype",
+    [(torch.float32, None), (torch.bfloat16, None), (torch.float16, None), (torch.bfloat16, torch.float32)],
+)
+@pytest.mark.parametrize("modalities,patterns,count", [(1, 1, 7), (3, 1, 7), (3, 4, 7), (3, 4, 0)])
+def test_reference_parity(dtype, output_dtype, modalities, patterns, count):
+    module, tensor, dispatch = _fixture(dtype, output_dtype, modalities, patterns, count=count)
+    original_tensor, original_weight = tensor.clone(), module.weight.detach().clone()
+    actual = module(tensor, dispatch)
+    torch.testing.assert_close(actual, _reference(module, tensor, dispatch), rtol=1e-6, atol=1e-6)
+    assert actual.dtype == (output_dtype or dtype)
+    torch.testing.assert_close(tensor, original_tensor, rtol=0, atol=0)
+    torch.testing.assert_close(module.weight, original_weight, rtol=0, atol=0)
+
+
+@pytest.mark.cpu
+def test_operator_gets_fp32_without_affine_weight():
+    module, tensor, dispatch = _fixture(torch.bfloat16, torch.float32, 3, 4)
+    with patch.object(torch.nn.functional, "rms_norm", wraps=torch.nn.functional.rms_norm) as operator:
+        module(tensor, dispatch)
+    operator.assert_called_once()
+    normalized_input, shape, weight, eps = operator.call_args.args
+    assert normalized_input.dtype == torch.float32
+    assert shape == (128,) and weight is None and eps == module.eps
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("case", ["scalar", "broadcast", "zero_width", "zero_values", "nan_inf", "no_dispatcher"])
+def test_special_values_and_shape_contracts(case):
+    module, tensor, dispatch = _fixture(torch.float32, None)
+    if case == "scalar":
+        tensor = torch.tensor(2.0)
+    elif case == "broadcast":
+        tensor = tensor[..., :1]
+    elif case == "zero_width":
+        module, tensor, dispatch = _fixture(torch.float32, None, width=0)
+    elif case == "zero_values":
+        tensor.zero_()
+    elif case == "nan_inf":
+        tensor[0, 0, 0], tensor[1, 0, 0] = torch.nan, torch.inf
+    else:
+        module.num_modality = 3
+        with pytest.raises(ValueError, match="modality_dispatcher is required"):
+            module(tensor)
+        return
+    torch.testing.assert_close(
+        module(tensor, dispatch), _reference(module, tensor, dispatch), rtol=1e-6, atol=1e-6, equal_nan=True
+    )
+
+
+@pytest.mark.cpu
+def test_gradients_and_checkpoint_scale_updates():
+    module, tensor, dispatch = _fixture(torch.float32, None, 3, 4)
+    tensor = tensor.clone().requires_grad_()
+    expected = _reference(module, tensor, dispatch)
+    actual = module(tensor, dispatch)
+    for grad, ref in zip(
+        torch.autograd.grad(actual.square().sum(), (tensor, module.weight)),
+        torch.autograd.grad(expected.square().sum(), (tensor, module.weight)),
+    ):
+        torch.testing.assert_close(grad, ref, rtol=2e-5, atol=2e-5)
+    keys = list(module.state_dict())
+    with torch.no_grad():
+        module.weight.add_(0.03)
+    torch.testing.assert_close(module(tensor, dispatch), _reference(module, tensor, dispatch), rtol=1e-6, atol=1e-6)
+    clone = MultiModalityRMSNorm(128, num_modality=3, num_patterns=4)
+    clone.load_state_dict(module.state_dict())
+    assert keys == ["weight"]
+    torch.testing.assert_close(clone(tensor, dispatch), module(tensor, dispatch), rtol=0, atol=0)
+
+
+@pytest.mark.cpu
+def test_low_precision_weights_keep_offset_rounding_order():
+    module, tensor, dispatch = _fixture(torch.bfloat16, torch.float32, 3, 4)
+    module = module.bfloat16()
+    torch.testing.assert_close(module(tensor, dispatch), _reference(module, tensor, dispatch), rtol=1e-6, atol=1e-6)
+
+
+@pytest.mark.cpu
+def test_compile_frontend_and_weight_changes():
+    module, tensor, dispatch = _fixture(torch.bfloat16, torch.float32, 3, 4)
+    graphs = []
+
+    def backend(graph, _inputs):
+        graphs.append(graph)
+        return graph.forward
+
+    compiled = torch.compile(module, backend=backend, fullgraph=True)
+    try:
+        for _ in range(2):
+            torch.testing.assert_close(
+                compiled(tensor, dispatch), _reference(module, tensor, dispatch), rtol=1e-6, atol=1e-6
+            )
+            with torch.no_grad():
+                module.weight.add_(0.125)
+        assert graphs
+    finally:
+        torch._dynamo.reset()
+
+
+@pytest.mark.cpu
+def test_tiny_model_parity():
+    model = Magi2PreviewTransformer(_tiny_config(num_layers=2)).eval()
+    _initialize_tiny_model(model, seed=7)
+    generator = torch.Generator().manual_seed(11)
+    packed, coords = torch.randn(6, 4, generator=generator), torch.ones(6, 9)
+    modalities = torch.tensor(
+        [Modality.VIDEO, Modality.VIDEO, Modality.AUDIO, Modality.AUDIO, Modality.TEXT, Modality.TEXT]
+    )
+    cu = torch.tensor([0, 6], dtype=torch.int32)
+    with torch.no_grad(), patch.object(MultiModalityRMSNorm, "forward", _reference):
+        expected = model(packed, coords, modalities, VarlenHandler(cu, cu, 6, 6))
+    with torch.no_grad(), patch.object(torch.nn.functional, "rms_norm", wraps=torch.nn.functional.rms_norm) as operator:
+        actual = model(packed, coords, modalities, VarlenHandler(cu, cu, 6, 6))
+    assert operator.call_count > 0
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.musa
+@pytest.mark.parametrize(
+    "dtype,output_dtype",
+    [(torch.float32, None), (torch.bfloat16, None), (torch.float16, None), (torch.bfloat16, torch.float32)],
+)
+def test_musa_rmsnorm_matches_reference(dtype, output_dtype):
+    if not hasattr(torch, "musa") or not torch.musa.is_available():
+        pytest.skip("requires a MUSA device")
+    for seed in (91, 92, 93):
+        for modalities, patterns, count, width in ((1, 1, 7, 128), (3, 4, 7, 1536), (3, 4, 0, 128), (3, 1, 9, 768)):
+            module, tensor, dispatch = _fixture(
+                dtype, output_dtype, modalities, patterns, width, count, device="musa", seed=seed
+            )
+            if patterns == 1:
+                tensor = tensor.expand(-1, 6, -1)  # One pattern shared by Q/K heads.
+            with (
+                torch.no_grad(),
+                patch.object(torch.nn.functional, "rms_norm", wraps=torch.nn.functional.rms_norm) as operator,
+            ):
+                actual = module(tensor, dispatch)
+            operator.assert_called_once()
+            assert operator.call_args.args[0].dtype == torch.float32
+            with torch.no_grad():
+                expected = _reference(module, tensor, dispatch)
+                module.out_dtype = torch.float32
+                before_cast = module(tensor, dispatch)
+                reference_fp32 = _reference(module, tensor, dispatch)
+            torch.testing.assert_close(before_cast, reference_fp32, rtol=1e-6, atol=1e-6)
+            torch.testing.assert_close(actual, before_cast.to(actual.dtype), rtol=0, atol=0)
+            torch.testing.assert_close(expected, reference_fp32.to(expected.dtype), rtol=0, atol=0)
+            if actual.dtype == torch.float32:
+                torch.testing.assert_close(actual, expected, rtol=1e-6, atol=1e-6)
+            else:
+                # FP32 reduction differences can cross a low-precision rounding
+                # midpoint. Bound that final rounding to one ULP, in addition
+                # to the independent FP32 and cast-order gates above.
+                reference_cpu = expected.cpu()
+                up = torch.nextafter(reference_cpu, torch.full_like(reference_cpu, float("inf"))).float()
+                down = torch.nextafter(reference_cpu, torch.full_like(reference_cpu, -float("inf"))).float()
+                ulp = torch.maximum(up - reference_cpu.float(), reference_cpu.float() - down)
+                assert torch.all((actual.cpu().float() - reference_cpu.float()).abs() <= ulp)

--- a/vllm_omni/diffusion/models/magi2/layers.py
+++ b/vllm_omni/diffusion/models/magi2/layers.py
@@ -259,7 +259,13 @@ class MultiModalityRMSNorm(nn.Module):
     ) -> torch.Tensor:
         original_dtype = tensor.dtype
         normalized = tensor.float()
-        normalized = normalized * torch.rsqrt(normalized.square().mean(dim=-1, keepdim=True) + self.eps)
+        if tensor.ndim > 0 and tensor.shape[-1] == self.dim and self.eps is not None:
+            # Reuse the backend RMSNorm operator without rounding the normalized
+            # activation before the checkpoint's (weight + 1) multiplication.
+            normalized = F.rms_norm(normalized, (self.dim,), None, self.eps)
+        else:
+            # Preserve broadcasting for nonstandard input shapes.
+            normalized = normalized * torch.rsqrt(normalized.square().mean(dim=-1, keepdim=True) + self.eps)
         if self.num_modality == 1:
             weight = self.weight.view(self.num_patterns, self.dim) + 1.0
             result = normalized * weight


### PR DESCRIPTION
## Summary

Use the existing PyTorch RMSNorm operation for MAGI-2's FP32 normalization, while keeping its checkpoint-specific affine operation outside the call.

- Input is still converted to FP32 before normalization.
- `F.rms_norm` receives no affine weight; MAGI-2 still applies its flattened, modality-major `(weight + 1)` scales afterward, then casts to the requested output dtype.
- Existing constructor, state-dict key/layout, modality grouping, multiple-pattern behavior and singleton-head broadcasting are retained.
- Nonstandard input shapes keep the original broadcast behavior. No per-call dtype override, new environment variable, model wiring, cache or custom kernel is added.

This is the normalization portion of the reference #7156 decomposition, without its BF16/FP16 intermediate downcasts or separate mHC overrides. Omni's standard RMSNorm parameter represents effective scale directly, so substituting it for MAGI-2's delta-scale parameter would change checkpoint semantics; only the unweighted normalization operation is reused here.

## Numerical contract and investigation

This is **not a bitwise-equivalence claim**. An initial MUSA test used a uniform `rtol=atol=1e-6` on all output dtypes: FP32 and BF16 cases passed, but 2 of 43008 FP16 values differed by one FP16 ULP.

An independent same-source diagnostic compared outputs before and after the final cast. Across nine dtype/shape cases, all pre-cast FP32 comparisons passed the original `1e-6` gate (largest absolute difference `9.54e-7`); both implementations' low-precision outputs exactly matched their own FP32 outputs cast at the end. The discrepant FP16 values straddled a rounding midpoint. For example, pre-cast `1.6381838322` versus `1.63818359375` rounded to `1.638671875` versus `1.6376953125`.

The final test makes the acceptance contract explicit and expands coverage to three seeds:

1. Pre-cast FP32 affine outputs must still satisfy `rtol=atol=1e-6`.
2. Each returned output must exactly equal the corresponding FP32 result cast to its dtype.
3. FP16/BF16 output differences must be at most one local ULP, measured as the larger spacing to the two representable neighbors of the reference value.

This replaces the inappropriate uniform FP32 tolerance on quantized outputs; it is an explicitly documented gate adjustment, not a retroactive pass for the initial run. Separate FA3 numerical gates are unchanged. Full-model acceptance remains a separate requirement.

## Validation

Tested commit `da47bf6772f7b91425d25045d8ea3e6e99a6fc19`, one signed-off commit based on upstream `d59d1664858956976a12797a8613bd4b1d803097`.

- Targeted pre-commit passed, including Ruff, mypy and test markers.
- **32 CPU tests passed**, 4 MUSA deselected: explicit original-formula parity, FP32 operation arguments, modality/pattern grouping with empty groups, input/state preservation, low-precision parameter offsets, gradients, state-dict reload and weight updates, shape/value edge cases and two-layer native model parity.
- A Dynamo test asserts actual FX graph creation and changed-weight behavior. Its backend runs the graph eagerly; it is not Inductor/capture validation.
- **4 MUSA tests passed** under the contract above. Three seeds, widths 128/768/1536, FP32/BF16/FP16 inputs, FP32 output overrides, strided/multi-head inputs, multiple scale patterns and empty modalities are covered. The real RMSNorm operation is observed receiving FP32 input and no weight.
- Final hardware: one 48-SM MTT S5000, driver `5.2.0-server`; no driver pin. Exact checkout installed editable without dependency changes.

Stack: torch/torch_musa `2.11.0.post1+musa5.2.0`, torchada `0.1.83`, vLLM `0.28.0`, vllm-musa `0.1.28`. MUSA entrypoint imports torchada first. The current dispatch table reports a composite RMSNorm registration; using this API alone does not establish that a particular kernel is fused or faster.

```bash
python -m pytest -q -o addopts= -m cpu \
  tests/diffusion/models/magi2/test_rmsnorm.py \
  tests/diffusion/models/magi2/test_native_preview.py
```

For MUSA, run the new test file with `-m musa` from a torchada-first entrypoint with one visible GPU.

**Not run:** CUDA hardware, GPU backward, Inductor/graph, full MUSA MAGI-2 checkpoint/video or performance. No DiT-step improvement is claimed; this remains Draft pending review and broader integration gates.
