### PR TITLE
[Bugfix][Core] Schedule async chunks atomically

### DIFF
--- a/docs/design/feature/async_chunk.md
+++ b/docs/design/feature/async_chunk.md
@@ -188,6 +188,9 @@ In sequential mode, each stage must wait for the previous stage to complete enti
      - **Before** `super().schedule()`: `process_pending_chunks(waiting, running)` moves requests waiting for chunks to `WAITING_FOR_CHUNK`, enqueues load tasks for background polling
      - **After** `super().schedule()`: `restore_queues(waiting, running)` restores requests with ready chunks back to waiting/running, `postprocess_scheduler_output(scheduler_output)` attaches cached additional_information, clears chunk-ready flags
    - **put_chunk** `save_async(pooler_output, request)`; **get_chunk** / **get_chunk_for_generation** `load_async(request)`
+   - **OmniGenerationScheduler atomic scheduling contract**: Connector-delivered async chunks are indivisible scheduling units. The generation scheduler must either admit a ready chunk in its entirety or defer it intact with its codes and metadata unchanged. It must never slice a chunk to fit the remaining step token budget, because consumers such as the Qwen3-TTS ICL first chunk validate received chunks against their declared metadata.
+   - A ready chunk larger than the full step budget (`max_num_scheduled_tokens`) can never be admitted in any step. Such a request is terminated through the standard cleanup path with `FINISHED_ERROR` and an ERROR engine output carrying the rejection reason.
+   - Non-chunk prompt inputs retain the existing splittable fast-path behavior.
 
 5. **Model Runners**: Handle chunk processing
    - `OmniGPUModelRunner`: Processes chunks in AR stages

--- a/tests/core/sched/test_generation_scheduler_atomic_chunk.py
+++ b/tests/core/sched/test_generation_scheduler_atomic_chunk.py
@@ -1,0 +1,520 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+"""Atomic scheduling of connector-delivered async chunks (generation stage).
+
+Regression coverage for the ICL first-chunk clipping crash: the waiting fast
+path scheduled ``min(required_tokens, token_budget)``, splitting a stateful
+codec chunk whose metadata still describes the complete chunk. With 57 first
+chunks of 1168 tokens and a 65536 token budget, the 57th chunk was clipped to
+the 128 token remainder and the ValueError killed the whole stage engine.
+
+Rules under test (see docs section 9.5 of the incident analysis):
+
+1. the waiting and running loops defer async chunks intact when the remaining
+   budget is insufficient -- never split, and never lose the ready marker;
+2. ready chunks larger than the full step budget fail their request through
+   the standard finish path and queue an explicit ERROR output, which a
+   zero-token engine step must still emit exactly once;
+3. non-chunk inputs (sender-only adapter / plain prompts) keep their previous
+   behavior on both paths.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+# Imports must run in this order: vllm_omni applies patches to vllm.v1.request
+# before Request / RequestStatus are bound in this module.
+# isort: off
+import vllm_omni  # noqa: F401 - import for side effects (patch vLLM)
+from vllm.sampling_params import SamplingParams
+from vllm.v1.core.sched.interface import PauseState
+from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
+from vllm.v1.engine import FinishReason
+from vllm.v1.request import Request, RequestStatus
+from vllm_omni.core.sched.omni_generation_scheduler import OmniGenerationScheduler
+# isort: on
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+BUDGET = 65536
+FIRST_CHUNK_TOKENS = (72 + 1) * 16  # 73 frames x 16 quantizers = 1168
+FOLLOWUP_TOKENS = 25 * 16  # 400
+OVERSIZED_TOKENS = BUDGET + 16  # 65552: can never fit a full step
+
+
+class FakeBlocks:
+    def get_block_ids(self, allow_none: bool = False):
+        return ()
+
+
+class FakeKV:
+    """Stands in for kv_cache_manager; allocation never fails by default."""
+
+    def __init__(self, fail_allocation: bool = False):
+        self.fail_allocation = fail_allocation
+
+    def new_step_starts(self):
+        pass
+
+    def allocate_slots(self, request, num_tokens, num_lookahead_tokens=0):
+        return None if self.fail_allocation else FakeBlocks()
+
+    def get_num_common_prefix_blocks(self, request_id):
+        return [0]
+
+    def take_events(self):
+        return []
+
+    def take_new_block_ids(self):
+        return []
+
+
+class FakeAdapter:
+    """Minimal chunk-receiving adapter honoring the ready-chunk contract.
+
+    ``postprocess_scheduler_output`` mirrors the real adapter's
+    ``_clear_chunk_ready``: only request ids actually scheduled in this step
+    lose their ready marker; deferred chunks stay ready for the next step.
+    """
+
+    def __init__(self, receives_chunks: bool = True):
+        self.receives_chunks = receives_chunks
+        self.requests_with_ready_chunks: set[str] = set()
+        self.replaced_streaming_prompt_ids: set[str] = set()
+        self.num_running_waiting_for_chunk = 0
+        self.restore_called = False
+        self.finish_calls: list[tuple] = []
+        self.finish_calls_unresolved: list[str] = []
+
+    def process_pending_chunks(self, waiting, running, scheduler_requests=None):
+        pass
+
+    def restore_queues(self, waiting, running, scheduler_requests=None):
+        self.restore_called = True
+
+    def is_done_receiving_chunks(self, request_id):
+        return False
+
+    def collect_failed_receive_request_ids(self):
+        return {}
+
+    def collect_timed_out_request_ids(self, timeout_s):
+        return set()
+
+    def collect_failed_send_request_ids(self):
+        return {}
+
+    def finish_requests(self, request_ids, finished_status, requests):
+        # Record the call and lock the real ordering contract: the adapter
+        # hook runs while the requests are still registered, so every
+        # targeted id must resolve in the passed request dict.
+        self.finish_calls.append((set(request_ids), finished_status))
+        self.finish_calls_unresolved = [req_id for req_id in request_ids if req_id not in requests]
+
+    def postprocess_scheduler_output(self, scheduler_output):
+        for req_id in getattr(scheduler_output, "num_scheduled_tokens", {}):
+            self.requests_with_ready_chunks.discard(req_id)
+
+
+def _make_scheduler(
+    *,
+    budget: int = BUDGET,
+    max_num_seqs: int = 128,
+    enable_chunked_prefill: bool = False,
+    receives_chunks: bool = True,
+    fail_allocation: bool = False,
+):
+    sched = OmniGenerationScheduler.__new__(OmniGenerationScheduler)
+    sched.chunk_transfer_adapter = FakeAdapter(receives_chunks=receives_chunks)
+    sched.scheduler_config = SimpleNamespace(enable_chunked_prefill=enable_chunked_prefill, async_scheduling=False)
+    sched.use_pp = False
+    sched.max_num_scheduled_tokens = budget
+    sched.max_num_running_reqs = max_num_seqs
+    sched.kv_cache_manager = FakeKV(fail_allocation=fail_allocation)
+    sched.kv_cache_config = SimpleNamespace(kv_cache_groups=[object()])
+    sched.policy = SchedulingPolicy.FCFS
+    sched.waiting = create_request_queue(sched.policy)
+    sched.skipped_waiting = create_request_queue(sched.policy)
+    sched.running = []
+    sched.requests = {}
+    sched.finished_req_ids = set()
+    sched.finished_req_ids_dict = {}
+    sched.connector = None
+    sched.ec_connector = None
+    sched.encoder_cache_manager = SimpleNamespace(get_freed_mm_hashes=lambda: [])
+    sched.needs_kv_cache_zeroing = False
+    sched.log_stats = False
+    sched.perf_metrics = None
+    sched.num_lookahead_tokens = 0
+    sched.num_waiting_for_streaming_input = 0
+    sched._retains_state_across_chunks = False
+    sched._pause_state = PauseState.UNPAUSED
+    sched._pending_finish_reqs = []
+    sched._pending_chunk_error_outputs = []
+    sched._latest_omni_connector_output = None
+    sched.input_coordinator = None
+    sched.use_v2_model_runner = False
+    sched.async_scheduling = False
+    sched.prev_step_scheduled_req_ids = set()
+    sched._last_stats_time = time.monotonic()  # make_stats() short-circuits
+
+    def _finish_requests(request_ids, finished_status):
+        # Minimal stand-in for the mixin/vLLM finish path, aligned with the
+        # real contracts that the scheduler code depends on:
+        # 1. the adapter hook runs first, while the requests are still
+        #    registered (it can still look them up);
+        # 2. the base path then skips already-finished requests and removes
+        #    the rest from the queues/registry;
+        # 3. finished IDs are recorded under each request's own client index.
+        # Resource release (KV/deferred free) is out of scope here; the real
+        # cleanup path is covered by test_omni_scheduler_finish_requests_purge.
+        sched.chunk_transfer_adapter.finish_requests(request_ids, finished_status, sched.requests)
+        finished = []
+        for req_id in set(request_ids):
+            request = sched.requests.get(req_id)
+            if request is None or request.is_finished():
+                continue
+            request.status = finished_status
+            del sched.requests[req_id]
+            sched.finished_req_ids.add(req_id)
+            sched.finished_req_ids_dict.setdefault(request.client_index, set()).add(req_id)
+            if request in sched.running:
+                sched.running.remove(request)
+            sched.waiting.remove_requests([request])
+            sched.chunk_transfer_adapter.requests_with_ready_chunks.discard(req_id)
+            finished.append(request)
+        return finished
+
+    sched.finish_requests = _finish_requests
+    sched._update_after_schedule = lambda scheduler_output: None
+    return sched
+
+
+def _make_request(request_id: str, num_tokens: int) -> Request:
+    request = Request(
+        request_id=request_id,
+        prompt_token_ids=list(range(num_tokens)),
+        sampling_params=SamplingParams(max_tokens=100000),
+        pooling_params=None,
+        arrival_time=100.0,
+        block_hasher=None,
+    )
+    request.status = RequestStatus.WAITING
+    request.client_index = 0
+    return request
+
+
+def _stage_waiting_chunk(sched, request: Request) -> None:
+    """Register a request whose full chunk has been committed by the adapter."""
+    sched.requests[request.request_id] = request
+    sched.waiting.add_request(request)
+    sched.chunk_transfer_adapter.requests_with_ready_chunks.add(request.request_id)
+
+
+def _stage_running_chunk(sched, request: Request) -> None:
+    sched.requests[request.request_id] = request
+    sched.running.append(request)
+    sched.chunk_transfer_adapter.requests_with_ready_chunks.add(request.request_id)
+
+
+def _make_runner_output():
+    return SimpleNamespace(
+        sampled_token_ids=None,
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=None,
+        multimodal_outputs=None,
+        num_nans_in_logits=0,
+        kv_connector_output=None,
+        ec_connector_output=None,
+        cudagraph_stats=None,
+        req_id_to_index={},
+    )
+
+
+class TestWaitingDefersWholeChunk:
+    @pytest.mark.parametrize("enable_chunked_prefill", [False, True])
+    def test_57th_first_chunk_deferred_intact(self, enable_chunked_prefill):
+        sched = _make_scheduler(enable_chunked_prefill=enable_chunked_prefill)
+        requests = [_make_request(f"speech-{i}", FIRST_CHUNK_TOKENS) for i in range(57)]
+        for request in requests:
+            _stage_waiting_chunk(sched, request)
+
+        output = sched.schedule()
+
+        # 56 whole chunks are scheduled; the 57th is deferred, never sliced.
+        assert len(output.num_scheduled_tokens) == 56
+        assert set(output.num_scheduled_tokens.values()) == {FIRST_CHUNK_TOKENS}
+        assert output.total_num_scheduled_tokens == 56 * FIRST_CHUNK_TOKENS
+        assert 128 not in output.num_scheduled_tokens.values()
+
+        deferred = requests[56]
+        assert deferred.request_id not in output.num_scheduled_tokens
+        # Intact data, still queued, still ready, still tracked.
+        assert len(deferred.prompt_token_ids) == FIRST_CHUNK_TOKENS
+        assert deferred.request_id in sched.requests
+        assert sched.waiting.peek_request() is deferred
+        assert deferred.request_id in sched.chunk_transfer_adapter.requests_with_ready_chunks
+        assert len(sched.running) == 56
+        # Only the scheduled chunks lose their ready marker (clear-on-schedule).
+        assert sched.chunk_transfer_adapter.requests_with_ready_chunks == {deferred.request_id}
+
+    def test_exact_fit_chunk_is_scheduled_whole(self):
+        sched = _make_scheduler(budget=FIRST_CHUNK_TOKENS)
+        request = _make_request("fit-1", FIRST_CHUNK_TOKENS)
+        _stage_waiting_chunk(sched, request)
+
+        output = sched.schedule()
+
+        assert output.num_scheduled_tokens == {request.request_id: FIRST_CHUNK_TOKENS}
+
+    def test_allocate_failure_defers_and_does_not_fall_back(self):
+        sched = _make_scheduler(fail_allocation=True)
+        request = _make_request("alloc-fail", FIRST_CHUNK_TOKENS)
+        _stage_waiting_chunk(sched, request)
+
+        output = sched.schedule()
+
+        # No fallback to the base scheduler (it does not know the chunk
+        # protocol); an empty adapter-path output is produced instead.
+        assert output.num_scheduled_tokens == {}
+        assert sched.chunk_transfer_adapter.restore_called
+        assert request.request_id in sched.requests
+        assert request.request_id in sched.chunk_transfer_adapter.requests_with_ready_chunks
+
+    def test_empty_prompt_request_is_parked_not_rejected(self):
+        # A huge stale prompt that is NOT ready must never be rejected by the
+        # oversized pre-check; an empty prompt is parked awaiting its chunk.
+        sched = _make_scheduler()
+        stale = _make_request("stale-huge", OVERSIZED_TOKENS)
+        sched.requests[stale.request_id] = stale
+        sched.waiting.add_request(stale)  # not in requests_with_ready_chunks
+
+        output = sched.schedule()
+
+        assert sched._pending_chunk_error_outputs == []
+        assert stale.request_id in sched.requests
+        assert stale.request_id not in output.num_scheduled_tokens
+
+
+class TestRunningDefersWholeChunk:
+    @pytest.mark.parametrize("enable_chunked_prefill", [True, False])
+    def test_followup_chunk_deferred_when_budget_insufficient(self, enable_chunked_prefill):
+        # Full budget 1000 fits each chunk whole, but after the filler request
+        # consumes 800 only 200 remain. With chunked prefill enabled the old
+        # guard would split the follow-up (min(400, 200)); the atomic rule
+        # must defer it intact instead.
+        sched = _make_scheduler(budget=1000, enable_chunked_prefill=enable_chunked_prefill)
+        filler = _make_request("filler-1", 800)
+        followup = _make_request("followup-1", FOLLOWUP_TOKENS)
+        _stage_running_chunk(sched, filler)
+        _stage_running_chunk(sched, followup)
+
+        output = sched.schedule()
+
+        assert output.num_scheduled_tokens == {filler.request_id: 800}
+        assert 200 not in output.num_scheduled_tokens.values()
+        assert len(followup.prompt_token_ids) == FOLLOWUP_TOKENS
+        assert followup.num_computed_tokens == 0
+        assert followup.request_id in sched.chunk_transfer_adapter.requests_with_ready_chunks
+
+    def test_consumed_running_chunk_not_rescheduled(self):
+        sched = _make_scheduler()
+        request = _make_request("consumed-1", FOLLOWUP_TOKENS)
+        request.num_computed_tokens = FOLLOWUP_TOKENS  # fully consumed
+        _stage_running_chunk(sched, request)
+
+        output = sched.schedule()
+
+        assert output.num_scheduled_tokens == {}
+        assert request in sched.running  # parked waiting for its next chunk
+
+
+class TestOversizedRejected:
+    def test_oversized_rejected_normal_request_continues(self):
+        sched = _make_scheduler()
+        oversized = _make_request("oversized-1", OVERSIZED_TOKENS)
+        oversized.resumable = True  # B2 must clear this on terminal failure
+        normal = _make_request("normal-1", FIRST_CHUNK_TOKENS)
+        _stage_waiting_chunk(sched, oversized)
+        _stage_waiting_chunk(sched, normal)
+
+        output = sched.schedule()
+
+        # The oversized chunk failed through the standard finish path with an
+        # explicit ERROR output queued; the normal chunk ran whole.
+        assert output.num_scheduled_tokens == {normal.request_id: FIRST_CHUNK_TOKENS}
+        assert oversized.request_id not in sched.requests
+        assert oversized.request_id in sched.finished_req_ids
+        assert oversized.status == RequestStatus.FINISHED_ERROR
+        assert oversized.resumable is False
+        # Exactly one batched finish call targeting only the oversized id,
+        # issued while the request was still registered.
+        assert sched.chunk_transfer_adapter.finish_calls == [({oversized.request_id}, RequestStatus.FINISHED_ERROR)]
+        assert sched.chunk_transfer_adapter.finish_calls_unresolved == []
+        # The queued terminal output carries the full error contract.
+        assert len(sched._pending_chunk_error_outputs) == 1
+        client_index, error_output = sched._pending_chunk_error_outputs[0]
+        assert client_index == 0
+        assert error_output.request_id == oversized.request_id
+        assert error_output.finish_reason == FinishReason.ERROR
+        assert error_output.new_token_ids == []
+        assert error_output.is_segment_finished is False
+        assert "65552" in error_output.stop_reason
+
+    def test_two_oversized_rejected_in_single_batched_finish_call(self):
+        sched = _make_scheduler()
+        oversized_a = _make_request("oversized-a", OVERSIZED_TOKENS)
+        oversized_b = _make_request("oversized-b", OVERSIZED_TOKENS + 32)
+        normal = _make_request("normal-1", FIRST_CHUNK_TOKENS)
+        for request in (oversized_a, oversized_b, normal):
+            _stage_waiting_chunk(sched, request)
+
+        output = sched.schedule()
+
+        # One batched finish call covering exactly the two oversized ids.
+        assert output.num_scheduled_tokens == {normal.request_id: FIRST_CHUNK_TOKENS}
+        assert len(sched.chunk_transfer_adapter.finish_calls) == 1
+        assert sched.chunk_transfer_adapter.finish_calls[0] == (
+            {oversized_a.request_id, oversized_b.request_id},
+            RequestStatus.FINISHED_ERROR,
+        )
+        assert sched.chunk_transfer_adapter.finish_calls_unresolved == []
+        assert len(sched._pending_chunk_error_outputs) == 2
+        errored_ids = {error_output.request_id for _, error_output in sched._pending_chunk_error_outputs}
+        assert errored_ids == {oversized_a.request_id, oversized_b.request_id}
+
+    def test_nonzero_client_index_routing(self):
+        sched = _make_scheduler()
+        oversized = _make_request("client-2-oversized", OVERSIZED_TOKENS)
+        oversized.client_index = 2
+        _stage_waiting_chunk(sched, oversized)
+
+        output = sched.schedule()
+
+        # Finished IDs and the queued output must follow the request's own
+        # client index, not a hardcoded one.
+        assert sched.finished_req_ids_dict == {2: {oversized.request_id}}
+        client_index, error_output = sched._pending_chunk_error_outputs[0]
+        assert client_index == 2
+        result = sched.update_from_output(output, _make_runner_output())
+        assert oversized.request_id in result[2].finished_requests
+        assert 0 not in result
+
+    @pytest.mark.parametrize("budget,chunk_tokens", [(1152, FIRST_CHUNK_TOKENS), (1000, FIRST_CHUNK_TOKENS)])
+    def test_boundary_budgets_reject_never_slice(self, budget, chunk_tokens):
+        sched = _make_scheduler(budget=budget)
+        request = _make_request("boundary-1", chunk_tokens)
+        _stage_waiting_chunk(sched, request)
+
+        output = sched.schedule()
+
+        # Never sliced to the budget remainder (1152 would look like exactly
+        # 72 frames; 1000 is not even frame-aligned).
+        assert output.num_scheduled_tokens == {}
+        assert request.request_id not in sched.requests
+        assert len(sched._pending_chunk_error_outputs) == 1
+
+    def test_zero_token_step_emits_error_output(self):
+        # Scope note: update_from_output() is invoked manually here, which
+        # proves the scheduler emits the queued error when the step output is
+        # processed -- it does not by itself prove the engine loop always
+        # reaches this call (that is exercised by engine-level e2e runs).
+        sched = _make_scheduler()
+        oversized = _make_request("lone-oversized", OVERSIZED_TOKENS)
+        _stage_waiting_chunk(sched, oversized)
+
+        output = sched.schedule()
+        assert output.num_scheduled_tokens == {}
+        assert oversized.request_id in output.finished_req_ids
+
+        result = sched.update_from_output(output, _make_runner_output())
+
+        engine_outputs = result[0]
+        assert oversized.request_id in engine_outputs.finished_requests
+        assert len(engine_outputs.outputs) == 1
+        terminal = engine_outputs.outputs[0]
+        assert terminal.request_id == oversized.request_id
+        assert terminal.new_token_ids == []
+        assert "65552" in terminal.stop_reason
+        # Queued errors are drained exactly once.
+        assert sched._pending_chunk_error_outputs == []
+
+    def test_error_emitted_exactly_once_across_two_schedules(self):
+        # Scope note: both steps here are zero-token; this checks the
+        # error-drain discipline of the queued-output list, not real
+        # in-flight batch cleanup (the real finish path is covered by
+        # test_omni_scheduler_finish_requests_purge).
+        sched = _make_scheduler()
+        oversized = _make_request("once-1", OVERSIZED_TOKENS)
+        _stage_waiting_chunk(sched, oversized)
+
+        first = sched.schedule()
+        assert len(sched._pending_chunk_error_outputs) == 1
+
+        # A second scheduling round must not re-emit or duplicate the error.
+        second = sched.schedule()
+        assert len(sched._pending_chunk_error_outputs) == 1
+        assert second.num_scheduled_tokens == {}
+
+        result = sched.update_from_output(second, _make_runner_output())
+        assert len(result[0].outputs) == 1
+        assert sched._pending_chunk_error_outputs == []
+        result_again = sched.update_from_output(first, _make_runner_output())
+        # The drained error is not re-emitted; an empty result may not even
+        # carry an entry for the client.
+        assert not result_again.get(0) or result_again[0].outputs == []
+
+
+class TestNonChunkBehaviorUnchanged:
+    @pytest.mark.parametrize("enable_chunked_prefill", [True, False])
+    def test_sender_only_adapter_waiting_still_clips(self, enable_chunked_prefill):
+        # Narrow-vs-wide guard: for a plain waiting input with the switch
+        # DISABLED, the wide version (atomic OR not enable_chunked_prefill)
+        # would defer the request; the narrow version must keep the legacy
+        # clip in BOTH switch states. This case is what distinguishes the
+        # two designs, so it is asserted for both.
+        sched = _make_scheduler(budget=128, enable_chunked_prefill=enable_chunked_prefill, receives_chunks=False)
+        request = _make_request("plain-1", 400)
+        sched.requests[request.request_id] = request
+        sched.waiting.add_request(request)
+
+        output = sched.schedule()
+
+        assert output.num_scheduled_tokens == {request.request_id: 128}
+
+    def test_sender_only_adapter_oversized_never_rejected(self):
+        sched = _make_scheduler(budget=BUDGET, enable_chunked_prefill=True, receives_chunks=False)
+        request = _make_request("plain-huge", OVERSIZED_TOKENS)
+        sched.requests[request.request_id] = request
+        sched.waiting.add_request(request)
+
+        output = sched.schedule()
+
+        assert sched._pending_chunk_error_outputs == []
+        assert output.num_scheduled_tokens == {request.request_id: BUDGET}
+
+    def test_plain_running_split_kept_when_chunked_prefill_enabled(self):
+        sched = _make_scheduler(budget=128, enable_chunked_prefill=True, receives_chunks=False)
+        request = _make_request("plain-run-1", FOLLOWUP_TOKENS)
+        sched.requests[request.request_id] = request
+        sched.running.append(request)
+
+        output = sched.schedule()
+
+        assert output.num_scheduled_tokens == {request.request_id: 128}
+
+    def test_plain_running_deferred_when_chunked_prefill_disabled(self):
+        sched = _make_scheduler(budget=128, enable_chunked_prefill=False, receives_chunks=False)
+        request = _make_request("plain-run-2", FOLLOWUP_TOKENS)
+        sched.requests[request.request_id] = request
+        sched.running.append(request)
+
+        output = sched.schedule()
+
+        assert output.num_scheduled_tokens == {}

--- a/tests/engine/test_orchestrator.py
+++ b/tests/engine/test_orchestrator.py
@@ -324,13 +324,33 @@ def _engine_core_outputs(tag: str, timestamp: float) -> SimpleNamespace:
     return SimpleNamespace(outputs=[tag], timestamp=timestamp, scheduler_stats=None, finished_requests=None)
 
 
-def _terminal_engine_core_outputs(request_id: str) -> EngineCoreOutputs:
+def _terminal_engine_core_outputs(
+    request_id: str,
+    *,
+    finish_reason: FinishReason = FinishReason.STOP,
+) -> EngineCoreOutputs:
     return EngineCoreOutputs(
         outputs=[
             EngineCoreOutput(
                 request_id=request_id,
                 new_token_ids=[],
-                finish_reason=FinishReason.STOP,
+                finish_reason=finish_reason,
+            )
+        ],
+        timestamp=1.0,
+        finished_requests={request_id},
+    )
+
+
+def _error_engine_core_outputs(request_id: str, reason: str) -> EngineCoreOutputs:
+    """Terminal ERROR output as emitted by the oversized-chunk rejection."""
+    return EngineCoreOutputs(
+        outputs=[
+            EngineCoreOutput(
+                request_id=request_id,
+                new_token_ids=[],
+                finish_reason=FinishReason.ERROR,
+                stop_reason=reason,
             )
         ],
         timestamp=1.0,
@@ -533,6 +553,7 @@ async def _enqueue_add_request(
     original_prompt,
     sampling_params_list,
     final_stage_id: int,
+    final_output_stage_ids: list[int] | None = None,
 ) -> None:
     orchestrator_fixture.request_sync_q.put_nowait(
         StageSubmissionMessage(
@@ -543,6 +564,7 @@ async def _enqueue_add_request(
             output_prompt_text=None,
             sampling_params_list=sampling_params_list,
             final_stage_id=final_stage_id,
+            final_output_stage_ids=final_output_stage_ids,
             preprocess_ms=0.0,
             request_timestamp=time.time(),
             enqueue_ts=time.perf_counter(),
@@ -947,6 +969,213 @@ async def test_async_chunk_processed_terminal_and_raw_terminal_finishes_once(orc
         assert terminal_msg.engine_outputs is processed_terminal
         assert terminal_msg.finished is True
         await _wait_for(lambda: request_id not in orchestrator_fixture.orchestrator.request_states)
+        await asyncio.sleep(0.05)
+        with pytest.raises(queue.Empty):
+            orchestrator_fixture.output_sync_q.get_nowait()
+    finally:
+        await _shutdown_orchestrator(orchestrator_fixture)
+
+
+@pytest.mark.asyncio
+async def test_async_chunk_raw_terminal_error_preserved_and_finishes_once(orchestrator_factory) -> None:
+    """An oversized-chunk ERROR terminal reaches the client as an error.
+
+    Regression for the raw-terminal fallback that used to replace
+    ``FinishReason.ERROR`` and its ``stop_reason`` with an empty successful
+    STOP output.
+    """
+    request_id = "req-stream-error-terminal"
+    reason = "async chunk requires 65552 tokens, but max_num_scheduled_tokens is 65536"
+    stage0 = FakeStageClient(stage_type="llm", final_output=False)
+    stage1 = FakeStageClient(stage_type="llm", final_output=True, final_output_type="audio")
+    orchestrator_fixture = orchestrator_factory(
+        [stage0, stage1],
+        output_processors=[FakeOutputProcessor(), FakeOutputProcessor()],
+        async_chunk=True,
+    )
+    request = FakePromptRequest(
+        request_id=request_id,
+        prompt_token_ids=[1, 2, 3, 4],
+    )
+
+    try:
+        await _enqueue_add_request(
+            orchestrator_fixture,
+            request_id=request_id,
+            prompt=request,
+            original_prompt={"prompt": "stream audio"},
+            sampling_params_list=[_sampling_params(), _sampling_params()],
+            final_stage_id=1,
+        )
+
+        await _wait_for(lambda: len(stage1.add_request_calls) == 1)
+        stage1.push_engine_core_outputs(_error_engine_core_outputs(request_id, reason))
+
+        error_msg = await _get_output_message(orchestrator_fixture)
+
+        assert error_msg.request_id == request_id
+        assert error_msg.stage_id == 1
+        assert error_msg.finished is True
+        engine_output = error_msg.engine_outputs
+        assert isinstance(engine_output, OmniRequestOutput)
+        assert engine_output.error == reason
+        assert engine_output.error_status_code == 500
+        assert engine_output.error_type == "server_error"
+        assert engine_output.finished is True
+        # Not downgraded to the empty successful STOP completion.
+        assert engine_output.outputs == []
+        await _wait_for(lambda: request_id not in orchestrator_fixture.orchestrator.request_states)
+        # abort=True cleanup reached every stage holding the request.
+        assert stage0.abort_calls == [[request_id]]
+        assert stage1.abort_calls == [[request_id]]
+        await asyncio.sleep(0.05)
+        with pytest.raises(queue.Empty):
+            orchestrator_fixture.output_sync_q.get_nowait()
+    finally:
+        await _shutdown_orchestrator(orchestrator_fixture)
+
+
+@pytest.mark.asyncio
+async def test_async_chunk_raw_terminal_error_multi_final_stage_fails_fast(orchestrator_factory) -> None:
+    """A final-stage ERROR fails fast instead of waiting for the other final stage."""
+    request_id = "req-stream-error-multi-final"
+    reason = "async chunk requires 65552 tokens, but max_num_scheduled_tokens is 65536"
+    stage0 = FakeStageClient(stage_type="llm", final_output=False)
+    stage1 = FakeStageClient(stage_type="llm", final_output=True, final_output_type="audio")
+    stage2 = FakeStageClient(stage_type="llm", final_output=True, final_output_type="audio")
+    orchestrator_fixture = orchestrator_factory(
+        [stage0, stage1, stage2],
+        output_processors=[
+            FakeOutputProcessor(),
+            FakeOutputProcessor(),
+            FakeOutputProcessor(),
+        ],
+        async_chunk=True,
+    )
+    request = FakePromptRequest(
+        request_id=request_id,
+        prompt_token_ids=[1, 2, 3, 4],
+    )
+
+    try:
+        await _enqueue_add_request(
+            orchestrator_fixture,
+            request_id=request_id,
+            prompt=request,
+            original_prompt={"prompt": "stream audio"},
+            sampling_params_list=[_sampling_params(), _sampling_params(), _sampling_params()],
+            final_stage_id=2,
+            final_output_stage_ids=[1, 2],
+        )
+
+        await _wait_for(lambda: len(stage1.add_request_calls) == 1 and len(stage2.add_request_calls) == 1)
+        # Only stage-1 terminates, with ERROR; stage-2 never finishes.
+        stage1.push_engine_core_outputs(_error_engine_core_outputs(request_id, reason))
+
+        # Without fail-fast the fallback would wait for stage-2 forever and
+        # this get would time out.
+        error_msg = await _get_output_message(orchestrator_fixture)
+
+        assert error_msg.request_id == request_id
+        assert error_msg.stage_id == 1
+        assert error_msg.finished is True
+        assert error_msg.engine_outputs.error == reason
+        assert error_msg.engine_outputs.error_status_code == 500
+        await _wait_for(lambda: request_id not in orchestrator_fixture.orchestrator.request_states)
+        # The still-running final stage was aborted with the request.
+        assert stage2.abort_calls == [[request_id]]
+        await asyncio.sleep(0.05)
+        with pytest.raises(queue.Empty):
+            orchestrator_fixture.output_sync_q.get_nowait()
+    finally:
+        await _shutdown_orchestrator(orchestrator_fixture)
+
+
+@pytest.mark.asyncio
+async def test_async_chunk_raw_terminal_length_keeps_empty_fallback(orchestrator_factory) -> None:
+    """Non-ERROR raw terminals keep the existing empty-output fallback."""
+    request_id = "req-stream-length-terminal"
+    stage0 = FakeStageClient(stage_type="llm", final_output=False)
+    stage1 = FakeStageClient(stage_type="llm", final_output=True, final_output_type="audio")
+    orchestrator_fixture = orchestrator_factory(
+        [stage0, stage1],
+        output_processors=[FakeOutputProcessor(), FakeOutputProcessor()],
+        async_chunk=True,
+    )
+    request = FakePromptRequest(
+        request_id=request_id,
+        prompt_token_ids=[1, 2, 3, 4],
+    )
+
+    try:
+        await _enqueue_add_request(
+            orchestrator_fixture,
+            request_id=request_id,
+            prompt=request,
+            original_prompt={"prompt": "stream audio"},
+            sampling_params_list=[_sampling_params(), _sampling_params()],
+            final_stage_id=1,
+        )
+
+        await _wait_for(lambda: len(stage1.add_request_calls) == 1)
+        stage1.push_engine_core_outputs(_terminal_engine_core_outputs(request_id, finish_reason=FinishReason.LENGTH))
+
+        terminal_msg = await _get_output_message(orchestrator_fixture)
+
+        assert terminal_msg.request_id == request_id
+        assert terminal_msg.stage_id == 1
+        assert terminal_msg.finished is True
+        engine_output = terminal_msg.engine_outputs
+        assert getattr(engine_output, "error", None) is None
+        assert engine_output.outputs[0].finish_reason == "stop"
+        assert engine_output.outputs[0].multimodal_output["audio"].numel() == 0
+        assert engine_output.finished is True
+        await _wait_for(lambda: request_id not in orchestrator_fixture.orchestrator.request_states)
+    finally:
+        await _shutdown_orchestrator(orchestrator_fixture)
+
+
+@pytest.mark.asyncio
+async def test_async_chunk_non_final_stage_error_fails_request(orchestrator_factory) -> None:
+    """An ERROR terminal from a non-final stage fails the whole request."""
+    request_id = "req-stream-error-stage0"
+    stage0 = FakeStageClient(stage_type="llm", final_output=False)
+    stage1 = FakeStageClient(stage_type="llm", final_output=True, final_output_type="audio")
+    orchestrator_fixture = orchestrator_factory(
+        [stage0, stage1],
+        output_processors=[FakeOutputProcessor(), FakeOutputProcessor()],
+        async_chunk=True,
+    )
+    request = FakePromptRequest(
+        request_id=request_id,
+        prompt_token_ids=[1, 2, 3, 4],
+    )
+
+    try:
+        await _enqueue_add_request(
+            orchestrator_fixture,
+            request_id=request_id,
+            prompt=request,
+            original_prompt={"prompt": "stream audio"},
+            sampling_params_list=[_sampling_params(), _sampling_params()],
+            final_stage_id=1,
+        )
+
+        await _wait_for(lambda: len(stage1.add_request_calls) == 1)
+        reason = "stage 0 blew up"
+        stage0.push_engine_core_outputs(_error_engine_core_outputs(request_id, reason))
+
+        error_msg = await _get_output_message(orchestrator_fixture)
+
+        assert error_msg.request_id == request_id
+        assert error_msg.stage_id == 0
+        assert error_msg.finished is True
+        assert error_msg.engine_outputs.error == reason
+        assert error_msg.engine_outputs.error_status_code == 500
+        assert error_msg.engine_outputs.error_type == "server_error"
+        await _wait_for(lambda: request_id not in orchestrator_fixture.orchestrator.request_states)
+        assert stage0.abort_calls == [[request_id]]
+        assert stage1.abort_calls == [[request_id]]
         await asyncio.sleep(0.05)
         with pytest.raises(queue.Empty):
             orchestrator_fixture.output_sync_q.get_nowait()

--- a/vllm_omni/core/sched/omni_generation_scheduler.py
+++ b/vllm_omni/core/sched/omni_generation_scheduler.py
@@ -39,6 +39,63 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
         self._init_omni_io_scheduling_state()
         self._retains_state_across_chunks = bool(getattr(model_config, "retains_state_across_chunks", False))
         self._pending_finish_reqs: list[Request] = []
+        self._pending_chunk_error_outputs: list[tuple[int, EngineCoreOutput]] = []
+
+    def _requires_atomic_chunk(self) -> bool:
+        adapter = self.chunk_transfer_adapter
+        return adapter is not None and adapter.receives_chunks
+
+    def _reject_oversized_ready_chunks(self) -> None:
+        if not self._requires_atomic_chunk():
+            return
+
+        adapter = self.chunk_transfer_adapter
+        assert adapter is not None  # Narrow Optional for type checking.
+        full_budget = self.max_num_scheduled_tokens
+
+        # finish_requests() mutates the queues; iterate a de-duplicated
+        # snapshot covering both waiting first chunks and running follow-ups.
+        candidates = {req.request_id: req for req in [*self.waiting, *self.running]}
+        rejected_reasons: dict[str, str] = {}
+        for req_id, request in candidates.items():
+            if req_id not in self.requests or request.is_finished():
+                continue
+            if req_id not in adapter.requests_with_ready_chunks:
+                # Only inspect chunks already handed to the scheduler thread;
+                # requests whose chunk has not arrived (or stale placeholders)
+                # are not new chunks and must not be rejected.
+                continue
+
+            # For 1-D codec inputs, _commit_received_chunk() replaces
+            # prompt_token_ids and resets num_computed_tokens to zero,
+            # so len(...) is the full chunk's scheduling length.
+            full_chunk_tokens = len(request.prompt_token_ids)
+            if full_chunk_tokens <= full_budget:
+                continue
+
+            reason = f"async chunk requires {full_chunk_tokens} tokens, but max_num_scheduled_tokens is {full_budget}"
+            logger.error("Rejecting async chunk for %s: %s", req_id, reason)
+            request.stop_reason = reason
+            rejected_reasons[req_id] = reason
+
+        if not rejected_reasons:
+            return
+
+        # Batch cleanup avoids repeatedly scanning queues for many bad requests.
+        # Keep the existing finish path: it reconciles queue status and handles
+        # connector cleanup, finished IDs and deferred KV-block release.
+        finished = self.finish_requests(set(rejected_reasons), RequestStatus.FINISHED_ERROR)
+        for finished_request in finished:
+            # This is a terminal request error, not a resumable segment boundary.
+            finished_request.resumable = False
+            error_output = self._make_omni_engine_output(
+                finished_request,
+                new_token_ids=[],
+                finish_reason=finished_request.get_finished_reason(),
+                stop_reason=rejected_reasons[finished_request.request_id],
+                is_segment_finished=False,
+            )
+            self._pending_chunk_error_outputs.append((finished_request.client_index, error_output))
 
     @staticmethod
     def _record_prefill_stats(request: Request) -> None:
@@ -104,6 +161,7 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
         self._drop_aborted_queued_requests()
         self._process_pending_omni_inputs(model_mode="generation")
         self._drop_aborted_queued_requests()
+        self._reject_oversized_ready_chunks()
         self._resync_streaming_input_counter()
 
         # OMNI: Track requests that are already finished (e.g., marked by connector)
@@ -121,9 +179,9 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
 
             num_computed_tokens = request.num_computed_tokens
             required_tokens = len(request.prompt_token_ids) - num_computed_tokens
-            if not self.scheduler_config.enable_chunked_prefill and required_tokens > token_budget:
-                # If chunked_prefill is disabled,
-                # we can stop the scheduling here.
+            must_take_whole = self._requires_atomic_chunk() or not self.scheduler_config.enable_chunked_prefill
+            if must_take_whole and required_tokens > token_budget:
+                # Stateful async chunks cannot be split across executions.
                 break
             # async_chunk: don't schedule placeholder tokens when no new chunk is available.
             if required_tokens <= 0:
@@ -197,6 +255,10 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
             # Allocate all input tokens for the request in one shot
             # (allocate 1 placeholder if zero)
             required_tokens = max(len(request.prompt_token_ids), 1)
+            if self._requires_atomic_chunk() and required_tokens > token_budget:
+                # Oversized chunks were rejected before entering this loop.
+                # Defer intact before allocating slots or popping the request.
+                break
             num_new_tokens = min(required_tokens, token_budget)
             new_blocks = self.kv_cache_manager.allocate_slots(
                 request,
@@ -386,6 +448,10 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
             perf_stats = self.perf_metrics.get_step_perf_stats_per_gpu(scheduler_output)
 
         outputs: dict[int, list[EngineCoreOutput]] = defaultdict(list)
+        # Emit queued terminal errors even when no model tokens were scheduled.
+        for client_index, error_output in self._pending_chunk_error_outputs:
+            outputs[client_index].append(error_output)
+        self._pending_chunk_error_outputs.clear()
         spec_decoding_stats: SpecDecodingStats | None = None
 
         failed_kv_load_req_ids = None

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -30,7 +30,7 @@ from vllm.logger import init_logger
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import RequestOutputKind, SamplingParams
-from vllm.v1.engine import EngineCoreOutputs
+from vllm.v1.engine import EngineCoreOutputs, FinishReason
 from vllm.v1.engine.exceptions import EngineDeadError
 from vllm.v1.metrics.stats import IterationStats
 
@@ -1100,16 +1100,16 @@ class Orchestrator:
         stage_id: int,
         replica_id: int,
         raw_outputs: Any,
-        raw_terminal_request_ids: set[str],
+        raw_terminal_outputs: dict[str, Any],
     ) -> list[Any]:
         """Process one raw LLM poll result; returns processed request outputs.
 
         Shared by the legacy poll loop and the event-driven dispatcher so both
         run the exact same per-output handling. Callers own the
         ``EngineDeadError`` catch, since eviction needs the replica id, and
-        supply ``raw_terminal_request_ids`` — the per-poll accumulator this
-        fills for the caller to drain through
-        ``_finish_raw_terminal_requests`` once routing is done.
+        supply ``raw_terminal_outputs`` — the per-poll accumulator this
+        fills (request id -> terminal ``EngineCoreOutput``) for the caller to
+        drain through ``_finish_raw_terminal_requests`` once routing is done.
         """
         pool = self.stage_pools[stage_id]
         await self._handle_kv_ready_raw_outputs(stage_id, raw_outputs)
@@ -1141,8 +1141,13 @@ class Orchestrator:
                 "new_prompt_len_snapshot",
                 None,
             )
-            if await self._apply_raw_terminal_stage_finish(stage_id, eco, req_state):
-                raw_terminal_request_ids.add(req_state.request_id)
+            # ERROR is request-fatal regardless of which pipeline stage
+            # produced it. Keep it separate from final-stage completion
+            # tracking so a non-final stage cannot leave the request hanging.
+            if getattr(eco, "finish_reason", None) == FinishReason.ERROR and not segment_finished:
+                raw_terminal_outputs[req_state.request_id] = eco
+            elif await self._apply_raw_terminal_stage_finish(stage_id, eco, req_state):
+                raw_terminal_outputs[req_state.request_id] = eco
         iteration_stats = IterationStats() if (self._stat_logger is not None and raw_outputs.outputs) else None
         processed = await pool.process_llm_raw_outputs(
             replica_id,
@@ -1192,7 +1197,7 @@ class Orchestrator:
                 for replica_id in pool.available_replica_ids():
                     if self._shutdown_event.is_set():
                         return
-                    raw_terminal_request_ids: set[str] = set()
+                    raw_terminal_outputs: dict[str, Any] = {}
 
                     # Shared catch so a dead replica on either poll path is
                     # evicted rather than tearing down every stage (#4285).
@@ -1214,7 +1219,7 @@ class Orchestrator:
                                 continue
 
                             processed = await self._process_llm_stage_outputs(
-                                stage_id, replica_id, raw_outputs, raw_terminal_request_ids
+                                stage_id, replica_id, raw_outputs, raw_terminal_outputs
                             )
                     except asyncio.CancelledError:
                         raise
@@ -1232,7 +1237,7 @@ class Orchestrator:
                         raise
 
                     await self._handle_processed_outputs(stage_id, replica_id, processed)
-                    await self._finish_raw_terminal_requests(stage_id, replica_id, raw_terminal_request_ids)
+                    await self._finish_raw_terminal_requests(stage_id, replica_id, raw_terminal_outputs)
                     idle = False
 
             self._orch_monitor.note_loop(idle=idle)
@@ -1441,7 +1446,7 @@ class Orchestrator:
                     )
                     raise payload
 
-                raw_terminal_request_ids: set[str] = set()
+                raw_terminal_outputs: dict[str, Any] = {}
                 try:
                     if kind == "diffusion":
                         pool = self.stage_pools[stage_id]
@@ -1452,7 +1457,7 @@ class Orchestrator:
                         processed = [payload]
                     else:
                         processed = await self._process_llm_stage_outputs(
-                            stage_id, replica_id, payload, raw_terminal_request_ids
+                            stage_id, replica_id, payload, raw_terminal_outputs
                         )
                 except asyncio.CancelledError:
                     raise
@@ -1472,7 +1477,7 @@ class Orchestrator:
                     raise
 
                 await self._handle_processed_outputs(stage_id, replica_id, processed)
-                await self._finish_raw_terminal_requests(stage_id, replica_id, raw_terminal_request_ids)
+                await self._finish_raw_terminal_requests(stage_id, replica_id, raw_terminal_outputs)
                 # Mirrors the legacy loop, which sets idle=False only after a
                 # poll produced outputs that were routed -- an evicted replica
                 # `continue`s above without marking the tick active.
@@ -1881,16 +1886,59 @@ class Orchestrator:
         self,
         stage_id: int,
         replica_id: int,
-        request_ids: set[str],
+        raw_terminal_outputs: dict[str, Any],
     ) -> None:
         """Finish streaming requests whose raw terminal had no processed output."""
         pool = self.stage_pools[stage_id]
-        if not pool.final_output:
-            return
 
-        for request_id in request_ids:
+        for request_id, eco in raw_terminal_outputs.items():
             req_state = self.request_states.get(request_id)
             if req_state is None or self._is_duplex_session_request(req_state):
+                continue
+
+            # A raw ERROR terminal (e.g. an oversized async chunk rejection)
+            # must reach the client as an error, not as the empty successful
+            # fallback below. Fail fast -- before the all-stages rendezvous --
+            # because the raw_terminal_outputs accumulator only lives for this
+            # poll, and the rejection reason cannot survive a cross-poll wait.
+            if getattr(eco, "finish_reason", None) == FinishReason.ERROR:
+                reason = getattr(eco, "stop_reason", None) or (
+                    f"Stage-{stage_id} terminated request {request_id} with an internal error"
+                )
+                logger.warning(
+                    "[Orchestrator] req=%s stage-%s raw terminal finished with error: %s",
+                    request_id,
+                    stage_id,
+                    reason,
+                )
+                error_output = OmniRequestOutput.from_error(
+                    request_id,
+                    str(reason),
+                    status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+                    error_type="server_error",
+                )
+                await self.output_async_queue.put(
+                    OutputMessage(
+                        request_id=request_id,
+                        stage_id=stage_id,
+                        replica_id=replica_id,
+                        engine_outputs=error_output,
+                        metrics=None,
+                        finished=True,
+                        stage_submit_ts=req_state.stage_submit_ts.get(stage_id),
+                    )
+                )
+                await self._cleanup_request_ids(
+                    [request_id, *self._cfg_tracker.cleanup_parent(request_id)],
+                    abort=True,
+                )
+                continue
+
+            # Ordinary raw terminals are client completions only when they
+            # come from a configured final-output stage. ERROR terminals are
+            # handled above for every stage because they terminate the whole
+            # request rather than advance the pipeline.
+            if not pool.final_output:
                 continue
 
             final_output_stage_ids = req_state.final_output_stage_ids or {req_state.final_stage_id}


### PR DESCRIPTION
## Purpose

Related to vllm-project/vllm#44933.

Prevent connector-delivered async chunks from being clipped to the
remaining scheduling budget. In our local trace, 57 chunks of 1168 tokens
hit B=65536: 56 were scheduled whole and the last was clipped to 128
tokens (`num_scheduled_tokens` shows 56 * 1168 + 128 = 65536). The
clipped codebook-major slice still carried metadata describing the
complete first chunk, so the ICL first-chunk invariant check raised and
killed the whole stage engine.

The change defers async chunks intact in both the waiting and running
scheduling paths when the remaining budget is insufficient, and rejects
ready chunks larger than the full step budget through the standard
finish path plus an explicit ERROR output (emitted even by zero-token
steps). Non-chunk fast-path behavior is kept unchanged. Decoder
validation remains enabled.

## Test Plan

New unit tests in tests/core/sched/test_generation_scheduler_atomic_chunk.py
cover: waiting and running chunks under both chunked-prefill settings,
exact-fit boundaries, non-chunk and sender-only adapters (legacy behavior
preserved), oversized rejection (single, batched, boundary budgets),
zero-token step error emission, error-exactly-once across schedules, and
non-zero client-index routing. Full scheduler-suite regression included.

Reproduction setup (identical for the Before/After runs below): two-stage
Qwen3-TTS pipeline (talker + code2wav) with async_chunk enabled and a
precomputed ICL voice profile (310-frame reference audio, last 72 frames
shipped as the first-chunk prefix); stage-1 (code2wav)
`max_num_batched_tokens=65536`, `max_num_seqs=128`; connector chunking
`codec_chunk_frames=25`, `codec_left_context_frames=72`,
`initial_codec_chunk_frames=1`, so an ICL first chunk is
(72+1)*16 = 1168 tokens. Load: `vllm bench serve --omni --backend
openai-audio-speech` with a zh seed-tts text dataset (~74s of audio per
request), concurrency 80, 300 requests.

**vLLM Version:** v0.28.0 (editable install, paired with the vllm-omni
commit below)

**vLLM-Omni Commit:** eb11446b (branch base of
fix/atomic-async-chunk-scheduling)

## Test Result

- Before (unpatched, setup above): reproduced deterministically -- the
  stage engine died on "ValueError: Qwen3-TTS async_chunk first ICL chunk
  must include its declared reference prefix" (qwen3_tts_code2wav.py:375,
  same site as our 2026-09-10 production incident) within one second of
  the burst; 0/300 requests completed, /health 503 afterwards
- Focused unit tests: python -m pytest
  tests/core/sched/test_generation_scheduler_atomic_chunk.py -q
  -> 20 passed
- Scheduler regression: python -m pytest tests/core/sched/ -m cpu -q
  -> 182 passed
- Lint/type: ruff check + ruff format --check (0.14.10, both files) and
  the repo's mypy-3.10 pre-commit hook -> all clean
- GPU end-to-end (patched, same setup as the Before run): 300 completed /
  0 failed in 225s (peak concurrency 107); zero "first ICL chunk" and
  zero "not divisible" log signatures during traffic; /health 200 after
  the run; manual short synthesis OK.

Deterministic unit-test behavior at B=65536: 56 whole 1168-token chunks
scheduled (65408 total), the 57th preserved intact and deferred to a
later step (not promised to be globally first in the next step).
