### PR TITLE
[Bugfix] Resample native Realtime input to model rate

### DIFF
--- a/tests/entrypoints/duplex/test_duplex_audio.py
+++ b/tests/entrypoints/duplex/test_duplex_audio.py
@@ -28,6 +28,24 @@ def test_pcm16_input_conversion_is_pure_and_reports_target_rate():
     assert np.allclose(samples, [-1.0, 0.0, 32767 / 32768])
 
 
+def test_pcm_f32_input_conversion_resamples_without_changing_format():
+    source = np.linspace(-0.5, 0.5, 160, dtype="<f4")
+    encoded = base64.b64encode(source.tobytes()).decode("ascii")
+
+    converted, fmt, sample_rate = convert_input_audio_with_rate(
+        encoded,
+        "pcm_f32le",
+        sample_rate_hz=16_000,
+        target_sample_rate_hz=24_000,
+    )
+
+    assert fmt == "pcm_f32le"
+    assert sample_rate == 24_000
+    samples = np.frombuffer(base64.b64decode(converted), dtype="<f4")
+    assert samples.size == 240
+    assert np.isfinite(samples).all()
+
+
 @pytest.mark.parametrize("sample_rate_hz", [8_000, 192_000])
 def test_pcm16_input_conversion_accepts_supported_sample_rate_boundaries(sample_rate_hz: int):
     encoded = base64.b64encode(np.zeros(8, dtype="<i2").tobytes()).decode("ascii")

--- a/tests/entrypoints/openai/test_duplex_protocol.py
+++ b/tests/entrypoints/openai/test_duplex_protocol.py
@@ -499,6 +499,7 @@ def test_duplex_capabilities_do_not_claim_core_kv_or_input_append():
     assert caps["implementation_level"] == "serving_session_adapter"
     assert caps["supports_kv_lease"] is False
     assert caps["supports_input_append"] is False
+    assert caps["input_sample_rate_hz"] is None
     assert caps["supports_reencode_context"] is True
     assert caps["adapter_patterns"] == ["chunk_group_append"]
     assert "turn_commit_only" in caps["input_modes"]
@@ -510,6 +511,7 @@ def test_minicpmo_native_capabilities_separate_model_state_from_core_kv_lease():
 
     assert caps["implementation_level"] == "model_native_duplex"
     assert caps["supports_input_append"] is True
+    assert caps["input_sample_rate_hz"] == 16_000
     assert caps["input_modes"] == ["append_audio_chunk"]
     assert caps["adapter_patterns"] == ["scheduler_data_plane"]
     assert caps["supports_model_internal_state"] is True

--- a/tests/entrypoints/openai_api/test_duplex_handler.py
+++ b/tests/entrypoints/openai_api/test_duplex_handler.py
@@ -1404,12 +1404,35 @@ async def test_realtime_server_vad_input_path_uses_runtime_capability(native: bo
     assert append is not None
     if native:
         assert append["format"] == "pcm_f32le"
-        assert append["sample_rate_hz"] == 16_000
-        assert len(base64.b64decode(append["audio"])) == 160 * 4
+        assert append["sample_rate_hz"] == 24_000
+        assert len(base64.b64decode(append["audio"])) == 240 * 4
     else:
         assert append["format"] == "pcm16"
         assert append["sample_rate_hz"] == 24_000
         np.testing.assert_array_equal(np.frombuffer(base64.b64decode(append["audio"]), dtype="<i2"), source)
+
+
+@pytest.mark.asyncio
+async def test_native_realtime_input_preserves_the_client_rate_until_runtime_selection():
+    ws = TimedWebSocket()
+    protocol = NativeRealtimeSessionProtocol(ws)  # type: ignore[arg-type]
+    protocol.bind_sender(ws.send_json)
+    protocol.bind_native_input_append(True)
+
+    source = np.zeros(160, dtype="<i2")
+    append = await protocol._to_duplex_event(
+        {
+            "type": "input_audio_buffer.append",
+            "audio": base64.b64encode(source.tobytes()).decode(),
+            "format": "pcm16",
+            "sample_rate_hz": 16_000,
+        }
+    )
+
+    assert append is not None
+    assert append["format"] == "pcm_f32le"
+    assert append["sample_rate_hz"] == 16_000
+    assert len(base64.b64decode(append["audio"])) == 160 * 4
 
 
 @pytest.mark.parametrize(("initial_rate_hz", "updated_rate_hz"), [(16_000, 24_000), (24_000, 16_000)])

--- a/tests/model_executor/models/nemotron_voicechat/duplex/test_runtime_contract.py
+++ b/tests/model_executor/models/nemotron_voicechat/duplex/test_runtime_contract.py
@@ -55,6 +55,12 @@ def _plan(extension, *, input_seq: int):
     )
 
 
+def test_serving_capabilities_declare_the_model_input_rate() -> None:
+    capabilities = NemotronVoiceChatServingRuntimeAdapter.capabilities(max_sessions=1)
+
+    assert capabilities.input_sample_rate_hz == 16_000
+
+
 def test_first_append_prefills_prompt_then_each_append_consumes_one_frame() -> None:
     extension = NemotronVoiceChatDuplexRuntimeExtension()
 

--- a/tests/model_executor/models/personaplex/duplex/test_unified_runtime.py
+++ b/tests/model_executor/models/personaplex/duplex/test_unified_runtime.py
@@ -239,6 +239,7 @@ def test_personaplex_capabilities_are_honest() -> None:
 
     assert multi.implementation_level == "model_native_duplex"
     assert multi.input_modes == ["append_audio_chunk"]
+    assert multi.input_sample_rate_hz == 24_000
     assert multi.chunk_period_ms == 80
     assert single.supports_multi_session is False
     assert multi.supports_multi_session is True

--- a/vllm_omni/entrypoints/duplex/audio.py
+++ b/vllm_omni/entrypoints/duplex/audio.py
@@ -62,6 +62,33 @@ def resample_pcm16_mono(raw: bytes, *, source_rate_hz: int, target_rate_hz: int)
     return np.clip(np.rint(resampled * 32768.0), -32768, 32767).astype("<i2").tobytes()
 
 
+def resample_pcm_f32_mono(raw: bytes, *, source_rate_hz: int, target_rate_hz: int) -> bytes:
+    """Resample little-endian mono float32 PCM without changing its format."""
+    if source_rate_hz <= 0 or target_rate_hz <= 0 or source_rate_hz == target_rate_hz:
+        return raw
+
+    samples = np.frombuffer(raw, dtype="<f4")
+    # Import lazily so the generic Duplex audio module does not pull in the
+    # OpenAI API server while the Duplex stack itself is being imported.
+    from vllm_omni.entrypoints.openai.audio_utils_mixin import StreamingAudioResampler
+
+    rate_gcd = math.gcd(source_rate_hz, target_rate_hz)
+    reduced_factor = max(source_rate_hz // rate_gcd, target_rate_hz // rate_gcd)
+    if reduced_factor > StreamingAudioResampler._max_polyphase_factor:
+        # Keep unusual client rates bounded while common audio rates use the
+        # high-quality polyphase path.
+        if samples.size <= 1:
+            return raw
+        target_size = max(1, int(round(samples.size * target_rate_hz / source_rate_hz)))
+        source_x = np.linspace(0.0, 1.0, num=samples.size, endpoint=True)
+        target_x = np.linspace(0.0, 1.0, num=target_size, endpoint=True)
+        resampled = np.interp(target_x, source_x, samples)
+    else:
+        resampler = StreamingAudioResampler(source_rate_hz, target_rate_hz)
+        resampled = resampler.process(samples, final=True)
+    return np.ascontiguousarray(resampled, dtype="<f4").tobytes()
+
+
 def decode_g711_ulaw(raw: bytes) -> bytes:
     if ulaw2lin is not None:
         return ulaw2lin(raw, 2)
@@ -156,15 +183,18 @@ def convert_input_audio_with_rate(
     fmt: object,
     *,
     sample_rate_hz: int | float | None = None,
-    target_sample_rate_hz: int = 16_000,
+    target_sample_rate_hz: int | None = 16_000,
 ) -> tuple[object, object, int | float | None]:
+    """Normalize supported input to float32 PCM and optionally resample it."""
     if not isinstance(audio, str) or not isinstance(fmt, str):
         return audio, fmt, sample_rate_hz
     normalized = fmt.lower()
-    if normalized not in {"pcm16", "pcm_s16le", "s16le", "g711_ulaw", "g711_alaw"}:
+    if normalized not in {"pcm16", "pcm_s16le", "s16le", "pcm_f32le", "g711_ulaw", "g711_alaw"}:
         return audio, fmt, sample_rate_hz
     if isinstance(sample_rate_hz, int | float):
         sample_rate_hz = validate_input_sample_rate_hz(sample_rate_hz)
+    if target_sample_rate_hz is not None:
+        target_sample_rate_hz = validate_input_sample_rate_hz(target_sample_rate_hz)
     try:
         raw = base64.b64decode(audio.strip(), validate=False)
     except (binascii.Error, ValueError):
@@ -175,16 +205,28 @@ def convert_input_audio_with_rate(
     elif normalized == "g711_alaw":
         raw = decode_g711_alaw(raw)
         sample_rate_hz = sample_rate_hz if isinstance(sample_rate_hz, int | float) else 8_000
+    elif normalized == "pcm_f32le":
+        if len(raw) % np.dtype("<f4").itemsize:
+            return audio, fmt, sample_rate_hz
     elif len(raw) % 2:
         return audio, fmt, sample_rate_hz
-    if isinstance(sample_rate_hz, int | float) and int(sample_rate_hz) != target_sample_rate_hz:
-        raw = resample_pcm16_mono(
+    if (
+        isinstance(sample_rate_hz, int | float)
+        and target_sample_rate_hz is not None
+        and int(sample_rate_hz) != target_sample_rate_hz
+    ):
+        resample = resample_pcm_f32_mono if normalized == "pcm_f32le" else resample_pcm16_mono
+        raw = resample(
             raw,
             source_rate_hz=int(sample_rate_hz),
             target_rate_hz=target_sample_rate_hz,
         )
         sample_rate_hz = target_sample_rate_hz
-    pcm = np.frombuffer(raw, dtype="<i2").astype(np.float32) / 32768.0
+    pcm = (
+        np.frombuffer(raw, dtype="<f4")
+        if normalized == "pcm_f32le"
+        else np.frombuffer(raw, dtype="<i2").astype(np.float32) / 32768.0
+    )
     encoded = base64.b64encode(np.ascontiguousarray(pcm, dtype="<f4").tobytes()).decode("ascii")
     return encoded, "pcm_f32le", sample_rate_hz
 

--- a/vllm_omni/entrypoints/duplex/protocol.py
+++ b/vllm_omni/entrypoints/duplex/protocol.py
@@ -103,6 +103,9 @@ class DuplexCapabilities:
     supports_barge_in: bool = True
     supports_playback_ack: bool = True
     supports_input_append: bool = False
+    # Native append runtimes declare the fixed sample rate consumed by their
+    # model. A missing rate means the runtime accepts the session input rate.
+    input_sample_rate_hz: int | None = None
     supports_replace_latest_chunk: bool = True
     supports_reencode_context: bool = True
     supports_rollback_to_checkpoint: bool = False
@@ -141,6 +144,7 @@ class DuplexCapabilities:
             "supports_barge_in": self.supports_barge_in,
             "supports_playback_ack": self.supports_playback_ack,
             "supports_input_append": self.supports_input_append,
+            "input_sample_rate_hz": self.input_sample_rate_hz,
             "supports_replace_latest_chunk": self.supports_replace_latest_chunk,
             "supports_reencode_context": self.supports_reencode_context,
             "supports_rollback_to_checkpoint": self.supports_rollback_to_checkpoint,

--- a/vllm_omni/entrypoints/duplex/realtime_input.py
+++ b/vllm_omni/entrypoints/duplex/realtime_input.py
@@ -374,6 +374,10 @@ class RealtimeInputTranslator(RealtimeStateOwner):
                         audio,
                         fmt,
                         sample_rate_hz=sample_rate_hz if isinstance(sample_rate_hz, int | float) else None,
+                        # Preserve the client rate: an implicit session may
+                        # not have a resolved model. The session runner
+                        # resamples after resolving input_sample_rate_hz.
+                        target_sample_rate_hz=None,
                     )
                 except ValueError as exc:
                     await self._send_realtime_payload(
@@ -1402,6 +1406,10 @@ class RealtimeInputTranslator(RealtimeStateOwner):
                         audio,
                         fmt,
                         sample_rate_hz=sample_rate_hz if isinstance(sample_rate_hz, int | float) else None,
+                        # Preserve the client rate: an implicit session may
+                        # not have a resolved model. The session runner
+                        # resamples after resolving input_sample_rate_hz.
+                        target_sample_rate_hz=None,
                     )
                 except ValueError as exc:
                     await self._send_realtime_payload(

--- a/vllm_omni/entrypoints/duplex/server_vad.py
+++ b/vllm_omni/entrypoints/duplex/server_vad.py
@@ -15,6 +15,8 @@ from typing import TYPE_CHECKING, Literal, Protocol
 import numpy as np
 from vllm.transformers_utils.repo_utils import try_get_local_file
 
+from vllm_omni.entrypoints.duplex.audio import validate_input_sample_rate_hz
+
 if TYPE_CHECKING:
     from vllm_omni.entrypoints.openai.audio_utils_mixin import StreamingAudioResampler
 
@@ -340,9 +342,21 @@ class ServerVADPipeline:
             raise ValueError("server_vad PCM16 input contains an incomplete sample")
         pcm16 = np.frombuffer(samples, dtype="<i2")
 
+        normalized = np.ascontiguousarray(pcm16, dtype=np.float32) * np.float32(1.0 / 32768.0)
+        return await self.push_float32(normalized, source_sample_rate_hz=source_sample_rate_hz)
+
+    async def push_float32(
+        self,
+        samples: np.ndarray,
+        *,
+        source_sample_rate_hz: int,
+    ) -> ServerVADBatch:
+        """Normalize chunked mono float32 input and run endpoint detection."""
+        source_sample_rate_hz = validate_input_sample_rate_hz(source_sample_rate_hz)
         if self._source_sample_rate_hz is not None and source_sample_rate_hz != self._source_sample_rate_hz:
             raise ValueError("server_vad input sample rate cannot change within a continuous audio stream")
-        if pcm16.size and self._source_sample_rate_hz is None:
+        normalized = np.ascontiguousarray(samples, dtype=np.float32).reshape(-1)
+        if normalized.size and self._source_sample_rate_hz is None:
             from vllm_omni.entrypoints.openai.audio_utils_mixin import StreamingAudioResampler
 
             self._input_resampler = (
@@ -352,7 +366,6 @@ class ServerVADPipeline:
             )
             self._source_sample_rate_hz = source_sample_rate_hz
 
-        normalized = np.ascontiguousarray(pcm16, dtype=np.float32) * np.float32(1.0 / 32768.0)
         if self._input_resampler is not None:
             normalized = self._input_resampler.process(normalized)
         return await self.push(normalized)

--- a/vllm_omni/entrypoints/duplex/session_runner.py
+++ b/vllm_omni/entrypoints/duplex/session_runner.py
@@ -60,6 +60,14 @@ _MAX_EVENT_BYTES = 15 * 1024 * 1024
 class DuplexSessionRunnerMixin:
     """Run one ordered WebSocket mailbox for a duplex session."""
 
+    @staticmethod
+    def _native_input_sample_rate_hz(session: DuplexSession) -> int:
+        """Return the fixed input rate declared by a native append runtime."""
+        sample_rate_hz = session.capabilities.input_sample_rate_hz
+        if sample_rate_hz is None:
+            raise ValueError("The selected native duplex runtime has no input sample rate")
+        return validate_input_sample_rate_hz(sample_rate_hz)
+
     async def handle_session(
         self,
         websocket: WebSocket,
@@ -1562,10 +1570,14 @@ class DuplexSessionRunnerMixin:
                     turn_based_server_vad = server_vad_config is not None and not native_input
                     if not turn_based_server_vad:
                         try:
+                            target_sample_rate_hz = (
+                                self._native_input_sample_rate_hz(session) if native_input else 16_000
+                            )
                             audio, fmt, sample_rate_hz = convert_input_audio_with_rate(
                                 audio,
                                 fmt,
                                 sample_rate_hz=sample_rate_hz,
+                                target_sample_rate_hz=target_sample_rate_hz,
                             )
                         except ValueError as exc:
                             await emit_event({"type": "error", "error": str(exc), "code": "bad_event"})
@@ -1615,8 +1627,9 @@ class DuplexSessionRunnerMixin:
                         previous_scratch_bytes = pipeline.scratch_bytes
                         try:
                             if native_input:
-                                if fmt != "pcm_f32le" or sample_rate_hz != pipeline.sample_rate_hz:
-                                    raise ValueError("native server_vad input must be mono PCM float32 at 16000 Hz")
+                                if fmt != "pcm_f32le":
+                                    raise ValueError("native server_vad input must be mono PCM float32")
+                                source_sample_rate_hz = validate_input_sample_rate_hz(sample_rate_hz)
                                 raw_audio = base64.b64decode(audio, validate=True)
                                 if len(raw_audio) % np.dtype("<f4").itemsize:
                                     raise ValueError("native server_vad input contains an incomplete float32 sample")
@@ -1680,7 +1693,10 @@ class DuplexSessionRunnerMixin:
                                 continue
                         try:
                             vad_batch = (
-                                await pipeline.push(normalized_audio)
+                                await pipeline.push_float32(
+                                    normalized_audio,
+                                    source_sample_rate_hz=source_sample_rate_hz,
+                                )
                                 if native_input
                                 else await pipeline.push_pcm16(
                                     raw_audio,

--- a/vllm_omni/model_executor/models/minicpmo_4_5/duplex/capabilities.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/duplex/capabilities.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from vllm_omni.entrypoints.duplex.protocol import DuplexCapabilities
+from vllm_omni.model_executor.models.minicpmo_4_5.duplex.policy import MiniCPMO45DuplexPolicy
 
 
 def minicpmo45_native_capabilities(*, max_sessions: int = 1) -> DuplexCapabilities:
@@ -13,6 +14,7 @@ def minicpmo45_native_capabilities(*, max_sessions: int = 1) -> DuplexCapabiliti
         supports_model_native_turn_policy=True,
         supports_barge_in=True,
         supports_input_append=True,
+        input_sample_rate_hz=MiniCPMO45DuplexPolicy.SAMPLE_RATE_HZ,
         supports_replace_latest_chunk=False,
         supports_reencode_context=False,
         supports_turn_commit_only=False,

--- a/vllm_omni/model_executor/models/nemotron_voicechat/duplex/serving_adapter.py
+++ b/vllm_omni/model_executor/models/nemotron_voicechat/duplex/serving_adapter.py
@@ -22,6 +22,7 @@ from vllm_omni.model_executor.models.nemotron_voicechat.duplex.data_plane import
     NemotronVoiceChatDataPlaneSession,
 )
 from vllm_omni.model_executor.models.nemotron_voicechat.duplex.input import (
+    NEMOTRON_VOICECHAT_SAMPLE_RATE,
     NemotronVoiceChatPcmAppendBuffer,
 )
 
@@ -203,6 +204,7 @@ class NemotronVoiceChatServingRuntimeAdapter:
             supports_barge_in=False,
             supports_playback_ack=True,
             supports_input_append=True,
+            input_sample_rate_hz=NEMOTRON_VOICECHAT_SAMPLE_RATE,
             supports_replace_latest_chunk=False,
             supports_reencode_context=False,
             supports_rollback_to_checkpoint=False,

--- a/vllm_omni/model_executor/models/personaplex/duplex/serving_adapter.py
+++ b/vllm_omni/model_executor/models/personaplex/duplex/serving_adapter.py
@@ -17,7 +17,7 @@ from vllm_omni.entrypoints.duplex.runtime_adapter import (
     ServingRuntimeConfigError,
     reject_changed_runtime_value,
 )
-from vllm_omni.model_executor.models.personaplex.duplex.config import DEFAULT_PERSONA
+from vllm_omni.model_executor.models.personaplex.duplex.config import DEFAULT_PERSONA, SAMPLE_RATE
 from vllm_omni.model_executor.models.personaplex.duplex.data_plane import (
     PersonaPlexDataPlaneContext,
     PersonaPlexDataPlaneSession,
@@ -120,6 +120,7 @@ class PersonaPlexServingRuntimeAdapter:
             supports_barge_in=False,
             supports_playback_ack=True,
             supports_input_append=True,
+            input_sample_rate_hz=SAMPLE_RATE,
             supports_replace_latest_chunk=False,
             supports_reencode_context=False,
             supports_rollback_to_checkpoint=False,


### PR DESCRIPTION
## Purpose

full duplex models only accept certain sample rates, resample input audio before it reaches the model.

## Test Plan

**vLLM Version:** 0.29.0

**vLLM-Omni Commit:** 7487e19421912825785244c2d26b55979fb15729

```
# unit test
pytest -s -v \
  tests/entrypoints/duplex/test_duplex_audio.py \
  tests/entrypoints/openai/test_duplex_protocol.py \
  tests/entrypoints/openai_api/test_duplex_handler.py \
  tests/model_executor/models/nemotron_voicechat/duplex/test_runtime_contract.py \
  tests/model_executor/models/personaplex/duplex/test_unified_runtime.py
# e2e test
TBD
```

## Test Result

TBD
