### PR TITLE
[Bugfix] Add embed_multimodal to MiniCPM-o 4.5 omni LLM class

### DIFF
--- a/tests/model_executor/models/minicpmo_4_5/test_minicpmo_4_5_omni_llm_embed.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_minicpmo_4_5_omni_llm_embed.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni_llm import (
+    MiniCPMO45OmniLLMForConditionalGeneration,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_embed_multimodal_delegates_to_get_multimodal_embeddings(monkeypatch):
+    """vLLM V1 encoder profiling calls embed_multimodal; without an override the
+    SupportsMultiModal protocol stub returns None and startup fails downstream."""
+    sentinel = (object(),)
+    seen: dict[str, object] = {}
+
+    def fake_get_multimodal_embeddings(self, **kwargs):
+        seen.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(
+        MiniCPMO45OmniLLMForConditionalGeneration,
+        "get_multimodal_embeddings",
+        fake_get_multimodal_embeddings,
+    )
+    model = object.__new__(MiniCPMO45OmniLLMForConditionalGeneration)
+
+    out = model.embed_multimodal(pixel_values="pv", audio_features="af")
+
+    assert out is sentinel
+    assert seen == {"pixel_values": "pv", "audio_features": "af"}

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py
@@ -4528,6 +4528,10 @@ class MiniCPMO45OmniLLMForConditionalGeneration(nn.Module, SupportsMultiModal, S
                 multimodal_embeddings += tuple(audio_embeddings)
         return multimodal_embeddings
 
+    def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
+        """vLLM V1 encoder profiling calls this; the inherited Protocol stub returns None."""
+        return self.get_multimodal_embeddings(**kwargs)
+
     def get_input_embeddings(
         self,
         input_ids: torch.Tensor,


### PR DESCRIPTION
`MiniCPMO45OmniLLMForConditionalGeneration` only implements the old
`get_multimodal_embeddings`. vLLM >= 0.28 calls `embed_multimodal` directly in V1
encoder-cache profiling and the runtime encoder paths, so the call falls through to
the `SupportsMultiModal` protocol stub, returns `None`, and startup fails later in a
`NoneType` error far from the cause. #7360 has the details.

The sibling wrapper in the same directory (`minicpmo_4_5_omni.py`) already delegates
`embed_multimodal` to `get_multimodal_embeddings`; this adds the same three lines to
the LLM class.

The new test builds the class with `object.__new__` (no weights), patches
`get_multimodal_embeddings`, and checks that `embed_multimodal` returns its result and
forwards the kwargs.

Verified on CPU with vLLM 0.29.0:

- with the fix, `pytest -m "core_model and cpu" tests/model_executor/models/minicpmo_4_5/`
  is `423 passed, 1 skipped`, and ruff 0.14.10 check/format are clean
- reverting only `minicpmo_4_5_omni_llm.py` and keeping the new test gives `1 failed`
  with `assert None is (...)`: the protocol stub's `None`, i.e. the bug this closes

Closes #7360
