### PR TITLE
[Bugfix][Qwen3-Omni] Restore the talker sampling seed

### DIFF
--- a/tests/config/test_config_factory.py
+++ b/tests/config/test_config_factory.py
@@ -2619,6 +2619,28 @@ class TestPlatformOverrides:
             config = deploy.stages[0].compilation_config or {}
             assert "+rotary_embedding" not in config.get("custom_ops", [])
 
+    def test_qwen3_omni_talker_sampling_is_seeded(self):
+        """The only stochastic Qwen3-Omni stage must stay reproducible.
+
+        Dropping this seed (as #4986 did) leaves the talker sampling codec
+        tokens unseeded at temperature 0.9, which reopened the audio-vs-text
+        nightly failures in #6090. Pin it so a cleanup cannot remove it again
+        without failing here.
+        """
+        deploy_path = Path(get_deploy_config_path("qwen3_omni_moe.yaml"))
+        pipeline = resolve_pipeline_config(
+            "qwen3_omni_moe",
+            Q3_OMNI_ALL_STAGES_HF_CONFIG,
+        )
+        assert isinstance(pipeline, PipelineConfig)
+
+        for platform in ("cpu", "cuda", "musa", "npu", "rocm", "xpu"):
+            deploy = _apply_platform_overrides(load_deploy_config(deploy_path), platform=platform)
+            stages = merge_pipeline_deploy(pipeline, deploy)
+            talker_sampling = stages[1].yaml_extras["default_sampling_params"]
+            assert talker_sampling["temperature"] > 0.0, "talker is expected to sample, not decode greedily"
+            assert talker_sampling.get("seed") == 42, f"talker sampling lost its seed on {platform}"
+
     def test_minicpmo_4_5_cuda_caps_talker_kv_cache(self):
         pipeline = resolve_pipeline_config("minicpmo_4_5")
         assert isinstance(pipeline, PipelineConfig)

--- a/vllm_omni/deploy/qwen3_omni_moe.yaml
+++ b/vllm_omni/deploy/qwen3_omni_moe.yaml
@@ -46,6 +46,16 @@ stages:
     input_connectors:
       from_stage_0: connector_of_shared_memory
     default_sampling_params:
+      # The talker is the only stochastic stage (the thinker and code2wav both
+      # decode greedily at temperature 0). Without a seed, every request draws
+      # fresh codec tokens, and a small fraction of draws derail into fluent
+      # nonsense part-way through an utterance while the thinker text stays
+      # correct -- the audio-vs-text nightly failures in #6090. This seed was
+      # present from the original deploy schema and was dropped as collateral
+      # in #4986; keep it so Qwen3-Omni speech is reproducible for a given
+      # request. It bounds sampling only: it does not make the talker immune
+      # to the underlying degeneration, which is tracked separately.
+      seed: 42
       temperature: 0.9
       top_k: 50
       max_tokens: 4096


### PR DESCRIPTION
### Purpose

Fixes the recurring audio-vs-text nightly failures tracked in #6090.

The talker is the only stochastic Qwen3-Omni stage — it samples codec tokens at `temperature: 0.9, top_k: 50`, while the thinker and code2wav both decode greedily at temperature 0. It carried `seed: 42` from the original deploy schema until `9a44e7e01` (#4986, "[Refactor][Phase 1] Remove redundant functions and logs"), which deleted the seed from stages 1 and 2. Nothing in that PR's title or description concerns sampling, so this looks like collateral damage in a log and dead-code cleanup rather than an intended change.

Since then every request draws fresh codec tokens, and a small fraction of draws derail part-way through an utterance into fluent nonsense while the thinker text stays correct. Sampled from the raw logs of four nightly jobs (13487 retry, 14799 attempt 1, 14799 retry, 14877):

- **~1.3%** of requests score at or below the 0.8 audio-vs-text gate
- **~3%** are visibly degraded (below 0.95)
- the rate is stable across independent jobs

At ~75 comparisons per run that leaves a run clean only about a third of the time, which matches the observed "fails most nights, occasionally passes on retry" pattern and the reshuffling failing-case set. Representative transcripts (thinker text was correct in every one of these):

| Build | Test | Sim | Transcript |
| --- | --- | --- | --- |
| 13487 retry | `test_large_image_to_text_audio_001[async_chunk]` | 0.0 | `වවවවවවවවවවව…` |
| 14799 retry | `test_speaker_002[async_chunk]` | 0.161 | "Gotti the Red's cronowell to go up to carry a specian…" |
| 14877 | `test_text_audio_to_text_audio_002[async_chunk]` | 0.789 | "… Like it.dig is all boroughly. Why did buy two-digit time ticket appraisean? …" |

### Changes

- `vllm_omni/deploy/qwen3_omni_moe.yaml`: restore `seed: 42` on stage 1, with a comment recording why it is there so it is not mistaken for redundancy again.
- `tests/config/test_config_factory.py`: assert the talker resolves to a seeded, still-stochastic sampling config on all six platforms.

Stage 2 also lost its seed in #4986, but it decodes greedily, so that seed was inert and is not restored.

### What this does not do

Two limits worth stating explicitly:

1. **A seed bounds sampling, not the logits.** Under continuous batching with five concurrent requests, batch composition still varies run to run, so this should sharply reduce variance but is not guaranteed to eliminate it.
2. **It does not fix the underlying defect.** The talker genuinely degenerates on a measurable fraction of draws; seeding stops CI from rolling the dice on every request but does not make the model more robust. That ~1.3% rate is the thing worth fixing and belongs with the speech-quality instability in #6158.

### Test

`tests/config/test_config_factory.py::TestPlatformOverrides::test_qwen3_omni_talker_sampling_is_seeded` passes with the change and fails without it (`talker sampling lost its seed on cpu`). The rest of `tests/config/test_config_factory.py` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtyuntKzbzPb34h5xKjbHm
