### PR TITLE
[Bugfix][XPU] Restore N-D output shape for W8A16 FP8 linear

### DIFF
--- a/tests/diffusion/quantization/test_quantization_fp8.py
+++ b/tests/diffusion/quantization/test_quantization_fp8.py
@@ -300,9 +300,20 @@ def test_single_stage_zimage_fp8_uses_less_memory():
     assert mem_fp8 < mem_bf16, f"FP8 ({mem_fp8:.2f} GiB) should use less memory than BF16 ({mem_bf16:.2f} GiB)"
 
 
-@hardware_test(res={"cuda": "L4"})
+@hardware_test(res={"cuda": "L4", "xpu": "B60"})
+@pytest.mark.advanced_model
 def test_single_stage_qwen_image_fp8():
-    """Qwen-Image (random weights) with FP8 generates valid images."""
+    """Qwen-Image (random weights) with FP8 generates valid images.
+
+    On XPU this also guards the W8A16 FP8 kernel handing its rank-3 diffusion
+    activation straight to ``torch.ops._xpu_C.fp8_gemm_w8a16``, whose registered
+    fake returns 2-D: inductor baked in a 2-D ``assert_size_stride`` that the
+    rank-3 result tripped, so ``fp8`` aborted during startup warmup and never
+    produced an image. ``advanced_model`` is what puts this in the XPU CI job,
+    which selects ``core_model``/``advanced_model``/``omni`` but never the
+    module-level ``full_model``; the CUDA jobs only run this directory nightly
+    under ``full_model``, so their selection is unchanged.
+    """
     model = "riverclouds/qwen_image_random"
     if current_omni_platform.is_npu() or current_omni_platform.is_rocm():
         pytest.skip("qwen_image_random not available on this platform")

--- a/tests/diffusion/quantization/test_quantization_fp8.py
+++ b/tests/diffusion/quantization/test_quantization_fp8.py
@@ -303,17 +303,7 @@ def test_single_stage_zimage_fp8_uses_less_memory():
 @hardware_test(res={"cuda": "L4", "xpu": "B60"})
 @pytest.mark.advanced_model
 def test_single_stage_qwen_image_fp8():
-    """Qwen-Image (random weights) with FP8 generates valid images.
-
-    On XPU this also guards the W8A16 FP8 kernel handing its rank-3 diffusion
-    activation straight to ``torch.ops._xpu_C.fp8_gemm_w8a16``, whose registered
-    fake returns 2-D: inductor baked in a 2-D ``assert_size_stride`` that the
-    rank-3 result tripped, so ``fp8`` aborted during startup warmup and never
-    produced an image. ``advanced_model`` is what puts this in the XPU CI job,
-    which selects ``core_model``/``advanced_model``/``omni`` but never the
-    module-level ``full_model``; the CUDA jobs only run this directory nightly
-    under ``full_model``, so their selection is unchanged.
-    """
+    """Qwen-Image (random weights) with FP8 generates valid images."""
     model = "riverclouds/qwen_image_random"
     if current_omni_platform.is_npu() or current_omni_platform.is_rocm():
         pytest.skip("qwen_image_random not available on this platform")

--- a/vllm_omni/platforms/xpu/patch.py
+++ b/vllm_omni/platforms/xpu/patch.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""XPU-specific patches for upstream vLLM behavior."""
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+def _patch_w8a16_fp8_nd_activation() -> None:
+    """Restore the N-D output shape for the XPU W8A16 FP8 linear kernel.
+
+    ``XPUW8A16FP8LinearKernel.apply_weights`` hands its activation straight to
+    ``torch.ops._xpu_C.fp8_gemm_w8a16``, skipping the flatten-then-reshape every
+    other ScaledMM kernel does. The op's registered fake always returns 2-D, so a
+    3-D activation makes inductor bake in a 2-D ``assert_size_stride`` that the
+    rank-3 result trips, killing FLUX.1 ``--quantization fp8`` at startup warmup.
+    Only >2-D inputs are affected, so LLM (token-flattened, 2-D) paths are not.
+    """
+    try:
+        from vllm.model_executor.kernels.linear.scaled_mm.xpu import (
+            XPUW8A16FP8LinearKernel,
+        )
+    except ImportError:
+        logger.debug("XPUW8A16FP8LinearKernel not available; skipping FP8 shape patch.")
+        return
+
+    _original_apply_weights = XPUW8A16FP8LinearKernel.apply_weights
+
+    def _patched_apply_weights(self, layer, x, bias=None):
+        output_shape = (*x.shape[:-1], layer.weight.shape[1])
+        x = x.reshape(-1, x.shape[-1])
+        return _original_apply_weights(self, layer, x, bias).view(*output_shape)
+
+    XPUW8A16FP8LinearKernel.apply_weights = _patched_apply_weights
+
+
+def apply_patches() -> None:
+    """Apply all XPU-specific patches."""
+    _patch_w8a16_fp8_nd_activation()

--- a/vllm_omni/platforms/xpu/platform.py
+++ b/vllm_omni/platforms/xpu/platform.py
@@ -11,6 +11,7 @@ from vllm.platforms.xpu import XPUPlatform
 
 from vllm_omni.diffusion.attention.backends.registry import DiffusionAttentionBackendEnum
 from vllm_omni.platforms.interface import OmniPlatform, OmniPlatformEnum
+from vllm_omni.platforms.xpu.patch import apply_patches
 
 logger = init_logger(__name__)
 
@@ -30,6 +31,10 @@ class XPUOmniPlatform(OmniPlatform, XPUPlatform):
     """
 
     _omni_enum = OmniPlatformEnum.XPU
+
+    def __init__(self):
+        super().__init__()
+        apply_patches()
 
     @classmethod
     def get_omni_ar_worker_cls(cls) -> str:


### PR DESCRIPTION
## Purpose

FLUX.1-dev with `--quantization fp8` crashes at server startup on Intel XPU:

```
AssertionError: wrong number of dimensions 3 for op: torch.ops._xpu_C.fp8_gemm_w8a16.default
RuntimeError: Orchestrator initialization failed: Dummy run failed
```

`XPUW8A16FP8LinearKernel.apply_weights` passes its activation straight to
`torch.ops._xpu_C.fp8_gemm_w8a16`, skipping the flatten-then-reshape every other ScaledMM
kernel does. The op preserves input rank; its registered fake always returns 2-D. They
agree for 2-D LLM activations, so only diffusion breaks: FLUX's 3-D `(batch, seq, hidden)`
makes inductor bake in a 2-D `assert_size_stride` that the rank-3 result trips.

This restores the existing contract — CUTLASS, ROCm, PyTorch, AITER, Marlin and XPU's own
W8A8 kernel (`xpu.py:119`) all reshape to `output_shape`; W8A16 is the only one that
doesn't. Numerics are unchanged (rank-3 GEMM is bit-exact against the flattened one) and
contiguous inputs reshape as a view, so there is no copy.

Sits next to the existing `_patch_flashinfer_fp8_scaled_mm_output_shape`, which fixes the
same bug for FlashInfer. Becomes a no-op once vLLM fixes `scaled_mm/xpu.py` upstream.

The SPDX header comes from the `check-spdx-header` hook, which flagged a pre-existing gap.

## Test Plan

```bash
vllm serve black-forest-labs/FLUX.1-dev --omni --tensor-parallel-size 1 \
  --quantization fp8 --host localhost --port 8000

curl -s http://localhost:8000/v1/images/generations -H 'Content-Type: application/json' \
  -d '{"model": "black-forest-labs/FLUX.1-dev", "prompt": "A red cube on a white background",
       "size": "512x512", "n": 1, "num_inference_steps": 20, "seed": 42,
       "response_format": "b64_json"}'
```

## Test Result

Before: server exits during startup warmup, no image. After: startup completes and the
request returns.

- `Selected XPUW8A16FP8LinearKernel` — FP8 active, no BF16 fallback
- `dummy run to warm up the model` → `Application startup complete.`
- 8.10 s, peak 29526 MB, 512x512

<img width="512" height="512" alt="flux_fp8_serve_512" src="https://github.com/user-attachments/assets/e8821c3e-ae5b-4565-a1bd-3f47ad3026bd" />


