### PR TITLE
[Bugfix] Preserve multimodal cache data across stage-0 replicas

### DIFF
--- a/tests/engine/test_async_omni_engine_stage_init.py
+++ b/tests/engine/test_async_omni_engine_stage_init.py
@@ -5,11 +5,27 @@ import concurrent.futures
 import contextlib
 import importlib
 import json
+import multiprocessing
 import os
 import time
 import types
+import uuid
 
 import pytest
+import torch
+from vllm.config import ModelConfig, MultiModalConfig, ParallelConfig, VllmConfig
+from vllm.multimodal.cache import (
+    MultiModalProcessorCacheInItem,
+    MultiModalProcessorOnlyCache,
+    MultiModalProcessorSenderCache,
+    MultiModalReceiverCache,
+    ShmObjectStoreReceiverCache,
+    ShmObjectStoreSenderCache,
+)
+from vllm.multimodal.inputs import MultiModalBatchedField, MultiModalFieldElem, MultiModalKwargsItem
+from vllm.multimodal.processing import BaseMultiModalProcessor
+from vllm.renderers import BaseRenderer
+from vllm.v1.engine.input_processor import InputProcessor
 
 from vllm_omni.diffusion.data import AttentionConfig
 from vllm_omni.engine import async_omni_engine as async_omni_engine_module
@@ -20,8 +36,11 @@ from vllm_omni.engine.stage_init_utils import (
     build_stage0_input_processor,
     compute_replica_layout,
     split_devices_for_replicas,
+    use_replica_safe_mm_processor_cache,
 )
+from vllm_omni.engine.stage_pool import StagePool
 from vllm_omni.engine.stage_runtime import StageRuntime
+from vllm_omni.inputs.preprocess import OmniInputPreprocessor
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -1847,3 +1866,156 @@ def test_port_from_zmq_address_parsing():
     assert _port_from_zmq_address(None) is None
     assert _port_from_zmq_address("ipc:///tmp/sock") is None
     assert _port_from_zmq_address("tcp://host:not-a-port") is None
+
+
+@pytest.fixture
+def mm_cache_frontend(mocker):
+    """Avoid model/tokenizer loading while using real vLLM cache implementations."""
+    model_config = mocker.Mock(spec=ModelConfig, skip_tokenizer_init=False)
+    model_config.get_multimodal_config.return_value = MultiModalConfig(mm_processor_cache_gb=0.01)
+    model_config.try_get_generation_config.return_value = {}
+    config = mocker.Mock(
+        spec=VllmConfig,
+        model_config=model_config,
+        parallel_config=mocker.Mock(spec=ParallelConfig, world_size=1),
+    )
+    processor = mocker.Mock(spec=BaseMultiModalProcessor, cache=MultiModalProcessorSenderCache(model_config))
+    renderer = mocker.Mock(spec=BaseRenderer, mm_processor=processor)
+    return config, mocker.Mock(spec=InputProcessor, renderer=renderer)
+
+
+@pytest.fixture
+def mm_cache_item():
+    return MultiModalKwargsItem({"audio": MultiModalFieldElem(data=torch.arange(16), field=MultiModalBatchedField())})
+
+
+@pytest.mark.parametrize("num_replicas", [1, 2, 3])
+def test_replica_safe_mm_processor_cache(mm_cache_frontend, mm_cache_item, num_replicas):
+    """A frontend hit must supply data even to a replica that never saw the item."""
+    config, frontend = mm_cache_frontend
+    sender_cache = frontend.renderer.mm_processor.cache
+    assert use_replica_safe_mm_processor_cache(frontend, config, num_replicas) is (num_replicas > 1)
+    cache = frontend.renderer.mm_processor.cache
+    assert (cache is sender_cache) is (num_replicas == 1)
+    receivers = [MultiModalReceiverCache(config.model_config) for _ in range(num_replicas)]
+
+    for request in range(num_replicas * 3):
+        # None on a hit means no HF processing: the cache must supply the item.
+        processed: MultiModalProcessorCacheInItem = (mm_cache_item, []) if request == 0 else None
+        data, updates = cache.get_and_update_item(processed, "audio-A")
+        received = receivers[request % num_replicas].get_and_update_item(data, "audio-A")
+        assert torch.equal(received["audio"].data, mm_cache_item["audio"].data)
+        assert updates == []
+
+
+def test_replica_safe_mm_processor_cache_after_receiver_eviction(mm_cache_frontend, mm_cache_item):
+    config, frontend = mm_cache_frontend
+    use_replica_safe_mm_processor_cache(frontend, config, 2)
+    cache = frontend.renderer.mm_processor.cache
+    receiver = MultiModalReceiverCache(config.model_config)
+    data, _ = cache.get_and_update_item((mm_cache_item, []), "audio-A")
+    receiver.get_and_update_item(data, "audio-A")
+    receiver.clear_cache()
+
+    data, _ = cache.get_and_update_item(None, "audio-A")
+    received = receiver.get_and_update_item(data, "audio-A")
+    assert torch.equal(received["audio"].data, mm_cache_item["audio"].data)
+
+
+@pytest.mark.parametrize("num_replicas", [1, 2, 3])
+def test_replica_safe_shm_processor_cache(monkeypatch, mm_cache_frontend, mm_cache_item, num_replicas):
+    config, frontend = mm_cache_frontend
+    config.model_config.get_multimodal_config.return_value = MultiModalConfig(
+        mm_processor_cache_type="shm", mm_processor_cache_gb=0.01, mm_shm_cache_max_object_size_mb=1
+    )
+    monkeypatch.setenv("VLLM_OBJECT_STORAGE_SHM_BUFFER_NAME", f"omni-test-{uuid.uuid4().hex}")
+    with contextlib.ExitStack() as cleanup:
+        sender = ShmObjectStoreSenderCache(config)
+        cleanup.callback(sender.close)
+        frontend.renderer.mm_processor.cache = sender
+        receivers = []
+        for _ in range(num_replicas):
+            receiver = ShmObjectStoreReceiverCache(config, multiprocessing.Lock())
+            # vLLM exposes close on the store, but not on the receiver cache.
+            cleanup.callback(receiver._shm_cache.close)
+            receivers.append(receiver)
+
+        assert use_replica_safe_mm_processor_cache(frontend, config, num_replicas) is (num_replicas > 1)
+        cache = frontend.renderer.mm_processor.cache
+        assert (cache is sender) is (num_replicas == 1)
+        for request in range(num_replicas * 3):
+            processed: MultiModalProcessorCacheInItem = (mm_cache_item, []) if request == 0 else None
+            data, _ = cache.get_and_update_item(processed, "audio-A")
+            receiver = receivers[request % num_replicas]
+            received = receiver.get_and_update_item(data, "audio-A")
+            receiver.touch_receiver_cache_item("audio-A", data)
+            assert torch.equal(received["audio"].data, mm_cache_item["audio"].data)
+
+
+@pytest.mark.parametrize("cache_factory", [lambda _: None, MultiModalProcessorOnlyCache])
+def test_replica_safe_mm_processor_cache_leaves_non_ipc_caches_alone(mm_cache_frontend, cache_factory):
+    config, frontend = mm_cache_frontend
+    cache = cache_factory(config.model_config)
+    frontend.renderer.mm_processor.cache = cache
+    assert not use_replica_safe_mm_processor_cache(frontend, config, 2, allow_dynamic_replicas=True)
+    assert frontend.renderer.mm_processor.cache is cache
+
+
+def test_replica_safe_mm_processor_cache_leaves_text_only_renderer_alone(mm_cache_frontend):
+    config, frontend = mm_cache_frontend
+    frontend.renderer.mm_processor = None
+    assert not use_replica_safe_mm_processor_cache(frontend, config, 2, allow_dynamic_replicas=True)
+
+
+@pytest.mark.parametrize("initial_replicas", [0, 1])
+def test_replica_safe_mm_processor_cache_with_later_replica(mm_cache_frontend, mm_cache_item, initial_replicas):
+    config, frontend = mm_cache_frontend
+    assert use_replica_safe_mm_processor_cache(frontend, config, initial_replicas, allow_dynamic_replicas=True)
+    cache = frontend.renderer.mm_processor.cache
+    data, _ = cache.get_and_update_item((mm_cache_item, []), "audio-A")
+    MultiModalReceiverCache(config.model_config).get_and_update_item(data, "audio-A")
+
+    # A new replica joins after the frontend has already cached this media.
+    new_receiver = MultiModalReceiverCache(config.model_config)
+    data, _ = cache.get_and_update_item(None, "audio-A")
+    received = new_receiver.get_and_update_item(data, "audio-A")
+    assert torch.equal(received["audio"].data, mm_cache_item["audio"].data)
+
+
+@pytest.mark.parametrize("num_replicas, distributed", [(1, False), (2, False), (3, False), (0, True), (1, True)])
+def test_initialize_stages_builds_replica_safe_mm_cache(mocker, mm_cache_frontend, num_replicas, distributed):
+    """Exercise both the engine-to-builder and builder-to-cache connections."""
+    config, frontend = mm_cache_frontend
+    engine = object.__new__(AsyncOmniEngine)
+    engine.stage_configs = []
+    engine.model = "dummy-model"
+    engine.config_path = "dummy-config"
+    engine.single_stage_mode = distributed
+    engine.async_chunk = False
+    engine.tokenizer = None
+    engine._single_stage_id_filter = 0 if distributed else None
+    engine._omni_master_address = "127.0.0.1"
+    engine._omni_master_port = 12345
+    engine._omni_dp_size_local = 1
+    engine._omni_heartbeat_timeout = 30.0
+    engine._omni_lb_policy = "random"
+    engine.request_queue = None
+    engine._log_stats = False
+    engine._parallel_stage_init = False
+    pool = mocker.Mock(
+        spec=StagePool,
+        stage_client=None,
+        stage_vllm_config=config,
+        output_processor=None,
+        live_num_replicas=num_replicas,
+    )
+    runtime = mocker.Mock(spec=StageRuntime, stage_pools=[pool])
+    mocker.patch.object(async_omni_engine_module, "create_stage_runtime", return_value=runtime)
+    mocker.patch("vllm_omni.engine.stage_init_utils.InputProcessor", return_value=frontend)
+    mocker.patch("vllm_omni.engine.stage_init_utils.OmniInputPreprocessor", spec=OmniInputPreprocessor)
+
+    engine._initialize_stages(stage_init_timeout=7)
+
+    assert engine.input_processor is frontend
+    expected_type = MultiModalProcessorOnlyCache if distributed or num_replicas > 1 else MultiModalProcessorSenderCache
+    assert isinstance(frontend.renderer.mm_processor.cache, expected_type)

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -343,7 +343,13 @@ class AsyncOmniEngine:
         self.stage_vllm_configs = [pool.stage_vllm_config for pool in self.stage_pools]
         self.output_processors = [pool.output_processor for pool in self.stage_pools]
         self.input_processor = (
-            build_stage0_input_processor(self.stage_vllm_configs[0])
+            build_stage0_input_processor(
+                self.stage_vllm_configs[0],
+                num_replicas=self._stage_pool_replica_count(self.stage_pools[0]),
+                # DistStageRuntime accepts new replicas after startup. Its
+                # membership controller is attached only after this method.
+                allow_dynamic_replicas=self.single_stage_mode,
+            )
             if self.stage_vllm_configs and self.stage_vllm_configs[0] is not None
             else None
         )

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -26,7 +26,13 @@ from pathlib import Path
 from typing import Any, Literal, cast
 
 import regex as re
+from vllm.config import VllmConfig
 from vllm.logger import init_logger
+from vllm.multimodal.cache import (
+    MultiModalProcessorOnlyCache,
+    MultiModalProcessorSenderCache,
+    ShmObjectStoreSenderCache,
+)
 from vllm.pooling_params import PoolingParams
 from vllm.renderers import BaseRenderer
 from vllm.sampling_params import SamplingParams
@@ -1546,8 +1552,70 @@ def _build_token_only_renderer(stage_vllm_config: Any) -> BaseRenderer:
     return _TokenOnlyRenderer(stage_vllm_config, tokenizer=None)
 
 
-def build_stage0_input_processor(stage_vllm_config: Any) -> InputProcessor:
-    """Build the shared stage-0 input processor."""
+def use_replica_safe_mm_processor_cache(
+    input_processor: InputProcessor,
+    stage_vllm_config: VllmConfig,
+    num_replicas: int,
+    *,
+    allow_dynamic_replicas: bool = False,
+) -> bool:
+    """Make the shared stage-0 multimodal processor cache safe for a replicated stage.
+
+    vLLM's IPC processor cache is split in two: the frontend (P0) keeps a
+    metadata-only shadow and strips the tensors of any item it has already
+    sent, trusting that the *one* engine (P1) still holds them. vllm-omni
+    runs ``num_replicas`` engine cores behind that single frontend, each with
+    its own receiver cache, so a request whose media was first sent to
+    replica A arrives at replica B without data -> ``MultiModalCacheMissError``
+    -> ``finish_reason="error"`` with no text. (vLLM itself avoids this
+    for data-parallel engines by selecting the "processor_only" cache type.)
+
+    ``multi_modal_uuids`` scoping in ``AsyncOmniEngine`` only helps prompts
+    that still carry raw ``multi_modal_data``; the OpenAI chat path arrives
+    already rendered (``mm_kwargs``/``mm_hashes``), after the frontend cache
+    has stripped the data. So for a replicated stage the frontend keeps the
+    processor-only cache: HF processing is still reused, but every request
+    carries its tensors and each replica's receiver cache fills on its own.
+
+    Distributed stages can add replicas after startup, so they must use
+    this cache even when only one replica is initially present. Switching
+    after serving starts would discard cached items and can race rendering.
+
+    Returns True when the cache was replaced.
+    """
+    if num_replicas <= 1 and not allow_dynamic_replicas:
+        return False
+    mm_processor = input_processor.renderer.mm_processor
+    if mm_processor is None:
+        return False
+    cache = mm_processor.cache
+    if not isinstance(cache, (MultiModalProcessorSenderCache, ShmObjectStoreSenderCache)):
+        return False
+    # renderer.mm_processor_cache is a read-only proxy to this attribute.
+    mm_processor.cache = MultiModalProcessorOnlyCache(stage_vllm_config.model_config)
+    logger.warning(
+        "Stage 0 is replacing %s with a processor-only multimodal cache "
+        "(replicas=%d, dynamic_replicas=%s) to send full data to every replica.",
+        type(cache).__name__,
+        num_replicas,
+        allow_dynamic_replicas,
+    )
+    return True
+
+
+def build_stage0_input_processor(
+    stage_vllm_config: VllmConfig,
+    *,
+    num_replicas: int = 1,
+    allow_dynamic_replicas: bool = False,
+) -> InputProcessor:
+    """Build the shared stage-0 input processor.
+
+    ``num_replicas`` is the stage-0 replica count; with more than one replica
+    or when ``allow_dynamic_replicas`` permits later replica additions,
+    the frontend multimodal cache must not strip data (see
+    :func:`use_replica_safe_mm_processor_cache`).
+    """
 
     patch_generation_config_if_needed(stage_vllm_config.model_config)
     if bool(getattr(stage_vllm_config.model_config, "skip_tokenizer_init", False)):
@@ -1560,6 +1628,9 @@ def build_stage0_input_processor(stage_vllm_config: Any) -> InputProcessor:
     input_processor.input_preprocessor = OmniInputPreprocessor(
         vllm_config=stage_vllm_config,
         renderer=input_processor.renderer,
+    )
+    use_replica_safe_mm_processor_cache(
+        input_processor, stage_vllm_config, num_replicas, allow_dynamic_replicas=allow_dynamic_replicas
     )
     return input_processor
 


### PR DESCRIPTION
## Purpose

Fixes #7295.

Fix repeated multimodal requests when one stage-0 frontend serves multiple engine replicas.
The IPC sender cache omits tensors on a frontend hit. A request routed to a replica that has
never received those tensors then ends with `finish_reason="error"` and empty content, although
HTTP status is 200. With two replicas and round-robin routing, sending the same new audio three
times reproduces `stop, error, stop`.

Use vLLM's `MultiModalProcessorOnlyCache` on the shared frontend for replicated stage 0.
Select it at startup for distributed runtimes as well, including those initially holding zero
or one replica, because headless replicas can join later. This preserves cached processing
results while always supplying tensors to the selected receiver. The OpenAI chat path is
already rendered before engine routing, so raw `multi_modal_uuids` scoping alone cannot fix it.

Local single-replica deployments, disabled caches, existing processor-only caches, and
text-only renderers are unchanged. LRU/SHM sender caches are replaced. Receiver caches remain;
the tradeoff is additional frontend tensor storage and tensor IPC on each request.

## Test Plan

**vLLM Version:** 0.28.0; PyTorch 2.13.0+cu130, CUDA runtime 13.0, Transformers 5.14.1.

**vLLM-Omni Commit:** `d3a86d70c70ae2e5b4559d56232e951689f1ec22`; base main `5e4baea64d0f4cd1b6ce147e4f7a28f0f41d995f`.

- L1 CPU: actual LRU and SHM caches with 1/2/3 receivers, receiver eviction, disabled and
  processor-only caches, text-only renderers, newly joined receivers, and engine-to-builder
  wiring for static and dynamic deployments. Only model/tokenizer setup is mocked.
- Fixed-replica GPU serving: Qwen3-Omni-30B-A3B-Instruct thinker-only on two H200 GPUs,
  TP=1, GPU memory utilization 0.60, prefix caching enabled, eager execution disabled.
- Dynamic serving: start the head with one replica, warm the frontend audio cache, attach
  another headless replica, then resend byte-identical audio with round-robin routing.
  Use `--disable-log-stats` to isolate cache behavior from the separate metrics failure below.

CPU commands, from the repository root (requires compatible vLLM dependencies, pytest and
pytest-mock; no model weights or GPU execution needed):

```bash
python -m pytest -q -o addopts='' tests/engine/test_async_omni_engine_stage_init.py
python -m pytest -q -o addopts='' tests/engine/test_async_omni_engine_stage_init.py -m 'core_model and cpu'
```

The existing Buildkite L1 engine CPU sweep already collects this module; no pipeline change.

Minimal serving reproduction: save the following as `/tmp/omni-replicas.yaml`:

```yaml
pipeline: qwen3_omni_moe_thinker_only
distributed_executor_backend: mp
enable_prefix_caching: true
stages:
  - stage_id: 0
    devices: "0,1"
    num_replicas: 2
    tensor_parallel_size: 1
    gpu_memory_utilization: 0.60
    max_num_seqs: 64
    enforce_eager: false
    async_scheduling: false
```

```bash
CUDA_VISIBLE_DEVICES=0,1 vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct \
  --omni --port 8099 --deploy-config /tmp/omni-replicas.yaml
```

After `/health` returns 200, run this against a fresh server using a short WAV file:

```python
import base64
import json
from pathlib import Path
from urllib.request import Request, urlopen

url = "http://127.0.0.1:8099"
with urlopen(url + "/v1/models") as response:
    model = json.load(response)["data"][0]["id"]
audio = base64.b64encode(Path("sample.wav").read_bytes()).decode()
body = {"model": model, "modalities": ["text"], "temperature": 0, "max_tokens": 128,
        "messages": [{"role": "user", "content": [
            {"type": "audio_url", "audio_url": {"url": "data:audio/wav;base64," + audio}},
            {"type": "text", "text": "Transcribe the audio briefly."}]}]}
for _ in range(3):
    request = Request(url + "/v1/chat/completions", data=json.dumps(body).encode(),
                      headers={"Content-Type": "application/json"})
    with urlopen(request, timeout=120) as response:
        choice = json.load(response)["choices"][0]
    print(choice["finish_reason"], len(choice["message"].get("content") or ""))
```

## Test Result

- CPU module: **72 passed**.
- Full changed-file pre-commit, including mypy-3.10: **passed**.
- Negative controls: disabling cache replacement makes the eviction regression fail with
  `MultiModalCacheMissError`; dropping the dynamic flag makes the engine wiring test fail.
- Before fix: 10 errors in 28 HTTP requests, 10 cache-miss warnings. Three fresh clips worked;
  repeated C returned `error, stop, error` and repeated D returned `error, stop`.
- Revised fixed-replica serving: **76/76 requests passed**, including 64 repeated audio requests
  at concurrency 8; **zero cache misses**.

- Dynamic serving with log stats disabled: **12/12 requests passed** before joining, then
  **76/76 passed** after joining, including 64 concurrent repeated audio requests; zero cache misses.
- With default log stats, joining succeeds but processing the first remote output raises
  `KeyError: (0, 1)` at `orchestrator.py`'s `_stage_replica_to_engine_idx` lookup. This mapping
  contains only initial replicas (tracked in #7296). That file is unchanged from the base; this separate issue
  requires its own fix. Default-stats dynamic serving is **not** validated as working.

SHM is covered by CPU cache tests; the GPU serving runs use LRU. These are correctness checks,
not throughput or general transcription-accuracy benchmarks.
