### PR TITLE
feat(comfyui): add MiniMax H3 first and last frame inputs

### DIFF
--- a/apps/ComfyUI-vLLM-Omni/README.md
+++ b/apps/ComfyUI-vLLM-Omni/README.md
@@ -117,11 +117,13 @@ You can configure per-stage sampling parameters for multi-stage models.
 </p>
 
 > [!TIP]
-> Connect a **frame** image for first-frame / image-to-video (e.g., Wan I2V, MiniMax-H3 FL2VA).
+> Connect **frame** for backward-compatible first-frame / image-to-video behavior. For MiniMax-H3 FL2VA,
+> connect **first_frame**, **last_frame**, or both to condition the start frame, end frame, or both.
 >
 > For reference-conditioned generation (MiniMax-H3 Ref2VA), connect a **Video References** node instead.
 >
-> Do not use `frame` and `references` together. Task routing is automatic from which inputs you connect.
+> Do not combine `frame` with `first_frame` or `last_frame`, and do not combine any frame input with
+> `references`. Task routing is automatic from which inputs you connect.
 
 ### TTS (e.g., Qwen TTS series)
 

--- a/apps/ComfyUI-vLLM-Omni/comfyui_vllm_omni/nodes.py
+++ b/apps/ComfyUI-vLLM-Omni/comfyui_vllm_omni/nodes.py
@@ -166,6 +166,8 @@ class VLLMOmniGenerateVideo(_VLLMOmniGenerateBase):
             },
             "optional": {
                 "frame": ("IMAGE",),
+                "first_frame": ("IMAGE",),
+                "last_frame": ("IMAGE",),
                 "references": ("VIDEO_REFERENCES",),
                 "sampling_params": ("SAMPLING_PARAMS",),
                 "lora": ("REMOTE_LORA",),
@@ -178,12 +180,25 @@ class VLLMOmniGenerateVideo(_VLLMOmniGenerateBase):
     FUNCTION = "generate"
 
     @classmethod
-    def VALIDATE_INPUTS(cls, url, model, frame=None, references=None, **_kwargs) -> str | Literal[True]:
+    def VALIDATE_INPUTS(
+        cls,
+        url,
+        model,
+        frame=None,
+        first_frame=None,
+        last_frame=None,
+        references=None,
+        **_kwargs,
+    ) -> str | Literal[True]:
         base = super().VALIDATE_INPUTS(url, model)
         if base is not True:
             return base
         if frame is not None and references is not None:
             return "Provide only one of frame or references, not both."
+        if frame is not None and (first_frame is not None or last_frame is not None):
+            return "Provide either frame or first_frame/last_frame, not both."
+        if references is not None and (first_frame is not None or last_frame is not None):
+            return "Provide either first_frame/last_frame or references, not both."
         return True
 
     async def generate(
@@ -197,6 +212,8 @@ class VLLMOmniGenerateVideo(_VLLMOmniGenerateBase):
         num_frames: int,
         negative_prompt: str | None = None,
         frame: torch.Tensor | None = None,
+        first_frame: torch.Tensor | None = None,
+        last_frame: torch.Tensor | None = None,
         references: dict | None = None,
         sampling_params: dict | list[dict] | None = None,
         model_params: dict | None = None,
@@ -229,6 +246,8 @@ class VLLMOmniGenerateVideo(_VLLMOmniGenerateBase):
             model=model,
             prompt=prompt,
             frame=frame,  # frame present => fl2va / Wan I2V
+            first_frame=first_frame,
+            last_frame=last_frame,
             references=references,
             width=width,
             height=height,

--- a/apps/ComfyUI-vLLM-Omni/comfyui_vllm_omni/utils/api_client.py
+++ b/apps/ComfyUI-vLLM-Omni/comfyui_vllm_omni/utils/api_client.py
@@ -267,6 +267,8 @@ class VLLMOmniClient:
         fps: int,
         negative_prompt: str | None = None,
         frame: torch.Tensor | None = None,
+        first_frame: torch.Tensor | None = None,
+        last_frame: torch.Tensor | None = None,
         references: dict | None = None,
         sampling_params: dict | None = None,
         model_params: dict | None = None,
@@ -275,6 +277,10 @@ class VLLMOmniClient:
     ) -> VideoInput:
         if frame is not None and references is not None:
             raise ValueError("Provide only one of frame or references, not both.")
+        if frame is not None and (first_frame is not None or last_frame is not None):
+            raise ValueError("Provide either frame or first_frame/last_frame, not both.")
+        if references is not None and (first_frame is not None or last_frame is not None):
+            raise ValueError("Provide either first_frame/last_frame or references, not both.")
 
         # === regular payload fields ===
         form = aiohttp.FormData()
@@ -294,12 +300,25 @@ class VLLMOmniClient:
 
         # === multimodal inputs (first-last-frames, references, etc.) ===
         input_reference_image: torch.Tensor | None = None
+        keyframe_images: list[tuple[str, torch.Tensor]] = []
         audio_reference: AudioInput | None = None
         reference_videos: list[VideoInput] = []
         video_task: str | None = None
 
         if frame is not None:
             input_reference_image = frame
+            video_task = "fl2va"
+        elif first_frame is not None or last_frame is not None:
+            frame_indices: list[int] = []
+            if first_frame is not None:
+                keyframe_images.append(("first_frame.png", first_frame))
+                frame_indices.append(0)
+            if last_frame is not None:
+                keyframe_images.append(("last_frame.png", last_frame))
+                frame_indices.append(-1)
+            if len(keyframe_images) == 1:
+                input_reference_image = keyframe_images[0][1]
+            extra_params["frame_indices"] = frame_indices
             video_task = "fl2va"
         elif references is not None:
             images = [references[k] for k in ("image_1", "image_2") if k in references and references[k] is not None]
@@ -330,13 +349,22 @@ class VLLMOmniClient:
             video_task = "t2va"
 
         if input_reference_image is not None:
-            image_filename = "image.png"  # Required for multipart form
+            image_filename = keyframe_images[0][0] if keyframe_images else "image.png"
             form.add_field(
                 "input_reference",
                 image_tensor_to_png_bytes(input_reference_image, image_filename),
                 filename=image_filename,
                 content_type="image/png",
             )
+
+        if len(keyframe_images) == 2:
+            for image_filename, image in keyframe_images:
+                form.add_field(
+                    "input_references",
+                    image_tensor_to_png_bytes(image, image_filename),
+                    filename=image_filename,
+                    content_type="image/png",
+                )
 
         if audio_reference is not None:
             form.add_field(

--- a/tests/e2e/features/comfyui/test_comfyui_integration.py
+++ b/tests/e2e/features/comfyui/test_comfyui_integration.py
@@ -78,6 +78,7 @@ class SamplingKind(str, Enum):
     TTS_DIFFUSION_SINGLE = "tts_diffusion_single"
     VIDEO_NONE = "video_none"
     VIDEO_DIFFUSION_SINGLE = "video_diffusion_single"
+    VIDEO_FL2VA = "video_fl2va"
     VIDEO_REF2VA_IMAGE_AUDIO = "video_ref2va_image_audio"
     VIDEO_REF2VA_MULTI_VIDEO = "video_ref2va_multi_video"
 
@@ -139,7 +140,7 @@ AR_LIST_SAMPLING_PARAMS = [
 
 VIDEO_MODEL_PARAMS = WanModelSpecificParams({"guidance_scale_2": 5.0, "boundary_ratio": 0.98, "flow_shift": 12.0})
 
-# Matches MiniMax-H3 recipe Ref2VA defaults (task is auto-routed by the client).
+# Matches MiniMax-H3 recipe defaults (task is auto-routed by the client).
 H3_MODEL_PARAMS = MiniMaxH3ModelSpecificParams(
     {
         "type": "minimax_h3",
@@ -394,6 +395,34 @@ def _build_mock_outputs(outputs: Iterable[OmniRequestOutput], sampling_case: Sam
                 LORA_PARAMS,
             )
             _assert_model_param_values(received_sampling_params_list[0], VIDEO_MODEL_PARAMS)
+        elif sampling_case.kind is SamplingKind.VIDEO_FL2VA:
+            assert len(received_sampling_params_list) == 1
+            assert isinstance(prompt, dict)
+            multi_modal_data = prompt.get("multi_modal_data")
+            assert isinstance(multi_modal_data, dict)
+            input_images = multi_modal_data.get("image")
+
+            if isinstance(input_images, list):
+                assert len(input_images) == 2
+                assert input_images[0].getpixel((0, 0)) == (0, 0, 0)
+                assert input_images[1].getpixel((0, 0)) == (255, 255, 255)
+                expected_frame_indices = [0, -1]
+            else:
+                assert isinstance(input_images, Image.Image)
+                pixel = input_images.getpixel((0, 0))
+                assert pixel in {(0, 0, 0), (255, 255, 255)}
+                is_first_frame = pixel == (0, 0, 0)
+                expected_frame_indices = [0] if is_first_frame else [-1]
+
+            _assert_model_param_values(
+                received_sampling_params_list[0],
+                {
+                    "flow_shift": 12.0,
+                    "task": "fl2va",
+                    "audio_flow_shift": 3.0,
+                    "frame_indices": expected_frame_indices,
+                },
+            )
         elif sampling_case.kind is SamplingKind.VIDEO_REF2VA_IMAGE_AUDIO:
             assert len(received_sampling_params_list) == 1
             assert isinstance(prompt, dict)
@@ -876,6 +905,95 @@ async def test_video_generation_node(api_server: str, model: str, image_input: b
     assert isinstance(result, tuple)
     assert len(result) == 1
     assert isinstance(result[0], VideoInput)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "server_case",
+    [
+        pytest.param(
+            ServerCase(
+                served_model="MiniMaxAI/MiniMax-H3",
+                stage_list=["diffusion"],
+                stage_configs=[{"stage_type": "diffusion", "final_output": True, "final_output_type": "video"}],
+                outputs=[_build_diffusion_video_output()],
+            ),
+            id="minimax-h3",
+        ),
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "sampling_case",
+    [pytest.param(SamplingCase(kind=SamplingKind.VIDEO_FL2VA, sampling_params=None), id="fl2va")],
+    indirect=True,
+)
+async def test_video_generation_node_minimax_h3_fl2va(api_server: str):
+    node = VLLMOmniGenerateVideo()
+    first_frame = torch.zeros((1, VIDEO_HEIGHT, VIDEO_WIDTH, 3), dtype=torch.float32)
+    last_frame = torch.ones((1, VIDEO_HEIGHT, VIDEO_WIDTH, 3), dtype=torch.float32)
+
+    for frame_inputs in (
+        {"first_frame": first_frame},
+        {"last_frame": last_frame},
+        {"first_frame": first_frame, "last_frame": last_frame},
+    ):
+        result = await node.generate(
+            url=api_server,
+            model="MiniMaxAI/MiniMax-H3",
+            prompt="A cinematic transition between the supplied keyframes.",
+            negative_prompt="",
+            width=VIDEO_WIDTH,
+            height=VIDEO_HEIGHT,
+            fps=VIDEO_FPS,
+            num_frames=VIDEO_NUM_FRAMES,
+            model_params=H3_MODEL_PARAMS,
+            **frame_inputs,
+        )
+
+        assert isinstance(result, tuple)
+        assert len(result) == 1
+        assert isinstance(result[0], VideoInput)
+
+
+def test_video_generation_node_exposes_explicit_keyframe_inputs():
+    optional_inputs = VLLMOmniGenerateVideo.INPUT_TYPES()["optional"]
+
+    assert optional_inputs["first_frame"] == ("IMAGE",)
+    assert optional_inputs["last_frame"] == ("IMAGE",)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"frame": object(), "first_frame": object()}, "frame or first_frame/last_frame"),
+        ({"frame": object(), "last_frame": object()}, "frame or first_frame/last_frame"),
+        ({"last_frame": object(), "references": {}}, "first_frame/last_frame or references"),
+    ],
+)
+async def test_video_generation_node_rejects_conflicting_frame_inputs(kwargs: dict, message: str):
+    node = VLLMOmniGenerateVideo()
+    validation_result = node.VALIDATE_INPUTS(
+        url="http://localhost:8000/v1",
+        model="MiniMaxAI/MiniMax-H3",
+        **kwargs,
+    )
+
+    assert isinstance(validation_result, str)
+    assert message in validation_result
+
+    with pytest.raises(ValueError, match=message):
+        await node.generate(
+            url="http://localhost:8000/v1",
+            model="MiniMaxAI/MiniMax-H3",
+            prompt="test",
+            width=VIDEO_WIDTH,
+            height=VIDEO_HEIGHT,
+            fps=VIDEO_FPS,
+            num_frames=VIDEO_NUM_FRAMES,
+            **kwargs,
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Part of #7380.

This PR completes NODE-01 by adding explicit `first_frame` and `last_frame` inputs to the existing ComfyUI `VLLMOmniGenerateVideo` node while preserving the legacy `frame` input behavior.

WF-02 is also part of this PR now.