### PR TITLE
[Bugfix] MiniMax-H3: scope audio decode backend determinism

### DIFF
--- a/vllm_omni/diffusion/models/minimax_h3/vae.py
+++ b/vllm_omni/diffusion/models/minimax_h3/vae.py
@@ -570,7 +570,8 @@ class MiniMaxH3AudioVAE(nn.Module):
             device=latent.device,
             dtype=latent.dtype,
         ).view(1, channels, 1)
-        waveform = self.remote.decode(latent * std + mean)
+        with _AudioVAEDeterminismContext():
+            waveform = self.remote.decode(latent * std + mean)
         if waveform.ndim != 3 or waveform.shape[1] != 1:
             raise ValueError(f"unexpected decoded audio shape {tuple(waveform.shape)}")
         return waveform.permute(1, 0, 2).contiguous().float()


### PR DESCRIPTION
## Problem and change

MiniMax-H3 audio reference encoding already enters `_AudioVAEDeterminismContext`, but generated audio decoding calls `remote.decode` with the ambient CUDA/cuDNN/SDPA settings. Apply the same existing scope to decode, restoring the caller's settings on both success and failure.

This is extracted from the historical H3 deployment patch that was previously bundled into #7425. It has no PDD dependency and makes no speedup or current GPU bitwise-reproducibility claim.

## Validation and remaining work

- Ruff and whitespace checks passed.
- A focused CPU check executed the exact changed class bodies with PyTorch 2.11.0+cu130: the decoder observed the intended backend flags, returned the existing float32 `(1, channels, samples)` output contract, and restored all saved flags after both success and an injected decoder error.
- Full package testing on the available H20 host is blocked by a dependency mismatch: its vLLM 0.26 lacks `vllm.entrypoints.serve.exception_handling`, which current vLLM-Omni imports.
- Ready for review; remaining validation is a matched GPU audio-decode comparison on a compatible environment, including latency and waveform repeatability. The context disables cuDNN/fast SDPA, so an audio-decode performance tradeoff must be measured before merging.

Self-review: the diff only scopes the existing decode call; model loading, latent normalization, waveform validation, and return layout are unchanged. No running service was restarted.
