### PR TITLE
[Bugfix][Diffusion] Preserve explicit AR KV overrides

### DIFF
--- a/tests/diffusion/ar_diffusion/test_capability_runner.py
+++ b/tests/diffusion/ar_diffusion/test_capability_runner.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 from collections import OrderedDict
 from contextlib import contextmanager
 from types import SimpleNamespace
@@ -175,6 +176,7 @@ def make_runner(
     available_bytes: int = 1 << 28,
     step_execution: bool = False,
     gpu_memory_fraction: float = 0.1,
+    kv_config: ARDiffusionKVConfig | None = None,
 ) -> ARDiffusionModelRunner:
     runner = object.__new__(ARDiffusionModelRunner)
     runner.od_config = SimpleNamespace(
@@ -185,7 +187,7 @@ def make_runner(
     )
     runner.device = torch.device("cpu")
     runner.pipeline = pipeline
-    runner.ar_diffusion_kv_config = ARDiffusionKVConfig(
+    runner.ar_diffusion_kv_config = kv_config or ARDiffusionKVConfig(
         enable=True,
         gpu_memory_fraction=gpu_memory_fraction,
     )
@@ -291,6 +293,39 @@ def test_lingbot_like_single_branch_session_reuse_reset_and_close():
     runner.close_session("s1")
     assert "s1" not in runner._sessions
     assert pipeline.closes == ["s1"]
+
+
+def test_explicit_falsy_kv_overrides_replace_model_defaults():
+    spec = dataclasses.replace(lingbot_like_spec(), reset_at_boundary=True)
+    runner = make_runner(
+        CapablePipeline(spec),
+        kv_config=ARDiffusionKVConfig(
+            enable=True,
+            sink_chunks=0,
+            reset_at_boundary=False,
+        ),
+    )
+
+    assert runner.kv_cache is not None
+    assert runner.kv_cache.spec.sink_chunks == 0
+    assert runner.kv_cache.spec.reset_at_boundary is False
+
+
+def test_unspecified_kv_overrides_use_model_defaults():
+    spec = dataclasses.replace(lingbot_like_spec(), reset_at_boundary=True)
+    runner = make_runner(CapablePipeline(spec))
+
+    assert runner.kv_cache is not None
+    assert runner.kv_cache.spec.sink_chunks == spec.sink_frames
+    assert runner.kv_cache.spec.reset_at_boundary is spec.reset_at_boundary
+
+
+def test_explicit_zero_window_override_is_rejected():
+    with pytest.raises(ValueError, match="window_chunks must be positive"):
+        make_runner(
+            CapablePipeline(lingbot_like_spec()),
+            kv_config=ARDiffusionKVConfig(enable=True, window_chunks=0),
+        )
 
 
 def test_lingbot_like_interleaved_sessions_keep_independent_kv_partitions():

--- a/tests/diffusion/ar_diffusion/test_kv_cache.py
+++ b/tests/diffusion/ar_diffusion/test_kv_cache.py
@@ -111,6 +111,50 @@ def test_kv_config_sliding_window_property():
     assert ARDiffusionKVConfig(chunk_size=16, window_chunks=None).sliding_window is None
 
 
+def test_kv_cache_normalizes_unspecified_standalone_defaults():
+    kv = ARDiffusionKVCache(
+        ARDiffusionKVConfig(enable=True, chunk_size=BLOCK, window_chunks=2),
+        num_layers=1,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        block_size=BLOCK,
+        max_model_len=4 * BLOCK,
+        available_bytes=1 << 16,
+        kv_branches=(ARDiffusionKVBranchSpec("main", 0),),
+        session_capacity=1,
+    )
+
+    assert kv.config.sink_chunks == 0
+    assert kv.config.reset_at_boundary is False
+
+
+@pytest.mark.parametrize(
+    ("config", "error"),
+    [
+        (ARDiffusionKVConfig(enable=True, chunk_size=BLOCK, window_chunks=0), "window_chunks must be positive"),
+        (
+            ARDiffusionKVConfig(enable=True, chunk_size=BLOCK, window_chunks=2, sink_chunks=-1),
+            "sink_chunks must be non-negative",
+        ),
+    ],
+)
+def test_kv_cache_rejects_invalid_window_overrides(config, error):
+    with pytest.raises(ValueError, match=error):
+        ARDiffusionKVCache(
+            config,
+            num_layers=1,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            block_size=BLOCK,
+            max_model_len=4 * BLOCK,
+            available_bytes=1 << 16,
+            kv_branches=(ARDiffusionKVBranchSpec("main", 0),),
+            session_capacity=1,
+        )
+
+
 # --- ARDiffusionRequestAdapter ------------------------------------------------------
 
 

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/config.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/config.py
@@ -19,10 +19,12 @@ class ARDiffusionKVConfig:
     chunk_size: int = 0
     # Resident window in chunks. ``None`` means full attention (no eviction).
     window_chunks: int | None = None
-    # Protected leading chunks (attention sink); never evicted.
-    sink_chunks: int = 0
-    # Boundary reset vs. sliding replacement.
-    reset_at_boundary: bool = False
+    # Protected leading chunks (attention sink); never evicted. ``None`` uses
+    # the model capability default, while 0 explicitly disables the sink.
+    sink_chunks: int | None = None
+    # Boundary reset vs. sliding replacement. ``None`` uses the model
+    # capability default, while False explicitly selects sliding replacement.
+    reset_at_boundary: bool | None = None
     # Fraction of free device memory used to admit additional resident
     # sessions. One session is admitted whenever it fits actual free memory.
     gpu_memory_fraction: float = 0.1

--- a/vllm_omni/experimental/ar_diffusion/kv_cache/manager.py
+++ b/vllm_omni/experimental/ar_diffusion/kv_cache/manager.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import inspect
 import os
 from collections.abc import Collection, Iterable, Sequence
+from dataclasses import replace
 
 import torch
 from vllm.logger import init_logger
@@ -181,10 +182,21 @@ class ARDiffusionKVCache:
             raise ValueError("ARDiffusionKVCache built with a disabled ARDiffusionKVConfig")
         if config.window_chunks is None:
             raise ValueError("Phase 1 requires a bounded window (window_chunks)")
+        if config.window_chunks <= 0:
+            raise ValueError(f"ARDiffusionKVConfig.window_chunks must be positive, got {config.window_chunks}")
         if config.chunk_size <= 0:
             raise ValueError("ARDiffusionKVConfig.chunk_size must be set (> 0)")
         if not kv_branches:
             raise ValueError("ARDiffusionKVCache requires at least one KV branch")
+        sink_chunks = 0 if config.sink_chunks is None else config.sink_chunks
+        if sink_chunks < 0:
+            raise ValueError(f"ARDiffusionKVConfig.sink_chunks must be non-negative, got {sink_chunks}")
+        reset_at_boundary = False if config.reset_at_boundary is None else config.reset_at_boundary
+        config = replace(
+            config,
+            sink_chunks=sink_chunks,
+            reset_at_boundary=reset_at_boundary,
+        )
         if session_capacity <= 0:
             raise ValueError(f"session_capacity must be positive, got {session_capacity}")
         kv_branch_names = [kv_branch.name for kv_branch in kv_branches]
@@ -236,8 +248,8 @@ class ARDiffusionKVCache:
             sliding_window=config.window_chunks * config.chunk_size,
             chunk_size=config.chunk_size,
             window_chunks=config.window_chunks,
-            sink_chunks=config.sink_chunks,
-            reset_at_boundary=config.reset_at_boundary,
+            sink_chunks=sink_chunks,
+            reset_at_boundary=reset_at_boundary,
         )
 
         # Scratch blocks are outside KVCacheManager ownership. A non-committing
@@ -274,7 +286,7 @@ class ARDiffusionKVCache:
         )
 
         def _required_managed_blocks(capacity: int) -> int:
-            resident_per_session = config.sink_chunks + config.window_chunks
+            resident_per_session = sink_chunks + config.window_chunks
             return self.num_local_kv_branches * (capacity * resident_per_session + self.frames_per_block) + 2
 
         def _required_bytes(capacity: int) -> int:

--- a/vllm_omni/experimental/ar_diffusion/runner.py
+++ b/vllm_omni/experimental/ar_diffusion/runner.py
@@ -125,9 +125,21 @@ class ARDiffusionModelRunner(DiffusionModelRunner):
         config = dataclasses.replace(
             self.ar_diffusion_kv_config,
             chunk_size=spec.tokens_per_frame,
-            window_chunks=self.ar_diffusion_kv_config.window_chunks or spec.window_frames,
-            sink_chunks=self.ar_diffusion_kv_config.sink_chunks or spec.sink_frames,
-            reset_at_boundary=self.ar_diffusion_kv_config.reset_at_boundary or spec.reset_at_boundary,
+            window_chunks=(
+                spec.window_frames
+                if self.ar_diffusion_kv_config.window_chunks is None
+                else self.ar_diffusion_kv_config.window_chunks
+            ),
+            sink_chunks=(
+                spec.sink_frames
+                if self.ar_diffusion_kv_config.sink_chunks is None
+                else self.ar_diffusion_kv_config.sink_chunks
+            ),
+            reset_at_boundary=(
+                spec.reset_at_boundary
+                if self.ar_diffusion_kv_config.reset_at_boundary is None
+                else self.ar_diffusion_kv_config.reset_at_boundary
+            ),
         )
         self.ar_diffusion_kv_config = config
         self._ar_diffusion_capability = capability


### PR DESCRIPTION
## Purpose

AR-Diffusion merged deployment overrides with model capability defaults using boolean `or`. As a result, explicit `sink_chunks=0` and `reset_at_boundary=false` values were discarded whenever the model default enabled an attention sink or boundary reset. An explicit `window_chunks=0` was also silently replaced instead of rejected.

This change gives override fields three-state semantics: `None` inherits the model capability, while explicit `0` / `False` values are preserved. The final cache configuration is normalized before entering paging and memory-budget logic, and invalid zero-window or negative-sink values fail fast.

## Reproduction

Use a model capability with `sink_frames > 0` and `reset_at_boundary=True`, then configure:

```yaml
ar_diffusion_kv_config:
  sink_chunks: 0
  reset_at_boundary: false
```

Before this change the runner retained the model defaults; after this change the resolved paging spec contains `sink_chunks == 0` and `reset_at_boundary is False`.

```bash
pytest -q tests/diffusion/ar_diffusion/test_capability_runner.py tests/diffusion/ar_diffusion/test_kv_cache.py -k "kv_overrides or zero_window or normalizes_unspecified or rejects_invalid_window"
```

## Test Plan

- Verify omitted overrides inherit model-provided sink/reset values.
- Verify explicit `0` and `False` override truthy model defaults.
- Verify standalone cache construction normalizes omitted values to `0` / `False`.
- Verify zero window size and negative sink size fail fast.

## Test Result

- `ruff check` passed for all five changed files.
- `ruff format --check` passed for all five changed files.
- `python -m compileall` and `git diff --check` passed.
- A CPU source-level verifier executed the checked-in config class and merge semantics; inheritance and explicit falsy override cases passed.
- Full pytest collection was attempted on macOS without a GPU, but the local environment lacks the project vLLM runtime dependency chain (`aiohttp`; the source checkout also reports missing `vllm._C`). The added tests are L1 CPU tests and should run in project CI.

**vLLM Version:** local source checkout `b80ce9dd2` (collection incomplete; see above)

**vLLM-Omni Commit:** `6c3e0e0d`

AI assistance: Used Codex to investigate the configuration bug, draft the implementation and regression tests, and review the PR. I reviewed the changes and verified the merge semantics with CPU-only checks.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)