### PR TITLE
[Test]:Add FP8 quantization support and A/B gates for MammothModa2

### DIFF
--- a/tests/e2e/offline_inference/test_mammoth_moda2_fp8_quantization.py
+++ b/tests/e2e/offline_inference/test_mammoth_moda2_fp8_quantization.py
@@ -1,0 +1,363 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""GPU end-to-end FP8 A/B gates for the MammothModa2 AR stage.
+
+These tests load the real ``MammothModa2-Dev`` checkpoint and compare BF16 vs
+FP8 generation, scoped to the AR stage:
+
+* ``test_ar_generation_smoke`` — each format loads and produces tokens.
+* ``test_bf16_vs_fp8_generation_consistency`` — AR-only understanding: the
+  base head / understanding expert under FP8 (token agreement + logprob
+  similarity + MAE).
+* ``test_bf16_vs_fp8_t2i_image_consistency`` — t2i (AR→DiT): drives the AR
+  stage to emit visual tokens, which exercises the generation experts
+  (``gen_mlp``) and the extra vocabulary/head (``gen_embed_tokens`` /
+  ``gen_head``) under FP8, and compares the decoded image.
+
+The CPU-only structural unit tests live in
+``tests/model_executor/models/mammoth_moda2/test_mammoth_moda2_quantization.py``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Local Dev checkpoint; override via env for CI / hub ids.
+MODEL_PATH = os.environ.get("MAMMOTH_MODA2_MODEL", "/root/autodl-fs/MammothModa2-Dev")
+
+# Quantization cases for the A/B gate. ``None`` is the BF16 baseline (the
+# ``quantization`` stage key is removed). FP8 is vLLM's runtime W8A8
+# (weight + activation) quantization, computed directly from the BF16
+# checkpoint — no pre-quantized weights required.
+QUANTIZATION_CASES = [None, "fp8"]
+
+# Hardware gate: any CUDA GPU (H100/B200 datacenter or RTX PRO 6000
+# workstation). ``@hardware_test`` pins specific SKUs, so use a plain skip
+# so local workstation cards can run the A/B gate too.
+_CUDA_ONLY = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a CUDA GPU")
+
+# Minimum token-level agreement between BF16 and a quantized run, required for
+# the A/B test to pass. TODO: tune after measuring real greedy-decoding drift.
+MIN_TOKEN_AGREEMENT = 0.9
+
+# Minimum cosine similarity between BF16 and quantized top-1 logprob sequences.
+# FP8 W8A8 typically lands ~0.94-0.99 on greedy logprobs (measured 0.9447 on
+# RTX PRO 6000); keep a margin below that to catch real breakage, not normal
+# quantization drift.
+MIN_LOGPROB_COSINE = 0.90
+
+_PROMPT = "Explain multimodal generation in three sentences."
+
+pytestmark = [pytest.mark.slow]
+
+
+# ---------------------------------------------------------------------------
+# AR-only understanding A/B
+# ---------------------------------------------------------------------------
+
+def _stage_config(quantization: str | None) -> str:
+    """Return a patched AR deploy config for the requested quantization.
+
+    ``None`` deletes the ``quantization`` key (BF16 baseline); otherwise the
+    key is set to ``quantization``.
+    """
+    from tests.helpers.stage_config import get_deploy_config_path, modify_stage_config
+
+    base = get_deploy_config_path("mammoth_moda2_ar.yaml")
+    if quantization is None:
+        return modify_stage_config(base, deletes={"stages": {0: ["quantization"]}})
+    return modify_stage_config(base, updates={"stages": {0: {"quantization": quantization}}})
+
+
+def _generate(model: str, quantization: str | None) -> tuple[list[int], list[float]]:
+    """Run the AR-only pipeline greedily, returning (token_ids, top1_logprobs)."""
+    from vllm.sampling_params import SamplingParams
+
+    from tests.helpers.runtime import OmniRunner
+    from vllm_omni.model_extras import build_x_to_text_prompt, get_x_to_text_model_family
+
+    family = get_x_to_text_model_family(model)
+    prompt_dict, _stop_ids = build_x_to_text_prompt(
+        model_family=family,
+        model=model,
+        prompt=_PROMPT,
+        has_image=False,
+    )
+    sampling_params = SamplingParams(temperature=0.0, max_tokens=32, detokenize=False, logprobs=1)
+
+    with OmniRunner(model, seed=42, deploy_config=_stage_config(quantization)) as runner:
+        outputs = list(runner.omni.generate([prompt_dict], [sampling_params]))
+
+    for out in outputs:
+        for completion in getattr(out, "outputs", None) or []:
+            token_ids = list(getattr(completion, "token_ids", None) or [])
+            return token_ids, _top1_logprobs(completion)
+    return [], []
+
+
+def _top1_logprobs(completion) -> list[float]:
+    """Extract the top-1 logprob at each generated step (empty if unavailable)."""
+    logprobs = getattr(completion, "logprobs", None)
+    if not logprobs:
+        return []
+    result: list[float] = []
+    for step in logprobs:
+        if not step:
+            result.append(float("nan"))
+            continue
+        best = max(step.values(), key=lambda lp: lp.logprob)
+        result.append(float(best.logprob))
+    return result
+
+
+def _cosine_sim(a: list[float], b: list[float]) -> float:
+    """Cosine similarity between two equal-length float sequences."""
+    a_t = torch.tensor(a, dtype=torch.float32)
+    b_t = torch.tensor(b, dtype=torch.float32)
+    return float(torch.nn.functional.cosine_similarity(a_t, b_t, dim=0))
+
+
+def _mean_abs_diff(a: list[float], b: list[float]) -> float:
+    """Mean absolute difference between two equal-length float sequences."""
+    a_t = torch.tensor(a, dtype=torch.float32)
+    b_t = torch.tensor(b, dtype=torch.float32)
+    return float((a_t - b_t).abs().mean())
+
+
+@_CUDA_ONLY
+@pytest.mark.omni
+@pytest.mark.parametrize("quantization", QUANTIZATION_CASES, ids=["bf16", "fp8"])
+def test_ar_generation_smoke(quantization: str | None):
+    """Each supported format loads and produces a non-empty greedy sequence."""
+    token_ids, _ = _generate(MODEL_PATH, quantization)
+    assert token_ids, f"no tokens generated for quantization={quantization!r}"
+
+
+@_CUDA_ONLY
+@pytest.mark.omni
+def test_bf16_vs_fp8_generation_consistency():
+    """A/B: BF16 vs FP8 — report token agreement + logprob similarity + MAE."""
+    bf16_ids, bf16_lp = _generate(MODEL_PATH, None)
+    fp8_ids, fp8_lp = _generate(MODEL_PATH, "fp8")
+
+    assert bf16_ids, "BF16 baseline produced no tokens"
+    assert fp8_ids, "FP8 run produced no tokens"
+
+    common = min(len(bf16_ids), len(fp8_ids))
+    token_agree = sum(a == b for a, b in zip(bf16_ids[:common], fp8_ids[:common])) / common
+
+    lp_common = min(len(bf16_lp), len(fp8_lp))
+    logprob_cos = _cosine_sim(bf16_lp[:lp_common], fp8_lp[:lp_common]) if lp_common > 0 else float("nan")
+    logprob_mae = _mean_abs_diff(bf16_lp[:lp_common], fp8_lp[:lp_common]) if lp_common > 0 else float("nan")
+
+    print(
+        f"[FP8 A/B] token_agreement={token_agree:.4f} "
+        f"logprob_cosine={logprob_cos:.4f} "
+        f"logprob_mae={logprob_mae:.4f}"
+    )
+
+    assert token_agree >= MIN_TOKEN_AGREEMENT, (
+        f"BF16/FP8 greedy sequences diverge too much: agreement={token_agree:.3f} < "
+        f"{MIN_TOKEN_AGREEMENT}. bf16={bf16_ids} fp8={fp8_ids}"
+    )
+    if logprob_cos == logprob_cos:  # not NaN
+        assert logprob_cos >= MIN_LOGPROB_COSINE, (
+            f"BF16/FP8 logprob sequences diverge too much: cosine={logprob_cos:.4f} < "
+            f"{MIN_LOGPROB_COSINE}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# t2i A/B — end-to-end trigger for generation experts + extra head
+# ---------------------------------------------------------------------------
+# The AR-only understanding test above never activates ``gen_mlp`` /
+# ``gen_embed_tokens`` / ``gen_head``, because those only fire for image tokens
+# (``input_ids >= gen_vocab_start_index == 152064``). The t2i task drives the AR
+# stage to emit visual tokens, exercising the generation experts and the extra
+# vocabulary/head under FP8 end to end.
+
+_AR_PATCH_SIZE = 16
+
+# Dev (Qwen3-VL) and Preview (Qwen2.5-VL) share the same vision token ids.
+_IMAGE_TOKEN_ID = 151655
+_VIDEO_TOKEN_ID = 151656
+_VISION_START_TOKEN_ID = 151652
+_VISION_END_TOKEN_ID = 151653
+
+
+def _load_t2i_gen_config(model: str) -> dict:
+    """Load ``t2i_generation_config.json`` from a local dir or hub id."""
+    import json
+    from pathlib import Path
+
+    local = Path(model) / "t2i_generation_config.json"
+    if local.exists():
+        return json.loads(local.read_text(encoding="utf-8"))
+
+    from huggingface_hub import snapshot_download
+
+    weights_dir = Path(snapshot_download(model))
+    cfg_path = weights_dir / "t2i_generation_config.json"
+    return json.loads(cfg_path.read_text(encoding="utf-8"))
+
+
+def _format_t2i_prompt(user_prompt: str, ar_width: int, ar_height: int) -> str:
+    return (
+        "<|im_start|>system\nYou are a helpful image generator.<|im_end|>\n"
+        f"<|im_start|>user\n{user_prompt}<|im_end|>\n"
+        "<|im_start|>assistant\n"
+        f"<|image start|>{ar_width}*{ar_height}<|image token|>"
+    )
+
+
+def _t2i_stage_config(quantization: str | None) -> str:
+    """Patch the AR→DiT deploy config: FP8 on the AR stage only (stage 0)."""
+    from tests.helpers.stage_config import get_deploy_config_path, modify_stage_config
+
+    base = get_deploy_config_path("mammoth_moda2.yaml")
+    if quantization is None:
+        return base
+    return modify_stage_config(base, updates={"stages": {0: {"quantization": quantization}}})
+
+
+def _generate_t2i_image(model: str, quantization: str | None) -> torch.Tensor:
+    """Run t2i (AR→DiT) and return the decoded image tensor."""
+    from vllm.sampling_params import SamplingParams
+
+    from tests.helpers.runtime import OmniRunner
+
+    gen_cfg = _load_t2i_gen_config(model)
+    eol_token_id = int(gen_cfg["eol_token_id"])
+    visual_start = int(gen_cfg["visual_token_start_id"])
+    visual_end = int(gen_cfg["visual_token_end_id"])
+
+    height, width = 256, 256  # small for CI speed
+    ar_height, ar_width = height // _AR_PATCH_SIZE, width // _AR_PATCH_SIZE
+    expected_grid_tokens = ar_height * (ar_width + 1)
+
+    formatted_prompt = _format_t2i_prompt("A cat sitting on a laptop keyboard", ar_width, ar_height)
+
+    ar_sampling = SamplingParams(
+        temperature=0.0,
+        top_k=1,
+        max_tokens=max(1, expected_grid_tokens + 1),
+        detokenize=False,
+    )
+    dit_sampling = SamplingParams(temperature=0.0, max_tokens=1, detokenize=False)
+
+    with OmniRunner(model, seed=42, deploy_config=_t2i_stage_config(quantization)) as runner:
+        outputs = list(
+            runner.omni.generate(
+                [
+                    {
+                        "prompt": formatted_prompt,
+                        "additional_information": {
+                            "omni_task": ["t2i"],
+                            "ar_width": [ar_width],
+                            "ar_height": [ar_height],
+                            "eol_token_id": [eol_token_id],
+                            "visual_token_start_id": [visual_start],
+                            "visual_token_end_id": [visual_end],
+                            "image_height": [height],
+                            "image_width": [width],
+                            "num_inference_steps": [2],
+                            "text_guidance_scale": [1.0],
+                            "cfg_range": [0.0, 1.0],
+                            "visual_ids": [
+                                _IMAGE_TOKEN_ID,
+                                _VIDEO_TOKEN_ID,
+                                _VISION_START_TOKEN_ID,
+                                _VISION_END_TOKEN_ID,
+                            ],
+                        },
+                    }
+                ],
+                [ar_sampling, dit_sampling],
+            )
+        )
+
+    return _extract_image_tensor(outputs)
+
+
+def _extract_image_tensor(outputs) -> torch.Tensor:
+    """Extract the decoded image as a ``(C, H, W)`` float tensor in ``[0, 1]``.
+
+    Reuses the official ``extract_images_from_outputs`` helper, which knows all
+    the payload shapes (``OmniRequestOutput.images`` plus the ``"image"`` /
+    ``"images"`` / ``"model_outputs"`` multimodal keys).
+    """
+    import numpy as np
+
+    from vllm_omni.diffusion.utils.image_output import extract_images_from_outputs
+
+    images = extract_images_from_outputs(outputs)
+    if not images:
+        debug = [
+            f"{type(out).__name__}(images={getattr(out, 'images', None)!r}, "
+            f"mm={getattr(out, 'multimodal_output', None)!r})"
+            for out in outputs
+        ]
+        raise AssertionError(f"no image tensor found in pipeline output; outputs={debug}")
+
+    arr = np.asarray(images[0], dtype=np.float32) / 255.0  # (H, W, C)
+    return torch.from_numpy(arr).permute(2, 0, 1)  # (C, H, W)
+
+
+def _image_rel_l2(a: torch.Tensor, b: torch.Tensor) -> float:
+    a_f, b_f = a.float(), b.float()
+    return float((b_f - a_f).norm() / a_f.norm())
+
+
+def _image_cosine(a: torch.Tensor, b: torch.Tensor) -> float:
+    return float(torch.nn.functional.cosine_similarity(a.flatten().float(), b.flatten().float(), dim=0))
+
+
+def _image_metrics(a: torch.Tensor, b: torch.Tensor) -> dict[str, float]:
+    """Full pixel-level comparison of two ``(C, H, W)`` images in ``[0, 1]``."""
+    import math
+
+    a_f, b_f = a.float(), b.float()
+    diff = (b_f - a_f).abs()
+    mse = float((b_f - a_f).pow(2).mean())
+
+    return {
+        "psnr_db": float(10 * math.log10(1.0 / mse)) if mse > 0 else float("inf"),
+        "mae": float(diff.mean()),
+        "max_abs": float(diff.max()),
+        "cosine": _image_cosine(a_f, b_f),
+        "rel_l2": _image_rel_l2(a_f, b_f),
+        # Fraction of pixels whose difference is below one uint8 step.
+        "pixel_match": float((diff < 1.0 / 255.0).float().mean()),
+    }
+
+
+@_CUDA_ONLY
+@pytest.mark.diffusion
+def test_bf16_vs_fp8_t2i_image_consistency():
+    """A/B: BF16 vs FP8 t2i — decoded image must match (gen experts + head OK)."""
+    bf16_img = _generate_t2i_image(MODEL_PATH, None)
+    fp8_img = _generate_t2i_image(MODEL_PATH, "fp8")
+
+    assert bf16_img.shape == fp8_img.shape, (bf16_img.shape, fp8_img.shape)
+
+    metrics = _image_metrics(bf16_img, fp8_img)
+
+    print("\n[FP8 t2i A/B] BF16 vs FP8 decoded image:")
+    for name in ("psnr_db", "mae", "max_abs", "cosine", "rel_l2", "pixel_match"):
+        print(f"  {name:12s} = {metrics[name]:.6f}")
+
+    # Same seed + greedy AR + deterministic DiT: a correctly quantized
+    # gen_mlp/gen_head must reproduce the same visual tokens, hence the image.
+    assert metrics["cosine"] >= 0.99, (
+        f"BF16/FP8 t2i images diverge too much: cosine={metrics['cosine']:.6f} < 0.99"
+    )
+    assert metrics["rel_l2"] < 0.05, (
+        f"BF16/FP8 t2i images diverge too much: rel_l2={metrics['rel_l2']:.6f} >= 0.05"
+    )

--- a/tests/e2e/offline_inference/test_mammoth_moda2_fp8_quantization.py
+++ b/tests/e2e/offline_inference/test_mammoth_moda2_fp8_quantization.py
@@ -62,6 +62,7 @@ pytestmark = [pytest.mark.slow]
 # AR-only understanding A/B
 # ---------------------------------------------------------------------------
 
+
 def _stage_config(quantization: str | None) -> str:
     """Return a patched AR deploy config for the requested quantization.
 
@@ -157,11 +158,7 @@ def test_bf16_vs_fp8_generation_consistency():
     logprob_cos = _cosine_sim(bf16_lp[:lp_common], fp8_lp[:lp_common]) if lp_common > 0 else float("nan")
     logprob_mae = _mean_abs_diff(bf16_lp[:lp_common], fp8_lp[:lp_common]) if lp_common > 0 else float("nan")
 
-    print(
-        f"[FP8 A/B] token_agreement={token_agree:.4f} "
-        f"logprob_cosine={logprob_cos:.4f} "
-        f"logprob_mae={logprob_mae:.4f}"
-    )
+    print(f"[FP8 A/B] token_agreement={token_agree:.4f} logprob_cosine={logprob_cos:.4f} logprob_mae={logprob_mae:.4f}")
 
     assert token_agree >= MIN_TOKEN_AGREEMENT, (
         f"BF16/FP8 greedy sequences diverge too much: agreement={token_agree:.3f} < "
@@ -169,8 +166,7 @@ def test_bf16_vs_fp8_generation_consistency():
     )
     if logprob_cos == logprob_cos:  # not NaN
         assert logprob_cos >= MIN_LOGPROB_COSINE, (
-            f"BF16/FP8 logprob sequences diverge too much: cosine={logprob_cos:.4f} < "
-            f"{MIN_LOGPROB_COSINE}"
+            f"BF16/FP8 logprob sequences diverge too much: cosine={logprob_cos:.4f} < {MIN_LOGPROB_COSINE}"
         )
 
 
@@ -355,9 +351,5 @@ def test_bf16_vs_fp8_t2i_image_consistency():
 
     # Same seed + greedy AR + deterministic DiT: a correctly quantized
     # gen_mlp/gen_head must reproduce the same visual tokens, hence the image.
-    assert metrics["cosine"] >= 0.99, (
-        f"BF16/FP8 t2i images diverge too much: cosine={metrics['cosine']:.6f} < 0.99"
-    )
-    assert metrics["rel_l2"] < 0.05, (
-        f"BF16/FP8 t2i images diverge too much: rel_l2={metrics['rel_l2']:.6f} >= 0.05"
-    )
+    assert metrics["cosine"] >= 0.99, f"BF16/FP8 t2i images diverge too much: cosine={metrics['cosine']:.6f} < 0.99"
+    assert metrics["rel_l2"] < 0.05, f"BF16/FP8 t2i images diverge too much: rel_l2={metrics['rel_l2']:.6f} >= 0.05"

--- a/tests/model_executor/models/mammoth_moda2/test_mammoth_moda2_quantization.py
+++ b/tests/model_executor/models/mammoth_moda2/test_mammoth_moda2_quantization.py
@@ -18,8 +18,8 @@ from __future__ import annotations
 
 import pytest
 import torch
-
 from vllm.model_executor.model_loader.weight_utils import maybe_remap_kv_scale_name
+
 from vllm_omni.model_executor.models.mammoth_moda2.mammoth_moda2 import (
     MammothModa2Qwen3ARForConditionalGeneration,
     moe_enable,

--- a/tests/model_executor/models/mammoth_moda2/test_mammoth_moda2_quantization.py
+++ b/tests/model_executor/models/mammoth_moda2/test_mammoth_moda2_quantization.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""CPU-only structural unit tests for MammothModa2 AR quantization wiring.
+
+Covers the pure logic that backs the FP8 quantization path, without requiring a
+GPU or a real checkpoint:
+
+* Generation-expert routing (``moe_enable`` / ``moe_forward``).
+* Extra generation vocabulary/head weight-name mapping (``hf_to_vllm_mapper``).
+* Base + generation vocabulary sizing from the Dev config.
+* Quantization-scale name remapping (``maybe_remap_kv_scale_name``).
+
+The GPU end-to-end FP8 A/B gates (understanding + t2i) live in
+``tests/e2e/offline_inference/test_mammoth_moda2_fp8_quantization.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from vllm.model_executor.model_loader.weight_utils import maybe_remap_kv_scale_name
+from vllm_omni.model_executor.models.mammoth_moda2.mammoth_moda2 import (
+    MammothModa2Qwen3ARForConditionalGeneration,
+    moe_enable,
+    moe_forward,
+)
+from vllm_omni.transformers_utils.configs.mammoth_moda2 import Mammothmoda2Config
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class TestMoeEnable:
+    """Generation-expert routing switch (``moe_type`` range parsing)."""
+
+    def test_range_inclusive_start_exclusive_end(self):
+        assert moe_enable("ffn-18:36", "ffn", 18) is True
+        assert moe_enable("ffn-18:36", "ffn", 35) is True
+
+    def test_before_start_disabled(self):
+        assert moe_enable("ffn-18:36", "ffn", 17) is False
+
+    def test_at_end_disabled(self):
+        assert moe_enable("ffn-18:36", "ffn", 36) is False
+
+    def test_wrong_layer_type_disabled(self):
+        assert moe_enable("ffn-18:36", "attention", 20) is False
+
+    def test_unbounded_range_enables_all_ffn(self):
+        assert moe_enable("ffn", "ffn", 0) is True
+
+    def test_none_disables(self):
+        assert moe_enable("none", "ffn", 20) is False
+
+
+class TestMoeForward:
+    """``gen_mlp`` vs ``mlp`` expert routing under different token masks."""
+
+    @staticmethod
+    def _experts():
+        und = lambda x: x * 0.0  # noqa: E731
+        gen = lambda x: x + 100.0  # noqa: E731
+        return und, gen
+
+    def test_no_gen_expert_routes_to_und(self):
+        hidden = torch.arange(8.0).reshape(2, 4)
+        und, _ = self._experts()
+        out = moe_forward(hidden, und, None, torch.tensor([True, False]))
+        assert torch.equal(out, und(hidden))
+
+    def test_none_mask_routes_to_und(self):
+        hidden = torch.arange(8.0).reshape(2, 4)
+        und, gen = self._experts()
+        out = moe_forward(hidden, und, gen, None)
+        assert torch.equal(out, und(hidden))
+
+    def test_all_false_mask_routes_to_und(self):
+        hidden = torch.arange(8.0).reshape(2, 4)
+        und, gen = self._experts()
+        out = moe_forward(hidden, und, gen, torch.tensor([False, False]))
+        assert torch.equal(out, und(hidden))
+
+    def test_all_true_mask_routes_to_gen(self):
+        hidden = torch.arange(8.0).reshape(2, 4)
+        und, gen = self._experts()
+        out = moe_forward(hidden, und, gen, torch.tensor([True, True]))
+        assert torch.equal(out, gen(hidden))
+
+    def test_mixed_mask_reorders_correctly(self):
+        hidden = torch.arange(12.0).reshape(3, 4)
+        und, gen = self._experts()
+        mask = torch.tensor([True, False, True])
+        out = moe_forward(hidden, und, gen, mask)
+
+        expected = torch.zeros_like(hidden)
+        expected[0] = gen(hidden[0])
+        expected[1] = und(hidden[1])
+        expected[2] = gen(hidden[2])
+        assert torch.equal(out, expected)
+
+    def test_mask_shape_mismatch_raises(self):
+        hidden = torch.arange(12.0).reshape(3, 4)
+        und, gen = self._experts()
+        with pytest.raises(ValueError):
+            moe_forward(hidden, und, gen, torch.tensor([True, False]))
+
+
+class TestCheckpointWeightsMapper:
+    """Checkpoint prefix remap: extra vocab/head + generation-side filtering."""
+
+    _CHECKPOINT_NAMES = [
+        "llm_model.model.visual.blocks.0.attn.q.weight",
+        "llm_model.lm_head.weight",
+        "llm_model.model.language_model.gen_embed_tokens.weight",
+        "llm_model.model.language_model.layers.0.self_attn.q_proj.weight",
+        "llm_model.gen_head.weight",
+        # Generation-side (DiT / VAE / tokenizer) weights must be skipped.
+        "gen_vae.decoder.conv_out.weight",
+        "gen_transformer.layers.0.weight",
+        "gen_tokenizer.image_tokenizer.quant_conv.weight",
+        "gen_image_condition_refiner.layers.0.weight",
+    ]
+
+    def test_prefix_remap_and_generation_side_filtering(self):
+        mapper = MammothModa2Qwen3ARForConditionalGeneration.hf_to_vllm_mapper
+        mapped = mapper.apply_list(self._CHECKPOINT_NAMES)
+
+        assert mapped == [
+            "visual.blocks.0.attn.q.weight",
+            "language_model.lm_head.weight",
+            "language_model.gen_embed_tokens.weight",
+            "language_model.layers.0.self_attn.q_proj.weight",
+            "language_model.gen_head.weight",
+        ]
+
+        # None of the generation-side sub-modules may survive the remap.
+        assert all(not name.startswith("gen_") for name in mapped)
+
+
+class TestExtraVocabHeadConfig:
+    """Extra generation vocabulary / head sizes derived from the Dev config."""
+
+    def test_dev_config_exposes_base_plus_gen_vocab(self):
+        config = Mammothmoda2Config(
+            llm_config={
+                "model_type": "mammothmoda2_qwen3_vl",
+                "text_config": {
+                    "model_type": "mammothmoda2_qwen3_vl_text",
+                    "vocab_size": 151936,
+                    "gen_vocab_size": 32800,
+                    "gen_vocab_start_index": 152064,
+                },
+            }
+        )
+
+        text_cfg = config.get_text_config()
+        # vLLM validates sampling against base + generation vocabulary.
+        assert text_cfg.vocab_size == 152064 + 32800
+        assert text_cfg.gen_vocab_start_index == 152064
+
+
+class TestQuantizationScaleRemap:
+    """Quantization-scale name remapping used by ``load_weights``.
+
+    Covers the ``maybe_remap_kv_scale_name`` path in
+    ``MammothModa2Qwen2ForCausalLM.load_weights`` (FP8 ``*_scale`` loading).
+    """
+
+    def test_existing_name_returns_unchanged(self):
+        params = {"model.layers.0.self_attn.attn.k_scale": None}
+        assert (
+            maybe_remap_kv_scale_name("model.layers.0.self_attn.attn.k_scale", params)
+            == "model.layers.0.self_attn.attn.k_scale"
+        )
+
+    def test_deprecated_kv_scale_remapped_to_k_scale(self):
+        params = {"model.layers.0.self_attn.attn.k_scale": None}
+        assert (
+            maybe_remap_kv_scale_name("model.layers.0.self_attn.kv_scale", params)
+            == "model.layers.0.self_attn.attn.k_scale"
+        )
+
+    def test_qkv_proj_scale_remapped(self):
+        params = {
+            "model.layers.0.self_attn.attn.k_scale": None,
+            "model.layers.0.self_attn.attn.v_scale": None,
+        }
+        assert (
+            maybe_remap_kv_scale_name("model.layers.0.self_attn.qkv_proj.k_scale", params)
+            == "model.layers.0.self_attn.attn.k_scale"
+        )
+        assert (
+            maybe_remap_kv_scale_name("model.layers.0.self_attn.qkv_proj.v_scale", params)
+            == "model.layers.0.self_attn.attn.v_scale"
+        )
+
+    def test_missing_scale_returns_none(self):
+        assert maybe_remap_kv_scale_name("model.layers.0.self_attn.qkv_proj.k_scale", {}) is None


### PR DESCRIPTION
<!-- markdownlint-disable -->
Resolves #7125 (FP8 portion). Part of #7075.

## Purpose
Enable online FP8 (dynamic W8A8) quantization for the MammothModa2 AR stage,computed directly from the BF16 checkpoint — no pre-quantized weights required.This reduces AR prefill/decode latency and peak GPU memory, and corresponds to PR 1 of the plan in #7125.

Tests added in `test_mammoth_moda2_fp8_quantization.py` (GPU E2E A/B gates,BF16 vs FP8 under the same seed with greedy decoding):

- `test_ar_generation_smoke[bf16|fp8]` — each format loads and produces a non-empty greedy sequence;
- `test_bf16_vs_fp8_generation_consistency` — AR text A/B: token agreement  ≥ 0.90, top-1 logprob cosine ≥ 0.90;
- `test_bf16_vs_fp8_t2i_image_consistency` — t2i image A/B with FP8 applied to  the AR stage only (stage 0), DiT kept in BF16: decoded-image cosine ≥ 0.99,  rel-L2 < 0.05.

CPU-only structural quantization unit tests live in
`tests/model_executor/models/mammoth_moda2/test_mammoth_moda2_quantization.py`.

Per #7125, both MammothModa2 versions (Preview and Dev, which have different AR-LLM architectures) are validated independently.
## Test Plan
```bash
pytest tests/model_executor/models/mammoth_moda2/test_mammoth_moda2_fp8_quantization.py -v -s
pytest tests/e2e/offline_inference/test_mammoth_moda2_fp8_quantization.py -v -s
```
All cases use seed=42 and greedy decoding (temperature=0, top_k=1); t2i uses 256×256 images with 2 diffusion steps (CI-speed configuration). The only A/B variable is the stage-0 quantization key.
**vLLM Version:0.28.0

**vLLM-Omni Commit:g3204a0b2a (0.1.dev2892)

## Test Result


**Hardware:** NVIDIA RTX PRO 6000 96 GB ×1, Python 3.12.

### MammothModa2-Preview — 4 passed in 288s ✅

| Test | Metric | Threshold | Measured | Result |
| :--- | :--- | :--- | :--- | :--- |
| smoke [bf16] / [fp8] | load + generate | — | — | ✅ |
| AR text A/B | token agreement | ≥ 0.90 | 1.0000 (32/32 identical) | ✅ |
| | top-1 logprob cosine | ≥ 0.90 | 0.9968 | ✅ |
| | logprob MAE | observed | 0.0338 | — |
| t2i image A/B | image cosine | ≥ 0.99 | 0.999898 | ✅ |
| | rel-L2 | < 0.05 | 0.0153 | ✅ |
| | PSNR / MAE / max-abs / pixel-match | observed | 43.36 dB / 0.0048 / 0.035 / 68.8% | — |

### MammothModa2-Dev — 4 passed ✅

| Test | Metric | Threshold | Measured | Result |
| :--- | :--- | :--- | :--- | :--- |
| smoke [bf16] / [fp8] | load + generate | — | — | ✅ |
| AR text A/B | token agreement | ≥ 0.90 | 1.0000 (32/32 identical) | ✅ |
| | top-1 logprob cosine | ≥ 0.90 | 0.9447 | ✅ |
| | logprob MAE | observed | 0.0210 | — |
| t2i image A/B | image cosine | ≥ 0.99 | 0.999980 | ✅ |
| | rel-L2 | < 0.05 | 0.0115 | ✅ |
| | PSNR / MAE / max-abs / pixel-match | observed | 43.96 dB / 0.0052 / 0.055 / 59.2% | — |

### Conclusion

- On **Preview**, FP8 greedy token sequences are identical to BF16 (agreement 1.0), with logprob cosine 0.9968.
- On both **Preview** and **Dev**, decoded-image differences are sub-pixel (PSNR > 43 dB, cosine > 0.9998); even under the strict pixel_match definition (diff < 1/255, one uint8 step), 59–69% of pixels are exactly identical and the differences are imperceptible.
- The generation experts (`gen_mlp`) and the extra vocabulary/head (`gen_embed_tokens` / `gen_head`) behave correctly under FP8; all A/B gates pass on both model versions.

### Notes

- INT8 (W8A8) and pre-quantized checkpoint loading are left to PR 2 per the plan in #7125; DiT quantization is owned by @xRay2016 under #7075.
