### PR TITLE
[Bugfix][Model] Fix FLUX.2 Klein Ulysses attention

### DIFF
--- a/tests/diffusion/models/flux2/test_flux2_klein_validation.py
+++ b/tests/diffusion/models/flux2/test_flux2_klein_validation.py
@@ -201,4 +201,7 @@ def test_config_sequence_parallel_size_is_used_before_groups_initialize(monkeypa
         ulysses_degree=expected_size,
     )
 
-    assert _get_sequence_parallel_size(config) == expected_size
+    sequence_parallel_size = _get_sequence_parallel_size(config)
+
+    assert sequence_parallel_size == expected_size
+    assert isinstance(sequence_parallel_size, int)

--- a/tests/diffusion/models/flux2/test_flux2_klein_validation.py
+++ b/tests/diffusion/models/flux2/test_flux2_klein_validation.py
@@ -1,9 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 import pytest
 import torch
 
+from vllm_omni.diffusion.data import DiffusionParallelConfig
+from vllm_omni.diffusion.models.flux2_klein.flux2_klein_transformer import (
+    Flux2Attention,
+    Flux2SingleTransformerBlock,
+    _get_sequence_parallel_size,
+)
 from vllm_omni.diffusion.models.flux2_klein.pipeline_flux2_klein import (
     Flux2KleinPipeline,
 )
@@ -78,3 +84,121 @@ def test_rejects_none_without_embeds():
 def test_accepts_none_with_prompt_embeds():
     pipe = _make_pipeline()
     _check(pipe, None, prompt_embeds=torch.randn(1, 256, 4096))
+
+
+def test_single_block_forwards_text_length_to_sp_attention():
+    class RecordingAttention(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.text_seq_len = None
+
+        def forward(self, hidden_states, **kwargs):
+            self.text_seq_len = kwargs.get("text_seq_len")
+            return torch.zeros_like(hidden_states)
+
+    block = object.__new__(Flux2SingleTransformerBlock)
+    torch.nn.Module.__init__(block)
+    block.norm = torch.nn.Identity()
+    block.attn = RecordingAttention()
+
+    hidden_states = torch.randn(1, 3, 4)
+    zeros = torch.zeros(1, 1, 4)
+    block(
+        hidden_states=hidden_states,
+        encoder_hidden_states=None,
+        temb_mod_params=(zeros, zeros, zeros),
+        text_seq_len=2,
+    )
+
+    assert block.attn.text_seq_len == 2
+
+
+def test_double_stream_uses_joint_attention_when_image_only_is_sp_sharded():
+    class Projection(torch.nn.Module):
+        def forward(self, hidden_states):
+            return torch.cat([hidden_states, hidden_states, hidden_states], dim=-1), None
+
+    class PassthroughLinear(torch.nn.Module):
+        def forward(self, hidden_states):
+            return hidden_states
+
+    class PassthroughRope(torch.nn.Module):
+        def forward(self, hidden_states, cos, sin):
+            return hidden_states
+
+    class RecordingAttention(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.metadata = None
+
+        def forward(self, query, key, value, metadata):
+            self.metadata = metadata
+            return torch.cat([metadata.joint_value, value], dim=1)
+
+    attention = object.__new__(Flux2Attention)
+    torch.nn.Module.__init__(attention)
+    attention.parallel_config = type("ParallelConfig", (), {"sequence_parallel_size": 8})()
+    attention.added_kv_proj_dim = 1
+    attention.inner_dim = 1
+    attention.query_num_heads = 1
+    attention.kv_num_heads = 1
+    attention.add_query_num_heads = 1
+    attention.add_kv_num_heads = 1
+    attention.to_qkv = Projection()
+    attention.add_kv_proj = Projection()
+    attention.norm_q = torch.nn.Identity()
+    attention.norm_k = torch.nn.Identity()
+    attention.norm_added_q = torch.nn.Identity()
+    attention.norm_added_k = torch.nn.Identity()
+    attention.rope = PassthroughRope()
+    attention.attn = RecordingAttention()
+    attention.to_add_out = PassthroughLinear()
+    attention.to_out = torch.nn.ModuleList([PassthroughLinear(), torch.nn.Identity()])
+
+    image = torch.randn(1, 2, 1)
+    text = torch.randn(1, 3, 1)
+    rotary = (torch.ones(5, 1), torch.zeros(5, 1))
+    attention(image, encoder_hidden_states=text, image_rotary_emb=rotary)
+
+    metadata = attention.attn.metadata
+    assert metadata is not None
+    assert metadata.joint_query.shape[1] == text.shape[1]
+    assert metadata.joint_key.shape[1] == text.shape[1]
+
+
+def test_runtime_sequence_parallel_size_overrides_stale_model_config(monkeypatch):
+    monkeypatch.setattr(
+        "vllm_omni.diffusion.models.flux2_klein.flux2_klein_transformer.model_parallel_is_initialized",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "vllm_omni.diffusion.models.flux2_klein.flux2_klein_transformer.get_sequence_parallel_world_size",
+        lambda: 8,
+    )
+    stale_config = type("ParallelConfig", (), {"sequence_parallel_size": 1})()
+
+    assert _get_sequence_parallel_size(stale_config) == 8
+
+
+@pytest.mark.parametrize(
+    ("configured_size", "expected_size"),
+    [
+        (None, 1),
+        (4, 4),
+    ],
+)
+def test_config_sequence_parallel_size_is_used_before_groups_initialize(monkeypatch, configured_size, expected_size):
+    monkeypatch.setattr(
+        "vllm_omni.diffusion.models.flux2_klein.flux2_klein_transformer.model_parallel_is_initialized",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        "vllm_omni.diffusion.models.flux2_klein.flux2_klein_transformer.get_sequence_parallel_world_size",
+        lambda: pytest.fail("runtime SP group must not be queried before initialization"),
+    )
+    config = DiffusionParallelConfig(
+        sequence_parallel_size=configured_size,
+        ulysses_degree=expected_size,
+    )
+
+    assert _get_sequence_parallel_size(config) == expected_size

--- a/vllm_omni/diffusion/models/flux2_klein/flux2_klein_transformer.py
+++ b/vllm_omni/diffusion/models/flux2_klein/flux2_klein_transformer.py
@@ -61,7 +61,8 @@ logger = init_logger(__name__)
 def _get_sequence_parallel_size(parallel_config: DiffusionParallelConfig) -> int:
     if model_parallel_is_initialized():
         return get_sequence_parallel_world_size()
-    return parallel_config.sequence_parallel_size
+    configured_size = parallel_config.sequence_parallel_size
+    return configured_size if configured_size is not None else 1
 
 
 if TYPE_CHECKING:

--- a/vllm_omni/diffusion/models/flux2_klein/flux2_klein_transformer.py
+++ b/vllm_omni/diffusion/models/flux2_klein/flux2_klein_transformer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
 
 # Copyright 2025 Black Forest Labs, The HuggingFace Team and The InstantX Team. All rights reserved.
 #
@@ -43,6 +43,10 @@ from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.layer import Attention
 from vllm_omni.diffusion.cache.cachedit import CacheDiTAdapterConfig
 from vllm_omni.diffusion.data import DiffusionParallelConfig, OmniDiffusionConfig
+from vllm_omni.diffusion.distributed.parallel_state import (
+    get_sequence_parallel_world_size,
+    model_parallel_is_initialized,
+)
 from vllm_omni.diffusion.distributed.sp_plan import (
     SequenceParallelInput,
     SequenceParallelOutput,
@@ -52,6 +56,14 @@ from vllm_omni.diffusion.layers.rope import RotaryEmbedding, apply_rope_to_qk
 from vllm_omni.diffusion.models.host_weight_contract import FinalLayoutModelContract
 
 logger = init_logger(__name__)
+
+
+def _get_sequence_parallel_size(parallel_config: DiffusionParallelConfig) -> int:
+    if model_parallel_is_initialized():
+        return get_sequence_parallel_world_size()
+    return parallel_config.sequence_parallel_size
+
+
 if TYPE_CHECKING:
     from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
 
@@ -243,9 +255,8 @@ class Flux2Attention(nn.Module):
             encoder_query = self.norm_added_q(encoder_query)
             encoder_key = self.norm_added_k(encoder_key)
 
-            sp_size = self.parallel_config.sequence_parallel_size
-            forward_ctx = get_forward_context()
-            use_sp_joint_attention = sp_size is not None and sp_size > 1 and not forward_ctx.split_text_embed_in_sp
+            sp_size = _get_sequence_parallel_size(self.parallel_config)
+            use_sp_joint_attention = sp_size > 1
 
             if use_sp_joint_attention and image_rotary_emb is not None:
                 cos, sin = image_rotary_emb
@@ -421,12 +432,9 @@ class Flux2ParallelSelfAttention(nn.Module):
         query = self.norm_q(query)
         key = self.norm_k(key)
 
-        sp_size = self.parallel_config.sequence_parallel_size
-        forward_ctx = get_forward_context()
+        sp_size = _get_sequence_parallel_size(self.parallel_config)
         text_seq_len = kwargs.get("text_seq_len", None)
-        use_sp_single_stream = (
-            sp_size is not None and sp_size > 1 and not forward_ctx.split_text_embed_in_sp and text_seq_len is not None
-        )
+        use_sp_single_stream = sp_size > 1 and text_seq_len is not None
 
         if use_sp_single_stream and image_rotary_emb is not None:
             cos, sin = image_rotary_emb
@@ -540,6 +548,7 @@ class Flux2SingleTransformerBlock(nn.Module):
         attn_output = self.attn(
             hidden_states=norm_hidden_states,
             image_rotary_emb=image_rotary_emb,
+            text_seq_len=text_seq_len,
             **joint_attention_kwargs,
         )
 
@@ -944,8 +953,8 @@ class Flux2Transformer2DModel(nn.Module):
 
         num_txt_tokens = encoder_hidden_states.shape[1]
 
-        sp_size = self.parallel_config.sequence_parallel_size
-        if sp_size is not None and sp_size > 1:
+        sp_size = _get_sequence_parallel_size(self.parallel_config)
+        if sp_size > 1:
             get_forward_context().split_text_embed_in_sp = False
 
         timestep = timestep.to(hidden_states.dtype) * 1000


### PR DESCRIPTION
## Purpose

Fix FLUX.2 Klein attention under Ulysses sequence parallelism when only image tokens are sharded and text tokens remain replicated.

The change reads the initialized runtime SP world size instead of relying on model-construction-time configuration, routes double-stream attention through joint attention in SP mode, and forwards the text sequence boundary into single-stream attention.

## Test Plan

```bash
pytest -q tests/diffusion/models/flux2/test_flux2_klein_validation.py
SKIP=actionlint pre-commit run --files vllm_omni/diffusion/models/flux2_klein/flux2_klein_transformer.py tests/diffusion/models/flux2/test_flux2_klein_validation.py
```

GPU E2E coverage used the FP8 FLUX.2 Klein checkpoint, 768x1360 image editing, four inference steps, fixed seed 0, and the `TORCH_SDPA` backend to isolate this fix from SageAttention-specific changes:

- TP1, Ulysses 1 (non-SP): passed, 3.824 s HTTP latency
- TP1, Ulysses 8: passed, 1.870 s HTTP latency
- Both runs produced valid 768x1360 RGB PNGs with visually consistent output

`actionlint` was skipped because this PR does not modify GitHub workflow files; all applicable hooks passed.

**vLLM Version:** 0.29.0

**vLLM-Omni Base Commit:** d3493384

## Test Result

- Flux2 Klein test module: `14 passed, 14 warnings`
- Non-SP GPU E2E: passed
- Ulysses SP8 GPU E2E: passed
- Applicable pre-commit hooks: passed, including Ruff, mypy, test marks, SPDX, forbidden imports, and torch.cuda checks

AI assistance: Used Cursor to diagnose the SP token-layout mismatch, draft the implementation and regression tests, run validation, and prepare this PR description. I reviewed the changes and test outputs.
