### PR TITLE
[Bugfix] Forward Qwen3-Omni streaming video sampling parameters

### DIFF
--- a/docs/serving/video_stream_api.md
+++ b/docs/serving/video_stream_api.md
@@ -64,6 +64,12 @@ WebSocket /v1/video/chat/stream
 | `enable_frame_filter` | bool | `true` | Enable EVS near-duplicate frame filtering. |
 | `frame_filter_threshold` | float, 0.0-1.0 | `0.95` | EVS similarity threshold. Higher keeps more frames; lower drops more near-duplicates. |
 
+Sampling parameter bugfix: `sampling_params_list` is now forwarded to the engine;
+earlier versions accepted this field but silently used deployment defaults instead.
+Each entry configures one stage in pipeline order. Omitted trailing stages use their
+deployment defaults. An omitted, `null`, or empty list keeps the engine defaults.
+Invalid sampling parameters return an `error` when the query is submitted.
+
 ### Legacy Aliases
 
 The server accepts these legacy field names and rewrites them before validation. New clients should send the canonical names above.

--- a/docs/serving/video_stream_api.md
+++ b/docs/serving/video_stream_api.md
@@ -60,15 +60,23 @@ WebSocket /v1/video/chat/stream
 | `max_frames` | integer, 1-256 | `50` | Maximum retained frame buffer size. Oldest frames are evicted first. |
 | `system_prompt` | string or null | null | Optional custom system prompt. |
 | `use_audio_in_video` | bool | `true` | Include streamed audio chunks in multimodal video understanding when audio is present. |
-| `sampling_params_list` | list or null | null | Optional per-stage sampling parameter overrides. |
+| `sampling_params_list` | list or null | null | Optional per-stage parameter dictionaries. Each provided entry replaces that stage's deployment sampling settings. |
 | `enable_frame_filter` | bool | `true` | Enable EVS near-duplicate frame filtering. |
 | `frame_filter_threshold` | float, 0.0-1.0 | `0.95` | EVS similarity threshold. Higher keeps more frames; lower drops more near-duplicates. |
 
 Sampling parameter bugfix: `sampling_params_list` is now forwarded to the engine;
 earlier versions accepted this field but silently used deployment defaults instead.
-Each entry configures one stage in pipeline order. Omitted trailing stages use their
-deployment defaults. An omitted, `null`, or empty list keeps the engine defaults.
-Invalid sampling parameters return an `error` when the query is submitted.
+Each provided entry constructs a fresh `SamplingParams` for that stage in pipeline
+order; it is not merged with that stage's deployment defaults. Fields absent from a
+provided entry use `SamplingParams` constructor defaults. Only omitted trailing
+stages keep their deployment defaults. An omitted, `null`, or empty list keeps the
+engine defaults. Invalid sampling parameters return an `error` when the query is
+submitted.
+
+For example, `[{"temperature": 0.2, "max_tokens": 64}]` configures the thinker while
+the talker and code2wav retain their deployment defaults. With only
+`[{"temperature": 0.2}]`, the thinker's `max_tokens` and `top_p` use constructor
+defaults, not its YAML values.
 
 ### Legacy Aliases
 

--- a/tests/entrypoints/openai_api/test_serving_video_stream.py
+++ b/tests/entrypoints/openai_api/test_serving_video_stream.py
@@ -151,7 +151,7 @@ def run_sampling_session(monkeypatch):
             for index, name in enumerate(("thinker", "talker", "code2wav"))
         ]
         engine.default_sampling_params_list = [
-            SamplingParams(temperature=0.4, max_tokens=64),
+            SamplingParams(temperature=0.4, max_tokens=64, top_p=0.85),
             SamplingParams(temperature=0.7, max_tokens=96),
             SamplingParams(temperature=0.8, max_tokens=128),
         ]
@@ -224,6 +224,26 @@ async def test_video_sampling_params_reach_engine(
     assert params[0].seed == 42
     assert all(param.output_kind == RequestOutputKind.CUMULATIVE for param in engine.default_sampling_params_list)
     assert next(msg for msg in ws.sent if msg["type"] == "response.text.done")["text"] == "answer"
+
+
+@pytest.mark.asyncio
+async def test_video_sampling_params_provided_stage_uses_constructor_defaults(run_sampling_session):
+    ws, engine = await run_sampling_session({"sampling_params_list": [{"temperature": 0.2}]})
+
+    assert not [msg for msg in ws.sent if msg["type"] == "error"]
+    engine.generate.assert_called_once()
+    params = engine.generate.call_args.kwargs["sampling_params_list"]
+    constructor_defaults = SamplingParams()
+    assert params[0].temperature == 0.2
+    for field in ("max_tokens", "top_p"):
+        assert getattr(params[0], field) == getattr(constructor_defaults, field)
+        assert getattr(params[0], field) != getattr(engine.default_sampling_params_list[0], field)
+    assert len(params) == 3
+    for param, default in zip(params[1:], engine.default_sampling_params_list[1:]):
+        assert param.temperature == default.temperature
+        assert param.max_tokens == default.max_tokens
+        assert param.top_p == default.top_p
+        assert param is not default
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/openai_api/test_serving_video_stream.py
+++ b/tests/entrypoints/openai_api/test_serving_video_stream.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Tests for the serving-layer streaming video WebSocket handler."""
 
 from __future__ import annotations
@@ -10,10 +10,14 @@ import io
 import json
 import threading
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from PIL import Image
+from vllm.sampling_params import RequestOutputKind, SamplingParams
 
+from tests.helpers.serving_chat import build_serving_chat
+from vllm_omni.config.stage_config import StageConfig
 from vllm_omni.entrypoints.openai import video_stream_base, video_stream_envs
 from vllm_omni.entrypoints.openai.serving_video_stream import (
     QwenOmniStreamingVideoHandler,
@@ -136,6 +140,110 @@ async def test_receive_config_accepts_client_legacy_aliases():
     assert config.num_frames == 7
     assert config.enable_frame_filter is False
     assert config.frame_filter_threshold == 0.87
+
+
+@pytest.fixture
+def run_sampling_session(monkeypatch):
+    async def run(config_overrides):
+        engine = MagicMock()
+        engine.stage_configs = [
+            StageConfig(stage_id=index, model_stage=name)
+            for index, name in enumerate(("thinker", "talker", "code2wav"))
+        ]
+        engine.default_sampling_params_list = [
+            SamplingParams(temperature=0.4, max_tokens=64),
+            SamplingParams(temperature=0.7, max_tokens=96),
+            SamplingParams(temperature=0.8, max_tokens=128),
+        ]
+
+        async def generate(**kwargs):
+            yield _text_result("answer")
+
+        engine.generate.side_effect = generate
+        handler = QwenOmniStreamingVideoHandler(
+            chat_service=build_serving_chat(engine_client=engine),
+            engine_client=engine,
+        )
+        monkeypatch.setattr(handler, "_preprocess_to_engine_prompt", AsyncMock(return_value={"prompt": "video"}))
+        ws = MockWebSocket(
+            [
+                json.dumps(
+                    {
+                        "type": "session.config",
+                        "model": "test",
+                        "modalities": ["text"],
+                        "enable_frame_filter": False,
+                        **config_overrides,
+                    }
+                ),
+                json.dumps({"type": "video.frame", "data": _b64(_make_jpeg())}),
+                json.dumps({"type": "video.query", "text": "describe"}),
+                json.dumps({"type": "video.done"}),
+            ]
+        )
+        await handler.handle_session(ws)
+        return ws, engine
+
+    return run
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_chunk_mode", ["on", "off"])
+@pytest.mark.parametrize("num_stage_overrides", [1, 3])
+async def test_video_sampling_params_reach_engine(
+    run_sampling_session, monkeypatch, async_chunk_mode, num_stage_overrides
+):
+    monkeypatch.setenv("VLLM_VIDEO_ASYNC_CHUNK", async_chunk_mode)
+    overrides = [
+        {"temperature": 0.2, "max_tokens": 1, "seed": 42},
+        {"temperature": 0.6, "max_tokens": 12},
+        {"temperature": 0.9, "max_tokens": 24},
+    ][:num_stage_overrides]
+
+    ws, engine = await run_sampling_session({"sampling_params_list": overrides})
+
+    assert not [msg for msg in ws.sent if msg["type"] == "error"]
+    engine.generate.assert_called_once()
+    params = engine.generate.call_args.kwargs["sampling_params_list"]
+    assert len(params) == 3
+    for index, param in enumerate(params):
+        assert isinstance(param, SamplingParams)
+        default = engine.default_sampling_params_list[index]
+        expected = (
+            overrides[index]
+            if index < len(overrides)
+            else {
+                "temperature": default.temperature,
+                "max_tokens": default.max_tokens,
+            }
+        )
+        assert param.temperature == expected["temperature"]
+        assert param.max_tokens == expected["max_tokens"]
+        assert param.output_kind == RequestOutputKind.DELTA
+        assert param is not default
+    assert params[0].seed == 42
+    assert all(param.output_kind == RequestOutputKind.CUMULATIVE for param in engine.default_sampling_params_list)
+    assert next(msg for msg in ws.sent if msg["type"] == "response.text.done")["text"] == "answer"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("config_overrides", [{}, {"sampling_params_list": None}, {"sampling_params_list": []}])
+async def test_video_sampling_params_omitted_preserve_engine_defaults(run_sampling_session, config_overrides):
+    ws, engine = await run_sampling_session(config_overrides)
+
+    assert not [msg for msg in ws.sent if msg["type"] == "error"]
+    engine.generate.assert_called_once()
+    assert engine.generate.call_args.kwargs.get("sampling_params_list") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalid_params", [{"temperature": -1}, {"max_tokens": 0}, {"unknown_sampling_option": 1}])
+async def test_video_sampling_params_invalid_do_not_reach_engine(run_sampling_session, invalid_params):
+    ws, engine = await run_sampling_session({"sampling_params_list": [invalid_params]})
+
+    engine.generate.assert_not_called()
+    assert any(msg["type"] == "error" for msg in ws.sent)
+    assert ws.sent[-1]["type"] == "session.done"
 
 
 @pytest.mark.asyncio

--- a/vllm_omni/entrypoints/openai/video_stream_base.py
+++ b/vllm_omni/entrypoints/openai/video_stream_base.py
@@ -647,9 +647,6 @@ class OmniStreamingVideoHandler:
             request_kwargs["mm_processor_kwargs"] = {
                 "use_audio_in_video": True,
             }
-        if config.sampling_params_list:
-            request_kwargs["sampling_params_list"] = config.sampling_params_list
-
         sampling_kwargs: dict[str, Any] = {}
         try:
             chat_request = ChatCompletionRequest(**request_kwargs)

--- a/vllm_omni/entrypoints/openai/video_stream_base.py
+++ b/vllm_omni/entrypoints/openai/video_stream_base.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Base WebSocket handler for streaming video input understanding.
 
 Shared session loop, frame/audio buffering, EVS pre-filter, prewarm,
@@ -50,6 +50,7 @@ from vllm_omni.entrypoints.openai.video_frame_filter import FrameSimilarityFilte
 from vllm_omni.entrypoints.openai.video_stream_context import (
     text_only_message,
 )
+from vllm_omni.entrypoints.utils import coerce_param_message_types
 from vllm_omni.outputs import OmniRequestOutput
 
 logger = init_logger(__name__)
@@ -649,8 +650,13 @@ class OmniStreamingVideoHandler:
         if config.sampling_params_list:
             request_kwargs["sampling_params_list"] = config.sampling_params_list
 
+        sampling_kwargs: dict[str, Any] = {}
         try:
             chat_request = ChatCompletionRequest(**request_kwargs)
+            if config.sampling_params_list:
+                params = self._chat_service._to_sampling_params_list(config.sampling_params_list)
+                # Explicit params must retain the engine's streaming output mode.
+                sampling_kwargs["sampling_params_list"] = coerce_param_message_types(params, is_streaming=True)
         except Exception as e:
             await self._send_error(websocket, f"Failed to build request: {e}")
             return
@@ -690,6 +696,7 @@ class OmniStreamingVideoHandler:
                 prompt=engine_prompt,
                 request_id=request_id,
                 output_modalities=config.modalities,
+                **sampling_kwargs,
             )
 
             async for output in result_gen:


### PR DESCRIPTION
## Purpose

Addresses D1 (P0.5) in #7223.

`WS /v1/video/chat/stream` accepts `session.config.sampling_params_list`, but the query handler only copies it into `ChatCompletionRequest`. The subsequent `generate()` call omits it, so overrides such as `temperature` and `max_tokens` silently have no effect.

Convert the overrides with the existing serving-chat helper and forward them to the engine, preserving streaming output kinds. Each provided dictionary constructs that stage from constructor defaults, rather than merging deployment settings. Omitted trailing stages use deployment defaults; omitted, null, and empty lists keep the existing engine-default behavior. Invalid sampling parameters produce a protocol error before generation. Document this observable bugfix separately from the planned Realtime migration.

## Test Plan

The regression drives `session.config → video.frame → video.query → video.done` through the real handler, with prompt preprocessing and generation mocked. Assertions inspect the sampling parameter objects received by `generate()`, including values, stage order, streaming output kinds, and unchanged deployment defaults.

Coverage: one-stage and full-stage overrides, both async-chunk modes, omitted/null/empty lists, constructor defaults for fields missing from a provided entry, and invalid values or unknown parameter names. The tests are collected by the existing `core_model and cpu` entrypoints CI step.

Run from the repository root with the development environment installed:

```bash
uv run --no-sync python -m pytest -o addopts='' \
  tests/entrypoints/openai_api/test_serving_video_stream.py \
  -m 'core_model and cpu' -q
```

To reproduce the original defect, apply only the added tests to the base and run the same command with `-k sampling_params`: the engine-call assertions fail because `sampling_params_list` is missing.

<details>
<summary>Full related suite command</summary>

```bash
uv run --no-sync python -m pytest -o addopts='' \
  --strict-markers --strict-config -q \
  tests/entrypoints/openai_api/test_serving_video_stream.py \
  tests/entrypoints/openai_api/test_video_stream_handler.py \
  tests/entrypoints/openai_api/test_video_stream_session.py \
  tests/entrypoints/openai_api/test_video_frame_filter.py \
  tests/entrypoints/openai_api/test_serving_chat_sampling_params.py \
  tests/entrypoints/openai_api/test_stage_params.py \
  tests/entrypoints/openai_api/test_serving_chat_multistage_generation.py \
  tests/entrypoints/openai_api/test_serving_chat_minicpmo45_stream_output_kinds.py \
  tests/entrypoints/test_utils.py \
  tests/entrypoints/test_async_omni.py \
  tests/entrypoints/test_omni_entrypoints.py
```

This wider suite includes two real-model request-ID tests, requiring one CUDA GPU and weights for `riverclouds/qwen_image_random` and `Qwen/Qwen2.5-Omni-7B`. The new regression itself does not load model weights. Local runs used `gpu run` on one NVIDIA L20X.

</details>

**vLLM Version:** 0.28.0 (PyTorch 2.13.0+cu129, Transformers 5.14.1)

**vLLM-Omni Commit:** base `c66df06c0` plus this change.

## Test Result

- Initial regression run, before the fix: 7 cases failed, 3 passed.
- Initial regression run, after the fix: all 10 cases passed.
- Full related suite: **267 passed** in 301.99 seconds, including both real-model tests. This run preceded a rebase over two documentation-only commits and the review follow-up.
- After the rebase and replacing the test stage-config stand-in with real `StageConfig` objects: **29 passed** in the complete streaming-video handler test file.
- Applicable pre-commit checks passed except `mypy-3.10`: the same 7 errors (3 in the handler, 4 in existing test helpers) were reproduced on the unmodified base using the same hook environment. That hook is skipped for the commit; no new type errors were reported in the prior full check.


- Review follow-up (`4ae64a35`): **104 passed** in 8.16 seconds across `test_serving_video_stream.py`, `test_serving_chat_sampling_params.py`, and `test_utils.py`, including the new constructor-vs-deployment-default regression. The broader 267-test suite was not rerun for this follow-up. The successful run used an isolated vLLM 0.28.0 package because the shared environment had upgraded to 0.29.0 and could no longer collect this branch.
