### PR TITLE
[Metrics][Duplex] Opt-in per-frame timing instrumentation on the async-chunk path (#7389 item 8)

### DIFF
--- a/tests/metrics/test_duplex_frame_timing.py
+++ b/tests/metrics/test_duplex_frame_timing.py
@@ -1,0 +1,310 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+from __future__ import annotations
+
+import itertools
+import logging
+import threading
+from collections import OrderedDict, defaultdict
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_omni.metrics import duplex_frame_timing
+from vllm_omni.metrics.duplex_frame_timing import (
+    DuplexTickPacer,
+    duplex_frame_timing_enabled,
+    get_tick_pacer,
+    log_frame_timing,
+    pop_chunk_put_age_ms,
+    record_chunk_put,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+_MODULE_LOGGER = "vllm_omni.metrics.duplex_frame_timing"
+
+
+@contextmanager
+def _capture_module_logs(caplog: pytest.LogCaptureFixture, level: int = logging.INFO):
+    target = logging.getLogger(_MODULE_LOGGER)
+    target.addHandler(caplog.handler)
+    previous_level = target.level
+    previous_propagate = target.propagate
+    target.setLevel(level)
+    # caplog also listens at the root; without this the same record lands
+    # in caplog twice via propagation.
+    target.propagate = False
+    try:
+        yield
+    finally:
+        target.removeHandler(caplog.handler)
+        target.setLevel(previous_level)
+        target.propagate = previous_propagate
+
+
+def _lines(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [record.getMessage() for record in caplog.records]
+
+
+@pytest.fixture
+def timing_enabled(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VLLM_OMNI_DUPLEX_FRAME_TIMING", "1")
+    monkeypatch.setattr(duplex_frame_timing, "_put_stamps_ns", OrderedDict())
+    monkeypatch.setattr(duplex_frame_timing, "_log_sequence", itertools.count(start=1))
+
+
+def test_disabled_by_default_emits_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.delenv("VLLM_OMNI_DUPLEX_FRAME_TIMING", raising=False)
+
+    assert not duplex_frame_timing_enabled()
+    with _capture_module_logs(caplog):
+        log_frame_timing("append", session="s1", jitter_ms=1.0)
+
+    assert _lines(caplog) == []
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on", "TRUE"])
+def test_flag_accepts_truthy_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("VLLM_OMNI_DUPLEX_FRAME_TIMING", value)
+    assert duplex_frame_timing_enabled()
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "off", "no"])
+def test_flag_rejects_falsy_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("VLLM_OMNI_DUPLEX_FRAME_TIMING", value)
+    assert not duplex_frame_timing_enabled()
+
+
+def test_log_line_is_greppable_and_joinable(
+    timing_enabled: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with _capture_module_logs(caplog):
+        log_frame_timing(
+            "append",
+            session="s1",
+            epoch=3,
+            bytes=7680,
+            jitter_ms=1.25,
+            drift_ms=None,
+        )
+
+    (line,) = _lines(caplog)
+    assert line.startswith("DUPLEX_FRAME_TIMING event=append t_ns=")
+    stamp = int(line.split("t_ns=")[1].split()[0])
+    assert stamp > 0
+    assert "session=s1" in line
+    assert "epoch=3" in line
+    assert "bytes=7680" in line
+    assert "jitter_ms=1.250" in line
+    assert "drift_ms=na" in line
+
+
+def test_log_every_throttles_per_event_lines(
+    monkeypatch: pytest.MonkeyPatch,
+    timing_enabled: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("VLLM_OMNI_DUPLEX_FRAME_TIMING_LOG_EVERY", "3")
+
+    with _capture_module_logs(caplog):
+        for _ in range(7):
+            log_frame_timing("audio_emit", session="s1")
+
+    emitted = _lines(caplog)
+    assert len(emitted) == 3  # events 1, 4 and 7 survive the 1-in-3 throttle
+
+
+def test_tick_pacer_first_observation_has_no_jitter() -> None:
+    pacer = DuplexTickPacer(0.08)
+
+    jitter_s, drift_s = pacer.observe(now_ns=1_000_000_000)
+
+    assert jitter_s is None
+    assert drift_s == pytest.approx(0.0)
+
+
+def test_tick_pacer_reports_jitter_and_drift() -> None:
+    pacer = DuplexTickPacer(0.08)
+    pacer.observe(now_ns=1_000_000_000)
+
+    # 85 ms after the anchor: 5 ms late for an 80 ms tick.
+    jitter_s, drift_s = pacer.observe(now_ns=1_000_000_000 + 85_000_000)
+
+    assert jitter_s == pytest.approx(0.005)
+    assert drift_s == pytest.approx(0.005)
+
+
+def test_tick_pacer_scales_expected_interval_with_frame_count() -> None:
+    pacer = DuplexTickPacer(0.08)
+    pacer.observe(now_ns=1_000_000_000)
+
+    # A 5-frame batch is on time if it lands 400 ms after the previous emit.
+    jitter_s, drift_s = pacer.observe(now_ns=1_000_000_000 + 400_000_000, ticks=5)
+
+    assert jitter_s == pytest.approx(0.0)
+    assert drift_s == pytest.approx(0.0)
+
+
+def test_tick_pacer_reports_stream_running_ahead_of_realtime() -> None:
+    pacer = DuplexTickPacer(0.08)
+    pacer.observe(now_ns=1_000_000_000)
+
+    # 6 frames of audio delivered over 400 ms: one frame ahead of realtime,
+    # reported as negative drift (positive would mean the stream is late).
+    _, drift_s = pacer.observe(now_ns=1_000_000_000 + 400_000_000, ticks=6)
+
+    assert drift_s == pytest.approx(-0.08)
+
+
+def test_tick_pacer_reanchors_after_a_long_pause() -> None:
+    pacer = DuplexTickPacer(0.08, reanchor_s=2.0)
+    pacer.observe(now_ns=1_000_000_000)
+    pacer.observe(now_ns=1_000_000_000 + 80_000_000)
+
+    # A 4 s pause is a stream restart, not 50 dropped ticks: the anchor
+    # re-bases so the following measurements stay meaningful.
+    _, drift_s = pacer.observe(now_ns=5_000_000_000)
+    assert drift_s == pytest.approx(0.0)
+
+    jitter_s, drift_s = pacer.observe(now_ns=5_000_000_000 + 80_000_000)
+    assert jitter_s == pytest.approx(0.0)
+    assert drift_s == pytest.approx(0.0)
+
+
+def test_get_tick_pacer_reuses_stream_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(duplex_frame_timing, "_tick_pacers", OrderedDict())
+
+    first = get_tick_pacer("append", "s1", 0.08)
+    assert get_tick_pacer("append", "s1", 0.08) is first
+    assert get_tick_pacer("emit", "s1", 0.08) is not first
+    # A changed tick period invalidates the cached cadence state.
+    assert get_tick_pacer("append", "s1", 0.1) is not first
+
+
+def test_get_tick_pacer_evicts_oldest_streams(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(duplex_frame_timing, "_tick_pacers", OrderedDict())
+    monkeypatch.setattr(duplex_frame_timing, "_MAX_TRACKED_STREAMS", 2)
+
+    get_tick_pacer("append", "s1", 0.08)
+    get_tick_pacer("append", "s2", 0.08)
+    get_tick_pacer("append", "s3", 0.08)
+
+    assert ("append", "s1") not in duplex_frame_timing._tick_pacers
+    assert ("append", "s3") in duplex_frame_timing._tick_pacers
+
+
+def test_chunk_handoff_age_uses_put_stamp(timing_enabled: None) -> None:
+    record_chunk_put("r1_0_0", t_ns=1_000_000_000)
+
+    age_ms = pop_chunk_put_age_ms("r1_0_0", now_ns=1_000_000_000 + 1_500_000)
+
+    assert age_ms == pytest.approx(1.5)
+    # The stamp is consumed: a second pop cannot double-report.
+    assert pop_chunk_put_age_ms("r1_0_0") is None
+
+
+def test_chunk_handoff_age_is_none_without_a_same_process_put(
+    timing_enabled: None,
+) -> None:
+    assert pop_chunk_put_age_ms("never-put") is None
+
+
+def test_record_chunk_put_requires_the_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VLLM_OMNI_DUPLEX_FRAME_TIMING", raising=False)
+    monkeypatch.setattr(duplex_frame_timing, "_put_stamps_ns", OrderedDict())
+
+    record_chunk_put("r1_0_0")
+
+    assert pop_chunk_put_age_ms("r1_0_0") is None
+
+
+def test_connector_put_site_emits_and_stamps(
+    timing_enabled: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from vllm_omni.data_entry_keys import OmniPayloadStruct
+    from vllm_omni.distributed.omni_connectors.transfer_adapter import chunk_transfer_adapter
+
+    adapter = SimpleNamespace(
+        connector=SimpleNamespace(stage_id=1, put=lambda **_kwargs: (True, 128, {})),
+        custom_process_next_stage_input_func=lambda **_kwargs: OmniPayloadStruct(),
+        _accepts_new_token_ids=lambda _processor: False,
+        put_req_chunk=defaultdict(int),
+        ramp_chunk_count=defaultdict(int),
+        _sender_state_lock=threading.Lock(),
+        _sender_tokens={},
+        record_send_failure=lambda *_args, **_kwargs: None,
+    )
+    task = {
+        "multimodal_output": None,
+        "request": SimpleNamespace(request_id="internal-1", external_req_id="r1"),
+        "is_finished": False,
+        "is_segment_finished": False,
+    }
+
+    with _capture_module_logs(caplog):
+        chunk_transfer_adapter.OmniChunkTransferAdapter._send_single_request_for_generation(adapter, task)
+
+    (line,) = _lines(caplog)
+    assert line.startswith("DUPLEX_FRAME_TIMING event=connector_put t_ns=")
+    assert "key=r1_1_0" in line
+    assert "ok=true" in line
+    assert "bytes=128" in line
+    assert "wrap_ms=" in line
+    # The put side stamped the chunk for the same-process handoff age.
+    assert pop_chunk_put_age_ms("r1_1_0") is not None
+
+
+def test_stage1_decode_site_reports_frame_count(
+    timing_enabled: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import torch
+    from torch import nn
+
+    from vllm_omni.model_executor.models.personaplex.personaplex_code2wav import PersonaPlexCode2Wav
+
+    class _FakeStreamingMimi(nn.Module):
+        def streaming_init(self, batch_size: int) -> None:
+            pass
+
+        def decode_frame(self, codes: torch.Tensor) -> torch.Tensor:
+            return torch.zeros(codes.shape[-1] * 4, dtype=torch.float32)
+
+        def reset_streaming(self) -> None:
+            pass
+
+    mimi_config = SimpleNamespace(num_codebooks=2, sample_rate=24000, samples_per_frame=4, mimi_name=None)
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            model="/unused",
+            hf_config=SimpleNamespace(mimi_config=mimi_config, mimi_name=None),
+            duplex_max_sessions=1,
+        ),
+        device_config=SimpleNamespace(device="cpu"),
+    )
+    model = PersonaPlexCode2Wav(vllm_config=vllm_config)
+    model.mimi = _FakeStreamingMimi()
+    model._mimi_device = torch.device("cpu")
+
+    # 2 codebooks x 3 frames, flattened codebook-major.
+    codes = torch.arange(3, dtype=torch.long).repeat(2)
+
+    with _capture_module_logs(caplog):
+        model(input_ids=codes, request_ids=["req-1"])
+
+    (line,) = _lines(caplog)
+    assert line.startswith("DUPLEX_FRAME_TIMING event=stage1_decode t_ns=")
+    assert "request_id=req-1" in line
+    assert "frames=3" in line
+    assert "decode_ms=" in line

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -16,6 +16,12 @@ from vllm.v1.request import Request, RequestStatus
 from vllm.v1.utils import ConstantList
 
 from vllm_omni.data_entry_keys import MetaStruct, OmniPayloadStruct, unflatten_payload
+from vllm_omni.metrics.duplex_frame_timing import (
+    duplex_frame_timing_enabled,
+    log_frame_timing,
+    pop_chunk_put_age_ms,
+    record_chunk_put,
+)
 
 from ..adapter import construct_next_stage_streaming_input_prompt
 from ..factory import OmniConnectorFactory
@@ -479,6 +485,8 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         connector_get_key = f"{external_req_id}_{target_stage_id}_{chunk_id}"
 
         # Use timeout=0 for non-blocking poll
+        timing_on = duplex_frame_timing_enabled()
+        get_t0 = time.perf_counter() if timing_on else 0.0
         try:
             result = self.connector.get(
                 str(target_stage_id),
@@ -497,6 +505,16 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
                 if self._registered_load_entries.get(req_id) is not entry:
                     return True
             return False
+
+        if timing_on:
+            log_frame_timing(
+                "connector_get",
+                key=connector_get_key,
+                stage=stage_id,
+                bytes=int(result[1]) if isinstance(result, tuple) else 0,
+                wrap_ms=(time.perf_counter() - get_t0) * 1e3,
+                handoff_ms=pop_chunk_put_age_ms(connector_get_key),
+            )
 
         with self._receiver_state_lock:
             # cleanup_receiver() can run while connector.get() is in flight.
@@ -789,12 +807,24 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
             logger.debug("Skipping cancelled chunk for request %s before connector put", external_req_id)
             return
 
+        timing_on = duplex_frame_timing_enabled()
+        put_t0 = time.perf_counter() if timing_on else 0.0
         success, size, metadata = self.connector.put(
             from_stage=str(stage_id),
             to_stage=str(next_stage_id),
             put_key=connector_put_key,
             data=payload_data,
         )
+        if timing_on:
+            record_chunk_put(connector_put_key)
+            log_frame_timing(
+                "connector_put",
+                key=connector_put_key,
+                stage=stage_id,
+                ok=bool(success),
+                bytes=int(size or 0),
+                wrap_ms=(time.perf_counter() - put_t0) * 1e3,
+            )
 
         with self._sender_state_lock:
             if sender_token is not None:

--- a/vllm_omni/entrypoints/duplex/runtime_bridge.py
+++ b/vllm_omni/entrypoints/duplex/runtime_bridge.py
@@ -24,6 +24,11 @@ from vllm_omni.entrypoints.duplex.runtime_adapter import (
     coerce_int,
     payload_turn_id,
 )
+from vllm_omni.metrics.duplex_frame_timing import (
+    duplex_frame_timing_enabled,
+    get_tick_pacer,
+    log_frame_timing,
+)
 
 logger = init_logger(__name__)
 
@@ -745,7 +750,26 @@ class NativeRuntimeBridgeMixin:
         if request_id is not None and session.active_request_id is None:
             session.bind_request(request_id)
         context = self._runtime_data_plane_context(session)
+        timing_on = duplex_frame_timing_enabled()
         for native_result in self._serving_runtime_adapter.data_plane.project(result, context=context):
+            if timing_on and isinstance(native_result, dict):
+                duration_ms = native_result.get("audio_duration_ms")
+                if isinstance(duration_ms, (int, float)) and duration_ms > 0:
+                    period_ms = session.capabilities.chunk_period_ms or 80
+                    frames = max(1, round(duration_ms / period_ms))
+                    jitter_s, drift_s = get_tick_pacer("emit", session.session_id, period_ms / 1000).observe(
+                        ticks=frames
+                    )
+                    log_frame_timing(
+                        "audio_emit",
+                        session=session.session_id,
+                        epoch=session.epoch,
+                        request_id=request_id,
+                        frames=frames,
+                        duration_ms=duration_ms,
+                        jitter_ms=None if jitter_s is None else jitter_s * 1e3,
+                        drift_ms=drift_s * 1e3,
+                    )
             close_reason_for_result, did_emit = await self._send_one_native_duplex_event(
                 send_json,
                 native_result,

--- a/vllm_omni/entrypoints/duplex/session_runner.py
+++ b/vllm_omni/entrypoints/duplex/session_runner.py
@@ -51,6 +51,11 @@ from vllm_omni.entrypoints.duplex.websocket import (
     is_input_event,
     normalize_duplex_input_event,
 )
+from vllm_omni.metrics.duplex_frame_timing import (
+    duplex_frame_timing_enabled,
+    get_tick_pacer,
+    log_frame_timing,
+)
 
 logger = init_logger(__name__)
 
@@ -1960,6 +1965,18 @@ class DuplexSessionRunnerMixin:
                         if pcm_reservation.byte_count == 0:
                             session.release_input_bytes(raw_audio_bytes)
                         payload = pcm_reservation.payload
+                        if pcm_reservation.byte_count > 0 and duplex_frame_timing_enabled():
+                            period_ms = session.capabilities.chunk_period_ms or 1000
+                            jitter_s, drift_s = get_tick_pacer("append", session.session_id, period_ms / 1000).observe()
+                            log_frame_timing(
+                                "append",
+                                session=session.session_id,
+                                epoch=session.epoch,
+                                bytes=pcm_reservation.byte_count,
+                                period_ms=period_ms,
+                                jitter_ms=None if jitter_s is None else jitter_s * 1e3,
+                                drift_ms=drift_s * 1e3,
+                            )
                     else:
                         session.append_audio(audio, fmt=fmt, sample_rate_hz=sample_rate_hz)
                     if native_input:

--- a/vllm_omni/metrics/duplex_frame_timing.py
+++ b/vllm_omni/metrics/duplex_frame_timing.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Opt-in per-frame timing instrumentation for the duplex async-chunk path.
+
+Enabled with ``VLLM_OMNI_DUPLEX_FRAME_TIMING=1`` (off by default); per-event
+lines can be throttled with ``VLLM_OMNI_DUPLEX_FRAME_TIMING_LOG_EVERY``
+(default ``1`` = every event). Every line shares the ``DUPLEX_FRAME_TIMING``
+prefix and a ``t_ns`` stamp (``time.monotonic_ns()``), the same clock family
+the client-side duplex timeline uses, so events from the API server and the
+stage worker processes can be joined on one host and, eventually, aligned
+with the client/benchmark metrics proposed in #7242 / #7025.
+
+Measurement points — one line per frame/chunk at each site:
+
+- ``append`` (duplex session runner, API server): a tick-sized user frame was
+  framed and reserved for the engine. Reports inter-append ``jitter_ms`` and
+  input ``drift_ms`` against the tick budget.
+- ``connector_put`` (chunk transfer adapter, stage worker): chunk written
+  into the inter-stage connector; ``wrap_ms`` is the ``connector.put`` wall
+  time.
+- ``connector_get`` (chunk transfer adapter, next stage worker): chunk read
+  out of the connector; ``wrap_ms`` is the ``connector.get`` wall time and
+  ``handoff_ms`` the put→get age when both sides run in one process. Across
+  processes, join ``key`` + ``t_ns`` from the two lines offline.
+- ``stage1_decode`` (PersonaPlex Code2Wav, stage-1 worker): streaming Mimi
+  decode time for the new frames of a request.
+- ``audio_emit`` (runtime bridge, API server): an audio delta was projected
+  for the client. Reports emit ``jitter_ms`` and output ``drift_ms`` against
+  the tick budget — the server-side counterpart of the client receive
+  timeline.
+
+All hooks are no-ops when the flag is unset; none of them changes control
+flow, payload contents, or ordering.
+"""
+
+from __future__ import annotations
+
+import itertools
+import os
+import threading
+import time
+from collections import OrderedDict
+from typing import Any
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_TRUTHY_FLAGS = ("1", "true", "yes", "on")
+
+# Streams (session-scoped pacers) and connector handoff stamps come and go
+# without a close hook at these sites, so both registries are LRU-capped
+# instead of relying on explicit lifecycle plumbing from the callers.
+_MAX_TRACKED_STREAMS = 1024
+_MAX_TRACKED_HANDOFFS = 4096
+
+_log_sequence = itertools.count(start=1)
+_handoff_lock = threading.Lock()
+
+
+def duplex_frame_timing_enabled() -> bool:
+    """Whether per-frame duplex timing instrumentation is switched on."""
+    return os.environ.get("VLLM_OMNI_DUPLEX_FRAME_TIMING", "").lower() in _TRUTHY_FLAGS
+
+
+def _log_every() -> int:
+    try:
+        return max(1, int(os.environ.get("VLLM_OMNI_DUPLEX_FRAME_TIMING_LOG_EVERY", "1") or 1))
+    except ValueError:
+        return 1
+
+
+def _format_field(value: Any) -> str:
+    if value is None:
+        return "na"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, float):
+        return f"{value:.3f}"
+    return str(value)
+
+
+def log_frame_timing(event: str, /, **fields: Any) -> None:
+    """Emit one greppable structured line for a frame-timing event.
+
+    A no-op unless ``VLLM_OMNI_DUPLEX_FRAME_TIMING`` is set; subject to the
+    ``..._LOG_EVERY`` throttle otherwise.
+    """
+    if not duplex_frame_timing_enabled():
+        return
+    if (next(_log_sequence) - 1) % _log_every() != 0:
+        return
+    body = " ".join(f"{key}={_format_field(value)}" for key, value in fields.items())
+    logger.info("DUPLEX_FRAME_TIMING event=%s t_ns=%d %s", event, time.monotonic_ns(), body)
+
+
+class DuplexTickPacer:
+    """Inter-arrival jitter and drift of a periodic stream vs its budget.
+
+    ``jitter_s`` is how much each observed interval deviates from the expected
+    ``period_s * ticks``; ``drift_s`` is how far the stream has slipped from
+    its anchor (``now - anchor - ticks_since_anchor * period_s`` — the anchor
+    arrival itself is not counted, so a stream that keeps delivering one
+    period of content per period of wall time reads zero drift). Duplex
+    streams pause and resume (the user stops talking, drain tasks restart),
+    so the anchor re-bases whenever the drift exceeds ``reanchor_s`` — after
+    a gap the accumulated number is a pause artifact, not cadence
+    information.
+    """
+
+    def __init__(self, period_s: float, *, reanchor_s: float = 2.0) -> None:
+        self.period_s = float(period_s)
+        self.reanchor_s = float(reanchor_s)
+        self._last_ns: int | None = None
+        self._anchor_ns: int | None = None
+        self._ticks = 0
+
+    def observe(self, now_ns: int | None = None, *, ticks: int = 1) -> tuple[float | None, float]:
+        """Record one arrival worth ``ticks`` periods; return (jitter_s, drift_s)."""
+        now = time.monotonic_ns() if now_ns is None else now_ns
+        ticks = max(1, ticks)
+        jitter_s: float | None = None
+        if self._last_ns is not None:
+            jitter_s = (now - self._last_ns) / 1e9 - self.period_s * ticks
+        if self._anchor_ns is None:
+            self._anchor_ns = now
+            self._ticks = 0
+            drift_s = 0.0
+        else:
+            drift_s = (now - self._anchor_ns) / 1e9 - (self._ticks + ticks) * self.period_s
+            if abs(drift_s) > self.reanchor_s:
+                self._anchor_ns = now
+                self._ticks = 0
+                drift_s = 0.0
+            else:
+                self._ticks += ticks
+        self._last_ns = now
+        return jitter_s, drift_s
+
+
+_tick_pacers: OrderedDict[tuple[str, str], DuplexTickPacer] = OrderedDict()
+
+
+def get_tick_pacer(scope: str, stream_id: str, period_s: float) -> DuplexTickPacer:
+    """Return the (LRU-capped) pacer for one measured stream, e.g. an append
+    or emit cadence of a duplex session."""
+    key = (scope, str(stream_id))
+    pacer = _tick_pacers.get(key)
+    if pacer is None or pacer.period_s != float(period_s):
+        pacer = DuplexTickPacer(period_s)
+        _tick_pacers[key] = pacer
+    else:
+        _tick_pacers.move_to_end(key)
+    while len(_tick_pacers) > _MAX_TRACKED_STREAMS:
+        _tick_pacers.popitem(last=False)
+    return pacer
+
+
+_put_stamps_ns: OrderedDict[str, int] = OrderedDict()
+
+
+def record_chunk_put(key: str, t_ns: int | None = None) -> None:
+    """Stamp a connector chunk at put time so the receiving side can report
+    its handoff age when both run in the same process."""
+    if not duplex_frame_timing_enabled():
+        return
+    stamp = time.monotonic_ns() if t_ns is None else t_ns
+    with _handoff_lock:
+        _put_stamps_ns[key] = stamp
+        while len(_put_stamps_ns) > _MAX_TRACKED_HANDOFFS:
+            _put_stamps_ns.popitem(last=False)
+
+
+def pop_chunk_put_age_ms(key: str, now_ns: int | None = None) -> float | None:
+    """Consume the put stamp for ``key`` and return its age in ms, or None
+    when the matching put happened in another process (join offline via the
+    ``connector_put`` / ``connector_get`` log lines instead)."""
+    with _handoff_lock:
+        stamp = _put_stamps_ns.pop(key, None)
+    if stamp is None:
+        return None
+    now = time.monotonic_ns() if now_ns is None else now_ns
+    return (now - stamp) / 1e6

--- a/vllm_omni/model_executor/models/personaplex/personaplex_code2wav.py
+++ b/vllm_omni/model_executor/models/personaplex/personaplex_code2wav.py
@@ -28,6 +28,7 @@ part of the vLLM weights iterator (the codec owns its own checkpoint; see the
 
 from __future__ import annotations
 
+import time
 from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any
@@ -38,6 +39,7 @@ from vllm.config import VllmConfig
 from vllm.forward_context import get_forward_context, is_forward_context_available
 from vllm.logger import init_logger
 
+from vllm_omni.metrics.duplex_frame_timing import duplex_frame_timing_enabled, log_frame_timing
 from vllm_omni.model_executor.models.output_templates import OmniOutput
 
 logger = init_logger(__name__)
@@ -226,7 +228,16 @@ class PersonaPlexCode2Wav(nn.Module):
             delta_kf = self._new_code_suffix(state_id, codes_kf)
             if delta_kf.shape[1] == 0:
                 continue
+            timing_on = duplex_frame_timing_enabled()
+            decode_t0 = time.perf_counter() if timing_on else 0.0
             wav = self._decode_streaming_frames(state_id, delta_kf.to(device=device))
+            if timing_on:
+                log_frame_timing(
+                    "stage1_decode",
+                    request_id=state_id if state_id is not None else "unknown",
+                    frames=int(delta_kf.shape[1]),
+                    decode_ms=(time.perf_counter() - decode_t0) * 1e3,
+                )
             if wav.numel() > 0:
                 audios[i] = wav.to(dtype=torch.float32).reshape(-1)
 


### PR DESCRIPTION
## What

Implements **item 8 of #7389**: opt-in, per-frame timing instrumentation on
the duplex async-chunk path, replacing the RFC's Section 2 *estimates* with
measured numbers and giving W5 concrete targets to work against.

Everything is gated by `VLLM_OMNI_DUPLEX_FRAME_TIMING` (off by default;
`VLLM_OMNI_DUPLEX_FRAME_TIMING_LOG_EVERY` throttles per-event lines, default
1). When enabled, each frame/chunk emits one greppable structured log line
with a shared `DUPLEX_FRAME_TIMING` prefix and a `time.monotonic_ns()` stamp:

| event | site | process | measures |
|---|---|---|---|
| `append` | `session_runner` (frame reservation) | API server | inter-append jitter, input drift vs the tick budget |
| `connector_put` | `OmniChunkTransferAdapter` sender | stage worker | `connector.put` wrap time, bytes |
| `connector_get` | `OmniChunkTransferAdapter` receiver | stage worker | `connector.get` wrap time; put→get handoff age when both sides share a process |
| `stage1_decode` | `PersonaPlexCode2Wav.forward` | stage-1 worker | streaming Mimi decode time, new-frame count |
| `audio_emit` | `runtime_bridge` (data-plane projection) | API server | emit jitter, output drift vs the tick budget |

Clock semantics intentionally align with the client-side duplex timeline
proposed in #7242 / #7025 (monotonic clock; tick period taken from backend
capabilities, not hard-coded), so server and client numbers line up once
those land — while keeping this PR dependency-free of both, since neither is
merged yet. Cross-process events join offline via the shared keys (session
id / request id / connector chunk key) plus `t_ns`; `CLOCK_MONOTONIC` is
system-wide on a single host.

## Why the shared modules

Three of the five measurements only exist in common code: the connector hop
lives in `OmniChunkTransferAdapter` (shared by every async-chunk pipeline),
and the tick ingress/egress live in the duplex `session_runner` /
`runtime_bridge` skeleton. PersonaPlex-private files alone cannot measure
them.

The hooks are strictly read-only observation:

* off by default; when disabled each site is a single short-circuited `if`
  with no extra work
* when enabled, timing + one `logger.info` — no control-flow, payload, or
  ordering changes; no new interactions with the adapter's existing
  sender/receiver locking (the handoff stamp registry carries its own lock)
* follows the precedent of `OmniTransferMetrics` / `TRANSFER_TX_S`, which
  already live in the common transfer layer

One behavior worth calling out for reviewers: with the flag on, the
`connector_put` / `connector_get` lines also fire for non-duplex async-chunk
pipelines (e.g. offline TTS). I'd argue that is a feature (generic transport
observability), but happy to gate or rename if preferred.

The new `DuplexTickPacer` re-bases its anchor when drift exceeds 2 s, so a
user pause or drain restart does not poison subsequent jitter/drift
readings; a stream that keeps delivering one period of content per period of
wall time reads zero drift.

## Usage

```bash
VLLM_OMNI_DUPLEX_FRAME_TIMING=1 <serve command>
# then
grep DUPLEX_FRAME_TIMING server.log