### PR TITLE
[Frontend] Extract shared Realtime protocol for RFC #6592 P0a

### DIFF
--- a/docs/design/feature/realtime_protocol.md
+++ b/docs/design/feature/realtime_protocol.md
@@ -1,0 +1,77 @@
+# Shared Realtime protocol extraction
+
+This is the behavior-preserving extraction portion of
+[RFC #6592 P0a](https://github.com/vllm-project/vllm-omni/issues/6592), preparing
+the shared codec needed by [RFC #7223](https://github.com/vllm-project/vllm-omni/issues/7223).
+It does not add Qwen Realtime support or require the runtime redesign in
+[#7181](https://github.com/vllm-project/vllm-omni/issues/7181).
+
+## Boundary
+
+`entrypoints/realtime/` owns wire validation, session defaults, conversation
+item projection, audio-format conversion, and response event serialization.
+`RealtimeSessionState` remains the same wire-only state object; it does not
+replace `DuplexSession` or own engine resources.
+
+| Module | Responsibility |
+| --- | --- |
+| `session.py` | Compose input/output codecs; preserve input and output ordering |
+| `input.py` | Decode session, conversation, audio-buffer, and response events into existing internal intents |
+| `output.py` | Project internal output into Realtime events, including response/item identity and terminal events |
+| `state.py` | Per-connection wire state and response projection records |
+| `audio.py` | Audio formats and sample-rate conversion |
+| `config.py` | Turn-detection configuration validation and existing native opt-in aliases |
+| `runner.py`, `adapters/base.py` | Supply a connection-local codec to a `RealtimeModelAdapter` |
+
+The adapter owns session execution. The existing `OmniDuplexSessionHandler`
+implements `RealtimeModelAdapter.handle_session` structurally and remains the
+first consumer, using the deployment-selected `ServingRuntimeAdapter` for
+MiniCPM or another supported duplex model. Admission, model input submission,
+response creation, cancellation, and cleanup still run through its existing
+ordered mailbox. The native route `/v1/duplex` is unchanged.
+
+The shared package has no dependency on a duplex handler, engine control plane,
+model implementation, or the OpenAI API server. Existing private names such as
+`_to_duplex_event` describe the inherited internal event vocabulary; they do not
+require a consumer to use the duplex runtime.
+
+## Deliberate limits of this draft boundary
+
+The RFC sketches `entrypoints/openai/realtime/`. The current
+`entrypoints/openai/__init__.py` eagerly imports the API server, which imports
+duplex serving. Putting a codec used by duplex under that package would create
+an import cycle. A sibling `entrypoints/realtime/` keeps the dependency one-way
+without changing server initialization or its package exports.
+
+The RFC also sketches per-operation `build_prompt`, `start_response`, `cancel`,
+and `supports` methods. This extraction does **not** pretend that native duplex
+can be reduced to one `generate()` call per response: model-owned LISTEN/SPEAK
+and continuous append remain in its existing execution owner. The draft uses
+the session-level adapter entry point actually consumed by that owner. A
+turn-based Qwen adapter and any finer-grained shared execution interface remain
+P0b work; this is not a claim that the whole RFC or its proposed adapter API is
+implemented.
+
+## Compatibility and validation
+
+The old `entrypoints/duplex/realtime_session.py`, `realtime_state.py`, and
+`audio.py` paths re-export the same implementations, not copies.
+`NativeRealtimeSessionProtocol` is an alias of `RealtimeSessionProtocol`.
+Existing duplex tests keep their imports and wire assertions unchanged.
+The input/output implementation mixins move without unused compatibility
+modules. Server VAD execution stays under duplex; only its pure configuration
+parser moves. Audio conversion uses the repository-required `pybase64` API
+after extraction.
+
+The extraction deliberately keeps existing defaults, compatibility aliases,
+native extensions (including `video_frames`), update barriers, response
+identity, and completion ordering. It does not claim blanket OpenAI GA
+conformance, add a profile selector, change the legacy Qwen STT route, or add
+video handling for Qwen.
+
+Focused CPU coverage includes old-path identity, connection isolation, adapter
+failure/cancellation propagation, and an isolated import-boundary check.
+The existing duplex protocol, handler, server VAD, and audio suites are the
+wire-behavior regression gate. Real MiniCPM and PersonaPlex session tests remain
+required before declaring the extraction ready to merge; static checks alone
+do not establish runtime compatibility.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -19,6 +19,7 @@ implementation contract; it is not, by itself, a general support claim.
 
 - [Full-Duplex Runtime (MiniCPM-o 4.5)](fullduplex.md)
 - [Full-Duplex Runtime (PersonaPlex)](fullduplex-personaplex.md)
+- [Shared Realtime Protocol Extraction](feature/realtime_protocol.md)
 - [Disaggregated Inference](feature/disaggregated_inference.md)
 - [Host Weight Runtime](feature/host_weight_runtime.md)
 - [Async Chunk](feature/async_chunk.md)

--- a/tests/engine/test_duplex_import_boundary.py
+++ b/tests/engine/test_duplex_import_boundary.py
@@ -45,6 +45,28 @@ def test_isolated_import_ignores_conflicting_gpu_visibility(monkeypatch: pytest.
     _assert_isolated_import_succeeds("import vllm_omni.outputs")
 
 
+def test_shared_realtime_codec_does_not_import_duplex_runtime_or_api_server() -> None:
+    _assert_isolated_import_succeeds("""
+import sys
+
+# The root package already imports the lazy model registry via OmniModelConfig.
+# Check dependencies added by the shared codec, not existing package setup.
+import vllm_omni
+
+before = set(sys.modules)
+import vllm_omni.entrypoints.realtime.runner
+
+forbidden = (
+    "vllm_omni.entrypoints.duplex",
+    "vllm_omni.entrypoints.openai",
+    "vllm_omni.engine.duplex",
+    "vllm_omni.model_executor.models",
+)
+loaded = sorted(name for name in sys.modules.keys() - before if name.startswith(forbidden))
+assert not loaded, loaded
+""")
+
+
 def test_stable_engine_imports_load_duplex_kernel_eagerly() -> None:
     # The duplex kernel is imported eagerly by the stable engine modules.
     # Model-specific duplex adapters must still load only via the

--- a/tests/entrypoints/realtime/test_protocol.py
+++ b/tests/entrypoints/realtime/test_protocol.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+import asyncio
+
+import pytest
+from fastapi import WebSocket
+from starlette.datastructures import QueryParams
+
+from vllm_omni.entrypoints.duplex.realtime_session import NativeRealtimeSessionProtocol
+from vllm_omni.entrypoints.duplex.realtime_state import RealtimeSessionState as LegacySessionState
+from vllm_omni.entrypoints.duplex.server_vad import ServerVADConfig as LegacyVADConfig
+from vllm_omni.entrypoints.realtime.adapters.base import RealtimeModelAdapter
+from vllm_omni.entrypoints.realtime.config import ServerVADConfig
+from vllm_omni.entrypoints.realtime.runner import run_realtime_session
+from vllm_omni.entrypoints.realtime.session import RealtimeSessionProtocol
+from vllm_omni.entrypoints.realtime.state import RealtimeSessionState
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_legacy_imports_share_the_same_implementation() -> None:
+    # Existing duplex suites keep their imports and assertions unchanged.
+    assert NativeRealtimeSessionProtocol is RealtimeSessionProtocol
+    assert LegacySessionState is RealtimeSessionState
+    assert LegacyVADConfig is ServerVADConfig
+
+
+@pytest.mark.asyncio
+async def test_runner_passes_a_connection_local_codec_to_the_adapter(mocker) -> None:
+    websocket = mocker.Mock(spec=WebSocket)
+    websocket.query_params = QueryParams("model=test-model&session_id=example")
+    adapter = mocker.Mock(spec=RealtimeModelAdapter)
+    adapter.handle_session = mocker.AsyncMock()
+
+    await run_realtime_session(websocket, adapter)
+    await run_realtime_session(websocket, adapter)
+
+    calls = adapter.handle_session.await_args_list
+    assert len(calls) == 2
+    first = calls[0].kwargs["realtime_protocol"]
+    second = calls[1].kwargs["realtime_protocol"]
+    assert calls[0].args == calls[1].args == (websocket,)
+    assert isinstance(first, RealtimeSessionProtocol)
+    assert first is not second
+    assert first._state is not second._state
+    assert first._default_session_payload() == {"model": "test-model", "session_id": "example"}
+    first._conversation_items["item-a"] = {"id": "item-a"}
+    assert not second._conversation_items
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_type", [RuntimeError, asyncio.CancelledError])
+async def test_runner_preserves_adapter_failure_and_cancellation(mocker, error_type) -> None:
+    websocket = mocker.Mock(spec=WebSocket)
+    websocket.query_params = QueryParams()
+    adapter = mocker.Mock(spec=RealtimeModelAdapter)
+    error = error_type("adapter stopped")
+    adapter.handle_session = mocker.AsyncMock(side_effect=error)
+
+    with pytest.raises(error_type) as caught:
+        await run_realtime_session(websocket, adapter)
+
+    assert caught.value is error
+    adapter.handle_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_shared_codec_keeps_response_create_and_cancel_as_execution_intents() -> None:
+    protocol = RealtimeSessionProtocol({})
+    options = {"instructions": "hello", "output_modalities": ["audio"]}
+    create = await protocol._to_duplex_event({"type": "response.create", "response": options})
+    assert create == {"type": "response.create", "response": options}
+    # Decoding an intent does not itself begin a model response.
+    assert protocol._active_response_id is None
+
+    projected = protocol.encode_outbound_event({"type": "response.created", "response_id": "response-a"})
+    assert projected[0]["type"] == "response.created"
+    cancel = await protocol._to_duplex_event({"type": "response.cancel"})
+    assert cancel == {"type": "response.cancel", "reason": "response.cancel", "response_id": "response-a"}
+
+
+def test_shared_codec_preserves_native_opt_in_alias_precedence() -> None:
+    protocol = RealtimeSessionProtocol({})
+    command = protocol._session_create_from_realtime(
+        {
+            "model": "test-model",
+            "extra_body": {"native_duplex": False, "minicpmo45_native_duplex": True},
+        }
+    )
+    extra = command["session"]["extra_body"]
+    assert extra["native_duplex"] is False
+    assert "minicpmo45_native_duplex" not in extra

--- a/vllm_omni/entrypoints/duplex/audio.py
+++ b/vllm_omni/entrypoints/duplex/audio.py
@@ -1,220 +1,41 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
-from __future__ import annotations
+"""Compatibility imports for the shared Realtime codec."""
 
-import base64
-import binascii
-import io
-import math
-import wave
-
-import numpy as np
-
-try:
-    from audioop import alaw2lin, lin2alaw, lin2ulaw, ulaw2lin
-except ImportError:  # pragma: no cover - audioop is removed in newer Python.
-    alaw2lin = lin2alaw = lin2ulaw = ulaw2lin = None
-
-
-MIN_INPUT_SAMPLE_RATE_HZ = 8_000
-MAX_INPUT_SAMPLE_RATE_HZ = 192_000
-
-
-def validate_input_sample_rate_hz(sample_rate_hz: object) -> int:
-    if (
-        isinstance(sample_rate_hz, bool)
-        or not isinstance(sample_rate_hz, int | float)
-        or (isinstance(sample_rate_hz, float) and not math.isfinite(sample_rate_hz))
-    ):
-        raise ValueError("sample_rate_hz must be a finite integer")
-    rate = int(sample_rate_hz)
-    if rate != sample_rate_hz:
-        raise ValueError("sample_rate_hz must be an integer")
-    if not MIN_INPUT_SAMPLE_RATE_HZ <= rate <= MAX_INPUT_SAMPLE_RATE_HZ:
-        raise ValueError(f"sample_rate_hz must be between {MIN_INPUT_SAMPLE_RATE_HZ} and {MAX_INPUT_SAMPLE_RATE_HZ}")
-    return rate
-
-
-def resample_pcm16_mono(raw: bytes, *, source_rate_hz: int, target_rate_hz: int) -> bytes:
-    if source_rate_hz <= 0 or target_rate_hz <= 0 or source_rate_hz == target_rate_hz:
-        return raw
-    # Import lazily so the generic Duplex audio module does not pull in the
-    # OpenAI API server while the Duplex stack itself is being imported.
-    from vllm_omni.entrypoints.openai.audio_utils_mixin import StreamingAudioResampler
-
-    samples = np.frombuffer(raw, dtype="<i2")
-    rate_gcd = math.gcd(source_rate_hz, target_rate_hz)
-    reduced_factor = max(source_rate_hz // rate_gcd, target_rate_hz // rate_gcd)
-    if reduced_factor > StreamingAudioResampler._max_polyphase_factor:
-        # The FIR size scales with the reduced ratio. Keep unusual client
-        # rates bounded while common audio rates use the high-quality path.
-        if samples.size <= 1:
-            return raw
-        target_size = max(1, int(round(samples.size * target_rate_hz / source_rate_hz)))
-        source_x = np.linspace(0.0, 1.0, num=samples.size, endpoint=True)
-        target_x = np.linspace(0.0, 1.0, num=target_size, endpoint=True)
-        resampled = np.interp(target_x, source_x, samples)
-        return np.clip(resampled, -32_768, 32_767).astype("<i2").tobytes()
-    resampler = StreamingAudioResampler(source_rate_hz, target_rate_hz)
-    normalized = samples.astype(np.float32) * np.float32(1.0 / 32768.0)
-    resampled = resampler.process(normalized, final=True)
-    return np.clip(np.rint(resampled * 32768.0), -32768, 32767).astype("<i2").tobytes()
-
-
-def decode_g711_ulaw(raw: bytes) -> bytes:
-    if ulaw2lin is not None:
-        return ulaw2lin(raw, 2)
-    data = np.frombuffer(raw, dtype=np.uint8)
-    value = np.bitwise_not(data).astype(np.int16)
-    sign = value & 0x80
-    exponent = (value >> 4) & 0x07
-    mantissa = value & 0x0F
-    sample = ((mantissa << 3) + 0x84) << exponent
-    return np.where(sign != 0, -(sample - 0x84), sample - 0x84).astype("<i2").tobytes()
-
-
-def decode_g711_alaw(raw: bytes) -> bytes:
-    if alaw2lin is not None:
-        return alaw2lin(raw, 2)
-    data = np.bitwise_xor(np.frombuffer(raw, dtype=np.uint8), 0x55).astype(np.int16)
-    sign = data & 0x80
-    exponent = (data >> 4) & 0x07
-    mantissa = data & 0x0F
-    sample = np.where(exponent == 0, (mantissa << 4) + 8, ((mantissa << 4) + 0x108) << (exponent - 1))
-    return np.where(sign != 0, sample, -sample).astype("<i2").tobytes()
-
-
-def encode_g711_ulaw(raw: bytes) -> bytes:
-    if lin2ulaw is not None:
-        return lin2ulaw(raw, 2)
-    pcm = np.clip(np.frombuffer(raw, dtype="<i2").astype(np.int32), -32635, 32635)
-    sign = np.where(pcm < 0, 0x80, 0)
-    magnitude = np.abs(pcm) + 0x84
-    exponent = np.zeros_like(magnitude)
-    for exp in range(7):
-        exponent = np.where(magnitude > (0xFF << exp), exp + 1, exponent)
-    mantissa = (magnitude >> (exponent + 3)) & 0x0F
-    return (np.bitwise_not(sign | (exponent << 4) | mantissa) & 0xFF).astype(np.uint8).tobytes()
-
-
-def encode_g711_alaw(raw: bytes) -> bytes:
-    if lin2alaw is not None:
-        return lin2alaw(raw, 2)
-    pcm = np.frombuffer(raw, dtype="<i2").astype(np.int32)
-    sign = np.where(pcm >= 0, 0x80, 0x00)
-    magnitude = np.abs(pcm)
-    exponent = np.zeros_like(magnitude)
-    for exp in range(1, 8):
-        exponent = np.where(magnitude >= (1 << (exp + 7)), exp, exponent)
-    mantissa = np.where(
-        exponent == 0,
-        (magnitude >> 4) & 0x0F,
-        (magnitude >> (exponent + 3)) & 0x0F,
-    )
-    return ((sign | (exponent << 4) | mantissa) ^ 0x55).astype(np.uint8).tobytes()
-
-
-def wav_payload_to_pcm16(raw: bytes) -> tuple[bytes | None, int | None]:
-    try:
-        with wave.open(io.BytesIO(raw), "rb") as wav_file:
-            channels = wav_file.getnchannels()
-            sample_width = wav_file.getsampwidth()
-            sample_rate_hz = wav_file.getframerate()
-            frames = wav_file.readframes(wav_file.getnframes())
-        if sample_width != 2:
-            return None, sample_rate_hz
-        if channels <= 1:
-            return frames, sample_rate_hz
-        pcm = np.frombuffer(frames, dtype="<i2").reshape(-1, channels)
-        mono = np.mean(pcm.astype(np.float32), axis=1)
-        return np.clip(mono, -32768, 32767).astype("<i2").tobytes(), sample_rate_hz
-    except (EOFError, ValueError, wave.Error):
-        return None, None
-
-
-def encode_float32_mono_wav_base64(
-    samples: np.ndarray,
-    *,
-    sample_rate_hz: int,
-) -> str:
-    """Package normalized mono float32 samples as a PCM16 WAV data payload."""
-    rate = validate_input_sample_rate_hz(sample_rate_hz)
-    normalized = np.ascontiguousarray(samples, dtype=np.float32).reshape(-1)
-    pcm16 = np.clip(np.rint(normalized * 32768.0), -32768, 32767).astype("<i2")
-    with io.BytesIO() as buffer:
-        with wave.open(buffer, "wb") as wav_file:
-            wav_file.setnchannels(1)
-            wav_file.setsampwidth(2)
-            wav_file.setframerate(rate)
-            wav_file.writeframes(pcm16.tobytes())
-        return base64.b64encode(buffer.getvalue()).decode("ascii")
-
-
-def convert_input_audio_with_rate(
-    audio: object,
-    fmt: object,
-    *,
-    sample_rate_hz: int | float | None = None,
-    target_sample_rate_hz: int = 16_000,
-) -> tuple[object, object, int | float | None]:
-    if not isinstance(audio, str) or not isinstance(fmt, str):
-        return audio, fmt, sample_rate_hz
-    normalized = fmt.lower()
-    if normalized not in {"pcm16", "pcm_s16le", "s16le", "g711_ulaw", "g711_alaw"}:
-        return audio, fmt, sample_rate_hz
-    if isinstance(sample_rate_hz, int | float):
-        sample_rate_hz = validate_input_sample_rate_hz(sample_rate_hz)
-    try:
-        raw = base64.b64decode(audio.strip(), validate=False)
-    except (binascii.Error, ValueError):
-        return audio, fmt, sample_rate_hz
-    if normalized == "g711_ulaw":
-        raw = decode_g711_ulaw(raw)
-        sample_rate_hz = sample_rate_hz if isinstance(sample_rate_hz, int | float) else 8_000
-    elif normalized == "g711_alaw":
-        raw = decode_g711_alaw(raw)
-        sample_rate_hz = sample_rate_hz if isinstance(sample_rate_hz, int | float) else 8_000
-    elif len(raw) % 2:
-        return audio, fmt, sample_rate_hz
-    if isinstance(sample_rate_hz, int | float) and int(sample_rate_hz) != target_sample_rate_hz:
-        raw = resample_pcm16_mono(
-            raw,
-            source_rate_hz=int(sample_rate_hz),
-            target_rate_hz=target_sample_rate_hz,
-        )
-        sample_rate_hz = target_sample_rate_hz
-    pcm = np.frombuffer(raw, dtype="<i2").astype(np.float32) / 32768.0
-    encoded = base64.b64encode(np.ascontiguousarray(pcm, dtype="<f4").tobytes()).decode("ascii")
-    return encoded, "pcm_f32le", sample_rate_hz
-
-
-def convert_output_audio(
-    audio: str,
-    *,
-    source_fmt: str,
-    target_fmt: str,
-    source_sample_rate_hz: int | None = None,
-    target_sample_rate_hz: int | None = None,
-) -> tuple[str, str, int | None]:
-    target = target_fmt.lower()
-    if target not in {"g711_ulaw", "g711_alaw"}:
-        return audio, source_fmt, source_sample_rate_hz
-    try:
-        raw = base64.b64decode(audio, validate=False)
-    except (binascii.Error, ValueError):
-        return audio, source_fmt, source_sample_rate_hz
-    source = source_fmt.lower()
-    if source == "wav":
-        pcm_raw, wav_rate = wav_payload_to_pcm16(raw)
-        if pcm_raw is None:
-            return audio, source_fmt, source_sample_rate_hz
-        raw = pcm_raw
-        source_sample_rate_hz = source_sample_rate_hz or wav_rate
-    elif source not in {"pcm", "pcm16", "pcm_s16le", "s16le"} or len(raw) % 2:
-        return audio, source_fmt, source_sample_rate_hz
-    target_rate = target_sample_rate_hz or 8_000
-    if source_sample_rate_hz is not None:
-        raw = resample_pcm16_mono(raw, source_rate_hz=source_sample_rate_hz, target_rate_hz=target_rate)
-    encoded = encode_g711_ulaw(raw) if target == "g711_ulaw" else encode_g711_alaw(raw)
-    return base64.b64encode(encoded).decode("ascii"), target, target_rate
+from vllm_omni.entrypoints.realtime.audio import (
+    MAX_INPUT_SAMPLE_RATE_HZ as MAX_INPUT_SAMPLE_RATE_HZ,
+)
+from vllm_omni.entrypoints.realtime.audio import (
+    MIN_INPUT_SAMPLE_RATE_HZ as MIN_INPUT_SAMPLE_RATE_HZ,
+)
+from vllm_omni.entrypoints.realtime.audio import (
+    convert_input_audio_with_rate as convert_input_audio_with_rate,
+)
+from vllm_omni.entrypoints.realtime.audio import (
+    convert_output_audio as convert_output_audio,
+)
+from vllm_omni.entrypoints.realtime.audio import (
+    decode_g711_alaw as decode_g711_alaw,
+)
+from vllm_omni.entrypoints.realtime.audio import (
+    decode_g711_ulaw as decode_g711_ulaw,
+)
+from vllm_omni.entrypoints.realtime.audio import (
+    encode_float32_mono_wav_base64 as encode_float32_mono_wav_base64,
+)
+from vllm_omni.entrypoints.realtime.audio import (
+    encode_g711_alaw as encode_g711_alaw,
+)
+from vllm_omni.entrypoints.realtime.audio import (
+    encode_g711_ulaw as encode_g711_ulaw,
+)
+from vllm_omni.entrypoints.realtime.audio import (
+    resample_pcm16_mono as resample_pcm16_mono,
+)
+from vllm_omni.entrypoints.realtime.audio import (
+    validate_input_sample_rate_hz as validate_input_sample_rate_hz,
+)
+from vllm_omni.entrypoints.realtime.audio import (
+    wav_payload_to_pcm16 as wav_payload_to_pcm16,
+)

--- a/vllm_omni/entrypoints/duplex/protocol.py
+++ b/vllm_omni/entrypoints/duplex/protocol.py
@@ -12,12 +12,24 @@ from uuid import uuid4
 
 import numpy as np
 
-from vllm_omni.entrypoints.duplex.audio import (
+from vllm_omni.entrypoints.realtime.audio import (
     encode_float32_mono_wav_base64,
 )
-from vllm_omni.entrypoints.duplex.server_vad import (
+from vllm_omni.entrypoints.realtime.config import (
+    LEGACY_NATIVE_DUPLEX_KEY as LEGACY_NATIVE_DUPLEX_KEY,
+)
+from vllm_omni.entrypoints.realtime.config import (
+    NATIVE_DUPLEX_KEY as NATIVE_DUPLEX_KEY,
+)
+from vllm_omni.entrypoints.realtime.config import (
     ServerVADConfig,
     parse_session_turn_detection,
+)
+from vllm_omni.entrypoints.realtime.config import (
+    native_duplex_opt_in as native_duplex_opt_in,
+)
+from vllm_omni.entrypoints.realtime.config import (
+    normalize_native_duplex_key as normalize_native_duplex_key,
 )
 
 
@@ -35,30 +47,6 @@ class DuplexSessionState(str, Enum):
     OPEN = "open"
     CLOSING = "closing"
     CLOSED = "closed"
-
-
-# Canonical extra_body key for the per-session opt-in to a model-native
-# duplex runtime, plus the deprecated model-prefixed spelling it replaced.
-# Client payloads may still use the legacy key; it is folded into the
-# canonical one at ingestion so everything downstream (and every echo in
-# session.created/session.updated) sees only NATIVE_DUPLEX_KEY.
-NATIVE_DUPLEX_KEY = "native_duplex"
-LEGACY_NATIVE_DUPLEX_KEY = "minicpmo45_native_duplex"
-
-
-def normalize_native_duplex_key(extra_body: dict[str, object]) -> dict[str, object]:
-    """Fold the deprecated alias into the canonical key (canonical wins)."""
-    if LEGACY_NATIVE_DUPLEX_KEY in extra_body:
-        legacy = extra_body.pop(LEGACY_NATIVE_DUPLEX_KEY)
-        extra_body.setdefault(NATIVE_DUPLEX_KEY, legacy)
-    return extra_body
-
-
-def native_duplex_opt_in(extra_body: Mapping[str, object]) -> object:
-    """Read the opt-in flag, accepting the deprecated alias for raw dicts."""
-    if NATIVE_DUPLEX_KEY in extra_body:
-        return extra_body[NATIVE_DUPLEX_KEY]
-    return extra_body.get(LEGACY_NATIVE_DUPLEX_KEY)
 
 
 class DuplexTurnState(str, Enum):

--- a/vllm_omni/entrypoints/duplex/realtime_session.py
+++ b/vllm_omni/entrypoints/duplex/realtime_session.py
@@ -1,147 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
-from __future__ import annotations
+"""Compatibility imports for the shared Realtime codec."""
 
-import json
-from typing import Any
-from uuid import uuid4
-
-from fastapi import WebSocket
-
-from vllm_omni.entrypoints.duplex import realtime_state as _state
-from vllm_omni.entrypoints.duplex.realtime_input import (
-    RealtimeInputTranslator,
+from vllm_omni.entrypoints.realtime.session import (
+    REALTIME_ERROR_TYPES_BY_CODE as REALTIME_ERROR_TYPES_BY_CODE,
 )
-from vllm_omni.entrypoints.duplex.realtime_output import (
-    RealtimeOutputProjector,
+from vllm_omni.entrypoints.realtime.session import (
+    REALTIME_INPUT_AUDIO_FORMATS as REALTIME_INPUT_AUDIO_FORMATS,
 )
-
-REALTIME_ERROR_TYPES_BY_CODE = _state.REALTIME_ERROR_TYPES_BY_CODE
-REALTIME_INPUT_AUDIO_FORMATS = _state.REALTIME_INPUT_AUDIO_FORMATS
-REALTIME_OUTPUT_AUDIO_FORMATS = _state.REALTIME_OUTPUT_AUDIO_FORMATS
-RealtimeSessionState = _state.RealtimeSessionState
-_RealtimeResponseState = _state._RealtimeResponseState
-
-
-class NativeRealtimeSessionProtocol(
-    RealtimeInputTranslator,
-    RealtimeOutputProjector,
-    _state.RealtimeStateOwner,
-):
-    """Compatibility facade for one native Realtime protocol session.
-
-    Input translation, output projection, and mutable state have separate
-    owners. The facade retains the established import path and private helper
-    surface used by serving and protocol contract tests.
-    """
-
-    def __init__(self, query_params: Any) -> None:
-        self._state = RealtimeSessionState.from_query_params(query_params)
-
-    def bind_sender(self, send_realtime_json) -> None:
-        self._send_realtime_json = send_realtime_json
-
-    def bind_native_input_append(self, enabled: bool) -> None:
-        """Use the serving-selected input path, independent of interruption policy."""
-        self._native_input_append = enabled
-
-    def _default_session_payload(self) -> dict[str, object]:
-        payload: dict[str, object] = {
-            "model": self._default_model,
-            "session_id": self._default_session_id,
-        }
-        if self._default_extra_body:
-            payload["extra_body"] = dict(self._default_extra_body)
-        return payload
-
-    async def receive_internal_event_text(self, websocket: WebSocket) -> str:
-        if not self._pending_outbound.empty():
-            return json.dumps(await self._pending_outbound.get())
-        if not self._opened and not self._resume_only and not self._autostarted_default_session and self._default_model:
-            self._opened = True
-            self._autostarted_default_session = True
-            return json.dumps(self._session_create_from_realtime(self._default_session_payload()))
-        while True:
-            if not self._pending_outbound.empty():
-                return json.dumps(await self._pending_outbound.get())
-            await self.wait_for_realtime_turn_detection_update()
-            raw = await websocket.receive_text()
-            try:
-                event = json.loads(raw)
-            except json.JSONDecodeError:
-                return raw
-            if not isinstance(event, dict):
-                return raw
-            if not self._opened and event.get("type") == "session.resume":
-                self._opened = True
-                translated = await self._to_duplex_event(event)
-                if translated is None:
-                    if not self._pending_outbound.empty():
-                        return json.dumps(await self._pending_outbound.get())
-                    continue
-                return json.dumps(translated)
-            if not self._opened and self._resume_only:
-                translated = await self._to_duplex_event(event)
-                if translated is None:
-                    if not self._pending_outbound.empty():
-                        return json.dumps(await self._pending_outbound.get())
-                    continue
-                return json.dumps(translated)
-            if not self._opened and event.get("type") != "session.update":
-                self._opened = True
-                await self._pending_outbound.put(self._session_create_from_realtime(self._default_session_payload()))
-                translated = await self._to_duplex_event(event)
-                if translated is not None:
-                    await self._send_realtime_input_ack(event)
-                    await self._pending_outbound.put(translated)
-                return json.dumps(await self._pending_outbound.get())
-            translated = await self._to_duplex_event(event)
-            if translated is None:
-                if not self._pending_outbound.empty():
-                    return json.dumps(await self._pending_outbound.get())
-                continue
-            await self._send_realtime_input_ack(event)
-            return json.dumps(translated)
-
-    def encode_outbound_event(self, data: dict[str, Any]) -> list[dict[str, object]]:
-        payloads = self._from_duplex_event(data)
-        for payload in payloads:
-            self._attach_event_id(payload)
-        return payloads
-
-    @staticmethod
-    def _attach_event_id(payload: dict[str, object]) -> None:
-        payload.setdefault("event_id", f"event_{uuid4().hex}")
-
-    async def _send_realtime_payload(self, payload: dict[str, object]) -> None:
-        self._attach_event_id(payload)
-        if (
-            self._hold_realtime_output_until_session_created
-            and payload.get("type") != "error"
-            and payload.get("type") != "session.created"
-        ):
-            self._held_realtime_payloads.append(payload)
-            return
-        if self._send_realtime_json is None:
-            raise RuntimeError("Native Realtime sender is not bound")
-        await self._send_realtime_json(payload)
-
-    @staticmethod
-    def _realtime_error_payload(
-        code: str,
-        message: str,
-        *,
-        event_id: object | None = None,
-        param: object | None = None,
-    ) -> dict[str, object]:
-        error: dict[str, object] = {
-            "type": REALTIME_ERROR_TYPES_BY_CODE.get(code, "invalid_request_error"),
-            "code": code,
-            "message": message,
-        }
-        if isinstance(event_id, str) and event_id:
-            error["event_id"] = event_id
-        if isinstance(param, str) and param:
-            error["param"] = param
-        return {"type": "error", "error": error}
+from vllm_omni.entrypoints.realtime.session import (
+    REALTIME_OUTPUT_AUDIO_FORMATS as REALTIME_OUTPUT_AUDIO_FORMATS,
+)
+from vllm_omni.entrypoints.realtime.session import (
+    RealtimeSessionState as RealtimeSessionState,
+)
+from vllm_omni.entrypoints.realtime.session import (
+    _RealtimeResponseState as _RealtimeResponseState,
+)

--- a/vllm_omni/entrypoints/duplex/realtime_state.py
+++ b/vllm_omni/entrypoints/duplex/realtime_state.py
@@ -1,245 +1,35 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
-from __future__ import annotations
+"""Compatibility imports for the shared Realtime codec."""
 
-import asyncio
-from dataclasses import dataclass, field
-from typing import Any, Generic, TypeVar
-
-REALTIME_INPUT_AUDIO_FORMATS = {
-    "pcm16",
-    "pcm_s16le",
-    "s16le",
-    "pcm_f32le",
-    "g711_ulaw",
-    "g711_alaw",
-}
-REALTIME_OUTPUT_AUDIO_FORMATS = {
-    "pcm16",
-    "pcm_s16le",
-    "s16le",
-    "wav",
-    "pcm",
-    "g711_ulaw",
-    "g711_alaw",
-}
-REALTIME_PCM_DEFAULT_SAMPLE_RATE_HZ = 24_000
-REALTIME_PCM_F32_DEFAULT_SAMPLE_RATE_HZ = 16_000
-REALTIME_G711_DEFAULT_SAMPLE_RATE_HZ = 8_000
-
-_RealtimeProtocolConfig = tuple[str, int, str, int | None, float]
-_PendingTurnDetectionUpdate = tuple[
-    bool,
-    dict[str, object] | None,
-    asyncio.Event,
-    _RealtimeProtocolConfig,
-]
-
-
-def realtime_default_sample_rate_hz(fmt: object) -> int | None:
-    if not isinstance(fmt, str):
-        return None
-    normalized = fmt.lower()
-    if normalized in {"pcm16", "pcm_s16le", "s16le", "pcm", "audio/pcm"}:
-        return REALTIME_PCM_DEFAULT_SAMPLE_RATE_HZ
-    if normalized in {"pcm_f32le", "audio/pcm_f32le"}:
-        return REALTIME_PCM_F32_DEFAULT_SAMPLE_RATE_HZ
-    if normalized in {"g711_ulaw", "g711_alaw", "audio/g711_ulaw", "audio/g711_alaw"}:
-        return REALTIME_G711_DEFAULT_SAMPLE_RATE_HZ
-    return None
-
-
-REALTIME_ERROR_TYPES_BY_CODE = {
-    "bad_event": "invalid_request_error",
-    "bad_audio": "invalid_request_error",
-    "config_timeout": "invalid_request_error",
-    "invalid_json": "invalid_request_error",
-    "event_too_large": "invalid_request_error",
-    "unknown_event": "invalid_request_error",
-    "internal_error": "server_error",
-    "runtime_open_failed": "server_error",
-    "runtime_open_unsupported": "server_error",
-    "runtime_append_failed": "server_error",
-    "runtime_append_task_failed": "server_error",
-    "runtime_signal_failed": "server_error",
-    "runtime_close_failed": "server_error",
-    "runtime_abort_failed": "server_error",
-    "runtime_data_plane_stream_failed": "server_error",
-    "runtime_data_plane_text_without_audio": "server_error",
-    "response_error": "server_error",
-    "chat_error": "server_error",
-    "server_vad_initialization_failed": "server_error",
-    "server_vad_inference_failed": "server_error",
-    "duplex_session_busy": "rate_limit_error",
-    "resource_exhausted": "rate_limit_error",
-    "input_backpressure": "rate_limit_error",
-    "response_already_active": "invalid_request_error",
-    "response_not_active": "invalid_request_error",
-    "response_create_without_input": "invalid_request_error",
-    "input_audio_buffer_empty": "invalid_request_error",
-    "server_vad_manual_commit_unsupported": "invalid_request_error",
-    "missing_item_id": "invalid_request_error",
-    "item_not_found": "invalid_request_error",
-    "playback_item_mismatch": "invalid_request_error",
-    "playback_item_not_found": "invalid_request_error",
-    "playback_ack_too_late": "invalid_request_error",
-    "unsupported_audio_format": "invalid_request_error",
-    "unsupported_ref_audio_path": "invalid_request_error",
-    "ref_audio_required": "invalid_request_error",
-    "model_update_unsupported": "invalid_request_error",
-    "voice_update_after_audio_unsupported": "invalid_request_error",
-    "ref_audio_update_unsupported": "invalid_request_error",
-    "native_text_append_unsupported": "invalid_request_error",
-    "runtime_native_stage_role_required": "server_error",
-    "runtime_native_runner_kv_required": "server_error",
-}
-
-
-@dataclass(slots=True)
-class _RealtimeResponseState:
-    item_id: str
-    transcript_parts: list[str] = field(default_factory=list)
-    text_parts: list[str] = field(default_factory=list)
-    audio_duration_ms: int | None = None
-    audio_text_marks: list[dict[str, int]] = field(default_factory=list)
-    audio_delta_emitted: bool = False
-    audio_done_emitted: bool = False
-    audio_part_added: bool = False
-    audio_part_done: bool = False
-    text_part_added: bool = False
-    text_part_done: bool = False
-    output_text_done: bool = False
-    output_item_done: bool = False
-    conversation_item_done: bool = False
-    speak_emitted: bool = False
-    done_emitted: bool = False
-
-    @property
-    def transcript(self) -> str:
-        return "".join(self.transcript_parts)
-
-    @property
-    def text(self) -> str:
-        return "".join(self.text_parts)
-
-
-@dataclass(slots=True)
-class RealtimeSessionState:
-    """Single mutable authority for one Realtime protocol session."""
-
-    _opened: bool = False
-    _autostarted_default_session: bool = False
-    _resume_only: bool = False
-    _pending_outbound: asyncio.Queue[dict[str, object]] = field(default_factory=asyncio.Queue)
-    _held_realtime_payloads: list[dict[str, object]] = field(default_factory=list)
-    _hold_realtime_output_until_session_created: bool = True
-    _default_model: object | None = None
-    _default_session_id: object | None = None
-    _default_extra_body: dict[str, object] = field(default_factory=dict)
-    _input_audio_format: str = "pcm16"
-    _input_sample_rate_hz: int = REALTIME_PCM_DEFAULT_SAMPLE_RATE_HZ
-    _output_audio_format: str = "pcm16"
-    _overlap_silence_rms: float = 0.003
-    _turn_detection: dict[str, object] | None = None
-    _native_input_append: bool = False
-    _pending_turn_detection_update: _PendingTurnDetectionUpdate | None = None
-    _send_realtime_json: Any = None
-    _initial_session_update: bool = False
-    _input_speech_started: bool = False
-    _response_states: dict[str | int, _RealtimeResponseState] = field(default_factory=dict)
-    _item_truncation_cursors: dict[str, tuple[int, int]] = field(default_factory=dict)
-    _active_response_id: str | None = None
-    _last_response_id: str | None = None
-    _conversation_items: dict[str, dict[str, object]] = field(default_factory=dict)
-    _last_conversation_item_id: str | None = None
-    _output_sample_rate_hz: int | None = None
-    _active_input_item_id: str | None = None
-    _input_audio_buffer_has_audio: bool = False
-    _input_audio_buffer_had_non_speech: bool = False
-    _input_audio_buffer_transcript_parts: list[str] = field(default_factory=list)
-    _turn_detection_configured: bool = False
-
-    @classmethod
-    def from_query_params(cls, query_params: Any) -> RealtimeSessionState:
-        if hasattr(query_params, "query_params"):
-            query_params = query_params.query_params
-        getter = query_params.get if hasattr(query_params, "get") else None
-        # Canonical query param plus the deprecated model-prefixed alias;
-        # both seed the canonical extra_body key.
-        native_duplex = None
-        if getter is not None:
-            native_duplex = getter("native_duplex")
-            if native_duplex is None:
-                native_duplex = getter("minicpmo45_native_duplex")
-        resume_only = getter("resume") if getter is not None else None
-        autostart = getter("autostart") if getter is not None else None
-        default_extra_body = {}
-        if str(native_duplex).strip().lower() in {"1", "true", "yes", "on"}:
-            default_extra_body["native_duplex"] = True
-        return cls(
-            _resume_only=(
-                str(resume_only).strip().lower() in {"1", "true", "yes", "on"}
-                or str(autostart).strip().lower() in {"0", "false", "no", "off"}
-            ),
-            _default_model=getter("model") if getter is not None else None,
-            _default_session_id=(getter("session_id") if getter is not None else None),
-            _default_extra_body=default_extra_body,
-        )
-
-
-_StateValue = TypeVar("_StateValue")
-
-
-class _RealtimeStateField(Generic[_StateValue]):
-    """Explicit descriptor binding one protocol attribute to session state."""
-
-    def __set_name__(self, owner: type, name: str) -> None:
-        del owner
-        self._name = name
-
-    def __get__(self, instance: Any, owner: type | None = None) -> _StateValue | _RealtimeStateField[_StateValue]:
-        del owner
-        if instance is None:
-            return self
-        return getattr(instance._state, self._name)
-
-    def __set__(self, instance: Any, value: _StateValue) -> None:
-        setattr(instance._state, self._name, value)
-
-
-class RealtimeStateOwner:
-    """Declare the mutable state surface shared by input/output projectors."""
-
-    _state: RealtimeSessionState
-    _opened: bool = _RealtimeStateField()
-    _autostarted_default_session: bool = _RealtimeStateField()
-    _resume_only: bool = _RealtimeStateField()
-    _pending_outbound: asyncio.Queue[dict[str, object]] = _RealtimeStateField()
-    _held_realtime_payloads: list[dict[str, object]] = _RealtimeStateField()
-    _hold_realtime_output_until_session_created: bool = _RealtimeStateField()
-    _default_model: object | None = _RealtimeStateField()
-    _default_session_id: object | None = _RealtimeStateField()
-    _default_extra_body: dict[str, object] = _RealtimeStateField()
-    _input_audio_format: str = _RealtimeStateField()
-    _input_sample_rate_hz: int = _RealtimeStateField()
-    _output_audio_format: str = _RealtimeStateField()
-    _overlap_silence_rms: float = _RealtimeStateField()
-    _turn_detection: dict[str, object] | None = _RealtimeStateField()
-    _native_input_append: bool = _RealtimeStateField()
-    _pending_turn_detection_update: _PendingTurnDetectionUpdate | None = _RealtimeStateField()
-    _send_realtime_json: Any = _RealtimeStateField()
-    _initial_session_update: bool = _RealtimeStateField()
-    _input_speech_started: bool = _RealtimeStateField()
-    _response_states: dict[str | int, _RealtimeResponseState] = _RealtimeStateField()
-    _item_truncation_cursors: dict[str, tuple[int, int]] = _RealtimeStateField()
-    _active_response_id: str | None = _RealtimeStateField()
-    _last_response_id: str | None = _RealtimeStateField()
-    _conversation_items: dict[str, dict[str, object]] = _RealtimeStateField()
-    _last_conversation_item_id: str | None = _RealtimeStateField()
-    _output_sample_rate_hz: int | None = _RealtimeStateField()
-    _active_input_item_id: str | None = _RealtimeStateField()
-    _input_audio_buffer_has_audio: bool = _RealtimeStateField()
-    _input_audio_buffer_had_non_speech: bool = _RealtimeStateField()
-    _input_audio_buffer_transcript_parts: list[str] = _RealtimeStateField()
-    _turn_detection_configured: bool = _RealtimeStateField()
+from vllm_omni.entrypoints.realtime.state import (
+    REALTIME_ERROR_TYPES_BY_CODE as REALTIME_ERROR_TYPES_BY_CODE,
+)
+from vllm_omni.entrypoints.realtime.state import (
+    REALTIME_G711_DEFAULT_SAMPLE_RATE_HZ as REALTIME_G711_DEFAULT_SAMPLE_RATE_HZ,
+)
+from vllm_omni.entrypoints.realtime.state import (
+    REALTIME_INPUT_AUDIO_FORMATS as REALTIME_INPUT_AUDIO_FORMATS,
+)
+from vllm_omni.entrypoints.realtime.state import (
+    REALTIME_OUTPUT_AUDIO_FORMATS as REALTIME_OUTPUT_AUDIO_FORMATS,
+)
+from vllm_omni.entrypoints.realtime.state import (
+    REALTIME_PCM_DEFAULT_SAMPLE_RATE_HZ as REALTIME_PCM_DEFAULT_SAMPLE_RATE_HZ,
+)
+from vllm_omni.entrypoints.realtime.state import (
+    REALTIME_PCM_F32_DEFAULT_SAMPLE_RATE_HZ as REALTIME_PCM_F32_DEFAULT_SAMPLE_RATE_HZ,
+)
+from vllm_omni.entrypoints.realtime.state import (
+    RealtimeSessionState as RealtimeSessionState,
+)
+from vllm_omni.entrypoints.realtime.state import (
+    RealtimeStateOwner as RealtimeStateOwner,
+)
+from vllm_omni.entrypoints.realtime.state import (
+    _RealtimeResponseState as _RealtimeResponseState,
+)
+from vllm_omni.entrypoints.realtime.state import (
+    realtime_default_sample_rate_hz as realtime_default_sample_rate_hz,
+)

--- a/vllm_omni/entrypoints/duplex/server_vad.py
+++ b/vllm_omni/entrypoints/duplex/server_vad.py
@@ -7,13 +7,19 @@ import asyncio
 import hashlib
 import threading
 import time
-from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, Protocol
+from typing import TYPE_CHECKING, Protocol
 
 import numpy as np
 from vllm.transformers_utils.repo_utils import try_get_local_file
+
+from vllm_omni.entrypoints.realtime.config import (
+    ServerVADConfig as ServerVADConfig,
+)
+from vllm_omni.entrypoints.realtime.config import (
+    parse_session_turn_detection as parse_session_turn_detection,
+)
 
 if TYPE_CHECKING:
     from vllm_omni.entrypoints.openai.audio_utils_mixin import StreamingAudioResampler
@@ -24,128 +30,6 @@ SILERO_VAD_FILENAME = "silero_vad.onnx"
 SILERO_VAD_SHA256 = "1a153a22f4509e292a94e67d6f9b85e8deb25b4988682b7e174c65279d8788e3"
 SILERO_VAD_MIN_THRESHOLD = 0.15
 SILERO_VAD_DEFAULT_MIN_SPEECH_DURATION_MS = 96
-
-_SERVER_VAD_FIELDS = {
-    "type",
-    "threshold",
-    "prefix_padding_ms",
-    "silence_duration_ms",
-    "create_response",
-    "interrupt_response",
-    "min_speech_duration_ms",
-}
-
-
-@dataclass(frozen=True, slots=True)
-class ServerVADConfig:
-    """Validated OpenAI-compatible ``server_vad`` session configuration."""
-
-    type: Literal["server_vad"] = "server_vad"
-    threshold: float = 0.5
-    prefix_padding_ms: int = 300
-    silence_duration_ms: int = 500
-    create_response: bool = True
-    # Omission is resolved from runtime capabilities before the session is opened.
-    interrupt_response: bool | None = None
-    min_speech_duration_ms: int | None = None
-
-    @classmethod
-    def from_value(cls, value: object) -> ServerVADConfig:
-        if not isinstance(value, dict):
-            raise ValueError("turn_detection must be null or an object")
-        unknown = sorted(set(value) - _SERVER_VAD_FIELDS)
-        if unknown:
-            raise ValueError(f"Unknown server_vad field(s): {', '.join(unknown)}")
-        vad_type = value.get("type")
-        if vad_type != "server_vad":
-            raise ValueError("turn_detection.type must be 'server_vad'")
-
-        threshold = value.get("threshold", 0.5)
-        if isinstance(threshold, bool) or not isinstance(threshold, int | float) or not 0 <= threshold <= 1:
-            raise ValueError("server_vad.threshold must be a number between 0 and 1")
-
-        prefix_padding_ms = value.get("prefix_padding_ms", 300)
-        if isinstance(prefix_padding_ms, bool) or not isinstance(prefix_padding_ms, int) or prefix_padding_ms < 0:
-            raise ValueError("server_vad.prefix_padding_ms must be a non-negative integer")
-
-        silence_duration_ms = value.get("silence_duration_ms", 500)
-        if (
-            isinstance(silence_duration_ms, bool)
-            or not isinstance(silence_duration_ms, int)
-            or silence_duration_ms <= 0
-        ):
-            raise ValueError("server_vad.silence_duration_ms must be a positive integer")
-
-        create_response = value.get("create_response", True)
-        if not isinstance(create_response, bool):
-            raise ValueError("server_vad.create_response must be a boolean")
-
-        interrupt_response = value.get("interrupt_response")
-        if "interrupt_response" in value and not isinstance(interrupt_response, bool):
-            raise ValueError("server_vad.interrupt_response must be a boolean")
-
-        min_speech_duration_ms = value.get("min_speech_duration_ms")
-        if min_speech_duration_ms is not None and (
-            isinstance(min_speech_duration_ms, bool)
-            or not isinstance(min_speech_duration_ms, int | float)
-            or not np.isfinite(float(min_speech_duration_ms))
-            or min_speech_duration_ms < 0
-        ):
-            raise ValueError("server_vad.min_speech_duration_ms must be a non-negative number")
-
-        return cls(
-            type=vad_type,
-            threshold=float(threshold),
-            prefix_padding_ms=prefix_padding_ms,
-            silence_duration_ms=silence_duration_ms,
-            create_response=create_response,
-            interrupt_response=interrupt_response,
-            min_speech_duration_ms=(int(min_speech_duration_ms) if min_speech_duration_ms is not None else None),
-        )
-
-    def as_dict(self) -> dict[str, object]:
-        result: dict[str, object] = {
-            "type": self.type,
-            "threshold": self.threshold,
-            "prefix_padding_ms": self.prefix_padding_ms,
-            "silence_duration_ms": self.silence_duration_ms,
-            "create_response": self.create_response,
-        }
-        if self.interrupt_response is not None:
-            result["interrupt_response"] = self.interrupt_response
-        if self.min_speech_duration_ms is not None:
-            result["min_speech_duration_ms"] = self.min_speech_duration_ms
-        return result
-
-
-def parse_session_turn_detection(
-    payload: Mapping[str, object],
-) -> tuple[bool, ServerVADConfig | None]:
-    """Extract and validate OpenAI-compatible turn detection aliases."""
-    configured_values: list[tuple[str, object]] = []
-    if "turn_detection" in payload:
-        configured_values.append(("turn_detection", payload["turn_detection"]))
-    audio = payload.get("audio")
-    if isinstance(audio, Mapping):
-        audio_input = audio.get("input")
-        if isinstance(audio_input, Mapping) and "turn_detection" in audio_input:
-            configured_values.append(("audio.input.turn_detection", audio_input["turn_detection"]))
-    if not configured_values:
-        return False, None
-
-    first_path, first_value = configured_values[0]
-    first_config = None if first_value is None else ServerVADConfig.from_value(first_value)
-    for field_path, value in configured_values[1:]:
-        config = None if value is None else ServerVADConfig.from_value(value)
-        if first_config is not None and config is not None:
-            # An omitted option must not conflict with an explicit alias value.
-            if first_config.interrupt_response is None:
-                first_config = replace(first_config, interrupt_response=config.interrupt_response)
-            if config.interrupt_response is None:
-                config = replace(config, interrupt_response=first_config.interrupt_response)
-        if config != first_config:
-            raise ValueError(f"{first_path} and {field_path} must not specify conflicting values")
-    return True, first_config
 
 
 class SpeechDetectorBackend(Protocol):

--- a/vllm_omni/entrypoints/duplex/serving.py
+++ b/vllm_omni/entrypoints/duplex/serving.py
@@ -41,10 +41,6 @@ from vllm_omni.entrypoints.duplex.protocol import (
     native_duplex_opt_in,
     normalize_native_duplex_key,
 )
-from vllm_omni.entrypoints.duplex.realtime_session import (
-    REALTIME_OUTPUT_AUDIO_FORMATS,
-    NativeRealtimeSessionProtocol,
-)
 from vllm_omni.entrypoints.duplex.runtime_adapter import (
     ServingRuntimeAdapter,
     ServingRuntimeConfigError,
@@ -76,6 +72,13 @@ from vllm_omni.entrypoints.duplex.websocket import (
     DOMAIN_TERMINAL_EVENTS,
     DuplexSessionTasks,
     DuplexWebSocketActor,
+)
+from vllm_omni.entrypoints.realtime.runner import run_realtime_session
+from vllm_omni.entrypoints.realtime.session import (
+    REALTIME_OUTPUT_AUDIO_FORMATS,
+)
+from vllm_omni.entrypoints.realtime.session import (
+    RealtimeSessionProtocol as NativeRealtimeSessionProtocol,
 )
 from vllm_omni.metrics.realtime import RealtimeVADMetrics
 
@@ -179,10 +182,7 @@ class OmniDuplexSessionHandler(
         )
 
     async def handle_realtime_session(self, websocket: WebSocket) -> None:
-        await self.handle_session(
-            websocket,
-            realtime_protocol=NativeRealtimeSessionProtocol(websocket.query_params),
-        )
+        await run_realtime_session(websocket, self)
 
     def _ensure_lifecycle_listener(self) -> None:
         if not isinstance(self._lifecycle_queue, asyncio.Queue):

--- a/vllm_omni/entrypoints/duplex/session_runner.py
+++ b/vllm_omni/entrypoints/duplex/session_runner.py
@@ -17,10 +17,6 @@ from vllm.logger import init_logger
 
 from vllm_omni.engine.duplex.lease import DuplexLeaseActivity
 from vllm_omni.engine.duplex.messages import DuplexFence
-from vllm_omni.entrypoints.duplex.audio import (
-    convert_input_audio_with_rate,
-    validate_input_sample_rate_hz,
-)
 from vllm_omni.entrypoints.duplex.commit_policy import (
     CommitAction,
     CommitSnapshot,
@@ -32,9 +28,6 @@ from vllm_omni.entrypoints.duplex.protocol import (
     DuplexSession,
     DuplexSessionState,
     DuplexTurnEventType,
-)
-from vllm_omni.entrypoints.duplex.realtime_session import (
-    NativeRealtimeSessionProtocol,
 )
 from vllm_omni.entrypoints.duplex.runtime_adapter import (
     PcmAppendReservation,
@@ -50,6 +43,13 @@ from vllm_omni.entrypoints.duplex.websocket import (
     DuplexWebSocketActor,
     is_input_event,
     normalize_duplex_input_event,
+)
+from vllm_omni.entrypoints.realtime.audio import (
+    convert_input_audio_with_rate,
+    validate_input_sample_rate_hz,
+)
+from vllm_omni.entrypoints.realtime.session import (
+    RealtimeSessionProtocol as NativeRealtimeSessionProtocol,
 )
 
 logger = init_logger(__name__)

--- a/vllm_omni/entrypoints/realtime/__init__.py
+++ b/vllm_omni/entrypoints/realtime/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""Shared Realtime wire protocol; no model or runtime ownership."""

--- a/vllm_omni/entrypoints/realtime/adapters/__init__.py
+++ b/vllm_omni/entrypoints/realtime/adapters/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""Execution boundary for consumers of the shared Realtime codec."""

--- a/vllm_omni/entrypoints/realtime/adapters/base.py
+++ b/vllm_omni/entrypoints/realtime/adapters/base.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from fastapi import WebSocket
+
+from vllm_omni.entrypoints.realtime.session import RealtimeSessionProtocol
+
+
+class RealtimeModelAdapter(Protocol):
+    """Execute a session using the shared wire codec.
+
+    The adapter owns admission, input delivery, model execution, cancellation,
+    and cleanup. It binds the codec's sender and uses it to decode input and
+    project output. The codec does not own a second execution state machine.
+
+    The existing duplex handler is the first structural implementation. Its
+    model-selected ServingRuntimeAdapter and native append path are unchanged;
+    a turn-based model need not implement that native runtime contract.
+    """
+
+    async def handle_session(
+        self,
+        websocket: WebSocket,
+        *,
+        realtime_protocol: RealtimeSessionProtocol,
+    ) -> None: ...

--- a/vllm_omni/entrypoints/realtime/audio.py
+++ b/vllm_omni/entrypoints/realtime/audio.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+import binascii
+import io
+import math
+import wave
+
+import numpy as np
+import pybase64 as base64
+
+try:
+    from audioop import alaw2lin, lin2alaw, lin2ulaw, ulaw2lin
+except ImportError:  # pragma: no cover - audioop is removed in newer Python.
+    alaw2lin = lin2alaw = lin2ulaw = ulaw2lin = None
+
+
+MIN_INPUT_SAMPLE_RATE_HZ = 8_000
+MAX_INPUT_SAMPLE_RATE_HZ = 192_000
+
+
+def validate_input_sample_rate_hz(sample_rate_hz: object) -> int:
+    if (
+        isinstance(sample_rate_hz, bool)
+        or not isinstance(sample_rate_hz, int | float)
+        or (isinstance(sample_rate_hz, float) and not math.isfinite(sample_rate_hz))
+    ):
+        raise ValueError("sample_rate_hz must be a finite integer")
+    rate = int(sample_rate_hz)
+    if rate != sample_rate_hz:
+        raise ValueError("sample_rate_hz must be an integer")
+    if not MIN_INPUT_SAMPLE_RATE_HZ <= rate <= MAX_INPUT_SAMPLE_RATE_HZ:
+        raise ValueError(f"sample_rate_hz must be between {MIN_INPUT_SAMPLE_RATE_HZ} and {MAX_INPUT_SAMPLE_RATE_HZ}")
+    return rate
+
+
+def resample_pcm16_mono(raw: bytes, *, source_rate_hz: int, target_rate_hz: int) -> bytes:
+    if source_rate_hz <= 0 or target_rate_hz <= 0 or source_rate_hz == target_rate_hz:
+        return raw
+    # Import lazily so the generic Duplex audio module does not pull in the
+    # OpenAI API server while the Duplex stack itself is being imported.
+    from vllm_omni.entrypoints.openai.audio_utils_mixin import StreamingAudioResampler
+
+    samples = np.frombuffer(raw, dtype="<i2")
+    rate_gcd = math.gcd(source_rate_hz, target_rate_hz)
+    reduced_factor = max(source_rate_hz // rate_gcd, target_rate_hz // rate_gcd)
+    if reduced_factor > StreamingAudioResampler._max_polyphase_factor:
+        # The FIR size scales with the reduced ratio. Keep unusual client
+        # rates bounded while common audio rates use the high-quality path.
+        if samples.size <= 1:
+            return raw
+        target_size = max(1, int(round(samples.size * target_rate_hz / source_rate_hz)))
+        source_x = np.linspace(0.0, 1.0, num=samples.size, endpoint=True)
+        target_x = np.linspace(0.0, 1.0, num=target_size, endpoint=True)
+        resampled = np.interp(target_x, source_x, samples)
+        return np.clip(resampled, -32_768, 32_767).astype("<i2").tobytes()
+    resampler = StreamingAudioResampler(source_rate_hz, target_rate_hz)
+    normalized = samples.astype(np.float32) * np.float32(1.0 / 32768.0)
+    resampled = resampler.process(normalized, final=True)
+    return np.clip(np.rint(resampled * 32768.0), -32768, 32767).astype("<i2").tobytes()
+
+
+def decode_g711_ulaw(raw: bytes) -> bytes:
+    if ulaw2lin is not None:
+        return ulaw2lin(raw, 2)
+    data = np.frombuffer(raw, dtype=np.uint8)
+    value = np.bitwise_not(data).astype(np.int16)
+    sign = value & 0x80
+    exponent = (value >> 4) & 0x07
+    mantissa = value & 0x0F
+    sample = ((mantissa << 3) + 0x84) << exponent
+    return np.where(sign != 0, -(sample - 0x84), sample - 0x84).astype("<i2").tobytes()
+
+
+def decode_g711_alaw(raw: bytes) -> bytes:
+    if alaw2lin is not None:
+        return alaw2lin(raw, 2)
+    data = np.bitwise_xor(np.frombuffer(raw, dtype=np.uint8), 0x55).astype(np.int16)
+    sign = data & 0x80
+    exponent = (data >> 4) & 0x07
+    mantissa = data & 0x0F
+    sample = np.where(exponent == 0, (mantissa << 4) + 8, ((mantissa << 4) + 0x108) << (exponent - 1))
+    return np.where(sign != 0, sample, -sample).astype("<i2").tobytes()
+
+
+def encode_g711_ulaw(raw: bytes) -> bytes:
+    if lin2ulaw is not None:
+        return lin2ulaw(raw, 2)
+    pcm = np.clip(np.frombuffer(raw, dtype="<i2").astype(np.int32), -32635, 32635)
+    sign = np.where(pcm < 0, 0x80, 0)
+    magnitude = np.abs(pcm) + 0x84
+    exponent = np.zeros_like(magnitude)
+    for exp in range(7):
+        exponent = np.where(magnitude > (0xFF << exp), exp + 1, exponent)
+    mantissa = (magnitude >> (exponent + 3)) & 0x0F
+    return (np.bitwise_not(sign | (exponent << 4) | mantissa) & 0xFF).astype(np.uint8).tobytes()
+
+
+def encode_g711_alaw(raw: bytes) -> bytes:
+    if lin2alaw is not None:
+        return lin2alaw(raw, 2)
+    pcm = np.frombuffer(raw, dtype="<i2").astype(np.int32)
+    sign = np.where(pcm >= 0, 0x80, 0x00)
+    magnitude = np.abs(pcm)
+    exponent = np.zeros_like(magnitude)
+    for exp in range(1, 8):
+        exponent = np.where(magnitude >= (1 << (exp + 7)), exp, exponent)
+    mantissa = np.where(
+        exponent == 0,
+        (magnitude >> 4) & 0x0F,
+        (magnitude >> (exponent + 3)) & 0x0F,
+    )
+    return ((sign | (exponent << 4) | mantissa) ^ 0x55).astype(np.uint8).tobytes()
+
+
+def wav_payload_to_pcm16(raw: bytes) -> tuple[bytes | None, int | None]:
+    try:
+        with wave.open(io.BytesIO(raw), "rb") as wav_file:
+            channels = wav_file.getnchannels()
+            sample_width = wav_file.getsampwidth()
+            sample_rate_hz = wav_file.getframerate()
+            frames = wav_file.readframes(wav_file.getnframes())
+        if sample_width != 2:
+            return None, sample_rate_hz
+        if channels <= 1:
+            return frames, sample_rate_hz
+        pcm = np.frombuffer(frames, dtype="<i2").reshape(-1, channels)
+        mono = np.mean(pcm.astype(np.float32), axis=1)
+        return np.clip(mono, -32768, 32767).astype("<i2").tobytes(), sample_rate_hz
+    except (EOFError, ValueError, wave.Error):
+        return None, None
+
+
+def encode_float32_mono_wav_base64(
+    samples: np.ndarray,
+    *,
+    sample_rate_hz: int,
+) -> str:
+    """Package normalized mono float32 samples as a PCM16 WAV data payload."""
+    rate = validate_input_sample_rate_hz(sample_rate_hz)
+    normalized = np.ascontiguousarray(samples, dtype=np.float32).reshape(-1)
+    pcm16 = np.clip(np.rint(normalized * 32768.0), -32768, 32767).astype("<i2")
+    with io.BytesIO() as buffer:
+        with wave.open(buffer, "wb") as wav_file:
+            wav_file.setnchannels(1)
+            wav_file.setsampwidth(2)
+            wav_file.setframerate(rate)
+            wav_file.writeframes(pcm16.tobytes())
+        return base64.b64encode(buffer.getvalue()).decode("ascii")
+
+
+def convert_input_audio_with_rate(
+    audio: object,
+    fmt: object,
+    *,
+    sample_rate_hz: int | float | None = None,
+    target_sample_rate_hz: int = 16_000,
+) -> tuple[object, object, int | float | None]:
+    if not isinstance(audio, str) or not isinstance(fmt, str):
+        return audio, fmt, sample_rate_hz
+    normalized = fmt.lower()
+    if normalized not in {"pcm16", "pcm_s16le", "s16le", "g711_ulaw", "g711_alaw"}:
+        return audio, fmt, sample_rate_hz
+    if isinstance(sample_rate_hz, int | float):
+        sample_rate_hz = validate_input_sample_rate_hz(sample_rate_hz)
+    try:
+        raw = base64.b64decode(audio.strip(), validate=False)
+    except (binascii.Error, ValueError):
+        return audio, fmt, sample_rate_hz
+    if normalized == "g711_ulaw":
+        raw = decode_g711_ulaw(raw)
+        sample_rate_hz = sample_rate_hz if isinstance(sample_rate_hz, int | float) else 8_000
+    elif normalized == "g711_alaw":
+        raw = decode_g711_alaw(raw)
+        sample_rate_hz = sample_rate_hz if isinstance(sample_rate_hz, int | float) else 8_000
+    elif len(raw) % 2:
+        return audio, fmt, sample_rate_hz
+    if isinstance(sample_rate_hz, int | float) and int(sample_rate_hz) != target_sample_rate_hz:
+        raw = resample_pcm16_mono(
+            raw,
+            source_rate_hz=int(sample_rate_hz),
+            target_rate_hz=target_sample_rate_hz,
+        )
+        sample_rate_hz = target_sample_rate_hz
+    pcm = np.frombuffer(raw, dtype="<i2").astype(np.float32) / 32768.0
+    encoded = base64.b64encode(np.ascontiguousarray(pcm, dtype="<f4").tobytes()).decode("ascii")
+    return encoded, "pcm_f32le", sample_rate_hz
+
+
+def convert_output_audio(
+    audio: str,
+    *,
+    source_fmt: str,
+    target_fmt: str,
+    source_sample_rate_hz: int | None = None,
+    target_sample_rate_hz: int | None = None,
+) -> tuple[str, str, int | None]:
+    target = target_fmt.lower()
+    if target not in {"g711_ulaw", "g711_alaw"}:
+        return audio, source_fmt, source_sample_rate_hz
+    try:
+        raw = base64.b64decode(audio, validate=False)
+    except (binascii.Error, ValueError):
+        return audio, source_fmt, source_sample_rate_hz
+    source = source_fmt.lower()
+    if source == "wav":
+        pcm_raw, wav_rate = wav_payload_to_pcm16(raw)
+        if pcm_raw is None:
+            return audio, source_fmt, source_sample_rate_hz
+        raw = pcm_raw
+        source_sample_rate_hz = source_sample_rate_hz or wav_rate
+    elif source not in {"pcm", "pcm16", "pcm_s16le", "s16le"} or len(raw) % 2:
+        return audio, source_fmt, source_sample_rate_hz
+    target_rate = target_sample_rate_hz or 8_000
+    if source_sample_rate_hz is not None:
+        raw = resample_pcm16_mono(raw, source_rate_hz=source_sample_rate_hz, target_rate_hz=target_rate)
+    encoded = encode_g711_ulaw(raw) if target == "g711_ulaw" else encode_g711_alaw(raw)
+    return base64.b64encode(encoded).decode("ascii"), target, target_rate

--- a/vllm_omni/entrypoints/realtime/config.py
+++ b/vllm_omni/entrypoints/realtime/config.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""Session option validation shared by Realtime and duplex serving."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from typing import Literal
+
+import numpy as np
+
+# Canonical extra_body key for the per-session opt-in to a model-native
+# duplex runtime, plus the deprecated model-prefixed spelling it replaced.
+# Client payloads may still use the legacy key; it is folded into the
+# canonical one at ingestion so everything downstream (and every echo in
+# session.created/session.updated) sees only NATIVE_DUPLEX_KEY.
+NATIVE_DUPLEX_KEY = "native_duplex"
+LEGACY_NATIVE_DUPLEX_KEY = "minicpmo45_native_duplex"
+
+
+def normalize_native_duplex_key(extra_body: dict[str, object]) -> dict[str, object]:
+    """Fold the deprecated alias into the canonical key (canonical wins)."""
+    if LEGACY_NATIVE_DUPLEX_KEY in extra_body:
+        legacy = extra_body.pop(LEGACY_NATIVE_DUPLEX_KEY)
+        extra_body.setdefault(NATIVE_DUPLEX_KEY, legacy)
+    return extra_body
+
+
+def native_duplex_opt_in(extra_body: Mapping[str, object]) -> object:
+    """Read the opt-in flag, accepting the deprecated alias for raw dicts."""
+    if NATIVE_DUPLEX_KEY in extra_body:
+        return extra_body[NATIVE_DUPLEX_KEY]
+    return extra_body.get(LEGACY_NATIVE_DUPLEX_KEY)
+
+
+_SERVER_VAD_FIELDS = {
+    "type",
+    "threshold",
+    "prefix_padding_ms",
+    "silence_duration_ms",
+    "create_response",
+    "interrupt_response",
+    "min_speech_duration_ms",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ServerVADConfig:
+    """Validated OpenAI-compatible ``server_vad`` session configuration."""
+
+    type: Literal["server_vad"] = "server_vad"
+    threshold: float = 0.5
+    prefix_padding_ms: int = 300
+    silence_duration_ms: int = 500
+    create_response: bool = True
+    # Omission is resolved from runtime capabilities before the session is opened.
+    interrupt_response: bool | None = None
+    min_speech_duration_ms: int | None = None
+
+    @classmethod
+    def from_value(cls, value: object) -> ServerVADConfig:
+        if not isinstance(value, dict):
+            raise ValueError("turn_detection must be null or an object")
+        unknown = sorted(set(value) - _SERVER_VAD_FIELDS)
+        if unknown:
+            raise ValueError(f"Unknown server_vad field(s): {', '.join(unknown)}")
+        vad_type = value.get("type")
+        if vad_type != "server_vad":
+            raise ValueError("turn_detection.type must be 'server_vad'")
+
+        threshold = value.get("threshold", 0.5)
+        if isinstance(threshold, bool) or not isinstance(threshold, int | float) or not 0 <= threshold <= 1:
+            raise ValueError("server_vad.threshold must be a number between 0 and 1")
+
+        prefix_padding_ms = value.get("prefix_padding_ms", 300)
+        if isinstance(prefix_padding_ms, bool) or not isinstance(prefix_padding_ms, int) or prefix_padding_ms < 0:
+            raise ValueError("server_vad.prefix_padding_ms must be a non-negative integer")
+
+        silence_duration_ms = value.get("silence_duration_ms", 500)
+        if (
+            isinstance(silence_duration_ms, bool)
+            or not isinstance(silence_duration_ms, int)
+            or silence_duration_ms <= 0
+        ):
+            raise ValueError("server_vad.silence_duration_ms must be a positive integer")
+
+        create_response = value.get("create_response", True)
+        if not isinstance(create_response, bool):
+            raise ValueError("server_vad.create_response must be a boolean")
+
+        interrupt_response = value.get("interrupt_response")
+        if "interrupt_response" in value and not isinstance(interrupt_response, bool):
+            raise ValueError("server_vad.interrupt_response must be a boolean")
+
+        min_speech_duration_ms = value.get("min_speech_duration_ms")
+        if min_speech_duration_ms is not None and (
+            isinstance(min_speech_duration_ms, bool)
+            or not isinstance(min_speech_duration_ms, int | float)
+            or not np.isfinite(float(min_speech_duration_ms))
+            or min_speech_duration_ms < 0
+        ):
+            raise ValueError("server_vad.min_speech_duration_ms must be a non-negative number")
+
+        return cls(
+            type=vad_type,
+            threshold=float(threshold),
+            prefix_padding_ms=prefix_padding_ms,
+            silence_duration_ms=silence_duration_ms,
+            create_response=create_response,
+            interrupt_response=interrupt_response,
+            min_speech_duration_ms=(int(min_speech_duration_ms) if min_speech_duration_ms is not None else None),
+        )
+
+    def as_dict(self) -> dict[str, object]:
+        result: dict[str, object] = {
+            "type": self.type,
+            "threshold": self.threshold,
+            "prefix_padding_ms": self.prefix_padding_ms,
+            "silence_duration_ms": self.silence_duration_ms,
+            "create_response": self.create_response,
+        }
+        if self.interrupt_response is not None:
+            result["interrupt_response"] = self.interrupt_response
+        if self.min_speech_duration_ms is not None:
+            result["min_speech_duration_ms"] = self.min_speech_duration_ms
+        return result
+
+
+def parse_session_turn_detection(
+    payload: Mapping[str, object],
+) -> tuple[bool, ServerVADConfig | None]:
+    """Extract and validate OpenAI-compatible turn detection aliases."""
+    configured_values: list[tuple[str, object]] = []
+    if "turn_detection" in payload:
+        configured_values.append(("turn_detection", payload["turn_detection"]))
+    audio = payload.get("audio")
+    if isinstance(audio, Mapping):
+        audio_input = audio.get("input")
+        if isinstance(audio_input, Mapping) and "turn_detection" in audio_input:
+            configured_values.append(("audio.input.turn_detection", audio_input["turn_detection"]))
+    if not configured_values:
+        return False, None
+
+    first_path, first_value = configured_values[0]
+    first_config = None if first_value is None else ServerVADConfig.from_value(first_value)
+    for field_path, value in configured_values[1:]:
+        config = None if value is None else ServerVADConfig.from_value(value)
+        if first_config is not None and config is not None:
+            # An omitted option must not conflict with an explicit alias value.
+            if first_config.interrupt_response is None:
+                first_config = replace(first_config, interrupt_response=config.interrupt_response)
+            if config.interrupt_response is None:
+                config = replace(config, interrupt_response=first_config.interrupt_response)
+        if config != first_config:
+            raise ValueError(f"{first_path} and {field_path} must not specify conflicting values")
+    return True, first_config

--- a/vllm_omni/entrypoints/realtime/input.py
+++ b/vllm_omni/entrypoints/realtime/input.py
@@ -4,26 +4,29 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import binascii
 from collections.abc import Callable
 from uuid import uuid4
 
 import numpy as np
+import pybase64 as base64
 
-from vllm_omni.entrypoints.duplex.audio import (
+from vllm_omni.entrypoints.realtime.audio import (
     convert_input_audio_with_rate,
     encode_float32_mono_wav_base64,
     validate_input_sample_rate_hz,
 )
-from vllm_omni.entrypoints.duplex.protocol import normalize_native_duplex_key
-from vllm_omni.entrypoints.duplex.realtime_state import (
+from vllm_omni.entrypoints.realtime.config import (
+    ServerVADConfig,
+    normalize_native_duplex_key,
+    parse_session_turn_detection,
+)
+from vllm_omni.entrypoints.realtime.state import (
     REALTIME_INPUT_AUDIO_FORMATS,
     REALTIME_OUTPUT_AUDIO_FORMATS,
     RealtimeStateOwner,
     realtime_default_sample_rate_hz,
 )
-from vllm_omni.entrypoints.duplex.server_vad import ServerVADConfig, parse_session_turn_detection
 
 
 class RealtimeInputTranslator(RealtimeStateOwner):

--- a/vllm_omni/entrypoints/realtime/output.py
+++ b/vllm_omni/entrypoints/realtime/output.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 from typing import Any
 from uuid import uuid4
 
-from vllm_omni.entrypoints.duplex.audio import convert_output_audio
-from vllm_omni.entrypoints.duplex.realtime_state import (
+from vllm_omni.entrypoints.realtime.audio import convert_output_audio
+from vllm_omni.entrypoints.realtime.state import (
     _RealtimeResponseState,
 )
 

--- a/vllm_omni/entrypoints/realtime/runner.py
+++ b/vllm_omni/entrypoints/realtime/runner.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from fastapi import WebSocket
+
+from vllm_omni.entrypoints.realtime.adapters.base import RealtimeModelAdapter
+from vllm_omni.entrypoints.realtime.session import RealtimeSessionProtocol
+
+
+async def run_realtime_session(websocket: WebSocket, adapter: RealtimeModelAdapter) -> None:
+    """Give one connection's codec to its existing execution owner."""
+    await adapter.handle_session(
+        websocket,
+        realtime_protocol=RealtimeSessionProtocol(websocket.query_params),
+    )

--- a/vllm_omni/entrypoints/realtime/session.py
+++ b/vllm_omni/entrypoints/realtime/session.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from uuid import uuid4
+
+from fastapi import WebSocket
+
+from vllm_omni.entrypoints.realtime import state as _state
+from vllm_omni.entrypoints.realtime.input import (
+    RealtimeInputTranslator,
+)
+from vllm_omni.entrypoints.realtime.output import (
+    RealtimeOutputProjector,
+)
+
+REALTIME_ERROR_TYPES_BY_CODE = _state.REALTIME_ERROR_TYPES_BY_CODE
+REALTIME_INPUT_AUDIO_FORMATS = _state.REALTIME_INPUT_AUDIO_FORMATS
+REALTIME_OUTPUT_AUDIO_FORMATS = _state.REALTIME_OUTPUT_AUDIO_FORMATS
+RealtimeSessionState = _state.RealtimeSessionState
+_RealtimeResponseState = _state._RealtimeResponseState
+
+
+class RealtimeSessionProtocol(
+    RealtimeInputTranslator,
+    RealtimeOutputProjector,
+    _state.RealtimeStateOwner,
+):
+    """Wire codec for one Realtime session.
+
+    Input translation, output projection, and mutable state have separate
+    owners. The model adapter owns execution; this codec owns only wire state.
+    Internal event names retain the established duplex vocabulary for compatibility.
+    """
+
+    def __init__(self, query_params: Any) -> None:
+        self._state = RealtimeSessionState.from_query_params(query_params)
+
+    def bind_sender(self, send_realtime_json) -> None:
+        self._send_realtime_json = send_realtime_json
+
+    def bind_native_input_append(self, enabled: bool) -> None:
+        """Use the serving-selected input path, independent of interruption policy."""
+        self._native_input_append = enabled
+
+    def _default_session_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "model": self._default_model,
+            "session_id": self._default_session_id,
+        }
+        if self._default_extra_body:
+            payload["extra_body"] = dict(self._default_extra_body)
+        return payload
+
+    async def receive_internal_event_text(self, websocket: WebSocket) -> str:
+        if not self._pending_outbound.empty():
+            return json.dumps(await self._pending_outbound.get())
+        if not self._opened and not self._resume_only and not self._autostarted_default_session and self._default_model:
+            self._opened = True
+            self._autostarted_default_session = True
+            return json.dumps(self._session_create_from_realtime(self._default_session_payload()))
+        while True:
+            if not self._pending_outbound.empty():
+                return json.dumps(await self._pending_outbound.get())
+            await self.wait_for_realtime_turn_detection_update()
+            raw = await websocket.receive_text()
+            try:
+                event = json.loads(raw)
+            except json.JSONDecodeError:
+                return raw
+            if not isinstance(event, dict):
+                return raw
+            if not self._opened and event.get("type") == "session.resume":
+                self._opened = True
+                translated = await self._to_duplex_event(event)
+                if translated is None:
+                    if not self._pending_outbound.empty():
+                        return json.dumps(await self._pending_outbound.get())
+                    continue
+                return json.dumps(translated)
+            if not self._opened and self._resume_only:
+                translated = await self._to_duplex_event(event)
+                if translated is None:
+                    if not self._pending_outbound.empty():
+                        return json.dumps(await self._pending_outbound.get())
+                    continue
+                return json.dumps(translated)
+            if not self._opened and event.get("type") != "session.update":
+                self._opened = True
+                await self._pending_outbound.put(self._session_create_from_realtime(self._default_session_payload()))
+                translated = await self._to_duplex_event(event)
+                if translated is not None:
+                    await self._send_realtime_input_ack(event)
+                    await self._pending_outbound.put(translated)
+                return json.dumps(await self._pending_outbound.get())
+            translated = await self._to_duplex_event(event)
+            if translated is None:
+                if not self._pending_outbound.empty():
+                    return json.dumps(await self._pending_outbound.get())
+                continue
+            await self._send_realtime_input_ack(event)
+            return json.dumps(translated)
+
+    def encode_outbound_event(self, data: dict[str, Any]) -> list[dict[str, object]]:
+        payloads = self._from_duplex_event(data)
+        for payload in payloads:
+            self._attach_event_id(payload)
+        return payloads
+
+    @staticmethod
+    def _attach_event_id(payload: dict[str, object]) -> None:
+        payload.setdefault("event_id", f"event_{uuid4().hex}")
+
+    async def _send_realtime_payload(self, payload: dict[str, object]) -> None:
+        self._attach_event_id(payload)
+        if (
+            self._hold_realtime_output_until_session_created
+            and payload.get("type") != "error"
+            and payload.get("type") != "session.created"
+        ):
+            self._held_realtime_payloads.append(payload)
+            return
+        if self._send_realtime_json is None:
+            raise RuntimeError("Native Realtime sender is not bound")
+        await self._send_realtime_json(payload)
+
+    @staticmethod
+    def _realtime_error_payload(
+        code: str,
+        message: str,
+        *,
+        event_id: object | None = None,
+        param: object | None = None,
+    ) -> dict[str, object]:
+        error: dict[str, object] = {
+            "type": REALTIME_ERROR_TYPES_BY_CODE.get(code, "invalid_request_error"),
+            "code": code,
+            "message": message,
+        }
+        if isinstance(event_id, str) and event_id:
+            error["event_id"] = event_id
+        if isinstance(param, str) and param:
+            error["param"] = param
+        return {"type": "error", "error": error}

--- a/vllm_omni/entrypoints/realtime/state.py
+++ b/vllm_omni/entrypoints/realtime/state.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, Generic, TypeVar
+
+REALTIME_INPUT_AUDIO_FORMATS = {
+    "pcm16",
+    "pcm_s16le",
+    "s16le",
+    "pcm_f32le",
+    "g711_ulaw",
+    "g711_alaw",
+}
+REALTIME_OUTPUT_AUDIO_FORMATS = {
+    "pcm16",
+    "pcm_s16le",
+    "s16le",
+    "wav",
+    "pcm",
+    "g711_ulaw",
+    "g711_alaw",
+}
+REALTIME_PCM_DEFAULT_SAMPLE_RATE_HZ = 24_000
+REALTIME_PCM_F32_DEFAULT_SAMPLE_RATE_HZ = 16_000
+REALTIME_G711_DEFAULT_SAMPLE_RATE_HZ = 8_000
+
+_RealtimeProtocolConfig = tuple[str, int, str, int | None, float]
+_PendingTurnDetectionUpdate = tuple[
+    bool,
+    dict[str, object] | None,
+    asyncio.Event,
+    _RealtimeProtocolConfig,
+]
+
+
+def realtime_default_sample_rate_hz(fmt: object) -> int | None:
+    if not isinstance(fmt, str):
+        return None
+    normalized = fmt.lower()
+    if normalized in {"pcm16", "pcm_s16le", "s16le", "pcm", "audio/pcm"}:
+        return REALTIME_PCM_DEFAULT_SAMPLE_RATE_HZ
+    if normalized in {"pcm_f32le", "audio/pcm_f32le"}:
+        return REALTIME_PCM_F32_DEFAULT_SAMPLE_RATE_HZ
+    if normalized in {"g711_ulaw", "g711_alaw", "audio/g711_ulaw", "audio/g711_alaw"}:
+        return REALTIME_G711_DEFAULT_SAMPLE_RATE_HZ
+    return None
+
+
+REALTIME_ERROR_TYPES_BY_CODE = {
+    "bad_event": "invalid_request_error",
+    "bad_audio": "invalid_request_error",
+    "config_timeout": "invalid_request_error",
+    "invalid_json": "invalid_request_error",
+    "event_too_large": "invalid_request_error",
+    "unknown_event": "invalid_request_error",
+    "internal_error": "server_error",
+    "runtime_open_failed": "server_error",
+    "runtime_open_unsupported": "server_error",
+    "runtime_append_failed": "server_error",
+    "runtime_append_task_failed": "server_error",
+    "runtime_signal_failed": "server_error",
+    "runtime_close_failed": "server_error",
+    "runtime_abort_failed": "server_error",
+    "runtime_data_plane_stream_failed": "server_error",
+    "runtime_data_plane_text_without_audio": "server_error",
+    "response_error": "server_error",
+    "chat_error": "server_error",
+    "server_vad_initialization_failed": "server_error",
+    "server_vad_inference_failed": "server_error",
+    "duplex_session_busy": "rate_limit_error",
+    "resource_exhausted": "rate_limit_error",
+    "input_backpressure": "rate_limit_error",
+    "response_already_active": "invalid_request_error",
+    "response_not_active": "invalid_request_error",
+    "response_create_without_input": "invalid_request_error",
+    "input_audio_buffer_empty": "invalid_request_error",
+    "server_vad_manual_commit_unsupported": "invalid_request_error",
+    "missing_item_id": "invalid_request_error",
+    "item_not_found": "invalid_request_error",
+    "playback_item_mismatch": "invalid_request_error",
+    "playback_item_not_found": "invalid_request_error",
+    "playback_ack_too_late": "invalid_request_error",
+    "unsupported_audio_format": "invalid_request_error",
+    "unsupported_ref_audio_path": "invalid_request_error",
+    "ref_audio_required": "invalid_request_error",
+    "model_update_unsupported": "invalid_request_error",
+    "voice_update_after_audio_unsupported": "invalid_request_error",
+    "ref_audio_update_unsupported": "invalid_request_error",
+    "native_text_append_unsupported": "invalid_request_error",
+    "runtime_native_stage_role_required": "server_error",
+    "runtime_native_runner_kv_required": "server_error",
+}
+
+
+@dataclass(slots=True)
+class _RealtimeResponseState:
+    item_id: str
+    transcript_parts: list[str] = field(default_factory=list)
+    text_parts: list[str] = field(default_factory=list)
+    audio_duration_ms: int | None = None
+    audio_text_marks: list[dict[str, int]] = field(default_factory=list)
+    audio_delta_emitted: bool = False
+    audio_done_emitted: bool = False
+    audio_part_added: bool = False
+    audio_part_done: bool = False
+    text_part_added: bool = False
+    text_part_done: bool = False
+    output_text_done: bool = False
+    output_item_done: bool = False
+    conversation_item_done: bool = False
+    speak_emitted: bool = False
+    done_emitted: bool = False
+
+    @property
+    def transcript(self) -> str:
+        return "".join(self.transcript_parts)
+
+    @property
+    def text(self) -> str:
+        return "".join(self.text_parts)
+
+
+@dataclass(slots=True)
+class RealtimeSessionState:
+    """Single mutable authority for one Realtime protocol session."""
+
+    _opened: bool = False
+    _autostarted_default_session: bool = False
+    _resume_only: bool = False
+    _pending_outbound: asyncio.Queue[dict[str, object]] = field(default_factory=asyncio.Queue)
+    _held_realtime_payloads: list[dict[str, object]] = field(default_factory=list)
+    _hold_realtime_output_until_session_created: bool = True
+    _default_model: object | None = None
+    _default_session_id: object | None = None
+    _default_extra_body: dict[str, object] = field(default_factory=dict)
+    _input_audio_format: str = "pcm16"
+    _input_sample_rate_hz: int = REALTIME_PCM_DEFAULT_SAMPLE_RATE_HZ
+    _output_audio_format: str = "pcm16"
+    _overlap_silence_rms: float = 0.003
+    _turn_detection: dict[str, object] | None = None
+    _native_input_append: bool = False
+    _pending_turn_detection_update: _PendingTurnDetectionUpdate | None = None
+    _send_realtime_json: Any = None
+    _initial_session_update: bool = False
+    _input_speech_started: bool = False
+    _response_states: dict[str | int, _RealtimeResponseState] = field(default_factory=dict)
+    _item_truncation_cursors: dict[str, tuple[int, int]] = field(default_factory=dict)
+    _active_response_id: str | None = None
+    _last_response_id: str | None = None
+    _conversation_items: dict[str, dict[str, object]] = field(default_factory=dict)
+    _last_conversation_item_id: str | None = None
+    _output_sample_rate_hz: int | None = None
+    _active_input_item_id: str | None = None
+    _input_audio_buffer_has_audio: bool = False
+    _input_audio_buffer_had_non_speech: bool = False
+    _input_audio_buffer_transcript_parts: list[str] = field(default_factory=list)
+    _turn_detection_configured: bool = False
+
+    @classmethod
+    def from_query_params(cls, query_params: Any) -> RealtimeSessionState:
+        if hasattr(query_params, "query_params"):
+            query_params = query_params.query_params
+        getter = query_params.get if hasattr(query_params, "get") else None
+        # Canonical query param plus the deprecated model-prefixed alias;
+        # both seed the canonical extra_body key.
+        native_duplex = None
+        if getter is not None:
+            native_duplex = getter("native_duplex")
+            if native_duplex is None:
+                native_duplex = getter("minicpmo45_native_duplex")
+        resume_only = getter("resume") if getter is not None else None
+        autostart = getter("autostart") if getter is not None else None
+        default_extra_body = {}
+        if str(native_duplex).strip().lower() in {"1", "true", "yes", "on"}:
+            default_extra_body["native_duplex"] = True
+        return cls(
+            _resume_only=(
+                str(resume_only).strip().lower() in {"1", "true", "yes", "on"}
+                or str(autostart).strip().lower() in {"0", "false", "no", "off"}
+            ),
+            _default_model=getter("model") if getter is not None else None,
+            _default_session_id=(getter("session_id") if getter is not None else None),
+            _default_extra_body=default_extra_body,
+        )
+
+
+_StateValue = TypeVar("_StateValue")
+
+
+class _RealtimeStateField(Generic[_StateValue]):
+    """Explicit descriptor binding one protocol attribute to session state."""
+
+    def __set_name__(self, owner: type, name: str) -> None:
+        del owner
+        self._name = name
+
+    def __get__(self, instance: Any, owner: type | None = None) -> _StateValue | _RealtimeStateField[_StateValue]:
+        del owner
+        if instance is None:
+            return self
+        return getattr(instance._state, self._name)
+
+    def __set__(self, instance: Any, value: _StateValue) -> None:
+        setattr(instance._state, self._name, value)
+
+
+class RealtimeStateOwner:
+    """Declare the mutable state surface shared by input/output projectors."""
+
+    _state: RealtimeSessionState
+    _opened: bool = _RealtimeStateField()
+    _autostarted_default_session: bool = _RealtimeStateField()
+    _resume_only: bool = _RealtimeStateField()
+    _pending_outbound: asyncio.Queue[dict[str, object]] = _RealtimeStateField()
+    _held_realtime_payloads: list[dict[str, object]] = _RealtimeStateField()
+    _hold_realtime_output_until_session_created: bool = _RealtimeStateField()
+    _default_model: object | None = _RealtimeStateField()
+    _default_session_id: object | None = _RealtimeStateField()
+    _default_extra_body: dict[str, object] = _RealtimeStateField()
+    _input_audio_format: str = _RealtimeStateField()
+    _input_sample_rate_hz: int = _RealtimeStateField()
+    _output_audio_format: str = _RealtimeStateField()
+    _overlap_silence_rms: float = _RealtimeStateField()
+    _turn_detection: dict[str, object] | None = _RealtimeStateField()
+    _native_input_append: bool = _RealtimeStateField()
+    _pending_turn_detection_update: _PendingTurnDetectionUpdate | None = _RealtimeStateField()
+    _send_realtime_json: Any = _RealtimeStateField()
+    _initial_session_update: bool = _RealtimeStateField()
+    _input_speech_started: bool = _RealtimeStateField()
+    _response_states: dict[str | int, _RealtimeResponseState] = _RealtimeStateField()
+    _item_truncation_cursors: dict[str, tuple[int, int]] = _RealtimeStateField()
+    _active_response_id: str | None = _RealtimeStateField()
+    _last_response_id: str | None = _RealtimeStateField()
+    _conversation_items: dict[str, dict[str, object]] = _RealtimeStateField()
+    _last_conversation_item_id: str | None = _RealtimeStateField()
+    _output_sample_rate_hz: int | None = _RealtimeStateField()
+    _active_input_item_id: str | None = _RealtimeStateField()
+    _input_audio_buffer_has_audio: bool = _RealtimeStateField()
+    _input_audio_buffer_had_non_speech: bool = _RealtimeStateField()
+    _input_audio_buffer_transcript_parts: list[str] = _RealtimeStateField()
+    _turn_detection_configured: bool = _RealtimeStateField()


### PR DESCRIPTION
## Purpose

Extract the existing Realtime wire codec from duplex serving into a shared frontend package, independently of #7181. This is the **protocol-extraction portion of RFC #6592 P0a**, not the complete RFC implementation. It prepares a reusable boundary for Qwen P0b and #7223 without bringing in the #7181 runtime prototype.

Based directly on `main` at `3d952d1334f78ac6a4adc595974264457a8eb810`.

- Move input translation, output projection, wire-only session state, audio conversion, and pure turn-detection configuration to `vllm_omni/entrypoints/realtime/`.
- Add a session-level `RealtimeModelAdapter` protocol and a small runner that supplies one codec per connection. The existing `OmniDuplexSessionHandler` is the first structural adapter; its ordered mailbox, `ServingRuntimeAdapter`, model execution, and cleanup remain unchanged.
- Preserve the old session/state/audio imports used by existing callers as re-exports of the same objects. Input/output implementation mixins are file moves, not duplicated implementations. Existing duplex test assertions are unchanged.
- Add focused CPU tests for compatibility identity, connection isolation, execution-intent forwarding, failure/cancellation propagation, and the shared package's import boundary.

No engine, scheduler, model, deploy YAML, benchmark, or CI workflow changes. This does not enable Qwen Realtime/video or change `/v1/duplex`.

### Design points for draft review

1. **Package placement:** the RFC sketches `entrypoints/openai/realtime/`. Today `openai/__init__.py` eagerly imports the API server, which imports duplex serving. A sibling `entrypoints/realtime/` avoids introducing that cycle or changing API-server initialization.
2. **Adapter granularity:** this draft uses `handle_session(websocket, *, realtime_protocol=...)`, not the RFC's proposed `build_prompt/start_response/cancel/supports` API. Native continuous append and model-owned LISTEN/SPEAK remain in their existing execution owner. The finer-grained shared adapter contract is still open; Qwen cannot be considered implemented by this extraction.
3. **Compatibility:** existing defaults, native extensions, internal intent names, response identity, and completion ordering are retained. This is not a claim of complete OpenAI GA conformance. The extracted audio modules use repository-required `pybase64` in place of stdlib `base64`; audio regression tests remain a gate.

See [the design note](docs/design/feature/realtime_protocol.md) for ownership and follow-up scope.

## Test Plan

**vLLM Version:** target CI version `0.29.0` from `docker/Dockerfile.ci`; no remote runtime version was verified in this run.

**vLLM-Omni Commit:** `2b4acc9cb414e89e5ac801bfed920e4f2d4408b5`

The following runtime checks are **pending**, not passing results. Run inside the remote Docker test environment with the matching vLLM build and test dependencies:

```bash
cd tests
pytest -s -v \
  entrypoints/realtime/test_protocol.py \
  entrypoints/openai/test_duplex_protocol.py \
  entrypoints/openai_api/test_duplex_handler.py \
  entrypoints/openai_api/test_server_vad.py \
  entrypoints/duplex/test_duplex_audio.py \
  engine/test_duplex_import_boundary.py \
  -m 'core_model and cpu'
```

Existing MiniCPM L2 CI-like regression command (from repository root; requires a CUDA GPU and MiniCPM-o 4.5 weights):

```bash
pytest -s -v tests/e2e/online_serving/test_minicpmo_4_5_duplex.py \
  tests/e2e/online_serving/test_duplex_client_live.py \
  -m 'core_model and cuda' --run-level 'core_model'
```

- [x] Quick repository precheck and diff-scoped simplification review.
- [x] Static comparison of moved implementations against the base revision.
- [ ] Focused CPU regressions above.
- [ ] Existing MiniCPM and PersonaPlex live-session regressions before marking ready.
- [ ] Maintainer agreement on the intentionally narrower adapter boundary.

## Test Result

- **Runtime validation not run:** the remote SSH entry point timed out before Slurm/container access. No host-machine pytest or model tests were substituted. No E2E, audio-equivalence, accuracy, or performance pass is claimed.
- **Static extraction comparison passed:** the five moved implementation modules are AST-equivalent after excluding top-level imports/docstrings and normalizing the protocol class rename. The four extracted configuration definitions also match the base. This does not prove runtime import or wire compatibility.
- **Static hooks passed:** Ruff check/format, debug statements, EOF/line-ending/whitespace checks, typos, test markers, SPDX, forbidden imports, and CUDA-call checks. Markdownlint CLI2 0.16.0 passed both changed documentation files.
- **Full pre-commit is not green:** its pinned Markdownlint environment could not initialize locally (`nodeenv: InvalidVersion: 'lts'`). The cached Markdownlint run above does not replace that exact pinned hook.
- **Mypy is not green on the base or this branch:** repeated runs on the final head and an untouched base worktree both reported 522 library errors in seven files; all normalized diagnostic signatures matched after mapping moved paths and the class rename. Test-file type checks passed (two files on the head). The existing descriptor/mixin typing debt remains; no broad typing cleanup or new ignore rules are included.

AI assistance: Codex assisted with implementation, tests, documentation, static comparison, and self-review. Runtime validation and human design review remain pending as listed above.
