### PR TITLE
[Bench] Add diffusion CLI args and backend wiring

### DIFF
--- a/vllm_omni/entrypoints/cli/benchmark/cli_args.py
+++ b/vllm_omni/entrypoints/cli/benchmark/cli_args.py
@@ -94,6 +94,39 @@ def add_multi_stage_cli_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
+_DIFFUSION_ENDPOINTS = frozenset({
+    "/v1/images/generations",
+    "/v1/images/edits",
+    "/v1/videos",
+})
+
+_DIFFUSION_BACKENDS = frozenset({
+    "openai-image-gen-omni",
+    "openai-image-edits-omni",
+    "openai-video-omni",
+})
+
+_DIFFUSION_TASK_TO_ENDPOINT = {
+    "t2i": "/v1/images/generations",
+    "i2i": "/v1/images/edits",
+    "t2v": "/v1/videos",
+    "i2v": "/v1/videos",
+}
+
+_ENDPOINT_TO_BACKEND = {
+    "/v1/images/generations": "openai-image-gen-omni",
+    "/v1/images/edits": "openai-image-edits-omni",
+    "/v1/videos": "openai-video-omni",
+}
+
+
+def is_diffusion_benchmark(args) -> bool:
+    """Return True when the benchmark targets a diffusion/image/video endpoint."""
+    endpoint = getattr(args, "endpoint", None) or ""
+    backend = getattr(args, "backend", None) or ""
+    return endpoint in _DIFFUSION_ENDPOINTS or backend in _DIFFUSION_BACKENDS
+
+
 def add_diffusion_cli_args(parser: argparse.ArgumentParser) -> None:
     """Add CLI arguments for diffusion model benchmarks."""
     group = parser.add_argument_group("Diffusion Models Options")
@@ -107,6 +140,64 @@ def add_diffusion_cli_args(parser: argparse.ArgumentParser) -> None:
             "(/v1/images/edits). "
             'Use --extra-body \'{"bot_task":"..."}\' to override per run.'
         ),
+    )
+    group.add_argument(
+        "--diffusion-dataset",
+        type=str,
+        choices=["random", "vbench", "custom"],
+        default="random",
+        help="Prompt source for diffusion benchmarks. "
+        "'random' generates synthetic prompts (default), "
+        "'vbench' downloads VBench prompts, "
+        "'custom' reads from --dataset-path JSONL.",
+    )
+    group.add_argument(
+        "--diffusion-task",
+        type=str,
+        choices=["t2i", "i2i", "t2v", "i2v"],
+        default=None,
+        help="Diffusion task type. Auto-maps to the appropriate endpoint: "
+        "t2i -> /v1/images/generations, i2i -> /v1/images/edits, "
+        "t2v/i2v -> /v1/videos. Overridden by explicit --endpoint.",
+    )
+    group.add_argument(
+        "--width",
+        type=int,
+        default=1024,
+        help="Output image/video width for diffusion generation (default: 1024).",
+    )
+    group.add_argument(
+        "--height",
+        type=int,
+        default=1024,
+        help="Output image/video height for diffusion generation (default: 1024).",
+    )
+    group.add_argument(
+        "--num-inference-steps",
+        type=int,
+        default=20,
+        help="Number of denoising steps for diffusion generation (default: 20).",
+    )
+    group.add_argument(
+        "--num-frames",
+        type=int,
+        default=None,
+        help="Number of video frames for video generation. "
+        "None for image generation (default: None).",
+    )
+    group.add_argument(
+        "--fps",
+        type=int,
+        default=None,
+        help="Video frames per second (default: None).",
+    )
+    group.add_argument(
+        "--random-request-config",
+        type=str,
+        default=None,
+        help="JSON array of weighted resolution profiles for random diffusion "
+        "prompts. Each entry: "
+        '{"width":W, "height":H, "num_inference_steps":S, "weight":P}.',
     )
 
 
@@ -271,7 +362,12 @@ def extend_omni_choices(parser: argparse.ArgumentParser) -> None:
                 if extra:
                     action.choices = list(action.choices) + extra
             if action.dest == "backend" and action.choices is not None:
-                extra = [choice for choice in ("openai-image-edits-omni",) if choice not in action.choices]
+                omni_backends = (
+                    "openai-image-edits-omni",
+                    "openai-image-gen-omni",
+                    "openai-video-omni",
+                )
+                extra = [choice for choice in omni_backends if choice not in action.choices]
                 if extra:
                     action.choices = list(action.choices) + extra
 
@@ -326,8 +422,27 @@ def add_omni_args(parser: argparse.ArgumentParser) -> None:
     add_diffusion_cli_args(parser)
 
 
+def _preprocess_diffusion_args(args: argparse.Namespace) -> None:
+    """Auto-map diffusion task to endpoint/backend when not explicitly set."""
+    task = getattr(args, "diffusion_task", None)
+    if task is None and not is_diffusion_benchmark(args):
+        return
+
+    endpoint = getattr(args, "endpoint", None)
+    backend = getattr(args, "backend", None)
+
+    if task and not endpoint:
+        args.endpoint = _DIFFUSION_TASK_TO_ENDPOINT[task]
+        endpoint = args.endpoint
+
+    if endpoint and endpoint in _ENDPOINT_TO_BACKEND and not backend:
+        args.backend = _ENDPOINT_TO_BACKEND[endpoint]
+
+
 def preprocess_serve_args(args: argparse.Namespace) -> None:
     """Apply serving benchmark CLI transformations after parsing."""
+    _preprocess_diffusion_args(args)
+
     if getattr(args, "dataset_name", None) == "omniinteract":
         if getattr(args, "backend", None) != "openai-realtime-duplex":
             raise ValueError("OmniInteract requires --backend openai-realtime-duplex")

--- a/vllm_omni/entrypoints/cli/benchmark/serve.py
+++ b/vllm_omni/entrypoints/cli/benchmark/serve.py
@@ -27,7 +27,7 @@ class OmniBenchmarkServingSubcommand(OmniBenchmarkSubcommandBase):
     """The `serve` subcommand for vllm bench."""
 
     name = "serve"
-    help = "Benchmark online serving. Supports Daily-Omni, OmniInteract, and Seed-TTS datasets."
+    help = "Benchmark online serving. Supports Daily-Omni, OmniInteract, Seed-TTS, and Diffusion datasets."
 
     @classmethod
     def add_cli_args(cls, parser: argparse.ArgumentParser) -> None:


### PR DESCRIPTION
## Summary
- Add 7 new CLI args for diffusion benchmarks: `--diffusion-dataset`, `--diffusion-task`, `--width`, `--height`, `--num-inference-steps`, `--num-frames`, `--fps`, `--random-request-config`
- Add `--diffusion-task` auto-mapping (t2i/i2i/t2v/i2v) to endpoint and backend
- Register `openai-image-gen-omni` and `openai-video-omni` as valid backend choices
- Update help text to include Diffusion datasets
- Part of Issue #6873, depends on PR #7068 and PR #7310

## Test plan
- [ ] `vllm bench serve --omni --help` shows all new diffusion args
- [ ] `--diffusion-task t2i` auto-maps to `/v1/images/generations` endpoint and `openai-image-gen-omni` backend
- [ ] `--diffusion-task t2v` auto-maps to `/v1/videos` endpoint and `openai-video-omni` backend
- [ ] Explicit `--endpoint` overrides `--diffusion-task` mapping
- [ ] Non-diffusion benchmark args unaffected