### PR TITLE
[Model][PersonaPlex] Add paced multi-session validation

### DIFF
--- a/docs/design/fullduplex-personaplex.md
+++ b/docs/design/fullduplex-personaplex.md
@@ -271,3 +271,73 @@ The required evidence is:
 
 Audio that is empty, all zero, non-finite, or only a protocol `listen` event is
 not a successful end-to-end result.
+
+### Paced multi-session load driver
+
+The existing driver keeps its two-session admission and slot-reuse validation
+when `--sessions` is omitted. Passing `--sessions N` selects a separate,
+bounded load mode; it does not replace the lifecycle test or change server
+admission capacity. Start an existing PersonaPlex server configured to admit
+the requested number of sessions, then run from a source checkout with the
+vLLM-Omni client dependencies installed:
+
+```bash
+python -m tests.e2e.online_serving.personaplex_realtime_duplex \
+  --model nvidia/personaplex-7b-v1 \
+  --input-wav /path/to/input.wav \
+  --sessions 2 --load-frames 1000 --drain-s 2 \
+  --server-revision SERVER_COMMIT --server-hardware A100-80GB \
+  --output-dir /tmp/personaplex-load-n2
+```
+
+Use a new output directory for every run. The driver refuses to overwrite an
+existing `load-result.json`. The server labels are supplied by the operator,
+not detected or verified by the client. Record the server command, package
+versions, checkpoint revision and hardware alongside a published measurement.
+
+All attempted sessions finish admission before admitted sessions share a
+common input start. A rejected session remains a failed row in the report;
+it is not removed from the denominator. Each session receives at most
+`--load-frames` input frames, without looping the WAV, and uses 80 ms pacing.
+A stalled send cannot cause a catch-up burst. The timeline records send
+schedule lateness so an overloaded client is visible rather than mistaken
+for a faster server. This mode measures steady concurrency, not join/leave
+interference; the original lifecycle mode still checks slot reuse.
+
+The fixed drain window is part of the measurement configuration. Audio
+arriving during cleanup is excluded, so closing cannot rescue a session that
+missed its observation deadline. Cleanup is attempted for admitted sessions
+even when audio validation fails. Protocol errors, missing/invalid audio,
+shared response IDs and cleanup failures make the report fail and the CLI
+exit nonzero. Cancellation closes transports and propagates to the caller.
+
+`load-result.json` retains per-session send and audio-packet timelines using
+the client's monotonic clock. It does not export handshake credentials or
+raw audio payloads. Metric definitions are explicit:
+
+| Field | Meaning |
+| --- | --- |
+| `client_audio_packet_interval_ms` | Consecutive nonempty packet arrivals: median, linear p99, max, and zero-based index of the first maximal interval. Interval index 0 ends at packet 1. One packet can contain multiple codec frames; this is not server tick latency. |
+| `client_first_audio_after_stream_start_ms` | First audio receipt minus first input send start; admission is excluded. |
+| `client_stream_rtf` | First input send start to last audio receipt, divided by received audio duration. This includes real-time input pacing and is not an inference-only RTF. |
+| `client_send_lateness_ms` | Send start minus its original shared schedule, clipped at zero. |
+| `frame_deficit` | Sent input frames minus received samples divided by 1920. |
+
+No output gives missing latency/RTF values, not zero. By default RTF is
+diagnostic; `--max-client-rtf` adds an explicit ceiling. The existing frame
+coverage, audible-frame and scheduler-data-plane checks still apply. Passing
+client-only metrics does not certify model quality or a real-time capacity
+target on another GPU. Begin with N=1 and N=2; higher N is a capacity
+experiment, not a promised property of an A100 or of this patch.
+
+Deterministic driver and localhost WebSocket checks need no model or GPU:
+
+```bash
+python -m pytest tests/e2e/online_serving/test_personaplex_load_driver.py \
+  -m 'core_model and cpu' --run-level core_model -q
+```
+
+These checks test the driver against controlled protocol responses. Run the
+command above against real weights separately before reporting model-serving
+performance. Server tick timestamps and generic TTFT/TPOT aggregation remain
+the responsibility of the existing duplex metrics paths, not this driver.

--- a/docs/design/fullduplex-personaplex.md
+++ b/docs/design/fullduplex-personaplex.md
@@ -315,6 +315,20 @@ exit nonzero. Cancellation closes transports and propagates to the caller.
 the client's monotonic clock. It does not export handshake credentials or
 raw audio payloads. Metric definitions are explicit:
 
+Load mode validates each nonempty audio packet's strict base64 encoding, PCM16
+sample alignment, 24 kHz sample rate and response identity. Valid aggregate
+audio cannot hide a malformed packet. Rejected packets make the session fail
+and appear in `invalid_audio_packets` with their event index, receive time and
+fixed diagnostic code; they do not contribute samples or timing intervals.
+Empty audio deltas remain legal and contribute no samples. This check does
+not change the public client's decoding or the default lifecycle mode.
+
+The probe accepts both the current OpenAI Realtime audio event name
+`response.audio.delta` and the legacy `response.output_audio.delta`. Validation
+uses the wire payload directly rather than relying on a particular client
+library's alias table, so a server-side event-name migration cannot silently
+turn real audio into a zero-output measurement.
+
 | Field | Meaning |
 | --- | --- |
 | `client_audio_packet_interval_ms` | Consecutive nonempty packet arrivals: median, linear p99, max, and zero-based index of the first maximal interval. Interval index 0 ends at packet 1. One packet can contain multiple codec frames; this is not server tick latency. |
@@ -325,10 +339,15 @@ raw audio payloads. Metric definitions are explicit:
 
 No output gives missing latency/RTF values, not zero. By default RTF is
 diagnostic; `--max-client-rtf` adds an explicit ceiling. The existing frame
-coverage, audible-frame and scheduler-data-plane checks still apply. Passing
-client-only metrics does not certify model quality or a real-time capacity
-target on another GPU. Begin with N=1 and N=2; higher N is a capacity
-experiment, not a promised property of an A100 or of this patch.
+coverage, audible-frame and scheduler-data-plane checks still apply. A longer
+`--drain-s` can demonstrate eventual completion under backlog, but it must not
+be reported as real-time capacity when the fixed-window run failed or client
+RTF exceeded the stated target. Likewise, the first live session can pay
+one-time model/codec/JIT costs; either use the server's configured duplex
+warmup path or label that run as cold-start evidence before comparing steady
+capacity. Passing client-only metrics does not certify model quality or a
+real-time capacity target on another GPU. Begin with N=1 and N=2; higher N is a
+capacity experiment, not a promised property of an A100 or of this patch.
 
 Deterministic driver and localhost WebSocket checks need no model or GPU:
 
@@ -338,6 +357,6 @@ python -m pytest tests/e2e/online_serving/test_personaplex_load_driver.py \
 ```
 
 These checks test the driver against controlled protocol responses. Run the
-command above against real weights separately before reporting model-serving
+load-driver command against real weights separately before reporting model-serving
 performance. Server tick timestamps and generic TTFT/TPOT aggregation remain
 the responsibility of the existing duplex metrics paths, not this driver.

--- a/tests/e2e/online_serving/personaplex_realtime_duplex.py
+++ b/tests/e2e/online_serving/personaplex_realtime_duplex.py
@@ -26,12 +26,7 @@ try:
 except ImportError as exc:  # pragma: no cover - driver dependency.
     raise SystemExit("Install websockets first: pip install websockets") from exc
 
-from vllm_omni.clients.duplex import (
-    AudioDelta,
-    EventCollector,
-    wrap_event,
-    write_pcm16_wav,
-)
+from vllm_omni.clients.duplex import EventCollector, write_pcm16_wav
 from vllm_omni.clients.duplex import (
     wait_for_condition as wait_for,
 )
@@ -39,6 +34,7 @@ from vllm_omni.clients.duplex import (
 SAMPLE_RATE_HZ = 24_000
 FRAME_SAMPLES = 1_920
 FRAME_PERIOD_S = FRAME_SAMPLES / SAMPLE_RATE_HZ
+AUDIO_DELTA_EVENT_TYPES = frozenset({"response.audio.delta", "response.output_audio.delta"})
 
 
 class _ProbeTransport(Protocol):
@@ -156,6 +152,38 @@ def _events(client: RawRealtimeProbe, event_type: str) -> list[dict[str, object]
     return [event for event in client.events.events if event.get("type") == event_type]
 
 
+def _audio_events(client: RawRealtimeProbe) -> list[dict[str, object]]:
+    """Return audio deltas from both current and legacy Realtime event names."""
+    return [event for event in client.events.events if event.get("type") in AUDIO_DELTA_EVENT_TYPES]
+
+
+def _validated_audio_event(event: dict[str, object]) -> bytes:
+    """Decode one wire audio delta without depending on client event aliases."""
+    encoded = event.get("delta")
+    if not isinstance(encoded, str):
+        raise ValueError("missing_audio_delta")
+    try:
+        chunk = base64.b64decode(encoded, validate=True)
+    except ValueError:
+        raise ValueError("invalid_audio_base64") from None
+    if chunk:
+        if len(chunk) % 2:
+            raise ValueError("unaligned_pcm16_packet")
+        if event.get("sample_rate_hz") != SAMPLE_RATE_HZ:
+            raise ValueError("invalid_audio_sample_rate")
+        if not isinstance(event.get("response_id"), str) or not event.get("response_id"):
+            raise ValueError("missing_audio_response_id")
+    return chunk
+
+
+def _validated_audio_chunks(client: RawRealtimeProbe) -> list[tuple[dict[str, object], bytes]]:
+    return [(event, _validated_audio_event(event)) for event in _audio_events(client)]
+
+
+def _audio_bytes(client: RawRealtimeProbe) -> bytes:
+    return b"".join(chunk for _, chunk in _validated_audio_chunks(client) if chunk)
+
+
 async def _open_session(
     args: argparse.Namespace,
     *,
@@ -259,11 +287,7 @@ def _audio_frame_stats(
 
 
 def _response_ids(client: RawRealtimeProbe) -> set[str]:
-    return {
-        str(event["response_id"])
-        for event in _events(client, "response.output_audio.delta")
-        if isinstance(event.get("response_id"), str)
-    }
+    return {str(event["response_id"]) for event in _audio_events(client) if isinstance(event.get("response_id"), str)}
 
 
 def _session_result(
@@ -273,8 +297,16 @@ def _session_result(
     args: argparse.Namespace,
     minimum_chunks: int,
 ) -> tuple[bytes, set[str], dict[str, object]]:
-    chunks = sum(len(items) for items in client.events.response_audio.values())
-    raw = client.events.audio_bytes()
+    if isinstance(client, RawRealtimeProbe):
+        audio_chunks = _validated_audio_chunks(client)
+        chunks = sum(bool(chunk) for _, chunk in audio_chunks)
+        raw = b"".join(chunk for _, chunk in audio_chunks if chunk)
+    else:
+        # Unit fixtures may provide an already-decoded EventCollector without
+        # retaining the base64 wire field. Real websocket probes always take
+        # the strict wire-validation path above.
+        chunks = sum(len(items) for items in client.events.response_audio.values())
+        raw = client.events.audio_bytes()
     if chunks < minimum_chunks or not raw or len(raw) % 2:
         raise AssertionError(f"invalid PCM16 output: chunks={chunks}, bytes={len(raw)}")
     pcm = np.frombuffer(raw, dtype="<i2").astype(np.float32) / 32768.0
@@ -283,11 +315,7 @@ def _session_result(
     # Audible speech is checked per frame below with the higher 1e-3 default.
     if not np.isfinite(pcm).all() or rms <= 1e-5:
         raise AssertionError(f"output audio is non-finite or silent: samples={pcm.size}, rms={rms}")
-    rates = {
-        rate
-        for event in _events(client, "response.output_audio.delta")
-        if isinstance(rate := event.get("sample_rate_hz"), int)
-    }
+    rates = {rate for event in _audio_events(client) if isinstance(rate := event.get("sample_rate_hz"), int)}
     if rates != {SAMPLE_RATE_HZ}:
         raise AssertionError(f"unexpected output sample rates: {sorted(rates)}")
     stats = _audio_frame_stats(
@@ -306,7 +334,7 @@ def _session_result(
         )
     runtime_metadata = [
         metadata["vllm_omni"]
-        for event in _events(client, "response.output_audio.delta")
+        for event in _audio_events(client)
         if isinstance((metadata := event.get("metadata")), dict) and isinstance(metadata.get("vllm_omni"), dict)
     ]
     if not any(
@@ -400,14 +428,12 @@ async def run(args: argparse.Namespace) -> dict[str, object]:
     )
     await asyncio.gather(
         wait_for(
-            lambda: len(primary.events.audio_bytes()) // (2 * FRAME_SAMPLES) >= primary_frames - args.max_frame_deficit,
+            lambda: len(_audio_bytes(primary)) // (2 * FRAME_SAMPLES) >= primary_frames - args.max_frame_deficit,
             timeout_s=args.timeout_s,
             label="primary frame coverage",
         ),
         wait_for(
-            lambda: (
-                len(secondary.events.audio_bytes()) // (2 * FRAME_SAMPLES) >= secondary_frames - args.max_frame_deficit
-            ),
+            lambda: (len(_audio_bytes(secondary)) // (2 * FRAME_SAMPLES) >= secondary_frames - args.max_frame_deficit),
             timeout_s=args.timeout_s,
             label="secondary frame coverage",
         ),
@@ -445,16 +471,14 @@ async def run(args: argparse.Namespace) -> dict[str, object]:
     await asyncio.gather(
         wait_for(
             lambda: (
-                len(secondary.events.audio_bytes()) // (2 * FRAME_SAMPLES)
-                >= secondary_total_frames - args.max_frame_deficit
+                len(_audio_bytes(secondary)) // (2 * FRAME_SAMPLES) >= secondary_total_frames - args.max_frame_deficit
             ),
             timeout_s=args.timeout_s,
             label="survivor frame coverage after slot recycle",
         ),
         wait_for(
             lambda: (
-                len(replacement.events.audio_bytes()) // (2 * FRAME_SAMPLES)
-                >= replacement_frames - args.max_frame_deficit
+                len(_audio_bytes(replacement)) // (2 * FRAME_SAMPLES) >= replacement_frames - args.max_frame_deficit
             ),
             timeout_s=args.timeout_s,
             label="replacement frame coverage",
@@ -529,16 +553,25 @@ def _load_metrics(client: RawRealtimeProbe, sends: list[tuple[float, float, floa
     packets: list[dict[str, object]] = []
     response_ids: set[str] = set()
     packet_times: list[float] = []
+    invalid_packets: list[dict[str, object]] = []
     samples = 0
-    for raw, received in zip(client.events.events, client.events.event_received_at_s):
-        event = wrap_event(raw)
-        chunk = event.audio if isinstance(event, AudioDelta) else None
+    for index, (raw, received) in enumerate(zip(client.events.events, client.events.event_received_at_s, strict=True)):
+        if raw.get("type") not in AUDIO_DELTA_EVENT_TYPES:
+            continue
+        try:
+            chunk = _validated_audio_event(raw)
+        except ValueError as exc:
+            # Only fixed diagnostic codes from the validator are exported,
+            # never audio payloads or details from the remote endpoint.
+            invalid_packets.append({"event_index": index, "received_at_s": received, "code": str(exc)})
+            continue
         if chunk:
             samples += len(chunk) // 2
             packet_times.append(received)
-            packets.append({"received_at_s": received, "samples": len(chunk) // 2, "response_id": event.response_id})
-            if event.response_id:
-                response_ids.add(event.response_id)
+            response_id = raw.get("response_id")
+            packets.append({"received_at_s": received, "samples": len(chunk) // 2, "response_id": response_id})
+            if isinstance(response_id, str) and response_id:
+                response_ids.add(response_id)
     intervals = [(b - a) * 1000 for a, b in zip(packet_times, packet_times[1:])]
     first_send = sends[0][1] if sends else None
     audio_duration = samples / SAMPLE_RATE_HZ
@@ -558,6 +591,7 @@ def _load_metrics(client: RawRealtimeProbe, sends: list[tuple[float, float, floa
             for i, (planned, sent, completed) in enumerate(sends)
         ],
         "audio_packet_timeline": packets,
+        "invalid_audio_packets": invalid_packets,
     }
 
 
@@ -659,6 +693,8 @@ async def _run_load_session(
         error = f"{error}; {cleanup_error}" if error else cleanup_error
     if client.events.errors():
         error = error or "server emitted a Realtime error"
+    if metrics["invalid_audio_packets"]:
+        error = error or "invalid audio packets"
     first_audio = metrics["client_first_audio_after_stream_start_ms"]
     if isinstance(first_audio, float) and first_audio < 0:
         error = error or "audio arrived before the first input frame"

--- a/tests/e2e/online_serving/personaplex_realtime_duplex.py
+++ b/tests/e2e/online_serving/personaplex_realtime_duplex.py
@@ -10,22 +10,26 @@ import base64
 import hashlib
 import json
 import math
+import time
 import uuid
 import wave
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Protocol
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import numpy as np
 
 try:
     import websockets
-    from websockets.exceptions import ConnectionClosed
+    from websockets.exceptions import ConnectionClosed, WebSocketException
 except ImportError as exc:  # pragma: no cover - driver dependency.
     raise SystemExit("Install websockets first: pip install websockets") from exc
 
 from vllm_omni.clients.duplex import (
+    AudioDelta,
     EventCollector,
+    wrap_event,
     write_pcm16_wav,
 )
 from vllm_omni.clients.duplex import (
@@ -35,6 +39,14 @@ from vllm_omni.clients.duplex import (
 SAMPLE_RATE_HZ = 24_000
 FRAME_SAMPLES = 1_920
 FRAME_PERIOD_S = FRAME_SAMPLES / SAMPLE_RATE_HZ
+
+
+class _ProbeTransport(Protocol):
+    async def recv(self) -> str | bytes: ...
+
+    async def send(self, message: str) -> None: ...
+
+    async def close(self) -> None: ...
 
 
 class RawRealtimeProbe:
@@ -50,7 +62,7 @@ class RawRealtimeProbe:
         self.url = url
         self.max_size = max_size
         self.events = EventCollector()
-        self._ws = None
+        self._ws: _ProbeTransport | None = None
         self._reader_task: asyncio.Task[None] | None = None
 
     async def __aenter__(self) -> RawRealtimeProbe:
@@ -69,6 +81,7 @@ class RawRealtimeProbe:
                 pass
 
     async def _read_events(self) -> None:
+        assert self._ws is not None
         try:
             while True:
                 raw = await self._ws.recv()
@@ -81,6 +94,7 @@ class RawRealtimeProbe:
             return
 
     async def send(self, event: dict[str, object]) -> None:
+        assert self._ws is not None
         await self._ws.send(json.dumps(event))
 
 
@@ -151,22 +165,7 @@ async def _open_session(
 ) -> tuple[RawRealtimeProbe, dict[str, object]]:
     client = RawRealtimeProbe(_realtime_url(args.url, args.model, session_id))
     await client.__aenter__()
-    await client.send(
-        {
-            "type": "session.update",
-            "session": {
-                "session_id": session_id,
-                "model": args.model,
-                "modalities": ["audio", "text"],
-                "input_audio_format": "pcm_f32le",
-                "output_audio_format": "pcm16",
-                "voice": args.voice,
-                "instructions": persona,
-                "turn_detection": None,
-                "extra_body": {"auto_response": True},
-            },
-        }
-    )
+    await client.send(_session_update(args, session_id=session_id, persona=persona))
     event_type = "error" if expect_error else "session.created"
     await wait_for(
         lambda: client.events.count(event_type) > 0,
@@ -174,6 +173,23 @@ async def _open_session(
         label=event_type,
     )
     return client, _events(client, event_type)[-1]
+
+
+def _session_update(args: argparse.Namespace, *, session_id: str, persona: str) -> dict[str, object]:
+    return {
+        "type": "session.update",
+        "session": {
+            "session_id": session_id,
+            "model": args.model,
+            "modalities": ["audio", "text"],
+            "input_audio_format": "pcm_f32le",
+            "output_audio_format": "pcm16",
+            "voice": args.voice,
+            "instructions": persona,
+            "turn_detection": None,
+            "extra_body": {"auto_response": True},
+        },
+    }
 
 
 async def _close_session(client: RawRealtimeProbe, *, timeout_s: float) -> None:
@@ -200,21 +216,22 @@ async def _stream_frames(
             frame_count = min(frame_count, max_frames)
     for seq in range(frame_count):
         frame = pcm[seq * FRAME_SAMPLES : (seq + 1) * FRAME_SAMPLES]
-        frame = np.pad(frame, (0, FRAME_SAMPLES - frame.size))
-        frame = np.ascontiguousarray(frame, dtype="<f4")
-        await client.send(
-            {
-                "type": "input_audio_buffer.append",
-                "audio": base64.b64encode(frame).decode("ascii"),
-                "format": "pcm_f32le",
-                "sample_rate_hz": SAMPLE_RATE_HZ,
-                "duration_ms": 80,
-                "audio_end_ms": (seq + 1) * 80,
-                "is_speech": bool(np.sqrt(np.mean(np.square(frame))) >= 1e-4),
-            }
-        )
+        await client.send(_frame_event(frame, seq))
         await asyncio.sleep(FRAME_PERIOD_S)
     return frame_count
+
+
+def _frame_event(frame: np.ndarray, seq: int) -> dict[str, object]:
+    frame = np.ascontiguousarray(np.pad(frame, (0, FRAME_SAMPLES - frame.size)), dtype="<f4")
+    return {
+        "type": "input_audio_buffer.append",
+        "audio": base64.b64encode(frame).decode("ascii"),
+        "format": "pcm_f32le",
+        "sample_rate_hz": SAMPLE_RATE_HZ,
+        "duration_ms": 80,
+        "audio_end_ms": (seq + 1) * 80,
+        "is_speech": bool(np.sqrt(np.mean(np.square(frame))) >= 1e-4),
+    }
 
 
 def _audio_frame_stats(
@@ -267,9 +284,9 @@ def _session_result(
     if not np.isfinite(pcm).all() or rms <= 1e-5:
         raise AssertionError(f"output audio is non-finite or silent: samples={pcm.size}, rms={rms}")
     rates = {
-        int(event["sample_rate_hz"])
+        rate
         for event in _events(client, "response.output_audio.delta")
-        if isinstance(event.get("sample_rate_hz"), int)
+        if isinstance(rate := event.get("sample_rate_hz"), int)
     }
     if rates != {SAMPLE_RATE_HZ}:
         raise AssertionError(f"unexpected output sample rates: {sorted(rates)}")
@@ -332,6 +349,8 @@ def _save(output_dir: Path, name: str, client: RawRealtimeProbe, raw: bytes) -> 
 
 
 async def run(args: argparse.Namespace) -> dict[str, object]:
+    if getattr(args, "sessions", None) is not None:
+        return await run_load(args)
     input_path = Path(args.input_wav)
     input_identity = _input_identity(
         input_path,
@@ -493,6 +512,238 @@ async def run(args: argparse.Namespace) -> dict[str, object]:
     return result
 
 
+def _distribution(values: list[float]) -> dict[str, int | float | None]:
+    if not values:
+        return {"count": 0, "median": None, "p99": None, "max": None, "argmax_index": None}
+    return {
+        "count": len(values),
+        "median": float(np.median(values)),
+        "p99": float(np.quantile(values, 0.99)),
+        "max": max(values),
+        "argmax_index": int(np.argmax(values)),
+    }
+
+
+def _load_metrics(client: RawRealtimeProbe, sends: list[tuple[float, float, float]]) -> dict[str, object]:
+    # Use the collector's local clock, never a timestamp supplied by the server.
+    packets: list[dict[str, object]] = []
+    response_ids: set[str] = set()
+    packet_times: list[float] = []
+    samples = 0
+    for raw, received in zip(client.events.events, client.events.event_received_at_s):
+        event = wrap_event(raw)
+        chunk = event.audio if isinstance(event, AudioDelta) else None
+        if chunk:
+            samples += len(chunk) // 2
+            packet_times.append(received)
+            packets.append({"received_at_s": received, "samples": len(chunk) // 2, "response_id": event.response_id})
+            if event.response_id:
+                response_ids.add(event.response_id)
+    intervals = [(b - a) * 1000 for a, b in zip(packet_times, packet_times[1:])]
+    first_send = sends[0][1] if sends else None
+    audio_duration = samples / SAMPLE_RATE_HZ
+    first_audio_ms = (packet_times[0] - first_send) * 1000 if packet_times and first_send is not None else None
+    client_rtf = (packet_times[-1] - first_send) / audio_duration if audio_duration and first_send is not None else None
+    return {
+        "input_frames": len(sends),
+        "output_samples": samples,
+        "frame_deficit": len(sends) - samples / FRAME_SAMPLES,
+        "response_ids": sorted(response_ids),
+        "client_first_audio_after_stream_start_ms": first_audio_ms,
+        "client_stream_rtf": client_rtf,
+        "client_audio_packet_interval_ms": _distribution(intervals),
+        "client_send_lateness_ms": _distribution([max(0.0, sent - planned) * 1000 for planned, sent, _ in sends]),
+        "input_timeline": [
+            {"frame_index": i, "planned_at_s": planned, "send_started_at_s": sent, "send_completed_at_s": completed}
+            for i, (planned, sent, completed) in enumerate(sends)
+        ],
+        "audio_packet_timeline": packets,
+    }
+
+
+def _check_load_connection(client: RawRealtimeProbe) -> None:
+    if client.events.errors():
+        raise RuntimeError("server emitted a Realtime error (see the session error count)")
+    if client._reader_task is not None and client._reader_task.done():
+        client._reader_task.result()  # Propagate malformed JSON/reader failures.
+        raise RuntimeError("connection closed before session completion")
+
+
+async def _wait_load_event(client: RawRealtimeProbe, event_type: str, timeout_s: float) -> None:
+    def received() -> bool:
+        if client.events.count(event_type):
+            return True
+        _check_load_connection(client)
+        return False
+
+    await wait_for(received, timeout_s=timeout_s, label=event_type)
+
+
+async def _paced_load_frames(
+    client: RawRealtimeProbe,
+    pcm: np.ndarray,
+    *,
+    epoch: float,
+    timeout_s: float,
+    sends: list[tuple[float, float, float]],
+) -> None:
+    next_send = epoch
+    for seq in range(math.ceil(pcm.size / FRAME_SAMPLES)):
+        await asyncio.sleep(max(0.0, next_send - time.monotonic()))
+        _check_load_connection(client)
+        event = _frame_event(pcm[seq * FRAME_SAMPLES : (seq + 1) * FRAME_SAMPLES], seq)
+        started = time.monotonic()
+        await asyncio.wait_for(client.send(event), timeout=timeout_s)
+        completed = time.monotonic()
+        sends.append((epoch + seq * FRAME_PERIOD_S, started, completed))
+        # Do not burst to catch up after a stalled send; report accumulated lag.
+        next_send = max(epoch + (seq + 1) * FRAME_PERIOD_S, completed + FRAME_PERIOD_S)
+
+
+async def _run_load_session(
+    args: argparse.Namespace,
+    pcm: np.ndarray,
+    index: int,
+    ready: asyncio.Future[None],
+    start: asyncio.Future[float],
+) -> dict[str, object]:
+    session_id = f"personaplex-load-{index}-{uuid.uuid4().hex}"
+    client = RawRealtimeProbe(_realtime_url(args.url, args.model, session_id))
+    sends: list[tuple[float, float, float]] = []
+    error: str | None = None
+    cleanup_error: str | None = None
+    metrics: dict[str, object] | None = None
+    phase = "admission"
+    try:
+        async with client:
+            try:
+                await asyncio.wait_for(
+                    client.send(_session_update(args, session_id=session_id, persona=args.persona)), args.timeout_s
+                )
+                await _wait_load_event(client, "session.created", args.timeout_s)
+                capabilities = _capabilities(_events(client, "session.created")[-1])
+                if (
+                    capabilities.get("chunk_period_ms") != 80
+                    or capabilities.get("supports_multi_session_same_replica") is not True
+                ):
+                    raise AssertionError("server did not advertise PersonaPlex multi-session capabilities")
+                ready.set_result(None)
+                phase = "stream"
+                epoch = await asyncio.shield(start)
+                await _paced_load_frames(client, pcm, epoch=epoch, timeout_s=args.timeout_s, sends=sends)
+                phase = "drain"
+                # Fixed, reported observation window. Closing must not extend
+                # it and let a slow session pass by flushing after the cutoff.
+                await asyncio.sleep(args.drain_s)
+                _check_load_connection(client)
+                _session_result(client, input_frames=len(sends), args=args, minimum_chunks=args.minimum_audio_chunks)
+            finally:
+                metrics = _load_metrics(client, sends)
+                if client.events.count("session.created") and not client.events.count("session.closed"):
+                    try:
+                        await asyncio.wait_for(client.send({"type": "session.close"}), args.timeout_s)
+                        await _wait_load_event(client, "session.closed", args.timeout_s)
+                    except (OSError, asyncio.TimeoutError, ValueError, RuntimeError, WebSocketException) as exc:
+                        cleanup_error = f"cleanup: {type(exc).__name__}"
+    except (OSError, asyncio.TimeoutError, ValueError, RuntimeError, AssertionError, WebSocketException) as exc:
+        # Exception messages may include handshake credentials or server data.
+        # Export the phase/type only; retain structured server codes below.
+        error = f"{phase}: {type(exc).__name__}"
+    finally:
+        # Admission failure must not leave the other sessions at the barrier.
+        if not ready.done():
+            ready.set_result(None)
+    if metrics is None:
+        metrics = _load_metrics(client, sends)
+    if cleanup_error:
+        error = f"{error}; {cleanup_error}" if error else cleanup_error
+    if client.events.errors():
+        error = error or "server emitted a Realtime error"
+    first_audio = metrics["client_first_audio_after_stream_start_ms"]
+    if isinstance(first_audio, float) and first_audio < 0:
+        error = error or "audio arrived before the first input frame"
+    rtf = metrics["client_stream_rtf"]
+    if args.max_client_rtf is not None and isinstance(rtf, float) and rtf > args.max_client_rtf:
+        error = error or f"client_stream_rtf exceeds {args.max_client_rtf}"
+    return {
+        "index": index,
+        "session_id": session_id,
+        "ok": error is None,
+        "error": error,
+        "server_error_count": len(client.events.errors()),
+        "server_error_codes": [
+            str(body.get("code", "unknown")) if isinstance(body := event.get("error"), dict) else "unknown"
+            for event in client.events.errors()
+        ],
+        **metrics,
+    }
+
+
+async def run_load(args: argparse.Namespace) -> dict[str, object]:
+    input_path = Path(args.input_wav)
+    identity = _input_identity(input_path, expected_sha256=args.expected_input_sha256)
+    pcm = _read_wav_as_float32(input_path)
+    if args.tail_s:
+        pcm = np.concatenate([pcm, np.zeros(round(args.tail_s * SAMPLE_RATE_HZ), dtype=np.float32)])
+    pcm = pcm[: args.load_frames * FRAME_SAMPLES]
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    # Refuse to silently overwrite evidence from a previous sweep.
+    result_path = output_dir / "load-result.json"
+    if result_path.exists():
+        raise FileExistsError(result_path)
+    loop = asyncio.get_running_loop()
+    start: asyncio.Future[float] = loop.create_future()
+    ready: list[asyncio.Future[None]] = [loop.create_future() for _ in range(args.sessions)]
+    tasks = [asyncio.create_task(_run_load_session(args, pcm, i, r, start)) for i, r in enumerate(ready)]
+    try:
+        await asyncio.gather(*ready)
+        start.set_result(time.monotonic())
+        rows = await asyncio.gather(*tasks)
+    finally:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+    seen: set[str] = set()
+    shared: set[str] = set()
+    for row in rows:
+        assert isinstance(row["response_ids"], list)
+        response_ids = set(row["response_ids"])
+        shared.update(seen & response_ids)
+        seen.update(response_ids)
+    for row in rows:
+        assert isinstance(row["response_ids"], list)
+        if shared.intersection(row["response_ids"]):
+            row.update(ok=False, error="concurrent sessions shared a response id")
+    result = {
+        "schema_version": 1,
+        "mode": "paced_multi_session",
+        "model": args.model,
+        "requested_sessions": args.sessions,
+        "passed_sessions": sum(row["ok"] is True for row in rows),
+        "ok": all(row["ok"] is True for row in rows),
+        "input": {**identity, "tail_s": args.tail_s, "load_frames": args.load_frames},
+        "frame_period_s": FRAME_PERIOD_S,
+        "drain_s": args.drain_s,
+        "max_client_rtf": args.max_client_rtf,
+        "acceptance": {
+            "max_frame_deficit": args.max_frame_deficit,
+            "min_voiced_frames": args.min_voiced_frames,
+            "minimum_audio_chunks": args.minimum_audio_chunks,
+            "voiced_frame_rms_threshold": args.voiced_frame_rms_threshold,
+        },
+        "shared_response_ids": sorted(shared),
+        "sessions": rows,
+        "reported_server": {"revision": args.server_revision, "hardware": args.server_hardware},
+        "measurement_origin": "client monotonic clock; admission excluded; streaming and drain retained",
+        "interval_definition": "nonempty audio packet arrivals, not server ticks or per-frame inference latency",
+    }
+    with result_path.open("x", encoding="utf-8") as stream:
+        json.dump(result, stream, ensure_ascii=False, indent=2, allow_nan=False)
+    return result
+
+
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--url", default="ws://127.0.0.1:8099/v1/realtime?duplex=1")
@@ -536,11 +787,39 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default=0,
         help="Frames sent after slot reuse; 0 replays the full input so the replacement must produce audible output.",
     )
-    return parser.parse_args(argv)
+    parser.add_argument(
+        "--sessions", type=int, help="Opt into paced load mode with N sessions; omit for the lifecycle test."
+    )
+    parser.add_argument(
+        "--load-frames", type=int, default=1000, help="Maximum input frames per load session (no repetition)."
+    )
+    parser.add_argument("--max-client-rtf", type=float, help="Optional client stream-window RTF acceptance ceiling.")
+    parser.add_argument("--server-revision", help="User-reported server commit/version; not verified by this client.")
+    parser.add_argument(
+        "--server-hardware", help="User-reported server hardware; not inferred from the client machine."
+    )
+    args = parser.parse_args(argv)
+    if args.sessions is not None:
+        if not 1 <= args.sessions <= 64 or not 1 <= args.load_frames <= 10000:
+            parser.error("load mode requires sessions in [1,64] and load-frames in [1,10000]")
+        for name in ("timeout_s", "drain_s", "tail_s"):
+            value = getattr(args, name)
+            if not math.isfinite(value) or value < 0 or (name == "timeout_s" and value == 0):
+                parser.error(f"{name} must be finite and non-negative (timeout must be positive)")
+        if args.max_client_rtf is not None and (not math.isfinite(args.max_client_rtf) or args.max_client_rtf <= 0):
+            parser.error("max-client-rtf must be finite and positive")
+        if args.max_frame_deficit < 0 or args.min_voiced_frames < 1 or args.minimum_audio_chunks < 1:
+            parser.error("frame-deficit must be non-negative; voiced frames and audio chunks must be positive")
+        if not math.isfinite(args.voiced_frame_rms_threshold) or args.voiced_frame_rms_threshold < 0:
+            parser.error("voiced-frame-rms-threshold must be finite and non-negative")
+    return args
 
 
 def main() -> None:
-    print(json.dumps(asyncio.run(run(parse_args())), ensure_ascii=False, indent=2))
+    result = asyncio.run(run(parse_args()))
+    print(json.dumps(result, ensure_ascii=False, indent=2, allow_nan=False))
+    if result.get("mode") == "paced_multi_session" and not result["ok"]:
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/tests/e2e/online_serving/test_personaplex_load_driver.py
+++ b/tests/e2e/online_serving/test_personaplex_load_driver.py
@@ -60,9 +60,9 @@ def _args(tmp_path, *extra):
     )
 
 
-def _audio(response_id="r", samples=1920):
+def _audio(response_id="r", samples=1920, event_type="response.output_audio.delta"):
     return {
-        "type": "response.output_audio.delta",
+        "type": event_type,
         "response_id": response_id,
         "delta": base64.b64encode(np.full(samples, 2000, dtype="<i2").tobytes()).decode("ascii"),
         "sample_rate_hz": driver.SAMPLE_RATE_HZ,
@@ -125,7 +125,26 @@ async def _server(mode="success"):
                     if mode == "bad_json":
                         await ws.send("{")
                     elif mode not in ("silent", "late_on_close"):
-                        await ws.send(json.dumps(_audio(response_id)))
+                        event_type = (
+                            "response.audio.delta" if mode == "current_audio_event" else "response.output_audio.delta"
+                        )
+                        packet = _audio(response_id, event_type=event_type)
+                        if mode == "odd_packet":
+                            raw_audio = base64.b64decode(packet["delta"])
+                            raw_audio = raw_audio + b"\x00" if state["frames"] == 1 else raw_audio[:-1]
+                            packet["delta"] = base64.b64encode(raw_audio).decode("ascii")
+                        if state["frames"] == 2:
+                            if mode == "missing_packet_rate":
+                                packet.pop("sample_rate_hz")
+                            elif mode == "string_packet_rate":
+                                packet["sample_rate_hz"] = "24000"
+                            elif mode == "invalid_base64":
+                                packet["delta"] = "!" + packet["delta"]
+                            elif mode == "orphan_audio":
+                                orphan = _audio(response_id)
+                                orphan.pop("response_id")
+                                await ws.send(json.dumps(orphan))
+                        await ws.send(json.dumps(packet))
                 elif message["type"] == "session.close":
                     state["close_requested"] = True
                     if mode == "late_on_close":
@@ -199,6 +218,30 @@ def test_empty_output_has_missing_not_zero_latency():
     assert intervals["p99"] is None
 
 
+@pytest.mark.parametrize("event_type", sorted(driver.AUDIO_DELTA_EVENT_TYPES))
+def test_session_result_accepts_current_and_legacy_audio_event_names(tmp_path, event_type):
+    client = driver.RawRealtimeProbe("ws://unused")
+    client.events.add(_audio(samples=driver.FRAME_SAMPLES, event_type=event_type), received_at_s=1.0)
+    raw, response_ids, stats = driver._session_result(
+        client,
+        input_frames=1,
+        args=_args(tmp_path, "--sessions", "1"),
+        minimum_chunks=1,
+    )
+    assert len(raw) == driver.FRAME_SAMPLES * 2
+    assert response_ids == {"r"}
+    assert stats["frame_deficit"] == 0
+
+
+def test_current_audio_event_name_contributes_load_metrics():
+    client = driver.RawRealtimeProbe("ws://unused")
+    client.events.add(_audio(samples=driver.FRAME_SAMPLES * 5, event_type="response.audio.delta"), received_at_s=10.4)
+    report = driver._load_metrics(client, [(10.0, 10.0, 10.01)])
+    assert report["output_samples"] == driver.FRAME_SAMPLES * 5
+    assert report["response_ids"] == ["r"]
+    assert report["invalid_audio_packets"] == []
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("sessions", [1, 2, 4])
 async def test_real_websocket_load_success(tmp_path, sessions):
@@ -218,6 +261,18 @@ async def test_real_websocket_load_success(tmp_path, sessions):
     assert saved == result
     origins = [row["input_timeline"][0]["planned_at_s"] for row in rows]
     assert len(set(origins)) == 1
+
+
+@pytest.mark.asyncio
+async def test_real_websocket_load_accepts_current_audio_event_name(tmp_path):
+    args = _args(tmp_path, "--sessions", "2")
+    async with _server("current_audio_event") as (url, states):
+        args.url = url
+        result = await driver.run(args)
+    assert result["ok"] is True
+    assert result["passed_sessions"] == 2
+    assert result["shared_response_ids"] == []
+    assert all(s["closed"] and s["close_requested"] for s in states)
 
 
 @pytest.mark.asyncio
@@ -368,3 +423,70 @@ async def test_handshake_rejection_is_retained_without_server_details(tmp_path, 
     assert isinstance(rows, list) and len(rows) == 2
     assert all(row["error"] == "admission: InvalidHandshake" for row in rows)
     assert "credentials-in-remote-handshake-detail" not in json.dumps(result)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sessions", [1, 2])
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "missing_packet_rate",
+        "string_packet_rate",
+        "invalid_base64",
+        "orphan_audio",
+        "odd_packet",
+    ],
+)
+async def test_load_rejects_invalid_individual_audio_packets(tmp_path, sessions, mode):
+    # The concatenated PCM can still meet coverage/voicing thresholds, so the
+    # validator must also check each packet before accepting the whole run.
+    args = _args(tmp_path, "--sessions", str(sessions))
+    async with _server(mode) as (url, states):
+        args.url = url
+        result = await asyncio.wait_for(driver.run(args), timeout=4)
+    assert result["ok"] is False
+    assert result["passed_sessions"] == 0
+    rows = result["sessions"]
+    assert isinstance(rows, list) and len(rows) == sessions
+    assert all(row["error"] is not None for row in rows)
+    expected_code = {
+        "missing_packet_rate": "invalid_audio_sample_rate",
+        "string_packet_rate": "invalid_audio_sample_rate",
+        "invalid_base64": "invalid_audio_base64",
+        "orphan_audio": "missing_audio_response_id",
+        "odd_packet": "unaligned_pcm16_packet",
+    }[mode]
+    assert all({packet["code"] for packet in row["invalid_audio_packets"]} == {expected_code} for row in rows)
+    assert all(
+        sum(packet["samples"] for packet in row["audio_packet_timeline"]) == row["output_samples"] for row in rows
+    )
+    assert all(state["closed"] and state["close_requested"] for state in states)
+    assert json.loads((tmp_path / "out/load-result.json").read_text()) == result
+
+
+def test_load_allows_empty_and_multi_frame_audio_packets():
+    client = driver.RawRealtimeProbe("ws://unused")
+    client.events.add(_audio(samples=0), received_at_s=1.0)
+    client.events.add(_audio(samples=driver.FRAME_SAMPLES * 5), received_at_s=1.4)
+    metrics = driver._load_metrics(client, [(1.0, 1.0, 1.001)])
+    assert metrics["invalid_audio_packets"] == []
+    assert metrics["output_samples"] == driver.FRAME_SAMPLES * 5
+    packets = metrics["audio_packet_timeline"]
+    assert isinstance(packets, list) and len(packets) == 1
+
+
+def test_load_packet_diagnostics_do_not_copy_remote_payload():
+    client = driver.RawRealtimeProbe("ws://unused")
+    event = _audio()
+    event["delta"] = "private-remote-payload!"
+    client.events.add(event, received_at_s=1.4)
+    metrics = driver._load_metrics(client, [])
+    assert metrics["output_samples"] == 0
+    assert metrics["invalid_audio_packets"] == [
+        {
+            "event_index": 0,
+            "received_at_s": 1.4,
+            "code": "invalid_audio_base64",
+        }
+    ]
+    assert "private-remote-payload" not in json.dumps(metrics)

--- a/tests/e2e/online_serving/test_personaplex_load_driver.py
+++ b/tests/e2e/online_serving/test_personaplex_load_driver.py
@@ -1,0 +1,370 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+import asyncio
+import base64
+import json
+import wave
+from contextlib import asynccontextmanager
+from typing import TypedDict
+
+import numpy as np
+import pytest
+import websockets
+
+from tests.e2e.online_serving import personaplex_realtime_duplex as driver
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class _ServerState(TypedDict):
+    index: int
+    closed: bool
+    frames: int
+    close_requested: bool
+
+
+def _args(tmp_path, *extra):
+    wav_path = tmp_path / "input.wav"
+    with wave.open(str(wav_path), "wb") as stream:
+        stream.setnchannels(1)
+        stream.setsampwidth(2)
+        stream.setframerate(driver.SAMPLE_RATE_HZ)
+        stream.writeframes(np.full(driver.FRAME_SAMPLES * 2, 2000, dtype="<i2").tobytes())
+    return driver.parse_args(
+        [
+            "--model",
+            "fixture-only",
+            "--input-wav",
+            str(wav_path),
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--sessions",
+            "2",
+            "--load-frames",
+            "2",
+            "--tail-s",
+            "0",
+            "--drain-s",
+            "0.04",
+            "--timeout-s",
+            "0.5",
+            "--min-voiced-frames",
+            "1",
+            "--minimum-audio-chunks",
+            "1",
+            "--max-frame-deficit",
+            "0",
+            *extra,
+        ]
+    )
+
+
+def _audio(response_id="r", samples=1920):
+    return {
+        "type": "response.output_audio.delta",
+        "response_id": response_id,
+        "delta": base64.b64encode(np.full(samples, 2000, dtype="<i2").tobytes()).decode("ascii"),
+        "sample_rate_hz": driver.SAMPLE_RATE_HZ,
+        "metadata": {
+            "vllm_omni": {
+                "runtime_impl": "scheduler_data_plane",
+                "uses_model_runner_scheduler": True,
+                "runner_kv_backed": True,
+            }
+        },
+    }
+
+
+@asynccontextmanager
+async def _server(mode="success"):
+    states: list[_ServerState] = []
+
+    async def handle(ws):
+        index = len(states)
+        state: _ServerState = {"index": index, "closed": False, "frames": 0, "close_requested": False}
+        states.append(state)
+        response_id = "shared" if mode == "shared_response" else f"r-{index}"
+        try:
+            async for raw in ws:
+                message = json.loads(raw)
+                if message["type"] == "session.update":
+                    if mode == "reject_second" and index == 1:
+                        await ws.send(json.dumps({"type": "error", "error": {"code": "resource_exhausted"}}))
+                        continue
+                    if mode == "missing_capabilities":
+                        await ws.send(
+                            json.dumps(
+                                {
+                                    "type": "session.created",
+                                    "session": {"resume_token": "must-not-be-exported"},
+                                }
+                            )
+                        )
+                        continue
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "type": "session.created",
+                                "session": {
+                                    "resume_token": "must-not-be-exported",
+                                    "capabilities": {
+                                        "chunk_period_ms": 80,
+                                        "supports_multi_session_same_replica": True,
+                                    },
+                                },
+                            }
+                        )
+                    )
+                    await ws.send(json.dumps({"type": "response.created", "response": {"id": response_id}}))
+                elif message["type"] == "input_audio_buffer.append":
+                    state["frames"] += 1
+                    if mode == "disconnect":
+                        await ws.close()
+                        return
+                    if mode == "bad_json":
+                        await ws.send("{")
+                    elif mode not in ("silent", "late_on_close"):
+                        await ws.send(json.dumps(_audio(response_id)))
+                elif message["type"] == "session.close":
+                    state["close_requested"] = True
+                    if mode == "late_on_close":
+                        await ws.send(json.dumps(_audio(response_id, samples=driver.FRAME_SAMPLES * state["frames"])))
+                    if mode == "error_on_close":
+                        await ws.send(json.dumps({"type": "error", "error": {"code": "cleanup_failed"}}))
+                    if mode != "no_close_ack":
+                        await ws.send(json.dumps({"type": "session.closed"}))
+        finally:
+            state["closed"] = True
+
+    async with websockets.serve(handle, "127.0.0.1", 0) as server:
+        port = server.sockets[0].getsockname()[1]
+        yield f"ws://127.0.0.1:{port}/v1/realtime", states
+
+
+def test_omitted_sessions_preserves_lifecycle_mode():
+    args = driver.parse_args(["--model", "unused", "--input-wav", "unused.wav"])
+    assert args.sessions is None
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        ["--sessions", "0"],
+        ["--sessions", "65"],
+        ["--load-frames", "0"],
+        ["--load-frames", "10001"],
+        ["--drain-s", "nan"],
+        ["--tail-s", "-1"],
+        ["--timeout-s", "0"],
+        ["--timeout-s", "inf"],
+        ["--max-client-rtf", "-1"],
+        ["--max-frame-deficit", "-1"],
+        ["--minimum-audio-chunks", "0"],
+        ["--min-voiced-frames", "0"],
+        ["--voiced-frame-rms-threshold", "nan"],
+    ],
+)
+def test_load_rejects_invalid_configuration(tmp_path, options):
+    with pytest.raises(SystemExit):
+        _args(tmp_path, *options)
+
+
+def test_metric_clock_and_packet_frame_distinction():
+    client = driver.RawRealtimeProbe("ws://unused")
+    client.events.add({"type": "session.created", "session": {"resume_token": "secret"}}, received_at_s=7)
+    for when in (10.4, 10.8, 11.6):
+        event = _audio(samples=driver.FRAME_SAMPLES * 5)
+        event["_client_received_at_s"] = -999.0
+        client.events.add(event, received_at_s=when)
+    report = driver._load_metrics(client, [(10, 10, 10.01)])
+    intervals = report["client_audio_packet_interval_ms"]
+    assert isinstance(intervals, dict)
+    assert intervals["count"] == 2
+    assert intervals["median"] == pytest.approx(600)
+    assert intervals["p99"] == pytest.approx(796)
+    assert intervals["max"] == pytest.approx(800)
+    assert intervals["argmax_index"] == 1
+    assert report["client_first_audio_after_stream_start_ms"] == pytest.approx(400)
+    assert report["output_samples"] == 15 * driver.FRAME_SAMPLES
+    assert "secret" not in json.dumps(report)
+    assert "-999" not in json.dumps(report)
+
+
+def test_empty_output_has_missing_not_zero_latency():
+    report = driver._load_metrics(driver.RawRealtimeProbe("ws://unused"), [])
+    assert report["client_stream_rtf"] is None
+    intervals = report["client_audio_packet_interval_ms"]
+    assert isinstance(intervals, dict)
+    assert intervals["p99"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sessions", [1, 2, 4])
+async def test_real_websocket_load_success(tmp_path, sessions):
+    args = _args(tmp_path, "--sessions", str(sessions))
+    async with _server() as (url, states):
+        args.url = url
+        result = await driver.run(args)
+    assert result["ok"] is True
+    assert result["passed_sessions"] == sessions
+    rows = result["sessions"]
+    assert isinstance(rows, list)
+    assert len(rows) == sessions
+    assert all(row["frame_deficit"] == 0 for row in rows)
+    assert all(s["closed"] and s["close_requested"] for s in states)
+    assert "must-not-be-exported" not in json.dumps(result)
+    saved = json.loads((tmp_path / "out/load-result.json").read_text())
+    assert saved == result
+    origins = [row["input_timeline"][0]["planned_at_s"] for row in rows]
+    assert len(set(origins)) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "reject_second",
+        "silent",
+        "disconnect",
+        "no_close_ack",
+        "shared_response",
+        "late_on_close",
+        "error_on_close",
+        "bad_json",
+        "missing_capabilities",
+    ],
+)
+async def test_real_websocket_failures_remain_in_results(tmp_path, mode):
+    args = _args(tmp_path)
+    async with _server(mode) as (url, states):
+        args.url = url
+        result = await asyncio.wait_for(driver.run(args), timeout=4)
+    assert result["ok"] is False
+    assert "must-not-be-exported" not in json.dumps(result)
+    assert result["requested_sessions"] == 2
+    rows = result["sessions"]
+    assert isinstance(rows, list)
+    assert len(rows) == 2
+    assert all(s["closed"] for s in states)
+    if mode == "reject_second":
+        assert result["passed_sessions"] == 1
+        rejected = next(row for row in rows if not row["ok"])
+        assert rejected["input_frames"] == 0
+        assert rejected["client_stream_rtf"] is None
+        assert rejected["server_error_codes"] == ["resource_exhausted"]
+    if mode == "silent":
+        # A failed measurement must still release its admitted session.
+        assert all(s["close_requested"] for s in states)
+    if mode == "late_on_close":
+        assert all(row["output_samples"] == 0 for row in rows)
+    if mode == "shared_response":
+        assert result["passed_sessions"] == 0
+
+
+@pytest.mark.asyncio
+async def test_existing_report_is_not_overwritten(tmp_path):
+    args = _args(tmp_path)
+    path = tmp_path / "out/load-result.json"
+    path.parent.mkdir()
+    path.write_text("previous measurement")
+    with pytest.raises(FileExistsError):
+        await driver.run(args)
+    assert path.read_text() == "previous measurement"
+
+
+@pytest.mark.asyncio
+async def test_cancellation_closes_all_connections(tmp_path):
+    args = _args(tmp_path, "--drain-s", "10")
+    async with _server() as (url, states):
+        args.url = url
+        task = asyncio.create_task(driver.run(args))
+
+        async def started():
+            while len(states) < 2 or not all(state["frames"] for state in states):
+                await asyncio.sleep(0.01)
+
+        await asyncio.wait_for(started(), timeout=3)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=3)
+    assert all(s["closed"] for s in states)
+
+
+@pytest.mark.asyncio
+async def test_client_rtf_ceiling_marks_slow_sessions_failed(tmp_path):
+    args = _args(tmp_path, "--max-client-rtf", "0.001")
+    async with _server() as (url, _):
+        args.url = url
+        result = await driver.run(args)
+    assert result["passed_sessions"] == 0
+    rows = result["sessions"]
+    assert isinstance(rows, list)
+    assert all("client_stream_rtf exceeds" in row["error"] for row in rows)
+
+
+@pytest.mark.asyncio
+async def test_stalled_send_does_not_cause_catchup_burst(monkeypatch):
+    class Clock:
+        now = 10.0
+
+        def monotonic(self):
+            return self.now
+
+        async def sleep(self, delay):
+            self.now += delay
+
+    class Client(driver.RawRealtimeProbe):
+        async def send(self, event):
+            if event["audio_end_ms"] == 80:
+                clock.now += 0.25
+
+    clock = Clock()
+    monkeypatch.setattr(driver, "time", clock)
+    monkeypatch.setattr(driver.asyncio, "sleep", clock.sleep)
+    monkeypatch.setattr(driver, "_check_load_connection", lambda _: None)
+    sends: list[tuple[float, float, float]] = []
+    await driver._paced_load_frames(
+        Client("ws://unused"),
+        np.zeros(driver.FRAME_SAMPLES * 3, dtype="<f4"),
+        epoch=10.0,
+        timeout_s=1.0,
+        sends=sends,
+    )
+    assert len(sends) == 3
+    assert sends[1][1] >= sends[0][2] + driver.FRAME_PERIOD_S
+    assert sends[1][1] - sends[1][0] == pytest.approx(0.25)
+    assert sends[2][1] >= sends[1][2] + driver.FRAME_PERIOD_S
+
+
+@pytest.mark.parametrize("ok", [True, False])
+def test_load_main_exit_status(tmp_path, monkeypatch, ok):
+    args = _args(tmp_path)
+
+    async def completed(_args):
+        return {"mode": "paced_multi_session", "ok": ok}
+
+    monkeypatch.setattr(driver, "parse_args", lambda: args)
+    monkeypatch.setattr(driver, "run", completed)
+    if ok:
+        driver.main()
+    else:
+        with pytest.raises(SystemExit) as exc:
+            driver.main()
+        assert exc.value.code == 1
+
+
+@pytest.mark.asyncio
+async def test_handshake_rejection_is_retained_without_server_details(tmp_path, monkeypatch):
+    from websockets.exceptions import InvalidHandshake
+
+    async def rejected(_self):
+        raise InvalidHandshake("credentials-in-remote-handshake-detail")
+
+    monkeypatch.setattr(driver.RawRealtimeProbe, "__aenter__", rejected)
+    result = await asyncio.wait_for(driver.run(_args(tmp_path)), timeout=3)
+    assert result["ok"] is False
+    rows = result["sessions"]
+    assert isinstance(rows, list) and len(rows) == 2
+    assert all(row["error"] == "admission: InvalidHandshake" for row in rows)
+    assert "credentials-in-remote-handshake-detail" not in json.dumps(result)


### PR DESCRIPTION
## Purpose

Part of RFC #7389 item 7. Add an opt-in paced N-session validation mode to the existing PersonaPlex Realtime driver. Omitting `--sessions` preserves the two-session admission and slot-reuse scenario; both modes now reject malformed individual audio packets that the older aggregate-only checks could tolerate.

This is validation infrastructure, not a server-throughput optimization, server-tick instrument, or a claim of real-time capacity on every GPU.

**Current code HEAD:** `5b171bb4b5b0b193ba36d39ef9c656cb9d564e34`.

Load mode keeps every attempted session in the denominator, gives admitted sessions a shared input start, prevents catch-up bursts after stalled sends, and freezes the observation window before cleanup. Packet arrivals and send timelines use the client clock, not server inference timing. Load mode does not probe N+1 admission; the existing lifecycle scenario owns that check.

Both current `response.output_audio.delta` and legacy `response.audio.delta` event names are accepted. Nonempty packets are checked for strict base64, PCM16 alignment, 24 kHz sample rate, and a nonempty response identity. Malformed-packet diagnostics use fixed codes and do not export raw audio or handshake text.

### Review follow-up in `5b171bb4`

- Retain the failed local acceptance check and safe numeric diagnostics instead of only `drain: AssertionError`.
- Merge `_session_result` statistics into load rows, including integral `frame_deficit`, output/voiced/silent frames, coverage, RMS, and chunk counts when available.
- Reuse `compute_continuity_stats` for underrun and continuity diagnostics. Client RTF and first-audio metrics retain their `client_` prefix. Continuity is not an additional acceptance gate.
- Surface client send-lateness p99 above one nominal frame as a warning, not a relaxed or additional acceptance gate.
- Use injectable pacing timing in tests and a separate `--cleanup-timeout-s` for session-close send/acknowledgement. The WebSocket close handshake has its own bound.
- Clarify lifecycle packet validation, N+1 scope, and current/legacy audio event names in the design document.

## Validation by revision

The following are previously reported results, not new executions for this description update. Counts refer to different selections and must not be added together.

| Source revision | Previously reported validation | Boundary |
| --- | --- | --- |
| `f41e952cf5d87473f0c50ad3e26dddc9e06b799c` | 129 related CPU/protocol tests passed, 0 failed, 15 warnings; applicable changed-file hooks passed | Earlier pre-review-follow-up tree; not a fresh 129-test result for current HEAD |
| `5b171bb4b5b0b193ba36d39ef9c656cb9d564e34` | The same 102 client/localhost WebSocket regressions passed on Windows and Linux/WSL; applicable local hooks passed | Current source; client/localhost validation, not full-server or GPU execution |

The current-head report is in [the author update](https://github.com/vllm-project/vllm-omni/pull/7428#issuecomment-5676763021), following [the scoped validation details](https://github.com/vllm-project/vllm-omni/pull/7428#issuecomment-5674891692). That update also records successful upstream Build Wheel and pre-commit jobs; build/lint success is not a model-serving result.

In a compatible full repository environment, the related-suite command is:

```bash
python -m pytest \
  tests/e2e/online_serving/test_personaplex_load_driver.py \
  tests/model_executor/models/personaplex/duplex \
  tests/model_executor/models/personaplex/test_streaming_code2wav.py \
  tests/clients/test_duplex_client.py \
  -m 'core_model and cpu' --run-level core_model -q
```

This is the selection used for the earlier 129-test result, not the command being claimed for the separate 102-test client-only run. The localhost matrix covers N=1/2/4, both audio event names, admission rejection, silent output, disconnect, malformed JSON, failed close, shared response IDs, cancellation, malformed individual packets, empty packets, and multi-frame packets. Synthetic PCM is protocol test data, not a model-quality reference.

## Retained A100 validation — earlier driver revision

The following measurements predate `5b171bb4`; they are retained baseline evidence, not current-head serving validation.

Server revision: `05ab5092695169ec711c2a0462e90e1b194968ad`  
Checkpoint: `nvidia/personaplex-7b-v1`, gated repo revision `fdaf4090a61cb315c138a1faee287ffd6c716309`  
GPU: NVIDIA A100 80GB PCIe  
Input WAV SHA-256: `2e5fd4eb3ee434ce107ee3a0591fa624a33f7683c7462f45fe651c443c9af941`

The host has CUDA 12.3 `nvcc` while the installed PyTorch runtime is CUDA 12.9; FlashInfer 0.6.18 sampling JIT requested unsupported `--compress-mode=size`. The server used the supported setting `VLLM_USE_FLASHINFER_SAMPLER=0`; system CUDA was not modified.

After one unreported cold-start warmup, steady N=1 passed `--max-client-rtf 1.1`: 94 input frames, 91 output frames (deficit 3), first audio about 245 ms after first input send, and client stream RTF about 1.027. Audio-packet interval median was about 407 ms; one packet can contain multiple codec frames, so this is not server tick latency.

N=2 did not establish real-time capacity. With a fixed 2 s drain, both sessions had deficit 23 and RTF about 1.64–1.65. With a 15 s diagnostic drain, both reached deficit 3 with independent response IDs, but still failed the unchanged 1.1 RTF ceiling at about 1.47–1.48. Long-drain completion is not two-session real-time success.

### Repeated A100 validation (2026-09-13)

The sweep used the same server and checkpoint, with driver/test file blobs verified against `f41e952c`. The client directory was an archive, not a separately verified full Git checkout.

After one recorded N=1 warmup (RTF 1.0225, deficit 3), three N=1/N=2 pairs ran in alternating order. Tail and drain remained 2 s, RTF ceiling 1.1, and deficit ceiling 4. All sessions sent 94 frames; `--load-frames 1000` is a cap, not a looping workload.

| Run | Client stream RTF | Frame deficit | Passed / attempted sessions |
| --- | --- | --- | --- |
| Repeat 1, N=1 | 1.0241 | 3 | 1/1 |
| Repeat 1, N=2 | 1.6641 / 1.6743 | 23 / 23 | 0/2 |
| Repeat 2, N=1 | 1.0226 | 3 | 1/1 |
| Repeat 2, N=2 | 1.4781 / 1.4906 | 13 / 18 | 0/2 |
| Repeat 3, N=1 | 1.0240 | 3 | 1/1 |
| Repeat 3, N=2 | 1.4890 / 1.4989 | 18 / 18 | 0/2 |

All N=2 failures are retained without retries or relaxed gates. No server error events, invalid audio packets, or shared response IDs were reported. The earlier driver recorded `drain: AssertionError`; current-head diagnostics improve that reporting but do not fix the underlying capacity result.

The sweep completed in about 215 s and the service released the GPU. Shutdown emitted one resource-tracker leaked-semaphore warning. The GPU was idle before launch, but exclusive use throughout was not independently certified. The first N=2 pair was slower than later pairs; warmup/order effects remain unisolated. Raw reports/timelines/logs were retained locally, not uploaded as an artifact bundle.

## Scope / review

The item-7 boundary was confirmed in RFC #7389: opt-in paced N-session validation, preserved lifecycle scenario, client-clock timing, and shared duplex metric definitions. Current-head re-review remains pending. #7294 overlaps the driver; whichever lands second needs integration review and fresh testing against the resulting base.

Server-side tick gather, batched Mimi, depformer graphs, and other throughput optimizations are separate RFC items. No new GPU result, capacity improvement, or maintainer approval is claimed by this description update. No code or commit history was changed.

AI assistance: ChatGPT assisted with implementation, validation support, and this description update. The contributor's existing commit sign-offs are unchanged.
