### PR TITLE
[Bugfix][Frontend] Preserve duplex chat audio format and duration

### DIFF
--- a/docs/serving/realtime_duplex_api.md
+++ b/docs/serving/realtime_duplex_api.md
@@ -381,6 +381,49 @@ Semantic divergences hidden behind shared names:
   the Tier 3 surface on top of the same Tier 1 events, so both kinds of
   client can share one deployment and one event log.
 
+### Turn-based Chat audio metadata
+
+For turn-based models served through Chat fallback, non-empty audio choices
+produced by the Omni Chat audio encoder include `audio_metadata`, in both
+streaming and complete Chat responses. Text-only choices do not require it.
+
+| Field | Meaning |
+| --- | --- |
+| `format` | Encoding of the returned audio, such as `pcm` or `wav`; `pcm16` requests normalize to `pcm`. |
+| `sample_rate_hz` | Sample rate used by the encoder, in samples per second. |
+| `frame_count` | Samples per channel in this chunk, or in the complete waveform for a non-streaming choice. Not a byte count. |
+| `channels` | Number of audio channels. |
+
+These values describe the waveform after audio transformations. Compressed
+formats may add codec padding that is not included in `frame_count`.
+The encoder uses a model-reported sample rate when available; Qwen3-Omni
+currently omits it and uses the existing 24 kHz default. This metadata does
+not independently determine a model's sample rate.
+
+Chat fallback requests the session's output format explicitly. Its internal
+`response.output_audio.delta` carries `format`, `sample_rate_hz`, `channels`,
+and `audio_duration_ms`. The Realtime endpoint exposes output `format` and
+`sample_rate_hz` on `response.audio.delta`, with duration in
+`metadata.audio_duration_ms`; it does not currently forward `channels`.
+The duration is cumulative for the response:
+integer frames are summed before converting to milliseconds and rounding down.
+Non-empty audio without valid metadata, or a sample-rate change within one
+response, fails that fallback response with `response_error`.
+
+In this Chat fallback path, `response.done.response.metadata.playback` reports:
+
+- `generated_ms`: cumulative source-waveform duration.
+- `sent_ms`: cumulative audio accepted into the server output path, including
+  queued or journaled audio. A journaled event remains accepted if the
+  subsequent send fails; this is not proof of socket delivery.
+- `played_ms`: cumulative playback reported by the client.
+- `committed_ms`: playback position used for history reconciliation.
+
+The native model path still records audio before sending; it does not yet
+share Chat fallback's output-acceptance timing. Only client playback reports
+establish what was played. The existing duration-proportional text truncation
+remains an approximation, not word-level audio alignment.
+
 ### Event catalogue
 
 Every event type the Realtime route accepts or emits, with a worked example in the next section: 21

--- a/tests/entrypoints/openai/test_duplex_protocol.py
+++ b/tests/entrypoints/openai/test_duplex_protocol.py
@@ -462,6 +462,54 @@ def test_duplex_playback_ack_tracks_committed_cursor_separately():
     assert session.playback.committed_ms == 2_000
 
 
+@pytest.mark.parametrize("sample_rate_hz,frame_count", [(22_050, 23), (24_000, 24)])
+def test_duplex_generated_audio_rounds_only_cumulative_frames(sample_rate_hz: int, frame_count: int):
+    session = DuplexSessionRegistry().create()
+    response_id = session.begin_response()
+
+    durations = [
+        session.record_generated_audio(response_id, frame_count=1, sample_rate_hz=sample_rate_hz)
+        for _ in range(frame_count)
+    ]
+
+    assert durations[:-1] == [0] * (frame_count - 1)
+    assert durations[-1] == 1
+    assert session.playback.generated_ms == 1
+    assert session.playback.sent_ms == 0
+    assert session.playback.played_ms == 0
+
+
+def test_duplex_generated_audio_rejects_rate_change_without_advancing():
+    session = DuplexSessionRegistry().create()
+    response_id = session.begin_response()
+    session.record_generated_audio(response_id, frame_count=2205, sample_rate_hz=22_050)
+
+    with pytest.raises(ValueError, match="sample rate changed"):
+        session.record_generated_audio(response_id, frame_count=2400, sample_rate_hz=24_000)
+
+    assert session.playback.generated_ms == 100
+    assert session.playback.sent_ms == 0
+
+
+def test_duplex_late_audio_accounting_cannot_change_new_response():
+    session = DuplexSessionRegistry().create()
+    old_response = session.begin_response()
+    session.record_generated_audio(old_response, frame_count=2205, sample_rate_hz=22_050)
+    session.barge_in()
+    new_response = session.begin_response()
+    session.record_generated_audio(new_response, frame_count=2400, sample_rate_hz=48_000)
+    current_state = session.turn_state
+
+    assert session.record_generated_audio(old_response, frame_count=2205, sample_rate_hz=22_050) is None
+    session.mark_audio_sent(100, response_id=old_response, text_chars=99)
+
+    assert session.playback_for_response(old_response).sent_ms == 100
+    assert session.playback.generated_ms == 50
+    assert session.playback.sent_ms == 0
+    assert session.assistant_audio_text_marks == ()
+    assert session.turn_state == current_state
+
+
 def test_duplex_history_commit_uses_audio_text_alignment_marks():
     registry = DuplexSessionRegistry()
     session = registry.create()

--- a/tests/entrypoints/openai/test_duplex_session_attachment.py
+++ b/tests/entrypoints/openai/test_duplex_session_attachment.py
@@ -123,22 +123,27 @@ def test_event_journal_overflow_is_explicit_and_does_not_evict_silently() -> Non
 
 
 @pytest.mark.asyncio
-async def test_registry_accepts_journaled_event_before_transport_failure(mocker) -> None:
+@pytest.mark.parametrize("journal", [False, True])
+async def test_registry_failed_send_is_accepted_only_when_journaled(mocker, journal: bool) -> None:
     registry = DuplexSessionAttachmentRegistry(replay_ttl_s=60.0, replay_max_bytes_per_session=4096)
     accepted = mocker.Mock()
+    expected_calls = [mocker.call()] if journal else []
 
     async def failing_send(payload):
-        accepted.assert_called_once_with()
+        assert accepted.call_args_list == expected_calls
         raise RuntimeError("transport lost")
 
-    await registry.create("sid-accepted-failure", incarnation=0, send=failing_send, close=mocker.AsyncMock())
+    await registry.create("sid-send-failure", incarnation=0, send=failing_send, close=mocker.AsyncMock())
 
     with pytest.raises(RuntimeError, match="transport lost"):
         await registry.send_event(
-            "sid-accepted-failure", {"type": "response.audio.delta", "delta": "AAAA"}, on_accepted=accepted
+            "sid-send-failure",
+            {"type": "response.audio.delta", "delta": "AAAA"},
+            journal=journal,
+            on_accepted=accepted,
         )
 
-    accepted.assert_called_once_with()
+    assert accepted.call_args_list == expected_calls
 
 
 @pytest.mark.asyncio
@@ -181,24 +186,6 @@ async def test_registry_unjournaled_event_is_accepted_after_successful_send(mock
 
     assert entry is None
     accepted.assert_called_once_with()
-
-
-@pytest.mark.asyncio
-async def test_registry_unjournaled_failed_send_is_not_accepted(mocker) -> None:
-    registry = DuplexSessionAttachmentRegistry(replay_ttl_s=60.0, replay_max_bytes_per_session=4096)
-    accepted = mocker.Mock()
-    send = mocker.AsyncMock(side_effect=RuntimeError("transport lost"))
-    await registry.create("sid-live-failure", incarnation=0, send=send, close=mocker.AsyncMock())
-
-    with pytest.raises(RuntimeError, match="transport lost"):
-        await registry.send_event(
-            "sid-live-failure",
-            {"type": "response.audio.delta", "delta": "AAAA"},
-            journal=False,
-            on_accepted=accepted,
-        )
-
-    accepted.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/openai/test_duplex_session_attachment.py
+++ b/tests/entrypoints/openai/test_duplex_session_attachment.py
@@ -123,6 +123,103 @@ def test_event_journal_overflow_is_explicit_and_does_not_evict_silently() -> Non
 
 
 @pytest.mark.asyncio
+async def test_registry_accepts_journaled_event_before_transport_failure(mocker) -> None:
+    registry = DuplexSessionAttachmentRegistry(replay_ttl_s=60.0, replay_max_bytes_per_session=4096)
+    accepted = mocker.Mock()
+
+    async def failing_send(payload):
+        accepted.assert_called_once_with()
+        raise RuntimeError("transport lost")
+
+    await registry.create("sid-accepted-failure", incarnation=0, send=failing_send, close=mocker.AsyncMock())
+
+    with pytest.raises(RuntimeError, match="transport lost"):
+        await registry.send_event(
+            "sid-accepted-failure", {"type": "response.audio.delta", "delta": "AAAA"}, on_accepted=accepted
+        )
+
+    accepted.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("journal", [False, True])
+async def test_registry_detached_event_is_accepted_only_when_journaled(mocker, journal: bool) -> None:
+    registry = DuplexSessionAttachmentRegistry(replay_ttl_s=60.0, replay_max_bytes_per_session=4096)
+    send = mocker.AsyncMock()
+    accepted = mocker.Mock()
+    created = await registry.create("sid-detached-acceptance", incarnation=0, send=send, close=mocker.AsyncMock())
+    await registry.detach("sid-detached-acceptance", attachment_generation=created.attachment_generation)
+
+    entry = await registry.send_event(
+        "sid-detached-acceptance",
+        {"type": "response.audio.delta", "delta": "AAAA"},
+        journal=journal,
+        on_accepted=accepted,
+    )
+
+    send.assert_not_awaited()
+    assert (entry is not None) is journal
+    assert accepted.call_count == int(journal)
+
+
+@pytest.mark.asyncio
+async def test_registry_unjournaled_event_is_accepted_after_successful_send(mocker) -> None:
+    registry = DuplexSessionAttachmentRegistry(replay_ttl_s=60.0, replay_max_bytes_per_session=4096)
+    accepted = mocker.Mock()
+
+    async def send(payload):
+        accepted.assert_not_called()
+
+    await registry.create("sid-live-acceptance", incarnation=0, send=send, close=mocker.AsyncMock())
+
+    entry = await registry.send_event(
+        "sid-live-acceptance",
+        {"type": "response.audio.delta", "delta": "AAAA"},
+        journal=False,
+        on_accepted=accepted,
+    )
+
+    assert entry is None
+    accepted.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_registry_unjournaled_failed_send_is_not_accepted(mocker) -> None:
+    registry = DuplexSessionAttachmentRegistry(replay_ttl_s=60.0, replay_max_bytes_per_session=4096)
+    accepted = mocker.Mock()
+    send = mocker.AsyncMock(side_effect=RuntimeError("transport lost"))
+    await registry.create("sid-live-failure", incarnation=0, send=send, close=mocker.AsyncMock())
+
+    with pytest.raises(RuntimeError, match="transport lost"):
+        await registry.send_event(
+            "sid-live-failure",
+            {"type": "response.audio.delta", "delta": "AAAA"},
+            journal=False,
+            on_accepted=accepted,
+        )
+
+    accepted.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_registry_overflow_does_not_accept_or_send_event(mocker) -> None:
+    registry = DuplexSessionAttachmentRegistry(replay_ttl_s=60.0, replay_max_bytes_per_session=100)
+    accepted = mocker.Mock()
+    send = mocker.AsyncMock()
+    await registry.create("sid-overflow-acceptance", incarnation=0, send=send, close=mocker.AsyncMock())
+
+    with pytest.raises(DuplexJournalOverflowError, match="byte limit"):
+        await registry.send_event(
+            "sid-overflow-acceptance",
+            {"type": "response.audio.delta", "delta": "A" * 200},
+            on_accepted=accepted,
+        )
+
+    accepted.assert_not_called()
+    send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_registry_resume_rotates_token_replays_and_atomically_replaces_attachment() -> None:
     clock = _Clock()
     registry = DuplexSessionAttachmentRegistry(

--- a/tests/entrypoints/openai_api/test_audio_format.py
+++ b/tests/entrypoints/openai_api/test_audio_format.py
@@ -12,7 +12,10 @@ Covers:
 
 from __future__ import annotations
 
+import base64
+import json
 from io import BytesIO
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -65,6 +68,13 @@ class TestCreateAudio:
         )
         response = mixin.create_audio(audio_obj)
         assert len(response.audio_data) > 0
+        assert response.audio_metadata is not None
+        assert response.audio_metadata.model_dump() == {
+            "format": fmt,
+            "sample_rate_hz": 24000,
+            "frame_count": 24000,
+            "channels": 1,
+        }
 
     def test_wav_magic_bytes(self, mixin, audio_tensor):
         audio_obj = CreateAudio(
@@ -113,10 +123,9 @@ class TestCreateAudio:
         response = mixin.create_audio(audio_obj)
         assert response.audio_data[:4] == b"RIFF"
         assert response.media_type == "audio/wav"
+        assert response.audio_metadata.format == "wav"
 
     def test_base64_encoding(self, mixin, audio_tensor):
-        import base64
-
         audio_obj = CreateAudio(
             audio_tensor=audio_tensor,
             sample_rate=24000,
@@ -143,6 +152,30 @@ class TestCreateAudio:
         with soundfile.SoundFile(BytesIO(response.audio_data)) as audio_file:
             assert audio_file.samplerate == 8000
             assert audio_file.frames == 8000
+            assert response.audio_metadata.sample_rate_hz == audio_file.samplerate
+            assert response.audio_metadata.frame_count == audio_file.frames
+
+    def test_metadata_matches_transformed_stereo_waveform(self, mixin, audio_tensor):
+        response = mixin.create_audio(
+            CreateAudio(
+                audio_tensor=np.stack((audio_tensor, audio_tensor)),
+                sample_rate=24000,
+                output_sample_rate=8000,
+                response_format="wav",
+                speed=2.0,
+                base64_encode=False,
+            )
+        )
+
+        with soundfile.SoundFile(BytesIO(response.audio_data)) as audio_file:
+            assert audio_file.frames == 4000
+            assert response.audio_metadata.model_dump() == {
+                "format": "wav",
+                "sample_rate_hz": audio_file.samplerate,
+                "frame_count": audio_file.frames,
+                "channels": audio_file.channels,
+            }
+            assert audio_file.channels == 2
 
 
 class TestStreamingAudioResampler:
@@ -262,3 +295,58 @@ class TestResolveAudioFormat:
             request = self._make_request({"format": fmt, "voice": "alloy"})
             result = serving_chat._resolve_audio_format(request)
             assert not isinstance(result, ErrorResponse), f"Format {fmt} should be accepted"
+
+
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("fmt", ["pcm", "wav"])
+def test_chat_audio_metadata_survives_response_serialization(stream, fmt):
+    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+    from vllm.entrypoints.openai.engine.protocol import ErrorResponse, UsageInfo
+
+    from vllm_omni.entrypoints.openai.protocol.chat_completion import (
+        OmniChatCompletionResponse,
+        OmniChatCompletionStreamResponse,
+    )
+    from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
+
+    serving_chat = object.__new__(OmniOpenAIServingChat)
+    output = SimpleNamespace(
+        index=0,
+        multimodal_output={"audio": [torch.zeros(17), torch.zeros(23)], "sr": torch.tensor(22050)},
+        finish_reason="stop",
+        stop_reason=None,
+        token_ids=[],
+    )
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "hello"}],
+        audio={"format": fmt, "voice": "alloy"},
+    )
+    choices = serving_chat._create_audio_choice(SimpleNamespace(outputs=[output]), "assistant", request, stream=stream)
+    assert not isinstance(choices, ErrorResponse)
+    response_type = OmniChatCompletionStreamResponse if stream else OmniChatCompletionResponse
+    response = response_type(
+        id="chatcmpl-audio-metadata",
+        created=0,
+        model="test-model",
+        choices=choices,
+        usage=UsageInfo(prompt_tokens=0, completion_tokens=0, total_tokens=0),
+    )
+
+    serialized = json.loads(response.model_dump_json(exclude_unset=True))
+    choice = serialized["choices"][0]
+    frame_count = 23 if stream else 40
+    assert choice["audio_metadata"] == {
+        "format": fmt,
+        "sample_rate_hz": 22050,
+        "frame_count": frame_count,
+        "channels": 1,
+    }
+    audio = choice["delta"]["content"] if stream else choice["message"]["audio"]["data"]
+    raw = base64.b64decode(audio)
+    if fmt == "wav":
+        with soundfile.SoundFile(BytesIO(raw)) as audio_file:
+            assert audio_file.frames == frame_count
+            assert audio_file.samplerate == 22050
+    else:
+        assert len(raw) == frame_count * 2

--- a/tests/entrypoints/openai_api/test_audio_format.py
+++ b/tests/entrypoints/openai_api/test_audio_format.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import base64
 import json
 from io import BytesIO
-from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -30,6 +29,8 @@ from vllm_omni.entrypoints.openai.protocol.audio import (
     SUPPORTED_CHAT_AUDIO_FORMATS,
     CreateAudio,
 )
+from vllm_omni.outputs import OmniRequestOutput
+from vllm_omni.outputs.mm_outputs import MultimodalCompletionOutput, MultimodalPayload
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -298,19 +299,26 @@ def test_chat_audio_metadata_survives_response_serialization(stream, fmt):
     from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
 
     serving_chat = object.__new__(OmniOpenAIServingChat)
-    output = SimpleNamespace(
+    output = MultimodalCompletionOutput(
         index=0,
-        multimodal_output={"audio": [torch.zeros(17), torch.zeros(23)], "sr": torch.tensor(22050)},
+        text="",
+        token_ids=[],
+        cumulative_logprob=None,
+        logprobs=None,
+        multimodal_output=MultimodalPayload.from_dict(
+            {"audio": [torch.zeros(17), torch.zeros(23)], "sr": torch.tensor(22050)}
+        ),
         finish_reason="stop",
         stop_reason=None,
-        token_ids=[],
     )
     request = ChatCompletionRequest(
         model="test-model",
         messages=[{"role": "user", "content": "hello"}],
         audio={"format": fmt, "voice": "alloy"},
     )
-    choices = serving_chat._create_audio_choice(SimpleNamespace(outputs=[output]), "assistant", request, stream=stream)
+    choices = serving_chat._create_audio_choice(
+        OmniRequestOutput(outputs=[output], final_output_type="audio"), "assistant", request, stream=stream
+    )
     assert not isinstance(choices, ErrorResponse)
     response_type = OmniChatCompletionStreamResponse if stream else OmniChatCompletionResponse
     response = response_type(

--- a/tests/entrypoints/openai_api/test_audio_format.py
+++ b/tests/entrypoints/openai_api/test_audio_format.py
@@ -137,45 +137,33 @@ class TestCreateAudio:
         decoded = base64.b64decode(response.audio_data)
         assert decoded[:4] == b"RIFF"
 
-    def test_resamples_wav_to_requested_output_rate(self, mixin, audio_tensor):
+    @pytest.mark.parametrize(
+        "channels,speed,frame_count",
+        [(1, 1.0, 8000), (2, 2.0, 4000)],
+        ids=["mono-resampled", "stereo-resampled-faster"],
+    )
+    def test_metadata_matches_transformed_waveform(self, mixin, audio_tensor, channels, speed, frame_count):
         response = mixin.create_audio(
             CreateAudio(
-                audio_tensor=audio_tensor,
+                audio_tensor=audio_tensor if channels == 1 else np.stack((audio_tensor, audio_tensor)),
                 sample_rate=24000,
                 output_sample_rate=8000,
                 response_format="wav",
-                speed=1.0,
+                speed=speed,
                 base64_encode=False,
             )
         )
 
         with soundfile.SoundFile(BytesIO(response.audio_data)) as audio_file:
             assert audio_file.samplerate == 8000
-            assert audio_file.frames == 8000
-            assert response.audio_metadata.sample_rate_hz == audio_file.samplerate
-            assert response.audio_metadata.frame_count == audio_file.frames
-
-    def test_metadata_matches_transformed_stereo_waveform(self, mixin, audio_tensor):
-        response = mixin.create_audio(
-            CreateAudio(
-                audio_tensor=np.stack((audio_tensor, audio_tensor)),
-                sample_rate=24000,
-                output_sample_rate=8000,
-                response_format="wav",
-                speed=2.0,
-                base64_encode=False,
-            )
-        )
-
-        with soundfile.SoundFile(BytesIO(response.audio_data)) as audio_file:
-            assert audio_file.frames == 4000
+            assert audio_file.frames == frame_count
+            assert audio_file.channels == channels
             assert response.audio_metadata.model_dump() == {
                 "format": "wav",
                 "sample_rate_hz": audio_file.samplerate,
                 "frame_count": audio_file.frames,
                 "channels": audio_file.channels,
             }
-            assert audio_file.channels == 2
 
 
 class TestStreamingAudioResampler:

--- a/tests/entrypoints/openai_api/test_duplex_handler.py
+++ b/tests/entrypoints/openai_api/test_duplex_handler.py
@@ -9,6 +9,7 @@ import io
 import json
 import struct
 import wave
+from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any
 
@@ -5024,9 +5025,10 @@ async def test_duplex_chat_audio_stream_uses_output_audio_delta_event():
     response_id = session.begin_response()
     sent: list[dict[str, Any]] = []
 
-    async def send_json(data: dict[str, Any]) -> bool:
+    async def send_json(data: dict[str, Any], *, on_accepted: Callable[[], None] | None = None) -> None:
         sent.append(data)
-        return True
+        if on_accepted is not None:
+            on_accepted()
 
     await handler._emit_chat_payload(
         session,
@@ -5117,9 +5119,10 @@ async def test_duplex_chat_full_audio_message_preserves_actual_format_and_durati
     response_id = session.begin_response()
     sent: list[dict[str, object]] = []
 
-    async def send_json(data: dict[str, object]) -> bool:
+    async def send_json(data: dict[str, object], *, on_accepted: Callable[[], None] | None = None) -> None:
         sent.append(data)
-        return True
+        if on_accepted is not None:
+            on_accepted()
 
     await handler._emit_chat_payload(
         session,
@@ -5161,9 +5164,10 @@ async def test_duplex_chat_audio_does_not_round_each_fragment():
     response_id = session.begin_response()
     sent: list[dict[str, object]] = []
 
-    async def send_json(data: dict[str, object]) -> bool:
+    async def send_json(data: dict[str, object], *, on_accepted: Callable[[], None] | None = None) -> None:
         sent.append(data)
-        return True
+        if on_accepted is not None:
+            on_accepted()
 
     for _ in range(23):
         await handler._emit_chat_payload(
@@ -5189,8 +5193,8 @@ async def test_duplex_chat_rejected_audio_is_generated_but_not_sent():
     session = DuplexSession(session_id="sid-chat-rejected-audio", config=DuplexSessionConfig())
     response_id = session.begin_response()
 
-    async def reject(data: dict[str, object]) -> bool:
-        return False
+    async def reject(data: dict[str, object], *, on_accepted: Callable[[], None] | None = None) -> None:
+        pass
 
     await handler._emit_chat_payload(session, _chat_audio_completion_payload(), session.epoch, response_id, reject)
 
@@ -5209,7 +5213,7 @@ async def test_duplex_chat_failed_audio_send_does_not_advance_sent():
     session = DuplexSession(session_id="sid-chat-failed-audio", config=DuplexSessionConfig())
     response_id = session.begin_response()
 
-    async def fail_send(data: dict[str, object]) -> bool:
+    async def fail_send(data: dict[str, object], *, on_accepted: Callable[[], None] | None = None) -> None:
         raise RuntimeError("output unavailable")
 
     with pytest.raises(RuntimeError, match="output unavailable"):
@@ -5233,10 +5237,11 @@ async def test_duplex_chat_late_send_completion_only_updates_old_response():
     send_started = asyncio.Event()
     finish_send = asyncio.Event()
 
-    async def delayed_send(data: dict[str, object]) -> bool:
+    async def delayed_send(data: dict[str, object], *, on_accepted: Callable[[], None] | None = None) -> None:
         send_started.set()
         await finish_send.wait()
-        return True
+        assert on_accepted is not None
+        on_accepted()
 
     emit_task = asyncio.create_task(
         handler._emit_chat_payload(session, _chat_audio_completion_payload(), session.epoch, old_response, delayed_send)
@@ -5277,9 +5282,10 @@ async def test_duplex_chat_missing_audio_metadata_reports_error():
     session = DuplexSession(session_id="sid-chat-missing-metadata", config=DuplexSessionConfig())
     sent: list[dict[str, object]] = []
 
-    async def send_json(data: dict[str, object]) -> bool:
+    async def send_json(data: dict[str, object], *, on_accepted: Callable[[], None] | None = None) -> None:
         sent.append(data)
-        return True
+        if on_accepted is not None:
+            on_accepted()
 
     await handler._run_response(session, send_json)
 
@@ -5334,9 +5340,10 @@ async def test_duplex_chat_stage_metrics_use_latest_streaming_snapshot():
     )
     sent: list[dict[str, Any]] = []
 
-    async def send_json(data: dict[str, Any]) -> bool:
+    async def send_json(data: dict[str, Any], *, on_accepted: Callable[[], None] | None = None) -> None:
         sent.append(data)
-        return True
+        if on_accepted is not None:
+            on_accepted()
 
     await handler._run_response(session, send_json)
 

--- a/tests/entrypoints/openai_api/test_duplex_handler.py
+++ b/tests/entrypoints/openai_api/test_duplex_handler.py
@@ -5333,6 +5333,13 @@ async def test_duplex_chat_stage_metrics_use_latest_streaming_snapshot():
 
     audio_deltas = [event for event in sent if event.get("type") == "response.output_audio.delta"]
     done = next(event for event in sent if event.get("type") == "response.done")
+    assert [event["audio_duration_ms"] for event in audio_deltas] == [100, 200, 300]
+    assert done["playback"] == {
+        "generated_ms": 300,
+        "sent_ms": 300,
+        "played_ms": 0,
+        "committed_ms": 0,
+    }
     assert all("vllm_omni" not in event for event in audio_deltas)
     assert done["vllm_omni"]["stage_metrics"]["0"] == {
         "num_tokens_out": 3,

--- a/tests/entrypoints/openai_api/test_duplex_handler.py
+++ b/tests/entrypoints/openai_api/test_duplex_handler.py
@@ -2182,7 +2182,8 @@ async def test_minicpmo_native_session_update_rejects_native_duplex_mode_flip():
     assert "session.updated" not in ws.sent_types()
 
 
-def test_native_realtime_protocol_audio_delta_preserves_sample_rate_hz():
+@pytest.mark.parametrize("sample_rate_hz", [22_050, 24_000])
+def test_native_realtime_protocol_audio_delta_preserves_sample_rate_hz(sample_rate_hz: int):
     ws = TimedWebSocket()
     protocol = NativeRealtimeSessionProtocol(ws)  # type: ignore[arg-type]
 
@@ -2192,7 +2193,8 @@ def test_native_realtime_protocol_audio_delta_preserves_sample_rate_hz():
             "response_id": "resp-a",
             "audio": "AAAA",
             "format": "pcm",
-            "sample_rate_hz": 24000,
+            "sample_rate_hz": sample_rate_hz,
+            "audio_duration_ms": 135,
         }
     )
 
@@ -2201,7 +2203,8 @@ def test_native_realtime_protocol_audio_delta_preserves_sample_rate_hz():
     ]
     assert {payload["type"] for payload in audio_events} == {"response.audio.delta"}
     assert {payload["format"] for payload in audio_events} == {"pcm16"}
-    assert {payload["sample_rate_hz"] for payload in audio_events} == {24000}
+    assert {payload["sample_rate_hz"] for payload in audio_events} == {sample_rate_hz}
+    assert audio_events[0]["metadata"]["audio_duration_ms"] == 135
 
 
 def test_native_realtime_protocol_ignores_removed_legacy_event_switches():
@@ -5021,8 +5024,9 @@ async def test_duplex_chat_audio_stream_uses_output_audio_delta_event():
     response_id = session.begin_response()
     sent: list[dict[str, Any]] = []
 
-    async def send_json(data: dict[str, Any]) -> None:
+    async def send_json(data: dict[str, Any]) -> bool:
         sent.append(data)
+        return True
 
     await handler._emit_chat_payload(
         session,
@@ -5032,7 +5036,13 @@ async def test_duplex_chat_audio_stream_uses_output_audio_delta_event():
                 {
                     "delta": {
                         "content": "AAAA",
-                    }
+                    },
+                    "audio_metadata": {
+                        "format": "wav",
+                        "sample_rate_hz": 22_050,
+                        "frame_count": 2205,
+                        "channels": 1,
+                    },
                 }
             ],
         },
@@ -5049,8 +5059,235 @@ async def test_duplex_chat_audio_stream_uses_output_audio_delta_event():
             "epoch": 0,
             "audio": "AAAA",
             "format": "wav",
+            "sample_rate_hz": 22_050,
+            "channels": 1,
+            "audio_duration_ms": 100,
         }
     ]
+    assert session.playback.generated_ms == 100
+    assert session.playback.sent_ms == 100
+    assert session.playback.played_ms == 0
+
+
+@pytest.mark.parametrize("response_format", ["pcm", "wav"])
+def test_duplex_chat_request_uses_response_audio_format(response_format: str):
+    handler = OmniDuplexSessionHandler(
+        chat_service=TurnBasedFakeChatService(FakeEngineClient()),
+        config_timeout_s=0.1,
+        idle_timeout_s=1,
+    )
+    extra_audio = {"format": "flac", "voice": "alloy"}
+    session = DuplexSession(
+        session_id="sid-chat-audio-format",
+        config=DuplexSessionConfig(response_format=response_format, extra_body={"audio": extra_audio}),
+    )
+    session.begin_response()
+
+    request = handler._build_chat_request(session, "format-request")
+
+    assert request.audio == {"format": response_format, "voice": "alloy"}
+    assert extra_audio == {"format": "flac", "voice": "alloy"}
+
+
+def _chat_audio_completion_payload(*, frame_count: int = 2205, sample_rate_hz: int = 22_050) -> dict[str, object]:
+    return {
+        "modality": "audio",
+        "choices": [
+            {
+                "delta": {"content": "AAAA"},
+                "audio_metadata": {
+                    "format": "pcm",
+                    "sample_rate_hz": sample_rate_hz,
+                    "frame_count": frame_count,
+                    "channels": 1,
+                },
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_duplex_chat_full_audio_message_preserves_actual_format_and_duration():
+    handler = OmniDuplexSessionHandler(
+        chat_service=TurnBasedFakeChatService(FakeEngineClient()),
+        config_timeout_s=0.1,
+        idle_timeout_s=1,
+    )
+    session = DuplexSession(session_id="sid-chat-full-audio", config=DuplexSessionConfig(response_format="wav"))
+    response_id = session.begin_response()
+    sent: list[dict[str, object]] = []
+
+    async def send_json(data: dict[str, object]) -> bool:
+        sent.append(data)
+        return True
+
+    await handler._emit_chat_payload(
+        session,
+        {
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "hello", "audio": {"data": "AAAA"}},
+                    "audio_metadata": {
+                        "format": "pcm",
+                        "sample_rate_hz": 22_050,
+                        "frame_count": 2205,
+                        "channels": 1,
+                    },
+                }
+            ],
+        },
+        session.epoch,
+        response_id,
+        send_json,
+    )
+
+    assert [event["type"] for event in sent] == ["response.text.delta", "response.output_audio.delta"]
+    assert sent[1]["audio"] == "AAAA"
+    assert sent[1]["format"] == "pcm"
+    assert sent[1]["sample_rate_hz"] == 22_050
+    assert sent[1]["audio_duration_ms"] == 100
+    assert session.assistant_text_buffer == ("hello",)
+    assert session.playback.sent_ms == 100
+
+
+@pytest.mark.asyncio
+async def test_duplex_chat_audio_does_not_round_each_fragment():
+    handler = OmniDuplexSessionHandler(
+        chat_service=TurnBasedFakeChatService(FakeEngineClient()),
+        config_timeout_s=0.1,
+        idle_timeout_s=1,
+    )
+    session = DuplexSession(session_id="sid-chat-sub-ms", config=DuplexSessionConfig())
+    response_id = session.begin_response()
+    sent: list[dict[str, object]] = []
+
+    async def send_json(data: dict[str, object]) -> bool:
+        sent.append(data)
+        return True
+
+    for _ in range(23):
+        await handler._emit_chat_payload(
+            session,
+            _chat_audio_completion_payload(frame_count=1),
+            session.epoch,
+            response_id,
+            send_json,
+        )
+
+    assert [event["audio_duration_ms"] for event in sent] == [0] * 22 + [1]
+    assert session.playback.generated_ms == 1
+    assert session.playback.sent_ms == 1
+
+
+@pytest.mark.asyncio
+async def test_duplex_chat_rejected_audio_is_generated_but_not_sent():
+    handler = OmniDuplexSessionHandler(
+        chat_service=TurnBasedFakeChatService(FakeEngineClient()),
+        config_timeout_s=0.1,
+        idle_timeout_s=1,
+    )
+    session = DuplexSession(session_id="sid-chat-rejected-audio", config=DuplexSessionConfig())
+    response_id = session.begin_response()
+
+    async def reject(data: dict[str, object]) -> bool:
+        return False
+
+    await handler._emit_chat_payload(session, _chat_audio_completion_payload(), session.epoch, response_id, reject)
+
+    assert session.playback.generated_ms == 100
+    assert session.playback.sent_ms == 0
+    assert session.playback.played_ms == 0
+
+
+@pytest.mark.asyncio
+async def test_duplex_chat_failed_audio_send_does_not_advance_sent():
+    handler = OmniDuplexSessionHandler(
+        chat_service=TurnBasedFakeChatService(FakeEngineClient()),
+        config_timeout_s=0.1,
+        idle_timeout_s=1,
+    )
+    session = DuplexSession(session_id="sid-chat-failed-audio", config=DuplexSessionConfig())
+    response_id = session.begin_response()
+
+    async def fail_send(data: dict[str, object]) -> bool:
+        raise RuntimeError("output unavailable")
+
+    with pytest.raises(RuntimeError, match="output unavailable"):
+        await handler._emit_chat_payload(
+            session, _chat_audio_completion_payload(), session.epoch, response_id, fail_send
+        )
+
+    assert session.playback.generated_ms == 100
+    assert session.playback.sent_ms == 0
+
+
+@pytest.mark.asyncio
+async def test_duplex_chat_late_send_completion_only_updates_old_response():
+    handler = OmniDuplexSessionHandler(
+        chat_service=TurnBasedFakeChatService(FakeEngineClient()),
+        config_timeout_s=0.1,
+        idle_timeout_s=1,
+    )
+    session = DuplexSession(session_id="sid-chat-late-audio", config=DuplexSessionConfig())
+    old_response = session.begin_response()
+    send_started = asyncio.Event()
+    finish_send = asyncio.Event()
+
+    async def delayed_send(data: dict[str, object]) -> bool:
+        send_started.set()
+        await finish_send.wait()
+        return True
+
+    emit_task = asyncio.create_task(
+        handler._emit_chat_payload(session, _chat_audio_completion_payload(), session.epoch, old_response, delayed_send)
+    )
+    try:
+        await asyncio.wait_for(send_started.wait(), timeout=1)
+        session.barge_in()
+        new_response = session.begin_response()
+        current_state = session.turn_state
+        finish_send.set()
+        await asyncio.wait_for(emit_task, timeout=1)
+
+        assert session.active_response_id == new_response
+        assert session.playback_for_response(old_response).sent_ms == 100
+        assert session.playback.generated_ms == 0
+        assert session.playback.sent_ms == 0
+        assert session.turn_state == current_state
+    finally:
+        emit_task.cancel()
+        await asyncio.gather(emit_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_duplex_chat_missing_audio_metadata_reports_error():
+    class MissingMetadataChatService(TurnBasedFakeChatService):
+        async def create_chat_completion(self, request, raw_request=None):
+            async def generate():
+                payload = {"modality": "audio", "choices": [{"delta": {"content": "AAAA"}}]}
+                yield f"data: {json.dumps(payload)}\n\n"
+
+            return generate()
+
+    handler = OmniDuplexSessionHandler(
+        chat_service=MissingMetadataChatService(FakeEngineClient()),
+        config_timeout_s=0.1,
+        idle_timeout_s=1,
+    )
+    session = DuplexSession(session_id="sid-chat-missing-metadata", config=DuplexSessionConfig())
+    sent: list[dict[str, object]] = []
+
+    async def send_json(data: dict[str, object]) -> bool:
+        sent.append(data)
+        return True
+
+    await handler._run_response(session, send_json)
+
+    assert [event["type"] for event in sent] == ["response.created", "error"]
+    assert sent[-1]["code"] == "response_error"
+    assert "AudioChunkMetadata" in sent[-1]["error"]
+    assert session.playback.generated_ms == 0
+    assert session.playback.sent_ms == 0
 
 
 @pytest.mark.asyncio
@@ -5069,7 +5306,17 @@ async def test_duplex_chat_stage_metrics_use_latest_streaming_snapshot():
                 for index, snapshot in enumerate(snapshots):
                     payload = {
                         "modality": "audio",
-                        "choices": [{"delta": {"content": f"audio-{index}"}}],
+                        "choices": [
+                            {
+                                "delta": {"content": f"audio-{index}"},
+                                "audio_metadata": {
+                                    "format": "pcm",
+                                    "sample_rate_hz": 24_000,
+                                    "frame_count": 2400,
+                                    "channels": 1,
+                                },
+                            }
+                        ],
                         "metrics": {"stage_metrics": {"0": snapshot}},
                     }
                     yield f"data: {json.dumps(payload)}\n\n"
@@ -5087,8 +5334,9 @@ async def test_duplex_chat_stage_metrics_use_latest_streaming_snapshot():
     )
     sent: list[dict[str, Any]] = []
 
-    async def send_json(data: dict[str, Any]) -> None:
+    async def send_json(data: dict[str, Any]) -> bool:
         sent.append(data)
+        return True
 
     await handler._run_response(session, send_json)
 

--- a/tests/entrypoints/openai_api/test_duplex_handler.py
+++ b/tests/entrypoints/openai_api/test_duplex_handler.py
@@ -10,6 +10,7 @@ import json
 import struct
 import wave
 from collections.abc import Callable
+from contextlib import nullcontext
 from types import SimpleNamespace
 from typing import Any
 
@@ -5184,45 +5185,28 @@ async def test_duplex_chat_audio_does_not_round_each_fragment():
 
 
 @pytest.mark.asyncio
-async def test_duplex_chat_rejected_audio_is_generated_but_not_sent():
+@pytest.mark.parametrize("send_error", [None, RuntimeError("output unavailable")], ids=["rejected", "failed"])
+async def test_duplex_chat_unaccepted_audio_is_generated_but_not_sent(send_error: RuntimeError | None):
     handler = OmniDuplexSessionHandler(
         chat_service=TurnBasedFakeChatService(FakeEngineClient()),
         config_timeout_s=0.1,
         idle_timeout_s=1,
     )
-    session = DuplexSession(session_id="sid-chat-rejected-audio", config=DuplexSessionConfig())
+    session = DuplexSession(session_id="sid-chat-unaccepted-audio", config=DuplexSessionConfig())
     response_id = session.begin_response()
 
-    async def reject(data: dict[str, object], *, on_accepted: Callable[[], None] | None = None) -> None:
-        pass
+    async def send_json(data: dict[str, object], *, on_accepted: Callable[[], None] | None = None) -> None:
+        if send_error is not None:
+            raise send_error
 
-    await handler._emit_chat_payload(session, _chat_audio_completion_payload(), session.epoch, response_id, reject)
-
-    assert session.playback.generated_ms == 100
-    assert session.playback.sent_ms == 0
-    assert session.playback.played_ms == 0
-
-
-@pytest.mark.asyncio
-async def test_duplex_chat_failed_audio_send_does_not_advance_sent():
-    handler = OmniDuplexSessionHandler(
-        chat_service=TurnBasedFakeChatService(FakeEngineClient()),
-        config_timeout_s=0.1,
-        idle_timeout_s=1,
-    )
-    session = DuplexSession(session_id="sid-chat-failed-audio", config=DuplexSessionConfig())
-    response_id = session.begin_response()
-
-    async def fail_send(data: dict[str, object], *, on_accepted: Callable[[], None] | None = None) -> None:
-        raise RuntimeError("output unavailable")
-
-    with pytest.raises(RuntimeError, match="output unavailable"):
+    with pytest.raises(RuntimeError, match="output unavailable") if send_error is not None else nullcontext():
         await handler._emit_chat_payload(
-            session, _chat_audio_completion_payload(), session.epoch, response_id, fail_send
+            session, _chat_audio_completion_payload(), session.epoch, response_id, send_json
         )
 
     assert session.playback.generated_ms == 100
     assert session.playback.sent_ms == 0
+    assert session.playback.played_ms == 0
 
 
 @pytest.mark.asyncio

--- a/vllm_omni/entrypoints/duplex/chat_fallback.py
+++ b/vllm_omni/entrypoints/duplex/chat_fallback.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import json
 from collections.abc import AsyncGenerator
+from functools import partial
 from typing import Any
 
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
@@ -269,7 +270,7 @@ class ChatFallbackProjectorMixin:
                 )
                 if duration_ms is None:
                     return
-                accepted = await send_json(
+                await send_json(
                     {
                         "type": "response.output_audio.delta",
                         "session_id": session.session_id,
@@ -280,10 +281,9 @@ class ChatFallbackProjectorMixin:
                         "sample_rate_hz": audio_metadata.sample_rate_hz,
                         "channels": audio_metadata.channels,
                         "audio_duration_ms": duration_ms,
-                    }
+                    },
+                    on_accepted=partial(session.mark_audio_sent, duration_ms, response_id=response_id),
                 )
-                if accepted is True:
-                    session.mark_audio_sent(duration_ms, response_id=response_id)
 
             finish_reason = choice.get("finish_reason")
             if finish_reason is not None and modality != "audio":

--- a/vllm_omni/entrypoints/duplex/chat_fallback.py
+++ b/vllm_omni/entrypoints/duplex/chat_fallback.py
@@ -14,7 +14,6 @@ from vllm.entrypoints.openai.engine.protocol import ErrorResponse
 from vllm.logger import init_logger
 
 from vllm_omni.entrypoints.duplex.protocol import DuplexSession
-from vllm_omni.entrypoints.openai.protocol.audio import AudioChunkMetadata
 
 logger = init_logger(__name__)
 
@@ -262,6 +261,10 @@ class ChatFallbackProjectorMixin:
                 if isinstance(message_audio, dict):
                     audio_content = message_audio.get("data")
             if isinstance(audio_content, str) and audio_content:
+                # The OpenAI package imports duplex serving during initialization.
+                # Defer this import until chat fallback has finished loading.
+                from vllm_omni.entrypoints.openai.protocol.audio import AudioChunkMetadata
+
                 audio_metadata = AudioChunkMetadata.model_validate(choice.get("audio_metadata"))
                 duration_ms = session.record_generated_audio(
                     response_id,

--- a/vllm_omni/entrypoints/duplex/chat_fallback.py
+++ b/vllm_omni/entrypoints/duplex/chat_fallback.py
@@ -13,6 +13,7 @@ from vllm.entrypoints.openai.engine.protocol import ErrorResponse
 from vllm.logger import init_logger
 
 from vllm_omni.entrypoints.duplex.protocol import DuplexSession
+from vllm_omni.entrypoints.openai.protocol.audio import AudioChunkMetadata
 
 logger = init_logger(__name__)
 
@@ -115,6 +116,13 @@ class ChatFallbackProjectorMixin:
         ):
             model_extra.pop(protocol_key, None)
         kwargs.update(model_extra)
+        if "audio" in response_config.modalities:
+            audio_options = kwargs.get("audio")
+            audio_options = dict(audio_options) if isinstance(audio_options, dict) else {}
+            # Chat defaults to WAV. Request the session's internal output format
+            # explicitly rather than relabeling the returned bytes as PCM.
+            audio_options["format"] = response_config.response_format
+            kwargs["audio"] = audio_options
         if isinstance(tools, list):
             kwargs["tools"] = tools
         if isinstance(tool_choice, str | dict):
@@ -190,6 +198,8 @@ class ChatFallbackProjectorMixin:
         response_id: str,
         send_json,
     ) -> None:
+        if session.epoch != epoch or session.active_response_id != response_id:
+            return
         metrics = payload.get("metrics")
         stage_metrics = metrics.get("stage_metrics") if isinstance(metrics, dict) else None
         if isinstance(stage_metrics, dict):
@@ -233,19 +243,7 @@ class ChatFallbackProjectorMixin:
                 content = message.get("content")
 
             if isinstance(content, str) and content:
-                if modality == "audio":
-                    session.mark_audio_sent()
-                    await send_json(
-                        {
-                            "type": "response.output_audio.delta",
-                            "session_id": session.session_id,
-                            "response_id": response_id,
-                            "epoch": epoch,
-                            "audio": content,
-                            "format": session.response_config.response_format,
-                        }
-                    )
-                else:
+                if modality != "audio":
                     session.append_assistant_text(content)
                     await send_json(
                         {
@@ -256,6 +254,36 @@ class ChatFallbackProjectorMixin:
                             "delta": content,
                         }
                     )
+
+            audio_content = content if modality == "audio" else None
+            if isinstance(message, dict):
+                message_audio = message.get("audio")
+                if isinstance(message_audio, dict):
+                    audio_content = message_audio.get("data")
+            if isinstance(audio_content, str) and audio_content:
+                audio_metadata = AudioChunkMetadata.model_validate(choice.get("audio_metadata"))
+                duration_ms = session.record_generated_audio(
+                    response_id,
+                    frame_count=audio_metadata.frame_count,
+                    sample_rate_hz=audio_metadata.sample_rate_hz,
+                )
+                if duration_ms is None:
+                    return
+                accepted = await send_json(
+                    {
+                        "type": "response.output_audio.delta",
+                        "session_id": session.session_id,
+                        "response_id": response_id,
+                        "epoch": epoch,
+                        "audio": audio_content,
+                        "format": audio_metadata.format,
+                        "sample_rate_hz": audio_metadata.sample_rate_hz,
+                        "channels": audio_metadata.channels,
+                        "audio_duration_ms": duration_ms,
+                    }
+                )
+                if accepted is True:
+                    session.mark_audio_sent(duration_ms, response_id=response_id)
 
             finish_reason = choice.get("finish_reason")
             if finish_reason is not None and modality != "audio":

--- a/vllm_omni/entrypoints/duplex/protocol.py
+++ b/vllm_omni/entrypoints/duplex/protocol.py
@@ -178,6 +178,8 @@ class DuplexPlaybackCursor:
     sent_ms: int = 0
     played_ms: int = 0
     committed_ms: int = 0
+    generated_frames: int = 0
+    sample_rate_hz: int | None = None
 
     def acknowledge(self, played_ms: int, committed_ms: int | None = None) -> None:
         self.played_ms = max(self.played_ms, max(0, int(played_ms)))
@@ -1103,25 +1105,54 @@ class DuplexSession:
         if text:
             self._response.assistant_text_buffer.append(text)
 
+    def record_generated_audio(self, response_id: str, *, frame_count: int, sample_rate_hz: int) -> int | None:
+        """Accumulate source frames, rounding only the cumulative duration.
+
+        A late chunk cannot change a different response's playback cursor.
+        This records encoded audio, not transport delivery or client playback.
+        """
+        if response_id != self.active_response_id:
+            return None
+        if type(frame_count) is not int or frame_count < 0:
+            raise ValueError("Audio frame_count must be a non-negative integer")
+        if type(sample_rate_hz) is not int or sample_rate_hz <= 0:
+            raise ValueError("Audio sample_rate_hz must be a positive integer")
+        playback = self._playback.current
+        if playback.sample_rate_hz is not None and playback.sample_rate_hz != sample_rate_hz:
+            raise ValueError("Audio sample rate changed within a response")
+        playback.sample_rate_hz = sample_rate_hz
+        playback.generated_frames += frame_count
+        playback.generated_ms = playback.generated_frames * 1000 // sample_rate_hz
+        return playback.generated_ms
+
     def mark_audio_sent(
         self,
         duration_ms: int | None = None,
         *,
+        response_id: str | None = None,
         text_chars: int | None = None,
         audio_text_marks: list[dict[str, object]] | None = None,
     ) -> None:
-        playback = self._playback.current
+        """Record cumulative audio accepted by the output path.
+
+        ``sent_ms`` includes queued/journaled output; only client acknowledgements
+        establish ``played_ms``. It is not confirmation of socket delivery.
+        """
+        playback = self._playback.current if response_id is None else self._playback.by_response.get(response_id)
+        if playback is None:
+            return
+        is_current = response_id is None or response_id == self.active_response_id
         if duration_ms is not None:
             playback.generated_ms = max(playback.generated_ms, duration_ms)
             playback.sent_ms = max(playback.sent_ms, duration_ms)
-            if text_chars is not None and text_chars >= 0:
+            if is_current and text_chars is not None and text_chars >= 0:
                 self._response.assistant_audio_text_marks.append(
                     DuplexAssistantAudioTextMark(
                         text_chars=int(text_chars),
                         audio_end_ms=max(0, int(duration_ms)),
                     )
                 )
-        if audio_text_marks:
+        if is_current and audio_text_marks:
             for raw_mark in audio_text_marks:
                 if not isinstance(raw_mark, dict):
                     continue
@@ -1135,7 +1166,8 @@ class DuplexSession:
                         audio_end_ms=max(0, int(raw_audio_end_ms)),
                     )
                 )
-        self.turn_state = DuplexTurnState.ASSISTANT_PLAYING
+        if is_current:
+            self.turn_state = DuplexTurnState.ASSISTANT_PLAYING
 
     def _playback_cursor_for_response(self, response_id: str | None = None) -> DuplexPlaybackCursor:
         if response_id is None:

--- a/vllm_omni/entrypoints/duplex/session_attachment.py
+++ b/vllm_omni/entrypoints/duplex/session_attachment.py
@@ -275,12 +275,18 @@ class DuplexSessionAttachmentRegistry:
         payload: Mapping[str, object],
         *,
         journal: bool = True,
+        on_accepted: Callable[[], None] | None = None,
     ) -> JournalEntry | None:
         """Sequence and dispatch one event to the current attachment.
 
         The per-session lock keeps wire order equal to journal order without
         serializing unrelated sessions. A detached session still records
         replayable events, but has no transport side effect.
+
+        ``on_accepted`` runs synchronously once the event is journaled, or
+        after a successful transport send when journaling is disabled. A later
+        send failure cannot undo acceptance into the journal. Detached,
+        non-journaled events do not invoke it. The callback must not raise.
         """
         async with self._lock:
             state = self._require(session_id)
@@ -291,8 +297,12 @@ class DuplexSessionAttachmentRegistry:
                 entry = state.journal.record(payload) if journal else None
                 attachment = state.attachment
                 wire_payload = dict(entry.payload) if entry is not None else dict(payload)
+            if entry is not None and on_accepted is not None:
+                on_accepted()
             if attachment is not None:
                 await attachment.send(wire_payload)
+                if entry is None and on_accepted is not None:
+                    on_accepted()
             return entry
 
     async def acknowledge(self, session_id: str, sequence: int) -> int:

--- a/vllm_omni/entrypoints/duplex/session_runner.py
+++ b/vllm_omni/entrypoints/duplex/session_runner.py
@@ -7,6 +7,7 @@ import asyncio
 import binascii
 import json
 import uuid
+from collections.abc import Callable
 from contextlib import suppress
 from copy import deepcopy
 
@@ -99,7 +100,9 @@ class DuplexSessionRunnerMixin:
             if callable(close):
                 await close(code=1000, reason=reason)
 
-        async def send_attachment_payload(payload: dict[str, object], *, journal: bool) -> None:
+        async def send_attachment_payload(
+            payload: dict[str, object], *, journal: bool, on_accepted: Callable[[], None] | None = None
+        ) -> None:
             assert session is not None
             session_id = session.session_id
             should_journal = journal and session_id not in self._resync_required_sessions
@@ -108,6 +111,7 @@ class DuplexSessionRunnerMixin:
                     session_id,
                     payload,
                     journal=should_journal,
+                    on_accepted=on_accepted,
                 )
             except DuplexJournalOverflowError:
                 first_overflow = session_id not in self._resync_required_sessions
@@ -129,6 +133,7 @@ class DuplexSessionRunnerMixin:
                     session_id,
                     payload,
                     journal=False,
+                    on_accepted=on_accepted,
                 )
 
         if realtime_protocol is not None:
@@ -155,23 +160,29 @@ class DuplexSessionRunnerMixin:
 
         event_emit_lock = asyncio.Lock()
 
-        async def send_outbound(payload: dict[str, object]) -> None:
+        async def send_outbound(payload: dict[str, object], *, on_accepted: Callable[[], None] | None = None) -> None:
             if not attachment_ready or session is None:
                 await actor.send_json(dict(payload))
+                if on_accepted is not None:
+                    on_accepted()
                 return
             if realtime_protocol is None:
                 await send_attachment_payload(
                     payload,
                     journal=payload.get("type") not in {"session.created", "session.resumed"},
+                    on_accepted=on_accepted,
                 )
                 return
             for projected in realtime_protocol.encode_outbound_event(payload):
                 await send_attachment_payload(
                     projected,
                     journal=projected.get("type") not in {"session.created", "session.resumed"},
+                    # Item/part announcements may precede the audio. Only the
+                    # actual audio event establishes acceptance of this chunk.
+                    on_accepted=on_accepted if projected.get("type") == "response.audio.delta" else None,
                 )
 
-        async def emit_event(payload: dict[str, object]) -> bool:
+        async def emit_event(payload: dict[str, object], *, on_accepted: Callable[[], None] | None = None) -> None:
             deferred_precreate_response = False
             async with event_emit_lock:
                 accepted, deferred_overlap_payload = await self._apply_outbound_session_event(
@@ -182,8 +193,8 @@ class DuplexSessionRunnerMixin:
                     realtime_protocol=realtime_protocol,
                 )
                 if not accepted:
-                    return False
-                await send_outbound(payload)
+                    return
+                await send_outbound(payload, on_accepted=on_accepted)
                 if deferred_overlap_payload is not None:
                     deferred_precreate_response = native.deferred_precreate_response
                     native.deferred_precreate_response = False
@@ -197,8 +208,6 @@ class DuplexSessionRunnerMixin:
                         deferred_overlap_payload if native.committed_audio_payload is deferred_overlap_payload else None
                     ),
                 )
-
-            return True
 
         writer_task = asyncio.create_task(actor.writer_loop(), name="duplex-session-writer")
         reader_task: asyncio.Task[None] | None = None

--- a/vllm_omni/entrypoints/duplex/session_runner.py
+++ b/vllm_omni/entrypoints/duplex/session_runner.py
@@ -171,7 +171,7 @@ class DuplexSessionRunnerMixin:
                     journal=projected.get("type") not in {"session.created", "session.resumed"},
                 )
 
-        async def emit_event(payload: dict[str, object]) -> None:
+        async def emit_event(payload: dict[str, object]) -> bool:
             deferred_precreate_response = False
             async with event_emit_lock:
                 accepted, deferred_overlap_payload = await self._apply_outbound_session_event(
@@ -182,7 +182,7 @@ class DuplexSessionRunnerMixin:
                     realtime_protocol=realtime_protocol,
                 )
                 if not accepted:
-                    return
+                    return False
                 await send_outbound(payload)
                 if deferred_overlap_payload is not None:
                     deferred_precreate_response = native.deferred_precreate_response
@@ -197,6 +197,8 @@ class DuplexSessionRunnerMixin:
                         deferred_overlap_payload if native.committed_audio_payload is deferred_overlap_payload else None
                     ),
                 )
+
+            return True
 
         writer_task = asyncio.create_task(actor.writer_loop(), name="duplex-session-writer")
         reader_task: asyncio.Task[None] | None = None

--- a/vllm_omni/entrypoints/openai/audio_utils_mixin.py
+++ b/vllm_omni/entrypoints/openai/audio_utils_mixin.py
@@ -9,7 +9,12 @@ import torch
 import torchaudio
 from vllm.logger import init_logger
 
-from vllm_omni.entrypoints.openai.protocol.audio import DEFAULT_AUDIO_FORMAT, AudioResponse, CreateAudio
+from vllm_omni.entrypoints.openai.protocol.audio import (
+    DEFAULT_AUDIO_FORMAT,
+    AudioChunkMetadata,
+    AudioResponse,
+    CreateAudio,
+)
 
 try:
     import soundfile
@@ -224,7 +229,16 @@ class AudioMixin:
 
             audio_data = base64.b64encode(audio_data).decode("utf-8")
 
-        return AudioResponse(audio_data=audio_data, media_type=media_type)
+        return AudioResponse(
+            audio_data=audio_data,
+            media_type=media_type,
+            audio_metadata=AudioChunkMetadata(
+                format=response_format,
+                sample_rate_hz=int(sample_rate),
+                frame_count=int(audio_tensor.shape[0]),
+                channels=1 if audio_tensor.ndim == 1 else int(audio_tensor.shape[1]),
+            ),
+        )
 
     @staticmethod
     def _resample_audio(audio_tensor: np.ndarray, source_rate: int, target_rate: int) -> np.ndarray:

--- a/vllm_omni/entrypoints/openai/protocol/audio.py
+++ b/vllm_omni/entrypoints/openai/protocol/audio.py
@@ -23,7 +23,7 @@ def _normalize_ref_audio_value(value):
         return None
     if isinstance(value, str):
         return value
-    if isinstance(value, list | tuple):
+    if isinstance(value, (list, tuple)):
         items = []
         for item in value:
             if not isinstance(item, str):
@@ -38,16 +38,16 @@ def _normalize_ref_audio_value(value):
 def _normalize_speaker_embedding_value(value):
     if value is None:
         return None
-    if not isinstance(value, list | tuple):
+    if not isinstance(value, (list, tuple)):
         raise TypeError("'speaker_embedding' must be a list of numbers or list of embedding vectors")
     if not value:
         return []
 
     first = value[0]
-    if isinstance(first, list | tuple):
+    if isinstance(first, (list, tuple)):
         embeddings = []
         for item in value:
-            if not isinstance(item, list | tuple):
+            if not isinstance(item, (list, tuple)):
                 raise TypeError("'speaker_embedding' must not mix flat and nested values")
             embeddings.append([float(x) for x in item])
         return embeddings

--- a/vllm_omni/entrypoints/openai/protocol/audio.py
+++ b/vllm_omni/entrypoints/openai/protocol/audio.py
@@ -23,7 +23,7 @@ def _normalize_ref_audio_value(value):
         return None
     if isinstance(value, str):
         return value
-    if isinstance(value, (list, tuple)):
+    if isinstance(value, list | tuple):
         items = []
         for item in value:
             if not isinstance(item, str):
@@ -38,16 +38,16 @@ def _normalize_ref_audio_value(value):
 def _normalize_speaker_embedding_value(value):
     if value is None:
         return None
-    if not isinstance(value, (list, tuple)):
+    if not isinstance(value, list | tuple):
         raise TypeError("'speaker_embedding' must be a list of numbers or list of embedding vectors")
     if not value:
         return []
 
     first = value[0]
-    if isinstance(first, (list, tuple)):
+    if isinstance(first, list | tuple):
         embeddings = []
         for item in value:
-            if not isinstance(item, (list, tuple)):
+            if not isinstance(item, list | tuple):
                 raise TypeError("'speaker_embedding' must not mix flat and nested values")
             embeddings.append([float(x) for x in item])
         return embeddings
@@ -410,9 +410,23 @@ class CreateAudio(BaseModel):
         arbitrary_types_allowed = True
 
 
+class AudioChunkMetadata(BaseModel):
+    """Waveform dimensions after transforms, before encoding.
+
+    Frames count samples per channel, not interleaved scalar samples or bytes.
+    For compressed formats this excludes any padding introduced by the codec.
+    """
+
+    format: str = Field(min_length=1, strict=True)
+    sample_rate_hz: int = Field(gt=0, strict=True)
+    frame_count: int = Field(ge=0, strict=True)
+    channels: int = Field(gt=0, strict=True)
+
+
 class AudioResponse(BaseModel):
     audio_data: bytes | str
     media_type: str
+    audio_metadata: AudioChunkMetadata | None = None
 
 
 # --- Batch Speech Models ---

--- a/vllm_omni/entrypoints/openai/protocol/chat_completion.py
+++ b/vllm_omni/entrypoints/openai/protocol/chat_completion.py
@@ -1,12 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
 from typing import Any
 
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionResponse, ChatCompletionStreamResponse
+from pydantic import SerializeAsAny
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionResponse,
+    ChatCompletionResponseChoice,
+    ChatCompletionResponseStreamChoice,
+    ChatCompletionStreamResponse,
+)
+
+from vllm_omni.entrypoints.openai.protocol.audio import AudioChunkMetadata
+
+
+class OmniChatCompletionResponseStreamChoice(ChatCompletionResponseStreamChoice):
+    audio_metadata: AudioChunkMetadata | None = None
+
+
+class OmniChatCompletionResponseChoice(ChatCompletionResponseChoice):
+    audio_metadata: AudioChunkMetadata | None = None
 
 
 class OmniChatCompletionStreamResponse(ChatCompletionStreamResponse):
+    choices: list[SerializeAsAny[ChatCompletionResponseStreamChoice]]
     modality: str | None = "text"
     metrics: dict[str, Any] | None = None
 
 
 class OmniChatCompletionResponse(ChatCompletionResponse):
+    choices: list[SerializeAsAny[ChatCompletionResponseChoice]]
     metrics: dict[str, Any] | None = None

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -34,7 +34,11 @@ from vllm_omni.entrypoints.openai.diffusion_request_utils import (
     apply_normalized_diffusion_request_extra_args,
     normalize_diffusion_request_args,
 )
-from vllm_omni.entrypoints.openai.protocol.chat_completion import OmniChatCompletionResponse
+from vllm_omni.entrypoints.openai.protocol.chat_completion import (
+    OmniChatCompletionResponse,
+    OmniChatCompletionResponseChoice,
+    OmniChatCompletionResponseStreamChoice,
+)
 from vllm_omni.entrypoints.utils import coerce_param_message_types
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniTextPrompt
 from vllm_omni.metrics import definitions as _metric_defs
@@ -2818,7 +2822,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         # omits "sr" and runs at 24kHz; Ming-flash-omni surfaces a 44.1kHz
         # AudioVAE rate via multimodal_output["sr"].
         sr_raw = mm_output.get("sr")
-        if isinstance(sr_raw, (list, tuple)):
+        if isinstance(sr_raw, list | tuple):
             sr_raw = next((item for item in sr_raw if item is not None), None)
         if sr_raw is None:
             sample_rate = 24000
@@ -2858,18 +2862,20 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
 
         for output in final_res.outputs:
             if stream:
-                choice_data = ChatCompletionResponseStreamChoice(
+                choice_data = OmniChatCompletionResponseStreamChoice(
                     index=output.index,
                     delta=DeltaMessage(role=role, content=audio_base64),
+                    audio_metadata=audio_response.audio_metadata,
                     logprobs=None,
                     finish_reason=output.finish_reason,
                     stop_reason=output.stop_reason,
                     token_ids=(as_list(output.token_ids) if request.return_token_ids else None),
                 )
             else:
-                choice_data = ChatCompletionResponseChoice(
+                choice_data = OmniChatCompletionResponseChoice(
                     index=output.index,
                     message=ChatMessage(role=role, audio=audio_obj),
+                    audio_metadata=audio_response.audio_metadata,
                     logprobs=None,
                     finish_reason="stop",
                     stop_reason=output.stop_reason,

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -2822,7 +2822,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         # omits "sr" and runs at 24kHz; Ming-flash-omni surfaces a 44.1kHz
         # AudioVAE rate via multimodal_output["sr"].
         sr_raw = mm_output.get("sr")
-        if isinstance(sr_raw, list | tuple):
+        if isinstance(sr_raw, (list, tuple)):
             sr_raw = next((item for item in sr_raw if item is not None), None)
         if sr_raw is None:
             sample_rate = 24000


### PR DESCRIPTION
## Problem

On the turn-based Qwen3-Omni Chat fallback path (`/v1/realtime?duplex=1`), requesting PCM can return WAV bytes labelled as PCM. Generated audio also ends with `generated_ms=sent_ms=0`, so playback/history accounting lacks its duration. This addresses part of #7055 D/E independently of #7278.

## Root cause

- Chat fallback left output encoding at Chat's WAV default.
- Chat choices discarded the encoder's chosen rate and final waveform dimensions.
- Fallback called `mark_audio_sent()` without a duration.

## Changes

- Request the session's audio format explicitly and carry typed `audio_metadata` from the final waveform: format, encoder sample rate, frames per channel, and channel count. Text/image choices are unchanged. The metadata import in fallback is deferred to avoid a circular dependency with OpenAI serving.
- Accumulate integer frames per response in `DuplexSession`, then convert the cumulative total to milliseconds.
- Record Chat fallback output acceptance after queuing, journaling, or a successful unjournaled send. A journaled event remains accepted if sending later fails; late callbacks stay bound to their original response.
- Document the public fields and failure behavior in `docs/serving/realtime_duplex_api.md`.

## Behavior and limits

- Non-empty fallback audio requires valid metadata; missing/invalid metadata or a sample-rate change within a response fails that response. The encoder uses the model-reported rate when available, or the existing 24 kHz default for Qwen3-Omni.
- Fallback now forwards the session output format to Chat's existing validator. If an unsupported format reaches fallback, for example through raw `/v1/duplex` session creation, the response is rejected with `Invalid audio format` instead of using the Chat default. Realtime already rejects unsupported formats before this point.
- In Chat fallback, `sent_ms` means accepted by the server output path, not delivered or played. Only client acknowledgement updates `played_ms`. Native model paths still record audio before sending; their timing is not unified here.
- Existing history truncation now receives nonzero durations, but retains its duration-proportional text approximation. VAD, input recovery, history-query behavior and cross-stage cancellation are outside this change.
- A separate unresolved observation on #6372 and the checked integration: the next Chat request retained a truncated answer while `conversation.item.retrieve` returned the full generated text. This PR does not fix that discrepancy or establish playback/history consistency end to end.
- With `ack_only`, nonzero fallback durations keep the existing raw `/v1/duplex` playback-cancellation path eligible after generation-task cleanup: `response.cancel` without a response ID can emit `audio.cancelled` while `committed_ms < sent_ms`. Realtime and cancellation naming an already completed response still return `response_not_active`. This is cancellation of remaining playback/history state, not a new abort of finished GPU work; the exact post-completion sequence lacks a dedicated regression test.
- Coverage is for Omni Chat audio choices, not every diffusion/audio-only producer. Frame counts exclude codec padding; real-model validation below covers PCM and WAV.

## Validation

Qwen3-Omni-30B-A3B-Instruct (`26291f7`), two GB200 GPUs per service, vLLM 0.28.0, official arm64 vLLM-Omni image; all three stages used async chunking and eager execution.

Before: `a916cbc` (#7278, with the main baseline's unchanged audio path). After: `2a0fe1f`. Current head `88ca1c1` only changes documentation and existing checks relative to that model-validated revision; it did not rerun the model.

| Case | Received waveform duration | Before generated/sent | After generated/sent |
| --- | ---: | ---: | ---: |
| PCM requested, completed | 91,016.875 ms | 0 / 0 ms; WAV bytes mislabeled PCM | 91,016 / 91,016 ms; actual PCM |
| WAV requested, completed | 82,136.875 ms | 0 / 0 ms | 82,136 / 82,136 ms |
| PCM requested, interrupted | 296.875 ms | 0 / 0 ms; WAV bytes mislabeled PCM | 296 / 296 ms; actual PCM |
| WAV requested, interrupted | 296.875 ms | 0 / 0 ms | 296 / 296 ms |

All four cases passed. Interrupted responses retained the injected `played_ms=148`, with no audio observed after the cancelled terminal during observation. Playback acknowledgements were synthetic, not speaker measurements; these runs do not measure exact GPU-stop timing or performance.

All 364 selected checks passed at `88ca1c1`. Disconnected/journal failure cases were covered by those checks, not the normal-connection model runs. Full mypy and repository-wide pre-commit were not run.

<details>
<summary>Real-model reproduction: PCM format and duration</summary>

Start a Qwen3-Omni server on port 18091 with top-level `duplex_session`, its configured server VAD artifact, and `async_chunk: true`. Leave the model stages turn-based; do not set their `session_mode: duplex`. In a client environment with `websockets` and `soundfile`, run from the repo root and set `MODEL` to the exact served name. This reproduces the completed PCM case using a complete conversation item.

```bash
MODEL=Qwen/Qwen3-Omni-30B-A3B-Instruct python - <<'PY'
import asyncio, base64, io, json, os, wave
from urllib.parse import urlencode
import soundfile as sf
import websockets

async def main():
    model = os.environ['MODEL']
    with wave.open('tests/assets/minicpmo_4_5/response_required_16k.wav', 'rb') as f:
        assert (f.getnchannels(), f.getsampwidth(), f.getframerate()) == (1, 2, 16000)
        audio = base64.b64encode(f.readframes(f.getnframes())).decode()
    url = 'ws://127.0.0.1:18091/v1/realtime?' + urlencode(
        {'duplex': '1', 'autostart': '0', 'model': model})
    async with websockets.connect(url, max_size=64 * 1024 * 1024) as ws:
        await ws.send(json.dumps({'type': 'session.update', 'session': {
            'model': model, 'modalities': ['audio', 'text'],
            'input_audio_format': 'pcm16', 'output_audio_format': 'pcm16',
            'sample_rate_hz': 16000, 'voice': 'Chelsie',
            'turn_detection': {'type': 'server_vad', 'create_response': False,
                               'interrupt_response': False},
            'extra_body': {'auto_response': False}}}))
        started = False
        duration_ms = 0.0
        while True:
            event = json.loads(await asyncio.wait_for(ws.recv(), timeout=180))
            if event['type'] == 'session.updated' and not started:
                started = True
                await ws.send(json.dumps({'type': 'conversation.item.create', 'item': {
                    'id': 'item_audio_accounting', 'type': 'message', 'role': 'user',
                    'content': [{'type': 'input_audio', 'audio': audio,
                                 'format': 'pcm16', 'sample_rate_hz': 16000}]}}))
                await ws.send(json.dumps({'type': 'response.create'}))
            if event['type'] == 'response.audio.delta':
                raw = base64.b64decode(event['delta'])
                if raw.startswith(b'RIFF'):
                    info = sf.info(io.BytesIO(raw))
                    duration_ms += info.frames * 1000 / info.samplerate
                    print('WAV bytes; advertised format:', event.get('format'))
                else:
                    duration_ms += len(raw) // 2 * 1000 / event['sample_rate_hz']
                print('received ms:', duration_ms, 'server ms:',
                      event.get('metadata', {}).get('audio_duration_ms'))
            if event['type'] == 'error':
                raise RuntimeError(event)
            if event['type'] == 'response.done':
                print(json.dumps(event, indent=2))
                break

asyncio.run(main())
PY
```

</details>

<details>
<summary>Focused check command</summary>

From the repo root in a matching vLLM-Omni development environment with the repository's pytest plugins installed:

```bash
python -m pytest -o addopts='' -q -p no:cacheprovider \
  tests/entrypoints/openai_api/test_audio_format.py \
  tests/entrypoints/openai_api/test_duplex_handler.py \
  tests/entrypoints/openai/test_duplex_protocol.py \
  tests/entrypoints/openai/test_duplex_session_attachment.py
```

</details>

## Related work

PR #6372 already provides format selection and streamed duration accounting. This PR independently fixes the main-based path and additionally tracks final-waveform frames/channels and response-local output acceptance. #6372 at `2f5cd75` and local integration `a55196b` with #7278 and this change passed real-model audio and two-turn checks; this is compatibility evidence, not an accuracy or performance comparison. Request-ID cancellation remains in #7278; the broader architecture work is #7181.

AI assistance: Codex assisted with code, validation, and PR writing.
