### PR TITLE
[Perf][Frontend] Chunk in-memory image file responses

### DIFF
--- a/tests/benchmarks/benchmark_image_file_response.py
+++ b/tests/benchmarks/benchmark_image_file_response.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Benchmark newline-split and fixed-size chunking of image file responses.
+
+Both variants stream the exact payload `ImageGenerationResponse.stream_response()`
+produces, so the measurement isolates the response layer: PNG encoding and ZIP
+building are shared by the variants and excluded from the timings.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import hashlib
+import io
+import json
+import statistics
+import time
+from collections.abc import AsyncIterator, Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+import numpy as np
+from PIL import Image
+from starlette.responses import StreamingResponse
+
+from vllm_omni.entrypoints.openai.protocol.images import (
+    _FILE_RESPONSE_CHUNK_SIZE,
+    ImageData,
+    ImageGenerationResponse,
+    _iter_file_chunks,
+)
+
+
+@dataclass(frozen=True)
+class BenchmarkVariant:
+    label: str
+    content: Callable[[bytes], Iterable[bytes] | AsyncIterator[memoryview]]
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be at least 1")
+    return parsed
+
+
+def _encode_png(*, width: int, height: int, seed: int) -> bytes:
+    """Encode incompressible noise, so the payload looks like a real photo."""
+    rng = np.random.default_rng(seed)
+    pixels = rng.integers(0, 256, size=(height, width, 3), dtype=np.uint8)
+    buffer = io.BytesIO()
+    Image.fromarray(pixels, mode="RGB").save(buffer, format="png")
+    return buffer.getvalue()
+
+
+async def _drain(response: StreamingResponse) -> tuple[bytes, int]:
+    """Run a response through ASGI, returning its body and non-empty frame count."""
+    body = bytearray()
+    frames = 0
+
+    async def send(message: dict[str, object]) -> None:
+        nonlocal frames
+        if message["type"] == "http.response.body" and message["body"]:
+            frames += 1
+            body.extend(cast(bytes, message["body"]))
+
+    async def receive() -> dict[str, str]:
+        return {"type": "http.disconnect"}
+
+    scope = {"type": "http", "method": "GET", "asgi": {"spec_version": "2.4"}}
+    await response(scope, receive, send)
+    return bytes(body), frames
+
+
+async def _build_payload(*, images: int, width: int, height: int, seed: int) -> bytes:
+    png = _encode_png(width=width, height=height, seed=seed)
+    response = ImageGenerationResponse(
+        created=0,
+        data=[ImageData(b64_json=base64.b64encode(png).decode()) for _ in range(images)],
+        output_format="png",
+        size=f"{width}x{height}",
+    )
+    payload, _ = await _drain(response.stream_response())
+    return payload
+
+
+async def _measure(variant: BenchmarkVariant, payload: bytes) -> dict[str, object]:
+    response = StreamingResponse(variant.content(payload), media_type="application/octet-stream")
+    cpu_start = time.process_time_ns()
+    wall_start = time.perf_counter_ns()
+    body, frames = await _drain(response)
+    wall_ms = (time.perf_counter_ns() - wall_start) / 1_000_000
+    process_cpu_ms = (time.process_time_ns() - cpu_start) / 1_000_000
+    return {
+        "label": variant.label,
+        "wall_ms": wall_ms,
+        "process_cpu_ms": process_cpu_ms,
+        "body_frames": frames,
+        "output_bytes": len(body),
+        "output_sha256": hashlib.sha256(body).hexdigest(),
+    }
+
+
+def _summarize(records: list[dict[str, object]], label: str) -> dict[str, object]:
+    selected = [record for record in records if record["label"] == label]
+    wall_values = [cast(float, record["wall_ms"]) for record in selected]
+    cpu_values = [cast(float, record["process_cpu_ms"]) for record in selected]
+    return {
+        "runs": len(selected),
+        "body_frames": cast(int, selected[0]["body_frames"]),
+        "wall_ms": {
+            "median": statistics.median(wall_values),
+            "min": min(wall_values),
+            "max": max(wall_values),
+        },
+        "process_cpu_ms": {
+            "median": statistics.median(cpu_values),
+            "min": min(cpu_values),
+            "max": max(cpu_values),
+        },
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--images", type=_positive_int, default=1, help="2 or more streams a ZIP archive")
+    parser.add_argument("--width", type=_positive_int, default=1024)
+    parser.add_argument("--height", type=_positive_int, default=1024)
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--rounds", type=_positive_int, default=3)
+    parser.add_argument("--seed", type=int, default=20260912)
+    parser.add_argument("--output-json", type=Path)
+    args = parser.parse_args()
+    if args.warmup < 0:
+        parser.error("--warmup must be non-negative")
+    return args
+
+
+async def _run(args: argparse.Namespace) -> dict[str, object]:
+    payload = await _build_payload(images=args.images, width=args.width, height=args.height, seed=args.seed)
+    baseline = BenchmarkVariant("newline_split", io.BytesIO)
+    candidate = BenchmarkVariant("fixed_size_chunks", _iter_file_chunks)
+
+    for _ in range(args.warmup):
+        for variant in (baseline, candidate):
+            await _measure(variant, payload)
+
+    records: list[dict[str, object]] = []
+    for round_index in range(args.rounds):
+        order = (baseline, candidate) if round_index % 2 == 0 else (candidate, baseline)
+        for variant in order:
+            record = await _measure(variant, payload)
+            record["round"] = round_index + 1
+            records.append(record)
+
+    output_hashes = {str(record["output_sha256"]) for record in records}
+    if len(output_hashes) != 1:
+        raise RuntimeError(f"benchmark variants produced different outputs: {sorted(output_hashes)}")
+
+    baseline_summary = _summarize(records, baseline.label)
+    candidate_summary = _summarize(records, candidate.label)
+    baseline_ms = cast(float, cast(dict[str, object], baseline_summary["wall_ms"])["median"])
+    candidate_ms = cast(float, cast(dict[str, object], candidate_summary["wall_ms"])["median"])
+    return {
+        "config": {
+            "images": args.images,
+            "width": args.width,
+            "height": args.height,
+            "warmup": args.warmup,
+            "rounds": args.rounds,
+            "seed": args.seed,
+            "chunk_size": _FILE_RESPONSE_CHUNK_SIZE,
+            "payload_bytes": len(payload),
+            "payload_newline_bytes": payload.count(b"\n"),
+        },
+        "records": records,
+        "summary": {
+            baseline.label: baseline_summary,
+            candidate.label: candidate_summary,
+            "median_wall_speedup": baseline_ms / candidate_ms,
+            "body_frame_ratio": (
+                cast(int, baseline_summary["body_frames"]) / cast(int, candidate_summary["body_frames"])
+            ),
+            "output_sha256": output_hashes.pop(),
+        },
+    }
+
+
+def main() -> None:
+    args = _parse_args()
+    result = asyncio.run(_run(args))
+    output_json = json.dumps(result, indent=2, sort_keys=True)
+    if args.output_json is not None:
+        args.output_json.write_text(output_json + "\n", encoding="utf-8")
+    print(output_json)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/entrypoints/openai_api/test_image_protocol.py
+++ b/tests/entrypoints/openai_api/test_image_protocol.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+import base64
+import io
+import zipfile
+
+import pytest
+from fastapi.responses import StreamingResponse
+
+from vllm_omni.entrypoints.openai.protocol.images import (
+    _FILE_RESPONSE_CHUNK_SIZE,
+    ImageData,
+    ImageGenerationResponse,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+_NEWLINE_HEAVY_PAYLOAD = (b"\x89PNG\n\x1a\n" * 64) + bytes(range(256)) * 8
+
+
+def _response(*payloads: bytes) -> ImageGenerationResponse:
+    return ImageGenerationResponse(
+        created=0,
+        data=[ImageData(b64_json=base64.b64encode(payload).decode()) for payload in payloads],
+        output_format="png",
+        size="1x1",
+    )
+
+
+async def _collect(response: StreamingResponse) -> list[bytes]:
+    return [bytes(chunk) async for chunk in response.body_iterator]
+
+
+@pytest.mark.asyncio
+async def test_single_file_response_chunks_ignore_newlines() -> None:
+    payload = _NEWLINE_HEAVY_PAYLOAD
+    assert b"\n" in payload
+
+    response = _response(payload).stream_response()
+    chunks = await _collect(response)
+
+    assert len(chunks) == 1
+    assert b"".join(chunks) == payload
+    assert response.headers["content-length"] == str(len(payload))
+    assert response.headers["content-type"] == "image/png"
+
+
+@pytest.mark.asyncio
+async def test_single_file_response_chunks_are_bounded() -> None:
+    payload = _NEWLINE_HEAVY_PAYLOAD * 200
+    expected_chunks = -(-len(payload) // _FILE_RESPONSE_CHUNK_SIZE)
+    assert expected_chunks > 1
+
+    chunks = await _collect(_response(payload).stream_response())
+
+    assert len(chunks) == expected_chunks
+    assert max(len(chunk) for chunk in chunks) <= _FILE_RESPONSE_CHUNK_SIZE
+    assert b"".join(chunks) == payload
+
+
+@pytest.mark.asyncio
+async def test_zip_file_response_streams_whole_archive() -> None:
+    payloads = (_NEWLINE_HEAVY_PAYLOAD, b"second image\nwith a newline")
+
+    response = _response(*payloads).stream_response()
+    chunks = await _collect(response)
+
+    zip_bytes = b"".join(chunks)
+    assert len(chunks) == -(-len(zip_bytes) // _FILE_RESPONSE_CHUNK_SIZE)
+    assert response.headers["content-length"] == str(len(zip_bytes))
+    assert response.headers["content-type"] == "application/zip"
+    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as archive:
+        assert archive.read("image_0.png") == payloads[0]
+        assert archive.read("image_1.png") == payloads[1]

--- a/vllm_omni/entrypoints/openai/protocol/images.py
+++ b/vllm_omni/entrypoints/openai/protocol/images.py
@@ -11,6 +11,7 @@ import base64
 import io
 import uuid
 import zipfile
+from collections.abc import AsyncIterator
 from enum import Enum
 from http import HTTPStatus
 from typing import Any, Literal
@@ -25,12 +26,21 @@ from vllm_omni.entrypoints.openai.image_api_utils import validate_layered_layers
 _INT64_MIN = -(2**63)
 _INT64_MAX = 2**63 - 1
 
+_FILE_RESPONSE_CHUNK_SIZE = 64 * 1024
+
 _IMAGE_FILE_METADATA = {
     "jpg": ("jpg", "image/jpeg"),
     "jpeg": ("jpeg", "image/jpeg"),
     "png": ("png", "image/png"),
     "webp": ("webp", "image/webp"),
 }
+
+
+async def _iter_file_chunks(data: bytes) -> AsyncIterator[memoryview]:
+    """Yield fixed-size chunks of an in-memory payload."""
+    view = memoryview(data)
+    for offset in range(0, len(view), _FILE_RESPONSE_CHUNK_SIZE):
+        yield view[offset : offset + _FILE_RESPONSE_CHUNK_SIZE]
 
 
 class ResponseFormat(str, Enum):
@@ -224,7 +234,7 @@ class ImageGenerationResponse(BaseModel):
             image_bytes = base64.b64decode(self.data[0].b64_json)
             filename = f"image_{uuid.uuid4().hex[:8]}.{extension}"
             return StreamingResponse(
-                io.BytesIO(image_bytes),
+                _iter_file_chunks(image_bytes),
                 media_type=media_type,
                 headers={
                     "Content-Disposition": f'attachment; filename="{filename}"',
@@ -240,7 +250,7 @@ class ImageGenerationResponse(BaseModel):
             zip_bytes = zip_buffer.getvalue()
             filename = f"images_{uuid.uuid4().hex[:8]}.zip"
             return StreamingResponse(
-                io.BytesIO(zip_bytes),
+                _iter_file_chunks(zip_bytes),
                 media_type="application/zip",
                 headers={
                     "Content-Disposition": f'attachment; filename="{filename}"',


### PR DESCRIPTION
## Purpose

`/v1/images/generations` with `response_format=file` served its payload through
`StreamingResponse(io.BytesIO(image_bytes))`. Iterating a `BytesIO` yields
**lines**, so Starlette split the already-materialized PNG/ZIP on every `0x0A`
byte in the binary payload and, because a `BytesIO` is a *sync* iterable, paid an
`iterate_in_threadpool` round-trip per fragment.

A 3 MiB PNG contains ~12k newline bytes, so one download became ~12k threadpool
hops and ~12k `http.response.body` sends. The payload is fully in memory before
the response is built and `Content-Length` is already set explicitly, so none of
that fragmentation bought anything.

This replaces the `BytesIO` with an async generator yielding fixed 64 KiB
`memoryview` slices, for both the single-image and the multi-image ZIP branch.
The response class, headers and body bytes are unchanged; only the chunk
boundaries are. 64 KiB (rather than one big chunk) keeps a yield point between
sends, so concurrent downloads still interleave and transport backpressure is
preserved.

Not changed: the encode/base64/ZIP path, the endpoint signature, and the
`ImageGenerationResponse | StreamingResponse` return type at the call site.

## Test Plan

Unit tests (new, `tests/entrypoints/openai_api/test_image_protocol.py`) — the
payloads deliberately contain `\n` so the old behavior fails them:

```bash
pytest tests/entrypoints/openai_api/test_image_protocol.py
pytest tests/entrypoints/openai_api/test_image_server.py -k "file or zip or format"
```

Benchmark (new, `tests/benchmarks/benchmark_image_file_response.py`) — both
variants stream the exact bytes `stream_response()` produces, so PNG encoding and
ZIP building are excluded from the timings, and the script fails if the two
variants do not hash identically:

```bash
# stdout also carries vllm_omni INFO lines, so read the JSON from the file
python tests/benchmarks/benchmark_image_file_response.py --rounds 5 --output-json single.json
python tests/benchmarks/benchmark_image_file_response.py --images 2 --rounds 5 --output-json zip.json
```

**vLLM Version:** 0.29.0

**vLLM-Omni Commit:** based on 7e520f9c (`origin/main`)

## Test Result

`test_image_protocol.py` 3 passed; `test_image_server.py -k "file or zip or format"`
10 passed.

Benchmark, median of 5 rounds, variants run in alternating order.
Host: Intel Xeon Gold 6530, Python 3.12.13, starlette 1.6.0, fastapi 0.136.3.
Payload is an incompressible 1024x1024 noise PNG (identical `output_sha256`
across both variants in every round):

| Payload | Variant | `http.response.body` sends | wall median | CPU median |
| --- | --- | --- | --- | --- |
| 3.01 MiB PNG | `newline_split` (before) | 12295 | 592.5 ms | 586.2 ms |
| 3.01 MiB PNG | `fixed_size_chunks` (after) | 49 | 3.3 ms | 3.3 ms |
| 6.01 MiB ZIP (2 images) | `newline_split` (before) | 24605 | 1207.9 ms | 1190.2 ms |
| 6.01 MiB ZIP (2 images) | `fixed_size_chunks` (after) | 97 | 6.4 ms | 6.4 ms |

Roughly 250x fewer sends and ~180x less time in the response layer. Wall time and
CPU time track each other, which confirms the old cost was scheduling overhead
rather than waiting on I/O. This is a response-layer micro-benchmark, not an
end-to-end serving throughput number.

Pre-commit gates run locally on the changed files: ruff 0.14.10 check + format,
`check-spdx-header`, `check-mark`, `check-forbidden-imports` — all pass. One
caveat: `mypy-3.10` reports `images.py:216` (`size: str = Field(None, ...)`),
which is pre-existing on `main` (line 202 there) and untouched by this diff; I
left it alone to keep the diff scoped.

AI assistance: Used Cursor to draft the chunking helper, the regression tests,
the benchmark script and this description. I reviewed every change, ran the
tests and benchmarks reported above myself, and confirmed the before/after
payloads are byte-identical.
