### PR TITLE
[AutoRound][Bugfix] Scope MXFP8 offline method to block_name_to_quantize

### DIFF
--- a/vllm_omni/quantization/inc_config.py
+++ b/vllm_omni/quantization/inc_config.py
@@ -74,10 +74,17 @@ class OmniINCConfig(INCConfig):
         """Get quantization method, handling AutoRound MXFP8 as a special case."""
         # Check if this is an AutoRound MXFP8 checkpoint (data_type="mx_fp")
         if hasattr(self, "data_type") and self.data_type == "mx_fp" and self.weight_bits == 8:
-            from vllm.model_executor.layers.linear import LinearBase
+            from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
 
             if isinstance(layer, LinearBase):
-                return IncMxfp8OfflineLinearMethod()
+                # Respect block_name_to_quantize: only quantize the transformer blocks
+                # (noise_refiner/context_refiner/layers), NOT the text encoder or other
+                # components. Reuse the parent INCConfigParser to decide, matching the
+                # parent INCConfig.get_quant_method behavior for MXFP4.
+                layer_config = self.config_parser.resolve(layer, prefix)
+                if layer_config.quantized:
+                    return IncMxfp8OfflineLinearMethod()
+                return UnquantizedLinearMethod()
             return None
 
         # Otherwise, use parent INCConfig logic


### PR DESCRIPTION

## Problem
`OmniINCConfig.get_quant_method`'s MXFP8 special case returned `IncMxfp8OfflineLinearMethod` for every `LinearBase` layer without consulting `block_name_to_quantize`. On AutoRound MXFP8 diffusion checkpoints (e.g. Z-Image-Turbo), the text encoder (BF16 weights, no MXFP8 scales in the checkpoint) was also routed into the MXFP8 path, corrupting text embeddings — generated content becomes unrelated to the prompt (Z-Image-Turbo GenEval 0.0005 vs 0.7584 bf16).

## Fix
Resolve the layer through the INC config parser (respecting `block_name_to_quantize`) and only attach `IncMxfp8OfflineLinearMethod` when the parser marks the layer quantized; otherwise return `UnquantizedLinearMethod`. Mirrors the parent INCConfig behavior used by MXFP4 (which already scopes correctly).

## Verification
- Z-Image-Turbo MXFP8 checkpoint, same prompt/seed ('a red bench in a park'): before fix — content mismatch (grid pattern), per-layer stats deviate up to 16% from bf16 from DiT layer 0; after fix — correct content, divergent layer records drop 122/204 → 44/204 (in line with MXFP4 quantization noise).
- MXFP4 path unchanged (parent logic).

AI assistance was used in root-cause debugging (layer-level divergence instrumentation) and patch preparation.

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

## Test Plan

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
