### PR TITLE
[Bugfix] Defer strategy device check until CLI stage overrides are merged

### DIFF
--- a/tests/config/composable_parallel/test_apply.py
+++ b/tests/config/composable_parallel/test_apply.py
@@ -152,3 +152,12 @@ def test_conflicting_lb_policy_across_roles():
                 "code2wav": [_stage_replica(2, "least_queue")],
             },
         )
+
+
+def test_apply_skips_device_guard_when_deferred():
+    # With validate_devices=False the eager pre-CLI device check is skipped;
+    # the caller (config factory) re-checks against post-CLI overrides.
+    stages = _qwen_stages()
+    stages[0].yaml_runtime["devices"] = "0"
+    apply_strategy_specs(stages, {"thinker": [_tp(2)]}, validate_devices=False)
+    assert stages[0].yaml_engine_args["tensor_parallel_size"] == 2

--- a/tests/config/composable_parallel/test_factory_integration.py
+++ b/tests/config/composable_parallel/test_factory_integration.py
@@ -137,3 +137,34 @@ def test_cli_overrides_strategy_with_warning():
     assert _resolved(stages, "talker").runtime.num_replicas == 3
     # ...and the override was warned about, naming the conflicting field.
     assert any("num_replicas" in m and "overrides the strategy-derived" in m for m in messages)
+
+
+def test_stage_override_devices_satisfy_strategy_post_cli():
+    """Documented flow: default deploy + strategy + --stage-overrides devices.
+
+    The device guard must judge the post-CLI layout (deferred to the
+    reconciliation pass), not the deploy defaults -- otherwise the
+    documented usage in strategy_tp2.yaml / the example README can never
+    resolve.
+    """
+    resolution = StageConfigFactory._resolve_legacy_from_registry(
+        OMNI_PIPELINES["qwen2_5_omni"],
+        {"stage_0_devices": "2,3"},
+        str(_DEPLOY),
+        strategy_specs={"thinker": [_tp(2)]},
+    )
+    thinker = next(s for s in resolution.stage_configs if s.model_stage == "thinker")
+    assert thinker.yaml_engine_args["tensor_parallel_size"] == 2
+    assert thinker.runtime_overrides["devices"] == "2,3"
+
+
+def test_missing_stage_override_devices_still_rejected_post_cli():
+    # The guard itself must not disappear: TP=2 with only the default
+    # single-GPU deploy and no CLI devices still fails, just later (post-CLI).
+    with pytest.raises(StrategyApplyError):
+        StageConfigFactory._resolve_legacy_from_registry(
+            OMNI_PIPELINES["qwen2_5_omni"],
+            {},
+            str(_DEPLOY),
+            strategy_specs={"thinker": [_tp(2)]},
+        )

--- a/vllm_omni/config/composable_parallel/apply.py
+++ b/vllm_omni/config/composable_parallel/apply.py
@@ -197,7 +197,9 @@ def _check_devices(runtime: dict[str, Any], cfg: OmniParallelConfig, *, role: Ro
     )
 
 
-def _apply_to_stage(stage: Any, cfg: OmniParallelConfig, *, role: RoleKey) -> None:
+def _apply_to_stage(
+    stage: Any, cfg: OmniParallelConfig, *, role: RoleKey, validate_devices: bool = True
+) -> None:
     engine_args = stage.yaml_engine_args
     runtime = stage.yaml_runtime
 
@@ -210,12 +212,15 @@ def _apply_to_stage(stage: Any, cfg: OmniParallelConfig, *, role: RoleKey) -> No
     if "stage_replica" in declared:
         _set_num_replicas(runtime, cfg.stage_replica_size, role=role)
 
-    _check_devices(runtime, cfg, role=role)
+    if validate_devices:
+        _check_devices(runtime, cfg, role=role)
 
 
 def apply_strategy_specs(
     stages: list[Any],
     strategy_specs: Mapping[RoleKey, Sequence[StrategySpec]],
+    *,
+    validate_devices: bool = True,
 ) -> StrategyApplyResult:
     """Overlay per-role strategy specs onto a merged stage list.
 
@@ -224,6 +229,10 @@ def apply_strategy_specs(
         strategy_specs: maps a role (a ``model_stage`` name, e.g. ``"thinker"``)
             to that stage's stack of ``StrategySpec`` (one per declared mesh
             axis). Role keys are ``model_stage`` names (str).
+        validate_devices: run the pre-spawn device-count check against the
+            deploy-time (pre-CLI-override) ``devices``. Leave on for direct
+            callers; pass ``False`` when per-stage CLI overrides are merged
+            after this overlay and the caller re-checks devices post-merge.
 
     Returns:
         A :class:`StrategyApplyResult` with the mutated stages and the derived
@@ -232,8 +241,9 @@ def apply_strategy_specs(
     Raises:
         StrategyApplyError: a role matched zero or multiple stages, a derived
             value conflicts with an explicit deploy value (including two roles
-            deriving different ``omni_lb_policy`` values), or a stage's device
-            count is inconsistent with its world size.
+            deriving different ``omni_lb_policy`` values), or -- when
+            ``validate_devices=True`` -- a stage's device count is inconsistent
+            with its world size.
         AxisTranslationError: the spec stack is invalid/unsupported.
         NotImplementedError: the spec stack requests routing not built yet.
     """
@@ -244,7 +254,7 @@ def apply_strategy_specs(
     for key, specs in strategy_specs.items():
         stage = _resolve_stage(stages, key)
         cfg = translate_strategy_stack(specs)
-        _apply_to_stage(stage, cfg, role=key)
+        _apply_to_stage(stage, cfg, role=key, validate_devices=validate_devices)
         result.per_role_config[key] = cfg
         stage_id = getattr(stage, "stage_id", None)
         if stage_id is not None:

--- a/vllm_omni/config/config_factory.py
+++ b/vllm_omni/config/config_factory.py
@@ -532,7 +532,12 @@ class StageConfigFactory:
             return None
         from vllm_omni.config.composable_parallel import apply_strategy_specs
 
-        applied = apply_strategy_specs(stages, strategy_specs)
+        # Defer the pre-spawn device check to _reconcile_strategy_with_cli:
+        # per-stage CLI overrides (--stage-overrides) are merged only after
+        # this overlay, so validating here would reject the documented flow
+        # of supplying devices via --stage-overrides on the default deploy.
+        # Reconciliation re-checks with the effective post-CLI values.
+        applied = apply_strategy_specs(stages, strategy_specs, validate_devices=False)
         if applied.omni_lb_policy is not None:
             logger.info(
                 "[composable_parallel] strategy derived omni_lb_policy=%r; it will be applied "


### PR DESCRIPTION
## What

`apply_strategy_specs` gains a `validate_devices: bool = True` keyword. The config factory passes `validate_devices=False` so the pre-spawn device-count check for strategy-overlaid stages runs in `_reconcile_strategy_with_cli` against the *effective post-CLI* values instead of the deploy-time snapshot.

## Why

Fixes #7367. The documented composable-parallel flow -- bundled default deploy config + strategy yaml + device layout supplied via `--stage-overrides` (`strategy_tp2.yaml` usage comment and the example README) -- could never resolve: `_apply_to_stage` validated `stage.yaml_runtime.devices` before per-stage CLI overrides were merged, so the check always saw the 1-GPU default and raised:

```
StrategyApplyError: role 'thinker': declared 1 device id(s) but the strategy world size is 2 (tp=2 * dp=1 * pp=1)
```

`_reconcile_strategy_with_cli` already re-runs `check_device_layout` on the post-CLI values (its docstring documents exactly that: "re-run the device-count check against the *effective* (post-CLI) tp/dp/pp/num_replicas/devices"), but the eager check made it unreachable for this flow. With `validate_devices=True` kept as the default, direct callers of `apply_strategy_specs` keep the existing eager guard.

## Test plan

- [x] `pytest tests/config/composable_parallel/ tests/config/test_config_factory.py` -- 405 passed (CPU-only, 4xL20 remote box)
- new `test_stage_override_devices_satisfy_strategy_post_cli`: the documented factory flow (strategy + `stage_0_devices` CLI override) resolves
- new `test_missing_stage_override_devices_still_rejected_post_cli`: the guard is deferred, not removed
- new `test_apply_skips_device_guard_when_deferred`: `validate_devices=False` skips the eager check
- [x] existing `test_device_guard_rejects_tp_on_single_gpu_deploy` stays green (direct-caller contract preserved)
- [x] end-to-end: the exact documented command now passes config resolution and spawns the TP=2 engine (both workers load weights) instead of raising at startup

DCO signed-off.
