### PR TITLE
[3/6][Feature][Diffusion] Thread generator into qwen_image scheduler.step

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -92,6 +92,7 @@ nav:
       - Session State Manager: features/session_state_manager.md
   - Integrations:
     - Custom Diffusion Pipeline: features/custom_pipeline.md
+    - Diffusion Scheduler Injection: features/scheduler_injection.md
     - ComfyUI: features/comfyui.md
   - Fault Tolerance:
     - Failure Modes: user_guide/fault_injection_reliability_matrix.md

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -67,6 +67,13 @@ The [Pipeline Parallelism guide](../user_guide/diffusion/parallelism/pipeline_pa
 remains available by direct link, but it is not promoted in the primary User
 Guide navigation until its user-facing support and placement are settled.
 
+## Integrations
+
+| Goal | User guide |
+| --- | --- |
+| Extend a stock pipeline with a custom class | [Custom Diffusion Pipeline](custom_pipeline.md) |
+| Inject a custom diffusion sampling scheduler | [Diffusion Scheduler Injection](scheduler_injection.md) |
+
 ## Experimental
 
 [Session State Manager](session_state_manager.md) is opt-in and experimental.

--- a/docs/features/scheduler_injection.md
+++ b/docs/features/scheduler_injection.md
@@ -1,0 +1,92 @@
+# Diffusion Scheduler Injection
+
+This guide covers injecting a custom diffusion *sampling* scheduler into a
+stock pipeline. It is the supported alternative to forking a pipeline when
+only the scheduler class needs to change (for example an SDE sampler that
+collects log-probs).
+
+This is **not** the stage request scheduler (`engine_args.scheduler_cls` /
+`OmniARScheduler`). The Python API and deploy YAML name is
+`diffusion_scheduler` so the two are distinguishable.
+
+## Options
+
+Set these on `AsyncOmni` / `OmniEngineArgs`, or under a deploy YAML stage's
+`engine_args`. There are no CLI flags (same as `custom_pipeline_args`).
+
+| Engine arg | `OmniDiffusionConfig` field | Meaning |
+| --- | --- | --- |
+| `diffusion_scheduler` | `scheduler` | Registry name or dotted class path |
+| `diffusion_scheduler_kwargs` | `scheduler_kwargs` | Extra kwargs for `from_pretrained()` |
+
+Resolution order inside `build_pipeline_scheduler`:
+
+1. Explicit `scheduler_cls` argument (pipeline-internal)
+2. `od_config.scheduler`
+3. The pipeline's existing default builder (bit-identical when unset)
+
+## Usage
+
+```python
+from vllm_omni.entrypoints.async_omni import AsyncOmni
+
+engine = AsyncOmni(
+    model="Qwen/Qwen-Image",
+    diffusion_scheduler="my_pkg.FlowMatchSDEDiscreteScheduler",
+    diffusion_scheduler_kwargs={},  # optional, forwarded to from_pretrained
+)
+```
+
+External packages can advertise classes through the empty
+`vllm_omni.schedulers` entry-point group declared in `pyproject.toml`:
+
+```toml
+[project.entry-points."vllm_omni.schedulers"]
+flow_match_sde = "my_pkg:FlowMatchSDEDiscreteScheduler"
+```
+
+Then `diffusion_scheduler="flow_match_sde"` resolves through the registry.
+
+## Injected-class contract
+
+The class must satisfy the same diffusers-style contract stock pipelines
+already use:
+
+- `step(noise_pred, t, latents, return_dict=False, generator=None)` — with
+  `return_dict=False` return a tuple whose first element is the stepped
+  latents
+- `set_timesteps(num_inference_steps, device=...)` and expose `.timesteps`.
+  Keep named parameters (`sigmas` / `timesteps`); a `*args, **kwargs` override
+  hides those names and breaks dummy warmup
+- `set_begin_index(...)` for pipeline-parallel timestep slicing
+- a `.config` attribute with at least `num_train_timesteps`
+- deepcopy-safe (step-wise execution deep-copies the scheduler per request)
+
+Construction matches the stock sites: the pipeline passes its resolved
+`local_files_only` (typically `os.path.exists(model)`) and `revision` into
+`cls.from_pretrained(od_config.model, subfolder="scheduler", ...)`.
+
+## Which pipelines honor the seam
+
+The factory is wired at every stock `from_pretrained` construction site that
+this PR covers, including:
+
+- `flux`, `flux_kontext`, `flux2`
+- `qwen_image`, `qwen_image_edit`, `qwen_image_edit_plus`, `qwen_image_layered`
+- `sd3`
+- `ltx2` (dynamic-shifting overwrite is skipped + warned when injection is set)
+- `wan2_2` and `wan2_2_i2v` (per-request `sample_solver` / `flow_shift` rebuild
+  is skipped + warned)
+- `glm_image`, `hidream_image`, `longcat_image*`, `longcat_video_avatar`
+- `hunyuan_video_1_5*`
+- `ernie_image`, `boogu_image`, `krea2`, `lingbot_video`
+
+Variants that construct a scheduler another way (for example DMD2's
+`DMD2EulerScheduler` overwrite, Helios, Cosmos3) skip the overwrite and
+leave the injected object when `od_config.scheduler` is set, or fail at
+pipeline load if the construction site never called
+`build_pipeline_scheduler`. An accepted `scheduler` field is never silently
+ignored.
+
+Custom pipelines remain supported until the rest of the RL injection surface
+is ready; see [Custom Diffusion Pipeline](custom_pipeline.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,11 @@ vllm-omni = "vllm_omni.entrypoints.cli.main:main"
 [project.entry-points."vllm.general_plugins"]
 vllm_omni_register_models = "vllm_omni.engine.arg_utils:register_omni_models_to_vllm"
 
+# External packages (e.g. verl-omni) advertise diffusion scheduler classes
+# under this group; vllm_omni.diffusion.models.schedulers.resolve_scheduler_cls
+# picks them up by name. Declared empty here so the group is owned by vllm-omni.
+[project.entry-points."vllm_omni.schedulers"]
+
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/diffusion/models/schedulers/test_registry.py
+++ b/tests/diffusion/models/schedulers/test_registry.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the diffusion scheduler registry and construction seam.
+
+Covers ``vllm_omni.diffusion.models.schedulers.registry``: name registration
+(direct + decorator), class resolution (registry / entry points / dotted
+path), the ``build_pipeline_scheduler`` resolution order, kwargs merging, the
+bit-identical default fallback, and the documented injected-scheduler
+contract.
+"""
+
+import copy
+import importlib.metadata
+import inspect
+from types import SimpleNamespace
+from typing import Any, ClassVar
+from unittest.mock import Mock
+
+import pytest
+
+import vllm_omni.diffusion.models.schedulers.registry as registry_mod
+from vllm_omni.diffusion.models.schedulers import (
+    FlowMatchEulerDiscreteScheduler,
+    build_pipeline_scheduler,
+    register_scheduler,
+    resolve_scheduler_cls,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class RecordingMockScheduler:
+    """Minimal scheduler satisfying the documented injection contract.
+
+    Records every ``from_pretrained`` call in the class-level ``constructed``
+    list so tests can inspect the exact construction arguments.
+    """
+
+    constructed: ClassVar[list[dict[str, Any]]] = []
+
+    def __init__(self, **config: Any) -> None:
+        self.config = dict(config)
+        self.timesteps: list[int] = []
+        self._begin_index = 0
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model: str,
+        subfolder: str | None = None,
+        local_files_only: bool = False,
+        **kwargs: Any,
+    ) -> "RecordingMockScheduler":
+        cls.constructed.append(
+            {
+                "model": model,
+                "subfolder": subfolder,
+                "local_files_only": local_files_only,
+                "kwargs": kwargs,
+            }
+        )
+        return cls(**kwargs)
+
+    def step(self, noise_pred, t, latents, return_dict=False, generator=None):
+        return (latents,)
+
+    def set_timesteps(self, num_inference_steps: int, device=None) -> None:
+        self.timesteps = list(range(num_inference_steps))
+
+    def set_begin_index(self, begin_index: int = 0) -> None:
+        self._begin_index = begin_index
+
+
+class OtherMockScheduler(RecordingMockScheduler):
+    """Second registrable class, distinguished by type."""
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry(monkeypatch):
+    """Snapshot the module-global registry and skip real entry-point scans."""
+    snapshot = dict(registry_mod._SCHEDULER_REGISTRY)
+    monkeypatch.setattr(registry_mod, "_entry_points_loaded", True)
+    RecordingMockScheduler.constructed.clear()
+    yield
+    registry_mod._SCHEDULER_REGISTRY.clear()
+    registry_mod._SCHEDULER_REGISTRY.update(snapshot)
+
+
+def _od_config(**overrides) -> SimpleNamespace:
+    """Stub OmniDiffusionConfig (duck-typed; the factory only uses getattr)."""
+    base = {
+        "model": "stub-model",
+        "scheduler": None,
+        "scheduler_kwargs": None,
+        "local_files_only": False,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def assert_scheduler_contract(scheduler: Any) -> None:
+    """Validate the documented injected-scheduler contract (registry.py docstring)."""
+    sig = inspect.signature(scheduler.step)
+    positional = [
+        p
+        for p in sig.parameters.values()
+        if p.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    ]
+    assert len(positional) >= 3, "step() must accept (noise_pred, t, latents) positionally"
+    assert "return_dict" in sig.parameters, "step() must accept return_dict"
+    assert "generator" in sig.parameters, "step() must accept generator"
+    assert callable(getattr(scheduler, "set_timesteps", None)), "set_timesteps() required"
+    assert callable(getattr(scheduler, "set_begin_index", None)), "set_begin_index() required"
+    assert hasattr(scheduler, "config"), ".config attribute required"
+    copy.deepcopy(scheduler)  # must be deepcopy-safe
+
+
+class TestRegisterAndResolve:
+    def test_register_direct_call(self):
+        register_scheduler("mock_direct", RecordingMockScheduler)
+        assert resolve_scheduler_cls("mock_direct") is RecordingMockScheduler
+
+    def test_register_decorator(self):
+        @register_scheduler("mock_decorated")
+        class DecoratedScheduler(RecordingMockScheduler):
+            pass
+
+        assert resolve_scheduler_cls("mock_decorated") is DecoratedScheduler
+
+    def test_resolve_none_passthrough(self):
+        assert resolve_scheduler_cls(None) is None
+
+    def test_resolve_class_passthrough(self):
+        assert resolve_scheduler_cls(RecordingMockScheduler) is RecordingMockScheduler
+
+    def test_resolve_by_dotted_path(self):
+        ref = (
+            "vllm_omni.diffusion.models.schedulers.scheduling_flow_match_euler_discrete.FlowMatchEulerDiscreteScheduler"
+        )
+        assert resolve_scheduler_cls(ref) is FlowMatchEulerDiscreteScheduler
+
+    def test_resolve_unknown_bare_name_raises_keyerror(self):
+        register_scheduler("mock_known", RecordingMockScheduler)
+        with pytest.raises(KeyError, match="Unknown scheduler 'nope'.*mock_known"):
+            resolve_scheduler_cls("nope")
+
+    def test_resolve_unknown_dotted_path_raises(self):
+        with pytest.raises(ModuleNotFoundError):
+            resolve_scheduler_cls("no.such.module.Scheduler")
+
+
+class _FakeEntryPoint:
+    def __init__(self, name: str, cls: type) -> None:
+        self.name = name
+        self._cls = cls
+
+    def load(self) -> type:
+        return self._cls
+
+
+class TestEntryPoints:
+    def _patch_entry_points(self, monkeypatch, eps: list[_FakeEntryPoint]) -> None:
+        monkeypatch.setattr(importlib.metadata, "entry_points", lambda group=None: eps)
+        monkeypatch.setattr(registry_mod, "_entry_points_loaded", False)
+
+    def test_entry_point_registered_and_resolvable(self, monkeypatch):
+        self._patch_entry_points(monkeypatch, [_FakeEntryPoint("ep_scheduler", RecordingMockScheduler)])
+        assert resolve_scheduler_cls("ep_scheduler") is RecordingMockScheduler
+
+    def test_entry_points_loaded_only_once(self, monkeypatch):
+        calls = []
+
+        def _fake_entry_points(group=None):
+            calls.append(group)
+            return [_FakeEntryPoint("ep_scheduler", RecordingMockScheduler)]
+
+        monkeypatch.setattr(importlib.metadata, "entry_points", _fake_entry_points)
+        monkeypatch.setattr(registry_mod, "_entry_points_loaded", False)
+        resolve_scheduler_cls("ep_scheduler")
+        resolve_scheduler_cls("ep_scheduler")
+        assert calls == [registry_mod.SCHEDULER_ENTRY_POINT_GROUP]
+
+    def test_direct_registration_wins_over_entry_point(self, monkeypatch):
+        register_scheduler("ep_scheduler", OtherMockScheduler)
+        self._patch_entry_points(monkeypatch, [_FakeEntryPoint("ep_scheduler", RecordingMockScheduler)])
+        assert resolve_scheduler_cls("ep_scheduler") is OtherMockScheduler
+
+
+class TestBuildPipelineScheduler:
+    def test_explicit_arg_beats_config(self):
+        register_scheduler("config_sched", RecordingMockScheduler)
+        od_config = _od_config(scheduler="config_sched")
+        result = build_pipeline_scheduler(od_config, scheduler_cls=OtherMockScheduler)
+        assert isinstance(result, OtherMockScheduler)
+
+    def test_config_beats_default_builder(self):
+        register_scheduler("config_sched", RecordingMockScheduler)
+        default_builder = Mock(return_value=object())
+        result = build_pipeline_scheduler(_od_config(scheduler="config_sched"), default_builder=default_builder)
+        assert isinstance(result, RecordingMockScheduler)
+        default_builder.assert_not_called()
+
+    def test_default_fallback_bit_identical(self):
+        sentinel = object()
+        default_builder = Mock(return_value=sentinel)
+        result = build_pipeline_scheduler(_od_config(), default_builder=default_builder)
+        assert result is sentinel, "default path must pass the builder's return value through untouched"
+        default_builder.assert_called_once_with()
+        assert RecordingMockScheduler.constructed == []
+
+    def test_construction_args_match_stock_sites(self):
+        register_scheduler("config_sched", RecordingMockScheduler)
+        od_config = _od_config(scheduler="config_sched", model="/local/model", local_files_only=True)
+        build_pipeline_scheduler(od_config)
+        assert RecordingMockScheduler.constructed == [
+            {
+                "model": "/local/model",
+                "subfolder": "scheduler",
+                "local_files_only": True,
+                "kwargs": {},
+            }
+        ]
+
+    def test_kwargs_merging_explicit_over_config(self):
+        register_scheduler("config_sched", RecordingMockScheduler)
+        od_config = _od_config(
+            scheduler="config_sched",
+            scheduler_kwargs={"shift": 1.0, "num_train_timesteps": 1000},
+        )
+        result = build_pipeline_scheduler(od_config, scheduler_kwargs={"shift": 3.0})
+        assert RecordingMockScheduler.constructed[-1]["kwargs"] == {"shift": 3.0, "num_train_timesteps": 1000}
+        assert result.config == {"shift": 3.0, "num_train_timesteps": 1000}
+
+    def test_config_accepts_dotted_path(self):
+        od_config = _od_config(scheduler=f"{__name__}.RecordingMockScheduler")
+        default_builder = Mock()
+        result = build_pipeline_scheduler(od_config, default_builder=default_builder)
+        assert isinstance(result, RecordingMockScheduler)
+        default_builder.assert_not_called()
+
+
+class TestSchedulerContract:
+    def test_mock_satisfies_contract(self):
+        scheduler = RecordingMockScheduler(num_train_timesteps=1000)
+        assert_scheduler_contract(scheduler)
+
+    def test_mock_step_and_timesteps_behavior(self):
+        scheduler = RecordingMockScheduler()
+        scheduler.set_timesteps(4)
+        assert scheduler.timesteps == [0, 1, 2, 3]
+        scheduler.set_begin_index(1)
+        assert scheduler._begin_index == 1
+        latents = object()
+        assert scheduler.step("noise", 0, latents, return_dict=False) == (latents,)
+
+    def test_deepcopy_gives_independent_state(self):
+        scheduler = RecordingMockScheduler()
+        scheduler.set_timesteps(4)
+        clone = copy.deepcopy(scheduler)
+        clone.set_timesteps(2)
+        assert scheduler.timesteps == [0, 1, 2, 3]
+        assert clone.timesteps == [0, 1]
+
+    def test_stock_flow_match_scheduler_satisfies_contract(self):
+        # The vendored stock scheduler must keep satisfying the contract that
+        # injected schedulers are held to (it is deep-copied per request in
+        # step-wise execution).
+        assert_scheduler_contract(FlowMatchEulerDiscreteScheduler())

--- a/tests/diffusion/models/schedulers/test_registry.py
+++ b/tests/diffusion/models/schedulers/test_registry.py
@@ -22,6 +22,8 @@ import vllm_omni.diffusion.models.schedulers.registry as registry_mod
 from vllm_omni.diffusion.models.schedulers import (
     FlowMatchEulerDiscreteScheduler,
     build_pipeline_scheduler,
+    ensure_scheduler_consumed,
+    is_injected_scheduler,
     register_scheduler,
     resolve_scheduler_cls,
 )
@@ -80,6 +82,7 @@ def _isolate_registry(monkeypatch):
     """Snapshot the module-global registry and skip real entry-point scans."""
     snapshot = dict(registry_mod._SCHEDULER_REGISTRY)
     monkeypatch.setattr(registry_mod, "_entry_points_loaded", True)
+    monkeypatch.setattr(registry_mod, "_consumed_scheduler_config_ids", set())
     RecordingMockScheduler.constructed.clear()
     yield
     registry_mod._SCHEDULER_REGISTRY.clear()
@@ -210,16 +213,41 @@ class TestBuildPipelineScheduler:
 
     def test_construction_args_match_stock_sites(self):
         register_scheduler("config_sched", RecordingMockScheduler)
-        od_config = _od_config(scheduler="config_sched", model="/local/model", local_files_only=True)
-        build_pipeline_scheduler(od_config)
+        od_config = _od_config(scheduler="config_sched", model="/local/model")
+        build_pipeline_scheduler(od_config, local_files_only=True, revision="abc123")
         assert RecordingMockScheduler.constructed == [
             {
                 "model": "/local/model",
                 "subfolder": "scheduler",
                 "local_files_only": True,
-                "kwargs": {},
+                "kwargs": {"revision": "abc123"},
             }
         ]
+
+    def test_missing_default_builder_raises_valueerror(self):
+        with pytest.raises(ValueError, match="No scheduler configured"):
+            build_pipeline_scheduler(_od_config())
+
+    def test_od_config_local_files_only_attr_is_ignored(self):
+        register_scheduler("config_sched", RecordingMockScheduler)
+        od_config = _od_config(scheduler="config_sched", model="hub/model", local_files_only=True)
+        build_pipeline_scheduler(od_config, local_files_only=False)
+        assert RecordingMockScheduler.constructed[-1]["local_files_only"] is False
+
+    def test_ensure_scheduler_consumed_raises_when_unwired(self):
+        od_config = _od_config(scheduler="config_sched")
+        with pytest.raises(ValueError, match="does not consume"):
+            ensure_scheduler_consumed(od_config, object())
+
+    def test_ensure_scheduler_consumed_passes_after_factory(self):
+        register_scheduler("config_sched", RecordingMockScheduler)
+        od_config = _od_config(scheduler="config_sched")
+        build_pipeline_scheduler(od_config, local_files_only=False)
+        ensure_scheduler_consumed(od_config, object())
+
+    def test_is_injected_scheduler(self):
+        assert is_injected_scheduler(_od_config(scheduler="x"))
+        assert not is_injected_scheduler(_od_config())
 
     def test_kwargs_merging_explicit_over_config(self):
         register_scheduler("config_sched", RecordingMockScheduler)

--- a/tests/diffusion/models/schedulers/test_registry.py
+++ b/tests/diffusion/models/schedulers/test_registry.py
@@ -266,3 +266,17 @@ class TestSchedulerContract:
         # injected schedulers are held to (it is deep-copied per request in
         # step-wise execution).
         assert_scheduler_contract(FlowMatchEulerDiscreteScheduler())
+
+    def test_set_timesteps_advertises_sigmas_for_retrieve_timesteps(self):
+        # Qwen-Image always synthesizes a custom sigma schedule, then
+        # retrieve_timesteps inspects set_timesteps for a named ``sigmas``.
+        scheduler = FlowMatchEulerDiscreteScheduler()
+        assert "sigmas" in inspect.signature(scheduler.set_timesteps).parameters
+
+    def test_e2e_helper_preserves_sigmas_on_set_timesteps(self):
+        from tests.e2e.features.helpers.custom_scheduler import FlowMatchEulerDiscreteSchedulerForTest
+
+        scheduler = FlowMatchEulerDiscreteSchedulerForTest()
+        params = inspect.signature(scheduler.set_timesteps).parameters
+        assert "sigmas" in params
+        assert "timesteps" in params

--- a/tests/diffusion/test_diffusion_config_propagation.py
+++ b/tests/diffusion/test_diffusion_config_propagation.py
@@ -173,3 +173,13 @@ def test_additional_config_roundtrip():
     additional_config = {"torchair_graph_config": {"enabled": True}}
     od = _roundtrip_diffusion_config(model="x", additional_config=additional_config)
     assert od.additional_config == additional_config
+
+
+def test_diffusion_scheduler_engine_arg_maps_to_od_config():
+    od = _roundtrip_diffusion_config(
+        model="x",
+        diffusion_scheduler="my_pkg.CustomScheduler",
+        diffusion_scheduler_kwargs={"shift": 3.0},
+    )
+    assert od.scheduler == "my_pkg.CustomScheduler"
+    assert od.scheduler_kwargs == {"shift": 3.0}

--- a/tests/e2e/features/helpers/custom_pipeline.py
+++ b/tests/e2e/features/helpers/custom_pipeline.py
@@ -27,6 +27,7 @@ from diffusers.utils import BaseOutput
 from diffusers.utils.torch_utils import randn_tensor
 from msgspec import field
 
+from tests.e2e.features.helpers.custom_scheduler import mark_scheduler_event
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.models.qwen_image import QwenImagePipeline
@@ -69,7 +70,17 @@ class FlowMatchSDEDiscreteSchedulerForTest(FlowMatchEulerDiscreteScheduler):
     """SDE version of the FlowMatchEulerDiscreteScheduler.
     The implementation is based on FlowGRPO paper (https://arxiv.org/abs/2505.05470)
     and diffusers v0.37 branch.
+
+    When ``VLLM_OMNI_CUSTOM_SCHEDULER_MARKER`` is set, construction and
+    ``step`` append marker lines so scheduler-injection tests can observe
+    this class from the pytest process. ``set_timesteps`` is inherited
+    unchanged so Qwen-Image's ``retrieve_timesteps`` still sees ``sigmas``.
     """
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        mark_scheduler_event("constructed")
+        return super().from_pretrained(*args, **kwargs)
 
     def step(
         self,
@@ -122,6 +133,7 @@ class FlowMatchSDEDiscreteSchedulerForTest(FlowMatchEulerDiscreteScheduler):
             return_logprobs (`bool`, *optional*, defaults to True):
                 Whether to return log probabilities of the previous sample.
         """
+        mark_scheduler_event("stepped")
 
         if isinstance(timestep, (int, torch.IntTensor, torch.LongTensor)):
             raise ValueError(

--- a/tests/e2e/features/helpers/custom_scheduler.py
+++ b/tests/e2e/features/helpers/custom_scheduler.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Test double for the scheduler-injection E2E tests.
+
+``FlowMatchEulerDiscreteSchedulerForTest`` subclasses the vendored
+``FlowMatchEulerDiscreteScheduler`` and records construction/timestepping/
+stepping by appending marker lines to the file named by the
+``VLLM_OMNI_CUSTOM_SCHEDULER_MARKER`` environment variable. Diffusion workers
+run in subprocesses, so in-process counters are not observable from the test
+process; the env var is inherited by child processes, making the marker file
+a cross-process observable.
+"""
+
+from __future__ import annotations
+
+import os
+
+from vllm_omni.diffusion.models.schedulers import FlowMatchEulerDiscreteScheduler
+
+MARKER_ENV_VAR = "VLLM_OMNI_CUSTOM_SCHEDULER_MARKER"
+
+
+class FlowMatchEulerDiscreteSchedulerForTest(FlowMatchEulerDiscreteScheduler):
+    """Stock flow-match Euler scheduler that proves it was used via a marker file."""
+
+    @staticmethod
+    def _mark(event: str) -> None:
+        path = os.environ.get(MARKER_ENV_VAR)
+        if path:
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(f"{event}\n")
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        cls._mark("constructed")
+        return super().from_pretrained(*args, **kwargs)
+
+    def set_timesteps(self, *args, **kwargs):
+        type(self)._mark("set_timesteps")
+        return super().set_timesteps(*args, **kwargs)
+
+    def step(self, *args, **kwargs):
+        type(self)._mark("stepped")
+        return super().step(*args, **kwargs)

--- a/tests/e2e/features/helpers/custom_scheduler.py
+++ b/tests/e2e/features/helpers/custom_scheduler.py
@@ -15,6 +15,7 @@ a cross-process observable.
 from __future__ import annotations
 
 import os
+from functools import wraps
 
 from vllm_omni.diffusion.models.schedulers import FlowMatchEulerDiscreteScheduler
 
@@ -36,10 +37,15 @@ class FlowMatchEulerDiscreteSchedulerForTest(FlowMatchEulerDiscreteScheduler):
         cls._mark("constructed")
         return super().from_pretrained(*args, **kwargs)
 
+    # Keep the parent parameter names. Qwen-Image / Flux / SD3 call
+    # inspect.signature(scheduler.set_timesteps) and reject wrappers whose
+    # signature is only (*args, **kwargs) — they look for a named ``sigmas``.
+    @wraps(FlowMatchEulerDiscreteScheduler.set_timesteps)
     def set_timesteps(self, *args, **kwargs):
         type(self)._mark("set_timesteps")
         return super().set_timesteps(*args, **kwargs)
 
+    @wraps(FlowMatchEulerDiscreteScheduler.step)
     def step(self, *args, **kwargs):
         type(self)._mark("stepped")
         return super().step(*args, **kwargs)

--- a/tests/e2e/features/helpers/custom_scheduler.py
+++ b/tests/e2e/features/helpers/custom_scheduler.py
@@ -22,19 +22,24 @@ from vllm_omni.diffusion.models.schedulers import FlowMatchEulerDiscreteSchedule
 MARKER_ENV_VAR = "VLLM_OMNI_CUSTOM_SCHEDULER_MARKER"
 
 
+def mark_scheduler_event(event: str) -> None:
+    """Append ``event`` to the marker file named by ``MARKER_ENV_VAR``.
+
+    No-op when the env var is unset, so instrumented schedulers can be reused
+    by tests that do not care about the marker file.
+    """
+    path = os.environ.get(MARKER_ENV_VAR)
+    if path:
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(f"{event}\n")
+
+
 class FlowMatchEulerDiscreteSchedulerForTest(FlowMatchEulerDiscreteScheduler):
     """Stock flow-match Euler scheduler that proves it was used via a marker file."""
 
-    @staticmethod
-    def _mark(event: str) -> None:
-        path = os.environ.get(MARKER_ENV_VAR)
-        if path:
-            with open(path, "a", encoding="utf-8") as f:
-                f.write(f"{event}\n")
-
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
-        cls._mark("constructed")
+        mark_scheduler_event("constructed")
         return super().from_pretrained(*args, **kwargs)
 
     # Keep the parent parameter names. Qwen-Image / Flux / SD3 call
@@ -42,10 +47,10 @@ class FlowMatchEulerDiscreteSchedulerForTest(FlowMatchEulerDiscreteScheduler):
     # signature is only (*args, **kwargs) — they look for a named ``sigmas``.
     @wraps(FlowMatchEulerDiscreteScheduler.set_timesteps)
     def set_timesteps(self, *args, **kwargs):
-        type(self)._mark("set_timesteps")
+        mark_scheduler_event("set_timesteps")
         return super().set_timesteps(*args, **kwargs)
 
     @wraps(FlowMatchEulerDiscreteScheduler.step)
     def step(self, *args, **kwargs):
-        type(self)._mark("stepped")
+        mark_scheduler_event("stepped")
         return super().step(*args, **kwargs)

--- a/tests/e2e/features/scheduler_injection/test_scheduler_injection.py
+++ b/tests/e2e/features/scheduler_injection/test_scheduler_injection.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""E2E tests for diffusion scheduler injection (``OmniDiffusionConfig.scheduler``).
+
+Validates that setting ``scheduler`` to a dotted scheduler class path injects
+that scheduler into the stock pipeline — no ``custom_pipeline_args`` needed —
+and that omitting it keeps the pipeline's default scheduler (the default
+construction path must stay bit-identical).
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import ExitStack
+
+import numpy as np
+import pytest
+
+from tests.e2e.features.helpers.custom_scheduler import MARKER_ENV_VAR
+from tests.helpers.mark import hardware_test
+from vllm_omni.entrypoints.async_omni import AsyncOmni
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+from vllm_omni.outputs import OmniRequestOutput
+
+INJECTED_SCHEDULER = "tests.e2e.features.helpers.custom_scheduler.FlowMatchEulerDiscreteSchedulerForTest"
+
+# Same tiny random model as the custom_pipeline e2e tests.
+MODEL = "tiny-random/Qwen-Image"
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion]
+
+
+def _sampling_params(*, seed: int = 42) -> OmniDiffusionSamplingParams:
+    return OmniDiffusionSamplingParams(
+        num_inference_steps=2,
+        guidance_scale=0.0,
+        height=256,
+        width=256,
+        seed=seed,
+    )
+
+
+async def _generate_once(
+    engine: AsyncOmni,
+    *,
+    request_id: str,
+    sampling_params: OmniDiffusionSamplingParams,
+) -> OmniRequestOutput:
+    last_output = None
+    async for output in engine.generate(
+        prompt="a beautiful sunset over the ocean with vibrant orange and purple clouds "
+        "reflecting on the calm water surface near a rocky coastline",
+        request_id=request_id,
+        sampling_params_list=[sampling_params],
+        output_modalities=["image"],
+    ):
+        last_output = output
+
+    assert last_output is not None
+    assert isinstance(last_output, OmniRequestOutput)
+    return last_output
+
+
+def _assert_valid_image_output(output: OmniRequestOutput) -> None:
+    assert output.final_output_type == "image"
+    assert output.images, "Expected at least one generated image"
+
+    image = output.images[0]
+    arr = np.asarray(image, dtype=np.float32) / 255.0
+
+    assert arr.ndim == 3 and arr.shape[2] == 3, f"Expected HWC RGB image, got shape={arr.shape}"
+    assert arr.shape[0] > 0 and arr.shape[1] > 0
+    assert 0.0 <= float(arr[0, 0, 0]) <= 1.0
+
+
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.asyncio
+async def test_scheduler_injection_uses_injected_scheduler(tmp_path, monkeypatch):
+    """``scheduler=<dotted path>`` must construct and step the injected class."""
+    marker = tmp_path / "scheduler_events.txt"
+    monkeypatch.setenv(MARKER_ENV_VAR, str(marker))
+
+    with ExitStack() as after:
+        engine = AsyncOmni(
+            model=MODEL,
+            scheduler=INJECTED_SCHEDULER,
+            enforce_eager=True,
+            max_num_seqs=1,
+        )
+        after.callback(engine.shutdown)
+
+        output = await _generate_once(
+            engine,
+            request_id=f"test_injected_{uuid.uuid4().hex[:8]}",
+            sampling_params=_sampling_params(seed=42),
+        )
+
+        _assert_valid_image_output(output)
+
+    assert marker.exists(), "injected scheduler never wrote its marker file"
+    events = marker.read_text(encoding="utf-8").splitlines()
+    assert "constructed" in events, f"injected scheduler was not constructed: {events}"
+    assert "stepped" in events, f"injected scheduler never stepped: {events}"
+
+
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.asyncio
+async def test_default_scheduler_path_without_injection(tmp_path, monkeypatch):
+    """Control run: without ``scheduler``, the pipeline default is used and the
+    injected test class is never touched."""
+    marker = tmp_path / "scheduler_events.txt"
+    monkeypatch.setenv(MARKER_ENV_VAR, str(marker))
+
+    with ExitStack() as after:
+        engine = AsyncOmni(
+            model=MODEL,
+            enforce_eager=True,
+            max_num_seqs=1,
+        )
+        after.callback(engine.shutdown)
+
+        output = await _generate_once(
+            engine,
+            request_id=f"test_default_{uuid.uuid4().hex[:8]}",
+            sampling_params=_sampling_params(seed=42),
+        )
+
+        _assert_valid_image_output(output)
+
+    assert not marker.exists(), "default path must not construct/step the injected scheduler"

--- a/tests/e2e/features/scheduler_injection/test_scheduler_injection.py
+++ b/tests/e2e/features/scheduler_injection/test_scheduler_injection.py
@@ -4,9 +4,10 @@
 """E2E tests for diffusion scheduler injection (``OmniDiffusionConfig.scheduler``).
 
 Validates that setting ``scheduler`` to a dotted scheduler class path injects
-that scheduler into the stock pipeline — no ``custom_pipeline_args`` needed —
-and that omitting it keeps the pipeline's default scheduler (the default
-construction path must stay bit-identical).
+that scheduler (here, the verl-omni SDE sampler) into the stock pipeline —
+no ``custom_pipeline_args`` needed — and that omitting it keeps the
+pipeline's default scheduler (the default construction path must stay
+bit-identical).
 """
 
 from __future__ import annotations
@@ -23,7 +24,9 @@ from vllm_omni.entrypoints.async_omni import AsyncOmni
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 from vllm_omni.outputs import OmniRequestOutput
 
-INJECTED_SCHEDULER = "tests.e2e.features.helpers.custom_scheduler.FlowMatchEulerDiscreteSchedulerForTest"
+# verl-omni-style SDE sampler (log-probs in step). Injection must use this
+# class on the stock Qwen-Image pipeline — no custom_pipeline_args.
+INJECTED_SCHEDULER = "tests.e2e.features.helpers.custom_pipeline.FlowMatchSDEDiscreteSchedulerForTest"
 
 # Same tiny random model as the custom_pipeline e2e tests.
 MODEL = "tiny-random/Qwen-Image"
@@ -77,7 +80,7 @@ def _assert_valid_image_output(output: OmniRequestOutput) -> None:
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 @pytest.mark.asyncio
 async def test_scheduler_injection_uses_injected_scheduler(tmp_path, monkeypatch):
-    """``scheduler=<dotted path>`` must construct and step the injected class."""
+    """``scheduler=<dotted path>`` must construct and step the injected SDE class."""
     marker = tmp_path / "scheduler_events.txt"
     monkeypatch.setenv(MARKER_ENV_VAR, str(marker))
 

--- a/tests/e2e/features/scheduler_injection/test_scheduler_injection.py
+++ b/tests/e2e/features/scheduler_injection/test_scheduler_injection.py
@@ -80,14 +80,14 @@ def _assert_valid_image_output(output: OmniRequestOutput) -> None:
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 @pytest.mark.asyncio
 async def test_scheduler_injection_uses_injected_scheduler(tmp_path, monkeypatch):
-    """``scheduler=<dotted path>`` must construct and step the injected SDE class."""
+    """``diffusion_scheduler=<dotted path>`` must construct and step the injected SDE class."""
     marker = tmp_path / "scheduler_events.txt"
     monkeypatch.setenv(MARKER_ENV_VAR, str(marker))
 
     with ExitStack() as after:
         engine = AsyncOmni(
             model=MODEL,
-            scheduler=INJECTED_SCHEDULER,
+            diffusion_scheduler=INJECTED_SCHEDULER,
             enforce_eager=True,
             max_num_seqs=1,
         )

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -611,6 +611,8 @@ class _DiffusionConfigProjection:
     override_transformer_cls_name: str | None = None
     worker_extension_cls: str | None = None
     custom_pipeline_args: dict[str, Any] | None = None
+    scheduler: str | None = None
+    scheduler_kwargs: dict[str, Any] | None = None
     additional_config: dict[str, Any] = field(default_factory=dict)
     enable_stage_verification: bool = True
     prompt_file_path: str | None = None

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -830,6 +830,8 @@ _STAGE_DEPLOY_ENGINE_FIELDS: tuple[str, ...] = tuple(_STAGE_DEPLOY_FIELDS)
 _DIFFUSION_BACKCOMPAT_ENGINE_FIELDS = frozenset(
     {
         "diffusion_attention_backend",
+        "diffusion_scheduler",
+        "diffusion_scheduler_kwargs",
         "kv_cache_dtype",
         "kv_cache_skip_layers",
         "kv_cache_skip_steps",

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -46,6 +46,17 @@ def normalize_omni_diffusion_kwargs(kwargs: Mapping[str, Any]) -> dict[str, Any]
     """Normalize legacy diffusion kwargs before config construction."""
     normalized = dict(kwargs)
 
+    # OmniEngineArgs / deploy YAML use diffusion_scheduler so users can
+    # distinguish it from stage scheduler_cls (request batching).
+    if normalized.get("diffusion_scheduler") is not None:
+        normalized["scheduler"] = normalized.pop("diffusion_scheduler")
+    else:
+        normalized.pop("diffusion_scheduler", None)
+    if normalized.get("diffusion_scheduler_kwargs") is not None:
+        normalized["scheduler_kwargs"] = normalized.pop("diffusion_scheduler_kwargs")
+    else:
+        normalized.pop("diffusion_scheduler_kwargs", None)
+
     # Backwards-compatibility: older callers may use a diffusion-specific
     # "static_lora_scale" kwarg. Normalize it to the canonical "lora_scale".
     if "static_lora_scale" in normalized:
@@ -758,9 +769,11 @@ class OmniDiffusionConfig:
     # Custom pipeline arguments for custom pipelines
     custom_pipeline_args: dict[str, Any] | None = None
 
-    # Scheduler injection: registry name (see vllm_omni.diffusion.models.schedulers)
-    # or dotted class path of a scheduler class to use instead of the pipeline's
-    # default scheduler. Constructed via cls.from_pretrained(model, subfolder="scheduler").
+    # Diffusion sampling-scheduler injection (not the request scheduler).
+    # Registry name (see vllm_omni.diffusion.models.schedulers) or dotted
+    # class path. Constructed via build_pipeline_scheduler / from_pretrained.
+    # Set from OmniEngineArgs.diffusion_scheduler. Pipelines that do not
+    # consume this field fail at load (ensure_scheduler_consumed).
     scheduler: str | None = None
     # Extra kwargs forwarded to the injected scheduler's from_pretrained().
     scheduler_kwargs: dict[str, Any] | None = None

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -758,6 +758,13 @@ class OmniDiffusionConfig:
     # Custom pipeline arguments for custom pipelines
     custom_pipeline_args: dict[str, Any] | None = None
 
+    # Scheduler injection: registry name (see vllm_omni.diffusion.models.schedulers)
+    # or dotted class path of a scheduler class to use instead of the pipeline's
+    # default scheduler. Constructed via cls.from_pretrained(model, subfolder="scheduler").
+    scheduler: str | None = None
+    # Extra kwargs forwarded to the injected scheduler's from_pretrained().
+    scheduler_kwargs: dict[str, Any] | None = None
+
     # Diffusion model loading format
     # "default", "custom_pipeline", "dummy", "diffusers" (HF diffusers adapter)
     diffusion_load_format: str = "default"

--- a/vllm_omni/diffusion/models/boogu_image/pipeline_boogu_image.py
+++ b/vllm_omni/diffusion/models/boogu_image/pipeline_boogu_image.py
@@ -49,6 +49,7 @@ from vllm_omni.diffusion.models.boogu_image.scheduling_flow_match_euler_discrete
 )
 from vllm_omni.diffusion.models.interface import SupportImageInput, SupportsComponentDiscovery
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
@@ -235,8 +236,12 @@ class BooguImagePipeline(nn.Module, ProgressBarMixin, SupportsComponentDiscovery
         boogu_subfolders = ["scheduler", "vae", "mllm", "processor"]
         prefetch_subfolders(model, boogu_subfolders, local_files_only=local_files_only)
 
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-            model, subfolder="scheduler", local_files_only=local_files_only
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
+                model, subfolder="scheduler", local_files_only=local_files_only
+            ),
+            local_files_only=local_files_only,
         )
 
         mllm = from_pretrained_with_prefetch(

--- a/vllm_omni/diffusion/models/dmd2/mixin.py
+++ b/vllm_omni/diffusion/models/dmd2/mixin.py
@@ -8,7 +8,7 @@ import os
 
 from vllm_omni.diffusion.data import DiffusionOutput
 from vllm_omni.diffusion.models.dmd2.config import DMD2Config
-from vllm_omni.diffusion.models.schedulers import DMD2EulerScheduler
+from vllm_omni.diffusion.models.schedulers import DMD2EulerScheduler, is_injected_scheduler
 from vllm_omni.diffusion.models.utils import _load_json
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 
@@ -28,12 +28,19 @@ class DMD2PipelineMixin:
 
         self.dmd2_config = DMD2Config.from_model_index(model_index)
 
-        self.scheduler = DMD2EulerScheduler(
-            num_train_timesteps=1000,
-            shift=1.0,
-            dmd2_timesteps=self.dmd2_config.resolve_timesteps(),
-            stochastic_sampling=(self.dmd2_config.solver == "sde"),
-        )
+        if is_injected_scheduler(self.od_config):
+            logger.warning(
+                "Skipping DMD2EulerScheduler overwrite: an injected scheduler "
+                "(od_config.scheduler=%r) is active and is left untouched.",
+                self.od_config.scheduler,
+            )
+        else:
+            self.scheduler = DMD2EulerScheduler(
+                num_train_timesteps=1000,
+                shift=1.0,
+                dmd2_timesteps=self.dmd2_config.resolve_timesteps(),
+                stochastic_sampling=(self.dmd2_config.solver == "sde"),
+            )
 
     def _sanitize_dmd2_request(self, req) -> None:
         """Sanitize CFG-related fields in-place. Works with both OmniDiffusionRequest and DiffusionRequestBatch."""

--- a/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
+++ b/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
@@ -24,6 +24,7 @@ from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineL
 from vllm_omni.diffusion.models.ernie_image.ernie_image_transformer import ErnieImageTransformer2DModel
 from vllm_omni.diffusion.models.interface import SupportImageInput
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
@@ -97,9 +98,13 @@ class ErnieImagePipeline(
         local_files_only = os.path.exists(model)
         logger.info("Local files only: %s", local_files_only)
 
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-            model,
-            subfolder="scheduler",
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
+                model,
+                subfolder="scheduler",
+                local_files_only=local_files_only,
+            ),
             local_files_only=local_files_only,
         )
 

--- a/vllm_omni/diffusion/models/flux/pipeline_flux.py
+++ b/vllm_omni/diffusion/models/flux/pipeline_flux.py
@@ -29,6 +29,7 @@ from vllm_omni.diffusion.models.dmd2 import DMD2PipelineMixin
 from vllm_omni.diffusion.models.flux import FluxTransformer2DModel
 from vllm_omni.diffusion.models.flux.flux_pipeline_mixin import FluxPipelineMixin
 from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.models.t5_encoder import T5EncoderModel
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
@@ -106,8 +107,11 @@ class FluxPipeline(
         # Check if model is a local path
         local_files_only = os.path.exists(model)
 
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-            model, subfolder="scheduler", local_files_only=local_files_only
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
+                model, subfolder="scheduler", local_files_only=local_files_only
+            ),
         )
         self.text_encoder = CLIPTextModel.from_pretrained(
             model, subfolder="text_encoder", local_files_only=local_files_only

--- a/vllm_omni/diffusion/models/flux/pipeline_flux.py
+++ b/vllm_omni/diffusion/models/flux/pipeline_flux.py
@@ -112,6 +112,7 @@ class FluxPipeline(
             default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
                 model, subfolder="scheduler", local_files_only=local_files_only
             ),
+            local_files_only=local_files_only,
         )
         self.text_encoder = CLIPTextModel.from_pretrained(
             model, subfolder="text_encoder", local_files_only=local_files_only

--- a/vllm_omni/diffusion/models/flux/pipeline_flux_kontext.py
+++ b/vllm_omni/diffusion/models/flux/pipeline_flux_kontext.py
@@ -33,6 +33,7 @@ from vllm_omni.diffusion.models.flux import (
 from vllm_omni.diffusion.models.flux.flux_pipeline_mixin import FluxPipelineMixin
 from vllm_omni.diffusion.models.interface import SupportImageInput, SupportsComponentDiscovery
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
@@ -109,9 +110,13 @@ class FluxKontextPipeline(
         model = od_config.model
         local_files_only = os.path.exists(model)
 
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-            model,
-            subfolder="scheduler",
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
+                model,
+                subfolder="scheduler",
+                local_files_only=local_files_only,
+            ),
             local_files_only=local_files_only,
         )
 

--- a/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
+++ b/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
@@ -34,6 +34,7 @@ from vllm_omni.diffusion.models.flux2 import Flux2Transformer2DModel
 from vllm_omni.diffusion.models.interface import SupportImageInput, SupportsComponentDiscovery
 from vllm_omni.diffusion.models.mistral_encoder import MistralEncoderModel
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
@@ -381,8 +382,12 @@ class Flux2Pipeline(
         # Check if model is a local path
         local_files_only = os.path.exists(model)
 
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-            model, subfolder="scheduler", local_files_only=local_files_only
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
+                model, subfolder="scheduler", local_files_only=local_files_only
+            ),
+            local_files_only=local_files_only,
         )
         self.weights_sources.append(
             DiffusersPipelineLoader.ComponentSource(

--- a/vllm_omni/diffusion/models/glm_image/pipeline_glm_image.py
+++ b/vllm_omni/diffusion/models/glm_image/pipeline_glm_image.py
@@ -47,6 +47,7 @@ from vllm_omni.diffusion.models.glm_image.glm_image_transformer import (
     GlmImageTransformer2DModel,
 )
 from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
@@ -277,8 +278,12 @@ class GlmImagePipeline(nn.Module, DiffusionPipelineProfilerMixin, SupportsCompon
             model_path = download_weights_from_hf_specific(model, od_config.revision, ["*"])
 
         # Load scheduler
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-            model_path, subfolder="scheduler", local_files_only=True
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
+                model_path, subfolder="scheduler", local_files_only=True
+            ),
+            local_files_only=True,
         )
 
         # Load text encoder (T5 for glyph embeddings)

--- a/vllm_omni/diffusion/models/hidream_image/pipeline_hidream_image.py
+++ b/vllm_omni/diffusion/models/hidream_image/pipeline_hidream_image.py
@@ -34,6 +34,7 @@ from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineL
 from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_prefetch, prefetch_subfolders
 from vllm_omni.diffusion.models.hidream_image import HiDreamImageTransformer2DModel
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
@@ -193,8 +194,12 @@ class HiDreamImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfile
         ]
         prefetch_subfolders(model, hidream_subfolders, local_files_only=local_files_only)
 
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-            model, subfolder="scheduler", local_files_only=local_files_only
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
+                model, subfolder="scheduler", local_files_only=local_files_only
+            ),
+            local_files_only=local_files_only,
         )
         self.vae = from_pretrained_with_prefetch(
             AutoencoderKL.from_pretrained,

--- a/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5.py
@@ -29,6 +29,7 @@ from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_p
 from vllm_omni.diffusion.models.hunyuan_video.hunyuan_video_15_transformer import HunyuanVideo15Transformer3DModel
 from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.models.t5_encoder import T5EncoderModel
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
@@ -140,8 +141,12 @@ class HunyuanVideo15Pipeline(
             torch_dtype=torch.float32,
         ).to(self.device)
 
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-            model, subfolder="scheduler", local_files_only=local_files_only
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
+                model, subfolder="scheduler", local_files_only=local_files_only
+            ),
+            local_files_only=local_files_only,
         )
 
         # Override the scheduler's shift if flow_shift is explicitly provided.

--- a/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5_i2v.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5_i2v.py
@@ -42,6 +42,7 @@ from vllm_omni.diffusion.models.hunyuan_video.pipeline_hunyuan_video_1_5 import 
 )
 from vllm_omni.diffusion.models.interface import SupportImageInput, SupportsComponentDiscovery
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.models.t5_encoder import T5EncoderModel
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
@@ -186,8 +187,12 @@ class HunyuanVideo15I2VPipeline(
             torch_dtype=torch.float32,
         ).to(self.device)
 
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-            model, subfolder="scheduler", local_files_only=local_files_only
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
+                model, subfolder="scheduler", local_files_only=local_files_only
+            ),
+            local_files_only=local_files_only,
         )
 
         # Override the scheduler's shift if flow_shift is explicitly provided.

--- a/vllm_omni/diffusion/models/krea2/pipeline_krea2.py
+++ b/vllm_omni/diffusion/models/krea2/pipeline_krea2.py
@@ -41,6 +41,7 @@ from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_p
 from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
 from vllm_omni.diffusion.models.krea2.krea2_transformer import Krea2Transformer2DModel
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
@@ -173,8 +174,12 @@ class Krea2Pipeline(nn.Module, DiffusionPipelineProfilerMixin, ProgressBarMixin,
         # See ``hub_prefetch.py`` for the transformers v5 subfolder race.
         prefetch_subfolders(model, subfolders, local_files_only=local_files_only)
 
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-            model, subfolder="scheduler", local_files_only=local_files_only
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
+                model, subfolder="scheduler", local_files_only=local_files_only
+            ),
+            local_files_only=local_files_only,
         )
 
         self.text_encoder = from_pretrained_with_prefetch(

--- a/vllm_omni/diffusion/models/lingbot_video/pipeline_lingbot_video.py
+++ b/vllm_omni/diffusion/models/lingbot_video/pipeline_lingbot_video.py
@@ -35,7 +35,7 @@ from vllm_omni.diffusion.models.lingbot_video.request_utils import (
     normalize_lingbot_request,
 )
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
-from vllm_omni.diffusion.models.schedulers import FlowUniPCMultistepScheduler
+from vllm_omni.diffusion.models.schedulers import FlowUniPCMultistepScheduler, build_pipeline_scheduler
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 from vllm_omni.errors import OmniClientError
@@ -374,10 +374,15 @@ class LingBotVideoPipeline(
             torch_dtype=vae_dtype,
             local_files_only=local_files_only,
         ).to(self.device)
-        self.scheduler = FlowUniPCMultistepScheduler.from_pretrained(
-            model,
-            subfolder=scheduler_subfolder,
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: FlowUniPCMultistepScheduler.from_pretrained(
+                model,
+                subfolder=scheduler_subfolder,
+                local_files_only=local_files_only,
+            ),
             local_files_only=local_files_only,
+            subfolder=scheduler_subfolder,
         )
         self.set_progress_bar_config(disable=bool(model_config.get("quiet_progress", True)))
         self.default_negative_prompt = DEFAULT_NEGATIVE_PROMPT

--- a/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image.py
+++ b/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image.py
@@ -30,6 +30,7 @@ from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineL
 from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_prefetch, prefetch_subfolders
 from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
 from vllm_omni.diffusion.models.longcat_image.longcat_image_transformer import LongCatImageTransformer2DModel
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 from vllm_omni.model_executor.model_loader.weight_utils import (
@@ -236,8 +237,12 @@ class LongCatImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfile
         longcat_subfolders = ["scheduler", "text_encoder", "tokenizer", "vae"]
         prefetch_subfolders(model, longcat_subfolders, local_files_only=local_files_only)
 
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-            model, subfolder="scheduler", local_files_only=local_files_only
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
+                model, subfolder="scheduler", local_files_only=local_files_only
+            ),
+            local_files_only=local_files_only,
         )
 
         self.text_encoder = from_pretrained_with_prefetch(

--- a/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image_edit.py
+++ b/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image_edit.py
@@ -35,6 +35,7 @@ from vllm_omni.diffusion.models.longcat_image.longcat_image_transformer import (
     LongCatImageTransformer2DModel,
 )
 from vllm_omni.diffusion.models.longcat_image.pipeline_longcat_image import calculate_shift
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
@@ -255,8 +256,12 @@ class LongCatImageEditPipeline(
         longcat_subfolders = ["scheduler", "text_encoder", "text_processor", "tokenizer", "vae"]
         prefetch_subfolders(model, longcat_subfolders, local_files_only=local_files_only)
 
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-            model, subfolder="scheduler", local_files_only=local_files_only
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
+                model, subfolder="scheduler", local_files_only=local_files_only
+            ),
+            local_files_only=local_files_only,
         )
         self.text_encoder = from_pretrained_with_prefetch(
             Qwen2_5_VLForConditionalGeneration.from_pretrained,

--- a/vllm_omni/diffusion/models/longcat_video/pipeline_longcat_video_avatar.py
+++ b/vllm_omni/diffusion/models/longcat_video/pipeline_longcat_video_avatar.py
@@ -36,6 +36,7 @@ from vllm_omni.diffusion.models.longcat_video.longcat_video_avatar_transformer i
     create_full_precision_avatar_dit,
     create_quantized_avatar_dit,
 )
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.inputs.data import OmniTextPrompt
 from vllm_omni.platforms import current_omni_platform
@@ -578,7 +579,12 @@ class LongCatVideoAvatarPipeline(nn.Module, SupportImageInput, SupportAudioInput
         dtype = getattr(self.od_config, "dtype", torch.bfloat16)
         base_dir = self._base_model_dir()
         self.tokenizer = AutoTokenizer.from_pretrained(str(base_dir), subfolder="tokenizer")
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(str(self.model_dir), subfolder="scheduler")
+        self.scheduler = build_pipeline_scheduler(
+            self.od_config,
+            default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
+                str(self.model_dir), subfolder="scheduler"
+            ),
+        )
 
         # vLLM initializes native pipelines under the target device context.
         # Build LongCat's large components on CPU first by default to avoid

--- a/vllm_omni/diffusion/models/ltx2/ltx2_components.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_components.py
@@ -30,6 +30,7 @@ from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_ltx2 import Dis
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_prefetch, prefetch_subfolders
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.offloader.module_collector import ModuleDiscovery
 
 if TYPE_CHECKING:
@@ -670,11 +671,14 @@ def initialize_pipeline_components(pipeline: Any, od_config: Any) -> None:
     quant_config = getattr(od_config, "quantization_config", None)
     pipeline.transformer = create_transformer_from_config(transformer_config, quant_config=quant_config)
     _place_aux_components(pipeline)
-    pipeline.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-        model,
-        subfolder="scheduler",
-        local_files_only=local_files_only,
-        revision=revision,
+    pipeline.scheduler = build_pipeline_scheduler(
+        od_config,
+        default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
+            model,
+            subfolder="scheduler",
+            local_files_only=local_files_only,
+            revision=revision,
+        ),
     )
     if profile.scheduler_use_dynamic_shifting:
         pipeline.scheduler = FlowMatchEulerDiscreteScheduler.from_config(

--- a/vllm_omni/diffusion/models/ltx2/ltx2_components.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_components.py
@@ -30,7 +30,7 @@ from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_ltx2 import Dis
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_prefetch, prefetch_subfolders
-from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler, is_injected_scheduler
 from vllm_omni.diffusion.offloader.module_collector import ModuleDiscovery
 
 if TYPE_CHECKING:
@@ -679,13 +679,22 @@ def initialize_pipeline_components(pipeline: Any, od_config: Any) -> None:
             local_files_only=local_files_only,
             revision=revision,
         ),
+        local_files_only=local_files_only,
+        revision=revision,
     )
     if profile.scheduler_use_dynamic_shifting:
-        pipeline.scheduler = FlowMatchEulerDiscreteScheduler.from_config(
-            pipeline.scheduler.config,
-            use_dynamic_shifting=True,
-            shift_terminal=profile.scheduler_shift_terminal,
-        )
+        if is_injected_scheduler(od_config):
+            logger.warning(
+                "Skipping LTx2 dynamic-shifting overwrite: an injected scheduler "
+                "(od_config.scheduler=%r) is active and is left untouched.",
+                od_config.scheduler,
+            )
+        else:
+            pipeline.scheduler = FlowMatchEulerDiscreteScheduler.from_config(
+                pipeline.scheduler.config,
+                use_dynamic_shifting=True,
+                shift_terminal=profile.scheduler_shift_terminal,
+            )
     validate_ltx_checkpoint(
         pipeline.scheduler.config,
         expected_kind=resolve_ltx_checkpoint_kind(pipeline.pipeline_kind),

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -37,6 +37,7 @@ from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
     QwenImageTransformer2DModel,
 )
 from vllm_omni.diffusion.models.qwen_image.rope_utils import txt_seq_lens_from_embeds
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.utils.prompt_utils import (
     validate_prompt_sequence_lengths,
@@ -310,8 +311,11 @@ class QwenImagePipeline(
             qwen_subfolders,
         )
 
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-            model, subfolder="scheduler", local_files_only=local_files_only
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
+                model, subfolder="scheduler", local_files_only=local_files_only
+            ),
         )
         # ``from_pretrained_with_prefetch`` re-prefetches and retries on a
         # half-written cache (missing-shard ``OSError`` and the default

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -316,6 +316,7 @@ class QwenImagePipeline(
             default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
                 model, subfolder="scheduler", local_files_only=local_files_only
             ),
+            local_files_only=local_files_only,
         )
         # ``from_pretrained_with_prefetch`` re-prefetches and retries on a
         # half-written cache (missing-shard ``OSError`` and the default

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
@@ -36,6 +36,7 @@ from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image import calculate_
 from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
     QwenImageTransformer2DModel,
 )
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.prompt_utils import (
@@ -259,8 +260,12 @@ class QwenImageEditPipeline(
             local_files_only=local_files_only,
         )
 
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-            model, subfolder="scheduler", local_files_only=local_files_only
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
+                model, subfolder="scheduler", local_files_only=local_files_only
+            ),
+            local_files_only=local_files_only,
         )
         # ``from_pretrained_with_prefetch`` re-prefetches and retries on a
         # half-written cache (missing-shard ``OSError`` and the default

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
@@ -41,6 +41,7 @@ from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
     QwenImageTransformer2DModel,
 )
 from vllm_omni.diffusion.models.qwen_image.rope_utils import txt_seq_lens_from_embeds
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.prompt_utils import (
@@ -226,8 +227,12 @@ class QwenImageEditPlusPipeline(
             qwen_subfolders,
         )
 
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-            model, subfolder="scheduler", local_files_only=local_files_only
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
+                model, subfolder="scheduler", local_files_only=local_files_only
+            ),
+            local_files_only=local_files_only,
         )
         # ``from_pretrained_with_prefetch`` re-prefetches and retries on a
         # half-written cache (missing-shard ``OSError`` and the default

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_layered.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_layered.py
@@ -36,6 +36,7 @@ from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
     QwenImageTransformer2DModel,
 )
 from vllm_omni.diffusion.models.qwen_image.rope_utils import txt_seq_lens_from_embeds
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.prompt_utils import (
@@ -233,8 +234,12 @@ class QwenImageLayeredPipeline(
         )
 
         # modules keep same as transformers & diffusers
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-            model, subfolder="scheduler", local_files_only=local_files_only
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
+                model, subfolder="scheduler", local_files_only=local_files_only
+            ),
+            local_files_only=local_files_only,
         )
         # ``from_pretrained_with_prefetch`` re-prefetches and retries on a
         # half-written cache (missing-shard ``OSError`` and the default

--- a/vllm_omni/diffusion/models/schedulers/__init__.py
+++ b/vllm_omni/diffusion/models/schedulers/__init__.py
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from vllm_omni.diffusion.models.schedulers.registry import (
+    build_pipeline_scheduler,
+    register_scheduler,
+    resolve_scheduler_cls,
+)
 from vllm_omni.diffusion.models.schedulers.scheduling_dmd2_euler import DMD2EulerScheduler
 from vllm_omni.diffusion.models.schedulers.scheduling_flow_match_euler_discrete import (
     FlowMatchEulerDiscreteScheduler,
@@ -13,4 +18,7 @@ __all__ = [
     "DMD2EulerScheduler",
     "FlowMatchEulerDiscreteScheduler",
     "FlowUniPCMultistepScheduler",
+    "build_pipeline_scheduler",
+    "register_scheduler",
+    "resolve_scheduler_cls",
 ]

--- a/vllm_omni/diffusion/models/schedulers/__init__.py
+++ b/vllm_omni/diffusion/models/schedulers/__init__.py
@@ -3,6 +3,8 @@
 
 from vllm_omni.diffusion.models.schedulers.registry import (
     build_pipeline_scheduler,
+    ensure_scheduler_consumed,
+    is_injected_scheduler,
     register_scheduler,
     resolve_scheduler_cls,
 )
@@ -19,6 +21,8 @@ __all__ = [
     "FlowMatchEulerDiscreteScheduler",
     "FlowUniPCMultistepScheduler",
     "build_pipeline_scheduler",
+    "ensure_scheduler_consumed",
+    "is_injected_scheduler",
     "register_scheduler",
     "resolve_scheduler_cls",
 ]

--- a/vllm_omni/diffusion/models/schedulers/registry.py
+++ b/vllm_omni/diffusion/models/schedulers/registry.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Scheduler registry and construction seam for diffusion pipelines.
+
+This module lets external packages (e.g. RL frameworks such as verl-omni)
+inject their own scheduler classes into vllm-omni's diffusion pipelines
+without editing any denoise loop. A scheduler class can be registered under
+a name via :func:`register_scheduler` or advertised through the
+``vllm_omni.schedulers`` entry-point group, and is then selected engine-wide
+via ``OmniDiffusionConfig.scheduler`` (registry name or dotted class path)
+with constructor overrides from ``OmniDiffusionConfig.scheduler_kwargs``.
+
+Injected scheduler classes must satisfy the same contract the stock
+pipelines already rely on (diffusers-style):
+
+* ``step(noise_pred, t, latents, return_dict=False, generator=None)`` —
+  called only through ``CFGParallelMixin.scheduler_step[_maybe_with_cfg]``;
+  with ``return_dict=False`` it must return a tuple whose first element is
+  the stepped latents. ``generator`` is only passed when not ``None``.
+* ``set_timesteps(num_inference_steps, device=...)`` and expose
+  ``.timesteps`` afterwards.
+* ``set_begin_index(...)`` for pipeline-parallel timestep slicing.
+* a ``.config`` attribute (diffusers ``ConfigMixin``-style) carrying at
+  least ``num_train_timesteps``.
+* deepcopy-safe: step-wise execution deep-copies the scheduler per request.
+
+Injected classes are constructed with
+``cls.from_pretrained(od_config.model, subfolder="scheduler",
+local_files_only=od_config.local_files_only, **scheduler_kwargs)``,
+matching how the stock schedulers are loaded. When no scheduler is
+configured, :func:`build_pipeline_scheduler` falls through to the calling
+pipeline's own ``default_builder`` so the default path stays bit-identical.
+
+This module must stay importable without torch/diffusers and must not
+import ``OmniDiffusionConfig`` at runtime (duck typing only) to avoid
+import cycles.
+"""
+
+import importlib
+import importlib.metadata
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from vllm_omni.diffusion.data import OmniDiffusionConfig
+
+SCHEDULER_ENTRY_POINT_GROUP = "vllm_omni.schedulers"
+
+_SCHEDULER_REGISTRY: dict[str, type] = {}
+_entry_points_loaded = False
+
+
+def register_scheduler(name: str, cls: type | None = None):
+    """Register a scheduler class under ``name``.
+
+    Usable as a direct call (``register_scheduler("flow_match_sde", MyScheduler)``)
+    or as a decorator (``@register_scheduler("flow_match_sde")``).
+    """
+
+    def _do(c: type) -> type:
+        _SCHEDULER_REGISTRY[name] = c
+        return c
+
+    return _do(cls) if cls is not None else _do
+
+
+def _load_entry_points() -> None:
+    global _entry_points_loaded
+    if _entry_points_loaded:
+        return
+    for ep in importlib.metadata.entry_points(group=SCHEDULER_ENTRY_POINT_GROUP):
+        _SCHEDULER_REGISTRY.setdefault(ep.name, ep.load())
+    _entry_points_loaded = True
+
+
+def resolve_scheduler_cls(ref: str | type | None) -> type | None:
+    """Resolve a scheduler reference to a class.
+
+    ``None`` and class objects pass through unchanged. Strings resolve
+    against the registry (including lazily loaded ``vllm_omni.schedulers``
+    entry points) first, then fall back to a dotted import path. A bare
+    unknown name raises ``KeyError`` listing the registered names.
+    """
+    if ref is None or isinstance(ref, type):
+        return ref
+    _load_entry_points()
+    if ref in _SCHEDULER_REGISTRY:
+        return _SCHEDULER_REGISTRY[ref]
+    module, _, attr = ref.rpartition(".")  # dotted-path fallback
+    if not module:
+        raise KeyError(f"Unknown scheduler '{ref}'. Registered: {sorted(_SCHEDULER_REGISTRY)}")
+    return getattr(importlib.import_module(module), attr)
+
+
+def build_pipeline_scheduler(
+    od_config: "OmniDiffusionConfig",
+    scheduler_cls: str | type | None = None,
+    scheduler_kwargs: dict[str, Any] | None = None,
+    default_builder: Callable[[], Any] | None = None,
+):
+    """Single construction seam replacing hardcoded scheduler ``from_pretrained`` sites.
+
+    Resolution order: explicit ``scheduler_cls`` arg > ``od_config.scheduler``
+    > pipeline default. When no scheduler is configured, ``default_builder``
+    is invoked and its return value is passed through untouched, preserving
+    the pipeline's existing construction bit-for-bit.
+    """
+    cls = resolve_scheduler_cls(scheduler_cls) or resolve_scheduler_cls(getattr(od_config, "scheduler", None))
+    if cls is None:
+        assert default_builder is not None
+        return default_builder()
+    kwargs = dict(getattr(od_config, "scheduler_kwargs", None) or {})
+    kwargs.update(scheduler_kwargs or {})
+    return cls.from_pretrained(
+        od_config.model,
+        subfolder="scheduler",
+        local_files_only=getattr(od_config, "local_files_only", False),
+        **kwargs,
+    )

--- a/vllm_omni/diffusion/models/schedulers/registry.py
+++ b/vllm_omni/diffusion/models/schedulers/registry.py
@@ -19,7 +19,12 @@ pipelines already rely on (diffusers-style):
   with ``return_dict=False`` it must return a tuple whose first element is
   the stepped latents. ``generator`` is only passed when not ``None``.
 * ``set_timesteps(num_inference_steps, device=...)`` and expose
-  ``.timesteps`` afterwards.
+  ``.timesteps`` afterwards. Named parameters must be preserved:
+  Qwen-Image / Flux / SD3 (and other ``retrieve_timesteps`` pipelines)
+  inspect ``scheduler.set_timesteps`` for ``sigmas`` / ``timesteps``.
+  Overriding with ``def set_timesteps(self, *args, **kwargs)`` hides
+  those names and fails dummy warmup with "does not support custom
+  sigmas schedules".
 * ``set_begin_index(...)`` for pipeline-parallel timestep slicing.
 * a ``.config`` attribute (diffusers ``ConfigMixin``-style) carrying at
   least ``num_train_timesteps``.

--- a/vllm_omni/diffusion/models/schedulers/registry.py
+++ b/vllm_omni/diffusion/models/schedulers/registry.py
@@ -31,11 +31,20 @@ pipelines already rely on (diffusers-style):
 * deepcopy-safe: step-wise execution deep-copies the scheduler per request.
 
 Injected classes are constructed with
-``cls.from_pretrained(od_config.model, subfolder="scheduler",
-local_files_only=od_config.local_files_only, **scheduler_kwargs)``,
-matching how the stock schedulers are loaded. When no scheduler is
-configured, :func:`build_pipeline_scheduler` falls through to the calling
-pipeline's own ``default_builder`` so the default path stays bit-identical.
+``cls.from_pretrained(od_config.model, subfolder=...,
+local_files_only=..., revision=..., **scheduler_kwargs)``.
+``local_files_only`` and ``revision`` are the values the calling pipeline
+already resolved (typically ``os.path.exists(model)`` and the pipeline
+revision). They are not fields on ``OmniDiffusionConfig``. When omitted,
+``local_files_only`` defaults to ``os.path.exists(od_config.model)`` and
+``revision`` is not passed. When no scheduler is configured,
+:func:`build_pipeline_scheduler` falls through to the calling pipeline's
+own ``default_builder`` so the default path stays bit-identical.
+
+Pipelines that construct a scheduler without this factory must fail when
+``od_config.scheduler`` is set. Call :func:`ensure_scheduler_consumed`
+after pipeline construction so an accepted config field is never silently
+ignored.
 
 This module must stay importable without torch/diffusers and must not
 import ``OmniDiffusionConfig`` at runtime (duck typing only) to avoid
@@ -44,6 +53,7 @@ import cycles.
 
 import importlib
 import importlib.metadata
+import os
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
@@ -54,6 +64,7 @@ SCHEDULER_ENTRY_POINT_GROUP = "vllm_omni.schedulers"
 
 _SCHEDULER_REGISTRY: dict[str, type] = {}
 _entry_points_loaded = False
+_consumed_scheduler_config_ids: set[int] = set()
 
 
 def register_scheduler(name: str, cls: type | None = None):
@@ -98,11 +109,40 @@ def resolve_scheduler_cls(ref: str | type | None) -> type | None:
     return getattr(importlib.import_module(module), attr)
 
 
+def is_injected_scheduler(od_config: "OmniDiffusionConfig") -> bool:
+    """True when ``od_config.scheduler`` selects a class other than the pipeline default."""
+    return getattr(od_config, "scheduler", None) is not None
+
+
+def mark_scheduler_consumed(od_config: "OmniDiffusionConfig") -> None:
+    """Record that this config's ``scheduler`` field was handled by a construction site."""
+    _consumed_scheduler_config_ids.add(id(od_config))
+
+
+def ensure_scheduler_consumed(od_config: "OmniDiffusionConfig", pipeline: Any) -> None:
+    """Fail if ``od_config.scheduler`` was set but no construction site consumed it."""
+    if not is_injected_scheduler(od_config):
+        return
+    if id(od_config) in _consumed_scheduler_config_ids:
+        return
+    pipeline_name = type(pipeline).__name__ if pipeline is not None else "pipeline"
+    raise ValueError(
+        f"{pipeline_name} does not consume OmniDiffusionConfig.scheduler="
+        f"{od_config.scheduler!r}. Wire the construction site through "
+        "build_pipeline_scheduler or reject the option explicitly. "
+        "See docs/features/scheduler_injection.md."
+    )
+
+
 def build_pipeline_scheduler(
     od_config: "OmniDiffusionConfig",
     scheduler_cls: str | type | None = None,
     scheduler_kwargs: dict[str, Any] | None = None,
     default_builder: Callable[[], Any] | None = None,
+    *,
+    local_files_only: bool | None = None,
+    revision: str | None = None,
+    subfolder: str = "scheduler",
 ):
     """Single construction seam replacing hardcoded scheduler ``from_pretrained`` sites.
 
@@ -110,16 +150,29 @@ def build_pipeline_scheduler(
     > pipeline default. When no scheduler is configured, ``default_builder``
     is invoked and its return value is passed through untouched, preserving
     the pipeline's existing construction bit-for-bit.
+
+    ``local_files_only`` and ``revision`` must be the pipeline-resolved values
+    (not ``getattr(od_config, "local_files_only")`` — that field does not exist
+    on ``OmniDiffusionConfig``).
     """
+    mark_scheduler_consumed(od_config)
     cls = resolve_scheduler_cls(scheduler_cls) or resolve_scheduler_cls(getattr(od_config, "scheduler", None))
     if cls is None:
-        assert default_builder is not None
+        if default_builder is None:
+            raise ValueError(
+                "No scheduler configured and no default_builder provided. "
+                "Set OmniDiffusionConfig.scheduler or pass default_builder."
+            )
         return default_builder()
     kwargs = dict(getattr(od_config, "scheduler_kwargs", None) or {})
     kwargs.update(scheduler_kwargs or {})
+    if local_files_only is None:
+        local_files_only = os.path.exists(od_config.model)
+    if revision is not None:
+        kwargs.setdefault("revision", revision)
     return cls.from_pretrained(
         od_config.model,
-        subfolder="scheduler",
-        local_files_only=getattr(od_config, "local_files_only", False),
+        subfolder=subfolder,
+        local_files_only=local_files_only,
         **kwargs,
     )

--- a/vllm_omni/diffusion/models/sd3/pipeline_sd3.py
+++ b/vllm_omni/diffusion/models/sd3/pipeline_sd3.py
@@ -22,6 +22,7 @@ from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_prefetch, prefetch_subfolders
 from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.models.sd3.sd3_transformer import (
     SD3Transformer2DModel,
 )
@@ -197,8 +198,11 @@ class StableDiffusion3Pipeline(nn.Module, CFGParallelMixin, DiffusionPipelinePro
         # don't carry weights and therefore don't take ``torch_dtype``.
         dtype = od_config.dtype
 
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-            model, subfolder="scheduler", local_files_only=local_files_only
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
+                model, subfolder="scheduler", local_files_only=local_files_only
+            ),
         )
         self.tokenizer = CLIPTokenizer.from_pretrained(model, subfolder="tokenizer", local_files_only=local_files_only)
         self.tokenizer_2 = CLIPTokenizer.from_pretrained(

--- a/vllm_omni/diffusion/models/sd3/pipeline_sd3.py
+++ b/vllm_omni/diffusion/models/sd3/pipeline_sd3.py
@@ -203,6 +203,7 @@ class StableDiffusion3Pipeline(nn.Module, CFGParallelMixin, DiffusionPipelinePro
             default_builder=lambda: FlowMatchEulerDiscreteScheduler.from_pretrained(
                 model, subfolder="scheduler", local_files_only=local_files_only
             ),
+            local_files_only=local_files_only,
         )
         self.tokenizer = CLIPTokenizer.from_pretrained(model, subfolder="tokenizer", local_files_only=local_files_only)
         self.tokenizer_2 = CLIPTokenizer.from_pretrained(

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
@@ -31,7 +31,7 @@ from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_p
 from vllm_omni.diffusion.models.dmd2 import DMD2PipelineMixin
 from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin, _is_rank_zero
-from vllm_omni.diffusion.models.schedulers import FlowUniPCMultistepScheduler
+from vllm_omni.diffusion.models.schedulers import FlowUniPCMultistepScheduler, build_pipeline_scheduler
 from vllm_omni.diffusion.models.wan2_2.scheduling_wan_euler import WanEulerScheduler
 from vllm_omni.diffusion.models.wan2_2.wan2_2_transformer import WanTransformer3DModel
 from vllm_omni.diffusion.postprocess import interpolate_video_tensor
@@ -432,7 +432,10 @@ class Wan22Pipeline(
 
         self._sample_solver = "unipc"
         self._flow_shift = od_config.flow_shift if od_config.flow_shift is not None else 5.0
-        self.scheduler = build_wan_scheduler(self._sample_solver, self._flow_shift)
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: build_wan_scheduler(self._sample_solver, self._flow_shift),
+        )
 
         self.vae_scale_factor_temporal = self.vae.config.scale_factor_temporal if getattr(self, "vae", None) else 4
         self.vae_scale_factor_spatial = self.vae.config.scale_factor_spatial if getattr(self, "vae", None) else 8
@@ -689,9 +692,20 @@ class Wan22Pipeline(
         sample_solver = resolve_wan_sample_solver(first_request, default=self._sample_solver)
         flow_shift = resolve_wan_flow_shift(first_request, self.od_config)
         if sample_solver != self._sample_solver or abs(flow_shift - self._flow_shift) > 1e-6:
-            self.scheduler = build_wan_scheduler(sample_solver, flow_shift)
-            self._sample_solver = sample_solver
-            self._flow_shift = flow_shift
+            if self.od_config.scheduler is not None:
+                # An injected scheduler owns stepping; rebuilding from
+                # per-request sample_solver/flow_shift would replace it.
+                logger.warning(
+                    "Ignoring per-request sample_solver=%s/flow_shift=%s: an injected scheduler "
+                    "(od_config.scheduler=%r) is active and is left untouched.",
+                    sample_solver,
+                    flow_shift,
+                    self.od_config.scheduler,
+                )
+            else:
+                self.scheduler = build_wan_scheduler(sample_solver, flow_shift)
+                self._sample_solver = sample_solver
+                self._flow_shift = flow_shift
 
         # Timesteps
         self.scheduler.set_timesteps(num_steps, device=device)

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
@@ -31,7 +31,11 @@ from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_p
 from vllm_omni.diffusion.models.dmd2 import DMD2PipelineMixin
 from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin, _is_rank_zero
-from vllm_omni.diffusion.models.schedulers import FlowUniPCMultistepScheduler, build_pipeline_scheduler
+from vllm_omni.diffusion.models.schedulers import (
+    FlowUniPCMultistepScheduler,
+    build_pipeline_scheduler,
+    is_injected_scheduler,
+)
 from vllm_omni.diffusion.models.wan2_2.scheduling_wan_euler import WanEulerScheduler
 from vllm_omni.diffusion.models.wan2_2.wan2_2_transformer import WanTransformer3DModel
 from vllm_omni.diffusion.postprocess import interpolate_video_tensor
@@ -62,6 +66,22 @@ def build_wan_scheduler(sample_solver: str, flow_shift: float) -> Any:
     raise ValueError(
         f"Unsupported Wan sample_solver: {sample_solver}. Expected one of: {sorted(WAN_SAMPLE_SOLVER_CHOICES)}"
     )
+
+
+def apply_wan_runtime_scheduler(pipeline: Any, sample_solver: str, flow_shift: float) -> None:
+    """Rebuild the Wan scheduler unless an injected class owns stepping."""
+    if is_injected_scheduler(pipeline.od_config):
+        logger.warning(
+            "Ignoring per-request sample_solver=%s/flow_shift=%s: an injected scheduler "
+            "(od_config.scheduler=%r) is active and is left untouched.",
+            sample_solver,
+            flow_shift,
+            pipeline.od_config.scheduler,
+        )
+        return
+    pipeline.scheduler = build_wan_scheduler(sample_solver, flow_shift)
+    pipeline._sample_solver = sample_solver
+    pipeline._flow_shift = flow_shift
 
 
 def resolve_wan_sample_solver(req: OmniDiffusionRequest, default: str = "unipc") -> str:
@@ -435,6 +455,7 @@ class Wan22Pipeline(
         self.scheduler = build_pipeline_scheduler(
             od_config,
             default_builder=lambda: build_wan_scheduler(self._sample_solver, self._flow_shift),
+            local_files_only=os.path.exists(od_config.model),
         )
 
         self.vae_scale_factor_temporal = self.vae.config.scale_factor_temporal if getattr(self, "vae", None) else 4
@@ -692,20 +713,7 @@ class Wan22Pipeline(
         sample_solver = resolve_wan_sample_solver(first_request, default=self._sample_solver)
         flow_shift = resolve_wan_flow_shift(first_request, self.od_config)
         if sample_solver != self._sample_solver or abs(flow_shift - self._flow_shift) > 1e-6:
-            if self.od_config.scheduler is not None:
-                # An injected scheduler owns stepping; rebuilding from
-                # per-request sample_solver/flow_shift would replace it.
-                logger.warning(
-                    "Ignoring per-request sample_solver=%s/flow_shift=%s: an injected scheduler "
-                    "(od_config.scheduler=%r) is active and is left untouched.",
-                    sample_solver,
-                    flow_shift,
-                    self.od_config.scheduler,
-                )
-            else:
-                self.scheduler = build_wan_scheduler(sample_solver, flow_shift)
-                self._sample_solver = sample_solver
-                self._flow_shift = flow_shift
+            apply_wan_runtime_scheduler(self, sample_solver, flow_shift)
 
         # Timesteps
         self.scheduler.set_timesteps(num_steps, device=device)

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
@@ -31,8 +31,10 @@ from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_p
 from vllm_omni.diffusion.models.dmd2 import DMD2PipelineMixin
 from vllm_omni.diffusion.models.interface import SupportImageInput, SupportsComponentDiscovery
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin, _is_rank_zero
+from vllm_omni.diffusion.models.schedulers import build_pipeline_scheduler
 from vllm_omni.diffusion.models.utils import _load_json
 from vllm_omni.diffusion.models.wan2_2.pipeline_wan2_2 import (
+    apply_wan_runtime_scheduler,
     build_wan_scheduler,
     create_transformer_from_config,
     load_transformer_config,
@@ -326,7 +328,11 @@ class Wan22I2VPipeline(
 
         self._sample_solver = "unipc"
         self._flow_shift = od_config.flow_shift if od_config.flow_shift is not None else 5.0
-        self.scheduler = build_wan_scheduler(self._sample_solver, self._flow_shift)
+        self.scheduler = build_pipeline_scheduler(
+            od_config,
+            default_builder=lambda: build_wan_scheduler(self._sample_solver, self._flow_shift),
+            local_files_only=os.path.exists(od_config.model),
+        )
 
         # VAE scale factors
         self.vae_scale_factor_temporal = self.vae.config.scale_factor_temporal if hasattr(self.vae, "config") else 4
@@ -622,9 +628,7 @@ class Wan22I2VPipeline(
         sample_solver = resolve_wan_sample_solver(first_request, default=self._sample_solver)
         flow_shift = resolve_wan_flow_shift(first_request, self.od_config)
         if sample_solver != self._sample_solver or abs(flow_shift - self._flow_shift) > 1e-6:
-            self.scheduler = build_wan_scheduler(sample_solver, flow_shift)
-            self._sample_solver = sample_solver
-            self._flow_shift = flow_shift
+            apply_wan_runtime_scheduler(self, sample_solver, flow_shift)
 
         # Timesteps
         self.scheduler.set_timesteps(num_steps, device=device)

--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -41,6 +41,7 @@ from vllm_omni.diffusion.models.interface import (
     supports_prompt_update,
     supports_step_execution,
 )
+from vllm_omni.diffusion.models.schedulers import ensure_scheduler_consumed
 from vllm_omni.diffusion.offloader import get_offload_backend
 from vllm_omni.diffusion.registry import _NO_CACHE_ACCELERATION
 from vllm_omni.diffusion.request import OmniDiffusionRequest
@@ -266,6 +267,7 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
                     custom_pipeline_name=custom_pipeline_name,
                     device=self.device,
                 )
+                ensure_scheduler_consumed(self.od_config, self.pipeline)
         time_after_load = time.perf_counter()
 
         logger.info(

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -174,6 +174,10 @@ class OmniEngineArgs(EngineArgs):
         custom_pipeline_args: Dictionary of arguments for custom pipeline
             initialization (e.g., ``{"pipeline_class": "my.Module"}``).
             Passed through to the diffusion stage engine.
+        scheduler: Optional registry name or dotted class path of a diffusion
+            scheduler class to inject instead of the pipeline default.
+        scheduler_kwargs: Optional extra kwargs forwarded to the injected
+            scheduler's ``from_pretrained()``.
     """
 
     stage_id: int = 0
@@ -231,6 +235,11 @@ class OmniEngineArgs(EngineArgs):
     output_modalities: list[str] | None = None
     log_stats: bool = False
     custom_pipeline_args: dict[str, Any] | None = None
+    # Diffusion scheduler injection (forwarded to OmniDiffusionConfig). No CLI
+    # flags are added for these (same as custom_pipeline_args); set them via
+    # the Python API or a deploy YAML's engine args.
+    scheduler: str | None = None
+    scheduler_kwargs: dict[str, Any] | None = None
     has_sampling_extra_args: bool = False
 
     def __post_init__(self) -> None:

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -174,10 +174,11 @@ class OmniEngineArgs(EngineArgs):
         custom_pipeline_args: Dictionary of arguments for custom pipeline
             initialization (e.g., ``{"pipeline_class": "my.Module"}``).
             Passed through to the diffusion stage engine.
-        scheduler: Optional registry name or dotted class path of a diffusion
-            scheduler class to inject instead of the pipeline default.
-        scheduler_kwargs: Optional extra kwargs forwarded to the injected
-            scheduler's ``from_pretrained()``.
+        diffusion_scheduler: Optional registry name or dotted class path of a
+            diffusion *sampling* scheduler class (not the request
+            ``scheduler_cls``) to inject instead of the pipeline default.
+        diffusion_scheduler_kwargs: Optional extra kwargs forwarded to the
+            injected diffusion scheduler's ``from_pretrained()``.
     """
 
     stage_id: int = 0
@@ -235,11 +236,12 @@ class OmniEngineArgs(EngineArgs):
     output_modalities: list[str] | None = None
     log_stats: bool = False
     custom_pipeline_args: dict[str, Any] | None = None
-    # Diffusion scheduler injection (forwarded to OmniDiffusionConfig). No CLI
-    # flags are added for these (same as custom_pipeline_args); set them via
-    # the Python API or a deploy YAML's engine args.
-    scheduler: str | None = None
-    scheduler_kwargs: dict[str, Any] | None = None
+    # Diffusion sampling-scheduler injection (forwarded to
+    # OmniDiffusionConfig.scheduler). Distinct from stage ``scheduler_cls``
+    # (request batching). No CLI flags (same as custom_pipeline_args); set
+    # via the Python API or a deploy YAML's engine args.
+    diffusion_scheduler: str | None = None
+    diffusion_scheduler_kwargs: dict[str, Any] | None = None
     has_sampling_extra_args: bool = False
 
     def __post_init__(self) -> None:

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1018,8 +1018,8 @@ class AsyncOmniEngine:
             "lora_scale": kwargs.get("lora_scale", 1.0),
             "lora_backend": kwargs.get("lora_backend", "peft"),
             "custom_pipeline_args": kwargs.get("custom_pipeline_args", None),
-            "scheduler": kwargs.get("scheduler", None),
-            "scheduler_kwargs": kwargs.get("scheduler_kwargs", None),
+            "scheduler": kwargs.get("diffusion_scheduler", kwargs.get("scheduler", None)),
+            "scheduler_kwargs": kwargs.get("diffusion_scheduler_kwargs", kwargs.get("scheduler_kwargs", None)),
             "worker_extension_cls": kwargs.get("worker_extension_cls", None),
             "trust_remote_code": (False if kwargs.get("trust_remote_code") is None else kwargs["trust_remote_code"]),
             "distributed_executor_backend": (

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1018,6 +1018,8 @@ class AsyncOmniEngine:
             "lora_scale": kwargs.get("lora_scale", 1.0),
             "lora_backend": kwargs.get("lora_backend", "peft"),
             "custom_pipeline_args": kwargs.get("custom_pipeline_args", None),
+            "scheduler": kwargs.get("scheduler", None),
+            "scheduler_kwargs": kwargs.get("scheduler_kwargs", None),
             "worker_extension_cls": kwargs.get("worker_extension_cls", None),
             "trust_remote_code": (False if kwargs.get("trust_remote_code") is None else kwargs["trust_remote_code"]),
             "distributed_executor_backend": (


### PR DESCRIPTION
## Summary

- Threads the request `generator` through `QwenImageCFGParallelMixin.diffuse()` into `scheduler_step_maybe_with_cfg`, matching the hunyuan_image3 precedent.
- Step-mode `step_scheduler` wiring lands in V6 with the qwen_image consumer.

Stacked **[3/6]** on V2. RFC: #6269. Consumer: [verl-omni#391](https://github.com/verl-project/verl-omni/issues/391).

## Test plan

- [ ] CPU: deepcopy isolation in `test_trajectory.py`
- [ ] GPU: SDE noise follows the request generator, not global RNG
