### PR TITLE
[Misc] Remove dead deploy keys from personaplex.yaml

### DIFF
--- a/vllm_omni/deploy/personaplex.yaml
+++ b/vllm_omni/deploy/personaplex.yaml
@@ -25,12 +25,8 @@ connectors:
     extra:
       shm_threshold_bytes: 65536
       codec_streaming: true
-      connector_get_sleep_s: 0.01
-      connector_get_max_wait_first_chunk: 3000
-      connector_get_max_wait: 300
       # Mimi runs at 12.5 Hz (80 ms / frame). Stream a few frames per chunk.
       codec_chunk_frames: 5
-      codec_left_context_frames: 10
       # Emit only the first audio chunk early, then return to codec_chunk_frames.
       initial_codec_chunk_frames: 1
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
[Misc] Remove dead deploy keys from personaplex.yaml

Addresses the item 1 in #7389.

## Purpose

Remove four dead connector `extra` keys from `vllm_omni/deploy/personaplex.yaml` that have no reader in the PersonaPlex
path:

- `connector_get_sleep_s`
- `connector_get_max_wait_first_chunk`
- `connector_get_max_wait`
- `codec_left_context_frames`

The PersonaPlex chunk processor reads only `codec_chunk_frames` and `initial_codec_chunk_frames` from the connector config
(`vllm_omni/model_executor/stage_input_processors/personaplex.py`), and its docstring notes PersonaPlex has "no left-context / ref-code complexity". Removing the four keys has no runtime effect.

## Test Plan

Grep evidence (the removed keys are not read on the PersonaPlex path):

```bash
grep -rn "connector_get_sleep_s\|connector_get_max_wait_first_chunk\|connector_get_max_wait" --include="*.py" vllm_omni
grep -rn "codec_left_context_frames" --include="*.py" \
  vllm_omni/model_executor/models/personaplex \
  vllm_omni/model_executor/stage_input_processors/personaplex.py \
  vllm_omni/engine/duplex
```

Config merge tests that load `personaplex.yaml` and verify it merges into stage configs :

```bash
cd tests
pytest -s -v \
  model_executor/models/personaplex/duplex/test_unified_runtime.py::test_personaplex_stage_engine_args \
  model_executor/models/personaplex/duplex/test_unified_runtime.py::test_personaplex_duplex_capacity_is_propagated_to_all_model_stages
```

**vLLM Version:** 0.29.0

**vLLM-Omni Commit:** fcffc3e72679c6e14f33a48aa772435e2c6dbcbe

## Test Result

Grep results:

- `connector_get_sleep_s`: appears only in deploy YAML files; no Python file reads this key.
- `connector_get_max_wait_first_chunk`: appears only as an assert in `tests/model_executor/models/minicpmo_4_5/test_pipeline.py`, which is unrelated to PersonaPlex.
- `connector_get_max_wait`: appears in `tests/model_executor/models/minicpmo_4_5/test_pipeline.py`,
  `tests/model_executor/stage_input_processors/test_qwen3_tts_async_chunk.py`,
  and `vllm_omni/model_executor/stage_input_processors/qwen3_tts.py` (a docstring comment); all unrelated to PersonaPlex.
- `codec_left_context_frames`: read by other models' processors from their own connector configs, but not used anywhere under the PersonaPlex paths (`vllm_omni/model_executor/models/personaplex`, `vllm_omni/model_executor/stage_input_processors/personaplex.py`, `vllm_omni/engine/duplex`), so the PersonaPlex connector does not need this parameter.

Test results:

```text
3 passed, 15 warnings in 0.12s
```

- `test_personaplex_stage_engine_args[skip_tokenizer_init-True]` PASSED
- `test_personaplex_stage_engine_args[enable_prefix_caching-False]` PASSED
- `test_personaplex_duplex_capacity_is_propagated_to_all_model_stages` PASSED

The 15 warnings are pre-existing and unrelated to this change:
`torch.jit.script_method` deprecation (emitted from inside torch) and the `audioop` deprecation in `vllm_omni/entrypoints/duplex/audio.py`.