### PR TITLE
[Bugfix][DreamZero] Refuse incoming session state when approaching OOM

### DIFF
--- a/tests/diffusion/models/dreamzero/test_session_state_equivalence.py
+++ b/tests/diffusion/models/dreamzero/test_session_state_equivalence.py
@@ -245,13 +245,15 @@ def test_bespoke_path_without_memory_manager() -> None:
     from collections import OrderedDict
 
     from vllm_omni.diffusion.models.dreamzero.pipeline_dreamzero import (
-        MAX_DREAMZERO_SESSIONS,
+        MAX_RESIDENT_DREAMZERO_SESSION_STATES,
         DreamZeroPipeline,
     )
 
     pipe = DreamZeroPipeline.__new__(DreamZeroPipeline)
     pipe._states = OrderedDict()
-    pipe._max_session_states = MAX_DREAMZERO_SESSIONS
+    # The bespoke store's own bound; MAX_DREAMZERO_SESSIONS counts KV slots and
+    # is far too large to bound 603 MiB-per-session model-owned state.
+    pipe._max_session_states = MAX_RESIDENT_DREAMZERO_SESSION_STATES
 
     state = DreamZeroPipeline._get_or_create_state(pipe, "x")
     assert isinstance(state, DreamZeroState)

--- a/tests/diffusion/models/dreamzero/test_session_state_lifecycle.py
+++ b/tests/diffusion/models/dreamzero/test_session_state_lifecycle.py
@@ -18,7 +18,6 @@ from collections import OrderedDict
 import pytest
 import torch
 
-from vllm_omni.diffusion.models.dreamzero import pipeline_dreamzero as pipeline_module
 from vllm_omni.diffusion.models.dreamzero.pipeline_dreamzero import (
     DREAMZERO_MODEL_OWNED_STATE_BYTES_PER_SESSION,
     MAX_DREAMZERO_SESSIONS,
@@ -26,11 +25,17 @@ from vllm_omni.diffusion.models.dreamzero.pipeline_dreamzero import (
     DreamZeroPipeline,
 )
 from vllm_omni.diffusion.models.dreamzero.state_dreamzero import DreamZeroState
+from vllm_omni.experimental.ar_diffusion.tick_protocol import (
+    AR_DIFFUSION_TICK_KEY,
+    ARDiffusionTickRequest,
+)
 from vllm_omni.experimental.world_models.adapters.state_dreamzero_adapter import (
     DreamZeroStateAdapter,
 )
 from vllm_omni.experimental.world_models.session_state import (
     LatentBuffer,
+    SessionAdmissionError,
+    SessionStateLostError,
     SessionStateManager,
 )
 
@@ -104,6 +109,57 @@ def test_raise_max_sessions_rejects_non_positive(capacity: int) -> None:
     assert manager.max_sessions == 2
 
 
+# -- SessionStateManager admission policy ------------------------------------
+
+
+def test_manager_evicts_when_full_by_default() -> None:
+    """Unchanged for every other model on this store (e.g. cosmos3): only an
+    opt-in makes admission fail instead."""
+    manager = SessionStateManager(max_sessions=2)
+
+    for index in range(3):
+        manager.get_or_create_session(f"s{index}")
+
+    assert len(manager) == 2
+    assert manager.evictions == 1
+    assert "s0" not in manager
+
+
+def test_manager_refuses_new_session_when_not_evicting() -> None:
+    manager = SessionStateManager(max_sessions=2, evict_when_full=False)
+    manager.get_or_create_session("s0")
+    manager.get_or_create_session("s1")
+
+    with pytest.raises(SessionAdmissionError, match="cannot admit session 's2'"):
+        manager.get_or_create_session("s2")
+
+    assert len(manager) == 2
+    assert manager.evictions == 0
+    # Both resident sessions survive the refusal.
+    assert "s0" in manager
+    assert "s1" in manager
+
+
+def test_manager_still_serves_resident_sessions_when_full() -> None:
+    manager = SessionStateManager(max_sessions=2, evict_when_full=False)
+    first = manager.get_or_create_session("s0")
+    manager.get_or_create_session("s1")
+
+    assert manager.get_or_create_session("s0") is first
+
+
+def test_manager_admits_again_after_drop_session() -> None:
+    manager = SessionStateManager(max_sessions=1, evict_when_full=False)
+    manager.get_or_create_session("s0")
+    with pytest.raises(SessionAdmissionError):
+        manager.get_or_create_session("s1")
+
+    assert manager.drop_session("s0") is True
+
+    assert manager.get_or_create_session("s1") is not None
+    assert len(manager) == 1
+
+
 # -- pipeline hook routing ---------------------------------------------------
 
 
@@ -156,15 +212,18 @@ def test_bespoke_hook_pops_states_and_clears_alias() -> None:
     assert pipe.state is None
 
 
-# -- bounded ``_states`` ------------------------------------------------------
+# -- admission, not eviction --------------------------------------------------
 #
 # The hooks above are the *only* removal path for ``_states``, and they are
 # reached solely from the AR-Diffusion runner's release path. A stage that holds
 # session state without hosting the engine -- the disaggregated encode stage,
 # where ``engine_backend: ARDiffusionEngine`` is set on denoise only -- never
-# receives that signal, so every finished session used to stay resident at
-# ~603 MiB each. These cover the backstop bound that makes the pipeline
-# memory-safe on its own.
+# receives that signal, so finished sessions accumulate at ~603 MiB each.
+#
+# The bound therefore refuses *new* sessions rather than evicting resident ones.
+# Per-session state includes the Wan VAE causal-convolution cache, which has no
+# recompute source, so evicting a session that is later continued would silently
+# restart its rollout and return normal-looking but wrong output.
 
 
 def _bespoke_pipe(max_states: int) -> DreamZeroPipeline:
@@ -173,104 +232,72 @@ def _bespoke_pipe(max_states: int) -> DreamZeroPipeline:
     pipe._states = OrderedDict()
     pipe._memory_manager = None
     pipe._max_session_states = max_states
-    pipe._session_state_evict_warned = False
     pipe.state = None
     return pipe
 
 
 def _seeded_state(marker: int) -> DreamZeroState:
-    """A state carrying a device-side tensor and a call history to lose."""
+    """A state carrying a device-side tensor and a call history that must survive."""
     state = DreamZeroState()
     state.vae_encoder_out = torch.zeros(marker + 1, dtype=torch.float32)
     state.call_count = marker + 1
     return state
 
 
-def test_insert_over_bound_evicts_oldest_and_keeps_newest() -> None:
+def test_new_session_at_the_bound_is_refused() -> None:
     pipe = _bespoke_pipe(2)
+    DreamZeroPipeline._get_or_create_state(pipe, "s0")
+    DreamZeroPipeline._get_or_create_state(pipe, "s1")
 
+    with pytest.raises(SessionAdmissionError, match="cannot admit DreamZero session 's2'"):
+        DreamZeroPipeline._get_or_create_state(pipe, "s2")
+
+    assert list(pipe._states) == ["s0", "s1"]
+
+
+def test_refusing_a_new_session_preserves_resident_history() -> None:
+    """The regression this whole change exists for: an arriving session must not
+    cost an existing one its unrecoverable VAE history."""
+    pipe = _bespoke_pipe(1)
+    resident = _seeded_state(3)
+    pipe._states["s0"] = resident
+    pipe.state = resident
+
+    with pytest.raises(SessionAdmissionError):
+        DreamZeroPipeline._get_or_create_state(pipe, "s1")
+
+    assert pipe._states["s0"] is resident
+    assert resident.vae_encoder_out is not None
+    assert resident.call_count == 4
+    assert pipe.state is resident
+
+
+def test_resident_session_is_still_served_at_the_bound() -> None:
+    """The bound gates admission, not lookup: a full table must keep serving the
+    sessions it already admitted, or capacity pressure would stall everyone."""
+    pipe = _bespoke_pipe(2)
     first = DreamZeroPipeline._get_or_create_state(pipe, "s0")
-    second = DreamZeroPipeline._get_or_create_state(pipe, "s1")
-    third = DreamZeroPipeline._get_or_create_state(pipe, "s2")
+    DreamZeroPipeline._get_or_create_state(pipe, "s1")
 
-    assert list(pipe._states) == ["s1", "s2"]
-    assert pipe._states["s1"] is second
-    assert pipe._states["s2"] is third
-    # The evicted session is gone, so it comes back as a distinct object.
-    assert DreamZeroPipeline._get_or_create_state(pipe, "s0") is not first
+    assert DreamZeroPipeline._get_or_create_state(pipe, "s0") is first
+    assert DreamZeroPipeline._require_session_state(pipe, "s0") is first
+    # Reuse still reorders, so ordering stays meaningful for observability.
+    assert list(pipe._states) == ["s1", "s0"]
 
 
-def test_reuse_reorders_so_the_active_session_is_never_the_victim() -> None:
-    """``move_to_end`` on a hit is what makes the bound an LRU and not a FIFO."""
-    pipe = _bespoke_pipe(2)
+def test_admission_recovers_after_a_session_is_released() -> None:
+    pipe = _bespoke_pipe(1)
     DreamZeroPipeline._get_or_create_state(pipe, "s0")
-    DreamZeroPipeline._get_or_create_state(pipe, "s1")
+    with pytest.raises(SessionAdmissionError):
+        DreamZeroPipeline._get_or_create_state(pipe, "s1")
 
-    # Touch the oldest so the *other* entry becomes the eviction candidate.
-    DreamZeroPipeline._get_or_create_state(pipe, "s0")
-    DreamZeroPipeline._get_or_create_state(pipe, "s2")
+    DreamZeroPipeline.close_ar_diffusion_session(pipe, "s0")
 
-    assert list(pipe._states) == ["s0", "s2"]
-
-
-def test_eviction_releases_the_evicted_state_buffers() -> None:
-    """Popping the entry is not enough: GC is too late to free device memory."""
-    pipe = _bespoke_pipe(1)
-    doomed = _seeded_state(0)
-    pipe._states["s0"] = doomed
-
-    DreamZeroPipeline._get_or_create_state(pipe, "s1")
-
-    assert "s0" not in pipe._states
-    # We still hold a reference, so this proves ``reset()`` ran rather than the
-    # object merely becoming unreachable.
-    assert doomed.vae_encoder_out is None
-    assert doomed.call_count == 0
+    assert DreamZeroPipeline._get_or_create_state(pipe, "s1") is not None
+    assert list(pipe._states) == ["s1"]
 
 
-def test_eviction_clears_the_alias_when_it_viewed_the_evicted_state() -> None:
-    pipe = _bespoke_pipe(1)
-    doomed = _seeded_state(0)
-    pipe._states["s0"] = doomed
-    pipe.state = doomed
-
-    DreamZeroPipeline._get_or_create_state(pipe, "s1")
-
-    assert pipe.state is None
-
-
-def test_eviction_keeps_an_alias_pointing_at_a_survivor() -> None:
-    pipe = _bespoke_pipe(2)
-    pipe._states["s0"] = _seeded_state(0)
-    survivor = DreamZeroPipeline._get_or_create_state(pipe, "s1")
-    pipe.state = survivor
-
-    DreamZeroPipeline._get_or_create_state(pipe, "s2")
-
-    assert "s0" not in pipe._states
-    assert pipe.state is survivor
-
-
-def test_eviction_warns_once_naming_the_missing_close(monkeypatch) -> None:
-    """Hitting the bound means a close was lost; say so, but only once."""
-    messages: list[str] = []
-
-    def _capture(msg, *args, **kwargs):
-        messages.append(msg % args if args else msg)
-
-    monkeypatch.setattr(pipeline_module.logger, "warning", _capture)
-
-    pipe = _bespoke_pipe(1)
-    for index in range(4):
-        DreamZeroPipeline._get_or_create_state(pipe, f"s{index}")
-
-    evict_warnings = [m for m in messages if "close_ar_diffusion_session()" in m]
-    assert len(evict_warnings) == 1
-    assert pipe._session_state_evict_warned is True
-    assert len(pipe._states) == 1
-
-
-def test_non_positive_bound_means_unbounded_not_evict_everything() -> None:
+def test_non_positive_bound_means_unbounded() -> None:
     pipe = _bespoke_pipe(0)
 
     for index in range(3):
@@ -279,12 +306,141 @@ def test_non_positive_bound_means_unbounded_not_evict_everything() -> None:
     assert len(pipe._states) == 3
 
 
+# -- continuation must find its history ---------------------------------------
+
+
+def test_continuation_of_an_unknown_session_fails_loudly() -> None:
+    """A continuation must never be served fresh state: ``reset_reason()`` reports
+    ``"session"`` for empty state, so the pipeline would quietly restart the
+    rollout while the denoise stage's KV for that session is still live."""
+    pipe = _bespoke_pipe(4)
+
+    with pytest.raises(SessionStateLostError, match="has no resident state"):
+        DreamZeroPipeline._require_session_state(pipe, "never-began")
+
+    # The failed lookup must not have created anything.
+    assert not pipe._states
+
+
+def test_continuation_error_says_how_to_recover() -> None:
+    pipe = _bespoke_pipe(4)
+
+    with pytest.raises(SessionStateLostError, match=r'extra_args\["reset"\]=True'):
+        DreamZeroPipeline._require_session_state(pipe, "gone")
+
+
+def test_continuation_returns_the_same_state_object() -> None:
+    pipe = _bespoke_pipe(4)
+    begun = DreamZeroPipeline._get_or_create_state(pipe, "s0")
+
+    assert DreamZeroPipeline._require_session_state(pipe, "s0") is begun
+
+
+def test_continuation_of_default_session_works() -> None:
+    """``__init__`` seeds ``"default"``, so a request that sends no session_id and
+    no reset still resolves."""
+    pipe = _bespoke_pipe(4)
+    default = DreamZeroPipeline._get_or_create_state(pipe, "default")
+
+    assert DreamZeroPipeline._require_session_state(pipe, None) is default
+
+
+def test_manager_path_continuation_does_not_create_via_the_adapter() -> None:
+    """The adapter's constructor calls ``get_or_create_session()``, so membership
+    has to be checked before it is built or the absent session is created by the
+    very lookup meant to report it missing."""
+    manager = SessionStateManager(max_sessions=4, evict_when_full=False)
+    pipe = _bespoke_pipe(4)
+    pipe._memory_manager = manager
+    pipe.num_frame_per_block = 2
+
+    with pytest.raises(SessionStateLostError):
+        DreamZeroPipeline._require_session_state(pipe, "never-began")
+
+    assert "never-began" not in manager
+    assert len(manager) == 0
+
+
+def test_manager_path_continuation_binds_an_existing_session() -> None:
+    manager = SessionStateManager(max_sessions=4, evict_when_full=False)
+    manager.get_or_create_session("s0")
+    pipe = _bespoke_pipe(4)
+    pipe._memory_manager = manager
+    pipe.num_frame_per_block = 2
+
+    adapter = DreamZeroPipeline._require_session_state(pipe, "s0")
+
+    assert isinstance(adapter, DreamZeroStateAdapter)
+    assert adapter.session_id == "s0"
+
+
+# -- begin-vs-continue is read the way the runner reads it --------------------
+
+
+def test_flat_reset_marks_a_begin() -> None:
+    assert DreamZeroPipeline._request_begins_session({"reset": True}) is True
+    assert DreamZeroPipeline._request_begins_session({"reset": False}) is False
+    assert DreamZeroPipeline._request_begins_session({}) is False
+
+
+def test_tick_reset_marks_a_begin_without_a_flat_key() -> None:
+    """A typed tick namespaces its fields and does not duplicate them at the top
+    level, and its extra_args are merged onto a *static* per-deployment template,
+    so the flat key cannot express per-request begin/continue on that path. The
+    runner releases the old session on the tick's value, so reading anything else
+    here would demand state the runner just dropped."""
+    tick = ARDiffusionTickRequest(session_id="s0", request_id="r0", chunk_index=0, reset=True)
+
+    assert DreamZeroPipeline._request_begins_session(tick.to_extra_args()) is True
+
+
+def test_tick_continuation_is_not_a_begin() -> None:
+    tick = ARDiffusionTickRequest(session_id="s0", request_id="r1", chunk_index=1, reset=False)
+
+    assert DreamZeroPipeline._request_begins_session(tick.to_extra_args()) is False
+
+
+def test_flat_reset_still_counts_alongside_a_tick() -> None:
+    """The consumer merges the tick over a template that may carry flat keys;
+    either source asserting a begin is enough, so a begin is never misread as a
+    continuation."""
+    tick = ARDiffusionTickRequest(session_id="s0", request_id="r0", chunk_index=0, reset=False)
+    merged = {"reset": True, **tick.to_extra_args()}
+
+    assert DreamZeroPipeline._request_begins_session(merged) is True
+
+
+def test_malformed_tick_falls_back_to_the_flat_key() -> None:
+    """The forward must not gain a new parse failure: a non-mapping tick is
+    ignored here and left for the runner's own validation to reject."""
+    assert DreamZeroPipeline._request_begins_session({AR_DIFFUSION_TICK_KEY: "nonsense"}) is False
+    assert DreamZeroPipeline._request_begins_session({AR_DIFFUSION_TICK_KEY: "nonsense", "reset": True}) is True
+
+
+# -- export consumes history, never creates it --------------------------------
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["decode_accumulated_video_latents", "clear_accumulated_video_latents"],
+)
+def test_export_helpers_refuse_an_unknown_session(method: str) -> None:
+    """These run from the video export worker at the end of a rollout; creating a
+    session there would mask a lost session rather than report it."""
+    pipe = _bespoke_pipe(4)
+
+    with pytest.raises(SessionStateLostError):
+        getattr(DreamZeroPipeline, method)(pipe, "never-began")
+
+    assert not pipe._states
+
+
 # -- capacity published by the runner ----------------------------------------
 
 
-def test_published_capacity_raises_the_floor_and_suppresses_eviction() -> None:
-    """A runner already reserves 603 MiB/session and evicts at its own bound,
-    signalling us each time, so we must not drop state it still holds live."""
+def test_published_capacity_raises_the_floor_and_admits_more() -> None:
+    """A runner already reserves 603 MiB/session and will keep that many live, so
+    refusing a session it has room for would be our bound, not its budget."""
     pipe = _bespoke_pipe(2)
 
     DreamZeroPipeline.set_resident_session_state_capacity(pipe, 5)
@@ -297,10 +453,9 @@ def test_published_capacity_raises_the_floor_and_suppresses_eviction() -> None:
 
 def test_published_capacity_reaches_the_manager_too() -> None:
     """Regression: the manager is built in ``__init__`` with the configured cap,
-    so raising only ``_max_session_states`` would leave it evicting at the lower
-    bound -- and its overflow drops the entry without resetting buffers, so the
-    next request would silently get a fresh session and lose its history."""
-    manager = SessionStateManager(max_sessions=2)
+    so raising only ``_max_session_states`` would leave the manager refusing at the
+    lower bound while the bespoke path admitted."""
+    manager = SessionStateManager(max_sessions=2, evict_when_full=False)
     pipe = _bespoke_pipe(2)
     pipe._memory_manager = manager
 
@@ -317,7 +472,7 @@ def test_published_capacity_reaches_the_manager_too() -> None:
 
 def test_published_capacity_never_lowers_the_bound() -> None:
     pipe = _bespoke_pipe(4)
-    manager = SessionStateManager(max_sessions=4)
+    manager = SessionStateManager(max_sessions=4, evict_when_full=False)
     pipe._memory_manager = manager
 
     DreamZeroPipeline.set_resident_session_state_capacity(pipe, 1)
@@ -351,18 +506,26 @@ def test_resident_state_bound_is_not_the_kv_slot_count() -> None:
     assert resident_bytes < 8 * 1024**3
 
 
-def test_manager_honours_the_same_small_bound() -> None:
-    """The two stores must be sized together.
+def test_manager_honours_the_same_small_bound_and_policy() -> None:
+    """The two stores must be sized *and policed* together.
 
     ``_drop_ar_diffusion_session_state()`` returns early on the manager path
-    without touching ``_states``, so a bound enforced on only one of them is
-    dead code for whichever path a deployment actually takes.
+    without touching ``_states``, so a bound enforced on only one of them is dead
+    code for whichever path a deployment actually takes -- and a bound that
+    refuses on one path while evicting on the other still loses history.
     """
-    manager = SessionStateManager(max_sessions=MAX_RESIDENT_DREAMZERO_SESSION_STATES)
+    manager = SessionStateManager(
+        max_sessions=MAX_RESIDENT_DREAMZERO_SESSION_STATES,
+        evict_when_full=False,
+    )
 
-    for index in range(MAX_RESIDENT_DREAMZERO_SESSION_STATES + 2):
+    for index in range(MAX_RESIDENT_DREAMZERO_SESSION_STATES):
         manager.get_or_create_session(f"s{index}")
 
+    with pytest.raises(SessionAdmissionError):
+        manager.get_or_create_session("one-too-many")
+
     assert len(manager) == MAX_RESIDENT_DREAMZERO_SESSION_STATES
-    assert manager.evictions == 2
-    assert "s0" not in manager
+    assert manager.evictions == 0
+    # Every admitted session is still there; none paid for the refused one.
+    assert all(f"s{index}" in manager for index in range(MAX_RESIDENT_DREAMZERO_SESSION_STATES))

--- a/tests/diffusion/models/dreamzero/test_session_state_lifecycle.py
+++ b/tests/diffusion/models/dreamzero/test_session_state_lifecycle.py
@@ -18,7 +18,13 @@ from collections import OrderedDict
 import pytest
 import torch
 
-from vllm_omni.diffusion.models.dreamzero.pipeline_dreamzero import DreamZeroPipeline
+from vllm_omni.diffusion.models.dreamzero import pipeline_dreamzero as pipeline_module
+from vllm_omni.diffusion.models.dreamzero.pipeline_dreamzero import (
+    DREAMZERO_MODEL_OWNED_STATE_BYTES_PER_SESSION,
+    MAX_DREAMZERO_SESSIONS,
+    MAX_RESIDENT_DREAMZERO_SESSION_STATES,
+    DreamZeroPipeline,
+)
 from vllm_omni.diffusion.models.dreamzero.state_dreamzero import DreamZeroState
 from vllm_omni.experimental.world_models.adapters.state_dreamzero_adapter import (
     DreamZeroStateAdapter,
@@ -61,6 +67,41 @@ def test_drop_session_recreates_fresh() -> None:
     manager.get_or_create_session("s").attrs["k"] = 1
     manager.drop_session("s")
     assert manager.get_or_create_session("s").attrs == {}
+
+
+# -- SessionStateManager.raise_max_sessions ----------------------------------
+
+
+def test_raise_max_sessions_lifts_the_bound_and_stops_evicting() -> None:
+    manager = SessionStateManager(max_sessions=2)
+
+    assert manager.raise_max_sessions(4) is True
+    assert manager.max_sessions == 4
+
+    for index in range(4):
+        manager.get_or_create_session(f"s{index}")
+    assert len(manager) == 4
+    assert manager.evictions == 0
+
+
+def test_raise_max_sessions_refuses_to_lower() -> None:
+    """Shrinking a live bound would silently strand accumulated history: the
+    overflow path drops the table entry without resetting buffers."""
+    manager = SessionStateManager(max_sessions=4)
+
+    assert manager.raise_max_sessions(2) is False
+    assert manager.raise_max_sessions(4) is False
+    assert manager.max_sessions == 4
+
+
+@pytest.mark.parametrize("capacity", [0, -1])
+def test_raise_max_sessions_rejects_non_positive(capacity: int) -> None:
+    manager = SessionStateManager(max_sessions=2)
+
+    with pytest.raises(ValueError, match="max_sessions must be positive"):
+        manager.raise_max_sessions(capacity)
+
+    assert manager.max_sessions == 2
 
 
 # -- pipeline hook routing ---------------------------------------------------
@@ -113,3 +154,215 @@ def test_bespoke_hook_pops_states_and_clears_alias() -> None:
 
     assert "sess" not in pipe._states
     assert pipe.state is None
+
+
+# -- bounded ``_states`` ------------------------------------------------------
+#
+# The hooks above are the *only* removal path for ``_states``, and they are
+# reached solely from the AR-Diffusion runner's release path. A stage that holds
+# session state without hosting the engine -- the disaggregated encode stage,
+# where ``engine_backend: ARDiffusionEngine`` is set on denoise only -- never
+# receives that signal, so every finished session used to stay resident at
+# ~603 MiB each. These cover the backstop bound that makes the pipeline
+# memory-safe on its own.
+
+
+def _bespoke_pipe(max_states: int) -> DreamZeroPipeline:
+    """A pipeline via __new__ on the bespoke path with a known state bound."""
+    pipe = DreamZeroPipeline.__new__(DreamZeroPipeline)
+    pipe._states = OrderedDict()
+    pipe._memory_manager = None
+    pipe._max_session_states = max_states
+    pipe._session_state_evict_warned = False
+    pipe.state = None
+    return pipe
+
+
+def _seeded_state(marker: int) -> DreamZeroState:
+    """A state carrying a device-side tensor and a call history to lose."""
+    state = DreamZeroState()
+    state.vae_encoder_out = torch.zeros(marker + 1, dtype=torch.float32)
+    state.call_count = marker + 1
+    return state
+
+
+def test_insert_over_bound_evicts_oldest_and_keeps_newest() -> None:
+    pipe = _bespoke_pipe(2)
+
+    first = DreamZeroPipeline._get_or_create_state(pipe, "s0")
+    second = DreamZeroPipeline._get_or_create_state(pipe, "s1")
+    third = DreamZeroPipeline._get_or_create_state(pipe, "s2")
+
+    assert list(pipe._states) == ["s1", "s2"]
+    assert pipe._states["s1"] is second
+    assert pipe._states["s2"] is third
+    # The evicted session is gone, so it comes back as a distinct object.
+    assert DreamZeroPipeline._get_or_create_state(pipe, "s0") is not first
+
+
+def test_reuse_reorders_so_the_active_session_is_never_the_victim() -> None:
+    """``move_to_end`` on a hit is what makes the bound an LRU and not a FIFO."""
+    pipe = _bespoke_pipe(2)
+    DreamZeroPipeline._get_or_create_state(pipe, "s0")
+    DreamZeroPipeline._get_or_create_state(pipe, "s1")
+
+    # Touch the oldest so the *other* entry becomes the eviction candidate.
+    DreamZeroPipeline._get_or_create_state(pipe, "s0")
+    DreamZeroPipeline._get_or_create_state(pipe, "s2")
+
+    assert list(pipe._states) == ["s0", "s2"]
+
+
+def test_eviction_releases_the_evicted_state_buffers() -> None:
+    """Popping the entry is not enough: GC is too late to free device memory."""
+    pipe = _bespoke_pipe(1)
+    doomed = _seeded_state(0)
+    pipe._states["s0"] = doomed
+
+    DreamZeroPipeline._get_or_create_state(pipe, "s1")
+
+    assert "s0" not in pipe._states
+    # We still hold a reference, so this proves ``reset()`` ran rather than the
+    # object merely becoming unreachable.
+    assert doomed.vae_encoder_out is None
+    assert doomed.call_count == 0
+
+
+def test_eviction_clears_the_alias_when_it_viewed_the_evicted_state() -> None:
+    pipe = _bespoke_pipe(1)
+    doomed = _seeded_state(0)
+    pipe._states["s0"] = doomed
+    pipe.state = doomed
+
+    DreamZeroPipeline._get_or_create_state(pipe, "s1")
+
+    assert pipe.state is None
+
+
+def test_eviction_keeps_an_alias_pointing_at_a_survivor() -> None:
+    pipe = _bespoke_pipe(2)
+    pipe._states["s0"] = _seeded_state(0)
+    survivor = DreamZeroPipeline._get_or_create_state(pipe, "s1")
+    pipe.state = survivor
+
+    DreamZeroPipeline._get_or_create_state(pipe, "s2")
+
+    assert "s0" not in pipe._states
+    assert pipe.state is survivor
+
+
+def test_eviction_warns_once_naming_the_missing_close(monkeypatch) -> None:
+    """Hitting the bound means a close was lost; say so, but only once."""
+    messages: list[str] = []
+
+    def _capture(msg, *args, **kwargs):
+        messages.append(msg % args if args else msg)
+
+    monkeypatch.setattr(pipeline_module.logger, "warning", _capture)
+
+    pipe = _bespoke_pipe(1)
+    for index in range(4):
+        DreamZeroPipeline._get_or_create_state(pipe, f"s{index}")
+
+    evict_warnings = [m for m in messages if "close_ar_diffusion_session()" in m]
+    assert len(evict_warnings) == 1
+    assert pipe._session_state_evict_warned is True
+    assert len(pipe._states) == 1
+
+
+def test_non_positive_bound_means_unbounded_not_evict_everything() -> None:
+    pipe = _bespoke_pipe(0)
+
+    for index in range(3):
+        DreamZeroPipeline._get_or_create_state(pipe, f"s{index}")
+
+    assert len(pipe._states) == 3
+
+
+# -- capacity published by the runner ----------------------------------------
+
+
+def test_published_capacity_raises_the_floor_and_suppresses_eviction() -> None:
+    """A runner already reserves 603 MiB/session and evicts at its own bound,
+    signalling us each time, so we must not drop state it still holds live."""
+    pipe = _bespoke_pipe(2)
+
+    DreamZeroPipeline.set_resident_session_state_capacity(pipe, 5)
+
+    assert pipe._max_session_states == 5
+    for index in range(5):
+        DreamZeroPipeline._get_or_create_state(pipe, f"s{index}")
+    assert len(pipe._states) == 5
+
+
+def test_published_capacity_reaches_the_manager_too() -> None:
+    """Regression: the manager is built in ``__init__`` with the configured cap,
+    so raising only ``_max_session_states`` would leave it evicting at the lower
+    bound -- and its overflow drops the entry without resetting buffers, so the
+    next request would silently get a fresh session and lose its history."""
+    manager = SessionStateManager(max_sessions=2)
+    pipe = _bespoke_pipe(2)
+    pipe._memory_manager = manager
+
+    DreamZeroPipeline.set_resident_session_state_capacity(pipe, 5)
+
+    assert pipe._max_session_states == 5
+    assert manager.max_sessions == 5
+
+    for index in range(5):
+        manager.get_or_create_session(f"s{index}")
+    assert len(manager) == 5
+    assert manager.evictions == 0
+
+
+def test_published_capacity_never_lowers_the_bound() -> None:
+    pipe = _bespoke_pipe(4)
+    manager = SessionStateManager(max_sessions=4)
+    pipe._memory_manager = manager
+
+    DreamZeroPipeline.set_resident_session_state_capacity(pipe, 1)
+
+    assert pipe._max_session_states == 4
+    assert manager.max_sessions == 4
+
+
+@pytest.mark.parametrize("capacity", [0, -1])
+def test_published_capacity_ignores_non_positive(capacity: int) -> None:
+    pipe = _bespoke_pipe(4)
+
+    DreamZeroPipeline.set_resident_session_state_capacity(pipe, capacity)
+
+    assert pipe._max_session_states == 4
+
+
+# -- the bound has to be able to fire ----------------------------------------
+
+
+def test_resident_state_bound_is_not_the_kv_slot_count() -> None:
+    """Regression guard for the trap this fix exists to close.
+
+    ``MAX_DREAMZERO_SESSIONS`` counts KV slots. Reusing it for model-owned state
+    puts the bound at 64 x 603 MiB = 38.6 GiB -- larger than any single device --
+    so it can never fire before the card OOMs, and a run under it looks exactly
+    like a run with no bound at all.
+    """
+    assert MAX_RESIDENT_DREAMZERO_SESSION_STATES < MAX_DREAMZERO_SESSIONS
+    resident_bytes = MAX_RESIDENT_DREAMZERO_SESSION_STATES * DREAMZERO_MODEL_OWNED_STATE_BYTES_PER_SESSION
+    assert resident_bytes < 8 * 1024**3
+
+
+def test_manager_honours_the_same_small_bound() -> None:
+    """The two stores must be sized together.
+
+    ``_drop_ar_diffusion_session_state()`` returns early on the manager path
+    without touching ``_states``, so a bound enforced on only one of them is
+    dead code for whichever path a deployment actually takes.
+    """
+    manager = SessionStateManager(max_sessions=MAX_RESIDENT_DREAMZERO_SESSION_STATES)
+
+    for index in range(MAX_RESIDENT_DREAMZERO_SESSION_STATES + 2):
+        manager.get_or_create_session(f"s{index}")
+
+    assert len(manager) == MAX_RESIDENT_DREAMZERO_SESSION_STATES
+    assert manager.evictions == 2
+    assert "s0" not in manager

--- a/tests/diffusion/models/dreamzero/test_session_state_lifecycle.py
+++ b/tests/diffusion/models/dreamzero/test_session_state_lifecycle.py
@@ -236,12 +236,59 @@ def _bespoke_pipe(max_states: int) -> DreamZeroPipeline:
     return pipe
 
 
+def _manager_backed_pipe(max_sessions: int) -> tuple[DreamZeroPipeline, SessionStateManager]:
+    """A pipeline on the opt-in manager path, policed the way ``__init__`` does it."""
+    manager = SessionStateManager(max_sessions=max_sessions, evict_when_full=False)
+    pipe = DreamZeroPipeline.__new__(DreamZeroPipeline)
+    pipe._states = OrderedDict()
+    pipe._memory_manager = manager
+    pipe._max_session_states = max_sessions
+    pipe.num_frame_per_block = 2
+    pipe.state = None
+    return pipe, manager
+
+
 def _seeded_state(marker: int) -> DreamZeroState:
-    """A state carrying a device-side tensor and a call history that must survive."""
+    """A state carrying a call history that must survive."""
     state = DreamZeroState()
     state.vae_encoder_out = torch.zeros(marker + 1, dtype=torch.float32)
     state.call_count = marker + 1
     return state
+
+
+def _mid_rollout_state() -> DreamZeroState:
+    """A state mid-rollout: VAE stream live, causal cache non-empty, prompt cached.
+
+    ``vae_enc_feat_map`` is the field with no recompute source and the bulk of the
+    ~603 MiB, so it is the one that actually has to survive capacity pressure --
+    asserting on ``len(_states)`` or object identity alone would not catch its
+    loss.
+    """
+    state = DreamZeroState()
+    state.vae_stream_initialized = True
+    state.vae_enc_feat_map = [torch.ones(2, 3, dtype=torch.float32)]
+    state.vae_encoder_out = torch.ones(1, 1, 4, dtype=torch.float32)
+    state.vae_pending_body_frames = torch.ones(3, dtype=torch.float32)
+    state.prompt_embeds = torch.ones(2, dtype=torch.float32)
+    state.language = torch.ones(2, dtype=torch.long)
+    state.call_count = 7
+    state.current_start_frame = 12
+    return state
+
+
+def _assert_mid_rollout_intact(state: DreamZeroState) -> None:
+    """Every field ``reset()`` would have cleared is still exactly as seeded."""
+    assert state.vae_stream_initialized is True
+    assert state.vae_enc_feat_map is not None
+    assert len(state.vae_enc_feat_map) == 1
+    assert torch.equal(state.vae_enc_feat_map[0], torch.ones(2, 3, dtype=torch.float32))
+    assert state.vae_encoder_out is not None
+    assert torch.equal(state.vae_encoder_out, torch.ones(1, 1, 4, dtype=torch.float32))
+    assert state.vae_pending_body_frames is not None
+    assert state.prompt_embeds is not None
+    assert state.language is not None
+    assert state.call_count == 7
+    assert state.current_start_frame == 12
 
 
 def test_new_session_at_the_bound_is_refused() -> None:
@@ -306,6 +353,103 @@ def test_non_positive_bound_means_unbounded() -> None:
     assert len(pipe._states) == 3
 
 
+def test_refusal_leaves_a_mid_rollout_session_completely_untouched() -> None:
+    """The unrecoverable fields, not just the dict entry.
+
+    ``vae_enc_feat_map`` has no recompute source, so this is the assertion that
+    actually distinguishes "refused the newcomer" from "quietly reset a live
+    session".
+    """
+    pipe = _bespoke_pipe(1)
+    live = _mid_rollout_state()
+    pipe._states["s0"] = live
+    pipe.state = live
+
+    with pytest.raises(SessionAdmissionError):
+        DreamZeroPipeline._get_or_create_state(pipe, "s1")
+
+    _assert_mid_rollout_intact(pipe._states["s0"])
+    # ...and it is still continuable, which is the point.
+    assert DreamZeroPipeline._require_session_state(pipe, "s0") is live
+
+
+def test_slots_are_reclaimed_across_many_begin_close_cycles() -> None:
+    """CPU stand-in for the long serial soak: admission must not leak slots.
+
+    Holds the table at its bound and then cycles one session out and one in, many
+    times over. A slot that is not truly reclaimed on close shows up as a refusal
+    part-way through instead of at the end.
+    """
+    pipe = _bespoke_pipe(4)
+    for index in range(4):
+        DreamZeroPipeline._get_or_create_state(pipe, f"resident{index}")
+
+    for cycle in range(100):
+        DreamZeroPipeline.close_ar_diffusion_session(pipe, f"resident{cycle % 4}")
+        DreamZeroPipeline._get_or_create_state(pipe, f"resident{cycle % 4}")
+        assert len(pipe._states) == 4
+
+    for index in range(4):
+        DreamZeroPipeline.close_ar_diffusion_session(pipe, f"resident{index}")
+    assert not pipe._states
+
+
+# -- the same rules on the manager path --------------------------------------
+#
+# The two stores refuse through different mechanisms: the bespoke path via
+# ``_admit_session_state()``, the manager path from inside the adapter's
+# constructor, which calls ``get_or_create_session()``. Both are reachable from
+# ``_get_or_create_state()``, so both need covering or a deployment's actual path
+# may be the untested one.
+
+
+def test_manager_path_refuses_a_new_session_at_the_bound() -> None:
+    pipe, manager = _manager_backed_pipe(2)
+    DreamZeroPipeline._get_or_create_state(pipe, "s0")
+    DreamZeroPipeline._get_or_create_state(pipe, "s1")
+
+    with pytest.raises(SessionAdmissionError):
+        DreamZeroPipeline._get_or_create_state(pipe, "s2")
+
+    assert len(manager) == 2
+    assert manager.evictions == 0
+    assert "s2" not in manager
+
+
+def test_manager_path_refusal_preserves_resident_sessions() -> None:
+    pipe, manager = _manager_backed_pipe(1)
+    resident = DreamZeroPipeline._get_or_create_state(pipe, "s0")
+    resident.call_count = 5
+
+    with pytest.raises(SessionAdmissionError):
+        DreamZeroPipeline._get_or_create_state(pipe, "s1")
+
+    assert "s0" in manager
+    # A fresh adapter is built per call, so read the session back through one.
+    assert DreamZeroPipeline._require_session_state(pipe, "s0").call_count == 5
+
+
+def test_manager_path_still_serves_a_resident_session_when_full() -> None:
+    pipe, manager = _manager_backed_pipe(2)
+    DreamZeroPipeline._get_or_create_state(pipe, "s0")
+    DreamZeroPipeline._get_or_create_state(pipe, "s1")
+
+    assert DreamZeroPipeline._get_or_create_state(pipe, "s0") is not None
+    assert len(manager) == 2
+
+
+def test_manager_path_admits_again_after_close() -> None:
+    pipe, manager = _manager_backed_pipe(1)
+    DreamZeroPipeline._get_or_create_state(pipe, "s0")
+    with pytest.raises(SessionAdmissionError):
+        DreamZeroPipeline._get_or_create_state(pipe, "s1")
+
+    DreamZeroPipeline.close_ar_diffusion_session(pipe, "s0")
+
+    assert DreamZeroPipeline._get_or_create_state(pipe, "s1") is not None
+    assert len(manager) == 1
+
+
 # -- continuation must find its history ---------------------------------------
 
 
@@ -359,6 +503,57 @@ def test_manager_path_continuation_does_not_create_via_the_adapter() -> None:
 
     assert "never-began" not in manager
     assert len(manager) == 0
+
+
+@pytest.mark.parametrize("hook", ["close_ar_diffusion_session", "reset_ar_diffusion_session"])
+def test_continuation_after_release_fails_instead_of_restarting(hook: str) -> None:
+    """The sequence the whole change exists to forbid.
+
+    A released session must not be silently re-served on empty state: that is the
+    path that returns normal-looking but wrong output, since ``reset_reason()``
+    reports ``"session"`` for a fresh state and the rollout quietly restarts.
+    """
+    pipe = _bespoke_pipe(4)
+    live = _mid_rollout_state()
+    pipe._states["s0"] = live
+    pipe.state = live
+
+    getattr(DreamZeroPipeline, hook)(pipe, "s0")
+
+    with pytest.raises(SessionStateLostError):
+        DreamZeroPipeline._require_session_state(pipe, "s0")
+    assert not pipe._states
+    # A fresh begin is the documented way back, and it starts genuinely clean.
+    reborn = DreamZeroPipeline._get_or_create_state(pipe, "s0")
+    assert reborn is not live
+    assert reborn.call_count == 0
+    assert reborn.vae_enc_feat_map is None
+
+
+def test_manager_path_continuation_after_release_fails() -> None:
+    pipe, manager = _manager_backed_pipe(4)
+    DreamZeroPipeline._get_or_create_state(pipe, "s0")
+
+    DreamZeroPipeline.close_ar_diffusion_session(pipe, "s0")
+
+    assert "s0" not in manager
+    with pytest.raises(SessionStateLostError):
+        DreamZeroPipeline._require_session_state(pipe, "s0")
+
+
+@pytest.mark.parametrize("hook", ["close_ar_diffusion_session", "reset_ar_diffusion_session"])
+def test_release_is_idempotent_and_unknown_release_is_a_no_op(hook: str) -> None:
+    """Repeat and stray releases must not double-release or resurrect a session."""
+    pipe = _bespoke_pipe(4)
+    pipe._states["s0"] = _mid_rollout_state()
+    survivor = DreamZeroPipeline._get_or_create_state(pipe, "s1")
+
+    getattr(DreamZeroPipeline, hook)(pipe, "s0")
+    getattr(DreamZeroPipeline, hook)(pipe, "s0")
+    getattr(DreamZeroPipeline, hook)(pipe, "never-existed")
+
+    assert list(pipe._states) == ["s1"]
+    assert pipe._states["s1"] is survivor
 
 
 def test_manager_path_continuation_binds_an_existing_session() -> None:
@@ -433,6 +628,38 @@ def test_export_helpers_refuse_an_unknown_session(method: str) -> None:
         getattr(DreamZeroPipeline, method)(pipe, "never-began")
 
     assert not pipe._states
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["decode_accumulated_video_latents", "clear_accumulated_video_latents"],
+)
+def test_export_must_run_before_the_session_is_released(method: str) -> None:
+    """Pins the ordering this creates: export consumes the accumulated history, so
+    it has to happen while the session is still resident. No in-tree caller closes
+    a DreamZero session before exporting, but a future one that did would now get a
+    clear error rather than an empty decode."""
+    pipe = _bespoke_pipe(4)
+    DreamZeroPipeline._get_or_create_state(pipe, "s0")
+    DreamZeroPipeline.close_ar_diffusion_session(pipe, "s0")
+
+    with pytest.raises(SessionStateLostError):
+        getattr(DreamZeroPipeline, method)(pipe, "s0")
+
+
+def test_clear_accumulated_latents_keeps_the_session_continuable() -> None:
+    """Clearing exported latents is not an end-of-session signal: the VAE stream
+    and frame history a continuation needs must survive it."""
+    pipe = _bespoke_pipe(4)
+    live = _mid_rollout_state()
+    live.video_latents_across_time = [torch.ones(1, 1, 2, 2, 2, dtype=torch.float32)]
+    pipe._states["s0"] = live
+
+    DreamZeroPipeline.clear_accumulated_video_latents(pipe, "s0")
+
+    assert live.video_latents_across_time == []
+    _assert_mid_rollout_intact(live)
+    assert DreamZeroPipeline._require_session_state(pipe, "s0") is live
 
 
 # -- capacity published by the runner ----------------------------------------

--- a/vllm_omni/diffusion/models/dreamzero/pipeline_dreamzero.py
+++ b/vllm_omni/diffusion/models/dreamzero/pipeline_dreamzero.py
@@ -74,6 +74,22 @@ MAX_DREAMZERO_SESSIONS = 64
 # entries. This is the measured persistent CUDA upper bound per live session.
 DREAMZERO_MODEL_OWNED_STATE_BYTES_PER_SESSION = 603 * 1024 * 1024
 
+# How many per-session states the pipeline keeps resident. Deliberately far
+# below ``MAX_DREAMZERO_SESSIONS``: that is a count of *KV* slots, which the KV
+# manager then shrinks to fit its own budget, whereas this bounds *model-owned*
+# state at DREAMZERO_MODEL_OWNED_STATE_BYTES_PER_SESSION each. At 603 MiB per
+# session, 64 resident states would be 38.6 GiB -- more than a whole device --
+# so reusing the KV count here would be a bound that can never fire before OOM.
+#
+# This is a backstop, not the primary lifecycle. Sessions are normally released
+# by the AR-Diffusion runner's explicit close/reset; a deployment that holds
+# session state on a stage with no runner (the disaggregated encode stage, where
+# ``engine_backend: ARDiffusionEngine`` is set on denoise only) never receives
+# that signal, and without a bound every finished session stays resident. Raise
+# it with OMNI_DIFFUSION_SESSION_STATE_MANAGER_MAX_SESSIONS if a deployment
+# genuinely interleaves more live sessions than this.
+MAX_RESIDENT_DREAMZERO_SESSION_STATES = 4
+
 # The pipeline's per-session state is a bespoke ``DreamZeroState`` by default, or
 # a ``DreamZeroStateAdapter`` view when the opt-in session manager is enabled.
 # The adapter mirrors ``DreamZeroState``'s surface, so every helper that reads or
@@ -469,10 +485,16 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         self._states: OrderedDict[str, DreamZeroState] = OrderedDict()
         # Opt-in: back per-session state with the shared SessionStateManager
         # (RFC #4480). Default off -> the bespoke DreamZeroState path above.
+        # One resolved cap drives *both* stores: the manager keeps its own LRU,
+        # and ``_states`` is bounded by ``_evict_stale_session_states()``. Sizing
+        # them separately is how a bound ends up enforced on only one of the two
+        # paths a deployment can take.
         self._use_memory_manager, mm_max_sessions = resolve_session_state_config(
             enable=od_config.enable_session_state_manager,
-            max_sessions=MAX_DREAMZERO_SESSIONS,
+            max_sessions=MAX_RESIDENT_DREAMZERO_SESSION_STATES,
         )
+        self._max_session_states = mm_max_sessions
+        self._session_state_evict_warned = False
         self._memory_manager: SessionStateManager | None = (
             SessionStateManager(max_sessions=mm_max_sessions) if self._use_memory_manager else None
         )
@@ -562,9 +584,92 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         if state is None:
             state = DreamZeroState()
             self._states[session_key] = state
+            # Only an insert can push the table over its bound; a hit just
+            # reorders it.
+            self._evict_stale_session_states()
         else:
             self._states.move_to_end(session_key)
         return state
+
+    def set_resident_session_state_capacity(self, capacity: int) -> None:
+        """Raise the resident-state floor to a runner's own session capacity.
+
+        The AR-Diffusion runner derives a memory-safe session capacity that
+        already reserves ``model_owned_state_bytes_per_session`` per session, and
+        evicts its own sessions at that bound -- signalling us each time. Lifting
+        our floor to match means we can never drop state for a session the runner
+        still considers live: it releases first, and we only ever evict what it
+        has already let go. Where there is no runner to signal (a disaggregated
+        stage that holds session state without hosting the engine) the configured
+        cap governs, which is exactly where the bound has to do the work.
+
+        Both stores are raised together. The manager was constructed in
+        ``__init__`` with the configured cap, so lifting only
+        ``_max_session_states`` would leave the manager path evicting at the lower
+        bound -- and its overflow drops the table entry *without* resetting
+        buffers, so an evicted session's next request would silently get a fresh
+        ``SessionState`` and lose its accumulated history.
+        """
+        capacity = int(capacity)
+        if capacity <= 0:
+            return
+        current = getattr(self, "_max_session_states", MAX_RESIDENT_DREAMZERO_SESSION_STATES)
+        if capacity <= current:
+            return
+        self._max_session_states = capacity
+        manager = getattr(self, "_memory_manager", None)
+        if manager is not None:
+            manager.raise_max_sessions(capacity)
+        logger.info(
+            "DreamZero: resident session-state capacity raised %d -> %d to match the engine's own capacity",
+            current,
+            capacity,
+        )
+
+    def _evict_stale_session_states(self) -> None:
+        """Bound ``_states`` by count, releasing each evicted session's buffers.
+
+        ``_states`` maintains LRU ordering via ``move_to_end`` but has no
+        eviction of its own: its only removal path is
+        ``_drop_ar_diffusion_session_state()``, reachable solely from the
+        AR-Diffusion runner's release path. Anything that holds session state
+        without a co-located runner therefore never sees an end-of-life signal,
+        and each finished session keeps its device tensors for the life of the
+        process. This is the backstop for that case.
+
+        Evicted states are reset rather than merely unreferenced, mirroring
+        ``SessionStateManager.drop_session()``: dropping the last reference leaves
+        the buffers for whenever GC next runs, which on an accelerator is too late
+        to be useful.
+        """
+        # getattr guards lightweight test fixtures that build the pipeline via
+        # __new__ and seed only ``_states``.
+        max_states = getattr(self, "_max_session_states", MAX_RESIDENT_DREAMZERO_SESSION_STATES)
+        if max_states <= 0:
+            # Non-positive means "no bound" rather than "evict everything".
+            return
+        while len(self._states) > max_states:
+            evicted_key, evicted = self._states.popitem(last=False)
+            try:
+                evicted.reset()
+            except Exception:  # noqa: BLE001 - eviction must free the table even if one state resists
+                logger.exception("DreamZero: failed to release evicted session state %s", evicted_key)
+            if getattr(self, "state", None) is evicted:
+                self.state = None
+            # Reaching the bound means a session was never closed: warn once,
+            # naming the cause, so the missing signal stays visible instead of
+            # being silently absorbed here.
+            if not getattr(self, "_session_state_evict_warned", False):
+                logger.warning(
+                    "DreamZero: evicted session state %s at the %d-session bound "
+                    "(~%d MiB each); a session ended without close_ar_diffusion_session(), "
+                    "so this stage is holding finished sessions. Expected when the pipeline "
+                    "holds session state on a stage that does not host the AR-Diffusion engine.",
+                    evicted_key,
+                    max_states,
+                    DREAMZERO_MODEL_OWNED_STATE_BYTES_PER_SESSION // (1024 * 1024),
+                )
+                self._session_state_evict_warned = True
 
     # -----------------------------------------------------------------------
     # Root config loading

--- a/vllm_omni/diffusion/models/dreamzero/pipeline_dreamzero.py
+++ b/vllm_omni/diffusion/models/dreamzero/pipeline_dreamzero.py
@@ -15,7 +15,7 @@ import math
 import os
 import re as re_module
 from collections import OrderedDict
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from contextlib import contextmanager
 
 import numpy as np
@@ -61,8 +61,11 @@ from vllm_omni.experimental.ar_diffusion.capability import (
     ARDiffusionKVBranchSpec,
     ARDiffusionKVCacheSpec,
 )
+from vllm_omni.experimental.ar_diffusion.tick_protocol import AR_DIFFUSION_TICK_KEY
 from vllm_omni.experimental.world_models.adapters.state_dreamzero_adapter import DreamZeroStateAdapter
 from vllm_omni.experimental.world_models.session_state import (
+    SessionAdmissionError,
+    SessionStateLostError,
     SessionStateManager,
     resolve_session_state_config,
 )
@@ -74,20 +77,28 @@ MAX_DREAMZERO_SESSIONS = 64
 # entries. This is the measured persistent CUDA upper bound per live session.
 DREAMZERO_MODEL_OWNED_STATE_BYTES_PER_SESSION = 603 * 1024 * 1024
 
-# How many per-session states the pipeline keeps resident. Deliberately far
+# How many per-session states the pipeline admits at once. Deliberately far
 # below ``MAX_DREAMZERO_SESSIONS``: that is a count of *KV* slots, which the KV
 # manager then shrinks to fit its own budget, whereas this bounds *model-owned*
 # state at DREAMZERO_MODEL_OWNED_STATE_BYTES_PER_SESSION each. At 603 MiB per
 # session, 64 resident states would be 38.6 GiB -- more than a whole device --
 # so reusing the KV count here would be a bound that can never fire before OOM.
 #
-# This is a backstop, not the primary lifecycle. Sessions are normally released
-# by the AR-Diffusion runner's explicit close/reset; a deployment that holds
-# session state on a stage with no runner (the disaggregated encode stage, where
-# ``engine_backend: ARDiffusionEngine`` is set on denoise only) never receives
-# that signal, and without a bound every finished session stays resident. Raise
-# it with OMNI_DIFFUSION_SESSION_STATE_MANAGER_MAX_SESSIONS if a deployment
-# genuinely interleaves more live sessions than this.
+# This is an *admission* limit, not an eviction threshold. Per-session state
+# includes the Wan VAE causal-convolution cache, which has no recompute source:
+# rebuilding it would mean re-encoding the whole observation history, which is
+# not retained. So a full table refuses the *new* session rather than dropping an
+# existing one -- continuing a session on freshly created state would silently
+# restart its rollout and return normal-looking but wrong output.
+#
+# Sessions are normally released by the AR-Diffusion runner's explicit
+# close/reset. A deployment that holds session state on a stage with no runner
+# (the disaggregated encode stage, where ``engine_backend: ARDiffusionEngine`` is
+# set on denoise only) never receives that signal, so finished sessions are never
+# released and admission eventually fails. That is the missing signal surfacing,
+# not this bound misbehaving. Raise it with
+# OMNI_DIFFUSION_SESSION_STATE_MANAGER_MAX_SESSIONS if a deployment genuinely
+# interleaves more live sessions than this.
 MAX_RESIDENT_DREAMZERO_SESSION_STATES = 4
 
 # The pipeline's per-session state is a bespoke ``DreamZeroState`` by default, or
@@ -485,18 +496,19 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         self._states: OrderedDict[str, DreamZeroState] = OrderedDict()
         # Opt-in: back per-session state with the shared SessionStateManager
         # (RFC #4480). Default off -> the bespoke DreamZeroState path above.
-        # One resolved cap drives *both* stores: the manager keeps its own LRU,
-        # and ``_states`` is bounded by ``_evict_stale_session_states()``. Sizing
-        # them separately is how a bound ends up enforced on only one of the two
-        # paths a deployment can take.
+        # One resolved cap drives *both* stores, and both refuse rather than
+        # evict: ``_states`` via ``_admit_session_state()`` and the manager via
+        # ``evict_when_full=False``. Sizing or policing them separately is how a
+        # bound ends up enforced on only one of the two paths a deployment takes.
         self._use_memory_manager, mm_max_sessions = resolve_session_state_config(
             enable=od_config.enable_session_state_manager,
             max_sessions=MAX_RESIDENT_DREAMZERO_SESSION_STATES,
         )
         self._max_session_states = mm_max_sessions
-        self._session_state_evict_warned = False
         self._memory_manager: SessionStateManager | None = (
-            SessionStateManager(max_sessions=mm_max_sessions) if self._use_memory_manager else None
+            SessionStateManager(max_sessions=mm_max_sessions, evict_when_full=False)
+            if self._use_memory_manager
+            else None
         )
         if self._use_memory_manager:
             logger.info("DreamZero: session state manager enabled (max_sessions=%d)", mm_max_sessions)
@@ -582,33 +594,115 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         session_key = str(session_id or "default")
         state = self._states.get(session_key)
         if state is None:
+            # Only an insert can exceed the bound; a hit just reorders.
+            self._admit_session_state(session_key)
             state = DreamZeroState()
             self._states[session_key] = state
-            # Only an insert can push the table over its bound; a hit just
-            # reorders it.
-            self._evict_stale_session_states()
         else:
             self._states.move_to_end(session_key)
         return state
 
+    def _require_session_state(self, session_id: str | None) -> DreamZeroSessionState:
+        """Return an already-admitted session's state, or fail.
+
+        The continuation counterpart to ``_get_or_create_state()``. A request that
+        continues a session must find the state that session built up; creating a
+        fresh one instead would silently restart the rollout, because
+        ``reset_reason()`` reports ``"session"`` for empty state and the pipeline
+        would quietly re-initialise. The Wan VAE causal-convolution cache has no
+        recompute source, so the history cannot be reconstructed -- and on a
+        disaggregated deployment the denoise stage's KV for this session is still
+        live, so the two stages would silently disagree. Fail instead.
+        """
+        session_key = str(session_id or "default")
+        manager = getattr(self, "_memory_manager", None)
+        if manager is not None:
+            # Check membership before building the adapter: the adapter's
+            # constructor calls get_or_create_session(), which would create the
+            # very state whose absence we are trying to report.
+            if session_key not in manager:
+                raise SessionStateLostError(self._session_state_lost_message(session_key))
+            return DreamZeroStateAdapter(
+                session_id,
+                manager,
+                vae_encoder_window=self.num_frame_per_block,
+            )
+        state = self._states.get(session_key)
+        if state is None:
+            raise SessionStateLostError(self._session_state_lost_message(session_key))
+        self._states.move_to_end(session_key)
+        return state
+
+    @staticmethod
+    def _request_begins_session(extra_args: Mapping[str, object]) -> bool:
+        """Whether this request begins a session, read the way the runner reads it.
+
+        A typed tick namespaces its fields under ``AR_DIFFUSION_TICK_KEY`` and
+        does *not* duplicate them at the top level, while the tick's own
+        ``extra_args`` is merged onto a static per-deployment template
+        (``ARDiffusionConsumer._sampling_params_for_tick``). So the flat key alone
+        cannot express per-request begin/continue on the tick path. The runner
+        releases the old session on the tick's value
+        (``ARDiffusionModelRunner.execute_model``), so reading a different source
+        here would leave the forward demanding state the runner just dropped.
+        Either source saying "begin" counts.
+        """
+        tick = extra_args.get(AR_DIFFUSION_TICK_KEY)
+        if isinstance(tick, Mapping) and bool(tick.get("reset", False)):
+            return True
+        return bool(extra_args.get("reset", False))
+
+    @staticmethod
+    def _session_state_lost_message(session_key: str) -> str:
+        return (
+            f"DreamZero session {session_key!r} has no resident state, so this request cannot "
+            "continue it. Its per-session history (including the VAE causal-convolution cache) "
+            "cannot be rebuilt, so the request is refused rather than silently restarted on empty "
+            'state. Begin a new session by sending a request with extra_args["reset"]=True.'
+        )
+
+    def _admit_session_state(self, session_key: str) -> None:
+        """Refuse a new session once the resident bound is reached.
+
+        Admission rather than eviction: every resident state holds history that
+        cannot be rebuilt, so the new session is refused instead of being paid for
+        by stranding an existing one. Sessions are normally released by the
+        AR-Diffusion runner's explicit close/reset, so reaching this bound means
+        either more sessions are genuinely live at once than the cap allows, or a
+        stage is holding finished sessions because that signal never arrived.
+        """
+        # getattr guards lightweight test fixtures that build the pipeline via
+        # __new__ and seed only ``_states``.
+        max_states = getattr(self, "_max_session_states", MAX_RESIDENT_DREAMZERO_SESSION_STATES)
+        if max_states <= 0 or len(self._states) < max_states:
+            # Non-positive means "no bound".
+            return
+        raise SessionAdmissionError(
+            f"cannot admit DreamZero session {session_key!r}: {len(self._states)} of {max_states} "
+            f"resident session states are in use (~{DREAMZERO_MODEL_OWNED_STATE_BYTES_PER_SESSION // (1024 * 1024)} "
+            "MiB each). Existing sessions hold history that cannot be rebuilt, so they are kept and "
+            "this one is refused. Either more sessions are live at once than the cap allows, or "
+            "finished sessions were never released because close_ar_diffusion_session() never "
+            "arrived -- which happens when the pipeline holds session state on a stage that does "
+            "not host the AR-Diffusion engine. Raise the cap with "
+            "OMNI_DIFFUSION_SESSION_STATE_MANAGER_MAX_SESSIONS if the concurrency is real."
+        )
+
     def set_resident_session_state_capacity(self, capacity: int) -> None:
-        """Raise the resident-state floor to a runner's own session capacity.
+        """Raise the admission bound to a runner's own session capacity.
 
         The AR-Diffusion runner derives a memory-safe session capacity that
         already reserves ``model_owned_state_bytes_per_session`` per session, and
-        evicts its own sessions at that bound -- signalling us each time. Lifting
-        our floor to match means we can never drop state for a session the runner
-        still considers live: it releases first, and we only ever evict what it
-        has already let go. Where there is no runner to signal (a disaggregated
-        stage that holds session state without hosting the engine) the configured
-        cap governs, which is exactly where the bound has to do the work.
+        will keep that many live. Lifting our bound to match keeps us from
+        refusing a session the engine has room for. Where there is no runner to
+        publish a capacity (a disaggregated stage that holds session state without
+        hosting the engine) the configured cap governs, which is exactly where the
+        bound has to do the work.
 
-        Both stores are raised together. The manager was constructed in
+        Both stores are raised together. The manager is constructed in
         ``__init__`` with the configured cap, so lifting only
-        ``_max_session_states`` would leave the manager path evicting at the lower
-        bound -- and its overflow drops the table entry *without* resetting
-        buffers, so an evicted session's next request would silently get a fresh
-        ``SessionState`` and lose its accumulated history.
+        ``_max_session_states`` would leave the manager path refusing at the lower
+        bound while the bespoke path admitted.
         """
         capacity = int(capacity)
         if capacity <= 0:
@@ -625,51 +719,6 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
             current,
             capacity,
         )
-
-    def _evict_stale_session_states(self) -> None:
-        """Bound ``_states`` by count, releasing each evicted session's buffers.
-
-        ``_states`` maintains LRU ordering via ``move_to_end`` but has no
-        eviction of its own: its only removal path is
-        ``_drop_ar_diffusion_session_state()``, reachable solely from the
-        AR-Diffusion runner's release path. Anything that holds session state
-        without a co-located runner therefore never sees an end-of-life signal,
-        and each finished session keeps its device tensors for the life of the
-        process. This is the backstop for that case.
-
-        Evicted states are reset rather than merely unreferenced, mirroring
-        ``SessionStateManager.drop_session()``: dropping the last reference leaves
-        the buffers for whenever GC next runs, which on an accelerator is too late
-        to be useful.
-        """
-        # getattr guards lightweight test fixtures that build the pipeline via
-        # __new__ and seed only ``_states``.
-        max_states = getattr(self, "_max_session_states", MAX_RESIDENT_DREAMZERO_SESSION_STATES)
-        if max_states <= 0:
-            # Non-positive means "no bound" rather than "evict everything".
-            return
-        while len(self._states) > max_states:
-            evicted_key, evicted = self._states.popitem(last=False)
-            try:
-                evicted.reset()
-            except Exception:  # noqa: BLE001 - eviction must free the table even if one state resists
-                logger.exception("DreamZero: failed to release evicted session state %s", evicted_key)
-            if getattr(self, "state", None) is evicted:
-                self.state = None
-            # Reaching the bound means a session was never closed: warn once,
-            # naming the cause, so the missing signal stays visible instead of
-            # being silently absorbed here.
-            if not getattr(self, "_session_state_evict_warned", False):
-                logger.warning(
-                    "DreamZero: evicted session state %s at the %d-session bound "
-                    "(~%d MiB each); a session ended without close_ar_diffusion_session(), "
-                    "so this stage is holding finished sessions. Expected when the pipeline "
-                    "holds session state on a stage that does not host the AR-Diffusion engine.",
-                    evicted_key,
-                    max_states,
-                    DREAMZERO_MODEL_OWNED_STATE_BYTES_PER_SESSION // (1024 * 1024),
-                )
-                self._session_state_evict_warned = True
 
     # -----------------------------------------------------------------------
     # Root config loading
@@ -1168,7 +1217,9 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
 
     def decode_accumulated_video_latents(self, session_id: str | None = None) -> torch.Tensor:
         """Decode all AR-chunk latents accumulated for ``session_id``."""
-        state = self._get_or_create_state(session_id)
+        # Export consumes an existing session's history; it must never be the
+        # thing that creates the session.
+        state = self._require_session_state(session_id)
         latents = state.get_concatenated_video_latents()
         if latents is None:
             session_key = str(session_id or "default")
@@ -1177,7 +1228,7 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
 
     def clear_accumulated_video_latents(self, session_id: str | None = None) -> None:
         """Clear accumulated video latents for ``session_id`` without resetting KV state."""
-        state = self._get_or_create_state(session_id)
+        state = self._require_session_state(session_id)
         state.clear_video_latents()
 
     # -----------------------------------------------------------------------
@@ -1484,7 +1535,14 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
                 )
             raise KeyError("robot_obs")
         session_id = str(extra_args.get("session_id") or "default")
-        state = self._get_or_create_state(session_id)
+        # ``reset`` is the protocol's begin-vs-continue signal (see the AR runner,
+        # which releases the old session on it). Only a begin may create state: a
+        # continuation must find the history its session built up, or fail loudly
+        # rather than restart the rollout on empty state.
+        if self._request_begins_session(extra_args):
+            state = self._get_or_create_state(session_id)
+        else:
+            state = self._require_session_state(session_id)
         self.state = state
         transform, unified_obs = self._transform_robot_obs(robot_obs)
         device = get_local_device()

--- a/vllm_omni/diffusion/models/dreamzero/pipeline_dreamzero.py
+++ b/vllm_omni/diffusion/models/dreamzero/pipeline_dreamzero.py
@@ -77,28 +77,13 @@ MAX_DREAMZERO_SESSIONS = 64
 # entries. This is the measured persistent CUDA upper bound per live session.
 DREAMZERO_MODEL_OWNED_STATE_BYTES_PER_SESSION = 603 * 1024 * 1024
 
-# How many per-session states the pipeline admits at once. Deliberately far
-# below ``MAX_DREAMZERO_SESSIONS``: that is a count of *KV* slots, which the KV
-# manager then shrinks to fit its own budget, whereas this bounds *model-owned*
-# state at DREAMZERO_MODEL_OWNED_STATE_BYTES_PER_SESSION each. At 603 MiB per
-# session, 64 resident states would be 38.6 GiB -- more than a whole device --
-# so reusing the KV count here would be a bound that can never fire before OOM.
+# Bound model-owned state separately from KV slots. DreamZero keeps VAE
+# causal history that cannot be reconstructed, so capacity pressure must
+# reject new sessions rather than evict live history.
 #
-# This is an *admission* limit, not an eviction threshold. Per-session state
-# includes the Wan VAE causal-convolution cache, which has no recompute source:
-# rebuilding it would mean re-encoding the whole observation history, which is
-# not retained. So a full table refuses the *new* session rather than dropping an
-# existing one -- continuing a session on freshly created state would silently
-# restart its rollout and return normal-looking but wrong output.
-#
-# Sessions are normally released by the AR-Diffusion runner's explicit
-# close/reset. A deployment that holds session state on a stage with no runner
-# (the disaggregated encode stage, where ``engine_backend: ARDiffusionEngine`` is
-# set on denoise only) never receives that signal, so finished sessions are never
-# released and admission eventually fails. That is the missing signal surfacing,
-# not this bound misbehaving. Raise it with
-# OMNI_DIFFUSION_SESSION_STATE_MANAGER_MAX_SESSIONS if a deployment genuinely
-# interleaves more live sessions than this.
+# The runner releases state on close/reset. Stages without that runner need
+# close propagation or will eventually reach this bound. Configure genuine
+# concurrency via OMNI_DIFFUSION_SESSION_STATE_MANAGER_MAX_SESSIONS.
 MAX_RESIDENT_DREAMZERO_SESSION_STATES = 4
 
 # The pipeline's per-session state is a bespoke ``DreamZeroState`` by default, or
@@ -494,12 +479,8 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         self.num_frame_per_block: int = ah_config["num_frame_per_block"]
 
         self._states: OrderedDict[str, DreamZeroState] = OrderedDict()
-        # Opt-in: back per-session state with the shared SessionStateManager
-        # (RFC #4480). Default off -> the bespoke DreamZeroState path above.
-        # One resolved cap drives *both* stores, and both refuse rather than
-        # evict: ``_states`` via ``_admit_session_state()`` and the manager via
-        # ``evict_when_full=False``. Sizing or policing them separately is how a
-        # bound ends up enforced on only one of the two paths a deployment takes.
+        # The optional shared manager and the default store use the same admission
+        # limit and reject-on-full policy.
         self._use_memory_manager, mm_max_sessions = resolve_session_state_config(
             enable=od_config.enable_session_state_manager,
             max_sessions=MAX_RESIDENT_DREAMZERO_SESSION_STATES,
@@ -594,7 +575,6 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         session_key = str(session_id or "default")
         state = self._states.get(session_key)
         if state is None:
-            # Only an insert can exceed the bound; a hit just reorders.
             self._admit_session_state(session_key)
             state = DreamZeroState()
             self._states[session_key] = state
@@ -603,23 +583,12 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         return state
 
     def _require_session_state(self, session_id: str | None) -> DreamZeroSessionState:
-        """Return an already-admitted session's state, or fail.
-
-        The continuation counterpart to ``_get_or_create_state()``. A request that
-        continues a session must find the state that session built up; creating a
-        fresh one instead would silently restart the rollout, because
-        ``reset_reason()`` reports ``"session"`` for empty state and the pipeline
-        would quietly re-initialise. The Wan VAE causal-convolution cache has no
-        recompute source, so the history cannot be reconstructed -- and on a
-        disaggregated deployment the denoise stage's KV for this session is still
-        live, so the two stages would silently disagree. Fail instead.
-        """
+        """Require resident state for continuation; never create replacement history."""
         session_key = str(session_id or "default")
         manager = getattr(self, "_memory_manager", None)
         if manager is not None:
-            # Check membership before building the adapter: the adapter's
-            # constructor calls get_or_create_session(), which would create the
-            # very state whose absence we are trying to report.
+            # Check membership first: constructing the adapter would create missing
+            # state and bypass continuation validation.
             if session_key not in manager:
                 raise SessionStateLostError(self._session_state_lost_message(session_key))
             return DreamZeroStateAdapter(
@@ -635,18 +604,7 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
 
     @staticmethod
     def _request_begins_session(extra_args: Mapping[str, object]) -> bool:
-        """Whether this request begins a session, read the way the runner reads it.
-
-        A typed tick namespaces its fields under ``AR_DIFFUSION_TICK_KEY`` and
-        does *not* duplicate them at the top level, while the tick's own
-        ``extra_args`` is merged onto a static per-deployment template
-        (``ARDiffusionConsumer._sampling_params_for_tick``). So the flat key alone
-        cannot express per-request begin/continue on the tick path. The runner
-        releases the old session on the tick's value
-        (``ARDiffusionModelRunner.execute_model``), so reading a different source
-        here would leave the forward demanding state the runner just dropped.
-        Either source saying "begin" counts.
-        """
+        """Treat either the typed tick or flat reset flag as a session begin."""
         tick = extra_args.get(AR_DIFFUSION_TICK_KEY)
         if isinstance(tick, Mapping) and bool(tick.get("reset", False)):
             return True
@@ -662,17 +620,8 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         )
 
     def _admit_session_state(self, session_key: str) -> None:
-        """Refuse a new session once the resident bound is reached.
-
-        Admission rather than eviction: every resident state holds history that
-        cannot be rebuilt, so the new session is refused instead of being paid for
-        by stranding an existing one. Sessions are normally released by the
-        AR-Diffusion runner's explicit close/reset, so reaching this bound means
-        either more sessions are genuinely live at once than the cap allows, or a
-        stage is holding finished sessions because that signal never arrived.
-        """
-        # getattr guards lightweight test fixtures that build the pipeline via
-        # __new__ and seed only ``_states``.
+        """Reject a new session at capacity, preserving all resident states."""
+        # Allow lightweight fixtures that initialize only _states.
         max_states = getattr(self, "_max_session_states", MAX_RESIDENT_DREAMZERO_SESSION_STATES)
         if max_states <= 0 or len(self._states) < max_states:
             # Non-positive means "no bound".
@@ -689,20 +638,10 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         )
 
     def set_resident_session_state_capacity(self, capacity: int) -> None:
-        """Raise the admission bound to a runner's own session capacity.
+        """Raise both stores' admission limits to the runner's resident capacity.
 
-        The AR-Diffusion runner derives a memory-safe session capacity that
-        already reserves ``model_owned_state_bytes_per_session`` per session, and
-        will keep that many live. Lifting our bound to match keeps us from
-        refusing a session the engine has room for. Where there is no runner to
-        publish a capacity (a disaggregated stage that holds session state without
-        hosting the engine) the configured cap governs, which is exactly where the
-        bound has to do the work.
-
-        Both stores are raised together. The manager is constructed in
-        ``__init__`` with the configured cap, so lifting only
-        ``_max_session_states`` would leave the manager path refusing at the lower
-        bound while the bespoke path admitted.
+        The runner budgets model-owned state per session. Without a publishing
+        runner, the configured limit applies. Never lower a live limit.
         """
         capacity = int(capacity)
         if capacity <= 0:
@@ -1217,8 +1156,6 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
 
     def decode_accumulated_video_latents(self, session_id: str | None = None) -> torch.Tensor:
         """Decode all AR-chunk latents accumulated for ``session_id``."""
-        # Export consumes an existing session's history; it must never be the
-        # thing that creates the session.
         state = self._require_session_state(session_id)
         latents = state.get_concatenated_video_latents()
         if latents is None:
@@ -1535,10 +1472,7 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
                 )
             raise KeyError("robot_obs")
         session_id = str(extra_args.get("session_id") or "default")
-        # ``reset`` is the protocol's begin-vs-continue signal (see the AR runner,
-        # which releases the old session on it). Only a begin may create state: a
-        # continuation must find the history its session built up, or fail loudly
-        # rather than restart the rollout on empty state.
+        # Only a begin may create state; continuations require existing history.
         if self._request_begins_session(extra_args):
             state = self._get_or_create_state(session_id)
         else:

--- a/vllm_omni/experimental/ar_diffusion/runner.py
+++ b/vllm_omni/experimental/ar_diffusion/runner.py
@@ -150,10 +150,8 @@ class ARDiffusionModelRunner(DiffusionModelRunner):
             device=self.device,
         )
         self._session_capacity = self.kv_cache.session_capacity
-        # Tell the pipeline how many sessions we will keep resident, so a pipeline
-        # that bounds its own per-session state does not evict one we still hold
-        # live. Optional by design: only pipelines that keep such a store
-        # implement it, so this stays off SupportsARDiffusionPipeline.
+        # Publish capacity to pipelines that bound model-owned state. The hook is
+        # optional because not every AR pipeline owns such a store.
         publish_capacity = getattr(capability, "set_resident_session_state_capacity", None)
         if callable(publish_capacity):
             publish_capacity(self._session_capacity)

--- a/vllm_omni/experimental/ar_diffusion/runner.py
+++ b/vllm_omni/experimental/ar_diffusion/runner.py
@@ -150,6 +150,13 @@ class ARDiffusionModelRunner(DiffusionModelRunner):
             device=self.device,
         )
         self._session_capacity = self.kv_cache.session_capacity
+        # Tell the pipeline how many sessions we will keep resident, so a pipeline
+        # that bounds its own per-session state does not evict one we still hold
+        # live. Optional by design: only pipelines that keep such a store
+        # implement it, so this stays off SupportsARDiffusionPipeline.
+        publish_capacity = getattr(capability, "set_resident_session_state_capacity", None)
+        if callable(publish_capacity):
+            publish_capacity(self._session_capacity)
         logger.info(
             "AR-Diffusion KV cache: blocks=%d layers=%d local_kv_heads=%d head_size=%d "
             "tokens/frame=%d frames/block=%d window=%d sink=%d kv_branches=%s cross=%s "

--- a/vllm_omni/experimental/world_models/session_state/__init__.py
+++ b/vllm_omni/experimental/world_models/session_state/__init__.py
@@ -16,7 +16,9 @@ from vllm_omni.experimental.world_models.session_state.attrs import SessionAttr
 from vllm_omni.experimental.world_models.session_state.base import StateObject
 from vllm_omni.experimental.world_models.session_state.manager import (
     DEFAULT_MAX_SESSIONS,
+    SessionAdmissionError,
     SessionState,
+    SessionStateLostError,
     SessionStateManager,
     resolve_session_state_config,
 )
@@ -28,7 +30,9 @@ __all__ = [
     "SeenStorages",
     "StateObject",
     "SessionAttr",
+    "SessionAdmissionError",
     "SessionState",
+    "SessionStateLostError",
     "SessionStateManager",
     "device_bytes",
     "resolve_session_state_config",

--- a/vllm_omni/experimental/world_models/session_state/manager.py
+++ b/vllm_omni/experimental/world_models/session_state/manager.py
@@ -176,6 +176,30 @@ class SessionStateManager:
             session.reset()
             return True
 
+    def raise_max_sessions(self, max_sessions: int) -> bool:
+        """Raise the LRU bound, never lower it. Returns whether it changed.
+
+        An owner that only learns how many sessions will really be live *after*
+        construction -- an engine publishing its own memory-derived capacity, say
+        -- has to be able to lift the bound, or this table evicts sessions that
+        owner still considers live.
+
+        Lowering is refused rather than honoured: already-resident sessions would
+        become evictable mid-life, and the overflow path in
+        ``get_or_create_session`` drops the table entry *without* resetting
+        buffers, so the next lookup silently returns a fresh ``SessionState`` and
+        the accumulated history is gone with no error. Shrinking a live bound is
+        never what a caller wants; call ``drop_session`` to release a session
+        deliberately.
+        """
+        if max_sessions <= 0:
+            raise ValueError(f"max_sessions must be positive, got {max_sessions}")
+        with self._lock:
+            if max_sessions <= self.max_sessions:
+                return False
+            self.max_sessions = max_sessions
+            return True
+
     def __len__(self) -> int:
         with self._lock:
             return len(self._sessions)

--- a/vllm_omni/experimental/world_models/session_state/manager.py
+++ b/vllm_omni/experimental/world_models/session_state/manager.py
@@ -37,24 +37,11 @@ M = TypeVar("M", bound=StateObject)
 
 
 class SessionAdmissionError(RuntimeError):
-    """No room to admit a new session.
-
-    Raised instead of evicting when a store is configured to reject on full.
-    Retryable: a caller can wait for a live session to end and try again. Derives
-    from ``RuntimeError`` so existing broad handlers keep working.
-    """
+    """Admission refused at capacity; retry after a session is released."""
 
 
 class SessionStateLostError(RuntimeError):
-    """A continuation arrived for a session whose state is no longer resident.
-
-    Distinct from ``SessionAdmissionError``: the session was admitted once, and
-    the history a continuation needs is gone. Raised rather than silently
-    returning a fresh session, because per-session state such as a VAE
-    causal-convolution cache has no recompute source -- continuing on empty state
-    produces normal-looking but wrong output. The caller must start a new session
-    explicitly.
-    """
+    """Continuation has no resident history; an explicit new session is required."""
 
 
 class SessionState:
@@ -136,12 +123,8 @@ class SessionStateManager:
         if max_sessions <= 0:
             raise ValueError(f"max_sessions must be positive, got {max_sessions}")
         self.max_sessions = max_sessions
-        # What to do when a new session arrives at ``max_sessions``. The default
-        # keeps the count-based LRU below. ``False`` makes admission fail instead,
-        # for a model whose per-session state cannot be rebuilt: there, dropping
-        # the oldest entry silently strands history a later continuation needs, so
-        # refusing the *new* session is the safe answer. Opt-in so models already
-        # relying on eviction are unaffected.
+        # Preserve LRU by default; models with unrecoverable history opt into
+        # rejecting new sessions at capacity.
         self.evict_when_full = evict_when_full
         # Recorded for observability; enforcement is left to an eviction
         # planner (see RFC #4480). Not scoped to a device: which pool a budget
@@ -171,9 +154,6 @@ class SessionStateManager:
             session = self._sessions.get(key)
             if session is None:
                 if not self.evict_when_full and len(self._sessions) >= self.max_sessions:
-                    # Admission, not eviction: the resident sessions keep history
-                    # that cannot be rebuilt, so the new one is refused rather
-                    # than paid for by stranding an existing session's state.
                     raise SessionAdmissionError(
                         f"cannot admit session {key!r}: {len(self._sessions)} of {self.max_sessions} "
                         "session slots are in use and this store is configured not to evict. "
@@ -216,20 +196,10 @@ class SessionStateManager:
             return True
 
     def raise_max_sessions(self, max_sessions: int) -> bool:
-        """Raise the LRU bound, never lower it. Returns whether it changed.
+        """Raise the session limit without making existing sessions evictable.
 
-        An owner that only learns how many sessions will really be live *after*
-        construction -- an engine publishing its own memory-derived capacity, say
-        -- has to be able to lift the bound, or this table evicts sessions that
-        owner still considers live.
-
-        Lowering is refused rather than honoured: already-resident sessions would
-        become evictable mid-life, and the overflow path in
-        ``get_or_create_session`` drops the table entry *without* resetting
-        buffers, so the next lookup silently returns a fresh ``SessionState`` and
-        the accumulated history is gone with no error. Shrinking a live bound is
-        never what a caller wants; call ``drop_session`` to release a session
-        deliberately.
+        Return whether the limit changed. Lowering is ignored; use
+        ``drop_session`` to release state explicitly.
         """
         if max_sessions <= 0:
             raise ValueError(f"max_sessions must be positive, got {max_sessions}")

--- a/vllm_omni/experimental/world_models/session_state/manager.py
+++ b/vllm_omni/experimental/world_models/session_state/manager.py
@@ -36,6 +36,27 @@ DEFAULT_MAX_SESSIONS = 64
 M = TypeVar("M", bound=StateObject)
 
 
+class SessionAdmissionError(RuntimeError):
+    """No room to admit a new session.
+
+    Raised instead of evicting when a store is configured to reject on full.
+    Retryable: a caller can wait for a live session to end and try again. Derives
+    from ``RuntimeError`` so existing broad handlers keep working.
+    """
+
+
+class SessionStateLostError(RuntimeError):
+    """A continuation arrived for a session whose state is no longer resident.
+
+    Distinct from ``SessionAdmissionError``: the session was admitted once, and
+    the history a continuation needs is gone. Raised rather than silently
+    returning a fresh session, because per-session state such as a VAE
+    causal-convolution cache has no recompute source -- continuing on empty state
+    produces normal-looking but wrong output. The caller must start a new session
+    explicitly.
+    """
+
+
 class SessionState:
     """The named ``StateObject`` collection for one session."""
 
@@ -110,10 +131,18 @@ class SessionStateManager:
         max_sessions: int = DEFAULT_MAX_SESSIONS,
         byte_budget: int | None = None,
         lock_factory: Callable[[], AbstractContextManager[object]] = threading.Lock,
+        evict_when_full: bool = True,
     ) -> None:
         if max_sessions <= 0:
             raise ValueError(f"max_sessions must be positive, got {max_sessions}")
         self.max_sessions = max_sessions
+        # What to do when a new session arrives at ``max_sessions``. The default
+        # keeps the count-based LRU below. ``False`` makes admission fail instead,
+        # for a model whose per-session state cannot be rebuilt: there, dropping
+        # the oldest entry silently strands history a later continuation needs, so
+        # refusing the *new* session is the safe answer. Opt-in so models already
+        # relying on eviction are unaffected.
+        self.evict_when_full = evict_when_full
         # Recorded for observability; enforcement is left to an eviction
         # planner (see RFC #4480). Not scoped to a device: which pool a budget
         # applies to is a question for whoever enforces it, so read
@@ -141,10 +170,20 @@ class SessionStateManager:
         with self._lock:
             session = self._sessions.get(key)
             if session is None:
+                if not self.evict_when_full and len(self._sessions) >= self.max_sessions:
+                    # Admission, not eviction: the resident sessions keep history
+                    # that cannot be rebuilt, so the new one is refused rather
+                    # than paid for by stranding an existing session's state.
+                    raise SessionAdmissionError(
+                        f"cannot admit session {key!r}: {len(self._sessions)} of {self.max_sessions} "
+                        "session slots are in use and this store is configured not to evict. "
+                        "Either more sessions are live at once than the cap allows, or finished "
+                        "sessions were never released -- end a session explicitly, or raise the cap."
+                    )
                 self.misses += 1
                 session = SessionState()
                 self._sessions[key] = session
-                while len(self._sessions) > self.max_sessions:
+                while self.evict_when_full and len(self._sessions) > self.max_sessions:
                     # Drop the oldest from the table only; do not free its
                     # buffers. An adapter still using the session keeps its own
                     # reference, so its state survives (matching a model's own


### PR DESCRIPTION
## Purpose

DreamZero session state contains VAE causal history that cannot be reconstructed from retained inputs. Evicting it, or creating empty state for a continuation, can silently restart a rollout.

This PR adds a model-state admission limit (default 4, configurable through `OMNI_DIFFUSION_SESSION_STATE_MANAGER_MAX_SESSIONS`). Both DreamZero state stores refuse new sessions with `SessionAdmissionError` when full; continuation and export lookups require existing state and raise `SessionStateLostError` when it is missing. The AR-Diffusion runner can raise the bound to its computed resident capacity. Other users of `SessionStateManager` retain eviction by default.

## Test Plan

**vLLM Version:** target v0.28.0 (`docker/Dockerfile.xpu`).
**vLLM-Omni Commit:** PR head `e187a2dcf5ea`.

Reproduce the policy cases by filling the state store and admitting another session, or releasing a session and attempting continuation/export. CPU tests cover refusal without losing resident history, both storage modes, capacity publication, close/reset, repeated begin/close cycles, and missing-state errors:

```bash
pytest -q tests/diffusion/models/dreamzero/test_session_state_lifecycle.py tests/diffusion/models/dreamzero/test_session_state_equivalence.py
```

Integration validation must also cover typed-tick versus flat-reset precedence, capacity after initialization/warmup, and unknown continuations at runner capacity.

## Test Result

No pytest pass summary or hardware result is recorded for this head; the commands above are pending validation.

Earlier control-flow probes at `7c6871fdb8df` exposed three integration concerns: conflicting tick/flat reset values can classify a continuation as a begin; the initialization `default` entry can consume admission capacity; and runner LRU can release a healthy session before pipeline validation rejects an unknown continuation. These require full-path regression checks before claiming safe session preservation.

This change adds admission and missing-state guards. It does not provide cross-stage close propagation or establish that session-memory growth is fixed.

