### PR TITLE
[Bugfix] Merge audio-only chat choices into the same-index text choice

### DIFF
--- a/tests/entrypoints/openai_api/test_serving_chat_audio_choice_merge.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_audio_choice_merge.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for merging audio-only choices into text choices.
+
+AR pipelines finish one output per modality (stage 0 text, then a later
+audio stage). Before the merge, a non-streaming text+audio request returned
+two choices that both claimed index 0: the text choice carried content and
+no audio, the audio-only choice carried audio and no content. Spec-shaped
+clients reading choices[0] silently lost the audio.
+"""
+
+from __future__ import annotations
+
+import pytest
+from openai.types.chat.chat_completion_audio import ChatCompletionAudio
+
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionResponseChoice,
+    ChatMessage,
+)
+
+from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _audio(audio_id: str = "audio-abc123") -> ChatCompletionAudio:
+    return ChatCompletionAudio(
+        id=audio_id,
+        data="UklGRiQ=",
+        expires_at=1789122547,
+        transcript="",
+    )
+
+
+def _text_choice(index: int = 0, content: str = "hello") -> ChatCompletionResponseChoice:
+    return ChatCompletionResponseChoice(
+        index=index,
+        message=ChatMessage(role="assistant", content=content),
+        logprobs=None,
+        finish_reason="stop",
+        stop_reason=None,
+    )
+
+
+def _audio_only_choice(index: int = 0, audio_id: str = "audio-abc123") -> ChatCompletionResponseChoice:
+    return ChatCompletionResponseChoice(
+        index=index,
+        message=ChatMessage(role="assistant", audio=_audio(audio_id)),
+        logprobs=None,
+        finish_reason="stop",
+        stop_reason=None,
+    )
+
+
+def _merge(choices):
+    return OmniOpenAIServingChat._merge_audio_choices_into_text(choices)
+
+
+def test_text_and_audio_choices_merge_into_one():
+    merged = _merge([_text_choice(), _audio_only_choice()])
+
+    assert len(merged) == 1
+    message = merged[0].message
+    assert message.content == "hello"
+    assert message.audio is not None
+    assert message.audio.id == "audio-abc123"
+    assert merged[0].index == 0
+
+
+def test_audio_only_request_keeps_standalone_choice():
+    merged = _merge([_audio_only_choice()])
+
+    assert len(merged) == 1
+    assert merged[0].message.content is None
+    assert merged[0].message.audio is not None
+
+
+def test_audio_choice_before_text_choice_merges():
+    merged = _merge([_audio_only_choice(), _text_choice()])
+
+    assert len(merged) == 1
+    assert merged[0].message.content == "hello"
+    assert merged[0].message.audio is not None
+
+
+def test_n_greater_than_one_pairs_by_index():
+    merged = _merge(
+        [
+            _text_choice(index=0, content="first"),
+            _text_choice(index=1, content="second"),
+            _audio_only_choice(index=0, audio_id="audio-zero"),
+            _audio_only_choice(index=1, audio_id="audio-one"),
+        ]
+    )
+
+    assert len(merged) == 2
+    by_index = {choice.index: choice for choice in merged}
+    assert by_index[0].message.content == "first"
+    assert by_index[0].message.audio.id == "audio-zero"
+    assert by_index[1].message.content == "second"
+    assert by_index[1].message.audio.id == "audio-one"
+
+
+def test_choices_without_audio_are_untouched():
+    text = _text_choice(index=0)
+    # Diffusion image choices carry list content via model_construct, the
+    # same bypass used by _create_image_choice (ChatMessage.content is str
+    # only for validated construction).
+    image_message = ChatMessage.model_construct(role="assistant")
+    object.__setattr__(image_message, "content", [{"type": "image_url"}])
+    if hasattr(image_message, "__pydantic_fields_set__"):
+        image_message.__pydantic_fields_set__.add("content")
+    image_style = ChatCompletionResponseChoice(
+        index=1,
+        message=image_message,
+        logprobs=None,
+        finish_reason="stop",
+        stop_reason=None,
+    )
+
+    merged = _merge([text, image_style])
+
+    assert merged == [text, image_style]
+
+
+def test_empty_choices_passthrough():
+    assert _merge([]) == []

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -2458,6 +2458,14 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     response_metrics.update(extra)
             choices.extend(choices_data)
 
+        # AR pipelines emit one finished output per modality (stage 0 text,
+        # then a later audio stage), and the loop above appends one choice per
+        # output. That yields two choices claiming the same index for a
+        # text+audio request, and spec-shaped clients reading choices[0]
+        # silently lose the audio: OpenAI chat-completions semantics carry
+        # text and audio in a single message (message.content + message.audio).
+        choices = self._merge_audio_choices_into_text(choices)
+
         response_metrics = self._filter_stage_metrics_detail(response_metrics, request)
 
         # Compute prompt_text for non-streaming response (upstream #42052)
@@ -2769,6 +2777,46 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         kv_transfer_params = final_res.kv_transfer_params
 
         return choices, usage, prompt_logprobs, prompt_token_ids, kv_transfer_params
+
+    @staticmethod
+    def _merge_audio_choices_into_text(
+        choices: list[ChatCompletionResponseChoice],
+    ) -> list[ChatCompletionResponseChoice]:
+        """Merge audio-only choices into the same-index text choice.
+
+        Non-streaming builders emit one choice per modality output, so a
+        text+audio request returns a text choice and an audio-only choice
+        that both claim index 0. The response model itself declares the
+        merged shape (ChatMessage carries both content and audio), and
+        OpenAI audio semantics put the waveform on message.audio of the
+        same message as the text. Audio-only requests keep their standalone
+        choice because there is no text choice to merge into.
+        """
+        merged: list[ChatCompletionResponseChoice] = []
+        text_by_index: dict[int, ChatCompletionResponseChoice] = {}
+        audio_only: dict[int, ChatCompletionResponseChoice] = {}
+        for choice in choices:
+            message = choice.message
+            if message.audio is not None and not message.content:
+                text_choice = text_by_index.get(choice.index)
+                if text_choice is not None:
+                    # Common order: text stage finishes first.
+                    text_choice.message.audio = message.audio
+                    continue
+                pending = audio_only.get(choice.index)
+                if pending is None:
+                    # Keep it for a text choice arriving later.
+                    audio_only[choice.index] = choice
+                else:
+                    merged.append(choice)
+                continue
+            pending = audio_only.pop(choice.index, None)
+            if pending is not None:
+                message.audio = pending.message.audio
+            text_by_index.setdefault(choice.index, choice)
+            merged.append(choice)
+        merged.extend(audio_only.values())
+        return merged
 
     def _create_audio_choice(
         self, omni_outputs: OmniRequestOutput, role: str, request: ChatCompletionRequest, stream: bool = False


### PR DESCRIPTION
## What

Non-streaming chat responses now merge the audio-only choice into the same-index text choice: a text+audio request returns **one** choice whose message carries both `content` and `audio` (`OpenAIChatCompletionAudio`), instead of two choices that both claim `index=0` (text choice with `audio=None`, audio-only choice with `content=None`).

## Why

Fixes #7376. AR pipelines finish one output per modality (stage 0 text, then a later audio stage), and `chat_completion_full_generator` appended one choice per modality output. Spec-shaped clients reading `choices[0]` silently lost the audio even though the server had generated and returned it (it sat in `choices[1]`), and the duplicate `index=0` violates the schema for an `n=1` request.

The merge restores the shape the response model itself declares (`ChatMessage` carries both `content` and `audio`) and matches OpenAI audio semantics. Audio-only requests (`modalities: ["audio"]`) keep their standalone choice; image/diffusion choices and the streaming path are unchanged.

## Test plan

- [x] new `tests/entrypoints/openai_api/test_serving_chat_audio_choice_merge.py` (6 tests, CPU-only): text+audio merge, audio-only standalone, audio-before-text order, `n>1` pairing by index, non-audio choices untouched, empty input
- [x] adjacent `tests/entrypoints/openai_api/` serving-chat suites: 96 passed, 1 pre-existing failure (`test_stream_prompt_token_details_include_zero_cached_and_multimodal_tokens` — also fails on a clean `a7c295d` checkout with the change stashed, unrelated to this PR)
- [x] e2e on 4xL20 (Qwen2.5-Omni-7B, `--omni`, main `a7c295d5`): before = 2 choices / `choices[0].message.audio` None; after = 1 choice with content + audio (988 KB RIFF decodable from `choices[0].message.audio.data`); streaming output byte-identical to before

DCO signed-off.
