### PR TITLE
[bugfix] Fix FP8 Quack kernels when using Context Parallelism and reduce number of recompilations

### DIFF
--- a/docs/user_guide/quantization/fp8.md
+++ b/docs/user_guide/quantization/fp8.md
@@ -57,47 +57,20 @@ keeps the unfused FlashInfer path.
 
 #### Compile cache and warmup
 
-quack has two caches: compiled kernels (`.o`) and autotuning results
-(`.autotune.json`). Kernel compilation is cached by layout, dtype, configuration,
-and other specialization arguments; tuning also depends on tensor shapes and
-strides. A cold tuning run can compile and benchmark many candidate kernels.
-Persisting compiled kernels alone does not prevent benchmarking again after a
-worker restart.
+quack caches compiled kernels (`.o`) and autotuning results (`.autotune.json`).
+A cold run compiles and benchmarks candidate kernels; later runs reuse the cache
+for matching shapes, layouts, and dtypes. Software changes can invalidate it.
 
-vLLM-Omni points `QUACK_CACHE_DIR` at `~/.cache/vllm_omni/quack` unless explicitly
-overridden. Quack 0.3.11's public autotune decorator already enables disk caching
-of tuning results; `QUACK_CACHE_AUTOTUNING=1` also enables it for callers that
-otherwise default it off. In containers, use a writable, persistent directory on
-the serving machine. Set cache controls before Quack is imported:
+vLLM-Omni points the cache at `~/.cache/vllm_omni/quack` (override with
+`QUACK_CACHE_DIR`). In containers, use a writable, persistent path so compiled
+kernels and tuning results survive restarts. Set cache controls before Quack is
+imported. If tuning repeats, leave `QUACK_FORCE_CACHE_UPDATE` unset and use
+`QUACK_PRINT_AUTOTUNING=1` to inspect tuning activity.
 
-```bash
-QUACK_CACHE_ENABLED=1 \
-QUACK_CACHE_AUTOTUNING=1 \
-QUACK_CACHE_DIR=/path/to/persistent/quack-cache \
-vllm serve <model> --omni --enforce-eager
-```
-
-On supported GPUs with quack installed, `--enforce-eager` keeps Quack GEMMs active
-while disabling the separate `torch.compile` layer. Do not combine this with
-`--force-cutlass-fp8` when testing Quack. If tuning repeats, check that
-`QUACK_FORCE_CACHE_UPDATE` is unset and set `QUACK_PRINT_AUTOTUNING=1` to inspect
-tuning activity. Even `QUACK_FORCE_CACHE_UPDATE=0` is a nonempty override in
-Quack 0.3.11. Keep the GPU and software environment consistent when reusing a
-cache; dependency or kernel-source changes can invalidate compiled artifacts.
-
-To skip the autotuning search while still using Quack, set
-`VLLM_OMNI_QUACK_FP8_AUTOTUNE=0` (default: `1`). This calls Quack's public
-`gemm(..., tuned=False)` entry point, which uses a heuristic/default kernel
-configuration. First-use JIT compilation may still occur, and steady-state
-performance may be lower than with a tuned configuration. This option does not
-disable `torch.compile`; use `--enforce-eager` separately when diagnosing graph
-recompilation.
-
-The wrapper keeps scale validation outside Dynamo tracing so that each layer's
-scale addresses and the growing validation cache do not specialize Torch graphs.
-The surrounding computation can still be compiled, with a graph break at scale
-validation. Quack GEMM is called through its public custom-op entry point with
-the combined scale passed as a device tensor.
+Multi-GPU diffusion workers compile Quack candidates in-process because daemon
+workers cannot create compiler children. Autotuning and caching remain enabled,
+including with sequence parallelism. Cold tuning may take longer because
+candidate compilation runs sequentially.
 
 To pre-warm specific shapes (e.g. at image build time):
 
@@ -107,11 +80,9 @@ from vllm_omni.quantization.quack_fp8 import warmup_quack_fp8
 warmup_quack_fp8([(14040, 2048, 6144), (14040, 2048, 2048)])
 ```
 
-The helper uses inference mode, no bias, and a transposed contiguous `[N, K]`
-weight, matching vLLM's per-tensor FP8 weight layout. Warmup must match the
-request's shapes, dtypes, strides, bias presence, and tuning mode. A startup
-dummy request or a different video size may leave additional configurations
-to compile or tune on the first real request.
+The helper uses inference mode, no bias, and vLLM's transposed weight layout.
+Warmup must match the request's shapes, dtypes, strides, and bias presence;
+the startup dummy run may leave additional configurations to compile or tune.
 
 > The PyPI package is `quack-kernels` (imported as `quack`); plain `pip install
 > quack` is an unrelated statistics library. Requires CUDA 12.9+ and Python 3.12.

--- a/docs/user_guide/quantization/fp8.md
+++ b/docs/user_guide/quantization/fp8.md
@@ -57,15 +57,47 @@ keeps the unfused FlashInfer path.
 
 #### Compile cache and warmup
 
-quack JIT-compiles its kernel once per distinct GEMM shape (tens of seconds, longer
-the first time across all autotuned configs). The compiled `.o` files are cached on
-disk and reused on later runs, so this is a one-time cost — **not** per request.
+quack has two caches: compiled kernels (`.o`) and autotuning results
+(`.autotune.json`). Kernel compilation is cached by layout, dtype, configuration,
+and other specialization arguments; tuning also depends on tensor shapes and
+strides. A cold tuning run can compile and benchmark many candidate kernels.
+Persisting compiled kernels alone does not prevent benchmarking again after a
+worker restart.
 
-vLLM-Omni points that cache at `~/.cache/vllm_omni/quack` (override with
-`QUACK_CACHE_DIR`) instead of quack's default under `/tmp`, so it survives restarts.
-In containers, set `QUACK_CACHE_DIR` to a mounted/persistent path — or bake it into
-the image — so the first cold start does not recompile. The engine's startup dummy
-run already exercises the kernels, so with a warm cache the first real request is fast.
+vLLM-Omni points `QUACK_CACHE_DIR` at `~/.cache/vllm_omni/quack` unless explicitly
+overridden. Quack 0.3.11's public autotune decorator already enables disk caching
+of tuning results; `QUACK_CACHE_AUTOTUNING=1` also enables it for callers that
+otherwise default it off. In containers, use a writable, persistent directory on
+the serving machine. Set cache controls before Quack is imported:
+
+```bash
+QUACK_CACHE_ENABLED=1 \
+QUACK_CACHE_AUTOTUNING=1 \
+QUACK_CACHE_DIR=/path/to/persistent/quack-cache \
+vllm serve <model> --omni --enforce-eager
+```
+
+On supported GPUs with quack installed, `--enforce-eager` keeps Quack GEMMs active
+while disabling the separate `torch.compile` layer. Do not combine this with
+`--force-cutlass-fp8` when testing Quack. If tuning repeats, check that
+`QUACK_FORCE_CACHE_UPDATE` is unset and set `QUACK_PRINT_AUTOTUNING=1` to inspect
+tuning activity. Even `QUACK_FORCE_CACHE_UPDATE=0` is a nonempty override in
+Quack 0.3.11. Keep the GPU and software environment consistent when reusing a
+cache; dependency or kernel-source changes can invalidate compiled artifacts.
+
+To skip the autotuning search while still using Quack, set
+`VLLM_OMNI_QUACK_FP8_AUTOTUNE=0` (default: `1`). This calls Quack's public
+`gemm(..., tuned=False)` entry point, which uses a heuristic/default kernel
+configuration. First-use JIT compilation may still occur, and steady-state
+performance may be lower than with a tuned configuration. This option does not
+disable `torch.compile`; use `--enforce-eager` separately when diagnosing graph
+recompilation.
+
+The wrapper keeps scale validation outside Dynamo tracing so that each layer's
+scale addresses and the growing validation cache do not specialize Torch graphs.
+The surrounding computation can still be compiled, with a graph break at scale
+validation. Quack GEMM is called through its public custom-op entry point with
+the combined scale passed as a device tensor.
 
 To pre-warm specific shapes (e.g. at image build time):
 
@@ -74,6 +106,12 @@ from vllm_omni.quantization.quack_fp8 import warmup_quack_fp8
 # (M, K, N) per linear; M = number of tokens for your resolution/frame count
 warmup_quack_fp8([(14040, 2048, 6144), (14040, 2048, 2048)])
 ```
+
+The helper uses inference mode, no bias, and a transposed contiguous `[N, K]`
+weight, matching vLLM's per-tensor FP8 weight layout. Warmup must match the
+request's shapes, dtypes, strides, bias presence, and tuning mode. A startup
+dummy request or a different video size may leave additional configurations
+to compile or tune on the first real request.
 
 > The PyPI package is `quack-kernels` (imported as `quack`); plain `pip install
 > quack` is an unrelated statistics library. Requires CUDA 12.9+ and Python 3.12.

--- a/docs/user_guide/quantization/fp8.md
+++ b/docs/user_guide/quantization/fp8.md
@@ -57,20 +57,18 @@ keeps the unfused FlashInfer path.
 
 #### Compile cache and warmup
 
-quack caches compiled kernels (`.o`) and autotuning results (`.autotune.json`).
-A cold run compiles and benchmarks candidate kernels; later runs reuse the cache
-for matching shapes, layouts, and dtypes. Software changes can invalidate it.
+quack JIT-compiles its kernel once per distinct GEMM shape (tens of seconds, longer
+the first time across all autotuned configs). The compiled `.o` files are cached on
+disk and reused on later runs, so this is a one-time cost — **not** per request.
 
-vLLM-Omni points the cache at `~/.cache/vllm_omni/quack` (override with
-`QUACK_CACHE_DIR`). In containers, use a writable, persistent path so compiled
-kernels and tuning results survive restarts. Set cache controls before Quack is
-imported. If tuning repeats, leave `QUACK_FORCE_CACHE_UPDATE` unset and use
-`QUACK_PRINT_AUTOTUNING=1` to inspect tuning activity.
-
-Multi-GPU diffusion workers compile Quack candidates in-process because daemon
-workers cannot create compiler children. Autotuning and caching remain enabled,
-including with sequence parallelism. Cold tuning may take longer because
-candidate compilation runs sequentially.
+vLLM-Omni points that cache at `~/.cache/vllm_omni/quack` (override with
+`QUACK_CACHE_DIR`) instead of quack's default under `/tmp`, so it survives restarts.
+In containers, set `QUACK_CACHE_DIR` to a mounted/persistent path — or bake it into
+the image — so the first cold start does not recompile. The engine's startup dummy
+run exercises the kernels, but new shapes, layouts, dtypes, or bias settings may
+still need compilation or tuning. The warmup helper uses inference mode and
+transposed weights without bias. Daemon workers compile candidates in-process
+while retaining autotuning and caching.
 
 To pre-warm specific shapes (e.g. at image build time):
 
@@ -79,10 +77,6 @@ from vllm_omni.quantization.quack_fp8 import warmup_quack_fp8
 # (M, K, N) per linear; M = number of tokens for your resolution/frame count
 warmup_quack_fp8([(14040, 2048, 6144), (14040, 2048, 2048)])
 ```
-
-The helper uses inference mode, no bias, and vLLM's transposed weight layout.
-Warmup must match the request's shapes, dtypes, strides, and bias presence;
-the startup dummy run may leave additional configurations to compile or tune.
 
 > The PyPI package is `quack-kernels` (imported as `quack`); plain `pip install
 > quack` is an unrelated statistics library. Requires CUDA 12.9+ and Python 3.12.

--- a/tests/quantization/test_quack_fp8_runtime.py
+++ b/tests/quantization/test_quack_fp8_runtime.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """CPU checks for Quack runtime scales and inference-compatible warmup."""
 
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -14,12 +14,56 @@ from vllm_omni.quantization import quack_fp8
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 
-def test_non_daemon_keeps_default_compilation(monkeypatch):
-    import_module = Mock(side_effect=AssertionError("must not import or patch the pool"))
+def test_compile_adapter_checks_daemon_when_tuning_starts(monkeypatch):
+    # spawn imports the worker module while unpickling its target, before
+    # _bootstrap installs the child Process (and its actual daemon flag).
+    process = SimpleNamespace(daemon=False)
+    pool = SimpleNamespace(
+        pool_scope=Mock(spec=[], side_effect=AssertionError("compiler child requested")),
+        suppress_pool=nullcontext,
+    )
+    monkeypatch.setattr(quack_fp8, "current_process", lambda: process)
+    monkeypatch.setattr(quack_fp8, "import_module", lambda name: pool)
+    quack_fp8._configure_quack_compilation()  # import-time installation
+    process.daemon = True  # worker target starts after _bootstrap
+    with pool.pool_scope() as active_pool:
+        assert active_pool is None
+
+
+@pytest.mark.parametrize("fail", [False, True])
+def test_non_daemon_keeps_default_compilation(monkeypatch, fail):
+    events = []
+    original_pool = object()
+
+    @contextmanager
+    def original_scope():
+        events.append("enter")
+        try:
+            yield original_pool
+        finally:
+            events.append("exit")
+
+    pool = SimpleNamespace(
+        pool_scope=original_scope,
+        suppress_pool=Mock(side_effect=AssertionError("must keep the normal compiler pool")),
+    )
     monkeypatch.setattr(quack_fp8, "current_process", lambda: SimpleNamespace(daemon=False))
-    monkeypatch.setattr(quack_fp8, "import_module", import_module)
+    monkeypatch.setattr(quack_fp8, "import_module", lambda name: pool)
     quack_fp8._configure_quack_compilation()
-    import_module.assert_not_called()
+
+    def compile_candidates():
+        with pool.pool_scope() as active_pool:
+            assert active_pool is original_pool
+            if fail:
+                raise RuntimeError("compile failed")
+
+    if fail:
+        with pytest.raises(RuntimeError, match="compile failed"):
+            compile_candidates()
+    else:
+        compile_candidates()
+    assert events == ["enter", "exit"]
+    pool.suppress_pool.assert_not_called()
 
 
 @pytest.mark.parametrize("missing_module", ["quack.cache", "quack.cache.async_compile"])
@@ -79,19 +123,22 @@ def test_daemon_compilation_suppresses_pool_without_constructing_executor(monkey
     assert pool.get_active_pool() is original_pool
 
 
-def test_daemon_autotuning_benchmarks_candidates_and_reuses_disk_cache(monkeypatch, tmp_path):
+@pytest.mark.parametrize("l2_rotate", [False, True])
+def test_daemon_autotuning_benchmarks_candidates_and_reuses_disk_cache(monkeypatch, tmp_path, l2_rotate):
     # Exercise Quack's real tuning loop with a CPU benchmark stand-in. Optional
     # because the quack extra is not installed in every CPU test environment.
     autotuner = pytest.importorskip("quack.autotuner")
     async_compile = pytest.importorskip("quack.cache.async_compile")
     monkeypatch.setenv("QUACK_CACHE_DIR", str(tmp_path))
     monkeypatch.delenv("QUACK_FORCE_CACHE_UPDATE", raising=False)
-    monkeypatch.setattr(quack_fp8, "current_process", lambda: SimpleNamespace(daemon=True))
+    process = SimpleNamespace(daemon=False)
+    monkeypatch.setattr(quack_fp8, "current_process", lambda: process)
     monkeypatch.setattr(autotuner, "_gpu_warmup", lambda: None)
     monkeypatch.setattr(async_compile, "_make_executor", Mock(side_effect=AssertionError("compiler child requested")))
     # Arrange for monkeypatch to restore the process-local adapter after this test.
     monkeypatch.setattr(async_compile, "pool_scope", async_compile.pool_scope)
     quack_fp8._configure_quack_compilation()
+    process.daemon = True
     candidates = []
 
     def kernel(x, *, tile):
@@ -104,12 +151,21 @@ def test_daemon_autotuning_benchmarks_candidates_and_reuses_disk_cache(monkeypat
         tile = candidates[-1]
         return [{16: 3.0, 32: 1.0, 64: 2.0}[tile]] * len(quantiles)
 
+    if l2_rotate:
+        monkeypatch.setattr(autotuner, "_pick_l2_rotate_count", lambda *args: 1)
+        monkeypatch.setattr(autotuner, "_clone_l2_rotate_inputs", lambda args, kwargs, count: ([args], [kwargs]))
+
+        def bench_l2_rotate(fn, arg_sets, kwarg_sets, *, extra_kwargs, quantiles):
+            return benchmark(lambda: fn(*arg_sets[0], **kwarg_sets[0], **extra_kwargs), quantiles)
+
+        monkeypatch.setattr(autotuner, "_bench_cuda_graph_l2_rotate", bench_l2_rotate)
+
     def make_tuner():
         return autotuner.Autotuner(
             kernel,
             key=[],
             configs=[autotuner.AutotuneConfig(tile=tile) for tile in (16, 32, 64)],
-            do_bench=benchmark,
+            do_bench=None if l2_rotate else benchmark,
             cache_results=True,
         )
 

--- a/tests/quantization/test_quack_fp8_runtime.py
+++ b/tests/quantization/test_quack_fp8_runtime.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""CPU checks for Quack dispatch settings and inference-compatible warmup."""
+"""CPU checks for Quack runtime scales and inference-compatible warmup."""
 
+from contextlib import contextmanager
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -10,6 +12,119 @@ import torch
 from vllm_omni.quantization import quack_fp8
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_non_daemon_keeps_default_compilation(monkeypatch):
+    import_module = Mock(side_effect=AssertionError("must not import or patch the pool"))
+    monkeypatch.setattr(quack_fp8, "current_process", lambda: SimpleNamespace(daemon=False))
+    monkeypatch.setattr(quack_fp8, "import_module", import_module)
+    quack_fp8._configure_quack_compilation()
+    import_module.assert_not_called()
+
+
+@pytest.mark.parametrize("missing_module", ["quack.cache", "quack.cache.async_compile"])
+def test_legacy_quack_needs_no_compile_pool_adapter(monkeypatch, missing_module):
+    monkeypatch.setattr(quack_fp8, "current_process", lambda: SimpleNamespace(daemon=True))
+    monkeypatch.setattr(quack_fp8, "import_module", Mock(side_effect=ModuleNotFoundError(name=missing_module)))
+    quack_fp8._configure_quack_compilation()
+
+
+def test_broken_async_compile_dependency_is_not_treated_as_legacy_quack(monkeypatch):
+    monkeypatch.setattr(quack_fp8, "current_process", lambda: SimpleNamespace(daemon=True))
+    monkeypatch.setattr(quack_fp8, "import_module", Mock(side_effect=ModuleNotFoundError(name="cutlass")))
+    with pytest.raises(ModuleNotFoundError):
+        quack_fp8._configure_quack_compilation()
+
+
+@pytest.mark.parametrize("fail", [False, True])
+def test_daemon_compilation_suppresses_pool_without_constructing_executor(monkeypatch, fail):
+    active_pool = object()
+    pool = SimpleNamespace(
+        pool_scope=Mock(spec=[], side_effect=AssertionError("must not construct a compiler executor")),
+        get_active_pool=lambda: active_pool,
+    )
+
+    @contextmanager
+    def suppress_pool():
+        nonlocal active_pool
+        previous, active_pool = active_pool, None
+        try:
+            yield
+        finally:
+            active_pool = previous
+
+    pool.suppress_pool = suppress_pool
+    original_pool = active_pool
+    monkeypatch.setattr(quack_fp8, "current_process", lambda: SimpleNamespace(daemon=True))
+    monkeypatch.setattr(quack_fp8, "import_module", lambda name: pool)
+    quack_fp8._configure_quack_compilation()
+    scope = pool.pool_scope
+    quack_fp8._configure_quack_compilation()
+    assert pool.pool_scope is scope
+
+    def compile_candidates():
+        with pool.pool_scope():
+            assert pool.get_active_pool() is None
+            with pool.pool_scope():
+                assert pool.get_active_pool() is None
+            assert pool.get_active_pool() is None
+            if fail:
+                raise RuntimeError("compile failed")
+
+    if fail:
+        with pytest.raises(RuntimeError, match="compile failed"):
+            compile_candidates()
+    else:
+        compile_candidates()
+    assert pool.get_active_pool() is original_pool
+
+
+def test_daemon_autotuning_benchmarks_candidates_and_reuses_disk_cache(monkeypatch, tmp_path):
+    # Exercise Quack's real tuning loop with a CPU benchmark stand-in. Optional
+    # because the quack extra is not installed in every CPU test environment.
+    autotuner = pytest.importorskip("quack.autotuner")
+    async_compile = pytest.importorskip("quack.cache.async_compile")
+    monkeypatch.setenv("QUACK_CACHE_DIR", str(tmp_path))
+    monkeypatch.delenv("QUACK_FORCE_CACHE_UPDATE", raising=False)
+    monkeypatch.setattr(quack_fp8, "current_process", lambda: SimpleNamespace(daemon=True))
+    monkeypatch.setattr(autotuner, "_gpu_warmup", lambda: None)
+    monkeypatch.setattr(async_compile, "_make_executor", Mock(side_effect=AssertionError("compiler child requested")))
+    # Arrange for monkeypatch to restore the process-local adapter after this test.
+    monkeypatch.setattr(async_compile, "pool_scope", async_compile.pool_scope)
+    quack_fp8._configure_quack_compilation()
+    candidates = []
+
+    def kernel(x, *, tile):
+        assert async_compile.get_active_pool() is None
+        candidates.append(tile)
+        return tile
+
+    def benchmark(fn, quantiles):
+        fn()
+        tile = candidates[-1]
+        return [{16: 3.0, 32: 1.0, 64: 2.0}[tile]] * len(quantiles)
+
+    def make_tuner():
+        return autotuner.Autotuner(
+            kernel,
+            key=[],
+            configs=[autotuner.AutotuneConfig(tile=tile) for tile in (16, 32, 64)],
+            do_bench=benchmark,
+            cache_results=True,
+        )
+
+    x = torch.ones(4)
+    tuner = make_tuner()
+    assert tuner(x) == 32
+    assert candidates == [16, 32, 64, 32]
+    candidates.clear()
+    assert tuner(x) == 32
+    assert candidates == [32]
+    assert list(tmp_path.rglob("*.autotune.json"))
+    candidates.clear()
+    assert make_tuner()(x) == 32  # A fresh tuner must use the persisted winner.
+    assert candidates == [32]
+    async_compile._make_executor.assert_not_called()
 
 
 def test_scale_validation_does_not_recompile_for_each_layer(monkeypatch):
@@ -50,12 +165,8 @@ def test_unpopulated_scales_are_rechecked_after_loading(monkeypatch):
     assert quack_fp8._scales_valid(scale_a, scale_b)
 
 
-@pytest.mark.parametrize("autotune, expected", [(None, True), ("0", False), ("false", False), ("1", True)])
 @pytest.mark.parametrize("with_bias", [False, True])
-def test_gemm_dispatch_keeps_runtime_scales_and_respects_autotuning(monkeypatch, autotune, expected, with_bias):
-    monkeypatch.delenv("VLLM_OMNI_QUACK_FP8_AUTOTUNE", raising=False)
-    if autotune is not None:
-        monkeypatch.setenv("VLLM_OMNI_QUACK_FP8_AUTOTUNE", autotune)
+def test_gemm_dispatch_keeps_runtime_scales(monkeypatch, with_bias):
     calls = []
 
     def gemm(a, b, *, out, bias, alpha, tuned):
@@ -81,7 +192,7 @@ def test_gemm_dispatch_keeps_runtime_scales_and_respects_autotuning(monkeypatch,
         if bias is not None:
             reference += bias
         torch.testing.assert_close(out, reference)
-    assert calls == [expected, expected]
+    assert calls == [True, True]
 
 
 def test_warmup_matches_inference_weight_layout(monkeypatch):
@@ -93,12 +204,11 @@ def test_warmup_matches_inference_weight_layout(monkeypatch):
         assert a.is_contiguous()
         assert b.stride() == (1, b.shape[0])
         assert bias is None
-        assert tuned is False
+        assert tuned is True
         calls.append((a.shape[0], a.shape[1], b.shape[1]))
         out.zero_()
 
     monkeypatch.setattr(quack_fp8, "_gemm_interface", SimpleNamespace(gemm=gemm))
-    monkeypatch.setenv("VLLM_OMNI_QUACK_FP8_AUTOTUNE", "0")
     monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
     shapes = [(4, 8, 6), (2, 16, 8)]
     quack_fp8.warmup_quack_fp8(shapes, device="cpu")

--- a/tests/quantization/test_quack_fp8_runtime.py
+++ b/tests/quantization/test_quack_fp8_runtime.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""CPU checks for Quack runtime scales and inference-compatible warmup."""
+"""CPU regressions for Quack compilation and warmup."""
 
-from contextlib import contextmanager, nullcontext
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -14,173 +14,27 @@ from vllm_omni.quantization import quack_fp8
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 
-def test_compile_adapter_checks_daemon_when_tuning_starts(monkeypatch):
-    # spawn imports the worker module while unpickling its target, before
-    # _bootstrap installs the child Process (and its actual daemon flag).
+def test_compile_pool_checks_daemon_at_tuning_time(monkeypatch):
     process = SimpleNamespace(daemon=False)
+    compiler_pool = object()
     pool = SimpleNamespace(
-        pool_scope=Mock(spec=[], side_effect=AssertionError("compiler child requested")),
-        suppress_pool=nullcontext,
+        pool_scope=Mock(spec=[], side_effect=lambda: nullcontext(compiler_pool)),
+        suppress_pool=Mock(side_effect=lambda: nullcontext(object())),
     )
+    original_scope = pool.pool_scope
     monkeypatch.setattr(quack_fp8, "current_process", lambda: process)
     monkeypatch.setattr(quack_fp8, "import_module", lambda name: pool)
-    quack_fp8._configure_quack_compilation()  # import-time installation
-    process.daemon = True  # worker target starts after _bootstrap
-    with pool.pool_scope() as active_pool:
-        assert active_pool is None
-
-
-@pytest.mark.parametrize("fail", [False, True])
-def test_non_daemon_keeps_default_compilation(monkeypatch, fail):
-    events = []
-    original_pool = object()
-
-    @contextmanager
-    def original_scope():
-        events.append("enter")
-        try:
-            yield original_pool
-        finally:
-            events.append("exit")
-
-    pool = SimpleNamespace(
-        pool_scope=original_scope,
-        suppress_pool=Mock(side_effect=AssertionError("must keep the normal compiler pool")),
-    )
-    monkeypatch.setattr(quack_fp8, "current_process", lambda: SimpleNamespace(daemon=False))
-    monkeypatch.setattr(quack_fp8, "import_module", lambda name: pool)
     quack_fp8._configure_quack_compilation()
-
-    def compile_candidates():
-        with pool.pool_scope() as active_pool:
-            assert active_pool is original_pool
-            if fail:
-                raise RuntimeError("compile failed")
-
-    if fail:
-        with pytest.raises(RuntimeError, match="compile failed"):
-            compile_candidates()
-    else:
-        compile_candidates()
-    assert events == ["enter", "exit"]
+    with pool.pool_scope() as active_pool:
+        assert active_pool is compiler_pool
     pool.suppress_pool.assert_not_called()
 
-
-@pytest.mark.parametrize("missing_module", ["quack.cache", "quack.cache.async_compile"])
-def test_legacy_quack_needs_no_compile_pool_adapter(monkeypatch, missing_module):
-    monkeypatch.setattr(quack_fp8, "current_process", lambda: SimpleNamespace(daemon=True))
-    monkeypatch.setattr(quack_fp8, "import_module", Mock(side_effect=ModuleNotFoundError(name=missing_module)))
-    quack_fp8._configure_quack_compilation()
-
-
-def test_broken_async_compile_dependency_is_not_treated_as_legacy_quack(monkeypatch):
-    monkeypatch.setattr(quack_fp8, "current_process", lambda: SimpleNamespace(daemon=True))
-    monkeypatch.setattr(quack_fp8, "import_module", Mock(side_effect=ModuleNotFoundError(name="cutlass")))
-    with pytest.raises(ModuleNotFoundError):
-        quack_fp8._configure_quack_compilation()
-
-
-@pytest.mark.parametrize("fail", [False, True])
-def test_daemon_compilation_suppresses_pool_without_constructing_executor(monkeypatch, fail):
-    active_pool = object()
-    pool = SimpleNamespace(
-        pool_scope=Mock(spec=[], side_effect=AssertionError("must not construct a compiler executor")),
-        get_active_pool=lambda: active_pool,
-    )
-
-    @contextmanager
-    def suppress_pool():
-        nonlocal active_pool
-        previous, active_pool = active_pool, None
-        try:
-            yield
-        finally:
-            active_pool = previous
-
-    pool.suppress_pool = suppress_pool
-    original_pool = active_pool
-    monkeypatch.setattr(quack_fp8, "current_process", lambda: SimpleNamespace(daemon=True))
-    monkeypatch.setattr(quack_fp8, "import_module", lambda name: pool)
-    quack_fp8._configure_quack_compilation()
-    scope = pool.pool_scope
-    quack_fp8._configure_quack_compilation()
-    assert pool.pool_scope is scope
-
-    def compile_candidates():
-        with pool.pool_scope():
-            assert pool.get_active_pool() is None
-            with pool.pool_scope():
-                assert pool.get_active_pool() is None
-            assert pool.get_active_pool() is None
-            if fail:
-                raise RuntimeError("compile failed")
-
-    if fail:
-        with pytest.raises(RuntimeError, match="compile failed"):
-            compile_candidates()
-    else:
-        compile_candidates()
-    assert pool.get_active_pool() is original_pool
-
-
-@pytest.mark.parametrize("l2_rotate", [False, True])
-def test_daemon_autotuning_benchmarks_candidates_and_reuses_disk_cache(monkeypatch, tmp_path, l2_rotate):
-    # Exercise Quack's real tuning loop with a CPU benchmark stand-in. Optional
-    # because the quack extra is not installed in every CPU test environment.
-    autotuner = pytest.importorskip("quack.autotuner")
-    async_compile = pytest.importorskip("quack.cache.async_compile")
-    monkeypatch.setenv("QUACK_CACHE_DIR", str(tmp_path))
-    monkeypatch.delenv("QUACK_FORCE_CACHE_UPDATE", raising=False)
-    process = SimpleNamespace(daemon=False)
-    monkeypatch.setattr(quack_fp8, "current_process", lambda: process)
-    monkeypatch.setattr(autotuner, "_gpu_warmup", lambda: None)
-    monkeypatch.setattr(async_compile, "_make_executor", Mock(side_effect=AssertionError("compiler child requested")))
-    # Arrange for monkeypatch to restore the process-local adapter after this test.
-    monkeypatch.setattr(async_compile, "pool_scope", async_compile.pool_scope)
-    quack_fp8._configure_quack_compilation()
+    # spawn installs the child's daemon flag after importing the worker module.
     process.daemon = True
-    candidates = []
-
-    def kernel(x, *, tile):
-        assert async_compile.get_active_pool() is None
-        candidates.append(tile)
-        return tile
-
-    def benchmark(fn, quantiles):
-        fn()
-        tile = candidates[-1]
-        return [{16: 3.0, 32: 1.0, 64: 2.0}[tile]] * len(quantiles)
-
-    if l2_rotate:
-        monkeypatch.setattr(autotuner, "_pick_l2_rotate_count", lambda *args: 1)
-        monkeypatch.setattr(autotuner, "_clone_l2_rotate_inputs", lambda args, kwargs, count: ([args], [kwargs]))
-
-        def bench_l2_rotate(fn, arg_sets, kwarg_sets, *, extra_kwargs, quantiles):
-            return benchmark(lambda: fn(*arg_sets[0], **kwarg_sets[0], **extra_kwargs), quantiles)
-
-        monkeypatch.setattr(autotuner, "_bench_cuda_graph_l2_rotate", bench_l2_rotate)
-
-    def make_tuner():
-        return autotuner.Autotuner(
-            kernel,
-            key=[],
-            configs=[autotuner.AutotuneConfig(tile=tile) for tile in (16, 32, 64)],
-            do_bench=None if l2_rotate else benchmark,
-            cache_results=True,
-        )
-
-    x = torch.ones(4)
-    tuner = make_tuner()
-    assert tuner(x) == 32
-    assert candidates == [16, 32, 64, 32]
-    candidates.clear()
-    assert tuner(x) == 32
-    assert candidates == [32]
-    assert list(tmp_path.rglob("*.autotune.json"))
-    candidates.clear()
-    assert make_tuner()(x) == 32  # A fresh tuner must use the persisted winner.
-    assert candidates == [32]
-    async_compile._make_executor.assert_not_called()
+    with pool.pool_scope() as active_pool:
+        assert active_pool is None
+    original_scope.assert_called_once_with()
+    pool.suppress_pool.assert_called_once_with()
 
 
 def test_scale_validation_does_not_recompile_for_each_layer(monkeypatch):
@@ -210,45 +64,6 @@ def test_scale_validation_does_not_recompile_for_each_layer(monkeypatch):
         assert len(compiled_graphs) == 1
     finally:
         torch._dynamo.reset()
-
-
-def test_unpopulated_scales_are_rechecked_after_loading(monkeypatch):
-    monkeypatch.setattr(quack_fp8, "_valid_scale_ptrs", set())
-    scale_a = torch.tensor([torch.finfo(torch.float32).min])
-    scale_b = torch.tensor([0.5])
-    assert not quack_fp8._scales_valid(scale_a, scale_b)
-    scale_a.fill_(0.25)
-    assert quack_fp8._scales_valid(scale_a, scale_b)
-
-
-@pytest.mark.parametrize("with_bias", [False, True])
-def test_gemm_dispatch_keeps_runtime_scales(monkeypatch, with_bias):
-    calls = []
-
-    def gemm(a, b, *, out, bias, alpha, tuned):
-        assert isinstance(alpha, torch.Tensor)
-        assert alpha.dtype == torch.float32
-        assert alpha.shape == (1,)
-        result = (a.float() @ b.float()) * alpha
-        if bias is not None:
-            result += bias
-        out.copy_(result)
-        calls.append(tuned)
-
-    monkeypatch.setattr(quack_fp8, "_gemm_interface", SimpleNamespace(gemm=gemm))
-    a = torch.arange(32, dtype=torch.float32).reshape(4, 8).to(torch.float8_e4m3fn)
-    b = torch.ones(6, 8, dtype=torch.float8_e4m3fn).t()
-    bias = torch.arange(6, dtype=torch.float32) if with_bias else None
-    # Different calibrated scales must reach the kernel as runtime inputs.
-    for scale in (0.25, 0.5):
-        scale_a = torch.tensor([scale])
-        scale_b = torch.tensor([0.5])
-        out = quack_fp8.quack_scaled_fp8_mm(a, b, scale_a, scale_b, torch.float32, bias)
-        reference = (a.float() @ b.float()) * scale * 0.5
-        if bias is not None:
-            reference += bias
-        torch.testing.assert_close(out, reference)
-    assert calls == [True, True]
 
 
 def test_warmup_matches_inference_weight_layout(monkeypatch):

--- a/tests/quantization/test_quack_fp8_runtime.py
+++ b/tests/quantization/test_quack_fp8_runtime.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU checks for Quack dispatch settings and inference-compatible warmup."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_omni.quantization import quack_fp8
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_scale_validation_does_not_recompile_for_each_layer(monkeypatch):
+    monkeypatch.setattr(quack_fp8, "_valid_scale_ptrs", set())
+    torch._dynamo.reset()
+    compiled_graphs = []
+
+    def backend(graph, example_inputs):
+        compiled_graphs.append(graph)
+        return graph.forward
+
+    def forward(x, scale_a, scale_b):
+        if quack_fp8._scales_valid(scale_a, scale_b):
+            return x * (scale_a * scale_b)
+        return x
+
+    try:
+        compiled = torch.compile(forward, backend=backend)
+        # Keep all pairs alive, as separate model layers do. Both pointer
+        # addresses and scale values differ; tensor metadata stays identical.
+        with torch.inference_mode():
+            pairs = [(torch.tensor([float(i + 1)]), torch.tensor([0.5])) for i in range(5)]
+            x = torch.ones(4)
+            for _ in range(2):
+                for scale_a, scale_b in pairs:
+                    torch.testing.assert_close(compiled(x, scale_a, scale_b), x * scale_a * scale_b)
+        assert len(compiled_graphs) == 1
+    finally:
+        torch._dynamo.reset()
+
+
+def test_unpopulated_scales_are_rechecked_after_loading(monkeypatch):
+    monkeypatch.setattr(quack_fp8, "_valid_scale_ptrs", set())
+    scale_a = torch.tensor([torch.finfo(torch.float32).min])
+    scale_b = torch.tensor([0.5])
+    assert not quack_fp8._scales_valid(scale_a, scale_b)
+    scale_a.fill_(0.25)
+    assert quack_fp8._scales_valid(scale_a, scale_b)
+
+
+@pytest.mark.parametrize("autotune, expected", [(None, True), ("0", False), ("false", False), ("1", True)])
+@pytest.mark.parametrize("with_bias", [False, True])
+def test_gemm_dispatch_keeps_runtime_scales_and_respects_autotuning(monkeypatch, autotune, expected, with_bias):
+    monkeypatch.delenv("VLLM_OMNI_QUACK_FP8_AUTOTUNE", raising=False)
+    if autotune is not None:
+        monkeypatch.setenv("VLLM_OMNI_QUACK_FP8_AUTOTUNE", autotune)
+    calls = []
+
+    def gemm(a, b, *, out, bias, alpha, tuned):
+        assert isinstance(alpha, torch.Tensor)
+        assert alpha.dtype == torch.float32
+        assert alpha.shape == (1,)
+        result = (a.float() @ b.float()) * alpha
+        if bias is not None:
+            result += bias
+        out.copy_(result)
+        calls.append(tuned)
+
+    monkeypatch.setattr(quack_fp8, "_gemm_interface", SimpleNamespace(gemm=gemm))
+    a = torch.arange(32, dtype=torch.float32).reshape(4, 8).to(torch.float8_e4m3fn)
+    b = torch.ones(6, 8, dtype=torch.float8_e4m3fn).t()
+    bias = torch.arange(6, dtype=torch.float32) if with_bias else None
+    # Different calibrated scales must reach the kernel as runtime inputs.
+    for scale in (0.25, 0.5):
+        scale_a = torch.tensor([scale])
+        scale_b = torch.tensor([0.5])
+        out = quack_fp8.quack_scaled_fp8_mm(a, b, scale_a, scale_b, torch.float32, bias)
+        reference = (a.float() @ b.float()) * scale * 0.5
+        if bias is not None:
+            reference += bias
+        torch.testing.assert_close(out, reference)
+    assert calls == [expected, expected]
+
+
+def test_warmup_matches_inference_weight_layout(monkeypatch):
+    calls = []
+
+    def gemm(a, b, *, out, bias, alpha, tuned):
+        assert torch.is_inference_mode_enabled()
+        assert a.dtype == b.dtype == torch.float8_e4m3fn
+        assert a.is_contiguous()
+        assert b.stride() == (1, b.shape[0])
+        assert bias is None
+        assert tuned is False
+        calls.append((a.shape[0], a.shape[1], b.shape[1]))
+        out.zero_()
+
+    monkeypatch.setattr(quack_fp8, "_gemm_interface", SimpleNamespace(gemm=gemm))
+    monkeypatch.setenv("VLLM_OMNI_QUACK_FP8_AUTOTUNE", "0")
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    shapes = [(4, 8, 6), (2, 16, 8)]
+    quack_fp8.warmup_quack_fp8(shapes, device="cpu")
+    assert calls == shapes

--- a/vllm_omni/quantization/quack_fp8.py
+++ b/vllm_omni/quantization/quack_fp8.py
@@ -41,6 +41,10 @@ def quack_enabled() -> bool:
     return _is_quack_capable()
 
 
+def _quack_autotune_enabled() -> bool:
+    return os.environ.get("VLLM_OMNI_QUACK_FP8_AUTOTUNE", "1").lower() in _TRUTHY
+
+
 def _set_persistent_cache_dir() -> None:
     if os.environ.get("QUACK_CACHE_DIR"):
         return
@@ -73,7 +77,11 @@ def _load_quack():
         torch2cute_dtype_map.setdefault(torch.float8_e5m2, cutlass.Float8E5M2)
 
         _gemm_interface = gemm_interface
-        logger.info("Quack FP8 fused-bias GEMM enabled (CuteDSL).")
+        logger.info(
+            "Quack FP8 fused-bias GEMM enabled (CuteDSL, autotune=%s, cache=%s).",
+            _quack_autotune_enabled(),
+            os.environ["QUACK_CACHE_DIR"],
+        )
         return gemm_interface
     except Exception as exc:  # noqa: BLE001
         logger.warning("Quack FP8 unavailable, using FlashInfer: %s", exc)
@@ -94,13 +102,16 @@ def quack_scaled_fp8_mm(
         return None
     out = torch.empty(a.shape[0], b.shape[1], device=a.device, dtype=out_dtype)
     alpha = scale_a.reshape(1).float() * scale_b.reshape(1).float()
-    gemm.gemm(a, b, out=out, bias=bias, alpha=alpha, tuned=True)
+    # Keep alpha as a device tensor: calibrated scale values are runtime data,
+    # not Python constants to specialize the compiled GEMM on.
+    gemm.gemm(a, b, out=out, bias=bias, alpha=alpha, tuned=_quack_autotune_enabled())
     return out
 
 
 _valid_scale_ptrs: set[tuple[int, int]] = set()
 
 
+@torch.compiler.disable
 def _scales_valid(scale_a: torch.Tensor, scale_b: torch.Tensor) -> bool:
     """True when both per-tensor scales are finite and positive.
 
@@ -109,6 +120,10 @@ def _scales_valid(scale_a: torch.Tensor, scale_b: torch.Tensor) -> bool:
     make ``alpha = scale_a * scale_b`` overflow to ``+inf`` and return an all-inf tile.
     Cache only positive results: a buffer still holding the sentinel is re-checked and
     picks up the fast path once the real scale is written.
+
+    Keep pointer checks and the mutable cache outside Dynamo tracing. Otherwise
+    different layers' scale addresses/cache updates specialize the surrounding
+    graph and trigger recompilation even when GEMM shapes are identical.
     """
     key = (scale_a.data_ptr(), scale_b.data_ptr())
     if key in _valid_scale_ptrs:
@@ -155,17 +170,21 @@ def install_quack_fp8_patch() -> None:
     logger.info("Patched FlashInfer FP8 ScaledMM to use quack fused-bias GEMM.")
 
 
+@torch.inference_mode()
 def warmup_quack_fp8(
     shapes: list[tuple[int, int, int]],
     device: str = "cuda",
     out_dtype: torch.dtype = torch.bfloat16,
 ) -> None:
+    """Warm no-bias GEMMs with the transposed weight layout used by vLLM."""
     if _load_quack() is None:
         return
     scale = torch.ones(1, device=device, dtype=torch.float32)
     for m, k, n in shapes:
         a = torch.zeros(m, k, device=device, dtype=torch.float8_e4m3fn)
-        b = torch.zeros(k, n, device=device, dtype=torch.float8_e4m3fn)
+        # ModelOpt transposes the contiguous [N, K] checkpoint weight after
+        # loading. A contiguous [K, N] here would warm a different cache key.
+        b = torch.zeros(n, k, device=device, dtype=torch.float8_e4m3fn).t()
         quack_scaled_fp8_mm(a, b, scale, scale, out_dtype)
     if torch.cuda.is_available():
         torch.accelerator.synchronize()

--- a/vllm_omni/quantization/quack_fp8.py
+++ b/vllm_omni/quantization/quack_fp8.py
@@ -5,6 +5,9 @@
 from __future__ import annotations
 
 import os
+from contextlib import contextmanager
+from importlib import import_module
+from multiprocessing import current_process
 
 import torch
 from vllm.logger import init_logger
@@ -41,10 +44,6 @@ def quack_enabled() -> bool:
     return _is_quack_capable()
 
 
-def _quack_autotune_enabled() -> bool:
-    return os.environ.get("VLLM_OMNI_QUACK_FP8_AUTOTUNE", "1").lower() in _TRUTHY
-
-
 def _set_persistent_cache_dir() -> None:
     if os.environ.get("QUACK_CACHE_DIR"):
         return
@@ -54,6 +53,37 @@ def _set_persistent_cache_dir() -> None:
         or os.path.join(os.path.expanduser("~"), ".cache")
     )
     os.environ["QUACK_CACHE_DIR"] = os.path.join(root, "vllm_omni", "quack")
+
+
+def _configure_quack_compilation() -> None:
+    """Keep autotuning in daemon workers without starting compiler children."""
+    if not current_process().daemon:
+        return
+    try:
+        async_compile = import_module("quack.cache.async_compile")
+    except ModuleNotFoundError as exc:
+        # Older Quack releases compile synchronously and have no async pool.
+        if exc.name not in {"quack.cache", "quack.cache.async_compile"}:
+            raise
+        return
+    if getattr(async_compile.pool_scope, "_omni_in_process", False):
+        return
+    suppress_pool = async_compile.suppress_pool
+
+    @contextmanager
+    def in_process_pool_scope():
+        # Quack 0.6.4 imports pool_scope inside its autotuner's cold-cache
+        # benchmark loop. Suppression makes jit_cache compile/load locally,
+        # so no CompilePending is raised and the loop never needs pool.poll.
+        # Replacing the scope also avoids constructing an unused executor.
+        # Candidate pruning, benchmarking, winner selection and disk caching
+        # stay in Quack. This adaptation is local to this daemon process.
+        with suppress_pool():
+            yield None
+
+    in_process_pool_scope._omni_in_process = True
+    async_compile.pool_scope = in_process_pool_scope
+    logger.info("Quack autotuning will compile candidates in-process in this daemon worker.")
 
 
 def _load_quack():
@@ -76,10 +106,10 @@ def _load_quack():
         torch2cute_dtype_map.setdefault(torch.float8_e4m3fn, cutlass.Float8E4M3FN)
         torch2cute_dtype_map.setdefault(torch.float8_e5m2, cutlass.Float8E5M2)
 
+        _configure_quack_compilation()
         _gemm_interface = gemm_interface
         logger.info(
-            "Quack FP8 fused-bias GEMM enabled (CuteDSL, autotune=%s, cache=%s).",
-            _quack_autotune_enabled(),
+            "Quack FP8 fused-bias GEMM enabled (CuteDSL, cache=%s).",
             os.environ["QUACK_CACHE_DIR"],
         )
         return gemm_interface
@@ -104,7 +134,7 @@ def quack_scaled_fp8_mm(
     alpha = scale_a.reshape(1).float() * scale_b.reshape(1).float()
     # Keep alpha as a device tensor: calibrated scale values are runtime data,
     # not Python constants to specialize the compiled GEMM on.
-    gemm.gemm(a, b, out=out, bias=bias, alpha=alpha, tuned=_quack_autotune_enabled())
+    gemm.gemm(a, b, out=out, bias=bias, alpha=alpha, tuned=True)
     return out
 
 

--- a/vllm_omni/quantization/quack_fp8.py
+++ b/vllm_omni/quantization/quack_fp8.py
@@ -64,16 +64,23 @@ def _configure_quack_compilation() -> None:
         if exc.name not in {"quack.cache", "quack.cache.async_compile"}:
             raise
         return
-    if getattr(async_compile.pool_scope, "_omni_daemon_safe", False):
+    original_pool_scope = getattr(async_compile, "pool_scope", None)
+    suppress_pool = getattr(async_compile, "suppress_pool", None)
+    if not callable(original_pool_scope) or not callable(suppress_pool):
+        logger.warning(
+            "Quack async compilation API is unsupported: pool_scope and suppress_pool must be callable. "
+            "Skipping the compilation patch; autotuning in daemon workers may fail."
+        )
         return
-    original_pool_scope = async_compile.pool_scope
+    if getattr(original_pool_scope, "_omni_daemon_safe", False):
+        return
 
     @contextmanager
     def daemon_safe_pool_scope():
         # spawn can import this module before installing the child's daemon flag.
         # Check at tuning time; suppress_pool keeps compilation in-process.
         if current_process().daemon:
-            with async_compile.suppress_pool():
+            with suppress_pool():
                 yield None
         else:
             with original_pool_scope() as pool:
@@ -144,7 +151,8 @@ def _scales_valid(scale_a: torch.Tensor, scale_b: torch.Tensor) -> bool:
     picks up the fast path once the real scale is written.
 
     Exclude pointer checks and cache updates from tracing to avoid recompilation
-    for each layer's scale addresses.
+    for each layer's scale addresses. For Cosmos3-Super-Image2Video-4Step request time (193 frames,
+    720p, single GB200) is: ~13 min on ToT vs. ~22 s with this fix.
     """
     key = (scale_a.data_ptr(), scale_b.data_ptr())
     if key in _valid_scale_ptrs:

--- a/vllm_omni/quantization/quack_fp8.py
+++ b/vllm_omni/quantization/quack_fp8.py
@@ -67,29 +67,17 @@ def _configure_quack_compilation() -> None:
     if getattr(async_compile.pool_scope, "_omni_daemon_safe", False):
         return
     original_pool_scope = async_compile.pool_scope
-    suppress_pool = async_compile.suppress_pool
-    logged_in_process = False
 
     @contextmanager
     def daemon_safe_pool_scope():
-        nonlocal logged_in_process
-        # spawn may import this module before _bootstrap installs the child
-        # Process and its daemon flag. Check when tuning starts, not at import.
-        if not current_process().daemon:
+        # spawn can import this module before installing the child's daemon flag.
+        # Check at tuning time; suppress_pool keeps compilation in-process.
+        if current_process().daemon:
+            with async_compile.suppress_pool():
+                yield None
+        else:
             with original_pool_scope() as pool:
                 yield pool
-            return
-        # Quack 0.6.4 imports pool_scope inside its autotuner's cold-cache
-        # benchmark loop. Suppression makes jit_cache compile/load locally,
-        # so no CompilePending is raised and the loop never needs pool.poll.
-        # Replacing the scope also avoids constructing an unused executor.
-        # Candidate pruning, benchmarking, winner selection and disk caching
-        # stay in Quack. This adaptation is local to this daemon process.
-        if not logged_in_process:
-            logger.info("Quack autotuning will compile candidates in-process in this daemon worker.")
-            logged_in_process = True
-        with suppress_pool():
-            yield None
 
     daemon_safe_pool_scope._omni_daemon_safe = True
     async_compile.pool_scope = daemon_safe_pool_scope
@@ -117,10 +105,7 @@ def _load_quack():
 
         _configure_quack_compilation()
         _gemm_interface = gemm_interface
-        logger.info(
-            "Quack FP8 fused-bias GEMM enabled (CuteDSL, cache=%s).",
-            os.environ["QUACK_CACHE_DIR"],
-        )
+        logger.info("Quack FP8 fused-bias GEMM enabled (CuteDSL).")
         return gemm_interface
     except Exception as exc:  # noqa: BLE001
         logger.warning("Quack FP8 unavailable, using FlashInfer: %s", exc)
@@ -141,8 +126,6 @@ def quack_scaled_fp8_mm(
         return None
     out = torch.empty(a.shape[0], b.shape[1], device=a.device, dtype=out_dtype)
     alpha = scale_a.reshape(1).float() * scale_b.reshape(1).float()
-    # Keep alpha as a device tensor: calibrated scale values are runtime data,
-    # not Python constants to specialize the compiled GEMM on.
     gemm.gemm(a, b, out=out, bias=bias, alpha=alpha, tuned=True)
     return out
 
@@ -160,9 +143,8 @@ def _scales_valid(scale_a: torch.Tensor, scale_b: torch.Tensor) -> bool:
     Cache only positive results: a buffer still holding the sentinel is re-checked and
     picks up the fast path once the real scale is written.
 
-    Keep pointer checks and the mutable cache outside Dynamo tracing. Otherwise
-    different layers' scale addresses/cache updates specialize the surrounding
-    graph and trigger recompilation even when GEMM shapes are identical.
+    Exclude pointer checks and cache updates from tracing to avoid recompilation
+    for each layer's scale addresses.
     """
     key = (scale_a.data_ptr(), scale_b.data_ptr())
     if key in _valid_scale_ptrs:
@@ -221,8 +203,6 @@ def warmup_quack_fp8(
     scale = torch.ones(1, device=device, dtype=torch.float32)
     for m, k, n in shapes:
         a = torch.zeros(m, k, device=device, dtype=torch.float8_e4m3fn)
-        # ModelOpt transposes the contiguous [N, K] checkpoint weight after
-        # loading. A contiguous [K, N] here would warm a different cache key.
         b = torch.zeros(n, k, device=device, dtype=torch.float8_e4m3fn).t()
         quack_scaled_fp8_mm(a, b, scale, scale, out_dtype)
     if torch.cuda.is_available():

--- a/vllm_omni/quantization/quack_fp8.py
+++ b/vllm_omni/quantization/quack_fp8.py
@@ -57,8 +57,6 @@ def _set_persistent_cache_dir() -> None:
 
 def _configure_quack_compilation() -> None:
     """Keep autotuning in daemon workers without starting compiler children."""
-    if not current_process().daemon:
-        return
     try:
         async_compile = import_module("quack.cache.async_compile")
     except ModuleNotFoundError as exc:
@@ -66,24 +64,35 @@ def _configure_quack_compilation() -> None:
         if exc.name not in {"quack.cache", "quack.cache.async_compile"}:
             raise
         return
-    if getattr(async_compile.pool_scope, "_omni_in_process", False):
+    if getattr(async_compile.pool_scope, "_omni_daemon_safe", False):
         return
+    original_pool_scope = async_compile.pool_scope
     suppress_pool = async_compile.suppress_pool
+    logged_in_process = False
 
     @contextmanager
-    def in_process_pool_scope():
+    def daemon_safe_pool_scope():
+        nonlocal logged_in_process
+        # spawn may import this module before _bootstrap installs the child
+        # Process and its daemon flag. Check when tuning starts, not at import.
+        if not current_process().daemon:
+            with original_pool_scope() as pool:
+                yield pool
+            return
         # Quack 0.6.4 imports pool_scope inside its autotuner's cold-cache
         # benchmark loop. Suppression makes jit_cache compile/load locally,
         # so no CompilePending is raised and the loop never needs pool.poll.
         # Replacing the scope also avoids constructing an unused executor.
         # Candidate pruning, benchmarking, winner selection and disk caching
         # stay in Quack. This adaptation is local to this daemon process.
+        if not logged_in_process:
+            logger.info("Quack autotuning will compile candidates in-process in this daemon worker.")
+            logged_in_process = True
         with suppress_pool():
             yield None
 
-    in_process_pool_scope._omni_in_process = True
-    async_compile.pool_scope = in_process_pool_scope
-    logger.info("Quack autotuning will compile candidates in-process in this daemon worker.")
+    daemon_safe_pool_scope._omni_daemon_safe = True
+    async_compile.pool_scope = daemon_safe_pool_scope
 
 
 def _load_quack():


### PR DESCRIPTION
<!-- markdownlint-disable -->
This PR fixes errors which showed up for multi-GPU inference with Quack FP8 kernels. It also reduces the number of recompilations coming from `torch.compile`

## Purpose
Before this PR and when using fresh cache, multi-GPU with `--ulysses-degree` would fail with the following error:

`AssertionError: daemonic processes are not allowed to have children`

Tested for FP8 Cosmos3 variants.

There would also be multiple `torch.compile` recompilations, effectively blocking us from using Quack FP8 kernels even for a single GPU case.

This PR fixes both issues. The daemon issue is fixed by compiling the Quack kernels in-process. The recompilation issue is fixed by excluding the scale validation from Dynamo tracing.
## Test Plan

### Unit tests
This PR adds 3 new unit tests.

### Serving tests

To reproduce the multi-GPU issue run the model as follows for an empty cache (run `rm -rf  ~/.cache/vllm_omni/quack` to make sure the cache is empty):

`vllm serve <local_cosmos3_path> --omni --ulysses-degree 2`
where `<local_cosmos3_path>` is the FP8 branch of `nvidia/Cosmos3-Super-Image2Video-4Step` model: https://huggingface.co/nvidia/Cosmos3-Super-Image2Video-4Step/tree/fp8.

After that run the request:
`curl -sS -X POST http://localhost:8000/v1/videos/sync -H "Accept: video/mp4" -F "prompt=A dog playing in the park" -F "negative_prompt=blurry, distorted, low quality" -F "size=1280x720" -F "num_frames=193" -F "fps=24" -F "num_inference_steps=4"  -F "seed=42" -F "input_reference=@input.png" -F 'extra_params={"use_resolution_template":false,"use_duration_template":false}' -o cosmos3_i2v.mp4`

`input.png` can be any image, this improvement is not about quality.

The inference is going to fail with `AssertionError: daemonic processes are not allowed to have children` error.

When running on 1 GPU, so without `--ulysses-degree 2` argument, this error won't show up, but instead we'll get warnings about exceeding the `torch.compile` cache size.

**vLLM Version:**
0.29
**vLLM-Omni Commit:**
ToT
## Test Result

### Unit tests
All new unit tests pass

### Serving tests
After this PR the single GPU inference doesn't exceed the `torch.compile` cache size, as there are no recompilations necessary. The Quack autotune also doesn't break for multi-GPU inference. It can take several minutes to autotune the Quack kernels on a first run, but after Quack cache is populated, new runs are quick.


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
