### PR TITLE
[Misc] Add SocialOmni evaluation

### DIFF
--- a/.buildkite/cuda/test-nightly.yml
+++ b/.buildkite/cuda/test-nightly.yml
@@ -51,7 +51,7 @@ steps:
           - export SEED_TTS_EVAL_DEVICE=cuda:1
           - |
             set +e
-            pytest -s -v tests/e2e/accuracy/qwen3_omni/test_qwen3_omni.py -m "full_model" --run-level full_model
+            pytest -s -v tests/e2e/accuracy/qwen3_omni/test_qwen3_omni.py tests/e2e/accuracy/test_qwen3_omni_socialomni_expansion.py -m "full_model" --run-level full_model
             EXIT=$$?
             buildkite-agent artifact upload "tests/e2e/accuracy/qwen3_omni/results/qwen_omni_acc/*.json"
             exit $$EXIT

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -50,6 +50,12 @@ Accuracy benchmarks for image generation/editing models, adapting external suite
 - **Layout**: `accuracy/text_to_image/` (GEBench), `accuracy/image_to_image/` (GEdit-Bench)
 - **Method**: generation and judge scoring both run through local `vllm-omni serve` endpoints
 
+### [SocialOmni](socialomni/README.md) — Audio-Visual Social Interaction
+
+Speaker attribution, turn-entry decisions, and response quality through the
+chat completions endpoint. Level 2 uses video prefixes and a fixed three-judge
+panel, with separate decision, generation, and scoring phases.
+
 ### Common serving metrics framework
 
 `vllm_omni/benchmarks/` extends `vllm bench serve --omni` with Omni-specific datasets, backends, and multimodal metrics. Key metrics include:

--- a/benchmarks/socialomni/README.md
+++ b/benchmarks/socialomni/README.md
@@ -62,7 +62,8 @@ uv run --no-sync python -m benchmarks.socialomni.evaluate \
 
 Remove `--mini` for all 2,000 Level 1 and 209 Level 2 samples. Use
 `--level level1` or `--level level2` to select one level. The first 200 Level 2
-records in source order also produce the paper subset metrics.
+records in source order also produce `first_200` metrics. This selection is
+not a verified manifest of the paper's 200-item core set.
 
 Create a local judge configuration with exactly these three names. Set each
 `model` to the corresponding model ID served by that endpoint:
@@ -89,6 +90,15 @@ Level 2 re-encodes video and audio up to the annotated timestamp before model
 requests. Model prompts receive neither the reference transcript nor the
 reference continuation. Responses are generated for every ground-truth YES,
 even when the model predicts NO. Only the judges receive reference material.
+
+The task questions and answer options come from the pinned dataset. The
+formatting instructions and judge rubric are implemented in the four
+`build_*_prompt` functions in [protocol.py](protocol.py). These are adapted
+prompts, not verbatim paper templates. The judge receives the target
+participant, reference context, reference continuation, and candidate text.
+The public [reference implementation](https://github.com/MAC-AutoML/SocialOmni/tree/0fab46ac73387675afc44c48f126e56615dbefb6)
+uses different prompting and scoring defaults; this runner follows the
+fixed-prefix, forced-response, complete three-judge protocol described above.
 
 Level 1 reports accuracy, macro-F1 (the mean F1 score over four answer
 positions), and accuracy by speaker visibility. Level 2 reports YES/NO
@@ -163,9 +173,19 @@ unparsable answers. Level 1 accuracy was 74.40%. Level 2 results were:
 The run used benchmark commit `0c96505280b1` and model snapshot
 `ea64d566a2a0731823dc44965e7f89bad78f95cb`, with model concurrency 1, one warmup
 per model phase, and judge concurrency 2/2/1 for GPT-4o/Gemini/Qwen3-Omni.
-These are observed results for this deployment, not a cross-framework
-performance comparison. The full command is the mini command above with
+These are observed results for this deployment, not a controlled reproduction
+of the paper or a cross-framework performance comparison. Prompts, model
+snapshot, serving templates, and media preprocessing must be matched before
+attributing score differences to the serving framework. The full command is the mini command above with
 `--mini` removed; set the judge concurrency values in `judges.json` accordingly.
+
+The first 200 decisions included 119 correct YES, 70 incorrect YES, nine
+incorrect NO, and two correct NO predictions. Predicting YES for every item
+would achieve 64% accuracy on this selection, above the observed 60.50%; high
+`Cov+` alone does not indicate better turn-entry decisions. Macro-F1, the
+mean of the YES and NO F1 scores, was 39.95%. Level 1 accuracy was 76.29%
+for visible speakers and 62.55% for visibility mismatches. These diagnostics
+are included in the result JSON alongside aggregate scores.
 
 `--max-concurrency` bounds model requests. Each non-empty model phase runs one
 warmup request per configured concurrent worker; `--warmup N` overrides this
@@ -190,7 +210,8 @@ uv run --no-sync python -m pytest \
 
 The GPU regression test starts the official two-GPU Qwen3-Omni server and
 runs the public command on the mini set. Install the benchmark dependencies
-above and set the dataset location to opt in:
+above. By default the test downloads the pinned metadata and four mini-set
+videos (about 17 MiB) under `HF_HOME` (the Hugging Face cache directory). To use an existing dataset:
 
 ```bash
 VLLM_SOCIALOMNI_DATASET_ROOT=/path/to/socialomni \
@@ -202,7 +223,7 @@ uv run --no-sync python -m pytest -sv \
 Set `VLLM_SOCIALOMNI_MODEL` to use a local checkpoint. The test checks parsed
 answers, response generation, and the incomplete-quality result without
 external judges. It is included in the existing nightly accuracy test command
-and skips when `VLLM_SOCIALOMNI_DATASET_ROOT` is unset. It does not run the full
-dataset or contact external judge services.
+and runs without a dataset-path override. It does not run the full dataset
+or contact external judge services.
 
 Reference: [SocialOmni paper](https://arxiv.org/abs/2603.16859).

--- a/benchmarks/socialomni/README.md
+++ b/benchmarks/socialomni/README.md
@@ -1,0 +1,123 @@
+# SocialOmni
+
+[SocialOmni](https://github.com/MAC-AutoML/SocialOmni) evaluates speaker
+attribution (Level 1) and whether and how a target participant should enter a
+conversation (Level 2). This runner sends chat completions to a vLLM-Omni
+server with video and embedded audio, requesting text output.
+
+## Setup
+
+Install vLLM-Omni following the [installation guide](../../docs/getting_started/installation/README.md).
+The client requires `aiohttp`; Level 2 also needs FFmpeg with H.264 and AAC
+encoders. The runner uses `ffmpeg` on `PATH`, falling back to `imageio-ffmpeg`.
+For a standalone client without a model installation, run the commands below
+with `uv run --no-project --with aiohttp --with imageio-ffmpeg python`.
+
+Download the [MIT-licensed dataset](https://huggingface.co/datasets/alexisty/SocialOmni)
+at the pinned revision:
+
+```bash
+uvx --from huggingface-hub hf download alexisty/SocialOmni \
+    --repo-type dataset --revision 3b76009b45090eaa54007454c93a831f3cc8e1e6 \
+    --local-dir /path/to/socialomni
+```
+
+The expected layout is `data/level_1/dataset.json` and
+`data/level_2/annotations.json`, with videos under each level. Results include
+metadata hashes and whether they match this revision; media content is not
+verified by those hashes.
+
+Run the client on the server host, or share identical absolute media paths.
+Both the dataset and prefix cache must be under the server's allowed media
+directory. For example, with the dataset at `/data/socialomni`:
+
+```bash
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni \
+    --host 127.0.0.1 --port 8091 \
+    --deploy-config vllm_omni/deploy/qwen3_omni_moe_thinking.yaml \
+    --allowed-local-media-path /data/socialomni
+```
+
+The upstream deployment configuration uses two GPUs and text output only,
+including when loading Instruct weights. Choose device and context settings
+that fit the videos and hardware; see the
+[Qwen3-Omni serving guide](../../examples/online_serving/qwen3_omni/README.md).
+The request contains one `video_url` and
+`mm_processor_kwargs.use_audio_in_video=true`, following the shared multimodal
+client. No separate audio item is sent.
+
+## Evaluation
+
+From the repository root, run a small deterministic selection covering both
+Level 1 visibility groups and Level 2 YES/NO decisions:
+
+```bash
+uv run --no-sync python -m benchmarks.socialomni.evaluate \
+    --dataset-root /data/socialomni \
+    --model Qwen/Qwen3-Omni-30B-A3B-Instruct \
+    --base-url http://127.0.0.1:8091 --mini \
+    --prefix-cache-dir /data/socialomni/prefixes \
+    --judge-config /path/to/judges.json
+```
+
+Remove `--mini` for all 2,000 Level 1 and 209 Level 2 samples. Use
+`--level level1` or `--level level2` to select one level. The first 200 Level 2
+records in source order also produce the paper subset metrics.
+
+Create a local judge configuration with exactly these three names. Set each
+`model` to the corresponding model ID served by that endpoint:
+
+```json
+{
+  "judges": [
+    {"name": "gpt-4o", "model": "gpt-4o", "base_url": "https://api.openai.com/v1", "api_key_env": "OPENAI_API_KEY", "max_concurrency": 4},
+    {"name": "gemini-2.5-pro", "model": "gemini-2.5-pro", "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions", "api_key_env": "GEMINI_API_KEY", "max_concurrency": 4},
+    {"name": "qwen3-omni", "model": "qwen3-omni", "base_url": "http://localhost:8092/v1", "api_key_env": null, "max_concurrency": 1}
+  ]
+}
+```
+
+Endpoints must accept OpenAI-compatible chat completions. API keys are read
+from the named environment variables; key values are not included in results.
+`--base-url` and judge URLs may include `/v1` or the complete
+`/chat/completions` path. Requests respect `HTTP_PROXY`, `HTTPS_PROXY`, and
+`NO_PROXY`. Set `NO_PROXY=localhost,127.0.0.1` for local servers.
+
+## Protocol and results
+
+Level 2 re-encodes video and audio up to the annotated timestamp before model
+requests. Model prompts receive neither the reference transcript nor the
+reference continuation. Responses are generated for every ground-truth YES,
+even when the model predicts NO. Only the judges receive reference material.
+
+Level 1 reports accuracy, macro-F1 (the mean F1 score over four answer
+positions), and accuracy by speaker visibility. Level 2 reports YES/NO
+classification and these response metrics:
+
+| Metric | Definition |
+| ------ | ---------- |
+| `QGold` | Three-judge mean quality over all ground-truth YES states; missing or empty generated responses contribute zero. |
+| `QEns` | Mean quality conditional on a correct YES decision and a non-empty successful response. |
+| `Cov+` | Fraction of ground-truth YES states meeting that condition. |
+| `QEns_joint` | `Cov+ * QEns`. |
+
+Every eligible response requires all three integer scores in
+`{0, 25, 50, 75, 100}`. Missing judges never produce a partial-panel mean.
+Omitting `--judge-config` allows a classification-only Level 2 run; quality
+remains unset and the run exits with status 1. Request failures and unparsable
+answers remain in the denominator and also make the run incomplete.
+
+Each run writes a unique JSON file under `benchmarks/results/socialomni/`,
+including configuration, client versions, metadata hashes, per-sample outputs,
+failures, and metrics. Client versions do not identify a remote server; retain
+its launch command, model revision, and software versions alongside results.
+Latency and throughput are client diagnostics, not paper quality metrics.
+
+`--max-concurrency` bounds model requests. Each non-empty model phase runs one
+warmup request per configured concurrent worker; `--warmup N` overrides this
+count. Warmup repeats initial samples and is discarded. Model wall time
+excludes prefix preparation, warmup, and judging. Judges have separate
+concurrency limits and no warmup. Transient requests are retried up to three
+times; an invalid judge score can trigger up to three scoring attempts.
+
+Reference: [SocialOmni paper](https://arxiv.org/abs/2603.16859).

--- a/benchmarks/socialomni/README.md
+++ b/benchmarks/socialomni/README.md
@@ -27,15 +27,14 @@ The expected layout is `data/level_1/dataset.json` and
 metadata hashes and whether they match this revision; media content is not
 verified by those hashes.
 
-Run the client on the server host, or share identical absolute media paths.
-Both the dataset and prefix cache must be under the server's allowed media
-directory. For example, with the dataset at `/data/socialomni`:
+The client embeds video bytes in each request, following the shared
+multimodal client. The server does not need access to the client's dataset or
+prefix cache. Start a text-output server:
 
 ```bash
 vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni \
     --host 127.0.0.1 --port 8091 \
-    --deploy-config vllm_omni/deploy/qwen3_omni_moe_thinking.yaml \
-    --allowed-local-media-path /data/socialomni
+    --deploy-config vllm_omni/deploy/qwen3_omni_moe_thinking.yaml
 ```
 
 The upstream deployment configuration uses two GPUs and text output only,
@@ -43,8 +42,8 @@ including when loading Instruct weights. Choose device and context settings
 that fit the videos and hardware; see the
 [Qwen3-Omni serving guide](../../examples/online_serving/qwen3_omni/README.md).
 The request contains one `video_url` and
-`mm_processor_kwargs.use_audio_in_video=true`, following the shared multimodal
-client. No separate audio item is sent.
+`mm_processor_kwargs.use_audio_in_video=true`. The video URL contains the
+base64-encoded video; no separate audio item is sent.
 
 ## Evaluation
 
@@ -116,7 +115,9 @@ Latency and throughput are client diagnostics, not paper quality metrics.
 `--max-concurrency` bounds model requests. Each non-empty model phase runs one
 warmup request per configured concurrent worker; `--warmup N` overrides this
 count. Warmup repeats initial samples and is discarded. Model wall time
-excludes prefix preparation, warmup, and judging. Judges have separate
+excludes prefix encoding, warmup, and judging, but includes reading and
+base64-encoding the request media. Request latency starts after that media
+preparation. Judges have separate
 concurrency limits and no warmup. Transient requests are retried up to three
 times; an invalid judge score can trigger up to three scoring attempts.
 

--- a/benchmarks/socialomni/README.md
+++ b/benchmarks/socialomni/README.md
@@ -34,7 +34,8 @@ prefix cache. Start a text-output server:
 ```bash
 vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni \
     --host 127.0.0.1 --port 8091 \
-    --deploy-config vllm_omni/deploy/qwen3_omni_moe_thinking.yaml
+    --deploy-config vllm_omni/deploy/qwen3_omni_moe_thinking.yaml \
+    --max-model-len 65536
 ```
 
 The upstream deployment configuration uses two GPUs and text output only,
@@ -145,6 +146,26 @@ selection checks the evaluation flow, not representative model quality.
 This run used vLLM 0.28.0, PyTorch 2.13.0+cu130, and Transformers 5.14.1.
 Judge latency depends on the provider and its load; elapsed time also depends
 on video duration, prefix cache state, and request concurrency.
+
+A full run with the same deployment processed all 2,000 Level 1 and 209
+Level 2 samples in 76.3 minutes, including prefix preparation and judging.
+All 2,342 measured model requests and 399 judge requests succeeded, with no
+unparsable answers. Level 1 accuracy was 74.40%. Level 2 results were:
+
+| Metric | All 209 samples | First 200 samples |
+| ------ | --------------- | ----------------- |
+| When accuracy | 60.29% | 60.50% |
+| `QGold` | 53.57 | 52.86 |
+| `QEns` | 52.96 | 52.17 |
+| `Cov+` | 93.23% | 92.97% |
+| `QEns_joint` | 49.37 | 48.50 |
+
+The run used benchmark commit `0c96505280b1` and model snapshot
+`ea64d566a2a0731823dc44965e7f89bad78f95cb`, with model concurrency 1, one warmup
+per model phase, and judge concurrency 2/2/1 for GPT-4o/Gemini/Qwen3-Omni.
+These are observed results for this deployment, not a cross-framework
+performance comparison. The full command is the mini command above with
+`--mini` removed; set the judge concurrency values in `judges.json` accordingly.
 
 `--max-concurrency` bounds model requests. Each non-empty model phase runs one
 warmup request per configured concurrent worker; `--warmup N` overrides this

--- a/benchmarks/socialomni/README.md
+++ b/benchmarks/socialomni/README.md
@@ -112,6 +112,40 @@ failures, and metrics. Client versions do not identify a remote server; retain
 its launch command, model revision, and software versions alongside results.
 Latency and throughput are client diagnostics, not paper quality metrics.
 
+Progress is written to stderr after warmup, at most once every five seconds
+and at the end of each phase. The final stdout JSON contains the result path
+and summary. `summary.elapsed_s` includes dataset loading, prefix preparation,
+warmup, model requests, and judging; it excludes server startup and result
+writing. `config.judges` records each judge's name, model, endpoint, and
+concurrency, omitting credentials and URL query strings.
+
+For example, a mini run with Qwen3-Omni-30B-A3B-Instruct on two H20 96 GB GPUs
+produced the following summary excerpt. All five measured model requests and
+three judge requests succeeded. With one warmup per model phase and cached
+prefixes, the run took 11.1 seconds, excluding server startup. This small
+selection checks the evaluation flow, not representative model quality.
+
+```json
+{
+  "status": "complete",
+  "elapsed_s": 11.134776549879462,
+  "level2": {
+    "metrics": {
+      "judge_status": {
+        "complete": true,
+        "eligible_responses": 1,
+        "completed_scores": 3,
+        "required_scores": 3
+      }
+    }
+  }
+}
+```
+
+This run used vLLM 0.28.0, PyTorch 2.13.0+cu130, and Transformers 5.14.1.
+Judge latency depends on the provider and its load; elapsed time also depends
+on video duration, prefix cache state, and request concurrency.
+
 `--max-concurrency` bounds model requests. Each non-empty model phase runs one
 warmup request per configured concurrent worker; `--warmup N` overrides this
 count. Warmup repeats initial samples and is discarded. Model wall time
@@ -120,5 +154,34 @@ base64-encoding the request media. Request latency starts after that media
 preparation. Judges have separate
 concurrency limits and no warmup. Transient requests are retried up to three
 times; an invalid judge score can trigger up to three scoring attempts.
+
+## Tests
+
+Run the client tests in the repository development environment:
+
+```bash
+uv run --no-sync python -m pytest \
+    tests/benchmarks/test_socialomni_dataset.py \
+    tests/benchmarks/test_socialomni_metrics.py \
+    tests/benchmarks/test_socialomni_protocol.py \
+    -m 'core_model and cpu' --run-level core_model
+```
+
+The GPU regression test starts the official two-GPU Qwen3-Omni server and
+runs the public command on the mini set. Install the benchmark dependencies
+above and set the dataset location to opt in:
+
+```bash
+VLLM_SOCIALOMNI_DATASET_ROOT=/path/to/socialomni \
+uv run --no-sync python -m pytest -sv \
+    tests/e2e/accuracy/test_qwen3_omni_socialomni_expansion.py \
+    -m 'full_model and omni and benchmark and cuda' --run-level full_model
+```
+
+Set `VLLM_SOCIALOMNI_MODEL` to use a local checkpoint. The test checks parsed
+answers, response generation, and the incomplete-quality result without
+external judges. It is included in the existing nightly accuracy test command
+and skips when `VLLM_SOCIALOMNI_DATASET_ROOT` is unset. It does not run the full
+dataset or contact external judge services.
 
 Reference: [SocialOmni paper](https://arxiv.org/abs/2603.16859).

--- a/benchmarks/socialomni/client.py
+++ b/benchmarks/socialomni/client.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from typing import TypeVar
+
+import aiohttp
+
+T = TypeVar("T")
+
+
+@dataclass
+class RequestResult:
+    request_id: str = ""
+    text: str = ""
+    is_success: bool = False
+    latency_s: float = 0.0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    error: str = ""
+
+
+async def run_phase(
+    items: Sequence[T],
+    send: Callable[[aiohttp.ClientSession, T], Awaitable[RequestResult]],
+    *,
+    max_concurrency: int,
+    timeout_s: float,
+    warmup: int | None = None,
+) -> tuple[list[RequestResult], float]:
+    """Run ordered requests with bounded concurrency, excluding warmup time."""
+    if max_concurrency < 1 or timeout_s <= 0 or (warmup is not None and warmup < 0):
+        raise ValueError("concurrency and timeout must be positive; warmup must be non-negative")
+    if not items:
+        return [], 0.0
+    semaphore = asyncio.Semaphore(max_concurrency)
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=timeout_s), trust_env=True) as session:
+
+        async def bounded(item: T) -> RequestResult:
+            async with semaphore:
+                return await send(session, item)
+
+        count = max_concurrency if warmup is None else warmup
+        await asyncio.gather(*(bounded(items[i % len(items)]) for i in range(count)))
+        started = time.perf_counter()
+        results = await asyncio.gather(*(bounded(item) for item in items))
+        return list(results), time.perf_counter() - started
+
+
+def request_metrics(results: Sequence[RequestResult], wall_clock_s: float) -> dict[str, int | float]:
+    successful = [result for result in results if result.is_success]
+    return {
+        "requests": len(results),
+        "successful_requests": len(successful),
+        "wall_clock_s": wall_clock_s,
+        "mean_latency_s": sum(result.latency_s for result in successful) / len(successful) if successful else 0.0,
+        "requests_per_second": len(successful) / wall_clock_s if wall_clock_s else 0.0,
+        "prompt_tokens": sum(result.prompt_tokens for result in successful),
+        "completion_tokens": sum(result.completion_tokens for result in successful),
+    }

--- a/benchmarks/socialomni/client.py
+++ b/benchmarks/socialomni/client.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 import asyncio
+import sys
 import time
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
@@ -10,6 +11,30 @@ from typing import TypeVar
 import aiohttp
 
 T = TypeVar("T")
+
+
+class Progress:
+    """Report phase progress to stderr without changing result output."""
+
+    def __init__(self, label: str, total: int) -> None:
+        self.label = label
+        self.total = total
+        self.completed = 0
+        self.failed = 0
+        self.started = self.last_report = time.perf_counter()
+        print(f"{label}: 0/{total}", file=sys.stderr, flush=True)
+
+    def update(self, success: bool = True) -> None:
+        self.completed += 1
+        self.failed += not success
+        now = time.perf_counter()
+        if self.completed == self.total or now - self.last_report >= 5:
+            print(
+                f"{self.label}: {self.completed}/{self.total}, {self.failed} failed, {now - self.started:.1f}s",
+                file=sys.stderr,
+                flush=True,
+            )
+            self.last_report = now
 
 
 @dataclass
@@ -30,6 +55,7 @@ async def run_phase(
     max_concurrency: int,
     timeout_s: float,
     warmup: int | None = None,
+    description: str | None = None,
 ) -> tuple[list[RequestResult], float]:
     """Run ordered requests with bounded concurrency, excluding warmup time."""
     if max_concurrency < 1 or timeout_s <= 0 or (warmup is not None and warmup < 0):
@@ -44,9 +70,19 @@ async def run_phase(
                 return await send(session, item)
 
         count = max_concurrency if warmup is None else warmup
+        if description and count:
+            print(f"{description}: warming up {count} requests", file=sys.stderr, flush=True)
         await asyncio.gather(*(bounded(items[i % len(items)]) for i in range(count)))
+        progress = Progress(description, len(items)) if description else None
         started = time.perf_counter()
-        results = await asyncio.gather(*(bounded(item) for item in items))
+
+        async def measured(item: T) -> RequestResult:
+            result = await bounded(item)
+            if progress:
+                progress.update(result.is_success)
+            return result
+
+        results = await asyncio.gather(*(measured(item) for item in items))
         return list(results), time.perf_counter() - started
 
 

--- a/benchmarks/socialomni/dataset.py
+++ b/benchmarks/socialomni/dataset.py
@@ -27,7 +27,7 @@ PREFIX_ENCODING = {
 
 SOCIALOMNI_DATASET_ID = "alexisty/SocialOmni"
 SOCIALOMNI_DATASET_REVISION = "3b76009b45090eaa54007454c93a831f3cc8e1e6"
-SOCIALOMNI_PAPER_CORE_SIZE = 200
+SOCIALOMNI_SUBSET_SIZE = 200
 SOCIALOMNI_METADATA_SHA256 = {
     "level1": "051f2e7ca0618de6e78843c64a3800606904be819f47c1e5c771f1c6a49faa23",
     "level2": "87137aa2270f65e9c9e124e54dc5b73d9fe9c4bf9317219a4efe88feb036c058",
@@ -137,12 +137,10 @@ def _video_path(level_dir: Path, raw: str, level: str, description: str) -> str:
     path = videos.joinpath(*parts).resolve()
     if not videos.is_relative_to(level_dir) or not path.is_relative_to(videos):
         raise ValueError(f"{description} media path escapes videos/")
-    if not path.is_file():
-        raise FileNotFoundError(f"{description} video is missing: {path}")
     return str(path)
 
 
-T = TypeVar("T")
+T = TypeVar("T", SocialOmniLevel1Sample, SocialOmniLevel2Sample)
 
 
 def _mini(samples: Sequence[T], groups: tuple[str, str], group: Callable[[T], str]) -> list[T]:
@@ -157,7 +155,11 @@ def _mini(samples: Sequence[T], groups: tuple[str, str], group: Callable[[T], st
 def _limit(samples: list[T], max_samples: int | None) -> list[T]:
     if max_samples is not None and max_samples < 0:
         raise ValueError("max_samples must be non-negative")
-    return samples if max_samples is None else samples[:max_samples]
+    selected = samples if max_samples is None else samples[:max_samples]
+    for sample in selected:
+        if not Path(sample.video_path).is_file():
+            raise FileNotFoundError(f"SocialOmni sample {sample.sample_id} video is missing: {sample.video_path}")
+    return selected
 
 
 def load_socialomni_level1_samples(

--- a/benchmarks/socialomni/dataset.py
+++ b/benchmarks/socialomni/dataset.py
@@ -1,0 +1,427 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Dataset loading for the SocialOmni benchmark."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import math
+import os
+import re
+import shutil
+import uuid
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, TypeVar
+
+PREFIX_ENCODING = {
+    "video_codec": "libx264",
+    "preset": "fast",
+    "crf": "18",
+    "audio_codec": "aac",
+    "audio_bitrate": "192k",
+}
+
+SOCIALOMNI_DATASET_ID = "alexisty/SocialOmni"
+SOCIALOMNI_DATASET_REVISION = "3b76009b45090eaa54007454c93a831f3cc8e1e6"
+SOCIALOMNI_PAPER_CORE_SIZE = 200
+SOCIALOMNI_METADATA_SHA256 = {
+    "level1": "051f2e7ca0618de6e78843c64a3800606904be819f47c1e5c771f1c6a49faa23",
+    "level2": "87137aa2270f65e9c9e124e54dc5b73d9fe9c4bf9317219a4efe88feb036c058",
+}
+
+
+@dataclass(frozen=True)
+class SocialOmniLevel1Sample:
+    sample_id: str
+    video_path: str
+    question: str
+    options: tuple[str, str, str, str]
+    gold_answer: str
+    visibility: str
+
+
+@dataclass(frozen=True)
+class SocialOmniLevel2Sample:
+    sample_id: str
+    video_path: str
+    timestamp_s: float
+    target_participant: str
+    question_when: str
+    question_how: str
+    gold_when: str
+    reference_response: str
+    reference_context: str
+
+
+def _level_dir(root: Path, level: str, metadata: str) -> Path:
+    candidates = [root / "data" / level, root / level]
+    if root.name == level:
+        candidates.insert(0, root)
+    for candidate in candidates:
+        if (candidate / metadata).is_file():
+            resolved = candidate.resolve()
+            if not resolved.is_relative_to(root):
+                raise ValueError(f"SocialOmni {level} directory escapes dataset root")
+            return resolved
+    raise FileNotFoundError(f"SocialOmni metadata not found: {candidates[0] / metadata}")
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid SocialOmni metadata {path}: {exc}") from exc
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def inspect_socialomni_dataset(dataset_root: str | Path, levels: Sequence[str]) -> dict[str, Any]:
+    """Identify local metadata against the pinned public dataset revision."""
+    root = Path(dataset_root).expanduser().resolve()
+    metadata_names = {
+        "level1": ("level_1", "dataset.json"),
+        "level2": ("level_2", "annotations.json"),
+    }
+    level_dirs = {level: _level_dir(root, *metadata_names[level]) for level in levels}
+    observed = {level: _sha256(level_dirs[level] / metadata_names[level][1]) for level in levels}
+    metadata_matches_expected_revision = all(observed[level] == SOCIALOMNI_METADATA_SHA256[level] for level in levels)
+    return {
+        "expected_huggingface_revision": SOCIALOMNI_DATASET_REVISION,
+        "verification_scope": "metadata_only",
+        "metadata_sha256": observed,
+        "metadata_matches_expected_revision": metadata_matches_expected_revision,
+    }
+
+
+def _object(value: Any, description: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TypeError(f"{description} must be a JSON object")
+    return value
+
+
+def _text(row: dict[str, Any], key: str, description: str) -> str:
+    value = str(row.get(key) or "").strip()
+    if not value:
+        raise ValueError(f"{description} has no non-empty {key!r}")
+    return value
+
+
+def _video_path(level_dir: Path, raw: str, level: str, description: str) -> str:
+    if "\\" in raw or "\x00" in raw:
+        raise ValueError(f"{description} uses an unsafe media path: {raw!r}")
+    relative = PurePosixPath(raw)
+    if relative.is_absolute() or any(part in {"", ".", ".."} for part in relative.parts):
+        raise ValueError(f"{description} uses an unsafe media path: {raw!r}")
+    parts = list(relative.parts)
+    if parts[:2] == ["data", level]:
+        parts = parts[2:]
+    elif parts[:1] == [level]:
+        parts = parts[1:]
+    elif parts[:1] in (["data"], ["level_1"], ["level_2"]):
+        raise ValueError(f"{description} references the wrong dataset level")
+    if parts[:1] == ["videos"]:
+        parts = parts[1:]
+    if not parts:
+        raise ValueError(f"{description} uses an empty media path")
+    videos = (level_dir / "videos").resolve()
+    path = videos.joinpath(*parts).resolve()
+    if not videos.is_relative_to(level_dir) or not path.is_relative_to(videos):
+        raise ValueError(f"{description} media path escapes videos/")
+    if not path.is_file():
+        raise FileNotFoundError(f"{description} video is missing: {path}")
+    return str(path)
+
+
+T = TypeVar("T")
+
+
+def _mini(samples: Sequence[T], groups: tuple[str, str], group: Callable[[T], str]) -> list[T]:
+    selected: dict[str, T] = {}
+    for sample in samples:
+        selected.setdefault(group(sample), sample)
+        if all(name in selected for name in groups):
+            return [selected[name] for name in groups]
+    raise ValueError(f"SocialOmni mini set is missing groups: {set(groups) - set(selected)}")
+
+
+def _limit(samples: list[T], max_samples: int | None) -> list[T]:
+    if max_samples is not None and max_samples < 0:
+        raise ValueError("max_samples must be non-negative")
+    return samples if max_samples is None else samples[:max_samples]
+
+
+def load_socialomni_level1_samples(
+    dataset_root: str | Path,
+    *,
+    max_samples: int | None = None,
+    mini: bool = False,
+) -> list[SocialOmniLevel1Sample]:
+    """Load speaker-attribution items while preserving nested media paths."""
+    root = Path(dataset_root).expanduser().resolve()
+    level_dir = _level_dir(root, "level_1", "dataset.json")
+    payload = _read_json(level_dir / "dataset.json")
+    if not isinstance(payload, list):
+        raise TypeError("SocialOmni Level 1 dataset.json must contain an array")
+    samples: list[SocialOmniLevel1Sample] = []
+    seen: set[str] = set()
+    for index, raw_row in enumerate(payload):
+        description = f"SocialOmni Level 1 row {index}"
+        row = _object(raw_row, description)
+        sample_id = _text(row, "id", description)
+        if sample_id in seen:
+            raise ValueError(f"Duplicate SocialOmni Level 1 sample id: {sample_id}")
+        seen.add(sample_id)
+        raw_options = row.get("options")
+        if not isinstance(raw_options, list) or len(raw_options) != 4:
+            raise ValueError(f"{description} must contain exactly four options")
+        options = tuple(
+            re.sub(r"^[A-D][.)]\s*", "", str(option).strip(), flags=re.IGNORECASE) for option in raw_options
+        )
+        answer = _text(row, "correct_answer", description).upper()
+        if answer not in {"A", "B", "C", "D"}:
+            raise ValueError(f"{description} has invalid correct_answer {answer!r}")
+        metadata = _object(row.get("metadata"), f"{description} metadata")
+        consistency = _text(metadata, "consistency", description).lower()
+        visibility = {
+            "consistent": "speaker_visible",
+            "inconsistent": "visibility_mismatch",
+        }.get(consistency)
+        if visibility is None:
+            raise ValueError(f"{description} has invalid consistency {consistency!r}")
+        samples.append(
+            SocialOmniLevel1Sample(
+                sample_id=sample_id,
+                video_path=_video_path(
+                    level_dir,
+                    _text(row, "video_path", description),
+                    "level_1",
+                    description,
+                ),
+                question=_text(row, "question", description),
+                options=options,  # type: ignore[arg-type]
+                gold_answer=answer,
+                visibility=visibility,
+            )
+        )
+    if mini:
+        samples = _mini(
+            samples,
+            ("speaker_visible", "visibility_mismatch"),
+            lambda sample: sample.visibility,
+        )
+    return _limit(samples, max_samples)
+
+
+def parse_socialomni_timestamp(value: Any) -> float:
+    """Parse seconds, MM:SS, or the source MM:SS:centiseconds notation."""
+    if isinstance(value, bool):
+        raise TypeError(f"Invalid SocialOmni timestamp type: {value!r}")
+    if isinstance(value, (int, float)):
+        seconds = float(value)
+    else:
+        text = str(value or "").strip()
+        if re.fullmatch(r"\d+(?:\.\d+)?", text):
+            seconds = float(text)
+        elif re.fullmatch(r"\d+:\d+(?:\.\d+)?", text):
+            minutes, tail = text.split(":")
+            seconds = int(minutes) * 60 + float(tail)
+        elif re.fullmatch(r"\d+:\d{2}:\d{2}", text):
+            minutes, tail, centiseconds = text.split(":")
+            seconds = int(minutes) * 60 + int(tail) + int(centiseconds) / 100
+        else:
+            raise ValueError(f"Invalid SocialOmni timestamp: {value!r}")
+    if not math.isfinite(seconds) or seconds <= 0:
+        raise ValueError(f"SocialOmni timestamp must be finite and positive: {value!r}")
+    return seconds
+
+
+def _gold_when(question: dict[str, Any], description: str) -> str:
+    answer = _text(question, "correct_answer", description).upper()
+    if answer in {"YES", "NO"}:
+        return answer
+    if answer not in {"A", "B"}:
+        raise ValueError(f"{description} has invalid correct_answer {answer!r}")
+    value = _text(question, f"option_{answer}", description).upper()
+    if value not in {"YES", "NO"}:
+        raise ValueError(f"{description} maps {answer} to invalid option {value!r}")
+    return value
+
+
+def _participant(question_how: str, question_when: str, description: str) -> str:
+    match = re.fullmatch(r"What should (.+?) say\?", question_how, re.IGNORECASE)
+    if not match:
+        match = re.match(r"(?:Should|Did) (.+?) speak(?:\s|\?)", question_when, re.IGNORECASE)
+    if not match:
+        raise ValueError(f"{description} does not identify the target participant")
+    return match.group(1).strip()
+
+
+def load_socialomni_level2_samples(
+    dataset_root: str | Path,
+    *,
+    max_samples: int | None = None,
+    mini: bool = False,
+) -> list[SocialOmniLevel2Sample]:
+    """Load all Level 2 items in source order."""
+    root = Path(dataset_root).expanduser().resolve()
+    level_dir = _level_dir(root, "level_2", "annotations.json")
+    payload = _read_json(level_dir / "annotations.json")
+    if isinstance(payload, dict):
+        declared = payload.get("total_samples")
+        payload = payload.get("data")
+        if isinstance(payload, list) and declared is not None and declared != len(payload):
+            raise ValueError("SocialOmni Level 2 total_samples does not match data length")
+    if not isinstance(payload, list):
+        raise TypeError("SocialOmni Level 2 annotations must contain an array")
+    samples: list[SocialOmniLevel2Sample] = []
+    seen: set[str] = set()
+    for index, raw_row in enumerate(payload):
+        description = f"SocialOmni Level 2 row {index}"
+        row = _object(raw_row, description)
+        sample_id = _text(row, "video_id", description)
+        if sample_id in seen:
+            raise ValueError(f"Duplicate SocialOmni Level 2 sample id: {sample_id}")
+        seen.add(sample_id)
+        when = _object(row.get("question_1"), f"{description} question_1")
+        how = _object(row.get("question_2"), f"{description} question_2")
+        question_when = _text(when, "question", f"{description} question_1")
+        question_how = _text(how, "question", f"{description} question_2")
+        gold_when = _gold_when(when, f"{description} question_1")
+        reference = str(how.get("answer") or "").strip()
+        if gold_when == "YES" and not reference:
+            raise ValueError(f"{description} has no reference response")
+        samples.append(
+            SocialOmniLevel2Sample(
+                sample_id=sample_id,
+                video_path=_video_path(
+                    level_dir,
+                    _text(row, "video_file", description),
+                    "level_2",
+                    description,
+                ),
+                timestamp_s=parse_socialomni_timestamp(_text(when, "timestamp", f"{description} question_1")),
+                target_participant=_participant(question_how, question_when, description),
+                question_when=question_when,
+                question_how=question_how,
+                gold_when=gold_when,
+                reference_response=reference,
+                reference_context=_text(row, "full_asr", description),
+            )
+        )
+    if mini:
+        samples = _mini(samples, ("YES", "NO"), lambda sample: sample.gold_when)
+    return _limit(samples, max_samples)
+
+
+def resolve_ffmpeg_executable() -> str | None:
+    system = shutil.which("ffmpeg")
+    if system:
+        return system
+    try:
+        import imageio_ffmpeg
+    except ImportError:
+        return None
+    bundled = Path(imageio_ffmpeg.get_ffmpeg_exe())
+    return str(bundled) if bundled.is_file() and os.access(bundled, os.X_OK) else None
+
+
+def build_ffmpeg_prefix_command(ffmpeg: str, source: Path, timestamp_s: float, output: Path) -> list[str]:
+    return [
+        ffmpeg,
+        "-nostdin",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        str(source),
+        "-t",
+        f"{timestamp_s:.6f}",
+        "-map",
+        "0:v:0",
+        "-map",
+        "0:a?",
+        "-c:v",
+        PREFIX_ENCODING["video_codec"],
+        "-preset",
+        PREFIX_ENCODING["preset"],
+        "-crf",
+        PREFIX_ENCODING["crf"],
+        "-c:a",
+        PREFIX_ENCODING["audio_codec"],
+        "-b:a",
+        PREFIX_ENCODING["audio_bitrate"],
+        "-movflags",
+        "+faststart",
+        "-y",
+        str(output),
+    ]
+
+
+async def create_video_prefix(
+    input_path: str | Path,
+    timestamp_s: float,
+    cache_dir: str | Path,
+    *,
+    timeout: float = 300.0,
+) -> Path:
+    """Re-encode video and audio up to the query time into an atomic cache entry."""
+    if not math.isfinite(timestamp_s) or timestamp_s <= 0:
+        raise ValueError("timestamp_s must be finite and positive")
+    if not math.isfinite(timeout) or timeout <= 0:
+        raise ValueError("timeout must be finite and positive")
+    source = Path(input_path).resolve()
+    if not source.is_file():
+        raise FileNotFoundError(source)
+    ffmpeg = resolve_ffmpeg_executable()
+    if not ffmpeg:
+        raise RuntimeError("ffmpeg is required for SocialOmni Level 2")
+    key = hashlib.sha256(
+        json.dumps(
+            {
+                "source_sha256": await asyncio.to_thread(_sha256, source),
+                "timestamp_s": f"{timestamp_s:.6f}",
+                "encoding": PREFIX_ENCODING,
+            },
+            sort_keys=True,
+        ).encode()
+    ).hexdigest()
+    cache = Path(cache_dir).expanduser().resolve()
+    cache.mkdir(parents=True, exist_ok=True)
+    output = cache / f"{key}.mp4"
+    if output.is_file() and output.stat().st_size:
+        return output
+    temporary = cache / f".{key}.{uuid.uuid4().hex}.tmp.mp4"
+    process = await asyncio.create_subprocess_exec(
+        *build_ffmpeg_prefix_command(ffmpeg, source, timestamp_s, temporary),
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        _, stderr = await asyncio.wait_for(process.communicate(), timeout=timeout)
+        if process.returncode or not temporary.is_file() or not temporary.stat().st_size:
+            raise RuntimeError(
+                f"ffmpeg prefix generation failed for {source}: {stderr.decode(errors='replace')[:2000]}"
+            )
+        temporary.replace(output)
+        return output
+    except asyncio.TimeoutError as exc:
+        raise RuntimeError(f"ffmpeg prefix generation timed out after {timeout}s for {source}") from exc
+    finally:
+        if process.returncode is None:
+            try:
+                process.kill()
+            except ProcessLookupError:
+                pass
+            await process.communicate()
+        temporary.unlink(missing_ok=True)

--- a/benchmarks/socialomni/evaluate.py
+++ b/benchmarks/socialomni/evaluate.py
@@ -40,6 +40,7 @@ from benchmarks.socialomni.protocol import (
     build_level1_result_records,
     load_judge_config,
     make_level1_send_fn,
+    public_endpoint,
     run_judges,
     run_level2_model,
     validate_judge_credentials,
@@ -113,6 +114,7 @@ async def run_socialomni(config: SocialOmniEvalConfig) -> dict[str, Any]:
     output: dict[str, Any] = {
         "config": {
             **asdict(config),
+            "base_url": public_endpoint(config.base_url),
             "dataset_root": str(Path(config.dataset_root).resolve()),
             "judge_config": None,
             "judges": [judge.public_dict() for judge in judges],

--- a/benchmarks/socialomni/evaluate.py
+++ b/benchmarks/socialomni/evaluate.py
@@ -19,7 +19,7 @@ from benchmarks.socialomni.client import RequestResult, request_metrics, run_pha
 from benchmarks.socialomni.dataset import (
     SOCIALOMNI_DATASET_ID,
     SOCIALOMNI_DATASET_REVISION,
-    SOCIALOMNI_PAPER_CORE_SIZE,
+    SOCIALOMNI_SUBSET_SIZE,
     inspect_socialomni_dataset,
     load_socialomni_level1_samples,
     load_socialomni_level2_samples,
@@ -242,19 +242,20 @@ async def run_socialomni(config: SocialOmniEvalConfig) -> dict[str, Any]:
                 "judges": request_metrics(judge_requests, wall_clock_s=judge_wall_s),
             },
         }
-        if len(records) >= SOCIALOMNI_PAPER_CORE_SIZE:
-            core = records[:SOCIALOMNI_PAPER_CORE_SIZE]
+        if len(records) >= SOCIALOMNI_SUBSET_SIZE:
+            core = records[:SOCIALOMNI_SUBSET_SIZE]
             core_complete = _judges_complete(core, bool(judges))
             core_metrics = compute_socialomni_level2_metrics(core) if core_complete else None
             core_summary: dict[str, Any] = {
                 "sample_count": len(core),
+                "selection": "source_order_first_200",
                 "when": (core_metrics["when"] if core_metrics else compute_socialomni_when_metrics(core)),
                 "quality": None,
                 "judges_complete": core_complete,
             }
             if core_metrics:
                 core_summary["quality"] = core_metrics["quality"]
-            output["paper_core_200"] = core_summary
+            output["first_200"] = core_summary
         output["per_sample"]["level2"] = records
 
     level2_complete = "level2" not in levels or (output["summary"]["level2"]["metrics"]["judge_status"]["complete"])

--- a/benchmarks/socialomni/evaluate.py
+++ b/benchmarks/socialomni/evaluate.py
@@ -1,0 +1,303 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Evaluate Qwen3-Omni on the SocialOmni paper protocol."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import subprocess
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any, Literal
+
+from benchmarks.socialomni.client import RequestResult, request_metrics, run_phase
+from benchmarks.socialomni.dataset import (
+    SOCIALOMNI_DATASET_ID,
+    SOCIALOMNI_DATASET_REVISION,
+    SOCIALOMNI_PAPER_CORE_SIZE,
+    inspect_socialomni_dataset,
+    load_socialomni_level1_samples,
+    load_socialomni_level2_samples,
+)
+from benchmarks.socialomni.metrics import (
+    SOCIALOMNI_JUDGE_NAMES,
+    JudgeCompletenessError,
+    compute_socialomni_level1_metrics,
+    compute_socialomni_level2_metrics,
+    compute_socialomni_when_metrics,
+    validate_judge_scores,
+)
+from benchmarks.socialomni.protocol import (
+    JUDGE_MAX_TOKENS,
+    LEVEL1_MAX_TOKENS,
+    LEVEL2_RESPONSE_MAX_TOKENS,
+    LEVEL2_WHEN_MAX_TOKENS,
+    build_level1_result_records,
+    load_judge_config,
+    make_level1_send_fn,
+    run_judges,
+    run_level2_model,
+    validate_judge_credentials,
+)
+
+
+@dataclass(frozen=True)
+class SocialOmniEvalConfig:
+    dataset_root: str
+    model: str
+    base_url: str
+    level: Literal["level1", "level2", "both"]
+    judge_config: str | None
+    prefix_cache_dir: str
+    mini: bool
+    max_samples: int | None
+    max_concurrency: int
+    timeout_s: int
+    output_dir: str
+    warmup: int | None = None
+
+
+def _request_failure(result: RequestResult, phase: str) -> dict[str, str] | None:
+    if result.is_success:
+        return None
+    return {
+        "phase": phase,
+        "request_id": result.request_id,
+        "error": result.error,
+    }
+
+
+def _judges_complete(records: list[dict[str, Any]], configured: bool) -> bool:
+    if not configured:
+        return False
+    try:
+        for record in records:
+            if (
+                record["gold_when"] == "YES"
+                and record["gold_response_success"]
+                and str(record["gold_response"]).strip()
+            ):
+                validate_judge_scores(record["gold_judge_scores"], str(record.get("sample_id", "")))
+    except JudgeCompletenessError:
+        return False
+    return True
+
+
+async def run_socialomni(config: SocialOmniEvalConfig) -> dict[str, Any]:
+    if config.max_concurrency < 1 or config.timeout_s <= 0:
+        raise ValueError("max_concurrency and timeout_s must be positive")
+    if config.warmup is not None and config.warmup < 0:
+        raise ValueError("warmup must be >= 0")
+    levels = ("level1", "level2") if config.level == "both" else (config.level,)
+    judges = load_judge_config(config.judge_config) if "level2" in levels and config.judge_config else []
+    validate_judge_credentials(judges)
+    warmup = config.max_concurrency if config.warmup is None else config.warmup
+    dataset_identity = inspect_socialomni_dataset(config.dataset_root, levels)
+    repository = Path(__file__).resolve().parents[2]
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repository, capture_output=True, text=True, check=False
+    ).stdout.strip()
+    versions = {}
+    for package in ("vllm", "vllm-omni", "aiohttp"):
+        try:
+            versions[package] = version(package)
+        except PackageNotFoundError:
+            versions[package] = None
+    provenance = {"commit": commit or None, "client_versions": versions}
+    output: dict[str, Any] = {
+        "config": {
+            **asdict(config),
+            "dataset_root": str(Path(config.dataset_root).resolve()),
+            "judge_config": None,
+            "dataset_id": SOCIALOMNI_DATASET_ID,
+            "expected_dataset_revision": SOCIALOMNI_DATASET_REVISION,
+            "warmup_per_nonempty_model_phase": warmup,
+            "judge_warmup": 0,
+            "generation": {
+                "temperature": 0.0,
+                "stream": False,
+                "level1_max_tokens": LEVEL1_MAX_TOKENS,
+                "level2_when_max_tokens": LEVEL2_WHEN_MAX_TOKENS,
+                "level2_response_max_tokens": LEVEL2_RESPONSE_MAX_TOKENS,
+                "judge_max_tokens": JUDGE_MAX_TOKENS,
+            },
+        },
+        "dataset": dataset_identity,
+        "provenance": provenance,
+        "summary": {},
+        "per_sample": {},
+        "failures": [],
+    }
+
+    if "level1" in levels:
+        samples = load_socialomni_level1_samples(
+            config.dataset_root,
+            mini=config.mini,
+            max_samples=config.max_samples,
+        )
+        request_results, wall_s = await run_phase(
+            samples,
+            make_level1_send_fn(config.model, config.base_url),
+            max_concurrency=config.max_concurrency,
+            timeout_s=config.timeout_s,
+            warmup=config.warmup,
+        )
+        records = build_level1_result_records(samples, request_results)
+        for record, result in zip(records, request_results, strict=True):
+            failure = _request_failure(result, "level1")
+            if failure:
+                output["failures"].append(failure)
+            elif not record["predicted_answer"]:
+                output["failures"].append(
+                    {
+                        "phase": "level1_parse",
+                        "request_id": result.request_id,
+                        "error": f"unparsable response: {result.text!r}",
+                    }
+                )
+        output["per_sample"]["level1"] = records
+        output["summary"]["level1"] = {
+            "metrics": compute_socialomni_level1_metrics(records),
+            "speed": request_metrics(request_results, wall_clock_s=wall_s),
+        }
+
+    if "level2" in levels:
+        samples = load_socialomni_level2_samples(
+            config.dataset_root,
+            mini=config.mini,
+            max_samples=config.max_samples,
+        )
+        records, model_requests, model_wall_s = await run_level2_model(
+            samples,
+            model=config.model,
+            base_url=config.base_url,
+            prefix_cache_dir=config.prefix_cache_dir,
+            max_concurrency=config.max_concurrency,
+            timeout_s=config.timeout_s,
+            warmup=config.warmup,
+        )
+        for result in model_requests:
+            failure = _request_failure(result, "level2_model")
+            if failure:
+                output["failures"].append(failure)
+
+        output["config"]["judges"] = [asdict(judge) for judge in judges]
+        judge_requests = []
+        judge_failures: list[dict[str, str]] = []
+        judge_wall_s = 0.0
+        if judges:
+            judge_started = time.perf_counter()
+            judge_requests, judge_failures = await run_judges(
+                samples,
+                records,
+                judges,
+                timeout_s=config.timeout_s,
+            )
+            judge_wall_s = time.perf_counter() - judge_started
+            output["failures"].extend(judge_failures)
+        for record in records:
+            if record["when_success"] and not record["predicted_when"]:
+                output["failures"].append(
+                    {
+                        "phase": "level2_parse",
+                        "request_id": f"{record['sample_id']}:when",
+                        "error": f"unparsable response: {record['when_raw_response']!r}",
+                    }
+                )
+
+        required_judgments = sum(
+            1
+            for record in records
+            if record["gold_when"] == "YES" and record["gold_response_success"] and str(record["gold_response"]).strip()
+        )
+        judges_complete = _judges_complete(records, bool(judges))
+        complete_metrics = compute_socialomni_level2_metrics(records) if judges_complete else None
+        selected = {
+            "when": (complete_metrics["when"] if complete_metrics else compute_socialomni_when_metrics(records)),
+            "quality": None,
+            "judge_status": {
+                "complete": judges_complete,
+                "eligible_responses": required_judgments,
+                "completed_scores": sum(len(record["gold_judge_scores"]) for record in records),
+                "required_scores": required_judgments * len(SOCIALOMNI_JUDGE_NAMES),
+            },
+        }
+        if complete_metrics:
+            selected["quality"] = complete_metrics["quality"]
+            selected["bootstrap"] = complete_metrics["bootstrap"]
+            selected["judge_names"] = complete_metrics["judge_names"]
+        output["summary"]["level2"] = {
+            "metrics": selected,
+            "speed": {
+                "model": request_metrics(model_requests, wall_clock_s=model_wall_s),
+                "judges": request_metrics(judge_requests, wall_clock_s=judge_wall_s),
+            },
+        }
+        if len(records) >= SOCIALOMNI_PAPER_CORE_SIZE:
+            core = records[:SOCIALOMNI_PAPER_CORE_SIZE]
+            core_complete = _judges_complete(core, bool(judges))
+            core_metrics = compute_socialomni_level2_metrics(core) if core_complete else None
+            core_summary: dict[str, Any] = {
+                "sample_count": len(core),
+                "when": (core_metrics["when"] if core_metrics else compute_socialomni_when_metrics(core)),
+                "quality": None,
+                "judges_complete": core_complete,
+            }
+            if core_metrics:
+                core_summary["quality"] = core_metrics["quality"]
+            output["paper_core_200"] = core_summary
+        output["per_sample"]["level2"] = records
+
+    level2_complete = "level2" not in levels or (output["summary"]["level2"]["metrics"]["judge_status"]["complete"])
+    output["summary"]["status"] = "complete" if level2_complete and not output["failures"] else "incomplete"
+    return output
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset-root", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--base-url", default="http://localhost:8000")
+    parser.add_argument("--level", choices=("level1", "level2", "both"), default="both")
+    parser.add_argument("--judge-config")
+    parser.add_argument("--prefix-cache-dir", default="benchmarks/cache/socialomni-prefixes")
+    parser.add_argument("--mini", action="store_true")
+    parser.add_argument("--max-samples", type=int)
+    parser.add_argument("--max-concurrency", type=int, default=1)
+    parser.add_argument("--timeout-s", type=int, default=300)
+    parser.add_argument("--warmup", type=int, default=None)
+    parser.add_argument("--output-dir", default="benchmarks/results/socialomni")
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    config = SocialOmniEvalConfig(**vars(args))
+    output = asyncio.run(run_socialomni(config))
+    commit = output["provenance"]["commit"] or "unknown"
+    stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    directory = Path(config.output_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"socialomni-{commit[:12]}-{stamp}-{uuid.uuid4().hex[:8]}.json"
+    with path.open("x", encoding="utf-8") as output_file:
+        json.dump(output, output_file, indent=2, allow_nan=False)
+        output_file.write("\n")
+    print(
+        json.dumps(
+            {
+                "status": output["summary"]["status"],
+                "result": str(path),
+            }
+        )
+    )
+    if output["summary"]["status"] != "complete":
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/socialomni/evaluate.py
+++ b/benchmarks/socialomni/evaluate.py
@@ -89,6 +89,7 @@ def _judges_complete(records: list[dict[str, Any]], configured: bool) -> bool:
 
 
 async def run_socialomni(config: SocialOmniEvalConfig) -> dict[str, Any]:
+    started = time.perf_counter()
     if config.max_concurrency < 1 or config.timeout_s <= 0:
         raise ValueError("max_concurrency and timeout_s must be positive")
     if config.warmup is not None and config.warmup < 0:
@@ -114,6 +115,7 @@ async def run_socialomni(config: SocialOmniEvalConfig) -> dict[str, Any]:
             **asdict(config),
             "dataset_root": str(Path(config.dataset_root).resolve()),
             "judge_config": None,
+            "judges": [judge.public_dict() for judge in judges],
             "dataset_id": SOCIALOMNI_DATASET_ID,
             "expected_dataset_revision": SOCIALOMNI_DATASET_REVISION,
             "warmup_per_nonempty_model_phase": warmup,
@@ -146,6 +148,7 @@ async def run_socialomni(config: SocialOmniEvalConfig) -> dict[str, Any]:
             max_concurrency=config.max_concurrency,
             timeout_s=config.timeout_s,
             warmup=config.warmup,
+            description="level1",
         )
         records = build_level1_result_records(samples, request_results)
         for record, result in zip(records, request_results, strict=True):
@@ -186,7 +189,6 @@ async def run_socialomni(config: SocialOmniEvalConfig) -> dict[str, Any]:
             if failure:
                 output["failures"].append(failure)
 
-        output["config"]["judges"] = [asdict(judge) for judge in judges]
         judge_requests = []
         judge_failures: list[dict[str, str]] = []
         judge_wall_s = 0.0
@@ -255,6 +257,7 @@ async def run_socialomni(config: SocialOmniEvalConfig) -> dict[str, Any]:
 
     level2_complete = "level2" not in levels or (output["summary"]["level2"]["metrics"]["judge_status"]["complete"])
     output["summary"]["status"] = "complete" if level2_complete and not output["failures"] else "incomplete"
+    output["summary"]["elapsed_s"] = time.perf_counter() - started
     return output
 
 
@@ -292,6 +295,7 @@ def main() -> None:
             {
                 "status": output["summary"]["status"],
                 "result": str(path),
+                "summary": output["summary"],
             }
         )
     )

--- a/benchmarks/socialomni/metrics.py
+++ b/benchmarks/socialomni/metrics.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Metrics for the SocialOmni paper protocol."""
+
+from __future__ import annotations
+
+import math
+import random
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+SOCIALOMNI_JUDGE_NAMES = ("gpt-4o", "gemini-2.5-pro", "qwen3-omni")
+SOCIALOMNI_SCORE_BUCKETS = frozenset({0, 25, 50, 75, 100})
+
+
+class JudgeCompletenessError(ValueError):
+    """A response has missing or invalid judge scores."""
+
+
+def _ratio(numerator: float, denominator: float) -> float:
+    return numerator / denominator if denominator else 0.0
+
+
+def wilson_interval(successes: int, total: int) -> dict[str, float]:
+    """Return a two-sided Wilson 95% confidence interval."""
+    if not 0 <= successes <= total:
+        raise ValueError("Wilson interval requires 0 <= successes <= total")
+    if total == 0:
+        return {"low": 0.0, "high": 0.0}
+    z = 1.959963984540054
+    proportion = successes / total
+    denominator = 1 + z**2 / total
+    center = (proportion + z**2 / (2 * total)) / denominator
+    radius = z * math.sqrt(proportion * (1 - proportion) / total + z**2 / (4 * total**2)) / denominator
+    return {"low": max(0.0, center - radius), "high": min(1.0, center + radius)}
+
+
+def _classification(gold: Sequence[int], predicted: Sequence[int | None], labels: Sequence[int]) -> dict[str, Any]:
+    if len(gold) != len(predicted):
+        raise ValueError("gold and predicted lengths differ")
+    correct = sum(expected == actual for expected, actual in zip(gold, predicted))
+    per_class: dict[str, dict[str, Any]] = {}
+    f1s: list[float] = []
+    for label in labels:
+        tp = sum(g == label and p == label for g, p in zip(gold, predicted))
+        fp = sum(g != label and p == label for g, p in zip(gold, predicted))
+        fn = sum(g == label and p != label for g, p in zip(gold, predicted))
+        precision = _ratio(tp, tp + fp)
+        recall = _ratio(tp, tp + fn)
+        f1 = _ratio(2 * precision * recall, precision + recall)
+        f1s.append(f1)
+        per_class[str(label)] = {
+            "support": tp + fn,
+            "true_positive": tp,
+            "false_positive": fp,
+            "false_negative": fn,
+            "precision": precision,
+            "precision_ci95": wilson_interval(tp, tp + fp),
+            "recall": recall,
+            "recall_ci95": wilson_interval(tp, tp + fn),
+            "f1": f1,
+        }
+    return {
+        "total_samples": len(gold),
+        "correct": correct,
+        "accuracy": _ratio(correct, len(gold)),
+        "accuracy_ci95": wilson_interval(correct, len(gold)),
+        "macro_f1": _ratio(sum(f1s), len(labels)),
+        "per_class": per_class,
+        "unparsable_or_failed": sum(value is None for value in predicted),
+    }
+
+
+def _choice(value: object) -> int | None:
+    text = str(value or "").strip().upper()
+    return ord(text) - ord("A") if text in {"A", "B", "C", "D"} else None
+
+
+def compute_socialomni_level1_metrics(records: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    """Compute fixed-denominator Level 1 metrics and visibility strata."""
+    rows = list(records)
+    gold = [_choice(row["gold_answer"]) for row in rows]
+    if any(value is None for value in gold):
+        raise ValueError("invalid Level 1 gold answer")
+    predicted = [(_choice(row.get("predicted_answer", "")) if row.get("is_success", True) else None) for row in rows]
+    result = _classification(gold, predicted, (0, 1, 2, 3))  # type: ignore[arg-type]
+    strata: dict[str, Any] = {}
+    for name in ("speaker_visible", "visibility_mismatch"):
+        indices = [i for i, row in enumerate(rows) if row["visibility"] == name]
+        current = _classification(
+            [gold[i] for i in indices],  # type: ignore[list-item]
+            [predicted[i] for i in indices],
+            (0, 1, 2, 3),
+        )
+        strata[name] = {key: current[key] for key in ("total_samples", "correct", "accuracy", "accuracy_ci95")}
+    result["strata"] = strata
+    result["visible_minus_mismatch_accuracy"] = (
+        strata["speaker_visible"]["accuracy"] - strata["visibility_mismatch"]["accuracy"]
+    )
+    return result
+
+
+def _when(value: object) -> int | None:
+    text = str(value or "").strip().upper()
+    return 1 if text == "YES" else 0 if text == "NO" else None
+
+
+def validate_judge_scores(value: object, sample_id: str) -> dict[str, int]:
+    """Require one integer score in the allowed buckets from each fixed judge."""
+    if not isinstance(value, Mapping) or set(value) != set(SOCIALOMNI_JUDGE_NAMES):
+        raise JudgeCompletenessError(f"sample {sample_id!r} requires all judges {SOCIALOMNI_JUDGE_NAMES}")
+    scores: dict[str, int] = {}
+    for judge in SOCIALOMNI_JUDGE_NAMES:
+        score = value[judge]
+        if type(score) is not int or score not in SOCIALOMNI_SCORE_BUCKETS:
+            raise JudgeCompletenessError(f"sample {sample_id!r} has invalid {judge!r} score {score!r}")
+        scores[judge] = int(score)
+    return scores
+
+
+def _quantile(values: Sequence[float], probability: float) -> float:
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * probability
+    lower, upper = math.floor(position), math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    return ordered[lower] * (upper - position) + ordered[upper] * (position - lower)
+
+
+def bootstrap_mean_interval(values: Sequence[float], *, seed: int, samples: int) -> dict[str, float] | None:
+    """Return a deterministic percentile-bootstrap 95% interval for a mean."""
+    if samples <= 0:
+        raise ValueError("bootstrap samples must be positive")
+    if not values:
+        return None
+    generator = random.Random(seed)
+    size = len(values)
+    means = [sum(values[generator.randrange(size)] for _ in range(size)) / size for _ in range(samples)]
+    return {"low": _quantile(means, 0.025), "high": _quantile(means, 0.975)}
+
+
+def compute_socialomni_level2_metrics(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    bootstrap_seed: int = 20260902,
+    bootstrap_samples: int = 10_000,
+) -> dict[str, Any]:
+    """Compute turn-entry and complete three-judge response metrics."""
+    rows = list(records)
+    when_metrics, gold, predicted = _level2_when_metrics(rows)
+
+    gold_scores: list[float] = []
+    conditional_scores: list[float] = []
+    joint_scores: list[float] = []
+    positive_total = 0
+    for index, row in enumerate(rows):
+        if gold[index] != 1:
+            continue
+        positive_total += 1
+        response = row.get("gold_response", "")
+        has_response = bool(row.get("gold_response_success", False) and isinstance(response, str) and response.strip())
+        score = 0.0
+        if has_response:
+            scores = validate_judge_scores(
+                row.get("gold_judge_scores", {}),
+                str(row.get("sample_id", index)),
+            )
+            score = sum(scores.values()) / len(scores)
+        gold_scores.append(score)
+        covered = predicted[index] == 1 and has_response
+        if covered:
+            conditional_scores.append(score)
+        joint_scores.append(score if covered else 0.0)
+
+    covered = len(conditional_scores)
+    qgold = _ratio(sum(gold_scores), len(gold_scores))
+    qens = _ratio(sum(conditional_scores), covered) if conditional_scores else None
+    cov_plus = _ratio(covered, positive_total)
+    quality = {
+        "gold_positive_samples": positive_total,
+        "covered_positive_samples": covered,
+        "qgold": qgold,
+        "qens": qens,
+        "cov_plus": cov_plus,
+        "qens_joint": cov_plus * qens if qens is not None else 0.0,
+        "cov_plus_ci95": wilson_interval(covered, positive_total),
+        "qgold_ci95": bootstrap_mean_interval(gold_scores, seed=bootstrap_seed, samples=bootstrap_samples),
+        "qens_ci95": bootstrap_mean_interval(conditional_scores, seed=bootstrap_seed + 1, samples=bootstrap_samples),
+        "qens_joint_ci95": bootstrap_mean_interval(joint_scores, seed=bootstrap_seed + 2, samples=bootstrap_samples),
+    }
+    return {
+        "judge_names": list(SOCIALOMNI_JUDGE_NAMES),
+        "bootstrap": {"seed": bootstrap_seed, "samples": bootstrap_samples},
+        "when": when_metrics,
+        "quality": quality,
+    }
+
+
+def _level2_when_metrics(
+    rows: Sequence[Mapping[str, Any]],
+) -> tuple[dict[str, Any], list[int | None], list[int | None]]:
+    gold = [_when(row["gold_when"]) for row in rows]
+    if any(value is None for value in gold):
+        raise ValueError("invalid Level 2 gold decision")
+    predicted = [(_when(row.get("predicted_when", "")) if row.get("when_success", True) else None) for row in rows]
+    classification = _classification(gold, predicted, (0, 1))  # type: ignore[arg-type]
+    positive = classification["per_class"]["1"]
+    negative = classification["per_class"]["0"]
+    when_metrics = {
+        "total_samples": classification["total_samples"],
+        "correct": classification["correct"],
+        "accuracy": classification["accuracy"],
+        "accuracy_ci95": classification["accuracy_ci95"],
+        "macro_f1": classification["macro_f1"],
+        "unparsable_or_failed": classification["unparsable_or_failed"],
+        "positive_precision": positive["precision"],
+        "positive_precision_ci95": positive["precision_ci95"],
+        "positive_recall": positive["recall"],
+        "positive_recall_ci95": positive["recall_ci95"],
+        "positive_f1": positive["f1"],
+        "confusion": {
+            "true_positive": positive["true_positive"],
+            "false_positive": positive["false_positive"],
+            "false_negative": positive["false_negative"],
+            "true_negative": negative["true_positive"],
+        },
+    }
+    return when_metrics, gold, predicted
+
+
+def compute_socialomni_when_metrics(records: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    """Compute Level 2 classification metrics without requiring judge output."""
+    metrics, _, _ = _level2_when_metrics(list(records))
+    return metrics

--- a/benchmarks/socialomni/protocol.py
+++ b/benchmarks/socialomni/protocol.py
@@ -47,13 +47,17 @@ class JudgeSpec:
     max_concurrency: int
 
     def public_dict(self) -> dict[str, str | int]:
-        endpoint = urlsplit(self.base_url)
         return {
             "name": self.name,
             "model": self.model,
-            "base_url": endpoint._replace(netloc=endpoint.netloc.rsplit("@", 1)[-1], query="", fragment="").geturl(),
+            "base_url": public_endpoint(self.base_url),
             "max_concurrency": self.max_concurrency,
         }
+
+
+def public_endpoint(url: str) -> str:
+    endpoint = urlsplit(url)
+    return endpoint._replace(netloc=endpoint.netloc.rsplit("@", 1)[-1], query="", fragment="").geturl()
 
 
 def chat_completions_url(base_url: str) -> str:
@@ -162,7 +166,7 @@ async def request_chat_completion(
                     last = RequestResult(
                         request_id=request_id,
                         latency_s=time.perf_counter() - request_started,
-                        error=f"HTTP {response.status}: {raw[:2000]}",
+                        error=f"HTTP {response.status}",
                     )
                     retry = response.status in RETRYABLE_STATUS or 500 <= response.status < 600
                 else:
@@ -172,7 +176,7 @@ async def request_chat_completion(
                         last = RequestResult(
                             request_id=request_id,
                             latency_s=time.perf_counter() - request_started,
-                            error=f"invalid JSON response: {exc}: {raw[:1000]}",
+                            error=f"invalid JSON response: {exc}",
                         )
                         retry = True
                     else:
@@ -180,7 +184,7 @@ async def request_chat_completion(
                             last = RequestResult(
                                 request_id=request_id,
                                 latency_s=time.perf_counter() - request_started,
-                                error=f"invalid JSON response object: {raw[:1000]}",
+                                error="invalid JSON response object",
                             )
                             retry = True
                         else:
@@ -218,7 +222,7 @@ async def request_chat_completion(
             last = RequestResult(
                 request_id=request_id,
                 latency_s=time.perf_counter() - request_started,
-                error=f"{type(exc).__name__}: {exc}",
+                error=f"{type(exc).__name__}: {public_endpoint(api_url)}",
             )
             retry = True
         if not retry or attempt + 1 == max_attempts:

--- a/benchmarks/socialomni/protocol.py
+++ b/benchmarks/socialomni/protocol.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import os
 import re
@@ -290,13 +291,14 @@ def build_judge_prompt(sample: SocialOmniLevel2Sample, candidate: str) -> str:
 
 
 def model_payload(model: str, prompt: str, video_path: str, max_tokens: int) -> dict[str, Any]:
+    video = base64.b64encode(Path(video_path).read_bytes()).decode("ascii")
     return {
         "model": model,
         "messages": [
             {
                 "role": "user",
                 "content": [
-                    {"type": "video_url", "video_url": {"url": Path(video_path).resolve().as_uri()}},
+                    {"type": "video_url", "video_url": {"url": f"data:video/mp4;base64,{video}"}},
                     {"type": "text", "text": prompt},
                 ],
             }
@@ -319,19 +321,36 @@ def judge_payload(judge: JudgeSpec, prompt: str) -> dict[str, Any]:
     }
 
 
+async def _request_model(
+    session: aiohttp.ClientSession,
+    *,
+    model: str,
+    base_url: str,
+    prompt: str,
+    video_path: str,
+    max_tokens: int,
+    request_id: str,
+) -> RequestResult:
+    try:
+        payload = await asyncio.to_thread(model_payload, model, prompt, video_path, max_tokens)
+    except OSError as exc:
+        return RequestResult(request_id=request_id, error=f"media preparation failed: {exc}")
+    return await request_chat_completion(
+        session, api_url=chat_completions_url(base_url), payload=payload, request_id=request_id
+    )
+
+
 def make_level1_send_fn(
     model: str, base_url: str
 ) -> Callable[[aiohttp.ClientSession, SocialOmniLevel1Sample], Awaitable[RequestResult]]:
     async def send(session: aiohttp.ClientSession, sample: SocialOmniLevel1Sample) -> RequestResult:
-        return await request_chat_completion(
+        return await _request_model(
             session,
-            api_url=chat_completions_url(base_url),
-            payload=model_payload(
-                model,
-                build_level1_prompt(sample),
-                sample.video_path,
-                LEVEL1_MAX_TOKENS,
-            ),
+            model=model,
+            base_url=base_url,
+            prompt=build_level1_prompt(sample),
+            video_path=sample.video_path,
+            max_tokens=LEVEL1_MAX_TOKENS,
             request_id=sample.sample_id,
         )
 
@@ -389,10 +408,13 @@ async def run_level2_model(
             sample, prefix = item
             prompt = build_when_prompt(sample) if phase == "when" else build_response_prompt(sample)
             max_tokens = LEVEL2_WHEN_MAX_TOKENS if phase == "when" else LEVEL2_RESPONSE_MAX_TOKENS
-            return await request_chat_completion(
+            return await _request_model(
                 session,
-                api_url=chat_completions_url(base_url),
-                payload=model_payload(model, prompt, str(prefix), max_tokens),
+                model=model,
+                base_url=base_url,
+                prompt=prompt,
+                video_path=str(prefix),
+                max_tokens=max_tokens,
                 request_id=f"{sample.sample_id}:{phase}",
             )
 

--- a/benchmarks/socialomni/protocol.py
+++ b/benchmarks/socialomni/protocol.py
@@ -14,10 +14,11 @@ from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 import aiohttp
 
-from benchmarks.socialomni.client import RequestResult, run_phase
+from benchmarks.socialomni.client import Progress, RequestResult, run_phase
 from benchmarks.socialomni.dataset import (
     SocialOmniLevel1Sample,
     SocialOmniLevel2Sample,
@@ -44,6 +45,15 @@ class JudgeSpec:
     base_url: str
     api_key_env: str | None
     max_concurrency: int
+
+    def public_dict(self) -> dict[str, str | int]:
+        endpoint = urlsplit(self.base_url)
+        return {
+            "name": self.name,
+            "model": self.model,
+            "base_url": endpoint._replace(netloc=endpoint.netloc.rsplit("@", 1)[-1], query="", fragment="").geturl(),
+            "max_concurrency": self.max_concurrency,
+        }
 
 
 def chat_completions_url(base_url: str) -> str:
@@ -376,6 +386,7 @@ async def run_level2_model(
     records: list[dict[str, Any]] = []
     prepared: list[tuple[SocialOmniLevel2Sample, Path]] = []
     requests: list[RequestResult] = []
+    progress = Progress("level2 prefixes", len(samples)) if samples else None
     for sample in samples:
         record = {
             "sample_id": sample.sample_id,
@@ -401,6 +412,8 @@ async def run_level2_model(
             record["requests"].append(asdict(failure))
         else:
             prepared.append((sample, prefix))
+        if progress:
+            progress.update(not record["requests"])
 
     by_id = {record["sample_id"]: record for record in records}
     measured_wall_s = 0.0
@@ -424,7 +437,12 @@ async def run_level2_model(
             )
 
         outcomes, wall_s = await run_phase(
-            cohort, send, max_concurrency=max_concurrency, timeout_s=timeout_s, warmup=warmup
+            cohort,
+            send,
+            max_concurrency=max_concurrency,
+            timeout_s=timeout_s,
+            warmup=warmup,
+            description=f"level2 {phase}",
         )
         measured_wall_s += wall_s
         requests.extend(outcomes)
@@ -491,7 +509,12 @@ async def run_judges(
             return result
 
         results, _ = await run_phase(
-            eligible, send, max_concurrency=judge.max_concurrency, timeout_s=timeout_s, warmup=0
+            eligible,
+            send,
+            max_concurrency=judge.max_concurrency,
+            timeout_s=timeout_s,
+            warmup=0,
+            description=f"judge {judge.name}",
         )
         return results
 

--- a/benchmarks/socialomni/protocol.py
+++ b/benchmarks/socialomni/protocol.py
@@ -1,0 +1,498 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Request construction and evaluation phases for SocialOmni."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import time
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+
+from benchmarks.socialomni.client import RequestResult, run_phase
+from benchmarks.socialomni.dataset import (
+    SocialOmniLevel1Sample,
+    SocialOmniLevel2Sample,
+    create_video_prefix,
+)
+from benchmarks.socialomni.metrics import (
+    SOCIALOMNI_JUDGE_NAMES,
+    SOCIALOMNI_SCORE_BUCKETS,
+)
+
+RETRYABLE_STATUS = frozenset({408, 429})
+# Reasoning-capable judges may consume hidden tokens before emitting the score.
+JUDGE_MAX_TOKENS = 8192
+JUDGE_PARSE_ATTEMPTS = 3
+LEVEL1_MAX_TOKENS = 32
+LEVEL2_WHEN_MAX_TOKENS = 8
+LEVEL2_RESPONSE_MAX_TOKENS = 256
+
+
+@dataclass(frozen=True)
+class JudgeSpec:
+    name: str
+    model: str
+    base_url: str
+    api_key_env: str | None
+    max_concurrency: int
+
+
+def chat_completions_url(base_url: str) -> str:
+    base = base_url.rstrip("/")
+    if base.endswith("/chat/completions"):
+        return base
+    return f"{base}/chat/completions" if base.endswith("/v1") else f"{base}/v1/chat/completions"
+
+
+def load_judge_config(path: str | Path) -> list[JudgeSpec]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    rows = payload.get("judges") if isinstance(payload, dict) else None
+    if not isinstance(rows, list) or len(rows) != 3:
+        raise ValueError("judge config must contain exactly three judges")
+    allowed = {"name", "model", "base_url", "api_key_env", "max_concurrency"}
+    judges: list[JudgeSpec] = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict) or set(row) - allowed:
+            raise ValueError(f"judges[{index}] has invalid fields")
+        for field in ("name", "model", "base_url"):
+            if not isinstance(row.get(field), str) or not row[field].strip():
+                raise ValueError(f"judges[{index}].{field} must be non-empty")
+        concurrency = row.get("max_concurrency", 1)
+        if type(concurrency) is not int or concurrency < 1:
+            raise ValueError(f"judges[{index}].max_concurrency must be >= 1")
+        api_key_env = row.get("api_key_env")
+        if api_key_env is not None and (
+            not isinstance(api_key_env, str) or not api_key_env or api_key_env != api_key_env.strip()
+        ):
+            raise ValueError(
+                f"judges[{index}].api_key_env must be a non-empty string without surrounding whitespace, or null"
+            )
+        judges.append(
+            JudgeSpec(
+                name=row["name"].strip(),
+                model=row["model"].strip(),
+                base_url=row["base_url"].strip(),
+                api_key_env=api_key_env,
+                max_concurrency=concurrency,
+            )
+        )
+    if {judge.name for judge in judges} != set(SOCIALOMNI_JUDGE_NAMES):
+        raise ValueError(f"judge names must be exactly {SOCIALOMNI_JUDGE_NAMES}")
+    return judges
+
+
+def _headers(api_key_env: str | None) -> dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    if api_key_env:
+        token = os.environ.get(api_key_env)
+        if not token:
+            raise RuntimeError(f"API key environment variable is not set: {api_key_env}")
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def validate_judge_credentials(judges: Sequence[JudgeSpec]) -> None:
+    """Fail before model inference when a configured judge credential is absent."""
+    for judge in judges:
+        _headers(judge.api_key_env)
+
+
+def _response_text(body: dict[str, Any]) -> str:
+    choices = body.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return ""
+    if not isinstance(choices[0], dict):
+        return ""
+    message = choices[0].get("message")
+    if not isinstance(message, dict):
+        return ""
+    content = message.get("content")
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        return "\n".join(
+            str(part.get("text", "")).strip()
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        ).strip()
+    return ""
+
+
+async def request_chat_completion(
+    session: aiohttp.ClientSession,
+    *,
+    api_url: str,
+    payload: dict[str, Any],
+    request_id: str,
+    api_key_env: str | None = None,
+    max_attempts: int = 3,
+) -> RequestResult:
+    """Send a chat completion, retrying transient errors up to max_attempts."""
+    request_started = time.perf_counter()
+    last = RequestResult(request_id=request_id, error="not attempted")
+    for attempt in range(max_attempts):
+        try:
+            async with session.post(api_url, json=payload, headers=_headers(api_key_env)) as response:
+                raw = await response.text()
+                if response.status >= 400:
+                    last = RequestResult(
+                        request_id=request_id,
+                        latency_s=time.perf_counter() - request_started,
+                        error=f"HTTP {response.status}: {raw[:2000]}",
+                    )
+                    retry = response.status in RETRYABLE_STATUS or 500 <= response.status < 600
+                else:
+                    try:
+                        body = json.loads(raw)
+                    except json.JSONDecodeError as exc:
+                        last = RequestResult(
+                            request_id=request_id,
+                            latency_s=time.perf_counter() - request_started,
+                            error=f"invalid JSON response: {exc}: {raw[:1000]}",
+                        )
+                        retry = True
+                    else:
+                        if not isinstance(body, dict):
+                            last = RequestResult(
+                                request_id=request_id,
+                                latency_s=time.perf_counter() - request_started,
+                                error=f"invalid JSON response object: {raw[:1000]}",
+                            )
+                            retry = True
+                        else:
+                            usage = body.get("usage") or {}
+                            if not isinstance(usage, dict):
+                                usage = {}
+                            try:
+                                prompt_tokens = usage.get("prompt_tokens", 0)
+                                completion_tokens = usage.get("completion_tokens", 0)
+                                for count in (prompt_tokens, completion_tokens):
+                                    if type(count) is not int or count < 0:
+                                        raise ValueError("token counts must be non-negative integers")
+                            except (TypeError, ValueError, OverflowError) as exc:
+                                return RequestResult(
+                                    request_id=request_id,
+                                    latency_s=time.perf_counter() - request_started,
+                                    error=f"invalid token usage: {exc}",
+                                )
+                            elapsed = time.perf_counter() - request_started
+                            return RequestResult(
+                                request_id=request_id,
+                                text=_response_text(body),
+                                is_success=True,
+                                latency_s=elapsed,
+                                prompt_tokens=prompt_tokens,
+                                completion_tokens=completion_tokens,
+                            )
+        except RuntimeError as exc:
+            return RequestResult(
+                request_id=request_id,
+                latency_s=time.perf_counter() - request_started,
+                error=str(exc),
+            )
+        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            last = RequestResult(
+                request_id=request_id,
+                latency_s=time.perf_counter() - request_started,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+            retry = True
+        if not retry or attempt + 1 == max_attempts:
+            return last
+        await asyncio.sleep(2**attempt)
+    return last
+
+
+def parse_choice(text: str, choices: Sequence[str]) -> str:
+    content = (text or "").strip().upper()
+    alphabet = "".join(re.escape(choice) for choice in choices)
+    match = re.fullmatch(rf"(?:(?:ANSWER|CHOICE)\s*(?:IS|:)?\s*)?([{alphabet}])[.)]?", content) or re.fullmatch(
+        rf"\\?BOXED\s*\{{\s*([{alphabet}])\s*\}}", content
+    )
+    return match.group(1) if match else ""
+
+
+def build_level1_result_records(
+    samples: Sequence[SocialOmniLevel1Sample], results: Sequence[RequestResult]
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "sample_id": sample.sample_id,
+            "gold_answer": sample.gold_answer,
+            "predicted_answer": (parse_choice(result.text, ("A", "B", "C", "D")) if result.is_success else ""),
+            "visibility": sample.visibility,
+            "is_success": result.is_success,
+            "raw_response": result.text,
+            "request": asdict(result),
+        }
+        for sample, result in zip(samples, results, strict=True)
+    ]
+
+
+def parse_when(text: str) -> str:
+    choice = parse_choice(text, ("A", "B"))
+    if choice:
+        return "YES" if choice == "A" else "NO"
+    normalized = (text or "").strip().upper()
+    return normalized if normalized in {"YES", "NO"} else ""
+
+
+def parse_judge_score(text: str) -> int | None:
+    values = re.findall(r"[+-]?(?:\d+(?:\.\d+)?|\.\d+)", text or "")
+    if len(values) != 1 or values[0] not in {"0", "25", "50", "75", "100"}:
+        return None
+    return int(values[0])
+
+
+def build_level1_prompt(sample: SocialOmniLevel1Sample) -> str:
+    options = "\n".join(
+        f"{letter}. {option}" for letter, option in zip(("A", "B", "C", "D"), sample.options, strict=True)
+    )
+    return (
+        f"{sample.question}\n{options}\nUse the video and its audio. "
+        "Reply on the last line as Answer: X, where X is A, B, C, or D."
+    )
+
+
+def build_when_prompt(sample: SocialOmniLevel2Sample) -> str:
+    return (
+        f"Target participant: {sample.target_participant}\n{sample.question_when}\n"
+        "A. YES\nB. NO\nUse only the provided audio-video prefix. "
+        "Reply exactly as Answer: A or Answer: B."
+    )
+
+
+def build_response_prompt(sample: SocialOmniLevel2Sample) -> str:
+    return (
+        f"Target participant: {sample.target_participant}\n{sample.question_how}\n"
+        "Use only the provided audio-video prefix. Return only the participant's next utterance."
+    )
+
+
+def build_judge_prompt(sample: SocialOmniLevel2Sample, candidate: str) -> str:
+    return (
+        "Score the candidate continuation for contextual fit, target-role consistency, "
+        "intent correctness, and key information completeness. Choose exactly one score "
+        "from {0, 25, 50, 75, 100}. Output only the score.\n\n"
+        f"Target participant:\n{sample.target_participant}\n\n"
+        f"Reference context:\n{sample.reference_context}\n\n"
+        f"Reference continuation:\n{sample.reference_response}\n\n"
+        f"Candidate continuation:\n{candidate}"
+    )
+
+
+def model_payload(model: str, prompt: str, video_path: str, max_tokens: int) -> dict[str, Any]:
+    return {
+        "model": model,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "video_url", "video_url": {"url": Path(video_path).resolve().as_uri()}},
+                    {"type": "text", "text": prompt},
+                ],
+            }
+        ],
+        "mm_processor_kwargs": {"use_audio_in_video": True},
+        "modalities": ["text"],
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+        "stream": False,
+    }
+
+
+def judge_payload(judge: JudgeSpec, prompt: str) -> dict[str, Any]:
+    return {
+        "model": judge.model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": JUDGE_MAX_TOKENS,
+        "temperature": 0.0,
+        "stream": False,
+    }
+
+
+def make_level1_send_fn(
+    model: str, base_url: str
+) -> Callable[[aiohttp.ClientSession, SocialOmniLevel1Sample], Awaitable[RequestResult]]:
+    async def send(session: aiohttp.ClientSession, sample: SocialOmniLevel1Sample) -> RequestResult:
+        return await request_chat_completion(
+            session,
+            api_url=chat_completions_url(base_url),
+            payload=model_payload(
+                model,
+                build_level1_prompt(sample),
+                sample.video_path,
+                LEVEL1_MAX_TOKENS,
+            ),
+            request_id=sample.sample_id,
+        )
+
+    return send
+
+
+async def run_level2_model(
+    samples: Sequence[SocialOmniLevel2Sample],
+    *,
+    model: str,
+    base_url: str,
+    prefix_cache_dir: str | Path,
+    max_concurrency: int,
+    timeout_s: int,
+    warmup: int | None = None,
+) -> tuple[list[dict[str, Any]], list[RequestResult], float]:
+    """Prepare video prefixes, then run decisions and gold-positive responses."""
+    records: list[dict[str, Any]] = []
+    prepared: list[tuple[SocialOmniLevel2Sample, Path]] = []
+    requests: list[RequestResult] = []
+    for sample in samples:
+        record = {
+            "sample_id": sample.sample_id,
+            "gold_when": sample.gold_when,
+            "predicted_when": "",
+            "when_success": False,
+            "when_raw_response": "",
+            "gold_response": "",
+            "gold_response_success": False if sample.gold_when == "YES" else None,
+            "gold_judge_scores": {},
+            "judge_results": {},
+            "requests": [],
+        }
+        records.append(record)
+        try:
+            prefix = await create_video_prefix(sample.video_path, sample.timestamp_s, prefix_cache_dir)
+        except (OSError, RuntimeError, ValueError) as exc:
+            failure = RequestResult(
+                request_id=f"{sample.sample_id}:prefix",
+                error=f"{type(exc).__name__}: {exc}",
+            )
+            requests.append(failure)
+            record["requests"].append(asdict(failure))
+        else:
+            prepared.append((sample, prefix))
+
+    by_id = {record["sample_id"]: record for record in records}
+    measured_wall_s = 0.0
+    for phase in ("when", "response"):
+        cohort = [item for item in prepared if phase == "when" or item[0].gold_when == "YES"]
+        if not cohort:
+            continue
+
+        async def send(session: aiohttp.ClientSession, item: tuple[SocialOmniLevel2Sample, Path]) -> RequestResult:
+            sample, prefix = item
+            prompt = build_when_prompt(sample) if phase == "when" else build_response_prompt(sample)
+            max_tokens = LEVEL2_WHEN_MAX_TOKENS if phase == "when" else LEVEL2_RESPONSE_MAX_TOKENS
+            return await request_chat_completion(
+                session,
+                api_url=chat_completions_url(base_url),
+                payload=model_payload(model, prompt, str(prefix), max_tokens),
+                request_id=f"{sample.sample_id}:{phase}",
+            )
+
+        outcomes, wall_s = await run_phase(
+            cohort, send, max_concurrency=max_concurrency, timeout_s=timeout_s, warmup=warmup
+        )
+        measured_wall_s += wall_s
+        requests.extend(outcomes)
+        for (sample, _prefix), result in zip(cohort, outcomes, strict=True):
+            record = by_id[sample.sample_id]
+            record["requests"].append(asdict(result))
+            if phase == "when":
+                record["when_success"] = result.is_success
+                record["when_raw_response"] = result.text
+                record["predicted_when"] = parse_when(result.text) if result.is_success else ""
+            else:
+                record["gold_response"] = result.text
+                record["gold_response_success"] = result.is_success
+    return records, requests, measured_wall_s
+
+
+async def run_judges(
+    samples: Sequence[SocialOmniLevel2Sample],
+    records: list[dict[str, Any]],
+    judges: Sequence[JudgeSpec],
+    *,
+    timeout_s: int,
+) -> tuple[list[RequestResult], list[dict[str, str]]]:
+    """Score responses with each judge's configured concurrency limit."""
+    by_id = {sample.sample_id: sample for sample in samples}
+    eligible = [
+        record
+        for record in records
+        if record["gold_when"] == "YES" and record["gold_response_success"] and str(record["gold_response"]).strip()
+    ]
+
+    async def run_judge(judge: JudgeSpec) -> list[RequestResult]:
+        async def send(session: aiohttp.ClientSession, record: dict[str, Any]) -> RequestResult:
+            sample = by_id[str(record["sample_id"])]
+            started = time.perf_counter()
+            total_prompt_tokens = 0
+            total_completion_tokens = 0
+            score = None
+            for attempt in range(JUDGE_PARSE_ATTEMPTS):
+                result = await request_chat_completion(
+                    session,
+                    api_url=chat_completions_url(judge.base_url),
+                    payload=judge_payload(judge, build_judge_prompt(sample, str(record["gold_response"]))),
+                    request_id=f"{sample.sample_id}:judge:{judge.name}",
+                    api_key_env=judge.api_key_env,
+                )
+                total_prompt_tokens += result.prompt_tokens
+                total_completion_tokens += result.completion_tokens
+                if not result.is_success:
+                    break
+                score = parse_judge_score(result.text)
+                if score in SOCIALOMNI_SCORE_BUCKETS:
+                    break
+                if attempt + 1 < JUDGE_PARSE_ATTEMPTS:
+                    await asyncio.sleep(2**attempt)
+            result.latency_s = time.perf_counter() - started
+            result.prompt_tokens = total_prompt_tokens
+            result.completion_tokens = total_completion_tokens
+            if score not in SOCIALOMNI_SCORE_BUCKETS:
+                result.is_success = False
+                result.error = result.error or (
+                    f"invalid judge score after {JUDGE_PARSE_ATTEMPTS} attempts: {result.text!r}"
+                )
+            return result
+
+        results, _ = await run_phase(
+            eligible, send, max_concurrency=judge.max_concurrency, timeout_s=timeout_s, warmup=0
+        )
+        return results
+
+    outcomes = await asyncio.gather(*(run_judge(judge) for judge in judges))
+    failures: list[dict[str, str]] = []
+    results: list[RequestResult] = []
+    for judge, judge_results in zip(judges, outcomes, strict=True):
+        for record, result in zip(eligible, judge_results, strict=True):
+            score = parse_judge_score(result.text) if result.is_success else None
+            results.append(result)
+            record["judge_results"][judge.name] = {
+                "score": score,
+                "raw_response": result.text,
+                "is_success": result.is_success,
+                "latency_s": result.latency_s,
+                "prompt_tokens": result.prompt_tokens,
+                "completion_tokens": result.completion_tokens,
+                "error": result.error,
+            }
+            if result.is_success and score is not None:
+                record["gold_judge_scores"][judge.name] = score
+            else:
+                failures.append(
+                    {
+                        "request_id": result.request_id,
+                        "sample_id": str(record["sample_id"]),
+                        "judge": judge.name,
+                        "error": result.error,
+                    }
+                )
+    return results, failures

--- a/benchmarks/socialomni/protocol.py
+++ b/benchmarks/socialomni/protocol.py
@@ -109,22 +109,27 @@ def validate_judge_credentials(judges: Sequence[JudgeSpec]) -> None:
 def _response_text(body: dict[str, Any]) -> str:
     choices = body.get("choices")
     if not isinstance(choices, list) or not choices:
-        return ""
+        raise RuntimeError("invalid completion response: expected non-empty choices")
     if not isinstance(choices[0], dict):
-        return ""
+        raise RuntimeError("invalid completion response: expected a choice object")
     message = choices[0].get("message")
     if not isinstance(message, dict):
-        return ""
-    content = message.get("content")
+        raise RuntimeError("invalid completion response: expected a message object")
+    if "content" not in message:
+        raise RuntimeError("invalid completion response: missing message content")
+    content = message["content"]
     if isinstance(content, str):
         return content.strip()
     if isinstance(content, list):
-        return "\n".join(
-            str(part.get("text", "")).strip()
+        if any(
+            not isinstance(part, dict) or part.get("type") != "text" or not isinstance(part.get("text"), str)
             for part in content
-            if isinstance(part, dict) and part.get("type") == "text"
-        ).strip()
-    return ""
+        ):
+            raise RuntimeError("invalid completion response: expected text content parts")
+        return "\n".join(part["text"].strip() for part in content).strip()
+    if content is None:
+        return ""
+    raise RuntimeError("invalid completion response: unsupported message content")
 
 
 async def request_chat_completion(
@@ -259,7 +264,7 @@ def build_level1_prompt(sample: SocialOmniLevel1Sample) -> str:
     )
     return (
         f"{sample.question}\n{options}\nUse the video and its audio. "
-        "Reply on the last line as Answer: X, where X is A, B, C, or D."
+        "Reply only as Answer: X, where X is A, B, C, or D. Do not include an explanation."
     )
 
 

--- a/docs/cli/bench/serve.md
+++ b/docs/cli/bench/serve.md
@@ -1,5 +1,11 @@
 # vLLM-Omni Benchmark CLI Guide
 
+For speaker attribution, turn-entry decisions, and response quality with a
+fixed three-judge panel, use the standalone
+[SocialOmni benchmark](https://github.com/vllm-project/vllm-omni/tree/main/benchmarks/socialomni).
+It runs separate decision, generation, and scoring phases through chat
+completions rather than the serving throughput command described below.
+
 The vllm bench command launches the vLLM-Omni benchmark to evaluate the performance of multimodal models.
 
 ## Notes

--- a/tests/benchmarks/test_socialomni_dataset.py
+++ b/tests/benchmarks/test_socialomni_dataset.py
@@ -96,6 +96,58 @@ def test_loaders_preserve_nested_paths_and_mini_groups(tmp_path: Path) -> None:
     assert second[0].timestamp_s == 3.25
 
 
+@pytest.mark.parametrize("level", ["level1", "level2"])
+def test_mini_requires_only_selected_media(tmp_path: Path, level: str) -> None:
+    if level == "level1":
+        directory = tmp_path / "data" / "level_1"
+        metadata = directory / "dataset.json"
+        rows = [
+            _level1("first", "first.mp4", "consistent"),
+            _level1("second", "second.mp4", "inconsistent"),
+            _level1("unused", "missing.mp4", "consistent"),
+        ]
+        loader = load_socialomni_level1_samples
+        path_key, id_key = "video_path", "id"
+    else:
+        directory = tmp_path / "data" / "level_2"
+        metadata = directory / "annotations.json"
+        rows = [
+            _level2("first", "first.mp4", "YES"),
+            _level2("second", "second.mp4", "NO"),
+            _level2("unused", "missing.mp4", "YES"),
+        ]
+        loader = load_socialomni_level2_samples
+        path_key, id_key = "video_file", "video_id"
+    videos = directory / "videos"
+    videos.mkdir(parents=True)
+    (videos / "first.mp4").touch()
+    (videos / "second.mp4").touch()
+    _write(metadata, rows)
+
+    assert [sample.sample_id for sample in loader(tmp_path, mini=True)] == ["first", "second"]
+    with pytest.raises(FileNotFoundError, match="missing.mp4"):
+        loader(tmp_path)
+    (videos / "second.mp4").unlink()
+    with pytest.raises(FileNotFoundError, match="second.mp4"):
+        loader(tmp_path, mini=True)
+    (videos / "second.mp4").touch()
+
+    rows[-1][path_key] = "../escape.mp4"
+    _write(metadata, rows)
+    with pytest.raises(ValueError, match="unsafe"):
+        loader(tmp_path, mini=True)
+    rows[-1][path_key] = "missing.mp4"
+    rows[-1][id_key] = "first"
+    _write(metadata, rows)
+    with pytest.raises(ValueError, match="Duplicate"):
+        loader(tmp_path, mini=True)
+    rows[-1][id_key] = "unused"
+    rows[-1]["question" if level == "level1" else "full_asr"] = ""
+    _write(metadata, rows)
+    with pytest.raises(ValueError, match="non-empty"):
+        loader(tmp_path, mini=True)
+
+
 def test_inspect_dataset_matches_expected_metadata_hashes(tmp_path: Path, monkeypatch) -> None:
     level1 = tmp_path / "data" / "level_1" / "dataset.json"
     level2 = tmp_path / "data" / "level_2" / "annotations.json"

--- a/tests/benchmarks/test_socialomni_dataset.py
+++ b/tests/benchmarks/test_socialomni_dataset.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+import asyncio
+import json
+from pathlib import Path
+
+import av
+import pytest
+
+from benchmarks.socialomni import dataset as socialomni
+from benchmarks.socialomni.dataset import (
+    build_ffmpeg_prefix_command,
+    create_video_prefix,
+    inspect_socialomni_dataset,
+    load_socialomni_level1_samples,
+    load_socialomni_level2_samples,
+    parse_socialomni_timestamp,
+    resolve_ffmpeg_executable,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _write(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def _level1(sample_id: str, video: str, consistency: str) -> dict[str, object]:
+    return {
+        "id": sample_id,
+        "video_path": video,
+        "question": "Who is speaking?",
+        "options": ["A. one", "B. two", "C. three", "D. four"],
+        "correct_answer": "A",
+        "metadata": {"consistency": consistency},
+    }
+
+
+def _level2(sample_id: str, video: str, answer: str) -> dict[str, object]:
+    return {
+        "video_id": sample_id,
+        "video_file": video,
+        "full_asr": "Reference text for the judge only.",
+        "question_1": {
+            "question": "Should Alex speak now?",
+            "timestamp": "00:03:25",
+            "correct_answer": "A" if answer == "YES" else "B",
+            "option_A": "YES",
+            "option_B": "NO",
+        },
+        "question_2": {
+            "question": "What should Alex say?",
+            "answer": "Hello" if answer == "YES" else "",
+        },
+        "metadata": {},
+    }
+
+
+def test_loaders_preserve_nested_paths_and_mini_groups(tmp_path: Path) -> None:
+    level1 = tmp_path / "data" / "level_1"
+    level2 = tmp_path / "data" / "level_2"
+    for path in (
+        level1 / "videos" / "nested" / "visible.mp4",
+        level1 / "videos" / "mismatch.mp4",
+        level2 / "videos" / "yes.mp4",
+        level2 / "videos" / "nested" / "no.mp4",
+    ):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+    _write(
+        level1 / "dataset.json",
+        [
+            _level1("visible", "nested/visible.mp4", "consistent"),
+            _level1("mismatch", "mismatch.mp4", "inconsistent"),
+        ],
+    )
+    _write(
+        level2 / "annotations.json",
+        {
+            "total_samples": 2,
+            "data": [
+                _level2("yes", "yes.mp4", "YES"),
+                _level2("no", "nested/no.mp4", "NO"),
+            ],
+        },
+    )
+
+    first = load_socialomni_level1_samples(tmp_path, mini=True)
+    second = load_socialomni_level2_samples(tmp_path, mini=True)
+
+    assert [sample.sample_id for sample in first] == ["visible", "mismatch"]
+    assert Path(first[0].video_path).relative_to(tmp_path).as_posix().endswith("videos/nested/visible.mp4")
+    assert [sample.gold_when for sample in second] == ["YES", "NO"]
+    assert second[0].timestamp_s == 3.25
+
+
+def test_inspect_dataset_matches_expected_metadata_hashes(tmp_path: Path, monkeypatch) -> None:
+    level1 = tmp_path / "data" / "level_1" / "dataset.json"
+    level2 = tmp_path / "data" / "level_2" / "annotations.json"
+    _write(level1, [])
+    _write(level2, {"total_samples": 0, "data": []})
+    expected_metadata = {
+        "level1": socialomni._sha256(level1),
+        "level2": socialomni._sha256(level2),
+    }
+    monkeypatch.setattr(socialomni, "SOCIALOMNI_METADATA_SHA256", expected_metadata)
+
+    identity = inspect_socialomni_dataset(tmp_path, ("level1", "level2"))
+
+    assert identity["metadata_sha256"] == expected_metadata
+    assert identity["verification_scope"] == "metadata_only"
+    assert identity["metadata_matches_expected_revision"] is True
+
+
+def test_inspect_dataset_rejects_modified_metadata_as_expected_revision(tmp_path: Path, monkeypatch) -> None:
+    metadata = tmp_path / "data" / "level_1" / "dataset.json"
+    _write(metadata, [])
+    monkeypatch.setattr(socialomni, "SOCIALOMNI_METADATA_SHA256", {"level1": "0" * 64})
+
+    identity = inspect_socialomni_dataset(tmp_path, ("level1",))
+
+    assert identity["metadata_matches_expected_revision"] is False
+
+
+def test_inspect_dataset_checks_only_requested_levels(tmp_path: Path) -> None:
+    _write(tmp_path / "data" / "level_1" / "dataset.json", [])
+    _write(tmp_path / "data" / "level_2" / "annotations.json", "invalid")
+
+    identity = inspect_socialomni_dataset(tmp_path, ("level1",))
+
+    assert set(identity["metadata_sha256"]) == {"level1"}
+
+
+@pytest.mark.parametrize("video", ["../escape.mp4", "/tmp/escape.mp4", "level_2/x.mp4"])
+def test_level1_rejects_path_escape(tmp_path: Path, video: str) -> None:
+    level = tmp_path / "data" / "level_1"
+    _write(level / "dataset.json", [_level1("bad", video, "consistent")])
+    with pytest.raises(ValueError, match="unsafe|wrong"):
+        load_socialomni_level1_samples(tmp_path)
+
+
+def test_level1_rejects_symlink_escape(tmp_path: Path) -> None:
+    outside = tmp_path / "outside.mp4"
+    outside.touch()
+    level = tmp_path / "data" / "level_1"
+    videos = level / "videos"
+    videos.mkdir(parents=True)
+    (videos / "escape.mp4").symlink_to(outside)
+    _write(level / "dataset.json", [_level1("bad", "escape.mp4", "consistent")])
+    with pytest.raises(ValueError, match="escapes"):
+        load_socialomni_level1_samples(tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [(3, 3.0), ("3.5", 3.5), ("01:03.5", 63.5), ("00:17:25", 17.25)],
+)
+def test_parse_timestamp(raw: object, expected: float) -> None:
+    assert parse_socialomni_timestamp(raw) == expected
+
+
+@pytest.mark.parametrize("raw", [True, "", "bad", 0, -1, float("nan"), float("inf")])
+def test_parse_timestamp_rejects_invalid_values(raw: object) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        parse_socialomni_timestamp(raw)
+
+
+def test_prefix_command_reencodes_video_and_audio(tmp_path: Path) -> None:
+    command = build_ffmpeg_prefix_command("ffmpeg", tmp_path / "source.mp4", 1.25, tmp_path / "prefix.mp4")
+    assert "-c:v" in command and "libx264" in command
+    assert "-c:a" in command and "aac" in command
+    assert "copy" not in command
+    assert "-nostdin" in command
+    assert command[command.index("-t") + 1] == "1.250000"
+
+
+@pytest.mark.asyncio
+async def test_prefix_media_ends_at_query_time(tmp_path: Path, monkeypatch) -> None:
+    ffmpeg = resolve_ffmpeg_executable()
+    if not ffmpeg:
+        pytest.skip("ffmpeg is unavailable")
+    source = tmp_path / "source.mp4"
+    process = await asyncio.create_subprocess_exec(
+        ffmpeg,
+        "-nostdin",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-f",
+        "lavfi",
+        "-i",
+        "color=size=64x64:rate=10:duration=2",
+        "-f",
+        "lavfi",
+        "-i",
+        "sine=frequency=440:duration=2",
+        "-shortest",
+        "-c:v",
+        "libx264",
+        "-c:a",
+        "aac",
+        "-y",
+        str(source),
+        stdin=asyncio.subprocess.DEVNULL,
+    )
+    try:
+        assert await asyncio.wait_for(process.wait(), timeout=30) == 0
+    finally:
+        if process.returncode is None:
+            process.kill()
+            await process.wait()
+    monkeypatch.chdir(tmp_path)
+    prefix = await create_video_prefix(source, 0.75, "cache")
+    assert prefix.is_absolute()
+    assert await create_video_prefix(source, 0.75, "cache") == prefix
+    server_dir = tmp_path / "server"
+    server_dir.mkdir()
+    monkeypatch.chdir(server_dir)
+    with av.open(str(prefix)) as container:
+        assert len(container.streams.video) == 1
+        assert len(container.streams.audio) == 1
+        assert container.duration is not None
+        assert container.duration / av.time_base <= 0.85
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel", [False, True])
+async def test_prefix_stops_process_and_removes_partial_file(tmp_path: Path, monkeypatch, cancel: bool) -> None:
+    source = tmp_path / "source.mp4"
+    source.write_bytes(b"source")
+    started = asyncio.Event()
+    stopped = asyncio.Event()
+
+    class Process:
+        returncode = None
+
+        async def communicate(self):
+            started.set()
+            await stopped.wait()
+            return b"", b""
+
+        def kill(self):
+            self.returncode = -9
+            stopped.set()
+
+    process = Process()
+
+    async def start_process(*command, **kwargs):
+        assert kwargs["stdin"] == asyncio.subprocess.DEVNULL
+        Path(command[-1]).write_bytes(b"partial")
+        return process
+
+    monkeypatch.setattr(socialomni, "resolve_ffmpeg_executable", lambda: "ffmpeg")
+    monkeypatch.setattr(socialomni.asyncio, "create_subprocess_exec", start_process)
+    task = asyncio.create_task(create_video_prefix(source, 1, tmp_path / "cache", timeout=0.01))
+    await started.wait()
+    if cancel:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    else:
+        with pytest.raises(RuntimeError, match="timed out"):
+            await task
+    assert stopped.is_set()
+    assert not list((tmp_path / "cache").iterdir())

--- a/tests/benchmarks/test_socialomni_metrics.py
+++ b/tests/benchmarks/test_socialomni_metrics.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+import pytest
+
+from benchmarks.socialomni.metrics import (
+    JudgeCompletenessError,
+    bootstrap_mean_interval,
+    compute_socialomni_level1_metrics,
+    compute_socialomni_level2_metrics,
+    validate_judge_scores,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _scores(a: int, b: int, c: int) -> dict[str, int]:
+    return {"gpt-4o": a, "gemini-2.5-pro": b, "qwen3-omni": c}
+
+
+@pytest.mark.parametrize("score", [True, 25.0, "25", [], None, 80])
+def test_judge_scores_reject_invalid_types_and_buckets(score) -> None:
+    scores = _scores(25, 50, 75)
+    scores["gpt-4o"] = score
+    with pytest.raises(JudgeCompletenessError):
+        validate_judge_scores(scores, "invalid")
+
+
+def test_level1_uses_fixed_denominator_and_visibility_strata() -> None:
+    metrics = compute_socialomni_level1_metrics(
+        [
+            {
+                "gold_answer": "A",
+                "predicted_answer": "A",
+                "visibility": "speaker_visible",
+                "is_success": True,
+            },
+            {
+                "gold_answer": "B",
+                "predicted_answer": "",
+                "visibility": "speaker_visible",
+                "is_success": False,
+            },
+            {
+                "gold_answer": "C",
+                "predicted_answer": "A",
+                "visibility": "visibility_mismatch",
+                "is_success": True,
+            },
+            {
+                "gold_answer": "D",
+                "predicted_answer": "D",
+                "visibility": "visibility_mismatch",
+                "is_success": True,
+            },
+        ]
+    )
+
+    assert metrics["total_samples"] == 4
+    assert metrics["accuracy"] == 0.5
+    assert metrics["unparsable_or_failed"] == 1
+    assert len(metrics["per_class"]) == 4
+    assert metrics["strata"]["speaker_visible"]["accuracy"] == 0.5
+    assert metrics["strata"]["visibility_mismatch"]["accuracy"] == 0.5
+    assert metrics["visible_minus_mismatch_accuracy"] == 0
+
+
+def test_level2_computes_paper_metrics() -> None:
+    records = [
+        {
+            "sample_id": "yes-covered",
+            "gold_when": "YES",
+            "predicted_when": "YES",
+            "when_success": True,
+            "gold_response": "one",
+            "gold_response_success": True,
+            "gold_judge_scores": _scores(25, 50, 75),
+        },
+        {
+            "sample_id": "yes-missed",
+            "gold_when": "YES",
+            "predicted_when": "NO",
+            "when_success": True,
+            "gold_response": "two",
+            "gold_response_success": True,
+            "gold_judge_scores": _scores(75, 75, 75),
+        },
+        {
+            "sample_id": "false-positive",
+            "gold_when": "NO",
+            "predicted_when": "YES",
+            "when_success": True,
+        },
+        {
+            "sample_id": "unparsable",
+            "gold_when": "NO",
+            "predicted_when": "",
+            "when_success": True,
+        },
+    ]
+
+    metrics = compute_socialomni_level2_metrics(records, bootstrap_samples=100)
+
+    assert metrics["when"]["accuracy"] == 0.25
+    assert metrics["when"]["unparsable_or_failed"] == 1
+    assert metrics["quality"]["qgold"] == 62.5
+    assert metrics["quality"]["qens"] == 50
+    assert metrics["quality"]["cov_plus"] == 0.5
+    assert metrics["quality"]["qens_joint"] == 25
+
+
+def test_level2_requires_all_three_judges_for_nonempty_response() -> None:
+    record = {
+        "sample_id": "incomplete",
+        "gold_when": "YES",
+        "predicted_when": "YES",
+        "when_success": True,
+        "gold_response": "hello",
+        "gold_response_success": True,
+        "gold_judge_scores": {"gpt-4o": 75, "qwen3-omni": 75},
+    }
+    with pytest.raises(JudgeCompletenessError):
+        compute_socialomni_level2_metrics([record])
+
+
+def test_failed_response_scores_zero_without_judges() -> None:
+    metrics = compute_socialomni_level2_metrics(
+        [
+            {
+                "sample_id": "empty",
+                "gold_when": "YES",
+                "predicted_when": "YES",
+                "when_success": True,
+                "gold_response": "",
+                "gold_response_success": False,
+                "gold_judge_scores": {},
+            }
+        ],
+        bootstrap_samples=10,
+    )
+    assert metrics["quality"]["qgold"] == 0
+    assert metrics["quality"]["cov_plus"] == 0
+    assert metrics["quality"]["qens"] is None
+
+
+def test_bootstrap_interval_is_deterministic() -> None:
+    first = bootstrap_mean_interval([0, 25, 100], seed=7, samples=100)
+    second = bootstrap_mean_interval([0, 25, 100], seed=7, samples=100)
+    assert first == second
+    assert first is not None and 0 <= first["low"] <= first["high"] <= 100

--- a/tests/benchmarks/test_socialomni_protocol.py
+++ b/tests/benchmarks/test_socialomni_protocol.py
@@ -6,7 +6,7 @@ import base64
 import json
 from collections import Counter
 from contextlib import asynccontextmanager
-from dataclasses import asdict, replace
+from dataclasses import replace
 from pathlib import Path
 
 import aiohttp
@@ -142,7 +142,7 @@ def test_judge_config_has_only_fixed_public_fields(tmp_path: Path, monkeypatch) 
                     {
                         "name": name,
                         "model": name,
-                        "base_url": "http://localhost:8000",
+                        "base_url": "https://user:password@example.com:443/v1?api_key=secret#token",
                         "api_key_env": "SECRET_VALUE" if index == 0 else None,
                         "max_concurrency": 1,
                     }
@@ -152,9 +152,14 @@ def test_judge_config_has_only_fixed_public_fields(tmp_path: Path, monkeypatch) 
         ),
         encoding="utf-8",
     )
-    public = [asdict(judge) for judge in load_judge_config(path)]
+    public = [judge.public_dict() for judge in load_judge_config(path)]
     assert "must-not-appear" not in json.dumps(public)
-    assert public[0]["api_key_env"] == "SECRET_VALUE"
+    assert public[0] == {
+        "name": "gpt-4o",
+        "model": "gpt-4o",
+        "base_url": "https://example.com:443/v1",
+        "max_concurrency": 1,
+    }
 
 
 @pytest.mark.parametrize("api_key_env", ["", " ", " KEY", "KEY ", 1])
@@ -274,6 +279,11 @@ async def test_complete_protocol_over_http(tmp_path, monkeypatch, failed_judge):
             )
         )
     assert len(seen) == 7
+    assert result["config"]["judges"] == [
+        {"name": name, "model": name, "base_url": base_url, "max_concurrency": 1}
+        for name in entrypoint.SOCIALOMNI_JUDGE_NAMES
+    ]
+    assert result["summary"]["elapsed_s"] > 0
     positive, negative = result["per_sample"]["level2"]
     assert positive["predicted_when"] == "NO"
     assert positive["gold_response"] == "candidate"
@@ -388,7 +398,7 @@ async def test_empty_completion_remains_successful(content, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_phase_warmup_concurrency_order_and_failures(monkeypatch):
+async def test_phase_warmup_concurrency_order_and_failures(monkeypatch, capsys):
     monkeypatch.setenv("no_proxy", "127.0.0.1")
     active, peak = 0, 0
     seen: Counter[int] = Counter()
@@ -418,6 +428,7 @@ async def test_phase_warmup_concurrency_order_and_failures(monkeypatch):
             send,
             max_concurrency=2,
             timeout_s=5,
+            description="requests",
         )
     assert seen == {0: 2, 1: 2, 2: 1}
     assert peak == 2
@@ -425,6 +436,11 @@ async def test_phase_warmup_concurrency_order_and_failures(monkeypatch):
     assert [result.is_success for result in results] == [True, True, False]
     assert "HTTP 400: bad input" in results[-1].error
     assert wall_s >= max(result.latency_s for result in results)
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "requests: warming up 2 requests" in captured.err
+    assert "requests: 0/3" in captured.err
+    assert "requests: 3/3, 1 failed" in captured.err
 
 
 @pytest.mark.asyncio

--- a/tests/benchmarks/test_socialomni_protocol.py
+++ b/tests/benchmarks/test_socialomni_protocol.py
@@ -1,0 +1,392 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+import asyncio
+import json
+from collections import Counter
+from contextlib import asynccontextmanager
+from dataclasses import asdict, replace
+from pathlib import Path
+
+import aiohttp
+import pytest
+from aiohttp import web
+
+from benchmarks.socialomni import evaluate as entrypoint
+from benchmarks.socialomni import protocol
+from benchmarks.socialomni.client import RequestResult, run_phase
+from benchmarks.socialomni.dataset import SocialOmniLevel1Sample, SocialOmniLevel2Sample
+from benchmarks.socialomni.protocol import (
+    JUDGE_MAX_TOKENS,
+    build_judge_prompt,
+    build_response_prompt,
+    build_when_prompt,
+    load_judge_config,
+    parse_choice,
+    parse_judge_score,
+    parse_when,
+    request_chat_completion,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _level1(path: str = "/tmp/video.mp4") -> SocialOmniLevel1Sample:
+    return SocialOmniLevel1Sample("one", path, "Who?", ("one", "two", "three", "four"), "A", "speaker_visible")
+
+
+def _level2(index: int = 0) -> SocialOmniLevel2Sample:
+    return SocialOmniLevel2Sample(
+        str(index),
+        "/tmp/video.mp4",
+        3.0,
+        "Alex",
+        "Should Alex speak now?",
+        "What should Alex say?",
+        "NO",
+        "private reference response",
+        "private reference transcript",
+    )
+
+
+def _config(**overrides) -> entrypoint.SocialOmniEvalConfig:
+    values = {
+        "dataset_root": ".",
+        "model": "qwen3-omni",
+        "base_url": "http://localhost:8000",
+        "level": "level1",
+        "judge_config": None,
+        "prefix_cache_dir": "cache",
+        "mini": False,
+        "max_samples": None,
+        "max_concurrency": 1,
+        "timeout_s": 30,
+        "output_dir": "results",
+    }
+    values.update(overrides)
+    return entrypoint.SocialOmniEvalConfig(**values)
+
+
+def test_model_prompts_do_not_leak_reference_material() -> None:
+    sample = _level2()
+    when = build_when_prompt(sample)
+    response = build_response_prompt(sample)
+    for secret in (sample.reference_context, sample.reference_response):
+        assert secret not in when
+        assert secret not in response
+    judge = build_judge_prompt(sample, "candidate")
+    assert sample.reference_context in judge
+    assert sample.reference_response in judge
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("Answer: A", "A"),
+        ("\\boxed{B}", "B"),
+        ("C", "C"),
+        ("A or B", ""),
+        ("Answer: A or B", ""),
+        ("Answer: A/B", ""),
+        ("Answer: A and B", ""),
+        ("Answer: A. Answer: B", ""),
+        ("\\boxed{A} or B", ""),
+    ],
+)
+def test_choice_parser_is_strict(raw: str, expected: str) -> None:
+    assert parse_choice(raw, ("A", "B", "C", "D")) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("Answer: A", "YES"),
+        ("Answer: B", "NO"),
+        ("YES", "YES"),
+        ("maybe", ""),
+        ("Answer: A or B", ""),
+    ],
+)
+def test_when_parser(raw: str, expected: str) -> None:
+    assert parse_when(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("75", 75),
+        ("Score: 25", 25),
+        ("75 or 100", None),
+        ("-25", None),
+        ("25.5", None),
+        (".25", None),
+        ("0.75", None),
+        ("125", None),
+        ("80 or 75", None),
+    ],
+)
+def test_judge_score_parser(raw: str, expected: int | None) -> None:
+    assert parse_judge_score(raw) == expected
+
+
+def test_judge_config_has_only_fixed_public_fields(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("SECRET_VALUE", "must-not-appear")
+    path = tmp_path / "judges.json"
+    path.write_text(
+        json.dumps(
+            {
+                "judges": [
+                    {
+                        "name": name,
+                        "model": name,
+                        "base_url": "http://localhost:8000",
+                        "api_key_env": "SECRET_VALUE" if index == 0 else None,
+                        "max_concurrency": 1,
+                    }
+                    for index, name in enumerate(("gpt-4o", "gemini-2.5-pro", "qwen3-omni"))
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    public = [asdict(judge) for judge in load_judge_config(path)]
+    assert "must-not-appear" not in json.dumps(public)
+    assert public[0]["api_key_env"] == "SECRET_VALUE"
+
+
+@pytest.mark.parametrize("api_key_env", ["", " ", " KEY", "KEY ", 1])
+def test_judge_config_rejects_invalid_key_names(tmp_path, api_key_env) -> None:
+    path = tmp_path / "judges.json"
+    path.write_text(
+        json.dumps(
+            {
+                "judges": [
+                    {
+                        "name": name,
+                        "model": name,
+                        "base_url": "http://localhost:8000",
+                        "api_key_env": api_key_env,
+                    }
+                    for name in ("gpt-4o", "gemini-2.5-pro", "qwen3-omni")
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="api_key_env"):
+        load_judge_config(path)
+
+
+@asynccontextmanager
+async def _server(handler):
+    app = web.Application()
+    app.router.add_post("/v1/chat/completions", handler)
+    server = web.AppRunner(app)
+    await server.setup()
+    try:
+        site = web.TCPSite(server, "127.0.0.1", 0)
+        await site.start()
+        yield f"http://127.0.0.1:{server.addresses[0][1]}"
+    finally:
+        await server.cleanup()
+
+
+def _completion(text, **extra):
+    return web.json_response({"choices": [{"message": {"content": text}}], **extra})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failed_judge", [None, "qwen3-omni"])
+async def test_complete_protocol_over_http(tmp_path, monkeypatch, failed_judge):
+    samples = [replace(_level2(0), gold_when="YES"), _level2(1)]
+    seen = []
+
+    async def completion(request):
+        payload = await request.json()
+        seen.append(payload)
+        limit = payload["max_tokens"]
+        if limit == JUDGE_MAX_TOKENS:
+            assert payload["messages"][0]["content"].count("private reference") == 2
+            assert "video_url" not in json.dumps(payload)
+            if payload["model"] == failed_judge:
+                return web.Response(status=400, text="judge unavailable")
+        else:
+            assert payload["mm_processor_kwargs"] == {"use_audio_in_video": True}
+            assert payload["modalities"] == ["text"]
+            content = payload["messages"][0]["content"]
+            assert [part["type"] for part in content] == ["video_url", "text"]
+            video_uri = content[0]["video_url"]["url"]
+            expected_path = Path("/tmp/video.mp4") if limit == 32 else tmp_path / "prefix.mp4"
+            assert video_uri == expected_path.resolve().as_uri()
+            assert "private reference" not in json.dumps(payload)
+            assert "videos" not in payload and "use_audio_in_video" not in payload
+        text = {32: "Answer: A", 8: "Answer: B", 256: "candidate", 8192: "75"}[limit]
+        return _completion(text, usage={"prompt_tokens": 2, "completion_tokens": 1})
+
+    async def prepared(*args):
+        return tmp_path / "prefix.mp4"
+
+    monkeypatch.setenv("no_proxy", "127.0.0.1")
+    monkeypatch.setattr(protocol, "create_video_prefix", prepared)
+    monkeypatch.setattr(entrypoint, "load_socialomni_level1_samples", lambda *a, **k: [_level1()])
+    monkeypatch.setattr(entrypoint, "load_socialomni_level2_samples", lambda *a, **k: samples)
+    monkeypatch.setattr(
+        entrypoint,
+        "inspect_socialomni_dataset",
+        lambda *a, **k: {
+            "metadata_matches_expected_revision": False,
+        },
+    )
+    async with _server(completion) as base_url:
+        config_path = tmp_path / "judges.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "judges": [
+                        {"name": name, "model": name, "base_url": base_url}
+                        for name in entrypoint.SOCIALOMNI_JUDGE_NAMES
+                    ]
+                }
+            )
+        )
+        result = await entrypoint.run_socialomni(
+            _config(
+                level="both",
+                base_url=base_url,
+                judge_config=str(config_path),
+                warmup=0,
+            )
+        )
+    assert len(seen) == 7
+    positive, negative = result["per_sample"]["level2"]
+    assert positive["predicted_when"] == "NO"
+    assert positive["gold_response"] == "candidate"
+    assert negative["gold_response_success"] is None
+    assert positive["gold_judge_scores"] == {
+        name: 75 for name in entrypoint.SOCIALOMNI_JUDGE_NAMES if name != failed_judge
+    }
+    metrics = result["summary"]["level2"]["metrics"]
+    assert metrics["judge_status"]["required_scores"] == 3
+    assert metrics["judge_status"]["complete"] is (failed_judge is None)
+    assert result["summary"]["status"] == ("incomplete" if failed_judge else "complete")
+    if failed_judge:
+        assert metrics["quality"] is None
+        assert result["failures"][0]["judge"] == failed_judge
+    else:
+        assert not result["failures"]
+        assert metrics["quality"]["qgold"] == 75
+        assert metrics["quality"]["cov_plus"] == 0
+
+
+@pytest.mark.asyncio
+async def test_phase_warmup_concurrency_order_and_failures(monkeypatch):
+    monkeypatch.setenv("no_proxy", "127.0.0.1")
+    active, peak = 0, 0
+    seen: Counter[int] = Counter()
+
+    async def completion(request):
+        nonlocal active, peak
+        item = (await request.json())["item"]
+        seen[item] += 1
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep(0.005 if item else 0.015)
+        active -= 1
+        return _completion(str(item)) if item != 2 else web.Response(status=400, text="bad input")
+
+    async with _server(completion) as base_url:
+
+        async def send(session, item):
+            return await request_chat_completion(
+                session,
+                api_url=f"{base_url}/v1/chat/completions",
+                payload={"item": item},
+                request_id=str(item),
+            )
+
+        results, wall_s = await run_phase(
+            [0, 1, 2],
+            send,
+            max_concurrency=2,
+            timeout_s=5,
+        )
+    assert seen == {0: 2, 1: 2, 2: 1}
+    assert peak == 2
+    assert [result.request_id for result in results] == ["0", "1", "2"]
+    assert [result.is_success for result in results] == [True, True, False]
+    assert "HTTP 400: bad input" in results[-1].error
+    assert wall_s >= max(result.latency_s for result in results)
+
+
+@pytest.mark.asyncio
+async def test_prefix_failure_stays_in_denominator_and_response_uses_gold(tmp_path, monkeypatch):
+    samples = [replace(_level2(i), gold_when="YES", video_path=f"/tmp/{i}.mp4") for i in range(2)]
+
+    async def prepared(path, *_args):
+        if path.endswith("/0.mp4"):
+            raise RuntimeError("broken media")
+        return tmp_path / "prefix.mp4"
+
+    sent = []
+
+    async def request(session, **kwargs):
+        sent.append(kwargs["request_id"])
+        return RequestResult(
+            request_id=kwargs["request_id"],
+            text="NO" if kwargs["request_id"].endswith(":when") else "candidate",
+            is_success=True,
+        )
+
+    monkeypatch.setattr(protocol, "create_video_prefix", prepared)
+    monkeypatch.setattr(protocol, "request_chat_completion", request)
+    records, requests, _ = await protocol.run_level2_model(
+        samples,
+        model="qwen3-omni",
+        base_url="http://localhost:8000",
+        prefix_cache_dir=tmp_path,
+        max_concurrency=2,
+        timeout_s=5,
+        warmup=0,
+    )
+    assert len(records) == 2
+    assert not records[0]["when_success"] and not records[0]["gold_response_success"]
+    assert requests[0].error == "RuntimeError: broken media"
+    assert records[1]["predicted_when"] == "NO" and records[1]["gold_response"] == "candidate"
+    assert sent == ["1:when", "1:response"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field", ["prompt_tokens", "completion_tokens"])
+@pytest.mark.parametrize("value", [True, -1, 1.5, "2", None])
+async def test_invalid_usage_is_request_failure(monkeypatch, field, value):
+    monkeypatch.setenv("no_proxy", "127.0.0.1")
+
+    async def completion(request):
+        return _completion("A", usage={field: value})
+
+    async with _server(completion) as base_url:
+        async with aiohttp.ClientSession() as session:
+            result = await request_chat_completion(
+                session,
+                api_url=f"{base_url}/v1/chat/completions",
+                payload={},
+                request_id="invalid",
+            )
+    assert not result.is_success
+    assert "invalid token usage" in result.error
+    assert result.prompt_tokens == result.completion_tokens == 0
+
+
+def test_judge_completeness_requires_configuration_and_every_score():
+    scores = dict.fromkeys(entrypoint.SOCIALOMNI_JUDGE_NAMES, 75)
+    row = {
+        "sample_id": "one",
+        "gold_when": "YES",
+        "gold_response_success": True,
+        "gold_response": "candidate",
+        "gold_judge_scores": scores,
+    }
+    assert entrypoint._judges_complete([row], True)
+    assert not entrypoint._judges_complete([row], False)
+    del scores["gpt-4o"]
+    assert not entrypoint._judges_complete([row], True)

--- a/tests/benchmarks/test_socialomni_protocol.py
+++ b/tests/benchmarks/test_socialomni_protocol.py
@@ -434,7 +434,7 @@ async def test_phase_warmup_concurrency_order_and_failures(monkeypatch, capsys):
     assert peak == 2
     assert [result.request_id for result in results] == ["0", "1", "2"]
     assert [result.is_success for result in results] == [True, True, False]
-    assert "HTTP 400: bad input" in results[-1].error
+    assert results[-1].error == "HTTP 400"
     assert wall_s >= max(result.latency_s for result in results)
     captured = capsys.readouterr()
     assert captured.out == ""
@@ -549,3 +549,43 @@ def test_judge_completeness_requires_configuration_and_every_score():
     assert not entrypoint._judges_complete([row], False)
     del scores["gpt-4o"]
     assert not entrypoint._judges_complete([row], True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status,body", [(401, "secret-token"), (200, "secret-token"), (200, '["secret-token"]')])
+async def test_error_responses_do_not_record_credentials(status, body, monkeypatch):
+    monkeypatch.setenv("TEST_JUDGE_KEY", "secret-token")
+
+    async def completion(request):
+        assert request.headers["Authorization"] == "Bearer secret-token"
+        return web.Response(status=status, text=body)
+
+    async with _server(completion) as base_url:
+        async with aiohttp.ClientSession() as session:
+            result = await request_chat_completion(
+                session,
+                api_url=f"{base_url}/v1/chat/completions",
+                payload={},
+                request_id="credentials",
+                api_key_env="TEST_JUDGE_KEY",
+                max_attempts=1,
+            )
+    assert not result.is_success
+    assert result.error
+    assert "secret-token" not in result.error
+
+
+@pytest.mark.asyncio
+async def test_connection_error_does_not_record_url_credentials(monkeypatch):
+    url = "https://user:password@example.com/v1/chat/completions?key=secret#token"
+
+    def invalid_url(*args, **kwargs):
+        raise aiohttp.InvalidURL(url)
+
+    async with aiohttp.ClientSession() as session:
+        monkeypatch.setattr(session, "post", invalid_url)
+        result = await request_chat_completion(
+            session, api_url=url, payload={}, request_id="invalid-url", max_attempts=1
+        )
+    assert not result.is_success
+    assert result.error == "InvalidURL: https://example.com/v1/chat/completions"

--- a/tests/benchmarks/test_socialomni_protocol.py
+++ b/tests/benchmarks/test_socialomni_protocol.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 import asyncio
+import base64
 import json
 from collections import Counter
 from contextlib import asynccontextmanager
@@ -198,7 +199,14 @@ def _completion(text, **extra):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("failed_judge", [None, "qwen3-omni"])
 async def test_complete_protocol_over_http(tmp_path, monkeypatch, failed_judge):
-    samples = [replace(_level2(0), gold_when="YES"), _level2(1)]
+    source = tmp_path / "source.mp4"
+    source.write_bytes(b"before-query\x00after-query")
+    prefix = tmp_path / "prefix.mp4"
+    prefix.write_bytes(b"before-query\x00")
+    samples = [
+        replace(_level2(0), gold_when="YES", video_path=str(source)),
+        replace(_level2(1), video_path=str(source)),
+    ]
     seen = []
 
     async def completion(request):
@@ -216,19 +224,21 @@ async def test_complete_protocol_over_http(tmp_path, monkeypatch, failed_judge):
             content = payload["messages"][0]["content"]
             assert [part["type"] for part in content] == ["video_url", "text"]
             video_uri = content[0]["video_url"]["url"]
-            expected_path = Path("/tmp/video.mp4") if limit == 32 else tmp_path / "prefix.mp4"
-            assert video_uri == expected_path.resolve().as_uri()
+            media_type, encoded = video_uri.split(",", 1)
+            assert media_type == "data:video/mp4;base64"
+            expected = source.read_bytes() if limit == 32 else prefix.read_bytes()
+            assert base64.b64decode(encoded, validate=True) == expected
             assert "private reference" not in json.dumps(payload)
             assert "videos" not in payload and "use_audio_in_video" not in payload
         text = {32: "Answer: A", 8: "Answer: B", 256: "candidate", 8192: "75"}[limit]
         return _completion(text, usage={"prompt_tokens": 2, "completion_tokens": 1})
 
     async def prepared(*args):
-        return tmp_path / "prefix.mp4"
+        return prefix
 
     monkeypatch.setenv("no_proxy", "127.0.0.1")
     monkeypatch.setattr(protocol, "create_video_prefix", prepared)
-    monkeypatch.setattr(entrypoint, "load_socialomni_level1_samples", lambda *a, **k: [_level1()])
+    monkeypatch.setattr(entrypoint, "load_socialomni_level1_samples", lambda *a, **k: [_level1(str(source))])
     monkeypatch.setattr(entrypoint, "load_socialomni_level2_samples", lambda *a, **k: samples)
     monkeypatch.setattr(
         entrypoint,
@@ -321,11 +331,13 @@ async def test_phase_warmup_concurrency_order_and_failures(monkeypatch):
 @pytest.mark.asyncio
 async def test_prefix_failure_stays_in_denominator_and_response_uses_gold(tmp_path, monkeypatch):
     samples = [replace(_level2(i), gold_when="YES", video_path=f"/tmp/{i}.mp4") for i in range(2)]
+    prefix = tmp_path / "prefix.mp4"
+    prefix.write_bytes(b"prefix bytes")
 
     async def prepared(path, *_args):
         if path.endswith("/0.mp4"):
             raise RuntimeError("broken media")
-        return tmp_path / "prefix.mp4"
+        return prefix
 
     sent = []
 
@@ -353,6 +365,38 @@ async def test_prefix_failure_stays_in_denominator_and_response_uses_gold(tmp_pa
     assert requests[0].error == "RuntimeError: broken media"
     assert records[1]["predicted_when"] == "NO" and records[1]["gold_response"] == "candidate"
     assert sent == ["1:when", "1:response"]
+
+
+def test_model_payload_embeds_video_bytes(tmp_path):
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"\x00\xff\x80video content")
+    payload = protocol.model_payload("qwen3-omni", "prompt", str(video), 8)
+    video_part, text_part = payload["messages"][0]["content"]
+    assert video_part["type"] == "video_url"
+    media_type, encoded = video_part["video_url"]["url"].split(",", 1)
+    assert media_type == "data:video/mp4;base64"
+    assert base64.b64decode(encoded, validate=True) == video.read_bytes()
+    assert text_part == {"type": "text", "text": "prompt"}
+    assert payload["mm_processor_kwargs"] == {"use_audio_in_video": True}
+    assert payload["modalities"] == ["text"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("directory", [False, True])
+async def test_unreadable_media_is_request_failure(tmp_path, monkeypatch, directory):
+    media = tmp_path if directory else tmp_path / "missing.mp4"
+
+    async def unexpected_request(*args, **kwargs):
+        pytest.fail("unreadable media must fail before an HTTP request")
+
+    monkeypatch.setattr(protocol, "request_chat_completion", unexpected_request)
+    send = protocol.make_level1_send_fn("qwen3-omni", "http://localhost:8000")
+    async with aiohttp.ClientSession() as session:
+        result = await send(session, _level1(str(media)))
+    assert not result.is_success
+    assert result.request_id == "one"
+    assert result.error
+    assert result.prompt_tokens == result.completion_tokens == 0
 
 
 @pytest.mark.asyncio

--- a/tests/benchmarks/test_socialomni_protocol.py
+++ b/tests/benchmarks/test_socialomni_protocol.py
@@ -251,6 +251,7 @@ async def test_complete_protocol_over_http(tmp_path, monkeypatch, failed_judge):
     monkeypatch.setattr(protocol, "create_video_prefix", prepared)
     monkeypatch.setattr(entrypoint, "load_socialomni_level1_samples", lambda *a, **k: [_level1(str(source))])
     monkeypatch.setattr(entrypoint, "load_socialomni_level2_samples", lambda *a, **k: samples)
+    monkeypatch.setattr(entrypoint, "SOCIALOMNI_SUBSET_SIZE", 2)
     monkeypatch.setattr(
         entrypoint,
         "inspect_socialomni_dataset",
@@ -279,6 +280,10 @@ async def test_complete_protocol_over_http(tmp_path, monkeypatch, failed_judge):
             )
         )
     assert len(seen) == 7
+    assert "paper_core_200" not in result
+    assert result["first_200"]["selection"] == "source_order_first_200"
+    assert result["first_200"]["sample_count"] == 2
+    assert result["first_200"]["judges_complete"] is (failed_judge is None)
     assert result["config"]["judges"] == [
         {"name": name, "model": name, "base_url": base_url, "max_concurrency": 1}
         for name in entrypoint.SOCIALOMNI_JUDGE_NAMES

--- a/tests/benchmarks/test_socialomni_protocol.py
+++ b/tests/benchmarks/test_socialomni_protocol.py
@@ -19,6 +19,8 @@ from benchmarks.socialomni.client import RequestResult, run_phase
 from benchmarks.socialomni.dataset import SocialOmniLevel1Sample, SocialOmniLevel2Sample
 from benchmarks.socialomni.protocol import (
     JUDGE_MAX_TOKENS,
+    LEVEL2_RESPONSE_MAX_TOKENS,
+    LEVEL2_WHEN_MAX_TOKENS,
     build_judge_prompt,
     build_response_prompt,
     build_when_prompt,
@@ -230,6 +232,10 @@ async def test_complete_protocol_over_http(tmp_path, monkeypatch, failed_judge):
             assert base64.b64decode(encoded, validate=True) == expected
             assert "private reference" not in json.dumps(payload)
             assert "videos" not in payload and "use_audio_in_video" not in payload
+            if limit == 32:
+                assert content[1]["text"].endswith(
+                    "Reply only as Answer: X, where X is A, B, C, or D. Do not include an explanation."
+                )
         text = {32: "Answer: A", 8: "Answer: B", 256: "candidate", 8192: "75"}[limit]
         return _completion(text, usage={"prompt_tokens": 2, "completion_tokens": 1})
 
@@ -286,6 +292,99 @@ async def test_complete_protocol_over_http(tmp_path, monkeypatch, failed_judge):
         assert not result["failures"]
         assert metrics["quality"]["qgold"] == 75
         assert metrics["quality"]["cov_plus"] == 0
+
+
+@pytest.mark.asyncio
+async def test_malformed_response_makes_level2_incomplete(tmp_path, monkeypatch):
+    prefix = tmp_path / "prefix.mp4"
+    prefix.write_bytes(b"prefix")
+    sample = replace(_level2(0), gold_when="YES", video_path=str(prefix))
+
+    async def prepared(*args):
+        return prefix
+
+    async def completion(request):
+        payload = await request.json()
+        if payload["max_tokens"] == LEVEL2_RESPONSE_MAX_TOKENS:
+            return web.json_response({})
+        assert payload["max_tokens"] == LEVEL2_WHEN_MAX_TOKENS
+        return _completion("Answer: A")
+
+    monkeypatch.setenv("no_proxy", "127.0.0.1")
+    monkeypatch.setattr(protocol, "create_video_prefix", prepared)
+    monkeypatch.setattr(entrypoint, "load_socialomni_level2_samples", lambda *a, **k: [sample])
+    monkeypatch.setattr(entrypoint, "inspect_socialomni_dataset", lambda *a, **k: {})
+    async with _server(completion) as base_url:
+        judges = tmp_path / "judges.json"
+        judges.write_text(
+            json.dumps(
+                {
+                    "judges": [
+                        {"name": name, "model": name, "base_url": base_url}
+                        for name in entrypoint.SOCIALOMNI_JUDGE_NAMES
+                    ]
+                }
+            )
+        )
+        result = await entrypoint.run_socialomni(
+            _config(level="level2", base_url=base_url, judge_config=str(judges), warmup=0)
+        )
+    assert result["summary"]["status"] == "incomplete"
+    assert not result["per_sample"]["level2"][0]["gold_response_success"]
+    assert len(result["failures"]) == 1
+    assert "invalid completion response" in result["failures"][0]["error"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "body",
+    [
+        {},
+        {"choices": []},
+        {"choices": [None]},
+        {"choices": [{}]},
+        {"choices": [{"message": {}}]},
+        {"choices": [{"message": {"content": 42}}]},
+        {"choices": [{"message": {"content": [{"type": "text", "text": 42}]}}]},
+    ],
+)
+async def test_malformed_completion_is_a_request_failure(body, monkeypatch):
+    monkeypatch.setenv("no_proxy", "127.0.0.1")
+
+    async def completion(request):
+        return web.json_response(body)
+
+    async with _server(completion) as base_url:
+        async with aiohttp.ClientSession() as session:
+            result = await request_chat_completion(
+                session,
+                api_url=f"{base_url}/v1/chat/completions",
+                payload={},
+                request_id="response",
+            )
+    assert not result.is_success
+    assert "invalid completion response" in result.error
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("content", ["", None, []])
+async def test_empty_completion_remains_successful(content, monkeypatch):
+    monkeypatch.setenv("no_proxy", "127.0.0.1")
+
+    async def completion(request):
+        return _completion(content)
+
+    async with _server(completion) as base_url:
+        async with aiohttp.ClientSession() as session:
+            result = await request_chat_completion(
+                session,
+                api_url=f"{base_url}/v1/chat/completions",
+                payload={},
+                request_id="response",
+            )
+    assert result.is_success
+    assert result.text == ""
+    assert result.error == ""
 
 
 @pytest.mark.asyncio

--- a/tests/e2e/accuracy/test_qwen3_omni_socialomni_expansion.py
+++ b/tests/e2e/accuracy/test_qwen3_omni_socialomni_expansion.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Run the SocialOmni mini set against a real Qwen3-Omni thinker server.
+
+Set VLLM_SOCIALOMNI_DATASET_ROOT to the extracted dataset to opt in. The model
+defaults to Qwen/Qwen3-Omni-30B-A3B-Instruct; VLLM_SOCIALOMNI_MODEL can select a
+local checkpoint. Requires two H100-class GPUs and the benchmark dependencies.
+External judges are intentionally not configured, so quality stays incomplete.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.helpers.mark import hardware_test
+from tests.helpers.runtime import OmniServerParams
+from tests.helpers.stage_config import get_deploy_config_path
+
+DATASET_ROOT = os.environ.get("VLLM_SOCIALOMNI_DATASET_ROOT")
+pytestmark = [
+    pytest.mark.full_model,
+    pytest.mark.omni,
+    pytest.mark.benchmark,
+    pytest.mark.skipif(not DATASET_ROOT, reason="Set VLLM_SOCIALOMNI_DATASET_ROOT to run SocialOmni"),
+]
+
+SERVER_PARAMS = OmniServerParams(
+    model=os.environ.get("VLLM_SOCIALOMNI_MODEL", "Qwen/Qwen3-Omni-30B-A3B-Instruct"),
+    stage_config_path=get_deploy_config_path("qwen3_omni_moe_thinking.yaml"),
+    server_args=["--max-model-len", "65536"],
+)
+
+
+@hardware_test(res={"cuda": "H100"}, num_cards=2)
+@pytest.mark.parametrize("omni_server", [SERVER_PARAMS], indirect=True)
+def test_socialomni_mini_without_judges(omni_server, tmp_path: Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "benchmarks.socialomni.evaluate",
+            "--dataset-root",
+            str(DATASET_ROOT),
+            "--model",
+            omni_server.model,
+            "--base-url",
+            f"http://{omni_server.host}:{omni_server.port}",
+            "--level",
+            "both",
+            "--mini",
+            "--warmup",
+            "0",
+            "--prefix-cache-dir",
+            str(tmp_path / "prefixes"),
+            "--output-dir",
+            str(tmp_path / "results"),
+        ],
+        cwd=Path(__file__).resolve().parents[3],
+        capture_output=True,
+        text=True,
+        timeout=1800,
+        check=False,
+    )
+    assert result.returncode == 1, result.stdout + result.stderr
+    paths = list((tmp_path / "results").glob("socialomni-*.json"))
+    assert len(paths) == 1, result.stdout + result.stderr
+    output = json.loads(paths[0].read_text())
+    assert output["failures"] == []
+    level1 = output["per_sample"]["level1"]
+    level2 = output["per_sample"]["level2"]
+    assert len(level1) == len(level2) == 2
+    assert all(record["predicted_answer"] in {"A", "B", "C", "D"} for record in level1)
+    assert {record["gold_when"] for record in level2} == {"YES", "NO"}
+    assert all(record["predicted_when"] in {"YES", "NO"} for record in level2)
+    response = next(record for record in level2 if record["gold_when"] == "YES")
+    assert response["gold_response_success"]
+    assert response["gold_response"].strip()
+    summary = output["summary"]
+    assert summary["level1"]["speed"]["successful_requests"] == 2
+    assert summary["level2"]["speed"]["model"]["successful_requests"] == 3
+    assert summary["status"] == "incomplete"
+    assert summary["level2"]["metrics"]["quality"] is None
+    assert summary["level2"]["metrics"]["judge_status"] == {
+        "complete": False,
+        "eligible_responses": 1,
+        "completed_scores": 0,
+        "required_scores": 3,
+    }

--- a/tests/e2e/accuracy/test_qwen3_omni_socialomni_expansion.py
+++ b/tests/e2e/accuracy/test_qwen3_omni_socialomni_expansion.py
@@ -2,7 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Run the SocialOmni mini set against a real Qwen3-Omni thinker server.
 
-Set VLLM_SOCIALOMNI_DATASET_ROOT to the extracted dataset to opt in. The model
+Downloads the pinned mini set by default. Set VLLM_SOCIALOMNI_DATASET_ROOT
+to use an extracted local dataset. The model
 defaults to Qwen/Qwen3-Omni-30B-A3B-Instruct; VLLM_SOCIALOMNI_MODEL can select a
 local checkpoint. Requires two H100-class GPUs and the benchmark dependencies.
 External judges are intentionally not configured, so quality stays incomplete.
@@ -16,16 +17,15 @@ from pathlib import Path
 
 import pytest
 
+from benchmarks.socialomni.dataset import SOCIALOMNI_DATASET_ID, SOCIALOMNI_DATASET_REVISION
 from tests.helpers.mark import hardware_test
 from tests.helpers.runtime import OmniServerParams
 from tests.helpers.stage_config import get_deploy_config_path
 
-DATASET_ROOT = os.environ.get("VLLM_SOCIALOMNI_DATASET_ROOT")
 pytestmark = [
     pytest.mark.full_model,
     pytest.mark.omni,
     pytest.mark.benchmark,
-    pytest.mark.skipif(not DATASET_ROOT, reason="Set VLLM_SOCIALOMNI_DATASET_ROOT to run SocialOmni"),
 ]
 
 SERVER_PARAMS = OmniServerParams(
@@ -35,16 +35,43 @@ SERVER_PARAMS = OmniServerParams(
 )
 
 
+@pytest.fixture(scope="module")
+def socialomni_dataset_root() -> Path:
+    if dataset_root := os.environ.get("VLLM_SOCIALOMNI_DATASET_ROOT"):
+        return Path(dataset_root).expanduser().resolve()
+
+    from huggingface_hub.constants import HF_HOME
+
+    from vllm_omni.transformers_utils.repo_utils import hf_api
+
+    root = Path(HF_HOME) / "socialomni" / SOCIALOMNI_DATASET_REVISION
+    hf_api().snapshot_download(
+        repo_id=SOCIALOMNI_DATASET_ID,
+        repo_type="dataset",
+        revision=SOCIALOMNI_DATASET_REVISION,
+        local_dir=root,
+        allow_patterns=[
+            "data/level_1/dataset.json",
+            "data/level_2/annotations.json",
+            "data/level_1/videos/video_1.mp4",
+            "data/level_1/videos/video_21.mp4",
+            "data/level_2/videos/video_0001.mp4",
+            "data/level_2/videos/video_0005.mp4",
+        ],
+    )
+    return root
+
+
 @hardware_test(res={"cuda": "H100"}, num_cards=2)
 @pytest.mark.parametrize("omni_server", [SERVER_PARAMS], indirect=True)
-def test_socialomni_mini_without_judges(omni_server, tmp_path: Path) -> None:
+def test_socialomni_mini_without_judges(socialomni_dataset_root: Path, omni_server, tmp_path: Path) -> None:
     result = subprocess.run(
         [
             sys.executable,
             "-m",
             "benchmarks.socialomni.evaluate",
             "--dataset-root",
-            str(DATASET_ROOT),
+            str(socialomni_dataset_root),
             "--model",
             omni_server.model,
             "--base-url",


### PR DESCRIPTION
## Purpose

Add [SocialOmni](https://github.com/MAC-AutoML/SocialOmni) evaluation through the chat completions endpoint: speaker attribution, turn-entry decisions, and response quality scored by GPT-4o, Gemini 2.5 Pro, and Qwen3-Omni.

The runner sends video with embedded audio using the shared multimodal client's inline-video format. Level 2 sends only the video prefix up to the annotated timestamp and generates a response for every ground-truth YES, including when the model predicts NO. Failed samples remain in metric denominators, and quality stays unset until all required judgments are available.

Includes dataset loading, prefix preparation, metrics, progress reporting, recorded judge settings without credentials, and documentation under `benchmarks/socialomni/`. A two-GPU regression test with automatic pinned mini-set download is included in the existing nightly accuracy command. The change is limited to evaluation, documentation, and tests.

AI assistance: Codex assisted with implementation, tests, documentation, and code review. I personally reviewed the changes and take responsibility for this contribution.

## Test Plan

From the repository root in the installed development environment:

```bash
uv run --frozen python -m pytest \
    tests/benchmarks/test_socialomni_dataset.py \
    tests/benchmarks/test_socialomni_metrics.py \
    tests/benchmarks/test_socialomni_protocol.py \
    -m 'core_model and cpu' --run-level core_model -q -o addopts=''
```

Tests cover dataset validation, metric denominators, media cutoff, inline payloads, reference isolation, generation after a predicted NO, judge completeness, malformed responses, retries, concurrency, and warmup.

For the model smoke test, start the official two-GPU deployment:

```bash
MODEL=/path/to/Qwen3-Omni-30B-A3B-Instruct
vllm serve "$MODEL" --omni --host 127.0.0.1 --port 8091 \
    --deploy-config vllm_omni/deploy/qwen3_omni_moe_thinking.yaml \
    --max-model-len 65536
```

In another terminal, set `MODEL` to the same path and run against the dataset revision pinned in the benchmark README:

```bash
uv run --no-project --with aiohttp --with imageio-ffmpeg \
    python -m benchmarks.socialomni.evaluate \
    --dataset-root /path/to/SocialOmni --model "$MODEL" \
    --base-url http://127.0.0.1:8091 --level both --mini \
    --max-concurrency 1 --warmup 1 --timeout-s 600 \
    --prefix-cache-dir /path/to/prefix-cache \
    --output-dir /path/to/results
```

This command exercises model requests without judges and exits with status 1 and unset quality. To include scoring, add `--judge-config /path/to/judges.json` using the three-judge configuration documented in `benchmarks/socialomni/README.md`.

**vLLM Version:** 0.28.0; PyTorch 2.13.0+cu130; Transformers 5.14.1; Python 3.12.13.

**vLLM-Omni Commit:** The full-dataset evaluation uses `0c96505280b1`. Full client validation now uses `fef7abf`; the GPU regression uses `b69db2e`. Subsequent changes improve error redaction and mini-set acquisition, clarify provenance, and rename the unverified `paper_core_200` output to `first_200`; model prompts and metric formulas are unchanged. Recomputing metrics from the preserved full-run responses and judgments gives identical results.

**Hardware/model:** 2 × NVIDIA H20 96 GB, driver 580.105.08; Qwen3-Omni-30B-A3B-Instruct snapshot `ea64d566a2a0731823dc44965e7f89bad78f95cb`. The official deployment uses tensor parallelism across two GPUs, bfloat16 weights, eager execution, and one concurrent sequence.

## Test Result

- URL-path follow-up `fef7abf`: 111 client tests passed on macOS, including 12 endpoint-path/query cases; all applicable pre-commit checks passed. The six query-bearing cases fail before the fix. The change preserves request query parameters without changing prompts, scoring, or saved-URL redaction.

- Code `b69db2e`: **99 tests passed** on both Linux/Python 3.12.13 with the repository root configuration and the standalone macOS/Python 3.13.14 client. Linux reported 14 dependency deprecation warnings.
- All applicable local pre-commit checks passed on the changed files. Response-validation regressions were also checked against the previous parser: all eight malformed-response cases failed before the fix and pass afterward.
- Loaded 2,000 Level 1 and 209 Level 2 records. Both metadata hashes matched the pinned dataset revision. Real 17-second and 34-second audio/video prefixes encoded successfully.
- The model mini run completed **5/5 measured requests**: two Level 1 answers, two Level 2 decisions, and one generated response. Each of the three phases had one warmup. No request or parsing failures occurred.
- A single public CLI invocation on the mini set completed all five model requests and all three required judgments in **11.1 seconds**, including warmup and cached prefix preparation. It exited successfully with `status: complete`.
- Code `b69db2e`: the GPU regression passed using the shared server fixture on two H20 GPUs: **1 passed in 313.54 seconds**, including automatic pinned mini-set download, model startup, requests, and teardown. No dataset-path override or external judges were used. The initial direct download timed out on this host; the successful run used its HTTP proxy. The test explicitly checks the incomplete-quality result.
- A single full CLI run processed **2,000 Level 1 + 209 Level 2 samples**, including 133 generated responses and **399/399 valid judgments**. All **2,342 model requests** succeeded, with no parsing failures. The run exited with `status: complete` in **4,576.3 seconds (76.3 minutes)**, including prefix preparation, warmup, and judging. Model concurrency was 1; judge concurrency was 2/2/1 for GPT-4o/Gemini/Qwen3-Omni.
- Observed Level 1 accuracy: **74.40%**. For all 209 Level 2 samples: when accuracy **60.29%**, QGold **53.57**, QEns **52.96**, Cov+ **93.23%**, QEns_joint **49.37**. The README also reports the separate first-200 subset. These are validation results for this deployment, not a cross-framework performance comparison.
- Code `d0f3a6c` also passed a mini CLI run with all three judges. The latest changes preserve those requests and scoring rules.
- The README identifies the adapted prompts and pinned public source. The first-200 selection is not claimed to be the paper core set. Its 60.50% decision accuracy is below an always-YES baseline of 64%; coverage is therefore not evidence of improved turn-entry behavior. Visibility-group results are reported as well.

The nightly regression downloads two pinned metadata files and four videos (about 17 MiB) under `HF_HOME`, unless `VLLM_SOCIALOMNI_DATASET_ROOT` selects existing data. It does not contact external judge services or run the full dataset.

