### PR TITLE
[CI/Build] Stabilize LTX2 vocoder autocast test on ROCm

### DIFF
--- a/tests/diffusion/models/ltx2/test_ltx2_vocoder_cuda.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_vocoder_cuda.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
-"""CUDA regression tests for LTX-2 BWE vocoder precision."""
+"""GPU regression tests for LTX-2 BWE vocoder precision."""
 
 import pytest
 import torch
@@ -14,10 +14,13 @@ pytestmark = [pytest.mark.core_model, pytest.mark.diffusion]
 class _BWEConvVocoder(torch.nn.Module):
     def __init__(self):
         super().__init__()
+        # Match the production LTX vocoder's conv_pre geometry. The previous
+        # single-channel 1x1 probe intermittently had no MIOpen algorithm.
         self.conv = torch.nn.Conv1d(
-            1,
-            1,
-            kernel_size=1,
+            128,
+            1024,
+            kernel_size=7,
+            padding=3,
             bias=False,
             device="cuda",
             dtype=torch.bfloat16,
@@ -33,12 +36,12 @@ class _BWEConvVocoder(torch.nn.Module):
         return output
 
 
-@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@hardware_test(res={"cuda": "L4", "rocm": "MI325"}, num_cards=1)
 def test_ltx_bwe_vocoder_runs_real_cuda_autocast_in_fp32():
     from vllm_omni.diffusion.models.ltx2.ltx2_runtime import _run_ltx_vocoder
 
     vocoder = _BWEConvVocoder()
-    generated_mel = torch.ones((1, 1, 4), device="cuda", dtype=torch.bfloat16)
+    generated_mel = torch.ones((1, 128, 64), device="cuda", dtype=torch.bfloat16)
 
     output = _run_ltx_vocoder(vocoder, generated_mel)
 


### PR DESCRIPTION
## What broke

The one-GPU AMD `Diffusion · Model Test` intermittently fails in:

```text
tests/diffusion/models/ltx2/test_ltx2_vocoder_cuda.py::test_ltx_bwe_vocoder_runs_real_cuda_autocast_in_fp32
MIOpen Error: No suitable algorithm was found to execute the required convolution
RuntimeError: miopenStatusUnknownError
```

Examples: [AMD build #11607](https://buildkite.com/vllm/vllm-omni-amd-ci/builds/11607) and [#11608](https://buildkite.com/vllm/vllm-omni-amd-ci/builds/11608).

## Reproduction

On an MI300 ROCm runner using the normal ready-suite environment:

```bash
pytest -s -v \
  tests/diffusion/models/ltx2/test_ltx2_vocoder_cuda.py::test_ltx_bwe_vocoder_runs_real_cuda_autocast_in_fp32 \
  -m 'core_model and cuda' \
  --run-level core_model
```

The original probe passes on some nodes and fails on others, so a single run is not sufficient to characterize it.

## Root cause

The regression test used a degenerate `Conv1d(1, 1, kernel_size=1)` with an input length of four. That shape does not represent the LTX BWE convolution stack and can leave MIOpen without a suitable enabled algorithm in the AMD CI configuration.

The production LTX vocoder begins with a 128-to-1024 channel, kernel-7 convolution. The test only needs a real convolution to verify that `_run_ltx_vocoder()` executes the BWE path in FP32 autocast while preserving BF16 parameters and converting the returned waveform back to the input dtype.

## Fix

- Replace the tiny synthetic convolution with the production-like LTX `conv_pre` geometry: 128 input channels, 1024 output channels, kernel 7, padding 3.
- Use a short `(1, 128, 64)` input so the test remains lightweight.
- Explicitly mark the test for both CUDA L4 and ROCm MI325 coverage.
- Preserve all existing dtype assertions and production behavior.

## Validation

- `python3 -m compileall -q tests/diffusion/models/ltx2/test_ltx2_vocoder_cuda.py`
- `pre-commit run --files tests/diffusion/models/ltx2/test_ltx2_vocoder_cuda.py`
  - Ruff, formatting, mypy-3.10, test-mark validation, SPDX, forbidden-import, and `torch.cuda` checks passed.
- Local pytest execution was not available because the local Python environment does not have PyTorch installed.
- Exact-head AMD CI: [`mi300_1: Diffusion · Model Test`](https://buildkite.com/vllm/vllm-omni-amd-ci/builds/11621#01a086d7-cd02-4371-ad38-779d3c57f5e7) passed on commit `54cf165875014dc8a7d863706949d47ad5943782`; the changed LTX2 test was selected and passed, with the job summary `29 passed, 22 skipped, 2657 deselected` in 62.31s.
- Exact-head CUDA CI: [`Diffusion · Model Test`](https://buildkite.com/vllm/vllm-omni/builds/14905#01a086d9-b81c-4a89-a6d0-57686b094650) passed on the same commit; the changed LTX2 test was selected and passed.
- The original case was intermittent. This establishes one exact-head ROCm pass; repeat execution across additional MI300 workers remains useful as burn-in before claiming the flake is statistically eliminated.

## AI assistance

Used Codex to diagnose the Buildkite failures, compare the test shape with the official LTX vocoder architecture, prepare the focused test change, and run local checks. I reviewed the resulting one-file diff and validation results.

