### PR TITLE
[CI] Skip Qwen3-Omni Server VAD multi-turn realtime test (#7279)

### DIFF
--- a/tests/entrypoints/openai_api/test_qwen3_omni_realtime_websocket.py
+++ b/tests/entrypoints/openai_api/test_qwen3_omni_realtime_websocket.py
@@ -408,6 +408,7 @@ class TestQwen3OmniRealtimeWebSocket:
     @pytest.mark.omni
     @hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=2)
     @pytest.mark.parametrize("omni_server", realtime_server_vad_server_params, indirect=True)
+    @pytest.mark.skip(reason="https://github.com/vllm-project/vllm-omni/issues/7279")
     def test_server_vad_multi_turn_without_client_commit(
         self,
         cached_silero_vad_artifact: str,


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Skip Merge CI Entrypoint Test case `test_server_vad_multi_turn_without_client_commit[server_vad]` until Server VAD can queue a second committed turn while the first response is still active.

Today the second turn is rejected with `rate_limit_error` / `input_backpressure` (`Only one committed Server VAD turn may wait for the active response`), which fails Merge CI.

Related to #7279 (skip only; does not fix the underlying queueing bug).

## Test Plan

No new tests. This PR only marks the known-failing case with `@pytest.mark.skip`.

Confirm collection still finds the case and applies the skip:

```bash
pytest -s -v tests/entrypoints/openai_api/test_qwen3_omni_realtime_websocket.py::TestQwen3OmniRealtimeWebSocket::test_server_vad_multi_turn_without_client_commit -m "advanced_model and omni" --run-level "advanced_model" --collect-only
```

CI-like Merge Entrypoint command (the skipped case should not fail the job):

```bash
pytest -s -v tests/entrypoints/openai_api/test_qwen3_omni_realtime_websocket.py -m "advanced_model and omni" --run-level "advanced_model"
```

**vLLM Version:** N/A (test skip only)

**vLLM-Omni Commit:** e06d75936

## Test Result

Not run locally (requires CUDA H100 ×2 and Silero VAD artifacts). Pending Buildkite Merge **Entrypoint Test with H100**.

Expected: `test_server_vad_multi_turn_without_client_commit[server_vad]` is SKIPPED with reason https://github.com/vllm-project/vllm-omni/issues/7279.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
