### PR TITLE
[NPU][CosyVoice3] Add A5 STFT fallback

### DIFF
--- a/docs/getting_started/installation/npu.md
+++ b/docs/getting_started/installation/npu.md
@@ -31,3 +31,17 @@ vLLM-Omni supports NPU through the vLLM Ascend Plugin (vllm-ascend). This is a c
 === "NPU from main"
 
     --8<-- "docs/getting_started/installation/npu/npu.inc.md:installation-main"
+
+## CosyVoice3 on Ascend 950 (A5)
+
+The A5 platform setup enables CPU STFT and ISTFT for the CosyVoice3 HiFiGAN
+vocoder because native STFT is unavailable on this platform. Both transforms,
+including complex-spectrum construction, run in float32 on CPU; their real
+outputs return to the caller's device and dtype. Other platforms keep the
+native transform path.
+
+This fallback introduces CPU/device transfers and is a correctness workaround,
+not a throughput optimization. End-to-end latency and CER must be measured on
+the exact hardware and software stack used for deployment. Use a matching
+vLLM/vLLM-Ascend/vLLM-Omni installation; this change does not make older runner
+interfaces compatible with current main.

--- a/tests/platforms/npu/test_cosyvoice3_stft.py
+++ b/tests/platforms/npu/test_cosyvoice3_stft.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""CPU contract tests for the A5 fallback; no NPU kernels are simulated.
+
+Import unrelated activation dependencies as stubs, then exercise the real
+HiFTGenerator spectral methods with real torch CPU transforms.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import torch
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def load_module(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hifigan(monkeypatch):
+    snake = ModuleType("vllm_omni.model_executor.models.common.snake_activation")
+    setattr(snake, "Snake", torch.nn.Identity)
+    monkeypatch.setitem(sys.modules, snake.__name__, snake)
+    return load_module(
+        "cosyvoice3_hifigan_under_test",
+        ROOT / "vllm_omni/model_executor/models/cosyvoice3/code2wav_core/hifigan.py",
+    )
+
+
+@pytest.fixture(params=["HiFTGenerator", "CausalHiFTGenerator"])
+def generator(hifigan, request):
+    # Only the spectral methods are under test; no model weights are needed.
+    cls = getattr(hifigan, request.param)
+    module = cls.__new__(cls)
+    torch.nn.Module.__init__(module)
+    module.istft_params = {"n_fft": 16, "hop_len": 4}
+    module.register_buffer("stft_window", torch.hann_window(16), persistent=False)
+    return module
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_cpu_fallback_matches_float32_reference(generator, dtype):
+    generator._stft_on_cpu = True
+    generator.stft_window = generator.stft_window.to(dtype)
+    waveform = torch.linspace(-0.4, 0.4, 128).unsqueeze(0).to(dtype)
+    window = generator.stft_window.float()
+    expected_spec = torch.stft(waveform.float(), 16, 4, 16, window=window, return_complex=True)
+    real, imag = generator._stft(waveform)
+    torch.testing.assert_close(real, expected_spec.real.to(dtype))
+    torch.testing.assert_close(imag, expected_spec.imag.to(dtype))
+    magnitude = expected_spec.abs().to(dtype)
+    phase = expected_spec.angle().to(dtype)
+    # Cast before complex construction; complex BF16 is not supported by torch.
+    spectrum = torch.complex(magnitude.float() * phase.float().cos(), magnitude.float() * phase.float().sin())
+    expected_audio = torch.istft(spectrum, 16, 4, 16, window=window).to(dtype)
+    actual_audio = generator._istft(magnitude, phase)
+    torch.testing.assert_close(actual_audio, expected_audio)
+    assert actual_audio.device == waveform.device
+    assert actual_audio.dtype == dtype
+    assert generator.stft_window.dtype == dtype
+
+
+def test_native_path_retains_float64_precision(generator):
+    assert generator._stft_on_cpu is False
+    waveform = torch.linspace(-0.4, 0.4, 128, dtype=torch.float64).unsqueeze(0)
+    spec = torch.stft(waveform, 16, 4, 16, window=generator.stft_window, return_complex=True)
+    real, imag = generator._stft(waveform)
+    torch.testing.assert_close(real, spec.real)
+    torch.testing.assert_close(imag, spec.imag)
+    torch.testing.assert_close(generator._istft(spec.abs(), spec.angle()), waveform)
+
+
+@pytest.mark.parametrize("a5", [False, True])
+def test_platform_patch_is_a5_only_and_idempotent(monkeypatch, hifigan, a5):
+    npu = ModuleType("vllm_omni.platforms.npu")
+    setattr(npu, "is_a5", lambda: a5)
+    monkeypatch.setitem(sys.modules, npu.__name__, npu)
+    monkeypatch.setitem(sys.modules, "vllm_omni.model_executor.models.cosyvoice3.code2wav_core.hifigan", hifigan)
+    patch = load_module("cosyvoice3_a5_patch", ROOT / "vllm_omni/platforms/npu/models/cosyvoice3.py")
+    patch.apply_cosyvoice3_patches()
+    patch.apply_cosyvoice3_patches()
+    assert hifigan.HiFTGenerator._stft_on_cpu is a5
+    assert hifigan.CausalHiFTGenerator._stft_on_cpu is a5

--- a/vllm_omni/model_executor/models/cosyvoice3/code2wav_core/hifigan.py
+++ b/vllm_omni/model_executor/models/cosyvoice3/code2wav_core/hifigan.py
@@ -380,6 +380,9 @@ class HiFTGenerator(nn.Module):
     https://arxiv.org/abs/2309.09493
     """
 
+    # Enabled by platform setup when native complex STFT/ISTFT is unavailable.
+    _stft_on_cpu = False
+
     def __init__(
         self,
         in_channels: int = 80,
@@ -489,6 +492,9 @@ class HiFTGenerator(nn.Module):
             block.remove_weight_norm()
 
     def _stft(self, x):
+        target_device, target_dtype = x.device, x.dtype
+        if self._stft_on_cpu:
+            x = x.to(device="cpu", dtype=torch.float32)
         spec = torch.stft(
             x,
             self.istft_params["n_fft"],
@@ -498,9 +504,17 @@ class HiFTGenerator(nn.Module):
             return_complex=True,
         )
         spec = torch.view_as_real(spec)  # [B, F, TT, 2]
+        if self._stft_on_cpu:
+            spec = spec.to(device=target_device, dtype=target_dtype)
         return spec[..., 0], spec[..., 1]
 
     def _istft(self, magnitude, phase):
+        target_device, target_dtype = magnitude.device, magnitude.dtype
+        if self._stft_on_cpu:
+            # Build the complex spectrum on CPU too: NPU complex operations
+            # are not required by the fallback path.
+            magnitude = magnitude.to(device="cpu", dtype=torch.float32)
+            phase = phase.to(device="cpu", dtype=torch.float32)
         magnitude = torch.clip(magnitude, max=1e2)
         real = magnitude * torch.cos(phase)
         img = magnitude * torch.sin(phase)
@@ -511,9 +525,13 @@ class HiFTGenerator(nn.Module):
             self.istft_params["n_fft"],
             window=self._get_stft_window(magnitude),
         )
+        if self._stft_on_cpu:
+            inverse_transform = inverse_transform.to(device=target_device, dtype=target_dtype)
         return inverse_transform
 
     def _get_stft_window(self, tensor: torch.Tensor) -> torch.Tensor:
+        if self._stft_on_cpu:
+            return self.stft_window.to(device="cpu", dtype=torch.float32)
         if self.stft_window.device != tensor.device:
             self.stft_window = self.stft_window.to(tensor.device)
         return self.stft_window

--- a/vllm_omni/platforms/npu/models/cosyvoice3.py
+++ b/vllm_omni/platforms/npu/models/cosyvoice3.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""CosyVoice3 spectral transforms on Ascend 950 (A5)."""
+
+from vllm_omni.platforms.npu import is_a5
+
+
+def apply_cosyvoice3_patches() -> None:
+    """Use CPU STFT/ISTFT only on the A5 platform, which lacks native STFT."""
+    if not is_a5():
+        return
+
+    from vllm_omni.model_executor.models.cosyvoice3.code2wav_core.hifigan import HiFTGenerator
+
+    # CausalHiFTGenerator inherits both spectral transforms and this flag.
+    HiFTGenerator._stft_on_cpu = True

--- a/vllm_omni/platforms/npu/platform.py
+++ b/vllm_omni/platforms/npu/platform.py
@@ -59,6 +59,7 @@ class NPUOmniPlatform(OmniPlatform, NPUPlatform):
         from vllm_ascend.utils import adapt_patch
 
         from vllm_omni.platforms.npu._310p import apply_patches as apply_310p_patches
+        from vllm_omni.platforms.npu.models.cosyvoice3 import apply_cosyvoice3_patches
         from vllm_omni.platforms.npu.models.minicpmo_4_5_code2wav import (
             apply_minicpmo_4_5_code2wav_patch,
         )
@@ -70,6 +71,7 @@ class NPUOmniPlatform(OmniPlatform, NPUPlatform):
         )
 
         adapt_patch(is_global_patch=True)
+        apply_cosyvoice3_patches()
         apply_minicpmo_4_5_code2wav_patch()
         apply_qwen3_tts_patches()
         apply_qwen3_tts_tokenizer_v2_patch()


### PR DESCRIPTION
## Motivation

CosyVoice3 code2wav invokes `torch.stft` and `torch.istft` in the HiFiGAN vocoder. On Ascend 950PR (A5), native STFT is unsupported, so synthesis fails before a waveform is produced.

## Modification

- Add an A5-only CPU float32 fallback for CosyVoice3 HiFiGAN STFT/ISTFT and complex-spectrum construction.
- Move real-valued outputs back to the caller's original device and dtype.
- Keep the native transform path unchanged on non-A5 platforms.
- Register the patch through the NPU platform setup.
- Add CPU contract tests and a concise NPU documentation note.

## Self-test

- `python -m ruff check vllm_omni/model_executor/models/cosyvoice3/code2wav_core/hifigan.py vllm_omni/platforms/npu/platform.py vllm_omni/platforms/npu/models/cosyvoice3.py tests/platforms/npu/test_cosyvoice3_stft.py`
- `python -m pytest --noconftest -o addopts= tests/platforms/npu/test_cosyvoice3_stft.py -q`
  - Result: `8 passed`

The test verifies A5-only activation, CPU float32 transform behavior, BF16 output restoration, and an unchanged native CPU path. Real Ascend 950PR end-to-end validation remains required.

## BC-breaking

No public API or configuration change. On A5 only, this replaces an unsupported native STFT/ISTFT call with a CPU correctness fallback; it may increase latency.

## Checklist

- [x] Scope is limited to the A5 STFT fallback.
- [x] Focused Ruff and CPU tests pass.
- [x] Commit includes DCO sign-off.
- [ ] Upstream CI, CLA, and real A5 validation are pending.

## AI assistance

This PR was prepared with Codex assistance and reviewed by the contributor before submission.