### PR TITLE
[Perf][Diffusion] Enable 128-token MH-MoE tiles on Hopper and fix deterministic scatter

### DIFF
--- a/tests/diffusion/models/magi2/test_mh_moe_kernel_cuda.py
+++ b/tests/diffusion/models/magi2/test_mh_moe_kernel_cuda.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""CUDA correctness tests for the MAGI-2 multi-head MoE fused expert kernel.
+
+Covers triton_mh_moe_forward at the released MAGI-2 Preview dimensions
+(heads=12, experts=256, top_k=6, d_head=256, d_expert=1280): numerical parity
+against the small-shape PyTorch oracle, and bitwise reproducibility of the
+deterministic scatter path across launches.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.models.magi2.mh_moe import (
+    compute_topk_probs_and_indices,
+    global_sort_routes,
+    torch_mh_moe_forward,
+    triton_mh_moe_forward,
+)
+
+pytestmark = [
+    pytest.mark.core_model,
+    pytest.mark.diffusion,
+    pytest.mark.cuda,
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required"),
+]
+
+_NUM_HEADS = 12
+_NUM_EXPERTS = 256
+_TOP_K = 6
+_D_HEAD = 256
+_D_EXPERT = 1280
+_DTYPE = torch.bfloat16
+
+
+@dataclass(frozen=True)
+class _MhMoeProblem:
+    x: torch.Tensor
+    gather_ids: torch.Tensor
+    probs: torch.Tensor
+    offsets: torch.Tensor
+    w_gate: torch.Tensor
+    w_up: torch.Tensor
+    w_down: torch.Tensor
+
+
+def _make_problem(seq: int, device: torch.device, seed: int = 1234) -> _MhMoeProblem:
+    """Build production-dimension routed inputs for the fused kernel."""
+    torch.manual_seed(seed)
+    x = torch.randn(seq, _NUM_HEADS, _D_HEAD, device=device, dtype=_DTYPE)
+    w_gate = torch.randn(_NUM_HEADS * _NUM_EXPERTS, _D_HEAD, _D_EXPERT, device=device, dtype=_DTYPE) * 0.02
+    w_up = torch.randn(_NUM_HEADS * _NUM_EXPERTS, _D_HEAD, _D_EXPERT, device=device, dtype=_DTYPE) * 0.02
+    w_down = torch.randn(_NUM_HEADS * _NUM_EXPERTS, _D_EXPERT, _D_HEAD, device=device, dtype=_DTYPE) * 0.02
+    logits = torch.randn(_NUM_HEADS, seq, _NUM_EXPERTS, device=device) * 0.5
+    probs, indices = compute_topk_probs_and_indices(logits, _TOP_K)
+    probs = probs * 4.9  # released routing scale
+    gather_ids, sorted_probs, offsets = global_sort_routes(probs, indices, _NUM_EXPERTS)
+    return _MhMoeProblem(x, gather_ids, sorted_probs, offsets, w_gate, w_up, w_down)
+
+
+def test_mh_moe_production_dim_parity() -> None:
+    device = torch.device("cuda:0")
+    problem = _make_problem(1024, device)
+    reference = torch_mh_moe_forward(
+        problem.x,
+        problem.gather_ids,
+        problem.probs,
+        problem.offsets,
+        problem.w_gate,
+        problem.w_up,
+        problem.w_down,
+    )
+    for deterministic in (True, False):
+        out = triton_mh_moe_forward(
+            problem.x,
+            problem.gather_ids,
+            problem.probs,
+            problem.offsets,
+            problem.w_gate,
+            problem.w_up,
+            problem.w_down,
+            deterministic=deterministic,
+        )
+        torch.testing.assert_close(out, reference, atol=5e-2, rtol=5e-2)
+
+
+def test_mh_moe_deterministic_path_is_bitwise_reproducible() -> None:
+    device = torch.device("cuda:0")
+    problem = _make_problem(1024, device)
+    outputs = [
+        triton_mh_moe_forward(
+            problem.x,
+            problem.gather_ids,
+            problem.probs,
+            problem.offsets,
+            problem.w_gate,
+            problem.w_up,
+            problem.w_down,
+            deterministic=True,
+        )
+        for _ in range(3)
+    ]
+    torch.accelerator.synchronize()
+    for later in outputs[1:]:
+        torch.testing.assert_close(outputs[0], later, rtol=0.0, atol=0.0)

--- a/tests/diffusion/models/magi2/test_native_preview.py
+++ b/tests/diffusion/models/magi2/test_native_preview.py
@@ -273,3 +273,29 @@ def test_strict_loader_covers_all_keys_and_uses_ema_router_bias() -> None:
     torch.testing.assert_close(
         target_moe.router.expert_bias_ema, torch.full_like(target_moe.router.expert_bias_ema, 3.0)
     )
+
+
+def test_select_block_config_dispatch_by_capability(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Kernel block configs follow the device compute capability (no GPU needed)."""
+
+    from vllm_omni.diffusion.models.magi2 import mh_moe
+
+    class _Capability:
+        def __init__(self, major: int) -> None:
+            self.major = major
+
+    def set_major(major: int | None) -> None:
+        monkeypatch.setattr(
+            mh_moe.current_omni_platform,
+            "get_device_capability",
+            lambda: None if major is None else _Capability(major),
+        )
+
+    set_major(9)  # Hopper (H100 / H200): large 128-token tiles with 3 stages
+    assert mh_moe._select_block_config() == (128, 64, 32, 3, 8)
+    set_major(10)  # Blackwell: 128-token tiles at 2 stages
+    assert mh_moe._select_block_config() == (128, 64, 32, 2, 8)
+    set_major(8)  # Ada (L20X): no shared-memory budget for 128-token tiles
+    assert mh_moe._select_block_config() == (64, 64, 32, 2, 4)
+    set_major(None)
+    assert mh_moe._select_block_config() == (64, 64, 32, 2, 4)

--- a/vllm_omni/diffusion/models/magi2/mh_moe.py
+++ b/vllm_omni/diffusion/models/magi2/mh_moe.py
@@ -276,23 +276,61 @@ def _deterministic_scatter(
     gather_ids: torch.Tensor,
     expert_offsets: torch.Tensor,
 ) -> torch.Tensor:
+    """Scatter sorted expert output back to per-head token rows.
+
+    scatter_add_ accumulates duplicate destinations with atomics, so its order
+    varies between launches and breaks the deterministic=True contract.  The
+    sorted layout already groups each destination's contributions contiguously;
+    sorting by destination once and reducing the runs with a fixed-order prefix
+    scan makes the result bitwise reproducible instead.
+    """
     num_flat_experts = expert_offsets.numel() - 1
     experts_per_head = num_flat_experts // reference.shape[1]
     expert_lengths = torch.diff(expert_offsets)
     head_values = torch.arange(num_flat_experts, device=gather_ids.device) // experts_per_head
     head_ids = torch.repeat_interleave(head_values, expert_lengths)
     scatter_ids = gather_ids.long() * reference.shape[1] + head_ids.long()
+    dest_order = torch.argsort(scatter_ids, stable=True)
+    sorted_scatter_ids = scatter_ids[dest_order]
+    sorted_expert_sums = sorted_output[dest_order].float()
+    is_group_start = torch.cat(
+        (
+            torch.ones(1, dtype=torch.bool, device=gather_ids.device),
+            sorted_scatter_ids[1:] != sorted_scatter_ids[:-1],
+        )
+    )
+    group_rows = sorted_scatter_ids[is_group_start]
+    group_ends = torch.where(is_group_start)[0]
+    group_end_exclusive = torch.cat((group_ends[1:], group_ends.new_tensor([sorted_scatter_ids.numel()])))
+    # Reduce contiguous same-destination runs with a fixed-order prefix scan;
+    # a scan along the contiguous axis is the fast CUDA path.
+    prefix_transposed = torch.cumsum(sorted_expert_sums.t().contiguous(), dim=1)
+    grouped = prefix_transposed[:, group_end_exclusive - 1]
+    if grouped.shape[1] > 1:
+        grouped[:, 1:] -= prefix_transposed[:, group_end_exclusive[:-1] - 1]
     output = torch.zeros_like(reference).view(-1, reference.shape[-1])
-    output.scatter_add_(0, scatter_ids[:, None].expand_as(sorted_output), sorted_output.to(output.dtype))
+    output[group_rows] = grouped.t().to(output.dtype)
     return output.view_as(reference)
 
 
 def _select_block_config() -> tuple[int, int, int, int, int]:
-    """Return the reference kernel config, capped for pre-Blackwell GPUs."""
+    """Return the fused MH-MoE launch config.
+
+    Config is (block_t, block_dh, block_de, num_stages, num_warps).  A 128-token
+    tile needs roughly 122 KB of shared memory, so it is only used where the
+    per-block budget admits a multi-stage pipeline: Blackwell at 2 stages and
+    Hopper (H100/H200) at 3, where it about doubles expert throughput at the
+    released MAGI-2 dimensions.  Pre-Hopper parts keep the portable 64-token
+    config.
+    """
 
     capability = current_omni_platform.get_device_capability()
-    if capability is not None and capability.major >= 10:  # Blackwell
+    if capability is None:
+        return (64, 64, 32, 2, 4)
+    if capability.major >= 10:  # Blackwell
         return (128, 64, 32, 2, 8)
+    if capability.major == 9:  # Hopper (H100 / H200)
+        return (128, 64, 32, 3, 8)
     # BLOCK_T=128 needs 122,880 bytes of shared memory and is not safe on the
     # qualified L20X path.  This is the reference kernel's portable config.
     return (64, 64, 32, 2, 4)


### PR DESCRIPTION
## Purpose

Speed up the MAGI-2 Preview multi-head MoE expert kernel on H100/H200 and make its `deterministic=True` path trustworthy.

- `_select_block_config()` now selects `(128, 64, 32, 3, 8)` on Hopper (sm_90). `BLOCK_T=128` was previously capped to the portable 64-token config because of the L20X (Ada) shared-memory limit; Hopper's 228 KiB/SM budget fits a 3-stage, 8-warp pipeline that roughly doubles expert throughput. Blackwell and Ada/fallback configs are unchanged, and capability-less devices keep the portable config.
- `_deterministic_scatter()` used `scatter_add_`, whose atomic reduction order changes between launches (observed ~43% of elements differing run to run), so `MAGI2_DETERMINISTIC=1` was not actually reproducible. Replaced with a stable sort by destination plus a fixed-order fp32 prefix scan, giving bitwise-identical results across launches while staying within normal BF16 numerics of the PyTorch oracle (max abs err ~0.016, mean ~1e-3).

## Test Plan

**vLLM Version:** 0.28.0 (local dev venv)
**vLLM-Omni Commit:** bc0c9f4b (branch point on origin/main)

H200 microbenchmark (release path, CUDA-event median, in-process A/B of the old portable config `(64,64,32,2,4)` vs the new Hopper config):

| seq | baseline | new | speedup |
|-----|----------|-----|---------|
| 256 | 2.65 ms  | 2.19 ms | 1.21x |
| 1024 | 2.72 ms | 2.25 ms | 1.21x |
| 4096 | 5.06 ms | 2.48 ms | 2.04x |
| 8192 | 8.55 ms | 4.44 ms | 1.93x |

ncu on the winning config (seq 1024): memory ~52% / compute ~41% of peak; the 128-token tile removes the low-occupancy penalty that capped the 64-token path.

New tests:
- `tests/diffusion/models/magi2/test_mh_moe_kernel_cuda.py`: production-dimension parity (triton vs torch oracle, atol/rtol 5e-2, both modes) and bitwise determinism of the deterministic path across 3 launches (2 passed).
- `test_native_preview.py`: capability dispatch for sm_90 / Blackwell / Ada / capability-less.

Local pre-commit (ruff, mypy-3.10, marks, SPDX, forbidden-import and torch.cuda gates) all pass.

## Test Result

- New CUDA tests: 2 passed.
- Collectable MAGI-2 CPU tests: 39 passed.
- Note: this dev environment has a vLLM 0.28 / vLLM-Omni commit skew (`compute_layout_strides` missing in `vllm.v1.kv_cache_interface`) that blocks local collection of part of the magi2 CPU suite; CI with matched versions covers it.