### PR TITLE
[Doc] Qwen3-TTS: add 0.6B on 1x A100 40GB

### DIFF
--- a/recipes/Qwen/Qwen3-TTS.md
+++ b/recipes/Qwen/Qwen3-TTS.md
@@ -263,7 +263,6 @@ curl -X POST http://localhost:8091/v1/audio/speech \
       gpu_memory_utilization: 0.15
   ```
 
-<!-- 2026-09-08, tianqi, add 1x A100 40GB 0.6B CustomVoice hardware section (measured) -->
 ### 1x A100 40GB (0.6B CustomVoice)
 
 #### Environment
@@ -351,7 +350,6 @@ curl -X POST http://localhost:8091/v1/audio/speech \
   Confirm `torch.__version__` contains `cu129`. If a CPU build is already
   installed, `uv pip install --torch-backend=cu129` is a no-op; use
   `--reinstall`.
-<!-- end -->
 
 ### 1x AMD MI300X, 1.7B checkpoints
 

--- a/recipes/Qwen/Qwen3-TTS.md
+++ b/recipes/Qwen/Qwen3-TTS.md
@@ -263,6 +263,96 @@ curl -X POST http://localhost:8091/v1/audio/speech \
       gpu_memory_utilization: 0.15
   ```
 
+<!-- 2026-09-08, tianqi, add 1x A100 40GB 0.6B CustomVoice hardware section (measured) -->
+### 1x A100 40GB (0.6B CustomVoice)
+
+#### Environment
+
+- OS: Linux 4.18.0-553 (RHEL 8.10), x86_64
+- Python: 3.12.14
+- PyTorch: 2.13.0+cu129
+- Driver / runtime: NVIDIA 570.124.06 / CUDA 12.8 (`nvidia-smi`); PyTorch CUDA 12.9
+- GPU: NVIDIA A100-SXM4-40GB, 40960 MiB
+- vLLM version: 0.28.0+cu129
+- vLLM-Omni version or commit: `3204a0b2ade0f05424b7f11e3bcc03cb3542e0c6`
+
+#### Command
+
+```bash
+vllm serve Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice \
+    --deploy-config vllm_omni/deploy/qwen3_tts.yaml \
+    --omni --port 8091
+```
+
+The default deploy config (`qwen3_tts.yaml`) works without modification on this
+A100 40GB. Both stages (talker + code2wav) share GPU 0 with
+`gpu_memory_utilization: 0.3` each.
+
+#### Verification
+
+**English synthesis:**
+
+```bash
+curl -X POST http://localhost:8091/v1/audio/speech \
+    -H "Content-Type: application/json" \
+    -d '{
+        "input": "Hello, this is Qwen3-TTS running on A100 40GB.",
+        "voice": "vivian",
+        "language": "English"
+    }' --output test_english.wav
+```
+
+**Chinese synthesis:**
+
+```bash
+curl -X POST http://localhost:8091/v1/audio/speech \
+    -H "Content-Type: application/json" \
+    -d '{
+        "input": "你好，这是在A100 40GB上运行的语音合成测试。",
+        "voice": "vivian",
+        "language": "Chinese"
+    }' --output test_chinese.wav
+```
+
+**With emotion instruction:**
+
+```bash
+curl -X POST http://localhost:8091/v1/audio/speech \
+    -H "Content-Type: application/json" \
+    -d '{
+        "input": "I am so excited about this!",
+        "voice": "vivian",
+        "language": "English",
+        "instructions": "Speak with great enthusiasm"
+    }' --output test_emotion.wav
+```
+
+#### Notes
+
+- Memory usage: **16283 MiB / 40960 MiB** peak (`nvidia-smi`) during the three
+  verification requests with the default deploy config
+  (`gpu_memory_utilization: 0.3` per stage). Stage 0 used 12404 MiB and stage 1
+  used 3862 MiB. The 0.6B weights occupy only ~2.4 GiB (Stage 0: 1.91 GiB,
+  Stage 1: 0.45 GiB); the rest is KV cache reserved as a fraction of device
+  memory, so the same `0.3` setting reads higher in GiB on 40GB than the
+  ~13.5 GiB idle figure on the 24GB 4090 profile above. To shrink the
+  reservation, use the `gpu_memory_utilization: 0.15` override documented in
+  that 4090 section.
+- vLLM 0.28.0's default wheel targets CUDA 13.0. Driver 570 cannot load that
+  variant. This qualification used the official CUDA 12.9 wheel (same pin as
+  the A100 Wan2.2 recipe):
+
+  ```bash
+  uv pip install \
+    'https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0%2Bcu129-cp38-abi3-manylinux_2_28_x86_64.whl' \
+    --torch-backend=cu129
+  ```
+
+  Confirm `torch.__version__` contains `cu129`. If a CPU build is already
+  installed, `uv pip install --torch-backend=cu129` is a no-op; use
+  `--reinstall`.
+<!-- end -->
+
 ### 1x AMD MI300X, 1.7B checkpoints
 
 #### Environment


### PR DESCRIPTION
## Purpose

Add a personally validated hardware section for `Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice` on 1x NVIDIA A100-SXM4-40GB.

Qwen3-TTS already has a recipe file (#3130) with a 1x RTX 4090 24GB 0.6B section (#4026) and a 1x MI300X 1.7B section. This PR only adds the missing 40GB A100 profile to `recipes/Qwen/Qwen3-TTS.md`. It does not add a new recipe file, change examples, or change runtime code.

The section follows the 4090 layout from #4026 (environment, serve command, English/Chinese/emotion curls, peak memory). Claimed on #2645 as `Qwen3-TTS, 1x A100 40GB`.

Relates to #2645.

## Test Plan

**vLLM Version:** `0.28.0+cu129`

**vLLM-Omni Commit:** `3204a0b2ade0f05424b7f11e3bcc03cb3542e0c6`

**Qualification environment:** 1x NVIDIA A100-SXM4-40GB (40960 MiB); RHEL 8.10 (kernel 4.18.0-553); Python 3.12.14; NVIDIA driver 570.124.06; CUDA 12.8 (`nvidia-smi`); PyTorch 2.13.0+cu129.

1. Start the server from the repository root with the bundled deploy config:

   ```bash
   vllm serve Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice      --deploy-config vllm_omni/deploy/qwen3_tts.yaml      --omni --port 8091
   ```

2. Curl English, Chinese, and emotion-instructed `/v1/audio/speech` requests (same three checks as the 4090 section). Confirm each response is a valid RIFF/WAVE file.

3. Record peak `nvidia-smi` during those three requests.

## Test Result

All three requests returned valid WAV:

| Request | Size | Wall time |
| --- | ---: | ---: |
| English | 314924 B | 7.05 s (first request / warmup) |
| Chinese | 257324 B | 0.66 s |
| Emotion | 130604 B | 0.36 s |

Peak GPU memory: **16283 MiB / 40960 MiB** (stage 0: 12404 MiB, stage 1: 3862 MiB). Weights are ~2.4 GiB; the rest is KV cache reserved at `gpu_memory_utilization: 0.3` per stage, so the same setting reads higher in GiB on 40GB than the ~13.5 GiB idle figure on the 24GB 4090 profile. Driver 570 cannot load the default CUDA 13.0 vLLM 0.28.0 wheel; this run used the official `vllm-0.28.0+cu129` wheel.

Documentation-only change. No MOS/WER.

Made with [Cursor](https://cursor.com)