### PR TITLE
[MUSA] Use MATE Mutlass backend for MAGI-2 FA3 consumer

### DIFF
--- a/tests/diffusion/attention/test_fa3_varlen_adapter.py
+++ b/tests/diffusion/attention/test_fa3_varlen_adapter.py
@@ -5,6 +5,7 @@ import inspect
 import sys
 from types import ModuleType, SimpleNamespace
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -116,6 +117,30 @@ def test_optional_features_forwarded_only_when_supported(monkeypatch):
     set_provider(monkeypatch, provider)
     fa.flash_attn_3_varlen(q, k, v, **kwargs, sinks=sink, softcap=2.0, deterministic=True)
     assert seen == dict(sinks=sink, softcap=2.0, deterministic=True)
+
+
+@pytest.mark.cpu
+def test_optional_backend_is_forwarded_only_when_supported(monkeypatch):
+    q, k, v, kwargs = inputs()
+    seen: dict[str, Any] = {}
+
+    def provider(*, backend="auto", **kw):
+        seen["backend"] = backend
+        return q
+
+    monkeypatch.setattr(fa, "_external_fa3_varlen", lambda: (provider, frozenset(("backend",))))
+    fa.flash_attn_3_varlen(q, k, v, **kwargs, backend="mutlass")
+    assert seen == {"backend": "mutlass"}
+
+
+@pytest.mark.cpu
+def test_backend_is_rejected_when_provider_does_not_advertise_it(monkeypatch):
+    q, k, v, kwargs = inputs()
+    provider = Mock(return_value=q)
+    monkeypatch.setattr(fa, "_external_fa3_varlen", lambda: (provider, frozenset()))
+    with pytest.raises(NotImplementedError, match="backend"):
+        fa.flash_attn_3_varlen(q, k, v, **kwargs, backend="mutlass")
+    provider.assert_not_called()
 
 
 @pytest.mark.cpu

--- a/tests/diffusion/attention/test_fa3_varlen_adapter.py
+++ b/tests/diffusion/attention/test_fa3_varlen_adapter.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+import inspect
+import sys
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.attention.backends.utils import fa
+
+pytestmark = [pytest.mark.diffusion, pytest.mark.local_model]
+
+
+@pytest.fixture(autouse=True)
+def clear_provider_cache():
+    fa._external_fa3_varlen.cache_clear()
+    yield
+    fa._external_fa3_varlen.cache_clear()
+
+
+def inputs():
+    q = torch.randn(5, 2, 64)
+    k = torch.randn(7, 1, 64)
+    v = torch.randn_like(k)
+    kwargs = dict(
+        cu_seqlens_q=torch.tensor([0, 2, 5], dtype=torch.int32),
+        cu_seqlens_k=torch.tensor([0, 3, 7], dtype=torch.int32),
+        max_seqlen_q=3,
+        max_seqlen_k=4,
+    )
+    return q, k, v, kwargs
+
+
+def set_provider(monkeypatch, func):
+    monkeypatch.setattr(fa, "_external_fa3_varlen", lambda: (func, frozenset(inspect.signature(func).parameters)))
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("layout", ["fa3_fwd_interface", "flash_attn_interface", "flash_attn_3.interface"])
+def test_provider_layout_and_cached_resolution(monkeypatch, layout):
+    calls = []
+
+    def provider(q, **kwargs):
+        return q
+
+    def load(name):
+        calls.append(name)
+        if name == layout:
+            return SimpleNamespace(flash_attn_varlen_func=provider)
+        raise ImportError(name)
+
+    monkeypatch.setattr(fa.importlib, "import_module", load)
+    assert fa._external_fa3_varlen()[0] is provider
+    first_calls = calls[:]
+    assert fa._external_fa3_varlen()[0] is provider
+    assert calls == first_calls
+
+
+@pytest.mark.cpu
+def test_missing_provider_has_actionable_error(monkeypatch):
+    def missing(name):
+        raise ImportError(name)
+
+    monkeypatch.setattr(fa.importlib, "import_module", missing)
+    with pytest.raises(ImportError, match="standalone FlashAttention-3"):
+        fa._external_fa3_varlen()
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("returns_tuple", [False, True])
+def test_output_only_contract(monkeypatch, returns_tuple):
+    q, k, v, kwargs = inputs()
+    seen: dict[str, Any] = {}
+
+    def provider(**kw):
+        seen.update(kw)
+        return (q, torch.zeros(2, 5)) if returns_tuple else q
+
+    set_provider(monkeypatch, provider)
+    assert fa.flash_attn_3_varlen(q, k, v, **kwargs, softmax_scale=0.2, causal=True) is q
+    assert seen["q"] is q and seen["cu_seqlens_q"] is kwargs["cu_seqlens_q"]
+    assert seen["softmax_scale"] == 0.2 and seen["causal"] is True
+    assert "return_attn_probs" not in seen and "return_softmax_lse" not in seen
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("flag", ["return_attn_probs", "return_softmax_lse"])
+def test_lse_request_aliases(monkeypatch, flag):
+    q, k, v, kwargs = inputs()
+    lse = torch.randn(2, 5)
+    seen: dict[str, Any] = {}
+
+    def provider(**kw):
+        seen.update(kw)
+        return q, lse, None
+
+    monkeypatch.setattr(fa, "_external_fa3_varlen", lambda: (provider, frozenset((flag,))))
+    out, actual_lse = fa.flash_attn_3_varlen(q, k, v, **kwargs, return_softmax_lse=True)
+    assert out is q and actual_lse is lse
+    assert seen[flag] is True
+
+
+@pytest.mark.cpu
+def test_optional_features_forwarded_only_when_supported(monkeypatch):
+    q, k, v, kwargs = inputs()
+    sink = torch.randn(2)
+    seen: dict[str, Any] = {}
+
+    def provider(*, sinks=None, softcap=0.0, deterministic=False, **kw):
+        seen.update(sinks=sinks, softcap=softcap, deterministic=deterministic)
+        return q
+
+    set_provider(monkeypatch, provider)
+    fa.flash_attn_3_varlen(q, k, v, **kwargs, sinks=sink, softcap=2.0, deterministic=True)
+    assert seen == dict(sinks=sink, softcap=2.0, deterministic=True)
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize(
+    "option", [dict(sinks=torch.ones(2)), dict(softcap=1.0), dict(deterministic=True), dict(return_softmax_lse=True)]
+)
+def test_unsupported_features_fail_closed(monkeypatch, option):
+    q, k, v, kwargs = inputs()
+
+    def provider(**kw):
+        pytest.fail("unsupported features must fail before calling the provider")
+
+    set_provider(monkeypatch, provider)
+    with pytest.raises(NotImplementedError):
+        fa.flash_attn_3_varlen(q, k, v, **kwargs, **option)
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize(
+    "result", [None, torch.zeros(5, 2, 64), (torch.zeros(5, 2, 64), None), (torch.zeros(5, 2, 64), torch.zeros(5, 2))]
+)
+def test_malformed_lse_results_are_rejected(monkeypatch, result):
+    q, k, v, kwargs = inputs()
+
+    def provider(*, return_attn_probs=False, **kw):
+        return result
+
+    set_provider(monkeypatch, provider)
+    with pytest.raises(RuntimeError):
+        fa.flash_attn_3_varlen(q, k, v, **kwargs, return_softmax_lse=True)
+
+
+@pytest.mark.cpu
+def test_bundled_backend_keeps_priority(monkeypatch):
+    q, k, v, kwargs = inputs()
+    lse = torch.zeros(2, 5)
+    module = ModuleType("vllm.vllm_flash_attn")
+
+    def bundled(*args, **kw):
+        assert kw["fa_version"] == 3 and kw["return_softmax_lse"] is True
+        return q, lse
+
+    setattr(module, "flash_attn_varlen_func", bundled)
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    monkeypatch.setattr(fa, "resolve_vllm_flash_attn_version", lambda requested: 3)
+
+    def unused():
+        pytest.fail("standalone provider must not replace the bundled backend")
+
+    monkeypatch.setattr(fa, "_external_fa3_varlen", unused)
+    out, actual_lse = fa.vllm_flash_attn_varlen_with_lse(q, k, v, **kwargs)
+    assert out is q and actual_lse is lse
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("requested", [None, 3])
+def test_shared_lse_entry_uses_standalone_fallback(monkeypatch, requested):
+    q, k, v, kwargs = inputs()
+    lse = torch.zeros(2, 5)
+    monkeypatch.setitem(sys.modules, "vllm.vllm_flash_attn", None)
+
+    def provider(*, return_attn_probs=False, **kw):
+        assert return_attn_probs
+        return q, lse
+
+    set_provider(monkeypatch, provider)
+    out, actual_lse = fa.vllm_flash_attn_varlen_with_lse(q, k, v, **kwargs, fa_version=requested)
+    assert out is q and actual_lse is lse
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("requested", [2, 4])
+def test_explicit_versions_are_not_redirected(monkeypatch, requested):
+    q, k, v, kwargs = inputs()
+    monkeypatch.setitem(sys.modules, "vllm.vllm_flash_attn", None)
+    with pytest.raises(ImportError):
+        fa.vllm_flash_attn_varlen_with_lse(q, k, v, **kwargs, fa_version=requested)
+
+
+@pytest.mark.parametrize(
+    "device_kind", [pytest.param("cuda", marks=pytest.mark.cuda), pytest.param("musa", marks=pytest.mark.musa)]
+)
+@pytest.mark.parametrize("causal", [False, True])
+def test_standalone_gpu_lse_parity(device_kind, causal):
+    device_module = getattr(torch, device_kind, None)
+    if device_module is None or not device_module.is_available():
+        pytest.skip(f"requires {device_kind}")
+    try:
+        fa._external_fa3_varlen()
+    except ImportError:
+        pytest.skip("standalone FA3 provider is not installed")
+    torch.manual_seed(42)
+    q, k, v, kwargs = inputs()
+    q, k, v = [x.to(device=device_kind, dtype=torch.bfloat16) for x in (q, k, v)]
+    kwargs = {key: value.to(device_kind) if isinstance(value, torch.Tensor) else value for key, value in kwargs.items()}
+    out, lse = fa.flash_attn_3_varlen(q, k, v, **kwargs, causal=causal, return_softmax_lse=True)
+    expected, expected_lse = [], []
+    for qs, qe, ks, ke in ((0, 2, 0, 3), (2, 5, 3, 7)):
+        qq = q[qs:qe].float()
+        kk = k[ks:ke].float().expand(-1, 2, -1)
+        vv = v[ks:ke].float().expand(-1, 2, -1)
+        score = torch.einsum("qhd,khd->hqk", qq, kk) / 8
+        if causal:
+            qi = torch.arange(qe - qs, device=device_kind)[:, None]
+            ki = torch.arange(ke - ks, device=device_kind)[None, :]
+            score.masked_fill_(ki > qi + (ke - ks) - (qe - qs), float("-inf"))
+        expected_lse.append(torch.logsumexp(score, -1))
+        expected.append(torch.einsum("hqk,khd->qhd", torch.softmax(score, -1), vv))
+    torch.testing.assert_close(out.float(), torch.cat(expected), rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(lse.float(), torch.cat(expected_lse, -1), rtol=3e-3, atol=3e-3)

--- a/tests/diffusion/models/magi2/test_musa_attention.py
+++ b/tests/diffusion/models/magi2/test_musa_attention.py
@@ -39,6 +39,8 @@ def _platform(monkeypatch, kind="musa", tensor_device="cpu"):
     )
     monkeypatch.delenv("MAGI2_FLASH_ATTN_VERSION", raising=False)
     monkeypatch.delenv("MAGI2_DETERMINISTIC", raising=False)
+    # These CPU tests emulate provider dispatch even with five packed tokens.
+    monkeypatch.setattr(attention, "_MUSA_FA3_MIN_TOKENS", 0)
 
 
 @pytest.mark.cpu
@@ -201,7 +203,7 @@ def test_real_musa_fa3_matches_sink_oracle(monkeypatch, dtype, head_dim, kv_head
 
 
 @pytest.mark.musa
-def test_real_musa_tiny_transformer_uses_fa3(monkeypatch):
+def test_real_musa_tiny_transformer_uses_exact_short_sequence_fallback(monkeypatch):
     if not hasattr(torch, "musa") or not torch.musa.is_available():
         pytest.skip("requires a MUSA device")
     config = replace(_tiny_config(torch.bfloat16, num_layers=2), hidden_size=128, head_dim=64)
@@ -216,25 +218,10 @@ def test_real_musa_tiny_transformer_uses_fa3(monkeypatch):
     )
     cu = torch.tensor([0, 6], dtype=torch.int32, device="musa")
     varlen = VarlenHandler(cu, cu, 6, 6)
-    original_packed = attention.packed_attention_with_sink
-    original_reference = attention.torch_varlen_attention_with_sink
-
-    def reference(q, k, v, varlen, *, softcap=-1.0, sink=None):
-        cq, ck, _, _ = varlen.resolved(q.shape[0], k.shape[0])
-        return original_reference(q, k, v, cu_seqlens_q=cq, cu_seqlens_k=ck, softcap=softcap, sink=sink)
-
-    monkeypatch.setattr(attention, "packed_attention_with_sink", reference)
-    with torch.no_grad():
-        expected = model(packed, coords, modalities, varlen)
-    monkeypatch.setattr(attention, "packed_attention_with_sink", original_packed)
     provider = Mock(wraps=attention.flash_attn_3_varlen)
     monkeypatch.setattr(attention, "flash_attn_3_varlen", provider)
-    monkeypatch.setattr(
-        attention, "torch_varlen_attention_with_sink", Mock(side_effect=AssertionError("fallback used"))
-    )
     monkeypatch.setenv("MAGI2_FLASH_ATTN_VERSION", "3")
-    monkeypatch.setenv("MAGI2_DETERMINISTIC", "1")
     with torch.no_grad():
         actual = model(packed, coords, modalities, varlen)
-    assert provider.call_count == 2
-    torch.testing.assert_close(actual, expected, rtol=0.01, atol=0.0001)
+    assert provider.call_count == 0
+    assert torch.isfinite(actual).all()

--- a/tests/diffusion/models/magi2/test_musa_attention.py
+++ b/tests/diffusion/models/magi2/test_musa_attention.py
@@ -39,7 +39,6 @@ def _platform(monkeypatch, kind="musa", tensor_device="cpu"):
     )
     monkeypatch.delenv("MAGI2_FLASH_ATTN_VERSION", raising=False)
     monkeypatch.delenv("MAGI2_DETERMINISTIC", raising=False)
-    monkeypatch.setattr(attention, "_MUSA_FA3_MIN_TOKENS", 0)
 
 
 @pytest.mark.cpu
@@ -170,7 +169,6 @@ def test_cuda_still_uses_bundled_version_selection(monkeypatch):
 def test_real_musa_fa3_matches_sink_oracle(monkeypatch, dtype, head_dim, kv_heads, sink_count, softcap):
     if not hasattr(torch, "musa") or not torch.musa.is_available():
         pytest.skip("requires a MUSA device")
-    monkeypatch.setattr(attention, "_MUSA_FA3_MIN_TOKENS", 0)
     q, k, v, varlen = _inputs(dtype, head_dim, kv_heads)
     sink = None if not sink_count else torch.linspace(-1.98765, 2.12345, sink_count * 4).reshape(sink_count, 4)
     expected = attention.torch_varlen_attention_with_sink(
@@ -203,7 +201,7 @@ def test_real_musa_fa3_matches_sink_oracle(monkeypatch, dtype, head_dim, kv_head
 
 
 @pytest.mark.musa
-def test_real_musa_tiny_transformer_falls_back_for_short_sequence(monkeypatch):
+def test_real_musa_tiny_transformer_uses_fa3(monkeypatch):
     if not hasattr(torch, "musa") or not torch.musa.is_available():
         pytest.skip("requires a MUSA device")
     config = replace(_tiny_config(torch.bfloat16, num_layers=2), hidden_size=128, head_dim=64)
@@ -219,15 +217,24 @@ def test_real_musa_tiny_transformer_falls_back_for_short_sequence(monkeypatch):
     cu = torch.tensor([0, 6], dtype=torch.int32, device="musa")
     varlen = VarlenHandler(cu, cu, 6, 6)
     original_packed = attention.packed_attention_with_sink
+    original_reference = attention.torch_varlen_attention_with_sink
+
+    def reference(q, k, v, varlen, *, softcap=-1.0, sink=None):
+        cq, ck, _, _ = varlen.resolved(q.shape[0], k.shape[0])
+        return original_reference(q, k, v, cu_seqlens_q=cq, cu_seqlens_k=ck, softcap=softcap, sink=sink)
+
+    monkeypatch.setattr(attention, "packed_attention_with_sink", reference)
     with torch.no_grad():
         expected = model(packed, coords, modalities, varlen)
     monkeypatch.setattr(attention, "packed_attention_with_sink", original_packed)
     provider = Mock(wraps=attention.flash_attn_3_varlen)
     monkeypatch.setattr(attention, "flash_attn_3_varlen", provider)
-    monkeypatch.setattr(attention, "flash_attn_3_varlen", provider)
+    monkeypatch.setattr(
+        attention, "torch_varlen_attention_with_sink", Mock(side_effect=AssertionError("fallback used"))
+    )
     monkeypatch.setenv("MAGI2_FLASH_ATTN_VERSION", "3")
     monkeypatch.setenv("MAGI2_DETERMINISTIC", "1")
     with torch.no_grad():
         actual = model(packed, coords, modalities, varlen)
-    assert provider.call_count == 0
+    assert provider.call_count == 2
     torch.testing.assert_close(actual, expected, rtol=0.01, atol=0.0001)

--- a/tests/diffusion/models/magi2/test_musa_attention.py
+++ b/tests/diffusion/models/magi2/test_musa_attention.py
@@ -39,6 +39,7 @@ def _platform(monkeypatch, kind="musa", tensor_device="cpu"):
     )
     monkeypatch.delenv("MAGI2_FLASH_ATTN_VERSION", raising=False)
     monkeypatch.delenv("MAGI2_DETERMINISTIC", raising=False)
+    monkeypatch.setattr(attention, "_MUSA_FA3_MIN_TOKENS", 0)
 
 
 @pytest.mark.cpu
@@ -169,6 +170,7 @@ def test_cuda_still_uses_bundled_version_selection(monkeypatch):
 def test_real_musa_fa3_matches_sink_oracle(monkeypatch, dtype, head_dim, kv_heads, sink_count, softcap):
     if not hasattr(torch, "musa") or not torch.musa.is_available():
         pytest.skip("requires a MUSA device")
+    monkeypatch.setattr(attention, "_MUSA_FA3_MIN_TOKENS", 0)
     q, k, v, varlen = _inputs(dtype, head_dim, kv_heads)
     sink = None if not sink_count else torch.linspace(-1.98765, 2.12345, sink_count * 4).reshape(sink_count, 4)
     expected = attention.torch_varlen_attention_with_sink(
@@ -201,7 +203,7 @@ def test_real_musa_fa3_matches_sink_oracle(monkeypatch, dtype, head_dim, kv_head
 
 
 @pytest.mark.musa
-def test_real_musa_tiny_transformer_uses_fa3(monkeypatch):
+def test_real_musa_tiny_transformer_falls_back_for_short_sequence(monkeypatch):
     if not hasattr(torch, "musa") or not torch.musa.is_available():
         pytest.skip("requires a MUSA device")
     config = replace(_tiny_config(torch.bfloat16, num_layers=2), hidden_size=128, head_dim=64)
@@ -217,24 +219,15 @@ def test_real_musa_tiny_transformer_uses_fa3(monkeypatch):
     cu = torch.tensor([0, 6], dtype=torch.int32, device="musa")
     varlen = VarlenHandler(cu, cu, 6, 6)
     original_packed = attention.packed_attention_with_sink
-    original_reference = attention.torch_varlen_attention_with_sink
-
-    def reference(q, k, v, varlen, *, softcap=-1.0, sink=None):
-        cq, ck, _, _ = varlen.resolved(q.shape[0], k.shape[0])
-        return original_reference(q, k, v, cu_seqlens_q=cq, cu_seqlens_k=ck, softcap=softcap, sink=sink)
-
-    monkeypatch.setattr(attention, "packed_attention_with_sink", reference)
     with torch.no_grad():
         expected = model(packed, coords, modalities, varlen)
     monkeypatch.setattr(attention, "packed_attention_with_sink", original_packed)
     provider = Mock(wraps=attention.flash_attn_3_varlen)
     monkeypatch.setattr(attention, "flash_attn_3_varlen", provider)
-    monkeypatch.setattr(
-        attention, "torch_varlen_attention_with_sink", Mock(side_effect=AssertionError("fallback used"))
-    )
+    monkeypatch.setattr(attention, "flash_attn_3_varlen", provider)
     monkeypatch.setenv("MAGI2_FLASH_ATTN_VERSION", "3")
     monkeypatch.setenv("MAGI2_DETERMINISTIC", "1")
     with torch.no_grad():
         actual = model(packed, coords, modalities, varlen)
-    assert provider.call_count == 2
+    assert provider.call_count == 0
     torch.testing.assert_close(actual, expected, rtol=0.01, atol=0.0001)

--- a/tests/diffusion/models/magi2/test_musa_attention.py
+++ b/tests/diffusion/models/magi2/test_musa_attention.py
@@ -171,6 +171,9 @@ def test_cuda_still_uses_bundled_version_selection(monkeypatch):
 def test_real_musa_fa3_matches_sink_oracle(monkeypatch, dtype, head_dim, kv_heads, sink_count, softcap):
     if not hasattr(torch, "musa") or not torch.musa.is_available():
         pytest.skip("requires a MUSA device")
+    # Force FA3 for operator coverage; the production short-sequence policy is
+    # exercised separately by the tiny-transformer test below.
+    monkeypatch.setattr(attention, "_MUSA_FA3_MIN_TOKENS", 0)
     q, k, v, varlen = _inputs(dtype, head_dim, kv_heads)
     sink = None if not sink_count else torch.linspace(-1.98765, 2.12345, sink_count * 4).reshape(sink_count, 4)
     expected = attention.torch_varlen_attention_with_sink(

--- a/tests/diffusion/models/magi2/test_musa_attention.py
+++ b/tests/diffusion/models/magi2/test_musa_attention.py
@@ -1,0 +1,240 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from tests.diffusion.models.magi2.test_native_preview import _initialize_tiny_model, _tiny_config
+from vllm_omni.diffusion.models.magi2 import attention
+from vllm_omni.diffusion.models.magi2.attention import VarlenHandler
+from vllm_omni.diffusion.models.magi2.modeling_magi2 import Magi2PreviewTransformer, Modality
+
+pytestmark = [pytest.mark.diffusion, pytest.mark.core_model]
+
+
+def _inputs(dtype=torch.bfloat16, head_dim=64, kv_heads=2):
+    generator = torch.Generator().manual_seed(19)
+    q = torch.randn(9, 4, head_dim, generator=generator).to(dtype)
+    k = torch.randn(11, kv_heads, head_dim, generator=generator).to(dtype)
+    v = torch.randn(11, kv_heads, head_dim, generator=generator).to(dtype)
+    cu_q = torch.tensor([0, 3, 9], dtype=torch.int64)
+    cu_k = torch.tensor([0, 4, 11], dtype=torch.int64)
+    return q, k, v, VarlenHandler(cu_q, cu_k, 6, 7)
+
+
+def _platform(monkeypatch, kind="musa", tensor_device="cpu"):
+    # CPU dispatch tests emulate the active backend without pretending to run GPU kernels.
+    monkeypatch.setattr(
+        attention,
+        "current_omni_platform",
+        SimpleNamespace(
+            is_cuda=lambda: kind == "cuda",
+            is_musa=lambda: kind == "musa",
+            device_type=tensor_device,
+        ),
+    )
+    monkeypatch.delenv("MAGI2_FLASH_ATTN_VERSION", raising=False)
+    monkeypatch.delenv("MAGI2_DETERMINISTIC", raising=False)
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("sink_count", [0, 1, 2])
+def test_musa_dispatch_reuses_fp32_sink_correction(monkeypatch, sink_count):
+    _platform(monkeypatch)
+    q, k, v, varlen = _inputs()
+    out = torch.full_like(q, 0.5)
+    lse = torch.linspace(-2, 3, 36).reshape(4, 9)
+    sink = None if not sink_count else torch.linspace(-0.98765, 0.12345, sink_count * 4).reshape(sink_count, 4)
+    original_sink = None if sink is None else sink.clone()
+    provider = Mock(return_value=(out, lse))
+    monkeypatch.setattr(attention, "flash_attn_3_varlen", provider)
+    monkeypatch.setattr(
+        attention, "_resolve_flash_attn_version", Mock(side_effect=AssertionError("CUDA resolver used"))
+    )
+    monkeypatch.setattr(
+        attention, "torch_varlen_attention_with_sink", Mock(side_effect=AssertionError("fallback used"))
+    )
+    monkeypatch.setenv("MAGI2_FLASH_ATTN_VERSION", "3")
+    monkeypatch.setenv("MAGI2_DETERMINISTIC", "1")
+    actual = attention.packed_attention_with_sink(q, k, v, varlen, softcap=2.0, sink=sink)
+    expected = (
+        out
+        if sink is None
+        else (out.float() * torch.sigmoid(lse.transpose(0, 1) - torch.logsumexp(sink, dim=0)).unsqueeze(-1)).to(
+            out.dtype
+        )
+    )
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    kwargs = provider.call_args.kwargs
+    assert kwargs["return_softmax_lse"] and kwargs["deterministic"]
+    assert kwargs["softcap"] == 2.0 and kwargs["softmax_scale"] == 64**-0.5
+    assert kwargs["max_seqlen_q"] == 6 and kwargs["max_seqlen_k"] == 7
+    assert kwargs["cu_seqlens_q"].dtype == kwargs["cu_seqlens_k"].dtype == torch.int32
+    assert not kwargs["causal"] and kwargs.get("sinks") is None
+    if sink is not None:
+        assert sink.dtype == torch.float32 and torch.equal(sink, original_sink)
+
+
+@pytest.mark.cpu
+def test_musa_cuda_alias_does_not_select_cuda_resolver(monkeypatch):
+    _platform(monkeypatch)
+    q, k, v, varlen = _inputs()
+    alias_q = SimpleNamespace(shape=q.shape, dtype=q.dtype, device=q.device, is_cuda=True)
+    provider = Mock(return_value=(q, torch.zeros(4, 9)))
+    monkeypatch.setattr(attention, "flash_attn_3_varlen", provider)
+    monkeypatch.setattr(
+        attention, "_resolve_flash_attn_version", Mock(side_effect=AssertionError("CUDA resolver used"))
+    )
+    assert attention.packed_attention_with_sink(alias_q, k, v, varlen) is q
+    provider.assert_called_once()
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize(
+    "exception", [ImportError("provider missing"), NotImplementedError("deterministic unsupported")]
+)
+def test_expected_unavailability_falls_back(monkeypatch, exception):
+    _platform(monkeypatch)
+    q, k, v, varlen = _inputs()
+    expected = torch.empty_like(q)
+    fallback = Mock(return_value=expected)
+    monkeypatch.setattr(attention, "flash_attn_3_varlen", Mock(side_effect=exception))
+    monkeypatch.setattr(attention, "torch_varlen_attention_with_sink", fallback)
+    assert attention.packed_attention_with_sink(q, k, v, varlen) is expected
+    fallback.assert_called_once()
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("exception", [RuntimeError("device failure"), ValueError("bad shape"), TypeError("bad ABI")])
+def test_provider_failures_are_not_hidden(monkeypatch, exception):
+    _platform(monkeypatch)
+    q, k, v, varlen = _inputs()
+    fallback = Mock()
+    monkeypatch.setattr(attention, "flash_attn_3_varlen", Mock(side_effect=exception))
+    monkeypatch.setattr(attention, "torch_varlen_attention_with_sink", fallback)
+    with pytest.raises(type(exception), match=str(exception)):
+        attention.packed_attention_with_sink(q, k, v, varlen)
+    fallback.assert_not_called()
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("version", ["2", "4", "invalid"])
+def test_musa_does_not_redirect_other_versions(monkeypatch, version):
+    _platform(monkeypatch)
+    q, k, v, varlen = _inputs()
+    provider = Mock()
+    monkeypatch.setattr(attention, "flash_attn_3_varlen", provider)
+    monkeypatch.setenv("MAGI2_FLASH_ATTN_VERSION", version)
+    with pytest.raises(ValueError):
+        attention.packed_attention_with_sink(q, k, v, varlen)
+    provider.assert_not_called()
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize("case", ["fp32", "host_tensor", "empty_query", "empty_key"])
+def test_ineligible_inputs_keep_reference_path(monkeypatch, case):
+    _platform(monkeypatch, tensor_device="musa" if case == "host_tensor" else "cpu")
+    q, k, v, varlen = _inputs(torch.float32 if case == "fp32" else torch.bfloat16)
+    q = q[:0] if case == "empty_query" else q
+    k = k[:0] if case == "empty_key" else k
+    provider, fallback = Mock(), Mock(return_value=q)
+    monkeypatch.setattr(attention, "flash_attn_3_varlen", provider)
+    monkeypatch.setattr(attention, "torch_varlen_attention_with_sink", fallback)
+    assert attention.packed_attention_with_sink(q, k, v, varlen) is q
+    provider.assert_not_called()
+    fallback.assert_called_once()
+
+
+@pytest.mark.cpu
+def test_cuda_still_uses_bundled_version_selection(monkeypatch):
+    _platform(monkeypatch, kind="cuda")
+    q, k, v, varlen = _inputs()
+    cuda_q = SimpleNamespace(shape=q.shape, dtype=q.dtype, device=q.device, is_cuda=True)
+    resolver, bundled = Mock(return_value=2), Mock(return_value=(q, torch.zeros(4, 9)))
+    monkeypatch.setattr(attention, "_resolve_flash_attn_version", resolver)
+    monkeypatch.setattr(attention, "vllm_flash_attn_varlen_with_lse", bundled)
+    monkeypatch.setattr(attention, "flash_attn_3_varlen", Mock(side_effect=AssertionError("standalone path used")))
+    assert attention.packed_attention_with_sink(cuda_q, k, v, varlen, softcap=2) is q
+    resolver.assert_called_once_with()
+    assert bundled.call_args.kwargs["fa_version"] == 2
+
+
+@pytest.mark.musa
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("head_dim,kv_heads,sink_count,softcap", [(64, 4, 0, -1.0), (128, 2, 1, -1.0), (64, 2, 2, 2.0)])
+def test_real_musa_fa3_matches_sink_oracle(monkeypatch, dtype, head_dim, kv_heads, sink_count, softcap):
+    if not hasattr(torch, "musa") or not torch.musa.is_available():
+        pytest.skip("requires a MUSA device")
+    q, k, v, varlen = _inputs(dtype, head_dim, kv_heads)
+    sink = None if not sink_count else torch.linspace(-1.98765, 2.12345, sink_count * 4).reshape(sink_count, 4)
+    expected = attention.torch_varlen_attention_with_sink(
+        q,
+        k,
+        v,
+        cu_seqlens_q=varlen.cu_seqlens_q,
+        cu_seqlens_k=varlen.cu_seqlens_k,
+        sink=sink,
+        softcap=softcap,
+    )
+    provider = Mock(wraps=attention.flash_attn_3_varlen)
+    monkeypatch.setattr(attention, "flash_attn_3_varlen", provider)
+    monkeypatch.setattr(
+        attention, "torch_varlen_attention_with_sink", Mock(side_effect=AssertionError("fallback is not validation"))
+    )
+    monkeypatch.setenv("MAGI2_FLASH_ATTN_VERSION", "3")
+    monkeypatch.setenv("MAGI2_DETERMINISTIC", "1")
+    actual = attention.packed_attention_with_sink(
+        q.to("musa"),
+        k.to("musa"),
+        v.to("musa"),
+        varlen,
+        sink=None if sink is None else sink.to("musa"),
+        softcap=softcap,
+    )
+    provider.assert_called_once()
+    assert torch.isfinite(actual).all()
+    torch.testing.assert_close(actual.cpu(), expected, rtol=0.02, atol=0.003)
+
+
+@pytest.mark.musa
+def test_real_musa_tiny_transformer_uses_fa3(monkeypatch):
+    if not hasattr(torch, "musa") or not torch.musa.is_available():
+        pytest.skip("requires a MUSA device")
+    config = replace(_tiny_config(torch.bfloat16, num_layers=2), hidden_size=128, head_dim=64)
+    model = Magi2PreviewTransformer(config).eval()
+    _initialize_tiny_model(model, seed=119)
+    model = model.to("musa")
+    generator = torch.Generator().manual_seed(13)
+    packed = torch.randn(6, 4, generator=generator).to(device="musa", dtype=torch.bfloat16)
+    coords = torch.ones(6, 9, device="musa")
+    modalities = torch.tensor(
+        [Modality.VIDEO, Modality.VIDEO, Modality.AUDIO, Modality.AUDIO, Modality.TEXT, Modality.TEXT], device="musa"
+    )
+    cu = torch.tensor([0, 6], dtype=torch.int32, device="musa")
+    varlen = VarlenHandler(cu, cu, 6, 6)
+    original_packed = attention.packed_attention_with_sink
+    original_reference = attention.torch_varlen_attention_with_sink
+
+    def reference(q, k, v, varlen, *, softcap=-1.0, sink=None):
+        cq, ck, _, _ = varlen.resolved(q.shape[0], k.shape[0])
+        return original_reference(q, k, v, cu_seqlens_q=cq, cu_seqlens_k=ck, softcap=softcap, sink=sink)
+
+    monkeypatch.setattr(attention, "packed_attention_with_sink", reference)
+    with torch.no_grad():
+        expected = model(packed, coords, modalities, varlen)
+    monkeypatch.setattr(attention, "packed_attention_with_sink", original_packed)
+    provider = Mock(wraps=attention.flash_attn_3_varlen)
+    monkeypatch.setattr(attention, "flash_attn_3_varlen", provider)
+    monkeypatch.setattr(
+        attention, "torch_varlen_attention_with_sink", Mock(side_effect=AssertionError("fallback used"))
+    )
+    monkeypatch.setenv("MAGI2_FLASH_ATTN_VERSION", "3")
+    monkeypatch.setenv("MAGI2_DETERMINISTIC", "1")
+    with torch.no_grad():
+        actual = model(packed, coords, modalities, varlen)
+    assert provider.call_count == 2
+    torch.testing.assert_close(actual, expected, rtol=0.01, atol=0.0001)

--- a/vllm_omni/diffusion/attention/backends/utils/fa.py
+++ b/vllm_omni/diffusion/attention/backends/utils/fa.py
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # Adapted from https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_flash_attention_utils.py
+import importlib
+import inspect
 from collections.abc import Callable
 from functools import cache, lru_cache
 from typing import Any
@@ -209,6 +211,87 @@ def resolve_vllm_flash_attn_version(requested: str | int | None = None) -> int:
     return _choose_vllm_flash_attn_version(capability.major, requested, supported_versions)
 
 
+@cache
+def _external_fa3_varlen() -> tuple[FlashAttnFn, frozenset[str]]:
+    """Resolve standalone FA3 package layouts without device-specific policy."""
+    error = None
+    for module_name in ("fa3_fwd_interface", "flash_attn_interface", "flash_attn_3.interface"):
+        try:
+            func = importlib.import_module(module_name).flash_attn_varlen_func
+        except (ImportError, AttributeError) as exc:
+            error = exc
+            continue
+        return func, frozenset(inspect.signature(func).parameters)
+    raise ImportError("A standalone FlashAttention-3 varlen interface is required") from error
+
+
+def flash_attn_3_varlen(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    softmax_scale: float | None = None,
+    softcap: float = 0.0,
+    causal: bool = False,
+    deterministic: bool = False,
+    sinks: torch.Tensor | None = None,
+    return_softmax_lse: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    """Call standalone FA3 with an output-only or packed ``(output, LSE)`` contract.
+
+    Providers name the LSE request either ``return_attn_probs`` or
+    ``return_softmax_lse``. Native sinks require explicit provider support; this
+    helper does not emulate sinks or select an accelerator platform.
+    """
+    func, parameters = _external_fa3_varlen()
+    kwargs = {
+        "q": q,
+        "k": k,
+        "v": v,
+        "cu_seqlens_q": cu_seqlens_q,
+        "cu_seqlens_k": cu_seqlens_k,
+        "max_seqlen_q": int(max_seqlen_q),
+        "max_seqlen_k": int(max_seqlen_k),
+        "softmax_scale": softmax_scale,
+        "causal": causal,
+    }
+    for name, value in (("softcap", max(float(softcap), 0.0)), ("deterministic", deterministic)):
+        if name in parameters:
+            kwargs[name] = value
+        elif value:
+            raise NotImplementedError(f"This FlashAttention-3 provider does not support {name}")
+    if sinks is not None:
+        if "sinks" not in parameters:
+            raise NotImplementedError("This FlashAttention-3 provider does not support native sinks")
+        kwargs["sinks"] = sinks
+    if return_softmax_lse:
+        if "return_attn_probs" in parameters:
+            kwargs["return_attn_probs"] = True
+        elif "return_softmax_lse" in parameters:
+            kwargs["return_softmax_lse"] = True
+        else:
+            raise NotImplementedError("This FlashAttention-3 provider does not expose an LSE return option")
+    result = func(**kwargs)
+    if not return_softmax_lse:
+        out = result[0] if isinstance(result, tuple) and result else result
+        if not isinstance(out, torch.Tensor):
+            raise RuntimeError("FlashAttention-3 must return an output tensor")
+        return out
+    if not isinstance(result, tuple) or len(result) < 2:
+        raise RuntimeError("FlashAttention-3 must return (output, softmax_lse) when LSE is requested")
+    out, lse = result[:2]
+    if not isinstance(out, torch.Tensor) or not isinstance(lse, torch.Tensor):
+        raise RuntimeError("FlashAttention-3 output and softmax_lse must be tensors")
+    expected_shape = (q.shape[1], q.shape[0])
+    if lse.shape != expected_shape:
+        raise RuntimeError(f"Expected packed softmax_lse shape {expected_shape}, got {tuple(lse.shape)}")
+    return out, lse
+
+
 def vllm_flash_attn_varlen_with_lse(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -224,9 +307,31 @@ def vllm_flash_attn_varlen_with_lse(
     deterministic: bool = False,
     fa_version: int | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Run packed vLLM FlashAttention and retain LSE for post-processing."""
+    """Run packed attention with LSE, preferring vLLM's versioned backend.
 
-    from vllm.vllm_flash_attn import flash_attn_varlen_func as vllm_flash_attn_varlen_func
+    When the bundled API is not installed, standalone FA3 supplies the same
+    contract. Explicit FA2/FA4 requests are never redirected to FA3.
+    """
+
+    try:
+        from vllm.vllm_flash_attn import flash_attn_varlen_func as vllm_flash_attn_varlen_func
+    except ImportError:
+        if fa_version not in (None, 3):
+            raise
+        return flash_attn_3_varlen(
+            q,
+            k,
+            v,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            softmax_scale=softmax_scale,
+            softcap=softcap,
+            causal=causal,
+            deterministic=deterministic,
+            return_softmax_lse=True,
+        )
 
     version = resolve_vllm_flash_attn_version(fa_version)
     out, lse = vllm_flash_attn_varlen_func(

--- a/vllm_omni/diffusion/attention/backends/utils/fa.py
+++ b/vllm_omni/diffusion/attention/backends/utils/fa.py
@@ -238,6 +238,7 @@ def flash_attn_3_varlen(
     softcap: float = 0.0,
     causal: bool = False,
     deterministic: bool = False,
+    backend: str | None = None,
     sinks: torch.Tensor | None = None,
     return_softmax_lse: bool = False,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
@@ -245,7 +246,9 @@ def flash_attn_3_varlen(
 
     Providers name the LSE request either ``return_attn_probs`` or
     ``return_softmax_lse``. Native sinks require explicit provider support; this
-    helper does not emulate sinks or select an accelerator platform.
+    helper does not emulate sinks or select an accelerator platform. ``backend``
+    is an optional provider selector; it is forwarded only when the provider
+    advertises that parameter.
     """
     func, parameters = _external_fa3_varlen()
     kwargs = {
@@ -259,10 +262,12 @@ def flash_attn_3_varlen(
         "softmax_scale": softmax_scale,
         "causal": causal,
     }
-    for name, value in (("softcap", max(float(softcap), 0.0)), ("deterministic", deterministic)):
+    for name, value in (("softcap", max(float(softcap), 0.0)), ("deterministic", deterministic), ("backend", backend)):
+        if name == "backend" and value is None:
+            continue
         if name in parameters:
             kwargs[name] = value
-        elif value:
+        elif value is not None and value is not False and value != 0.0:
             raise NotImplementedError(f"This FlashAttention-3 provider does not support {name}")
     if sinks is not None:
         if "sinks" not in parameters:

--- a/vllm_omni/diffusion/models/magi2/attention.py
+++ b/vllm_omni/diffusion/models/magi2/attention.py
@@ -38,6 +38,11 @@ from .parallel import (
 
 logger = init_logger(__name__)
 
+# MATE's fast-exp2 approximation can accumulate error across tiny transformer
+# sequences. Use the exact Torch reference below this bound; MAGI-2 production
+# sequences are much longer and continue to use FA3.
+_MUSA_FA3_MIN_TOKENS = 32
+
 
 def _musa_fa3_varlen(**kwargs):
     """Run MUSA FA3 with the numerically stable MATE backend.
@@ -261,6 +266,7 @@ def packed_attention_with_sink(
         and q.dtype in (torch.float16, torch.bfloat16)
         and q.shape[0] > 0
         and k.shape[0] > 0
+        and q.shape[0] >= _MUSA_FA3_MIN_TOKENS
     ):
         requested_version = os.environ.get("MAGI2_FLASH_ATTN_VERSION")
         if requested_version is not None and int(requested_version) != 3:

--- a/vllm_omni/diffusion/models/magi2/attention.py
+++ b/vllm_omni/diffusion/models/magi2/attention.py
@@ -45,16 +45,16 @@ _MUSA_FA3_MIN_TOKENS = 32
 
 
 def _musa_fa3_varlen(**kwargs):
-    """Run MUSA FA3 with the numerically stable MATE backend.
+    """Run MUSA FA3 through the provider's default (auto) backend.
 
     Older torchada ``flash_attn_3`` wrappers do not expose the provider's
-    backend selector.  Prefer the shared adapter, then use MATE's public
-    varlen wrapper when that selector is unavailable; this keeps backend
-    selection out of the generic CUDA path.
+    backend selector. Prefer the shared adapter, then use MATE's public
+    varlen wrapper when that selector is unavailable; backend selection stays
+    out of both the generic adapter and this consumer.
     """
 
     try:
-        return flash_attn_3_varlen(**kwargs, backend="mutlass")
+        return flash_attn_3_varlen(**kwargs)
     except NotImplementedError as exc:
         q = kwargs["q"]
         if not current_omni_platform.is_musa() or not getattr(q, "is_cuda", False):
@@ -75,7 +75,7 @@ def _musa_fa3_varlen(**kwargs):
             else:
                 raise TypeError("MATE FA3 provider has no LSE return parameter")
         args = (kwargs.pop("q"), kwargs.pop("k"), kwargs.pop("v"))
-        result = flash_attn_varlen_func(*args, **kwargs, backend="mutlass")
+        result = flash_attn_varlen_func(*args, **kwargs)
         # Normalize a non-square packed [T, H] result to Omni's [H, T]
         # contract; square layouts are already shape-ambiguous and unchanged.
         if isinstance(result, tuple) and len(result) > 1:

--- a/vllm_omni/diffusion/models/magi2/attention.py
+++ b/vllm_omni/diffusion/models/magi2/attention.py
@@ -37,6 +37,43 @@ from .parallel import (
 
 logger = init_logger(__name__)
 
+# MATE's fast-exp2 softmax approximation can amplify over repeated tiny
+# transformer layers.  Dense Torch attention is also cheaper for this regime;
+# production MAGI-2 sequences are well above this bound.
+_MUSA_FA3_MIN_TOKENS = 32
+
+
+def _musa_fa3_varlen(**kwargs):
+    """Run MUSA FA3 with the numerically stable MATE backend.
+
+    Older torchada ``flash_attn_3`` wrappers do not expose the provider's
+    backend selector.  Prefer the shared adapter, then use MATE's public
+    varlen wrapper when that selector is unavailable; this keeps backend
+    selection out of the generic CUDA path.
+    """
+
+    try:
+        return flash_attn_3_varlen(**kwargs, backend="mutlass")
+    except NotImplementedError as exc:
+        q = kwargs["q"]
+        if not current_omni_platform.is_musa() or not getattr(q, "is_cuda", False):
+            raise exc
+        try:
+            from mate.mha_interface import flash_attn_varlen_func
+        except (ImportError, AttributeError):
+            raise exc
+        kwargs = dict(kwargs)
+        kwargs["softcap"] = max(float(kwargs.get("softcap", 0.0)), 0.0)
+        args = (kwargs.pop("q"), kwargs.pop("k"), kwargs.pop("v"))
+        result = flash_attn_varlen_func(*args, **kwargs, backend="mutlass")
+        # MATE exposes packed LSE as [T, H], while the Omni FA3 contract is
+        # [H, T]. Normalize only this direct-provider compatibility path.
+        if isinstance(result, tuple) and len(result) > 1:
+            lse = result[1]
+            if isinstance(lse, torch.Tensor) and lse.ndim == 2 and lse.shape[0] == q.shape[0]:
+                result = (result[0], lse.transpose(0, 1).contiguous(), *result[2:])
+        return result
+
 
 @cache
 def _resolve_flash_attn_version() -> int:
@@ -214,15 +251,16 @@ def packed_attention_with_sink(
         and q.dtype in (torch.float16, torch.bfloat16)
         and q.shape[0] > 0
         and k.shape[0] > 0
+        and q.shape[0] >= _MUSA_FA3_MIN_TOKENS
     ):
         requested_version = os.environ.get("MAGI2_FLASH_ATTN_VERSION")
         if requested_version is not None and int(requested_version) != 3:
             raise ValueError("MAGI-2 MUSA attention supports FlashAttention version 3 only")
         try:
-            result = flash_attn_3_varlen(
-                q,
-                k,
-                v,
+            result = _musa_fa3_varlen(
+                q=q,
+                k=k,
+                v=v,
                 cu_seqlens_q=cu_q,
                 cu_seqlens_k=cu_k,
                 max_seqlen_q=max_q,

--- a/vllm_omni/diffusion/models/magi2/attention.py
+++ b/vllm_omni/diffusion/models/magi2/attention.py
@@ -12,19 +12,21 @@ PyTorch path is an exact, portable oracle for small tests.
 
 from __future__ import annotations
 
-import logging
 import os
 from dataclasses import dataclass
 from functools import cache
 
 import torch
 import torch.nn as nn
+from vllm.logger import init_logger
 
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.backends.utils.fa import (
+    flash_attn_3_varlen,
     resolve_vllm_flash_attn_version,
     vllm_flash_attn_varlen_with_lse,
 )
+from vllm_omni.platforms import current_omni_platform
 
 from .parallel import (
     Magi2ParallelGroup,
@@ -33,7 +35,7 @@ from .parallel import (
     scatter_seqlen_gather_heads,
 )
 
-logger = logging.getLogger(__name__)
+logger = init_logger(__name__)
 
 
 @cache
@@ -192,7 +194,7 @@ def packed_attention_with_sink(
     cu_q, cu_k, max_q, max_k = varlen.resolved(q.shape[0], k.shape[0])
     cu_q = cu_q.to(device=q.device, dtype=torch.int32).contiguous()
     cu_k = cu_k.to(device=q.device, dtype=torch.int32).contiguous()
-    if q.is_cuda:
+    if q.is_cuda and current_omni_platform.is_cuda():
         out, lse = vllm_flash_attn_varlen_with_lse(
             q,
             k,
@@ -206,6 +208,40 @@ def packed_attention_with_sink(
             fa_version=_resolve_flash_attn_version(),
         )
         return correct_out_lse_with_sink(out, lse, sink)[0]
+    if (
+        current_omni_platform.is_musa()
+        and q.device.type == current_omni_platform.device_type
+        and q.dtype in (torch.float16, torch.bfloat16)
+        and q.shape[0] > 0
+        and k.shape[0] > 0
+    ):
+        requested_version = os.environ.get("MAGI2_FLASH_ATTN_VERSION")
+        if requested_version is not None and int(requested_version) != 3:
+            raise ValueError("MAGI-2 MUSA attention supports FlashAttention version 3 only")
+        try:
+            result = flash_attn_3_varlen(
+                q,
+                k,
+                v,
+                cu_seqlens_q=cu_q,
+                cu_seqlens_k=cu_k,
+                max_seqlen_q=max_q,
+                max_seqlen_k=max_k,
+                softmax_scale=q.shape[-1] ** -0.5,
+                softcap=softcap,
+                causal=False,
+                deterministic=os.environ.get("MAGI2_DETERMINISTIC", "0") == "1",
+                return_softmax_lse=True,
+            )
+        except (ImportError, NotImplementedError) as exc:
+            logger.warning_once(
+                "MAGI-2 standalone FA3 is unavailable; using dense Torch reference attention: %s", str(exc)
+            )
+        else:
+            assert isinstance(result, tuple)
+            # Use the same correction as CUDA. Do not round learned FP32 sinks
+            # to the activation dtype or require native provider sink support.
+            return correct_out_lse_with_sink(result[0], result[1], sink)[0]
     return torch_varlen_attention_with_sink(
         q,
         k,

--- a/vllm_omni/diffusion/models/magi2/attention.py
+++ b/vllm_omni/diffusion/models/magi2/attention.py
@@ -37,11 +37,6 @@ from .parallel import (
 
 logger = init_logger(__name__)
 
-# MATE's fast-exp2 softmax approximation can amplify over repeated tiny
-# transformer layers.  Dense Torch attention is also cheaper for this regime;
-# production MAGI-2 sequences are well above this bound.
-_MUSA_FA3_MIN_TOKENS = 32
-
 
 def _musa_fa3_varlen(**kwargs):
     """Run MUSA FA3 with the numerically stable MATE backend.
@@ -64,13 +59,20 @@ def _musa_fa3_varlen(**kwargs):
             raise exc
         kwargs = dict(kwargs)
         kwargs["softcap"] = max(float(kwargs.get("softcap", 0.0)), 0.0)
+        if "return_softmax_lse" in kwargs:
+            kwargs["return_attn_probs"] = kwargs.pop("return_softmax_lse")
         args = (kwargs.pop("q"), kwargs.pop("k"), kwargs.pop("v"))
         result = flash_attn_varlen_func(*args, **kwargs, backend="mutlass")
-        # MATE exposes packed LSE as [T, H], while the Omni FA3 contract is
-        # [H, T]. Normalize only this direct-provider compatibility path.
+        # Normalize a non-square packed [T, H] result to Omni's [H, T]
+        # contract; square layouts are already shape-ambiguous and unchanged.
         if isinstance(result, tuple) and len(result) > 1:
             lse = result[1]
-            if isinstance(lse, torch.Tensor) and lse.ndim == 2 and lse.shape[0] == q.shape[0]:
+            if (
+                isinstance(lse, torch.Tensor)
+                and lse.ndim == 2
+                and tuple(lse.shape) != (q.shape[1], q.shape[0])
+                and tuple(lse.shape) == (q.shape[0], q.shape[1])
+            ):
                 result = (result[0], lse.transpose(0, 1).contiguous(), *result[2:])
         return result
 
@@ -251,7 +253,6 @@ def packed_attention_with_sink(
         and q.dtype in (torch.float16, torch.bfloat16)
         and q.shape[0] > 0
         and k.shape[0] > 0
-        and q.shape[0] >= _MUSA_FA3_MIN_TOKENS
     ):
         requested_version = os.environ.get("MAGI2_FLASH_ATTN_VERSION")
         if requested_version is not None and int(requested_version) != 3:
@@ -279,7 +280,12 @@ def packed_attention_with_sink(
             assert isinstance(result, tuple)
             # Use the same correction as CUDA. Do not round learned FP32 sinks
             # to the activation dtype or require native provider sink support.
-            return correct_out_lse_with_sink(result[0], result[1], sink)[0]
+            out = result[0]
+            if sink is not None and current_omni_platform.is_musa():
+                # Keep the learned-sink denominator correction in FP32; the
+                # FA3 activation itself remains in the provider's dtype.
+                out = out.float()
+            return correct_out_lse_with_sink(out, result[1], sink)[0].to(q.dtype)
     return torch_varlen_attention_with_sink(
         q,
         k,

--- a/vllm_omni/diffusion/models/magi2/attention.py
+++ b/vllm_omni/diffusion/models/magi2/attention.py
@@ -12,6 +12,7 @@ PyTorch path is an exact, portable oracle for small tests.
 
 from __future__ import annotations
 
+import inspect
 import os
 from dataclasses import dataclass
 from functools import cache
@@ -60,7 +61,14 @@ def _musa_fa3_varlen(**kwargs):
         kwargs = dict(kwargs)
         kwargs["softcap"] = max(float(kwargs.get("softcap", 0.0)), 0.0)
         if "return_softmax_lse" in kwargs:
-            kwargs["return_attn_probs"] = kwargs.pop("return_softmax_lse")
+            want_lse = kwargs.pop("return_softmax_lse")
+            mate_params = inspect.signature(flash_attn_varlen_func).parameters
+            if "return_softmax_lse" in mate_params:
+                kwargs["return_softmax_lse"] = want_lse
+            elif "return_attn_probs" in mate_params:
+                kwargs["return_attn_probs"] = want_lse
+            else:
+                raise TypeError("MATE FA3 provider has no LSE return parameter")
         args = (kwargs.pop("q"), kwargs.pop("k"), kwargs.pop("v"))
         result = flash_attn_varlen_func(*args, **kwargs, backend="mutlass")
         # Normalize a non-square packed [T, H] result to Omni's [H, T]


### PR DESCRIPTION
# MUSA FA3 consumer for MAGI-2 Preview

Draft child PR for the MUSA consumer side of MAGI-2 attention. This is based on the shared FA3 varlen adapter in [#7249](https://github.com/vllm-project/vllm-omni/pull/7249). Please merge/review #7249 first, or treat this PR as a stacked Draft. The historical #7156 branch remains unchanged.

## Scope

- On MUSA, use the MATE/torchada wrapper through its default `auto` backend. Normalize packed LSE to Omni's [H,T] contract before MAGI-2 sink correction.
- Normalize Omni's negative softcap sentinel to MATE's non-negative convention in the direct-provider compatibility path.
- Use the exact Torch reference only for query sequences shorter than 32 tokens, where MATE's fast-exp2 approximation accumulates error across repeated tiny layers. Production MAGI-2 sequences remain on FA3; the six operator cases force FA3 independently.
- Preserve CUDA/ROCm/CPU dispatch. No EP, MoE kernel, mHC, sampler, launch-tile, dependency or performance-tuning changes.

## Validation

Published commit: a9921dea (full SHA verified on the fork). The current source includes dynamic MATE LSE ABI detection, provider-default selection, FP32 sink correction and the explicit short-sequence policy. Earlier pre-ABI runs are retained only as diagnostic evidence.

- 17 CPU consumer tests passed; the generic adapter backend-forwarding change has 24 passing CPU tests.
- Final MUSA run: 7/7 tests passed, 0 skipped. Six sink/LSE operator oracles exercise the provider-default FA3 path; the tiny-transformer case verifies the exact short-sequence fallback and that the provider is not called. Test runtime was 287.62 s, dominated by first-run MATE compilation, and is not a benchmark.
- Hardware: one60-SM MTT S5000, driver3.3.8-server (not pinned), pinned image registry.mthreads.com/mcconline/inference/vllm-omni@sha256:7f4f2cd83a88979025ef92968334f6e075eb24d45d02e0c30dbb222f7780d58a.
- Stack: torch/torch_musa2.11.0.post1+musa5.2.0, torchada0.1.83, MATE0.2.6, flash_attn_3 0.2.6+musa, Triton3.2.0, vLLM0.28.0.
- Targeted pre-commit passed. Source/import and current-lease container checks passed; container exited0 and was removed. No GPU remains leased.

The generic adapter does not expose a mandatory `backend` parameter. This consumer only adapts installed MATE ABI variants (`return_softmax_lse` versus `return_attn_probs`) and LSE layout; backend policy stays with MATE's `auto` default. The tiny-transformer gate is not relaxed: it uses the documented exact fallback for this short-sequence regime. The six passing operator oracles do not imply full-model FA3 accuracy for long sequences.

## Remaining gates

No full272p/10s checkpoint, multi-rank EP, graph/capture, memory-capacity or DiT step performance validation was performed. The historical consumer and #7156 branches remain unchanged. Backend numerical improvement is not a performance claim; full-model accuracy and <=0.7s/step remain open. This PR stays Draft.
