### PR TITLE
[Doc] Document num_outputs_per_prompt for /v1/videos

### DIFF
--- a/docs/user_guide/examples/online_serving/text_to_video.md
+++ b/docs/user_guide/examples/online_serving/text_to_video.md
@@ -199,11 +199,20 @@ curl -X POST http://localhost:8091/v1/videos \
 | `boundary_ratio`      | float  | None    | Boundary split ratio for low/high DiT (Wan2.2)   |
 | `flow_shift`          | float  | None    | Scheduler flow shift (Wan2.2)                    |
 | `seed`                | int    | None    | Random seed (reproducible)                       |
+| `num_outputs_per_prompt` | int  | 1       | Number of videos to generate (1-10, MiniMax H3); only the first is returned, see below |
 | `lora`                | object | None    | LoRA configuration                               |
 | `enable_frame_interpolation` | bool | false | Enable RIFE frame interpolation before MP4 encoding |
 | `frame_interpolation_exp` | int | 1 | Interpolation exponent; 1=2x temporal resolution, 2=4x |
 | `frame_interpolation_scale` | float | 1.0 | RIFE inference scale; use 0.5 for high-resolution inputs |
 | `frame_interpolation_model_path` | str | None | Local directory or Hugging Face repo ID with `flownet.pkl`; defaults to `elfgum/RIFE-4.22.lite` |
+
+!!! note "Only the first output is returned"
+    `num_outputs_per_prompt` is forwarded to the pipeline, so the model does
+    generate that many videos and you pay the generation cost for all of them.
+    `/v1/videos` and `/v1/videos/sync` then return only the **first** one,
+    because an async video job stores a single file per video id. The server
+    logs a warning when it discards the extra outputs. Keep this at `1`
+    unless you have a specific reason to generate videos you will not receive.
 
 ## Frame Interpolation
 


### PR DESCRIPTION
`num_outputs_per_prompt` isn't in any of the video docs, which is what #6899 is
asking about. It's already listed in `text_to_image.md` and `image_to_image.md`,
so the omission looks accidental.

It's worth more than just a table row, because the behavior is surprising:
`serving_video.py` forwards the value, so N videos actually get generated, and
then `generate_video_bytes` returns `videos[0]` and logs
`"generated %d outputs; returning only the first"`. Set it to 4 and you pay for
4 videos and receive 1. The note says that plainly so nobody has to find it in
the server log.

Only touching `text_to_video.md` here, since it carries the canonical
`/v1/videos` parameter table. `image_to_video.md` and `speech_to_video.md` are
shaped differently — happy to add the note there too if you'd rather have it in
all three.
