### PR TITLE
[Test] Use public render_jinja_template in MiniCPM-o native template test

### DIFF
--- a/tests/model_executor/models/minicpmo_4_5/test_chat_template.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_chat_template.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 from jinja2 import TemplateError
-from transformers.utils.chat_template_utils import _compile_jinja_template
+from transformers.utils.chat_template_utils import render_jinja_template
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -26,12 +26,15 @@ TEMPLATE = Path(__file__).resolve().parents[4] / "vllm_omni/transformers_utils/c
     ],
 )
 def test_native_content_concatenation(parts, expected):
-    rendered = _compile_jinja_template(TEMPLATE.read_text()).render(
-        messages=[{"role": "user", "content": parts}],
+    # render_jinja_template takes a batch of conversations and returns
+    # (rendered_conversations, continuation_chunks), so [0][0] is the string.
+    rendered = render_jinja_template(
+        [[{"role": "user", "content": parts}]],
+        chat_template=TEMPLATE.read_text(),
         add_generation_prompt=True,
         enable_thinking=False,
         use_tts_template=True,
-    )
+    )[0][0]
     assert rendered == (
         f"<|im_start|>user\n{expected}<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n<|tts_bos|>"
     )
@@ -39,7 +42,8 @@ def test_native_content_concatenation(parts, expected):
 
 def test_unsupported_part_is_not_silently_discarded():
     with pytest.raises(TemplateError, match="Unsupported MiniCPM-o content part"):
-        _compile_jinja_template(TEMPLATE.read_text()).render(
-            messages=[{"role": "user", "content": [{"type": "unknown"}]}],
+        render_jinja_template(
+            [[{"role": "user", "content": [{"type": "unknown"}]}]],
+            chat_template=TEMPLATE.read_text(),
             add_generation_prompt=True,
         )


### PR DESCRIPTION
[Test] Use public render_jinja_template in MiniCPM-o native template test

## Purpose

Follow-up to #7344 (now merged) per its review thread: the new CPU test imports the private `transformers.utils.chat_template_utils._compile_jinja_template`, which can move in a future transformers release and break the test. `chat_template_utils` exposes a public `render_jinja_template` (compile + render in one call) — use that instead.

## Change

In `tests/model_executor/models/minicpmo_4_5/test_chat_template.py`:
- `_compile_jinja_template(TEMPLATE.read_text()).render(messages=[...], ...)` → `render_jinja_template([[...]], chat_template=TEMPLATE.read_text(), ...)`
- `conversations` takes a batch and the return is `(rendered_conversations, continuation_chunks)`, so the string is extracted with `[0][0]` (noted in a comment).

No expected-output changes: the rendered strings are byte-identical.

## Test Plan

- [x] `pytest tests/model_executor/models/minicpmo_4_5/test_chat_template.py` — 8/8 pass on transformers 5.14.1, including the `TemplateError` expectation
- [x] ruff check + format clean
