### PR TITLE
[Bugfix] Route Music3 float32 attention to SDPA

### DIFF
--- a/tests/model_executor/models/test_minimax_music3_dit_attention.py
+++ b/tests/model_executor/models/test_minimax_music3_dit_attention.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Attention dtype routing for MiniMax Music 3's float32 acoustic stage."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import nn
+
+from vllm_omni.model_executor.models.minimax_music3 import dit
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class _BackendType:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def get_name(self) -> str:
+        return self.name
+
+
+class _Backend(nn.Module):
+    def __init__(self, *, name: str, explicit: bool) -> None:
+        super().__init__()
+        self.attn_backend = _BackendType(name)
+        self.backend_explicit = explicit
+        self.calls = 0
+
+    def forward(self, q, k, v):
+        del k, v
+        self.calls += 1
+        return torch.full_like(q, 7)
+
+
+def _attention(monkeypatch, *, backend_name: str, explicit: bool):
+    backend = _Backend(name=backend_name, explicit=explicit)
+    monkeypatch.setattr(dit, "_build_native_attention", lambda **_kwargs: backend)
+    return dit.Attention(8, head_dim=4), backend
+
+
+@pytest.mark.parametrize(
+    "backend_name",
+    ["FLASH_ATTN", "FLASH_ATTN_HUB", "FLASH_ATTN_3_HUB"],
+)
+def test_float32_uses_sdpa_for_automatic_flash_backend(monkeypatch, backend_name):
+    attention, backend = _attention(monkeypatch, backend_name=backend_name, explicit=False)
+    q = torch.randn(2, 5, 2, 4)
+
+    actual = attention._attend(q, q, q)
+
+    expected = torch.nn.functional.scaled_dot_product_attention(
+        q.transpose(1, 2),
+        q.transpose(1, 2),
+        q.transpose(1, 2),
+        is_causal=False,
+        scale=attention.softmax_scale,
+    ).transpose(1, 2)
+    torch.testing.assert_close(actual, expected)
+    assert backend.calls == 0
+    assert attention.backend_name == f"TORCH_SDPA(float32)/{backend_name}(lower precision)"
+
+
+@pytest.mark.parametrize(
+    ("dtype", "explicit"),
+    [
+        (torch.float16, False),
+        (torch.bfloat16, False),
+        (torch.float32, True),
+    ],
+)
+def test_lower_precision_or_explicit_flash_backend_remains_authoritative(monkeypatch, dtype, explicit):
+    attention, backend = _attention(monkeypatch, backend_name="FLASH_ATTN", explicit=explicit)
+    q = torch.zeros(1, 3, 2, 4, dtype=dtype)
+
+    actual = attention._attend(q, q, q)
+
+    assert backend.calls == 1
+    torch.testing.assert_close(actual, torch.full_like(q, 7))
+
+
+def test_float32_uses_sdpa_when_native_attention_is_unavailable(monkeypatch):
+    monkeypatch.setattr(dit, "_build_native_attention", lambda **_kwargs: None)
+    attention = dit.Attention(8, head_dim=4)
+    q = torch.randn(1, 3, 2, 4)
+
+    actual = attention._attend(q, q, q)
+
+    expected = torch.nn.functional.scaled_dot_product_attention(
+        q.transpose(1, 2),
+        q.transpose(1, 2),
+        q.transpose(1, 2),
+        is_causal=False,
+        scale=attention.softmax_scale,
+    ).transpose(1, 2)
+    torch.testing.assert_close(actual, expected)
+    assert attention.backend_name == "TORCH_SDPA"
+
+
+def test_float32_keeps_non_flash_automatic_backend(monkeypatch):
+    attention, backend = _attention(monkeypatch, backend_name="SDPA", explicit=False)
+    q = torch.zeros(1, 3, 2, 4)
+
+    actual = attention._attend(q, q, q)
+
+    assert backend.calls == 1
+    torch.testing.assert_close(actual, torch.full_like(q, 7))

--- a/tests/model_executor/models/test_minimax_music3_dit_attention.py
+++ b/tests/model_executor/models/test_minimax_music3_dit_attention.py
@@ -12,6 +12,14 @@ from vllm_omni.model_executor.models.minimax_music3 import dit
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
+_FLOAT32_INCOMPATIBLE_BACKENDS = [
+    "FLASH_ATTN",
+    "FLASH_ATTN_HUB",
+    "FLASH_ATTN_3_HUB",
+    "CUDNN_ATTN",
+    "FLASHINFER_ATTN",
+]
+
 
 class _BackendType:
     def __init__(self, name: str) -> None:
@@ -42,9 +50,9 @@ def _attention(monkeypatch, *, backend_name: str, explicit: bool):
 
 @pytest.mark.parametrize(
     "backend_name",
-    ["FLASH_ATTN", "FLASH_ATTN_HUB", "FLASH_ATTN_3_HUB"],
+    _FLOAT32_INCOMPATIBLE_BACKENDS,
 )
-def test_float32_uses_sdpa_for_automatic_flash_backend(monkeypatch, backend_name):
+def test_float32_uses_sdpa_for_automatic_incompatible_backend(monkeypatch, backend_name):
     attention, backend = _attention(monkeypatch, backend_name=backend_name, explicit=False)
     q = torch.randn(2, 5, 2, 4)
 
@@ -62,6 +70,7 @@ def test_float32_uses_sdpa_for_automatic_flash_backend(monkeypatch, backend_name
     assert attention.backend_name == f"TORCH_SDPA(float32)/{backend_name}(lower precision)"
 
 
+@pytest.mark.parametrize("backend_name", _FLOAT32_INCOMPATIBLE_BACKENDS)
 @pytest.mark.parametrize(
     ("dtype", "explicit"),
     [
@@ -70,8 +79,8 @@ def test_float32_uses_sdpa_for_automatic_flash_backend(monkeypatch, backend_name
         (torch.float32, True),
     ],
 )
-def test_lower_precision_or_explicit_flash_backend_remains_authoritative(monkeypatch, dtype, explicit):
-    attention, backend = _attention(monkeypatch, backend_name="FLASH_ATTN", explicit=explicit)
+def test_lower_precision_or_explicit_backend_remains_authoritative(monkeypatch, backend_name, dtype, explicit):
+    attention, backend = _attention(monkeypatch, backend_name=backend_name, explicit=explicit)
     q = torch.zeros(1, 3, 2, 4, dtype=dtype)
 
     actual = attention._attend(q, q, q)
@@ -98,7 +107,7 @@ def test_float32_uses_sdpa_when_native_attention_is_unavailable(monkeypatch):
     assert attention.backend_name == "TORCH_SDPA"
 
 
-def test_float32_keeps_non_flash_automatic_backend(monkeypatch):
+def test_float32_keeps_compatible_automatic_backend(monkeypatch):
     attention, backend = _attention(monkeypatch, backend_name="SDPA", explicit=False)
     q = torch.zeros(1, 3, 2, 4)
 

--- a/vllm_omni/model_executor/models/minimax_music3/dit.py
+++ b/vllm_omni/model_executor/models/minimax_music3/dit.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 """Condition encoder and flow-matching transformer for MiniMax Music 3.
 
 Stage 1 turns the AR stage's conditioning frames into a DAC latent in two
@@ -16,13 +16,12 @@ a single ``to_qkv`` so each block runs one GEMM instead of three.
 :func:`remap_transformer_state` performs that fusion, and is the only place
 the checkpoint's layout is reinterpreted.
 
-Attention runs through the project's own diffusion attention layer, so this
-model picks up the same backend selection, sequence-parallel plumbing and
-KV-quant policy as every other transformer in the tree. That layer resolves
-its backend from the diffusion config, which an ``LLM_GENERATION`` stage such
-as this one does not set; it tolerates that and falls through to the platform
-default. If it cannot be built at all the block runs plain SDPA instead, a
-choice made once when the blocks are built and never inside ``forward``.
+Attention uses the project's diffusion attention layer when its selected
+backend supports the runtime dtype. This ``LLM_GENERATION`` stage does not set
+a diffusion backend and therefore gets the platform default. CUDA commonly
+resolves that default to FlashAttention, so the model routes its native
+float32 decode through SDPA while retaining FlashAttention for supported
+lower-precision inputs. An explicitly selected backend remains authoritative.
 """
 
 from __future__ import annotations
@@ -74,6 +73,16 @@ _TRANSFORMER_IN_DIM = DIT_LATENT_CHANNELS * 2 + _CONDITION_DIM
 # The prompt interpolation floor from the reference sampler. Sigma never
 # reaches exactly zero, so the noise term never fully vanishes.
 _SIGMA_FLOOR = 1e-6
+
+# These backends reject float32 Q/K/V. MiniMax Music 3 decodes in float32, so
+# an automatically selected Flash backend must not receive its attention
+# tensors. Explicit backend choices retain the shared layer's fail-fast
+# contract instead of being silently replaced here.
+_FLOAT32_UNSUPPORTED_BACKENDS = {
+    "FLASH_ATTN",
+    "FLASH_ATTN_HUB",
+    "FLASH_ATTN_3_HUB",
+}
 
 
 class FourierFeatures(nn.Module):
@@ -149,10 +158,7 @@ def _build_native_attention(*, num_heads: int, head_size: int, softmax_scale: fl
     except Exception as exc:  # noqa: BLE001 - any failure means: use SDPA
         _NATIVE_ATTENTION_UNAVAILABLE = repr(exc)
         logger.warning(
-            "MiniMax Music 3 DiT could not build the diffusion attention layer "
-            "(%s); running torch SDPA instead. The stage decodes in float32, "
-            "for which the diffusion layer dispatches to SDPA anyway, so this "
-            "changes performance bookkeeping and not the audio.",
+            "MiniMax Music 3 DiT could not build the diffusion attention layer (%s); running torch SDPA instead.",
             exc,
         )
         return None
@@ -180,10 +186,19 @@ class Attention(nn.Module):
             softmax_scale=self.softmax_scale,
             prefix=prefix,
         )
-        self.backend_name = self.backend.attn_backend.get_name() if self.backend is not None else "TORCH_SDPA"
+        native_backend_name = self.backend.attn_backend.get_name() if self.backend is not None else None
+        self._auto_float32_sdpa = (
+            self.backend is not None
+            and not getattr(self.backend, "backend_explicit", False)
+            and native_backend_name in _FLOAT32_UNSUPPORTED_BACKENDS
+        )
+        if self._auto_float32_sdpa:
+            self.backend_name = f"TORCH_SDPA(float32)/{native_backend_name}(lower precision)"
+        else:
+            self.backend_name = native_backend_name or "TORCH_SDPA"
 
     def _attend(self, q: Tensor, k: Tensor, v: Tensor) -> Tensor:
-        if self.backend is not None:
+        if self.backend is not None and not (q.dtype == torch.float32 and self._auto_float32_sdpa):
             return self.backend(q, k, v)
         q, k, v = (t.transpose(1, 2) for t in (q, k, v))
         out = F.scaled_dot_product_attention(q, k, v, is_causal=False, scale=self.softmax_scale)

--- a/vllm_omni/model_executor/models/minimax_music3/dit.py
+++ b/vllm_omni/model_executor/models/minimax_music3/dit.py
@@ -19,9 +19,10 @@ the checkpoint's layout is reinterpreted.
 Attention uses the project's diffusion attention layer when its selected
 backend supports the runtime dtype. This ``LLM_GENERATION`` stage does not set
 a diffusion backend and therefore gets the platform default. CUDA commonly
-resolves that default to FlashAttention, so the model routes its native
-float32 decode through SDPA while retaining FlashAttention for supported
-lower-precision inputs. An explicitly selected backend remains authoritative.
+resolves that default to FlashAttention, cuDNN, or FlashInfer, so the model
+routes its native float32 decode through SDPA while retaining the selected
+backend for supported lower-precision inputs. An explicitly selected backend
+remains authoritative.
 """
 
 from __future__ import annotations
@@ -75,13 +76,16 @@ _TRANSFORMER_IN_DIM = DIT_LATENT_CHANNELS * 2 + _CONDITION_DIM
 _SIGMA_FLOOR = 1e-6
 
 # These backends reject float32 Q/K/V. MiniMax Music 3 decodes in float32, so
-# an automatically selected Flash backend must not receive its attention
-# tensors. Explicit backend choices retain the shared layer's fail-fast
-# contract instead of being silently replaced here.
+# automatically selected incompatible backends must not receive its attention
+# tensors. This includes cuDNN and FlashInfer selected on Blackwell. Explicit
+# backend choices retain the shared layer's fail-fast contract instead of
+# being silently replaced here.
 _FLOAT32_UNSUPPORTED_BACKENDS = {
     "FLASH_ATTN",
     "FLASH_ATTN_HUB",
     "FLASH_ATTN_3_HUB",
+    "CUDNN_ATTN",
+    "FLASHINFER_ATTN",
 }
 
 


### PR DESCRIPTION
## Purpose

Fixes #7238.

MiniMax Music 3 loads its acoustic DiT and conditioning inputs in float32. On the affected CUDA setup, the shared diffusion attention layer automatically selects FlashAttention, which rejects those Q/K/V tensors with `FlashAttention only supports fp16, bf16, and fp8_e4m3 data type`. Music generation therefore fails in the first DiT attention block.

Route float32 attention through torch SDPA when a float32-incompatible backend was selected automatically: FlashAttention, cuDNN, or FlashInfer. This also covers Blackwell, where the CUDA selector prefers cuDNN and can fall back to FlashInfer for Music3's 64-wide heads. Preserve the selected native backend for lower-precision inputs and honor explicit backend selections. Report both runtime routes in the backend description. This change preserves the model's existing precision policy and does not change shared attention dispatch.

## Test Plan

**vLLM Version:** 0.28.0; PyTorch 2.13.0+cu132.

**vLLM-Omni Commit:** baseline `35a83a08850f4184e683a82201156038be5ae725`; fix `62acc0505f36f2a8faa4504d1c24779361d844f8` (includes the Blackwell follow-up to `89780c84`).

**Hardware:** NVIDIA H20-3e for real-backend verification.

Minimal attention-boundary reproduction, with CUDA and the automatic FlashAttention backend available (no model checkpoint required):

```bash
python - <<'PY'
import torch
from vllm_omni.model_executor.models.minimax_music3.dit import Attention

attention = Attention(64, head_dim=64).to(device="cuda", dtype=torch.float32)
q = torch.randn(2, 17, 1, 64, device="cuda", dtype=torch.float32)
print(attention.backend_name)
with torch.inference_mode():
    actual = attention._attend(q, q, q)
    expected = torch.nn.functional.scaled_dot_product_attention(
        q.transpose(1, 2), q.transpose(1, 2), q.transpose(1, 2),
        is_causal=False, scale=attention.softmax_scale,
    ).transpose(1, 2)
    torch.testing.assert_close(actual, expected)
print(actual.shape, actual.dtype)
PY
```

CPU regression and model tests:

```bash
python -m pytest -q \
  tests/model_executor/models/test_minimax_music3_dit_attention.py \
  tests/model_executor/models/test_minimax_music3_batch_payload.py \
  tests/model_executor/models/test_minimax_music3_frame_state.py \
  tests/model_executor/models/test_minimax_music3_prompt.py \
  tests/model_executor/models/test_minimax_music3_repo_root.py \
  tests/model_executor/models/test_minimax_music3_row_binding.py
```

## Test Result

- Reproduced the original float32 error with the actual automatic `FLASH_ATTN` backend on H20-3e.
- Verified the fixed float32 result against torch SDPA and exercised the actual BF16 FA3 path on the same GPU; BF16 output was finite.
- All MiniMax Music 3 CPU model tests: **112 passed**, including **22** attention-routing regressions covering the three Flash-family names, cuDNN, FlashInfer, lower-precision routing, explicit selection, non-Flash selection, and unavailable native attention.
- Full pre-commit passed every applicable hook. Ruff check, Ruff format-check, and `git diff --check` passed.
- The expanded CPU routing tests failed on the previous PR head for exactly the automatic cuDNN and FlashInfer FP32 cases (2 failed, 20 passed). These tests use backend stubs; no Blackwell hardware validation was performed.
- Full Music3 checkpoint/server E2E and end-to-end audio-quality/performance comparisons were **not run**. GPU verification targets the attention boundary from the reported traceback. The installed FA3 build rejected FP16; BF16 was used to verify the native lower-precision route.

AI assistance: Codex assisted with the implementation, regression tests, validation, static review, and PR description.
