### PR TITLE
[Bugfix][Model] Fix FLUX.2 Klein multi-image edit metadata

### DIFF
--- a/tests/diffusion/test_diffusion_config_propagation.py
+++ b/tests/diffusion/test_diffusion_config_propagation.py
@@ -17,6 +17,7 @@ from vllm_omni.diffusion.data import (
 )
 from vllm_omni.diffusion.diffusion_kv.config import DiffusionKVCacheMode
 from vllm_omni.diffusion.model_metadata import (
+    FLUX2_KLEIN_MAX_INPUT_IMAGES,
     HUNYUAN_IMAGE3_MAX_INPUT_IMAGES,
     QWEN_IMAGE_EDIT_PLUS_MAX_INPUT_IMAGES,
 )
@@ -194,6 +195,18 @@ def test_qwen_image_edit_plus_sets_generic_multimodal_limit():
 
     assert od_config.supports_multimodal_inputs is True
     assert od_config.max_multimodal_image_inputs == QWEN_IMAGE_EDIT_PLUS_MAX_INPUT_IMAGES
+
+
+def test_flux2_klein_sets_generic_multimodal_limit():
+    od_config = OmniDiffusionConfig(
+        model="black-forest-labs/FLUX.2-klein-9B",
+        model_class_name="Flux2KleinPipeline",
+    )
+
+    od_config.update_multimodal_support()
+
+    assert od_config.supports_multimodal_inputs is True
+    assert od_config.max_multimodal_image_inputs == FLUX2_KLEIN_MAX_INPUT_IMAGES
 
 
 def test_task_type_roundtrip():

--- a/vllm_omni/diffusion/model_metadata.py
+++ b/vllm_omni/diffusion/model_metadata.py
@@ -19,6 +19,8 @@ class DiffusionModelMetadata:
     final_output_type: str | None = None
 
 
+# FLUX.2 Klein supports up to four reference images.
+FLUX2_KLEIN_MAX_INPUT_IMAGES = 4
 QWEN_IMAGE_EDIT_PLUS_MAX_INPUT_IMAGES = 4
 # Upstream HunyuanImage-3.0 "Multi-Image Fusion" caps reference images at 3.
 HUNYUAN_IMAGE3_MAX_INPUT_IMAGES = 3
@@ -27,6 +29,10 @@ BOOGU_IMAGE_MAX_INPUT_IMAGES = 1
 
 
 _DIFFUSION_MODEL_METADATA: dict[str, DiffusionModelMetadata] = {
+    "Flux2KleinPipeline": DiffusionModelMetadata(
+        supports_multimodal_inputs=True,
+        max_multimodal_image_inputs=FLUX2_KLEIN_MAX_INPUT_IMAGES,
+    ),
     "QwenImageEditPlusPipeline": DiffusionModelMetadata(
         supports_multimodal_inputs=True,
         max_multimodal_image_inputs=QWEN_IMAGE_EDIT_PLUS_MAX_INPUT_IMAGES,


### PR DESCRIPTION
## Purpose

Advertise FLUX.2 Klein's multi-reference image capability through the shared diffusion model metadata so the OpenAI-compatible image editing endpoint accepts multiple input images.

The metadata also enforces the model's documented limit of four reference images instead of treating the limit as unbounded.

Related to #2541.

Official capability reference: https://docs.bfl.ai/flux_2/flux2_overview

## Test Plan

```bash
pytest -q tests/diffusion/test_diffusion_config_propagation.py::test_flux2_klein_sets_generic_multimodal_limit
pytest -q tests/diffusion/test_diffusion_config_propagation.py
SKIP=actionlint pre-commit run --files vllm_omni/diffusion/model_metadata.py tests/diffusion/test_diffusion_config_propagation.py
```

`actionlint` was skipped because this PR does not modify GitHub workflow files; all applicable hooks passed.

**vLLM Version:** 0.29.0

**vLLM-Omni Commit:** 02aaa34059478280eb3e6a5ee05a9484f0fa23c4

## Test Result

- Focused regression: `1 passed, 14 warnings`
- Full test module: `24 passed, 14 warnings`
- Applicable pre-commit hooks: passed, including Ruff, mypy, test marks, SPDX, forbidden imports, and torch.cuda checks

AI assistance: Used Cursor to review the metadata contract, draft the regression test and PR description, and run validation. I reviewed the changes and test results.
