### PR TITLE
[Kernel] Add dual-output RVQ RMSNorm fusion benchmark

### DIFF
--- a/benchmarks/kernels/bench_rvq_rmsnorm.py
+++ b/benchmarks/kernels/bench_rvq_rmsnorm.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Measure both observable RVQ/RMSNorm outputs against compiled PyTorch."""
+
+import argparse
+import json
+import math
+import random
+import statistics
+from functools import partial
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    # Create the evidence file before GPU setup and preserve partial failures.
+    with args.output.open("x") as output:
+        output.write("{}\n")
+
+    import torch
+    import torch._inductor.config as inductor_config
+    from vllm.triton_utils import triton
+
+    from benchmarks.kernels.rvq_rmsnorm import make_variant, native_region
+
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (12, 0):
+        raise RuntimeError("This confirmation matrix requires SM120")
+    if not inductor_config.emulate_precision_casts:
+        raise RuntimeError("Set TORCHINDUCTOR_EMULATE_PRECISION_CASTS=1 before starting Python")
+    if triton.__version__ != "3.7.1":
+        raise RuntimeError("The recorded matrix used Triton 3.7.1; validate other versions separately")
+
+    baseline = torch.compile(native_region, fullgraph=True, dynamic=False)
+    candidate = make_variant(4)
+    result = {"torch": torch.__version__, "triton": triton.__version__, "rows": [], "success": False}
+    rng = random.Random(60932)
+
+    def checkpoint():
+        args.output.write_text(json.dumps(result, indent=2, allow_nan=False) + "\n")
+
+    with torch.inference_mode(), torch._dynamo.config.patch(recompile_limit=256):
+        for dtype in (torch.float16, torch.bfloat16):
+            for frames in (1, 32, 128):
+                for strided in (False, True):
+                    generator = torch.Generator(device="cuda").manual_seed(947)
+                    codes = torch.randint(
+                        2048,
+                        (1, 16, frames * (2 if strided else 1)),
+                        device="cuda",
+                        generator=generator,
+                    )
+                    if strided:
+                        codes = codes[..., ::2]
+                    weight = torch.randn(16 * 2048, 1024, dtype=dtype, device="cuda", generator=generator)
+                    offsets = (torch.arange(16, device="cuda") * 2048).view(1, 16, 1)
+                    gamma = torch.randn(1024, dtype=dtype, device="cuda", generator=generator)
+                    inputs = codes, weight, offsets, gamma, 1e-5
+                    expected = native_region(*inputs)
+                    calls = {"A": partial(baseline, *inputs), "P": partial(candidate, *inputs)}
+                    for call in calls.values():
+                        for actual, target in zip(call(), expected, strict=True):
+                            for classifier in (torch.isfinite, torch.isnan, torch.isposinf, torch.isneginf):
+                                assert torch.equal(classifier(actual), classifier(target))
+                            finite = torch.isfinite(target)
+                            torch.testing.assert_close(actual[finite], target[finite], atol=0.002, rtol=0.002)
+                    for mode in ("eager", "graph"):
+                        arms, ratios = [], []
+                        for block in range(3):
+                            order = rng.choice(("APPA", "PAAP"))
+                            timings = {"A": [], "P": []}
+                            for position, arm in enumerate(order):
+                                if mode == "eager":
+                                    ms = triton.testing.do_bench(calls[arm], warmup=5, rep=20, return_mode="median")
+                                else:
+                                    ms = triton.testing.do_bench_cudagraph(calls[arm], rep=20, return_mode="median")
+                                if not math.isfinite(ms) or ms <= 0:
+                                    raise ValueError("Invalid timing; retain this incomplete result")
+                                timings[arm].append(ms)
+                                arms.append({"block": block, "position": position, "arm": arm, "ms": ms})
+                            ratios.append(
+                                statistics.mean(map(math.log, timings["P"]))
+                                - statistics.mean(map(math.log, timings["A"]))
+                            )
+                        result["rows"].append(
+                            {
+                                "dtype": str(dtype),
+                                "frames": frames,
+                                "strided": strided,
+                                "mode": mode,
+                                "latency_reduction_percent": 100 * (1 - math.exp(statistics.mean(ratios))),
+                                "arms": arms,
+                            }
+                        )
+                        checkpoint()
+    result["success"] = True
+    checkpoint()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/rvq_rmsnorm.md
+++ b/benchmarks/kernels/rvq_rmsnorm.md
@@ -1,20 +1,75 @@
-# Dual-output RVQ and first RMSNorm fusion
+# Native-order RVQ and first RMSNorm experiment
 
-This opt-in benchmark fuses a 16-quantizer embedding mean with the first input
-RMSNorm. It returns both the low-precision raw residual and normalized values.
-The residual is rounded before FP32 RMS statistics, and normalization is cast
-before multiplication by the live gamma. Keeping both outputs observable is
-necessary to represent the complete consumer region.
+The opt-in A13 primitive uses two Triton kernels. The first reduces 16 embedding
+rows in native accumulation order into a rounded raw residual, using 128-channel
+tiles. The second reads that residual directly in the native RMS reduction lanes
+and writes normalized values. The raw residual remains observable, and the cast
+before live gamma multiplication is preserved.
 
-The primitive is isolated under `benchmarks/kernels`; no model default or
-Transformer consumer is changed. This is a proposal for a reusable fusion
-boundary, not a claim about complete text-to-audio requests.
+The experiment remains under `benchmarks/kernels`. Model defaults and production
+consumers are unchanged. The previous one-program region prototype is superseded;
+its 1.638–58.314% region measurements do not describe A13.
 
-## Reproduce
+## Complete Code2Wav validation
 
-Install vLLM-Omni with an SM120-capable CUDA runtime. The measured environment
-used Torch 2.13.0+cu130, Triton 3.7.1 and an NVIDIA RTX PRO 5000 Blackwell.
-The benchmark checks SM120 and the recorded Triton version explicitly.
+The archived A13 r2 run used one RTX PRO 4000 Blackwell 24 GB (SM120), Torch
+2.13.0+cu130, CUDA 13.0, Triton 3.7.1 and Transformers 5.14.1. The checkpoint
+revision is `12a3ac6661e685620bbc6616b7217b26469a81dd`; all three required files,
+230 tensors and the HF implementation were hash-verified. All eight Transformer
+layers and the complete waveform decoder execute. Inputs are seeded synthetic
+codec IDs, so this is complete codec-to-waveform execution, not full text/audio
+Omni request E2E.
+
+The baseline is compiled RVQ followed by native first RMSNorm and the shared
+complete consumer. A prior whole-region compiled baseline failed waveform
+correctness in two cases and was rejected. Both arms use the same isolated mask
+adapter for capture; the installed HF forward is unchanged and is the output
+reference. Initial r1 timings overlapped other work and were rejected; only the
+fresh r2 cohort is reported.
+
+All 24 original/changed raw-and-normalized stage cases and all 72 original,
+changed-input and restored complete-waveform comparisons are bit-exact. Four
+semantic GPU groups pass without skips. The test retains its original
+`atol=rtol=0.002` and reports the stronger observed bit equality separately.
+All 768 timing arms and 48 path checks completed. The candidate traces contain
+both `_rvq_native_mean_kernel` and `_native_first_rmsnorm_kernel`; neither occurs
+in the baseline. Graph traces verify replay independently of timing.
+
+Each case/mode has three warmup calls and eight alternating APPA/PAAP blocks,
+with ten complete forward calls per timing arm. Synchronized wall time includes
+the complete waveform consumer and excludes compilation, model loading, warmup,
+input copies and profiling. Positive values below mean lower candidate latency.
+
+| Dtype | Frames | Strided codes | Eager latency reduction | Graph latency reduction |
+|---|---:|---|---:|---:|
+| float16 | 1 | False | -0.091675% | +0.470098% |
+| float16 | 1 | True | +0.351706% | +0.193401% |
+| float16 | 32 | False | +0.565889% | -0.229305% |
+| float16 | 32 | True | +0.053497% | -0.200676% |
+| float16 | 128 | False | +0.117682% | +0.030157% |
+| float16 | 128 | True | +0.050532% | +0.009659% |
+| bfloat16 | 1 | False | +0.541099% | +0.341701% |
+| bfloat16 | 1 | True | +0.378751% | +0.271446% |
+| bfloat16 | 32 | False | +0.447490% | -0.225574% |
+| bfloat16 | 32 | True | +0.727869% | -0.190366% |
+| bfloat16 | 128 | False | +0.071706% | +0.048593% |
+| bfloat16 | 128 | True | +0.061728% | +0.043783% |
+
+There are **19 positive and 5 negative scenarios**. All four T32 Graph scenarios
+regress by about 0.19–0.23%; FP16/T1/contiguous eager also regresses. No causal
+attribution for these small differences has been established. These are
+single-cohort descriptive observations, with no confidence interval or stable
+all-scenario speedup claim. Peak VRAM was not recorded in this cohort.
+
+## Reproduce and review
+
+[The complete frozen runner, model/source hashes, stage checks and every timing arm](https://gist.github.com/0z5a/32cd168d1ed19b4bf86f9a75596d788c)
+are available as one archive. Its README gives the exact frozen-runtime command,
+source layout and checkpoint checks. The `performance_accepted` field only means
+that timing passed correctness/provenance/path gates; `all_speedups_positive`
+is false and records the failed performance goal.
+
+The repository also retains a small generated-parameter region diagnostic:
 
 ```bash
 TORCHINDUCTOR_EMULATE_PRECISION_CASTS=1 python -m benchmarks.kernels.bench_rvq_rmsnorm --output rvq-results.json
@@ -22,31 +77,13 @@ TORCHINDUCTOR_EMULATE_PRECISION_CASTS=1 pytest tests/model_executor/layers/test_
 pytest tests/model_executor/layers/test_rvq_rmsnorm_cpu.py
 ```
 
-Both timing arms use `torch.compile(fullgraph=True, dynamic=False)` and
-`emulate_precision_casts=True`. Four warps are fixed for all confirmation
-cases. The matrix covers FP16/BF16, 1/32/128 frames, contiguous/strided codes,
-hidden width 1024, 16 codebooks with 2048 entries each, and epsilon 1e-5.
-Gamma and table values are generated, not extracted from a model checkpoint.
-Each case measures eager and Graph execution in three paired quartets,
-retaining all 288 timing arms across 24 case/mode combinations.
+That region runner compares against whole-region compiled PyTorch and does not
+reproduce the checkpoint-derived Code2Wav table above. Unsupported input metadata
+uses native arithmetic. Bit-exact behavior is established only for the frozen
+runtime and tested cases; other shapes retain the numerical regression contract.
 
-## Recorded result and numerical contract
-
-The archived confirmation improved all 24 case/mode combinations by
-**1.638–58.314%** relative to compiled PyTorch over this complete dual-output
-region. These are descriptive paired reductions, not full-model speedups or
-confidence intervals. The checked-in runner exposes the same matrix; its new
-publication entry point has not been timed on a GPU.
-
-Finite outputs are compared with `atol=rtol=0.002`; NaN, positive/negative
-infinity and finite masks must match exactly. This fusion does not promise
-bitwise equality. GPU regressions cover hidden tails, changed live buffers,
-nondefault streams, Graph replay, nonfinite values, lazy views, mixed gamma
-dtype, autocast, gradients and empty inputs. Unsupported metadata uses the
-native arithmetic, preserving dtype promotion and gradient behavior.
-
-The kernel arithmetic and launch arguments are preserved from the tested
-source. Publication changes use project Triton imports and the platform
-current-device API, format the source, and provide a standalone matrix runner.
-New hardware, compiler versions and production consumer integration require
-their own numerical and complete-model validation.
+Publication preserves all three Triton function ASTs, arithmetic and launch
+arguments from the validated source. It adapts imports/current-device lookup to
+project APIs and adds a frozen-runtime exact-output regression. The public wrapper
+and new regression have not received a fresh GPU run. CPU metadata checks and
+changed-file hooks are reported separately in the PR.

--- a/benchmarks/kernels/rvq_rmsnorm.md
+++ b/benchmarks/kernels/rvq_rmsnorm.md
@@ -1,75 +1,20 @@
-# Native-order RVQ and first RMSNorm experiment
+# Dual-output RVQ and first RMSNorm fusion
 
-The opt-in A13 primitive uses two Triton kernels. The first reduces 16 embedding
-rows in native accumulation order into a rounded raw residual, using 128-channel
-tiles. The second reads that residual directly in the native RMS reduction lanes
-and writes normalized values. The raw residual remains observable, and the cast
-before live gamma multiplication is preserved.
+This opt-in benchmark fuses a 16-quantizer embedding mean with the first input
+RMSNorm. It returns both the low-precision raw residual and normalized values.
+The residual is rounded before FP32 RMS statistics, and normalization is cast
+before multiplication by the live gamma. Keeping both outputs observable is
+necessary to represent the complete consumer region.
 
-The experiment remains under `benchmarks/kernels`. Model defaults and production
-consumers are unchanged. The previous one-program region prototype is superseded;
-its 1.638–58.314% region measurements do not describe A13.
+The primitive is isolated under `benchmarks/kernels`; no model default or
+Transformer consumer is changed. This is a proposal for a reusable fusion
+boundary, not a claim about complete text-to-audio requests.
 
-## Complete Code2Wav validation
+## Reproduce
 
-The archived A13 r2 run used one RTX PRO 4000 Blackwell 24 GB (SM120), Torch
-2.13.0+cu130, CUDA 13.0, Triton 3.7.1 and Transformers 5.14.1. The checkpoint
-revision is `12a3ac6661e685620bbc6616b7217b26469a81dd`; all three required files,
-230 tensors and the HF implementation were hash-verified. All eight Transformer
-layers and the complete waveform decoder execute. Inputs are seeded synthetic
-codec IDs, so this is complete codec-to-waveform execution, not full text/audio
-Omni request E2E.
-
-The baseline is compiled RVQ followed by native first RMSNorm and the shared
-complete consumer. A prior whole-region compiled baseline failed waveform
-correctness in two cases and was rejected. Both arms use the same isolated mask
-adapter for capture; the installed HF forward is unchanged and is the output
-reference. Initial r1 timings overlapped other work and were rejected; only the
-fresh r2 cohort is reported.
-
-All 24 original/changed raw-and-normalized stage cases and all 72 original,
-changed-input and restored complete-waveform comparisons are bit-exact. Four
-semantic GPU groups pass without skips. The test retains its original
-`atol=rtol=0.002` and reports the stronger observed bit equality separately.
-All 768 timing arms and 48 path checks completed. The candidate traces contain
-both `_rvq_native_mean_kernel` and `_native_first_rmsnorm_kernel`; neither occurs
-in the baseline. Graph traces verify replay independently of timing.
-
-Each case/mode has three warmup calls and eight alternating APPA/PAAP blocks,
-with ten complete forward calls per timing arm. Synchronized wall time includes
-the complete waveform consumer and excludes compilation, model loading, warmup,
-input copies and profiling. Positive values below mean lower candidate latency.
-
-| Dtype | Frames | Strided codes | Eager latency reduction | Graph latency reduction |
-|---|---:|---|---:|---:|
-| float16 | 1 | False | -0.091675% | +0.470098% |
-| float16 | 1 | True | +0.351706% | +0.193401% |
-| float16 | 32 | False | +0.565889% | -0.229305% |
-| float16 | 32 | True | +0.053497% | -0.200676% |
-| float16 | 128 | False | +0.117682% | +0.030157% |
-| float16 | 128 | True | +0.050532% | +0.009659% |
-| bfloat16 | 1 | False | +0.541099% | +0.341701% |
-| bfloat16 | 1 | True | +0.378751% | +0.271446% |
-| bfloat16 | 32 | False | +0.447490% | -0.225574% |
-| bfloat16 | 32 | True | +0.727869% | -0.190366% |
-| bfloat16 | 128 | False | +0.071706% | +0.048593% |
-| bfloat16 | 128 | True | +0.061728% | +0.043783% |
-
-There are **19 positive and 5 negative scenarios**. All four T32 Graph scenarios
-regress by about 0.19–0.23%; FP16/T1/contiguous eager also regresses. No causal
-attribution for these small differences has been established. These are
-single-cohort descriptive observations, with no confidence interval or stable
-all-scenario speedup claim. Peak VRAM was not recorded in this cohort.
-
-## Reproduce and review
-
-[The complete frozen runner, model/source hashes, stage checks and every timing arm](https://gist.github.com/0z5a/32cd168d1ed19b4bf86f9a75596d788c)
-are available as one archive. Its README gives the exact frozen-runtime command,
-source layout and checkpoint checks. The `performance_accepted` field only means
-that timing passed correctness/provenance/path gates; `all_speedups_positive`
-is false and records the failed performance goal.
-
-The repository also retains a small generated-parameter region diagnostic:
+Install vLLM-Omni with an SM120-capable CUDA runtime. The measured environment
+used Torch 2.13.0+cu130, Triton 3.7.1 and an NVIDIA RTX PRO 5000 Blackwell.
+The benchmark checks SM120 and the recorded Triton version explicitly.
 
 ```bash
 TORCHINDUCTOR_EMULATE_PRECISION_CASTS=1 python -m benchmarks.kernels.bench_rvq_rmsnorm --output rvq-results.json
@@ -77,13 +22,31 @@ TORCHINDUCTOR_EMULATE_PRECISION_CASTS=1 pytest tests/model_executor/layers/test_
 pytest tests/model_executor/layers/test_rvq_rmsnorm_cpu.py
 ```
 
-That region runner compares against whole-region compiled PyTorch and does not
-reproduce the checkpoint-derived Code2Wav table above. Unsupported input metadata
-uses native arithmetic. Bit-exact behavior is established only for the frozen
-runtime and tested cases; other shapes retain the numerical regression contract.
+Both timing arms use `torch.compile(fullgraph=True, dynamic=False)` and
+`emulate_precision_casts=True`. Four warps are fixed for all confirmation
+cases. The matrix covers FP16/BF16, 1/32/128 frames, contiguous/strided codes,
+hidden width 1024, 16 codebooks with 2048 entries each, and epsilon 1e-5.
+Gamma and table values are generated, not extracted from a model checkpoint.
+Each case measures eager and Graph execution in three paired quartets,
+retaining all 288 timing arms across 24 case/mode combinations.
 
-Publication preserves all three Triton function ASTs, arithmetic and launch
-arguments from the validated source. It adapts imports/current-device lookup to
-project APIs and adds a frozen-runtime exact-output regression. The public wrapper
-and new regression have not received a fresh GPU run. CPU metadata checks and
-changed-file hooks are reported separately in the PR.
+## Recorded result and numerical contract
+
+The archived confirmation improved all 24 case/mode combinations by
+**1.638–58.314%** relative to compiled PyTorch over this complete dual-output
+region. These are descriptive paired reductions, not full-model speedups or
+confidence intervals. The checked-in runner exposes the same matrix; its new
+publication entry point has not been timed on a GPU.
+
+Finite outputs are compared with `atol=rtol=0.002`; NaN, positive/negative
+infinity and finite masks must match exactly. This fusion does not promise
+bitwise equality. GPU regressions cover hidden tails, changed live buffers,
+nondefault streams, Graph replay, nonfinite values, lazy views, mixed gamma
+dtype, autocast, gradients and empty inputs. Unsupported metadata uses the
+native arithmetic, preserving dtype promotion and gradient behavior.
+
+The kernel arithmetic and launch arguments are preserved from the tested
+source. Publication changes use project Triton imports and the platform
+current-device API, format the source, and provide a standalone matrix runner.
+New hardware, compiler versions and production consumer integration require
+their own numerical and complete-model validation.

--- a/benchmarks/kernels/rvq_rmsnorm.md
+++ b/benchmarks/kernels/rvq_rmsnorm.md
@@ -1,0 +1,52 @@
+# Dual-output RVQ and first RMSNorm fusion
+
+This opt-in benchmark fuses a 16-quantizer embedding mean with the first input
+RMSNorm. It returns both the low-precision raw residual and normalized values.
+The residual is rounded before FP32 RMS statistics, and normalization is cast
+before multiplication by the live gamma. Keeping both outputs observable is
+necessary to represent the complete consumer region.
+
+The primitive is isolated under `benchmarks/kernels`; no model default or
+Transformer consumer is changed. This is a proposal for a reusable fusion
+boundary, not a claim about complete text-to-audio requests.
+
+## Reproduce
+
+Install vLLM-Omni with an SM120-capable CUDA runtime. The measured environment
+used Torch 2.13.0+cu130, Triton 3.7.1 and an NVIDIA RTX PRO 5000 Blackwell.
+The benchmark checks SM120 and the recorded Triton version explicitly.
+
+```bash
+TORCHINDUCTOR_EMULATE_PRECISION_CASTS=1 python -m benchmarks.kernels.bench_rvq_rmsnorm --output rvq-results.json
+TORCHINDUCTOR_EMULATE_PRECISION_CASTS=1 pytest tests/model_executor/layers/test_rvq_rmsnorm_gpu.py
+pytest tests/model_executor/layers/test_rvq_rmsnorm_cpu.py
+```
+
+Both timing arms use `torch.compile(fullgraph=True, dynamic=False)` and
+`emulate_precision_casts=True`. Four warps are fixed for all confirmation
+cases. The matrix covers FP16/BF16, 1/32/128 frames, contiguous/strided codes,
+hidden width 1024, 16 codebooks with 2048 entries each, and epsilon 1e-5.
+Gamma and table values are generated, not extracted from a model checkpoint.
+Each case measures eager and Graph execution in three paired quartets,
+retaining all 288 timing arms across 24 case/mode combinations.
+
+## Recorded result and numerical contract
+
+The archived confirmation improved all 24 case/mode combinations by
+**1.638–58.314%** relative to compiled PyTorch over this complete dual-output
+region. These are descriptive paired reductions, not full-model speedups or
+confidence intervals. The checked-in runner exposes the same matrix; its new
+publication entry point has not been timed on a GPU.
+
+Finite outputs are compared with `atol=rtol=0.002`; NaN, positive/negative
+infinity and finite masks must match exactly. This fusion does not promise
+bitwise equality. GPU regressions cover hidden tails, changed live buffers,
+nondefault streams, Graph replay, nonfinite values, lazy views, mixed gamma
+dtype, autocast, gradients and empty inputs. Unsupported metadata uses the
+native arithmetic, preserving dtype promotion and gradient behavior.
+
+The kernel arithmetic and launch arguments are preserved from the tested
+source. Publication changes use project Triton imports and the platform
+current-device API, format the source, and provide a standalone matrix runner.
+New hardware, compiler versions and production consumer integration require
+their own numerical and complete-model validation.

--- a/benchmarks/kernels/rvq_rmsnorm.py
+++ b/benchmarks/kernels/rvq_rmsnorm.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
-"""Opt-in dual-output RVQ/first-RMSNorm compiled benchmark primitive.
+"""Opt-in tiled RVQ and native-order first RMSNorm benchmark primitive.
 
-One program owns the complete hidden vector of one frame. Q is reduced before
-the mandatory raw dtype rounding; H is reduced only after that rounding. This
-launch layout has just one CTA at B=T=1 and can increase register pressure.
+RVQ programs own 128-channel tiles and preserve the native Q16 arithmetic.
+A second kernel reads the rounded residual and preserves native RMS statistics.
+Both outputs remain observable; no cross-program synchronization is assumed.
 """
 
 import torch
@@ -27,7 +27,31 @@ def native_region(codes, weight, offsets, gamma, eps):
 
 
 @triton.jit
-def _rvq_rmsnorm_dual_kernel(
+def _rvq_row(
+    codes,
+    weight,
+    offsets,
+    batch,
+    token,
+    channel,
+    stride_b: tl.constexpr,
+    stride_q: tl.constexpr,
+    stride_t: tl.constexpr,
+    stride_offset: tl.constexpr,
+    hidden: tl.constexpr,
+    entries: tl.constexpr,
+    quantizer: tl.constexpr,
+):
+    code = tl.load(codes + batch * stride_b + quantizer * stride_q + token * stride_t)
+    offset = tl.load(offsets + quantizer * stride_offset)
+    row = (code + offset).to(tl.int64)
+    valid = (row >= 0) & (row < entries)
+    tl.device_assert(valid, "RVQ embedding index out of range")
+    return tl.load(weight + row * hidden + channel, valid & (channel < hidden), 0).to(tl.float32)
+
+
+@triton.jit
+def _rvq_native_mean_kernel(
     codes,
     weight,
     offsets,
@@ -44,27 +68,141 @@ def _rvq_rmsnorm_dual_kernel(
     entries: tl.constexpr,
     block_h: tl.constexpr,
     eps: tl.constexpr,
+    native_width: tl.constexpr,
 ):
     frame = tl.program_id(0).to(tl.int64)
     batch, token = frame // time, frame % time
-    quantizer = tl.arange(0, 16).to(tl.int64)
+    channel = (tl.program_id(1) * block_h + tl.arange(0, block_h)).to(tl.int64)
+    if time * hidden > 1:
+        acc0 = tl.full((block_h,), 0, tl.float32)
+        acc1 = tl.full((block_h,), 0, tl.float32)
+        acc2 = tl.full((block_h,), 0, tl.float32)
+        acc3 = tl.full((block_h,), 0, tl.float32)
+        for step in tl.static_range(4):
+            acc0 = acc0 + _rvq_row(
+                codes,
+                weight,
+                offsets,
+                batch,
+                token,
+                channel,
+                stride_b,
+                stride_q,
+                stride_t,
+                stride_offset,
+                hidden,
+                entries,
+                step * 4,
+            )
+            acc1 = acc1 + _rvq_row(
+                codes,
+                weight,
+                offsets,
+                batch,
+                token,
+                channel,
+                stride_b,
+                stride_q,
+                stride_t,
+                stride_offset,
+                hidden,
+                entries,
+                step * 4 + 1,
+            )
+            acc2 = acc2 + _rvq_row(
+                codes,
+                weight,
+                offsets,
+                batch,
+                token,
+                channel,
+                stride_b,
+                stride_q,
+                stride_t,
+                stride_offset,
+                hidden,
+                entries,
+                step * 4 + 2,
+            )
+            acc3 = acc3 + _rvq_row(
+                codes,
+                weight,
+                offsets,
+                batch,
+                token,
+                channel,
+                stride_b,
+                stride_q,
+                stride_t,
+                stride_offset,
+                hidden,
+                entries,
+                step * 4 + 3,
+            )
+        mean = (((acc0 + acc1) + acc2) + acc3) * (1.0 / 16.0)
+    else:
+        quantizer = tl.arange(0, 16).to(tl.int64)
+        code = tl.load(codes + batch * stride_b + quantizer * stride_q + token * stride_t)
+        offset = tl.load(offsets + quantizer * stride_offset)
+        row = (code + offset).to(tl.int64)
+        valid_row = (row >= 0) & (row < entries)
+        tl.device_assert(valid_row, "RVQ embedding index out of range")
+        embedding = tl.load(
+            weight + row[:, None] * hidden + channel[None, :], valid_row[:, None] & (channel[None, :] < hidden), 0
+        ).to(tl.float32)
+        mean = tl.sum(embedding, axis=0) * (1.0 / 16.0)
+    tl.store(raw_output + frame * hidden + channel, mean, channel < hidden)
+
+
+@triton.jit
+def _native_first_rmsnorm_kernel(
+    codes,
+    weight,
+    offsets,
+    gamma,
+    raw_output,
+    normalized_output,
+    stride_b: tl.constexpr,
+    stride_q: tl.constexpr,
+    stride_t: tl.constexpr,
+    stride_offset: tl.constexpr,
+    stride_gamma: tl.constexpr,
+    time: tl.constexpr,
+    hidden: tl.constexpr,
+    entries: tl.constexpr,
+    block_h: tl.constexpr,
+    eps: tl.constexpr,
+    native_width: tl.constexpr,
+):
+    frame = tl.program_id(0).to(tl.int64)
+    batch, token = frame // time, frame % time  # noqa: F841 - preserve validated Triton AST
     channel = tl.arange(0, block_h).to(tl.int64)
-    code = tl.load(codes + batch * stride_b + quantizer * stride_q + token * stride_t)
-    offset = tl.load(offsets + quantizer * stride_offset)
-    # Preserve native int32/int64 addition promotion/overflow before widening
-    # the combined row for table address arithmetic.
-    row = (code + offset).to(tl.int64)
-    valid_row = (row >= 0) & (row < entries)
-    tl.device_assert(valid_row, "RVQ embedding index out of range")
-    embedding = tl.load(
-        weight + row[:, None] * hidden + channel[None, :], valid_row[:, None] & (channel[None, :] < hidden), 0
-    ).to(tl.float32)
-    mean = tl.sum(embedding, axis=0) * (1.0 / 16.0)
-    # The residual's rounding is also the input boundary for RMS statistics.
-    raw_low = mean.to(raw_output.dtype.element_ty)
+    raw_low = tl.load(raw_output + frame * hidden + channel, channel < hidden, 0)
     raw_float = raw_low.to(tl.float32)
-    squares = tl.where(channel < hidden, raw_float * raw_float, 0.0)
-    variance = tl.sum(squares, axis=0) / hidden
+    if hidden == 1024:
+        # Load each native reduction lane directly from the rounded residual.
+        # This avoids redistributing the full H vector through repeated gathers
+        # while keeping Torch Reduce.cuh arithmetic and cast boundaries exact.
+        lane = tl.arange(0, native_width)
+        acc0 = tl.full((native_width,), 0, tl.float32)
+        acc1 = tl.full((native_width,), 0, tl.float32)
+        acc2 = tl.full((native_width,), 0, tl.float32)
+        acc3 = tl.full((native_width,), 0, tl.float32)
+        for step in tl.static_range(1024 // (native_width * 4)):
+            base = lane * 4 + step * native_width * 4
+            value0 = tl.load(raw_output + frame * hidden + base).to(tl.float32)
+            acc0 = acc0 + value0 * value0
+            value1 = tl.load(raw_output + frame * hidden + base + 1).to(tl.float32)
+            acc1 = acc1 + value1 * value1
+            value2 = tl.load(raw_output + frame * hidden + base + 2).to(tl.float32)
+            acc2 = acc2 + value2 * value2
+            value3 = tl.load(raw_output + frame * hidden + base + 3).to(tl.float32)
+            acc3 = acc3 + value3 * value3
+        partial = ((acc0 + acc1) + acc2) + acc3
+        variance = tl.sum(partial, axis=0) * (1.0 / 1024.0)
+    else:
+        squares = tl.where(channel < hidden, raw_float * raw_float, 0.0)
+        variance = tl.sum(squares, axis=0) / hidden
     epsilon_float = tl.full((), eps, tl.float32)
     inverse_rms = tl.rsqrt(variance + epsilon_float)
     normalized_low = (raw_float * inverse_rms).to(raw_output.dtype.element_ty)
@@ -72,7 +210,6 @@ def _rvq_rmsnorm_dual_kernel(
     # HF casts before gamma multiplication, rather than only at the end.
     normalized = normalized_low.to(tl.float32) * scale
     output_offset = frame * hidden + channel
-    tl.store(raw_output + output_offset, raw_low, channel < hidden)
     tl.store(normalized_output + output_offset, normalized, channel < hidden)
 
 
@@ -146,6 +283,24 @@ def inspect_inputs(codes, weight, offsets, gamma, eps):
         entries,
         triton.next_power_of_2(hidden),
         float(eps),
+        min(
+            256,
+            512
+            // min(
+                16,
+                (
+                    16
+                    if batch * time >= 16
+                    else 8
+                    if batch * time >= 8
+                    else 4
+                    if batch * time >= 4
+                    else 2
+                    if batch * time >= 2
+                    else 1
+                ),
+            ),
+        ),
     )
     # Outputs are allocated with exactly the checked weight dtype and device.
     signature = (device.index, code_dtype, weight_dtype, offset_dtype, gamma_dtype)
@@ -158,7 +313,7 @@ def can_use_variant(codes, weight, offsets, gamma, eps):
 
 def make_variant(num_warps):
     if num_warps not in (4, 8):
-        raise ValueError("num_warps must be four or eight")
+        raise ValueError("Supported launch widths are four or eight warps")
 
     def entry(codes, weight, offsets, gamma, eps):
         metadata = inspect_inputs(codes, weight, offsets, gamma, eps)
@@ -168,8 +323,30 @@ def make_variant(num_warps):
         raw = torch.empty((batch, time, hidden), dtype=dtype, device=device)
         normalized = torch.empty_like(raw)
         if batch != 0 and time != 0:
-            _rvq_rmsnorm_dual_kernel[(batch * time, 1, 1)](
-                codes, weight, offsets, gamma, raw, normalized, *constants, num_warps=num_warps, debug=True
+            mean_constants = (*constants[:8], 128, *constants[9:])
+            _rvq_native_mean_kernel[(batch * time, triton.cdiv(hidden, 128), 1)](
+                codes,
+                weight,
+                offsets,
+                gamma,
+                raw,
+                normalized,
+                *mean_constants,
+                num_warps=num_warps,
+                debug=True,
+                enable_fp_fusion=False,
+            )
+            _native_first_rmsnorm_kernel[(batch * time, 1, 1)](
+                codes,
+                weight,
+                offsets,
+                gamma,
+                raw,
+                normalized,
+                *constants,
+                num_warps=num_warps,
+                debug=True,
+                enable_fp_fusion=False,
             )
         return raw, normalized
 
@@ -177,7 +354,7 @@ def make_variant(num_warps):
     # live shape/stride/dtype/device/epsilon and Inductor owns normal dispatch.
     # No task-managed cache retains tensor pointers or streams.
     compiled = torch.compile(entry, fullgraph=True, dynamic=False)
-    compiled.__name__ = f"rvq_rmsnorm_w{num_warps}"
+    compiled.__name__ = f"rvq_rmsnorm_tiled_native_w{num_warps}"
 
     def call(codes, weight, offsets, gamma, eps):
         # Dynamo 2.13 cannot trace is_neg/is_conj booleans. Check these four

--- a/benchmarks/kernels/rvq_rmsnorm.py
+++ b/benchmarks/kernels/rvq_rmsnorm.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Opt-in dual-output RVQ/first-RMSNorm compiled benchmark primitive.
+
+One program owns the complete hidden vector of one frame. Q is reduced before
+the mandatory raw dtype rounding; H is reduced only after that rounding. This
+launch layout has just one CTA at B=T=1 and can increase register pressure.
+"""
+
+import torch
+from vllm.triton_utils import tl, triton
+
+from vllm_omni.platforms import current_omni_platform
+
+
+def native_region(codes, weight, offsets, gamma, eps):
+    import torch
+    import torch.nn.functional as F
+
+    raw = F.embedding(codes + offsets, weight).mean(1)
+    input_dtype = raw.dtype
+    hidden_states = raw.to(torch.float32)
+    variance = hidden_states.pow(2).mean(-1, keepdim=True)
+    hidden_states = hidden_states * torch.rsqrt(variance + eps)
+    normalized = gamma * hidden_states.to(input_dtype)
+    return raw, normalized
+
+
+@triton.jit
+def _rvq_rmsnorm_dual_kernel(
+    codes,
+    weight,
+    offsets,
+    gamma,
+    raw_output,
+    normalized_output,
+    stride_b: tl.constexpr,
+    stride_q: tl.constexpr,
+    stride_t: tl.constexpr,
+    stride_offset: tl.constexpr,
+    stride_gamma: tl.constexpr,
+    time: tl.constexpr,
+    hidden: tl.constexpr,
+    entries: tl.constexpr,
+    block_h: tl.constexpr,
+    eps: tl.constexpr,
+):
+    frame = tl.program_id(0).to(tl.int64)
+    batch, token = frame // time, frame % time
+    quantizer = tl.arange(0, 16).to(tl.int64)
+    channel = tl.arange(0, block_h).to(tl.int64)
+    code = tl.load(codes + batch * stride_b + quantizer * stride_q + token * stride_t)
+    offset = tl.load(offsets + quantizer * stride_offset)
+    # Preserve native int32/int64 addition promotion/overflow before widening
+    # the combined row for table address arithmetic.
+    row = (code + offset).to(tl.int64)
+    valid_row = (row >= 0) & (row < entries)
+    tl.device_assert(valid_row, "RVQ embedding index out of range")
+    embedding = tl.load(
+        weight + row[:, None] * hidden + channel[None, :], valid_row[:, None] & (channel[None, :] < hidden), 0
+    ).to(tl.float32)
+    mean = tl.sum(embedding, axis=0) * (1.0 / 16.0)
+    # The residual's rounding is also the input boundary for RMS statistics.
+    raw_low = mean.to(raw_output.dtype.element_ty)
+    raw_float = raw_low.to(tl.float32)
+    squares = tl.where(channel < hidden, raw_float * raw_float, 0.0)
+    variance = tl.sum(squares, axis=0) / hidden
+    epsilon_float = tl.full((), eps, tl.float32)
+    inverse_rms = tl.rsqrt(variance + epsilon_float)
+    normalized_low = (raw_float * inverse_rms).to(raw_output.dtype.element_ty)
+    scale = tl.load(gamma + channel * stride_gamma, channel < hidden, 0).to(tl.float32)
+    # HF casts before gamma multiplication, rather than only at the end.
+    normalized = normalized_low.to(tl.float32) * scale
+    output_offset = frame * hidden + channel
+    tl.store(raw_output + output_offset, raw_low, channel < hidden)
+    tl.store(normalized_output + output_offset, normalized, channel < hidden)
+
+
+def supported_epsilon(eps):
+    # PyTorch converts Python integers directly to its scalar representation.
+    # Above 2**53, this wrapper's later int->Python-float conversion can double
+    # round before fp32, even below int64's limit. Larger ints stay native.
+    return (type(eps) is int and 0 <= eps <= 2**53) or (type(eps) is float and 0 <= eps <= 3.4028234663852886e38)
+
+
+def inspect_inputs(codes, weight, offsets, gamma, eps):
+    """Validate live metadata once and reuse only immutable values downstream."""
+    tensors = (codes, weight, offsets, gamma)
+    if not torch.compiler.is_compiling() and any(tensor.is_neg() or tensor.is_conj() for tensor in tensors):
+        return None
+    if (
+        torch.is_grad_enabled()
+        or not all(
+            type(tensor) in (torch.Tensor, torch.nn.Parameter)
+            and tensor.layout == torch.strided
+            and not tensor.is_nested
+            for tensor in tensors
+        )
+        or not codes.is_cuda
+        or torch.version.hip is not None
+        or torch.is_autocast_enabled("cuda")
+        or not supported_epsilon(eps)
+    ):
+        return None
+    device = codes.device
+    if (
+        device != weight.device
+        or device != offsets.device
+        or device != gamma.device
+        or device.index != current_omni_platform.current_device()
+    ):
+        return None
+    code_shape, weight_shape, offset_shape, gamma_shape = codes.shape, weight.shape, offsets.shape, gamma.shape
+    if (
+        len(code_shape) != 3
+        or len(weight_shape) != 2
+        or len(offset_shape) != 3
+        or len(gamma_shape) != 1
+        or code_shape[1] != 16
+        or offset_shape != (1, 16, 1)
+    ):
+        return None
+    code_dtype, weight_dtype, offset_dtype, gamma_dtype = codes.dtype, weight.dtype, offsets.dtype, gamma.dtype
+    if (
+        code_dtype not in (torch.int32, torch.int64)
+        or offset_dtype not in (torch.int32, torch.int64)
+        or weight_dtype not in (torch.float16, torch.bfloat16)
+        or gamma_dtype != weight_dtype
+        or not weight.is_contiguous()
+        or weight_shape[0] <= 0
+        or not 0 < weight_shape[1] <= 2048
+        or gamma_shape[0] != weight_shape[1]
+    ):
+        return None
+    code_stride, offset_stride, gamma_stride = codes.stride(), offsets.stride(), gamma.stride()
+    if any(value < 0 for values in (code_stride, offset_stride, gamma_stride) for value in values):
+        return None
+    batch, _, time = code_shape
+    entries, hidden = weight_shape
+    constants = (
+        *code_stride,
+        offset_stride[1],
+        gamma_stride[0],
+        time,
+        hidden,
+        entries,
+        triton.next_power_of_2(hidden),
+        float(eps),
+    )
+    # Outputs are allocated with exactly the checked weight dtype and device.
+    signature = (device.index, code_dtype, weight_dtype, offset_dtype, gamma_dtype)
+    return batch, time, hidden, device, weight_dtype, constants, signature
+
+
+def can_use_variant(codes, weight, offsets, gamma, eps):
+    return inspect_inputs(codes, weight, offsets, gamma, eps) is not None
+
+
+def make_variant(num_warps):
+    if num_warps not in (4, 8):
+        raise ValueError("num_warps must be four or eight")
+
+    def entry(codes, weight, offsets, gamma, eps):
+        metadata = inspect_inputs(codes, weight, offsets, gamma, eps)
+        if metadata is None:
+            return native_region(codes, weight, offsets, gamma, eps)
+        batch, time, hidden, device, dtype, constants, signature = metadata
+        raw = torch.empty((batch, time, hidden), dtype=dtype, device=device)
+        normalized = torch.empty_like(raw)
+        if batch != 0 and time != 0:
+            _rvq_rmsnorm_dual_kernel[(batch * time, 1, 1)](
+                codes, weight, offsets, gamma, raw, normalized, *constants, num_warps=num_warps, debug=True
+            )
+        return raw, normalized
+
+    # Both benchmark arms use fullgraph=True and dynamic=False. Dynamo guards
+    # live shape/stride/dtype/device/epsilon and Inductor owns normal dispatch.
+    # No task-managed cache retains tensor pointers or streams.
+    compiled = torch.compile(entry, fullgraph=True, dynamic=False)
+    compiled.__name__ = f"rvq_rmsnorm_w{num_warps}"
+
+    def call(codes, weight, offsets, gamma, eps):
+        # Dynamo 2.13 cannot trace is_neg/is_conj booleans. Check these four
+        # live tensors outside its graph; never erase or resolve a lazy view.
+        if any(tensor.is_neg() or tensor.is_conj() for tensor in (codes, weight, offsets, gamma)):
+            return native_region(codes, weight, offsets, gamma, eps)
+        return compiled(codes, weight, offsets, gamma, eps)
+
+    call.__name__ = compiled.__name__
+    return call

--- a/benchmarks/kernels/rvq_rmsnorm.py
+++ b/benchmarks/kernels/rvq_rmsnorm.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
-"""Opt-in tiled RVQ and native-order first RMSNorm benchmark primitive.
+"""Opt-in dual-output RVQ/first-RMSNorm compiled benchmark primitive.
 
-RVQ programs own 128-channel tiles and preserve the native Q16 arithmetic.
-A second kernel reads the rounded residual and preserves native RMS statistics.
-Both outputs remain observable; no cross-program synchronization is assumed.
+One program owns the complete hidden vector of one frame. Q is reduced before
+the mandatory raw dtype rounding; H is reduced only after that rounding. This
+launch layout has just one CTA at B=T=1 and can increase register pressure.
 """
 
 import torch
@@ -27,31 +27,7 @@ def native_region(codes, weight, offsets, gamma, eps):
 
 
 @triton.jit
-def _rvq_row(
-    codes,
-    weight,
-    offsets,
-    batch,
-    token,
-    channel,
-    stride_b: tl.constexpr,
-    stride_q: tl.constexpr,
-    stride_t: tl.constexpr,
-    stride_offset: tl.constexpr,
-    hidden: tl.constexpr,
-    entries: tl.constexpr,
-    quantizer: tl.constexpr,
-):
-    code = tl.load(codes + batch * stride_b + quantizer * stride_q + token * stride_t)
-    offset = tl.load(offsets + quantizer * stride_offset)
-    row = (code + offset).to(tl.int64)
-    valid = (row >= 0) & (row < entries)
-    tl.device_assert(valid, "RVQ embedding index out of range")
-    return tl.load(weight + row * hidden + channel, valid & (channel < hidden), 0).to(tl.float32)
-
-
-@triton.jit
-def _rvq_native_mean_kernel(
+def _rvq_rmsnorm_dual_kernel(
     codes,
     weight,
     offsets,
@@ -68,141 +44,27 @@ def _rvq_native_mean_kernel(
     entries: tl.constexpr,
     block_h: tl.constexpr,
     eps: tl.constexpr,
-    native_width: tl.constexpr,
 ):
     frame = tl.program_id(0).to(tl.int64)
     batch, token = frame // time, frame % time
-    channel = (tl.program_id(1) * block_h + tl.arange(0, block_h)).to(tl.int64)
-    if time * hidden > 1:
-        acc0 = tl.full((block_h,), 0, tl.float32)
-        acc1 = tl.full((block_h,), 0, tl.float32)
-        acc2 = tl.full((block_h,), 0, tl.float32)
-        acc3 = tl.full((block_h,), 0, tl.float32)
-        for step in tl.static_range(4):
-            acc0 = acc0 + _rvq_row(
-                codes,
-                weight,
-                offsets,
-                batch,
-                token,
-                channel,
-                stride_b,
-                stride_q,
-                stride_t,
-                stride_offset,
-                hidden,
-                entries,
-                step * 4,
-            )
-            acc1 = acc1 + _rvq_row(
-                codes,
-                weight,
-                offsets,
-                batch,
-                token,
-                channel,
-                stride_b,
-                stride_q,
-                stride_t,
-                stride_offset,
-                hidden,
-                entries,
-                step * 4 + 1,
-            )
-            acc2 = acc2 + _rvq_row(
-                codes,
-                weight,
-                offsets,
-                batch,
-                token,
-                channel,
-                stride_b,
-                stride_q,
-                stride_t,
-                stride_offset,
-                hidden,
-                entries,
-                step * 4 + 2,
-            )
-            acc3 = acc3 + _rvq_row(
-                codes,
-                weight,
-                offsets,
-                batch,
-                token,
-                channel,
-                stride_b,
-                stride_q,
-                stride_t,
-                stride_offset,
-                hidden,
-                entries,
-                step * 4 + 3,
-            )
-        mean = (((acc0 + acc1) + acc2) + acc3) * (1.0 / 16.0)
-    else:
-        quantizer = tl.arange(0, 16).to(tl.int64)
-        code = tl.load(codes + batch * stride_b + quantizer * stride_q + token * stride_t)
-        offset = tl.load(offsets + quantizer * stride_offset)
-        row = (code + offset).to(tl.int64)
-        valid_row = (row >= 0) & (row < entries)
-        tl.device_assert(valid_row, "RVQ embedding index out of range")
-        embedding = tl.load(
-            weight + row[:, None] * hidden + channel[None, :], valid_row[:, None] & (channel[None, :] < hidden), 0
-        ).to(tl.float32)
-        mean = tl.sum(embedding, axis=0) * (1.0 / 16.0)
-    tl.store(raw_output + frame * hidden + channel, mean, channel < hidden)
-
-
-@triton.jit
-def _native_first_rmsnorm_kernel(
-    codes,
-    weight,
-    offsets,
-    gamma,
-    raw_output,
-    normalized_output,
-    stride_b: tl.constexpr,
-    stride_q: tl.constexpr,
-    stride_t: tl.constexpr,
-    stride_offset: tl.constexpr,
-    stride_gamma: tl.constexpr,
-    time: tl.constexpr,
-    hidden: tl.constexpr,
-    entries: tl.constexpr,
-    block_h: tl.constexpr,
-    eps: tl.constexpr,
-    native_width: tl.constexpr,
-):
-    frame = tl.program_id(0).to(tl.int64)
-    batch, token = frame // time, frame % time  # noqa: F841 - preserve validated Triton AST
+    quantizer = tl.arange(0, 16).to(tl.int64)
     channel = tl.arange(0, block_h).to(tl.int64)
-    raw_low = tl.load(raw_output + frame * hidden + channel, channel < hidden, 0)
+    code = tl.load(codes + batch * stride_b + quantizer * stride_q + token * stride_t)
+    offset = tl.load(offsets + quantizer * stride_offset)
+    # Preserve native int32/int64 addition promotion/overflow before widening
+    # the combined row for table address arithmetic.
+    row = (code + offset).to(tl.int64)
+    valid_row = (row >= 0) & (row < entries)
+    tl.device_assert(valid_row, "RVQ embedding index out of range")
+    embedding = tl.load(
+        weight + row[:, None] * hidden + channel[None, :], valid_row[:, None] & (channel[None, :] < hidden), 0
+    ).to(tl.float32)
+    mean = tl.sum(embedding, axis=0) * (1.0 / 16.0)
+    # The residual's rounding is also the input boundary for RMS statistics.
+    raw_low = mean.to(raw_output.dtype.element_ty)
     raw_float = raw_low.to(tl.float32)
-    if hidden == 1024:
-        # Load each native reduction lane directly from the rounded residual.
-        # This avoids redistributing the full H vector through repeated gathers
-        # while keeping Torch Reduce.cuh arithmetic and cast boundaries exact.
-        lane = tl.arange(0, native_width)
-        acc0 = tl.full((native_width,), 0, tl.float32)
-        acc1 = tl.full((native_width,), 0, tl.float32)
-        acc2 = tl.full((native_width,), 0, tl.float32)
-        acc3 = tl.full((native_width,), 0, tl.float32)
-        for step in tl.static_range(1024 // (native_width * 4)):
-            base = lane * 4 + step * native_width * 4
-            value0 = tl.load(raw_output + frame * hidden + base).to(tl.float32)
-            acc0 = acc0 + value0 * value0
-            value1 = tl.load(raw_output + frame * hidden + base + 1).to(tl.float32)
-            acc1 = acc1 + value1 * value1
-            value2 = tl.load(raw_output + frame * hidden + base + 2).to(tl.float32)
-            acc2 = acc2 + value2 * value2
-            value3 = tl.load(raw_output + frame * hidden + base + 3).to(tl.float32)
-            acc3 = acc3 + value3 * value3
-        partial = ((acc0 + acc1) + acc2) + acc3
-        variance = tl.sum(partial, axis=0) * (1.0 / 1024.0)
-    else:
-        squares = tl.where(channel < hidden, raw_float * raw_float, 0.0)
-        variance = tl.sum(squares, axis=0) / hidden
+    squares = tl.where(channel < hidden, raw_float * raw_float, 0.0)
+    variance = tl.sum(squares, axis=0) / hidden
     epsilon_float = tl.full((), eps, tl.float32)
     inverse_rms = tl.rsqrt(variance + epsilon_float)
     normalized_low = (raw_float * inverse_rms).to(raw_output.dtype.element_ty)
@@ -210,6 +72,7 @@ def _native_first_rmsnorm_kernel(
     # HF casts before gamma multiplication, rather than only at the end.
     normalized = normalized_low.to(tl.float32) * scale
     output_offset = frame * hidden + channel
+    tl.store(raw_output + output_offset, raw_low, channel < hidden)
     tl.store(normalized_output + output_offset, normalized, channel < hidden)
 
 
@@ -283,24 +146,6 @@ def inspect_inputs(codes, weight, offsets, gamma, eps):
         entries,
         triton.next_power_of_2(hidden),
         float(eps),
-        min(
-            256,
-            512
-            // min(
-                16,
-                (
-                    16
-                    if batch * time >= 16
-                    else 8
-                    if batch * time >= 8
-                    else 4
-                    if batch * time >= 4
-                    else 2
-                    if batch * time >= 2
-                    else 1
-                ),
-            ),
-        ),
     )
     # Outputs are allocated with exactly the checked weight dtype and device.
     signature = (device.index, code_dtype, weight_dtype, offset_dtype, gamma_dtype)
@@ -313,7 +158,7 @@ def can_use_variant(codes, weight, offsets, gamma, eps):
 
 def make_variant(num_warps):
     if num_warps not in (4, 8):
-        raise ValueError("Supported launch widths are four or eight warps")
+        raise ValueError("num_warps must be four or eight")
 
     def entry(codes, weight, offsets, gamma, eps):
         metadata = inspect_inputs(codes, weight, offsets, gamma, eps)
@@ -323,30 +168,8 @@ def make_variant(num_warps):
         raw = torch.empty((batch, time, hidden), dtype=dtype, device=device)
         normalized = torch.empty_like(raw)
         if batch != 0 and time != 0:
-            mean_constants = (*constants[:8], 128, *constants[9:])
-            _rvq_native_mean_kernel[(batch * time, triton.cdiv(hidden, 128), 1)](
-                codes,
-                weight,
-                offsets,
-                gamma,
-                raw,
-                normalized,
-                *mean_constants,
-                num_warps=num_warps,
-                debug=True,
-                enable_fp_fusion=False,
-            )
-            _native_first_rmsnorm_kernel[(batch * time, 1, 1)](
-                codes,
-                weight,
-                offsets,
-                gamma,
-                raw,
-                normalized,
-                *constants,
-                num_warps=num_warps,
-                debug=True,
-                enable_fp_fusion=False,
+            _rvq_rmsnorm_dual_kernel[(batch * time, 1, 1)](
+                codes, weight, offsets, gamma, raw, normalized, *constants, num_warps=num_warps, debug=True
             )
         return raw, normalized
 
@@ -354,7 +177,7 @@ def make_variant(num_warps):
     # live shape/stride/dtype/device/epsilon and Inductor owns normal dispatch.
     # No task-managed cache retains tensor pointers or streams.
     compiled = torch.compile(entry, fullgraph=True, dynamic=False)
-    compiled.__name__ = f"rvq_rmsnorm_tiled_native_w{num_warps}"
+    compiled.__name__ = f"rvq_rmsnorm_w{num_warps}"
 
     def call(codes, weight, offsets, gamma, eps):
         # Dynamo 2.13 cannot trace is_neg/is_conj booleans. Check these four

--- a/tests/model_executor/layers/test_rvq_rmsnorm_cpu.py
+++ b/tests/model_executor/layers/test_rvq_rmsnorm_cpu.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Real CPU tensor metadata checks for the prototype's pointer-dispatch guard.
+
+The guard expression is extracted without importing Triton or the kernel
+module. Every tensor is explicitly on CPU; no CUDA method is called.
+"""
+
+import ast
+import unittest
+import warnings
+from collections.abc import Callable
+from pathlib import Path
+from types import CodeType, ModuleType
+from typing import ClassVar
+
+import pytest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class StorageGuardTests(unittest.TestCase):
+    torch: ClassVar[ModuleType]
+    storage_expression: ClassVar[CodeType]
+    lazy_expression: ClassVar[CodeType]
+    epsilon_predicate: ClassVar[Callable]
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import torch
+        except ImportError as error:
+            raise unittest.SkipTest("optional CPU Torch installation required") from error
+        cls.torch = torch
+        tree = ast.parse((Path(__file__).resolve().parents[3] / "benchmarks/kernels/rvq_rmsnorm.py").read_text())
+        function = next(
+            node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "inspect_inputs"
+        )
+        guards = [
+            node
+            for node in ast.walk(function)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "all"
+            and len(node.args) == 1
+            and isinstance(node.args[0], ast.GeneratorExp)
+            and isinstance(node.args[0].generators[0].iter, ast.Name)
+            and node.args[0].generators[0].iter.id == "tensors"
+        ]
+        assert len(guards) == 1
+        cls.storage_expression = compile(ast.Expression(guards[0]), "prototype-storage-guard", "eval")
+        cls.lazy_expression = compile(
+            ast.Expression(next(node for node in function.body if isinstance(node, ast.If)).test),
+            "lazy-view-guard",
+            "eval",
+        )
+        epsilon_function = next(
+            node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "supported_epsilon"
+        )
+        namespace: dict = {}
+        exec(
+            compile(ast.Module(body=[epsilon_function], type_ignores=[]), "prototype-epsilon-guard", "exec"), namespace
+        )
+        cls.epsilon_predicate = staticmethod(namespace["supported_epsilon"])
+
+    def accepted(self, tensors):
+        namespace = {"torch": self.torch, "tensors": tensors}
+        return not eval(self.lazy_expression, namespace) and eval(self.storage_expression, namespace)
+
+    def inputs(self):
+        torch = self.torch
+        return [
+            torch.zeros((1, 16, 1), dtype=torch.int64, device="cpu"),
+            torch.ones((32, 4), dtype=torch.float16, device="cpu"),
+            torch.zeros((1, 16, 1), dtype=torch.int64, device="cpu"),
+            torch.ones((4,), dtype=torch.float16, device="cpu"),
+        ]
+
+    def test_dense_parameter_and_broadcast_zero_stride_remain_supported_storage(self):
+        torch = self.torch
+        tensors = self.inputs()
+        self.assertTrue(self.accepted(tensors))
+        tensors[3] = torch.nn.Parameter(tensors[3])
+        self.assertTrue(self.accepted(tensors))
+        tensors[3] = torch.ones((1,), device="cpu", dtype=torch.float16).expand(4)
+        self.assertEqual(tensors[3].stride(), (0,))
+        self.assertTrue(self.accepted(tensors))
+
+    def test_lazy_negative_view_on_each_input_requires_native_dispatch(self):
+        torch = self.torch
+        for index in range(4):
+            with self.subTest(index=index):
+                tensors = self.inputs()
+                original = tensors[index]
+                tensors[index] = torch._neg_view(original)
+                self.assertEqual(type(tensors[index]), torch.Tensor)
+                self.assertEqual(tensors[index].data_ptr(), original.data_ptr())
+                self.assertTrue(tensors[index].is_neg())
+                self.assertFalse(self.accepted(tensors))
+
+    def test_sparse_nested_and_tensor_subclasses_require_native_dispatch(self):
+        torch = self.torch
+        tensors = self.inputs()
+        tensors[3] = torch.sparse_coo_tensor(
+            [[0, 2]], [1.0, 2.0], (4,), dtype=torch.float16, device="cpu", check_invariants=True
+        )
+        self.assertFalse(self.accepted(tensors))
+        tensors = self.inputs()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            tensors[3] = torch.nested.nested_tensor([torch.ones(2), torch.ones(3)], device="cpu")
+        self.assertTrue(tensors[3].is_nested)
+        self.assertFalse(self.accepted(tensors))
+
+        from torch import Tensor
+
+        class TensorSubclass(Tensor):
+            pass
+
+        tensors = self.inputs()
+        tensors[3] = tensors[3].as_subclass(TensorSubclass)
+        self.assertFalse(self.accepted(tensors))
+
+    def test_large_python_integer_epsilon_preserves_native_scalar_error(self):
+        torch = self.torch
+        variance = torch.ones((1,), device="cpu", dtype=torch.float32)
+        self.assertFalse(self.epsilon_predicate(10**30))
+        with self.assertRaises(OverflowError):
+            variance + 10**30
+        self.assertTrue(self.epsilon_predicate(float(10**30)))
+        self.assertTrue(torch.isfinite(variance + float(10**30)).all().item())
+        rounding_counterexample = 2**53 + 2**29 + 1
+        self.assertNotEqual(
+            (variance + rounding_counterexample).item(), (variance + float(rounding_counterexample)).item()
+        )
+        self.assertFalse(self.epsilon_predicate(rounding_counterexample))
+        for epsilon in (0, 2**53, 0.0, 1e-5):
+            self.assertTrue(self.epsilon_predicate(epsilon))
+        for epsilon in (True, -1, 2**53 + 1, 2**63 - 1, 2**63, 10**400, float("nan"), float("inf")):
+            self.assertFalse(self.epsilon_predicate(epsilon))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/model_executor/layers/test_rvq_rmsnorm_gpu.py
+++ b/tests/model_executor/layers/test_rvq_rmsnorm_gpu.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""GPU regression coverage for both observable RVQ/RMSNorm outputs."""
+
+import unittest
+from collections.abc import Callable
+from types import ModuleType
+from typing import TYPE_CHECKING, ClassVar
+
+if TYPE_CHECKING:
+    from vllm_omni.platforms.interface import OmniPlatform
+
+import pytest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cuda]
+
+
+class GpuRmsnormTests(unittest.TestCase):
+    torch: ClassVar[ModuleType]
+    variant: ClassVar[ModuleType]
+    native: ClassVar[Callable]
+    platform: ClassVar[type["OmniPlatform"]]
+    budgets: ClassVar[tuple[int, int]]
+    compiled: ClassVar[Callable]
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import torch
+            from vllm.triton_utils import triton
+        except ImportError as error:
+            raise unittest.SkipTest(str(error)) from error
+        if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (12, 0):
+            raise unittest.SkipTest("requires an SM120 GPU")
+        if triton.__version__ != "3.7.1":
+            raise unittest.SkipTest("requires the audited Triton 3.7.1 launcher ABI")
+        import torch._dynamo.config as config
+        import torch._inductor.config as inductor_config
+
+        from benchmarks.kernels import rvq_rmsnorm
+        from benchmarks.kernels.rvq_rmsnorm import native_region
+        from vllm_omni.platforms import current_omni_platform
+
+        if not inductor_config.emulate_precision_casts:
+            raise RuntimeError("Set TORCHINDUCTOR_EMULATE_PRECISION_CASTS=1 before starting pytest")
+        cls.torch, cls.variant, cls.native = torch, rvq_rmsnorm, staticmethod(native_region)
+        cls.platform = current_omni_platform
+        cls.budgets = (config.recompile_limit, config.accumulated_recompile_limit)
+        config.recompile_limit = 256
+        config.accumulated_recompile_limit = max(1024, config.accumulated_recompile_limit)
+        cls.compiled = staticmethod(torch.compile(native_region, fullgraph=True, dynamic=False))
+
+    @classmethod
+    def tearDownClass(cls):
+        import torch._dynamo.config as config
+
+        config.recompile_limit, config.accumulated_recompile_limit = cls.budgets
+
+    def inputs(self, dtype, *, hidden=37, strided=False, index_dtype=None, seed=42):
+        torch = self.torch
+        index_dtype = torch.int64 if index_dtype is None else index_dtype
+        generator = torch.Generator(device="cuda").manual_seed(seed)
+        backing = torch.randint(32, (2, 16, 7 if strided else 3), device="cuda", dtype=index_dtype, generator=generator)
+        codes = backing[..., 1::2] if strided else backing
+        weight = torch.randn(16 * 32, hidden, device="cuda", dtype=dtype, generator=generator)
+        offsets = (torch.arange(16, device="cuda", dtype=index_dtype) * 32).view(1, 16, 1)
+        gamma = torch.randn(hidden, device="cuda", dtype=dtype, generator=generator)
+        if strided:
+            storage = torch.empty((1, 33, 1), device="cuda", dtype=index_dtype)
+            offset_view = storage[:, 1::2, :]
+            offset_view.copy_(offsets)
+            offsets = offset_view
+            storage = torch.empty(2 * hidden + 1, device="cuda", dtype=dtype)
+            gamma_view = storage[1::2]
+            gamma_view.copy_(gamma)
+            gamma = gamma_view
+        return codes, weight, offsets, gamma, 1e-5
+
+    def assert_pair(self, actual, expected):
+        torch = self.torch
+        self.assertEqual(type(actual), tuple)
+        self.assertEqual(len(actual), 2)
+        if actual[0].numel():
+            self.assertNotEqual(actual[0].data_ptr(), actual[1].data_ptr())
+        for value, target in zip(actual, expected):
+            self.assertEqual(value.shape, target.shape)
+            self.assertEqual(value.dtype, target.dtype)
+            for classifier in (torch.isnan, torch.isposinf, torch.isneginf, torch.isfinite):
+                self.assertTrue(torch.equal(classifier(value), classifier(target)))
+            finite = torch.isfinite(target)
+            torch.testing.assert_close(value[finite], target[finite], atol=0.002, rtol=0.002)
+
+    def check(self, call, inputs):
+        expected = self.native(*inputs)
+        compiled = self.compiled(*inputs)
+        actual = call(*inputs)
+        self.assert_pair(compiled, expected)
+        self.assert_pair(actual, expected)
+        self.assert_pair(actual, compiled)
+        return actual
+
+    def test_both_configurations_dtypes_hidden_tail_strides_and_new_buffers(self):
+        torch = self.torch
+        with torch.inference_mode():
+            for warps in (4, 8):
+                call = self.variant.make_variant(warps)
+                keep_alive = []
+                for dtype in (torch.float16, torch.bfloat16):
+                    for hidden in (37, 1024):
+                        for strided in (False, True):
+                            with self.subTest(warps=warps, dtype=dtype, hidden=hidden, strided=strided):
+                                for seed in (42, 43):
+                                    inputs = self.inputs(dtype, hidden=hidden, strided=strided, seed=seed)
+                                    keep_alive.append(inputs)
+                                    self.check(call, inputs)
+                                self.check(call, inputs)
+
+    def test_nonfinite_values_zero_epsilon_and_fp32_variance_overflow(self):
+        torch = self.torch
+        with torch.inference_mode():
+            for warps in (4, 8):
+                call = self.variant.make_variant(warps)
+                for dtype in (torch.float16, torch.bfloat16):
+                    for pattern in (
+                        "nan",
+                        "positive_inf",
+                        "negative_inf",
+                        "opposite_inf",
+                        "gamma_nonfinite",
+                        "zero_eps",
+                    ):
+                        with self.subTest(warps=warps, dtype=dtype, pattern=pattern):
+                            inputs = list(self.inputs(dtype))
+                            inputs[0].zero_()
+                            if pattern == "nan":
+                                inputs[1][0, 0] = float("nan")
+                            elif pattern == "positive_inf":
+                                inputs[1][0, 0] = float("inf")
+                            elif pattern == "negative_inf":
+                                inputs[1][0, 0] = -float("inf")
+                            elif pattern == "opposite_inf":
+                                inputs[1][0, 0], inputs[1][32, 0] = float("inf"), -float("inf")
+                            elif pattern == "gamma_nonfinite":
+                                inputs[3][0], inputs[3][1] = float("inf"), float("nan")
+                            else:
+                                inputs[1].zero_()
+                                inputs[4] = 0.0
+                            self.check(call, tuple(inputs))
+                inputs = list(self.inputs(torch.bfloat16))
+                inputs[1].fill_(1e20)  # finite raw; separately fp32 square overflows
+                self.check(call, tuple(inputs))
+
+    def test_cached_nondefault_stream_and_graph_replay_use_live_gamma_codes_and_epsilon(self):
+        torch = self.torch
+        with torch.inference_mode():
+            call = self.variant.make_variant(8)
+            inputs = self.inputs(torch.bfloat16, hidden=1024, strided=True)
+            self.check(call, inputs)
+            stream = torch.cuda.Stream()
+            stream.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(stream):
+                torch.cuda._sleep(2_000_000)
+                inputs[0].fill_(4)
+                inputs[3].add_(0.25)
+                output = call(*inputs)
+            stream.synchronize()
+            self.assert_pair(output, self.native(*inputs))
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph, stream=stream):
+                captured = call(*inputs)
+            for index in (1, 5, 9):
+                inputs[0].fill_(index)
+                inputs[3].add_(0.0625)
+                graph.replay()
+                self.platform.synchronize()
+                self.assert_pair(captured, self.native(*inputs))
+            changed_epsilon = (*inputs[:-1], 0.125)
+            self.check(call, changed_epsilon)
+
+    def test_fallback_promotion_lazy_views_autograd_empty_and_zero_stride_gamma(self):
+        torch = self.torch
+        call = self.variant.make_variant(4)
+        with torch.inference_mode():
+            inputs = self.inputs(torch.bfloat16, index_dtype=torch.int32)
+            self.check(call, inputs)
+            for dtype in (torch.float16, torch.float32, torch.float64):
+                changed = (*inputs[:3], inputs[3].to(dtype), inputs[4])
+                self.assertFalse(self.variant.can_use_variant(*changed))
+                self.assert_pair(call(*changed), self.native(*changed))
+                self.assertEqual(call(*changed)[1].dtype, torch.promote_types(torch.bfloat16, dtype))
+            for index in range(4):
+                changed_inputs = list(inputs)
+                # Integer logical indices stay valid while retaining a lazy
+                # negative view bit, so this test cannot poison the CUDA context.
+                changed_inputs[index] = torch._neg_view(-changed_inputs[index])
+                self.assertFalse(self.variant.can_use_variant(*changed_inputs))
+                self.assert_pair(call(*changed_inputs), self.native(*changed_inputs))
+            broadcast_gamma = inputs[3][:1].expand(inputs[3].shape[0])
+            self.check(call, (*inputs[:3], broadcast_gamma, inputs[4]))
+            empty = (inputs[0][:0], *inputs[1:])
+            self.assert_pair(call(*empty), self.native(*empty))
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                self.assertFalse(self.variant.can_use_variant(*inputs))
+                self.assert_pair(call(*inputs), self.native(*inputs))
+        with torch.enable_grad():
+            inputs = list(self.inputs(torch.float16))
+            inputs[1].requires_grad_()
+            inputs[3].requires_grad_()
+            self.assertFalse(self.variant.can_use_variant(*inputs))
+            raw, normalized = call(*inputs)
+            (raw.float().sum() + normalized.float().sum()).backward()
+            self.assertIsNotNone(inputs[1].grad)
+            self.assertIsNotNone(inputs[3].grad)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/model_executor/layers/test_rvq_rmsnorm_gpu.py
+++ b/tests/model_executor/layers/test_rvq_rmsnorm_gpu.py
@@ -99,28 +99,6 @@ class GpuRmsnormTests(unittest.TestCase):
         self.assert_pair(actual, compiled)
         return actual
 
-    def test_native_order_raw_and_norm_on_frozen_runtime(self):
-        torch = self.torch
-        if torch.__version__ != "2.13.0+cu130":
-            self.skipTest("Bit-exact reduction contract was measured on Torch 2.13.0+cu130")
-        call = self.variant.make_variant(4)
-        with torch.inference_mode():
-            for dtype in (torch.float16, torch.bfloat16):
-                for frames in (1, 32, 128):
-                    for strided in (False, True):
-                        generator = torch.Generator(device="cuda").manual_seed(947)
-                        backing = torch.randint(2048, (1, 16, frames * 2), device="cuda", generator=generator)
-                        codes = backing[..., ::2] if strided else backing[..., :frames].contiguous()
-                        weight = torch.randn(32768, 1024, dtype=dtype, device="cuda", generator=generator)
-                        offsets = (torch.arange(16, device="cuda") * 2048).view(1, 16, 1)
-                        gamma = torch.randn(1024, dtype=dtype, device="cuda", generator=generator)
-                        for delta in (0, 17):
-                            if delta:
-                                codes.copy_((codes + delta) % 2048)
-                            inputs = codes, weight, offsets, gamma, 1e-5
-                            for actual, expected in zip(call(*inputs), self.native(*inputs), strict=True):
-                                torch.testing.assert_close(actual, expected, rtol=0, atol=0)
-
     def test_both_configurations_dtypes_hidden_tail_strides_and_new_buffers(self):
         torch = self.torch
         with torch.inference_mode():

--- a/tests/model_executor/layers/test_rvq_rmsnorm_gpu.py
+++ b/tests/model_executor/layers/test_rvq_rmsnorm_gpu.py
@@ -99,6 +99,28 @@ class GpuRmsnormTests(unittest.TestCase):
         self.assert_pair(actual, compiled)
         return actual
 
+    def test_native_order_raw_and_norm_on_frozen_runtime(self):
+        torch = self.torch
+        if torch.__version__ != "2.13.0+cu130":
+            self.skipTest("Bit-exact reduction contract was measured on Torch 2.13.0+cu130")
+        call = self.variant.make_variant(4)
+        with torch.inference_mode():
+            for dtype in (torch.float16, torch.bfloat16):
+                for frames in (1, 32, 128):
+                    for strided in (False, True):
+                        generator = torch.Generator(device="cuda").manual_seed(947)
+                        backing = torch.randint(2048, (1, 16, frames * 2), device="cuda", generator=generator)
+                        codes = backing[..., ::2] if strided else backing[..., :frames].contiguous()
+                        weight = torch.randn(32768, 1024, dtype=dtype, device="cuda", generator=generator)
+                        offsets = (torch.arange(16, device="cuda") * 2048).view(1, 16, 1)
+                        gamma = torch.randn(1024, dtype=dtype, device="cuda", generator=generator)
+                        for delta in (0, 17):
+                            if delta:
+                                codes.copy_((codes + delta) % 2048)
+                            inputs = codes, weight, offsets, gamma, 1e-5
+                            for actual, expected in zip(call(*inputs), self.native(*inputs), strict=True):
+                                torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
     def test_both_configurations_dtypes_hidden_tail_strides_and_new_buffers(self):
         torch = self.torch
         with torch.inference_mode():


### PR DESCRIPTION
## Purpose

Add an opt-in dual-output RVQ plus first-RMSNorm fusion experiment with a runnable paired benchmark and numerical regression suite. A single Triton program per frame reduces 16 embedding rows, writes the rounded raw residual, then computes RMS statistics from that rounded value and writes the normalized output. Gamma remains a live input and multiplication occurs after the activation cast.

Both outputs are observable: keeping only normalized values would omit the first attention residual and change the benchmark boundary. Unsupported metadata falls back to native arithmetic. The experiment remains under `benchmarks/kernels`; this PR does not change a model's default execution path or claim complete text-to-audio improvement. Open-PR searches for RVQ/RMSNorm found no duplicate of this experiment.

## Test Plan

**vLLM Version:** the benchmark requires an installed vLLM exposing `triton_utils`; the measured kernel environment was Torch 2.13.0+cu130 and Triton 3.7.1.

**vLLM-Omni Commit:** 7e520f9cc47e6884520ea8f3f9ab94ab97b34780 (publication base).

- `TORCHINDUCTOR_EMULATE_PRECISION_CASTS=1 python -m benchmarks.kernels.bench_rvq_rmsnorm --output rvq-results.json`
- `TORCHINDUCTOR_EMULATE_PRECISION_CASTS=1 pytest tests/model_executor/layers/test_rvq_rmsnorm_gpu.py`
- `pytest tests/model_executor/layers/test_rvq_rmsnorm_cpu.py`
- Changed-file pre-commit hooks, including mypy, hardware/CI markers, SPDX, forbidden imports and platform API checks.

## Test Result

Archived SM120 confirmation on NVIDIA RTX PRO 5000 Blackwell: **24/24 positive region comparisons**, **288 timing arms**, with descriptive paired latency reductions of **1.638–58.314%**. Both baseline and candidate were compiled with `fullgraph=True`, `dynamic=False`, and `emulate_precision_casts=True`; four warps were fixed across FP16/BF16, 1/32/128 frames, contiguous/strided codes, 16 codebooks of 2048 entries, hidden width 1024 and epsilon 1e-5. Parameters were generated, not checkpoint-derived.

For example, FP16 with 128 frames and strided codes had the following complete-region measurements:

| Mode | Baseline median µs | Fused median µs | Paired latency reduction |
| --- | ---: | ---: | ---: |
| Eager events | 14.3360 | 10.2400 | 28.64% |
| CUDA Graph | 9.9975 | 4.1679 | 58.17% |

Finite values use `atol=rtol=0.002`; finite/NaN/positive-infinity/negative-infinity masks match exactly. This is not a bitwise-equality claim. The archived four GPU test methods cover tails, dtypes, strided/live buffers, nondefault streams, Graph replay, nonfinite values, mixed gamma dtype, lazy views, autocast, gradients and empty inputs.

Fresh publication checks: **4 CPU tests and four subtests passed; 4 GPU methods skipped** on the CPU-only host. All changed-file hooks passed. The Triton kernel AST is identical to the tested source. Publication changes replace imports/current-device access with project APIs and provide the standalone entry point. That entry point and the wrapper port have not received a fresh GPU run. Model consumer integration and full-model E2E remain outside this PR's measured scope.
