### PR TITLE
[XPU][Docker] Align XPU image and CI with vLLM v0.29.0

### DIFF
--- a/.buildkite/intel/pipeline-intel.yml
+++ b/.buildkite/intel/pipeline-intel.yml
@@ -10,7 +10,7 @@ steps:
           DOCKER_BUILDKIT: "1"
           # Buildkite will automatically replace this with the actual commit hash
           VLLM_IMAGE_TAG: "${BUILDKITE_COMMIT}"
-          VLLM_VERSION: "v0.28.0"
+          VLLM_VERSION: "v0.29.0"
         priority: 100
         timeout_in_minutes: 60
         soft_fail: false

--- a/docker/Dockerfile.xpu
+++ b/docker/Dockerfile.xpu
@@ -1,5 +1,5 @@
-# Target vLLM version: v0.29.0 (tag @ 98dff2a81d74). Keep VLLM_VERSION aligned
-# with docker/Dockerfile.ci VLLM_BASE_TAG on every rebase.
+# Target vLLM version: v0.29.0. Keep VLLM_VERSION aligned with the target vLLM
+# release on every rebase.
 #
 # This file layers vLLM-Omni on top of the published upstream XPU image, which
 # already ships a self-consistent XPU runtime (torch-xpu, oneCCL/UCX+NIXL, the

--- a/docker/Dockerfile.xpu
+++ b/docker/Dockerfile.xpu
@@ -1,5 +1,5 @@
-# Target vLLM version: v0.28.0. Keep VLLM_VERSION aligned with the target vLLM
-# release on every rebase.
+# Target vLLM version: v0.29.0 (tag @ 98dff2a81d74). Keep VLLM_VERSION aligned
+# with docker/Dockerfile.ci VLLM_BASE_TAG on every rebase.
 #
 # This file layers vLLM-Omni on top of the published upstream XPU image, which
 # already ships a self-consistent XPU runtime (torch-xpu, oneCCL/UCX+NIXL, the
@@ -18,7 +18,7 @@
 #
 # .buildkite/intel/scripts/run-xpu-test.sh automates that pull-then-build fallback.
 ARG VLLM_BASE_IMAGE=vllm/vllm-openai-xpu
-ARG VLLM_VERSION=v0.28.0
+ARG VLLM_VERSION=v0.29.0
 ARG VLLM_BASE=${VLLM_BASE_IMAGE}:${VLLM_VERSION}
 
 FROM ${VLLM_BASE} AS vllm-omni


### PR DESCRIPTION
## Summary

Bump Intel XPU Docker and CI from vLLM v0.28.0 to v0.29.0 :

- `docker/Dockerfile.xpu`: `VLLM_VERSION=v0.29.0`
- `.buildkite/intel/pipeline-intel.yml`: `VLLM_VERSION: "v0.29.0"`

## Test plan

- [x] Built `vllm-xpu:latest` from `docker/Dockerfile.xpu`
- [x] Intel XPU CI (`run-xpu-test.sh` pytest suite) passed on XPU