### PR TITLE
[BugFix] Align MiniCPM-o 4.5 duplex speech conditioning

### DIFF
--- a/tests/clients/test_duplex_client.py
+++ b/tests/clients/test_duplex_client.py
@@ -829,8 +829,8 @@ def test_pcm16_wav_round_trip(tmp_path):
 
 
 def test_duplex_unit_boundary_and_residual_math():
-    assert duplex_unit_boundary_ms(0) == 1030
-    assert duplex_unit_boundary_ms(2) == 3030
+    assert duplex_unit_boundary_ms(0) == 1000
+    assert duplex_unit_boundary_ms(2) == 3000
     assert has_residual_model_unit(b"\x00" * 32_000, chunk_period_ms=1000) is False
     assert has_residual_model_unit(b"\x00" * 32_002, chunk_period_ms=1000) is True
     created = {"type": "session.created", "session": {"capabilities": {"chunk_period_ms": 500}}}
@@ -854,9 +854,13 @@ async def test_stream_pcm_sends_each_units_composite_beside_its_base_frame():
         # A composite belongs to the unit it was captured in, so it rides the
         # same append as that unit's base frame; a unit without one sends the
         # base alone. Frame k rides the append that closes model unit k.
-        assert [event["video_frames"] for event in appends if "video_frames" in event] == [["f0", "s0"], ["f1"]]
-        assert [event["audio_end_ms"] for event in appends if "video_frames" in event] == [1200, 2200]
-        assert frames_sent == 2
+        assert [event["video_frames"] for event in appends if "video_frames" in event] == [
+            ["f0", "s0"],
+            ["f1"],
+            ["f1"],
+        ]
+        assert [event["audio_end_ms"] for event in appends if "video_frames" in event] == [1000, 2000, 3000]
+        assert frames_sent == 3
         sock.feed(SESSION_CLOSED)
 
 

--- a/tests/config/test_config_factory.py
+++ b/tests/config/test_config_factory.py
@@ -1272,10 +1272,10 @@ class TestDeployConfigLoading:
         stages = merge_pipeline_deploy(pipeline, deploy)
 
         assert deploy.async_chunk is True
-        assert stages[0].yaml_engine_args["async_scheduling"] is True
-        assert stages[1].yaml_engine_args["async_scheduling"] is True
-        assert "Async" in (stages[0].scheduler_cls or "")
-        assert "Async" in (stages[1].scheduler_cls or "")
+        assert stages[0].yaml_engine_args["async_scheduling"] is False
+        assert stages[1].yaml_engine_args["async_scheduling"] is False
+        assert "Async" not in (stages[0].scheduler_cls or "")
+        assert "Async" not in (stages[1].scheduler_cls or "")
         assert [stage.devices for stage in deploy.stages] == ["0", "0", "0"]
         assert deploy.stages[1].enforce_eager is False
         assert stages[1].yaml_extras["default_sampling_params"]["max_tokens"] == 4096

--- a/tests/e2e/online_serving/test_minicpmo_realtime_duplex_drivers.py
+++ b/tests/e2e/online_serving/test_minicpmo_realtime_duplex_drivers.py
@@ -1979,19 +1979,18 @@ def test_realtime_duplex_demo_streams_one_video_frame_per_model_unit():
     messages = _send_seconds_of_audio(demo, seconds=3, frames=["f0", "f1", "f2", "f3"])
 
     # Frame k rides the append that closes model unit k, so Stage0 can bind it
-    # to that unit's audio. 3 s of audio closes units at 1030 ms and 2030 ms and
-    # leaves a residual too short for a third, so only two frames go out.
-    assert _sent_video_frames(messages) == [["f0"], ["f1"]]
+    # to that unit's audio. 3 s of audio closes units at 1000, 2000, and 3000 ms.
+    assert _sent_video_frames(messages) == [["f0"], ["f1"], ["f2"]]
     frame_indices = [index for index, message in enumerate(messages) if "video_frames" in message]
-    assert frame_indices == [5, 10]
+    assert frame_indices == [4, 9, 14]
     # The carrying appends are exactly the ones that reach a unit boundary.
-    assert [messages[index]["audio_end_ms"] for index in frame_indices] == [1200, 2200]
+    assert [messages[index]["audio_end_ms"] for index in frame_indices] == [1000, 2000, 3000]
 
 
 def test_realtime_duplex_demo_never_sends_a_frame_before_its_unit_can_close():
     """Regression: frame 0 used to ride the very first 200 ms append.
 
-    Stage0 cannot close a unit until 1030 ms of audio has arrived, and it does
+    Stage0 cannot close a unit until 1000 ms of audio has arrived, and it does
     not carry frames across appends, so a frame sent that early was silently
     dropped and every later frame ended up one unit ahead of its audio.
     """
@@ -2008,11 +2007,19 @@ def test_realtime_duplex_demo_never_sends_a_frame_before_its_unit_can_close():
 def test_realtime_duplex_demo_holds_the_last_video_frame_when_audio_outlives_the_clip():
     demo = _load_demo_module()
 
-    # 4 s of audio closes three units (1030/2030/3030 ms); the two-frame clip
-    # holds its last frame for the third.
-    assert _sent_video_frames(_send_seconds_of_audio(demo, seconds=4, frames=["a", "b"])) == [["a"], ["b"], ["b"]]
+    # 4 s of audio closes four units; the two-frame clip holds its last frame.
+    assert _sent_video_frames(_send_seconds_of_audio(demo, seconds=4, frames=["a", "b"])) == [
+        ["a"],
+        ["b"],
+        ["b"],
+        ["b"],
+    ]
     # A still image is a one-element clip and therefore repeats every unit.
-    assert _sent_video_frames(_send_seconds_of_audio(demo, seconds=3, frames=["still"])) == [["still"], ["still"]]
+    assert _sent_video_frames(_send_seconds_of_audio(demo, seconds=3, frames=["still"])) == [
+        ["still"],
+        ["still"],
+        ["still"],
+    ]
 
 
 def test_realtime_duplex_demo_sends_each_units_stacked_composite_next_to_its_base_frame():
@@ -2028,7 +2035,7 @@ def test_realtime_duplex_demo_sends_each_units_stacked_composite_next_to_its_bas
     # Official pairing is frame_list=[base, composite of that unit's interior],
     # so the composite belongs to the same unit as the base beside it -- never
     # to the previous one. A unit without interior sub-frames sends base alone.
-    assert _sent_video_frames(messages) == [["f0", "s0"], ["f1", "s1"], ["f2"]]
+    assert _sent_video_frames(messages) == [["f0", "s0"], ["f1", "s1"], ["f2"], ["f2"]]
 
 
 def test_minicpmo_duplex_camera_fixture_returns_flat_base_frame_track(tmp_path, monkeypatch):

--- a/tests/model_executor/stage_input_processors/test_minicpmo_4_5_omni.py
+++ b/tests/model_executor/stage_input_processors/test_minicpmo_4_5_omni.py
@@ -25,6 +25,11 @@ def _output(
 ):
     mm_output = dict(multimodal_output or {})
     mm_output["latent"] = latent
+    if "duplex_prompt_token_ids" in mm_output and "latent_input_ids" not in mm_output:
+        forwarded_ids = [*prompt_ids, *output_ids]
+        assert len(forwarded_ids) == latent.shape[0]
+        mm_output["latent_input_ids"] = torch.tensor(forwarded_ids).reshape(-1, 1)
+        mm_output["latent_positions"] = torch.arange(len(forwarded_ids)).reshape(-1, 1)
     completion = SimpleNamespace(
         token_ids=output_ids if token_list is None else token_list,
         text="hello",
@@ -140,6 +145,103 @@ def test_native_duplex_speak_segment_reaches_split_talker() -> None:
     assert info["meta"]["segment_end"] is True
     assert info["duplex"]["epoch"] == 3
     assert info["duplex"]["turn_id"] == 7
+
+
+def test_native_duplex_uses_forwarded_row_ledger_after_later_audio_prefill() -> None:
+    prompt_ids = [101, 102]
+    output_ids = [9304, 21, 22, 9308]
+    row_ids = [101, 102, 9304, 21, 22, 999, 999]
+    latent = torch.arange(len(row_ids) * 4, dtype=torch.float32).reshape(-1, 4)
+    metadata = {
+        "tts_bos_token_id": 9301,
+        "tts_eos_token_id": 9302,
+        "listen_token_id": 9303,
+        "speak_token_id": 9304,
+        "chunk_eos_token_id": 9308,
+        "chunk_tts_eos_token_id": 9309,
+        "turn_eos_token_id": 9310,
+    }
+    source = _output(
+        prompt_ids=prompt_ids,
+        output_ids=output_ids,
+        latent=latent,
+        multimodal_output={
+            "duplex_prompt_token_ids": prompt_ids,
+            "latent_input_ids": torch.tensor(row_ids).reshape(-1, 1),
+            "latent_positions": torch.arange(len(row_ids)).reshape(-1, 1),
+            "meta": metadata,
+        },
+    )
+    context = SimpleNamespace(bridge_states={"duplex": {"epoch": 3, "model_turn_id": 7}})
+
+    converted = llm2tts([source], prompt=[{}], _streaming_context=context)[0]
+
+    info = converted["model_intermediate_buffer"]
+    assert info["ids"]["tts"] == [21, 22]
+    assert torch.equal(torch.tensor(info["hidden_states"]["tts"]), latent[3:5])
+
+
+def test_native_duplex_selects_latest_contiguous_forwarded_span() -> None:
+    prompt_ids = [101, 102]
+    output_ids = [9304, 21, 22, 9308]
+    row_ids = [101, 21, 22, 102, 9304, 21, 22, 999]
+    positions = [0, 1, 3, 4, 5, 6, 7, 8]
+    latent = torch.arange(len(row_ids) * 4, dtype=torch.float32).reshape(-1, 4)
+    source = _output(
+        prompt_ids=prompt_ids,
+        output_ids=output_ids,
+        latent=latent,
+        multimodal_output={
+            "duplex_prompt_token_ids": prompt_ids,
+            "latent_input_ids": torch.tensor(row_ids).reshape(-1, 1),
+            "latent_positions": torch.tensor(positions).reshape(-1, 1),
+            "meta": {
+                "tts_bos_token_id": 9301,
+                "tts_eos_token_id": 9302,
+                "listen_token_id": 9303,
+                "speak_token_id": 9304,
+                "chunk_eos_token_id": 9308,
+                "chunk_tts_eos_token_id": 9309,
+                "turn_eos_token_id": 9310,
+            },
+        },
+    )
+    context = SimpleNamespace(bridge_states={"duplex": {"epoch": 3, "model_turn_id": 7}})
+
+    converted = llm2tts([source], prompt=[{}], _streaming_context=context)[0]
+
+    info = converted["model_intermediate_buffer"]
+    assert torch.equal(torch.tensor(info["hidden_states"]["tts"]), latent[5:7])
+
+
+def test_native_duplex_rejects_missing_forwarded_terminal_token() -> None:
+    prompt_ids = [101, 102]
+    output_ids = [9304, 21, 9310, 9308]
+    row_ids = [101, 102, 9304, 21, 999, 999]
+    latent = torch.arange(len(row_ids) * 4, dtype=torch.float32).reshape(-1, 4)
+    source = _output(
+        prompt_ids=prompt_ids,
+        output_ids=output_ids,
+        latent=latent,
+        multimodal_output={
+            "duplex_prompt_token_ids": prompt_ids,
+            "latent_input_ids": torch.tensor(row_ids).reshape(-1, 1),
+            "latent_positions": torch.arange(len(row_ids)).reshape(-1, 1),
+            "meta": {
+                "tts_bos_token_id": 9301,
+                "tts_eos_token_id": 9302,
+                "listen_token_id": 9303,
+                "speak_token_id": 9304,
+                "chunk_eos_token_id": 9308,
+                "chunk_tts_eos_token_id": 9309,
+                "turn_eos_token_id": 9310,
+            },
+        },
+    )
+    context = SimpleNamespace(bridge_states={"duplex": {"epoch": 3, "model_turn_id": 7}})
+
+    with pytest.raises(ValueError, match="no forwarded span"):
+        llm2tts([source], prompt=[{}], _streaming_context=context)
 
 
 def test_native_duplex_continuation_appends_only_new_talker_condition() -> None:

--- a/vllm_omni/clients/duplex.py
+++ b/vllm_omni/clients/duplex.py
@@ -90,13 +90,10 @@ __all__ = [
 PCM16_SAMPLE_RATE = 16_000
 PCM16_BYTES_PER_SAMPLE = 2
 
-# Server-side model unit boundaries, in cumulative appended audio.
-# Stage0 configures the streaming mel processor with first_chunk_ms=1035 and
-# chunk_ms=1000; the processor aligns the first chunk down to a hop_length (160
-# samples) multiple, so unit 0 closes at 16480 samples and every later unit
-# closes 16000 samples after it. Camera frames must ride the append that closes
-# a unit, otherwise Stage0 cannot bind them to that unit's audio.
-DUPLEX_FIRST_UNIT_MS = 1030
+# The native PCM reservation closes every 1000 ms, including the first unit.
+# Stage0 adds the first mel window's padding internally; the camera frame must
+# arrive with the reservation, before that internal padding is applied.
+DUPLEX_FIRST_UNIT_MS = 1000
 DUPLEX_UNIT_MS = 1000
 
 
@@ -774,10 +771,9 @@ class DuplexClient:
         model unit ``k`` (see :func:`duplex_unit_boundary_ms`), which
         reproduces the official ``streaming_prefill(audio_waveform=<1 s>,
         frame_list=[frame])`` pairing: a second of audio and the picture
-        captured during it enter the same unit. Sending on whole-second
-        boundaries instead would strand frame 0 on an append that cannot
-        close a unit yet, and shift every later frame one unit ahead of its
-        audio.
+        captured during it enter the same unit. Sending a frame before its
+        whole-second unit boundary would strand it on an append that cannot
+        close the unit yet.
 
         ``stacked_video_frames`` is the optional parallel track of composites
         (see ``vllm_omni.experimental.fullduplex.video_stacking``): entry ``k``

--- a/vllm_omni/deploy/minicpmo_4_5.yaml
+++ b/vllm_omni/deploy/minicpmo_4_5.yaml
@@ -33,6 +33,8 @@ connectors:
 
 stages:
   - stage_id: 0
+    # Stateful duplex sampling must not mutate state on discarded lookahead steps.
+    async_scheduling: false
     max_num_seqs: 4
     # Leave headroom on the shared GPU for Talker KV + concurrent Code2Wav.
     gpu_memory_utilization: 0.55
@@ -63,6 +65,8 @@ stages:
       repetition_penalty: 1.0
 
   - stage_id: 1
+    # Stateful duplex sampling must not mutate state on discarded lookahead steps.
+    async_scheduling: false
     max_num_seqs: 4
     # Preserve the checkpoint's full-attention Talker prompt while it fits;
     # native duplex rolls over to a one-chunk window at context capacity.

--- a/vllm_omni/model_executor/models/minicpmo_4_5/duplex/adapter.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/duplex/adapter.py
@@ -231,7 +231,8 @@ class MiniCPMO45NativeDuplexServingAdapter:
             "chunk_eos_token_id",
             "chunk_tts_eos_token_id",
             "listen_token_id",
-            "turn_eos_token_id",
+            # turn_eos conditions the Talker: consume it in the next forward
+            # before a unit terminator stops native generation, as HF does.
         )
         for field in stop_token_fields:
             token = MiniCPMO45DuplexPolicy.SPECIAL_TOKEN_FIELDS[field]

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni.py
@@ -558,6 +558,11 @@ class MiniCPMO45OmniForConditionalGeneration(nn.Module, SupportsMultiModal, Supp
 
             # Return hidden states with latent in multimodal_outputs for stage_input_processors
             multimodal_outputs = {"latent": text_hidden_states}
+            # Keep per-forward row identities alongside the latent payload.
+            if thinker_input_ids is not None and thinker_positions is not None:
+                multimodal_outputs["latent_input_ids"] = thinker_input_ids.reshape(-1, 1)
+                multimodal_outputs["latent_positions"] = thinker_positions.reshape(-1, 1)
+
             runtime_info = kwargs.get("runtime_additional_information")
             if runtime_info and isinstance(runtime_info, list) and len(runtime_info) > 0:
                 duplex_rows = []

--- a/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/minicpmo_4_5_omni.py
@@ -900,13 +900,11 @@ def llm2tts(
                             special_token_ids.get("chunk_tts_eos_token_id"),
                         }
                         break
-                # Map output indices onto hidden rows by END alignment: the
-                # leading decision tokens of the delta may ALSO be folded into
-                # the resumable prompt (they belong to earlier non-forwarded
-                # segments), so prompt_len + delta over-counts them and
-                # front-aligned indexing truncates the slice. The hidden
-                # tensor's last len(out_ids) rows are the delta's rows.
-                hidden_base = int(thinker_hidden_states.shape[0]) - len(out_ids)
+                # Accumulated rows precede the sampled output IDs by one:
+                # the next forward consumes that sampled token and yields the
+                # post-token hidden required by the official duplex Talker.
+                # The handoff requires that forward to have run.
+                hidden_base = int(thinker_hidden_states.shape[0]) - len(out_ids) + 1
                 if hidden_base >= 0 and out_end > out_start:
                     tts_token_ids_slice = torch.tensor(out_ids[out_start:out_end], dtype=torch.long)
                     tts_hidden_slice = (
@@ -934,7 +932,7 @@ def llm2tts(
                             special_token_ids.get("chunk_tts_eos_token_id"),
                         }
                         break
-                hidden_base = int(thinker_hidden_states.shape[0]) - len(out_ids)
+                hidden_base = int(thinker_hidden_states.shape[0]) - len(out_ids) + 1
                 if hidden_base >= 0 and out_end > out_start:
                     tts_token_ids_slice = torch.tensor(out_ids[out_start:out_end], dtype=torch.long)
                     tts_hidden_slice = (
@@ -942,6 +940,34 @@ def llm2tts(
                         .to(torch.float32)
                         .contiguous()
                     )
+        # Resolve the speech span against actual forwarded token positions,
+        # including when newer non-speaking units have extended the payload.
+        if is_native_duplex_handoff and tts_token_ids_slice is not None and tts_token_ids_slice.numel():
+            row_ids = mm_output.get("latent_input_ids")
+            row_positions = mm_output.get("latent_positions")
+            if not isinstance(row_ids, torch.Tensor) or not isinstance(row_positions, torch.Tensor):
+                raise ValueError("MiniCPM-o native duplex: missing latent row identities")
+            row_ids = row_ids.reshape(-1).tolist()
+            row_positions = row_positions.reshape(-1).tolist()
+            if len(row_ids) != thinker_hidden_states.shape[0] or len(row_positions) != len(row_ids):
+                raise ValueError(
+                    "MiniCPM-o native duplex: row ledger shape mismatch "
+                    f"{len(row_ids)} / {thinker_hidden_states.shape[0]}"
+                )
+            target = tts_token_ids_slice.reshape(-1).tolist()
+            width = len(target)
+            candidates = [
+                i
+                for i in range(len(row_ids) - width + 1)
+                if row_ids[i : i + width] == target
+                and row_positions[i : i + width] == list(range(row_positions[i], row_positions[i] + width))
+            ]
+            if not candidates:
+                raise ValueError(
+                    f"MiniCPM-o native duplex: no forwarded span for {target}; ledger tail={row_ids[-30:]}"
+                )
+            chosen = max(candidates, key=lambda i: (row_positions[i], i))
+            tts_hidden_slice = thinker_hidden_states[chosen : chosen + width].to(torch.float32).contiguous()
         handoff_ids = _coerce_token_id_list(tts_token_ids_slice) if tts_token_ids_slice is not None else None
         if is_native_duplex_handoff and handoff_ids:
             handoff_text = _decode_native_duplex_token_ids(


### PR DESCRIPTION
## Purpose

Fixes #7044.

MiniCPM-o 4.5 native duplex could generate speech that did not match the Thinker text. Video frames could also miss the first audio unit, and asynchronous lookahead sampling could corrupt duplex session state.

### Reproduction

Start the server:

```bash
vllm serve openbmb/MiniCPM-o-4_5 \
    --omni \
    --deploy-config vllm_omni/deploy/minicpmo_4_5.yaml \
    --trust-remote-code \
    --host 0.0.0.0 \
    --port 8099
```

Run the official example video:

```bash
python examples/online_serving/minicpmo/realtime_duplex_demo.py \
    --input-video /path/to/MiniCPM-o-4_5/assets/omni_duplex1.mp4 \
    --ref-audio /path/to/MiniCPM-o-4_5/assets/HT_ref_audio.wav \
    --require-audio
```

Before this fix, the Thinker text and generated speech could describe different content.

### Root cause

Four independent problems affected the native duplex path:

1. The stage bridge selected Talker hidden states by offsets in accumulated tensors. After subsequent audio prefill or repeated text, those offsets could point to hidden states from different forwarded tokens.
2. `<|turn_eos|>` was treated as an immediate stop token, so its post-token hidden state was never computed even though the official Talker conditions on it.
3. The client used a 1030 ms first-unit boundary even though the server reserves native PCM in 1000 ms units. The first video frame therefore entered the following unit.
4. Asynchronous lookahead sampling mutated stateful duplex metadata even when the speculative output was discarded.

### Fix

- Carry the Thinker input token IDs and positions alongside latent hidden states.
- Resolve Talker conditioning from the latest contiguous forwarded-token span.
- Allow `<|turn_eos|>` to complete one forward pass before the unit terminator stops generation.
- Align the first media boundary with the server’s 1000 ms PCM reservation.
- Disable asynchronous scheduling for the stateful Thinker and Talker stages.
- Add regressions for later audio prefill, repeated text, discontinuous positions, missing terminal hidden states, frame timing, and scheduler selection.

## Test Plan

Run the affected bridge, client, configuration, and duplex-driver tests:

```bash
python -m pytest -q \
    tests/model_executor/stage_input_processors/test_minicpmo_4_5_omni.py \
    tests/clients/test_duplex_client.py \
    tests/e2e/online_serving/test_minicpmo_realtime_duplex_drivers.py \
    tests/config/test_config_factory.py
```

Run the related MiniCPM-o and native duplex tests:

```bash
python -m pytest -q \
    tests/model_executor/models/minicpmo_4_5/test_llm2tts.py \
    tests/model_executor/models/minicpmo_4_5/duplex \
    tests/worker/test_native_duplex_hooks.py
```

**vLLM Version:** 0.28.0

**vLLM-Omni Commit:** `088f81661a0c4f45b3f73562f77bd3fba3bd257b`

## Test Result

- Bridge, client, configuration, and duplex-driver tests: `472 passed`
- MiniCPM-o and native duplex tests: `101 passed, 1 skipped`
- Ruff formatting and lint checks passed
- YAML, test-marker, SPDX, whitespace, and typo checks passed

Manual end-to-end validation used an RTX 5090 32 GB instance and `openbmb/MiniCPM-o-4_5/assets/omni_duplex1.mp4`. The official implementation and the corrected vLLM-Omni pipeline produced the same response text:

> 好的，没问题。到 24 楼了。是的，你刚才开门了。

Both implementations consumed all 35 video frames without request errors. For 16 captured codec chunks replayed with identical inputs, every complete decoder waveform passed `atol=1e-5, rtol=1e-4`; the maximum absolute difference was `1.97e-6`.





