### PR TITLE
Wan server cache dit

### DIFF
--- a/.claude/skills/add-diffusion-model/references/cache-dit-patterns.md
+++ b/.claude/skills/add-diffusion-model/references/cache-dit-patterns.md
@@ -170,6 +170,13 @@ def enable_cache_for_dual_transformer(pipeline, cache_config):
 
 Key difference: `refresh_context` must be called on **each transformer separately** with its own step count.
 
+`_split_inference_steps` needs the boundary and the effective step count that the
+denoise loop will use, so let the pipeline compute it (Wan2.2 exposes
+`resolve_cache_dit_step_split()`) rather than probing the live scheduler — probing
+it would clobber the state `forward` is about to set up. Pass `None` instead of
+`0` for a stage that never runs: Cache-DiT reads `num_inference_steps=0` as "this
+inference is already over" and re-refreshes on every call.
+
 ### Choosing the ForwardPattern
 
 | Pattern | Block forward signature | Example models |
@@ -194,6 +201,18 @@ CUSTOM_DIT_ENABLERS = {
 ```
 
 The key must match `pipeline.__class__.__name__`.
+
+## Request-Boundary Refresh
+
+`DiffusionModelRunner._refresh_cache_for_requests()` refreshes the cache context
+before **every** batch. Cache-DiT's context is persistent and shared across
+requests, so a skipped refresh makes the next request resume the previous one's
+step counters and residual buffers — the second generation comes out corrupted.
+
+If the request omits `num_inference_steps`, the runner asks the pipeline through
+`resolve_num_inference_steps()` (or a `num_inference_steps` attribute). Implement
+that hook on any pipeline whose `forward` applies its own step-count default,
+otherwise the cache context is sized for a schedule that never runs.
 
 ## Configuration Parameters
 

--- a/docs/design/feature/cache_dit.md
+++ b/docs/design/feature/cache_dit.md
@@ -9,6 +9,7 @@ This section describes how to add cache-dit acceleration to a new diffusion pipe
 - [Overview](#overview)
 - [Standard Models: Automatic Support](#standard-models-automatic-support)
 - [Custom Architectures: Writing Custom Implementation](#custom-architectures-writing-custom-implementation)
+- [Request-Boundary Refresh](#request-boundary-refresh)
 - [Testing](#testing)
 - [Troubleshooting](#troubleshooting)
 - [Reference Implementations](#reference-implementations)
@@ -154,6 +155,12 @@ def refresh_cache_context(pipeline, num_inference_steps, verbose=True):
     cache_dit.refresh_context(pipeline.transformer_2, num_inference_steps=low_steps, ...)
 ```
 
+Splitting the step count needs the boundary and the effective step count the
+denoise loop will use, which only the pipeline knows. Wan2.2 exposes
+`resolve_cache_dit_step_split()` for this (see
+[Request-Boundary Refresh](#request-boundary-refresh)); the enabler prefers it
+over inspecting the pipeline directly.
+
 ### Example 2: Multi-Block-List Model (LongCatImage)
 
 LongCatImage has a single transformer with two block lists: `transformer_blocks` and `single_transformer_blocks`.
@@ -192,6 +199,44 @@ CUSTOM_DIT_ENABLERS = {
     "YourCustomPipeline": enable_cache_for_your_model,  # Add here
 }
 ```
+
+---
+
+## Request-Boundary Refresh
+
+Cache-DiT keeps its per-request state — step counters, residual buffers, and
+calibrator history — on a persistent context that lives as long as the installed
+hooks. In online serving that context is shared by every request, so the runner
+rebuilds it before each batch:
+
+`DiffusionModelRunner._refresh_cache_for_requests()` calls
+`CacheDiTBackend.refresh()` on **every** batch. Skipping it would let a request
+resume the previous request's cache: the new request starts past its warmup
+window and reuses stale residuals, which produces a visibly corrupted output
+from the second generation onward.
+
+The step count comes from the request when it pins one. When it does not, the
+runner asks the pipeline via `resolve_num_inference_steps()` (falling back to a
+`num_inference_steps` attribute), because a pipeline that defaults the step count
+internally is the only thing that knows the real value:
+
+```python
+# vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
+class Wan22DenoiseScheduleMixin:
+    default_num_inference_steps: ClassVar[int] = 40
+
+    def resolve_num_inference_steps(self, num_inference_steps): ...
+    def resolve_cache_dit_step_split(self, num_inference_steps): ...
+```
+
+If the step count still cannot be resolved, the refresh runs anyway with no
+override: Cache-DiT recreates the context from its installed configuration and
+drops the per-request state. Resetting on an unknown step count is always
+correct; skipping the reset never is.
+
+When adding a pipeline that defaults `num_inference_steps` itself, implement
+`resolve_num_inference_steps()` so the cache context is sized to the schedule the
+denoise loop will actually run.
 
 ---
 

--- a/examples/online_serving/text_to_video/README.md
+++ b/examples/online_serving/text_to_video/README.md
@@ -37,11 +37,39 @@ bash run_server.sh
 
 The script allows overriding:
 - `MODEL` (default: `Wan-AI/Wan2.2-T2V-A14B-Diffusers`)
-- `PORT` (default: `8091`)
+- `PORT` (default: `8098`)
 - `BOUNDARY_RATIO` (default: `0.875`)
 - `FLOW_SHIFT` (default: `5.0`)
 - `CACHE_BACKEND` (default: `none`)
+- `CACHE_CONFIG` (default: unset; JSON passed to `--cache-config`)
 - `ENABLE_CACHE_DIT_SUMMARY` (default: `0`)
+
+#### Start with Cache-DiT Acceleration
+
+Wan2.2 T2V/I2V are MoE checkpoints, so Cache-DiT caches the high-noise and
+low-noise experts under separate contexts split at `--boundary-ratio`:
+
+```bash
+CACHE_BACKEND=cache_dit ENABLE_CACHE_DIT_SUMMARY=1 bash run_server.sh
+```
+
+Or directly:
+
+```bash
+vllm serve Wan-AI/Wan2.2-T2V-A14B-Diffusers --omni --port 8098 \
+    --boundary-ratio 0.875 --flow-shift 5.0 \
+    --cache-backend cache_dit \
+    --cache-config '{"Fn_compute_blocks": 1, "Bn_compute_blocks": 0, "max_warmup_steps": 4}'
+```
+
+Pass `--boundary-ratio` at startup. It decides how the denoise steps split
+between the two experts, and Cache-DiT sizes each expert's cache context from
+that split; a server-wide value keeps the split stable across requests.
+
+Requests do not need to send `num_inference_steps` — the pipeline default (40)
+is used for both denoising and cache sizing. Set
+`ENABLE_CACHE_DIT_SUMMARY=1` to log per-request hit/miss statistics, which is the
+quickest way to confirm the cache is being exercised and reset per request.
 
 ## Async Job Behavior
 

--- a/examples/online_serving/text_to_video/run_server.sh
+++ b/examples/online_serving/text_to_video/run_server.sh
@@ -6,6 +6,7 @@ PORT="${PORT:-8098}"
 BOUNDARY_RATIO="${BOUNDARY_RATIO:-0.875}"
 FLOW_SHIFT="${FLOW_SHIFT:-5.0}"
 CACHE_BACKEND="${CACHE_BACKEND:-none}"
+CACHE_CONFIG="${CACHE_CONFIG:-}"
 ENABLE_CACHE_DIT_SUMMARY="${ENABLE_CACHE_DIT_SUMMARY:-0}"
 
 echo "Starting Wan2.2 server..."
@@ -18,14 +19,19 @@ if [ "$ENABLE_CACHE_DIT_SUMMARY" != "0" ]; then
     echo "Cache-DiT summary: enabled"
 fi
 
-CACHE_BACKEND_FLAG=""
+EXTRA_ARGS=()
 if [ "$CACHE_BACKEND" != "none" ]; then
-    CACHE_BACKEND_FLAG="--cache-backend $CACHE_BACKEND"
+    EXTRA_ARGS+=(--cache-backend "$CACHE_BACKEND")
+    if [ -n "$CACHE_CONFIG" ]; then
+        EXTRA_ARGS+=(--cache-config "$CACHE_CONFIG")
+    fi
+fi
+if [ "$ENABLE_CACHE_DIT_SUMMARY" != "0" ]; then
+    EXTRA_ARGS+=(--enable-cache-dit-summary)
 fi
 
 vllm serve "$MODEL" --omni \
     --port "$PORT" \
     --boundary-ratio "$BOUNDARY_RATIO" \
     --flow-shift "$FLOW_SHIFT" \
-    $CACHE_BACKEND_FLAG \
-    $(if [ "$ENABLE_CACHE_DIT_SUMMARY" != "0" ]; then echo "--enable-cache-dit-summary"; fi)
+    "${EXTRA_ARGS[@]}"

--- a/tests/diffusion/test_diffusion_model_runner.py
+++ b/tests/diffusion/test_diffusion_model_runner.py
@@ -279,23 +279,27 @@ def test_refresh_cache_prefers_request_steps_then_schedule_then_pipeline_default
         req.sampling_params.num_inference_steps = num_inference_steps
         req.sampling_params.timesteps = timesteps
         req.sampling_params.sigmas = sigmas
-        DiffusionModelRunner._refresh_cache_for_requests(runner, [req], od_config=runner.od_config)
+        DiffusionModelRunner._refresh_cache_for_requests(runner, [req])
 
     assert [steps for _, steps, _ in cache_backend.refresh_calls] == [20, 30, 8, 8, 3, 50]
 
 
 @pytest.mark.core_model
 @pytest.mark.cpu
-def test_refresh_cache_without_request_or_pipeline_default_warns(caplog):
+def test_refresh_cache_without_request_or_pipeline_default_still_refreshes():
+    """An unresolved step count must not skip the refresh.
+
+    Cache backends hold per-request state, so a skipped refresh would let this
+    request resume the previous one's step counters and residual buffers.
+    """
     cache_backend = _EnabledCacheBackend()
     runner = _make_runner(cache_backend=cache_backend, cache_backend_name="cache_dit")
     req = _make_request()
     req.sampling_params.num_inference_steps = None
 
-    DiffusionModelRunner._refresh_cache_for_requests(runner, [req], od_config=runner.od_config)
+    DiffusionModelRunner._refresh_cache_for_requests(runner, [req])
 
-    assert cache_backend.refresh_calls == []
-    assert "requires num_inference_steps to be passed explicitly" in caplog.text
+    assert [steps for _, steps, _ in cache_backend.refresh_calls] == [None]
 
 
 @pytest.mark.core_model
@@ -651,6 +655,64 @@ def test_execute_model_cache_summary_follows_pipeline_owned_cache_dit_state(monk
 
     assert output.output == "ok"
     assert cache_summary_calls == ([(runner.pipeline, True)] if cache_dit_enabled else [])
+
+
+class _RecordingCacheBackend:
+    def __init__(self):
+        self.refresh_calls = []
+
+    def is_enabled(self):
+        return True
+
+    def refresh(self, pipeline, num_inference_steps, verbose=True):
+        self.refresh_calls.append(num_inference_steps)
+
+
+def _refresh_cache_for_request(pipeline, requested_steps, cache_backend_name="cache_dit"):
+    cache_backend = _RecordingCacheBackend()
+    runner = _make_runner(cache_backend=cache_backend, cache_backend_name=cache_backend_name)
+    runner.pipeline = pipeline
+    req = _make_request_with_params(
+        "req-0",
+        SimpleNamespace(num_inference_steps=requested_steps, timesteps=None, sigmas=None),
+    )
+
+    DiffusionModelRunner._refresh_cache_for_requests(runner, [req])
+
+    return cache_backend.refresh_calls
+
+
+@pytest.mark.core_model
+@pytest.mark.cpu
+def test_refresh_cache_uses_the_request_step_count():
+    assert _refresh_cache_for_request(SimpleNamespace(), requested_steps=28) == [28]
+
+
+@pytest.mark.core_model
+@pytest.mark.cpu
+def test_refresh_cache_falls_back_to_the_pipeline_resolved_step_count():
+    """A request may omit the step count and let the pipeline default apply."""
+    pipeline = SimpleNamespace(resolve_num_inference_steps=lambda steps: 40)
+
+    assert _refresh_cache_for_request(pipeline, requested_steps=None) == [40]
+
+
+@pytest.mark.core_model
+@pytest.mark.cpu
+def test_refresh_cache_falls_back_to_the_pipeline_step_attribute():
+    assert _refresh_cache_for_request(SimpleNamespace(num_inference_steps=25), requested_steps=None) == [25]
+
+
+@pytest.mark.core_model
+@pytest.mark.cpu
+@pytest.mark.parametrize("cache_backend_name", ["cache_dit", "tea_cache", "mag_cache", "step_cache"])
+def test_refresh_cache_still_runs_when_the_step_count_is_unknown(cache_backend_name):
+    """Skipping the refresh would leak the previous request's cache into this one."""
+    assert _refresh_cache_for_request(
+        SimpleNamespace(),
+        requested_steps=None,
+        cache_backend_name=cache_backend_name,
+    ) == [None]
 
 
 @pytest.mark.core_model

--- a/vllm_omni/diffusion/cache/base.py
+++ b/vllm_omni/diffusion/cache/base.py
@@ -75,7 +75,7 @@ class CacheBackend(ABC):
         raise NotImplementedError("Subclasses must implement enable()")
 
     @abstractmethod
-    def refresh(self, pipeline: Any, num_inference_steps: int, verbose: bool = True) -> None:
+    def refresh(self, pipeline: Any, num_inference_steps: int | None, verbose: bool = True) -> None:
         """
         Refresh cache state for new generation.
 
@@ -85,8 +85,11 @@ class CacheBackend(ABC):
         Args:
             pipeline: Diffusion pipeline instance. The backend can extract:
                      - transformer: via pipeline.transformer
-            num_inference_steps: Number of inference steps for the current generation.
-                                May be used for cache context updates.
+            num_inference_steps: Number of inference steps for the current generation,
+                                or None when neither the request nor the pipeline
+                                advertises one. May be used for cache context
+                                updates; implementations must still reset their
+                                per-request state when it is None.
             verbose: Whether to log refresh operations (default: True)
         """
         raise NotImplementedError("Subclasses must implement refresh()")

--- a/vllm_omni/diffusion/cache/cachedit/backend.py
+++ b/vllm_omni/diffusion/cache/cachedit/backend.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-RefreshCacheContextFunc: TypeAlias = Callable[[Any, int, bool], None]
+RefreshCacheContextFunc: TypeAlias = Callable[[Any, int | None, bool], None]
 
 
 @dataclass(frozen=True)
@@ -108,9 +108,24 @@ def _build_cache_context_refresh(
     projected_config = CacheDiTConfig.from_diffusion_config(cache_config)
 
     def refresh_cache_context(
-        pipeline: SupportsComponentDiscovery, num_inference_steps: int, verbose: bool = True
+        pipeline: SupportsComponentDiscovery, num_inference_steps: int | None, verbose: bool = True
     ) -> None:
         transformer = get_pipeline_transformer(pipeline)
+
+        if num_inference_steps is None:
+            # The step count is unknown, but the context must still be rebuilt or
+            # the next request would resume this request's step counters and
+            # residual buffers. Refreshing with an empty override keeps the
+            # installed configuration and only drops the per-request state.
+            cache_dit.refresh_context(
+                transformer,
+                cache_config=DBCacheConfig().reset(
+                    force_refresh_step_hint=projected_config.force_refresh_step_hint,
+                    force_refresh_step_policy=projected_config.force_refresh_step_policy,
+                ),
+                verbose=verbose,
+            )
+            return
 
         # Cache-DiT has no predefined SCM mask for these small step counts.
         scm_supported_steps = num_inference_steps >= 8 or num_inference_steps in (4, 6)
@@ -329,7 +344,9 @@ class CacheDiTBackend(CacheBackend):
                 del pipeline._cache_dit_targets
             self.enabled = False
 
-    def refresh(self, pipeline: SupportsComponentDiscovery, num_inference_steps: int, verbose: bool = True) -> None:
+    def refresh(
+        self, pipeline: SupportsComponentDiscovery, num_inference_steps: int | None, verbose: bool = True
+    ) -> None:
         if not self.enabled or not self._refresh_funcs:
             logger.warning("Cache-dit is not enabled. Cannot refresh cache context.")
             return

--- a/vllm_omni/diffusion/cache/cachedit/model_specific.py
+++ b/vllm_omni/diffusion/cache/cachedit/model_specific.py
@@ -29,6 +29,7 @@ from vllm_omni.diffusion.cache.cachedit.backend import (
     RefreshCacheContextFunc,
     _build_cache_context_refresh,
     _default_get_pipeline_transformer,
+    _make_pipeline_transformer_getter,
     _maybe_build_block_adapter,
     enable_cache_for_dit,
 )
@@ -37,39 +38,7 @@ from vllm_omni.diffusion.cache.cachedit.config import CacheDiTConfig
 logger = init_logger(__name__)
 
 
-# from https://github.com/vipshop/cache-dit/pull/542
-def _split_wan22_inference_steps(pipeline, num_inference_steps: int) -> tuple[int, int]:
-    """Split inference steps into high-noise and low-noise steps for Wan2.2.
-
-    This is an internal helper function specific to Wan2.2's dual-transformer
-    architecture that uses boundary_ratio to determine the split point.
-
-    Args:
-        num_inference_steps: Total number of inference steps.
-
-    Returns:
-        A tuple of (num_high_noise_steps, num_low_noise_steps).
-    """
-    if pipeline.boundary_ratio is not None:
-        boundary_timestep = pipeline.boundary_ratio * pipeline.scheduler.config.num_train_timesteps
-    else:
-        boundary_timestep = None
-
-    # Set timesteps to calculate the split
-    device = next(pipeline.transformer.parameters()).device
-    pipeline.scheduler.set_timesteps(num_inference_steps, device=device)
-
-    timesteps = pipeline.scheduler.timesteps
-    num_high_noise_steps = 0  # high-noise steps for transformer
-    for t in timesteps:
-        if boundary_timestep is None or t >= boundary_timestep:
-            num_high_noise_steps += 1
-    # low-noise steps for transformer_2
-    num_low_noise_steps = num_inference_steps - num_high_noise_steps
-    return num_high_noise_steps, num_low_noise_steps
-
-
-def enable_cache_for_wan22(pipeline: Any, cache_config: Any) -> RefreshCacheContextFunc:
+def enable_cache_for_wan22(pipeline: Any, cache_config: Any) -> CacheDiTEnableResult:
     """Enable cache-dit for Wan2.2 single or dual-transformer architecture.
 
     Wan2.2 can use single or dual transformers (transformer and transformer_2) that need
@@ -80,23 +49,38 @@ def enable_cache_for_wan22(pipeline: Any, cache_config: Any) -> RefreshCacheCont
         cache_config: DiffusionCacheConfig instance with cache configuration.
 
     Returns:
-        A refresh function that can be called to update cache context with new num_inference_steps.
+        A refresh function that can be called to update cache context with new
+        num_inference_steps, paired with the transformers to release on teardown.
     """
     projected_config = CacheDiTConfig.from_diffusion_config(cache_config)
     db_cache_config = projected_config.to_db_cache_config()
     calibrator_config = projected_config.to_calibrator_config()
 
-    if getattr(pipeline, "transformer_2", None) is None:
-        logger.info("transformer_2 not found, enabling cache-dit for single transformer mode")
+    transformer = getattr(pipeline, "transformer", None)
+    transformer_2 = getattr(pipeline, "transformer_2", None)
+
+    if transformer is None and transformer_2 is None:
+        raise ValueError(f"{type(pipeline).__name__} has no loaded transformer to enable cache-dit on")
+
+    if transformer is None or transformer_2 is None:
+        # Only one expert is resident.  Either the checkpoint is single-expert
+        # (Wan2.1-style), or it is a Wan2.2 MoE checkpoint run with
+        # boundary_ratio pinned to 1.0 / 0.0, which makes Wan22Pipeline load
+        # only the low-noise / high-noise expert respectively.  Both cases must
+        # key off whichever attribute actually holds a module: assuming the
+        # survivor is always ``transformer`` crashes the low-noise-only run.
+        active_name = "transformer" if transformer is not None else "transformer_2"
+        active_transformer = transformer if transformer is not None else transformer_2
+        logger.info("Enabling cache-dit for single transformer mode on %s", active_name)
         cache_dit.enable_cache(
             BlockAdapter(
-                transformer=pipeline.transformer,
+                transformer=active_transformer,
                 # For VACE, cache only the main denoising blocks. The
                 # conditioning branch (vace_blocks) has a different forward
                 # contract and produces per-step hints from the current latent
                 # plus vace_context; keeping it outside CacheDiT preserves the
                 # control signal while still accelerating the repeated backbone.
-                blocks=[pipeline.transformer.blocks],
+                blocks=[active_transformer.blocks],
                 forward_pattern=[ForwardPattern.Pattern_2],
                 params_modifiers=[
                     ParamsModifier(cache_config=db_cache_config, calibrator_config=calibrator_config),
@@ -106,7 +90,15 @@ def enable_cache_for_wan22(pipeline: Any, cache_config: Any) -> RefreshCacheCont
             cache_config=db_cache_config,
             calibrator_config=calibrator_config,
         )
-        return _build_cache_context_refresh(cache_config)
+        # The refresh callback must read the same attribute we cached; the
+        # default getter hardcodes ``pipeline.transformer``, which is None here
+        # when only the low-noise expert was loaded.  A single expert also runs
+        # every step, so no high/low split is applied.  Reporting the target
+        # explicitly keeps teardown off that same hardcoded attribute.
+        return CacheDiTEnableResult(
+            refresh=_build_cache_context_refresh(cache_config, _make_pipeline_transformer_getter(active_name)),
+            targets=(active_transformer,),
+        )
 
     cache_dit.enable_cache(
         BlockAdapter(
@@ -151,18 +143,33 @@ def enable_cache_for_wan22(pipeline: Any, cache_config: Any) -> RefreshCacheCont
     refresh_trans_one = _build_cache_context_refresh(cache_config)
     refresh_trans_two = _build_cache_context_refresh(cache_config, lambda pipeline: pipeline.transformer_2)
 
-    def refresh_cache_context(pipeline: Any, num_inference_steps: int, verbose: bool = True) -> None:
+    def refresh_cache_context(pipeline: Any, num_inference_steps: int | None, verbose: bool = True) -> None:
         """Refresh cache context for both transformers with new num_inference_steps.
+
+        Both experts are refreshed even when the split is unknown: a skipped
+        refresh would leak this request's step counters and residual buffers into
+        the next one.
 
         Args:
             pipeline: The Wan2.2 pipeline instance.
-            num_inference_steps: New number of inference steps.
+            num_inference_steps: New number of inference steps, or ``None`` when
+                the request did not pin one.
         """
-        num_high_noise_steps, num_low_noise_steps = _split_wan22_inference_steps(pipeline, num_inference_steps)
-        refresh_trans_one(pipeline, num_high_noise_steps, verbose)
-        refresh_trans_two(pipeline, num_low_noise_steps, verbose)
+        num_high_noise_steps, num_low_noise_steps = pipeline.resolve_cache_dit_step_split(num_inference_steps)
+        # A stage with zero steps never runs, so leave its context step count
+        # unset rather than pinning it to 0 (which Cache-DiT reads as "this
+        # inference is already over" and re-refreshes on every call).
+        refresh_trans_one(pipeline, num_high_noise_steps or None, verbose)
+        refresh_trans_two(pipeline, num_low_noise_steps or None, verbose)
 
-    return refresh_cache_context
+    # Both experts are wrapped by the adapter above, so both have to be reported
+    # as teardown targets: the default fallback only releases
+    # ``pipeline.transformer`` and would leave transformer_2 hooked after
+    # ``disable()``.
+    return CacheDiTEnableResult(
+        refresh=refresh_cache_context,
+        targets=(pipeline.transformer, pipeline.transformer_2),
+    )
 
 
 def enable_cache_for_wan22_s2v(pipeline: Any, cache_config: Any) -> RefreshCacheContextFunc:
@@ -211,9 +218,9 @@ def enable_cache_for_wan22_s2v(pipeline: Any, cache_config: Any) -> RefreshCache
 
     transformer.after_transformer_block = _noop_after_transformer_block
 
-    def refresh_cache_context(pipeline: Any, num_inference_steps: int, verbose: bool = True) -> None:
+    def refresh_cache_context(pipeline: Any, num_inference_steps: int | None, verbose: bool = True) -> None:
         """Refresh cache context for the S2V transformer."""
-        if projected_config.scm_steps_mask_policy is None:
+        if projected_config.scm_steps_mask_policy is None or num_inference_steps is None:
             cache_dit.refresh_context(
                 pipeline.transformer,
                 num_inference_steps=num_inference_steps,

--- a/vllm_omni/diffusion/cache/magcache/backend.py
+++ b/vllm_omni/diffusion/cache/magcache/backend.py
@@ -120,7 +120,7 @@ class MagCacheBackend(CacheBackend):
         self._registered = True
         self.enabled = True
 
-    def refresh(self, pipeline: Any, num_inference_steps: int) -> None:
+    def refresh(self, pipeline: Any, num_inference_steps: int | None) -> None:
         """Refresh MagCache state for new generation.
 
         Clears all cached residuals and resets counters/accumulators.

--- a/vllm_omni/diffusion/cache/stepcache/backend.py
+++ b/vllm_omni/diffusion/cache/stepcache/backend.py
@@ -112,14 +112,14 @@ class StepCacheBackend(CacheBackend):
 
         self.enabled = True
 
-    def refresh(self, pipeline: Any, num_inference_steps: int, verbose: bool = True) -> None:
+    def refresh(self, pipeline: Any, num_inference_steps: int | None, verbose: bool = True) -> None:
         """Refresh stepcache state for a new generation."""
         state = get_stepcache_state(pipeline)
         if state is not None:
             state.reset()
             if verbose:
                 logger.debug(
-                    "stepcache state refreshed (num_inference_steps=%d)",
+                    "stepcache state refreshed (num_inference_steps=%s)",
                     num_inference_steps,
                 )
         elif verbose and is_stepcache_active(pipeline):

--- a/vllm_omni/diffusion/cache/teacache/backend.py
+++ b/vllm_omni/diffusion/cache/teacache/backend.py
@@ -199,7 +199,7 @@ class TeaCacheBackend(CacheBackend):
         # Mark as enabled
         self.enabled = True
 
-    def refresh(self, pipeline: Any, num_inference_steps: int, verbose: bool = True) -> None:
+    def refresh(self, pipeline: Any, num_inference_steps: int | None, verbose: bool = True) -> None:
         """
         Refresh TeaCache state for new generation.
 

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
@@ -316,8 +316,59 @@ _WAN_TEXT_ENCODER_OFFLOAD_PLAN = OffloadPlan(
 )
 
 
+class Wan22DenoiseScheduleMixin:
+    """Expose the denoise schedule ``forward`` is about to run.
+
+    Cache backends prepare their per-request state before ``forward`` starts, so
+    they cannot read the resolved step count or the MoE boundary off the pipeline
+    yet. These helpers recompute both from the same defaults ``forward`` applies,
+    which keeps a Cache-DiT context refresh aligned with the denoise loop it is
+    meant to accelerate.
+    """
+
+    default_num_inference_steps: ClassVar[int] = 40
+
+    def resolve_num_inference_steps(self, num_inference_steps: int | None) -> int:
+        """Return the step count ``forward`` will denoise with."""
+        if getattr(self, "is_dmd", False):
+            # The distilled checkpoint ignores request-level step counts.
+            return len(FASTWAN_DMD_TIMESTEPS)
+        if num_inference_steps is None or num_inference_steps <= 0:
+            return self.default_num_inference_steps
+        return num_inference_steps
+
+    def resolve_denoise_timesteps(self, num_inference_steps: int | None) -> torch.Tensor:
+        """Return the timesteps ``forward`` will iterate over."""
+        if getattr(self, "is_dmd", False):
+            return torch.tensor(FASTWAN_DMD_TIMESTEPS, dtype=torch.float32)
+        # Probe a throwaway scheduler: ``forward`` rebuilds and re-arms the live
+        # one from the request, so advancing it here would be observable.
+        scheduler = build_wan_scheduler(self._sample_solver, self._flow_shift)
+        scheduler.set_timesteps(
+            self.resolve_num_inference_steps(num_inference_steps),
+            device=torch.device("cpu"),
+        )
+        return scheduler.timesteps
+
+    def resolve_cache_dit_step_split(self, num_inference_steps: int | None) -> tuple[int, int]:
+        """Split the denoise steps across the high-noise and low-noise experts.
+
+        Returns ``(num_high_noise_steps, num_low_noise_steps)``, matching how
+        ``diffuse`` picks ``transformer`` versus ``transformer_2``.
+
+        Split algorithm from https://github.com/vipshop/cache-dit/pull/542.
+        """
+        # Mirrors the fallback ``forward`` applies when boundary_ratio is unset.
+        boundary_ratio = self.boundary_ratio if self.boundary_ratio is not None else 0.875
+        boundary_timestep = boundary_ratio * self.scheduler.config.num_train_timesteps
+        timesteps = self.resolve_denoise_timesteps(num_inference_steps)
+        num_high_noise_steps = int((timesteps >= boundary_timestep).sum())
+        return num_high_noise_steps, len(timesteps) - num_high_noise_steps
+
+
 class Wan22Pipeline(
     nn.Module,
+    Wan22DenoiseScheduleMixin,
     PipelineParallelMixin,
     CFGParallelMixin,
     ProgressBarMixin,
@@ -662,12 +713,10 @@ class Wan22Pipeline(
         mod_value = self.vae_scale_factor_spatial * patch_size[1]  # 16*2=32 for TI2V, 8*2=16 for I2V
         height = (height // mod_value) * mod_value
         width = (width // mod_value) * mod_value
-        if self.is_dmd:
-            # The checkpoint was distilled for these three transitions. Ignore
-            # request-level step counts, including the engine's 1-step warmup.
-            num_steps = len(FASTWAN_DMD_TIMESTEPS)
-        else:
-            num_steps = 40 if common.num_inference_steps is None else common.num_inference_steps
+        # The DMD checkpoint was distilled for three fixed transitions, so
+        # request-level step counts (including the engine's 1-step warmup) are
+        # ignored; ``resolve_num_inference_steps`` encodes that.
+        num_steps = self.resolve_num_inference_steps(common.num_inference_steps)
 
         output_type = common.output_type or "np"
         num_outputs_per_prompt = common.num_outputs_per_prompt or 1

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
@@ -33,6 +33,7 @@ from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin, _is_rank_z
 from vllm_omni.diffusion.models.utils import _load_json
 from vllm_omni.diffusion.models.wan2_2.pipeline_wan2_2 import (
     _WAN_TEXT_ENCODER_OFFLOAD_PLAN,
+    Wan22DenoiseScheduleMixin,
     build_wan_scheduler,
     create_transformer_from_config,
     load_transformer_config,
@@ -173,6 +174,7 @@ def get_wan22_i2v_pre_process_func(
 
 class Wan22I2VPipeline(
     nn.Module,
+    Wan22DenoiseScheduleMixin,
     SupportImageInput,
     PipelineParallelMixin,
     CFGParallelMixin,
@@ -516,7 +518,7 @@ class Wan22I2VPipeline(
         height = common.height or 480
         width = common.width or 832
         num_frames = common.num_frames or 81
-        num_steps = 40 if common.num_inference_steps is None else common.num_inference_steps
+        num_steps = self.resolve_num_inference_steps(common.num_inference_steps)
 
         output_type = common.output_type or "np"
         num_outputs_per_prompt = common.num_outputs_per_prompt or 1

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_vace.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_vace.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from copy import copy
+from typing import ClassVar
 
 import PIL.Image
 import torch
@@ -189,6 +190,9 @@ class Wan22VACEPipeline(Wan22Pipeline, SupportImageInput):
     Extends Wan22Pipeline with VACE-specific context creation and weight loading.
     All VACE modes (T2V, R2V, V2V, MV2V) are handled by varying the inputs.
     """
+
+    # VACE's own forward defaults to 50 steps, not the base pipeline's 40.
+    default_num_inference_steps: ClassVar[int] = 50
 
     def __init__(
         self,

--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -640,12 +640,7 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
                 gen_device = self.device
             sampling_params.generator = torch.Generator(device=gen_device).manual_seed(sampling_params.seed)
 
-    def _refresh_cache_for_requests(
-        self,
-        reqs: list[OmniDiffusionRequest],
-        *,
-        od_config: OmniDiffusionConfig,
-    ) -> None:
+    def _refresh_cache_for_requests(self, reqs: list[OmniDiffusionRequest]) -> None:
         first_req = reqs[0]
         if self.cache_backend is None or not self.cache_backend.is_enabled():
             return
@@ -659,26 +654,34 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
         if num_inference_steps is None and first_req.sampling_params.sigmas is not None:
             num_inference_steps = len(first_req.sampling_params.sigmas)
         if num_inference_steps is None:
-            num_inference_steps = getattr(self.pipeline, "default_num_inference_steps", None)
-        if num_inference_steps is None and od_config.cache_backend in (
-            "tea_cache",
-            "step_cache",
-        ):
-            # When num_inference_steps is None, some pipelines defer to their
-            # own defaults. TeaCache refresh ignores this value; step_cache
-            # refresh is a no-op because per-chunk state resets in the denoise
-            # loop. Use the pipeline default when available to keep refresh
-            # behavior aligned with single-request execution.
-            num_inference_steps = getattr(self.pipeline, "num_inference_steps", 0) or 0
+            # The request left the step count to the pipeline's own default, so
+            # ask the pipeline rather than leaving the cache context unsized.
+            num_inference_steps = self._resolve_pipeline_num_inference_steps()
 
-        if num_inference_steps is not None:
-            self.cache_backend.refresh(self.pipeline, num_inference_steps)
-        else:
-            logger.warning(
-                "Failed to refresh the diffusion transformer cache; backend %s "
-                "currently requires num_inference_steps to be passed explicitly",
-                od_config.cache_backend,
-            )
+        # Always refresh, even with an unresolved step count. Cache backends hold
+        # per-request state (residual buffers, step counters), so skipping the
+        # refresh would let this batch resume the previous request's cache and
+        # produce a corrupted output.
+        self.cache_backend.refresh(self.pipeline, num_inference_steps)
+
+    def _resolve_pipeline_num_inference_steps(self) -> int | None:
+        """Ask the pipeline which step count it will actually denoise with.
+
+        Requests may omit ``num_inference_steps`` and let the pipeline apply its
+        own default, which cache backends need in order to size a request
+        context. Returns ``None`` when the pipeline does not advertise one.
+        """
+
+        resolve = getattr(self.pipeline, "resolve_num_inference_steps", None)
+        if callable(resolve):
+            return resolve(None)
+        # Pipelines without the resolver still advertise their default either as
+        # a class-level constant or as a live attribute.
+        return (
+            getattr(self.pipeline, "default_num_inference_steps", None)
+            or getattr(self.pipeline, "num_inference_steps", None)
+            or None
+        )
 
     def _runner_output_from_outputs(
         self,
@@ -738,7 +741,7 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
                     use_prefetch=allow_single_output,
                 )
 
-            self._refresh_cache_for_requests(reqs, od_config=od_config)
+            self._refresh_cache_for_requests(reqs)
 
             batch = DiffusionRequestBatch(requests=reqs)
             is_primary = not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Cache-DiT keeps its per-request state — step counters, residual buffers and calibrator
history — on a context that lives as long as the installed hooks. In online serving that
context is shared by every request, so it has to be rebuilt at each request boundary.
Three bugs kept that from happening for Wan2.2, and the first one silently disabled
Cache-DiT entirely: **`--cache-backend cache_dit` was as slow as no caching at all.**

**1. The refresh was skipped whenever the step count could not be resolved.**
`DiffusionModelRunner._refresh_cache_for_requests()` only refreshed when
`num_inference_steps` was known; otherwise it logged
`"currently requires num_inference_steps to be passed explicitly"` and left the context
untouched. Wan2.2 does not advertise the default its `forward` applies (40), so any
`/v1/videos` request that omits `num_inference_steps` leaves the context sized by the
engine's 1-step warmup — Cache-DiT then believes the inference is already over and never
caches anything. The refresh now always runs; an unresolved step count rebuilds the context
from the installed configuration instead of skipping the reset. Resetting on an unknown step
count is always correct; skipping the reset never is.

**2. Wan2.2 could not report the schedule it was about to run.**
Cache backends prepare their state *before* `forward` starts, so they cannot read the
resolved step count or the MoE boundary off the pipeline yet. The enabler worked around this
by probing the **live** scheduler (`pipeline.scheduler.set_timesteps(...)`), which clobbers
the state `forward` is about to set up. `Wan22DenoiseScheduleMixin` now exposes
`resolve_num_inference_steps()` and `resolve_cache_dit_step_split()`, which recompute both
from the same defaults `forward` applies using a throwaway scheduler. `forward` calls the
same resolver, so the two cannot drift.

**3. A single-expert Wan2.2 MoE run crashed, and dual-expert teardown leaked hooks.**
With `--boundary-ratio 1.0` / `0.0` only the low-noise / high-noise expert is loaded, so
`pipeline.transformer` may be `None`; the enabler assumed the surviving expert was always
`transformer` and crashed at startup. It now keys off whichever attribute holds a module,
and reports its exact teardown targets via `CacheDiTEnableResult` so `disable()` releases
**both** experts in the normal dual-expert case instead of only `transformer`.

Because an unknown step count now reaches the backends, `CacheBackend.refresh()` and the
three other backends widen to `int | None`. A stage with zero steps is passed as `None`
rather than `0`, which Cache-DiT reads as "this inference is already over" and would
re-refresh on every call.

## Test Plan

- `pytest tests/diffusion/cache tests/diffusion/models/wan2_2 tests/diffusion/test_diffusion_model_runner.py`
- 480p online serving on `Wan-AI/Wan2.2-T2V-A14B-Diffusers`, 8× Intel Arc Pro B70 (32 GiB),
  `--tensor-parallel-size 8`, `--boundary-ratio 0.875 --flow-shift 5.0`. Two sequential
  `POST /v1/videos` jobs, `size=832x480`, `seconds=2`, `fps=16` (33 frames), seed 42, and
  **`num_inference_steps` deliberately omitted** so the pipeline default (40) applies.
- Same model started with `--boundary-ratio 1.0 --cache-backend cache_dit` (single resident
  expert) for bug 3.

## Test Result

### 480p serving, two sequential requests

| Config | req 1 | req 2 | mean | vs. no cache |
| --- | --- | --- | --- | --- |
| `--cache-backend none` | 244.6 s | 244.7 s | 244.7 s | 1.00× |
| `cache_dit`, **before** this PR | 246.7 s | 244.6 s | 245.7 s | **1.00× (no benefit)** |
| `cache_dit`, **after** this PR | 104.3 s | 102.3 s | 103.3 s | **2.37×** |

# test result explained

Before this PR, enabling `cache_dit` bought nothing: it matched the uncached baseline to
within run-to-run noise. The server log explains why — the refresh never ran, so the context
kept the 1-step sizing from the engine warmup:

```
# before: 16 × (2 requests × 8 TP ranks)
WARNING ... Failed to refresh the diffusion transformer cache; backend cache_dit
            currently requires num_inference_steps to be passed explicitly
# only ever one refresh, from the warmup, and both experts stay at N1:
Refreshing cache context for transformer with num_inference_steps: 2
  DBCache_F1B0_W4I1M0MC3_R0.24_N1_CFG1     # high-noise expert, 1 step
  DBCache_F1B0_W2I1M20MC3_R0.24_N1_CFG1    # low-noise expert, 1 step
```

```
# after: zero warnings, one refresh per request, split across the two experts
Refreshing cache context for transformer with num_inference_steps: 40   (× 2 requests)
  DBCache_F1B0_W4I1M0MC3_R0.24_N17_CFG1    # high-noise expert, 17 steps
  DBCache_F1B0_W2I1M20MC3_R0.24_N23_CFG1   # low-noise expert, 23 steps
```

17 + 23 = 40, matching how `diffuse` splits the schedule at `boundary_ratio=0.875`, and the
split is re-derived identically for every request.



**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
