### PR TITLE
[Benchmark] Add Omni-DuplexEval performance case

### DIFF
--- a/tests/benchmarks/duplex/test_duplex_eval_backend.py
+++ b/tests/benchmarks/duplex/test_duplex_eval_backend.py
@@ -1,0 +1,832 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""Offline unit tests for the Omni-DuplexEval backend module (D1 + D2).
+
+Covers contract, routing, exclude/take semantics, generation-ledger math,
+artifact publication, merge protocol and session-options translation.
+See ``plans/omni-duplex-eval-backend-design.md`` §9.1 for the test matrix.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+try:
+    from vllm_omni.entrypoints.cli.benchmark import cli_args as _cli_args
+except ImportError:  # vllm may be missing in the offline stub environment
+    _cli_args = None  # type: ignore[assignment]
+
+# ------------------------------------------------------------------ #
+# Module-level markers (required by tools/pre_commit/check_test_marks.py)
+# ------------------------------------------------------------------ #
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+# ------------------------------------------------------------------ #
+# Internal helpers used by multiple tests
+# ------------------------------------------------------------------ #
+
+
+@dataclass
+class _FakeOutput:
+    """Minimal output stub with the attributes ``finalize_duplex_eval_batch`` reads."""
+
+    duplex_eval_case_result: object = None
+    success: bool = True
+    latency: float = 1.0
+    error: str = ""
+    prompt_len: int = 0
+    duplex_session_metrics: dict[str, object] | None = None
+
+
+def _make_options(**overrides: Any) -> dict[str, Any]:
+    """Return a full ``DuplexEvalSessionOptions`` field dict with testable defaults."""
+    base = {
+        "response_root": Path("/tmp/responses"),
+        "score_dir": Path("/tmp/scores"),
+        "ref_audio": "tests/assets/ref.wav",
+        "fps": 1.0,
+        "mix": "question",
+        "pace": "realtime",
+        "clock": "media",
+        "unit_ms": 1000,
+        "overwrite": False,
+        "exclude_ids": (),
+        "write_artifacts": False,  # off by default to avoid filesystem I/O
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_sample(
+    sample_id: str = "s1",
+    split: str = "RTD_OCR",
+    family: str = "rtd",
+    task_type: str | None = None,
+) -> SimpleNamespace:
+    """Return a lightweight sample-like object for tests that don't need the real dataclass."""
+    return SimpleNamespace(
+        id=sample_id,
+        split=split,
+        family=family,
+        task_type=task_type,
+        video="",
+        question_audio=None,
+    )
+
+
+# ================================================================== #
+# T1: ``DuplexEvalDataset.sample`` contract
+# ================================================================== #
+
+
+class TestDuplexEvalDatasetContract:
+    """T1: mandatory ``options``, ``num_requests=0``, prefix, shuffle guard."""
+
+    def test_options_is_mandatory_keyword_only(self) -> None:
+        """Calling ``sample()`` without ``options`` raises TypeError."""
+        from vllm_omni.benchmarks.data_modules.duplex_eval_dataset import (
+            DuplexEvalDataset,
+        )
+
+        dataset = DuplexEvalDataset(dataset="dummy", disable_shuffle=True)
+        with pytest.raises(TypeError, match="options"):
+            dataset.sample(None, 1)  # type: ignore[call-arg]
+
+    def test_num_requests_zero_returns_all(self, monkeypatch) -> None:
+        """``num_requests=0`` selects every available sample (no capping)."""
+        from vllm_omni.benchmarks.data_modules.duplex_eval_dataset import (
+            DuplexEvalDataset,
+            DuplexEvalSessionOptions,
+        )
+
+        samples_pool = [_make_sample(f"s{i}") for i in range(5)]
+        monkeypatch.setattr(
+            "vllm_omni.benchmarks.data_modules.duplex_eval_dataset.load_samples",
+            lambda *a, **kw: samples_pool,
+        )
+        options = DuplexEvalSessionOptions(**_make_options())
+        # Pin a single split so the split-agnostic stub is not reused per split
+        # when ``split="all"`` expands to every known split.
+        dataset = DuplexEvalDataset(dataset="dummy", split="RTD_OCR", disable_shuffle=True)
+        requests = dataset.sample(None, 0, options=options)
+        assert len(requests) == 5
+
+    def test_request_id_prefix(self, monkeypatch) -> None:
+        from vllm_omni.benchmarks.data_modules.duplex_eval_dataset import (
+            DuplexEvalDataset,
+            DuplexEvalSessionOptions,
+        )
+
+        monkeypatch.setattr(
+            "vllm_omni.benchmarks.data_modules.duplex_eval_dataset.load_samples",
+            lambda *a, **kw: [_make_sample("x1")],
+        )
+        options = DuplexEvalSessionOptions(**_make_options())
+        dataset = DuplexEvalDataset(dataset="dummy", disable_shuffle=True)
+        requests = dataset.sample(None, 1, request_id_prefix="pre-", options=options)
+        assert requests[0].request_id == "pre-0"
+
+    def test_disable_shuffle_preserves_order(self, monkeypatch) -> None:
+        from vllm_omni.benchmarks.data_modules.duplex_eval_dataset import (
+            DuplexEvalDataset,
+            DuplexEvalSessionOptions,
+        )
+
+        ids = [f"s{i}" for i in range(10)]
+        samples_pool = [_make_sample(sample_id=id_) for id_ in ids]
+        monkeypatch.setattr(
+            "vllm_omni.benchmarks.data_modules.duplex_eval_dataset.load_samples",
+            lambda *a, **kw: samples_pool,
+        )
+        options = DuplexEvalSessionOptions(**_make_options())
+        dataset = DuplexEvalDataset(dataset="dummy", disable_shuffle=True)
+        requests = dataset.sample(None, 10, options=options)
+        assert [r.duplex_eval_sample.id for r in requests] == ids
+
+
+# ================================================================== #
+# T2: Dataset routing
+# ================================================================== #
+
+
+class TestDatasetRouting:
+    """T2: directory / .parquet / JSON manifest all reach different loaders."""
+
+    def test_json_manifest_routes_to_read_manifest(self, tmp_path, monkeypatch) -> None:
+        from vllm_omni.benchmarks.data_modules.duplex_eval_dataset import (
+            DuplexEvalDataset,
+            DuplexEvalSessionOptions,
+        )
+
+        manifest = tmp_path / "samples.json"
+        manifest.write_text(
+            json.dumps([{"id": "m1", "split": "RTD_OCR", "video": "clip.mp4"}]),
+            encoding="utf-8",
+        )
+        options = DuplexEvalSessionOptions(**_make_options())
+        dataset = DuplexEvalDataset(dataset=str(manifest), disable_shuffle=True)
+        requests = dataset.sample(None, 1, options=options)
+        assert len(requests) == 1
+        assert requests[0].duplex_eval_sample.id == "m1"
+
+
+# ================================================================== #
+# T3: ``DuplexEvalSampleRequest`` field integrity
+# ================================================================== #
+
+
+class TestSampleRequestFields:
+    """T3: fields are correctly mounted; others are zero-values."""
+
+    def test_fields_are_mounted(self, monkeypatch) -> None:
+        from vllm_omni.benchmarks.data_modules.duplex_eval_dataset import (
+            DuplexEvalDataset,
+            DuplexEvalSampleRequest,
+            DuplexEvalSessionOptions,
+        )
+
+        ds_sample = _make_sample("s42", split="PR_correction", family="pr")
+        monkeypatch.setattr(
+            "vllm_omni.benchmarks.data_modules.duplex_eval_dataset.load_samples",
+            lambda *a, **kw: [ds_sample],
+        )
+        options = DuplexEvalSessionOptions(**_make_options())
+        dataset = DuplexEvalDataset(dataset="dummy", disable_shuffle=True)
+        requests = dataset.sample(None, 1, options=options)
+        req = requests[0]
+        assert isinstance(req, DuplexEvalSampleRequest)
+        assert req.duplex_eval_sample is ds_sample
+        assert req.duplex_eval_options is options
+        assert req.prompt == ""
+        assert req.prompt_len == 0
+        assert req.multi_modal_data is None
+
+
+# ================================================================== #
+# T4: ``normalize_exclude_ids()``
+# ================================================================== #
+
+
+class TestNormalizeExcludeIds:
+    """T4: bare id and split/id forms; invalid format raises."""
+
+    def test_bare_id_accepted(self) -> None:
+        from vllm_omni.benchmarks.data_modules.duplex_eval_dataset import (
+            normalize_exclude_ids,
+        )
+
+        result = normalize_exclude_ids(["565"])
+        assert "565" in result
+
+    def test_split_id_accepted(self) -> None:
+        from vllm_omni.benchmarks.data_modules.duplex_eval_dataset import (
+            normalize_exclude_ids,
+        )
+
+        result = normalize_exclude_ids(["RTD_OCR/565"])
+        assert "RTD_OCR/565" in result
+
+    def test_empty_input_returns_empty(self) -> None:
+        from vllm_omni.benchmarks.data_modules.duplex_eval_dataset import (
+            normalize_exclude_ids,
+        )
+
+        assert normalize_exclude_ids([]) == frozenset()
+
+    def test_invalid_format_raises(self) -> None:
+        from vllm_omni.benchmarks.data_modules.duplex_eval_dataset import (
+            normalize_exclude_ids,
+        )
+
+        with pytest.raises(ValueError, match="invalid exclude-id"):
+            normalize_exclude_ids(["a/b/c"])  # too many slashes
+
+    def test_whitespace_skipped(self) -> None:
+        from vllm_omni.benchmarks.data_modules.duplex_eval_dataset import (
+            normalize_exclude_ids,
+        )
+
+        result = normalize_exclude_ids(["  ", "565"])
+        assert len(result) == 1
+
+
+# ================================================================== #
+# T5: exclude BEFORE limit per split
+# ================================================================== #
+
+
+class TestExcludeBeforeLimit:
+    """T5: exclude is applied per-split before limit (§8.5 D-2)."""
+
+    def test_exclude_before_limit(self, monkeypatch) -> None:
+        from vllm_omni.benchmarks.data_modules.duplex_eval_dataset import (
+            DuplexEvalDataset,
+            DuplexEvalSessionOptions,
+        )
+
+        # 6 samples across 2 splits (3 each)
+        samples = [
+            _make_sample("s0", split="RTD_OCR", family="rtd"),
+            _make_sample("s1", split="RTD_OCR", family="rtd"),
+            _make_sample("s2", split="RTD_OCR", family="rtd"),
+            _make_sample("s3", split="PR_correction", family="pr"),
+            _make_sample("s4", split="PR_correction", family="pr"),
+            _make_sample("s5", split="PR_correction", family="pr"),
+        ]
+
+        def fake_load(dataset, *, split, family, media_root, ids):
+            return [s for s in samples if s.split == split and (family == "all" or s.family == family)]
+
+        monkeypatch.setattr(
+            "vllm_omni.benchmarks.data_modules.duplex_eval_dataset.load_samples",
+            fake_load,
+        )
+
+        exclude = ("s0",)
+        options = DuplexEvalSessionOptions(**_make_options(exclude_ids=exclude, write_artifacts=False))
+        # limit=4 per split → after exclude there are 2 per split,
+        # but we cap at 2 each = 4 total
+        dataset = DuplexEvalDataset(
+            dataset="dummy",
+            split="all",
+            family="all",
+            limit=2,
+            exclude_ids=exclude,
+            disable_shuffle=True,
+        )
+        requests = dataset.sample(None, 10, options=options)
+        selected_ids = [r.duplex_eval_sample.id for r in requests]
+        assert "s0" not in selected_ids, "excluded sample still present"
+        assert len(selected_ids) <= 4, "limit after exclude not respected"
+        # With 2 per split after exclude(3-1=2), limit=2 takes all, so total=4
+        assert len(selected_ids) == 4
+
+
+# ================================================================== #
+# T6: ``--ids`` and ``--exclude-ids`` mutex (dataset-level).
+# ================================================================== #
+
+
+class TestIdsExcludeMutex:
+    """T6: the preprocess-serve check rejects both ids and exclude-ids."""
+
+    def test_mutex_raises_value_error(self) -> None:
+        """The serve-side CLI check rejects both flags.
+
+        Uses a guard so the test is skipped when vllm (and therefore
+        ``cli_args``) is not importable (offline stub environment).
+        """
+        if _cli_args is None:
+            pytest.skip("cli_args not importable (vllm may be missing)")
+
+        import argparse
+
+        args = argparse.Namespace(
+            dataset_name="omni-duplex-eval",
+            backend="openai-realtime-duplex",
+            endpoint="/v1/realtime",
+            duplex_eval_ref_audio="tests/assets/ref.wav",
+            duplex_eval_pace="realtime",
+            duplex_eval_allow_invalid_clock=False,
+            duplex_eval_ids=["s1"],
+            duplex_eval_exclude_ids=["s2"],
+            explicit_keys=(),
+        )
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            _cli_args.preprocess_serve_args(args)  # type: ignore[union-attr]
+
+
+# ================================================================== #
+# T10: ``generation_summary`` counting
+# ================================================================== #
+
+
+class TestGenerationSummary:
+    """T10: total/generated/generation_failed arithmetic."""
+
+    def test_all_success(self) -> None:
+        from vllm_omni.benchmarks.duplex_eval import (
+            DuplexEvalCaseResult,
+            generation_summary,
+        )
+
+        results = [
+            DuplexEvalCaseResult(id="s1", split="RTD_OCR", family="rtd", success=True),
+            DuplexEvalCaseResult(id="s2", split="RTD_OCR", family="rtd", success=True),
+        ]
+        s = generation_summary(results)
+        assert s["total"] == 2
+        assert s["generated"] == 2
+        assert s["generation_failed"] == 0
+        assert s["failure_ids"] == []
+
+    def test_partial_failure(self) -> None:
+        from vllm_omni.benchmarks.duplex_eval import (
+            DuplexEvalCaseResult,
+            generation_summary,
+        )
+
+        results = [
+            DuplexEvalCaseResult(id="ok", split="RTD_OCR", family="rtd", success=True),
+            DuplexEvalCaseResult(
+                id="fail",
+                split="PR_correction",
+                family="pr",
+                success=False,
+                error="timeout",
+            ),
+        ]
+        s = generation_summary(results)
+        assert s["total"] == 2
+        assert s["generated"] == 1
+        assert s["generation_failed"] == 1
+        assert "PR_correction/fail" in s["failure_ids"]
+
+
+# ================================================================== #
+# T11: ``finalize_duplex_eval_batch`` no duplex samples → ``None``
+# ================================================================== #
+
+
+class TestFinalizeNone:
+    """T11: returns None when no duplex-eval sample ran."""
+
+    def test_returns_none_when_no_duplex_results(self) -> None:
+        from vllm_omni.benchmarks.data_modules.omniinteract_dataset import (
+            OmniInteractSampleRequest,
+        )
+        from vllm_omni.benchmarks.duplex_eval import finalize_duplex_eval_batch
+
+        # Non-duplex requests — should be filtered out
+        requests = [SimpleNamespace(__class__=OmniInteractSampleRequest)]
+        outputs = [SimpleNamespace()]
+        result = finalize_duplex_eval_batch(requests, outputs)
+        assert result is None
+
+
+# ================================================================== #
+# T12: ``finalize_duplex_eval_batch`` never calls a judge (no network)
+# ================================================================== #
+
+
+class TestFinalizeNoNetwork:
+    """T12: no judge/network calls inside finalize (v2 §5.2)."""
+
+    def test_finalize_succeeds_without_judge(self, monkeypatch) -> None:
+        from vllm_omni.benchmarks.data_modules.duplex_eval_dataset import (
+            DuplexEvalSampleRequest,
+            DuplexEvalSessionOptions,
+        )
+        from vllm_omni.benchmarks.duplex_eval import (
+            DuplexEvalCaseResult,
+            finalize_duplex_eval_batch,
+        )
+
+        # If finalize ever touches a judge, this would raise.
+        monkeypatch.setattr(
+            "vllm_omni.benchmarks.data_modules.duplex_eval_dataset.load_samples",
+            lambda *a, **kw: [],
+        )
+
+        options = DuplexEvalSessionOptions(**_make_options())
+        sample_ds = _make_sample("s1")
+        req = DuplexEvalSampleRequest(
+            prompt="",
+            prompt_len=0,
+            expected_output_len=0,
+            request_id="0",
+            duplex_eval_sample=sample_ds,
+            duplex_eval_options=options,
+        )
+        result = DuplexEvalCaseResult(id="s1", split="RTD_OCR", family="rtd", success=True)
+        output = _FakeOutput(duplex_eval_case_result=result)
+
+        summary = finalize_duplex_eval_batch([req], [output])
+        assert summary is not None
+        assert summary["generated"] == 1
+
+
+# ================================================================== #
+# T13: ``finalize_*`` output has no judge fields
+# ================================================================== #
+
+
+class TestFinalizeNoJudgeFields:
+    """T13: returned dict must NOT contain score_summary or judge_*."""
+
+    def test_no_judge_fields(self, monkeypatch) -> None:
+        from vllm_omni.benchmarks.data_modules.duplex_eval_dataset import (
+            DuplexEvalSampleRequest,
+            DuplexEvalSessionOptions,
+        )
+        from vllm_omni.benchmarks.duplex_eval import (
+            DuplexEvalCaseResult,
+            finalize_duplex_eval_batch,
+        )
+
+        options = DuplexEvalSessionOptions(**_make_options())
+        sample_ds = _make_sample("s1")
+        req = DuplexEvalSampleRequest(
+            prompt="",
+            prompt_len=0,
+            expected_output_len=0,
+            request_id="0",
+            duplex_eval_sample=sample_ds,
+            duplex_eval_options=options,
+        )
+        result = DuplexEvalCaseResult(id="s1", split="RTD_OCR", family="rtd", success=True)
+        output = _FakeOutput(duplex_eval_case_result=result)
+
+        summary = finalize_duplex_eval_batch([req], [output])
+        assert summary is not None
+        assert "score_summary" not in summary
+        assert "judge_enabled" in summary
+        assert summary["judge_enabled"] is False
+        assert summary["scored"] == 0
+        assert summary["score_failed"] == 0
+
+
+# ================================================================== #
+# T14: artifact atomicity
+# ================================================================== #
+
+
+class TestFinalizeArtifacts:
+    """T14: batch_summary.json and eval_manifest.jsonl written atomically."""
+
+    def test_artifacts_written(self, tmp_path, monkeypatch) -> None:
+        from vllm_omni.benchmarks.data_modules.duplex_eval_dataset import (
+            DuplexEvalSampleRequest,
+            DuplexEvalSessionOptions,
+        )
+        from vllm_omni.benchmarks.duplex_eval import (
+            BATCH_ARTIFACTS,
+            DuplexEvalCaseResult,
+            finalize_duplex_eval_batch,
+        )
+
+        score_dir = tmp_path / "scores"
+        options = DuplexEvalSessionOptions(
+            **_make_options(
+                score_dir=score_dir,
+                write_artifacts=True,
+            )
+        )
+        sample_ds = _make_sample("s1")
+        req = DuplexEvalSampleRequest(
+            prompt="",
+            prompt_len=0,
+            expected_output_len=0,
+            request_id="0",
+            duplex_eval_sample=sample_ds,
+            duplex_eval_options=options,
+        )
+        result = DuplexEvalCaseResult(id="s1", split="RTD_OCR", family="rtd", success=True)
+        output = _FakeOutput(duplex_eval_case_result=result)
+
+        summary = finalize_duplex_eval_batch([req], [output])
+        assert summary is not None
+        assert summary["artifacts_complete"] is True
+        for name in BATCH_ARTIFACTS:
+            assert (score_dir / name).exists(), f"{name} not written"
+
+    def test_artifact_failure_reported(self, tmp_path, monkeypatch) -> None:
+        from vllm_omni.benchmarks.data_modules.duplex_eval_dataset import (
+            DuplexEvalSampleRequest,
+            DuplexEvalSessionOptions,
+        )
+        from vllm_omni.benchmarks.duplex_eval import (
+            DuplexEvalCaseResult,
+            finalize_duplex_eval_batch,
+        )
+
+        score_dir = tmp_path / "scores"
+        # Make the score_dir a file so writing fails.
+        score_dir.touch()
+
+        options = DuplexEvalSessionOptions(
+            **_make_options(
+                score_dir=score_dir,
+                write_artifacts=True,
+            )
+        )
+        sample_ds = _make_sample("s1")
+        req = DuplexEvalSampleRequest(
+            prompt="",
+            prompt_len=0,
+            expected_output_len=0,
+            request_id="0",
+            duplex_eval_sample=sample_ds,
+            duplex_eval_options=options,
+        )
+        result = DuplexEvalCaseResult(id="s1", split="RTD_OCR", family="rtd", success=True)
+        output = _FakeOutput(duplex_eval_case_result=result)
+
+        summary = finalize_duplex_eval_batch([req], [output])
+        assert summary is not None
+        assert summary["artifacts_complete"] is False
+        assert len(summary.get("artifact_errors", [])) > 0
+
+
+# ================================================================== #
+# T15: duplex_eval should not pollute ``result_percentile_metrics``.
+#       Structural assertion: the module does not export a judge.
+# ================================================================== #
+
+
+class TestNoJudgePollution:
+    """T15: structural assertion — duplex_eval module has no judge imports."""
+
+    def test_no_judge_import(self) -> None:
+        import vllm_omni.benchmarks.duplex_eval as de
+
+        source = Path(de.__file__).read_text(encoding="utf-8")
+        assert "judge" not in source.lower() or "merge_duplex_eval_into_result" in source
+        # Verify that the judge-evaluation function names are not present.
+        assert "_evaluate_rows" not in source
+        assert "evaluate_sample" not in source
+
+
+# ================================================================== #
+# T16: placeholder ``duplex_session_metrics`` suppress pseudo-zero TTFT
+# ================================================================== #
+
+
+class TestPlaceholderSessionMetrics:
+    """T16: ``duplex_session_metrics`` is a dict with ``mean_ttft_ms: None``."""
+
+    def test_placeholder_structure(self) -> None:
+        metrics = {
+            "mean_ttft_ms": None,
+            "mean_ttfp_ms": None,
+            "mean_rtf": None,
+            "source": "omni-duplex-eval",
+        }
+        assert isinstance(metrics, dict)
+        assert metrics["mean_ttft_ms"] is None
+
+
+# ================================================================== #
+# T17: ``options_from_args`` default values
+# ================================================================== #
+
+
+class TestOptionsFromArgs:
+    """T17: CLI args → DuplexEvalSessionOptions with correct defaults."""
+
+    def test_defaults(self) -> None:
+        from vllm_omni.benchmarks.duplex_eval import options_from_args
+
+        args = SimpleNamespace()
+        opts = options_from_args(args)
+        assert opts.fps == 1.0
+        assert opts.mix == "question"
+        assert opts.pace == "realtime"
+        assert opts.clock == "media"
+        assert opts.unit_ms == 1000
+        assert opts.overwrite is False
+        assert opts.exclude_ids == ()
+
+    def test_fields_are_read(self) -> None:
+        from vllm_omni.benchmarks.duplex_eval import options_from_args
+
+        args = SimpleNamespace(
+            duplex_eval_output_dir="custom-responses",
+            duplex_eval_score_dir="custom-scores",
+            duplex_eval_ref_audio="audio.wav",
+            duplex_eval_fps=2.0,
+            duplex_eval_mix="question",
+            duplex_eval_pace="as-fast-as-possible",
+            duplex_eval_clock="media",
+            duplex_eval_unit_ms=500,
+            duplex_eval_overwrite=True,
+            duplex_eval_exclude_ids=["565"],
+            duplex_eval_no_artifacts=True,
+        )
+        opts = options_from_args(args)
+        assert str(opts.response_root).endswith("custom-responses")
+        assert str(opts.score_dir).endswith("custom-scores")
+        assert opts.ref_audio == "audio.wav"
+        assert opts.fps == 2.0
+        assert opts.pace == "as-fast-as-possible"
+        assert opts.unit_ms == 500
+        assert opts.overwrite is True
+        assert opts.exclude_ids == ("565",)
+        assert opts.write_artifacts is False
+
+
+# ================================================================== #
+# T19: ``_locate_result_file`` uniqueness
+# ================================================================== #
+
+
+class TestLocateResultFile:
+    """T19: 0 or ≥2 matches → AssertionError; 1 match → returned."""
+
+    def test_zero_matches_raises(self, tmp_path) -> None:
+        from vllm_omni.benchmarks.duplex_eval import _locate_result_file
+
+        with pytest.raises(AssertionError, match="expected exactly one"):
+            _locate_result_file(
+                bench_dir=tmp_path,
+                test_name="nonexistent",
+                dataset_name="omni-duplex-eval",
+                flow=1,
+                num_prompt=3,
+                since=time.time(),
+            )
+
+    def test_exactly_one_match(self, tmp_path) -> None:
+        from vllm_omni.benchmarks.duplex_eval import _locate_result_file
+
+        result = tmp_path / "result_my_test_abc_omni-duplex-eval_1_3_in42_out84_20250301-120000.json"
+        result.write_text("{}", encoding="utf-8")
+        since = time.time() - 10
+        found = _locate_result_file(
+            bench_dir=tmp_path,
+            test_name="my_test",
+            dataset_name="omni-duplex-eval",
+            flow=1,
+            num_prompt=3,
+            since=since,
+        )
+        assert found.name == result.name
+
+
+# ================================================================== #
+# T20: ``merge_duplex_eval_into_result`` phase guard
+# ================================================================== #
+
+
+class TestMergePhaseGuard:
+    """T20: ``phase != "generate"`` → AssertionError; normal merge advances phase."""
+
+    def test_refuses_second_merge(self, tmp_path) -> None:
+        from vllm_omni.benchmarks.duplex_eval import (
+            merge_duplex_eval_into_result,
+        )
+
+        duplex = {
+            "phase": "generate+evaluate+summarize",
+            "total": 3,
+            "generated": 3,
+        }
+        payload = {
+            "completed": True,
+            "e2el": {"mean": 1.5},
+            "Hardware": {"gpu": "H100"},
+            "duplex_eval": duplex,
+        }
+        result_path = tmp_path / "result.json"
+        result_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        with pytest.raises(AssertionError, match="refusing to merge"):
+            merge_duplex_eval_into_result(
+                result_path,
+                score_summary={"samples": 3},
+                judge_meta={"model": "judge-model"},
+                phases=["generate", "evaluate", "summarize"],
+            )
+
+    def test_normal_merge_succeeds(self, tmp_path) -> None:
+        from vllm_omni.benchmarks.duplex_eval import (
+            merge_duplex_eval_into_result,
+        )
+
+        duplex = {
+            "phase": "generate",
+            "total": 3,
+            "generated": 3,
+            "score_dir": "duplex-eval-scores",
+        }
+        payload = {
+            "completed": True,
+            "e2el": {"mean": 1.5},
+            "Hardware": {"gpu": "H100"},
+            "baseline": {"mean_tpot_ms": 200.0},
+            "duplex_eval": duplex,
+        }
+        result_path = tmp_path / "result.json"
+        result_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        merged = merge_duplex_eval_into_result(
+            result_path,
+            score_summary={"samples": 3},
+            judge_meta={"model": "judge-model"},
+            phases=["generate", "evaluate", "summarize"],
+        )
+        d = merged["duplex_eval"]
+        assert d["phase"] == "generate+evaluate+summarize"
+        assert d["phases"] == ["generate", "evaluate", "summarize"]
+        assert d["judge_enabled"] is True
+        assert d["scored"] == 3
+        # Extra fields from the original payload were NOT touched.
+        assert merged["completed"] is True
+        assert merged["e2el"]["mean"] == 1.5
+
+
+# ================================================================== #
+# T21: idempotent merge / atomicity
+# ================================================================== #
+
+
+class TestMergeIdempotent:
+    """T21: second merge is blocked; .tmp residue does not exist on success."""
+
+    def test_second_merge_blocked(self, tmp_path) -> None:
+        from vllm_omni.benchmarks.duplex_eval import (
+            merge_duplex_eval_into_result,
+        )
+
+        duplex = {
+            "phase": "generate",
+            "total": 1,
+            "generated": 1,
+            "score_dir": "duplex-eval-scores",
+        }
+        payload = {"completed": True, "duplex_eval": duplex}
+        result_path = tmp_path / "result.json"
+        result_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        merge_duplex_eval_into_result(
+            result_path,
+            score_summary={"samples": 1},
+            judge_meta={},
+            phases=["generate", "evaluate", "summarize"],
+        )
+        # Second merge → phase guard blocks.
+        with pytest.raises(AssertionError, match="refusing to merge"):
+            merge_duplex_eval_into_result(
+                result_path,
+                score_summary={"samples": 1},
+                judge_meta={},
+                phases=["generate", "evaluate", "summarize"],
+            )
+
+    def test_no_tmp_residue_on_success(self, tmp_path) -> None:
+        from vllm_omni.benchmarks.duplex_eval import (
+            merge_duplex_eval_into_result,
+        )
+
+        duplex = {
+            "phase": "generate",
+            "total": 1,
+            "generated": 1,
+            "score_dir": "duplex-eval-scores",
+        }
+        payload = {"completed": True, "duplex_eval": duplex}
+        result_path = tmp_path / "result.json"
+        result_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        merge_duplex_eval_into_result(
+            result_path,
+            score_summary={"samples": 1},
+            judge_meta={},
+            phases=["generate", "evaluate", "summarize"],
+        )
+        tmp_files = list(tmp_path.glob("*.tmp"))
+        assert len(tmp_files) == 0, f".tmp residue: {tmp_files}"

--- a/tests/benchmarks/duplex/test_duplex_eval_cli_args.py
+++ b/tests/benchmarks/duplex/test_duplex_eval_cli_args.py
@@ -1,0 +1,380 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""Offline unit tests for the Omni-DuplexEval ``vllm bench serve`` CLI wiring.
+
+M3 / T22-T33: dataset choice extension, the ``--duplex-eval-*`` argument group
+(exactly 15 options) and every ``preprocess_serve_args`` validation rule, each
+with a positive and a negative case.
+
+All tests are fully offline. A missing/stale vLLM that makes the CLI package
+un-importable is reported as a *skip*, never an error: ``cli_args`` is a leaf
+module (stdlib only) and is loaded by file path in that case.
+
+See ``plans/omni-duplex-eval-backend-design.md`` §5.4 and §9.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DUPLEX_EVAL_PREFIX = "--duplex-eval-"
+_EXPECTED_OPTIONS = frozenset(
+    {
+        "--duplex-eval-split",
+        "--duplex-eval-family",
+        "--duplex-eval-media-root",
+        "--duplex-eval-limit",
+        "--duplex-eval-ids",
+        "--duplex-eval-exclude-ids",
+        "--duplex-eval-output-dir",
+        "--duplex-eval-score-dir",
+        "--duplex-eval-ref-audio",
+        "--duplex-eval-fps",
+        "--duplex-eval-pace",
+        "--duplex-eval-clock",
+        "--duplex-eval-overwrite",
+        "--duplex-eval-allow-invalid-clock",
+        "--duplex-eval-no-artifacts",
+    }
+)
+_EXPECTED_DEFAULTS = {
+    "duplex_eval_split": "all",
+    "duplex_eval_family": "all",
+    "duplex_eval_media_root": None,
+    "duplex_eval_limit": None,
+    "duplex_eval_ids": None,
+    "duplex_eval_exclude_ids": None,
+    "duplex_eval_output_dir": Path("duplex-eval-responses"),
+    "duplex_eval_score_dir": Path("duplex-eval-scores"),
+    "duplex_eval_ref_audio": None,
+    "duplex_eval_fps": 1.0,
+    "duplex_eval_pace": "realtime",
+    "duplex_eval_clock": "media",
+    "duplex_eval_overwrite": False,
+    "duplex_eval_allow_invalid_clock": False,
+    "duplex_eval_no_artifacts": False,
+}
+
+
+def _load_cli_args():
+    """Return the ``cli_args`` module, falling back to a file-path load.
+
+    ``vllm_omni.entrypoints.cli.__init__`` imports ``vllm.entrypoints.launchers``
+    on some vLLM builds. Loading the leaf module directly keeps these tests
+    runnable even when that optional package import fails.
+    """
+    try:
+        from vllm_omni.entrypoints.cli.benchmark import cli_args
+
+        return cli_args
+    except ImportError:
+        path = _REPO_ROOT / "vllm_omni" / "entrypoints" / "cli" / "benchmark" / "cli_args.py"
+        if not path.exists():  # pragma: no cover - repository layout guard
+            pytest.skip("cli_args.py is not available", allow_module_level=True)
+        spec = importlib.util.spec_from_file_location("_duplex_eval_cli_args_under_test", path)
+        if spec is None or spec.loader is None:  # pragma: no cover - defensive
+            pytest.skip("cli_args.py cannot be loaded", allow_module_level=True)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+
+cli_args = _load_cli_args()
+
+
+def _require_dataset_module() -> None:
+    """Skip when the dataset adapter (and therefore vLLM) is unavailable."""
+    pytest.importorskip("vllm_omni.benchmarks.data_modules.duplex_eval_dataset")
+
+
+def _serve_args(**overrides) -> argparse.Namespace:
+    """A fully valid ``omni-duplex-eval`` namespace that passes every rule."""
+    base: dict = {
+        "dataset_name": "omni-duplex-eval",
+        "backend": "openai-realtime-duplex",
+        "endpoint": "/v1/realtime",
+        "duplex_eval_ref_audio": "tests/assets/ref.wav",
+        "ignore_eos": False,
+        "profile": False,
+        "skip_tokenizer_init": False,
+        "probe_request_rate": 0.0,
+        "duplex_eval_pace": "realtime",
+        "duplex_eval_allow_invalid_clock": False,
+        "duplex_eval_ids": None,
+        "duplex_eval_exclude_ids": None,
+        "explicit_keys": (),
+        "num_prompts": 5,
+        "max_concurrency": 2,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _duplex_actions(parser: argparse.ArgumentParser) -> dict[str, argparse.Action]:
+    return {
+        action.dest: action
+        for action in parser._actions
+        if action.option_strings and any(opt.startswith(_DUPLEX_EVAL_PREFIX) for opt in action.option_strings)
+    }
+
+
+# ================================================================== #
+# T22: dataset choices contain ``omni-duplex-eval``
+# ================================================================== #
+
+
+class TestDatasetChoices:
+    """T22: the new dataset token is registered on the serve parser."""
+
+    def test_constant_contains_token(self) -> None:
+        assert "omni-duplex-eval" in cli_args._OMNI_BENCH_DATASET_CHOICES
+
+    def test_extend_omni_choices_adds_token(self) -> None:
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--dataset-name", dest="dataset_name", choices=["sharegpt", "hf"])
+        cli_args.extend_omni_choices(parser)
+        action = next(a for a in parser._actions if a.dest == "dataset_name")
+        assert "omni-duplex-eval" in action.choices
+        for choice in cli_args._OMNI_BENCH_DATASET_CHOICES:
+            assert choice in action.choices
+
+    def test_extend_omni_choices_handles_shadow_parser(self) -> None:
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--dataset-name", dest="dataset_name", choices=["hf"])
+        shadow = argparse.ArgumentParser()
+        shadow.add_argument("--dataset-name", dest="dataset_name", choices=["hf"])
+        setattr(parser, "_shadow", shadow)
+        cli_args.extend_omni_choices(parser)
+        for target in (parser, shadow):
+            action = next(a for a in target._actions if a.dest == "dataset_name")
+            assert "omni-duplex-eval" in action.choices
+
+
+# ================================================================== #
+# T23: ``add_duplex_eval_cli_args`` registers exactly 15 options
+# ================================================================== #
+
+
+class TestDuplexEvalArgRegistration:
+    """T23: option set, defaults, types/choices and ``add_omni_args`` hookup."""
+
+    def test_exactly_fifteen_options(self) -> None:
+        parser = argparse.ArgumentParser()
+        cli_args.add_duplex_eval_cli_args(parser)
+        option_strings = {
+            opt for action in parser._actions for opt in action.option_strings if opt.startswith(_DUPLEX_EVAL_PREFIX)
+        }
+        assert option_strings == set(_EXPECTED_OPTIONS)
+        assert len(option_strings) == 15
+
+    def test_no_judge_options_registered(self) -> None:
+        parser = argparse.ArgumentParser()
+        cli_args.add_duplex_eval_cli_args(parser)
+        for action in parser._actions:
+            assert "judge" not in action.dest
+            for opt in action.option_strings:
+                assert "judge" not in opt
+
+    def test_defaults(self) -> None:
+        _require_dataset_module()
+        parser = argparse.ArgumentParser()
+        cli_args.add_duplex_eval_cli_args(parser)
+        args = parser.parse_args([])
+        for dest, expected in _EXPECTED_DEFAULTS.items():
+            assert getattr(args, dest) == expected, dest
+
+    def test_types_and_choices(self) -> None:
+        _require_dataset_module()
+        parser = argparse.ArgumentParser()
+        cli_args.add_duplex_eval_cli_args(parser)
+        actions = _duplex_actions(parser)
+        assert actions["duplex_eval_limit"].type is cli_args._non_negative_int
+        assert actions["duplex_eval_fps"].type is cli_args._positive_finite_float
+        assert actions["duplex_eval_ref_audio"].type is cli_args._existing_file
+        assert actions["duplex_eval_output_dir"].type is Path
+        assert actions["duplex_eval_score_dir"].type is Path
+        assert actions["duplex_eval_ids"].nargs == "+"
+        assert actions["duplex_eval_exclude_ids"].nargs == "+"
+        assert actions["duplex_eval_family"].choices == ["all", "rtd", "pr"]
+        assert actions["duplex_eval_pace"].choices == ["realtime", "as-fast-as-possible"]
+        assert actions["duplex_eval_clock"].choices == ["media"]
+        for dest in ("duplex_eval_overwrite", "duplex_eval_allow_invalid_clock", "duplex_eval_no_artifacts"):
+            assert actions[dest].default is False
+            assert actions[dest].nargs == 0
+
+    def test_registered_by_add_omni_args(self, monkeypatch) -> None:
+        parser = argparse.ArgumentParser()
+        for helper in (
+            "add_daily_omni_cli_args",
+            "add_omniinteract_cli_args",
+            "add_seed_tts_cli_args",
+            "add_multi_stage_cli_args",
+            "add_diffusion_cli_args",
+        ):
+            monkeypatch.setattr(cli_args, helper, lambda _parser: None)
+        recorded: list[bool] = []
+        original = cli_args.add_duplex_eval_cli_args
+
+        def _spy(target: argparse.ArgumentParser) -> None:
+            recorded.append(True)
+            original(target)
+
+        monkeypatch.setattr(cli_args, "add_duplex_eval_cli_args", _spy)
+        cli_args.add_omni_args(parser)
+        assert recorded == [True]
+        assert _EXPECTED_OPTIONS <= {
+            opt for action in parser._actions for opt in action.option_strings if opt.startswith(_DUPLEX_EVAL_PREFIX)
+        }
+
+
+# ================================================================== #
+# T24: ``_non_negative_int``
+# ================================================================== #
+
+
+class TestNonNegativeInt:
+    """T24: accepts 0/positive, rejects negatives and non-integers."""
+
+    def test_accepts_zero_and_positive(self) -> None:
+        assert cli_args._non_negative_int("0") == 0
+        assert cli_args._non_negative_int("7") == 7
+
+    def test_rejects_negative(self) -> None:
+        with pytest.raises(argparse.ArgumentTypeError, match="non-negative"):
+            cli_args._non_negative_int("-1")
+
+    def test_rejects_non_integer(self) -> None:
+        with pytest.raises(ValueError, match="invalid literal"):
+            cli_args._non_negative_int("abc")
+
+
+# ================================================================== #
+# T25-T33: ``preprocess_serve_args`` validation rules
+# ================================================================== #
+
+
+class TestBackendRule:
+    """T25: backend must be ``openai-realtime-duplex``."""
+
+    def test_valid_backend_passes(self) -> None:
+        args = _serve_args()
+        cli_args.preprocess_serve_args(args)
+        assert args.num_prompts == 3  # not explicit → default
+
+    def test_wrong_backend_raises(self) -> None:
+        with pytest.raises(ValueError, match="backend openai-realtime-duplex"):
+            cli_args.preprocess_serve_args(_serve_args(backend="openai-chat-omni"))
+
+
+class TestEndpointRule:
+    """T26: endpoint must be ``/v1/realtime``."""
+
+    def test_valid_endpoint_passes(self) -> None:
+        cli_args.preprocess_serve_args(_serve_args(endpoint="/v1/realtime"))
+
+    def test_wrong_endpoint_raises(self) -> None:
+        with pytest.raises(ValueError, match="endpoint /v1/realtime"):
+            cli_args.preprocess_serve_args(_serve_args(endpoint="/v1/chat/completions"))
+
+
+class TestRefAudioRule:
+    """T27: ``--duplex-eval-ref-audio`` is mandatory."""
+
+    def test_valid_ref_audio_passes(self) -> None:
+        cli_args.preprocess_serve_args(_serve_args(duplex_eval_ref_audio="/tmp/ref.wav"))
+
+    def test_missing_ref_audio_raises(self) -> None:
+        with pytest.raises(ValueError, match="ref-audio"):
+            cli_args.preprocess_serve_args(_serve_args(duplex_eval_ref_audio=None))
+
+
+class TestBannedFlags:
+    """T28: ``--ignore-eos`` / ``--profile`` / ``--skip-tokenizer-init`` banned."""
+
+    @pytest.mark.parametrize("flag", ["ignore_eos", "profile", "skip_tokenizer_init"])
+    def test_banned_flag_raises(self, flag: str) -> None:
+        with pytest.raises(ValueError, match="does not support"):
+            cli_args.preprocess_serve_args(_serve_args(**{flag: True}))
+
+    def test_all_disabled_passes(self) -> None:
+        cli_args.preprocess_serve_args(_serve_args(ignore_eos=False, profile=False, skip_tokenizer_init=False))
+
+
+class TestProbeRequestRateRule:
+    """T29: ``--probe-request-rate`` is rejected."""
+
+    def test_zero_passes(self) -> None:
+        cli_args.preprocess_serve_args(_serve_args(probe_request_rate=0.0))
+
+    def test_positive_raises(self) -> None:
+        with pytest.raises(ValueError, match="probe-request-rate"):
+            cli_args.preprocess_serve_args(_serve_args(probe_request_rate=1.0))
+
+
+class TestPaceClockRule:
+    """T30: non-realtime pace needs ``--duplex-eval-allow-invalid-clock``."""
+
+    def test_realtime_pace_passes(self) -> None:
+        cli_args.preprocess_serve_args(_serve_args(duplex_eval_pace="realtime"))
+
+    def test_fast_pace_without_optin_raises(self) -> None:
+        with pytest.raises(ValueError, match="clock=invalid"):
+            cli_args.preprocess_serve_args(_serve_args(duplex_eval_pace="as-fast-as-possible"))
+
+    def test_fast_pace_with_optin_passes(self) -> None:
+        cli_args.preprocess_serve_args(
+            _serve_args(duplex_eval_pace="as-fast-as-possible", duplex_eval_allow_invalid_clock=True)
+        )
+
+
+class TestIdsExcludeMutex:
+    """T31: ``--duplex-eval-ids`` and ``--duplex-eval-exclude-ids`` are exclusive."""
+
+    def test_single_selector_passes(self) -> None:
+        cli_args.preprocess_serve_args(_serve_args(duplex_eval_ids=["565"]))
+        cli_args.preprocess_serve_args(_serve_args(duplex_eval_exclude_ids=["565"]))
+
+    def test_both_selectors_raise(self) -> None:
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            cli_args.preprocess_serve_args(_serve_args(duplex_eval_ids=["565"], duplex_eval_exclude_ids=["566"]))
+
+
+class TestNumPromptsDefault:
+    """T32: omitted ``--num-prompts`` folds to 3; explicit value is preserved."""
+
+    def test_default_is_three(self) -> None:
+        args = _serve_args(num_prompts=99, explicit_keys=())
+        cli_args.preprocess_serve_args(args)
+        assert args.num_prompts == 3
+
+    def test_explicit_value_preserved(self) -> None:
+        args = _serve_args(num_prompts=7, explicit_keys=("num_prompts",))
+        cli_args.preprocess_serve_args(args)
+        assert args.num_prompts == 7
+
+
+class TestMaxConcurrencyRule:
+    """T33: omitted ``--max-concurrency`` folds to 1; non-positive is rejected."""
+
+    def test_default_is_one(self) -> None:
+        args = _serve_args(max_concurrency=None)
+        cli_args.preprocess_serve_args(args)
+        assert args.max_concurrency == 1
+
+    @pytest.mark.parametrize("value", [0, -3])
+    def test_non_positive_raises(self, value: int) -> None:
+        with pytest.raises(ValueError, match="max-concurrency"):
+            cli_args.preprocess_serve_args(_serve_args(max_concurrency=value))
+
+    def test_positive_value_preserved(self) -> None:
+        args = _serve_args(max_concurrency=4)
+        cli_args.preprocess_serve_args(args)
+        assert args.max_concurrency == 4

--- a/tests/benchmarks/duplex/test_duplex_eval_judge.py
+++ b/tests/benchmarks/duplex/test_duplex_eval_judge.py
@@ -1,0 +1,320 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""Offline unit tests for the Qwen3-Omni judge adaptation (M3).
+
+Covers the three-level ``select_judge_text`` strategy, the ``modalities``
+request-body opt-in, the parameterised ``content_frame_limit`` frame budget
+(including byte-for-byte equivalence with the legacy 16-frame implementation)
+and the unchanged judge protocol / ``timeout=600``.
+
+Fully offline: the HTTP transport is replaced by a stub, no server is needed.
+
+See ``plans/omni-duplex-eval-backend-design.md`` §5.6a/b, §9 rows T7-T9.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+try:
+    from vllm_omni.benchmarks.duplex import omni_duplex_eval_eval as eval_mod
+    from vllm_omni.benchmarks.duplex import omni_duplex_eval_judge as judge_mod
+except ImportError:  # pragma: no cover - offline stub environment
+    pytest.skip("judge/eval module is not importable", allow_module_level=True)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _old_content_frame_times(duration: float) -> list[float]:
+    """The pre-M3 16-frame implementation, reproduced verbatim for regression."""
+    if duration <= 0:
+        return []
+    times = []
+    timestamp = 0.0
+    while timestamp < duration:
+        times.append(min(timestamp, max(0.0, duration - 0.01)))
+        timestamp += 3.0
+    if len(times) > 16:
+        stride = (len(times) - 1) / 15
+        times = [times[round(i * stride)] for i in range(16)]
+    return times
+
+
+# ================================================================== #
+# ``select_judge_text`` three-level strategy (T8)
+# ================================================================== #
+
+
+class TestSelectJudgeText:
+    """Level 1: text modality; level 2: first non-empty; level 3: choices[0]."""
+
+    def test_prefers_text_modality_choice(self) -> None:
+        payload = {
+            "choices": [
+                {"modality": "audio", "message": {"content": "AUDIO"}},
+                {"modality": "text", "message": {"content": "TEXT"}},
+            ]
+        }
+        assert judge_mod.select_judge_text(payload) == "TEXT"
+
+    def test_modality_under_message_is_honoured(self) -> None:
+        payload = {
+            "choices": [
+                {"message": {"modality": "audio", "content": "AUDIO"}},
+                {"message": {"modality": "text", "content": "TEXT"}},
+            ]
+        }
+        assert judge_mod.select_judge_text(payload) == "TEXT"
+
+    def test_text_modality_with_blank_text_falls_back(self) -> None:
+        payload = {
+            "choices": [
+                {"modality": "text", "message": {"content": "   "}},
+                {"message": {"content": "SECOND"}},
+            ]
+        }
+        assert judge_mod.select_judge_text(payload) == "SECOND"
+
+    def test_first_non_empty_message_without_modality(self) -> None:
+        payload = {
+            "choices": [
+                {"message": {"content": ""}},
+                {"message": {"content": "SECOND"}},
+            ]
+        }
+        assert judge_mod.select_judge_text(payload) == "SECOND"
+
+    def test_single_choice_is_returned(self) -> None:
+        payload = {"choices": [{"message": {"content": "ONLY"}}]}
+        assert judge_mod.select_judge_text(payload) == "ONLY"
+
+    def test_blank_choices_fall_back_to_first(self) -> None:
+        payload = {"choices": [{"message": {"content": ""}}, {"message": {"content": "  "}}]}
+        assert judge_mod.select_judge_text(payload) == ""
+
+    def test_list_content_flattens_text_parts(self) -> None:
+        payload = {
+            "choices": [
+                {
+                    "message": {
+                        "content": [
+                            {"type": "text", "text": "A"},
+                            {"type": "image_url", "image_url": {"url": "x"}},
+                            {"type": "text", "text": "B"},
+                        ]
+                    }
+                }
+            ]
+        }
+        assert judge_mod.select_judge_text(payload) == "AB"
+
+    @pytest.mark.parametrize("payload", [{}, {"choices": []}, {"choices": "nope"}, {"choices": None}])
+    def test_no_choices_raises(self, payload) -> None:
+        with pytest.raises(ValueError, match="no choices"):
+            judge_mod.select_judge_text(payload)
+
+
+# ================================================================== #
+# ``DuplexJudge`` request-body invariance (T9)
+# ================================================================== #
+
+
+class _FakeResponse:
+    ok = True
+    status_code = 200
+    text = ""
+
+    def json(self) -> dict:
+        return {"choices": [{"message": {"content": "OK"}}]}
+
+
+class TestDuplexJudgeRequestBody:
+    """``modalities=None`` keeps the body unchanged; an explicit list opts in."""
+
+    def _patch_transport(self, monkeypatch) -> dict:
+        captured: dict = {}
+
+        def _post(url, *, json=None, headers=None, timeout=None, **kwargs):
+            captured.update(url=url, body=json, headers=headers, timeout=timeout)
+            return _FakeResponse()
+
+        monkeypatch.setattr(judge_mod.requests, "post", _post)
+        return captured
+
+    def test_defaults(self) -> None:
+        parameters = inspect.signature(judge_mod.DuplexJudge.__init__).parameters
+        assert parameters["timeout"].default == 600
+        assert parameters["modalities"].default is None
+        assert parameters["api_key"].default == "EMPTY"
+
+    def test_body_has_no_extra_keys_without_modalities(self, monkeypatch) -> None:
+        captured = self._patch_transport(monkeypatch)
+        judge = judge_mod.DuplexJudge("http://judge:8000", "test-judge")
+        assert judge.modalities is None
+
+        assert judge.chat("prompt") == "OK"
+
+        assert set(captured["body"]) == {"model", "messages", "temperature", "max_tokens"}
+        assert captured["body"]["model"] == "test-judge"
+        assert captured["body"]["temperature"] == 0.1
+        assert captured["body"]["max_tokens"] == 1200
+        assert captured["timeout"] == 600
+        assert captured["url"].endswith("/v1/chat/completions")
+
+    def test_modalities_are_written_when_requested(self, monkeypatch) -> None:
+        captured = self._patch_transport(monkeypatch)
+        judge = judge_mod.DuplexJudge("http://judge:8000", "test-judge", modalities=["text"])
+        assert judge.modalities == ("text",)
+
+        judge.chat("prompt")
+
+        assert captured["body"]["modalities"] == ["text"]
+
+    def test_empty_modalities_is_not_written(self, monkeypatch) -> None:
+        captured = self._patch_transport(monkeypatch)
+        judge = judge_mod.DuplexJudge("http://judge:8000", "test-judge", modalities=[])
+        assert judge.modalities is None
+        judge.chat("prompt")
+        assert "modalities" not in captured["body"]
+
+    def test_system_message_is_prepended(self, monkeypatch) -> None:
+        captured = self._patch_transport(monkeypatch)
+        judge_mod.DuplexJudge("http://judge:8000", "test-judge").chat("hi", system="be careful")
+        messages = captured["body"]["messages"]
+        assert messages[0] == {"role": "system", "content": "be careful"}
+        assert messages[1]["role"] == "user"
+
+    def test_url_builder_is_unchanged(self) -> None:
+        assert judge_mod._build_openai_url("http://h:1", "/chat/completions") == "http://h:1/v1/chat/completions"
+        assert judge_mod._build_openai_url("http://h:1/v1", "/chat/completions") == "http://h:1/v1/chat/completions"
+        assert (
+            judge_mod._build_openai_url("http://h:1/v1/chat/completions", "/chat/completions")
+            == "http://h:1/v1/chat/completions"
+        )
+
+
+# ================================================================== #
+# ``_content_frame_times`` frame budget (T7)
+# ================================================================== #
+
+
+class TestContentFrameTimes:
+    """``max_frames=16`` reproduces the legacy sequence; smaller caps truncate."""
+
+    @pytest.mark.parametrize("duration", [0.0, 1.0, 3.0, 10.0, 47.9, 48.0, 100.0, 300.0, 1000.0])
+    def test_default_matches_legacy(self, duration: float) -> None:
+        assert eval_mod._content_frame_times(duration) == _old_content_frame_times(duration)
+        assert eval_mod._content_frame_times(duration, max_frames=16) == _old_content_frame_times(duration)
+
+    def test_constant_is_sixteen(self) -> None:
+        assert eval_mod.CONTENT_FRAME_LIMIT == 16
+
+    def test_smaller_budget_truncates(self) -> None:
+        legacy = _old_content_frame_times(300.0)
+        capped = eval_mod._content_frame_times(300.0, max_frames=8)
+        assert len(capped) == 8
+        assert capped[0] == legacy[0]
+        assert capped[-1] == legacy[-1]
+
+    def test_short_clip_is_not_padded(self) -> None:
+        times = eval_mod._content_frame_times(5.0, max_frames=8)
+        assert 0 < len(times) <= 8
+
+    @pytest.mark.parametrize("duration", [0.0, -5.0])
+    def test_non_positive_duration_is_empty(self, duration: float) -> None:
+        assert eval_mod._content_frame_times(duration) == []
+
+
+# ================================================================== #
+# ``evaluate_sample(..., content_frame_limit=...)`` wiring
+# ================================================================== #
+
+
+class _StubJudge:
+    model = "stub-judge"
+
+    def temporal(self, prompt, frames):
+        return "{}"
+
+    def content(self, prompt, video=None, frames=None, *, mode="video_url"):
+        return "{}"
+
+
+class TestEvaluateSampleFrameLimit:
+    """``content_frame_limit`` reaches ``_content_frame_times(max_frames=...)``."""
+
+    def _prepare(self, tmp_path, monkeypatch) -> Path:
+        response_path = tmp_path / "s1.json"
+        response_path.write_text(json.dumps([]), encoding="utf-8")
+        monkeypatch.setattr(eval_mod, "validate_clock", lambda meta, allow_invalid=False: None)
+        monkeypatch.setattr(eval_mod, "materialize_media", lambda *a, **k: tmp_path / "video.mp4")
+        monkeypatch.setattr(eval_mod, "video_duration", lambda path: 30.0)
+        monkeypatch.setattr(eval_mod, "_extract_frames", lambda path, times: [b"\xff\xd8frame"])
+        monkeypatch.setattr(eval_mod, "build_content_prompt", lambda *a, **k: "content-prompt")
+        monkeypatch.setattr(eval_mod, "parse_judge_json", lambda text: {})
+        monkeypatch.setattr(eval_mod, "summarize_temporal_results", lambda rows: {})
+        return response_path
+
+    def _sample(self) -> SimpleNamespace:
+        return SimpleNamespace(
+            id="s1",
+            split="RTD_OCR",
+            family="rtd",
+            task_type=None,
+            video="",
+            video_duration=30.0,
+            question_text="q",
+            answer1="a1",
+            answer2="a2",
+        )
+
+    def test_explicit_limit_is_forwarded(self, tmp_path, monkeypatch) -> None:
+        response_path = self._prepare(tmp_path, monkeypatch)
+        recorded: dict = {}
+
+        def _record(duration, *, max_frames=16):
+            recorded["max_frames"] = max_frames
+            return [0.0, 1.0]
+
+        monkeypatch.setattr(eval_mod, "_content_frame_times", _record)
+
+        eval_mod.evaluate_sample(
+            self._sample(),
+            response_path,
+            tmp_path / "score.json",
+            _StubJudge(),
+            judge_video_mode="frame-sample",
+            content_frame_limit=7,
+        )
+
+        assert recorded["max_frames"] == 7
+
+    def test_default_limit_is_constant(self, tmp_path, monkeypatch) -> None:
+        response_path = self._prepare(tmp_path, monkeypatch)
+        recorded: dict = {}
+
+        def _record(duration, *, max_frames=16):
+            recorded["max_frames"] = max_frames
+            return [0.0, 1.0]
+
+        monkeypatch.setattr(eval_mod, "_content_frame_times", _record)
+
+        eval_mod.evaluate_sample(
+            self._sample(),
+            response_path,
+            tmp_path / "score.json",
+            _StubJudge(),
+            judge_video_mode="frame-sample",
+        )
+
+        assert recorded["max_frames"] == eval_mod.CONTENT_FRAME_LIMIT
+
+    def test_signature_default_is_constant(self) -> None:
+        parameters = inspect.signature(eval_mod.evaluate_sample).parameters
+        assert parameters["content_frame_limit"].default == eval_mod.CONTENT_FRAME_LIMIT

--- a/tests/benchmarks/duplex/test_duplex_eval_patch.py
+++ b/tests/benchmarks/duplex/test_duplex_eval_patch.py
@@ -1,0 +1,415 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""Offline unit tests for the Omni-DuplexEval ``patch.py`` wiring (M3).
+
+Covers the data dispatch in ``get_samples``, ``is_duplex_eval`` exact
+equality, per-request metadata attachment, the realtime dispatcher, the
+generation-ledger finalizer and the result assembly / placeholder session
+metrics contract.
+
+Everything is exercised with stubs, monkeypatching and in-memory objects: no
+GPU, weights, network or real server process is required.
+
+See ``plans/omni-duplex-eval-backend-design.md`` §5.3, §4.4 and §9.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import inspect
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+try:
+    import vllm_omni.benchmarks.patch.patch as patch_mod
+    from vllm_omni.benchmarks.duplex import omni_duplex_eval_eval as eval_mod
+    from vllm_omni.benchmarks.duplex import omni_duplex_eval_judge as judge_mod
+except ImportError:  # pragma: no cover - offline stub environment
+    pytest.skip("vLLM / patch module is not importable", allow_module_level=True)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+_DUPLEX_NAME = "omni-duplex-eval"
+
+
+def _make_options(**overrides) -> patch_mod.DuplexEvalSessionOptions:
+    base: dict = {
+        "response_root": Path("/tmp/duplex-responses"),
+        "score_dir": Path("/tmp/duplex-scores"),
+        "ref_audio": "tests/assets/ref.wav",
+        "write_artifacts": False,
+    }
+    base.update(overrides)
+    return patch_mod.DuplexEvalSessionOptions(**base)
+
+
+def _make_sample(
+    sample_id: str = "s1",
+    split: str = "RTD_OCR",
+    family: str = "rtd",
+) -> SimpleNamespace:
+    return SimpleNamespace(id=sample_id, split=split, family=family, task_type=None, video="", question_audio=None)
+
+
+def _make_duplex_request(sample=None, options=None) -> patch_mod.DuplexEvalSampleRequest:
+    return patch_mod.DuplexEvalSampleRequest(
+        prompt="",
+        prompt_len=0,
+        expected_output_len=0,
+        request_id="0",
+        duplex_eval_sample=sample if sample is not None else _make_sample(),
+        duplex_eval_options=options if options is not None else _make_options(),
+    )
+
+
+def _make_rfi() -> patch_mod.RequestFuncInput:
+    return patch_mod.RequestFuncInput(
+        prompt="",
+        api_url="http://127.0.0.1:8000",
+        prompt_len=0,
+        output_len=0,
+        model="test-model",
+    )
+
+
+def _serve_dataset_args(**overrides) -> argparse.Namespace:
+    base: dict = {
+        "dataset_name": _DUPLEX_NAME,
+        "backend": "openai-realtime-duplex",
+        "dataset_path": None,
+        "seed": 1,
+        "request_id_prefix": "",
+        "disable_shuffle": True,
+        "num_prompts": 0,
+        "duplex_eval_split": "RTD_OCR",
+        "duplex_eval_family": "all",
+        "duplex_eval_media_root": None,
+        "duplex_eval_limit": 4,
+        "duplex_eval_ids": None,
+        "duplex_eval_exclude_ids": ["565"],
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+class _StubDataset:
+    """Captures ``__init__``/``sample`` calls and returns a fixed row count."""
+
+    def __init__(self, returns: int = 3) -> None:
+        self.returns = returns
+        self.init_kwargs: dict | None = None
+        self.sample_kwargs: dict | None = None
+
+    def __call__(self, **kwargs):  # used as the monkeypatched class
+        self.init_kwargs = kwargs
+        return self
+
+    def sample(self, tokenizer, num_requests, *, request_id_prefix="", options=None):
+        self.sample_kwargs = {
+            "tokenizer": tokenizer,
+            "num_requests": num_requests,
+            "request_id_prefix": request_id_prefix,
+            "options": options,
+        }
+        return [object() for _ in range(self.returns)]
+
+
+# ================================================================== #
+# ``get_samples`` dispatch
+# ================================================================== #
+
+
+class TestGetSamplesDispatch:
+    """``dataset_name == "omni-duplex-eval"`` routes to ``DuplexEvalDataset``."""
+
+    def test_dispatches_and_folds_num_prompts(self, monkeypatch) -> None:
+        stub = _StubDataset(returns=3)
+        options_sentinel = object()
+        monkeypatch.setattr(patch_mod, "DuplexEvalDataset", stub)
+        monkeypatch.setattr(patch_mod, "options_from_args", lambda args: options_sentinel)
+
+        args = _serve_dataset_args()
+        requests = patch_mod.get_samples(args, tokenizer=None)
+
+        assert len(requests) == 3
+        assert args.num_prompts == 3  # 0/all folded to measured length
+        assert stub.init_kwargs is not None
+        assert stub.init_kwargs["dataset"] == patch_mod.DEFAULT_DUPLEX_EVAL_DATASET
+        assert stub.init_kwargs["split"] == "RTD_OCR"
+        assert stub.init_kwargs["limit"] == 4
+        assert stub.init_kwargs["exclude_ids"] == ["565"]
+        assert stub.init_kwargs["disable_shuffle"] is True
+        assert stub.sample_kwargs["num_requests"] == 0
+        assert stub.sample_kwargs["options"] is options_sentinel
+
+    def test_dataset_path_overrides_default(self, monkeypatch) -> None:
+        stub = _StubDataset(returns=1)
+        monkeypatch.setattr(patch_mod, "DuplexEvalDataset", stub)
+        monkeypatch.setattr(patch_mod, "options_from_args", lambda args: object())
+
+        patch_mod.get_samples(_serve_dataset_args(dataset_path="/mirror"), tokenizer=None)
+
+        assert stub.init_kwargs["dataset"] == "/mirror"
+
+    def test_empty_selection_raises(self, monkeypatch) -> None:
+        monkeypatch.setattr(patch_mod, "DuplexEvalDataset", _StubDataset(returns=0))
+        monkeypatch.setattr(patch_mod, "options_from_args", lambda args: object())
+
+        with pytest.raises(ValueError, match="No Omni-DuplexEval samples"):
+            patch_mod.get_samples(_serve_dataset_args(), tokenizer=None)
+
+
+# ================================================================== #
+# ``is_duplex_eval`` exact equality
+# ================================================================== #
+
+
+class TestIsDuplexEvalExactEquality:
+    """T: the dispatch predicate is an exact ``==`` match, not a prefix."""
+
+    def test_source_uses_exact_equality(self) -> None:
+        source = inspect.getsource(patch_mod.get_samples)
+        assert 'is_duplex_eval = args.dataset_name == "omni-duplex-eval"' in source
+        assert "startswith" not in source.split("is_duplex_eval")[1].split("\n")[0]
+
+    def test_exact_name_dispatches(self, monkeypatch) -> None:
+        stub = _StubDataset(returns=1)
+        monkeypatch.setattr(patch_mod, "DuplexEvalDataset", stub)
+        monkeypatch.setattr(patch_mod, "options_from_args", lambda args: object())
+        patch_mod.get_samples(_serve_dataset_args(dataset_name=_DUPLEX_NAME), tokenizer=None)
+        assert stub.init_kwargs is not None
+
+    @pytest.mark.parametrize("name", ["omni-duplex-eval-x", "duplex-eval", "omni-duplex"])
+    def test_near_miss_falls_through(self, monkeypatch, name: str) -> None:
+        created: list[dict] = []
+
+        class _Guarded:
+            def __init__(self, **kwargs):
+                created.append(kwargs)
+
+            def sample(self, *args, **kwargs):  # pragma: no cover - must not run
+                raise AssertionError("duplex dispatch must not trigger")
+
+        fallback: list[bool] = []
+        monkeypatch.setattr(patch_mod, "DuplexEvalDataset", _Guarded)
+        monkeypatch.setattr(patch_mod, "options_from_args", lambda args: object())
+        monkeypatch.setattr(patch_mod, "get_samples_old", lambda args, tokenizer: fallback.append(True) or [])
+
+        args = _serve_dataset_args(dataset_name=name)
+        with contextlib.suppress(Exception):
+            patch_mod.get_samples(args, tokenizer=None)
+
+        assert created == []
+        assert fallback == [True]
+
+
+# ================================================================== #
+# ``_attach_duplex_eval_to_request_func_input``
+# ================================================================== #
+
+
+class TestAttachToRequestFuncInput:
+    """T: per-request sample/options are mounted and the call is idempotent."""
+
+    def test_mounts_and_is_idempotent(self) -> None:
+        sample = _make_sample()
+        options = _make_options()
+        request = _make_duplex_request(sample=sample, options=options)
+        rfi = _make_rfi()
+
+        patch_mod._attach_duplex_eval_to_request_func_input(request, rfi)
+        assert rfi.duplex_eval_sample is sample
+        assert rfi.duplex_eval_options is options
+
+        patch_mod._attach_duplex_eval_to_request_func_input(request, rfi)
+        assert rfi.duplex_eval_sample is sample
+        assert rfi.duplex_eval_options is options
+
+    def test_ignores_non_duplex_request(self) -> None:
+        plain = patch_mod.SampleRequest(prompt="p", prompt_len=1, expected_output_len=1, request_id="0")
+        rfi = _make_rfi()
+        patch_mod._attach_duplex_eval_to_request_func_input(plain, rfi)
+        assert not hasattr(rfi, "duplex_eval_sample")
+        assert not hasattr(rfi, "duplex_eval_options")
+
+
+# ================================================================== #
+# Realtime dispatch
+# ================================================================== #
+
+
+class TestRealtimeDispatch:
+    """A request carrying ``duplex_eval_sample`` uses ``_async_request_duplex_eval``."""
+
+    def test_routes_to_duplex_eval(self, monkeypatch) -> None:
+        seen: list[object] = []
+
+        async def _fake(rfi, *, pbar=None):
+            seen.append(pbar)
+            return "SENTINEL"
+
+        monkeypatch.setattr(patch_mod, "_async_request_duplex_eval", _fake)
+        rfi = _make_rfi()
+        rfi.duplex_eval_sample = _make_sample()
+
+        result = asyncio.run(patch_mod.async_request_openai_realtime_duplex(rfi, session=None, pbar=None))
+
+        assert result == "SENTINEL"
+        assert seen == [None]
+
+
+# ================================================================== #
+# ``_async_request_duplex_eval`` placeholder session metrics
+# ================================================================== #
+
+
+class TestDuplexEvalRequestPlaceholder:
+    """Per-output ``duplex_session_metrics`` is a dict with three ``None`` keys."""
+
+    def test_placeholder_keys_are_none(self, monkeypatch) -> None:
+        async def _fake_case(sample, config):
+            return patch_mod.DuplexEvalCaseResult(id="s1", split="RTD_OCR", family="rtd", success=True, latency_s=0.5)
+
+        monkeypatch.setattr(patch_mod, "run_duplex_eval_case", _fake_case)
+        rfi = _make_rfi()
+        rfi.duplex_eval_sample = _make_sample()
+        rfi.duplex_eval_options = _make_options()
+
+        output = asyncio.run(patch_mod._async_request_duplex_eval(rfi, pbar=None))
+
+        assert output.success is True
+        assert set(output.duplex_session_metrics) == {
+            "mean_ttft_ms",
+            "mean_ttfp_ms",
+            "mean_rtf",
+            "source",
+        }
+        for key in ("mean_ttft_ms", "mean_ttfp_ms", "mean_rtf"):
+            assert output.duplex_session_metrics[key] is None
+        assert output.duplex_session_metrics["source"] == "omni-duplex-eval"
+        assert output.duplex_eval_case_result.success is True
+
+    def test_missing_options_marks_failure(self, monkeypatch) -> None:
+        rfi = _make_rfi()
+        rfi.duplex_eval_sample = _make_sample()
+        # no duplex_eval_options mounted → the request must fail, not raise
+        output = asyncio.run(patch_mod._async_request_duplex_eval(rfi, pbar=None))
+        assert output.success is False
+        assert output.error
+        assert output.duplex_eval_case_result is not None
+
+
+# ================================================================== #
+# Finalize: generation ledger only, no judge in the serve path
+# ================================================================== #
+
+
+class TestFinalizeNoJudge:
+    """``finalize_duplex_eval_batch`` never invokes a judge entry point."""
+
+    def test_finalize_never_calls_judge(self, monkeypatch) -> None:
+        judge_calls: list[object] = []
+
+        def _boom(*args, **kwargs):
+            judge_calls.append(args)
+            raise AssertionError("judge entry point must not run in the serve path")
+
+        monkeypatch.setattr(judge_mod, "DuplexJudge", _boom)
+        monkeypatch.setattr(judge_mod, "select_judge_text", _boom)
+        monkeypatch.setattr(eval_mod, "evaluate_sample", _boom)
+
+        request = _make_duplex_request()
+        case_result = patch_mod.DuplexEvalCaseResult(id="s1", split="RTD_OCR", family="rtd", success=True)
+        output = patch_mod.MixRequestFuncOutput()
+        setattr(output, "duplex_eval_case_result", case_result)
+
+        summary = patch_mod.finalize_duplex_eval_batch([request], [output])
+
+        assert judge_calls == []
+        assert summary is not None
+        assert summary["phase"] == "generate"
+        assert summary["judge_enabled"] is False
+        assert summary["scored"] == 0
+        assert "score_summary" not in summary
+
+    def test_patch_module_has_no_judge_symbols(self) -> None:
+        assert not hasattr(patch_mod, "DuplexJudge")
+        assert not hasattr(patch_mod, "select_judge_text")
+        source = Path(patch_mod.__file__).read_text(encoding="utf-8")
+        assert "omni_duplex_eval_judge" not in source
+
+
+# ================================================================== #
+# Result assembly + session-metrics aggregation semantics
+# ================================================================== #
+
+
+class TestResultAssembly:
+    """``phase == "generate"`` is what the benchmark writes into the result."""
+
+    def test_result_wiring_is_present(self) -> None:
+        source = inspect.getsource(patch_mod.benchmark)
+        assert "duplex_eval_summary = finalize_duplex_eval_batch(input_requests, outputs)" in source
+        assert "if duplex_eval_summary is not None:" in source
+        assert 'result["duplex_eval"] = duplex_eval_summary' in source
+
+    def test_summary_phase_is_generate(self) -> None:
+        request = _make_duplex_request()
+        case_result = patch_mod.DuplexEvalCaseResult(id="s1", split="RTD_OCR", family="rtd", success=True)
+        output = patch_mod.MixRequestFuncOutput()
+        setattr(output, "duplex_eval_case_result", case_result)
+        summary = patch_mod.finalize_duplex_eval_batch([request], [output])
+        assert summary is not None
+        assert summary["phase"] == "generate"
+
+
+class TestPlaceholderSuppressesPseudoZero:
+    """A ``None`` placeholder must not become a valid ``0.0`` metric sample."""
+
+    def _run(self, with_placeholder: bool):
+        from vllm.benchmarks.serve import TaskType
+
+        output = patch_mod.MixRequestFuncOutput()
+        output.ttft = 0.0
+        output.latency = 1.0
+        output.success = True
+        output.output_len = 0
+        if with_placeholder:
+            output.duplex_session_metrics = {
+                "mean_ttft_ms": None,
+                "mean_ttfp_ms": None,
+                "mean_rtf": None,
+                "source": "omni-duplex-eval",
+            }
+        request = patch_mod.SampleRequest(prompt="", prompt_len=0, expected_output_len=0, request_id="0")
+        metrics, _ = patch_mod.calculate_metrics(
+            input_requests=[request],
+            outputs=[output],
+            dur_s=1.0,
+            tokenizer=None,
+            selected_percentiles=[50.0],
+            goodput_config_dict={},
+            task_type=TaskType.GENERATION,
+            selected_percentile_metrics=[],
+            max_concurrency=1,
+            request_rate=float("inf"),
+            benchmark_duration=1.0,
+        )
+        return metrics
+
+    def test_placeholder_yields_zero_samples(self, capsys) -> None:
+        metrics = self._run(with_placeholder=True)
+        capsys.readouterr()
+        assert metrics.num_ttft_samples == 0
+        assert getattr(metrics, "num_audio_ttfp_samples", 0) == 0
+        assert getattr(metrics, "num_audio_rtf_samples", 0) == 0
+
+    def test_without_placeholder_zero_ttft_counts(self, capsys) -> None:
+        metrics = self._run(with_placeholder=False)
+        capsys.readouterr()
+        assert metrics.num_ttft_samples == 1

--- a/tests/benchmarks/duplex/test_omni_duplex_eval.py
+++ b/tests/benchmarks/duplex/test_omni_duplex_eval.py
@@ -101,6 +101,80 @@ def test_local_parquet_file_is_routed_to_hf_loader(tmp_path, monkeypatch):
     assert samples[0].family == "pr"
 
 
+def test_hf_collapse_to_train_keeps_row_split_identity(tmp_path, monkeypatch):
+    # datasets.load_dataset collapses a config-less local mirror (a bare data/
+    # directory) into a single generic ``train`` split. Rows that already carry
+    # their own split/subset identity must keep it so family inference is not
+    # poisoned by the generic name (regression for the direct-read path).
+    hf_dir = tmp_path / "Omni-DuplexEval"
+    data_dir = hf_dir / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "train-00000-of-00021.parquet").write_bytes(b"PAR1")
+
+    def fake_load_dataset(name, **kwargs):
+        return {
+            "train": [
+                {"id": "pr", "split": "PR_correction", "question_text": "Correct this."},
+                {"id": "pr-subset", "subset": "PR_event_reminder", "question_text": "Remind me."},
+                {"id": "rtd", "split": "RTD_OCR", "question_text": "Read this."},
+            ]
+        }
+
+    monkeypatch.setitem(sys.modules, "datasets", SimpleNamespace(load_dataset=fake_load_dataset))
+    samples = load_samples(hf_dir)
+    by_id = {sample.id: sample for sample in samples}
+    assert by_id["pr"].split == "PR_correction"
+    assert by_id["pr"].family == "pr"
+    assert by_id["pr"].task_type == "correction"
+    assert by_id["pr-subset"].split == "PR_event_reminder"
+    assert by_id["pr-subset"].family == "pr"
+    assert by_id["pr-subset"].task_type == "proactive_reminder"
+    assert by_id["rtd"].split == "RTD_OCR"
+    assert by_id["rtd"].family == "rtd"
+
+
+def test_hf_config_layout_stamps_split_name_when_row_has_none(tmp_path, monkeypatch):
+    # With a proper config-per-split mirror the loader still stamps the Hugging
+    # Face split name onto rows that do not identify themselves (unchanged).
+    hf_dir = tmp_path / "Omni-DuplexEval"
+    data_dir = hf_dir / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "RTD_OCR-00000-of-00001.parquet").write_bytes(b"PAR1")
+    (data_dir / "PR_correction-00000-of-00001.parquet").write_bytes(b"PAR1")
+
+    def fake_load_dataset(name, **kwargs):
+        return {
+            "RTD_OCR": [{"id": "rtd", "question_text": "Read this."}],
+            "PR_correction": [{"id": "pr", "question_text": "Correct this."}],
+        }
+
+    monkeypatch.setitem(sys.modules, "datasets", SimpleNamespace(load_dataset=fake_load_dataset))
+    samples = load_samples(hf_dir)
+    by_id = {sample.id: sample for sample in samples}
+    assert by_id["rtd"].split == "RTD_OCR"
+    assert by_id["rtd"].family == "rtd"
+    assert by_id["pr"].split == "PR_correction"
+    assert by_id["pr"].family == "pr"
+    assert by_id["pr"].task_type == "correction"
+
+
+def test_hf_collapse_to_train_without_row_identity_raises_actionable_error(tmp_path, monkeypatch):
+    # A row that carries no split/family/task_type and lands in a generic
+    # collapsed ``train`` split cannot be routed; the loader must raise a clear,
+    # actionable ValueError instead of the bare family_for_split message.
+    hf_dir = tmp_path / "Omni-DuplexEval"
+    data_dir = hf_dir / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "train-00000-of-00021.parquet").write_bytes(b"PAR1")
+
+    def fake_load_dataset(name, **kwargs):
+        return {"train": [{"id": "x", "question_text": "What is this?"}]}
+
+    monkeypatch.setitem(sys.modules, "datasets", SimpleNamespace(load_dataset=fake_load_dataset))
+    with pytest.raises(ValueError, match="config per split"):
+        load_samples(hf_dir)
+
+
 def test_non_manifest_file_raises_clear_error(tmp_path):
     # A plain non-JSON file (e.g. a README) must surface a clear ValueError
     # listing the accepted inputs instead of a raw JSONDecodeError.

--- a/tests/benchmarks/duplex/test_omni_duplex_eval.py
+++ b/tests/benchmarks/duplex/test_omni_duplex_eval.py
@@ -64,6 +64,52 @@ def test_hugging_face_subset_names_are_splits(monkeypatch):
     assert sample.task_type == "correction"
 
 
+def test_local_hf_dataset_directory_is_routed_to_hf_loader(tmp_path, monkeypatch):
+    # An existing local Hugging Face dataset layout (directory with a
+    # ``data/*.parquet`` file) must be loaded through ``datasets.load_dataset``
+    # instead of being parsed as a JSON/JSONL manifest.
+    hf_dir = tmp_path / "Omni-DuplexEval"
+    data_dir = hf_dir / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "train-00000-of-00001.parquet").write_bytes(b"PAR1")
+    calls = []
+
+    def fake_load_dataset(name, **kwargs):
+        calls.append((name, kwargs))
+        return [{"id": "pr", "split": "PR_correction", "question_text": "Correct this."}]
+
+    monkeypatch.setitem(sys.modules, "datasets", SimpleNamespace(load_dataset=fake_load_dataset))
+    samples = load_samples(hf_dir)
+    assert calls == [(str(hf_dir), {})]
+    assert len(samples) == 1
+    assert samples[0].task_type == "correction"
+
+
+def test_local_parquet_file_is_routed_to_hf_loader(tmp_path, monkeypatch):
+    parquet = tmp_path / "samples.parquet"
+    parquet.write_bytes(b"PAR1")
+    calls = []
+
+    def fake_load_dataset(name, **kwargs):
+        calls.append((name, kwargs))
+        return [{"id": "pr", "split": "PR_correction", "question_text": "Correct this."}]
+
+    monkeypatch.setitem(sys.modules, "datasets", SimpleNamespace(load_dataset=fake_load_dataset))
+    samples = load_samples(str(parquet))
+    assert calls == [("parquet", {"data_files": str(parquet)})]
+    assert len(samples) == 1
+    assert samples[0].family == "pr"
+
+
+def test_non_manifest_file_raises_clear_error(tmp_path):
+    # A plain non-JSON file (e.g. a README) must surface a clear ValueError
+    # listing the accepted inputs instead of a raw JSONDecodeError.
+    bad = tmp_path / "README.md"
+    bad.write_text("# readme\nnot a manifest", encoding="utf-8")
+    with pytest.raises(ValueError, match="JSON/JSONL manifest"):
+        load_samples(str(bad))
+
+
 def test_response_aliases_and_clock_guard():
     assert split_text("One. Two!") == ["One.", "Two!"]
     assert normalize_response_items({"chunks": [{"text": "x", "current_time": 800}]}) == [

--- a/tests/benchmarks/duplex/test_omni_duplex_eval_media.py
+++ b/tests/benchmarks/duplex/test_omni_duplex_eval_media.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_omni.benchmarks.duplex.omni_duplex_eval_media import materialize_media
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_dict_with_bytes_materializes_a_real_file(tmp_path):
+    # A Hugging Face Audio/Video feature value {"bytes": ..., "path": ...} used
+    # to short-circuit on ``path`` (the artifact name inside the dataset, which
+    # does not exist on disk), so downstream ffmpeg saw a missing file. Inline
+    # bytes must win and be written to a real file whose content equals bytes.
+    payload = b"\x00\xff\x01RIFFfake-content"
+    resolved = materialize_media({"bytes": payload, "path": "question_audio.wav"}, tmp_path, "s1_question", ".wav")
+    assert resolved.is_file()
+    assert resolved.read_bytes() == payload
+    assert resolved.parent == tmp_path
+    assert resolved.name == "s1_question.wav"
+
+
+def test_dict_extension_comes_from_path_safely(tmp_path):
+    payload = b"flac-ish-bytes"
+    resolved = materialize_media({"bytes": payload, "path": "audio/clip.FLAC"}, tmp_path, "s1", ".wav")
+    assert resolved.name == "s1.flac"
+    assert resolved.read_bytes() == payload
+    # A path with no usable extension falls back to the caller's suffix.
+    resolved = materialize_media({"bytes": payload, "path": "audio/clip"}, tmp_path, "s2", ".wav")
+    assert resolved.name == "s2.wav"
+    assert resolved.read_bytes() == payload
+
+
+def test_materialization_is_idempotent_and_updated(tmp_path):
+    payload = b"abc"
+    first = materialize_media({"bytes": payload, "path": "q.wav"}, tmp_path, "s", ".wav")
+    second = materialize_media({"bytes": payload, "path": "q.wav"}, tmp_path, "s", ".wav")
+    assert first == second
+    assert first.read_bytes() == payload
+    replacement = b"xyz"
+    third = materialize_media({"bytes": replacement, "path": "q.wav"}, tmp_path, "s", ".wav")
+    assert third == first
+    assert third.read_bytes() == replacement
+
+
+def test_str_path_and_path_only_mapping_returned_as_is(tmp_path):
+    existing = tmp_path / "clip.mp4"
+    existing.write_bytes(b"video")
+    assert materialize_media(str(existing), tmp_path, "s", ".mp4") == existing
+    assert materialize_media({"path": str(existing)}, tmp_path, "s", ".mp4") == existing
+
+
+def test_raw_bytes_value_is_written(tmp_path):
+    payload = b"raw-media"
+    resolved = materialize_media(payload, tmp_path, "r", ".bin")
+    assert resolved.name == "r.bin"
+    assert resolved.read_bytes() == payload
+
+
+def test_unresolvable_value_raises_clear_error(tmp_path):
+    with pytest.raises(ValueError, match="cannot materialize"):
+        materialize_media(None, tmp_path, "s", ".wav")
+    with pytest.raises(ValueError, match="cannot materialize"):
+        materialize_media({"path": None}, tmp_path, "s", ".wav")

--- a/tests/dfx/perf/scripts/run_benchmark.py
+++ b/tests/dfx/perf/scripts/run_benchmark.py
@@ -4,9 +4,16 @@
 import json
 import math
 import os
+import re
+import subprocess
+import sys
 import threading
+import time
+import urllib.error
+import urllib.request
 from collections.abc import Callable
 from contextlib import AbstractContextManager, ExitStack, contextmanager
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -161,6 +168,225 @@ def benchmark_params(request):
     }
 
 
+# ---------------------------------------------------------------------------
+# Omni-DuplexEval three-phase orchestration (design v2 §3.1 / §5.7 / §8.4)
+#
+# Phase 1 (generate, timed, peak 1 card) stays on the existing
+# ``omni_server`` + ``conftest.run_benchmark`` path. Phase 2 (judge) and
+# Phase 3 (summarize + merge) run after the timed server has exited, in
+# separate sub-processes, so the judge never shares a card or a time slice
+# with the benchmark window.
+# ---------------------------------------------------------------------------
+
+DUPLEX_EVAL_DATASET_NAME = "omni-duplex-eval"
+
+#: ``benchmark_params`` keys that are *not* ``vllm bench serve`` CLI flags.
+#: Every other key is rendered as ``--<key with underscores -> dashes>``; an
+#: unknown flag is a hard argparse error, so this allow-list must stay in sync
+#: with the perf JSON (see ``tests/dfx/perf/tests/test_runner_metadata.py``).
+_BENCHMARK_PARAM_EXCLUDE_KEYS = frozenset(
+    {
+        "request_rate",
+        "baseline",
+        "num_prompts",
+        "max_concurrency",
+        "num_warmups",
+        "task",
+        "name",
+        "enabled",
+        "eval_phase",
+        "trust_remote_code",
+        "expected_duplex_audio_turns_per_session",
+        # Omni-DuplexEval judge / summarizer knobs: Phase 2/3 only (design §8.3).
+        "duplex_eval_judge_video_mode",
+        "duplex_eval_judge_fps",
+        "duplex_eval_judge_modalities",
+        "duplex_eval_judge_model",
+        "duplex_eval_content_frame_limit",
+        "duplex_eval_eval_workers",
+        "duplex_eval_exclude_ids_pending",
+        # Optional Gate knob: minimum number of successfully scored samples.
+        "duplex_eval_min_scored",
+    }
+)
+
+_JUDGE_HEALTH_RETRIES = 60
+_JUDGE_HEALTH_INTERVAL_S = 2.0
+_JUDGE_HEALTH_TIMEOUT_S = 5.0
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_ENV_VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)")
+
+_duplex_eval_lock = threading.Lock()
+_judge_server_lock = threading.Lock()
+#: Phase-1 results that Phase 2/3 must judge and merge (design §5.7 registry).
+_DUPLEX_EVAL_CASES: list[dict[str, Any]] = []
+#: test_names whose Phase-1 parametrization was actually *collected* (even if it
+#: failed before registering a result). Distinguishes "deselected by -m" from
+#: "generation broke", so the Phase-2 guard fails loudly only in the latter.
+_DUPLEX_EVAL_ATTEMPTED: set[str] = set()
+
+
+def _duplex_eval_configs() -> list[dict[str, Any]]:
+    """Collected perf configs that declare at least one Omni-DuplexEval case."""
+    return [
+        cfg
+        for cfg in BENCHMARK_CONFIGS
+        if any(
+            (entry or {}).get("dataset_name") == DUPLEX_EVAL_DATASET_NAME
+            for entry in (cfg.get("benchmark_params") or [])
+        )
+    ]
+
+
+def _judge_server_params_by_test_name() -> dict[str, dict[str, Any]]:
+    return {str(cfg["test_name"]): dict(cfg.get("judge_server_params") or {}) for cfg in _duplex_eval_configs()}
+
+
+def _expand_env_path(value: str) -> str:
+    """Expand ``${VAR}`` / ``$VAR`` / ``~`` so perf JSON never embeds host paths."""
+
+    def _replace(match: re.Match[str]) -> str:
+        name = match.group(1) or match.group(2)
+        resolved = os.environ.get(name)
+        if not resolved:
+            raise ValueError(
+                f"Omni-DuplexEval perf config references unset environment variable {name!r}; "
+                "export it (e.g. BENCHMARK_ASSETS=<mirror root>) or point dataset_path at a "
+                "pinned Hugging Face id"
+            )
+        return resolved
+
+    return os.path.expanduser(_ENV_VAR_RE.sub(_replace, value))
+
+
+def _resolve_duplex_eval_params(params: dict[str, Any]) -> dict[str, Any]:
+    """Resolve env-var/``~`` path parameters and fail loudly on a missing mirror.
+
+    Design §8.6 requires the cropped local mirror to live outside the repo, so
+    the JSON references it through ``BENCHMARK_ASSETS`` rather than a
+    machine-specific absolute path.
+    """
+    resolved = dict(params)
+    for key in ("dataset_path", "duplex_eval_media_root", "duplex_eval_ref_audio"):
+        value = resolved.get(key)
+        if isinstance(value, str) and ("$" in value or value.startswith("~")):
+            try:
+                resolved[key] = _expand_env_path(value)
+            except ValueError as exc:
+                pytest.fail(str(exc), pytrace=False)
+    dataset_path = resolved.get("dataset_path")
+    if isinstance(dataset_path, str) and dataset_path.startswith(("/", "~")) and not Path(dataset_path).exists():
+        pytest.fail(
+            f"Omni-DuplexEval dataset_path {dataset_path!r} does not exist. Build the cropped local "
+            "mirror (design §8.6, tools/benchmarks/build_omni_duplex_eval_mirror.py) and export "
+            "BENCHMARK_ASSETS, or pin a Hugging Face dataset id.",
+            pytrace=False,
+        )
+    return resolved
+
+
+def _register_duplex_eval_case(
+    *,
+    test_name: str,
+    params: dict[str, Any],
+    result_path: str,
+    num_prompt: int,
+    selected_ids: list[str],
+) -> None:
+    with _duplex_eval_lock:
+        _DUPLEX_EVAL_CASES.append(
+            {
+                "test_name": test_name,
+                "params": dict(params),
+                "result_path": result_path,
+                "num_prompt": int(num_prompt),
+                "selected_ids": list(selected_ids),
+            }
+        )
+
+
+def _register_phase_one_result(
+    *,
+    result: dict[str, Any],
+    params: dict[str, Any],
+    test_name: str,
+    flow: Any,
+    num_prompt: int,
+    since: float,
+) -> None:
+    """Locate and record the Phase-1 perf result so Phase 2/3 can merge into it."""
+    if params.get("dataset_name") != DUPLEX_EVAL_DATASET_NAME:
+        return
+    from vllm_omni.benchmarks.duplex_eval import _locate_result_file
+
+    result_path = _locate_result_file(
+        bench_dir=os.environ.get("BENCHMARK_DIR", "tests"),
+        test_name=test_name,
+        dataset_name=DUPLEX_EVAL_DATASET_NAME,
+        flow=flow,
+        num_prompt=num_prompt,
+        since=since,
+    )
+    summary = result.get("duplex_eval") or {}
+    _register_duplex_eval_case(
+        test_name=test_name,
+        params=params,
+        result_path=str(result_path),
+        num_prompt=num_prompt,
+        selected_ids=[str(item) for item in (summary.get("selected_ids") or [])],
+    )
+
+
+def _assert_duplex_eval_result(result: dict[str, Any], params: dict[str, Any], num_prompt: int) -> None:
+    """Gate G1-G6 (design §7.2), tolerant of the pre-merge (generate-only) phase."""
+    summary = result.get("duplex_eval")
+    assert isinstance(summary, dict), "Omni-DuplexEval summary is missing"
+    assert summary.get("total") == num_prompt, (
+        f"Omni-DuplexEval selected {summary.get('total')} samples, expected {num_prompt}"
+    )
+    assert summary.get("generated") == summary.get("total"), (
+        "Omni-DuplexEval generation incomplete: "
+        f"generated={summary.get('generated')} total={summary.get('total')} ids={summary.get('failure_ids')}"
+    )
+    assert summary.get("artifacts_complete") is True, "Omni-DuplexEval artifacts are incomplete"
+    assert summary.get("clock") == "media", f"Omni-DuplexEval clock must be 'media', got {summary.get('clock')!r}"
+    assert not summary.get("clock_mismatch_ids"), (
+        f"Omni-DuplexEval clock mismatch ids={summary.get('clock_mismatch_ids')}"
+    )
+    exclude = {str(item) for item in (params.get("duplex_eval_exclude_ids") or [])}
+    assert {str(item) for item in (summary.get("exclude_ids") or [])} == exclude, (
+        f"Omni-DuplexEval exclude-id echo mismatch: result={summary.get('exclude_ids')} params={sorted(exclude)}"
+    )
+    # G6: `exclude_ids` may be bare ids ("565") or `split/id`, while
+    # `selected_ids` is always `split/id`; compare on both forms so a bare id
+    # exclusion is not silently vacuous (design §7.2 leaves this implicit).
+    overlap = sorted(
+        str(key)
+        for key in (summary.get("selected_ids") or [])
+        if str(key) in exclude or str(key).rsplit("/", 1)[-1] in exclude
+    )
+    assert not overlap, f"Omni-DuplexEval excluded samples were still selected: {overlap}"
+
+    if not summary.get("judge_enabled"):
+        # Phase 1 (generate-only) or a degraded judge run: G4/G5 do not apply.
+        return
+    assert summary.get("phase") == "generate+evaluate+summarize", (
+        f"Omni-DuplexEval judge phase did not complete: phase={summary.get('phase')!r}"
+    )
+    score_summary = summary.get("score_summary")
+    assert isinstance(score_summary, dict), "Omni-DuplexEval score_summary is missing"
+    assert score_summary.get("protocol_pin"), "Omni-DuplexEval score_summary is missing protocol_pin"
+    assert summary.get("scored") == score_summary.get("samples"), (
+        "Omni-DuplexEval scored count disagrees with score_summary.samples"
+    )
+    min_scored = params.get("duplex_eval_min_scored")
+    if min_scored is not None:
+        assert int(summary.get("scored") or 0) >= int(min_scored), (
+            f"Omni-DuplexEval judge coverage too low: scored={summary.get('scored')} "
+            f"min_scored={min_scored} pending={summary.get('pending_ids')}"
+        )
+
+
 def _resolve_num_warmups(params: dict[str, Any], *, default: int) -> int:
     value = params.get("num_warmups")
     if value is None:
@@ -172,6 +398,8 @@ def _resolve_num_warmups(params: dict[str, Any], *, default: int) -> int:
 
 def assert_result(result, params, num_prompt) -> None:
     assert result["completed"] == num_prompt, "Request failures exist"
+    if params.get("dataset_name") == DUPLEX_EVAL_DATASET_NAME:
+        _assert_duplex_eval_result(result, params, num_prompt)
     if params.get("dataset_name") == "omniinteract":
         summary = result.get("omniinteract")
         assert isinstance(summary, dict), "OmniInteract summary is missing"
@@ -216,6 +444,12 @@ def test_performance_benchmark(omni_server, benchmark_params):
     test_name = benchmark_params["test_name"]
     params = benchmark_params["params"]
     dataset_name = params.get("dataset_name", "")
+    if dataset_name == DUPLEX_EVAL_DATASET_NAME:
+        # Resolve ${VAR}/~ mirror references before the generic CLI rendering
+        # below turns every key into a ``vllm bench serve`` flag.
+        params = _resolve_duplex_eval_params(params)
+        with _duplex_eval_lock:
+            _DUPLEX_EVAL_ATTEMPTED.add(test_name)
 
     host = omni_server.host
     port = omni_server.port
@@ -248,18 +482,7 @@ def test_performance_benchmark(omni_server, benchmark_params):
         raise ValueError("The number of prompts does not match the QPS or max_concurrency")
 
     args = ["--host", host, "--port", str(port)]
-    exclude_keys = {
-        "request_rate",
-        "baseline",
-        "num_prompts",
-        "max_concurrency",
-        "num_warmups",
-        "task",
-        "enabled",
-        "eval_phase",
-        "trust_remote_code",
-        "expected_duplex_audio_turns_per_session",
-    }
+    exclude_keys = _BENCHMARK_PARAM_EXCLUDE_KEYS
 
     for key, value in params.items():
         if key in exclude_keys or value is None:
@@ -285,6 +508,7 @@ def test_performance_benchmark(omni_server, benchmark_params):
 
     # QPS / request-rate sweep
     for sweep_index, (qps, num_prompt) in enumerate(zip(qps_list, num_prompt_list)):
+        phase_one_started = time.time()
         args = args + ["--request-rate", str(qps), "--num-prompts", str(num_prompt)]
         result = run_benchmark(
             args=args,
@@ -300,9 +524,18 @@ def test_performance_benchmark(omni_server, benchmark_params):
             num_warmups=_resolve_num_warmups(params, default=2),
         )
         assert_result(result, params, num_prompt)
+        _register_phase_one_result(
+            result=result,
+            params=params,
+            test_name=test_name,
+            flow=qps,
+            num_prompt=num_prompt,
+            since=phase_one_started,
+        )
 
     # concurrency test
     for sweep_index, (concurrency, num_prompt) in enumerate(zip(max_concurrency_list, num_prompt_list)):
+        phase_one_started = time.time()
         args = args + ["--max-concurrency", str(concurrency), "--num-prompts", str(num_prompt), "--request-rate", "inf"]
         result = run_benchmark(
             args=args,
@@ -318,3 +551,246 @@ def test_performance_benchmark(omni_server, benchmark_params):
             num_warmups=_resolve_num_warmups(params, default=max(2, int(concurrency))),
         )
         assert_result(result, params, num_prompt)
+        _register_phase_one_result(
+            result=result,
+            params=params,
+            test_name=test_name,
+            flow=concurrency,
+            num_prompt=num_prompt,
+            since=phase_one_started,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 2/3/4: judge server, evaluate, summarize, merge, Gate (design §5.7)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def judge_server_context():
+    """Lazily start/stop the Qwen3-Omni judge server (separate lock from omni_server)."""
+    with _judge_server_lock:
+        active_context = _SingleActiveContext()
+        try:
+            yield active_context
+        finally:
+            active_context.close()
+
+
+def _omni_bench_cli() -> list[str]:
+    return [sys.executable, "-m", "vllm_omni.entrypoints.cli.main", "bench"]
+
+
+def _judge_health_url(host: str, port: int) -> str:
+    return f"http://{host}:{port}/v1/models"
+
+
+def _wait_for_judge_health(host: str, port: int, *, required: bool) -> bool:
+    """Poll the judge's OpenAI endpoint; hard-fail unless ``required`` is false."""
+    url = _judge_health_url(host, port)
+    last_error: str | None = None
+    for _attempt in range(_JUDGE_HEALTH_RETRIES):
+        try:
+            with urllib.request.urlopen(url, timeout=_JUDGE_HEALTH_TIMEOUT_S) as response:
+                if response.status == 200:
+                    return True
+                last_error = f"HTTP {response.status}"
+        except (urllib.error.URLError, OSError, ValueError) as exc:
+            last_error = str(exc)
+        time.sleep(_JUDGE_HEALTH_INTERVAL_S)
+    message = f"Omni-DuplexEval judge unreachable at {url} after {_JUDGE_HEALTH_RETRIES} attempts: {last_error}"
+    if required:
+        pytest.fail(message, pytrace=False)
+    print(f"{message} (judge_server_params.required=false -> degrading)")
+    return False
+
+
+def _judge_server_param(test_name: str, judge_cfg: dict[str, Any]) -> tuple:
+    """Build the ``_start_omni_server`` tuple for the judge (reuses its construction)."""
+    model = str(judge_cfg.get("model") or "").strip()
+    if not model:
+        pytest.fail(f"{test_name}: judge_server_params.model is required", pytrace=False)
+    extra_cli_args = tuple(str(item) for item in (judge_cfg.get("extra_cli_args") or ()))
+    use_omni = bool(judge_cfg.get("use_omni", True))
+    return (f"{test_name}::judge", model, None, None, extra_cli_args, use_omni)
+
+
+def _run_or_fail(command: list[str], *, phase: str) -> None:
+    print(f"[duplex-eval] {phase}: {' '.join(command)}")
+    process = subprocess.run(command, capture_output=True, text=True, cwd=str(_REPO_ROOT))
+    if process.stdout:
+        print(process.stdout)
+    if process.returncode != 0:
+        tail = "\n".join((process.stderr or "").strip().splitlines()[-50:])
+        pytest.fail(
+            f"Omni-DuplexEval {phase} failed with exit code {process.returncode}\n"
+            f"command: {' '.join(command)}\nstderr tail:\n{tail}",
+            pytrace=False,
+        )
+
+
+def _build_evaluate_command(case: dict[str, Any], *, judge_url: str, judge_model: str) -> list[str]:
+    """Translate the serve-side case parameters into the standalone evaluate CLI (U7)."""
+    params = case["params"]
+    command = _omni_bench_cli() + ["omni-duplex-eval", "--omni", "evaluate"]
+    command += ["--dataset", str(params["dataset_path"]), "--split", str(params.get("duplex_eval_split", "all"))]
+    command += ["--response-root", str(params["duplex_eval_output_dir"])]
+    command += ["--score-root", str(params["duplex_eval_score_dir"])]
+    if params.get("duplex_eval_media_root"):
+        command += ["--media-root", str(params["duplex_eval_media_root"])]
+    command += ["--judge-base-url", judge_url, "--judge-model", judge_model]
+    command += ["--judge-video-mode", str(params.get("duplex_eval_judge_video_mode", "frame-sample"))]
+    command += ["--judge-fps", str(int(params.get("duplex_eval_judge_fps", 2)))]
+    command += ["--content-frame-limit", str(int(params.get("duplex_eval_content_frame_limit", 16)))]
+    command += ["--eval-workers", str(int(params.get("duplex_eval_eval_workers", 1)))]
+    if params.get("duplex_eval_allow_invalid_clock"):
+        command.append("--allow-invalid-clock")
+    modalities = params.get("duplex_eval_judge_modalities")
+    if modalities:
+        command += ["--judge-modalities", *[str(item) for item in modalities]]
+    # Phase-1 selected_ids are ``split/id``; ``load_samples`` matches bare ids and
+    # ``--split`` already pins the split, so strip the prefix (design §5.7 P2).
+    selected_ids = [str(item).rsplit("/", 1)[-1] for item in (case.get("selected_ids") or [])]
+    command += ["--ids", *selected_ids]
+    exclude_ids = [str(item) for item in (params.get("duplex_eval_exclude_ids") or [])]
+    if exclude_ids:
+        command += ["--exclude-ids", *exclude_ids]
+    return command
+
+
+def _build_summarize_command(score_dir: Path) -> list[str]:
+    return _omni_bench_cli() + [
+        "omni-duplex-eval",
+        "--omni",
+        "summarize",
+        "--score-root",
+        str(score_dir),
+        "--output-json",
+        str(score_dir / "score_summary.json"),
+    ]
+
+
+def _judge_metadata(params: dict[str, Any], *, judge_url: str, judge_model: str, protocol_pin: str) -> dict[str, Any]:
+    from vllm_omni.benchmarks.duplex.omni_duplex_eval_eval import CONTENT_FRAME_LIMIT
+
+    return {
+        "model": judge_model,
+        "base_url": judge_url,
+        "video_mode": str(params.get("duplex_eval_judge_video_mode", "frame-sample")),
+        "fps": int(params.get("duplex_eval_judge_fps", 2)),
+        "modalities": [str(item) for item in (params.get("duplex_eval_judge_modalities") or [])],
+        "content_frame_limit": int(params.get("duplex_eval_content_frame_limit", CONTENT_FRAME_LIMIT)),
+        "eval_workers": int(params.get("duplex_eval_eval_workers", 1)),
+        "protocol_pin": protocol_pin,
+    }
+
+
+def _record_judge_skipped(result_path: Path, reason: str) -> None:
+    """Degraded path (``judge_server_params.required=false``): mark and keep G1-G3."""
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    duplex = payload.get("duplex_eval")
+    if not isinstance(duplex, dict):
+        raise AssertionError(f"duplex_eval side-channel missing in {result_path}")
+    if duplex.get("phase") != "generate":
+        raise AssertionError(f"refusing to mark judge skipped: duplex_eval.phase={duplex.get('phase')!r}")
+    duplex["judge_enabled"] = False
+    duplex["judge_skipped_reason"] = reason
+    tmp = result_path.with_suffix(result_path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    os.replace(tmp, result_path)
+
+
+def _run_duplex_eval_phase2_and_merge(
+    case: dict[str, Any],
+    *,
+    judge_server: Any,
+    judge_cfg: dict[str, Any],
+) -> None:
+    from vllm_omni.benchmarks.duplex.omni_duplex_eval_metrics import PROTOCOL_PIN
+    from vllm_omni.benchmarks.duplex_eval import merge_duplex_eval_into_result
+
+    params = case["params"]
+    result_path = Path(str(case["result_path"]))
+    score_dir = Path(str(params["duplex_eval_score_dir"]))
+    judge_url = f"http://{judge_server.host}:{judge_server.port}"
+    judge_model = str(judge_cfg.get("model") or "")
+    if not case.get("selected_ids"):
+        pytest.fail(f"Omni-DuplexEval Phase 1 recorded no selected_ids for {result_path.name}", pytrace=False)
+
+    # Guard O-6: the judge must score exactly the Phase-1 selection set.
+    _run_or_fail(
+        _build_evaluate_command(case, judge_url=judge_url, judge_model=judge_model),
+        phase="evaluate",
+    )
+    _run_or_fail(_build_summarize_command(score_dir), phase="summarize")
+
+    summary_path = score_dir / "score_summary.json"
+    if not summary_path.exists():
+        pytest.fail(f"Omni-DuplexEval summarize produced no {summary_path}", pytrace=False)
+    score_summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    if score_summary.get("protocol_pin") != PROTOCOL_PIN:
+        pytest.fail(
+            f"Omni-DuplexEval protocol pin mismatch: {score_summary.get('protocol_pin')!r} != {PROTOCOL_PIN!r}",
+            pytrace=False,
+        )
+
+    judge_meta = _judge_metadata(params, judge_url=judge_url, judge_model=judge_model, protocol_pin=PROTOCOL_PIN)
+    merged = merge_duplex_eval_into_result(
+        result_path,
+        score_summary=score_summary,
+        judge_meta=judge_meta,
+        phases=["generate", "evaluate", "summarize"],
+    )
+    # Gate G4-G6 on the merged result (Phase 1 already ran G1-G3).
+    assert_result(merged, params, int(case["num_prompt"]))
+
+
+@pytest.mark.benchmark
+@pytest.mark.omni
+@pytest.mark.local_model
+def test_duplex_eval_judge_and_merge(omni_server_context, judge_server_context):
+    """Phase 2/3/4: judge with a separate 2-card server, summarize, merge, Gate.
+
+    Defined *after* ``test_performance_benchmark`` so pytest runs it once the
+    Phase-1 parametrization has finished and every timed duplex server has been
+    stopped (design §5.7 方案 A). Its ``omni`` + ``local_model`` marks mirror the
+    documented local command (``-m "omni and local_model"``); an extra mark
+    clause (e.g. ``cards_2``) would deselect this phase, so keep the documented
+    expression.
+    """
+    if not _DUPLEX_EVAL_CASES:
+        with _duplex_eval_lock:
+            attempted = sorted(_DUPLEX_EVAL_ATTEMPTED)
+        if attempted:
+            pytest.fail(
+                "Omni-DuplexEval generation phase produced no result; judge phase cannot run "
+                f"(attempted test_names: {attempted})",
+                pytrace=False,
+            )
+        pytest.skip("no Omni-DuplexEval case collected in this run")
+
+    # Release the timed duplex server's cards before the judge starts (顺序独占).
+    omni_server_context.close()
+
+    judge_cfg_by_name = _judge_server_params_by_test_name()
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for case in list(_DUPLEX_EVAL_CASES):
+        grouped.setdefault(case["test_name"], []).append(case)
+
+    for test_name, cases in grouped.items():
+        judge_cfg = judge_cfg_by_name.get(test_name) or {}
+        required = bool(judge_cfg.get("required", True))
+        judge_param = _judge_server_param(test_name, judge_cfg)
+        judge_server = judge_server_context.acquire(judge_param, partial(_start_omni_server, judge_param))
+        try:
+            healthy = _wait_for_judge_health(judge_server.host, judge_server.port, required=required)
+            for case in cases:
+                if not healthy:
+                    _record_judge_skipped(
+                        Path(str(case["result_path"])),
+                        "judge unreachable (judge_server_params.required=false)",
+                    )
+                    continue
+                _run_duplex_eval_phase2_and_merge(case, judge_server=judge_server, judge_cfg=judge_cfg)
+        finally:
+            judge_server_context.close()

--- a/tests/dfx/perf/tests/test_minicpmo_4_5_omni_duplex_eval.json
+++ b/tests/dfx/perf/tests/test_minicpmo_4_5_omni_duplex_eval.json
@@ -1,0 +1,148 @@
+[
+  {
+    "test_name": "test_minicpmo_4_5_omni_duplex_eval",
+    "mark": [
+      {
+        "hardware_marks": {
+          "res": {
+            "cuda": "H100",
+            "npu": "A3"
+          },
+          "num_cards": 2
+        }
+      },
+      "local_model",
+      "omni"
+    ],
+    "server_params": {
+      "model": "openbmb/MiniCPM-o-4_5",
+      "extra_cli_args": [
+        "--deploy-config",
+        "vllm_omni/deploy/minicpmo_4_5.yaml",
+        "--trust-remote-code"
+      ]
+    },
+    "judge_server_params": {
+      "model": "Qwen/Qwen3-Omni-30B-A3B-Instruct",
+      "extra_cli_args": [
+        "--deploy-config",
+        "vllm_omni/deploy/qwen3_omni_moe_thinking.yaml",
+        "--trust-remote-code"
+      ],
+      "required": true
+    },
+    "benchmark_params": [
+      {
+        "name": "rtd_ocr",
+        "dataset_name": "omni-duplex-eval",
+        "dataset_path": "${BENCHMARK_ASSETS}/omni-duplex-eval/mirror-v1",
+        "backend": "openai-realtime-duplex",
+        "endpoint": "/v1/realtime",
+        "num_prompts": [
+          6
+        ],
+        "max_concurrency": [
+          2
+        ],
+        "num_warmups": 0,
+        "disable_shuffle": true,
+        "duplex_eval_split": "RTD_OCR",
+        "duplex_eval_limit": 8,
+        "duplex_eval_exclude_ids": [
+          "517",
+          "565"
+        ],
+        "duplex_eval_media_root": "${BENCHMARK_ASSETS}/omni-duplex-eval/mirror-v1/media",
+        "duplex_eval_ref_audio": "tests/assets/minicpmo_4_5/response_required_16k.wav",
+        "duplex_eval_output_dir": "tests/dfx/perf/results/omni-duplex-eval/responses/RTD_OCR",
+        "duplex_eval_score_dir": "tests/dfx/perf/results/omni-duplex-eval/scores/RTD_OCR",
+        "percentile-metrics": "e2el",
+        "duplex_eval_judge_video_mode": "frame-sample",
+        "duplex_eval_judge_fps": 2,
+        "duplex_eval_judge_modalities": [
+          "text"
+        ],
+        "duplex_eval_content_frame_limit": 24,
+        "duplex_eval_eval_workers": 2,
+        "duplex_eval_judge_model": "Qwen/Qwen3-Omni-30B-A3B-Instruct",
+        "duplex_eval_exclude_ids_pending": [
+          "583 (RTD_OCR row_idx 23; judge-stage failure; split verified via HF datasets-server)",
+          "584 (RTD_OCR row_idx 24; judge-stage failure; split verified via HF datasets-server)",
+          "585 (RTD_OCR row_idx 25; judge-stage failure; split verified via HF datasets-server)",
+          "590 (RTD_OCR row_idx 30; judge-stage failure; split verified via HF datasets-server)",
+          "393 (RTD_world_knowledge row_idx 33; judge-stage failure; split NOT selected in this case -> no-op, kept as placeholder only)"
+        ]
+      },
+      {
+        "name": "rtd_omni",
+        "dataset_name": "omni-duplex-eval",
+        "dataset_path": "${BENCHMARK_ASSETS}/omni-duplex-eval/mirror-v1",
+        "backend": "openai-realtime-duplex",
+        "endpoint": "/v1/realtime",
+        "num_prompts": [
+          6
+        ],
+        "max_concurrency": [
+          2
+        ],
+        "num_warmups": 0,
+        "disable_shuffle": true,
+        "duplex_eval_split": "RTD_Omni",
+        "duplex_eval_limit": 8,
+        "duplex_eval_exclude_ids": [
+          "517",
+          "565"
+        ],
+        "duplex_eval_media_root": "${BENCHMARK_ASSETS}/omni-duplex-eval/mirror-v1/media",
+        "duplex_eval_ref_audio": "tests/assets/minicpmo_4_5/response_required_16k.wav",
+        "duplex_eval_output_dir": "tests/dfx/perf/results/omni-duplex-eval/responses/RTD_Omni",
+        "duplex_eval_score_dir": "tests/dfx/perf/results/omni-duplex-eval/scores/RTD_Omni",
+        "percentile-metrics": "e2el",
+        "duplex_eval_judge_video_mode": "frame-sample",
+        "duplex_eval_judge_fps": 2,
+        "duplex_eval_judge_modalities": [
+          "text"
+        ],
+        "duplex_eval_content_frame_limit": 24,
+        "duplex_eval_eval_workers": 2,
+        "duplex_eval_judge_model": "Qwen/Qwen3-Omni-30B-A3B-Instruct",
+        "duplex_eval_exclude_ids_pending": []
+      },
+      {
+        "name": "rtd_interaction_relation",
+        "dataset_name": "omni-duplex-eval",
+        "dataset_path": "${BENCHMARK_ASSETS}/omni-duplex-eval/mirror-v1",
+        "backend": "openai-realtime-duplex",
+        "endpoint": "/v1/realtime",
+        "num_prompts": [
+          6
+        ],
+        "max_concurrency": [
+          2
+        ],
+        "num_warmups": 0,
+        "disable_shuffle": true,
+        "duplex_eval_split": "RTD_interaction_relation",
+        "duplex_eval_limit": 8,
+        "duplex_eval_exclude_ids": [
+          "517",
+          "565"
+        ],
+        "duplex_eval_media_root": "${BENCHMARK_ASSETS}/omni-duplex-eval/mirror-v1/media",
+        "duplex_eval_ref_audio": "tests/assets/minicpmo_4_5/response_required_16k.wav",
+        "duplex_eval_output_dir": "tests/dfx/perf/results/omni-duplex-eval/responses/RTD_interaction_relation",
+        "duplex_eval_score_dir": "tests/dfx/perf/results/omni-duplex-eval/scores/RTD_interaction_relation",
+        "percentile-metrics": "e2el",
+        "duplex_eval_judge_video_mode": "frame-sample",
+        "duplex_eval_judge_fps": 2,
+        "duplex_eval_judge_modalities": [
+          "text"
+        ],
+        "duplex_eval_content_frame_limit": 24,
+        "duplex_eval_eval_workers": 2,
+        "duplex_eval_judge_model": "Qwen/Qwen3-Omni-30B-A3B-Instruct",
+        "duplex_eval_exclude_ids_pending": []
+      }
+    ]
+  }
+]

--- a/tests/dfx/perf/tests/test_runner_metadata.py
+++ b/tests/dfx/perf/tests/test_runner_metadata.py
@@ -3,8 +3,10 @@
 
 """Tests for DFX runner metadata field exclusion."""
 
+import argparse
 import json
 from contextlib import contextmanager
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -588,3 +590,219 @@ def test_omni_tpot_baseline_rejects_missing_or_nonfinite_sample(num_tpot_samples
             {"baseline": {"H100": {"mean_tpot_ms": 20.0}}},
             1,
         )
+
+
+# ---------------------------------------------------------------------------
+# Omni-DuplexEval runner metadata (design v2 §9.2, T22-T33)
+# ---------------------------------------------------------------------------
+
+_DUPLEX_EVAL_PERF_JSON = Path(__file__).with_name("test_minicpmo_4_5_omni_duplex_eval.json")
+
+# Keys rendered by the generic ``run_benchmark`` loop that are *not* served by
+# ``add_duplex_eval_cli_args`` (upstream ``vllm bench serve`` takes them).
+_UPSTREAM_SERVE_KEYS = frozenset(
+    {
+        "dataset_name",
+        "dataset_path",
+        "backend",
+        "endpoint",
+        "num_prompts",
+        "max_concurrency",
+        "num_warmups",
+        "disable_shuffle",
+        "trust_remote_code",
+        "percentile-metrics",
+        "no_oversample",
+        "extra_body",
+    }
+)
+
+
+def _load_duplex_eval_config() -> dict:
+    return json.loads(_DUPLEX_EVAL_PERF_JSON.read_text(encoding="utf-8"))[0]
+
+
+def _duplex_eval_params(**overrides) -> dict:
+    params = {"dataset_name": "omni-duplex-eval", "duplex_eval_exclude_ids": ["517", "565"]}
+    params.update(overrides)
+    return params
+
+
+def _merged_duplex_summary(**overrides) -> dict:
+    summary = {
+        "total": 6,
+        "generated": 6,
+        "generation_failed": 0,
+        "failure_ids": [],
+        "artifacts_complete": True,
+        "clock": "media",
+        "clock_mismatch_ids": [],
+        "exclude_ids": ["517", "565"],
+        "selected_ids": ["RTD_OCR/560", "RTD_OCR/561"],
+        "phase": "generate+evaluate+summarize",
+        "judge_enabled": True,
+        "scored": 6,
+        "score_summary": {"protocol_pin": "pin", "samples": 6},
+    }
+    summary.update(overrides)
+    return summary
+
+
+def test_omni_duplex_result_accepts_complete_merged_summary():
+    """T22: complete generation + merged judge phase passes the Gate."""
+    from tests.dfx.perf.scripts.run_benchmark import assert_result
+
+    assert_result({"completed": 6, "duplex_eval": _merged_duplex_summary()}, _duplex_eval_params(), 6)
+
+
+def test_omni_duplex_result_rejects_incomplete_generation():
+    """T23: generated < total fails loudly (the two known stuck samples)."""
+    from tests.dfx.perf.scripts.run_benchmark import assert_result
+
+    summary = _merged_duplex_summary(generated=5, generation_failed=1, failure_ids=["RTD_OCR/565"])
+    with pytest.raises(AssertionError, match="generation incomplete"):
+        assert_result({"completed": 6, "duplex_eval": summary}, _duplex_eval_params(), 6)
+
+
+def test_omni_duplex_result_rejects_incomplete_artifacts():
+    """T24: a missing generation ledger fails the Gate."""
+    from tests.dfx.perf.scripts.run_benchmark import assert_result
+
+    summary = _merged_duplex_summary(artifacts_complete=False)
+    with pytest.raises(AssertionError, match="artifacts are incomplete"):
+        assert_result({"completed": 6, "duplex_eval": summary}, _duplex_eval_params(), 6)
+
+
+def test_omni_duplex_result_tolerates_degraded_judge():
+    """T25: judge_enabled=false + skip reason keeps only G1-G3."""
+    from tests.dfx.perf.scripts.run_benchmark import assert_result
+
+    summary = _merged_duplex_summary(
+        judge_enabled=False,
+        phase="generate",
+        judge_skipped_reason="judge unreachable (judge_server_params.required=false)",
+        scored=0,
+    )
+    del summary["score_summary"]
+    assert_result({"completed": 6, "duplex_eval": summary}, _duplex_eval_params(), 6)
+
+
+def test_omni_duplex_result_rejects_exclude_echo_mismatch():
+    """T26a: the effective exclude list must be echoed back verbatim."""
+    from tests.dfx.perf.scripts.run_benchmark import assert_result
+
+    with pytest.raises(AssertionError, match="exclude-id echo mismatch"):
+        assert_result(
+            {"completed": 6, "duplex_eval": _merged_duplex_summary(exclude_ids=["517"])}, _duplex_eval_params(), 6
+        )
+
+
+def test_omni_duplex_result_rejects_excluded_sample_selected():
+    """T26b: an excluded sample must never appear in selected_ids."""
+    from tests.dfx.perf.scripts.run_benchmark import assert_result
+
+    summary = _merged_duplex_summary(selected_ids=["RTD_OCR/517"])
+    with pytest.raises(AssertionError, match="excluded samples were still selected"):
+        assert_result({"completed": 6, "duplex_eval": summary}, _duplex_eval_params(), 6)
+
+
+def test_omni_duplex_result_needs_no_benchmark_mode():
+    """T27: the duplex-eval branch must not depend on a ``benchmark_mode`` key."""
+    from tests.dfx.perf.scripts.run_benchmark import assert_result
+
+    params = _duplex_eval_params()
+    assert "benchmark_mode" not in params
+    assert_result({"completed": 6, "duplex_eval": _merged_duplex_summary()}, params, 6)
+
+
+def test_omni_duplex_result_without_baseline_skips_tpot_assertion():
+    """T28: no baseline block means no TPOT sample assertions (locking B2)."""
+    from tests.dfx.perf.scripts.run_benchmark import assert_result
+
+    result = {"completed": 6, "duplex_eval": _merged_duplex_summary(), "mean_tpot_ms": float("nan")}
+    assert_result(result, _duplex_eval_params(), 6)
+
+
+def test_omni_duplex_custom_percentile_keys_do_not_assert():
+    """T29: unknown percentile metrics are inert for the duplex-eval Gate."""
+    from tests.dfx.perf.scripts.run_benchmark import assert_result
+
+    params = _duplex_eval_params(**{"percentile-metrics": "e2el,judge_latency_ms"})
+    assert_result({"completed": 6, "duplex_eval": _merged_duplex_summary()}, params, 6)
+
+
+def test_omni_duplex_perf_json_marks_resolve():
+    """T30: the shipped JSON declares exactly one hardware_marks + local_model/omni."""
+    from tests.dfx.conftest import resolve_pytest_marks
+
+    config = _load_duplex_eval_config()
+    assert sum(1 for item in config["mark"] if isinstance(item, dict) and "hardware_marks" in item) == 1
+    names = {mark.name for mark in resolve_pytest_marks(config["mark"])}
+    assert {"local_model", "omni", "cards_2", "H100", "A3", "cuda", "npu"} <= names
+    assert "full_model" not in names
+
+
+def test_omni_duplex_judge_server_params_ignored_by_server_parser(tmp_path):
+    """T31: ``judge_server_params`` must not leak into the duplex server params."""
+    from tests.dfx.conftest import _create_unique_server_params
+
+    config = _load_duplex_eval_config()
+    assert "judge_server_params" in config
+    rows = _create_unique_server_params([config], tmp_path)
+    assert len(rows) == 1
+    test_name, model, _deploy, _overrides, _extra, _use_omni = rows[0]
+    assert test_name == config["test_name"]
+    assert model == config["server_params"]["model"]
+
+
+def _duplex_eval_serve_cli_keys() -> set[str]:
+    from vllm_omni.entrypoints.cli.benchmark.cli_args import add_duplex_eval_cli_args
+
+    parser = argparse.ArgumentParser()
+    add_duplex_eval_cli_args(parser)
+    return {
+        option[2:].replace("-", "_")
+        for action in parser._actions
+        for option in action.option_strings
+        if option.startswith("--")
+    }
+
+
+def test_omni_duplex_perf_json_keys_are_cli_or_excluded():
+    """T32: every JSON key is either a real CLI flag or in the exclude allow-list.
+
+    This is the reverse check for the silent argparse failure described in
+    design §12.1 V3: a ``benchmark_params`` key that is neither excluded nor a
+    registered ``vllm bench serve`` flag makes the whole case fail to launch.
+    """
+    from tests.dfx.perf.scripts.run_benchmark import _BENCHMARK_PARAM_EXCLUDE_KEYS
+
+    allowed = set(_BENCHMARK_PARAM_EXCLUDE_KEYS) | _duplex_eval_serve_cli_keys() | set(_UPSTREAM_SERVE_KEYS)
+    config = _load_duplex_eval_config()
+    for params in config["benchmark_params"]:
+        unknown = set(params) - allowed
+        assert not unknown, f"perf JSON keys rendered as unknown flags: {sorted(unknown)}"
+
+
+def test_omni_duplex_hardware_marks_accept_cuda_and_npu_same_cards():
+    """T33a: branch B-2 mark shape (cuda H100 + npu A3, num_cards=2) is legal."""
+    from tests.helpers.mark import hardware_marks
+
+    names = {mark.name for mark in hardware_marks(res={"cuda": "H100", "npu": "A3"}, num_cards=2)}
+    assert {"H100", "A3", "cuda", "npu", "cards_2"} <= names
+
+
+def test_omni_duplex_hardware_marks_reject_mixed_card_counts():
+    """T33b: per-platform card counts must match (branch B-1 needs a split test_name)."""
+    from tests.helpers.mark import hardware_marks
+
+    with pytest.raises(ValueError, match="different per-platform num_cards"):
+        hardware_marks(res={"cuda": "H100", "npu": "A3"}, num_cards={"cuda": 2, "npu": 1})
+
+
+def test_omni_duplex_perf_json_avoids_host_absolute_paths():
+    """The JSON must reference the mirror through BENCHMARK_ASSETS, never a host path."""
+    for params in _load_duplex_eval_config()["benchmark_params"]:
+        dataset_path = params["dataset_path"]
+        assert dataset_path.startswith("${BENCHMARK_ASSETS}")
+        assert not dataset_path.startswith("/Users/")

--- a/vllm_omni/benchmarks/data_modules/duplex_eval_dataset.py
+++ b/vllm_omni/benchmarks/data_modules/duplex_eval_dataset.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""Omni-DuplexEval dataset adapter for the standard serving benchmark.
+
+This module only wires the existing ``vllm_omni.benchmarks.duplex`` loader into
+the ``BenchmarkDataset`` / ``SampleRequest`` contract used by ``vllm bench serve``.
+Split selection, family filtering, media resolution and row normalisation stay in
+:func:`vllm_omni.benchmarks.duplex.omni_duplex_eval_dataset.load_samples` so the
+standalone CLI and the serving backend share one implementation.
+
+v2 (design §5.1): no judge options — ``DuplexEvalJudgeOptions`` has been removed
+from this module; the judge lives exclusively in the DFX runner (Phase 2 / Phase 3).
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import regex as re
+from vllm.benchmarks.datasets import BenchmarkDataset, SampleRequest
+from vllm.tokenizers import TokenizerLike
+
+from vllm_omni.benchmarks.duplex.omni_duplex_eval_dataset import (
+    DEFAULT_DATASET,
+    PR_SPLITS,
+    RTD_SPLITS,
+    DuplexSample,
+    load_samples,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DUPLEX_EVAL_FAMILIES: tuple[str, ...] = ("all", "rtd", "pr")
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+_EXCLUDE_RE = re.compile(r"^(?:[^/]+/)?[^/]+$")
+
+
+def normalize_exclude_ids(raw: Iterable[str]) -> frozenset[str]:
+    """Normalise ``--exclude-ids`` entries to ``split/id`` form.
+
+    A bare id (e.g. ``"565"``) is accepted and stored as-is — the per-split
+    filter in :meth:`DuplexEvalDataset.sample` checks both ``split/id`` and
+    bare ``id`` so that a short form works as a universal exclude across all
+    splits.
+
+    Raises ``ValueError`` when a token does not match the expected pattern.
+    """
+    result: set[str] = set()
+    for token in raw:
+        token = token.strip()
+        if not token:
+            continue
+        if not _EXCLUDE_RE.match(token):
+            raise ValueError(f"invalid exclude-id format {token!r}: expected 'id' or 'split/id'")
+        result.add(token)
+    return frozenset(result)
+
+
+def sample_ids(samples: Iterable[DuplexSample]) -> list[str]:
+    """Return ``split/id`` keys that identify the selected samples."""
+    return [f"{sample.split}/{sample.id}" for sample in samples]
+
+
+# ---------------------------------------------------------------------------
+# Options
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DuplexEvalSessionOptions:
+    """Generation layout shared by every sample in one run (v2: no judge)."""
+
+    response_root: Path
+    score_dir: Path
+    ref_audio: str
+    fps: float = 1.0
+    mix: str = "question"
+    pace: str = "realtime"
+    clock: str = "media"
+    unit_ms: int = 1000
+    overwrite: bool = False
+    exclude_ids: tuple[str, ...] = ()
+    write_artifacts: bool = True
+
+
+# ---------------------------------------------------------------------------
+# Sample request
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DuplexEvalSampleRequest(SampleRequest):
+    duplex_eval_sample: DuplexSample | None = None
+    duplex_eval_options: DuplexEvalSessionOptions | None = None
+
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+
+
+def _iter_splits(split: str) -> list[str]:
+    """Expand ``"all"`` into the known split names; otherwise return [split]."""
+    if split == "all":
+        return sorted(RTD_SPLITS | PR_SPLITS)
+    return [split]
+
+
+class DuplexEvalDataset(BenchmarkDataset):
+    """Adapter that exposes the ``duplex/`` loader via the ``BenchmarkDataset`` contract.
+
+    Parameters
+    ----------
+    dataset
+        Hugging Face dataset id, local path to a dataset directory or
+        a ``.parquet`` file, or a JSON/JSONL manifest file path.
+    split
+        Split name or ``"all"`` (default).  When ``"all"``, samples are loaded
+        split by split so that exclude-then-limit semantics work correctly.
+    family
+        Family filter: ``"all"`` (default), ``"rtd"`` or ``"pr"``.
+    media_root
+        Optional base directory for resolving relative media paths.
+    limit
+        Maximum number of samples **per split** (after exclusion).
+        ``None`` means no limit.
+    ids
+        Only include samples whose id appears in this sequence.
+    exclude_ids
+        Exclude samples whose id (bare or ``split/id``) appears in this
+        sequence.  Applied **before** ``limit`` per split.
+    random_seed
+        Seed for shuffling after loading.
+    disable_shuffle
+        When ``True``, skip shuffling (deterministic order).
+    """
+
+    def __init__(
+        self,
+        *,
+        dataset: str = DEFAULT_DATASET,
+        split: str = "all",
+        family: str = "all",
+        media_root: str | Path | None = None,
+        limit: int | None = None,
+        ids: Sequence[str] | None = None,
+        exclude_ids: Sequence[str] | None = None,
+        random_seed: int = 0,
+        disable_shuffle: bool = False,
+    ) -> None:
+        super().__init__(
+            dataset_path=str(dataset),
+            random_seed=random_seed,
+            disable_shuffle=disable_shuffle,
+        )
+        self.dataset = dataset
+        self.split = split or "all"
+        self.family = family or "all"
+        self.media_root = media_root
+        self.limit = limit
+        self.ids = tuple(ids) if ids else None
+        self.exclude_ids = tuple(exclude_ids) if exclude_ids else ()
+
+    def sample(
+        self,
+        tokenizer: TokenizerLike | None,
+        num_requests: int,
+        *,
+        request_id_prefix: str = "",
+        options: DuplexEvalSessionOptions,
+        **_: Any,
+    ) -> list[SampleRequest]:
+        """Select, shuffle and package samples.
+
+        Semantics (per design §5.1 / §8.5 D-2):
+
+        1. Expand ``split`` to individual split names.
+        2. For each split, load samples via ``load_samples``.
+        3. **Exclude** matching entries from the loaded list.
+        4. **Limit** the remaining entries per split.
+        5. Collect across splits, shuffle, slice to ``num_requests``.
+        """
+        del tokenizer
+        exclude = normalize_exclude_ids(self.exclude_ids) if self.exclude_ids else frozenset()
+        picked: list[DuplexSample] = []
+
+        for split_name in _iter_splits(self.split):
+            rows = load_samples(
+                self.dataset,
+                split=split_name,
+                family=self.family,
+                media_root=self.media_root,
+                ids=self.ids,
+            )
+            # Exclude before limit (§8.5 D-2).
+            rows = [s for s in rows if f"{s.split}/{s.id}" not in exclude and s.id not in exclude]
+            if self.limit is not None:
+                rows = rows[: max(0, self.limit)]
+            picked.extend(rows)
+
+        if not picked:
+            raise ValueError("No Omni-DuplexEval samples were selected")
+
+        if not self.disable_shuffle:
+            random.Random(self.random_seed).shuffle(picked)
+
+        # ``num_requests == 0`` means every available sample.
+        if num_requests and num_requests > 0:
+            picked = picked[:num_requests]
+
+        return [
+            DuplexEvalSampleRequest(
+                prompt="",
+                prompt_len=0,
+                expected_output_len=0,
+                multi_modal_data=None,
+                request_id=f"{request_id_prefix}{index}",
+                duplex_eval_sample=sample,
+                duplex_eval_options=options,
+            )
+            for index, sample in enumerate(picked)
+        ]
+
+
+__all__ = [
+    "DUPLEX_EVAL_FAMILIES",
+    "DuplexEvalDataset",
+    "DuplexEvalSampleRequest",
+    "DuplexEvalSessionOptions",
+    "normalize_exclude_ids",
+    "sample_ids",
+]

--- a/vllm_omni/benchmarks/duplex/omni_duplex_eval_dataset.py
+++ b/vllm_omni/benchmarks/duplex/omni_duplex_eval_dataset.py
@@ -7,6 +7,14 @@ The loader accepts a Hugging Face dataset id, a local Hugging Face dataset
 layout (a directory or a ``.parquet`` file), a JSON/JSONL manifest, or an
 already materialized iterable.  Media is deliberately resolved at use time so
 the benchmark remains usable in air-gapped environments.
+
+Local directory mirrors are expected to follow a Hugging Face dataset layout
+with one ``data/<config>`` subfolder per split (config names are the RTD_*/PR_*
+split names), so each split's identity survives ``datasets.load_dataset``.
+Pointing the loader at a bare ``data/`` directory that Hugging Face collapses
+into a single ``train`` split only works when every row already carries its own
+``split``/``subset``/``config`` or ``family``/``task_type`` identity; otherwise
+the loader raises a clear error that explains the required layout.
 """
 
 from __future__ import annotations
@@ -69,6 +77,22 @@ def family_for_split(split: str, task_type: str | None = None) -> str:
     raise ValueError(f"cannot infer benchmark family from split {split!r}")
 
 
+def _identity_error(split: str, sample_id: str, *, family: bool) -> str:
+    """Build an actionable error for a row whose family/task cannot be derived."""
+    subject = "family" if family else "proactive-reminder task type"
+    label = f" for sample {sample_id!r}" if sample_id else ""
+    detail = (
+        "the split is not an RTD_*/PR_* name and no per-row 'task_type' is present"
+        if family
+        else "no per-row 'task_type' is present"
+    )
+    return (
+        f"cannot infer the Omni-DuplexEval {subject}{label} from split {split!r}: {detail}. "
+        "Load a local Omni-DuplexEval mirror laid out with one Hugging Face config per "
+        "split (RTD_*/PR_*), or add per-row 'family'/'task_type'/'split' columns."
+    )
+
+
 def _value(row: dict[str, Any], *keys: str, default: Any = None) -> Any:
     for key in keys:
         if key in row and row[key] is not None:
@@ -103,12 +127,25 @@ class DuplexSample:
     @classmethod
     def from_row(cls, row: dict[str, Any], *, split: str | None = None, media_root: Path | None = None) -> DuplexSample:
         chosen_split = str(split or _value(row, "split", "subset", "config", default=""))
+        sample_id = str(_value(row, "id", "sample_id", "uid", "name", default=""))
         task_value = _value(row, "task_type", "task", "type")
-        family = str(_value(row, "family", default="") or family_for_split(chosen_split, task_value))
+        family_value = _value(row, "family", default="")
+        if family_value:
+            family = str(family_value)
+        else:
+            try:
+                family = family_for_split(chosen_split, task_value)
+            except ValueError as exc:
+                raise ValueError(_identity_error(chosen_split, sample_id, family=True)) from exc
         task = None
         if family == "pr":
-            task = canonical_task_type(str(task_value)) if task_value else task_type_for_split(chosen_split)
-        sample_id = str(_value(row, "id", "sample_id", "uid", "name", default=""))
+            if task_value:
+                task = canonical_task_type(str(task_value))
+            else:
+                try:
+                    task = task_type_for_split(chosen_split)
+                except ValueError as exc:
+                    raise ValueError(_identity_error(chosen_split, sample_id, family=False)) from exc
         video = _value(row, "video", "video_path", "video_file")
         audio = _value(row, "question_audio", "audio", "question_wav")
         if media_root:
@@ -172,7 +209,19 @@ def _rows_from_hf(dataset: str, *, split: str | None) -> list[dict[str, Any]]:
     else:
         loaded = load_dataset(dataset, **load_kwargs)
     if isinstance(loaded, dict):
-        return [{**dict(row), "split": name} for name, table in loaded.items() for row in table]
+        rows = []
+        for name, table in loaded.items():
+            for row in table:
+                item = dict(row)
+                # Hugging Face collapses a config-less local directory (bare
+                # ``data/`` mirror) into a single generic split (``train``).
+                # Keep a row's own split identity (split/subset/config) so
+                # family inference is not poisoned by that generic name; only
+                # stamp the split when the row does not identify itself.
+                if not any(item.get(key) for key in ("split", "subset", "config")):
+                    item["split"] = name
+                rows.append(item)
+        return rows
     return [dict(row) for row in loaded]
 
 

--- a/vllm_omni/benchmarks/duplex/omni_duplex_eval_dataset.py
+++ b/vllm_omni/benchmarks/duplex/omni_duplex_eval_dataset.py
@@ -3,7 +3,8 @@
 
 """Dataset and split normalization for Omni-DuplexEval.
 
-The loader accepts a Hugging Face dataset id, a JSON/JSONL manifest, or an
+The loader accepts a Hugging Face dataset id, a local Hugging Face dataset
+layout (a directory or a ``.parquet`` file), a JSON/JSONL manifest, or an
 already materialized iterable.  Media is deliberately resolved at use time so
 the benchmark remains usable in air-gapped environments.
 """
@@ -148,6 +149,33 @@ def _read_manifest(path: Path) -> list[dict[str, Any]]:
     return payload
 
 
+def _rows_from_hf(dataset: str, *, split: str | None) -> list[dict[str, Any]]:
+    """Load rows from a Hugging Face dataset id or a local dataset layout.
+
+    ``datasets.load_dataset`` accepts a remote id, a local dataset directory
+    (``dataset_info.json`` + ``data/*.parquet``) and, via the ``parquet``
+    builder, a single ``.parquet`` file, which keeps the benchmark usable
+    offline with a locally mirrored copy of the dataset.
+    """
+    try:
+        from datasets import load_dataset
+    except ImportError as exc:
+        raise RuntimeError(
+            "datasets is required to load a Hugging Face dataset id or a local "
+            "dataset directory/parquet file; use a local JSON/JSONL manifest instead"
+        ) from exc
+    load_kwargs: dict[str, Any] = {}
+    if split and split != "all":
+        load_kwargs["split"] = split
+    if Path(dataset).suffix.lower() == ".parquet":
+        loaded = load_dataset("parquet", data_files=dataset, **load_kwargs)
+    else:
+        loaded = load_dataset(dataset, **load_kwargs)
+    if isinstance(loaded, dict):
+        return [{**dict(row), "split": name} for name, table in loaded.items() for row in table]
+    return [dict(row) for row in loaded]
+
+
 def load_samples(
     dataset: str | Path | Iterable[dict[str, Any]] = DEFAULT_DATASET,
     *,
@@ -157,25 +185,29 @@ def load_samples(
     limit: int | None = None,
     ids: Iterable[str] | None = None,
 ) -> list[DuplexSample]:
-    if isinstance(dataset, (str, Path)) and Path(str(dataset)).exists():
-        rows = _read_manifest(Path(str(dataset)))
-    elif not isinstance(dataset, (str, Path)):
-        rows = list(dataset)
-    else:
-        try:
-            from datasets import load_dataset
-        except ImportError as exc:
-            raise RuntimeError("datasets is required for Hugging Face loading; use a local manifest instead") from exc
-        kwargs: dict[str, Any] = {}
-        if split and split != "all":
-            kwargs["split"] = split
-        loaded = load_dataset(str(dataset), **kwargs)
-        if isinstance(loaded, dict):
-            rows = []
-            for name, table in loaded.items():
-                rows.extend({**dict(row), "split": name} for row in table)
+    if isinstance(dataset, str | Path):
+        path = Path(str(dataset))
+        if path.exists():
+            # A directory or a ``.parquet`` file is a Hugging Face dataset
+            # layout (e.g. a locally mirrored Omni-DuplexEval snapshot); only
+            # single JSON/JSONL files are parsed as manifests.  Routing by path
+            # shape instead of mere existence lets local Hugging Face datasets
+            # load through ``datasets.load_dataset``.
+            if path.is_dir() or path.suffix.lower() == ".parquet":
+                rows = _rows_from_hf(str(path), split=split)
+            else:
+                try:
+                    rows = _read_manifest(path)
+                except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                    raise ValueError(
+                        f"cannot load dataset from {str(path)!r}: expected a "
+                        "JSON/JSONL manifest file, a local Hugging Face dataset "
+                        "directory, or a single .parquet file"
+                    ) from exc
         else:
-            rows = [dict(row) for row in loaded]
+            rows = _rows_from_hf(str(dataset), split=split)
+    else:
+        rows = list(dataset)
     wanted = set(str(item) for item in ids) if ids else None
     root = Path(media_root).expanduser() if media_root else None
     result = []

--- a/vllm_omni/benchmarks/duplex/omni_duplex_eval_eval.py
+++ b/vllm_omni/benchmarks/duplex/omni_duplex_eval_eval.py
@@ -26,6 +26,12 @@ from .omni_duplex_eval_metrics import (
     temporal_window,
 )
 
+# Safe default frame budget for the judge's content pass. 16 matches the
+# original Qwen2.5-VL image-token calibration; it stays the default so existing
+# callers are byte-for-byte unaffected, while Qwen3-Omni callers can pass a
+# different ``content_frame_limit`` (design §5.6b).
+CONTENT_FRAME_LIMIT = 16
+
 
 def _read(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
@@ -50,6 +56,7 @@ def evaluate_sample(
     judge_video_mode: str = "video_url",
     window_size: float = 10.0,
     allow_invalid_clock: bool = False,
+    content_frame_limit: int = CONTENT_FRAME_LIMIT,
 ) -> dict[str, Any]:
     raw = _read(response_path)
     meta = (
@@ -105,7 +112,7 @@ def evaluate_sample(
             )
         content_frames = None
         if judge_video_mode == "frame-sample":
-            content_frames = _extract_frames(video_path, _content_frame_times(duration))
+            content_frames = _extract_frames(video_path, _content_frame_times(duration, max_frames=content_frame_limit))
         content = parse_judge_json(
             judge.content(
                 build_content_prompt(_text(items), sample.question_text, [sample.answer1, sample.answer2]),
@@ -175,8 +182,14 @@ def _extract_frames(path: str | Path, timestamps: list[float]) -> list[bytes]:
     return frames
 
 
-def _content_frame_times(duration: float) -> list[float]:
-    """Sample the full video at approximately one frame every three seconds."""
+def _content_frame_times(duration: float, *, max_frames: int = CONTENT_FRAME_LIMIT) -> list[float]:
+    """Sample the full video at approximately one frame every three seconds.
+
+    ``max_frames`` bounds the frame count to a judge-specific image-token
+    budget. The default mirrors the original Qwen2.5-VL calibration, so
+    ``max_frames=CONTENT_FRAME_LIMIT`` reproduces the previous sequence
+    element-for-element (design §5.6b / test T7).
+    """
     if duration <= 0:
         return []
     times = []
@@ -184,11 +197,10 @@ def _content_frame_times(duration: float) -> list[float]:
     while timestamp < duration:
         times.append(min(timestamp, max(0.0, duration - 0.01)))
         timestamp += 3.0
-    # Qwen2.5-VL has a finite per-request image-token budget. Preserve
-    # coverage while bounding long clips to a safely portable frame count.
-    if len(times) > 16:
-        stride = (len(times) - 1) / 15
-        times = [times[round(i * stride)] for i in range(16)]
+    # Preserve coverage while bounding long clips to the caller's budget.
+    if max_frames > 1 and len(times) > max_frames:
+        stride = (len(times) - 1) / (max_frames - 1)
+        times = [times[round(i * stride)] for i in range(max_frames)]
     return times
 
 

--- a/vllm_omni/benchmarks/duplex/omni_duplex_eval_judge.py
+++ b/vllm_omni/benchmarks/duplex/omni_duplex_eval_judge.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -22,20 +23,86 @@ def _build_openai_url(base_url: str, api_path: str) -> str:
     return f"{base}/v1{normalized_path}"
 
 
+def _choice_modality(choice: dict[str, Any]) -> str:
+    """Read the modality tag from a choice; ``""`` when the server omits it."""
+    modality = choice.get("modality")
+    if modality is None:
+        message = choice.get("message")
+        if isinstance(message, dict):
+            modality = message.get("modality")
+    return str(modality) if modality else ""
+
+
+def _message_text(choice: dict[str, Any]) -> str:
+    """Extract the plain text of ``choice.message.content``.
+
+    String content is returned unchanged; list content (multimodal parts) is
+    flattened by concatenating the ``text`` field of each text part.
+    """
+    message = choice.get("message")
+    content = message.get("content") if isinstance(message, dict) else None
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(
+            str(part.get("text", ""))
+            for part in content
+            if isinstance(part, dict) and part.get("type", "text") == "text"
+        )
+    return "" if content is None else str(content)
+
+
+def select_judge_text(payload: dict[str, Any]) -> str:
+    """Pick the judge answer from an OpenAI-compatible response.
+
+    Three-level strategy (design §5.6a) so a Qwen3-Omni multi-modality judge
+    that also emits audio choices still yields the text answer:
+
+    1. the first choice explicitly tagged ``modality == "text"`` with text;
+    2. otherwise the first choice whose message text is non-empty;
+    3. otherwise ``choices[0]`` (preserves the single-choice behaviour).
+    """
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise ValueError("judge response contains no choices")
+    for choice in choices:
+        if isinstance(choice, dict) and _choice_modality(choice) == "text" and _message_text(choice).strip():
+            return _message_text(choice)
+    for choice in choices:
+        if isinstance(choice, dict) and _message_text(choice).strip():
+            return _message_text(choice)
+    first = choices[0]
+    return _message_text(first) if isinstance(first, dict) else str(first)
+
+
 class DuplexJudge:
-    def __init__(self, base_url: str, model: str, *, api_key: str = "EMPTY", timeout: int = 600) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        model: str,
+        *,
+        api_key: str = "EMPTY",
+        timeout: int = 600,
+        modalities: Sequence[str] | None = None,
+    ) -> None:
         self.base_url, self.model, self.api_key, self.timeout = base_url, model, api_key, timeout
+        # ``None`` keeps the request body byte-identical to the pre-Qwen3-Omni
+        # client; only an explicit list asks the server for those modalities.
+        self.modalities = tuple(modalities) if modalities else None
 
     def chat(self, content: Any, *, system: str | None = None, max_tokens: int = 1200) -> str:
         messages = ([{"role": "system", "content": system}] if system else []) + [{"role": "user", "content": content}]
+        body: dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": 0.1,
+            "max_tokens": max_tokens,
+        }
+        if self.modalities:
+            body["modalities"] = list(self.modalities)
         response = requests.post(
             _build_openai_url(self.base_url, "/chat/completions"),
-            json={
-                "model": self.model,
-                "messages": messages,
-                "temperature": 0.1,
-                "max_tokens": max_tokens,
-            },
+            json=body,
             headers={"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"},
             timeout=self.timeout,
         )
@@ -43,7 +110,7 @@ class DuplexJudge:
             raise requests.HTTPError(
                 f"{response.status_code} response from judge: {response.text[:500]}", response=response
             )
-        return str(response.json()["choices"][0]["message"]["content"])
+        return select_judge_text(response.json())
 
     def temporal(self, prompt: str, frames: list[bytes]) -> str:
         content: list[dict[str, Any]] = [{"type": "text", "text": prompt}]

--- a/vllm_omni/benchmarks/duplex/omni_duplex_eval_media.py
+++ b/vllm_omni/benchmarks/duplex/omni_duplex_eval_media.py
@@ -5,7 +5,9 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
+import tempfile
 import wave
 from collections.abc import Iterator
 from pathlib import Path
@@ -20,20 +22,57 @@ def _run_ffmpeg(args: list[str]) -> bytes:
 
 
 def materialize_media(value: Any, output_dir: str | Path, stem: str, suffix: str) -> Path:
-    """Resolve common Hugging Face media values to a local file."""
+    """Resolve common Hugging Face media values to a local file.
+
+    ``str``/``Path`` values are returned as-is. Inline byte payloads (a
+    ``bytes``/``bytearray`` or a Hugging Face ``Audio``/``Video``/``Image``
+    feature mapping ``{"bytes": ..., "path": ...}``) are written to a real file
+    under ``output_dir`` and that existing path is returned. For such mappings
+    the ``path`` key is the original artifact name inside the dataset, which is
+    usually *not* present on the local disk, so it is only used to pick a
+    content extension and never treated as an existing file. A mapping or
+    object carrying only a ``path`` (no inline ``bytes``) is returned as an
+    already-materialized file reference.
+    """
     if isinstance(value, str | Path):
         return Path(value)
     path = value.get("path") if isinstance(value, dict) else getattr(value, "path", None)
-    if path:
-        return Path(path)
     payload = value.get("bytes") if isinstance(value, dict) else None
     if payload is None and isinstance(value, bytes | bytearray):
         payload = value
-    if payload is None:
-        raise ValueError(f"cannot materialize media value for {stem!r}")
-    destination = Path(output_dir) / f"{stem}{suffix}"
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    destination.write_bytes(bytes(payload))
+    if payload is not None:
+        return _write_media_bytes(payload, output_dir, stem, _media_extension(path, suffix))
+    if path:
+        return Path(path)
+    raise ValueError(f"cannot materialize media value for {stem!r}")
+
+
+def _media_extension(path: str | Path | None, fallback: str) -> str:
+    """Pick a safe lower-case file extension from ``path`` when available."""
+    extension = Path(str(path)).suffix.lower() if path else ""
+    if extension.startswith(".") and len(extension) <= 8 and extension[1:].isalnum():
+        return extension
+    return fallback
+
+
+def _write_media_bytes(payload: bytes | bytearray, output_dir: str | Path, stem: str, extension: str) -> Path:
+    data = bytes(payload)
+    root = Path(output_dir)
+    root.mkdir(parents=True, exist_ok=True)
+    destination = root / f"{stem}{extension}"
+    if destination.exists() and destination.read_bytes() == data:
+        return destination
+    fd, temporary = tempfile.mkstemp(dir=root, prefix=f".{destination.name}.", suffix=".part")
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+        os.replace(temporary, destination)
+    except OSError:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
     return destination
 
 

--- a/vllm_omni/benchmarks/duplex_eval.py
+++ b/vllm_omni/benchmarks/duplex_eval.py
@@ -1,0 +1,476 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""Omni-DuplexEval generation and artifacts for serving benchmarks.
+
+The serving backend only *generates* samples inside the timed benchmark window.
+Judging is deliberately absent from this module (v2 design §5.2): the DFX runner
+performs Phase 2 (evaluate) and Phase 3 (summarize + merge) in separate
+sub-processes after the omni server has exited, then merges the score summary
+back into the perf result through
+:func:`merge_duplex_eval_into_result` (the only writer, guarded by the
+``phase == "generate"`` assertion).
+
+Generation reuses
+:func:`vllm_omni.benchmarks.duplex.omni_duplex_eval_runner.generate_sample`;
+no per-sample inline judging ever happens inside the timed window.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import copy
+import fcntl
+import hashlib
+import json
+import logging
+import os
+import time
+from collections import Counter
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from vllm_omni.benchmarks.data_modules.duplex_eval_dataset import (
+    DuplexEvalSampleRequest,
+    DuplexEvalSessionOptions,
+    normalize_exclude_ids,
+)
+from vllm_omni.benchmarks.duplex.omni_duplex_eval_dataset import DuplexSample
+from vllm_omni.benchmarks.duplex.omni_duplex_eval_runner import generate_sample
+
+BATCH_ARTIFACTS = ("batch_summary.json", "eval_manifest.jsonl")
+ARTIFACT_LOCK_FILE = ".duplex_eval.lock"
+_MERGE_PROVENANCE_SOURCE = "tests/dfx/perf/scripts/run_benchmark.py"
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Config / result
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DuplexEvalRequestConfig:
+    """Thin per-request wrapper; generation layout lives in ``options``."""
+
+    model: str
+    url: str
+    options: DuplexEvalSessionOptions
+
+
+@dataclass
+class DuplexEvalCaseResult:
+    """Lifecycle signals of one generated sample (no judge fields in v2)."""
+
+    id: str
+    split: str
+    family: str
+    task_type: str | None = None
+    response_path: str = ""
+    success: bool = False
+    error: str = ""
+    latency_s: float = 0.0
+    response_done: bool | None = None
+    drain_timeout: str | None = None
+    close_timeout: str | None = None
+    clock: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return copy.deepcopy(vars(self))
+
+
+# ---------------------------------------------------------------------------
+# Generation
+# ---------------------------------------------------------------------------
+
+
+async def run_duplex_eval_case(
+    sample: DuplexSample,
+    config: DuplexEvalRequestConfig,
+) -> DuplexEvalCaseResult:
+    """Generate one sample and report its lifecycle signals.
+
+    Generation only; judging is deferred to the DFX runner so the timed
+    benchmark window never includes judge calls (v2 design §5.2).
+    """
+    options = config.options
+    if not options.ref_audio:
+        raise ValueError("ref_audio is required for MiniCPM-o native-duplex audio output")
+    if not config.url:
+        raise ValueError("a Realtime WebSocket url is required for Omni-DuplexEval generation")
+    result = DuplexEvalCaseResult(id=sample.id, split=sample.split, family=sample.family, task_type=sample.task_type)
+    started_at = time.monotonic()
+    try:
+        output = await generate_sample(
+            sample,
+            url=config.url,
+            model=config.model,
+            ref_audio=options.ref_audio,
+            output_root=options.response_root,
+            fps=options.fps,
+            mix=options.mix,
+            pace=options.pace,
+            clock=options.clock,
+            overwrite=options.overwrite,
+            unit_ms=options.unit_ms,
+        )
+        result.response_path = str(output)
+        meta = _read_meta(output)
+        result.response_done = bool(meta.get("response_done"))
+        result.drain_timeout = meta.get("drain_timeout")
+        result.close_timeout = meta.get("close_timeout")
+        result.clock = str(meta.get("clock", ""))
+        result.success = result.response_done and result.drain_timeout is None and result.close_timeout is None
+        if not result.success:
+            result.error = _lifecycle_error(result)
+    except Exception as exc:  # noqa: BLE001 - a failed sample must not abort the batch
+        result.success = False
+        result.error = str(exc)
+    result.latency_s = max(0.0, time.monotonic() - started_at)
+    return result
+
+
+def _read_meta(output: Path) -> dict[str, Any]:
+    meta_path = output.with_name(output.stem + ".meta.json")
+    if not meta_path.exists():
+        return {}
+    try:
+        payload = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _lifecycle_error(result: DuplexEvalCaseResult) -> str:
+    if not result.response_done:
+        return f"response.done was not observed (drain_timeout={result.drain_timeout!r})"
+    if result.drain_timeout is not None:
+        return f"drain timed out: {result.drain_timeout}"
+    if result.close_timeout is not None:
+        return f"close timed out: {result.close_timeout}"
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Generation ledger
+# ---------------------------------------------------------------------------
+
+
+def generation_summary(results: list[DuplexEvalCaseResult]) -> dict[str, Any]:
+    """Compact generation counts (v2: no ``scored`` / ``score_summary``)."""
+    total = len(results)
+    generated = sum(result.success for result in results)
+    return {
+        "total": total,
+        "generated": generated,
+        "generation_failed": total - generated,
+        "failure_ids": [f"{result.split}/{result.id}" for result in results if not result.success],
+    }
+
+
+def _options_from_requests(
+    input_requests: list[Any],
+) -> DuplexEvalSessionOptions | None:
+    for request in input_requests:
+        if isinstance(request, DuplexEvalSampleRequest) and request.duplex_eval_options is not None:
+            return request.duplex_eval_options
+    return None
+
+
+def _clock_summary(
+    results: list[DuplexEvalCaseResult],
+) -> tuple[str, list[str]]:
+    observed: Counter[str] = Counter()
+    for result in results:
+        if result.clock:
+            observed[result.clock] += 1
+    clock = observed.most_common(1)[0][0] if observed else ""
+    mismatch_ids = [f"{result.split}/{result.id}" for result in results if result.clock and result.clock != "media"]
+    return clock, mismatch_ids
+
+
+def _ref_audio_sha256(path: str) -> str | None:
+    try:
+        return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Batch artifacts
+# ---------------------------------------------------------------------------
+
+
+def _manifest_row(sample: DuplexSample, result: DuplexEvalCaseResult) -> dict[str, Any]:
+    return {
+        "id": sample.id,
+        "split": sample.split,
+        "family": sample.family,
+        "task_type": sample.task_type,
+        "response": result.response_path,
+        "generated": result.success,
+        "response_done": result.response_done,
+        "drain_timeout": result.drain_timeout,
+        "close_timeout": result.close_timeout,
+        "clock": result.clock,
+        "error": result.error,
+    }
+
+
+def _atomic_write_text(path: Path, value: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(value, encoding="utf-8")
+    temporary.replace(path)
+
+
+def _atomic_write_json(path: Path, value: object) -> None:
+    _atomic_write_text(path, json.dumps(value, ensure_ascii=False, indent=2) + "\n")
+
+
+def write_batch_artifacts(
+    score_dir: str | Path,
+    samples: list[DuplexSample],
+    results: list[DuplexEvalCaseResult],
+    summary: dict[str, Any],
+) -> None:
+    manifest = [_manifest_row(sample, result) for sample, result in zip(samples, results, strict=True)]
+    _atomic_write_json(Path(score_dir) / "batch_summary.json", summary)
+    _atomic_write_text(
+        Path(score_dir) / "eval_manifest.jsonl",
+        "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in manifest),
+    )
+
+
+def clear_batch_artifacts(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    for name in BATCH_ARTIFACTS:
+        (root / name).unlink(missing_ok=True)
+
+
+@contextlib.contextmanager
+def duplex_eval_output_lock(root: Path) -> Iterator[None]:
+    """Serialize runs that share one batch-artifact root."""
+    root.mkdir(parents=True, exist_ok=True)
+    with (root / ARTIFACT_LOCK_FILE).open("a+b") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def rows_from_outputs(
+    input_requests: list[Any],
+    outputs: list[Any],
+) -> tuple[list[DuplexSample], list[DuplexEvalCaseResult], list[Any]]:
+    """Pair dataset samples with their executed outputs, preserving order."""
+    samples: list[DuplexSample] = []
+    results: list[DuplexEvalCaseResult] = []
+    paired_outputs: list[Any] = []
+    for sample, output in zip(input_requests, outputs, strict=True):
+        if not isinstance(sample, DuplexEvalSampleRequest) or sample.duplex_eval_sample is None:
+            continue
+        result = getattr(output, "duplex_eval_case_result", None)
+        if not isinstance(result, DuplexEvalCaseResult):
+            continue
+        samples.append(sample.duplex_eval_sample)
+        results.append(result)
+        paired_outputs.append(output)
+    return samples, results, paired_outputs
+
+
+def finalize_duplex_eval_batch(
+    input_requests: list[Any],
+    outputs: list[Any],
+) -> dict[str, Any] | None:
+    """Window-external wrap-up (v2: generation-ledger only, never calls a judge).
+
+    1) collect ``duplex_eval_case_result`` from the executed outputs;
+    2) compute ``total`` / ``generated`` / ``generation_failed`` / ``failure_ids``;
+    3) aggregate ``clock`` and list ``clock_mismatch_ids``;
+    4) echo the effective ``exclude_ids`` and ``selected_ids``;
+    5) write ``<score_dir>/batch_summary.json`` + ``eval_manifest.jsonl``.
+
+    Returns a compact summary (without ``results[]``) for
+    ``result["duplex_eval"]``; ``None`` when no duplex-eval sample ran.
+    """
+    samples, results, _ = rows_from_outputs(input_requests, outputs)
+    if not results:
+        return None
+    options = _options_from_requests(input_requests)
+    if options is None:
+        raise ValueError("duplex_eval results present but session options are missing")
+
+    summary = generation_summary(results)
+    clock, clock_mismatch_ids = _clock_summary(results)
+    summary.update(
+        {
+            "phase": "generate",
+            "clock": clock,
+            "clock_mismatch_ids": clock_mismatch_ids,
+            "pace": options.pace,
+            "fps": options.fps,
+            "mix": options.mix,
+            "unit_ms": options.unit_ms,
+            "overwrite": options.overwrite,
+            "response_root": str(options.response_root),
+            "score_dir": str(options.score_dir),
+            "exclude_ids": sorted(normalize_exclude_ids(options.exclude_ids)),
+            "selected_ids": [f"{sample.split}/{sample.id}" for sample in samples],
+            "judge_enabled": False,
+            "scored": 0,
+            "score_failed": 0,
+            "ref_audio_sha256": _ref_audio_sha256(options.ref_audio),
+        }
+    )
+    if options.write_artifacts:
+        try:
+            write_batch_artifacts(options.score_dir, samples, results, summary)
+        except OSError as exc:  # noqa: BLE001 - preserve benchmark metrics
+            summary["artifacts_complete"] = False
+            summary["artifact_errors"] = [str(exc)]
+            logger.exception("Omni-DuplexEval batch artifact publication failed: %s", exc)
+        else:
+            summary["artifacts_complete"] = True
+    else:
+        summary["artifacts_complete"] = False
+        summary["artifact_errors"] = ["batch artifacts disabled by --duplex-eval-no-artifacts"]
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# CLI translation
+# ---------------------------------------------------------------------------
+
+
+def options_from_args(args: Any) -> DuplexEvalSessionOptions:
+    """Translate parsed CLI arguments into the shared session options (v2)."""
+    return DuplexEvalSessionOptions(
+        response_root=Path(getattr(args, "duplex_eval_output_dir", "duplex-eval-responses")),
+        score_dir=Path(getattr(args, "duplex_eval_score_dir", "duplex-eval-scores")),
+        ref_audio=str(getattr(args, "duplex_eval_ref_audio", "") or ""),
+        fps=float(getattr(args, "duplex_eval_fps", 1.0)),
+        mix=str(getattr(args, "duplex_eval_mix", "question")),
+        pace=str(getattr(args, "duplex_eval_pace", "realtime")),
+        clock=str(getattr(args, "duplex_eval_clock", "media")),
+        unit_ms=int(getattr(args, "duplex_eval_unit_ms", 1000)),
+        overwrite=bool(getattr(args, "duplex_eval_overwrite", False)),
+        exclude_ids=tuple(getattr(args, "duplex_eval_exclude_ids", None) or ()),
+        write_artifacts=not bool(getattr(args, "duplex_eval_no_artifacts", False)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Result-file location and Phase-3 merge (used by the DFX runner)
+# ---------------------------------------------------------------------------
+
+
+def _locate_result_file(
+    *,
+    bench_dir: str | Path,
+    test_name: str,
+    dataset_name: str,
+    flow: str | int,
+    num_prompt: int,
+    since: float,
+) -> Path:
+    """Locate this run's perf result by filename prefix + mtime uniqueness.
+
+    The file name embeds a ``%Y%m%d-%H%M%S`` timestamp (conftest), so it
+    cannot be reconstructed by path joining; use prefix glob +
+    ``mtime >= since`` and demand exactly one hit.
+    """
+    pattern = f"result_{test_name}_*{dataset_name}_{flow}_{num_prompt}_in*_out*.json"
+    hits = [p for p in Path(bench_dir).glob(pattern) if p.stat().st_mtime >= since - 1.0]
+    if len(hits) != 1:
+        raise AssertionError(
+            f"expected exactly one perf result for {test_name}/{flow}/"
+            f"{num_prompt}, got {[str(p) for p in hits]} under {bench_dir}"
+        )
+    return hits[0]
+
+
+def _pending_ids_from_manifest(score_dir: str | Path) -> list[str]:
+    """Generated-but-not-scored ``split/id`` keys (troubleshooting)."""
+    manifest = Path(score_dir) / "eval_manifest.jsonl"
+    if not manifest.exists():
+        return []
+    pending: list[str] = []
+    for line in manifest.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not row.get("generated"):
+            continue
+        split, sample_id = row.get("split"), row.get("id")
+        if split and sample_id:
+            score_path = Path(score_dir) / str(split) / f"{sample_id}.json"
+            if not score_path.exists():
+                pending.append(f"{split}/{sample_id}")
+    return pending
+
+
+def merge_duplex_eval_into_result(
+    result_path: Path,
+    *,
+    score_summary: dict[str, Any],
+    judge_meta: dict[str, Any],
+    phases: list[str],
+) -> dict[str, Any]:
+    """Merge the Phase-3 score summary into the perf result (unique writer).
+
+    - asserts ``duplex_eval.phase == "generate"`` (W2) so a second merge is
+      refused instead of silently drifting;
+    - only adds/overwrites the ``duplex_eval`` subtree, leaving ``completed`` /
+      ``e2el`` / ``Hardware`` / ``baseline`` untouched;
+    - replaces the file atomically via ``tmp`` + :func:`os.replace` (W3).
+    """
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    duplex = payload.get("duplex_eval")
+    if not isinstance(duplex, dict):
+        raise AssertionError(f"duplex_eval side-channel missing in {result_path}")
+    if duplex.get("phase") != "generate":
+        raise AssertionError(f"refusing to merge: duplex_eval.phase={duplex.get('phase')!r}")
+
+    duplex["phase"] = "generate+evaluate+summarize"
+    duplex["phases"] = phases
+    duplex["judge"] = judge_meta
+    duplex["judge_enabled"] = True
+    duplex["score_summary"] = score_summary
+    duplex["scored"] = int(score_summary.get("samples", 0) or 0)
+    duplex["score_failed"] = max(0, int(duplex.get("generated", 0) or 0) - duplex["scored"])
+    duplex["pending_ids"] = _pending_ids_from_manifest(str(duplex.get("score_dir", "duplex-eval-scores")))
+    duplex["merge_provenance"] = {
+        "merged_by": _MERGE_PROVENANCE_SOURCE,
+        "merged_at_unix": time.time(),
+        "score_root": str(duplex.get("score_dir", "")),
+        "summary_source": "score_summary.json",
+    }
+
+    tmp = result_path.with_suffix(result_path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    os.replace(tmp, result_path)
+    return payload
+
+
+__all__ = [
+    "BATCH_ARTIFACTS",
+    "ARTIFACT_LOCK_FILE",
+    "DuplexEvalCaseResult",
+    "DuplexEvalRequestConfig",
+    "clear_batch_artifacts",
+    "duplex_eval_output_lock",
+    "finalize_duplex_eval_batch",
+    "generation_summary",
+    "merge_duplex_eval_into_result",
+    "options_from_args",
+    "rows_from_outputs",
+    "run_duplex_eval_case",
+    "write_batch_artifacts",
+]

--- a/vllm_omni/benchmarks/patch/patch.py
+++ b/vllm_omni/benchmarks/patch/patch.py
@@ -50,6 +50,11 @@ from vllm_omni.benchmarks.data_modules.daily_omni_dataset import (
     daily_omni_local_videos_dir,
     resolve_daily_omni_local_root,
 )
+from vllm_omni.benchmarks.data_modules.duplex_eval_dataset import (
+    DuplexEvalDataset,
+    DuplexEvalSampleRequest,
+    DuplexEvalSessionOptions,
+)
 from vllm_omni.benchmarks.data_modules.omniinteract_dataset import (
     DEFAULT_OMNIINTERACT_REPO,
     OmniInteractDataset,
@@ -67,6 +72,14 @@ from vllm_omni.benchmarks.data_modules.seed_tts_dataset import (
 )
 from vllm_omni.benchmarks.data_modules.sound_effect_dataset import SoundEffectDataset
 from vllm_omni.benchmarks.data_modules.ttsd_dataset import TTSDDataset
+from vllm_omni.benchmarks.duplex.omni_duplex_eval_dataset import DEFAULT_DATASET as DEFAULT_DUPLEX_EVAL_DATASET
+from vllm_omni.benchmarks.duplex_eval import (
+    DuplexEvalCaseResult,
+    DuplexEvalRequestConfig,
+    finalize_duplex_eval_batch,
+    options_from_args,
+    run_duplex_eval_case,
+)
 from vllm_omni.benchmarks.omniinteract import (
     VIDEO_FPS,
     OmniInteractBenchmarkConfig,
@@ -334,6 +347,13 @@ def _attach_omniinteract_to_request_func_input(sample: SampleRequest, rfi: Reque
     setattr(rfi, "omniinteract_prepared_input", sample.omniinteract_prepared_input)
 
 
+def _attach_duplex_eval_to_request_func_input(sample: SampleRequest, rfi: RequestFuncInput) -> None:
+    if not isinstance(sample, DuplexEvalSampleRequest):
+        return
+    setattr(rfi, "duplex_eval_sample", sample.duplex_eval_sample)
+    setattr(rfi, "duplex_eval_options", sample.duplex_eval_options)
+
+
 def _append_error(existing: str, message: str) -> str:
     return f"{existing}\n{message}" if existing else message
 
@@ -441,6 +461,7 @@ def get_samples(args, tokenizer):
         "sound-effect",
     )
     is_omniinteract = args.dataset_name == "omniinteract"
+    is_duplex_eval = args.dataset_name == "omni-duplex-eval"
 
     # Check if we need to handle omni-related backends/datasets
     is_omni_backend = args.backend in [
@@ -449,7 +470,9 @@ def get_samples(args, tokenizer):
         "openai-realtime-duplex",
         "daily-omni",
     ]
-    is_omni_dataset = is_daily_omni or is_seed_tts or is_omniinteract or args.dataset_name == "random-mm"
+    is_omni_dataset = (
+        is_daily_omni or is_seed_tts or is_omniinteract or is_duplex_eval or args.dataset_name == "random-mm"
+    )
 
     if not is_omni_backend and not is_omni_dataset:
         # Not an omni-related request, delegate to original implementation
@@ -510,6 +533,33 @@ def get_samples(args, tokenizer):
                 ref_audio_data_url=encoded_ref_audio,
             )
         # Replace OmniInteract's ``0`` (all) with the measured request count.
+        args.num_prompts = len(requests)
+        return requests
+
+    if is_duplex_eval:
+        dataset_path = getattr(args, "dataset_path", None)
+        dataset = str(dataset_path) if dataset_path else DEFAULT_DUPLEX_EVAL_DATASET
+        options = options_from_args(args)
+        duplex_dataset = DuplexEvalDataset(
+            dataset=dataset,
+            split=str(getattr(args, "duplex_eval_split", "all")),
+            family=str(getattr(args, "duplex_eval_family", "all")),
+            media_root=getattr(args, "duplex_eval_media_root", None),
+            limit=getattr(args, "duplex_eval_limit", None),
+            ids=getattr(args, "duplex_eval_ids", None),
+            exclude_ids=getattr(args, "duplex_eval_exclude_ids", None),
+            random_seed=args.seed,
+            disable_shuffle=getattr(args, "disable_shuffle", False),
+        )
+        requests = duplex_dataset.sample(
+            tokenizer,
+            args.num_prompts,
+            request_id_prefix=args.request_id_prefix,
+            options=options,
+        )
+        if not requests:
+            raise ValueError("No Omni-DuplexEval samples were selected")
+        # Replace Omni-DuplexEval's ``0`` (all) with the measured request count.
         args.num_prompts = len(requests)
         return requests
 
@@ -2310,6 +2360,64 @@ async def _async_request_omniinteract(
     return output
 
 
+async def _async_request_duplex_eval(
+    request_func_input: RequestFuncInput,
+    *,
+    pbar: tqdm | None = None,
+) -> MixRequestFuncOutput:
+    """Drive one Omni-DuplexEval sample through the timed generation window.
+
+    Generation only: the lifecycle signals returned by
+    :func:`run_duplex_eval_case` (``response_done`` / ``drain_timeout`` /
+    ``close_timeout``) let the batch finaliser flag hung samples. Judging is
+    intentionally absent (v2 design §5.2).
+    """
+    sample = getattr(request_func_input, "duplex_eval_sample", None)
+    options = getattr(request_func_input, "duplex_eval_options", None)
+    output = MixRequestFuncOutput()
+    output.prompt_len = request_func_input.prompt_len
+    output.start_time = time.perf_counter()
+    try:
+        if sample is None or not isinstance(options, DuplexEvalSessionOptions):
+            raise ValueError("DuplexEval RequestFuncInput is missing its dataset session layout")
+        config = DuplexEvalRequestConfig(
+            model=request_func_input.model_name or request_func_input.model,
+            url=_realtime_websocket_url(request_func_input.api_url),
+            options=options,
+        )
+        case_result = await run_duplex_eval_case(sample, config)
+        output.latency = case_result.latency_s
+        output.success = case_result.success
+        output.error = case_result.error
+        # Explicit ``None`` placeholder: without it metrics.py would treat the
+        # default ``output.ttft == 0.0`` as a real sample and report pseudo-zero
+        # TTFT / audio TTFP / RTF (v2 design §4.4).
+        output.duplex_session_metrics = {
+            "mean_ttft_ms": None,
+            "mean_ttfp_ms": None,
+            "mean_rtf": None,
+            "source": "omni-duplex-eval",
+        }
+        setattr(output, "duplex_eval_case_result", case_result)
+    except Exception:
+        output.success = False
+        output.error = traceback.format_exc()
+        logger.error("Omni-DuplexEval Realtime request failed: %s", output.error)
+        setattr(
+            output,
+            "duplex_eval_case_result",
+            DuplexEvalCaseResult(
+                id=getattr(sample, "id", ""),
+                split=getattr(sample, "split", ""),
+                family=getattr(sample, "family", ""),
+                error=output.error,
+            ),
+        )
+    if pbar:
+        pbar.update(1)
+    return output
+
+
 class _RealtimeTTSProbe:
     """Explicit-session Realtime TTS driver over the public duplex client.
 
@@ -2400,6 +2508,8 @@ async def async_request_openai_realtime_duplex(
     del session
     if getattr(request_func_input, "omniinteract_case", None) is not None:
         return await _async_request_omniinteract(request_func_input, pbar=pbar)
+    if getattr(request_func_input, "duplex_eval_sample", None) is not None:
+        return await _async_request_duplex_eval(request_func_input, pbar=pbar)
     output = MixRequestFuncOutput()
     output.prompt_len = request_func_input.prompt_len
     output.start_time = time.perf_counter()
@@ -2883,6 +2993,7 @@ async def benchmark(
         _attach_daily_omni_to_request_func_input(request, request_func_input)
         _attach_seed_tts_to_request_func_input(request, request_func_input)
         _attach_omniinteract_to_request_func_input(request, request_func_input)
+        _attach_duplex_eval_to_request_func_input(request, request_func_input)
         tasks.append(
             asyncio.create_task(limited_request_func(request_func_input=request_func_input, session=session, pbar=pbar))
         )
@@ -2898,6 +3009,8 @@ async def benchmark(
     benchmark_duration = time.perf_counter() - benchmark_start_time
 
     omniinteract_summary = _finalize_omniinteract_batch(input_requests, outputs)
+    # Generation-time ledger only: no judge, no network, outside the timed window.
+    duplex_eval_summary = finalize_duplex_eval_batch(input_requests, outputs)
 
     if task_type == TaskType.GENERATION:
         metrics, actual_output_lens = calculate_metrics(
@@ -3000,6 +3113,8 @@ async def benchmark(
         result["duplex_session_metrics"] = duplex_session_metrics
     if omniinteract_summary is not None:
         result["omniinteract"] = omniinteract_summary
+    if duplex_eval_summary is not None:
+        result["duplex_eval"] = duplex_eval_summary
 
     from vllm_omni.benchmarks.data_modules.daily_omni_eval import (
         compute_daily_omni_accuracy_metrics,

--- a/vllm_omni/entrypoints/cli/benchmark/cli_args.py
+++ b/vllm_omni/entrypoints/cli/benchmark/cli_args.py
@@ -23,12 +23,20 @@ import math
 from pathlib import Path
 
 _DEFAULT_OMNIINTERACT_NUM_PROMPTS = 3
+_DEFAULT_DUPLEX_EVAL_NUM_PROMPTS = 3
 
 
 def _positive_finite_float(value: str) -> float:
     parsed = float(value)
     if not math.isfinite(parsed) or parsed <= 0:
         raise argparse.ArgumentTypeError(f"must be a finite positive number, got {value!r}")
+    return parsed
+
+
+def _non_negative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError(f"must be non-negative, got {value!r}")
     return parsed
 
 
@@ -75,6 +83,110 @@ def add_omniinteract_cli_args(parser: argparse.ArgumentParser) -> None:
         type=Path,
         default=Path("omniinteract-output"),
         help="Directory for case and evaluator artifacts.",
+    )
+
+
+def add_duplex_eval_cli_args(parser: argparse.ArgumentParser) -> None:
+    """Add the Omni-DuplexEval generation arguments for ``vllm bench serve``.
+
+    Judge arguments intentionally do not exist here: scoring runs in a separate
+    process (Phase 2/3 of the DFX runner) after the timed benchmark window, so
+    ``vllm bench serve`` never contains a judge code path (design §3.6 / §5.4).
+    """
+    from vllm_omni.benchmarks.data_modules.duplex_eval_dataset import (
+        DUPLEX_EVAL_FAMILIES,
+    )
+
+    group = parser.add_argument_group("Omni-DuplexEval Benchmark Options")
+    group.add_argument(
+        "--duplex-eval-split",
+        type=str,
+        default="all",
+        help="Single split (e.g. RTD_OCR) or 'all' for every known RTD/PR split.",
+    )
+    group.add_argument(
+        "--duplex-eval-family",
+        choices=list(DUPLEX_EVAL_FAMILIES),
+        default="all",
+        help="Family filter: 'all', 'rtd' (realtime-description) or 'pr' (proactive-reminder).",
+    )
+    group.add_argument(
+        "--duplex-eval-media-root",
+        type=str,
+        default=None,
+        help="Base directory used to resolve relative media paths; loader errors on a missing root.",
+    )
+    group.add_argument(
+        "--duplex-eval-limit",
+        type=_non_negative_int,
+        default=None,
+        help="Maximum number of samples per split (applied after exclusion).",
+    )
+    group.add_argument(
+        "--duplex-eval-ids",
+        nargs="+",
+        default=None,
+        help="Explicit sample-id allow-list; mutually exclusive with --duplex-eval-exclude-ids.",
+    )
+    group.add_argument(
+        "--duplex-eval-exclude-ids",
+        nargs="+",
+        default=None,
+        help="Exclusion list ('<id>' or '<split>/<id>'); applied before --duplex-eval-limit.",
+    )
+    group.add_argument(
+        "--duplex-eval-output-dir",
+        type=Path,
+        default=Path("duplex-eval-responses"),
+        help="Root directory for generated sample artifacts.",
+    )
+    group.add_argument(
+        "--duplex-eval-score-dir",
+        type=Path,
+        default=Path("duplex-eval-scores"),
+        help="Root directory for the generation ledger and Phase-2 score artifacts.",
+    )
+    group.add_argument(
+        "--duplex-eval-ref-audio",
+        type=_existing_file,
+        default=None,
+        help="Reference WAV required by MiniCPM-o native-duplex audio output.",
+    )
+    group.add_argument(
+        "--duplex-eval-fps",
+        type=_positive_finite_float,
+        default=1.0,
+        help="Frame-sampling rate used while generating the duplex response.",
+    )
+    group.add_argument(
+        "--duplex-eval-pace",
+        choices=["realtime", "as-fast-as-possible"],
+        default="realtime",
+        help="Generation pace; non-realtime records clock=invalid and needs --duplex-eval-allow-invalid-clock.",
+    )
+    group.add_argument(
+        "--duplex-eval-clock",
+        choices=["media"],
+        default="media",
+        help="Timeline used for generated artifacts.",
+    )
+    group.add_argument(
+        "--duplex-eval-overwrite",
+        action="store_true",
+        default=False,
+        help="Regenerate samples even when their artifacts already exist.",
+    )
+    group.add_argument(
+        "--duplex-eval-allow-invalid-clock",
+        action="store_true",
+        default=False,
+        help="Permit clock=invalid artifacts (troubleshooting only).",
+    )
+    group.add_argument(
+        "--duplex-eval-no-artifacts",
+        action="store_true",
+        default=False,
+        help="Skip publishing the batch_summary.json / eval_manifest.jsonl generation ledger.",
     )
 
 
@@ -259,6 +371,7 @@ def add_seed_tts_cli_args(parser: argparse.ArgumentParser) -> None:
 _OMNI_BENCH_DATASET_CHOICES = (
     "daily-omni",
     "omniinteract",
+    "omni-duplex-eval",
     "seed-tts",
     "seed-tts-text",
     "seed-tts-design",
@@ -331,6 +444,7 @@ def add_omni_args(parser: argparse.ArgumentParser) -> None:
     """Register all vLLM-Omni serving benchmark arguments."""
     add_daily_omni_cli_args(parser)
     add_omniinteract_cli_args(parser)
+    add_duplex_eval_cli_args(parser)
     add_seed_tts_cli_args(parser)
     add_multi_stage_cli_args(parser)
     add_diffusion_cli_args(parser)
@@ -360,6 +474,38 @@ def preprocess_serve_args(args: argparse.Namespace) -> None:
             args.max_concurrency = 1
         elif max_concurrency <= 0:
             raise ValueError("OmniInteract requires --max-concurrency to be positive")
+    if getattr(args, "dataset_name", None) == "omni-duplex-eval":
+        if getattr(args, "backend", None) != "openai-realtime-duplex":
+            raise ValueError("Omni-DuplexEval requires --backend openai-realtime-duplex")
+        if getattr(args, "endpoint", None) != "/v1/realtime":
+            raise ValueError("Omni-DuplexEval requires --endpoint /v1/realtime")
+        if not getattr(args, "duplex_eval_ref_audio", None):
+            raise ValueError("Omni-DuplexEval requires --duplex-eval-ref-audio")
+        for banned, flag in (
+            ("ignore_eos", "--ignore-eos"),
+            ("profile", "--profile"),
+            ("skip_tokenizer_init", "--skip-tokenizer-init"),
+        ):
+            if getattr(args, banned, False):
+                raise ValueError(f"Omni-DuplexEval does not support {flag}")
+        if float(getattr(args, "probe_request_rate", 0.0) or 0.0) > 0:
+            raise ValueError("Omni-DuplexEval does not support --probe-request-rate")
+        if str(getattr(args, "duplex_eval_pace", "realtime")) != "realtime" and not getattr(
+            args, "duplex_eval_allow_invalid_clock", False
+        ):
+            raise ValueError(
+                "--duplex-eval-pace as-fast-as-possible records clock=invalid; pass "
+                "--duplex-eval-allow-invalid-clock to score it"
+            )
+        if getattr(args, "duplex_eval_ids", None) and getattr(args, "duplex_eval_exclude_ids", None):
+            raise ValueError("--duplex-eval-ids and --duplex-eval-exclude-ids are mutually exclusive")
+        if "num_prompts" not in getattr(args, "explicit_keys", ()):
+            args.num_prompts = _DEFAULT_DUPLEX_EVAL_NUM_PROMPTS
+        max_concurrency = getattr(args, "max_concurrency", None)
+        if max_concurrency is None:
+            args.max_concurrency = 1
+        elif max_concurrency <= 0:
+            raise ValueError("Omni-DuplexEval requires --max-concurrency to be positive")
     extra_body = dict(getattr(args, "extra_body", None) or {})
     bot_task = getattr(args, "bot_task", None)
     backend = getattr(args, "backend", None)

--- a/vllm_omni/entrypoints/cli/benchmark/omni_duplex_eval.py
+++ b/vllm_omni/entrypoints/cli/benchmark/omni_duplex_eval.py
@@ -15,8 +15,18 @@ from vllm_omni.entrypoints.cli.benchmark.base import OmniBenchmarkSubcommandBase
 
 
 def _common(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--dataset", default=DEFAULT_DATASET)
-    parser.add_argument("--split", default="all")
+    parser.add_argument(
+        "--dataset",
+        default=DEFAULT_DATASET,
+        help=(
+            "Hugging Face dataset id, a JSON/JSONL manifest, or a local Hugging Face "
+            "dataset directory. A local directory must be a dataset layout (one "
+            "data/<config> subfolder per RTD_*/PR_* split) or a single .parquet file; "
+            "a bare data/ directory collapses to a single 'train' split and only works "
+            "if every row already carries split/family/task_type identity."
+        ),
+    )
+    parser.add_argument("--split", default="all", help="Restrict to one split (e.g. RTD_OCR) or 'all'.")
     parser.add_argument("--family", choices=("all", "rtd", "pr"), default="all")
     parser.add_argument("--media-root")
     parser.add_argument("--limit", type=int)

--- a/vllm_omni/entrypoints/cli/benchmark/omni_duplex_eval.py
+++ b/vllm_omni/entrypoints/cli/benchmark/omni_duplex_eval.py
@@ -7,8 +7,13 @@ import concurrent.futures
 import json
 from pathlib import Path
 
+from vllm_omni.benchmarks.data_modules.duplex_eval_dataset import normalize_exclude_ids
 from vllm_omni.benchmarks.duplex.omni_duplex_eval_dataset import DEFAULT_DATASET, load_samples
-from vllm_omni.benchmarks.duplex.omni_duplex_eval_eval import evaluate_sample, summarize_scores
+from vllm_omni.benchmarks.duplex.omni_duplex_eval_eval import (
+    CONTENT_FRAME_LIMIT,
+    evaluate_sample,
+    summarize_scores,
+)
 from vllm_omni.benchmarks.duplex.omni_duplex_eval_judge import DuplexJudge
 from vllm_omni.benchmarks.duplex.omni_duplex_eval_runner import generate_sample
 from vllm_omni.entrypoints.cli.benchmark.base import OmniBenchmarkSubcommandBase
@@ -31,6 +36,16 @@ def _common(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--media-root")
     parser.add_argument("--limit", type=int)
     parser.add_argument("--ids", nargs="*")
+    parser.add_argument(
+        "--exclude-ids",
+        nargs="*",
+        default=None,
+        help=(
+            "Exclusion list ('<id>' or '<split>/<id>'), applied before --limit. Same "
+            "semantics as `vllm bench serve --duplex-eval-exclude-ids`: bare ids are "
+            "universal excludes, `split/id` entries only match that split."
+        ),
+    )
 
 
 def add_cli_args(parser: argparse.ArgumentParser) -> None:
@@ -56,27 +71,82 @@ def add_cli_args(parser: argparse.ArgumentParser) -> None:
     evaluate.add_argument("--judge-api-key", default="EMPTY")
     evaluate.add_argument("--judge-video-mode", choices=("video_url", "frame-sample"), default="video_url")
     evaluate.add_argument("--judge-fps", type=int, default=2)
+    evaluate.add_argument(
+        "--judge-modalities",
+        nargs="+",
+        default=None,
+        help=(
+            "Request body `modalities` for the judge (e.g. `text`). Omitted by default so "
+            "the request body stays byte-identical to single-choice judges."
+        ),
+    )
+    evaluate.add_argument(
+        "--content-frame-limit",
+        type=int,
+        default=CONTENT_FRAME_LIMIT,
+        help=(
+            "Maximum number of sampled frames for the judge content pass. Defaults to "
+            "CONTENT_FRAME_LIMIT so the frame sequence is unchanged for legacy judges."
+        ),
+    )
     evaluate.add_argument("--window-size", type=float, default=10.0)
     evaluate.add_argument("--allow-invalid-clock", action="store_true")
     evaluate.add_argument("--eval-workers", type=int, default=1)
     evaluate.add_argument("--overwrite", action="store_true")
     summarize = actions.add_parser("summarize")
     summarize.add_argument("--score-root", required=True)
+    summarize.add_argument(
+        "--output-json",
+        type=Path,
+        default=None,
+        help="Also write the summary to this path (used by the DFX runner for a deterministic read).",
+    )
 
 
-def run(args: argparse.Namespace) -> int:
-    if args.action == "summarize":
-        print(json.dumps(summarize_scores(args.score_root), ensure_ascii=False, indent=2))
-        return 0
+def _apply_exclude_ids(samples, exclude_ids):
+    """Drop excluded samples, mirroring ``DuplexEvalDataset.sample`` semantics.
 
+    ``normalize_exclude_ids`` keeps bare ids and ``split/id`` tokens; a sample is
+    dropped when either its bare id or its ``split/id`` key is listed.
+    """
+    exclude = normalize_exclude_ids(exclude_ids or ())
+    if not exclude:
+        return list(samples)
+    return [sample for sample in samples if f"{sample.split}/{sample.id}" not in exclude and sample.id not in exclude]
+
+
+def _select_samples(args: argparse.Namespace):
+    """Load samples and apply the shared ``exclude -> limit`` ordering.
+
+    ``limit`` is applied *after* exclusion so the standalone CLI matches the
+    serving adapter's per-split ``exclude`` then ``limit`` semantics
+    (design §5.1 / §8.5 D-2).
+    """
     samples = load_samples(
         args.dataset,
         split=args.split,
         family=args.family,
         media_root=args.media_root,
-        limit=args.limit,
+        limit=None,
         ids=args.ids,
     )
+    samples = _apply_exclude_ids(samples, getattr(args, "exclude_ids", None))
+    if args.limit is not None:
+        samples = samples[: max(0, args.limit)]
+    return samples
+
+
+def run(args: argparse.Namespace) -> int:
+    if args.action == "summarize":
+        summary = summarize_scores(args.score_root)
+        if getattr(args, "output_json", None) is not None:
+            output = Path(args.output_json)
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+        print(json.dumps(summary, ensure_ascii=False, indent=2))
+        return 0
+
+    samples = _select_samples(args)
     if args.action == "generate":
         if args.concurrency < 1:
             raise ValueError("--concurrency must be at least 1")
@@ -106,7 +176,12 @@ def run(args: argparse.Namespace) -> int:
 
     if args.eval_workers < 1:
         raise ValueError("--eval-workers must be at least 1")
-    judge = DuplexJudge(args.judge_base_url, args.judge_model, api_key=args.judge_api_key)
+    judge = DuplexJudge(
+        args.judge_base_url,
+        args.judge_model,
+        api_key=args.judge_api_key,
+        modalities=getattr(args, "judge_modalities", None),
+    )
 
     def evaluate_one(sample) -> None:
         response_path = Path(args.response_root) / sample.split / f"{sample.id}.json"
@@ -122,6 +197,7 @@ def run(args: argparse.Namespace) -> int:
             judge_video_mode=args.judge_video_mode,
             window_size=args.window_size,
             allow_invalid_clock=args.allow_invalid_clock,
+            content_frame_limit=getattr(args, "content_frame_limit", CONTENT_FRAME_LIMIT),
         )
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=args.eval_workers) as executor:


### PR DESCRIPTION
## Purpose

Add Omni-DuplexEval as a benchmark dataset backend for `vllm bench serve` (Route B — backend-ization). This PR implements a 3-phase sequential orchestration for the DFX perf case MiniCPM-o 4.5:

- **Phase 1 (generate)**: duplex server (MiniCPM-o 4.5, 1 card) + serve → sample generation with timing
- **Phase 2 (judge)**: Qwen3-Omni thinker-only server (2 cards, tp=2) + evaluate → Qwen3-Omni judges quality
- **Phase 3 (summarize)**: merge results + write artifacts

This PR depends on #7331, which provides the local HF dataset loading capability (`_rows_from_hf()`).

## Test Plan

**Tests added:**
- 87 new offline tests across 3 test files:
  - `tests/benchmarks/duplex/test_duplex_eval_cli_args.py` (34 tests): CLI args registration + 9 preprocess validation rules
  - `tests/benchmarks/duplex/test_duplex_eval_patch.py` (19 tests): 5 patch wiring points in `patch.py`
  - `tests/benchmarks/duplex/test_duplex_eval_judge.py` (34 tests): `select_judge_text()` 3-level strategy, modalities, frame limits
- 14 new runner metadata tests (T22–T33) in `tests/dfx/perf/tests/test_runner_metadata.py`
- Fixed D1/D2 defects in existing `test_duplex_eval_backend.py` (monkeypatch target, exclude_ids param)
- Full regression: 392 passed / 0 failed / 0 skipped on vllm-omni:base-v029 image
- Pre-commit hooks passed (ruff, forbidden imports, etc.)

**Real-hardware test:**
- Run `bash tests/dfx/perf/scripts/run_benchmark.sh tests/dfx/perf/tests/test_minicpmo_4_5_omni_duplex_eval.json` with 2 NPU 910B2 cards (A3 server) on the `benchmark-Omni-DuplexEval` branch

**vLLM Version:** v0.29.0 (repo CI baseline, `docker/Dockerfile.ci:7`)

**vLLM-Omni Commit:** b0064a8f (branch `benchmark-Omni-DuplexEval`)

## Test Result

- **Baseline**: TBD (will be added after real-hardware run passes)
- **Pre-commit**: all tools/ hooks passed
- **Local unit test**: 392 passed / 0 failed / 0 skipped (vllm 0.29, arm64)
- **Skip list**:
  - `duplex_eval_exclude_ids` = [517, 565] (generation hang)
  - `duplex_eval_exclude_ids_pending` = [583, 584, 585, 590, 393] (judge failure, awaiting real-hardware investigation)


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
