### PR TITLE
[Bugfix][Frontend] Roll back cancelled duplex resume delivery

### DIFF
--- a/tests/entrypoints/openai/test_duplex_session_attachment.py
+++ b/tests/entrypoints/openai/test_duplex_session_attachment.py
@@ -278,6 +278,87 @@ async def test_registry_resume_delivery_failure_keeps_one_shot_old_token_recover
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("detached", [False, True], ids=["takeover", "reconnect"])
+@pytest.mark.parametrize("cancel_during", ["session.resumed", "replayed"])
+async def test_registry_cancelled_resume_delivery_keeps_token_recovery(detached: bool, cancel_during: str) -> None:
+    registry = DuplexSessionAttachmentRegistry(replay_ttl_s=60.0, replay_max_bytes_per_session=4096)
+    delivery_started = asyncio.Event()
+    wire: list[dict[str, object]] = []
+
+    async def send(payload: dict[str, object]) -> None:
+        wire.append(payload)
+
+    async def close(reason: str) -> None:
+        del reason
+
+    async def blocked_send(payload: dict[str, object]) -> None:
+        if payload["type"] == cancel_during:
+            delivery_started.set()
+            await asyncio.Future()
+
+    created = await registry.create("sid-cancel", incarnation=0, send=send, close=close)
+    if detached:
+        assert await registry.detach("sid-cancel", attachment_generation=1)
+    await registry.send_event("sid-cancel", {"type": "replayed"})
+    task = asyncio.create_task(
+        registry.resume(
+            "sid-cancel",
+            incarnation=0,
+            resume_token=created.resume_token.plaintext,
+            last_received_server_event_seq=0,
+            send=blocked_send,
+            close=close,
+            activation_payload_factory=lambda token, generation: {
+                "type": "session.resumed",
+                "resume_token": token.plaintext,
+                "attachment_generation": generation,
+            },
+        )
+    )
+    try:
+        await asyncio.wait_for(delivery_started.wait(), timeout=2.0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=2.0)
+
+        assert task.cancelled()
+        assert not await registry.is_current_attachment("sid-cancel", 2)
+        await registry.authenticate_resume(
+            "sid-cancel", incarnation=0, resume_token=created.resume_token.plaintext, last_received_server_event_seq=0
+        )
+        # No writes to the abandoned connection; the outbound lock is released
+        # and events accumulated while detached remain available to the retry.
+        wire.clear()
+        await asyncio.wait_for(registry.send_event("sid-cancel", {"type": "while_detached"}), timeout=2.0)
+        assert wire == []
+        recovered = await asyncio.wait_for(
+            registry.resume(
+                "sid-cancel",
+                incarnation=0,
+                resume_token=created.resume_token.plaintext,
+                last_received_server_event_seq=0,
+                send=send,
+                close=close,
+            ),
+            timeout=2.0,
+        )
+        assert recovered.attachment_generation == 3
+        assert [entry.payload["type"] for entry in recovered.replay_entries] == ["replayed", "while_detached"]
+        assert await registry.is_current_attachment("sid-cancel", 3)
+        with pytest.raises(InvalidResumeTokenError):
+            await registry.authenticate_resume(
+                "sid-cancel",
+                incarnation=0,
+                resume_token=created.resume_token.plaintext,
+                last_received_server_event_seq=0,
+            )
+    finally:
+        task.cancel()
+        await asyncio.wait_for(asyncio.gather(task, return_exceptions=True), timeout=2.0)
+        await registry.close("sid-cancel")
+
+
+@pytest.mark.asyncio
 async def test_registry_concurrent_resume_allows_exactly_one_rotated_token_winner() -> None:
     registry = DuplexSessionAttachmentRegistry(
         replay_ttl_s=60.0,

--- a/vllm_omni/entrypoints/duplex/session_attachment.py
+++ b/vllm_omni/entrypoints/duplex/session_attachment.py
@@ -397,7 +397,9 @@ class DuplexSessionAttachmentRegistry:
                     await send(dict(activation_payload_factory(rotated_token, attachment_generation)))
                     for entry in replay_entries:
                         await send(dict(entry.payload))
-                except Exception:
+                except (Exception, asyncio.CancelledError):
+                    # Cancelled delivery may not have reached the client either;
+                    # retain the existing recovery path and re-raise cancellation.
                     async with self._lock:
                         if (
                             self._sessions.get(session_id) is state


### PR DESCRIPTION
## Purpose

Treat cancellation during duplex resume activation/replay like the existing failed-delivery rollback, then propagate CancelledError. Without it the rotated, abandoned connection generation remains current and the prior token cannot use the intended retry path.

This is a two-file fix against current main 02aaa34059478280eb3e6a5ee05a9484f0fa23c4; it does not include PR #7413's framework changes. The same issue was discussed with its author, and a separately validated author-branch adaptation is preserved. This main version uses the current incarnation-based API.

## Test Plan and Results

- Four new deterministic cancellation cases: takeover/reconnect, each during activation or replay. **4 fail** on unchanged main and pass after the fix.
- The attachment registry, lease and public duplex-client files together: **63 passed, 0 failed, 0 skipped**.
- The cases assert cancellation propagation, obsolete attachment removal, released outbound lock, retained replay and one-shot old-token recovery. This preserves existing failed-delivery semantics; it does not claim to redesign grace timers or arbitrary repeated-cancel handling.
- Applicable changed-file pre-commit checks passed, including mypy-3.10, SPDX and test markers.

~~~bash
python -m pytest tests/entrypoints/openai/test_duplex_session_attachment.py tests/engine/duplex/test_duplex_lease.py tests/clients/test_duplex_client.py -m 'core_model and cpu' --run-level core_model -q
~~~

Retained output: 63 passed, 15 warnings in 0.78s (rerun on signed head e07daf39). Python 3.12 CPU environment, actual registry/lease/client code; the local adapter disables NVML discovery only. No GPU or live model run is claimed. Earlier 66-test results against #7413 are not reused as current-main results.

AI assistance: ChatGPT assisted with implementation, tests, and this description.
