### PR TITLE
[Model] Reduce LTX-2.5 distributed DiffVAE decode memory

### DIFF
--- a/tests/diffusion/models/ltx2/test_ltx2_vae.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_vae.py
@@ -661,11 +661,62 @@ class TestLTXDiffusionDecoder:
                 drop_leading_frame=task.drop_leading_frame,
                 crop_trailing_ghost=task.crop_trailing_ghost,
             )
+            assert task.output_shape == tile_shape
             expected = randn_tensor(tile_shape, generator=reference_generator, device=z.device, dtype=z.dtype)
             actual = randn_tensor(tile_shape, generator=task.noise_generator, device=z.device, dtype=z.dtype)
             torch.testing.assert_close(actual, expected)
 
         assert torch.equal(distributed_generator.get_state(), reference_generator.get_state())
+
+    def test_distributed_diffusion_sends_exact_size_tiles_to_rank_zero(self, monkeypatch):
+        from vllm_omni.diffusion.distributed.autoencoders.distributed_vae_executor import GridSpec
+        from vllm_omni.diffusion.models.ltx2.vae.distributed import (
+            DistributedLTX2VideoDiffusionDecoderModel,
+            LTX2VideoDiffusionTileTask,
+        )
+
+        model = object.__new__(DistributedLTX2VideoDiffusionDecoderModel)
+        torch.nn.Module.__init__(model)
+        model.distributed_executor = SimpleNamespace(parallel_size=2, world_size=2, rank=1, group=None)
+        z = torch.zeros(1, 1, 1, 1, 1)
+        shapes = ((1, 1, 1, 2, 2), (1, 1, 1, 2, 1), (1, 1, 1, 1, 2), (1, 1, 1, 1, 1))
+        tasks = [
+            LTX2VideoDiffusionTileTask(
+                tile_id=index,
+                grid_coord=(0, index // 2, index % 2),
+                tensor=z,
+                workload=workload,
+                output_shape=shapes[index],
+            )
+            for index, workload in enumerate((4, 3, 2, 1))
+        ]
+        grid_spec = GridSpec(split_dims=(2, 3, 4), grid_shape=(1, 2, 2), output_dtype=torch.float32)
+        model._distributed_tile_split = lambda *_args: (tasks, grid_spec)
+        model._distributed_tile_exec = lambda task, _steps: torch.full(
+            model._distributed_tile_output_shape(task),
+            float(task.tile_id + 1),
+        )
+        model._distributed_tile_merge = lambda tiles, _spec: torch.stack(
+            [tiles[task.grid_coord].flatten()[0] for task in tasks]
+        )
+        transfers = []
+        monkeypatch.setattr(torch.distributed, "send", lambda tile, **_kwargs: transfers.append(tile.clone()))
+
+        nonzero_result = model._execute_distributed_exact_size_decode(z, None, 1)
+
+        assert nonzero_result.numel() == 0
+        assert [tuple(tile.shape) for tile in transfers] == [shapes[1], shapes[2]]
+
+        model.distributed_executor.rank = 0
+
+        def recv(tile, **_kwargs):
+            tile.copy_(transfers.pop(0))
+
+        monkeypatch.setattr(torch.distributed, "recv", recv)
+        rank_zero_result = model._execute_distributed_exact_size_decode(z, None, 1)
+
+        torch.testing.assert_close(rank_zero_result, torch.tensor([1.0, 2.0, 3.0, 4.0]))
+        assert not transfers
 
 
 class TestLTXOutputRank:

--- a/tests/diffusion/models/ltx2/test_ltx2_vae.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_vae.py
@@ -702,7 +702,13 @@ class TestLTXDiffusionDecoder:
         transfers = []
         monkeypatch.setattr(torch.distributed, "send", lambda tile, **_kwargs: transfers.append(tile.clone()))
 
-        nonzero_result = model._execute_distributed_exact_size_decode(z, None, 1)
+        reference_tiles = {task.grid_coord: model._distributed_tile_exec(task, 1) for task in tasks}
+        model._distributed_streaming_merger = lambda _spec, _z: SimpleNamespace(
+            add=lambda coord, tile: reference_tiles.__setitem__(coord, tile),
+            finish=lambda: model._distributed_tile_merge(reference_tiles, grid_spec),
+        )
+
+        nonzero_result = model._execute_distributed_streaming_decode(z, None, 1)
 
         assert nonzero_result.numel() == 0
         assert [tuple(tile.shape) for tile in transfers] == [shapes[1], shapes[2]]
@@ -713,10 +719,147 @@ class TestLTXDiffusionDecoder:
             tile.copy_(transfers.pop(0))
 
         monkeypatch.setattr(torch.distributed, "recv", recv)
-        rank_zero_result = model._execute_distributed_exact_size_decode(z, None, 1)
+        rank_zero_result = model._execute_distributed_streaming_decode(z, None, 1)
 
         torch.testing.assert_close(rank_zero_result, torch.tensor([1.0, 2.0, 3.0, 4.0]))
         assert not transfers
+
+    def test_distributed_diffusion_streaming_merge_matches_reference_order(self):
+        from vllm_omni.diffusion.models.ltx2.vae.distributed import (
+            DistributedLTX2VideoDiffusionDecoderModel,
+            LTX2VideoDiffusionTilePlan,
+            _LTX2VideoDiffusionStreamingMerger,
+        )
+
+        model = object.__new__(DistributedLTX2VideoDiffusionDecoderModel)
+        torch.nn.Module.__init__(model)
+        model.decoder = SimpleNamespace(out_channels=1)
+        plan = LTX2VideoDiffusionTilePlan(
+            temporal_tiles=((0, 2), (1, 3)),
+            height_tiles=((0, 3), (2, 5), (4, 7)),
+            width_tiles=((0, 3), (2, 5), (4, 7)),
+            num_frames=3,
+            height=7,
+            width=7,
+            scale_t=1,
+            scale_h=1,
+            scale_w=1,
+            stride_t=1,
+            stride_h=2,
+            stride_w=2,
+            blend_frames=1,
+            blend_height=1,
+            blend_width=1,
+            single_step_x0=True,
+        )
+        generator = torch.Generator().manual_seed(123)
+        tiles = {
+            (t_idx, h_idx, w_idx): torch.randn((1, 1, 2, 3, 3), generator=generator)
+            for t_idx in range(len(plan.temporal_tiles))
+            for h_idx in range(len(plan.height_tiles))
+            for w_idx in range(len(plan.width_tiles))
+        }
+        expected = model._merge_tiled_decode({coord: tile.clone() for coord, tile in tiles.items()}, plan)
+        merger = _LTX2VideoDiffusionStreamingMerger(
+            model,
+            plan,
+            batch_size=1,
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+        )
+
+        for coord in tiles:
+            merger.add(coord, tiles[coord].clone())
+
+        torch.testing.assert_close(merger.finish(), expected, rtol=0, atol=0)
+
+    def test_distributed_diffusion_streaming_merge_scale_t_two_matches_reference(self):
+        from vllm_omni.diffusion.models.ltx2.vae.distributed import (
+            DistributedLTX2VideoDiffusionDecoderModel,
+            LTX2VideoDiffusionTilePlan,
+            _LTX2VideoDiffusionStreamingMerger,
+        )
+
+        model = object.__new__(DistributedLTX2VideoDiffusionDecoderModel)
+        torch.nn.Module.__init__(model)
+        model.decoder = SimpleNamespace(out_channels=1)
+        plan = LTX2VideoDiffusionTilePlan(
+            temporal_tiles=((0, 2), (1, 3)),
+            height_tiles=((0, 2),),
+            width_tiles=((0, 2),),
+            num_frames=3,
+            height=2,
+            width=2,
+            scale_t=2,
+            scale_h=1,
+            scale_w=1,
+            stride_t=1,
+            stride_h=2,
+            stride_w=2,
+            blend_frames=2,
+            blend_height=0,
+            blend_width=0,
+            single_step_x0=True,
+        )
+        generator = torch.Generator().manual_seed(123)
+        tiles = {
+            (0, 0, 0): torch.randn((1, 1, 3, 2, 2), generator=generator),
+            (1, 0, 0): torch.randn((1, 1, 4, 2, 2), generator=generator),
+        }
+        expected = model._merge_tiled_decode({coord: tile.clone() for coord, tile in tiles.items()}, plan)
+        merger = _LTX2VideoDiffusionStreamingMerger(
+            model,
+            plan,
+            batch_size=1,
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+        )
+
+        for coord, tile in tiles.items():
+            merger.add(coord, tile.clone())
+
+        torch.testing.assert_close(merger.finish(), expected, rtol=0, atol=0)
+
+    def test_distributed_diffusion_streaming_merge_crops_short_clip_context(self):
+        from vllm_omni.diffusion.models.ltx2.vae.distributed import (
+            DistributedLTX2VideoDiffusionDecoderModel,
+            LTX2VideoDiffusionTilePlan,
+            _LTX2VideoDiffusionStreamingMerger,
+        )
+
+        model = object.__new__(DistributedLTX2VideoDiffusionDecoderModel)
+        torch.nn.Module.__init__(model)
+        model.decoder = SimpleNamespace(out_channels=3)
+        plan = LTX2VideoDiffusionTilePlan(
+            temporal_tiles=((0, 1),),
+            height_tiles=((0, 2),),
+            width_tiles=((0, 2),),
+            num_frames=1,
+            height=2,
+            width=2,
+            scale_t=2,
+            scale_h=1,
+            scale_w=1,
+            stride_t=1,
+            stride_h=2,
+            stride_w=2,
+            blend_frames=0,
+            blend_height=0,
+            blend_width=0,
+            single_step_x0=True,
+        )
+        tile = torch.randn((1, 3, 11, 2, 2), generator=torch.Generator().manual_seed(123))
+        merger = _LTX2VideoDiffusionStreamingMerger(
+            model,
+            plan,
+            batch_size=1,
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+        )
+
+        merger.add((0, 0, 0), tile)
+
+        torch.testing.assert_close(merger.finish(), tile[:, :, :1], rtol=0, atol=0)
 
 
 class TestLTXOutputRank:

--- a/vllm_omni/diffusion/models/ltx2/vae/distributed.py
+++ b/vllm_omni/diffusion/models/ltx2/vae/distributed.py
@@ -19,7 +19,6 @@ from diffusers.utils import logging
 from diffusers.utils.torch_utils import randn_tensor
 
 from vllm_omni.diffusion.distributed.autoencoders.distributed_vae_executor import (
-    DistributedOperator,
     DistributedVaeMixin,
     GridSpec,
     TileTask,
@@ -70,6 +69,7 @@ class LTX2VideoDiffusionTileTask(TileTask):
     crop_trailing_ghost: bool = False
     noise_generator: torch.Generator | list[torch.Generator] | None = None
     x_t: torch.Tensor | None = None
+    output_shape: tuple[int, int, int, int, int] | None = None
 
 
 class DistributedLTX2VideoDiffusionDecoderModel(LTX2VideoDiffusionDecoderModel, DistributedVaeMixin):
@@ -354,6 +354,7 @@ class DistributedLTX2VideoDiffusionDecoderModel(LTX2VideoDiffusionDecoderModel, 
                     crop_trailing_ghost=is_trailing,
                     noise_generator=tile_generator,
                     x_t=x_t,
+                    output_shape=tile_pixel_shape,
                 )
             )
 
@@ -402,6 +403,67 @@ class DistributedLTX2VideoDiffusionDecoderModel(LTX2VideoDiffusionDecoderModel, 
             raise TypeError(f"Expected an LTX2VideoDiffusionTilePlan, got {type(plan)!r}.")
         return self._merge_tiled_decode(tiles, plan)
 
+    @staticmethod
+    def _distributed_tile_output_shape(
+        task: LTX2VideoDiffusionTileTask,
+    ) -> tuple[int, int, int, int, int]:
+        if task.output_shape is None:
+            raise RuntimeError(f"Missing output shape for LTX DiffVAE tile {task.tile_id}.")
+        return task.output_shape
+
+    @staticmethod
+    def _balance_distributed_tile_tasks(
+        tasks: list[LTX2VideoDiffusionTileTask],
+        num_ranks: int,
+    ) -> list[list[LTX2VideoDiffusionTileTask]]:
+        workloads: list[int | float] = [0] * num_ranks
+        assigned: list[list[LTX2VideoDiffusionTileTask]] = [[] for _ in range(num_ranks)]
+        for task in sorted(tasks, key=lambda item: item.workload, reverse=True):
+            rank = workloads.index(min(workloads))
+            assigned[rank].append(task)
+            workloads[rank] += task.workload
+        return assigned
+
+    def _execute_distributed_exact_size_decode(
+        self,
+        z: torch.Tensor,
+        generator: torch.Generator | list[torch.Generator] | None,
+        num_inference_steps: int,
+    ) -> torch.Tensor:
+        """Decode local tiles and send exact-size results to rank 0."""
+        executor = self.distributed_executor
+        parallel_size = min(executor.parallel_size, executor.world_size)
+        tasks, grid_spec = self._distributed_tile_split(z, generator, num_inference_steps)
+        assigned = self._balance_distributed_tile_tasks(tasks, parallel_size)
+        local_tasks = assigned[executor.rank] if executor.rank < parallel_size else []
+        local_results = {task.tile_id: self._distributed_tile_exec(task, num_inference_steps) for task in local_tasks}
+        task_owner = {task.tile_id: owner for owner, rank_tasks in enumerate(assigned) for task in rank_tasks}
+        output_dtype = grid_spec.output_dtype if grid_spec.output_dtype is not None else z.dtype
+        tiles: dict[tuple[int, int, int], torch.Tensor] = {}
+
+        for task in sorted(tasks, key=lambda item: item.tile_id):
+            owner = task_owner[task.tile_id]
+            if executor.rank == 0:
+                if owner == 0:
+                    tile = local_results.pop(task.tile_id)
+                else:
+                    tile = torch.empty(
+                        self._distributed_tile_output_shape(task),
+                        device=z.device,
+                        dtype=output_dtype,
+                    )
+                    dist.recv(tile, src=owner, group=executor.group)
+                tiles[task.grid_coord] = tile
+            elif executor.rank == owner:
+                tile = local_results.pop(task.tile_id)
+                if not tile.is_contiguous():
+                    tile = tile.contiguous()
+                dist.send(tile, dst=0, group=executor.group)
+
+        if executor.rank == 0:
+            return self._distributed_tile_merge(tiles, grid_spec)
+        return torch.empty(0, device=z.device, dtype=output_dtype)
+
     def tiled_decode(
         self,
         z: torch.Tensor,
@@ -413,14 +475,10 @@ class DistributedLTX2VideoDiffusionDecoderModel(LTX2VideoDiffusionDecoderModel, 
 
         logger.debug("LTX-2.5 diffusion decoder running with distributed stage-4/stage-5 tiles")
         num_inference_steps = num_inference_steps or self.decoder.default_num_inference_steps
-        result = self.distributed_executor.execute(
+        result = self._execute_distributed_exact_size_decode(
             z,
-            DistributedOperator(
-                split=lambda tensor: self._distributed_tile_split(tensor, generator, num_inference_steps),
-                exec=lambda task: self._distributed_tile_exec(task, num_inference_steps),
-                merge=self._distributed_tile_merge,
-            ),
-            broadcast_result=False,
+            generator,
+            num_inference_steps,
         )
         if result.numel() == 0:
             # The base decode method crops five dimensions before the LTX

--- a/vllm_omni/diffusion/models/ltx2/vae/distributed.py
+++ b/vllm_omni/diffusion/models/ltx2/vae/distributed.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
+from itertools import product
 from typing import Any
 
 import torch
@@ -70,6 +71,159 @@ class LTX2VideoDiffusionTileTask(TileTask):
     noise_generator: torch.Generator | list[torch.Generator] | None = None
     x_t: torch.Tensor | None = None
     output_shape: tuple[int, int, int, int, int] | None = None
+
+
+class _LTX2VideoDiffusionStreamingMerger:
+    """Reference-order spatiotemporal tile blending with bounded storage."""
+
+    def __init__(
+        self,
+        model: DistributedLTX2VideoDiffusionDecoderModel,
+        plan: LTX2VideoDiffusionTilePlan,
+        *,
+        batch_size: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> None:
+        self.model = model
+        self.plan = plan
+        self.expected_coords = iter(
+            product(
+                range(len(plan.temporal_tiles)),
+                range(len(plan.height_tiles)),
+                range(len(plan.width_tiles)),
+            )
+        )
+        self.num_tiles = len(plan.temporal_tiles) * len(plan.height_tiles) * len(plan.width_tiles)
+        self.num_consumed = 0
+        self.output = torch.empty(
+            (
+                batch_size,
+                model.decoder.out_channels,
+                plan.num_frames * plan.scale_t - (1 if plan.scale_t == 2 else 0),
+                plan.height * plan.scale_h,
+                plan.width * plan.scale_w,
+            ),
+            device=device,
+            dtype=dtype,
+        )
+        self.output_frame_offset = 0
+        self.current_t = -1
+        self.current_h = -1
+        self.previous_group: torch.Tensor | None = None
+        self.current_group: torch.Tensor | None = None
+        self.previous_row: list[torch.Tensor | None] = []
+        self.current_row: list[torch.Tensor | None] = []
+
+    def _finish_current_group(self) -> None:
+        if self.current_group is None:
+            return
+
+        group = self.current_group
+        if self.current_t > 0:
+            if self.previous_group is None:
+                raise RuntimeError(f"Missing temporal tile before LTX DiffVAE tile group {self.current_t}.")
+            group = self.model.blend_t(self.previous_group, group, self.plan.blend_frames)
+
+        if self.current_t < len(self.plan.temporal_tiles) - 1:
+            keep_frames = self.plan.stride_t * self.plan.scale_t
+            if self.current_t == 0 and self.plan.scale_t == 2:
+                keep_frames -= 1
+        else:
+            keep_frames = group.shape[2]
+        keep_frames = min(keep_frames, self.output.shape[2] - self.output_frame_offset)
+        self.output[:, :, self.output_frame_offset : self.output_frame_offset + keep_frames].copy_(
+            group[:, :, :keep_frames]
+        )
+        self.output_frame_offset += keep_frames
+        self.previous_group = group
+        self.current_group = None
+
+    def _start_group(self, t_idx: int, tile: torch.Tensor) -> None:
+        self._finish_current_group()
+        self.current_t = t_idx
+        self.current_h = -1
+        self.previous_row = []
+        self.current_row = []
+        self.current_group = torch.empty(
+            (
+                tile.shape[0],
+                tile.shape[1],
+                tile.shape[2],
+                self.plan.height * self.plan.scale_h,
+                self.plan.width * self.plan.scale_w,
+            ),
+            device=tile.device,
+            dtype=tile.dtype,
+        )
+
+    def add(self, coord: tuple[int, int, int], tile: torch.Tensor) -> None:
+        expected = next(self.expected_coords)
+        if coord != expected:
+            raise ValueError(f"Expected LTX DiffVAE tile {expected}, got {coord}.")
+
+        t_idx, h_idx, w_idx = coord
+        if t_idx != self.current_t:
+            self._start_group(t_idx, tile)
+        if h_idx != self.current_h:
+            if h_idx != self.current_h + 1 or w_idx != 0:
+                raise ValueError(f"Unexpected LTX DiffVAE tile row transition at {coord}.")
+            self.previous_row = self.current_row
+            self.current_row = []
+            self.current_h = h_idx
+
+        if h_idx > 0:
+            above = self.previous_row[w_idx]
+            if above is None:
+                raise RuntimeError(f"Missing tile above LTX DiffVAE tile {coord}.")
+            overlap = self.plan.height_tiles[h_idx - 1][1] - self.plan.height_tiles[h_idx][0]
+            tile = self.model.blend_v(above, tile, overlap * self.plan.scale_h)
+            self.previous_row[w_idx] = None
+        if w_idx > 0:
+            left = self.current_row[w_idx - 1]
+            if left is None:
+                raise RuntimeError(f"Missing tile left of LTX DiffVAE tile {coord}.")
+            overlap = self.plan.width_tiles[w_idx - 1][1] - self.plan.width_tiles[w_idx][0]
+            tile = self.model.blend_h(left, tile, overlap * self.plan.scale_w)
+        self.current_row.append(tile)
+
+        keep_height = (
+            (self.plan.height_tiles[h_idx + 1][0] - self.plan.height_tiles[h_idx][0]) * self.plan.scale_h
+            if h_idx < len(self.plan.height_tiles) - 1
+            else tile.shape[3]
+        )
+        keep_width = (
+            (self.plan.width_tiles[w_idx + 1][0] - self.plan.width_tiles[w_idx][0]) * self.plan.scale_w
+            if w_idx < len(self.plan.width_tiles) - 1
+            else tile.shape[4]
+        )
+        core = tile[:, :, :, :keep_height, :keep_width]
+        h_start = self.plan.height_tiles[h_idx][0] * self.plan.scale_h
+        w_start = self.plan.width_tiles[w_idx][0] * self.plan.scale_w
+        if self.current_group is None:
+            raise RuntimeError(f"Missing output group for LTX DiffVAE tile {coord}.")
+        self.current_group[
+            :,
+            :,
+            :,
+            h_start : h_start + keep_height,
+            w_start : w_start + keep_width,
+        ].copy_(core)
+
+        self.num_consumed += 1
+
+    def finish(self) -> torch.Tensor:
+        if self.num_consumed != self.num_tiles:
+            raise RuntimeError(f"Merged {self.num_consumed} LTX DiffVAE tiles, expected {self.num_tiles}.")
+        self._finish_current_group()
+        if self.output_frame_offset != self.output.shape[2]:
+            raise RuntimeError(
+                f"Merged {self.output_frame_offset} LTX DiffVAE frames, expected {self.output.shape[2]}."
+            )
+        self.previous_group = None
+        self.previous_row = []
+        self.current_row = []
+        return self.output
 
 
 class DistributedLTX2VideoDiffusionDecoderModel(LTX2VideoDiffusionDecoderModel, DistributedVaeMixin):
@@ -411,6 +565,22 @@ class DistributedLTX2VideoDiffusionDecoderModel(LTX2VideoDiffusionDecoderModel, 
             raise RuntimeError(f"Missing output shape for LTX DiffVAE tile {task.tile_id}.")
         return task.output_shape
 
+    def _distributed_streaming_merger(
+        self,
+        grid_spec: GridSpec,
+        z: torch.Tensor,
+    ) -> _LTX2VideoDiffusionStreamingMerger:
+        plan = grid_spec.tile_spec["plan"]
+        if not isinstance(plan, LTX2VideoDiffusionTilePlan):
+            raise TypeError(f"Expected an LTX2VideoDiffusionTilePlan, got {type(plan)!r}.")
+        return _LTX2VideoDiffusionStreamingMerger(
+            self,
+            plan,
+            batch_size=z.shape[0],
+            device=z.device,
+            dtype=grid_spec.output_dtype or z.dtype,
+        )
+
     @staticmethod
     def _balance_distributed_tile_tasks(
         tasks: list[LTX2VideoDiffusionTileTask],
@@ -424,13 +594,13 @@ class DistributedLTX2VideoDiffusionDecoderModel(LTX2VideoDiffusionDecoderModel, 
             workloads[rank] += task.workload
         return assigned
 
-    def _execute_distributed_exact_size_decode(
+    def _execute_distributed_streaming_decode(
         self,
         z: torch.Tensor,
         generator: torch.Generator | list[torch.Generator] | None,
         num_inference_steps: int,
     ) -> torch.Tensor:
-        """Decode local tiles and send exact-size results to rank 0."""
+        """Decode local tiles and stream exact-size results to rank 0."""
         executor = self.distributed_executor
         parallel_size = min(executor.parallel_size, executor.world_size)
         tasks, grid_spec = self._distributed_tile_split(z, generator, num_inference_steps)
@@ -439,11 +609,13 @@ class DistributedLTX2VideoDiffusionDecoderModel(LTX2VideoDiffusionDecoderModel, 
         local_results = {task.tile_id: self._distributed_tile_exec(task, num_inference_steps) for task in local_tasks}
         task_owner = {task.tile_id: owner for owner, rank_tasks in enumerate(assigned) for task in rank_tasks}
         output_dtype = grid_spec.output_dtype if grid_spec.output_dtype is not None else z.dtype
-        tiles: dict[tuple[int, int, int], torch.Tensor] = {}
+        merger = self._distributed_streaming_merger(grid_spec, z) if executor.rank == 0 else None
 
         for task in sorted(tasks, key=lambda item: item.tile_id):
             owner = task_owner[task.tile_id]
             if executor.rank == 0:
+                if merger is None:
+                    raise RuntimeError("Missing rank-0 LTX DiffVAE streaming merger.")
                 if owner == 0:
                     tile = local_results.pop(task.tile_id)
                 else:
@@ -453,15 +625,19 @@ class DistributedLTX2VideoDiffusionDecoderModel(LTX2VideoDiffusionDecoderModel, 
                         dtype=output_dtype,
                     )
                     dist.recv(tile, src=owner, group=executor.group)
-                tiles[task.grid_coord] = tile
+                merger.add(task.grid_coord, tile)
+                del tile
             elif executor.rank == owner:
                 tile = local_results.pop(task.tile_id)
                 if not tile.is_contiguous():
                     tile = tile.contiguous()
                 dist.send(tile, dst=0, group=executor.group)
+                del tile
 
         if executor.rank == 0:
-            return self._distributed_tile_merge(tiles, grid_spec)
+            if merger is None:
+                raise RuntimeError("Missing rank-0 LTX DiffVAE streaming merger.")
+            return merger.finish()
         return torch.empty(0, device=z.device, dtype=output_dtype)
 
     def tiled_decode(
@@ -475,7 +651,7 @@ class DistributedLTX2VideoDiffusionDecoderModel(LTX2VideoDiffusionDecoderModel, 
 
         logger.debug("LTX-2.5 diffusion decoder running with distributed stage-4/stage-5 tiles")
         num_inference_steps = num_inference_steps or self.decoder.default_num_inference_steps
-        result = self._execute_distributed_exact_size_decode(
+        result = self._execute_distributed_streaming_decode(
             z,
             generator,
             num_inference_steps,


### PR DESCRIPTION
## Summary

- Replace LTX-2.5 distributed DiffVAE's padded all-gather with exact-size decoded-tile transfers to rank 0.
- Merge tiles incrementally in the same temporal/height/width order as the existing Diffusers-derived path, avoiding retention of the complete decoded-tile set.
- Keep tile geometry, workload assignment, RNG behavior, output contract, and the shared distributed VAE executor unchanged.

The existing path pads every rank to the largest local decoded-tile batch, allocates gathered copies on every rank, and reconstructs all tiles on rank 0 before blending. The new LTX-specific path retains local decoded results but transfers one exact-size tile at a time and consumes it immediately on rank 0.

## Memory and performance

A same-GPU A/B compared `main` at `063745430` with the PR production code at `3452bbefc` on four NVIDIA H200 GPUs with BF16, 121 frames at 1920 x 1088, USP 4, VAE patch parallel 4, and unchanged Diffusers tile defaults. Each ref ran one full-shape warmup followed by three measured requests on the same physical GPUs.

| Metric | `main` | This PR | Delta |
| --- | ---: | ---: | ---: |
| Final decode, hot mean | 2491.36 ms | 2473.27 ms | **-18.09 ms (-0.73%)** |
| Rank-0 allocator peak reserved | 97.109 GiB | 93.984 GiB | **-3.125 GiB** |

All warmup and measured requests completed successfully. Current head `f598d22f7` differs from the measured PR head only by an additional CPU merge-regression test; production code is unchanged.

## Correctness and tests

- Streaming merge matches the existing reference merge exactly (`rtol=0`, `atol=0`), including `scale_t=2` across multiple temporal groups and short-clip temporal cropping.

This is an exactness result, not a perceptual-similarity claim: for identical decoded tiles, the final RGB tensor is bitwise-identical to the previous path. Tile geometry, task assignment, RNG behavior, and decoder math are unchanged; the four-GPU E2E A/B above is used for memory and performance evidence.

- A four-GPU NVIDIA H200 end-to-end A/B completed at 1920 x 1088 with one warmup and three measured requests per ref.
- `57 passed`: `test_ltx2_vae.py` and `test_ltx2_ops_platform.py` at the current PR head.
- All pre-commit hooks for the changed files and `git diff --check` pass.
