### PR TITLE
[Bugfix][Benchmark] Make judge frame-overflow recovery explicit

### DIFF
--- a/examples/online_serving/minicpmo/README.md
+++ b/examples/online_serving/minicpmo/README.md
@@ -279,6 +279,39 @@ generation records `clock=media`; artifacts generated with
 `--pace as-fast-as-possible` record `clock=invalid` and evaluation rejects
 them unless `--allow-invalid-clock` is explicit.
 
+### Judge context overflow with sampled frames
+
+`--judge-frame-overflow error` is the default: a rejected judge request fails
+without changing its input. To opt into reduced-frame recovery, add
+`--judge-frame-overflow reduce` to `evaluate`, normally together with
+`--judge-video-mode frame-sample`.
+
+The policy applies to both temporal image-frame calls and frame-sample content
+calls. It retries only explicit context-length errors returned as HTTP 400 or
+500. Each retry uses approximately half as many frames, sampled uniformly from
+the original timeline. Multiple retained frames preserve the endpoints; a
+single retained frame uses the original middle frame. Ordinary HTTP failures,
+rate limits, transport timeouts, and an overflow with only one frame remaining
+still propagate. The `video_url` content request is unchanged; temporal judging
+always uses image frames and can still use the opt-in policy.
+
+This is failure recovery, **not proactive token budgeting**. It does not resize
+images, estimate the judge's tokenizer, guarantee that one image fits, or recover
+an oversized request that only times out instead of returning a recognized
+context-length error.
+
+Each score records `judge_frame_overflow`. Content and temporal frame results
+record `frame_count_initial`, `frame_count`, and `frame_budget_retries` (the number
+of recovery retries, not a measured token budget). The RTD summary reports
+`judge_frame_overflow_policies` and `frame_reduction_samples`.
+
+Reduced frames can omit short events or useful OCR evidence and therefore change
+the evaluation workload. Use a separate `--score-root` for each policy/model
+configuration, or explicitly use `--overwrite`; otherwise existing score files
+are reused. Do not compare mixed-policy summaries as though they used identical
+inputs. No claim is made that reduced-frame scores equal the original protocol's
+scores.
+
 ## Related examples
 
 - [Offline MiniCPM-o inference](../../offline_inference/minicpmo/)

--- a/tests/benchmarks/duplex/test_omni_duplex_eval_frame_budget.py
+++ b/tests/benchmarks/duplex/test_omni_duplex_eval_frame_budget.py
@@ -1,0 +1,264 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+import io
+import json
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pybase64 as base64
+import pytest
+import requests
+from PIL import Image
+
+from vllm_omni.benchmarks.duplex import omni_duplex_eval_eval as eval_mod
+from vllm_omni.benchmarks.duplex.omni_duplex_eval_dataset import DuplexSample
+from vllm_omni.benchmarks.duplex.omni_duplex_eval_judge import DuplexJudge
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.benchmark]
+
+OVERFLOW = "The decoder prompt (length 93016) is longer than the maximum model length of 65536"
+
+
+def _http_error(status: int, body: str) -> requests.HTTPError:
+    response = requests.Response()
+    response.status_code = status
+    response._content = body.encode()
+    return requests.HTTPError(f"{status} response from judge", response=response)
+
+
+@pytest.mark.parametrize("status", [401, 403, 413, 429, 502, 503])
+def test_classifier_rejects_unrelated_http_status(status: int) -> None:
+    assert not eval_mod._is_prompt_too_long_error(_http_error(status, OVERFLOW))
+
+
+@pytest.mark.parametrize("status", [400, 500])
+def test_classifier_accepts_reported_prompt_overflow(status: int) -> None:
+    assert eval_mod._is_prompt_too_long_error(_http_error(status, OVERFLOW))
+
+
+@pytest.mark.parametrize("status", [400, 500])
+def test_classifier_accepts_explicit_context_length_code(status: int) -> None:
+    body = json.dumps({"error": {"code": "context_length_exceeded", "message": "Context is full"}})
+    assert eval_mod._is_prompt_too_long_error(_http_error(status, body))
+
+
+def test_classifier_does_not_match_unrelated_json_fields() -> None:
+    body = json.dumps({"error": {"message": "Model worker failed"}, "debug": OVERFLOW})
+    assert not eval_mod._is_prompt_too_long_error(_http_error(500, body))
+
+
+def test_classifier_requires_an_http_response() -> None:
+    assert not eval_mod._is_prompt_too_long_error(requests.HTTPError(OVERFLOW))
+
+
+@pytest.mark.parametrize("count", [0, 1, 16])
+@pytest.mark.parametrize("allow_reduction", [False, True])
+def test_success_preserves_input_and_does_not_retry(count: int, allow_reduction: bool) -> None:
+    frames = [bytes([i]) for i in range(count)]
+    calls = []
+
+    def call(selected: list[bytes]) -> str:
+        calls.append(list(selected))
+        return "score"
+
+    result, selected, retries = eval_mod._judge_frames_with_overflow_retry(
+        call, frames, allow_reduction=allow_reduction
+    )
+    assert (result, selected, retries) == ("score", frames, 0)
+    assert calls == [frames]
+    assert frames == [bytes([i]) for i in range(count)]
+
+
+def test_subsampling_uses_original_timeline_and_preserves_endpoints() -> None:
+    frames = [bytes([i]) for i in range(16)]
+    calls = []
+
+    def call(selected: list[bytes]) -> str:
+        calls.append(list(selected))
+        if len(selected) > 4:
+            raise _http_error(500, OVERFLOW)
+        return "score"
+
+    result, selected, retries = eval_mod._judge_frames_with_overflow_retry(call, frames, allow_reduction=True)
+    assert result == "score"
+    assert [len(batch) for batch in calls] == [16, 8, 4]
+    assert selected == [bytes([i]) for i in [0, 5, 10, 15]]
+    assert retries == 2
+    assert all(batch[0] == frames[0] and batch[-1] == frames[-1] for batch in calls)
+    assert len(frames) == 16
+
+
+@pytest.mark.parametrize("count", [0, 1, 2, 3, 16, 17])
+def test_exhausted_retry_propagates_without_empty_fallback(count: int) -> None:
+    frames = [bytes([i]) for i in range(count)]
+    calls = []
+    error = _http_error(500, OVERFLOW)
+
+    def call(selected: list[bytes]) -> str:
+        calls.append(list(selected))
+        raise error
+
+    with pytest.raises(requests.HTTPError) as caught:
+        eval_mod._judge_frames_with_overflow_retry(call, frames, allow_reduction=True)
+    assert caught.value is error
+    expected_counts = [count]
+    while expected_counts[-1] > 1:
+        expected_counts.append((expected_counts[-1] + 1) // 2)
+    assert [len(batch) for batch in calls] == expected_counts
+    if count:
+        assert calls[-1] == [frames[count // 2]]
+
+
+@pytest.mark.parametrize("exception", [requests.ReadTimeout("timeout"), requests.ConnectionError("disconnected")])
+def test_transport_failures_are_not_retried(exception: Exception) -> None:
+    calls = []
+
+    def call(selected: list[bytes]) -> str:
+        calls.append(selected)
+        raise exception
+
+    with pytest.raises(type(exception)) as caught:
+        eval_mod._judge_frames_with_overflow_retry(call, [b"a", b"b"], allow_reduction=True)
+    assert caught.value is exception
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize("status", [401, 429, 500])
+def test_unrelated_http_errors_are_not_retried(status: int) -> None:
+    calls = []
+    error = _http_error(status, "Model worker failed")
+
+    def call(selected: list[bytes]) -> str:
+        calls.append(selected)
+        raise error
+
+    with pytest.raises(requests.HTTPError) as caught:
+        eval_mod._judge_frames_with_overflow_retry(call, [b"a", b"b"], allow_reduction=True)
+    assert caught.value is error
+    assert len(calls) == 1
+
+
+@contextmanager
+def _http_judge(limit: int = 4) -> Iterator[tuple[DuplexJudge, list[int]]]:
+    """Real HTTP and production judge client; deterministic fixture, not a model."""
+    counts: list[int] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            self.connection.settimeout(5)
+            payload = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            assert self.path == "/v1/chat/completions"
+            assert payload["model"] == "fixture-judge"
+            assert payload["max_tokens"] == 1200
+            parts = payload["messages"][-1]["content"]
+            images = [part for part in parts if part["type"] == "image_url"]
+            for part in images:
+                data = base64.b64decode(part["image_url"]["url"].split(",", 1)[1])
+                with Image.open(io.BytesIO(data)) as image:
+                    assert image.size == (3734, 2100)
+            counts.append(len(images))
+            response: dict[str, object]
+            if len(images) > limit:
+                status = 500
+                response = {"error": {"message": OVERFLOW}}
+            else:
+                status = 200
+                score = json.dumps({"content_score": 4, "temporal_score": 4, "is_relevant": 1})
+                response = {"choices": [{"message": {"content": score}}]}
+            encoded = json.dumps(response).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+        def log_message(self, *args) -> None:
+            pass
+
+    with ThreadingHTTPServer(("127.0.0.1", 0), Handler) as server:
+        thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.01}, daemon=True)
+        thread.start()
+        try:
+            yield DuplexJudge(f"http://127.0.0.1:{server.server_port}", "fixture-judge", timeout=5), counts
+        finally:
+            server.shutdown()
+            thread.join(timeout=5)
+            assert not thread.is_alive()
+
+
+def _sample_inputs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, with_sentence: bool = True):
+    response_path = tmp_path / "responses" / "sample.json"
+    response_path.parent.mkdir()
+    items = [{"sentence": "A person moves.", "start": 2.0, "end": 4.0}] if with_sentence else []
+    response_path.write_text(json.dumps(items), encoding="utf-8")
+    response_path.with_name("sample.meta.json").write_text('{"clock": "media"}', encoding="utf-8")
+    score_path = tmp_path / "scores" / "RTD_OCR" / "sample.json"
+    sample = DuplexSample(
+        id="sample",
+        split="RTD_OCR",
+        family="rtd",
+        task_type=None,
+        video=tmp_path / "video.mp4",
+        video_duration=48.0,
+        question_text="What happened?",
+        answer1="A person moves.",
+    )
+    with io.BytesIO() as buffer:
+        Image.new("RGB", (3734, 2100), "white").save(buffer, format="JPEG")
+        frame = buffer.getvalue()
+    monkeypatch.setattr(eval_mod, "materialize_media", lambda *args, **kwargs: sample.video)
+    monkeypatch.setattr(eval_mod, "_extract_frames", lambda *args, **kwargs: [frame] * 16)
+    monkeypatch.setenv("NO_PROXY", "127.0.0.1,localhost")
+    return sample, response_path, score_path
+
+
+def test_real_http_temporal_and_content_recovery(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    sample, response_path, score_path = _sample_inputs(tmp_path, monkeypatch)
+    with _http_judge() as (judge, counts):
+        result = eval_mod.evaluate_sample(
+            sample, response_path, score_path, judge, judge_video_mode="frame-sample", judge_frame_overflow="reduce"
+        )
+    assert counts == [16, 8, 4, 16, 8, 4]
+    assert result["judge_frame_overflow"] == "reduce"
+    for row in [result["temporal"]["sentences"][0], result["content"]]:
+        assert row["frame_count_initial"] == 16
+        assert row["frame_count"] == 4
+        assert row["frame_budget_retries"] == 2
+    assert json.loads(score_path.read_text(encoding="utf-8")) == result
+    summary = eval_mod.summarize_scores(tmp_path / "scores")
+    assert summary["rtd"]["frame_reduction_samples"] == 1
+    assert summary["rtd"]["judge_frame_overflow_policies"] == ["reduce"]
+
+
+def test_default_policy_fails_without_changing_frames(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    sample, response_path, score_path = _sample_inputs(tmp_path, monkeypatch)
+    with _http_judge() as (judge, counts), pytest.raises(requests.HTTPError):
+        eval_mod.evaluate_sample(sample, response_path, score_path, judge, judge_video_mode="frame-sample")
+    assert counts == [16]
+    assert not score_path.exists()
+
+
+def test_video_url_content_is_not_changed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    sample, response_path, score_path = _sample_inputs(tmp_path, monkeypatch, with_sentence=False)
+    with _http_judge() as (judge, counts):
+        result = eval_mod.evaluate_sample(sample, response_path, score_path, judge, judge_frame_overflow="reduce")
+    assert counts == [0]
+    assert "frame_count" not in result["content"]
+
+
+def test_success_keeps_frames_and_reports_zero_retries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    sample, response_path, score_path = _sample_inputs(tmp_path, monkeypatch)
+    with _http_judge(limit=16) as (judge, counts):
+        result = eval_mod.evaluate_sample(
+            sample, response_path, score_path, judge, judge_video_mode="frame-sample", judge_frame_overflow="reduce"
+        )
+    assert counts == [16, 16]
+    assert result["content"]["frame_count"] == 16
+    assert result["content"]["frame_budget_retries"] == 0
+    assert eval_mod.summarize_scores(tmp_path / "scores")["rtd"]["frame_reduction_samples"] == 0

--- a/tests/e2e/features/fullduplex/test_omni_duplex_eval_cli.py
+++ b/tests/e2e/features/fullduplex/test_omni_duplex_eval_cli.py
@@ -9,16 +9,94 @@ import json
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
+import requests
 
+from vllm_omni.benchmarks.duplex import omni_duplex_eval_eval as eval_mod
 from vllm_omni.benchmarks.duplex import omni_duplex_eval_runner as runner
 from vllm_omni.benchmarks.duplex.omni_duplex_eval_dataset import DuplexSample
+from vllm_omni.benchmarks.duplex.omni_duplex_eval_eval import _judge_content_with_frame_budget
 from vllm_omni.benchmarks.duplex.omni_duplex_eval_judge import DuplexJudge
 from vllm_omni.entrypoints.cli.benchmark import omni_duplex_eval as cli
 from vllm_omni.entrypoints.cli.benchmark.omni_duplex_eval import OmniDuplexEvalSubcommand
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.benchmark]
+
+
+def _judge_http_error(text: str) -> requests.HTTPError:
+    response = requests.Response()
+    response.status_code = 500
+    response._content = text.encode()
+    return requests.HTTPError("500 response from judge", response=response)
+
+
+def test_frame_sample_judge_degrades_only_for_prompt_length_errors():
+    calls = []
+
+    class Judge:
+        def content(self, prompt, video, frames, *, mode):
+            calls.append(list(frames))
+            if len(frames) > 4:
+                raise _judge_http_error(
+                    "The decoder prompt (length 93016) is longer than the maximum model length of 65536"
+                )
+            return '{"content_score": 4}'
+
+    result, used_frames, retries = _judge_content_with_frame_budget(
+        Judge(), "prompt", Path("video.mp4"), list(range(16)), mode="frame-sample"
+    )
+
+    assert result == '{"content_score": 4}'
+    assert used_frames == [0, 5, 10, 15]
+    assert retries == 2
+    assert [len(frames) for frames in calls] == [16, 8, 4]
+
+
+def test_frame_sample_judge_does_not_hide_unrelated_http_errors():
+    class Judge:
+        def content(self, prompt, video, frames, *, mode):
+            raise _judge_http_error("Internal model worker failure")
+
+    with pytest.raises(requests.HTTPError, match="500 response from judge"):
+        _judge_content_with_frame_budget(Judge(), "prompt", Path("video.mp4"), [b"a", b"b"], mode="frame-sample")
+
+
+def test_evaluate_records_frame_budget_degradation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    response_path = tmp_path / "sample.json"
+    response_path.write_text("[]", encoding="utf-8")
+    response_path.with_name("sample.meta.json").write_text('{"clock": "media"}', encoding="utf-8")
+    score_path = tmp_path / "score.json"
+    sample = SimpleNamespace(
+        id="sample",
+        family="rtd",
+        task_type="content",
+        video="video.mp4",
+        video_duration=30.0,
+        question_text="question",
+        answer1="a1",
+        answer2="a2",
+    )
+    monkeypatch.setattr(eval_mod, "materialize_media", lambda *args, **kwargs: Path("video.mp4"))
+    monkeypatch.setattr(eval_mod, "_content_frame_times", lambda duration: list(range(16)))
+    monkeypatch.setattr(eval_mod, "_extract_frames", lambda path, timestamps: [bytes([i]) for i in timestamps])
+
+    class Judge:
+        model = "judge"
+
+        def content(self, prompt, video, frames, *, mode):
+            if len(frames) > 4:
+                raise _judge_http_error(
+                    "The decoder prompt (length 93016) is longer than the maximum model length of 65536"
+                )
+            return '{"content_score": 4}'
+
+    result = eval_mod.evaluate_sample(sample, response_path, score_path, Judge(), judge_video_mode="frame-sample")
+    assert result["content"]["content_score"] == 4
+    assert result["content"]["frame_count_initial"] == 16
+    assert result["content"]["frame_count"] == 4
+    assert result["content"]["frame_budget_retries"] == 2
 
 
 def test_cli_generate_evaluate_summarize_flow(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys):

--- a/tests/e2e/features/fullduplex/test_omni_duplex_eval_cli.py
+++ b/tests/e2e/features/fullduplex/test_omni_duplex_eval_cli.py
@@ -9,15 +9,11 @@ import json
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
-import requests
 
-from vllm_omni.benchmarks.duplex import omni_duplex_eval_eval as eval_mod
 from vllm_omni.benchmarks.duplex import omni_duplex_eval_runner as runner
 from vllm_omni.benchmarks.duplex.omni_duplex_eval_dataset import DuplexSample
-from vllm_omni.benchmarks.duplex.omni_duplex_eval_eval import _judge_content_with_frame_budget
 from vllm_omni.benchmarks.duplex.omni_duplex_eval_judge import DuplexJudge
 from vllm_omni.entrypoints.cli.benchmark import omni_duplex_eval as cli
 from vllm_omni.entrypoints.cli.benchmark.omni_duplex_eval import OmniDuplexEvalSubcommand
@@ -25,78 +21,31 @@ from vllm_omni.entrypoints.cli.benchmark.omni_duplex_eval import OmniDuplexEvalS
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.benchmark]
 
 
-def _judge_http_error(text: str) -> requests.HTTPError:
-    response = requests.Response()
-    response.status_code = 500
-    response._content = text.encode()
-    return requests.HTTPError("500 response from judge", response=response)
+@pytest.mark.parametrize("policy", [None, "error", "reduce"])
+def test_cli_forwards_explicit_frame_overflow_policy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, policy):
+    parser = argparse.ArgumentParser()
+    OmniDuplexEvalSubcommand.add_cli_args(parser)
+    argv = [
+        "evaluate",
+        "--response-root",
+        str(tmp_path / "responses"),
+        "--score-root",
+        str(tmp_path / "scores"),
+        "--judge-model",
+        "fixture-judge",
+    ]
+    if policy is not None:
+        argv.extend(["--judge-frame-overflow", policy])
+    sample = DuplexSample("sample", "RTD_OCR", "rtd", None, tmp_path / "video.mp4")
+    monkeypatch.setattr(cli, "load_samples", lambda *args, **kwargs: [sample])
+    observed = []
 
+    def evaluate(*args, **kwargs):
+        observed.append(kwargs["judge_frame_overflow"])
 
-def test_frame_sample_judge_degrades_only_for_prompt_length_errors():
-    calls = []
-
-    class Judge:
-        def content(self, prompt, video, frames, *, mode):
-            calls.append(list(frames))
-            if len(frames) > 4:
-                raise _judge_http_error(
-                    "The decoder prompt (length 93016) is longer than the maximum model length of 65536"
-                )
-            return '{"content_score": 4}'
-
-    result, used_frames, retries = _judge_content_with_frame_budget(
-        Judge(), "prompt", Path("video.mp4"), list(range(16)), mode="frame-sample"
-    )
-
-    assert result == '{"content_score": 4}'
-    assert used_frames == [0, 5, 10, 15]
-    assert retries == 2
-    assert [len(frames) for frames in calls] == [16, 8, 4]
-
-
-def test_frame_sample_judge_does_not_hide_unrelated_http_errors():
-    class Judge:
-        def content(self, prompt, video, frames, *, mode):
-            raise _judge_http_error("Internal model worker failure")
-
-    with pytest.raises(requests.HTTPError, match="500 response from judge"):
-        _judge_content_with_frame_budget(Judge(), "prompt", Path("video.mp4"), [b"a", b"b"], mode="frame-sample")
-
-
-def test_evaluate_records_frame_budget_degradation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    response_path = tmp_path / "sample.json"
-    response_path.write_text("[]", encoding="utf-8")
-    response_path.with_name("sample.meta.json").write_text('{"clock": "media"}', encoding="utf-8")
-    score_path = tmp_path / "score.json"
-    sample = SimpleNamespace(
-        id="sample",
-        family="rtd",
-        task_type="content",
-        video="video.mp4",
-        video_duration=30.0,
-        question_text="question",
-        answer1="a1",
-        answer2="a2",
-    )
-    monkeypatch.setattr(eval_mod, "materialize_media", lambda *args, **kwargs: Path("video.mp4"))
-    monkeypatch.setattr(eval_mod, "_content_frame_times", lambda duration: list(range(16)))
-    monkeypatch.setattr(eval_mod, "_extract_frames", lambda path, timestamps: [bytes([i]) for i in timestamps])
-
-    class Judge:
-        model = "judge"
-
-        def content(self, prompt, video, frames, *, mode):
-            if len(frames) > 4:
-                raise _judge_http_error(
-                    "The decoder prompt (length 93016) is longer than the maximum model length of 65536"
-                )
-            return '{"content_score": 4}'
-
-    result = eval_mod.evaluate_sample(sample, response_path, score_path, Judge(), judge_video_mode="frame-sample")
-    assert result["content"]["content_score"] == 4
-    assert result["content"]["frame_count_initial"] == 16
-    assert result["content"]["frame_count"] == 4
-    assert result["content"]["frame_budget_retries"] == 2
+    monkeypatch.setattr(cli, "evaluate_sample", evaluate)
+    OmniDuplexEvalSubcommand.cmd(parser.parse_args(argv))
+    assert observed == [policy or "error"]
 
 
 def test_cli_generate_evaluate_summarize_flow(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys):

--- a/vllm_omni/benchmarks/duplex/omni_duplex_eval_eval.py
+++ b/vllm_omni/benchmarks/duplex/omni_duplex_eval_eval.py
@@ -6,9 +6,12 @@
 from __future__ import annotations
 
 import json
+import logging
 import subprocess
+from collections.abc import Callable
+from functools import partial
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 
 import requests
 
@@ -43,6 +46,7 @@ def _text(items: list[dict[str, Any]]) -> str:
 
 
 _T = TypeVar("_T")
+logger = logging.getLogger(__name__)
 
 
 def _uniform_subsample(values: list[_T], count: int) -> list[_T]:
@@ -56,37 +60,52 @@ def _uniform_subsample(values: list[_T], count: int) -> list[_T]:
 
 def _is_prompt_too_long_error(exc: requests.HTTPError) -> bool:
     response = exc.response
-    text = response.text if response is not None else str(exc)
-    normalized = text.lower()
+    if response is None or response.status_code not in (400, 500):
+        return False
+    try:
+        payload = response.json()
+    except ValueError:
+        message = response.text
+    else:
+        error = payload.get("error") if isinstance(payload, dict) else None
+        if not isinstance(error, dict):
+            return False
+        if error.get("code") == "context_length_exceeded":
+            return True
+        message = error.get("message")
+        if not isinstance(message, str):
+            return False
+    normalized = message.lower()
     return "prompt" in normalized and "longer than the maximum model length" in normalized
 
 
-def _judge_content_with_frame_budget(
-    judge: DuplexJudge,
-    prompt: str,
-    video_path: str | Path,
+def _judge_frames_with_overflow_retry(
+    call: Callable[[list[bytes]], str],
     frames: list[bytes],
     *,
-    mode: str,
+    allow_reduction: bool,
 ) -> tuple[str, list[bytes], int]:
-    """Retry frame-sample judging with fewer representative frames on length overflow.
+    """Optionally retry an explicit context overflow with fewer original frames.
 
-    The judge owns the exact multimodal tokenization rules, so use its explicit
-    max-model-length rejection as the budget signal instead of hard-coding a
-    model-specific pixels-to-tokens approximation.
+    This is bounded failure recovery, not proactive token budgeting. A judge
+    rejection at one frame still propagates; no score or empty fallback is made.
     """
     original_frames = list(frames)
     used_frames = original_frames
     retries = 0
     while True:
         try:
-            return judge.content(prompt, video_path, frames=used_frames, mode=mode), used_frames, retries
+            return call(used_frames), used_frames, retries
         except requests.HTTPError as exc:
-            if mode != "frame-sample" or len(used_frames) <= 1 or not _is_prompt_too_long_error(exc):
+            if not allow_reduction or len(used_frames) <= 1 or not _is_prompt_too_long_error(exc):
                 raise
-            next_count = max(1, len(used_frames) // 2)
+            next_count = (len(used_frames) + 1) // 2
             used_frames = _uniform_subsample(original_frames, next_count)
             retries += 1
+            logger.warning(
+                "Judge context overflow; retrying with fewer uniformly selected frames",
+                extra={"initial_frame_count": len(original_frames), "frame_count": next_count, "retry": retries},
+            )
 
 
 def evaluate_sample(
@@ -97,9 +116,12 @@ def evaluate_sample(
     *,
     judge_fps: int = 2,
     judge_video_mode: str = "video_url",
+    judge_frame_overflow: Literal["error", "reduce"] = "error",
     window_size: float = 10.0,
     allow_invalid_clock: bool = False,
 ) -> dict[str, Any]:
+    if judge_frame_overflow not in ("error", "reduce"):
+        raise ValueError("judge_frame_overflow must be 'error' or 'reduce'")
     raw = _read(response_path)
     meta = (
         _read(response_path.with_name(response_path.stem + ".meta.json"))
@@ -116,6 +138,7 @@ def evaluate_sample(
         "response_meta": meta,
         "judge_model": getattr(judge, "model", None),
         "judge_video_mode": judge_video_mode,
+        "judge_frame_overflow": judge_frame_overflow,
     }
     if sample.family == "rtd":
         video_path = materialize_media(sample.video, score_path.parent / ".media", sample.id, ".mp4")
@@ -137,9 +160,12 @@ def evaluate_sample(
                 )
                 continue
             frames = _extract_frames(video_path, _times(*window, fps=judge_fps))
-            parsed = parse_judge_json(
-                judge.temporal(build_temporal_prompt(*window, item["sentence"], sample.question_text), frames)
+            temporal_response, used_frames, retries = _judge_frames_with_overflow_retry(
+                partial(judge.temporal, build_temporal_prompt(*window, item["sentence"], sample.question_text)),
+                frames,
+                allow_reduction=judge_frame_overflow == "reduce",
             )
+            parsed = parse_judge_json(temporal_response)
             temporal_rows.append(
                 {
                     **item,
@@ -150,24 +176,25 @@ def evaluate_sample(
                     "window_end": window[1],
                     "error": None,
                     **parsed,
+                    "frame_count_initial": len(frames),
+                    "frame_count": len(used_frames),
+                    "frame_budget_retries": retries,
                 }
             )
-        content_frames = None
+        content_prompt = build_content_prompt(_text(items), sample.question_text, [sample.answer1, sample.answer2])
         if judge_video_mode == "frame-sample":
             content_frames = _extract_frames(video_path, _content_frame_times(duration))
-        content_prompt = build_content_prompt(_text(items), sample.question_text, [sample.answer1, sample.answer2])
-        content_response, used_content_frames, frame_budget_retries = _judge_content_with_frame_budget(
-            judge,
-            content_prompt,
-            video_path,
-            content_frames or [],
-            mode=judge_video_mode,
-        )
-        content = parse_judge_json(content_response)
-        if content_frames is not None:
+            content_response, used_content_frames, retries = _judge_frames_with_overflow_retry(
+                partial(judge.content, content_prompt, video_path, mode=judge_video_mode),
+                content_frames,
+                allow_reduction=judge_frame_overflow == "reduce",
+            )
+            content = parse_judge_json(content_response)
             content["frame_count_initial"] = len(content_frames)
             content["frame_count"] = len(used_content_frames)
-            content["frame_budget_retries"] = frame_budget_retries
+            content["frame_budget_retries"] = retries
+        else:
+            content = parse_judge_json(judge.content(content_prompt, video_path, frames=None, mode=judge_video_mode))
         result.update(
             {
                 "temporal": {"sentences": temporal_rows, "summary": summarize_temporal_results(temporal_rows)},
@@ -284,6 +311,15 @@ def summarize_scores(score_root: str | Path) -> dict[str, Any]:
         result["rtd"] = {
             "mean_content_score": sum(item["content_score"] for item in rtd_temporal) / len(rtd_temporal),
             "mean_avg_temporal_score": sum(item["avg_temporal_score"] for item in rtd_temporal) / len(rtd_temporal),
+            "judge_frame_overflow_policies": sorted(
+                {row.get("judge_frame_overflow", "error") for row in rows if "temporal" in row}
+            ),
+            "frame_reduction_samples": sum(
+                row.get("content", {}).get("frame_budget_retries", 0) > 0
+                or any(item.get("frame_budget_retries", 0) > 0 for item in row["temporal"].get("sentences", []))
+                for row in rows
+                if "temporal" in row
+            ),
             "by_task": {
                 task: {
                     "mean_content_score": sum(item["content"] for item in values) / len(values),

--- a/vllm_omni/benchmarks/duplex/omni_duplex_eval_eval.py
+++ b/vllm_omni/benchmarks/duplex/omni_duplex_eval_eval.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
+
+import requests
 
 from .omni_duplex_eval_clock import normalize_response_items, validate_clock
 from .omni_duplex_eval_dataset import DuplexSample
@@ -38,6 +40,53 @@ def _write(path: Path, value: Any) -> None:
 
 def _text(items: list[dict[str, Any]]) -> str:
     return " ".join(str(item.get("sentence", item.get("text", ""))).strip() for item in items).strip()
+
+
+_T = TypeVar("_T")
+
+
+def _uniform_subsample(values: list[_T], count: int) -> list[_T]:
+    if count >= len(values):
+        return list(values)
+    if count <= 1:
+        return [values[len(values) // 2]]
+    stride = (len(values) - 1) / (count - 1)
+    return [values[round(i * stride)] for i in range(count)]
+
+
+def _is_prompt_too_long_error(exc: requests.HTTPError) -> bool:
+    response = exc.response
+    text = response.text if response is not None else str(exc)
+    normalized = text.lower()
+    return "prompt" in normalized and "longer than the maximum model length" in normalized
+
+
+def _judge_content_with_frame_budget(
+    judge: DuplexJudge,
+    prompt: str,
+    video_path: str | Path,
+    frames: list[bytes],
+    *,
+    mode: str,
+) -> tuple[str, list[bytes], int]:
+    """Retry frame-sample judging with fewer representative frames on length overflow.
+
+    The judge owns the exact multimodal tokenization rules, so use its explicit
+    max-model-length rejection as the budget signal instead of hard-coding a
+    model-specific pixels-to-tokens approximation.
+    """
+    original_frames = list(frames)
+    used_frames = original_frames
+    retries = 0
+    while True:
+        try:
+            return judge.content(prompt, video_path, frames=used_frames, mode=mode), used_frames, retries
+        except requests.HTTPError as exc:
+            if mode != "frame-sample" or len(used_frames) <= 1 or not _is_prompt_too_long_error(exc):
+                raise
+            next_count = max(1, len(used_frames) // 2)
+            used_frames = _uniform_subsample(original_frames, next_count)
+            retries += 1
 
 
 def evaluate_sample(
@@ -106,16 +155,19 @@ def evaluate_sample(
         content_frames = None
         if judge_video_mode == "frame-sample":
             content_frames = _extract_frames(video_path, _content_frame_times(duration))
-        content = parse_judge_json(
-            judge.content(
-                build_content_prompt(_text(items), sample.question_text, [sample.answer1, sample.answer2]),
-                video_path,
-                frames=content_frames,
-                mode=judge_video_mode,
-            )
+        content_prompt = build_content_prompt(_text(items), sample.question_text, [sample.answer1, sample.answer2])
+        content_response, used_content_frames, frame_budget_retries = _judge_content_with_frame_budget(
+            judge,
+            content_prompt,
+            video_path,
+            content_frames or [],
+            mode=judge_video_mode,
         )
+        content = parse_judge_json(content_response)
         if content_frames is not None:
-            content["frame_count"] = len(content_frames)
+            content["frame_count_initial"] = len(content_frames)
+            content["frame_count"] = len(used_content_frames)
+            content["frame_budget_retries"] = frame_budget_retries
         result.update(
             {
                 "temporal": {"sentences": temporal_rows, "summary": summarize_temporal_results(temporal_rows)},

--- a/vllm_omni/entrypoints/cli/benchmark/omni_duplex_eval.py
+++ b/vllm_omni/entrypoints/cli/benchmark/omni_duplex_eval.py
@@ -45,6 +45,12 @@ def add_cli_args(parser: argparse.ArgumentParser) -> None:
     evaluate.add_argument("--judge-model", required=True)
     evaluate.add_argument("--judge-api-key", default="EMPTY")
     evaluate.add_argument("--judge-video-mode", choices=("video_url", "frame-sample"), default="video_url")
+    evaluate.add_argument(
+        "--judge-frame-overflow",
+        choices=("error", "reduce"),
+        default="error",
+        help="On explicit judge context overflow: fail (default), or retry image-frame calls with fewer frames.",
+    )
     evaluate.add_argument("--judge-fps", type=int, default=2)
     evaluate.add_argument("--window-size", type=float, default=10.0)
     evaluate.add_argument("--allow-invalid-clock", action="store_true")
@@ -110,6 +116,7 @@ def run(args: argparse.Namespace) -> int:
             judge,
             judge_fps=args.judge_fps,
             judge_video_mode=args.judge_video_mode,
+            judge_frame_overflow=args.judge_frame_overflow,
             window_size=args.window_size,
             allow_invalid_clock=args.allow_invalid_clock,
         )


### PR DESCRIPTION
## Purpose

Addresses the context-overflow failure reported in #7375 for image-frame judging. Covers both temporal and frame-sampled content evaluation; no model-specific pixel-to-token formula is assumed.

This is bounded recovery after an explicit judge context-length error, not proactive token budgeting:

- `--judge-frame-overflow error` is the default: preserve the requested frames and propagate failure.
- `--judge-frame-overflow reduce` opts in to retrying failed image-frame calls with fewer uniformly selected original frames (for example, 16 -> 8 -> 4). Keep both endpoints while at least two frames remain and use the middle original frame at one frame. If that still fails, propagate the error; never fabricate a score or send an empty fallback.
- Retry only recognized context errors on HTTP 400/500. Authentication, rate limits, gateway errors, unrelated model failures, transport timeouts and connection errors are not swallowed.
- Record the selected policy, initial/final frame counts and retries in scores, and count reduced samples/policies in summaries. The documentation warns that reduced inputs can change scores and should not be treated as protocol-equivalent benchmark results.
- The content `video_url` path is unchanged. Temporal image-frame requests use the explicit policy independently.

The signed follow-up `623fbbb1b096ef4921e0bb40f4d878310e507031` is appended to `8d284c2a134fd4c68b587548aa4b109d44e6cb2b` without rewriting history. It replaces the initial content-only recovery with the shared opt-in policy. This remains a draft while the revised evaluation policy and new checks receive review.

## Test Plan

**vLLM-Omni base:** `627630d7e4725d94c84b64e9996f97bdec2044fe` (parent of the original PR commit).  
**vLLM version:** 0.28.0 in the local CPU test environment.  
**Environment:** WSL Linux, Python 3.12.3, PyTorch 2.11.0+cpu, pytest 9.1.1, requests 2.34.2.

In a compatible repository environment:

```bash
python -m pytest tests/benchmarks/duplex/test_omni_duplex_eval_frame_budget.py \
  -m 'core_model and cpu' --run-level=core_model -q
python -m pytest tests/e2e/features/fullduplex/test_omni_duplex_eval_cli.py \
  -m 'core_model and cpu' --run-level=core_model -q
```

Local execution used the existing NVML-discovery-only adapter for CPU PyTorch. The CLI-leaf run additionally bypassed the unrelated top-level CLI initializer because it is incompatible with the installed vLLM environment. The real benchmark command, evaluator, judge, fixtures and tests still ran. These adapters are not included in this patch and this is not a full top-level CLI/server validation.

## Test Result

Freshly rerun on the unchanged signed follow-up:

- **34 passed** in the new core benchmark module: error classification, bounded retries, default behavior, input selection, score/summary metadata and production judge HTTP requests.
- **6 passed** in the CLI-leaf module, with the adapter limitation above.
- All applicable changed-file pre-commit hooks and `git diff --check` passed.

Retained development controls on the same file tree:

- Initial classifier tests on the old signed implementation: **10 failures / 2 passes**.
- The original PR version fails on the temporal 16-frame request. The revised opt-in version completes temporal and content calls with observed counts **[16, 8, 4, 16, 8, 4]**.
- HTTP tests use real requests and 3734x2100 JPEG payloads, but the localhost server returns deterministic scores. It is not a real judge model or tokenizer, and media extraction is a controlled fixture.

No real-model/GPU evaluation, full-dataset scoring, proactive context-fit guarantee or unchanged-score claim is made. Build/lint/DCO success must not be interpreted as end-to-end model validation.

AI assistance: ChatGPT assisted with implementation, tests, validation, and PR drafting.
