### PR TITLE
[Bugfix][MiniCPM-o 4.5] Handle superseded playback.ack, pin the APM 30s reset, scale the demo wait budget

### DIFF
--- a/examples/online_serving/minicpmo/realtime_duplex_demo.py
+++ b/examples/online_serving/minicpmo/realtime_duplex_demo.py
@@ -437,6 +437,14 @@ async def run_demo(args: argparse.Namespace) -> dict[str, object]:
     if not input_pcm16:
         raise ValueError("input WAV has no audio")
 
+    # Long inputs need proportionally longer waits: realtime pacing already
+    # spends the clip duration streaming, and burst mode leaves the server a
+    # full backlog to process after the commit. Scale with the clip unless
+    # the operator pinned a timeout explicitly.
+    timeout_s = args.timeout_s
+    if timeout_s is None:
+        timeout_s = max(60.0, 45.0 + 1.5 * _pcm16_wav_duration_s(Path(input_wav)))
+
     collector = _StreamingEventCollector(stream_writer)
     client = DuplexClient(
         args.url,
@@ -448,7 +456,7 @@ async def run_demo(args: argparse.Namespace) -> dict[str, object]:
         session_id=args.session_id,
         reconnect=None,
         heartbeat_interval_s=None,
-        handshake_timeout_s=args.timeout_s,
+        handshake_timeout_s=timeout_s,
     )
     async with client:
         consume_task = asyncio.create_task(collector.consume(client))
@@ -477,7 +485,7 @@ async def run_demo(args: argparse.Namespace) -> dict[str, object]:
         try:
             await wait_for_condition(
                 lambda: _input_committed_index(collector.events, commit_event_cursor) is not None,
-                timeout_s=args.timeout_s,
+                timeout_s=timeout_s,
                 label="input_audio_buffer.committed",
             )
             committed_index = _input_committed_index(collector.events, commit_event_cursor)
@@ -488,7 +496,7 @@ async def run_demo(args: argparse.Namespace) -> dict[str, object]:
             if wait_for_post_commit_decision:
                 await wait_for_condition(
                     lambda: _post_commit_model_decision(collector.events, committed_index) is not None,
-                    timeout_s=args.timeout_s,
+                    timeout_s=timeout_s,
                     label="post-commit model decision or response drain",
                 )
                 post_commit_decision = _post_commit_model_decision(collector.events, committed_index)
@@ -496,7 +504,7 @@ async def run_demo(args: argparse.Namespace) -> dict[str, object]:
             wait_error = str(exc)
         await acknowledge_collected_playback(client, collector)
         close_error: str | None = None
-        await client.close(timeout_s=args.timeout_s)
+        await client.close(timeout_s=timeout_s)
         # close() returns when the client's reader observed session.closed;
         # the collector is a separate subscriber task, so wait for it to
         # drain before checking, or a normal close reads as a failure.
@@ -691,7 +699,17 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--output-dir", default="/tmp/minicpmo_realtime_duplex_demo")
     parser.add_argument("--chunk-ms", type=int, default=200)
-    parser.add_argument("--timeout-s", type=float, default=60.0)
+    parser.add_argument(
+        "--timeout-s",
+        type=float,
+        default=None,
+        help=(
+            "Wait budget for the handshake, input commit, post-commit model "
+            "decision, and session close. Default scales with the input clip "
+            "(max(60, 45 + 1.5 * duration_s)) so long videos do not trip the "
+            "post-commit waits; pass a value to pin it."
+        ),
+    )
     parser.add_argument(
         "--temperature",
         type=float,

--- a/tests/entrypoints/openai_api/test_duplex_handler.py
+++ b/tests/entrypoints/openai_api/test_duplex_handler.py
@@ -5341,7 +5341,7 @@ async def test_playback_ack_recovers_missing_response_history_registration():
 
 
 @pytest.mark.asyncio
-async def test_playback_ack_rejects_response_after_followup_user_commit():
+async def test_playback_ack_after_followup_user_commit_is_noop():
     handler = OmniDuplexSessionHandler(
         chat_service=FakeChatService(FakeEngineClient()),
         config_timeout_s=0.1,
@@ -5373,8 +5373,10 @@ async def test_playback_ack_rejects_response_after_followup_user_commit():
         ws.send_json,
     )
 
-    assert ws.sent_types() == ["error"]
-    assert ws.sent[0]["code"] == "playback_ack_too_late"
+    # The ack lost the race against the follow-up user commit. It is a
+    # pipelining artifact, not a client bug, so the server must not fail the
+    # session: no error event, no history mutation.
+    assert ws.sent_types() == []
     assert session.history == (
         {"role": "user", "content": "user A"},
         {"role": "user", "content": "user B"},

--- a/tests/model_executor/models/minicpmo_4_5/test_streaming_audio_cache.py
+++ b/tests/model_executor/models/minicpmo_4_5/test_streaming_audio_cache.py
@@ -13,8 +13,10 @@ from transformers.models.whisper.modeling_whisper import WhisperConfig
 
 from vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni_llm import (
     WHISPER_ATTENTION_CLASSES,
+    MiniCPMO45OmniLLMForConditionalGeneration,
     MiniCPMWhisperEncoder,
     MiniCPMWhisperEncoderLayer,
+    MultiModalProjector,
     _get_audio_cache_length,
 )
 
@@ -154,3 +156,92 @@ def test_encoder_reuses_cache_across_streaming_chunks(attn_implementation: str) 
 
     assert torch.isfinite(second.last_hidden_state).all()
     assert not torch.allclose(second.last_hidden_state, stateless.last_hidden_state)
+
+
+class _StreamingAPMHarness(nn.Module):
+    """Bind the production streaming method onto a minimal audio stack.
+
+    ``get_audio_embedding_streaming`` only touches the APM encoder, the
+    projector/pooler, and ``audio_past_key_values``; binding the unmodified
+    method onto this harness drives the exact production code path on CPU.
+    """
+
+    get_audio_embedding_streaming = MiniCPMO45OmniLLMForConditionalGeneration.get_audio_embedding_streaming
+    _get_feat_extract_output_lengths = MiniCPMO45OmniLLMForConditionalGeneration._get_feat_extract_output_lengths
+
+    def __init__(self, max_source_positions: int = 1500, pool_step: int = 5):
+        super().__init__()
+        config = WhisperConfig(
+            num_mel_bins=16,
+            d_model=32,
+            encoder_layers=2,
+            encoder_attention_heads=2,
+            encoder_ffn_dim=128,
+            max_source_positions=max_source_positions,
+            dropout=0.0,
+            attention_dropout=0.0,
+        )
+        config._attn_implementation = "sdpa"
+        self.apm = MiniCPMWhisperEncoder(config)
+        self.audio_avg_pooler = nn.AvgPool1d(pool_step, stride=pool_step)
+        self.audio_projection_layer = MultiModalProjector(in_dim=32, out_dim=32)
+        self.audio_encoder_layer = -1
+        self.audio_past_key_values = None
+        self.config = SimpleNamespace(audio_pool_step=pool_step)
+
+
+def test_streaming_audio_cache_resets_once_at_apm_position_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """47 streamed one-second units cross the 1500-position APM boundary once.
+
+    Official MiniCPM-o 4.5 (checkpoint modeling_minicpmo.py and the unified
+    duplex demo) hard-resets ``audio_past_key_values`` at the same boundary:
+    the APM's learned absolute positions cap the audio encoder at ~30s of
+    context, after which the cache rebuilds from scratch. This locks the
+    official alignment in: exactly one reset, the cache never exceeds the
+    position limit, and every post-reset chunk still yields the expected
+    finite embeddings.
+    """
+    torch.manual_seed(0)
+    model = _StreamingAPMHarness().eval()
+    reset_warnings: list[str] = []
+    monkeypatch.setattr(
+        "vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni_llm.logger.warning",
+        lambda *args, **kwargs: reset_warnings.append(str(args)),
+    )
+
+    chunk_mel_frames = 104  # 2 prefix + 100 core + 2 suffix mel frames per 1s unit
+    per_chunk_tokens = 10  # 100 core conv frames, pool_step 5
+    num_chunks = 47  # >45s of streamed audio
+
+    cache_lengths: list[int] = []
+    with torch.no_grad():
+        for chunk_idx in range(num_chunks):
+            data = {
+                "audio_features": torch.randn(1, 16, chunk_mel_frames),
+                "audio_feature_lens": [torch.tensor([chunk_mel_frames])],
+            }
+            embeds = model.get_audio_embedding_streaming(
+                data,
+                use_extra_context=True,
+                prefix_extra_frames=0 if chunk_idx == 0 else 2,
+                suffix_extra_frames=2,
+            )
+            cache_lengths.append(_get_audio_cache_length(model.audio_past_key_values))
+
+            assert len(embeds) == 1
+            chunk = embeds[0][0]
+            assert chunk.shape[0] == per_chunk_tokens
+            assert torch.isfinite(chunk).all()
+
+    # Chunk 0 appends 51 net frames, later chunks 50 each: the boundary fires
+    # when the accumulated cache plus the incoming chunk would reach 1500
+    # (1451 + 50), i.e. once, at the ~30s mark. The cache then rebuilds from
+    # that chunk and keeps growing for the remaining ~17s.
+    assert cache_lengths[0] == 51
+    assert cache_lengths[28] == 51 + 28 * 50
+    assert cache_lengths[29] == 50
+    assert cache_lengths[-1] == 50 + (num_chunks - 30) * 50
+    assert max(cache_lengths) < 1500
+    assert len(reset_warnings) == 1

--- a/vllm_omni/entrypoints/duplex/serving.py
+++ b/vllm_omni/entrypoints/duplex/serving.py
@@ -1920,14 +1920,16 @@ class OmniDuplexSessionHandler(
                 )
                 return
             if session.playback_ack_is_too_late(response_id, item_id):
-                await send_json(
-                    {
-                        "type": "error",
-                        "session_id": session.session_id,
-                        "epoch": session.epoch,
-                        "code": "playback_ack_too_late",
-                        "error": "playback.ack arrived after a later user input was committed.",
-                    }
+                # A pipelining client computes this ack before it observes the
+                # user-input commit that supersedes the acked response, so the
+                # race is benign and unavoidable: the superseded response never
+                # entered history and the ack has nothing to update. Ignore it
+                # instead of failing the session with a protocol error.
+                logger.warning(
+                    "Ignoring superseded playback.ack for response %s in session %s "
+                    "(a later user input was committed first).",
+                    response_id,
+                    session.session_id,
                 )
                 return
             # Reserve the response's current history position before any later

--- a/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py
+++ b/vllm_omni/model_executor/models/minicpmo_4_5/minicpmo_4_5_omni_llm.py
@@ -4500,8 +4500,14 @@ class MiniCPMO45OmniLLMForConditionalGeneration(nn.Module, SupportsMultiModal, S
             cache_length = _get_audio_cache_length(self.audio_past_key_values)
             apm_max_len = self.apm.embed_positions.weight.shape[0]
             if cache_length + current_seq_len >= apm_max_len:
+                # Official MiniCPM-o 4.5 (checkpoint modeling and the unified
+                # duplex demo) resets the audio KV at the APM's absolute
+                # position limit instead of sliding it: the learned Whisper
+                # positions cannot be re-aligned the way RoPE caches can.
                 logger.warning(
-                    "audio_past_key_values length %s exceeds %s, reset.",
+                    "audio_past_key_values length %s exceeds the APM position limit %s "
+                    "(~30s of streamed audio); resetting the audio encoder cache "
+                    "to match official MiniCPM-o 4.5 streaming behavior.",
                     cache_length + current_seq_len,
                     apm_max_len,
                 )


### PR DESCRIPTION
## Purpose

Three small, independent hardening changes for MiniCPM-o 4.5 native full-duplex, from investigating #7251. Complementary to #7271 (frame-group mounting + vision budget sizing): zero file overlap, either PR can land first.

### 1. Superseded playback.ack fails the whole session (entrypoints/duplex/serving.py)

What broke: when a pipelining client sends playback.ack for a response that a later user-input commit has already superseded, the handler emits a playback_ack_too_late error event and clients treat it as a fatal protocol error (burst-mode runs report ok: false on it; see #7251 point 3).

Root cause: the client computes the ack before it can observe the superseding commit — a benign, unavoidable pipelining race. The superseded response never entered history, so the ack has nothing to update. The in-repo omniinteract benchmark already tolerates this error code for exactly this reason.

Fix: log a warning and ignore the ack (no error event, no history mutation). The handler test is updated from "sends error" to "sends nothing".

### 2. Pin the official 30 s APM audio-KV reset (test + log wording)

#7251 point 2 reported the 1500-position audio_past_key_values reset as a leak. It is official parity: the checkpoint's modeling_minicpmo.py and the official unified duplex demo hard-reset at the same boundary (the APM's learned absolute Whisper positions cannot be re-aligned the way RoPE caches can). No behavior change — the reset log now states the semantics instead of reading like a leak, and a new regression test streams 47 one-second units through the production get_audio_embedding_streaming and asserts exactly one reset at the boundary, the cache never exceeding the limit, and finite embeddings after the reset.

### 3. Duplex demo wait budget does not scale with input length (realtime_duplex_demo.py)

The fixed 60 s default covered the ~35 s demo clip but timed out the post-commit waits on longer videos: realtime pacing already spends the clip duration streaming, and burst mode leaves the server a full backlog to process after the commit. Repro on main: python examples/online_serving/minicpmo/realtime_duplex_demo.py --url ... --input-wav <60s+ clip> --input-video <matching mp4> --ref-audio ... → post-commit wait aborts around 60 s. Default is now max(60, 45 + 1.5 * duration_s) unless --timeout-s is pinned.

## Test Plan

New/updated tests: `pytest tests/model_executor/models/minicpmo_4_5/test_streaming_audio_cache.py tests/entrypoints/openai_api/test_duplex_handler.py`
Full local suites:
`pytest tests/model_executor/models/minicpmo_4_5/duplex/ tests/engine/duplex/test_duplex_runtime.py` → 46 passed
`pytest tests/entrypoints/openai_api/test_duplex_handler.py tests/benchmarks/test_omniinteract.py tests/model_executor/models/minicpmo_4_5/test_streaming_audio_cache.py` → 326 passed
End-to-end: RTX 4090 24 GB, AWQ checkpoint, 64 s duplex audio+video case (--stack-frames 2): ok: true, no errors, video_frames_sent = 63/64 (exact: the 64th frame needs audio ≥ 64030 ms, the wav is 64000 ms), exactly two APM resets (30 s / 60 s boundaries), no residual frame backlog at commit. Verified on both the 0.28 and 0.29 stacks.
vLLM Version: 0.28.0 / 0.29.0 (torch 2.13.0+cu130)

vLLM-Omni Commit: based on 7e520f9cc (#7018)

## Test Result

46 passed, 16 warnings in 0.91s and 326 passed, 18 warnings in 15.60s locally on this branch. test_playback_ack_after_followup_user_commit_is_noop fails on main (main sends the error event) and passes here; test_streaming_audio_cache_resets_once_at_apm_position_limit pins current main behavior unchanged.

Refs #7251.

