### PR TITLE
[CI/Build] Align CUDA release image with vLLM 0.29

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=vllm/vllm-openai:v0.28.0
+ARG BASE_IMAGE=vllm/vllm-openai:v0.29.0
 FROM ${BASE_IMAGE}
 
 ARG COMMON_WORKDIR=/app


### PR DESCRIPTION
## Purpose

CUDA release/nightly images still inherit vLLM 0.28.0 after the vLLM 0.29 rebase (#7230). Omni imports `vllm.entrypoints.launchers.cli_args`, which is absent in 0.28.0, so the serving CLI fails before a model can load.

Update the default CUDA base to `vllm/vllm-openai:v0.29.0`, matching the source-install instructions. The release pipeline builds both architectures with this Dockerfile and does not override `BASE_IMAGE`.

Related to #7400. The merged NPU (#7433) and XPU (#7441) alignment fixes do not change this CUDA Dockerfile.

## Reproduction

The failure requires neither a GPU nor model weights. Run the CLI import in the affected AMD64 nightly:

```bash
docker run --rm --platform linux/amd64 --entrypoint python3 \
  vllm/vllm-omni:nightly-bad50980c9e2679d4fa6352b0fbb121af9dfbb40 \
  -c "import importlib, importlib.metadata; print('vllm=' + importlib.metadata.version('vllm'), flush=True); importlib.import_module('vllm_omni.entrypoints.cli.serve')"
```

## Test Plan

- Run that Python import probe in the affected nightly and in a matching vLLM 0.29.0 runtime.
- Validate real Qwen3-TTS serving on one NVIDIA L4 using `Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice`.
- Run applicable pre-commit hooks and `git diff --check`; complete the repository's full PR precheck, scoped to the one-line image change.

**Earlier L4 validation environment:** Python 3.12.3; corrected runtime: vLLM 0.29.0, PyTorch 2.13.0+cu130, Transformers 5.14.1; Omni source `d3493384cfc6c4b9ba1fc4e534e91fe588ecb4f1`.

## Test Result

The CPU probes ran in Modal containers:

```text
Affected nightly: vllm=0.28.0
ModuleNotFoundError: No module named 'vllm.entrypoints.launchers'
Exit code: 1

Corrected runtime: vllm=0.29.0
Omni serve CLI import passed
Exit code: 0
```

The corrected runtime started both Qwen3-TTS stages and completed 18 speech requests (two warmups and 16 measured requests). EOF, mixed-line-ending, trailing-whitespace, spelling, and diff checks passed.

### Full Docker build follow-up (12 September)

Built the unmodified `docker/Dockerfile.cuda` at this PR's commit `edb9a002e7d0cee9650affde8bb5c147588abd27` with Docker 29.1.3/BuildKit on a Modal Linux AMD64 CPU VM. Used a clean full checkout and the Dockerfile's default arguments and install command, without extra dependency constraints or version overrides. The build and a CPU CLI import inside the resulting container both passed:

```bash
DOCKER_BUILDKIT=1 docker build --progress=plain \
  -f docker/Dockerfile.cuda -t oss-omni:pr7445 .
docker run --rm --network none --entrypoint python3 oss-omni:pr7445 \
  -c "import importlib; importlib.import_module('vllm_omni.entrypoints.cli.serve'); print('FULL_DOCKER_BUILD_CLI_IMPORT_PASSED')"
```

The built image reports vLLM 0.29.0, Omni `0.29.0rc2.dev41+gedb9a002e`, PyTorch `2.13.0+cu130`, and Transformers 5.14.1. Both commands exited 0. No GPU or model weights were needed for this packaging/startup check.

The earlier speech tests used a separately assembled matching runtime. GPU inference was not rerun in the newly built Docker image, and ARM64 was not tested. No new unit test was added for the version string; the before/after import checks exercise the actual failure.

AI assistance: Codex investigated the mismatch, prepared the one-line patch and this description, and ran the recorded checks.
