### PR TITLE
[Doc][NPU] Keep AllGather for MiniMax-H3 INT8 DLO

### DIFF
--- a/recipes/MiniMaxAI/MiniMax-H3-NPU.md
+++ b/recipes/MiniMaxAI/MiniMax-H3-NPU.md
@@ -252,8 +252,9 @@ throughput guarantee.
   supports the H3 native `tile` mode only.
 - RainFusion block-sparse attention and INT8 quantization are validated for
   T2VA only; use the BF16 dense configuration for FL2VA and Ref2VA.
-- Online quantization cannot be combined with distributed layerwise offload
-  while AllGather is enabled; pass `--dlo-no-use-allgather` in that case.
+- Online INT8 quantization can be combined with distributed layerwise offload
+  while AllGather is enabled. Keep AllGather enabled for SP>1; use
+  `--dlo-no-use-allgather` only when collective communication is unavailable.
 
 ## Additional resources
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Correct the MiniMax-H3 NPU recipe by removing the default recommendation to use `--dlo-no-use-allgather` with INT8 distributed layerwise offload. AllGather remains the recommended default for SP>1.

Fixes #7353.

## Test Plan

**vLLM Version:** N/A (documentation-only change)

**vLLM-Omni Commit:** `3d952d13`

- `git diff --check`

## Test Result

Documentation-only change. No runtime tests required.