### PR TITLE
[Bugfix] Reject incomplete cross-stage KV payloads

### DIFF
--- a/tests/distributed/omni_connectors/test_kv_flow.py
+++ b/tests/distributed/omni_connectors/test_kv_flow.py
@@ -275,8 +275,8 @@ def test_manager_extraction_tuple_layout(kv_config, mock_connector, common_const
         assert data["layer_blocks"]["value_cache"][idx].shape == expected_shape
 
 
-def test_manager_extraction_mismatched_kv_block_counts(kv_config, mock_connector, common_constants):
-    """Mismatched key/value block counts should not crash extraction."""
+def test_manager_extraction_rejects_incomplete_kv_blocks(kv_config, mock_connector, common_constants):
+    """Never send a compacted KV sequence when a requested block is unavailable."""
     block_size = common_constants["block_size"]
     num_heads = common_constants["num_heads"]
     head_dim = common_constants["head_dim"]
@@ -286,7 +286,7 @@ def test_manager_extraction_mismatched_kv_block_counts(kv_config, mock_connector
     value_blocks = torch.randn(2, block_size, num_heads, head_dim)
     kv_caches = [(key_blocks, value_blocks)]
 
-    finished_reqs = {req_id: {"block_ids": [0, 1, 2], "seq_len": 32}}
+    finished_reqs = {req_id: {"block_ids": [0, 1, 2], "seq_len": 3 * block_size}}
 
     manager = OmniKVTransferManager(kv_config)
     manager._connector = mock_connector
@@ -296,12 +296,81 @@ def test_manager_extraction_mismatched_kv_block_counts(kv_config, mock_connector
 
     full_request_id = f"omni_stage1_to_stage2_kv_cache_{req_id}"
     expected_key = f"stage1->stage2:{full_request_id}"
-    assert expected_key in mock_connector.store
+    assert expected_key not in mock_connector.store
 
-    data = _decode_stored_payload(mock_connector.store[expected_key])
-    expected_shape = (2 * block_size, num_heads, head_dim)
-    assert data["layer_blocks"]["key_cache"][0].shape == expected_shape
-    assert data["layer_blocks"]["value_cache"][0].shape == expected_shape
+
+def test_manager_extraction_ignores_unneeded_trailing_block_ids(kv_config, common_constants):
+    block_size = common_constants["block_size"]
+    num_heads = common_constants["num_heads"]
+    head_dim = common_constants["head_dim"]
+    req_id = common_constants["req_id"]
+
+    key_blocks = torch.arange(3 * block_size * num_heads * head_dim, dtype=torch.float32).reshape(
+        3, block_size, num_heads, head_dim
+    )
+    value_blocks = -key_blocks
+    manager = OmniKVTransferManager(kv_config)
+
+    data = manager._extract_kv_cache(
+        req_id,
+        block_ids=[2, 0, 99],
+        seq_len=2 * block_size,
+        kv_caches=[(key_blocks, value_blocks)],
+        block_size=block_size,
+        cache_dtype="float32",
+    )
+
+    assert data is not None
+    assert data.block_ids == [2, 0]
+    assert torch.equal(data.layer_blocks["key_cache"][0], torch.cat((key_blocks[2], key_blocks[0])))
+    assert torch.equal(data.layer_blocks["value_cache"][0], torch.cat((value_blocks[2], value_blocks[0])))
+
+
+@pytest.mark.parametrize("block_ids", [[0], [0, 2]])
+def test_manager_extraction_rejects_missing_required_block(
+    kv_config,
+    common_constants,
+    block_ids,
+):
+    block_size = common_constants["block_size"]
+    num_heads = common_constants["num_heads"]
+    head_dim = common_constants["head_dim"]
+    req_id = common_constants["req_id"]
+    key_blocks = torch.randn(2, block_size, num_heads, head_dim)
+    value_blocks = torch.randn(2, block_size, num_heads, head_dim)
+
+    data = OmniKVTransferManager(kv_config)._extract_kv_cache(
+        req_id,
+        block_ids=block_ids,
+        seq_len=2 * block_size,
+        kv_caches=[(key_blocks, value_blocks)],
+        block_size=block_size,
+        cache_dtype="float32",
+    )
+
+    assert data is None
+
+
+def test_manager_extraction_rejects_missing_layer(kv_config, common_constants):
+    block_size = common_constants["block_size"]
+    num_heads = common_constants["num_heads"]
+    head_dim = common_constants["head_dim"]
+    req_id = common_constants["req_id"]
+    valid_layer = (
+        torch.randn(1, block_size, num_heads, head_dim),
+        torch.randn(1, block_size, num_heads, head_dim),
+    )
+
+    data = OmniKVTransferManager(kv_config)._extract_kv_cache(
+        req_id,
+        block_ids=[0],
+        seq_len=block_size,
+        kv_caches=[valid_layer, "invalid-layer"],
+        block_size=block_size,
+        cache_dtype="float32",
+    )
+
+    assert data is None
 
 
 @pytest.mark.parametrize(

--- a/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py
+++ b/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py
@@ -1050,12 +1050,29 @@ class OmniKVTransferManager:
             cache_dtype: Data type of the cache
             custom_metadata: Optional custom metadata to include
 
-        Note: If key/value block counts differ, extraction uses only the overlapping
-        block range. Extra key/value blocks are ignored, so returned KV may be partial.
-
         Returns:
             KVCacheTransferData if extraction successful, None otherwise
         """
+        if block_size <= 0:
+            logger.warning("Request %s has invalid KV block size %s", req_id, block_size)
+            return None
+        if seq_len <= 0:
+            logger.warning("Request %s has invalid KV sequence length %s", req_id, seq_len)
+            return None
+
+        required_block_count = (seq_len + block_size - 1) // block_size
+        if len(block_ids) < required_block_count:
+            logger.warning(
+                "Request %s needs %s KV blocks for seq_len=%s and block_size=%s, but only %s block IDs were provided",
+                req_id,
+                required_block_count,
+                seq_len,
+                block_size,
+                len(block_ids),
+            )
+            return None
+        required_block_ids = block_ids[:required_block_count]
+
         num_layers = len(kv_caches)
         key_cache: list[torch.Tensor | None] = [None] * num_layers
         value_cache: list[torch.Tensor | None] = [None] * num_layers
@@ -1063,41 +1080,55 @@ class OmniKVTransferManager:
         for layer_idx, layer_kv in enumerate(kv_caches):
             kv_pair = normalize_layer_kv(layer_kv, req_id=req_id, layer_idx=layer_idx, block_size=block_size)
             if kv_pair is None:
-                continue
+                logger.warning(
+                    "Rejecting incomplete KV extraction for request %s: layer %s could not be normalized",
+                    req_id,
+                    layer_idx,
+                )
+                return None
             key_blocks, value_blocks = kv_pair
 
+            available_blocks = min(key_blocks.shape[0], value_blocks.shape[0])
             if key_blocks.shape[0] != value_blocks.shape[0]:
                 logger.warning(
-                    f"Layer {layer_idx} for request {req_id} has mismatched KV block counts: "
-                    f"key={key_blocks.shape[0]}, value={value_blocks.shape[0]}; using shared range"
+                    "Layer %s for request %s has mismatched KV block counts: key=%s, value=%s",
+                    layer_idx,
+                    req_id,
+                    key_blocks.shape[0],
+                    value_blocks.shape[0],
                 )
 
-            # Validate block IDs - shape: [num_blocks, block_size, n_heads, head_dim]
-            max_block = min(key_blocks.shape[0], value_blocks.shape[0]) - 1
-            valid_ids = [bid for bid in block_ids if 0 <= bid <= max_block]
-            if not valid_ids:
-                continue
+            invalid_ids = [block_id for block_id in required_block_ids if not 0 <= block_id < available_blocks]
+            if invalid_ids:
+                logger.warning(
+                    "Rejecting incomplete KV extraction for request %s: layer %s cannot provide block IDs %s "
+                    "(available blocks=%s)",
+                    req_id,
+                    layer_idx,
+                    invalid_ids,
+                    available_blocks,
+                )
+                return None
 
             # Extract and reshape: [n_blocks, block_size, n_heads, head_dim]
             # -> [seq_len, n_heads, head_dim]
-            selected_k = key_blocks[valid_ids]
-            selected_v = value_blocks[valid_ids]
+            selected_k = key_blocks[required_block_ids]
+            selected_v = value_blocks[required_block_ids]
             flat_k = selected_k.flatten(0, 1)
             flat_v = selected_v.flatten(0, 1)
-            if seq_len < flat_k.shape[0]:
-                flat_k = flat_k[:seq_len]
-                flat_v = flat_v[:seq_len]
+            flat_k = flat_k[:seq_len]
+            flat_v = flat_v[:seq_len]
 
             key_cache[layer_idx] = flat_k.detach().contiguous()
             value_cache[layer_idx] = flat_v.detach().contiguous()
 
-        if not any(k is not None for k in key_cache):
+        if not key_cache:
             return None
 
         return KVCacheTransferData(
             request_id=req_id,
             layer_blocks={"key_cache": key_cache, "value_cache": value_cache},
-            block_ids=block_ids,
+            block_ids=required_block_ids,
             metadata={
                 "block_size": block_size,
                 "num_layers": num_layers,


### PR DESCRIPTION
## Purpose

Cross-stage KV extraction previously filtered out unavailable block IDs and malformed layers, then still serialized the remaining tensors with the original `seq_len`. That compacts the logical token sequence and can make the downstream stage consume silently corrupted KV state.

This change makes extraction fail closed unless every required logical block is available in both K and V for every layer. It also trims irrelevant trailing block-table entries while preserving the order of the required non-contiguous physical blocks.

## Reproduction

Before this change, a request with `block_ids=[0, 1, 2]`, `seq_len=3 * block_size`, three key blocks, and only two value blocks still emitted a two-block payload whose metadata claimed the full sequence length.

```bash
pytest -q tests/distributed/omni_connectors/test_kv_flow.py -k manager_extraction
```

## Test Plan

- Verify normal stacked and tuple KV layouts still extract the requested token sequence.
- Verify non-contiguous physical block IDs retain logical token order.
- Reject a short block table, an out-of-range required block, mismatched K/V capacity, and a malformed layer.

## Test Result

- `ruff check` passed for both changed files.
- `ruff format --check` passed for both changed files.
- `python -m compileall` and `git diff --check` passed.
- A CPU source-level verifier executed the checked-in `normalize_layer_kv` and `_extract_kv_cache` implementations and passed all normal/incomplete cases.
- Full pytest collection was attempted on macOS without a GPU, but the local environment lacks the project vLLM runtime dependency chain (`aiohttp`; the source checkout also reports missing `vllm._C`). The added tests are L1 CPU tests and should run in project CI.

**vLLM Version:** local source checkout `b80ce9dd2` (collection incomplete; see above)

**vLLM-Omni Commit:** `12276a8a`

AI assistance: Used Codex to investigate the bug, draft the implementation and regression tests, and review the PR. I reviewed the changes and verified the core extraction behavior with CPU-only checks.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)