### PR TITLE
fix(qwen-image): drop the shadowed dead _get_qwen_prompt_embeds duplicate

### DIFF
--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
@@ -377,51 +377,6 @@ class QwenImageEditPipeline(
     def _get_qwen_prompt_embeds(
         self,
         prompt: str | list[str] = None,
-        image: torch.Tensor | None = None,
-        dtype: torch.dtype | None = None,
-    ):
-        dtype = dtype or self.text_encoder.dtype
-
-        prompt = [prompt] if isinstance(prompt, str) else prompt
-
-        template = self.prompt_template_encode
-        drop_idx = self.prompt_template_encode_start_idx
-        txt = [template.format(e) for e in prompt]
-
-        model_inputs = self.processor(
-            text=txt,
-            images=image,
-            padding=True,
-            return_tensors="pt",
-        ).to(self.device)
-
-        outputs = self.text_encoder(
-            input_ids=model_inputs.input_ids,
-            attention_mask=model_inputs.attention_mask,
-            pixel_values=model_inputs.pixel_values,
-            image_grid_thw=model_inputs.image_grid_thw,
-            output_hidden_states=True,
-        )
-
-        hidden_states = outputs.hidden_states[-1]
-        split_hidden_states = self._extract_masked_hidden(hidden_states, model_inputs.attention_mask)
-        split_hidden_states = [e[drop_idx:] for e in split_hidden_states]
-        attn_mask_list = [torch.ones(e.size(0), dtype=torch.long, device=e.device) for e in split_hidden_states]
-        max_seq_len = max([e.size(0) for e in split_hidden_states])
-        prompt_embeds = torch.stack(
-            [torch.cat([u, u.new_zeros(max_seq_len - u.size(0), u.size(1))]) for u in split_hidden_states]
-        )
-        encoder_attention_mask = torch.stack(
-            [torch.cat([u, u.new_zeros(max_seq_len - u.size(0))]) for u in attn_mask_list]
-        )
-
-        prompt_embeds = prompt_embeds.to(dtype=dtype, device=self.device)
-
-        return prompt_embeds, encoder_attention_mask
-
-    def _get_qwen_prompt_embeds(
-        self,
-        prompt: str | list[str] = None,
         image: PIL.Image.Image | torch.Tensor | None = None,
         dtype: torch.dtype | None = None,
         max_sequence_length: int | None = None,


### PR DESCRIPTION
### Problem

`QwenImageEditPipeline._get_qwen_prompt_embeds` is defined **twice** in
`vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py`. In Python
the second `def` silently shadows the first, so the first 44-line copy is dead
code that can never run.

The two definitions are not interchangeable:

- The **first** (dead) copy has signature `(self, prompt, image, dtype)` and no
  sequence-length validation.
- The **second** (live) copy adds `max_sequence_length` / `prompt_name`, calls
  `validate_prompt_sequence_lengths(...)`, and is what `encode_prompt` actually
  invokes:

  ```python
  prompt_embeds, prompt_embeds_mask = self._get_qwen_prompt_embeds(
      prompt, image,
      max_sequence_length=max_sequence_length,
      prompt_name=prompt_name,
  )
  ```

  Those keyword arguments only exist on the second definition — the first would
  raise `TypeError` if it were ever bound.

### Fix

Remove the unreachable first definition. This is a pure no-op at runtime (the
live method is untouched) and drops a latent footgun.

`+0 / -45`, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
