### PR TITLE
[Bugfix][Model] Enable distributed VAE for FLUX.2 Klein

### DIFF
--- a/tests/diffusion/models/flux2/test_flux2_klein_distributed_vae.py
+++ b/tests/diffusion/models/flux2/test_flux2_klein_distributed_vae.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_flux2 import (
+    DistributedAutoencoderKLFlux2,
+)
+from vllm_omni.diffusion.models.flux2_klein import pipeline_flux2_klein
+
+
+class _Component:
+    def __init__(self, config) -> None:
+        self.config = config
+
+    def to(self, _device):
+        return self
+
+
+def test_klein_pipeline_loads_distributed_vae(monkeypatch) -> None:
+    loaded_factories = {}
+
+    def fake_load(factory, _model, *, subfolder, **_kwargs):
+        loaded_factories[subfolder] = factory
+        if subfolder == "vae":
+            return _Component(SimpleNamespace(block_out_channels=[1, 1, 1, 1], latent_channels=32))
+        return _Component(SimpleNamespace())
+
+    monkeypatch.setattr(pipeline_flux2_klein, "get_local_device", lambda: torch.device("cpu"))
+    monkeypatch.setattr(pipeline_flux2_klein, "prefetch_subfolders", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(pipeline_flux2_klein, "from_pretrained_with_prefetch", fake_load)
+    monkeypatch.setattr(
+        pipeline_flux2_klein.FlowMatchEulerDiscreteScheduler,
+        "from_pretrained",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        pipeline_flux2_klein.Qwen2TokenizerFast,
+        "from_pretrained",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(pipeline_flux2_klein, "get_transformer_config_kwargs", lambda *_args: {})
+    monkeypatch.setattr(pipeline_flux2_klein, "Flux2Transformer2DModel", lambda **_kwargs: object())
+    monkeypatch.setattr(
+        pipeline_flux2_klein.Flux2KleinPipeline,
+        "setup_diffusion_pipeline_profiler",
+        lambda *_args, **_kwargs: None,
+    )
+    od_config = SimpleNamespace(
+        model="test-model",
+        tf_model_config={},
+        quantization_config=None,
+        enable_diffusion_pipeline_profiler=False,
+    )
+
+    pipeline_flux2_klein.Flux2KleinPipeline(od_config=od_config)
+
+    assert loaded_factories["vae"].__self__ is DistributedAutoencoderKLFlux2

--- a/vllm_omni/diffusion/models/flux2_klein/pipeline_flux2_klein.py
+++ b/vllm_omni/diffusion/models/flux2_klein/pipeline_flux2_klein.py
@@ -26,7 +26,6 @@ import PIL.Image
 import torch
 import torch.nn as nn
 from diffusers.image_processor import VaeImageProcessor
-from diffusers.models.autoencoders.autoencoder_kl_flux2 import AutoencoderKLFlux2
 from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion import retrieve_timesteps
 from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion_img2img import retrieve_latents
 from diffusers.schedulers import FlowMatchEulerDiscreteScheduler
@@ -36,6 +35,7 @@ from vllm.logger import init_logger
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_flux2 import DistributedAutoencoderKLFlux2
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
@@ -248,7 +248,7 @@ class Flux2KleinPipeline(
             local_files_only=local_files_only,
         )
         self.vae = from_pretrained_with_prefetch(
-            AutoencoderKLFlux2.from_pretrained,
+            DistributedAutoencoderKLFlux2.from_pretrained,
             model,
             subfolder="vae",
             prefetch_list=flux2_subfolders,


### PR DESCRIPTION
## Summary

- Load `DistributedAutoencoderKLFlux2` in the FLUX.2 Klein pipeline, matching the existing FLUX.2 pipeline.
- Make `--vae-patch-parallel-size` effective for FLUX.2 Klein instead of warning that the setting is ignored.
- Add a regression test that verifies the Klein pipeline selects the distributed-capable VAE factory.

## Behavior

The default `vae_patch_parallel_size=1` path remains unchanged: distributed execution stays disabled and encode/decode delegate to the original Diffusers implementation. The existing distributed patch/tile executor is activated only when VAE patch parallelism is explicitly requested.

## Tests

```text
pytest -q -o addopts='' \
  tests/diffusion/models/flux2/test_flux2_klein_distributed_vae.py \
  tests/diffusion/models/flux2/test_flux2_klein_validation.py \
  tests/diffusion/distributed/test_vae_patch_parallel.py

30 passed
```
